### PR TITLE
refactor: type stream log payloads at boundaries

### DIFF
--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -18,16 +18,13 @@ import { formatCliWorkflowCallLine } from '@cli/runtime/workflowCallText';
 import { TOOL_OUTPUT_CORNER } from '@cli/tui/ui/glyphs';
 import { redactSecrets } from '@logger/redaction';
 import {
-  ErrorLogDataSchema,
-  FileListEntrySchema,
-  GroupLogPayloadSchema,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
   TOOL_USE_STATUS,
-  WorkflowAttemptMarkerSchema,
-  WorkflowCallProgressSchema,
   isPlainAgentIdentity,
   isTerminalWorkflowCallProgress,
+  type ErrorLogData,
+  type FileListEntry,
   type StreamLogEntry,
   type TaskGroup,
 } from '@shared/schemas';
@@ -65,31 +62,13 @@ const MAX_ERROR_DETAIL_LENGTH = 240;
  * Project successful local context-media preparation. FILE_LIST does not
  * claim that a remote provider subsequently accepted the attachment.
  */
-function projectFileListImages(data: unknown): LoadedImage[] {
-  if (!Array.isArray(data)) return [];
-
-  const images: LoadedImage[] = [];
-  const seen = new Set<string>();
-  for (const candidate of data) {
-    const entry = FileListEntrySchema.safeParse(candidate);
-    if (
-      !entry.success ||
-      !entry.data.ok ||
-      entry.data.media?.kind !== 'image'
-    ) {
-      continue;
+function projectFileListImages(data: readonly FileListEntry[]): LoadedImage[] {
+  return data.flatMap((entry) => {
+    if (!entry.ok || entry.media?.kind !== 'image' || !entry.path.trim()) {
+      return [];
     }
-    if (!entry.data.path.trim()) continue;
-    const image = {
-      path: entry.data.path,
-      sizeBytes: entry.data.media.sizeBytes,
-    };
-    const key = `${image.path}\u0000${image.sizeBytes}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    images.push(image);
-  }
-  return images;
+    return [{ path: entry.path, sizeBytes: entry.media.sizeBytes }];
+  });
 }
 
 const TRANSCRIPT_MESSAGE_TYPES = new Set<string>([
@@ -204,12 +183,7 @@ function phaseGroupData(
   ) {
     return null;
   }
-  // Same parse `updateTaskGroups` uses for the identical group-log payload:
-  // display fields recover independently, while malformed attempt ownership
-  // rejects the payload and therefore cannot masquerade as a legacy omission.
-  const payload = GroupLogPayloadSchema.safeParse(entry.data);
-  if (!payload.success) return null;
-  const { kind, index, total, attemptId } = payload.data;
+  const { kind, index, total, attemptId } = entry.data;
   if (kind !== 'phase') return null;
   return {
     ...(index !== undefined ? { index } : {}),
@@ -226,29 +200,20 @@ function logEntryRole(
   return 'assistant';
 }
 
-function renderLogEntryText(
-  role: 'error' | 'user',
+function renderErrorLogEntryText(
   text: string,
-  data: unknown,
+  data: ErrorLogData | undefined,
 ): string {
-  switch (role) {
-    case 'error': {
-      const safeSummary = redactSecrets(safeTerminalText(text));
-      const parsed = ErrorLogDataSchema.safeParse(data);
-      if (!parsed.success) return appendCliApiSwitchHint(safeSummary);
-
-      const detail = truncateSummary(
-        redactSecrets(safeTerminalText(parsed.data.message)),
-        MAX_ERROR_DETAIL_LENGTH,
-      );
-      const withDetail = detail
-        ? `${safeSummary}\n${TOOL_OUTPUT_CORNER} ${detail}`
-        : safeSummary;
-      return appendCliApiSwitchHint(withDetail, parsed.data.exhaustionReason);
-    }
-    case 'user':
-      return summarizeFollowupMessage(text);
-  }
+  const safeSummary = redactSecrets(safeTerminalText(text));
+  if (!data) return appendCliApiSwitchHint(safeSummary);
+  const detail = truncateSummary(
+    redactSecrets(safeTerminalText(data.message)),
+    MAX_ERROR_DETAIL_LENGTH,
+  );
+  const withDetail = detail
+    ? `${safeSummary}\n${TOOL_OUTPUT_CORNER} ${detail}`
+    : safeSummary;
+  return appendCliApiSwitchHint(withDetail, data.exhaustionReason);
 }
 
 /**
@@ -314,9 +279,7 @@ function renderLogEntryFresh(
   }
 
   if (entry.messageType === MESSAGE_TYPES.WORKFLOW_TASK) {
-    const parsed = WorkflowCallProgressSchema.safeParse(entry.data);
-    if (!parsed.success) return null;
-    const call = parsed.data;
+    const call = entry.data;
     const next: ConversationEntry = {
       ...baseLogEntryFields(
         entry,
@@ -373,8 +336,10 @@ function renderLogEntryFresh(
   if (role === 'assistant') {
     assistantTranscript = trimAssistantTranscriptLead(text);
     renderedText = normalizeKnownHtmlForCliMarkdown(assistantTranscript);
+  } else if (entry.messageType === MESSAGE_TYPES.ERROR) {
+    renderedText = renderErrorLogEntryText(text, entry.data);
   } else {
-    renderedText = renderLogEntryText(role, text, entry.data);
+    renderedText = summarizeFollowupMessage(text);
   }
   if (
     role === 'assistant' &&
@@ -833,12 +798,16 @@ function applyChangedLogEntry(
     markerCandidate &&
     entry.seqNo >= state.workflowAttemptSeqNo
   ) {
-    const marker = WorkflowAttemptMarkerSchema.safeParse(entry.data);
     // A malformed declared boundary must supersede the preceding attempt.
     // Retaining its identifier would project prior-run rows as current.
-    state.workflowAttemptId = marker.success
-      ? marker.data.attemptId
-      : undefined;
+    state.workflowAttemptId =
+      typeof entry.data === 'object' &&
+      entry.data !== null &&
+      'attemptId' in entry.data &&
+      typeof entry.data.attemptId === 'string' &&
+      entry.data.attemptId.length > 0
+        ? entry.data.attemptId
+        : undefined;
     state.workflowAttemptBoundaryDeclared = true;
     state.workflowAttemptSeqNo = entry.seqNo;
   }

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -15,6 +15,7 @@ import {
   STREAM_PHASE,
   STREAM_STATUS,
   WorkflowCallProgressSchema,
+  StreamPhaseSchema,
   type GettingStartedAction,
   type LogMessageData,
   type StreamLifecycleStatus,
@@ -428,8 +429,7 @@ export class TaskGroupList extends LitElement {
     if (group.kind !== 'phase') return nothing;
     const calls = messages.flatMap((message) => {
       if (message.messageType !== MESSAGE_TYPES.WORKFLOW_TASK) return [];
-      const parsed = WorkflowCallProgressSchema.safeParse(message.data);
-      return parsed.success ? [parsed.data] : [];
+      return [message.data];
     });
     const { done, total } = workflowPhaseCallProgress(calls);
     if (total === 0) return nothing;

--- a/packages/extension/src/progressView/frontend/formatters/index.ts
+++ b/packages/extension/src/progressView/frontend/formatters/index.ts
@@ -7,9 +7,13 @@
 import { html, nothing, type TemplateResult } from 'lit';
 
 // Local imports - formatter helpers
-import type { LogMessageData, MessageType } from '@shared/schemas';
+import {
+  MESSAGE_TYPES,
+  type LogMessageData,
+  type LogMessageOf,
+  type MessageType,
+} from '@shared/schemas';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
-import { isObject } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
   isStreamingTextLogMessage,
@@ -38,10 +42,14 @@ import {
 } from './logFormatters/toolFormatters/webFormatters';
 import { formatWorkflowCallTemplate } from './logFormatters/workflowCallFormatter';
 
-type TemplateFormatterFn = (
-  message: LogMessageData,
+type TemplateFormatterFn<T extends MessageType> = (
+  message: LogMessageOf<T>,
   options?: FormatOptions & { isRunning?: boolean },
 ) => FormatResult;
+
+type TemplateFormatterMap = {
+  [T in MessageType]?: TemplateFormatterFn<T>;
+};
 
 /** Message types that render nothing when the formatter produces no result. */
 const NULLABLE_TYPES: Set<MessageType> = new Set([
@@ -63,10 +71,10 @@ function formatRenderError(label: string, errorMsg: string): TemplateResult {
  * `label` may be a fixed string or a function deriving the label from the
  * message (e.g. naming the tool in a tool-use error card).
  */
-function wrapWithErrorHandling(
-  fn: TemplateFormatterFn,
-  label: string | ((message: LogMessageData) => string),
-): TemplateFormatterFn {
+function wrapWithErrorHandling<T extends MessageType>(
+  fn: TemplateFormatterFn<T>,
+  label: string | ((message: LogMessageOf<T>) => string),
+): TemplateFormatterFn<T> {
   return (message, options) => {
     const resolvedLabel = typeof label === 'function' ? label(message) : label;
     try {
@@ -79,18 +87,24 @@ function wrapWithErrorHandling(
 }
 
 /** Name the tool in formatter errors so a bad card is actionable. */
-function getToolUseRenderLabel(message: LogMessageData): string {
-  const data = message.data;
-  if (!isObject(data)) return 'tool use';
-  const toolName = typeof data.toolName === 'string' ? data.toolName : '';
+function getToolUseRenderLabel(
+  message: LogMessageOf<typeof MESSAGE_TYPES.TOOL_USE>,
+): string {
+  const toolName = message.data.toolName ?? '';
   return toolName.trim() ? `tool use (${toolName.trim()})` : 'tool use';
 }
 
 /** Map of message types to their formatter functions. */
-const TEMPLATE_FORMATTERS: Partial<Record<MessageType, TemplateFormatterFn>> = {
+const TEMPLATE_FORMATTERS: TemplateFormatterMap = {
   // Collapsible content banners
-  thinking: wrapWithErrorHandling(formatBannerContentTemplate, 'thinking'),
-  scratchpad: wrapWithErrorHandling(formatBannerContentTemplate, 'scratchpad'),
+  thinking: wrapWithErrorHandling<typeof MESSAGE_TYPES.THINKING>(
+    formatBannerContentTemplate,
+    'thinking',
+  ),
+  scratchpad: wrapWithErrorHandling<typeof MESSAGE_TYPES.SCRATCHPAD>(
+    formatBannerContentTemplate,
+    'scratchpad',
+  ),
 
   // Tool/search/fetch results
   toolUse: wrapWithErrorHandling(formatToolUseTemplate, getToolUseRenderLabel),
@@ -98,7 +112,7 @@ const TEMPLATE_FORMATTERS: Partial<Record<MessageType, TemplateFormatterFn>> = {
   webFetch: wrapWithErrorHandling(formatWebFetchTemplate, 'web fetch'),
 
   // Model response
-  modelResponse: wrapWithErrorHandling(
+  modelResponse: wrapWithErrorHandling<typeof MESSAGE_TYPES.MODEL_RESPONSE>(
     formatBannerContentTemplate,
     'Assistant',
   ),
@@ -109,7 +123,10 @@ const TEMPLATE_FORMATTERS: Partial<Record<MessageType, TemplateFormatterFn>> = {
     formatMissingOutputsTemplate,
     'missing outputs',
   ),
-  latexdiff: wrapWithErrorHandling(formatLatexdiffTemplate, 'latexdiff'),
+  latexdiff: wrapWithErrorHandling<typeof MESSAGE_TYPES.LATEXDIFF>(
+    formatLatexdiffTemplate,
+    'latexdiff',
+  ),
   statistics: wrapWithErrorHandling(formatStatisticsTemplate, 'statistics'),
   contextManagement: wrapWithErrorHandling(
     formatContextManagementTemplate,
@@ -122,12 +139,11 @@ const TEMPLATE_FORMATTERS: Partial<Record<MessageType, TemplateFormatterFn>> = {
 
   // Special cases
   contextState: () => null, // Displayed in footer
-  contextCompactionActivity: wrapWithErrorHandling(
-    formatCompactionActivityTemplate,
-    'context compaction activity',
-  ),
+  contextCompactionActivity: wrapWithErrorHandling<
+    typeof MESSAGE_TYPES.CONTEXT_COMPACTION_ACTIVITY
+  >(formatCompactionActivityTemplate, 'context compaction activity'),
   userMessage: wrapWithErrorHandling(formatUserMessageTemplate, 'user message'),
-  progressStatus: wrapWithErrorHandling(
+  progressStatus: wrapWithErrorHandling<typeof MESSAGE_TYPES.PROGRESS_STATUS>(
     formatProgressStatusTemplate,
     'progress status',
   ),
@@ -153,7 +169,10 @@ export function formatLogEntry(
   const formatter = messageType ? TEMPLATE_FORMATTERS[messageType] : undefined;
 
   if (messageType && formatter) {
-    const result = formatter(logMessage, templateOptions);
+    // Runtime lookup preserves the messageType/payload correlation encoded by
+    // TemplateFormatterMap; TypeScript cannot retain that correlation through
+    // an indexed access over the full MessageType union.
+    const result = formatter(logMessage as never, templateOptions);
     if (result) return result;
     if (NULLABLE_TYPES.has(messageType)) return nothing;
   }

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
@@ -18,9 +18,9 @@ import type {
   StatItem,
 } from '@progressView/frontend/components/ContextManagement';
 import {
-  ContextManagementDataSchema,
+  MESSAGE_TYPES,
   type ContextManagementData,
-  type LogMessageData,
+  type LogMessageOf,
 } from '@shared/schemas';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { formatCompactTokenCount } from '@utils/core';
@@ -148,22 +148,19 @@ function buildContextManagementItems(data: ContextManagementData): {
 
 /** Format context management event as TemplateResult. */
 export function formatContextManagementTemplate(
-  message: LogMessageData,
+  message: LogMessageOf<typeof MESSAGE_TYPES.CONTEXT_MANAGEMENT>,
 ): FormatResult {
   const { id, data } = message;
 
-  const parsed = ContextManagementDataSchema.safeParse(data);
-  if (!parsed.success) return null;
-
   // Hide max_tokens_reduced events when the reduced value is still comfortable
   if (
-    parsed.data.action === 'max_tokens_reduced' &&
-    parsed.data.reducedMaxTokens >= MAX_TOKENS_REDUCED_DISPLAY_THRESHOLD
+    data.action === 'max_tokens_reduced' &&
+    data.reducedMaxTokens >= MAX_TOKENS_REDUCED_DISPLAY_THRESHOLD
   ) {
     return null;
   }
 
-  const { config, items, summary } = buildContextManagementItems(parsed.data);
+  const { config, items, summary } = buildContextManagementItems(data);
 
   return html`
     <context-management

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
@@ -7,9 +7,6 @@
  * templates with `// prettier-ignore` to prevent whitespace issues.
  */
 
-// Third-party imports
-import { z } from 'zod';
-
 // Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/details/details.js';
 
@@ -22,11 +19,13 @@ import { html, type TemplateResult } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 // Local imports - shared schemas and utilities
-import type { ExtendedTokenUsageStats, LogMessageData } from '@shared/schemas';
+import type {
+  ExtendedTokenUsageStats,
+  LogMessageData,
+  LogMessageOf,
+} from '@shared/schemas';
 import {
-  ExtendedTokenUsageStatsSchema,
-  FileListEntrySchema,
-  MissingOutputsPayloadSchema,
+  MESSAGE_TYPES,
   OUTPUT_DOCUMENTS_TAG,
   parseDiffResultEntries,
 } from '@shared/schemas';
@@ -64,22 +63,11 @@ function buildFileListDetails(options: {
 }
 
 /** Format file list entry as TemplateResult. */
-export function formatFileListTemplate(message: LogMessageData): FormatResult {
-  const { id, data, text } = message;
-  // Validate with Zod schema - renderer handles display field computation
-  const parseResult = z.array(FileListEntrySchema).safeParse(data);
-
-  // Raw fallback when parsing fails
-  if (!parseResult.success) {
-    return buildFileListDetails({
-      logId: id,
-      iconName: 'file',
-      label: 'Files (raw)',
-      items: html`<pre>${text ?? ''}</pre>`,
-    });
-  }
-
-  const { items, summary } = buildFileListRender(parseResult.data);
+export function formatFileListTemplate(
+  message: LogMessageOf<typeof MESSAGE_TYPES.FILE_LIST>,
+): FormatResult {
+  const { id, data } = message;
+  const { items, summary } = buildFileListRender(data);
   return buildFileListDetails({
     logId: id,
     iconName: 'file',
@@ -97,16 +85,10 @@ function renderXmlLink(xmlFile: string): TemplateResult {
 
 /** Format missing outputs entry as TemplateResult. */
 export function formatMissingOutputsTemplate(
-  message: LogMessageData,
+  message: LogMessageOf<typeof MESSAGE_TYPES.MISSING_OUTPUTS>,
 ): FormatResult {
   const { id, data } = message;
-  // Parse with Zod schema
-  const parseResult = MissingOutputsPayloadSchema.safeParse(data);
-  if (!parseResult.success) {
-    return null;
-  }
-
-  const { missing, xmlFile } = parseResult.data;
+  const { missing, xmlFile } = data;
 
   // Special case: only XML link, no missing files
   if (missing.length === 0 && xmlFile) {
@@ -206,14 +188,10 @@ const STATISTICS_CONFIG = Object.freeze({
 
 /** Format statistics entry as TemplateResult. */
 export function formatStatisticsTemplate(
-  message: LogMessageData,
+  message: LogMessageOf<typeof MESSAGE_TYPES.STATISTICS>,
 ): FormatResult {
   const { id, data } = message;
-  // Use partial schema to allow missing optional fields
-  const parseResult = ExtendedTokenUsageStatsSchema.partial().safeParse(data);
-  if (!parseResult.success) return null;
-
-  const stats = parseResult.data;
+  const stats = data;
   const items = STAT_FIELDS.filter(([key]) => stats[key] !== undefined).map(
     ([key, icon, label, formatter]) => ({
       icon,

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
@@ -23,11 +23,11 @@ import { when } from 'lit/directives/when.js';
 
 // Local imports - shared schemas and utilities
 import {
-  ErrorLogDataSchema,
-  UserMessagePayloadSchema,
+  MESSAGE_TYPES,
   type ErrorLogData,
   type LogLevel,
   type LogMessageData,
+  type LogMessageOf,
 } from '@shared/schemas';
 import { INCLUDED_ACCESS } from '@shared/copy/modelAccess';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
@@ -49,13 +49,10 @@ function buildLevelIcon(level: LogLevel): TemplateResult {
 
 /** Format user message entry as TemplateResult. */
 export function formatUserMessageTemplate(
-  message: LogMessageData,
+  message: LogMessageOf<typeof MESSAGE_TYPES.USER_MESSAGE>,
 ): FormatResult {
   const { id, text, timestamp, data } = message;
-  const payload = UserMessagePayloadSchema.safeParse(data);
-  const workflowSummary = payload.success
-    ? (payload.data.workflowSummary ?? null)
-    : null;
+  const workflowSummary = data?.workflowSummary ?? null;
   // prettier-ignore
   return html`<user-message .text=${text ?? ''} .logId=${id} .timestamp=${timestamp} .workflowSummary=${workflowSummary}></user-message>`;
 }
@@ -103,16 +100,14 @@ const ERROR_DETAIL_FIELDS = [
 ] as const satisfies ReadonlyArray<keyof ErrorLogData>;
 
 /** Format error message as TemplateResult. */
-export function formatErrorTemplate(message: LogMessageData): FormatResult {
+export function formatErrorTemplate(
+  message: LogMessageOf<typeof MESSAGE_TYPES.ERROR>,
+): FormatResult {
   const { id, groupId, timestamp, text, data } = message;
   const { fullTimestamp, timeDisplay, tooltipTimestamp } =
     formatDisplayTimestamp(new Date(timestamp));
 
-  // Parse error data with schema - use empty object if invalid
-  const parseResult = ErrorLogDataSchema.safeParse(data);
-  const errorData: Partial<ErrorLogData> = parseResult.success
-    ? parseResult.data
-    : {};
+  const errorData: Partial<ErrorLogData> = data ?? {};
   const isRelayError = errorData.isRelayError === true;
 
   // Build summary text (used for display and duplicate detection)

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -14,7 +14,7 @@
 import { html, nothing, type TemplateResult } from 'lit';
 
 // Local imports - shared utilities
-import type { LogMessageData } from '@shared/schemas';
+import { MESSAGE_TYPES, type LogMessageOf } from '@shared/schemas';
 import { normalizeToolUseForRender } from '@shared/toolUse';
 import {
   DELEGATE_MULTI_AGENTS_TOOL_NAME,
@@ -69,7 +69,7 @@ function inputPathOf(input: Record<string, unknown>): string {
 
 /** Format tool use log entry as TemplateResult. */
 export function formatToolUseTemplate(
-  message: LogMessageData,
+  message: LogMessageOf<typeof MESSAGE_TYPES.TOOL_USE>,
   options?: { executionLabels?: ExecutionLabels },
 ): FormatResult {
   const { timestamp, data } = message;
@@ -79,7 +79,7 @@ export function formatToolUseTemplate(
   // Keep the raw value local to this render so fallback sections can include
   // fields outside the common schema without retaining a second copy in UI
   // state.
-  const parsed = isObject(data) ? data : {};
+  const parsed = data;
 
   const {
     toolName,

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts
@@ -13,11 +13,7 @@ import {
   SPINNER_ICON_NAME,
 } from '@progressView/frontend/formatters/htmlBuilders';
 import type { FormatResult } from '@progressView/frontend/formatters/baseLogFormatter';
-import {
-  WebSearchPayloadSchema,
-  WebFetchPayloadSchema,
-  type LogMessageData,
-} from '@shared/schemas';
+import { MESSAGE_TYPES, type LogMessageOf } from '@shared/schemas';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { tryParseUrl } from '@utils/core';
@@ -42,15 +38,11 @@ const STATUS_ICONS: Record<string, TeXRAIconName | typeof SPINNER_ICON_NAME> = {
 };
 
 /** Format web search results as TemplateResult. */
-export function formatWebSearchTemplate(message: LogMessageData): FormatResult {
+export function formatWebSearchTemplate(
+  message: LogMessageOf<typeof MESSAGE_TYPES.WEB_SEARCH>,
+): FormatResult {
   const { data } = message;
-  if (!data || typeof data !== 'object') return null;
-
-  // Parsed (not merely cast) so `WebSearchPayloadItemSchema` actually
-  // sanitizes each result's `url` — a `javascript:`/`data:` scheme from a
-  // web_search tool result must never reach the `<a href>` below.
-  const { query, results, provider, status } =
-    WebSearchPayloadSchema.parse(data);
+  const { query, results, provider, status } = data;
   const searchResults = results ?? [];
   const resultCount = searchResults.length;
   const statusKey = status ?? '';
@@ -114,14 +106,11 @@ const FETCH_ERROR_LABELS: Record<string, string> = {
 };
 
 /** Format web fetch results as TemplateResult. */
-export function formatWebFetchTemplate(message: LogMessageData): FormatResult {
+export function formatWebFetchTemplate(
+  message: LogMessageOf<typeof MESSAGE_TYPES.WEB_FETCH>,
+): FormatResult {
   const { data } = message;
-  if (!data || typeof data !== 'object') return null;
-
-  // Parsed (not merely cast) so `WebFetchPayloadSchema` actually sanitizes
-  // `url` — a `javascript:`/`data:` scheme from a web_fetch tool result must
-  // never reach the `<a href>` below.
-  const { url, title, status, errorCode } = WebFetchPayloadSchema.parse(data);
+  const { url, title, status, errorCode } = data;
   const isFailed = status === 'failed';
 
   const iconName = isFailed ? 'circle-exclamation' : 'cloud-arrow-down';

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowCallFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowCallFormatter.ts
@@ -6,9 +6,9 @@ import { ProgressEvents } from '@progressView/frontend/events';
 
 // Local imports - shared contracts
 import {
+  MESSAGE_TYPES,
   WORKFLOW_TASK_STATUS_LABEL,
-  WorkflowCallProgressSchema,
-  type LogMessageData,
+  type LogMessageOf,
   type WorkflowCallProgress,
 } from '@shared/schemas';
 import {
@@ -47,9 +47,9 @@ function terminalMetadata(
 
 /** Render one workflow call as a status card updated in place by log id. */
 export function formatWorkflowCallTemplate(
-  message: LogMessageData,
+  message: LogMessageOf<typeof MESSAGE_TYPES.WORKFLOW_TASK>,
 ): TemplateResult {
-  const call = WorkflowCallProgressSchema.parse(message.data);
+  const call = message.data;
   const detail = workflowCallDetail(call);
   const hasChildStream = call.childStreamId !== undefined;
   const openChildStream = (event: Event): void => {

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -2,8 +2,6 @@ import { create } from 'mutative';
 
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
-  ActiveSkillsSnapshotSchema,
-  ContextStateDataSchema,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
   isToolUseState,
@@ -24,6 +22,9 @@ import { appState } from '../progressState';
 import { ensureStreamState, type StreamLogs } from '../store';
 
 function toLogMessage(entry: StreamLogEntry): LogMessageData {
+  // `entry` is already the messageType-discriminated source union. Object
+  // spread cannot retain that correlation, so reassert it after projecting
+  // only the shared envelope fields.
   return {
     id: entry.id,
     seqNo: entry.seqNo,
@@ -34,7 +35,7 @@ function toLogMessage(entry: StreamLogEntry): LogMessageData {
     ...(entry.messageType ? { messageType: entry.messageType } : {}),
     ...(entry.verbose !== undefined ? { verbose: entry.verbose } : {}),
     ...(entry.data !== undefined ? { data: entry.data } : {}),
-  };
+  } as LogMessageData;
 }
 
 interface EntryResult {
@@ -103,14 +104,7 @@ function applyEntry(
     if (!isToolUseState(streamState)) {
       return { logChanged: false, stateChanged: false, updatedIndices: [] };
     }
-    const snapshot = ActiveSkillsSnapshotSchema.safeParse(entry.data);
-    if (!snapshot.success) {
-      console.warn(
-        '[logSlice] Cleared malformed active-skills entry',
-        snapshot.error,
-      );
-    }
-    streamState.activeSkills = snapshot.success ? snapshot.data.skills : [];
+    streamState.activeSkills = entry.data.skills;
     return { logChanged: false, stateChanged: true, updatedIndices: [] };
   }
 
@@ -134,18 +128,8 @@ function applyEntry(
   );
 
   if (entry.messageType === MESSAGE_TYPES.CONTEXT_STATE) {
-    const contextState = ContextStateDataSchema.safeParse(entry.data);
-    if (contextState.success) {
-      streamState.contextState = contextState.data;
-      stateChanged = true;
-    } else {
-      // The context gauge silently freezing at its last value is the visible
-      // symptom of a producer/schema mismatch, so say so.
-      console.warn(
-        '[logSlice] Dropped malformed context-state entry',
-        contextState.error,
-      );
-    }
+    streamState.contextState = entry.data;
+    stateChanged = true;
   }
 
   if (entry.type !== STREAM_LOG_ENTRY_TYPES.LOG) {

--- a/packages/trace-viewer/src/replayTrace.ts
+++ b/packages/trace-viewer/src/replayTrace.ts
@@ -8,15 +8,15 @@ import type {
 } from '@shared/schemas';
 import {
   AgentCategory,
+  END_GROUP_STATUS,
   executionStatusToRunOutcome,
+  STREAM_PHASE,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_STATUS,
-  StreamLifecycleStatusSchema,
   streamStatusToLifecycleStatus,
 } from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import type { TraceDocument } from '@transcript';
-import { isObject } from '@utils/core';
 
 type UpdateStreamsMessage = Extract<
   ProgressViewOutboundMessage,
@@ -90,19 +90,16 @@ function findRootStageId(
  * terminal status does this default to `READY`, same as an unqualified
  * successful finish.
  *
- * The terminal group row's `data.status` is parsed with
- * `StreamLifecycleStatusSchema` (StreamPhase-or-legacy-StreamStatus union,
- * already shipped — §2), not the narrower legacy-only `StreamStatusSchema`:
+ * The terminal group row's `data.status` is typed at trace import as the
+ * StreamPhase-or-legacy-EndGroupStatus union, not narrowed here:
  * `assembleTrace()` (src/transcript/traceAssembler.ts) is a `StreamLogStore`
  * client, so every `TraceDocument` it builds — including one assembled from
  * pre-cutover on-disk history — carries the canonical `RunOutcome` values
  * `StreamLogStore.parsePersistedEntries` normalizes to (#7993 step 2), not
  * just the legacy 2-value `EndGroupStatus` strings a genuinely
  * externally-authored, never-reassembled `trace.json` predating this cutover
- * would still carry. `StreamLifecycleStatusSchema` accepts both, so this one
- * parse call keeps working for freshly-`assembleTrace()`d documents and for
- * historical exported files alike — no per-entry rewrite of `trace.entries`,
- * which stays exactly the future work §8.3 scopes separately.
+ * would still carry. The trace-import schema accepts both, so this projection
+ * works for freshly assembled documents and historical exported files alike.
  */
 function toStreamLifecycleStatus(trace: TraceDocument): StreamLifecycleStatus {
   if (trace.terminalStatus !== null) {
@@ -113,9 +110,7 @@ function toStreamLifecycleStatus(trace: TraceDocument): StreamLifecycleStatus {
   for (const entry of trace.entries.toReversed()) {
     if (entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_END) continue;
     if (entry.groupId !== undefined) continue;
-    if (!isObject(entry.data)) continue;
-    const kind =
-      typeof entry.data.kind === 'string' ? entry.data.kind : undefined;
+    const kind = entry.data.kind;
     if (kind !== undefined) {
       if (NESTED_STAGE_KINDS.has(kind)) continue;
     } else if (entry.id !== rootStageId) {
@@ -126,8 +121,13 @@ function toStreamLifecycleStatus(trace: TraceDocument): StreamLifecycleStatus {
       // else sharing the "no parent" shape is a nested round/phase/session.
       continue;
     }
-    const status = StreamLifecycleStatusSchema.safeParse(entry.data.status);
-    if (status.success) return status.data;
+    if (entry.data.status === END_GROUP_STATUS.ERROR) {
+      return STREAM_PHASE.FAILED;
+    }
+    if (entry.data.status === END_GROUP_STATUS.STOPPED) {
+      return STREAM_PHASE.COMPLETED;
+    }
+    if (entry.data.status !== undefined) return entry.data.status;
   }
   return trace.snapshot.status
     ? streamStatusToLifecycleStatus(trace.snapshot.status)

--- a/packages/trace-viewer/src/traceDataSchema.ts
+++ b/packages/trace-viewer/src/traceDataSchema.ts
@@ -10,6 +10,7 @@ import { TraceDocumentSchema } from '@transcript/traceDocumentSchema';
 import {
   STREAM_SNAPSHOT_SCHEMA_VERSION,
   StreamSnapshotSchema,
+  TraceStreamLogEntrySchema,
 } from '@shared/schemas';
 
 const TraceStreamSnapshotSchema = StreamSnapshotSchema.extend({
@@ -19,6 +20,7 @@ const TraceStreamSnapshotSchema = StreamSnapshotSchema.extend({
 });
 
 export const TraceDataSchema = TraceDocumentSchema.extend({
+  entries: z.array(TraceStreamLogEntrySchema),
   snapshot: TraceStreamSnapshotSchema,
 });
 

--- a/src/model/projectWorkflowCallEntry.ts
+++ b/src/model/projectWorkflowCallEntry.ts
@@ -2,7 +2,6 @@ import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
-  WorkflowCallProgressSchema,
   type StreamLogEntry,
 } from '@shared/schemas';
 
@@ -26,14 +25,11 @@ export function projectWorkflowCallEntry(
   ) {
     return entry;
   }
-  const data = entry.data;
-  if (typeof data !== 'object' || data === null) return entry;
-  const call = WorkflowCallProgressSchema.safeParse(data);
-  if (!call.success) return entry;
-  if (!('model' in call.data) || call.data.model === undefined) return entry;
-  const model = getRuntimeModelLabel(call.data.model);
-  if (model === call.data.model) return entry;
-  return { ...entry, data: { ...data, model } };
+  const call = entry.data;
+  if (!('model' in call) || call.model === undefined) return entry;
+  const model = getRuntimeModelLabel(call.model);
+  if (model === call.model) return entry;
+  return { ...entry, data: { ...call, model } } as StreamLogEntry;
 }
 
 /** Project every entry in a trace/stream-log range. */

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -44,6 +44,7 @@ export * from './workflowScriptDelivery';
 
 // Layer 3: Depends on layer 2
 export * from './log';
+export * from './streamLogEntry';
 export * from './taskGroup';
 export * from './todo';
 export * from './todoDisplay';

--- a/src/shared/schemas/log.ts
+++ b/src/shared/schemas/log.ts
@@ -76,7 +76,7 @@ export const STREAM_LOG_ENTRY_TYPES = {
   GROUP_END: 'group-end',
 } as const;
 
-export const StreamLogEntryTypeSchema = z.enum(STREAM_LOG_ENTRY_TYPES);
+const StreamLogEntryTypeSchema = z.enum(STREAM_LOG_ENTRY_TYPES);
 
 const LoadedMediaMetadataSchema = z.discriminatedUnion('kind', [
   z.object({

--- a/src/shared/schemas/log.ts
+++ b/src/shared/schemas/log.ts
@@ -7,7 +7,7 @@ export const LOG_LEVELS = {
   DEBUG: 'debug',
 } as const;
 
-const LogLevelSchema = z.enum(LOG_LEVELS);
+export const LogLevelSchema = z.enum(LOG_LEVELS);
 export type LogLevel = z.infer<typeof LogLevelSchema>;
 
 /**
@@ -54,7 +54,7 @@ export const MESSAGE_TYPES = {
   DEFAULT: 'default',
 } as const;
 
-const MessageTypeSchema = z.enum(MESSAGE_TYPES);
+export const MessageTypeSchema = z.enum(MESSAGE_TYPES);
 
 export type MessageType = z.infer<typeof MessageTypeSchema>;
 
@@ -76,7 +76,7 @@ export const STREAM_LOG_ENTRY_TYPES = {
   GROUP_END: 'group-end',
 } as const;
 
-const StreamLogEntryTypeSchema = z.enum(STREAM_LOG_ENTRY_TYPES);
+export const StreamLogEntryTypeSchema = z.enum(STREAM_LOG_ENTRY_TYPES);
 
 const LoadedMediaMetadataSchema = z.discriminatedUnion('kind', [
   z.object({
@@ -110,48 +110,8 @@ export const FileListEntrySchema = z.object({
 
 export type FileListEntry = z.infer<typeof FileListEntrySchema>;
 
-export const StreamLogEntrySchema = z.strictObject({
-  seqNo: z.int().positive(),
-  /**
-   * Monotone order in which immutable transcript rows became printable.
-   * Unlike seqNo, this is assigned when an existing row settles, so cold
-   * reconstruction preserves the same append-only chronology as a live UI.
-   */
-  settlementSeqNo: z.int().positive().optional(),
-  id: z.string().min(1),
-  type: StreamLogEntryTypeSchema,
-  level: LogLevelSchema,
-  timestamp: z.number(),
-  groupId: z.string().optional(),
-  messageType: MessageTypeSchema.optional(),
-  text: z.string().optional(),
-  verbose: z.boolean().optional(),
-  data: z.unknown().optional(),
-});
-
-export type StreamLogEntry = z.infer<typeof StreamLogEntrySchema>;
-
 export const StreamLogTextDeltaSchema = z.strictObject({
   id: z.string().min(1),
   appendText: z.string().min(1),
 });
 export type StreamLogTextDelta = z.infer<typeof StreamLogTextDeltaSchema>;
-
-const LogMessageDataSchema = z.strictObject({
-  id: z.string().min(1),
-  /**
-   * Wire append sequence of the source `StreamLogEntry`, carried through so
-   * the frontend can order live rows by `seqNo` instead of wall-clock
-   * `timestamp`. Optional for archived/compat rows predating sequence
-   * tracking; ordering falls back to `timestamp` when it is absent.
-   */
-  seqNo: z.int().positive().optional(),
-  text: z.string(),
-  level: LogLevelSchema,
-  timestamp: z.number(),
-  groupId: z.string().optional(),
-  messageType: MessageTypeSchema.optional(),
-  verbose: z.boolean().optional(),
-  data: z.unknown().optional(),
-});
-export type LogMessageData = z.infer<typeof LogMessageDataSchema>;

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -19,7 +19,7 @@ import { AgentCategory } from '../agent';
 
 import { StreamTabIdSchema } from '../identifiers';
 import { StreamLogTextDeltaSchema } from '../log';
-import { StreamLogEntrySchema } from '../streamLogEntry';
+import { StreamLogEntryBatchSchema } from '../streamLogEntry';
 import {
   AgentOptionDataSchema,
   ModelOptionDataSchema,
@@ -119,8 +119,8 @@ export const UpdateStreamStatusMessageSchema = StreamScopedBaseSchema.extend({
 const LogDeltaMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.LOG_DELTA),
   streamId: StreamTabIdSchema,
-  entries: z.array(StreamLogEntrySchema),
-  updates: z.array(StreamLogEntrySchema).prefault([]),
+  entries: StreamLogEntryBatchSchema,
+  updates: StreamLogEntryBatchSchema.prefault([]),
   textDeltas: z.array(StreamLogTextDeltaSchema).prefault([]),
 });
 

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -18,7 +18,8 @@ import { GoalStatusSchema } from '../goal';
 import { AgentCategory } from '../agent';
 
 import { StreamTabIdSchema } from '../identifiers';
-import { StreamLogEntrySchema, StreamLogTextDeltaSchema } from '../log';
+import { StreamLogTextDeltaSchema } from '../log';
+import { StreamLogEntrySchema } from '../streamLogEntry';
 import {
   AgentOptionDataSchema,
   ModelOptionDataSchema,

--- a/src/shared/schemas/streamLogEntry.ts
+++ b/src/shared/schemas/streamLogEntry.ts
@@ -1,0 +1,291 @@
+import { z } from 'zod';
+
+import { ActiveSkillsSnapshotSchema } from './activeSkills';
+import {
+  CompactionActivityDataSchema,
+  ContextManagementDataSchema,
+  ContextStateDataSchema,
+} from './contextManagement';
+import { ErrorLogDataSchema } from './errors';
+import {
+  FileListEntrySchema,
+  LogLevelSchema,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  MessageTypeSchema,
+} from './log';
+import {
+  MissingOutputsPayloadSchema,
+  ToolUseLogSchema,
+  UserMessagePayloadSchema,
+  WebFetchPayloadSchema,
+  WebSearchPayloadSchema,
+} from './progressView/data';
+import { GroupLogPayloadSchema, TraceGroupLogPayloadSchema } from './taskGroup';
+import { ExtendedTokenUsageStatsSchema } from './usage';
+import { WorkflowCallProgressSchema } from './workflowCallProgress';
+
+const StreamingTextDataSchema = z.looseObject({
+  status: z.enum(['running', 'completed']).optional(),
+  archivedRole: z.string().optional(),
+});
+
+/** One payload contract per MessageType; both transcript and UI rows reuse it. */
+const StreamMessageDataSchemas = {
+  [MESSAGE_TYPES.THINKING]: StreamingTextDataSchema.optional(),
+  [MESSAGE_TYPES.SCRATCHPAD]: StreamingTextDataSchema.optional(),
+  [MESSAGE_TYPES.FILE_LIST]: z.array(FileListEntrySchema),
+  [MESSAGE_TYPES.MISSING_OUTPUTS]: MissingOutputsPayloadSchema,
+  [MESSAGE_TYPES.LATEXDIFF]: z.unknown().optional(),
+  [MESSAGE_TYPES.STATISTICS]: ExtendedTokenUsageStatsSchema.partial(),
+  [MESSAGE_TYPES.TOOL_USE]: ToolUseLogSchema,
+  [MESSAGE_TYPES.WEB_SEARCH]: WebSearchPayloadSchema,
+  [MESSAGE_TYPES.WEB_FETCH]: WebFetchPayloadSchema,
+  [MESSAGE_TYPES.MODEL_RESPONSE]: StreamingTextDataSchema.optional(),
+  [MESSAGE_TYPES.USER_MESSAGE]: UserMessagePayloadSchema.optional(),
+  [MESSAGE_TYPES.PROGRESS_STATUS]: z.unknown().optional(),
+  [MESSAGE_TYPES.CONTEXT_COMPACTION_ACTIVITY]: CompactionActivityDataSchema,
+  [MESSAGE_TYPES.ERROR]: ErrorLogDataSchema.optional(),
+  [MESSAGE_TYPES.INTERNAL]: z.unknown().optional(),
+  [MESSAGE_TYPES.CONTEXT_MANAGEMENT]: ContextManagementDataSchema,
+  [MESSAGE_TYPES.CONTEXT_STATE]: ContextStateDataSchema,
+  [MESSAGE_TYPES.ACTIVE_SKILLS]: ActiveSkillsSnapshotSchema,
+  [MESSAGE_TYPES.WORKFLOW_TASK]: WorkflowCallProgressSchema,
+  [MESSAGE_TYPES.DEFAULT]: z.unknown().optional(),
+} satisfies Record<z.infer<typeof MessageTypeSchema>, z.ZodType>;
+
+const LogMessageDataSchemas = {
+  ...StreamMessageDataSchemas,
+  // The frontend projection synthesizes a CompactionActivityBlock from one
+  // or more source lifecycle rows before creating the display message.
+  [MESSAGE_TYPES.CONTEXT_COMPACTION_ACTIVITY]: z.unknown(),
+};
+
+const streamLogSharedFields = {
+  seqNo: z.int().positive(),
+  /**
+   * Monotone order in which immutable transcript rows became printable.
+   * Unlike seqNo, this is assigned when an existing row settles, so cold
+   * reconstruction preserves the same append-only chronology as a live UI.
+   */
+  settlementSeqNo: z.int().positive().optional(),
+  id: z.string().min(1),
+  level: LogLevelSchema,
+  timestamp: z.number(),
+  groupId: z.string().optional(),
+  text: z.string().optional(),
+  verbose: z.boolean().optional(),
+};
+
+const logEntryBase = z.strictObject({
+  ...streamLogSharedFields,
+  type: z.literal(STREAM_LOG_ENTRY_TYPES.LOG),
+});
+
+const messageEntry = <T extends string, S extends z.ZodType>(
+  messageType: T,
+  data: S,
+) =>
+  logEntryBase.extend({
+    messageType: z.literal(messageType),
+    data,
+  });
+
+const StreamLogMessageEntrySchema = z.discriminatedUnion('messageType', [
+  messageEntry(MESSAGE_TYPES.THINKING, StreamMessageDataSchemas.thinking),
+  messageEntry(MESSAGE_TYPES.SCRATCHPAD, StreamMessageDataSchemas.scratchpad),
+  messageEntry(MESSAGE_TYPES.FILE_LIST, StreamMessageDataSchemas.fileList),
+  messageEntry(
+    MESSAGE_TYPES.MISSING_OUTPUTS,
+    StreamMessageDataSchemas.missingOutputs,
+  ),
+  messageEntry(MESSAGE_TYPES.LATEXDIFF, StreamMessageDataSchemas.latexdiff),
+  messageEntry(MESSAGE_TYPES.STATISTICS, StreamMessageDataSchemas.statistics),
+  messageEntry(MESSAGE_TYPES.TOOL_USE, StreamMessageDataSchemas.toolUse),
+  messageEntry(MESSAGE_TYPES.WEB_SEARCH, StreamMessageDataSchemas.webSearch),
+  messageEntry(MESSAGE_TYPES.WEB_FETCH, StreamMessageDataSchemas.webFetch),
+  messageEntry(
+    MESSAGE_TYPES.MODEL_RESPONSE,
+    StreamMessageDataSchemas.modelResponse,
+  ),
+  messageEntry(
+    MESSAGE_TYPES.USER_MESSAGE,
+    StreamMessageDataSchemas.userMessage,
+  ),
+  messageEntry(
+    MESSAGE_TYPES.PROGRESS_STATUS,
+    StreamMessageDataSchemas.progressStatus,
+  ),
+  messageEntry(
+    MESSAGE_TYPES.CONTEXT_COMPACTION_ACTIVITY,
+    StreamMessageDataSchemas.contextCompactionActivity,
+  ),
+  messageEntry(MESSAGE_TYPES.ERROR, StreamMessageDataSchemas.error),
+  messageEntry(MESSAGE_TYPES.INTERNAL, StreamMessageDataSchemas.internal),
+  messageEntry(
+    MESSAGE_TYPES.CONTEXT_MANAGEMENT,
+    StreamMessageDataSchemas.contextManagement,
+  ),
+  messageEntry(
+    MESSAGE_TYPES.CONTEXT_STATE,
+    StreamMessageDataSchemas.contextState,
+  ),
+  messageEntry(
+    MESSAGE_TYPES.ACTIVE_SKILLS,
+    StreamMessageDataSchemas.activeSkills,
+  ),
+  messageEntry(
+    MESSAGE_TYPES.WORKFLOW_TASK,
+    StreamMessageDataSchemas.workflowTask,
+  ),
+  messageEntry(MESSAGE_TYPES.DEFAULT, StreamMessageDataSchemas.default),
+]);
+
+const MessageTypeAbsentLogEntrySchema = logEntryBase.extend({
+  messageType: z.undefined().optional(),
+  data: z.unknown().optional(),
+});
+
+const GroupStreamLogEntrySchema = z.strictObject({
+  ...streamLogSharedFields,
+  type: z.enum([
+    STREAM_LOG_ENTRY_TYPES.GROUP_START,
+    STREAM_LOG_ENTRY_TYPES.GROUP_END,
+  ]),
+  messageType: z.literal(MESSAGE_TYPES.DEFAULT).optional(),
+  data: GroupLogPayloadSchema.prefault({}),
+});
+
+/**
+ * Canonical stream-log row. Log payloads are discriminated by `messageType`;
+ * group payloads use the entry `type` because group rows have no semantic
+ * message payload. Persistence and trace import parse this contract once so
+ * downstream projections receive typed data directly.
+ */
+export const StreamLogEntrySchema = z.union([
+  GroupStreamLogEntrySchema,
+  StreamLogMessageEntrySchema,
+  MessageTypeAbsentLogEntrySchema,
+]);
+
+export type StreamLogEntry = z.infer<typeof StreamLogEntrySchema>;
+
+export type StreamLogEntryOf<
+  T extends NonNullable<StreamLogEntry['messageType']>,
+> = Extract<StreamLogEntry, { messageType: T }>;
+
+const StreamLogEntryEnvelopeSchema = z.union([
+  logEntryBase.extend({
+    messageType: MessageTypeSchema.optional(),
+    data: z.unknown().optional(),
+  }),
+  GroupStreamLogEntrySchema.extend({ data: z.unknown().optional() }),
+]);
+
+/**
+ * Exported traces are a permanent compatibility boundary. Parse each row
+ * independently: recover stale group display fields field-by-field, and
+ * degrade any other malformed typed payload to a generic row so one old
+ * nested payload cannot make the whole trace unusable.
+ */
+export const TraceStreamLogEntrySchema = z
+  .unknown()
+  .transform((raw, context): StreamLogEntry => {
+    const canonical = StreamLogEntrySchema.safeParse(raw);
+    if (canonical.success) return canonical.data;
+
+    const envelope = StreamLogEntryEnvelopeSchema.safeParse(raw);
+    if (!envelope.success) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Invalid stream-log entry envelope',
+      });
+      return z.NEVER;
+    }
+
+    const entry = envelope.data;
+    if (entry.type !== STREAM_LOG_ENTRY_TYPES.LOG) {
+      const recovered = TraceGroupLogPayloadSchema.safeParse(entry.data ?? {});
+      if (recovered.success) {
+        return StreamLogEntrySchema.parse({ ...entry, data: recovered.data });
+      }
+    }
+
+    return StreamLogEntrySchema.parse({
+      ...entry,
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      data: entry.data,
+    });
+  });
+
+const logMessageSharedFields = {
+  id: z.string().min(1),
+  /**
+   * Wire append sequence of the source `StreamLogEntry`, carried through so
+   * the frontend can order live rows by `seqNo` instead of wall-clock
+   * `timestamp`. Optional for archived/compat rows predating sequence
+   * tracking; ordering falls back to `timestamp` when it is absent.
+   */
+  seqNo: z.int().positive().optional(),
+  text: z.string(),
+  level: LogLevelSchema,
+  timestamp: z.number(),
+  groupId: z.string().optional(),
+  verbose: z.boolean().optional(),
+};
+
+const logMessageBase = z.strictObject(logMessageSharedFields);
+const logMessage = <T extends string, S extends z.ZodType>(
+  messageType: T,
+  data: S,
+) => logMessageBase.extend({ messageType: z.literal(messageType), data });
+
+export const LogMessageDataSchema = z.union([
+  z.discriminatedUnion('messageType', [
+    logMessage(MESSAGE_TYPES.THINKING, LogMessageDataSchemas.thinking),
+    logMessage(MESSAGE_TYPES.SCRATCHPAD, LogMessageDataSchemas.scratchpad),
+    logMessage(MESSAGE_TYPES.FILE_LIST, LogMessageDataSchemas.fileList),
+    logMessage(
+      MESSAGE_TYPES.MISSING_OUTPUTS,
+      LogMessageDataSchemas.missingOutputs,
+    ),
+    logMessage(MESSAGE_TYPES.LATEXDIFF, LogMessageDataSchemas.latexdiff),
+    logMessage(MESSAGE_TYPES.STATISTICS, LogMessageDataSchemas.statistics),
+    logMessage(MESSAGE_TYPES.TOOL_USE, LogMessageDataSchemas.toolUse),
+    logMessage(MESSAGE_TYPES.WEB_SEARCH, LogMessageDataSchemas.webSearch),
+    logMessage(MESSAGE_TYPES.WEB_FETCH, LogMessageDataSchemas.webFetch),
+    logMessage(
+      MESSAGE_TYPES.MODEL_RESPONSE,
+      LogMessageDataSchemas.modelResponse,
+    ),
+    logMessage(MESSAGE_TYPES.USER_MESSAGE, LogMessageDataSchemas.userMessage),
+    logMessage(
+      MESSAGE_TYPES.PROGRESS_STATUS,
+      LogMessageDataSchemas.progressStatus,
+    ),
+    logMessage(
+      MESSAGE_TYPES.CONTEXT_COMPACTION_ACTIVITY,
+      LogMessageDataSchemas.contextCompactionActivity,
+    ),
+    logMessage(MESSAGE_TYPES.ERROR, LogMessageDataSchemas.error),
+    logMessage(MESSAGE_TYPES.INTERNAL, LogMessageDataSchemas.internal),
+    logMessage(
+      MESSAGE_TYPES.CONTEXT_MANAGEMENT,
+      LogMessageDataSchemas.contextManagement,
+    ),
+    logMessage(MESSAGE_TYPES.CONTEXT_STATE, LogMessageDataSchemas.contextState),
+    logMessage(MESSAGE_TYPES.ACTIVE_SKILLS, LogMessageDataSchemas.activeSkills),
+    logMessage(MESSAGE_TYPES.WORKFLOW_TASK, LogMessageDataSchemas.workflowTask),
+    logMessage(MESSAGE_TYPES.DEFAULT, LogMessageDataSchemas.default),
+  ]),
+  logMessageBase.extend({
+    messageType: z.undefined().optional(),
+    data: z.unknown().optional(),
+  }),
+]);
+
+export type LogMessageData = z.infer<typeof LogMessageDataSchema>;
+
+export type LogMessageOf<T extends NonNullable<LogMessageData['messageType']>> =
+  Extract<LogMessageData, { messageType: T }>;

--- a/src/shared/schemas/streamLogEntry.ts
+++ b/src/shared/schemas/streamLogEntry.ts
@@ -182,13 +182,8 @@ const StreamLogEntryEnvelopeSchema = z.union([
   GroupStreamLogEntrySchema.extend({ data: z.unknown().optional() }),
 ]);
 
-/**
- * Exported traces are a permanent compatibility boundary. Parse each row
- * independently: recover stale group display fields field-by-field, and
- * degrade any other malformed typed payload to a generic row so one old
- * nested payload cannot make the whole trace unusable.
- */
-export const TraceStreamLogEntrySchema = z
+/** Recover a well-formed stream-log envelope with a malformed nested payload. */
+const ResilientStreamLogEntrySchema = z
   .unknown()
   .transform((raw, context): StreamLogEntry => {
     const canonical = StreamLogEntrySchema.safeParse(raw);
@@ -218,6 +213,29 @@ export const TraceStreamLogEntrySchema = z
       data: entry.data,
     });
   });
+
+/**
+ * Exported traces are a permanent compatibility boundary. Parse each row
+ * independently: recover stale group display fields field-by-field, and
+ * degrade any other malformed typed payload to a generic row so one old
+ * nested payload cannot make the whole trace unusable.
+ */
+export const TraceStreamLogEntrySchema = ResilientStreamLogEntrySchema;
+
+/**
+ * Live deltas are a batch transport boundary. Recover each well-formed row
+ * independently so one stale nested payload cannot discard later entries in
+ * the same frame. Rows without even a stream-log envelope are omitted: there
+ * is no stable id, sequence, or type from which to construct a safe row.
+ */
+export const StreamLogEntryBatchSchema = z
+  .array(z.unknown())
+  .transform((entries) =>
+    entries.flatMap((entry) => {
+      const parsed = ResilientStreamLogEntrySchema.safeParse(entry);
+      return parsed.success ? [parsed.data] : [];
+    }),
+  );
 
 const logMessageSharedFields = {
   id: z.string().min(1),

--- a/src/shared/schemas/taskGroup.ts
+++ b/src/shared/schemas/taskGroup.ts
@@ -32,12 +32,6 @@ export type TaskGroup = z.infer<typeof TaskGroupSchema>;
  * `status`/`kind` membership with hand-rolled type guards duplicating
  * `TaskGroupStatusSchema`/`StageKindSchema`.
  *
- * Each field validates (and recovers via `.catch(undefined)`) independently
- * so one invalid field — e.g. an unrecognized `status` from an older/newer
- * producer — doesn't fail the whole payload and drop sibling fields that
- * were otherwise usable; the old per-field guards had this per-field
- * tolerance and a single `.safeParse()` on a non-catching schema would not.
- *
  * `status` accepts both vocabularies a wire row can still carry post-#7993
  * step 3: the native `TaskGroupStatus` (the `StreamPhase` running/completed/
  * cancelled/failed subset) every live/persisted `group-start`/`group-end`
@@ -50,20 +44,36 @@ export type TaskGroup = z.infer<typeof TaskGroupSchema>;
  * is a strict subset of it and needs no separate union member; only the
  * still-disjoint legacy `EndGroupStatus` vocabulary does. The shared
  * projection maps a legacy value UP to the native value it corresponds to;
- * a value in neither vocabulary still falls back to `undefined` here, same
- * as any other display field. `attemptId` is different: it owns physical-run
+ * a value in neither vocabulary is rejected at the canonical persistence
+ * boundary. Exported traces recover stale display fields independently in
+ * `TraceGroupLogPayloadSchema`. `attemptId` is different: it owns physical-run
  * identity, so genuine absence remains valid for older rows while a malformed
  * present value rejects the payload instead of becoming a legacy omission.
  */
-export const GroupLogPayloadSchema = z.looseObject({
-  status: z
-    .union([TaskGroupStatusSchema, EndGroupStatusSchema])
-    .optional()
-    .catch(undefined),
-  kind: StageKindSchema.optional().catch(undefined),
-  index: taskGroupIndexField.optional().catch(undefined),
-  total: taskGroupTotalField.optional().catch(undefined),
+const groupLogPayloadFields = {
+  status: z.union([TaskGroupStatusSchema, EndGroupStatusSchema]).optional(),
+  kind: StageKindSchema.optional(),
+  index: taskGroupIndexField.optional(),
+  total: taskGroupTotalField.optional(),
   attemptId: z.string().min(1).optional(),
-  name: z.string().optional().catch(undefined),
-  endTime: taskGroupEndTimeField.optional().catch(undefined),
+  name: z.string().optional(),
+  endTime: taskGroupEndTimeField.optional(),
+};
+
+export const GroupLogPayloadSchema = z.looseObject(groupLogPayloadFields);
+
+/**
+ * Permanent exported-trace recovery for group rows written by older versions.
+ * Each display-only field recovers independently so one stale value does not
+ * discard the whole trace entry. Attempt identity remains strict because
+ * erasing malformed ownership would attach work to the wrong physical run.
+ */
+export const TraceGroupLogPayloadSchema = z.looseObject({
+  ...groupLogPayloadFields,
+  status: groupLogPayloadFields.status.catch(undefined),
+  kind: groupLogPayloadFields.kind.catch(undefined),
+  index: groupLogPayloadFields.index.catch(undefined),
+  total: groupLogPayloadFields.total.catch(undefined),
+  name: groupLogPayloadFields.name.catch(undefined),
+  endTime: groupLogPayloadFields.endTime.catch(undefined),
 });

--- a/src/shared/schemas/workflowCallProgress.ts
+++ b/src/shared/schemas/workflowCallProgress.ts
@@ -22,12 +22,11 @@ export const WorkflowCallIdentitySchema = z.strictObject({
 });
 export type WorkflowCallIdentity = z.infer<typeof WorkflowCallIdentitySchema>;
 
-/** Durable boundary between physical runs appended to one workflow stream. */
-export const WorkflowAttemptMarkerSchema = z.strictObject({
-  kind: z.literal('workflowAttempt'),
-  attemptId: z.string().min(1),
-});
-export type WorkflowAttemptMarker = z.infer<typeof WorkflowAttemptMarkerSchema>;
+/** Durable boundary emitted by the controlled workflow transcript writer. */
+export type WorkflowAttemptMarker = {
+  readonly kind: 'workflowAttempt';
+  readonly attemptId: string;
+};
 
 const WorkflowCallTerminalMetadataSchema = z.strictObject({
   model: z.string().min(1).optional(),

--- a/src/shared/streams/compactionActivityProjection.ts
+++ b/src/shared/streams/compactionActivityProjection.ts
@@ -1,5 +1,4 @@
 import {
-  CompactionActivityDataSchema,
   MESSAGE_TYPES,
   type CompactionActivityOutcome,
   type StreamLogEntry,
@@ -106,9 +105,7 @@ export function applyCompactionActivityEntries(
       continue;
     }
 
-    const parsed = CompactionActivityDataSchema.safeParse(entry.data);
-    if (!parsed.success) continue;
-    const { operationId, state } = parsed.data;
+    const { operationId, state } = entry.data;
     const existingIndex = projection.indexByOperationId.get(operationId);
 
     if (state === 'started') {

--- a/src/shared/streams/taskGroupProjection.ts
+++ b/src/shared/streams/taskGroupProjection.ts
@@ -7,10 +7,8 @@
 
 import {
   END_GROUP_STATUS,
-  GroupLogPayloadSchema,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_PHASE,
-  TaskGroupStatusSchema,
   type EndGroupStatus,
   type StreamLogEntry,
   type TaskGroup,
@@ -27,12 +25,11 @@ import {
 function taskGroupEndStatus(
   value: TaskGroupStatus | EndGroupStatus | undefined,
 ): TaskGroupStatus {
-  const native = TaskGroupStatusSchema.safeParse(value);
-  if (native.success) return native.data;
   if (value === END_GROUP_STATUS.ERROR) return STREAM_PHASE.FAILED;
-  // Legacy `stopped`, an unrecognized value, and an absent one all read as a
-  // group that ended without a recorded failure.
-  return STREAM_PHASE.COMPLETED;
+  if (value === END_GROUP_STATUS.STOPPED || value === undefined) {
+    return STREAM_PHASE.COMPLETED;
+  }
+  return value;
 }
 
 /**
@@ -90,38 +87,22 @@ export function upsertTaskGroupFromStreamLog(
     taskGroupIndex.set(entry.id, groupIndex);
   }
 
-  // A missing payload is valid for legacy lifecycle rows. A present malformed
-  // payload is not: in particular, erasing corrupted attempt ownership would
-  // turn a phase row into an apparently unowned generic group.
-  const parsedPayload = GroupLogPayloadSchema.safeParse(
-    entry.data === undefined ? {} : entry.data,
-  );
-  if (!parsedPayload.success) {
-    // A malformed terminal row cannot safely settle the projected group, but
-    // retaining its valid start would leave the UI claiming that work is
-    // still running forever. Omit that presentation row without inventing a
-    // session outcome or accepting the corrupt ownership metadata.
-    if (entry.type === STREAM_LOG_ENTRY_TYPES.GROUP_END && groupIndex >= 0) {
-      taskGroups.splice(groupIndex, 1);
-      taskGroupIndex.delete(entry.id);
-      for (const [index, group] of taskGroups.entries()) {
-        if (index >= groupIndex) taskGroupIndex.set(group.id, index);
-      }
-    }
-    return true;
-  }
-  const payload = parsedPayload.data;
+  const payload = entry.data;
 
   if (entry.type === STREAM_LOG_ENTRY_TYPES.GROUP_START) {
     // GROUP_START only carries the native status vocabulary because the run
     // has not ended. Invalid or absent values therefore mean "running".
-    const startStatus = TaskGroupStatusSchema.safeParse(payload.status);
+    const startStatus =
+      payload.status === END_GROUP_STATUS.ERROR ||
+      payload.status === END_GROUP_STATUS.STOPPED
+        ? STREAM_PHASE.RUNNING
+        : (payload.status ?? STREAM_PHASE.RUNNING);
     const name = entry.text ?? payload.name ?? entry.id;
     const nextGroup: TaskGroup = {
       id: entry.id,
       name,
       startTime: entry.timestamp,
-      status: startStatus.success ? startStatus.data : STREAM_PHASE.RUNNING,
+      status: startStatus,
       ...(entry.groupId ? { parentGroupId: entry.groupId } : {}),
       ...taskGroupStageMetadata(name, payload.kind, payload.index),
       ...(payload.total !== undefined ? { total: payload.total } : {}),

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -1889,7 +1889,7 @@ describe('CLI transcript state', () => {
     );
   });
 
-  it('renders typed loaded images once and excludes ordinary file lists', () => {
+  it('renders typed loaded images in source order and excludes ordinary file lists', () => {
     const logger = runTrace(root);
     logger.domain({
       key: 'filesLoaded',
@@ -1951,10 +1951,12 @@ describe('CLI transcript state', () => {
       finalized: true,
       images: [
         { path: '/private/tmp/loaded.png', sizeBytes: 8704 },
+        { path: '/private/tmp/loaded.png', sizeBytes: 8704 },
         { path: '/private/tmp/paper.pdf', sizeBytes: 8192 },
       ],
     });
     expect(transcriptEntryLayout(entries[0]).lines).toEqual([
+      '› [image] /private/tmp/loaded.png (8.5 KiB)',
       '› [image] /private/tmp/loaded.png (8.5 KiB)',
       '› [image] /private/tmp/paper.pdf (8 KiB)',
     ]);
@@ -2091,20 +2093,6 @@ describe('CLI transcript state', () => {
       '! Model request failed (no retry available)',
       '  ⎿ HTTP 400 Bad Request – status code without a body',
     ]);
-  });
-
-  it('keeps the error summary when structured error data is malformed', () => {
-    const logger = runTrace(root);
-    logModelError(logger, 'Model request failed', {
-      message: { nested: 'not a canonical message' },
-      rawErrorBody: { apiKey: 'secret-must-not-render' },
-      userRetryable: 'sometimes',
-    });
-
-    syncStreamLog(root);
-
-    const entries = streamEntries(root);
-    expect(entries[0]?.text).toBe('Model request failed');
   });
 
   it('removes terminal control sequences from model-error reasons', () => {

--- a/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
+++ b/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
@@ -17,6 +17,8 @@ import {
   RUN_OUTCOME,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_PHASE,
+  ProgressViewOutboundMessageSchema,
+  StreamLogEntrySchema,
   createStreamState,
   type ProgressViewOutboundHandlerRegistry,
   type ProgressViewOutboundMessage,
@@ -58,9 +60,10 @@ function seedWorkflowStream(): () => ProgressState {
 const handlers: Partial<ProgressViewOutboundHandlerRegistry> = logHandlers;
 
 function dispatch(message: ProgressViewOutboundMessage) {
-  const handler = handlers[message.command];
+  const parsed = ProgressViewOutboundMessageSchema.parse(message);
+  const handler = handlers[parsed.command];
   expect(handler).toBeDefined();
-  assertSupported(handler!)(message as never);
+  assertSupported(handler!)(parsed as never);
 }
 
 function dispatchLogDelta(
@@ -196,35 +199,12 @@ describe('LOG_DELTA text deltas', () => {
     });
     expect(streamLogs?.updatedMessageIndices).toEqual([0]);
   });
-
-  it('keeps valid group-start fields when status is unrecognized', () => {
-    const getState = seedWorkflowStream();
-
-    dispatchLogDelta([
-      {
-        seqNo: 1,
-        id: 'group-1',
-        type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
-        level: LOG_LEVELS.INFO,
-        timestamp: 100,
-        text: 'Round 1',
-        data: { status: 'bogus', kind: 'round', index: 1, total: 3 },
-      },
-    ]);
-
-    const group = getState().streamStates.get(STREAM_ID)?.taskGroups[0];
-    expect(group?.status).toBe(STREAM_PHASE.RUNNING);
-    expect(group?.kind).toBe('round');
-    expect(group?.index).toBe(1);
-    expect(group?.total).toBe(3);
-  });
 });
 
 // #7993 step 3: GROUP_END data.status is the native RunOutcome vocabulary
 // ('completed'/'cancelled'/'failed'). Legacy values the trace-viewer still
 // forwards raw ('stopped'/'error') map up to the native values
-// StreamLogStore.parsePersistedEntries would produce; anything else falls
-// back to STREAM_PHASE.COMPLETED.
+// StreamLogStore.parsePersistedEntries would produce.
 describe('LOG_DELTA GROUP_END task-group status (#7993 step 3)', () => {
   beforeEach(() => {
     resetProgressState();
@@ -243,7 +223,7 @@ describe('LOG_DELTA GROUP_END task-group status (#7993 step 3)', () => {
   }
 
   function groupEndEntry(id: string, status: unknown): StreamLogEntry {
-    return {
+    return StreamLogEntrySchema.parse({
       seqNo: 2,
       id,
       type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
@@ -251,18 +231,16 @@ describe('LOG_DELTA GROUP_END task-group status (#7993 step 3)', () => {
       timestamp: 200,
       text: 'Run: agent',
       data: { status, endTime: 200 },
-    };
+    });
   }
 
   it.each([
-    // Canonical RunOutcome values, legacy trace-viewer values mapped up to
-    // them, and the fallback for unrecognized statuses.
+    // Canonical RunOutcome values and legacy trace-viewer values mapped up.
     ['completed', RUN_OUTCOME.COMPLETED],
     ['cancelled', RUN_OUTCOME.CANCELLED],
     ['failed', RUN_OUTCOME.FAILED],
     ['stopped', RUN_OUTCOME.COMPLETED],
     ['error', RUN_OUTCOME.FAILED],
-    ['bogus', STREAM_PHASE.COMPLETED],
   ] as const)(
     'maps GROUP_END data.status %s to task-group status %s',
     (wireStatus, expectedStatus) => {
@@ -310,7 +288,7 @@ describe('LOG_DELTA active skill snapshots', () => {
   });
 
   function activeSkillsEntry(seqNo: number, data: unknown): StreamLogEntry {
-    return {
+    return StreamLogEntrySchema.parse({
       seqNo,
       settlementSeqNo: seqNo,
       id: `skills-${seqNo}`,
@@ -319,7 +297,7 @@ describe('LOG_DELTA active skill snapshots', () => {
       timestamp: seqNo,
       messageType: MESSAGE_TYPES.ACTIVE_SKILLS,
       data,
-    };
+    });
   }
 
   it('replays the latest stream-scoped snapshot and hides its metadata rows', () => {
@@ -376,26 +354,7 @@ describe('LOG_DELTA active skill snapshots', () => {
     });
   });
 
-  it('clears malformed latest data and never projects it onto workflow streams', () => {
-    const toolState = createInitialState();
-    toolState.streamStates.set(
-      STREAM_ID,
-      createStreamState(AgentCategory.ToolUse, {
-        activeSkills: [
-          {
-            name: 'stale',
-            description: 'Stale skill.',
-            source: 'user',
-          },
-        ],
-      }),
-    );
-    appState.set(toolState);
-    dispatchLogDelta([activeSkillsEntry(1, { skills: [{ path: '/secret' }] })]);
-    expect(appState.get().streamStates.get(STREAM_ID)).toMatchObject({
-      activeSkills: [],
-    });
-
+  it('never projects active skills onto workflow streams', () => {
     const workflowState = createInitialState();
     workflowState.streamStates.set(
       STREAM_ID,

--- a/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
+++ b/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
@@ -116,6 +116,39 @@ describe('LOG_DELTA text deltas', () => {
     expect(getState().streamLogs.get(STREAM_ID)?.logs[0]?.text).toBe('hello');
   });
 
+  it('recovers malformed rows without discarding their live delta batch', () => {
+    const getState = seedWorkflowStream();
+
+    const parsed = ProgressViewOutboundMessageSchema.parse({
+      command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+      streamId: STREAM_ID,
+      entries: [
+        {
+          seqNo: 1,
+          id: 'malformed-file-list',
+          type: STREAM_LOG_ENTRY_TYPES.LOG,
+          level: LOG_LEVELS.INFO,
+          timestamp: 100,
+          messageType: MESSAGE_TYPES.FILE_LIST,
+          text: 'files',
+          data: [{ name: 'missing required path and ok fields' }],
+        },
+        modelResponseEntry('still delivered', 'completed'),
+      ],
+    });
+
+    const handler = handlers[parsed.command];
+    assertSupported(handler!)(parsed as never);
+
+    const logs = getState().streamLogs.get(STREAM_ID)?.logs;
+    expect(logs).toHaveLength(2);
+    expect(logs?.map((entry) => entry.text)).toEqual([
+      'files',
+      'still delivered',
+    ]);
+    expect(logs?.[0]?.messageType).toBe(MESSAGE_TYPES.DEFAULT);
+  });
+
   it('appends streamed text without whole-entry replacement and finalizes via full update', () => {
     const getState = seedWorkflowStream();
 

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -675,10 +675,6 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
         phase: 'Map',
         status: 'running',
       }),
-      // A malformed row must drop out of the fold rather than throw.
-      workflowTaskMessage('phase-map', 'task-bad', 5, {
-        id: 'broken',
-      } as unknown as WorkflowCallProgress),
     ];
 
     const list = await renderList([run, phase], messages);

--- a/src/test-kernel/progressView/ThinkingBlockStreamingRender.vitest.ts
+++ b/src/test-kernel/progressView/ThinkingBlockStreamingRender.vitest.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   LOG_LEVELS,
+  LogMessageDataSchema,
   MESSAGE_TYPES,
   type LogMessageData,
 } from '@shared/schemas';
@@ -21,7 +22,7 @@ function renderEntry(message: LogMessageData): Element {
 
 /** A streaming thinking entry, overridable per test. */
 function logMessage(overrides: Partial<LogMessageData>): LogMessageData {
-  return {
+  return LogMessageDataSchema.parse({
     id: 'msg-1',
     text: 'text',
     level: LOG_LEVELS.INFO,
@@ -29,7 +30,7 @@ function logMessage(overrides: Partial<LogMessageData>): LogMessageData {
     messageType: MESSAGE_TYPES.THINKING,
     data: { status: 'running' },
     ...overrides,
-  };
+  });
 }
 
 /**

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.ts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.ts
@@ -2,7 +2,12 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 
 // Local imports - shared schemas
-import { LOG_LEVELS, type LogMessageData } from '@shared/schemas';
+import {
+  LOG_LEVELS,
+  LogMessageDataSchema,
+  MESSAGE_TYPES,
+  type LogMessageOf,
+} from '@shared/schemas';
 
 // Local imports - test utilities
 import {
@@ -57,15 +62,18 @@ function renderTemplateInDocument(template: FormatterTemplate): HTMLElement {
 }
 
 /** The shared shell of an INFO-level tool-use log entry. */
-function toolUseMessage(id: string, data: unknown): LogMessageData {
-  return {
+function toolUseMessage(
+  id: string,
+  data: unknown,
+): LogMessageOf<typeof MESSAGE_TYPES.TOOL_USE> {
+  return LogMessageDataSchema.parse({
     id,
     text: '',
     level: LOG_LEVELS.INFO,
     timestamp: 1,
     messageType: 'toolUse',
     data,
-  };
+  }) as LogMessageOf<typeof MESSAGE_TYPES.TOOL_USE>;
 }
 
 /** Renders an `executions` tool call with subagent labels and returns the title. */
@@ -202,7 +210,7 @@ return { papers, question: args.question };`;
       { length: 20 },
       (_, i) => `[${i}/100] Built Mathlib.Example.Module${i}`,
     ).join(' ');
-    const message: LogMessageData = {
+    const message: ReturnType<typeof toolUseMessage> = {
       id: 'bash-timeout',
       text: '',
       level: LOG_LEVELS.ERROR,
@@ -492,7 +500,11 @@ const SUMMARY_CONTROL_CASES = [
         level: LOG_LEVELS.ERROR,
         timestamp: 1,
         messageType: 'error',
-        data: { operation: 'test-op' },
+        data: {
+          message: 'something failed',
+          operation: 'test-op',
+          userRetryable: false,
+        },
       }),
   },
 ];

--- a/src/test-kernel/progressView/WebFormattersUrlSanitization.vitest.ts
+++ b/src/test-kernel/progressView/WebFormattersUrlSanitization.vitest.ts
@@ -2,7 +2,13 @@
 // formatters must never emit a live anchor for a dangerous scheme even when
 // the schema layer has already been sanitized.
 import { beforeAll, describe, expect, it } from 'vitest';
-import { LOG_LEVELS, type LogMessageData } from '@shared/schemas';
+import {
+  LOG_LEVELS,
+  LogMessageDataSchema,
+  MESSAGE_TYPES,
+  type LogMessageData,
+  type LogMessageOf,
+} from '@shared/schemas';
 import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
 
 type WebFormatters =
@@ -23,8 +29,10 @@ beforeAll(async () => {
   ({ render } = await import('lit'));
 });
 
-function webSearchMessage(url: string): LogMessageData {
-  return {
+function webSearchMessage(
+  url: string,
+): LogMessageOf<typeof MESSAGE_TYPES.WEB_SEARCH> {
+  return LogMessageDataSchema.parse({
     id: 'web-search-1',
     text: '',
     level: LOG_LEVELS.INFO,
@@ -36,11 +44,13 @@ function webSearchMessage(url: string): LogMessageData {
       status: 'completed',
       results: [{ url, title: 'Click me', domain: 'example.com' }],
     },
-  };
+  }) as LogMessageOf<typeof MESSAGE_TYPES.WEB_SEARCH>;
 }
 
-function webFetchMessage(url: string): LogMessageData {
-  return {
+function webFetchMessage(
+  url: string,
+): LogMessageOf<typeof MESSAGE_TYPES.WEB_FETCH> {
+  return LogMessageDataSchema.parse({
     id: 'web-fetch-1',
     text: '',
     level: LOG_LEVELS.INFO,
@@ -51,7 +61,7 @@ function webFetchMessage(url: string): LogMessageData {
       title: 'Fetched page',
       status: 'completed',
     },
-  };
+  }) as LogMessageOf<typeof MESSAGE_TYPES.WEB_FETCH>;
 }
 
 function renderTemplate(template: Parameters<typeof render>[0]): HTMLElement {

--- a/src/test-kernel/shared/CompactionActivityProjection.vitest.ts
+++ b/src/test-kernel/shared/CompactionActivityProjection.vitest.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
+  StreamLogEntrySchema,
   type CompactionActivityData,
   type StreamLogEntry,
 } from '@shared/schemas';
@@ -27,7 +28,7 @@ function activityEntry(
   operationId: string,
   state: CompactionActivityData['state'],
 ): StreamLogEntry {
-  return {
+  return StreamLogEntrySchema.parse({
     seqNo,
     id: `event-${seqNo}`,
     type: STREAM_LOG_ENTRY_TYPES.LOG,
@@ -35,14 +36,14 @@ function activityEntry(
     timestamp: seqNo * 10,
     messageType: MESSAGE_TYPES.CONTEXT_COMPACTION_ACTIVITY,
     data: { activity: 'context_compaction', operationId, state },
-  };
+  });
 }
 
 function advancingEntry(
   seqNo: number,
   messageType: StreamLogEntry['messageType'] = MESSAGE_TYPES.MODEL_RESPONSE,
 ): StreamLogEntry {
-  return {
+  return StreamLogEntrySchema.parse({
     seqNo,
     id: `event-${seqNo}`,
     type: STREAM_LOG_ENTRY_TYPES.LOG,
@@ -50,7 +51,7 @@ function advancingEntry(
     timestamp: seqNo * 10,
     messageType,
     text: 'advanced',
-  };
+  });
 }
 
 describe('compaction activity projection', () => {
@@ -90,14 +91,11 @@ describe('compaction activity projection', () => {
     ]);
   });
 
-  it('ignores orphan terminals, malformed payloads, and obsolete records', () => {
-    const malformed: StreamLogEntry[] = [
-      activityEntry(1, 'orphan', 'completed'),
-      { ...activityEntry(2, 'bad', 'started'), data: { state: 'started' } },
-      { ...activityEntry(3, 'bad', 'started'), data: null },
-    ];
-
-    expect(projectCompactionActivities(malformed).blocks).toEqual([]);
+  it('ignores orphan terminal records', () => {
+    expect(
+      projectCompactionActivities([activityEntry(1, 'orphan', 'completed')])
+        .blocks,
+    ).toEqual([]);
   });
 
   it('matches full replay and incremental application', () => {

--- a/src/test-kernel/shared/TaskGroupProjection.vitest.ts
+++ b/src/test-kernel/shared/TaskGroupProjection.vitest.ts
@@ -4,6 +4,7 @@ import {
   LOG_LEVELS,
   RUN_OUTCOME,
   STREAM_LOG_ENTRY_TYPES,
+  StreamLogEntrySchema,
   STREAM_PHASE,
   type StreamLogEntry,
   type TaskGroup,
@@ -35,80 +36,17 @@ function entry(
     | typeof STREAM_LOG_ENTRY_TYPES.GROUP_END,
   overrides: GroupEntryOverrides = {},
 ): StreamLogEntry {
-  return {
+  return StreamLogEntrySchema.parse({
     seqNo: type === STREAM_LOG_ENTRY_TYPES.GROUP_START ? 1 : 2,
     id,
     type,
     level: LOG_LEVELS.INFO,
     timestamp: type === STREAM_LOG_ENTRY_TYPES.GROUP_START ? 100 : 200,
     ...overrides,
-  };
+  });
 }
 
 describe('task-group StreamLog projection', () => {
-  it('distinguishes absent attempt identity from malformed ownership', () => {
-    const taskGroups = projectTaskGroupsFromStreamLog([
-      entry('valid-phase', STREAM_LOG_ENTRY_TYPES.GROUP_START, {
-        text: 'Explore',
-        data: { kind: 'phase' },
-      }),
-      entry('invalid-phase', STREAM_LOG_ENTRY_TYPES.GROUP_START, {
-        text: 'Stale phase',
-        data: { kind: 'phase', attemptId: '' },
-      }),
-    ]);
-
-    expect(taskGroups).toMatchObject([
-      {
-        id: 'valid-phase',
-        name: 'Explore',
-        kind: 'phase',
-      },
-    ]);
-    expect(taskGroups.some((group) => group.id === 'invalid-phase')).toBe(
-      false,
-    );
-  });
-
-  it('removes a projected group when its terminal ownership is malformed', () => {
-    const taskGroups = projectTaskGroupsFromStreamLog([
-      entry('valid-phase', STREAM_LOG_ENTRY_TYPES.GROUP_START, {
-        text: 'Explore',
-        data: { kind: 'phase', attemptId: 'attempt-1' },
-      }),
-      entry('neighbor', STREAM_LOG_ENTRY_TYPES.GROUP_START, {
-        text: 'Verify',
-        data: { kind: 'phase', attemptId: 'attempt-1' },
-      }),
-      entry('valid-phase', STREAM_LOG_ENTRY_TYPES.GROUP_END, {
-        text: 'Explore',
-        data: {
-          kind: 'phase',
-          attemptId: '',
-          status: RUN_OUTCOME.COMPLETED,
-          endTime: 200,
-        },
-      }),
-      entry('neighbor', STREAM_LOG_ENTRY_TYPES.GROUP_END, {
-        text: 'Verify',
-        data: {
-          kind: 'phase',
-          attemptId: 'attempt-1',
-          status: RUN_OUTCOME.COMPLETED,
-          endTime: 250,
-        },
-      }),
-    ]);
-
-    expect(taskGroups).toEqual([
-      expect.objectContaining({
-        id: 'neighbor',
-        status: RUN_OUTCOME.COMPLETED,
-        endTime: 250,
-      }),
-    ]);
-  });
-
   it('projects group metadata and completes groups in source order', () => {
     const taskGroups = projectTaskGroupsFromStreamLog([
       entry('run-1', STREAM_LOG_ENTRY_TYPES.GROUP_START, {
@@ -182,6 +120,7 @@ describe('task-group StreamLog projection', () => {
     const taskGroups = projectTaskGroupsFromStreamLog([
       entry('run-1', STREAM_LOG_ENTRY_TYPES.GROUP_START, {
         text: 'Run: auditor',
+        data: {},
       }),
     ]);
     const staleIndex = new Map([['run-1', 4]]);

--- a/src/test-kernel/traceViewer/replayTrace.vitest.ts
+++ b/src/test-kernel/traceViewer/replayTrace.vitest.ts
@@ -17,6 +17,7 @@ import {
   STREAM_STATUS,
   STREAM_LOG_ENTRY_TYPES,
   StreamSnapshotSchema,
+  StreamLogEntrySchema,
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
@@ -72,12 +73,12 @@ function stageEntry(
     Partial<Pick<TraceEntry, 'groupId'>>,
 ): TraceEntry {
   const { groupId, ...rest } = entry;
-  return {
+  return StreamLogEntrySchema.parse({
     ...rest,
     level: LOG_LEVELS.INFO,
     messageType: MESSAGE_TYPES.DEFAULT,
     ...(groupId === undefined ? {} : { groupId }),
-  };
+  });
 }
 
 function legacyTrace(

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -14,6 +14,7 @@ import {
   RUN_OUTCOME,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_PHASE,
+  StreamLogEntrySchema,
   type StreamLogEntry,
 } from '@shared/schemas';
 import { createDeferred, waitForCondition } from '@test/support/asyncTestUtils';
@@ -98,14 +99,14 @@ function logEntry(
   seqNo: number,
   timestamp: number,
 ): StreamLogEntry {
-  return {
+  return StreamLogEntrySchema.parse({
     ...namedEntry(
       `${streamId}-${seqNo}`,
       timestamp,
       `${streamId} entry ${seqNo}`,
     ),
     seqNo,
-  };
+  });
 }
 
 function summary(

--- a/src/test-kernel/transcript/traceViewerSchema.vitest.ts
+++ b/src/test-kernel/transcript/traceViewerSchema.vitest.ts
@@ -172,6 +172,44 @@ describe('trace-viewer TraceDataSchema', () => {
     expectTraceRejected(trace({ entries: [{ notAStreamLogEntry: true }] }));
   });
 
+  it('recovers malformed nested trace payloads without rejecting sibling entries', () => {
+    const parsed = parseTraceData(
+      trace({
+        entries: [
+          {
+            seqNo: 1,
+            id: 'bad-files',
+            type: STREAM_LOG_ENTRY_TYPES.LOG,
+            level: LOG_LEVELS.INFO,
+            timestamp: 1,
+            messageType: MESSAGE_TYPES.FILE_LIST,
+            data: [{ path: '/tmp/incomplete' }],
+            text: 'Legacy files',
+          },
+          {
+            seqNo: 2,
+            id: 'legacy-group',
+            type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
+            level: LOG_LEVELS.INFO,
+            timestamp: 2,
+            data: { status: 'future-status', kind: 'run', total: 3 },
+          },
+        ],
+      }),
+    );
+
+    expect(parsed.entries[0]).toMatchObject({
+      id: 'bad-files',
+      messageType: MESSAGE_TYPES.DEFAULT,
+      text: 'Legacy files',
+    });
+    expect(parsed.entries[1]).toMatchObject({
+      id: 'legacy-group',
+      data: { kind: 'run', total: 3 },
+    });
+    expect(parsed.entries[1]?.data).toHaveProperty('status', undefined);
+  });
+
   it('rejects a null/undefined/primitive trace payload', () => {
     expectTraceRejected(null);
     expectTraceRejected(undefined);

--- a/src/transcript/StreamLog.ts
+++ b/src/transcript/StreamLog.ts
@@ -2,7 +2,6 @@ import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
   STREAMING_TEXT_MESSAGE_TYPES,
-  WorkflowCallProgressSchema,
   isTerminalWorkflowCallProgress,
   type StreamLogEntry,
   type StreamLogTextDelta,
@@ -246,11 +245,11 @@ export function nonterminalWorkflowCall(
   ) {
     return undefined;
   }
-  const call = WorkflowCallProgressSchema.safeParse(entry.data);
-  if (!call.success || isTerminalWorkflowCallProgress(call.data)) {
+  const call = entry.data;
+  if (isTerminalWorkflowCallProgress(call)) {
     return undefined;
   }
-  return call.data;
+  return call;
 }
 
 export class StreamLog {
@@ -448,11 +447,11 @@ export class StreamLog {
     entry: StreamLogAppendInput,
     settled: boolean,
   ): StreamLogEntry {
-    const fullEntry: StreamLogEntry = {
+    const fullEntry = {
       ...entry,
       seqNo: this.seqCounter + 1,
       ...(settled ? { settlementSeqNo: this.settlementSeqCounter + 1 } : {}),
-    };
+    } as StreamLogEntry;
     this.seqCounter = fullEntry.seqNo;
     if (settled) this.settlementSeqCounter += 1;
     this.indexById.set(fullEntry.id, this.entries.length);
@@ -497,13 +496,13 @@ export class StreamLog {
     // AgentTrace. Persisted entries are parsed when loaded from storage.
     // Spreading `current` reads its (possibly lazy) text getter, so this is
     // where a streaming entry's chunks are joined into a plain value.
-    const updated: StreamLogEntry = {
+    const updated = {
       ...current,
       ...patch,
       id: current.id,
       seqNo: current.seqNo,
       ...(settlementSeqNo !== undefined ? { settlementSeqNo } : {}),
-    };
+    } as StreamLogEntry;
     if (settlementSeqNo !== current.settlementSeqNo) {
       this.settlementSeqCounter += 1;
     }

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -11,15 +11,12 @@ import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
   ToolResultSchema,
-  ToolUseLogSchema,
   type ExecutionId,
   type ExecutionMeta,
   type StreamLogEntry,
+  type StreamLogEntryOf,
   type StreamTabId,
   type ToolUseLog,
-  UserMessagePayloadSchema,
-  WebFetchPayloadSchema,
-  WebSearchPayloadSchema,
 } from '@shared/schemas';
 import { assertNever, isObject } from '@utils/core';
 
@@ -147,10 +144,11 @@ function toolResultText(tool: ToolUseLog): string | undefined {
  * `[document attachment]`; otherwise keep the plain-string
  * `content` shape every other conversation consumer already expects.
  */
-function userMessageEntryToMessages(entry: StreamLogEntry): unknown[] {
+function userMessageEntryToMessages(
+  entry: StreamLogEntryOf<typeof MESSAGE_TYPES.USER_MESSAGE>,
+): unknown[] {
   if (!entry.text) return [];
-  const parsed = UserMessagePayloadSchema.safeParse(entry.data);
-  const attachments = parsed.success ? (parsed.data.attachments ?? []) : [];
+  const attachments = entry.data?.attachments ?? [];
   const role = archivedConversationRole(entry, 'user');
   if (attachments.length === 0) {
     return [{ role, content: entry.text }];
@@ -194,10 +192,10 @@ function thinkingEntryToMessages(entry: StreamLogEntry): unknown[] {
   ];
 }
 
-function toolUseEntryToMessages(entry: StreamLogEntry): unknown[] {
-  const parsed = ToolUseLogSchema.safeParse(entry.data);
-  if (!parsed.success) return [];
-  const tool = parsed.data;
+function toolUseEntryToMessages(
+  entry: StreamLogEntryOf<typeof MESSAGE_TYPES.TOOL_USE>,
+): unknown[] {
+  const tool = entry.data;
   const messages: unknown[] = [
     {
       role: 'assistant',
@@ -221,18 +219,19 @@ function toolUseEntryToMessages(entry: StreamLogEntry): unknown[] {
 }
 
 /** Anthropic-shaped `server_tool_use` + `web_search_tool_result` blocks. */
-function webSearchEntryToMessages(entry: StreamLogEntry): unknown[] {
-  const parsed = WebSearchPayloadSchema.safeParse(entry.data);
-  if (!parsed.success) return [];
+function webSearchEntryToMessages(
+  entry: StreamLogEntryOf<typeof MESSAGE_TYPES.WEB_SEARCH>,
+): unknown[] {
+  const data = entry.data;
   const blocks: unknown[] = [];
-  if (parsed.data.query) {
+  if (data.query) {
     blocks.push({
       type: 'server_tool_use',
       name: 'web_search',
-      input: { query: parsed.data.query },
+      input: { query: data.query },
     });
   }
-  const results = (parsed.data.results ?? [])
+  const results = (data.results ?? [])
     .filter((result) => result.url)
     .map((result) => ({
       type: 'web_search_result',
@@ -245,21 +244,23 @@ function webSearchEntryToMessages(entry: StreamLogEntry): unknown[] {
   return blocks.length > 0 ? [{ role: 'assistant', content: blocks }] : [];
 }
 
-function webFetchEntryToMessages(entry: StreamLogEntry): unknown[] {
-  const parsed = WebFetchPayloadSchema.safeParse(entry.data);
-  if (!parsed.success || !parsed.data.url) return [];
+function webFetchEntryToMessages(
+  entry: StreamLogEntryOf<typeof MESSAGE_TYPES.WEB_FETCH>,
+): unknown[] {
+  const data = entry.data;
+  if (!data.url) return [];
   return [
     {
       role: 'assistant',
       content: [
         {
           type: 'web_fetch_tool_result',
-          url: parsed.data.url,
-          ...(parsed.data.title !== undefined && { title: parsed.data.title }),
+          url: data.url,
+          ...(data.title !== undefined && { title: data.title }),
           // `page_content` is the field name normalizeConversationForExport's
           // ContentBlockSchema already recognizes for this block type (#7508).
-          ...(parsed.data.content !== undefined && {
-            page_content: parsed.data.content,
+          ...(data.content !== undefined && {
+            page_content: data.content,
           }),
         },
       ],


### PR DESCRIPTION
## Summary

- define one exhaustive `messageType`-keyed payload map for persisted transcript rows and progress-view messages
- validate payloads at persisted-log, exported-trace, and live-delta boundaries while preserving valid rows from malformed batches
- remove downstream parse-and-skip branches across CLI, progress view, projections, replay, and completed-run archives
- remove render-time file-list deduplication and retire malformed-fixture tests that bypassed the typed boundaries

## Net elements (R6)

- 1 schema module added; 33 existing files changed; net +162 lines (682 added, 520 removed).
- Public schema surface adds the canonical typed stream-log contracts and one batch-recovery schema; consumer formatter APIs were reshaped, not duplicated.

## Consumer counts (R8)

- `LOG_DELTA`: one backend bridge emit path and one frontend reducer handler; the outbound schema is their shared wire boundary. No emit path or export was deleted or re-routed.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `npx vitest run --config vitest.config.mjs --reporter=minimal --silent=passed-only` (878 files passed, 1 skipped; 10,724 tests passed, 5 skipped)
- `npm exec vitest -- run src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts` (13 passed)
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- `npm run lint -- --quiet`
- R8 grep for downstream `safeParse(...data)` / `parse(...entry.data)` sites: no matches in the affected consumer paths

Closes #10760
Closes #10761