### PR TITLE
refactor: retire settings history status exports

### DIFF
--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -84,12 +84,6 @@ export { type Goal } from './goal';
 export { type MemoryViewItem, type MemoryPreview } from './memoryViewMessages';
 
 export {
-  HISTORY_RUN_STATUS_LABEL,
-  resolveHistoryRunStatus,
-  type HistoryRunStatus,
-} from './historyRunStatus';
-
-export {
   API_ACCESS_MODE_OPTIONS,
   DEFAULT_GLOBAL_STREAMING,
   DEFAULT_QUOTA_AUTO_SWITCHED,

--- a/src/test-kernel/cli/HistoryStatus.vitest.ts
+++ b/src/test-kernel/cli/HistoryStatus.vitest.ts
@@ -19,8 +19,8 @@ import {
   EXECUTION_META_SCHEMA_VERSION,
   EXECUTION_STATUS,
   AgentCategory,
-  resolveHistoryRunStatus,
 } from '@shared/schemas';
+import { resolveHistoryRunStatus } from '@shared/schemas/historyRunStatus';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 


### PR DESCRIPTION
Retires the Settings History barrel re-exports that no remaining settings consumer uses. The CLI continues to import the canonical history-status module directly.\n\nThis removes the two dead-code ratchet findings exposed after the duplicate Settings History surface was removed.\n\nValidation: knip dead-code findings: 8 current (unusedFiles=2, unusedExports=6, unusedTypes=0, duplicateExports=0) vs 8 baselined
Dead-code ratchet OK: no new unused files/exports/types found. and .