### PR TITLE
fix(onboarding): serialize extension funnel refreshes

### DIFF
--- a/packages/desktop/src/main/desktopOnboardingIpc.ts
+++ b/packages/desktop/src/main/desktopOnboardingIpc.ts
@@ -2,6 +2,7 @@ import {
   planOnboardingFunnelTransition,
   type OnboardingFunnelState,
 } from '@controllers/onboarding/onboardingFunnel';
+import { OnboardingRefreshQueue } from '@controllers/onboarding/OnboardingRefreshQueue';
 import { platform } from '@platform/platform';
 import type { StateStore } from '@platform/interfaces';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
@@ -64,8 +65,9 @@ export function createDesktopOnboardingIpc(
   // state. A latch coalesces overlapping requests: while one refresh is in
   // flight, a single re-run is queued and run once the current one settles, so
   // callers always observe a consistent terminal state.
-  let refreshChain: Promise<void> = Promise.resolve();
-  let rerunRequested = false;
+  const funnelRefreshQueue = new OnboardingRefreshQueue(
+    runOnboardingFunnelRefresh,
+  );
 
   function postCurrentState(): void {
     const dismissed = state.get<boolean>(
@@ -128,21 +130,7 @@ export function createDesktopOnboardingIpc(
   }
 
   function refreshOnboardingFunnel(): Promise<void> {
-    // If a refresh is already running, mark that another full pass is needed
-    // and return the chain tail — every caller resolves only once the queued
-    // pass has settled, so they all observe the same terminal funnel state.
-    rerunRequested = true;
-    refreshChain = refreshChain
-      .catch(() => undefined)
-      .then(async () => {
-        // Collapse multiple overlapping requests that arrived while a pass was
-        // running into a single re-run.
-        while (rerunRequested) {
-          rerunRequested = false;
-          await runOnboardingFunnelRefresh();
-        }
-      });
-    return refreshChain;
+    return funnelRefreshQueue.run();
   }
 
   async function dismiss(): Promise<void> {

--- a/packages/extension/src/webview/MainViewProvider.ts
+++ b/packages/extension/src/webview/MainViewProvider.ts
@@ -1,5 +1,4 @@
 // Third-party imports
-import PQueue from 'p-queue';
 import * as vscode from 'vscode';
 
 // Local imports
@@ -23,6 +22,7 @@ import {
   planOnboardingFunnelTransition,
   type OnboardingFunnelState,
 } from '@controllers/onboarding/onboardingFunnel';
+import { OnboardingRefreshQueue } from '@controllers/onboarding/OnboardingRefreshQueue';
 import { appSignals } from '@eventBus/AppSignals';
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import {
@@ -83,10 +83,9 @@ export class MainViewProvider
    * transition based on a stale previous funnel state, and collapse any burst
    * that arrives during a pass into one terminal re-run.
    */
-  private readonly onboardingFunnelRefreshQueue = new PQueue({
-    concurrency: 1,
-  });
-  private onboardingFunnelRerunRequested = false;
+  private readonly onboardingFunnelRefreshQueue = new OnboardingRefreshQueue(
+    () => this.refreshOnboardingFunnelSerially(),
+  );
 
   // Debounced refresh for agent option changes
   private debouncedRefreshAgentOptions = debounce(
@@ -211,13 +210,7 @@ export class MainViewProvider
    * hooks replay via refreshOptionsAndView — and after welcome-card actions.
    */
   refreshOnboardingFunnel(): Promise<void> {
-    this.onboardingFunnelRerunRequested = true;
-    return this.onboardingFunnelRefreshQueue.add(async () => {
-      while (this.onboardingFunnelRerunRequested) {
-        this.onboardingFunnelRerunRequested = false;
-        await this.refreshOnboardingFunnelSerially();
-      }
-    });
+    return this.onboardingFunnelRefreshQueue.run();
   }
 
   private async refreshOnboardingFunnelSerially(): Promise<void> {

--- a/packages/extension/src/webview/MainViewProvider.ts
+++ b/packages/extension/src/webview/MainViewProvider.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import * as vscode from 'vscode';
+import PQueue from 'p-queue';
 
 // Local imports
 import { refresh, computeAgentOptionsData, getAgent } from '@agent/index';
@@ -76,6 +77,14 @@ export class MainViewProvider
   /** A State 1 entry observed with no view keeps its setup-agent selection
    *  pending until a launcher exists to receive it. */
   private pendingSetupAgentSelection = false;
+  /**
+   * Funnel refresh derives an edge-triggered transition after awaiting the
+   * credential probe. Serialize callers so a later completion cannot commit a
+   * transition based on a stale previous funnel state.
+   */
+  private readonly onboardingFunnelRefreshQueue = new PQueue({
+    concurrency: 1,
+  });
 
   // Debounced refresh for agent option changes
   private debouncedRefreshAgentOptions = debounce(
@@ -199,7 +208,13 @@ export class MainViewProvider
    * Invoked by the message handler on webview ready — which credential-changed
    * hooks replay via refreshOptionsAndView — and after welcome-card actions.
    */
-  async refreshOnboardingFunnel(): Promise<void> {
+  refreshOnboardingFunnel(): Promise<void> {
+    return this.onboardingFunnelRefreshQueue.add(async () => {
+      await this.refreshOnboardingFunnelSerially();
+    });
+  }
+
+  private async refreshOnboardingFunnelSerially(): Promise<void> {
     const view = this.getMainModeView();
     // Mode === MAIN is not enough: after an HTML swap the document has not
     // installed its listener yet. Posting into that window drops messages, and

--- a/packages/extension/src/webview/MainViewProvider.ts
+++ b/packages/extension/src/webview/MainViewProvider.ts
@@ -1,6 +1,5 @@
 // Third-party imports
 import * as vscode from 'vscode';
-import PQueue from 'p-queue';
 
 // Local imports
 import { refresh, computeAgentOptionsData, getAgent } from '@agent/index';
@@ -80,11 +79,11 @@ export class MainViewProvider
   /**
    * Funnel refresh derives an edge-triggered transition after awaiting the
    * credential probe. Serialize callers so a later completion cannot commit a
-   * transition based on a stale previous funnel state.
+   * transition based on a stale previous funnel state, and collapse any burst
+   * that arrives during a pass into one terminal re-run.
    */
-  private readonly onboardingFunnelRefreshQueue = new PQueue({
-    concurrency: 1,
-  });
+  private onboardingFunnelRefreshChain: Promise<void> = Promise.resolve();
+  private onboardingFunnelRerunRequested = false;
 
   // Debounced refresh for agent option changes
   private debouncedRefreshAgentOptions = debounce(
@@ -209,9 +208,16 @@ export class MainViewProvider
    * hooks replay via refreshOptionsAndView — and after welcome-card actions.
    */
   refreshOnboardingFunnel(): Promise<void> {
-    return this.onboardingFunnelRefreshQueue.add(async () => {
-      await this.refreshOnboardingFunnelSerially();
-    });
+    this.onboardingFunnelRerunRequested = true;
+    this.onboardingFunnelRefreshChain = this.onboardingFunnelRefreshChain
+      .catch(() => undefined)
+      .then(async () => {
+        while (this.onboardingFunnelRerunRequested) {
+          this.onboardingFunnelRerunRequested = false;
+          await this.refreshOnboardingFunnelSerially();
+        }
+      });
+    return this.onboardingFunnelRefreshChain;
   }
 
   private async refreshOnboardingFunnelSerially(): Promise<void> {

--- a/packages/extension/src/webview/MainViewProvider.ts
+++ b/packages/extension/src/webview/MainViewProvider.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import PQueue from 'p-queue';
 import * as vscode from 'vscode';
 
 // Local imports
@@ -82,7 +83,9 @@ export class MainViewProvider
    * transition based on a stale previous funnel state, and collapse any burst
    * that arrives during a pass into one terminal re-run.
    */
-  private onboardingFunnelRefreshChain: Promise<void> = Promise.resolve();
+  private readonly onboardingFunnelRefreshQueue = new PQueue({
+    concurrency: 1,
+  });
   private onboardingFunnelRerunRequested = false;
 
   // Debounced refresh for agent option changes
@@ -209,15 +212,12 @@ export class MainViewProvider
    */
   refreshOnboardingFunnel(): Promise<void> {
     this.onboardingFunnelRerunRequested = true;
-    this.onboardingFunnelRefreshChain = this.onboardingFunnelRefreshChain
-      .catch(() => undefined)
-      .then(async () => {
-        while (this.onboardingFunnelRerunRequested) {
-          this.onboardingFunnelRerunRequested = false;
-          await this.refreshOnboardingFunnelSerially();
-        }
-      });
-    return this.onboardingFunnelRefreshChain;
+    return this.onboardingFunnelRefreshQueue.add(async () => {
+      while (this.onboardingFunnelRerunRequested) {
+        this.onboardingFunnelRerunRequested = false;
+        await this.refreshOnboardingFunnelSerially();
+      }
+    });
   }
 
   private async refreshOnboardingFunnelSerially(): Promise<void> {

--- a/src/controllers/onboarding/OnboardingRefreshQueue.ts
+++ b/src/controllers/onboarding/OnboardingRefreshQueue.ts
@@ -1,0 +1,19 @@
+import PQueue from 'p-queue';
+
+/** Serialize funnel refreshes and collapse an in-flight burst to one rerun. */
+export class OnboardingRefreshQueue {
+  private readonly queue = new PQueue({ concurrency: 1 });
+  private rerunRequested = false;
+
+  constructor(private readonly refresh: () => Promise<void>) {}
+
+  run(): Promise<void> {
+    this.rerunRequested = true;
+    return this.queue.add(async () => {
+      while (this.rerunRequested) {
+        this.rerunRequested = false;
+        await this.refresh();
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Serialize extension onboarding-funnel refreshes with the same single-writer discipline already used by the desktop host.

## Root cause

The extension derives an edge-triggered transition only after awaiting a credential probe. Concurrent refreshes could therefore commit `onboardingFunnelState` out of order and emit a stale funnel push.

## Maintainer disposition for #10753

- Funnel serialization: proceed with this bounded fix.
- S2 delivery-id suppression and S1 resumability authority: intentionally unchanged. The issue records those as separate architectural rulings and no ruling is yet present.

## Validation

- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/webview/MainAppDesktopGating.vitest.ts`
- `corepack pnpm exec eslint packages/extension/src/webview/MainViewProvider.ts`
- `git diff --check`
<!-- auto-label retry -->