### PR TITLE
refactor(settings): key the tab wire by panel name and drop dead tool surface

### DIFF
--- a/docs/dev/verification.md
+++ b/docs/dev/verification.md
@@ -96,4 +96,4 @@ re-implementing one of these per host, push the new code into
 - Empty state helper: `src/shared/wa/emptyState.ts`
 - Persisted state: `src/shared/state/PersistedState.ts`
 - Host bridge: `src/shared/hostBridge.ts`
-- Settings tabs: `src/shared/schemas/settingsViewMessages.ts` (`SETTINGS_TAB`)
+- Settings tabs: `src/shared/schemas/settingsViewMessages.ts` (`SETTINGS_TAB_ORDER`)

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -82,10 +82,10 @@ import type {
   MainViewExecuteMessage,
   MainViewPersistedState,
   RequestOpenFilePayload,
-  SettingsTab,
+  SettingsTabPanelName,
   StreamTabId,
 } from '@shared/schemas';
-import { INSTRUCTION_ACTION, SETTINGS_TAB } from '@shared/schemas';
+import { INSTRUCTION_ACTION } from '@shared/schemas';
 import { unsupported, unsupportedCommands } from '@shared/utils/dispatcher';
 import {
   formatActiveStreamRetention,
@@ -525,7 +525,7 @@ export class DesktopProgressBridge {
       readKey: (provider) => lookupApiKey(platform().secrets, provider),
       hasUsableKey: (provider) => hasUsableApiKey(platform().secrets, provider),
       promptForApiKey: async () => {
-        this.showSettings(SETTINGS_TAB.MODELS);
+        this.showSettings('models');
         await this.options.host.showInfoMessage(
           'Add a provider API key in Models, then use "Retry" on the request.',
         );
@@ -1068,11 +1068,8 @@ export class DesktopProgressBridge {
    * owner the rail and menu commands use, so a stream-initiated navigation
    * lands identically.
    */
-  private showSettings(tabIndex?: SettingsTab): void {
-    postDesktopSettingsView(
-      (message) => this.postToRenderer(message),
-      tabIndex,
-    );
+  private showSettings(tab?: SettingsTabPanelName): void {
+    postDesktopSettingsView((message) => this.postToRenderer(message), tab);
   }
 
   private handlePresentationEvent<K extends RuntimePresentationEvent>(

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -1,10 +1,9 @@
 import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@shared/ipc';
-import type { MainViewInboundMessage, SettingsTab } from '@shared/schemas';
-import {
-  AgentCategory,
-  MainViewInboundMessageSchema,
-  SETTINGS_TAB,
+import type {
+  MainViewInboundMessage,
+  SettingsTabPanelName,
 } from '@shared/schemas';
+import { AgentCategory, MainViewInboundMessageSchema } from '@shared/schemas';
 import {
   DESKTOP_SHELL_COMMANDS,
   type DesktopLayoutPanel,
@@ -70,10 +69,13 @@ export function createDesktopShellActions(
     });
   }
 
-  function showSettings(tabIndex?: SettingsTab, agentSubTab?: AgentCategory) {
+  function showSettings(
+    tab?: SettingsTabPanelName,
+    agentSubTab?: AgentCategory,
+  ) {
     postDesktopSettingsView(
       (message) => renderer.postToRenderer(message),
-      tabIndex,
+      tab,
       agentSubTab,
     );
   }
@@ -85,7 +87,7 @@ export function createDesktopShellActions(
 
   function openAgentDirectory(customDirSet?: boolean) {
     if (customDirSet !== true) {
-      showSettings(SETTINGS_TAB.AGENTS);
+      showSettings('agents');
       return;
     }
     void openCustomAgentDirectory().catch(reportAsyncError);
@@ -193,24 +195,24 @@ function dispatchMainViewInboundOnShell(
     }
     case MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS:
       actions.showSettings(
-        SETTINGS_TAB.AGENTS,
+        'agents',
         message.sessionType === AgentCategory.ToolUse
           ? AgentCategory.ToolUse
           : undefined,
       );
       return true;
     case MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS:
-      actions.showSettings(SETTINGS_TAB.MODELS);
+      actions.showSettings('models');
       return true;
     case MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER:
       actions.signIn();
       return true;
     case MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY:
     case MAIN_VIEW_COMMANDS.OPEN_SET_PROVIDER_API_KEY:
-      actions.showSettings(SETTINGS_TAB.MODELS);
+      actions.showSettings('models');
       return true;
     case MAIN_VIEW_COMMANDS.OPEN_MULTI_AGENT_SETTINGS:
-      actions.showSettings(SETTINGS_TAB.MULTI_AGENT);
+      actions.showSettings('multi-agent');
       return true;
     case MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY:
       actions.openAgentDirectory(message.customDirSet === true);

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -8,7 +8,6 @@ import '@awesome.me/webawesome/dist/components/input/input.js';
 import { html, nothing, render } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 import type { StreamTabId, StreamTabInfo } from '@shared/schemas';
-import { SETTINGS_TAB } from '@shared/schemas';
 import { formatDesktopAccelerator } from '@shared/commands/accelerators';
 import type { DesktopShortcutEntry } from '@shared/commands/shortcutPreferences';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
@@ -340,7 +339,7 @@ export function createDesktopCommandPalette({
             size="s"
             @click=${() => {
               close();
-              actions.showSettings(SETTINGS_TAB.SHORTCUTS);
+              actions.showSettings('shortcuts');
             }}
           >
             ${waIcon('code', { slot: 'start' })} Customize shortcuts

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -53,11 +53,7 @@ import { COMMON_COMMANDS, PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import '@settingsView/frontend';
 import '@webview/frontend';
 import { hostBridge, postMessage } from '@shared/hostBridge';
-import {
-  SETTINGS_TAB,
-  type StreamTabId,
-  type DesktopThemeKind,
-} from '@shared/schemas';
+import type { StreamTabId, DesktopThemeKind } from '@shared/schemas';
 
 import { Signal } from '@shared/signals';
 import { resolvePostMessageTargetOrigin } from '@shared/postMessageOrigin';
@@ -153,7 +149,7 @@ const startupTeamPanel = createStartupTeamPanel({
   dismiss: () => postMessage(DESKTOP_ONBOARDING_COMMANDS.DISMISS),
   onVisibilityChanged: rerenderShell,
   showLauncher: returnToLauncher,
-  openMultiAgent: () => openSettingsTab(SETTINGS_TAB.MULTI_AGENT),
+  openMultiAgent: () => openSettingsTab('multi-agent'),
 });
 
 // =============================================================================
@@ -1266,13 +1262,13 @@ try {
 type ShowSettingsArgs = Parameters<DesktopCommandActions['showSettings']>;
 
 function openSettingsTab(
-  tabIndex?: ShowSettingsArgs[0],
+  tab?: ShowSettingsArgs[0],
   agentSubTab?: ShowSettingsArgs[1],
 ): void {
   openKind('settings');
-  if (tabIndex == null) return;
+  if (tab == null) return;
   window.postMessage(
-    buildDesktopSettingsTabMessage(tabIndex, agentSubTab),
+    buildDesktopSettingsTabMessage(tab, agentSubTab),
     resolvePostMessageTargetOrigin(window.location.origin),
   );
 }

--- a/packages/desktop/src/shared/desktopCommandSurface.ts
+++ b/packages/desktop/src/shared/desktopCommandSurface.ts
@@ -1,16 +1,20 @@
 import type {
   AgentCategory,
   GettingStartedAction,
-  SettingsTab,
+  SettingsTabPanelName,
   StreamTabId,
 } from '@shared/schemas';
-import { SETTINGS_TAB } from '@shared/schemas';
 import { MAIN_VIEW_COMMANDS, SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   toElectronAccelerator,
   toPlatformAccelerator,
 } from '@shared/commands/accelerators';
-import { commandCatalogById, type CommandId } from '@shared/commands/catalog';
+import {
+  commandCatalogById,
+  settingsTabByCommand,
+  type CommandId,
+  type SettingsTabCommandId,
+} from '@shared/commands/catalog';
 import {
   dispatchCommandFromRegistry,
   type CommandHandler,
@@ -148,7 +152,7 @@ export interface DesktopCommandMenuEntry {
 export interface DesktopCommandActions {
   showLauncher(): void;
   openWorkbench(kind: DesktopWorkbenchKind): void;
-  showSettings(tabIndex?: SettingsTab, agentSubTab?: AgentCategory): void;
+  showSettings(tab?: SettingsTabPanelName, agentSubTab?: AgentCategory): void;
   showStream?(streamId: StreamTabId): void;
   openDesktopDocs(): void;
   openLogFolder(): void;
@@ -163,7 +167,7 @@ export interface DesktopCommandActions {
 
 export interface DesktopSettingsTabMessage {
   command: typeof SETTINGS_VIEW_COMMANDS.SET_TAB;
-  tabIndex: SettingsTab;
+  tab: SettingsTabPanelName;
   agentSubTab?: AgentCategory;
 }
 
@@ -312,14 +316,16 @@ const DESKTOP_COMMAND_HANDLERS = {
   ),
   'texra.showDashboard': action((a) => a.showSettings()),
   'texra.mainView.reset': action((a) => a.resetMainView()),
-  'texra.showMemory': action((a) => a.showSettings(SETTINGS_TAB.MEMORY)),
-  'texra.showModels': action((a) => a.showSettings(SETTINGS_TAB.MODELS)),
-  'texra.showAgents': action((a) => a.showSettings(SETTINGS_TAB.AGENTS)),
-  'texra.showTools': action((a) => a.showSettings(SETTINGS_TAB.TOOLS)),
-  'texra.showMultiAgent': action((a) =>
-    a.showSettings(SETTINGS_TAB.MULTI_AGENT),
-  ),
-  'texra.showGitSettings': action((a) => a.showSettings(SETTINGS_TAB.GIT)),
+  // `texra.show*` rows derived from the catalog's `settingsTab` field
+  // (`settingsTabByCommand`) — same source the extension handler map uses.
+  ...(Object.fromEntries(
+    (
+      Object.entries(settingsTabByCommand) as [
+        SettingsTabCommandId,
+        SettingsTabPanelName,
+      ][]
+    ).map(([id, tab]) => [id, action((a) => a.showSettings(tab))]),
+  ) as Record<SettingsTabCommandId, DesktopCommandHandler>),
   [DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER]: action((a) => a.openLogFolder()),
   [DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER]: action((a) =>
     a.openWorkspaceFolder(),
@@ -363,12 +369,12 @@ function isDesktopLocalCommandId(id: string): id is DesktopLocalCommandId {
 }
 
 export function buildDesktopSettingsTabMessage(
-  tabIndex: SettingsTab,
+  tab: SettingsTabPanelName,
   agentSubTab?: AgentCategory,
 ): DesktopSettingsTabMessage {
   return {
     command: SETTINGS_VIEW_COMMANDS.SET_TAB,
-    tabIndex,
+    tab,
     ...(agentSubTab && { agentSubTab }),
   };
 }
@@ -380,15 +386,15 @@ export function buildDesktopSettingsTabMessage(
  */
 export function postDesktopSettingsView(
   postToRenderer: (message: unknown) => void,
-  tabIndex?: SettingsTab,
+  tab?: SettingsTabPanelName,
   agentSubTab?: AgentCategory,
 ): void {
   postToRenderer({
     command: DESKTOP_SHELL_COMMANDS.OPEN_WORKBENCH,
     kind: 'settings',
   });
-  if (tabIndex == null) return;
-  postToRenderer(buildDesktopSettingsTabMessage(tabIndex, agentSubTab));
+  if (tab == null) return;
+  postToRenderer(buildDesktopSettingsTabMessage(tab, agentSubTab));
 }
 
 export function buildDesktopMainViewResetMessage(): DesktopMainViewResetMessage {

--- a/packages/desktop/tests/e2e/electronApp.ts
+++ b/packages/desktop/tests/e2e/electronApp.ts
@@ -267,34 +267,31 @@ export async function openWorkbench(
 }
 
 /**
- * Route to Settings and activate the tab at `tabIndex`, waiting for the
- * settings-app shadow root to mount so the target panel can be inspected.
- * Pass `panel` (its `data-panel` value) to additionally wait until that page
- * button reports `data-active="true"` — callers that assert on which panel
- * rendered should confirm this instead of racing the previous tab's render.
+ * Route to Settings and activate the tab named `tab` (its wire panel name,
+ * which is also the nav button's `data-panel` value), waiting until that page
+ * button reports `data-active="true"` so callers never race the previous
+ * tab's render.
  */
 export async function setSettingsTab(
   launched: LaunchedApp,
-  tabIndex: number,
-  panel?: string,
+  tab: string,
 ): Promise<void> {
   await openWorkbench(launched, 'settings');
-  await launched.page.evaluate((idx) => {
-    window.postMessage({ command: 'setTab', tabIndex: idx }, '*');
-  }, tabIndex);
+  await launched.page.evaluate((panel) => {
+    window.postMessage({ command: 'setTab', tab: panel }, '*');
+  }, tab);
   await launched.page.waitForFunction(
     (activePanel) => {
       const settingsApp = document.querySelector('settings-app');
       const root = settingsApp?.shadowRoot;
       if (!root) return false;
-      if (activePanel == null) return true;
       return (
         root.querySelector(
           `.settings-page-button[data-panel="${activePanel}"][data-active="true"]`,
         ) != null
       );
     },
-    panel,
+    tab,
     { timeout: 10_000 },
   );
 }

--- a/packages/desktop/tests/e2e/screenshots.spec.ts
+++ b/packages/desktop/tests/e2e/screenshots.spec.ts
@@ -84,7 +84,7 @@ test('launcher screenshot', async ({}, testInfo) => {
 
 test('settings screenshot', async ({}, testInfo) => {
   // Open the Multi-Agent settings page — the most visually rich area.
-  await setSettingsTab(launched, 4, 'multi-agent');
+  await setSettingsTab(launched, 'multi-agent');
   await launched.page.screenshot({
     path: getScreenshotPath(testInfo, 'settings.png'),
     fullPage: false,

--- a/packages/desktop/tests/e2e/settingsPersistence.spec.ts
+++ b/packages/desktop/tests/e2e/settingsPersistence.spec.ts
@@ -16,10 +16,6 @@ import {
   findWorkspaceStoragePath,
 } from './workspaceStorageFixture.js';
 
-const SETTINGS_TAB_INDEX = {
-  MEMORY: 0,
-} as const;
-
 const MEMORY_FILE_NAME = 'playwright-relaunch-memory.md';
 const MEMORY_DISPLAY_PATH = `/memories/${MEMORY_FILE_NAME}`;
 const MEMORY_PREVIEW_TEXT =
@@ -116,7 +112,7 @@ async function waitForMemoryEntry(launched: LaunchedApp): Promise<void> {
 }
 
 async function verifyMemoryEntryIsListed(launched: LaunchedApp): Promise<void> {
-  await setSettingsTab(launched, SETTINGS_TAB_INDEX.MEMORY);
+  await setSettingsTab(launched, 'memory');
   await sendHostCommand(launched, { command: 'getMemoryData' });
   await waitForMemoryEntry(launched);
 }

--- a/packages/desktop/tests/e2e/trajectories.spec.ts
+++ b/packages/desktop/tests/e2e/trajectories.spec.ts
@@ -22,19 +22,6 @@ import {
  * a regression guard for the trajectory itself, not the full feature.
  */
 
-// SETTINGS_TAB indices (mirror of `src/shared/schemas/settingsViewMessages.ts`
-// `SETTINGS_TAB_ORDER`). Inlined for the same reason as in screenshots.spec.ts:
-// the Playwright ESM loader trips over the schema import.
-const SETTINGS_TAB_INDEX = {
-  MEMORY: 0,
-  MODELS: 1,
-  AGENTS: 2,
-  MULTI_AGENT: 3,
-  TOOLS: 4,
-  LATEX: 7,
-  ACCOUNT: 9,
-} as const;
-
 let launched: LaunchedApp;
 
 test.beforeAll(async () => {
@@ -96,7 +83,7 @@ test('first launch shows a usable launcher chrome', async () => {
 test('settings → models tab mounts and provider settings are reachable', async () => {
   // Confirm the Models panel actually activated; without this we may catch
   // the previous tab's render and report a false positive.
-  await setSettingsTab(launched, SETTINGS_TAB_INDEX.MODELS, 'models');
+  await setSettingsTab(launched, 'models');
   // Sanity: the panel mounted its child custom element. The provider list lives
   // another shadow root deep, so structural presence is sufficient here.
   const panelHasChild = await launched.page.evaluate(() => {
@@ -107,7 +94,7 @@ test('settings → models tab mounts and provider settings are reachable', async
 });
 
 test('account and usage lives in its own settings panel', async () => {
-  await setSettingsTab(launched, SETTINGS_TAB_INDEX.ACCOUNT, 'account');
+  await setSettingsTab(launched, 'account');
 
   const structure = await launched.page.evaluate(() => {
     const root = document.querySelector('settings-app')?.shadowRoot;
@@ -130,7 +117,7 @@ test('account and usage lives in its own settings panel', async () => {
  * the desktop app on a shared Electron user-data directory.
  */
 test('settings → memory tab mounts', async () => {
-  await setSettingsTab(launched, SETTINGS_TAB_INDEX.MEMORY, 'memory');
+  await setSettingsTab(launched, 'memory');
 });
 
 /**
@@ -198,7 +185,7 @@ test('logs workbench renders the desktop log viewer', async () => {
  * surfaces a copy-the-command dialog rather than running it for the user).
  */
 test('settings → tools tab mounts', async () => {
-  await setSettingsTab(launched, SETTINGS_TAB_INDEX.TOOLS, 'tools');
+  await setSettingsTab(launched, 'tools');
 });
 
 /**
@@ -208,14 +195,14 @@ test('settings → tools tab mounts', async () => {
  * covering it cheaply is worth the few hundred ms.
  */
 test('rapid settings-tab switching does not crash the renderer', async () => {
-  for (const idx of [
-    SETTINGS_TAB_INDEX.MEMORY,
-    SETTINGS_TAB_INDEX.MODELS,
-    SETTINGS_TAB_INDEX.AGENTS,
-    SETTINGS_TAB_INDEX.MULTI_AGENT,
-    SETTINGS_TAB_INDEX.LATEX,
-  ]) {
-    await setSettingsTab(launched, idx);
+  for (const tab of [
+    'memory',
+    'models',
+    'agents',
+    'multi-agent',
+    'latex',
+  ] as const) {
+    await setSettingsTab(launched, tab);
   }
   // The chrome must still be alive after the burst.
   await expect(

--- a/packages/desktop/tests/e2e/verify-fixes.spec.ts
+++ b/packages/desktop/tests/e2e/verify-fixes.spec.ts
@@ -13,13 +13,10 @@ import {
 // resolve a relative .js import of a TS file under src/shared (see
 // packages/desktop/tests/e2e/README.md § Cross-package imports;
 // settingsPersistence.spec.ts does the same). Source of truth:
-// SETTINGS_VIEW_CMD.SET_TAB in src/shared/ipc.ts; SETTINGS_TAB_INDEX.TOOLS
-// (index of 'TOOLS' in SETTINGS_TAB_ORDER) in
+// SETTINGS_VIEW_CMD.SET_TAB in src/shared/ipc.ts; the panel name is the
+// `SettingsTabPanelName` wire value from
 // src/shared/schemas/settingsViewMessages.ts.
 const SET_TAB_COMMAND = 'setTab';
-const SETTINGS_TAB_INDEX = {
-  TOOLS: 4,
-} as const;
 
 let launched: LaunchedApp;
 
@@ -147,12 +144,12 @@ test('command palette keeps each icon and label in one compact row', async ({}, 
 test('settings workbench scrolls (Tools tab top + bottom)', async ({}, testInfo) => {
   await openWorkbench(launched, 'settings');
   await launched.page.evaluate(
-    ({ command, tabIndex }) => {
-      window.postMessage({ command, tabIndex }, '*');
+    ({ command, tab }) => {
+      window.postMessage({ command, tab }, '*');
     },
     {
       command: SET_TAB_COMMAND,
-      tabIndex: SETTINGS_TAB_INDEX.TOOLS,
+      tab: 'tools',
     },
   );
   // Wait for the Tools page to be marked active AND its content to have

--- a/packages/desktop/tests/e2e/workspaceTabs.spec.ts
+++ b/packages/desktop/tests/e2e/workspaceTabs.spec.ts
@@ -493,7 +493,7 @@ test('loads tools, centers every compact nav icon, and customizes shortcuts', as
     .toBeLessThanOrEqual(520);
 
   await page.evaluate(() => {
-    window.postMessage({ command: 'setTab', tabIndex: 4 }, '*');
+    window.postMessage({ command: 'setTab', tab: 'tools' }, '*');
   });
   await expect(page.locator('tools-tab tool-card').first()).toBeVisible({
     timeout: 5_000,
@@ -531,7 +531,7 @@ test('loads tools, centers every compact nav icon, and customizes shortcuts', as
   }
 
   await page.evaluate(() => {
-    window.postMessage({ command: 'setTab', tabIndex: 10 }, '*');
+    window.postMessage({ command: 'setTab', tab: 'shortcuts' }, '*');
   });
   const shortcuts = page.locator('shortcuts-tab');
   await expect(
@@ -568,8 +568,8 @@ test('keeps settings banners consistent in a narrow side panel', async () => {
   // Memory/Models/Teams/Goals pages dropped theirs in the native-settings
   // consolidation, so they are no longer part of this consistency check.
   const bannerTabs = [
-    { index: 10, tag: 'account-tab' },
-    { index: 11, tag: 'shortcuts-tab' },
+    { tab: 'account', tag: 'account-tab' },
+    { tab: 'shortcuts', tag: 'shortcuts-tab' },
   ] as const;
   const bannerMetrics: Array<{
     readonly borderRadius: string;
@@ -580,9 +580,9 @@ test('keeps settings banners consistent in a narrow side panel', async () => {
 
   await openSidebarWorkbench('Settings');
   for (const tab of bannerTabs) {
-    await page.evaluate((tabIndex) => {
-      window.postMessage({ command: 'setTab', tabIndex }, '*');
-    }, tab.index);
+    await page.evaluate((panel) => {
+      window.postMessage({ command: 'setTab', tab: panel }, '*');
+    }, tab.tab);
 
     const banner = page.locator(`${tab.tag} .settings-banner`).first();
     await expect(banner).toBeVisible();

--- a/packages/extension/src/commands/extensionCommandHandlers.ts
+++ b/packages/extension/src/commands/extensionCommandHandlers.ts
@@ -17,16 +17,20 @@ import type {
   AcceptCopyMeta,
   AgentCategory,
   FileLocation,
-  SettingsTab,
+  SettingsTabPanelName,
 } from '@shared/schemas';
 import {
   AcceptCopyMetaSchema,
   AgentCategorySchema,
   FileLocationSchema,
-  SETTINGS_TAB,
+  SETTINGS_TAB_PANEL_BY_NAME,
   StreamTabIdSchema,
 } from '@shared/schemas';
-import { commandCatalog } from '@shared/commands/catalog';
+import {
+  commandCatalog,
+  settingsTabByCommand,
+  type SettingsTabCommandId,
+} from '@shared/commands/catalog';
 import {
   awaitTrue,
   definedHandler,
@@ -154,7 +158,7 @@ export const EXTENSION_REGISTRY_CATALOG_COMMAND_IDS: readonly ExtensionRegistryC
  */
 export interface ExtensionCommandActions {
   showSettings(
-    tabIndex?: SettingsTab,
+    tab?: SettingsTabPanelName,
     agentSubTab?: AgentCategory,
   ): Promise<void>;
   resetMainView(): Promise<void>;
@@ -215,18 +219,30 @@ export interface ExtensionCommandActions {
   execute(input: unknown): Promise<void>;
 }
 
+/**
+ * `texra.show*` rows derived from the catalog's `settingsTab` field so the
+ * command → tab mapping lives in one place (`settingsTabByCommand`).
+ * `texra.showAgents` is re-declared below: it additionally accepts an
+ * agent-category sub-tab argument.
+ */
+const SETTINGS_TAB_COMMAND_HANDLERS = Object.fromEntries(
+  (
+    Object.entries(settingsTabByCommand) as [
+      SettingsTabCommandId,
+      SettingsTabPanelName,
+    ][]
+  ).map(([id, tab]) => [
+    id,
+    (actions: ExtensionCommandActions) => awaitTrue(actions.showSettings(tab)),
+  ]),
+) as Record<
+  SettingsTabCommandId,
+  (actions: ExtensionCommandActions) => Promise<boolean>
+>;
+
 export const EXTENSION_COMMAND_HANDLERS = {
+  ...SETTINGS_TAB_COMMAND_HANDLERS,
   'texra.showDashboard': (actions) => awaitTrue(actions.showSettings()),
-  'texra.showMemory': (actions) =>
-    awaitTrue(actions.showSettings(SETTINGS_TAB.MEMORY)),
-  'texra.showModels': (actions) =>
-    awaitTrue(actions.showSettings(SETTINGS_TAB.MODELS)),
-  'texra.showTools': (actions) =>
-    awaitTrue(actions.showSettings(SETTINGS_TAB.TOOLS)),
-  'texra.showMultiAgent': (actions) =>
-    awaitTrue(actions.showSettings(SETTINGS_TAB.MULTI_AGENT)),
-  'texra.showGitSettings': (actions) =>
-    awaitTrue(actions.showSettings(SETTINGS_TAB.GIT)),
   'texra.mainView.reset': (actions) => awaitTrue(actions.resetMainView()),
   'texra.cleanOutput': (actions) => awaitTrue(actions.cleanOutput()),
   'texra.cleanBuild': (actions) => awaitTrue(actions.cleanBuild()),
@@ -292,7 +308,7 @@ export const EXTENSION_COMMAND_HANDLERS = {
   'texra.auth.grok.signIn': (actions) => awaitTrue(actions.signInGrok()),
   'texra.auth.signOut': (actions) => awaitTrue(actions.signOut()),
   'texra.auth.viewProfile': (actions) =>
-    awaitTrue(actions.showSettings(SETTINGS_TAB.ACCOUNT)),
+    awaitTrue(actions.showSettings(SETTINGS_TAB_PANEL_BY_NAME.ACCOUNT)),
   [EXTENSION_COMMANDS.RUN_SETUP_ASSISTANT]: (actions) =>
     awaitTrue(actions.runSetupAssistant()),
   [EXTENSION_COMMANDS.OPEN_GETTING_STARTED]: (actions) =>
@@ -352,7 +368,9 @@ export const EXTENSION_COMMAND_HANDLERS = {
   'texra.showAgents': definedHandler(
     ShowAgentsArgsSchema,
     (actions: ExtensionCommandActions, subTab?: AgentCategory) =>
-      awaitTrue(actions.showSettings(SETTINGS_TAB.AGENTS, subTab)),
+      awaitTrue(
+        actions.showSettings(settingsTabByCommand['texra.showAgents'], subTab),
+      ),
   ),
 } as const satisfies Record<
   ExtensionRegistryCommandId,

--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -73,8 +73,8 @@ export function createExtensionCommandActions(
     settingsViewProvider.refreshAfterProviderKeyChange(provider);
 
   return {
-    showSettings(tabIndex, agentSubTab) {
-      return settingsViewProvider.showSettingsView(tabIndex, agentSubTab);
+    showSettings(tab, agentSubTab) {
+      return settingsViewProvider.showSettingsView(tab, agentSubTab);
     },
     async resetMainView() {
       const webviewView = await getMainWebview(RESET_CHANNEL);

--- a/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
@@ -14,22 +14,16 @@ const MIN_SCROLLBACK = 4_000;
 const MAX_VISIBLE_ROWS = 20;
 
 /**
- * Events that signal an ancestor disclosure container revealed this terminal,
- * so it should refit to its now-visible container. Covers both the legacy
- * native `<details>` `toggle` event (still emitted by any un-migrated
- * surface) and Web Awesome's `<wa-details>`, which is not a `<details>` and
- * never fires `toggle` — it dispatches `wa-show` synchronously when it starts
- * opening and `wa-after-show` once its reveal animation finishes. Listening
- * to both wa-details events covers the immediate-open case (matching the old
- * un-animated native-toggle timing) and the post-animation case (accurate
- * final layout for the fit-addon column/row calculation).
+ * Events that signal the ancestor `<wa-details>` disclosure revealed this
+ * terminal, so it should refit to its now-visible container. `wa-show` fires
+ * synchronously when the disclosure starts opening (immediate-open case) and
+ * `wa-after-show` once its reveal animation finishes (accurate final layout
+ * for the fit-addon column/row calculation).
  */
-const TERMINAL_REFIT_EVENTS = ['toggle', 'wa-show', 'wa-after-show'] as const;
+const TERMINAL_REFIT_EVENTS = ['wa-show', 'wa-after-show'] as const;
 
-/** Ancestor selector for the ancestor disclosure container, matching both
- * the Web Awesome `<wa-details>` custom element and any un-migrated native
- * `<details>` surface. */
-const DETAILS_ANCESTOR_SELECTOR = 'wa-details, details';
+/** Ancestor selector for the `<wa-details>` disclosure container. */
+const DETAILS_ANCESTOR_SELECTOR = 'wa-details';
 
 interface TerminalTextUpdatePlan {
   reset: boolean;

--- a/packages/extension/src/settingsView/SettingsViewProvider.ts
+++ b/packages/extension/src/settingsView/SettingsViewProvider.ts
@@ -12,7 +12,7 @@ import {
   runAfterAgentCatalogAuthRefresh,
 } from '@frontend/auth/agentCatalogRefreshScope';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import type { AgentCategory, SettingsTab } from '@shared/schemas';
+import type { AgentCategory, SettingsTabPanelName } from '@shared/schemas';
 
 // Local file imports
 import { SettingsViewMessageHandler } from './SettingsViewMessageHandler';
@@ -58,11 +58,11 @@ export class SettingsViewProvider extends BaseWebviewProvider {
 
   /**
    * Create and show the webview panel (for command palette activation)
-   * @param tabIndex Optional tab to switch to after showing
+   * @param tab Optional panel name to switch to after showing
    * @param agentSubTab Optional sub-tab for the agents tab ('workflow' | 'toolUse')
    */
   public async showSettingsView(
-    tabIndex?: SettingsTab,
+    tab?: SettingsTabPanelName,
     agentSubTab?: AgentCategory,
   ): Promise<void> {
     const isNew = this.createOrShowPanel({
@@ -76,10 +76,10 @@ export class SettingsViewProvider extends BaseWebviewProvider {
       await this.messageHandler.sendAllData(this._view.webview);
     }
 
-    if (tabIndex != null && this._view) {
+    if (tab != null && this._view) {
       await this._view.webview.postMessage({
         command: SETTINGS_VIEW_COMMANDS.SET_TAB,
-        tabIndex,
+        tab,
         ...(agentSubTab && { agentSubTab }),
       });
     }

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -19,9 +19,7 @@ import { commonViewStyles, designTokens } from '@shared/styles';
 // Local imports - shared schemas and constants
 import {
   dispatchSettingsViewOutbound,
-  SETTINGS_TAB,
   SETTINGS_TAB_PANEL_BY_NAME,
-  SETTINGS_TAB_PANEL_NAMES,
   type SettingsTabPanelName,
   type SettingsViewOutboundHandlerRegistry,
 } from '@shared/schemas';
@@ -108,7 +106,7 @@ import {
   quotaAutoSwitched,
   reliabilitySettings,
   resetSettingsState,
-  selectedTabIndex,
+  selectedPanel,
   sessionProblem,
   spendingStatus,
   spendingStatusError,
@@ -195,9 +193,7 @@ export class SettingsApp extends SettingsAppBase {
   }
 
   private selectSettingsEntry(entry: SettingsNavEntry): void {
-    const selectedIndex = SETTINGS_TAB_PANEL_NAMES.indexOf(entry.panel);
-    if (selectedIndex < 0) return;
-    selectedTabIndex.set(selectedIndex);
+    selectedPanel.set(entry.panel);
     requestAnimationFrame(() => {
       const panel =
         this.shadowRoot?.querySelector<HTMLElement>('.settings-panel');
@@ -244,7 +240,7 @@ export class SettingsApp extends SettingsAppBase {
   };
 
   private handleManageProviderKeys(): void {
-    selectedTabIndex.set(SETTINGS_TAB.MODELS);
+    selectedPanel.set(SETTINGS_TAB_PANEL_BY_NAME.MODELS);
   }
 
   private renderProviderKeyModal(): TemplateResult | typeof nothing {
@@ -517,9 +513,7 @@ export class SettingsApp extends SettingsAppBase {
       unsupportedCommands.get(),
       SETTINGS_VIEW_COMMANDS.GET_GOAL_LIST,
     );
-    const requestedPanel =
-      SETTINGS_TAB_PANEL_NAMES[selectedTabIndex.get()] ??
-      SETTINGS_TAB_PANEL_BY_NAME.ACCOUNT;
+    const requestedPanel = selectedPanel.get();
     const activePanel =
       !desktopHost && requestedPanel === SETTINGS_TAB_PANEL_BY_NAME.SHORTCUTS
         ? SETTINGS_TAB_PANEL_BY_NAME.ACCOUNT

--- a/packages/extension/src/settingsView/frontend/settingsNav.ts
+++ b/packages/extension/src/settingsView/frontend/settingsNav.ts
@@ -1,11 +1,7 @@
 /**
- * Settings top-navigation presentation layer.
- *
- * Deliberately separate from the tab wire format. `SETTINGS_TAB_ORDER` fixes
- * the indices that travel over IPC (`SET_TAB.tabIndex`) and are hand-copied
- * into the desktop e2e index tables, so nav grouping, nav order, labels, and
- * icons live here and address panels by name. Reordering or regrouping the nav
- * therefore cannot change what an existing index means.
+ * Settings top-navigation presentation layer: nav grouping, nav order, labels,
+ * and icons. Panels are addressed by name — the same panel name that travels
+ * over IPC as `SET_TAB.tab`.
  */
 
 import {

--- a/packages/extension/src/settingsView/frontend/settingsState.ts
+++ b/packages/extension/src/settingsView/frontend/settingsState.ts
@@ -70,8 +70,9 @@ import {
   DEFAULT_LATEX_SETTINGS_STATUS,
   DEFAULT_QUOTA_AUTO_SWITCHED,
   DEFAULT_TOOL_PATH_PROTECTION_ENABLED,
-  SETTINGS_TAB,
+  SETTINGS_TAB_PANEL_BY_NAME,
 } from '@shared/schemas';
+import type { SettingsTabPanelName } from '@shared/schemas';
 import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 
 /** Target for the desktop-host "set provider key" modal. */
@@ -103,14 +104,11 @@ const { trackedSignal, resetAll: resetTrackedSignals } =
 // ---------------------------------------------------------------------------
 /**
  * Opening panel when the host asks for the settings view without naming a tab.
- *
- * Named, not `0`: SETTINGS_TAB_ORDER is an append-only wire format, so index 0
- * means whichever panel happened to be added first (MEMORY) rather than
- * anything intended. Account is also the first nav group, so this matches what
- * the nav already presents as the entry point.
+ * Account is the first nav group, so this matches what the nav already
+ * presents as the entry point.
  */
-export const selectedTabIndex = trackedSignal<number>(
-  () => SETTINGS_TAB.ACCOUNT,
+export const selectedPanel = trackedSignal<SettingsTabPanelName>(
+  () => SETTINGS_TAB_PANEL_BY_NAME.ACCOUNT,
 );
 
 // ---------------------------------------------------------------------------

--- a/packages/extension/src/settingsView/frontend/slices/tabSlice.ts
+++ b/packages/extension/src/settingsView/frontend/slices/tabSlice.ts
@@ -10,13 +10,13 @@ import type { SettingsViewOutboundHandlerRegistry } from '@shared/schemas';
 
 import {
   agentSubTab,
-  selectedTabIndex,
+  selectedPanel,
   unsupportedCommands,
 } from '../settingsState';
 
 export const tabHandlers = {
   [SETTINGS_VIEW_COMMANDS.SET_TAB]: (data) => {
-    selectedTabIndex.set(data.tabIndex);
+    selectedPanel.set(data.tab);
     agentSubTab.set(data.agentSubTab);
   },
   [SETTINGS_VIEW_COMMANDS.SET_UNSUPPORTED_COMMANDS]: (data) => {

--- a/packages/extension/src/settingsView/frontend/tabs/SubscriptionsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/SubscriptionsTab.ts
@@ -16,7 +16,7 @@ import { CODING_PLAN_SUBSCRIPTIONS } from '@shared/codingPlanSubscriptions';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { postMessage } from '@shared/hostBridge';
 import {
-  SETTINGS_TAB,
+  SETTINGS_TAB_PANEL_BY_NAME,
   type ChatGptAuthStatus,
   type CopilotRouteInfo,
   type GrokAuthStatus,
@@ -191,7 +191,7 @@ export class SubscriptionsTab extends LitElement {
                 appearance: 'outlined',
                 onClick: () =>
                   postMessage(SETTINGS_VIEW_COMMANDS.SET_TAB, {
-                    tabIndex: SETTINGS_TAB.MODELS,
+                    tab: SETTINGS_TAB_PANEL_BY_NAME.MODELS,
                   }),
               })}
             </div>

--- a/scripts/capture-walkthrough-media.mjs
+++ b/scripts/capture-walkthrough-media.mjs
@@ -190,7 +190,7 @@ const webviewViews = [
       ),
     },
     messages: [
-      { command: 'setTab', tabIndex: 1 },
+      { command: 'setTab', tab: 'models' },
       {
         command: 'updateProfile',
         authenticated: false,

--- a/src/agent/modelHandlers/support/priceUtils.ts
+++ b/src/agent/modelHandlers/support/priceUtils.ts
@@ -35,7 +35,7 @@ export interface LongContextPricingTier {
   outputPrice: number;
 }
 
-export interface StandardPriceTokens {
+interface StandardPriceTokens {
   inputTokens: number;
   outputTokens: number;
   /**

--- a/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
+++ b/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
@@ -51,7 +51,7 @@ import { formatToolResultTextWithAttachments } from '../utils/toolAttachmentUtil
 
 type VscodeLmUsage = undefined;
 
-export interface VscodeLmResponse {
+interface VscodeLmResponse {
   readonly text: string;
   readonly toolCalls: readonly LanguageModelToolCallPart[];
   readonly usage: VscodeLmUsage;

--- a/src/shared/commands/catalog.ts
+++ b/src/shared/commands/catalog.ts
@@ -1,3 +1,5 @@
+import type { SettingsTabPanelName } from '../schemas/settingsViewMessages';
+
 export interface CommandKeybinding {
   key: string;
   mac?: string;
@@ -12,6 +14,13 @@ export interface CommandCatalogEntry {
   icon?: string;
   enablement?: string;
   keybinding?: CommandKeybinding;
+  /**
+   * Settings panel this command opens. Single source of truth for the
+   * command → settings-tab mapping: both hosts derive their `showSettings`
+   * handler rows from {@link settingsTabByCommand} instead of hand-mirroring
+   * the tab per host.
+   */
+  settingsTab?: SettingsTabPanelName;
   /**
    * Set on entries whose VS Code extension registration goes through the
    * shared `dispatchCommandFromRegistry` handler map (see
@@ -232,6 +241,7 @@ export const commandCatalog = [
     title: 'Show Memory',
     category: 'TeXRA',
     icon: '$(database)',
+    settingsTab: 'memory',
   },
   {
     id: 'texra.showModels',
@@ -239,6 +249,7 @@ export const commandCatalog = [
     title: 'Show Models',
     category: 'TeXRA',
     icon: '$(hubot)',
+    settingsTab: 'models',
   },
   {
     id: 'texra.showAgents',
@@ -246,6 +257,7 @@ export const commandCatalog = [
     title: 'Show Agents',
     category: 'TeXRA',
     icon: '$(symbol-method)',
+    settingsTab: 'agents',
   },
   {
     id: 'texra.showTools',
@@ -253,6 +265,7 @@ export const commandCatalog = [
     title: 'Show Tool Dashboard',
     category: 'TeXRA',
     icon: '$(tools)',
+    settingsTab: 'tools',
   },
   {
     id: 'texra.showMultiAgent',
@@ -260,6 +273,7 @@ export const commandCatalog = [
     title: 'Show Multi-Agent Settings',
     category: 'TeXRA',
     icon: '$(organization)',
+    settingsTab: 'multi-agent',
   },
   {
     id: 'texra.showGitSettings',
@@ -267,6 +281,7 @@ export const commandCatalog = [
     title: 'Show Git Settings',
     category: 'TeXRA',
     icon: '$(git-branch)',
+    settingsTab: 'git',
   },
   {
     id: 'texra.showMainView',
@@ -424,6 +439,22 @@ export const packageCommandContributions: PackageCommandContribution[] = (
 export const commandCatalogById = new Map<CommandId, CommandCatalogEntry>(
   commandCatalog.map((entry) => [entry.id, entry]),
 );
+
+/** Ids of the catalog entries that open the settings view on a specific tab. */
+export type SettingsTabCommandId = Extract<
+  (typeof commandCatalog)[number],
+  { settingsTab: SettingsTabPanelName }
+>['id'];
+
+/**
+ * Command → settings panel, derived from the `settingsTab` catalog field.
+ * Both hosts build their `showSettings` handler rows from this map.
+ */
+export const settingsTabByCommand = Object.fromEntries(
+  commandCatalog.flatMap((entry) =>
+    'settingsTab' in entry ? [[entry.id, entry.settingsTab]] : [],
+  ),
+) as Record<SettingsTabCommandId, SettingsTabPanelName>;
 
 const commandKeybindingOrder = [
   'texra.showMainView',

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -106,13 +106,11 @@ export type {
 } from './agentCliSettings';
 
 /**
- * Tab name order — single source of truth for tab indices, and a wire format:
- * `SETTINGS_TAB.X` indices travel over IPC (`SET_TAB.tabIndex`) and are
- * hand-copied as integer tables in the desktop e2e specs and the walkthrough
- * capture script.
- *
- * New entries append at the end. Retired internal panels are removed together
- * with their producers and command surfaces so no stale IPC target remains.
+ * The set of settings tabs — single source of truth for tab names. The wire
+ * format is the derived panel name (`SET_TAB.tab`), so order carries no
+ * meaning beyond stable iteration. Retired internal panels are removed
+ * together with their producers and command surfaces so no stale IPC target
+ * remains.
  */
 export const SETTINGS_TAB_ORDER = [
   'MEMORY',
@@ -167,24 +165,11 @@ export const SETTINGS_TAB_PANEL_BY_NAME = Object.fromEntries(
 export const SETTINGS_TAB_PANEL_NAMES: readonly SettingsTabPanelName[] =
   SETTINGS_TAB_ORDER.map((name) => SETTINGS_TAB_PANEL_BY_NAME[name]);
 
-/** Tab indices derived from ordered array */
-export const SETTINGS_TAB = Object.fromEntries(
-  SETTINGS_TAB_ORDER.map((name, index) => [name, index]),
-) as Record<SettingsTabName, number>;
-
-export type SettingsTab = (typeof SETTINGS_TAB)[keyof typeof SETTINGS_TAB];
-
 /**
- * Presentation-only grouping for the settings top navigation.
- *
- * Deliberately a second, independent layer: `SETTINGS_TAB_ORDER` is the wire
- * format (indices cross IPC and are hand-copied into e2e index tables), so nav
- * grouping and nav display order must never be expressed by reordering it.
- * Groups address panels by `SettingsTabName`, which the nav renders as the
- * panel name (`SETTINGS_TAB_PANEL_BY_NAME`) and `SettingsApp.handleTabShow`
- * resolves back to an index via `SETTINGS_TAB_PANEL_NAMES.indexOf(...)` — so
- * regrouping or reordering the nav changes no index and no `SETTINGS_TAB.X`
- * call site.
+ * Presentation-only grouping for the settings top navigation. Groups address
+ * panels by `SettingsTabName`, which the nav renders as the panel name
+ * (`SETTINGS_TAB_PANEL_BY_NAME`) — the same name that travels over IPC as
+ * `SET_TAB.tab`.
  *
  * Every tab must appear in exactly one group, or its panel becomes unreachable
  * from the nav while still being a valid IPC target. `SharedSchemas.vitest.ts`
@@ -203,13 +188,10 @@ export const SETTINGS_TAB_GROUPS = [
   tabs: readonly SettingsTabName[];
 }[];
 
-/** Outbound schema to switch tabs */
+/** Outbound schema to switch tabs, addressed by panel name. */
 const SetTabMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.SET_TAB),
-  tabIndex: z
-    .int()
-    .min(0)
-    .max(SETTINGS_TAB_ORDER.length - 1),
+  tab: z.enum(SETTINGS_TAB_PANEL_NAMES),
   agentSubTab: AgentCategorySchema.optional(),
 });
 

--- a/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
+++ b/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
@@ -9,7 +9,6 @@ import {
   type ExtensionCommandActions,
   type ExtensionRegistryCommandId,
 } from '@commands/extensionCommandHandlers';
-import { SETTINGS_TAB } from '@shared/schemas';
 import {
   commandCatalog,
   type CommandCatalogEntry,
@@ -154,17 +153,13 @@ describe('extension command surface — catalog-tagged command dispatch', () => 
     await expect(dispatch(actions, 'texra.auth.viewProfile')).resolves.toBe(
       true,
     );
-    expect(actions.showSettings).toHaveBeenCalledExactlyOnceWith(
-      SETTINGS_TAB.ACCOUNT,
-    );
+    expect(actions.showSettings).toHaveBeenCalledExactlyOnceWith('account');
   });
 
-  it('texra.showMemory passes the memory tab index', async () => {
+  it('texra.showMemory passes the memory panel name', async () => {
     const actions = makeActions();
     await expect(dispatch(actions, 'texra.showMemory')).resolves.toBe(true);
-    expect(actions.showSettings).toHaveBeenCalledExactlyOnceWith(
-      SETTINGS_TAB.MEMORY,
-    );
+    expect(actions.showSettings).toHaveBeenCalledExactlyOnceWith('memory');
   });
 
   it('texra.showAgents forwards parsed agent-category sub-tab', async () => {
@@ -173,7 +168,7 @@ describe('extension command surface — catalog-tagged command dispatch', () => 
       dispatch(actions, 'texra.showAgents', 'toolUse'),
     ).resolves.toBe(true);
     expect(actions.showSettings).toHaveBeenCalledExactlyOnceWith(
-      SETTINGS_TAB.AGENTS,
+      'agents',
       'toolUse',
     );
   });
@@ -182,7 +177,7 @@ describe('extension command surface — catalog-tagged command dispatch', () => 
     const actions = makeActions();
     await expect(dispatch(actions, 'texra.showAgents')).resolves.toBe(true);
     expect(actions.showSettings).toHaveBeenCalledExactlyOnceWith(
-      SETTINGS_TAB.AGENTS,
+      'agents',
       undefined,
     );
   });

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.ts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - shared schemas
-import { AgentCategory, SETTINGS_TAB } from '@shared/schemas';
+import { AgentCategory } from '@shared/schemas';
 import { delay } from '@utils/core';
 
 // Local imports - test DOM utilities
@@ -20,7 +20,7 @@ interface DesktopCommandPaletteModule {
     actions: {
       showLauncher(): void;
       openWorkbench(kind: 'settings' | 'logs'): void;
-      showSettings(tabIndex?: number): void;
+      showSettings(tab?: string): void;
       showStream?(streamId: string): void;
     };
     getStreams?: () => DesktopPaletteStream[];
@@ -198,7 +198,7 @@ describe('desktop command palette', () => {
     pressKey(paletteInput(controller.element), { key: 'Enter' });
     await flushDialogTicks();
 
-    expect(actions.showSettings).toHaveBeenCalledWith(SETTINGS_TAB.MODELS);
+    expect(actions.showSettings).toHaveBeenCalledWith('models');
     expect(controller.element.open).toBe(false);
   });
 

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.ts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.ts
@@ -8,7 +8,6 @@ import type {
 } from '@desktop/shared/desktopCommandSurface';
 
 // Local imports - command catalog and shared schemas
-import { SETTINGS_TAB } from '@shared/schemas';
 import {
   formatDesktopAccelerator,
   toElectronAccelerator,
@@ -35,12 +34,12 @@ const DESKTOP_DISPATCH_CASES: ReadonlyArray<
   ['texra.desktop.toggleBottomBar', 'toggleBottomBar', []],
   ['texra.desktop.toggleSidePanel', 'toggleSidePanel', []],
   ['texra.desktop.toggleSummaryBar', 'toggleSummaryBar', []],
-  ['texra.showMemory', 'showSettings', [SETTINGS_TAB.MEMORY]],
-  ['texra.showModels', 'showSettings', [SETTINGS_TAB.MODELS]],
-  ['texra.showAgents', 'showSettings', [SETTINGS_TAB.AGENTS]],
-  ['texra.showTools', 'showSettings', [SETTINGS_TAB.TOOLS]],
-  ['texra.showMultiAgent', 'showSettings', [SETTINGS_TAB.MULTI_AGENT]],
-  ['texra.showGitSettings', 'showSettings', [SETTINGS_TAB.GIT]],
+  ['texra.showMemory', 'showSettings', ['memory']],
+  ['texra.showModels', 'showSettings', ['models']],
+  ['texra.showAgents', 'showSettings', ['agents']],
+  ['texra.showTools', 'showSettings', ['tools']],
+  ['texra.showMultiAgent', 'showSettings', ['multi-agent']],
+  ['texra.showGitSettings', 'showSettings', ['git']],
   ['texra.desktop.openWorkspaceFolder', 'openWorkspaceFolder', []],
   ['texra.desktop.saveFile', 'saveFile', []],
   ['texra.desktop.openLogFolder', 'openLogFolder', []],
@@ -264,7 +263,7 @@ describe('desktop command surface', () => {
     launcherItem?.click?.();
     modelsItem?.click?.();
     expect(actions.showLauncher).toHaveBeenCalledOnce();
-    expect(actions.showSettings).toHaveBeenCalledWith(SETTINGS_TAB.MODELS);
+    expect(actions.showSettings).toHaveBeenCalledWith('models');
 
     const helpMenu = menu.find((item) => item.label === 'Help');
     const helpSubmenu = helpMenu?.submenu ?? [];

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.ts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.ts
@@ -5,7 +5,7 @@ import {
   MAIN_VIEW_COMMANDS,
   SETTINGS_VIEW_COMMANDS,
 } from '@shared/ipc';
-import { AgentCategory, SETTINGS_TAB } from '@shared/schemas';
+import { AgentCategory } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { FakeStateStore } from '@test/support/FakePlatform';
 import { createModuleMocks } from '@test/support/moduleMocks';
@@ -201,7 +201,7 @@ describe('desktop IPC adapters', () => {
     });
     expect(postToRenderer).toHaveBeenNthCalledWith(3, {
       command: SETTINGS_VIEW_COMMANDS.SET_TAB,
-      tabIndex: SETTINGS_TAB.MODELS,
+      tab: 'models',
     });
     expect(postToRenderer).toHaveBeenNthCalledWith(4, {
       command: 'desktop:openWorkbench',
@@ -210,7 +210,7 @@ describe('desktop IPC adapters', () => {
     expect(postToRenderer).toHaveBeenNthCalledWith(5, {
       agentSubTab: AgentCategory.ToolUse,
       command: SETTINGS_VIEW_COMMANDS.SET_TAB,
-      tabIndex: SETTINGS_TAB.AGENTS,
+      tab: 'agents',
     });
     expect(postToRenderer).toHaveBeenNthCalledWith(6, {
       command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
@@ -236,7 +236,7 @@ describe('desktop IPC adapters', () => {
     });
     expect(postToRenderer).toHaveBeenCalledWith({
       command: SETTINGS_VIEW_COMMANDS.SET_TAB,
-      tabIndex: SETTINGS_TAB.AGENTS,
+      tab: 'agents',
     });
   });
 

--- a/src/test-kernel/desktop/DesktopShortcutRegistry.vitest.ts
+++ b/src/test-kernel/desktop/DesktopShortcutRegistry.vitest.ts
@@ -19,7 +19,7 @@ interface ShortcutRegistryModule {
     actions: {
       showLauncher(): void;
       openWorkbench(kind: 'settings' | 'logs'): void;
-      showSettings(tabIndex?: number): void;
+      showSettings(tab?: string): void;
     };
     openCommands(): void;
     platform?: NodeJS.Platform;

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts
@@ -14,7 +14,7 @@ import {
   PROGRESS_VIEW_COMMANDS,
   SETTINGS_VIEW_COMMANDS,
 } from '@shared/ipc';
-import { AgentCategory, SETTINGS_TAB } from '@shared/schemas';
+import { AgentCategory } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { FakeConfigProvider, FakeStateStore } from '@test/support/FakePlatform';
 import { createModuleMocks } from '@test/support/moduleMocks';
@@ -485,16 +485,16 @@ describe('desktop main-view IPC', () => {
     expect(capabilities.shellActions.showSettings).toHaveBeenNthCalledWith(1);
     expect(capabilities.shellActions.showSettings).toHaveBeenNthCalledWith(
       2,
-      SETTINGS_TAB.MODELS,
+      'models',
     );
     expect(capabilities.shellActions.showSettings).toHaveBeenNthCalledWith(
       3,
-      SETTINGS_TAB.AGENTS,
+      'agents',
       AgentCategory.ToolUse,
     );
     expect(capabilities.shellActions.showSettings).toHaveBeenNthCalledWith(
       4,
-      SETTINGS_TAB.MULTI_AGENT,
+      'multi-agent',
     );
     expect(capabilities.shellActions.openAgentDirectory).toHaveBeenCalledWith(
       false,

--- a/src/test-kernel/schemas/SharedSchemas.vitest.ts
+++ b/src/test-kernel/schemas/SharedSchemas.vitest.ts
@@ -5,7 +5,6 @@
 import { describe, expect, it } from 'vitest';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import {
-  SETTINGS_TAB,
   SETTINGS_TAB_GROUPS,
   SETTINGS_TAB_ORDER,
   SETTINGS_TAB_PANEL_NAMES,
@@ -177,24 +176,10 @@ describe('settings view tab definitions', () => {
     );
   });
 
-  // `SETTINGS_TAB.X` indices cross the IPC boundary as `SET_TAB.tabIndex`, so
-  // the mapping is pinned literally. A retired internal panel must disappear
-  // from this contract together with every producer and handler.
-  it('pins the settings tab wire contract (index + panel name)', () => {
-    expect(SETTINGS_TAB).toEqual({
-      MEMORY: 0,
-      MODELS: 1,
-      AGENTS: 2,
-      MULTI_AGENT: 3,
-      TOOLS: 4,
-      AI_AGENTS: 5,
-      GIT: 6,
-      LATEX: 7,
-      GOAL: 8,
-      ACCOUNT: 9,
-      SHORTCUTS: 10,
-      SUBSCRIPTIONS: 11,
-    });
+  // Panel names cross the IPC boundary as `SET_TAB.tab`, so the set is pinned
+  // literally. A retired internal panel must disappear from this contract
+  // together with every producer and handler.
+  it('pins the settings tab wire contract (panel names)', () => {
     expect(SETTINGS_TAB_PANEL_NAMES).toEqual([
       'memory',
       'models',

--- a/src/test-kernel/settings/SettingsNavGroups.vitest.ts
+++ b/src/test-kernel/settings/SettingsNavGroups.vitest.ts
@@ -3,11 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports - nav presentation layer + tab wire format
 import { SETTINGS_NAV_GROUPS } from '@settingsView/frontend/settingsNav';
-import {
-  SETTINGS_TAB,
-  SETTINGS_TAB_ORDER,
-  SETTINGS_TAB_PANEL_NAMES,
-} from '@shared/schemas';
+import { SETTINGS_TAB_ORDER } from '@shared/schemas';
 
 const navEntries = SETTINGS_NAV_GROUPS.flatMap((group) => group.entries);
 
@@ -17,20 +13,6 @@ describe('settings nav groups', () => {
 
     expect(new Set(names).size).toBe(names.length);
     expect([...names].sort()).toEqual([...SETTINGS_TAB_ORDER].sort());
-  });
-
-  // This is the index-compatibility check the nav rests on: a tab carries only
-  // a panel name, and `SettingsApp.handleTabShow` turns that name back into the
-  // wire index with `SETTINGS_TAB_PANEL_NAMES.indexOf(...)`. If a tab's panel
-  // name ever resolved to a different index than `SETTINGS_TAB` assigns, the
-  // navigation would silently open the wrong panel while every hardcoded index
-  // table still matched.
-  it('resolves each navigation tab to its own panel index', () => {
-    for (const entry of navEntries) {
-      expect(SETTINGS_TAB_PANEL_NAMES.indexOf(entry.panel)).toBe(
-        SETTINGS_TAB[entry.name],
-      );
-    }
   });
 
   it('labels every tab and group heading', () => {

--- a/src/test-kernel/settings/SettingsNavigation.vitest.ts
+++ b/src/test-kernel/settings/SettingsNavigation.vitest.ts
@@ -14,7 +14,8 @@ vi.mock('@shared/hostBridge', () => ({
 import type { SettingsNavGroup } from '@settingsView/frontend/settingsNav';
 import { postMessage } from '@shared/hostBridge';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import { SETTINGS_TAB, SETTINGS_TAB_PANEL_BY_NAME } from '@shared/schemas';
+import { SETTINGS_TAB_PANEL_BY_NAME } from '@shared/schemas';
+import type { SettingsTabPanelName } from '@shared/schemas';
 
 import {
   mountComponent,
@@ -29,12 +30,12 @@ const THIRTY_ONE_DAYS_MS = 31 * 24 * 60 * 60 * 1_000;
 let navGroups: readonly SettingsNavGroup[] = [];
 let settingsState: typeof import('@settingsView/frontend/settingsState');
 
-function setSelectedTabIndex(index: number): void {
-  settingsState.selectedTabIndex.set(index);
+function setSelectedPanel(panel: SettingsTabPanelName): void {
+  settingsState.selectedPanel.set(panel);
 }
 
-function getSelectedTabIndex(): number {
-  return settingsState.selectedTabIndex.get();
+function getSelectedPanel(): SettingsTabPanelName {
+  return settingsState.selectedPanel.get();
 }
 
 function declareAllCommandsSupported(): void {
@@ -42,12 +43,12 @@ function declareAllCommandsSupported(): void {
 }
 
 async function mountSettingsApp(
-  initialTab = SETTINGS_TAB.ACCOUNT,
+  initialTab: SettingsTabPanelName = SETTINGS_TAB_PANEL_BY_NAME.ACCOUNT,
 ): Promise<LitElementLike> {
   const app = document.createElement('settings-app') as LitElementLike;
   app.setAttribute('data-desktop-view', 'settings');
   declareAllCommandsSupported();
-  setSelectedTabIndex(initialTab);
+  setSelectedPanel(initialTab);
   document.body.append(app);
   await app.updateComplete;
   return app;
@@ -99,7 +100,7 @@ describe('hierarchical settings navigation', () => {
   });
 
   beforeEach(() => {
-    setSelectedTabIndex(SETTINGS_TAB.ACCOUNT);
+    setSelectedPanel(SETTINGS_TAB_PANEL_BY_NAME.ACCOUNT);
   });
 
   it('refreshes settings at the UTC monthly quota rollover', async () => {
@@ -179,7 +180,7 @@ describe('hierarchical settings navigation', () => {
       categoryButton(app, group.label).click();
       await app.updateComplete;
 
-      expect(getSelectedTabIndex()).toBe(SETTINGS_TAB[group.entries[0]!.name]);
+      expect(getSelectedPanel()).toBe(group.entries[0]!.panel);
       expect(activePanelLabel(app)).toBe(group.entries[0]!.label);
       expect(
         app.shadowRoot?.querySelectorAll('.settings-page-button'),
@@ -188,14 +189,14 @@ describe('hierarchical settings navigation', () => {
       for (const entry of group.entries) {
         pageButton(app, entry.panel).click();
         await app.updateComplete;
-        expect(getSelectedTabIndex()).toBe(SETTINGS_TAB[entry.name]);
+        expect(getSelectedPanel()).toBe(entry.panel);
         expect(activePanelLabel(app)).toBe(entry.label);
       }
     }
   });
 
-  it('activates the page addressed by a wire index', async () => {
-    const app = await mountSettingsApp(SETTINGS_TAB.LATEX);
+  it('activates the page addressed by a wire panel name', async () => {
+    const app = await mountSettingsApp(SETTINGS_TAB_PANEL_BY_NAME.LATEX);
 
     expect(activePanelLabel(app)).toBe('LaTeX');
     expect(
@@ -211,7 +212,7 @@ describe('hierarchical settings navigation', () => {
 
     for (const group of navGroups) {
       for (const entry of group.entries) {
-        setSelectedTabIndex(SETTINGS_TAB[entry.name]);
+        setSelectedPanel(entry.panel);
         await app.updateComplete;
 
         const header = app.shadowRoot?.querySelector('.settings-page-header');
@@ -240,7 +241,7 @@ describe('hierarchical settings navigation', () => {
     );
     await app.updateComplete;
 
-    expect(getSelectedTabIndex()).toBe(SETTINGS_TAB.MODELS);
+    expect(getSelectedPanel()).toBe(SETTINGS_TAB_PANEL_BY_NAME.MODELS);
     expect(activePanelLabel(app)).toBe('Providers & Models');
     expect(app.shadowRoot?.querySelector('models-tab')).not.toBeNull();
     expect(app.shadowRoot?.querySelector('account-tab')).toBeNull();
@@ -282,7 +283,7 @@ describe('hierarchical settings navigation', () => {
   it('keeps desktop-only shortcuts out of the extension navigation', async () => {
     const app = document.createElement('settings-app') as LitElementLike;
     declareAllCommandsSupported();
-    setSelectedTabIndex(SETTINGS_TAB.SHORTCUTS);
+    setSelectedPanel(SETTINGS_TAB_PANEL_BY_NAME.SHORTCUTS);
     document.body.append(app);
     await app.updateComplete;
 

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -77,7 +77,7 @@ export function publishAgentCliStreamUsage(
   );
 }
 
-export interface AgentCliResumeLabels {
+interface AgentCliResumeLabels {
   notActiveLabel: string;
   idParamName: string;
   summaryLabel: string;
@@ -175,7 +175,7 @@ async function resumeOrLaunchAgentCliSession(
   }
 }
 
-export interface AgentCliLaunchParams {
+interface AgentCliLaunchParams {
   parentStreamId: StreamTabId;
   parentExecutionId: ExecutionId | undefined;
   agentName: string;
@@ -298,7 +298,7 @@ async function withAgentCliApproval(
 
 /** Run context resolved for an agent-CLI launch, handed to the provider's
  * `launch` callback by {@link dispatchAgentCliTool}. */
-export interface AgentCliLaunchContext {
+interface AgentCliLaunchContext {
   parentStreamId: StreamTabId;
   parentExecutionId: ExecutionId | undefined;
   parentWorkingDirectory: string | undefined;
@@ -376,7 +376,7 @@ interface AgentCliTurnUsage {
   output_tokens?: number;
 }
 
-export interface AgentCliLoopParams<TTurn> {
+interface AgentCliLoopParams<TTurn> {
   childStream: ChildStream;
   parentStreamId: StreamTabId;
   executionId: ExecutionId;

--- a/src/tools/core/define.ts
+++ b/src/tools/core/define.ts
@@ -50,9 +50,9 @@ interface DefinedToolHosts {
  * protected member on an anonymous class type. Naming the type sidesteps that
  * without widening `BaseTool.execute` to public.
  */
-export type DefinedToolClass<T> = abstract new (
-  override?: Partial<ToolDefinition>,
-) => BaseTool<T> & DefinedToolFlags & DefinedToolHosts;
+export type DefinedToolClass<T> = abstract new () => BaseTool<T> &
+  DefinedToolFlags &
+  DefinedToolHosts;
 
 /**
  * Define a tool with type-safe schema and either a static or dynamic description.
@@ -76,20 +76,6 @@ export function defineTool<T>(
   const getDescription = (): string =>
     typeof def.description === 'function' ? def.description() : def.description;
 
-  const buildDefinition = (
-    override?: Partial<ToolDefinition>,
-  ): ToolDefinition => ({
-    name: def.name,
-    description: getDescription(),
-    parameters: toToolParameters(def.schema),
-    // Include original Zod schema for SDK-native conversions (OpenAI, Anthropic)
-    zodSchema: def.schema,
-    ...(def.availabilityCategory && {
-      availabilityCategory: def.availabilityCategory,
-    }),
-    ...override,
-  });
-
   abstract class GeneratedTool extends BaseTool<T> {
     // The return annotation checks these fields against EXECUTION_FLAGS.
     readonly parallelSafe = def.parallelSafe;
@@ -99,8 +85,20 @@ export function defineTool<T>(
     readonly streamsOutput = def.streamsOutput;
     readonly hosts = def.hosts;
 
-    constructor(override?: Partial<ToolDefinition>) {
-      super(buildDefinition(override), def.schema);
+    constructor() {
+      super(
+        {
+          name: def.name,
+          description: getDescription(),
+          parameters: toToolParameters(def.schema),
+          // Include original Zod schema for SDK-native conversions (OpenAI, Anthropic)
+          zodSchema: def.schema,
+          ...(def.availabilityCategory && {
+            availabilityCategory: def.availabilityCategory,
+          }),
+        },
+        def.schema,
+      );
     }
   }
 

--- a/src/tools/delegation/delegationAvailability.ts
+++ b/src/tools/delegation/delegationAvailability.ts
@@ -90,7 +90,7 @@ const NO_AGENTS_LINE =
 /** How an agent's tool list is rendered inside a roster entry. */
 type AgentListToolsStyle = 'block' | 'inline' | 'none';
 
-export interface FormatAgentListOptions {
+interface FormatAgentListOptions {
   /** Where an agent's tool list goes when present. Defaults to `'block'`. */
   readonly tools?: AgentListToolsStyle;
   /** Collapse newlines inside descriptions to spaces. Defaults to `true`. */

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -78,7 +78,7 @@ export interface InBandSubagentExecutionOptions extends InBandSubagentExecutionB
   readonly parentExecutionId: ExecutionId;
 }
 
-export interface StableInBandSubagentExecutionOptions {
+interface StableInBandSubagentExecutionOptions {
   /** Cryptographic identity of the prompt/options call, stable across restart. */
   readonly executionId: ExecutionId;
   readonly parentExecutionId: ExecutionId;
@@ -100,16 +100,16 @@ export interface StableInBandSubagentExecutionOptions {
  * Options for the XML-delivery API. A one-shot run context need not have a
  * persisted parent execution, so parentage is optional here.
  */
-export interface InBandSubagentDeliveryOptions extends InBandSubagentExecutionBaseOptions {
+interface InBandSubagentDeliveryOptions extends InBandSubagentExecutionBaseOptions {
   readonly parentExecutionId?: ExecutionId;
 }
 
-export interface InBandSubagentExecutionResult {
+interface InBandSubagentExecutionResult {
   readonly executionId: ExecutionId;
   readonly result: AgentFinalResult;
 }
 
-export interface InBandSubagentDeliveryResult extends InBandSubagentExecutionResult {
+interface InBandSubagentDeliveryResult extends InBandSubagentExecutionResult {
   readonly delivery: string;
 }
 

--- a/src/tools/delegation/nativeSubagentStrategy.ts
+++ b/src/tools/delegation/nativeSubagentStrategy.ts
@@ -129,7 +129,7 @@ export interface ChildRunLaunchOptions {
   readonly onStreamResolved?: (streamId: StreamTabId) => void;
 }
 
-export interface NativeSubagentStrategyParams extends ChildRunLaunchOptions {
+interface NativeSubagentStrategyParams extends ChildRunLaunchOptions {
   readonly config: AgentConfig;
   readonly agentCategoryExplicit: boolean;
   readonly executionId: ExecutionId;

--- a/src/tools/delegation/subagentResults.ts
+++ b/src/tools/delegation/subagentResults.ts
@@ -43,7 +43,7 @@ import {
   formatChildRunError,
 } from './deliveryEnvelope';
 
-export type SubagentResultMeta = Extract<ResultMeta, { producer: 'subagent' }>;
+type SubagentResultMeta = Extract<ResultMeta, { producer: 'subagent' }>;
 
 // ============================================================================
 // Formatting helpers
@@ -421,7 +421,7 @@ function truncateDiff(diff: string, maxLines: number): string {
 }
 
 /** Info about a diff file written to the execution's run directory. */
-export interface DiffFileInfo {
+interface DiffFileInfo {
   /** The relative path within the run directory (e.g. "diffs/chapter1.tex.diff"). */
   diffRelPath: string;
   /** True when the change ratio exceeded the large-change threshold. */

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -113,14 +113,6 @@ export interface ExternalToolDef {
   readonly toggleable?: boolean;
   /** When true, detect setup but show the integration as not yet enabled. */
   readonly comingSoon?: boolean;
-  /**
-   * VS Code command ID invoked by the "fix this" action button in the
-   * "tools were excluded" notification. Overrides the default Tools tab
-   * link — use this when real setup lives elsewhere (e.g. Git tab for a
-   * GitHub token). The label for that button is `installActionLabel`.
-   */
-  readonly installActionCommand?: string;
-  readonly installActionLabel?: string;
 }
 
 // ============================================================
@@ -482,8 +474,6 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     configNotes: `Token stored in host secret storage or read from GITHUB_TOKEN/GH_TOKEN. The CLI /config → GitHub token row and the VS Code Git tab both manage the stored token. Requires a git repository in the workspace. Polls every ${PR_POLL_INTERVAL_MS / 1000}s; cap: ${MAX_CONCURRENT_PR_SUBSCRIPTIONS} concurrent PRs and ${MAX_CONCURRENT_REPO_SUBSCRIPTIONS} concurrent repos. Bot-authored events are dropped end-to-end by policy.`,
     authNote: 'Uses personal access token',
     toggleable: true,
-    installActionCommand: 'texra.showGitSettings',
-    installActionLabel: 'Open Git settings',
     ...prerequisitesChecks({
       probe: getGitHubPRPrerequisites,
       resolve: resolveGitHubPRPrerequisites,


### PR DESCRIPTION
## Summary

Executes the deletions from #10855 and #10856 as one PR.

**Part 1 — dead tool surface (#10855)**
- Deleted `installActionCommand`/`installActionLabel` from `ExternalToolDef` and the single assignment on the github-subscription entry (`src/tools/externalToolDefs.ts`). Zero readers existed anywhere.
- Deleted the never-used `override?: Partial<ToolDefinition>` constructor parameter from `defineTool` (`src/tools/core/define.ts`) and inlined `buildDefinition` into the constructor. Re-verified before cutting: `new [A-Z]\w*Tool([^)]` matches only `new TerminalTool(capture)` in `src/tools/structuredOutput.ts`, whose own constructor calls `super()` with no args.
- Un-exported 14 module-private types (delegation, agentCliShared, vscodelm handler, priceUtils). Each re-verified to have zero external importers before removing `export`.

**Part 2 — settings-tab wire keyed by panel name (#10856)**
- `SET_TAB` now carries `tab: z.enum(SETTINGS_TAB_PANEL_NAMES)` instead of an append-only integer `tabIndex`; deleted the `SETTINGS_TAB` index map, the `SettingsTab` type, and the append-only-indices comment machinery. `SETTINGS_TAB_ORDER`/`SETTINGS_TAB_PANEL_BY_NAME`/`SETTINGS_TAB_PANEL_NAMES` remain as the name SSOT.
- All producers/consumers now speak panel names: extension (`SettingsViewProvider`, command surface, `SubscriptionsTab`), desktop (`desktopCommandSurface`, `desktopShellIpc`, `desktopAgentExecution`, palette, renderer), and the webview state — `selectedTabIndex: number` became `selectedPanel: SettingsTabPanelName`, killing the `SETTINGS_TAB_PANEL_NAMES.indexOf(...)` round-trip in `SettingsApp`.
- Command → tab SSOT: `CommandCatalogEntry.settingsTab?: SettingsTabPanelName` populated on the six tab-opening `texra.show*` entries; both hosts derive their `showSettings` handler rows from the new `settingsTabByCommand` map, deleting the hand-mirrored rows. `texra.showAgents` keeps a declared row (it forwards an agent-category sub-tab) but reads its tab from the catalog. Icons intentionally left as-is per the issue note (`users` vs `diagram-project` drift not unified here).
- Non-production integer mirrors deleted: `SETTINGS_TAB_INDEX` tables in `trajectories.spec.ts`, `settingsPersistence.spec.ts`, `verify-fixes.spec.ts`; `workspaceTabs.spec.ts` raw posts; `scripts/capture-walkthrough-media.mjs`. `setSettingsTab` in `electronApp.ts` collapses `(tabIndex, panel?)` into one panel-name argument and now always confirms the active page button — this also fixes a latent mismatch in `screenshots.spec.ts`, which passed index 4 (TOOLS) while waiting on the `multi-agent` panel.
- TerminalOutput dead compat: dropped the native-`<details>` `toggle` refit event and the `, details` ancestor selector. Verified the only remaining native `<details>` is the launcher's `desktop-file-context` in `MainApp.ts`, which never hosts a terminal.

Deviations from the issue text:
- "Seven `texra.show*` entries": six catalog entries actually open a specific tab (`showMemory/showModels/showAgents/showTools/showMultiAgent/showGitSettings`). `texra.showDashboard` opens settings with no tab and `texra.auth.viewProfile` (not `show*`, outside the cited line ranges) keeps its one-line row now spelled `SETTINGS_TAB_PANEL_BY_NAME.ACCOUNT`.
- Tests pinning deleted behavior were deleted, not rewritten: the index-compat check in `SettingsNavGroups.vitest.ts` and the literal `SETTINGS_TAB` index pin in `SharedSchemas.vitest.ts` (the panel-name wire pin remains).

## Net elements (R6)

- **Deleted:** `installActionCommand` + `installActionLabel` fields and their one producer; `defineTool` `override` parameter + `buildDefinition` helper; 14 `export` keywords (symbols now module-private); `SETTINGS_TAB` map + `SettingsTab` type; 3 hand-copied e2e index tables; 11 hand-written host handler rows (5 extension + 6 desktop) replaced by one derived map; the `indexOf` name→index round-trip; 1 obsolete test; `'toggle'` refit event + `details` selector arm.
- **Added:** `CommandCatalogEntry.settingsTab` field; `settingsTabByCommand` + `SettingsTabCommandId` (consumed by both hosts); one derived-handler spread per host.
- Diff: 41 files, +269/−329 (net −60 lines).

## Consumer counts (R8)

- 14 un-exported types: 0 external importers each (repo-wide `grep -w` per symbol at HEAD).
- `installActionCommand`/`installActionLabel`: 0 readers outside the defining file.
- `defineTool` override argument: 0 call sites passing arguments (grep above).
- New exports arrive with consumers in the same PR: `settingsTabByCommand` (extension handlers, desktop handlers), `SettingsTabCommandId` (same two), `selectedPanel` (SettingsApp, tabSlice, SettingsNavigation suite), `SettingsTabPanelName` uses widened across hosts.

## Verification

- `npm run typecheck` — green (workspace, test-kernel, agent, cli, trace-viewer, desktop).
- `FORCE_COLOR=0 vitest run` over settings/desktop/commands/schemas/tools/progressView/priceUtils suites — 209 files, 1684 tests, all green.
- Changed-file eslint — clean (the two `.mjs` `no-undef` hits in `capture-walkthrough-media.mjs` are pre-existing on untouched lines; e2e specs are outside the lint config).
- `git diff --check` — clean; prettier applied.
- `npm run check:dead-code-ratchet` — OK (8 vs 8 baselined, no new findings).
- Desktop e2e specs typecheck (ad-hoc `tsc` over `tests/e2e`; the single error is a pre-existing Electron menu-role comparison in untouched `menuLifetime.spec.ts`).

Closes #10855. Closes #10856.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
