### PR TITLE
Unify approval-request id spellings onto requestId (§2.2 item 2)

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -1034,7 +1034,7 @@ function makeRetryApprovalPayload(): RetryPermission {
 
 function makePlanApprovalPayload(): PlanApprovalPermission {
   return {
-    approvalId: 'harness-plan-approval',
+    requestId: 'harness-plan-approval',
     streamId: STREAM_ID,
     goalEnabled: PLAN_APPROVAL_GOAL,
     plan: {
@@ -1045,7 +1045,7 @@ function makePlanApprovalPayload(): PlanApprovalPermission {
 
 function makeAgentProposalPayload() {
   return {
-    proposalId: 'harness-agent-proposal',
+    requestId: 'harness-agent-proposal',
     streamId: STREAM_ID,
     agentCategory: AgentCategory.ToolUse,
     agent: 'review',

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -296,8 +296,8 @@ export class DesktopProgressBridge {
           },
           proposal: createAgentProposalTransport({
             getRenderer: () => this.backend.renderer,
-            isPending: (proposalId) =>
-              this.backend.approvalHandlers.proposal.get(proposalId) !==
+            isPending: (requestId) =>
+              this.backend.approvalHandlers.proposal.get(requestId) !==
               undefined,
           }),
         },
@@ -745,24 +745,24 @@ export class DesktopProgressBridge {
         sendFollowUp: (stream, text) => this.sendFollowUp(stream, text),
       },
       agentProposal: {
-        getPendingProposal: (proposalId) =>
-          this.backend.approvalHandlers.proposal.get(proposalId),
+        getPendingProposal: (requestId) =>
+          this.backend.approvalHandlers.proposal.get(requestId),
         restoreRunConfig: async (config) => this.restoreRunConfig(config),
         openFile: (file) => this.options.host.openPath(file),
-        settleProposal: (proposalId, result) => {
+        settleProposal: (requestId, result) => {
           const resolved = this.hostInteractions.submitProposalDecision(
-            proposalId,
+            requestId,
             result,
           );
           if (!resolved) {
             this.logger.warn(
-              `No pending desktop host interaction found for proposal: ${proposalId}`,
+              `No pending desktop host interaction found for proposal: ${requestId}`,
             );
           }
         },
-        onMissingProposal: (proposalId) => {
+        onMissingProposal: (requestId) => {
           this.logger.warn(
-            `No pending desktop agent proposal found for setup: ${proposalId}`,
+            `No pending desktop agent proposal found for setup: ${requestId}`,
           );
         },
         onInvalidProposal: (issues) => {
@@ -772,7 +772,7 @@ export class DesktopProgressBridge {
         },
         onSetupComplete: (proposal) => {
           this.logger.info(
-            `Desktop agent proposal ${proposal.proposalId} set up in main view`,
+            `Desktop agent proposal ${proposal.requestId} set up in main view`,
             {
               data: { agent: proposal.agent },
             },
@@ -849,7 +849,7 @@ export class DesktopProgressBridge {
             ),
           handlePlanApprovalAction: (message) => {
             this.hostInteractions.submitPlanDecision(
-              message.approvalId,
+              message.requestId,
               message.action === 'reject'
                 ? { action: 'reject', feedback: message.feedback }
                 : { action: message.action },

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -437,8 +437,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         },
       },
       agentProposal: {
-        getPendingProposal: (proposalId) =>
-          this.provider.getPendingAgentProposal(proposalId),
+        getPendingProposal: (requestId) =>
+          this.provider.getPendingAgentProposal(requestId),
         restoreRunConfig: async (config) => {
           return (
             (await this.runViewCommand<boolean>('texra.restoreState', [
@@ -447,22 +447,22 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           );
         },
         openFile: (file) => this.runViewCommand('texra.openFile', [file]),
-        settleProposal: (proposalId, result) => {
+        settleProposal: (requestId, result) => {
           const resolved = this.interactions.submitProposalDecision(
-            proposalId,
+            requestId,
             result,
           );
           if (!resolved) {
             this.logger.warn(
               this.channel,
-              `No pending host interaction found for proposal: ${proposalId}`,
+              `No pending host interaction found for proposal: ${requestId}`,
             );
           }
         },
-        onMissingProposal: (proposalId) => {
+        onMissingProposal: (requestId) => {
           this.logger.warn(
             this.channel,
-            `No pending agent proposal found for setup: ${proposalId}`,
+            `No pending agent proposal found for setup: ${requestId}`,
           );
         },
         onInvalidProposal: (issues) => {
@@ -473,7 +473,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         onSetupComplete: (proposal) => {
           this.logger.info(
             this.channel,
-            `Agent proposal ${proposal.proposalId} set up in main view`,
+            `Agent proposal ${proposal.requestId} set up in main view`,
             {
               data: { agent: proposal.agent },
             },
@@ -864,9 +864,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private handlePlanApprovalAction(
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION>,
   ): void {
-    const { approvalId, action } = data;
+    const { requestId, action } = data;
     this.interactions.submitPlanDecision(
-      approvalId,
+      requestId,
       action === 'reject'
         ? { action: 'reject', feedback: data.feedback }
         : { action },

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -132,8 +132,8 @@ export class ProgressViewProvider extends BaseWebviewProvider {
           },
           proposal: createAgentProposalTransport({
             getRenderer: () => this.backend.renderer,
-            isPending: (proposalId) =>
-              this.backend.approvalHandlers.proposal.get(proposalId) !==
+            isPending: (requestId) =>
+              this.backend.approvalHandlers.proposal.get(requestId) !==
               undefined,
           }),
         },
@@ -347,9 +347,9 @@ export class ProgressViewProvider extends BaseWebviewProvider {
   }
 
   public getPendingAgentProposal(
-    proposalId: string,
+    requestId: string,
   ): AgentProposalPermission | undefined {
-    return this.backend.approvalHandlers.proposal.get(proposalId);
+    return this.backend.approvalHandlers.proposal.get(requestId);
   }
 
   private canSendToWebview(): boolean {

--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -347,9 +347,9 @@ export class LogList extends LitElement {
       event,
       '.proposal-restore-link',
     );
-    if (proposalLink?.dataset.proposalId) {
+    if (proposalLink?.dataset.proposalInputId) {
       event.preventDefault();
-      const proposal = getProposalInput(proposalLink.dataset.proposalId);
+      const proposal = getProposalInput(proposalLink.dataset.proposalInputId);
       if (proposal) {
         postMessage(PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG, {
           proposal,

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -52,10 +52,10 @@ import { processMarkdownContent } from '../formatters/markdownRenderer';
 import { getComposedPathElement } from '../utils';
 import type { PermissionState } from '../permissionState';
 
-function proposalIdOf(
+function proposalRequestIdOf(
   p: PermissionState | null | undefined,
 ): string | undefined {
-  return p?.kind === PERMISSION_KIND.PROPOSAL ? p.data.proposalId : undefined;
+  return p?.kind === PERMISSION_KIND.PROPOSAL ? p.data.requestId : undefined;
 }
 
 @customElement('proposal-request-panel')
@@ -84,7 +84,9 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
     if (!changed.has('permission')) return;
     const previous = changed.get('permission') as
       PermissionState | null | undefined;
-    if (proposalIdOf(previous) !== proposalIdOf(this.permission)) {
+    if (
+      proposalRequestIdOf(previous) !== proposalRequestIdOf(this.permission)
+    ) {
       this.selectedModel = null;
       this.selectedAgent = null;
     }

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -344,14 +344,14 @@ export function handlePermissionAction(
         ? ({
             command: PROGRESS_VIEW_COMMANDS.ENABLE_SUPER_YOLO_BYPASS,
             stream: data.streamId,
-            initiatingProposalId: data.proposalId,
+            initiatingProposalId: data.requestId,
           } satisfies ProgressViewInboundMessage)
         : undefined;
       let message: ProgressViewInboundMessage;
       if (decision.action === 'approve' || approveAllDelegatedWork) {
         message = {
           command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-          proposalId: data.proposalId,
+          requestId: data.requestId,
           action: 'approve',
           ...(decision.model ? { model: decision.model } : {}),
           ...(decision.agent ? { agent: decision.agent } : {}),
@@ -359,22 +359,22 @@ export function handlePermissionAction(
       } else if (decision.action === 'reject') {
         message = {
           command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-          proposalId: data.proposalId,
+          requestId: data.requestId,
           action: 'reject',
           ...(decision.feedback ? { feedback: decision.feedback } : {}),
         };
       } else {
         message = {
           command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-          proposalId: data.proposalId,
+          requestId: data.requestId,
           action: 'setup',
         };
       }
       postWithOptionalBypass(bypassMessage, message);
       // Optimistic removal — track resolved ID so late SHOW is a no-op
-      const removed = removePrompt(PERMISSION_KIND.PROPOSAL, data.proposalId);
+      const removed = removePrompt(PERMISSION_KIND.PROPOSAL, data.requestId);
       if (!removed) {
-        addResolvedProposalId(data.proposalId);
+        addResolvedProposalId(data.requestId);
       }
       break;
     }
@@ -382,13 +382,13 @@ export function handlePermissionAction(
       const { data, decision } = detail;
       postPermissionMessage({
         command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
-        approvalId: data.approvalId,
+        requestId: data.requestId,
         action: decision.action,
         ...(decision.action === 'reject' && decision.feedback
           ? { feedback: decision.feedback }
           : {}),
       });
-      removePrompt(PERMISSION_KIND.PLAN_APPROVAL, data.approvalId);
+      removePrompt(PERMISSION_KIND.PLAN_APPROVAL, data.requestId);
       break;
     }
     case PERMISSION_KIND.EXTERNAL_INQUIRY: {

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -213,7 +213,7 @@ export function formatToolUseTemplate(
     DELEGATION_TOOL_CATEGORY,
     toolName,
   );
-  const proposalId =
+  const proposalInputId =
     isProposalBearingDelegation && !isInProgress
       ? registerProposalInput(input, toolName)
       : null;
@@ -223,7 +223,7 @@ export function formatToolUseTemplate(
   // stopSummaryToggleKeydown for why the keydown path additionally needs an
   // explicit stopPropagation.
   // prettier-ignore
-  const extraContent = html`${timerTemplate ?? nothing}${spillPath ? buildSpillArtifactButton(spillPath) : nothing}${proposalId ? html`<button type="button" class="proposal-restore-link proposal-banner-setup" data-proposal-id=${proposalId} title="Setup this proposal configuration" @keydown=${stopSummaryToggleKeydown}>${waIcon('reply')} Setup</button>` : nothing}`;
+  const extraContent = html`${timerTemplate ?? nothing}${spillPath ? buildSpillArtifactButton(spillPath) : nothing}${proposalInputId ? html`<button type="button" class="proposal-restore-link proposal-banner-setup" data-proposal-input-id=${proposalInputId} title="Setup this proposal configuration" @keydown=${stopSummaryToggleKeydown}>${waIcon('reply')} Setup</button>` : nothing}`;
 
   return buildToolUseDetails({
     message,

--- a/packages/extension/src/progressView/frontend/permissionState.ts
+++ b/packages/extension/src/progressView/frontend/permissionState.ts
@@ -18,7 +18,6 @@ import type {
   UserQuestionPermission,
 } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
-import { assertNever } from '@utils/core';
 
 export type PermissionState =
   | { kind: typeof PERMISSION_KIND.TOOL_EDIT; data: ToolEditPermission }
@@ -44,27 +43,14 @@ export type PermissionState =
     };
 
 /**
- * Each permission kind's wire schema names its id field differently
- * (`requestId` / `streamId` / `proposalId` / `approvalId`). Switching on
- * `kind` here narrows `data` to the matching variant, so callers get the id
- * without a `Record<string, unknown>` cast into an untyped field name.
+ * Every permission kind's wire schema carries `requestId`, except retry,
+ * which is keyed by `streamId` (one pending retry per stream, a new request
+ * replaces the old one).
  */
 export function permissionId(permission: PermissionState): string {
-  switch (permission.kind) {
-    case PERMISSION_KIND.RETRY:
-      return permission.data.streamId;
-    case PERMISSION_KIND.PLAN_APPROVAL:
-      return permission.data.approvalId;
-    case PERMISSION_KIND.PROPOSAL:
-      return permission.data.proposalId;
-    case PERMISSION_KIND.TOOL_EDIT:
-    case PERMISSION_KIND.BASH:
-    case PERMISSION_KIND.EXTERNAL_INQUIRY:
-    case PERMISSION_KIND.USER_QUESTION:
-      return permission.data.requestId;
-    default:
-      return assertNever(permission, 'Unhandled PermissionState kind');
-  }
+  return permission.kind === PERMISSION_KIND.RETRY
+    ? permission.data.streamId
+    : permission.data.requestId;
 }
 
 /** Stable identity key for a pending permission, used for selection/dedup. */

--- a/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
@@ -43,7 +43,7 @@ export function addResolvedProposalId(id: string): void {
 // ============================================================
 
 /**
- * Upsert a proposal permission. If one with the same proposalId already exists
+ * Upsert a proposal permission. If one with the same requestId already exists
  * (e.g., a model-options update after the initial show), replace it in-place
  * to preserve ordering. Otherwise prepend as a new permission.
  */
@@ -54,7 +54,7 @@ function upsertProposalPermission(
   const idx = permissions.findIndex(
     (p) =>
       p.kind === PERMISSION_KIND.PROPOSAL &&
-      p.data.proposalId === permission.data.proposalId,
+      p.data.requestId === permission.data.requestId,
   );
   if (idx < 0) {
     permissions$.set([permission, ...permissions]);
@@ -121,7 +121,7 @@ export const permissionHandlers = {
       const { permission } = data;
       if (permission.kind === PERMISSION_KIND.PROPOSAL) {
         // Drop if this proposal was already resolved (out-of-order messages)
-        if (resolvedProposalIds.delete(permission.data.proposalId)) return;
+        if (resolvedProposalIds.delete(permission.data.requestId)) return;
         upsertProposalPermission({
           kind: PERMISSION_KIND.PROPOSAL,
           data: permission.data,

--- a/src/controllers/progressView/ProgressAgentProposalController.ts
+++ b/src/controllers/progressView/ProgressAgentProposalController.ts
@@ -19,11 +19,11 @@ type AgentProposalActionInput =
   WithoutCommand<ProgressAgentProposalActionMessage>;
 
 export interface ProgressAgentProposalControllerDeps {
-  getPendingProposal(proposalId: string): AgentProposalPermission | undefined;
+  getPendingProposal(requestId: string): AgentProposalPermission | undefined;
   restoreRunConfig(config: AgentConfig): Promise<boolean>;
   openFile(path: string): Promise<void>;
-  settleProposal(proposalId: string, result: ProposalResult): void;
-  onMissingProposal?(proposalId: string): void;
+  settleProposal(requestId: string, result: ProposalResult): void;
+  onMissingProposal?(requestId: string): void;
   onInvalidProposal?(issues: unknown): void;
   onSetupComplete?(proposal: AgentProposalPermission): void;
 }
@@ -34,16 +34,16 @@ export class ProgressAgentProposalController {
   async handleAction(input: AgentProposalActionInput): Promise<boolean> {
     switch (input.action) {
       case 'setup':
-        return this.setupProposal(input.proposalId);
+        return this.setupProposal(input.requestId);
       case 'approve':
-        this.deps.settleProposal(input.proposalId, {
+        this.deps.settleProposal(input.requestId, {
           action: 'approve',
           ...(input.model ? { model: input.model } : {}),
           ...(input.agent ? { agent: input.agent } : {}),
         });
         return true;
       case 'reject':
-        this.deps.settleProposal(input.proposalId, {
+        this.deps.settleProposal(input.requestId, {
           action: 'reject',
           ...(input.feedback ? { feedback: input.feedback } : {}),
         });
@@ -60,10 +60,10 @@ export class ProgressAgentProposalController {
     return this.deps.restoreRunConfig(result.data);
   }
 
-  private async setupProposal(proposalId: string): Promise<boolean> {
-    const proposal = this.deps.getPendingProposal(proposalId);
+  private async setupProposal(requestId: string): Promise<boolean> {
+    const proposal = this.deps.getPendingProposal(requestId);
     if (!proposal) {
-      this.deps.onMissingProposal?.(proposalId);
+      this.deps.onMissingProposal?.(requestId);
       return false;
     }
 
@@ -75,7 +75,7 @@ export class ProgressAgentProposalController {
         );
         await this.deps.openFile(scriptPath.fsPath);
       } catch (error) {
-        this.deps.settleProposal(proposalId, {
+        this.deps.settleProposal(requestId, {
           action: 'reject',
           feedback: `Unable to open the workflow script for setup: ${toErrorMessage(error)}`,
         });
@@ -84,7 +84,7 @@ export class ProgressAgentProposalController {
     } else {
       const restored = await this.restoreProposalConfig(proposal);
       if (!restored) {
-        this.deps.settleProposal(proposalId, {
+        this.deps.settleProposal(requestId, {
           action: 'reject',
           feedback: 'Unable to restore the proposal configuration for setup.',
         });
@@ -92,7 +92,7 @@ export class ProgressAgentProposalController {
       }
     }
 
-    this.deps.settleProposal(proposalId, { action: 'setup' });
+    this.deps.settleProposal(requestId, { action: 'setup' });
     this.deps.onSetupComplete?.(proposal);
     return true;
   }

--- a/src/controllers/progressView/backend/agentProposalTransport.ts
+++ b/src/controllers/progressView/backend/agentProposalTransport.ts
@@ -29,10 +29,10 @@ const log = createLog('agentProposalTransport');
 export function createAgentProposalTransport(options: {
   /** Read lazily: hosts wire this before their backend field is assigned. */
   getRenderer(): LitSessionRenderer;
-  isPending(proposalId: string): boolean;
+  isPending(requestId: string): boolean;
 }): {
   show(proposal: AgentProposalPermission): void;
-  dismiss(proposalId: string): void;
+  dismiss(requestId: string): void;
 } {
   const { getRenderer, isPending } = options;
 
@@ -67,7 +67,7 @@ export function createAgentProposalTransport(options: {
         return undefined;
       }),
     ]);
-    if (!isPending(proposal.proposalId)) return;
+    if (!isPending(proposal.requestId)) return;
     getRenderer().showPermission({
       kind: PERMISSION_KIND.PROPOSAL,
       data: proposal,
@@ -85,8 +85,8 @@ export function createAgentProposalTransport(options: {
       });
       void sendResolvedOptions(proposal);
     },
-    dismiss(proposalId) {
-      getRenderer().resolvePermission(PERMISSION_KIND.PROPOSAL, proposalId);
+    dismiss(requestId) {
+      getRenderer().resolvePermission(PERMISSION_KIND.PROPOSAL, requestId);
     },
   };
 }

--- a/src/controllers/progressView/backend/progressBackendUiConfig.ts
+++ b/src/controllers/progressView/backend/progressBackendUiConfig.ts
@@ -39,12 +39,12 @@ export interface ApprovalRequestHandlerSet {
   retry: ApprovalRequestHandler<RetryPermission, 'streamId', RetryResult>;
   proposal: ApprovalRequestHandler<
     AgentProposalPermission,
-    'proposalId',
+    'requestId',
     ProposalResult
   >;
   planApproval: ApprovalRequestHandler<
     PlanApprovalPermission,
-    'approvalId',
+    'requestId',
     PlanApprovalResult
   >;
   externalInquiry: ApprovalRequestHandler<
@@ -193,9 +193,9 @@ export function buildApprovalRequestHandlerSet(
     >(renderer, canSend, PERMISSION_KIND.BASH, 'requestId'),
     planApproval: webviewPermissionHandler<
       typeof PERMISSION_KIND.PLAN_APPROVAL,
-      'approvalId',
+      'requestId',
       PlanApprovalResult
-    >(renderer, canSend, PERMISSION_KIND.PLAN_APPROVAL, 'approvalId'),
+    >(renderer, canSend, PERMISSION_KIND.PLAN_APPROVAL, 'requestId'),
     externalInquiry: new ExternalInquiryRequestHandler({
       show: (data) =>
         renderer.showPermission({
@@ -222,19 +222,19 @@ export function buildApprovalRequestHandlerSet(
     proposal: overrides.proposal
       ? new ApprovalRequestHandler<
           AgentProposalPermission,
-          'proposalId',
+          'requestId',
           ProposalResult
         >(
-          'proposalId',
+          'requestId',
           overrides.proposal.show,
           overrides.proposal.dismiss,
           canSend,
         )
       : webviewPermissionHandler<
           typeof PERMISSION_KIND.PROPOSAL,
-          'proposalId',
+          'requestId',
           ProposalResult
-        >(renderer, canSend, PERMISSION_KIND.PROPOSAL, 'proposalId'),
+        >(renderer, canSend, PERMISSION_KIND.PROPOSAL, 'requestId'),
   };
 }
 

--- a/src/controllers/progressView/backend/progressHostInteractions.ts
+++ b/src/controllers/progressView/backend/progressHostInteractions.ts
@@ -301,8 +301,7 @@ export function createProgressHostInteractions(
       });
       handlers().proposal.completeWhere(
         (item) =>
-          item.streamId === streamId &&
-          item.proposalId !== initiatingProposalId,
+          item.streamId === streamId && item.requestId !== initiatingProposalId,
         { action: 'approve' },
       );
       await options.getToolEditApprovals().approvePendingForStream(streamId);

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -161,7 +161,7 @@ const BashApprovalActionMessageSchema = z.discriminatedUnion('action', [
 
 const ProposalActionMessageBase = {
   command: z.literal(PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION),
-  proposalId: z.string().min(1),
+  requestId: z.string().min(1),
 };
 const AgentProposalActionMessageSchema = z.discriminatedUnion('action', [
   z.strictObject({
@@ -182,7 +182,7 @@ export type ProgressAgentProposalActionMessage = z.infer<
 
 const PlanActionMessageBase = {
   command: z.literal(PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION),
-  approvalId: z.string().min(1),
+  requestId: z.string().min(1),
 };
 const PlanApprovalActionMessageSchema = z.discriminatedUnion('action', [
   z.strictObject({

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -87,7 +87,7 @@ export const AgentProposalSchema = z.discriminatedUnion('agentCategory', [
 export type AgentProposal = z.infer<typeof AgentProposalSchema>;
 
 const ProposalPermissionBaseSchema = z.object({
-  proposalId: z.string(),
+  requestId: z.string(),
   streamId: StreamTabIdSchema,
 });
 
@@ -215,7 +215,7 @@ export type ToolEditApprovalAction =
   'approve' | 'reject' | 'openDiff' | 'showLatexdiff' | 'previewProposed';
 
 export const PlanApprovalPermissionSchema = z.strictObject({
-  approvalId: z.string(),
+  requestId: z.string(),
   streamId: StreamTabIdSchema,
   plan: PlanSchema,
   /**

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -218,7 +218,7 @@ export function createRecordingHost(options: RecordingHostOptions = {}): {
       pendingPlans.delete(requestId);
       events.push({
         event: 'resolvePlanApproval',
-        payload: { approvalId: requestId },
+        payload: { requestId },
       });
       pending.settle(decision);
       return true;
@@ -229,7 +229,7 @@ export function createRecordingHost(options: RecordingHostOptions = {}): {
       pendingProposals.delete(requestId);
       events.push({
         event: 'resolveAgentProposal',
-        payload: { proposalId: requestId },
+        payload: { requestId },
       });
       pending.settle(decision);
       return true;
@@ -291,7 +291,7 @@ export function createRecordingHost(options: RecordingHostOptions = {}): {
         payload: request,
       });
       return new Promise((resolve) => {
-        pendingPlans.set(request.approvalId, {
+        pendingPlans.set(request.requestId, {
           streamId: request.streamId,
           settle: resolve,
         });
@@ -303,7 +303,7 @@ export function createRecordingHost(options: RecordingHostOptions = {}): {
         payload: request,
       });
       return new Promise((resolve) => {
-        pendingProposals.set(request.proposalId, {
+        pendingProposals.set(request.requestId, {
           streamId: request.streamId,
           settle: resolve,
         });
@@ -352,21 +352,21 @@ export function createRecordingHost(options: RecordingHostOptions = {}): {
       });
       pending.settle({ action: 'reject' });
     }
-    for (const [approvalId, pending] of pendingPlans) {
+    for (const [requestId, pending] of pendingPlans) {
       if (!match('planApproval', pending.streamId)) continue;
-      pendingPlans.delete(approvalId);
+      pendingPlans.delete(requestId);
       events.push({
         event: 'resolvePlanApproval',
-        payload: { approvalId },
+        payload: { requestId },
       });
       pending.settle({ action: 'reject' });
     }
-    for (const [proposalId, pending] of pendingProposals) {
+    for (const [requestId, pending] of pendingProposals) {
       if (!match('proposal', pending.streamId)) continue;
-      pendingProposals.delete(proposalId);
+      pendingProposals.delete(requestId);
       events.push({
         event: 'resolveAgentProposal',
-        payload: { proposalId },
+        payload: { requestId },
       });
       pending.settle({ action: 'reject' });
     }

--- a/src/test-kernel/agent/runtime/RunLifecycleInteractionCancel.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunLifecycleInteractionCancel.vitest.ts
@@ -54,11 +54,11 @@ function lifecycleCase(): {
 
 function requestApproval(
   session: SessionHandle,
-  approvalId: string,
+  requestId: string,
   streamId: StreamTabId,
 ) {
   return session.interactions.requestPlanApproval({
-    approvalId,
+    requestId,
     streamId,
     plan,
     goalEnabled: false,

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -267,7 +267,7 @@ describe('SessionHandle', () => {
 
     try {
       const planA = a.interactions.requestPlanApproval({
-        approvalId: 'approval:a',
+        requestId: 'approval:a',
         streamId,
         plan,
         goalEnabled: false,
@@ -278,7 +278,7 @@ describe('SessionHandle', () => {
         operation: 'Model invocation',
       });
       const planB = b.interactions.requestPlanApproval({
-        approvalId: 'approval:b',
+        requestId: 'approval:b',
         streamId,
         plan,
         goalEnabled: false,

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -84,15 +84,15 @@ function createHandlerSet(events: UiEvent[]): ApprovalRequestHandlerSet {
       'retry',
       'streamId',
     ),
-    proposal: handler<AgentProposalPermission, 'proposalId', ProposalResult>(
+    proposal: handler<AgentProposalPermission, 'requestId', ProposalResult>(
       'proposal',
-      'proposalId',
+      'requestId',
     ),
     planApproval: handler<
       PlanApprovalPermission,
-      'approvalId',
+      'requestId',
       PlanApprovalResult
-    >('planApproval', 'approvalId'),
+    >('planApproval', 'requestId'),
     externalInquiry: handler<ExternalInquiryPermission, 'requestId'>(
       'externalInquiry',
       'requestId',
@@ -180,7 +180,7 @@ function createControllablePlanAdapter(
     requestPlanApproval(request, requestOptions?: HostInteractionOptions) {
       requests.push(request);
       return new Promise((settle) =>
-        pending.set(request.approvalId, {
+        pending.set(request.requestId, {
           request,
           cancellationScope: requestOptions?.cancellationScope,
           settle,
@@ -235,11 +235,11 @@ const criticism = {
 
 function requestPlan(
   session: SessionHandle,
-  approvalId: string,
+  requestId: string,
   stream: StreamTabId = streamId,
 ): Promise<PlanApprovalResult> {
   return session.interactions.requestPlanApproval({
-    approvalId,
+    requestId,
     streamId: stream,
     plan,
     goalEnabled: false,
@@ -248,10 +248,10 @@ function requestPlan(
 
 function requestProposal(
   session: SessionHandle,
-  proposalId: string,
+  requestId: string,
 ): Promise<ProposalResult> {
   return session.interactions.requestAgentProposal({
-    proposalId,
+    requestId,
     streamId,
     ...proposal,
   });

--- a/src/test-kernel/agent/runtime/SessionScope.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionScope.vitest.ts
@@ -128,13 +128,13 @@ describe('approval reset scope', () => {
 
     try {
       const planA = a.interactions.requestPlanApproval({
-        approvalId: 'approval:a',
+        requestId: 'approval:a',
         streamId,
         plan,
         goalEnabled: false,
       });
       const planB = b.interactions.requestPlanApproval({
-        approvalId: 'approval:b',
+        requestId: 'approval:b',
         streamId,
         plan,
         goalEnabled: false,

--- a/src/test-kernel/cli/AgentProposal.vitest.ts
+++ b/src/test-kernel/cli/AgentProposal.vitest.ts
@@ -70,7 +70,7 @@ describe('CLI agent proposal approval layout', () => {
 
   it('budgets a compact multi-agent workflow summary and saved script path', () => {
     const payload = {
-      proposalId: 'proposal-1',
+      requestId: 'proposal-1',
       streamId: 'stream-1',
       agent: 'reviewer',
       agentCategory: AgentCategory.Workflow,

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -1283,7 +1283,7 @@ describe('App approval surface ownership', () => {
     void enqueueApproval({
       kind: 'planApproval',
       payload: {
-        approvalId: 'plan-dashboard-root',
+        requestId: 'plan-dashboard-root',
         streamId: ROOT,
         plan: { objective: 'Verify the dashboard root.' },
         goalEnabled: false,
@@ -1298,7 +1298,7 @@ describe('App approval surface ownership', () => {
         const pending = currentApproval.get()?.payload;
         return (
           pending?.kind === 'planApproval' &&
-          pending.payload.approvalId === 'plan-dashboard-root'
+          pending.payload.requestId === 'plan-dashboard-root'
         );
       });
       await waitFor(() => stdout.output.includes('Approve plan?'));

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.ts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.ts
@@ -102,7 +102,7 @@ function agentProposal(
   overrides: Partial<AgentProposalPermission> = {},
 ): AgentProposalPermission {
   const base = {
-    proposalId: 'proposal-1',
+    requestId: 'proposal-1',
     streamId: 'root@deepseekT#abc',
     agent: 'review',
     model: 'deepseekT',
@@ -811,7 +811,7 @@ describe('buildAgentProposalApprovalContent', () => {
     expect(summary).toContain('Model: deepseekT');
     expect(summary).toContain('Instruction:');
     expect(summary).toContain('  Please verify the proof carefully.');
-    expect(summary).not.toContain('proposalId');
+    expect(summary).not.toContain('requestId');
     expect(summary).not.toContain('streamId');
     expect(summary).not.toContain('{');
     expect(details).toBeUndefined();

--- a/src/test-kernel/cli/ApprovalQueue.vitest.ts
+++ b/src/test-kernel/cli/ApprovalQueue.vitest.ts
@@ -255,7 +255,7 @@ describe('CLI approval queue', () => {
   it('clears every pending kind for a stream via clearApprovalsWhere, leaving other streams alone', async () => {
     const planPayload = {
       kind: 'planApproval',
-      payload: { approvalId: 'approval-1', streamId: 'stream-a' },
+      payload: { requestId: 'approval-1', streamId: 'stream-a' },
     } as ApprovalPayload;
     const staleForStreamA = bashPayload('stream-a');
     const untouched = bashPayload('stream-b');

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
@@ -577,7 +577,7 @@ describe('TUI retry approvals', () => {
   it('enables the complete delegated-task approval mode at the proposal decision site', async () => {
     const { presentationHost, interactions } = tui();
     const result = interactions.requestAgentProposal?.({
-      proposalId: 'proposal-bypass',
+      requestId: 'proposal-bypass',
       streamId: 'proposal-bypass-stream',
       agent: 'critic',
       agentSource: null,
@@ -626,7 +626,7 @@ describe('TUI retry approvals', () => {
     const { interactions } = tui();
     const streamId = 'parallel-approval-stream';
     const proposal = interactions.requestAgentProposal?.({
-      proposalId: 'proposal-current',
+      requestId: 'proposal-current',
       streamId,
       agent: 'critic',
       agentSource: null,
@@ -650,7 +650,7 @@ describe('TUI retry approvals', () => {
     void enqueueApproval({
       kind: 'planApproval',
       payload: {
-        approvalId: 'plan-excluded',
+        requestId: 'plan-excluded',
         streamId,
         goalEnabled: false,
         plan: { objective: 'Keep the approval categories distinct.' },
@@ -699,7 +699,7 @@ describe('TUI retry approvals', () => {
       },
     });
 
-    await waitForApproval('proposal', { proposalId: 'proposal-current' });
+    await waitForApproval('proposal', { requestId: 'proposal-current' });
     currentApproval.get()?.decide({ accepted: true, bypass: 'superYolo' });
 
     await expect(proposal).resolves.toEqual({ action: 'approve' });
@@ -722,7 +722,7 @@ describe('TUI retry approvals', () => {
     const { interactions } = tui();
     const streamId = 'proposal-one-off-stream';
     const result = interactions.requestAgentProposal?.({
-      proposalId: 'proposal-one-off',
+      requestId: 'proposal-one-off',
       streamId,
       agent: 'critic',
       agentSource: null,

--- a/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.ts
+++ b/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.ts
@@ -88,13 +88,13 @@ describe('createTuiHostInteractions', () => {
   it('cancels a queued plan approval for the target stream, leaving other streams untouched', async () => {
     const interactions = tuiInteractions();
     const planResult = interactions.requestPlanApproval?.({
-      approvalId: 'approval-a',
+      requestId: 'approval-a',
       streamId: 'stream-a',
       plan,
       goalEnabled: false,
     });
     const otherStreamResult = interactions.requestPlanApproval?.({
-      approvalId: 'approval-b',
+      requestId: 'approval-b',
       streamId: 'stream-b',
       plan,
       goalEnabled: false,
@@ -119,7 +119,7 @@ describe('createTuiHostInteractions', () => {
   it('settles plan decisions through the shared mapper: goal action kept, silent rejection omits feedback', async () => {
     const interactions = tuiInteractions();
     const goalResult = interactions.requestPlanApproval?.({
-      approvalId: 'approval-goal',
+      requestId: 'approval-goal',
       streamId: 'stream-a',
       plan,
       goalEnabled: true,
@@ -134,7 +134,7 @@ describe('createTuiHostInteractions', () => {
     });
 
     const rejected = interactions.requestPlanApproval?.({
-      approvalId: 'approval-reject',
+      requestId: 'approval-reject',
       streamId: 'stream-a',
       plan,
       goalEnabled: false,
@@ -150,7 +150,7 @@ describe('createTuiHostInteractions', () => {
   it('cancels a queued agent proposal for the target stream', async () => {
     const interactions = tuiInteractions();
     const proposalResult = interactions.requestAgentProposal?.({
-      proposalId: 'proposal-a',
+      requestId: 'proposal-a',
       streamId: 'stream-a',
       ...proposal,
     });
@@ -237,7 +237,7 @@ describe('createTuiHostInteractions', () => {
   it('a retry-kind cancel leaves a queued plan approval on the same stream pending', async () => {
     const interactions = tuiInteractions();
     const planResult = interactions.requestPlanApproval?.({
-      approvalId: 'approval-kind',
+      requestId: 'approval-kind',
       streamId: 'stream-a',
       plan,
       goalEnabled: false,

--- a/src/test-kernel/controllers/ProgressAgentProposalController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressAgentProposalController.vitest.ts
@@ -13,7 +13,7 @@ import { resolveWorkspaceRelativePath } from '@tools/pathResolution';
 
 function createWorkflowProposal(): AgentProposalPermission {
   return {
-    proposalId: 'proposal-1',
+    requestId: 'proposal-1',
     streamId: 'stream-1',
     agentCategory: AgentCategory.Workflow,
     agent: 'proofreader',
@@ -32,9 +32,9 @@ function createController(
   overrides: Partial<ProgressAgentProposalControllerDeps> = {},
 ): {
   controller: ProgressAgentProposalController;
-  resolved: { proposalId: string; result: unknown }[];
+  resolved: { requestId: string; result: unknown }[];
 } {
-  const resolved: { proposalId: string; result: unknown }[] = [];
+  const resolved: { requestId: string; result: unknown }[] = [];
   const controller = new ProgressAgentProposalController({
     getPendingProposal: () => createWorkflowProposal(),
     restoreRunConfig: async () => {
@@ -43,8 +43,8 @@ function createController(
     openFile: async () => {
       throw new Error('open should not run');
     },
-    settleProposal: (proposalId, result) => {
-      resolved.push({ proposalId, result });
+    settleProposal: (requestId, result) => {
+      resolved.push({ requestId, result });
     },
     ...overrides,
   });
@@ -90,13 +90,13 @@ describe('ProgressAgentProposalController', () => {
 
     expect(
       await controller.handleAction({
-        proposalId: proposal.proposalId,
+        requestId: proposal.requestId,
         action: 'setup',
       }),
     ).toBe(true);
     expect(restored).toHaveLength(1);
     expect(resolved).toStrictEqual([
-      { proposalId: 'proposal-1', result: { action: 'setup' } },
+      { requestId: 'proposal-1', result: { action: 'setup' } },
     ]);
     expect(restored[0]).toStrictEqual({
       agentCategory: AgentCategory.Workflow,
@@ -126,7 +126,7 @@ describe('ProgressAgentProposalController', () => {
 
     expect(
       await controller.handleAction({
-        proposalId: proposal.proposalId,
+        requestId: proposal.requestId,
         action: 'setup',
       }),
     ).toBe(true);
@@ -137,7 +137,7 @@ describe('ProgressAgentProposalController', () => {
       ).fsPath,
     ]);
     expect(resolved).toStrictEqual([
-      { proposalId: 'proposal-1', result: { action: 'setup' } },
+      { requestId: 'proposal-1', result: { action: 'setup' } },
     ]);
   });
 
@@ -152,13 +152,13 @@ describe('ProgressAgentProposalController', () => {
 
     expect(
       await controller.handleAction({
-        proposalId: proposal.proposalId,
+        requestId: proposal.requestId,
         action: 'setup',
       }),
     ).toBe(false);
     expect(resolved).toStrictEqual([
       {
-        proposalId: 'proposal-1',
+        requestId: 'proposal-1',
         result: {
           action: 'reject',
           feedback:
@@ -175,14 +175,14 @@ describe('ProgressAgentProposalController', () => {
       settleProposal: () => {
         throw new Error('resolve should not run');
       },
-      onMissingProposal: (proposalId) => {
-        missingProposalId = proposalId;
+      onMissingProposal: (requestId) => {
+        missingProposalId = requestId;
       },
     });
 
     expect(
       await controller.handleAction({
-        proposalId: 'missing-proposal',
+        requestId: 'missing-proposal',
         action: 'setup',
       }),
     ).toBe(false);
@@ -196,13 +196,13 @@ describe('ProgressAgentProposalController', () => {
 
     expect(
       await controller.handleAction({
-        proposalId: 'proposal-1',
+        requestId: 'proposal-1',
         action: 'setup',
       }),
     ).toBe(false);
     expect(resolved).toStrictEqual([
       {
-        proposalId: 'proposal-1',
+        requestId: 'proposal-1',
         result: {
           action: 'reject',
           feedback: 'Unable to restore the proposal configuration for setup.',
@@ -216,7 +216,7 @@ describe('ProgressAgentProposalController', () => {
 
     expect(
       await controller.handleAction({
-        proposalId: 'proposal-approve',
+        requestId: 'proposal-approve',
         action: 'approve',
         model: 'gpt-5.4',
         agent: 'critic',
@@ -224,18 +224,18 @@ describe('ProgressAgentProposalController', () => {
     ).toBe(true);
     expect(
       await controller.handleAction({
-        proposalId: 'proposal-reject',
+        requestId: 'proposal-reject',
         action: 'reject',
         feedback: 'too broad',
       }),
     ).toBe(true);
     expect(resolved).toStrictEqual([
       {
-        proposalId: 'proposal-approve',
+        requestId: 'proposal-approve',
         result: { action: 'approve', model: 'gpt-5.4', agent: 'critic' },
       },
       {
-        proposalId: 'proposal-reject',
+        requestId: 'proposal-reject',
         result: { action: 'reject', feedback: 'too broad' },
       },
     ]);
@@ -245,17 +245,17 @@ describe('ProgressAgentProposalController', () => {
     const { controller, resolved } = createController();
 
     await controller.handleAction({
-      proposalId: 'proposal-approve',
+      requestId: 'proposal-approve',
       action: 'approve',
     });
     await controller.handleAction({
-      proposalId: 'proposal-reject',
+      requestId: 'proposal-reject',
       action: 'reject',
     });
 
     expect(resolved).toStrictEqual([
-      { proposalId: 'proposal-approve', result: { action: 'approve' } },
-      { proposalId: 'proposal-reject', result: { action: 'reject' } },
+      { requestId: 'proposal-approve', result: { action: 'approve' } },
+      { requestId: 'proposal-reject', result: { action: 'reject' } },
     ]);
   });
 });

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -656,7 +656,7 @@ describe('createProgressViewCommandHandlers - approvals', () => {
     expectDispatched(
       {
         command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
-        approvalId: 'plan-1',
+        requestId: 'plan-1',
         action: 'approve_and_goal',
       },
       handlers,
@@ -673,7 +673,7 @@ describe('createProgressViewCommandHandlers - approvals', () => {
     expectDispatched(
       {
         command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-        proposalId: 'proposal-1',
+        requestId: 'proposal-1',
         action: 'approve',
         agent: 'review',
         model: 'deepseek',
@@ -696,7 +696,7 @@ describe('createProgressViewCommandHandlers - approvals', () => {
     });
     expect(actions.approval.handlePlanApprovalAction).toHaveBeenCalledWith({
       command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
-      approvalId: 'plan-1',
+      requestId: 'plan-1',
       action: 'approve_and_goal',
     });
     expect(actions.approval.handleUserQuestionAction).toHaveBeenCalledWith({
@@ -707,7 +707,7 @@ describe('createProgressViewCommandHandlers - approvals', () => {
     });
     expect(actions.approval.handleAgentProposalAction).toHaveBeenCalledWith({
       command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-      proposalId: 'proposal-1',
+      requestId: 'proposal-1',
       action: 'approve',
       agent: 'review',
       model: 'deepseek',
@@ -726,11 +726,11 @@ describe('permission action schemas', () => {
   };
   const proposal = {
     command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-    proposalId: 'proposal-1',
+    requestId: 'proposal-1',
   };
   const plan = {
     command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
-    approvalId: 'plan-1',
+    requestId: 'plan-1',
   };
 
   it.each([

--- a/src/test-kernel/controllers/ProgressViewHost.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewHost.vitest.ts
@@ -84,8 +84,8 @@ function createHostHarness(
       getPendingProposal: () => undefined,
       restoreRunConfig: async () => false,
       openFile: vi.fn(),
-      settleProposal: (proposalId, result) => {
-        settledProposals.push({ proposalId, result });
+      settleProposal: (requestId, result) => {
+        settledProposals.push({ requestId, result });
       },
     },
     commands: {
@@ -163,7 +163,7 @@ describe('ProgressViewHost', () => {
     });
     await host.commandHandlers[PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION]?.({
       command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-      proposalId: 'proposal-1',
+      requestId: 'proposal-1',
       action: 'approve',
     });
 
@@ -177,7 +177,7 @@ describe('ProgressViewHost', () => {
     assert.deepEqual(harness.infoMessages, ['Label "main-thm" not found.']);
     assert.deepEqual(harness.settledProposals, [
       {
-        proposalId: 'proposal-1',
+        requestId: 'proposal-1',
         result: { action: 'approve' },
       },
     ]);

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -154,7 +154,7 @@ type TestableBridge = {
  * interactions, kept structural so tests can post plain fixture objects. */
 type BridgeInteractions = {
   requestPlanApproval?: (request: {
-    approvalId: string;
+    requestId: string;
     streamId: StreamTabId;
     plan: { objective: string };
     goalEnabled: boolean;
@@ -303,7 +303,7 @@ type ProgressMessage = {
     compileFailures: Record<string, unknown>;
   };
   activeState?: unknown;
-  permission?: { data?: { approvalId?: string } };
+  permission?: { data?: { requestId?: string } };
   executionId?: string;
   stdout?: string;
   stderr?: string;
@@ -1206,7 +1206,7 @@ describe('DesktopProgressBridge', () => {
 
     messages.length = 0;
     const result = bridgeInteractions(bridge).requestPlanApproval?.({
-      approvalId: 'plan-host-interaction',
+      requestId: 'plan-host-interaction',
       streamId: 'stream-plan' as StreamTabId,
       plan: { objective: 'Check the desktop host interaction port.' },
       goalEnabled: false,
@@ -1214,7 +1214,7 @@ describe('DesktopProgressBridge', () => {
 
     await waitForShownPermission(messages, {
       kind: PERMISSION_KIND.PLAN_APPROVAL,
-      data: { approvalId: 'plan-host-interaction' },
+      data: { requestId: 'plan-host-interaction' },
     });
 
     const handlePlan = assertSupported(
@@ -1224,7 +1224,7 @@ describe('DesktopProgressBridge', () => {
     );
     await handlePlan({
       command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
-      approvalId: 'plan-host-interaction',
+      requestId: 'plan-host-interaction',
       action: 'approve',
     });
 
@@ -1242,7 +1242,7 @@ describe('DesktopProgressBridge', () => {
 
     messages.length = 0;
     const result = bridgeInteractions(bridge).requestAgentProposal?.({
-      proposalId: 'proposal-host-interaction',
+      requestId: 'proposal-host-interaction',
       streamId: 'stream-proposal',
       agentCategory: AgentCategory.Workflow,
       agent: 'proofreader',
@@ -1258,7 +1258,7 @@ describe('DesktopProgressBridge', () => {
 
     await waitForShownPermission(messages, {
       kind: PERMISSION_KIND.PROPOSAL,
-      data: { proposalId: 'proposal-host-interaction' },
+      data: { requestId: 'proposal-host-interaction' },
     });
 
     const handleProposal = assertSupported(
@@ -1268,7 +1268,7 @@ describe('DesktopProgressBridge', () => {
     );
     await handleProposal({
       command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-      proposalId: 'proposal-host-interaction',
+      requestId: 'proposal-host-interaction',
       action: 'approve',
     });
 
@@ -1766,7 +1766,7 @@ describe('DesktopProgressBridge', () => {
           replayWhenAttached: true,
         });
         void session.interactions.requestPlanApproval?.({
-          approvalId: 'close-during-attachment',
+          requestId: 'close-during-attachment',
           streamId: 'attachment-close-stream' as StreamTabId,
           plan: { objective: 'Close while replaying this approval.' },
           goalEnabled: false,
@@ -2010,7 +2010,7 @@ describe('DesktopProgressBridge', () => {
     activateStream(bridge, 'plan-delete-stream');
 
     const result = bridgeInteractions(bridge).requestPlanApproval?.({
-      approvalId: 'plan-cancel-on-delete',
+      requestId: 'plan-cancel-on-delete',
       streamId: 'plan-delete-stream' as StreamTabId,
       plan: { objective: 'Check cancellation on stream delete.' },
       goalEnabled: false,
@@ -2018,7 +2018,7 @@ describe('DesktopProgressBridge', () => {
 
     await waitForShownPermission(messages, {
       kind: PERMISSION_KIND.PLAN_APPROVAL,
-      data: { approvalId: 'plan-cancel-on-delete' },
+      data: { requestId: 'plan-cancel-on-delete' },
     });
 
     await deleteStreamViaInbound(bridge, 'plan-delete-stream' as StreamTabId);
@@ -2494,7 +2494,7 @@ describe('DesktopProgressBridge', () => {
     // Register the pending proposal the way production does: through the
     // session's typed host interactions, not a host progress event.
     const result = bridgeInteractions(bridge).requestAgentProposal?.({
-      proposalId: 'proposal-1',
+      requestId: 'proposal-1',
       streamId: 'stream-1',
       agentCategory: AgentCategory.Workflow,
       agent: 'proofreader',
@@ -2519,7 +2519,7 @@ describe('DesktopProgressBridge', () => {
     );
     await handleProposal({
       command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-      proposalId: 'proposal-1',
+      requestId: 'proposal-1',
       action: 'setup',
     });
 
@@ -2880,7 +2880,7 @@ describe('DesktopProgressBridge', () => {
       owner.close();
       const pendingApproval =
         owner.processSession.interactions.requestPlanApproval?.({
-          approvalId: 'approval-during-reopen-load',
+          requestId: 'approval-during-reopen-load',
           streamId,
           plan: { objective: 'Wait for canonical state.' },
           goalEnabled: false,
@@ -2942,7 +2942,7 @@ describe('DesktopProgressBridge', () => {
               PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
             ).filter(
               (message) =>
-                message.permission?.data?.approvalId ===
+                message.permission?.data?.requestId ===
                 'approval-during-reopen-load',
             ),
           ).toHaveLength(1);
@@ -3010,7 +3010,7 @@ describe('DesktopProgressBridge', () => {
         const planPromise = bridgeInteractions(
           owner.bridgeA,
         ).requestPlanApproval?.({
-          approvalId: 'plan-rebound',
+          requestId: 'plan-rebound',
           streamId,
           plan: { objective: 'Prove approvals reach the new window.' },
           goalEnabled: false,
@@ -3020,7 +3020,7 @@ describe('DesktopProgressBridge', () => {
         // Its presentation moves to the currently attached window.
         await waitForShownPermission(messagesB, {
           kind: PERMISSION_KIND.PLAN_APPROVAL,
-          data: { approvalId: 'plan-rebound' },
+          data: { requestId: 'plan-rebound' },
         });
         expect(
           progressMessages(messagesA, PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION),
@@ -3193,14 +3193,14 @@ describe('DesktopProgressBridge', () => {
       const { bridgeB } = await owner.reopen(messagesB);
 
       const approval = bridgeInteractions(owner.bridgeA).requestPlanApproval?.({
-        approvalId: 'plan-second-window-close',
+        requestId: 'plan-second-window-close',
         streamId,
         plan: { objective: 'Survive a second window close.' },
         goalEnabled: false,
       });
       expect(approval).toBeDefined();
       await waitForShownPermission(messagesB, {
-        data: { approvalId: 'plan-second-window-close' },
+        data: { requestId: 'plan-second-window-close' },
       });
 
       const staleInteractionsB = bridgeB.hostInteractions;
@@ -3210,7 +3210,7 @@ describe('DesktopProgressBridge', () => {
       try {
         await bridgeC.waitUntilReady();
         await waitForShownPermission(messagesC, {
-          data: { approvalId: 'plan-second-window-close' },
+          data: { requestId: 'plan-second-window-close' },
         });
         let settled = false;
         void approval?.then(() => {
@@ -3247,21 +3247,21 @@ describe('DesktopProgressBridge', () => {
       const pendingBeforeClose = bridgeInteractions(
         owner.bridgeA,
       ).requestPlanApproval?.({
-        approvalId: 'plan-before-close',
+        requestId: 'plan-before-close',
         streamId,
         plan: { objective: 'Preserve the pending approval.' },
         goalEnabled: false,
       });
       expect(pendingBeforeClose).toBeDefined();
       await waitForShownPermission(messagesA, {
-        data: { approvalId: 'plan-before-close' },
+        data: { requestId: 'plan-before-close' },
       });
 
       owner.close();
       const pendingWhileClosed = bridgeInteractions(
         owner.bridgeA,
       ).requestPlanApproval?.({
-        approvalId: 'plan-while-closed',
+        requestId: 'plan-while-closed',
         streamId,
         plan: { objective: 'Buffer the approval until repair.' },
         goalEnabled: false,
@@ -3292,13 +3292,13 @@ describe('DesktopProgressBridge', () => {
           isApprovalBypassedForStream(streamId, bridgeSession(bridgeB)),
         ).toBe(true);
 
-        for (const approvalId of ['plan-before-close', 'plan-while-closed']) {
-          await waitForShownPermission(messagesB, { data: { approvalId } });
+        for (const requestId of ['plan-before-close', 'plan-while-closed']) {
+          await waitForShownPermission(messagesB, { data: { requestId } });
         }
 
-        for (const approvalId of ['plan-before-close', 'plan-while-closed']) {
+        for (const requestId of ['plan-before-close', 'plan-while-closed']) {
           expect(
-            bridgeB.hostInteractions.submitPlanDecision(approvalId, {
+            bridgeB.hostInteractions.submitPlanDecision(requestId, {
               action: 'approve',
             }),
           ).toBe(true);
@@ -3325,14 +3325,14 @@ describe('DesktopProgressBridge', () => {
         const planPromise = bridgeInteractions(
           owner.bridgeA,
         ).requestPlanApproval?.({
-          approvalId: 'plan-rebound-delete',
+          requestId: 'plan-rebound-delete',
           streamId,
           plan: { objective: 'Cancel through the durable owner.' },
           goalEnabled: false,
         });
         expect(planPromise).toBeDefined();
         await waitForShownPermission(messagesB, {
-          data: { approvalId: 'plan-rebound-delete' },
+          data: { requestId: 'plan-rebound-delete' },
         });
 
         await deleteStreamViaInbound(bridgeB, streamId);
@@ -3357,7 +3357,7 @@ describe('DesktopProgressBridge', () => {
       owner.close();
       const pendingApproval =
         owner.processSession.interactions.requestPlanApproval({
-          approvalId: 'plan-requested-while-headless',
+          requestId: 'plan-requested-while-headless',
           streamId,
           plan: { objective: 'Restore the detached approval stream.' },
           goalEnabled: false,
@@ -3374,7 +3374,7 @@ describe('DesktopProgressBridge', () => {
           ).filter(
             (message) =>
               message.action === 'show' &&
-              message.permission?.data?.approvalId ===
+              message.permission?.data?.requestId ===
                 'plan-requested-while-headless',
           );
           expect(approvalShows).toHaveLength(1);
@@ -3523,7 +3523,7 @@ describe('DesktopProgressBridge', () => {
       owner.close();
       const pendingApproval =
         owner.processSession.interactions.requestPlanApproval({
-          approvalId: 'headless-remove-approval',
+          requestId: 'headless-remove-approval',
           streamId: childStreamId,
           plan: { objective: 'This must be released.' },
           goalEnabled: false,

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.ts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.ts
@@ -35,7 +35,7 @@ interface DesktopHostInteractions {
     streamId?: StreamTabId;
   }): Promise<BashSettlement>;
   requestPlanApproval(request: {
-    approvalId: string;
+    requestId: string;
     streamId: StreamTabId;
     goalEnabled: boolean;
     plan: { objective: string };
@@ -148,11 +148,11 @@ describe('createDesktopHostInteractions', () => {
     const { interactions, handlers, toolEditApprovals } =
       await createInteractions();
     const current = interactions.requestAgentProposal({
-      proposalId: 'proposal-current',
+      requestId: 'proposal-current',
       streamId: 'stream-a',
     });
     const parallel = interactions.requestAgentProposal({
-      proposalId: 'proposal-parallel',
+      requestId: 'proposal-parallel',
       streamId: 'stream-a',
     });
     const bash = interactions.requestBashApproval({
@@ -353,7 +353,7 @@ describe('createDesktopHostInteractions', () => {
     const { interactions } = await createInteractions(handlers);
 
     const resultPromise = interactions.requestAgentProposal({
-      proposalId: 'proposal-a',
+      requestId: 'proposal-a',
       streamId: 'stream-a' as StreamTabId,
       agentCategory: 'toolUse',
       agent: 'demo-agent',
@@ -386,7 +386,7 @@ describe('createDesktopHostInteractions', () => {
       streamId: 'stream-a' as StreamTabId,
     });
     const planPromise = interactions.requestPlanApproval({
-      approvalId: 'plan-a',
+      requestId: 'plan-a',
       streamId: 'stream-b' as StreamTabId,
       goalEnabled: false,
       plan: { objective: 'Prove the lemma.' },

--- a/src/test-kernel/desktop/DesktopWindowTitle.vitest.ts
+++ b/src/test-kernel/desktop/DesktopWindowTitle.vitest.ts
@@ -136,7 +136,7 @@ describe('desktop process-session window title', () => {
     const handle = trackRunningAgent(session, 'execution:approval', streamId);
     try {
       const firstApproval = session.interactions.requestPlanApproval({
-        approvalId: 'approval:running',
+        requestId: 'approval:running',
         streamId,
         plan: { objective: 'Check the title.' },
         goalEnabled: false,
@@ -149,7 +149,7 @@ describe('desktop process-session window title', () => {
 
       session.executions.untrack(handle.executionId);
       const secondApproval = session.interactions.requestPlanApproval({
-        approvalId: 'approval:idle',
+        requestId: 'approval:idle',
         streamId,
         plan: { objective: 'Check the idle title.' },
         goalEnabled: false,
@@ -220,7 +220,7 @@ describe('desktop process-session window title', () => {
     const streamId = 'stream:reopen' as StreamTabId;
     try {
       void firstSession.interactions.requestPlanApproval({
-        approvalId: 'approval:reopen',
+        requestId: 'approval:reopen',
         streamId,
         plan: { objective: 'Preserve this request across window detach.' },
         goalEnabled: false,

--- a/src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts
+++ b/src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts
@@ -17,7 +17,7 @@ import {
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
 const proposal = {
-  proposalId: 'proposal-1',
+  requestId: 'proposal-1',
   streamId: 'stream-1',
   agentCategory: AgentCategory.ToolUse,
   agent: 'search',
@@ -71,12 +71,12 @@ describe('ApprovalRequestHandlerSet helpers', () => {
       permission: { kind: PERMISSION_KIND.PROPOSAL, data: proposal },
     });
 
-    expect(handlers.proposal.dismiss(proposal.proposalId)).toBe(true);
+    expect(handlers.proposal.dismiss(proposal.requestId)).toBe(true);
     expect(messages).toContainEqual({
       command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
       action: 'resolve',
       kind: PERMISSION_KIND.PROPOSAL,
-      id: proposal.proposalId,
+      id: proposal.requestId,
     });
   });
 
@@ -93,8 +93,8 @@ describe('ApprovalRequestHandlerSet helpers', () => {
     expect(show).toHaveBeenCalledWith(proposal);
     expect(messages).toEqual([]);
 
-    expect(handlers.proposal.dismiss(proposal.proposalId)).toBe(true);
-    expect(dismiss).toHaveBeenCalledWith(proposal.proposalId);
+    expect(handlers.proposal.dismiss(proposal.requestId)).toBe(true);
+    expect(dismiss).toHaveBeenCalledWith(proposal.requestId);
     expect(messages).toEqual([]);
   });
 

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
@@ -192,9 +192,9 @@ describe('createExtensionHostInteractions', () => {
       session,
     });
 
-    function requestProposal(proposalId: string, instruction: string) {
+    function requestProposal(requestId: string, instruction: string) {
       return interactions.requestAgentProposal?.({
-        proposalId,
+        requestId,
         streamId: STREAM_A,
         agent: 'assistant',
         model: 'gpt-5',
@@ -268,7 +268,7 @@ describe('createExtensionHostInteractions', () => {
     });
 
     const resultPromise = interactions.requestPlanApproval?.({
-      approvalId: 'plan-a',
+      requestId: 'plan-a',
       streamId: STREAM_A,
       goalEnabled: true,
       plan: { objective: 'Prove the compactness lemma.' },
@@ -295,7 +295,7 @@ describe('createExtensionHostInteractions', () => {
       },
     });
     expect(handlers.transport.planApproval.show).toHaveBeenCalledWith({
-      approvalId: 'plan-a',
+      requestId: 'plan-a',
       streamId: 'stream-a',
       goalEnabled: true,
       plan: { objective: 'Prove the compactness lemma.' },
@@ -327,7 +327,7 @@ describe('createExtensionHostInteractions', () => {
     });
 
     const resultPromise = interactions.requestPlanApproval?.({
-      approvalId: 'plan-show-failure',
+      requestId: 'plan-show-failure',
       streamId: STREAM_A,
       goalEnabled: false,
       plan: { objective: 'Fail before becoming pending.' },
@@ -828,7 +828,7 @@ describe('createExtensionHostInteractions', () => {
       operation: 'Model invocation',
     });
     const planPromise = interactions.requestPlanApproval?.({
-      approvalId: 'plan-a',
+      requestId: 'plan-a',
       streamId: STREAM_A,
       goalEnabled: false,
       plan: { objective: 'Survive a retry-scoped cancel.' },

--- a/src/test-kernel/progressView/PermissionActionEventHandlers.vitest.ts
+++ b/src/test-kernel/progressView/PermissionActionEventHandlers.vitest.ts
@@ -60,7 +60,7 @@ const retryData = {
   model: 'claude-sonnet',
 };
 const proposalData = {
-  proposalId: 'proposal-1',
+  requestId: 'proposal-1',
   streamId: 'stream-1',
   agentCategory: AgentCategory.ToolUse,
   agent: 'researcher',
@@ -72,7 +72,7 @@ const proposalData = {
   rootUserInstruction: null,
 };
 const planData = {
-  approvalId: 'plan-1',
+  requestId: 'plan-1',
   streamId: 'stream-1',
   plan: { objective: 'Finish the refactor and verify it.' },
   goalEnabled: true,
@@ -254,7 +254,7 @@ const actionCases: PermissionCase[] = [
     }),
     calls: [
       call(PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION, {
-        proposalId: 'proposal-1',
+        requestId: 'proposal-1',
         action: 'approve',
         model: 'gpt-5',
         agent: 'reviewer',
@@ -274,7 +274,7 @@ const actionCases: PermissionCase[] = [
         initiatingProposalId: 'proposal-1',
       }),
       call(PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION, {
-        proposalId: 'proposal-1',
+        requestId: 'proposal-1',
         action: 'approve',
         model: 'gpt-5',
         agent: 'reviewer',
@@ -291,7 +291,7 @@ const actionCases: PermissionCase[] = [
     detail: detail.proposal(decision),
     calls: [
       call(PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION, {
-        proposalId: 'proposal-1',
+        requestId: 'proposal-1',
         ...decision,
       }),
     ],
@@ -307,7 +307,7 @@ const actionCases: PermissionCase[] = [
     detail: detail.plan(decision),
     calls: [
       call(PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION, {
-        approvalId: 'plan-1',
+        requestId: 'plan-1',
         ...decision,
       }),
     ],

--- a/src/test-kernel/progressView/PermissionDedup.vitest.ts
+++ b/src/test-kernel/progressView/PermissionDedup.vitest.ts
@@ -1,10 +1,10 @@
 /**
  * Regression test for a dedup bug fixed alongside the `permissionId()`
- * helper: the old `UPDATE_PERMISSION` "show" handler hardcoded `'requestId'`
- * as the id field for every permission kind except `RETRY`, so
- * `PLAN_APPROVAL` — whose id field is `approvalId` — never matched an
- * existing entry and duplicate plan-approval prompts were never
- * deduplicated on `replay()`.
+ * helper: the old `UPDATE_PERMISSION` "show" handler read the wrong id field
+ * for `PLAN_APPROVAL` (which then spelled its id `approvalId`), so a replayed
+ * plan-approval prompt never matched an existing entry and duplicates were
+ * never deduplicated on `replay()`. The id spellings have since been unified
+ * onto `requestId`; the replay-dedup behavior is what this pins.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -17,14 +17,14 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import type { StreamTabId } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
-function showPlanApproval(approvalId: string) {
+function showPlanApproval(requestId: string) {
   return {
     command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
     action: 'show' as const,
     permission: {
       kind: PERMISSION_KIND.PLAN_APPROVAL,
       data: {
-        approvalId,
+        requestId,
         streamId: 'stream-1' as StreamTabId,
         plan: { objective: 'Do the thing.' },
         goalEnabled: false,
@@ -33,12 +33,12 @@ function showPlanApproval(approvalId: string) {
   };
 }
 
-describe('permission dedup by kind-specific id field', () => {
+describe('permission dedup by permission id', () => {
   beforeEach(() => {
     resetProgressState();
   });
 
-  it('does not duplicate a PLAN_APPROVAL prompt replayed with the same approvalId', () => {
+  it('does not duplicate a PLAN_APPROVAL prompt replayed with the same requestId', () => {
     const onError = vi.fn();
 
     dispatchMessage(showPlanApproval('approval-1'), onError);
@@ -52,7 +52,7 @@ describe('permission dedup by kind-specific id field', () => {
     expect(permissions$.get()).toHaveLength(1);
   });
 
-  it('still shows a second PLAN_APPROVAL prompt with a different approvalId', () => {
+  it('still shows a second PLAN_APPROVAL prompt with a different requestId', () => {
     const onError = vi.fn();
 
     dispatchMessage(showPlanApproval('approval-1'), onError);

--- a/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
@@ -185,7 +185,7 @@ describe('progressView dispatchMessage (createDispatcher migration)', () => {
       {
         kind: PERMISSION_KIND.PLAN_APPROVAL,
         data: {
-          approvalId: 'approval-1',
+          requestId: 'approval-1',
           streamId: 'stream-1' as StreamTabId,
           plan: { objective: 'Do the thing.' },
           goalEnabled: false,

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
@@ -338,7 +338,7 @@ describe('progress-view onboarding refresh wiring', () => {
       method: 'submitProposalDecision' as const,
       message: {
         command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-        proposalId: 'proposal-a',
+        requestId: 'proposal-a',
         action: 'approve',
         model: 'gemini31p',
         agent: 'critic',
@@ -353,7 +353,7 @@ describe('progress-view onboarding refresh wiring', () => {
       method: 'submitPlanDecision' as const,
       message: {
         command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
-        approvalId: 'plan-a',
+        requestId: 'plan-a',
         action: 'reject',
         feedback: 'state the invariant first',
       },

--- a/src/test-kernel/progressView/ProposalRequestPanel.vitest.ts
+++ b/src/test-kernel/progressView/ProposalRequestPanel.vitest.ts
@@ -34,7 +34,7 @@ function createPermission(): ProposalRequestPanel['permission'] {
   return {
     kind: 'proposal',
     data: {
-      proposalId: 'proposal-1',
+      requestId: 'proposal-1',
       streamId: 'stream-a',
       agentCategory: AgentCategory.Workflow,
       agent: 'writer',

--- a/src/test-kernel/progressView/approvalHandlerSetHarness.ts
+++ b/src/test-kernel/progressView/approvalHandlerSetHarness.ts
@@ -80,14 +80,14 @@ export function createRecordingApprovalHandlers(): RecordingApprovalHandlerSet {
   const retry = handler<RetryPermission, 'streamId', RetryResult>('streamId');
   const proposal = handler<
     AgentProposalPermission,
-    'proposalId',
+    'requestId',
     ProposalResult
-  >('proposalId');
+  >('requestId');
   const planApproval = handler<
     PlanApprovalPermission,
-    'approvalId',
+    'requestId',
     PlanApprovalResult
-  >('approvalId');
+  >('requestId');
   const externalInquiry = handler<ExternalInquiryPermission, 'requestId'>(
     'requestId',
   );

--- a/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
+++ b/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
@@ -93,7 +93,7 @@ function submitPlanDecision(
   decision: PlanApprovalResult,
 ): boolean {
   return decisions.submitPlan(
-    (approval.payload as { approvalId: string }).approvalId,
+    (approval.payload as { requestId: string }).requestId,
     decision,
   );
 }

--- a/src/tools/delegation/proposalFlow.ts
+++ b/src/tools/delegation/proposalFlow.ts
@@ -191,7 +191,7 @@ export async function requestDelegationProposal(
   }
 
   const interaction = currentSession().interactions.requestAgentProposal({
-    proposalId: generateShortId(),
+    requestId: generateShortId(),
     streamId,
     ...proposal,
   });

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -236,13 +236,13 @@ pause/complete only affect autonomous goals; with no goal running they return gu
     streamId: string,
     workPlanState: WorkPlanState,
   ): Promise<ToolResult> {
-    const approvalId = `plan-${generateShortId()}`;
+    const requestId = `plan-${generateShortId()}`;
     const goalEnabled = isGoalEnabled();
 
     logger.info('Requesting approval for plan objective');
 
     const interaction = currentSession().interactions.requestPlanApproval({
-      approvalId,
+      requestId,
       streamId,
       plan,
       goalEnabled,


### PR DESCRIPTION
## Summary

Executes docs/proposals/2026-08-15-shared-contracts-and-retirement.md **§2.2 item 2**: one id field — `requestId` — everywhere at the schema level. `AgentProposalPermission.proposalId` and `PlanApprovalPermission.approvalId` become `requestId` in the canonical `*PermissionSchema`s (`src/shared/schemas/prompts.ts`) and the inbound action-message schemas (`progressView/inbound.ts`), propagated through every consumer: producers (`PlanTool`, `proposalFlow`), the shared `ApprovalRequestHandlerSet` id-field literals, extension/desktop handlers, the webview `{kind,data}` union consumers, and all test pins.

**Atomic-rename ruling:** maintainer ruled GO/aggressive; the doc's "confirm with owner" flag is resolved — payload field names are NOT in the item-6 literal freeze (the freeze names message-type literals). Internal monorepo wire, both ends ship in one bundle: no parse-side compat alias, no dated migration.

## R6 — What was removed / collapsed

- `permissionId()` (webview `permissionState.ts`) collapses from a 7-arm kind switch to a single ternary: retry keys by `streamId` (one pending retry per stream, deliberate), everything else reads `requestId`. Its `assertNever` import goes with it.
- `ApprovalRequestHandlerSet`'s `'proposalId'` / `'approvalId'` id-field type literals unify onto `'requestId'` (`progressBackendUiConfig.ts`, test harness).
- The `Host*Request` runtime aliases (`HostPlanApprovalRequest`, `HostAgentProposalRequest`) alias `prompts.ts` types and inherit the rename with zero edits.
- Net: −13 lines (238+/251−, 44 files, most of it mechanical field-spelling churn in tests).

## R8 — Boundaries checked / non-goals

- **No frozen surface carries the old spellings.** The fields exist only on the live webview/IPC wire; no persisted trace/NDJSON vocabulary, resume data, or state schema includes them (verified: zero hits in `src/agent` trace schemas and persisted-state schemas). No boundary re-projection needed.
- **CLI:** `approvalQueue.ts`/modals settle by queue-item identity, not by id field — zero CLI production edits needed (verified by grep, contrary to the initial site list).
- **`initiatingProposalId`** (ENABLE_SUPER_YOLO_BYPASS inbound field) is a *reference to* a proposal's request id, not one of the three spellings — kept.
- **Disambiguation, not false unification:** the webview proposal content-store key (locally generated lookup id for the log "Setup" button) renamed `proposalId` → `proposalInputId` / `data-proposal-input-id`; it is a different concept from the wire request id.
- Items 1/3/4/5 of §2.2 (alias remaining mirrors, CLI PermissionPayload, ToolEditApprovalResult `{action}`, zombie `ApprovalDecisionSchema`) are out of scope here.
- Remaining grep hits for the old spellings in production + tests: **zero**, except one historical-comment mention in `PermissionDedup.vitest.ts` documenting the retired spelling the regression guarded against.

## Gates

- `npm run typecheck` — clean (exit 0)
- `FORCE_COLOR=0 npx vitest run` over progressView / controllers / agent (incl. runtime + ProgressBridge) / desktop / cli / schemas / shared / webview / frontend suites — 619 files, 8,510 tests passed
- `npm run format:check` — clean
- eslint on all 44 changed files — clean
- `npm run check:dead-code-ratchet` — OK (8 vs 8 baselined)

No new tests (rename is behavior-preserving; existing pins updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)