### PR TITLE
feat: add CLI GitHub token setup and flatten usage meters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ All notable changes to this project will be documented in this file.
 
 #### Improvements
 
+- **Subscription usage no longer repeats the same percentages** — plan meters
+  show each window once, without a disclosure header that restates the same
+  5-hour and 7-day figures.
 - **Workflow runs trade the Follow-up chat panel for a Copy button** — the
   panel that started a tool-use chat from a workflow's outputs (agent picker,
   model picker, note box) is gone. In its place the run's header toolbar has a
@@ -95,6 +98,8 @@ All notable changes to this project will be documented in this file.
 
 #### Features
 
+- **`/config` can store a GitHub token** — set, replace, or remove the personal
+  access token used by GitHub subscriptions without leaving the CLI.
 - **`texra agents show` omits access-group tags** — remote agent details no
   longer print visibility labels.
 

--- a/packages/cli/src/chat/tui/forms/ApiKeyEntryForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ApiKeyEntryForm.tsx
@@ -3,7 +3,7 @@
 // local state and is never rendered (BaseTextInput `masked`) or logged.
 
 import { Box, Text, useInput } from 'ink';
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 
 import { COLOR_ERROR } from '@cli/tui/ui/colors';
 import { KeyHints } from '@cli/tui/ui/KeyHints';
@@ -27,12 +27,49 @@ export interface ApiKeyEntryFormProps {
   readonly onCancel: () => void;
 }
 
