### PR TITLE
Stream-schema fixes: retire legacy StreamStatus from snapshot write side, declare identity fields once (§2.6)

### DIFF
--- a/packages/trace-viewer/src/replayTrace.ts
+++ b/packages/trace-viewer/src/replayTrace.ts
@@ -12,7 +12,6 @@ import {
   STREAM_PHASE,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_STATUS,
-  streamStatusToLifecycleStatus,
 } from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { buildStreamContentRender } from '@shared/streams/streamContentSync';
@@ -87,9 +86,11 @@ function findRootStageId(
  * `terminalStatus` is `null` for traces that predate outcome tracking (or
  * never reached a terminal state). For those legacy traces, derive status from
  * the persisted transcript's last terminal group row before falling back to the
- * older snapshot-status escape hatch. Only when neither source records a
- * terminal status does this default to `READY`, same as an unqualified
- * successful finish.
+ * older snapshot-status escape hatch (already normalized to `StreamPhase` at
+ * trace parse — `StreamSnapshotSchema.status`'s legacy-inbound member maps the
+ * retired 7-value vocabulary, with legacy `ready` parsing to absent). Only
+ * when no source records a terminal status does this default to `READY`, same
+ * as an unqualified successful finish.
  *
  * The terminal group row's `data.status` is typed at trace import as the
  * StreamPhase-or-legacy-EndGroupStatus union, not narrowed here:
@@ -131,9 +132,7 @@ function toStreamLifecycleStatus(trace: TraceDocument): StreamLifecycleStatus {
     }
     if (status !== undefined) return status;
   }
-  return trace.snapshot.status
-    ? streamStatusToLifecycleStatus(trace.snapshot.status)
-    : STREAM_STATUS.READY;
+  return trace.snapshot.status ?? STREAM_STATUS.READY;
 }
 
 /** The record's display name across both arms of the config union. */

--- a/packages/trace-viewer/src/traceDataSchema.ts
+++ b/packages/trace-viewer/src/traceDataSchema.ts
@@ -1,27 +1,16 @@
 /**
  * Runtime validation for trace data loaded from `trace.json` or
- * `window.__TEXRA_TRACE__`. The shared document schema owns the format; this
- * external boundary only tightens snapshot-version handling so a future
- * snapshot is rejected instead of normalized as a legacy omission.
+ * `window.__TEXRA_TRACE__`. The shared document schema owns the format,
+ * including snapshot-version handling: a missing `schemaVersion` is a legacy
+ * omission, a future one is rejected rather than normalized.
  */
 import { z } from 'zod';
 
+import { TraceStreamLogEntrySchema } from '@shared/schemas';
 import { TraceDocumentSchema } from '@transcript/traceDocumentSchema';
-import {
-  STREAM_SNAPSHOT_SCHEMA_VERSION,
-  StreamSnapshotSchema,
-  TraceStreamLogEntrySchema,
-} from '@shared/schemas';
-
-const TraceStreamSnapshotSchema = StreamSnapshotSchema.extend({
-  schemaVersion: z
-    .literal(STREAM_SNAPSHOT_SCHEMA_VERSION)
-    .prefault(STREAM_SNAPSHOT_SCHEMA_VERSION),
-});
 
 export const TraceDataSchema = TraceDocumentSchema.extend({
   entries: z.array(TraceStreamLogEntrySchema),
-  snapshot: TraceStreamSnapshotSchema,
 });
 
 export type TraceData = z.infer<typeof TraceDataSchema>;

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -14,12 +14,10 @@ import { createLog } from '@logger/logUtils';
 import {
   type ActiveChildInfo,
   type ConversationProgress,
-  type ExecutionId,
   type StreamStage,
-  type RunIdentity,
+  type StreamIdentityFields,
   type StreamPhase,
   type StreamTabId,
-  type UserFollowUpSupport,
   AgentCategory,
 } from '@shared/schemas';
 import { compareByNewestCreationTime } from '@shared/streams/streamOrdering';
@@ -39,17 +37,13 @@ interface SessionStreamConfigDetails {
   workingDirectory?: string;
 }
 
