### PR TITLE
refactor: harvest six ruled compat readers across auth, flows, streams, and transcript

### DIFF
--- a/src/agent/implementations/flows/reflection/output/compileCheck.ts
+++ b/src/agent/implementations/flows/reflection/output/compileCheck.ts
@@ -279,7 +279,7 @@ async function compileOne(
     invalidCharPattern: /[^a-zA-Z0-9._-]/g,
     replacement: '_',
   });
-  const pathHash = truncatedHexId(pathForSafeName, PATH_HASH_LENGTH, 'sha1');
+  const pathHash = truncatedHexId(pathForSafeName, PATH_HASH_LENGTH);
   const sanitizedStem = sanitizedName.slice(0, MAX_SANITIZED_STEM_LENGTH);
   const safeName = `${sanitizedStem}_${pathHash}`;
   const buildDir = path.join(

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -23,11 +23,9 @@ import {
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import {
-  WORKFLOW_DOCUMENT_OUTPUT_EXT,
   WORKFLOW_RAW_OUTPUT_EXT,
   workflowOutputPath,
 } from '@shared/constants/workflowOutput';
-import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { TaskRunFileService } from '@utils/files/taskRunStorage';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 import { LatexDiffManager } from './output/LatexDiffManager';
@@ -145,24 +143,10 @@ export async function runReflectionFlow<C = unknown>(
 
   const getOutputFileLocation = async (
     round: number,
-  ): Promise<AgentFileLocation> => {
-    const canonical = fileService.createLocation(
+  ): Promise<AgentFileLocation> =>
+    fileService.createLocation(
       workflowOutputPath({ ext: WORKFLOW_RAW_OUTPUT_EXT, round }),
     ) as AgentFileLocation;
-    // Resume-from-pre-refactor compat: if a round was partially written on an
-    // older build that used `.tex` for non-scratchpad agents, keep using that
-    // file on resume so initializeOutputAndPrefill sees the existing content
-    // instead of starting a fresh round at output.xml.
-    if (!(await AbsoluteFS.exists(canonical.absolutePath))) {
-      const legacy = fileService.createLocation(
-        workflowOutputPath({ ext: WORKFLOW_DOCUMENT_OUTPUT_EXT, round }),
-      ) as AgentFileLocation;
-      if (await AbsoluteFS.exists(legacy.absolutePath)) {
-        return legacy;
-      }
-    }
-    return canonical;
-  };
 
   const workflowOutputPolicy: WorkflowOutputPolicy = {
     shouldAutoOpenPdfOrLog: () =>

--- a/src/agent/runtime/modelHandlerCompatibilityInference.ts
+++ b/src/agent/runtime/modelHandlerCompatibilityInference.ts
@@ -49,26 +49,6 @@ export function inferAndLogPersistedModelHandlerCompatibilityKey(
   return compatibilityKey;
 }
 
-function stringValue(value: unknown): string | undefined {
-  if (typeof value !== 'string') return undefined;
-  return value.trim() || undefined;
-}
-
-function currentModelFromRawSharedState(
-  shared: Record<string, unknown>,
-): string | undefined {
-  const modelId = stringValue(shared.modelId);
-  if (modelId) return modelId;
-  // Records written before `modelId` carry the model only in `MODEL`, and this
-  // reader runs on raw bytes that never passed the migration boundary.
-  const userChannels = asRecord(asRecord(shared.stateSlices)?.userChannels);
-  if (!userChannels) return undefined;
-  return (
-    stringValue(asRecord(userChannels.transient)?.MODEL) ??
-    stringValue(asRecord(userChannels.input)?.MODEL)
-  );
-}
-
 export function inferPersistedFlowModelHandlerCompatibilityKey(
   model: string,
   shared: unknown,
@@ -83,7 +63,5 @@ export function inferPersistedFlowModelHandlerCompatibilityKey(
 
   // Inference reads model identity only; the persisted messages never fed the
   // decision, so they are not parsed here.
-  return inferPersistedModelHandlerCompatibilityKey(
-    currentModelFromRawSharedState(record) ?? model,
-  );
+  return inferPersistedModelHandlerCompatibilityKey(model);
 }

--- a/src/auth/SupabaseAuthCoordinator.ts
+++ b/src/auth/SupabaseAuthCoordinator.ts
@@ -1,7 +1,6 @@
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import {
-  GITHUB_TOKEN_REFRESH_URL,
   SUPABASE_CONFIG,
   SUPABASE_SESSION_KEY,
   TOKEN_REFRESH_THRESHOLD_MS,
@@ -12,12 +11,9 @@ import {
 } from './oauth/sessionAccess';
 import { SupabaseClient } from './SupabaseClient';
 import {
-  DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
   SupabaseSessionCoordinator,
   type SupabaseSessionLog,
 } from './SupabaseSession';
-
-const DEFAULT_AUTH_EDGE_FUNCTION_TIMEOUT_MS = 30000;
 
 export interface HostAuthCoordinatorInit {
   readonly secrets: SessionSecretStore;
@@ -52,9 +48,6 @@ export function createHostAuthCoordinator(
     getClient: () => SupabaseClient.getClient(),
     whenReady: init.whenReady ?? (async () => {}),
     tokenRefreshThresholdMs: TOKEN_REFRESH_THRESHOLD_MS,
-    defaultSessionExpiryMs: DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
-    githubTokenRefreshUrl: GITHUB_TOKEN_REFRESH_URL,
-    edgeFunctionTimeoutMs: DEFAULT_AUTH_EDGE_FUNCTION_TIMEOUT_MS,
     log: init.log,
   });
   SupabaseClient.setAuthProvider(coordinator);

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -5,10 +5,8 @@ import {
   parseAuthCallbackCode,
   type AuthCallbackUriParts,
 } from './authCallback';
-import { fetchWithTimeout } from './fetchWithTimeout';
 import {
   parseStoredSupabaseSession,
-  parseTokenExchangeResponse,
   toStorableSupabaseSession,
   type SupabaseCallbackResult,
   type SupabaseSession,
@@ -45,10 +43,6 @@ export interface SupabaseSessionCoordinatorOptions {
   getClient: () => Client;
   whenReady: () => Promise<void>;
   tokenRefreshThresholdMs: number;
-  defaultSessionExpiryMs: number;
-  githubTokenRefreshUrl: string;
-  edgeFunctionTimeoutMs: number;
-  fetch?: typeof fetch;
   log?: SupabaseSessionLog;
 }
 
@@ -259,11 +253,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     return { success: true, session: toStorableSupabaseSession(data.session) };
   }
 
-  /**
-   * Refresh session with concurrency protection.
-   * Routes to custom endpoint for GitHub auth sessions, otherwise uses Supabase
-   * native refresh.
-   */
+  /** Refresh session via Supabase native refresh, with concurrency protection. */
   async refreshSession(
     session: SupabaseSession,
     expectedVersion = this.sessionMutationVersion,
@@ -273,11 +263,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     }
 
     this.lastRefreshFailure = null;
-    this.refreshPromise = (
-      session.useCustomRefresh
-        ? this.refreshViaCustomEndpoint(session)
-        : this.refreshViaSupabase(session)
-    )
+    this.refreshPromise = this.refreshViaSupabase(session)
       .then((refreshed) =>
         refreshed
           ? this.storeRefreshIfCurrent(refreshed, expectedVersion)
@@ -402,9 +388,6 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     }
 
     await this.storeSession(refreshed);
-    if (refreshed.useCustomRefresh) {
-      this.log.info('SupabaseSession', 'Token refreshed via custom endpoint');
-    }
     return this.isCurrentStoredSession(refreshed)
       ? refreshed
       : this.loadStableSession();
@@ -417,37 +400,5 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
       this.lastStoredSession.refreshToken === session.refreshToken &&
       this.lastStoredSession.id === session.id
     );
-  }
-
-  private async refreshViaCustomEndpoint(
-    session: SupabaseSession,
-  ): Promise<SupabaseSession | null> {
-    const response = await fetchWithTimeout(
-      this.options.githubTokenRefreshUrl,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ refresh_token: session.refreshToken }),
-      },
-      this.options.edgeFunctionTimeoutMs,
-      'Token refresh timeout',
-      this.options.fetch,
-    );
-
-    if (!response.ok) {
-      this.lastRefreshFailure = classifyAuthFailureStatus(response.status);
-      this.log.warn(
-        'SupabaseSession',
-        `Token refresh failed: ${response.status}`,
-      );
-      return null;
-    }
-
-    const data = await parseTokenExchangeResponse(response, this.log);
-    this.lastRefreshFailure = null;
-    return toStorableSupabaseSession(data, {
-      fallbackLabel: session.account.label,
-      defaultExpiryMs: this.options.defaultSessionExpiryMs,
-    });
   }
 }

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -40,13 +40,6 @@ export const SUPABASE_CONFIG: SupabaseConfig = {
 };
 
 /**
- * Edge function URL for custom token refresh.
- * Used for sessions minted by the auth edge functions rather than by a
- * standard Supabase OAuth callback.
- */
-export const GITHUB_TOKEN_REFRESH_URL = `https://${SUPABASE_CUSTOM_DOMAIN}/functions/v1/auth-github/refresh`;
-
-/**
  * Base URL for the device-code (RFC 8628 style) sign-in edge function.
  * Used by headless terminals where a loopback OAuth callback can't work.
  */

