### PR TITLE
feat(model): drive quota fallback from one route catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this project will be documented in this file.
   older Flash models keep working while Google serves them.
 - **Lean Project remotes are available after sign-in** — the hosted Lean
   agents no longer need a special access group.
+- **Grok subscription quota can fall back to an xAI API key** — when a SuperGrok
+  plan hits its usage limit, the retry prompt can turn off the Grok preference
+  and continue on a saved xAI key, the same way ChatGPT, Kimi Code, and GLM
+  Coding Plan already do.
 
 #### Bug Fixes
 

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -16,7 +16,7 @@
 import { computed, signal, type Signal } from '@lit-labs/signals';
 
 import type { ApprovalBypassKind } from '@shared/approvalBypassKind';
-import type { CodingPlanSubscriptionId } from '@shared/codingPlanSubscriptions';
+import type { QuotaFallbackRouteId } from '@shared/quotaFallbackRoutes';
 import type {
   AgentProposalPermission,
   ApiAccessMode,
@@ -68,11 +68,8 @@ export interface ApprovalDecision extends Readonly<SharedApprovalDecision> {
   readonly bypass?: ApprovalBypassKind;
   /** Credential mode to apply before accepting this approval. */
   readonly apiMode?: ApiAccessMode;
-  /** Turn off the "prefer ChatGPT subscription" preference before accepting,
-   *  so a Codex usage-limit retry routes through the OpenAI API key. */
-  readonly disableChatGptSubscription?: boolean;
-  /** Turn off the exhausted coding-plan preference before accepting. */
-  readonly disableCodingPlan?: CodingPlanSubscriptionId;
+  /** Turn off the matching quota-fallback preference before accepting. */
+  readonly disableQuotaRoute?: QuotaFallbackRouteId;
   /** Plan-only approval action when plain approve/reject is not specific enough. */
   readonly planAction?: Extract<PlanApprovalAction, 'approve_and_goal'>;
 }

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -63,7 +63,9 @@ import {
   type CodingPlanSubscriptionRuntime,
 } from '@model/codingPlanSubscriptions';
 import { isPreferCodexSubscription } from '@model/codex/codexPreference';
+import { isPreferXaiSubscription } from '@model/xai/xaiPreference';
 import { platform } from '@platform/platform';
+import { quotaFallbackRouteById } from '@shared/quotaFallbackRoutes';
 import {
   isUpstreamCreditDepletedError,
   type AgentProposalPermission,
@@ -86,6 +88,7 @@ import {
   setCliCodingPlanSubscription,
   setCliCodexSubscription,
 } from './codexSubscription';
+import { setCliXaiSubscription } from './xaiSubscription';
 import {
   approveQueuedDelegatedWorkForStream,
   approvalPayloadStreamId,
@@ -136,13 +139,20 @@ function maybeAutoSwitchRetry(
 
   // Coding-plan quotas (Kimi Code, GLM Coding Plan) have a fallback route that
   // re-uses an already-stored key, so auto-switch when that key exists.
+  // OAuth subscriptions (ChatGPT, Grok) stay explicit: the user must confirm.
   // Kimi Code-exclusive models never reach this branch: the classifier above
   // gates them to 'none', keeping the modal without an API-key switch.
-  if (action.startsWith('disable-coding-plan:')) {
+  if (action.startsWith('disable-quota-route:')) {
+    const decision = cliRetryApiSwitchDecision(payload);
+    if (
+      decision.disableQuotaRoute === undefined ||
+      quotaFallbackRouteById(decision.disableQuotaRoute)?.codingPlanId ===
+        undefined
+    ) {
+      return undefined;
+    }
     if (payload.personalApiKeyAvailable !== true) return undefined;
-    // The switch decision's single owner is the classifier's sibling, so the
-    // auto-switch cannot drift from the modal.
-    return cliRetryApiSwitchDecision(payload);
+    return decision;
   }
 
   return undefined;
@@ -444,8 +454,7 @@ async function requestRetryInteraction(
     }
     if (
       decision.apiMode !== undefined ||
-      decision.disableChatGptSubscription === true ||
-      decision.disableCodingPlan !== undefined
+      decision.disableQuotaRoute !== undefined
     ) {
       await switchRetryToPersonalCredentials(decision, promptRequest, {
         prepareRetry: options?.prepareRetry,
@@ -458,7 +467,9 @@ async function requestRetryInteraction(
       // the user must not be told a switch happened that did not.
       if (
         retryDecision.source === 'automatic' &&
-        decision.disableCodingPlan !== undefined
+        decision.disableQuotaRoute !== undefined &&
+        quotaFallbackRouteById(decision.disableQuotaRoute)?.codingPlanId !==
+          undefined
       ) {
         notify('credentialSwitched');
       }
@@ -681,7 +692,15 @@ async function applyRetryCredentialCommit(
   signal.throwIfAborted();
   const previousApiMode = getCliApiMode();
   const previousOpenRouter = cliOpenRouterEnabled();
-  const previousSubscriptionPreference = isPreferCodexSubscription();
+  const oauthRoute = decision.disableQuotaRoute;
+  const disableChatGpt = oauthRoute === 'chatgpt';
+  const disableGrok = oauthRoute === 'grok';
+  const previousChatGptPreference = disableChatGpt
+    ? isPreferCodexSubscription()
+    : false;
+  const previousGrokPreference = disableGrok
+    ? isPreferXaiSubscription()
+    : false;
   let apiModeWriteStarted = false;
   let subscriptionWriteStarted = false;
   try {
@@ -691,7 +710,7 @@ async function applyRetryCredentialCommit(
       await runRetryTask(() => setCliApiMode(apiMode), signal);
       signal.throwIfAborted();
     }
-    if (decision.disableChatGptSubscription) {
+    if (disableChatGpt) {
       subscriptionWriteStarted = true;
       const update = await runRetryTask(
         () => setCliCodexSubscription(false),
@@ -700,6 +719,19 @@ async function applyRetryCredentialCommit(
       if (update.effective) {
         throw new Error(
           'ChatGPT subscription remains enabled by a more specific setting.',
+        );
+      }
+      signal.throwIfAborted();
+    }
+    if (disableGrok) {
+      subscriptionWriteStarted = true;
+      const update = await runRetryTask(
+        () => setCliXaiSubscription(false),
+        signal,
+      );
+      if (update.effective) {
+        throw new Error(
+          'Grok subscription remains enabled by a more specific setting.',
         );
       }
       signal.throwIfAborted();
@@ -718,24 +750,42 @@ async function applyRetryCredentialCommit(
     let openRouterToPreserve = previousOpenRouter;
     const rollbackFailures = await rollbackChangedSettings([
       {
-        writeStarted: subscriptionWriteStarted,
+        writeStarted: subscriptionWriteStarted && disableChatGpt,
         needsRollback: () => !isPreferCodexSubscription(),
         restore: async () => {
           const update = await setCliCodexSubscription(
-            previousSubscriptionPreference,
+            previousChatGptPreference,
           );
-          if (update.effective !== previousSubscriptionPreference) {
+          if (update.effective !== previousChatGptPreference) {
             throw new Error(
               `ChatGPT subscription preference remained ${String(update.effective)}.`,
             );
           }
         },
         restoredInMemory: () =>
-          isPreferCodexSubscription() === previousSubscriptionPreference,
+          isPreferCodexSubscription() === previousChatGptPreference,
         memoryRestoredContext:
           'The previous ChatGPT subscription preference appears restored in memory, but persistence could not be confirmed',
         restoreFailedContext:
           'Could not restore the ChatGPT subscription preference',
+      },
+      {
+        writeStarted: subscriptionWriteStarted && disableGrok,
+        needsRollback: () => !isPreferXaiSubscription(),
+        restore: async () => {
+          const update = await setCliXaiSubscription(previousGrokPreference);
+          if (update.effective !== previousGrokPreference) {
+            throw new Error(
+              `Grok subscription preference remained ${String(update.effective)}.`,
+            );
+          }
+        },
+        restoredInMemory: () =>
+          isPreferXaiSubscription() === previousGrokPreference,
+        memoryRestoredContext:
+          'The previous Grok subscription preference appears restored in memory, but persistence could not be confirmed',
+        restoreFailedContext:
+          'Could not restore the Grok subscription preference',
       },
       ...(codingPlanRollback ? [codingPlanRollback] : []),
       {
@@ -822,7 +872,9 @@ async function switchRetryToPersonalCredentials(
   // disable, preparation, and rollback all stay inside one commit-queue slot
   // so a second coding-plan retry cannot interleave: its disable must wait
   // until this retry's rollback (if any) has finished.
-  const codingPlanId = decision.disableCodingPlan;
+  const codingPlanId = decision.disableQuotaRoute
+    ? quotaFallbackRouteById(decision.disableQuotaRoute)?.codingPlanId
+    : undefined;
   const codingPlanRuntime = codingPlanId
     ? codingPlanSubscriptionRuntimes.find(
         (runtime) => runtime.descriptor.id === codingPlanId,

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -65,7 +65,10 @@ import {
 import { isPreferCodexSubscription } from '@model/codex/codexPreference';
 import { isPreferXaiSubscription } from '@model/xai/xaiPreference';
 import { platform } from '@platform/platform';
-import { quotaFallbackRouteById } from '@shared/quotaFallbackRoutes';
+import {
+  isCodingPlanQuotaRoute,
+  type QuotaFallbackRouteId,
+} from '@shared/quotaFallbackRoutes';
 import {
   isUpstreamCreditDepletedError,
   type AgentProposalPermission,
@@ -146,8 +149,7 @@ function maybeAutoSwitchRetry(
     const decision = cliRetryApiSwitchDecision(payload);
     if (
       decision.disableQuotaRoute === undefined ||
-      quotaFallbackRouteById(decision.disableQuotaRoute)?.codingPlanId ===
-        undefined
+      !isCodingPlanQuotaRoute(decision.disableQuotaRoute)
     ) {
       return undefined;
     }
@@ -468,8 +470,7 @@ async function requestRetryInteraction(
       if (
         retryDecision.source === 'automatic' &&
         decision.disableQuotaRoute !== undefined &&
-        quotaFallbackRouteById(decision.disableQuotaRoute)?.codingPlanId !==
-          undefined
+        isCodingPlanQuotaRoute(decision.disableQuotaRoute)
       ) {
         notify('credentialSwitched');
       }
@@ -678,6 +679,34 @@ function throwWithRollbackFailures(
   throw error;
 }
 
+interface OauthCliPreference {
+  readonly label: string;
+  readonly isPrefer: () => boolean;
+  readonly setPrefer: (
+    enabled: boolean,
+  ) => Promise<{ readonly effective: boolean }>;
+}
+
+function oauthCliPreference(
+  id: QuotaFallbackRouteId | undefined,
+): OauthCliPreference | undefined {
+  if (id === 'chatgpt') {
+    return {
+      label: 'ChatGPT',
+      isPrefer: isPreferCodexSubscription,
+      setPrefer: setCliCodexSubscription,
+    };
+  }
+  if (id === 'grok') {
+    return {
+      label: 'Grok',
+      isPrefer: isPreferXaiSubscription,
+      setPrefer: setCliXaiSubscription,
+    };
+  }
+  return undefined;
+}
+
 /** Commit the access-mode and subscription writes for a retry switch.
  *
  *  Runs while the commit queue already holds its slot. On failure it rolls
@@ -692,15 +721,8 @@ async function applyRetryCredentialCommit(
   signal.throwIfAborted();
   const previousApiMode = getCliApiMode();
   const previousOpenRouter = cliOpenRouterEnabled();
-  const oauthRoute = decision.disableQuotaRoute;
-  const disableChatGpt = oauthRoute === 'chatgpt';
-  const disableGrok = oauthRoute === 'grok';
-  const previousChatGptPreference = disableChatGpt
-    ? isPreferCodexSubscription()
-    : false;
-  const previousGrokPreference = disableGrok
-    ? isPreferXaiSubscription()
-    : false;
+  const oauth = oauthCliPreference(decision.disableQuotaRoute);
+  const previousOauthPreference = oauth?.isPrefer() ?? false;
   let apiModeWriteStarted = false;
   let subscriptionWriteStarted = false;
   try {
@@ -710,28 +732,12 @@ async function applyRetryCredentialCommit(
       await runRetryTask(() => setCliApiMode(apiMode), signal);
       signal.throwIfAborted();
     }
-    if (disableChatGpt) {
+    if (oauth) {
       subscriptionWriteStarted = true;
-      const update = await runRetryTask(
-        () => setCliCodexSubscription(false),
-        signal,
-      );
+      const update = await runRetryTask(() => oauth.setPrefer(false), signal);
       if (update.effective) {
         throw new Error(
-          'ChatGPT subscription remains enabled by a more specific setting.',
-        );
-      }
-      signal.throwIfAborted();
-    }
-    if (disableGrok) {
-      subscriptionWriteStarted = true;
-      const update = await runRetryTask(
-        () => setCliXaiSubscription(false),
-        signal,
-      );
-      if (update.effective) {
-        throw new Error(
-          'Grok subscription remains enabled by a more specific setting.',
+          `${oauth.label} subscription remains enabled by a more specific setting.`,
         );
       }
       signal.throwIfAborted();
@@ -749,44 +755,26 @@ async function applyRetryCredentialCommit(
     // off.
     let openRouterToPreserve = previousOpenRouter;
     const rollbackFailures = await rollbackChangedSettings([
-      {
-        writeStarted: subscriptionWriteStarted && disableChatGpt,
-        needsRollback: () => !isPreferCodexSubscription(),
-        restore: async () => {
-          const update = await setCliCodexSubscription(
-            previousChatGptPreference,
-          );
-          if (update.effective !== previousChatGptPreference) {
-            throw new Error(
-              `ChatGPT subscription preference remained ${String(update.effective)}.`,
-            );
-          }
-        },
-        restoredInMemory: () =>
-          isPreferCodexSubscription() === previousChatGptPreference,
-        memoryRestoredContext:
-          'The previous ChatGPT subscription preference appears restored in memory, but persistence could not be confirmed',
-        restoreFailedContext:
-          'Could not restore the ChatGPT subscription preference',
-      },
-      {
-        writeStarted: subscriptionWriteStarted && disableGrok,
-        needsRollback: () => !isPreferXaiSubscription(),
-        restore: async () => {
-          const update = await setCliXaiSubscription(previousGrokPreference);
-          if (update.effective !== previousGrokPreference) {
-            throw new Error(
-              `Grok subscription preference remained ${String(update.effective)}.`,
-            );
-          }
-        },
-        restoredInMemory: () =>
-          isPreferXaiSubscription() === previousGrokPreference,
-        memoryRestoredContext:
-          'The previous Grok subscription preference appears restored in memory, but persistence could not be confirmed',
-        restoreFailedContext:
-          'Could not restore the Grok subscription preference',
-      },
+      ...(oauth === undefined
+        ? []
+        : [
+            {
+              writeStarted: subscriptionWriteStarted,
+              needsRollback: () => !oauth.isPrefer(),
+              restore: async () => {
+                const update = await oauth.setPrefer(previousOauthPreference);
+                if (update.effective !== previousOauthPreference) {
+                  throw new Error(
+                    `${oauth.label} subscription preference remained ${String(update.effective)}.`,
+                  );
+                }
+              },
+              restoredInMemory: () =>
+                oauth.isPrefer() === previousOauthPreference,
+              memoryRestoredContext: `The previous ${oauth.label} subscription preference appears restored in memory, but persistence could not be confirmed`,
+              restoreFailedContext: `Could not restore the ${oauth.label} subscription preference`,
+            },
+          ]),
       ...(codingPlanRollback ? [codingPlanRollback] : []),
       {
         writeStarted: apiModeWriteStarted,
@@ -872,9 +860,11 @@ async function switchRetryToPersonalCredentials(
   // disable, preparation, and rollback all stay inside one commit-queue slot
   // so a second coding-plan retry cannot interleave: its disable must wait
   // until this retry's rollback (if any) has finished.
-  const codingPlanId = decision.disableQuotaRoute
-    ? quotaFallbackRouteById(decision.disableQuotaRoute)?.codingPlanId
-    : undefined;
+  const codingPlanId =
+    decision.disableQuotaRoute !== undefined &&
+    isCodingPlanQuotaRoute(decision.disableQuotaRoute)
+      ? decision.disableQuotaRoute
+      : undefined;
   const codingPlanRuntime = codingPlanId
     ? codingPlanSubscriptionRuntimes.find(
         (runtime) => runtime.descriptor.id === codingPlanId,
@@ -898,19 +888,6 @@ async function switchRetryToPersonalCredentials(
               signal,
             );
             signal.throwIfAborted();
-          } catch (error) {
-            throwWithRollbackFailures(
-              error,
-              await rollbackChangedSettings([
-                codingPlanRollbackConfig(
-                  runtime,
-                  previousCodingPlanEnabled,
-                  codingPlanWriteStarted,
-                ),
-              ]),
-            );
-          }
-          try {
             await prepareRetryClient(prepareRetry, 'personal', signal);
           } catch (error) {
             throwWithRollbackFailures(

--- a/packages/cli/src/runtime/approval/approvalPrompts.ts
+++ b/packages/cli/src/runtime/approval/approvalPrompts.ts
@@ -4,7 +4,6 @@ import { defaultSession } from '@agent/runtime';
 import { isRelayMonthlyLimitMessage } from '@common/errors/sdkError/relayDetection';
 import { warn as logWarning } from '@logger/logUtils';
 import {
-  isChatGptSubscriptionLimitError,
   isCredentialExhausted,
   type AgentProposalPermission,
   type ExhaustionReason,
@@ -13,9 +12,10 @@ import {
   type ApprovalDecision,
 } from '@shared/schemas';
 import {
-  CODING_PLAN_SUBSCRIPTIONS,
-  type CodingPlanSubscriptionId,
-} from '@shared/codingPlanSubscriptions';
+  quotaFallbackRouteById,
+  quotaFallbackRouteForExhaustion,
+  type QuotaFallbackRouteId,
+} from '@shared/quotaFallbackRoutes';
 import { isKimiCodeExclusiveRetryModel } from '@shared/model/kimiCodeRetryGate';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -52,9 +52,6 @@ export type CliDecisionApprovalRequest =
 
 const CLI_PERSONAL_API_RETRY_HINT =
   'Use `/api personal` in the chat TUI, or press `k` on the retry prompt, to switch to your own API keys.';
-
-const CLI_CHATGPT_SUBSCRIPTION_RETRY_HINT =
-  'Use `/api personal` in the chat TUI, or press `k` on the retry prompt, to switch from your ChatGPT subscription to your own API keys.';
 
 export interface CliApprovalPromptHooks {
   readonly beforePrompt?: () => void;
@@ -108,35 +105,40 @@ export function warnApprovalDenied(context: CliContext, gate?: string): void {
  * `RetryPermission` maps to exactly one action; consumers (the retry modal's
  * switch decision, the retry request message, and the auto-switch) switch on
  * this instead of re-deriving precedence from overlapping predicates.
- * Precedence: a ChatGPT-subscription limit wins over a coding-plan
- * exhaustion, which wins over relay exhaustion.
+ * Precedence: a catalogued quota-fallback route (ChatGPT, Grok, coding
+ * plan) wins over relay exhaustion.
  */
 export type CliRetryAction =
-  | 'disable-chatgpt'
-  | `disable-coding-plan:${CodingPlanSubscriptionId}`
-  | 'switch-to-personal'
-  | 'none';
+  `disable-quota-route:${QuotaFallbackRouteId}` | 'switch-to-personal' | 'none';
+
+const DISABLE_QUOTA_ROUTE_PREFIX = 'disable-quota-route:';
+
+function quotaRouteIdFromAction(
+  action: CliRetryAction,
+): QuotaFallbackRouteId | undefined {
+  if (!action.startsWith(DISABLE_QUOTA_ROUTE_PREFIX)) return undefined;
+  return action.slice(
+    DISABLE_QUOTA_ROUTE_PREFIX.length,
+  ) as QuotaFallbackRouteId;
+}
 
 export function classifyCliRetryAction(
   payload: RetryPermission,
 ): CliRetryAction {
   const details = payload.errorDetails;
-  if (isChatGptSubscriptionLimitError(details)) return 'disable-chatgpt';
-  const codingPlan = CODING_PLAN_SUBSCRIPTIONS.find(
-    (plan) => plan.exhaustionReason === details?.exhaustionReason,
-  );
-  if (codingPlan) {
+  const route = quotaFallbackRouteForExhaustion(details?.exhaustionReason);
+  if (route) {
     // Kimi Code-exclusive models are served only by the coding endpoint, so
     // turning the plan off cannot reroute them to a Moonshot fallback. They
     // keep the retry modal without an API-key switch, exactly like the
     // auto-switch gate in the TUI.
     if (
-      codingPlan.id === 'kimiCode' &&
+      route.id === 'kimiCode' &&
       isKimiCodeExclusiveRetryModel(payload.model)
     ) {
       return 'none';
     }
-    return `disable-coding-plan:${codingPlan.id}`;
+    return `${DISABLE_QUOTA_ROUTE_PREFIX}${route.id}`;
   }
   if (
     details != null &&
@@ -151,18 +153,11 @@ export function classifyCliRetryAction(
 
 /** The switch hint line for a retry action, or undefined for 'none'. */
 export function cliRetryActionHint(action: CliRetryAction): string | undefined {
-  if (action.startsWith('disable-coding-plan:')) {
-    const id = action.slice(
-      'disable-coding-plan:'.length,
-    ) as CodingPlanSubscriptionId;
-    const plan = CODING_PLAN_SUBSCRIPTIONS.find(
-      (candidate) => candidate.id === id,
-    );
-    if (!plan) return undefined;
-    return `Use \`/api personal\` in the chat TUI, or press \`k\` on the retry prompt, to switch from your ${plan.retrySourceName} to ${plan.retryFallbackName}.`;
-  }
-  if (action === 'disable-chatgpt') {
-    return CLI_CHATGPT_SUBSCRIPTION_RETRY_HINT;
+  const routeId = quotaRouteIdFromAction(action);
+  if (routeId !== undefined) {
+    const route = quotaFallbackRouteById(routeId);
+    if (!route) return undefined;
+    return `Use \`/api personal\` in the chat TUI, or press \`k\` on the retry prompt, to switch from your ${route.retrySourceName} to ${route.retryFallbackName}.`;
   }
   return action === 'switch-to-personal'
     ? CLI_PERSONAL_API_RETRY_HINT
@@ -184,34 +179,24 @@ export function isCliApiSwitchableRetry(payload: RetryPermission): boolean {
 interface CliRetryApiSwitchDecision {
   readonly accepted: true;
   readonly apiMode: 'personal';
-  readonly disableChatGptSubscription?: boolean;
-  readonly disableCodingPlan?: CodingPlanSubscriptionId;
+  readonly disableQuotaRoute?: QuotaFallbackRouteId;
 }
 
 /**
- * Map a failed retry to the subscription/plan toggle it disables. Every
- * switch flips API mode to personal keys; a subscription or coding-plan retry
- * additionally turns off the preference that routed onto the exhausted
- * credential. Drives off {@link classifyCliRetryAction} so the modal cannot
- * drift from the classifier.
+ * Map a failed retry to the quota-fallback route it disables. Every switch
+ * flips API mode to personal keys; a catalogued route additionally turns
+ * off the preference that routed onto the exhausted credential. Drives off
+ * {@link classifyCliRetryAction} so the modal cannot drift from the classifier.
  */
 export function cliRetryApiSwitchDecision(
   payload: RetryPermission,
 ): CliRetryApiSwitchDecision {
   const action = classifyCliRetryAction(payload);
-  if (action.startsWith('disable-coding-plan:')) {
+  const routeId = quotaRouteIdFromAction(action);
+  if (routeId !== undefined) {
     return {
       accepted: true,
-      disableCodingPlan: action.slice(
-        'disable-coding-plan:'.length,
-      ) as CodingPlanSubscriptionId,
-      apiMode: 'personal',
-    };
-  }
-  if (action === 'disable-chatgpt') {
-    return {
-      accepted: true,
-      disableChatGptSubscription: true,
+      disableQuotaRoute: routeId,
       apiMode: 'personal',
     };
   }

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -65,10 +65,6 @@ import {
   computeModelOptionsData,
   invalidateModelOptionsCache,
 } from '@model/computeModelOptions';
-import {
-  isPreferCodexSubscription,
-  setPreferCodexSubscription,
-} from '@model/codex/codexPreference';
 import { platform } from '@platform/platform';
 import {
   COMMON_COMMANDS,
@@ -534,10 +530,6 @@ export class DesktopProgressBridge {
         getServerSideKeyService().getUseIncludedModelAccess(),
       setUseIncludedModelAccess: async (enabled) => {
         await getServerSideKeyService().setUseIncludedModelAccess(enabled);
-      },
-      getPreferChatGptSubscription: isPreferCodexSubscription,
-      setPreferChatGptSubscription: async (enabled) => {
-        await setPreferCodexSubscription(enabled);
       },
       invalidateModelOptionsCache,
       isRetryPending: (stream, requestId) =>

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -32,10 +32,6 @@ import type { PromptHost } from '@hosts/uiHosts';
 import { apiKeySecretName } from '@model/apiProviders';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { getRuntimeModelDirectFallback } from '@model/runtimeModelRegistry';
-import {
-  isPreferCodexSubscription,
-  setPreferCodexSubscription,
-} from '@model/codex/codexPreference';
 import { platform } from '@platform/platform';
 import type {
   GettingStartedAction,
@@ -584,10 +580,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         getServerSideKeyService().getUseIncludedModelAccess(),
       setUseIncludedModelAccess: (enabled) =>
         getServerSideKeyService().setUseIncludedModelAccess(enabled),
-      getPreferChatGptSubscription: isPreferCodexSubscription,
-      setPreferChatGptSubscription: async (enabled) => {
-        await setPreferCodexSubscription(enabled);
-      },
       invalidateModelOptionsCache,
       isRetryPending: (stream, requestId) =>
         this.interactions.isRetryPending(stream, requestId),

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -62,6 +62,7 @@ import {
   isUserAbort,
 } from '@common/errors/sdkError/errorPatterns';
 import { getSdkErrorMessage } from '@common/errors/sdkError/providerErrorFormat';
+import { attachSdkCredentialRoute } from '@common/errors/sdkError/sdkRequestEndpoint';
 import type { ResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import {
   allowsModelRelay,
@@ -1242,6 +1243,9 @@ export abstract class ModelHandler<
       } catch (err) {
         this.sdkErrorTagger(err, this.config.provider);
         this.attachSdkRequestEndpoint(err, options.client);
+        if (credentialRoute !== undefined) {
+          attachSdkCredentialRoute(err, credentialRoute);
+        }
         throw err;
       } finally {
         this.activeAttemptCredentialRoute = undefined;

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -68,6 +68,10 @@ import {
   parseGlmCodingPlanLimit,
 } from './glmCodingPlanDetection';
 import {
+  describeXaiSubscriptionLimit,
+  parseXaiSubscriptionLimit,
+} from './xaiSubscriptionDetection';
+import {
   type SdkErrorEntry,
   SDK_ERRORS,
   SDK_ERRORS_BY_KIND,
@@ -76,6 +80,51 @@ import {
 
 /** Partial result before relay detection (isRelayError/rawErrorBody added later). */
 type SdkMatchResult = Omit<ProviderError, 'isRelayError' | 'rawErrorBody'>;
+
+interface QuotaLimitMatch {
+  readonly exhaustionReason: ExhaustionReason;
+  readonly message: string;
+}
+
+/**
+ * First matching quota-fallback detector. Order is the catalog's: ChatGPT,
+ * Grok, then coding plans. Reasons are mutually exclusive, so the first hit
+ * is the only hit.
+ */
+function detectQuotaLimit(
+  err: unknown,
+  rawErrorBody: unknown,
+): QuotaLimitMatch | undefined {
+  const chatgpt = parseChatGptSubscriptionLimit(rawErrorBody);
+  if (chatgpt) {
+    return {
+      exhaustionReason: 'chatgpt-subscription',
+      message: describeChatGptSubscriptionLimit(chatgpt),
+    };
+  }
+  const grok = parseXaiSubscriptionLimit(err, rawErrorBody);
+  if (grok) {
+    return {
+      exhaustionReason: 'xai-subscription',
+      message: describeXaiSubscriptionLimit(grok),
+    };
+  }
+  const kimi = parseKimiCodeSubscriptionLimit(err, rawErrorBody);
+  if (kimi) {
+    return {
+      exhaustionReason: 'kimi-code-subscription',
+      message: describeKimiCodeSubscriptionLimit(kimi),
+    };
+  }
+  const glm = parseGlmCodingPlanLimit(rawErrorBody);
+  if (glm) {
+    return {
+      exhaustionReason: 'glm-coding-plan',
+      message: describeGlmCodingPlanLimit(glm),
+    };
+  }
+  return undefined;
+}
 
 /**
  * Single source of truth for the user-facing HTTP error string and its message
@@ -256,34 +305,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   // Anthropic 400 "credit balance is too low" still wants the "Use your
   // own API key" affordance so the user can switch credentials.
   const isUpstreamCreditDepleted = isUpstreamCreditDepletedBody(rawErrorBody);
-  // ChatGPT-subscription (Codex) quota exhaustion. Treated as a credential
-  // exhaustion so auto-retry is suppressed (the quota won't return mid-run) and
-  // the retry UI offers a switch to the user's own API key — but it disables
-  // the subscription preference, not relay, on accept.
-  const chatgptSubscriptionLimit = parseChatGptSubscriptionLimit(rawErrorBody);
-  const isChatGptSubscriptionLimited = chatgptSubscriptionLimit !== null;
-  const chatgptSubscriptionMessage = chatgptSubscriptionLimit
-    ? describeChatGptSubscriptionLimit(chatgptSubscriptionLimit)
-    : undefined;
-  // Kimi Code (Moonshot coding-subscription) quota exhaustion — same pattern:
-  // a credential exhaustion that disables the "Prefer Kimi Code" preference on
-  // accept so dual-backend Kimi models re-route through the Moonshot API key.
-  const kimiCodeSubscriptionLimit = parseKimiCodeSubscriptionLimit(
-    err,
-    rawErrorBody,
-  );
-  const isKimiCodeSubscriptionLimited = kimiCodeSubscriptionLimit !== null;
-  const kimiCodeSubscriptionMessage = kimiCodeSubscriptionLimit
-    ? describeKimiCodeSubscriptionLimit(kimiCodeSubscriptionLimit)
-    : undefined;
-  // GLM Coding Plan quota exhaustion — same pattern: a credential exhaustion
-  // that turns off the Coding Plan toggle on accept so GLM requests re-route
-  // through the regular pay-as-you-go endpoint.
-  const glmCodingPlanLimit = parseGlmCodingPlanLimit(rawErrorBody);
-  const isGlmCodingPlanLimited = glmCodingPlanLimit !== null;
-  const glmCodingPlanMessage = glmCodingPlanLimit
-    ? describeGlmCodingPlanLimit(glmCodingPlanLimit)
-    : undefined;
+  const quotaLimit = detectQuotaLimit(err, rawErrorBody);
   // GLM Coding Plan transient rate limit / overload (codes 1302/1305): surface
   // a clear "retry in a moment" message, but keep it retryable — it is NOT a
   // quota exhaustion, so no switch-to-regular-endpoint affordance.
@@ -293,22 +315,13 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   // Prefer the actionable subscription-limit message over the raw
   // `HTTP 429 – The usage limit has been reached`.
   const subscriptionLimitMessage =
-    chatgptSubscriptionMessage ??
-    kimiCodeSubscriptionMessage ??
-    glmCodingPlanMessage ??
-    glmCodingPlanRateLimitMessage;
-  // Priority mirrors the pre-refactor OR order: ChatGPT-subscription and
-  // upstream-credit are independently detected first; relay monthly limit
-  // (by body or message) is the remaining exhaustion condition. Explicit SDK
-  // metadata precedes these legacy body heuristics.
+    quotaLimit?.message ?? glmCodingPlanRateLimitMessage;
+  // Priority: an explicit SDK stamp wins; then the first matching
+  // quota-fallback detector; then upstream-credit; then relay monthly limit.
   let exhaustionReason: ExhaustionReason | undefined = sdkExhaustionReason;
   if (exhaustionReason === undefined) {
-    if (isChatGptSubscriptionLimited) {
-      exhaustionReason = 'chatgpt-subscription';
-    } else if (isKimiCodeSubscriptionLimited) {
-      exhaustionReason = 'kimi-code-subscription';
-    } else if (isGlmCodingPlanLimited) {
-      exhaustionReason = 'glm-coding-plan';
+    if (quotaLimit !== undefined) {
+      exhaustionReason = quotaLimit.exhaustionReason;
     } else if (isUpstreamCreditDepleted) {
       exhaustionReason = 'upstream-credit';
     } else if (

--- a/src/common/errors/sdkError/sdkRequestEndpoint.ts
+++ b/src/common/errors/sdkError/sdkRequestEndpoint.ts
@@ -1,5 +1,15 @@
 import { isObject } from '@utils/core';
 
+/** Credential route stamped on a thrown SDK error. Mirrors
+ *  `ModelCredentialRoute` without importing `@agent` (common → agent is
+ *  a forbidden architecture edge). */
+export type SdkCredentialRoute =
+  | 'api-key'
+  | 'chatgpt-subscription'
+  | 'xai-subscription'
+  | 'openrouter'
+  | 'relay';
+
 /**
  * Side channel carrying the endpoint a thrown SDK error was sent to, for SDKs
  * whose error type carries status/body/headers but no request config (the
@@ -26,4 +36,29 @@ export function detectSdkRequestBaseURL(err: unknown): string | undefined {
   const own = (err as { request?: { baseURL?: unknown } }).request;
   if (typeof own?.baseURL === 'string') return own.baseURL;
   return requestBaseURLs.get(err);
+}
+
+/**
+ * Side channel carrying the credential route a thrown SDK error was sent
+ * on. SuperGrok and ChatGPT share `api.x.ai` / `api.openai.com` with the
+ * API-key path, so endpoint inspection cannot tell a subscription quota
+ * failure from a key rate-limit — the route stamp can.
+ */
+const requestCredentialRoutes = new WeakMap<object, SdkCredentialRoute>();
+
+/** Record the credential route `err` was sent on, unless one is already set. */
+export function attachSdkCredentialRoute(
+  err: unknown,
+  route: SdkCredentialRoute,
+): void {
+  if (!isObject(err)) return;
+  if (detectSdkCredentialRoute(err) !== undefined) return;
+  requestCredentialRoutes.set(err, route);
+}
+
+/** The credential route recorded for `err`. */
+export function detectSdkCredentialRoute(
+  err: unknown,
+): SdkCredentialRoute | undefined {
+  return isObject(err) ? requestCredentialRoutes.get(err) : undefined;
 }

--- a/src/common/errors/sdkError/xaiSubscriptionDetection.ts
+++ b/src/common/errors/sdkError/xaiSubscriptionDetection.ts
@@ -1,0 +1,67 @@
+import { formatResetDuration } from './chatgptSubscriptionDetection';
+import {
+  errorBodyCandidates,
+  pickNumberField,
+  pickStringField,
+} from './errorInspection';
+import { detectSdkCredentialRoute } from './sdkRequestEndpoint';
+
+/**
+ * Detection + formatting for the Grok (xAI SuperGrok) subscription usage
+ * limit. SuperGrok hits the same `api.x.ai` surface as an API key, so the
+ * request's credential-route stamp is the only reliable "this was a
+ * subscription call" signal. Combined with quota/usage-limit wording (and
+ * not a transient rate-limit phrase) that identifies a plan whose quota
+ * ran out — the signal that lets the retry UI offer a switch to the
+ * stored xAI API key.
+ */
+export interface XaiSubscriptionLimit {
+  readonly resetsInSeconds?: number;
+}
+
+/** Distinctive SuperGrok / xAI plan-quota phrasing. Transient 429 rate
+ *  limits ("rate limit", "too many requests") do not match and must not
+ *  flip the preference. */
+const USAGE_LIMIT_PATTERN =
+  /usage limit|quota.{0,24}(exceeded|exhausted|reached)|exceeded your (usage|quota)|weekly (usage )?limit|monthly (usage )?limit/i;
+
+/**
+ * Parse a Grok-subscription usage-limit error, or `null` when the error is
+ * not a SuperGrok quota exhaustion. Requires the subscription route stamp
+ * so a direct xAI API-key 429 cannot be misread as plan exhaustion.
+ */
+export function parseXaiSubscriptionLimit(
+  err: unknown,
+  rawErrorBody: unknown,
+): XaiSubscriptionLimit | null {
+  if (detectSdkCredentialRoute(err) !== 'xai-subscription') return null;
+
+  const message =
+    errorBodyCandidates(rawErrorBody)
+      .map((candidate) => pickStringField(candidate, 'message'))
+      .find((candidate) => candidate !== undefined) ??
+    (typeof (err as { message?: unknown }).message === 'string'
+      ? (err as { message: string }).message
+      : undefined);
+  if (!message || !USAGE_LIMIT_PATTERN.test(message)) return null;
+
+  const resetsInSeconds = errorBodyCandidates(rawErrorBody)
+    .map((candidate) => pickNumberField(candidate, 'resets_in_seconds'))
+    .find((value): value is number => value !== undefined);
+
+  return { resetsInSeconds };
+}
+
+/** Human-readable message for a Grok-subscription usage-limit error. */
+export function describeXaiSubscriptionLimit(
+  info: XaiSubscriptionLimit,
+): string {
+  const reset =
+    info.resetsInSeconds !== undefined
+      ? ` Resets in ${formatResetDuration(info.resetsInSeconds)}.`
+      : '';
+  return (
+    `Grok subscription usage limit reached.${reset}` +
+    ' Switch to your own xAI API key to keep working, or wait until the limit resets.'
+  );
+}

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -3,9 +3,9 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 
 // Local imports
 import type { ApiProvider } from '@model/apiProviders';
-import { codingPlanSubscriptionRuntimes } from '@model/codingPlanSubscriptions';
 import type { CopilotRouteOverride } from '@model/copilotRouting';
 import { resolveDirectModelApiKeyProvider } from '@model/openRouterRouting';
+import { quotaFallbackRuntimes } from '@model/quotaFallbackRoutes';
 import type { ExhaustionReason, StreamTabId } from '@shared/schemas';
 import {
   isKimiCodeExclusiveModel,
@@ -30,15 +30,15 @@ export interface ProgressApiKeyRetryRequest {
 }
 
 /**
- * One API-key-based coding-plan subscription (GLM Coding Plan, Kimi Code) that
- * the retry controller can turn off when its quota is exhausted. Both share the
- * same shape: a toggle that routes requests through a coding endpoint, and a
- * quota-exhaustion reason that signals the toggle should be disabled so requests
- * re-route through the regular pay-as-you-go endpoint.
+ * One quota-fallback route (ChatGPT, Grok, GLM Coding Plan, Kimi Code) the
+ * retry controller can turn off when its quota is exhausted. Accepting the
+ * switch disables the route's preference so the same model retries on the
+ * fallback credential.
  */
-interface CodingPlanToggle {
-  /** The exhaustion reason that signals this plan's quota ran out. */
+export interface QuotaFallbackToggle {
   readonly exhaustionReason: ExhaustionReason;
+  readonly disableIncludedAccess: boolean;
+  readonly fallbackApiProvider?: ApiProvider;
   readonly getEnabled: () => boolean;
   readonly setEnabled: (enabled: boolean) => Promise<void>;
   readonly restoreEnabled?: (enabled: boolean) => Promise<void>;
@@ -47,9 +47,8 @@ interface CodingPlanToggle {
 interface ProgressApiKeyPreparationResult {
   proceeded: boolean;
   disabledIncludedModelAccess: boolean;
-  disabledChatGptSubscription: boolean;
-  /** Exhaustion reasons whose coding-plan toggle was turned off. */
-  disabledCodingPlans: readonly ExhaustionReason[];
+  /** Exhaustion reasons whose quota-fallback toggle was turned off. */
+  disabledQuotaRoutes: readonly ExhaustionReason[];
 }
 
 export interface ProgressApiKeyRetryResult extends ProgressApiKeyPreparationResult {
@@ -58,8 +57,7 @@ export interface ProgressApiKeyRetryResult extends ProgressApiKeyPreparationResu
 
 interface ProgressApiRoutingSnapshot {
   readonly useIncludedModelAccess: boolean;
-  readonly preferChatGptSubscription: boolean;
-  readonly codingPlans: ReadonlyMap<ExhaustionReason, boolean>;
+  readonly quotaRoutes: ReadonlyMap<ExhaustionReason, boolean>;
 }
 
 function noRetryResult(): ProgressApiKeyRetryResult {
@@ -67,8 +65,7 @@ function noRetryResult(): ProgressApiKeyRetryResult {
     proceeded: false,
     retried: false,
     disabledIncludedModelAccess: false,
-    disabledChatGptSubscription: false,
-    disabledCodingPlans: [],
+    disabledQuotaRoutes: [],
   };
 }
 
@@ -79,10 +76,9 @@ export interface ProgressApiKeyRetryControllerDeps {
   promptForApiKey(provider?: ApiProvider): Promise<void>;
   getUseIncludedModelAccess(): boolean;
   setUseIncludedModelAccess(enabled: boolean): Promise<void>;
-  getPreferChatGptSubscription(): boolean;
-  setPreferChatGptSubscription(enabled: boolean): Promise<void>;
-  /** API-key-based coding-plan subscriptions (GLM Coding Plan, Kimi Code). */
-  codingPlanToggles?: readonly CodingPlanToggle[];
+  /** Quota-fallback routes (ChatGPT, Grok, GLM, Kimi). Defaults to the
+   *  shared runtime catalog. Tests inject a local table. */
+  quotaFallbackToggles?: readonly QuotaFallbackToggle[];
   invalidateModelOptionsCache(): void;
   isRetryPending(stream: StreamTabId, requestId: string): boolean;
   triggerRetry(
@@ -134,11 +130,13 @@ export class ProgressApiKeyRetryController {
     );
   }
 
-  private get codingPlanToggles(): readonly CodingPlanToggle[] {
+  private get quotaFallbackToggles(): readonly QuotaFallbackToggle[] {
     return (
-      this.deps.codingPlanToggles ??
-      codingPlanSubscriptionRuntimes.map((runtime) => ({
+      this.deps.quotaFallbackToggles ??
+      quotaFallbackRuntimes.map((runtime) => ({
         exhaustionReason: runtime.descriptor.exhaustionReason,
+        disableIncludedAccess: runtime.descriptor.disableIncludedAccess,
+        fallbackApiProvider: runtime.descriptor.fallbackApiProvider,
         getEnabled: runtime.getEnabled,
         setEnabled: runtime.setEnabled,
         restoreEnabled: runtime.restoreEnabled,
@@ -229,33 +227,70 @@ export class ProgressApiKeyRetryController {
     return this.hasAnyUsableKey(providersToCheck);
   }
 
-  // chatgpt-subscription auth is OpenAI-only (providerCapabilities.ts), so
-  // that exhaustion reason always means the OpenAI key, regardless of provider.
+  // OAuth subscriptions pin the fallback key provider (ChatGPT → openai,
+  // Grok → xai) so a mislabeled SDK provider cannot prompt for the wrong key.
   private resolveProvider(
     request: Pick<ProgressApiKeyRetryRequest, 'provider' | 'exhaustionReason'>,
   ): ApiProvider | undefined {
-    return request.exhaustionReason === 'chatgpt-subscription'
-      ? 'openai'
-      : request.provider;
+    const route = this.quotaFallbackToggles.find(
+      (candidate) => candidate.exhaustionReason === request.exhaustionReason,
+    );
+    return route?.fallbackApiProvider ?? request.provider;
   }
 
   private shouldDisableIncludedModelAccess(
     request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
   ): boolean {
-    return (
-      request.viaRelay === true ||
-      request.exhaustionReason === 'chatgpt-subscription' ||
-      request.exhaustionReason === 'copilot-subscription'
+    if (request.viaRelay === true) return true;
+    if (request.exhaustionReason === 'copilot-subscription') return true;
+    return this.matchingQuotaToggles(request).some(
+      (toggle) => toggle.disableIncludedAccess,
     );
   }
 
-  private isSubscriptionExhausted(
+  /** Whether this toggle should turn off for `request`. Catalog match plus
+   *  the two request-specific extras that are not their own exhaustion
+   *  reason: Copilot→ChatGPT, and a dual-backend Kimi credit reroute. */
+  private shouldDisableToggle(
+    toggle: QuotaFallbackToggle,
     request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
   ): boolean {
-    if (request.exhaustionReason === 'chatgpt-subscription') return true;
-    return (
+    if (request.exhaustionReason === toggle.exhaustionReason) return true;
+    if (
+      toggle.exhaustionReason === 'chatgpt-subscription' &&
       request.exhaustionReason === 'copilot-subscription' &&
       request.chatGptSubscriptionEligible === true
+    ) {
+      return true;
+    }
+    // An `upstream-credit` failure on a dual-backend Kimi model means the
+    // broken credential is the `kimiCode` key, but the forwarded SDK
+    // provider is `moonshot`. The coding-plan quota reason does not match,
+    // so without this branch the "Prefer Kimi Code" switch would stay on
+    // and the retry rebuild would re-select the exhausted coding endpoint
+    // instead of the newly entered Moonshot key.
+    //
+    // Deliberately conservative: do not consult the live route resolver
+    // here. The failed handler was dispatched under the persisted
+    // `ModelHandlerKimi` compatibility key, and the retry rebuild pins that
+    // same key, so a later OpenRouter preference change cannot make the
+    // rebuild take a non-coding route. The request's
+    // `kimiCodeRoutedOnFailure` flag is captured from that failed handler,
+    // so unrelated `kimi3` failures through OpenRouter, Moonshot, or the
+    // relay leave the preference untouched.
+    return (
+      toggle.exhaustionReason === 'kimi-code-subscription' &&
+      request.exhaustionReason === 'upstream-credit' &&
+      request.kimiCodeRoutedOnFailure === true &&
+      this.isDualBackendKimiCodeModel(request.model)
+    );
+  }
+
+  private matchingQuotaToggles(
+    request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
+  ): readonly QuotaFallbackToggle[] {
+    return this.quotaFallbackToggles.filter((toggle) =>
+      this.shouldDisableToggle(toggle, request),
     );
   }
 
@@ -268,8 +303,7 @@ export class ProgressApiKeyRetryController {
     // persistence, so a throw midway must roll back every switch that may
     // have landed instead of stranding global toggles the retry never uses.
     let disabledIncludedModelAccess = false;
-    let disabledChatGptSubscription = false;
-    const disabledCodingPlans: ExhaustionReason[] = [];
+    const disabledQuotaRoutes: ExhaustionReason[] = [];
     try {
       // Disable relay (included access) so the retry uses the user's own key,
       // not the relay JWT, whenever the switch promises "your own API key".
@@ -282,47 +316,12 @@ export class ProgressApiKeyRetryController {
         this.deps.invalidateModelOptionsCache();
       }
 
-      // The subscription quota is exhausted, so turn off the preference and let
-      // Codex-eligible models route through the now-usable OpenAI key on retry.
-      // Remark: prefer-off sticks after the quota resets — users may forget to
-      // re-enable it. A temporary / resume-on-reset override would be kinder.
-      if (
-        this.deps.getPreferChatGptSubscription() &&
-        this.isSubscriptionExhausted(request)
-      ) {
-        disabledChatGptSubscription = true;
-        await this.deps.setPreferChatGptSubscription(false);
-        this.deps.invalidateModelOptionsCache();
-      }
-
-      // Any API-key-based coding-plan subscription (GLM Coding Plan, Kimi Code)
-      // whose quota is exhausted: turn off its toggle so requests re-route through
-      // the regular pay-as-you-go endpoint on retry.
-      for (const toggle of this.codingPlanToggles) {
-        const planExhaustion =
-          request.exhaustionReason === toggle.exhaustionReason;
-        // An `upstream-credit` failure on a dual-backend Kimi model means the
-        // broken credential is the `kimiCode` key, but the forwarded SDK
-        // provider is `moonshot`. The coding-plan quota reason does not match,
-        // so without this branch the "Prefer Kimi Code" switch would stay on
-        // and the retry rebuild would re-select the exhausted coding endpoint
-        // instead of the newly entered Moonshot key.
-        //
-        // Deliberately conservative: do not consult the live route resolver
-        // here. The failed handler was dispatched under the persisted
-        // `ModelHandlerKimi` compatibility key, and the retry rebuild pins that
-        // same key, so a later OpenRouter preference change cannot make the
-        // rebuild take a non-coding route. The request's
-        // `kimiCodeRoutedOnFailure` flag is captured from that failed handler,
-        // so unrelated `kimi3` failures through OpenRouter, Moonshot, or the
-        // relay leave the preference untouched.
-        const kimiCodeCreditReroute =
-          toggle.exhaustionReason === 'kimi-code-subscription' &&
-          request.exhaustionReason === 'upstream-credit' &&
-          request.kimiCodeRoutedOnFailure === true &&
-          this.isDualBackendKimiCodeModel(request.model);
-        if (toggle.getEnabled() && (planExhaustion || kimiCodeCreditReroute)) {
-          disabledCodingPlans.push(toggle.exhaustionReason);
+      // One chain: turn off every matching quota-fallback preference so the
+      // retry rebuilds onto the fallback credential. Remark: prefer-off
+      // sticks after the quota resets — users may forget to re-enable it.
+      for (const toggle of this.quotaFallbackToggles) {
+        if (toggle.getEnabled() && this.shouldDisableToggle(toggle, request)) {
+          disabledQuotaRoutes.push(toggle.exhaustionReason);
           await toggle.setEnabled(false);
           this.deps.invalidateModelOptionsCache();
         }
@@ -331,15 +330,13 @@ export class ProgressApiKeyRetryController {
       return {
         proceeded: true,
         disabledIncludedModelAccess,
-        disabledChatGptSubscription,
-        disabledCodingPlans,
+        disabledQuotaRoutes,
       };
     } catch (error) {
       await this.restoreAfterError(before, {
         proceeded: true,
         disabledIncludedModelAccess,
-        disabledChatGptSubscription,
-        disabledCodingPlans,
+        disabledQuotaRoutes,
       });
       throw error;
     }
@@ -378,9 +375,8 @@ export class ProgressApiKeyRetryController {
   private routingSnapshot(): ProgressApiRoutingSnapshot {
     return {
       useIncludedModelAccess: this.deps.getUseIncludedModelAccess(),
-      preferChatGptSubscription: this.deps.getPreferChatGptSubscription(),
-      codingPlans: new Map(
-        this.codingPlanToggles.map((toggle) => [
+      quotaRoutes: new Map(
+        this.quotaFallbackToggles.map((toggle) => [
           toggle.exhaustionReason,
           toggle.getEnabled(),
         ]),
@@ -392,28 +388,21 @@ export class ProgressApiKeyRetryController {
     before: ProgressApiRoutingSnapshot,
     prepared: ProgressApiKeyPreparationResult,
   ): Promise<void> {
-    // Roll back in reverse application order: the coding-plan toggles
+    // Roll back in reverse application order: quota-fallback toggles
     // switched last, so they come back first. Every restore is attempted
     // even when an earlier one fails; the first failure rethrows once the
     // rest have run (compensation per the error-handling checklist's L2).
     const restores: Array<() => Promise<void>> = [];
-    for (const reason of [...prepared.disabledCodingPlans].reverse()) {
-      const toggle = this.codingPlanToggles.find(
+    for (const reason of [...prepared.disabledQuotaRoutes].reverse()) {
+      const toggle = this.quotaFallbackToggles.find(
         (candidate) => candidate.exhaustionReason === reason,
       );
       if (toggle)
         restores.push(() =>
           (toggle.restoreEnabled ?? toggle.setEnabled)(
-            before.codingPlans.get(reason) ?? false,
+            before.quotaRoutes.get(reason) ?? false,
           ),
         );
-    }
-    if (prepared.disabledChatGptSubscription) {
-      restores.push(() =>
-        this.deps.setPreferChatGptSubscription(
-          before.preferChatGptSubscription,
-        ),
-      );
     }
     if (prepared.disabledIncludedModelAccess) {
       restores.push(() =>

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -5,7 +5,10 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 import type { ApiProvider } from '@model/apiProviders';
 import type { CopilotRouteOverride } from '@model/copilotRouting';
 import { resolveDirectModelApiKeyProvider } from '@model/openRouterRouting';
-import { quotaFallbackRuntimes } from '@model/quotaFallbackRoutes';
+import {
+  quotaFallbackRuntimes,
+  type QuotaFallbackRuntime,
+} from '@model/quotaFallbackRoutes';
 import type { ExhaustionReason, StreamTabId } from '@shared/schemas';
 import {
   isKimiCodeExclusiveModel,
@@ -27,21 +30,6 @@ export interface ProgressApiKeyRetryRequest {
   kimiCodeRoutedOnFailure?: boolean;
   chatGptSubscriptionEligible?: boolean;
   viaRelay?: boolean;
-}
-
-/**
- * One quota-fallback route (ChatGPT, Grok, GLM Coding Plan, Kimi Code) the
- * retry controller can turn off when its quota is exhausted. Accepting the
- * switch disables the route's preference so the same model retries on the
- * fallback credential.
- */
-export interface QuotaFallbackToggle {
-  readonly exhaustionReason: ExhaustionReason;
-  readonly disableIncludedAccess: boolean;
-  readonly fallbackApiProvider?: ApiProvider;
-  readonly getEnabled: () => boolean;
-  readonly setEnabled: (enabled: boolean) => Promise<void>;
-  readonly restoreEnabled?: (enabled: boolean) => Promise<void>;
 }
 
 interface ProgressApiKeyPreparationResult {
@@ -78,7 +66,7 @@ export interface ProgressApiKeyRetryControllerDeps {
   setUseIncludedModelAccess(enabled: boolean): Promise<void>;
   /** Quota-fallback routes (ChatGPT, Grok, GLM, Kimi). Defaults to the
    *  shared runtime catalog. Tests inject a local table. */
-  quotaFallbackToggles?: readonly QuotaFallbackToggle[];
+  quotaFallbackRuntimes?: readonly QuotaFallbackRuntime[];
   invalidateModelOptionsCache(): void;
   isRetryPending(stream: StreamTabId, requestId: string): boolean;
   triggerRetry(
@@ -130,18 +118,8 @@ export class ProgressApiKeyRetryController {
     );
   }
 
-  private get quotaFallbackToggles(): readonly QuotaFallbackToggle[] {
-    return (
-      this.deps.quotaFallbackToggles ??
-      quotaFallbackRuntimes.map((runtime) => ({
-        exhaustionReason: runtime.descriptor.exhaustionReason,
-        disableIncludedAccess: runtime.descriptor.disableIncludedAccess,
-        fallbackApiProvider: runtime.descriptor.fallbackApiProvider,
-        getEnabled: runtime.getEnabled,
-        setEnabled: runtime.setEnabled,
-        restoreEnabled: runtime.restoreEnabled,
-      }))
-    );
+  private get fallbackRuntimes(): readonly QuotaFallbackRuntime[] {
+    return this.deps.quotaFallbackRuntimes ?? quotaFallbackRuntimes;
   }
 
   async useOwnApiKey(
@@ -232,10 +210,11 @@ export class ProgressApiKeyRetryController {
   private resolveProvider(
     request: Pick<ProgressApiKeyRetryRequest, 'provider' | 'exhaustionReason'>,
   ): ApiProvider | undefined {
-    const route = this.quotaFallbackToggles.find(
-      (candidate) => candidate.exhaustionReason === request.exhaustionReason,
+    const route = this.fallbackRuntimes.find(
+      (candidate) =>
+        candidate.descriptor.exhaustionReason === request.exhaustionReason,
     );
-    return route?.fallbackApiProvider ?? request.provider;
+    return route?.descriptor.fallbackApiProvider ?? request.provider;
   }
 
   private shouldDisableIncludedModelAccess(
@@ -243,21 +222,25 @@ export class ProgressApiKeyRetryController {
   ): boolean {
     if (request.viaRelay === true) return true;
     if (request.exhaustionReason === 'copilot-subscription') return true;
-    return this.matchingQuotaToggles(request).some(
-      (toggle) => toggle.disableIncludedAccess,
+    return this.fallbackRuntimes.some(
+      (runtime) =>
+        this.shouldDisableRuntime(runtime, request) &&
+        runtime.descriptor.disableIncludedAccess,
     );
   }
 
-  /** Whether this toggle should turn off for `request`. Catalog match plus
+  /** Whether this route should turn off for `request`. Catalog match plus
    *  the two request-specific extras that are not their own exhaustion
    *  reason: Copilot→ChatGPT, and a dual-backend Kimi credit reroute. */
-  private shouldDisableToggle(
-    toggle: QuotaFallbackToggle,
+  private shouldDisableRuntime(
+    runtime: QuotaFallbackRuntime,
     request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
   ): boolean {
-    if (request.exhaustionReason === toggle.exhaustionReason) return true;
+    if (request.exhaustionReason === runtime.descriptor.exhaustionReason) {
+      return true;
+    }
     if (
-      toggle.exhaustionReason === 'chatgpt-subscription' &&
+      runtime.descriptor.exhaustionReason === 'chatgpt-subscription' &&
       request.exhaustionReason === 'copilot-subscription' &&
       request.chatGptSubscriptionEligible === true
     ) {
@@ -279,18 +262,10 @@ export class ProgressApiKeyRetryController {
     // so unrelated `kimi3` failures through OpenRouter, Moonshot, or the
     // relay leave the preference untouched.
     return (
-      toggle.exhaustionReason === 'kimi-code-subscription' &&
+      runtime.descriptor.exhaustionReason === 'kimi-code-subscription' &&
       request.exhaustionReason === 'upstream-credit' &&
       request.kimiCodeRoutedOnFailure === true &&
       this.isDualBackendKimiCodeModel(request.model)
-    );
-  }
-
-  private matchingQuotaToggles(
-    request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
-  ): readonly QuotaFallbackToggle[] {
-    return this.quotaFallbackToggles.filter((toggle) =>
-      this.shouldDisableToggle(toggle, request),
     );
   }
 
@@ -319,10 +294,13 @@ export class ProgressApiKeyRetryController {
       // One chain: turn off every matching quota-fallback preference so the
       // retry rebuilds onto the fallback credential. Remark: prefer-off
       // sticks after the quota resets — users may forget to re-enable it.
-      for (const toggle of this.quotaFallbackToggles) {
-        if (toggle.getEnabled() && this.shouldDisableToggle(toggle, request)) {
-          disabledQuotaRoutes.push(toggle.exhaustionReason);
-          await toggle.setEnabled(false);
+      for (const runtime of this.fallbackRuntimes) {
+        if (
+          runtime.getEnabled() &&
+          this.shouldDisableRuntime(runtime, request)
+        ) {
+          disabledQuotaRoutes.push(runtime.descriptor.exhaustionReason);
+          await runtime.setEnabled(false);
           this.deps.invalidateModelOptionsCache();
         }
       }
@@ -376,9 +354,9 @@ export class ProgressApiKeyRetryController {
     return {
       useIncludedModelAccess: this.deps.getUseIncludedModelAccess(),
       quotaRoutes: new Map(
-        this.quotaFallbackToggles.map((toggle) => [
-          toggle.exhaustionReason,
-          toggle.getEnabled(),
+        this.fallbackRuntimes.map((runtime) => [
+          runtime.descriptor.exhaustionReason,
+          runtime.getEnabled(),
         ]),
       ),
     };
@@ -394,14 +372,12 @@ export class ProgressApiKeyRetryController {
     // rest have run (compensation per the error-handling checklist's L2).
     const restores: Array<() => Promise<void>> = [];
     for (const reason of [...prepared.disabledQuotaRoutes].reverse()) {
-      const toggle = this.quotaFallbackToggles.find(
-        (candidate) => candidate.exhaustionReason === reason,
+      const runtime = this.fallbackRuntimes.find(
+        (candidate) => candidate.descriptor.exhaustionReason === reason,
       );
-      if (toggle)
+      if (runtime)
         restores.push(() =>
-          (toggle.restoreEnabled ?? toggle.setEnabled)(
-            before.quotaRoutes.get(reason) ?? false,
-          ),
+          runtime.restoreEnabled(before.quotaRoutes.get(reason) ?? false),
         );
     }
     if (prepared.disabledIncludedModelAccess) {

--- a/src/model/quotaFallbackRoutes.ts
+++ b/src/model/quotaFallbackRoutes.ts
@@ -8,6 +8,7 @@ import {
   setPreferXaiSubscription,
 } from '@model/xai/xaiPreference';
 import {
+  isCodingPlanQuotaRoute,
   QUOTA_FALLBACK_ROUTES,
   type QuotaFallbackRoute,
   type QuotaFallbackRouteId,
@@ -20,24 +21,24 @@ export interface QuotaFallbackRuntime {
   readonly restoreEnabled: (enabled: boolean) => Promise<void>;
 }
 
+async function setCodexEnabled(enabled: boolean): Promise<void> {
+  await setPreferCodexSubscription(enabled);
+}
+
+async function setXaiEnabled(enabled: boolean): Promise<void> {
+  await setPreferXaiSubscription(enabled);
+}
+
 const OAUTH_RUNTIME_BY_ID = {
   chatgpt: {
     getEnabled: isPreferCodexSubscription,
-    setEnabled: async (enabled) => {
-      await setPreferCodexSubscription(enabled);
-    },
-    restoreEnabled: async (enabled) => {
-      await setPreferCodexSubscription(enabled);
-    },
+    setEnabled: setCodexEnabled,
+    restoreEnabled: setCodexEnabled,
   },
   grok: {
     getEnabled: isPreferXaiSubscription,
-    setEnabled: async (enabled) => {
-      await setPreferXaiSubscription(enabled);
-    },
-    restoreEnabled: async (enabled) => {
-      await setPreferXaiSubscription(enabled);
-    },
+    setEnabled: setXaiEnabled,
+    restoreEnabled: setXaiEnabled,
   },
 } as const satisfies Record<
   Extract<QuotaFallbackRouteId, 'chatgpt' | 'grok'>,
@@ -47,9 +48,9 @@ const OAUTH_RUNTIME_BY_ID = {
 function runtimeFor(
   descriptor: QuotaFallbackRoute,
 ): Omit<QuotaFallbackRuntime, 'descriptor'> {
-  if (descriptor.codingPlanId !== undefined) {
+  if (isCodingPlanQuotaRoute(descriptor.id)) {
     const coding = codingPlanSubscriptionRuntimes.find(
-      (candidate) => candidate.descriptor.id === descriptor.codingPlanId,
+      (candidate) => candidate.descriptor.id === descriptor.id,
     );
     if (coding === undefined) {
       throw new Error(`Unknown coding-plan subscription: ${descriptor.id}`);
@@ -60,7 +61,7 @@ function runtimeFor(
       restoreEnabled: coding.restoreEnabled,
     };
   }
-  return OAUTH_RUNTIME_BY_ID[descriptor.id as 'chatgpt' | 'grok'];
+  return OAUTH_RUNTIME_BY_ID[descriptor.id];
 }
 
 /** Runtime catalog consumed by retry policy. */

--- a/src/model/quotaFallbackRoutes.ts
+++ b/src/model/quotaFallbackRoutes.ts
@@ -1,0 +1,74 @@
+import { codingPlanSubscriptionRuntimes } from '@model/codingPlanSubscriptions';
+import {
+  isPreferCodexSubscription,
+  setPreferCodexSubscription,
+} from '@model/codex/codexPreference';
+import {
+  isPreferXaiSubscription,
+  setPreferXaiSubscription,
+} from '@model/xai/xaiPreference';
+import {
+  QUOTA_FALLBACK_ROUTES,
+  type QuotaFallbackRoute,
+  type QuotaFallbackRouteId,
+} from '@shared/quotaFallbackRoutes';
+
+export interface QuotaFallbackRuntime {
+  readonly descriptor: QuotaFallbackRoute;
+  readonly getEnabled: () => boolean;
+  readonly setEnabled: (enabled: boolean) => Promise<void>;
+  readonly restoreEnabled: (enabled: boolean) => Promise<void>;
+}
+
+const OAUTH_RUNTIME_BY_ID = {
+  chatgpt: {
+    getEnabled: isPreferCodexSubscription,
+    setEnabled: async (enabled) => {
+      await setPreferCodexSubscription(enabled);
+    },
+    restoreEnabled: async (enabled) => {
+      await setPreferCodexSubscription(enabled);
+    },
+  },
+  grok: {
+    getEnabled: isPreferXaiSubscription,
+    setEnabled: async (enabled) => {
+      await setPreferXaiSubscription(enabled);
+    },
+    restoreEnabled: async (enabled) => {
+      await setPreferXaiSubscription(enabled);
+    },
+  },
+} as const satisfies Record<
+  Extract<QuotaFallbackRouteId, 'chatgpt' | 'grok'>,
+  Omit<QuotaFallbackRuntime, 'descriptor'>
+>;
+
+function runtimeFor(
+  descriptor: QuotaFallbackRoute,
+): Omit<QuotaFallbackRuntime, 'descriptor'> {
+  if (descriptor.codingPlanId !== undefined) {
+    const coding = codingPlanSubscriptionRuntimes.find(
+      (candidate) => candidate.descriptor.id === descriptor.codingPlanId,
+    );
+    if (coding === undefined) {
+      throw new Error(`Unknown coding-plan subscription: ${descriptor.id}`);
+    }
+    return {
+      getEnabled: coding.getEnabled,
+      setEnabled: coding.setEnabled,
+      restoreEnabled: coding.restoreEnabled,
+    };
+  }
+  return OAUTH_RUNTIME_BY_ID[descriptor.id as 'chatgpt' | 'grok'];
+}
+
+/** Runtime catalog consumed by retry policy. */
+export const quotaFallbackRuntimes = Object.freeze(
+  QUOTA_FALLBACK_ROUTES.map((descriptor) =>
+    Object.freeze({
+      descriptor,
+      ...runtimeFor(descriptor),
+    }),
+  ),
+);

--- a/src/shared/quotaFallbackRoutes.ts
+++ b/src/shared/quotaFallbackRoutes.ts
@@ -1,0 +1,98 @@
+import {
+  CODING_PLAN_SUBSCRIPTIONS,
+  type CodingPlanSubscriptionId,
+} from './codingPlanSubscriptions';
+import type { ExhaustionReason } from './schemas/errors';
+
+/**
+ * One switchable quota-fallback route: when its usage quota is exhausted,
+ * accepting "use your own API key" turns off this route's preference so the
+ * same model retries on the fallback credential.
+ *
+ * Policy only — preference get/set lives in `@model/quotaFallbackRoutes`.
+ * Keeping this module dependency-free lets the CLI classifier, retry
+ * controller, and browser retry copy share one catalog.
+ */
+type OauthQuotaFallbackRouteId = 'chatgpt' | 'grok';
+export type QuotaFallbackRouteId =
+  OauthQuotaFallbackRouteId | CodingPlanSubscriptionId;
+
+type QuotaFallbackExhaustionReason = Extract<
+  ExhaustionReason,
+  | 'chatgpt-subscription'
+  | 'xai-subscription'
+  | 'glm-coding-plan'
+  | 'kimi-code-subscription'
+>;
+
+export interface QuotaFallbackRoute {
+  readonly id: QuotaFallbackRouteId;
+  readonly exhaustionReason: QuotaFallbackExhaustionReason;
+  /** Direct-key provider the retry should prompt for, when it differs from
+   *  the forwarded SDK provider. */
+  readonly fallbackApiProvider?: 'openai' | 'xai';
+  /** Whether accepting the switch must also turn off included (relay) access
+   *  so the retry cannot still prefer the relay JWT. */
+  readonly disableIncludedAccess: boolean;
+  readonly retryFallbackName: string;
+  readonly retrySourceName: string;
+  /** Set when this route is one of {@link CODING_PLAN_SUBSCRIPTIONS}. */
+  readonly codingPlanId?: CodingPlanSubscriptionId;
+}
+
+const OAUTH_QUOTA_FALLBACK_ROUTES = Object.freeze([
+  Object.freeze({
+    id: 'chatgpt',
+    exhaustionReason: 'chatgpt-subscription',
+    fallbackApiProvider: 'openai',
+    disableIncludedAccess: true,
+    retryFallbackName: 'your own OpenAI API key',
+    retrySourceName: 'ChatGPT subscription',
+  }),
+  Object.freeze({
+    id: 'grok',
+    exhaustionReason: 'xai-subscription',
+    fallbackApiProvider: 'xai',
+    disableIncludedAccess: true,
+    retryFallbackName: 'your own xAI API key',
+    retrySourceName: 'Grok subscription',
+  }),
+] as const satisfies readonly QuotaFallbackRoute[]);
+
+/** Canonical catalog of quota-fallback routes supported by every host. */
+export const QUOTA_FALLBACK_ROUTES: readonly QuotaFallbackRoute[] =
+  Object.freeze([
+    ...OAUTH_QUOTA_FALLBACK_ROUTES,
+    ...CODING_PLAN_SUBSCRIPTIONS.map((plan) =>
+      Object.freeze({
+        id: plan.id,
+        exhaustionReason: plan.exhaustionReason,
+        disableIncludedAccess: false,
+        retryFallbackName: plan.retryFallbackName,
+        retrySourceName: plan.retrySourceName,
+        codingPlanId: plan.id,
+      }),
+    ),
+  ]);
+
+const ROUTE_BY_ID = new Map<QuotaFallbackRouteId, QuotaFallbackRoute>(
+  QUOTA_FALLBACK_ROUTES.map((route) => [route.id, route]),
+);
+
+const ROUTE_BY_EXHAUSTION = new Map<ExhaustionReason, QuotaFallbackRoute>(
+  QUOTA_FALLBACK_ROUTES.map((route) => [route.exhaustionReason, route]),
+);
+
+/** Resolve the quota-fallback route that a classified exhaustion should switch. */
+export function quotaFallbackRouteForExhaustion(
+  reason: ExhaustionReason | undefined,
+): QuotaFallbackRoute | undefined {
+  return reason === undefined ? undefined : ROUTE_BY_EXHAUSTION.get(reason);
+}
+
+/** Resolve a quota-fallback route by catalog id. */
+export function quotaFallbackRouteById(
+  id: QuotaFallbackRouteId,
+): QuotaFallbackRoute | undefined {
+  return ROUTE_BY_ID.get(id);
+}

--- a/src/shared/quotaFallbackRoutes.ts
+++ b/src/shared/quotaFallbackRoutes.ts
@@ -36,8 +36,6 @@ export interface QuotaFallbackRoute {
   readonly disableIncludedAccess: boolean;
   readonly retryFallbackName: string;
   readonly retrySourceName: string;
-  /** Set when this route is one of {@link CODING_PLAN_SUBSCRIPTIONS}. */
-  readonly codingPlanId?: CodingPlanSubscriptionId;
 }
 
 const OAUTH_QUOTA_FALLBACK_ROUTES = Object.freeze([
@@ -70,7 +68,6 @@ export const QUOTA_FALLBACK_ROUTES: readonly QuotaFallbackRoute[] =
         disableIncludedAccess: false,
         retryFallbackName: plan.retryFallbackName,
         retrySourceName: plan.retrySourceName,
-        codingPlanId: plan.id,
       }),
     ),
   ]);
@@ -95,4 +92,11 @@ export function quotaFallbackRouteById(
   id: QuotaFallbackRouteId,
 ): QuotaFallbackRoute | undefined {
   return ROUTE_BY_ID.get(id);
+}
+
+/** True when `id` is one of {@link CODING_PLAN_SUBSCRIPTIONS}. */
+export function isCodingPlanQuotaRoute(
+  id: QuotaFallbackRouteId,
+): id is CodingPlanSubscriptionId {
+  return CODING_PLAN_SUBSCRIPTIONS.some((plan) => plan.id === id);
 }

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -52,6 +52,11 @@ export const ExhaustionReasonSchema = z.enum([
    *  exhausted; accepting the switch turns off the Coding Plan toggle so GLM
    *  requests route through the regular pay-as-you-go endpoint. */
   'glm-coding-plan',
+  /** A Grok (xAI SuperGrok) subscription request was rejected because the
+   *  plan's usage quota is exhausted; accepting the switch disables the
+   *  "prefer Grok subscription" preference so xAI models re-route through
+   *  the stored xAI API key. */
+  'xai-subscription',
 ]);
 export type ExhaustionReason = z.infer<typeof ExhaustionReasonSchema>;
 
@@ -188,20 +193,6 @@ export const ProviderErrorPartialSchema = z.preprocess(
   ProviderErrorObjectSchema.partial(),
 );
 export type ProviderErrorPartial = z.infer<typeof ProviderErrorPartialSchema>;
-
-/** Single source of truth for "this error is a ChatGPT-subscription (Codex)
- *  usage-limit rejection". Both hosts (VS Code progress view, CLI approval
- *  policy) branch on this to switch the retry from the relay/personal-key path
- *  to disabling the subscription preference. Accepts any error shape carrying
- *  the field (full `ProviderError`, `ProviderErrorPartial`, or `RetryErrorInfo`)
- *  so the predicate stays the one place that owns the verdict.
- *  Remark: that disable-prefer design is a known tradeoff — after the quota
- *  resets, users may forget the preference was turned off. */
-export function isChatGptSubscriptionLimitError(
-  errorDetails: Pick<ProviderError, 'exhaustionReason'> | undefined | null,
-): boolean {
-  return errorDetails?.exhaustionReason === 'chatgpt-subscription';
-}
 
 /** Single source of truth for "the upstream provider account itself is out of
  *  credit/quota" — the key the user has IS the broken one, so the auto-resume

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.ts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.ts
@@ -913,11 +913,11 @@ describe('formatRetryRequestMessage', () => {
       'Kimi Code subscription',
     );
     expect(formatRetryRequestMessage(retry)).toContain('Moonshot API keys');
-    expect(classifyCliRetryAction(retry)).toBe('disable-coding-plan:kimiCode');
+    expect(classifyCliRetryAction(retry)).toBe('disable-quota-route:kimiCode');
     expect(cliRetryApiSwitchDecision(retry)).toEqual({
       accepted: true,
       apiMode: 'personal',
-      disableCodingPlan: 'kimiCode',
+      disableQuotaRoute: 'kimiCode',
     });
   });
 
@@ -932,12 +932,12 @@ describe('formatRetryRequestMessage', () => {
     };
 
     expect(classifyCliRetryAction(retry)).toBe(
-      'disable-coding-plan:glmCodingPlan',
+      'disable-quota-route:glmCodingPlan',
     );
     expect(cliRetryApiSwitchDecision(retry)).toEqual({
       accepted: true,
       apiMode: 'personal',
-      disableCodingPlan: 'glmCodingPlan',
+      disableQuotaRoute: 'glmCodingPlan',
     });
     expect(formatRetryRequestMessage(retry)).toContain('regular GLM endpoint');
   });

--- a/src/test-kernel/cli/RetryRequest.vitest.ts
+++ b/src/test-kernel/cli/RetryRequest.vitest.ts
@@ -106,7 +106,7 @@ describe('CLI retry request', () => {
       await expect(decision).resolves.toEqual({
         accepted: true,
         apiMode: 'personal',
-        disableChatGptSubscription: true,
+        disableQuotaRoute: 'chatgpt',
       });
       expect(currentApproval.get()).toBeUndefined();
     } finally {

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
@@ -325,7 +325,7 @@ async function settleRetryContinuation(): Promise<void> {
 const PERSONAL_KEY_RETRY: ApprovalDecision = {
   accepted: true,
   apiMode: 'personal',
-  disableChatGptSubscription: true,
+  disableQuotaRoute: 'chatgpt',
 };
 
 async function waitForApproval(

--- a/src/test-kernel/common/XaiSubscriptionDetection.vitest.ts
+++ b/src/test-kernel/common/XaiSubscriptionDetection.vitest.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatProviderHttpError } from '@common/errors/sdkError/providerErrorFormat';
+import {
+  attachSdkCredentialRoute,
+  detectSdkCredentialRoute,
+} from '@common/errors/sdkError/sdkRequestEndpoint';
+import {
+  describeXaiSubscriptionLimit,
+  parseXaiSubscriptionLimit,
+} from '@common/errors/sdkError/xaiSubscriptionDetection';
+
+const USAGE_LIMIT_BODY = {
+  message: "You've reached your weekly usage limit.",
+  resets_in_seconds: 3600,
+} as const;
+
+function stampedError(message: string, body?: unknown): Error {
+  const error = new Error(message) as Error & { error?: unknown };
+  if (body !== undefined) error.error = body;
+  attachSdkCredentialRoute(error, 'xai-subscription');
+  return error;
+}
+
+describe('parseXaiSubscriptionLimit', () => {
+  it('ignores quota wording without the subscription route stamp', () => {
+    expect(
+      parseXaiSubscriptionLimit(new Error(USAGE_LIMIT_BODY.message), {
+        error: USAGE_LIMIT_BODY,
+      }),
+    ).toBeNull();
+  });
+
+  it('parses a stamped SuperGrok usage-limit body', () => {
+    const error = stampedError('rejected');
+    expect(detectSdkCredentialRoute(error)).toBe('xai-subscription');
+    expect(
+      parseXaiSubscriptionLimit(error, { error: USAGE_LIMIT_BODY }),
+    ).toEqual({ resetsInSeconds: 3600 });
+  });
+
+  it('ignores a stamped transient rate limit', () => {
+    const error = stampedError('rate limited');
+    expect(
+      parseXaiSubscriptionLimit(error, {
+        error: { message: 'Rate limit reached. Too many requests.' },
+      }),
+    ).toBeNull();
+  });
+
+  it('formats a human-readable reset hint', () => {
+    expect(describeXaiSubscriptionLimit({ resetsInSeconds: 3600 })).toContain(
+      'Resets in 1h',
+    );
+  });
+});
+
+describe('formatProviderHttpError for Grok subscription limits', () => {
+  it('classifies a stamped usage-limit error as switchable exhaustion', () => {
+    const error = stampedError('xAI rejected the request', USAGE_LIMIT_BODY);
+    const providerError = formatProviderHttpError(error);
+    expect(providerError.exhaustionReason).toBe('xai-subscription');
+    expect(providerError.userRetryable).toBe(true);
+    expect(providerError.message).toContain('Grok subscription usage limit');
+  });
+});

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -7,6 +7,8 @@ import {
 } from '@controllers/progressView/ProgressApiKeyRetryController';
 import type { ApiProvider } from '@model/apiProviders';
 import { prefersCopilotRoute } from '@model/copilotRouting';
+import type { QuotaFallbackRuntime } from '@model/quotaFallbackRoutes';
+import type { QuotaFallbackRoute } from '@shared/quotaFallbackRoutes';
 import { installPlatform } from '@test/support/setupPlatform';
 
 const PROVIDERS = [
@@ -28,6 +30,26 @@ const RETRIED_WITH_OWN_KEY_RESULT = {
   disabledIncludedModelAccess: true,
   disabledQuotaRoutes: [],
 };
+
+function testRuntime(
+  descriptor: Pick<
+    QuotaFallbackRoute,
+    'id' | 'exhaustionReason' | 'disableIncludedAccess' | 'fallbackApiProvider'
+  >,
+  getEnabled: () => boolean,
+  setEnabled: (enabled: boolean) => Promise<void>,
+): QuotaFallbackRuntime {
+  return {
+    descriptor: {
+      retryFallbackName: descriptor.id,
+      retrySourceName: descriptor.id,
+      ...descriptor,
+    },
+    getEnabled,
+    setEnabled,
+    restoreEnabled: setEnabled,
+  };
+}
 
 interface HarnessOptions {
   keys?: Partial<Record<ApiProvider, string | undefined>>;
@@ -96,45 +118,57 @@ function createHarness(options: HarnessOptions = {}): {
       setUseIncludedModelAccess: async (enabled) => {
         includedAccessValues.push(enabled);
       },
-      quotaFallbackToggles: [
-        {
-          exhaustionReason: 'chatgpt-subscription',
-          disableIncludedAccess: true,
-          fallbackApiProvider: 'openai',
-          getEnabled: () => preferChatGptSubscription,
-          setEnabled: async (enabled) => {
+      quotaFallbackRuntimes: [
+        testRuntime(
+          {
+            id: 'chatgpt',
+            exhaustionReason: 'chatgpt-subscription',
+            disableIncludedAccess: true,
+            fallbackApiProvider: 'openai',
+          },
+          () => preferChatGptSubscription,
+          async (enabled) => {
             preferChatGptSubscription = enabled;
             chatGptSubscriptionValues.push(enabled);
           },
-        },
-        {
-          exhaustionReason: 'xai-subscription',
-          disableIncludedAccess: true,
-          fallbackApiProvider: 'xai',
-          getEnabled: () => preferGrokSubscription,
-          setEnabled: async (enabled) => {
+        ),
+        testRuntime(
+          {
+            id: 'grok',
+            exhaustionReason: 'xai-subscription',
+            disableIncludedAccess: true,
+            fallbackApiProvider: 'xai',
+          },
+          () => preferGrokSubscription,
+          async (enabled) => {
             preferGrokSubscription = enabled;
             grokSubscriptionValues.push(enabled);
           },
-        },
-        {
-          exhaustionReason: 'glm-coding-plan',
-          disableIncludedAccess: false,
-          getEnabled: () => glmCodingPlan,
-          setEnabled: async (enabled) => {
+        ),
+        testRuntime(
+          {
+            id: 'glmCodingPlan',
+            exhaustionReason: 'glm-coding-plan',
+            disableIncludedAccess: false,
+          },
+          () => glmCodingPlan,
+          async (enabled) => {
             glmCodingPlan = enabled;
             glmCodingPlanValues.push(enabled);
           },
-        },
-        {
-          exhaustionReason: 'kimi-code-subscription',
-          disableIncludedAccess: false,
-          getEnabled: () => kimiCode,
-          setEnabled: async (enabled) => {
+        ),
+        testRuntime(
+          {
+            id: 'kimiCode',
+            exhaustionReason: 'kimi-code-subscription',
+            disableIncludedAccess: false,
+          },
+          () => kimiCode,
+          async (enabled) => {
             kimiCode = enabled;
             kimiCodeValues.push(enabled);
           },
-        },
+        ),
       ],
       invalidateModelOptionsCache: () => {
         invalidations += 1;

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -20,15 +20,13 @@ const IDLE_RESULT = {
   proceeded: false,
   retried: false,
   disabledIncludedModelAccess: false,
-  disabledChatGptSubscription: false,
-  disabledCodingPlans: [],
+  disabledQuotaRoutes: [],
 };
 const RETRIED_WITH_OWN_KEY_RESULT = {
   proceeded: true,
   retried: true,
   disabledIncludedModelAccess: true,
-  disabledChatGptSubscription: false,
-  disabledCodingPlans: [],
+  disabledQuotaRoutes: [],
 };
 
 interface HarnessOptions {
@@ -36,6 +34,7 @@ interface HarnessOptions {
   prompt?(keys: Map<ApiProvider, string | undefined>): void;
   glmCodingPlan?: boolean;
   kimiCode?: boolean;
+  grok?: boolean;
   retryAvailable?: boolean;
   retryPending?: boolean;
   triggerRetry?: ProgressApiKeyRetryControllerDeps['triggerRetry'];
@@ -50,6 +49,7 @@ function createHarness(options: HarnessOptions = {}): {
   chatGptSubscriptionValues: boolean[];
   glmCodingPlanValues: boolean[];
   kimiCodeValues: boolean[];
+  grokSubscriptionValues: boolean[];
   invalidations: number;
   retries: string[];
 } {
@@ -63,7 +63,9 @@ function createHarness(options: HarnessOptions = {}): {
   const chatGptSubscriptionValues: boolean[] = [];
   const glmCodingPlanValues: boolean[] = [];
   const kimiCodeValues: boolean[] = [];
+  const grokSubscriptionValues: boolean[] = [];
   let preferChatGptSubscription = true;
+  let preferGrokSubscription = options.grok ?? true;
   let glmCodingPlan = options.glmCodingPlan ?? true;
   let kimiCode = options.kimiCode ?? true;
   let invalidations = 0;
@@ -76,6 +78,7 @@ function createHarness(options: HarnessOptions = {}): {
     chatGptSubscriptionValues,
     glmCodingPlanValues,
     kimiCodeValues,
+    grokSubscriptionValues,
     get invalidations() {
       return invalidations;
     },
@@ -93,14 +96,30 @@ function createHarness(options: HarnessOptions = {}): {
       setUseIncludedModelAccess: async (enabled) => {
         includedAccessValues.push(enabled);
       },
-      getPreferChatGptSubscription: () => preferChatGptSubscription,
-      setPreferChatGptSubscription: async (enabled) => {
-        preferChatGptSubscription = enabled;
-        chatGptSubscriptionValues.push(enabled);
-      },
-      codingPlanToggles: [
+      quotaFallbackToggles: [
+        {
+          exhaustionReason: 'chatgpt-subscription',
+          disableIncludedAccess: true,
+          fallbackApiProvider: 'openai',
+          getEnabled: () => preferChatGptSubscription,
+          setEnabled: async (enabled) => {
+            preferChatGptSubscription = enabled;
+            chatGptSubscriptionValues.push(enabled);
+          },
+        },
+        {
+          exhaustionReason: 'xai-subscription',
+          disableIncludedAccess: true,
+          fallbackApiProvider: 'xai',
+          getEnabled: () => preferGrokSubscription,
+          setEnabled: async (enabled) => {
+            preferGrokSubscription = enabled;
+            grokSubscriptionValues.push(enabled);
+          },
+        },
         {
           exhaustionReason: 'glm-coding-plan',
+          disableIncludedAccess: false,
           getEnabled: () => glmCodingPlan,
           setEnabled: async (enabled) => {
             glmCodingPlan = enabled;
@@ -109,6 +128,7 @@ function createHarness(options: HarnessOptions = {}): {
         },
         {
           exhaustionReason: 'kimi-code-subscription',
+          disableIncludedAccess: false,
           getEnabled: () => kimiCode,
           setEnabled: async (enabled) => {
             kimiCode = enabled;
@@ -314,8 +334,7 @@ describe('ProgressApiKeyRetryController', () => {
       proceeded: true,
       retried: true,
       disabledIncludedModelAccess: true,
-      disabledChatGptSubscription: true,
-      disabledCodingPlans: [],
+      disabledQuotaRoutes: ['chatgpt-subscription'],
     });
     // The subscription quota failed, not the key — a stored key is already
     // usable, so "Use your own API key" must not jump to the key-input prompt.
@@ -324,6 +343,31 @@ describe('ProgressApiKeyRetryController', () => {
     expect(harness.chatGptSubscriptionValues).toStrictEqual([false]);
     expect(harness.invalidations).toBe(2);
     expect(harness.retries).toStrictEqual(['stream-d']);
+  });
+
+  it('disables the Grok subscription and retries with the existing xAI key, no prompt', async () => {
+    const harness = createHarness({
+      keys: { xai: 'stored-xai' },
+    });
+
+    const result = await harness.controller.useOwnApiKey({
+      stream: 'stream-grok',
+      requestId: 'retry-grok',
+      provider: 'xai',
+      exhaustionReason: 'xai-subscription',
+    });
+
+    expect(result).toStrictEqual({
+      proceeded: true,
+      retried: true,
+      disabledIncludedModelAccess: true,
+      disabledQuotaRoutes: ['xai-subscription'],
+    });
+    expect(harness.prompts).toStrictEqual([]);
+    expect(harness.includedAccessValues).toStrictEqual([false]);
+    expect(harness.grokSubscriptionValues).toStrictEqual([false]);
+    expect(harness.invalidations).toBe(2);
+    expect(harness.retries).toStrictEqual(['stream-grok']);
   });
 
   it('does not disable the subscription when no usable OpenAI key is available', async () => {
@@ -359,8 +403,7 @@ describe('ProgressApiKeyRetryController', () => {
       proceeded: true,
       retried: true,
       disabledIncludedModelAccess: false,
-      disabledChatGptSubscription: false,
-      disabledCodingPlans: ['glm-coding-plan'],
+      disabledQuotaRoutes: ['glm-coding-plan'],
     });
     // The coding-plan quota failed, not the key — a stored key is already
     // usable, so "Use your own API key" must not jump to the key-input prompt.
@@ -388,8 +431,7 @@ describe('ProgressApiKeyRetryController', () => {
       proceeded: true,
       retried: true,
       disabledIncludedModelAccess: false,
-      disabledChatGptSubscription: false,
-      disabledCodingPlans: [],
+      disabledQuotaRoutes: [],
     });
     expect(harness.glmCodingPlanValues).toStrictEqual([]);
   });
@@ -581,8 +623,7 @@ describe('ProgressApiKeyRetryController', () => {
       proceeded: true,
       retried: true,
       disabledIncludedModelAccess: true,
-      disabledChatGptSubscription: true,
-      disabledCodingPlans: [],
+      disabledQuotaRoutes: ['chatgpt-subscription'],
     });
     expect(harness.includedAccessValues).toStrictEqual([false, true, false]);
     expect(harness.chatGptSubscriptionValues).toStrictEqual([
@@ -657,8 +698,7 @@ describe('ProgressApiKeyRetryController', () => {
       proceeded: true,
       retried: true,
       disabledIncludedModelAccess: false,
-      disabledChatGptSubscription: false,
-      disabledCodingPlans: [],
+      disabledQuotaRoutes: [],
     });
     // The SDK error identifies the open-platform Moonshot provider, but the
     // exclusive handler rebinds with `kimiCode`; the prompt and key check must
@@ -692,8 +732,7 @@ describe('ProgressApiKeyRetryController', () => {
       proceeded: true,
       retried: true,
       disabledIncludedModelAccess: false,
-      disabledChatGptSubscription: false,
-      disabledCodingPlans: ['kimi-code-subscription'],
+      disabledQuotaRoutes: ['kimi-code-subscription'],
     });
     // The forwarded SDK provider is `moonshot`, so that is the credential the
     // panel asks to replace; the routing step then turns off "Prefer Kimi
@@ -732,8 +771,7 @@ describe('ProgressApiKeyRetryController', () => {
       proceeded: true,
       retried: true,
       disabledIncludedModelAccess: false,
-      disabledChatGptSubscription: false,
-      disabledCodingPlans: [],
+      disabledQuotaRoutes: [],
     });
     // A canonical `kimi3` can also fail through OpenRouter, Moonshot, or the
     // relay. Those failed handlers were not dispatched onto the Kimi Code

--- a/src/test-kernel/shared/CodingPlanSubscriptions.vitest.ts
+++ b/src/test-kernel/shared/CodingPlanSubscriptions.vitest.ts
@@ -6,6 +6,10 @@ import {
   codingPlanForUsageRoute,
   codingPlanForUsageSetting,
 } from '@shared/codingPlanSubscriptions';
+import {
+  QUOTA_FALLBACK_ROUTES,
+  quotaFallbackRouteForExhaustion,
+} from '@shared/quotaFallbackRoutes';
 import { SUBSCRIPTION_USAGE_PROVIDERS } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
@@ -43,6 +47,22 @@ describe('coding-plan subscription catalog', () => {
     );
     expect(codingPlanForUsageSetting(GlobalStateKey.GLM_USE_CHINA)?.id).toBe(
       'glmCodingPlan',
+    );
+  });
+});
+
+describe('quota-fallback route catalog', () => {
+  it('covers ChatGPT, Grok, and every coding plan exactly once', () => {
+    expect(QUOTA_FALLBACK_ROUTES.map((route) => route.id)).toEqual([
+      'chatgpt',
+      'grok',
+      ...CODING_PLAN_SUBSCRIPTIONS.map((plan) => plan.id),
+    ]);
+    expect(quotaFallbackRouteForExhaustion('xai-subscription')?.id).toBe(
+      'grok',
+    );
+    expect(quotaFallbackRouteForExhaustion('chatgpt-subscription')?.id).toBe(
+      'chatgpt',
     );
   });
 });


### PR DESCRIPTION
## Summary

ChatGPT, GLM Coding Plan, and Kimi Code each grew their own quota-exhaustion retry path. This folds those routes — and Grok, which had subscription routing but no quota switch — into one catalog-driven chain so the next provider is a catalog row plus a detector, not another bespoke controller/CLI/host patch.

`QUOTA_FALLBACK_ROUTES` owns the policy (exhaustion reason, fallback credential, whether included access must turn off, retry copy). The retry controller, CLI classifier, and error formatter walk that table. Grok subscription quota now falls back to a saved xAI key the same way ChatGPT already does.

This is credential/route failover for the same model, not Claude-style `fallbackModel` (opus → sonnet on a 529). Putting quota routing on Agent SDK `fallbackModel` would mix those concerns.

## Issue acceptance gates

No tracking issue. Acceptance:

- ChatGPT, GLM, and Kimi keep their current retry behavior (including Kimi exclusive-model block and dual-backend credit reroute).
- Grok subscription usage-limit errors classify as `xai-subscription` and can switch to a stored xAI key.
- Adding another provider does not require a new retry-controller branch, CLI action type, or host ChatGPT-style dep.

## Single source of truth

`src/shared/quotaFallbackRoutes.ts` owns the policy catalog. `@model/quotaFallbackRoutes` attaches get/set. Detection stays per-provider (error shapes differ) and registers into one `detectQuotaLimit` list.

## Duplication and abstraction budget

Removed the ChatGPT special case from `ProgressApiKeyRetryController` and the `disable-chatgpt` / `disable-coding-plan:*` split in the CLI. Hosts no longer pass ChatGPT prefer get/set.

Kept special: Kimi handler rebuild (coding endpoint is pinned in the live config), Kimi exclusive models (no Moonshot fallback), Copilot/relay (different semantics), and the CLI OAuth rollback ladder (not extracted — historically a net-adding table).

## Net elements (R6)

- Files: 20 changed (4 added, 16 modified, 0 deleted)
- Exported symbols: +14 / −1 (`isChatGptSubscriptionLimitError`)
- New types/interfaces: `QuotaFallbackRoute`, `QuotaFallbackRouteId`, `QuotaFallbackRuntime`, `QuotaFallbackToggle`, `XaiSubscriptionLimit`, `SdkCredentialRoute`
- Net LoC: +684 / −267 (+417)

The LoC increase is the Grok detector, credential-route stamp, catalog/runtime, and tests. The ChatGPT/coding-plan special cases in the controller and hosts are gone.

## Consumer counts (R8)

- `isChatGptSubscriptionLimitError`: 0 remaining (deleted with its last call site in `classifyCliRetryAction`)
- `disableChatGptSubscription` / `disableCodingPlan`: 0 remaining (replaced by `disableQuotaRoute`)
- Controller deps `getPreferChatGptSubscription` / `setPreferChatGptSubscription` / `codingPlanToggles`: 0 remaining (default runtime catalog)

## Host impact

Extension: retry controller uses the shared catalog; ChatGPT prefer wiring deleted.

Desktop: same as extension.

CLI: one `disableQuotaRoute` decision; coding-plan auto-switch still requires a stored key; ChatGPT/Grok stay explicit.

## Scheduled refactoring

None.

## Validation

- `tsc --noEmit` for workspace, CLI, and desktop
- Vitest: `ProgressApiKeyRetryController`, `TuiApprovalRetry`, `ApprovalAdapter`, `RetryRequest`, ChatGPT/GLM/Grok detection, `SdkErrorUtils`, `ModelFactoryRouting`, `RetryState`, `CodingPlanSubscriptions`
- ESLint on the changed TypeScript files
- `npm run check:dead-code-ratchet`
- Pre-commit: Prettier, docs-root boundary, guidance refs