### PR TITLE
fix(session): hide provisionally removed stream tabs

### DIFF
--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -193,6 +193,7 @@ export class SessionState {
   selectableStreamNames(): StreamTabId[] {
     return this.streamLogs
       .keys()
+      .filter((name) => !this.isStreamRemoved(name))
       .map((name) => ({
         name,
         creationTimestamp: this.getStreamMetadata(name).creationTimestamp,

--- a/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
@@ -1299,6 +1299,26 @@ describe('ProgressBackend', () => {
     ).toMatchObject({ name: stream, creationTimestamp: 100 });
   });
 
+  it('omits a provisionally removed stream from the selectable rail', () => {
+    const { backend } = createRecordingBackend();
+    const retained = 'retained-stream' as StreamTabId;
+    const removing = 'removing-stream' as StreamTabId;
+
+    backend.state.streamLogs.ensureStream(retained);
+    backend.state.streamLogs.ensureStream(removing);
+    backend.state.beginStreamRemoval(removing);
+
+    // The durable transcript stays resident until the guarded deletion
+    // commits, but the removal barrier is already the live membership
+    // authority for every stream-tab projection.
+    expect(backend.state.streamLogs.has(removing)).toBe(true);
+    expect(backend.state.selectableStreamNames()).toContain(retained);
+    expect(backend.state.selectableStreamNames()).not.toContain(removing);
+    expect(
+      buildStreamInfos(backend.state).map((stream) => stream.name),
+    ).not.toContain(removing);
+  });
+
   it('keeps a dated tab dated after its transcript is released', () => {
     const { backend } = createRecordingBackend();
     const stream = 'evicted-timestamp-stream' as StreamTabId;


### PR DESCRIPTION
## Summary

Hide streams from the selectable Stream-tab rail as soon as the existing removal barrier is installed.

## Root cause

`selectableStreamNames()` enumerated resident transcript keys without consulting the session-owned removal tombstone, leaving a short window where a provisionally removed stream could remain visible until its guarded durable deletion completed.

## Validation

- `corepack pnpm typecheck:workspace`
- `corepack pnpm typecheck:test-kernel`
- `corepack pnpm vitest run src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts`
- `corepack pnpm lint src/controllers/session/SessionState.ts src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts`
- `git diff --check`