### PR TITLE
refactor: simplify agent launch and CLI lifecycle

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -112,7 +112,7 @@ class AgentRunStream implements AgentRun {
   private iteratorClosed = false;
   private iteratorStarted = false;
   private failure: { readonly error: unknown } | undefined;
-  private interruptPending = false;
+  private readonly launchAbortController = new AbortController();
   readonly result: Promise<AgentFlowResult>;
 
   constructor(start: (stream: AgentRunStream) => Promise<AgentFlowResult>) {
@@ -125,7 +125,10 @@ class AgentRunStream implements AgentRun {
 
   attachHandle(handle: RuntimeAgentRunHandle): void {
     this.liveHandle = handle;
-    if (this.interruptPending) handle.interrupt();
+  }
+
+  get launchSignal(): AbortSignal {
+    return this.launchAbortController.signal;
   }
 
   attachEvents(session: RuntimeSessionHandle): void {
@@ -151,7 +154,7 @@ class AgentRunStream implements AgentRun {
     if (this.liveHandle) {
       this.liveHandle.interrupt();
     } else {
-      this.interruptPending = true;
+      this.launchAbortController.abort();
     }
   }
 
@@ -284,6 +287,7 @@ export function runAgent(input: RunAgentInput): AgentRun {
         { config },
         {
           approvalPromptsUnavailable: true,
+          launchSignal: stream.launchSignal,
           onRun: (handle) => stream.attachHandle(handle),
           onStreamResolved: (streamId) => stream.selectStream(streamId),
           session,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -284,7 +284,7 @@ export function runAgent(input: RunAgentInput): AgentRun {
         ...(input.model ? { model: input.model } : {}),
       });
       return await runValidatedAgent(
-        { config },
+        { kind: 'fresh', config },
         {
           approvalPromptsUnavailable: true,
           launchSignal: stream.launchSignal,

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -426,9 +426,8 @@ export function createChatSessionController(
       .then(() => AgentConfigSchema.parse(config))
       .then((registeredConfig) =>
         runAgent(
-          { config: registeredConfig, executionId },
+          { kind: 'fresh', config: registeredConfig, executionId },
           {
-            registerExecution: true,
             enforceCategory: true,
             approvalPromptsUnavailable: approvalsUnavailable,
             onApprovalPolicyDenial: () =>

--- a/packages/cli/src/chat/tui/sessionExitController.ts
+++ b/packages/cli/src/chat/tui/sessionExitController.ts
@@ -2,18 +2,15 @@
 //
 // Extracted from runChatTui's `runChat` so the exit subsystem — the SIGINT/
 // SIGTERM/SIGHUP/SIGTSTP/SIGCONT handlers, the double-tap-to-exit confirmation,
-// and the two teardown paths (a synchronous signal exit vs the graceful
-// waitUntilExit teardown) — lives as one cohesive unit instead of ~14 closures
+// and the cause-aware teardown — lives as one cohesive unit instead of ~14 closures
 // co-captured in the 870-line entry function. This is pure code motion: every
 // closure body is unchanged; the only difference is that the runtime session
 // values the closures used to capture directly now arrive via an explicit
 // {@link SessionExitControllerContext}.
 //
-// Teardown ownership (unchanged from the inline version): a signal exit runs
-// `exitNow()`, which does the full teardown and `process.exit()`s itself; its
-// `ink.unmount()` resolves `waitUntilExit` and re-enters `gracefulTeardown()`,
-// which no-ops via the `exiting` guard so the drain / hint / cleanup never run
-// twice.
+// Teardown ownership: signal and ordinary exits enter one memoized operation.
+// A signal cause restores terminal modes synchronously before its first await,
+// then skips the graceful queue/run drain and exits with the signal code.
 
 import { completeOwnedExecutionLease } from '@agent/storage';
 import { readCliCwd } from '@cli/runtime/cliContext';
@@ -113,9 +110,13 @@ interface SessionExitController {
   readonly requestInputExit: () => void;
   /** Hand off the platform signal owner and install this controller's handlers. */
   readonly install: () => void;
-  /** The post-`waitUntilExit` graceful teardown (no-ops after a signal exit). */
+  /** The post-`waitUntilExit` graceful teardown (joins a signal teardown). */
   readonly gracefulTeardown: () => Promise<void>;
 }
+
+type ExitCause =
+  | { readonly kind: 'graceful' }
+  | { readonly kind: 'signal'; readonly exitCode: number };
 
 export function createSessionExitController(
   ctx: SessionExitControllerContext,
@@ -126,10 +127,7 @@ export function createSessionExitController(
   // whether a second Ctrl-C confirms the exit already requested by the first.
   let exitConfirmationExpiresAt = 0;
   const terminalJobControlSupported = supportsTerminalJobControl();
-  // Set once a signal exit (exitNow) starts: its ink.unmount() resolves
-  // waitUntilExit and re-enters gracefulTeardown, which guards on this to avoid
-  // draining persistence / printing the resume hint a second time.
-  let exiting = false;
+  let teardownPromise: Promise<void> | undefined;
   const clearExitConfirmation = (): void => {
     exitConfirmationExpiresAt = 0;
     clearTransientNotice();
@@ -205,26 +203,6 @@ export function createSessionExitController(
       // process.exit below remains the terminal owner when shutdown fails.
     }
   };
-  const exitNow = (exitCode: number): void => {
-    const resumableIdle = ctx.isResumableIdle();
-    exiting = true;
-    ctx.suspendTerminalTitle();
-    removeProcessHandlers();
-    clearExitConfirmation();
-    ink.unmount();
-    cleanupTerminalModes({ clearItermProgress: ctx.clearItermProgress });
-    // Print the resume hint last, after Ink has torn down and the terminal modes
-    // are restored, so it lands at the bottom of the transcript and stays in
-    // scrollback (copyable). cleanupTerminalModes no longer disturbs the screen.
-    printResumeHintOnExit();
-    // Synchronous signal exits (SIGINT double-tap / SIGTERM / SIGHUP) own the
-    // whole teardown here (gracefulTeardown skips when `exiting`), so drain
-    // persistence and run platform shutdown before exiting. Both steps settle
-    // their own failures so none escape under --unhandled-rejections=strict.
-    void persistBeforePlatformShutdown(resumableIdle).finally(() =>
-      process.exit(exitCode),
-    );
-  };
   const armExit = (): void => {
     exitConfirmationExpiresAt = Date.now() + EXIT_CONFIRMATION_TTL_MS;
     setTransientNotice('Press Ctrl-C again to exit', {
@@ -246,7 +224,10 @@ export function createSessionExitController(
         requestInputExit();
         return;
       case 'force-exit':
-        exitNow(CliExitCode.Interrupted);
+        void teardown({
+          kind: 'signal',
+          exitCode: CliExitCode.Interrupted,
+        });
         return;
       case 'preserve-exit':
         // Resumable-idle: exit WITHOUT interrupting. This preserves the
@@ -255,8 +236,8 @@ export function createSessionExitController(
         // terminal status too; an intentional idle exit after a successful turn
         // should not report SIGINT/130.
         //
-        // exitNow() calls process.exit, leaving the flow on disk.
-        exitNow(session.runExitCode);
+        // Signal teardown calls process.exit, leaving the flow on disk.
+        void teardown({ kind: 'signal', exitCode: session.runExitCode });
         return;
       case 'interrupt-and-arm-exit':
         session.stopRequested = true;
@@ -274,7 +255,7 @@ export function createSessionExitController(
       session.stopRequested = true;
       ctx.interruptActive();
     }
-    exitNow(exitCode);
+    void teardown({ kind: 'signal', exitCode });
   };
   const handleSigterm = (): void => handleTermSignal(143);
   const handleSighup = (): void => handleTermSignal(129);
@@ -324,62 +305,78 @@ export function createSessionExitController(
     }
   };
 
-  const gracefulTeardown = async (): Promise<void> => {
-    // A signal exit (SIGINT/SIGTERM/SIGHUP) runs exitNow(), which does the full
-    // teardown and process.exit()s itself; its ink.unmount() resolves
-    // waitUntilExit and re-enters here. Skip the entire graceful teardown in
-    // that case — re-running it would duplicate the drain / hint / cleanup, and
-    // the resumableIdle process.exit() below would race exitNow's async exit,
-    // dropping the flush and the signal exit code.
-    if (exiting) return;
+  const beginTeardown = (cause: ExitCause): Promise<void> => {
     removeProcessHandlers();
     clearExitConfirmation();
-    let disposalFailed = false;
-    let disposalFailure: unknown;
-    try {
-      ctx.disposables.dispose();
-    } catch (error) {
-      disposalFailed = true;
-      disposalFailure = error;
+    if (cause.kind === 'signal') {
+      const resumableIdle = ctx.isResumableIdle();
+      ctx.suspendTerminalTitle();
+      ink.unmount();
+      // This synchronous prefix is load-bearing: force/signal exits must restore
+      // the terminal before the first await so a stalled flush cannot strand raw
+      // mode or emulator keyboard state.
+      cleanupTerminalModes({ clearItermProgress: ctx.clearItermProgress });
+      printResumeHintOnExit();
+      return persistBeforePlatformShutdown(resumableIdle).finally(() =>
+        process.exit(cause.exitCode),
+      );
     }
-    await ctx.followUpQueue.onIdle();
-    // A suspended (idle/WAITING) root session is resumable: its flow record
-    // survives only if we DON'T interrupt the flow (interrupt clears it). See
-    // chatTuiIsResumableIdleOnExit for the live-flow check that distinguishes
-    // this state from a resume slot that is still rehydrating.
-    const resumableIdle = ctx.isResumableIdle();
-    if (chatTuiRunPending(session) && !resumableIdle) {
-      session.stopRequested = true;
-      ctx.interruptActive();
-      // Only await a run we actually interrupted/finished. A resumableIdle run
-      // is parked at the WAIT node and its runPromise NEVER resolves, so
-      // awaiting it would hang the process here.
-      await session.runPromise;
-    }
-    await persistAndReleaseResumableIdleLease(resumableIdle);
-    cleanupTerminalModes({ clearItermProgress: ctx.clearItermProgress });
-    ctx.disposeTerminalRestoreOnExit();
-    // Print the resume hint after the terminal modes are restored, but before
-    // resetCliState() clears the stream tree the hint is built from.
-    printResumeHintOnExit();
-    resetCliState();
-    if (resumableIdle) {
-      // The dangling runPromise keeps the event loop alive, so a normal return
-      // would never let the process exit. Force-exit here, AFTER persistence is
-      // flushed and the resume hint is printed, preserving the suspended flow
-      // record on disk for `texra resume`. Run platform shutdown first so queued
-      // usage logs flush — bin/texra.ts's finally won't on exit().
-      if (disposalFailed) {
-        log.error(
-          `Session resource disposal failed during exit: ${toErrorMessage(disposalFailure)}`,
-        );
+
+    return (async () => {
+      let disposalFailed = false;
+      let disposalFailure: unknown;
+      try {
+        ctx.disposables.dispose();
+      } catch (error) {
+        disposalFailed = true;
+        disposalFailure = error;
       }
-      await runPlatformShutdown();
-      if (disposalFailed) session.runExitCode = CliExitCode.AgentError;
-      process.exit(session.runExitCode);
-    }
-    if (disposalFailed) throw disposalFailure;
+      await ctx.followUpQueue.onIdle();
+      // A suspended (idle/WAITING) root session is resumable: its flow record
+      // survives only if we DON'T interrupt the flow (interrupt clears it). See
+      // chatTuiIsResumableIdleOnExit for the live-flow check that distinguishes
+      // this state from a resume slot that is still rehydrating.
+      const resumableIdle = ctx.isResumableIdle();
+      if (chatTuiRunPending(session) && !resumableIdle) {
+        session.stopRequested = true;
+        ctx.interruptActive();
+        // Only await a run we actually interrupted/finished. A resumableIdle run
+        // is parked at the WAIT node and its runPromise NEVER resolves, so
+        // awaiting it would hang the process here.
+        await session.runPromise;
+      }
+      await persistAndReleaseResumableIdleLease(resumableIdle);
+      cleanupTerminalModes({ clearItermProgress: ctx.clearItermProgress });
+      ctx.disposeTerminalRestoreOnExit();
+      // Print the resume hint after the terminal modes are restored, but before
+      // resetCliState() clears the stream tree the hint is built from.
+      printResumeHintOnExit();
+      resetCliState();
+      if (resumableIdle) {
+        // The dangling runPromise keeps the event loop alive, so a normal return
+        // would never let the process exit. Force-exit here, AFTER persistence is
+        // flushed and the resume hint is printed, preserving the suspended flow
+        // record on disk for `texra resume`. Run platform shutdown first so queued
+        // usage logs flush — bin/texra.ts's finally won't on exit().
+        if (disposalFailed) {
+          log.error(
+            `Session resource disposal failed during exit: ${toErrorMessage(disposalFailure)}`,
+          );
+        }
+        await runPlatformShutdown();
+        if (disposalFailed) session.runExitCode = CliExitCode.AgentError;
+        process.exit(session.runExitCode);
+      }
+      if (disposalFailed) throw disposalFailure;
+    })();
   };
+
+  const teardown = (cause: ExitCause): Promise<void> => {
+    teardownPromise ??= beginTeardown(cause);
+    return teardownPromise;
+  };
+
+  const gracefulTeardown = (): Promise<void> => teardown({ kind: 'graceful' });
 
   return {
     handleSigint,

--- a/packages/cli/src/chat/tui/sessionExitController.ts
+++ b/packages/cli/src/chat/tui/sessionExitController.ts
@@ -30,7 +30,7 @@ import {
 } from '@cli/tui/terminalCleanup';
 import { createLog } from '@logger/logUtils';
 import type { DisposableStore } from '@platform/disposable';
-import { tryPlatform } from '@platform/platform';
+import { platform } from '@platform/platform';
 import type { TexraApprovalPolicy } from '@shared/approvalPolicy';
 import { assertNever } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -190,7 +190,7 @@ export function createSessionExitController(
   // is idempotent-safe to call again, so the normal return path can still
   // rely on bin/texra.ts's own `finally`.
   const runPlatformShutdown = (): Promise<void> =>
-    runCliPlatformShutdownSequence(tryPlatform()?.lifecycle);
+    runCliPlatformShutdownSequence(platform().lifecycle);
   const persistBeforePlatformShutdown = async (
     resumableIdle: boolean,
   ): Promise<void> => {

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -80,7 +80,6 @@ export async function runToolUseAgent(
 
       const execution = await executeCliToolUseConfig(config, runContext, {
         enforceCategory: true,
-        registerExecution: true,
         stopAfterCycle: true,
         recoveryInputIsDurable: hasMaterializedStdinInput !== true,
         categoryMismatchMessage: `Agent "${init.agent}" resolved to a non tool-use run.`,

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -259,7 +259,6 @@ export async function runMultiAgentPreset(
 
       const execution = await executeCliToolUseConfig(config, runContext, {
         enforceCategory: true,
-        registerExecution: true,
         stopAfterCycle: true,
         recoveryInputIsDurable: hasMaterializedStdinInput !== true,
         categoryMismatchMessage: `Multi-agent preset "${init.preset}" resolved to a non tool-use execution.`,

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -144,7 +144,6 @@ export async function runWorkflowAgent(
       };
 
       return executeCliWorkflowConfig(config, runContext, {
-        registerExecution: true,
         categoryMismatchMessage: `Agent "${init.agent}" resolved to a non workflow run.`,
         output: init.output,
         outputDir: init.outputDir,
@@ -167,7 +166,6 @@ export async function executeCliWorkflowConfig(
   config: AgentConfigPayload,
   runContext: CliContext,
   options: {
-    readonly registerExecution?: boolean;
     readonly categoryMismatchMessage: string;
     readonly output?: string;
     readonly outputDir?: string;
@@ -218,7 +216,6 @@ export async function executeCliWorkflowConfig(
   };
   const execution = await executeCliConfig(config, runContext, {
     enforceCategory: true,
-    registerExecution: options.registerExecution,
     executionId: options.executionId,
     modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
     onInterruptedExecutionFinalized: recoveryInputIsDurable

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -378,7 +378,7 @@ export async function initCliPlatform(
   }
 
   if (!supabaseAuthInitialized) {
-    initializeCliSupabaseAuth(cliPlatformLog, context.storageRoot);
+    initializeCliSupabaseAuth(cliPlatformLog);
     supabaseAuthInitialized = true;
   }
 

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -299,12 +299,12 @@ export async function executeCliRequest(
         writeLine: writeTextStderr,
       })
     : () => undefined;
+  const launchExecutionId = request.executionId;
   let ownedExecutionId: ExecutionId | undefined;
   const launchAbortController = new AbortController();
   let shutdownRequested = false;
   let shutdownInterrupted = false;
   let workflowOutputPublicationCommitted = false;
-  let runLifecycleStarted = false;
   let shutdownArtifactFailure: unknown;
   let shutdownFinalizationFailureReported = false;
   const reportFinalizationFailure = (error: unknown): void => {
@@ -408,18 +408,12 @@ export async function executeCliRequest(
       // detached child cannot outlive the exiting CLI process, so the
       // detach-on-stop toggle is not consulted on this path.
       const interruptionAccepted =
-        !workflowOutputPublicationCommitted && ownedExecutionId
-          ? session.executions.kill(ownedExecutionId, {
+        !workflowOutputPublicationCommitted && launchExecutionId
+          ? session.executions.kill(launchExecutionId, {
               detachActiveChildren: false,
             })
           : false;
-      // Before lifecycle registration, the launch signal is the cancellation
-      // authority. Afterwards, only an accepted registry stop may replace the
-      // run's own terminal verdict with CANCELLED.
-      shutdownInterrupted =
-        (!workflowOutputPublicationCommitted && !runLifecycleStarted) ||
-        interruptionAccepted ||
-        shutdownInterrupted;
+      shutdownInterrupted = interruptionAccepted || shutdownInterrupted;
       let resumableCheckpoint:
         Extract<ResumabilityDecision, { resumable: true }> | undefined;
       if (shutdownInterrupted && ownedExecutionId) {
@@ -497,21 +491,6 @@ export async function executeCliRequest(
         onExecutionLeaseAcquired: (runWithOwnership, executionId) => {
           ownedExecutionId = executionId;
           settleLeaseScope(runWithOwnership);
-          if (shutdownRequested && !runLifecycleStarted) {
-            shutdownInterrupted = true;
-          }
-        },
-        onRun: () => {
-          runLifecycleStarted = true;
-          // Acquisition precedes registry tracking. If shutdown landed in
-          // between, interrupt as soon as the canonical handle becomes live.
-          if (shutdownRequested && ownedExecutionId) {
-            // Same deliberate cascade as the shutdown-phase kill above.
-            shutdownInterrupted =
-              session.executions.kill(ownedExecutionId, {
-                detachActiveChildren: false,
-              }) || shutdownInterrupted;
-          }
         },
         stopAfterCycle: options.stopAfterCycle,
         approvalPromptsUnavailable: cliApprovalPromptsUnavailable(

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -6,6 +6,7 @@ import {
   trackTerminalResultPresentation,
   type AgentConfigPayload,
   type RunAgentOptions,
+  type RunAgentRequest,
 } from '@agent/runtime';
 import {
   deriveResumability,
@@ -14,10 +15,7 @@ import {
   type OwnedExecutionLeaseScope,
   type ResumabilityDecision,
 } from '@agent/storage';
-import {
-  validateExecutionRequest,
-  type ValidatedExecutionRequest,
-} from '@agent/core/state/executionRequests';
+import { validateExecutionRequest } from '@agent/core/state/executionRequests';
 import { AgentError } from '@common/errors';
 import { isUserAbort } from '@common/errors/sdkError/errorPatterns';
 import {
@@ -66,7 +64,6 @@ type CliWorkflowOutputHandler = (
 interface CliExecuteOptions {
   /** Forwarded to `runAgent`. */
   readonly enforceCategory?: boolean;
-  readonly registerExecution?: boolean;
   /** Stop a tool-use execution after one model/tool cycle. */
   readonly stopAfterCycle?: boolean;
   /** Additional tools unavailable in this CLI runtime. */
@@ -105,8 +102,7 @@ export interface CliConfigExecuteOptions<
   readonly categoryMismatchMessage?: string;
   /**
    * Resume an existing execution under its persisted id instead of minting a
-   * fresh one. `runAgent` treats a request that carries an id as a resume and
-   * reuses its registered record.
+   * fresh one. The CLI turns this into explicit resume intent for `runAgent`.
    */
   readonly executionId?: ExecutionId;
 }
@@ -149,8 +145,11 @@ export async function executeCliConfig<
     return { ok: false, exitCode: CliExitCode.Usage };
   }
 
+  const request: RunAgentRequest = resumedExecutionId
+    ? { kind: 'resume', ...validation.request, executionId }
+    : { kind: 'fresh', ...validation.request, executionId };
   const execution = await executeCliRequest(
-    validation.request,
+    request,
     runContext,
     executeOptions,
   );
@@ -245,7 +244,7 @@ export async function executeCliToolUseConfig(
  * so the crash handler still reports it.
  */
 export async function executeCliRequest(
-  request: ValidatedExecutionRequest,
+  request: RunAgentRequest,
   runContext: CliContext,
   options: CliExecuteOptions = {},
 ): Promise<
@@ -471,7 +470,6 @@ export async function executeCliRequest(
       return await runAgent(request, {
         session,
         enforceCategory: options.enforceCategory,
-        registerExecution: options.registerExecution,
         openWorkflowOutput:
           openWorkflowOutput === undefined
             ? undefined

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -24,7 +24,7 @@ import {
   hasErrorPresentationPending,
   hasErrorPresentedMarker,
 } from '@common/errors/sdkError/errorMetadata';
-import { tryPlatform } from '@platform/platform';
+import { platform } from '@platform/platform';
 import { SHUTDOWN_PHASE } from '@platform/interfaces';
 import { RUN_OUTCOME, type ExecutionId, AgentCategory } from '@shared/schemas';
 import { aggregateError, generateExecutionId } from '@utils/core';
@@ -397,7 +397,7 @@ export async function executeCliRequest(
     })();
     return shutdownStatusFinalized;
   };
-  const disposeShutdownStatus = tryPlatform()?.lifecycle.onShutdown(
+  const disposeShutdownStatus = platform().lifecycle.onShutdown(
     SHUTDOWN_PHASE.BEFORE,
     async () => {
       shutdownRequested = true;
@@ -583,7 +583,7 @@ export async function executeCliRequest(
     }
   }
 
-  disposeShutdownStatus?.dispose();
+  disposeShutdownStatus.dispose();
   let finalizationCompleted = false;
   const cleanupFailures: unknown[] = [];
   try {

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -20,14 +20,13 @@ import {
   getConfiguredRelayToken,
 } from '@auth/relayToken';
 import { getServerSideKeyService } from '@auth/serverKeys';
-import { tryPlatform } from '@platform/platform';
+import { platform } from '@platform/platform';
 import type { PlatformSecrets } from '@platform/secrets';
 import { INCLUDED_ACCESS } from '@shared/copy/modelAccess';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local file imports
 import { readCliEnv } from './cliContext';
-import { getCliSecrets } from './cliSecrets';
 import { openBrowser } from './browser';
 import { startLoopbackCallbackServer } from './supabaseAuthCallbackServer';
 import {
@@ -102,10 +101,9 @@ const deferredAuthLog: LogBackend = {
 
 export function initializeCliSupabaseAuth(
   log?: LogBackend,
-  storageRoot?: string,
 ): SupabaseSessionCoordinator {
   activeAuthLog = log ?? activeAuthLog;
-  const secrets = tryPlatform()?.secrets ?? getCliSecrets(storageRoot);
+  const secrets = platform().secrets;
   if (!coordinator || coordinatorSecrets !== secrets) {
     coordinator = createHostAuthCoordinator({
       secrets,

--- a/packages/cli/src/runtime/workflowInputs.ts
+++ b/packages/cli/src/runtime/workflowInputs.ts
@@ -5,7 +5,7 @@ import { glob, hasMagic } from 'glob';
 
 import { CliUsageError } from '@cli/runtime/cliContext';
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
-import { tryPlatform } from '@platform/platform';
+import { platform } from '@platform/platform';
 import { SHUTDOWN_PHASE } from '@platform/interfaces';
 import type { Disposable } from '@platform/interfaces';
 import { unique } from '@utils/core';
@@ -144,7 +144,7 @@ export function createStdinWorkflowInputMaterializer(options: {
     })();
     await cleanupPromise;
   };
-  shutdownCleanup = tryPlatform()?.lifecycle.onShutdown(
+  shutdownCleanup = platform().lifecycle.onShutdown(
     SHUTDOWN_PHASE.BEFORE,
     inputFile.cleanup,
   );

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1264,7 +1264,7 @@ export class DesktopProgressBridge {
     options: DesktopRunExecutionOptions = {},
   ): Promise<void> {
     return launchDesktopAgent(
-      request,
+      { kind: 'fresh', ...request },
       {
         session: this.session,
       },

--- a/packages/desktop/src/main/desktopAgentLaunch.ts
+++ b/packages/desktop/src/main/desktopAgentLaunch.ts
@@ -1,9 +1,9 @@
 import {
   selectAutoOpenFinalOutput,
   type RunAgentOptions,
+  type RunAgentRequest,
   type SessionHandle,
 } from '@agent/runtime';
-import type { ValidatedExecutionRequest } from '@agent/core/state/executionRequests';
 import type { RequestOpenFilePayload } from '@shared/schemas';
 import { DIAGNOSTICS_READ_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
 import type { RegisteredToolName } from '@tools/registry';
@@ -36,7 +36,7 @@ export type DesktopAgentLaunchOptions = Pick<
 
 /** Start a desktop run with process-owned dependencies only. */
 export async function launchDesktopAgent(
-  request: ValidatedExecutionRequest,
+  request: RunAgentRequest,
   context: DesktopAgentLaunchContext,
   options: DesktopAgentLaunchOptions = {},
 ): Promise<void> {

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -135,7 +135,7 @@ function resumeDesktopStream(
         }),
       executeWorkflow: (config, executionId, modelHandlerCompatibilityKey) =>
         launchDesktopAgent(
-          { config, executionId },
+          { kind: 'resume', config, executionId },
           { session: context.session, canAcquireResumeLease },
           { modelHandlerCompatibilityKey, suppressErrorNotification: true },
         ),

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -941,9 +941,12 @@ function createWindow(options: {
         // process-owned run begins and therefore cannot retain the window for
         // the duration of the run.
         await getAgentExecution();
-        return launchDesktopAgent(preparation.request, {
-          session: options.processSession,
-        });
+        return launchDesktopAgent(
+          { kind: 'fresh', ...preparation.request },
+          {
+            session: options.processSession,
+          },
+        );
       },
       signInWithChatGpt: () => settingsIpc.signInChatGpt(),
       // The desktop shell can't host the VS Code getting-started walkthrough, so

--- a/packages/extension/src/commands/agent/executeCommand.ts
+++ b/packages/extension/src/commands/agent/executeCommand.ts
@@ -52,25 +52,25 @@ export async function runExecuteCommand(
       .optional()
       .parse(wrapped?.copilotRouteOverride);
 
-    await runAgent(
-      { config, executionId: wrapped?.executionId },
-      {
-        openWorkflowOutput: openFinalOutputIfAvailable,
-        // Set only by the "fix LaTeX" actions (see handleFixCompilation and the
-        // progress-view compile fixer); a direct main-view launch omits it and
-        // keeps the user's selected model.
-        preferHelperModel: wrapped?.preferHelperModel === true,
-        modelHandlerCompatibilityKey,
-        copilotRouteOverride,
-        onRun: wrapped?.onRun,
-        // In-process-only resume admission guard. It is never serialized: the
-        // VS Code command action still receives a single `input` argument
-        // across the registry/dispatch boundary.
-        ...(options.canAcquireResumeLease && {
-          canAcquireResumeLease: options.canAcquireResumeLease,
-        }),
-      },
-    );
+    const request = wrapped?.executionId
+      ? ({ kind: 'resume', config, executionId: wrapped.executionId } as const)
+      : ({ kind: 'fresh', config } as const);
+    await runAgent(request, {
+      openWorkflowOutput: openFinalOutputIfAvailable,
+      // Set only by the "fix LaTeX" actions (see handleFixCompilation and the
+      // progress-view compile fixer); a direct main-view launch omits it and
+      // keeps the user's selected model.
+      preferHelperModel: wrapped?.preferHelperModel === true,
+      modelHandlerCompatibilityKey,
+      copilotRouteOverride,
+      onRun: wrapped?.onRun,
+      // In-process-only resume admission guard. It is never serialized: the
+      // VS Code command action still receives a single `input` argument
+      // across the registry/dispatch boundary.
+      ...(options.canAcquireResumeLease && {
+        canAcquireResumeLease: options.canAcquireResumeLease,
+      }),
+    });
   } catch (error) {
     if (error instanceof ZodError) {
       const message = `Invalid agent configuration. ${z.prettifyError(error)}`;

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -253,7 +253,7 @@ export async function launchSetupAssistant(): Promise<
     // fresh load.
     await loadAgents();
 
-    const launch = () => runAgent({ config }, {});
+    const launch = () => runAgent({ kind: 'fresh', config }, {});
 
     if (resolution.requiresOpenRouter) {
       await withOpenRouterFlagOn(launch);

--- a/packages/extension/src/frontend/review/AgentReviewService.ts
+++ b/packages/extension/src/frontend/review/AgentReviewService.ts
@@ -311,7 +311,7 @@ class AgentReviewServiceImpl {
       // a completed review from a failed or cancelled one. The run itself
       // is visible as a regular tool-use session in the progress view.
       const result = await runAgent(
-        { config },
+        { kind: 'fresh', config },
         {
           openWorkflowOutput: openFinalOutputIfAvailable,
           stopAfterCycle: true,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -56,7 +56,7 @@ export type {
 
 // runAgent
 export { runAgent } from './runAgent';
-export type { RunAgentOptions } from './runAgent';
+export type { RunAgentOptions, RunAgentRequest } from './runAgent';
 
 // SessionResumeRetrieval
 export { retrieveSessionResumeData } from './SessionResumeRetrieval';

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -143,7 +143,7 @@ export interface ResumeStreamPorts {
   ): Promise<boolean>;
   executeWorkflow(
     config: AgentConfig,
-    executionId: ExecutionId | undefined,
+    executionId: ExecutionId,
     modelHandlerCompatibilityKey:
       ModelHandlerCompatibilityKey | null | undefined,
   ): Promise<void>;

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -34,7 +34,7 @@ export interface ResumeQueuedToolUseOptions extends Pick<
   /** Recheck canonical admission atomically while acquiring the resumed lease. */
   readonly canAcquireResumeLease?: () => boolean | Promise<boolean>;
   /** Query a caller-owned stop request at the resumed flow attachment boundary. */
-  readonly isCancellationRequested?: () => boolean;
+  readonly isCancellationRequested: () => boolean;
   /**
    * Fires with the resumed run's raw outcome — terminal or WAITING — right
    * after the call returns successfully. Native child-run strategies use this

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -24,6 +24,7 @@ import {
   ResumeAdmissionCancelledError,
   type ExecuteAgentOptions,
 } from './executeAgent';
+import { AgentExecutionHandle } from './ExecutionHandle';
 import { getStreamTabId } from './streamTab';
 import { defaultSession } from './SessionHandle';
 import type { AgentFlowResult } from './AgentFlowResult';
@@ -105,137 +106,171 @@ export async function runAgent(
   const shouldRegister =
     registerExecutionOption ?? request.executionId === undefined;
   const runSession = executeAgentOptions.session ?? defaultSession();
-
-  // Resolved before registerExecution so the stored record and the run agree
-  // on the model.
-  const config = preferHelperModel
-    ? await applyHelperModelPreference(request.config)
-    : request.config;
-
-  const userFollowUpSupport =
-    config.agentCategory === AgentCategory.ToolUse &&
-    executeAgentOptions.stopAfterCycle !== true
-      ? USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE
-      : USER_FOLLOW_UP_SUPPORT.UNSUPPORTED;
-
-  if (shouldRegister) {
-    await registerExecution(executionId, config, config.agent, {
-      streamId: getStreamTabId(config.agent, { executionId }),
-      identity: { kind: 'agent', agent: config.agent },
-      userFollowUpSupport,
-    });
-  } else {
-    const lease = await acquireResumedExecutionLease(
-      executionId,
-      canAcquireResumeLease,
-    );
-    if (lease === 'cancelled') {
-      throw new ResumeAdmissionCancelledError(executionId);
-    }
-  }
-
-  const runWithOwnership = captureOwnedExecutionLease(executionId);
-  onExecutionLeaseAcquired?.(runWithOwnership, executionId);
-  return await runWithOwnership(async () => {
-    let lifecycleStarted = false;
-    let runResult: AgentFlowResult | undefined;
-    let runFailure: { error: unknown } | undefined;
-    let finalArtifactsHandled = false;
-    let previousTerminalOutcome: RunOutcome | undefined;
-    let resumedStreamId: StreamTabId | undefined;
-    const callerOnRun = executeAgentOptions.onRun;
-    try {
-      // A resumed execution is no longer described by the terminal facts its
-      // previous run persisted; drop them before this run writes anything a
-      // reader would project them onto.
-      if (!shouldRegister) {
-        const cleared = await clearTerminalExecutionState(executionId);
-        resumedStreamId = cleared.streamId;
-        previousTerminalOutcome = cleared.previousOutcome;
-      }
-      const result = await executeAgent(config, executionId, {
-        ...executeAgentOptions,
-        // Forward the session resolved above: without it the launch context
-        // redefaults to the ambient `currentSession()`, which can disagree
-        // with the lease handling's `runSession` inside another run's async
-        // context.
-        session: runSession,
-        streamTabIdOverride: resumedStreamId,
-        userFollowUpSupport,
-        onRun: async (handle) => {
-          lifecycleStarted = true;
-          await callerOnRun?.(handle);
-        },
-      });
-      runResult = result;
-    } catch (error) {
-      runFailure = { error };
-      const restoredOutcome = shouldRegister
-        ? RUN_OUTCOME.FAILED
-        : previousTerminalOutcome;
-      if (!lifecycleStarted && restoredOutcome !== undefined) {
-        // finalizeExecutionWithLease already marks the owned lease undurable
-        // when the terminal status did not reach disk; this site only needs
-        // to fold the persistence error into the run failure.
-        const finalization = await finalizeExecutionWithLease({
+  const launchAbortController = new AbortController();
+  const launchSignal = executeAgentOptions.launchSignal
+    ? AbortSignal.any([
+        executeAgentOptions.launchSignal,
+        launchAbortController.signal,
+      ])
+    : launchAbortController.signal;
+  const launchStreamId = getStreamTabId(request.config.agent, { executionId });
+  const launchHandle = runSession.executions.getHandle(executionId)
+    ? undefined
+    : new AgentExecutionHandle(
+        {
+          streamId: launchStreamId,
           executionId,
-          outcome: restoredOutcome,
-          flowRecord: shouldRegister ? 'delete' : 'preserve',
+          identity: { kind: 'agent', agent: request.config.agent },
+          category: request.config.agentCategory,
+        },
+        launchStreamId,
+      );
+  const detachLaunchInterrupt = launchHandle?.attachInterruptHandler({
+    interrupt: () => launchAbortController.abort(),
+  });
+  if (launchHandle) runSession.executions.track(launchHandle);
+
+  try {
+    // Resolved before registerExecution so the stored record and the run agree
+    // on the model.
+    const config = preferHelperModel
+      ? await applyHelperModelPreference(request.config)
+      : request.config;
+
+    const userFollowUpSupport =
+      config.agentCategory === AgentCategory.ToolUse &&
+      executeAgentOptions.stopAfterCycle !== true
+        ? USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE
+        : USER_FOLLOW_UP_SUPPORT.UNSUPPORTED;
+
+    if (shouldRegister) {
+      await registerExecution(executionId, config, config.agent, {
+        streamId: getStreamTabId(config.agent, { executionId }),
+        identity: { kind: 'agent', agent: config.agent },
+        userFollowUpSupport,
+      });
+    } else {
+      const lease = await acquireResumedExecutionLease(
+        executionId,
+        canAcquireResumeLease,
+      );
+      if (lease === 'cancelled') {
+        throw new ResumeAdmissionCancelledError(executionId);
+      }
+    }
+
+    const runWithOwnership = captureOwnedExecutionLease(executionId);
+    onExecutionLeaseAcquired?.(runWithOwnership, executionId);
+    return await runWithOwnership(async () => {
+      let lifecycleStarted = false;
+      let runResult: AgentFlowResult | undefined;
+      let runFailure: { error: unknown } | undefined;
+      let finalArtifactsHandled = false;
+      let previousTerminalOutcome: RunOutcome | undefined;
+      let resumedStreamId: StreamTabId | undefined;
+      const callerOnRun = executeAgentOptions.onRun;
+      try {
+        // A resumed execution is no longer described by the terminal facts its
+        // previous run persisted; drop them before this run writes anything a
+        // reader would project them onto.
+        if (!shouldRegister) {
+          const cleared = await clearTerminalExecutionState(executionId);
+          resumedStreamId = cleared.streamId;
+          previousTerminalOutcome = cleared.previousOutcome;
+        }
+        const result = await executeAgent(config, executionId, {
+          ...executeAgentOptions,
+          launchSignal,
+          // Forward the session resolved above: without it the launch context
+          // redefaults to the ambient `currentSession()`, which can disagree
+          // with the lease handling's `runSession` inside another run's async
+          // context.
+          session: runSession,
+          streamTabIdOverride: resumedStreamId,
+          userFollowUpSupport,
+          onRun: async (handle) => {
+            lifecycleStarted = true;
+            await callerOnRun?.(handle);
+          },
         });
-        if (finalization.status === 'failed') {
-          runFailure = {
-            error: new AggregateError(
-              [error, finalization.error],
-              `Execution ${executionId} failed before lifecycle startup and its terminal status could not be persisted`,
-            ),
-          };
+        runResult = result;
+      } catch (error) {
+        runFailure = { error };
+        const restoredOutcome = shouldRegister
+          ? RUN_OUTCOME.FAILED
+          : previousTerminalOutcome;
+        if (!lifecycleStarted && restoredOutcome !== undefined) {
+          // finalizeExecutionWithLease already marks the owned lease undurable
+          // when the terminal status did not reach disk; this site only needs
+          // to fold the persistence error into the run failure.
+          const finalization = await finalizeExecutionWithLease({
+            executionId,
+            outcome: restoredOutcome,
+            flowRecord: shouldRegister ? 'delete' : 'preserve',
+          });
+          if (finalization.status === 'failed') {
+            runFailure = {
+              error: new AggregateError(
+                [error, finalization.error],
+                `Execution ${executionId} failed before lifecycle startup and its terminal status could not be persisted`,
+              ),
+            };
+          }
         }
       }
-    }
 
-    const artifactFailures: unknown[] = [];
-    try {
-      finalArtifactsHandled = (await beforeLeaseRelease?.()) === true;
-    } catch (error) {
-      artifactFailures.push(error);
-      // Host-owned final state failed to persist: poison the lease so the
-      // drain below completes as abandon rather than releasing a record
-      // whose host-side artifacts are not durable.
-      markOwnedExecutionLeaseUndurable(executionId);
-    }
-    if (!finalArtifactsHandled) {
-      // A failed host hook may already have abandoned ownership. Still try
-      // the ordinary drain: callbacks can also fail before touching session
-      // artifacts, and preserving those artifacts is worth the attempt. If
-      // ownership is gone, the resulting lease-lost error remains secondary
-      // to the host hook's original failure in the aggregate below.
+      const artifactFailures: unknown[] = [];
       try {
-        await runSession.releaseExecutionLease(executionId);
+        finalArtifactsHandled = (await beforeLeaseRelease?.()) === true;
       } catch (error) {
         artifactFailures.push(error);
+        // Host-owned final state failed to persist: poison the lease so the
+        // drain below completes as abandon rather than releasing a record
+        // whose host-side artifacts are not durable.
+        markOwnedExecutionLeaseUndurable(executionId);
       }
-    }
+      if (!finalArtifactsHandled) {
+        // A failed host hook may already have abandoned ownership. Still try
+        // the ordinary drain: callbacks can also fail before touching session
+        // artifacts, and preserving those artifacts is worth the attempt. If
+        // ownership is gone, the resulting lease-lost error remains secondary
+        // to the host hook's original failure in the aggregate below.
+        try {
+          await runSession.releaseExecutionLease(executionId);
+        } catch (error) {
+          artifactFailures.push(error);
+        }
+      }
 
-    if (artifactFailures.length > 0) {
-      const artifactFailure =
-        artifactFailures.length === 1
-          ? artifactFailures[0]
-          : new AggregateError(
-              artifactFailures,
-              `Execution ${executionId} has multiple final artifact failures`,
-            );
-      if (runFailure) {
-        throw new AggregateError(
-          [runFailure.error, artifactFailure],
-          `Execution ${executionId} failed and its final artifacts could not be persisted`,
-        );
+      if (artifactFailures.length > 0) {
+        const artifactFailure =
+          artifactFailures.length === 1
+            ? artifactFailures[0]
+            : new AggregateError(
+                artifactFailures,
+                `Execution ${executionId} has multiple final artifact failures`,
+              );
+        if (runFailure) {
+          throw new AggregateError(
+            [runFailure.error, artifactFailure],
+            `Execution ${executionId} failed and its final artifacts could not be persisted`,
+          );
+        }
+        throw artifactFailure;
       }
-      throw artifactFailure;
+      if (runFailure) throw runFailure.error;
+      if (!runResult) {
+        throw new Error(`Execution ${executionId} finished without a result.`);
+      }
+      return runResult;
+    });
+  } finally {
+    detachLaunchInterrupt?.();
+    if (
+      launchHandle &&
+      runSession.executions.getHandle(executionId) === launchHandle
+    ) {
+      runSession.executions.untrack(executionId);
     }
-    if (runFailure) throw runFailure.error;
-    if (!runResult) {
-      throw new Error(`Execution ${executionId} finished without a result.`);
-    }
-    return runResult;
-  });
+  }
 }

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -8,7 +8,7 @@ import {
 } from '@agent/storage/executionLease';
 import { finalizeExecutionWithLease } from '@agent/storage/terminalPersistence';
 
-import type { ValidatedExecutionRequest } from '@agent/core/state/executionRequests';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import {
   AgentCategory,
   RUN_OUTCOME,
@@ -62,7 +62,6 @@ export interface RunAgentOptions extends Pick<
     scope: OwnedExecutionLeaseScope,
     executionId: ExecutionId,
   ) => void;
-  registerExecution?: boolean;
   /** Recheck canonical admission atomically while acquiring a resumed lease. */
   canAcquireResumeLease?: () => boolean | Promise<boolean>;
   /**
@@ -74,12 +73,24 @@ export interface RunAgentOptions extends Pick<
   preferHelperModel?: boolean;
 }
 
+export type RunAgentRequest =
+  | {
+      readonly kind: 'fresh';
+      readonly config: AgentConfig;
+      readonly executionId?: ExecutionId;
+    }
+  | {
+      readonly kind: 'resume';
+      readonly config: AgentConfig;
+      readonly executionId: ExecutionId;
+    };
+
 /**
  * START HERE — the high-level entry every host uses to run an agent.
  *
- * Validates-then-runs: assigns an executionId when the request omits one (a
- * fresh run), registers fresh runs in the execution store (resume reuses the
- * record; override via `registerExecution`), runs the agent, and — for a
+ * Validates-then-runs: assigns an executionId when a fresh request omits one,
+ * registers fresh runs in the execution store, reuses a resumed run's record,
+ * runs the agent, and — for a
  * workflow result — invokes `openWorkflowOutput` so the host can surface output.
  *
  * Use this unless you need per-chunk streaming/lifecycle callbacks or subagent
@@ -87,7 +98,7 @@ export interface RunAgentOptions extends Pick<
  * caller owns executionId generation and `registerExecution`.
  */
 export async function runAgent(
-  request: ValidatedExecutionRequest,
+  request: RunAgentRequest,
   options: RunAgentOptions,
 ): Promise<AgentFlowResult> {
   // Split the `runAgent`-only options off; the rest (`executeAgentOptions`) is
@@ -96,15 +107,13 @@ export async function runAgent(
   const {
     beforeLeaseRelease,
     onExecutionLeaseAcquired,
-    registerExecution: registerExecutionOption,
     canAcquireResumeLease,
     preferHelperModel,
     ...executeAgentOptions
   } = options;
 
   const executionId = request.executionId ?? generateExecutionId();
-  const shouldRegister =
-    registerExecutionOption ?? request.executionId === undefined;
+  const shouldRegister = request.kind === 'fresh';
   const runSession = executeAgentOptions.session ?? defaultSession();
   const launchAbortController = new AbortController();
   const launchSignal = executeAgentOptions.launchSignal

--- a/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
@@ -84,11 +84,15 @@ const FINALIZE_RESULT = {
   flowRecord: 'deleted',
 };
 
-type RunOptions = Omit<Parameters<typeof runAgent>[1], 'session'>;
+type RunOptions = Omit<Parameters<typeof runAgent>[1], 'session'> & {
+  readonly kind?: 'fresh' | 'resume';
+};
 
-function launch(options: RunOptions = {}): ReturnType<typeof runAgent> {
+function launch({ kind = 'resume', ...options }: RunOptions = {}): ReturnType<
+  typeof runAgent
+> {
   return runAgent(
-    { config: CONFIG, executionId: EXECUTION_ID },
+    { kind, config: CONFIG, executionId: EXECUTION_ID },
     { session: SESSION, ...options },
   );
 }
@@ -119,7 +123,7 @@ describe('runAgent execution ownership', () => {
         }),
     );
 
-    const run = launch({ registerExecution: true });
+    const run = launch({ kind: 'fresh' });
     expect(trackedHandle?.interrupt()).toBe(true);
     finishRegistration();
     await run;
@@ -129,7 +133,7 @@ describe('runAgent execution ownership', () => {
   });
 
   it('registers and releases an explicitly identified fresh run', async () => {
-    await launch({ registerExecution: true });
+    await launch({ kind: 'fresh' });
 
     expect(mocks.registerExecution).toHaveBeenCalledOnce();
     // #9590 obligation 1: registration carries the birth stream identity and
@@ -200,7 +204,7 @@ describe('runAgent execution ownership', () => {
   });
 
   it('leaves a freshly registered run without a terminal-fact clear', async () => {
-    await launch({ registerExecution: true });
+    await launch({ kind: 'fresh' });
 
     expect(mocks.clearTerminalExecutionState).not.toHaveBeenCalled();
   });
@@ -237,7 +241,7 @@ describe('runAgent execution ownership', () => {
       order.push('release');
       return { status: 'released' } as const;
     });
-    await expect(launch({ registerExecution: true })).rejects.toBe(launchError);
+    await expect(launch({ kind: 'fresh' })).rejects.toBe(launchError);
 
     expect(order).toEqual(['finalize', 'release']);
     expect(mocks.finalizeExecution).toHaveBeenCalledWith({
@@ -254,7 +258,7 @@ describe('runAgent execution ownership', () => {
       throw launchError;
     });
 
-    await expect(launch({ registerExecution: true })).rejects.toBe(launchError);
+    await expect(launch({ kind: 'fresh' })).rejects.toBe(launchError);
 
     expect(mocks.finalizeExecution).not.toHaveBeenCalled();
     expect(mocks.completeOwnedExecutionLease).toHaveBeenCalledWith(
@@ -293,7 +297,7 @@ describe('runAgent execution ownership', () => {
       error: persistenceError,
     });
 
-    const failure = await launch({ registerExecution: true }).catch(
+    const failure = await launch({ kind: 'fresh' }).catch(
       (error: unknown) => error,
     );
 
@@ -318,7 +322,7 @@ describe('runAgent execution ownership', () => {
     });
 
     await launch({
-      registerExecution: true,
+      kind: 'fresh',
       beforeLeaseRelease: async () => {
         order.push('artifacts');
       },
@@ -335,7 +339,7 @@ describe('runAgent execution ownership', () => {
   it('delegates workflow output finalization to the live execution lifecycle', async () => {
     const openWorkflowOutput = vi.fn();
 
-    await launch({ registerExecution: true, openWorkflowOutput });
+    await launch({ kind: 'fresh', openWorkflowOutput });
 
     expect(mocks.executeAgent).toHaveBeenCalledWith(
       CONFIG,
@@ -352,7 +356,7 @@ describe('runAgent execution ownership', () => {
       return EXECUTE_RESULT;
     });
     await launch({
-      registerExecution: true,
+      kind: 'fresh',
       beforeLeaseRelease: async () => {
         order.push('host-artifacts-and-release');
         return true;
@@ -373,7 +377,7 @@ describe('runAgent execution ownership', () => {
     });
 
     const failure = await launch({
-      registerExecution: true,
+      kind: 'fresh',
       beforeLeaseRelease: async () => {
         throw artifactError;
       },

--- a/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
@@ -51,10 +51,23 @@ const CONFIG = AgentConfigSchema.parse({
   model: 'test-model',
 });
 const flushArtifacts = vi.fn();
+let trackedHandle:
+  import('@agent/runtime/ExecutionHandle').AgentExecutionHandle | undefined;
 // The real exit choreography over the fake's flushArtifacts and the mocked
 // lease verbs, so the existing renew/flush/complete/abandon assertions keep
 // observing the same tree through its one owner.
 const SESSION = {
+  executions: {
+    track: vi.fn((handle) => {
+      trackedHandle = handle;
+    }),
+    getHandle: vi.fn((executionId) =>
+      trackedHandle?.executionId === executionId ? trackedHandle : undefined,
+    ),
+    untrack: vi.fn((executionId) => {
+      if (trackedHandle?.executionId === executionId) trackedHandle = undefined;
+    }),
+  },
   flushArtifacts,
   releaseExecutionLease: SessionHandle.prototype.releaseExecutionLease,
 } as never;
@@ -83,6 +96,7 @@ function launch(options: RunOptions = {}): ReturnType<typeof runAgent> {
 describe('runAgent execution ownership', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    trackedHandle = undefined;
     mocks.registerExecution.mockResolvedValue(undefined);
     mocks.acquireResumedExecutionLease.mockResolvedValue('acquired');
     mocks.clearTerminalExecutionState.mockResolvedValue({
@@ -94,6 +108,24 @@ describe('runAgent execution ownership', () => {
     flushArtifacts.mockResolvedValue(undefined);
     mocks.finalizeExecution.mockResolvedValue(FINALIZE_RESULT);
     mocks.executeAgent.mockResolvedValue(EXECUTE_RESULT);
+  });
+
+  it('makes a fresh launch interruptible before registration settles', async () => {
+    let finishRegistration!: () => void;
+    mocks.registerExecution.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRegistration = resolve;
+        }),
+    );
+
+    const run = launch({ registerExecution: true });
+    expect(trackedHandle?.interrupt()).toBe(true);
+    finishRegistration();
+    await run;
+
+    const executeOptions = mocks.executeAgent.mock.calls[0]?.[2];
+    expect(executeOptions?.launchSignal?.aborted).toBe(true);
   });
 
   it('registers and releases an explicitly identified fresh run', async () => {

--- a/src/test-kernel/agent/runtime/resumeQueuedToolUse.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeQueuedToolUse.vitest.ts
@@ -28,6 +28,7 @@ const completed = {
   files: [],
   totalCostUsd: 0,
 };
+const isCancellationRequested = (): boolean => false;
 
 function snapshot() {
   return createToolUseResumeData({ streamId: STREAM });
@@ -75,6 +76,7 @@ describe('resumeQueuedToolUseFromResumeData ownership', () => {
     await expect(
       resumeQueuedToolUseFromResumeData(STREAM, snapshot(), {
         session,
+        isCancellationRequested,
         tools,
         onFollowUpQueueReady: () => {
           expect(
@@ -105,6 +107,7 @@ describe('resumeQueuedToolUseFromResumeData ownership', () => {
 
     const first = resumeQueuedToolUseFromResumeData(STREAM, snapshot(), {
       session,
+      isCancellationRequested,
       onError: vi.fn(),
     });
     await vi.waitFor(() =>
@@ -113,6 +116,7 @@ describe('resumeQueuedToolUseFromResumeData ownership', () => {
     await expect(
       resumeQueuedToolUseFromResumeData(STREAM, snapshot(), {
         session,
+        isCancellationRequested,
         onError: vi.fn(),
       }),
     ).resolves.toBe(false);
@@ -129,6 +133,7 @@ describe('resumeQueuedToolUseFromResumeData ownership', () => {
     await expect(
       resumeQueuedToolUseFromResumeData(STREAM, snapshot(), {
         session,
+        isCancellationRequested,
         onError: vi.fn(),
       }),
     ).resolves.toBe(false);
@@ -146,6 +151,7 @@ describe('resumeQueuedToolUseFromResumeData ownership', () => {
 
     const resuming = resumeQueuedToolUseFromResumeData(STREAM, snapshot(), {
       session,
+      isCancellationRequested,
       onError: vi.fn(),
     });
     await vi.waitFor(() =>
@@ -183,6 +189,7 @@ describe('resumeQueuedToolUseFromResumeData ownership', () => {
       resumeQueuedToolUseFromResumeData(STREAM, snapshot(), {
         session,
         recovery,
+        isCancellationRequested,
         onError: vi.fn(),
       }),
     ).resolves.toBe(true);

--- a/src/test-kernel/cli/CliInitPlatform.vitest.ts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.ts
@@ -119,7 +119,10 @@ vi.mock('@platform/platform', () => ({
   initPlatform: vi.fn(),
   tryPlatform: mocks.tryPlatform,
   tryGlobalState: () => mocks.tryPlatform()?.globalState,
-  platform: () => ({ config: { get: (_key: string, def: unknown) => def } }),
+  platform: () => ({
+    config: { get: (_key: string, def: unknown) => def },
+    globalState: mocks.cliGlobalState,
+  }),
 }));
 
 // initCliPlatform delegates shared Node-host construction and runtime wiring to
@@ -259,7 +262,6 @@ describe('CLI platform init', () => {
     expect(mocks.initNodeAgentRuntime).toHaveBeenCalledOnce();
     expect(mocks.initializeCliSupabaseAuth).toHaveBeenCalledWith(
       expect.anything(),
-      '/tmp/texra-storage-root',
     );
   });
 

--- a/src/test-kernel/cli/CliSupabaseAuth.vitest.ts
+++ b/src/test-kernel/cli/CliSupabaseAuth.vitest.ts
@@ -12,7 +12,6 @@ const mocks = vi.hoisted(() => {
       secrets: init.secrets,
     })),
     clearServerKeyCaches: vi.fn(),
-    getCliSecrets: vi.fn(),
     getConfiguredRelayToken: vi.fn(),
     getStoredSessionState: vi.fn(),
     getUserTier: vi.fn(),
@@ -23,7 +22,7 @@ const mocks = vi.hoisted(() => {
     signInWithOAuth: vi.fn(),
     startLoopbackCallbackServer: vi.fn(),
     toStorableSupabaseSession: vi.fn((session) => session),
-    tryPlatform: vi.fn(),
+    platform: vi.fn(),
     invalidateRemoteAgentsAfterSignOut: vi.fn(),
   };
 });
@@ -72,15 +71,11 @@ vi.mock('@auth/serverKeys', () => ({
 }));
 
 vi.mock('@platform/platform', () => ({
-  tryPlatform: mocks.tryPlatform,
+  platform: mocks.platform,
 }));
 
 vi.mock('@cli/runtime/cliContext', () => ({
   readCliEnv: () => ({}),
-}));
-
-vi.mock('@cli/runtime/cliSecrets', () => ({
-  getCliSecrets: mocks.getCliSecrets,
 }));
 
 vi.mock('@cli/runtime/browser', () => ({
@@ -147,39 +142,22 @@ function stubSuccessfulSignIns(session: {
 describe('CLI Supabase auth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.tryPlatform.mockReturnValue(null);
-    mocks.getCliSecrets.mockReturnValue({ kind: 'cli-secrets' });
+    mocks.platform.mockReturnValue({ secrets: { kind: 'platform-secrets' } });
     mocks.setUseIncludedModelAccess.mockResolvedValue(undefined);
     mocks.invalidateRemoteAgentsAfterSignOut.mockResolvedValue(undefined);
   });
 
   it('uses platform-owned secrets after CLI platform init', async () => {
     const platformSecrets = { kind: 'platform-secrets' };
-    mocks.tryPlatform.mockReturnValue({ secrets: platformSecrets });
+    mocks.platform.mockReturnValue({ secrets: platformSecrets });
     const { initializeCliSupabaseAuth } = await loadSupabaseAuth();
 
-    initializeCliSupabaseAuth(undefined, '/tmp/sandbox-storage');
+    initializeCliSupabaseAuth();
     initializeCliSupabaseAuth();
 
     expect(mocks.createHostAuthCoordinator).toHaveBeenCalledTimes(1);
     expect(mocks.createHostAuthCoordinator).toHaveBeenCalledWith(
       expect.objectContaining({ secrets: platformSecrets }),
-    );
-    expect(mocks.getCliSecrets).not.toHaveBeenCalled();
-  });
-
-  it('does not rebind no-arg auth init to the default secrets path', async () => {
-    const cliSecrets = { kind: 'sandbox-secrets' };
-    mocks.getCliSecrets.mockReturnValue(cliSecrets);
-    const { initializeCliSupabaseAuth } = await loadSupabaseAuth();
-
-    initializeCliSupabaseAuth(undefined, '/tmp/sandbox-storage');
-    initializeCliSupabaseAuth();
-
-    expect(mocks.createHostAuthCoordinator).toHaveBeenCalledTimes(1);
-    expect(mocks.getCliSecrets).toHaveBeenCalledWith('/tmp/sandbox-storage');
-    expect(mocks.createHostAuthCoordinator).toHaveBeenCalledWith(
-      expect.objectContaining({ secrets: cliSecrets }),
     );
   });
 

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
@@ -276,7 +276,6 @@ describe('CLI multi-agent run command', () => {
     expect(mocks.executeCliToolUseConfig).toHaveBeenCalledTimes(1);
     expect(mocks.executeCliToolUseConfig.mock.calls[0]?.[2]).toMatchObject({
       enforceCategory: true,
-      registerExecution: true,
       recoveryInputIsDurable: true,
       stopAfterCycle: true,
     });

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -146,8 +146,11 @@ const COMPLETED_WORKFLOW_RUN: Parameters<
   compileFailures: [],
 };
 
-function baseRequest(): CliRequest {
-  return { config: {}, executionId: 'exec-1' } as CliRequest;
+function baseRequest(kind: 'fresh' | 'resume' = 'fresh'): CliRequest {
+  const request = { config: {}, executionId: 'exec-1' } as const;
+  return kind === 'fresh'
+    ? ({ kind, ...request } as CliRequest)
+    : ({ kind, ...request } as CliRequest);
 }
 
 function toolUseConfig() {
@@ -866,11 +869,11 @@ describe('executeCliRequest', () => {
   });
 
   it.each([
-    { label: 'fresh', options: { registerExecution: true } },
-    { label: 'resumed', options: {} },
+    { label: 'fresh', kind: 'fresh' },
+    { label: 'resumed', kind: 'resume' },
   ] as const)(
     'marks $label owned executions interrupted during platform shutdown',
-    async ({ options }) => {
+    async ({ kind }) => {
       const { platform, executeCliRequest } = await installFakePlatform();
       const { flushSpy } = await spyOnTranscriptFlush();
       const { defaultSession } = await import('@agent/runtime/SessionHandle');
@@ -891,8 +894,7 @@ describe('executeCliRequest', () => {
         publishRun = options.onRun;
       });
 
-      const run = executeCliRequest(baseRequest(), cliContext(), {
-        ...options,
+      const run = executeCliRequest(baseRequest(kind), cliContext(), {
         onInterruptedExecutionFinalized,
       });
       await vi.waitFor(() => expect(publishLeaseScope).toBeDefined());
@@ -974,7 +976,6 @@ describe('executeCliRequest', () => {
     });
 
     const run = executeCliRequest(baseRequest(), cliContext(), {
-      registerExecution: true,
       onInterruptedExecutionFinalized,
     });
     await vi.waitFor(() => expect(publishLeaseScope).toBeDefined());
@@ -1005,7 +1006,6 @@ describe('executeCliRequest', () => {
       leaseOptions = options;
     });
     const run = executeCliRequest(baseRequest(), cliContext(), {
-      registerExecution: true,
       onInterruptedExecutionFinalized,
     });
     await vi.waitFor(() => expect(leaseOptions).toBeDefined());
@@ -1051,7 +1051,6 @@ describe('executeCliRequest', () => {
       });
 
       const run = executeCliRequest(baseRequest(), cliContext(), {
-        registerExecution: true,
         onInterruptedExecutionFinalized,
       });
       await vi.waitFor(() => expect(publishLeaseScope).toBeDefined());
@@ -1096,9 +1095,7 @@ describe('executeCliRequest', () => {
       leaseOptions = options;
     });
 
-    const run = executeCliRequest(baseRequest(), cliContext(), {
-      registerExecution: true,
-    });
+    const run = executeCliRequest(baseRequest(), cliContext(), {});
     await vi.waitFor(() => expect(leaseOptions).toBeDefined());
     leaseOptions?.onExecutionLeaseAcquired?.(
       runWithOwnership,
@@ -1129,9 +1126,7 @@ describe('executeCliRequest', () => {
       },
     );
 
-    const run = executeCliRequest(baseRequest(), cliContext(), {
-      registerExecution: true,
-    });
+    const run = executeCliRequest(baseRequest(), cliContext(), {});
     await vi.waitFor(() => expect(launchSignal).toBeDefined());
 
     await platform.lifecycle.runShutdown();
@@ -1151,9 +1146,7 @@ describe('executeCliRequest', () => {
     const hangingRun = stubHangingRun((options) => {
       leaseOptions = options;
     });
-    const run = executeCliRequest(baseRequest(), cliContext(), {
-      registerExecution: true,
-    });
+    const run = executeCliRequest(baseRequest(), cliContext(), {});
     await vi.waitFor(() => expect(leaseOptions).toBeDefined());
     leaseOptions?.onExecutionLeaseAcquired?.(
       (operation: () => unknown) => operation(),
@@ -1178,7 +1171,6 @@ describe('executeCliRequest', () => {
     });
     let publicationCommitted: boolean | undefined;
     const run = executeCliRequest(baseRequest(), cliContext(), {
-      registerExecution: true,
       openWorkflowOutput: async (_result, tryCommitPublication) => {
         publicationCommitted = tryCommitPublication();
       },
@@ -1221,7 +1213,6 @@ describe('executeCliRequest', () => {
     });
     let publicationCommitted: boolean | undefined;
     const run = executeCliRequest(baseRequest(), cliContext(), {
-      registerExecution: true,
       openWorkflowOutput: async (_result, tryCommitPublication) => {
         publicationCommitted = tryCommitPublication();
       },
@@ -1289,7 +1280,6 @@ describe('executeCliRequest', () => {
     );
 
     const run = executeCliRequest(baseRequest(), cliContext(), {
-      registerExecution: true,
       openWorkflowOutput: async (_result, tryCommitPublication) => {
         publicationCommitted = tryCommitPublication();
         throw outputFailure;
@@ -1327,9 +1317,7 @@ describe('executeCliRequest', () => {
       }, 'exec-1' as ExecutionId);
     });
 
-    const run = executeCliRequest(baseRequest(), cliContext(), {
-      registerExecution: true,
-    });
+    const run = executeCliRequest(baseRequest(), cliContext(), {});
     await vi.waitFor(() => expect(mocks.runAgent).toHaveBeenCalledOnce());
     const shutdown = platform.lifecycle.runShutdown();
     await Promise.resolve();
@@ -1359,7 +1347,6 @@ describe('executeCliRequest', () => {
 
     const onInterruptedExecutionFinalized = vi.fn();
     const run = executeCliRequest(baseRequest(), cliContext(), {
-      registerExecution: true,
       onInterruptedExecutionFinalized,
     });
     await vi.waitFor(() => expect(mocks.runAgent).toHaveBeenCalledOnce());
@@ -1397,9 +1384,7 @@ describe('executeCliRequest', () => {
     const { platform, executeCliRequest } = await installFakePlatform();
     const request = baseRequest();
 
-    await executeCliRequest(request, cliContext(), {
-      registerExecution: true,
-    });
+    await executeCliRequest(request, cliContext(), {});
     mocks.finalizeExecution.mockClear();
     await platform.lifecycle.runShutdown();
 
@@ -1428,7 +1413,6 @@ describe('executeCliConfig', () => {
       outcomePersisted: true,
     });
     return executeCliToolUseConfig(toolUseConfig(), cliContext(), {
-      registerExecution: true,
       stopAfterCycle: true,
     });
   }
@@ -1457,7 +1441,6 @@ describe('executeCliConfig', () => {
     mocks.writeTextStderrAndWait.mockReturnValueOnce(recoveryWrite);
 
     const run = executeCliToolUseConfig(toolUseConfig(), context, {
-      registerExecution: true,
       stopAfterCycle: true,
     });
     await vi.waitFor(() => expect(publishLeaseScope).toBeDefined());
@@ -1501,7 +1484,6 @@ describe('executeCliConfig', () => {
     });
 
     const run = executeCliToolUseConfig(toolUseConfig(), cliContext(), {
-      registerExecution: true,
       recoveryInputIsDurable: false,
     });
     await vi.waitFor(() => expect(publishLeaseScope).toBeDefined());

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -5,6 +5,8 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { RunAgentOptions } from '@agent/runtime/runAgent';
+import { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { executeCliRequest } from '@cli/runtime/runExecution';
 import { AgentError } from '@common/errors';
@@ -179,6 +181,7 @@ type LeaseOptions = {
   openWorkflowOutput?: RunAgentOptions['openWorkflowOutput'];
   onRun?: () => void;
   launchSignal?: AbortSignal;
+  session?: SessionHandle;
   onExecutionLeaseAcquired?: (
     scope: (operation: () => unknown) => unknown,
     executionId: ExecutionId,
@@ -194,11 +197,30 @@ function stubHangingRun(handleOptions: (options: LeaseOptions) => void): {
   resolve: (result: unknown) => void;
 } {
   let resolveRun!: (result: unknown) => void;
-  mocks.runAgent.mockImplementation(async (_request, options: LeaseOptions) => {
+  mocks.runAgent.mockImplementation(async (request, options: LeaseOptions) => {
     handleOptions(options);
-    return new Promise((resolve) => {
-      resolveRun = resolve;
-    });
+    const executionId = request.executionId as ExecutionId;
+    const streamId = `chat#${executionId}` as StreamTabId;
+    const launchHandle = new AgentExecutionHandle(
+      {
+        streamId,
+        executionId,
+        identity: { kind: 'agent', agent: 'chat' },
+        category: 'toolUse',
+      },
+      streamId,
+    );
+    launchHandle.attachInterruptHandler({ interrupt: () => undefined });
+    options.session?.executions.track(launchHandle);
+    try {
+      return await new Promise((resolve) => {
+        resolveRun = resolve;
+      });
+    } finally {
+      if (options.session?.executions.getHandle(executionId) === launchHandle) {
+        options.session.executions.untrack(executionId);
+      }
+    }
   });
   return { resolve: (result: unknown) => resolveRun(result) };
 }

--- a/src/test-kernel/cli/SessionExitLease.vitest.ts
+++ b/src/test-kernel/cli/SessionExitLease.vitest.ts
@@ -20,7 +20,7 @@ vi.mock('@cli/runtime/logSinks', () => ({
   writeTextStdout: mocks.writeTextStdout,
 }));
 vi.mock('@platform/platform', () => ({
-  tryPlatform: () => undefined,
+  platform: () => ({ lifecycle: {} }),
 }));
 vi.mock('@cli/chat/tui/state/childExecutions', () => ({
   childStreamEntries: { get: () => [] },

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -666,6 +666,7 @@ function expectWorkflowResume(
 ): void {
   expect(runAgent).toHaveBeenCalledWith(
     {
+      kind: 'resume',
       config: expect.objectContaining(config),
       executionId,
     },
@@ -2257,7 +2258,7 @@ describe('DesktopProgressBridge', () => {
 
     // Fresh run: the existing execution id is dropped (no resume reuse).
     expect(runAgent).toHaveBeenCalledWith(
-      { config: expect.objectContaining(runConfig) },
+      { kind: 'fresh', config: expect.objectContaining(runConfig) },
       expect.objectContaining({
         session: expect.objectContaining({
           interactions: expect.objectContaining({ emit: expect.any(Function) }),

--- a/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.ts
@@ -319,7 +319,7 @@ describe('createDesktopAgentExecution', () => {
 
     await execution.handleExecute({ command: 'execute' });
     expect(runAgent).toHaveBeenCalledWith(
-      request,
+      { kind: 'fresh', ...request },
       expect.objectContaining({
         openWorkflowOutput: expect.any(Function),
         runtimeUnavailableTools: [

--- a/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
@@ -159,6 +159,7 @@ async function resumePersistedStream(
   const resumed = await resumeQueuedToolUseFromResumeData(streamId, resume, {
     session,
     recovery,
+    isCancellationRequested: () => false,
     onError: (error) => {
       throw error;
     },

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -28,7 +28,7 @@ import {
 import { currentSession } from '@agent/runtime/SessionHandle';
 import { BASH_CHILD_STREAM_PREFIX } from '@agent/runtime/streamTab';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
-import { tryPlatform } from '@platform/platform';
+import { platform } from '@platform/platform';
 import {
   BASH_BACKGROUND_LOG_CAP_CHARS,
   BASH_TOOL_DEFAULT_TIMEOUT_MS,
@@ -299,7 +299,7 @@ export class BashTool extends defineTool({
     const runContext = contexts?.runContext;
     const cwd =
       parseWorkingDirectory(getRunContextWorkingDirectory(runContext)) ??
-      tryPlatform()?.workspace.getWorkspacePath();
+      platform().workspace.getWorkspacePath();
 
     // Request approval before executing the command.
     const approval = await requestBashApproval({ command: input.command, cwd });

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -106,8 +106,7 @@ async function mutateIndex(
   mutate: (index: StreamTabId[]) => StreamTabId[],
 ): Promise<void> {
   await indexMutex.runExclusive(async () => {
-    const state = tryWorkspaceState();
-    if (!state) return;
+    const state = platform().workspaceState;
     const index = readIndex();
     const next = mutate(index);
     if (next !== index) {
@@ -265,9 +264,7 @@ export const GoalStore = Object.freeze({
     return updated;
   },
 
-  /** Drop the record (used on complete, abandon, or conversation delete).
-   *  Bootstrap-tolerant — cleanup paths shouldn't fail loudly if state isn't
-   *  wired yet. */
+  /** Drop the record (used on complete, abandon, or conversation delete). */
   async forget(streamId: StreamTabId, session?: SessionHandle): Promise<void> {
     // Dual-context: PlanTool forgets in-run (→ run session via ALS); hosts
     // pass their owning session for non-default windows.
@@ -284,8 +281,7 @@ export const GoalStore = Object.freeze({
     streamIds: readonly StreamTabId[],
     session?: SessionHandle,
   ): Promise<void> {
-    const state = tryWorkspaceState();
-    if (!state) return;
+    const state = platform().workspaceState;
     // Gate on raw key presence, not parse success, so explicit cleanup can
     // still remove an invalid record without first reading it.
     const toRemove = streamIds.filter(

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -16,7 +16,7 @@
 // Local imports
 import { appSignals } from '@eventBus/AppSignals';
 import { createLog } from '@logger/logUtils';
-import { tryGlobalState } from '@platform/platform';
+import { platform } from '@platform/platform';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import type { RegisteredToolName } from '@tools/registry';
 import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
@@ -77,8 +77,7 @@ export function getDisabledToolNames(): ReadonlySet<string> {
 export async function seedDisabledToolDefaults(
   versionStateKey: string,
 ): Promise<void> {
-  const state = tryGlobalState();
-  if (!state) return;
+  const state = platform().globalState;
 
   const lastKnownVersion = state.get<string>(versionStateKey);
   const disabledTools = state.get<string[]>(GlobalStateKey.DISABLED_TOOLS);


### PR DESCRIPTION
## Summary

This batches four closely related launch and lifecycle cleanups into one larger PR:

- make goal mutations, CLI lifecycle registration, workspace resolution, auth, and startup tool seeding require an initialized platform instead of silently dropping work
- replace the CLI TUI dual exit paths with one memoized, cause-aware teardown while preserving synchronous terminal restoration for signal exits
- register an interruptible launch handle before asynchronous agent setup, deleting the CLI onRun race repair and the package SDK interruptPending buffer
- make fresh versus resume intent explicit at the shared runtime boundary, remove the registerExecution boolean/ID heuristic, and require every queued-resume host to supply its synchronous cancellation predicate

The platform-access portion is the broad safe first stage of #10762. Bootstrap and platformless-SDK exceptions remain intentional; shared extension view-message and desktop settings paths remain sequenced behind G2 (#10758 / #10782) and G1 (#10757 / #10781).

Closes #10749
Closes #10750
Closes #10751
Part of #10762

## Net elements

- 34 files changed, 435 insertions, 395 deletions
- one exported discriminated request type replaces the optional-ID inference contract
- deleted exitNow, the exiting re-entry guard, runLifecycleStarted, the onRun shutdown re-check, interruptPending, registerExecution options, the shouldRegister heuristic, and 11 post-init try-platform call sites
- added one launch-boundary regression case in the existing runAgent ownership suite; other tests update durable boundary expectations only

## Validation

- npm run format
- npm run typecheck
- npm run lint
- npm run compile:fast
- focused lifecycle/runtime/cross-host suites: 10 files, 170 tests passed; desktop expectation suites: 2 files, 86 tests passed
- npm test: 878 files passed, 1 skipped; 10,728 tests passed, 5 skipped
- R8 greps for exitNow, exiting, runLifecycleStarted, interruptPending, registerExecution options, the old ID heuristic, and the staged try-platform accessor census