### PR TITLE
fix: close out spill-opener follow-ups (#10847, #10848, #10614)

### DIFF
--- a/packages/cli/src/chat/tui/panes/TranscriptReader.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptReader.tsx
@@ -85,6 +85,7 @@ export function hydratedTranscript(
     if (entry.role === 'tool') {
       return {
         ...entry,
+        ...(spill.kind === 'failed' ? { spillFailed: true } : {}),
         toolUse: {
           ...entry.toolUse,
           outputText:

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -121,8 +121,9 @@ export interface DisplayLineOptions {
   readonly width?: number;
   /** Retained subagent identities used by executions wait/view headers. */
   readonly executionLabels?: ExecutionLabels;
-  /** Include recovered output for compact tool kinds in the full transcript. */
-  readonly includeCompactOutput?: boolean;
+  /** Compact-tool output in the full transcript: 'loaded' prepends the
+   *  "Full output:" header, 'failed' shows the failure notice without it. */
+  readonly compactOutput?: 'loaded' | 'failed';
 }
 
 /** One styled fragment of a tool row. */
@@ -363,9 +364,11 @@ function buildStyledLines(
     !patchGroups &&
     !toolUse.isError;
   const compactOutput =
-    options.includeCompactOutput && !opts.showOutput
+    options.compactOutput !== undefined && !opts.showOutput
       ? [
-          row([{ text: 'Full output:' }]),
+          ...(options.compactOutput === 'loaded'
+            ? [row([{ text: 'Full output:' }])]
+            : []),
           ...toolUse.outputText
             .split('\n')
             .map((line) => row([{ text: line }])),
@@ -444,7 +447,7 @@ export function toolUseStyledLines(
     toolUse.toolName === 'executions' && options.executionLabels
       ? executionsSubagentSummary(toolUse.input, options.executionLabels)
       : undefined;
-  const key = `${options.elide === false ? 'f' : 'e'}|${options.includeCompactOutput ? 'c' : 'n'}|${options.width ?? 'd'}|${executionSummary ?? ''}`;
+  const key = `${options.elide === false ? 'f' : 'e'}|${options.compactOutput ?? 'n'}|${options.width ?? 'd'}|${executionSummary ?? ''}`;
   let cached = styledLinesCache.get(toolUse);
   const hit = cached?.get(key);
   if (hit) return hit;

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -397,7 +397,13 @@ export function fullTranscriptEntryLayout(
       toolUseDisplayLines(entry.toolUse, {
         elide: false,
         executionLabels,
-        includeCompactOutput: entry.spillPath !== undefined,
+        // Gate the "Full output:" header on actual recovery: a failed spill
+        // keeps the bounded preview plus failure notice, without the header.
+        ...(entry.spillPath === undefined
+          ? {}
+          : {
+              compactOutput: entry.spillFailed === true ? 'failed' : 'loaded',
+            }),
       }),
       layout.columns,
     ),

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -67,6 +67,9 @@ interface ConversationEntryBase {
   readonly finalized: boolean;
   /** Recorder-owned full text, available only through the on-demand reader. */
   readonly spillPath?: string;
+  /** Set by the on-demand reader when the spill artifact failed to load, so
+   *  renderers can show the failure notice without the "Full output:" header. */
+  readonly spillFailed?: boolean;
 }
 
 type ConversationEntryOrigin =

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -856,9 +856,13 @@ export class DesktopProgressBridge {
             try {
               await this.options.host.openPath(file);
             } catch (error) {
-              await this.options.host.showErrorMessage(
-                `Full output could not be opened: ${toErrorMessage(error)}`,
-              );
+              // The desktop preview host already surfaced its own "Failed to
+              // open file …" dialog before rethrowing (desktopPreviewHost's
+              // fail() shows-then-throws), so reporting here would stack a
+              // second toast on the same failure (#10848). Log only.
+              this.logger.warn('Failed to open the full output artifact', {
+                data: toLogData(error),
+              });
             }
           },
         },

--- a/src/test-kernel/agent/storage/ExecutionMetaWrites.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionMetaWrites.vitest.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { finalizeExecution, getExecutionStore } from '@agent/storage';
 import { writeSessionDescription } from '@agent/storage/executionLifecycle';
@@ -56,6 +56,39 @@ describe('execution metadata updates', () => {
       outcome: RUN_OUTCOME.COMPLETED,
     });
     expect(meta?.workflow).toBeUndefined();
+  });
+
+  it('resolves to a failed result instead of rejecting when the terminal write fails', async () => {
+    const id = 'bbb004' as ExecutionId;
+    const store = getExecutionStore(id);
+    await store.writeMeta({
+      timestamp: new Date(0).toISOString(),
+    });
+
+    // Catchless callers (terminalPersistence, runAgent, CLI finalization)
+    // rely on finalizeExecution never rejecting: every store failure must
+    // surface as a 'failed' result (#10614). CANCELLED + 'preserve' skips
+    // the fail-closed flow-record delete, isolating the terminal-write arm.
+    const writeError = new Error('terminal write rejected');
+    const writeSpy = vi
+      .spyOn(store, 'writeMeta')
+      .mockRejectedValueOnce(writeError);
+    try {
+      await expect(
+        finalizeExecution({
+          executionId: id,
+          outcome: RUN_OUTCOME.CANCELLED,
+          flowRecord: 'preserve',
+        }),
+      ).resolves.toEqual({
+        status: 'failed',
+        error: writeError,
+        stage: 'terminal-status',
+        outcomePersisted: false,
+      });
+    } finally {
+      writeSpy.mockRestore();
+    }
   });
 
   it('accepts a later update after one fails on absent metadata', async () => {

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -1999,9 +1999,12 @@ describe('CLI conversation transcript', () => {
     );
 
     expect(hydrated?.entries[0]?.spillPath).toBe(spillPath);
-    expect(transcriptToLines(hydrated, 80)).toEqual(
-      expect.arrayContaining(['Full output:', expect.stringContaining(notice)]),
-    );
+    expect(hydrated?.entries[0]?.spillFailed).toBe(true);
+    const lines = transcriptToLines(hydrated, 80);
+    // The failure notice renders without a "Full output:" header — the header
+    // promises recovered output that a failed spill does not have.
+    expect(lines).toContainEqual(expect.stringContaining(notice));
+    expect(lines).not.toContain('Full output:');
   });
 
   it('uses the full print width without Ink-only role padding', () => {

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -272,6 +272,8 @@ type CreateBridgeOptions = {
   showInfoMessage?: (message: string) => Promise<void> | void;
   onRunCompleted?: () => void;
   openPath?: (filePath: string, line?: number) => Promise<void>;
+  /** Seeds the fake filesystem (e.g. a transcript spill artifact). */
+  files?: Record<string, string>;
   observeRendererMessage?: (message: unknown) => void;
   /** Captures `this.logger.error(...)` calls made by the bridge under test. */
   loggerErrorSpy?: ReturnType<typeof vi.fn<AgentTrace['error']>>;
@@ -346,7 +348,7 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
     import('@platform/platform'),
     import('@test/support/FakePlatform'),
   ]);
-  initPlatform(createFakePlatform({}, { agentResume }));
+  initPlatform(createFakePlatform({ files: options.files }, { agentResume }));
   mocks.doMock('@agent/runtime/SessionResumeRetrieval', () => ({
     retrieveSessionResumeData:
       options.retrieveSessionResumeData ?? vi.fn(async () => null),
@@ -1153,6 +1155,38 @@ describe('DesktopProgressBridge', () => {
     await settleProgressEvents();
 
     expect(openPath).toHaveBeenCalledWith('/runs/exec-1/output/paper.pdf');
+  });
+
+  it('does not add a second toast when the spill artifact open fails late (#10848)', async () => {
+    // The desktop preview host surfaces its own "Failed to open file …"
+    // dialog before rethrowing, so the spill wrapper must log rather than
+    // stack a "Full output could not be opened" toast on top of it.
+    const messages: unknown[] = [];
+    const showErrorMessage = vi.fn();
+    const openPath = vi.fn(async () => {
+      throw new Error('no external viewer');
+    });
+    const spillPath = 'executions/abcdef123456/toolOutput/tool.txt';
+    const bridge = await createBridge(messages, {
+      files: { [`/workspace/.texra/storage/${spillPath}`]: 'spilled output' },
+      showErrorMessage,
+      openPath,
+    });
+
+    const handler = assertSupported(
+      bridge.progressViewInboundHandlers[
+        PROGRESS_VIEW_COMMANDS.OPEN_SPILL_ARTIFACT
+      ],
+    );
+    await handler({
+      command: PROGRESS_VIEW_COMMANDS.OPEN_SPILL_ARTIFACT,
+      spillPath,
+    });
+
+    expect(openPath).toHaveBeenCalledWith(
+      `/workspace/.texra/storage/${spillPath}`,
+    );
+    expect(showErrorMessage).not.toHaveBeenCalled();
   });
 
   it('installs host interactions on the desktop runtime host', async () => {


### PR DESCRIPTION
## Summary

Three small follow-ups from the spill-artifact opener work (#10833) and the error-channel refactor (#10603):

1. **CLI (#10847):** a compact tool row whose spill artifact failed to load rendered the bounded preview under the "Full output:" header, before the failure notice — the header promised full output while showing truncated content. The `includeCompactOutput` boolean is replaced by a `compactOutput: 'loaded' | 'failed'` state (carried via a `spillFailed` flag set at hydration); the header now renders only when the spill text was actually recovered.
2. **Desktop (#10848):** a late spill-open failure produced two error toasts — `previewHost.openPath`'s own "Failed to open file …" dialog and the wrapper's "Full output could not be opened: …". `openSpillArtifact`'s catch now only logs (matching the `requestOpenFile` pattern); paths that surface nothing on their own keep their messages.
3. **Agent (#10614):** adds one guard test pinning `finalizeExecution`'s never-throws contract — a rejecting terminal `writeMeta` resolves to `{ status: 'failed', ... }` instead of throwing, the invariant the catchless callers in `terminalPersistence`, `runAgent`, and CLI `executionFinalization` rely on.

## Issue acceptance gates

- Closes #10847 — failure case renders the failure notice without the "Full output:" label; loaded spills keep the header.
- Closes #10848 — a late open failure surfaces exactly one error message.
- Closes #10614 — guard test asserts `finalizeExecution` resolves (not rejects) on an injected store-write failure.

## Single source of truth

- CLI: the hydration-time `spillFailed` flag on the transcript entry owns the loaded/failed fact; renderers only consume it.
- Desktop: `previewHost.openPath`'s `fail()` helper remains the single error surface for late open failures.

## Duplication and abstraction budget

No new abstractions. Removed the duplicate error-toast path on desktop; replaced a boolean display option with a two-state enum per repo convention.

## Net elements (R6)

n/a — not a refactor/simplify PR (bug fixes + one regression test).

## Consumer counts (R8)

`includeCompactOutput` had exactly one caller (`transcriptEntryLayout.ts`); no remaining references after the rename to `compactOutput`.

## Host impact

Extension: none.

Desktop: single error toast instead of two when a spill artifact disappears before opening.

CLI: failed compact-tool spills no longer show the misleading "Full output:" header.

## Scheduled refactoring

None. The parent tracker #10846 has no remaining children after these two fixes land.

## Validation

- `npm run lint` — clean.
- `npm test` — 875 files / 10,725 tests passed.
- Targeted suites during development: `ConversationTranscript.vitest.ts` (73/73), `DesktopAgentExecution.vitest.ts` (77/77), `ExecutionMetaWrites.vitest.ts` (4/4).
- `npm run typecheck:cli`, `typecheck:desktop`, `typecheck:workspace`, `typecheck:test-kernel` — all clean.
