### PR TITLE
fix(usage): tag SuperGrok subscription logs as grok

### DIFF
--- a/src/test-kernel/telemetry/UsageLogService.vitest.ts
+++ b/src/test-kernel/telemetry/UsageLogService.vitest.ts
@@ -415,6 +415,7 @@ describe('UsageLogService', () => {
     it.each([
       'relay',
       'chatgpt-subscription',
+      'xai-subscription',
       'kimi-code-subscription',
       'glm-coding-plan-subscription',
     ] as const)(

--- a/supabase/functions/log-usage/usageValidation.ts
+++ b/supabase/functions/log-usage/usageValidation.ts
@@ -74,7 +74,8 @@ export function subscriptionSourceForUsage(
     case 'glm-coding-plan-subscription':
       return entry.subscriptionSource ?? 'glm';
     case 'xai-subscription':
-      return entry.subscriptionSource ?? 'xai';
+      // Product name, matching chatgpt/kimi/glm — not the provider id `xai`.
+      return entry.subscriptionSource ?? 'grok';
     default:
       return undefined;
   }

--- a/supabase/functions/log-usage/usageValidation_test.ts
+++ b/supabase/functions/log-usage/usageValidation_test.ts
@@ -64,7 +64,7 @@ Deno.test('classifies GLM Coding Plan usage under the GLM source', () => {
   equal(subscriptionSourceForUsage(parsed), 'glm');
 });
 
-Deno.test('classifies Grok usage under the xai subscription source', () => {
+Deno.test('classifies Grok usage under the grok subscription source', () => {
   const parsed = UsageLogEntrySchema.parse({
     ...usageEntry(),
     model: 'grok-5',
@@ -72,7 +72,7 @@ Deno.test('classifies Grok usage under the xai subscription source', () => {
     usageRoute: 'xai-subscription',
   });
 
-  equal(subscriptionSourceForUsage(parsed), 'xai');
+  equal(subscriptionSourceForUsage(parsed), 'grok');
 });
 
 Deno.test('keeps paid usage outside subscription sources', () => {


### PR DESCRIPTION
## Summary

SuperGrok subscription rounds already land in `subscription_usage_logs`, but `log-usage` tagged them as `source = xai` (the provider id). ChatGPT, Kimi Code, and GLM use product names, so a `source = grok` filter never saw those rows.

This writes `xai-subscription` entries as `source = grok`. Existing `xai` rows need a one-time SQL rename on prod (private-infra migration `20260817120000_rename_subscription_source_xai_to_grok.sql`); that is not applied by this PR.

## Issue acceptance gates

No linked issue. SuperGrok subscription usage is visible under `source = grok` in `subscription_usage_logs` / `subscription_usage_by_source`.

## Single source of truth

`subscriptionSourceForUsage` in `supabase/functions/log-usage/usageValidation.ts`.

## Duplication and abstraction budget

None. One default string and its test.

## Net elements (R6)

n/a — not a refactor PR.

## Consumer counts (R8)

n/a — no emit path or export was removed.

## Host impact

Extension: none (edge function only).

Desktop: none.

CLI: none.

## Scheduled refactoring

None. Apply the private-infra SQL on prod after this function deploys so historical `xai` rows match.

## Validation

- `deno test` in `supabase/functions/log-usage` (usageValidation + equivalentCost)
- `npx vitest run src/test-kernel/telemetry/UsageLogService.vitest.ts`