### PR TITLE
refactor(schemas): move ToolDefinition from src/model to src/shared/schemas

### DIFF
--- a/src/agent/core/definition/AgentDataclass.ts
+++ b/src/agent/core/definition/AgentDataclass.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 
-import { ToolDefinitionSchema } from '@model/ToolDefinition';
 import {
   AgentCategory,
   AgentCategorySchema,
   AgentNameSchema,
   OUTPUT_END_TAG,
+  ToolDefinitionSchema,
 } from '@shared/schemas';
 
 /**

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -33,13 +33,13 @@ import {
 } from '@common/errors/sdkError/providerErrorFormat';
 import { includedModelAccess } from '@model/includedModelAccess';
 import type { ResolvedModelConfig } from '@model/openRouterRouting';
-import type { ToolDefinition } from '@model/ToolDefinition';
 import {
   DEFAULT_CORE_SETTINGS,
   ModelRetryMaxAttemptsSchema,
   STREAM_PHASE,
   toRetryErrorInfo,
   type RetryErrorInfo,
+  type ToolDefinition,
 } from '@shared/schemas';
 import { isKimiCodeExclusiveModel } from '@shared/model/kimiCodeRetryGate';
 import { generateShortId } from '@utils/core';

--- a/src/agent/core/tools/ToolTypes.ts
+++ b/src/agent/core/tools/ToolTypes.ts
@@ -2,8 +2,7 @@
  * Core tool type definitions: ITool, IToolRegistry, MapToolRegistry.
  */
 