+export interface CredentialEntryFormProps {
+  readonly title: string;
+  readonly helper?: ReactNode;
+  readonly placeholder: string;
+  readonly savedHint: ReactNode;
+  readonly error?: string;
+  readonly saving?: boolean;
+  readonly onSubmit: (key: string) => void;
+  readonly onCancel: () => void;
+}
+
 export function ApiKeyEntryForm(
   props: ApiKeyEntryFormProps,
 ): React.JSX.Element {
-  const [key, setKey] = useState('');
   const label = providerDisplayName(props.provider);
   const keyUrl = PROVIDER_URLS[props.provider];
+
+  return (
+    <CredentialEntryForm
+      title="Use my own provider API key"
+      helper={
+        <>
+          <Text dimColor>Provider: {label}</Text>
+          {keyUrl ? <Text dimColor>Get a key: {keyUrl}</Text> : null}
+        </>
+      }
+      placeholder="enter your API key (hidden)"
+      savedHint={
+        <>
+          Stored in TeXRA secrets on Enter — or set{' '}
+          {apiKeyEnvName(props.provider)} in your environment.
+        </>
+      }
+      {...props}
+    />
+  );
+}
+
+/** Shared masked credential entry used by provider keys and GitHub tokens. */
+export function CredentialEntryForm(
+  props: CredentialEntryFormProps,
+): React.JSX.Element {
+  const [key, setKey] = useState('');
 
   // BaseTextInput ignores Escape (returns early in its own useInput), so handle
   // it here to back out of key entry. Enter is owned by BaseTextInput's
@@ -44,15 +81,14 @@ export function ApiKeyEntryForm(
   });
 
   return (
-    <FormFrame title="Use my own provider API key" showCloseHint={false}>
-      <Text dimColor>Provider: {label}</Text>
-      {keyUrl ? <Text dimColor>Get a key: {keyUrl}</Text> : null}
+    <FormFrame title={props.title} showCloseHint={false}>
+      {props.helper}
       <Box marginTop={1}>
         <Text>{`${POINTER} `}</Text>
         <BaseTextInput
           value={key}
           masked
-          placeholder="enter your API key (hidden)"
+          placeholder={props.placeholder}
           onChange={setKey}
           onSubmit={(value) => {
             const trimmed = value.trim();
@@ -64,10 +100,7 @@ export function ApiKeyEntryForm(
         {props.error ? (
           <Text color={COLOR_ERROR}>{`${CROSS} ${props.error}`}</Text>
         ) : (
-          <Text dimColor>
-            Stored in TeXRA secrets on Enter — or set{' '}
-            {apiKeyEnvName(props.provider)} in your environment.
-          </Text>
+          <Text dimColor>{props.savedHint}</Text>
         )}
         {props.saving ? <Text dimColor>Saving…</Text> : null}
       </Box>

--- a/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
@@ -3,6 +3,11 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { cliSettingsStores } from '@cli/runtime/settingsStores';
 import { applyCliGitAuthorConfig } from '@cli/runtime/gitAuthor';
 import {
+  loadGitHubTokenStatus,
+  removeGitHubToken,
+  saveGitHubToken,
+} from '@cli/runtime/githubToken';
+import {
   loadProviderApiKeyStatuses,
   saveProviderApiKey,
 } from '@cli/runtime/providerApiKey';
@@ -20,6 +25,11 @@ import { setPreferKimiCode } from '@utils/config/providerConfig';
 import { refreshSubscriptionPreferenceViews } from '../state/codexSubscription';
 import { AgentRosterForm } from './AgentRosterForm';
 import { ConfigForm, type ConfigFormProps } from './ConfigForm';
+import {
+  formatGitHubTokenSummary,
+  GitHubTokenForm,
+  type GitHubTokenStatusView,
+} from './GitHubTokenForm';
 import {
   formatProviderApiKeySummary,
   ProviderApiKeyForm,
@@ -41,6 +51,9 @@ export interface CreateCliConfigFormPropsInput extends CliConfigFormProps {
   readonly apiKeyStatusView?: ProviderApiKeyStatusView;
   readonly markProviderApiKeySet?: (provider: ApiProvider) => void;
   readonly refreshApiKeyStatuses?: () => void | Promise<void>;
+  readonly githubTokenStatusView?: GitHubTokenStatusView;
+  readonly markGitHubTokenSet?: () => void;
+  readonly refreshGitHubTokenStatus?: () => void | Promise<void>;
 }
 
 /**
@@ -59,6 +72,11 @@ const INITIAL_API_KEY_STATUS_VIEW: ProviderApiKeyStatusView = {
   error: false,
 };
 
+const INITIAL_GITHUB_TOKEN_STATUS_VIEW: GitHubTokenStatusView = {
+  loading: true,
+  error: false,
+};
+
 /**
  * Construct the canonical CLI configuration interface. Both the standalone
  * command and the in-chat form use this function, so persistence and runtime
@@ -70,6 +88,8 @@ export function createCliConfigFormProps(
   const { stores } = props;
   const apiKeyStatusView =
     props.apiKeyStatusView ?? INITIAL_API_KEY_STATUS_VIEW;
+  const githubTokenStatusView =
+    props.githubTokenStatusView ?? INITIAL_GITHUB_TOKEN_STATUS_VIEW;
   return {
     availableRows: props.availableRows,
     entries: CLI_STATE_SETTINGS,
@@ -108,6 +128,11 @@ export function createCliConfigFormProps(
         label: 'API keys',
         description: formatProviderApiKeySummary(apiKeyStatusView),
       },
+      {
+        name: 'github-token',
+        label: 'GitHub token',
+        description: formatGitHubTokenSummary(githubTokenStatusView),
+      },
     ],
     formRenderers: {
       agents: (onBack) => (
@@ -131,6 +156,23 @@ export function createCliConfigFormProps(
           onCancel={onBack}
         />
       ),
+      'github-token': (onBack) => (
+        <GitHubTokenForm
+          availableRows={props.availableRows}
+          statusView={githubTokenStatusView}
+          onSave={async (token) => {
+            await saveGitHubToken(token);
+            props.markGitHubTokenSet?.();
+            await props.refreshGitHubTokenStatus?.();
+          }}
+          onRemove={async () => {
+            await removeGitHubToken();
+            await props.refreshGitHubTokenStatus?.();
+          }}
+          onDone={onBack}
+          onCancel={onBack}
+        />
+      ),
       tools: (onBack) => (
         <ToolsListForm availableRows={props.availableRows} onClose={onBack} />
       ),
@@ -146,8 +188,11 @@ export function CliConfigForm(props: CliConfigFormProps): React.JSX.Element {
   const [stores] = useState(() => props.stores ?? cliSettingsStores());
   const [apiKeyStatusView, setApiKeyStatusView] =
     useState<ProviderApiKeyStatusView>(INITIAL_API_KEY_STATUS_VIEW);
+  const [githubTokenStatusView, setGitHubTokenStatusView] =
+    useState<GitHubTokenStatusView>(INITIAL_GITHUB_TOKEN_STATUS_VIEW);
   const mounted = useRef(false);
   const requestSequence = useRef(0);
+  const githubTokenRequestSequence = useRef(0);
   const onError = useRef(props.onError);
   onError.current = props.onError;
 
@@ -155,6 +200,15 @@ export function CliConfigForm(props: CliConfigFormProps): React.JSX.Element {
     if (!mounted.current) return;
     setApiKeyStatusView((current) => ({
       statuses: { ...current.statuses, [provider]: 'set' },
+      loading: current.loading,
+      error: false,
+    }));
+  }, []);
+
+  const markGitHubTokenSet = useCallback(() => {
+    if (!mounted.current) return;
+    setGitHubTokenStatusView((current) => ({
+      status: 'secret',
       loading: current.loading,
       error: false,
     }));
@@ -184,14 +238,44 @@ export function CliConfigForm(props: CliConfigFormProps): React.JSX.Element {
     }
   }, []);
 
+  const refreshGitHubTokenStatus = useCallback(async () => {
+    const request = ++githubTokenRequestSequence.current;
+    if (mounted.current) {
+      setGitHubTokenStatusView((current) => ({
+        ...current,
+        loading: true,
+        error: false,
+      }));
+    }
+    try {
+      const status = await loadGitHubTokenStatus();
+      if (!mounted.current || request !== githubTokenRequestSequence.current) {
+        return;
+      }
+      setGitHubTokenStatusView({ status, loading: false, error: false });
+    } catch (error: unknown) {
+      if (!mounted.current || request !== githubTokenRequestSequence.current) {
+        return;
+      }
+      setGitHubTokenStatusView((current) => ({
+        ...current,
+        loading: false,
+        error: true,
+      }));
+      onError.current?.(error);
+    }
+  }, []);
+
   useEffect(() => {
     mounted.current = true;
     void refreshApiKeyStatuses();
+    void refreshGitHubTokenStatus();
     return () => {
       mounted.current = false;
       requestSequence.current += 1;
+      githubTokenRequestSequence.current += 1;
     };
-  }, [refreshApiKeyStatuses]);
+  }, [refreshApiKeyStatuses, refreshGitHubTokenStatus]);
 
   return (
     <ConfigForm
@@ -201,6 +285,9 @@ export function CliConfigForm(props: CliConfigFormProps): React.JSX.Element {
         apiKeyStatusView,
         markProviderApiKeySet,
         refreshApiKeyStatuses,
+        githubTokenStatusView,
+        markGitHubTokenSet,
+        refreshGitHubTokenStatus,
       })}
     />
   );

--- a/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
@@ -67,15 +67,15 @@ const MODEL_ROUTING_SETTING_KEYS: ReadonlySet<string> = new Set([
   GlobalStateKey.GLM_CODING_PLAN,
 ]);
 
-const INITIAL_API_KEY_STATUS_VIEW: ProviderApiKeyStatusView = {
+const INITIAL_API_KEY_STATUS_VIEW: ProviderApiKeyStatusView = Object.freeze({
   loading: true,
   error: false,
-};
+} as const);
 
-const INITIAL_GITHUB_TOKEN_STATUS_VIEW: GitHubTokenStatusView = {
+const INITIAL_GITHUB_TOKEN_STATUS_VIEW: GitHubTokenStatusView = Object.freeze({
   loading: true,
   error: false,
-};
+} as const);
 
 /**
  * Construct the canonical CLI configuration interface. Both the standalone

--- a/packages/cli/src/chat/tui/forms/GitHubTokenForm.tsx
+++ b/packages/cli/src/chat/tui/forms/GitHubTokenForm.tsx
@@ -130,6 +130,7 @@ export function GitHubTokenForm(
       action="select"
       escapeAction="back"
       onSelect={(action) => {
+        if (saving) return;
         setError(undefined);
         if (action === 'set') {
           setEntering(true);

--- a/packages/cli/src/chat/tui/forms/GitHubTokenForm.tsx
+++ b/packages/cli/src/chat/tui/forms/GitHubTokenForm.tsx
@@ -1,16 +1,14 @@
-import { Box, Text, useInput } from 'ink';
+import { Text } from 'ink';
 import { useState } from 'react';
 
 import { tryOpenBrowser } from '@cli/runtime/browser';
 import type { GitHubTokenStatus } from '@cli/runtime/githubToken';
 import { COLOR_ERROR } from '@cli/tui/ui/colors';
-import { KeyHints } from '@cli/tui/ui/KeyHints';
-import { CROSS, POINTER } from '@cli/tui/ui/glyphs';
+import { CROSS } from '@cli/tui/ui/glyphs';
 import { GITHUB_TOKEN_CREATE_URL } from '@tools/github/githubAuth';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-import { BaseTextInput } from '../input/BaseTextInput';
-import { FormFrame } from './_shared/FormFrame';
+import { CredentialEntryForm } from './ApiKeyEntryForm';
 import { ListForm } from './_shared/ListForm';
 
 export interface GitHubTokenStatusView {
@@ -116,7 +114,7 @@ export function GitHubTokenForm(
       description={
         <Text dimColor>
           {formatGitHubTokenSummary({
-            status,
+            status: props.statusView?.status,
             loading: props.statusView?.loading ?? false,
             error: props.statusView?.error ?? false,
           })}
@@ -165,47 +163,13 @@ function GitHubTokenEntryForm(props: {
   readonly onSubmit: (token: string) => void;
   readonly onCancel: () => void;
 }): React.JSX.Element {
-  const [token, setToken] = useState('');
-
-  useInput((_input, k) => {
-    if (k.escape && !props.saving) props.onCancel();
-  });
-
   return (
-    <FormFrame title="Set GitHub token" showCloseHint={false}>
-      <Text dimColor>Get a token: {GITHUB_TOKEN_CREATE_URL}</Text>
-      <Box marginTop={1}>
-        <Text>{`${POINTER} `}</Text>
-        <BaseTextInput
-          value={token}
-          masked
-          placeholder="enter your GitHub token (hidden)"
-          onChange={setToken}
-          onSubmit={(value) => {
-            const trimmed = value.trim();
-            if (trimmed && !props.saving) props.onSubmit(trimmed);
-          }}
-        />
-      </Box>
-      <Box marginTop={1} flexDirection="column">
-        {props.error ? (
-          <Text color={COLOR_ERROR}>{`${CROSS} ${props.error}`}</Text>
-        ) : (
-          <Text dimColor>
-            Stored in TeXRA secrets on Enter — or set GH_TOKEN / GITHUB_TOKEN.
-          </Text>
-        )}
-        {props.saving ? <Text dimColor>Saving…</Text> : null}
-      </Box>
-      <Box marginTop={1}>
-        <KeyHints
-          hints={[
-            { key: 'Enter', action: 'save' },
-            { key: 'Esc', action: 'back' },
-          ]}
-          confirmCancel={false}
-        />
-      </Box>
-    </FormFrame>
+    <CredentialEntryForm
+      title="Set GitHub token"
+      helper={<Text dimColor>Get a token: {GITHUB_TOKEN_CREATE_URL}</Text>}
+      placeholder="enter your GitHub token (hidden)"
+      savedHint="Stored in TeXRA secrets on Enter — or set GH_TOKEN / GITHUB_TOKEN."
+      {...props}
+    />
   );
 }

--- a/packages/cli/src/chat/tui/forms/GitHubTokenForm.tsx
+++ b/packages/cli/src/chat/tui/forms/GitHubTokenForm.tsx
@@ -1,0 +1,211 @@
+import { Box, Text, useInput } from 'ink';
+import { useState } from 'react';
+
+import { tryOpenBrowser } from '@cli/runtime/browser';
+import type { GitHubTokenStatus } from '@cli/runtime/githubToken';
+import { COLOR_ERROR } from '@cli/tui/ui/colors';
+import { KeyHints } from '@cli/tui/ui/KeyHints';
+import { CROSS, POINTER } from '@cli/tui/ui/glyphs';
+import { GITHUB_TOKEN_CREATE_URL } from '@tools/github/githubAuth';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+
+import { BaseTextInput } from '../input/BaseTextInput';
+import { FormFrame } from './_shared/FormFrame';
+import { ListForm } from './_shared/ListForm';
+
+export interface GitHubTokenStatusView {
+  readonly status?: GitHubTokenStatus;
+  readonly loading: boolean;
+  readonly error: boolean;
+}
+
+type GitHubTokenAction = 'set' | 'remove' | 'open-url';
+
+export function formatGitHubTokenSummary(view: GitHubTokenStatusView): string {
+  if (!view.status) {
+    if (view.loading && !view.error) return 'Checking token';
+    return 'Status unavailable';
+  }
+  let label = 'Not set';
+  if (view.status === 'secret') label = 'Token set';
+  else if (view.status === 'env') label = 'From GH_TOKEN / GITHUB_TOKEN';
+  if (view.error) return `${label} · status unavailable`;
+  return view.loading ? `${label} · refreshing` : label;
+}
+
+function buildGitHubTokenActionItems(status: GitHubTokenStatus) {
+  const items: Array<{
+    value: GitHubTokenAction;
+    label: string;
+    description?: string;
+  }> = [
+    {
+      value: 'set',
+      label: status === 'secret' ? 'Replace token' : 'Set token',
+      description: 'stored in TeXRA secrets',
+    },
+  ];
+  if (status === 'secret') {
+    items.push({
+      value: 'remove',
+      label: 'Remove token',
+      description: 'forget the stored token',
+    });
+  }
+  items.push({
+    value: 'open-url',
+    label: 'Create on GitHub…',
+    description: 'repo scope pre-selected',
+  });
+  return items;
+}
+
+function statusHint(status: GitHubTokenStatus | undefined): string {
+  if (status === 'env') {
+    return 'A token is already available from GH_TOKEN or GITHUB_TOKEN. Setting one here overrides it.';
+  }
+  return 'Needs repo for private repos, public_repo for public. Or export GH_TOKEN / GITHUB_TOKEN.';
+}
+
+export interface GitHubTokenFormProps {
+  readonly availableRows?: number;
+  readonly statusView?: GitHubTokenStatusView;
+  readonly onSave: (token: string) => Promise<void>;
+  readonly onRemove: () => Promise<void>;
+  readonly onDone: () => void;
+  readonly onCancel: () => void;
+}
+
+/** Masked GitHub PAT entry and status, kept inside the CLI process. */
+export function GitHubTokenForm(
+  props: GitHubTokenFormProps,
+): React.JSX.Element {
+  const [entering, setEntering] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string>();
+
+  if (entering) {
+    return (
+      <GitHubTokenEntryForm
+        error={error}
+        saving={saving}
+        onCancel={() => {
+          setError(undefined);
+          setEntering(false);
+        }}
+        onSubmit={(token) => {
+          setSaving(true);
+          void props
+            .onSave(token)
+            .then(() => props.onDone())
+            .catch((saveError: unknown) => {
+              setSaving(false);
+              setError(toErrorMessage(saveError));
+            });
+        }}
+      />
+    );
+  }
+
+  const status = props.statusView?.status ?? 'none';
+  return (
+    <ListForm
+      title="GitHub token"
+      availableRows={props.availableRows}
+      items={buildGitHubTokenActionItems(status)}
+      description={
+        <Text dimColor>
+          {formatGitHubTokenSummary({
+            status,
+            loading: props.statusView?.loading ?? false,
+            error: props.statusView?.error ?? false,
+          })}
+          {'. '}
+          {statusHint(props.statusView?.status)}
+        </Text>
+      }
+      detail={
+        error ? (
+          <Text color={COLOR_ERROR}>{`${CROSS} ${error}`}</Text>
+        ) : undefined
+      }
+      action="select"
+      escapeAction="back"
+      onSelect={(action) => {
+        setError(undefined);
+        if (action === 'set') {
+          setEntering(true);
+          return;
+        }
+        if (action === 'remove') {
+          setSaving(true);
+          void props
+            .onRemove()
+            .then(() => props.onDone())
+            .catch((removeError: unknown) => {
+              setSaving(false);
+              setError(toErrorMessage(removeError));
+            });
+          return;
+        }
+        void tryOpenBrowser(GITHUB_TOKEN_CREATE_URL).then((opened) => {
+          if (!opened) {
+            setError(`Open ${GITHUB_TOKEN_CREATE_URL} to create a token.`);
+          }
+        });
+      }}
+      onCancel={props.onCancel}
+    />
+  );
+}
+
+function GitHubTokenEntryForm(props: {
+  readonly error?: string;
+  readonly saving?: boolean;
+  readonly onSubmit: (token: string) => void;
+  readonly onCancel: () => void;
+}): React.JSX.Element {
+  const [token, setToken] = useState('');
+
+  useInput((_input, k) => {
+    if (k.escape && !props.saving) props.onCancel();
+  });
+
+  return (
+    <FormFrame title="Set GitHub token" showCloseHint={false}>
+      <Text dimColor>Get a token: {GITHUB_TOKEN_CREATE_URL}</Text>
+      <Box marginTop={1}>
+        <Text>{`${POINTER} `}</Text>
+        <BaseTextInput
+          value={token}
+          masked
+          placeholder="enter your GitHub token (hidden)"
+          onChange={setToken}
+          onSubmit={(value) => {
+            const trimmed = value.trim();
+            if (trimmed && !props.saving) props.onSubmit(trimmed);
+          }}
+        />
+      </Box>
+      <Box marginTop={1} flexDirection="column">
+        {props.error ? (
+          <Text color={COLOR_ERROR}>{`${CROSS} ${props.error}`}</Text>
+        ) : (
+          <Text dimColor>
+            Stored in TeXRA secrets on Enter — or set GH_TOKEN / GITHUB_TOKEN.
+          </Text>
+        )}
+        {props.saving ? <Text dimColor>Saving…</Text> : null}
+      </Box>
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: 'Enter', action: 'save' },
+            { key: 'Esc', action: 'back' },
+          ]}
+          confirmCancel={false}
+        />
+      </Box>
+    </FormFrame>
+  );
+}

--- a/packages/cli/src/chat/tui/forms/GitHubTokenForm.tsx
+++ b/packages/cli/src/chat/tui/forms/GitHubTokenForm.tsx
@@ -127,6 +127,12 @@ export function GitHubTokenForm(
           <Text color={COLOR_ERROR}>{`${CROSS} ${error}`}</Text>
         ) : undefined
       }
+      detailRows={error ? 1 : 0}
+      compactDetail={
+        error ? (
+          <Text color={COLOR_ERROR}>{`${CROSS} ${error}`}</Text>
+        ) : undefined
+      }
       action="select"
       escapeAction="back"
       onSelect={(action) => {

--- a/packages/cli/src/runtime/credentialInput.ts
+++ b/packages/cli/src/runtime/credentialInput.ts
@@ -6,7 +6,7 @@ const PROVIDER_PLACEHOLDER_PATTERNS: readonly RegExp[] = [
 ];
 
 const GITHUB_PLACEHOLDER_PATTERNS: readonly RegExp[] = [
-  /^(?:sk-?)?(?:x{3,}|\*{3,}|\.{3,}|<.*>|your[- _]?.*)$/i,
+  /^(?:sk-?)?(?:x{3,}|\*{3,}|\.{3,}|<.*>|your[- _]?.*)/i,
   /^(?:(?:api|github)[- _]?)?(?:key|token)[- _]?here$/i,
   /^placeholder$/i,
   /^example$/i,

--- a/packages/cli/src/runtime/credentialInput.ts
+++ b/packages/cli/src/runtime/credentialInput.ts
@@ -6,7 +6,8 @@ const PROVIDER_PLACEHOLDER_PATTERNS: readonly RegExp[] = [
 ];
 
 const GITHUB_PLACEHOLDER_PATTERNS: readonly RegExp[] = [
-  /^(?:sk-?)?(?:x{3,}|\*{3,}|\.{3,}|<.*>|your[- _]?.*)/i,
+  /^(?:(?:gh[pousr]_|github_pat_)|sk-?)?(?:x{3,}|\*{3,}|\.{3,}|<.*>|your[- _]?.*)/i,
+  /^\[.*(?:redacted|github[- _]?token).*\]/i,
   /^(?:(?:api|github)[- _]?)?(?:key|token)[- _]?here$/i,
   /^placeholder$/i,
   /^example$/i,

--- a/packages/cli/src/runtime/credentialInput.ts
+++ b/packages/cli/src/runtime/credentialInput.ts
@@ -1,0 +1,14 @@
+const PLACEHOLDER_PATTERNS: readonly RegExp[] = [
+  /^(?:sk-?)?(?:x{3,}|\*{3,}|\.{3,}|<.*>|your[- _]?.*)$/i,
+  /^(?:(?:api|github)[- _]?)?(?:key|token)[- _]?here$/i,
+  /^placeholder$/i,
+  /^example$/i,
+];
+
+/** Reject common masked/example values before they enter the secret store. */
+export function looksLikeCredentialPlaceholder(value: string): boolean {
+  return (
+    value.length < 8 ||
+    PLACEHOLDER_PATTERNS.some((pattern) => pattern.test(value))
+  );
+}

--- a/packages/cli/src/runtime/credentialInput.ts
+++ b/packages/cli/src/runtime/credentialInput.ts
@@ -1,4 +1,11 @@
-const PLACEHOLDER_PATTERNS: readonly RegExp[] = [
+const PROVIDER_PLACEHOLDER_PATTERNS: readonly RegExp[] = [
+  /^(sk-?)?(x{3,}|\*{3,}|\.{3,}|<.*>|your[- _]?(?:api[- _]?)?key)/i,
+  /^(?:api[- _]?)?key[- _]?here$/i,
+  /^placeholder$/i,
+  /^example$/i,
+];
+
+const GITHUB_PLACEHOLDER_PATTERNS: readonly RegExp[] = [
   /^(?:sk-?)?(?:x{3,}|\*{3,}|\.{3,}|<.*>|your[- _]?.*)$/i,
   /^(?:(?:api|github)[- _]?)?(?:key|token)[- _]?here$/i,
   /^placeholder$/i,
@@ -6,9 +13,13 @@ const PLACEHOLDER_PATTERNS: readonly RegExp[] = [
 ];
 
 /** Reject common masked/example values before they enter the secret store. */
-export function looksLikeCredentialPlaceholder(value: string): boolean {
-  return (
-    value.length < 8 ||
-    PLACEHOLDER_PATTERNS.some((pattern) => pattern.test(value))
-  );
+export function looksLikeCredentialPlaceholder(
+  value: string,
+  kind: 'provider' | 'github' = 'provider',
+): boolean {
+  const patterns =
+    kind === 'github'
+      ? GITHUB_PLACEHOLDER_PATTERNS
+      : PROVIDER_PLACEHOLDER_PATTERNS;
+  return value.length < 8 || patterns.some((pattern) => pattern.test(value));
 }

--- a/packages/cli/src/runtime/githubToken.ts
+++ b/packages/cli/src/runtime/githubToken.ts
@@ -15,7 +15,7 @@ export function loadGitHubTokenStatus(): Promise<GitHubTokenStatus> {
 export async function saveGitHubToken(token: string): Promise<void> {
   const trimmed = token.trim();
   if (!trimmed) throw new Error('GitHub token is empty.');
-  if (looksLikeCredentialPlaceholder(trimmed)) {
+  if (looksLikeCredentialPlaceholder(trimmed, 'github')) {
     throw new Error(
       'This looks like a placeholder rather than a GitHub token. Enter a personal access token from GitHub.',
     );

--- a/packages/cli/src/runtime/githubToken.ts
+++ b/packages/cli/src/runtime/githubToken.ts
@@ -1,0 +1,28 @@
+import { platform } from '@platform/platform';
+import {
+  GITHUB_TOKEN_STORAGE_KEY,
+  resolveGitHubTokenSource,
+} from '@tools/github/githubAuth';
+import { looksLikeCredentialPlaceholder } from './credentialInput';
+
+export type GitHubTokenStatus = 'secret' | 'env' | 'none';
+
+export function loadGitHubTokenStatus(): Promise<GitHubTokenStatus> {
+  return resolveGitHubTokenSource(platform().secrets);
+}
+
+/** Persist a GitHub PAT without exposing it outside the credential store. */
+export async function saveGitHubToken(token: string): Promise<void> {
+  const trimmed = token.trim();
+  if (!trimmed) throw new Error('GitHub token is empty.');
+  if (looksLikeCredentialPlaceholder(trimmed)) {
+    throw new Error(
+      'This looks like a placeholder rather than a GitHub token. Enter a personal access token from GitHub.',
+    );
+  }
+  await platform().secrets.set(GITHUB_TOKEN_STORAGE_KEY, trimmed);
+}
+
+export async function removeGitHubToken(): Promise<void> {
+  await platform().secrets.delete(GITHUB_TOKEN_STORAGE_KEY);
+}

--- a/packages/cli/src/runtime/providerApiKey.ts
+++ b/packages/cli/src/runtime/providerApiKey.ts
@@ -7,24 +7,12 @@ import {
   type ApiProvider,
 } from '@model/apiProviders';
 import { platform } from '@platform/platform';
+import { looksLikeCredentialPlaceholder } from './credentialInput';
 
 export function loadProviderApiKeyStatuses(): Promise<
   Record<ApiProvider, ApiKeyStatus>
 > {
   return loadApiKeyStatusMap(platform().secrets, API_PROVIDERS);
-}
-
-const PLACEHOLDER_PATTERNS: readonly RegExp[] = [
-  /^(sk-?)?(x{3,}|\*{3,}|\.{3,}|<.*>|your[- _]?(?:api[- _]?)?key)/i,
-  /^(?:api[- _]?)?key[- _]?here$/i,
-  /^placeholder$/i,
-  /^example$/i,
-];
-
-function looksLikePlaceholder(key: string): boolean {
-  return (
-    key.length < 8 || PLACEHOLDER_PATTERNS.some((pattern) => pattern.test(key))
-  );
 }
 
 /** Persist a provider key without exposing it outside the credential store. */
@@ -34,7 +22,7 @@ export async function saveProviderApiKey(
 ): Promise<void> {
   const trimmed = key.trim();
   if (!trimmed) throw new Error('API key is empty.');
-  if (looksLikePlaceholder(trimmed)) {
+  if (looksLikeCredentialPlaceholder(trimmed)) {
     throw new Error(
       `This looks like a placeholder rather than a ${provider} API key. Enter the key issued by the provider.`,
     );

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -2,7 +2,6 @@ import type { SessionHandle } from '@agent/runtime';
 import { formatError } from '@common/errors';
 import { SettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
 import {
-  GITHUB_TOKEN_CREATE_URL,
   listGitHubSubscriptionEntries,
   unsubscribeGitHubKey,
 } from '@controllers/settingsView/githubSubscriptions';
@@ -29,6 +28,7 @@ import { buildReliabilityAndOrchestrationMessage } from '@shared/settingsView/ha
 import type { SettingsStatePorts } from '@shared/settingsView/types';
 import { GoalStore, subscribeGoalStateChanges } from '@tools/goal';
 import {
+  GITHUB_TOKEN_CREATE_URL,
   GITHUB_TOKEN_STORAGE_KEY,
   resolveGitHubTokenSource,
 } from '@tools/github/githubAuth';

--- a/packages/extension/src/settingsView/frontend/components/profile/SubscriptionUsageRow.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/SubscriptionUsageRow.ts
@@ -77,6 +77,10 @@ export class SubscriptionUsageRow extends LitElement {
         font-variant-numeric: tabular-nums;
       }
 
+      .usage-plan {
+        font-weight: 600;
+      }
+
       .usage-updated,
       .usage-unavailable-detail {
         color: var(--vscode-descriptionForeground);
@@ -116,6 +120,7 @@ export class SubscriptionUsageRow extends LitElement {
       <div class="settings-row subscription-usage-row">
         <div class="settings-row-text">
           <div class="usage-card">
+            <span class="usage-plan">${snapshot.planName} usage</span>
             ${snapshot.windows.map((window) => {
               const label = subscriptionUsageWindowLabel(window);
               const percent = formatSubscriptionUsagePercent(

--- a/packages/extension/src/settingsView/frontend/components/profile/SubscriptionUsageRow.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/SubscriptionUsageRow.ts
@@ -50,9 +50,12 @@ export class SubscriptionUsageRow extends LitElement {
         min-width: 0;
       }
 
-      .usage-facts {
+      .usage-card {
         display: grid;
         gap: 0.4rem;
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
+        background-color: var(--wa-color-surface-lowered, transparent);
+        border-radius: var(--wa-border-radius-m, 0.5rem);
       }
 
       .usage-window {
@@ -109,46 +112,35 @@ export class SubscriptionUsageRow extends LitElement {
       `;
     }
 
-    const summary = snapshot.windows
-      .map(
-        (window) =>
-          `${subscriptionUsageWindowLabel(window)}: ${formatSubscriptionUsagePercent(window.percentUsed)}`,
-      )
-      .join(' · ');
     return html`
       <div class="settings-row subscription-usage-row">
         <div class="settings-row-text">
-          <wa-details
-            class="panel-collapsible"
-            summary="${snapshot.planName} usage · ${summary}"
-          >
-            <div class="usage-facts">
-              ${snapshot.windows.map((window) => {
-                const label = subscriptionUsageWindowLabel(window);
-                const percent = formatSubscriptionUsagePercent(
-                  window.percentUsed,
-                );
-                const reset = formatSubscriptionUsageReset(
-                  window.resetAt,
-                  this.now,
-                );
-                return html`
-                  <div class="usage-window">
-                    <span>${label}: ${percent}</span>
-                    <progress
-                      max="100"
-                      value=${window.percentUsed}
-                      aria-label="${snapshot.providerName} ${label} usage: ${percent} used"
-                    ></progress>
-                    <span>${reset ?? ''}</span>
-                  </div>
-                `;
-              })}
-              <span class="usage-updated">
-                ${formatSubscriptionUsageUpdated(snapshot.fetchedAt, this.now)}
-              </span>
-            </div>
-          </wa-details>
+          <div class="usage-card">
+            ${snapshot.windows.map((window) => {
+              const label = subscriptionUsageWindowLabel(window);
+              const percent = formatSubscriptionUsagePercent(
+                window.percentUsed,
+              );
+              const reset = formatSubscriptionUsageReset(
+                window.resetAt,
+                this.now,
+              );
+              return html`
+                <div class="usage-window">
+                  <span>${label}: ${percent}</span>
+                  <progress
+                    max="100"
+                    value=${window.percentUsed}
+                    aria-label="${snapshot.providerName} ${label} usage: ${percent} used"
+                  ></progress>
+                  <span>${reset ?? ''}</span>
+                </div>
+              `;
+            })}
+            <span class="usage-updated">
+              ${formatSubscriptionUsageUpdated(snapshot.fetchedAt, this.now)}
+            </span>
+          </div>
         </div>
       </div>
     `;

--- a/packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts
@@ -8,7 +8,6 @@
 import * as vscode from 'vscode';
 
 import {
-  GITHUB_TOKEN_CREATE_URL,
   listGitHubSubscriptionEntries,
   unsubscribeGitHubKey,
 } from '@controllers/settingsView/githubSubscriptions';
@@ -21,7 +20,10 @@ import {
 } from '@progressView/progressNavigation';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { SETTINGS_VIEW_CMD, type SettingsMessageFor } from '@shared/schemas';
-import { GITHUB_TOKEN_STORAGE_KEY } from '@tools/github/githubAuth';
+import {
+  GITHUB_TOKEN_CREATE_URL,
+  GITHUB_TOKEN_STORAGE_KEY,
+} from '@tools/github/githubAuth';
 import {
   withHandlerErrorHandling,
   type SettingsHandlerContext,

--- a/src/controllers/settingsView/githubSubscriptions.ts
+++ b/src/controllers/settingsView/githubSubscriptions.ts
@@ -8,14 +8,6 @@ import {
   repoSubscriptionRegistry,
 } from '@tools/github/subscriptionBindings';
 
-/**
- * GitHub "new personal access token" page, pre-filled with the description and
- * scope the subscription poller needs. Opened verbatim by the extension and
- * desktop Git tabs, so the query string (notably `scopes`) lives here once.
- */
-export const GITHUB_TOKEN_CREATE_URL =
-  'https://github.com/settings/tokens/new?description=TeXRA%20PR%20subscription&scopes=repo';
-
 interface GitHubSubscriptionOwner {
   readonly streamId: string;
   readonly label: string;

--- a/src/test-kernel/cli/ConfigForm.vitest.ts
+++ b/src/test-kernel/cli/ConfigForm.vitest.ts
@@ -76,6 +76,11 @@ const providerApiKeyRuntime = vi.hoisted(() => ({
   load: vi.fn(),
   save: vi.fn(),
 }));
+const githubTokenRuntime = vi.hoisted(() => ({
+  load: vi.fn(),
+  save: vi.fn(),
+  remove: vi.fn(),
+}));
 
 vi.mock('@model/computeModelOptions', () => ({
   invalidateModelOptionsCache,
@@ -83,6 +88,11 @@ vi.mock('@model/computeModelOptions', () => ({
 vi.mock('@cli/runtime/providerApiKey', () => ({
   loadProviderApiKeyStatuses: providerApiKeyRuntime.load,
   saveProviderApiKey: providerApiKeyRuntime.save,
+}));
+vi.mock('@cli/runtime/githubToken', () => ({
+  loadGitHubTokenStatus: githubTokenRuntime.load,
+  saveGitHubToken: githubTokenRuntime.save,
+  removeGitHubToken: githubTokenRuntime.remove,
 }));
 
 function apiKeyStatuses(
@@ -102,6 +112,12 @@ beforeEach(() => {
   providerApiKeyRuntime.load.mockResolvedValue(apiKeyStatuses());
   providerApiKeyRuntime.save.mockReset();
   providerApiKeyRuntime.save.mockResolvedValue(undefined);
+  githubTokenRuntime.load.mockReset();
+  githubTokenRuntime.load.mockResolvedValue('none');
+  githubTokenRuntime.save.mockReset();
+  githubTokenRuntime.save.mockResolvedValue(undefined);
+  githubTokenRuntime.remove.mockReset();
+  githubTokenRuntime.remove.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -145,6 +161,19 @@ async function submitOpenAiApiKey(
   stdin.write('1');
   await waitFor(() => stdout.output.includes('Use my own provider API key'));
   stdin.write(key);
+  stdin.write('\r');
+}
+
+async function submitGitHubToken(
+  stdin: FakeStdin,
+  stdout: FakeStdout,
+  token = 'ghp_private-test-token',
+): Promise<void> {
+  stdin.write('3');
+  await waitFor(() => stdout.output.includes('Set token'));
+  stdin.write('1');
+  await waitFor(() => stdout.output.includes('Set GitHub token'));
+  stdin.write(token);
   stdin.write('\r');
 }
 
@@ -593,6 +622,27 @@ describe('CliConfigForm API-key status lifecycle', () => {
     await sleep(20);
     expect(stripAnsi(rendered.stdout.output)).toBe('');
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('saves a GitHub token from /config without rendering the secret', async () => {
+    githubTokenRuntime.load
+      .mockResolvedValueOnce('none')
+      .mockResolvedValueOnce('secret');
+    const rendered = await renderCliConfigForm();
+
+    try {
+      await waitFor(() => rendered.stdout.output.includes('GitHub token'));
+      rendered.stdout.output = '';
+      await submitGitHubToken(rendered.stdin, rendered.stdout);
+      await waitFor(() => githubTokenRuntime.save.mock.calls.length === 1);
+      expect(githubTokenRuntime.save).toHaveBeenCalledWith(
+        'ghp_private-test-token',
+      );
+      expect(rendered.stdout.output).not.toContain('ghp_private-test-token');
+      await waitFor(() => rendered.stdout.output.includes('Token set'));
+    } finally {
+      rendered.instance.unmount();
+    }
   });
 
   it('uses the same status-aware form in standalone config and /config', async () => {

--- a/src/test-kernel/cli/SaveProviderApiKey.vitest.ts
+++ b/src/test-kernel/cli/SaveProviderApiKey.vitest.ts
@@ -37,6 +37,8 @@ describe('saveProviderApiKey', () => {
 
   it.each([
     'sk-xxx',
+    'sk-xxx-123',
+    'xxxabc-secret',
     '<your-key>',
     'your-api-key',
     'your_api_key',

--- a/src/test-kernel/cli/SaveProviderApiKey.vitest.ts
+++ b/src/test-kernel/cli/SaveProviderApiKey.vitest.ts
@@ -86,10 +86,13 @@ describe('saveGitHubToken', () => {
     mocks.set.mockReset().mockResolvedValue(undefined);
   });
 
-  it('rejects a masked prefix even when it has a suffix', async () => {
-    await expect(saveGitHubToken('xxx-not-a-real-token')).rejects.toThrow(
-      'placeholder',
-    );
+  it.each([
+    'xxx-not-a-real-token',
+    'ghp_xxx-not-a-real-token',
+    'github_pat_***-not-a-real-token',
+    '[REDACTED_GITHUB_TOKEN]',
+  ])('rejects the GitHub placeholder %s', async (placeholder) => {
+    await expect(saveGitHubToken(placeholder)).rejects.toThrow('placeholder');
     expect(mocks.set).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/cli/SaveProviderApiKey.vitest.ts
+++ b/src/test-kernel/cli/SaveProviderApiKey.vitest.ts
@@ -15,6 +15,7 @@ vi.mock('@model/apiProviders', async (importOriginal) => {
 });
 
 const { saveProviderApiKey } = await import('@cli/runtime/providerApiKey');
+const { saveGitHubToken } = await import('@cli/runtime/githubToken');
 
 describe('saveProviderApiKey', () => {
   beforeEach(() => {
@@ -77,5 +78,18 @@ describe('saveProviderApiKey', () => {
     await saveProviderApiKey('anthropic', 'sk-ant-secret');
 
     expect(order).toEqual(['set', 'invalidateApiKeyCache']);
+  });
+});
+
+describe('saveGitHubToken', () => {
+  beforeEach(() => {
+    mocks.set.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('rejects a masked prefix even when it has a suffix', async () => {
+    await expect(saveGitHubToken('xxx-not-a-real-token')).rejects.toThrow(
+      'placeholder',
+    );
+    expect(mocks.set).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/settings/SubscriptionUsageRendering.vitest.ts
+++ b/src/test-kernel/settings/SubscriptionUsageRendering.vitest.ts
@@ -124,6 +124,7 @@ describe('subscription usage rendering', () => {
     expect(styleText).toContain('flex: 1 1 100%');
     expect(styleText).toContain('min-width: 0');
     const text = kimiRow!.shadowRoot?.textContent ?? '';
+    expect(text).toContain('Kimi Code plan usage');
     expect(text.split('5-hour: 25%')).toHaveLength(2);
     expect(text.split('7-day: 100%')).toHaveLength(2);
     const meters = kimiRow!.shadowRoot?.querySelectorAll('progress');

--- a/src/test-kernel/settings/SubscriptionUsageRendering.vitest.ts
+++ b/src/test-kernel/settings/SubscriptionUsageRendering.vitest.ts
@@ -91,7 +91,7 @@ describe('subscription usage rendering', () => {
   beforeEach(() => mocks.postMessage.mockClear());
   afterEach(() => vi.useRealTimers());
 
-  it('renders native collapsed summaries, accessible meters, and one refresh action', async () => {
+  it('renders accessible meters and one refresh action', async () => {
     const tab = await mountTab();
 
     expect(mocks.postMessage).toHaveBeenCalledWith(
@@ -113,8 +113,7 @@ describe('subscription usage rendering', () => {
     const kimiRow = getKimiUsageRow(tab);
     expect(kimiRow).not.toBeNull();
     await kimiRow!.updateComplete;
-    const details = kimiRow!.shadowRoot?.querySelector('wa-details');
-    expect(details?.closest('.settings-row-text')).not.toBeNull();
+    expect(kimiRow!.shadowRoot?.querySelector('wa-details')).toBeNull();
     const styleText = (
       kimiRow!.constructor as unknown as {
         styles: readonly { cssText: string }[];
@@ -124,15 +123,15 @@ describe('subscription usage rendering', () => {
       .join('\n');
     expect(styleText).toContain('flex: 1 1 100%');
     expect(styleText).toContain('min-width: 0');
-    expect(details?.getAttribute('summary')).toContain(
-      '5-hour: 25% · 7-day: 100%',
-    );
+    const text = kimiRow!.shadowRoot?.textContent ?? '';
+    expect(text.split('5-hour: 25%')).toHaveLength(2);
+    expect(text.split('7-day: 100%')).toHaveLength(2);
     const meters = kimiRow!.shadowRoot?.querySelectorAll('progress');
     expect(meters).toHaveLength(2);
     expect(meters?.[0]?.getAttribute('aria-label')).toBe(
       'Kimi Code 5-hour usage: 25% used',
     );
-    expect(kimiRow!.shadowRoot?.textContent).toContain('resets in 1d 21h');
+    expect(text).toContain('resets in 1d 21h');
     expect(tab.shadowRoot?.textContent).not.toContain('Grok usage unavailable');
   });
 

--- a/src/test-kernel/telemetry/UsageLogService.vitest.ts
+++ b/src/test-kernel/telemetry/UsageLogService.vitest.ts
@@ -415,6 +415,7 @@ describe('UsageLogService', () => {
     it.each([
       'relay',
       'chatgpt-subscription',
+      'xai-subscription',
       'kimi-code-subscription',
       'glm-coding-plan-subscription',
     ] as const)(

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -475,11 +475,11 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     installGuide:
       'Requires a git-tracked workspace and a GitHub personal access token:\n\n' +
       '  1. Open the folder as a git repo (or `git init` + set a github.com remote).\n' +
-      '  2. In VS Code, TeXRA settings → Git tab can open the token page with the right scopes pre-filled.\n' +
+      '  2. In the CLI, /config → GitHub token can store a token or open the token page with the right scopes pre-filled. In VS Code, use TeXRA settings → Git tab.\n' +
       '  3. Scopes: "repo" for private repositories, "public_repo" for public only.\n' +
       '  4. Store the token in host secret storage, or export GITHUB_TOKEN/GH_TOKEN for CLI and automation.',
     installUrl: 'https://github.com/settings/tokens',
-    configNotes: `Token stored in host secret storage or read from GITHUB_TOKEN/GH_TOKEN. In VS Code, the Git tab manages the stored token. Requires a git repository in the workspace. Polls every ${PR_POLL_INTERVAL_MS / 1000}s; cap: ${MAX_CONCURRENT_PR_SUBSCRIPTIONS} concurrent PRs and ${MAX_CONCURRENT_REPO_SUBSCRIPTIONS} concurrent repos. Bot-authored events are dropped end-to-end by policy.`,
+    configNotes: `Token stored in host secret storage or read from GITHUB_TOKEN/GH_TOKEN. The CLI /config → GitHub token row and the VS Code Git tab both manage the stored token. Requires a git repository in the workspace. Polls every ${PR_POLL_INTERVAL_MS / 1000}s; cap: ${MAX_CONCURRENT_PR_SUBSCRIPTIONS} concurrent PRs and ${MAX_CONCURRENT_REPO_SUBSCRIPTIONS} concurrent repos. Bot-authored events are dropped end-to-end by policy.`,
     authNote: 'Uses personal access token',
     toggleable: true,
     installActionCommand: 'texra.showGitSettings',
@@ -499,10 +499,10 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
           return 'GitHub token detected and workspace is a git repo. Ready to subscribe to PR activity.';
         }
         if (!tokenPresent && !inGitRepo) {
-          return 'Open a git-tracked folder, or run git init and add a github.com remote. Then set a token in the Git tab.';
+          return 'Open a git-tracked folder, or run git init and add a github.com remote. Then set a token in /config → GitHub token or the Git tab.';
         }
         if (!tokenPresent) {
-          return 'This workspace is a git repo. Set a GitHub personal access token in the Git tab to enable PR activity subscriptions.';
+          return 'This workspace is a git repo. Set a GitHub personal access token in /config → GitHub token or the Git tab to enable PR activity subscriptions.';
         }
         return 'GitHub token is set. Open a git-tracked folder, or run git init and add a github.com remote, to use PR activity subscriptions.';
       },

--- a/src/tools/github/githubAuth.ts
+++ b/src/tools/github/githubAuth.ts
@@ -3,7 +3,8 @@
  *
  * Host-neutral: reads from the platform secrets port (each host wires its own
  * secret store) with GitHub environment-variable fallbacks. The token is
- * persisted under `github.token` (set via the Git settings tab or CLI secrets),
+ * persisted under `github.token` (set via the Git settings tab, `/config` →
+ * GitHub token, or CLI secrets),
  * while the conventional env vars are `GH_TOKEN` and `GITHUB_TOKEN`; hence the
  * explicit fallback. Because every host wires `platform().secrets`, GitHub
  * tools work in the CLI and desktop too, not just the extension.
@@ -13,6 +14,13 @@ import type { PlatformSecrets } from '@platform/secrets';
 
 /** SecretStorage key under which the GitHub PAT is persisted. */
 export const GITHUB_TOKEN_STORAGE_KEY = 'github.token';
+
+/**
+ * GitHub "new personal access token" page, pre-filled with the description and
+ * scope the subscription poller needs. Opened verbatim by every host.
+ */
+export const GITHUB_TOKEN_CREATE_URL =
+  'https://github.com/settings/tokens/new?description=TeXRA%20PR%20subscription&scopes=repo';
 
 /** Environment variables accepted by GitHub tools, in precedence order. */
 const GITHUB_TOKEN_ENV_VARS = ['GH_TOKEN', 'GITHUB_TOKEN'] as const;

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -127,7 +127,7 @@ function parsePath(raw: string): ParsedPath {
 async function requireToken(): Promise<void> {
   if (!(await getGitHubToken())) {
     throw new ToolError(
-      'No GitHub token configured. Set one in host settings (VS Code: TeXRA settings → Git tab → "Set token"), or export GITHUB_TOKEN or GH_TOKEN. Needs `repo` scope for private repos, `public_repo` for public.',
+      'No GitHub token configured. In the CLI, open /config → GitHub token. In VS Code, use TeXRA settings → Git tab → "Set token". Or export GITHUB_TOKEN or GH_TOKEN. Needs `repo` scope for private repos, `public_repo` for public.',
     );
   }
 }
@@ -501,7 +501,7 @@ export class GitHubSubscriptionTool extends defineTool({
     '- list: list active subscriptions on this stream.',
     '- find_current: resolve the current git branch to its PR path (returns "owner/repo/pulls/N").',
     'Bot-authored events are dropped end-to-end by policy.',
-    `Caps: ${MAX_CONCURRENT_PR_SUBSCRIPTIONS} concurrent PR subscriptions, ${MAX_CONCURRENT_ISSUE_SUBSCRIPTIONS} concurrent issue subscriptions, ${MAX_CONCURRENT_REPO_SUBSCRIPTIONS} concurrent repo subscriptions per process. Poll interval ≈ ${PR_POLL_INTERVAL_MS / 1000}s. Requires a GitHub token: set it in host settings, or via GITHUB_TOKEN or GH_TOKEN.`,
+    `Caps: ${MAX_CONCURRENT_PR_SUBSCRIPTIONS} concurrent PR subscriptions, ${MAX_CONCURRENT_ISSUE_SUBSCRIPTIONS} concurrent issue subscriptions, ${MAX_CONCURRENT_REPO_SUBSCRIPTIONS} concurrent repo subscriptions per process. Poll interval ≈ ${PR_POLL_INTERVAL_MS / 1000}s. Requires a GitHub token: set it in /config → GitHub token, the VS Code Git tab, or via GITHUB_TOKEN or GH_TOKEN.`,
   ].join(' '),
   schema: GitHubSubscriptionInputSchema,
 }) {

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -501,7 +501,7 @@ export class GitHubSubscriptionTool extends defineTool({
     '- list: list active subscriptions on this stream.',
     '- find_current: resolve the current git branch to its PR path (returns "owner/repo/pulls/N").',
     'Bot-authored events are dropped end-to-end by policy.',
-    `Caps: ${MAX_CONCURRENT_PR_SUBSCRIPTIONS} concurrent PR subscriptions, ${MAX_CONCURRENT_ISSUE_SUBSCRIPTIONS} concurrent issue subscriptions, ${MAX_CONCURRENT_REPO_SUBSCRIPTIONS} concurrent repo subscriptions per process. Poll interval ≈ ${PR_POLL_INTERVAL_MS / 1000}s. Requires a GitHub token: set it in /config → GitHub token, the VS Code Git tab, or via GITHUB_TOKEN or GH_TOKEN.`,
+    `Caps: ${MAX_CONCURRENT_PR_SUBSCRIPTIONS} concurrent PR subscriptions, ${MAX_CONCURRENT_ISSUE_SUBSCRIPTIONS} concurrent issue subscriptions, ${MAX_CONCURRENT_REPO_SUBSCRIPTIONS} concurrent repo subscriptions per process. Poll interval ≈ ${PR_POLL_INTERVAL_MS / 1000}s. Requires a GitHub token: set it via /config → GitHub token (CLI), the settings Git tab (VS Code / desktop), or GITHUB_TOKEN / GH_TOKEN.`,
   ].join(' '),
   schema: GitHubSubscriptionInputSchema,
 }) {

--- a/supabase/functions/log-usage/usageValidation.ts
+++ b/supabase/functions/log-usage/usageValidation.ts
@@ -74,7 +74,8 @@ export function subscriptionSourceForUsage(
     case 'glm-coding-plan-subscription':
       return entry.subscriptionSource ?? 'glm';
     case 'xai-subscription':
-      return entry.subscriptionSource ?? 'xai';
+      // Product name, matching chatgpt/kimi/glm — not the provider id `xai`.
+      return entry.subscriptionSource ?? 'grok';
     default:
       return undefined;
   }

--- a/supabase/functions/log-usage/usageValidation_test.ts
+++ b/supabase/functions/log-usage/usageValidation_test.ts
@@ -64,7 +64,7 @@ Deno.test('classifies GLM Coding Plan usage under the GLM source', () => {
   equal(subscriptionSourceForUsage(parsed), 'glm');
 });
 
-Deno.test('classifies Grok usage under the xai subscription source', () => {
+Deno.test('classifies Grok usage under the grok subscription source', () => {
   const parsed = UsageLogEntrySchema.parse({
     ...usageEntry(),
     model: 'grok-5',
@@ -72,7 +72,7 @@ Deno.test('classifies Grok usage under the xai subscription source', () => {
     usageRoute: 'xai-subscription',
   });
 
-  equal(subscriptionSourceForUsage(parsed), 'xai');
+  equal(subscriptionSourceForUsage(parsed), 'grok');
 });
 
 Deno.test('keeps paid usage outside subscription sources', () => {


### PR DESCRIPTION
## Summary

Two settings fixes from the same session:

- **Subscription usage** no longer repeats `5-hour: 4% · 7-day: 48%` in a disclosure header and again on each meter. The card now lists each window once, with its bar, reset time, and freshness.
- **`/config` can store a GitHub token.** The CLI can set, replace, or remove the personal access token used by `github_subscription`, or open GitHub's token page with `repo` scope pre-selected. Missing-token errors now point at `/config -> GitHub token` as well as the VS Code Git tab.

This PR is stacked on #10815 so its diff contains only the settings and CLI work.

## Issue acceptance gates

No linked issue. Acceptance:

- Settings usage cards do not restate the same window percentages in a collapsed summary.
- `/config` shows a GitHub token row; saving a token persists it in TeXRA secrets and does not print the secret.

## Single source of truth

- Token storage key and create URL: `src/tools/github/githubAuth.ts`
- CLI persist/load/remove: `packages/cli/src/runtime/githubToken.ts`
- Credential placeholder detection: `packages/cli/src/runtime/credentialInput.ts`
- Usage presentation remains `src/shared/subscriptionUsagePresentation.ts`; the settings row only renders it.

## Duplication and abstraction budget

Moved `GITHUB_TOKEN_CREATE_URL` next to the token key and repointed all consumers directly to that source. Shared the provider-key and GitHub-token placeholder detector after the second genuine call site appeared.

## Net elements (R6)

n/a - feature/UX change, not a refactor/simplify PR.

## Consumer counts (R8)

- `GITHUB_TOKEN_CREATE_URL`: 3 direct host consumers; the controller re-export shim was deleted.
- Credential placeholder detector: 2 CLI runtime consumers.

## Host impact

Extension:

- Subscription usage meters render inline, without a repeating disclosure header.

Desktop:

- Same settings usage card and direct token-create URL import.

CLI:

- `/config` gains a GitHub token row (set / replace / remove / create on GitHub).
- `github_subscription` missing-token copy mentions `/config`.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm eslint` on the six review-cleanup files
- `npm run typecheck:workspace`
- `npm run typecheck:cli`
- `npm run typecheck:desktop`
- Focused ConfigForm, provider-key, and subscription rendering suites (74 tests passed)
- Exact-head GitHub CI pending
