### PR TITLE
refactor: consolidate hand-rolled object-guards onto isObject

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -86,6 +86,7 @@ import type {
 import { AgentCategory, MESSAGE_TYPES, OUTPUT_END_TAG } from '@shared/schemas';
 import { INCLUDED_ACCESS, OWN_API_KEYS } from '@shared/copy/modelAccess';
 import { DEFAULT_COMPACTION_THRESHOLD_PERCENT } from '@shared/constants/contextManagement';
+import { isObject } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { extractScratchpad } from '@utils/text/xmlExtraction';
 import {
@@ -684,7 +685,7 @@ export abstract class ModelHandler<
 
   /** Route of the credential a client built by this handler captured, if known. */
   getCredentialRouteForClient(client: C): ModelCredentialRoute | undefined {
-    return typeof client === 'object' && client !== null
+    return isObject(client)
       ? this.clientWireIdentities.get(client)?.route
       : undefined;
   }
@@ -696,10 +697,9 @@ export abstract class ModelHandler<
    * treats it as opaque.
    */
   getWireRouteKey(client: C): string {
-    const wireIdentity =
-      typeof client === 'object' && client !== null
-        ? this.clientWireIdentities.get(client)
-        : undefined;
+    const wireIdentity = isObject(client)
+      ? this.clientWireIdentities.get(client)
+      : undefined;
     return JSON.stringify([
       this.config.provider,
       wireIdentity?.route ?? 'configured',
@@ -1227,10 +1227,9 @@ export abstract class ModelHandler<
   createResponse(
     options: CreateResponseOptions<M, C>,
   ): Promise<CreateResponseResult<Resp, M>> {
-    const identity =
-      typeof options.client === 'object' && options.client !== null
-        ? this.clientWireIdentities.get(options.client)
-        : undefined;
+    const identity = isObject(options.client)
+      ? this.clientWireIdentities.get(options.client)
+      : undefined;
     const credentialRoute = identity?.route;
     return this.withCreateResponseGuard(async () => {
       this.activeAttemptCredentialRoute = credentialRoute;

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -10,6 +10,7 @@ import type { ToolDefinition } from '@shared/schemas';
 
 // Local imports - shared
 import { TOOL_JSON_SCHEMA_OPTIONS } from '@shared/tools/toolJsonSchema';
+import { isObject } from '@utils/core';
 
 // Type imports - third-party
 import type {
@@ -59,7 +60,7 @@ interface JSONSchemaObject {
 }
 
 function isSchemaObject(value: unknown): value is JSONSchemaObject {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+  return isObject(value);
 }
 
 function schemaLiteralValue(schema: JSONSchemaObject): unknown {

--- a/src/controllers/modelAccess/subscriptionUsage/subscriptionUsageParsing.ts
+++ b/src/controllers/modelAccess/subscriptionUsage/subscriptionUsageParsing.ts
@@ -1,5 +1,5 @@
 import type { SubscriptionUsageWindow } from '@shared/schemas';
-import { clamp } from '@utils/core';
+import { clamp, isObject } from '@utils/core';
 
 export type JsonObject = Record<string, unknown>;
 
@@ -24,9 +24,7 @@ export function assertSubscriptionUsageResponse(response: Response): void {
 }
 
 export function asObject(value: unknown): JsonObject | undefined {
-  return value !== null && typeof value === 'object' && !Array.isArray(value)
-    ? (value as JsonObject)
-    : undefined;
+  return isObject(value) ? value : undefined;
 }
 
 function finiteNumber(value: unknown): number | undefined {


### PR DESCRIPTION
## Summary

Scheduled scan for consolidation opportunities (duplicate logic, hand-rolled code that a native/shared utility already covers) found the same "non-null, non-array object" type guard reimplemented inline in three places instead of importing the existing `isObject` from `@utils/core`. This PR swaps those three sites onto the shared guard.

- `src/controllers/modelAccess/subscriptionUsage/subscriptionUsageParsing.ts` — `asObject()` had a byte-identical body to `isObject`.
- `src/agent/modelHandlers/ModelHandler.ts` — three inline `typeof x === 'object' && x !== null` checks in `getCredentialRouteForClient`, `getWireRouteKey`, and `createResponse`.
- `src/agent/modelHandlers/toolConversion.ts` — `isSchemaObject()` had an identical body to `isObject`, just with a local type predicate.

Note: `src/common/errors/sdkError/providerErrorFormat.ts` has a fourth occurrence of the same shape (`typeof rawErrorBody === 'object' && rawErrorBody !== null`), but `isObject` excludes arrays where that check doesn't — swapping it would change behavior for array-shaped error bodies (a diagnostic-only comparison), so it's left as-is rather than folded into a "purely mechanical" PR.

## Issue acceptance gates

No tracking issue — this is a small, self-contained consolidation surfaced directly by a codebase scan, not staged through the tech-debt tournament ledger (that ledger, #8974, was closed by the maintainer as producing unreliable state).

## Single source of truth

`isObject` in `src/utils/core/index.ts` is now the sole implementation of the "non-null, non-array object" guard at all four touched call sites; the three former inline/local reimplementations are gone.

## Duplication and abstraction budget

Removed duplication only — no new abstraction added. `isObject` already existed with 2+ existing callers before this PR.

## Net elements (R6)

3 files changed, 12 insertions(+), 14 deletions(-); net -2 LoC. No exported symbols added or removed (`git diff | grep -E '^[+-]export'` is empty) — `asObject` and `isSchemaObject` keep their existing signatures and call sites unchanged.

## Consumer counts (R8)

n/a — no emit path, export, or public API surface changed; only internal function bodies were simplified. Call sites (`asObject`'s 13+ callers, `isSchemaObject`'s 6 internal callers, `ModelHandler`'s 3 methods) are unaffected by signature.

## Host impact

Extension: none — no VS Code-facing behavior change.

Desktop: none.

CLI: none.

## Scheduled refactoring

None. (One related opportunity — the `providerErrorFormat.ts` array-exclusion caveat noted above — is intentionally not filed as follow-up work per repo guidance against filing speculative debt issues; it can be picked up ad hoc if someone wants to also change that behavior.)

## Validation

- `npm run typecheck` — full workspace (core, test-kernel, agent, cli, trace-viewer, desktop) — clean.
- `npm run lint` — clean (one import-order issue on `toolConversion.ts` auto-fixed via `eslint --fix`).
- `npx prettier --check` — clean (one formatting fix applied to `ModelHandler.ts` via `--write`).
- `npm run check:dead-code-ratchet` — no new unused files/exports/types.
- Targeted tests: `SubscriptionUsageService.vitest.ts`, `ToolConversion.vitest.ts`, `ModelClientRouteSnapshot.vitest.ts` — 93/93 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kh3Z4QEefXHzYCgchJYHxk)_