### PR TITLE
fix(cli): read included-access spend from the server snapshot

### DIFF
--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -241,12 +241,16 @@ async function runOrchestration(context: CliContext): Promise<number> {
     // Load the model registry up front so the launcher can offer a model pick
     // after an agent/team choice. Best-effort: an unavailable registry just
     // launches with the default model instead of blocking the launcher.
-    const [models, statusLines] = await Promise.all([
-      getCliModelAccessList({
-        apiMode,
-      }).catch((): readonly CliModelAccess[] => []),
-      loadCliApiStatus({ apiMode }),
-    ]);
+    const models = await getCliModelAccessList({
+      apiMode,
+    }).catch((): readonly CliModelAccess[] => []);
+    // Sequenced, not parallel: the model list is what fetches /tier-config with
+    // auth (computeModelOptionsData -> canUseServerSideKeys), which commits the
+    // relay spend snapshot the included-usage segment reads. Racing the two
+    // would drop that segment on a cold launch. The status read itself is warm
+    // (auth profile and secrets are already cached above), so it adds no
+    // round-trip of its own.
+    const statusLines = await loadCliApiStatus({ apiMode });
     const allowDefaultModelLaunch = await canLaunchWithDefaultModel(
       launchContext,
       models,

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -1,18 +1,20 @@
+import { getServerSideKeyService } from '@auth/serverKeys';
 import { SubscriptionUsageService } from '@controllers/modelAccess/subscriptionUsage/SubscriptionUsageService';
 import { configuredApiKeyProviders } from '@model/apiProviders';
 import { platform } from '@platform/platform';
 import { CODING_PLAN_SUBSCRIPTIONS } from '@shared/codingPlanSubscriptions';
 import { formatSubscriptionUsageSummary } from '@shared/subscriptionUsagePresentation';
-import type {
-  ApiAccessMode,
-  SubscriptionUsageProvider,
-  SubscriptionUsageSnapshot,
+import {
+  spendingQuotaRemainingPercent,
+  type ApiAccessMode,
+  type SpendingStatus,
+  type SubscriptionUsageProvider,
+  type SubscriptionUsageSnapshot,
 } from '@shared/schemas';
 import { providerDisplayName } from '@shared/constants/providers';
 import { OWN_API_KEYS } from '@shared/copy/modelAccess';
 import { RESEARCHER_ACCESS_AUTH } from '@shared/copy/accountAuth';
 import { RESEARCHER_ACCESS } from '@shared/copy/onboarding';
-import { toErrorMessage } from '@utils/errors/errorMessage';
 import { formatPercent } from '@utils/text/stringUtils';
 
 import { getCliApiMode } from './apiAccessMode';
@@ -26,13 +28,7 @@ import {
   type CliModelAccessStatus,
 } from './modelAccessRoute';
 import { readCliModelAccessStatus } from './modelAccessSelection';
-import { fetchRelayUsageSummary, type RelayUsageSummary } from './relayUsage';
-import {
-  getCliAuthProfile,
-  getCliSessionAccessToken,
-  resolveCliUsageTier,
-  type CliAuthProfile,
-} from './supabaseAuth';
+import { getCliAuthProfile, type CliAuthProfile } from './supabaseAuth';
 
 interface SubscriptionUsageReader {
   getUsage(
@@ -51,9 +47,15 @@ export const AUTH_SIGNED_IN_LINE_PREFIX = 'auth: signed in';
  *  tier, usage). The launcher truncates at this to keep the status line short. */
 export const AUTH_STATUS_SEGMENT_SEPARATOR = ' · ';
 
-export function formatRelayUsageStatus(summary: RelayUsageSummary): string {
-  const used = formatPercent(summary.usagePercent, 1);
-  const remaining = formatPercent(Math.max(0, 100 - summary.usagePercent), 1);
+/**
+ * Render the relay's own spend figure. Both percentages come from the
+ * server-computed `spendingStatus` — the same snapshot the chat status bar and
+ * the Settings quota meter read — so no two surfaces can quote different
+ * numbers for one month's included access.
+ */
+export function formatRelayUsageStatus(status: SpendingStatus): string {
+  const used = formatPercent(status.percentUsed);
+  const remaining = formatPercent(spendingQuotaRemainingPercent(status));
   return `included usage this month: ${used} used, ${remaining} remaining`;
 }
 
@@ -174,26 +176,35 @@ interface LoadCliApiStatusOptions {
   readonly includeActionHint?: boolean;
 }
 
+/**
+ * The included-access usage segment, read from the relay's own spend snapshot.
+ *
+ * `refresh` is for user-invoked status only: it bypasses the tier-config cache
+ * and pays a round-trip. The launcher leaves it off and reads whatever snapshot
+ * this process already holds, so opening the launcher never blocks on a spend
+ * query of its own; a snapshot that has not been fetched yet omits the segment
+ * rather than stalling the launcher. A spend check the server *failed* is never
+ * rendered as clean zero usage — it is reported on the line (TierService also
+ * logs it at `warn`).
+ */
 async function loadIncludedUsageLine(
   profile: CliAuthProfile,
+  options: { readonly refresh?: boolean } = {},
 ): Promise<string | undefined> {
   if (!profile.authenticated || !profile.tier) return undefined;
-  // Usage reads usage_logs via PostgREST with a session token; a relay-scoped
-  // CI token cannot read it, while a session alongside that token can.
-  const canReadUsage =
-    profile.credentialSource !== 'relayToken' ||
-    (await getCliSessionAccessToken()) !== null;
-  if (!canReadUsage) {
-    return 'included usage: run `texra login` to view usage (TEXRA_RELAY_TOKEN on its own cannot read it)';
+  const serverSideKeys = getServerSideKeyService();
+  const status = options.refresh
+    ? await serverSideKeys.refreshSpendingStatus()
+    : serverSideKeys.getSpendingStatus();
+  if (status) return formatRelayUsageStatus(status);
+
+  const failure = serverSideKeys.getSpendingStatusError();
+  if (failure) {
+    return `included usage: ${failure.failureReason ?? 'the server could not check your spend'}`;
   }
-  try {
-    const usageTier = (await resolveCliUsageTier(profile)) ?? 'free';
-    return formatRelayUsageStatus(
-      await fetchRelayUsageSummary({ tier: usageTier }),
-    );
-  } catch (error: unknown) {
-    return `included usage: ${toErrorMessage(error)}`;
-  }
+  return options.refresh
+    ? 'included usage: could not read your usage right now, try again in a moment'
+    : undefined;
 }
 
 /** Compact status lines used by the launcher. */
@@ -259,7 +270,7 @@ export async function loadCliDetailedAccountStatusLines(options: {
   ]);
   const includedUsage =
     access.apiFallback === 'included'
-      ? await loadIncludedUsageLine(profile)
+      ? await loadIncludedUsageLine(profile, { refresh: true })
       : undefined;
   // Detailed /api status is user-invoked, so reopening it is the manual refresh
   // path. Ordinary chat startup and the status bar never call this service.

--- a/src/test-kernel/cli/ApiStatus.vitest.ts
+++ b/src/test-kernel/cli/ApiStatus.vitest.ts
@@ -5,30 +5,19 @@ import {
   formatCliAuthStatusLine,
   formatRelayUsageStatus,
 } from '@cli/runtime/apiStatus';
-import type { RelayUsageSummary } from '@cli/runtime/relayUsage';
+import type { SpendingStatus } from '@shared/schemas';
 
 describe('CLI API status text', () => {
   it('shows relay quota usage as a percentage', () => {
-    const summary: RelayUsageSummary = {
-      periodStart: '2026-05-01T00:00:00.000Z',
-      periodEnd: '2026-06-01T00:00:00.000Z',
-      tier: 'Ultra',
-      limitUsd: 300,
-      costUsd: 42,
-      remainingUsd: 258,
-      usagePercent: 14,
-      streamCount: 3,
-      inputTokens: 1,
-      netInputTokens: 1,
-      outputTokens: 1,
-      cachedTokens: 0,
-      reasoningTokens: 0,
-      modelsUsed: 2,
-      providersUsed: 1,
+    const status: SpendingStatus = {
+      currentSpend: 42,
+      limit: 300,
+      remaining: 258,
+      percentUsed: 14,
     };
 
-    expect(formatRelayUsageStatus(summary)).toBe(
-      'included usage this month: 14.0% used, 86.0% remaining',
+    expect(formatRelayUsageStatus(status)).toBe(
+      'included usage this month: 14% used, 86% remaining',
     );
   });
 

--- a/src/test-kernel/cli/ApiStatusLoad.vitest.ts
+++ b/src/test-kernel/cli/ApiStatusLoad.vitest.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-  fetchRelayUsageSummary: vi.fn(),
+  getSpendingStatus: vi.fn(),
+  refreshSpendingStatus: vi.fn(),
+  getSpendingStatusError: vi.fn(),
   getCliApiMode: vi.fn(),
   getCliAuthProfile: vi.fn(),
-  getCliSessionAccessToken: vi.fn(),
   readCliModelAccessStatus: vi.fn(),
-  resolveCliUsageTier: vi.fn(),
   lookupApiKeyOrigin: vi.fn(),
   getSubscriptionUsage: vi.fn(),
   secrets: {},
@@ -32,12 +32,14 @@ vi.mock('@cli/runtime/apiAccessMode', async (importOriginal) => {
 
 vi.mock('@cli/runtime/supabaseAuth', () => ({
   getCliAuthProfile: mocks.getCliAuthProfile,
-  getCliSessionAccessToken: mocks.getCliSessionAccessToken,
-  resolveCliUsageTier: mocks.resolveCliUsageTier,
 }));
 
-vi.mock('@cli/runtime/relayUsage', () => ({
-  fetchRelayUsageSummary: mocks.fetchRelayUsageSummary,
+vi.mock('@auth/serverKeys', () => ({
+  getServerSideKeyService: () => ({
+    getSpendingStatus: mocks.getSpendingStatus,
+    refreshSpendingStatus: mocks.refreshSpendingStatus,
+    getSpendingStatusError: mocks.getSpendingStatusError,
+  }),
 }));
 
 vi.mock('@cli/runtime/modelAccessSelection', () => ({
@@ -94,6 +96,16 @@ function codingPlans(
   };
 }
 
+/** Server-computed relay spend snapshot, shaped as /tier-config returns it. */
+function spendingStatus(percentUsed: number) {
+  return {
+    currentSpend: percentUsed,
+    limit: 100,
+    remaining: 100 - percentUsed,
+    percentUsed,
+  };
+}
+
 /** Model-access status with the included fallback and every route off. */
 function useIncludedAccessStatus(): void {
   mocks.readCliModelAccessStatus.mockResolvedValue({
@@ -141,15 +153,13 @@ function renderPreferenceRoute(
 
 describe('loadCliApiStatus', () => {
   beforeEach(() => {
-    mocks.fetchRelayUsageSummary.mockReset();
+    mocks.getSpendingStatus.mockReset().mockReturnValue(null);
+    mocks.refreshSpendingStatus.mockReset().mockResolvedValue(null);
+    mocks.getSpendingStatusError.mockReset().mockReturnValue(null);
     mocks.getCliApiMode.mockReset().mockReturnValue('personal');
     mocks.getCliAuthProfile.mockReset().mockResolvedValue({
       authenticated: false,
     });
-    mocks.getCliSessionAccessToken
-      .mockReset()
-      .mockResolvedValue('session-token');
-    mocks.resolveCliUsageTier.mockReset().mockResolvedValue('free');
     mocks.readCliModelAccessStatus.mockReset().mockResolvedValue({
       apiFallback: 'personal',
       preferences: {
@@ -222,13 +232,14 @@ describe('loadCliApiStatus', () => {
       tier: 'Ultra',
       credentialSource: 'session',
     });
-    mocks.resolveCliUsageTier.mockResolvedValue('Ultra');
-    mocks.fetchRelayUsageSummary.mockResolvedValue({ usagePercent: 100.3 });
+    mocks.getSpendingStatus.mockReturnValue(spendingStatus(100));
 
     await expect(loadCliApiStatus({ apiMode: 'included' })).resolves.toEqual([
       'api: included access',
-      'auth: signed in as researcher@example.com · tier: Ultra · included usage this month: 100.3% used, 0% remaining',
+      'auth: signed in as researcher@example.com · tier: Ultra · included usage this month: 100% used, 0% remaining',
     ]);
+    // The launcher reads the cached snapshot; it never pays a refresh.
+    expect(mocks.refreshSpendingStatus).not.toHaveBeenCalled();
   });
 
   it('groups personal keys with their route and omits unused included quota', async () => {
@@ -240,8 +251,7 @@ describe('loadCliApiStatus', () => {
       note: 'Account metadata may be stale.',
     });
     setPersonalKeys('deepseek');
-    mocks.resolveCliUsageTier.mockResolvedValue('Researcher');
-    mocks.fetchRelayUsageSummary.mockResolvedValue({ usagePercent: 25 });
+    mocks.getSpendingStatus.mockReturnValue(spendingStatus(25));
 
     await expect(loadCliApiStatus()).resolves.toEqual([
       'api: your own API keys',
@@ -249,7 +259,7 @@ describe('loadCliApiStatus', () => {
       'auth: signed in as researcher@example.com · tier: Researcher',
       'Account metadata may be stale.',
     ]);
-    expect(mocks.fetchRelayUsageSummary).not.toHaveBeenCalled();
+    expect(mocks.getSpendingStatus).not.toHaveBeenCalled();
   });
 
   it('does not couple compact launcher status to model-access reads', async () => {
@@ -285,8 +295,7 @@ describe('loadCliApiStatus', () => {
       credentialSource: 'session',
     });
     setPersonalKeys('deepseek', 'glm', 'kimiCode');
-    mocks.resolveCliUsageTier.mockResolvedValue('Ultra');
-    mocks.fetchRelayUsageSummary.mockResolvedValue({ usagePercent: 24.5 });
+    mocks.refreshSpendingStatus.mockResolvedValue(spendingStatus(25));
 
     const lines = await accountStatusLines('included');
     const joined = lines.join('\n');
@@ -298,7 +307,7 @@ describe('loadCliApiStatus', () => {
       'Kimi Code: preferred · key configured',
     );
     expect(lineFor(lines, 'Otherwise')).toBe(
-      'Otherwise: Included access · signed in as texra@example.com · Ultra · included usage this month: 24.5% used, 75.5% remaining',
+      'Otherwise: Included access · signed in as texra@example.com · Ultra · included usage this month: 25% used, 75% remaining',
     );
     expect(lineFor(lines, 'Other API keys')).toBe(
       'Other API keys: DeepSeek, GLM',
@@ -539,7 +548,7 @@ describe('loadCliApiStatus', () => {
     const lines = await accountStatusLines('included');
 
     expect(lines).toEqual(['Otherwise: Included access · signed out']);
-    expect(mocks.fetchRelayUsageSummary).not.toHaveBeenCalled();
+    expect(mocks.refreshSpendingStatus).not.toHaveBeenCalled();
   });
 
   it('keeps included-only account, tier, and usage on the fallback route', async () => {
@@ -550,37 +559,16 @@ describe('loadCliApiStatus', () => {
       tier: 'Researcher',
       credentialSource: 'session',
     });
-    mocks.resolveCliUsageTier.mockResolvedValue('Researcher');
-    mocks.fetchRelayUsageSummary.mockResolvedValue({ usagePercent: 10 });
+    mocks.refreshSpendingStatus.mockResolvedValue(spendingStatus(10));
 
     const lines = await accountStatusLines('included');
 
     expect(lines).toEqual([
-      'Otherwise: Included access · signed in as included@example.com · Researcher · included usage this month: 10.0% used, 90.0% remaining',
+      'Otherwise: Included access · signed in as included@example.com · Researcher · included usage this month: 10% used, 90% remaining',
     ]);
   });
 
-  it('owns the CI-token limitation on the included fallback', async () => {
-    useIncludedAccessStatus();
-    mocks.getCliAuthProfile.mockResolvedValue({
-      authenticated: true,
-      accountLabel: 'CI token (TEXRA_RELAY_TOKEN)',
-      tier: 'Researcher',
-      credentialSource: 'relayToken',
-    });
-    mocks.getCliSessionAccessToken.mockResolvedValue(null);
-
-    const lines = await accountStatusLines('included');
-    const fallback = lineFor(lines, 'Otherwise');
-
-    expect(fallback).toContain('CI token (TEXRA_RELAY_TOKEN)');
-    expect(fallback).toContain('Researcher');
-    expect(fallback).toContain('TEXRA_RELAY_TOKEN on its own cannot read it');
-    expect(lines.filter((line) => line.includes('CI token'))).toHaveLength(1);
-    expect(mocks.fetchRelayUsageSummary).not.toHaveBeenCalled();
-  });
-
-  it('owns usage-fetch failures on the included fallback', async () => {
+  it('owns a failed server-side spend check on the included fallback', async () => {
     useIncludedAccessStatus();
     mocks.getCliAuthProfile.mockResolvedValue({
       authenticated: true,
@@ -588,8 +576,10 @@ describe('loadCliApiStatus', () => {
       tier: 'Ultra',
       credentialSource: 'session',
     });
-    mocks.resolveCliUsageTier.mockResolvedValue('Ultra');
-    mocks.fetchRelayUsageSummary.mockRejectedValue(new Error('quota offline'));
+    mocks.getSpendingStatusError.mockReturnValue({
+      spendCheckFailed: true,
+      failureReason: 'quota offline',
+    });
 
     const lines = await accountStatusLines('included');
 


### PR DESCRIPTION
## Summary

The monthly included-access spend figure was computed twice, by two independent
pipelines, and both could be on screen at once at different precisions and
different freshness:

- **Server (authoritative):** `supabase/functions/relay/index.ts:399-409` computes
  `spendingStatus` from `checkSpendingLimit` as an **integer** percent, returns it
  on `/tier-config`, and `TierService` caches it. The chat status bar
  (`StatusBar.tsx` → `getSpendingStatus()`) and the Settings quota meter
  (`RelayQuotaMeter.ts`) already read exactly this.
- **Client (duplicate):** `packages/cli/src/runtime/relayUsage.ts:85-158` paginated
  `/rest/v1/usage_logs` through PostgREST and re-derived the same aggregate at
  **one decimal** (`14.0% used`), rendered by
  `packages/cli/src/runtime/apiStatus.ts:54-58`.

`loadIncludedUsageLine` now reads the server snapshot, so the CLI status line,
the chat status bar, and the Settings meter cannot quote different numbers for
one month's included access.

**Startup latency.** `loadCliApiStatus` is awaited before the launcher can draw
(`packages/cli/src/commands/orchestrate.ts`). Every CLI launch in `included`
mode paid a paginated PostgREST round-trip for a number the in-process
`TierService` snapshot already holds. The launcher path now reads that snapshot
synchronously and issues **no network call of its own**. It is sequenced after
`getCliModelAccessList` rather than raced with it: `computeModelOptionsData` →
`canUseServerSideKeys()` (`src/model/computeModelOptions.ts:489`) is the only
thing that fetches `/tier-config` with auth and commits the snapshot, and the
launcher already gates its first draw on that model list, so the read is warm
and the sequencing costs no round-trip. (The race was caught by the review bot;
see the PR comment for why the alternative fix would have doubled the access
fetch.) The user-invoked `texra api` detail path passes `refresh: true` and
keeps its round-trip, which is the one place a manual refresh is what the user
asked for.

**No silent degradation.** A spend check the *server* failed is reported on the
line from `getSpendingStatusError()` (`included usage: <failureReason>`), never
rendered as a clean 0%. `TierService` already logs the same failure at `warn`
(`TierService.ts:130-137`), so the failure is both logged and surfaced.

**Incidental fix.** The old client pipeline needed a GoTrue session to read
`usage_logs`, so a `TEXRA_RELAY_TOKEN`-only environment got the apology line
"TEXRA_RELAY_TOKEN on its own cannot read it" instead of a number. The relay
authenticates `/tier-config` with that same token
(`SupabaseClient.getRelayAccessToken()`), so CI-token users now see their real
usage. The `resolveCliUsageTier` round-trip that existed only to parameterize
the client query is gone from this path too.

## Issue acceptance gates

No issue; track work. Gates: server `spendingStatus` is the single source for CLI
included-access display; behavior preserved for users not on the included tier
(`mode !== 'included'` never touches spend at all — asserted); launcher gains no
blocking network call of its own.

## Single source of truth

`TierService`'s `spendingStatus` — the relay-computed snapshot reached through
`getServerSideKeyService().getSpendingStatus()` / `.refreshSpendingStatus()` —
now owns the included-access spend figure for every surface. Percent formatting
of the remainder goes through the shared `spendingQuotaRemainingPercent()` in
`src/shared/schemas/spendingStatus.ts`, the same helper the Settings quota meter
and the CLI status bar use.

## Duplication and abstraction budget

Removed: the second spend-aggregate derivation on the CLI status path
(`fetchRelayUsageSummary` call, the session-token capability probe, the
`resolveCliUsageTier` re-resolution, and the local `100 - usagePercent`
arithmetic at a precision no other surface used). No new abstraction, no new
module, no wrapper — the call site now reads an existing accessor.

## Net elements (R6)

- Files: 4 changed, **0 added, 0 deleted**.
- Exported symbols: **0 added, 0 deleted** (`formatRelayUsageStatus` changes its
  parameter type `RelayUsageSummary` → `SpendingStatus`; still one export).
- Classes/interfaces/enums/types: **0 added, 0 deleted**.
- Net LoC: **-6** (98 insertions, 104 deletions).
- Tests: **0 added**; 1 obsolete block deleted (the CI-token limitation case,
  whose limitation no longer exists), 1 renamed and rewritten in place
  (usage-fetch failure → server-side spend-check failure). Per repo test policy
  this is a behavior-preserving re-route, so no new tests.

## Consumer counts (R8)

No emit path or export was deleted; `formatRelayUsageStatus` keeps its name and
its two consumers (`apiStatus.ts` itself, `ApiStatus.vitest.ts`).

**Verified keep — `relayUsage.ts` is NOT deleted.** Grepped every consumer of the
module before touching it:

| Symbol | Consumers after this PR |
| --- | --- |
| `fetchRelayUsageSummary` | 1 production (`packages/cli/src/commands/auth.ts:357`) + 1 suite (`RelayUsage.vitest.ts`) |
| `RelayUsageSummary` | 1 production (`auth.ts:25`) |
| `getCliSessionAccessToken` | 2 production (`auth.ts:347`, `relayTokens.ts:114,139`) |
| `resolveCliUsageTier` | 1 production (`auth.ts:356`) |

`texra auth usage` needs per-log detail the server snapshot provably does not
carry — `streamCount`, the `inputTokens` / `netInputTokens` / `cachedTokens` /
`outputTokens` / `reasoningTokens` breakdown, `modelsUsed` / `providersUsed`, and
an arbitrary `--month` — against `SpendingStatus`'s four fields (`currentSpend`,
`limit`, `remaining`, `percentUsed`, `src/shared/schemas/spendingStatus.ts:9-14`).
Only the **duplicated aggregate** on the status path is deleted; the detail
command keeps its pipeline unchanged.

## Host impact

Extension: none — already read the server snapshot.

Desktop: none — already read the server snapshot.

CLI: launcher status in `included` mode no longer pays a paginated PostgREST
round-trip and shows the same integer percent as the chat status bar; the model
list and the status line are sequenced rather than raced so the snapshot is
populated when read; percent display changes `14.0%` → `14%`; a
`TEXRA_RELAY_TOKEN`-only environment now shows real usage instead of an apology
line; `texra api` (detail) unchanged apart from the same number and precision.
`texra auth usage` untouched.

`packages/cli/src/chat/tui/**` was read for reference only and not modified —
`StatusBar.tsx:215` is the existing precedent this change aligns with.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — pass
- `FORCE_COLOR=0 npx vitest run src/test-kernel/cli/ApiStatus.vitest.ts src/test-kernel/cli/ApiStatusLoad.vitest.ts src/test-kernel/cli/RelayUsage.vitest.ts src/test-kernel/auth/TierService.vitest.ts src/test-kernel/shared/SpendingQuota.vitest.ts` — 5 files, 72 tests, pass
- `FORCE_COLOR=0 npx vitest run src/test-kernel/cli/Orchestration.vitest.ts` — 40 tests, pass
- `FORCE_COLOR=0 npx vitest run src/test-kernel/cli/{SlashCommandDispatch,OnboardingState,ModelAccessForm,AuthCommand}.vitest.ts` — 4 files, 60 tests, pass
- `FORCE_COLOR=0 npx vitest run src/test-kernel/architecture` — 17 files, 101 tests, pass
- `npm run format:check` — pass
- `npx eslint` on the changed files — clean
- `npm run check:dead-code-ratchet` — 8 findings vs 8 baselined, no new orphans

🤖 Generated with [Claude Code](https://claude.com/claude-code)
