### PR TITLE
refactor: delete dead props, params, and test-only fallbacks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,5 @@
   "typescript.tsc.autoDetect": "off",
   // Use the workspace TypeScript (6.0.3) so the editor matches the build; the
   // bundled VS Code TS server is older and rejects `ignoreDeprecations: "6.0"`.
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "texra.ui.showLoginBanner": false
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -153,7 +153,6 @@ export interface AppProps {
   /** Suspend the process (Ctrl-Z). Raw mode swallows the tty driver's own
    *  ^Z→SIGTSTP translation, so the parsed key must be routed explicitly. */
   readonly onSuspend?: () => void;
-  readonly inputDisabled?: boolean;
   readonly history?: InputHistory;
 }
 
@@ -214,8 +213,7 @@ export function App(props: AppProps): React.JSX.Element {
   const childInputHidden =
     focusedChildFollowUpRoute({ activeStreamId, parentStream, streams })
       .kind === 'reject';
-  const appInputDisabled =
-    props.inputDisabled === true || foregroundOpen || childListFocused;
+  const appInputDisabled = foregroundOpen || childListFocused;
   const inputDisabledMessage = childListFocused
     ? SESSION_LIST.choosing
     : undefined;

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -44,10 +44,6 @@ export interface BaseTextInputProps {
    *  the full editable value passed to onChange/onSubmit. */
   readonly maxDisplayRows?: number;
   readonly displayWidth?: number;
-  /** Pin the caret externally. When omitted, the component tracks the caret
-   *  internally so arrow keys / Home/End / Ctrl-A,E,U,K,W work out of the box. */
-  readonly cursor?: number;
-  readonly onCursorChange?: (cursor: number) => void;
   readonly onSubmit: (value: string) => void;
   readonly onInputChunkSubmit?: (value: string) => void;
   readonly onChange: (value: string) => void;
@@ -387,12 +383,10 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
     onChange,
     onInputChunkSubmit,
     onSubmit,
-    onCursorChange,
   } = props;
 
-  const isControlled = props.cursor !== undefined;
   const [internalCursor, setInternalCursor] = useState<number>(value.length);
-  const cursor = clampCursor(props.cursor ?? internalCursor, value.length);
+  const cursor = clampCursor(internalCursor, value.length);
 
   // Mirror the latest value/cursor for async handlers (image paste): a
   // clipboard probe that resolves after the user keeps typing must insert at
@@ -413,20 +407,15 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
   useEffect(() => {
     if (lastEmittedValueRef.current === value) return;
     lastEmittedValueRef.current = value;
-    if (!isControlled) setInternalCursor(value.length);
-    onCursorChange?.(value.length);
-  }, [value, isControlled, onCursorChange]);
+    setInternalCursor(value.length);
+  }, [value]);
 
