### PR TITLE
fix: show why custom agents fail to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable changes to this project will be documented in this file.
 - **An unknown agent name is reported once, with next-step guidance** — the
   error no longer appears twice, and command-line users now get the same
   "agent not found" hint as the other surfaces.
+- **Custom agents that fail to load now say why** — invalid YAML or retired
+  settings no longer vanish from Settings → Agents. The tab lists the skipped
+  files, and `texra agents list` writes the same reasons to stderr.
 - **Long Grok prompts report their true cost** — xAI raises per-token rates
   once a prompt crosses the model's long-context threshold; usage costs for
   those requests no longer underreport.

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty';
 
-import { loadAgents } from '@agent/index';
+import { getCustomAgentScanIssues, loadAgents } from '@agent/index';
 
 import {
   AGENT_NAME_DESCRIPTION,
@@ -40,6 +40,9 @@ export async function listAgents(
       options.category,
     );
     if (hiddenNotice) writeTextStderr(hiddenNotice);
+    for (const issue of getCustomAgentScanIssues()) {
+      writeTextStderr(`Skipped custom agent ${issue.path}: ${issue.message}`);
+    }
   }
 
   emitCliResult(

--- a/packages/desktop/src/main/desktopAgentSettingsController.ts
+++ b/packages/desktop/src/main/desktopAgentSettingsController.ts
@@ -4,6 +4,7 @@ import {
   type AgentEntry,
   type AgentRosterController,
   getAgent,
+  getCustomAgentScanIssues,
 } from '@agent/index';
 import type {
   computeAgentOptionsData,
@@ -251,6 +252,7 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
       await buildAgentSelectionMessage({
         loadAgents: this.registry.loadAgents,
         buildSelectionItems: () => this.catalogController.buildSelectionItems(),
+        getCustomAgentScanIssues,
       }),
     );
   }

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -77,6 +77,7 @@ import {
   copilotRouteInfos,
   customAgentDir,
   customAgentDirIsDefault,
+  customAgentScanIssues,
   customPresets,
   detachSubagentsOnStop,
   multiAgentSettingsRevision,
@@ -406,6 +407,7 @@ export class SettingsApp extends SettingsAppBase {
             .agents=${agentSelectionItems.get()}
             .customAgentDir=${customAgentDir.get()}
             .customAgentDirIsDefault=${customAgentDirIsDefault.get()}
+            .customAgentScanIssues=${customAgentScanIssues.get()}
             .initialSubTab=${agentSubTab.get()}
             .reliabilitySettings=${reliabilitySettings.get()}
             .unsupportedCommands=${unsupportedCommands.get()}

--- a/packages/extension/src/settingsView/frontend/settingsState.ts
+++ b/packages/extension/src/settingsView/frontend/settingsState.ts
@@ -28,6 +28,7 @@ import {
 import type {
   AgentCategory,
   AgentModePreset,
+  AgentScanIssue,
   AgentSelectionItem,
   ByCategory,
   ChatGptAuthStatus,
@@ -164,6 +165,7 @@ export const agentSelectionItems = trackedSignal<
 >(() => byCategory(() => []));
 export const customAgentDir = trackedSignal(() => '');
 export const customAgentDirIsDefault = trackedSignal(() => true);
+export const customAgentScanIssues = trackedSignal<AgentScanIssue[]>(() => []);
 export const agentSubTab = trackedSignal<AgentCategory | undefined>(
   () => undefined,
 );

--- a/packages/extension/src/settingsView/frontend/slices/agentSelectionSlice.ts
+++ b/packages/extension/src/settingsView/frontend/slices/agentSelectionSlice.ts
@@ -7,11 +7,13 @@ import {
   agentSelectionItems,
   customAgentDir,
   customAgentDirIsDefault,
+  customAgentScanIssues,
 } from '../settingsState';
 
 export const agentSelectionHandlers = {
   [SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION]: (data) => {
     agentSelectionItems.set(data.agents);
+    customAgentScanIssues.set(data.customAgentIssues);
   },
 
   [SETTINGS_VIEW_COMMANDS.UPDATE_CUSTOM_AGENT_DIR]: (data) => {

--- a/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -12,13 +12,18 @@ import {
 import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { commonViewStyles, designTokens } from '@shared/styles';
+import {
+  commonViewStyles,
+  designTokens,
+  settingsBannerStyles,
+} from '@shared/styles';
 
 // Local imports - shared schemas
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { postMessage } from '@shared/hostBridge';
 import type {
   AgentCategory,
+  AgentScanIssue,
   AgentSelectionItem,
   ByCategory,
   NumberSetting,
@@ -30,9 +35,11 @@ import {
   renderIconActionButton,
   renderLabeledActionButton,
 } from '@shared/wa/actionButtons';
+import { renderSettingsBanner } from '@shared/wa/settingsBanner';
 import { renderSettingsSectionHeading } from '@shared/wa/settingsSection';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
+import { pluralize } from '@utils/text/stringUtils';
 
 // Local imports - settings view components (side-effect: register)
 import '../components/profile/AgentSelectionPanel';
@@ -45,6 +52,7 @@ export class AgentsTab extends UnsupportedCommandsMixin(LitElement) {
   static override styles = [
     designTokens,
     commonViewStyles,
+    settingsBannerStyles,
     css`
       :host {
         display: block;
@@ -58,6 +66,19 @@ export class AgentsTab extends UnsupportedCommandsMixin(LitElement) {
         text-overflow: ellipsis;
         white-space: nowrap;
         min-width: 0;
+      }
+
+      .custom-agent-issues-banner {
+        margin-top: var(--wa-space-m);
+      }
+
+      .custom-agent-issues {
+        margin: var(--wa-space-s) 0 0;
+        padding-left: 1.2em;
+      }
+
+      .custom-agent-issues li + li {
+        margin-top: var(--wa-space-2xs);
       }
 
       .agent-category + .agent-category,
@@ -76,6 +97,7 @@ export class AgentsTab extends UnsupportedCommandsMixin(LitElement) {
     byCategory(() => []);
   @property({ attribute: false }) customAgentDir = '';
   @property({ attribute: false }) customAgentDirIsDefault = true;
+  @property({ attribute: false }) customAgentScanIssues: AgentScanIssue[] = [];
   @property({ attribute: false }) initialSubTab?: AgentCategory;
   @property({ attribute: false }) reliabilitySettings: NumberSetting[] = [];
 
@@ -111,6 +133,28 @@ export class AgentsTab extends UnsupportedCommandsMixin(LitElement) {
 
   private handleSaveTeam(): void {
     postMessage(SETTINGS_VIEW_COMMANDS.SAVE_AGENT_MODE_PRESET);
+  }
+
+  private renderCustomAgentIssues(): TemplateResult | typeof nothing {
+    const issues = this.customAgentScanIssues;
+    if (issues.length === 0) return nothing;
+    return renderSettingsBanner({
+      id: 'custom-agent-scan-issues',
+      className: 'custom-agent-issues-banner',
+      variant: 'warning',
+      icon: 'triangle-exclamation',
+      title: `${issues.length} custom ${pluralize(issues.length, 'agent')} could not be loaded`,
+      description:
+        'These files are in the folder above. TeXRA skipped them because the YAML is invalid or uses retired settings.',
+      detail: html`
+        <ul class="custom-agent-issues">
+          ${issues.map(
+            (issue) =>
+              html`<li><code>${issue.path}</code> — ${issue.message}</li>`,
+          )}
+        </ul>
+      `,
+    });
   }
 
   private renderAgentCategory(
@@ -218,6 +262,7 @@ export class AgentsTab extends UnsupportedCommandsMixin(LitElement) {
               }
             </div>
           </div>
+          ${this.renderCustomAgentIssues()}
         </div>
         ${this.renderAgentCategory(
           'toolUse',

--- a/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -145,7 +145,7 @@ export class AgentsTab extends UnsupportedCommandsMixin(LitElement) {
       icon: 'triangle-exclamation',
       title: `${issues.length} custom ${pluralize(issues.length, 'agent')} could not be loaded`,
       description:
-        'These files are in the folder above. TeXRA skipped them because the YAML is invalid or uses retired settings.',
+        'These files are in the folder above. TeXRA skipped them; each entry below gives the reason.',
       detail: html`
         <ul class="custom-agent-issues">
           ${issues.map(

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -11,6 +11,7 @@ import * as vscode from 'vscode';
 import {
   type AgentRosterController,
   getAgent,
+  getCustomAgentScanIssues,
   loadAgents,
   refresh as refreshAgents,
 } from '@agent/index';
@@ -119,6 +120,7 @@ export class AgentHandlers {
       await buildAgentSelectionMessage({
         loadAgents,
         buildSelectionItems: () => this.catalogController.buildSelectionItems(),
+        getCustomAgentScanIssues,
       }),
     );
   }

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -178,6 +178,8 @@ async function doLoad(
       scanDirectory(toolUseDir, 'builtInToolUse'),
       includeRemote ? loadRemoteAgents() : Promise.resolve([]),
     ]);
+  // builtInScan.issues and toolUseScan.issues are intentionally unused:
+  // only custom-agent scan failures are a product surface.
 
   // Register all entries. Inline definitions were normalized at registration
   // and live outside the directory scan, so they are re-merged on every load —
@@ -194,7 +196,6 @@ async function doLoad(
   if (loadEpoch !== epoch) return false;
 
   cache.clear();
-  // Built-in/tool-use scan.issues stay in logs only; Settings/CLI list custom skips.
   customScanIssues = Object.freeze(customScan.issues);
   for (const entry of allEntries) {
     cache.set(agentKeyOf(entry), entry);

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -8,6 +8,7 @@ import type {
   AgentCategory as AgentCategoryType,
   AgentDelegationScope,
   AgentOptionData,
+  AgentScanIssue,
   AgentSource,
 } from '@shared/schemas';
 import {
@@ -22,7 +23,7 @@ import { PREFERRED_TOOL_USE_AGENTS } from '@shared/constants/agents';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { hasDelegationTool } from '@shared/constants/delegationTools';
 import { byName } from '@utils/core';
-import { scanDirectory, type AgentScanIssue } from './agentYamlScanner';
+import { scanDirectory } from './agentYamlScanner';
 import {
   clearInlineAgentDefinitions,
   defineInlineAgents,

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -194,6 +194,7 @@ async function doLoad(
   if (loadEpoch !== epoch) return false;
 
   cache.clear();
+  // Built-in/tool-use scan.issues stay in logs only; Settings/CLI list custom skips.
   customScanIssues = Object.freeze(customScan.issues);
   for (const entry of allEntries) {
     cache.set(agentKeyOf(entry), entry);

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -22,7 +22,7 @@ import { PREFERRED_TOOL_USE_AGENTS } from '@shared/constants/agents';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { hasDelegationTool } from '@shared/constants/delegationTools';
 import { byName } from '@utils/core';
-import { scanDirectory } from './agentYamlScanner';
+import { scanDirectory, type AgentScanIssue } from './agentYamlScanner';
 import {
   clearInlineAgentDefinitions,
   defineInlineAgents,
@@ -69,6 +69,9 @@ const cache = new Map<string, AgentEntry>();
  * leaves the previous catalog described exactly as it still is.
  */
 let catalog: { readonly includesRemote: boolean } | undefined;
+
+/** Custom-directory YAML the last published load could not turn into an agent. */
+let customScanIssues: readonly AgentScanIssue[] = Object.freeze([]);
 
 /**
  * The load producing the next catalog. Every load chains on it, so the registry
@@ -167,7 +170,7 @@ async function doLoad(
     dirs.builtInToolUse(),
   ]);
 
-  const [customEntries, builtInEntries, toolUseEntries, remoteEntries] =
+  const [customScan, builtInScan, toolUseScan, remoteEntries] =
     await Promise.all([
       scanDirectory(customDir, 'custom'),
       scanDirectory(builtInDir, 'builtInWorkflow'),
@@ -181,15 +184,16 @@ async function doLoad(
   // them.
   const allEntries = [
     ...inlineAgentEntries(),
-    ...customEntries,
-    ...builtInEntries,
-    ...toolUseEntries,
+    ...customScan.entries,
+    ...builtInScan.entries,
+    ...toolUseScan.entries,
     ...remoteEntries,
   ];
 
   if (loadEpoch !== epoch) return false;
 
   cache.clear();
+  customScanIssues = Object.freeze(customScan.issues);
   for (const entry of allEntries) {
     cache.set(agentKeyOf(entry), entry);
   }
@@ -304,6 +308,14 @@ export function getAgentsByCategory(category: AgentCategory): AgentEntry[] {
 /** Get agents by source. */
 export function getAgentsBySource(source: AgentSource): AgentEntry[] {
   return [...cache.values()].filter((e) => e.source === source);
+}
+
+/**
+ * Custom-directory YAML files the last published load skipped, with the
+ * reason. Empty until a load publishes a catalog.
+ */
+export function getCustomAgentScanIssues(): readonly AgentScanIssue[] {
+  return customScanIssues;
 }
 
 /**

--- a/src/agent/index/agentYamlScanner.ts
+++ b/src/agent/index/agentYamlScanner.ts
@@ -1,5 +1,7 @@
 /** Stateless YAML scanning for the agent registry. */
 
+import * as path from 'node:path';
+
 import { glob } from 'glob';
 import pMap from 'p-map';
 
@@ -13,12 +15,23 @@ import { parseYamlWith } from '@common/parsing/safeParseYaml';
 import { createLog } from '@logger/logUtils';
 import type { AgentSource } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas';
-import { filterNotNull, groupBy } from '@utils/core';
+import { groupBy, isObject } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import type { AgentEntry } from './agentEntry';
 
 const log = createLog('agentRegistry');
+
+/** A YAML file the scanner found but could not turn into an agent. */
+export interface AgentScanIssue {
+  readonly path: string;
+  readonly message: string;
+}
+
+interface AgentDirectoryScan {
+  readonly entries: AgentEntry[];
+  readonly issues: AgentScanIssue[];
+}
 
 interface ParsedAgentYaml {
   readonly name: string;
@@ -43,8 +56,8 @@ export function extractToolNames(
 export async function scanDirectory(
   dir: string,
   source: AgentSource,
-): Promise<AgentEntry[]> {
-  if (!dir) return [];
+): Promise<AgentDirectoryScan> {
+  if (!dir) return { entries: [], issues: [] };
 
   try {
     const files = (
@@ -54,27 +67,46 @@ export async function scanDirectory(
         nodir: true,
       })
     ).toSorted();
-    const parsed = (
-      await pMap(files, readYamlDefinition, { concurrency: 8 })
-    ).filter(filterNotNull);
-    const unique = entriesWithUniqueNames(parsed);
+    const issues: AgentScanIssue[] = [];
+    const parsed: ParsedAgentYaml[] = [];
+    for (const result of await pMap(
+      files,
+      (yamlPath) => readYamlDefinition(yamlPath, dir),
+      { concurrency: 8 },
+    )) {
+      if (result.ok) parsed.push(result.value);
+      else issues.push(result.issue);
+    }
+    const unique = entriesWithUniqueNames(parsed, dir, issues);
     const definitions = new Map(
       unique.map((entry) => [entry.name, entry] as const),
     );
-    const entries = unique
-      .map((entry) => scanYaml(entry, source, definitions))
-      .filter(filterNotNull);
+    const entries: AgentEntry[] = [];
+    for (const entry of unique) {
+      const scanned = scanYaml(entry, source, definitions);
+      if (scanned) {
+        entries.push(scanned);
+        continue;
+      }
+      issues.push({
+        path: relativeScanPath(dir, entry.path),
+        message: 'Agent definition could not be read.',
+      });
+    }
 
     log.debug(`Scanned ${entries.length} agents from ${source}`);
-    return entries;
+    return { entries, issues };
   } catch (err) {
-    log.error(`Failed to scan ${dir}: ${toErrorMessage(err)}`);
-    return [];
+    const message = toErrorMessage(err);
+    log.error(`Failed to scan ${dir}: ${message}`);
+    return { entries: [], issues: [{ path: dir, message }] };
   }
 }
 
 function entriesWithUniqueNames(
   entries: readonly ParsedAgentYaml[],
+  dir: string,
+  issues: AgentScanIssue[],
 ): ParsedAgentYaml[] {
   const byName = groupBy(entries, (entry) => entry.name);
 
@@ -85,6 +117,12 @@ function entriesWithUniqueNames(
       log.warn(
         `Duplicate agent name "${name}" in ${paths}; skipping all duplicates.`,
       );
+      for (const match of matches) {
+        issues.push({
+          path: relativeScanPath(dir, match.path),
+          message: `Duplicate agent name "${name}".`,
+        });
+      }
       continue;
     }
     unique.push(matches[0]);
@@ -94,23 +132,59 @@ function entriesWithUniqueNames(
 
 async function readYamlDefinition(
   yamlPath: string,
-): Promise<ParsedAgentYaml | null> {
+  dir: string,
+): Promise<
+  { ok: true; value: ParsedAgentYaml } | { ok: false; issue: AgentScanIssue }
+> {
+  const displayPath = relativeScanPath(dir, yamlPath);
   try {
     const content = await AbsoluteFS.read(yamlPath);
     const parsed = parseYamlWith(content, AgentDefinitionSchema);
     if (parsed.isErr()) {
-      log.warn(`Failed to scan ${yamlPath}: ${toErrorMessage(parsed.error)}`);
-      return null;
+      const message = formatScanFailure(parsed.error);
+      log.warn(`Failed to scan ${yamlPath}: ${message}`);
+      return { ok: false, issue: { path: displayPath, message } };
     }
     return {
-      name: parsed.value.name,
-      path: yamlPath,
-      definition: parsed.value,
+      ok: true,
+      value: {
+        name: parsed.value.name,
+        path: yamlPath,
+        definition: parsed.value,
+      },
     };
   } catch (err) {
-    log.warn(`Failed to scan ${yamlPath}: ${toErrorMessage(err)}`);
-    return null;
+    const message = formatScanFailure(err);
+    log.warn(`Failed to scan ${yamlPath}: ${message}`);
+    return { ok: false, issue: { path: displayPath, message } };
   }
+}
+
+function relativeScanPath(dir: string, yamlPath: string): string {
+  const relative = path.relative(dir, yamlPath);
+  return relative || yamlPath;
+}
+
+function formatScanFailure(error: unknown): string {
+  if (isObject(error) && Array.isArray(error.issues)) {
+    const formatted = error.issues
+      .map((issue) => formatSchemaIssue(issue))
+      .filter((part) => part.length > 0);
+    if (formatted.length > 0) return formatted.join('; ');
+  }
+  return toErrorMessage(error);
+}
+
+function formatSchemaIssue(issue: unknown): string {
+  if (!isObject(issue)) return '';
+  const where = Array.isArray(issue.path) ? issue.path.join('.') : '';
+  const prefix = where ? `${where}: ` : '';
+  if (issue.code === 'unrecognized_keys' && Array.isArray(issue.keys)) {
+    return `${prefix}unrecognized keys ${issue.keys.filter((key) => typeof key === 'string').join(', ')}`;
+  }
+  return typeof issue.message === 'string' && issue.message
+    ? `${prefix}${issue.message}`
+    : '';
 }
 
 type InheritedBlockName = 'prompts' | 'settings';

--- a/src/agent/index/agentYamlScanner.ts
+++ b/src/agent/index/agentYamlScanner.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 
 import { glob } from 'glob';
 import pMap from 'p-map';
+import { ZodError, type ZodIssue } from 'zod';
 
 import { mergeInheritedAgentObject } from '@agent/core/definition/agentDefinitionInheritance';
 import {
@@ -15,7 +16,7 @@ import { parseYamlWith } from '@common/parsing/safeParseYaml';
 import { createLog } from '@logger/logUtils';
 import type { AgentScanIssue, AgentSource } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas';
-import { groupBy, isObject } from '@utils/core';
+import { groupBy } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import type { AgentEntry } from './agentEntry';
@@ -160,7 +161,7 @@ function relativeScanPath(dir: string, yamlPath: string): string {
 }
 
 function formatScanFailure(error: unknown): string {
-  if (isObject(error) && Array.isArray(error.issues)) {
+  if (error instanceof ZodError) {
     const formatted = error.issues
       .map((issue) => formatSchemaIssue(issue))
       .filter((part) => part.length > 0);
@@ -169,16 +170,13 @@ function formatScanFailure(error: unknown): string {
   return toErrorMessage(error);
 }
 
-function formatSchemaIssue(issue: unknown): string {
-  if (!isObject(issue)) return '';
-  const where = Array.isArray(issue.path) ? issue.path.join('.') : '';
+function formatSchemaIssue(issue: ZodIssue): string {
+  const where = issue.path.join('.');
   const prefix = where ? `${where}: ` : '';
-  if (issue.code === 'unrecognized_keys' && Array.isArray(issue.keys)) {
-    return `${prefix}unrecognized keys ${issue.keys.filter((key) => typeof key === 'string').join(', ')}`;
+  if (issue.code === 'unrecognized_keys') {
+    return `${prefix}unrecognized keys ${issue.keys.join(', ')}`;
   }
-  return typeof issue.message === 'string' && issue.message
-    ? `${prefix}${issue.message}`
-    : '';
+  return issue.message ? `${prefix}${issue.message}` : '';
 }
 
 type InheritedBlockName = 'prompts' | 'settings';

--- a/src/agent/index/agentYamlScanner.ts
+++ b/src/agent/index/agentYamlScanner.ts
@@ -84,13 +84,13 @@ export async function scanDirectory(
     const entries: AgentEntry[] = [];
     for (const entry of unique) {
       const scanned = scanYaml(entry, source, definitions);
-      if (scanned) {
-        entries.push(scanned);
+      if (scanned.ok) {
+        entries.push(scanned.entry);
         continue;
       }
       issues.push({
         path: relativeScanPath(dir, entry.path),
-        message: 'Agent definition could not be read.',
+        message: scanned.message,
       });
     }
 
@@ -239,7 +239,7 @@ function scanYaml(
   entry: ParsedAgentYaml,
   source: AgentSource,
   definitions: Map<string, ParsedAgentYaml>,
-): AgentEntry | null {
+): { ok: true; entry: AgentEntry } | { ok: false; message: string } {
   try {
     const settingsBlock = inheritedDefinitionBlock(
       entry,
@@ -286,19 +286,22 @@ function scanYaml(
     }
 
     return {
-      name: entry.name,
-      source,
-      path: entry.path,
-      category,
-      description: entry.definition.description,
-      tools: tools?.length ? tools : undefined,
-      defaultOutputFiles: defaultOutputFiles?.length
-        ? defaultOutputFiles
-        : undefined,
-      rounds,
+      ok: true,
+      entry: {
+        name: entry.name,
+        source,
+        path: entry.path,
+        category,
+        description: entry.definition.description,
+        tools: tools?.length ? tools : undefined,
+        defaultOutputFiles: defaultOutputFiles?.length
+          ? defaultOutputFiles
+          : undefined,
+        rounds,
+      },
     };
   } catch (err) {
     log.warn(`Failed to scan ${entry.path}: ${toErrorMessage(err)}`);
-    return null;
+    return { ok: false, message: toErrorMessage(err) };
   }
 }

--- a/src/agent/index/agentYamlScanner.ts
+++ b/src/agent/index/agentYamlScanner.ts
@@ -13,7 +13,7 @@ import {
 } from '@agent/core/definition/AgentDataclass';
 import { parseYamlWith } from '@common/parsing/safeParseYaml';
 import { createLog } from '@logger/logUtils';
-import type { AgentSource } from '@shared/schemas';
+import type { AgentScanIssue, AgentSource } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas';
 import { groupBy, isObject } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
@@ -21,12 +21,6 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import type { AgentEntry } from './agentEntry';
 
 const log = createLog('agentRegistry');
-
-/** A YAML file the scanner found but could not turn into an agent. */
-export interface AgentScanIssue {
-  readonly path: string;
-  readonly message: string;
-}
 
 interface AgentDirectoryScan {
   readonly entries: AgentEntry[];

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -39,6 +39,7 @@ export {
   resolveAgentForLaunch,
   getAgentsByCategory,
   getAgentsBySource,
+  getCustomAgentScanIssues,
   refresh,
   invalidateRemoteAgentsAfterSignOut,
   // Typed data options

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -231,10 +231,18 @@ const AgentSelectionItemSchema = AgentMetadataBaseSchema.extend({
 });
 export type AgentSelectionItem = z.infer<typeof AgentSelectionItemSchema>;
 
+/** A custom-agent YAML file the registry found but could not load. */
+const AgentScanIssueSchema = z.object({
+  path: z.string(),
+  message: z.string(),
+});
+export type AgentScanIssue = z.infer<typeof AgentScanIssueSchema>;
+
 /** Outbound: backend → frontend agent selection data */
 const UpdateAgentSelectionMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION),
   agents: z.record(AgentCategorySchema, z.array(AgentSelectionItemSchema)),
+  customAgentIssues: z.array(AgentScanIssueSchema).prefault([]),
 });
 export type UpdateAgentSelectionMessage = z.infer<
   typeof UpdateAgentSelectionMessageSchema

--- a/src/shared/settingsView/handlers/agentSelectionHandlers.ts
+++ b/src/shared/settingsView/handlers/agentSelectionHandlers.ts
@@ -22,7 +22,7 @@ import type {
 export interface AgentSelectionPorts {
   loadAgents(): Promise<void>;
   buildSelectionItems(): ByCategory<AgentSelectionItem[]>;
-  getCustomAgentScanIssues?: () => readonly AgentScanIssue[];
+  getCustomAgentScanIssues(): readonly AgentScanIssue[];
 }
 
 export async function buildAgentSelectionMessage(
@@ -32,7 +32,7 @@ export async function buildAgentSelectionMessage(
   return {
     command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
     agents: ports.buildSelectionItems(),
-    customAgentIssues: [...(ports.getCustomAgentScanIssues?.() ?? [])],
+    customAgentIssues: [...ports.getCustomAgentScanIssues()],
   };
 }
 

--- a/src/shared/settingsView/handlers/agentSelectionHandlers.ts
+++ b/src/shared/settingsView/handlers/agentSelectionHandlers.ts
@@ -11,6 +11,7 @@
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type {
   AgentModePreset,
+  AgentScanIssue,
   AgentSelectionItem,
   ByCategory,
   UpdateAgentModePresetsMessage,
@@ -21,6 +22,7 @@ import type {
 export interface AgentSelectionPorts {
   loadAgents(): Promise<void>;
   buildSelectionItems(): ByCategory<AgentSelectionItem[]>;
+  getCustomAgentScanIssues?: () => readonly AgentScanIssue[];
 }
 
 export async function buildAgentSelectionMessage(
@@ -30,6 +32,7 @@ export async function buildAgentSelectionMessage(
   return {
     command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
     agents: ports.buildSelectionItems(),
+    customAgentIssues: [...(ports.getCustomAgentScanIssues?.() ?? [])],
   };
 }
 

--- a/src/test-kernel/agent/AgentYamlScanner.vitest.ts
+++ b/src/test-kernel/agent/AgentYamlScanner.vitest.ts
@@ -75,7 +75,7 @@ describe('agent YAML scanner', () => {
       ],
     });
 
-    const entries = await scanDirectory(agentDir, 'custom');
+    const { entries } = await scanDirectory(agentDir, 'custom');
 
     expect(entries.find((entry) => entry.name === 'child')?.rounds).toBe(4);
     expect(entries.find((entry) => entry.name === 'prompt-child')?.rounds).toBe(
@@ -91,7 +91,7 @@ describe('agent YAML scanner', () => {
       'Readable Helper.yaml': toolUseAgent('helper', 'help'),
     });
 
-    const entries = await scanDirectory(agentDir, 'custom');
+    const { entries } = await scanDirectory(agentDir, 'custom');
 
     expect(entries.map((entry) => entry.name)).toEqual(['helper']);
   });
@@ -108,7 +108,7 @@ describe('agent YAML scanner', () => {
       ],
     });
 
-    const entries = await scanDirectory(agentDir, 'custom');
+    const { entries } = await scanDirectory(agentDir, 'custom');
 
     expect(entries).toEqual([]);
   });
@@ -120,7 +120,7 @@ describe('agent YAML scanner', () => {
       'unique.yaml': toolUseAgent('unique', 'unique'),
     });
 
-    const entries = await scanDirectory(agentDir, 'custom');
+    const { entries } = await scanDirectory(agentDir, 'custom');
 
     expect(entries.map((entry) => entry.name)).toEqual(['unique']);
   });
@@ -131,8 +131,35 @@ describe('agent YAML scanner', () => {
       'valid.yaml': toolUseAgent('valid', 'hi'),
     });
 
-    const entries = await scanDirectory(agentDir, 'custom');
+    const { entries } = await scanDirectory(agentDir, 'custom');
 
     expect(entries.map((entry) => entry.name)).toEqual(['valid']);
+  });
+
+  it('reports skipped custom YAML files as scan issues', async () => {
+    const agentDir = await createAgentDir({
+      'broken.yaml': ['name: "unterminated'],
+      'retired.yaml': [
+        'name: retired',
+        'settings:',
+        '  agentCategory: workflow',
+        '  documentTag: documents',
+      ],
+      'valid.yaml': toolUseAgent('valid', 'hi'),
+    });
+
+    const { entries, issues } = await scanDirectory(agentDir, 'custom');
+
+    expect(entries.map((entry) => entry.name)).toEqual(['valid']);
+    expect(issues).toEqual([
+      expect.objectContaining({
+        path: 'broken.yaml',
+        message: expect.stringMatching(/unterminated|Nested mappings|YAML/iu),
+      }),
+      expect.objectContaining({
+        path: 'retired.yaml',
+        message: expect.stringContaining('documentTag'),
+      }),
+    ]);
   });
 });

--- a/src/test-kernel/settings/SettingsStyleContracts.vitest.ts
+++ b/src/test-kernel/settings/SettingsStyleContracts.vitest.ts
@@ -10,6 +10,7 @@ const SETTINGS_PROFILE_ROOT =
   'packages/extension/src/settingsView/frontend/components/profile';
 const SETTINGS_BANNER_TABS = [
   'AccountTab.ts',
+  'AgentsTab.ts',
   'LaTeXTab.ts',
   'ShortcutsTab.ts',
 ] as const;

--- a/src/test-kernel/settings/settingsNotificationHandlers.vitest.ts
+++ b/src/test-kernel/settings/settingsNotificationHandlers.vitest.ts
@@ -46,6 +46,7 @@ describe('settingsView notification message builders', () => {
     const message = await buildAgentSelectionMessage({
       loadAgents,
       buildSelectionItems,
+      getCustomAgentScanIssues: () => [],
     });
 
     expect(loadAgents).toHaveBeenCalledOnce();

--- a/src/test-kernel/settings/settingsNotificationHandlers.vitest.ts
+++ b/src/test-kernel/settings/settingsNotificationHandlers.vitest.ts
@@ -53,7 +53,27 @@ describe('settingsView notification message builders', () => {
     expect(message).toEqual({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
       agents: { workflow: [workflowItem], toolUse: [toolUseItem] },
+      customAgentIssues: [],
     });
+  });
+
+  it('buildAgentSelectionMessage includes custom agent scan issues', async () => {
+    const issues = [
+      {
+        path: 'retired.yaml',
+        message: 'settings: unrecognized keys documentTag',
+      },
+    ];
+    const message = await buildAgentSelectionMessage({
+      loadAgents: vi.fn().mockResolvedValue(undefined),
+      buildSelectionItems: vi.fn().mockReturnValue({
+        workflow: [],
+        toolUse: [],
+      }),
+      getCustomAgentScanIssues: () => issues,
+    });
+
+    expect(message.customAgentIssues).toEqual(issues);
   });
 
   it('buildCustomAgentDirMessage wraps the resolved status', async () => {

--- a/src/test-kernel/support/agentCatalogMock.ts
+++ b/src/test-kernel/support/agentCatalogMock.ts
@@ -24,6 +24,7 @@ const agentCatalogMock = vi.hoisted(() => ({
   getAgent: vi.fn(),
   getAgentsByCategory: vi.fn(),
   getVisibleAgents: vi.fn(),
+  getCustomAgentScanIssues: vi.fn(() => []),
   loadAgents: vi.fn(),
   refresh: vi.fn(),
   resolveAgentForLaunch: vi.fn(),


### PR DESCRIPTION
## Summary

Custom agent YAML files that fail to parse (invalid YAML, retired settings such as `documentTag`/`prefills`, duplicate names) were skipped with only a log warning. Settings → Agents then showed no Custom group and no explanation, so a brand-new distinct agent could vanish.

The scanner now returns those skip reasons with the catalog. Settings → Agents shows them under the custom-agents folder, and `texra agents list` writes the same lines to stderr. Invalid files are still not loaded.

## Issue acceptance gates

No tracked issue. Reproduced locally: every file in `~/.texra/global-storage/custom_agents` was rejected (retired keys or an unquoted colon in a description) and the Agents tab listed only Remote + Built-in.

## Single source of truth

`scanDirectory` in `src/agent/index/agentYamlScanner.ts` owns skip reasons. The registry publishes the last custom-directory issues via `getCustomAgentScanIssues()`. Settings and the CLI read that list; they do not rescan.

## Duplication and abstraction budget

No new pass-through layer. The existing `UPDATE_AGENT_SELECTION` message gained `customAgentIssues`. Hosts pass the registry getter into the existing `buildAgentSelectionMessage` helper.

## Net elements (R6)

n/a — bug fix, not a refactor.

## Consumer counts (R8)

n/a — new field and getter; no emit path removed.

## Host impact

Extension: Agents tab warning banner under the custom-agents path.

Desktop: same settings webview and message builder.

CLI: `texra agents list` prints skipped files on stderr.

## Scheduled refactoring

None.

## Validation

- `npx vitest run` on AgentYamlScanner, AgentRegistry, settings notification builders, SettingsStyleContracts, ExtensionAgentHandlers, DesktopAgentSettingsController, AgentsCommand (61 tests passed)
- `npx eslint` on the changed TypeScript files (clean)
- `tsc --noEmit --project packages/desktop/tsconfig.renderer.json` (clean after adding the missing `pluralize` import)
- Prettier via the commit hook