### PR TITLE
docs: reconcile consolidation proposals with landed state

### DIFF
--- a/docs/proposals/2026-08-15-cross-host-consolidation.md
+++ b/docs/proposals/2026-08-15-cross-host-consolidation.md
@@ -19,6 +19,39 @@
 > C19 (relocation withdrawn), §4i (webview fallback narrower than claimed),
 > §4k (example replaced with the narrower true claim).
 
+> **Reconciled against origin/main `e00b9317f7` (2026-08-19).** The lifecycle
+> plane largely executed — C2/C3/C21 landed in one resume-hardening PR
+> (#10699), V4b/c were ruled and landed (#10739), C10's silent branch is loud
+> (#10924), and §4a landed over-delivered (#10693 then the Wave A collapse).
+> §4i landed (#10713) and §4k's code landed by a better mechanism than
+> prescribed (#10704, a texmath-mirroring block probe rather than a
+> `MATH_SPAN_PATTERNS` addition) — though the `\begin…\end` test this doc
+> named as the missing piece is still missing. V3 is **fixed** by #10925, and
+> V9/DR13 is substantially resolved (see the row — the doc's "two truth
+> sources" framing was wrong at HEAD). **The composition-root plane
+> (§2c) is untouched: not one of C4/C5/C6/C7/C8/C15 has a landing PR**, and
+> C4/V10 is the live user-facing defect in the set — a malformed project
+> config still hard-fails every `texra` command on the one host with no
+> settings UI. Also genuinely open: C1 (whose framing is superseded — see the
+> row), C12, C13a/c, C16, C17, C9/V11a, V2 (worse than written), V5 (real
+> harm changed), V6, V7, V11b, and eight of the eleven #9021 rows.
+> Three rows landed by a _better_ mechanism than proposed (C14, §4k, V9) and
+> should be read down to their actual residue rather than whole; two rows
+> evaporated with the relay retirement (#10894 attic + recovery record, #10896
+> client plane) rather than being consolidated — C-minor(a)'s
+> `clearAllCaches` repetition and V2's relay-spend mitigation — and with them
+> the separately-tracked included-access spend consolidation, whose subject no
+> longer exists: `relayUsage.ts` is deleted and `apiStatus.ts` carries no
+> included-access line. (What survives is deliberate: one dated legacy copy
+> string at `src/shared/copy/modelAccess.ts:59-68`, marked "delete after
+> 2026-11" and backed by live tests — not leftover debt.) Three claims were
+> already stale at this
+> doc's own pin (C-minor(c), V12's "undocumented", and the `src/hosts/nodeHost.ts`
+> path in C7/C8/C14 — the file has been at `src/platform/defaults/nodeHost.ts`
+> since `3122ace2bc`). One regression to triage separately: C13b was resolved
+> by **deleting** the CLI's ACTIVE_SKILLS handling, so the CLI can no longer
+> observe active skills at all.
+
 > **Follow-up:** the maintainer subsequently ruled for maximal consolidation
 > ("same data structure, UI rendered differently, collapse
 > projectors/adapters/bridges, single source of truth"). The target
@@ -115,7 +148,39 @@ standing review criterion for the whole program.
 
 ### 2a. Projection plane
 
-- **C1. The delta-feed driver is written twice.** Ext/desktop
+**Row status at `e00b9317f7` (2026-08-19).** C1 **superseded — the extraction
+is withdrawn** (see the row). C20 **LANDED #10932** (the "zero CLI callers"
+claim is now false: `streamViews.ts:124` calls `buildStreamTabInfo`; residual
+ad-hoc `getRuntimeModelLabel` calls survive in four CLI files). C13a **OPEN**
+— three live copies, `isEmptyUsage` still with zero host importers. C13b
+**RESOLVED BY DELETION, flag it** — the CLI's two ACTIVE_SKILLS sites went with
+the Wave A slice retype (#10895) rather than converging on a shared
+`latestActiveSkills`, so the CLI cannot observe active skills at all; that is a
+capability regression to triage, not a consolidation. C13c **OPEN**. C17
+**OPEN** — the counts still are not on `ToolEditApprovalRequest` and
+`DiffView.statsFromHunks` still recomputes. C22 **PARTIAL #10892 — and now
+three representations, not two**: `startedAt` shipped and the CLI ticks from
+it, but the redundant `formatDuration` stamp survives on the wire and the
+webview still renders it. C18 **PARTIAL #10889** — the SYNC branch and
+`streamStates` go through the shared builders; the `StreamTabInfo` literal is
+still hand-built. Doc correction: `ProgressStreamProjectionBuilder.ts` no
+longer exists; the live owner is `src/shared/streams/streamContentSync.ts`.
+
+- **C1. The delta-feed driver is written twice.**
+  **SUPERSEDED 2026-08-19 — the `StreamLogFeed` extraction is withdrawn**
+  (issue #10673, closed NOT_PLANNED; substrate doc §7). The premise did not
+  survive re-audit: the buffer/gap-detect/resync half was already one
+  implementation (`StreamLogDeltaBuffer`, `src/transcript/StreamLog.ts:64`) and
+  the coalescing half already had a shared owner (`createFlushableDebounce`,
+  twelve consumers) — both imported by both sites. What is left is divergent
+  host policy, and it has diverged _further_ since this row was written: the
+  CLI copy gained `logInstanceId`, `hasUndrainedChanges`, and mode-flip
+  invalidation the webview has no use for. A single feed with two overriding
+  consumers is the shape the repo's own LOC lesson says net-adds. Read the
+  paragraph below as a description of a real duplication that was priced and
+  declined, not as pending work.
+
+  Ext/desktop
   (`src/controllers/progressView/backend/WebviewBridge.ts`, 189 L) and the CLI
   TUI (`packages/cli/src/chat/tui/state/subscribeStreamLog.ts`, 500 L)
   implement the identical algorithm over `StreamLogStore.onChange`: buffer
@@ -128,6 +193,7 @@ standing review criterion for the whole program.
   subscribe+buffer+coalesce+resync, calling back
   `(streamId, batch | 'resync')`; both sites become sinks. **Net:** ~−120 L
   and one class of resync bug. Highest-value item in this audit.
+
 - **C20. CLI display metadata bypasses `buildStreamTabInfo`.**
   `src/controllers/session/streamTabInfo.ts:32` +
   `streamInfoUtils.ts:19,48` serve ext+desktop; **zero CLI callers**. The CLI
@@ -192,6 +258,24 @@ standing review criterion for the whole program.
   fenced `legacyTraceIdentity` parser at `:140-156`.)
 
 ### 2b. Lifecycle plane
+
+**Row status at `e00b9317f7` (2026-08-19).** C2 **LANDED #10699**
+(`resumeStreamWithRecovery` in `resolveAndResumeStream.ts:75`, both GUI
+wrappers converted; the CLI kept its in-function claim as adjudicated). C3
+**LANDED #10699** — the discriminated `resolved | read-failed | incomplete`
+resolution goes through the port and one shared
+`describeResumeStateResolution`, closing V4a; the contract-change-first
+sequencing this row insisted on is what made it work. C21 **LANDED #10699**
+(`describeResumeFailure`, four call sites — one more than this row counted;
+the CLI pre-check stayed CLI-only as designed). C10 **PARTIAL #10924** — the
+_defect_ is fixed and is the more valuable half: the extension's silent branch
+now logs **and** surfaces, and the false "both callers own their own reporting"
+comment is replaced; the six-site `validateOrReport` dedup did not happen. C11
+**PARTIAL #10699** — the double-toast bug is dead, but it was fixed by making
+the extension a **fourth** `trackTerminalResultPresentation` caller, so the
+duplication this row wanted removed grew by 33% and the row is now pure dedup
+with no bug attached. C12 **OPEN** — the ladder is still duplicated and desktop
+still discards `docsCommand`, so desktop users still get the dead-end error.
 
 - **C2. Resume recovery claim/release triad — byte-identical, 2 hosts.**
   `packages/extension/src/commands/agent/resumeFromResumeData.ts:46-50,106-108`
@@ -272,6 +356,28 @@ hostPorts)` on the existing `MainViewExecutionController`. **Net:** −1 copy
   - 1 restored affordance.
 
 ### 2c. Composition-root / platform plane
+
+**This plane is where the program did not go.** At `e00b9317f7` (2026-08-19)
+**none of C4, C5, C6, C7, C8 or C15 has a landing PR**, and two of them moved
+the wrong way: C8's extension literal grew a member, and the factory still
+constructs `new JsonConfigProvider` unconditionally so the SDK's
+`MemoryConfigProvider` still cannot route through it. C5's scope shrank by one
+member for an unrelated reason — #10865 deleted `watch` from both providers —
+leaving `get`/`inspect`/`isExplicitlySet` still byte-equivalent. C4 is the
+**highest-priority live defect in this doc**: the CLI still opens the project
+config unguarded (`initPlatform.ts:229-231` over a `JsonStore.open` that
+rethrows non-ENOENT), so a malformed `.texra/config.json` hard-fails every
+`texra` command on the one host with no settings UI to fix it — and desktop
+hard-codes `'config.json'` at two sites, not one. C14 **LANDED by a better
+mechanism (#10716)**: rather than a three-caller `registerCoreShutdownHandlers`,
+`PollingSourceBase` self-registers its own `disposeAll` on `platform().lifecycle`,
+which fixes every host at once and matches the lifecycle doc's scoping note;
+desktop separately gained `killActiveRecording`. The residue is one line —
+`clearStoreCache` is still extension-only.
+
+**Path correction:** C7, C8 and C14 cite `src/hosts/nodeHost.ts`. The file has
+been at `src/platform/defaults/nodeHost.ts` since before this doc's own
+reproduction pin.
 
 - **C4. Project-config store selection + `canCreateOrWrite` — verbatim, 2
   hosts; 3rd host throws instead.**
@@ -395,7 +501,33 @@ resetQuotaFlip: true })` is repeated unconditionally at 6 sites across the
   `secretManager.ts:31-72` is a pass-through over `platform().secrets` (4 of
   6 members one-line delegations) — a deletion candidate, not an extraction.
 
+**Row status at `e00b9317f7` (2026-08-19).** C9 **OPEN** — all six descriptors
+live, and rider V11a is confirmed: desktop still imports only
+`loginWithLoopback`. C-minor(a) is **MOOT by deletion, not consolidation** —
+`getServerSideKeyService`/`clearAllCaches` went with the relay client plane
+(#10896), so the argument that the call belonged inside the shared coordinator
+was never tested. C-minor(b) **PARTIAL** — the harm is fixed (auth now reads
+`platform().secrets`, one derivation), but `getCliSecrets`' storageRoot
+memoization survives and is now pinned by a test. C-minor(c) **stale as
+written** — `secretManager.ts` was never a `platform().secrets` pass-through at
+this doc's own pin; it is presentation-only helpers, so "deletion candidate" is
+the wrong verdict.
+
 ### 2e. Rendering plane (needs one editorial ruling first)
+
+**Row status at `e00b9317f7` (2026-08-19).** C16 **OPEN**, unchanged — all four
+divergences intact (MCP inversion, truncation budgets, error-text collapse,
+output-suppression rulesets), and `buildDelegationSections` /
+`buildWorkflowScriptSections` still have no CLI counterpart. The editorial
+ruling this row was blocked on has since been granted (the 2026-08-19 parity
+directive), so C16 is now unblocked mechanics, and the shared
+`src/shared/transcript/toolRowModel.ts` in flight on `track/transcript-parity`
+is its execution. One correction: the shared normalizer this row builds on is
+`normalizeToolUseForRender` (`src/shared/toolUse.ts:205`) — the raw
+`normalizeToolUseData` has zero direct production callers now. C19 **OPEN** —
+the withdrawal of the `htmlMarkdownNormalize.ts` relocation was honored (it is
+still CLI-local), and the surviving half is unfixed: the header still claims
+both hosts render follow-up summaries while exactly one CLI caller exists.
 
 - **C16. Tool-row assembly: two folds over one `NormalizedToolUse`.** The
   normalizer is shared (`src/shared/toolUse.ts:81`, 2 callers); every display
@@ -427,6 +559,61 @@ headerPreview, sections[], errorPreview, elision}`; CLI paints spans,
 ## 3. Band 2 — divergence register (correctness; each needs a ruling or is a plain bug)
 
 Format: mechanism → consequence → convergence/ruling needed.
+
+**Register status at `e00b9317f7` (2026-08-19).** **V3 FIXED #10925** — the two
+contradicting SSOTs are one row shape; `CLI_CORE_SETTING_PATHS` and the
+overloaded `hosts:` field are both gone, and the specific rows this entry
+flagged are now consistent. **V4 confirmed ruled + landed** (#10699/#10739),
+exactly as the entry describes, desktop fence included. **V8 LANDED #10694**
+with two corrections: only one explicit-cascade kill site survives (#10800
+removed the second), and `detachSubagentsOnStop`'s own JSDoc still asserts an
+unqualified "shared by every host" without the quit-asymmetry paragraph the
+lifecycle doc owed it. **V9/DR13 substantially resolved** — see below. **V12
+PARTIAL**, and this entry was stale when written: `'never'` was already a
+named shared constant at the reproduction pin; what is still true is that the
+settings catalog records only the `'ask'` prefault, so the fence exists in code
+and not in the catalog. Everything else — V1, V2, V5, V6, V7, V10, V11 — is
+**still true at HEAD**, three of them with the harm restated below.
+
+**V2 is worse than written.** `UsageLogService` has zero references in
+`packages/desktop` — not just no `initialize`, but no `dispose()` either — and
+the relay retirement removed the mitigation this entry relied on: `UsageMonitor`
+no longer force-flushes per relay round, so on desktop any queue under ten
+entries is now silently dropped at quit, including plan accounting.
+`refreshModelListStateIfNeeded` is a stronger finding than the entry claims: it
+has **no production caller on any host**.
+
+**V5's harm changed, and the entry's framing with it.** The 120 s stale horizon
+this entry cites is gone — #10778 replaced heartbeat liveness with
+socket-presence proof (`executionLease.ts` version 2, verdicts
+`alive | dead | unprovable`), so quitting mid-run no longer blocks `texra
+resume` for two minutes. What survives is the real residue: no host except the
+CLI persists a terminal outcome at exit, and an `unprovable` verdict still
+fails closed. The lifecycle doc's §3 fix 2 (an awaited session-owned drain)
+remains unimplemented.
+
+**V9/DR13 — REFUTED as written; one owner exists.** The entry's "two truth
+sources" framing does not hold at HEAD. `deriveResumability`
+(`src/agent/storage/resumability.ts:95`) is the single durable-state authority,
+reached by `SessionHandle`, `ToolUseFollowUp`, `restartRepair`,
+`SessionResumeRetrieval`, `ExecutionsTool`, and three CLI call sites. What
+#10927 added (with #10940's follow-ups) is **not** a second derivation but a
+display-side wrapper, `deriveOfferableResumability`, which gates the shared
+decision on execution-lease liveness and fails closed loudly on an
+unclassifiable lease — because a run executing _right now_ has exactly the
+resumable durable shape, so every listing was advertising live work as
+resumable. **Admission semantics are deliberately unchanged**: `texra resume`
+and the in-process resume paths still call `deriveResumability` directly, and
+the rationale is written at the function's declaration. Both display surfaces
+are gated — the CLI listing (`toolUseResumeData.ts:56`) and the GUI WAITING
+badges (`detectWaitingStreams.ts:26`). The CLI's extra strictness — a stamped
+`meta.streamId` and a successful resume-state read — is a deliberate strict
+superset of _requirements_ over the one owner, not a rival derivation:
+deleting it would have `/resume` offer rows it then refuses. Two honest
+residues: a run with a valid flow record but no stamped `streamId` still shows
+WAITING in the GUI and non-resumable in the CLI, and the lease-gating behavior
+is **thinly pinned** — no test names `deriveOfferableResumability`, and
+`History.vitest.ts` mocks `readCliResumeDataForListing` wholesale.
 
 - **V1. Same setting key, three physical stores.**
   - Git-author keys (`texra.git.*`, catalog says
@@ -619,6 +806,26 @@ or a deliberately terser editorial line?" — after which each row is
 mechanical. Today the answer is undeclared, which is how the drift
 accumulated.
 
+**Register status at `e00b9317f7` (2026-08-19): 2 landed, 1 partial, 8 open —
+and the editorial ruling has been granted.** The maintainer's 2026-08-19
+directive — _"the TUI should render the same state extension/desktop have"_ —
+is the answer this section said was undeclared, and it settles the register in
+favour of parity. The shared `src/shared/transcript/` row model executing it is
+in flight on `track/transcript-parity`; rows (b), (d), (e), (g), (h) and (j)
+are its scope. **(a) LANDED** (#10693, then the Wave A collapse:
+`childExecutions.ts` 585 → 241 L, the duplicated cap gone, the shared roster
+the sole owner). **(i) LANDED #10713** — and by the route this row prescribed:
+a declared shared policy, `normalizeToolUseForRender`, keeping the row live
+with a bounded diagnostic, called by both hosts, so the CLI's parity comment is
+now true. **(k) PARTIAL #10704** — the code landed by a better mechanism than
+prescribed (a container/fence-aware markdown-it block probe mirroring texmath's
+`beg_end`, plus adjacency guards that fix the inverse false positive), but the
+`\begin…\end` test this row named as "the missing piece" is **still missing**,
+now guarding considerably more machinery. **(e) may be worse**: routing the CLI
+through the shared normalizer means a feedback row with no summary now renders
+blank rather than merely omitting the instruction. **(b)** shrank to 10 webview
+fields, not 11 — relay labeling went with the relay plane.
+
 - **(a) Retained finished subagent rows.**
   `sessionSignalsAdapter.ts:206-209` filters
   `badges.subagents.filter((c) => c.finishedAt === undefined)` — one line
@@ -713,7 +920,14 @@ CP4/CP5 + §2 territory (the projection sweep confirmed
 
 ## 5. Overlap with the 2026-07-09 drift register
 
-Re-checked at this HEAD during the sweep:
+Re-checked at this HEAD during the sweep, and again on 2026-08-19 — the
+changes since: **DR13's resumability facet is closed** (one owner plus a
+display-side lease gate; see V9 above), so the row below is stale in that half;
+its history-projection half stands. **CP2's stream-stop half stayed ruled**,
+and the CLI-setter half is now the settings-catalog's business (#10925 gave
+every row a `slots` map, so "the CLI reports these as unknown keys" needs
+re-checking against the new catalog before it is re-filed). **CP4/CP5** are
+unchanged. DR2, DR3, DR6 and DR8 are all still open exactly as written.
 
 - **DR2 (prompt replay):** half-converged since adjudication — both hosts now
   call `replayApprovalRequestHandlers` (`ProgressViewProvider.ts:334-340`,
@@ -795,6 +1009,21 @@ needing none). Suggested order:
    `enforceCategory` (V6), AppSignals wiring scope (V7), resumable truth
    source (V9/DR13), callback-binding bar (V11b), approval-policy default
    fence (V12). Resume admission (V4b/c) is no longer pending: ruled + landed.
+
+**Execution status at `e00b9317f7` (2026-08-19).** Step 1's plain bugs mostly
+landed (V2 is the exception, and it got worse); §4i and §4k's code shipped;
+V1a's "missing host argument" was corrected away on review rather than fixed,
+since no host argument was missing. Step 2 landed C2+C3+C11+C21 as the single
+resume-hardening PR this step proposed (#10699) and closed V4a/d with it, but
+C1 is withdrawn, C4 never started, C10 landed only its bug half, C14 landed by
+self-registration instead, and C12 is untouched. **Step 3 did not happen** —
+C5, C6, C7, C8, C15 and C9 are all open, which makes the composition-root plane
+the single largest untouched block in this doc. Step 4's rulings: the
+CLI-transcript parity charter was **granted** (2026-08-19) and is executing;
+V3 was settled by the catalog collapse; V9/DR13 resolved to one owner plus a
+display-side gate. Still awaiting a ruling: settings-store unification (V1),
+lease-at-quit (V5, whose design the lifecycle doc owns), `enforceCategory`
+(V6), AppSignals wiring scope (V7), and the callback-binding bar (V11b).
 
 Everything here was found by scoped sweeps, not adjudicated line-by-line the
 way the 2026-07-09 audit was; treat each row as _verified-at-citation_ but

--- a/docs/proposals/2026-08-15-lifecycle-ownership.md
+++ b/docs/proposals/2026-08-15-lifecycle-ownership.md
@@ -17,6 +17,26 @@
 > the shutdown deadline extended to an abort-then-advance contract, the
 > SDK's deliberate run-scoped cleanup recorded as a process-root
 > exception, and the §6 step-9 wording aligned with §4's no-table rework.
+>
+> **Reconciled against origin/main `e00b9317f7` (2026-08-19).** The idiom
+> question is settled and executed: the house `DisposableStore`
+> (`src/platform/disposable.ts`, 48 L) has nine production consumers, the
+> deferred surfaces stayed deferred (`[Symbol.dispose]` and leak assertions
+> absent; `move()` landed with the one consumer that deleted a mechanism), and
+> `lifecycle.onShutdown` now runs the abort-then-advance join-with-deadline the
+> review rider specified. Steps 1, 2, 3 and 7 landed in full (#10716, #10780,
+> #10723, #10755, #10893); steps 5, 8 and 9 landed in part. **The widest-impact
+> fix did not land: §3 fix 2, quit-time lease settlement at the session root,
+> is still open** — the CLI UI remains the sole implementation and is still
+> `isResumableIdle()`-gated, so the four-host resume-block gap this doc
+> identified is live exactly as written. Also open: the extension
+> activation-failure catch (fix 5), `resolveEmitSession`'s silent skip (fix 7),
+> the async-dispose split (step 6, all 8 sites), recording's view/window
+> re-rooting, the `childRunLoop` finally ladder, presentation-lease backstops,
+> LaTeX signal threading, and the toggle-store move — which #10925 did **not**
+> carry despite collapsing the settings catalogs (both toggles still resolve to
+> `workspaceState`). The stale `SessionHandle.ts:142` "process-output poller"
+> comment §7 flagged is still there.
 
 ## 0. The verdict, at two altitudes
 
@@ -159,6 +179,22 @@ closure sites — stores in new and touched code only.
    make, not a leak: either desktop installs a default session or the
    fallback logs at warn (silent-degradation rule).
 
+**Per-fix status at `e00b9317f7` (2026-08-19):** 1 **LANDED #10716/#10780**
+(`PollingSourceBase` unrefs its timer and self-registers `disposeAll`; the
+extension-only registrations deleted). 2 **OPEN** — no lease settlement is
+registered on any shutdown path; `sessionExitController.ts:183` is still the
+sole, idle-gated implementation. 3 **PARTIAL #10716** — the interim
+process-shutdown backstop landed on both recording-capable hosts; the
+view/window re-rooting did not (`src/tools/media/audio.ts:26` is still a module
+singleton). 4 **LANDED #10893** (`lifecycleHost.ts:45-102`, 5 s per-phase
+deadline, handlers receive the abort signal, laggard logged, phase advances).
+5 **OPEN** — `activate()` still has no top-level catch; the dual
+`UsageLogService` registration was **not** deleted but entrenched with a
+comment explaining it substitutes for this fix, which couples the two: landing
+fix 5 is what makes the second registration genuinely redundant. 6 **LANDED
+#10755**. 7 **OPEN** — neither branch of the ruling was taken; the skip is
+still silent and desktop is still the host with no default session.
+
 Non-fixes recorded so they aren't re-reported: lease heartbeat (correct),
 idle OpenAI WS (deliberate), detached-group crash orphan (documented
 tradeoff), `inlineAgents` (deliberate, name-bounded — but delete or wire
@@ -216,6 +252,21 @@ other two hosts already agree on, rather than the shared path bending to
 the Memento. `interactionOwnership` needs one ruling: promote to the
 shared registry contract or fence as CLI modality.
 
+**Status at `e00b9317f7` (2026-08-19):** repair 1 **LANDED #10694 then half
+regressed** — both headless `kill` sites gained the explicit
+`{detachActiveChildren: false}` and the deliberate-cascade comment, but #10800
+("simplify agent launch and CLI lifecycle") removed one of the two; only
+`runExecution.ts:406` carries it now. Repair 2 (the quit-asymmetry paragraph at
+`detachSubagentsOnStop`'s declaration) is **OPEN** — that JSDoc still covers
+only the SSOT-and-live-read rationale. Toggle-store unification is **OPEN**:
+#10925 collapsed the settings catalogs but did not move
+`DETACH_SUBAGENTS_ON_STOP` / `ALLOW_ORCHESTRATOR_KILL`, which still declare
+`slots: sameSlot('workspaceState')` and still route through the extension's
+`WorktreeMemento` — the 2026-08-15 ruling recorded above is unexecuted.
+`interactionOwnership` needed no new ruling: it was already promoted to the
+shared registry contract in `docs/design/execution-interaction-ownership.md`,
+and the code matches.
+
 Also verified in this sweep: **LaTeX compiles are uniformly signal-less**
 (`compileLatex2Pdf`/latexdiff take timeout only; the `executeCommand`
 substrate supports `signal` but no caller threads it — a user stop never
@@ -267,6 +318,28 @@ split avoids), `signal-exit` (Ink already embeds it; keep one exit matrix).
 
 PRs 1–5 independent except 4-after-3; 6–9 ride on 2. Every step leaves the
 tree with strictly fewer teardown mechanisms than it found.
+
+**Step status at `e00b9317f7` (2026-08-19):** 1 **LANDED** (#10716, #10780).
+2 **LANDED** (#10723 — `src/platform/disposable.ts`, nine production consumers;
+`RESET_HOOKS` stayed repeatable as prescribed). 3 **LANDED** (#10755 —
+`SessionHandle.teardown` is a store, `dispose()` is one line, the
+comment-enforced order and the hand-rolled aggregation are gone). 4 **OPEN**
+— the ordering constraint held it behind 3, and it never followed. 5
+**PARTIAL** (#10893 — the deadline landed and the bespoke CLI grace race is
+gone; the activation catch and the dual `UsageLogService` registration are
+not). 6 **OPEN** — all 8 async dispose sites remain, and the `void`-cast
+survives at `extension.ts:495`. 7 **LANDED** (#10893 — window-root store,
+`pendingDesktopDiffHostDispose` absent). 8 **PARTIAL** (#10893 for the
+session-keyed agent-CLI registries; #10805 collapsed the stream→execution
+resolver; `AgentLaunchResources.ts` deleted outright in favour of a store with
+`move()` — recording scoping and `clearInlineAgents` still open). 9
+**PARTIAL** — see §4.
+
+One claim did not reproduce at HEAD: §1's "Lean disposal from
+three-owners-in-three-modules". Only one shutdown registration is findable
+(`directLspAdapter.ts:88`) plus the extension's hand-called fourth path
+(`extension.ts:770`), so the row's real remaining content is that fourth path,
+not a three-way split.
 
 ## 7. Honest notes
 

--- a/docs/proposals/2026-08-15-shared-contracts-and-retirement.md
+++ b/docs/proposals/2026-08-15-shared-contracts-and-retirement.md
@@ -22,6 +22,25 @@
 > present at `3122ace2bc`; the docs branch has been merged with main so
 > future reviews see the current tree.
 
+> **Reconciled against origin/main `e00b9317f7` (2026-08-19).** Most of this
+> doc has executed. Landed: §2.1 in one PR (#10925 — the six catalogs are one
+> `StateSettingEntry` row and every list is a filter over it), §2.2 items
+> 1/2/4/5 (#10715, #10738, #10741, #10908 — `requestId` was an atomic rename,
+> no compat alias), §2.3 (#10719, #10810, #10932), §2.4 (#10806, #10866),
+> §2.5's scalar writes (#10891), §2.6 defects 1–2 (#10907), §2.7 both defects
+> (#10688, #10811), §2.8 (#10891), and all three retirement tiers plus the
+> dated-horizon retirements (#10601, #10887, #10888, #10890). §2.9 was
+> **counter-ruled** — see the row. What remains genuinely open: §2.2 item 3
+> (the CLI's own `ApprovalPayload` union), `SettingsCredentialActions` (§2.5),
+> the desktop `UsageLogService` / `refreshModelListStateIfNeeded` bootstrap
+> gaps (§2.5 / audit V2 — and `refreshModelListStateIfNeeded` is now
+> production-dead on _every_ host, which is worse than this doc claimed), and
+> §4b projection-zero, still gated on two supersessions the maintainer has not
+> granted. One stray from the §2.5 sweep worth a follow-up:
+> `SET_CHATGPT_PREFER_SUBSCRIPTION` survived the literal collapse. Read §7.6's
+> arithmetic as superseded — Wave D is withdrawn (substrate doc §7) and Wave
+> A's per-file nets came in well short of the table.
+
 Method: four sweeps on a fresh origin/main worktree — contract-surface
 census, dead-code/retirement hunt, catalog-fragmentation study
 (settings/status/capability), and claim-by-claim re-verification of the
@@ -90,6 +109,16 @@ Ranked by contradiction count × drift risk. For each: the fragments, what
 each is doing, the single contract, and what deletes.
 
 ### 2.1 Settings capability catalogs — ~30 contradicting rows, 6 answer-sites
+
+**LANDED #10925 (2026-08-19), in one atomic PR** — the "watch: if any absorbed
+catalog survives temporarily, this becomes a seventh catalog" risk did not
+materialize. `StateSettingEntry` carries `slots` / `honoredBy` / `surfaces` /
+`onWrite` (`stateSettings.ts:219-227`); `CLI_CORE_SETTING_PATHS`,
+`EXTENSION_ONLY_CORE_SETTING_PATHS`, their `_AssertEveryCorePathClassified`
+guard, `PROVIDER_SETTINGS`, and `cliStore` are all absent. The live behavior
+split closed with them: the Models tab's raw `globalState.update` bypass is
+gone (zero `globalState.update` sites repo-wide), so schema validation and the
+Kimi/OpenRouter mutual exclusion now apply on every write path.
 
 Six places answer "does host H honor setting S, and where is it stored":
 the `STATE_SETTINGS` rows' `hosts` + `store`/`cliStore`
@@ -201,6 +230,24 @@ The CLI's payload union diverges from the wire union on 2 of 7 arms
 Deletes ≈ 20–25 declarations; kills the class of "approval kind added,
 one host silently misses a field" bugs.
 
+**Status at `e00b9317f7` (2026-08-19): items 1, 2, 4, 5 LANDED; item 3 OPEN.**
+Item 1 — `HostPlanApprovalRequest` (#10715) and `HostAgentProposalRequest`
+(#10738) are `Readonly<…Permission>` aliases; `HostBashApprovalRequest`
+remains the deliberate minimal request per the review carve-out;
+`ToolEditApprovalRequest.streamId: StreamTabId | null` landed and the cast is
+gone. Item 2 — **LANDED #10908 as an atomic rename**: `approvalId` and
+`proposalId` have zero live sites and no parse-side alias was introduced, so
+the compatibility-retirement condition never had to be exercised; the
+maintainer resolved the "confirm with owner" flag — payload field names are
+not in the item-6 freeze, which names message-type literals. Item 4 — LANDED
+#10741 (`{action}`, `toolEdit` in `HostInteractionResultByKind` and
+`cancellationResultFactories`). Item 5 — LANDED #10715 (`ApprovalDecisionSchema`
+absent). Item 3 — **OPEN**: the CLI still declares its own seven-arm
+`{kind,payload}` union at `approvalQueue.ts:43-56`. Its arms now reference the
+shared permission types, so a new wire arm is less likely to drift silently,
+but it is not `PermissionPayload` and no requestId-keyed adornment split
+exists.
+
 ### 2.3 Progress-view fact wire — 12 targeted commands are slices of one payload
 
 Verified precisely at this HEAD: 12 of the 30 outbound arms
@@ -233,6 +280,15 @@ of hand-written field declarations, 5 port methods × 2 implementations,
 between the snapshot and targeted paths that item 8's "intended end state"
 currently lacks.
 
+**LANDED #10719 / #10810 / #10932 (2026-08-19).** `pickProjection` derives the
+pure slices from one `projectionShape`; the delta-semantic arms kept their
+envelopes as this row prescribed. The port gained `invalidate(streamId, slice)`
+and lost five methods plus `onParentStreamChanged`'s dead second argument
+(22 → 18). The `progressEvents.ts` half landed **as amended**: the ~8
+interfaces survive — they are the `SessionFact` vocabulary upstream of the
+wire, which this doc's own §7.2 said does not delete — but their members are
+now `z.infer` of the message schemas, which is where the drift risk was.
+
 ### 2.4 Tool/capability gating — 6 tools answered in up to 4 places
 
 Eight fragments answer "can host H use tool T": the availability probe
@@ -261,6 +317,16 @@ unavailability derive it)_. Deserved and kept: the probe cache
 a run-context _parameter_ (subagent inheritance, test substitution),
 `SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES` (absorbed as three declarations).
 
+**LANDED #10806 / #10866 (2026-08-19).** `defineTool({hosts})` exists
+(`src/tools/core/define.ts:73`); `packages/cli/src/runtime/unavailableTools.ts`
+and `DESKTOP_UNAVAILABLE_TOOLS` are deleted; the dashboard filter takes the
+asking host and drops a group only when every tool in it declares itself
+unavailable there (#10924 completed that half, fixing a user-visible bug —
+the desktop Tools tab had been showing green cards for tools the host cannot
+run). `hideFromCli` survives on exactly the integration-only row the review
+carve-out named (`externalToolDefs.ts:109`, one writer: `texra-cli` with
+`tools: []`), which is the designed end state, not a miss.
+
 ### 2.5 Settings command surface — ~14 bespoke literals over one generic write
 
 The Zod contract and registry type are genuinely single; the fragmentation
@@ -280,6 +346,20 @@ placeholder-key rejection into the shared `commitProviderKey` (today only
 the CLI rejects `sk-xxxxxx`). Third: the two desktop bootstrap gaps
 (`refreshModelListStateIfNeeded`, `UsageLogService`) re-confirmed — the
 audit doc's V2, unchanged.
+
+**Status (2026-08-19): first item LANDED #10891; second and third OPEN.** Five
+scalar-write literals (`SET_PROVIDER_ENDPOINT`, `SET_PROVIDER_STREAMING`,
+`SET_GLOBAL_STREAMING`, `SET_HELPER_MODEL`, `SET_PREFER_SHORT_MODEL_NAMES`)
+route through `UPDATE_STATE_SETTING` and are gone with their inbound arms and
+both hosts' handler entries — but the sweep left
+`SET_CHATGPT_PREFER_SUBSCRIPTION` behind; finish it or fence it.
+`SettingsCredentialActions` was never written:
+`src/controllers/settingsView/backend/` still holds only `SettingsAgentActions`,
+so the ~140/~180/19 L credential wiring and the CLI-only `sk-xxxxxx` rejection
+stand. The two desktop bootstrap gaps are unchanged and one is now worse —
+`refreshModelListStateIfNeeded` has **no production caller on any host**, so
+retired-model sweeps and stale-route clears run nowhere, not just not on
+desktop.
 
 ### 2.6 "A stream" — 11 schemas, mostly disciplined, four defects
 
@@ -306,6 +386,14 @@ is the substrate doc's business, not this one). The defects:
 4. `HistoryItemSchema`'s config summary triple is parallel to the listing
    entry's projection rather than derived from it.
 
+**Status (2026-08-19): 1 and 2 LANDED #10907; 3 gated; 4 MOOT.** The snapshot
+write side types against `StreamPhaseSchema` with the review-caught
+legacy-inbound union on the parse side, so archived `trace.json` exports still
+parse; `StreamIdentityFieldsSchema` is declared once and `StreamTabInfoSchema`
+extends it. Defect 3 rides the gated §4b work. Defect 4 is **MOOT** —
+`HistoryItemSchema` no longer exists: #10811 retired the duplicate history
+surface outright, which is a better outcome than deriving the triple.
+
 ### 2.7 Status vocabularies — two defects, everything else fenced
 
 1. **`cardStatusFor` folds `CANCELLED` into `failed`**
@@ -328,6 +416,13 @@ is the substrate doc's business, not this one). The defects:
    shared display record (the `streamStatusDisplay` idiom); both hosts
    project.
 
+**LANDED (2026-08-19).** Defect 1 in #10688: `cardStatusFor` is gone, replaced
+by the compile-exhaustive `WORKFLOW_CALL_STATUS_PROJECTION` with a
+`satisfies` pin; `CANCELLED` maps to `'cancelled'` and the dead `waiting` key
+is deleted — so `WORKFLOW_TASK_STATUS_LABEL.cancelled` went live as §7.4 row 3
+predicted. Defect 2 in #10811: `HISTORY_RUN_STATUS_LABEL` is shared and the CLI
+consumes it; `HISTORY_STATUS_BADGES` is absent.
+
 ### 2.8 Main-view banners — 12 literals for one concept
 
 `SHOW_/HIDE_` × six banner kinds + two dismissals; 9 of 12 arms are
@@ -338,7 +433,25 @@ the item-6 freeze (verified: the freeze names progress-view); confirm no
 external consumer (none found) and land. The file-slot literals stay —
 factory-derived, zero drift risk.
 
+**LANDED #10891 (2026-08-19).** One `SET_BANNER {banner, visible, data?}`
+literal (`ipc.ts:54`) with a single schema arm over a banner-surface enum; zero
+`SHOW_*_BANNER` / `HIDE_*_BANNER` literals remain. The item-6 reading held —
+no external consumer surfaced.
+
 ### 2.9 Usage shapes — one naming split
+
+> **REJECTED — counter-ruled (2026-08-19).** The rename does not happen. #10796
+> moved usage normalization into `ModelHandler.extractNormalizedResponse`,
+> making `NormalizedUsage` the single carrier at the provider boundary rather
+> than a downstream re-shape, and the schema now declares the split
+> deliberate and authoritative in its own doc-comment
+> (`src/agent/types/NormalizedUsage.ts:15-23`): the base's
+> `cacheReadInputTokens` / `cacheCreationInputTokens` are never populated for a
+> `NormalizedUsage`, so `cachedInputTokens` / `cacheCreationTokens` are _the_
+> names, and `.extend()`-ing the full base — this row's proposal — would
+> inherit two dead fields and duplicate `cacheMissInputTokens`. The gate this
+> row set (check `UsageLogTypes` for external consumers) is therefore moot;
+> treat this as closed, not pending.
 
 `NormalizedUsage` deliberately renames two cache fields
 (`cachedInputTokens`, `cacheCreationTokens`) vs the canonical
@@ -352,6 +465,17 @@ sites. Rename to the canonical spellings and `.extend()` instead of
 Dead code to remove now, with two-direction grep evidence. knip's baseline
 is at **8 findings** (already burned down); everything here is in its blind
 spots.
+
+**LANDED in full (2026-08-19).** Tier 1: #10601 merged; `cleanupAllApprovals`
+and `DIAGNOSTICS_ADD_RUNTIME_CAPABILITY` are absent. Tier 2: all six
+zero-writer options are gone (`webAwesomeIcons`' `canvas` became a hardcoded
+attribute rather than an option). Tier 3: the house ruling went **test-kernel**
+— `withToolEnvironment` moved there, the other five seams are deleted, and
+`pathFix`'s injectable seam is gone in favour of calling the npm package
+directly. Scheduled retirements: `LEGACY_ICON_ALIASES` retired early under the
+2026-08-18 ruling (#10887); `midEraWorkflowOutputStem` correctly **kept** with
+its 2027-04-21 horizon and live readers; the owed checkpoint-ledger doc-drift
+fix landed (#10688) and now cites symbols that exist.
 
 ### Tier 1 — pure-dead, high confidence
 
@@ -418,7 +542,10 @@ sites but invoked dynamically via ``executeCommand(`texra.${command}`)``
 consumer each); all `SessionFact` arms (the empty handler arms are
 `assertNever`-mandated); all citty CLI flags; all 8 desktop
 `unsupported()` sites (they _are_ the capability SSOT);
-`spendCheckFailed` (external relay contract — keep pending relay check);
+`spendCheckFailed` (external relay contract — **the relay check resolved:
+the plane was retired by #10894/#10896, so this row and the whole
+included-access spend surface, `relayUsage.ts` included, are gone rather than
+consolidated**);
 zero `@deprecated` markers repo-wide; no `SessionRendererPort` method is a
 no-op in both hosts.
 
@@ -437,6 +564,18 @@ landed part of it (§5): the remaining Wave C is the §2.3 derivation
 **≈ −450..−550** rather than the previous ≈ −1,050.
 
 ## 4b. The projection-zero option (maintainer follow-up, 2026-08-15)
+
+> **STILL GATED (2026-08-19).** The safe first stage landed (§2.3), and every
+> line of it survives into this design as intended. The gate has not moved: the
+> two supersessions item 1 asks for — §0.1 item 8's dual-path clause and item
+> 6's progress-view literal freeze — have **not** been granted, and both
+> clauses stand unchanged in `2026-08-03-ssot-consolidation-plan.md:62-90`.
+> (Item 8's separate `StreamSlice` clause _was_ superseded and executed by the
+> substrate program's Wave A; that is a different clause and does not carry
+> this one.) At HEAD all 12 targeted literals remain in `src/shared/ipc.ts`
+> and `runTrackingSlice.ts` / `taskSlice.ts` still exist. The bandwidth
+> measurement in item 3 has not been taken either. Nothing below is stale —
+> it is unstarted, by design.
 
 The maintainer asked whether projections can be eliminated outright rather
 than derived. Honest inventory of what "projection" covers and how far the
@@ -530,31 +669,41 @@ it doesn't land). Rule applied: a new name is only legitimate if the PR
 that introduces it deletes ≥2 hand-rolled equivalents and the concept
 already exists in the code's own vocabulary or the ecosystem's.
 
-| Proposed name                                                                                                                             | Doc                           | Verdict                                                                                                                                                                                                                                                                        |
-| ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ChildStopPolicy` table                                                                                                                   | lifecycle §4                  | **REWORKED** — the SSOT function already exists; fixed to 3 call-site repairs + 1 doc paragraph. No table.                                                                                                                                                                     |
-| `DisposableStore`                                                                                                                         | lifecycle §2                  | REPLACEMENT — the ecosystem-standard shape; replaces ≥10 hand-rolled registries/arrays, each deleted as it migrates; vitest leak-assert makes it self-policing. Not a coordinator.                                                                                             |
-| five "lifetime roots"                                                                                                                     | lifecycle §1                  | REPLACEMENT — all five anchors pre-exist; the "roots" are documentation of them, zero new objects.                                                                                                                                                                             |
-| `invalidate(streamId, slice)`                                                                                                             | substrate §6 / contracts §2.3 | REPLACEMENT — deletes 5 port methods × 2 impls; port shrinks 22→17(→~5 under projection-zero). The `slice` key type reuses the projection shape's existing field names, no new vocabulary.                                                                                     |
-| `pickProjection`                                                                                                                          | contracts §2.3                | REPLACEMENT — declares once what 12 arms restate; every field name already exists on the wire.                                                                                                                                                                                 |
-| `StreamLogFeed`                                                                                                                           | substrate §7                  | REPLACEMENT — mechanical dedup of two identical drivers (~−180).                                                                                                                                                                                                               |
-| `projectTranscriptRow` / `TranscriptRow`                                                                                                  | substrate §5 B-2              | **FLAGGED** — genuinely a new model on the webview side; honestly +60 LoC; lands only under its drift-elimination justification and the six policy rulings. B-1 (ordering key) alone is REPLACEMENT (−49 + bug fix).                                                           |
-| `SettingEntry` expanded row (`slots`/`honoredBy`/`surfaces`/`onWrite`)                                                                    | contracts §2.1                | REPLACEMENT — one row absorbs six catalogs; every field renames an existing fact, and each absorbed catalog deletes in the same series. Watch: if any absorbed catalog survives "temporarily", this becomes a seventh catalog — the exact hack; land atomically per catalog.   |
-| `defineTool({hosts})`                                                                                                                     | contracts §2.4                | REPLACEMENT — a field on the existing per-tool row; three rosters + `hideFromCli` delete.                                                                                                                                                                                      |
-| `SUBSCRIPTION_PROVIDERS` registry                                                                                                         | audit C9                      | REPLACEMENT — registry-as-contract is an adjudicated KEEP species; 6 restatements → 2 rows.                                                                                                                                                                                    |
-| `SET_BANNER` message                                                                                                                      | contracts §2.8                | REPLACEMENT — 12 literals delete with it.                                                                                                                                                                                                                                      |
-| `HostInteractionRequestByKind` aliases                                                                                                    | contracts §2.2                | REPLACEMENT — the alias pattern already exists in-file for 3 of 7 kinds; this finishes it and deletes 4 interfaces.                                                                                                                                                            |
-| `resumeStreamWithRecovery`, `describeResumeStateResolution`, `withUnhandledFailureReporting`, `validateOrReport`, `describeResumeFailure` | audit C1–C21                  | **FLAGGED** — helper extractions; the repo's history says extract-shared net-ADDS. Each is only legitimate because it deletes byte-identical copies in ≥2 hosts in the same PR and closes a named correctness gap; any that can't show net-≤0 _plus_ the bug fix doesn't land. |
-| `JsonStoreSecrets` base + `withEnvOverride`                                                                                               | audit C6                      | **FLAGGED** — base-class extraction with 2 implementers; borderline under the LOC lesson. The non-negotiable part is the missing PQueue on Electron (a bug); the base class lands only if net-negative, else fix the bug alone.                                                |
-| `TuiApprovalAdornments`                                                                                                                   | contracts §2.2 item 3         | FLAGGED-minor — relocates 2 existing fields out of the payload union; only worth it as part of the union unification, never alone.                                                                                                                                             |
-| `TraceDocument → SessionState` hydrator                                                                                                   | substrate §6d                 | REPLACEMENT — deletes the hand-built payload duplication (~−100); the hydrator's target type exists.                                                                                                                                                                           |
-| headless `SessionRendererPort` impl                                                                                                       | substrate §3                  | REPLACEMENT — a port implementation (the port exists); deletes the hand-rolled `RenderState` fold (~−175).                                                                                                                                                                     |
+| Proposed name                                                                                                                             | Doc                           | Verdict                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ChildStopPolicy` table                                                                                                                   | lifecycle §4                  | **REWORKED** — the SSOT function already exists; fixed to 3 call-site repairs + 1 doc paragraph. No table.                                                                                                                                                                                                                                                                                                                             |
+| `DisposableStore`                                                                                                                         | lifecycle §2                  | REPLACEMENT — the ecosystem-standard shape; replaces ≥10 hand-rolled registries/arrays, each deleted as it migrates; vitest leak-assert makes it self-policing. Not a coordinator.                                                                                                                                                                                                                                                     |
+| five "lifetime roots"                                                                                                                     | lifecycle §1                  | REPLACEMENT — all five anchors pre-exist; the "roots" are documentation of them, zero new objects.                                                                                                                                                                                                                                                                                                                                     |
+| `invalidate(streamId, slice)`                                                                                                             | substrate §6 / contracts §2.3 | REPLACEMENT — deletes 5 port methods × 2 impls; port shrinks 22→17(→~5 under projection-zero). The `slice` key type reuses the projection shape's existing field names, no new vocabulary.                                                                                                                                                                                                                                             |
+| `pickProjection`                                                                                                                          | contracts §2.3                | REPLACEMENT — declares once what 12 arms restate; every field name already exists on the wire.                                                                                                                                                                                                                                                                                                                                         |
+| `StreamLogFeed`                                                                                                                           | substrate §7                  | **WITHDRAWN 2026-08-19** (was REPLACEMENT) — premise stale: `StreamLogDeltaBuffer` and `createFlushableDebounce` already own the shared halves and the residue is divergent host policy, not one algorithm written twice. Issue #10673 closed NOT_PLANNED; the −180 leaves the program total.                                                                                                                                          |
+| `projectTranscriptRow` / `TranscriptRow`                                                                                                  | substrate §5 B-2              | **FLAGGED** — genuinely a new model on the webview side; honestly +60 LoC; lands only under its drift-elimination justification and the six policy rulings. B-1 (ordering key) alone is REPLACEMENT (−49 + bug fix). **2026-08-19: rulings granted** by the maintainer's parity directive; in flight on `track/transcript-parity`, so the +60 is now a claim the landing PR must account for. B-1 landed as `compareBySeqNo` (#10717). |
+| `SettingEntry` expanded row (`slots`/`honoredBy`/`surfaces`/`onWrite`)                                                                    | contracts §2.1                | REPLACEMENT — one row absorbs six catalogs; every field renames an existing fact, and each absorbed catalog deletes in the same series. Watch: if any absorbed catalog survives "temporarily", this becomes a seventh catalog — the exact hack; land atomically per catalog.                                                                                                                                                           |
+| `defineTool({hosts})`                                                                                                                     | contracts §2.4                | REPLACEMENT — a field on the existing per-tool row; three rosters + `hideFromCli` delete.                                                                                                                                                                                                                                                                                                                                              |
+| `SUBSCRIPTION_PROVIDERS` registry                                                                                                         | audit C9                      | REPLACEMENT — registry-as-contract is an adjudicated KEEP species; 6 restatements → 2 rows.                                                                                                                                                                                                                                                                                                                                            |
+| `SET_BANNER` message                                                                                                                      | contracts §2.8                | REPLACEMENT — 12 literals delete with it.                                                                                                                                                                                                                                                                                                                                                                                              |
+| `HostInteractionRequestByKind` aliases                                                                                                    | contracts §2.2                | REPLACEMENT — the alias pattern already exists in-file for 3 of 7 kinds; this finishes it and deletes 4 interfaces.                                                                                                                                                                                                                                                                                                                    |
+| `resumeStreamWithRecovery`, `describeResumeStateResolution`, `withUnhandledFailureReporting`, `validateOrReport`, `describeResumeFailure` | audit C1–C21                  | **FLAGGED** — helper extractions; the repo's history says extract-shared net-ADDS. Each is only legitimate because it deletes byte-identical copies in ≥2 hosts in the same PR and closes a named correctness gap; any that can't show net-≤0 _plus_ the bug fix doesn't land.                                                                                                                                                         |
+| `JsonStoreSecrets` base + `withEnvOverride`                                                                                               | audit C6                      | **FLAGGED** — base-class extraction with 2 implementers; borderline under the LOC lesson. The non-negotiable part is the missing PQueue on Electron (a bug); the base class lands only if net-negative, else fix the bug alone.                                                                                                                                                                                                        |
+| `TuiApprovalAdornments`                                                                                                                   | contracts §2.2 item 3         | FLAGGED-minor — relocates 2 existing fields out of the payload union; only worth it as part of the union unification, never alone.                                                                                                                                                                                                                                                                                                     |
+| `TraceDocument → SessionState` hydrator                                                                                                   | substrate §6d                 | REPLACEMENT — deletes the hand-built payload duplication (~−100); the hydrator's target type exists.                                                                                                                                                                                                                                                                                                                                   |
+| headless `SessionRendererPort` impl                                                                                                       | substrate §3                  | REPLACEMENT — a port implementation (the port exists); deletes the hand-rolled `RenderState` fold (~−175).                                                                                                                                                                                                                                                                                                                             |
 
 Standing guard for execution agents: any PR whose "consolidation" adds a
 name not on this ledger, or lands a ledger name without its paired
 deletions, is the flagged failure mode — reject in review.
 
 ## 6. Execution shape
+
+**Status at `e00b9317f7` (2026-08-19):** step 1 landed in full; step 2 landed
+(#10719/#10810/#10932 for §2.3, #10715/#10738/#10741/#10908 for the approval
+plane); step 3 landed for §2.1 (#10925), §2.4 (#10806/#10866), §2.6 (#10907),
+§2.8 (#10891) and the scalar-write half of §2.5 (#10891), while
+`SettingsCredentialActions` never started and §2.9 was counter-ruled out of
+existence; step 4's ruling went **test-kernel** and its mechanical PR landed;
+step 5's Wave A landed and Wave C landed in its revised form. The N1 baseline
+prune obligation held — no PR in the series was blocked by stale ratchet
+headroom.
 
 1. **Now, no ruling needed:** land #10601; the `cleanupAllApprovals` +
    orphaned-options + `DIAGNOSTICS_ADD` removals (one or two PRs); the two
@@ -724,6 +873,18 @@ Every revival row is a §5b ledger entry: the PR introducing it must name its pa
 - **Stale sub-claim narrowed:** the audit's "approvalQueue recomputes relativePath/line counts" did not reproduce outside `DiffView.statsFromHunks:52-63` — only that ~15 L dies (C17); `diffHunks.ts` keeps (3 consumers).
 
 ### 7.6 Honest totals and reconciliation against the first-order estimate
+
+> **Superseded by outcome (2026-08-19).** Two of the table's rows are void:
+> **Wave D's −180 is withdrawn** (the extraction was cancelled, substrate doc
+> §7 / issue #10673), and **Wave A's production net did not reach
+> −983..−1,058** — the containers collapsed but landed short per file
+> (`sessionSignalsAdapter` 372 → 312 against a ~90 target,
+> `runProgressRenderer` 573 → 535 against ~395, `cliState` 929 → 876 against
+> ~490, and `subscribeStreamArtifacts` survives at 222 L rather than deleting).
+> The contracts and lifecycle nets landed closer to plan. The pattern is the
+> one the repo's LOC lesson already predicted: the drift-elimination compile
+> links — this section's stated "real deliverable" — arrived; the line counts
+> did not. Do not quote the totals below without this note.
 
 Production LOC, net, by wave (adversarial corrections applied):
 

--- a/docs/proposals/2026-08-15-single-substrate-hosts-as-renderers.md
+++ b/docs/proposals/2026-08-15-single-substrate-hosts-as-renderers.md
@@ -31,6 +31,26 @@
 > canonical), the 6d hydrator re-targeted to a browser-safe DTO, and three
 > §4 promotion rows corrected (`compactingActive` withdrawn, `resumable` →
 > `resumeEligible`, root-run identity → execution-keyed query).
+>
+> **Reconciled against origin/main `e00b9317f7` (2026-08-19).** Wave A's three
+> steps landed — #10892 (child state + the status rail onto `SessionState`),
+> #10895 (`StreamSlice` retyped, adapter mirrors deleted), #10932 (port
+> `invalidate` narrowing, a headless `SessionRendererPort`, shared stream
+> labels). Wave C landed in its revised form (#10719 derivation, #10889
+> builder fold + the 6d replay hydrator, #10932 port collapse). B-1 landed as
+> a shared `compareBySeqNo` (#10717) — the wire field is `seqNo`, not the
+> `sourceSeqNo` this doc named. **Wave D is withdrawn** (§7). What remains
+> genuinely open is most of the §4 promotion list — `contextState` (still the
+> live CLI gauge bug), `runStartedAt`, `thinkingActive`, root-run stream
+> identity, run input files + `plannedRounds` — plus B-2, whose five policy
+> rulings the maintainer's 2026-08-19 directive supplied and which is in
+> flight on `track/transcript-parity`, and the two §6-item-4 stragglers
+> (`contentStore`, `streamMetaSlice`), both gated behind projection-zero.
+> The LoC arithmetic did not survive contact: the CLI containers deleted
+> real duplication but landed well short of the per-file targets
+> (`sessionSignalsAdapter` 372 → 312 against ~90, `runProgressRenderer`
+> 573 → 535 against ~395, `cliState` 929 → 876 against ~490) — read the §3
+> table as a direction, not a budget.
 
 ## 0. The directive as a ruling, and what it does to prior rulings
 
@@ -170,6 +190,12 @@ without pruning the baseline in the same commit **fails** the set-based
 ratchet. Two structural unlocks carry
 ~70% of it:
 
+**LANDED.** U1 shipped in #10693; U2 in #10805 (stable-identity read cache on
+`SessionState`) and #10932 (the port narrowed to `invalidate(streamId, slice)`).
+The container rows below landed across #10892 / #10895 / #10932 with the
+per-file nets stated in the reconciliation header; two rows did not land and
+are marked in place.
+
 - **U1 — stop dropping retained children.** One line:
   `sessionSignalsAdapter.ts:208` filters `finishedAt === undefined` out of
   the roster the shared applier just computed (retention, phase-merge,
@@ -196,6 +222,37 @@ Then, container by container:
 | `streamViews.ts`                    | 262   | ~140                               | **−120**       | label/parentLabel re-derivation replaced by `buildStreamTabInfo` output (this also fixes the drift where ext and CLI print different names for the same run — `getCleanAgentName(runIdentityName(…))` vs `runIdentityDisplayName`).                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `statusBarDisplay.ts` context gauge | ~35   | ~8                                 | **−27**        | needs the `contextState` promotion (§4); until then the CLI's context window is _wrong_ on subscription/compaction routes — this is a correctness fix wearing a refactor.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `resumeHint.ts` targets             | ~42   | ~27                                | **−15**        | needs the `resumable` promotion (§4).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+
+**Row-by-row status at `e00b9317f7` (2026-08-19):**
+
+- `childExecutions.ts` — **LANDED #10892**, 585 → 241; the module is now a
+  bound `SessionState` + revision signal with no state of its own. The
+  tombstone rider landed separately (#10805) as `SessionState._removedStreams`.
+- `cliState.ts` `StreamSlice` — **LANDED #10895** as a retype, not a
+  composition: 30 fields → 15, every mirror deleted, but the slice is still a
+  standalone interface rather than the `StreamState & CliOnlyFields` shape this
+  row named, and the file is 876 L against the ~490 target. The §0.1-item-8
+  supersession is executed.
+- `sessionSignalsAdapter.ts` — **LANDED #10892/#10895/#10932** for the
+  mechanism (the per-field patch forwarders and the dual status path are gone;
+  `subscribeStreamStatus.ts` is deleted), **not** for the arithmetic: 372 →
+  312 against a ~90 target.
+- `runProgressRenderer.ts` — **LANDED #10932**: a real headless
+  `SessionRendererPort` implementation over the shared applier, `RenderState`'s
+  six fields down to a three-field `RootRunConfigState`. Net −38, not −175.
+- `subscribeStreamArtifacts.ts` — **PARTIAL #10718/#10735/#10895.** The
+  slice-copying is gone (renderers read the canonical projection), but the file
+  survives at 222 L holding the async disk-preload edge and its invalidation.
+  The "−135 to zero" line was wrong: there was a real asynchronous concern
+  underneath the copying.
+- `streamViews.ts` — **LANDED #10932**; the CLI calls `buildStreamTabInfo`, so
+  the ext/CLI name drift this row named is closed.
+- `statusBarDisplay.ts` context gauge — **OPEN.** Still
+  `MODEL_CONFIGS[model]?.contextWindow`; the correctness bug this row called
+  "a correctness fix wearing a refactor" is live, gated on the `contextState`
+  promotion (§4).
+- `resumeHint.ts` targets — **LANDED #10754** via the `resumeEligible` roster
+  field.
 
 Ratchet note for the whole wave: anything relocated lands in
 `src/controllers/session/` (the CLAUDE.md-sanctioned home for host-neutral
@@ -224,6 +281,35 @@ is noted).
 | `cumulativeUsage` sum rule                 | CLI eager-sums, webview lazy-sums                                                           | one owner; if it must be the snapshot store, the +1 surface unit is declared in the PR                                                                          | two summing sites, one rule                                                                                                                                                                                                                                                         |
 | display-label rule                         | `buildStreamTabInfo` vs `runIdentityDisplayName`                                            | one of them (ruling)                                                                                                                                            | same run, two names                                                                                                                                                                                                                                                                 |
 
+**Promotion status at `e00b9317f7` (2026-08-19)** — this is where the program's
+remaining work concentrates:
+
+- `contextState` — **OPEN.** Not on `StreamExecutionState`; the webview still
+  folds it out of the log rail and `statusBarDisplay.ts:221` still reads
+  `MODEL_CONFIGS[model]?.contextWindow`. The §7.4 revival note explains why it
+  is the hard one: it has no fact-rail writer today.
+- removal tombstone / resurrection guard — **LANDED #10805**, as
+  `SessionState._removedStreams` + `isStreamRemoved`, documented as the single
+  owner of the rejection; the shared applier honors it for every host, which
+  is the cross-host bug this row predicted.
+- `runStartedAt` — **OPEN.** Still CLI-only (`cliState.ts`).
+- `thinkingActive` — **OPEN.** Still derived CLI-side from the log rail.
+- `resumeEligible` — **LANDED #10754** on the roster row
+  (`streamState.ts:34`), produced by `executionRegistry.ts`.
+- root-run stream identity — **OPEN.** Three copies survive (two in
+  `cliState.ts`, one in `runProgressRenderer.ts`); no execution-keyed query
+  exists.
+- run input files + `plannedRounds` — **OPEN.** Still headless-only, now in
+  `RootRunConfigState`, whose own comment concedes no shared record carries
+  them.
+- `cumulativeUsage` sum rule — **LANDED.** One owner,
+  `StreamArtifactProjection.sumUsageStats`; the CLI reads it rather than
+  eager-summing.
+- display-label rule — **LANDED #10932** for the ruling
+  (`buildStreamTabInfo` wins, the CLI adopted it); residual direct
+  `runIdentityDisplayName` calls survive in `childExecutions.ts` and three
+  webview components, which is projection, not a second rule.
+
 ## 5. Wave B — transcript: collapse the rules, keep the containers
 
 The deep study's reframe: there are not two row models — there is **one
@@ -235,6 +321,11 @@ ambition: ~700 LoC of `transcriptFold` is Ink-specific incremental
 machinery with no webview consumer, and moving it to `src/shared/` for one
 caller is the banned extraction. What is shared is the **policy**:
 
+- **B-1 — LANDED #10717.** The shared comparator is `compareBySeqNo`
+  (`src/shared/streams/streamOrdering.ts`), consumed by the webview's
+  `messageIndex`; the wire field is spelled `seqNo`, not the `sourceSeqNo`
+  this row named (`sourceSeqNo` is a CLI-side name). One timestamp comparator
+  survives on the timeline path and is deliberate.
 - **B-1 (do first, pays in LoC): the ordering slice — REVISED on review.**
   _(The original form shared the settlement key with the webview; review
   correctly objected that a mutable in-place-updating timeline ordered by
@@ -249,6 +340,16 @@ caller is the banned extraction. What is shared is the **policy**:
   `compareBySourceSeq` helper, two consumers. Net still ≈ −40..−49; the
   "webview ordering bug" claim narrows to ties/skew rather than
   settlement-vs-start.
+- **B-2 — RULINGS GRANTED, IN FLIGHT.** The five policy rulings this row
+  waited on were supplied by the maintainer's 2026-08-19 directive — _"the TUI
+  should render the same state extension/desktop have"_ — which settles
+  membership, error-detail shape, tool-output suppression, header assembly, and
+  the settlement predicate in favour of parity rather than per-host editorial
+  lines. The shared `src/shared/transcript/` row model implementing it
+  (`projectTranscriptRow`, `toolRowModel`, `transcriptText`) is in flight on
+  branch `track/transcript-parity`; it is **not** on main at
+  `e00b9317f7`. The declared +60 LoC is the one estimate to re-check against
+  the landing PR.
 - **B-2: one row model, projected per entry.** A pure
   `projectTranscriptRow(entry, ctx): TranscriptRow | undefined` in
   `src/shared/transcript/` (~350–420 LoC, the `workflowCall.ts` register:
@@ -279,7 +380,9 @@ caller is the banned extraction. What is shared is the **policy**:
   (~1,400), all width/ANSI code. The transcript rail stays separate from the
   fact rail (trap #7, still binding).
 
-Policy rulings needed before B-2 (each one sentence from the maintainer):
+Policy rulings needed before B-2 — **granted 2026-08-19** by the directive
+above; the parity answer applies to all five (each one sentence from the
+maintainer):
 membership set (CLI's 5-type allowlist vs webview's 15 formatters, or one
 allowlist + per-host mode), error-detail shape (1 capped field vs 11
 uncapped), quota-hint canon (CLI API-switch hint vs webview relay label),
@@ -295,6 +398,20 @@ superseding §0.1 item 6 — and item 8 explicitly blesses the
 snapshot+targeted dual path as the intended end state. The census found a
 strictly better, ruling-clean path; the supersession request is withdrawn.
 Full detail: `2026-08-15-shared-contracts-and-retirement.md` §2.3._
+
+**LANDED (2026-08-19).** Item 1 in #10719 (`pickProjection` over a
+`projectionShape` declared once, 10 arms derived; #10810 deleted the dead
+shape bundle it left behind), item 2 in #10932 (`invalidate(streamId, slice)`;
+`onParentStreamChanged` has zero occurrences repo-wide; port 22 → 18 methods),
+item 3 **as amended** — `progressEvents.ts` keeps its interfaces (they are the
+`SessionFact` vocabulary, upstream of the wire, and the doc said they do not
+delete) but their members are now `z.infer` of the message schemas — item 4
+and 6d in #10889 (`ProgressStreamProjectionBuilder` deleted with no shim,
+`replayTrace` hydrating through `buildStreamContentRender` /
+`buildStreamMetadata` on the browser-safe DTO path). Two item-4 stragglers
+remain **OPEN and gated**: `contentStore.ts` (127 L — the upheld
+Lit-DOM-modality dispute, deletable only under B-2) and `streamMetaSlice.ts`
+(169 L — whole-module death only under projection-zero).
 
 The verified fact stands, sharper than before: **12 of the 30 outbound
 arms are single-field projections of the `SYNC_STREAM_CONTENT` render
@@ -334,6 +451,22 @@ ProgressBridge suite as the parity harness.
   keep (~90, fenced).
 
 ## 7. Wave D — one delta pump
+
+> **WITHDRAWN — premise stale (2026-08-19, issue #10673 closed NOT_PLANNED).**
+> A re-audit before execution found the shared pieces already extracted: the
+> buffer/gap-detect/resync half is one implementation, `StreamLogDeltaBuffer`
+> (`src/transcript/StreamLog.ts:64`), consumed by both `WebviewBridge` and
+> `subscribeStreamLog`; and the coalescing half is `createFlushableDebounce`
+> (`@utils/core`), which already has twelve consumers including both sites.
+> What is left in each file is not the same algorithm written twice — it is
+> divergent host policy over one shared substrate: the bridge's 16 ms frame
+> interval and postMessage resync handshake versus the TUI's mode-flip
+> invalidation, generation guards, non-restarting scheduler, and residency
+> lease. Extracting a `StreamLogFeed` over that would be a single shared
+> abstraction with two consumers that each need to override it — the shape the
+> repo's own LOC lesson says net-adds. The `transcriptResidencyLeaseSites`
+> allowlist row therefore stays on `subscribeStreamLog.ts`; the claimed
+> −180 LoC is withdrawn from the program total.
 
 `WebviewBridge` and `subscribeStreamLog` implement the same
 subscribe/buffer/16 ms/gap-detect/resync algorithm over
@@ -413,6 +546,19 @@ Order chosen so each wave is independently shippable and the risky ruling
 5. **D:** `StreamLogFeed`. ≈ −180.
 6. **Promotions (§4)** ride whichever wave first needs them; each fixes a
    named cross-host gap and cites it.
+
+**Execution status at `e00b9317f7` (2026-08-19):** steps 1–2 landed (#10693,
+#10805, #10892, #10895, #10932 — the §0.1-item-8 `StreamSlice` supersession is
+executed, and it remains the program's only one); step 3's B-1 landed
+(#10717) and B-2 is in flight on `track/transcript-parity` with its rulings
+granted; step 4 landed (#10719, #10810, #10889, #10932); **step 5 is
+withdrawn** (§7); step 6's promotions are where the residual work sits — two
+of eight landed (#10754, #10805), one was already single-owner
+(`cumulativeUsage`), one was ruled (`buildStreamTabInfo`), and four remain
+open. The LoC total below is stale in both directions: Wave A's deletions
+were real but smaller per file than projected, Wave D's −180 is withdrawn,
+and the honest reading is that the deliverable landed (one substrate, hosts
+reading it) while the arithmetic did not.
 
 Rough program total (post-verification, and adding the contracts +
 retirement doc's own waves): **≈ −2,100..−2,500 LoC net**, four per-stream

--- a/docs/proposals/2026-08-16-define-out-of-existence.md
+++ b/docs/proposals/2026-08-16-define-out-of-existence.md
@@ -16,6 +16,21 @@
 > wave-1 candidates were struck down that way and are recorded in §3/§4
 > (the wave-1 refutation lives in §3, the race refutations in §4) so
 > they are never re-flagged.
+>
+> **Reconciled against origin/main `e00b9317f7` (2026-08-19).** This doc
+> executed almost completely: **18 of the 19 deletions have landed**, mostly
+> through #10788, #10792, #10800, #10801, #10802, #10803 and #10890, with
+> #10875 / #10892 / #10896 erasing residue afterwards. D2 is the only partial
+> (the required-sync port landed and the extension hole is closed, but three
+> downstream ports still carry optional `?.()` arms — see the row). D8 landed
+> in a stronger shape than proposed: a loud constructor `RangeError` rather
+> than a silent clamp. Both §3 rows were correctly kept, and the §4
+> irreducibility register stands untouched. What remains genuinely open is
+> exactly the two structural findings the doc itself said were not quick PRs —
+> **S1** (one persisted resumability authority) and **S2** (one follow-up
+> delivery authority), where the situation has sharpened: `childRunLoop.ts:65`
+> now documents in code that duplicate delivery is impossible by construction
+> while the transport-level suppression S2 condemns still runs.
 
 The scoreboard: **~40 race mechanisms + ~30 edge handlers censused →
 19 verified deletions (D1–D19: 15 from the two invented-edge waves + 4
@@ -31,6 +46,27 @@ are the briefly-noted rows already owned by other program docs.
 
 Each row survived adversarial verification with an exhaustive producer
 census. Format: machinery → construction-level fix → what deletes.
+
+**Per-row status at `e00b9317f7` (2026-08-19).** LANDED: D1 (#10800 — the
+explicit `{kind}` union is at `runAgent.ts:76-86`; the surviving
+`shouldRegister` local is a derivation from declared intent, not the old
+inference), D3 (#10801), D4 (#10778), D5 (#10803), D6 (#10801, then moot with
+the relay removal), D7 (#10801), D8 (#10788, **as a throw** — the stronger
+option §3 offered for a sibling guard), D9 (#10801), D10 (#10801), D11
+(#10802), D12 (#10792), D13 (#10802), D14 (#10801 for the field, #10875 for
+the base interface), D15 (#10803 for the emission reorder, #10892 for the CLI
+marker-refresh apparatus — the #10693 WATCH is closed the way this doc wanted,
+by making the edge impossible), D16 (#10890, with the declared
+one-stale-read R6 line written at the commit site), D17 (#10801), D18 (#10800
+— one `beginTeardown(cause)`, the `exiting` re-entry guard gone, and the
+load-bearing rider held: terminal-mode restoration stays synchronous before
+any await), D19 (#10800 — stub handle tracked at id assignment;
+`runLifecycleStarted` and `interruptPending` absent). **D2 is PARTIAL**
+(#10739, #10800): `isCancellationRequested` is required on
+`ResumeQueuedToolUseOptions` and the extension threads it, but the optional
+arms survive at `executeAgent.ts:116`, `executeAgent.ts:530` and
+`resolveAndResumeStream.ts:141` — the ~20 LoC this row counted as deleted is
+mostly still there, and the construction guarantee only holds at the one port.
 
 ### 1a. Launch/resume intent (runtime)
 
@@ -205,6 +241,18 @@ census. Format: machinery → construction-level fix → what deletes.
   producer-less finding.)_ Flagged for the maintainer's call;
   `turnToken` attribution stays either way.
 
+**Both OPEN at `e00b9317f7` (2026-08-19).** S1's apparatus is intact
+(`SessionHandle.waitingRepairProbes`, `probeWaitingRepair`,
+`statusGenerationsAtScan`, and `StreamStatusService`'s exported generation
+surface); nothing since 2026-08-15 has touched it, which matches the doc's own
+"coordinate with the substrate program; not a quick PR". S2's
+`admittedDeliveryIds` check-and-add is unchanged, still carrying #9664's
+"not crash-safe exactly-once" comment — and the producer-less finding has since
+been asserted in code: `childRunLoop.ts:65-67` now states that duplicate
+delivery is impossible by construction and there is "nothing left to dedupe
+against". Two owners now document contradictory beliefs about the same
+mechanism, which is a stronger argument for the ruling than the doc had.
+
 ## 3. Kept with adjustment
 
 - **Approval-queue cycle guard**: edge confirmed unproducible today, but
@@ -248,6 +296,12 @@ re-stomping; the extension's _unserialized_ twin is a latent stale-push
 bug — fix by adding the desktop's serialization via `PQueue`, the one
 place machinery should be _added_).
 
+**Both rows held (2026-08-19).** The approval-queue cycle guard kept option A —
+the 6 LoC of `seen`-set insurance at `streamApprovalQueue.ts:67-72`, not
+converted to a throw; either was sanctioned. The round-update protocol was not
+touched, correctly: `reset` is still on the wire with its rationale comment,
+and `clearMissingOutputs` is still the only path that propagates it.
+
 ## 5. Execution shape
 
 1. **Mechanical batch, no ruling** (one or two PRs): D3, D4, D6, D7, D8,
@@ -266,3 +320,11 @@ place machinery should be _added_).
 
 Every PR body carries the §5b ledger discipline: the _deleted_ machinery
 is the paired deletion; no new names are introduced anywhere in this doc.
+
+**Execution status at `e00b9317f7` (2026-08-19):** steps 1–2 landed (across
+#10788, #10792, #10800, #10801, #10802, #10803, #10890); step 3 landed for D1
+and partially for D2 (see §1a); step 4 landed (#10803 + #10892, resolving the
+#10693 WATCH). Step 5's rulings: the funnel serialization was granted and
+landed (#10824 gave the extension the desktop's `PQueue`); **S2's dedup
+deletion and S1's scheduling are still the maintainer's open calls** — they are
+the whole of what this doc has left.

--- a/docs/proposals/2026-08-16-overdefensive-top10.md
+++ b/docs/proposals/2026-08-16-overdefensive-top10.md
@@ -12,6 +12,26 @@
 > and two inflated sub-claims (#5's flagship catch story, 2 of #10's four
 > FS sites) are rewritten to what the code actually does. R6 net-element
 > accounting applies to every PR; R8 consumer-greps are named per entry.
+>
+> **Reconciled against origin/main `e00b9317f7` (2026-08-19).** The plan
+> executed as sequenced: **the three gates landed first** (#10781, #10782,
+> #10783 — G1 surfaces desktop async failures to a real dialog and the
+> post-startup handler surfaces-then-quits rather than suppressing the crash;
+> G2 installs an ExtHost `unhandledRejection` and gives view-dispatch `onError`
+> a user surface; G3 installs the renderer listener on the normal path and the
+> `hostBridge` throw-at-boot followed), which unblocked everything else.
+> **Seven entries are fully landed** (1, 2, 3, 5, 7, 9, 10) and three are
+> partial (4, 6, 8). The re-counts are the honest measure of the sweep: entry
+> 1's 27 consumer `safeParse`+skip branches → 0, entry 2's 42 `try*` sites →
+> 12 (7 production, every one a documented KEEP), entry 6's 24 optional-logger
+> sites → 7, entry 7's 17 `?? ''` sites → 0 in production, entry 8's four
+> `provider.toLowerCase()` sites → 2. What remains genuinely open is small and
+> named: `terminalStatus.ts:60-78`'s second-owner read (4d), the
+> `SupabaseSessionLog` all-optional interface plus four desktop
+> optional-callback stragglers (6), and lowercase-provider-once-at-registry-load
+> (8) — which is self-documented in the code, at `providerConfig.ts:35`, as
+> waiting on this entry. `agentRoster.ts:59` is not open work: it is the
+> policy-gated KEEP this doc demoted it to.
 
 Scoreboard: **~230 defensive sites censused → ~180 removable across 10
 families (est. net −660..−710 LoC of pure defense — the sum of the
@@ -52,6 +72,54 @@ land in a log-only or silent row are sequenced behind §3's gates G1-G3
 a renderer throw kills the UI, not the run.
 
 ## 1. The top 10
+
+**Per-entry status at `e00b9317f7` (2026-08-19):**
+
+1. **LANDED #10799.** `data` is a `z.discriminatedUnion('messageType', …)`
+   validated at exactly the two boundaries named; **27 consumer branches → 0**.
+   The verifier's discriminant correction was right — the union keys on
+   `messageType`, and `z.unknown()` survives only for genuinely opaque payloads.
+2. **LANDED #10814.** **42 sites in 23 files → 12**, of which 7 are production
+   and every one is a documented KEEP (goalStore's pre-init reads, a fenced
+   `getConfigBeforePlatformInit`, the platformless-SDK guard, three bootstrap
+   callers). The `serverKeys` KEEP is moot — that module went with the relay
+   plane.
+3. **LANDED #10789 / #10864 / #10887 / #10888** for all four age-out
+   mechanisms, including the load-bearing precondition (`emptySnapshot()` now
+   constructs a canonical `{workPlan:{}}`). `withLegacyUsageRoute` has zero
+   hits repo-wide, so the `streamData.ts` strictification precondition became
+   moot rather than being executed. `agentRoster.ts:59` correctly **kept**, now
+   with an expanded permanent-reader rationale.
+4. **PARTIAL.** (a) **LANDED #10794/#10890** by the prescribed route — the
+   window is unrepresentable: the lease is acquired first and the record read
+   under it, so the second read and the `isDeepStrictEqual` compare are gone.
+   (b) **LANDED #10792.** (c) **LANDED #10793** — one parse, and the silent
+   filter is gone. (d) **OPEN** — `terminalStatus.ts` still prefers
+   `meta.outcome` over the `result.outcome` in hand; only the read failure
+   became loud.
+5. **LANDED #10791.** `streamSnapshot.ts` has zero `.catch(`; `schemaVersion`
+   is `.prefault` with the reason written down, and per-field recovery stayed
+   loud rather than becoming the more-destructive whole-object parse the review
+   warned about. `UsageMonitor`'s `.catch('unknown')` is gone and **both**
+   encompassing catches were loudened (`error` / `warn`) — the honest outcome
+   this entry predicted.
+6. **PARTIAL #10786.** **24 → 7**, and 2 of the 24 evaporated with the relay
+   plane. Residue: the all-optional `SupabaseSessionLog` interface itself
+   (`supabaseSessionTypes.ts:53-58`) driving three `?.` sites, plus the four
+   desktop optional-host-callback stragglers this entry said to "fold in or
+   exclude".
+7. **LANDED #10787.** `normalizeOutput` returns `string`; **17 → 0** production
+   `?? ''` sites, and both null-semantics consumers were rewritten in the same
+   PR as the precondition required.
+8. **PARTIAL #10790.** The double `safeParse`, the vars-bag laundering (now a
+   typed field, no `.catch([])`), and the retired-vocabulary comment all
+   landed. The `provider.toLowerCase()` half is **4 → 2** and self-documented
+   as deferred at `providerConfig.ts:35`, which names this entry as the PR that
+   closes it.
+9. **LANDED #10781/#10782/#10783** — see the gate table in §3.
+10. **LANDED #10788.** All three confirmed REMOVEs shipped (FNF-discriminate
+    then rethrow; both `assertNever` gaps; the engine clamp became a
+    constructor `RangeError`), and the three review demotions were honored.
 
 Format per entry: pattern → quantified extent → representatives →
 disposition → execution shape → est. net LoC.
@@ -404,6 +472,12 @@ remove), the exported-trace legacy boundary (`taskGroup.ts:62-68`,
 these lists stops and records it; it does not "fix" it.
 
 ## 3. Execution plan
+
+**ALL THREE GATES LANDED (2026-08-19)** — the sequencing worked exactly as
+designed, and the review-caught constraint on G1 was honored: the desktop's
+post-startup rejection handler surfaces then quits (`fatalStartupError.ts:21-39`)
+rather than converting Node's default crash into continued execution with
+inconsistent main-process state.
 
 **Land the gates first (entry #9; ~25 LoC total, one small PR per
 host):**


### PR DESCRIPTION
The six consolidation-program proposals are read as live obligations by every later audit and agent sweep. Most of what they propose has landed since they were written; some rows were withdrawn or refuted. Rows that silently landed cost the next campaign a re-proposal cycle — that has happened twice in this repo's history. Each doc now tells the truth about `origin/main e00b9317f7`.

Docs-only: `git diff --name-only` is six files under `docs/proposals/`. No new root-level doc, no file moved.

## What I verified

Every row was checked against code at HEAD, not against PR titles — six parallel verification sweeps over the ~90 PRs merged since 2026-08-16, each returning a per-row verdict with file:line evidence and PR attribution. Where a doc gave a count (27 consumer branches, 42 `try*` sites, 17 `?? ''` sites, 22 port methods) the count was retaken at HEAD.

## Counts per doc

| doc | landed | partial | open | withdrawn / refuted / moot |
| --- | --- | --- | --- | --- |
| `single-substrate-hosts-as-renderers` | 13 | 6 | 8 | 1 withdrawn (Wave D) |
| `shared-contracts-and-retirement` | 16 | 2 | 4 | 1 counter-ruled (§2.9), 1 moot (§2.6.4) |
| `cross-host-consolidation` | 10 | 9 | 24 | 1 refuted (V9/DR13), 2 moot via relay retirement, 3 stale-at-pin |
| `define-out-of-existence` | 18 of 19 D-items + 2 kept-rows | 1 (D2) | 2 (S1, S2) | — |
| `overdefensive-top10` | 7 entries + all 3 gates | 3 | 3 named sub-items | — |
| `lifecycle-ownership` | steps 1/2/3/7 + 3 leak fixes | steps 5/8/9 | step 4/6 + 4 leak fixes | 1 claim did not reproduce (Lean three-owners) |

## Rulings recorded, not just status

- **Wave D (`StreamLogFeed`) — WITHDRAWN.** Issue #10673 closed NOT_PLANNED. `StreamLogDeltaBuffer` and `createFlushableDebounce` already own the shared halves; the residue is divergent host policy, and the CLI copy has diverged further since the row was written. The −180 leaves the program total.
- **§2.9 usage naming — REJECTED.** #10796 made `NormalizedUsage` the carrier at the model boundary; the schema documents `cachedInputTokens`/`cacheCreationTokens` as authoritative with the reason (`NormalizedUsage.ts:15-23`). The `UsageLogTypes` gate is moot.
- **DR13 / "two truth sources" — REFUTED.** One owner, `deriveResumability`. #10927/#10940 added a display-side `deriveOfferableResumability` that gates on lease liveness and fails closed loudly; admission semantics are deliberately unchanged. The CLI's extra strictness is a superset of *requirements* — deleting it would make `/resume` offer rows it then refuses.
- **Included-access spend consolidation — obsoleted** by the relay retirement (#10894/#10896): `relayUsage.ts` is deleted and `apiStatus.ts` has no included-access line.
- **Projection-zero — still GATED.** SSOT §0.1 items 6 and 8 stand unchanged in the source doc; the supersessions were never granted.
- **B-2's five transcript policy rulings — GRANTED** by the 2026-08-19 directive "the TUI should render the same state extension/desktop have"; the shared `src/shared/transcript/` row model implementing it is in flight on `track/transcript-parity`.

## What genuinely remains open across the program

1. **Composition-root plane (cross-host §2c) — the largest untouched block.** None of C4/C5/C6/C7/C8/C15 has a landing PR. **C4/V10 is a live user-facing defect**: a malformed `.texra/config.json` still hard-fails every `texra` command on the one host with no settings UI.
2. **Lifecycle §3 fix 2** — quit-time lease settlement at the session root, the doc's own "widest-impact fix". Never landed; the CLI UI is still the sole, idle-gated implementation.
3. **Substrate §4 promotions** — `contextState` (still the live CLI gauge bug), `runStartedAt`, `thinkingActive`, root-run stream identity, run input files + `plannedRounds`.
4. **V2 desktop telemetry, now worse** — zero `UsageLogService` refs in `packages/desktop`, and the relay retirement removed the per-round force-flush that was mitigating it. `refreshModelListStateIfNeeded` has no production caller on *any* host.
5. **V7 AppSignals** — still zero references in desktop and CLI.
6. **S1/S2** (define-out-of-existence) — the two structural findings, both maintainer calls.
7. Smaller, all named in place: §2.2 item 3, `SettingsCredentialActions`, C12's `docsCommand`, C16/C17, C9/V11a, eight #9021 rows, three overdefensive sub-items, the async-dispose split, LaTeX signal threading, the toggle-store move.

## Corrections to the brief I was given

- **#10925 did not move the child-work policy toggles.** It collapsed the settings catalogs; `DETACH_SUBAGENTS_ON_STOP` / `ALLOW_ORCHESTRATOR_KILL` still declare `slots: sameSlot('workspaceState')`. The 2026-08-15 shared-store ruling is unexecuted.
- **#10893 did not land lifecycle §3 fix 2.** It landed the deadline, window root, launch-resource store, and session-keyed registries — lease settlement is untouched.
- **§4a landed at #10693**, before the named window; #10892/#10895 completed it.
- **One regression to triage separately:** C13b was resolved by *deleting* the CLI's ACTIVE_SKILLS handling (#10895), so the CLI can no longer observe active skills at all.
- **One repair regressed:** #10694 landed both explicit-cascade `kill` sites; #10800 removed one.
- **Three rows landed by a better mechanism than proposed** (C14 self-registration, §4k a texmath-mirroring block probe, V9 a display-side wrapper) — each is now read down to its residue. §4k's named missing test is still missing.

## Gates

`npm run format:check` and `npm run check:guidance-refs` both pass. `git diff --name-only` shows only `docs/proposals/*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)