### PR TITLE
fix: settle transcript groups on completion

### DIFF
--- a/src/test-kernel/transcript/StreamLog.vitest.ts
+++ b/src/test-kernel/transcript/StreamLog.vitest.ts
@@ -96,6 +96,26 @@ describe('StreamLog', () => {
     expect(delta.textChunks).toEqual([]);
   });
 
+  it('warns and drops late updates to settled entries', () => {
+    const log = new StreamLog();
+    const settled = log.appendSettled({
+      id: 'complete',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      text: 'done',
+      messageType: MESSAGE_TYPES.DEFAULT,
+    });
+    log.drainEmission();
+
+    expect(log.update('complete', { text: 'late change' })).toBeUndefined();
+    expect(log.settle('complete', { text: 'late change' })).toBeUndefined();
+    expect(log.getRange(0).find((entry) => entry.id === 'complete')).toEqual(
+      settled,
+    );
+    expect(log.drainEmission().dirtied).toEqual([]);
+  });
+
   it('assigns one durable settlement order when rows become printable', () => {
     const log = new StreamLog();
     const header = log.appendSettled({
@@ -138,7 +158,7 @@ describe('StreamLog', () => {
 
     expect(header.settlementSeqNo).toBe(1);
     expect(completed?.settlementSeqNo).toBe(2);
-    expect(revised?.settlementSeqNo).toBe(2);
+    expect(revised).toBeUndefined();
     expect(later.settlementSeqNo).toBe(3);
   });
 

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -101,6 +101,7 @@ describe('attachTranscriptRecorder StreamPhase-native group rows (issue #7993)',
     const endEntry = row(stage.id);
 
     expect(endEntry?.type).toBe(STREAM_LOG_ENTRY_TYPES.GROUP_END);
+    expect(endEntry?.settlementSeqNo).toBeDefined();
     expect(dataOf(endEntry).status).toBe(RUN_OUTCOME.COMPLETED);
   });
 
@@ -195,7 +196,7 @@ describe('attachTranscriptRecorder response.finalized (issue #7086)', () => {
     );
     expect(modelResponseEntries).toHaveLength(1);
     expect(modelResponseEntries[0]?.id).toBe(output.id);
-    expect(modelResponseEntries[0]?.text).toBe('Done \\checkmark');
+    expect(modelResponseEntries[0]?.text).toBe('Done ✓');
   });
 
   it('appends a fresh MODEL_RESPONSE entry when the round never streamed', () => {

--- a/src/transcript/StreamLog.ts
+++ b/src/transcript/StreamLog.ts
@@ -1,3 +1,4 @@
+import { createLog } from '@logger/logUtils';
 import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
@@ -9,6 +10,8 @@ import {
   type WorkflowCallProgress,
 } from '@shared/schemas';
 import { isObject } from '@utils/core';
+
+const logger = createLog('StreamLog');
 
 export type StreamLogAppendInput = Omit<
   StreamLogEntry,
@@ -479,10 +482,13 @@ export class StreamLog {
     if (index === undefined) return undefined;
 
     const current = this.entries[index];
-    const settlementSeqNo =
-      settle && current.settlementSeqNo === undefined
-        ? this.settlementSeqCounter + 1
-        : current.settlementSeqNo;
+    if (current.settlementSeqNo !== undefined) {
+      logger.warn(`Ignoring update to settled transcript entry: ${id}`);
+      return undefined;
+    }
+    const settlementSeqNo = settle
+      ? this.settlementSeqCounter + 1
+      : current.settlementSeqNo;
     if (
       settlementSeqNo === current.settlementSeqNo &&
       Object.entries(patch).every(([key, value]) =>

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -188,8 +188,8 @@ export function attachTranscriptRecorder(
       state.enabled = false;
     }
   };
-  // Stage presentation lives only on stage.start — `store.update` at
-  // stage.end replaces `data` wholesale (see StreamLog.update), so without
+  // Stage presentation lives only on stage.start — `store.settle` at
+  // stage.end replaces `data` wholesale (see StreamLog.settle), so without
   // this the persisted GROUP_END row would forget whether the stage was the
   // root "Run:" stage or a nested round/phase/session. Replayed legacy traces
   // rely on that distinction to tell a root run's terminal status apart from
@@ -324,7 +324,7 @@ export function attachTranscriptRecorder(
           if (event.kind === 'round' || event.kind === 'session') {
             pendingModelResponseId = undefined;
           }
-          writer.appendSettled({
+          writer.append({
             id: event.id,
             type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
             level: 'info',
@@ -344,7 +344,7 @@ export function attachTranscriptRecorder(
         case 'stage.end': {
           const metadata = stageMetadata.get(event.id);
           stageMetadata.delete(event.id);
-          writer.update(event.id, {
+          writer.settle(event.id, {
             type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
             data: {
               status: event.status ?? RUN_OUTCOME.COMPLETED,


### PR DESCRIPTION
Closes #10774.

Makes settled transcript entries immutable: late `update` or duplicate `settle` calls warn and leave the row unchanged. Group starts remain mutable while running and `stage.end` settles the same row, establishing one durable terminal coordinate.

Also makes late `response.finalized` reconciliation a loud, contained no-op once the stream entry has already settled.

Validation:
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- focused ESLint
- `corepack pnpm vitest run src/test-kernel/transcript/StreamLog.vitest.ts src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts --config vitest.config.mjs`