-import type { ToolDefinition } from '@model/ToolDefinition';
-import type { ToolResult } from '@shared/schemas';
+import type { ToolDefinition, ToolResult } from '@shared/schemas';
 
 /**
  * Contract for tool implementations.

--- a/src/agent/implementations/flows/reflection/ResponseCycleFlow.ts
+++ b/src/agent/implementations/flows/reflection/ResponseCycleFlow.ts
@@ -25,11 +25,11 @@ import { K_SLICE } from '@agent/core/constants';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { ModelInvocationNode } from '@agent/core/flows/ModelInvocationNode';
 import type { ResponseCycleServices } from '@agent/core/flows/CycleServices';
-import type { ToolDefinition } from '@model/ToolDefinition';
 import {
   AgentFileLocationSchema,
   MESSAGE_TYPES,
   OUTPUT_END_TAG,
+  type ToolDefinition,
 } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { AbsoluteFS } from '@utils/files/absoluteFS';

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -40,11 +40,11 @@ import {
   PARTIAL_TEXT_TAIL_MAX,
   takeTail,
 } from '@common/errors/sdkError/errorPatterns';
-import type { ToolDefinition } from '@model/ToolDefinition';
 import { composeLongRunningModelDispatcher } from '@platform/defaults/longRunningModelTransport';
 import type {
   FileLocation,
   MediaAttachmentKind,
+  ToolDefinition,
   ToolFileAttachment,
   ToolResult,
 } from '@shared/schemas';

--- a/src/agent/modelHandlers/openai/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerKimi.ts
@@ -4,7 +4,7 @@ import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
 // Local imports - agent
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { TokenCountOptions } from '@agent/types/ModelHandlerContracts';
-import type { ToolDefinition } from '@model/ToolDefinition';
+import type { ToolDefinition } from '@shared/schemas';
 import { isKimiCodeExclusiveModel } from '@shared/model/kimiCodeRetryGate';
 import { AUXILIARY_MAX_RETRIES } from '../support/auxiliaryRetry';
 import { resolveMoonshotRequestParameters } from '../support/moonshotRequestParameters';

--- a/src/agent/modelHandlers/openai/modelHandlerMiniMax.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerMiniMax.ts
@@ -1,6 +1,6 @@
 // Local file imports
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
-import type { ToolDefinition } from '@model/ToolDefinition';
+import type { ToolDefinition } from '@shared/schemas';
 import { ReasoningModelHandlerOpenAI } from './reasoningModelHandlerOpenAI';
 import { joinReasoningItemsText } from '../utils/reasoningDetailsText';
 

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -30,10 +30,10 @@ import {
 } from '@common/errors/sdkError/errorPatterns';
 import { buildErrorLogData } from '@common/errors/sdkError/providerErrorFormat';
 import { handleStreamingFailure } from '@common/errors/sdkError/streamFailure';
-import type { ToolDefinition } from '@model/ToolDefinition';
 import type {
   FileLocation,
   MediaAttachmentKind,
+  ToolDefinition,
   ToolFileAttachment,
   ToolResult,
 } from '@shared/schemas';

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -5,8 +5,8 @@ import { toJSONSchema } from 'zod';
 import { createLog } from '@logger/logUtils';
 
 // Type imports
-import type { ToolDefinition } from '@model/ToolDefinition';
 import type { LanguageModelToolDefinition } from '@platform/languageModel';
+import type { ToolDefinition } from '@shared/schemas';
 
 // Local imports - shared
 import { TOOL_JSON_SCHEMA_OPTIONS } from '@shared/tools/toolJsonSchema';

--- a/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
+++ b/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
@@ -22,7 +22,6 @@ import {
 } from '@common/errors/sdkError/errorPatterns';
 import { handleStreamingFailure } from '@common/errors/sdkError/streamFailure';
 import type { ResponseTextProcessing } from '@latex/texraResponseTextProcessing';
-import type { ToolDefinition } from '@model/ToolDefinition';
 import { copilotRouteForModel } from '@model/runtimeModelRegistry';
 import { platform } from '@platform/platform';
 import {
@@ -39,6 +38,7 @@ import {
 import type {
   FileLocation,
   MediaAttachmentKind,
+  ToolDefinition,
   ToolFileAttachment,
   ToolResult,
 } from '@shared/schemas';

--- a/src/agent/runtime/agentToolResolution.ts
+++ b/src/agent/runtime/agentToolResolution.ts
@@ -25,8 +25,8 @@
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { AgentToolUseSetting } from '@agent/core/definition/AgentDataclass';
 import { createLog } from '@logger/logUtils';
-import type { ToolDefinition } from '@model/ToolDefinition';
 import { computeModelOptionsData } from '@model/computeModelOptions';
+import type { ToolDefinition } from '@shared/schemas';
 import { hasDelegationTool } from '@shared/constants/delegationTools';
 import { getDefaultToolRegistry } from '@tools/registry';
 import {

--- a/src/agent/types/ModelHandlerContracts.ts
+++ b/src/agent/types/ModelHandlerContracts.ts
@@ -1,6 +1,6 @@
 // Local imports
-import type { ToolDefinition } from '@model/ToolDefinition';
 import type { LanguageModelToolCallPart } from '@platform/languageModel';
+import type { ToolDefinition } from '@shared/schemas';
 
 // Local file imports
 import type { ProviderMessage } from './ProviderMessage';

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -16,6 +16,7 @@ export * from './usage';
 export * from './contextManagement';
 export * from './spendingStatus';
 export * from './onboarding';
+export * from './toolDefinition';
 
 // Layer 1b: Standalone schemas and shared settings
 export * from './agentSkills';

--- a/src/shared/schemas/toolDefinition.ts
+++ b/src/shared/schemas/toolDefinition.ts
@@ -1,6 +1,6 @@
 import { z, type ZodType } from 'zod';
 
-import { AgentCategorySchema } from '@shared/schemas';
+import { AgentCategorySchema } from './agent';
 
 /**
  * Zod schema for validating tool definition structure.

--- a/src/test-kernel/agent/followUp/ToolUseToolResolution.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseToolResolution.vitest.ts
@@ -6,7 +6,7 @@ import {
   type ResolvedAgentTools,
 } from '@agent/runtime/agentToolResolution';
 import { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
-import type { ToolDefinition } from '@model/ToolDefinition';
+import type { ToolDefinition } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { installPlatform } from '@test/support/setupPlatform';
 import { DiagnosticsTool } from '@tools/DiagnosticsTool';

--- a/src/test-kernel/agent/modelHandlers/AnthropicCacheBeta.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicCacheBeta.vitest.ts
@@ -2,7 +2,7 @@ import { ModelProvider } from 'llm-zoo';
 import { describe, expect, it, vi } from 'vitest';
 
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/anthropic/modelHandlerAnthropic';
-import type { ToolDefinition } from '@model/ToolDefinition';
+import type { ToolDefinition } from '@shared/schemas';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 import { spiedTrace } from '@test/support/spiedTrace';
 import type { MessageParam } from '@anthropic-ai/sdk/resources/messages';

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerDeepSeek.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerDeepSeek.vitest.ts
@@ -8,8 +8,7 @@ import { ModelProvider, ReasoningEffort } from 'llm-zoo';
 // Local imports
 import { noopTrace } from '@agent/trace';
 import { ModelHandlerDeepSeek } from '@agent/modelHandlers/openai/modelHandlerDeepSeek';
-import type { ToolDefinition } from '@model/ToolDefinition';
-import { AgentCategory } from '@shared/schemas';
+import { AgentCategory, type ToolDefinition } from '@shared/schemas';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 type ConfigOverrides = Parameters<typeof buildTestModelConfig>[1];

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -38,9 +38,8 @@ import {
   isProviderErrorAutoRetryable,
   normalizeProviderError,
 } from '@common/errors/sdkError/providerErrorFormat';
-import type { ToolDefinition } from '@model/ToolDefinition';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import { AgentCategory } from '@shared/schemas';
+import { AgentCategory, type ToolDefinition } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 import { spiedTrace } from '@test/support/spiedTrace';

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -13,7 +13,7 @@ import {
   toOpenAITools,
   toOpenAIResponseTools,
 } from '@agent/modelHandlers/toolConversion';
-import type { ToolDefinition } from '@model/ToolDefinition';
+import type { ToolDefinition } from '@shared/schemas';
 import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
 import { REPO_ROOT } from '@test/support/repoScan';
 import { resolveToolDefinitions } from '@tools/registry';

--- a/src/test-kernel/tools/DelegationAgentAvailability.vitest.ts
+++ b/src/test-kernel/tools/DelegationAgentAvailability.vitest.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { ToolDefinition } from '@model/ToolDefinition';
+import type { ToolDefinition } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
   getVisibleAgents: vi.fn(),

--- a/src/test-kernel/tools/DelegationDescriptionBlock.vitest.ts
+++ b/src/test-kernel/tools/DelegationDescriptionBlock.vitest.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { ToolDefinition } from '@model/ToolDefinition';
+import type { ToolDefinition } from '@shared/schemas';
 import { replaceDelegationDescriptionBlock } from '@tools/delegation/delegationAvailability';
 
 const LINE = /^Anchor:.*$/m;

--- a/src/test-kernel/tools/DelegationModelAvailability.vitest.ts
+++ b/src/test-kernel/tools/DelegationModelAvailability.vitest.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { ToolDefinition } from '@model/ToolDefinition';
-import type { ModelOptionData } from '@shared/schemas';
+import type { ModelOptionData, ToolDefinition } from '@shared/schemas';
 import {
   availableModelNamesFromOptions,
   selectDelegationModelFromAvailableNames,

--- a/src/test-kernel/tools/DelegationWorktreeAvailability.vitest.ts
+++ b/src/test-kernel/tools/DelegationWorktreeAvailability.vitest.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { ToolDefinition } from '@model/ToolDefinition';
+import type { ToolDefinition } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
   isWorktreeSupportEnabled: vi.fn(),

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -3,11 +3,11 @@ import { z, ZodError, type ZodType } from 'zod';
 
 // Local imports - core tool types (single source of truth)
 import type { ITool } from '@agent/core/tools/ToolTypes';
-import type { ToolDefinition } from '@model/ToolDefinition';
 import {
   DIAGNOSTIC_TYPE_VALIDATION_ERROR,
   formatZodIssuesForDiagnostics,
   ToolError,
+  type ToolDefinition,
   type ToolResult,
 } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';

--- a/src/tools/core/define.ts
+++ b/src/tools/core/define.ts
@@ -2,7 +2,7 @@
 import { toJSONSchema, type ZodType } from 'zod';
 
 // Type imports
-import type { ToolDefinition } from '@model/ToolDefinition';
+import type { ToolDefinition } from '@shared/schemas';
 
 // Local imports - shared
 import { TOOL_JSON_SCHEMA_OPTIONS } from '@shared/tools/toolJsonSchema';

--- a/src/tools/delegation/delegationAvailability.ts
+++ b/src/tools/delegation/delegationAvailability.ts
@@ -30,12 +30,12 @@ import {
 } from '@agent/index/agentRegistry';
 import type { AgentEntry } from '@agent/index/agentEntry';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
-import type { ToolDefinition } from '@model/ToolDefinition';
 import { decideRunModel } from '@model/runModelDecision';
 import type {
   AgentCategory,
   AgentDelegationScope,
   ModelOptionData,
+  ToolDefinition,
 } from '@shared/schemas';
 import { isModelOptionAvailable } from '@shared/schemas';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -4,7 +4,7 @@ import stableStringify from 'fast-json-stable-stringify';
 // Local imports
 import type { ITool, IToolRegistry } from '@agent/core/tools/ToolTypes';
 import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
-import type { ToolDefinition } from '@model/ToolDefinition';
+import type { ToolDefinition } from '@shared/schemas';
 import type { CanonicalToolDisplayName } from '@shared/tools/toolKind';
 import {
   DELEGATE_MULTI_AGENTS_TOOL_NAME,


### PR DESCRIPTION
## Summary

A structural-debt sweep of the codebase (module/file structure, duplicate logic, ownership boundaries) found `src/model/ToolDefinition.ts` misplaced: `ToolDefinitionSchema` is the wire schema for an agent tool's shape (`name`/`description`/`parameters`/`zodSchema`/`availabilityCategory`), consumed by `src/tools/`, `src/agent/core/`, and `src/agent/modelHandlers/`. It has no relationship to `src/model/`'s actual concern — which model/route to pick, availability, pricing (`computeModelOptions.ts`, `openRouterRouting.ts`, `providerCapabilities.ts`, etc.). It ended up there by historical accident, not design.

This is exactly the kind of thing CLAUDE.md already names as `src/shared/`'s job ("wire contracts and UI-shared message types"). The rest of `src/model/` and `src/agent/modelHandlers/` were checked for the same class of confusion and found genuinely clean — `src/model` computes routing/pricing decisions, `modelHandlers` calls into those decisions rather than reimplementing them.

This PR moves the schema to `src/shared/schemas/toolDefinition.ts`, exports it from the existing barrel (following the file's own layered-export convention), and repoints the 25 importers at `@shared/schemas`. No behavior change — pure move + import-path update.

## Issue acceptance gates

No linked issue — found via a general codebase audit for confusing/overlapping module responsibilities. Acceptance: `ToolDefinitionSchema`/`ToolDefinition` live in `src/shared/schemas/`, `src/model/` no longer contains a tool wire-schema, and every importer resolves through `@shared/schemas`.

## Single source of truth

`src/shared/schemas/toolDefinition.ts` (barrel-exported via `src/shared/schemas/index.ts`) is now the sole definition of the tool wire shape — unchanged in content, just relocated next to the codebase's other wire contracts instead of sitting inside the model-routing package.

## Duplication and abstraction budget

No duplication removed or added — this is a pure relocation to fix a misleading location, not a consolidation of multiple implementations. No new abstraction introduced.

## Net elements (R6)

Files: 1 renamed (`src/model/ToolDefinition.ts` → `src/shared/schemas/toolDefinition.ts`), 25 files with import-specifier-only edits. Net LoC: +27/-30 across the diff (mostly import-line reshuffling to merge into existing `@shared/schemas` import blocks); zero new or deleted exported symbols — `ToolDefinitionSchema`/`ToolDefinition` are exported exactly as before, from a new location.

## Consumer counts (R8)

25 production/test files imported `ToolDefinition`/`ToolDefinitionSchema` from `@model/ToolDefinition` (verified via `git grep` against the base commit: 24 import the `ToolDefinition` type, 1 — `src/agent/core/definition/AgentDataclass.ts` — imports the `ToolDefinitionSchema` value); all 25 repointed to `@shared/schemas` in this PR. Zero remaining references to `@model/ToolDefinition` (verified via repo-wide grep after the change).

## Host impact

Extension: none — host-agnostic schema move only.

Desktop: none.

CLI: none.

## Scheduled refactoring

None — this was the single most significant, self-contained finding from the sweep. Two other candidate areas (host-layer duplication across extension/desktop/cli; broader contract-fragmentation families in `src/agent/runtime`, progress-view wire, settings catalogs) were checked and found either already well-factored or already covered by an existing, actively-adjudicated internal audit (`docs/proposals/2026-08-15-shared-contracts-and-retirement.md`) with maintainer rulings and sequencing — not something to re-litigate or execute unsupervised in this pass.

Note: `docs/proposals/2026-08-03-run-classification-consolidation.md:623` cites the old `ToolDefinition.ts:18-30` path. Left untouched — proposal docs are historical/frozen artifacts, not live documentation, and updating stale citations in past proposals is out of scope here.

## Validation

- `npm run typecheck:workspace` — clean
- `npm run typecheck:test-kernel` — clean
- `npx eslint` over all touched files — clean (fixed 3 `import/order` violations from the specifier change)
- `npx prettier --check` over all touched files — clean
- `npm run check:dead-code-ratchet` — no new findings (10 baselined, unchanged)
- `npx vitest run src/test-kernel/architecture/` — 102/102 passed (all boundary/ratchet tests, including `sharedSchemasDeepImportRatchet.vitest.ts`)
- `npx vitest run src/test-kernel/tools src/test-kernel/agent src/test-kernel/model` — 4058/4058 passed (1 pre-existing skip)
