### PR TITLE
fix: reload resume state after lease

### DIFF
--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -17,14 +17,16 @@ import type { AgentConfig } from '@agent/runtime';
 import { loadChatExportInput } from '@agent/export/loadChatExportInput';
 import type { ChatExportInput } from '@agent/export/schemas';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
-import type { ExecutionId, ExecutionMeta } from '@shared/schemas';
-import { ExecutionIdSchema, RunOutcomeSchema } from '@shared/schemas';
 import {
+  ExecutionIdSchema,
   HISTORY_RUN_STATUS,
   HISTORY_RUN_STATUS_LABEL,
+  RunOutcomeSchema,
   resolveHistoryRunStatus,
+  type ExecutionId,
+  type ExecutionMeta,
   type HistoryRunStatus,
-} from '@shared/schemas/historyRunStatus';
+} from '@shared/schemas';
 import { runOutcomeToExecutionStatus } from '@shared/streams/streamStatus';
 import { GoalStore } from '@tools/goal';
 import {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -69,8 +69,8 @@ export interface RunToolUseFlowInput<
   /** Abort this run's sticky signal. */
   interrupt: () => void;
   setting: AgentToolUseSetting;
-  /** Canonical shared state and the persisted value observed during retrieval. */
-  resume?: Readonly<{ shared: PreparedShared; sourceShared: unknown }>;
+  /** Canonical shared state loaded after the execution lease is acquired. */
+  resume?: Readonly<{ shared: PreparedShared }>;
   /** One batch already drained by an external child-turn owner. */
   drainedFollowUps?: readonly FollowUpQueueBatchItem[];
   /**
@@ -461,13 +461,9 @@ export async function runToolUseFlow<C = unknown>(
 
     if (flowRecord) logger.debug('Resuming tool-use flow from persistence');
     if (flowRecord && input.resume) {
-      // Retrieval owns the single migration/validation boundary. The second
-      // read may be self-healed only when it still matches the exact value
-      // retrieval observed; any intervening drift must fail loudly instead of
-      // being overwritten by the earlier canonical copy.
-      if (!isDeepStrictEqual(flowRecord.shared, input.resume.sourceShared)) {
-        throw new PersistedFlowStateError(executionId, 'invalid-shared');
-      }
+      // `resumeToolUseFromResumeData` reloads the record only after it owns
+      // the execution lease. This is therefore the same authoritative record
+      // it handed to the flow, with no optimistic-concurrency window to check.
       const resumedShared: PreparedShared = stampCompatibilityKey(
         input.resume.shared,
         compatibilityKey,

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -469,6 +469,9 @@ export async function runToolUseFlow<C = unknown>(
         compatibilityKey,
       );
       if (!isDeepStrictEqual(flowRecord.shared, resumedShared)) {
+        logger.debug(
+          'Healed a persisted tool-use shared-state mismatch after resume handoff.',
+        );
         flowRecord.shared = resumedShared;
         await kv.write(
           flowKey(executionId),

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -39,8 +39,6 @@ const logger = createLog('SessionResumeRetrieval');
 export interface ToolUseResumeData {
   readonly type: 'toolUse';
   readonly shared: PreparedShared;
-  /** Exact persisted value observed before one-time migration/self-heal. */
-  readonly sourceShared: unknown;
   readonly agentConfig: AgentConfig;
   readonly executionId: ExecutionId;
   readonly streamId: StreamTabId;
@@ -207,7 +205,6 @@ async function retrieveToolUseResumeData(
     return {
       type: 'toolUse',
       shared,
-      sourceShared: structuredClone(flowRecord.shared),
       executionId,
       streamId,
       ...(options.parentStreamId !== undefined && {

--- a/src/agent/runtime/UsageMonitor.ts
+++ b/src/agent/runtime/UsageMonitor.ts
@@ -9,7 +9,7 @@ import type {
   StreamTabId,
   UsageRoute,
 } from '@shared/schemas';
-import { AgentCategory, UsageProviderSchema } from '@shared/schemas';
+import { AgentCategory } from '@shared/schemas';
 import {
   USAGE_LOG_FLUSH_OUTCOME,
   UsageLogService,
@@ -206,15 +206,19 @@ export class UsageMonitor {
 
       // Log to backend for analytics/billing. Relay-backed rounds wait for the
       // flush because the next relay request enforces the cap from DB state.
-      await this.logToBackend(stateGlobal.totalResponseTimeMs, {
-        inputTokens: roundInputTokens,
-        outputTokens: roundOutputTokens,
-        cachedInputTokens: roundCacheReadTokens,
-        cacheMissInputTokens: roundCacheMissTokens.billing,
-        reasoningTokens: roundReasoningTokens,
-        cost: roundCost,
-        usageRoute,
-      });
+      await this.logToBackend(
+        stateGlobal.totalResponseTimeMs,
+        {
+          inputTokens: roundInputTokens,
+          outputTokens: roundOutputTokens,
+          cachedInputTokens: roundCacheReadTokens,
+          cacheMissInputTokens: roundCacheMissTokens.billing,
+          reasoningTokens: roundReasoningTokens,
+          cost: roundCost,
+          usageRoute,
+        },
+        latestUsage.provider,
+      );
     } catch (error) {
       logger.error(`Error printing ${runKind} statistics`, { data: error });
     }
@@ -269,12 +273,12 @@ export class UsageMonitor {
       | 'reasoningTokens'
       | 'cost'
     > & { cacheMissInputTokens: number; usageRoute?: UsageRoute },
+    provider: NonNullable<
+      AgentRunStateSnapshot['usageAccumulator']['latestUsage']
+    >['provider'],
   ): Promise<void> {
     try {
       const { config } = this.modelInfo;
-      const provider = UsageProviderSchema.catch('unknown').parse(
-        config.provider,
-      );
       const cachedInputTokens = usage.cachedInputTokens ?? 0;
       const usedRelay = usage.usageRoute === 'relay';
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -60,10 +60,13 @@ import {
   type WorkflowFlowResult,
 } from './AgentFlowResult';
 import { generateSessionDescription } from './sessionDescription';
-import type { SessionHandle } from './SessionHandle';
+import {
+  retrieveSessionResumeData,
+  type ToolUseResumeData,
+} from './SessionResumeRetrieval';
 import type { AgentExecutionHandle, AgentRunHandle } from './ExecutionHandle';
 import type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKey';
-import type { ToolUseResumeData } from './SessionResumeRetrieval';
+import type { SessionHandle } from './SessionHandle';
 
 const CHANNEL = 'executeAgent';
 const logger = createLog(CHANNEL);
@@ -535,6 +538,114 @@ export interface ResumeToolUseFromResumeDataOptions extends SubagentRunOptions {
  * is a subagent — and can therefore legitimately resolve WAITING again — comes
  * from persisted lineage (`hasPersistedParent`), never from the caller.
  */
+async function resumeToolUseWithOwnedLease(
+  resume: ToolUseResumeData,
+  options: ResumeToolUseFromResumeDataOptions = {},
+): Promise<AgentRuntimeFlowResult> {
+  // Resolve persisted lineage before launch assembly activates the stream and
+  // transfers its resources. Storage failures must propagate without leaving
+  // an activated resume stream outside lifecycle cleanup.
+  let isSubagent: boolean;
+  let userFollowUpSupport: UserFollowUpSupport;
+  let ctx: AgentLaunchContext;
+  try {
+    // This execution is running again, so the terminal facts its previous
+    // run left behind stop describing it here, before any turn of the
+    // resumed run can write a result envelope for readers to project onto.
+    await clearTerminalExecutionState(resume.executionId);
+    [isSubagent, userFollowUpSupport] = await Promise.all([
+      hasPersistedParent(resume.executionId),
+      getPersistedUserFollowUpSupport(resume.executionId),
+    ]);
+    ctx = await buildAgentLaunchContext({
+      config: resume.agentConfig,
+      executionId: resume.executionId,
+      streamTabIdOverride: resume.streamId,
+      // SessionResumeRetrieval already resolved the persisted ?? inferred key
+      // for this exact record; do not re-infer here.
+      modelHandlerCompatibilityKey: resume.shared.modelHandlerCompatibilityKey,
+      suppressViewSwitch: isSubagent,
+      // Host resume callers surface their own warning toast on failure;
+      // skip the bus-level error to avoid double-notifying.
+      suppressErrorNotification: true,
+      session: options.session,
+      toolPolicy: {
+        approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+        runtimeUnavailableTools: options.runtimeUnavailableTools,
+      },
+    });
+  } catch (error) {
+    throw await releaseOwnedExecutionLeaseAfterFailure(
+      resume.executionId,
+      error,
+    );
+  }
+  const { setting } = ctx;
+  const { streamId: runStreamId, session: runSession } = ctx.runScope;
+
+  // Only the run itself is guarded here. The release below is deliberately
+  // outside: a release that fails must not be retried by the catch arm.
+  let result: AgentRuntimeFlowResult;
+  try {
+    result = await withExecutionRunContext(
+      ctx,
+      { onApprovalPolicyDenial: options.onApprovalPolicyDenial },
+      async () => {
+        if (setting.agentCategory !== AgentCategory.ToolUse) {
+          // Keep this historical diagnostic byte-for-byte for external monitors.
+          throw new AgentError(
+            'Attempted to resume a non tool-use agent with resumeToolUseFromSnapshot.',
+          );
+        }
+
+        await runSession.transcripts.ensureLoaded(runStreamId);
+
+        return await runFlowWithLifecycle(
+          ctx,
+          async (handle, lifecycle) =>
+            launchToolUseRun(
+              ctx,
+              handle,
+              lifecycle,
+              { ...options, setting, isSubagent },
+              {
+                kind: 'resume',
+                resume,
+                drainedFollowUps: options.drainedFollowUps,
+                takePendingFollowUps: options.takePendingFollowUps,
+                isCancellationRequested: options.isCancellationRequested,
+                onCancellationAtFlowAttachment:
+                  options.onCancellationAtFlowAttachment,
+              },
+            ),
+          buildLifecycleOptions(
+            { ...options, userFollowUpSupport },
+            isSubagent,
+          ),
+        );
+      },
+    );
+  } catch (error) {
+    // The run's own failure is the one the caller must see; a release failure
+    // on top of it is additional information, not a replacement.
+    try {
+      await runSession.releaseExecutionLease(resume.executionId);
+    } catch (releaseError) {
+      throw new AggregateError(
+        [error, releaseError],
+        `Execution ${resume.executionId} failed and its final artifacts could not be persisted`,
+      );
+    }
+    throw error;
+  }
+  // A WAITING result keeps the lease: the next resume owns this execution.
+  if (!isWaitingFlowResult(result)) {
+    await runSession.releaseExecutionLease(resume.executionId);
+  }
+  return result;
+}
+
+/** Resume a persisted tool-use session after claiming its execution lease. */
 export async function resumeToolUseFromResumeData(
   resume: ToolUseResumeData,
   options: ResumeToolUseFromResumeDataOptions = {},
@@ -546,110 +657,29 @@ export async function resumeToolUseFromResumeData(
   if (lease === 'cancelled') {
     throw new ResumeAdmissionCancelledError(resume.executionId);
   }
-  const runWithOwnership = captureOwnedExecutionLease(resume.executionId);
-  return await runWithOwnership(async () => {
-    // Resolve persisted lineage before launch assembly activates the stream and
-    // transfers its resources. Storage failures must propagate without leaving
-    // an activated resume stream outside lifecycle cleanup.
-    let isSubagent: boolean;
-    let userFollowUpSupport: UserFollowUpSupport;
-    let ctx: AgentLaunchContext;
+  return await captureOwnedExecutionLease(resume.executionId)(async () => {
     try {
-      // This execution is running again, so the terminal facts its previous
-      // run left behind stop describing it here, before any turn of the
-      // resumed run can write a result envelope for readers to project onto.
-      await clearTerminalExecutionState(resume.executionId);
-      [isSubagent, userFollowUpSupport] = await Promise.all([
-        hasPersistedParent(resume.executionId),
-        getPersistedUserFollowUpSupport(resume.executionId),
-      ]);
-      ctx = await buildAgentLaunchContext({
-        config: resume.agentConfig,
-        executionId: resume.executionId,
-        streamTabIdOverride: resume.streamId,
-        // SessionResumeRetrieval already resolved the persisted ?? inferred key
-        // for this exact record; do not re-infer here.
-        modelHandlerCompatibilityKey:
-          resume.shared.modelHandlerCompatibilityKey,
-        suppressViewSwitch: isSubagent,
-        // Host resume callers surface their own warning toast on failure;
-        // skip the bus-level error to avoid double-notifying.
-        suppressErrorNotification: true,
-        session: options.session,
-        toolPolicy: {
-          approvalPromptsUnavailable: options.approvalPromptsUnavailable,
-          runtimeUnavailableTools: options.runtimeUnavailableTools,
-        },
-      });
+      // The caller's lookup only decides whether a resume may be attempted.
+      // Its shared state is never launched: reload after the lease is owned so
+      // this process has a single authoritative persisted snapshot.
+      const leasedResume = await retrieveSessionResumeData(
+        resume.streamId,
+        resume.executionId,
+        resume.agentConfig,
+        { parentStreamId: resume.parentStreamId },
+      );
+      if (leasedResume?.type !== 'toolUse') {
+        throw new Error(
+          `Execution ${resume.executionId} no longer has a resumable tool-use session.`,
+        );
+      }
+      return await resumeToolUseWithOwnedLease(leasedResume, options);
     } catch (error) {
       throw await releaseOwnedExecutionLeaseAfterFailure(
         resume.executionId,
         error,
       );
     }
-    const { setting } = ctx;
-    const { streamId: runStreamId, session: runSession } = ctx.runScope;
-
-    // Only the run itself is guarded here. The release below is deliberately
-    // outside: a release that fails must not be retried by the catch arm.
-    let result: AgentRuntimeFlowResult;
-    try {
-      result = await withExecutionRunContext(
-        ctx,
-        { onApprovalPolicyDenial: options.onApprovalPolicyDenial },
-        async () => {
-          if (setting.agentCategory !== AgentCategory.ToolUse) {
-            // Keep this historical diagnostic byte-for-byte for external monitors.
-            throw new AgentError(
-              'Attempted to resume a non tool-use agent with resumeToolUseFromSnapshot.',
-            );
-          }
-
-          await runSession.transcripts.ensureLoaded(runStreamId);
-
-          return await runFlowWithLifecycle(
-            ctx,
-            async (handle, lifecycle) =>
-              launchToolUseRun(
-                ctx,
-                handle,
-                lifecycle,
-                { ...options, setting, isSubagent },
-                {
-                  kind: 'resume',
-                  resume,
-                  drainedFollowUps: options.drainedFollowUps,
-                  takePendingFollowUps: options.takePendingFollowUps,
-                  isCancellationRequested: options.isCancellationRequested,
-                  onCancellationAtFlowAttachment:
-                    options.onCancellationAtFlowAttachment,
-                },
-              ),
-            buildLifecycleOptions(
-              { ...options, userFollowUpSupport },
-              isSubagent,
-            ),
-          );
-        },
-      );
-    } catch (error) {
-      // The run's own failure is the one the caller must see; a release failure
-      // on top of it is additional information, not a replacement.
-      try {
-        await runSession.releaseExecutionLease(resume.executionId);
-      } catch (releaseError) {
-        throw new AggregateError(
-          [error, releaseError],
-          `Execution ${resume.executionId} failed and its final artifacts could not be persisted`,
-        );
-      }
-      throw error;
-    }
-    // A WAITING result keeps the lease: the next resume owns this execution.
-    if (!isWaitingFlowResult(result)) {
-      await runSession.releaseExecutionLease(resume.executionId);
-    }
-    return result;
   });
 }
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -79,6 +79,14 @@ export class ResumeAdmissionCancelledError extends Error {
   }
 }
 
+/** A claimed execution no longer has the persisted tool-use state to resume. */
+export class ResumeSessionUnavailableError extends Error {
+  constructor(readonly executionId: ExecutionId) {
+    super('This session can no longer be resumed. Start a new run instead.');
+    this.name = 'ResumeSessionUnavailableError';
+  }
+}
+
 /** Create the awaited round-finalized callback used by agent flows. */
 function createUsageRecordingCallback(
   ctx: AgentLaunchContext,
@@ -645,7 +653,12 @@ async function resumeToolUseWithOwnedLease(
   return result;
 }
 
-/** Resume a persisted tool-use session after claiming its execution lease. */
+/**
+ * Resume a persisted tool-use session after claiming its execution lease.
+ * Whether the run is a subagent — and can therefore legitimately resolve
+ * WAITING again — comes from persisted lineage (`hasPersistedParent`), never
+ * from the caller.
+ */
 export async function resumeToolUseFromResumeData(
   resume: ToolUseResumeData,
   options: ResumeToolUseFromResumeDataOptions = {},
@@ -658,28 +671,31 @@ export async function resumeToolUseFromResumeData(
     throw new ResumeAdmissionCancelledError(resume.executionId);
   }
   return await captureOwnedExecutionLease(resume.executionId)(async () => {
+    let leasedResume: ToolUseResumeData;
     try {
       // The caller's lookup only decides whether a resume may be attempted.
       // Its shared state is never launched: reload after the lease is owned so
       // this process has a single authoritative persisted snapshot.
-      const leasedResume = await retrieveSessionResumeData(
+      const retrievedResume = await retrieveSessionResumeData(
         resume.streamId,
         resume.executionId,
         resume.agentConfig,
         { parentStreamId: resume.parentStreamId },
       );
-      if (leasedResume?.type !== 'toolUse') {
-        throw new Error(
-          `Execution ${resume.executionId} no longer has a resumable tool-use session.`,
-        );
+      if (retrievedResume?.type !== 'toolUse') {
+        throw new ResumeSessionUnavailableError(resume.executionId);
       }
-      return await resumeToolUseWithOwnedLease(leasedResume, options);
+      leasedResume = retrievedResume;
     } catch (error) {
       throw await releaseOwnedExecutionLeaseAfterFailure(
         resume.executionId,
         error,
       );
     }
+    // `resumeToolUseWithOwnedLease` owns release after its launch boundary,
+    // including its own setup failures. Keep it outside the retrieval guard so
+    // a run failure is not released twice by nested rollback paths.
+    return await resumeToolUseWithOwnedLease(leasedResume, options);
   });
 }
 

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -99,7 +99,10 @@ export { resumeQueuedToolUseFromResumeData } from './resumeQueuedToolUse';
 export type { ManualCompactionRequestResult } from './executionRegistry';
 
 // executeAgent
-export { resumeToolUseFromResumeData } from './executeAgent';
+export {
+  resumeToolUseFromResumeData,
+  ResumeSessionUnavailableError,
+} from './executeAgent';
 
 // textEnhancement
 export { polishTextWithAI } from './textEnhancement';

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -10,7 +10,10 @@ import {
   retrieveSessionResumeData,
   type ToolUseResumeData,
 } from './SessionResumeRetrieval';
-import { ResumeAdmissionCancelledError } from './executeAgent';
+import {
+  ResumeAdmissionCancelledError,
+  ResumeSessionUnavailableError,
+} from './executeAgent';
 import type { SessionHandle } from './SessionHandle';
 import type { StreamStatusMachine } from './StreamStatusService';
 import type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKey';
@@ -36,7 +39,7 @@ type UnresolvedResumeState = Exclude<
 >;
 
 interface ResumeFailureDescription {
-  readonly kind: 'lease-active' | 'unexpected';
+  readonly kind: 'lease-active' | 'not-resumable' | 'unexpected';
   readonly message: string;
 }
 
@@ -52,16 +55,20 @@ export function describeResumeStateResolution(
     : 'No persisted run state was found for this stream. Start a new run instead.';
 }
 
-/** Classify lease contention without making hosts recognize storage errors. */
+/** Classify expected resume outcomes without making hosts recognize storage errors. */
 export function describeResumeFailure(
   error: unknown,
 ): ResumeFailureDescription {
-  return error instanceof ExecutionLeaseActiveError
-    ? { kind: 'lease-active', message: error.message }
-    : {
-        kind: 'unexpected',
-        message: `Resume failed: ${toErrorMessage(error)}`,
-      };
+  if (error instanceof ExecutionLeaseActiveError) {
+    return { kind: 'lease-active', message: error.message };
+  }
+  if (error instanceof ResumeSessionUnavailableError) {
+    return { kind: 'not-resumable', message: error.message };
+  }
+  return {
+    kind: 'unexpected',
+    message: `Resume failed: ${toErrorMessage(error)}`,
+  };
 }
 
 /** Claim and release the byte-identical GUI recovery ownership triad. */

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -26,6 +26,7 @@ export * from './coreSettings';
 export * from './opResults';
 export * from './stateSettings';
 export * from './workflowScriptFiles';
+export * from './historyRunStatus';
 
 // Layer 2b: Depends on layer 1
 export * from './agentPresets';
@@ -62,10 +63,9 @@ export * from './progressView';
 
 // Layer 6: Other view message schemas
 export * from './commonViewMessages';
-// Memory/History/Profile view-message schemas have a single public home in
-// settingsViewMessages (the canonical settings entry point), which re-exports
-// the symbols consumers need. They are not re-exported directly here, so each
-// family is published through exactly one barrel path.
+// Memory/Profile view-message schemas have a single public home in
+// settingsViewMessages. History status is shared with the CLI and is exported
+// above from its host-neutral leaf module.
 export * from './settingsViewMessages';
 export * from './subscriptionUsage';
 

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -84,12 +84,6 @@ export { type Goal } from './goal';
 export { type MemoryViewItem, type MemoryPreview } from './memoryViewMessages';
 
 export {
-  HISTORY_RUN_STATUS_LABEL,
-  resolveHistoryRunStatus,
-  type HistoryRunStatus,
-} from './historyRunStatus';
-
-export {
   API_ACCESS_MODE_OPTIONS,
   DEFAULT_GLOBAL_STREAMING,
   DEFAULT_QUOTA_AUTO_SWITCHED,

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -258,7 +258,6 @@ function responseModelHandler(
 function buildToolUseResumeData(
   executionId: ExecutionId,
   streamId: StreamTabId,
-  sourceShared?: unknown,
 ): ToolUseResumeData {
   const shared = {
     messages: [],
@@ -272,7 +271,6 @@ function buildToolUseResumeData(
     streamId,
     agentConfig: CONFIG,
     shared,
-    sourceShared: sourceShared ?? structuredClone(shared),
   };
 }
 
@@ -294,7 +292,6 @@ function buildResponseResumeData(
     streamId,
     agentConfig: CONFIG,
     shared,
-    sourceShared: structuredClone(shared),
   };
 }
 
@@ -702,11 +699,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
         `chat@gpt54#abc-flow-stale-response-${suffix}` as StreamTabId;
       const resume = buildResponseResumeData(executionId, streamId, 'A');
       if (persistRecord) {
-        await writeFlowRecord(
-          executionId,
-          resume.sourceShared,
-          WAITING_AT_START,
-        );
+        await writeFlowRecord(executionId, resume.shared, WAITING_AT_START);
       }
 
       const result = await runPersistedFlow(executionId, streamId, resume);
@@ -728,7 +721,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       const streamId =
         `chat@gpt54#abc-flow-fresh-resumed-response-${suffix}` as StreamTabId;
       const resume = buildResponseResumeData(executionId, streamId, prior);
-      await writeFlowRecord(executionId, resume.sourceShared, WAITING_AT_START);
+      await writeFlowRecord(executionId, resume.shared, WAITING_AT_START);
 
       const result = await runPersistedFlow(executionId, streamId, resume, {
         modelHandler: responseModelHandler([{ text: fresh }]),
@@ -744,7 +737,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const streamId =
       'chat@gpt54#abc-flow-identical-partial-response' as StreamTabId;
     const resume = buildResponseResumeData(executionId, streamId, 'A');
-    await writeFlowRecord(executionId, resume.sourceShared, WAITING_AT_START);
+    await writeFlowRecord(executionId, resume.shared, WAITING_AT_START);
 
     const result = await runPersistedFlow(executionId, streamId, resume, {
       modelHandler: responseModelHandler([{ text: 'A' }], {
@@ -784,9 +777,8 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const resume: ToolUseResumeData = {
       ...baseResume,
       shared,
-      sourceShared: structuredClone(shared),
     };
-    await writeFlowRecord(executionId, resume.sourceShared, WAITING_AT_START);
+    await writeFlowRecord(executionId, resume.shared, WAITING_AT_START);
     const providerError = Object.assign(
       new Error('Answerless provider failure'),
       {
@@ -866,7 +858,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const executionId = 'abc-flow-compacted-response' as ExecutionId;
     const streamId = 'chat@gpt54#abc-flow-compacted-response' as StreamTabId;
     const resume = buildResponseResumeData(executionId, streamId, 'A');
-    await writeFlowRecord(executionId, resume.sourceShared, WAITING_AT_START);
+    await writeFlowRecord(executionId, resume.shared, WAITING_AT_START);
 
     const result = await runPersistedFlow(executionId, streamId, resume, {
       modelHandler: responseModelHandler([
@@ -1047,7 +1039,6 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const snapshot: ToolUseResumeData = {
       ...base,
       shared: failedShared,
-      sourceShared: structuredClone(failedShared),
     };
     // A terminal cursor makes the resumed flow exit COMPLETE without stepping
     // any node, leaving the failed shared state exactly as persisted.
@@ -1125,7 +1116,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     };
     // A terminal cursor makes the resumed flow exit COMPLETE without stepping
     // any node, so the run completes without a structured result.
-    await writeFlowRecord(executionId, snapshot.sourceShared, {
+    await writeFlowRecord(executionId, snapshot.shared, {
       cursor: { nextNodeId: null, lastAction: FlowTransition.COMPLETE },
     });
     const session = createTestSession();
@@ -1146,21 +1137,6 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
   });
 
   it.each([
-    {
-      name: 'invalid shared state',
-      reason: 'invalid-shared',
-      stored: {
-        flowName: 'texra',
-        shared: {
-          messages: [],
-          shouldSkipCycle: 'false',
-          stateSlices: null,
-        },
-        createdAt: '2026-01-01T00:00:00.000Z',
-        cursor: { nextNodeId: 'start' },
-        nodes: [],
-      },
-    },
     {
       name: 'legacy record without a replay cursor',
       reason: 'unsupported-record',
@@ -1220,9 +1196,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       const expectedError = {
         name: PersistedFlowStateError.name,
         reason,
-        ...(reason !== 'invalid-shared' && {
-          cause: expect.objectContaining({ name: 'ZodError' }),
-        }),
+        cause: expect.objectContaining({ name: 'ZodError' }),
       };
       await expect(
         runPersistedFlow(executionId, streamId, snapshot),
@@ -1392,11 +1366,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const store = getExecutionStore(executionId);
     let flowContext: ToolUseSetupContext | undefined;
     const storedShared = activeHandlerShared();
-    const snapshot = buildToolUseResumeData(
-      executionId,
-      streamId,
-      storedShared,
-    );
+    const snapshot = buildToolUseResumeData(executionId, streamId);
     await writeFlowRecord(executionId, storedShared);
     const abortError = createAbortError();
     // Reject the flow's first node-step persist with the provider's abort:
@@ -1497,11 +1467,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const streamId = 'chat@gpt54#abc-cancel-active-followup' as StreamTabId;
     const session = createTestSession();
     const storedShared = activeHandlerShared();
-    const snapshot = buildToolUseResumeData(
-      executionId,
-      streamId,
-      storedShared,
-    );
+    const snapshot = buildToolUseResumeData(executionId, streamId);
     await writeFlowRecord(executionId, storedShared);
     // `resumeQueuedToolUseFromResumeData` holds the recovery lease across the
     // whole host resume, so the flow borrows that consumer's queue instead of
@@ -1566,11 +1532,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const streamId = 'chat@gpt54#abc-cancel-child-followup' as StreamTabId;
     const session = createTestSession();
     const storedShared = activeHandlerShared();
-    const snapshot = buildToolUseResumeData(
-      executionId,
-      streamId,
-      storedShared,
-    );
+    const snapshot = buildToolUseResumeData(executionId, streamId);
     await writeFlowRecord(executionId, storedShared);
     const childLease = session.followUps.claimLive(streamId, 'child');
     expect(childLease).toBeDefined();

--- a/src/test-kernel/agent/runtime/AgentLaunchActivation.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchActivation.vitest.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   hasPersistedParent: vi.fn(),
   load: vi.fn(),
   releaseOwnedExecutionLeaseAfterFailure: vi.fn(),
+  retrieveSessionResumeData: vi.fn(),
   resolve: vi.fn(),
 }));
 
@@ -44,6 +45,9 @@ vi.mock('@agent/storage/executionLease', () => ({
   completeOwnedExecutionLease: mocks.completeOwnedExecutionLease,
   releaseOwnedExecutionLeaseAfterFailure:
     mocks.releaseOwnedExecutionLeaseAfterFailure,
+}));
+vi.mock('@agent/runtime/SessionResumeRetrieval', () => ({
+  retrieveSessionResumeData: mocks.retrieveSessionResumeData,
 }));
 
 import { noopTrace } from '@agent/trace';
@@ -174,6 +178,7 @@ describe('native agent launch activation', () => {
         agentConfig: config,
         shared: { modelHandlerCompatibilityKey: MODEL_HANDLER_KEY },
       });
+      mocks.retrieveSessionResumeData.mockResolvedValueOnce(resume);
 
       const payload = await captureActivation((session) =>
         resumeToolUseFromResumeData(resume, { session }),

--- a/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
+++ b/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   invokeModelOrTool: vi.fn(),
   runFlowWithLifecycle: vi.fn(),
   runToolUseFlow: vi.fn(),
+  retrieveSessionResumeData: vi.fn(),
   acquireResumedExecutionLease: vi.fn(),
   validateOwnedExecutionLease: vi.fn(),
   runWithExecutionLeaseWriteFence: vi.fn(
@@ -62,6 +63,10 @@ vi.mock('@agent/implementations/flows/reflection/runReflectionFlow', () => ({
 
 vi.mock('@agent/implementations/flows/tooluse/runToolUseFlow', () => ({
   runToolUseFlow: mocks.runToolUseFlow,
+}));
+
+vi.mock('@agent/runtime/SessionResumeRetrieval', () => ({
+  retrieveSessionResumeData: mocks.retrieveSessionResumeData,
 }));
 
 // Local imports
@@ -142,6 +147,10 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.acquireResumedExecutionLease.mockResolvedValue('existing');
+    mocks.retrieveSessionResumeData.mockImplementation(
+      async (streamId, executionId, agentConfig) =>
+        createToolUseResumeData({ executionId, streamId, agentConfig }),
+    );
     mocks.clearTerminalExecutionState.mockResolvedValue(undefined);
     mocks.getPersistedUserFollowUpSupport.mockResolvedValue(
       USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
@@ -168,6 +177,14 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
     const executionId = 'e9503-boundary' as ExecutionId;
     const streamId = 'stream-9503-boundary' as StreamTabId;
     const order: string[] = [];
+    mocks.acquireResumedExecutionLease.mockImplementationOnce(async () => {
+      order.push('lease');
+      return 'existing';
+    });
+    mocks.retrieveSessionResumeData.mockImplementationOnce(async () => {
+      order.push('retrieve');
+      return createToolUseResumeData({ executionId, streamId });
+    });
     mocks.clearTerminalExecutionState.mockImplementationOnce(async () => {
       order.push('clear');
     });
@@ -186,7 +203,7 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
     );
 
     expect(mocks.clearTerminalExecutionState).toHaveBeenCalledWith(executionId);
-    expect(order).toEqual(['clear', 'launch', 'flow']);
+    expect(order).toEqual(['lease', 'retrieve', 'clear', 'launch', 'flow']);
   });
 
   it('preserves persisted native follow-up support across resumed waiting turns', async () => {

--- a/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
+++ b/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
@@ -75,6 +75,7 @@ import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
 import {
   resumeToolUseFromResumeData,
   ResumeAdmissionCancelledError,
+  ResumeSessionUnavailableError,
 } from '@agent/runtime/executeAgent';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
@@ -254,6 +255,9 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
       snapshot.executionId,
       storageError,
     );
+    expect(mocks.releaseOwnedExecutionLeaseAfterFailure).toHaveBeenCalledTimes(
+      1,
+    );
   });
 
   it('resolves execution lineage before activating the resume stream', async () => {
@@ -273,6 +277,9 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
       snapshot.executionId,
       storageError,
     );
+    expect(mocks.releaseOwnedExecutionLeaseAfterFailure).toHaveBeenCalledTimes(
+      1,
+    );
   });
 
   it('does not build a launch context when canonical admission is withdrawn under the lease lock', async () => {
@@ -291,6 +298,16 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
       }),
     ).rejects.toBeInstanceOf(ResumeAdmissionCancelledError);
 
+    expect(mocks.buildAgentLaunchContext).not.toHaveBeenCalled();
+  });
+
+  it('reports a reloaded session that is no longer resumable distinctly', async () => {
+    const snapshot = createToolUseResumeData();
+    mocks.retrieveSessionResumeData.mockResolvedValueOnce(null);
+
+    await expect(resumeToolUseFromResumeData(snapshot)).rejects.toBeInstanceOf(
+      ResumeSessionUnavailableError,
+    );
     expect(mocks.buildAgentLaunchContext).not.toHaveBeenCalled();
   });
 

--- a/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
+++ b/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
@@ -10,13 +10,19 @@ vi.mock('@agent/runtime/SessionResumeRetrieval', () => ({
 }));
 
 import {
+  describeResumeFailure,
   resolveAndResumeStream,
   type ResumeStreamPorts,
 } from '@agent/runtime/resolveAndResumeStream';
+import { ResumeSessionUnavailableError } from '@agent/runtime/executeAgent';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { STREAM_PHASE, type StreamTabId } from '@shared/schemas';
+import {
+  STREAM_PHASE,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 import {
   clearStreamStatusForTest,
   seedStreamStatusForTest,
@@ -80,6 +86,18 @@ describe('resolveAndResumeStream', () => {
 
   afterEach(() => {
     clearStreamStatusForTest(defaultSession().status, STREAM);
+  });
+
+  it('describes a session that became unavailable during resume without masking it as storage failure', () => {
+    expect(
+      describeResumeFailure(
+        new ResumeSessionUnavailableError('exec-1' as ExecutionId),
+      ),
+    ).toEqual({
+      kind: 'not-resumable',
+      message:
+        'This session can no longer be resumed. Start a new run instead.',
+    });
   });
 
   it('routes a tool-use snapshot to the resume port', async () => {

--- a/src/test-kernel/cli/chatSessionController.vitest.ts
+++ b/src/test-kernel/cli/chatSessionController.vitest.ts
@@ -63,6 +63,7 @@ vi.mock('@agent/runtime/resumeQueuedToolUse', () => ({
 vi.mock('@agent/runtime/executeAgent', () => ({
   executeAgent: mocks.executeAgent,
   resumeToolUseFromResumeData: mocks.resumeToolUseFromResumeData,
+  ResumeSessionUnavailableError: class ResumeSessionUnavailableError extends Error {},
 }));
 
 vi.mock('@agent/runtime/runAgent', () => ({

--- a/src/test-kernel/support/toolUseResumeTestUtils.ts
+++ b/src/test-kernel/support/toolUseResumeTestUtils.ts
@@ -36,7 +36,6 @@ export function createToolUseResumeData(
       model: 'test-model',
       agentCategory: 'toolUse',
     }),
-    sourceShared: structuredClone(shared),
     ...overrides,
     shared,
   };


### PR DESCRIPTION
Closes #10764 (a).

Claims the execution lease before reloading the persisted tool-use resume record, so the launch uses one authoritative post-lease snapshot. Removes the superseded source-state drift comparison and its test scaffolding.

Validation:
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- focused ESLint
- `corepack pnpm vitest run src/test-kernel/agent/SessionResumeRetrieval.vitest.ts src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts src/test-kernel/agent/runtime/resumeQueuedToolUse.vitest.ts --config vitest.config.mjs` (66 tests)