### PR TITLE
refactor: small adjudicated deletion batch — D16 arbitration, resume drift check, test-only seams, overdefensive residue

### DIFF
--- a/packages/desktop/src/main/platform/pathFix.ts
+++ b/packages/desktop/src/main/platform/pathFix.ts
@@ -12,7 +12,6 @@ const MACOS_PATH_ENTRIES = [
 
 interface LaunchPathRepairOptions {
   env?: Pick<NodeJS.ProcessEnv, 'PATH'>;
-  fixPath?: () => void;
   platform?: NodeJS.Platform;
 }
 
@@ -34,11 +33,9 @@ export function repairLaunchPath(
   const env = options.env ?? process.env;
   const platform = options.platform ?? process.platform;
   if (platform === 'darwin') {
-    if (options.fixPath != null) {
-      options.fixPath();
-    } else if (env === process.env) {
-      fixPath();
-    }
+    // Only the real process environment goes through fix-path; injected
+    // environments get the deterministic prepend below only.
+    if (env === process.env) fixPath();
     // ':' is the POSIX PATH separator; this branch only runs on darwin.
     env.PATH = prependMissingPathEntries(env.PATH, MACOS_PATH_ENTRIES, ':');
   }

--- a/packages/desktop/src/renderer/logsPane.ts
+++ b/packages/desktop/src/renderer/logsPane.ts
@@ -46,7 +46,6 @@ export interface LogsPaneOptions {
     callback: () => void,
     intervalMs: number,
   ) => number;
-  readonly cancelRefresh?: (handle: number) => void;
   readonly refreshIntervalMs?: number;
 }
 
@@ -169,8 +168,6 @@ export function createLogsPane(
     options.scheduleRefresh ??
     ((callback: () => void, intervalMs: number) =>
       window.setInterval(callback, intervalMs));
-  const cancelRefresh =
-    options.cancelRefresh ?? ((handle: number) => window.clearInterval(handle));
   const refreshIntervalMs =
     options.refreshIntervalMs ?? LOG_AUTO_REFRESH_INTERVAL_MS;
 
@@ -286,7 +283,7 @@ export function createLogsPane(
     if (active === nextActive) return;
     active = nextActive;
     if (!active) {
-      if (refreshHandle != null) cancelRefresh(refreshHandle);
+      if (refreshHandle != null) window.clearInterval(refreshHandle);
       refreshHandle = undefined;
       return;
     }

--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -105,7 +105,7 @@ function findCommitInHistory(
     return sanitizedCommit;
   }
 
-  return labelResult.stdout ?? sanitizedCommit;
+  return labelResult.stdout;
 }
 
 async function promptInput(

--- a/packages/extension/src/common/state/index.ts
+++ b/packages/extension/src/common/state/index.ts
@@ -4,8 +4,6 @@
 //   - import key constants from '@shared/state/stateKeys' (canonical, no vscode dependency)
 //   - access state via platform() from '@platform/platform'
 //     (platform().workspaceState / platform().globalState)
-//   - for pre-init-tolerant access use tryWorkspaceState() / tryGlobalState()
-//     from '@platform/platform'
 // Only extension-host wiring (packages/extension/src/) may use these exports.
 export { workspaceSM, globalSM, initializeStateManagers } from './stateManager';
 export { setPendingState, consumePendingState } from './pendingStateManager';

--- a/src/agent/followUp/ToolFileInteractionContext.ts
+++ b/src/agent/followUp/ToolFileInteractionContext.ts
@@ -7,13 +7,7 @@ import type {
   FileInteractionState,
   WorkPlanState,
 } from '@agent/core/state/AgentWorkspaceState';
-import {
-  createRunContext,
-  tryUseRunContext,
-  withRunContext,
-  type CreateRunContextOptions,
-  type RunContext,
-} from '@agent/runtime/RunContext';
+import { tryUseRunContext, type RunContext } from '@agent/runtime/RunContext';
 
 /** Optional lifecycle callbacks a tool call may be given, grouped since they
  *  vary together by call site rather than independently. */
@@ -75,22 +69,4 @@ export function getCurrentToolContexts(): CurrentToolContexts | undefined {
     runContext: tryUseRunContext(),
     callContext,
   };
-}
-
-/**
- * Test helper: install a RunContext and a tool-call frame in one call.
- *
- * Tests that exercise tools-side code typically need both an active run
- * (for `tryUseRunContext()` consumers) and a tool-call frame (for tracker
- * and callbacks). This wraps the two stack pushes in one composer.
- */
-export function withToolEnvironment<T>(
-  env: { run: CreateRunContextOptions; call: ToolCallContext },
-  fn: () => Promise<T> | T,
-): Promise<T> {
-  return Promise.resolve(
-    withRunContext(createRunContext(env.run), () =>
-      withToolFileInteractionContext(env.call, fn),
-    ),
-  );
 }

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -35,9 +35,9 @@ export type StateSlicesSnapshot = z.output<typeof StateSlicesSchema>;
  *
  * Default `z.object` semantics by decision (#10641), matching reflection's
  * shared schema: unknown top-level keys in a persisted record are accepted
- * but stripped at this parse boundary, and the existing deep-equal
- * self-heal checks on both resume paths then rewrite the healed record.
- * The heal is one-directional: an upgrade → resume-on-older-build →
+ * but stripped at this parse boundary, and the resumed flow's first
+ * persisted step then rewrites the stripped record. The strip is
+ * one-directional: an upgrade → resume-on-older-build →
  * upgrade cycle permanently erases the newer build's unknown keys, so a
  * future load-bearing top-level field must be added with that erasure in
  * mind. Deliberately not `z.strictObject` — a record written by a newer

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -1,6 +1,5 @@
 // Node imports
 import { randomUUID } from 'node:crypto';
-import { isDeepStrictEqual } from 'node:util';
 
 // Local imports
 import { logSdkError } from '@agent/trace';
@@ -17,10 +16,7 @@ import { type SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   PersistedFlow,
   PersistedFlowStateError,
-  flowKey,
   readPersistedFlowRecord,
-  stampCompatibilityKey,
-  stampFlowRecordSchemaVersion,
 } from '@agent/node/persistedFlow';
 import { type AgentToolUseSetting } from '@agent/core/definition/AgentDataclass';
 import type { ITool, IToolRegistry } from '@agent/core/tools/ToolTypes';
@@ -444,52 +440,40 @@ export async function runToolUseFlow<C = unknown>(
       throw startupInterruption;
     }
 
-    persistenceRecoveryPending = true;
-    const flowRecord = await readPersistedFlowRecord(kv, executionId);
-    // Cancellation can also arrive while the recovery read is pending. Do not
-    // start a migration or repair write after that handoff.
-    if (signal.aborted) {
+    if (input.resume) {
+      // `resumeToolUseFromResumeData` reads the record only after it owns the
+      // execution lease (acquire-then-read), so `input.resume.shared` is the
+      // authoritative persisted snapshot with no unleased window left to
+      // double-check. PersistedFlow's own schema-checked read below is the
+      // single disk read for the resumed state.
+      logger.debug('Resuming tool-use flow from persistence');
+    } else {
+      persistenceRecoveryPending = true;
+      const flowRecord = await readPersistedFlowRecord(kv, executionId);
+      // Cancellation can also arrive while the recovery read is pending. Do
+      // not start a repair write after that handoff.
+      if (signal.aborted) {
+        persistenceRecoveryPending = false;
+        earlyResult = { outcome };
+        throw startupInterruption;
+      }
+      if (flowRecord) {
+        const parsed = parseToolUseShared(flowRecord.shared);
+        if (!parsed.success) {
+          throw new PersistedFlowStateError(executionId, 'invalid-shared', {
+            cause: parsed.error,
+          });
+        }
+        throw new PersistedFlowStateError(executionId, 'unexpected-record');
+      }
+      // Cleanup may delete a terminal flow record only after absence was
+      // confirmed.
       persistenceRecoveryPending = false;
-      preserveResumeRecord = input.resume !== undefined;
-      earlyResult = { outcome };
-      throw startupInterruption;
     }
     // Past both startup cancellation guards: any later interrupt() is a
     // genuine mid-run cancellation, so go back to the normal destructive
     // queue clear instead of the resume-startup rescue above.
     inResumeStartupWindow = false;
-
-    if (flowRecord) logger.debug('Resuming tool-use flow from persistence');
-    if (flowRecord && input.resume) {
-      // `resumeToolUseFromResumeData` reloads the record only after it owns
-      // the execution lease. This is therefore the same authoritative record
-      // it handed to the flow, with no optimistic-concurrency window to check.
-      const resumedShared: PreparedShared = stampCompatibilityKey(
-        input.resume.shared,
-        compatibilityKey,
-      );
-      if (!isDeepStrictEqual(flowRecord.shared, resumedShared)) {
-        logger.debug(
-          'Healed a persisted tool-use shared-state mismatch after resume handoff.',
-        );
-        flowRecord.shared = resumedShared;
-        await kv.write(
-          flowKey(executionId),
-          stampFlowRecordSchemaVersion(flowRecord),
-        );
-      }
-    } else if (flowRecord) {
-      const parsed = parseToolUseShared(flowRecord.shared);
-      if (!parsed.success) {
-        throw new PersistedFlowStateError(executionId, 'invalid-shared', {
-          cause: parsed.error,
-        });
-      }
-      throw new PersistedFlowStateError(executionId, 'unexpected-record');
-    }
-    // Cleanup may delete a terminal flow record only after absence was
-    // confirmed or a present record passed its migration boundary.
-    persistenceRecoveryPending = false;
 
     let resumedFollowUps: readonly FollowUpQueueBatchItem[] = [
       ...(input.drainedFollowUps ?? []),

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -322,15 +322,6 @@ export function getCustomAgentScanIssues(): readonly AgentScanIssue[] {
 }
 
 /**
- * Whether the local registry has been loaded so `getAgent` lookups are
- * meaningful. Callers that distinguish "agent absent" from "registry not yet
- * loaded" must check this first — an empty cache looks identical otherwise.
- */
-export function isAgentRegistryReady(): boolean {
-  return catalog !== undefined;
-}
-
-/**
  * Force a new load after every older one has settled, superseding any load
  * still queued from before. The cache keeps serving the catalog it already
  * published until the new one lands, including when the refresh fails.

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -157,7 +157,7 @@ export async function readPersistedFlowRecord(
   return parsed.data;
 }
 
-export function stampFlowRecordSchemaVersion<T extends FlowRecord>(flow: T): T {
+function stampFlowRecordSchemaVersion<T extends FlowRecord>(flow: T): T {
   flow.schemaVersion = FLOW_RECORD_SCHEMA_VERSION;
   return flow;
 }

--- a/src/controllers/modelAccess/subscriptionUsage/SubscriptionUsageService.ts
+++ b/src/controllers/modelAccess/subscriptionUsage/SubscriptionUsageService.ts
@@ -78,13 +78,6 @@ interface CacheEntry {
   readonly expiresAt: number;
 }
 
-interface ResolvedRequest {
-  readonly id: number;
-  readonly key: string;
-  readonly variant: boolean | string | undefined;
-  readonly variantResolutionFailed: boolean;
-}
-
 interface SubscriptionUsageAdapter {
   readonly resolveVariant?: () => boolean | string | Promise<boolean | string>;
   readonly fetch: (
@@ -127,11 +120,6 @@ export class SubscriptionUsageService {
     string,
     Promise<SubscriptionUsageSnapshot>
   >();
-  private readonly latestRequests = new Map<
-    SubscriptionUsageProvider,
-    ResolvedRequest
-  >();
-  private nextRequestId = 0;
 
   constructor(init: SubscriptionUsageServiceInit = {}) {
     this.http = init.http ?? fetch;
@@ -201,80 +189,45 @@ export class SubscriptionUsageService {
     provider: SubscriptionUsageProvider,
     options: { readonly forceRefresh?: boolean } = {},
   ): Promise<SubscriptionUsageSnapshot> {
-    const requestId = ++this.nextRequestId;
     const adapter = this.adapters[provider];
     let variant: boolean | string | undefined;
-    let variantResolutionFailed = false;
     try {
       variant = await adapter.resolveVariant?.();
     } catch {
-      variantResolutionFailed = true;
-    }
-
-    const variantKey = variantResolutionFailed
-      ? 'variant-error'
-      : (variant ?? 'default');
-    const resolved: ResolvedRequest = {
-      id: requestId,
-      key: `${provider}:${variantKey}`,
-      variant,
-      variantResolutionFailed,
-    };
-    const latest = this.latestRequests.get(provider);
-    if (!latest || latest.id < requestId) {
-      this.latestRequests.set(provider, resolved);
-    } else if (latest.key !== resolved.key) {
-      return this.getUsageForRequest(provider, latest, false);
-    }
-    return this.getUsageForRequest(
-      provider,
-      resolved,
-      options.forceRefresh ?? false,
-    );
-  }
-
-  private async getUsageForRequest(
-    provider: SubscriptionUsageProvider,
-    resolved: ResolvedRequest,
-    forceRefresh: boolean,
-  ): Promise<SubscriptionUsageSnapshot> {
-    if (resolved.variantResolutionFailed) {
       return this.unavailable(provider, 'request_failed');
     }
+    const key = `${provider}:${variant ?? 'default'}`;
 
-    if (forceRefresh) {
-      this.cache.delete(resolved.key);
-      this.pending.delete(resolved.key);
+    if (options.forceRefresh) {
+      this.cache.delete(key);
+      this.pending.delete(key);
     } else {
-      const cached = this.cache.get(resolved.key);
+      const cached = this.cache.get(key);
       if (cached && cached.expiresAt > this.now()) return cached.snapshot;
     }
 
-    const inFlight = this.pending.get(resolved.key);
+    const inFlight = this.pending.get(key);
     if (inFlight) return inFlight;
 
-    const request = this.fetchUsage(provider, resolved.variant).then(
-      (snapshot) => {
-        if (this.pending.get(resolved.key) !== request) {
-          return this.getUsage(provider);
-        }
-        const latest = this.latestRequests.get(provider);
-        if (latest && latest.key !== resolved.key) {
-          return this.getUsageForRequest(provider, latest, false);
-        }
-        this.cache.set(resolved.key, {
+    // Return-path choice (D16, define-out-of-existence §1e): when invalidate()
+    // races an in-flight fetch, the identity check below keeps the stale result
+    // out of the cache, but the already-waiting caller still receives it — one
+    // accepted stale read on a read-only usage display.
+    const request = this.fetchUsage(provider, variant).then((snapshot) => {
+      if (this.pending.get(key) === request) {
+        this.cache.set(key, {
           snapshot,
           expiresAt: this.now() + this.cacheTtlMs,
         });
-        return snapshot;
-      },
-    );
-    this.pending.set(resolved.key, request);
+      }
+      return snapshot;
+    });
+    this.pending.set(key, request);
     try {
       return await request;
     } finally {
-      if (this.pending.get(resolved.key) === request) {
-        this.pending.delete(resolved.key);
+      if (this.pending.get(key) === request) {
+        this.pending.delete(key);
       }
     }
   }

--- a/src/controllers/settingsView/SettingsViewHost.ts
+++ b/src/controllers/settingsView/SettingsViewHost.ts
@@ -35,7 +35,6 @@ interface SettingsViewHostOptions {
   readonly memoryPrompt: MemoryControllerOptions['prompt'];
   readonly respond?: SettingsRespond;
   readonly modelSelectionExtras?: ModelSelectionExtras;
-  readonly beforeModelSelectionMessage?: () => Awaitable<void>;
   readonly controllers?: {
     readonly memory?: SettingsMemoryController;
     readonly modelSelection?: SettingsModelSelectionController;
@@ -140,7 +139,6 @@ export class SettingsViewHost {
   }
 
   async sendModelSelectionData(respond?: SettingsRespond): Promise<void> {
-    await this.options.beforeModelSelectionMessage?.();
     await this.post(
       await this.modelSelectionController.buildModelSelectionMessage(),
       respond,

--- a/src/test-kernel/agent/AgentRegistry.vitest.ts
+++ b/src/test-kernel/agent/AgentRegistry.vitest.ts
@@ -11,7 +11,6 @@ import {
   getAgentsBySource,
   getVisibleAgent,
   getVisibleAgents,
-  isAgentRegistryReady,
   invalidateRemoteAgentsAfterSignOut,
   loadAgents,
   refresh,
@@ -264,8 +263,7 @@ describe('agent registry', () => {
     }
   });
 
-  it('keeps the registry marked ready when a later refresh fails', async () => {
-    expect(isAgentRegistryReady()).toBe(true);
+  it('keeps the registry serving when a later refresh fails', async () => {
     expect(getAgent('assistant')?.name).toBe('assistant');
 
     useAgentDirectories({
@@ -277,7 +275,6 @@ describe('agent registry', () => {
     try {
       await expect(loadAgents()).rejects.toThrow('refresh failed');
 
-      expect(isAgentRegistryReady()).toBe(true);
       expect(getAgent('assistant')?.name).toBe('assistant');
     } finally {
       useAgentDirectories();

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -1011,53 +1011,44 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     expect(detached).toHaveLength(1);
   });
 
-  it.each([
-    { name: 'resumed run', resume: true },
-    { name: 'fresh launch', resume: false },
-  ])(
-    'releases follow-ups while preserving the record after a persistence read failure: $name',
-    async ({ resume }) => {
-      const suffix = resume ? 'resume' : 'fresh';
-      const executionId = `abc-flow-read-failure-${suffix}` as ExecutionId;
-      const streamId =
-        `chat@gpt54#abc-flow-read-failure-${suffix}` as StreamTabId;
-      const snapshot = resume
-        ? buildToolUseResumeData(executionId, streamId)
-        : undefined;
-      const store = getExecutionStore(executionId);
-      const session = createTestSession();
-      const readFailure = new Error('flow storage unavailable');
-      const readSpy = vi
-        .spyOn(store, 'read')
-        .mockRejectedValueOnce(readFailure);
-      const deleteSpy = vi.spyOn(store, 'delete');
+  // A resumed run has no pre-flow recovery read any more: retrieval reads the
+  // record under the execution lease and hands it in, so only a fresh launch
+  // still probes for a leftover record here.
+  it('releases follow-ups while preserving the record after a persistence read failure', async () => {
+    const executionId = `abc-flow-read-failure-fresh` as ExecutionId;
+    const streamId = `chat@gpt54#abc-flow-read-failure-fresh` as StreamTabId;
+    const snapshot = undefined;
+    const store = getExecutionStore(executionId);
+    const session = createTestSession();
+    const readFailure = new Error('flow storage unavailable');
+    const readSpy = vi.spyOn(store, 'read').mockRejectedValueOnce(readFailure);
+    const deleteSpy = vi.spyOn(store, 'delete');
 
-      try {
-        await expect(
-          runPersistedFlow(executionId, streamId, snapshot, {
-            attachment: {
-              attach: (context) => {
-                context.session.appendFollowUp({
-                  text: 'queued before recovery',
-                });
-              },
+    try {
+      await expect(
+        runPersistedFlow(executionId, streamId, snapshot, {
+          attachment: {
+            attach: (context) => {
+              context.session.appendFollowUp({
+                text: 'queued before recovery',
+              });
             },
-            session,
-          }),
-        ).rejects.toMatchObject({
-          name: PersistedFlowStateError.name,
-          reason: 'read-failed',
-          cause: readFailure,
-        });
-        expect(deleteSpy).not.toHaveBeenCalled();
-        expect(session.followUps.getAll(streamId)).toEqual([]);
-      } finally {
-        readSpy.mockRestore();
-        deleteSpy.mockRestore();
-        session.followUps.terminalize(streamId);
-      }
-    },
-  );
+          },
+          session,
+        }),
+      ).rejects.toMatchObject({
+        name: PersistedFlowStateError.name,
+        reason: 'read-failed',
+        cause: readFailure,
+      });
+      expect(deleteSpy).not.toHaveBeenCalled();
+      expect(session.followUps.getAll(streamId)).toEqual([]);
+    } finally {
+      readSpy.mockRestore();
+      deleteSpy.mockRestore();
+      session.followUps.terminalize(streamId);
+    }
+  });
 
   it('preserves the structured flow error when teardown also fails', async () => {
     const executionId = 'abc-flow-primary-and-teardown-failure' as ExecutionId;
@@ -1219,11 +1210,14 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
         nodes: [],
       },
     },
+    // Fresh launches only: a resume handoff over a malformed record is
+    // unrepresentable now that retrieval validates the same envelope under
+    // the execution lease before any resume reaches the flow.
   ])('rejects and preserves $name', async ({ name, reason, stored }) => {
     const slug = name.replaceAll(' ', '-');
     const executionId = `abc-flow-${slug}` as ExecutionId;
     const streamId = `chat@gpt54#abc-flow-${slug}` as StreamTabId;
-    const snapshot = buildToolUseResumeData(executionId, streamId);
+    const snapshot = undefined;
     const store = getExecutionStore(executionId);
     await store.write(flowKey(executionId), stored);
     const deleteSpy = vi.spyOn(store, 'delete');
@@ -1303,49 +1297,6 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     }
   });
 
-  it('skips repair writes when cancellation arrives during the recovery read', async () => {
-    const executionId = 'abc-cancel-read' as ExecutionId;
-    const streamId = 'chat@gpt54#abc-cancel-read' as StreamTabId;
-    const snapshot = buildToolUseResumeData(executionId, streamId);
-    const store = getExecutionStore(executionId);
-    let flowContext: ToolUseSetupContext | undefined;
-    const readSpy = vi.spyOn(store, 'read').mockImplementationOnce(async () => {
-      flowContext?.interrupt();
-      return {
-        flowName: 'texra',
-        shared: {
-          messages: [],
-          shouldSkipCycle: true,
-          stateSlices: snapshot.shared.stateSlices,
-        },
-        createdAt: new Date().toISOString(),
-        cursor: { nextNodeId: 'start' },
-        nodes: [],
-      };
-    });
-    const writeSpy = vi.spyOn(store, 'write');
-    const deleteSpy = vi.spyOn(store, 'delete');
-
-    try {
-      const result = await runPersistedFlow(executionId, streamId, snapshot, {
-        attachment: {
-          attach: (context) => {
-            flowContext = context;
-          },
-        },
-      });
-
-      expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
-      expect(readSpy).toHaveBeenCalledWith(flowKey(executionId));
-      expect(writeSpy).not.toHaveBeenCalled();
-      expect(deleteSpy).not.toHaveBeenCalled();
-    } finally {
-      readSpy.mockRestore();
-      writeSpy.mockRestore();
-      deleteSpy.mockRestore();
-    }
-  });
-
   it('preserves the resumable flow after an established run is interrupted', async () => {
     const executionId = 'abc-interrupted-conversation' as ExecutionId;
     const streamId = 'chat@gpt54#abc-interrupted-conversation' as StreamTabId;
@@ -1409,8 +1360,8 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     // Reject the flow's first node-step persist with the provider's abort:
     // the run then fails mid-flight through the public storage boundary, the
     // same way a real cancellation reaches `runToolUseFlow` out of the flow.
-    // Only step writes append to the nodes audit log, so the resume
-    // boundary's self-heal write (nodes stays empty) passes through untouched.
+    // Only step writes append to the nodes audit log, so any other write
+    // (nodes stays empty) passes through untouched.
     const realWrite = store.write.bind(store);
     let abortFired = false;
     const writeSpy = vi
@@ -1457,33 +1408,26 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     }
   });
 
-  it('preserves a follow-up appended during setup when cancellation arrives during the recovery read (issue #8049 P2)', async () => {
+  it('preserves a follow-up appended during setup when cancellation lands at attach (issue #8049 P2)', async () => {
     // Once setup attaches the live flow context, a new follow-up can enter its
-    // session queue before the flow is interruptible. When an external
-    // cancellation then lands while the recovery read is pending -- the same
-    // window as the sibling test above -- the run reports CANCELLED with the
-    // resume record preserved, and the queued input must survive with it:
+    // session queue before the flow is interruptible. When a cancellation
+    // lands in that startup window, the run reports CANCELLED with the resume
+    // record preserved, and the queued input must survive with it:
     // `resumeQueuedToolUseFromResumeData` never restores follow-ups on this
-    // success path, so dropping the item here would lose it for good.
+    // success path, so dropping the item here would lose it for good. (The
+    // former async window during a pre-flow recovery read no longer exists:
+    // a resumed flow does no disk read before it becomes interruptible.)
     const executionId = 'abc-cancel-followup' as ExecutionId;
     const streamId = 'chat@gpt54#abc-cancel-followup' as StreamTabId;
     const snapshot = buildToolUseResumeData(executionId, streamId);
-    const store = getExecutionStore(executionId);
     const session = createTestSession();
-    let flowContext: ToolUseSetupContext | undefined;
-    const readSpy = vi.spyOn(store, 'read').mockImplementationOnce(async () => {
-      // Cancellation arrives while the recovery read is pending -- after
-      // setup already appended the live follow-up below.
-      flowContext?.interrupt();
-      return undefined;
-    });
 
     try {
       const result = await runPersistedFlow(executionId, streamId, snapshot, {
         attachment: {
           attach: (context) => {
-            flowContext = context;
             context.session.appendFollowUp({ text: 'queued during resume' });
+            context.interrupt();
           },
         },
         session,
@@ -1495,7 +1439,6 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
         'queued during resume',
       ]);
     } finally {
-      readSpy.mockRestore();
       session.dispose();
     }
   });
@@ -1622,12 +1565,11 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     }
   });
 
-  it('skips the resume self-heal write when the persisted record is already canonical (issue #8018)', async () => {
+  it('does not write during resume startup before the first flow step (issue #8018)', async () => {
     // `resumeToolUseFromResumeData` passes the resume handoff on every
-    // native-subagent turn, so the resume-branch self-heal write must not
-    // fire when the persisted record already matches what would be
-    // written -- otherwise every turn costs a `StorageFSKVStore` disk
-    // write for a no-op overwrite of identical bytes.
+    // native-subagent turn, so resume startup must not add its own disk
+    // write ahead of the flow's step writes -- otherwise every turn costs
+    // a `StorageFSKVStore` disk write for a no-op overwrite.
     const executionId = 'abc143' as ExecutionId;
     const streamId = 'chat@gpt54#abc143' as StreamTabId;
     await writeFlowRecord(
@@ -1656,10 +1598,8 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       // `PersistedFlow` still legitimately persists its own node-cursor
       // progress once as the flow steps through to WAITING -- that write is
       // not under test here. What must NOT happen is a *second*, earlier
-      // write from the resume-branch self-heal repairing an already-
-      // canonical record. Every write the flow does make must already carry
-      // the final WAITING cursor, never the pre-step one the self-heal write
-      // would have produced.
+      // resume-startup write. Every write the flow does make must already
+      // carry the final WAITING cursor, never a pre-step one.
       expect(writeSpy.mock.calls.length).toBeGreaterThan(0);
       for (const [, record] of writeSpy.mock.calls) {
         expect((record as FlowRecord).cursor).toEqual({

--- a/src/test-kernel/agent/runtime/agentLoad.vitest.ts
+++ b/src/test-kernel/agent/runtime/agentLoad.vitest.ts
@@ -22,7 +22,6 @@ import {
   resolveAgentForLaunch,
   type ResolvedAgent,
 } from '@agent/index';
-import { isAgentRegistryReady } from '@agent/index/agentRegistry';
 import {
   loadAgentSettingAndPrompts,
   validateAgentYamlContent,
@@ -573,7 +572,7 @@ describe('agent registry load state', () => {
     const counter = { scans: 0 };
     await installDirectories(countingDirectories(counter));
     await refresh({ includeRemote: false });
-    assert.strictEqual(isAgentRegistryReady(), true);
+    assert.strictEqual(getAgent('custom:stateProbe')?.name, 'stateProbe');
 
     const scanFailure = new Error('agent directory unavailable');
     await installDirectories({
@@ -586,9 +585,7 @@ describe('agent registry load state', () => {
 
     await assert.rejects(refresh({ includeRemote: false }), scanFailure);
 
-    // A failed rebuild leaves the previously published catalog in place, so
-    // readiness must keep describing what the cache still holds.
-    assert.strictEqual(isAgentRegistryReady(), true);
+    // A failed rebuild leaves the previously published catalog in place.
     assert.strictEqual(getAgent('custom:stateProbe')?.name, 'stateProbe');
   });
 });

--- a/src/test-kernel/controllers/SettingsViewHost.vitest.ts
+++ b/src/test-kernel/controllers/SettingsViewHost.vitest.ts
@@ -35,7 +35,6 @@ describe('SettingsViewHost', () => {
     });
     const modelSelection = createModelSelectionController(globalState);
     const messages: unknown[] = [];
-    const beforeModelSelectionMessage = vi.fn();
     const host = new SettingsViewHost({
       state: {
         workspaceState: new FakeStateStore(),
@@ -48,7 +47,6 @@ describe('SettingsViewHost', () => {
       respond: (message) => {
         messages.push(message);
       },
-      beforeModelSelectionMessage,
       controllers: {
         modelSelection,
       },
@@ -82,6 +80,5 @@ describe('SettingsViewHost', () => {
     expect(globalState.get(GlobalStateKey.ENABLED_MODELS)).toEqual([
       'sonnet46T',
     ]);
-    expect(beforeModelSelectionMessage).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/test-kernel/controllers/modelAccess/SubscriptionUsageService.vitest.ts
+++ b/src/test-kernel/controllers/modelAccess/SubscriptionUsageService.vitest.ts
@@ -528,7 +528,7 @@ describe('SubscriptionUsageService', () => {
     [true, GLM_CODING_PLAN_USAGE_URL, GLM_CODING_PLAN_INTERNATIONAL_USAGE_URL],
     [false, GLM_CODING_PLAN_INTERNATIONAL_USAGE_URL, GLM_CODING_PLAN_USAGE_URL],
   ])(
-    'returns the newer GLM region when the older request resolves last: China=%s',
+    'serves concurrent GLM region requests from independent cache keys: China=%s',
     async (initialUseChina, olderUrl, newerUrl) => {
       let useChina = initialUseChina;
       const responses = new Map<string, (response: Response) => void>();
@@ -572,7 +572,8 @@ describe('SubscriptionUsageService', () => {
         olderUrl,
         newerUrl,
       ]);
-      expect(olderCaller).toStrictEqual(newer);
+      expect(newer.windows[0]?.percentUsed).toBe(80);
+      expect(olderCaller.windows[0]?.percentUsed).toBe(10);
     },
   );
 
@@ -607,76 +608,6 @@ describe('SubscriptionUsageService', () => {
       expect(http).not.toHaveBeenCalled();
     },
   );
-
-  it('keeps a newer GLM success when an older region resolver fails later', async () => {
-    let rejectOlder!: (error: Error) => void;
-    const olderRegion = new Promise<boolean>((_resolve, reject) => {
-      rejectOlder = reject;
-    });
-    let regionCall = 0;
-    const http = vi.fn<SubscriptionUsageHttp>(async () =>
-      jsonResponse({
-        success: true,
-        data: {
-          limits: [{ type: 'TOKENS_LIMIT', percentage: 80, unit: 3 }],
-        },
-      }),
-    );
-    const service = serviceWith(
-      http,
-      credentials({
-        useGlmChina: () => (regionCall++ === 0 ? olderRegion : false),
-      }),
-    );
-
-    const olderRequest = service.getUsage('glmCodingPlan');
-    const newer = await service.getUsage('glmCodingPlan');
-    rejectOlder(new Error('stale region lookup failed'));
-    const olderCaller = await olderRequest;
-
-    expect(newer).toMatchObject({
-      state: 'available',
-      windows: [expect.objectContaining({ percentUsed: 80 })],
-    });
-    expect(olderCaller).toStrictEqual(newer);
-  });
-
-  it('lets a newer GLM region failure supersede an older in-flight result', async () => {
-    let resolveOlder!: (response: Response) => void;
-    const olderResponse = new Promise<Response>((resolve) => {
-      resolveOlder = resolve;
-    });
-    let regionCall = 0;
-    const http = vi.fn<SubscriptionUsageHttp>(() => olderResponse);
-    const service = serviceWith(
-      http,
-      credentials({
-        useGlmChina: () => {
-          if (regionCall++ === 0) return true;
-          return Promise.reject(new Error('new region lookup failed'));
-        },
-      }),
-    );
-
-    const olderRequest = service.getUsage('glmCodingPlan');
-    await vi.waitFor(() => expect(http).toHaveBeenCalledOnce());
-    const newer = await service.getUsage('glmCodingPlan');
-    resolveOlder(
-      jsonResponse({
-        success: true,
-        data: {
-          limits: [{ type: 'TOKENS_LIMIT', percentage: 10, unit: 3 }],
-        },
-      }),
-    );
-    const olderCaller = await olderRequest;
-
-    expect(newer).toMatchObject({
-      state: 'unavailable',
-      reason: 'request_failed',
-    });
-    expect(olderCaller).toStrictEqual(newer);
-  });
 
   it('does not fall back across GLM hosts when the selected region fails', async () => {
     const http = vi.fn<SubscriptionUsageHttp>(async () =>
@@ -868,7 +799,10 @@ describe('SubscriptionUsageService', () => {
     expect(http).toHaveBeenCalledTimes(2);
   });
 
-  it('replaces an invalidated in-flight snapshot instead of returning old-account usage', async () => {
+  // Pins the D16 return-path choice (define-out-of-existence §1e): the caller
+  // already waiting on an invalidated fetch accepts one stale read, but the
+  // stale result never enters the cache — later callers see new-account usage.
+  it('keeps an invalidated in-flight snapshot out of the cache', async () => {
     const responses: Array<(response: Response) => void> = [];
     const http = vi.fn<SubscriptionUsageHttp>(
       () =>
@@ -892,9 +826,13 @@ describe('SubscriptionUsageService', () => {
       newAccountRequest,
     ]);
     expect(oldCallerSnapshot).toMatchObject({
+      windows: [expect.objectContaining({ percentUsed: 10 })],
+    });
+    expect(newCallerSnapshot).toMatchObject({
       windows: [expect.objectContaining({ percentUsed: 80 })],
     });
-    expect(oldCallerSnapshot).toStrictEqual(newCallerSnapshot);
+    expect(await service.getUsage('kimiCode')).toBe(newCallerSnapshot);
+    expect(http).toHaveBeenCalledTimes(2);
   });
 
   it('deduplicates concurrent requests for the same provider', async () => {

--- a/src/test-kernel/desktop/DesktopLogsPane.vitest.ts
+++ b/src/test-kernel/desktop/DesktopLogsPane.vitest.ts
@@ -30,7 +30,6 @@ interface LogsPaneModule {
   createLogsPane(options?: {
     sendCommand?: (command: string) => void;
     scheduleRefresh?: (callback: () => void, intervalMs: number) => number;
-    cancelRefresh?: (handle: number) => void;
     refreshIntervalMs?: number;
   }): LogsPaneController;
   parseDesktopLogEntries(text: string): DesktopLogEntry[];
@@ -159,7 +158,7 @@ describe('desktop logs pane', () => {
   it('runs one guarded refresh timer only while the Logs tab is active', async () => {
     const { createLogsPane } = await loadLogsPane();
     const sendCommand = vi.fn();
-    const cancelRefresh = vi.fn();
+    const cancelRefresh = vi.spyOn(window, 'clearInterval');
     let refreshTick: (() => void) | undefined;
     const controller = createLogsPane({
       sendCommand,
@@ -168,7 +167,6 @@ describe('desktop logs pane', () => {
         refreshTick = callback;
         return 17;
       },
-      cancelRefresh,
       refreshIntervalMs: 2_500,
     });
     document.body.append(controller.element);
@@ -187,6 +185,7 @@ describe('desktop logs pane', () => {
     refreshTick?.();
     expect(cancelRefresh).toHaveBeenCalledWith(17);
     expect(sendCommand).toHaveBeenCalledTimes(2);
+    cancelRefresh.mockRestore();
   });
 
   it('preserves the four existing toolbar commands', async () => {

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
@@ -318,21 +318,17 @@ describe('desktop composition root and launch environment', () => {
       '@desktop/main/platform/pathFix',
     );
     const env = { PATH: '/custom/bin:/usr/bin' };
-    const fixPath = vi.fn();
 
     const first = repairLaunchPath({
       env,
-      fixPath,
       platform: 'darwin',
     });
     const second = repairLaunchPath({
       env,
-      fixPath,
       platform: 'darwin',
     });
 
     expect(first).toBe(second);
-    expect(fixPath).toHaveBeenCalledTimes(2);
     expect(second.split(':')).toEqual([
       '/Library/TeX/texbin',
       '/opt/homebrew/bin',
@@ -348,7 +344,6 @@ describe('desktop composition root and launch environment', () => {
     expect(
       repairLaunchPath({
         env: linuxEnv,
-        fixPath,
         platform: 'linux',
       }),
     ).toBe('/custom/bin');

--- a/src/test-kernel/support/toolEnvironment.ts
+++ b/src/test-kernel/support/toolEnvironment.ts
@@ -1,0 +1,27 @@
+import {
+  createRunContext,
+  withRunContext,
+  type CreateRunContextOptions,
+} from '@agent/runtime/RunContext';
+import {
+  withToolFileInteractionContext,
+  type ToolCallContext,
+} from '@agent/followUp/ToolFileInteractionContext';
+
+/**
+ * Test helper: install a RunContext and a tool-call frame in one call.
+ *
+ * Tests that exercise tools-side code typically need both an active run
+ * (for `tryUseRunContext()` consumers) and a tool-call frame (for tracker
+ * and callbacks). This wraps the two stack pushes in one composer.
+ */
+export function withToolEnvironment<T>(
+  env: { run: CreateRunContextOptions; call: ToolCallContext },
+  fn: () => Promise<T> | T,
+): Promise<T> {
+  return Promise.resolve(
+    withRunContext(createRunContext(env.run), () =>
+      withToolFileInteractionContext(env.call, fn),
+    ),
+  );
+}

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -29,7 +29,7 @@ import { ToolUseDispatchNode } from '@agent/implementations/flows/tooluse/toolUs
 import { createToolUseRoundFlow } from '@agent/implementations/flows/tooluse/ToolUseRoundFlow';
 import type { ToolUseRoundShared } from '@agent/implementations/flows/tooluse/toolUseRound/roundShared';
 import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
-import { withToolEnvironment } from '@agent/followUp/ToolFileInteractionContext';
+import { withToolEnvironment } from '@test/support/toolEnvironment';
 import * as toolUseFollowUp from '@agent/followUp/ToolUseFollowUp';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import { defaultSession } from '@agent/runtime/SessionHandle';

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -29,7 +29,6 @@ import { ToolUseDispatchNode } from '@agent/implementations/flows/tooluse/toolUs
 import { createToolUseRoundFlow } from '@agent/implementations/flows/tooluse/ToolUseRoundFlow';
 import type { ToolUseRoundShared } from '@agent/implementations/flows/tooluse/toolUseRound/roundShared';
 import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
-import { withToolEnvironment } from '@test/support/toolEnvironment';
 import * as toolUseFollowUp from '@agent/followUp/ToolUseFollowUp';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import { defaultSession } from '@agent/runtime/SessionHandle';
@@ -46,6 +45,7 @@ import {
   type ToolResult,
   AgentCategory,
 } from '@shared/schemas';
+import { withToolEnvironment } from '@test/support/toolEnvironment';
 import {
   clearStreamStatusForTest,
   seedStreamStatusForTest,

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -16,7 +16,6 @@ import {
 import { captureOwnedExecutionLease } from '@agent/storage/executionLease';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { FileInteractionState } from '@agent/core/state/AgentWorkspaceState';
-import { withToolEnvironment } from '@test/support/toolEnvironment';
 import * as toolUseFollowUp from '@agent/followUp/ToolUseFollowUp';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
@@ -27,6 +26,7 @@ import {
   type StreamTabId,
   AgentCategory,
 } from '@shared/schemas';
+import { withToolEnvironment } from '@test/support/toolEnvironment';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { ExecutionsTool } from '@tools/ExecutionsTool';
 import { BashTool } from '@tools/bash';

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -16,7 +16,7 @@ import {
 import { captureOwnedExecutionLease } from '@agent/storage/executionLease';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { FileInteractionState } from '@agent/core/state/AgentWorkspaceState';
-import { withToolEnvironment } from '@agent/followUp/ToolFileInteractionContext';
+import { withToolEnvironment } from '@test/support/toolEnvironment';
 import * as toolUseFollowUp from '@agent/followUp/ToolUseFollowUp';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import {

--- a/src/test-kernel/tools/GitHubAuth.vitest.ts
+++ b/src/test-kernel/tools/GitHubAuth.vitest.ts
@@ -5,7 +5,7 @@ import { installPlatform } from '@test/support/setupPlatform';
 /** Secret/env fixture for one row of a token-precedence table. */
 interface TokenCase {
   readonly name: string;
-  /** Real process env, read only while no platform is initialized. */
+  /** Real process env, stubbed to prove tokens only flow via the secrets port. */
   readonly processEnv?: Record<string, string>;
   /** Value persisted under `GITHUB_TOKEN_STORAGE_KEY`, if any. */
   readonly secret?: string;
@@ -42,18 +42,8 @@ afterEach(() => {
 describe('getGitHubToken', () => {
   it.each<TokenCase & { expected: string }>([
     {
-      name: 'uses the GITHUB_TOKEN fallback before platform initialization',
-      processEnv: { GITHUB_TOKEN: 'github-env-token' },
-      expected: 'github-env-token',
-    },
-    {
-      name: 'uses the GH_TOKEN fallback before platform initialization',
-      processEnv: { GH_TOKEN: 'gh-env-token' },
-      expected: 'gh-env-token',
-    },
-    {
-      name: 'prefers GH_TOKEN over GITHUB_TOKEN',
-      processEnv: {
+      name: 'prefers GH_TOKEN over GITHUB_TOKEN from the secrets env port',
+      secretsEnv: {
         GITHUB_TOKEN: 'github-env-token',
         GH_TOKEN: 'gh-env-token',
       },
@@ -61,18 +51,9 @@ describe('getGitHubToken', () => {
     },
     {
       name: 'ignores blank environment token values',
-      processEnv: { GITHUB_TOKEN: '   ', GH_TOKEN: 'gh-env-token' },
+      secretsEnv: { GITHUB_TOKEN: '   ', GH_TOKEN: 'gh-env-token' },
       expected: 'gh-env-token',
     },
-  ])('$name', async (tokenCase) => {
-    stubProcessEnv(tokenCase);
-
-    const { getGitHubToken } = await import('@tools/github/githubAuth');
-
-    await expect(getGitHubToken()).resolves.toBe(tokenCase.expected);
-  });
-
-  it.each<TokenCase & { expected: string }>([
     {
       name: 'prefers the platform secret when the platform is initialized',
       processEnv: {

--- a/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
+++ b/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
@@ -9,11 +9,11 @@ import {
   FileInteractionState,
   WorkPlanState,
 } from '@agent/core/state/AgentWorkspaceState';
-import { withToolEnvironment } from '@test/support/toolEnvironment';
 import type { PlanApprovalResult } from '@agent/runtime/HostInteractions';
 import { platform, type Platform } from '@platform/platform';
 import { planSummaryLine, GOAL_FEATURE_FLAG_KEY } from '@shared/schemas';
 import type { Plan, StreamTabId } from '@shared/schemas';
+import { withToolEnvironment } from '@test/support/toolEnvironment';
 import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
 import { FakeConfigProvider } from '@test/support/FakePlatform';
 import { GoalStore } from '@tools/goal';

--- a/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
+++ b/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
@@ -9,7 +9,7 @@ import {
   FileInteractionState,
   WorkPlanState,
 } from '@agent/core/state/AgentWorkspaceState';
-import { withToolEnvironment } from '@agent/followUp/ToolFileInteractionContext';
+import { withToolEnvironment } from '@test/support/toolEnvironment';
 import type { PlanApprovalResult } from '@agent/runtime/HostInteractions';
 import { platform, type Platform } from '@platform/platform';
 import { planSummaryLine, GOAL_FEATURE_FLAG_KEY } from '@shared/schemas';

--- a/src/test-kernel/tools/lean/LeanServerRegistry.vitest.ts
+++ b/src/test-kernel/tools/lean/LeanServerRegistry.vitest.ts
@@ -4,7 +4,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
-  clearLeanServerRegistry,
   isLeanServerActive,
   listLeanServers,
   registerLeanServer,
@@ -28,7 +27,7 @@ function makeServer(partial: Partial<LeanServerInfo>): LeanServerInfo {
 }
 
 afterEach(() => {
-  clearLeanServerRegistry();
+  for (const server of listLeanServers()) unregisterLeanServer(server.id);
 });
 
 describe('leanServerRegistry', () => {

--- a/src/test-kernel/tools/lean/LeanTools.vitest.ts
+++ b/src/test-kernel/tools/lean/LeanTools.vitest.ts
@@ -10,8 +10,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { findExternalToolDef } from '@tools/externalToolDefs';
 import { defaultResolveWorkspaceRoot } from '@tools/lean/direct/directLspAdapter';
 import {
-  clearLeanServerRegistry,
+  listLeanServers,
   registerLeanServer,
+  unregisterLeanServer,
   updateLeanServer,
 } from '@tools/lean/leanServerRegistry';
 import { extractHoverText } from '@tools/lean/leanTypes';
@@ -100,7 +101,7 @@ describe('defaultResolveWorkspaceRoot', () => {
 
 describe('Lean external tool status', () => {
   afterEach(() => {
-    clearLeanServerRegistry();
+    for (const server of listLeanServers()) unregisterLeanServer(server.id);
   });
 
   it('counts only starting and running Lean servers as active', async () => {

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -22,7 +22,7 @@ import {
   type Disposable,
   type LifecycleHost,
 } from '@platform/interfaces';
-import { tryPlatform } from '@platform/platform';
+import { platform } from '@platform/platform';
 import { jitteredExponentialBackoffMs } from '@utils/core';
 import {
   createBoundedIdSet,
@@ -407,10 +407,10 @@ export abstract class PollingSourceBase<
 
   /**
    * Register `disposeAll` with the platform shutdown registry exactly once per
-   * lifecycle instance. Uses `tryPlatform()` so the base stays usable in
-   * browser/test contexts where no platform is installed, and defers to the
-   * first subscription so the shared singletons (constructed at module load,
-   * before `initPlatform()`) still register once the platform exists.
+   * lifecycle instance. Runs on the first subscription, which only happens
+   * after `initPlatform()` in every host — the shared singletons constructed
+   * at module load do nothing until then, so `platform()` throwing here means
+   * a genuine initialization-order defect, not an expected state.
    *
    * Re-checked on every subscribe, so a lifecycle replacement (extension
    * reactivation or test-harness reinstall) is picked up on the next
@@ -419,8 +419,8 @@ export abstract class PollingSourceBase<
    * installs a new lifecycle while the previous one is still live.
    */
   private registerShutdownIfNeeded(): void {
-    const lifecycle = tryPlatform()?.lifecycle;
-    if (!lifecycle || this.shutdownLifecycle === lifecycle) return;
+    const lifecycle = platform().lifecycle;
+    if (this.shutdownLifecycle === lifecycle) return;
     this.clearShutdownRegistration();
     this.shutdownRegistration = lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () =>
       this.disposeAll(),

--- a/src/tools/github/githubAuth.ts
+++ b/src/tools/github/githubAuth.ts
@@ -9,7 +9,7 @@
  * explicit fallback. Because every host wires `platform().secrets`, GitHub
  * tools work in the CLI and desktop too, not just the extension.
  */
-import { tryPlatform } from '@platform/platform';
+import { platform } from '@platform/platform';
 import type { PlatformSecrets } from '@platform/secrets';
 
 /** SecretStorage key under which the GitHub PAT is persisted. */
@@ -41,11 +41,10 @@ function getGitHubEnvToken(
 }
 
 export async function getGitHubToken(): Promise<string | undefined> {
-  const secrets = tryPlatform()?.secrets;
-  // No platform yet (e.g. module-level init before `initPlatform()` runs):
-  // there's no secrets seam to call, so read process.env directly — same
-  // documented pre-init exception as `tryPlatform()` itself.
-  if (!secrets) return getGitHubEnvToken((name) => process.env[name]);
+  // Every caller runs post-init (tool status probes, GitHub client, setup
+  // commands), so an uninitialized platform here is a programming error and
+  // must throw instead of silently degrading to a process.env read.
+  const secrets = platform().secrets;
   const stored = await secrets.get(GITHUB_TOKEN_STORAGE_KEY);
   return (
     normalizeGitHubToken(stored) ??

--- a/src/tools/lean/leanServerRegistry.ts
+++ b/src/tools/lean/leanServerRegistry.ts
@@ -95,11 +95,6 @@ export function unregisterLeanServer(id: string): void {
   servers.delete(id);
 }
 
-/** Clear all entries so registry-dependent tests remain isolated. */
-export function clearLeanServerRegistry(): void {
-  servers.clear();
-}
-
 function statusTail(info: LeanServerInfo, now: number): string {
   switch (info.status) {
     case 'error':

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -28,6 +28,10 @@ const PROVIDERS: ReadonlyMap<string, ProviderStateEntry> = new Map(
   PROVIDER_STATE_ENTRIES.map((provider) => [provider.id, provider]),
 );
 
+// The lowercase retry is load-bearing: the API-key spelling 'openRouter'
+// (EXTRA_API_KEY_PROVIDER_IDS, ModelHandler dispatch) and the registry id
+// 'openrouter' must resolve to the same entry until the carrier is retyped
+// (overdefensive-top10 #8's "lowercase once at registry load" is that PR).
 function entry(provider: string): ProviderStateEntry | undefined {
   return PROVIDERS.get(provider) ?? PROVIDERS.get(provider.toLowerCase());
 }

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -166,13 +166,8 @@ async function tryExeca(
 }
 
 /** Whether a probe result carries a version-like pattern (e.g., "3.7.1"). */
-function hasVersionOutput(result: {
-  stdout?: string;
-  stderr?: string;
-}): boolean {
-  return (
-    /\d+\.\d+/.test(result.stdout ?? '') || /\d+\.\d+/.test(result.stderr ?? '')
-  );
+function hasVersionOutput(result: { stdout: string; stderr: string }): boolean {
+  return /\d+\.\d+/.test(result.stdout) || /\d+\.\d+/.test(result.stderr);
 }
 
 /** Split a probe command string into an executable and its arguments. */


### PR DESCRIPTION
Executes the maintainer-ruled batch of four small deletions (GO, aggressive). Net **−242 lines** (187 ins / 429 del across 30 files). Nothing under `packages/cli/src/chat/tui/**` is touched.

## 1. D16 — SubscriptionUsageService arbitration collapse (`docs/proposals/2026-08-16-define-out-of-existence.md` §1e)

Deletes `latestRequests`, `nextRequestId`, the `ResolvedRequest` carrier, and **both re-dispatch branches**; `getUsageForRequest` folds back into `getUsage`. The variant joins the cache key (already the case); the identity-checked commit remains the one irreducible boundary. (`generations` was already gone at HEAD.)

**Declared return-path choice (R6 line):** when `invalidate()` races an in-flight fetch, the identity check keeps the stale result **out of the cache**, but the already-waiting caller **accepts one stale read** — on a read-only usage display. Stated in a comment at the commit site and pinned by the adapted regression scenario (old caller sees old-account usage once; a follow-up read returns new-account usage with no extra fetch). Two arbitration-only tests (older-caller-redirected-to-newer) deleted with the machinery; the concurrent-region test now pins per-variant cache-key independence.

*Item net: −65 prod / −60 test.*

## 2. Resume acquire-then-read residue (`docs/proposals/2026-08-16-overdefensive-top10.md` #4a)

Re-verified at HEAD: the KEEP-conditioning reorder **already landed** — `resumeToolUseFromResumeData` acquires the execution lease, then re-reads via `retrieveSessionResumeData` (executeAgent.ts:659ff). This PR deletes the now-dead residue in `runToolUseFlow.ts`: the flow-preamble second disk read on the resume path and the `isDeepStrictEqual` drift heal + write. `PersistedFlow`'s own schema-checked read is the single disk read for resumed state; a validation failure routes through the same run-path catcher (`classifyAgentError` → `finalizeFailedRun`). The fresh-launch leftover-record guards (`invalid-shared` / `unexpected-record`, read-failure preservation, cancellation window) stay, now scoped to the non-resume branch.

Riders verified: the heal's normalization write-back is redundant (readShared re-parses at the boundary; the first step write persists the normalized shared — schema doc comment updated); the compat-key stamp is redundant (retrieval re-infers keyless legacy records per resume; `executeAgent.ts:571` consumes the key from `resume.shared`, not disk). Tests pinning the deleted drift window (malformed-record-under-resume-handoff, cancel-during-recovery-read) were injecting states now unrepresentable — retrieval validates the same envelope under the lease — and were adapted to fresh-launch form or deleted; the #8049 P2 follow-up-preservation invariant is re-pinned at the surviving sync cancel-at-attach window. `stampFlowRecordSchemaVersion` un-exported (internal callers remain).

*Item net: −25 prod / −90 test (incl. R6 scaffolding-test deletions).*

## 3. Test-only-seam purge (contracts doc §3 Tier 3)

**Convention (house ruling, applied here):** test-only injection seams live in test-kernel, not production modules.

- `isAgentRegistryReady` — deleted; its docstring described a caller class that does not exist. Tests now assert via `getAgent(...)` (which they already did on the adjacent line).
- `withToolEnvironment` — self-labeled "Test helper:" in production; moved to `src/test-kernel/support/toolEnvironment.ts`; 3 test callers repointed.
- `clearLeanServerRegistry` — deleted; tests reset via public `listLeanServers` + `unregisterLeanServer`.
- `logsPane.cancelRefresh` option — deleted; production always `window.clearInterval`; test spies on it.
- `SettingsViewHost.beforeModelSelectionMessage` — option + call site deleted; zero production passers.
- `pathFix.fixPath` option — deleted; the existing `env === process.env` guard already keeps injected test envs away from the real fix-path.

*Item net: −45 prod (moved helper re-added in test-kernel).*

## 4. Overdefensive residue (overdefensive doc #2 / #7 / #8)

- `githubAuth.getGitHubToken` → `platform().secrets` (throwing). All callers (tool status probes, GitHub client, subscription tool, setup commands) run post-init; the silent `process.env` pre-init fallback deleted, with its 4 pre-init test cases (env-precedence coverage retained via the secrets-port cases).
- `PollingSourceBase.registerShutdownIfNeeded` → `platform().lifecycle` (throwing). Runs only on first subscribe, which is post-init in every host; the "browser context" claim in the old comment was stale (`src/tools/` is not browser-reachable).
- `packages/extension/src/common/state/index.ts` — stale comment recommending `try*` access dropped.
- `stdout ?? ` residue: producer flip already landed (`normalizeOutput` returns `string`); the two dead consumer re-defaults deleted (`toolUtils.hasVersionOutput` param tightened to required strings; `gitCommands.ts` label fallback). `execUtils.ts:120`'s `err.stdout ?? ''` is the producer's own execa-error boundary guard — kept.

### Keeps (honored verbatim, with evidence)

- **Bootstrap `try*` callers** — `packages/cli/src/runtime/initPlatform.ts`, `bin/texra.ts`, `packages/agent/src/index.ts` (doc KEEP list).
- **`serverKeys` `tryGlobalState`** — deliberate platformless-SDK support (doc KEEP, comment in file).
- **`goalStore` reads** — carry the written pre-init rationale (`goalStore.ts:58-61`); goalStore **writes** already use throwing `platform()` at HEAD, nothing to do.
- **`getConfigBeforePlatformInit`** (configUtils.ts) — turned out live: its one consumer is `isDebugModeEnabled` (`src/logger/logUtils.ts:125`), documented pre-init fatal/startup logging. Reported, not forced.
- **`providerConfig.entry` lowercase retry** — turned out live: it bridges the `'openRouter'` API-key spelling (`EXTRA_API_KEY_PROVIDER_IDS`, `ModelHandler.ts:594`) with the registry id `'openrouter'`, pinned by `ConfigUtils.vitest.ts` ("uses the same setting for API-key and model-dispatch spellings"). Left in place with a comment pointing at the doc-#8 carrier-retype PR as the real fix. The other cited `provider.toLowerCase()` sites (`ServerSideKeyService.ts`, `UsageMonitor.ts`) are already gone at HEAD.

### Excluded (per ruling)
§2.9 usage naming (counter-ruled by #10796) and `hideFromCli` residue (#10806 carve-out) untouched.

## Gates
- `npm run typecheck` — green (all packages)
- `FORCE_COLOR=0 npx vitest run` over the 17 touched suites — 341 tests green
- scoped eslint over all touched files — clean
- `npm run check:dead-code-ratchet` — OK (8 vs 8 baselined; no baseline widening)
- prettier — clean

R8 greps run both directions for every deleted symbol; no remaining references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)