### PR TITLE
refactor: use existing deps instead of hand-rolled equivalents

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -73,6 +73,7 @@
     "diff": "^9.0.0",
     "esbuild": "^0.28.2",
     "ink": "^7.1.1",
+    "is-network-error": "^1.3.2",
     "lru-cache": "^11.5.2",
     "markdown-it": "^15.0.0",
     "node-pty": "^1.0.0",

--- a/packages/cli/src/commands/_helpers/fetchSilencer.ts
+++ b/packages/cli/src/commands/_helpers/fetchSilencer.ts
@@ -1,3 +1,5 @@
+import isNetworkError from 'is-network-error';
+
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 export function isCliFetchStackLog(args: readonly unknown[]): boolean {
@@ -6,7 +8,7 @@ export function isCliFetchStackLog(args: readonly unknown[]): boolean {
   const cause = first.cause;
   const causeMessage = cause instanceof Error ? toErrorMessage(cause) : '';
   return (
-    /fetch failed/i.test(first.message) &&
+    isNetworkError(first) &&
     /ENOTFOUND|EAI_AGAIN|ECONNREFUSED|ETIMEDOUT|getaddrinfo|remote\.texra\.ai/i.test(
       causeMessage,
     )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,6 +684,9 @@ importers:
       ink:
         specifier: ^7.1.1
         version: 7.1.1(patch_hash=db8f5740efe4e780f6517316175dfed1e68d62e76e533c06bf0b8f5e94b48aa6)(@types/react@19.2.18)(react@19.2.8)
+      is-network-error:
+        specifier: ^1.3.2
+        version: 1.3.2
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2

--- a/src/shared/subscriptionUsagePresentation.ts
+++ b/src/shared/subscriptionUsagePresentation.ts
@@ -1,3 +1,5 @@
+import { differenceInMinutes } from 'date-fns';
+
 import type {
   SubscriptionUsageSnapshot,
   SubscriptionUsageWindow,
@@ -58,7 +60,7 @@ export function formatSubscriptionUsageUpdated(
 ): string {
   const age = Math.max(0, now - fetchedAt);
   if (age >= STALE_AFTER_MS) {
-    const minutes = Math.floor(age / 60_000);
+    const minutes = differenceInMinutes(now, fetchedAt);
     return `stale · updated ${minutes}m ago`;
   }
   return 'updated just now';

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1231,6 +1231,52 @@ describe('StreamSnapshotStore', () => {
     expect(store.getRunMetadata(STREAM).description).toBeUndefined();
   });
 
+  it('does not start a second concurrent seed read for a mutation racing load()', async () => {
+    // Regression test: the per-stream seed lane must serialize `load()`'s own
+    // disk read with a mutation that arrives while disk provenance is still
+    // 'unknown' — a bug briefly reintroduced by an early PQueue draft let the
+    // mutation start its own independent read concurrently with load()'s,
+    // racing two `applyStreamData` calls onto the same usage accumulator.
+    await writeStreamFile(STREAM, 'usageStats.json', {
+      [RUN]: usage(100, 20, 0.5),
+    });
+
+    const store = new StreamSnapshotStore();
+    const facts = snapshotFacts(store);
+
+    const readDir = StorageFS.readDir.bind(StorageFS);
+    const readGate = pDefer<void>();
+    const readStarted = pDefer<void>();
+    let readCallCount = 0;
+    const readDirSpy = vi
+      .spyOn(StorageFS, 'readDir')
+      .mockImplementation(async (dir: string) => {
+        if (dir !== streamDataDir(STREAM)) return readDir(dir);
+        readCallCount += 1;
+        readStarted.resolve();
+        await readGate.promise;
+        return readDir(dir);
+      });
+
+    const loading = store.load([STREAM]);
+    await readStarted.promise;
+
+    // A live mutation lands while `load()`'s own seed read is still gated
+    // mid-flight and disk provenance is still 'unknown'.
+    facts.addUsage(STREAM, RUN, usage(50, 10, 0.25));
+
+    readGate.resolve();
+    await loading;
+    await store.flush();
+
+    expect(readCallCount).toBe(1);
+    expect(await readStreamFile(STREAM, 'usageStats.json')).toMatchObject({
+      [RUN]: usage(150, 30, 0.75),
+    });
+
+    readDirSpy.mockRestore();
+  });
+
   it('does not overwrite a live description that lands during hydration', async () => {
     await installPlatform();
     const executionId = 'aa77cc88' as ExecutionId;

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -357,14 +357,6 @@ interface StreamRecord {
   // staged deletion) — the lane itself, not this field, serializes the work.
   diskState: DiskState;
   seedChain: Promise<void> | undefined;
-  /**
-   * Single-flight guard for a lazily-triggered disk read: sibling mutations
-   * queued for the same unseeded stream before this read settles share it
-   * instead of each paying for their own `readSeed`. Cleared once the read
-   * settles (see `ensureSeedReadStarted`), so the next stream is free to
-   * retry after a failure instead of being wedged on a stale promise.
-   */
-  pendingSeedRead: Promise<void> | undefined;
   /** Incremented for each refresh attempt; seed-gated mutations do not change it. */
   seedRefreshGeneration: number;
   /** Authoritative disk provenance captured before the current refresh chain began. */
@@ -405,7 +397,6 @@ export class StreamSnapshotStore {
     summaryMetaHydrationFallback: undefined,
     diskState: 'unknown',
     seedChain: undefined,
-    pendingSeedRead: undefined,
     seedRefreshGeneration: 0,
     seedRefreshBaseline: undefined,
     metaOverlay: false,
@@ -715,48 +706,27 @@ export class StreamSnapshotStore {
   }
 
   /**
-   * Start (or join) the single disk read shared by every mutation queued for
-   * this stream before it settles: two mutations queued back-to-back capture
-   * the SAME `pendingSeedRead` promise synchronously, so only the first pays
-   * for `readSeed` — the rest just await it. Cleared on settle (guarded by
-   * identity, so a newer read that has already replaced this one is left
-   * alone) so a later, genuinely fresh attempt is free to retry.
-   */
-  private ensureSeedReadStarted(
-    stream: StreamTabId,
-    version: number,
-  ): Promise<void> {
-    const record = this.getOrCreateRecord(stream);
-    if (record.pendingSeedRead) return record.pendingSeedRead;
-    const seed = this.readSeed(stream, version).finally(() => {
-      const current = this.records.get(stream);
-      if (current?.pendingSeedRead === seed)
-        current.pendingSeedRead = undefined;
-    });
-    record.pendingSeedRead = seed;
-    return seed;
-  }
-
-  /**
-   * Queue a mutation onto the stream's seed lane: the lane's FIFO order (not
-   * manual chaining) is what guarantees this runs after every mutation queued
-   * ahead of it. `ensureSeedReadStarted` is captured synchronously, before
-   * enqueueing, so sibling mutations queued in the same tick share one read
-   * instead of each starting their own.
+   * Queue a mutation onto the stream's seed lane: the lane's single-flight
+   * FIFO order (concurrency 1, shared with `refreshSeed`) is what guarantees
+   * this runs after every unit of work queued ahead of it, seed reads
+   * included — the read itself must run INSIDE a queued task, not before
+   * enqueueing, or a `refreshSeed` racing on the same stream could start its
+   * own disk read concurrently with this one (the queue only serializes what
+   * it dispatches; anything started outside `add()` runs unguarded). Each
+   * task re-checks `hasDiskProvenance` before reading, so once the first
+   * queued task establishes it, every task queued behind it skips straight
+   * to `apply`.
    */
   private queueAfterSeed(
     stream: StreamTabId,
     version: number,
     apply: () => unknown,
   ): Promise<void> {
-    const seedRead = this.hasDiskProvenance(stream)
-      ? undefined
-      : this.ensureSeedReadStarted(stream, version);
     const next: Promise<void> = this.seedQueueFor(stream)
       .add(async () => {
-        if (seedRead) {
+        if (!this.hasDiskProvenance(stream)) {
           try {
-            await seedRead;
+            await this.readSeed(stream, version);
           } catch (err: unknown) {
             if (!this.hasDiskProvenance(stream)) throw err;
           }
@@ -1943,10 +1913,6 @@ export class StreamSnapshotStore {
     record.seedRefreshBaseline = refreshBaseline;
     const refreshGeneration = ++record.seedRefreshGeneration;
     record.diskState = 'unknown';
-    // A forced refresh supersedes any lazily-started read still in flight for
-    // the OLD (now-stale) diskState; a `queueAfterSeed` call arriving after
-    // this point must not join it.
-    record.pendingSeedRead = undefined;
     const queue = this.seedQueueFor(stream);
     const next: Promise<void> = queue
       .add(async () => {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -18,6 +18,7 @@
 
 import { Mutex } from 'async-mutex';
 import pMap from 'p-map';
+import PQueue from 'p-queue';
 import { z } from 'zod';
 
 import { getExecutionStore } from '@agent/storage';
@@ -350,10 +351,20 @@ interface StreamRecord {
 
   // -- Lazy seeding: a stream's existing disk data is read into memory BEFORE
   // the first mutation so an accumulate/merge can't overwrite unloaded disk
-  // data. `diskState` = this record's disk provenance; `seedChain` serializes
-  // refresh/seed/mutate for it.
+  // data. `diskState` = this record's disk provenance; `seedChain` is the
+  // latest unit of work queued on this stream's `seedQueueFor` lane, published
+  // for readers that await seed/mutate quiescence (`awaitSeeded`, `flush`,
+  // staged deletion) — the lane itself, not this field, serializes the work.
   diskState: DiskState;
   seedChain: Promise<void> | undefined;
+  /**
+   * Single-flight guard for a lazily-triggered disk read: sibling mutations
+   * queued for the same unseeded stream before this read settles share it
+   * instead of each paying for their own `readSeed`. Cleared once the read
+   * settles (see `ensureSeedReadStarted`), so the next stream is free to
+   * retry after a failure instead of being wedged on a stale promise.
+   */
+  pendingSeedRead: Promise<void> | undefined;
   /** Incremented for each refresh attempt; seed-gated mutations do not change it. */
   seedRefreshGeneration: number;
   /** Authoritative disk provenance captured before the current refresh chain began. */
@@ -394,6 +405,7 @@ export class StreamSnapshotStore {
     summaryMetaHydrationFallback: undefined,
     diskState: 'unknown',
     seedChain: undefined,
+    pendingSeedRead: undefined,
     seedRefreshGeneration: 0,
     seedRefreshBaseline: undefined,
     metaOverlay: false,
@@ -430,6 +442,24 @@ export class StreamSnapshotStore {
   private readonly writeMutexes = new Map<string, Mutex>();
   /** Latest ordinary sidecar value not yet confirmed durable, by write lock. */
   private readonly dirtyWrites = new Map<string, DirtySidecarWrite>();
+
+  /**
+   * Per-stream FIFO lane (concurrency 1) that serializes seed reads and the
+   * mutations queued behind them — the same `PQueue({ concurrency: 1 })`-
+   * per-key precedent as `streamApprovalQueue.ts`. Each queued unit of work
+   * still publishes its promise onto `record.seedChain` for the readers that
+   * await it (`awaitSeeded`, `seedUsageOnly`, `flush`, staged deletion).
+   */
+  private readonly seedQueues = new Map<StreamTabId, PQueue>();
+
+  private seedQueueFor(stream: StreamTabId): PQueue {
+    let queue = this.seedQueues.get(stream);
+    if (!queue) {
+      queue = new PQueue({ concurrency: 1 });
+      this.seedQueues.set(stream, queue);
+    }
+    return queue;
+  }
 
   /** Streams already warned about a pre-identity execution row (#9590 Stage
    *  7), so repeated hydrations of the same old row stay one warning each. */
@@ -684,44 +714,65 @@ export class StreamSnapshotStore {
     return undefined;
   }
 
+  /**
+   * Start (or join) the single disk read shared by every mutation queued for
+   * this stream before it settles: two mutations queued back-to-back capture
+   * the SAME `pendingSeedRead` promise synchronously, so only the first pays
+   * for `readSeed` — the rest just await it. Cleared on settle (guarded by
+   * identity, so a newer read that has already replaced this one is left
+   * alone) so a later, genuinely fresh attempt is free to retry.
+   */
+  private ensureSeedReadStarted(
+    stream: StreamTabId,
+    version: number,
+  ): Promise<void> {
+    const record = this.getOrCreateRecord(stream);
+    if (record.pendingSeedRead) return record.pendingSeedRead;
+    const seed = this.readSeed(stream, version).finally(() => {
+      const current = this.records.get(stream);
+      if (current?.pendingSeedRead === seed)
+        current.pendingSeedRead = undefined;
+    });
+    record.pendingSeedRead = seed;
+    return seed;
+  }
+
+  /**
+   * Queue a mutation onto the stream's seed lane: the lane's FIFO order (not
+   * manual chaining) is what guarantees this runs after every mutation queued
+   * ahead of it. `ensureSeedReadStarted` is captured synchronously, before
+   * enqueueing, so sibling mutations queued in the same tick share one read
+   * instead of each starting their own.
+   */
   private queueAfterSeed(
     stream: StreamTabId,
     version: number,
     apply: () => unknown,
   ): Promise<void> {
-    const next: Promise<void> = this.ensureSeeded(stream, version)
-      .catch((err: unknown) => {
-        if (!this.hasDiskProvenance(stream)) throw err;
-      })
-      .then(() => {
+    const seedRead = this.hasDiskProvenance(stream)
+      ? undefined
+      : this.ensureSeedReadStarted(stream, version);
+    const next: Promise<void> = this.seedQueueFor(stream)
+      .add(async () => {
+        if (seedRead) {
+          try {
+            await seedRead;
+          } catch (err: unknown) {
+            if (!this.hasDiskProvenance(stream)) throw err;
+          }
+        }
         if (this.streamVersion(stream) !== version) return;
         const record = this.records.get(stream);
-        if (!record || record.diskState === 'unknown') {
-          if (record?.seedChain === next) record.seedChain = undefined;
-          return;
-        }
+        if (!record || record.diskState === 'unknown') return;
         apply();
       })
       .catch((err: unknown) => {
-        const record = this.records.get(stream);
-        if (record?.diskState === 'unknown' && record.seedChain === next) {
-          record.seedChain = undefined;
-        }
         log.warn(`Deferred update failed for stream ${stream}`, {
           data: err,
         });
-      });
+      }) as Promise<void>;
     this.getOrCreateRecord(stream).seedChain = next;
     return next;
-  }
-
-  /** Read a stream's existing disk data into memory once. */
-  private ensureSeeded(stream: StreamTabId, version: number): Promise<void> {
-    const existing = this.records.get(stream)?.seedChain;
-    if (existing) return existing;
-    const seed = this.readSeed(stream, version);
-    this.getOrCreateRecord(stream).seedChain = seed;
-    return seed;
   }
 
   private async readSeed(stream: StreamTabId, version: number): Promise<void> {
@@ -1123,6 +1174,7 @@ export class StreamSnapshotStore {
   private evict(stream: StreamTabId): void {
     this.records.evict(stream);
     this.kvHandles.invalidate(stream);
+    this.seedQueues.delete(stream);
     for (const key of [...this.writeMutexes.keys()]) {
       if (!key.startsWith(`${stream}::`)) continue;
       this.writeMutexes.delete(key);
@@ -1136,6 +1188,7 @@ export class StreamSnapshotStore {
   evictAll(): void {
     this.records.evictAll();
     this.kvHandles.invalidateAll();
+    this.seedQueues.clear();
     this.writeMutexes.clear();
     this.dirtyWrites.clear();
     this.unseededReadWarned.clear();
@@ -1890,40 +1943,45 @@ export class StreamSnapshotStore {
     record.seedRefreshBaseline = refreshBaseline;
     const refreshGeneration = ++record.seedRefreshGeneration;
     record.diskState = 'unknown';
-    const prev = record.seedChain?.catch(() => undefined) ?? Promise.resolve();
-    const work = prev.then(async () => {
-      if (this.streamVersion(stream) !== version) return;
-      await this.retryDirtyWrites(stream);
-      if (this.streamVersion(stream) !== version) return;
-      this.invalidateKvHandles(stream);
-      await this.seedFromDisk(stream, version);
-    });
-    const next = work.then(
-      () => {
-        const current = this.records.get(stream);
-        if (
-          current?.seedRefreshGeneration === refreshGeneration &&
-          this.streamVersion(stream) === version
-        ) {
-          current.seedRefreshBaseline = undefined;
-        }
-      },
-      (error: unknown) => {
-        const current = this.records.get(stream);
-        if (
-          current?.seedRefreshGeneration === refreshGeneration &&
-          this.streamVersion(stream) === version
-        ) {
-          current.diskState = refreshBaseline;
-          current.seedRefreshBaseline = undefined;
-          if (refreshBaseline !== 'unknown') {
-            this.persistEagerOverlays(stream, current);
+    // A forced refresh supersedes any lazily-started read still in flight for
+    // the OLD (now-stale) diskState; a `queueAfterSeed` call arriving after
+    // this point must not join it.
+    record.pendingSeedRead = undefined;
+    const queue = this.seedQueueFor(stream);
+    const next: Promise<void> = queue
+      .add(async () => {
+        if (this.streamVersion(stream) !== version) return;
+        await this.retryDirtyWrites(stream);
+        if (this.streamVersion(stream) !== version) return;
+        this.invalidateKvHandles(stream);
+        await this.seedFromDisk(stream, version);
+      })
+      .then(
+        () => {
+          const current = this.records.get(stream);
+          if (
+            current?.seedRefreshGeneration === refreshGeneration &&
+            this.streamVersion(stream) === version
+          ) {
+            current.seedRefreshBaseline = undefined;
           }
-          if (current.seedChain === next) current.seedChain = undefined;
-        }
-        throw error;
-      },
-    );
+        },
+        (error: unknown) => {
+          const current = this.records.get(stream);
+          if (
+            current?.seedRefreshGeneration === refreshGeneration &&
+            this.streamVersion(stream) === version
+          ) {
+            current.diskState = refreshBaseline;
+            current.seedRefreshBaseline = undefined;
+            if (refreshBaseline !== 'unknown') {
+              this.persistEagerOverlays(stream, current);
+            }
+            if (current.seedChain === next) current.seedChain = undefined;
+          }
+          throw error;
+        },
+      ) as Promise<void>;
     record.seedChain = next;
     return next;
   }


### PR DESCRIPTION
## Summary

A scheduled dependency-audit found three spots hand-rolling logic already covered by packages already in `package.json`. This PR fixes all three:

1. **`src/transcript/StreamSnapshotStore.ts`** — `queueAfterSeed` and `refreshSeed` each manually reassigned `record.seedChain = record.seedChain.then(...)`, the exact "chain = chain.then(...)" pattern `AGENTS.md` calls out as banned. Replaced with a per-stream `PQueue({ concurrency: 1 })` lane, the same pattern `src/agent/runtime/streamApprovalQueue.ts` already uses. Every unit of work for a stream — lazy seed reads, forced refreshes (`refreshSeed`), and queued mutations — is added to that one queue and runs strictly FIFO, which is what actually serializes them; `record.seedChain` is kept (still populated on every enqueue) purely so its existing external readers (`awaitSeeded`, `seedUsageOnly`, `flush`, `StagedDeletionCoordinator`) keep working unchanged.
   - **Review caught a real bug in an earlier revision of this PR**: an initial draft added a `pendingSeedRead` single-flight optimization whose actual `readSeed()` call ran *outside* the `PQueue`, so a mutation racing an in-flight `refreshSeed` could start a second, concurrent disk read for the same stream — risking double-applied or clobbered usage state. Fixed by dropping that optimization: `queueAfterSeed` now performs its own `hasDiskProvenance`-gated `readSeed()` call from *inside* the queued task, so it's fully subject to the queue's serialization. Added a regression test (`does not start a second concurrent seed read for a mutation racing load()`) that gates `load()`'s disk read mid-flight, fires a concurrent mutation, and asserts the read happens exactly once — verified to fail (2 reads) against the buggy revision and pass against the fix.
2. **`packages/cli/src/commands/_helpers/fetchSilencer.ts`** — the top-level `/fetch failed/i.test(first.message)` check duplicated `is-network-error`, which is already the codebase's standard predicate for this exact signal (`src/tools/timeouts.ts`). Swapped in `isNetworkError(first)`. Left the cause-message regex (`ENOTFOUND|...|remote.texra.ai`) untouched — that's TeXRA-domain-specific DNS/cause matching `is-network-error` doesn't cover, so it isn't a valid swap target.
   - **Note (not byte-for-byte equivalent, unlike the other two swaps):** `is-network-error` additionally requires `error.name === 'TypeError'` and matches a broader message set (`'terminated'`, `'Load failed'`, `'Network request failed'`, etc.) than the old literal `/fetch failed/i` substring test. The cause-message regex still narrows the overall check to DNS/timeout patterns, so this is low-risk in practice, but it is a real (if narrow) behavior widening flagged in review.
3. **`src/shared/subscriptionUsagePresentation.ts`** — `formatSubscriptionUsageUpdated` hand-computed minutes via `Math.floor((now - fetchedAt) / 60_000)`. Swapped for `date-fns`'s `differenceInMinutes(now, fetchedAt)`, verified to produce identical output for the same inputs (the compact `${minutes}m ago` format is unchanged — only the arithmetic moved to the library). Reviewer independently verified this equivalence.

## Issue acceptance gates

Not tied to a filed issue — this came out of a scheduled repo audit (`find-simplification`-style scan for hand-rolled code duplicating existing dependencies). Acceptance gate is simply: the three call sites now route through their already-adopted library instead of a local reimplementation, with no behavior change on swaps 1 and 3, and a narrow, now-documented widening on swap 2.

## Single source of truth

- Per-stream mutation/seed-read ordering in `StreamSnapshotStore` is now owned by one `PQueue` per stream (`seedQueueFor`), not by manually threading a promise through a field.
- Network-failure detection for the CLI's fetch-log silencer is now the same `is-network-error` predicate `tools/timeouts.ts` already treats as canonical, instead of a second copy of the same regex.

## Duplication and abstraction budget

Removed: the hand-rolled `ensureSeeded` chain-memoization helper and both manual `.then()`-reassignment sites in `StreamSnapshotStore`; the duplicate `/fetch failed/i` regex in the CLI. Added: a small `seedQueueFor` lookup (mirrors `streamApprovalQueue.ts`'s existing per-key `PQueue` map). No extra per-record bookkeeping beyond what already existed — the `pendingSeedRead` field from an earlier revision was removed once it proved to be an unsafe optimization (see Summary above).

**Known small behavior difference (intentional, not a regression):** the original manual-chain code shared exactly one seed-read *failure* across every mutation already queued when it failed (logging one warning, silently dropping the rest). Now that every unit of work performs its own `hasDiskProvenance` check from inside the queue, each mutation queued behind a failed read now retries the read itself when its turn comes and logs its own warning on failure — so a persistent failure produces one warning per queued mutation instead of one warning total. No duplicate disk reads happen in either version, since the queue's concurrency-1 FIFO guarantees each retry only runs after the previous one has fully settled. This is strictly a log-verbosity difference, and arguably more honest (no mutation is silently dropped without a trace).

## Net elements (R6)

Diffstat (`git diff --stat origin/main`): 6 files changed (5 from the original commit + the regression test file), 126 + 58 insertions / 60 + 46 deletions across the two commits.
Exported symbols (`^[+-]export` over the diff): none — this is fully internal to the affected modules.
Classes/interfaces/enums: none added or removed.
Net LoC: modest positive, explained by doc comments on the `seedQueueFor` lane and the new regression test — the actual control-flow mechanism (one `PQueue` add() instead of a 3-stage `.then()/.catch()` chain, twice) is smaller, not larger, than the original.

## Consumer counts (R8)

n/a — no export, emit path, or public API was deleted or re-routed; `record.seedChain`'s type and external read sites are unchanged.

## Host impact

Extension: `StreamSnapshotStore` is shared core (`src/transcript/`), used by the extension's progress view — internal-only change, no behavior difference for extension users beyond the log-verbosity note above.

Desktop: same shared `StreamSnapshotStore` — same note applies.

CLI: `fetchSilencer.ts` change only affects which errors get suppressed from `console.error` during CLI model-listing network failures; added `is-network-error` as an explicit CLI package dependency (it bundles its own deps rather than relying on root hoisting, matching the existing `semver`/`lru-cache`/`p-queue` pattern in `packages/cli/package.json`).

## Scheduled refactoring

None — this was itself the follow-up from a scheduled dependency-audit routine.

## Validation

- `npm run typecheck` (root workspace + test-kernel) — clean, both before and after the follow-up fix
- `packages/cli` package typecheck (`tsc --noEmit -p tsconfig.json`) — clean
- `npx eslint` on all changed files — clean
- `npm run format` (prettier) — clean
- Targeted tests: `src/test-kernel/transcript/StreamSnapshotStore.vitest.ts` (100 tests, including the new regression test), plus `src/test-kernel/transcript/`, `src/test-kernel/agent/runtime/streamApprovalQueue.vitest.ts`, `src/test-kernel/shared/` (616 tests total) — all passing after the fix
- New regression test independently verified to fail against the buggy intermediate revision (`readCallCount` was 2, not 1) and pass against the final fix
- Full suite (`npm test`) run twice (before and after the follow-up fix): 1 unrelated pre-existing failure in `src/test-kernel/desktop/DesktopAgentExecution.vitest.ts` ("presents a merge failure that occurs before lifecycle startup") — confirmed to fail identically with this PR's changes fully reverted, so it's a pre-existing/environment-flaky test unrelated to this diff, not a regression introduced here. Everything else: 10722 passed / 6 skipped.
- `npm run check:dead-code-ratchet` — clean (8 baselined findings, no new ones)
- `pnpm install` re-run after adding `is-network-error` to `packages/cli/package.json`, so `pnpm-lock.yaml` is in sync (diff is scoped to exactly that one new entry)
