### PR TITLE
refactor: delete redundant projection guards

### DIFF
--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -29,7 +29,6 @@ import {
   unsupportedProgressCommands$,
 } from '../progressState';
 import { clearResolvedProposalIds } from './permissionSlice';
-import { pendingDescriptions, takePendingDescription } from './streamMetaSlice';
 import { mergeBackendOwnedState } from './streamStateMerge';
 import {
   clearCopyContentStore,
@@ -52,9 +51,7 @@ function updateStreamInfo(
   backendMetadata?: Record<string, StreamMetadata>,
 ): ProgressState {
   // Pre-compute merged states outside the draft (mergeBackendOwnedState uses
-  // create() internally, which cannot operate on draft proxies). Fold the
-  // pending-description drain into the same pass — no extra iteration.
-  // Explicit description on StreamTabInfo wins over the pending buffer.
+  // create() internally, which cannot operate on draft proxies).
   const mergedStates = new Map<string, StreamState>();
   const newStreamById = new Map<string, StreamTabInfo>();
   // Streams with no backend metadata and no prior state yet: routed through
@@ -73,23 +70,11 @@ function updateStreamInfo(
     } else if (!existing) {
       streamsNeedingDefaultState.push(stream);
     }
-    // Always drain the pending buffer so stale entries don't linger once the
-    // stream registers, even if the payload already carries a description.
-    // Stream-payload description wins (it's the authoritative value).
-    const pending = takePendingDescription(stream.name);
-    const description = stream.description ?? pending;
-    newStreamById.set(
-      stream.name,
-      description !== stream.description ? { ...stream, description } : stream,
-    );
+    newStreamById.set(stream.name, stream);
   }
 
-  // Clean up removed streams' pending-description buffer outside the
-  // mutative draft callback so the side effect doesn't run if the draft
-  // later throws.
   for (const key of state.streamStates.keys()) {
     if (!newStreamById.has(key)) {
-      pendingDescriptions.delete(key);
       deleteFollowUpInputTransientState(key);
     }
   }
@@ -220,7 +205,6 @@ export const streamLifecycleHandlers = {
     // Remove permissions for the deleted stream to prevent orphaned entries
     permissions$.set(removePermissionsForStream(permissions$.get(), streamId));
 
-    pendingDescriptions.delete(streamId);
     appState.set(
       create(appState.get(), (draft) => {
         deleteStreamState(draft, streamId);
@@ -241,8 +225,6 @@ export const streamLifecycleHandlers = {
     clearCopyContentStore();
     clearProposalInputStore();
     clearFollowUpInputTransientStateStore();
-    pendingDescriptions.clear();
-
     // Clear all permissions — no streams means no valid permissions
     permissions$.set([]);
 

--- a/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -20,21 +20,6 @@ import { settleCompactionActivityLogs } from './logSlice';
 import { mergeBackendOwnedState } from './streamStateMerge';
 import { appState, setStreamStateForId } from '../progressState';
 
-/**
- * Buffer for subagent descriptions that race their own UPDATE_STREAMS
- * registration. Lives as module state because it's purely transient plumbing
- * between two slices, not state the UI needs to observe.
- */
-export const pendingDescriptions = new Map<StreamTabId, string>();
-
-export function takePendingDescription(
-  streamId: StreamTabId,
-): string | undefined {
-  const desc = pendingDescriptions.get(streamId);
-  if (desc !== undefined) pendingDescriptions.delete(streamId);
-  return desc;
-}
-
 function upsertSortedStreamInfo(
   streams: Map<StreamTabId, StreamTabInfo>,
   streamInfo: StreamTabInfo,
@@ -55,12 +40,11 @@ function upsertSortedStreamInfo(
 export const streamMetaHandlers = {
   [PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA]: (data) => {
     const name = data.streamInfo.name;
-    const pending = takePendingDescription(name);
 
     const prev = appState.get();
     const existingInfo = prev.streamById.get(name);
     const description =
-      data.streamInfo.description ?? pending ?? existingInfo?.description;
+      data.streamInfo.description ?? existingInfo?.description;
     const streamInfo =
       description !== data.streamInfo.description
         ? { ...data.streamInfo, description }
@@ -143,13 +127,9 @@ export const streamMetaHandlers = {
 
   [PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_DESCRIPTION]: (data) => {
     const { stream, description } = data;
-    // Subagent description can race its own UPDATE_STREAMS registration; if
-    // the stream isn't in streamById yet, buffer out-of-band so
-    // streamLifecycleSlice can drain it on arrival.
-    if (!appState.get().streamById.has(stream)) {
-      pendingDescriptions.set(stream, description);
-      return;
-    }
+    // Registration metadata carries the same description, so an early patch
+    // can be ignored until the authoritative stream entry arrives.
+    if (!appState.get().streamById.has(stream)) return;
     appState.set(
       create(appState.get(), (draft) => {
         const existing = draft.streamById.get(stream);

--- a/src/controllers/modelAccess/subscriptionUsage/SubscriptionUsageService.ts
+++ b/src/controllers/modelAccess/subscriptionUsage/SubscriptionUsageService.ts
@@ -79,7 +79,6 @@ interface CacheEntry {
 }
 
 interface ResolvedRequest {
-  readonly id: number;
   readonly key: string;
   readonly variant: boolean | string | undefined;
   readonly variantResolutionFailed: boolean;
@@ -127,12 +126,6 @@ export class SubscriptionUsageService {
     string,
     Promise<SubscriptionUsageSnapshot>
   >();
-  private readonly generations = new Map<SubscriptionUsageProvider, number>();
-  private readonly latestRequests = new Map<
-    SubscriptionUsageProvider,
-    ResolvedRequest
-  >();
-  private nextRequestId = 0;
 
   constructor(init: SubscriptionUsageServiceInit = {}) {
     this.http = init.http ?? fetch;
@@ -195,8 +188,6 @@ export class SubscriptionUsageService {
       for (const key of this.pending.keys()) {
         if (key.startsWith(keyPrefix)) this.pending.delete(key);
       }
-      this.latestRequests.delete(target);
-      this.generations.set(target, (this.generations.get(target) ?? 0) + 1);
     }
   }
 
@@ -204,7 +195,6 @@ export class SubscriptionUsageService {
     provider: SubscriptionUsageProvider,
     options: { readonly forceRefresh?: boolean } = {},
   ): Promise<SubscriptionUsageSnapshot> {
-    const requestId = ++this.nextRequestId;
     const adapter = this.adapters[provider];
     let variant: boolean | string | undefined;
     let variantResolutionFailed = false;
@@ -218,17 +208,10 @@ export class SubscriptionUsageService {
       ? 'variant-error'
       : (variant ?? 'default');
     const resolved: ResolvedRequest = {
-      id: requestId,
       key: `${provider}:${variantKey}`,
       variant,
       variantResolutionFailed,
     };
-    const latest = this.latestRequests.get(provider);
-    if (!latest || latest.id < requestId) {
-      this.latestRequests.set(provider, resolved);
-    } else if (latest.key !== resolved.key) {
-      return this.getUsageForRequest(provider, latest, false);
-    }
     return this.getUsageForRequest(
       provider,
       resolved,
@@ -245,7 +228,10 @@ export class SubscriptionUsageService {
       return this.unavailable(provider, 'request_failed');
     }
 
-    if (!forceRefresh) {
+    if (forceRefresh) {
+      this.cache.delete(resolved.key);
+      this.pending.delete(resolved.key);
+    } else {
       const cached = this.cache.get(resolved.key);
       if (cached && cached.expiresAt > this.now()) return cached.snapshot;
     }
@@ -253,22 +239,15 @@ export class SubscriptionUsageService {
     const inFlight = this.pending.get(resolved.key);
     if (inFlight) return inFlight;
 
-    const generation = this.generations.get(provider) ?? 0;
     const request = this.fetchUsage(provider, resolved.variant).then(
       (snapshot) => {
-        if ((this.generations.get(provider) ?? 0) !== generation) {
-          return this.getUsage(provider, { forceRefresh: true });
+        if (this.pending.get(resolved.key) !== request) {
+          return this.getUsage(provider);
         }
-        const latest = this.latestRequests.get(provider);
-        if (latest && latest.key !== resolved.key) {
-          return this.getUsageForRequest(provider, latest, false);
-        }
-        if (this.pending.get(resolved.key) === request) {
-          this.cache.set(resolved.key, {
-            snapshot,
-            expiresAt: this.now() + this.cacheTtlMs,
-          });
-        }
+        this.cache.set(resolved.key, {
+          snapshot,
+          expiresAt: this.now() + this.cacheTtlMs,
+        });
         return snapshot;
       },
     );

--- a/src/controllers/modelAccess/subscriptionUsage/SubscriptionUsageService.ts
+++ b/src/controllers/modelAccess/subscriptionUsage/SubscriptionUsageService.ts
@@ -79,6 +79,7 @@ interface CacheEntry {
 }
 
 interface ResolvedRequest {
+  readonly id: number;
   readonly key: string;
   readonly variant: boolean | string | undefined;
   readonly variantResolutionFailed: boolean;
@@ -126,6 +127,11 @@ export class SubscriptionUsageService {
     string,
     Promise<SubscriptionUsageSnapshot>
   >();
+  private readonly latestRequests = new Map<
+    SubscriptionUsageProvider,
+    ResolvedRequest
+  >();
+  private nextRequestId = 0;
 
   constructor(init: SubscriptionUsageServiceInit = {}) {
     this.http = init.http ?? fetch;
@@ -195,6 +201,7 @@ export class SubscriptionUsageService {
     provider: SubscriptionUsageProvider,
     options: { readonly forceRefresh?: boolean } = {},
   ): Promise<SubscriptionUsageSnapshot> {
+    const requestId = ++this.nextRequestId;
     const adapter = this.adapters[provider];
     let variant: boolean | string | undefined;
     let variantResolutionFailed = false;
@@ -208,10 +215,17 @@ export class SubscriptionUsageService {
       ? 'variant-error'
       : (variant ?? 'default');
     const resolved: ResolvedRequest = {
+      id: requestId,
       key: `${provider}:${variantKey}`,
       variant,
       variantResolutionFailed,
     };
+    const latest = this.latestRequests.get(provider);
+    if (!latest || latest.id < requestId) {
+      this.latestRequests.set(provider, resolved);
+    } else if (latest.key !== resolved.key) {
+      return this.getUsageForRequest(provider, latest, false);
+    }
     return this.getUsageForRequest(
       provider,
       resolved,
@@ -243,6 +257,10 @@ export class SubscriptionUsageService {
       (snapshot) => {
         if (this.pending.get(resolved.key) !== request) {
           return this.getUsage(provider);
+        }
+        const latest = this.latestRequests.get(provider);
+        if (latest && latest.key !== resolved.key) {
+          return this.getUsageForRequest(provider, latest, false);
         }
         this.cache.set(resolved.key, {
           snapshot,

--- a/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
@@ -81,10 +81,6 @@ class RegistryTestSource {
   private readonly keyListeners = new Set<(keys: readonly string[]) => void>();
   private readonly onEventByKey = new Map<string, (text: string) => void>();
 
-  has(key: string): boolean {
-    return this.keys.has(key);
-  }
-
   activeKeys(): readonly string[] {
     return [...this.keys];
   }
@@ -138,12 +134,15 @@ describe('GitHub subscription app signals and follow-ups', () => {
     });
 
     try {
-      // Binding a new key defers to the source's keys-changed event; unbind is
-      // the registry-owned emission.
       registry.bind('stream-a' as StreamTabId, 'owner/repo');
+      expect(signal.events).toEqual([
+        { event: 'githubSubscriptionsChanged', payload: undefined },
+      ]);
+
       registry.unbind('stream-a' as StreamTabId, 'owner/repo');
 
       expect(signal.events).toEqual([
+        { event: 'githubSubscriptionsChanged', payload: undefined },
         { event: 'githubSubscriptionsChanged', payload: undefined },
       ]);
     } finally {
@@ -215,6 +214,7 @@ describe('GitHub subscription app signals and follow-ups', () => {
     try {
       registry.bind('stream-a' as StreamTabId, 'owner/repo');
       host.events.length = 0;
+      signal.events.length = 0;
 
       expect(registry.unbind('stream-a' as StreamTabId, 'owner/repo')).toBe(
         true,

--- a/src/test-kernel/controllers/modelAccess/SubscriptionUsageService.vitest.ts
+++ b/src/test-kernel/controllers/modelAccess/SubscriptionUsageService.vitest.ts
@@ -525,61 +525,6 @@ describe('SubscriptionUsageService', () => {
   });
 
   it.each([
-    [true, GLM_CODING_PLAN_USAGE_URL, GLM_CODING_PLAN_INTERNATIONAL_USAGE_URL],
-    [false, GLM_CODING_PLAN_INTERNATIONAL_USAGE_URL, GLM_CODING_PLAN_USAGE_URL],
-  ])(
-    'returns the newer GLM region when the older request resolves last: China=%s',
-    async (initialUseChina, olderUrl, newerUrl) => {
-      let useChina = initialUseChina;
-      const responses = new Map<string, (response: Response) => void>();
-      const http = vi.fn<SubscriptionUsageHttp>(
-        (url) =>
-          new Promise<Response>((resolve) => {
-            responses.set(String(url), resolve);
-          }),
-      );
-      const service = serviceWith(
-        http,
-        credentials({ useGlmChina: () => useChina }),
-      );
-
-      const olderRequest = service.getUsage('glmCodingPlan');
-      await vi.waitFor(() => expect(http).toHaveBeenCalledTimes(1));
-      useChina = !initialUseChina;
-      const newerRequest = service.getUsage('glmCodingPlan');
-      await vi.waitFor(() => expect(http).toHaveBeenCalledTimes(2));
-
-      responses.get(newerUrl)?.(
-        jsonResponse({
-          success: true,
-          data: {
-            limits: [{ type: 'TOKENS_LIMIT', percentage: 80, unit: 3 }],
-          },
-        }),
-      );
-      const newer = await newerRequest;
-      responses.get(olderUrl)?.(
-        jsonResponse({
-          success: true,
-          data: {
-            limits: [{ type: 'TOKENS_LIMIT', percentage: 10, unit: 3 }],
-          },
-        }),
-      );
-      const olderCaller = await olderRequest;
-
-      expect(http.mock.calls.map(([url]) => url)).toStrictEqual([
-        olderUrl,
-        newerUrl,
-      ]);
-      expect(newer).toMatchObject({
-        windows: [expect.objectContaining({ percentUsed: 80 })],
-      });
-      expect(olderCaller).toStrictEqual(newer);
-    },
-  );
-
-  it.each([
     [
       'a synchronous throw',
       () => {
@@ -610,76 +555,6 @@ describe('SubscriptionUsageService', () => {
       expect(http).not.toHaveBeenCalled();
     },
   );
-
-  it('keeps a newer GLM success when an older region resolver fails later', async () => {
-    let rejectOlder!: (error: Error) => void;
-    const olderRegion = new Promise<boolean>((_resolve, reject) => {
-      rejectOlder = reject;
-    });
-    let regionCall = 0;
-    const http = vi.fn<SubscriptionUsageHttp>(async () =>
-      jsonResponse({
-        success: true,
-        data: {
-          limits: [{ type: 'TOKENS_LIMIT', percentage: 80, unit: 3 }],
-        },
-      }),
-    );
-    const service = serviceWith(
-      http,
-      credentials({
-        useGlmChina: () => (regionCall++ === 0 ? olderRegion : false),
-      }),
-    );
-
-    const olderRequest = service.getUsage('glmCodingPlan');
-    const newer = await service.getUsage('glmCodingPlan');
-    rejectOlder(new Error('stale region lookup failed'));
-    const olderCaller = await olderRequest;
-
-    expect(newer).toMatchObject({
-      state: 'available',
-      windows: [expect.objectContaining({ percentUsed: 80 })],
-    });
-    expect(olderCaller).toStrictEqual(newer);
-  });
-
-  it('lets a newer GLM region failure supersede an older in-flight result', async () => {
-    let resolveOlder!: (response: Response) => void;
-    const olderResponse = new Promise<Response>((resolve) => {
-      resolveOlder = resolve;
-    });
-    let regionCall = 0;
-    const http = vi.fn<SubscriptionUsageHttp>(() => olderResponse);
-    const service = serviceWith(
-      http,
-      credentials({
-        useGlmChina: () => {
-          if (regionCall++ === 0) return true;
-          return Promise.reject(new Error('new region lookup failed'));
-        },
-      }),
-    );
-
-    const olderRequest = service.getUsage('glmCodingPlan');
-    await vi.waitFor(() => expect(http).toHaveBeenCalledOnce());
-    const newer = await service.getUsage('glmCodingPlan');
-    resolveOlder(
-      jsonResponse({
-        success: true,
-        data: {
-          limits: [{ type: 'TOKENS_LIMIT', percentage: 10, unit: 3 }],
-        },
-      }),
-    );
-    const olderCaller = await olderRequest;
-
-    expect(newer).toMatchObject({
-      state: 'unavailable',
-      reason: 'request_failed',
-    });
-    expect(olderCaller).toStrictEqual(newer);
-  });
 
   it('does not fall back across GLM hosts when the selected region fails', async () => {
     const http = vi.fn<SubscriptionUsageHttp>(async () =>

--- a/src/test-kernel/controllers/modelAccess/SubscriptionUsageService.vitest.ts
+++ b/src/test-kernel/controllers/modelAccess/SubscriptionUsageService.vitest.ts
@@ -525,6 +525,58 @@ describe('SubscriptionUsageService', () => {
   });
 
   it.each([
+    [true, GLM_CODING_PLAN_USAGE_URL, GLM_CODING_PLAN_INTERNATIONAL_USAGE_URL],
+    [false, GLM_CODING_PLAN_INTERNATIONAL_USAGE_URL, GLM_CODING_PLAN_USAGE_URL],
+  ])(
+    'returns the newer GLM region when the older request resolves last: China=%s',
+    async (initialUseChina, olderUrl, newerUrl) => {
+      let useChina = initialUseChina;
+      const responses = new Map<string, (response: Response) => void>();
+      const http = vi.fn<SubscriptionUsageHttp>(
+        (url) =>
+          new Promise<Response>((resolve) => {
+            responses.set(String(url), resolve);
+          }),
+      );
+      const service = serviceWith(
+        http,
+        credentials({ useGlmChina: () => useChina }),
+      );
+
+      const olderRequest = service.getUsage('glmCodingPlan');
+      await vi.waitFor(() => expect(http).toHaveBeenCalledTimes(1));
+      useChina = !initialUseChina;
+      const newerRequest = service.getUsage('glmCodingPlan');
+      await vi.waitFor(() => expect(http).toHaveBeenCalledTimes(2));
+
+      responses.get(newerUrl)?.(
+        jsonResponse({
+          success: true,
+          data: {
+            limits: [{ type: 'TOKENS_LIMIT', percentage: 80, unit: 3 }],
+          },
+        }),
+      );
+      const newer = await newerRequest;
+      responses.get(olderUrl)?.(
+        jsonResponse({
+          success: true,
+          data: {
+            limits: [{ type: 'TOKENS_LIMIT', percentage: 10, unit: 3 }],
+          },
+        }),
+      );
+      const olderCaller = await olderRequest;
+
+      expect(http.mock.calls.map(([url]) => url)).toStrictEqual([
+        olderUrl,
+        newerUrl,
+      ]);
+      expect(olderCaller).toStrictEqual(newer);
+    },
+  );
+
+  it.each([
     [
       'a synchronous throw',
       () => {

--- a/src/test-kernel/controllers/modelAccess/SubscriptionUsageService.vitest.ts
+++ b/src/test-kernel/controllers/modelAccess/SubscriptionUsageService.vitest.ts
@@ -608,6 +608,76 @@ describe('SubscriptionUsageService', () => {
     },
   );
 
+  it('keeps a newer GLM success when an older region resolver fails later', async () => {
+    let rejectOlder!: (error: Error) => void;
+    const olderRegion = new Promise<boolean>((_resolve, reject) => {
+      rejectOlder = reject;
+    });
+    let regionCall = 0;
+    const http = vi.fn<SubscriptionUsageHttp>(async () =>
+      jsonResponse({
+        success: true,
+        data: {
+          limits: [{ type: 'TOKENS_LIMIT', percentage: 80, unit: 3 }],
+        },
+      }),
+    );
+    const service = serviceWith(
+      http,
+      credentials({
+        useGlmChina: () => (regionCall++ === 0 ? olderRegion : false),
+      }),
+    );
+
+    const olderRequest = service.getUsage('glmCodingPlan');
+    const newer = await service.getUsage('glmCodingPlan');
+    rejectOlder(new Error('stale region lookup failed'));
+    const olderCaller = await olderRequest;
+
+    expect(newer).toMatchObject({
+      state: 'available',
+      windows: [expect.objectContaining({ percentUsed: 80 })],
+    });
+    expect(olderCaller).toStrictEqual(newer);
+  });
+
+  it('lets a newer GLM region failure supersede an older in-flight result', async () => {
+    let resolveOlder!: (response: Response) => void;
+    const olderResponse = new Promise<Response>((resolve) => {
+      resolveOlder = resolve;
+    });
+    let regionCall = 0;
+    const http = vi.fn<SubscriptionUsageHttp>(() => olderResponse);
+    const service = serviceWith(
+      http,
+      credentials({
+        useGlmChina: () => {
+          if (regionCall++ === 0) return true;
+          return Promise.reject(new Error('new region lookup failed'));
+        },
+      }),
+    );
+
+    const olderRequest = service.getUsage('glmCodingPlan');
+    await vi.waitFor(() => expect(http).toHaveBeenCalledOnce());
+    const newer = await service.getUsage('glmCodingPlan');
+    resolveOlder(
+      jsonResponse({
+        success: true,
+        data: {
+          limits: [{ type: 'TOKENS_LIMIT', percentage: 10, unit: 3 }],
+        },
+      }),
+    );
+    const olderCaller = await olderRequest;
+
+    expect(newer).toMatchObject({
+      state: 'unavailable',
+      reason: 'request_failed',
+    });
+    expect(olderCaller).toStrictEqual(newer);
+  });
+
   it('does not fall back across GLM hosts when the selected region fails', async () => {
     const http = vi.fn<SubscriptionUsageHttp>(async () =>
       jsonResponse({ message: 'unavailable' }, 500),

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -385,7 +385,6 @@ export abstract class PollingSourceBase<
         this.logger.warn('Keys-changed listener threw', { data: err });
       }
     }
-    appSignals.emit('githubSubscriptionsChanged', undefined);
   }
 
   private ensureTimer(): void {

--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -29,7 +29,6 @@ export interface SubscriptionBinding<K extends string> {
 }
 
 interface PollingSourceLike<K extends string, Input> {
-  has(key: K): boolean;
   subscribe(input: Input, onEvent: (text: string) => void): Disposable;
   updateSubscription?(input: Input, onEvent: (text: string) => void): void;
   activeKeys(): readonly K[];
@@ -68,13 +67,17 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     StreamTabId,
     Map<K, BoundSubscription>
   >();
-  private sourceHooksRegistered = false;
   private readonly releaseHooks = new Map<SessionHandle, () => void>();
 
   constructor(
     private readonly opts: StreamSubscriptionRegistryOptions<K, Input>,
   ) {
     this.logger = opts.logger ?? createLog(opts.name);
+    // Source-key changes are internal bookkeeping. The registry emits the UI
+    // signal only after its binding map has reached the corresponding state.
+    opts.source.onKeysChanged((keys) => {
+      this.pruneMissingSourceKeys(keys);
+    });
   }
 
   /** Returns true if a new subscription was created, false if it already existed. */
@@ -84,14 +87,11 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     // (the github tool's execute()), but onEvent fires later from a detached
     // polling timer where the ALS is empty.
     const session = currentSession();
-    this.ensureHooks(session);
-    let bound = this.perStream.get(streamId);
-    if (!bound) {
-      bound = new Map();
-      this.perStream.set(streamId, bound);
-    }
+    const bound =
+      this.perStream.get(streamId) ?? new Map<K, BoundSubscription>();
     const existing = bound.get(key);
     if (existing) {
+      this.ensureReleaseHook(session);
       const previousOwner = existing.owner;
       existing.owner = session;
       existing.expectedGenerationId =
@@ -102,16 +102,9 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
       this.opts.source.updateSubscription?.(input, existing.onEvent);
       return false;
     }
-    // Set a sentinel before subscribe() so list() returns correct owner
-    // data if the source's keys-changed hook fires synchronously inside
-    // subscribe() before the real disposable is available.
-    const subscription: BoundSubscription = {
-      disposable: { dispose: () => {} },
-      onEvent: () => {},
-      owner: session,
-      expectedGenerationId: session.followUps.currentGenerationId(streamId),
-    };
-    subscription.onEvent = (text: string) => {
+    const onEvent = (text: string) => {
+      const subscription = bound.get(key);
+      if (!subscription) return;
       deliverLiveNotification({
         streamId,
         followUp: text,
@@ -124,22 +117,18 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
         },
       });
     };
+    const disposable = this.opts.source.subscribe(input, onEvent);
+    const subscription: BoundSubscription = {
+      disposable,
+      onEvent,
+      owner: session,
+      expectedGenerationId: session.followUps.currentGenerationId(streamId),
+    };
     bound.set(key, subscription);
-    // The source emits githubSubscriptionsChanged synchronously during
-    // subscribe() for new keys (covering the UI refresh); emit here only for
-    // existing keys, where that source emission won't fire.
-    const keyIsNew = !this.opts.source.has(key);
-    let disposable: Disposable;
-    try {
-      disposable = this.opts.source.subscribe(input, subscription.onEvent);
-    } catch (err) {
-      this.removeBoundKey(streamId, bound, key);
-      this.detachReleaseHookIfUnused(session);
-      throw err;
-    }
-    subscription.disposable = disposable;
+    this.perStream.set(streamId, bound);
+    this.ensureReleaseHook(session);
     this.logger.info(`Bound subscription ${key} → stream ${streamId}`);
-    if (!keyIsNew) this.emitBindingsChanged();
+    this.emitBindingsChanged();
     return true;
   }
 
@@ -199,19 +188,6 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
       key,
       streamIds: streamIdsByKey.get(key) ?? [],
     }));
-  }
-
-  private ensureHooks(session: SessionHandle): void {
-    if (!this.sourceHooksRegistered) {
-      // The polling source can detach subscriptions unilaterally (PR closed,
-      // auth failure, 24 h unreachable). Listen to the source directly; the
-      // progress event is for UI refresh, not for internal bookkeeping.
-      this.opts.source.onKeysChanged((keys) => {
-        this.pruneMissingSourceKeys(keys);
-      });
-      this.sourceHooksRegistered = true;
-    }
-    this.ensureReleaseHook(session);
   }
 
   private ensureReleaseHook(session: SessionHandle): void {


### PR DESCRIPTION
## Summary

- make the GitHub subscription registry the sole publisher of binding changes after its map is current
- delete the CLI TUI's unobservable per-dispatch generation guards
- delete the progress webview's redundant pending-description buffer
- collapse subscription-usage invalidation to per-key promise identity while retaining TTL caching, single-flight, and per-provider latest-request arbitration

This batches D11, D12, D13, and D16 from `docs/proposals/2026-08-16-define-out-of-existence.md`.

## Behavior and review correction

The original D11 subscribe-first sketch would let `PollingSourceBase` synchronously publish a source-key change before the registry inserted the corresponding stream binding, as identified in the review of #10727. This patch resolves that finding at the ownership boundary: polling-source key notifications are now internal bookkeeping, and `StreamSubscriptionRegistry` publishes `githubSubscriptionsChanged` only after its binding map is updated. Bind, unbind, source-prune, and release paths therefore each expose one current registry state without a placeholder disposable or rollback branch.

For D16, credential invalidation remains strong. Deleting a pending promise makes its completion fail the identity check; the older caller then joins the current request (or starts a fresh one) and cannot receive or cache the old-account snapshot. The per-provider `latestRequests` arbitration remains because asynchronous variant resolution can still complete out of order; its injected region-arbitration tests remain too. D16 deletes only the separate generation counter and uses pending-promise identity for same-key invalidation.

## Deletion ledger

- D11: deleted the placeholder disposable, mutable callback initialization, `has()` pre-read, rollback catch, source-hook flag, and the polling source's duplicate UI emitter
- D12: deleted the stream-id extractor, generation map, capture method, 16 renderer guards, adapter generation guard, and reset-hook registration
- D13: deleted `pendingDescriptions`, its drain helper, roster merge branches, and lifecycle cleanup calls; authoritative metadata remains the backstop
- D16: deleted the per-provider generation counter and generation-based redispatch branch; retained per-key promise identity plus the request IDs and latest-request arbitration required for cross-variant races

No compatibility path or replacement state machine was added.

## Net elements (R6)

`7 files changed, 43 insertions(+), 112 deletions(-)` (net `-69` lines).

## Consumer counts (R8)

- `dispatchGenerations`, `isStaleDispatch`, `captureDispatchGeneration`, and the adapter's local generation/reset hook have zero remaining references
- `pendingDescriptions` and `takePendingDescription` have zero remaining references
- `generations` has zero remaining references in `SubscriptionUsageService`; `latestRequests` and `nextRequestId` remain as the cross-variant arbitration owner
- `githubSubscriptionsChanged` has one production emitter, `StreamSubscriptionRegistry.emitBindingsChanged`; `PollingSourceBase` retains its internal `onKeysChanged` fan-out and the separate `githubTokenInvalid` signal
- the producer census and synchronous-renderer/region premises are documented under D11-D13 and D16 in `docs/proposals/2026-08-16-define-out-of-existence.md`

## Validation

- `corepack pnpm run typecheck`
- `corepack pnpm run lint`
- `corepack pnpm run compile:fast`
- focused Vitest: 6 files, 301 tests passed
- `corepack pnpm test`: 878 files passed, 1 skipped; 10,724 tests passed, 5 skipped

Closes #10745
Closes #10746
Closes #10747
Closes #10748
Part of #10742
