### PR TITLE
refactor(desktop): collapse ChatGPT/Grok sign-out and preference twins

### DIFF
--- a/packages/desktop/src/main/desktopCredentialSettingsController.ts
+++ b/packages/desktop/src/main/desktopCredentialSettingsController.ts
@@ -435,70 +435,81 @@ export class DefaultDesktopCredentialSettingsController implements DesktopCreden
     }
   }
 
-  private async signOutChatGpt(): Promise<void> {
+  private async signOutSubscription(options: {
+    displayName: string;
+    signOut: () => Promise<void>;
+    refresh: () => Promise<void>;
+  }): Promise<void> {
     try {
-      await codexCoordinator().signOut();
+      await options.signOut();
       await this.options.notifications.showInfoMessage(
-        'Signed out of ChatGPT.',
+        `Signed out of ${options.displayName}.`,
       );
     } catch (error) {
       await this.options.notifications.showErrorMessage(
-        `ChatGPT sign-out failed: ${toErrorMessage(error)}`,
+        `${options.displayName} sign-out failed: ${toErrorMessage(error)}`,
       );
       this.options.onError(error);
     } finally {
-      await this.refreshAfterChatGptAuthChange();
+      await options.refresh();
     }
   }
 
+  private async signOutChatGpt(): Promise<void> {
+    await this.signOutSubscription({
+      displayName: 'ChatGPT',
+      signOut: () => codexCoordinator().signOut(),
+      refresh: () => this.refreshAfterChatGptAuthChange(),
+    });
+  }
+
   private async signOutGrok(): Promise<void> {
+    await this.signOutSubscription({
+      displayName: 'Grok',
+      signOut: () => xaiCoordinator().signOut(),
+      refresh: () => this.refreshAfterGrokAuthChange(),
+    });
+  }
+
+  private async setSubscriptionPreference(options: {
+    displayName: string;
+    enabled: boolean;
+    setPrefer: (enabled: boolean) => Promise<{ effective: boolean }>;
+    refresh: () => Promise<void>;
+  }): Promise<void> {
     try {
-      await xaiCoordinator().signOut();
-      await this.options.notifications.showInfoMessage('Signed out of Grok.');
+      const update = await options.setPrefer(options.enabled);
+      if (update.effective !== options.enabled) {
+        await this.options.notifications.showWarningMessage(
+          `A more specific setting still keeps ${options.displayName} subscription ${update.effective ? 'enabled' : 'disabled'}.`,
+        );
+      }
     } catch (error) {
       await this.options.notifications.showErrorMessage(
-        `Grok sign-out failed: ${toErrorMessage(error)}`,
+        `${options.displayName} subscription preference update failed: ${toErrorMessage(error)}`,
       );
       this.options.onError(error);
     } finally {
-      await this.refreshAfterGrokAuthChange();
+      await options.refresh();
     }
   }
 
   private async setChatGptPreferSubscription(enabled: boolean): Promise<void> {
-    try {
-      const update = await setPreferCodexSubscription(enabled);
-      if (update.effective !== enabled) {
-        await this.options.notifications.showWarningMessage(
-          `A more specific setting still keeps ChatGPT subscription ${update.effective ? 'enabled' : 'disabled'}.`,
-        );
-      }
-    } catch (error) {
-      await this.options.notifications.showErrorMessage(
-        `ChatGPT subscription preference update failed: ${toErrorMessage(error)}`,
-      );
-      this.options.onError(error);
-    } finally {
-      await this.refreshAfterChatGptAuthChange();
-    }
+    await this.setSubscriptionPreference({
+      displayName: 'ChatGPT',
+      enabled,
+      setPrefer: setPreferCodexSubscription,
+      refresh: () => this.refreshAfterChatGptAuthChange(),
+    });
   }
 
   private async setGrokPreferSubscription(enabled: boolean): Promise<void> {
-    try {
-      const update = await setPreferXaiSubscription(enabled);
-      if (update.effective !== enabled) {
-        await this.options.notifications.showWarningMessage(
-          `A more specific setting still keeps Grok subscription ${update.effective ? 'enabled' : 'disabled'}.`,
-        );
-      }
-    } catch (error) {
-      await this.options.notifications.showErrorMessage(
-        `Grok subscription preference update failed: ${toErrorMessage(error)}`,
-      );
-      this.options.onError(error);
-    } finally {
-      await this.refreshAfterGrokAuthChange();
-    }
+    await this.setSubscriptionPreference({
+      displayName: 'Grok',
+      enabled,
+      setPrefer: setPreferXaiSubscription,
+      refresh: () => this.refreshAfterGrokAuthChange(),
+    });
   }
 
   async postProfileData(): Promise<void> {


### PR DESCRIPTION
## Summary

Scheduled codebase audit for overlapping/confusing responsibilities. The clearest tractable finding: `DesktopCredentialSettingsController` (`packages/desktop/src/main/desktopCredentialSettingsController.ts`) reimplemented the ChatGPT (Codex) / Grok (xAI) "subscription twin" inline for **sign-out** and **preference-toggle** handling — two pairs of methods with an identical try/notify/catch/finally shape, differing only in coordinator, preference setter, and display name.

This twin was already deduped for **sign-in** in the same file via a private `signInSubscription({ displayName, login, accountLabel, enablePrefer, refresh })` helper, and deduped independently for the extension host via `SubscriptionHandlers`/`SubscriptionProvider` in `packages/extension/src/settingsView/handlers/subscriptionHandlers.ts`. Desktop's sign-out and preference-toggle paths were the one copy of the pattern left unfactored.

This PR extends the file's own existing `signInSubscription` idiom to sign-out and preference updates:
- `signOutChatGpt`/`signOutGrok` → both now delegate to a new private `signOutSubscription({ displayName, signOut, refresh })`.
- `setChatGptPreferSubscription`/`setGrokPreferSubscription` → both now delegate to a new private `setSubscriptionPreference({ displayName, enabled, setPrefer, refresh })`.

Behavior is unchanged: same messages, same error handling, same refresh calls — verified by diffing string interpolation (`` `Signed out of ${displayName}.` `` etc.) against the original per-provider literals.

## Issue acceptance gates

No pre-existing issue; this is the deliverable of a scheduled responsibility-overlap audit. Acceptance gate: the ChatGPT and Grok sign-out/preference-toggle flows in this file are expressed once each, not twice, with no behavior change.

## Single source of truth

The shape of "sign out of a subscription provider" and "apply a subscription routing preference" now each live in one private method (`signOutSubscription`, `setSubscriptionPreference`) on `DefaultDesktopCredentialSettingsController`, mirroring the pre-existing `signInSubscription` helper for the sign-in leg of the same flow.

## Duplication and abstraction budget

Removed: two near-identical 15-line method bodies (`signOutChatGpt`/`signOutGrok`) and two near-identical 17-line method bodies (`setChatGptPreferSubscription`/`setGrokPreferSubscription`), each differing only in coordinator, setter, and display string.

Added: two private helpers, following the exact call shape the file already established for sign-in (`signInSubscription`) — no new class, no new file, no cross-host abstraction. Net diff is +48/-37 lines in one file; the four public-facing per-provider methods (`signOutChatGpt`, `signOutGrok`, `setChatGptPreferSubscription`, `setGrokPreferSubscription`) remain as thin, named entry points so callers and the `DesktopChatGptHandlers`/`DesktopGrokHandlers` wiring are unaffected.

## Net elements (R6)

- Files: 1 changed, 0 added, 0 deleted.
- Exported symbols: 0 added, 0 removed (`git diff HEAD~1 HEAD -- packages/desktop/src/main/desktopCredentialSettingsController.ts | grep -E '^[+-].*export'` → no matches — all changed methods are private).
- Classes/interfaces/enums: 0 added, 0 removed.
- Net LoC: +11 (48 insertions, 37 deletions), reflecting two new shared private helpers replacing four duplicated method bodies.

## Consumer counts (R8)

No emit path, export, or public API changed or re-routed — n/a. `chatGptHandlers`/`grokHandlers` wiring (`this.chatGptHandlers`, `this.grokHandlers` in the constructor) is untouched; the four provider-specific methods it points to keep their existing signatures.

## Host impact

Extension: none — no files in `packages/extension` touched.

Desktop: `signOutChatGpt`, `signOutGrok`, `setChatGptPreferSubscription`, `setGrokPreferSubscription` now delegate to two new shared private helpers on the same controller; external behavior (user-facing messages, error handling, refresh calls) is unchanged.

CLI: none — no files in `packages/cli` touched.

## Scheduled refactoring

None — this fix is self-contained. (The audit also surfaced two larger, already-tracked structural findings — lifecycle/shutdown ownership diffusion per `docs/proposals/2026-08-15-lifecycle-ownership.md`, and duplicated dirty-write/retry logic between `StreamLogStore` and `StreamSnapshotStore` per the repo's 2026-08-07 triage — both intentionally out of scope for this PR as multi-file, already-adjudicated efforts.)

## Validation

- `npm run typecheck:desktop` — passes clean (all four desktop tsconfig projects).
- `npx eslint packages/desktop/src/main/desktopCredentialSettingsController.ts` — no findings.
- `npx prettier --check packages/desktop/src/main/desktopCredentialSettingsController.ts` — passes.
- No dedicated unit test exists for this controller (none added or removed); behavior-preserving refactor per this repo's testing-discipline guardrail (`AGENTS.md` "Testing discipline") — the delegated helpers' request/response shapes were checked by hand against the original per-provider bodies rather than exercised through new tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XbW5TdordWyocgLXhBAayy)_