-  const moveCursor = useCallback(
-    (next: number) => {
-      const latest = latestStateRef.current;
-      const c = clampCursor(next, latest.value.length);
-      latestStateRef.current = { value: latest.value, cursor: c };
-      if (!isControlled) setInternalCursor(c);
-      onCursorChange?.(c);
-    },
-    [isControlled, onCursorChange],
-  );
+  const moveCursor = useCallback((next: number) => {
+    const latest = latestStateRef.current;
+    const c = clampCursor(next, latest.value.length);
+    latestStateRef.current = { value: latest.value, cursor: c };
+    setInternalCursor(c);
+  }, []);
 
   const moveCursorTo = useCallback(
     (target: (value: string, cursor: number) => number) => {
@@ -442,10 +431,9 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
       latestStateRef.current = { value: edit.value, cursor: c };
       lastEmittedValueRef.current = edit.value;
       onChange(edit.value);
-      if (!isControlled) setInternalCursor(c);
-      onCursorChange?.(c);
+      setInternalCursor(c);
     },
-    [isControlled, onChange, onCursorChange],
+    [onChange],
   );
 
   const syncLatestExternalValue = useCallback((): TextEdit => {
@@ -457,10 +445,9 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
     const cursor = clampCursor(latest.cursor, externalValue.length);
     const next = { value: externalValue, cursor };
     latestStateRef.current = next;
-    if (!isControlled) setInternalCursor(cursor);
-    onCursorChange?.(cursor);
+    setInternalCursor(cursor);
     return next;
-  }, [isControlled, onCursorChange, props.readLatestValue]);
+  }, [props.readLatestValue]);
 
   const prepareInputChunkState = useCallback(
     (input: string): TextEdit => {

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -59,8 +59,6 @@ export interface InputBarProps {
   readonly disabledMessage?: string;
   /** Preserve component state while giving foreground panels the input rows. */
   readonly collapseWhenDisabled?: boolean;
-  /** Prompt prefix (e.g. `>`). */
-  readonly prompt?: string;
   /** Persistent input history (optional — undefined disables Ctrl-R). */
   readonly history?: InputHistory;
   /** Whether the input currently owns terminal keys. */
@@ -102,7 +100,7 @@ const INPUT_BAR_MAX_CONTENT_ROWS = 5;
 const INPUT_BAR_DECORATION_COLUMNS = 6;
 
 export function InputBar(props: InputBarProps): React.JSX.Element {
-  const { disabled, history, onSubmit, prompt } = props;
+  const { disabled, history, onSubmit } = props;
   const keyboardActive = props.keyboardActive ?? true;
   const [value, setValueState] = useState('');
   const reverseSearchOpen = useSignal(reverseSearchOpenSignal);
@@ -423,7 +421,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         aria-role="textbox"
       >
         <Text aria-hidden color={COLOR_HINT}>
-          {prompt ?? POINTER}{' '}
+          {POINTER}{' '}
         </Text>
         {disabled && props.disabledMessage ? (
           <Text dimColor>{props.disabledMessage}</Text>

--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -116,32 +116,21 @@ export function editPatchGroups(
   return groups.length > 0 ? groups : undefined;
 }
 
-export function diffDisplayLines(
-  hunks: readonly Hunk[],
-  maxHunkLines = 0,
-): DiffDisplayLine[] {
+export function diffDisplayLines(hunks: readonly Hunk[]): DiffDisplayLine[] {
   return hunks.flatMap((hunk) => {
     const lines = hunk.lines.filter(
       (line) => !line.startsWith(NO_NEWLINE_MARKER),
     );
-    const visible = maxHunkLines > 0 ? lines.slice(0, maxHunkLines) : lines;
-    const remaining = maxHunkLines > 0 ? lines.length - maxHunkLines : 0;
     const hunkHeader = `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`;
     const rendered: DiffDisplayLine[] = [
       { kind: 'header', text: hunkHeader },
-      ...visible.map((line): DiffDisplayLine => {
+      ...lines.map((line): DiffDisplayLine => {
         const marker = line.at(0);
         if (marker === '+') return { kind: 'added', text: line };
         if (marker === '-') return { kind: 'removed', text: line };
         return { kind: 'context', text: line };
       }),
     ];
-    if (remaining > 0) {
-      rendered.push({
-        kind: 'overflow',
-        text: `… ${remaining} more lines`,
-      });
-    }
     return rendered;
   });
 }
@@ -149,10 +138,9 @@ export function diffDisplayLines(
 export function wrappedDiffDisplayLines(
   hunks: readonly Hunk[],
   width: number,
-  maxHunkLines = 0,
 ): DiffDisplayLine[] {
   const diffWidth = clampModalWidth(width);
-  return diffDisplayLines(hunks, maxHunkLines).flatMap((line) =>
+  return diffDisplayLines(hunks).flatMap((line) =>
     wrapAnsiToWidth(line.text, diffWidth)
       .split('\n')
       .map((text): DiffDisplayLine => ({ ...line, text })),
@@ -278,15 +266,14 @@ function compactBoundedDiffDisplayLines(
 
 export function scrollBoundedDiffDisplayLines(
   hunks: readonly Hunk[],
-  maxHunkLines = 0,
   maxDisplayLines = 0,
   scrollOffset = 0,
   width?: number,
 ): DiffDisplayLine[] {
   const lines =
     width === undefined
-      ? diffDisplayLines(hunks, maxHunkLines)
-      : wrappedDiffDisplayLines(hunks, width, maxHunkLines);
+      ? diffDisplayLines(hunks)
+      : wrappedDiffDisplayLines(hunks, width);
   if (maxDisplayLines <= 0 || lines.length <= maxDisplayLines) return lines;
   if (maxDisplayLines <= COMPACT_SCROLLABLE_CONTENT_ROWS) {
     return compactBoundedDiffDisplayLines(lines, maxDisplayLines, width);
@@ -323,8 +310,6 @@ interface DiffViewProps {
   readonly hunks: readonly Hunk[];
   /** Maximum total rendered diff rows before truncating; 0 = no truncation. */
   readonly maxDisplayLines?: number;
-  /** Maximum context lines per hunk before truncating; 0 = no truncation. */
-  readonly maxHunkLines?: number;
   /** Starting diff row when maxDisplayLines truncates the display. */
   readonly scrollOffset?: number;
   readonly width?: number;
@@ -332,11 +317,9 @@ interface DiffViewProps {
 
 export function DiffView(props: DiffViewProps): React.JSX.Element {
   const maxDisplayLines = props.maxDisplayLines ?? 0;
-  const max = props.maxHunkLines ?? 0;
   const width = clampModalWidth(props.width ?? DEFAULT_DIFF_WIDTH);
   const lines = scrollBoundedDiffDisplayLines(
     props.hunks,
-    max,
     maxDisplayLines,
     props.scrollOffset ?? 0,
     width,

--- a/packages/cli/src/runtime/logSinks.ts
+++ b/packages/cli/src/runtime/logSinks.ts
@@ -13,9 +13,6 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
  * CLI is the only consumer.
  */
 export interface LogFields {
-  readonly streamId?: string;
-  readonly runId?: string;
-  readonly groupId?: string;
   readonly [key: string]: unknown;
 }
 
@@ -170,9 +167,8 @@ export async function askCliQuestion(
 
 class StderrTextSink implements LogSink {
   write(record: LogRecord): void {
-    const stream = record.fields.streamId ? ` [${record.fields.streamId}]` : '';
     writeTextStderr(
-      `${record.ts} ${record.level.toUpperCase()}${stream} ${record.message}`,
+      `${record.ts} ${record.level.toUpperCase()} ${record.message}`,
     );
   }
 }

--- a/packages/desktop/src/main/desktopMainViewStartup.ts
+++ b/packages/desktop/src/main/desktopMainViewStartup.ts
@@ -9,7 +9,6 @@ import { createTeamCatalogPorts } from '@controllers/mainView/teamCatalogPorts';
 import { computeModelOptionsData } from '@model/computeModelOptions';
 import type { StateStore } from '@platform/interfaces';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
-import { getConfig } from '@utils/config/configUtils';
 
 import {
   createCommandHandler,
@@ -37,7 +36,6 @@ export function createDesktopMainViewStartup({
   globalState,
 }: DesktopMainViewStartupOptions): DesktopMessageHandler {
   const startupController = new MainViewStartupController({
-    getConfig,
     loadOptions: async () => {
       if (loadOptions != null) return loadOptions();
       const [agentOptions, teamOptions, modelOptions] = await Promise.all([

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -12,7 +12,6 @@ import {
   dispatchMainViewInbound,
   MainViewInboundHandlerRegistry,
 } from '@shared/schemas';
-import { getConfig } from '@utils/config/configUtils';
 
 import { DiffManager } from './managers/DiffManager';
 import { FileManager } from './managers/FileManager';
@@ -64,7 +63,6 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     this.diffManager = new DiffManager();
     this.instructionManager = new InstructionManager();
     this.startupController = new MainViewStartupController({
-      getConfig,
       loadOptions,
       getAuthStatus,
       globalState: context.globalState,

--- a/src/controllers/mainView/MainViewStartupController.ts
+++ b/src/controllers/mainView/MainViewStartupController.ts
@@ -33,7 +33,6 @@ export interface MainViewStartupOptions {
 }
 
 export interface MainViewStartupControllerDeps {
-  getConfig<T>(key: string, defaultValue: T): T;
   loadOptions(): Promise<MainViewStartupOptions>;
   getAuthStatus(): Promise<MainViewAuthStatus>;
   globalState: StateStore;
@@ -55,22 +54,15 @@ export class MainViewStartupController {
 
   /**
    * Banner dismissals live in global state and are written only by the
-   * banner's own close button. They were `texra.ui.show*Banner` settings until
-   * they moved here, so a pre-move `false` still counts as dismissed; nothing
-   * writes the legacy key back.
+   * banner's own close button.
    */
-  private isBannerDismissed(
-    key: GlobalStateKey,
-    legacySettingPath: string,
-  ): boolean {
-    if (this.deps.globalState.get<boolean>(key) === true) return true;
-    return this.deps.getConfig<boolean>(legacySettingPath, true) === false;
+  private isBannerDismissed(key: GlobalStateKey): boolean {
+    return this.deps.globalState.get<boolean>(key) === true;
   }
 
   getOrchestratorBannerMessage(): MainViewStartupMessage {
     const dismissed = this.isBannerDismissed(
       GlobalStateKey.ORCHESTRATOR_BANNER_DISMISSED,
-      'ui.showOrchestratorBanner',
     );
     return {
       command: dismissed
@@ -85,10 +77,7 @@ export class MainViewStartupController {
 
     const showLoginBanner =
       !authStatus.authenticated &&
-      !this.isBannerDismissed(
-        GlobalStateKey.LOGIN_BANNER_DISMISSED,
-        'ui.showLoginBanner',
-      );
+      !this.isBannerDismissed(GlobalStateKey.LOGIN_BANNER_DISMISSED);
 
     return [
       {

--- a/src/controllers/progressView/backend/LitSessionRenderer.ts
+++ b/src/controllers/progressView/backend/LitSessionRenderer.ts
@@ -58,7 +58,7 @@ export class LitSessionRenderer implements SessionRendererPort {
     private readonly webviewBridge: WebviewBridge,
     private readonly send: (message: ProgressViewOutboundMessage) => void,
     private readonly hasTarget: () => boolean,
-    private readonly getActiveStream: () => PresentedStreamId = () => '',
+    private readonly getActiveStream: () => PresentedStreamId,
     /**
      * Commands this host's inbound registry declares `unsupported(...)`
      * (see `unsupportedCommands` in `@shared/utils/dispatcher`). Included

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -3,10 +3,9 @@ import PQueue from 'p-queue';
 import { RUN_FACT_EVENT_TYPES } from '@agent/trace';
 import type { DeleteStreamResult, SessionStores } from '@agent/storage';
 import type { HostApprovalBypassStateUpdate } from '@agent/runtime/HostInteractions';
-import {
-  defaultSession,
-  type SessionHandle,
-  type WorkspaceStorageTransitionHooks,
+import type {
+  SessionHandle,
+  WorkspaceStorageTransitionHooks,
 } from '@agent/runtime/SessionHandle';
 import {
   WebviewBridge,
@@ -70,9 +69,9 @@ export interface ProgressBackendOptions {
   approvals: ProgressBackendApprovalOptions;
   lifecycle: ProgressBackendLifecycleOptions;
   reportTranscriptLoadError(error: unknown, stream: StreamTabId | ''): void;
-  getStreamControls?: GetProgressStreamControls;
-  /** Session that owns this backend's coordination state (defaults to the process session). */
-  session?: SessionHandle;
+  getStreamControls: GetProgressStreamControls;
+  /** Session that owns this backend's coordination state. */
+  session: SessionHandle;
   /**
    * `session` when the caller has already loaded and swept the session's
    * stores at process start. A process-owned session has opened the canonical
@@ -124,7 +123,7 @@ export class ProgressBackend {
   private disposed = false;
 
   constructor(options: ProgressBackendOptions) {
-    this.session = options.session ?? defaultSession();
+    this.session = options.session;
     this.stateOwnership = options.stateOwnership ?? 'backend';
     this.lifecycle = options.lifecycle;
     this.reportTranscriptLoadError = options.reportTranscriptLoadError;

--- a/src/controllers/progressView/backend/ProgressStreamProjectionBuilder.ts
+++ b/src/controllers/progressView/backend/ProgressStreamProjectionBuilder.ts
@@ -1,10 +1,7 @@
 import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
 
 // Local imports - progress view
-import {
-  getDefaultProgressStreamControls,
-  type GetProgressStreamControls,
-} from '@controllers/progressView/progressStreamControls';
+import type { GetProgressStreamControls } from '@controllers/progressView/progressStreamControls';
 // Local imports - session
 import {
   buildStreamInfo,
@@ -42,7 +39,7 @@ export interface ProjectedStreamRoster {
 export class ProgressStreamProjectionBuilder {
   constructor(
     private readonly state: SessionState,
-    private readonly getStreamControls: GetProgressStreamControls = getDefaultProgressStreamControls,
+    private readonly getStreamControls: GetProgressStreamControls,
   ) {}
 
   streamMetadata(

--- a/src/controllers/progressView/progressStreamControls.ts
+++ b/src/controllers/progressView/progressStreamControls.ts
@@ -28,15 +28,6 @@ export type GetProgressStreamControls = (
   stream: StreamTabId,
 ) => ProgressStreamControls;
 
-export function getDefaultProgressStreamControls(): ProgressStreamControls {
-  return {
-    bashBypass: false,
-    toolEditBypass: false,
-    superYoloBypass: false,
-    goalActive: false,
-  };
-}
-
 export function getProgressStreamControls(
   streamId: StreamTabId,
   session?: SessionHandle,

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -26,7 +26,6 @@ interface ExtractResult {
 
 interface ExtractOptions {
   timeout?: number;
-  channel?: string;
 }
 
 // AbortSignal.timeout() covers the entire request including body streaming,
@@ -236,8 +235,7 @@ class ArxivSourceProcessor {
     destDir: string,
     options: ExtractOptions = {},
   ): Promise<ExtractResult> {
-    const channel = options.channel ?? this.channel;
-    const log = createLog(channel);
+    const log = this.log;
     log.debug(`Extracting tar file: ${tarPath} to ${destDir}`);
 
     try {

--- a/src/test-kernel/cli/DiffView.vitest.ts
+++ b/src/test-kernel/cli/DiffView.vitest.ts
@@ -32,7 +32,7 @@ describe('CLI diff display', () => {
   it('keeps the overflow marker inside the total display budget', () => {
     const hunks = alternatingHunks(SIX_LINE_HUNK_SOURCE);
 
-    const lines = scrollBoundedDiffDisplayLines(hunks, 30, 4, 0);
+    const lines = scrollBoundedDiffDisplayLines(hunks, 4, 0);
 
     expect(lines).toHaveLength(4);
     expect(lines.at(-1)).toMatchObject({
@@ -44,7 +44,7 @@ describe('CLI diff display', () => {
   it('renders scroll markers around the visible diff window', () => {
     const hunks = alternatingHunks(SIX_LINE_HUNK_SOURCE);
 
-    const lines = scrollBoundedDiffDisplayLines(hunks, 0, 4, 2);
+    const lines = scrollBoundedDiffDisplayLines(hunks, 4, 2);
 
     expect(lines).toHaveLength(4);
     expect(lines[0]).toMatchObject({
@@ -71,7 +71,7 @@ describe('CLI diff display', () => {
   it('shows a changed line in a one-row diff window', () => {
     const hunks = alternatingHunks(FOUR_LINE_HUNK_SOURCE);
 
-    const lines = scrollBoundedDiffDisplayLines(hunks, 0, 1, 0);
+    const lines = scrollBoundedDiffDisplayLines(hunks, 1, 0);
 
     expect(lines).toHaveLength(1);
     expect(['added', 'removed']).toContain(lines[0]?.kind);
@@ -80,7 +80,7 @@ describe('CLI diff display', () => {
   it('prioritizes changed rows in a cramped diff window', () => {
     const hunks = alternatingHunks(FOUR_LINE_HUNK_SOURCE);
 
-    const lines = scrollBoundedDiffDisplayLines(hunks, 0, 3, 0);
+    const lines = scrollBoundedDiffDisplayLines(hunks, 3, 0);
 
     expect(lines).toHaveLength(3);
     expect(lines[0]?.kind).toBe('removed');
@@ -107,7 +107,6 @@ describe('CLI diff display', () => {
 
     const topLines = scrollBoundedDiffDisplayLines(
       hunks,
-      0,
       maxDisplayLines,
       0,
       width,
@@ -122,7 +121,6 @@ describe('CLI diff display', () => {
     );
     const initialLines = scrollBoundedDiffDisplayLines(
       hunks,
-      0,
       maxDisplayLines,
       initialOffset,
       width,
@@ -148,7 +146,6 @@ describe('CLI diff display', () => {
     const initialOffset = initialDiffScrollOffset(hunks, 80, maxDisplayLines);
     const initialLines = scrollBoundedDiffDisplayLines(
       hunks,
-      0,
       maxDisplayLines,
       initialOffset,
       80,
@@ -185,7 +182,6 @@ describe('CLI diff display', () => {
 
     const initialLines = scrollBoundedDiffDisplayLines(
       hunks,
-      0,
       maxDisplayLines,
       initialDiffScrollOffset(hunks, 32, maxDisplayLines),
       32,
@@ -230,7 +226,6 @@ describe('CLI diff display', () => {
     const maxDisplayLines = 6;
     const initialLines = scrollBoundedDiffDisplayLines(
       hunks,
-      0,
       maxDisplayLines,
       initialDiffScrollOffset(hunks, 80, maxDisplayLines),
       80,
@@ -255,7 +250,7 @@ describe('CLI diff display', () => {
     expect(rendered).toContain('after $2n-1$.');
     expect(rendered).not.toContain('…');
     expect(lines.length).toBeGreaterThan(
-      scrollBoundedDiffDisplayLines(hunks, 0, 0, 0).length,
+      scrollBoundedDiffDisplayLines(hunks, 0, 0).length,
     );
   });
 
@@ -266,7 +261,7 @@ describe('CLI diff display', () => {
       'This is a deliberately long replacement sentence that needs multiple visual rows.',
     );
 
-    const lines = scrollBoundedDiffDisplayLines(hunks, 0, 4, 0, 24);
+    const lines = scrollBoundedDiffDisplayLines(hunks, 4, 0, 24);
 
     expect(lines).toHaveLength(4);
     expect(lines.at(-1)).toMatchObject({
@@ -279,7 +274,7 @@ describe('CLI diff display', () => {
   it('keeps wrapped overflow markers to one visual row at narrow widths', () => {
     const hunks = buildHunks('draft.tex', 'old sentence', 'x'.repeat(220));
 
-    const lines = scrollBoundedDiffDisplayLines(hunks, 0, 4, 0, 20);
+    const lines = scrollBoundedDiffDisplayLines(hunks, 4, 0, 20);
     const marker = lines.at(-1);
 
     expect(lines).toHaveLength(4);

--- a/src/test-kernel/controllers/MainViewStartupController.vitest.ts
+++ b/src/test-kernel/controllers/MainViewStartupController.vitest.ts
@@ -43,7 +43,6 @@ function createController(
   overrides: Partial<MainViewStartupControllerDeps> = {},
 ): MainViewStartupController {
   return new MainViewStartupController({
-    getConfig: (_key, defaultValue) => defaultValue,
     loadOptions: async () => ({
       modelOptionsByCategory: { workflow: [], toolUse: [] },
       agentOptions: {},
@@ -56,17 +55,9 @@ function createController(
 }
 
 describe('MainViewStartupController', () => {
-  it('uses config to choose the orchestrator banner message', () => {
+  it('shows the orchestrator banner by default', () => {
     expect(createController().getOrchestratorBannerMessage()).toStrictEqual({
       command: MAIN_VIEW_COMMANDS.SHOW_ORCHESTRATOR_BANNER,
-    });
-  });
-
-  it('hides the orchestrator banner when disabled', () => {
-    const controller = createController({ getConfig: <T>() => false as T });
-
-    expect(controller.getOrchestratorBannerMessage()).toStrictEqual({
-      command: MAIN_VIEW_COMMANDS.HIDE_ORCHESTRATOR_BANNER,
     });
   });
 

--- a/src/test-kernel/latex/ArxivProcessor.vitest.ts
+++ b/src/test-kernel/latex/ArxivProcessor.vitest.ts
@@ -89,7 +89,7 @@ describe('arXiv processor logger channel', () => {
     );
   });
 
-  it('logs extraction failures on the owner channel and honors a channel override', async () => {
+  it('logs extraction failures on the owner channel', async () => {
     const error = vi.spyOn(logger, 'error').mockImplementation(() => {});
     const dir = await makeTempDir('texra-arxiv-', tempDirs);
     const missingTar = path.join(dir, 'missing.tar');
@@ -99,16 +99,6 @@ describe('arXiv processor logger channel', () => {
     expect(fallback.success).toBe(false);
     expect(error).toHaveBeenCalledWith(
       'arxivProcessor',
-      expect.stringContaining('Failed to extract tar file'),
-    );
-
-    const overridden = await ArxivProcessor.extractTarFile(missingTar, dir, {
-      channel: 'arxivExtractOverride',
-    });
-
-    expect(overridden.success).toBe(false);
-    expect(error).toHaveBeenCalledWith(
-      'arxivExtractOverride',
       expect.stringContaining('Failed to extract tar file'),
     );
   });

--- a/src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts
+++ b/src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts
@@ -41,6 +41,7 @@ function recordingHandlers(
       unused,
       (message) => messages.push(message),
       () => true,
+      () => '',
     ),
     canSend: () => true,
     overrides,

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -42,6 +42,7 @@ import {
   createRecordingBackend,
   emitActiveStream,
   emitRunConfig,
+  stubStreamControls,
   toolUseConfig,
   track,
 } from './progressBackendHarness';
@@ -1128,6 +1129,7 @@ describe('ProgressBackend', () => {
         reportTranscriptLoadError: vi.fn(),
         approvals: createApprovalOptions(),
         lifecycle,
+        getStreamControls: stubStreamControls,
       }),
     );
     backendRef.current = backend;
@@ -1152,11 +1154,13 @@ describe('ProgressBackend', () => {
     const backend = track(
       new ProgressBackend({
         storage: new FakeStateStore(),
+        session: track(createTestSession()),
         sendMessage: sent,
         hasTarget: () => hasTarget,
         reportTranscriptLoadError: vi.fn(),
         approvals: createApprovalOptions(),
         lifecycle: createLifecycleOptions(),
+        getStreamControls: stubStreamControls,
       }),
     );
 
@@ -1183,11 +1187,13 @@ describe('ProgressBackend', () => {
     const backend = track(
       new ProgressBackend({
         storage: new FakeStateStore(),
+        session: track(createTestSession()),
         sendMessage: sent,
         hasTarget: () => true,
         reportTranscriptLoadError: vi.fn(),
         approvals: createApprovalOptions(),
         lifecycle: createLifecycleOptions(),
+        getStreamControls: stubStreamControls,
       }),
     );
 

--- a/src/test-kernel/progressView/StreamContentSync.vitest.ts
+++ b/src/test-kernel/progressView/StreamContentSync.vitest.ts
@@ -89,7 +89,12 @@ interface SyncHarness {
 }
 
 async function createSyncHarness(
-  getControls?: GetProgressStreamControls,
+  getControls: GetProgressStreamControls = () => ({
+    bashBypass: false,
+    toolEditBypass: false,
+    superYoloBypass: false,
+    goalActive: false,
+  }),
 ): Promise<SyncHarness> {
   const state = new SessionState();
   await state.snapshots.load([]);
@@ -112,6 +117,7 @@ async function createSyncHarness(
       messages.push(payload);
     },
     () => true,
+    () => '',
   );
   return { state, messages, bridge, renderer };
 }

--- a/src/test-kernel/progressView/progressBackendHarness.ts
+++ b/src/test-kernel/progressView/progressBackendHarness.ts
@@ -14,7 +14,8 @@ import type {
   DeleteExecutionResult,
 } from '@agent/storage/executionListing';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { SessionHandle } from '@agent/runtime/SessionHandle';
+import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
+import type { GetProgressStreamControls } from '@controllers/progressView/progressStreamControls';
 import {
   ProgressBackend,
   type ProgressBackendOptions,
@@ -62,6 +63,14 @@ export async function createLiveStoreSession(): Promise<SessionHandle> {
   });
 }
 
+/** Stream controls with every bypass off and no goal — the pre-run default. */
+export const stubStreamControls: GetProgressStreamControls = () => ({
+  bashBypass: false,
+  toolEditBypass: false,
+  superYoloBypass: false,
+  goalActive: false,
+});
+
 export function toolUseConfig(agent: string, model: string): AgentConfig {
   return {
     agent,
@@ -78,6 +87,7 @@ export function createRecordingBackend(): {
   const backend = track(
     new ProgressBackend({
       storage: new FakeStateStore(),
+      session: defaultSession(),
       sendMessage: (message) => {
         messages.push(message);
         return true;
@@ -86,6 +96,7 @@ export function createRecordingBackend(): {
       reportTranscriptLoadError: vi.fn(),
       approvals: createApprovalOptions(),
       lifecycle: createLifecycleOptions(),
+      getStreamControls: stubStreamControls,
     }),
   );
   return { backend, messages };
@@ -116,6 +127,7 @@ export function createIsolatedRecordingBackend(
       reportTranscriptLoadError,
       approvals: createApprovalOptions(),
       lifecycle,
+      getStreamControls: stubStreamControls,
     }),
   );
   return { backend, lifecycle, messages, reportTranscriptLoadError, session };


### PR DESCRIPTION
## Summary

Executes **Batch B — dead props, params, and test-only fallbacks across hosts** from the adversarially-verified 2026-08-18 round-2 deletion manifest. Eight deletions, all anchors re-verified against origin/main before editing; none proved load-bearing, so no items were skipped. Net −68 LOC (75+/143−).

1. **BaseTextInput controlled-cursor mode** (`packages/cli/src/chat/tui/input/BaseTextInput.tsx`) — deleted the `cursor`/`onCursorChange` props and the `isControlled` machinery. Verified: none of the 7 render sites (ApiKeyEntryForm, ConfigForm, ReverseSearch, ExternalInquiry, ConfirmCard, UserQuestion, InputBar) passes either prop, and there are no prop spreads. The caret is now purely internal state.
2. **DiffView `maxHunkLines`** (`packages/cli/src/chat/tui/render/DiffView.tsx`) — deleted the parameter from `diffDisplayLines`, `wrappedDiffDisplayLines`, `scrollBoundedDiffDisplayLines`, and `DiffViewProps`, plus the unreachable per-hunk slice/`… N more lines` branch. Only `DiffView.vitest.ts` ever passed a non-zero value (a no-op even there: 30 > hunk length). The `overflow` line kind is **kept** — live via `maxDisplayLines`. Test call sites shifted positionally.
3. **`AppProps.inputDisabled`** (`packages/cli/src/chat/tui/App.tsx`) — no caller (runChatTui, tui-harness, both App test suites) passes it.
4. **`InputBarProps.prompt`** (`packages/cli/src/chat/tui/panes/InputBar.tsx`) — always rendered as `POINTER`; no caller passes it.
5. **`LogFields` `streamId`/`runId`/`groupId` + `[streamId]` decoration** (`packages/cli/src/runtime/logSinks.ts`) — producer-less; no log call site anywhere passes these fields. The index signature stays.
6. **Legacy banner-settings fallback** (`src/controllers/mainView/MainViewStartupController.ts`) — the `ui.show*Banner` config keys were retired by #9490 and exist in no schema; banner dismissal lives solely in global state. Deleted `legacySettingPath`, the `getConfig` dep at both construction sites (`MainViewMessageHandler.ts`, `desktopMainViewStartup.ts`), the config-fallback test, and the stray `"texra.ui.showLoginBanner": false` in `.vscode/settings.json` (ruled deletable, OSS-readiness audit).
7. **ProgressBackend test-only fallbacks → required** — `ProgressBackendOptions.session` (was `?? defaultSession()`), `ProgressBackendOptions.getStreamControls` + `ProgressStreamProjectionBuilder`'s `getDefaultProgressStreamControls` default (helper deleted), and `LitSessionRenderer.getActiveStream` (was `= () => ''`). Both production hosts already pass all three. Five test constructions get explicit `session`/`getStreamControls` stubs; the two direct renderer tests pass `() => ''`. The `stateOwnership ?? 'backend'` fallback is live and untouched.
8. **`ExtractOptions.channel`** (`src/latex/arxivProcessor.ts`) — the sole production caller passes `{ timeout }` only; `extractTarFile` now logs on the owner channel unconditionally. The test's channel-override half goes with it.

## R6 — anchors re-verified

Every anchor was re-checked at HEAD (33a47fc84c) with fresh greps for callers, prop spreads, JSX usage, and test constructions before deletion. Zero skips: no item proved load-bearing.

## R8 — gates

- `npm run typecheck` (all 6 projects) — green
- `FORCE_COLOR=0 vitest run src/test-kernel/cli/ src/test-kernel/controllers/ src/test-kernel/latex/ src/test-kernel/progressView/` — 264 files, 3768 passed / 1 skipped (ArxivProcessor tests live in `src/test-kernel/latex/ArxivProcessor.vitest.ts`)
- `eslint` on all 20 changed TS/TSX files — clean
- `prettier --check` on all changed files — clean
- `git diff --check` — clean
- `npm run check:dead-code-ratchet` — OK (8 findings vs 8 baselined, no widening)
- `pnpm-lock.yaml` churn reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)