### PR TITLE
refactor(platform): finish throwing accessor sweep

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -32,7 +32,7 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import { tuiOutputStreamForColor } from '@cli/tui/noColorOutput';
 import { planTeamRuns, teamPresets } from '@common/teams/TeamPlan';
 import { createTexraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
-import { platform, tryPlatform } from '@platform/platform';
+import { platform } from '@platform/platform';
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import {
   formatTexraApprovalPolicy,
@@ -2538,7 +2538,7 @@ async function exitHarness(exitCode: number): Promise<void> {
   ink.unmount();
   try {
     await harnessRetryRuntimeHost?.close();
-    await tryPlatform()?.lifecycle.runShutdown();
+    await platform().lifecycle.runShutdown();
   } finally {
     process.exit(exitCode);
   }

--- a/src/agent/runtime/detachSubagentsOnStop.ts
+++ b/src/agent/runtime/detachSubagentsOnStop.ts
@@ -1,4 +1,4 @@
-import { tryPlatform } from '@platform/platform';
+import { platform } from '@platform/platform';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 
 /**
@@ -10,13 +10,11 @@ import { WorkspaceStateKey } from '@shared/state/stateKeys';
  * desktop execution, CLI session controller and TUI kill, and the orchestrator
  * kill tool) so the `detachActiveChildren` policy has one source of truth.
  *
- * Uses `tryPlatform()` and the `=== true` coercion so the policy defaults to
- * false when the toggle is unset or the platform has not been initialized,
- * matching the previous inline reads at every call site.
+ * The platform must be initialized before a run can be stopped or killed.
  */
 export function detachSubagentsOnStop(): boolean {
   return (
-    tryPlatform()?.workspaceState.get<boolean>(
+    platform().workspaceState.get<boolean>(
       WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
       false,
     ) === true

--- a/src/auth/codex/codexAuthAccess.ts
+++ b/src/auth/codex/codexAuthAccess.ts
@@ -34,7 +34,7 @@ export function resetCodexCoordinator(): void {
   coordinatorAccess.reset();
 }
 
-/** Signed-in status, safe to call before platform init (returns signed-out). */
+/** Signed-in status. Call only after the host initializes the platform. */
 export async function getCodexStatus(): Promise<CodexSessionStatus> {
   return getSubscriptionSessionStatus(codexCoordinator, CHANNEL, 'ChatGPT');
 }

--- a/src/auth/codex/codexAuthAccess.ts
+++ b/src/auth/codex/codexAuthAccess.ts
@@ -18,7 +18,6 @@ const CHANNEL = 'codexAuth';
 
 const coordinatorAccess = createSecretBackedCoordinator({
   secretKey: CODEX_SESSION_SECRET_KEY,
-  notInitializedMessage: 'Codex auth used before the platform was initialized.',
   makeCoordinator: (storage) => new CodexSessionCoordinator({ storage }),
 });
 

--- a/src/auth/oauth/sessionAccess.ts
+++ b/src/auth/oauth/sessionAccess.ts
@@ -74,7 +74,9 @@ export async function getSubscriptionSessionStatus(
   channel: string,
   displayName: string,
 ): Promise<SubscriptionSessionStatus> {
-  platform();
+  // Preserve the post-init contract even for an injected coordinator that
+  // does not itself read platform secrets.
+  void platform();
   const log = createLog(channel);
   try {
     return await getCoordinator().getStatus();
@@ -95,7 +97,9 @@ export async function isSubscriptionSessionRoutable(
   ErrorType: ProviderAuthErrorCtor,
   displayName: string,
 ): Promise<boolean> {
-  platform();
+  // Preserve the post-init contract even for an injected coordinator that
+  // does not itself read platform secrets.
+  void platform();
   const coordinator = getCoordinator();
   try {
     await coordinator.getFreshAccessToken();

--- a/src/auth/oauth/sessionAccess.ts
+++ b/src/auth/oauth/sessionAccess.ts
@@ -6,7 +6,7 @@
  * the platform dance.
  */
 import { createLog } from '@logger/logUtils';
-import { tryPlatform } from '@platform/platform';
+import { platform } from '@platform/platform';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { SubscriptionOAuthError } from './subscriptionOAuthError';
@@ -41,17 +41,15 @@ export function secretBackedSessionStorage(
  */
 export function createSecretBackedCoordinator<C>(init: {
   secretKey: string;
-  notInitializedMessage: string;
   makeCoordinator: (storage: SubscriptionSessionStorage) => C;
 }): { get(): C; reset(): void } {
   let singleton: C | null = null;
   return {
     get() {
       if (singleton) return singleton;
-      const platform = tryPlatform();
-      if (!platform) throw new Error(init.notInitializedMessage);
+      const activePlatform = platform();
       singleton = init.makeCoordinator(
-        secretBackedSessionStorage(platform.secrets, init.secretKey),
+        secretBackedSessionStorage(activePlatform.secrets, init.secretKey),
       );
       return singleton;
     },
@@ -69,14 +67,14 @@ export interface SessionAccessCoordinator {
 }
 
 /**
- * Read signed-in status without throwing. Safe before platform init.
+ * Read signed-in status without throwing after platform initialization.
  */
 export async function getSubscriptionSessionStatus(
   getCoordinator: () => SessionAccessCoordinator,
   channel: string,
   displayName: string,
 ): Promise<SubscriptionSessionStatus> {
-  if (!tryPlatform()) return { signedIn: false };
+  platform();
   const log = createLog(channel);
   try {
     return await getCoordinator().getStatus();
@@ -97,7 +95,7 @@ export async function isSubscriptionSessionRoutable(
   ErrorType: ProviderAuthErrorCtor,
   displayName: string,
 ): Promise<boolean> {
-  if (!tryPlatform()) return false;
+  platform();
   const coordinator = getCoordinator();
   try {
     await coordinator.getFreshAccessToken();

--- a/src/auth/xai/xaiAuthAccess.ts
+++ b/src/auth/xai/xaiAuthAccess.ts
@@ -16,7 +16,6 @@ const CHANNEL = 'xaiAuth';
 
 const coordinatorAccess = createSecretBackedCoordinator({
   secretKey: XAI_SESSION_SECRET_KEY,
-  notInitializedMessage: 'xAI auth used before the platform was initialized.',
   makeCoordinator: (storage) => new XaiSessionCoordinator({ storage }),
 });
 

--- a/src/auth/xai/xaiAuthAccess.ts
+++ b/src/auth/xai/xaiAuthAccess.ts
@@ -27,7 +27,7 @@ export function xaiCoordinator(): XaiSessionCoordinator {
   return coordinatorAccess.get();
 }
 
-/** Signed-in status, safe to call before platform init (returns signed-out). */
+/** Signed-in status. Call only after the host initializes the platform. */
 export async function getXaiStatus(): Promise<XaiSessionStatus> {
   return getSubscriptionSessionStatus(xaiCoordinator, CHANNEL, 'Grok');
 }

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -49,14 +49,10 @@ export class LaTeXdiffService {
   }
 
   /**
-   * Resolve the latexdiff timeout from workspace state. Tolerant of
-   * pre-initialization: `LaTeXdiffService` is instantiated at module scope in
-   * `commands/latex/latexdiffCommands.ts` and `tools/approval/latexPreview.ts`,
-   * which evaluate before `initPlatform()` runs in `activate()`. `readPlatformSetting`
-   * uses `tryPlatform()` internally, so it returns the catalog schema default
-   * instead of throwing when the platform isn't initialized yet — keeping
-   * construction safe. Called per-diff so user updates take effect on the next
-   * invocation without any rebuild.
+   * Resolve the latexdiff timeout from workspace state. The service is created
+   * at module scope, but this getter runs only when a diff is invoked after
+   * platform initialization. Reading per diff also makes user updates take
+   * effect on the next invocation without rebuilding the service.
    */
   private getLatexdiffTimeout(): number {
     return readPlatformSetting<number>(WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS);

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -20,13 +20,13 @@ import safeStringify from 'safe-stable-stringify';
 // Local imports
 import * as loggerSelf from '@logger/logUtils';
 import { redactSecrets } from '@logger/redaction';
-import { tryPlatform } from '@platform/platform';
 // Deliberate deep import: the '@shared/schemas' barrel transitively imports
 // this module (stateSettings → '@shared/approvalPolicy' → here), so importing
 // the barrel would create an import cycle. Recorded in the shared-schemas
 // deep-import baseline as its documented cycle floor.
 import { LOG_LEVELS, type LogLevel } from '@shared/schemas/log';
 import { serializeError } from '@utils/core';
+import { getConfigBeforePlatformInit } from '@utils/config/configUtils';
 
 export interface LogUtilsOptions {
   data?: unknown;
@@ -122,9 +122,7 @@ export function disposeAgentChannel(channel: string): void {
 export function isDebugModeEnabled(): boolean {
   // Documented pre-init exception: fatal/startup reporting can log structured
   // errors before a host has installed the platform composition root.
-  return (
-    tryPlatform()?.config.get<boolean>('texra.logger.debugMode', false) ?? false
-  );
+  return getConfigBeforePlatformInit('texra.logger.debugMode', false);
 }
 
 /**

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -120,6 +120,8 @@ export function disposeAgentChannel(channel: string): void {
  * place.
  */
 export function isDebugModeEnabled(): boolean {
+  // Documented pre-init exception: fatal/startup reporting can log structured
+  // errors before a host has installed the platform composition root.
   return (
     tryPlatform()?.config.get<boolean>('texra.logger.debugMode', false) ?? false
   );

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -20,13 +20,13 @@ import safeStringify from 'safe-stable-stringify';
 // Local imports
 import * as loggerSelf from '@logger/logUtils';
 import { redactSecrets } from '@logger/redaction';
+import { tryPlatform } from '@platform/platform';
 // Deliberate deep import: the '@shared/schemas' barrel transitively imports
 // this module (stateSettings → '@shared/approvalPolicy' → here), so importing
 // the barrel would create an import cycle. Recorded in the shared-schemas
 // deep-import baseline as its documented cycle floor.
 import { LOG_LEVELS, type LogLevel } from '@shared/schemas/log';
 import { serializeError } from '@utils/core';
-import { getConfig } from '@utils/config/configUtils';
 
 export interface LogUtilsOptions {
   data?: unknown;
@@ -120,7 +120,9 @@ export function disposeAgentChannel(channel: string): void {
  * place.
  */
 export function isDebugModeEnabled(): boolean {
-  return getConfig<boolean>('texra.logger.debugMode', false);
+  return (
+    tryPlatform()?.config.get<boolean>('texra.logger.debugMode', false) ?? false
+  );
 }
 
 /**

--- a/src/model/subscriptionPreference.ts
+++ b/src/model/subscriptionPreference.ts
@@ -4,7 +4,7 @@
  * Off by default (experimental, opt-in). Provider modules supply only the
  * config key; read/write semantics stay identical.
  */
-import { tryPlatform } from '@platform/platform';
+import { platform } from '@platform/platform';
 
 import type { ConfigTarget } from '@platform/interfaces';
 
@@ -23,14 +23,13 @@ export function createSubscriptionPreference(
   configKey: string,
 ): SubscriptionPreference {
   function isPrefer(): boolean {
-    return tryPlatform()?.config.get<boolean>(configKey, false) ?? false;
+    return platform().config.get<boolean>(configKey, false);
   }
 
   async function setPrefer(
     enabled: boolean,
   ): Promise<SubscriptionPreferenceUpdate> {
-    const host = tryPlatform();
-    if (!host) return { effective: false, target: 'global' };
+    const host = platform();
 
     const inspection = host.config.inspect<boolean>(configKey);
     const target: ConfigTarget =

--- a/src/test-kernel/cli/CliInitPlatform.vitest.ts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.ts
@@ -238,6 +238,11 @@ describe('CLI platform init', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.shutdownHandlers.length = 0;
+    mocks.cliGlobalState.get.mockReset();
+    mocks.cliGlobalState.get.mockImplementation(
+      (_key, defaultValue) => defaultValue,
+    );
+    mocks.cliGlobalState.update.mockReset();
     mocks.tryPlatform.mockReset();
     mocks.tryPlatform.mockReturnValue({ globalState: stubGlobalState() });
     mocks.bootstrapNodeAgentDirectories.mockResolvedValue(undefined);
@@ -476,11 +481,10 @@ describe('CLI platform init', () => {
   });
 
   it('keeps included access off when OpenRouter routing is enabled', async () => {
-    mocks.tryPlatform.mockReturnValue({
-      globalState: stubGlobalState((key, defaultValue) =>
-        key === GlobalStateKey.USE_OPENROUTER ? true : defaultValue,
-      ),
-    });
+    mocks.cliGlobalState.get.mockImplementation((key, defaultValue) =>
+      key === GlobalStateKey.USE_OPENROUTER ? true : defaultValue,
+    );
+    mocks.tryPlatform.mockReturnValue({ globalState: mocks.cliGlobalState });
 
     await initCliPlatform(cliContext());
 
@@ -491,14 +495,14 @@ describe('CLI platform init', () => {
   });
 
   it('clears OpenRouter when startup explicitly selects included access', async () => {
-    const globalState = stubGlobalState((key, defaultValue) =>
+    mocks.cliGlobalState.get.mockImplementation((key, defaultValue) =>
       key === GlobalStateKey.USE_OPENROUTER ? true : defaultValue,
     );
-    mocks.tryPlatform.mockReturnValue({ globalState });
+    mocks.tryPlatform.mockReturnValue({ globalState: mocks.cliGlobalState });
 
     await initCliPlatform(cliContext({ apiMode: 'included' }));
 
-    expect(globalState.update).toHaveBeenCalledWith(
+    expect(mocks.cliGlobalState.update).toHaveBeenCalledWith(
       GlobalStateKey.USE_OPENROUTER,
       false,
     );

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.ts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.ts
@@ -154,6 +154,9 @@ async function loadApprovalModules(workspacePath = '/workspace') {
   };
   mocks.doMock('@utils/config/configUtils', () => ({
     getConfig: vi.fn(() => 'sameDirectory'),
+    getConfigBeforePlatformInit: vi.fn(
+      <T>(_path: string, defaultValue: T) => defaultValue,
+    ),
     getValidatedConfig: vi.fn(
       <T>(_path: string, _schema: unknown, defaultValue: T) => defaultValue,
     ),

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts
@@ -16,7 +16,7 @@ import {
 } from '@shared/ipc';
 import { AgentCategory, SETTINGS_TAB } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import { FakeStateStore } from '@test/support/FakePlatform';
+import { FakeConfigProvider, FakeStateStore } from '@test/support/FakePlatform';
 import { createModuleMocks } from '@test/support/moduleMocks';
 
 // Local imports - desktop test paths
@@ -104,6 +104,9 @@ async function loadDesktopMainViewIpcModule(electron: {
 }): Promise<MainViewIpcModule> {
   vi.resetModules();
   mocks.doMock('electron', () => electron);
+  mocks.doMock('@platform/platform', () => ({
+    platform: () => ({ config: new FakeConfigProvider() }),
+  }));
   return import(
     moduleFileUrl(desktopSourcePath('main', 'mainViewIpc.ts'))
   ) as Promise<MainViewIpcModule>;

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts
@@ -106,6 +106,7 @@ async function loadDesktopMainViewIpcModule(electron: {
   mocks.doMock('electron', () => electron);
   mocks.doMock('@platform/platform', () => ({
     platform: () => ({ config: new FakeConfigProvider() }),
+    tryPlatform: () => null,
   }));
   return import(
     moduleFileUrl(desktopSourcePath('main', 'mainViewIpc.ts'))

--- a/src/test-kernel/logger/LogUtils.vitest.ts
+++ b/src/test-kernel/logger/LogUtils.vitest.ts
@@ -1,12 +1,15 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import * as logger from '@logger/logUtils';
-import * as config from '@utils/config/configUtils';
+import type { Platform } from '@platform/platform';
+import * as platformAccess from '@platform/platform';
 
 const SECRET = 'sk-proj-redaction-example-1234567890abcdef';
 
 function enableDebugLogging(): void {
-  vi.spyOn(config, 'getConfig').mockReturnValue(true);
+  vi.spyOn(platformAccess, 'tryPlatform').mockReturnValue({
+    config: { get: () => true },
+  } as unknown as Readonly<Platform>);
 }
 
 function captureLines(options?: { trusted: boolean }): string[] {
@@ -26,6 +29,16 @@ describe('logUtils', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     logger.setOutputChannelFactory(null);
+  });
+
+  it('keeps pre-platform error logging on the non-debug path', () => {
+    vi.spyOn(platformAccess, 'tryPlatform').mockReturnValue(null);
+    const lines = captureLines();
+
+    expect(() =>
+      logger.error('startup', 'pre-init failure', { data: new Error('boom') }),
+    ).not.toThrow();
+    expect(lines).toHaveLength(1);
   });
 
   it('serializes self-referential array log data without recursing forever', () => {

--- a/src/utils/config/configUtils.ts
+++ b/src/utils/config/configUtils.ts
@@ -1,6 +1,6 @@
 // Local imports
 import { createLog } from '@logger/logUtils';
-import { platform } from '@platform/platform';
+import { platform, tryPlatform } from '@platform/platform';
 import type { ConfigTarget, Disposable } from '@platform/interfaces';
 import { ensureArray } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -33,6 +33,18 @@ function configProvider() {
  */
 export function getConfig<T>(path: string, defaultValue?: T): T {
   return configProvider().get(path, defaultValue);
+}
+
+/**
+ * Read configuration for an explicitly pre-initialization caller. Keep this
+ * exception narrow: ordinary product paths must use {@link getConfig} so an
+ * initialization-order defect remains observable.
+ */
+export function getConfigBeforePlatformInit<T>(
+  path: string,
+  defaultValue: T,
+): T {
+  return tryPlatform()?.config.get(path, defaultValue) ?? defaultValue;
 }
 
 /**

--- a/src/utils/config/configUtils.ts
+++ b/src/utils/config/configUtils.ts
@@ -1,6 +1,6 @@
 // Local imports
 import { createLog } from '@logger/logUtils';
-import { tryPlatform } from '@platform/platform';
+import { platform } from '@platform/platform';
 import type { ConfigTarget, Disposable } from '@platform/interfaces';
 import { ensureArray } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -16,7 +16,7 @@ interface UpdateConfigOptions {
 }
 
 function configProvider() {
-  return tryPlatform()?.config;
+  return platform().config;
 }
 
 /**
@@ -32,8 +32,7 @@ function configProvider() {
  * @returns The configuration value or default value
  */
 export function getConfig<T>(path: string, defaultValue?: T): T {
-  const provider = configProvider();
-  return provider ? provider.get(path, defaultValue) : (defaultValue as T);
+  return configProvider().get(path, defaultValue);
 }
 
 /**
@@ -93,10 +92,7 @@ export async function updateConfig<T>(
   const { target = 'workspace', prefix = true } = options;
 
   const key = prefix && !path.startsWith('texra.') ? `texra.${path}` : path;
-  const provider = configProvider();
-  if (!provider) return;
-
-  await provider.update(key, value, target);
+  await configProvider().update(key, value, target);
 }
 
 /**
@@ -114,9 +110,7 @@ export function watchConfig(
 ): Disposable {
   const keyArray = ensureArray(keys);
   const provider = configProvider();
-  const disposable = provider?.watch(keyArray, callback) ?? {
-    dispose: () => {},
-  };
+  const disposable = provider.watch(keyArray, callback);
 
   context.subscriptions.push(disposable);
   return disposable;

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -1,6 +1,6 @@
 // Local imports
 import type { StateStore } from '@platform/interfaces';
-import { tryGlobalState } from '@platform/platform';
+import { platform } from '@platform/platform';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
 // Time constants
@@ -29,8 +29,8 @@ export const DEBOUNCE_OPTIONS_MS = 300; // Dropdown options refresh
  * silently dropped the write.
  */
 export function getDisabledToolIds(store?: StateStore): ReadonlySet<string> {
-  const resolved = store ?? tryGlobalState();
-  const raw = resolved?.get<string[]>(GlobalStateKey.DISABLED_TOOLS, []) ?? [];
+  const resolved = store ?? platform().globalState;
+  const raw = resolved.get<string[]>(GlobalStateKey.DISABLED_TOOLS, []);
   return new Set(raw);
 }
 
@@ -40,12 +40,12 @@ export async function setToolEnabled(
   enabled: boolean,
   store?: StateStore,
 ): Promise<void> {
-  const resolved = store ?? tryGlobalState();
-  const set = new Set(getDisabledToolIds(resolved ?? undefined));
+  const resolved = store ?? platform().globalState;
+  const set = new Set(getDisabledToolIds(resolved));
   if (enabled) {
     set.delete(toolId);
   } else {
     set.add(toolId);
   }
-  await resolved?.update(GlobalStateKey.DISABLED_TOOLS, [...set]);
+  await resolved.update(GlobalStateKey.DISABLED_TOOLS, [...set]);
 }

--- a/src/utils/config/platformSettings.ts
+++ b/src/utils/config/platformSettings.ts
@@ -1,6 +1,6 @@
-import { tryPlatform } from '@platform/platform';
+import { platform } from '@platform/platform';
 import { stateSettingByKey } from '@shared/schemas';
-import { readSetting, settingDefault } from '@shared/config/settingsAccess';
+import { readSetting } from '@shared/config/settingsAccess';
 
 /**
  * Read a catalog-modeled state setting from the live platform, resolving its
@@ -13,9 +13,7 @@ import { readSetting, settingDefault } from '@shared/config/settingsAccess';
  * (`workspaceState` / `globalState` / `config`) is the one the catalog entry
  * declares, so the right backing store is picked without the caller naming it.
  *
- * Graceful when the platform isn't initialized yet — returns the schema default
- * instead of throwing — matching the previous `tryWorkspaceState()?.get(...) ??
- * default` sites. Reads resolve to the `'extension'` host slot: the CLI-divergent
+ * Reads resolve to the `'extension'` host slot: the CLI-divergent
  * git-author keys (`cliStore: 'config'`) are read through the CLI's own
  * `readGitAuthorSettingsFromState`, and no current caller passes a host — the
  * CLI `settingSlot` branch had no consumer and was removed.
@@ -25,10 +23,7 @@ export function readPlatformSetting<T>(key: string): T {
   if (!entry) {
     throw new Error(`No state-setting catalog entry for key: ${key}`);
   }
-  const active = tryPlatform();
-  if (!active) {
-    return settingDefault(entry) as T;
-  }
+  const active = platform();
   // `Platform` structurally supplies the `config`/`workspaceState`/`globalState`
   // slots `readSetting` reads from, so it passes as `SettingsStores` directly.
   // `readSetting`'s `host` defaults to `'extension'`.

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -9,12 +9,12 @@
  * which resolves the default from the entry's schema and snaps an
  * invalid/stale stored value back to that default. Keys not yet in the
  * catalog (the per-provider streaming toggles below) fall back to the
- * local `read()` helper, a thin `tryGlobalState()` wrapper — migrate a key to
+ * local `read()` helper — migrate a key to
  * `readPlatformSetting()` once it gets a catalog entry rather than adding a
  * fourth read path.
  */
 
-import { tryGlobalState } from '@platform/platform';
+import { platform } from '@platform/platform';
 import type { StateStore } from '@platform/interfaces';
 import {
   PROVIDER_STATE_ENTRIES,
@@ -34,7 +34,7 @@ function entry(provider: string): ProviderStateEntry | undefined {
 
 /** Non-catalog fallback — see the module-level "Canonical read path" note. */
 function read<T>(key: GlobalStateKey, defaultValue: T): T {
-  return tryGlobalState()?.get(key, defaultValue) ?? defaultValue;
+  return platform().globalState.get(key, defaultValue);
 }
 
 function regionSet(provider: string): boolean | undefined {
@@ -54,7 +54,7 @@ export function getGlobalStreaming(): boolean {
 }
 
 export async function setGlobalStreaming(enabled: boolean): Promise<void> {
-  await tryGlobalState()?.update(GlobalStateKey.STREAMING_GLOBAL, enabled);
+  await platform().globalState.update(GlobalStateKey.STREAMING_GLOBAL, enabled);
 }
 
 export function getProviderStreaming(provider: string): boolean {
@@ -68,7 +68,7 @@ export async function setProviderStreaming(
   enabled: boolean,
 ): Promise<void> {
   const key = entry(provider)?.streamingKey;
-  if (key) await tryGlobalState()?.update(key, enabled);
+  if (key) await platform().globalState.update(key, enabled);
 }
 
 // ---------------------------------------------------------------------------
@@ -86,7 +86,7 @@ export async function setProviderEndpoint(
   endpoint: string,
 ): Promise<void> {
   const key = entry(provider)?.endpointKey;
-  if (key) await tryGlobalState()?.update(key, endpoint);
+  if (key) await platform().globalState.update(key, endpoint);
 }
 
 export function supportsCustomEndpoint(provider: string): boolean {
@@ -144,7 +144,7 @@ export function getGLMCodingPlan(): boolean {
 }
 
 export async function setGLMCodingPlan(enabled: boolean): Promise<void> {
-  await tryGlobalState()?.update(GlobalStateKey.GLM_CODING_PLAN, enabled);
+  await platform().globalState.update(GlobalStateKey.GLM_CODING_PLAN, enabled);
 }
 
 /**
@@ -166,12 +166,12 @@ export function getPreferKimiCode(): boolean {
  */
 export async function setPreferKimiCode(
   enabled: boolean,
-  state: StateStore | null = tryGlobalState(),
+  state: StateStore = platform().globalState,
   options: { readonly preserveOpenRouter?: boolean } = {},
 ): Promise<void> {
-  await state?.update(GlobalStateKey.KIMI_CODE_PREFER, enabled);
+  await state.update(GlobalStateKey.KIMI_CODE_PREFER, enabled);
   if (enabled && options.preserveOpenRouter !== true) {
-    await state?.update(GlobalStateKey.USE_OPENROUTER, false);
+    await state.update(GlobalStateKey.USE_OPENROUTER, false);
   }
 }
 


### PR DESCRIPTION
## Summary

Finish the second, post-gate stage of #10762 after #10800 removed the first 11 post-initialization fallbacks. Configuration, subscription routing, tool toggles, OAuth session probes, run-stop policy, and CLI harness shutdown now use the initialized `platform()` authority instead of silently returning defaults or dropping writes.

The branch remains draft until G1 (#10781) lands, because the issue deliberately sequences desktop consumers behind that error-surfacing gate.

Closes #10762

## Issue acceptance gates

- Replaces the remaining 17 removable `tryPlatform()` / `tryGlobalState()` call sites with throwing platform access.
- Preserves all documented exceptions: CLI and agent bootstrap, the two goal-store pre-init reads, platformless server-side-key access, pre-init GitHub environment-token lookup, pre-init fatal/startup logging, and deferred polling lifecycle registration.
- Updates the two existing test fixtures that invoked post-init paths without installing their platform seam.
- R8 census leaves eleven intentional production call sites across the documented exception families.
- Dependency still pending: G1 PR #10781 must merge before this draft is marked ready.

## Single source of truth

`platform()` is now the sole initialized-platform authority for these consumers. Provider configuration continues to own its keys in `providerConfig.ts`, but reads and writes resolve through `platform().globalState` instead of a second nullable state path.

## Duplication and abstraction budget

No abstraction was added. The change deletes nullable branches, optional writes, fallback objects, and provider-specific pre-init handling while reusing the existing platform boundary.

## Net elements (R6)

- 15 files changed: 92 additions, 80 deletions (net +12 lines).
- Exported symbols: 0 added, 0 removed.
- Classes/interfaces/enums: 0 added, 0 removed.
- Deleted 17 removable accessor calls and the `notInitializedMessage` duplication from both subscription providers.

## Consumer counts (R8)

The production census now contains eleven intentional `try*` calls:

- 5 bootstrap/shutdown calls in the agent package and CLI bootstrap files.
- 2 documented read-only goal-store calls.
- 1 platformless server-side-key call.
- 1 pre-init GitHub environment-token call.
- 1 pre-init fatal/startup logging call.
- 1 deferred polling lifecycle-registration call.

No removable post-init consumer remains.

## Host impact

Extension: settings, subscription preferences, tool toggles, and stop policy now surface an initialization-order bug instead of falling back or dropping a write.

Desktop: the same shared paths now rely on the initialized desktop platform; existing main-view IPC fixtures install the platform seam they exercise.

CLI: provider state, tool toggles, OAuth probes, and harness shutdown use the initialized CLI platform. Bootstrap-only nullable access remains unchanged.

## Scheduled refactoring

None. This completes the remaining #10762 sweep once its G1 dependency lands.

## Validation

- `corepack pnpm typecheck`
- `npm run compile:fast`
- `npm run lint`
- `npm test` — 874 files passed, 1 skipped; 10,672 tests passed, 5 skipped
- Focused configuration/auth/tool/latexdiff suites — 10 files, 65 tests passed
- Updated CLI-init and desktop-main-view fixtures — 2 files, 31 tests passed
- `git diff --check`
- R8 grep for `tryPlatform()` / `tryGlobalState()` / `tryWorkspaceState()`
