### PR TITLE
fix: cap GPT-5.6 ChatGPT sessions at the Codex 272k input budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **GPT-5.6 ChatGPT-subscription sessions use the same 272k input budget as GPT-5.5** —
+  matching the current Codex catalog, so history is compacted before the
+  unofficial backend rejects a turn.
 - **A missing helper model falls back to DeepSeek V4 Flash** — disabling or
   removing the helper no longer silently switches auxiliary tasks to the
   first picker model.

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -52,8 +52,6 @@ export interface ProviderCapabilityKey {
  * (128k → 400k), same split OpenCode uses.
  */
 export const CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT = 272_000;
-export const CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW =
-  CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT + 128_000;
 
 /** Trailing llm-zoo date pin (`-2026-04-23`) on a model `fullName`. */
 const CODEX_MODEL_DATE_PIN = /-\d{4}-\d{2}-\d{2}$/;

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -45,13 +45,15 @@ export interface ProviderCapabilityKey {
   readonly useOpenRouter: boolean;
 }
 
-/** Default Codex budget (GPT-5.5 and earlier). */
-export const CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW = 400_000;
+/**
+ * ChatGPT-subscription Codex input budget. Matches Codex CLI 0.145.0's
+ * `context_window` / `max_context_window` for GPT-5.5 and GPT-5.6 Sol /
+ * Terra / Luna. Displayed context is this plus the registry `maxOutputTokens`
+ * (128k → 400k), same split OpenCode uses.
+ */
 export const CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT = 272_000;
-
-/** GPT-5.6 Codex budget: 372k input plus 128k output. */
-export const CODEX_GPT56_SUBSCRIPTION_CONTEXT_WINDOW = 500_000;
-export const CODEX_GPT56_SUBSCRIPTION_INPUT_LIMIT = 372_000;
+export const CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW =
+  CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT + 128_000;
 
 /** Trailing llm-zoo date pin (`-2026-04-23`) on a model `fullName`. */
 const CODEX_MODEL_DATE_PIN = /-\d{4}-\d{2}-\d{2}$/;
@@ -65,22 +67,6 @@ export function codexBackendModelId(config: {
   readonly fullName: string;
 }): string {
   return config.shortName || config.fullName.replace(CODEX_MODEL_DATE_PIN, '');
-}
-
-function codexSubscriptionTokenLimits(model: ModelConfig): {
-  contextWindow: number;
-  inputTokenLimit: number;
-} {
-  if (codexBackendModelId(model).startsWith('gpt-5.6')) {
-    return {
-      contextWindow: CODEX_GPT56_SUBSCRIPTION_CONTEXT_WINDOW,
-      inputTokenLimit: CODEX_GPT56_SUBSCRIPTION_INPUT_LIMIT,
-    };
-  }
-  return {
-    contextWindow: CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
-    inputTokenLimit: CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,
-  };
 }
 
 /**
@@ -122,14 +108,19 @@ export function resolveCodexSubscriptionProfile({
   if (model.provider !== ModelProvider.OPENAI) return null;
   if (model.openRouterOnly) return null;
   if (!isCodexSubscriptionEligible(model)) return null;
-  const tokenLimits = codexSubscriptionTokenLimits(model);
+  const inputTokenLimit = Math.min(
+    CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,
+    model.contextWindow,
+  );
+  const contextWindow = Math.min(
+    inputTokenLimit + model.maxOutputTokens,
+    model.contextWindow,
+  );
 
   return {
     authMode: 'chatgpt-subscription',
-    ...zeroCostAccessOverrides(
-      Math.min(tokenLimits.contextWindow, model.contextWindow),
-    ),
-    inputTokenLimit: Math.min(tokenLimits.inputTokenLimit, model.contextWindow),
+    ...zeroCostAccessOverrides(contextWindow),
+    inputTokenLimit,
     usageRoute: 'chatgpt-subscription',
     openAIResponses: {
       backgroundMode: 'disabled',

--- a/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
@@ -50,9 +50,11 @@ const config: ModelConfig = buildTestModelConfig({
 // gpt-5.5 declares a 1,050,000-token window over the OpenAI API, but the Codex
 // subscription backend enforces a far smaller ceiling — the override must clamp
 // the effective window to that ceiling while the subscription drives requests.
+// Use the real Codex output budget so the displayed window is 272k + 128k = 400k.
 const largeWindowConfig: ModelConfig = {
   ...config,
   contextWindow: 1_050_000,
+  maxOutputTokens: 128_000,
 };
 
 const LARGE_WINDOW_SUBSCRIPTION_CONTEXT =
@@ -142,8 +144,7 @@ describe('ModelHandlerCodex subscription fallback', () => {
     const handler = await newSubscriptionHandler(largeWindowConfig);
 
     // The model's own 1.05M API window must not leak through on the
-    // subscription path. The displayed ceiling includes this fixture's output
-    // allowance in addition to the shared Codex input budget.
+    // subscription path, where the backend rejects requests past the ceiling.
     expect(handler.getEffectiveContextWindow()).toBe(
       LARGE_WINDOW_SUBSCRIPTION_CONTEXT,
     );

--- a/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
@@ -7,10 +7,7 @@ import type { ModelCredentialRoute } from '@agent/types/ModelHandlerContracts';
 import { CODEX_BACKEND_BASE_URL, resetCodexCoordinator } from '@auth/codex';
 import { setServerSideKeyService } from '@auth/serverKeys';
 import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
-import {
-  CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
-  CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,
-} from '@model/providerCapabilities';
+import { CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT } from '@model/providerCapabilities';
 import {
   setPreferCodexSubscription,
   isPreferCodexSubscription,
@@ -57,6 +54,9 @@ const largeWindowConfig: ModelConfig = {
   ...config,
   contextWindow: 1_050_000,
 };
+
+const LARGE_WINDOW_SUBSCRIPTION_CONTEXT =
+  CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT + largeWindowConfig.maxOutputTokens;
 
 const ONE_MILLION_INPUT_TOKENS = {
   input_tokens: 1_000_000,
@@ -142,16 +142,17 @@ describe('ModelHandlerCodex subscription fallback', () => {
     const handler = await newSubscriptionHandler(largeWindowConfig);
 
     // The model's own 1.05M API window must not leak through on the
-    // subscription path, where the backend rejects requests past the ceiling.
+    // subscription path. The displayed ceiling includes this fixture's output
+    // allowance in addition to the shared Codex input budget.
     expect(handler.getEffectiveContextWindow()).toBe(
-      CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
+      LARGE_WINDOW_SUBSCRIPTION_CONTEXT,
     );
   });
 
   it('restores the full model window after falling back to the API key', async () => {
     const handler = await newSubscriptionHandler(largeWindowConfig);
     expect(handler.getEffectiveContextWindow()).toBe(
-      CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
+      LARGE_WINDOW_SUBSCRIPTION_CONTEXT,
     );
 
     // "Use your own API key" routes to the real OpenAI API, which honors the
@@ -252,7 +253,7 @@ describe('ModelHandlerCodex subscription fallback', () => {
 
     await setPreferCodexSubscription(false);
     expect(handler.getEffectiveContextWindow()).toBe(
-      CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
+      LARGE_WINDOW_SUBSCRIPTION_CONTEXT,
     );
     expect(handler.computePrice(RAW_USAGE)).toBe(0);
     expect(handler.getLastCredentialUsageRoute()).toBe('chatgpt-subscription');

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -733,9 +733,9 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    // gpt-5.6's Codex subscription budget caps to 500k
-    // (CODEX_GPT56_SUBSCRIPTION_CONTEXT_WINDOW), not the raw 1.05M API window.
-    expect(leftTexts(display)).toContain('187k/500k (37%)');
+    // gpt-5.6's Codex subscription budget caps to 400k
+    // (CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW), not the raw 1.05M API window.
+    expect(leftTexts(display)).toContain('187k/400k (47%)');
   });
 
   it('uses the default 400k subscription budget for earlier Codex models', () => {

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -733,8 +733,8 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    // gpt-5.6's Codex subscription budget caps to 400k
-    // (CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW), not the raw 1.05M API window.
+    // gpt-5.6's Codex subscription budget caps to 400k (272k input plus its
+    // 128k output allowance), not the raw 1.05M API window.
     expect(leftTexts(display)).toContain('187k/400k (47%)');
   });
 

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -19,7 +19,7 @@ import {
   shouldRouteModelThroughOpenRouter,
 } from '@model/openRouterRouting';
 import {
-  CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
+  CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,
   isCodexSubscriptionEligible,
 } from '@model/providerCapabilities';
 import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
@@ -399,7 +399,11 @@ describe('computeModelOptionsData relay quota state', () => {
 
     expect(model.availability).toBe('subscription-access');
     expect(model.context).toBe(
-      `${Math.round(CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW / 1000)}K`,
+      `${Math.round(
+        (CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT +
+          MODEL_CONFIGS.gpt55.maxOutputTokens) /
+          1000,
+      )}K`,
     );
     expect(model.cost).toBe('$0.000/$0.000');
     expect(model.hint).not.toContain(FAST_FIRST_RESPONSE_HINT);

--- a/src/test-kernel/model/ProviderCapabilities.vitest.ts
+++ b/src/test-kernel/model/ProviderCapabilities.vitest.ts
@@ -15,7 +15,6 @@ import {
 import { installTexraModelAccess } from '@controllers/modelAccess/installTexraModelAccess';
 import {
   CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,
-  CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
   isCodexSubscriptionActive,
   resolveCodexSubscriptionCapabilities,
   resolveCodexSubscriptionProfile,
@@ -78,7 +77,8 @@ describe('provider capabilities', () => {
 
     expect(capabilities).toMatchObject({
       authMode: 'chatgpt-subscription',
-      contextWindow: CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
+      contextWindow:
+        CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT + gpt55Config.maxOutputTokens,
       inputTokenLimit: CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,
       inputPrice: 0,
       outputPrice: 0,
@@ -117,9 +117,6 @@ describe('provider capabilities', () => {
           CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT + model.maxOutputTokens,
         inputTokenLimit: CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,
       });
-      expect(capabilities?.contextWindow).toBe(
-        CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
-      );
     },
   );
 });

--- a/src/test-kernel/model/ProviderCapabilities.vitest.ts
+++ b/src/test-kernel/model/ProviderCapabilities.vitest.ts
@@ -16,8 +16,6 @@ import { installTexraModelAccess } from '@controllers/modelAccess/installTexraMo
 import {
   CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,
   CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
-  CODEX_GPT56_SUBSCRIPTION_INPUT_LIMIT,
-  CODEX_GPT56_SUBSCRIPTION_CONTEXT_WINDOW,
   isCodexSubscriptionActive,
   resolveCodexSubscriptionCapabilities,
   resolveCodexSubscriptionProfile,
@@ -42,14 +40,6 @@ const gpt55Config: ModelConfig = {
   },
   openRouterOnly: false,
   codexSubscription: true,
-};
-
-const gpt56Config: ModelConfig = {
-  ...gpt55Config,
-  name: 'gpt56--',
-  label: 'GPT-5.6 Luna',
-  fullName: 'gpt-5.6-luna',
-  shortName: 'gpt-5.6-luna',
 };
 
 const signedInSession: CodexSession = {
@@ -112,17 +102,26 @@ describe('provider capabilities', () => {
     });
   });
 
-  it('uses the larger Codex input budget for GPT-5.6', () => {
-    const capabilities = resolveCodexSubscriptionProfile({
-      model: gpt56Config,
-      useOpenRouter: false,
-    });
+  it.each(['gpt56', 'gpt56-', 'gpt56--'] as const)(
+    'caps ChatGPT-subscription %s to the Codex 272k input / 400k context budget',
+    (id) => {
+      const model = MODEL_CONFIGS[id];
+      const capabilities = resolveCodexSubscriptionProfile({
+        model,
+        useOpenRouter: false,
+      });
 
-    expect(capabilities).toMatchObject({
-      contextWindow: CODEX_GPT56_SUBSCRIPTION_CONTEXT_WINDOW,
-      inputTokenLimit: CODEX_GPT56_SUBSCRIPTION_INPUT_LIMIT,
-    });
-  });
+      expect(model.codexSubscription).toBe(true);
+      expect(capabilities).toMatchObject({
+        contextWindow:
+          CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT + model.maxOutputTokens,
+        inputTokenLimit: CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,
+      });
+      expect(capabilities?.contextWindow).toBe(
+        CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
+      );
+    },
+  );
 });
 
 describe('ChatGPT subscription model routing', () => {


### PR DESCRIPTION
## Summary

ChatGPT-subscription sessions on GPT-5.6 Sol, Terra, and Luna now use the same Codex budget as GPT-5.5: 272k input, 400k displayed context (input plus the registry 128k output). Compaction and the status bar follow those numbers instead of the old 372k / 500k split.

Codex CLI 0.145.0 lists `context_window` and `max_context_window` as 272000 for all three GPT-5.6 variants. OpenCode matched that today in anomalyco/opencode#39082. Our larger GPT-5.6-only cap let sessions run past the window the first-party harness advertises; the unofficial Codex backend then rejected the turn without a recoverable overflow error.

API-key and relay routes are unchanged. They still use the llm-zoo 1.05M window.

## Issue acceptance gates

No tracking issue. Acceptance:

- [x] GPT-5.6 Sol / Terra / Luna ChatGPT-subscription profiles resolve to 272k input and 400k context
- [x] GPT-5.5 subscription budget is unchanged (400k / 272k)
- [x] API-key and relay status still shows the raw 1.05M registry window
- [x] Displayed subscription context is `272k + model.maxOutputTokens`, not a second hardcoded GPT-5.6 constant

## Single source of truth

`src/model/providerCapabilities.ts` — `CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT` (272k). Displayed context is that input cap plus the model's registry `maxOutputTokens`.

## Duplication and abstraction budget

Removed `codexSubscriptionTokenLimits` and the GPT-5.6-only 500k / 372k constants. One budget for every ChatGPT-subscription model.

## Net elements (R6)

n/a — bug fix, not a refactor PR.

## Consumer counts (R8)

n/a — deleted file-local helper and two exports that only this module and its suite consumed.

## Host impact

Extension: model picker and progress context use the smaller subscription window on ChatGPT auth.

Desktop: same shared profile.

CLI: status bar for GPT-5.6 subscription usage shows `187k/400k` instead of `187k/500k`.

## Scheduled refactoring

None. A 1M ChatGPT-account opt-in is deliberately not added; Codex still clamps Sol to the catalog 272k max.

## Validation

- `npx vitest run src/test-kernel/model/ProviderCapabilities.vitest.ts src/test-kernel/cli/StatusBar.vitest.ts src/test-kernel/model/ComputeModelOptions.vitest.ts src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts`

- Post-audit fallback correction: 144 focused tests passed; workspace/test-kernel typechecks, full lint, Prettier, and diff checks passed.