--- a/src/auth/supabaseSessionTypes.ts
+++ b/src/auth/supabaseSessionTypes.ts
@@ -13,13 +13,6 @@ const SupabaseSessionSchema = z.object({
     label: z.string().transform((label) => label.trim()),
   }),
   expiresAt: z.number(),
-  /**
-   * Present only on sessions stored before VS Code GitHub sign-in moved to
-   * native GoTrue sessions; no sign-in flow sets it today. It keeps those
-   * sessions refreshing through the custom endpoint rather than forcing a
-   * re-sign-in.
-   */
-  useCustomRefresh: z.boolean().optional(),
 });
 export type SupabaseSession = z.infer<typeof SupabaseSessionSchema>;
 
@@ -167,7 +160,6 @@ export function toStorableSupabaseSession(
   options?: {
     fallbackLabel?: string;
     defaultExpiryMs?: number;
-    useCustomRefresh?: boolean;
   },
 ): SupabaseSession {
   return {
@@ -187,8 +179,5 @@ export function toStorableSupabaseSession(
       nativeSession.expires_in,
       options?.defaultExpiryMs ?? DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
     ),
-    ...(options?.useCustomRefresh === undefined
-      ? {}
-      : { useCustomRefresh: options.useCustomRefresh }),
   };
 }

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -143,15 +143,7 @@ export async function scanRunDirForOutputs(
       const nonArtifact = allTexFiles.filter(
         (f) => !hasBetweenRoundDiffSuffix(path.parse(f).name),
       );
-      // Raw round output is output.xml (never collected by collectTexFiles).
-      // Guard for pre-refactor runs where non-scratchpad agents wrote output.tex
-      // as the raw wrapper: drop it when real extracted outputs exist alongside.
-      const rawStem = `${WORKFLOW_OUTPUT_BASENAME}.tex`;
-      const texFiles =
-        nonArtifact.length > 1 && nonArtifact.includes(rawStem)
-          ? nonArtifact.filter((f) => f !== rawStem)
-          : nonArtifact;
-      for (const fileRelToRound of texFiles) {
+      for (const fileRelToRound of nonArtifact) {
         const relativePath = path.join(entryName, fileRelToRound);
         const location = createRunStorageLocation(
           path.join(runDirAbsolute, relativePath),

--- a/src/shared/constants/workflowOutput.ts
+++ b/src/shared/constants/workflowOutput.ts
@@ -21,9 +21,6 @@ import { getCleanAgentName } from '@shared/schemas';
 /** The fixed basename of every workflow output file (no extension). */
 export const WORKFLOW_OUTPUT_BASENAME = 'output';
 
-/** The fixed extension for TeXRA-named LaTeX workflow outputs. */
-export const WORKFLOW_DOCUMENT_OUTPUT_EXT = 'tex';
-
 /** The fixed extension for raw workflow round output. */
 export const WORKFLOW_RAW_OUTPUT_EXT = 'xml';
 

--- a/src/shared/schemas/streamLogEntry.ts
+++ b/src/shared/schemas/streamLogEntry.ts
@@ -27,7 +27,6 @@ import { WorkflowCallProgressSchema } from './workflowCallProgress';
 
 const StreamingTextDataSchema = z.looseObject({
   status: z.enum(['running', 'completed']).optional(),
-  archivedRole: z.string().optional(),
   spillPath: z.string().optional(),
 });
 

--- a/src/shared/streams/taskGroupProjection.ts
+++ b/src/shared/streams/taskGroupProjection.ts
@@ -32,32 +32,14 @@ function taskGroupEndStatus(
   return value;
 }
 
-/**
- * Recover the exact zero-based `rN` round labels written before typed stage
- * metadata was persisted. Human-facing `Round N` labels have not had one
- * stable indexing convention, so they remain unclassified rather than being
- * assigned a guessed index.
- *
- * Introduced pre-#7164; replacement (typed stage metadata) shipped
- * 2026-07-05. Retire after 2026-10-05, pending an exported-trace permanence
- * ruling (see #10857).
- */
+/** The optional `kind`/`index` stage metadata carried on a lifecycle row. */
 function taskGroupStageMetadata(
-  name: string,
   kind: TaskGroup['kind'],
   index: number | undefined,
 ): Pick<TaskGroup, 'kind' | 'index'> {
-  const legacyMatch =
-    kind === undefined || kind === 'round' ? /^r(\d+)$/.exec(name) : null;
-  const inferredRoundIndex = legacyMatch
-    ? Number.parseInt(legacyMatch[1], 10)
-    : undefined;
-  const normalizedKind =
-    kind ?? (inferredRoundIndex !== undefined ? 'round' : undefined);
-  const normalizedIndex = index ?? inferredRoundIndex;
   return {
-    ...(normalizedKind !== undefined ? { kind: normalizedKind } : {}),
-    ...(normalizedIndex !== undefined ? { index: normalizedIndex } : {}),
+    ...(kind !== undefined ? { kind } : {}),
+    ...(index !== undefined ? { index } : {}),
   };
 }
 
@@ -108,7 +90,7 @@ export function upsertTaskGroupFromStreamLog(
       startTime: entry.timestamp,
       status: startStatus,
       ...(entry.groupId ? { parentGroupId: entry.groupId } : {}),
-      ...taskGroupStageMetadata(name, payload.kind, payload.index),
+      ...taskGroupStageMetadata(payload.kind, payload.index),
       ...(payload.total !== undefined ? { total: payload.total } : {}),
     };
 
@@ -133,7 +115,7 @@ export function upsertTaskGroupFromStreamLog(
       startTime: entry.timestamp,
       status,
       ...(entry.groupId ? { parentGroupId: entry.groupId } : {}),
-      ...taskGroupStageMetadata(name, payload.kind, payload.index),
+      ...taskGroupStageMetadata(payload.kind, payload.index),
       ...(payload.total !== undefined ? { total: payload.total } : {}),
       ...(endTime !== undefined ? { endTime } : {}),
     });

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerCompatibilityInference.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerCompatibilityInference.vitest.ts
@@ -12,24 +12,6 @@ const logger: Pick<AgentTrace, 'info'> = { info };
 const GOOGLE_KEYLESS_ERROR =
   'Persisted Google sessions without a model-handler identity cannot be resumed.';
 
-/** Keyless flow state whose only model hint is the MODEL channel variable. */
-function keylessFlowState(modelVariable: string) {
-  return {
-    messages: [
-      {
-        type: 'user_input',
-        content: [{ type: 'text', text: 'continue' }],
-      },
-    ],
-    stateSlices: {
-      userChannels: {
-        input: {},
-        transient: { MODEL: modelVariable },
-      },
-    },
-  };
-}
-
 describe('model handler compatibility inference', () => {
   beforeEach(() => {
     info.mockClear();
@@ -37,19 +19,13 @@ describe('model handler compatibility inference', () => {
 
   it('rejects keyless Google transcripts without inspecting their format', () => {
     expect(() =>
-      inferPersistedFlowModelHandlerCompatibilityKey(
-        'gpt54',
-        keylessFlowState('gemini35f'),
-      ),
-    ).toThrow(GOOGLE_KEYLESS_ERROR);
-    expect(info).not.toHaveBeenCalled();
-  });
-
-  it('prefers the persisted model id over the MODEL variable', () => {
-    expect(() =>
-      inferPersistedFlowModelHandlerCompatibilityKey('gpt54', {
-        modelId: 'gemini35f',
-        ...keylessFlowState('gpt54'),
+      inferPersistedFlowModelHandlerCompatibilityKey('gemini35f', {
+        messages: [
+          {
+            type: 'user_input',
+            content: [{ type: 'text', text: 'continue' }],
+          },
+        ],
       }),
     ).toThrow(GOOGLE_KEYLESS_ERROR);
     expect(info).not.toHaveBeenCalled();

--- a/src/test-kernel/auth/SupabaseSessionLifecycle.vitest.ts
+++ b/src/test-kernel/auth/SupabaseSessionLifecycle.vitest.ts
@@ -65,25 +65,11 @@ function makeExchangeResponse(
   };
 }
 
-// A refresh endpoint reply that migrates a custom-refresh session back onto the
-// native path.
-const REFRESHED_SESSION_BODY = JSON.stringify({
-  access_token: 'new-access',
-  refresh_token: 'new-refresh',
-  expires_at: 789,
-  token_type: 'bearer',
-  user: {
-    id: 'user-id',
-    email: 'new@example.com',
-  },
-});
-
-function expiredCustomSession(): SupabaseSession {
+function expiredSession(): SupabaseSession {
   return makeSession({
     accessToken: 'old-access',
     refreshToken: 'old-refresh',
     expiresAt: Date.now() - 1_000,
-    useCustomRefresh: true,
   });
 }
 
@@ -149,15 +135,11 @@ function createClient(overrides?: Partial<Client['auth']>): Client {
 const COORDINATOR_CONFIG = {
   whenReady: async () => {},
   tokenRefreshThresholdMs: 60_000,
-  defaultSessionExpiryMs: DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
-  githubTokenRefreshUrl: 'https://example.supabase.co/functions/v1/refresh',
-  edgeFunctionTimeoutMs: 30_000,
 };
 
 function createCoordinator(options?: {
   initialSession?: SupabaseSession;
   client?: Client;
-  fetch?: typeof fetch;
 }): {
   coordinator: SupabaseSessionCoordinator;
   read: () => SupabaseSession | null;
@@ -171,7 +153,6 @@ function createCoordinator(options?: {
       ...COORDINATOR_CONFIG,
       storage,
       getClient: () => options?.client ?? createClient(),
-      fetch: options?.fetch,
     }),
     read,
     getReadCount,
@@ -253,9 +234,7 @@ describe('SupabaseSession', () => {
 
   describe('toStorableSupabaseSession', () => {
     it('converts Supabase native sessions into the stored shape', () => {
-      const session = toStorableSupabaseSession(makeNativeSession(), {
-        useCustomRefresh: true,
-      });
+      const session = toStorableSupabaseSession(makeNativeSession());
 
       assert.equal(session.id, 'user-id');
       assert.equal(session.accessToken, 'access-token');
@@ -265,7 +244,6 @@ describe('SupabaseSession', () => {
         label: 'user@example.com',
       });
       assert.equal(session.expiresAt, 123_000);
-      assert.equal(session.useCustomRefresh, true);
     });
 
     it('trims whitespace from the native session email label', () => {
@@ -517,30 +495,6 @@ describe('SupabaseSession', () => {
       });
     });
 
-    it('refreshes custom sessions through the injected fetch boundary', async () => {
-      const { coordinator, read, getReadCount } = createCoordinator({
-        initialSession: expiredCustomSession(),
-        fetch: async () =>
-          new Response(REFRESHED_SESSION_BODY, { status: 200 }),
-      });
-
-      assert.equal(await coordinator.ensureFreshToken(), 'new-access');
-      assert.equal(getReadCount(), 1);
-
-      // The refresh endpoint returns a native GoTrue session, so the stored
-      // result drops useCustomRefresh and migrates to the standard path.
-      assert.deepEqual(read(), {
-        id: 'user-id',
-        accessToken: 'new-access',
-        refreshToken: 'new-refresh',
-        account: {
-          id: 'user-id',
-          label: 'new@example.com',
-        },
-        expiresAt: 789_000,
-      });
-    });
-
     it('force-refreshes native sessions without reloading storage', async () => {
       const initialSession = makeSession({
         accessToken: 'old-access',
@@ -557,38 +511,16 @@ describe('SupabaseSession', () => {
       assert.equal(getReadCount(), 1);
     });
 
-    it.each([
-      {
-        name: 'custom refresh',
-        initial: expiredCustomSession(),
-        fetch: async () =>
-          new Response(REFRESHED_SESSION_BODY, { status: 200 }),
-        expected: { accessToken: 'new-access', refreshToken: 'new-refresh' },
-      },
-      {
-        name: 'native refresh',
-        initial: makeSession({
-          accessToken: 'old-access',
-          refreshToken: 'old-refresh',
-          expiresAt: Date.now() - 1_000,
-        }),
-        fetch: undefined,
-        expected: {
-          accessToken: 'refreshed-access',
-          refreshToken: 'refreshed-refresh',
-        },
-      },
-    ])(
-      'returns $name session tokens without reloading storage',
-      async ({ initial, fetch, expected }) => {
-        const { coordinator, getReadCount } = createCoordinator({
-          initialSession: initial,
-          fetch,
-        });
-        assert.deepEqual(await coordinator.getSessionTokens(), expected);
-        assert.equal(getReadCount(), 1);
-      },
-    );
+    it('returns refreshed session tokens without reloading storage', async () => {
+      const { coordinator, getReadCount } = createCoordinator({
+        initialSession: expiredSession(),
+      });
+      assert.deepEqual(await coordinator.getSessionTokens(), {
+        accessToken: 'refreshed-access',
+        refreshToken: 'refreshed-refresh',
+      });
+      assert.equal(getReadCount(), 1);
+    });
 
     it('does not return tokens cleared while loading the session', async () => {
       const { coordinator, getReadCount } = createClearingStorageCoordinator({
@@ -625,13 +557,26 @@ describe('SupabaseSession', () => {
     it('does not resurrect a cleared session when refresh finishes later', async () => {
       const refreshStarted = createDeferred();
       const allowRefresh = createDeferred();
-      const { coordinator, read } = createCoordinator({
-        initialSession: expiredCustomSession(),
-        fetch: async () => {
+      const client = createClient({
+        refreshSession: async () => {
           refreshStarted.resolve();
           await allowRefresh.promise;
-          return new Response(REFRESHED_SESSION_BODY);
+          return {
+            data: {
+              session: {
+                access_token: 'refreshed-access',
+                refresh_token: 'refreshed-refresh',
+                expires_at: 456,
+                user: { id: 'user-id', email: 'user@example.com' },
+              },
+            },
+            error: null,
+          };
         },
+      } as unknown as Partial<Client['auth']>);
+      const { coordinator, read } = createCoordinator({
+        initialSession: expiredSession(),
+        client,
       });
 
       const tokenPromise = coordinator.ensureFreshToken();
@@ -646,16 +591,16 @@ describe('SupabaseSession', () => {
     it('reclassifies when a new session replaces one whose refresh failed', async () => {
       const refreshStarted = createDeferred();
       const allowRefreshFailure = createDeferred();
-      const { coordinator, read } = createCoordinator({
-        initialSession: expiredCustomSession(),
-        fetch: async () => {
+      const client = createClient({
+        refreshSession: async () => {
           refreshStarted.resolve();
           await allowRefreshFailure.promise;
-          return new Response(
-            JSON.stringify({ error: 'invalid refresh token' }),
-            { status: 401 },
-          );
+          return { data: { session: null }, error: { status: 401 } };
         },
+      } as unknown as Partial<Client['auth']>);
+      const { coordinator, read } = createCoordinator({
+        initialSession: expiredSession(),
+        client,
       });
 
       const statePromise = coordinator.getStoredSessionState();
@@ -701,14 +646,17 @@ describe('SupabaseSession', () => {
           coordinator.ensureFreshToken(),
       },
     ])(
-      'classifies custom refresh HTTP $status as $failure and returns no token',
+      'classifies refresh HTTP $status as $failure and returns no token',
       async ({ status, failure, request }) => {
+        const client = createClient({
+          refreshSession: async () => ({
+            data: { session: null },
+            error: { status },
+          }),
+        } as unknown as Partial<Client['auth']>);
         const { coordinator } = createCoordinator({
-          initialSession: expiredCustomSession(),
-          fetch: async () =>
-            new Response(JSON.stringify({ error: 'refresh rejected' }), {
-              status,
-            }),
+          initialSession: expiredSession(),
+          client,
         });
 
         assert.equal(await request(coordinator), null);

--- a/src/test-kernel/cli/WorkflowRunDetails.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunDetails.vitest.ts
@@ -136,18 +136,18 @@ describe('selectWorkflowRunDetailLines', () => {
     ]);
   });
 
-  it('renders a normalized rN round and sanitizes terminal controls', () => {
+  it('renders a typed round and sanitizes terminal controls', () => {
     const lines = selectWorkflowRunDetailLines(
       {
         taskGroups: projectTaskGroupsFromStreamLog([
           {
             seqNo: 1,
-            id: 'legacy-r3',
+            id: 'round-3',
             type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
             level: LOG_LEVELS.INFO,
             timestamp: 0,
             text: 'r3',
-            data: { status: STREAM_PHASE.RUNNING },
+            data: { status: STREAM_PHASE.RUNNING, kind: 'round', index: 3 },
           },
         ]),
         outputFilesByRound: {},

--- a/src/test-kernel/shared/TaskGroupProjection.vitest.ts
+++ b/src/test-kernel/shared/TaskGroupProjection.vitest.ts
@@ -140,49 +140,6 @@ describe('task-group StreamLog projection', () => {
     expect(taskGroups[0]?.endTime).toBe(250);
   });
 
-  it('normalizes an exact zero-based rN label at the shared boundary', () => {
-    const lifecycle = entry('legacy-round', STREAM_LOG_ENTRY_TYPES.GROUP_END, {
-      text: 'r3',
-      data: { status: 'stopped', endTime: 200 },
-    });
-    const batch = projectTaskGroupsFromStreamLog([lifecycle]);
-    const incremental: typeof batch = [];
-
-    expect(
-      upsertTaskGroupFromStreamLog(
-        incremental,
-        new Map<string, number>(),
-        lifecycle,
-      ),
-    ).toBe(true);
-    expect(batch).toEqual(incremental);
-    expect(batch).toMatchObject([
-      {
-        id: 'legacy-round',
-        kind: 'round',
-        index: 3,
-        status: RUN_OUTCOME.COMPLETED,
-      },
-    ]);
-  });
-
-  it('does not guess an index for an ambiguous human-facing Round N label', () => {
-    const [group] = projectTaskGroupsFromStreamLog([
-      entry('legacy-round', STREAM_LOG_ENTRY_TYPES.GROUP_END, {
-        text: 'Round 3',
-        data: { status: 'stopped', endTime: 200 },
-      }),
-    ]);
-
-    expect(group).toMatchObject({
-      id: 'legacy-round',
-      name: 'Round 3',
-      status: RUN_OUTCOME.COMPLETED,
-    });
-    expect(group?.kind).toBeUndefined();
-    expect(group?.index).toBeUndefined();
-  });
-
   it('ignores ordinary log rows', () => {
     const taskGroups = projectTaskGroupsFromStreamLog([
       {

--- a/src/test-kernel/utils/UtilsCore.vitest.ts
+++ b/src/test-kernel/utils/UtilsCore.vitest.ts
@@ -365,13 +365,9 @@ describe('coalesceAsync', () => {
 });
 
 describe('truncatedHexId', () => {
-  it('defaults to a sha256 prefix of the requested length', () => {
+  it('returns a sha256 prefix of the requested length', () => {
     expect(truncatedHexId('source', 8)).toBe('41cf6794');
     expect(truncatedHexId('source', 16)).toBe('41cf6794ba4200b8');
-  });
-
-  it('keeps the compile-log sha1 spelling', () => {
-    expect(truncatedHexId('path.tex', 8, 'sha1')).toBe('eefc4296');
   });
 });
 

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -149,7 +149,7 @@ function userMessageEntryToMessages(
 ): unknown[] {
   if (!entry.text) return [];
   const attachments = entry.data?.attachments ?? [];
-  const role = archivedConversationRole(entry, 'user');
+  const role = 'user';
   if (attachments.length === 0) {
     return [{ role, content: entry.text }];
   }
@@ -168,18 +168,10 @@ function modelResponseEntryToMessages(entry: StreamLogEntry): unknown[] {
   if (!entry.text?.trim()) return [];
   return [
     {
-      role: archivedConversationRole(entry, 'assistant'),
+      role: 'assistant',
       content: [{ type: 'text', text: entry.text }],
     },
   ];
-}
-
-function archivedConversationRole(
-  entry: StreamLogEntry,
-  fallback: string,
-): string {
-  const data = isObject(entry.data) ? entry.data : {};
-  return typeof data.archivedRole === 'string' ? data.archivedRole : fallback;
 }
 
 function thinkingEntryToMessages(entry: StreamLogEntry): unknown[] {

--- a/src/utils/core/idHash.ts
+++ b/src/utils/core/idHash.ts
@@ -9,19 +9,9 @@ import type { ExecutionId } from '@shared/schemas';
 
 type ExecutionIdentity = Readonly<Record<string, string | number>>;
 
-/**
- * Algorithms used by truncated hex IDs. `sha1` is compile-log only — drop
- * that member with the 2026-11-09 legacy compile-log spellings.
- */
-type TruncatedHexAlgorithm = 'sha256' | 'sha1';
-
-/** Stable hex prefix of a digest. Default algorithm is sha256. */
-export function truncatedHexId(
-  source: BinaryLike,
-  length: number,
-  algorithm: TruncatedHexAlgorithm = 'sha256',
-): string {
-  return createHash(algorithm).update(source).digest('hex').slice(0, length);
+/** Stable hex prefix of a sha256 digest. */
+export function truncatedHexId(source: BinaryLike, length: number): string {
+  return createHash('sha256').update(source).digest('hex').slice(0, length);
 }
 
 /** Derive a stable execution ID from named identity fields. */


### PR DESCRIPTION
Maintainer ruling (2026-08-18, recorded): all dated compat-retirement horizons for intermediate-era data are void — intermediate-era data may break; delete now, loudly, no migrations. Companion to #10887 (disjoint files; none of that PR's remnants are touched here).

Net: **−283 LoC** (73 insertions / 356 deletions, 18 files). Sources: #10867 (rulings 1–3), #10857 item 3, contracts-doc §3, #10259.

## Retired items (per-item nets)

1. **`useCustomRefresh` custom session-refresh arm** (−126: prod −74, tests −52) — schema field + `refreshViaCustomEndpoint` + the refresh-route ternary (`src/auth/SupabaseSession.ts`), the `toStorableSupabaseSession` option (`supabaseSessionTypes.ts`), the now-dead coordinator options (`defaultSessionExpiryMs`, `githubTokenRefreshUrl`, `edgeFunctionTimeoutMs`, `fetch`) and `GITHUB_TOKEN_REFRESH_URL` (`config.ts`). No sign-in flow has set the flag since VS Code GitHub sign-in moved to native GoTrue sessions; the arm self-retired on first successful refresh. **Acceptance:** a stored session that still carries the flag refreshes through native GoTrue; if its refresh token is not native-refreshable the user re-signs-in once.
2. **Pre-refactor `.tex` era-trio** (−27) — `WORKFLOW_DOCUMENT_OUTPUT_EXT` (`workflowOutput.ts`), the resume-from-`.tex` fallback in `runReflectionFlow.ts`, and the `output.tex` raw-wrapper filter in `latexdiff/outputDiscovery.ts`. Deleted as the trio per #10867 ruling 1. **Accepted degradation (recorded):** latexdiff against pre-refactor-era outputs stops resolving — resumes of partially-written pre-refactor rounds restart at `output.xml`, and latexdiff over multi-output pre-refactor run dirs now includes the raw `output.tex` wrapper instead of dropping it.
3. **`currentModelFromRawSharedState` + `stringValue`** (−46: prod −22, tests −24) — `modelHandlerCompatibilityInference.ts`. Inference now keys on the launch-context model only. **Accepted blindness (per #10867 ruling 3):** keyless pre-`modelId` Google records no longer trip the loud resume guard via their persisted `MODEL` channel hint.
4. **Orphaned `archivedRole` reader** (−9) — `completedRunArchive.ts` + the schema field (`streamLogEntry.ts`). Producer deleted by #9755; roles now come from the entry type alone, as every current producer writes.
5. **Legacy `rN` round-label inference** (−61: prod −18, tests −43) — `taskGroupProjection.ts`; `taskGroupStageMetadata` now passes through typed `kind`/`index` only. **Exported-trace acceptance (per #10857 item 3, resolved by the 2026-08-18 ruling):** traces exported before typed stage metadata (#7164, 2026-07-05) render their `rN` groups unclassified — no round kind/index — instead of inferring them from the label.
6. **Compile-log sha1 spelling** (−14) — `'sha1'` union member and the now-single-valued `algorithm` parameter of `truncatedHexId` (`idHash.ts`), the `'sha1'` argument in `compileCheck.ts` (#10259, horizon voided). Compile-log names for rounds recompiled across the upgrade get a new hash suffix; stale-log cleanup of old-named logs simply misses once.

## R6 — consumer evidence (what read each deleted surface)

- `useCustomRefresh`: writers — none (repo-wide grep; the CLI device-code flow explicitly mints native sessions, `supabaseAuth.ts:200-205`); readers — only the two deleted sites in `SupabaseSession.ts` and the deleted tests. `GITHUB_TOKEN_REFRESH_URL`: sole consumer was the deleted coordinator option. `refreshViaCustomEndpoint` was the sole consumer of the four deleted coordinator options.
- `WORKFLOW_DOCUMENT_OUTPUT_EXT`: sole importer was `runReflectionFlow.ts`'s deleted fallback. The `outputDiscovery.ts` filter was module-private. No test pinned either arm (checked `OutputDiscovery.vitest.ts`, `RunLatexdiff.vitest.ts`, `ReflectionOutputLocation.vitest.ts`).
- `currentModelFromRawSharedState`/`stringValue`: module-private; sole caller `inferPersistedFlowModelHandlerCompatibilityKey:87`. Two tests pinned the MODEL-channel arm (deleted); the keyless-Google loud-guard test was retargeted to the surviving model-argument path.
- `archivedRole`: zero writers repo-wide; sole reader `archivedConversationRole` (deleted); schema field had no other typed reader; no test referenced it.
- `rN` inference: module-private to `taskGroupStageMetadata`; downstream consumers (`transcriptFold.ts`, `logSlice.ts`, `cliState.ts`) read only the projected `kind`/`index`. Pinning tests deleted (`TaskGroupProjection.vitest.ts` ×2); `WorkflowRunDetails.vitest.ts` trimmed to typed metadata, keeping its terminal-control-sanitization coverage.
- `'sha1'`: sole production caller `compileCheck.ts:282`; all other `truncatedHexId` callers already used the default. Pinning test deleted (`UtilsCore.vitest.ts`).

## R8 — looks-orphaned-but-isn't checks

- `parseTokenExchangeResponse` / `GitHubTokenExchangeResponse` **kept** — live consumers in the CLI device-code flow (`supabaseAuthDeviceCode.ts:15-16,145`); only the SupabaseSession-internal use was deleted, the re-export stands.
- `fetchWithTimeout` **kept** — live consumers `relayToken.ts`, `relayTokensClient.ts`, `supabaseAuthDeviceCode.ts`.
- `DEFAULT_SUPABASE_SESSION_EXPIRY_MS` **kept** — CLI device sign-in and `toStorableSupabaseSession`'s default still read it.
- `midEraWorkflowOutputStem` and the `<base>_<chunk>_r{round}_<model>` grammar (`workflowOutputCopyStem`, `legacyWorkflowOutputRoundRegex`, `normalizeLegacyModel`) **kept** — explicitly out of ruling scope; "Save as copy" is a live writer and housekeeping/XML-packing are live readers.
- CLI NDJSON legacy names **kept** — explicitly out of scope (D3 version clock).
- `taskGroupEndStatus` `EndGroupStatus` normalization **kept** — permanent per #9432, not part of item 5.
- `asRecord` in `modelHandlerCompatibilityInference.ts` **kept** — still narrows the persisted record for the explicit-key parse.
- `WORKFLOW_OUTPUT_BASENAME` in `outputDiscovery.ts` **kept** — still feeds the generic-stem source-label fallback.
- The replayTrace "no data.kind" legacy-round test keys on entry ordering (`findRootStageId`), not the deleted inference — verified, untouched.
- knip baseline: no deleted export was baselined; `check:dead-code-ratchet` passes with zero baseline edits (8 vs 8).

## Test changes (no new tests)

Compat-pinned tests deleted or trimmed. Two auth race tests and the failure-classification pair exercised durable coordinator behavior *through* the deleted custom-fetch seam; they were ported in place to the native `refreshSession` seam (same assertions, no added cases). One `it.each` collapsed to its surviving native arm.

## Gates

- `npm run typecheck` — exit 0
- `FORCE_COLOR=0 npx vitest run` on touched + adjacent suites (auth lifecycle, CLI supabase auth, compatibility inference, task-group projection, UtilsCore, OutputDiscovery, RunLatexdiff, GeneratedLatexdiffArtifact, CompiledPdfArtifacts, completedRunArchive, ExecutionsConversationFormat, normalizeConversation, WorkflowRunDetails, LogDeltaTextDeltas, replayTrace, StreamLogDelta, ReflectionOutputLocation, ResponseCycleCancellation) — 19 files / 178 tests, all green
- `npx eslint` on all 18 changed files — clean
- `npm run check:dead-code-ratchet` — OK, no baseline changes needed
- `npx prettier --check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
