### PR TITLE
refactor(schemas): remove the RemoteAgent residue and shrink the knip baseline

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -37,16 +37,6 @@
       "name": "packages/trace-viewer/vite.standalone.config.ts"
     },
     {
-      "file": "src/shared/schemas/profileViewMessages.ts",
-      "category": "types",
-      "name": "RemoteAgent"
-    },
-    {
-      "file": "src/shared/schemas/settingsViewMessages.ts",
-      "category": "types",
-      "name": "RemoteAgent"
-    },
-    {
       "file": "src/test-kernel/support/setupFakePlatform.ts",
       "category": "files",
       "name": "src/test-kernel/support/setupFakePlatform.ts"

--- a/src/shared/schemas/profileViewMessages.ts
+++ b/src/shared/schemas/profileViewMessages.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import { PROFILE_VIEW_COMMANDS } from '@shared/ipc';
 import { ProviderSettingDefSchema } from '@shared/constants/providers';
 import { INCLUDED_ACCESS, OWN_API_KEYS } from '@shared/copy/modelAccess';
-import { AgentMetadataBaseSchema } from './agent';
+
 import { commandOnly } from './messageFactories';
 import {
   SpendingStatusErrorSchema,
@@ -31,20 +31,6 @@ export const DEFAULT_GLOBAL_STREAMING = true;
 const ProfileUserSchema = z.object({
   email: z.string(),
 });
-
-/**
- * Remote agent data for the profile view.
- * Extends AgentMetadataBaseSchema (name, category, description) with
- * profile-specific fields. Description is required (non-optional) here.
- *
- * No longer carried on UPDATE_PROFILE; kept only because
- * `settingsViewMessages.ts` re-exports the type (follow-up removal).
- */
-const RemoteAgentSchema = AgentMetadataBaseSchema.extend({
-  description: z.string(), // override optional → required for display
-  supportsMultipleOutput: z.boolean(),
-});
-export type RemoteAgent = z.infer<typeof RemoteAgentSchema>;
 
 const ApiAccessModeSchema = z.enum(['included', 'personal']);
 export type ApiAccessMode = z.infer<typeof ApiAccessModeSchema>;

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -91,7 +91,6 @@ export {
   type NumberSetting,
   type ProviderKeyStatus,
   type ProviderSetting,
-  type RemoteAgent,
   type SessionProblem,
   type UpdateProfileMessage,
 } from './profileViewMessages';


### PR DESCRIPTION
## Summary

The follow-up promised in #10873's body, unblocked now that #10866 and #10873 are both merged: deletes the consumer-less `type RemoteAgent` re-export from `settingsViewMessages.ts`, the `RemoteAgentSchema`/type (+ now-orphaned `AgentMetadataBaseSchema` import) it forced `profileViewMessages.ts` to retain, and the two temporary knip-baseline entries — restoring the baseline's never-widen invariant.

## Net elements (R6)

3 files, +2/−25; −1 exported type, −1 schema const, −2 baseline entries (10 → 8).

## Consumer counts (R8)

`type RemoteAgent`: 0 importers repo-wide outside the two schema files (all `*RemoteAgent*` grep hits are distinct symbols: `isRemoteAgent`, `loadRemoteAgent`, `ViewRemoteAgentPromptMessageSchema`, …).

## Validation

typecheck clean; vitest schemas+controllers 42 files / 464 tests green; eslint clean; `git diff --check` clean; dead-code ratchet: 8 current vs 8 baselined (shrunk in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)