### PR TITLE
fix(hosts): report validation failures, hide host-unavailable tool cards

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -35,14 +35,13 @@ import { buildStreamInfo } from '@controllers/session/streamInfoUtils';
 import { ProgressBackend } from '@controllers/progressView/backend/ProgressBackend';
 import { getProgressStreamControls } from '@controllers/progressView/progressStreamControls';
 import { ProgressApiKeyRetryController } from '@controllers/progressView/ProgressApiKeyRetryController';
+import { ProgressFollowUpController } from '@controllers/progressView/ProgressFollowUpController';
+import { ProgressFollowUpPolishController } from '@controllers/progressView/ProgressFollowUpPolishController';
 import {
-  ProgressFollowUpController,
-  type ProgressFollowUpPlan,
-} from '@controllers/progressView/ProgressFollowUpController';
-import {
-  ProgressFollowUpPolishController,
-  type ProgressFollowUpPolishResult,
-} from '@controllers/progressView/ProgressFollowUpPolishController';
+  applyFollowUpPlan,
+  applyFollowUpPolishResult,
+  type FollowUpApplyPorts,
+} from '@controllers/progressView/followUpApply';
 import {
   ProgressWorkflowActionsController,
   type WorkflowDiffRequest,
@@ -557,47 +556,25 @@ export class DesktopProgressBridge {
     await this.options.host.showErrorMessage(message);
   }
 
-  /** Desktop counterpart of the extension's `applyFollowUpPolishResult`. */
-  private async applyFollowUpPolishResult(
-    result: ProgressFollowUpPolishResult,
-  ): Promise<void> {
-    if (result.kind === 'skipped') return;
-    this.postToRenderer(result.update);
-    switch (result.kind) {
-      case 'updated':
-        return;
-      case 'failed':
-        await this.options.host.showErrorMessage(result.userMessage);
-        return;
-      case 'exception':
-        this.logger.error(result.logMessage, {
-          data: result.logData ? toLogData(result.logData) : undefined,
-        });
-        await this.options.host.showErrorMessage(result.userMessage);
-    }
-  }
-
-  /**
-   * Carry out a plan from `ProgressFollowUpController`, the desktop counterpart
-   * of the extension's `applyFollowUpPlan`. As documented on the plan type, the
-   * only `execute` producer is the compile fixer, so those runs opt into the
-   * configured helper model.
-   */
-  private async applyFollowUpPlan(plan: ProgressFollowUpPlan): Promise<void> {
-    switch (plan.kind) {
-      case 'warning':
-        await this.options.host.showWarningMessage(plan.message);
-        return;
-      case 'info':
-        await this.options.host.showInfoMessage(plan.message);
-        return;
-      case 'execute': {
-        await this.runValidatedExecutionRequest(plan.request, {
-          preferHelperModel: true,
-        });
-      }
-    }
-  }
+  /** This host's bindings for the shared follow-up plan/polish interpreters. */
+  private readonly followUpPorts: FollowUpApplyPorts = {
+    showInfo: (message) => this.options.host.showInfoMessage(message),
+    showWarning: (message) => this.options.host.showWarningMessage(message),
+    showError: (message) => this.options.host.showErrorMessage(message),
+    logError: (message, error) => {
+      this.logger.error(message, {
+        data: error ? toLogData(error) : undefined,
+      });
+    },
+    post: (message) => {
+      this.postToRenderer(message);
+    },
+    runCompileFixer: async (request) => {
+      await this.runValidatedExecutionRequest(request, {
+        preferHelperModel: true,
+      });
+    },
+  };
 
   /** Stream-toolbar diff: delegate to the shared round-aware latexdiff core. */
   private async runWorkflowDiff(request: WorkflowDiffRequest): Promise<void> {
@@ -895,8 +872,9 @@ export class DesktopProgressBridge {
           await this.options.host.showErrorMessage('Failed to restore state');
         }
       },
-      applyFollowUpPlan: (plan) => this.applyFollowUpPlan(plan),
-      applyPolishResult: (result) => this.applyFollowUpPolishResult(result),
+      applyFollowUpPlan: (plan) => applyFollowUpPlan(plan, this.followUpPorts),
+      applyPolishResult: (result) =>
+        applyFollowUpPolishResult(result, this.followUpPorts),
       onPolishError: async (stream, error) => {
         const message = toErrorMessage(error);
         this.postToRenderer({

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -816,7 +816,7 @@ function createWindow(options: {
         buildItems: async (cachedResults) => {
           const { buildToolDashboardItems } =
             await import('@controllers/settingsView/ToolDashboardData');
-          return buildToolDashboardItems(cachedResults);
+          return buildToolDashboardItems('desktop', cachedResults);
         },
         getCachedCheckResults: async () => {
           const { getLastCheckResults } =

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -319,9 +319,6 @@ export async function activate(context: vscode.ExtensionContext) {
     runtimeSession.flushArtifacts(),
   );
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => clearStoreCache());
-  lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () =>
-    appSignals.emit('extensionDeactivating', undefined),
-  );
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => disposeDiffRefresh());
   await StorageFS.ensureDir(RUNS_STORAGE_DIR);
   FileLister.initialize(context);

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -10,14 +10,13 @@ import { getServerSideKeyService } from '@auth/serverKeys';
 import { apiKeyCommands } from '@commands/api/apiKeyCommands';
 import { BaseViewMessageHandler } from '@common/webview';
 import { ProgressApiKeyRetryController } from '@controllers/progressView/ProgressApiKeyRetryController';
+import { ProgressFollowUpPolishController } from '@controllers/progressView/ProgressFollowUpPolishController';
+import { ProgressFollowUpController } from '@controllers/progressView/ProgressFollowUpController';
 import {
-  ProgressFollowUpPolishController,
-  type ProgressFollowUpPolishResult,
-} from '@controllers/progressView/ProgressFollowUpPolishController';
-import {
-  ProgressFollowUpController,
-  type ProgressFollowUpPlan,
-} from '@controllers/progressView/ProgressFollowUpController';
+  applyFollowUpPlan,
+  applyFollowUpPolishResult,
+  type FollowUpApplyPorts,
+} from '@controllers/progressView/followUpApply';
 import type { ProgressHostInteractions } from '@controllers/progressView/backend/progressHostInteractions';
 import { ProgressWorkflowActionsController } from '@controllers/progressView/ProgressWorkflowActionsController';
 import { ProgressViewHost } from '@controllers/progressView/ProgressViewHost';
@@ -101,6 +100,25 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
    */
   private readonly showInfo = async (message: string): Promise<void> => {
     await this.host.info(message);
+  };
+
+  /** This host's bindings for the shared follow-up plan/polish interpreters. */
+  private readonly followUpPorts: FollowUpApplyPorts = {
+    showInfo: this.showInfo,
+    showWarning: async (message) => {
+      await this.host.warning(message);
+    },
+    showError: async (message) => {
+      await this.host.error(message);
+    },
+    logError: (message, error) => {
+      this.logger.error(this.channel, message, { data: error });
+    },
+    post: (message) => {
+      this.postToActiveView(message);
+    },
+    runCompileFixer: (request) =>
+      this.executeValidated(request, { preferHelperModel: true }),
   };
 
   constructor(
@@ -190,8 +208,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       restoreRunConfig: async (config) => {
         await this.runViewCommand('texra.restoreState', [config]);
       },
-      applyFollowUpPlan: (plan) => this.applyFollowUpPlan(plan),
-      applyPolishResult: (result) => this.applyFollowUpPolishResult(result),
+      applyFollowUpPlan: (plan) => applyFollowUpPlan(plan, this.followUpPorts),
+      applyPolishResult: (result) =>
+        applyFollowUpPolishResult(result, this.followUpPorts),
       onPolishProgress: (message) => {
         polishProgress?.report({ message });
       },
@@ -838,29 +857,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     });
   }
 
-  private async applyFollowUpPolishResult(
-    result: ProgressFollowUpPolishResult,
-  ): Promise<void> {
-    switch (result.kind) {
-      case 'skipped':
-        return;
-      case 'updated':
-        this.postToActiveView(result.update);
-        return;
-      case 'failed':
-        this.postToActiveView(result.update);
-        await this.host.error(result.userMessage);
-        return;
-      case 'exception':
-        this.postToActiveView(result.update);
-        this.logger.error(this.channel, result.logMessage, {
-          data: result.logData,
-        });
-        await this.host.error(result.userMessage);
-        return;
-    }
-  }
-
   private handlePlanApprovalAction(
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION>,
   ): void {
@@ -878,8 +874,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   // ============================================================
 
   /**
-   * Validate an agent request and run it. Both callers own their own
-   * user-facing failure reporting, so a rejected request is only logged.
+   * Validate an agent request and run it. No caller reports the rejection, so
+   * this owns it: a request dropped here is a run the user asked for and would
+   * otherwise never see start or fail.
    */
   private async executeValidated(
     request: ExecutionRequest,
@@ -888,6 +885,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     const validation = validateExecutionRequest(request);
     if (!validation.valid) {
       this.logger.error(this.channel, validation.message);
+      await this.host.error(validation.message);
       return;
     }
     await this.runViewCommand('texra.execute', [
@@ -905,6 +903,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     const validation = validateExecutionRequest(request);
     if (!validation.valid) {
       this.logger.error(this.channel, validation.message);
+      await this.host.error(validation.message);
       return false;
     }
 
@@ -922,20 +921,5 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         () => resolve(false),
       );
     });
-  }
-
-  private async applyFollowUpPlan(plan: ProgressFollowUpPlan): Promise<void> {
-    switch (plan.kind) {
-      case 'warning':
-        await this.host.warning(plan.message);
-        return;
-      case 'info':
-        await this.host.info(plan.message);
-        return;
-      case 'execute':
-        // Follow-up 'execute' plans are the compile fixer (latexFixer), so run
-        // them on the configured helper model.
-        await this.executeValidated(plan.request, { preferHelperModel: true });
-    }
   }
 }

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -19,7 +19,6 @@ import { replayApprovalRequestHandlers } from '@controllers/progressView/backend
 import { ProgressBackend } from '@controllers/progressView/backend/ProgressBackend';
 import { getProgressStreamControls } from '@controllers/progressView/progressStreamControls';
 
