### PR TITLE
docs(runtime): make the stop-gesture split explicit, wire the CLI detach setter

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -327,6 +327,10 @@ export function createChatSessionController(
     clearApprovals();
     if (!session.streamId) return;
     session.interruptedStreamId = session.streamId;
+    // Ctrl-C is a configured stop surface: the user stopped the root run, so
+    // the detach-on-stop toggle decides whether active subagents survive it.
+    // `stopStream` below is the other gesture and answers deliberately
+    // differently.
     runtimeSession.executions.stopAgentStream(session.streamId, {
       detachActiveChildren: detachSubagentsOnStop(),
     });
@@ -862,6 +866,11 @@ export function createChatSessionController(
       requestStop();
       session.interruptedStreamId = streamId;
     }
+    // Bare Escape is a focus-scoped gesture — "stop only the focused stream"
+    // (#9009) — so descendants are always detached rather than cascaded into:
+    // the user stopped one stream, not the tree. The detach-on-stop toggle
+    // governs the configured stop surfaces (Ctrl-C above, the TUI kill action,
+    // the GUI stop buttons) and is deliberately not consulted here.
     runtimeSession.executions.stopAgentStream(streamId, {
       detachActiveChildren: true,
     });

--- a/src/agent/runtime/detachSubagentsOnStop.ts
+++ b/src/agent/runtime/detachSubagentsOnStop.ts
@@ -5,10 +5,25 @@ import { WorkspaceStateKey } from '@shared/state/stateKeys';
  * Whether stopping or killing an agent stream should detach its active child
  * executions instead of letting them die with the parent.
  *
- * Read live at stop/kill time so the desktop and extension settings toggle
- * takes effect immediately, and shared by every host (extension stop command,
- * desktop execution, CLI session controller and TUI kill, and the orchestrator
- * kill tool) so the `detachActiveChildren` policy has one source of truth.
+ * Read live at stop/kill time so a settings change takes effect immediately.
+ *
+ * This owns the policy for the *configured* stop surfaces, in every host: the
+ * extension stop command and review-run stop, the desktop stream stop, the CLI
+ * root-run interrupt (Ctrl-C) and TUI kill action, and the orchestrator
+ * `executions` kill tool. Two stop paths deliberately do not consult it, and
+ * each declares that at its own call site rather than reading a default:
+ *
+ * - Bare Escape in the CLI TUI is a focus-scoped gesture — "stop only the
+ *   focused stream" — so `stopStream` always detaches descendants instead of
+ *   cascading into streams the user never focused
+ *   (`packages/cli/src/chat/chatSessionController.ts`, #9009).
+ * - Headless CLI shutdown always cascades: a detached child cannot outlive the
+ *   exiting process, so honoring the toggle there would strand children
+ *   without finalization (`packages/cli/src/runtime/runExecution.ts`).
+ *
+ * Host quit is a separate axis this toggle does not govern. The extension and
+ * desktop abandon native children to the restart-repair path; the CLI kills or
+ * interrupts them, because the process that owns them is the one going away.
  *
  * The platform must be initialized before a run can be stopped or killed.
  */

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -43,7 +43,14 @@ import { SessionEventHub } from './SessionEventHub';
 
 const logger = createChannelTrace('executionRegistry');
 
-/** Child policy shared by `kill()` and `stopAgentStream()`. */
+/**
+ * Child policy shared by `kill()` and `stopAgentStream()`. The caller owns the
+ * decision because only it knows which gesture it is serving: the configured
+ * stop surfaces resolve it through `detachSubagentsOnStop()`, the CLI's
+ * focus-scoped bare-Escape stop always detaches, and process shutdown always
+ * cascades. Omitting the field means cascade — the conservative reading, since
+ * a child left running has no owner to report to.
+ */
 export interface ExecutionStopOptions {
   readonly detachActiveChildren?: boolean;
 }
@@ -563,7 +570,7 @@ export class ExecutionRegistry {
   }
 
   /**
-   * Stop a visible agent stream and apply the same child policy everywhere.
+   * Stop a visible agent stream and apply the caller's declared child policy.
    *
    * Hosts should call this instead of reconstructing stop behavior from
    * child-interrupts, root interrupts, and stream-status writes.

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -697,6 +697,11 @@ const GIT_WORKTREE_RUNTIME_REACHABILITY = {
   through:
     'packages/cli/src/runtime/initPlatform.ts -> packages/cli/src/runtime/gitAuthor.ts -> src/tools/delegation/DelegationTools.ts',
 } satisfies CliRuntimeReachability;
+const DETACH_SUBAGENTS_RUNTIME_REACHABILITY = {
+  command: 'texra chat',
+  through:
+    'packages/cli/src/commands/chat.ts -> packages/cli/src/chat/tui/runChatTui.tsx -> packages/cli/src/chat/chatSessionController.ts -> src/agent/runtime/detachSubagentsOnStop.ts',
+} satisfies CliRuntimeReachability;
 const WORKFLOW_COMPILE_RUNTIME_REACHABILITY = {
   command:
     'texra run <workflow-agent> --input paper.tex --instruction "revise the paper"',
@@ -979,8 +984,11 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       'Let active subagents continue when the orchestrator is stopped.',
     category: 'multi-agent',
     slots: sameSlot('workspaceState'),
-    honoredBy: everyHost('src/agent/runtime/detachSubagentsOnStop.ts'),
-    surfaces: { settingsView: 'multi-agent' },
+    honoredBy: everyHost(
+      'src/agent/runtime/detachSubagentsOnStop.ts',
+      DETACH_SUBAGENTS_RUNTIME_REACHABILITY,
+    ),
+    surfaces: { settingsView: 'multi-agent', cliConfig: true },
   }),
 
   // --- External coding agent controls ---------------------------------------

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -392,6 +392,8 @@ describe('state settings catalog', () => {
     //    tool-use agent prompts, skipping skill discovery when disabled.
     //  - texra.approvalPolicy is read by cliConfig / cliContext and seeded onto
     //    SessionHandle before bash/edit approval boundaries decide.
+    //  - detach-subagents-on-stop is read by detachSubagentsOnStop() when the
+    //    chat TUI stops the root run (Ctrl-C) or kills a subagent execution.
     // auto-open-pdf (no CLI opener), latexdiff, and the formatter are
     // intentionally excluded. Changing the CLI roster must be a deliberate edit
     // here, not an accident of flipping `honoredBy.cli` or `surfaces.cliConfig`.
@@ -404,6 +406,7 @@ describe('state settings catalog', () => {
         WorkspaceStateKey.CODEX_APPROVAL_POLICY,
         WorkspaceStateKey.CODEX_REASONING_EFFORT,
         WorkspaceStateKey.CODEX_SANDBOX_MODE,
+        WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
         WorkspaceStateKey.GIT_AUTHOR_EMAIL,
         WorkspaceStateKey.GIT_AUTHOR_NAME,
         WorkspaceStateKey.GIT_MARK_COMMITS,


### PR DESCRIPTION
## Summary

`src/agent/runtime/detachSubagentsOnStop.ts` documented itself as "shared by
every host … so the `detachActiveChildren` policy has one source of truth."
That is false at HEAD, and deliberately so. Two stop paths do not consult it,
and one of them — `stopStream` in `chatSessionController.ts` — sat with a bare
`detachActiveChildren: true` five hundred lines below `interruptActiveRun` in
the *same file*, which calls the SSOT. That is the "one host contradicts
itself" reading the discovery sweep flagged.

Enumerating every stop site at HEAD shows the shape is three **gestures**, not
one policy with exceptions. V8 (`docs/proposals/2026-08-15-cross-host-consolidation.md`
§3) already adjudicated two of them as deliberate action-semantic divergence
rather than SSOT bypass, and that adjudication is **not re-litigated here**.
What was missing is that the divergence was undeclared: the SSOT overclaimed,
and the divergent literals did not say why they were literals.

So this PR fixes it where it is — the SSOT's docblock and the two call sites —
and settles CP2's remaining half by giving the CLI a setter for a toggle it
already honors.

### Call-site table (all stop sites at HEAD, classified by gesture)

| # | Site | Value passed | Gesture | Verdict |
|---|------|--------------|---------|---------|
| 1 | `src/tools/ExecutionsTool.ts:1095` — orchestrator `executions` kill tool | `detachSubagentsOnStop()` | configured stop | correct, unchanged |
| 2 | `packages/extension/src/commands/agent/agentCommands.ts:6` — `stopAgent` command | `detachSubagentsOnStop()` | configured stop | correct, unchanged |
| 3 | `packages/extension/src/frontend/review/AgentReviewRunController.ts:123` — review-run stop | `detachSubagentsOnStop()` | configured stop | correct, unchanged |
| 4 | `packages/desktop/src/main/desktopAgentExecution.ts:313` — desktop `lifecycle.stopStream` | `detachSubagentsOnStop()` | configured stop | correct, unchanged |
| 5 | `packages/cli/src/chat/chatSessionController.ts:330` — `interruptActiveRun` (Ctrl-C root stop) | `detachSubagentsOnStop()` | configured stop | correct; **gained a declaring comment** so the in-file pair with #6 reads as two gestures, not a contradiction |
| 6 | `packages/cli/src/chat/chatSessionController.ts:865` — `stopStream` (bare Escape) | `true` | **focus-scoped stop** | correct per V8 / #9009; **gained the declaring comment** it lacked |
| 7 | `packages/cli/src/chat/tui/runChatTui.tsx:523` — TUI `onKillExecution` | `detachSubagentsOnStop()` | configured stop | correct, unchanged |
| 8 | `packages/cli/src/runtime/runExecution.ts:406` — `SHUTDOWN_PHASE.BEFORE` kill | `false` | **process shutdown** | correct per V8; already carries its declaring comment (landed earlier) |
| 9 | `packages/agent/src/index.ts:157` — SDK `interrupt()` | n/a (`liveHandle.interrupt()`) | **not a stream stop** | classified out: an embedder aborting the one run it owns. Children are stopped by the per-run `finally` (`index.ts:304-317`), because no embedder runs host shutdown handlers. |

Sites 6 and 8 are the two literals; V8 ruled both deliberate — bare Escape is
the focus-scoped gesture ("Stop only the focused stream", `App.tsx:149-152`)
and always detaches descendants, while headless shutdown always cascades
because a detached child cannot outlive the exiting process. Confirmed still
true at HEAD: `stopStream`'s only consumer chain is
`onInterruptStream` → `triggerEscapeInterrupt` / `handleBareEscape`
(`runChatTui.tsx:517`, `appInteractionPolicy.ts:96`, `App.tsx:596`), so it is
reachable from no surface other than bare Escape.

### What was refuted

**A `StopGesture` parameter on `ExecutionStopOptions` — rejected.** The brief
asked whether the gesture should become the parameter so the boolean literals
disappear. It should not, on four counts:

1. **Zero deletions.** §5b's standing rule: a new name is legitimate only if
   the PR deletes ≥2 hand-rolled equivalents in the same change. Enumeration
   found no hand-rolled equivalent to collapse — all nine sites already funnel
   through one option field on one shared owner, and `detachSubagentsOnStop()`
   would survive as the resolver's body. Net: +1 union type, +1 resolver,
   −0.
2. **It inverts the layering.** `ExecutionStopOptions` is a runtime-kernel
   contract in a VS Code-free zone. A `gesture` field makes the kernel's stop
   API speak UI vocabulary ("bare Escape", "stop button") and makes the
   registry read `platform().workspaceState` on its callers' behalf — pulling
   a settings read *into* the kernel that the hosts currently own. The
   push-UI-to-the-caller rule points the other way.
3. **It would be a classifier with two singleton classes.** 6 of 9 sites are
   the same gesture; the other two have exactly one call site each. That
   encodes the call-site list, not a policy.
4. **It re-litigates a closed ruling.** Lifecycle §4 already called a policy
   table beside the SSOT "an invented concept wearing a consolidation
   costume", and §5b recorded `ChildStopPolicy` as **REWORKED → "3 call-site
   repairs + 1 doc paragraph. No table."** A gesture enum is that table with
   the rows turned into type members.

**Making `detachActiveChildren` required — also rejected.** Tempting under
"define the edge out of existence", but the accounting does not support it:
all 9 production sites already pass it explicitly, so the trap has zero live
instances, while the change forces `{ detachActiveChildren: false }` onto 29
option-less test call sites across 4 suites (≈ +70 LoC of churn on a seam) to
guard a hypothetical. The omitted default is documented instead, at the type,
as a written decision rather than an accident.

## Issue acceptance gates

Not issue-driven. Sources: `docs/proposals/2026-08-15-cross-host-consolidation.md`
§3 V8 (adjudication) and CP2 (CLI setter gap);
`docs/proposals/2026-08-15-lifecycle-ownership.md` §4 item 2 (the doc paragraph
that never landed — item 1's explicit shutdown literal did land);
`docs/proposals/2026-08-15-shared-contracts-and-retirement.md` §5b (the
REWORKED verdict this PR honors).

- V8 documentation gap — **closed**: the SSOT now enumerates the three
  gestures instead of overclaiming universality, and both divergent literals
  declare themselves.
- Lifecycle §4 item 2 (quit-asymmetry paragraph at the SSOT declaration) —
  **closed**.
- CP2 "CLI has no setter" — **closed** (see Host impact).

## Single source of truth

`detachSubagentsOnStop()` (`src/agent/runtime/detachSubagentsOnStop.ts`)
remains the sole owner of the configured-stop child policy, and is now the
documentation home for the full gesture split, including the two paths that
deliberately answer without it and the separate host-quit axis it does not
govern. `src/shared/schemas/stateSettings.ts` remains the sole owner of which
hosts honor and can edit the toggle; the CLI `/config` roster derives from
`surfaces.cliConfig` there, not from a second list.

## Duplication and abstraction budget

**No new abstraction.** No new type, function, export, or file. The
`StopGesture`/`ChildStopPolicy` shape is explicitly rejected above under §5b's
"deletes ≥2 hand-rolled equivalents" rule.

Duplication avoided rather than removed: the alternative designs each would
have added a vocabulary layer over an SSOT that already exists.

The one non-comment change is the setting row: `surfaces.cliConfig: true` plus
a `CliRuntimeReachability` constant, both existing fields on an existing row —
the same shape `CODEX_SANDBOX_MODE`, `GIT_MARK_COMMITS`, and
`GIT_WORKTREE_SUPPORT` already use. It adds no catalog; it fills in two fields
the catalog already defines.

## Net elements (R6)

- **Files:** 5 changed, 0 added, 0 deleted (`5 files changed, 50 insertions(+), 8 deletions(-)`)
- **Exported symbols:** 0 added, 0 deleted (`^[+-]export` over the diff = 0)
- **Classes / interfaces / enums / type aliases:** 0 added, 0 deleted
- **Functions:** 0 added, 0 deleted
- **Module-level constants:** +1 (`DETACH_SUBAGENTS_RUNTIME_REACHABILITY`, file-local, non-exported, one consumer — matches the four sibling reachability constants beside it)
- **Net LoC:** +42, of which **+40 is comment and documentation text** and +2 is the setting row (`cliConfig: true`, the reachability reference) plus its test-pin line

The net-add is deliberate and is the deliverable: the refuted alternatives were
the LoC-negative-looking ones that add vocabulary. The two structural changes
here (a setting surface flag, a roster pin) are the CP2 fix.

## Consumer counts (R8)

No emit path or export deleted or re-routed. Grepped, for the record:

- `detachSubagentsOnStop` — 6 production call sites (`ExecutionsTool.ts`,
  `agentCommands.ts`, `AgentReviewRunController.ts`, `desktopAgentExecution.ts`,
  `chatSessionController.ts`, `runChatTui.tsx`); unchanged by this PR.
- `ExecutionStopOptions.detachActiveChildren` — 9 production sites (table
  above) + 5 test sites passing it explicitly + 29 test sites relying on the
  documented cascade default; **signature unchanged**, so all remain valid.
- `WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP` — readers unchanged. Writers
  gain one: the CLI `/config` panel, via `CLI_STATE_SETTINGS`
  (`packages/cli/src/commands/config.ts:63`,
  `packages/cli/src/chat/tui/forms/CliConfigForm.tsx:150`), both of which
  derive from `surfaces.cliConfig` with no per-key wiring.
- `CLI_STATE_SETTINGS` — 2 production consumers (both above) + 2 test suites;
  membership grows by 1, and the deliberate-edit pin in
  `src/test-kernel/shared/stateSettings.vitest.ts:399` is updated with its
  rationale line, as that pin requires.

## Host impact

**Extension:** No behavior change. Its two stop surfaces already consult the
toggle and are unchanged; the settings view already offers the checkbox.

**Desktop:** No behavior change. Same as the extension.

**CLI:** One user-visible change — `texra` gains a setter for
`texra.detachSubagentsOnStop` ("Keep subagents running") in the `/config` TUI
panel and `texra config` listing. Previously the CLI *honored* the toggle at
three sites but offered no way to change it, so its only settable value was
whatever the extension, desktop, or a hand-edited `state.json` had left in the
shared store — an advertised-but-unsettable toggle. Storage slot is unchanged
(`workspaceState`, the shared `~/.texra` state store), so a value set in one
host is the value every host reads. Stop *behavior* is unchanged in all three
hosts: no call site's resolved value moved.

## Scheduled refactoring

`ALLOW_ORCHESTRATOR_KILL` is the exact same shape — honored by the CLI through
`src/tools/ExecutionsTool.ts`, surfaced only in the extension/desktop settings
view, no CLI setter. It is deliberately out of scope here to keep this PR to
the adjudicated finding; it needs the same two fields
(`surfaces.cliConfig: true` + a reachability path) whenever the settings-catalog
track next touches the multi-agent category.

Toggle-store unification (the extension's Memento vs the shared `state.json`)
stays owned by the settings-catalog work per the 2026-08-15 maintainer ruling;
untouched here.

## Validation

- `npm run typecheck` — pass (all workspaces)
- `FORCE_COLOR=0 npx vitest run src/test-kernel/agent/runtime src/test-kernel/settings src/test-kernel/cli` — 3200 passed, 1 skipped. The 2 failures in `src/test-kernel/cli/TranscriptSessionPolicy.vitest.ts` are **pre-existing 10 s test-timeout flakes unrelated to this change**, verified by running that suite on a detached `origin/main` in the same worktree, where it fails **4/4**.
- `FORCE_COLOR=0 npx vitest run` on the directly touched suites — 7 files, 239 passed (`shared/stateSettings`, `cli/ConfigForm`, `cli/chatSessionController`, `agent/runtime/ExecutionRegistry`, `cli/RunExecution`, `shared/StateSettingWrite`, `desktop/DesktopSettingsIpc`)
- `npm run format:check` — pass
- `NODE_OPTIONS=--max-old-space-size=8192 npx eslint <5 changed files>` — clean
- `npm run check:dead-code-ratchet` — 8 current vs 8 baselined, OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
