### PR TITLE
docs: clarify resume admission fallback

### DIFF
--- a/docs/proposals/2026-08-15-cross-host-consolidation.md
+++ b/docs/proposals/2026-08-15-cross-host-consolidation.md
@@ -510,7 +510,9 @@ login` does not sign in the GUI hosts and vice-versa. Ruling: is
   `canAcquireResumeLease` rechecks it under the lease lock. Desktop alone
   also checks the durable authoritative stream identity
   (`desktopAgentResume.ts:84-94`), fenced as desktop-only — extension/CLI
-  must not copy it.
+  must not copy it. The rejected shared-default admission port would wrongly
+  centralize host-owned cancellation; the optional port instead documents the
+  monotone contract while each host retains its own lifecycle authority.
 - **V5. Only the CLI settles executions at exit.** CLI shutdown
   (`runExecution.ts:344-399`) kills, persists `CANCELLED` with `'preserve'`,
   releases the lease, derives resumability, then advertises recovery.

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -212,9 +212,10 @@ export async function resolveAndResumeStream(
     return true;
   } catch (error) {
     if (isCancellationRequested()) return false;
-    // A workflow resume that loses the admission race is an expected
-    // cancellation, not a resume failure. Tool-use already classifies this
-    // same error as a silent `false`; the workflow branch must match it.
+    // Shipped hosts share this attempt's monotone cancellation latch, so the
+    // preceding check handles their lost-admission path. Keep this fallback
+    // for a future host that supplies the lease guard without the optional
+    // cancellation port: it must still fail silently rather than toast.
     if (error instanceof ResumeAdmissionCancelledError) return false;
     try {
       await ports.reportFailure?.(streamId, error);

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -212,10 +212,11 @@ export async function resolveAndResumeStream(
     return true;
   } catch (error) {
     if (isCancellationRequested()) return false;
-    // Shipped hosts share this attempt's monotone cancellation latch, so the
-    // preceding check handles their lost-admission path. Keep this fallback
-    // for a future host that supplies the lease guard without the optional
-    // cancellation port: it must still fail silently rather than toast.
+    // Shipped hosts that pass the lease guard share this attempt's monotone
+    // cancellation latch, so the preceding check handles their lost-admission
+    // path. Keep this fallback for a future host that supplies the lease guard
+    // without the optional cancellation port: it must still fail silently
+    // rather than toast.
     if (error instanceof ResumeAdmissionCancelledError) return false;
     try {
       await ports.reportFailure?.(streamId, error);


### PR DESCRIPTION
Closes #10771 and #10772.

Clarifies that shipped hosts use their monotone cancellation latch for admission loss, while the `ResumeAdmissionCancelledError` branch protects future optional-port callers. Records why V4 retained host-owned latches instead of a shared default admission port.

Validation:
- `corepack pnpm run typecheck:workspace`
- focused ESLint
- `corepack pnpm vitest run src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts --config vitest.config.mjs` (15 tests)