### PR TITLE
refactor(modelHandlers): split createResponseImpl into named phases

### DIFF
--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -14,6 +14,7 @@ import { platform } from '@platform/platform';
 import type { ApiAccessMode } from '@shared/schemas';
 import { AgentCategory, byCategory } from '@shared/schemas';
 import { getFirstRunDone } from '@shared/state/onboardingState';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import {
   firstRunSetupAgentOverride,
@@ -135,7 +136,7 @@ async function canLaunchWithDefaultModel(
     return true;
   } catch (error) {
     log.warn(
-      `Unable to select the default CLI model: ${error instanceof Error ? error.message : String(error)}`,
+      `Unable to select the default CLI model: ${toErrorMessage(error)}`,
     );
     return false;
   }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -1442,6 +1442,168 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
   }
 
   /**
+   * Clear a cached compaction result that belongs to a genuinely different
+   * input, before {@link createResponseImpl} decides whether to reuse it.
+   *
+   * A same-turn retry (PocketFlow's Node._exec reuses the same prepRes, hence
+   * the same `messages` reference, across retry attempts) keeps its cached
+   * result instead — otherwise the chain anchor that compaction already
+   * cleared on chainState (which survives retries permanently) would outlive
+   * this payload, forcing a redundant re-compaction on every retry. A retained
+   * pending response is handled by the caller before this state can be
+   * discarded.
+   *
+   * This reference check alone is NOT sufficient to distinguish a same-turn
+   * retry from the next turn, because PocketFlow's ModelInvocationNode.post()
+   * mutates `shared.messages` in place, so the reference is often identical
+   * across turns too. The primary guard against cross-turn reuse is
+   * applyCompactionState() clearing compactionResult on every successful call;
+   * this method only ever matters while a compaction from a still-in-flight
+   * (unsuccessful) attempt is pending.
+   */
+  private invalidateStaleCompactionCache(messages: ResponseInputItem[]): void {
+    if (
+      this.compactionResult !== undefined &&
+      (this.compactionResult.sourceMessages !== messages ||
+        this.compactionResult.sourceFingerprint !==
+          this.messagesTailFingerprint(messages))
+    ) {
+      // Reference or content changed — a follow-up appended after a failed
+      // turn mutates the SAME array in place, so identity alone would replay
+      // a stale pre-follow-up payload and silently drop the user's message.
+      this.compactionResult = undefined;
+    }
+  }
+
+  /**
+   * Decide the execution transport for this request. Extracted from
+   * {@link createResponseImpl} verbatim; owns the mutually-exclusive
+   * background / streaming / WebSocket selection plus the debug logging that
+   * explains why an enabled toggle was skipped.
+   */
+  private resolveExecutionMode(): {
+    useBackgroundResponses: boolean;
+    useStreaming: boolean;
+    useWebSocket: boolean;
+  } {
+    // Route through isBackgroundModeActive() so provider-profile policy actually
+    // gates the request, not just the predicate.
+    const useBackgroundResponses = this.isBackgroundModeActive();
+    const streamingToggleEnabled = useBackgroundResponses
+      ? super.getStreamingConfig()
+      : this.getStreamingConfig();
+    const useStreaming = streamingToggleEnabled && !useBackgroundResponses;
+    const useWebSocket =
+      this.isWebSocketModeEnabled() && !useBackgroundResponses;
+
+    if (
+      !useBackgroundResponses &&
+      this.isBackgroundModeToggleEnabled() &&
+      this.isBackgroundModeEligible()
+    ) {
+      if (this.getOpenAIResponseCapabilities()?.backgroundMode === 'disabled') {
+        this.logger.debug(
+          'Background mode toggle is enabled but the active provider profile disables background execution. Proceeding without background mode.',
+        );
+      } else {
+        this.logger.debug(
+          'Background mode toggle is enabled but this handler does not support background execution. Proceeding without background mode.',
+        );
+      }
+    } else if (streamingToggleEnabled && useBackgroundResponses) {
+      this.logger.debug(
+        'Background mode enabled; skipping streaming to avoid unstable behavior.',
+      );
+    }
+
+    return { useBackgroundResponses, useStreaming, useWebSocket };
+  }
+
+  /**
+   * Resolve the messages actually sent this turn: reuse a cached compaction,
+   * run a fresh compaction at the manual/threshold trigger, or pass the input
+   * through untouched. Extracted from {@link createResponseImpl} verbatim; the
+   * compaction path mutates `this.compactionResult` as a side effect, which the
+   * caller reads back for its downstream slicing and return value.
+   */
+  private async resolveEffectiveMessages(args: {
+    client: OpenAI;
+    messages: ResponseInputItem[];
+    systemPrompt: string | undefined;
+    signal: AbortSignal | undefined;
+    convertedTools: ReturnType<typeof toOpenAIResponseTools> | undefined;
+  }): Promise<{
+    effectiveMessages: ResponseInputItem[];
+    compactedThisCall: boolean;
+    compactedMessages: ResponseInputItem[] | undefined;
+  }> {
+    const { client, messages, systemPrompt, signal, convertedTools } = args;
+
+    // Check if compaction is needed before processing the request
+    let effectiveMessages = messages;
+    // Track if compaction happened in THIS call (not previous calls)
+    let compactedThisCall = false;
+    // Store compacted messages for return value (captured when compaction succeeds)
+    let compactedMessages: ResponseInputItem[] | undefined;
+    const reusableCompaction = this.compactionResult;
+    if (reusableCompaction) {
+      // Anything surviving the staleness check above compacted this exact input.
+      // Same-turn retry of an input that already compacted successfully on a
+      // prior attempt (see the cache check above): reuse it instead of
+      // hitting the compact endpoint again. Re-running compaction here would
+      // be a silent no-op from the caller's perspective but a real, wasted
+      // API round trip, since chainState's anchor clear already committed
+      // permanently and doesn't need redoing.
+      effectiveMessages = reusableCompaction.compactedMessages;
+      compactedThisCall = true;
+      compactedMessages = reusableCompaction.compactedMessages;
+    } else if (this.shouldCompact()) {
+      // Consume the manual compaction request now that compaction is being
+      // attempted. For automatic compaction (threshold-based) no request is
+      // pending, so this reports false and changes nothing.
+      const wasManualRequest = this.consumeCompactionRequest();
+      if (wasManualRequest) {
+        // Requested compactions come from the manual command, the live-count
+        // threshold, or the overflow recovery — each already logged its
+        // trigger; this line records the execution.
+        logProgressStatus(
+          this.logger,
+          `Compacting conversation (requested, ${this.chainState.getCumulativeInputTokens()} input tokens)`,
+        );
+      } else {
+        const threshold = this.getCompactionTokenThreshold();
+        logProgressStatus(
+          this.logger,
+          `Compacting conversation (${this.chainState.getCumulativeInputTokens()} tokens exceed ${this.getCompactionThresholdPercent()}% threshold of ${threshold} tokens)`,
+        );
+      }
+      // A backend that keeps no server-side response state (the ChatGPT-
+      // subscription/Codex profile) has nothing for the stateful compact
+      // endpoint to act on, so it always goes through the client-side
+      // summarize-and-resend fallback instead (#7213).
+      effectiveMessages = this.storesResponsesServerSide
+        ? await this.compactConversation(
+            client,
+            messages,
+            systemPrompt,
+            signal,
+            convertedTools,
+          )
+        : await this.compactConversationClientSide(client, messages, signal);
+      // compactionResult is set if compaction succeeded
+      const { compactionResult } = this;
+      compactedThisCall = compactionResult !== undefined;
+      if (compactionResult) {
+        // Note: the chain anchor is already cleared inside compactConversation()
+        // immediately after the compact endpoint succeeds (before token counting).
+        compactedMessages = compactionResult.compactedMessages;
+      }
+    }
+
+    return { effectiveMessages, compactedThisCall, compactedMessages };
+  }
+
+  /**
    * Phase 1: BUILD - Construct the shared base request parameters (including
    * the reasoning config) used by both token counting and the API call.
    * Extracted from {@link createResponseImpl} verbatim.
@@ -1679,63 +1841,12 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
       }
     }
 
-    // Clear any stale compaction result from a genuinely different input. A
-    // same-turn retry (PocketFlow's Node._exec reuses the same prepRes, hence
-    // the same `messages` reference, across retry attempts) keeps its cached
-    // result below instead — otherwise the chain anchor that compaction
-    // already cleared on chainState (which survives retries permanently)
-    // would outlive this payload, forcing a redundant re-compaction on every
-    // retry. A retained pending response is handled above before this state
-    // can be discarded.
-    //
-    // This reference check alone is NOT sufficient to distinguish a same-turn
-    // retry from the next turn, because PocketFlow's ModelInvocationNode.post()
-    // mutates `shared.messages` in place, so the reference is often identical
-    // across turns too. The primary guard against cross-turn reuse is
-    // applyCompactionState() clearing compactionResult on every successful
-    // call; this line only ever matters while a compaction from a still-in-
-    // flight (unsuccessful) attempt is pending.
-    if (
-      this.compactionResult !== undefined &&
-      (this.compactionResult.sourceMessages !== messages ||
-        this.compactionResult.sourceFingerprint !==
-          this.messagesTailFingerprint(messages))
-    ) {
-      // Reference or content changed — a follow-up appended after a failed
-      // turn mutates the SAME array in place, so identity alone would replay
-      // a stale pre-follow-up payload and silently drop the user's message.
-      this.compactionResult = undefined;
-    }
+    // Clear any stale compaction cache before deciding whether to reuse it
+    // below (see {@link invalidateStaleCompactionCache}).
+    this.invalidateStaleCompactionCache(messages);
 
-    // Route through isBackgroundModeActive() so provider-profile policy actually
-    // gates the request, not just the predicate.
-    const useBackgroundResponses = this.isBackgroundModeActive();
-    const streamingToggleEnabled = useBackgroundResponses
-      ? super.getStreamingConfig()
-      : this.getStreamingConfig();
-    const useStreaming = streamingToggleEnabled && !useBackgroundResponses;
-    const useWebSocket =
-      this.isWebSocketModeEnabled() && !useBackgroundResponses;
-
-    if (
-      !useBackgroundResponses &&
-      this.isBackgroundModeToggleEnabled() &&
-      this.isBackgroundModeEligible()
-    ) {
-      if (this.getOpenAIResponseCapabilities()?.backgroundMode === 'disabled') {
-        this.logger.debug(
-          'Background mode toggle is enabled but the active provider profile disables background execution. Proceeding without background mode.',
-        );
-      } else {
-        this.logger.debug(
-          'Background mode toggle is enabled but this handler does not support background execution. Proceeding without background mode.',
-        );
-      }
-    } else if (streamingToggleEnabled && useBackgroundResponses) {
-      this.logger.debug(
-        'Background mode enabled; skipping streaming to avoid unstable behavior.',
-      );
-    }
+    const { useBackgroundResponses, useStreaming, useWebSocket } =
+      this.resolveExecutionMode();
 
     // Convert tools early so they're available for both compaction token counting and the API call
     const convertedTools = tools?.length
@@ -1745,66 +1856,16 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
         })
       : undefined;
 
-    // Check if compaction is needed before processing the request
-    let effectiveMessages = messages;
-    // Track if compaction happened in THIS call (not previous calls)
-    let compactedThisCall = false;
-    // Store compacted messages for return value (captured when compaction succeeds)
-    let compactedMessages: ResponseInputItem[] | undefined;
-    const reusableCompaction = this.compactionResult;
-    if (reusableCompaction) {
-      // Anything surviving the staleness check above compacted this exact input.
-      // Same-turn retry of an input that already compacted successfully on a
-      // prior attempt (see the cache check above): reuse it instead of
-      // hitting the compact endpoint again. Re-running compaction here would
-      // be a silent no-op from the caller's perspective but a real, wasted
-      // API round trip, since chainState's anchor clear already committed
-      // permanently and doesn't need redoing.
-      effectiveMessages = reusableCompaction.compactedMessages;
-      compactedThisCall = true;
-      compactedMessages = reusableCompaction.compactedMessages;
-    } else if (this.shouldCompact()) {
-      // Consume the manual compaction request now that compaction is being
-      // attempted. For automatic compaction (threshold-based) no request is
-      // pending, so this reports false and changes nothing.
-      const wasManualRequest = this.consumeCompactionRequest();
-      if (wasManualRequest) {
-        // Requested compactions come from the manual command, the live-count
-        // threshold, or the overflow recovery — each already logged its
-        // trigger; this line records the execution.
-        logProgressStatus(
-          this.logger,
-          `Compacting conversation (requested, ${this.chainState.getCumulativeInputTokens()} input tokens)`,
-        );
-      } else {
-        const threshold = this.getCompactionTokenThreshold();
-        logProgressStatus(
-          this.logger,
-          `Compacting conversation (${this.chainState.getCumulativeInputTokens()} tokens exceed ${this.getCompactionThresholdPercent()}% threshold of ${threshold} tokens)`,
-        );
-      }
-      // A backend that keeps no server-side response state (the ChatGPT-
-      // subscription/Codex profile) has nothing for the stateful compact
-      // endpoint to act on, so it always goes through the client-side
-      // summarize-and-resend fallback instead (#7213).
-      effectiveMessages = this.storesResponsesServerSide
-        ? await this.compactConversation(
-            client,
-            messages,
-            systemPrompt,
-            signal,
-            convertedTools,
-          )
-        : await this.compactConversationClientSide(client, messages, signal);
-      // compactionResult is set if compaction succeeded
-      const { compactionResult } = this;
-      compactedThisCall = compactionResult !== undefined;
-      if (compactionResult) {
-        // Note: the chain anchor is already cleared inside compactConversation()
-        // immediately after the compact endpoint succeeds (before token counting).
-        compactedMessages = compactionResult.compactedMessages;
-      }
-    }
+    // Reuse a cached compaction, run a fresh one at the manual/threshold
+    // trigger, or pass the input through unchanged.
+    const { effectiveMessages, compactedThisCall, compactedMessages } =
+      await this.resolveEffectiveMessages({
+        client,
+        messages,
+        systemPrompt,
+        signal,
+        convertedTools,
+      });
 
     // After compaction in THIS call, send all compacted messages.
     // If already compacted (from previous call), also send all messages.

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -1441,27 +1441,20 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
     return true;
   }
 
-  /**
-   * Clear a cached compaction result that belongs to a genuinely different
-   * input, before {@link createResponseImpl} decides whether to reuse it.
-   *
-   * A same-turn retry (PocketFlow's Node._exec reuses the same prepRes, hence
-   * the same `messages` reference, across retry attempts) keeps its cached
-   * result instead — otherwise the chain anchor that compaction already
-   * cleared on chainState (which survives retries permanently) would outlive
-   * this payload, forcing a redundant re-compaction on every retry. A retained
-   * pending response is handled by the caller before this state can be
-   * discarded.
-   *
-   * This reference check alone is NOT sufficient to distinguish a same-turn
-   * retry from the next turn, because PocketFlow's ModelInvocationNode.post()
-   * mutates `shared.messages` in place, so the reference is often identical
-   * across turns too. The primary guard against cross-turn reuse is
-   * applyCompactionState() clearing compactionResult on every successful call;
-   * this method only ever matters while a compaction from a still-in-flight
-   * (unsuccessful) attempt is pending.
-   */
+  /** Drop a cached compaction result that no longer matches the current input. */
   private invalidateStaleCompactionCache(messages: ResponseInputItem[]): void {
+    // A same-turn retry (PocketFlow's Node._exec reuses the same prepRes, hence
+    // the same `messages` reference, across retry attempts) keeps its cached
+    // result — otherwise the chain anchor that compaction already cleared on
+    // chainState (which survives retries permanently) would outlive this
+    // payload, forcing a redundant re-compaction on every retry. A retained
+    // pending response is handled by the caller before this state can be
+    // discarded. This reference check alone is NOT sufficient to distinguish a
+    // same-turn retry from the next turn, because ModelInvocationNode.post()
+    // mutates `shared.messages` in place, so the reference is often identical
+    // across turns too; the primary cross-turn guard is applyCompactionState()
+    // clearing compactionResult on every successful call. This only matters
+    // while a compaction from a still-in-flight (unsuccessful) attempt is pending.
     if (
       this.compactionResult !== undefined &&
       (this.compactionResult.sourceMessages !== messages ||
@@ -1475,12 +1468,7 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
     }
   }
 
-  /**
-   * Decide the execution transport for this request. Extracted from
-   * {@link createResponseImpl} verbatim; owns the mutually-exclusive
-   * background / streaming / WebSocket selection plus the debug logging that
-   * explains why an enabled toggle was skipped.
-   */
+  /** Select the mutually-exclusive background / streaming / WebSocket transport. */
   private resolveExecutionMode(): {
     useBackgroundResponses: boolean;
     useStreaming: boolean;
@@ -1519,13 +1507,7 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
     return { useBackgroundResponses, useStreaming, useWebSocket };
   }
 
-  /**
-   * Resolve the messages actually sent this turn: reuse a cached compaction,
-   * run a fresh compaction at the manual/threshold trigger, or pass the input
-   * through untouched. Extracted from {@link createResponseImpl} verbatim; the
-   * compaction path mutates `this.compactionResult` as a side effect, which the
-   * caller reads back for its downstream slicing and return value.
-   */
+  /** Resolve the messages sent this turn (reuse / compact / pass through); may set `this.compactionResult`. */
   private async resolveEffectiveMessages(args: {
     client: OpenAI;
     messages: ResponseInputItem[];


### PR DESCRIPTION
## Summary

This PR follows a codebase-wide tech-debt audit (5 candidate areas, scanned by
subagents and then cross-checked against the repo's design ledger under
`docs/dev/audits/`, `docs/proposals/`, and `docs/prds/`). The audit's headline
result is that **this codebase is already well-refactored** — most raw-size
"debt" turned out to be intrinsic complexity, a deliberately-frozen seam, a
PRD-governed design, or an extraction that was already done. See *Scheduled
refactoring* below for the full disposition of every candidate.

What this PR lands is the one candidate that is simultaneously blessed by the
ledger, isolated, and fully unit-test-verifiable: splitting the Responses-API
`createResponseImpl` orchestrator into named phase methods, plus one trivial
error-helper consistency fix.

**`createResponseImpl` (openai/modelHandlerOpenAIResponse.ts)** was a ~284-line
method that interleaved stale-compaction-cache invalidation, transport-mode
selection, and compaction resolution inline with the token-counting and
dispatch phases. The file already demonstrated the target style
(`buildResponseBaseParams`, `dispatchOpenAIResponseExecution` were extracted
verbatim) but left the middle unsplit. Three self-contained phases are now
private methods, moved **verbatim** (no logic change):

- `invalidateStaleCompactionCache(messages)`
- `resolveExecutionMode()` → `{ useBackgroundResponses, useStreaming, useWebSocket }`
- `resolveEffectiveMessages({…})` → `{ effectiveMessages, compactedThisCall, compactedMessages }`

`createResponseImpl` now reads as a phase pipeline and drops from 284 to 183
lines. Statement ordering and the `this.compactionResult` side effect are
preserved exactly.

Additionally, one inline `error instanceof Error ? error.message : String(error)`
in the CLI `orchestrate` command is replaced with the canonical
`toErrorMessage()` helper (`@utils/errors/errorMessage`) already used ~429×
across the tree.

## Issue acceptance gates

No tracked issue — this originated from an ad-hoc tech-debt audit. Self-imposed
gate: behavior-preserving relocation, verified by typecheck + the full
model-handler test suite, with zero new tests (per the repo's testing-budget
rule for behavior-preserving refactors).

## Single source of truth

No ownership moved. The transport-mode decision, stale-compaction-cache rule,
and compaction resolution each now have a single named home
(`resolveExecutionMode` / `invalidateStaleCompactionCache` /
`resolveEffectiveMessages`) instead of being inlined in the orchestrator, but
the owning class (`ModelHandlerOpenAIResponse`) is unchanged.

## Duplication and abstraction budget

No new abstraction and no cross-file indirection: the three new methods are
private, single-caller **phase extractions within the same class**, matching
the existing `buildResponseBaseParams` / `dispatchOpenAIResponseExecution`
pattern in the same file. This is altitude reduction of one hot method, not a
new factory or seam. No pass-through layer added.

## Net elements (R6)

- Files: **0 added / 0 deleted** (2 modified).
- Exported symbols: **0 added / 0 removed** (`^[+-]export` over the diff is empty).
- Classes / interfaces / enums: **0**.
- Methods: **+3 private** (all consumed in the same file by their single caller).
- Net LoC: **+62** (+179 / −117). This is a complexity refactor, not a LoC
  refactor: the win is `createResponseImpl` shrinking 284 → 183 lines; the net
  increase is method signatures, return-object literals, and the detailed
  rationale comments relocated onto the new methods' JSDoc.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed. The extracted methods
are private with exactly one in-file caller each (`createResponseImpl`).

## Host impact

Extension: none (model-handler layer is host-agnostic).

Desktop: none.

CLI: one log-message helper swap in `orchestrate.ts` (`toErrorMessage`);
identical output for the real (Error) path.

## Scheduled refactoring

The audit's other four candidate areas were **deliberately not bundled here**,
each for a documented reason:

- **Transcript storage engine** (merge `StreamSnapshotStore`/`StreamLogStore`,
  drop the seed-overlay machine, drop the summary-meta mirror) — **rejected by
  the governing design.** `docs/prds/2026-08-11-transcript-memory-architecture.md`
  deliberately keeps two stores (:237-262), explicitly retains the overlay/replay
  machinery (:285, :428-430), and keeps `meta.json` authoritative (:426-427). Not
  debt.
- **Hoisting the `createToolUseFollowUpMessages` batched-of-one wrapper** onto
  the base handler — collides with the deliberately-frozen `IModelHandler`
  optional-`createBatchedToolUseFollowUpMessages` seam, recorded as a "Trap"
  across ~15 audit checkpoints (e.g. `docs/dev/audits/2026-08-01-…:276`). Not debt.
- **Per-provider media-mapping consolidation** — the high-value part (structural
  classification) was **already extracted** into `classifyMediaEntry` /
  `unknownMediaCategoryWarning` (`support/mediaClassification.ts`), and Google is
  deliberately excluded there. The residual dispatch shell is near break-even on
  LoC with real callback-abstraction cost.
- **Cross-host progress-view / settings-view wiring consolidation** into
  `src/controllers/` — genuinely blessed and the largest remaining opportunity
  (`docs/proposals/2026-08-03-ssot-consolidation-plan.md` F2/F3;
  `docs/proposals/2026-08-15-cross-host-consolidation.md`), but it is an
  actively-sequenced maintainer plan with coordination constraints, spans 6+
  large host files, and is only typecheck-verifiable in a headless environment
  (real host-behavior divergence that unit tests won't catch). It should land as
  its own attended PR (respecting the fence that `DesktopProgressBridge` stays an
  IPC/callback layer, not a state layer — `2026-08-15-single-substrate-hosts-as-renderers.md:374-375`).
- **`ServerChainState` chain-resend/recovery hoist** (Google + OpenAIResponse) —
  the ledger classifies this as behavior-risky, needs-own-PR, with the stale-id
  predicate kept injectable (`2026-08-10-simplifier-fleet-round1-strategy.md` H1).

Recommended next PR: the cross-host settings/progress wiring consolidation
(F2 `SettingsCredentialActions` + F3 `applyStateSettingWrite` + the progress-view
port-graph factory), done with host-level validation.

## Validation

- `npm run typecheck` — green.
- `npx vitest run src/test-kernel/agent/modelHandlers/` — 775 passed / 4 skipped
  (63 files), including the 41-test `ModelHandlerOpenAIResponse` suite.
- `eslint` + `prettier --check` on both changed files — clean.
- Not run: the desktop/extension host apps (headless environment); not needed —
  the change is confined to the host-agnostic model-handler layer plus one CLI
  log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaZmrYLbayXDaEzz6rc1j3

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaZmrYLbayXDaEzz6rc1j3)_