### PR TITLE
feat: cut transcripts over to append-only JSONL with single-coordinate settlement

### DIFF
--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -113,18 +113,26 @@ function isStaticTranscriptEntryAt(
   );
 }
 
-/** `(settlement order, synthetic-after-source tiebreak)` sort key for one entry. */
+/**
+ * `(printable order, synthetic-after-source tiebreak)` for one entry.
+ * Settlement order is the single printable coordinate: a group heading's
+ * slot is reserved when it opens and consumed by its terminal settlement,
+ * so headings sort at their open position without a second field.
+ */
 function transcriptOrderKey(
   entry: ConversationEntry,
   index: number,
-): readonly [seq: number, synthetic: number] {
+): readonly [seq: number, sourcePosition: number] {
   const seq =
     entry.settlementSeqNo ??
     entry.syntheticAfterSettlementSeqNo ??
     entry.sourceSeqNo ??
     index + 1;
-  const synthetic = entry.syntheticAfterSettlementSeqNo !== undefined ? 1 : 0;
-  return [seq, synthetic];
+  const sourcePosition =
+    entry.syntheticAfterSeq !== undefined
+      ? entry.syntheticAfterSeq + 0.5
+      : (entry.sourceSeqNo ?? index + 1);
+  return [seq, sourcePosition];
 }
 
 function compareTranscriptOrderKeys(
@@ -137,15 +145,10 @@ function compareTranscriptOrderKeys(
 /**
  * Printable rows in their append-only scrollback order.
  *
- * Source-backed rows use the durable order in which they became immutable.
- * Synthetic rows retain the settlement cursor captured when the CLI appended
- * them, with their original array position as the final stable tie-breaker.
- * Consumers that place rows relative to `<Static>` output must use this same
- * order rather than the stream's mutable storage order.
- *
- * Runs on every stream-sync tick, and entries arrive in settlement order on
- * all but the rare reorder — so it skips the O(n log n) sort whenever the
- * filtered slice is already ordered, at the cost of one O(n) pass over it.
+ * Source-backed rows use the durable order in which their rendered view became
+ * immutable. Synthetic rows retain the settlement cursor captured when the
+ * CLI appended them. Consumers that place rows relative to `<Static>` output
+ * must use this same order rather than mutable storage order.
  */
 export function orderedStaticTranscriptEntries(
   entries: readonly ConversationEntry[],

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -73,7 +73,11 @@ type ConversationEntryOrigin =
       readonly synthetic?: false;
       /** Durable StreamLog position, including legacy rows without settlement order. */
       readonly sourceSeqNo?: number;
-      /** Source-owned order in which this immutable row became printable. */
+      /**
+       * Source-owned order in which this immutable row became printable. A
+       * group heading's slot is reserved when it opens, so its terminal
+       * settlement already encodes open-time order.
+       */
       readonly settlementSeqNo?: number;
       readonly syntheticKind?: never;
       readonly syntheticAfterSeq?: never;

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -218,7 +218,7 @@ function renderErrorLogEntryText(
 
 /**
  * Fields every {@link ConversationEntry} shares, regardless of role: the
- * source identity plus the two spreads (`messageType`, `settlementSeqNo`)
+ * source identity plus optional source-owned presentation fields
  * that must stay absent — not merely `undefined` — when the source entry
  * doesn't carry them, matching {@link ConversationEntry}'s optional-key shape.
  */
@@ -241,9 +241,11 @@ function baseLogEntryFields<R extends ConversationEntry['role']>(
 
 /**
  * Renders a log entry from scratch. `prev` is consulted only for phase
- * count inheritance (a GROUP_END row carries no index/total of its own);
- * finalization here is source-owned only — the fold re-applies inherited
- * promotion at the row's slot, so an already-promoted row never rolls back.
+ * count inheritance (a GROUP_END row carries no index/total of its own).
+ * A phase header's rendered content is stable at GROUP_START; settlement only
+ * adds status/endTime, so it is printable immediately. Finalization here is
+ * source-owned only — the fold re-applies inherited promotion at the row's
+ * slot, so an already-promoted row never rolls back.
  */
 function renderLogEntryFresh(
   entry: StreamLogEntry,

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -415,8 +415,8 @@ function transitionStopBeforeRunStart(ctx: AgentLaunchContext): void {
  * from the parent stage's trace (see `createRunTrace`'s `dispose`). Emitting
  * `stage.end` through an already-desubscribed trace reaches no subscriber, so
  * update the session's transcript store directly instead, mirroring exactly
- * what `TexraTranscriptRecorder`'s own `stage.end` handler writes for a
- * `kind: 'run'` stage (see `beginRunStage` in AgentLaunchContext.ts). Each
+ * what `TexraTranscriptRecorder`'s own `stage.end` handler writes. StreamLog
+ * carries the start row's stage metadata into the terminal row. Each
  * suspension opens its own stage id (fresh `nanoid` per `beginRunStage` call,
  * including on resume), so this can never double-close a stage some other turn
  * already ended.
@@ -435,12 +435,11 @@ async function closeSuspendedTranscriptGroup(
   );
   try {
     if (handle.executionLeaseLost) return;
-    writer.update(parentStageId, {
+    writer.settle(parentStageId, {
       type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
       data: {
         status: RUN_OUTCOME.CANCELLED,
         endTime: Date.now(),
-        kind: 'run',
       },
     });
   } finally {

--- a/src/common/storage/KVStore.ts
+++ b/src/common/storage/KVStore.ts
@@ -1,10 +1,10 @@
 /**
  * Generic StorageFS-backed key-value store.
  *
- * Each key is one plain-JSON file, `encodeURIComponent(key).json`, in the
- * store's directory; the directory listing is the index. Failures are never
- * swallowed: a missing file reads as `undefined`, every other error throws to
- * the caller, so a genuine I/O failure can never masquerade as absent data.
+ * A key defaults to one plain-JSON file, `encodeURIComponent(key).json`, and
+ * extension-aware methods support caller-owned text formats in the same
+ * directory. The directory listing is the index. Failures are never swallowed:
+ * a missing file reads as `undefined`, every other error throws to the caller.
  */
 
 import * as path from 'node:path';
@@ -14,12 +14,12 @@ import { isFile } from '@utils/files/fsEntryType';
 import { hasExtension } from '@utils/core/pathCore';
 import { StorageFS } from '@utils/files/storageFS';
 
-function keyToPath(dir: string, key: string): string {
-  return path.join(dir, `${encodeURIComponent(key)}.json`);
+function keyToPath(dir: string, key: string, extension = '.json'): string {
+  return path.join(dir, `${encodeURIComponent(key)}${extension}`);
 }
 
-function filenameToKey(filename: string): string {
-  return decodeURIComponent(filename.replace(/\.json$/, ''));
+function filenameToKey(filename: string, extension = '.json'): string {
+  return decodeURIComponent(filename.slice(0, -extension.length));
 }
 
 async function withMissingFallback<T>(
@@ -61,6 +61,34 @@ export class KVStore {
     return JSON.parse(raw) as T;
   }
 
+  /** Read a non-JSON storage value without imposing a serialization format. */
+  async readText(key: string, extension: string): Promise<string | undefined> {
+    return withMissingFallback(
+      () => StorageFS.read(keyToPath(this.dir, key, extension)),
+      undefined,
+    );
+  }
+
+  /** Append text to one storage value; callers own record framing. */
+  async appendText(
+    key: string,
+    extension: string,
+    content: string,
+  ): Promise<void> {
+    await StorageFS.ensureDir(this.dir);
+    await StorageFS.appendFile(keyToPath(this.dir, key, extension), content);
+  }
+
+  /** Atomically replace a caller-owned text value. */
+  async writeTextAtomic(
+    key: string,
+    extension: string,
+    content: string,
+  ): Promise<void> {
+    await StorageFS.ensureDir(this.dir);
+    await StorageFS.writeAtomic(keyToPath(this.dir, key, extension), content);
+  }
+
   async write<T = unknown>(key: string, value: T): Promise<void> {
     // Ensured on every write, not latched once: `dir` is storage-root
     // relative, so a cached store outlives the root it first saw (workspace
@@ -76,31 +104,55 @@ export class KVStore {
   }
 
   async delete(key: string): Promise<void> {
+    await this.deleteWithExtension(key, '.json');
+  }
+
+  async deleteWithExtension(key: string, extension: string): Promise<void> {
     await withMissingFallback(
-      () => StorageFS.delete(keyToPath(this.dir, key)),
+      () => StorageFS.delete(keyToPath(this.dir, key, extension)),
       undefined,
     );
   }
 
   async exists(key: string): Promise<boolean> {
-    return StorageFS.exists(keyToPath(this.dir, key));
+    return this.existsWithExtension(key, '.json');
+  }
+
+  async existsWithExtension(key: string, extension: string): Promise<boolean> {
+    return StorageFS.exists(keyToPath(this.dir, key, extension));
   }
 
   async modifiedAt(key: string): Promise<number | undefined> {
+    return this.modifiedAtWithExtension(key, '.json');
+  }
+
+  async modifiedAtWithExtension(
+    key: string,
+    extension: string,
+  ): Promise<number | undefined> {
     return withMissingFallback(
-      async () => (await StorageFS.stat(keyToPath(this.dir, key))).mtime,
+      async () =>
+        (await StorageFS.stat(keyToPath(this.dir, key, extension))).mtime,
       undefined,
     );
   }
 
   async listKeys(prefix?: string): Promise<string[]> {
+    return this.listKeysWithExtension('.json', prefix);
+  }
+
+  /** List keys whose files use a caller-owned extension. */
+  async listKeysWithExtension(
+    extension: string,
+    prefix?: string,
+  ): Promise<string[]> {
     const entries = await withMissingFallback(
       () => StorageFS.readDir(this.dir),
       [],
     );
     return entries
-      .filter(([name, type]) => isFile(type) && hasExtension(name, '.json'))
-      .map(([name]) => filenameToKey(name))
+      .filter(([name, type]) => isFile(type) && hasExtension(name, extension))
+      .map(([name]) => filenameToKey(name, extension))
       .filter((key) => !prefix || key.startsWith(prefix));
   }
 

--- a/src/shared/schemas/streamLogEntry.ts
+++ b/src/shared/schemas/streamLogEntry.ts
@@ -67,6 +67,9 @@ const streamLogSharedFields = {
    * Monotone order in which immutable transcript rows became printable.
    * Unlike seqNo, this is assigned when an existing row settles, so cold
    * reconstruction preserves the same append-only chronology as a live UI.
+   * A mutable group heading's slot is reserved when it opens and consumed
+   * by its terminal settlement, so headings keep open-time order under this
+   * single coordinate.
    */
   settlementSeqNo: z.int().positive().optional(),
   id: z.string().min(1),

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -225,7 +225,7 @@ function seedOpenRunGroup(
     throw new Error('The fixture parent stage must carry an id.');
   }
   withTranscriptWriter(defaultSession().transcripts, streamId, (writer) =>
-    writer.appendSettled({
+    writer.append({
       id: parentStageId,
       type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
       level: 'info',

--- a/src/test-kernel/cli/CliPersistenceFlush.vitest.ts
+++ b/src/test-kernel/cli/CliPersistenceFlush.vitest.ts
@@ -30,6 +30,7 @@ function notFound(): NodeJS.ErrnoException {
 function emptyStorage(): { writes: Map<string, unknown> } {
   const writes = new Map<string, unknown>();
   vi.spyOn(StorageFS, 'readDir').mockResolvedValue([]);
+  vi.spyOn(StorageFS, 'read').mockRejectedValue(notFound());
   vi.spyOn(StorageFS, 'readJson').mockRejectedValue(notFound());
   vi.spyOn(StorageFS, 'ensureDir').mockResolvedValue(undefined);
   vi.spyOn(StorageFS, 'stat').mockRejectedValue(notFound());
@@ -41,10 +42,23 @@ function emptyStorage(): { writes: Map<string, unknown> } {
       typeof content === 'string'
         ? content
         : Buffer.from(content).toString('utf8');
-    writes.set(target, JSON.parse(text));
+    writes.set(target, target.endsWith('.jsonl') ? text : JSON.parse(text));
   };
   vi.spyOn(StorageFS, 'write').mockImplementation(recordWrite);
   vi.spyOn(StorageFS, 'writeAtomic').mockImplementation(recordWrite);
+  vi.spyOn(StorageFS, 'appendFile').mockImplementation(
+    async (target, content) => {
+      const previous = writes.get(target);
+      const text =
+        typeof content === 'string'
+          ? content
+          : Buffer.from(content).toString('utf8');
+      writes.set(
+        target,
+        `${typeof previous === 'string' ? previous : ''}${text}`,
+      );
+    },
+  );
   vi.spyOn(StorageFS, 'delete').mockResolvedValue(undefined);
   return { writes };
 }
@@ -70,9 +84,9 @@ describe('CLI StreamLog persistence (flush on exit is load-bearing)', () => {
     const store = await StreamLogStore.open();
 
     const streamId = 'reviewer@opus#e1';
-    const logFile = path.join(
+    const journalFile = path.join(
       STREAM_LOGS_DIR,
-      `${encodeURIComponent(streamId)}.json`,
+      `${encodeURIComponent(streamId)}.jsonl`,
     );
     appendTranscriptEntry(store, streamId, entry('a', 'first'));
     appendTranscriptEntry(store, streamId, entry('b', 'second'));
@@ -80,13 +94,25 @@ describe('CLI StreamLog persistence (flush on exit is load-bearing)', () => {
     // The SAVE_DEBOUNCE_MS (300ms) timer has not fired in this synchronous
     // window, so nothing is on disk yet — this is exactly the tail the exit
     // path would lose without an explicit flush.
-    expect(storage.writes.has(logFile)).toBe(false);
+    expect(storage.writes.has(journalFile)).toBe(false);
 
     await store.flush();
 
-    expect(storage.writes.get(logFile)).toEqual([
-      expect.objectContaining({ id: 'a', text: 'first' }),
-      expect.objectContaining({ id: 'b', text: 'second' }),
+    const journal = storage.writes.get(journalFile);
+    expect(typeof journal).toBe('string');
+    const records = String(journal)
+      .trimEnd()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(records).toEqual([
+      expect.objectContaining({
+        op: 'append',
+        entry: expect.objectContaining({ id: 'a', text: 'first' }),
+      }),
+      expect.objectContaining({
+        op: 'append',
+        entry: expect.objectContaining({ id: 'b', text: 'second' }),
+      }),
     ]);
   });
 

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -378,8 +378,40 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
         kvStoreBacking.set(this.key(key), value);
       }
 
+      async readText(
+        key: string,
+        extension: string,
+      ): Promise<string | undefined> {
+        const value = kvStoreBacking.get(this.extensionKey(key, extension));
+        return typeof value === 'string' ? value : undefined;
+      }
+
+      async appendText(
+        key: string,
+        extension: string,
+        content: string,
+      ): Promise<void> {
+        const storageKey = this.extensionKey(key, extension);
+        kvStoreBacking.set(
+          storageKey,
+          `${String(kvStoreBacking.get(storageKey) ?? '')}${content}`,
+        );
+      }
+
+      async writeTextAtomic(
+        key: string,
+        extension: string,
+        content: string,
+      ): Promise<void> {
+        kvStoreBacking.set(this.extensionKey(key, extension), content);
+      }
+
       async delete(key: string): Promise<void> {
         kvStoreBacking.delete(this.key(key));
+      }
+
+      async deleteWithExtension(key: string, extension: string): Promise<void> {
+        kvStoreBacking.delete(this.extensionKey(key, extension));
       }
 
       async deleteDir(): Promise<void> {
@@ -392,8 +424,19 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
         return kvStoreBacking.has(this.key(key));
       }
 
+      async existsWithExtension(
+        key: string,
+        extension: string,
+      ): Promise<boolean> {
+        return kvStoreBacking.has(this.extensionKey(key, extension));
+      }
+
       async modifiedAt(): Promise<number | undefined> {
         return 1;
+      }
+
+      async modifiedAtWithExtension(): Promise<number | undefined> {
+        return undefined;
       }
 
       async listKeys(): Promise<string[]> {
@@ -405,12 +448,23 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
         }
         const prefix = `${this.dir}/`;
         return [...kvStoreBacking.keys()]
-          .filter((key) => key.startsWith(prefix))
+          .filter((key) => key.startsWith(prefix) && !key.endsWith('.jsonl'))
           .map((key) => key.slice(prefix.length));
+      }
+
+      async listKeysWithExtension(extension: string): Promise<string[]> {
+        const prefix = `${this.dir}/`;
+        return [...kvStoreBacking.keys()]
+          .filter((key) => key.startsWith(prefix) && key.endsWith(extension))
+          .map((key) => key.slice(prefix.length, -extension.length));
       }
 
       private key(key: string): string {
         return `${this.dir}/${key}`;
+      }
+
+      private extensionKey(key: string, extension: string): string {
+        return `${this.key(key)}${extension}`;
       }
     },
   }));

--- a/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.ts
@@ -116,7 +116,17 @@ async function createExecution(options: {
 
       async write(): Promise<void> {}
 
+      async readText(): Promise<undefined> {
+        return undefined;
+      }
+
+      async appendText(): Promise<void> {}
+
+      async writeTextAtomic(): Promise<void> {}
+
       async delete(): Promise<void> {}
+
+      async deleteWithExtension(): Promise<void> {}
 
       async deleteDir(): Promise<void> {}
 
@@ -124,8 +134,24 @@ async function createExecution(options: {
         return false;
       }
 
+      async existsWithExtension(): Promise<boolean> {
+        return false;
+      }
+
+      async modifiedAt(): Promise<undefined> {
+        return undefined;
+      }
+
+      async modifiedAtWithExtension(): Promise<undefined> {
+        return undefined;
+      }
+
       async listKeys(): Promise<string[]> {
         if (options.transcriptOpenError) throw options.transcriptOpenError;
+        return [];
+      }
+
+      async listKeysWithExtension(): Promise<string[]> {
         return [];
       }
     },

--- a/src/test-kernel/logger/RunTraceDispose.vitest.ts
+++ b/src/test-kernel/logger/RunTraceDispose.vitest.ts
@@ -71,6 +71,7 @@ describe('createRunTrace dispose', () => {
     const failure = new Error('delayed transcript write failed');
     const writer: TranscriptWriter = {
       streamId: 'failed-stream' as StreamTabId,
+      reserveSettlement: vi.fn(),
       append: vi.fn((entry) => ({ ...entry, seqNo: 0 })),
       appendSettled: vi.fn((entry) => ({ ...entry, seqNo: 0 })),
       update: vi.fn(),
@@ -116,6 +117,7 @@ describe('createRunTrace dispose', () => {
       get streamId(): StreamTabId {
         throw setupFailure;
       },
+      reserveSettlement: vi.fn(),
       append: vi.fn(),
       appendSettled: vi.fn(),
       update: vi.fn(),

--- a/src/test-kernel/transcript/StreamLog.vitest.ts
+++ b/src/test-kernel/transcript/StreamLog.vitest.ts
@@ -96,6 +96,27 @@ describe('StreamLog', () => {
     expect(delta.textChunks).toEqual([]);
   });
 
+  it('warns and drops late updates to settled entries', () => {
+    const log = new StreamLog();
+    const settled = log.appendSettled({
+      id: 'complete',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      text: 'done',
+      messageType: MESSAGE_TYPES.DEFAULT,
+    });
+    log.drainEmission();
+
+    expect(log.update('complete', { text: 'late change' })).toBeUndefined();
+    expect(log.settle('complete', { text: 'late change' })).toBeUndefined();
+    expect(log.appendText('complete', 'late text')).toBeUndefined();
+    expect(log.getRange(0).find((entry) => entry.id === 'complete')).toEqual(
+      settled,
+    );
+    expect(log.drainEmission().dirtied).toEqual([]);
+  });
+
   it('assigns one durable settlement order when rows become printable', () => {
     const log = new StreamLog();
     const header = log.appendSettled({
@@ -138,7 +159,7 @@ describe('StreamLog', () => {
 
     expect(header.settlementSeqNo).toBe(1);
     expect(completed?.settlementSeqNo).toBe(2);
-    expect(revised?.settlementSeqNo).toBe(2);
+    expect(revised).toBeUndefined();
     expect(later.settlementSeqNo).toBe(3);
   });
 

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -33,6 +33,7 @@ interface MockStorageOptions {
   /** Values are usually arrays; non-array values simulate corrupt logs. */
   logs: Record<string, unknown>;
   summaries: Record<string, unknown>;
+  journals?: Record<string, string>;
   rawLogJson?: Record<string, string>;
   rawSummaryJson?: Record<string, string>;
   logReadError?: Error;
@@ -44,7 +45,7 @@ interface MockStorageOptions {
   logMtimes?: Record<string, number>;
   summaryMtimes?: Record<string, number>;
   onLogRead?: (key: string) => Promise<void> | void;
-  onLogDelete?: (key: string) => Promise<void> | void;
+  onLogDelete?: (key: string, journal?: boolean) => Promise<void> | void;
   onLogWrite?: (key: string) => Promise<void> | void;
   onSummaryWrite?: (key: string) => Promise<void> | void;
   pauseLogWriteKey?: string;
@@ -52,6 +53,14 @@ interface MockStorageOptions {
 
 function storageFile(dir: string, key: string): string {
   return path.join(dir, `${encodeURIComponent(key)}.json`);
+}
+
+function journalFile(dir: string, key: string): string {
+  return path.join(dir, `${encodeURIComponent(key)}.jsonl`);
+}
+
+function isJournalFile(target: string): boolean {
+  return target.endsWith('.jsonl');
 }
 
 /** Which of the two stream-log directories a mocked target file lives in. */
@@ -71,7 +80,7 @@ function writtenLog(
 }
 
 function streamKeyFromFile(target: string): string {
-  return decodeURIComponent(path.basename(target).replace(/\.json$/, ''));
+  return decodeURIComponent(path.basename(target).replace(/\.jsonl?$/, ''));
 }
 
 function notFound(): NodeJS.ErrnoException {
@@ -134,6 +143,19 @@ function writtenSummary(
   streamId: string,
 ): unknown {
   return writes.get(storageFile(STREAM_LOG_SUMMARIES_DIR, streamId));
+}
+
+function writtenJournal(
+  writes: ReadonlyMap<string, unknown>,
+  streamId: string,
+): unknown[] {
+  const raw = writes.get(journalFile(STREAM_LOGS_DIR, streamId));
+  if (typeof raw !== 'string') return [];
+  return raw
+    .trimEnd()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
 }
 
 function runningGroupEntry(
@@ -205,6 +227,7 @@ function fileStat(mtime: number): FileStat {
 function mockStorage({
   logs,
   summaries,
+  journals: initialJournals = {},
   rawLogJson = {},
   rawSummaryJson = {},
   logReadError,
@@ -221,6 +244,7 @@ function mockStorage({
   onSummaryWrite,
   pauseLogWriteKey,
 }: MockStorageOptions): {
+  deletePersistedStream: (streamId: string) => void;
   deletes: string[];
   ensuredDirs: string[];
   fullLogReads: () => number;
@@ -235,13 +259,27 @@ function mockStorage({
   const deletes: string[] = [];
   const ensuredDirs: string[] = [];
   const writes = new Map<string, unknown>();
+  const journals: Record<string, string> = { ...initialJournals };
+  const projectedLogs: Record<string, unknown[]> = {};
 
   vi.spyOn(StorageFS, 'readDir').mockImplementation(async (target) => {
     if (target !== STREAM_LOGS_DIR) throw notFound();
-    return Object.keys(logs).map((key) => [
-      `${encodeURIComponent(key)}.json`,
-      FileType.File,
-    ]);
+    return [
+      ...Object.keys(logs).map(
+        (key) =>
+          [`${encodeURIComponent(key)}.json`, FileType.File] as [
+            string,
+            number,
+          ],
+      ),
+      ...Object.keys(journals).map(
+        (key) =>
+          [`${encodeURIComponent(key)}.jsonl`, FileType.File] as [
+            string,
+            number,
+          ],
+      ),
+    ];
   });
 
   // KVStore reads raw strings through StorageFS, so hand back JSON
@@ -255,6 +293,12 @@ function mockStorage({
     }
 
     if (areaOf(target) === 'log') {
+      if (isJournalFile(target)) {
+        if (!Object.hasOwn(journals, key)) throw notFound();
+        fullLogReads += 1;
+        await onLogRead?.(key);
+        return journals[key];
+      }
       if (!Object.hasOwn(logs, key)) throw notFound();
       fullLogReads += 1;
       if (logReadError) throw logReadError;
@@ -274,7 +318,11 @@ function mockStorage({
   vi.spyOn(StorageFS, 'exists').mockImplementation(async (target) => {
     const key = streamKeyFromFile(target);
     if (areaOf(target) === 'summary') return Object.hasOwn(summaries, key);
-    if (areaOf(target) === 'log') return Object.hasOwn(logs, key);
+    if (areaOf(target) === 'log') {
+      return isJournalFile(target)
+        ? Object.hasOwn(journals, key)
+        : Object.hasOwn(logs, key);
+    }
     throw new Error(`Unexpected exists target: ${target}`);
   });
   vi.spyOn(StorageFS, 'stat').mockImplementation(async (target) => {
@@ -284,7 +332,12 @@ function mockStorage({
       return fileStat(summaryMtimes[key] ?? 2);
     }
     if (areaOf(target) === 'log') {
-      if (!Object.hasOwn(logs, key)) throw notFound();
+      if (
+        isJournalFile(target)
+          ? !Object.hasOwn(journals, key)
+          : !Object.hasOwn(logs, key)
+      )
+        throw notFound();
       return fileStat(logMtimes[key] ?? 1);
     }
     throw new Error(`Unexpected stat target: ${target}`);
@@ -317,14 +370,98 @@ function mockStorage({
       typeof content === 'string'
         ? content
         : Buffer.from(content).toString('utf8');
+    if (areaOf(target) === 'log' && isJournalFile(target)) {
+      const key = streamKeyFromFile(target);
+      journals[key] = text;
+      writes.set(target, text);
+      for (const line of text.trimEnd().split('\n')) {
+        if (!line) continue;
+        const record = JSON.parse(line) as {
+          op: string;
+          entries?: unknown[];
+        };
+        if (record.op === 'seed') {
+          projectedLogs[key] = structuredClone(record.entries ?? []);
+          writes.set(storageFile(STREAM_LOGS_DIR, key), projectedLogs[key]);
+        }
+      }
+      return;
+    }
     writes.set(target, JSON.parse(text));
   };
   vi.spyOn(StorageFS, 'write').mockImplementation(recordWrite);
   vi.spyOn(StorageFS, 'writeAtomic').mockImplementation(recordWrite);
+  vi.spyOn(StorageFS, 'appendFile').mockImplementation(
+    async (target, content) => {
+      if (logWriteError && areaOf(target) === 'log') throw logWriteError;
+      const key = streamKeyFromFile(target);
+      if (
+        pauseLogWriteKey != null &&
+        !pausedLogWriteUsed &&
+        target === journalFile(STREAM_LOGS_DIR, pauseLogWriteKey)
+      ) {
+        pausedLogWriteUsed = true;
+        pausedWriteStarted.resolve();
+        await pausedWriteRelease.promise;
+      }
+      const text =
+        typeof content === 'string'
+          ? content
+          : Buffer.from(content).toString('utf8');
+      journals[key] = (journals[key] ?? '') + text;
+      writes.set(target, journals[key]);
+      // Keep the existing test helper's projected view in sync.
+      const projected =
+        projectedLogs[key] ??
+        (Array.isArray(logs[key]) ? structuredClone(logs[key]) : []);
+      for (const line of text.trimEnd().split('\n')) {
+        if (!line) continue;
+        const record = JSON.parse(line) as {
+          op: string;
+          entry?: StreamLogEntry;
+          id?: string;
+          patch?: Record<string, unknown>;
+          text?: string;
+          settled?: boolean;
+        };
+        if (record.op === 'ensure') continue;
+        if (record.op === 'append' && record.entry) {
+          projected.push(record.entry);
+          continue;
+        }
+        const entry = projected.find(
+          (value): value is Record<string, unknown> =>
+            typeof value === 'object' &&
+            value !== null &&
+            (value as Record<string, unknown>).id === record.id,
+        );
+        if (!entry) continue;
+        if (record.op === 'update' && record.patch) {
+          Object.assign(entry, record.patch);
+          if (record.settled && entry.settlementSeqNo === undefined) {
+            entry.settlementSeqNo =
+              Math.max(
+                projected.length,
+                0,
+                ...projected.map((value) =>
+                  typeof value === 'object' && value !== null
+                    ? (((value as Record<string, unknown>).settlementSeqNo as
+                        number | undefined) ?? 0)
+                    : 0,
+                ),
+              ) + 1;
+          }
+        }
+      }
+      projectedLogs[key] = projected;
+      writes.set(storageFile(STREAM_LOGS_DIR, key), projected);
+      await onLogWrite?.(key);
+    },
+  );
   vi.spyOn(StorageFS, 'delete').mockImplementation(async (target) => {
     if (logDeleteError && areaOf(target) === 'log') throw logDeleteError;
     if (areaOf(target) === 'log') {
-      await onLogDelete?.(streamKeyFromFile(target));
+      await onLogDelete?.(streamKeyFromFile(target), isJournalFile(target));
     }
     if (
       summaryDeleteError &&
@@ -334,9 +471,22 @@ function mockStorage({
     }
     deletes.push(target);
     writes.delete(target);
+    if (areaOf(target) === 'log') {
+      const key = streamKeyFromFile(target);
+      if (isJournalFile(target)) delete journals[key];
+      else delete logs[key];
+      if (isJournalFile(target) || !Object.hasOwn(journals, key)) {
+        delete projectedLogs[key];
+      }
+    }
   });
 
   return {
+    deletePersistedStream: (streamId) => {
+      delete logs[streamId];
+      delete journals[streamId];
+      delete projectedLogs[streamId];
+    },
     deletes,
     ensuredDirs,
     fullLogReads: () => fullLogReads,
@@ -389,7 +539,6 @@ describe('StreamLogStore load', () => {
     await first.flush();
 
     expect(writtenLog(storage.writes, 'registered-empty')).toEqual([]);
-    logs['registered-empty'] = [];
 
     const second = await StreamLogStore.open();
     expect(second.keys()).toEqual(['registered-empty']);
@@ -400,9 +549,46 @@ describe('StreamLogStore load', () => {
     expect(storage.fullLogReads()).toBe(2);
   });
 
+  it('replays append-only mutations over an unchanged legacy array', async () => {
+    const legacy = [logEntry('alpha', 1, 100)];
+    const storage = mockStorage({
+      logs: { alpha: structuredClone(legacy) },
+      summaries: { alpha: summary(100, 100) },
+    });
+    const first = await StreamLogStore.open();
+    await first.ensureLoaded('alpha');
+    const writer = first.acquireWriter('alpha', 'execution-alpha');
+    writer.update('alpha-1', { level: LOG_LEVELS.ERROR });
+    writer.appendText('alpha-1', ' resumed');
+    writer.settle('alpha-1', {});
+    writer.close();
+    await first.flush();
+
+    expect(writtenJournal(storage.writes, 'alpha')).toMatchObject([
+      { op: 'seed' },
+      { op: 'update', id: 'alpha-1', settled: false },
+      {
+        op: 'update',
+        id: 'alpha-1',
+        settled: true,
+        patch: { text: 'alpha entry 1 resumed' },
+      },
+    ]);
+
+    const reopened = await StreamLogStore.open();
+    await reopened.ensureLoaded('alpha');
+    expect(reopened.get('alpha')?.getRange(0)).toMatchObject([
+      {
+        id: 'alpha-1',
+        level: LOG_LEVELS.ERROR,
+        text: 'alpha entry 1 resumed',
+      },
+    ]);
+  });
+
   it('distinguishes another process deletion from a stale local summary', async () => {
     const logs: Record<string, unknown> = { alpha: [] };
-    mockStorage({ logs, summaries: {} });
+    const storage = mockStorage({ logs, summaries: {} });
 
     const staleProcessStore = await StreamLogStore.open();
     expect(staleProcessStore.has('alpha')).toBe(true);
@@ -412,7 +598,7 @@ describe('StreamLogStore load', () => {
 
     // A different process commits deletion while this store retains the
     // summary it loaded at startup.
-    delete logs.alpha;
+    storage.deletePersistedStream('alpha');
 
     expect(staleProcessStore.has('alpha')).toBe(true);
     await expect(
@@ -515,6 +701,38 @@ describe('StreamLogStore load', () => {
     writer.close();
     await store.flush();
     expect(store.get('alpha')).toBeUndefined();
+  });
+
+  it('persists metadata recorded while rehydration is in flight', async () => {
+    const meta = {
+      identity: { kind: 'agent' as const, agent: 'polish' },
+      executionId: 'racing-metadata',
+      description: 'Recorded during rehydration',
+    };
+    const readStarted = createDeferred();
+    const readGate = createDeferred();
+    const storage = mockStorage({
+      logs: { alpha: [logEntry('alpha', 1, 100)] },
+      summaries: {
+        alpha: summary(100, 100, { hasRunningGroup: false }),
+      },
+      onLogRead: async () => {
+        readStarted.resolve();
+        await readGate.promise;
+      },
+    });
+    const store = await StreamLogStore.open();
+    const loading = store.ensureLoaded('alpha');
+    await readStarted.promise;
+
+    store.recordSummaryMeta('alpha', meta);
+    readGate.resolve();
+    await loading;
+
+    await waitForCondition(
+      () => writtenSummary(storage.writes, 'alpha') !== undefined,
+    );
+    expect(writtenSummary(storage.writes, 'alpha')).toMatchObject({ meta });
   });
 
   it('keeps a writer-owned rehydrate resident when focus clears eviction', async () => {
@@ -808,8 +1026,11 @@ describe('StreamLogStore load', () => {
       summaries: {
         alpha: { firstTimestamp: 200, lastTimestamp: 200 },
       },
-      onLogDelete: () => {
-        reClaimed = true;
+      // The re-claim lands during the durable delete: the journal removal is
+      // the new format's irreversible step, while load-time legacy conversion
+      // also deletes the retired base file and must not trip the flag.
+      onLogDelete: (_key, journal) => {
+        if (journal) reClaimed = true;
       },
     });
     const store = await StreamLogStore.open();
@@ -835,8 +1056,11 @@ describe('StreamLogStore load', () => {
       summaries: {
         alpha: { firstTimestamp: 200, lastTimestamp: 200 },
       },
-      onLogDelete: () => {
-        reClaimed = true;
+      // The re-claim lands during the durable delete: the journal removal is
+      // the new format's irreversible step, while load-time legacy conversion
+      // also deletes the retired base file and must not trip the flag.
+      onLogDelete: (_key, journal) => {
+        if (journal) reClaimed = true;
       },
     });
     const store = await StreamLogStore.open();
@@ -1090,7 +1314,13 @@ describe('StreamLogStore load', () => {
   it('rehydrates summarized streams with stale running groups', async () => {
     const storage = mockStorage({
       logs: {
-        alpha: [runningGroupEntry('alpha', 1, 100)],
+        alpha: [
+          {
+            ...runningGroupEntry('alpha', 1, 100),
+            // Pre-#10774 writers settled GROUP_START rows immediately.
+            settlementSeqNo: 1,
+          },
+        ],
       },
       summaries: {
         alpha: summary(100, 100, { hasRunningGroup: true }),
@@ -1112,6 +1342,12 @@ describe('StreamLogStore load', () => {
     // endRunningGroupsForStreams() defaults to RUN_OUTCOME.FAILED, the orphan
     // sweep's caller-classified default.
     expect(entry?.data).toEqual({ status: RUN_OUTCOME.FAILED, endTime: 300 });
+    const reloaded = await StreamLogStore.open();
+    await reloaded.ensureLoaded('alpha');
+    // The recovery sweep settles the orphaned group with a fresh slot after
+    // the existing rows (the settlement counter starts past them); the stale
+    // running-order coordinate is dropped, not preserved.
+    expect(reloaded.get('alpha')?.getRange(0).at(0)?.settlementSeqNo).toBe(2);
     expect(writtenSummary(storage.writes, 'alpha')).toEqual(
       settledSummary(100, 100),
     );
@@ -1329,6 +1565,7 @@ describe('StreamLogStore load', () => {
     };
     const legacyRunningStartEntry: StreamLogEntry = {
       seqNo: 3,
+      settlementSeqNo: 3,
       id: 'delta-legacy-running',
       type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
       level: LOG_LEVELS.INFO,
@@ -1364,6 +1601,12 @@ describe('StreamLogStore load', () => {
     expect(entries.find((e) => e.id === 'delta-legacy-running')?.data).toEqual({
       status: STREAM_PHASE.RUNNING,
     });
+    // The stale running-order coordinate is dropped, not preserved: the row
+    // returns to the canonical mutable shape and recovery assigns a fresh
+    // slot when it settles.
+    expect(
+      entries.find((e) => e.id === 'delta-legacy-running')?.settlementSeqNo,
+    ).toBeUndefined();
   });
 
   it('does not load selected streams whose summaries have no running group', async () => {
@@ -1476,6 +1719,52 @@ describe('StreamLogStore load', () => {
     expect(storage.deletes).toContain(
       storageFile(STREAM_LOG_SUMMARIES_DIR, 'delete-me'),
     );
+  });
+
+  it('lets delete drain a legacy load before removing its seed journal', async () => {
+    const loadStarted = createDeferred();
+    const releaseLoad = createDeferred();
+    mockStorage({
+      logs: { alpha: [logEntry('alpha', 1, 100)] },
+      summaries: { alpha: summary(100, 100) },
+      onLogRead: async () => {
+        loadStarted.resolve();
+        await releaseLoad.promise;
+      },
+    });
+    const store = await StreamLogStore.open();
+
+    const load = store.ensureLoaded('alpha');
+    await loadStarted.promise;
+    const deletion = store.delete('alpha');
+    releaseLoad.resolve();
+    await Promise.all([load, deletion]);
+
+    expect(store.has('alpha')).toBe(false);
+    expect((await StreamLogStore.open()).has('alpha')).toBe(false);
+  });
+
+  it('lets delete drain a direct legacy read before removing its seed journal', async () => {
+    const readStarted = createDeferred();
+    const releaseRead = createDeferred();
+    mockStorage({
+      logs: { alpha: [logEntry('alpha', 1, 100)] },
+      summaries: { alpha: summary(100, 100) },
+      onLogRead: async () => {
+        readStarted.resolve();
+        await releaseRead.promise;
+      },
+    });
+    const store = await StreamLogStore.open();
+
+    const read = store.readEntries('alpha');
+    await readStarted.promise;
+    const deletion = store.delete('alpha');
+    releaseRead.resolve();
+    await Promise.all([read, deletion]);
+
+    expect(store.has('alpha')).toBe(false);
+    expect((await StreamLogStore.open()).has('alpha')).toBe(false);
   });
 
   it('flushes unrelated dirty streams when delete cancels a pending save', async () => {
@@ -1615,7 +1904,9 @@ describe('StreamLogStore load', () => {
     expect(writtenLog(storage.writes, 'alpha')).toEqual([
       expect.objectContaining({ id: 'alpha-1', seqNo: 1 }),
       unknownFutureEntry,
-      expect.objectContaining({ id: 'alpha-3', seqNo: 2 }),
+      // Legacy rows remain byte-for-byte in the base array; JSONL records
+      // carry their live sequence and are renumbered only when replayed.
+      expect.objectContaining({ id: 'alpha-3', seqNo: 3 }),
       malformedEntry,
       expect.objectContaining({ id: 'alpha-new', seqNo: 3 }),
     ]);
@@ -1705,7 +1996,27 @@ describe('StreamLogStore load', () => {
     );
   });
 
-  it('writes dirty transcripts sequentially', async () => {
+  it('flushes healthy streams before reporting a failed-load stream', async () => {
+    const storage = mockStorage({ logs: {}, summaries: {} });
+    const store = await StreamLogStore.open();
+    appendTranscriptEntry(store, 'blocked', logEntry('blocked', 1, 100));
+    appendTranscriptEntry(store, 'healthy', logEntry('healthy', 1, 200));
+
+    const state = (
+      store as unknown as {
+        streams: Map<string, { loadFailed?: boolean }>;
+      }
+    ).streams.get('blocked');
+    if (!state) throw new Error('Expected blocked stream state');
+    state.loadFailed = true;
+
+    await expect(store.flush()).rejects.toThrow(
+      'skipped 1 stream(s) whose persisted transcript failed to load',
+    );
+    expect(writtenLog(storage.writes, 'healthy')).toHaveLength(1);
+  });
+
+  it('persists unrelated transcripts independently', async () => {
     let activeWrites = 0;
     let maximumActiveWrites = 0;
     const storage = mockStorage({
@@ -1725,7 +2036,7 @@ describe('StreamLogStore load', () => {
 
     await store.flush();
 
-    expect(maximumActiveWrites).toBe(1);
+    expect(maximumActiveWrites).toBe(3);
     expect(
       ['alpha', 'beta', 'gamma'].every((streamId) =>
         storage.writes.has(storageFile(STREAM_LOGS_DIR, streamId)),
@@ -1744,13 +2055,122 @@ describe('StreamLogStore load', () => {
   });
 });
 
-describe('StreamLogStore save throttle', () => {
+describe('StreamLogStore append-only persistence', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it('writes periodically under sustained sub-window appends and drains on flush', async () => {
+  it('repairs a valid journal record that lacks its final newline', async () => {
+    const seed = JSON.stringify({
+      version: 1,
+      opId: '11111111-1111-4111-8111-111111111111',
+      op: 'seed',
+      entries: [logEntry('alpha', 1, 100)],
+    });
+    const storage = mockStorage({
+      logs: {},
+      summaries: {},
+      journals: { alpha: seed },
+    });
+
+    const store = await StreamLogStore.open();
+    await store.ensureLoaded('alpha');
+
+    expect(storage.writes.get(journalFile(STREAM_LOGS_DIR, 'alpha'))).toBe(
+      `${seed}\n`,
+    );
+    expect(store.get('alpha')?.getRange(0).at(0)?.id).toBe('alpha-1');
+  });
+
+  it('ignores an invalid update record without corrupting its entry', async () => {
+    const journal = [
+      {
+        version: 1,
+        opId: '11111111-1111-4111-8111-111111111111',
+        op: 'seed',
+        entries: [logEntry('alpha', 1, 100)],
+      },
+      {
+        version: 1,
+        opId: '22222222-2222-4222-8222-222222222222',
+        op: 'update',
+        id: 'alpha-1',
+        patch: { text: 42 },
+        settled: true,
+      },
+    ]
+      .map((record) => JSON.stringify(record))
+      .join('\n');
+    mockStorage({
+      logs: {},
+      summaries: {},
+      journals: { alpha: `${journal}\n` },
+    });
+
+    const store = await StreamLogStore.open();
+    await store.ensureLoaded('alpha');
+
+    expect(store.get('alpha')?.getRange(0).at(0)).toMatchObject({
+      id: 'alpha-1',
+      text: 'alpha entry 1',
+    });
+  });
+
+  it('preserves invalid overlay records when replacing a legacy array', async () => {
+    const invalidRecord = {
+      version: 1,
+      opId: '22222222-2222-4222-8222-222222222222',
+      op: 'future-operation',
+      payload: { keep: true },
+    };
+    const append = {
+      version: 1,
+      opId: '11111111-1111-4111-8111-111111111111',
+      op: 'append',
+      entry: logEntry('alpha', 2, 200),
+      settled: false,
+    };
+    const storage = mockStorage({
+      logs: { alpha: [logEntry('alpha', 1, 100)] },
+      summaries: {},
+      journals: {
+        alpha: `${JSON.stringify(invalidRecord)}\n${JSON.stringify(append)}\n`,
+      },
+    });
+
+    await StreamLogStore.open();
+
+    expect(writtenJournal(storage.writes, 'alpha')).toEqual([
+      expect.objectContaining({
+        op: 'seed',
+        entries: expect.arrayContaining([invalidRecord]),
+      }),
+    ]);
+  });
+
+  it('loads a seeded journal without parsing a corrupt retired array', async () => {
+    const seed = JSON.stringify({
+      version: 1,
+      opId: '11111111-1111-4111-8111-111111111111',
+      op: 'seed',
+      entries: [logEntry('alpha', 1, 100)],
+    });
+    const storage = mockStorage({
+      logs: { alpha: [] },
+      summaries: {},
+      rawLogJson: { alpha: '{"corrupt":' },
+      journals: { alpha: `${seed}\n` },
+    });
+
+    const store = await StreamLogStore.open();
+    await store.ensureLoaded('alpha');
+
+    expect(store.get('alpha')?.getRange(0).at(0)?.id).toBe('alpha-1');
+    expect(storage.deletes).toContain(storageFile(STREAM_LOGS_DIR, 'alpha'));
+  });
+
+  it('persists streaming text only when the whole entry settles', async () => {
     let logWrites = 0;
     const storage = mockStorage({
       logs: {},
@@ -1764,26 +2184,25 @@ describe('StreamLogStore save throttle', () => {
 
     const writer = store.acquireWriter('alpha', 'execution-alpha');
     writer.append(namedEntry('m1', 1, ''));
-    // 20 chunks 100ms apart: a trailing debounce would reset its timer on
-    // every append and never write until the stream pauses; the max-wait
-    // throttle must produce a durable write per 300ms window regardless.
+    // Chunk-level records are deliberately not durable: independently
+    // redacted chunks can preserve a secret split across chunk boundaries.
     for (let i = 0; i < 20; i += 1) {
       writer.appendText('m1', `chunk-${i} `);
       await vi.advanceTimersByTimeAsync(100);
     }
-    expect(logWrites).toBeGreaterThanOrEqual(5);
+    expect(logWrites).toBe(1);
 
-    // The tail landed after the last periodic write; flush drains it.
-    const writesBeforeFlush = logWrites;
+    // Settlement materializes and persists the whole-buffer text once.
+    writer.settle('m1', {});
     writer.close();
     await store.flush();
-    expect(logWrites).toBeGreaterThan(writesBeforeFlush);
+    expect(logWrites).toBe(2);
     expect(writtenLog(storage.writes, 'alpha')[0]?.text).toBe(
       Array.from({ length: 20 }, (_, i) => `chunk-${i} `).join(''),
     );
   });
 
-  it('bounds the durability gap to one throttle window for a first append', async () => {
+  it('starts persistence on the next event-loop turn for a first append', async () => {
     const storage = mockStorage({ logs: {}, summaries: {} });
     const store = await StreamLogStore.open();
     vi.useFakeTimers();
@@ -1792,12 +2211,12 @@ describe('StreamLogStore save throttle', () => {
     writer.append(namedEntry('m1', 1, 'first entry'));
     expect(writtenLog(storage.writes, 'alpha')).toBeUndefined();
 
-    await vi.advanceTimersByTimeAsync(300);
+    await vi.advanceTimersByTimeAsync(0);
     expect(writtenLog(storage.writes, 'alpha')).toHaveLength(1);
     writer.close();
   });
 
-  it('queues a save window that fires while a write batch is in flight', async () => {
+  it('serializes a later mutation behind an in-flight append', async () => {
     const bothWritesLanded = createDeferred();
     let logWrites = 0;
     const storage = mockStorage({
@@ -1814,16 +2233,14 @@ describe('StreamLogStore save throttle', () => {
 
     const writer = store.acquireWriter('alpha', 'execution-alpha');
     writer.append(namedEntry('m1', 1, ''));
-    writer.appendText('m1', 'first ');
-    await vi.advanceTimersByTimeAsync(300);
+    writer.update('m1', { text: 'first ' });
+    await vi.advanceTimersByTimeAsync(0);
     await storage.waitForPausedWrite();
 
-    // Mutate while the first batch's write hangs, and let a second window
-    // fire. An unserialized second batch would persist the newer snapshot
-    // during the pause and then get clobbered when the paused older write
-    // completes last; the queued batch must instead run after it.
-    writer.appendText('m1', 'second');
-    await vi.advanceTimersByTimeAsync(300);
+    // Mutate while the first append hangs. A concurrent append could land
+    // out of order; the later mutation must instead run after it.
+    writer.update('m1', { text: 'first second' });
+    await vi.advanceTimersByTimeAsync(0);
     storage.releasePausedWrite();
     await bothWritesLanded.promise;
     writer.close();
@@ -1843,10 +2260,10 @@ describe('StreamLogStore save throttle', () => {
 
     const writer = store.acquireWriter('alpha', 'execution-alpha');
     writer.append(namedEntry('m1', 1, 'first'));
-    await vi.advanceTimersByTimeAsync(300);
+    await vi.advanceTimersByTimeAsync(0);
     await storage.waitForPausedWrite();
 
-    // A rollback reload must not resolve while a write batch is still
+    // A rollback reload must not resolve while an append is still
     // running against the pre-rollback adapters.
     let reloaded = false;
     const reload = store.reload({ discardPendingWrites: true }).then(() => {
@@ -1972,7 +2389,7 @@ describe('StreamLogStore summary metadata mirror', () => {
     expect(reopened.getSummaryMeta('alpha')).toEqual(META);
   });
 
-  it('does not persist dirty log fields through a metadata-only write', async () => {
+  it('carries metadata with the immediate log append', async () => {
     const storage = mockStorage({
       logs: { alpha: [logEntry('alpha', 1, 200)] },
       summaries: { alpha: summary(200, 200) },
@@ -1984,7 +2401,13 @@ describe('StreamLogStore summary metadata mirror', () => {
     store.recordSummaryMeta('alpha', META);
     await delay(0);
 
-    expect(writtenSummary(storage.writes, 'alpha')).toBeUndefined();
+    expect(writtenJournal(storage.writes, 'alpha')).toEqual([
+      expect.objectContaining({ op: 'seed' }),
+      expect.objectContaining({
+        op: 'append',
+        entry: expect.objectContaining({ id: 'alpha-2' }),
+      }),
+    ]);
 
     await store.flush();
     expect(writtenSummary(storage.writes, 'alpha')).toMatchObject({

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -102,6 +102,7 @@ describe('attachTranscriptRecorder StreamPhase-native group rows (issue #7993)',
     const endEntry = row(stage.id);
 
     expect(endEntry?.type).toBe(STREAM_LOG_ENTRY_TYPES.GROUP_END);
+    expect(endEntry?.settlementSeqNo).toBeDefined();
     expect(dataOf(endEntry).status).toBe(RUN_OUTCOME.COMPLETED);
   });
 
@@ -211,6 +212,42 @@ describe('attachTranscriptRecorder response.finalized (issue #7086)', () => {
     expect(modelResponseEntries[0]?.text).toBe('The answer is 2.');
   });
 
+  it('bounds and spills a non-streaming finalized response', async () => {
+    const trace = new TraceEmitter();
+    const streamId = 'stream:non-stream-spill' as StreamTabId;
+    const store = StreamLogStore.ephemeral('test');
+    store.ensureStream(streamId);
+    const writes: Array<{ path: string; content: string }> = [];
+    const recorder = attachTranscriptRecorder(
+      trace,
+      store.acquireWriter(streamId, streamId),
+      {
+        pathFor: (id) => `executions/test/toolOutput/${id}.txt`,
+        write: async (path, content) => {
+          writes.push({ path, content });
+        },
+      },
+    );
+    const response = `${'line\n'.repeat(2_100)}API_KEY=non-stream-secret`;
+
+    trace.responseFinalized(response);
+    await recorder.flushSpills();
+
+    const entry = store.get(streamId)?.getRange(0).at(-1);
+    expect(entry?.messageType).toBe(MESSAGE_TYPES.MODEL_RESPONSE);
+    expect(entry?.text).toContain('retained in run artifacts');
+    expect(entry?.text).not.toContain('non-stream-secret');
+    expect(dataOf(entry).spillPath).toBe(
+      `executions/test/toolOutput/${entry?.id}.txt`,
+    );
+    expect(writes).toEqual([
+      {
+        path: `executions/test/toolOutput/${entry?.id}.txt`,
+        content: expect.not.stringContaining('non-stream-secret'),
+      },
+    ]);
+  });
+
   it('does not let an earlier round leak its stream id into a later round', () => {
     const { trace, rows } = attachRecorder();
 
@@ -302,6 +339,31 @@ describe('attachTranscriptRecorder response.finalized (issue #7086)', () => {
 });
 
 describe('attachTranscriptRecorder workflow task state', () => {
+  it('settles a model response that ends after a new round starts', () => {
+    const { trace, row } = attachRecorder();
+    const response = trace.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
+    response.append('Final answer');
+
+    const nextRound = trace.openStage('Next round', { kind: 'round' });
+    trace.toolStart({
+      logId: 'tool:next-round',
+      toolName: 'read',
+      input: { path: 'paper.tex' },
+    });
+    trace.toolEnd({ logId: 'tool:next-round', status: 'completed' });
+    response.finalize();
+
+    expect(row(response.id)).toMatchObject({
+      settlementSeqNo: 1,
+      text: 'Final answer',
+      data: { status: 'completed' },
+    });
+    // The heading reserved slot 2 at open but is still running, so no
+    // settlement is visible on the row yet; the tool settles after it.
+    expect(row(nextRound.id)?.settlementSeqNo).toBeUndefined();
+    expect(row('tool:next-round')?.settlementSeqNo).toBe(3);
+  });
+
   it('assigns source settlement order before terminal status projection', () => {
     const streamId = 'stream:terminal-settlement' as StreamTabId;
     const { trace, handleStatus, row, rows } = attachRecorder(streamId);

--- a/src/transcript/StreamLog.ts
+++ b/src/transcript/StreamLog.ts
@@ -1,3 +1,4 @@
+import { createLog } from '@logger/logUtils';
 import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
@@ -8,6 +9,8 @@ import {
   type WorkflowCallProgress,
 } from '@shared/schemas';
 import { isObject } from '@utils/core';
+
+const logger = createLog('StreamLog');
 
 export type StreamLogAppendInput = Omit<
   StreamLogEntry,
@@ -281,6 +284,7 @@ export class StreamLog {
    */
   private readonly pendingTextChunks = new Map<string, string[]>();
   private settlementSeqCounter = 0;
+  private readonly reservedSettlements = new Map<string, number>();
   private runningGroupCount = 0;
   private runningStreamingTextCount = 0;
   private nonterminalWorkflowCallCount = 0;
@@ -343,6 +347,25 @@ export class StreamLog {
   /** Latest durable append-only transcript order allocated by this stream. */
   get settlementHead(): number {
     return this.settlementSeqCounter;
+  }
+
+  /**
+   * Reserve a mutable entry's eventual settlement slot at its open time, so
+   * a group heading settles at the position it appeared instead of where its
+   * terminal record lands — `updateWithSettlement` consumes the reservation
+   * as the entry's `settlementSeqNo`. In-memory only, deliberately: the
+   * settlement coordinate is the single persisted ordering authority, so a
+   * crash drops unconsumed reservations and the recovery sweep settles those
+   * orphans in sweep order instead.
+   */
+  reserveSettlement(id: string): void {
+    const index = this.indexById.get(id);
+    if (index === undefined) return;
+    if (this.entries[index].settlementSeqNo !== undefined) return;
+    if (!this.reservedSettlements.has(id)) {
+      this.settlementSeqCounter += 1;
+      this.reservedSettlements.set(id, this.settlementSeqCounter);
+    }
   }
 
   /**
@@ -478,12 +501,18 @@ export class StreamLog {
     if (index === undefined) return undefined;
 
     const current = this.entries[index];
-    const settlementSeqNo =
-      settle && current.settlementSeqNo === undefined
-        ? this.settlementSeqCounter + 1
-        : current.settlementSeqNo;
+    if (current.settlementSeqNo !== undefined) {
+      logger.warn(`Ignoring update to settled transcript entry: ${id}`);
+      return undefined;
+    }
+    const reservedSettlement = settle
+      ? this.reservedSettlements.get(id)
+      : undefined;
+    const settlementSeqNo = settle
+      ? (reservedSettlement ?? this.settlementSeqCounter + 1)
+      : current.settlementSeqNo;
     if (
-      settlementSeqNo === current.settlementSeqNo &&
+      !settle &&
       Object.entries(patch).every(([key, value]) =>
         Object.is(current[key as keyof StreamLogUpdatePatch], value),
       )
@@ -496,16 +525,27 @@ export class StreamLog {
     // AgentTrace. Persisted entries are parsed when loaded from storage.
     // Spreading `current` reads its (possibly lazy) text getter, so this is
     // where a streaming entry's chunks are joined into a plain value.
+    const mergedData =
+      current.type === STREAM_LOG_ENTRY_TYPES.GROUP_START &&
+      patch.type === STREAM_LOG_ENTRY_TYPES.GROUP_END &&
+      patch.data !== undefined
+        ? { ...current.data, ...patch.data }
+        : patch.data;
     const updated = {
       ...current,
       ...patch,
+      ...(mergedData !== undefined ? { data: mergedData } : {}),
       id: current.id,
       seqNo: current.seqNo,
       ...(settlementSeqNo !== undefined ? { settlementSeqNo } : {}),
     } as StreamLogEntry;
-    if (settlementSeqNo !== current.settlementSeqNo) {
+    if (
+      settlementSeqNo !== current.settlementSeqNo &&
+      reservedSettlement === undefined
+    ) {
       this.settlementSeqCounter += 1;
     }
+    if (settle) this.reservedSettlements.delete(id);
 
     this.countEntry(current, -1);
     this.countEntry(updated, 1);
@@ -524,6 +564,10 @@ export class StreamLog {
 
     const current = this.entries[index];
     if (current.type !== STREAM_LOG_ENTRY_TYPES.LOG) return undefined;
+    if (current.settlementSeqNo !== undefined) {
+      logger.warn(`Ignoring text append to settled transcript entry: ${id}`);
+      return undefined;
+    }
 
     let acc = this.streamingText.get(id);
     if (!acc) {

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { isDeepStrictEqual } from 'node:util';
 import pMap from 'p-map';
 import PQueue from 'p-queue';
@@ -12,6 +13,7 @@ import {
   END_GROUP_STATUS,
   ExecutionIdSchema,
   RUN_OUTCOME,
+  STREAM_PHASE,
   RunIdentitySchema,
   STREAM_LOG_ENTRY_TYPES,
   StreamLogEntrySchema,
@@ -20,7 +22,7 @@ import {
   type StreamLogEntry,
   type StreamTabId,
 } from '@shared/schemas';
-import { createFlushableDebounce, filterNotNull, isObject } from '@utils/core';
+import { filterNotNull, isObject } from '@utils/core';
 import { createListenerSet } from '@utils/core/listenerSet';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { StorageFS } from '@utils/files/storageFS';
@@ -38,11 +40,12 @@ import {
   type StreamLogUpdatePatch,
 } from './StreamLog';
 
-const SAVE_MAX_WAIT_MS = 300;
 export const STREAM_LOGS_DIR = WORKSPACE_STORAGE_LAYOUT.streamLogs;
 export const STREAM_LOG_SUMMARIES_DIR =
   WORKSPACE_STORAGE_LAYOUT.streamLogSummaries;
 const STREAM_LOG_LOAD_CONCURRENCY = 8;
+const STREAM_LOG_JOURNAL_EXTENSION = '.jsonl';
+const STREAM_LOG_JOURNAL_VERSION = 1;
 const LOG_TAG = 'StreamLogStore';
 const log = createLog(LOG_TAG);
 
@@ -126,6 +129,91 @@ interface ParsedPersistedEntries {
   preservedRawEntries: StreamLogPreservedRawEntry[];
 }
 
+const StreamLogJournalRecordSchema = z.discriminatedUnion('op', [
+  z.object({
+    version: z.literal(STREAM_LOG_JOURNAL_VERSION),
+    opId: z.uuid(),
+    op: z.literal('seed'),
+    entries: z.array(z.unknown()),
+  }),
+  z.object({
+    version: z.literal(STREAM_LOG_JOURNAL_VERSION),
+    opId: z.uuid(),
+    op: z.literal('ensure'),
+  }),
+  z.object({
+    version: z.literal(STREAM_LOG_JOURNAL_VERSION),
+    opId: z.uuid(),
+    op: z.literal('append'),
+    entry: StreamLogEntrySchema,
+    settled: z.boolean(),
+  }),
+  z.object({
+    version: z.literal(STREAM_LOG_JOURNAL_VERSION),
+    opId: z.uuid(),
+    op: z.literal('update'),
+    id: z.string().min(1),
+    patch: z.looseObject({}),
+    settled: z.boolean(),
+  }),
+]);
+type StreamLogJournalRecord = z.infer<typeof StreamLogJournalRecordSchema>;
+type StreamLogJournalRecordInput =
+  | { readonly op: 'ensure' }
+  | { readonly op: 'seed'; readonly entries: readonly unknown[] }
+  | {
+      readonly op: 'append';
+      readonly entry: StreamLogEntry;
+      readonly settled: boolean;
+    }
+  | {
+      readonly op: 'update';
+      readonly id: string;
+      readonly patch: StreamLogUpdatePatch;
+      readonly settled: boolean;
+    };
+
+interface ParsedJsonlRecords {
+  readonly entries: unknown[];
+  readonly repairedText?: string;
+}
+
+/** Parse independent records and isolate corrupt or torn lines loudly. */
+function parseJsonlEntries(
+  streamId: StreamTabId,
+  raw: string,
+): ParsedJsonlRecords {
+  const lines = raw.split('\n');
+  const entries: unknown[] = [];
+  let repairedText: string | undefined;
+  for (const [index, line] of lines.entries()) {
+    if (!line) continue;
+    try {
+      entries.push(JSON.parse(line));
+    } catch (error) {
+      const tornTail = index === lines.length - 1 && !raw.endsWith('\n');
+      log.warn(
+        `Stream ${streamId}: ignoring ${tornTail ? 'torn final' : 'malformed'} journal line ${index + 1}: ${toErrorMessage(error)}`,
+      );
+      if (tornTail) repairedText = lines.slice(0, index).join('\n') + '\n';
+    }
+  }
+  if (raw.length > 0 && !raw.endsWith('\n') && repairedText === undefined) {
+    repairedText = `${raw}\n`;
+  }
+  return { entries, ...(repairedText !== undefined ? { repairedText } : {}) };
+}
+
+function toJournalRecord(
+  record: StreamLogJournalRecordInput,
+): StreamLogJournalRecord {
+  return {
+    version: STREAM_LOG_JOURNAL_VERSION,
+    opId: randomUUID(),
+    ...record,
+  } as StreamLogJournalRecord;
+}
+
 type StreamLogStoreMode =
   | { readonly kind: 'persistent' }
   | { readonly kind: 'read-only' }
@@ -186,6 +274,7 @@ export async function clearPersistedSummaryParentStream(
 
 export interface TranscriptWriter {
   readonly streamId: StreamTabId;
+  reserveSettlement(id: string): void;
   append(entry: StreamLogAppendInput): StreamLogEntry;
   appendSettled(entry: StreamLogAppendInput): StreamLogEntry;
   update(id: string, patch: StreamLogUpdatePatch): StreamLogEntry | undefined;
@@ -245,8 +334,20 @@ interface StreamState {
   loadFailed?: boolean;
   /** In-flight `ensureLoaded`; deduplicates concurrent calls for one stream. */
   pendingLoad?: Promise<void>;
+  /** Completion of the latest queued non-resident `readEntries` read. */
+  pendingRead?: Promise<void>;
   /** Exact mutation capabilities currently keeping a stream resident. */
   writer?: StreamWriterOwnership;
+  /** Unflushed append-only records, retained until their exact prefix lands. */
+  journalRecords?: StreamLogJournalRecord[];
+  /** A failed append may have left a torn tail that must be repaired first. */
+  journalNeedsTailRepair?: boolean;
+  /** Current task in the per-stream persistence queue. */
+  persistenceWork?: Promise<void>;
+  /** The derived summary must be refreshed after the journal prefix lands. */
+  summaryDirty?: boolean;
+  /** Last asynchronous persistence error, surfaced and retried by flush(). */
+  persistenceError?: unknown;
 }
 
 /**
@@ -273,6 +374,36 @@ function toSummary(source: SummarySource): StreamLogSummary {
       ? { hasNonterminalWorkflowCall: true }
       : {}),
   };
+}
+
+function parsePersistedUpdate(
+  current: StreamLogEntry,
+  patch: Record<string, unknown>,
+): StreamLogUpdatePatch | undefined {
+  const mergedData =
+    current.type === STREAM_LOG_ENTRY_TYPES.GROUP_START &&
+    patch.type === STREAM_LOG_ENTRY_TYPES.GROUP_END &&
+    isObject(patch.data)
+      ? { ...current.data, ...patch.data }
+      : patch.data;
+  const result = StreamLogEntrySchema.safeParse({
+    ...current,
+    ...patch,
+    ...(mergedData !== undefined ? { data: mergedData } : {}),
+    id: current.id,
+    seqNo: current.seqNo,
+    ...(current.settlementSeqNo !== undefined
+      ? { settlementSeqNo: current.settlementSeqNo }
+      : {}),
+  });
+  if (!result.success) return undefined;
+  const {
+    id: _id,
+    seqNo: _seqNo,
+    settlementSeqNo: _settlementSeqNo,
+    ...validatedPatch
+  } = result.data;
+  return validatedPatch;
 }
 
 /**
@@ -305,17 +436,38 @@ function normalizeGroupStatusEntry(entry: StreamLogEntry): StreamLogEntry {
   if (!isObject(entry.data) || typeof entry.data.status !== 'string') {
     return entry;
   }
+  let normalized = entry;
   switch (entry.data.status) {
     case END_GROUP_STATUS.STOPPED:
-      return {
+      normalized = {
         ...entry,
         data: { ...entry.data, status: RUN_OUTCOME.COMPLETED },
       };
+      break;
     case END_GROUP_STATUS.ERROR:
-      return { ...entry, data: { ...entry.data, status: RUN_OUTCOME.FAILED } };
-    default:
-      return entry;
+      normalized = {
+        ...entry,
+        data: { ...entry.data, status: RUN_OUTCOME.FAILED },
+      };
+      break;
   }
+
+  // Temporary reader introduced 2026-08-17 for pre-#10774 logs. Group-start
+  // rows used to allocate settlement order while still running; restore them
+  // to the canonical mutable shape so recovery can terminalize them through
+  // StreamLog.settle(), which assigns a fresh slot. The stale running-order
+  // coordinate is dropped rather than preserved — settlement is the single
+  // ordering authority. Retire after 2026-11-17, when those internal logs
+  // are outside the compatibility window.
+  if (
+    normalized.type === STREAM_LOG_ENTRY_TYPES.GROUP_START &&
+    normalized.data.status === STREAM_PHASE.RUNNING &&
+    normalized.settlementSeqNo !== undefined
+  ) {
+    const { settlementSeqNo: _legacySettlement, ...unsettled } = normalized;
+    return unsettled as StreamLogEntry;
+  }
+  return normalized;
 }
 
 /**
@@ -339,22 +491,13 @@ export class StreamLogStore {
   /**
    * All per-stream resident state (heavy log, leases, load failure, pending
    * release/load, active writer) in one record per stream. See
-   * {@link StreamState}. `summaries`, `writeTombstones`, and `dirtyIds` are
-   * deliberately kept separate because they do not share this lifecycle.
+   * {@link StreamState}. `summaries` and `writeTombstones` are deliberately
+   * kept separate because they do not share this lifecycle.
    */
   private readonly streams = new ResidentStreamRegistry<
     StreamTabId,
     StreamState
   >(() => ({}));
-  /**
-   * Streams with unsaved changes awaiting `executeWrite`, kept as a dedicated
-   * set (not a `StreamState` field) so the `save()` hot path can test
-   * dirtiness in O(1) via `.size`/`.has` instead of scanning every record.
-   * A dirty stream always has a resident `log` (or a deferred `loadFailed`/
-   * `pendingLoad` record), so its `StreamState` is never pruned while it is
-   * still listed here — see `pruneStreamState`.
-   */
-  private readonly dirtyIds = new Set<StreamTabId>();
   /**
    * Streams that return to cold storage whenever their leases drain. This
    * policy outlives resident state so a terminal stream remains cold after a
@@ -370,6 +513,8 @@ export class StreamLogStore {
   private readonly kvHandles = new KVStoreCache<string>(
     (dir) => new KVStore(dir, { compactJson: true }),
   );
+  /** One serial queue per active stream; different streams remain independent. */
+  private readonly persistenceQueues = new Map<StreamTabId, PQueue>();
 
   /**
    * Lightweight summary per stream (first/last timestamp). Populated at open
@@ -389,23 +534,6 @@ export class StreamLogStore {
     StreamSummaryMeta
   >();
 
-  /**
-   * Max-wait throttle for the persistence path: the first dirty mutation in a
-   * window starts the timer and later mutations join it without resetting it
-   * (`scheduleSave`'s `pending` guard), so sustained sub-window appends still
-   * produce a durable write every SAVE_MAX_WAIT_MS instead of starving a
-   * trailing debounce. A crash mid-stream loses at most one window.
-   */
-  private readonly saveThrottle = createFlushableDebounce(
-    () => void this.executeWrite(),
-    SAVE_MAX_WAIT_MS,
-  );
-  /**
-   * Serializes write batches: a throttle window, a flush, or a delete that
-   * starts a write while one is still in flight queues behind it instead of
-   * racing it, so two batches can never persist the same stream out of order.
-   */
-  private readonly writeQueue = new PQueue({ concurrency: 1 });
   private writeGeneration = 0;
   private readonly writeTombstones = new Set<StreamTabId>();
   private clearing = false;
@@ -420,6 +548,40 @@ export class StreamLogStore {
   /** Handle over `STREAM_LOGS_DIR`; re-resolved after a storage-root reload. */
   private kv(): KVStore {
     return this.kvHandles.get(STREAM_LOGS_DIR);
+  }
+
+  private persistenceQueue(streamId: StreamTabId): PQueue {
+    let queue = this.persistenceQueues.get(streamId);
+    if (!queue) {
+      queue = new PQueue({ concurrency: 1 });
+      this.persistenceQueues.set(streamId, queue);
+    }
+    return queue;
+  }
+
+  private retirePersistenceQueueIfIdle(
+    streamId: StreamTabId,
+    queue: PQueue,
+  ): void {
+    if (
+      queue.pending === 0 &&
+      queue.size === 0 &&
+      this.persistenceQueues.get(streamId) === queue
+    ) {
+      this.persistenceQueues.delete(streamId);
+    }
+  }
+
+  private async runInPersistenceQueue<T>(
+    streamId: StreamTabId,
+    task: () => Promise<T>,
+  ): Promise<T> {
+    const queue = this.persistenceQueue(streamId);
+    try {
+      return (await queue.add(task)) as T;
+    } finally {
+      this.retirePersistenceQueueIfIdle(streamId, queue);
+    }
   }
 
   /** Handle over `STREAM_LOG_SUMMARIES_DIR`; same lifecycle as `kv()`. */
@@ -438,10 +600,7 @@ export class StreamLogStore {
 
   /**
    * Drop a record once none of its fields hold state, so an idle stream costs
-   * no memory. Dirtiness lives in the separate `dirtyIds` set and is
-   * intentionally NOT consulted here: a dirty stream always retains a `log`
-   * (or a `loadFailed`/`pendingLoad` deferral record), so the field checks
-   * below already keep its record alive.
+   * no memory.
    */
   private pruneStreamState(streamId: StreamTabId): void {
     this.streams.pruneIfEmpty(
@@ -453,13 +612,14 @@ export class StreamLogStore {
           s.presentationLeases.size === 0) &&
         !s.loadFailed &&
         s.pendingLoad === undefined &&
-        s.writer === undefined,
+        s.pendingRead === undefined &&
+        s.writer === undefined &&
+        !s.journalNeedsTailRepair &&
+        (s.journalRecords === undefined || s.journalRecords.length === 0) &&
+        s.persistenceWork === undefined &&
+        !s.summaryDirty &&
+        s.persistenceError === undefined,
     );
-  }
-
-  /** Snapshot of streams with unsaved changes (list form of `dirtyIds`). */
-  private dirtyStreamIds(): StreamTabId[] {
-    return [...this.dirtyIds];
   }
 
   /** In-flight `ensureLoaded` promises across every resident stream. */
@@ -555,13 +715,15 @@ export class StreamLogStore {
 
   /** Read a transcript once without adding it to the resident set. */
   async readEntries(streamId: StreamTabId): Promise<StreamLogEntry[]> {
+    if (this.pendingReload) await this.pendingReload;
+    if (this.clearing || this.writeTombstones.has(streamId)) return [];
     const resident = this.streams.get(streamId)?.log;
     if (resident) return resident.toJSON();
     if (this.mode.kind === 'ephemeral' || !this.summaries.has(streamId)) {
       return [];
     }
-    const raw = await this.kv().read<unknown[]>(streamId);
-    const parsed = this.parsePersistedEntries(streamId, raw);
+    const parsed = await this.readPersistedEntries(streamId);
+    if (!parsed) return [];
     return new StreamLog(parsed.entries, parsed.preservedRawEntries).toJSON();
   }
 
@@ -581,7 +743,7 @@ export class StreamLogStore {
    */
   async hasAuthoritativeStream(streamId: StreamTabId): Promise<boolean> {
     if (this.mode.kind === 'ephemeral') return this.has(streamId);
-    return this.kv().exists(streamId);
+    return this.hasPersistedStream(streamId);
   }
 
   keys(): StreamTabId[] {
@@ -635,16 +797,9 @@ export class StreamLogStore {
     if (isDeepStrictEqual(summary.meta, meta)) return;
     summary.meta = meta;
     this.stateRevision += 1;
-    // Share the transcript queue so flush/reload drains this write before a
-    // storage-root change. Re-read at execution time, and let a dirty
-    // transcript's own write carry the metadata: persisting its newer
-    // log-derived summary fields before the authoritative log would make a
-    // crash-time cache look more durable than it is.
-    void this.writeQueue.add(async () => {
-      if (this.dirtyIds.has(streamId)) return;
-      const current = this.summaries.get(streamId);
-      if (current) await this.maintainSummaryCache(streamId, { ...current });
-    });
+    if (this.mode.kind === 'persistent') {
+      this.markPersistentChange(streamId);
+    }
   }
 
   /** Land metadata recorded before this stream existed in the registry. */
@@ -666,18 +821,18 @@ export class StreamLogStore {
     )
       return;
     this.ensureStreamState(streamId).log = new StreamLog();
+    this.queueJournalRecord(streamId, toJournalRecord({ op: 'ensure' }));
     this.summaries.set(streamId, {});
     this.adoptPendingSummaryMeta(streamId);
     this.stateRevision += 1;
     if (this.mode.kind === 'persistent') {
-      this.markDirty(streamId);
-      this.scheduleSave();
+      this.markPersistentChange(streamId);
     }
   }
 
   /**
    * Drop heavy entries from memory while keeping the on-disk copy authoritative.
-   * If there are pending writes, queue the release so `executeWrite` can flush
+   * If there are pending writes, queue the release so `persistStream` can flush
    * first and actually evict afterwards; otherwise releases immediately.
    * Subsequent access must go through `ensureLoaded` to rehydrate.
    */
@@ -769,6 +924,12 @@ export class StreamLogStore {
 
     return {
       streamId,
+      reserveSettlement: (id) => {
+        assertOwned();
+        // In-memory slot reservation — no entry mutates and nothing lands in
+        // the journal, so this bypasses mutateEntry's commit/notify path.
+        writerState.log?.reserveSettlement(id);
+      },
       append: (entry) => {
         assertOwned();
         return this.appendEntry(streamId, entry, false);
@@ -779,14 +940,41 @@ export class StreamLogStore {
       },
       update: (id, patch) => {
         assertOwned();
-        return this.mutateEntry(streamId, (log) => log.update(id, patch));
+        return this.mutateEntry(
+          streamId,
+          (log) => log.update(id, patch),
+          () => toJournalRecord({ op: 'update', id, patch, settled: false }),
+        );
       },
       settle: (id, patch) => {
         assertOwned();
-        return this.mutateEntry(streamId, (log) => log.settle(id, patch));
+        return this.mutateEntry(
+          streamId,
+          (log) => log.settle(id, patch),
+          (updated) => {
+            // Chunk updates are intentionally memory-only. Settlement must
+            // persist the fully materialized entry, including accumulated text.
+            const {
+              id: _id,
+              seqNo: _seqNo,
+              settlementSeqNo: _settlementSeqNo,
+              ...settledPatch
+            } = updated;
+            return toJournalRecord({
+              op: 'update',
+              id,
+              patch: settledPatch,
+              settled: true,
+            });
+          },
+        );
       },
       appendText: (id, text) => {
         assertOwned();
+        // Streaming text remains in the recorder's bounded in-memory window.
+        // Only the whole-buffer redacted settle patch is durable: persisting
+        // independently redacted chunks could retain a secret split across
+        // chunk boundaries forever in the append-only file.
         return this.mutateEntry(streamId, (log) => log.appendText(id, text));
       },
       close: () => {
@@ -876,9 +1064,9 @@ export class StreamLogStore {
     if (state?.log !== undefined && state.loadFailed !== true) return;
     if (!this.summaries.has(streamId)) return;
     if (state?.pendingLoad) return state.pendingLoad;
+    let recoveredFromLoad = false;
     const work = (async () => {
       try {
-        const raw = await this.kv().read<unknown[]>(streamId);
         // If `delete` or `clear` ran during the read, don't resurrect it.
         if (
           this.clearing ||
@@ -887,7 +1075,8 @@ export class StreamLogStore {
         ) {
           return;
         }
-        const diskEntries = this.parsePersistedEntries(streamId, raw);
+        const diskEntries = await this.readPersistedEntries(streamId);
+        if (!diskEntries) return;
         const live = this.streams.get(streamId)?.log;
         if (live && live.size > 0) {
           // A concurrent `append` populated the log during the disk read.
@@ -902,8 +1091,7 @@ export class StreamLogStore {
           this.ensureStreamState(streamId).log = merged;
           this.stateRevision += 1;
           this.refreshSummary(streamId, merged);
-          this.markDirty(streamId);
-          this.scheduleSave();
+          this.markPersistentChange(streamId);
           // The merge renumbered seqNos under a fresh log instance, so
           // fold-state consumers must rebuild rather than apply a delta.
           this.notify(streamId, { reset: true });
@@ -922,11 +1110,11 @@ export class StreamLogStore {
         }
         // Load recovered — saves can persist this stream again. If a save
         // was deferred while the load was in flight (dirty stream re-queued
-        // by executeWrite), flush it now so we don't wait for another
+        // by persistStream), flush it now so we don't wait for another
         // append to unblock it.
         const recovered = this.streams.get(streamId);
         if (recovered) recovered.loadFailed = false;
-        if (this.dirtyIds.has(streamId)) this.scheduleSave();
+        recoveredFromLoad = true;
       } catch (err) {
         // Keep the disk copy authoritative and surface the failed read. A
         // caller may retry `ensureLoaded`, but no append is accepted until a
@@ -947,6 +1135,9 @@ export class StreamLogStore {
       if (state) {
         state.pendingLoad = undefined;
         this.tryRelease(streamId);
+        if (recoveredFromLoad && this.hasPendingPersistence(streamId)) {
+          this.schedulePersistence(streamId);
+        }
       }
     }
   }
@@ -976,8 +1167,11 @@ export class StreamLogStore {
     const appended = settled
       ? logInstance.appendSettled(entry)
       : logInstance.append(entry);
-    this.commitChange(streamId, logInstance);
-    this.scheduleSave();
+    this.queueJournalRecord(
+      streamId,
+      toJournalRecord({ op: 'append', entry: appended, settled }),
+    );
+    this.commitChange(streamId, logInstance, true);
     return appended;
   }
 
@@ -989,6 +1183,7 @@ export class StreamLogStore {
   private mutateEntry(
     streamId: StreamTabId,
     apply: (log: StreamLog) => StreamLogEntry | undefined,
+    journalRecord?: (updated: StreamLogEntry) => StreamLogJournalRecord,
   ): StreamLogEntry | undefined {
     this.assertWritableStream(streamId);
     const logInstance = this.streams.get(streamId)?.log;
@@ -997,9 +1192,21 @@ export class StreamLogStore {
     const updated = apply(logInstance);
     if (!updated) return undefined;
 
-    this.commitChange(streamId, logInstance);
-    this.scheduleSave();
+    if (journalRecord) {
+      this.queueJournalRecord(streamId, journalRecord(updated));
+    }
+    this.commitChange(streamId, logInstance, journalRecord !== undefined);
     return updated;
+  }
+
+  private queueJournalRecord(
+    streamId: StreamTabId,
+    record: StreamLogJournalRecord,
+  ): void {
+    if (this.mode.kind !== 'persistent') return;
+    const state = this.ensureStreamState(streamId);
+    state.journalRecords ??= [];
+    state.journalRecords.push(record);
   }
 
   getTimestampRange(streamId: StreamTabId): {
@@ -1020,14 +1227,20 @@ export class StreamLogStore {
   ): Promise<void> {
     this.assertWritableStore('delete a transcript stream');
     this.writeTombstones.add(streamId);
-    this.saveThrottle.cancel();
-    let retrySave = false;
     let releasedEntries: ParsedPersistedEntries | undefined;
+    let reseedSummary = false;
 
     try {
-      await this.executeWrite();
-      // A re-claim may have landed while pending writes drained. Refuse before
-      // the irreversible durable delete so its transcript is never erased.
+      const state = this.streams.get(streamId);
+      const pending = [
+        state?.pendingLoad,
+        state?.pendingRead,
+        state?.persistenceWork,
+      ].filter((work): work is Promise<void> => work !== undefined);
+      if (pending.length > 0) await Promise.allSettled(pending);
+      // A re-claim may have landed while pending journal work drained. Refuse
+      // before the irreversible durable delete so its transcript is never
+      // erased.
       if (options?.shouldDelete && !options.shouldDelete()) {
         throw new StreamDeletionSupersededError(streamId);
       }
@@ -1051,6 +1264,10 @@ export class StreamLogStore {
         }
         log.info(`Deleting stream: ${streamId}`);
         await this.kv().delete(streamId);
+        await this.kv().deleteWithExtension(
+          streamId,
+          STREAM_LOG_JOURNAL_EXTENSION,
+        );
         await this.deleteSummaryCache(streamId);
       }
       // The durable delete is irreversible. Re-check again before forgetting
@@ -1066,6 +1283,15 @@ export class StreamLogStore {
           this.ensureStreamState(streamId).log = restored;
           this.refreshSummary(streamId, restored);
         }
+        // The durable journal was already deleted above. Re-seed it from the
+        // surviving in-memory log directly — bypassing the persistence queue,
+        // which would skip (and re-delete) while the tombstone is still set —
+        // so the re-claimed identity keeps its transcript across restarts.
+        const restored = this.streams.get(streamId)?.log;
+        if (restored) {
+          await this.writeSeedJournal(streamId, restored.toPersistedEntries());
+          reseedSummary = true;
+        }
         throw new StreamDeletionSupersededError(streamId);
       }
       // The summaries map is the progress tab registry. Commit its removal
@@ -1073,17 +1299,17 @@ export class StreamLogStore {
       // stream whose transcript cleanup failed.
       this.forgetStreamState(streamId);
       this.stateRevision += 1;
-    } catch (error) {
-      // executeWrite() drains dirty ids while the tombstone suppresses writes.
-      // Restore the retry marker if deletion fails and a resident log remains.
-      if (this.streams.get(streamId)?.log !== undefined) {
-        this.markDirty(streamId);
-        retrySave = true;
-      }
-      throw error;
     } finally {
       this.writeTombstones.delete(streamId);
-      if (retrySave) this.scheduleSave();
+      if (reseedSummary) {
+        // Re-persist the summary cache the delete removed, now that the
+        // tombstone no longer suppresses this stream's persistence queue.
+        const state = this.streams.get(streamId);
+        if (state) {
+          state.summaryDirty = true;
+          this.schedulePersistence(streamId);
+        }
+      }
     }
   }
 
@@ -1092,12 +1318,15 @@ export class StreamLogStore {
     const count = this.summaries.size;
     this.clearing = true;
     this.writeGeneration += 1;
-    this.saveThrottle.cancel();
-    this.forgetAllStreamState();
     this.stateRevision += 1;
 
     try {
-      await this.writeQueue.onIdle();
+      const pending = [...this.streams.values()].flatMap((state) =>
+        [state.pendingLoad, state.pendingRead, state.persistenceWork].filter(
+          (work): work is Promise<void> => work !== undefined,
+        ),
+      );
+      await Promise.allSettled(pending);
       this.forgetAllStreamState();
       if (this.mode.kind === 'ephemeral') return;
 
@@ -1132,9 +1361,6 @@ export class StreamLogStore {
       new Set(streamIds),
       status,
     );
-    if (affected.length > 0) {
-      this.scheduleSave();
-    }
     // Preserve logs that were resident before this call; only release the
     // cold logs loaded specifically for recovery.
     for (const streamId of streamsToLoad) {
@@ -1158,11 +1384,23 @@ export class StreamLogStore {
       for (const entry of logInstance.getRange(0, logInstance.head)) {
         if (isRunningGroupEntry(entry)) {
           const existingData = isObject(entry.data) ? entry.data : {};
-          const updated = logInstance.settle(entry.id, {
+          const patch = {
             type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
             data: { ...existingData, status, endTime: now },
-          });
-          if (updated) updatedAny = true;
+          } satisfies StreamLogUpdatePatch;
+          const updated = logInstance.settle(entry.id, patch);
+          if (updated) {
+            this.queueJournalRecord(
+              streamId,
+              toJournalRecord({
+                op: 'update',
+                id: entry.id,
+                patch,
+                settled: true,
+              }),
+            );
+            updatedAny = true;
+          }
           continue;
         }
 
@@ -1172,10 +1410,22 @@ export class StreamLogStore {
         // stuck rendering as an in-progress entry forever (#7276).
         if (isRunningStreamingTextEntry(entry)) {
           const existingData = isObject(entry.data) ? entry.data : {};
-          const updated = logInstance.settle(entry.id, {
+          const patch = {
             data: { ...existingData, status: 'completed' },
-          });
-          if (updated) updatedAny = true;
+          } satisfies StreamLogUpdatePatch;
+          const updated = logInstance.settle(entry.id, patch);
+          if (updated) {
+            this.queueJournalRecord(
+              streamId,
+              toJournalRecord({
+                op: 'update',
+                id: entry.id,
+                patch,
+                settled: true,
+              }),
+            );
+            updatedAny = true;
+          }
           continue;
         }
 
@@ -1194,17 +1444,29 @@ export class StreamLogStore {
                   error:
                     'The previous host stopped before this call completed.',
                 };
-          const updated = logInstance.settle(entry.id, {
+          const patch = {
             level: call.status === 'planned' ? 'info' : 'error',
             data: recoveredCall,
-          });
-          if (updated) updatedAny = true;
+          } satisfies StreamLogUpdatePatch;
+          const updated = logInstance.settle(entry.id, patch);
+          if (updated) {
+            this.queueJournalRecord(
+              streamId,
+              toJournalRecord({
+                op: 'update',
+                id: entry.id,
+                patch,
+                settled: true,
+              }),
+            );
+            updatedAny = true;
+          }
         }
       }
 
       if (updatedAny) {
         affected.push(streamId);
-        this.commitChange(streamId, logInstance);
+        this.commitChange(streamId, logInstance, true);
       }
     }
 
@@ -1237,67 +1499,120 @@ export class StreamLogStore {
     }
   }
 
-  /**
-   * Throttled internal persistence trigger; every mutator schedules it.
-   * Fire-and-forget by design: only `flush()` is awaitable, and it drains,
-   * retries, and throws.
-   */
-  private scheduleSave(): void {
+  private hasPendingPersistence(streamId: StreamTabId): boolean {
+    const state = this.streams.get(streamId);
+    return (
+      (state?.journalRecords?.length ?? 0) > 0 || state?.summaryDirty === true
+    );
+  }
+
+  /** Start one stream's append chain immediately; `flush()` is the error gate. */
+  private schedulePersistence(streamId: StreamTabId): void {
     this.assertWritableStore('save transcripts');
-    if (this.mode.kind === 'ephemeral' || this.dirtyIds.size === 0) return;
-    // Throttle, not debounce: only start a window when none is open, so a
-    // sustained stream of mutations cannot keep pushing the write out.
-    if (!this.saveThrottle.pending) this.saveThrottle.schedule();
+    if (this.mode.kind !== 'persistent') return;
+    const state = this.ensureStreamState(streamId);
+    if (
+      state.pendingLoad ||
+      state.persistenceWork ||
+      !this.hasPendingPersistence(streamId)
+    )
+      return;
+    state.persistenceError = undefined;
+    const expectedGeneration = this.writeGeneration;
+    const queue = this.persistenceQueue(streamId);
+    const task = queue.add(() =>
+      this.persistStream(streamId, expectedGeneration),
+    );
+    const work = Promise.allSettled([task, queue.onIdle()]).then(
+      ([taskResult]) => {
+        if (taskResult.status === 'rejected') throw taskResult.reason;
+      },
+    );
+    state.persistenceWork = work;
+    void work
+      .catch((error: unknown) => {
+        const current = this.streams.get(streamId);
+        if (current) current.persistenceError = error;
+      })
+      .finally(() => {
+        const current = this.streams.get(streamId);
+        if (!current || current.persistenceWork !== work) return;
+        current.persistenceWork = undefined;
+        this.retirePersistenceQueueIfIdle(streamId, queue);
+        if (
+          current.persistenceError === undefined &&
+          expectedGeneration === this.writeGeneration &&
+          !this.shouldSkipWrite(streamId, expectedGeneration) &&
+          this.hasPendingPersistence(streamId)
+        ) {
+          this.schedulePersistence(streamId);
+          return;
+        }
+        if (!this.hasPendingPersistence(streamId)) {
+          this.releaseLease(streamId, 'flush');
+        }
+      });
   }
 
   async flush(): Promise<void> {
     this.assertWritableStore('flush transcripts');
     if (this.mode.kind === 'ephemeral') return;
 
-    // Drain iteratively: executeWrite may re-queue streams that are still
-    // rehydrating (`pendingLoads`) or whose prior load failed. Wait for
-    // those to resolve and then re-run the save, so shutdown doesn't lose
-    // appends that landed on a resumed stream. Bound the loop by the set
-    // of streams that could still make progress — if the only dirty
-    // entries are persistently `loadFailed`, we can't persist them.
-    // Cap the write retries so a persistent write error (disk full, perm
-    // denied) doesn't hang shutdown forever — `executeWrite`'s catch
-    // re-marks failed streams dirty, which would otherwise spin.
     const MAX_WRITE_RETRIES = 3;
-    let writeAttempts = 0;
-    while (true) {
+    for (let attempt = 1; attempt <= MAX_WRITE_RETRIES; attempt += 1) {
       const loads = this.pendingLoads();
-      if (this.saveThrottle.pending) {
-        this.saveThrottle.cancel();
-        await this.executeWrite();
-        writeAttempts++;
-      } else if (this.writeQueue.size > 0 || this.writeQueue.pending > 0) {
-        await this.writeQueue.onIdle();
-      } else if (loads.length > 0) {
-        await Promise.allSettled(loads);
-      } else {
-        // No in-flight work. Decide whether anything deferred can still
-        // be persisted in another save cycle.
-        const dirty = this.dirtyStreamIds();
-        const canRetry = dirty.some(
-          (id) => this.streams.get(id)?.loadFailed !== true,
-        );
-        if (!canRetry) {
-          if (dirty.length > 0) {
-            throw new Error(
-              `Cannot flush ${dirty.length} stream(s) whose persisted transcripts failed to load.`,
-            );
-          }
-          return;
+      if (loads.length > 0) await Promise.allSettled(loads);
+
+      const loadFailures: Error[] = [];
+      for (const [streamId, state] of this.streams) {
+        if (this.shouldSkipWrite(streamId, this.writeGeneration)) continue;
+        if (state.loadFailed && this.hasPendingPersistence(streamId)) {
+          loadFailures.push(
+            new Error(
+              `Cannot flush stream ${streamId} because its persisted transcript failed to load.`,
+            ),
+          );
+          continue;
         }
-        if (writeAttempts >= MAX_WRITE_RETRIES) {
-          throw new Error(
-            `Transcript flush failed after ${MAX_WRITE_RETRIES} retries; ` +
-              `${dirty.length} stream(s) remain dirty.`,
+        if (this.hasPendingPersistence(streamId)) {
+          this.schedulePersistence(streamId);
+        }
+      }
+
+      const work = [...this.streams.values()].flatMap((state) =>
+        state.persistenceWork ? [state.persistenceWork] : [],
+      );
+      await Promise.allSettled(work);
+      const pending = [...this.streams]
+        .filter(
+          ([streamId]) =>
+            !this.shouldSkipWrite(streamId, this.writeGeneration) &&
+            this.streams.get(streamId)?.loadFailed !== true &&
+            this.hasPendingPersistence(streamId),
+        )
+        .map(([streamId]) => streamId);
+      if (pending.length === 0) {
+        if (loadFailures.length > 0) {
+          throw new AggregateError(
+            loadFailures,
+            `Transcript flush skipped ${loadFailures.length} stream(s) whose persisted transcript failed to load.`,
           );
         }
-        await this.executeWrite();
-        writeAttempts++;
+        return;
+      }
+      if (attempt === MAX_WRITE_RETRIES) {
+        const errors = [
+          ...loadFailures,
+          ...[...this.streams.values()].flatMap((state) =>
+            state.persistenceError === undefined
+              ? []
+              : [state.persistenceError],
+          ),
+        ];
+        throw new AggregateError(
+          errors,
+          `Transcript flush failed after ${MAX_WRITE_RETRIES} retries; ${pending.length} stream(s) remain pending.`,
+        );
       }
     }
   }
@@ -1311,11 +1626,17 @@ export class StreamLogStore {
   }
 
   /** Shared post-mutation bookkeeping for append/update/appendText/group-end. */
-  private commitChange(streamId: StreamTabId, logInstance: StreamLog): void {
+  private commitChange(
+    streamId: StreamTabId,
+    logInstance: StreamLog,
+    persist: boolean,
+  ): void {
     this.assertWritableStore('commit transcript changes');
     this.refreshSummary(streamId, logInstance);
     this.stateRevision += 1;
-    if (this.mode.kind === 'persistent') this.markDirty(streamId);
+    if (persist && this.mode.kind === 'persistent') {
+      this.markPersistentChange(streamId);
+    }
     this.notify(streamId);
   }
 
@@ -1343,20 +1664,30 @@ export class StreamLogStore {
     // Sample before the first await: run facts may arrive while pending writes
     // drain or the replacement adapters prepare, and the reload must not fold
     // those new-root facts into the state it is about to replace.
-    const revision = this.stateRevision;
+    let revision = this.stateRevision;
     if (discardPendingWrites) {
-      this.saveThrottle.cancel();
       // Invalidate and drain any in-flight batch before the adapters
       // repoint: a write started before a storage-root rollback must not
       // keep landing streams against the restored root. The generation
       // bump makes the batch's remaining per-stream writes skip; the
       // drain keeps a mid-write stream from straddling the repoint.
       this.writeGeneration += 1;
-      await this.writeQueue.onIdle();
+      const pending = [...this.streams.values()].flatMap((state) =>
+        [state.pendingLoad, state.pendingRead, state.persistenceWork].filter(
+          (work): work is Promise<void> => work !== undefined,
+        ),
+      );
+      await Promise.allSettled(pending);
+      revision = this.stateRevision;
     } else if (this.mode.kind === 'persistent') {
       await this.flush();
     }
-    if (!discardPendingWrites && this.dirtyIds.size > 0) {
+    if (
+      !discardPendingWrites &&
+      [...this.streams].some(([streamId]) =>
+        this.hasPendingPersistence(streamId),
+      )
+    ) {
       throw new Error(
         'Cannot reload transcripts while persistent writes remain unresolved.',
       );
@@ -1381,7 +1712,11 @@ export class StreamLogStore {
   private async readPersistentSummaries(): Promise<
     Map<StreamTabId, StreamLogSummary>
   > {
-    const streamIds = await this.kv().listKeys();
+    const [legacyIds, journalIds] = await Promise.all([
+      this.kv().listKeys(),
+      this.kv().listKeysWithExtension(STREAM_LOG_JOURNAL_EXTENSION),
+    ]);
+    const streamIds = [...new Set([...legacyIds, ...journalIds])];
     const results = await pMap(
       streamIds,
       (streamId) => this.loadStreamSummary(streamId as StreamTabId),
@@ -1405,11 +1740,10 @@ export class StreamLogStore {
     summaries: ReadonlyMap<StreamTabId, StreamLogSummary>,
   ): void {
     // One clear drops every resident per-stream field (log, leases,
-    // loadFailed, pendingLoad, writer). `summaries`, `releaseRequests`,
-    // `writeTombstones`, and `dirtyIds` do not share the record's lifecycle
-    // and are cleared separately.
+    // loadFailed, pendingLoad, pendingRead, writer). `summaries`, `releaseRequests`,
+    // `writeTombstones` does not share the record's lifecycle and is cleared
+    // separately.
     this.streams.clear();
-    this.dirtyIds.clear();
     this.releaseRequests.clear();
     this.summaries.clear();
     for (const [streamId, summary] of summaries) {
@@ -1442,12 +1776,12 @@ export class StreamLogStore {
       return { streamId, summary: persistedSummary };
     }
 
-    const raw = await this.kv().read<unknown[]>(streamId);
-    // `listKeys()` found the stream, but it may have been deleted before the
-    // read completed. Only an existing authoritative `[]` is registration
-    // evidence; KVStore's missing-file `undefined` is not.
-    if (raw === undefined) return null;
-    const entries = this.parsePersistedEntries(streamId, raw);
+    // A discovered file may disappear before its read completes. Recheck the
+    // union so neither a legacy array nor a journal-only empty registration is
+    // resurrected after deletion.
+    if (!(await this.hasPersistedStream(streamId))) return null;
+    const entries = await this.readPersistedEntries(streamId);
+    if (!entries) return null;
     const summary = this.summarizeEntries(entries.entries);
     // Empty transcripts have no timestamps, so their authoritative log file,
     // rather than the optional summary cache, remains the registration marker.
@@ -1465,17 +1799,25 @@ export class StreamLogStore {
       const summary = this.parsePersistedSummary(persisted);
       if (!summary) return undefined;
 
-      const [summaryMtime, logMtime] = await Promise.all([
+      const [summaryMtime, legacyMtime, journalMtime] = await Promise.all([
         this.summaryKv().modifiedAt(streamId),
         this.kv().modifiedAt(streamId),
+        this.kv().modifiedAtWithExtension(
+          streamId,
+          STREAM_LOG_JOURNAL_EXTENSION,
+        ),
       ]);
+      const logMtime = Math.max(
+        legacyMtime ?? -Infinity,
+        journalMtime ?? -Infinity,
+      );
       // A missing log mtime means the authoritative log is gone (deleted, or
       // never written) — orphaned summary, not merely stale. Trusting it here
       // would register a stream that has no log to load, so `ensureLoaded`
       // reads back an empty transcript instead of surfacing it as missing.
       if (
         summaryMtime !== undefined &&
-        (logMtime === undefined || summaryMtime < logMtime)
+        (!Number.isFinite(logMtime) || summaryMtime < logMtime)
       ) {
         return undefined;
       }
@@ -1531,30 +1873,73 @@ export class StreamLogStore {
     return result.data;
   }
 
-  private async writeStream(
+  private async persistStream(
     streamId: StreamTabId,
-    logInstance: StreamLog,
-    expectedGeneration: number = this.writeGeneration,
+    expectedGeneration: number,
   ): Promise<void> {
-    if (this.shouldSkipWrite(streamId, expectedGeneration)) return;
-    await this.kv().write(streamId, logInstance.toPersistedEntries());
-    if (this.shouldSkipWrite(streamId, expectedGeneration)) {
-      await this.kv().delete(streamId);
-      await this.deleteSummaryCache(streamId);
-      return;
-    }
+    while (!this.shouldSkipWrite(streamId, expectedGeneration)) {
+      const state = this.streams.get(streamId);
+      if (!state) return;
+      const records = state.journalRecords?.slice() ?? [];
+      if (records.length > 0 && state.journalNeedsTailRepair) {
+        const raw = await this.kv().readText(
+          streamId,
+          STREAM_LOG_JOURNAL_EXTENSION,
+        );
+        if (raw !== undefined) {
+          const parsed = parseJsonlEntries(streamId, raw);
+          if (parsed.repairedText !== undefined) {
+            await this.kv().writeTextAtomic(
+              streamId,
+              STREAM_LOG_JOURNAL_EXTENSION,
+              parsed.repairedText,
+            );
+          }
+        }
+        state.journalNeedsTailRepair = false;
+      }
+      if (records.length > 0) {
+        try {
+          await this.kv().appendText(
+            streamId,
+            STREAM_LOG_JOURNAL_EXTENSION,
+            `${records.map((record) => JSON.stringify(record)).join('\n')}\n`,
+          );
+        } catch (error) {
+          state.journalNeedsTailRepair = true;
+          throw error;
+        }
+        // Mutations can queue records while the append is in flight. Remove
+        // only the durable prefix; the loop picks up the remainder.
+        state.journalRecords?.splice(0, records.length);
+      }
 
-    // Carry the snapshot-owned `meta` block forward: `toSummary` only knows
-    // log-derived fields, and persisting it bare would strip the metadata
-    // mirror `recordSummaryMeta` last wrote for this stream.
-    const meta = this.summaries.get(streamId)?.meta;
-    await this.maintainSummaryCache(streamId, {
-      ...toSummary(logInstance),
-      ...(meta !== undefined && { meta }),
-    });
-    if (this.shouldSkipWrite(streamId, expectedGeneration)) {
-      await this.kv().delete(streamId);
-      await this.deleteSummaryCache(streamId);
+      if (this.shouldSkipWrite(streamId, expectedGeneration)) {
+        await this.kv().delete(streamId);
+        await this.kv().deleteWithExtension(
+          streamId,
+          STREAM_LOG_JOURNAL_EXTENSION,
+        );
+        await this.deleteSummaryCache(streamId);
+        return;
+      }
+      // A mutation can enqueue another journal record while the append above
+      // is in flight. Drain that record before writing the derived summary so
+      // the summary mtime remains at least as new as its authoritative log.
+      if ((state.journalRecords?.length ?? 0) > 0) continue;
+      if (state.summaryDirty) {
+        const summary = this.summaries.get(streamId);
+        state.summaryDirty = false;
+        try {
+          if (summary) {
+            await this.maintainSummaryCache(streamId, { ...summary });
+          }
+        } catch (error) {
+          state.summaryDirty = true;
+          throw error;
+        }
+      }
+      if (!this.hasPendingPersistence(streamId)) return;
     }
   }
 
@@ -1572,12 +1957,11 @@ export class StreamLogStore {
 
   private forgetStreamState(streamId: StreamTabId): void {
     // Dropping the record removes every resident field for this stream at
-    // once. `summaries` (a separate registry) and `dirtyIds` (the separate
-    // dirtiness set) are cleared here too; the in-flight `writeTombstones`
-    // guard is intentionally left untouched — its lifetime is owned by
-    // `delete()`'s try/finally, not by this cascade.
+    // once. `summaries` is cleared here too; the in-flight
+    // `writeTombstones` guard is intentionally left untouched — its lifetime
+    // is owned by `delete()`'s try/finally, not by this cascade.
     this.streams.delete(streamId);
-    this.dirtyIds.delete(streamId);
+    this.persistenceQueues.delete(streamId);
     this.releaseRequests.delete(streamId);
     this.summaries.delete(streamId);
     this.pendingSummaryMeta.delete(streamId);
@@ -1588,7 +1972,7 @@ export class StreamLogStore {
     // is deliberately not cleared here — `clear()` owns and clears it in its
     // own finally block.
     this.streams.clear();
-    this.dirtyIds.clear();
+    this.persistenceQueues.clear();
     this.releaseRequests.clear();
     this.summaries.clear();
     this.pendingSummaryMeta.clear();
@@ -1656,12 +2040,11 @@ export class StreamLogStore {
     log.warn(message);
   }
 
-  private markDirty(streamId: StreamTabId): void {
-    // Callers always hold a resident record for this stream (a fresh log, a
-    // merge, or a deferred loadFailed/pendingLoad record), so dirtiness only
-    // needs to be recorded in the set — see the `dirtyIds` field note.
-    this.dirtyIds.add(streamId);
+  private markPersistentChange(streamId: StreamTabId): void {
+    const state = this.ensureStreamState(streamId);
+    state.summaryDirty = true;
     this.acquireLease(streamId, 'flush');
+    this.schedulePersistence(streamId);
   }
 
   private acquireLease(
@@ -1693,7 +2076,8 @@ export class StreamLogStore {
       !this.releaseRequests.has(streamId) ||
       (state.leases?.size ?? 0) > 0 ||
       (state.presentationLeases?.size ?? 0) > 0 ||
-      this.dirtyIds.has(streamId) ||
+      this.hasPendingPersistence(streamId) ||
+      state.persistenceWork !== undefined ||
       state.pendingLoad
     ) {
       return;
@@ -1778,64 +2162,209 @@ export class StreamLogStore {
     return parsed;
   }
 
-  private executeWrite(): Promise<void> {
-    // One batch at a time: a save window that fires while a batch is still
-    // writing queues behind it, so two batches can never interleave `kv`
-    // writes for the same stream (the later batch could otherwise persist
-    // the older snapshot last). The batch snapshots `dirtyIds` when it
-    // starts, so a queued batch picks up mutations made during its
-    // predecessor; a batch that finds nothing dirty is a no-op.
-    return this.writeQueue.add(() => this.runWriteBatch());
+  /**
+   * Read the canonical journal. A legacy array is converted once into a seed
+   * record and unlinked only after the atomic journal replacement succeeds.
+   */
+  private async readPersistedEntries(
+    streamId: StreamTabId,
+  ): Promise<ParsedPersistedEntries | undefined> {
+    const work = this.runInPersistenceQueue(streamId, () =>
+      this.readPersistedEntriesSerialized(streamId),
+    );
+    const completion = work.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.ensureStreamState(streamId).pendingRead = completion;
+    try {
+      return await work;
+    } finally {
+      const state = this.streams.get(streamId);
+      if (state?.pendingRead === completion) {
+        state.pendingRead = undefined;
+        this.pruneStreamState(streamId);
+      }
+    }
   }
 
-  private async runWriteBatch(): Promise<void> {
-    // Skip streams whose rehydrate is pending or errored — writing now
-    // would clobber the authoritative on-disk history with a fresh
-    // empty-plus-new-appends log before `ensureLoaded` merges disk entries
-    // back in. Keep them dirty so the next save retries after the load
-    // resolves.
-    const allDirty = this.dirtyStreamIds();
-    this.dirtyIds.clear();
-    const toWrite: StreamTabId[] = [];
-    for (const streamId of allDirty) {
-      const state = this.streams.get(streamId);
-      if (state?.loadFailed || state?.pendingLoad !== undefined) {
-        this.markDirty(streamId);
-      } else {
-        toWrite.push(streamId);
+  private async readPersistedEntriesSerialized(
+    streamId: StreamTabId,
+  ): Promise<ParsedPersistedEntries | undefined> {
+    const journal = await this.kv().readText(
+      streamId,
+      STREAM_LOG_JOURNAL_EXTENSION,
+    );
+    if (journal === undefined) {
+      const legacy = await this.kv().read<unknown>(streamId);
+      if (legacy === undefined) return undefined;
+      const base = this.parsePersistedEntries(streamId, legacy);
+      if (this.mode.kind === 'persistent') {
+        await this.replaceWithSeedJournal(streamId, legacy as unknown[]);
       }
+      return base;
     }
 
-    if (toWrite.length === 0) return;
+    const parsedJournal = parseJsonlEntries(streamId, journal);
+    const parsedRecords = parsedJournal.entries.map((raw) =>
+      StreamLogJournalRecordSchema.safeParse(raw),
+    );
+    const journalHasSeed = parsedRecords.some(
+      (result) => result.success && result.data.op === 'seed',
+    );
+    const legacyExists = await this.kv().exists(streamId);
+    const legacy =
+      legacyExists && !journalHasSeed
+        ? await this.kv().read<unknown>(streamId)
+        : undefined;
+    const base =
+      legacy === undefined
+        ? { entries: [], preservedRawEntries: [] }
+        : this.parsePersistedEntries(streamId, legacy);
+    if (
+      parsedJournal.repairedText !== undefined &&
+      this.mode.kind === 'persistent'
+    ) {
+      await this.kv().writeTextAtomic(
+        streamId,
+        STREAM_LOG_JOURNAL_EXTENSION,
+        parsedJournal.repairedText,
+      );
+    }
 
-    log.debug(`Writing ${toWrite.length} dirty stream(s)`);
-    const writeGeneration = this.writeGeneration;
-
-    // Write streams one at a time. Each KV write serializes the stream's full
-    // transcript to JSON before the filesystem await; starting every dirty
-    // stream together retains all of those large JSON strings simultaneously.
-    // Sequential writes keep peak memory proportional to one serialized
-    // transcript while preserving independent per-stream failure handling.
-    try {
-      for (const streamId of toWrite) {
-        const logInstance = this.streams.get(streamId)?.log;
-        if (!logInstance) continue;
-        try {
-          await this.writeStream(streamId, logInstance, writeGeneration);
-        } catch {
-          // Failed writes re-mark their stream dirty so the next save retries.
-          // Continue draining the batch so one unavailable file does not
-          // prevent unrelated transcripts from becoming durable.
-          if (this.streams.get(streamId)?.log !== undefined)
-            this.markDirty(streamId);
+    let currentBase = base;
+    let logInstance = new StreamLog(base.entries, base.preservedRawEntries);
+    let sawSeed = false;
+    const seen = new Map<string, StreamLogJournalRecord>();
+    let invalidRecords = 0;
+    const invalidJournalValues: unknown[] = [];
+    for (const [index, result] of parsedRecords.entries()) {
+      if (!result.success) {
+        invalidRecords += 1;
+        const raw = parsedJournal.entries[index];
+        if (raw !== undefined) invalidJournalValues.push(raw);
+        continue;
+      }
+      const record = result.data;
+      const previous = seen.get(record.opId);
+      if (previous !== undefined) {
+        if (!isDeepStrictEqual(previous, record)) {
+          throw new Error(
+            `Stream ${streamId}: duplicate journal operation ${record.opId} differs from its first record.`,
+          );
         }
+        continue;
       }
-    } finally {
-      for (const streamId of toWrite) {
-        const state = this.streams.get(streamId);
-        if (state && !this.dirtyIds.has(streamId))
-          this.releaseLease(streamId, 'flush');
+      seen.set(record.opId, record);
+      switch (record.op) {
+        case 'seed': {
+          if (sawSeed) {
+            log.warn(
+              `Stream ${streamId}: ignoring an additional journal seed record.`,
+            );
+            break;
+          }
+          currentBase = this.parsePersistedEntries(streamId, record.entries);
+          logInstance = new StreamLog(
+            currentBase.entries,
+            currentBase.preservedRawEntries,
+          );
+          sawSeed = true;
+          break;
+        }
+        case 'ensure':
+          break;
+        case 'append': {
+          const {
+            seqNo: _seqNo,
+            settlementSeqNo: _settlementSeqNo,
+            ...entry
+          } = record.entry;
+          if (record.settled) logInstance.appendSettled(entry);
+          else logInstance.append(entry);
+          break;
+        }
+        case 'update':
+          {
+            const current = logInstance.getById(record.id);
+            const patch = current
+              ? parsePersistedUpdate(current, record.patch)
+              : (record.patch as StreamLogUpdatePatch);
+            if (!patch) {
+              invalidRecords += 1;
+              const raw = parsedJournal.entries[index];
+              if (raw !== undefined) invalidJournalValues.push(raw);
+              break;
+            }
+            if (record.settled) {
+              logInstance.settle(record.id, patch);
+            } else {
+              logInstance.update(record.id, patch);
+            }
+          }
+          break;
       }
     }
+    if (invalidRecords > 0) {
+      log.warn(
+        `Stream ${streamId}: ${formatResultCount(invalidRecords, 'journal record')} did not parse; preserving the raw values.`,
+      );
+    }
+
+    const parsed = {
+      entries: logInstance.toJSON(),
+      preservedRawEntries: currentBase.preservedRawEntries,
+    };
+    if (this.mode.kind === 'persistent' && legacyExists) {
+      if (!sawSeed) {
+        // One-time conversion of the unshipped JSON-plus-JSONL overlay shape,
+        // as well as ordinary legacy arrays, into one canonical journal.
+        await this.replaceWithSeedJournal(streamId, [
+          ...logInstance.toPersistedEntries(),
+          ...invalidJournalValues,
+        ]);
+      } else {
+        await this.deleteLegacyLog(streamId);
+      }
+    }
+    return parsed;
+  }
+
+  private async writeSeedJournal(
+    streamId: StreamTabId,
+    entries: readonly unknown[],
+  ): Promise<void> {
+    const seed = toJournalRecord({ op: 'seed', entries });
+    await this.kv().writeTextAtomic(
+      streamId,
+      STREAM_LOG_JOURNAL_EXTENSION,
+      `${JSON.stringify(seed)}\n`,
+    );
+  }
+
+  private async replaceWithSeedJournal(
+    streamId: StreamTabId,
+    entries: readonly unknown[],
+  ): Promise<void> {
+    await this.writeSeedJournal(streamId, entries);
+    await this.deleteLegacyLog(streamId);
+  }
+
+  private async deleteLegacyLog(streamId: StreamTabId): Promise<void> {
+    try {
+      await this.kv().delete(streamId);
+    } catch (error) {
+      log.warn(
+        `Failed to remove retired transcript array for ${streamId}: ${toErrorMessage(error)}`,
+      );
+    }
+  }
+
+  private async hasPersistedStream(streamId: StreamTabId): Promise<boolean> {
+    const [legacy, journal] = await Promise.all([
+      this.kv().exists(streamId),
+      this.kv().existsWithExtension(streamId, STREAM_LOG_JOURNAL_EXTENSION),
+    ]);
+    return legacy || journal;
   }
 }

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -27,8 +27,10 @@
  * Redaction is lossy by construction: a literal `API_KEY=<value>` in a
  * model-written code sample is scrubbed along with a real key.
  */
+// Third-party imports
 import PQueue from 'p-queue';
 
+// Local imports - agent trace and transcript dependencies
 import type {
   AgentEvent,
   AgentTrace,
@@ -162,11 +164,6 @@ interface StreamSinkState {
   updateDebounce: FlushableDebounce;
 }
 
-type StageMetadata = Pick<
-  Extract<AgentEvent, { type: 'stage.start' }>,
-  'kind' | 'index' | 'total' | 'attemptId'
->;
-
 /**
  * Subscribe to a trace and route every event into the StreamLogStore for the
  * given streamId. Returns an `unsubscribe()` plus a `flushPending()` used by
@@ -281,9 +278,9 @@ export function attachTranscriptRecorder(
       queue = new PQueue({ concurrency: 1 });
       spillQueues.set(path, queue);
     }
-    const pending = Promise.resolve(
-      queue.add(() => spillWriter.write(path, text)),
-    )
+    const pending = queue
+      .add(() => spillWriter.write(path, text))
+      .then(() => undefined)
       .catch((error: unknown) => {
         pendingSpillFailure ??= error;
       })
@@ -339,13 +336,7 @@ export function attachTranscriptRecorder(
       state.enabled = false;
     }
   };
-  // Stage presentation lives only on stage.start — `store.update` at
-  // stage.end replaces `data` wholesale (see StreamLog.update), so without
-  // this the persisted GROUP_END row would forget whether the stage was the
-  // root "Run:" stage or a nested round/phase/session. Replayed legacy traces
-  // rely on that distinction to tell a root run's terminal status apart from
-  // a round's (see toStreamLifecycleStatus in packages/trace-viewer).
-  const stageMetadata = new Map<string, StageMetadata>();
+  const activeStageIds = new Set<string>();
   const workflowCallEntries = new Set<string>();
   const activeToolEntries = new Map<string, ToolUseLog>();
   let transcriptBoundaryClosed = false;
@@ -357,6 +348,26 @@ export function attachTranscriptRecorder(
   // session stage can contain several model invocations, so the outer stage is
   // too coarse to be the only reset boundary.
   let pendingModelResponseId: string | undefined;
+  const detachedModelResponseIds = new Set<string>();
+
+  const settlePendingModelResponse = (): void => {
+    if (!pendingModelResponseId) return;
+    const id = pendingModelResponseId;
+    pendingModelResponseId = undefined;
+    // An active stream remains mutable until stream.end materializes its final
+    // text. Remember that it crossed the model/tool boundary so stream.end can
+    // settle it even though it is no longer the current response correlator.
+    if (streams.has(id)) {
+      // Mutable ancestor headings precede the response in source order. Give
+      // them their terminal positions first; otherwise reserving the response
+      // would move it ahead of its still-open group during cold replay.
+      for (const stageId of activeStageIds) {
+        writer.reserveSettlement(stageId);
+      }
+      detachedModelResponseIds.add(id);
+      writer.reserveSettlement(id);
+    } else writer.settle(id, {});
+  };
 
   const flushStream = (state: StreamSinkState, id: string): void => {
     state.updateDebounce.cancel();
@@ -379,8 +390,11 @@ export function attachTranscriptRecorder(
         data: { status: state.ended ? 'completed' : 'running' },
         verbose: isDebugModeEnabled(),
       } satisfies StreamLogAppendInput;
-      if (state.ended) writer.appendSettled(entry);
-      else writer.append(entry);
+      if (state.ended && state.messageType !== MESSAGE_TYPES.MODEL_RESPONSE) {
+        writer.appendSettled(entry);
+      } else {
+        writer.append(entry);
+      }
       state.created = true;
       return;
     }
@@ -395,7 +409,15 @@ export function attachTranscriptRecorder(
     }
 
     if (state.ended) {
-      writer.settle(id, boundModelResponse(id, state.buffer));
+      const patch = boundModelResponse(id, state.buffer);
+      if (state.messageType === MESSAGE_TYPES.MODEL_RESPONSE) {
+        // The raw stream ends before response.finalized carries the
+        // authoritative post-replacement text. Keep this row mutable until
+        // that event reconciles and settles it.
+        writer.update(id, patch);
+      } else {
+        writer.settle(id, patch);
+      }
     }
   };
 
@@ -463,16 +485,16 @@ export function attachTranscriptRecorder(
             ...(event.attemptId !== undefined
               ? { attemptId: event.attemptId }
               : {}),
-          } satisfies StageMetadata;
-          stageMetadata.set(event.id, metadata);
+          };
+          activeStageIds.add(event.id);
           // A new model-turn boundary starts fresh: whatever MODEL_RESPONSE
           // stream the previous turn may have opened is no longer this turn's
           // to reuse. Tool-use turns are session stages containing several
           // inner model/tool rounds, while other flows expose round stages.
           if (event.kind === 'round' || event.kind === 'session') {
-            pendingModelResponseId = undefined;
+            settlePendingModelResponse();
           }
-          writer.appendSettled({
+          writer.append({
             id: event.id,
             type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
             level: 'info',
@@ -486,18 +508,21 @@ export function attachTranscriptRecorder(
             },
             verbose: isDebugModeEnabled(),
           });
+          // Reserve the heading's settlement slot at open so its eventual
+          // terminal settlement keeps this position: children and detached
+          // responses settling inside the group take later slots, and rows
+          // that settled before this append already hold earlier ones.
+          writer.reserveSettlement(event.id);
           return;
         }
 
         case 'stage.end': {
-          const metadata = stageMetadata.get(event.id);
-          stageMetadata.delete(event.id);
-          writer.update(event.id, {
+          activeStageIds.delete(event.id);
+          writer.settle(event.id, {
             type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
             data: {
               status: event.status ?? RUN_OUTCOME.COMPLETED,
               endTime: Date.now(),
-              ...metadata,
             },
           });
           return;
@@ -505,7 +530,7 @@ export function attachTranscriptRecorder(
 
         case 'tool.start': {
           if (transcriptBoundaryClosed) return;
-          pendingModelResponseId = undefined;
+          settlePendingModelResponse();
           // event.logId is the canonical id — SDK consumers correlate
           // tool.start/end by it and the store entry shares the same id so
           // callers can lookup with store.get(streamId).find(e => e.id === logId).
@@ -529,7 +554,6 @@ export function attachTranscriptRecorder(
         }
 
         case 'tool.end': {
-          if (transcriptBoundaryClosed) return;
           const result = (event.result ?? {}) as Partial<ToolUseLog>;
           const redactedResult =
             typeof result.toolName === 'string'
@@ -553,8 +577,9 @@ export function attachTranscriptRecorder(
             } as ToolUseLog,
           } satisfies StreamLogUpdatePatch;
           if (event.status === TOOL_USE_STATUS.IN_PROGRESS) {
-            writer.update(event.logId, patch);
-            activeToolEntries.set(event.logId, patch.data);
+            if (writer.update(event.logId, patch)) {
+              activeToolEntries.set(event.logId, patch.data);
+            }
           } else {
             writer.settle(event.logId, patch);
             activeToolEntries.delete(event.logId);
@@ -701,7 +726,6 @@ export function attachTranscriptRecorder(
         }
 
         case 'stream.chunk': {
-          if (transcriptBoundaryClosed) return;
           const state = streams.get(event.id);
           if (!state || !state.enabled) return;
           state.pending.push(event.text);
@@ -717,7 +741,6 @@ export function attachTranscriptRecorder(
         }
 
         case 'stream.end': {
-          if (transcriptBoundaryClosed) return;
           const state = streams.get(event.id);
           if (!state) return;
           if (typeof event.finalText === 'string') {
@@ -727,6 +750,9 @@ export function attachTranscriptRecorder(
           state.ended = true;
           flushStream(state, event.id);
           streams.delete(event.id);
+          if (detachedModelResponseIds.delete(event.id)) {
+            writer.settle(event.id, {});
+          }
           return;
         }
 
@@ -855,11 +881,33 @@ export function attachTranscriptRecorder(
       // Workflow calls are deliberately absent: their typed bridge cleanup
       // owns planned/running terminal transitions and settles them afterward.
       transcriptBoundaryClosed = true;
-      pendingModelResponseId = undefined;
+      if (isTerminalOutcomePhase(event.phase)) {
+        for (const id of activeStageIds) {
+          writer.settle(id, {
+            type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
+            data: {
+              status: event.phase,
+              endTime: Date.now(),
+            },
+          });
+        }
+        activeStageIds.clear();
+      }
       for (const [id, state] of streams) {
         state.ended = true;
         flushStream(state, id);
+        if (state.messageType === MESSAGE_TYPES.MODEL_RESPONSE) {
+          writer.settle(id, {});
+          detachedModelResponseIds.delete(id);
+          if (pendingModelResponseId === id) pendingModelResponseId = undefined;
+        }
         streams.delete(id);
+      }
+      if (pendingModelResponseId) {
+        // A provider/abort path may close the stream without emitting the
+        // authoritative response.finalized event. Settle the fully flushed,
+        // redacted stream text at the lifecycle boundary.
+        settlePendingModelResponse();
       }
       for (const [id, data] of activeToolEntries) {
         writer.settle(id, {


### PR DESCRIPTION
## Summary

Re-lands the JSONL cutover (closed #10819) onto current main, redesigned per the directive that closed the previous stack ("redesigned from the single Stream-tab authority"):

- one append-only `.jsonl` journal per stream is the canonical transcript format: a `seed` record from one-shot legacy conversion, then per-mutation records folded on read; torn tails repaired before retry; malformed lines isolated loudly
- the store-wide 300 ms rewrite throttle and global write queue are replaced by immediate, independently serialized per-stream appends
- **`presentationSeqNo` is deleted — settlement is the single persisted ordering coordinate.** A mutable group heading's slot is reserved in the settlement counter when it opens (in-memory) and consumed by its terminal settlement, so cold replay keeps open-time order with no parallel field; the recorder reserves at `GROUP_START` append so headings order before their children
- settled ⇒ immutable enforcement, group settle at `stage.end` with the `GROUP_END` metadata fold, and the `logHead` wire-field removal carry over from the closed #10817, minus its parallel ordering state — closes #10774
- `delete()` reconciled with #10805's supersession semantics on main: a superseded durable delete re-seeds the canonical journal from the surviving log (`writeSeedJournal`) so a re-claimed workflow identity keeps its transcript across restarts, and re-persists its summary once the tombstone lifts

Refs #10773 (stays open — the family umbrella; summary retirement and the #10842/#10843/#10844 retirement gates follow). The temporary pre-#10774 group-start reader is dated 2026-08-17, retire after 2026-11-17.

## Crash-loss semantics change (ratified here, per the review note on #10819)

Streamed chunks are memory-only until settlement. This fixes redaction permanence — a secret split across streaming chunks can never persist in the raw, user-shareable file — and changes crash loss from "≤300 ms of streamed tail" to "the in-flight streamed entry." Settlement persists the materialized, redacted whole entry.

## Recovery-ordering note

A crash before a group settles drops its in-memory slot reservation; the recovery sweep settles such orphans with fresh slots in sweep order. Crash-only, and strictly better than the previous stack's behavior on every non-crash path while carrying one less persisted field.

## Validation

- `npm run typecheck` (workspace, clean)
- `npm test`: 875 files passed, 1 skipped; 10,724 tests passed, 5 skipped
- focused: transcript suites (279), `RunTraceDispose`
- changed-file ESLint clean; `git diff --check` clean
- 17 files, +1,678/−380 vs main (the substrate lands whole; net-negative arrives with #10842/#10843/#10844 per the #10773 completion gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)