### PR TITLE
refactor: retire terminal output preview cap

### DIFF
--- a/src/test-kernel/tools/setup/SendToTerminalTool.vitest.ts
+++ b/src/test-kernel/tools/setup/SendToTerminalTool.vitest.ts
@@ -150,9 +150,9 @@ describe('SendToTerminalTool', () => {
     assert.equal(runs.length, 0);
   });
 
-  it('truncates from the head, not the tail — the success/error line is at the end', async () => {
-    // Output longer than the tool's preview cap. We sentinel the start
-    // and end so we can see which side survived truncation.
+  it('returns complete terminal output for recorder-owned bounding', async () => {
+    // The transcript recorder owns output bounds and spill artifacts. Keep both
+    // sentinels so the tool does not discard either half before that boundary.
     const head = 'BEGIN_MARKER\n' + 'x'.repeat(8_000);
     const end = 'Setting up perl ... done\nEND_MARKER';
     const { tool } = setupTool({
@@ -168,11 +168,11 @@ describe('SendToTerminalTool', () => {
     assert.equal(result.status, 'executed');
     assert.ok(
       (result.output ?? '').includes('END_MARKER'),
-      'tail (success line) must survive truncation',
+      'tail must be preserved for the recorder',
     );
     assert.ok(
-      !(result.output ?? '').includes('BEGIN_MARKER'),
-      'head must be elided when output exceeds the preview cap',
+      (result.output ?? '').includes('BEGIN_MARKER'),
+      'head must be preserved for the recorder',
     );
   });
 });

--- a/src/tools/setup/SendToTerminalTool.ts
+++ b/src/tools/setup/SendToTerminalTool.ts
@@ -8,14 +8,12 @@ import {
   requestBashApproval,
 } from '@tools/approval/bashApproval';
 import { executed } from '@tools/core/result';
-import { tailWithEllipsis } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from '../core/define';
 import { getSetupPlatform } from './platform';
 
 const DEFAULT_TIMEOUT_MS = 300_000;
-const OUTPUT_PREVIEW_MAX = 4_000;
 const TERMINAL_NAME_PREFIX = 'TeXRA: ';
 
 const SendToTerminalInputSchema = z.strictObject({
@@ -86,10 +84,8 @@ export class SendToTerminalTool extends defineTool({
     const summary = timedOut
       ? `"${name}" timed out after ${Math.round(timeoutMs / 1000)}s`
       : `"${name}" exited ${exitLabel}`;
-    const tail = output.trim()
-      ? '\n\n' + tailWithEllipsis(output, OUTPUT_PREVIEW_MAX)
-      : '';
+    const outputText = output.trim() ? `\n\n${output}` : '';
 
-    return executed(summary + tail, summary);
+    return executed(summary + outputText, summary);
   }
 }


### PR DESCRIPTION
Closes #10831.

## What changed
- Removed the 4,000-character display-only truncation from `send_to_terminal`.
- The complete captured terminal result now reaches the transcript recorder, which is the shared 2,000-line / 50 KB bound and spill-artifact boundary.

## Retained limits
- `grep` retains its `maxBuffer` ceiling because it constrains subprocess capture before any tool result exists.
- Memory previews remain bounded because they are settings-file previews, not transcript tool results.

## Validation
- `corepack pnpm vitest run src/test-kernel/tools/setup/SendToTerminalTool.vitest.ts`
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- `corepack pnpm run lint`
- `git diff --check`