### PR TITLE
refactor(output): one vocabulary for how an artifact reads to a human

### DIFF
--- a/packages/cli/src/chat/tui/panes/WorkflowRunDetails.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkflowRunDetails.tsx
@@ -24,6 +24,8 @@ import {
 import {
   STREAM_PHASE,
   WORKFLOW_TASK_STATUS_LABEL,
+  outputDiffCounts,
+  outputDisplayName,
   roundIndexedEntries,
   type CompileFailure,
   type OutputFileInfo,
@@ -180,19 +182,13 @@ function workflowRunDetailGroups(
         role: 'outputHeading',
       });
       for (const [index, file] of outputs.entries()) {
-        const path =
-          file.location.kind === 'external'
-            ? file.location.absolutePath
-            : file.location.relativePath;
-        const diff =
-          file.diff === null
-            ? ''
-            : ` (+${file.diff.added ?? 0} -${file.diff.removed ?? 0})`;
+        const counts = outputDiffCounts(file.diff);
+        const diff = counts ? ` (+${counts.added} -${counts.removed})` : '';
         lines.push({
           key: `output:${round}:${file.location.absolutePath}:${index}`,
           // Neutral bullet, not `›` — POINTER means "focused row / your
           // input" everywhere else, and these are static file rows.
-          text: `    • ${safeTerminalText(path)}${diff}`,
+          text: `    • ${safeTerminalText(outputDisplayName(file))}${diff}`,
           tone: 'neutral',
           role: 'output',
         });

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -17,9 +17,17 @@ import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import type { CompileFailure, OutputFileInfo } from '@shared/schemas';
-import { getEffectiveDiffBase, roundIndexedEntries } from '@shared/schemas';
+import {
+  fileLocationDisplayPath,
+  getEffectiveDiffBase,
+  outputDiffCounts,
+  outputDisplayName,
+  roundIndexedEntries,
+  type CompileFailure,
+  type OutputFileInfo,
+} from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
+import { formatRoundStageLabel } from '@shared/streams/streamStatusDisplay';
 import { UnsupportedCommandsMixin } from '@shared/wa/unsupportedCommandsMixin';
 import { isKnownUnsupported } from '@shared/utils/dispatcher';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
@@ -233,7 +241,7 @@ export class FileList extends UnsupportedCommandsMixin(LitElement) {
     return html`
       <wa-details
         class="round-collapsible panel-collapsible"
-        summary=${`r${round}`}
+        summary=${formatRoundStageLabel({ index: round })}
         open
       >
         ${rows}
@@ -252,16 +260,8 @@ export class FileList extends UnsupportedCommandsMixin(LitElement) {
     const idPrefix = `file-action-r${round}-f${fileIndex}`;
 
     const location = file.location;
-    // Prefer: workspace original → source doc name → run-storage relative path.
-    // Use the compact variant so an external location (e.g. a run-storage file
-    // outside the workspace root) shows its basename instead of a long absolute
-    // path; the full path stays in the tooltip below.
-    const displayPath =
-      this.getCompactDisplayPath(file.lineage?.original) ||
-      this.getSourceDisplayPath(file.source) ||
-      this.getCompactDisplayPath(location);
-    const { dir, basename } = parsePath(displayPath);
-    const tooltipPath = this.getDisplayPath(location);
+    const { dir, basename } = parsePath(outputDisplayName(file));
+    const tooltipPath = fileLocationDisplayPath(location);
     const effectiveBase =
       getEffectiveDiffBase(file.lineage)?.absolutePath ?? '';
     const diffBase = file.lineage?.diffBase?.absolutePath;
@@ -377,68 +377,16 @@ export class FileList extends UnsupportedCommandsMixin(LitElement) {
     this.dispatchEvent(ProgressEvents.compileFixerRun());
   }
 
-  private getDisplayPath(
-    loc: OutputFileInfo['location'] | null | undefined,
-  ): string {
-    if (!loc) return '';
-    return loc.kind === 'workspace' || loc.kind === 'runStorage'
-      ? loc.relativePath
-      : loc.absolutePath;
-  }
-
-  /**
-   * Like {@link getDisplayPath} but collapses an external location to its
-   * basename so a long absolute path (e.g. a run-storage file resolved as
-   * external because it sits outside the workspace root) doesn't dominate the
-   * row. The full path remains available via the row's tooltip.
-   */
-  private getCompactDisplayPath(
-    loc: OutputFileInfo['location'] | null | undefined,
-  ): string {
-    if (!loc) return '';
-    if (loc.kind === 'workspace' || loc.kind === 'runStorage') {
-      return loc.relativePath;
-    }
-    return parsePath(loc.absolutePath).basename;
-  }
-
-  /**
-   * Derive a display path from the source document name when lineage.original
-   * is absent (e.g. multi-doc extractions whose names don't match a base file).
-   * Returns empty string for generic names that shouldn't override the fallback.
-   */
-  private getSourceDisplayPath(source: string | undefined): string {
-    if (
-      !source ||
-      source === 'output' ||
-      source === 'output.xml' ||
-      source === 'output.tex'
-    )
-      return '';
-    // Treat a trailing all-alpha suffix as a real extension (.tex, .txt, .bib…).
-    // Suffixes containing digits (.v2, .r3) are version qualifiers, not
-    // extensions, so .tex is appended in those cases.
-    const hasExt = /\.[a-zA-Z]+$/.test(source);
-    return hasExt ? source : `${source}.tex`;
-  }
-
   private renderDiffStats(
     file: OutputFileInfo,
   ): TemplateResult | typeof nothing {
-    const diff = file.diff;
-    if (!diff || diff.added === undefined) {
-      return nothing;
-    }
-
-    const removed =
-      diff.removed !== undefined
-        ? html`<span class="removed">-${diff.removed}</span>`
-        : nothing;
+    const counts = outputDiffCounts(file.diff);
+    if (!counts) return nothing;
 
     return html`
       <span class="file-stats">
-        <span class="added">+${diff.added}</span>
-        ${removed}
+        <span class="added">+${counts.added}</span>
+        <span class="removed">-${counts.removed}</span>
       </span>
     `;
   }

--- a/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
+++ b/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
@@ -14,6 +14,7 @@ import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
 import type { DiffResultDisplay, DiffStatus } from '@shared/schemas';
+import { formatRoundStageLabel } from '@shared/streams/streamStatusDisplay';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
@@ -125,8 +126,10 @@ export class LatexdiffResults extends LitElement {
 
     const icon = LATEXDIFF_STATUS_ICONS[status];
     const baseLabel =
-      baseRound === null ? displayName : `${displayName} [r${baseRound}]`;
-    const revisedLabel = `[r${revisedRound}]`;
+      baseRound === null
+        ? displayName
+        : `${displayName} [${formatRoundStageLabel({ index: baseRound })}]`;
+    const revisedLabel = `[${formatRoundStageLabel({ index: revisedRound })}]`;
 
     const entryId = `latexdiff-entry-${index}`;
     return html`

--- a/src/agent/implementations/flows/reflection/output/LatexDiffManager.ts
+++ b/src/agent/implementations/flows/reflection/output/LatexDiffManager.ts
@@ -6,6 +6,7 @@ import { LaTeXdiffResult, LaTeXdiffService } from '@latex/latexdiff';
 import { compileLatex2Pdf } from '@latex/texTools';
 import { platform } from '@platform/platform';
 import {
+  fileLocationDisplayPath,
   type DiffResult,
   type ExecutionId,
   type FileLocation,
@@ -15,10 +16,7 @@ import {
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
-import {
-  createRunStorageLocation,
-  getComparablePath,
-} from '@utils/files/fileLocation';
+import { createRunStorageLocation } from '@utils/files/fileLocation';
 import { TaskRunFileService } from '@utils/files/taskRunStorage';
 import { checkToolInstalled } from '@utils/system/toolUtils';
 import { readPlatformSetting } from '@utils/config/platformSettings';
@@ -145,7 +143,7 @@ export class LatexDiffManager {
       };
 
       const outputByPath = new Map(
-        outputFiles.map((f) => [getComparablePath(f.location), f]),
+        outputFiles.map((f) => [fileLocationDisplayPath(f.location), f]),
       );
 
       this.logger.debug('Base files', {
@@ -279,7 +277,7 @@ export class LatexDiffManager {
     this.logger.debug(`Matched ${description}`, {
       data: pairs.map(
         ([outputPath, loc]) =>
-          `${path.basename(getComparablePath(loc))} -> ${path.basename(outputPath)}`,
+          `${path.basename(fileLocationDisplayPath(loc))} -> ${path.basename(outputPath)}`,
       ),
     });
   }

--- a/src/agent/implementations/flows/reflection/output/OutputFileProcessor.ts
+++ b/src/agent/implementations/flows/reflection/output/OutputFileProcessor.ts
@@ -1,6 +1,9 @@
 import { reportMissingOutputs } from '@agent/runtime/runFactEvents';
-import type { FileLocation } from '@shared/schemas';
-import { OUTPUT_DOCUMENTS_TAG } from '@shared/schemas';
+import {
+  fileLocationDisplayPath,
+  OUTPUT_DOCUMENTS_TAG,
+  type FileLocation,
+} from '@shared/schemas';
 import { normalizeFilePath } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { replaceInputCommands } from './fileMapping';
@@ -85,11 +88,7 @@ export class OutputFileProcessor {
     // a `% main.tex` header) must not map onto several same-named base
     // files in different directories.
     const pathOf = (location: FileLocation): string =>
-      normalizeFilePath(
-        location.kind === 'external'
-          ? location.absolutePath
-          : location.relativePath,
-      );
+      normalizeFilePath(fileLocationDisplayPath(location));
     const basesMatching = (source: string): number =>
       baseFiles.filter((base) => {
         const path = pathOf(base);

--- a/src/agent/implementations/flows/reflection/output/compileCheck.ts
+++ b/src/agent/implementations/flows/reflection/output/compileCheck.ts
@@ -3,12 +3,14 @@ import * as path from 'node:path';
 import type { AgentTrace } from '@agent/trace';
 import { compileLatex2Pdf, type CompileLatex2PdfResult } from '@latex/texTools';
 import { hasLatexCompiler } from '@latex/latexToolchain';
-import type {
-  CompileFailure,
-  CompileResult,
-  ExecutionId,
-  FileLocation,
-  OutputFileInfo,
+import {
+  fileLocationDisplayPath,
+  isGenericOutputStem,
+  type CompileFailure,
+  type CompileResult,
+  type ExecutionId,
+  type FileLocation,
+  type OutputFileInfo,
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { LATEX_CONFIG_RANGES } from '@shared/constants/latexConfig';
@@ -16,7 +18,6 @@ import { parseWorkflowOutputRoundDir } from '@shared/constants/workflowOutput';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import {
   createRunStorageLocation,
-  getComparablePath,
   pathToLocation,
 } from '@utils/files/fileLocation';
 import { type TaskRunFileService } from '@utils/files/taskRunStorage';
@@ -44,10 +45,6 @@ export interface CompileCheckContext {
 const COMPILE_LOG_EXCERPT_CHAR_LIMIT = 12000;
 const MIN_TIMEOUT_MS = LATEX_CONFIG_RANGES.workflowAutoCompileTimeoutMs.min;
 
-// Generic raw-wrapper stems are run-storage internals, not the meaningful
-// document name, so they must never leak into a compile display name.
-const GENERIC_OUTPUT_STEMS = new Set(['output', 'output.xml', 'output.tex']);
-
 export interface CompileCheckResult {
   failures: CompileFailure[];
   artifacts: CompiledPdfArtifact[];
@@ -72,7 +69,7 @@ export function getWorkflowAutoCompileTimeoutMs(): number {
 function getCompileDisplayName(file: OutputFileInfo): string {
   const rawBase = path.basename(file.location.absolutePath);
   const srcBase = file.source ? path.basename(file.source) : '';
-  return srcBase && srcBase !== rawBase && !GENERIC_OUTPUT_STEMS.has(srcBase)
+  return srcBase && srcBase !== rawBase && !isGenericOutputStem(srcBase)
     ? srcBase
     : rawBase;
 }
@@ -180,7 +177,7 @@ export async function runCompileCheck(
       // comparable path (still useful context, even though it isn't a log).
       let fallbackRelativePath: string;
       try {
-        fallbackRelativePath = getComparablePath(outputFile.location);
+        fallbackRelativePath = fileLocationDisplayPath(outputFile.location);
       } catch {
         fallbackRelativePath = outputFile.location.absolutePath;
       }
@@ -264,7 +261,7 @@ async function compileOne(
   // (ch1/main.tex vs ch2/main.tex). Strip the leading r<N>/ segment because
   // it is already added explicitly as `r${currentRound}_` below — without
   // this, a location like `r0/main.tex` would produce `r0_r0_main.tex.log`.
-  const rawComparablePath = getComparablePath(outputFile.location);
+  const rawComparablePath = fileLocationDisplayPath(outputFile.location);
   const comparablePath = rawComparablePath.replaceAll('\\', '/');
   const roundPrefix = `r${currentRound}/`;
   const pathForSafeName = comparablePath.startsWith(roundPrefix)

--- a/src/agent/implementations/flows/reflection/output/compiledPdfArtifacts.ts
+++ b/src/agent/implementations/flows/reflection/output/compiledPdfArtifacts.ts
@@ -4,16 +4,14 @@ import * as path from 'node:path';
 // Local imports
 import { isFileNotFoundError } from '@common/errors';
 import { platform } from '@platform/platform';
-import type {
-  ExecutionId,
-  FileLocation,
-  RunStorageFileLocation,
+import {
+  fileLocationDisplayPath,
+  type ExecutionId,
+  type FileLocation,
+  type RunStorageFileLocation,
 } from '@shared/schemas';
 import { parseWorkflowOutputRoundDir } from '@shared/constants/workflowOutput';
-import {
-  createRunStorageLocation,
-  getComparablePath,
-} from '@utils/files/fileLocation';
+import { createRunStorageLocation } from '@utils/files/fileLocation';
 import { isFile } from '@utils/files/fsEntryType';
 import { hasExtension } from '@utils/core/pathCore';
 
@@ -60,7 +58,10 @@ function toPdfRelativePath(options: PublishCompiledPdfOptions): string {
   const comparablePath =
     options.source.kind === 'external'
       ? path.basename(options.displayName)
-      : stripRoundPrefix(getComparablePath(options.source), options.round);
+      : stripRoundPrefix(
+          fileLocationDisplayPath(options.source),
+          options.round,
+        );
   const parsed = path.parse(comparablePath || options.displayName);
   const stem = parsed.name || path.basename(options.displayName, parsed.ext);
   const pdfStem = `${stem || 'output'}${options.pdfStemSuffix ?? ''}`;

--- a/src/agent/implementations/flows/reflection/output/diffComputation.ts
+++ b/src/agent/implementations/flows/reflection/output/diffComputation.ts
@@ -7,12 +7,14 @@
 
 import { isFileNotFoundError } from '@common/errors';
 import { createLog } from '@logger/logUtils';
-import type { DiffStats, FileLocation, OutputFileInfo } from '@shared/schemas';
-import { AbsoluteFS } from '@utils/files/absoluteFS';
 import {
-  createWorkspaceLocation,
-  getComparablePath,
-} from '@utils/files/fileLocation';
+  fileLocationDisplayPath,
+  type DiffStats,
+  type FileLocation,
+  type OutputFileInfo,
+} from '@shared/schemas';
+import { AbsoluteFS } from '@utils/files/absoluteFS';
+import { createWorkspaceLocation } from '@utils/files/fileLocation';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { diffLineChanges } from '@utils/text/diff';
@@ -109,7 +111,7 @@ export async function computeOutputDiffStats(
   return Promise.all(
     roundOutputs.map(async (output) => {
       const location = output.location;
-      const locationPath = getComparablePath(location);
+      const locationPath = fileLocationDisplayPath(location);
 
       const entry = mapping.get(locationPath);
       const baseLocation = entry?.base ?? null;
@@ -121,7 +123,7 @@ export async function computeOutputDiffStats(
       if (
         !diffBaseLocation &&
         originalLocation &&
-        getComparablePath(originalLocation) !== locationPath
+        fileLocationDisplayPath(originalLocation) !== locationPath
       ) {
         diffBaseLocation = originalLocation;
       }
@@ -133,7 +135,7 @@ export async function computeOutputDiffStats(
       // so the diff stats reflect real changes against the original.
       if (!diffBaseLocation && !originalLocation && baseFiles.length === 1) {
         const candidate = baseFiles[0];
-        if (getComparablePath(candidate) !== locationPath) {
+        if (fileLocationDisplayPath(candidate) !== locationPath) {
           diffBaseLocation = candidate;
         }
       }

--- a/src/agent/implementations/flows/reflection/output/fileMapping.ts
+++ b/src/agent/implementations/flows/reflection/output/fileMapping.ts
@@ -1,11 +1,10 @@
 import * as path from 'node:path';
 
 import type { AgentTrace } from '@agent/trace/AgentTrace';
-import type { FileLocation } from '@shared/schemas';
+import { fileLocationDisplayPath, type FileLocation } from '@shared/schemas';
 import { normalizeLatexPath, getPathSegments } from '@utils/core/pathCore';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
-import { getComparablePath } from '@utils/files/fileLocation';
 
 /**
  * Create a mapping between two file lists based on name similarity.
@@ -35,7 +34,7 @@ export function createFileMapping(
     : (name: string) => name;
 
   for (const target of targetFiles) {
-    const targetPath = getComparablePath(target);
+    const targetPath = fileLocationDisplayPath(target);
     const targetBaseName = path.basename(targetPath);
     const targetName = normalizeName(path.parse(targetBaseName).name);
 
@@ -43,7 +42,7 @@ export function createFileMapping(
     let bestMatchScore = 0;
 
     for (const sourceFile of sourceFiles) {
-      const sourcePath = getComparablePath(sourceFile);
+      const sourcePath = fileLocationDisplayPath(sourceFile);
       const sourceName = normalizeName(
         path.parse(path.basename(sourcePath)).name,
       );
@@ -101,7 +100,7 @@ export async function replaceInputCommands(
     `File mappings for input replacement: ${[...baseToOutputMap.entries()]
       .map(
         ([basePath, outputLoc]) =>
-          `${path.basename(basePath)} -> ${path.basename(getComparablePath(outputLoc))}`,
+          `${path.basename(basePath)} -> ${path.basename(fileLocationDisplayPath(outputLoc))}`,
       )
       .join(', ')}`,
   );
@@ -109,7 +108,7 @@ export async function replaceInputCommands(
   // Build replacement lookup: generates all path suffix variants for flexible matching
   const replacementLookup = new Map<string, string>();
   for (const [baseFile, outputLoc] of baseToOutputMap) {
-    const outputFile = getComparablePath(outputLoc);
+    const outputFile = fileLocationDisplayPath(outputLoc);
     const baseSegments = getPathSegments(baseFile);
     const outputSegments = getPathSegments(outputFile);
     const maxDepth = Math.min(baseSegments.length, outputSegments.length);
@@ -147,7 +146,7 @@ export async function replaceInputCommands(
   }
 
   for (const outputLocation of outputFiles) {
-    const outputPath = getComparablePath(outputLocation);
+    const outputPath = fileLocationDisplayPath(outputLocation);
 
     try {
       const content = await AbsoluteFS.read(outputLocation.absolutePath);

--- a/src/agent/implementations/flows/reflection/output/lineageMapping.ts
+++ b/src/agent/implementations/flows/reflection/output/lineageMapping.ts
@@ -7,9 +7,8 @@
 
 import * as path from 'node:path';
 
-import type { FileLocation } from '@shared/schemas';
+import { fileLocationDisplayPath, type FileLocation } from '@shared/schemas';
 import { normalizeFilePath } from '@utils/core';
-import { getComparablePath } from '@utils/files/fileLocation';
 import { createFileMapping } from './fileMapping';
 
 import type { OutputState } from './outputState';
@@ -45,13 +44,13 @@ function invertMapping(
 ): Map<string, FileLocation> {
   const result = new Map<string, FileLocation>();
   const sourceByPath = new Map(
-    sourceLocations.map((f) => [getComparablePath(f), f]),
+    sourceLocations.map((f) => [fileLocationDisplayPath(f), f]),
   );
 
   for (const [sourcePath, targetLoc] of forwardMapping) {
     const sourceLoc = sourceByPath.get(sourcePath);
     if (sourceLoc) {
-      result.set(getComparablePath(targetLoc), sourceLoc);
+      result.set(fileLocationDisplayPath(targetLoc), sourceLoc);
     }
   }
 
@@ -99,7 +98,7 @@ export function traceFileLineage(
 
   const baseEntries: BaseEntry[] = baseFiles.map((loc) => ({
     loc,
-    ...computePathKeys(getComparablePath(loc)),
+    ...computePathKeys(fileLocationDisplayPath(loc)),
   }));
   const currentLocations = currentOutputs.map((entry) => entry.location);
 
@@ -122,7 +121,7 @@ export function traceFileLineage(
 
   const mapping = new Map<string, RoundFileEntry>();
   for (const entry of currentOutputs) {
-    const key = getComparablePath(entry.location);
+    const key = fileLocationDisplayPath(entry.location);
     const origin = findMatchingBaseFile(baseEntries, entry.source);
     mapping.set(key, {
       base: origin ?? baseToOutput.get(key),

--- a/src/agent/implementations/flows/reflection/output/outputState.ts
+++ b/src/agent/implementations/flows/reflection/output/outputState.ts
@@ -16,6 +16,7 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { AgentWorkflowSetting } from '@agent/core/definition/AgentDataclass';
 import type { RunScope } from '@agent/runtime/RunScope';
 import {
+  fileLocationDisplayPath,
   type CompileFailure,
   type FileLocation,
   type OutputFileInfo,
@@ -23,7 +24,7 @@ import {
   type RoundOutput,
   type StorageKey,
 } from '@shared/schemas';
-import { getComparablePath, pathToLocation } from '@utils/files/fileLocation';
+import { pathToLocation } from '@utils/files/fileLocation';
 import { TaskRunFileService } from '@utils/files/taskRunStorage';
 
 export interface OutputState {
@@ -157,7 +158,7 @@ function collectRunSupportFiles(agentConfig: AgentConfig): FileLocation[] {
   for (const value of allPaths) {
     if (!value) continue;
     const location = pathToLocation(value);
-    extras.set(getComparablePath(location), location);
+    extras.set(fileLocationDisplayPath(location), location);
   }
 
   return [...extras.values()];

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -43,15 +43,15 @@ import {
   takeTail,
 } from '@common/errors/sdkError/errorPatterns';
 import { composeLongRunningModelDispatcher } from '@platform/defaults/longRunningModelTransport';
-import type {
-  FileLocation,
-  MediaAttachmentKind,
-  ToolDefinition,
-  ToolFileAttachment,
-  ToolResult,
+import {
+  fileLocationShortDisplayPath,
+  type FileLocation,
+  type MediaAttachmentKind,
+  type ToolDefinition,
+  type ToolFileAttachment,
+  type ToolResult,
 } from '@shared/schemas';
 import { filterNotNull, generateShortId, isNonEmptyString } from '@utils/core';
-import { getShortDisplayPath } from '@utils/files/fileLocation';
 import { joinNonEmpty, pluralize } from '@utils/text/stringUtils';
 import { getConfig } from '@utils/config/configUtils';
 
@@ -740,7 +740,9 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       return [];
     }
 
-    const label = mediaFiles.map((loc) => getShortDisplayPath(loc)).join(', ');
+    const label = mediaFiles
+      .map((loc) => fileLocationShortDisplayPath(loc))
+      .join(', ');
     const verb = context === 'initial' ? 'Attached' : 'Processing';
     return [
       this.textMedia(

--- a/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
+++ b/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
@@ -8,12 +8,15 @@ import pMap from 'p-map';
 import { logFilesLoaded, type AgentTrace } from '@agent/trace';
 import type { MediaEntry } from '@agent/types/mediaTypes';
 import { getSdkErrorMessage } from '@common/errors/sdkError/providerErrorFormat';
-import type { FileLocation, LoadedMediaMetadata } from '@shared/schemas';
+import {
+  fileLocationDisplayPath,
+  type FileLocation,
+  type LoadedMediaMetadata,
+} from '@shared/schemas';
 
 // Local imports - utils
 import { ensureArray } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
-import { getComparablePath } from '@utils/files/fileLocation';
 import { getMimeType } from '@utils/files/mimeUtils';
 import { getExtensionLowercase } from '@utils/core/pathCore';
 import {
@@ -179,7 +182,7 @@ export class MediaAttachmentProcessor {
 
     for (const loadResult of loadResults) {
       if (!loadResult.ok) {
-        const displayPath = getComparablePath(loadResult.location);
+        const displayPath = fileLocationDisplayPath(loadResult.location);
         this.logger.error(
           `Failed to load media entry for ${displayPath}: ${getSdkErrorMessage(loadResult.reason)}`,
           {
@@ -217,7 +220,7 @@ export class MediaAttachmentProcessor {
     const absolutePath = location.absolutePath;
     // Workspace/run-storage paths remain concise and relative; external media
     // keeps its absolute path so a terminal row identifies the actual file.
-    const displayPath = getComparablePath(location);
+    const displayPath = fileLocationDisplayPath(location);
     const fileExistsResult = await AbsoluteFS.exists(absolutePath);
 
     if (!fileExistsResult) {

--- a/src/controllers/progressView/ProgressFollowUpController.ts
+++ b/src/controllers/progressView/ProgressFollowUpController.ts
@@ -3,15 +3,15 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { ExecutionRequest } from '@agent/core/state/executionRequests';
 import { detectGeneratedLatexdiffArtifact } from '@latex/latexdiff/diffFileNameManager';
 import { decideRunModel } from '@model/runModelDecision';
-import type {
-  CompileFailure,
-  FileLocation,
-  OutputFileInfo,
-  RoundIndexed,
-  StreamTabId,
+import {
+  AgentCategory,
+  fileLocationAddressPath,
+  type CompileFailure,
+  type OutputFileInfo,
+  type RoundIndexed,
+  type StreamTabId,
 } from '@shared/schemas';
-import { AgentCategory } from '@shared/schemas';
-import { runStorageFilePath } from '@shared/copy/workflowRunContext';
+import { formatRoundStageLabel } from '@shared/streams/streamStatusDisplay';
 import type { RunMetadata } from '@transcript/StreamSnapshotStore';
 import { pluralize } from '@utils/text/stringUtils';
 
@@ -198,16 +198,15 @@ export class ProgressFollowUpController {
     const editableFiles = targets.map((target) => target.path);
     const editableHint = `Editable workspace ${pluralize(editableFiles.length, 'target')}: ${editableFiles.join(', ')}`;
     const latexdiffContext = this.formatLatexdiffTargetContext(targets);
-    const failureLines = compileFailures.map((failure) => {
-      const outputPath = this.formatCompileFailureOutputPath(
-        failure.output,
-        executionId,
-      );
-      const logPath = executionId
-        ? runStorageFilePath(executionId, failure.logRelativePath)
-        : failure.log.absolutePath;
-      return `- r${failure.round} ${failure.displayName}: output ${outputPath}; compile log ${logPath}`;
-    });
+    // Both halves of the line address the artifact through the execution that
+    // owns it, which a run-storage location carries. The run asking about the
+    // failure is a second, potentially disagreeing source for the same fact --
+    // and when it disagrees (a failure recorded by an earlier execution of the
+    // stream), it is the wrong one.
+    const failureLines = compileFailures.map(
+      (failure) =>
+        `- ${formatRoundStageLabel({ index: failure.round })} ${failure.displayName}: output ${fileLocationAddressPath(failure.output)}; compile log ${fileLocationAddressPath(failure.log)}`,
+    );
 
     return [
       'The workflow compile check failed. Diagnose and fix the generated LaTeX output using the compile log context below.',
@@ -353,18 +352,5 @@ export class ProgressFollowUpController {
     const originalInputRecovery = originalConfig.inputFiles.filter(Boolean);
 
     return [...generatedOutputSources, ...originalInputRecovery];
-  }
-
-  private formatCompileFailureOutputPath(
-    output: FileLocation,
-    executionId: string | undefined,
-  ): string {
-    if (executionId && output.kind === 'runStorage') {
-      return runStorageFilePath(executionId, output.relativePath);
-    }
-    if (output.kind === 'external') {
-      return output.absolutePath;
-    }
-    return output.relativePath;
   }
 }

--- a/src/shared/copy/workflowRunContext.ts
+++ b/src/shared/copy/workflowRunContext.ts
@@ -1,43 +1,14 @@
 import {
+  fileLocationAddressPath,
   roundIndexedEntries,
   runIdentityDisplayName,
   type CompileFailure,
-  type FileLocation,
   type OutputFileInfo,
   type RoundIndexed,
   type StreamTabInfo,
 } from '@shared/schemas';
+import { formatRoundStageLabel } from '@shared/streams/streamStatusDisplay';
 import { filterNotNullish } from '@utils/core';
-
-/**
- * Reference to a run-storage file the way an agent prompt addresses it:
- * `/executions/<executionId>/files/<relativePath>`. The one definition of that
- * convention — the compile-fixer prompt builder and the progress view's
- * copy-run-context button both address run storage through it.
- */
-export function runStorageFilePath(
-  executionId: string,
-  relativePath: string,
-): string {
-  return `/executions/${executionId}/files/${relativePath}`;
-}
-
-/**
- * How a location reads in copied text. A run-storage location carries the
- * execution that owns it, so the path resolves without the caller supplying
- * one; workspace paths stay relative because that is how the user (and an
- * agent's file tools) refer to them.
- */
-function locationPath(location: FileLocation): string {
-  switch (location.kind) {
-    case 'runStorage':
-      return runStorageFilePath(location.executionId, location.relativePath);
-    case 'workspace':
-      return location.relativePath;
-    case 'external':
-      return location.absolutePath;
-  }
-}
 
 export interface WorkflowRunContextInput {
   stream: StreamTabInfo;
@@ -80,7 +51,9 @@ export function formatWorkflowRunContext(
     for (const [round, files] of outputs) {
       for (const file of files) {
         const source = file.source ? ` (source: ${file.source})` : '';
-        lines.push(`- r${round}: ${locationPath(file.location)}${source}`);
+        lines.push(
+          `- ${formatRoundStageLabel({ index: round })}: ${fileLocationAddressPath(file.location)}${source}`,
+        );
       }
     }
   }
@@ -90,7 +63,7 @@ export function formatWorkflowRunContext(
     for (const [round, rows] of failures) {
       for (const failure of rows) {
         lines.push(
-          `- r${round} ${failure.displayName}: log ${locationPath(failure.log)}`,
+          `- ${formatRoundStageLabel({ index: round })} ${failure.displayName}: log ${fileLocationAddressPath(failure.log)}`,
         );
       }
     }

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod';
 
-import { DiffStatsSchema, LineCountSchema } from './lineChanges';
+import { getBasename } from '@utils/core';
+import {
+  DiffStatsSchema,
+  LineCountSchema,
+  type DiffStats,
+} from './lineChanges';
 import { ExecutionIdSchema } from './identifiers';
 import { RoundNumberSchema } from './roundIndexed';
 
@@ -42,6 +47,75 @@ export type RunStorageFileLocation = z.infer<
 export type ExternalFileLocation = z.infer<typeof ExternalFileLocationSchema>;
 export type FileLocation = z.infer<typeof FileLocationSchema>;
 export type AgentFileLocation = z.infer<typeof AgentFileLocationSchema>;
+
+// ============================================================================
+// How a file location reads to a human
+// ============================================================================
+//
+// One vocabulary for turning a `FileLocation` into text, shared by the agent
+// core, both webview hosts and the CLI TUI. It lives beside the schema rather
+// than in `@utils/files` because the webviews cannot reach a module that
+// imports `node:path`, and a browser-unreachable definition is exactly how
+// this rule came to be re-derived in every renderer.
+
+/**
+ * How a location reads as a path: workspace and run-storage files by their
+ * relative path — that is how the user and the agent's file tools refer to
+ * them — and external files by their absolute path, the only path they have.
+ *
+ * This doubles as a location's comparable identity: two locations naming the
+ * same file agree here, so output-to-base maps key on it.
+ */
+export function fileLocationDisplayPath(location: FileLocation): string {
+  return location.kind === 'external'
+    ? location.absolutePath
+    : location.relativePath;
+}
+
+/**
+ * Like {@link fileLocationDisplayPath} but collapses an external location to
+ * its basename, so a long absolute path (e.g. a run-storage file resolved as
+ * external because it sits outside the workspace root) cannot dominate a UI
+ * row or a prompt line. The full path stays on `absolutePath`.
+ */
+export function fileLocationShortDisplayPath(location: FileLocation): string {
+  return location.kind === 'external'
+    ? getBasename(location.absolutePath)
+    : location.relativePath;
+}
+
+/**
+ * Reference to a run-storage file the way an agent prompt addresses it:
+ * `/executions/<executionId>/files/<relativePath>`. The one definition of that
+ * convention.
+ */
+export function runStorageFilePath(
+  executionId: string,
+  relativePath: string,
+): string {
+  return `/executions/${executionId}/files/${relativePath}`;
+}
+
+/**
+ * How a location is addressed in text that leaves the UI — copied run context,
+ * follow-up prompts, subagent results. A run-storage location carries the
+ * execution that owns it, so its `/executions/...` route resolves without the
+ * caller supplying one; every other kind reads as its display path.
+ */
+export function fileLocationAddressPath(location: FileLocation): string {
+  return location.kind === 'runStorage'
+    ? runStorageFilePath(location.executionId, location.relativePath)
+    : fileLocationDisplayPath(location);
+}
+
+// Generic raw-wrapper stems are run-storage internals, not the meaningful
+// document name, so they must never surface as an artifact's name.
+const GENERIC_OUTPUT_STEMS = new Set(['output', 'output.xml', 'output.tex']);
+
+/** Whether a document name is a generic raw-wrapper stem rather than a name. */
+export function isGenericOutputStem(name: string): boolean {
+  return GENERIC_OUTPUT_STEMS.has(name);
+}
 
 /** Run identity used when accepting an edited file as a postfixed copy. */
 export const AcceptCopyMetaSchema = z.strictObject({
@@ -111,6 +185,43 @@ export type OutputFileSummary = z.infer<typeof OutputFileSummarySchema>;
 export type CompileFailure = z.infer<typeof CompileFailureSchema>;
 
 /**
+ * The name an output artifact reads by. The workspace document it descends
+ * from wins, because that is the file the user recognizes; failing that the
+ * document name the model emitted, unless it is a generic raw-wrapper stem;
+ * and only then the artifact's own path, which carries run-storage internals
+ * such as the `r<round>/` prefix.
+ */
+export function outputDisplayName(file: OutputFileInfo): string {
+  const original = file.lineage?.original;
+  if (original) return fileLocationShortDisplayPath(original);
+
+  const { source } = file;
+  if (source && !isGenericOutputStem(source)) {
+    // Treat a trailing all-alpha suffix as a real extension (.tex, .txt,
+    // .bib…). Suffixes containing digits (.v2, .r3) are version qualifiers,
+    // not extensions, so `.tex` is appended in those cases.
+    return /\.[a-zA-Z]+$/.test(source) ? source : `${source}.tex`;
+  }
+  return fileLocationShortDisplayPath(file.location);
+}
+
+/**
+ * The +/- counts an artifact's diff chip shows, or `null` when there is no
+ * chip to show. `DiffStats` is partial because a brand-new file is recorded as
+ * `{ added }` with nothing removed, so a present-but-absent side reads as
+ * zero — but stats with neither side are a *failed* diff computation, and
+ * rendering those as `+0 -0` would state a change count nobody measured.
+ */
+export function outputDiffCounts(
+  diff: DiffStats | null | undefined,
+): { added: number; removed: number } | null {
+  if (!diff || (diff.added === undefined && diff.removed === undefined)) {
+    return null;
+  }
+  return { added: diff.added ?? 0, removed: diff.removed ?? 0 };
+}
+
+/**
  * The output a finished run treats as final: the last output of the highest
  * round. The CLI's prior pickers both kept the later element on a round tie,
  * and callers' output order is not guaranteed to lead with the primary
@@ -160,16 +271,10 @@ export const RoundOutputSchema = z.strictObject({
 });
 export type RoundOutput = z.infer<typeof RoundOutputSchema>;
 
-function displayPath(location: FileLocation): string {
-  return location.kind === 'external'
-    ? location.absolutePath
-    : location.relativePath;
-}
-
 export const OutputFileSummaryFromInfoSchema = OutputFileInfoSchema.transform(
   (output) => ({
     round: output.round,
-    relativePath: displayPath(output.location),
+    relativePath: fileLocationDisplayPath(output.location),
     absolutePath: output.location.absolutePath,
     location: output.location.kind,
     originalPath: getEffectiveDiffBase(output.lineage)?.absolutePath ?? null,
@@ -182,7 +287,7 @@ export const CompileFailureSummaryFromFailureSchema =
   CompileFailureSchema.transform((failure) => ({
     round: failure.round,
     displayName: failure.displayName,
-    outputPath: displayPath(failure.output),
+    outputPath: fileLocationDisplayPath(failure.output),
     logPath: failure.logRelativePath,
     logAbsolutePath: failure.log.absolutePath,
   })).pipe(CompileFailureSummarySchema);

--- a/src/test-kernel/agent/modelHandlers/support/MediaAttachmentProcessor.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/support/MediaAttachmentProcessor.vitest.ts
@@ -18,10 +18,11 @@ import {
 import type { MediaEntry } from '@agent/types/mediaTypes';
 import { attachProviderError } from '@common/errors/sdkError/errorMetadata';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { fileLocationDisplayPath } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
-import { getComparablePath, pathToLocation } from '@utils/files/fileLocation';
+import { pathToLocation } from '@utils/files/fileLocation';
 
 interface MediaLogRecorder extends AgentTrace {
   debugMessages: string[];
@@ -201,7 +202,7 @@ describe('MediaAttachmentProcessor', () => {
   it('processes PDF fixtures using native ingestion when supported', async () => {
     const pdfPath = await createPdfFixture();
     const pdfLocation = pathToLocation(pdfPath);
-    const displayPath = getComparablePath(pdfLocation);
+    const displayPath = fileLocationDisplayPath(pdfLocation);
     const stub = createMediaLogRecorder();
     const processor = createProcessor(stub, {
       supportsVision: true,
@@ -260,7 +261,7 @@ describe('MediaAttachmentProcessor', () => {
 
     expectAudioResult(
       results,
-      getComparablePath(audioLocation),
+      fileLocationDisplayPath(audioLocation),
       'audio/wav',
       audioPath,
     );
@@ -328,7 +329,7 @@ describe('MediaAttachmentProcessor', () => {
 
       expectAudioResult(
         results,
-        getComparablePath(audioLocation),
+        fileLocationDisplayPath(audioLocation),
         mediaType,
         audioPath,
       );
@@ -343,7 +344,7 @@ describe('MediaAttachmentProcessor', () => {
   it('reports empty media fixtures as failed loads', async () => {
     const emptyPath = await createEmptyFixture();
     const emptyLocation = pathToLocation(emptyPath);
-    const displayPath = getComparablePath(emptyLocation);
+    const displayPath = fileLocationDisplayPath(emptyLocation);
     const stub = createMediaLogRecorder();
     const processor = createProcessor(stub, { supportsVision: true });
 
@@ -370,7 +371,7 @@ describe('MediaAttachmentProcessor', () => {
       Buffer.from('not-png'),
     );
     const mediaLocation = pathToLocation(mediaPath);
-    const displayPath = getComparablePath(mediaLocation);
+    const displayPath = fileLocationDisplayPath(mediaLocation);
     const stub = createMediaLogRecorder();
     const processor = createProcessor(stub, { supportsVision: true });
     const fsBackedExists = absoluteFsAny.exists;

--- a/src/test-kernel/agent/output/CompileCheck.vitest.ts
+++ b/src/test-kernel/agent/output/CompileCheck.vitest.ts
@@ -272,9 +272,9 @@ describe('runCompileCheck', () => {
     const executionId = 'compile-outer-backstop';
     await seedCompilableMainTex(executionId);
 
-    const filesModule = await import('@utils/files/fileLocation');
+    const schemasModule = await import('@shared/schemas');
     const comparablePathSpy = vi
-      .spyOn(filesModule, 'getComparablePath')
+      .spyOn(schemasModule, 'fileLocationDisplayPath')
       .mockImplementationOnce(() => {
         throw new Error('simulated bookkeeping bug');
       });
@@ -291,7 +291,7 @@ describe('runCompileCheck', () => {
       expect(mocks.compileLatex2Pdf).not.toHaveBeenCalled();
       expect(result.compileResult?.status).toBe('failed');
       expect(result.failures).toHaveLength(1);
-      // The second (uninstrumented) call to getComparablePath, made from the
+      // The second (uninstrumented) call to fileLocationDisplayPath, made from the
       // backstop itself, resolves normally -- so the failure gets a real,
       // resolvable path instead of a broken placeholder string.
       expect(result.failures[0].logRelativePath).toBe(relativePath);

--- a/src/test-kernel/agent/output/LineageMapping.vitest.ts
+++ b/src/test-kernel/agent/output/LineageMapping.vitest.ts
@@ -5,11 +5,8 @@ import {
   createOutputState,
   ensureRoundData,
 } from '@agent/implementations/flows/reflection/output/outputState';
-import type { ExecutionId } from '@shared/schemas';
-import {
-  createRunStorageLocation,
-  getComparablePath,
-} from '@utils/files/fileLocation';
+import { fileLocationDisplayPath, type ExecutionId } from '@shared/schemas';
+import { createRunStorageLocation } from '@utils/files/fileLocation';
 
 describe('workflow output lineage mapping', () => {
   const executionId: ExecutionId = 'abc123';
@@ -48,10 +45,10 @@ describe('workflow output lineage mapping', () => {
 
     const mapping = traceFileLineage(state, [chapter1, chapter2], 0);
 
-    const chapter1Entry = mapping.get(getComparablePath(chapter1Output));
+    const chapter1Entry = mapping.get(fileLocationDisplayPath(chapter1Output));
     expect(chapter1Entry?.origin).toBe(chapter1);
     expect(chapter1Entry?.base).toBe(chapter1);
-    const chapter2Entry = mapping.get(getComparablePath(chapter2Output));
+    const chapter2Entry = mapping.get(fileLocationDisplayPath(chapter2Output));
     expect(chapter2Entry?.origin).toBe(chapter2);
     expect(chapter2Entry?.base).toBe(chapter2);
   });

--- a/src/test-kernel/cli/WorkflowRunDetails.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunDetails.vitest.ts
@@ -145,7 +145,7 @@ describe('selectWorkflowRunDetailLines', () => {
       '✓ Repository audit Finished · 9s',
       '✓ r1/2 Finished · 7s',
       '  Generated files',
-      '    • output/paper.tex (+12 -3)',
+      '    • paper.tex (+12 -3)',
       '  ⚠ r1 · Missing expected output: appendix.tex',
       '  ✗ r1 · Compile check failed: paper.pdf · paper.log',
       '□ r2/2 Planned',

--- a/src/test-kernel/controllers/ProgressFollowUpController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressFollowUpController.vitest.ts
@@ -148,8 +148,10 @@ describe('ProgressFollowUpController', () => {
     expect(config.instruction ?? '').toMatch(
       /Editable workspace targets: source\.tex, main\.tex/,
     );
+    // Addressed through the execution that owns the artifact (`exec-old`, on
+    // the failure's own locations), not the execution asking about it.
     expect(config.instruction ?? '').toMatch(
-      /output \/executions\/exec-123\/files\/answer\.tex; compile log \/executions\/exec-123\/files\/answer\.log/,
+      /output \/executions\/exec-old\/files\/answer\.tex; compile log \/executions\/exec-old\/files\/answer\.log/,
     );
   });
 

--- a/src/test-kernel/progressView/StreamHeader.vitest.ts
+++ b/src/test-kernel/progressView/StreamHeader.vitest.ts
@@ -376,7 +376,7 @@ describe('stream-header', () => {
           'Execution: a1b2c3d4',
           '',
           'Outputs:',
-          '- r2: /executions/a1b2c3d4/files/answer.tex (source: main.tex)',
+          '- r3: /executions/a1b2c3d4/files/answer.tex (source: main.tex)',
         ].join('\n'),
       );
       expect(commands).toHaveLength(0);

--- a/src/test-kernel/shared/WorkflowRunContextCopy.vitest.ts
+++ b/src/test-kernel/shared/WorkflowRunContextCopy.vitest.ts
@@ -76,7 +76,7 @@ describe('formatWorkflowRunContext', () => {
         'Goal: Rewrite the introduction',
         '',
         'Outputs:',
-        '- r2: /executions/a1b2c3d4/files/answer.tex (source: main.tex)',
+        '- r3: /executions/a1b2c3d4/files/answer.tex (source: main.tex)',
       ].join('\n'),
     );
   });
@@ -109,8 +109,8 @@ describe('formatWorkflowRunContext', () => {
     });
 
     // A blank source drops the parenthetical rather than printing "()".
-    expect(text).toContain('- r1: chapter.tex\n');
-    expect(text).toContain('- r1: /elsewhere/appendix.tex');
+    expect(text).toContain('- r2: chapter.tex\n');
+    expect(text).toContain('- r2: /elsewhere/appendix.tex');
     expect(text).not.toContain('(source: )');
   });
 
@@ -133,7 +133,7 @@ describe('formatWorkflowRunContext', () => {
       compileFailures: {},
     });
 
-    expect(text.indexOf('- r2:')).toBeLessThan(text.indexOf('- r10:'));
+    expect(text.indexOf('- r3:')).toBeLessThan(text.indexOf('- r11:'));
   });
 
   it('lists compile failures with their log paths', () => {
@@ -144,7 +144,7 @@ describe('formatWorkflowRunContext', () => {
     });
 
     expect(text).toContain(
-      '- r2 answer.tex: log /executions/a1b2c3d4/files/answer.log',
+      '- r3 answer.tex: log /executions/a1b2c3d4/files/answer.log',
     );
   });
 

--- a/src/test-kernel/utils/TextDiffCallers.vitest.ts
+++ b/src/test-kernel/utils/TextDiffCallers.vitest.ts
@@ -12,7 +12,7 @@ import {
   ensureRoundData,
 } from '@agent/implementations/flows/reflection/output/outputState';
 import type { RoundFileMapping } from '@agent/implementations/flows/reflection/output/types';
-import type { ExecutionId } from '@shared/schemas';
+import { fileLocationDisplayPath, type ExecutionId } from '@shared/schemas';
 import { installPlatform } from '@test/support/setupPlatform';
 import { computeAndWriteWorkflowDiffs } from '@tools/delegation/subagentResults';
 import {
@@ -22,10 +22,7 @@ import {
   writeApprovedContent,
 } from '@tools/approval/toolEditApproval';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
-import {
-  createExternalLocation,
-  getComparablePath,
-} from '@utils/files/fileLocation';
+import { createExternalLocation } from '@utils/files/fileLocation';
 import { getRunDir } from '@utils/files/runStorageFs';
 
 function installFakePlatform(
@@ -57,7 +54,7 @@ describe('shared text-diff caller fixtures', () => {
     ];
     const baseLocation = createExternalLocation('/workspace/base.tex');
     const mapping: RoundFileMapping = new Map([
-      [getComparablePath(outputLocation), { base: baseLocation }],
+      [fileLocationDisplayPath(outputLocation), { base: baseLocation }],
     ]);
 
     const [output] = await computeOutputDiffStats(

--- a/src/tools/OpenPdfTool.ts
+++ b/src/tools/OpenPdfTool.ts
@@ -7,8 +7,12 @@ import {
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
 import { currentSession } from '@agent/runtime/SessionHandle';
-import type { FileLocation } from '@shared/schemas';
-import { ToolError, type ToolResult } from '@shared/schemas';
+import {
+  fileLocationDisplayPath,
+  ToolError,
+  type FileLocation,
+  type ToolResult,
+} from '@shared/schemas';
 import {
   currentToolRoot,
   resolveWorkspaceRelativePath,
@@ -47,10 +51,7 @@ export class OpenPdfTool extends defineTool({
     }
 
     const location = resolvePdfLocation(input.path);
-    const displayPath =
-      location.kind === 'workspace' || location.kind === 'runStorage'
-        ? location.relativePath
-        : location.absolutePath;
+    const displayPath = fileLocationDisplayPath(location);
 
     if (!hasExtension(location.absolutePath, '.pdf')) {
       throw new ToolError(`open_pdf only opens PDF files: ${displayPath}`);

--- a/src/tools/delegation/subagentResults.ts
+++ b/src/tools/delegation/subagentResults.ts
@@ -23,7 +23,11 @@ import {
 } from '@agent/runtime/AgentFinalResult';
 import { normalizeProviderError } from '@common/errors/sdkError/providerErrorFormat';
 import { createLog } from '@logger/logUtils';
-import type { ExecutionId, OutputFileSummary } from '@shared/schemas';
+import {
+  runStorageFilePath,
+  type ExecutionId,
+  type OutputFileSummary,
+} from '@shared/schemas';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 import { formatDuration, unique } from '@utils/core';
@@ -64,7 +68,7 @@ function formatOutputFile(
 ): string {
   const readPath =
     o.location === 'runStorage'
-      ? `/executions/${executionId}/files/${o.relativePath}`
+      ? runStorageFilePath(executionId, o.relativePath)
       : o.absolutePath;
   const attrs = [
     `path="${escapeAttr(o.relativePath)}"`,

--- a/src/utils/files/fileLocation.ts
+++ b/src/utils/files/fileLocation.ts
@@ -2,6 +2,7 @@
 import * as path from 'node:path';
 
 import {
+  fileLocationDisplayPath,
   type ExecutionId,
   type ExternalFileLocation,
   type FileLocation,
@@ -44,21 +45,11 @@ export function createExternalLocation(
 }
 
 /**
- * Get a comparable path for file matching and mapping.
- * Returns relativePath for workspace/runStorage files, absolutePath for external files.
- */
-export function getComparablePath(location: FileLocation): string {
-  return location.kind === 'external'
-    ? location.absolutePath
-    : location.relativePath;
-}
-
-/**
  * Get directory path from a FileLocation.
  * Returns relativePath's directory for workspace/runStorage, absolutePath's for external.
  */
 export function getFileDirectory(location: FileLocation): string {
-  return path.dirname(getComparablePath(location));
+  return path.dirname(fileLocationDisplayPath(location));
 }
 
 /**
@@ -85,19 +76,4 @@ export function pathToLocation(target: string): FileLocation {
   }
 
   return createWorkspaceLocation(resolved.absolutePath, resolved.relativePath);
-}
-
-/**
- * Get a short display-friendly path for a file location.
- * For workspace files, returns the relative path (e.g., "logos/mpq-logo.pdf").
- * For external files, returns just the basename (not the full absolute path).
- *
- * This provides a concise human-readable path suitable for showing to users or models,
- * while absolutePath should be used for actual file operations.
- */
-export function getShortDisplayPath(location: FileLocation): string {
-  if (location.kind === 'workspace' || location.kind === 'runStorage') {
-    return location.relativePath;
-  }
-  return path.basename(location.absolutePath);
 }


### PR DESCRIPTION
## Summary

"How an output artifact reads to a human" was four rules — the
`FileLocation`→display-path rule, the output display name, the run-storage
address, and the round label — re-derived in roughly fourteen places across
the agent core, the progress-view webview, and the CLI TUI. The canonical
helpers existed (`@utils/files/fileLocation`), but that module imports
`node:path`, so no webview could reach it; `FileList.getCompactDisplayPath`
and friends existed only because of that.

This moves the vocabulary to `src/shared/schemas/output.ts` — beside the schema
it describes, and browser-safe: it reaches `getBasename` from `@utils/core`,
one of the seven browser-reachable utils, exactly the way
`src/shared/schemas/diffResult.ts:3` already does.

New single owners:

| Helper | Replaces |
| --- | --- |
| `fileLocationDisplayPath` | `getComparablePath` + a private `displayPath` in `output.ts` + 6 inline `kind === 'external' ? … : …` copies |
| `fileLocationShortDisplayPath` | `getShortDisplayPath` + `FileList.getCompactDisplayPath` |
| `fileLocationAddressPath` | private `locationPath` (workflowRunContext) + private `formatCompileFailureOutputPath` (ProgressFollowUpController) |
| `runStorageFilePath` | same function, moved out of `@shared/copy/workflowRunContext`; `subagentResults.ts` stops hand-writing the `/executions/…/files/…` string |
| `outputDisplayName` | `FileList.getSourceDisplayPath` + `getCompactDisplayPath` chain, and the CLI pane's inline path pick |
| `isGenericOutputStem` | `GENERIC_OUTPUT_STEMS` in `compileCheck.ts` + the inline `'output' \| 'output.xml' \| 'output.tex'` test in `FileList.ts` |
| `outputDiffCounts` | the webview's and the CLI's separate diff-chip rules |

### Three user-visible divergences this fixes

These are bug fixes, not just consolidation.

| # | Before | After |
| --- | --- | --- |
| 1 | The progress view's **file list said `r0` while the task list on the same screen said `r1`** for the same round: `FileList` printed `r${round}` from the zero-based index, `TaskGroupList` printed `formatRoundStageLabel`. The latexdiff results panel printed `[r0]` from the same zero-based index. | `formatRoundStageLabel` is the only producer of a user-facing round label. All three read `r1`. |
| 2 | One artifact read by **three names**: `output/paper.tex` in the CLI run-details pane (raw relative path), `paper.tex` in the extension file list (lineage/source pick), and a third basename in the compile-failure row. | The file list and the CLI pane share `outputDisplayName`. The compile display name keeps its basename shape — that string also seeds on-disk compile-log and PDF names — but no longer carries its own copy of the generic-stem rule. |
| 3 | When the diff computation **failed**, `computeDiffStats` returns `{}`; the webview then rendered no chip (right) while the CLI rendered **`(+0 -0)`** — stating a change count nobody measured. A new file (`{ added: N }`, no base) also read `+N` in the webview but `+N -0` in the CLI. | `outputDiffCounts` answers once: no counts at all → no chip in either host; a present-but-absent side reads as zero, so a new file is `+N -0` everywhere. |

### Model-facing decision (deliberate, not a side effect)

Round labels are not UI-only. `ProgressFollowUpController` builds the
compile-fixer follow-up prompt, and `formatWorkflowRunContext` builds the text
the copy-run-context button puts on the clipboard for pasting into a prompt.
Both printed `r${round}` from the zero-based index; both now print
`formatRoundStageLabel`, i.e. one-based.

A second, smaller model-facing change: in the compile-fixer prompt, a failure
line's `output …; compile log …` pair is now addressed entirely through
`fileLocationAddressPath`, i.e. through the execution each location carries.
Previously the output half used the location's execution and the log half used
the execution *asking* about the failure — two sources for one fact. They agree
in the ordinary case (the failure belongs to the current run) and the prompt
text is then byte-identical; when they disagree (a failure recorded by an
earlier execution of the same stream) the caller-supplied id pointed into the
wrong run's storage. `ProgressFollowUpController.vitest.ts` had a fixture with
deliberately divergent ids pinning the old rule; it now pins the new one, with
the reason in a comment.

**These change prompt bytes on purpose.** The alternative — keeping the model
on zero-based labels — would mean a user reading "r1" in the file list and
telling the model about "round 1" while the prompt calls the same round "r0".
One numbering for both is the point of the change.

Two things deliberately *not* renumbered:

- `subagentResults.ts` emits `<round number="{round}">` — a machine-readable
  attribute, not a label. It keeps the raw zero-based index; only the
  `/executions/…/files/…` convention was taken over from `runStorageFilePath`.
- `src/shared/constants/workflowOutput.ts`'s `r<N>/` segment is a **filesystem**
  path parsed back at `compileCheck.ts:100`. Untouched.

## Issue acceptance gates

No issue — track work from the artifact-display-vocabulary sweep. Self-imposed
gates: one producer per user-facing round label; one display-name rule shared
by file list and CLI pane; one diff-chip rule; browser-reachable helper set
unchanged.

## Single source of truth

`src/shared/schemas/output.ts` owns how a `FileLocation` and an
`OutputFileInfo` read to a human. `src/shared/streams/streamStatusDisplay.ts`
(`formatRoundStageLabel`) owns the user-facing round label — now including the
progress-view file list and both model-facing text builders.

## Duplication and abstraction budget

Removed: ~14 re-derivations of the display-path rule, two private copies of
the generic-output-stem set, two private copies of the run-storage address
rule, two copies of the diff-chip rule, and one of the two round-label
producers. No new layer: the helpers are pure functions on existing schema
types, called directly at the render/format site — `@utils/files/fileLocation`
now imports one of them rather than defining its own.

## Net elements (R6)

- Files: 27 changed, 0 added, 0 deleted.
- Exported symbols (`^[+-]export` over the diff): **+7 / −3 = net +4**
  (`fileLocationDisplayPath`, `fileLocationShortDisplayPath`,
  `fileLocationAddressPath`, `runStorageFilePath`, `isGenericOutputStem`,
  `outputDisplayName`, `outputDiffCounts` vs `getComparablePath`,
  `getShortDisplayPath`, `runStorageFilePath`-at-its-old-home).
- Private constructs deleted: 6 (`displayPath`, `locationPath`,
  `formatCompileFailureOutputPath`, `FileList.getDisplayPath`,
  `FileList.getCompactDisplayPath`, `FileList.getSourceDisplayPath`) plus the
  `GENERIC_OUTPUT_STEMS` module const, folded into `isGenericOutputStem`.
  Named-function delta is therefore **−2**; the ~14 collapsed inline
  derivations are not counted as constructs.
- Classes/interfaces/enums: 0 added, 0 deleted.
- Net LoC: **278 insertions, 288 deletions = −10**. Honest read: small, because
  the four consolidated helpers carry doc comments the inline copies did not.
  The win here is one-behavior-one-place plus three bug fixes, not LoC.

## Consumer counts (R8)

No emit path added, deleted, or re-routed. Export deletions/moves, grepped on
the base commit (391033e694):

- `getComparablePath` — 13 files referenced it (8 production, 4 test, 1
  defining module). All re-pointed to `fileLocationDisplayPath`; 0 references
  remain in `src/` or `packages/` (one historical mention survives in
  `docs/proposals/2026-08-03-ssot-consolidation-plan.md`, left as record).
- `getShortDisplayPath` — 1 consumer (`modelHandlerGoogleInteractions.ts`),
  re-pointed to `fileLocationShortDisplayPath`; 0 references remain.
- `runStorageFilePath` — moved module, not deleted. 2 consumers
  (`ProgressFollowUpController`, `workflowRunContext`), both re-pointed;
  `subagentResults.ts` becomes a third by adopting the convention. 0 imports of
  the old path remain.

## Host impact

**Extension:** progress-view file list and latexdiff results panel now label
rounds `r1`-based (matching the task list beside them), the file list shows the
unified artifact name, and the diff chip follows the shared rule. The copy-run-context text (`StreamHeader`) and the
compile-fixer follow-up prompt are one-based.

**Desktop:** no display-name renderer of its own; inherits the one-based
follow-up prompt through the shared `ProgressFollowUpController`.

**CLI:** the run-details pane shows the unified artifact name
(`output/paper.tex` → `paper.tex`) and no longer prints `(+0 -0)` for a failed
diff computation.

## Scheduled refactoring

None. Two knowingly-unfinished edges are documented above: `compileCheck`'s
basename-shaped display name (it seeds on-disk filenames) and
`subagentResults`' zero-based `<round number>` attribute (machine-readable).

## Validation

- `npm run typecheck` — clean (all four projects).
- `FORCE_COLOR=0 npx vitest run` over the touched suites and the surrounding
  `architecture` / `shared` / `progressView` / `cli` / `agent/output` /
  `tools` / `controllers` directories (407 files, 4984 tests) — green. Five pinned
  expectations updated to the new behavior: `WorkflowRunDetails` artifact
  name, `WorkflowRunContextCopy` and `StreamHeader` round labels,
  `ProgressFollowUpController` failure-line addressing, and the `CompileCheck`
  spy target. `progressView/FileList.vitest.ts` is keyboard-activation only
  and needed no change. **No new tests** (test budget: this is a
  behavior-consolidating refactor).
- `npm run format:check` — clean.
- `npx eslint` over all changed files — clean (one `import/order` fix applied).
- `node scripts/check-browser-safe-utils.mjs` — **62 total, 7 reachable**, no
  drift. The new home reaches only `@utils/core`, already reachable.
- `npm run check:dead-code-ratchet` — 8 current vs 8 baselined, no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
