### PR TITLE
fix(session): harden stream removal ownership

### DIFF
--- a/packages/desktop/src/main/desktopProcessStores.ts
+++ b/packages/desktop/src/main/desktopProcessStores.ts
@@ -58,7 +58,7 @@ export async function initializeDesktopProcessStores(session: SessionHandle) {
         // Check in the following microtask so the process fallback runs only
         // when no presentation owns the removal.
         queueMicrotask(() => {
-          if (stores.hasStreamDeletionClaim(streamId, expectedIncarnation)) {
+          if (stores.hasStreamDeletionClaim(streamId)) {
             if (pendingRemovals.get(streamId) === expectedIncarnation) {
               pendingRemovals.delete(streamId);
             }

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -153,14 +153,17 @@ export class SessionStores {
     };
   }
 
-  hasStreamDeletionClaim(
-    stream: StreamTabId,
-    expectedIncarnation: number,
-  ): boolean {
-    return (
-      (this.streamDeletionClaims.get(stream)?.get(expectedIncarnation)?.size ??
-        0) > 0
-    );
+  /**
+   * Whether a live presentation currently owns this stream's removal.
+   *
+   * The desktop process store deliberately does not need to duplicate the
+   * state-side incarnation counter: it only decides whether to start a
+   * headless fallback in the removal microtask. Any outstanding claim means
+   * that a presentation already owns that decision, and claims are released
+   * when its deletion settles or fails.
+  */
+  hasStreamDeletionClaim(stream: StreamTabId): boolean {
+    return (this.streamDeletionClaims.get(stream)?.size ?? 0) !== 0;
   }
 
   deleteStream(

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -161,7 +161,7 @@ export class SessionStores {
    * headless fallback in the removal microtask. Any outstanding claim means
    * that a presentation already owns that decision, and claims are released
    * when its deletion settles or fails.
-  */
+   */
   hasStreamDeletionClaim(stream: StreamTabId): boolean {
     return (this.streamDeletionClaims.get(stream)?.size ?? 0) !== 0;
   }

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -175,8 +175,8 @@ export class ProgressBackend {
     });
     this.hasPendingPermissions = ui.hasPendingPermissions;
     this.factApplier = new SessionFactApplier(this.state, this.renderer, {
-      deleteStream: (stream, expectedIncarnation) =>
-        this.deleteStream(stream, expectedIncarnation),
+      deleteStream: (stream, expectedIncarnation, beforeRetainedRepair) =>
+        this.deleteStream(stream, expectedIncarnation, beforeRetainedRepair),
     });
     this.setApprovalBypassState = ui.setApprovalBypassState;
   }
@@ -464,6 +464,7 @@ export class ProgressBackend {
   async deleteStream(
     stream: StreamTabId,
     expectedIncarnation?: number,
+    beforeRetainedRepair?: (outcome: 'active' | 'failed') => void,
   ): Promise<DeleteStreamResult | undefined> {
     const wasActive = this.presentation.activeStream === stream;
     const activationGeneration = this.activationGeneration;
@@ -538,6 +539,11 @@ export class ProgressBackend {
         retained,
         commandRemoval.created,
       );
+    } else if (retained === 'active' || retained === 'failed') {
+      // A fact-path removal owns its barrier in SessionFactApplier. Let it
+      // retire and replay before this retained-state rebuild enumerates the
+      // selectable rail, which deliberately hides provisional removals.
+      beforeRetainedRepair?.(retained);
     }
 
     if (retained === 'active' || retained === 'failed') {

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -527,6 +527,19 @@ export class ProgressBackend {
     }
     releaseDeletionClaim();
 
+    if (commandRemoval) {
+      // Retire a retained command-owned tombstone before rebuilding the tab
+      // rail. selectableStreamNames() deliberately hides provisional
+      // removals, so repairing presentation first would omit the stream that
+      // durable cleanup just reported as still live.
+      this.factApplier.completeCommandRemoval(
+        stream,
+        commandRemoval.incarnation,
+        retained,
+        commandRemoval.created,
+      );
+    }
+
     if (retained === 'active' || retained === 'failed') {
       // Best-effort presentation repair, each failure isolated so a broken
       // rebuild cannot suppress the retention notification and neither can
@@ -554,14 +567,6 @@ export class ProgressBackend {
       }
     }
 
-    if (commandRemoval) {
-      this.factApplier.completeCommandRemoval(
-        stream,
-        commandRemoval.incarnation,
-        retained,
-        commandRemoval.created,
-      );
-    }
     return retained;
   }
 

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -80,6 +80,7 @@ export type SessionFactApplierOptions = {
   deleteStream: (
     stream: StreamTabId,
     expectedIncarnation?: number,
+    beforeRetainedRepair?: (outcome: 'active' | 'failed') => void,
   ) =>
     | void
     | DeleteStreamResult
@@ -341,41 +342,51 @@ export class SessionFactApplier {
               streamId,
               expectedIncarnation,
             );
+            let settled = false;
+            const settleDeletion = (
+              outcome: void | DeleteStreamResult | undefined,
+            ): void => {
+              // A prior removeStream fact for the same incarnation owns this
+              // deletion's settlement (the store dedups its delete promise);
+              // only the owning barrier retires the tombstone and replays.
+              if (!created || settled) return;
+              settled = true;
+              this.finishPendingDeletion(streamId, pending);
+              const retired =
+                (outcome === 'active' ||
+                  outcome === 'failed' ||
+                  outcome === 'superseded') &&
+                this.state.retireStreamTombstone(streamId, expectedIncarnation);
+              // A retained deletion still lives: replay the facts buffered
+              // while it was provisional so status/stage/roster/metadata are
+              // not stuck stale. Replay only when the retirement above
+              // actually removed THIS removal's barrier — a superseded
+              // deletion whose identity a fresh run re-claimed (or a newer
+              // deletion B owns) must never replay through that newer
+              // barrier. A committed deletion discards them (the stream is
+              // gone).
+              if ((outcome === 'active' || outcome === 'failed') && retired) {
+                this.replayDeferredFacts(pending.facts);
+              }
+            };
             return Promise.resolve(
-              this.options.deleteStream(streamId, expectedIncarnation),
+              this.options.deleteStream(
+                streamId,
+                expectedIncarnation,
+                settleDeletion,
+              ),
             ).then(
               (outcome) => {
-                // A prior removeStream fact for the same incarnation owns this
-                // deletion's settlement (the store dedups its delete promise);
-                // only the owning barrier retires the tombstone and replays.
-                if (!created) return;
-                this.finishPendingDeletion(streamId, pending);
-                const retired =
-                  (outcome === 'active' ||
-                    outcome === 'failed' ||
-                    outcome === 'superseded') &&
-                  this.state.retireStreamTombstone(
-                    streamId,
-                    expectedIncarnation,
-                  );
-                // A retained deletion still lives: replay the facts buffered
-                // while it was provisional so status/stage/roster/metadata are
-                // not stuck stale. Replay only when the retirement above
-                // actually removed THIS removal's barrier — a superseded
-                // deletion whose identity a fresh run re-claimed (or a newer
-                // deletion B owns) must never replay through that newer
-                // barrier. A committed deletion discards them (the stream is
-                // gone).
-                if ((outcome === 'active' || outcome === 'failed') && retired) {
-                  this.replayDeferredFacts(pending.facts);
-                }
+                settleDeletion(outcome);
               },
               (error) => {
                 // Ambiguous failure: keep the barrier (the stream may have
                 // deleted), but drop the provisional buffer — there is no
                 // outcome to replay against. The error still propagates to the
                 // event-error wrapper.
-                if (created) this.finishPendingDeletion(streamId, pending);
+                if (created && !settled) {
+                  this.finishPendingDeletion(streamId, pending);
+                }
                 throw error;
               },
             );

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -76,6 +76,14 @@ export type SessionFactApplierOptions = {
    * The applier passes the incarnation captured when the barrier was set so
    * the host can refuse to delete a deterministic identity that a fresh run
    * re-claimed while the deletion was queued.
+   *
+   * A host that rebuilds retained presentation state must invoke
+   * `beforeRetainedRepair` with its `active`/`failed` outcome before that
+   * rebuild enumerates selectable streams. The callback retires the
+   * provisional removal barrier and replays buffered facts; rebuilding first
+   * would omit the still-live stream because selectable projections hide
+   * provisional removals. Hosts without a selectable-stream repair path may
+   * ignore the optional hook and let normal promise settlement retire it.
    */
   deleteStream: (
     stream: StreamTabId,

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -193,6 +193,7 @@ export class SessionState {
   selectableStreamNames(): StreamTabId[] {
     return this.streamLogs
       .keys()
+      .filter((name) => !this.isStreamRemoved(name))
       .map((name) => ({
         name,
         creationTimestamp: this.getStreamMetadata(name).creationTimestamp,

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -186,9 +186,9 @@ export class SessionState {
 
   /**
    * Stream tabs offered for selection, newest first — the order
-   * `buildStreamInfos` renders. Membership and rotation only depend on
-   * creation time, so this answers them without building tab infos or
-   * touching the worktree resolver.
+   * `buildStreamInfos` renders. Provisionally removed streams are excluded;
+   * membership and rotation otherwise depend only on creation time, so this
+   * answers them without building tab infos or touching the worktree resolver.
    */
   selectableStreamNames(): StreamTabId[] {
     return this.streamLogs

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -291,6 +291,22 @@ describe('SessionStores deletion coordination', () => {
     });
   });
 
+  it('reports a live presentation claim without process incarnation state', async () => {
+    await withSession(async (session) => {
+      const stream = 'presentation-owned-delete' as StreamTabId;
+      const stores = new SessionStores({
+        streamLogs: session.transcripts,
+        snapshots: new StreamSnapshotStore(),
+      });
+
+      const releaseClaim = stores.claimStreamDeletion(stream, 1);
+      expect(stores.hasStreamDeletionClaim(stream)).toBe(true);
+
+      releaseClaim();
+      expect(stores.hasStreamDeletionClaim(stream)).toBe(false);
+    });
+  });
+
   it('releases one canonical stream once when single and bulk deletion overlap', async () => {
     await withSession(async (session) => {
       const stream = 'tool@test#abc001' as StreamTabId;

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -3586,6 +3586,83 @@ describe('DesktopProgressBridge', () => {
       }
     });
 
+    it('does not start a process fallback for a newer presentation deletion claim', async () => {
+      const streamId = 'reclaimed-presentation-delete' as StreamTabId;
+      const owner = await createProcessOwner({
+        streamId,
+        executionId: 'ec00f9' as ExecutionId,
+      });
+      seedStreamStatusForTest(owner.processSession.status, streamId, {
+        phase: STREAM_PHASE.COMPLETED,
+      });
+      const firstRelease = createDeferred();
+      const secondRelease = createDeferred();
+      const waitForRelease = vi
+        .spyOn(owner.sessionStores, 'waitForOwnedExecutionRelease')
+        .mockReturnValueOnce(firstRelease.promise)
+        .mockReturnValueOnce(secondRelease.promise);
+      const processFallback = vi.spyOn(
+        owner.sessionStores,
+        'deleteStreamAfterOwnedExecutionRelease',
+      );
+
+      try {
+        emitSessionFact(owner.bridgeA, 'removeStream', {
+          streamId,
+        });
+        await vi.waitFor(() =>
+          expect(owner.sessionStores.hasStreamDeletionClaim(streamId)).toBe(
+            true,
+          ),
+        );
+        // Let the process fallback observe the presentation's first claim and
+        // retire its own pending-removal marker before the identity is
+        // legitimately re-claimed.
+        await settleProgressEvents();
+
+        const freshExecutionId = 'ec00fa' as ExecutionId;
+        snapshotFacts(owner.progressSnapshotStore).setRunStart({
+          streamId,
+          executionId: freshExecutionId,
+          identity: {
+            kind: 'multiAgentWorkflow',
+            workflowName: 'reclaimed-workflow',
+          },
+        });
+        const { handle: freshHandle } = owner.createHandle({
+          executionId: freshExecutionId,
+        });
+        owner.processSession.executions.trackAgentExecution(freshHandle, {
+          status: STREAM_PHASE.COMPLETED,
+        });
+        activateStream(owner.bridgeA, streamId);
+        firstRelease.resolve();
+        await vi.waitFor(() =>
+          expect(owner.sessionStores.hasStreamDeletionClaim(streamId)).toBe(
+            false,
+          ),
+        );
+        expect(waitForRelease).toHaveBeenCalledTimes(1);
+
+        emitSessionFact(owner.bridgeA, 'removeStream', {
+          streamId,
+        });
+        await vi.waitFor(() =>
+          expect(owner.sessionStores.hasStreamDeletionClaim(streamId)).toBe(
+            true,
+          ),
+        );
+        await vi.waitFor(() => expect(waitForRelease).toHaveBeenCalledTimes(2));
+        await settleProgressEvents();
+
+        expect(processFallback).not.toHaveBeenCalled();
+        expect(owner.processSession.transcripts.has(streamId)).toBe(true);
+      } finally {
+        firstRelease.resolve();
+        secondRelease.resolve();
+      }
+    });
+
     it('reattaches while an overlapping headless deletion settles as failed', async () => {
       const streamId = 'headless-remove-owner' as StreamTabId;
       const failedStreamId = 'headless-remove-failure' as StreamTabId;

--- a/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
@@ -1299,6 +1299,26 @@ describe('ProgressBackend', () => {
     ).toMatchObject({ name: stream, creationTimestamp: 100 });
   });
 
+  it('omits a provisionally removed stream from the selectable rail', () => {
+    const { backend } = createRecordingBackend();
+    const retained = 'retained-stream' as StreamTabId;
+    const removing = 'removing-stream' as StreamTabId;
+
+    backend.state.streamLogs.ensureStream(retained);
+    backend.state.streamLogs.ensureStream(removing);
+    backend.state.beginStreamRemoval(removing);
+
+    // The durable transcript stays resident until the guarded deletion
+    // commits, but the removal barrier is already the live membership
+    // authority for every stream-tab projection.
+    expect(backend.state.streamLogs.has(removing)).toBe(true);
+    expect(backend.state.selectableStreamNames()).toContain(retained);
+    expect(backend.state.selectableStreamNames()).not.toContain(removing);
+    expect(
+      buildStreamInfos(backend.state).map((stream) => stream.name),
+    ).not.toContain(removing);
+  });
+
   it('keeps a dated tab dated after its transcript is released', () => {
     const { backend } = createRecordingBackend();
     const stream = 'evicted-timestamp-stream' as StreamTabId;

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -1110,7 +1110,15 @@ describe('ProgressBackend', () => {
 
   it('retains rendered state when durable stream cleanup fails', async () => {
     const session = track(createTestSession());
-    const lifecycle = createLifecycleOptions();
+    const backendRef: { current?: RecordingTarget['backend'] } = {};
+    const selectableAtRebuild: StreamTabId[][] = [];
+    const lifecycle = createLifecycleOptions({
+      rebuildRenderedStreams: vi.fn(async () => {
+        selectableAtRebuild.push(
+          backendRef.current?.state.selectableStreamNames() ?? [],
+        );
+      }),
+    });
     const backend = track(
       new ProgressBackend({
         storage: new FakeStateStore(),
@@ -1122,6 +1130,7 @@ describe('ProgressBackend', () => {
         lifecycle,
       }),
     );
+    backendRef.current = backend;
     const stream = 'retained-stream' as StreamTabId;
     backend.state.streamLogs.ensureStream(stream);
     vi.spyOn(backend.state, 'clearStream').mockResolvedValueOnce('failed');
@@ -1132,6 +1141,8 @@ describe('ProgressBackend', () => {
     expect(lifecycle.rebuildRenderedStreams).toHaveBeenCalledWith({
       syncActiveStream: true,
     });
+    expect(selectableAtRebuild).toContainEqual([stream]);
+    expect(backend.state.isStreamRemoved(stream)).toBe(false);
     expect(lifecycle.notifyDeletionRetained).toHaveBeenCalledWith(0, 1);
   });
 

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -219,6 +219,38 @@ describe('ProgressBackend', () => {
     }
   });
 
+  it('retires a retained fact removal before rebuilding the selectable rail', async () => {
+    const backendRef: { current?: RecordingTarget['backend'] } = {};
+    const selectableAtRebuild: StreamTabId[][] = [];
+    const lifecycle = createLifecycleOptions({
+      rebuildRenderedStreams: vi.fn(async () => {
+        selectableAtRebuild.push(
+          backendRef.current?.state.selectableStreamNames() ?? [],
+        );
+      }),
+    });
+    const target = createIsolatedRecordingBackend(
+      createTestSession(),
+      lifecycle,
+    );
+    const { backend } = target;
+    backendRef.current = backend;
+    backend.setupEventListeners();
+    const streamId = 'retained-fact-stream' as StreamTabId;
+    backend.state.streamLogs.ensureStream(streamId);
+    vi.spyOn(backend.state, 'clearStream').mockResolvedValueOnce('failed');
+
+    emitRemoveStream(target, streamId);
+
+    await vi.waitFor(() =>
+      expect(lifecycle.rebuildRenderedStreams).toHaveBeenCalledWith({
+        syncActiveStream: true,
+      }),
+    );
+    expect(selectableAtRebuild).toContainEqual([streamId]);
+    expect(backend.state.isStreamRemoved(streamId)).toBe(false);
+  });
+
   it('handles removeStream session facts before backend load', async () => {
     const target = createIsolatedRecordingBackend();
     const { backend } = target;

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -275,7 +275,7 @@ describe('ProgressBackend', () => {
       expect(session.executions.getAgentHandleByStream(stream)).toBeUndefined();
 
       const deletion = backend.deleteStream(stream);
-      expect(backend.state.stores.hasStreamDeletionClaim(stream, 0)).toBe(true);
+      expect(backend.state.stores.hasStreamDeletionClaim(stream)).toBe(true);
       await vi.waitFor(() =>
         expect(waitForRelease).toHaveBeenCalledWith(stream),
       );
@@ -287,9 +287,7 @@ describe('ProgressBackend', () => {
       expect(clearStream).toHaveBeenCalledWith(stream, {
         expectedIncarnation: 0,
       });
-      expect(backend.state.stores.hasStreamDeletionClaim(stream, 0)).toBe(
-        false,
-      );
+      expect(backend.state.stores.hasStreamDeletionClaim(stream)).toBe(false);
       expect(backend.state.streamLogs.has(stream)).toBe(false);
     } finally {
       releaseLease();


### PR DESCRIPTION
## Summary

Batch the related stream-removal follow-ups into one lifecycle change:

- hide streams from the selectable tab rail as soon as their removal barrier is installed
- let the desktop fallback recognize any live presentation deletion claim
- keep incarnation tracking in its authoritative owner, SessionState
- retire retained command- and fact-path tombstones before rebuilding presentation so failed cleanup restores the tab and active selection

## Root causes

The selectable stream list did not consult the removal barrier, leaving a provisionally removed tab visible while durable deletion was pending. Separately, the desktop fallback compared against stale process-local incarnation state and could race a live ProgressBackend owner. Combining the fixes exposed ordering issues on both command and session-fact retention paths: presentation rebuilt before the provisional tombstone retired, so a still-live stream remained filtered.

## Validation

- corepack pnpm typecheck:workspace
- corepack pnpm typecheck:test-kernel
- targeted four-file Vitest run: 168 passed
- targeted ESLint across all changed production and test files
- git diff --check

Fixes #10835.
Fixes #10837.