-import { appSignals } from '@eventBus/AppSignals';
 import { VscodeToolEditApprovalHost } from '@frontend/approval/VscodeToolEditApprovalHost';
 import { VscodePromptHost } from '@frontend/hosts/VscodePromptHost';
 import { createAgentPresentationHost } from '@frontend/events/agentEventListeners';
@@ -248,11 +247,6 @@ export class ProgressViewProvider extends BaseWebviewProvider {
 
   public async initialize(): Promise<void> {
     await this.backend.load();
-    this._disposables.add({
-      dispose: appSignals.on('extensionDeactivating', () => {
-        this.backend.markAllRunningTasksAsCancelled();
-      }),
-    });
     this.logger.debug('ProgressViewProvider initialized');
   }
 

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -857,7 +857,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     const cachedResults = options?.skipChecks
       ? (getLastCheckResults() ?? undefined)
       : undefined;
-    const items = await buildToolDashboardItems(cachedResults);
+    const items = await buildToolDashboardItems('extension', cachedResults);
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
       items,

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -33,7 +33,6 @@ import type {
   SetActiveStreamPayload,
   StreamTabId,
 } from '@shared/schemas';
-import { STREAM_PHASE } from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { isInFlightPhase } from '@shared/streams/streamStatus';
 import type { TranscriptPresentationLease } from '@transcript/StreamLogStore';
@@ -399,22 +398,6 @@ export class ProgressBackend {
     const current = this.presentation.activeStream;
     if (current && this.hasPendingPermissions(current)) return;
     void this.activateStream(stream);
-  }
-
-  /**
-   * Cancel every still-running stream because the app itself is going away.
-   * App-lifecycle only (extension deactivating); not a session fact.
-   */
-  markAllRunningTasksAsCancelled(): void {
-    for (const [stream, status] of this.state.streamStatus.entries()) {
-      if (status === STREAM_PHASE.RUNNING) {
-        this.state.streamStatus.transition(
-          stream,
-          STREAM_PHASE.CANCELLED,
-          'restart-repair',
-        );
-      }
-    }
   }
 
   /** Awaitable status application for tests and hosts that cannot fire-and-forget. */

--- a/src/controllers/progressView/followUpApply.ts
+++ b/src/controllers/progressView/followUpApply.ts
@@ -1,0 +1,61 @@
+/**
+ * Host-neutral interpretation of the follow-up plan and polish-result unions.
+ *
+ * The consumer of both unions is already shared
+ * ({@link createProgressViewSecondTierHandlers}); only the switch that turns a
+ * union member into host messaging had escaped into each host, once per host,
+ * with no behavioural difference beyond the verb names of the notification
+ * ports. Hosts now bind {@link FollowUpApplyPorts} and pass it here.
+ */
+
+// Local imports
+import type { ExecutionRequest } from '@agent/core/state/executionRequests';
+import type { ProgressViewOutboundMessage } from '@shared/schemas';
+import type { ProgressFollowUpPlan } from './ProgressFollowUpController';
+import type { ProgressFollowUpPolishResult } from './ProgressFollowUpPolishController';
+
+/** Host messaging ports the two interpreters need. */
+export interface FollowUpApplyPorts {
+  readonly showInfo: (message: string) => Promise<void> | void;
+  readonly showWarning: (message: string) => Promise<void> | void;
+  readonly showError: (message: string) => Promise<void> | void;
+  readonly logError: (message: string, error: Error | undefined) => void;
+  readonly post: (message: ProgressViewOutboundMessage) => void;
+  /**
+   * Run a compile-fixer request. Follow-up `execute` plans are only ever the
+   * compile fixer (latexFixer), so both hosts run them on the configured
+   * helper model.
+   */
+  readonly runCompileFixer: (request: ExecutionRequest) => Promise<void>;
+}
+
+/** Carry out a plan from `ProgressFollowUpController`. */
+export async function applyFollowUpPlan(
+  plan: ProgressFollowUpPlan,
+  ports: FollowUpApplyPorts,
+): Promise<void> {
+  switch (plan.kind) {
+    case 'warning':
+      await ports.showWarning(plan.message);
+      return;
+    case 'info':
+      await ports.showInfo(plan.message);
+      return;
+    case 'execute':
+      await ports.runCompileFixer(plan.request);
+  }
+}
+
+/** Render a result from `ProgressFollowUpPolishController`. */
+export async function applyFollowUpPolishResult(
+  result: ProgressFollowUpPolishResult,
+  ports: FollowUpApplyPorts,
+): Promise<void> {
+  if (result.kind === 'skipped') return;
+  ports.post(result.update);
+  if (result.kind === 'updated') return;
+  if (result.kind === 'exception') {
+    ports.logError(result.logMessage, result.logData);
+  }
+  await ports.showError(result.userMessage);
+}

--- a/src/controllers/settingsView/ToolDashboardData.ts
+++ b/src/controllers/settingsView/ToolDashboardData.ts
@@ -7,9 +7,13 @@
  */
 
 // Local imports
+import type { ToolHost } from '@agent/core/tools/ToolTypes';
 import type { ToolCommandKind, ToolDashboardItem } from '@shared/schemas';
 import { findExternalToolDef } from '@tools/externalToolDefs';
-import type { RegisteredToolName } from '@tools/registry';
+import {
+  isDefaultToolUnavailableOnHost,
+  type RegisteredToolName,
+} from '@tools/registry';
 import {
   runExternalToolChecks,
   type ExternalToolCheckResult,
@@ -56,7 +60,11 @@ export function planToolTerminalAction(input: {
 // Static tool metadata
 // ============================================================
 
-/** Tool groups that are always available (built-in, no external deps). */
+/**
+ * Built-in tool groups with no external dependencies. A group is omitted from
+ * the dashboard when every tool in it declares itself unavailable on the
+ * asking host.
+ */
 const BUILTIN_TOOLS: (Omit<ToolDashboardItem, 'status' | 'tools'> & {
   toolNames: readonly RegisteredToolName[];
 })[] = [
@@ -144,20 +152,25 @@ const BUILTIN_TOOLS: (Omit<ToolDashboardItem, 'status' | 'tools'> & {
 /**
  * Build the complete tool dashboard items list.
  *
+ * @param host - the product host asking. A built-in group whose every tool
+ *   declares itself unavailable on that host is dropped rather than shown as
+ *   "available": the tool would throw its host-exclusion reason if called.
  * @param cachedResults - when provided, skips network probes and uses
  *   these results (including their `statusDetail`). Used by the toggle
  *   handler for instant UI updates.
  */
 export async function buildToolDashboardItems(
+  host: ToolHost,
   cachedResults?: ExternalToolCheckResult[],
 ): Promise<ToolDashboardItem[]> {
-  const builtinItems: ToolDashboardItem[] = BUILTIN_TOOLS.map(
-    ({ toolNames, ...rest }) => ({
-      ...rest,
-      tools: toolNames.map((name) => ({ name })),
-      status: 'available' as const,
-    }),
-  );
+  const builtinItems: ToolDashboardItem[] = BUILTIN_TOOLS.filter(
+    ({ toolNames }) =>
+      !toolNames.every((name) => isDefaultToolUnavailableOnHost(name, host)),
+  ).map(({ toolNames, ...rest }) => ({
+    ...rest,
+    tools: toolNames.map((name) => ({ name })),
+    status: 'available' as const,
+  }));
 
   const results = cachedResults ?? (await runExternalToolChecks());
 

--- a/src/eventBus/AppSignals.ts
+++ b/src/eventBus/AppSignals.ts
@@ -8,9 +8,6 @@ import { EventEmitter } from 'node:events';
  * CLAUDE.md.
  */
 export interface AppSignalPayloads {
-  /** The VS Code extension is shutting down. */
-  extensionDeactivating: undefined;
-
   /**
    * GitHub rejected the configured token. Frontends can surface the failure
    * and direct the user to token settings.


### PR DESCRIPTION
## Summary

Four host-plane fixes batched onto one branch. Two of them are user-visible bug
fixes; the other two delete machinery that only one host ever had.

1. **Delete the `extensionDeactivating` AppSignal** — the declaration
   (`src/eventBus/AppSignals.ts`), its sole emitter (extension shutdown phase),
   its sole consumer (`ProgressViewProvider.initialize`), and
   `ProgressBackend.markAllRunningTasksAsCancelled`, which the deletion
   orphans. **This is not a missing desktop wire.** The signal was a
   hand-rolled pre-run of restart repair, which already sweeps the same
   RUNNING/WAITING phases with kernel-proven liveness *and* finalizes the
   execution record — the signal handler did neither. `ProgressBackend.load()`
   already awaits `waitUntilReady()` host-neutrally, so there was never a
   desktop gap this covered. The orphaned method is deleted, never baselined.

2. **Tool dashboard respects host exclusions** (user-visible bug fix).
   `buildToolDashboardItems` now takes the asking host and drops a built-in
   group when *every* tool in it declares itself unavailable there
   (`isDefaultToolUnavailableOnHost`). Before this, the desktop Tools tab
   showed a green "LaTeX Diagnostics — available" card for a tool whose own
   definition says `desktop: { available: false }` and which throws its
   host-exclusion reason when invoked. Only `latex-diagnostics` is affected
   today, and only on desktop; the extension list is byte-identical.

3. **Host-neutral follow-up interpretation.** The plan / polish-result
   interpretation switch was duplicated per host
   (`ProgressViewMessageHandler` and `desktopAgentExecution`), differing in
   nothing but the verb names of the notification ports. Both hosts already
   register these as callbacks into the same host-neutral deps bag, so only
   the switch had escaped; it now lives beside its consumer in
   `src/controllers/progressView/followUpApply.ts` with each host binding a
   `FollowUpApplyPorts`.

4. **The extension's validation gate is loud** (user-visible bug fix).
   `executeValidated` and `executeValidatedUntilStarted` logged the rejection
   and returned, so a request rejected by `validateExecutionRequest` produced
   *nothing* the user could see — affecting resume and re-run through
   `ProgressViewHost` and the compile-fixer follow-up plan. Both now surface
   the failure through the host's existing error port (`this.host.error`). The
   in-file comment claiming "both callers own their own user-facing failure
   reporting" was false and is deleted. No `validateOrReport` abstraction was
   introduced — this is two added lines and a corrected comment.

## Issue acceptance gates

No issue; batched track work.

## Single source of truth

- Shutdown-time stream repair: restart repair alone (was: restart repair plus a
  partial, extension-only signal handler).
- Follow-up plan / polish-result interpretation:
  `@controllers/progressView/followUpApply` (was: one copy per host).
- Tool availability on a host: the tool definitions' `hosts` block, read
  through `isDefaultToolUnavailableOnHost` (was: the dashboard hardcoding
  `status: 'available'` for every built-in group on every host).

## Duplication and abstraction budget

Removed: two switch statements duplicated across two hosts (4 private methods →
2 shared functions). The one new abstraction, `FollowUpApplyPorts`, owns the
host-boundary decision (which notification verb, which logger, which post
channel) and has 2 binders — it is not a pass-through: the switch bodies moved
into it wholesale.

## Net elements (R6)

Overall: 10 files changed, **+146 / −139 = +7 net LoC**; +1 file; +3 exported
symbols (`FollowUpApplyPorts`, `applyFollowUpPlan`, `applyFollowUpPolishResult`);
−4 private methods; −1 public method; −1 event-bus key; 0 new classes/enums.

Per item:

| Item | Net LoC | Constructs |
| --- | --- | --- |
| 1 — delete `extensionDeactivating` | **−29** | −1 signal key, −1 emitter, −1 subscription, −1 public method (`markAllRunningTasksAsCancelled`), −1 import |
| 2 — host-aware tool dashboard | **+13** | +1 parameter, +1 import, +4 lines of corrected `BUILTIN_TOOLS` comment; correctness fix, presented as one |
| 3 — shared follow-up interpretation | **+20** | +1 file (61 lines incl. 20 lines of doc comment), +3 exports, −4 private methods, −2 duplicated switches |
| 4 — loud validation gate | **+3** | +2 statements, corrected comment |

Item 3 is net-positive LoC, as extract-shared-abstraction changes in this repo
usually are; the win it buys is the removed per-host divergence, not lines.

## Consumer counts (R8)

- `extensionDeactivating`: **1 emitter** (`packages/extension/src/extension.ts`),
  **1 subscriber** (`ProgressViewProvider.initialize`) — both deleted. Grep over
  the tree after the change finds the name only in three dated
  `docs/proposals`/`docs/prds` files, which are historical records and stay.
- `ProgressBackend.markAllRunningTasksAsCancelled`: **1 caller** (the subscriber
  above), **0 test assertions** — deleted, not baselined; the dead-code ratchet
  stays at 8 findings vs 8 baselined.
- `buildToolDashboardItems`: **2 callers**, both updated with a literal host.
- `applyFollowUpPlan` / `applyPolishResult` deps-bag callbacks: **2 registration
  sites** (one per host), both re-pointed at the shared functions.
- `AppSignals` test mocks: `ProgressThemeSync.vitest.ts` and
  `ExtensionWorkspaceTransition.vitest.ts` mock the bus generically for *other*
  signals and were confirmed untouched and still passing.

## Host impact

Extension: validation failures are now reported to the user instead of only
logged (bug fix). The `extensionDeactivating` shutdown hook is gone; restart
repair already covers it. Tool dashboard contents unchanged.

Desktop: the bogus "LaTeX Diagnostics — available" card no longer appears (bug
fix). Follow-up handling now runs the shared interpreters.

CLI: none — no CLI surface touched.

## Scheduled refactoring

None.

## Validation

- `npm run check:dead-code-ratchet` — OK, 8 current vs 8 baselined (no new
  unused files/exports/types; the orphaned method was deleted rather than
  baselined).
- `npm run typecheck` — exit 0 across workspace, test-kernel, agent, cli,
  trace-viewer, desktop.
- `FORCE_COLOR=0 npx vitest run src/test-kernel/{progressView,desktop,settings,controllers,tools}`
  — 289 files, 2454 tests, all passing.
- `FORCE_COLOR=0 npx vitest run src/test-kernel/architecture` — passing.
  (`subsystemEdgeRatchet` hit its 10s per-test timeout once under parallel load
  and passes in 3s when run alone; not a violation.)
- `npm run format:check` — clean.
- `NODE_OPTIONS=--max-old-space-size=8192 npx eslint <10 changed files>` — clean.
- `npm run check:browser-safe-utils` (62 total / 7 reachable) and
  `npm run check:guidance-refs` — both OK.

No new tests, per this track's instruction. Being precise about what that
means: items 1, 3, and 4 run through the existing progressView/desktop/settings
suites (2454 tests, all passing), but item 2's new predicate has **no direct
coverage** — the desktop settings suites mock `dashboard.buildItems`, so the
real `buildToolDashboardItems('desktop', …)` filter is never executed by a
test. A single narrow regression test at that builder boundary would be within
the repo's one-test-per-bug-fix budget if wanted; say the word and I will add
it.

## Review response

- **Stale `BUILTIN_TOOLS` comment** — fixed in this branch. It said the groups
  are "always available", which item 2 makes false; it now states the
  host-omission rule. Same class of defect as item 4's false comment.
- **Item 2 coverage overstated** — corrected in the Validation section above.
- **Group-level predicate is all-or-nothing** — acknowledged as a latent
  limitation, not reachable today: `diagnostics` is the only host-excluded
  built-in tool and it is a singleton group. A future multi-tool group with
  partial host exclusions would list the excluded tools under a green group;
  worth remembering when adding a `hosts` block to a multi-tool group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