-/** Canonical current metadata used by every session stream consumer. */
-export interface SessionStreamMetadata {
-  /** The run's identity, verbatim from `run.start` or the durable store. */
-  identity?: RunIdentity;
-  userFollowUpSupport?: UserFollowUpSupport;
-  agentCategory?: AgentCategory;
-  isRemote?: boolean;
-  creationTimestamp: number;
-  executionId?: ExecutionId;
-  parentStreamId?: StreamTabId;
-  description?: string;
+/**
+ * Canonical current metadata used by every session stream consumer. The
+ * identity/pointer fields are the shared {@link StreamIdentityFields} shape
+ * (declared once beside `StreamTabInfoSchema`), so this record and the wire
+ * tab info cannot drift apart field-by-field.
+ */
+export interface SessionStreamMetadata extends StreamIdentityFields {
   config?: SessionStreamConfigDetails;
 }
 

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -244,6 +244,29 @@ const WorktreeInfoSchema = z.object({
 export type WorktreeInfo = z.infer<typeof WorktreeInfoSchema>;
 
 /**
+ * The identity/pointer fields every per-stream metadata surface carries —
+ * declared once so the wire tab shape ({@link StreamTabInfoSchema}) and the
+ * session-side metadata record (`SessionStreamMetadata`,
+ * `@controllers/session/SessionState`) cannot drift apart field-by-field.
+ */
+const StreamIdentityFieldsSchema = z.object({
+  /** The run's identity, verbatim from `run.start` or the durable store. */
+  identity: RunIdentitySchema.optional(),
+  /** Runtime behavior declared by the launch source, not UI visibility. */
+  userFollowUpSupport: UserFollowUpSupportSchema.optional(),
+  /** The agent's execution mode (agent runs only) — display/routing data
+   * beside the identity, sourced from the run's config. */
+  agentCategory: AgentCategorySchema.optional(),
+  isRemote: z.boolean().optional(),
+  creationTimestamp: z.number(),
+  executionId: ExecutionIdSchema.optional(),
+  parentStreamId: StreamTabIdSchema.optional(),
+  /** AI-generated summary of what this session aims to accomplish. */
+  description: z.string().optional(),
+});
+export type StreamIdentityFields = z.infer<typeof StreamIdentityFieldsSchema>;
+
+/**
  * One flat wire shape per stream tab. The parsed {@link RunIdentitySchema}
  * struct travels verbatim — renderers key on `identity.kind` instead of
  * inferring ownership from whichever optional field is present — and hosts
@@ -252,25 +275,13 @@ export type WorktreeInfo = z.infer<typeof WorktreeInfoSchema>;
  * driving the store by hand); absent renders as pending, never as a default
  * kind.
  */
-export const StreamTabInfoSchema = z.object({
+export const StreamTabInfoSchema = StreamIdentityFieldsSchema.extend({
   name: z.string(),
   label: z.string(),
-  identity: RunIdentitySchema.optional(),
-  /** Runtime behavior declared by the launch source, not UI visibility. */
-  userFollowUpSupport: UserFollowUpSupportSchema.optional(),
-  /** The agent's execution mode (agent runs only) — display/routing data
-   * beside the identity, sourced from the run's config. */
-  agentCategory: AgentCategorySchema.optional(),
   model: z.string().optional(),
   modelLabel: z.string().optional(),
   /** Full, untruncated command that spawned a process stream. */
   command: z.string().optional(),
-  isRemote: z.boolean().optional(),
-  creationTimestamp: z.number(),
-  executionId: ExecutionIdSchema.optional(),
-  parentStreamId: StreamTabIdSchema.optional(),
-  /** AI-generated summary of what this session aims to accomplish. */
-  description: z.string().optional(),
   /** Git worktree / PR context for streams whose agents operate in a
    * worktree other than the workspace root. Surfaced as a chip on the tab. */
   worktree: WorktreeInfoSchema.optional(),

--- a/src/shared/schemas/streamSnapshot.ts
+++ b/src/shared/schemas/streamSnapshot.ts
@@ -25,7 +25,12 @@
 import { z } from 'zod';
 
 import { ExecutionIdSchema, StreamTabIdSchema } from './identifiers';
-import { StreamStatusSchema } from './stream';
+import {
+  STREAM_STATUS,
+  StreamPhaseSchema,
+  StreamStatusSchema,
+  streamStatusToLifecycleStatus,
+} from './stream';
 import {
   BackendOwnedFieldsSchema,
   RoundKeyedOutputSidecarValueSchemas,
@@ -76,10 +81,31 @@ export const PersistedWorkPlanSchema = z.object({
 // StreamSnapshot — the assembled logical view (durable + log-derived + liveness)
 // ============================================================================
 
+/**
+ * Legacy-inbound member for `status`: archived `trace.json` exports (the §8.3
+ * permanently-fenced boundary — a static exported file stays legacy-shaped
+ * forever) still carry the retired 7-value `StreamStatus` vocabulary.
+ * Normalized once here, at the parse entry point, into the canonical
+ * `StreamPhase` via the same collapse `streamStatusToLifecycleStatus` performs
+ * everywhere else; `ready` has no phase equivalent ("no run recorded") and
+ * normalizes to absent. Downstream code never sees a legacy value.
+ */
+const LegacyStreamStatusAsPhaseSchema = StreamStatusSchema.transform(
+  (status) => {
+    const lifecycle = streamStatusToLifecycleStatus(status);
+    return lifecycle === STREAM_STATUS.READY ? undefined : lifecycle;
+  },
+);
+
 export const StreamSnapshotSchema = SharedBackendOwnedFieldsSchema.extend({
+  /**
+   * Missing on legacy assemblies/exports → current version; a PRESENT wrong
+   * version fails the parse loudly (`.prefault`, not `.catch` — a swallowed
+   * future version would consume unknown-shaped fields as v1).
+   */
   schemaVersion: z
     .literal(STREAM_SNAPSHOT_SCHEMA_VERSION)
-    .catch(STREAM_SNAPSHOT_SCHEMA_VERSION),
+    .prefault(STREAM_SNAPSHOT_SCHEMA_VERSION),
   streamId: StreamTabIdSchema,
 
   // -- Durable display state (persisted in field-scoped files) --------------
@@ -110,7 +136,9 @@ export const StreamSnapshotSchema = SharedBackendOwnedFieldsSchema.extend({
   description: z.string().optional(),
 
   // -- Log-derived (recomputed from the StreamLog on load) ------------------
-  status: StreamStatusSchema.optional(),
+  status: z
+    .union([StreamPhaseSchema, LegacyStreamStatusAsPhaseSchema])
+    .optional(),
   // conversationProgress comes from SharedBackendOwnedFieldsSchema above.
 
   // -- Liveness (NEVER restored as live — clamp on hydrate) -----------------

--- a/src/test-kernel/schemas/SchemaMigrations.vitest.ts
+++ b/src/test-kernel/schemas/SchemaMigrations.vitest.ts
@@ -6,6 +6,7 @@ import {
   ContextManagementDataSchema,
   STREAM_PHASE,
   STREAM_STATUS,
+  StreamSnapshotSchema,
 } from '@shared/schemas';
 
 // Minimal NormalizedUsage fixture: all required fields, no optionals.
@@ -128,5 +129,26 @@ describe('ActiveChildInfoSchema — flat roster row', () => {
         status: STREAM_STATUS.INITIALIZING,
       }),
     ).toThrow();
+  });
+});
+
+describe('StreamSnapshotSchema.status — legacy-inbound normalization', () => {
+  // Archived trace.json exports (the permanently-fenced §8.3 boundary) still
+  // carry the retired 7-value StreamStatus. The parse entry point normalizes
+  // them into StreamPhase once; downstream never sees a legacy value.
+  it.each([
+    { legacy: STREAM_STATUS.INITIALIZING, expected: STREAM_PHASE.RUNNING },
+    { legacy: STREAM_STATUS.RESUMING, expected: STREAM_PHASE.RUNNING },
+    { legacy: STREAM_STATUS.ERROR, expected: STREAM_PHASE.FAILED },
+    { legacy: STREAM_STATUS.STOPPED, expected: STREAM_PHASE.COMPLETED },
+    // `ready` has no phase equivalent ("no run recorded") → absent.
+    { legacy: STREAM_STATUS.READY, expected: undefined },
+  ])('normalizes legacy "$legacy" to "$expected"', ({ legacy, expected }) => {
+    const result = StreamSnapshotSchema.parse({
+      streamId: 'stream:legacy',
+      status: legacy,
+    });
+
+    expect(result.status).toBe(expected);
   });
 });


### PR DESCRIPTION
Executes the §2.6 GO items from `docs/proposals/2026-08-15-shared-contracts-and-retirement.md` (maintainer ruling: GO; one PR).

## 1. `StreamSnapshotSchema.status` — last production writer of retired `STREAM_STATUS`

- **Write side** now types against `StreamPhaseSchema` only.
- **Parse side** gets the doc's review-caught legacy-inbound member: archived `trace.json` exports (the §8.3 permanently-fenced boundary) carrying `ready`/`initializing`/`resuming`/`error`/`stopped` parse through `TraceDataSchema` → `StreamSnapshotSchema`, so the union's legacy member `.transform()`s them into the canonical phase via the same collapse `streamStatusToLifecycleStatus` performs everywhere else. Legacy `ready` (no phase equivalent — "no run recorded") normalizes to absent; `replayTrace`'s fallback then simplifies to `trace.snapshot.status ?? READY` with identical rendered results for every legacy value.
- `STREAM_STATUS` itself does **not** delete — trace-viewer `replayTrace.ts` keeps it, fence only (per the doc's row for this item).

### Rider: `schemaVersion.catch(...)` remnant (verified before removing)

What it swallowed: (a) a *missing* `schemaVersion` — every `assembleSnapshot` parse, since the assembler never supplies one — and (b) a *present wrong* version, silently coerced to v1. (a) is legitimate defaulting → `.prefault()`. (b) is the silent-degradation defect: consuming a future shape's fields as v1. Now it fails the parse loudly (in `assembleSnapshot` that lands in the existing logged empty-snapshot recovery; at the trace-import boundary it is the existing loud rejection). Since base behavior now matches the trace-viewer's deliberate tightening override, `TraceStreamSnapshotSchema` deletes as redundant.

## 2. `StreamIdentityFieldsSchema` — declare the shared identity/pointer fields once

`StreamTabInfo` (wire, `src/shared/schemas/stream.ts`) and `SessionStreamMetadata` (`src/controllers/session/SessionState.ts`) maintained the same 8 identity/pointer fields (`identity`, `userFollowUpSupport`, `agentCategory`, `isRemote`, `creationTimestamp`, `executionId`, `parentStreamId`, `description`) in two hand-kept declarations. `StreamIdentityFieldsSchema` now declares them once; `StreamTabInfoSchema` `.extend()`s it and `SessionStreamMetadata` extends the inferred `StreamIdentityFields` type. No wire-shape change (field set and optionality identical — typecheck + all consumer suites green).

**Deliberately deferred (scope caution):** the doc's builder-collapse half of item 2 brushes `SessionState` and the CLI TUI files just reworked by the Wave A PRs (#10892/#10895). This PR lands only the schema-level declare-once; collapsing the remaining builder entry points onto the shared field schema is follow-up work once Wave A settles.

## Tests

Per the doc's allowance, one legacy-inbound parse pin added to the existing `SchemaMigrations.vitest.ts` suite (the transform is new behavior and is the doc's named regression case — a hard enum swap would have rejected permanently-fenced files). The existing `replayTrace.vitest.ts` legacy-status regressions (#7188) pass unchanged through the new parse path — they are the end-to-end pins for `error`→`failed` / `stopped`→`completed`.

## Verified

- Re-verified §2.6 anchors at HEAD: `streamSnapshot.ts` status field + `schemaVersion.catch` both present as cited; `assembleSnapshot` never writes `status` (the schema surface was the writer); `replayTrace.ts:134-135` was the sole `snapshot.status` reader.
- Two-direction grep: no other producer/consumer of `StreamSnapshot.status`; `streamStatusToLifecycleStatus` retains its other consumer (`StreamLifecycleStatusSchema`).
- `npm run typecheck` — green (all workspaces)
- `FORCE_COLOR=0 npx vitest run` on replayTrace, StreamSnapshotStore, traceAssembler, traceViewerSchema, standaloneTraceHtml, SharedStreams, SchemaMigrations, streamInfoUtils, StreamMetaState, StreamTabsStatus, StreamTree, WorkflowRunContextCopy — 246 tests green
- `npm run format:check` — green
- Scoped eslint on all touched files — green
- `npm run check:dead-code-ratchet` — 8 vs 8 baseline, no new findings
- `pnpm --filter @texra/trace-viewer build` — green (replay schemas touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)