### PR TITLE
refactor(agent): delete write-only reflection state and dead trace options

### DIFF
--- a/packages/extension/src/commands/agent/agentCreatorCommands.ts
+++ b/packages/extension/src/commands/agent/agentCreatorCommands.ts
@@ -186,8 +186,8 @@ function buildVSCodeUI(): AgentCreatorUI {
       void vscode.window.showInformationMessage(`Created agent at ${filePath}`);
     },
 
-    async promptAddToConfig(agentName, isEdited, category) {
-      await promptToAddAgentToConfig(agentName, 'custom', isEdited, category);
+    async promptAddToConfig(agentName, category) {
+      await promptToAddAgentToConfig(agentName, 'custom', category);
     },
 
     async openCreatedFile(filePath) {

--- a/packages/extension/src/frontend/agents/register.ts
+++ b/packages/extension/src/frontend/agents/register.ts
@@ -13,7 +13,6 @@ const log = createLog('AgentRegister');
 export async function promptToAddAgentToConfig(
   agentName: string,
   source: AgentSource,
-  autoAdd = false,
   category: 'workflow' | 'toolUse' = 'workflow',
 ): Promise<void> {
   const roster = createWorkspaceAgentRosterController();
@@ -25,7 +24,6 @@ export async function promptToAddAgentToConfig(
   }
 
   const shouldAdd =
-    autoAdd ||
     (await vscode.window.showInformationMessage(
       `Agent "${agentName}" was created or modified. Show it in the agent dropdown?`,
       'Add Agent',

--- a/src/agent/core/state/AgentWorkspaceState.ts
+++ b/src/agent/core/state/AgentWorkspaceState.ts
@@ -304,12 +304,6 @@ export class WorkPlanState {
     if (!a || !b) return false;
     return a.objective === b.objective;
   }
-
-  reset(): void {
-    this._todos = [];
-    this._plan = null;
-    this._planSummary = null;
-  }
 }
 
 const AgentWorkspaceSnapshotFieldsSchema = z.object({

--- a/src/agent/implementations/agentCreator/agentCreatorFlow.ts
+++ b/src/agent/implementations/agentCreator/agentCreatorFlow.ts
@@ -185,11 +185,7 @@ export interface AgentCreatorUI {
   ): Promise<{ tools: string[]; groups: string[] } | undefined>;
   getCustomAgentDir(): Promise<string>;
   showCreatedInfo(filePath: string): void;
-  promptAddToConfig(
-    agentName: string,
-    isEdited: boolean,
-    category: AgentCategory,
-  ): Promise<void>;
+  promptAddToConfig(agentName: string, category: AgentCategory): Promise<void>;
   openCreatedFile(filePath: string): Promise<void>;
   renderTemplate(template: string, vars: Record<string, unknown>): string;
 }
@@ -394,6 +390,6 @@ export async function runAgentCreator(
   const yamlContent = await generateAgentYaml(config, blueprint, ui);
   await AbsoluteFS.write(blueprint.filePath, yamlContent);
   ui.showCreatedInfo(blueprint.filePath);
-  await ui.promptAddToConfig(agentName, false, category);
+  await ui.promptAddToConfig(agentName, category);
   await ui.openCreatedFile(blueprint.filePath);
 }

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -11,7 +11,6 @@ import { ProviderMessageArraySchema } from '@agent/types/ProviderMessage';
 import { ModelHandlerCompatibilityKeySchema } from '@agent/runtime/modelHandlerCompatibilityKey';
 import {
   AgentFileLocationSchema,
-  CompileResultSchema,
   RetryErrorInfoSchema,
   RoundOutputSchema,
 } from '@shared/schemas';
@@ -34,7 +33,6 @@ export const ReflectionFlowStateSchema = z.object({
   conversation: ProviderMessageArraySchema,
   runStateSnapshot: AgentRunStateSnapshotSchema,
 
-  roundStateSnapshots: z.array(ConversationRoundStateSnapshotSchema),
   roundOutputs: z.array(RoundOutputSchema),
 
   continueRounds: z.boolean(),
@@ -45,9 +43,6 @@ export const ReflectionFlowStateSchema = z.object({
 
   /** Provider-message format used by the persisted conversation. */
   modelHandlerCompatibilityKey: ModelHandlerCompatibilityKeySchema.nullish(),
-
-  /** Final LaTeX compile status for the last completed round, when checked. */
-  lastCompileResult: CompileResultSchema.optional(),
 
   /** One-shot repair context injected into the next round's user request. */
   compileFailureContext: z.string().optional(),

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -210,11 +210,6 @@ export class OutputNode<C = unknown> extends Node<
       rawOutput: null,
       outputs: [],
       compileFailures: [],
-      xmlSummary: {
-        tagContents: {},
-        singleOutputFile: null,
-        sourceLocation: null,
-      },
     });
 
     return {
@@ -297,19 +292,14 @@ export class OutputNode<C = unknown> extends Node<
 
     // Project the canonical live collection into PersistedFlow's cloned state.
     shared.roundOutputs = roundsToPersisted(outputState);
-    if (execRes.compileResult) {
-      shared.lastCompileResult = execRes.compileResult;
-      const compileFailureContext =
-        workflowOutputPolicy.shouldRejectOnCompileFailure()
-          ? formatCompileFailureRoundContext(execRes.compileResult)
-          : undefined;
-      if (compileFailureContext) {
-        shared.compileFailureContext = compileFailureContext;
-      } else {
-        delete shared.compileFailureContext;
-      }
+    const compileFailureContext =
+      execRes.compileResult &&
+      workflowOutputPolicy.shouldRejectOnCompileFailure()
+        ? formatCompileFailureRoundContext(execRes.compileResult)
+        : undefined;
+    if (compileFailureContext) {
+      shared.compileFailureContext = compileFailureContext;
     } else {
-      delete shared.lastCompileResult;
       delete shared.compileFailureContext;
     }
 

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -182,7 +182,6 @@ export class ResponseCycleNode<C = unknown> extends Node<
       excludeAssemblyStrings: true,
     });
     shared.conversation = prepRes.context.messages;
-    shared.roundStateSnapshots.push(prepRes.context.stateRoundSnapshot);
 
     return FlowTransition.DEFAULT;
   }

--- a/src/agent/implementations/flows/reflection/output/OutputFileProcessor.ts
+++ b/src/agent/implementations/flows/reflection/output/OutputFileProcessor.ts
@@ -1,16 +1,8 @@
 import { reportMissingOutputs } from '@agent/runtime/runFactEvents';
-import type {
-  FileLocation,
-  OutputFileInfo,
-  OutputXmlSummary,
-} from '@shared/schemas';
+import type { FileLocation } from '@shared/schemas';
 import { OUTPUT_DOCUMENTS_TAG } from '@shared/schemas';
 import { normalizeFilePath } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
-import {
-  extractMultipleTextFromTag,
-  extractTextFromTag,
-} from '@utils/text/xmlExtraction';
 import { replaceInputCommands } from './fileMapping';
 
 import { tryOperation } from './outputOperations';
@@ -32,7 +24,6 @@ export class OutputFileProcessor {
   async processMultipleOutputs(
     outputLocation: FileLocation,
     currRound: number,
-    rawLocation: FileLocation,
   ): Promise<void> {
     const { logger } = this.deps;
 
@@ -54,7 +45,7 @@ export class OutputFileProcessor {
           logger.debug(
             `No processed files were generated from ${outputLocation.absolutePath}`,
           );
-          await this.handleNoOutputs(currRound, outputLocation, rawLocation);
+          await this.handleNoOutputs(currRound, outputLocation);
           return;
         }
 
@@ -63,14 +54,12 @@ export class OutputFileProcessor {
           await replaceInputCommands(this.deps.baseFiles, locations, logger);
         }
         ensureRoundData(this.state, currRound).outputs = processedPairs;
-        await this.captureXmlSummary(currRound, rawLocation, processedPairs);
       },
       {
         logger,
         level: 'debug',
         label: 'Error processing output file',
-        recover: () =>
-          this.handleNoOutputs(currRound, outputLocation, rawLocation),
+        recover: () => this.handleNoOutputs(currRound, outputLocation),
       },
     );
   }
@@ -122,11 +111,9 @@ export class OutputFileProcessor {
   private async handleNoOutputs(
     currRound: number,
     outputLocation: FileLocation,
-    rawLocation: FileLocation,
   ): Promise<void> {
     await this.emitMissingOutputs(currRound, outputLocation);
     ensureRoundData(this.state, currRound).outputs = [];
-    await this.captureXmlSummary(currRound, rawLocation, []);
   }
 
   /** Logs and signals the UI that a round produced no extractable output files. */
@@ -159,71 +146,5 @@ export class OutputFileProcessor {
       missing: [],
       xmlFile: outputLocation.absolutePath,
     });
-  }
-
-  private async captureXmlSummary(
-    round: number,
-    rawOutput: FileLocation | null,
-    processed: OutputFileInfo[],
-  ): Promise<void> {
-    const data = ensureRoundData(this.state, round);
-    const singleFile =
-      processed.length === 1 ? processed[0].location.absolutePath : null;
-
-    const buildSummary = (
-      tagContents: Record<string, string[]> = {},
-    ): OutputXmlSummary => ({
-      tagContents,
-      singleOutputFile: singleFile,
-      sourceLocation: rawOutput,
-    });
-
-    if (!rawOutput?.absolutePath) {
-      data.xmlSummary = buildSummary();
-      return;
-    }
-
-    await tryOperation(
-      async () => {
-        const rawContent = await AbsoluteFS.read(rawOutput.absolutePath);
-        const tagContents: Record<string, string[]> = {};
-
-        const documentEntries = extractMultipleTextFromTag(
-          rawContent,
-          OUTPUT_DOCUMENTS_TAG,
-        );
-        if (documentEntries.length > 0) {
-          tagContents[OUTPUT_DOCUMENTS_TAG] = documentEntries.map((e) =>
-            e.content.trim(),
-          );
-        } else {
-          const singleDocument = extractTextFromTag(
-            rawContent,
-            OUTPUT_DOCUMENTS_TAG,
-          ).trim();
-          if (singleDocument) {
-            tagContents[OUTPUT_DOCUMENTS_TAG] = [singleDocument];
-          }
-        }
-
-        const scratchpadContent = extractTextFromTag(
-          rawContent,
-          'scratchpad',
-        ).trim();
-        if (scratchpadContent) {
-          tagContents.scratchpad = [scratchpadContent];
-        }
-
-        data.xmlSummary = buildSummary(tagContents);
-      },
-      {
-        logger: this.deps.logger,
-        level: 'debug',
-        label: `Failed to collect XML summary for round ${round}`,
-        recover: () => {
-          data.xmlSummary = buildSummary();
-        },
-      },
-    );
   }
 }

--- a/src/agent/implementations/flows/reflection/output/outputFileExtraction.ts
+++ b/src/agent/implementations/flows/reflection/output/outputFileExtraction.ts
@@ -66,17 +66,12 @@ export async function extractFilesFromXml(
 
       const data = ensureRoundData(state, currRound);
       data.rawOutput ??= outputLocation;
-      const rawLocation = data.rawOutput;
 
       const fileProcessor = new OutputFileProcessor(state, deps, xmlManager);
 
       // The unified protocol emits <documents><document name="..."> containers
       // (N >= 1), so all agents route through the multi-document path.
-      await fileProcessor.processMultipleOutputs(
-        outputLocation,
-        currRound,
-        rawLocation,
-      );
+      await fileProcessor.processMultipleOutputs(outputLocation, currRound);
     },
   );
 }

--- a/src/agent/implementations/flows/reflection/output/outputState.ts
+++ b/src/agent/implementations/flows/reflection/output/outputState.ts
@@ -16,7 +16,6 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { AgentWorkflowSetting } from '@agent/core/definition/AgentDataclass';
 import type { RunScope } from '@agent/runtime/RunScope';
 import {
-  OutputXmlSummarySchema,
   type CompileFailure,
   type FileLocation,
   type OutputFileInfo,
@@ -118,7 +117,6 @@ export function ensureRoundData(
     rawOutput: null,
     outputs: [],
     compileFailures: [],
-    xmlSummary: OutputXmlSummarySchema.parse({}),
   };
   state.rounds.set(round, data);
   return data;

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -230,7 +230,6 @@ export async function runReflectionFlow<C = unknown>(
       conversation: [],
       modelHandlerCompatibilityKey: compatibilityKey,
       runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
-      roundStateSnapshots: [],
       roundOutputs: [],
       continueRounds: true,
       endTurn: false,

--- a/src/agent/runtime/modelHandlerCompatibilityInference.ts
+++ b/src/agent/runtime/modelHandlerCompatibilityInference.ts
@@ -25,13 +25,6 @@ export function inferPersistedModelHandlerCompatibilityKey(
 ): ModelHandlerCompatibilityKey | undefined {
   const modelConfig = getRuntimeModelConfig(model);
 
-  // Copilot had no direct handler before ModelHandlerVscodeLm. Its only
-  // runnable legacy route was OpenRouter, so a keyless persisted transcript
-  // necessarily uses the OpenRouter message format. New Copilot sessions
-  // persist their explicit compatibility key and do not enter this inference.
-  if (modelConfig?.provider === ModelProvider.COPILOT) {
-    return 'ModelHandlerOpenRouterNative';
-  }
   if (modelConfig?.provider === ModelProvider.GOOGLE) {
     throw new Error(
       'Persisted Google sessions without a model-handler identity cannot be resumed.',

--- a/src/agent/trace/AgentTrace.ts
+++ b/src/agent/trace/AgentTrace.ts
@@ -16,7 +16,6 @@ import type { RunOutcome, UpdateStreamUsagePayload } from '@shared/schemas';
 import type {
   AgentEvent,
   ContextStateData,
-  LogEvent,
   ResponseFinalizedEvent,
   StreamKind,
   ToolStatus,
@@ -39,11 +38,6 @@ export interface StageOptions {
   readonly total?: number;
   /** Physical workflow attempt that owns this stage, when applicable. */
   readonly attemptId?: string;
-  /**
-   * Outcome to emit at stage.end when no explicit status is supplied.
-   * Defaults to `completed`.
-   */
-  readonly defaultStatus?: RunOutcome;
   /**
    * Skip stage creation but propagate parent context to nested calls.
    * `handle.id` is undefined; `handle.within(fn)` runs `fn` in the parent
@@ -72,8 +66,6 @@ export interface StageHandle {
 export interface StreamOptions {
   /** Explicit id; otherwise a fresh one is generated. */
   readonly id?: string;
-  /** Level used for the underlying log entries. */
-  readonly level?: LogEvent['level'];
   /** Stage id stamped on the start event; defaults to the active scope. */
   readonly stageId?: string;
   /**

--- a/src/agent/trace/TraceEmitter.ts
+++ b/src/agent/trace/TraceEmitter.ts
@@ -216,7 +216,6 @@ export class TraceEmitter implements AgentTrace {
   // ─── Stages ────────────────────────────────────────────────────────
 
   openStage(label: string, options: StageOptions = {}): StageHandle {
-    const defaultStatus = options.defaultStatus ?? RUN_OUTCOME.COMPLETED;
     const parentId =
       options.parent?.id ?? options.parentId ?? this.activeStageId();
 
@@ -235,7 +234,7 @@ export class TraceEmitter implements AgentTrace {
       total: options.total,
       attemptId: options.attemptId,
     });
-    return new StageHandleImpl(this, id, defaultStatus);
+    return new StageHandleImpl(this, id);
   }
 
   // ─── Streams ───────────────────────────────────────────────────────
@@ -277,7 +276,6 @@ class StageHandleImpl implements StageHandle {
   constructor(
     private readonly trace: TraceEmitter,
     readonly id: string,
-    private readonly defaultStatus: RunOutcome,
   ) {}
 
   end(status?: RunOutcome): void {
@@ -286,7 +284,7 @@ class StageHandleImpl implements StageHandle {
     this.trace.emit({
       type: 'stage.end',
       id: this.id,
-      status: status ?? this.defaultStatus,
+      status: status ?? RUN_OUTCOME.COMPLETED,
     });
   }
 

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -61,7 +61,7 @@ interface StageStamp {
 }
 
 /** Plain log line — sugar for debug/info/warn/error converges here. */
-export interface LogEvent extends StageStamp {
+interface LogEvent extends StageStamp {
   readonly type: 'log';
   readonly level: 'debug' | 'info' | 'warn' | 'error';
   readonly message: string;

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -138,7 +138,7 @@ export const CompileFailureSummarySchema = z.object({
 });
 type CompileFailureSummary = z.infer<typeof CompileFailureSummarySchema>;
 
-export const CompileResultSchema = z.discriminatedUnion('status', [
+const CompileResultSchema = z.discriminatedUnion('status', [
   z.strictObject({
     status: z.literal('ok'),
     round: RoundNumberSchema,
@@ -152,20 +152,11 @@ export const CompileResultSchema = z.discriminatedUnion('status', [
 ]);
 export type CompileResult = z.infer<typeof CompileResultSchema>;
 
-export const OutputXmlSummarySchema = z.strictObject({
-  tagContents: z.record(z.string(), z.array(z.string())).prefault(() => ({})),
-  singleOutputFile: z.string().nullable().prefault(null),
-  sourceLocation: FileLocationSchema.nullable().prefault(null),
-});
-
-export type OutputXmlSummary = z.infer<typeof OutputXmlSummarySchema>;
-
 export const RoundOutputSchema = z.strictObject({
   round: RoundNumberSchema,
   rawOutput: FileLocationSchema.nullable(),
   outputs: OutputFileInfoSchema.array(),
   compileFailures: CompileFailureSchema.array().prefault(() => []),
-  xmlSummary: OutputXmlSummarySchema,
 });
 export type RoundOutput = z.infer<typeof RoundOutputSchema>;
 

--- a/src/shared/schemas/roundIndexed.ts
+++ b/src/shared/schemas/roundIndexed.ts
@@ -8,8 +8,8 @@
  * step exists anywhere.
  *
  * Deliberately NOT unified into this shape (different requirements, not
- * history): `RoundOutput[]` (a per-round aggregate carrying `rawOutput` and
- * `xmlSummary`, owned by the reflection flow) and `DiffResult.baseRound` /
+ * history): `RoundOutput[]` (a per-round aggregate carrying `rawOutput`,
+ * owned by the reflection flow) and `DiffResult.baseRound` /
  * `revisedRound` (scalar round references, already legacy-normalized at their
  * own parse entry in `diffResult.ts`).
  */

--- a/src/test-kernel/agent/AgentCreatorOrchestration.vitest.ts
+++ b/src/test-kernel/agent/AgentCreatorOrchestration.vitest.ts
@@ -109,11 +109,7 @@ describe('agent creator orchestration', () => {
       resolve('/agents/editor.yaml'),
       'generated: true',
     );
-    expect(ui.promptAddToConfig).toHaveBeenCalledWith(
-      'editor',
-      false,
-      'workflow',
-    );
+    expect(ui.promptAddToConfig).toHaveBeenCalledWith('editor', 'workflow');
     expect(ui.openCreatedFile).toHaveBeenCalledWith(
       resolve('/agents/editor.yaml'),
     );
@@ -151,11 +147,7 @@ describe('agent creator orchestration', () => {
         ),
       }),
     );
-    expect(ui.promptAddToConfig).toHaveBeenCalledWith(
-      'researcher',
-      false,
-      'toolUse',
-    );
+    expect(ui.promptAddToConfig).toHaveBeenCalledWith('researcher', 'toolUse');
   });
 
   it('stops before description when name selection is cancelled', async () => {

--- a/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
+++ b/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
@@ -217,7 +217,6 @@ describe('runReflectionFlow persisted-state recovery', () => {
       outputLocation: null,
       conversation: [],
       runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
-      roundStateSnapshots: [],
       roundOutputs: [],
       continueRounds: true,
       endTurn: false,

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerCompatibilityInference.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerCompatibilityInference.vitest.ts
@@ -35,21 +35,6 @@ describe('model handler compatibility inference', () => {
     info.mockClear();
   });
 
-  it('keeps keyless legacy Copilot transcripts on OpenRouter', () => {
-    expect(
-      inferAndLogPersistedModelHandlerCompatibilityKey('copilot4o', logger),
-    ).toBe('ModelHandlerOpenRouterNative');
-    expect(info).toHaveBeenCalledWith(
-      'Inferred model-handler compatibility for keyless persisted run',
-      {
-        data: {
-          model: 'copilot4o',
-          compatibilityKey: 'ModelHandlerOpenRouterNative',
-        },
-      },
-    );
-  });
-
   it('rejects keyless Google transcripts without inspecting their format', () => {
     expect(() =>
       inferPersistedFlowModelHandlerCompatibilityKey(
@@ -83,19 +68,6 @@ describe('model handler compatibility inference', () => {
       }),
     ).toBe('ModelHandlerOpenRouterNative');
     expect(info).not.toHaveBeenCalled();
-  });
-
-  it('infers from the model alone when the record carries no parseable messages', () => {
-    expect(
-      inferPersistedFlowModelHandlerCompatibilityKey('gpt54', {
-        stateSlices: {
-          userChannels: {
-            input: {},
-            transient: { MODEL: 'copilot4o' },
-          },
-        },
-      }),
-    ).toBe('ModelHandlerOpenRouterNative');
   });
 
   it('does not log when inference is inconclusive', () => {

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -266,7 +266,6 @@ describe('output progress events', () => {
       },
     );
 
-    expect(shared.lastCompileResult).toEqual(fixture.compileResult);
     if (rejectOnCompileFailure) {
       expect(shared.compileFailureContext).toContain(
         'previous workflow round was rejected',
@@ -285,12 +284,6 @@ describe('output progress events', () => {
     const shared = {
       roundOutputs: [],
       compileFailureContext: 'old context',
-      lastCompileResult: {
-        status: 'failed',
-        round: 0,
-        failures: [],
-        logExcerpt: 'old log',
-      },
     } as unknown as ReflectionFlowShared;
 
     await runOutputPost(
@@ -310,7 +303,6 @@ describe('output progress events', () => {
       },
     );
 
-    expect(shared.lastCompileResult).toEqual(compileResult);
     expect(shared.compileFailureContext).toBeUndefined();
   });
 
@@ -342,11 +334,7 @@ describe('output progress events', () => {
         state,
         processorDeps(logger),
         xmlManager,
-      ).processMultipleOutputs(
-        createLocation(outputPath),
-        round,
-        createLocation('/tmp/raw-output.xml'),
-      );
+      ).processMultipleOutputs(createLocation(outputPath), round);
 
       expect(runEventsOfType(events, 'updateMissingOutputs')).toMatchObject([
         {
@@ -385,11 +373,7 @@ describe('output progress events', () => {
         createOutputState(),
         processorDeps(logger),
         xmlManager,
-      ).processMultipleOutputs(
-        createLocation('/tmp/output.xml'),
-        5,
-        createLocation('/tmp/output.xml'),
-      );
+      ).processMultipleOutputs(createLocation('/tmp/output.xml'), 5);
 
       expect(warnings).toHaveLength(1);
       expect(warnings[0]).toContain('no files could be extracted');

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -922,7 +922,6 @@ Appendix.
     await processor.processMultipleOutputs(
       createExternalLocation('/tmp/run/output.xml'),
       0,
-      createExternalLocation('/tmp/run/output.xml'),
     );
 
     const roundOutputs = state.rounds.get(0)?.outputs ?? [];
@@ -1331,7 +1330,6 @@ Appendix.
     await processor.processMultipleOutputs(
       createExternalLocation('/tmp/run/r1/output.xml'),
       1,
-      createExternalLocation('/tmp/run/r1/output.xml'),
     );
 
     const roundOutputs = state.rounds.get(1)?.outputs ?? [];

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -136,7 +136,6 @@ export function reflectionFlowShared(
     outputLocation: null,
     conversation: [],
     runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
-    roundStateSnapshots: [],
     roundOutputs: [],
     continueRounds: true,
     endTurn: false,

--- a/src/test-kernel/cli/HistoryStatus.vitest.ts
+++ b/src/test-kernel/cli/HistoryStatus.vitest.ts
@@ -166,7 +166,6 @@ describe('CLI history status formatting', () => {
         outputLocation: null,
         conversation: [],
         runStateSnapshot: {},
-        roundStateSnapshots: [],
         roundOutputs: [],
         continueRounds: false,
         endTurn: false,

--- a/src/test-kernel/schemas/OutputSummaryTransforms.vitest.ts
+++ b/src/test-kernel/schemas/OutputSummaryTransforms.vitest.ts
@@ -59,11 +59,6 @@ function roundOutput(overrides: Partial<RoundOutput> = {}): RoundOutput {
     rawOutput: null,
     outputs: [],
     compileFailures: [],
-    xmlSummary: {
-      tagContents: {},
-      singleOutputFile: null,
-      sourceLocation: null,
-    },
     ...overrides,
   };
 }

--- a/src/test-kernel/schemas/SchemaMigrations.vitest.ts
+++ b/src/test-kernel/schemas/SchemaMigrations.vitest.ts
@@ -4,7 +4,6 @@ import { RunUsageAccumulatorJSONSchema } from '@agent/core/usage/RunUsageAccumul
 import {
   ActiveChildInfoSchema,
   ContextManagementDataSchema,
-  OutputXmlSummarySchema,
   STREAM_PHASE,
   STREAM_STATUS,
 } from '@shared/schemas';
@@ -44,43 +43,6 @@ describe('RunUsageAccumulatorJSONSchema — canonical shape', () => {
         normalizedSnapshots: [{ round: 0, usage: usageFixture }],
       }),
     ).toThrow();
-  });
-});
-
-describe('OutputXmlSummarySchema — tagContents values', () => {
-  it('passes a string[] value through unchanged', () => {
-    const result = OutputXmlSummarySchema.parse({
-      tagContents: { authors: ['Alice', 'Bob'] },
-    });
-
-    expect(result.tagContents['authors']).toEqual(['Alice', 'Bob']);
-  });
-
-  it('defaults a missing tagContents to an empty record', () => {
-    const result = OutputXmlSummarySchema.parse({});
-
-    expect(result.tagContents).toEqual({});
-  });
-
-  it.each([
-    ['a retired bare-string value', { tagContents: { title: 'My Paper' } }],
-    ['a malformed value', { tagContents: { broken: 42 } }],
-  ])('rejects %s instead of coercing it', (_label, payload) => {
-    // The string-to-array coercion and its .catch([]) are retired: persisted
-    // data that no longer parses must fail loudly, not degrade silently.
-    expect(() => OutputXmlSummarySchema.parse(payload)).toThrow();
-  });
-});
-
-describe('OutputXmlSummarySchema — strict shape', () => {
-  it.each([
-    [
-      'an unrecognized key on a record without documents',
-      { tagContents: {}, unexpected: 1 },
-    ],
-    ['the retired documents key', { tagContents: {}, documents: [] }],
-  ])('rejects %s', (_label, payload) => {
-    expect(() => OutputXmlSummarySchema.parse(payload)).toThrow();
   });
 });
 

--- a/src/utils/text/xmlExtraction.ts
+++ b/src/utils/text/xmlExtraction.ts
@@ -93,7 +93,7 @@ function extractNamedDocuments(
  * Extract multiple document elements from an XML container tag
  * Used as a fallback for extracting documents when XML parsing fails
  */
-export function extractMultipleTextFromTag(
+function extractMultipleTextFromTag(
   inputContent: string,
   containerTag?: string,
 ): Array<{ content: string; name: string }> {


### PR DESCRIPTION
## Summary

Batch A of the adversarially-verified 2026-08-18 round-2 deletion manifest: six dead-code cuts in reflection flow state, agent-runtime, trace options, and the agent creator. Every anchor was re-verified against origin/main before cutting; all six survived verification, none were skipped.

1. **`roundStateSnapshots` + `lastCompileResult`** — persisted `ReflectionFlowState` fields written on every round (`ResponseCycleNode`, `OutputNode`) and read by nothing repo-wide. `ReflectionFlowStateSchema` is a plain `z.object`, so old persisted keys are silently stripped on resume-parse — no migration needed.
2. **`xmlSummary` / `OutputXmlSummarySchema` pipeline** — `captureXmlSummary` in `OutputFileProcessor` (66 lines), the `RoundOutput.xmlSummary` field, and every fixture init. The last reader was deleted by #10612. The now-unused `rawLocation` parameter chain through `processMultipleOutputs`/`handleNoOutputs` is dropped with it.
3. **`StageOptions.defaultStatus` + `StreamOptions.level`** — zero producers anywhere; `TraceEmitter.openStream` never read `level`. `RUN_OUTCOME.COMPLETED` is inlined at the single `stage.end` fallback; the orphaned `LogEvent` import is gone from `AgentTrace.ts`.
4. **`WorkPlanState.reset()`** — zero callers.
5. **COPILOT compat-inference arm** — ruling-backed retirement (2026-08-10 simplifier-fleet strategy doc, Theme F: "can retire now"). The Google keyless throw and `currentModelFromRawSharedState` are ruling-gated and untouched.
6. **agentCreator `isEdited`/`autoAdd` chain** — the only production call passed `false`, so `promptToAddAgentToConfig`'s `autoAdd ||` branch was statically dead. Parameter deleted through the whole chain (flow interface → command wiring → register.ts).

Exports orphaned by the cuts are unexported rather than baselined (all still used internally): `LogEvent` (events.ts union member), `CompileResultSchema` (type derivation only), `extractMultipleTextFromTag` (xmlExtraction-internal).

**Accepted caveat (xmlSummary):** a reflection run left UNFINISHED before this change fails resume loudly — `RoundOutputSchema` is a `strictObject`, so a persisted `roundOutputs` entry still carrying `xmlSummary` rejects at parse. This is consistent with the intermediate-data-disposable ruling (#9590 lineage): fail loudly, don't age-gate a compat reader.

## Net elements (R6)

- 27 files changed, **+26 / −267** lines (net **−241**)
- Deleted: 2 schema fields + 1 schema (`OutputXmlSummarySchema`) + 1 type, 1 private method (`captureXmlSummary`), 1 public method (`WorkPlanState.reset`), 2 option fields (`defaultStatus`, `level`), 1 inference arm, 1 parameter threaded through 4 signatures (`isEdited`/`autoAdd`), 1 parameter threaded through 3 signatures (`rawLocation`)
- Added: zero new elements — no new exports, helpers, or layers

## Consumer counts (R8)

- `roundStateSnapshots`: 1 writer, 0 readers → deleted
- `lastCompileResult`: 1 writer, 0 readers (last reader gone) → deleted
- `xmlSummary`: 3 writers (`captureXmlSummary` x2 paths + 2 literal inits), 0 readers since #10612 → deleted
- `StageOptions.defaultStatus` / `StreamOptions.level`: 0 producers each → deleted
- `WorkPlanState.reset()`: 0 callers → deleted
- COPILOT arm: reachable only from keyless persisted transcripts; retire-now ruling → deleted
- `promptToAddAgentToConfig` `autoAdd`: 1 caller, statically `false` → deleted
- Unexported (internal consumers remain): `LogEvent` (1 internal use), `CompileResultSchema` (1), `extractMultipleTextFromTag` (1)

## Gates

- `npm run typecheck` — pass (all workspaces)
- `vitest run src/test-kernel/agent/ src/test-kernel/model/ src/test-kernel/logger/ src/test-kernel/transcript/ src/test-kernel/schemas/ src/test-kernel/utils/ src/test-kernel/cli/HistoryStatus.vitest.ts` — 258 files / 3979 tests pass
- eslint on all changed files — clean
- `git diff --check` — clean
- `npm run check:dead-code-ratchet` — OK (no new findings; baseline unchanged)
- prettier — clean; pnpm-lock.yaml churn reverted

Tests pinning deleted behavior were deleted, not rewritten (Copilot inference cases, `OutputXmlSummarySchema` describes, `lastCompileResult` assertions); surviving suites updated to the narrowed signatures. Zero new tests, per testing discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)