### PR TITLE
fix(executions): pin the KV-named-directory skip and correct two run-file docs

### DIFF
--- a/src/agent/storage/resumability.ts
+++ b/src/agent/storage/resumability.ts
@@ -42,7 +42,12 @@ export const RESUMABILITY_CAUSE = {
   INVALID_META: 'invalid-meta',
   UNREADABLE_FLOW: 'unreadable-flow',
   UNREADABLE_META: 'unreadable-meta',
-  /** A host still holds the execution's lease — it is running, not waiting. */
+  /**
+   * The execution's lease is still held, so it is not waiting to be resumed.
+   * `inspectExecutionLease` reports `foreign` for any owner it cannot prove
+   * dead, so this covers both a demonstrably live host and an owner whose
+   * liveness is merely unprovable — both fail closed for the same reason.
+   */
   ACTIVE_LEASE: 'active-lease',
   /** Ownership could not be classified, so liveness is unproven. */
   UNREADABLE_LEASE: 'unreadable-lease',

--- a/src/test-kernel/tools/RunGeneratedFiles.vitest.ts
+++ b/src/test-kernel/tools/RunGeneratedFiles.vitest.ts
@@ -33,11 +33,14 @@ describe('listRunGeneratedFiles', () => {
       [path.join(RUN_PATH, 'vanished.tex')]: 'gone',
       [path.join(RUN_PATH, 'blocked.tex')]: 'blocked',
       [path.join(RUN_PATH, 'unreadable.tex')]: 'unreadable',
+      // A KV-*named* directory is internal metadata all the way down: the walk
+      // must skip it before recursing, or its children leak into the listing.
+      [path.join(RUN_PATH, 'meta.json', 'buried.tex')]: 'buried',
     },
   });
   afterEach(() => vi.restoreAllMocks());
 
-  it('lists generated metadata in path order and omits concurrent disappearance', async () => {
+  it('lists in path order, skipping KV-named subtrees and concurrent disappearance', async () => {
     failStatFor(
       path.join(RUN_PATH, 'vanished.tex'),
       fsError('ENOENT', 'entry disappeared after readDir'),

--- a/src/tools/executions/executionKvFiles.ts
+++ b/src/tools/executions/executionKvFiles.ts
@@ -1,10 +1,10 @@
 /**
  * Internal KV metadata files stored alongside an execution's generated
- * output. Shared by the run-directory listing in `ExecutionsTool.ts` and the
- * CLI's history file listing (`packages/cli/src/runtime/history/generatedFiles.ts`)
- * so the two stay in sync on what counts as internal metadata.
+ * output. Consumed by `runGeneratedFiles.ts`, the single run-directory walk
+ * behind both the agent-facing `/executions/{id}/files` listing and the CLI's
+ * history file listing, so the two agree on what counts as internal metadata.
  *
- * The reserved-key vocabulary itself (meta, config, todos, `child-*`, …) is
+ * The reserved-key vocabulary itself (meta, config, report, `child-*`, …) is
  * owned by `ExecutionKVStore`; the `flow_*` prefix is owned by
  * `persistedFlow`; workflow checkpoint keys are owned by `multiAgentWorkflow`.
  * This module only strips the on-disk `.json` suffix and defers to those


### PR DESCRIPTION
Review follow-ups to #10927 (`refactor(executions): share one run-file walk, gate resumable listings on lease liveness`), which merged before they could land. Closes #10936, closes #10937.

## The regression test #10927 owed

#10927's headline user-facing fix was the KV-named-**directory** skip. The old `ExecutionsTool` walk filtered KV entries by basename *after* walking, so a directory whose name satisfied `isKVFile` was dropped from the listing but its children were kept — a generated file nested there appeared in the agent's `/executions/{id}/files` and never in `texra history`. The CLI copy skipped before recursion and never saw them. The shared walk took the CLI behavior; nothing pinned it.

`src/test-kernel/tools/RunGeneratedFiles.vitest.ts` now carries a `meta.json/buried.tex` fixture, so the suite's existing exact-listing assertion is the regression pin — no new test file, no new case, one fixture. Verified by removing the `isKVFile(name)` skip: the assertion fails with both `meta.json` and `meta.json/buried.tex` present.

**One correction to the reviews and to #10927's own body:** `todos` is not a reserved KV key, so the `todos.json/` example everyone (including me) used would not have reproduced this. `RESERVED_KEY_NAMES` derives from `SINGLE_VALUE_KEYS` — `meta`, `config`, `report`, `workspace-files`, `result-meta`, `turn-state` — plus the `child-*` prefix, `flow_*`, and the workflow-script / stable-subagent checkpoint keys. `meta.json` is the smallest name that actually reproduces it.

## Two doc corrections in the same territory

- `executionKvFiles.ts`'s header named `packages/cli/src/runtime/history/generatedFiles.ts` as its CLI consumer — a file #10927 deleted. It now points at `runGeneratedFiles.ts`, the single walk behind both surfaces.
- The same header's reserved-key example listed `todos`, which was never in the set. Corrected while it was under the cursor, since that stale example is what seeded the wrong reproduction above.
- `RESUMABILITY_CAUSE.ACTIVE_LEASE` said "a host still holds the lease — it is running". `inspectExecutionLease` returns `foreign` for any owner it cannot prove dead, so the cause also fires for an owner whose liveness is merely unprovable. The comment now covers both and states why they fail closed identically: without proof that nobody owns the run, offering it invites a double resume.

## Not included

#10938 (unit tests for `deriveOfferableResumability`'s four branches) stays open and declined for now — it is a fail-closed gate over an existing derivation plus `inspectExecutionLease`, whose classification is already pinned in `ExecutionLease.vitest.ts`, so pinning the branches means mocking a churning module seam for assertions that restate the `if`. Rationale in #10927's discussion.

## Verification

`npm run typecheck`, `FORCE_COLOR=0 npx vitest run src/test-kernel/tools/RunGeneratedFiles.vitest.ts src/test-kernel/agent/storage/Resumability.vitest.ts` (18 passed), `npm run format:check`, `eslint` on the three changed files, `npm run check:guidance-refs`, `npm run check:dead-code-ratchet` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
