### PR TITLE
refactor(tools): dedupe child-execution registration and nullish-default schemas

### DIFF
--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -9,6 +9,7 @@ import { formatToolOutput } from '@tools/formatting';
 import { wrapApiCall } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 import { executed } from '@tools/core/result';
+import { withDefault } from '@tools/core/schemaDefaults';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { isDirectory, isFile } from '@utils/files/fsEntryType';
@@ -42,16 +43,13 @@ async function listExtractedEntries(dirFsPath: string): Promise<string> {
 
 const ArxivDownloadInputSchema = z.strictObject({
   id: z.string().describe('arXiv identifier or URL for the source archive.'),
-  autoIndent: z
-    .boolean()
-    .nullish()
-    .transform((v) => v ?? true)
-    .describe('Auto-indent extracted TeX files after downloading source.'),
-  destination: z
-    .enum(['root', 'references'])
-    .nullish()
-    .transform((v) => v ?? ('references' as const))
-    .describe('Where to extract the source: workspace root or References/.'),
+  autoIndent: withDefault(z.boolean(), true).describe(
+    'Auto-indent extracted TeX files after downloading source.',
+  ),
+  destination: withDefault(
+    z.enum(['root', 'references']),
+    'references' as const,
+  ).describe('Where to extract the source: workspace root or References/.'),
 });
 
 export type ArxivDownloadInput = z.infer<typeof ArxivDownloadInputSchema>;

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -14,14 +14,13 @@ import { ARXIV_CONSTANTS } from '@tools/citation/constants';
 import { rateLimitedApiCall } from '@tools/citation/rateLimiter';
 import { defineTool } from '@tools/core/define';
 import { executed } from '@tools/core/result';
+import { withDefault } from '@tools/core/schemaDefaults';
 
 const ArxivMetadataInputSchema = z.strictObject({
   id: z.string().describe('arXiv identifier or URL for the paper.'),
-  includeAbstract: z
-    .boolean()
-    .nullish()
-    .transform((v) => v ?? true)
-    .describe('Include the paper abstract in the metadata response.'),
+  includeAbstract: withDefault(z.boolean(), true).describe(
+    'Include the paper abstract in the metadata response.',
+  ),
   maxAuthors: z
     .int()
     .positive()

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -23,6 +23,7 @@ import {
   extractBasePaperMetadata,
 } from '@tools/arxiv/arxivShared';
 import { executed } from '@tools/core/result';
+import { withDefault } from '@tools/core/schemaDefaults';
 import { pluralize } from '@utils/text/stringUtils';
 
 type Category = Parameters<typeof catQuery>[0];
@@ -35,28 +36,20 @@ const ArxivSearchInputSchema = z.strictObject({
   query: z
     .string()
     .describe('Search query terms, title text, or author names.'),
-  field: SearchFieldSchema.nullish()
-    .transform((v) => v ?? 'all')
-    .describe(
-      'Search field: "author" for author names, "title" for paper titles, "abstract" for abstracts, "all" (default) for all fields',
-    ),
+  field: withDefault(SearchFieldSchema, 'all' as const).describe(
+    'Search field: "author" for author names, "title" for paper titles, "abstract" for abstracts, "all" (default) for all fields',
+  ),
   categories: z
     .array(z.string())
     .nullish()
     .describe('Optional arXiv category filters such as "math.NT" or "cs.AI".'),
-  maxResults: z
-    .int()
-    .positive()
-    .max(ARXIV_CONSTANTS.MAX_RESULTS)
-    .nullish()
-    .transform((v) => v ?? ARXIV_CONSTANTS.DEFAULT_RESULTS)
-    .describe('Maximum number of papers to return.'),
-  start: z
-    .int()
-    .min(0)
-    .nullish()
-    .transform((v) => v ?? 0)
-    .describe('Zero-based result offset for pagination.'),
+  maxResults: withDefault(
+    z.int().positive().max(ARXIV_CONSTANTS.MAX_RESULTS),
+    ARXIV_CONSTANTS.DEFAULT_RESULTS,
+  ).describe('Maximum number of papers to return.'),
+  start: withDefault(z.int().min(0), 0).describe(
+    'Zero-based result offset for pagination.',
+  ),
   sortBy: SortBySchema.nullish().describe('arXiv sort field to use.'),
   sortOrder: SortOrderSchema.nullish().describe('Sort direction for results.'),
 });

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -53,6 +53,7 @@ import {
   requestBashApproval,
 } from '@tools/approval/bashApproval';
 import { executed } from '@tools/core/result';
+import { withDefault } from '@tools/core/schemaDefaults';
 import { formatDuration, generateExecutionId } from '@utils/core';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 import { executeCommand } from '@utils/system/execUtils';
@@ -245,13 +246,9 @@ const BashInputSchema = z.strictObject({
     .describe(
       'Timeout in milliseconds (max 600,000 ms / 10 min, default 120,000 ms / 2 min).',
     ),
-  run_in_background: z
-    .boolean()
-    .nullish()
-    .transform((v) => v ?? false)
-    .describe(
-      'Run command in background. Returns immediately with execution ID and a background task tab. Result delivered as follow-up when complete.',
-    ),
+  run_in_background: withDefault(z.boolean(), false).describe(
+    'Run command in background. Returns immediately with execution ID and a background task tab. Result delivered as follow-up when complete.',
+  ),
 });
 
 type BashInput = z.infer<typeof BashInputSchema>;

--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -12,6 +12,7 @@ import { ToolError, type ToolResult } from '@shared/schemas';
 import { requireNonEmptyString } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 import { executed } from '@tools/core/result';
+import { withDefault } from '@tools/core/schemaDefaults';
 import { pluralize } from '@utils/text/stringUtils';
 
 // Local file imports
@@ -20,13 +21,10 @@ import { rateLimitedApiCall } from './rateLimiter';
 
 const CROSSREF_SEARCH_FIELDS = {
   query: z.string().describe('Bibliographic search query for Crossref works.'),
-  rows: z
-    .int()
-    .positive()
-    .max(CROSSREF_CONSTANTS.MAX_ROWS)
-    .nullish()
-    .transform((v) => v ?? CROSSREF_CONSTANTS.DEFAULT_ROWS)
-    .describe('Maximum number of works to return.'),
+  rows: withDefault(
+    z.int().positive().max(CROSSREF_CONSTANTS.MAX_ROWS),
+    CROSSREF_CONSTANTS.DEFAULT_ROWS,
+  ).describe('Maximum number of works to return.'),
   offset: z
     .int()
     .min(0)

--- a/src/tools/core/schemaDefaults.ts
+++ b/src/tools/core/schemaDefaults.ts
@@ -1,0 +1,16 @@
+// Third-party imports
+import type { z } from 'zod';
+
+/**
+ * A tool input field that accepts both `undefined` and `null` (required for
+ * OpenAI-compatible structured output, which needs optional fields to also
+ * be nullable) but resolves to a concrete default when either is given.
+ * `.default()` alone does not cover this: it only substitutes for
+ * `undefined`, never for an explicit `null`.
+ */
+export function withDefault<Schema extends z.ZodTypeAny>(
+  schema: Schema,
+  value: z.output<Schema>,
+) {
+  return schema.nullish().transform((v) => v ?? value);
+}

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -14,23 +14,22 @@
 
 // Local imports
 import { getExecutionStore, type ResultMeta } from '@agent/storage';
-import { registerOwnedExecution } from '@agent/storage/executionLifecycle';
 import {
   ExecutionLeaseLostError,
   runWithInactiveExecutionLease,
   type OwnedExecutionLeaseScope,
 } from '@agent/storage/executionLease';
-import {
-  AgentConfigSchema,
-  type AgentConfigPayload,
+import type {
+  AgentConfig,
+  AgentConfigPayload,
 } from '@agent/core/definition/AgentConfig';
 import type { AgentFinalResult } from '@agent/runtime/AgentFinalResult';
-import { getStreamTabId } from '@agent/runtime/streamTab';
 import { createLog } from '@logger/logUtils';
 import {
   RUN_OUTCOME,
   USER_FOLLOW_UP_SUPPORT,
   type ExecutionId,
+  type StreamTabId,
   type SubagentProgressUpdate,
 } from '@shared/schemas';
 import { generateExecutionId, KeyedMutex } from '@utils/core';
@@ -55,6 +54,7 @@ import {
   createNativeSubagentStrategy,
   type ChildRunLaunchOptions,
 } from './nativeSubagentStrategy';
+import { registerAgentChildExecution } from './registerAgentChildExecution';
 
 const LOG_CHANNEL = 'inBandSubagentExecution';
 const log = createLog(LOG_CHANNEL);
@@ -373,25 +373,21 @@ async function executeInBand(
 ): Promise<CompletedInBandSubagent> {
   options.signal?.throwIfAborted();
 
-  const config = AgentConfigSchema.parse(options.configPayload);
   const startedAt = Date.now();
-  const workingDirectory = config.workingDirectory ?? undefined;
-  const childStreamId = getStreamTabId(config.agent, { executionId });
   const store = getExecutionStore(executionId);
 
+  let config: AgentConfig;
+  let childStreamId: StreamTabId;
   let runWithOwnership: OwnedExecutionLeaseScope;
   try {
-    runWithOwnership = await registerOwnedExecution(
-      executionId,
-      config,
-      options.agentName,
-      {
-        streamId: childStreamId,
-        identity: { kind: 'agent', agent: config.agent },
-        userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
+    ({ config, childStreamId, runWithOwnership } =
+      await registerAgentChildExecution({
+        executionId,
+        configPayload: options.configPayload,
+        agentName: options.agentName,
         parentExecutionId: options.parentExecutionId,
-      },
-    );
+        userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
+      }));
   } catch (cause) {
     if (mode === 'required-result') {
       throw new SubagentDurabilityError(
@@ -401,6 +397,7 @@ async function executeInBand(
     }
     throw cause;
   }
+  const workingDirectory = config.workingDirectory ?? undefined;
   let stableCompletionCommitted = false;
   const completed = await runWithOwnership(async () => {
     let settledTurn: SettledInBandTurn | undefined;

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -330,6 +330,26 @@ async function throwRetryableDurabilityError(
   throw error;
 }
 
+/**
+ * Register the parsed child, reclassifying a registration failure as a
+ * retryable `SubagentDurabilityError` only in `required-result` mode — a
+ * `best-effort-delivery` caller rethrows the raw cause unwrapped.
+ */
+async function registerInBandChild(
+  mode: PersistenceMode,
+  params: Parameters<typeof registerParsedAgentChildExecution>[0],
+): Promise<OwnedExecutionLeaseScope> {
+  try {
+    return await registerParsedAgentChildExecution(params);
+  } catch (cause) {
+    if (mode !== 'required-result') throw cause;
+    throw new SubagentDurabilityError(
+      `Failed to register subagent ${params.executionId}.`,
+      { cause },
+    );
+  }
+}
+
 function recordCost(
   onCost: InBandSubagentExecutionBaseOptions['onCost'],
   totalCostUsd: number | undefined,
@@ -385,25 +405,14 @@ async function executeInBand(
   const workingDirectory = config.workingDirectory ?? undefined;
   const store = getExecutionStore(executionId);
 
-  let runWithOwnership: OwnedExecutionLeaseScope;
-  try {
-    runWithOwnership = await registerParsedAgentChildExecution({
-      executionId,
-      config,
-      childStreamId,
-      agentName: options.agentName,
-      parentExecutionId: options.parentExecutionId,
-      userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
-    });
-  } catch (cause) {
-    if (mode === 'required-result') {
-      throw new SubagentDurabilityError(
-        `Failed to register subagent ${executionId}.`,
-        { cause },
-      );
-    }
-    throw cause;
-  }
+  const runWithOwnership = await registerInBandChild(mode, {
+    executionId,
+    config,
+    childStreamId,
+    agentName: options.agentName,
+    parentExecutionId: options.parentExecutionId,
+    userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
+  });
   let stableCompletionCommitted = false;
   const completed = await runWithOwnership(async () => {
     let settledTurn: SettledInBandTurn | undefined;

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -19,17 +19,13 @@ import {
   runWithInactiveExecutionLease,
   type OwnedExecutionLeaseScope,
 } from '@agent/storage/executionLease';
-import type {
-  AgentConfig,
-  AgentConfigPayload,
-} from '@agent/core/definition/AgentConfig';
+import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import type { AgentFinalResult } from '@agent/runtime/AgentFinalResult';
 import { createLog } from '@logger/logUtils';
 import {
   RUN_OUTCOME,
   USER_FOLLOW_UP_SUPPORT,
   type ExecutionId,
-  type StreamTabId,
   type SubagentProgressUpdate,
 } from '@shared/schemas';
 import { generateExecutionId, KeyedMutex } from '@utils/core';
@@ -54,7 +50,10 @@ import {
   createNativeSubagentStrategy,
   type ChildRunLaunchOptions,
 } from './nativeSubagentStrategy';
-import { registerAgentChildExecution } from './registerAgentChildExecution';
+import {
+  parseAgentChildConfig,
+  registerParsedAgentChildExecution,
+} from './registerAgentChildExecution';
 
 const LOG_CHANNEL = 'inBandSubagentExecution';
 const log = createLog(LOG_CHANNEL);
@@ -373,21 +372,29 @@ async function executeInBand(
 ): Promise<CompletedInBandSubagent> {
   options.signal?.throwIfAborted();
 
+  // Parsing/deriving stays outside the durability try below: a malformed
+  // config is a caller-input error, not an infrastructure failure, so it
+  // must propagate raw rather than being wrapped into a retryable
+  // SubagentDurabilityError (which the workflow-script runner escalates to a
+  // run-fatal WorkflowRunAbortError instead of resolving this call to null).
+  const { config, childStreamId } = parseAgentChildConfig(
+    options.configPayload,
+    executionId,
+  );
   const startedAt = Date.now();
+  const workingDirectory = config.workingDirectory ?? undefined;
   const store = getExecutionStore(executionId);
 
-  let config: AgentConfig;
-  let childStreamId: StreamTabId;
   let runWithOwnership: OwnedExecutionLeaseScope;
   try {
-    ({ config, childStreamId, runWithOwnership } =
-      await registerAgentChildExecution({
-        executionId,
-        configPayload: options.configPayload,
-        agentName: options.agentName,
-        parentExecutionId: options.parentExecutionId,
-        userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
-      }));
+    runWithOwnership = await registerParsedAgentChildExecution({
+      executionId,
+      config,
+      childStreamId,
+      agentName: options.agentName,
+      parentExecutionId: options.parentExecutionId,
+      userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
+    });
   } catch (cause) {
     if (mode === 'required-result') {
       throw new SubagentDurabilityError(
@@ -397,7 +404,6 @@ async function executeInBand(
     }
     throw cause;
   }
-  const workingDirectory = config.workingDirectory ?? undefined;
   let stableCompletionCommitted = false;
   const completed = await runWithOwnership(async () => {
     let settledTurn: SettledInBandTurn | undefined;

--- a/src/tools/delegation/registerAgentChildExecution.ts
+++ b/src/tools/delegation/registerAgentChildExecution.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared "reserve and take ownership of one agent-identity child execution"
+ * ceremony, used by every delegation path that launches a plain agent (as
+ * opposed to a multi-agent workflow run, which registers a different
+ * identity kind and config shape).
+ */
+
+// Local imports
+import {
+  AgentConfigSchema,
+  type AgentConfig,
+  type AgentConfigPayload,
+} from '@agent/core/definition/AgentConfig';
+import type { OwnedExecutionLeaseScope } from '@agent/storage/executionLease';
+import { registerOwnedExecution } from '@agent/storage/executionLifecycle';
+import { getStreamTabId } from '@agent/runtime/streamTab';
+import type {
+  ExecutionId,
+  StreamTabId,
+  UserFollowUpSupport,
+} from '@shared/schemas';
+
+interface RegisterAgentChildExecutionOptions {
+  readonly executionId: ExecutionId;
+  readonly configPayload: AgentConfigPayload;
+  readonly agentName: string;
+  readonly parentExecutionId: ExecutionId | undefined;
+  /** A fixed support level, or one derived from the parsed config (e.g. by agent category). */
+  readonly userFollowUpSupport:
+    UserFollowUpSupport | ((config: AgentConfig) => UserFollowUpSupport);
+}
+
+interface RegisterAgentChildExecutionResult {
+  readonly config: AgentConfig;
+  readonly childStreamId: StreamTabId;
+  readonly runWithOwnership: OwnedExecutionLeaseScope;
+}
+
+/**
+ * Must derive the stream id from the same fields `AgentLaunchContext`'s
+ * `reservedStreamId` uses (the parsed config's `agent`, not a caller-supplied
+ * display name), or the loop acquires the wrong follow-up queue/interrupt
+ * slot.
+ */
+export async function registerAgentChildExecution(
+  options: RegisterAgentChildExecutionOptions,
+): Promise<RegisterAgentChildExecutionResult> {
+  const config = AgentConfigSchema.parse(options.configPayload);
+  const childStreamId = getStreamTabId(config.agent, {
+    executionId: options.executionId,
+  });
+  const userFollowUpSupport =
+    typeof options.userFollowUpSupport === 'function'
+      ? options.userFollowUpSupport(config)
+      : options.userFollowUpSupport;
+  const runWithOwnership = await registerOwnedExecution(
+    options.executionId,
+    config,
+    options.agentName,
+    {
+      streamId: childStreamId,
+      identity: { kind: 'agent', agent: config.agent },
+      userFollowUpSupport,
+      parentExecutionId: options.parentExecutionId,
+    },
+  );
+  return { config, childStreamId, runWithOwnership };
+}

--- a/src/tools/delegation/registerAgentChildExecution.ts
+++ b/src/tools/delegation/registerAgentChildExecution.ts
@@ -3,6 +3,12 @@
  * ceremony, used by every delegation path that launches a plain agent (as
  * opposed to a multi-agent workflow run, which registers a different
  * identity kind and config shape).
+ *
+ * Split into a pure parse step and an async registration step so a caller
+ * that wraps registration failures (e.g. into a durability error) can keep
+ * config-validation failures outside that wrapping, matching how a config
+ * parse error and a lease-registration error are meant to propagate
+ * differently to their caller.
  */
 
 // Local imports
@@ -20,6 +26,50 @@ import type {
   UserFollowUpSupport,
 } from '@shared/schemas';
 
+interface ParsedAgentChildConfig {
+  readonly config: AgentConfig;
+  readonly childStreamId: StreamTabId;
+}
+
+/**
+ * Parse the child's config and derive its stream id. Must derive the stream
+ * id from the same fields `AgentLaunchContext`'s `reservedStreamId` uses (the
+ * parsed config's `agent`, not a caller-supplied display name), or the loop
+ * acquires the wrong follow-up queue/interrupt slot.
+ */
+export function parseAgentChildConfig(
+  configPayload: AgentConfigPayload,
+  executionId: ExecutionId,
+): ParsedAgentChildConfig {
+  const config = AgentConfigSchema.parse(configPayload);
+  const childStreamId = getStreamTabId(config.agent, { executionId });
+  return { config, childStreamId };
+}
+
+interface RegisterParsedAgentChildExecutionOptions extends ParsedAgentChildConfig {
+  readonly executionId: ExecutionId;
+  readonly agentName: string;
+  readonly parentExecutionId: ExecutionId | undefined;
+  readonly userFollowUpSupport: UserFollowUpSupport;
+}
+
+/** Register the owned execution lease for an already-parsed child config. */
+export async function registerParsedAgentChildExecution(
+  options: RegisterParsedAgentChildExecutionOptions,
+): Promise<OwnedExecutionLeaseScope> {
+  return registerOwnedExecution(
+    options.executionId,
+    options.config,
+    options.agentName,
+    {
+      streamId: options.childStreamId,
+      identity: { kind: 'agent', agent: options.config.agent },
+      userFollowUpSupport: options.userFollowUpSupport,
+      parentExecutionId: options.parentExecutionId,
+    },
+  );
+}
+
 interface RegisterAgentChildExecutionOptions {
   readonly executionId: ExecutionId;
   readonly configPayload: AgentConfigPayload;
@@ -30,39 +80,29 @@ interface RegisterAgentChildExecutionOptions {
     UserFollowUpSupport | ((config: AgentConfig) => UserFollowUpSupport);
 }
 
-interface RegisterAgentChildExecutionResult {
-  readonly config: AgentConfig;
-  readonly childStreamId: StreamTabId;
+interface RegisterAgentChildExecutionResult extends ParsedAgentChildConfig {
   readonly runWithOwnership: OwnedExecutionLeaseScope;
 }
 
-/**
- * Must derive the stream id from the same fields `AgentLaunchContext`'s
- * `reservedStreamId` uses (the parsed config's `agent`, not a caller-supplied
- * display name), or the loop acquires the wrong follow-up queue/interrupt
- * slot.
- */
+/** Parse and register in one call, for callers with no separate error handling to preserve across the two steps. */
 export async function registerAgentChildExecution(
   options: RegisterAgentChildExecutionOptions,
 ): Promise<RegisterAgentChildExecutionResult> {
-  const config = AgentConfigSchema.parse(options.configPayload);
-  const childStreamId = getStreamTabId(config.agent, {
-    executionId: options.executionId,
-  });
+  const { config, childStreamId } = parseAgentChildConfig(
+    options.configPayload,
+    options.executionId,
+  );
   const userFollowUpSupport =
     typeof options.userFollowUpSupport === 'function'
       ? options.userFollowUpSupport(config)
       : options.userFollowUpSupport;
-  const runWithOwnership = await registerOwnedExecution(
-    options.executionId,
+  const runWithOwnership = await registerParsedAgentChildExecution({
+    executionId: options.executionId,
     config,
-    options.agentName,
-    {
-      streamId: childStreamId,
-      identity: { kind: 'agent', agent: config.agent },
-      userFollowUpSupport,
-      parentExecutionId: options.parentExecutionId,
-    },
-  );
+    childStreamId,
+    agentName: options.agentName,
+    parentExecutionId: options.parentExecutionId,
+    userFollowUpSupport,
+  });
   return { config, childStreamId, runWithOwnership };
 }

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -8,24 +8,18 @@
  */
 
 // Local imports
-import { registerOwnedExecution } from '@agent/storage/executionLifecycle';
-import {
-  AgentConfigSchema,
-  type AgentConfigPayload,
-} from '@agent/core/definition/AgentConfig';
+import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import {
   getRunContextExecutionId,
   getRunContextSession,
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
-import { getStreamTabId } from '@agent/runtime/streamTab';
 import { createLog } from '@logger/logUtils';
 import {
   AgentCategory,
   TODO_STATUS,
   USER_FOLLOW_UP_SUPPORT,
-  type ExecutionId,
   type StreamTabId,
   type SubagentProgressUpdate,
 } from '@shared/schemas';
@@ -39,6 +33,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { startDetachedChildRunLoop } from './detachedChildRun';
 import { executeSubagentForDeliveryInBand } from './inBandSubagentExecution';
 import { createNativeSubagentStrategy } from './nativeSubagentStrategy';
+import { registerAgentChildExecution } from './registerAgentChildExecution';
 
 // ============================================================================
 // Shared utilities
@@ -184,31 +179,17 @@ export async function executeSubagent(
 
   const executionId = generateExecutionId();
   const startedAt = Date.now();
-  const config = AgentConfigSchema.parse(childConfigPayload);
-  // Must match the id `buildAgentLaunchContext` actually reserves for this
-  // executionId (see AgentLaunchContext.ts's `reservedStreamId`), or the
-  // loop acquires the wrong follow-up queue/interrupt slot. That reservation
-  // uses the canonical config's agent/model — not the `agentName` parameter,
-  // which callers may resolve differently
-  // (e.g. an approved agent override's display name vs. its registry name).
-  // Derive from the exact same fields, not a parallel formula.
-  const childStreamId = getStreamTabId(config.agent, {
-    executionId,
-  });
-  const runWithOwnership = await registerOwnedExecution(
-    executionId,
-    config,
-    agentName,
-    {
-      streamId: childStreamId,
-      identity: { kind: 'agent', agent: config.agent },
-      userFollowUpSupport:
+  const { config, childStreamId, runWithOwnership } =
+    await registerAgentChildExecution({
+      executionId,
+      configPayload: childConfigPayload,
+      agentName,
+      parentExecutionId,
+      userFollowUpSupport: (config) =>
         config.agentCategory === AgentCategory.ToolUse
           ? USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE
           : USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
-      parentExecutionId,
-    },
-  );
+    });
 
   return await runWithOwnership(async () => {
     const isToolUse = config.agentCategory === AgentCategory.ToolUse;

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -10,6 +10,7 @@ import { ToolError, type ToolResult } from '@shared/schemas';
 import { getGitignoreMatcher } from '@tools/gitignore';
 import { resolveAndFormat, currentToolRoot } from '@tools/pathResolution';
 import { executed } from '@tools/core/result';
+import { withDefault } from '@tools/core/schemaDefaults';
 import { executeCommand } from '@utils/system/execUtils';
 import { splitOutputLines } from '@utils/text/stringUtils';
 
@@ -27,13 +28,9 @@ const GrepInputSchema = z.strictObject({
     .string()
     .nullish()
     .describe('Glob filter for file names (e.g. "*.tex").'),
-  output_mode: z
-    .enum(OUTPUT_MODES)
-    .nullish()
-    .transform((v) => v ?? 'content')
-    .describe(
-      'Must be "content", "files_with_matches", or "count". For context lines around matches, use -C instead.',
-    ),
+  output_mode: withDefault(z.enum(OUTPUT_MODES), 'content' as const).describe(
+    'Must be "content", "files_with_matches", or "count". For context lines around matches, use -C instead.',
+  ),
   '-B': z
     .int()
     .min(0)

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -19,6 +19,7 @@ import {
 } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
 import { errorResult, executed } from '@tools/core/result';
+import { withDefault } from '@tools/core/schemaDefaults';
 import { ensureArray } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
@@ -61,12 +62,9 @@ type LeanLoogleInput = z.infer<typeof LeanLoogleInputSchema>;
 const LoogleHitSchema = z.looseObject({
   name: z.string(),
   type: z.string(),
-  // `.prefault()` only substitutes for `undefined`, not explicit `null` — and
-  // Loogle, like the sibling `doc` field below, may send either for `module`.
-  module: z
-    .string()
-    .nullish()
-    .transform((value) => value ?? ''),
+  // Loogle, like the sibling `doc` field below, may send either undefined or
+  // explicit null for `module`; `withDefault` (unlike `.prefault()`) covers both.
+  module: withDefault(z.string(), ''),
   // Loogle may omit, null, or empty `doc`; formatHit already guards on truthiness.
   doc: z.string().nullish(),
 });

--- a/src/tools/texcount/TexcountTool.ts
+++ b/src/tools/texcount/TexcountTool.ts
@@ -7,6 +7,7 @@ import { getTeXCount } from '@latex/texcount';
 import { ToolError, type ToolResult } from '@shared/schemas';
 import { defineTool } from '@tools/core/define';
 import { executed } from '@tools/core/result';
+import { withDefault } from '@tools/core/schemaDefaults';
 import { ensureArray } from '@utils/core';
 import { formatResultCount } from '@utils/text/stringUtils';
 
@@ -14,11 +15,10 @@ const TexcountInputSchema = z.strictObject({
   files: z
     .union([z.string(), z.array(z.string()).min(1)])
     .describe('LaTeX file path or non-empty list of LaTeX files to count.'),
-  mode: z
-    .enum(['separate', 'include', 'sum'])
-    .nullish()
-    .transform((v) => v ?? 'separate')
-    .describe('How texcount should combine files: separate, include, or sum.'),
+  mode: withDefault(
+    z.enum(['separate', 'include', 'sum']),
+    'separate' as const,
+  ).describe('How texcount should combine files: separate, include, or sum.'),
   format: z
     .enum(['raw', 'stats'])
     .nullish()

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -13,6 +13,7 @@ import {
 } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
 import { executed } from '@tools/core/result';
+import { withDefault } from '@tools/core/schemaDefaults';
 
 const DDG_TIMEOUT_MS = 15_000; // 15 s
 const DDG_RETRIES = 2;
@@ -21,13 +22,9 @@ const WebSearchInputSchema = z.strictObject({
   query: z
     .string()
     .describe('Search query to send to the web search provider.'),
-  max_results: z
-    .number()
-    .min(1)
-    .max(5)
-    .nullish()
-    .transform((v) => v ?? 3)
-    .describe('Maximum number of search results to return, up to 5.'),
+  max_results: withDefault(z.number().min(1).max(5), 3).describe(
+    'Maximum number of search results to return, up to 5.',
+  ),
 });
 
 export type WebSearchInput = z.infer<typeof WebSearchInputSchema>;


### PR DESCRIPTION
## Summary

A repo-wide tech-debt scan flagged two concentrated, low-risk duplications in `src/tools/`. This PR fixes both:

1. **Delegation child-execution registration** was copy-pasted across `subagentExecution.ts` and `inBandSubagentExecution.ts`: parse the agent config → derive the child stream id → `registerOwnedExecution`. The stream-id derivation is fragile by the code's own admission — a comment warns it "must match the id `buildAgentLaunchContext` actually reserves for this executionId... or the loop acquires the wrong follow-up queue/interrupt slot" — yet that invariant was re-explained (and re-risked) at every call site.
2. **Tool input schemas** repeated the same `.nullish().transform((v) => v ?? DEFAULT)` triplet 12 times across 9 files, needed because OpenAI-compatible structured output requires optional fields to also be nullable, so a plain `.default()` (which only catches `undefined`, not `null`) doesn't work.

**Update:** review caught that the first extraction initially widened `executeInBand`'s try/catch to also cover config parsing, reclassifying a config-validation failure as a retryable `SubagentDurabilityError` (→ a run-fatal `WorkflowRunAbortError` in the workflow-script runner) instead of letting it propagate raw. Fixed by splitting the helper into a pure `parseAgentChildConfig()` step (called before the try) and `registerParsedAgentChildExecution()` (the part that can actually fail as an infrastructure error) — see review thread discussion for detail.

## Issue acceptance gates

No tracked issue; this is a proactive tech-debt cleanup from a codebase-wide quality scan. Gates self-imposed for this PR: behavior-preserving (verified by full typecheck + the existing test suite, including the test that pins the stream-id invariant, and re-verified after the error-classification fix above), no new duplication introduced, no dead exports.

## Single source of truth

- `src/tools/delegation/registerAgentChildExecution.ts` is now the one place that parses an `AgentConfigPayload`, derives the child `StreamTabId`, and registers the owned execution lease for a plain-agent child. It exposes three functions: `parseAgentChildConfig()` (pure parse+derive), `registerParsedAgentChildExecution()` (the lease-registration call alone, for a caller that needs to keep parse errors outside its own try/catch), and `registerAgentChildExecution()` (both combined, for a caller with no such distinction to preserve). The stream-id-must-match-`AgentLaunchContext` invariant is documented and enforced here once instead of twice.
- `src/tools/core/schemaDefaults.ts`'s `withDefault()` is now the one implementation of the nullish-but-defaulted tool-input-field pattern.

## Duplication and abstraction budget

Removed: the ~25-line registration ceremony duplicated between `subagentExecution.ts` (`executeSubagent`) and `inBandSubagentExecution.ts` (`executeInBand`), including its safety-critical explanatory comment. Removed: 12 near-identical 3-5 line `.nullish().transform(...)` blocks across 9 tool-schema files, collapsed to one-line `withDefault(schema, value)` calls.

`subagentExecution.ts` uses the combined `registerAgentChildExecution()` (1 caller); `inBandSubagentExecution.ts` uses the split `parseAgentChildConfig()` + `registerParsedAgentChildExecution()` (1 caller each, plus `registerAgentChildExecution()` itself calls both internally) to preserve its pre-existing error-boundary. `withDefault()` has 12 call sites across 9 files. All consistent with the project's "factories need multiple callers" rule — no speculative generality, no options nobody uses.

`WorkflowScriptTool.ts`'s registration was deliberately left alone: its config shape (`name`/`instruction`/`model`, not a full `AgentConfig`) and identity kind (`multiAgentWorkflow`, not `agent`) genuinely differ, so folding it into the same helper would have required a lossy, overly-generic signature for a false convergence.

## Net elements (R6)

- Files: 13 changed across both commits, 2 new (`registerAgentChildExecution.ts`, `schemaDefaults.ts`), 11 modified.
- Exported symbols: `+3` (`registerAgentChildExecution`, `parseAgentChildConfig`, `registerParsedAgentChildExecution`, `withDefault` — 4 total, one dropped from the initial count since the fix split one export into three); `0` removed.
- Classes/interfaces/enums: `+4` interfaces in the registration helper (`ParsedAgentChildConfig`, `RegisterParsedAgentChildExecutionOptions`, `RegisterAgentChildExecutionOptions`, `RegisterAgentChildExecutionResult`); none elsewhere.
- Net LoC: positive (two new small, documented helper files carry their own header/imports, and the error-classification fix added a further explanatory comment), but the actual duplicated *logic* — the registration ceremony and the transform triplet — is now expressed exactly once per concept instead of 2–3 times.

## Consumer counts (R8)

Not a removed/re-routed emit path or export — n/a. (New exports each have 1–12 consumers, listed above.)

## Host impact

Extension: none — `src/tools/` is host-agnostic; no `packages/extension` files touched.

Desktop: none — no `packages/desktop` files touched.

CLI: none — no `packages/cli` files touched.

## Scheduled refactoring

None. This PR intentionally stops at two well-scoped, low-risk wins from the broader scan; larger items identified (provider model-handler orchestration duplication, the two parallel transcript persistence stores, settings threaded through 5–7 files, CLI-vs-extension tool-render duplication) are left for separate, individually-reviewed PRs given their higher risk/complexity.

## Validation

- `npm run typecheck` — full workspace (core, test-kernel, agent package build, cli, trace-viewer, desktop) — clean, re-run after the error-classification fix.
- `npx eslint` on every touched file — clean.
- `npx vitest run src/test-kernel/tools` — 98 test files, 802 tests, all passing (includes `SubagentExecutionChildStreamId.vitest.ts`, which pins the exact invariant this refactor had to preserve) — re-run after the fix.
- `npm run check:dead-code-ratchet` — no new unused exports/files (8 baseline, unchanged).
- `npx prettier --write` on every touched file — already properly formatted.
