### PR TITLE
fix(runtime): log normalized usage provider

### DIFF
--- a/src/agent/runtime/UsageMonitor.ts
+++ b/src/agent/runtime/UsageMonitor.ts
@@ -9,7 +9,7 @@ import type {
   StreamTabId,
   UsageRoute,
 } from '@shared/schemas';
-import { AgentCategory, UsageProviderSchema } from '@shared/schemas';
+import { AgentCategory } from '@shared/schemas';
 import {
   USAGE_LOG_FLUSH_OUTCOME,
   UsageLogService,
@@ -206,15 +206,19 @@ export class UsageMonitor {
 
       // Log to backend for analytics/billing. Relay-backed rounds wait for the
       // flush because the next relay request enforces the cap from DB state.
-      await this.logToBackend(stateGlobal.totalResponseTimeMs, {
-        inputTokens: roundInputTokens,
-        outputTokens: roundOutputTokens,
-        cachedInputTokens: roundCacheReadTokens,
-        cacheMissInputTokens: roundCacheMissTokens.billing,
-        reasoningTokens: roundReasoningTokens,
-        cost: roundCost,
-        usageRoute,
-      });
+      await this.logToBackend(
+        stateGlobal.totalResponseTimeMs,
+        {
+          inputTokens: roundInputTokens,
+          outputTokens: roundOutputTokens,
+          cachedInputTokens: roundCacheReadTokens,
+          cacheMissInputTokens: roundCacheMissTokens.billing,
+          reasoningTokens: roundReasoningTokens,
+          cost: roundCost,
+          usageRoute,
+        },
+        latestUsage.provider,
+      );
     } catch (error) {
       logger.error(`Error printing ${runKind} statistics`, { data: error });
     }
@@ -269,12 +273,12 @@ export class UsageMonitor {
       | 'reasoningTokens'
       | 'cost'
     > & { cacheMissInputTokens: number; usageRoute?: UsageRoute },
+    provider: NonNullable<
+      AgentRunStateSnapshot['usageAccumulator']['latestUsage']
+    >['provider'],
   ): Promise<void> {
     try {
       const { config } = this.modelInfo;
-      const provider = UsageProviderSchema.catch('unknown').parse(
-        config.provider,
-      );
       const cachedInputTokens = usage.cachedInputTokens ?? 0;
       const usedRelay = usage.usageRoute === 'relay';
 


### PR DESCRIPTION
## Summary

- restore the per-round normalized usage provider as the backend billing provider
- keep model configuration limited to model metadata, so OpenRouter-routed rounds are logged as OpenRouter

## Root cause

#10790 derived billing provider from the model configuration. That configuration identifies the underlying model family and can be `others`, while normalized round usage records the canonical provider that served the request.

## Validation

- `pnpm vitest run src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts`
- `pnpm run typecheck:test-kernel`
- `pnpm run typecheck:workspace`
- `pnpm eslint src/agent/runtime/UsageMonitor.ts src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts`