### PR TITLE
Dedup architecture-ratchet SCAN_ROOTS and agent build-script fs helpers

### DIFF
--- a/packages/agent/scripts/fsWalk.mjs
+++ b/packages/agent/scripts/fsWalk.mjs
@@ -1,0 +1,23 @@
+import { readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+export async function isFile(filePath) {
+  try {
+    return (await stat(filePath)).isFile();
+  } catch (error) {
+    if (error?.code === 'ENOENT' || error?.code === 'ENOTDIR') return false;
+    throw error;
+  }
+}
+
+export async function walkFiles(directory, predicate) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const nested = await Promise.all(
+    entries.map((entry) => {
+      const target = path.join(directory, entry.name);
+      if (entry.isDirectory()) return walkFiles(target, predicate);
+      return !predicate || predicate(entry.name) ? [target] : [];
+    }),
+  );
+  return nested.flat();
+}

--- a/packages/agent/scripts/rewrite-declaration-aliases.mjs
+++ b/packages/agent/scripts/rewrite-declaration-aliases.mjs
@@ -1,6 +1,8 @@
-import { readFile, readdir, stat, writeFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { isFile, walkFiles } from './fsWalk.mjs';
 
 const packageRoot = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
 const repositoryRoot = path.resolve(packageRoot, '../..');
@@ -15,15 +17,6 @@ const aliases = Object.entries(tsconfig.compilerOptions.paths)
     ),
   )
   .toSorted(([left], [right]) => right.length - left.length);
-
-async function isFile(filePath) {
-  try {
-    return (await stat(filePath)).isFile();
-  } catch (error) {
-    if (error?.code === 'ENOENT' || error?.code === 'ENOTDIR') return false;
-    throw error;
-  }
-}
 
 async function resolveSource(specifier) {
   for (const [pattern, targets] of aliases) {
@@ -61,21 +54,6 @@ function emittedPath(sourcePath) {
     .replace(/\.tsx?$/u, '.d.ts');
 }
 
-async function declarationFiles(directory) {
-  const entries = await readdir(directory, { withFileTypes: true });
-  const nested = await Promise.all(
-    entries.map((entry) => {
-      const target = path.join(directory, entry.name);
-      return entry.isDirectory()
-        ? declarationFiles(target)
-        : entry.name.endsWith('.d.ts')
-          ? [target]
-          : [];
-    }),
-  );
-  return nested.flat();
-}
-
 const moduleSpecifier =
   /(?<prefix>\bfrom\s*|\bimport\s*\(\s*|\bimport\s+|\bexport\s+\*\s+from\s*)(?<quote>['"])(?<specifier>[^'"]+)\k<quote>/gu;
 
@@ -106,7 +84,9 @@ async function resolveDeclarationSpecifier(specifier, declaration) {
   return relative.startsWith('.') ? relative : `./${relative}`;
 }
 
-for (const declaration of await declarationFiles(outputRoot)) {
+for (const declaration of await walkFiles(outputRoot, (name) =>
+  name.endsWith('.d.ts'),
+)) {
   const original = await readFile(declaration, 'utf8');
   let rewritten = '';
   let cursor = 0;

--- a/packages/agent/scripts/validate-artifacts.mjs
+++ b/packages/agent/scripts/validate-artifacts.mjs
@@ -1,6 +1,8 @@
-import { readFile, readdir, stat } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { isFile, walkFiles } from './fsWalk.mjs';
 
 const packageRoot = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
 const repositoryRoot = path.resolve(packageRoot, '../..');
@@ -12,27 +14,7 @@ const rootTsconfig = JSON.parse(
   await readFile(path.join(repositoryRoot, 'tsconfig.json'), 'utf8'),
 );
 
-async function filesBelow(directory) {
-  const entries = await readdir(directory, { withFileTypes: true });
-  const nested = await Promise.all(
-    entries.map((entry) => {
-      const target = path.join(directory, entry.name);
-      return entry.isDirectory() ? filesBelow(target) : [target];
-    }),
-  );
-  return nested.flat();
-}
-
-async function isFile(filePath) {
-  try {
-    return (await stat(filePath)).isFile();
-  } catch (error) {
-    if (error?.code === 'ENOENT' || error?.code === 'ENOTDIR') return false;
-    throw error;
-  }
-}
-
-const allFiles = await filesBelow(distRoot);
+const allFiles = await walkFiles(distRoot);
 const declarationFiles = allFiles.filter((file) => file.endsWith('.d.ts'));
 const declarationText = (
   await Promise.all(declarationFiles.map((file) => readFile(file, 'utf8')))

--- a/src/test-kernel/architecture/agentRuntimeProgressEventsBoundary.vitest.ts
+++ b/src/test-kernel/architecture/agentRuntimeProgressEventsBoundary.vitest.ts
@@ -7,6 +7,7 @@ import * as ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 import {
+  ALL_HOST_PRODUCTION_ROOTS,
   REPO_ROOT,
   SOURCE_FILE,
   sourceFilesUnder,
@@ -38,17 +39,10 @@ const ALLOWED_CLI_PROJECTION_IMPORTERS = [
   'src/test-kernel/cli/RunProgressRenderer.vitest.ts',
 ] as const;
 
-const SCAN_ROOTS = [
-  'packages/cli/src',
-  'packages/desktop/src',
-  'packages/extension/src',
-  'src',
-] as const;
-
 const SOURCE_OR_OUTPUT_EXTENSION = /\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;
 
 function scanFiles(excludeTestKernel: boolean): string[] {
-  return SCAN_ROOTS.flatMap((root) =>
+  return ALL_HOST_PRODUCTION_ROOTS.flatMap((root) =>
     sourceFilesUnder(resolve(REPO_ROOT, root), {
       missingDirReturnsEmpty: true,
       repoRelative: true,

--- a/src/test-kernel/architecture/approvalPolicyAuthorityRatchet.vitest.ts
+++ b/src/test-kernel/architecture/approvalPolicyAuthorityRatchet.vitest.ts
@@ -6,17 +6,12 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  ALL_HOST_PRODUCTION_ROOTS,
+  expectRealCoverage,
   productionFilesUnder,
   REPO_ROOT,
   stripComments,
 } from '../support/repoScan';
-
-const SCAN_ROOTS = [
-  'packages/cli/src',
-  'packages/desktop/src',
-  'packages/extension/src',
-  'src',
-] as const;
 
 /** Only the shared module may define the three-value TeXRA policy vocabulary. */
 const VOCABULARY_OWNER = 'src/shared/approvalPolicy.ts';
@@ -67,7 +62,7 @@ function offendersMatching(
   pattern: RegExp,
   allowlist: ReadonlySet<string>,
 ): string[] {
-  return SCAN_ROOTS.flatMap(productionFilesUnder)
+  return ALL_HOST_PRODUCTION_ROOTS.flatMap(productionFilesUnder)
     .filter((file) => !allowlist.has(file))
     .filter((file) => pattern.test(readProductionSource(file)))
     .toSorted();
@@ -106,10 +101,6 @@ describe('approval policy authority ratchet', () => {
   });
 
   it('actually scans the production source roots', () => {
-    const scanned = SCAN_ROOTS.reduce(
-      (total, root) => total + productionFilesUnder(root).length,
-      0,
-    );
-    expect(scanned).toBeGreaterThan(100);
+    expectRealCoverage(ALL_HOST_PRODUCTION_ROOTS);
   });
 });

--- a/src/test-kernel/architecture/progressEventHandlerRetirement.vitest.ts
+++ b/src/test-kernel/architecture/progressEventHandlerRetirement.vitest.ts
@@ -6,6 +6,8 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  ALL_HOST_PRODUCTION_ROOTS,
+  expectRealCoverage,
   productionFilesUnder,
   REPO_ROOT,
   stripComments,
@@ -20,13 +22,6 @@ const RETIRED_DESKTOP_PROGRESS_BRIDGE_TERMS = [
   'DesktopProgressEventBridge',
   'desktopProgressEventBridge',
   'progress-event bridge',
-] as const;
-
-const SCAN_ROOTS = [
-  'packages/cli/src',
-  'packages/desktop/src',
-  'packages/extension/src',
-  'src',
 ] as const;
 
 function mentionsRetiredSymbol(file: string): boolean {
@@ -50,7 +45,7 @@ describe('ProgressEventHandler retirement boundary', () => {
   );
 
   it('removes the ProgressEventHandler class name from production sources', () => {
-    const offenders = SCAN_ROOTS.flatMap(productionFilesUnder)
+    const offenders = ALL_HOST_PRODUCTION_ROOTS.flatMap(productionFilesUnder)
       .filter(mentionsRetiredSymbol)
       .toSorted();
 
@@ -66,10 +61,6 @@ describe('ProgressEventHandler retirement boundary', () => {
   });
 
   it('actually scans the production source roots', () => {
-    const scanned = SCAN_ROOTS.reduce(
-      (total, root) => total + productionFilesUnder(root).length,
-      0,
-    );
-    expect(scanned).toBeGreaterThan(100);
+    expectRealCoverage(ALL_HOST_PRODUCTION_ROOTS);
   });
 });

--- a/src/test-kernel/architecture/sessionFactAmbientHelperRetirement.vitest.ts
+++ b/src/test-kernel/architecture/sessionFactAmbientHelperRetirement.vitest.ts
@@ -6,17 +6,12 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  ALL_HOST_PRODUCTION_ROOTS,
+  expectRealCoverage,
   productionFilesUnder,
   REPO_ROOT,
   stripComments,
 } from '../support/repoScan';
-
-const SCAN_ROOTS = [
-  'packages/cli/src',
-  'packages/desktop/src',
-  'packages/extension/src',
-  'src',
-] as const;
 
 const RETIRED_AMBIENT_HELPER_SYMBOL = /\bemitRuntimeEvent\b/;
 
@@ -27,7 +22,7 @@ function referencesEmitRuntimeEvent(file: string): boolean {
 
 describe('ambient session-fact helper retirement', () => {
   it('keeps the retired ambient session-fact helper out of production code', () => {
-    const references = SCAN_ROOTS.flatMap(productionFilesUnder)
+    const references = ALL_HOST_PRODUCTION_ROOTS.flatMap(productionFilesUnder)
       .filter(referencesEmitRuntimeEvent)
       .toSorted();
 
@@ -35,10 +30,6 @@ describe('ambient session-fact helper retirement', () => {
   });
 
   it('actually scans the production source roots', () => {
-    const scanned = SCAN_ROOTS.reduce(
-      (total, root) => total + productionFilesUnder(root).length,
-      0,
-    );
-    expect(scanned).toBeGreaterThan(100);
+    expectRealCoverage(ALL_HOST_PRODUCTION_ROOTS);
   });
 });

--- a/src/test-kernel/architecture/transcriptResidencyLeaseSites.vitest.ts
+++ b/src/test-kernel/architecture/transcriptResidencyLeaseSites.vitest.ts
@@ -6,17 +6,11 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  ALL_HOST_PRODUCTION_ROOTS,
   productionFilesUnder,
   REPO_ROOT,
   stripComments,
 } from '../support/repoScan';
-
-const SCAN_ROOTS = [
-  'packages/cli/src',
-  'packages/desktop/src',
-  'packages/extension/src',
-  'src',
-] as const;
 
 /** Runtime sites allowed to perform ordinary transcript hydration. */
 const HYDRATION_SITE_ALLOWLIST = new Set([
@@ -37,7 +31,7 @@ const PRESENTATION_LEASE_SITE_ALLOWLIST = new Set([
 
 /** Files under a scan root that match `pattern` and are not allowlisted. */
 function findOffenders(pattern: RegExp, allowlist: Set<string>): string[] {
-  return SCAN_ROOTS.flatMap(productionFilesUnder)
+  return ALL_HOST_PRODUCTION_ROOTS.flatMap(productionFilesUnder)
     .filter((file) => !allowlist.has(file))
     .filter((file) =>
       pattern.test(

--- a/src/test-kernel/support/repoScan.ts
+++ b/src/test-kernel/support/repoScan.ts
@@ -7,10 +7,20 @@ import { readdirSync } from 'node:fs';
 import { join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { expect } from 'vitest';
+
 export const REPO_ROOT = resolve(
   fileURLToPath(new URL('.', import.meta.url)),
   '../../..',
 );
+
+/** The four host production roots most architecture ratchets scan. */
+export const ALL_HOST_PRODUCTION_ROOTS = [
+  'packages/cli/src',
+  'packages/desktop/src',
+  'packages/extension/src',
+  'src',
+] as const;
 
 export const SOURCE_FILE = /\.(?:ts|tsx|mts|cts)$/;
 
@@ -55,6 +65,15 @@ export function productionFilesUnder(root: string): string[] {
     repoRelative: true,
     excludeTestKernel: true,
   });
+}
+
+/** Guards against a silently-vacuous scan across `roots` matching none of `min`. */
+export function expectRealCoverage(roots: readonly string[], min = 100): void {
+  const scanned = roots.reduce(
+    (total, root) => total + productionFilesUnder(root).length,
+    0,
+  );
+  expect(scanned).toBeGreaterThan(min);
 }
 
 /** Drop comments so a prose mention like "do not import from 'vscode'" can't

--- a/src/test-kernel/support/repoScan.ts
+++ b/src/test-kernel/support/repoScan.ts
@@ -15,12 +15,12 @@ export const REPO_ROOT = resolve(
 );
 
 /** The four host production roots most architecture ratchets scan. */
-export const ALL_HOST_PRODUCTION_ROOTS = [
+export const ALL_HOST_PRODUCTION_ROOTS = Object.freeze([
   'packages/cli/src',
   'packages/desktop/src',
   'packages/extension/src',
   'src',
-] as const;
+] as const);
 
 export const SOURCE_FILE = /\.(?:ts|tsx|mts|cts)$/;
 


### PR DESCRIPTION
## Summary

A structural layer-boundary audit (12 seams, adversarially verified) found the codebase's core/host separation to be healthy overall — no genuine abstraction-layer violations survived scrutiny. It did surface two small, low-risk, verified duplications outside the layering question itself, both fixed here:

1. Five files under `src/test-kernel/architecture/` each hardcoded the same four-entry `SCAN_ROOTS` array, and three of them additionally hand-wrote an identical "reduce + `toBeGreaterThan(100)`" coverage sanity check.
2. `packages/agent/scripts/validate-artifacts.mjs` and `rewrite-declaration-aliases.mjs` — two sequential steps in the agent SDK's own build pipeline — each defined a byte-identical `isFile()` check and a near-identical recursive directory walker.

## Issue acceptance gates

No linked issue; this is the audit's own shortlist. Acceptance gate: both dedups are behavior-preserving (verified by tests + a real build run) and touch no production/public-API surface.

## Single source of truth

- `src/test-kernel/support/repoScan.ts` now owns `ALL_HOST_PRODUCTION_ROOTS` (the four-root array) and `expectRealCoverage(roots, min)` (the sanity-check body) for the architecture ratchets that scan all four host roots.
- `packages/agent/scripts/fsWalk.mjs` now owns `isFile()` and `walkFiles(directory, predicate?)` for the agent package's own build scripts.

`hostedAuthImportBoundary.vitest.ts` (different, narrower root set) and `dependencyDirection.vitest.ts` (uses `VSCODE_FREE_ZONES`, unrelated) were deliberately left alone.

## Duplication and abstraction budget

Removed: 5 duplicated local `SCAN_ROOTS` consts, 3 duplicated coverage-check bodies, 2 duplicated `isFile()` definitions, and 2 near-identical directory walkers (`filesBelow`/`declarationFiles`).

Added: 2 new exports on the existing `repoScan.ts` test-support module (no new file) and one new file, `fsWalk.mjs`, with 2 exports, imported by exactly its two real callers. No new abstraction layer — both additions sit in the same tier (test-support plumbing, build-script plumbing) the duplicated code already lived in.

The two scripts' `moduleSpecifier` regexes were *not* merged — they were verified to be genuinely different (one is a strict superset of the other, plus a third distinct regex in `validate-artifacts.mjs`), so merging them would have silently changed what each script checks.

## Net elements (R6)

Diffstat: 9 files changed, 68 insertions(+), 103 deletions(-), net **-35 LoC**.

Exported symbols: +4 (`ALL_HOST_PRODUCTION_ROOTS`, `expectRealCoverage`, `isFile`, `walkFiles`). Local (unexported) bindings removed: 9 (5× `SCAN_ROOTS`, `isFile`×2, `filesBelow`, `declarationFiles`) minus 3 sanity-check bodies collapsed to one-line calls. Net element delta: -4 (test-kernel/architecture) and -1 (agent scripts).

## Consumer counts (R8)

Not deleting or re-routing an emit path or export — n/a.

## Host impact

Extension: none.

Desktop: none.

CLI: none.

Both changes are confined to test-kernel test-support tooling and the agent SDK's own build-time Node scripts; no runtime/production path is touched.

## Scheduled refactoring

None — this exhausts the audit's verified, actionable findings. (The audit also noted a few sub-threshold advisory items — a 3-import layering inversion in the flow kernel, two hardcoded terminal-action strings, an undocumented sync/stream constraint in `AbsoluteFS`, and a 4-entry if-chain that could become a table — none cleared the bar for action.)

## Validation

- `npx vitest run src/test-kernel/architecture` — 17 files, 101 tests, all pass.
- `npx vitest run src/test-kernel` — full suite, 871 files / 10664 tests pass (6 pre-existing skips).
- `npm run typecheck` — passes, including `typecheck:agent`, which runs the actual `packages/agent` build (`clean → bundle → tsc → rewrite-declaration-aliases.mjs → validate-artifacts.mjs`) end-to-end through the new `fsWalk.mjs` and reports "Validated 721 declarations and 69 external packages."
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — 8 findings, unchanged from baseline (no new dead code).
- `npx prettier --check` — clean (repoScan.ts formatting auto-fixed).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CE25QyPn54mg7Ptg8N6RhP)_