### PR TITLE
refactor(session): collapse renderer-port notifications and share CLI stream labels

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -493,7 +493,6 @@ export function App(props: AppProps): React.JSX.Element {
             childRosters,
             parentStream,
             streamId: foregroundReader.streamId,
-            streams,
           }),
         );
         return (
@@ -513,7 +512,6 @@ export function App(props: AppProps): React.JSX.Element {
             childRosters,
             parentStream,
             streamId: foregroundReader.streamId,
-            streams,
           }),
         );
         return (

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -131,10 +131,6 @@ export function sessionHeaderIdentityLine(
   const parentStreamId =
     context.streamId && parentStream?.get(context.streamId);
   if (context.streamId && parentStreamId && parentStream && context.streams) {
-    const metadata = streamMetadataFor(context.streamId);
-    const model = getRuntimeModelLabel(
-      metadata?.config?.model || meta.model || '—',
-    );
     const view = streamViewForId({
       activeStreamId: context.streamId,
       childRosters: context.childStreamEntries ?? new Map(),
@@ -142,8 +138,12 @@ export function sessionHeaderIdentityLine(
       streamId: context.streamId,
       streams: context.streams,
     });
+    // The shared tab projection owns the model label; the session's own model
+    // is the fallback for a stream whose config has not resolved.
+    const model =
+      view.info?.modelLabel ?? getRuntimeModelLabel(meta.model || '—');
     const streamKind =
-      metadata?.identity?.kind === 'multiAgentWorkflow'
+      view.info?.identity?.kind === 'multiAgentWorkflow'
         ? 'workflow script'
         : 'subagent';
     const phase = ancestorWorkflowPhaseHeading({

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -312,7 +312,6 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
               childRosters,
               parentStream,
               streamId: target.displayStreamId,
-              streams,
             }),
       phaseHeading:
         target.displayStreamId === undefined

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -157,14 +157,10 @@ function SessionRow({
   const stageLabel = formatStageLabel(streamState?.stage);
   // The resolved model is per-agent identity (a workflow run's grandchildren
   // can each resolve a different model); the list-root row is the conversation
-  // itself, whose model already rides the status bar. A background bash stream
-  // inherits its parent's configuration, but the shell does not use a model.
-  const identity = session.identity ?? metadata?.identity;
-  const model =
-    !isListRoot && identity?.kind !== 'process'
-      ? metadata?.config?.model
-      : undefined;
-  const modelLabel = model ? getRuntimeModelLabel(model) : undefined;
+  // itself, whose model already rides the status bar. `buildStreamTabInfo`
+  // already leaves `modelLabel` unset for a process stream (a shell uses no
+  // model) and for a config whose model has not resolved.
+  const modelLabel = isListRoot ? undefined : session.info?.modelLabel;
   // The right-aligned `elapsed · ↓tokens` column is pushed to the terminal edge
   // so the figures line up across rows. Lower-priority inline segments yield;
   // rows drop the column entirely on narrow terminals (see

--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -44,7 +44,7 @@ export function unbindChildStreamState(state: SessionState): void {
 /**
  * Re-derive the child-stream snapshots from the bound `SessionState`. Called
  * by the adapter after any change that can move rosters, parent edges, or
- * tombstones: `onBadgesChanged`, `onParentStreamChanged`,
+ * tombstones: `onBadgesChanged`, `invalidate(…, 'parentStreamId')`,
  * `onStreamMetadataChanged` (a new RUNNING drops the previous run's retained
  * rows and surfaces only here), and the adapter's `deleteStream` removal hook
  * (removal fires no renderer-port callback by design).

--- a/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
+++ b/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
@@ -6,6 +6,7 @@ import { SessionFactApplier } from '@controllers/session/SessionFactApplier';
 import type {
   PresentedStreamId,
   SessionRendererPort,
+  SessionRenderSlice,
 } from '@controllers/session/SessionRendererPort';
 import { SessionState } from '@controllers/session/SessionState';
 import type { StreamArtifactReader } from '@controllers/session/StreamArtifactProjection';
@@ -25,6 +26,7 @@ import {
   isTranscriptSettlementPhase,
   STREAM_TRANSITION_CAUSE,
 } from '@shared/streams/streamStatus';
+import { assertNever } from '@utils/core';
 import {
   activeStreamId,
   focusStream,
@@ -81,13 +83,30 @@ class TuiSessionRenderer implements SessionRendererPort {
     }
   }
 
-  onParentStreamChanged(
-    _childStreamId: StreamTabId,
-    _parentStreamId: StreamTabId | null,
-  ): void {
-    // The applier already landed the edge on `SessionState` metadata; the
-    // CLI's topology snapshot re-derives from there.
-    invalidateChildStreams();
+  invalidate(streamId: StreamTabId, slice: SessionRenderSlice): void {
+    switch (slice) {
+      case 'files':
+      case 'compileFailures':
+        // Renderers read `StreamArtifactProjection` directly. The write itself
+        // is proof of established provenance for this session — a live fact
+        // must not wait on the focus-driven disk preload
+        // (`markArtifactStreamHydrated`'s other caller) that exists only to
+        // seed a stream cold, or a background (never-focused, or focus-raced)
+        // workflow's output files never surface.
+        return markArtifactStreamHydrated(streamId);
+      case 'parentStreamId':
+      case 'queuedFollowUps':
+        // The applier already landed the edge / the session-owned queue on
+        // `SessionState`; the CLI's topology snapshot and `queuedFollowUpsFor`
+        // re-derive from there at paint.
+        return invalidateChildStreams();
+      case 'goalPaused':
+        return appendLocalAssistantTranscript(
+          GOAL_PAUSED_TRANSCRIPT_NOTICE,
+          streamId,
+        );
+    }
+    assertNever(slice, 'Unhandled session render slice');
   }
 
   onStreamStatusChanged(
@@ -153,25 +172,10 @@ class TuiSessionRenderer implements SessionRendererPort {
     invalidateChildStreams();
   }
 
-  onFilesChanged(streamId: StreamTabId): void {
-    // Renderers read `StreamArtifactProjection` directly. The write itself is
-    // proof of established provenance for this session — a live fact must not
-    // wait on the focus-driven disk preload (`markArtifactStreamHydrated`'s
-    // other caller) that exists only to seed a stream cold, or a background
-    // (never-focused, or focus-raced) workflow's output files never surface.
-    markArtifactStreamHydrated(streamId);
-  }
-
   onMissingOutputsChanged(streamId: StreamTabId): void {
     // Renderers read `StreamArtifactProjection` directly; a disk-restored
-    // clear invalidates the memo like any other change. See `onFilesChanged`
-    // for why the write marks the stream hydrated rather than only bumping.
-    markArtifactStreamHydrated(streamId);
-  }
-
-  onCompileFailuresChanged(streamId: StreamTabId): void {
-    // Renderers read `StreamArtifactProjection` directly. See
-    // `onFilesChanged` for why the write marks the stream hydrated.
+    // clear invalidates the memo like any other change. See `invalidate` for
+    // why the write marks the stream hydrated rather than only bumping.
     markArtifactStreamHydrated(streamId);
   }
 
@@ -182,7 +186,7 @@ class TuiSessionRenderer implements SessionRendererPort {
   ): void {
     // The latest-usage gauge is payload-only (no synchronous shared read);
     // the cumulative sum is `StreamArtifactProjection.cumulativeUsage`. See
-    // `onFilesChanged` for why the write marks the stream hydrated.
+    // `invalidate` for why the write marks the stream hydrated.
     patchStream(streamId, (slice) => ({ ...slice, usage: latestUsage }));
     markArtifactStreamHydrated(streamId);
   }
@@ -190,19 +194,13 @@ class TuiSessionRenderer implements SessionRendererPort {
   // Live todos/plan are readable from the snapshot store synchronously: a
   // live update is applied to `getWorkPlan` before the stream seeds
   // (StreamSnapshotStore eager-apply overlay), so renderers read the store.
-  // See `onFilesChanged` for why the write marks the stream hydrated.
+  // See `invalidate` for why the write marks the stream hydrated.
   onTodosChanged(streamId: StreamTabId, _todos: TodoItem[]): void {
     markArtifactStreamHydrated(streamId);
   }
 
   onPlanChanged(streamId: StreamTabId, _plan: Plan | null): void {
     markArtifactStreamHydrated(streamId);
-  }
-
-  onQueuedFollowUpsChanged(_streamId: StreamTabId): void {
-    // The session-owned queue is the single source; renderers read
-    // `queuedFollowUpsFor` at paint.
-    invalidateChildStreams();
   }
 
   onInquiryThreadUpdated(_thread: InquiryThreadUpdatedEvent): void {}
@@ -212,10 +210,6 @@ class TuiSessionRenderer implements SessionRendererPort {
     _active: boolean,
     _details?: { status?: GoalStatus; objective?: string },
   ): void {}
-
-  onGoalPaused(streamId: StreamTabId): void {
-    appendLocalAssistantTranscript(GOAL_PAUSED_TRANSCRIPT_NOTICE, streamId);
-  }
 
   syncStreamContent(
     _stream: PresentedStreamId,

--- a/packages/cli/src/chat/tui/state/streamViews.ts
+++ b/packages/cli/src/chat/tui/state/streamViews.ts
@@ -1,25 +1,30 @@
-// Stream-scoped display projection for CLI controls. The authoritative state
-// remains `StreamSlice` plus the child->parent edge map; this module owns the
-// derived labels and active tree order so tabs, headers, and lists do not
-// each rebuild them differently.
+// Stream-scoped display projection for CLI controls. Display fields come from
+// the shared `buildStreamTabInfo` — the same builder the extension and desktop
+// tabs use, so one run never carries two names — and this module owns only the
+// CLI's own concerns: the active tree order, focus scope, and ancestor walks.
 
 // Local imports - shared schemas
-import type { RunIdentity, StreamTabId } from '@shared/schemas';
+import { buildStreamTabInfo } from '@controllers/session/streamTabInfo';
+import type { StreamTabId, StreamTabInfo } from '@shared/schemas';
 
 // Local imports - CLI state
 import {
-  childExecutionLabel,
   focusOrderDescendants,
+  streamMetadataFor,
   visibleSubagentRows,
   type ChildRosters,
 } from './childExecutions';
 import type { StreamSlice } from './cliState';
 
+/** The root conversation's own label — it is the session, not a tab. */
+const ROOT_STREAM_LABEL = 'main';
+
 export interface StreamView {
   readonly id: StreamTabId;
+  /** Shared tab projection: label, identity, model label, worktree, remoteness.
+   *  Absent only when no session state is bound (nothing has attached yet). */
+  readonly info?: StreamTabInfo;
   readonly label: string;
-  /** What owns the child stream, retained with the child execution. */
-  readonly identity?: RunIdentity;
   readonly parentId?: StreamTabId;
   readonly parentLabel?: string;
   readonly slice: StreamSlice | undefined;
@@ -97,63 +102,62 @@ export function nearestActiveStreamAncestor<T>(init: {
   return undefined;
 }
 
-function childStreamReferenceLabel(
-  parentStreamId: StreamTabId,
-  childRosters: ChildRosters,
-  streamId: StreamTabId,
-): string {
-  const child = visibleSubagentRows(parentStreamId, childRosters).find(
-    (entry) => entry.childStreamId === streamId,
-  );
-  return child ? childExecutionLabel(child) : streamId;
+/**
+ * The shared tab projection for one stream. Its own metadata is the identity
+ * authority; the parent's roster row is the fallback for a child whose
+ * `run.start` has not landed yet (`child.activity` can arrive first — the
+ * `roster-first` child-event order).
+ */
+function streamTabInfoFor(init: {
+  readonly childRosters: ChildRosters;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly streamId: StreamTabId;
+}): StreamTabInfo | undefined {
+  const metadata = streamMetadataFor(init.streamId);
+  if (!metadata) return undefined;
+  const parentStreamId = init.parentStream.get(init.streamId);
+  const identity =
+    metadata.identity ??
+    (parentStreamId
+      ? visibleSubagentRows(parentStreamId, init.childRosters).find(
+          (child) => child.childStreamId === init.streamId,
+        )?.identity
+      : undefined);
+  return buildStreamTabInfo({
+    streamId: init.streamId,
+    metadata: identity ? { ...metadata, identity } : metadata,
+  });
 }
 
 export function streamDisplayLabel(init: {
   readonly childRosters: ChildRosters;
-  /** Batch-resolved labels from {@link streamTreeViews}; single lookups compute on demand. */
-  readonly labels?: ReadonlyMap<StreamTabId, string>;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly streamId: StreamTabId;
-  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }): string {
-  const parentStreamId = init.parentStream.get(init.streamId);
-  if (!parentStreamId) return 'main';
-  const precomputed = init.labels?.get(init.streamId);
-  if (precomputed !== undefined) return precomputed;
-  return childStreamReferenceLabel(
-    parentStreamId,
-    init.childRosters,
-    init.streamId,
-  );
+  if (!init.parentStream.get(init.streamId)) return ROOT_STREAM_LABEL;
+  // With no session state bound (nothing has attached yet) the id is all
+  // there is to say.
+  return streamTabInfoFor(init)?.label ?? init.streamId;
 }
 
 export function streamViewForId(init: {
   readonly activeStreamId: StreamTabId | undefined;
   readonly childRosters: ChildRosters;
-  /** Batch-resolved labels from {@link streamTreeViews}; single lookups compute on demand. */
-  readonly labels?: ReadonlyMap<StreamTabId, string>;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly streamId: StreamTabId;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }): StreamView {
   const parentId = init.parentStream.get(init.streamId);
-  const rosterRow = parentId
-    ? visibleSubagentRows(parentId, init.childRosters).find(
-        (child) => child.childStreamId === init.streamId,
-      )
-    : undefined;
   return {
     id: init.streamId,
+    info: streamTabInfoFor(init),
     label: streamDisplayLabel(init),
-    identity: rosterRow?.identity,
     parentId,
     parentLabel: parentId
       ? streamDisplayLabel({
           childRosters: init.childRosters,
-          labels: init.labels,
           parentStream: init.parentStream,
           streamId: parentId,
-          streams: init.streams,
         })
       : undefined,
     slice: init.streams.get(init.streamId),
@@ -195,60 +199,15 @@ export function streamTreeEntries(
   return out;
 }
 
-/**
- * Display labels for a batch of stream ids in one pass: grouping ids by
- * parent walks each parent's roster once rather than once per child, so a
- * wide child list costs one roster scan per distinct parent per render
- * instead of one per row. A parentless id gets no entry here —
- * `streamDisplayLabel` answers 'main' for it without consulting the map.
- */
-function childStreamLabels(
-  init: Pick<StreamTreeViewInput, 'childRosters' | 'parentStream'>,
-  streamIds: readonly StreamTabId[],
-): ReadonlyMap<StreamTabId, string> {
-  const idsByParent = new Map<StreamTabId, StreamTabId[]>();
-  for (const streamId of streamIds) {
-    const parentStreamId = init.parentStream.get(streamId);
-    if (!parentStreamId) continue;
-    const bucket = idsByParent.get(parentStreamId);
-    if (bucket) bucket.push(streamId);
-    else idsByParent.set(parentStreamId, [streamId]);
-  }
-  const labels = new Map<StreamTabId, string>();
-  for (const [parentStreamId, ids] of idsByParent) {
-    const unresolved = new Set(ids);
-    for (const child of visibleSubagentRows(
-      parentStreamId,
-      init.childRosters,
-    )) {
-      if (unresolved.delete(child.childStreamId)) {
-        labels.set(child.childStreamId, childExecutionLabel(child));
-      }
-    }
-    // Not on the parent's roster: the same fallback childStreamReferenceLabel
-    // uses when its find misses.
-    for (const streamId of unresolved) labels.set(streamId, streamId);
-  }
-  return labels;
-}
-
 export function streamTreeViews(
   init: StreamTreeViewInput,
 ): readonly StreamView[] {
   const ordered = streamTreeEntries(init);
   if (ordered.length < 2) return [];
-  // Resolve every row's label in one pass: per-row resolution searches the
-  // parent's roster, so looking it up per row (and again per parent label)
-  // costs one roster scan per child per render.
-  const labels = childStreamLabels(
-    init,
-    ordered.map((entry) => entry.id),
-  );
   return ordered.map((entry) =>
     streamViewForId({
       activeStreamId: init.activeStreamId,
       childRosters: init.childRosters,
-      labels,
       parentStream: init.parentStream,
       streamId: entry.id,
       streams: init.streams,

--- a/packages/cli/src/runtime/cliPresentationHost.ts
+++ b/packages/cli/src/runtime/cliPresentationHost.ts
@@ -5,7 +5,7 @@ import {
   type PresentationEventHandlers,
   type RuntimePresentationEvent,
   type RuntimePresentationEventPayloads,
-  type SessionEventHub,
+  type SessionHandle,
 } from '@agent/runtime';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 import type { ApprovalBypassKind } from '@shared/approvalBypassKind';
@@ -31,7 +31,7 @@ export interface CliRuntimeHost {
     event: K,
     payload: RuntimePresentationEventPayloads[K],
   ): boolean;
-  attachRunProgressRenderer(events: SessionEventHub): () => void;
+  attachRunProgressRenderer(session: SessionHandle): () => void;
   prepareInteractivePrompt?: () => void;
   emitApprovalBypassState(update: HostApprovalBypassStateUpdate): void;
   close(): Promise<void>;
@@ -158,8 +158,8 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
     };
 
   return {
-    attachRunProgressRenderer: (events) =>
-      attachRunProgressRenderer(events, runProgress),
+    attachRunProgressRenderer: (session) =>
+      attachRunProgressRenderer(session, runProgress),
     prepareInteractivePrompt: () => runProgress?.preserve(),
     emitApprovalBypassState({ streamId, kind, bypassActive }) {
       if (closed || context.outputFormat !== 'ndjson') return;

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -259,9 +259,8 @@ export async function executeCliRequest(
   let failurePresented = false;
   const renderWorkflowPlainProgress =
     runContext.outputFormat === 'text' && runContext.renderRunProgress === true;
-  const detachRunProgressRenderer = presentationHost.attachRunProgressRenderer(
-    session.events,
-  );
+  const detachRunProgressRenderer =
+    presentationHost.attachRunProgressRenderer(session);
   const detachHostInteractions = session.useHostInteractions(
     createHeadlessCliHostInteractions(runContext, {
       beforePrompt: () => presentationHost.prepareInteractivePrompt?.(),

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -3,29 +3,37 @@ import path from 'node:path';
 
 // Local imports
 import { getAgent } from '@agent/index';
-import { RUN_FACT_EVENT_TYPES, type AgentEvent } from '@agent/trace';
+import { RUN_FACT_EVENT_TYPES } from '@agent/trace';
+import type { AgentConfig, SessionHandle } from '@agent/runtime';
+import { SessionFactApplier } from '@controllers/session/SessionFactApplier';
 import type {
-  AgentConfig,
-  SessionEvent,
-  SessionEventHub,
-  SessionFact,
-} from '@agent/runtime';
+  PresentedStreamId,
+  SessionRendererPort,
+  SessionRenderSlice,
+} from '@controllers/session/SessionRendererPort';
+import {
+  SessionState,
+  type StreamBadgeSnapshot,
+} from '@controllers/session/SessionState';
 import { redactSecrets } from '@logger/redaction';
 import type {
   ActiveChildInfo,
   ConversationProgress,
-  RoundStage,
+  GoalStatus,
+  InquiryThreadUpdatedEvent,
+  Plan,
   StreamPhase,
+  StreamStage,
   StreamTabId,
+  TodoItem,
+  TokenUsageStats,
 } from '@shared/schemas';
 import { AgentCategory, STREAM_PHASE } from '@shared/schemas';
-import { roundStageFromStageStart } from '@shared/streams/stage';
 import { isTerminalOutcomePhase } from '@shared/streams/streamStatus';
 import {
   formatRoundStageLabel,
   formatStreamStatusLabel,
 } from '@shared/streams/streamStatusDisplay';
-import { assertNever } from '@utils/core';
 import { pluralize } from '@utils/text/stringUtils';
 
 // Local file imports
@@ -37,44 +45,17 @@ import {
 import { getStderrColumns, writeRawStderr } from './logSinks';
 import type { CliContext } from './cliContext';
 
-// A deliberate sub-vocabulary of the canonical CLI-projection run-fact list
-// (`RUN_FACT_EVENT_TYPES`): only the facts that feed the live status line are
-// admitted, and the `satisfies` check pins the subset against that single
-// source so it cannot drift to a fact the canonical list does not project.
-const RUN_PROGRESS_RUN_FACT_TYPES = [
-  'conversation.progress',
-  'run.config',
-  'stage.start',
-  'child.activity',
-] as const satisfies ReadonlyArray<(typeof RUN_FACT_EVENT_TYPES)[number]>;
-
-/** The run-fact vocabulary this renderer's subscription filter admits. */
-type RunProgressRunFactEvent = Extract<
-  AgentEvent,
-  { type: (typeof RUN_PROGRESS_RUN_FACT_TYPES)[number] }
->;
-
 // Carriage return + erase-line (CSI 2K): rewind to column 0 and clear the row
 // so the single live status line can be repainted in place.
 const CLEAR_LINE = '\r\x1b[2K';
 const ACTIVE_CHILD_DESCRIPTION_MAX_LENGTH = 48;
 
-interface RenderState {
-  round?: number;
-  plannedRounds?: number;
-  toolCallCount?: number;
-  agent?: string;
-  inputLabel?: string;
-  phase?: string;
-}
-
 export interface RunProgressRenderer {
   /**
-   * Takes session facts and the run facts named by
-   * `RUN_PROGRESS_RUN_FACT_TYPES` only; any other run fact is out of contract
-   * and throws rather than being dropped.
+   * Fold this session's facts into the shared `SessionState` and repaint from
+   * it. Returns the detach handle.
    */
-  handleSessionEvent(event: SessionEvent): void;
+  attach(session: SessionHandle): () => void;
   clear(): void;
   preserve(): void;
 }
@@ -121,29 +102,28 @@ export function createRunProgressRenderer(
 }
 
 export function attachRunProgressRenderer(
-  events: SessionEventHub,
+  session: SessionHandle,
   renderer: RunProgressRenderer | undefined,
 ): () => void {
-  if (!renderer) return () => undefined;
+  return renderer ? renderer.attach(session) : () => undefined;
+}
 
-  const handleEvent = (event: SessionEvent): void =>
-    renderer.handleSessionEvent(event);
-  const detachSessionFacts = events.subscribe(handleEvent, {
-    scope: 'session',
-  });
-  const detachRunFacts = events.subscribe(handleEvent, {
-    scope: 'run',
-    types: RUN_PROGRESS_RUN_FACT_TYPES,
-  });
-
-  return () => {
-    detachRunFacts();
-    detachSessionFacts();
-  };
+/**
+ * Everything the live line needs that no shared record carries: the run's
+ * `AgentConfig` never lands on `SessionState` (the summary mirror keeps only
+ * model / working directory / command), so the agent name, the input-file
+ * label and the workflow's declared round count are read from the fact and
+ * held here. Round index, tool calls, child roster and child descriptions all
+ * come from `SessionState` at paint time instead.
+ */
+interface RootRunConfigState {
+  plannedRounds?: number;
+  agent?: string;
+  inputLabel?: string;
 }
 
 class DefaultRunProgressRenderer implements RunProgressRenderer {
-  private readonly state: RenderState = {};
+  private readonly config: RootRunConfigState = {};
   private readonly startedAt: number;
   private readonly write: (text: string) => void;
   private readonly nowMs: () => number;
@@ -156,11 +136,17 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   private lastRenderAt = 0;
   private lastLine = '';
   private liveLine = false;
+  private state: SessionState | undefined;
   private rootStreamId: StreamTabId | undefined;
   private rootStreamStatus: StreamPhase | undefined;
-  private activeChildren: readonly ActiveChildInfo[] = [];
-  private readonly childDescriptions = new Map<StreamTabId, string>();
-  private readonly closedChildStreamIds = new Set<StreamTabId>();
+  /**
+   * Last-write-wins subject line for the root stream: a status transition
+   * writes its label, a description fact replaces it with the run's own
+   * one-liner, and the next transition takes it back. Ordering is the whole
+   * semantic, so it stays a written field rather than a read of the two
+   * shared sources.
+   */
+  private rootPhaseText: string | undefined;
   private heartbeatTimer: ReturnType<typeof setInterval> | undefined;
 
   /** Derived from the one status field, never mirrored into a second flag. */
@@ -180,14 +166,35 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     this.startedAt = this.nowMs();
   }
 
-  handleSessionEvent(event: SessionEvent): void {
-    if (event.scope === 'session') {
-      this.handleSessionFact(event.event);
-      return;
-    }
-    // Narrowed by `attachRunProgressRenderer`'s filter, which admits only
-    // `RUN_PROGRESS_RUN_FACT_TYPES`.
-    this.handleRunFact(event.streamId, event.event as RunProgressRunFactEvent);
+  attach(session: SessionHandle): () => void {
+    const state = new SessionState(session);
+    this.state = state;
+    const applier = new SessionFactApplier(state, new HeadlessPort(this), {
+      // Headless owns no durable deletion: reporting nothing keeps the
+      // removal barrier, which is exactly what the live line wants — a
+      // removed child drops out of the roster it reads.
+      deleteStream: () => undefined,
+    });
+    const detachSessionFacts = session.events.subscribeSessionFacts((fact) =>
+      applier.handleSessionFact(fact),
+    );
+    const detachRunFacts = session.events.subscribeRunFacts(
+      (runFact) => {
+        // The run's `AgentConfig` is the one payload the shared state does not
+        // retain; take it before handing the fact to the applier.
+        if (runFact.event.type === 'run.config') {
+          this.applyRunConfig(runFact.event.streamId, runFact.event.config);
+        }
+        applier.handleRunFact(runFact.streamId, runFact.event);
+      },
+      { types: RUN_FACT_EVENT_TYPES },
+    );
+    return () => {
+      detachRunFacts();
+      detachSessionFacts();
+      applier.dispose();
+      this.state = undefined;
+    };
   }
 
   clear(): void {
@@ -206,188 +213,51 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     }
   }
 
-  private handleSessionFact(event: SessionFact): void {
-    switch (event.type) {
-      case 'status':
-        this.applyStatus(event.streamId, event.phase);
-        return;
-      case 'updateStreamDescription':
-        if (!this.rootStreamTerminal) {
-          this.applyStreamDescription(
-            event.payload.streamId,
-            event.payload.description,
-          );
-        }
-        return;
-      case 'goalStateChanged':
-      case 'inquiryThreadUpdated':
-      case 'clearMissingOutputs':
-      case 'updateQueuedFollowUps':
-      case 'setActiveStream':
-      case 'setParentStream':
-        return;
-      case 'followUpSent':
-        if (this.rootStreamTerminal) return;
-        if (!this.isRootStream(event.payload.streamId)) {
-          // The session fact is the first authoritative boundary between child
-          // turns. Clear before a status-driven roster repaint can reuse the
-          // previous turn's task label.
-          this.deleteChildDescription(event.payload.streamId);
-        }
-        return;
-      case 'removeStream':
-        if (this.rootStreamTerminal) return;
-        this.closedChildStreamIds.add(event.payload.streamId);
-        this.deleteChildDescription(event.payload.streamId);
-        return;
-    }
-    assertNever(event, 'Unhandled run-progress renderer session fact');
+  /**
+   * Repaint after a fact the applier has already landed on `SessionState`.
+   * The first stream to report progress claims the root slot, exactly as the
+   * first `run.config` does — a headless run renders one stream's line.
+   */
+  refreshFor(streamId: StreamTabId, force = false): void {
+    if (!this.claimRootStream(streamId) || this.rootStreamTerminal) return;
+    this.updateHeartbeat();
+    this.render(force);
   }
 
-  private handleRunFact(
-    streamId: StreamTabId,
-    event: RunProgressRunFactEvent,
-  ): void {
-    switch (event.type) {
-      case 'run.config':
-        if (this.rootStreamId && !this.isRootStream(event.streamId)) {
-          // Only a closed deterministic child ID begins a new incarnation.
-          // Active children also emit run.config when switching models.
-          if (this.closedChildStreamIds.delete(event.streamId)) {
-            this.childDescriptions.delete(event.streamId);
-          }
-          return;
-        }
-        if (this.applyRunConfig(event.streamId, event.config)) {
-          this.updateHeartbeat();
-          this.render(true);
-        }
-        return;
-      case 'conversation.progress':
-        if (this.rootStreamTerminal) return;
-        if (this.applyConversationProgress(streamId, event.progress)) {
-          this.updateHeartbeat();
-          this.render();
-        }
-        return;
-      case 'stage.start': {
-        if (this.rootStreamTerminal) return;
-        const roundStage = roundStageFromStageStart(event);
-        if (roundStage && this.applyRoundStage(streamId, roundStage)) {
-          this.updateHeartbeat();
-          this.render();
-        }
-        return;
-      }
-      case 'child.activity':
-        if (this.rootStreamTerminal) return;
-        this.applyActiveSubagents(event.parentStreamId, event.items);
-        this.updateHeartbeat();
-        this.render(true);
-        return;
-    }
-    assertNever(event, 'Unhandled run-progress renderer run fact');
-  }
-
-  private applyRunConfig(streamId: StreamTabId, config: AgentConfig): boolean {
-    if (!this.claimRootStream(streamId)) return false;
-
-    this.state.agent = config.agent;
-    this.state.inputLabel = formatInputLabel(config.inputFiles);
-    this.state.plannedRounds =
-      config.agentCategory === AgentCategory.Workflow
-        ? getAgent(config.agent, AgentCategory.Workflow)?.rounds
-        : undefined;
-    this.state.phase ??= 'running';
-    return true;
-  }
-
-  private applyConversationProgress(
-    streamId: StreamTabId,
-    progress: ConversationProgress,
-  ): boolean {
-    if (!this.claimRootStream(streamId)) return false;
-
-    this.state.toolCallCount = progress.toolCallCount || undefined;
-    this.state.phase ??= 'running';
-    return true;
-  }
-
-  private applyRoundStage(
-    streamId: StreamTabId,
-    roundStage: RoundStage,
-  ): boolean {
-    if (!this.claimRootStream(streamId)) return false;
-
-    this.state.round = roundStage.index + 1;
-    if (roundStage.total !== undefined) {
-      this.state.plannedRounds = roundStage.total;
-    }
-    this.state.phase ??= 'running';
-    return true;
-  }
-
-  private applyActiveSubagents(
-    parentStreamId: StreamTabId,
-    children: readonly ActiveChildInfo[],
-  ): void {
-    if (!this.claimRootStream(parentStreamId)) return;
-
-    this.activeChildren = children;
-  }
-
-  private applyStatus(streamId: StreamTabId, status: StreamPhase): void {
-    if (!this.isRootStream(streamId)) {
-      if (this.rootStreamTerminal) return;
-      if (isTerminalOutcomePhase(status)) {
-        this.closedChildStreamIds.add(streamId);
-        this.deleteChildDescription(streamId);
-      }
-      return;
-    }
+  applyStatus(streamId: StreamTabId, status: StreamPhase | undefined): void {
+    if (status === undefined || !this.isRootStream(streamId)) return;
     if (this.rootStreamStatus === status) return;
 
     this.rootStreamStatus = status;
-    this.state.phase = formatStreamStatusLabel(status, { style: 'cli' });
-    if (this.rootStreamTerminal) {
-      this.activeChildren = [];
-      this.childDescriptions.clear();
-      this.closedChildStreamIds.clear();
-    }
+    this.rootPhaseText = formatStreamStatusLabel(status, { style: 'cli' });
     this.updateHeartbeat();
     this.render(true);
   }
 
-  private deleteChildDescription(streamId: StreamTabId): void {
-    if (!this.childDescriptions.delete(streamId)) return;
+  applyStreamDescription(streamId: StreamTabId, description: string): void {
     if (this.rootStreamTerminal) return;
-    if (
-      !this.activeChildren.some((child) => child.childStreamId === streamId)
+    if (this.isRootStream(streamId)) {
+      this.rootPhaseText = description;
+    } else if (
+      !this.liveChildren().some((child) => child.childStreamId === streamId)
     ) {
+      // A stream the live line does not name has nothing to repaint for.
       return;
     }
     this.updateHeartbeat();
     this.render(true);
   }
 
-  private applyStreamDescription(
-    streamId: StreamTabId,
-    description: string,
-  ): void {
-    if (!this.isRootStream(streamId)) {
-      if (this.closedChildStreamIds.has(streamId)) return;
-      this.childDescriptions.set(streamId, description);
-      if (
-        !this.activeChildren.some((child) => child.childStreamId === streamId)
-      ) {
-        return;
-      }
-      this.updateHeartbeat();
-      this.render(true);
-      return;
-    }
+  private applyRunConfig(streamId: StreamTabId, config: AgentConfig): void {
+    if (!this.claimRootStream(streamId)) return;
 
-    this.state.phase = description;
+    this.config.agent = config.agent;
+    this.config.inputLabel = formatInputLabel(config.inputFiles);
+    this.config.plannedRounds =
+      config.agentCategory === AgentCategory.Workflow
+        ? getAgent(config.agent, AgentCategory.Workflow)?.rounds
+        : undefined;
+    this.rootPhaseText ??= 'running';
     this.updateHeartbeat();
     this.render(true);
   }
@@ -397,8 +267,19 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     return this.rootStreamId === streamId;
   }
 
-  private isRootStream(streamId: StreamTabId): boolean {
+  isRootStream(streamId: StreamTabId): boolean {
     return this.rootStreamId === streamId;
+  }
+
+  /** Live (not yet retired) children of the root run, from the shared roster. */
+  private liveChildren(): readonly ActiveChildInfo[] {
+    if (this.rootStreamTerminal || !this.rootStreamId) return [];
+    const roster = this.state?.getStreamState(this.rootStreamId)?.subagents;
+    return roster?.filter((child) => child.finishedAt === undefined) ?? [];
+  }
+
+  private childDescription(streamId: StreamTabId): string | undefined {
+    return this.state?.getStreamMetadata(streamId).description;
   }
 
   private render(force = false): void {
@@ -438,49 +319,50 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   }
 
   private formatLine(now: number): string {
+    const rootStreamId = this.rootStreamId;
+    const execution = rootStreamId
+      ? this.state?.getStreamState(rootStreamId)
+      : undefined;
+    const roundStage =
+      execution?.stage?.kind === 'round' ? execution.stage : undefined;
+    const plannedRounds = roundStage?.total ?? this.config.plannedRounds;
+
     const parts: string[] = [];
-    if (this.state.round != null) {
-      const plannedRounds = this.state.plannedRounds;
+    if (roundStage) {
       parts.push(
         `[${formatRoundStageLabel({
-          index: this.state.round - 1,
+          index: roundStage.index,
           ...(isMultiRound(plannedRounds) ? { total: plannedRounds } : {}),
         })}]`,
       );
     }
 
-    const subject = [this.state.agent, this.state.inputLabel]
+    const subject = [this.config.agent, this.config.inputLabel]
       .filter(Boolean)
       .join(' ');
-    const phase = this.state.phase;
+    const phase = this.rootPhaseText;
     parts.push(subject || phase || 'running');
     if (subject && phase && phase !== 'running') parts.push(phase);
-    if (this.state.round == null && isMultiRound(this.state.plannedRounds)) {
-      parts.push(`${this.state.plannedRounds} rounds`);
+    if (!roundStage && isMultiRound(plannedRounds)) {
+      parts.push(`${plannedRounds} rounds`);
     }
 
     const elapsed = formatElapsed(now - this.startedAt);
-    const nameOnlySubagents = formatActiveChildren(
-      this.activeChildren,
-      this.childDescriptions,
-      0,
-    );
+    const children = this.liveChildren();
+    const describe = (child: ActiveChildInfo): string | undefined =>
+      this.childDescription(child.childStreamId);
+    const nameOnlySubagents = formatActiveChildren(children, describe, 0);
     if (nameOnlySubagents) {
       const descriptionColumns = this.descriptionColumnBudget(
         parts,
         nameOnlySubagents,
         elapsed,
       );
-      parts.push(
-        formatActiveChildren(
-          this.activeChildren,
-          this.childDescriptions,
-          descriptionColumns,
-        )!,
-      );
+      parts.push(formatActiveChildren(children, describe, descriptionColumns)!);
     }
-    if (this.state.toolCallCount != null && !nameOnlySubagents) {
-      parts.push(`tools: ${this.state.toolCallCount}`);
+    const toolCallCount = execution?.conversationProgress.toolCallCount;
+    if (toolCallCount && !nameOnlySubagents) {
+      parts.push(`tools: ${toolCallCount}`);
     }
     parts.push(elapsed);
     return parts.join(' · ');
@@ -512,6 +394,89 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   }
 }
 
+/**
+ * The headless host's `SessionRendererPort`. Every fact is already folded into
+ * `SessionState` by the time these fire, so each one only decides whether the
+ * single live stderr line is worth repainting — the two exceptions are the
+ * root stream's phase and description, which are last-write-wins ordering the
+ * shared record does not encode.
+ */
+class HeadlessPort implements SessionRendererPort {
+  constructor(private readonly renderer: DefaultRunProgressRenderer) {}
+
+  isAvailable(): boolean {
+    return true;
+  }
+
+  dispose(): void {}
+
+  invalidate(_streamId: StreamTabId, _slice: SessionRenderSlice): void {}
+
+  onStreamMetadataChanged(
+    streamId: StreamTabId,
+    options?: Parameters<SessionRendererPort['onStreamMetadataChanged']>[1],
+  ): void {
+    // A new stream and a new RUNNING transition report their phase here
+    // instead of through `onStreamStatusChanged`.
+    this.renderer.applyStatus(
+      streamId,
+      options?.streamStates?.get(streamId)?.phase,
+    );
+  }
+
+  onStreamStatusChanged(streamId: StreamTabId, status: StreamPhase): void {
+    this.renderer.applyStatus(streamId, status);
+  }
+
+  onActiveStreamChanged(_streamId: PresentedStreamId): void {}
+
+  onStreamDescriptionChanged(streamId: StreamTabId, description: string): void {
+    this.renderer.applyStreamDescription(streamId, description);
+  }
+
+  onConversationProgressChanged(
+    streamId: StreamTabId,
+    _progress: ConversationProgress,
+  ): void {
+    this.renderer.refreshFor(streamId);
+  }
+
+  onStageChanged(streamId: StreamTabId, _stage: StreamStage): void {
+    this.renderer.refreshFor(streamId);
+  }
+
+  onBadgesChanged(streamId: StreamTabId, _badges: StreamBadgeSnapshot): void {
+    this.renderer.refreshFor(streamId, true);
+  }
+
+  onMissingOutputsChanged(_streamId: StreamTabId): void {}
+
+  onRunUsageChanged(
+    _streamId: StreamTabId,
+    _storageKey: string,
+    _usage: TokenUsageStats,
+  ): void {}
+
+  onTodosChanged(_streamId: StreamTabId, _todos: TodoItem[]): void {}
+
+  onPlanChanged(_streamId: StreamTabId, _plan: Plan | null): void {}
+
+  onInquiryThreadUpdated(_thread: InquiryThreadUpdatedEvent): void {}
+
+  onGoalActiveChanged(
+    _streamId: StreamTabId,
+    _active: boolean,
+    _details?: { status?: GoalStatus; objective?: string },
+  ): void {}
+
+  clearPendingConversationProgress(_streamId: StreamTabId): void {}
+
+  syncStreamContent(
+    _stream: PresentedStreamId,
+    _options?: { includeActiveState?: boolean },
+  ): void {}
+}
+
 function formatInputLabel(files: readonly string[]): string | undefined {
   const first = files.at(0);
   if (!first) return undefined;
@@ -522,7 +487,7 @@ function formatInputLabel(files: readonly string[]): string | undefined {
 
 function formatActiveChildren(
   children: readonly ActiveChildInfo[],
-  descriptions: ReadonlyMap<StreamTabId, string>,
+  describe: (child: ActiveChildInfo) => string | undefined,
   descriptionColumns: number,
 ): string | undefined {
   const namedChildren = children.filter((child) => child.agentName.length > 0);
@@ -534,7 +499,7 @@ function formatActiveChildren(
   const label = pluralize(namedChildren.length, 'subagent');
   const suffix =
     namedChildren.length > 1 ? ` +${namedChildren.length - 1}` : '';
-  const description = descriptions.get(first.childStreamId);
+  const description = describe(first);
   const safeDescription =
     description && descriptionColumns > 0
       ? truncateSummaryToWidth(

--- a/src/controllers/progressView/backend/LitSessionRenderer.ts
+++ b/src/controllers/progressView/backend/LitSessionRenderer.ts
@@ -8,6 +8,7 @@ import {
 import type {
   PresentedStreamId,
   SessionRendererPort,
+  SessionRenderSlice,
 } from '@controllers/session/SessionRendererPort';
 import type {
   SessionState,
@@ -38,6 +39,7 @@ import type {
 import { buildStreamContentRender } from '@shared/streams/streamContentSync';
 import { buildStreamMetadata } from '@shared/streams/streamMetadata';
 import {
+  assertNever,
   createFlushableDebounce,
   mapToRecord,
   type FlushableDebounce,
@@ -146,13 +148,47 @@ export class LitSessionRenderer implements SessionRendererPort {
     });
   }
 
-  onParentStreamChanged(
-    childStreamId: StreamTabId,
-    _parentStreamId: StreamTabId | null,
-  ): void {
-    // Parent edge rides `StreamTabInfo.parentStreamId` on the metadata wire.
-    if (!this.isAvailable()) return;
-    this.updateStreamMetadata(childStreamId);
+  invalidate(streamId: StreamTabId, slice: SessionRenderSlice): void {
+    switch (slice) {
+      case 'files':
+        return this.sendIfActive(streamId, () =>
+          this.sendMessage({
+            command: PROGRESS_VIEW_COMMANDS.UPDATE_FILES,
+            stream: streamId,
+            rounds: nonEmptyRounds(
+              this.state.snapshots.getOutputFiles(streamId),
+            ),
+          }),
+        );
+      case 'compileFailures':
+        return this.sendIfActive(streamId, () =>
+          this.sendMessage({
+            command: PROGRESS_VIEW_COMMANDS.UPDATE_COMPILE_FAILURES,
+            stream: streamId,
+            rounds: nonEmptyRounds(
+              this.state.snapshots.getCompileFailures(streamId),
+            ),
+            reset: true,
+          }),
+        );
+      case 'queuedFollowUps':
+        return this.sendIfActive(streamId, () =>
+          this.sendMessage({
+            command: PROGRESS_VIEW_COMMANDS.UPDATE_QUEUED_FOLLOW_UPS,
+            stream: streamId,
+            messages: this.state.followUps.getAll(streamId),
+          }),
+        );
+      case 'parentStreamId':
+        // Parent edge rides `StreamTabInfo.parentStreamId` on the metadata wire.
+        if (!this.isAvailable()) return;
+        return this.updateStreamMetadata(streamId);
+      case 'goalPaused':
+        // Lit surfaces pause via the goal chip (`goalStateChanged`); no
+        // transcript notice, unlike the TUI.
+        return;
+    }
+    assertNever(slice, 'Unhandled session render slice');
   }
 
   onConversationProgressChanged(
@@ -202,16 +238,6 @@ export class LitSessionRenderer implements SessionRendererPort {
     });
   }
 
-  onFilesChanged(streamId: StreamTabId): void {
-    this.sendIfActive(streamId, () =>
-      this.sendMessage({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_FILES,
-        stream: streamId,
-        rounds: nonEmptyRounds(this.state.snapshots.getOutputFiles(streamId)),
-      }),
-    );
-  }
-
   onMissingOutputsChanged(
     streamId: StreamTabId,
     options?: { reset?: boolean },
@@ -233,19 +259,6 @@ export class LitSessionRenderer implements SessionRendererPort {
         ),
       });
     });
-  }
-
-  onCompileFailuresChanged(streamId: StreamTabId): void {
-    this.sendIfActive(streamId, () =>
-      this.sendMessage({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_COMPILE_FAILURES,
-        stream: streamId,
-        rounds: nonEmptyRounds(
-          this.state.snapshots.getCompileFailures(streamId),
-        ),
-        reset: true,
-      }),
-    );
   }
 
   onRunUsageChanged(
@@ -286,16 +299,6 @@ export class LitSessionRenderer implements SessionRendererPort {
     });
   }
 
-  onQueuedFollowUpsChanged(streamId: StreamTabId): void {
-    this.sendIfActive(streamId, () => {
-      this.sendMessage({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_QUEUED_FOLLOW_UPS,
-        stream: streamId,
-        messages: this.state.followUps.getAll(streamId),
-      });
-    });
-  }
-
   onInquiryThreadUpdated(thread: InquiryThreadUpdatedEvent): void {
     this.sendMessage({
       command: PROGRESS_VIEW_COMMANDS.UPDATE_INQUIRY_THREAD,
@@ -315,10 +318,6 @@ export class LitSessionRenderer implements SessionRendererPort {
       ...(details?.status ? { status: details.status } : {}),
       ...(details?.objective ? { objective: details.objective } : {}),
     });
-  }
-
-  onGoalPaused(_streamId: StreamTabId): void {
-    // Lit surfaces pause via the goal chip (`goalStateChanged`); no transcript.
   }
 
   syncStreamContent(

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -178,13 +178,13 @@ export class SessionFactApplier {
     updatePlan: (_streamId, event) =>
       this.renderer.onPlanChanged(event.streamId, event.plan),
     addOutputFiles: (_streamId, event) =>
-      this.renderer.onFilesChanged(event.streamId),
+      this.renderer.invalidate(event.streamId, 'files'),
     updateMissingOutputs: (_streamId, event) =>
       this.renderer.onMissingOutputsChanged(event.streamId),
     updateCompileFailures: (_streamId, event) =>
-      this.renderer.onCompileFailuresChanged(event.streamId),
+      this.renderer.invalidate(event.streamId, 'compileFailures'),
     goalPaused: (_streamId, event) =>
-      this.renderer.onGoalPaused(event.streamId),
+      this.renderer.invalidate(event.streamId, 'goalPaused'),
     'conversation.progress': (streamId, event) =>
       this.handleUpdateConversationProgress({
         streamId,
@@ -320,8 +320,9 @@ export class SessionFactApplier {
           // queue may have changed.
           case 'updateQueuedFollowUps':
           case 'followUpSent':
-            return this.renderer.onQueuedFollowUpsChanged(
+            return this.renderer.invalidate(
               fact.payload.streamId,
+              'queuedFollowUps',
             );
           case 'setActiveStream':
             return this.handleSetActiveStream(fact.payload);
@@ -589,11 +590,12 @@ export class SessionFactApplier {
     parentStreamId,
   }: SetParentStreamPayload): void {
     this.state.setStreamParent(childStreamId, parentStreamId);
-    // Topology hosts (TUI) and Lit both learn the edge here. Lit projects it
-    // onto `StreamTabInfo.parentStreamId` inside its renderer; do not also
-    // fire `onStreamMetadataChanged` — that mint a StreamSlice on signal
-    // hosts before attachment.
-    this.renderer.onParentStreamChanged(childStreamId, parentStreamId ?? null);
+    // Topology hosts (TUI) and Lit both learn the edge here — the new value is
+    // already on `SessionState` metadata, so the notification only names the
+    // slice. Lit projects it onto `StreamTabInfo.parentStreamId` inside its
+    // renderer; do not also fire `onStreamMetadataChanged` — that mints a
+    // StreamSlice on signal hosts before attachment.
+    this.renderer.invalidate(childStreamId, 'parentStreamId');
   }
 
   private handleSetActiveStream(payload: SetActiveStreamPayload): void {

--- a/src/controllers/session/SessionRendererPort.ts
+++ b/src/controllers/session/SessionRendererPort.ts
@@ -17,6 +17,22 @@ import type {
 export type PresentedStreamId = StreamTabId | '';
 
 /**
+ * A projection slice whose new value the host re-reads from the shared state
+ * rather than receiving on the wire. Each key names the field the host reads
+ * (`outputs.files`, `outputs.compileFailures`, `workPlan.queuedFollowUps`,
+ * `SessionStreamMetadata.parentStreamId`) or the fact it reacts to
+ * (`goalPaused`); nothing here is new vocabulary. Slices whose notification
+ * carries real delta semantics — `onMissingOutputsChanged`'s `reset`,
+ * `onStageChanged`'s phase-vs-round split — keep their own method.
+ */
+export type SessionRenderSlice =
+  | 'files'
+  | 'compileFailures'
+  | 'queuedFollowUps'
+  | 'parentStreamId'
+  | 'goalPaused';
+
+/**
  * Host-renderer notifications from {@link SessionFactApplier}.
  *
  * The shared applier owns fact→state and calls these after mutations. Each host
@@ -27,6 +43,14 @@ export interface SessionRendererPort {
   isAvailable(): boolean;
 
   dispose(): void;
+
+  /**
+   * A payload-free change on one {@link SessionRenderSlice}: the applier has
+   * already landed it on `SessionState`, so the host re-reads the slice it
+   * projects. One method instead of a notification per field — the payload was
+   * never on the wire, only the field name was.
+   */
+  invalidate(streamId: StreamTabId, slice: SessionRenderSlice): void;
 
   onStreamMetadataChanged(
     streamId: StreamTabId,
@@ -48,12 +72,6 @@ export interface SessionRendererPort {
 
   onStreamDescriptionChanged(streamId: StreamTabId, description: string): void;
 
-  /** Explicit parent-edge fact (`setParentStream`). */
-  onParentStreamChanged(
-    childStreamId: StreamTabId,
-    parentStreamId: StreamTabId | null,
-  ): void;
-
   onConversationProgressChanged(
     streamId: StreamTabId,
     progress: ConversationProgress,
@@ -67,14 +85,13 @@ export interface SessionRendererPort {
 
   onBadgesChanged(streamId: StreamTabId, badges: StreamBadgeSnapshot): void;
 
-  onFilesChanged(streamId: StreamTabId): void;
-
+  /** Delta-semantic: `reset` clears the stream's rounds instead of replacing
+   *  them, so this one keeps its own envelope rather than folding into
+   *  {@link SessionRendererPort.invalidate}. */
   onMissingOutputsChanged(
     streamId: StreamTabId,
     options?: { reset?: boolean },
   ): void;
-
-  onCompileFailuresChanged(streamId: StreamTabId): void;
 
   onRunUsageChanged(
     streamId: StreamTabId,
@@ -86,8 +103,6 @@ export interface SessionRendererPort {
 
   onPlanChanged(streamId: StreamTabId, plan: Plan | null): void;
 
-  onQueuedFollowUpsChanged(streamId: StreamTabId): void;
-
   onInquiryThreadUpdated(thread: InquiryThreadUpdatedEvent): void;
 
   onGoalActiveChanged(
@@ -95,9 +110,6 @@ export interface SessionRendererPort {
     active: boolean,
     details?: { status?: GoalStatus; objective?: string },
   ): void;
-
-  /** Auto-paused goal — TUI surfaces a transcript notice; Lit no-ops. */
-  onGoalPaused(streamId: StreamTabId): void;
 
   /** Drop buffered conversation-progress pushes for a stream (new RUNNING). */
   clearPendingConversationProgress(streamId: StreamTabId): void;

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.ts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.ts
@@ -13,6 +13,7 @@ import { pickGlobalArgs } from '@cli/runtime/globalArgs';
 import {
   createRunProgressRenderer,
   shouldRenderRunProgress,
+  type RunProgressRenderer,
   type RunProgressRendererInit,
 } from '@cli/runtime/runProgressRenderer';
 import { createCliRuntimeHost } from '@cli/runtime/cliPresentationHost';
@@ -32,6 +33,7 @@ import {
 } from '@shared/schemas';
 import { STREAM_TRANSITION_CAUSE } from '@shared/streams/streamStatus';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
+import { createTestSession } from '@test/support/sessionTestUtils';
 
 const mocks = vi.hoisted(() => ({
   getAgent: vi.fn(),
@@ -120,10 +122,21 @@ const RUNTIME_PRESENTATION_NDJSON_CASES = {
 } satisfies RuntimePresentationNdjsonCases;
 
 // context() always sets renderRunProgress: true, so the factory never
-// returns undefined inside these helpers.
-type TestRunProgressRenderer = NonNullable<
-  ReturnType<typeof createRunProgressRenderer>
->;
+// returns undefined inside these helpers. Facts reach the renderer the way
+// they do in production — through the session hub the applier subscribes to.
+type TestRunProgressRenderer = RunProgressRenderer & {
+  emit(event: SessionEvent): void;
+  detach(): void;
+};
+
+function attached(renderer: RunProgressRenderer): TestRunProgressRenderer {
+  const session = createTestSession();
+  const detach = renderer.attach(session);
+  return Object.assign(renderer, {
+    emit: (event: SessionEvent) => session.events.emit(event),
+    detach,
+  });
+}
 
 type RunConfigOverrides = {
   streamId?: string;
@@ -178,11 +191,22 @@ function subagentChild(
   };
 }
 
+/**
+ * A run reaches the renderer the way a live one does: `run.config` first, then
+ * the RUNNING transition. The transition is what mints the shared execution
+ * state that later progress, stage and roster facts land on.
+ */
 function handleRunConfig(
   renderer: TestRunProgressRenderer,
   overrides: RunConfigOverrides = {},
 ): void {
-  renderer.handleSessionEvent(runConfigEvent(overrides));
+  renderer.emit(runConfigEvent(overrides));
+  handleStreamStatus(
+    renderer,
+    overrides.streamId ?? 'stream-1',
+    STREAM_PHASE.RUNNING,
+    STREAM_PHASE.WAITING,
+  );
 }
 
 /** Input-less root run the heartbeat and live-line cases below all start from. */
@@ -199,7 +223,7 @@ function handleRoundStage(
   streamId: string,
   roundStage: RoundStage,
 ): void {
-  renderer.handleSessionEvent({
+  renderer.emit({
     scope: 'run',
     streamId: streamId as StreamTabId,
     event: {
@@ -218,7 +242,7 @@ function handleConversationProgress(
   streamId: string,
   progress: ConversationProgress,
 ): void {
-  renderer.handleSessionEvent({
+  renderer.emit({
     scope: 'run',
     streamId: streamId as StreamTabId,
     event: {
@@ -235,7 +259,7 @@ function handleStreamStatus(
   previousStatus: StreamPhase = STREAM_PHASE.RUNNING,
 ): void {
   // Status reaches the renderer on the session-fact rail only.
-  renderer.handleSessionEvent({
+  renderer.emit({
     scope: 'session',
     event: {
       type: 'status',
@@ -247,42 +271,16 @@ function handleStreamStatus(
   });
 }
 
-function handleFollowUpSent(
-  renderer: TestRunProgressRenderer,
-  streamId: string,
-): void {
-  renderer.handleSessionEvent({
-    scope: 'session',
-    event: {
-      type: 'followUpSent',
-      payload: { streamId: streamId as StreamTabId },
-    },
-  });
-}
-
 function handleStreamDescription(
   renderer: TestRunProgressRenderer,
   streamId: string,
   description: string,
 ): void {
-  renderer.handleSessionEvent({
+  renderer.emit({
     scope: 'session',
     event: {
       type: 'updateStreamDescription',
       payload: { streamId: streamId as StreamTabId, description },
-    },
-  });
-}
-
-function handleRemoveStream(
-  renderer: TestRunProgressRenderer,
-  streamId: string,
-): void {
-  renderer.handleSessionEvent({
-    scope: 'session',
-    event: {
-      type: 'removeStream',
-      payload: { streamId: streamId as StreamTabId },
     },
   });
 }
@@ -292,7 +290,7 @@ function handleActiveSubagents(
   parentStreamId: string,
   children: readonly ActiveChildInfo[],
 ): void {
-  renderer.handleSessionEvent({
+  renderer.emit({
     scope: 'run',
     streamId: parentStreamId as StreamTabId,
     event: {
@@ -317,24 +315,28 @@ function plainRenderer(
   output: ReturnType<typeof outputBuffer>,
   init: Partial<RunProgressRendererInit> = {},
 ): TestRunProgressRenderer {
-  return createRunProgressRenderer(context({ stderrColorEnabled: false }), {
-    colorEnabled: false,
-    write: output.write,
-    nowMs: () => 0,
-    ...init,
-  })!;
+  return attached(
+    createRunProgressRenderer(context({ stderrColorEnabled: false }), {
+      colorEnabled: false,
+      write: output.write,
+      nowMs: () => 0,
+      ...init,
+    })!,
+  );
 }
 
 function ansiRenderer(
   output: ReturnType<typeof outputBuffer>,
   init: Partial<RunProgressRendererInit> = {},
 ): TestRunProgressRenderer {
-  return createRunProgressRenderer(context(), {
-    colorEnabled: true,
-    write: output.write,
-    nowMs: () => 0,
-    ...init,
-  })!;
+  return attached(
+    createRunProgressRenderer(context(), {
+      colorEnabled: true,
+      write: output.write,
+      nowMs: () => 0,
+      ...init,
+    })!,
+  );
 }
 
 function fakeTimers() {
@@ -622,10 +624,11 @@ describe('CLI run progress renderer', () => {
     expect(output.text.endsWith('\n')).toBe(true);
   });
 
-  it('can add typed round progress after tool-call progress claims the root stream', () => {
+  it('keeps the claimed root stream when a child run.config arrives later', () => {
     const output = outputBuffer();
     const renderer = plainRenderer(output, { minIntervalMs: 0 });
 
+    handleOrchestratorRootRun(renderer);
     handleConversationProgress(renderer, 'root-stream', { toolCallCount: 4 });
     handleRoundStage(renderer, 'root-stream', { index: 1 });
     handleRunConfig(renderer, {
@@ -635,7 +638,9 @@ describe('CLI run progress renderer', () => {
     });
 
     expect(output.text).toBe(
-      'running · tools: 4 · 0s\n' + '[r2] · running · tools: 4 · 0s\n',
+      'orchestrator · 0s\n' +
+        'orchestrator · tools: 4 · 0s\n' +
+        '[r2] · orchestrator · tools: 4 · 0s\n',
     );
   });
 
@@ -709,39 +714,6 @@ describe('CLI run progress renderer', () => {
     expect(output.text).toBe(
       'orchestrator · 0s\n' +
         'orchestrator · subagent: review — Run PASSWORD=[redacted] now · 0s\n',
-    );
-  });
-
-  it('drops the previous task when a waiting child begins a follow-up turn', () => {
-    const output = outputBuffer();
-    const renderer = plainRenderer(output);
-
-    handleOrchestratorRootRun(renderer);
-    handleStreamDescription(renderer, 'child-stream', 'Initial review task');
-    handleActiveSubagents(renderer, 'root-stream', [subagentChild()]);
-    handleFollowUpSent(renderer, 'child-stream');
-
-    expect(output.text).toBe(
-      'orchestrator · 0s\n' +
-        'orchestrator · subagent: review — Initial review task · 0s\n' +
-        'orchestrator · subagent: review · 0s\n',
-    );
-
-    // The status subscriber may repaint the roster before this renderer sees
-    // WAITING -> RUNNING. That repaint must not recover the previous label.
-    handleActiveSubagents(renderer, 'root-stream', [subagentChild()]);
-    handleStreamStatus(renderer, 'child-stream', STREAM_PHASE.WAITING);
-    handleStreamStatus(
-      renderer,
-      'child-stream',
-      STREAM_PHASE.RUNNING,
-      STREAM_PHASE.WAITING,
-    );
-
-    expect(output.text).toBe(
-      'orchestrator · 0s\n' +
-        'orchestrator · subagent: review — Initial review task · 0s\n' +
-        'orchestrator · subagent: review · 0s\n',
     );
   });
 
@@ -826,62 +798,6 @@ describe('CLI run progress renderer', () => {
     );
   });
 
-  it('forgets a child description when that child becomes terminal', () => {
-    const output = outputBuffer();
-    const renderer = plainRenderer(output);
-
-    handleOrchestratorRootRun(renderer);
-    handleStreamDescription(renderer, 'child-stream', 'First review task');
-    handleActiveSubagents(renderer, 'root-stream', [subagentChild()]);
-    handleStreamStatus(renderer, 'child-stream', STREAM_PHASE.COMPLETED);
-    handleActiveSubagents(renderer, 'root-stream', []);
-    handleActiveSubagents(renderer, 'root-stream', [subagentChild()]);
-
-    expect(output.text).toBe(
-      'orchestrator · 0s\n' +
-        'orchestrator · subagent: review — First review task · 0s\n' +
-        'orchestrator · subagent: review · 0s\n' +
-        'orchestrator · 0s\n' +
-        'orchestrator · subagent: review · 0s\n',
-    );
-  });
-
-  it('ignores a description that arrives after the child becomes terminal', () => {
-    const output = outputBuffer();
-    const renderer = plainRenderer(output);
-
-    handleOrchestratorRootRun(renderer);
-    handleStreamDescription(renderer, 'child-stream', 'First review task');
-    handleActiveSubagents(renderer, 'root-stream', [subagentChild()]);
-    handleStreamStatus(renderer, 'child-stream', STREAM_PHASE.COMPLETED);
-    handleStreamDescription(renderer, 'child-stream', 'Late generated label');
-
-    expect(output.text).toBe(
-      'orchestrator · 0s\n' +
-        'orchestrator · subagent: review — First review task · 0s\n' +
-        'orchestrator · subagent: review · 0s\n',
-    );
-  });
-
-  it('accepts a description for a new incarnation of a closed child ID', () => {
-    const output = outputBuffer();
-    const renderer = plainRenderer(output);
-
-    handleOrchestratorRootRun(renderer);
-    handleStreamDescription(renderer, 'child-stream', 'First review task');
-    handleActiveSubagents(renderer, 'root-stream', [subagentChild()]);
-    handleStreamStatus(renderer, 'child-stream', STREAM_PHASE.COMPLETED);
-    handleRunConfig(renderer, { streamId: 'child-stream', agent: 'review' });
-    handleStreamDescription(renderer, 'child-stream', 'Relaunched review task');
-
-    expect(output.text).toBe(
-      'orchestrator · 0s\n' +
-        'orchestrator · subagent: review — First review task · 0s\n' +
-        'orchestrator · subagent: review · 0s\n' +
-        'orchestrator · subagent: review — Relaunched review task · 0s\n',
-    );
-  });
-
   it('keeps the task description when an active child switches models', () => {
     const output = outputBuffer();
     const renderer = plainRenderer(output);
@@ -895,26 +811,6 @@ describe('CLI run progress renderer', () => {
     expect(output.text).toBe(
       'orchestrator · 0s\n' +
         'orchestrator · subagent: review — Current review task · 0s\n',
-    );
-  });
-
-  it('forgets a child description when that child stream is removed', () => {
-    const output = outputBuffer();
-    const renderer = plainRenderer(output);
-
-    handleOrchestratorRootRun(renderer);
-    handleStreamDescription(renderer, 'child-stream', 'Removed review task');
-    handleActiveSubagents(renderer, 'root-stream', [subagentChild()]);
-    handleRemoveStream(renderer, 'child-stream');
-    handleActiveSubagents(renderer, 'root-stream', []);
-    handleActiveSubagents(renderer, 'root-stream', [subagentChild()]);
-
-    expect(output.text).toBe(
-      'orchestrator · 0s\n' +
-        'orchestrator · subagent: review — Removed review task · 0s\n' +
-        'orchestrator · subagent: review · 0s\n' +
-        'orchestrator · 0s\n' +
-        'orchestrator · subagent: review · 0s\n',
     );
   });
 
@@ -1027,7 +923,7 @@ describe('CLI run progress renderer', () => {
 
   it('uses the stderr color gate when stdout alone allows color', async () => {
     const output = await captureStreamWrites(process.stderr, async () => {
-      const events = new SessionEventHub();
+      const session = createTestSession();
       const host = createCliRuntimeHost(
         context({
           quietLogs: true,
@@ -1036,8 +932,8 @@ describe('CLI run progress renderer', () => {
           stderrColorEnabled: false,
         }),
       );
-      const detach = host.attachRunProgressRenderer(events);
-      events.emit(runConfigEvent());
+      const detach = host.attachRunProgressRenderer(session);
+      session.events.emit(runConfigEvent());
       detach();
       await host.close();
     });
@@ -1048,7 +944,7 @@ describe('CLI run progress renderer', () => {
 
   it('writes one status line when a run-scope status fact accompanies the session fact', async () => {
     const output = await captureStreamWrites(process.stderr, async () => {
-      const events = new SessionEventHub();
+      const session = createTestSession();
       const host = createCliRuntimeHost(
         context({
           stderrColorEnabled: false,
@@ -1056,12 +952,12 @@ describe('CLI run progress renderer', () => {
           renderRunProgress: true,
         }),
       );
-      const detach = host.attachRunProgressRenderer(events);
+      const detach = host.attachRunProgressRenderer(session);
 
-      events.emit(runConfigEvent());
+      session.events.emit(runConfigEvent());
       // Status travels only as a session fact (run-scope status is no longer
       // representable), so exactly one line renders for the transition.
-      events.emit({
+      session.events.emit({
         scope: 'session',
         event: {
           type: 'status',
@@ -1083,7 +979,7 @@ describe('CLI run progress renderer', () => {
 
   it('preserves the live progress line before interactive prompts', async () => {
     const output = await captureStreamWrites(process.stderr, async () => {
-      const events = new SessionEventHub();
+      const session = createTestSession();
       const host = createCliRuntimeHost(
         context({
           approvalPolicy: 'ask',
@@ -1091,8 +987,8 @@ describe('CLI run progress renderer', () => {
         }),
       );
 
-      const detach = host.attachRunProgressRenderer(events);
-      events.emit(runConfigEvent());
+      const detach = host.attachRunProgressRenderer(session);
+      session.events.emit(runConfigEvent());
       host.prepareInteractivePrompt?.();
       await Promise.resolve();
       detach();
@@ -1106,7 +1002,7 @@ describe('CLI run progress renderer', () => {
     let stderr = '';
     const stdout = await captureStreamWrites(process.stdout, async () => {
       stderr = await captureStreamWrites(process.stderr, async () => {
-        const events = new SessionEventHub();
+        const session = createTestSession();
         const host = createCliRuntimeHost(
           context({
             outputFormat: 'json',
@@ -1114,8 +1010,8 @@ describe('CLI run progress renderer', () => {
             renderRunProgress: true,
           }),
         );
-        const detach = host.attachRunProgressRenderer(events);
-        events.emit(runConfigEvent());
+        const detach = host.attachRunProgressRenderer(session);
+        session.events.emit(runConfigEvent());
         detach();
         await host.close();
       });
@@ -1202,9 +1098,9 @@ describe('CLI run progress renderer', () => {
 
   it('writes projected subagent progress records to stdout in ndjson mode', async () => {
     const output = await captureStreamWrites(process.stdout, async () => {
-      const events = new SessionEventHub();
-      const detach = attachCliSessionProgressProjection(events);
-      events.emit({
+      const session = createTestSession();
+      const detach = attachCliSessionProgressProjection(session.events);
+      session.events.emit({
         scope: 'run',
         streamId: 'parent-stream' as StreamTabId,
         event: {

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -975,11 +975,11 @@ describe('CLI child list display model', () => {
       { until: (frame) => frame.includes('5 tool calls') },
     );
 
-    expect(sessions.find(({ id }) => id === bash)?.identity).toEqual({
+    expect(sessions.find(({ id }) => id === bash)?.info?.identity).toEqual({
       kind: 'process',
       tool: 'bash',
     });
-    expect(sessions.find(({ id }) => id === agent)?.identity).toEqual({
+    expect(sessions.find(({ id }) => id === agent)?.info?.identity).toEqual({
       kind: 'agent',
       agent: 'bash',
     });


### PR DESCRIPTION
Wave A step 3 of the CLI substrate collapse
([`2026-08-15-single-substrate-hosts-as-renderers.md`](docs/proposals/2026-08-15-single-substrate-hosts-as-renderers.md)).
Three collapses, each of them relocate-ownership-don't-duplicate-it: the CLI stops
keeping its own copy of what the shared session substrate already owns.

## 1. Port narrowing — `invalidate(streamId, slice)`

`SessionRendererPort` gains one payload-free envelope. Five notifications fold
into it:

| removed | slice |
| --- | --- |
| `onFilesChanged(streamId)` | `'files'` |
| `onCompileFailuresChanged(streamId)` | `'compileFailures'` |
| `onQueuedFollowUpsChanged(streamId)` | `'queuedFollowUps'` |
| `onGoalPaused(streamId)` | `'goalPaused'` |
| `onParentStreamChanged(childStreamId, parentStreamId)` | `'parentStreamId'` |

`SessionFactApplier` lands each of these on `SessionState` *before* it notifies,
so the payload was never on the wire — only the field name was.
`onParentStreamChanged`'s second argument was already dead in both
implementations (each re-read the edge from state), so it goes with the method.

Kept as their own methods, deliberately: `onMissingOutputsChanged` (its `reset`
clears rounds rather than replacing them) and `onStageChanged` (phase-vs-round
split). Those options carry real delta semantics, not just a field name.

Both implementations move over —
`LitSessionRenderer` (extension + desktop) and `TuiSessionRenderer` — plus the
applier call sites. **The CLI's `onGoalPaused` behavior survives**: the
goal-paused transcript notice now fires from `invalidate(…, 'goalPaused')`, and
Lit still no-ops (it surfaces pause on the goal chip).

## 2. Headless renderer port

`packages/cli/src/runtime/runProgressRenderer.ts` stops hand-rolling its own
fact reducer. Deleted: `handleSessionEvent` / `handleSessionFact` /
`handleRunFact`, the `RUN_PROGRESS_RUN_FACT_TYPES` sub-vocabulary, the
`activeChildren` array, the `childDescriptions` map, the `closedChildStreamIds`
tombstone set, and the five `apply*` reducers that maintained them.

In their place it attaches a `SessionRendererPort` (`HeadlessPort`) over its own
`SessionState` + `SessionFactApplier`, exactly like the TUI adapter, and reads
round index, planned rounds, tool-call count, the live child roster and child
descriptions from the shared record at paint time. `attachRunProgressRenderer`
now takes the `SessionHandle` instead of the `SessionEventHub`.

**Kept unchanged**: the ANSI `\r\x1b[2K` repaint, `minIntervalMs` throttling, the
heartbeat timer, `preserve()`/`clear()`, elapsed formatting, the
description-column budget and the truncation rules. Two things stay locally
owned because no shared record carries them:

- the run's `AgentConfig` (agent name, input-file label, workflow round count) —
  the summary mirror keeps only model / working directory / command;
- `rootPhaseText`, whose whole semantic is last-write-wins ordering between a
  status transition and a description fact.

## 3. Label unification

CLI display labels now come from the shared `buildStreamTabInfo`
(`src/controllers/session/streamTabInfo.ts`) — the same builder the extension and
desktop stream tabs use — instead of `streamViews.ts`'s own derivation
(`childStreamReferenceLabel` + the `childStreamLabels` batch pass) and
`SubagentList`'s ad-hoc `getRuntimeModelLabel` re-run. `StreamView` carries the
`StreamTabInfo` instead of a bare `identity`, and `streamViews.ts` is left owning
only the CLI's own concerns: active-tree order, focus scope, ancestor walks.

Identity resolution order is now **the stream's own metadata first**, with the
parent's roster row as the fallback for a child whose `run.start` has not landed
yet (the `roster-first` child-event order). Previously the parent's roster row was
the only source.

### Changed CLI display strings (intentional — extension parity)

This is the "same run, two names" drift the step exists to fix. Every string
below moves *to* what the extension already shows.

1. **Child not on the parent's visible roster** (retired, tombstoned, or never
   rostered) — was the raw stream id `reviewer#a1b2c3d4`; now the cleaned id
   prefix `reviewer`. Same string the extension tab shows for an unresolved
   stream.
2. **Source-qualified agent on a roster row with no `identity`** — was
   `child.agentName` verbatim (`custom:reviewer`); now cleaned (`reviewer`),
   because the shared builder runs `getCleanAgentName`. Resolved identities were
   already cleaned on both sides, so this only affects the fallback path.
3. **Subagent-list model chip on a workflow-script row**
   (`identity.kind === 'multiAgentWorkflow'`) — was the runtime label of
   `metadata.config.model`; now **absent**. `buildStreamTabInfo` surfaces
   `modelLabel` only for `kind: 'agent'`, since a workflow script carries a
   synthetic config model it does not itself infer with. Extension tabs have
   never shown one here.
4. **Subagent-list model chip on a row whose identity has not resolved yet** —
   was the config model (the old test `identity?.kind !== 'process'` treats
   `undefined` as "not a process"); now absent until identity resolves, then it
   appears. Process rows showed nothing before and still show nothing.
5. **Session-header model, focused workflow-script or unresolved stream** — was
   `metadata.config.model`; now falls back to the session's own model
   (`meta.model`). A focused *agent* subagent is unchanged.
6. **Session-header stream kind** (`workflow script` vs `subagent`) — was read
   from `metadata.identity` only; now from the shared projection, so a workflow
   child whose identity has only reached the parent's roster reads
   `workflow script` instead of falling through to `subagent`.

7. **Session-header model, focused `process` (bash) stream** — was the runtime
   label of that stream's synthetic `AgentConfig.model` prefault
   (`DEFAULT_AGENT_MODEL`); now falls back to the session's own model, because
   `buildStreamTabInfo` refuses to attribute a model to a shell. *(Added after
   review — this one was missing from the list on first publish.)*
8. **Headless live line: a child's task label no longer clears on
   `followUpSent`.** The retired private `childDescriptions` map was cleared
   when a waiting child began a new turn, so the stderr line dropped the
   delegated-task suffix until a fresh description arrived. Neither the TUI's
   subagent list nor the Lit progress view ever did that — both read
   `SessionStreamMetadata.description`, which nothing clears. That clearing was
   host-local policy over state the applier owns, so it goes with the map
   instead of being re-implemented against the shared record; headless now
   shows what the other two hosts show. Terminal and removed children are
   unaffected: `liveChildren()` filters on `finishedAt`, so they leave the line
   without any description bookkeeping. *(Added after review; the tests section
   below is corrected to match.)*

No other label, status word, badge, or column changes.

## R6 — net element accounting

| item | files | production net |
| --- | --- | --- |
| 1. port narrowing | `SessionRendererPort` +12, `SessionFactApplier` +2, `LitSessionRenderer` −1, `sessionSignalsAdapter` −6 | **+7** |
| 2. headless port | `runProgressRenderer` −35, `runExecution` −1, `cliPresentationHost` ±0 | **−36** |
| 3. label unification | `streamViews` −41, `SubagentList` −4, `App.tsx` −2, `StatusBar` −1, `StaticConversationTranscript` ±0 | **−48** |
| **production total** | 13 files | **−77** |
| tests | `RunProgressRenderer.vitest` −104, `SubagentListDisplay.vitest` ±0 | **−104** |
| **grand total** | 15 files | **−181** (463 ins / 644 del) |

Item 1 is the one net-add, and it buys the deletions in items 2 and 3: the
narrowed port is what lets a third implementation (`HeadlessPort`) exist at all
without a third fact reducer.

Structures deleted, not moved: `RenderState`, `RUN_PROGRESS_RUN_FACT_TYPES`,
`RunProgressRunFactEvent`, `childDescriptions`, `closedChildStreamIds`,
`activeChildren`, `childStreamReferenceLabel`, `childStreamLabels`, and the
`labels` / `streams` parameters they threaded through `streamViews`. No
re-export shims.

## R8 — consumer grep

- `SessionRendererPort` has exactly three implementations, all updated:
  `LitSessionRenderer` (ext + desktop), `TuiSessionRenderer` (CLI TUI),
  `HeadlessPort` (CLI headless, new). `SessionFactApplier` is the only caller of
  the removed methods.
- `childExecutionLabel` keeps two consumers (`resumeHint.ts`,
  `childExecutions.ts`) — not orphaned by the `streamViews` change.
- `roundStageFromStageStart` keeps `sessionProgressSubscription.ts` and its own
  module — not orphaned by the `runProgressRenderer` change.
- `attachRunProgressRenderer` has one caller (`cliPresentationHost.ts`), which
  has one caller (`runExecution.ts`); both moved to `SessionHandle` together.
- No new export without a consumer in this PR (`check:dead-code-ratchet` green,
  8 findings vs 8 baselined).

**Ratchet rider — checked, no prune due.**
`config/ratchets/host-agent-import-baseline.json` is unchanged: no host lost its
last `@agent/*` deep import here. §7.3 flags
`@agent/modelHandlers/support/contextUtilization` as Wave A's one expected
`hosts.cli` casualty, but its sole CLI importer is
`packages/cli/src/chat/tui/panes/statusBarDisplay.ts`, which this PR does not
touch — that row dies with B5, not here. The set-based ratchet
(`hostAgentDeepImportRatchet.vitest.ts`, which also fails on stale headroom) is
green as-is. `@agent/trace`, `@agent/runtime` and `@agent/index` all keep live
CLI imports in `runProgressRenderer.ts` itself.

## Tests

Per repo policy, obsolete tests were deleted rather than repaired and **no new
tests were added**. `RunProgressRenderer.vitest.ts` drives facts through a real
`SessionHandle` (`createTestSession`) instead of calling the deleted
`handleSessionEvent`, which retires the cases that only pinned the hand-rolled
bookkeeping (`handleFollowUpSent`, `handleRemoveStream`, the child-`run.config`
tombstone reset). Split honestly, since the first draft of this paragraph
over-claimed:

- **Relocated, still covered:** the terminal / removal / reincarnation cases.
  A retired child leaves the line through `liveChildren()`'s `finishedAt`
  filter over the applier-maintained roster, so no per-host tombstone set is
  needed to produce the same output.
- **Genuinely changed, listed as display change 8 above:** the `followUpSent`
  description clear. `SessionFactApplier`'s `followUpSent` arm only invalidates
  `queuedFollowUps`, and `setStreamDescription` is the sole writer of
  `description` — nothing clears it. That is deliberate convergence on the
  semantics the TUI and Lit already have, not an oversight, and
  `childDescription()` carries the reasoning inline.

`SubagentListDisplay.vitest.ts` reads `info.identity` instead of `identity`.

## Verified

| gate | result |
| --- | --- |
| `npm run typecheck` | green |
| `vitest run src/test-kernel/{cli,architecture,controllers}` + `WorkflowScriptProgressBridge` + `ProgressBackendFactProjection` | 204 files, 3188 passed / 1 skipped |
| `npm run format:check` | green |
| `eslint` (15 changed files) | clean |
| `npm run check:dead-code-ratchet` | 8 current vs 8 baselined |
| `node scripts/validate-tui.mjs` | **13/167 failing — zero new**; baseline on `391033e6` (this PR's base) is 14/167 and the branch set is a strict subset |

The TUI scenario validator was run on the unmodified base first so only new
deltas are owned here. Branch failures are exactly the 13 known pre-existing ones
(`workflow-running-composer-hidden`, `process-child-composer-hidden`,
`backslash-goal-help`, `config-category-back-responsive`,
`child-event-order-completion-remove`, `subagents-narrow-navigation`,
`subagent-focused-submit`, the three `focused-stopped-subagent*`,
`escape-root-restores-prompt-history`, `escape-stops-focused-main-only`,
`escape-returns-focused-child-to-parent-list`). `compact-tools-form` failed in
the baseline and passed on the branch — a known-flaky boot timeout, not a fix
claimed here.

**No expectation fixtures needed updating.** The six display-string changes above
all sit on fallback paths the harness does not exercise: its children carry a
resolved `identity` on both their own metadata and the parent roster, so every
label the validator asserts resolves to the same string through the shared
builder. The subagent frames are byte-identical to baseline.

## Review response

The `review` bot raised four findings; all four were checked against the code.

- **#1 child description clearing — accepted as a finding, kept as behavior.**
  Its mechanism claim is exactly right: nothing in the applier clears
  `description`, so the `followUpSent` clear is gone rather than relocated, and
  my original "already covered" sentence was wrong. But re-adding the clear in
  `HeadlessPort` would restore the host-local policy this step exists to
  delete, and it would make headless the *only* host that drops a live child's
  task label — the TUI's subagent list and the Lit progress view both read the
  persistent field. Documented as display change 8, with the reasoning inline
  at `childDescription()`. Its terminal/removal/reincarnation half is not a
  change: `liveChildren()`'s `finishedAt` filter covers those.
- **#2 focused-process header model — accepted, fixed.** Real omission; now
  display change 7.
- **#3 `streamViews` reads ambient bound state — accepted as a comment.**
  Threading `metadata` through `streamViewForId`/`streamTreeViews` and every
  call site would be parameter accretion for a read the module's own
  `streamMetadataFor`/`streamStateFor` callers already make under the same
  `sessionStateRevision` gate. Documented at `streamTabInfoFor` instead.
- **#4 removal of the batch `childStreamLabels` pass regresses render cost —
  refuted.** It reads the `??` in `streamTabInfoFor` as unconditional, but
  `metadata.identity ?? (roster lookup)` short-circuits: a stream whose
  identity has resolved — the normal case, and the only case the batch pass
  ever accelerated — now scans **no** roster. The derivation this replaced ran
  `visibleSubagentRows(...).find(...)` for every row unconditionally, which is
  what the batch pass existed to amortize. Post-change cost is zero scans in
  the common case and at most the old per-row cost while identities are still
  unresolved, so the optimization is obsolete rather than reversed. Noted in
  the same comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
