### PR TITLE
refactor(transcript): register streams at run-fact projection and delete the summary-meta antechamber

### DIFF
--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -376,8 +376,14 @@ export class SessionHandle {
 
     // A parked WAITING stream is not part of the bounded startup seed, so its
     // snapshot record is deliberately absent. Resolve the authoritative
-    // one-file sidecar FK first, then the always-resident summary mirror for
-    // legacy streams without a persisted FK. A read failure must not reject a
+    // one-file sidecar FK first, then the always-resident summary mirror. The
+    // mirror arm is load-bearing, not just legacy compat: `run.start`
+    // publishes the execution id to the mirror synchronously while the async
+    // sidecar FK flush may still be in flight (or lost to a crash), so a
+    // genuinely owned stream can transiently have only the mirror FK. It also
+    // covers legacy streams that never got a persisted sidecar FK; the two
+    // roles share this one read and separate only once run identity becomes a
+    // synchronous appended fact. A read failure must not reject a
     // follow-up submission; let `submitFollowUp` surface its own routing result.
     let executionId: string | undefined;
     try {
@@ -724,8 +730,11 @@ export class SessionHandle {
       async (streamId) => {
         // The stream→execution reverse edge is the persisted sidecar FK;
         // name resemblance is never ownership. Read that authority first and
-        // fall back to the always-resident summary mirror only for legacy
-        // streams without a persisted FK. A stream with neither stays unmapped
+        // fall back to the always-resident summary mirror. The mirror arm is
+        // load-bearing beyond legacy streams without a persisted FK: `run.start`
+        // publishes to the mirror synchronously while the sidecar FK flush is
+        // async, so a crash inside that window leaves the mirror as the only
+        // record of ownership. A stream with neither stays unmapped
         // and is skipped by repair.
         try {
           const persisted =

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -2123,20 +2123,19 @@ describe('StreamLogStore summary metadata mirror', () => {
     expect(store.getSummaryMeta('alpha')).toBeUndefined();
   });
 
-  it('holds metadata for an unregistered stream without minting a tab and lands it on registration', async () => {
+  it('registers an unknown stream at metadata projection', async () => {
     mockStorage({ logs: {}, summaries: {} });
     const store = await StreamLogStore.open();
 
+    // Run facts can legitimately project before the stream's first append;
+    // recording metadata registers the stream so the metadata is immediately
+    // readable, and a later ensureStream is a no-op.
     store.recordSummaryMeta('gamma', META);
-    // Not registered: the antechamber never mints a phantom tab...
-    expect(store.has('gamma')).toBe(false);
-    expect(store.keys()).toEqual([]);
-    // ...but the metadata is already readable, because run facts can
-    // legitimately project before registration.
+    expect(store.has('gamma')).toBe(true);
     expect(store.getSummaryMeta('gamma')).toEqual(META);
 
     store.ensureStream('gamma');
-    expect(store.has('gamma')).toBe(true);
+    expect(store.keys()).toEqual(['gamma']);
     expect(store.getSummaryMeta('gamma')).toEqual(META);
     await store.flush();
   });

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -379,17 +379,6 @@ export class StreamLogStore {
   private readonly summaries = new Map<StreamTabId, StreamLogSummary>();
 
   /**
-   * Antechamber for snapshot metadata recorded before its stream is
-   * registered (run facts project ahead of `ensureStream`). Never listed —
-   * `has()`/`keys()` stay `summaries`-based — and adopted into the summary
-   * at registration; dropped with the stream otherwise.
-   */
-  private readonly pendingSummaryMeta = new Map<
-    StreamTabId,
-    StreamSummaryMeta
-  >();
-
-  /**
    * Max-wait throttle for the persistence path: the first dirty mutation in a
    * window starts the timer and later mutations join it without resetting it
    * (`scheduleSave`'s `pending` guard), so sustained sub-window appends still
@@ -598,15 +587,10 @@ export class StreamLogStore {
   /**
    * The snapshot-owned display metadata mirrored into this stream's summary,
    * or `undefined` for a stream whose summary predates the mirror (legacy
-   * rows backfill lazily on their next sidecar hydration). Metadata recorded
-   * ahead of stream registration is served from the antechamber, so a run
-   * fact that projects before `ensureStream` is never invisible.
+   * rows backfill lazily on their next sidecar hydration).
    */
   getSummaryMeta(streamId: StreamTabId): StreamSummaryMeta | undefined {
-    return (
-      this.summaries.get(streamId)?.meta ??
-      this.pendingSummaryMeta.get(streamId)
-    );
+    return this.summaries.get(streamId)?.meta;
   }
 
   /**
@@ -614,25 +598,19 @@ export class StreamLogStore {
    * always-resident summary (memory now, summary cache asynchronously).
    * Whole-object replacement — the publisher owns field lifecycles — and a
    * deep-equal no-op gate, so the startup hydration sweep republishing
-   * unchanged metadata for every stream costs no writes. A stream this store
-   * does not know yet holds its metadata in `pendingSummaryMeta`: `summaries`
-   * is the tab registry and registering here would mint a phantom stream, but
-   * run facts legitimately project ahead of registration, so the metadata
-   * waits in the antechamber and lands when `ensureStream` (or the first
-   * append) registers the stream.
+   * unchanged metadata for every stream costs no writes. Run facts may
+   * legitimately project before the stream's first append, so an unknown
+   * stream is registered here: `ensureStream` no-ops for known streams, and
+   * run facts only project for streams whose run genuinely started, so
+   * registering at projection cannot mint a phantom tab.
    */
   recordSummaryMeta(streamId: StreamTabId, meta: StreamSummaryMeta): void {
+    // Writability is asserted before `ensureStream`, so a read-only open can
+    // never reach the registration below.
     this.assertWritableStore('record stream summary metadata');
+    this.ensureStream(streamId);
     const summary = this.summaries.get(streamId);
-    if (!summary) {
-      if (isDeepStrictEqual(this.pendingSummaryMeta.get(streamId), meta))
-        return;
-      this.pendingSummaryMeta.set(streamId, meta);
-      this.stateRevision += 1;
-      return;
-    }
-    this.pendingSummaryMeta.delete(streamId);
-    if (isDeepStrictEqual(summary.meta, meta)) return;
+    if (summary === undefined || isDeepStrictEqual(summary.meta, meta)) return;
     summary.meta = meta;
     this.stateRevision += 1;
     // Share the transcript queue so flush/reload drains this write before a
@@ -645,13 +623,6 @@ export class StreamLogStore {
       const current = this.summaries.get(streamId);
       if (current) await this.maintainSummaryCache(streamId, { ...current });
     });
-  }
-
-  /** Land metadata recorded before this stream existed in the registry. */
-  private adoptPendingSummaryMeta(streamId: StreamTabId): void {
-    const pending = this.pendingSummaryMeta.get(streamId);
-    if (pending === undefined) return;
-    this.recordSummaryMeta(streamId, pending);
   }
 
   ensureStream(streamId: StreamTabId): void {
@@ -667,7 +638,6 @@ export class StreamLogStore {
       return;
     this.ensureStreamState(streamId).log = new StreamLog();
     this.summaries.set(streamId, {});
-    this.adoptPendingSummaryMeta(streamId);
     this.stateRevision += 1;
     if (this.mode.kind === 'persistent') {
       this.markDirty(streamId);
@@ -970,7 +940,6 @@ export class StreamLogStore {
       state.log = logInstance;
       if (!this.summaries.has(streamId)) {
         this.summaries.set(streamId, {});
-        this.adoptPendingSummaryMeta(streamId);
       }
     }
     const appended = settled
@@ -1415,18 +1384,6 @@ export class StreamLogStore {
     for (const [streamId, summary] of summaries) {
       this.summaries.set(streamId, summary);
     }
-    // Metadata recorded while a stream was unregistered lands now if the
-    // replacement set knows the stream (no-op on read-only opens: the
-    // antechamber only fills through recordSummaryMeta, which is writable-only).
-    // Entries absent from the replacement belong to the previous storage root
-    // and are discarded.
-    for (const streamId of [...this.pendingSummaryMeta.keys()]) {
-      if (this.summaries.has(streamId)) {
-        this.adoptPendingSummaryMeta(streamId);
-      } else {
-        this.pendingSummaryMeta.delete(streamId);
-      }
-    }
     this.writeTombstones.clear();
     this.clearing = false;
     this.stateRevision += 1;
@@ -1580,7 +1537,6 @@ export class StreamLogStore {
     this.dirtyIds.delete(streamId);
     this.releaseRequests.delete(streamId);
     this.summaries.delete(streamId);
-    this.pendingSummaryMeta.delete(streamId);
   }
 
   private forgetAllStreamState(): void {
@@ -1591,7 +1547,6 @@ export class StreamLogStore {
     this.dirtyIds.clear();
     this.releaseRequests.clear();
     this.summaries.clear();
-    this.pendingSummaryMeta.clear();
   }
 
   private assertWritableStore(operation: string): void {


### PR DESCRIPTION
## Summary

**Item A — antechamber deleted (define-out-of-existence).** `StreamLogStore.recordSummaryMeta` used to park metadata in a `pendingSummaryMeta` map whenever the stream was not yet in `summaries`, with adoption hooks scattered across registration, first-append, reload, and forget paths. The "metadata exists before its stream is registered" state is now unrepresentable: `recordSummaryMeta` registers the stream first via the existing `ensureStream` (a no-op for known streams; run facts only project for streams whose run genuinely started, so registration at projection cannot mint a phantom tab) and records the metadata directly. `getSummaryMeta` is now a single `summaries.get(id)?.meta` read. Read-only opens are unaffected: `recordSummaryMeta` asserts writability *before* the `ensureStream` call, so a read-only store throws exactly as before and never reaches registration.

**Item B — summary-mirror arm in SessionHandle's ownership ladder: SKIPPED (comments corrected instead).** The ladder ending in `this.transcripts.getSummaryMeta(streamId)?.executionId` (repairWaitingIfResumable, probeWaitingRepair, runRestartRepair) was investigated for a legacy-compat cut. Finding: the legacy arm and the crash-window role share one read — there is no branch, condition, or marker that only legacy streams hit. `run.start` publishes the execution id to the mirror synchronously while the sidecar meta.json FK flush is async, so a genuinely owned stream can transiently (or, after a crash, permanently) have only the mirror FK; the identical `??` fallback also serves streams that predate the persisted sidecar FK. The arm is deletable only when run identity becomes a synchronous appended fact — journal spec §3.1. Until then it stays, and the comments that labeled it "legacy fallback" now name the crash-window role as its live justification.

## Net elements (R6)

Deleted:
- `pendingSummaryMeta` map field (+ doc block)
- `adoptPendingSummaryMeta` method and its 2 adoption call sites (`ensureStream`, `appendEntry` first-append path)
- the park branch in `recordSummaryMeta`
- the adoption/discard sweep in `replaceSummaries`
- the antechamber fallback arm in `getSummaryMeta`
- the 2 forget-path deletions (`forgetStreamState`, `forgetAllStreamState`)

Added: one `ensureStream(streamId)` call in `recordSummaryMeta`.

Net: −37 lines (30 insertions / 67 deletions, comments included); one private method, one field, and six special-case sites removed; zero new elements.

## Consumer counts (R8)

- `recordSummaryMeta`: 1 production caller (SessionHandle's `summaryMetaSink` wiring) — unchanged.
- `getSummaryMeta`: 11 production call sites (SessionHandle ×5, ToolUseFollowUp ×1, SessionStores ×2, SessionState ×3) — all now served from `summaries` only; the antechamber-served window is gone because the stream is registered at projection.
- `adoptPendingSummaryMeta`: was private with 3 internal callers; deleted with all of them.
- `ensureStream`: gains 1 internal caller; external surface unchanged.

## Tests

Updated the one test pinning antechamber behavior (`StreamLogStoreLoad.vitest.ts`) to pin the new invariant: an unknown stream is registered at metadata projection. No new test files.

Gates: `npm run typecheck` green; `vitest run src/test-kernel/transcript/ src/test-kernel/agent/runtime/ src/test-kernel/agent/storage/SessionStores.vitest.ts src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts` — 53 files / 862 tests passed; changed-file eslint clean; `git diff --check` clean.

Refs #10858.

🤖 Generated with [Claude Code](https://claude.com/claude-code)