### PR TITLE
fix(session): unify stream removal and metadata reads

### DIFF
--- a/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
+++ b/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
@@ -284,8 +284,11 @@ export function attachSessionSignalsAdapter({
     // reaction there, while the shared applier only updates session facts and
     // requests lease-aware eviction. The old TUI ignored status facts here.
     if (fact.type === 'status') return;
-    applier.handleSessionFact(fact);
-    if (fact.type === 'setActiveStream') {
+    const sessionStreamId = getSessionFactStreamId(fact);
+    if (sessionStreamId) renderer.captureDispatchGeneration(sessionStreamId);
+    const admitted = applier.handleSessionFact(fact);
+    // A refused attachment (removed stream) must not move the TUI focus.
+    if (admitted && fact.type === 'setActiveStream') {
       const streamId = fact.payload.streamId;
       if (!streamId) {
         renderer.onActiveStreamChanged('');

--- a/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
+++ b/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
@@ -284,11 +284,8 @@ export function attachSessionSignalsAdapter({
     // reaction there, while the shared applier only updates session facts and
     // requests lease-aware eviction. The old TUI ignored status facts here.
     if (fact.type === 'status') return;
-    const sessionStreamId = getSessionFactStreamId(fact);
-    if (sessionStreamId) renderer.captureDispatchGeneration(sessionStreamId);
-    const admitted = applier.handleSessionFact(fact);
-    // A refused attachment (removed stream) must not move the TUI focus.
-    if (admitted && fact.type === 'setActiveStream') {
+    applier.handleSessionFact(fact);
+    if (fact.type === 'setActiveStream') {
       const streamId = fact.payload.streamId;
       if (!streamId) {
         renderer.onActiveStreamChanged('');

--- a/packages/desktop/src/main/desktopProcessStores.ts
+++ b/packages/desktop/src/main/desktopProcessStores.ts
@@ -53,30 +53,39 @@ export async function initializeDesktopProcessStores(session: SessionHandle) {
         const { streamId } = sessionEvent.event.payload;
         const expectedIncarnation = streamIncarnations.get(streamId) ?? 0;
         pendingRemovals.set(streamId, expectedIncarnation);
-        // SessionStores tracks the lease barrier immediately so a window
-        // reattaching before terminal artifact persistence finishes cannot
-        // replay a stream already marked removed.
-        void stores
-          .deleteStreamAfterOwnedExecutionRelease(streamId, {
-            shouldDelete: deletionGuard(streamId, expectedIncarnation),
-          })
-          .then((outcome) => {
-            if (outcome === 'superseded') {
-              logger.info(
-                `Skipped deletion for re-claimed desktop stream ${streamId}`,
-              );
-            }
-          })
-          .catch((error: unknown) => {
-            logger.warn('Failed to delete a headless desktop stream', {
-              data: toLogData(error),
-            });
-          })
-          .finally(() => {
+        // Let a live ProgressBackend claim the deletion synchronously while
+        // this fact is dispatched. Only the process-level headless fallback
+        // starts in the following microtask, so the two hosts never create
+        // separate guard slots for the same removal.
+        queueMicrotask(() => {
+          if (stores.hasPendingStreamDeletion(streamId)) {
             if (pendingRemovals.get(streamId) === expectedIncarnation) {
               pendingRemovals.delete(streamId);
             }
-          });
+            return;
+          }
+          void stores
+            .deleteStreamAfterOwnedExecutionRelease(streamId, {
+              shouldDelete: deletionGuard(streamId, expectedIncarnation),
+            })
+            .then((outcome) => {
+              if (outcome === 'superseded') {
+                logger.info(
+                  `Skipped deletion for re-claimed desktop stream ${streamId}`,
+                );
+              }
+            })
+            .catch((error: unknown) => {
+              logger.warn('Failed to delete a headless desktop stream', {
+                data: toLogData(error),
+              });
+            })
+            .finally(() => {
+              if (pendingRemovals.get(streamId) === expectedIncarnation) {
+                pendingRemovals.delete(streamId);
+              }
+            });
+        });
       }
     },
     { scope: 'session' },

--- a/packages/desktop/src/main/desktopProcessStores.ts
+++ b/packages/desktop/src/main/desktopProcessStores.ts
@@ -1,6 +1,7 @@
 import type { SessionHandle } from '@agent/runtime';
 import { createSessionStores } from '@controllers/session/sessionStores';
 import { createLog } from '@logger/logUtils';
+import type { StreamTabId } from '@shared/schemas';
 import { toLogData } from './desktopLogUtils.js';
 
 /**
@@ -10,14 +11,23 @@ export async function initializeDesktopProcessStores(session: SessionHandle) {
   const logger = createLog('DesktopProcessStores');
   const stores = createSessionStores(session);
   await stores.sweepLeftoverStreams();
-  const streamIncarnations = new Map<string, number>();
+  const streamIncarnations = new Map<StreamTabId, number>();
+  const pendingRemovals = new Map<StreamTabId, number>();
 
   const detachStreamRemoval = session.events.subscribe(
     (sessionEvent) => {
       if (sessionEvent.scope !== 'session') return;
       if (sessionEvent.event.type === 'setActiveStream') {
         const { streamId } = sessionEvent.event.payload;
-        if (!streamId) return;
+        if (
+          !streamId ||
+          !pendingRemovals.has(streamId) ||
+          session.snapshots.getRunMetadata(streamId, { quiet: true }).identity
+            ?.kind !== 'multiAgentWorkflow' ||
+          !session.executions.getAgentHandleByStream(streamId)
+        ) {
+          return;
+        }
         streamIncarnations.set(
           streamId,
           (streamIncarnations.get(streamId) ?? 0) + 1,
@@ -27,6 +37,7 @@ export async function initializeDesktopProcessStores(session: SessionHandle) {
       if (sessionEvent.event.type === 'removeStream') {
         const { streamId } = sessionEvent.event.payload;
         const expectedIncarnation = streamIncarnations.get(streamId) ?? 0;
+        pendingRemovals.set(streamId, expectedIncarnation);
         // SessionStores tracks the lease barrier immediately so a window
         // reattaching before terminal artifact persistence finishes cannot
         // replay a stream already marked removed.
@@ -35,10 +46,22 @@ export async function initializeDesktopProcessStores(session: SessionHandle) {
             shouldDelete: () =>
               (streamIncarnations.get(streamId) ?? 0) === expectedIncarnation,
           })
+          .then((outcome) => {
+            if (outcome === 'superseded') {
+              logger.info(
+                `Skipped deletion for re-claimed desktop stream ${streamId}`,
+              );
+            }
+          })
           .catch((error: unknown) => {
             logger.warn('Failed to delete a headless desktop stream', {
               data: toLogData(error),
             });
+          })
+          .finally(() => {
+            if (pendingRemovals.get(streamId) === expectedIncarnation) {
+              pendingRemovals.delete(streamId);
+            }
           });
       }
     },

--- a/packages/desktop/src/main/desktopProcessStores.ts
+++ b/packages/desktop/src/main/desktopProcessStores.ts
@@ -67,6 +67,7 @@ export async function initializeDesktopProcessStores(session: SessionHandle) {
           void stores
             .deleteStreamAfterOwnedExecutionRelease(streamId, {
               shouldDelete: deletionGuard(streamId, expectedIncarnation),
+              expectedIncarnation,
             })
             .then((outcome) => {
               if (outcome === 'superseded') {

--- a/packages/desktop/src/main/desktopProcessStores.ts
+++ b/packages/desktop/src/main/desktopProcessStores.ts
@@ -13,6 +13,21 @@ export async function initializeDesktopProcessStores(session: SessionHandle) {
   await stores.sweepLeftoverStreams();
   const streamIncarnations = new Map<StreamTabId, number>();
   const pendingRemovals = new Map<StreamTabId, number>();
+  const deletionGuards = new Map<
+    StreamTabId,
+    { readonly incarnation: number; readonly guard: () => boolean }
+  >();
+  const deletionGuard = (
+    streamId: StreamTabId,
+    expectedIncarnation: number,
+  ): (() => boolean) => {
+    const cached = deletionGuards.get(streamId);
+    if (cached?.incarnation === expectedIncarnation) return cached.guard;
+    const guard = (): boolean =>
+      (streamIncarnations.get(streamId) ?? 0) === expectedIncarnation;
+    deletionGuards.set(streamId, { incarnation: expectedIncarnation, guard });
+    return guard;
+  };
 
   const detachStreamRemoval = session.events.subscribe(
     (sessionEvent) => {
@@ -43,8 +58,7 @@ export async function initializeDesktopProcessStores(session: SessionHandle) {
         // replay a stream already marked removed.
         void stores
           .deleteStreamAfterOwnedExecutionRelease(streamId, {
-            shouldDelete: () =>
-              (streamIncarnations.get(streamId) ?? 0) === expectedIncarnation,
+            shouldDelete: deletionGuard(streamId, expectedIncarnation),
           })
           .then((outcome) => {
             if (outcome === 'superseded') {
@@ -75,6 +89,7 @@ export async function initializeDesktopProcessStores(session: SessionHandle) {
     dispose() {
       detachStreamRemoval();
       detachArtifactFlusher();
+      deletionGuards.clear();
     },
   };
 }

--- a/packages/desktop/src/main/desktopProcessStores.ts
+++ b/packages/desktop/src/main/desktopProcessStores.ts
@@ -53,12 +53,12 @@ export async function initializeDesktopProcessStores(session: SessionHandle) {
         const { streamId } = sessionEvent.event.payload;
         const expectedIncarnation = streamIncarnations.get(streamId) ?? 0;
         pendingRemovals.set(streamId, expectedIncarnation);
-        // Let a live ProgressBackend claim the deletion synchronously while
-        // this fact is dispatched. Only the process-level headless fallback
-        // starts in the following microtask, so the two hosts never create
-        // separate guard slots for the same removal.
+        // A live ProgressBackend claims this incarnation synchronously during
+        // fact dispatch, before its deletion preparation reaches an await.
+        // Check in the following microtask so the process fallback runs only
+        // when no presentation owns the removal.
         queueMicrotask(() => {
-          if (stores.hasPendingStreamDeletion(streamId)) {
+          if (stores.hasStreamDeletionClaim(streamId, expectedIncarnation)) {
             if (pendingRemovals.get(streamId) === expectedIncarnation) {
               pendingRemovals.delete(streamId);
             }

--- a/packages/desktop/src/main/desktopProcessStores.ts
+++ b/packages/desktop/src/main/desktopProcessStores.ts
@@ -10,19 +10,31 @@ export async function initializeDesktopProcessStores(session: SessionHandle) {
   const logger = createLog('DesktopProcessStores');
   const stores = createSessionStores(session);
   await stores.sweepLeftoverStreams();
+  const streamIncarnations = new Map<string, number>();
 
   const detachStreamRemoval = session.events.subscribe(
     (sessionEvent) => {
-      if (
-        sessionEvent.scope === 'session' &&
-        sessionEvent.event.type === 'removeStream'
-      ) {
+      if (sessionEvent.scope !== 'session') return;
+      if (sessionEvent.event.type === 'setActiveStream') {
         const { streamId } = sessionEvent.event.payload;
+        if (!streamId) return;
+        streamIncarnations.set(
+          streamId,
+          (streamIncarnations.get(streamId) ?? 0) + 1,
+        );
+        return;
+      }
+      if (sessionEvent.event.type === 'removeStream') {
+        const { streamId } = sessionEvent.event.payload;
+        const expectedIncarnation = streamIncarnations.get(streamId) ?? 0;
         // SessionStores tracks the lease barrier immediately so a window
         // reattaching before terminal artifact persistence finishes cannot
         // replay a stream already marked removed.
         void stores
-          .deleteStreamAfterOwnedExecutionRelease(streamId)
+          .deleteStreamAfterOwnedExecutionRelease(streamId, {
+            shouldDelete: () =>
+              (streamIncarnations.get(streamId) ?? 0) === expectedIncarnation,
+          })
           .catch((error: unknown) => {
             logger.warn('Failed to delete a headless desktop stream', {
               data: toLogData(error),

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -505,6 +505,7 @@ export class SessionStores {
     await Promise.all(
       [...streamsByExecution].map(async ([executionId, streams]) => {
         let failedAdjacentStreams = new Set<StreamTabId>();
+        let supersededAdjacentStreams = new Set<StreamTabId>();
         const shouldDelete = shouldDeleteStream
           ? () => streams.every((stream) => shouldDeleteStream(stream))
           : undefined;
@@ -516,10 +517,14 @@ export class SessionStores {
               shouldDeleteStream,
             );
             failedAdjacentStreams = cleanup.failed;
+            supersededAdjacentStreams = cleanup.superseded;
             throwAggregated(
               cleanup.failures,
               'Multiple adjacent cleanups failed',
             );
+            if (cleanup.superseded.size > 0) {
+              throw new StreamDeletionSupersededError();
+            }
           },
           shouldDelete,
         );
@@ -543,35 +548,51 @@ export class SessionStores {
           return;
         }
         if (outcome.kind === 'superseded') {
-          for (const stream of streams) active.add(stream);
+          if (supersededAdjacentStreams.size === 0) {
+            for (const stream of streams) active.add(stream);
+            return;
+          }
+          for (const stream of supersededAdjacentStreams) active.add(stream);
+          for (const stream of streams) {
+            if (!supersededAdjacentStreams.has(stream)) deleted.add(stream);
+          }
+          await this.notifyCanonicalDeletions(
+            streams,
+            canonicalStreams,
+            supersededAdjacentStreams,
+          );
           return;
         }
         log.warn(
           `Failed to delete streams for execution ${executionId}: ${toErrorMessage(outcome.error)}`,
           { data: outcome.error },
         );
-        // `retained` means the execution deletion failed before its
-        // `beforeDelete` cleanup committed. With per-stream cleanup failures
-        // some streams in the group DID commit, so only those exact committed
-        // streams belong in `deleted`; the failed ones are the retained set.
-        // With no per-stream failures the cleanup never ran, so nothing
-        // committed and `deleted` must stay empty even for snapshot-only
+        // `retained` normally means execution deletion failed before its
+        // `beforeDelete` cleanup committed. When adjacent cleanup did run,
+        // retain only the streams that failed or were superseded; the others
+        // committed and belong in `deleted`. With no adjacent outcome, cleanup
+        // never ran, so `deleted` must stay empty even for snapshot-only
         // identities that have no canonical tab to report in `failed`.
-        const retainedStreams =
-          failedAdjacentStreams.size > 0
-            ? failedAdjacentStreams
-            : streams.filter((stream) => this.streamLogs.has(stream));
-        for (const stream of retainedStreams) failed.add(stream);
-        if (failedAdjacentStreams.size > 0) {
+        const retainedAdjacentStreams = new Set([
+          ...failedAdjacentStreams,
+          ...supersededAdjacentStreams,
+        ]);
+        if (retainedAdjacentStreams.size === 0) {
           for (const stream of streams) {
-            if (!failedAdjacentStreams.has(stream)) deleted.add(stream);
+            if (this.streamLogs.has(stream)) failed.add(stream);
           }
-          await this.notifyCanonicalDeletions(
-            streams,
-            canonicalStreams,
-            failedAdjacentStreams,
-          );
+          return;
         }
+        for (const stream of failedAdjacentStreams) failed.add(stream);
+        for (const stream of supersededAdjacentStreams) active.add(stream);
+        for (const stream of streams) {
+          if (!retainedAdjacentStreams.has(stream)) deleted.add(stream);
+        }
+        await this.notifyCanonicalDeletions(
+          streams,
+          canonicalStreams,
+          retainedAdjacentStreams,
+        );
       }),
     );
     return { active, failed, deleted };
@@ -876,9 +897,11 @@ export class SessionStores {
     shouldDeleteStream?: (stream: StreamTabId) => boolean,
   ): Promise<{
     failed: Set<StreamTabId>;
+    superseded: Set<StreamTabId>;
     failures: unknown[];
   }> {
     const failed = new Set<StreamTabId>();
+    const superseded = new Set<StreamTabId>();
     const failures: unknown[] = [];
     await Promise.all(
       streams.map(async (stream) => {
@@ -888,11 +911,15 @@ export class SessionStores {
             shouldDeleteStream ? () => shouldDeleteStream(stream) : undefined,
           );
         } catch (error) {
+          if (error instanceof StreamDeletionSupersededError) {
+            superseded.add(stream);
+            return;
+          }
           failed.add(stream);
           failures.push(error);
         }
       }),
     );
-    return { failed, failures };
+    return { failed, superseded, failures };
   }
 }

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -13,6 +13,7 @@ import { waitForOwnedExecutionLeaseRelease } from '@agent/storage/executionLease
 import { createLog } from '@logger/logUtils';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import type { StreamLogStore, StreamSnapshotStore } from '@transcript';
+import { StreamDeletionSupersededError } from '@transcript/StreamLogStore';
 import type { StagedStreamSnapshotDeletion } from '@transcript/StagedDeletionCoordinator';
 import { canUseStreamDataDir } from '@transcript/streamDataPaths';
 import { throwAggregated, unique } from '@utils/core';
@@ -51,9 +52,11 @@ export interface SessionStoresOptions {
 export interface DeleteAllStreamsResult {
   readonly active: ReadonlySet<StreamTabId>;
   readonly failed: ReadonlySet<StreamTabId>;
+  /** Streams whose adjacent durable state this call actually deleted. */
+  readonly deleted: ReadonlySet<StreamTabId>;
 }
 
-export type DeleteStreamResult = 'deleted' | 'active' | 'failed';
+export type DeleteStreamResult = 'deleted' | 'active' | 'failed' | 'superseded';
 
 /**
  * Result of removing an execution together with its adjacent stream state.
@@ -64,7 +67,8 @@ export type DeleteStreamResult = 'deleted' | 'active' | 'failed';
 type ExecutionDeletionOutcome =
   | { readonly kind: 'completed'; readonly result: DeleteExecutionResult }
   | { readonly kind: 'streams-deleted'; readonly error: unknown }
-  | { readonly kind: 'retained'; readonly error: unknown };
+  | { readonly kind: 'retained'; readonly error: unknown }
+  | { readonly kind: 'superseded' };
 
 /**
  * Coordinates the durable footprint for a progress stream.
@@ -87,9 +91,16 @@ export class SessionStores {
         children: readonly StreamTabId[],
       ) => void | Promise<void>)
     | undefined;
+  /**
+   * Single-flight per stream, then per guard reference. The guard is stable per
+   * incarnation (`SessionState` memoizes it), so two removals of the same
+   * identity at the same incarnation share one promise, while a re-claimed
+   * identity's new guard starts its own deletion independently. `undefined`
+   * is the slot for unguarded deletions.
+   */
   private readonly pendingStreamDeletions = new Map<
     StreamTabId,
-    Promise<DeleteStreamResult>
+    Map<(() => boolean) | undefined, Promise<DeleteStreamResult>>
   >();
   private pendingDeleteAll: Promise<DeleteAllStreamsResult> | undefined;
   private readonly deletionQueue = new PQueue({ concurrency: 1 });
@@ -110,9 +121,15 @@ export class SessionStores {
     if (executionId) await waitForOwnedExecutionLeaseRelease(executionId);
   }
 
-  deleteStream(stream: StreamTabId): Promise<DeleteStreamResult> {
-    return this.trackStreamDeletion(stream, () =>
-      this.enqueueDeletion(() => this.deleteStreamAndNotify(stream)),
+  deleteStream(
+    stream: StreamTabId,
+    options?: { readonly shouldDelete?: () => boolean },
+  ): Promise<DeleteStreamResult> {
+    const shouldDelete = options?.shouldDelete;
+    return this.trackStreamDeletion(stream, shouldDelete, () =>
+      this.enqueueDeletion(() =>
+        this.deleteStreamAndNotify(stream, shouldDelete),
+      ),
     );
   }
 
@@ -133,7 +150,7 @@ export class SessionStores {
   deleteStreamAfterOwnedExecutionRelease(
     stream: StreamTabId,
   ): Promise<DeleteStreamResult> {
-    return this.trackStreamDeletion(stream, async () => {
+    return this.trackStreamDeletion(stream, undefined, async () => {
       // Track the whole wait so a presentation attaching during terminal
       // artifact persistence cannot replay a stream already marked removed.
       // If the ownership read fails here, report `failed` immediately rather
@@ -154,23 +171,36 @@ export class SessionStores {
 
   private trackStreamDeletion(
     stream: StreamTabId,
+    guard: (() => boolean) | undefined,
     start: () => Promise<DeleteStreamResult>,
   ): Promise<DeleteStreamResult> {
-    const existing = this.pendingStreamDeletions.get(stream);
+    let byGuard = this.pendingStreamDeletions.get(stream);
+    if (!byGuard) {
+      byGuard = new Map();
+      this.pendingStreamDeletions.set(stream, byGuard);
+    }
+    const existing = byGuard.get(guard);
     if (existing) return existing;
     const pending = start();
-    this.pendingStreamDeletions.set(stream, pending);
-    const finish = (): void => this.finishStreamDeletion(stream, pending);
+    byGuard.set(guard, pending);
+    const finish = (): void =>
+      this.finishStreamDeletion(stream, guard, pending);
     void pending.then(finish, finish);
     return pending;
   }
 
   private async deleteStreamAndNotify(
     stream: StreamTabId,
+    shouldDelete?: () => boolean,
   ): Promise<DeleteStreamResult> {
+    if (shouldDelete && !shouldDelete()) return 'superseded';
     const hadCanonicalStream = this.streamLogs.has(stream);
-    const result = await this.deleteStreamOnce(stream);
+    const result = await this.deleteStreamOnce(stream, shouldDelete);
     if (result === 'deleted' && hadCanonicalStream) {
+      // Re-check immediately before the canonical-deleted notify: a re-claim
+      // landing during the goal-forget await (inside `deleteStreamOnce`) must
+      // not clear the fresh incarnation's resources.
+      if (shouldDelete && !shouldDelete()) return 'superseded';
       await this.notifyDeleted(stream);
     }
     return result;
@@ -182,7 +212,9 @@ export class SessionStores {
       this.pendingDeleteAll !== undefined
     ) {
       await Promise.allSettled([
-        ...this.pendingStreamDeletions.values(),
+        ...[...this.pendingStreamDeletions.values()].flatMap((byGuard) => [
+          ...byGuard.values(),
+        ]),
         ...(this.pendingDeleteAll ? [this.pendingDeleteAll] : []),
       ]);
     }
@@ -201,11 +233,13 @@ export class SessionStores {
 
   private finishStreamDeletion(
     stream: StreamTabId,
+    guard: (() => boolean) | undefined,
     pending: Promise<DeleteStreamResult>,
   ): void {
-    if (this.pendingStreamDeletions.get(stream) === pending) {
-      this.pendingStreamDeletions.delete(stream);
-    }
+    const byGuard = this.pendingStreamDeletions.get(stream);
+    if (byGuard?.get(guard) !== pending) return;
+    byGuard.delete(guard);
+    if (byGuard.size === 0) this.pendingStreamDeletions.delete(stream);
   }
 
   private async notifyDeleted(stream: StreamTabId): Promise<void> {
@@ -252,8 +286,10 @@ export class SessionStores {
 
   private async deleteStreamOnce(
     stream: StreamTabId,
+    shouldDelete?: () => boolean,
   ): Promise<DeleteStreamResult> {
     if (!canUseStreamDataDir(stream)) return 'deleted';
+    if (shouldDelete && !shouldDelete()) return 'superseded';
 
     let executionId: ExecutionId | undefined;
     try {
@@ -266,10 +302,13 @@ export class SessionStores {
       return 'failed';
     }
 
+    if (shouldDelete && !shouldDelete()) return 'superseded';
+
     if (!executionId) {
       try {
-        await this.deleteStreamSidecars(stream);
+        await this.deleteStreamSidecars(stream, shouldDelete);
       } catch (error) {
+        if (error instanceof StreamDeletionSupersededError) return 'superseded';
         log.warn(
           `Stream ${stream} was retained because cleanup was incomplete: ${toErrorMessage(error)}`,
           { data: error },
@@ -279,8 +318,10 @@ export class SessionStores {
       return 'deleted';
     }
 
-    const outcome = await this.deleteExecutionWithStreamState(executionId, () =>
-      this.deleteStreamSidecars(stream),
+    const outcome = await this.deleteExecutionWithStreamState(
+      executionId,
+      () => this.deleteStreamSidecars(stream, shouldDelete),
+      shouldDelete,
     );
     switch (outcome.kind) {
       case 'completed':
@@ -297,6 +338,8 @@ export class SessionStores {
           { data: outcome.error },
         );
         return 'failed';
+      case 'superseded':
+        return 'superseded';
     }
   }
 
@@ -308,17 +351,25 @@ export class SessionStores {
   private async deleteExecutionWithStreamState(
     executionId: ExecutionId,
     cleanup: () => Promise<void>,
+    shouldDelete?: () => boolean,
   ): Promise<ExecutionDeletionOutcome> {
+    if (shouldDelete && !shouldDelete()) return { kind: 'superseded' };
     let cleanupCompleted = false;
     try {
       const result = await this.deleteExecution(executionId, {
         beforeDelete: async () => {
+          if (shouldDelete && !shouldDelete()) {
+            throw new StreamDeletionSupersededError();
+          }
           await cleanup();
           cleanupCompleted = true;
         },
       });
       return { kind: 'completed', result };
     } catch (error) {
+      if (error instanceof StreamDeletionSupersededError) {
+        return { kind: 'superseded' };
+      }
       return cleanupCompleted
         ? { kind: 'streams-deleted', error }
         : { kind: 'retained', error };
@@ -420,10 +471,12 @@ export class SessionStores {
       streamsByExecution.set(executionId, streams);
     }
     const active = new Set<StreamTabId>();
+    const deleted = new Set<StreamTabId>();
     await Promise.all(
       streamsWithoutExecution.map(async (stream) => {
         try {
           await this.deleteStreamSidecars(stream);
+          deleted.add(stream);
           if (canonicalStreams.has(stream)) await this.notifyDeleted(stream);
         } catch (error) {
           log.warn(
@@ -453,11 +506,13 @@ export class SessionStores {
           if (outcome.result.status === 'active') {
             for (const stream of streams) active.add(stream);
           } else {
+            for (const stream of streams) deleted.add(stream);
             await this.notifyCanonicalDeletions(streams, canonicalStreams);
           }
           return;
         }
         if (outcome.kind === 'streams-deleted') {
+          for (const stream of streams) deleted.add(stream);
           log.warn(
             `Streams for execution ${executionId} were deleted, but execution cleanup was incomplete: ${toErrorMessage(outcome.error)}`,
             { data: outcome.error },
@@ -465,16 +520,27 @@ export class SessionStores {
           await this.notifyCanonicalDeletions(streams, canonicalStreams);
           return;
         }
+        if (outcome.kind === 'superseded') return;
         log.warn(
           `Failed to delete streams for execution ${executionId}: ${toErrorMessage(outcome.error)}`,
           { data: outcome.error },
         );
+        // `retained` means the execution deletion failed before its
+        // `beforeDelete` cleanup committed. With per-stream cleanup failures
+        // some streams in the group DID commit, so only those exact committed
+        // streams belong in `deleted`; the failed ones are the retained set.
+        // With no per-stream failures the cleanup never ran, so nothing
+        // committed and `deleted` must stay empty even for snapshot-only
+        // identities that have no canonical tab to report in `failed`.
         const retainedStreams =
           failedAdjacentStreams.size > 0
             ? failedAdjacentStreams
             : streams.filter((stream) => this.streamLogs.has(stream));
         for (const stream of retainedStreams) failed.add(stream);
         if (failedAdjacentStreams.size > 0) {
+          for (const stream of streams) {
+            if (!failedAdjacentStreams.has(stream)) deleted.add(stream);
+          }
           await this.notifyCanonicalDeletions(
             streams,
             canonicalStreams,
@@ -483,7 +549,7 @@ export class SessionStores {
         }
       }),
     );
-    return { active, failed };
+    return { active, failed, deleted };
   }
 
   /**
@@ -622,6 +688,7 @@ export class SessionStores {
               );
               return;
             }
+            if (outcome.kind === 'superseded') return;
             if (outcome.result.status === 'active') return;
             if (outcome.result.status === 'deleted') {
               sweptExecutionIds.push(executionId);
@@ -689,16 +756,45 @@ export class SessionStores {
     return swept;
   }
 
-  private async deleteStreamSidecars(stream: StreamTabId): Promise<void> {
+  private async deleteStreamSidecars(
+    stream: StreamTabId,
+    shouldDelete?: () => boolean,
+  ): Promise<void> {
     const snapshotDeletion = await this.snapshots.stageDeleteStream(
       stream,
       (children) => this.notifyChildrenDetached(stream, children),
     );
+    // The generation guard is re-checked after staging: `stageDeleteStream`
+    // awaits, and a workflow relaunch can claim the identity during that
+    // await. Only an unchanged generation may cross the transcript commit
+    // point below; a superseded deletion rolls its staging back and leaves
+    // the fresh incarnation untouched.
+    if (shouldDelete && !shouldDelete()) {
+      try {
+        await snapshotDeletion.rollback();
+      } catch (rollbackError) {
+        log.warn(
+          `Stream ${stream} deletion was superseded, but snapshot staging rollback was incomplete: ${toErrorMessage(rollbackError)}`,
+          { data: rollbackError },
+        );
+      }
+      throw new StreamDeletionSupersededError(stream);
+    }
     try {
       // The transcript registry is the commit point for tab visibility.
       // Snapshot sidecars are only renamed before this, so a failure can roll
-      // them back without reconstructing state from partial files.
-      await this.streamLogs.delete(stream);
+      // them back without reconstructing state from partial files. The guard
+      // travels into `delete` itself so it is re-checked after the durable
+      // transcript delete but before in-memory state is forgotten.
+      await this.streamLogs.delete(stream, { shouldDelete });
+      // `delete` re-checked the guard before forgetting in-memory state. This
+      // final check runs with no await between it and the snapshot commit, so
+      // a re-claim that landed during the transcript I/O above can roll the
+      // snapshot staging back instead of having its buffered sidecar writes
+      // discarded by `commit`.
+      if (shouldDelete && !shouldDelete()) {
+        throw new StreamDeletionSupersededError(stream);
+      }
     } catch (error) {
       try {
         await snapshotDeletion.rollback();
@@ -711,16 +807,42 @@ export class SessionStores {
       throw error;
     }
 
-    const cleanup = await Promise.allSettled([
-      snapshotDeletion.commit(),
-      this.goalEntries?.forget(stream),
-    ]);
-    for (const result of cleanup) {
-      if (result.status === 'fulfilled') continue;
+    // The snapshot commit is the irreversible sidecar delete. Inspect its
+    // supersede result rather than swallowing it in `allSettled`: a re-claim
+    // landing during the staged copy's delete must report `superseded`, not
+    // `deleted`, so `deleteStreamOnce` skips the canonical-deleted notify and
+    // this removal never forgets the fresh incarnation's goal or clears its
+    // resources.
+    let superseded = false;
+    try {
+      superseded = await snapshotDeletion.commit(shouldDelete);
+    } catch (error) {
+      // The transcript already committed, so a snapshot-cleanup failure keeps
+      // the deletion `deleted`; it is logged here and still followed by goal
+      // cleanup, matching the prior best-effort auxiliary-cleanup contract.
       log.warn(
-        `Stream ${stream} was deleted, but auxiliary cleanup was incomplete: ${toErrorMessage(result.reason)}`,
-        { data: result.reason },
+        `Stream ${stream} was deleted, but snapshot commit was incomplete: ${toErrorMessage(error)}`,
+        { data: error },
       );
+    }
+    if (superseded) {
+      throw new StreamDeletionSupersededError(stream);
+    }
+    // Re-check before the awaited goal forget and before this method reports
+    // the deletion committed: a re-claim landing during the snapshot commit's
+    // child-detachment/flush must not forget the fresh incarnation's goal.
+    if (shouldDelete && !shouldDelete()) {
+      throw new StreamDeletionSupersededError(stream);
+    }
+    if (this.goalEntries) {
+      try {
+        await this.goalEntries.forget(stream);
+      } catch (error) {
+        log.warn(
+          `Stream ${stream} was deleted, but goal cleanup was incomplete: ${toErrorMessage(error)}`,
+          { data: error },
+        );
+      }
     }
   }
 

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -960,7 +960,7 @@ export class SessionStores {
     await Promise.all(
       streams.map(async (stream) => {
         try {
-          await this.deleteAdjacentStreamState(
+          await this.deleteStreamSidecars(
             stream,
             shouldDeleteStream ? () => shouldDeleteStream(stream) : undefined,
           );

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -99,6 +99,10 @@ export class SessionStores {
     StreamTabId,
     Map<number | undefined, Promise<DeleteStreamResult>>
   >();
+  private readonly streamDeletionClaims = new Map<
+    StreamTabId,
+    Map<number, Set<symbol>>
+  >();
   private pendingDeleteAll: Promise<DeleteAllStreamsResult> | undefined;
   private readonly deletionQueue = new PQueue({ concurrency: 1 });
 
@@ -118,9 +122,45 @@ export class SessionStores {
     if (executionId) await waitForOwnedExecutionLeaseRelease(executionId);
   }
 
-  /** Whether a host projection already owns deletion for this stream. */
-  hasPendingStreamDeletion(stream: StreamTabId): boolean {
-    return (this.pendingStreamDeletions.get(stream)?.size ?? 0) > 0;
+  /**
+   * Claim presentation ownership before deletion preparation reaches its
+   * first await. The process-level desktop fallback uses this synchronous
+   * signal to distinguish a live projection from a genuinely headless run.
+   */
+  claimStreamDeletion(
+    stream: StreamTabId,
+    expectedIncarnation: number,
+  ): () => void {
+    let byIncarnation = this.streamDeletionClaims.get(stream);
+    if (!byIncarnation) {
+      byIncarnation = new Map();
+      this.streamDeletionClaims.set(stream, byIncarnation);
+    }
+    let claims = byIncarnation.get(expectedIncarnation);
+    if (!claims) {
+      claims = new Set();
+      byIncarnation.set(expectedIncarnation, claims);
+    }
+    const claim = Symbol(stream);
+    claims.add(claim);
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      claims.delete(claim);
+      if (claims.size === 0) byIncarnation.delete(expectedIncarnation);
+      if (byIncarnation.size === 0) this.streamDeletionClaims.delete(stream);
+    };
+  }
+
+  hasStreamDeletionClaim(
+    stream: StreamTabId,
+    expectedIncarnation: number,
+  ): boolean {
+    return (
+      (this.streamDeletionClaims.get(stream)?.get(expectedIncarnation)?.size ??
+        0) > 0
+    );
   }
 
   deleteStream(

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -119,6 +119,11 @@ export class SessionStores {
     if (executionId) await waitForOwnedExecutionLeaseRelease(executionId);
   }
 
+  /** Whether a host projection already owns deletion for this stream. */
+  hasPendingStreamDeletion(stream: StreamTabId): boolean {
+    return (this.pendingStreamDeletions.get(stream)?.size ?? 0) > 0;
+  }
+
   deleteStream(
     stream: StreamTabId,
     options?: { readonly shouldDelete?: () => boolean },

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -14,7 +14,6 @@ import { createLog } from '@logger/logUtils';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import type { StreamLogStore, StreamSnapshotStore } from '@transcript';
 import { StreamDeletionSupersededError } from '@transcript/StreamLogStore';
-import type { StagedStreamSnapshotDeletion } from '@transcript/StagedDeletionCoordinator';
 import { canUseStreamDataDir } from '@transcript/streamDataPaths';
 import { throwAggregated, unique } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -31,7 +30,6 @@ type ListExecutionStreamReferencesFn = () => Promise<
 
 interface GoalEntryStore {
   forget(stream: StreamTabId): Promise<void>;
-  forgetMany(streams: readonly StreamTabId[]): Promise<void>;
 }
 
 export interface SessionStoresOptions {
@@ -413,9 +411,13 @@ export class SessionStores {
     }
   }
 
-  deleteAll(): Promise<DeleteAllStreamsResult> {
+  deleteAll(options?: {
+    readonly shouldDelete?: (stream: StreamTabId) => boolean;
+  }): Promise<DeleteAllStreamsResult> {
     if (this.pendingDeleteAll) return this.pendingDeleteAll;
-    const pending = this.enqueueDeletion(() => this.deleteAllOnce());
+    const pending = this.enqueueDeletion(() =>
+      this.deleteAllOnce(options?.shouldDelete),
+    );
     this.pendingDeleteAll = pending;
     const finish = (): void => this.finishDeleteAll(pending);
     void pending.then(finish, finish);
@@ -426,7 +428,9 @@ export class SessionStores {
     if (this.pendingDeleteAll === pending) this.pendingDeleteAll = undefined;
   }
 
-  private async deleteAllOnce(): Promise<DeleteAllStreamsResult> {
+  private async deleteAllOnce(
+    shouldDeleteStream?: (stream: StreamTabId) => boolean,
+  ): Promise<DeleteAllStreamsResult> {
     await this.reconcileStagedDeletions(new Set(this.streamLogs.keys()));
     const [persistedStreams, stagedDeletions] = await Promise.all([
       this.snapshots.listPersistedStreams(),
@@ -474,11 +478,18 @@ export class SessionStores {
     const deleted = new Set<StreamTabId>();
     await Promise.all(
       streamsWithoutExecution.map(async (stream) => {
+        const shouldDelete = shouldDeleteStream
+          ? () => shouldDeleteStream(stream)
+          : undefined;
         try {
-          await this.deleteStreamSidecars(stream);
+          await this.deleteStreamSidecars(stream, shouldDelete);
           deleted.add(stream);
           if (canonicalStreams.has(stream)) await this.notifyDeleted(stream);
         } catch (error) {
+          if (error instanceof StreamDeletionSupersededError) {
+            active.add(stream);
+            return;
+          }
           log.warn(
             `Failed to delete stream ${stream}: ${toErrorMessage(error)}`,
             { data: error },
@@ -490,16 +501,23 @@ export class SessionStores {
     await Promise.all(
       [...streamsByExecution].map(async ([executionId, streams]) => {
         let failedAdjacentStreams = new Set<StreamTabId>();
+        const shouldDelete = shouldDeleteStream
+          ? () => streams.every((stream) => shouldDeleteStream(stream))
+          : undefined;
         const outcome = await this.deleteExecutionWithStreamState(
           executionId,
           async () => {
-            const cleanup = await this.deleteAdjacentStreamStates(streams);
+            const cleanup = await this.deleteAdjacentStreamStates(
+              streams,
+              shouldDeleteStream,
+            );
             failedAdjacentStreams = cleanup.failed;
             throwAggregated(
               cleanup.failures,
               'Multiple adjacent cleanups failed',
             );
           },
+          shouldDelete,
         );
 
         if (outcome.kind === 'completed') {
@@ -520,7 +538,10 @@ export class SessionStores {
           await this.notifyCanonicalDeletions(streams, canonicalStreams);
           return;
         }
-        if (outcome.kind === 'superseded') return;
+        if (outcome.kind === 'superseded') {
+          for (const stream of streams) active.add(stream);
+          return;
+        }
         log.warn(
           `Failed to delete streams for execution ${executionId}: ${toErrorMessage(outcome.error)}`,
           { data: outcome.error },
@@ -848,21 +869,19 @@ export class SessionStores {
 
   private async deleteAdjacentStreamStates(
     streams: readonly StreamTabId[],
+    shouldDeleteStream?: (stream: StreamTabId) => boolean,
   ): Promise<{
     failed: Set<StreamTabId>;
     failures: unknown[];
   }> {
     const failed = new Set<StreamTabId>();
     const failures: unknown[] = [];
-    const staged = new Map<StreamTabId, StagedStreamSnapshotDeletion>();
     await Promise.all(
       streams.map(async (stream) => {
         try {
-          staged.set(
+          await this.deleteAdjacentStreamState(
             stream,
-            await this.snapshots.stageDeleteStream(stream, (children) =>
-              this.notifyChildrenDetached(stream, children),
-            ),
+            shouldDeleteStream ? () => shouldDeleteStream(stream) : undefined,
           );
         } catch (error) {
           failed.add(stream);
@@ -870,44 +889,6 @@ export class SessionStores {
         }
       }),
     );
-
-    const transcriptResults = await Promise.all(
-      streams
-        .filter((stream) => !failed.has(stream))
-        .map(async (stream) => {
-          try {
-            await this.streamLogs.delete(stream);
-            return { stream, status: 'fulfilled' as const };
-          } catch (error) {
-            return { stream, status: 'rejected' as const, error };
-          }
-        }),
-    );
-    for (const result of transcriptResults) {
-      if (result.status === 'fulfilled') continue;
-      failed.add(result.stream);
-      failures.push(result.error);
-      try {
-        await staged.get(result.stream)?.rollback();
-      } catch (rollbackError) {
-        failures.push(rollbackError);
-      }
-    }
-
-    const committedStreams = streams.filter((stream) => !failed.has(stream));
-    const cleanup = await Promise.allSettled([
-      ...committedStreams.map((stream) => staged.get(stream)?.commit()),
-      committedStreams.length > 0
-        ? this.goalEntries?.forgetMany(committedStreams)
-        : undefined,
-    ]);
-    for (const result of cleanup) {
-      if (result.status === 'fulfilled') continue;
-      log.warn(
-        `Streams were deleted, but auxiliary cleanup was incomplete: ${toErrorMessage(result.reason)}`,
-        { data: result.reason },
-      );
-    }
     return { failed, failures };
   }
 }

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -90,15 +90,14 @@ export class SessionStores {
       ) => void | Promise<void>)
     | undefined;
   /**
-   * Single-flight per stream, then per guard reference. The guard is stable per
-   * incarnation (`SessionState` memoizes it), so two removals of the same
-   * identity at the same incarnation share one promise, while a re-claimed
-   * identity's new guard starts its own deletion independently. `undefined`
-   * is the slot for unguarded deletions.
+   * Single-flight per stream, then per incarnation. Process- and
+   * presentation-owned removals use different guard functions, but the same
+   * incarnation identifies the same deletion. A re-claimed identity's new
+   * incarnation starts independently. `undefined` is the unkeyed slot.
    */
   private readonly pendingStreamDeletions = new Map<
     StreamTabId,
-    Map<(() => boolean) | undefined, Promise<DeleteStreamResult>>
+    Map<number | undefined, Promise<DeleteStreamResult>>
   >();
   private pendingDeleteAll: Promise<DeleteAllStreamsResult> | undefined;
   private readonly deletionQueue = new PQueue({ concurrency: 1 });
@@ -126,10 +125,13 @@ export class SessionStores {
 
   deleteStream(
     stream: StreamTabId,
-    options?: { readonly shouldDelete?: () => boolean },
+    options?: {
+      readonly shouldDelete?: () => boolean;
+      readonly expectedIncarnation?: number;
+    },
   ): Promise<DeleteStreamResult> {
     const shouldDelete = options?.shouldDelete;
-    return this.trackStreamDeletion(stream, shouldDelete, () =>
+    return this.trackStreamDeletion(stream, options?.expectedIncarnation, () =>
       this.enqueueDeletion(() =>
         this.deleteStreamAndNotify(stream, shouldDelete),
       ),
@@ -152,33 +154,40 @@ export class SessionStores {
 
   deleteStreamAfterOwnedExecutionRelease(
     stream: StreamTabId,
-    options?: { readonly shouldDelete?: () => boolean },
+    options?: {
+      readonly shouldDelete?: () => boolean;
+      readonly expectedIncarnation?: number;
+    },
   ): Promise<DeleteStreamResult> {
     const shouldDelete = options?.shouldDelete;
-    return this.trackStreamDeletion(stream, shouldDelete, async () => {
-      // Track the whole wait so a presentation attaching during terminal
-      // artifact persistence cannot replay a stream already marked removed.
-      // If the ownership read fails here, report `failed` immediately rather
-      // than enqueueing a second read that could decide the stream has no
-      // execution and delete it.
-      try {
-        await this.waitForOwnedExecutionRelease(stream);
-      } catch (error) {
-        log.warn(
-          `Stream ${stream} was retained because its execution ownership could not be read: ${toErrorMessage(error)}`,
-          { data: error },
+    return this.trackStreamDeletion(
+      stream,
+      options?.expectedIncarnation,
+      async () => {
+        // Track the whole wait so a presentation attaching during terminal
+        // artifact persistence cannot replay a stream already marked removed.
+        // If the ownership read fails here, report `failed` immediately rather
+        // than enqueueing a second read that could decide the stream has no
+        // execution and delete it.
+        try {
+          await this.waitForOwnedExecutionRelease(stream);
+        } catch (error) {
+          log.warn(
+            `Stream ${stream} was retained because its execution ownership could not be read: ${toErrorMessage(error)}`,
+            { data: error },
+          );
+          return 'failed';
+        }
+        return this.enqueueDeletion(() =>
+          this.deleteStreamAndNotify(stream, shouldDelete),
         );
-        return 'failed';
-      }
-      return this.enqueueDeletion(() =>
-        this.deleteStreamAndNotify(stream, shouldDelete),
-      );
-    });
+      },
+    );
   }
 
   private trackStreamDeletion(
     stream: StreamTabId,
-    guard: (() => boolean) | undefined,
+    expectedIncarnation: number | undefined,
     start: () => Promise<DeleteStreamResult>,
   ): Promise<DeleteStreamResult> {
     let byGuard = this.pendingStreamDeletions.get(stream);
@@ -186,12 +195,12 @@ export class SessionStores {
       byGuard = new Map();
       this.pendingStreamDeletions.set(stream, byGuard);
     }
-    const existing = byGuard.get(guard);
+    const existing = byGuard.get(expectedIncarnation);
     if (existing) return existing;
     const pending = start();
-    byGuard.set(guard, pending);
+    byGuard.set(expectedIncarnation, pending);
     const finish = (): void =>
-      this.finishStreamDeletion(stream, guard, pending);
+      this.finishStreamDeletion(stream, expectedIncarnation, pending);
     void pending.then(finish, finish);
     return pending;
   }
@@ -240,12 +249,12 @@ export class SessionStores {
 
   private finishStreamDeletion(
     stream: StreamTabId,
-    guard: (() => boolean) | undefined,
+    expectedIncarnation: number | undefined,
     pending: Promise<DeleteStreamResult>,
   ): void {
     const byGuard = this.pendingStreamDeletions.get(stream);
-    if (byGuard?.get(guard) !== pending) return;
-    byGuard.delete(guard);
+    if (byGuard?.get(expectedIncarnation) !== pending) return;
+    byGuard.delete(expectedIncarnation);
     if (byGuard.size === 0) this.pendingStreamDeletions.delete(stream);
   }
 

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -147,8 +147,10 @@ export class SessionStores {
 
   deleteStreamAfterOwnedExecutionRelease(
     stream: StreamTabId,
+    options?: { readonly shouldDelete?: () => boolean },
   ): Promise<DeleteStreamResult> {
-    return this.trackStreamDeletion(stream, undefined, async () => {
+    const shouldDelete = options?.shouldDelete;
+    return this.trackStreamDeletion(stream, shouldDelete, async () => {
       // Track the whole wait so a presentation attaching during terminal
       // artifact persistence cannot replay a stream already marked removed.
       // If the ownership read fails here, report `failed` immediately rather
@@ -163,7 +165,9 @@ export class SessionStores {
         );
         return 'failed';
       }
-      return this.enqueueDeletion(() => this.deleteStreamAndNotify(stream));
+      return this.enqueueDeletion(() =>
+        this.deleteStreamAndNotify(stream, shouldDelete),
+      );
     });
   }
 

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -1,4 +1,5 @@
 // Local imports
+import type { DeleteStreamResult } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { notifyFollowUpSent } from '@agent/followUp/ToolUseFollowUp';
 import {
@@ -95,7 +96,9 @@ export interface ProgressViewLifecycleCommandActions {
     stream: StreamTabId | '',
     requestId: string,
   ): Promise<void> | void;
-  deleteStream(stream: StreamTabId): Promise<void> | void;
+  deleteStream(
+    stream: StreamTabId,
+  ): Promise<DeleteStreamResult | undefined> | void;
   deleteAllStreams(): Promise<void> | void;
   stopStream(stream: StreamTabId): Promise<void> | void;
 }
@@ -226,8 +229,10 @@ export function createProgressViewCommandHandlers(
   return {
     [PROGRESS_VIEW_COMMANDS.SWITCH_STREAM]: (data) =>
       lifecycle.setActiveStream(data.stream, data.requestId),
-    [PROGRESS_VIEW_COMMANDS.DELETE_STREAM]: (data) =>
-      lifecycle.deleteStream(data.stream),
+    [PROGRESS_VIEW_COMMANDS.DELETE_STREAM]: async (data) => {
+      // The outcome matters to the session-fact applier, not the dispatcher.
+      await lifecycle.deleteStream(data.stream);
+    },
     [PROGRESS_VIEW_COMMANDS.DELETE_ALL]: () => lifecycle.deleteAllStreams(),
     [PROGRESS_VIEW_COMMANDS.STOP_STREAM]: (data) =>
       lifecycle.stopStream(data.stream),

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -1,7 +1,7 @@
 import PQueue from 'p-queue';
 
 import { RUN_FACT_EVENT_TYPES } from '@agent/trace';
-import type { SessionStores } from '@agent/storage';
+import type { DeleteStreamResult, SessionStores } from '@agent/storage';
 import type { HostApprovalBypassStateUpdate } from '@agent/runtime/HostInteractions';
 import {
   defaultSession,
@@ -175,7 +175,8 @@ export class ProgressBackend {
     });
     this.hasPendingPermissions = ui.hasPendingPermissions;
     this.factApplier = new SessionFactApplier(this.state, this.renderer, {
-      deleteStream: (stream) => this.deleteStream(stream),
+      deleteStream: (stream, expectedIncarnation) =>
+        this.deleteStream(stream, expectedIncarnation),
     });
     this.setApprovalBypassState = ui.setApprovalBypassState;
   }
@@ -230,7 +231,14 @@ export class ProgressBackend {
     stream: PresentedStreamId,
     requestId?: string,
   ): Promise<void> {
-    if (stream && !this.state.streamLogs.has(stream)) {
+    // The fact path re-claims a deterministic workflow stream before it
+    // reaches this call; every other removed identity must not be focused,
+    // even when `streamLogs` still has a summary for a provisional removal
+    // that has not committed yet.
+    if (
+      stream &&
+      (this.state.isStreamRemoved(stream) || !this.state.streamLogs.has(stream))
+    ) {
       // A newer rejected request still supersedes every older hydration. Its
       // visual intent is settled back to the confirmed selection below.
       this.activationGeneration += 1;
@@ -428,12 +436,13 @@ export class ProgressBackend {
   /** Inject a session fact (tests / rare host seeds). Prefer the hub in production. */
   applySessionFact(
     ...args: Parameters<SessionFactApplier['handleSessionFact']>
-  ): void {
-    this.factApplier.handleSessionFact(...args);
+  ): boolean {
+    const admitted = this.factApplier.handleSessionFact(...args);
     const [fact] = args;
-    if (fact.type === 'setActiveStream') {
+    if (admitted && fact.type === 'setActiveStream') {
       this.handleStreamPresentationRequest(fact.payload);
     }
+    return admitted;
   }
 
   /** Inject a run fact (tests / rare host seeds). Prefer the hub in production. */
@@ -447,29 +456,107 @@ export class ProgressBackend {
     });
   }
 
-  async deleteStream(stream: StreamTabId): Promise<void> {
+  /**
+   * Delete a stream's durable state. Resolves to the retention outcome so the
+   * session-fact applier can keep its removal barrier provisional until the
+   * deletion commits: `active`/`failed` mean the stream still lives.
+   */
+  async deleteStream(
+    stream: StreamTabId,
+    expectedIncarnation?: number,
+  ): Promise<DeleteStreamResult | undefined> {
     const wasActive = this.presentation.activeStream === stream;
     const activationGeneration = this.activationGeneration;
     const storageGeneration = this.storageGeneration;
-    const retained = await this.enqueuePreparedStorageOperation(
-      () => this.prepareStreamDeletion(stream),
-      (ownershipReadFailed) => {
-        if (storageGeneration !== this.storageGeneration) {
-          return Promise.resolve(undefined);
-        }
-        if (ownershipReadFailed) {
-          return Promise.resolve('failed' as const);
-        }
-        return this.deleteStreamNow(stream, wasActive, activationGeneration);
-      },
-    );
-    if (retained) {
-      await this.lifecycle.rebuildRenderedStreams({ syncActiveStream: true });
-      await this.lifecycle.notifyDeletionRetained(
-        retained === 'active' ? 1 : 0,
-        retained === 'failed' ? 1 : 0,
+
+    // A host command (no caller incarnation) owns its removal barrier and
+    // pending buffer through the applier, exactly like a `removeStream` fact.
+    // If a fact-path barrier already owns this identity, do not start a second
+    // deletion or touch that barrier.
+    let commandRemoval: { incarnation: number; created: boolean } | undefined;
+    if (expectedIncarnation === undefined) {
+      commandRemoval = this.factApplier.beginCommandRemoval(stream);
+      if (!commandRemoval.created) return 'superseded';
+      expectedIncarnation = commandRemoval.incarnation;
+    }
+
+    let retained: DeleteStreamResult | undefined;
+    try {
+      retained = await this.enqueuePreparedStorageOperation(
+        // Pre-delete preparation is the one failure shape we can classify: it
+        // definitely did not delete anything, so report `failed` and let the
+        // applier retire the provisional barrier. A post-delete failure is
+        // ambiguous and stays a rejection, so the barrier is kept.
+        () =>
+          this.prepareStreamDeletion(stream).catch((error) => {
+            log.warn(
+              `Stream ${stream} was retained because deletion preparation failed`,
+              { data: error },
+            );
+            return true;
+          }),
+        (preparationRetained) => {
+          if (storageGeneration !== this.storageGeneration) {
+            return Promise.resolve(undefined);
+          }
+          if (preparationRetained) {
+            return Promise.resolve('failed' as const);
+          }
+          return this.deleteStreamNow(
+            stream,
+            wasActive,
+            activationGeneration,
+            expectedIncarnation,
+          );
+        },
+      );
+    } catch (error) {
+      if (commandRemoval) {
+        this.factApplier.abortCommandRemoval(
+          stream,
+          commandRemoval.incarnation,
+          commandRemoval.created,
+        );
+      }
+      throw error;
+    }
+
+    if (retained === 'active' || retained === 'failed') {
+      // Best-effort presentation repair, each failure isolated so a broken
+      // rebuild cannot suppress the retention notification and neither can
+      // make the deletion outcome disappear. The session-fact applier must
+      // still see `active`/`failed` and retire its provisional tombstone.
+      try {
+        await this.lifecycle.rebuildRenderedStreams({ syncActiveStream: true });
+      } catch (error) {
+        log.warn(
+          'Failed to rebuild rendered streams after a retained deletion',
+          {
+            data: { stream, retained, error },
+          },
+        );
+      }
+      try {
+        await this.lifecycle.notifyDeletionRetained(
+          retained === 'active' ? 1 : 0,
+          retained === 'failed' ? 1 : 0,
+        );
+      } catch (error) {
+        log.warn('Failed to notify after a retained stream deletion', {
+          data: { stream, retained, error },
+        });
+      }
+    }
+
+    if (commandRemoval) {
+      this.factApplier.completeCommandRemoval(
+        stream,
+        commandRemoval.incarnation,
+        retained,
+        commandRemoval.created,
       );
     }
+    return retained;
   }
 
   /** Whether local durable state exists for `stream` (log or task snapshot). */
@@ -523,15 +610,25 @@ export class ProgressBackend {
     stream: StreamTabId,
     wasActive: boolean,
     activationGenerationAtStart: number,
-  ): Promise<'active' | 'failed' | undefined> {
+    expectedIncarnation?: number,
+  ): Promise<'deleted' | 'active' | 'failed' | 'superseded' | undefined> {
+    // `undefined` means the deletion never ran (reserved id / cannot-use data
+    // dir), not "deleted": the command path relies on a committed deletion
+    // being reported as `deleted` so it keeps the tombstone it just installed.
     if (!canUseStreamDataDir(stream)) return undefined;
 
     const hadDeletableData = this.hasDeletableStreamData(stream);
-    const deletion = await this.state.clearStream(stream);
+    const deletion =
+      expectedIncarnation === undefined
+        ? await this.state.clearStream(stream)
+        : await this.state.clearStream(stream, { expectedIncarnation });
     if (deletion !== 'deleted') {
       return deletion;
     }
-    if (!hadDeletableData) return undefined;
+    // `clearStream` deleted and tombstoned the stream, so report `deleted`
+    // even when it had no durable data (ephemeral-only): the caller must not
+    // retire the tombstone a stale fact could then resurrect through.
+    if (!hadDeletableData) return 'deleted';
 
     this.lifecycle.cleanupDeletedStream(stream);
     this.webviewBridge.clearStream(stream);
@@ -577,7 +674,7 @@ export class ProgressBackend {
       // changed; the active stream's content is still on screen and correct.
       await this.lifecycle.rebuildRenderedStreams({ syncActiveStream: false });
     }
-    return undefined;
+    return 'deleted';
   }
 
   async deleteAllStreams(): Promise<void> {
@@ -595,14 +692,30 @@ export class ProgressBackend {
       activationGeneration !== this.activationGeneration &&
       (this.latestActivationTarget === '' ||
         this.state.streamLogs.has(this.latestActivationTarget));
-    await this.lifecycle.rebuildRenderedStreams({
-      syncActiveStream: !outcome.allDeleted && !newerIntentControlsSelection,
-    });
+    try {
+      await this.lifecycle.rebuildRenderedStreams({
+        syncActiveStream: !outcome.allDeleted && !newerIntentControlsSelection,
+      });
+    } catch (error) {
+      log.warn('Failed to rebuild rendered streams after bulk deletion', {
+        data: { allDeleted: outcome.allDeleted, error },
+      });
+    }
     if (!outcome.allDeleted) {
-      await this.lifecycle.notifyDeletionRetained(
-        outcome.activeCount,
-        outcome.failedCount,
-      );
+      try {
+        await this.lifecycle.notifyDeletionRetained(
+          outcome.activeCount,
+          outcome.failedCount,
+        );
+      } catch (error) {
+        log.warn('Failed to notify after a retained bulk deletion', {
+          data: {
+            activeCount: outcome.activeCount,
+            failedCount: outcome.failedCount,
+            error,
+          },
+        });
+      }
     }
   }
 
@@ -762,8 +875,11 @@ export class ProgressBackend {
       this.session.events.subscribe(
         (sessionEvent) => {
           if (sessionEvent.scope !== 'session') return;
-          this.factApplier.handleSessionFact(sessionEvent.event);
-          if (sessionEvent.event.type === 'setActiveStream') {
+          const admitted = this.factApplier.handleSessionFact(
+            sessionEvent.event,
+          );
+          // A refused attachment (removed stream) must not activate or lease.
+          if (admitted && sessionEvent.event.type === 'setActiveStream') {
             this.handleStreamPresentationRequest(sessionEvent.event.payload);
           }
         },

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -479,6 +479,10 @@ export class ProgressBackend {
       if (!commandRemoval.created) return 'superseded';
       expectedIncarnation = commandRemoval.incarnation;
     }
+    const releaseDeletionClaim = this.state.stores.claimStreamDeletion(
+      stream,
+      expectedIncarnation,
+    );
 
     let retained: DeleteStreamResult | undefined;
     try {
@@ -511,6 +515,7 @@ export class ProgressBackend {
         },
       );
     } catch (error) {
+      releaseDeletionClaim();
       if (commandRemoval) {
         this.factApplier.abortCommandRemoval(
           stream,
@@ -520,6 +525,7 @@ export class ProgressBackend {
       }
       throw error;
     }
+    releaseDeletionClaim();
 
     if (retained === 'active' || retained === 'failed') {
       // Best-effort presentation repair, each failure isolated so a broken

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -1,3 +1,4 @@
+import type { DeleteStreamResult } from '@agent/storage';
 import { RUN_FACT_EVENT_TYPES, type AgentEvent } from '@agent/trace';
 import type { SessionFact } from '@agent/runtime/SessionEventHub';
 import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
@@ -46,9 +47,68 @@ type RunFactHandlers = {
   ) => void | Promise<void>;
 };
 
+/**
+ * A fact whose stream was provisionally removed while its deletion was still
+ * in flight. Buffered until the delete outcome is known, then either replayed
+ * (the deletion was retained and the stream is still live) or discarded (the
+ * deletion committed or was superseded).
+ */
+type DeferredFact =
+  | { readonly kind: 'session'; readonly fact: SessionFact }
+  | {
+      readonly kind: 'run';
+      readonly streamId: StreamTabId;
+      readonly event: SessionRunFactEvent;
+    };
+
+/** A provisional removal barrier and the facts its async delete deferred. */
+interface PendingDeletion {
+  readonly incarnation: number;
+  readonly facts: DeferredFact[];
+}
+
 export type SessionFactApplierOptions = {
-  deleteStream: (stream: StreamTabId) => void | Promise<void>;
+  /**
+   * Host durable-delete for a removed stream. The resolved outcome decides
+   * the removal barrier's fate: `active`/`failed` mean the stream was
+   * retained — still alive — so the applier retires the barrier and its
+   * facts flow again; `deleted` (or a host that reports nothing) keeps it.
+   * The applier passes the incarnation captured when the barrier was set so
+   * the host can refuse to delete a deterministic identity that a fresh run
+   * re-claimed while the deletion was queued.
+   */
+  deleteStream: (
+    stream: StreamTabId,
+    expectedIncarnation?: number,
+  ) =>
+    | void
+    | DeleteStreamResult
+    | undefined
+    | Promise<void | DeleteStreamResult | undefined>;
 };
+
+/**
+ * Every stream identity a session fact names, in one place: the removal
+ * tombstone guards all of them, so an identity extracted anywhere else would
+ * be a fact the tombstone does not own. `removeStream` is listed for
+ * completeness but is never refused — it is the tombstone writer.
+ */
+function sessionFactStreamIds(fact: SessionFact): StreamTabId[] {
+  switch (fact.type) {
+    case 'status':
+      return [fact.streamId];
+    case 'removeStream':
+      return [fact.payload.streamId];
+    case 'setParentStream':
+      return fact.payload.parentStreamId
+        ? [fact.payload.childStreamId, fact.payload.parentStreamId]
+        : [fact.payload.childStreamId];
+    case 'inquiryThreadUpdated':
+      return fact.payload.parentStreamId ? [fact.payload.parentStreamId] : [];
+    default:
+      return fact.payload.streamId ? [fact.payload.streamId] : [];
+  }
+}
 
 /**
  * Host-neutral session fact applier: mutates {@link SessionState} and notifies
@@ -69,6 +129,15 @@ export class SessionFactApplier {
    * stream with the reopened view, so a stale "already delivered" entry here
    * cannot starve it. */
   private readonly registeredWithRenderer = new Set<StreamTabId>();
+
+  /**
+   * Provisional removal barriers by stream: the incarnation each captured and
+   * the facts arriving while its delete was still in flight. Keyed by stream,
+   * holding only the most recent barrier — a superseded deletion's buffer is
+   * dropped with it (its facts named a superseded incarnation), while a newer
+   * barrier installs its own.
+   */
+  private readonly pendingDeletions = new Map<StreamTabId, PendingDeletion>();
 
   /**
    * Run-fact dispatch table (see `RUN_FACT_EVENT_TYPES`); keys stay exhaustive.
@@ -153,7 +222,55 @@ export class SessionFactApplier {
     this.renderer.onStreamMetadataChanged(streamId, options);
   }
 
-  handleSessionFact(fact: SessionFact): void {
+  /**
+   * Apply one session fact. Returns whether the fact was admitted: a fact
+   * naming a removed stream is stale and refused (removal is final), and
+   * callers that react to a fact beyond state application — presentation
+   * activation, leases — must not react to a refused one.
+   */
+  handleSessionFact(fact: SessionFact): boolean {
+    // A committed tombstone is reopened only by a legitimate workflow
+    // attachment with live-execution evidence. The stream's current metadata
+    // still names the workflow identity (the snapshot projection of the fresh
+    // `run.start` landed before this applier), and the execution registry
+    // holds the freshly tracked handle. A delayed stale `run.start` cannot
+    // satisfy this gate because it carries no attachment and no live handle.
+    if (
+      fact.type === 'setActiveStream' &&
+      fact.payload.streamId !== null &&
+      this.state.isStreamRemoved(fact.payload.streamId) &&
+      this.state.getStreamMetadata(fact.payload.streamId).identity?.kind ===
+        'multiAgentWorkflow' &&
+      this.state.hasLiveStreamExecution(fact.payload.streamId)
+    ) {
+      // The fresh attachment is the first delivery for the new incarnation,
+      // even when a prior host delete left this applier's registry untouched.
+      this.registeredWithRenderer.delete(fact.payload.streamId);
+      this.state.claimStreamIdentity(fact.payload.streamId);
+    }
+    if (
+      fact.type !== 'removeStream' &&
+      sessionFactStreamIds(fact).some((streamId) =>
+        this.state.isStreamRemoved(streamId),
+      )
+    ) {
+      // Refused — but a provisional barrier (delete still in flight) buffers
+      // the fact so a retained deletion can replay it. A committed tombstone
+      // has no pending barrier, so the fact is simply stale and dropped.
+      this.deferSessionFact(fact);
+      return false;
+    }
+    this.applySessionFact(fact);
+    return true;
+  }
+
+  /**
+   * The single application body for an admitted session fact. Replay of
+   * buffered facts must NOT call this directly — it re-runs the admission
+   * path (`handleSessionFact`) so every identity a multi-stream fact names is
+   * revalidated against the tombstone set.
+   */
+  private applySessionFact(fact: SessionFact): void {
     // Wrap once, and RETURN each case so async handlers' promises reach
     // `withEventErrorHandling` (a discarded promise would let a post-await
     // rejection escape its thenable check as an unhandled rejection).
@@ -194,9 +311,68 @@ export class SessionFactApplier {
             );
           case 'setParentStream':
             return this.handleSetParentStream(fact.payload);
-          case 'removeStream':
-            this.registeredWithRenderer.delete(fact.payload.streamId);
-            return this.options.deleteStream(fact.payload.streamId);
+          case 'removeStream': {
+            const { streamId } = fact.payload;
+            // Provisional barrier: facts racing the host delete are refused
+            // now, but the barrier becomes permanent only when the deletion
+            // actually commits. The captured incarnation travels with the
+            // host delete, so a workflow relaunch that claims the identity
+            // while the delete is queued makes the delete report
+            // `superseded` instead of erasing the fresh run. A
+            // retained/live/failed/superseded outcome retires the barrier so
+            // a still-live or freshly re-claimed stream is not frozen — but
+            // only when the barrier still carries THIS removal's incarnation,
+            // because a newer deletion B may already own the identity. The
+            // host delete option must surface that outcome even when
+            // presentation repair fails; any other rejection leaves the
+            // barrier in place and is logged by the event-error wrapper,
+            // because the stream may have deleted.
+            const { incarnation: expectedIncarnation } =
+              this.state.beginStreamRemoval(streamId);
+            this.registeredWithRenderer.delete(streamId);
+            const { pending, created } = this.beginPendingDeletion(
+              streamId,
+              expectedIncarnation,
+            );
+            return Promise.resolve(
+              this.options.deleteStream(streamId, expectedIncarnation),
+            ).then(
+              (outcome) => {
+                // A prior removeStream fact for the same incarnation owns this
+                // deletion's settlement (the store dedups its delete promise);
+                // only the owning barrier retires the tombstone and replays.
+                if (!created) return;
+                this.finishPendingDeletion(streamId, pending);
+                const retired =
+                  (outcome === 'active' ||
+                    outcome === 'failed' ||
+                    outcome === 'superseded') &&
+                  this.state.retireStreamTombstone(
+                    streamId,
+                    expectedIncarnation,
+                  );
+                // A retained deletion still lives: replay the facts buffered
+                // while it was provisional so status/stage/roster/metadata are
+                // not stuck stale. Replay only when the retirement above
+                // actually removed THIS removal's barrier — a superseded
+                // deletion whose identity a fresh run re-claimed (or a newer
+                // deletion B owns) must never replay through that newer
+                // barrier. A committed deletion discards them (the stream is
+                // gone).
+                if ((outcome === 'active' || outcome === 'failed') && retired) {
+                  this.replayDeferredFacts(pending.facts);
+                }
+              },
+              (error) => {
+                // Ambiguous failure: keep the barrier (the stream may have
+                // deleted), but drop the provisional buffer — there is no
+                // outcome to replay against. The error still propagates to the
+                // event-error wrapper.
+                if (created) this.finishPendingDeletion(streamId, pending);
+                throw error;
+              },
+            );
+          }
         }
         assertNever(fact, 'Unhandled session fact');
       },
@@ -204,6 +380,25 @@ export class SessionFactApplier {
   }
 
   handleRunFact(streamId: StreamTabId, event: SessionRunFactEvent): void {
+    // A run fact for a removed stream is stale by definition — for
+    // `child.activity` the fact's stream is the parent, so this also keeps a
+    // late roster from re-minting a removed parent's state. A delayed
+    // `run.start` therefore cannot reopen a committed tombstone; the re-claim
+    // lives in `handleSessionFact`, on the workflow attachment that carries
+    // live-execution evidence for the new incarnation. A provisional barrier
+    // buffers the fact so a retained deletion can replay it.
+    if (this.state.isStreamRemoved(streamId)) {
+      this.deferRunFact(streamId, event);
+      return;
+    }
+    this.applyRunFact(streamId, event);
+  }
+
+  /** The single application body for an admitted run fact. */
+  private applyRunFact(
+    streamId: StreamTabId,
+    event: SessionRunFactEvent,
+  ): void {
     // The table is exhaustive over `RunFactType`, so a slot always exists;
     // TypeScript just cannot correlate a union event with its own slot.
     const handle = this.runFactHandlers[event.type] as (
@@ -215,6 +410,135 @@ export class SessionFactApplier {
       `failed to handle ${event.type} fact`,
       () => handle(streamId, event),
     );
+  }
+
+  /**
+   * Open (or reuse) the provisional buffer for `streamId` at `incarnation`.
+   * A second `removeStream` for the same incarnation reuses the existing
+   * buffer and does not re-own the deletion settlement.
+   */
+  private beginPendingDeletion(
+    streamId: StreamTabId,
+    incarnation: number,
+  ): { readonly pending: PendingDeletion; readonly created: boolean } {
+    const existing = this.pendingDeletions.get(streamId);
+    if (existing && existing.incarnation === incarnation) {
+      return { pending: existing, created: false };
+    }
+    const pending: PendingDeletion = { incarnation, facts: [] };
+    this.pendingDeletions.set(streamId, pending);
+    return { pending, created: true };
+  }
+
+  private finishPendingDeletion(
+    streamId: StreamTabId,
+    pending: PendingDeletion,
+  ): void {
+    if (this.pendingDeletions.get(streamId) === pending) {
+      this.pendingDeletions.delete(streamId);
+    }
+  }
+
+  /**
+   * Buffer a refused session fact into the most recent provisional barrier it
+   * names. Facts naming only committed tombstones (no pending barrier) are
+   * stale and dropped.
+   */
+  private deferSessionFact(fact: SessionFact): void {
+    for (const streamId of sessionFactStreamIds(fact)) {
+      const pending = this.pendingDeletions.get(streamId);
+      if (pending) {
+        pending.facts.push({ kind: 'session', fact });
+        return;
+      }
+    }
+  }
+
+  /** Buffer a refused run fact for a provisional barrier, or drop it. */
+  private deferRunFact(
+    streamId: StreamTabId,
+    event: SessionRunFactEvent,
+  ): void {
+    const pending = this.pendingDeletions.get(streamId);
+    if (pending) pending.facts.push({ kind: 'run', streamId, event });
+  }
+
+  /**
+   * Reapply buffered facts in arrival order after a retained deletion. Goes
+   * back through the public admission paths rather than the raw apply bodies,
+   * so a multi-stream session fact (e.g. `setParentStream`) is revalidated
+   * against every identity it names — if another identity is still removed,
+   * the replayed fact is refused (and re-buffered/dropped) instead of being
+   * applied through a stale barrier.
+   */
+  private replayDeferredFacts(facts: readonly DeferredFact[]): void {
+    for (const deferred of facts) {
+      if (deferred.kind === 'session') {
+        this.handleSessionFact(deferred.fact);
+      } else {
+        this.handleRunFact(deferred.streamId, deferred.event);
+      }
+    }
+  }
+
+  /**
+   * Begin a command-owned removal barrier and pending buffer, so facts racing
+   * a host command deletion are buffered exactly as they are for a
+   * `removeStream` fact. Returns `created === false` when a fact-path barrier
+   * already owns the identity; the caller must then skip the deletion and
+   * leave that barrier untouched.
+   */
+  beginCommandRemoval(streamId: StreamTabId): {
+    incarnation: number;
+    created: boolean;
+  } {
+    const { incarnation, created } = this.state.beginStreamRemoval(streamId);
+    this.registeredWithRenderer.delete(streamId);
+    if (created) this.beginPendingDeletion(streamId, incarnation);
+    return { incarnation, created };
+  }
+
+  /**
+   * Complete a command-owned removal once its host delete resolves. A retained
+   * (`active`/`failed`) outcome retires the barrier and replays buffered facts;
+   * a committed outcome discards the buffer; anything the command path reports
+   * as `undefined` (reserved id, no durable data, storage-root change) retires
+   * the barrier because nothing was deleted.
+   */
+  completeCommandRemoval(
+    streamId: StreamTabId,
+    incarnation: number,
+    outcome: DeleteStreamResult | undefined,
+    created: boolean,
+  ): void {
+    if (!created) return;
+    const pending = this.pendingDeletions.get(streamId);
+    if (pending && pending.incarnation === incarnation) {
+      this.finishPendingDeletion(streamId, pending);
+    }
+    const retired =
+      outcome !== 'deleted' &&
+      this.state.retireStreamTombstone(streamId, incarnation);
+    if (retired && (outcome === 'active' || outcome === 'failed') && pending) {
+      this.replayDeferredFacts(pending.facts);
+    }
+  }
+
+  /**
+   * Drop a command-owned buffer on an ambiguous failure: keep the barrier (the
+   * stream may have deleted) but discard the buffered facts, exactly as the
+   * fact path does on a rejected host delete.
+   */
+  abortCommandRemoval(
+    streamId: StreamTabId,
+    incarnation: number,
+    created: boolean,
+  ): void {
+    if (!created) return;
+    const pending = this.pendingDeletions.get(streamId);
+    if (pending && pending.incarnation === incarnation) {
+      this.finishPendingDeletion(streamId, pending);
+    }
   }
 
   private handleUpdateStreamDescription({
@@ -336,6 +660,13 @@ export class SessionFactApplier {
     parentStreamId: StreamTabId,
     next: StreamExecutionState['subagents'],
   ): void {
+    // Rows naming a removed child stay removed: a stale roster cannot put a
+    // tombstoned identity back. Both the incoming snapshot and the previously
+    // stored roster are filtered, so the retention step below cannot re-add a
+    // removed child as a finished row.
+    next = next.filter(
+      (child) => !this.state.isStreamRemoved(child.childStreamId),
+    );
     // Roster facts can arrive before RUNNING/config creates the parent state
     // (TUI child-event-order `roster-first`). Provision a ToolUse bucket so
     // retention still runs; a later run.config refreshes the real category.
@@ -344,7 +675,9 @@ export class SessionFactApplier {
     this.state.getOrCreateStreamState(parentStreamId, category);
 
     this.state.updateStreamState(parentStreamId, (prev) => {
-      const previous = prev.subagents;
+      const previous = prev.subagents.filter(
+        (child) => !this.state.isStreamRemoved(child.childStreamId),
+      );
       const liveBefore = previous.filter(
         (child) => child.finishedAt === undefined,
       );
@@ -406,9 +739,20 @@ export class SessionFactApplier {
     previousPhase?: StreamPhase,
     substate?: StreamSubstate,
   ): Promise<void> {
+    // A status for a removed stream is stale: removal is final, so the
+    // transition must not re-mint the transcript or execution state the
+    // removal dropped. Public entry (hosts also reach this method directly),
+    // so the refusal lives here and not only in `handleSessionFact`.
+    if (this.state.isStreamRemoved(streamId)) return;
     // Land the status-machine phase in the parent rosters before this handler
     // can suspend, so rows are written in fact order and a slow active-phase
     // rehydrate can never overwrite a later phase.
+    //
+    // This pre-await write is deliberately residual: a removal landing during
+    // the rehydrate await below cannot undo it. That is safe because the child
+    // untrack path emits `child.activity` before `removeStream`, so the parent
+    // roster drop supersedes any status this row carries, and
+    // `updateChildRoster` filters tombstoned children before retention.
     const rosterParents = this.state.recordChildPhase(streamId, status);
 
     // Active phases keep the full log resident for runtime writes. Terminal
@@ -423,6 +767,10 @@ export class SessionFactApplier {
         await this.state.streamLogs.ensureLoaded(streamId);
       }
     }
+    // The rehydrate await is an interleaving window: a removal that landed
+    // during it makes every mutation below — eviction, run-state minting,
+    // renderer notification — stale. Revalidate before any of them.
+    if (this.state.isStreamRemoved(streamId)) return;
 
     // Settlement watermark for status-time compaction finalization. Read after
     // any active-phase rehydrate and before inactive unfocused eviction —

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -105,8 +105,15 @@ function sessionFactStreamIds(fact: SessionFact): StreamTabId[] {
         : [fact.payload.childStreamId];
     case 'inquiryThreadUpdated':
       return fact.payload.parentStreamId ? [fact.payload.parentStreamId] : [];
-    default:
+    case 'goalStateChanged':
+    case 'clearMissingOutputs':
+    case 'updateQueuedFollowUps':
+    case 'followUpSent':
+    case 'setActiveStream':
+    case 'updateStreamDescription':
       return fact.payload.streamId ? [fact.payload.streamId] : [];
+    default:
+      return assertNever(fact, 'Unhandled session fact stream identity');
   }
 }
 

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -156,12 +156,9 @@ export class SessionState {
   private readonly _removedStreams = new Map<StreamTabId, number>();
   /**
    * Stable deletion guards, one per (stream, incarnation). `SessionStores`
-   * dedups its pending deletion by guard reference, so two removals of the
-   * same identity at the same incarnation must hand it the same function —
-   * otherwise a `removeStream` fact racing a direct delete would run the
-   * deletion twice. A re-claimed identity gets a new incarnation and a new
-   * guard, which is exactly what lets a superseded deletion and the fresh
-   * incarnation's deletion proceed independently.
+   * dedups pending work by incarnation, while every participant still uses
+   * its guard to stop that shared deletion when the identity is re-claimed.
+   * A fresh incarnation gets a new guard and a new deletion slot.
    */
   private readonly _deletionGuards = new Map<
     StreamTabId,
@@ -602,6 +599,7 @@ export class SessionState {
     // replay. This method only commits the durable delete and the tombstone.
     const deletion = await this.stores.deleteStream(stream, {
       shouldDelete: this.deletionGuard(stream, expectedIncarnation),
+      expectedIncarnation,
     });
     if (deletion !== 'deleted') return deletion;
     if (!this.isCurrentIncarnation(stream, expectedIncarnation)) {

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -636,9 +636,18 @@ export class SessionState {
       ...this._sessionState.keys(),
       ...Array.from(this.streamStatus.entries(), ([stream]) => stream),
     ]);
+    const identitiesAtStart = new Set<StreamTabId>([
+      ...preExistingEphemeral,
+      ...this._streamIncarnations.keys(),
+      ...this.streamLogs.keys(),
+    ]);
     const incarnationsAtStart = new Map(this._streamIncarnations);
     const deletion = await this.stores.deleteAll({
       shouldDelete: (stream) =>
+        // Sessionless staged residue is intentionally absent from the live
+        // transcript map and remains eligible for cleanup. A fresh run that
+        // appears after the snapshot has a live transcript and is fenced out.
+        (identitiesAtStart.has(stream) || !this.streamLogs.has(stream)) &&
         this.incarnationOf(stream) === (incarnationsAtStart.get(stream) ?? 0),
     });
     const retained = new Set([...deletion.active, ...deletion.failed]);

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -59,6 +59,7 @@ export interface SessionStreamMetadata {
  * carried through every patch that has nothing to say about it.
  */
 type StoredStreamMetadata = Omit<SessionStreamMetadata, 'creationTimestamp'>;
+const EMPTY_STORED_STREAM_METADATA: StoredStreamMetadata = Object.freeze({});
 
 /** Ephemeral session state per stream (not persisted). */
 interface StreamSessionState {
@@ -70,6 +71,14 @@ interface StreamSessionState {
    * saw it.
    */
   provisionalCreationTimestamp: number;
+}
+
+interface CachedStreamMetadata {
+  readonly stored: StoredStreamMetadata;
+  readonly summary: ReturnType<StreamLogStore['getSummaryMeta']>;
+  readonly firstTimestamp: number | undefined;
+  readonly removed: boolean;
+  readonly value: Readonly<SessionStreamMetadata>;
 }
 
 /**
@@ -112,6 +121,52 @@ export class SessionState {
   // -- Ephemeral state (session-only, not persisted) --------------------------
   private readonly _streamStates = new Map<StreamTabId, StreamExecutionState>();
   private readonly _sessionState = new Map<StreamTabId, StreamSessionState>();
+  private readonly _streamMetadataCache = new Map<
+    StreamTabId,
+    CachedStreamMetadata
+  >();
+  /**
+   * Per-stream incarnation generation, bumped only by a legitimate claim on
+   * the identity (`claimStreamIdentity`, from a workflow attachment with live
+   * execution evidence). A removal captures the generation it saw and only
+   * commits if the generation is unchanged, so a fresh deterministic run that
+   * starts while an old delete is queued invalidates that delete instead of
+   * being erased.
+   */
+  private readonly _streamIncarnations = new Map<StreamTabId, number>();
+  /**
+   * Identities removed this session, mapped to the incarnation they were
+   * removed at. The fact applier refuses any later fact naming a removed
+   * stream, so a stale status, roster, edge, or attachment fact cannot
+   * re-mint the transcript, execution, or metadata state deletion dropped.
+   * This map is the single owner of that rejection.
+   *
+   * Durable sidecar finality is owned by {@link SessionStores} + the snapshot
+   * store's staged-deletion/eviction write guards, not by this tombstone; its
+   * "removal is final" semantics are scoped to this in-memory projection.
+   *
+   * Lifecycle: deliberately uncapped, because every eviction policy invented
+   * so far reopens resurrection for an evicted id and would be a false
+   * finality claim. An entry retires when a fresh workflow attachment
+   * legitimately re-claims the identity (live-execution evidence → {@link
+   * SessionFactApplier}), or when the whole storage root is replaced
+   * (`resetAfterStorageRootChange`). Otherwise it lives for the session — the
+   * proven horizon for in-flight facts.
+   */
+  private readonly _removedStreams = new Map<StreamTabId, number>();
+  /**
+   * Stable deletion guards, one per (stream, incarnation). `SessionStores`
+   * dedups its pending deletion by guard reference, so two removals of the
+   * same identity at the same incarnation must hand it the same function —
+   * otherwise a `removeStream` fact racing a direct delete would run the
+   * deletion twice. A re-claimed identity gets a new incarnation and a new
+   * guard, which is exactly what lets a superseded deletion and the fresh
+   * incarnation's deletion proceed independently.
+   */
+  private readonly _deletionGuards = new Map<
+    StreamTabId,
+    { readonly incarnation: number; readonly guard: () => boolean }
+  >();
 
   readonly streamStatus: StreamStatusMachine;
   readonly followUps: ToolUseFollowUpQueue;
@@ -191,10 +246,9 @@ export class SessionState {
    * mirror that hasn't caught up can never clear a live field.
    */
   private applySummaryMetadata(
-    stream: StreamTabId,
     stored: StoredStreamMetadata,
+    meta: ReturnType<StreamLogStore['getSummaryMeta']>,
   ): StoredStreamMetadata {
-    const meta = this.streamLogs.getSummaryMeta(stream);
     const merged: StoredStreamMetadata = { ...stored };
     if (meta?.identity) merged.identity = meta.identity;
     merged.userFollowUpSupport = meta?.userFollowUpSupport;
@@ -212,6 +266,15 @@ export class SessionState {
     return merged;
   }
 
+  /** Replace one live metadata record and invalidate its derived view. */
+  private setStoredStreamMetadata(
+    stream: StreamTabId,
+    metadata: StoredStreamMetadata,
+  ): void {
+    this.getOrCreateSession(stream).metadata = metadata;
+    this._streamMetadataCache.delete(stream);
+  }
+
   /**
    * Apply metadata known before durable task state catches up. The durable
    * authority is overlaid at read time (`getStreamMetadata`), so late events
@@ -223,29 +286,60 @@ export class SessionState {
     patch: Partial<StoredStreamMetadata>,
   ): void {
     const state = this.getOrCreateSession(stream);
-    state.metadata = this.applyMetadataPatch(state.metadata, patch);
+    this.setStoredStreamMetadata(
+      stream,
+      this.applyMetadataPatch(state.metadata, patch),
+    );
   }
 
   /** Start a run fresh, dropping this session's live-only metadata. */
   resetStreamMetadataForRun(stream: StreamTabId): void {
-    this.getOrCreateSession(stream).metadata = {};
+    this.setStoredStreamMetadata(stream, {});
   }
 
   /**
-   * Read effective metadata, creating the ephemeral record when needed. The
-   * transcript's first entry dates the tab as soon as one exists; until then
-   * the record's provisional timestamp stands in.
+   * Read effective metadata. For a live stream this lazily creates the
+   * ephemeral record and latches its provisional creation timestamp to the
+   * transcript's first entry, so a later eviction cannot move an established
+   * tab back to when this session first saw it. A removed stream is read
+   * read-only from the durable summary mirror: the tombstone gate calls this
+   * to inspect a re-claimed identity, and minting the ephemeral record here
+   * would undo the deletion the barrier exists to protect.
    */
   getStreamMetadata(stream: StreamTabId): Readonly<SessionStreamMetadata> {
-    const session = this.getOrCreateSession(stream);
+    const removed = this.isStreamRemoved(stream);
+    const session = removed ? undefined : this.getOrCreateSession(stream);
+    const stored = session?.metadata ?? EMPTY_STORED_STREAM_METADATA;
+    const summary = this.streamLogs.getSummaryMeta(stream);
     const firstTimestamp = this.streamLogs.getTimestampRange(stream).first;
-    if (firstTimestamp !== undefined) {
+    if (session && firstTimestamp !== undefined) {
       session.provisionalCreationTimestamp = firstTimestamp;
     }
-    return {
-      ...this.applySummaryMetadata(stream, session.metadata),
-      creationTimestamp: session.provisionalCreationTimestamp,
+    const cached = this._streamMetadataCache.get(stream);
+    if (
+      cached?.stored === stored &&
+      cached.summary === summary &&
+      cached.firstTimestamp === firstTimestamp &&
+      cached.removed === removed
+    ) {
+      return cached.value;
+    }
+    const value: Readonly<SessionStreamMetadata> = {
+      ...this.applySummaryMetadata(stored, summary),
+      creationTimestamp:
+        firstTimestamp ??
+        session?.provisionalCreationTimestamp ??
+        cached?.value.creationTimestamp ??
+        Date.now(),
     };
+    this._streamMetadataCache.set(stream, {
+      stored,
+      summary,
+      firstTimestamp,
+      removed,
+      value,
+    });
+    return value;
   }
 
   setStreamParent(
@@ -253,14 +347,20 @@ export class SessionState {
     parent: StreamTabId | null | undefined,
   ): void {
     const state = this.getOrCreateSession(stream);
-    state.metadata = this.applyMetadataPatch(state.metadata, {
-      parentStreamId: parent ?? undefined,
-    });
+    this.setStoredStreamMetadata(
+      stream,
+      this.applyMetadataPatch(state.metadata, {
+        parentStreamId: parent ?? undefined,
+      }),
+    );
   }
 
   setStreamDescription(stream: StreamTabId, description: string): void {
     const state = this.getOrCreateSession(stream);
-    state.metadata = this.applyMetadataPatch(state.metadata, { description });
+    this.setStoredStreamMetadata(
+      stream,
+      this.applyMetadataPatch(state.metadata, { description }),
+    );
   }
 
   // todos/plan are owned + persisted by StreamSnapshotStore (workPlan.json).
@@ -370,13 +470,146 @@ export class SessionState {
 
   // -- Lifecycle --------------------------------------------------------------
 
-  async clearStream(stream: StreamTabId): Promise<DeleteStreamResult> {
-    const deletion = await this.stores.deleteStream(stream);
+  /**
+   * Begin a removal barrier for `stream`, capturing its current incarnation.
+   * Explicit ownership: `created` is true only when this call installed a new
+   * barrier. When a barrier already exists (a `removeStream` fact racing a
+   * direct delete, or a command racing a fact-path removal) the existing
+   * incarnation is returned with `created === false`, so a caller that finds
+   * one can avoid starting a second deletion or touching/retiring a barrier
+   * it does not own.
+   */
+  beginStreamRemoval(stream: StreamTabId): {
+    incarnation: number;
+    created: boolean;
+  } {
+    const existing = this._removedStreams.get(stream);
+    if (existing !== undefined) {
+      return { incarnation: existing, created: false };
+    }
+    const incarnation = this.incarnationOf(stream);
+    this._removedStreams.set(stream, incarnation);
+    this._streamMetadataCache.delete(stream);
+    return { incarnation, created: true };
+  }
+
+  /**
+   * A legitimate workflow attachment claims a deterministic stream identity:
+   * bump its incarnation and drop any removal barrier, so the new run's facts
+   * flow and any queued deletion captured against the previous incarnation is
+   * stale. Called only when the applier has live-execution evidence for the
+   * claim — never from a bare `run.start`, which a delayed stale event could
+   * replay after the deletion committed.
+   */
+  claimStreamIdentity(stream: StreamTabId): number {
+    const next = this.incarnationOf(stream) + 1;
+    this._streamIncarnations.set(stream, next);
+    this._removedStreams.delete(stream);
+    // A re-claimed identity starts a fresh run: drop any ephemeral session and
+    // execution state the previous incarnation left behind (a provisional
+    // removal may not have committed yet). The status machine is left alone —
+    // the fresh run has already tracked its own phase there.
+    this._sessionState.delete(stream);
+    this._streamStates.delete(stream);
+    this._streamMetadataCache.delete(stream);
+    return next;
+  }
+
+  /** Whether `stream` was removed this session and must not be resurrected. */
+  isStreamRemoved(stream: StreamTabId): boolean {
+    return this._removedStreams.has(stream);
+  }
+
+  /**
+   * Current live-execution evidence for a re-claim: the execution registry
+   * holds a handle for this exact stream. A fresh workflow relaunch tracks its
+   * handle before its attachment fact lands, while a replayed `run.start`
+   * does not, so this is the gate that lets a legitimate re-claim through and
+   * keeps a stale fact from reopening a committed tombstone.
+   */
+  hasLiveStreamExecution(stream: StreamTabId): boolean {
+    return this.session.executions.getAgentHandleByStream(stream) !== undefined;
+  }
+
+  /**
+   * Drop the tombstone only if it still belongs to `expectedIncarnation`.
+   * Used when a removal's durable delete ended in retention
+   * (`active`/`failed`/`superseded`): the stream still lives, so its facts
+   * must flow again. A fresh deletion B may already have installed its own
+   * barrier for a newer incarnation; this retirement must never remove that.
+   * Returns whether it actually removed the barrier: callers that buffer facts
+   * across a provisional deletion must replay them only when this returns
+   * true, so a superseded deletion A can never replay through deletion B's
+   * newer barrier.
+   */
+  retireStreamTombstone(
+    stream: StreamTabId,
+    expectedIncarnation: number,
+  ): boolean {
+    if (this._removedStreams.get(stream) === expectedIncarnation) {
+      this._removedStreams.delete(stream);
+      this._streamMetadataCache.delete(stream);
+      return true;
+    }
+    return false;
+  }
+
+  private incarnationOf(stream: StreamTabId): number {
+    return this._streamIncarnations.get(stream) ?? 0;
+  }
+
+  private isCurrentIncarnation(
+    stream: StreamTabId,
+    incarnation: number,
+  ): boolean {
+    return this.incarnationOf(stream) === incarnation;
+  }
+
+  /** Stable per-incarnation fence for {@link SessionStores.deleteStream}. */
+  private deletionGuard(
+    stream: StreamTabId,
+    expectedIncarnation: number,
+  ): () => boolean {
+    const cached = this._deletionGuards.get(stream);
+    if (cached && cached.incarnation === expectedIncarnation) {
+      return cached.guard;
+    }
+    const guard = (): boolean =>
+      this.isCurrentIncarnation(stream, expectedIncarnation);
+    this._deletionGuards.set(stream, {
+      incarnation: expectedIncarnation,
+      guard,
+    });
+    return guard;
+  }
+
+  async clearStream(
+    stream: StreamTabId,
+    options?: { readonly expectedIncarnation?: number },
+  ): Promise<DeleteStreamResult> {
+    const expectedIncarnation =
+      options?.expectedIncarnation ?? this.incarnationOf(stream);
+    if (!this.isCurrentIncarnation(stream, expectedIncarnation)) {
+      return 'superseded';
+    }
+
+    // The removal barrier is installed by the caller (the fact applier for a
+    // `removeStream` fact, or `ProgressBackend` for a host command) before
+    // this storage await, and that caller owns its retirement and buffered-fact
+    // replay. This method only commits the durable delete and the tombstone.
+    const deletion = await this.stores.deleteStream(stream, {
+      shouldDelete: this.deletionGuard(stream, expectedIncarnation),
+    });
     if (deletion !== 'deleted') return deletion;
+    if (!this.isCurrentIncarnation(stream, expectedIncarnation)) {
+      return 'superseded';
+    }
 
     this.streamStatus.clearStream(stream);
     this._sessionState.delete(stream);
     this._streamStates.delete(stream);
+    this._streamMetadataCache.delete(stream);
+    this._removedStreams.set(stream, expectedIncarnation);
 
     return 'deleted';
   }
@@ -387,21 +620,44 @@ export class SessionState {
       { data: { stack: new Error().stack } },
     );
 
-    const knownStreams = new Set<StreamTabId>([
-      ...this.streamLogs.keys(),
-      ...this._sessionState.keys(),
-      ...this._streamStates.keys(),
-      ...Array.from(this.streamStatus.entries(), ([stream]) => stream),
-    ]);
+    // Capture the ephemeral-only identity set before the bulk delete awaits:
+    // this operation may only clear/tombstone identities that existed when it
+    // began. A stream created during the bulk snapshot (a fresh run) is not in
+    // this set and must survive untouched. `deleteAll` still reports the exact
+    // durable identities it committed as `deleted`, and that result is the
+    // sole source for tombstoning durable streams — deriving them from a
+    // pre-delete enumeration would reintroduce the TOCTOU this barrier exists
+    // to close.
+    const preExistingEphemeral = this.ephemeralStreamIds();
     const deletion = await this.stores.deleteAll();
-    const retainedStreams = new Set([...deletion.active, ...deletion.failed]);
-    for (const stream of knownStreams) {
-      if (retainedStreams.has(stream)) continue;
+    const retained = new Set([...deletion.active, ...deletion.failed]);
+    const clearIdentity = (stream: StreamTabId): void => {
       this.streamStatus.clearStream(stream);
       this._sessionState.delete(stream);
       this._streamStates.delete(stream);
+      this._streamMetadataCache.delete(stream);
+      this._removedStreams.set(stream, this.incarnationOf(stream));
+    };
+    for (const stream of deletion.deleted) clearIdentity(stream);
+    // Ephemeral-only identities (for example a RUNNING transition that created
+    // execution/status state without ever minting a durable transcript) are
+    // invisible to `SessionStores.deleteAll`, so the exact durable `deleted`
+    // set cannot contain them. Clear and tombstone the pre-existing ones too,
+    // but never clear durable identities the bulk delete reported retained and
+    // never clear a stream that appeared after the snapshot.
+    for (const stream of preExistingEphemeral) {
+      if (retained.has(stream) || this._removedStreams.has(stream)) continue;
+      clearIdentity(stream);
     }
     return deletion;
+  }
+
+  private ephemeralStreamIds(): Set<StreamTabId> {
+    return new Set<StreamTabId>([
+      ...this._streamStates.keys(),
+      ...this._sessionState.keys(),
+      ...Array.from(this.streamStatus.entries(), ([stream]) => stream),
+    ]);
   }
 
   async load(stateOwnership: 'backend' | 'session' = 'backend'): Promise<void> {
@@ -432,10 +688,20 @@ export class SessionState {
     this.logger.info('[Persistence] State load complete');
   }
 
-  /** Drop workspace-scoped caches before loading a replacement storage root. */
+  /**
+   * Drop workspace-scoped caches before loading a replacement storage root.
+   * The incarnation generations and deletion-guard memoization are identity
+   * projections over the old root's stream ids, so they reset with the
+   * tombstones: a re-claimed identity in the new root must start from
+   * incarnation 0 again.
+   */
   resetAfterStorageRootChange(): void {
     this._sessionState.clear();
     this._streamStates.clear();
+    this._streamMetadataCache.clear();
+    this._removedStreams.clear();
+    this._streamIncarnations.clear();
+    this._deletionGuards.clear();
   }
 
   /**

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -631,7 +631,11 @@ export class SessionState {
     // sole source for tombstoning durable streams — deriving them from a
     // pre-delete enumeration would reintroduce the TOCTOU this barrier exists
     // to close.
-    const preExistingEphemeral = this.ephemeralStreamIds();
+    const preExistingEphemeral = new Set<StreamTabId>([
+      ...this._streamStates.keys(),
+      ...this._sessionState.keys(),
+      ...Array.from(this.streamStatus.entries(), ([stream]) => stream),
+    ]);
     const incarnationsAtStart = new Map(this._streamIncarnations);
     const deletion = await this.stores.deleteAll({
       shouldDelete: (stream) =>
@@ -657,14 +661,6 @@ export class SessionState {
       clearIdentity(stream);
     }
     return deletion;
-  }
-
-  private ephemeralStreamIds(): Set<StreamTabId> {
-    return new Set<StreamTabId>([
-      ...this._streamStates.keys(),
-      ...this._sessionState.keys(),
-      ...Array.from(this.streamStatus.entries(), ([stream]) => stream),
-    ]);
   }
 
   async load(stateOwnership: 'backend' | 'session' = 'backend'): Promise<void> {

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -326,6 +326,9 @@ export class SessionState {
     }
     const value: Readonly<SessionStreamMetadata> = {
       ...this.applySummaryMetadata(stored, summary),
+      // A removed, never-read stream has no durable timestamp to recover.
+      // Latch an ordering-only value without recreating its ephemeral record;
+      // removed streams are excluded from the rail and never listed again.
       creationTimestamp:
         firstTimestamp ??
         session?.provisionalCreationTimestamp ??
@@ -629,7 +632,11 @@ export class SessionState {
     // pre-delete enumeration would reintroduce the TOCTOU this barrier exists
     // to close.
     const preExistingEphemeral = this.ephemeralStreamIds();
-    const deletion = await this.stores.deleteAll();
+    const incarnationsAtStart = new Map(this._streamIncarnations);
+    const deletion = await this.stores.deleteAll({
+      shouldDelete: (stream) =>
+        this.incarnationOf(stream) === (incarnationsAtStart.get(stream) ?? 0),
+    });
     const retained = new Set([...deletion.active, ...deletion.failed]);
     const clearIdentity = (stream: StreamTabId): void => {
       this.streamStatus.clearStream(stream);

--- a/src/controllers/session/sessionStores.ts
+++ b/src/controllers/session/sessionStores.ts
@@ -21,7 +21,6 @@ export function createSessionStores(session: SessionHandle): SessionStores {
     snapshots: session.snapshots,
     goalEntries: {
       forget: (stream) => GoalStore.forget(stream, session),
-      forgetMany: (streams) => GoalStore.forgetMany(streams, session),
     },
     onCanonicalStreamDeleted: (stream) => {
       session.status.clearStream(stream);

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -518,10 +518,17 @@ describe('SessionStores deletion admission (#9590 A2)', () => {
   it('retains a bulk-deleted identity re-claimed during transcript cleanup', async () => {
     await withSession(async (session) => {
       const stream = 'tool@test#bulk-fence' as StreamTabId;
+      const sibling = 'tool@test#bulk-sibling' as StreamTabId;
+      const executionId = 'bulk-fence' as ExecutionId;
       session.transcripts.ensureStream(stream);
+      session.transcripts.ensureStream(sibling);
+      const snapshots = new StreamSnapshotStore();
+      ownExecution(snapshots, stream, executionId);
+      ownExecution(snapshots, sibling, executionId);
       const stores = new SessionStores({
         streamLogs: session.transcripts,
-        snapshots: new StreamSnapshotStore(),
+        snapshots,
+        deleteExecution: deletionSpy(),
       });
 
       let reClaimed = false;
@@ -542,6 +549,9 @@ describe('SessionStores deletion admission (#9590 A2)', () => {
       expect(result.failed).not.toContain(stream);
       expect(result.deleted).not.toContain(stream);
       expect(session.transcripts.has(stream)).toBe(true);
+      expect(result.deleted).toContain(sibling);
+      expect(result.failed).not.toContain(sibling);
+      expect(session.transcripts.has(sibling)).toBe(false);
     });
   });
 });

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -291,10 +291,10 @@ describe('SessionStores deletion coordination', () => {
       const bulk = stores.deleteAll();
       unblockDeletion();
 
-      await expect(Promise.all([single, bulk])).resolves.toEqual([
-        'deleted',
-        { active: new Set(), failed: new Set() },
-      ]);
+      const [singleResult, bulkResult] = await Promise.all([single, bulk]);
+      expect(singleResult).toBe('deleted');
+      expect(bulkResult.active).toEqual(new Set());
+      expect(bulkResult.failed).toEqual(new Set());
       expect(releases).toEqual([stream]);
     });
   });
@@ -479,6 +479,39 @@ describe('SessionStores deletion admission (#9590 A2)', () => {
       await expect(
         getExecutionStore(executionId).readMeta(),
       ).resolves.not.toBeNull();
+    });
+  });
+
+  it('refuses a deletion whose generation guard flips during the transcript delete', async () => {
+    await withSession(async (session) => {
+      const stream = 'tool@test#fence' as StreamTabId;
+      session.transcripts.ensureStream(stream);
+      const snapshots = new StreamSnapshotStore();
+      const stores = new SessionStores({
+        streamLogs: session.transcripts,
+        snapshots,
+      });
+
+      // The generation fence must stay atomic with the transcript commit. Flip
+      // the guard once `delete` is entered — a deterministic workflow re-claim
+      // landing while the transcript delete drains pending writes — and assert
+      // the delete reports `superseded` with the transcript still resident.
+      let reClaimed = false;
+      const shouldDelete = (): boolean => !reClaimed;
+      const originalDelete = session.transcripts.delete.bind(
+        session.transcripts,
+      );
+      vi.spyOn(session.transcripts, 'delete').mockImplementation(
+        async (streamId, options) => {
+          reClaimed = true;
+          return originalDelete(streamId, options);
+        },
+      );
+
+      await expect(stores.deleteStream(stream, { shouldDelete })).resolves.toBe(
+        'superseded',
+      );
+      expect(session.transcripts.has(stream)).toBe(true);
     });
   });
 });

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -514,6 +514,36 @@ describe('SessionStores deletion admission (#9590 A2)', () => {
       expect(session.transcripts.has(stream)).toBe(true);
     });
   });
+
+  it('retains a bulk-deleted identity re-claimed during transcript cleanup', async () => {
+    await withSession(async (session) => {
+      const stream = 'tool@test#bulk-fence' as StreamTabId;
+      session.transcripts.ensureStream(stream);
+      const stores = new SessionStores({
+        streamLogs: session.transcripts,
+        snapshots: new StreamSnapshotStore(),
+      });
+
+      let reClaimed = false;
+      const originalDelete = session.transcripts.delete.bind(
+        session.transcripts,
+      );
+      vi.spyOn(session.transcripts, 'delete').mockImplementation(
+        async (streamId, options) => {
+          if (streamId === stream) reClaimed = true;
+          return originalDelete(streamId, options);
+        },
+      );
+
+      const result = await stores.deleteAll({
+        shouldDelete: (streamId) => streamId !== stream || !reClaimed,
+      });
+      expect(result.active).toContain(stream);
+      expect(result.failed).not.toContain(stream);
+      expect(result.deleted).not.toContain(stream);
+      expect(session.transcripts.has(stream)).toBe(true);
+    });
+  });
 });
 
 describe('SessionStores startup sweep', () => {

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -251,6 +251,46 @@ describe('SessionStores deletion coordination', () => {
     });
   });
 
+  it('joins process and presentation deletion at the same incarnation', async () => {
+    await withSession(async (session) => {
+      const stream = 'shared-incarnation-delete' as StreamTabId;
+      session.transcripts.ensureStream(stream);
+      const stores = new SessionStores({
+        streamLogs: session.transcripts,
+        snapshots: new StreamSnapshotStore(),
+      });
+      let releaseLease!: () => void;
+      const leaseReleased = new Promise<void>((resolve) => {
+        releaseLease = resolve;
+      });
+      vi.spyOn(stores, 'waitForOwnedExecutionRelease').mockReturnValue(
+        leaseReleased,
+      );
+      const deleteTranscript = vi.spyOn(session.transcripts, 'delete');
+
+      try {
+        const processDeletion = stores.deleteStreamAfterOwnedExecutionRelease(
+          stream,
+          {
+            shouldDelete: () => true,
+            expectedIncarnation: 4,
+          },
+        );
+        const presentationDeletion = stores.deleteStream(stream, {
+          shouldDelete: () => true,
+          expectedIncarnation: 4,
+        });
+
+        expect(presentationDeletion).toBe(processDeletion);
+        releaseLease();
+        await expect(processDeletion).resolves.toBe('deleted');
+        expect(deleteTranscript).toHaveBeenCalledOnce();
+      } finally {
+        releaseLease();
+      }
+    });
+  });
+
   it('releases one canonical stream once when single and bulk deletion overlap', async () => {
     await withSession(async (session) => {
       const stream = 'tool@test#abc001' as StreamTabId;

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -487,7 +487,6 @@ async function createBridge(
     snapshots: progressSnapshotStore,
     goalEntries: {
       forget: (stream) => bridgeGoalStore.forget(stream, session),
-      forgetMany: (streams) => bridgeGoalStore.forgetMany(streams, session),
     },
     onCanonicalStreamDeleted: (stream) => {
       session.status.clearStream(stream);

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -3552,6 +3552,13 @@ describe('DesktopProgressBridge', () => {
         await vi.waitFor(() =>
           expect(waitForRelease).toHaveBeenCalledWith(childStreamId),
         );
+        owner.processSession.events.emit({
+          scope: 'session',
+          event: {
+            type: 'setActiveStream',
+            payload: { streamId: childStreamId },
+          },
+        });
         const pendingDrain = vi.spyOn(
           owner.sessionStores,
           'waitForPendingStreamDeletions',

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -2060,7 +2060,7 @@ describe('DesktopProgressBridge', () => {
     expect(lastContentSync(messages)).toMatchObject({ stream: 'third' });
   });
 
-  it('falls back if a deleted stream is reactivated during deletion', async () => {
+  it('refuses desktop reactivation while a stream deletion is pending', async () => {
     const messages: unknown[] = [];
     const bridge = await createBridge(messages);
 
@@ -2068,6 +2068,7 @@ describe('DesktopProgressBridge', () => {
     activateStream(bridge, 'second');
     await settleProgressEvents();
     bridge.setActiveStream('first');
+    await settleProgressEvents();
     messages.length = 0;
 
     const deletePromise = deleteStreamViaInbound(bridge, 'second');
@@ -2076,17 +2077,8 @@ describe('DesktopProgressBridge', () => {
 
     expect(
       progressMessages(messages, PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM),
-    ).toEqual([
-      {
-        activeStream: 'second',
-        command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
-      },
-      {
-        activeStream: 'first',
-        command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
-      },
-    ]);
-    expect(lastContentSync(messages)).toMatchObject({ stream: 'first' });
+    ).toEqual([]);
+    expect(lastStreamSync(messages)).toMatchObject({ activeStream: 'first' });
   });
 
   it('emits delete-all cleanup before syncing an empty stream list', async () => {

--- a/src/test-kernel/progressView/ProgressBackendCleanup.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendCleanup.vitest.ts
@@ -328,6 +328,49 @@ describe('ProgressBackend cleanup', () => {
     }
   });
 
+  it('preserves a stream created after bulk cleanup starts', async () => {
+    const { backend } = createIsolatedRecordingBackend();
+    const existing = toolStreamAndExecution('bulk-existing');
+    const fresh = toolStreamAndExecution('bulk-fresh');
+    await seedOwnedStream(backend, existing, { load: true });
+
+    let releaseList!: () => void;
+    const listReleased = new Promise<void>((resolve) => {
+      releaseList = resolve;
+    });
+    let markListStarted!: () => void;
+    const listStarted = new Promise<void>((resolve) => {
+      markListStarted = resolve;
+    });
+    const listPersistedStreams =
+      backend.state.snapshots.listPersistedStreams.bind(
+        backend.state.snapshots,
+      );
+    vi.spyOn(
+      backend.state.snapshots,
+      'listPersistedStreams',
+    ).mockImplementationOnce(async () => {
+      markListStarted();
+      await listReleased;
+      return listPersistedStreams();
+    });
+
+    const cleanup = backend.state.clearAll();
+    await listStarted;
+    registerStream(backend, fresh);
+    releaseList();
+
+    await expect(cleanup).resolves.toEqual({
+      active: new Set([fresh.stream]),
+      failed: new Set(),
+      deleted: new Set([existing.stream]),
+    });
+    expect(backend.state.streamLogs.has(existing.stream)).toBe(false);
+    expect(backend.state.streamLogs.has(fresh.stream)).toBe(true);
+
+    await backend.state.clearAll();
+  });
+
   it('reconciles required cleanup and final execution cleanup independently', async () => {
     const failed = toolStreamAndExecution('fa11ed6966');
     const incomplete = toolStreamAndExecution('faded6966');

--- a/src/test-kernel/progressView/ProgressBackendCleanup.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendCleanup.vitest.ts
@@ -286,7 +286,11 @@ describe('ProgressBackend cleanup', () => {
 
       // A log-only stream carries no sidecar FK, so it owns no execution:
       // its stream state clears and the leased execution stays untouched.
-      expect(retained).toEqual({ active: new Set(), failed: new Set() });
+      expect(retained).toEqual({
+        active: new Set(),
+        failed: new Set(),
+        deleted: new Set([stream]),
+      });
       expect(backend.state.streamLogs.has(stream)).toBe(false);
       await expectStored(`executions/${executionId}`, true);
     } finally {
@@ -313,6 +317,7 @@ describe('ProgressBackend cleanup', () => {
       expect(retained).toEqual({
         active: new Set(),
         failed: new Set(),
+        deleted: new Set([stream]),
       });
       expect(backend.state.streamLogs.has(stream)).toBe(false);
       await expectStored(`executions/${executionId}`, false);
@@ -350,6 +355,7 @@ describe('ProgressBackend cleanup', () => {
       expect(result).toEqual({
         active: new Set(),
         failed: new Set([failed.stream]),
+        deleted: new Set([incomplete.stream, deleted.stream]),
       });
       expect(backend.state.streamLogs.has(failed.stream)).toBe(true);
       expect(backend.state.streamLogs.has(incomplete.stream)).toBe(false);
@@ -373,6 +379,7 @@ describe('ProgressBackend cleanup', () => {
       await expect(backend.state.clearAll()).resolves.toEqual({
         active: new Set(),
         failed: new Set(),
+        deleted: new Set([stream]),
       });
 
       expect(backend.state.streamLogs.has(stream)).toBe(false);
@@ -410,6 +417,7 @@ describe('ProgressBackend cleanup', () => {
       expect(result).toEqual({
         active: new Set(),
         failed: new Set([failedStream]),
+        deleted: new Set([deletedStream]),
       });
       expect(backend.state.streamLogs.has(failedStream)).toBe(true);
       expect(backend.state.streamLogs.has(deletedStream)).toBe(false);

--- a/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
@@ -1231,6 +1231,45 @@ describe('ProgressBackend', () => {
     expect(workflowScript?.model).toBeUndefined();
   });
 
+  it('keeps metadata reads stable until an owning input changes', () => {
+    const { backend } = createRecordingBackend();
+    const stream = 'stable-metadata-stream' as StreamTabId;
+    const executionId = 'e5ab1e' as ExecutionId;
+
+    backend.state.streamLogs.ensureStream(stream);
+    const initial = backend.state.getStreamMetadata(stream);
+    expect(backend.state.getStreamMetadata(stream)).toBe(initial);
+
+    backend.state.updateStreamMetadata(stream, { isRemote: true });
+    const patched = backend.state.getStreamMetadata(stream);
+    expect(patched).not.toBe(initial);
+    expect(patched.isRemote).toBe(true);
+    expect(backend.state.getStreamMetadata(stream)).toBe(patched);
+
+    snapshotFacts(backend.state.snapshots).setRunConfig(
+      stream,
+      toolUseConfig('search', 'deepseekproT'),
+      executionId,
+    );
+    const summarized = backend.state.getStreamMetadata(stream);
+    expect(summarized).not.toBe(patched);
+    expect(summarized.config?.model).toBe('deepseekproT');
+    expect(backend.state.getStreamMetadata(stream)).toBe(summarized);
+
+    appendTranscriptEntry(backend.state.streamLogs, stream, {
+      id: 'first-entry',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 100,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      text: 'first transcript entry',
+    });
+    const dated = backend.state.getStreamMetadata(stream);
+    expect(dated).not.toBe(summarized);
+    expect(dated.creationTimestamp).toBe(100);
+    expect(backend.state.getStreamMetadata(stream)).toBe(dated);
+  });
+
   it('promotes the transcript first timestamp into canonical metadata', () => {
     const { backend } = createRecordingBackend();
     const stream = 'timestamp-stream' as StreamTabId;

--- a/src/test-kernel/progressView/ProgressBackendPresentation.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendPresentation.vitest.ts
@@ -48,7 +48,7 @@ function mockSuccessfulClear(
   } else {
     vi.spyOn(backend.state, 'clearAll').mockImplementation(async () => {
       await body();
-      return { active: new Set(), failed: new Set() };
+      return { active: new Set(), failed: new Set(), deleted: new Set() };
     });
   }
 }
@@ -168,6 +168,7 @@ async function expectRetentionNoticeDoesNotBlockStorageRootReplacement(
     vi.spyOn(backend.state, 'clearAll').mockResolvedValue({
       active: new Set([stream]),
       failed: new Set(),
+      deleted: new Set(),
     });
   }
 

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -65,6 +65,7 @@ function stubClearAll(
   vi.spyOn(backend.state, 'clearAll').mockResolvedValue({
     active,
     failed: new Set(),
+    deleted: new Set(),
   });
 }
 
@@ -227,7 +228,11 @@ describe('ProgressBackend', () => {
 
     emitRemoveStream(target, streamId);
 
-    await vi.waitFor(() => expect(clearStream).toHaveBeenCalledWith(streamId));
+    await vi.waitFor(() =>
+      expect(clearStream).toHaveBeenCalledWith(streamId, {
+        expectedIncarnation: 0,
+      }),
+    );
   });
 
   it('refuses reserved stream identifiers before durable cleanup', async () => {
@@ -278,7 +283,9 @@ describe('ProgressBackend', () => {
       releaseLease();
       await deletion;
 
-      expect(clearStream).toHaveBeenCalledWith(stream);
+      expect(clearStream).toHaveBeenCalledWith(stream, {
+        expectedIncarnation: 0,
+      });
       expect(backend.state.streamLogs.has(stream)).toBe(false);
     } finally {
       releaseLease();
@@ -696,7 +703,7 @@ describe('ProgressBackend', () => {
   });
 
   it('recovers when an inactive stream becomes selected during deletion', async () => {
-    const { backend, messages } = createIsolatedRecordingBackend();
+    const { backend } = createIsolatedRecordingBackend();
     const fallback = 'surviving-fallback' as StreamTabId;
     const deleting = 'selected-while-deleting' as StreamTabId;
     const releaseClear = gateClearStream(backend);
@@ -707,17 +714,18 @@ describe('ProgressBackend', () => {
 
     const deletion = backend.deleteStream(deleting);
     await vi.waitFor(() =>
-      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting),
+      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting, {
+        expectedIncarnation: 0,
+      }),
     );
     await backend.activateStream(deleting);
     releaseClear();
     await deletion;
 
     expect(backend.presentation.activeStream).toBe(fallback);
-    expect(messages).toContainEqual({
-      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
-      activeStream: fallback,
-    });
+    // The command barrier refuses selecting the stream being deleted, so the
+    // fallback stays active without a recovery re-assertion.
+    expect(backend.state.streamLogs.has(deleting)).toBe(false);
   });
 
   it('preserves explicit deselection during active-stream deletion', async () => {
@@ -732,7 +740,9 @@ describe('ProgressBackend', () => {
 
     const deletion = backend.deleteStream(deleting);
     await vi.waitFor(() =>
-      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting),
+      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting, {
+        expectedIncarnation: 0,
+      }),
     );
     backend.presentation.select('');
     releaseClear();
@@ -766,7 +776,9 @@ describe('ProgressBackend', () => {
 
     const deletion = backend.deleteStream(deleting);
     await vi.waitFor(() =>
-      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting),
+      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting, {
+        expectedIncarnation: 0,
+      }),
     );
     const activation = backend.activateStream(requested, 'pending-request');
     await vi.waitFor(() =>
@@ -811,7 +823,9 @@ describe('ProgressBackend', () => {
 
     const deletion = backend.deleteStream(deleting);
     await vi.waitFor(() =>
-      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting),
+      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting, {
+        expectedIncarnation: 0,
+      }),
     );
     const activation = backend.activateStream(requested, 'failed-request');
     await vi.waitFor(() =>
@@ -854,7 +868,9 @@ describe('ProgressBackend', () => {
 
     const deletion = backend.deleteStream(deleting);
     await vi.waitFor(() =>
-      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting),
+      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting, {
+        expectedIncarnation: 0,
+      }),
     );
     await backend.activateStream(committed);
     vi.spyOn(backend.state.snapshots, 'preload').mockImplementationOnce(
@@ -940,7 +956,11 @@ describe('ProgressBackend', () => {
     backend.presentation.select(deleting);
     vi.spyOn(backend.state, 'clearAll').mockImplementation(async () => {
       await clearGate;
-      return { active: new Set([requested]), failed: new Set() };
+      return {
+        active: new Set([requested]),
+        failed: new Set(),
+        deleted: new Set(),
+      };
     });
 
     const deletion = backend.deleteAllStreams();

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -275,6 +275,7 @@ describe('ProgressBackend', () => {
       expect(session.executions.getAgentHandleByStream(stream)).toBeUndefined();
 
       const deletion = backend.deleteStream(stream);
+      expect(backend.state.stores.hasStreamDeletionClaim(stream, 0)).toBe(true);
       await vi.waitFor(() =>
         expect(waitForRelease).toHaveBeenCalledWith(stream),
       );
@@ -286,6 +287,9 @@ describe('ProgressBackend', () => {
       expect(clearStream).toHaveBeenCalledWith(stream, {
         expectedIncarnation: 0,
       });
+      expect(backend.state.stores.hasStreamDeletionClaim(stream, 0)).toBe(
+        false,
+      );
       expect(backend.state.streamLogs.has(stream)).toBe(false);
     } finally {
       releaseLease();

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -828,6 +828,33 @@ describe('StreamLogStore load', () => {
     expect(store.has('alpha')).toBe(true);
   });
 
+  it('re-persists a released log re-claimed during durable deletion', async () => {
+    let reClaimed = false;
+    const storage = mockStorage({
+      logs: { alpha: [logEntry('alpha', 1, 200)] },
+      summaries: {
+        alpha: { firstTimestamp: 200, lastTimestamp: 200 },
+      },
+      onLogDelete: () => {
+        reClaimed = true;
+      },
+    });
+    const store = await StreamLogStore.open();
+    expect(store.get('alpha')).toBeUndefined();
+
+    await expect(
+      store.delete('alpha', { shouldDelete: () => !reClaimed }),
+    ).rejects.toMatchObject({ name: 'StreamDeletionSupersededError' });
+
+    await waitForCondition(
+      () => writtenLog(storage.writes, 'alpha') !== undefined,
+    );
+    expect(writtenLog(storage.writes, 'alpha')).toEqual([
+      logEntry('alpha', 1, 200),
+    ]);
+    expect(store.has('alpha')).toBe(true);
+  });
+
   it('clears authoritative logs when summary cache clearing fails', async () => {
     const storage = mockStorage({
       logs: { alpha: [logEntry('alpha', 1, 200)] },

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -44,6 +44,7 @@ interface MockStorageOptions {
   logMtimes?: Record<string, number>;
   summaryMtimes?: Record<string, number>;
   onLogRead?: (key: string) => Promise<void> | void;
+  onLogDelete?: (key: string) => Promise<void> | void;
   onLogWrite?: (key: string) => Promise<void> | void;
   onSummaryWrite?: (key: string) => Promise<void> | void;
   pauseLogWriteKey?: string;
@@ -215,6 +216,7 @@ function mockStorage({
   logMtimes = {},
   summaryMtimes = {},
   onLogRead,
+  onLogDelete,
   onLogWrite,
   onSummaryWrite,
   pauseLogWriteKey,
@@ -321,6 +323,9 @@ function mockStorage({
   vi.spyOn(StorageFS, 'writeAtomic').mockImplementation(recordWrite);
   vi.spyOn(StorageFS, 'delete').mockImplementation(async (target) => {
     if (logDeleteError && areaOf(target) === 'log') throw logDeleteError;
+    if (areaOf(target) === 'log') {
+      await onLogDelete?.(streamKeyFromFile(target));
+    }
     if (
       summaryDeleteError &&
       (target === STREAM_LOG_SUMMARIES_DIR || areaOf(target) === 'summary')
@@ -793,6 +798,33 @@ describe('StreamLogStore load', () => {
     await expect(store.delete('alpha')).rejects.toThrow('log delete denied');
 
     expect(store.keys()).toEqual(['alpha']);
+    expect(store.has('alpha')).toBe(true);
+  });
+
+  it('re-persists a resident log re-claimed during durable deletion', async () => {
+    let reClaimed = false;
+    const storage = mockStorage({
+      logs: { alpha: [logEntry('alpha', 1, 200)] },
+      summaries: {
+        alpha: { firstTimestamp: 200, lastTimestamp: 200 },
+      },
+      onLogDelete: () => {
+        reClaimed = true;
+      },
+    });
+    const store = await StreamLogStore.open();
+    await store.ensureLoaded('alpha');
+
+    await expect(
+      store.delete('alpha', { shouldDelete: () => !reClaimed }),
+    ).rejects.toMatchObject({ name: 'StreamDeletionSupersededError' });
+
+    await waitForCondition(
+      () => writtenLog(storage.writes, 'alpha') !== undefined,
+    );
+    expect(writtenLog(storage.writes, 'alpha')).toEqual([
+      logEntry('alpha', 1, 200),
+    ]);
     expect(store.has('alpha')).toBe(true);
   });
 

--- a/src/transcript/StagedDeletionCoordinator.ts
+++ b/src/transcript/StagedDeletionCoordinator.ts
@@ -63,7 +63,14 @@ async function storagePathExists(target: string): Promise<boolean> {
 }
 
 export interface StagedStreamSnapshotDeletion {
-  commit(): Promise<void>;
+  /**
+   * Commit the staged deletion. `shouldDelete`, when provided, is re-checked
+   * after the staged copy is removed: a re-claim landing during that awaited
+   * delete keeps its fresh sidecar writes buffered, and this replays them
+   * instead of discarding them with the deletion state. Returns whether the
+   * commit was superseded (buffered writes were replayed rather than dropped).
+   */
+  commit(shouldDelete?: () => boolean): Promise<boolean>;
   rollback(): Promise<void>;
 }
 
@@ -524,10 +531,11 @@ export class StagedDeletionCoordinator {
 
       let settled = false;
       return {
-        commit: async () => {
-          if (settled) return;
+        commit: async (shouldDelete?: () => boolean): Promise<boolean> => {
+          if (settled) return false;
           settled = true;
           this.host.evict(stream);
+          let superseded = false;
           try {
             if (state.phase === 'staged' && stagedDir) {
               try {
@@ -539,9 +547,27 @@ export class StagedDeletionCoordinator {
                 );
               }
             }
+            // A re-claim landing while the staged copy was being deleted kept
+            // its fresh sidecar writes buffered here (the stream stayed in
+            // `deletionStates`). Replay them so the new incarnation's sidecars
+            // survive the commit instead of being discarded with the deletion
+            // state. A replay write failure must not demote the supersede: the
+            // deletion still did not commit, so report superseded regardless.
+            if (shouldDelete && !shouldDelete()) {
+              superseded = true;
+              try {
+                await this.drainStagedWrites(stream, state);
+              } catch (error) {
+                log.warn(
+                  `Stream ${stream} was superseded, but buffered sidecar replay was incomplete.`,
+                  { data: error },
+                );
+              }
+            }
           } finally {
             this.settleStagedDeletion(stream, state);
           }
+          return superseded;
         },
         rollback: async () => {
           if (settled) return;

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -1021,6 +1021,7 @@ export class StreamLogStore {
     this.assertWritableStore('delete a transcript stream');
     this.writeTombstones.add(streamId);
     this.saveThrottle.cancel();
+    let retrySave = false;
 
     try {
       await this.executeWrite();
@@ -1049,11 +1050,14 @@ export class StreamLogStore {
     } catch (error) {
       // executeWrite() drains dirty ids while the tombstone suppresses writes.
       // Restore the retry marker if deletion fails and a resident log remains.
-      if (this.streams.get(streamId)?.log !== undefined)
+      if (this.streams.get(streamId)?.log !== undefined) {
         this.markDirty(streamId);
+        retrySave = true;
+      }
       throw error;
     } finally {
       this.writeTombstones.delete(streamId);
+      if (retrySave) this.scheduleSave();
     }
   }
 

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -46,6 +46,32 @@ const STREAM_LOG_LOAD_CONCURRENCY = 8;
 const LOG_TAG = 'StreamLogStore';
 const log = createLog(LOG_TAG);
 
+/**
+ * A deletion guard decided the stream was re-claimed while the delete was
+ * committed. Thrown inside {@link StreamLogStore.delete} so the caller can
+ * roll adjacent snapshot staging back instead of discarding a fresh
+ * incarnation's buffered writes.
+ */
+export class StreamDeletionSupersededError extends Error {
+  constructor(readonly subject?: string) {
+    super(
+      subject === undefined
+        ? 'Stream deletion superseded'
+        : `Stream deletion superseded for ${subject}`,
+    );
+    this.name = 'StreamDeletionSupersededError';
+  }
+}
+
+export interface StreamLogDeleteOptions {
+  /**
+   * Re-checked inside the serialized deletion: once after pending writes drain
+   * and again after the durable transcript delete but before in-memory state is
+   * forgotten. Returning `false` aborts the delete.
+   */
+  readonly shouldDelete?: () => boolean;
+}
+
 type StreamLogListener = (streamId: StreamTabId, delta: StreamLogDelta) => void;
 
 /**
@@ -988,17 +1014,32 @@ export class StreamLogStore {
     };
   }
 
-  async delete(streamId: StreamTabId): Promise<void> {
+  async delete(
+    streamId: StreamTabId,
+    options?: StreamLogDeleteOptions,
+  ): Promise<void> {
     this.assertWritableStore('delete a transcript stream');
     this.writeTombstones.add(streamId);
     this.saveThrottle.cancel();
 
     try {
       await this.executeWrite();
+      // A re-claim may have landed while pending writes drained. Refuse before
+      // the irreversible durable delete so its transcript is never erased.
+      if (options?.shouldDelete && !options.shouldDelete()) {
+        throw new StreamDeletionSupersededError(streamId);
+      }
       if (this.mode.kind !== 'ephemeral') {
         log.info(`Deleting stream: ${streamId}`);
         await this.kv().delete(streamId);
         await this.deleteSummaryCache(streamId);
+      }
+      // The durable delete is irreversible. Re-check again before forgetting
+      // in-memory state: a re-claim that landed while the KV delete was in
+      // flight kept its resident transcript alive, and `forgetStreamState`
+      // must not drop it.
+      if (options?.shouldDelete && !options.shouldDelete()) {
+        throw new StreamDeletionSupersededError(streamId);
       }
       // The summaries map is the progress tab registry. Commit its removal
       // only after durable deletion succeeds so callers can retain and retry a

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -1022,6 +1022,7 @@ export class StreamLogStore {
     this.writeTombstones.add(streamId);
     this.saveThrottle.cancel();
     let retrySave = false;
+    let releasedEntries: ParsedPersistedEntries | undefined;
 
     try {
       await this.executeWrite();
@@ -1031,6 +1032,23 @@ export class StreamLogStore {
         throw new StreamDeletionSupersededError(streamId);
       }
       if (this.mode.kind !== 'ephemeral') {
+        // A released stream has no resident log for the failure path to
+        // re-persist. Preserve its authoritative entries across the delete's
+        // commit window so a concurrent identity re-claim cannot turn the
+        // durable delete into permanent transcript loss.
+        if (
+          options?.shouldDelete &&
+          this.streams.get(streamId)?.log === undefined &&
+          this.summaries.has(streamId)
+        ) {
+          const raw = await this.kv().read<unknown[]>(streamId);
+          if (raw !== undefined) {
+            releasedEntries = this.parsePersistedEntries(streamId, raw);
+          }
+          if (!options.shouldDelete()) {
+            throw new StreamDeletionSupersededError(streamId);
+          }
+        }
         log.info(`Deleting stream: ${streamId}`);
         await this.kv().delete(streamId);
         await this.deleteSummaryCache(streamId);
@@ -1040,6 +1058,14 @@ export class StreamLogStore {
       // flight kept its resident transcript alive, and `forgetStreamState`
       // must not drop it.
       if (options?.shouldDelete && !options.shouldDelete()) {
+        if (this.streams.get(streamId)?.log === undefined && releasedEntries) {
+          const restored = new StreamLog(
+            releasedEntries.entries,
+            releasedEntries.preservedRawEntries,
+          );
+          this.ensureStreamState(streamId).log = restored;
+          this.refreshSummary(streamId, restored);
+        }
         throw new StreamDeletionSupersededError(streamId);
       }
       // The summaries map is the progress tab registry. Commit its removal

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1170,8 +1170,16 @@ export class StreamSnapshotStore {
   ): Promise<StagedStreamSnapshotDeletion> {
     const deletion = await this.deletions.stage(stream);
     return {
-      commit: async () => {
-        await deletion.commit();
+      commit: async (shouldDelete?: () => boolean): Promise<boolean> => {
+        // A late supersede means the fresh incarnation re-claimed the stream
+        // while the staged copy was being deleted; its buffered sidecars were
+        // replayed back into the live namespace, so the stream still lives and
+        // the child-detachment/projection/flush below must not run.
+        if (await deletion.commit(shouldDelete)) return true;
+        // Re-check before the awaited detachment/flush below: a re-claim
+        // landing right after the staged copy was removed must not detach the
+        // fresh incarnation's children or flush against its live namespace.
+        if (shouldDelete && !shouldDelete()) return true;
         let children: StreamTabId[] = [];
         try {
           children = await this.detachPersistedChildren(stream);
@@ -1197,6 +1205,7 @@ export class StreamSnapshotStore {
             { data: error },
           );
         }
+        return false;
       },
       rollback: () => deletion.rollback(),
     };


### PR DESCRIPTION
## Summary

- make `SessionState` the single owner of removed-stream tombstones and incarnation fences
- serialize transcript, snapshot, execution, goal, and presentation cleanup behind one guarded deletion result
- claim live presentation deletion synchronously so the desktop headless fallback cannot race or outlive a retained deletion
- restore both resident and released transcripts when a re-claim supersedes an in-flight durable delete
- buffer facts only while deletion is provisional, replaying them when the stream is retained and dropping them after a committed delete
- cache the merged stream metadata projection by its live patch, durable summary, and transcript timestamp inputs

## Root cause

Deleting a stream removed its current stores, but a late session fact could recreate the in-memory projection after deletion. The previous host-specific filtering masked that resurrection in the CLI without protecting extension and desktop state. Concurrent deletion and deterministic workflow relaunch also lacked an identity generation fence, so stale cleanup could erase a fresh incarnation. Desktop additionally had process- and presentation-owned deletion paths that could diverge before storage single-flight began.

The shared session substrate now installs a removal barrier before asynchronous cleanup, carries its incarnation through every durable store, and admits a re-claim only with live workflow-execution evidence. A live `ProgressBackend` claims deletion ownership before its first await, so the process fallback runs only for a genuinely headless stream. Guarded transcript deletion preserves a released stream's authoritative entries across the irreversible commit window and re-persists them when a fresh incarnation supersedes cleanup. All hosts consume the same deletion outcome. Separately, `getStreamMetadata()` now returns a stable derived object until one of its owning inputs changes, avoiding render-cadence allocation without introducing another subscription surface.

## Validation

- `corepack pnpm run typecheck`
- `corepack pnpm run lint`
- `corepack pnpm run compile:fast`
- focused storage, deletion, lifecycle, projection, and desktop integration suites (230 tests)
- focused post-review regressions: SessionStores, StreamLogStore, ProgressBackend lifecycle, and desktop integration (254 passing test executions)
- full Vitest suite (878 files passed, 1 skipped; 10,730 tests passed, 5 skipped)

Fixes #10668.