### PR TITLE
refactor(tools): give the child-execution stream-id formula an owner and split ExecutionsTool

### DIFF
--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -5,12 +5,6 @@
  * executions.
  */
 
-// Node imports
-import * as path from 'node:path';
-
-// Third-party imports
-import { z } from 'zod';
-
 // Local imports
 import {
   deriveResumability,
@@ -18,12 +12,10 @@ import {
   listExecutionWorkspaceFiles,
   unwrapResultMeta,
   type ChildRecord,
-  type ExecutionKVStore,
   type TodoEntry,
   listExecutions,
   resolveExecutionWorkspaceFilePath,
 } from '@agent/storage';
-import type { RunRecord } from '@agent/core/definition/RunRecord';
 import {
   currentSession,
   type SessionHandle,
@@ -39,28 +31,13 @@ import { createLog } from '@logger/logUtils';
 import type { FileStat } from '@platform/interfaces';
 import { platform } from '@platform/platform';
 import {
-  deriveWorkflowCounts,
   ExecutionIdSchema,
-  LOG_LEVELS,
-  MESSAGE_TYPES,
-  stageTitleFor,
-  STREAM_LOG_ENTRY_TYPES,
-  TERMINAL_WORKFLOW_CALL_STATUSES,
   ToolError,
   type ExecutionId,
-  type StreamLogEntry,
   type ToolResult,
   type WorkflowExecutionSnapshot,
-  WORKFLOW_CALL_STATUS,
 } from '@shared/schemas';
-import {
-  BASH_BACKGROUND_LOG_CAP_CHARS,
-  type BackgroundBashOutputSource,
-  EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
-  getBackgroundBashOutputSource,
-  EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
-  EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
-} from '@shared/toolUse';
+import { BASH_BACKGROUND_LOG_CAP_CHARS } from '@shared/toolUse';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { requireRunStream, requireStreamId } from '@tools/contextHelpers';
 import { assertNoParentTraversal } from '@tools/pathResolution';
@@ -70,7 +47,7 @@ import {
   readCompletedRunConversation,
   readCompletedRunTodos,
 } from '@transcript';
-import { assertNever, clamp, unique } from '@utils/core';
+import { assertNever, unique } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { StorageFS } from '@utils/files/storageFS';
 import { isDirectory } from '@utils/files/fsEntryType';
@@ -99,83 +76,28 @@ import {
   formatFileView,
   paginateToolListing,
   formatPaginationHint,
-  ViewRangeSchema,
 } from './formatting';
+import { serializeFilteredConfig } from './executions/configView';
 import { formatConversation } from './executions/conversationFormat';
+import { EXECUTION_PATH_LIST } from './executions/pathCatalog';
+import {
+  OUTPUT_MAX_LINES,
+  OUTPUT_TAIL_LINES,
+  projectProcessOutput,
+} from './executions/processOutput';
 import { listRunGeneratedFiles } from './executions/runGeneratedFiles';
+import {
+  ExecutionsToolInputSchema,
+  type ExecutionsToolInput,
+} from './executions/toolInput';
+import { turnAttributionNote } from './executions/turnAttribution';
 import {
   listenForFollowUp,
   shouldSkipWait,
 } from './executions/waitCoordination';
+import { workflowExecutionView } from './executions/workflowSummaryView';
 
 const log = createLog('ExecutionsTool');
-
-// ============================================================================
-// Resource path catalog
-// ============================================================================
-
-/**
- * Single source of truth for the virtual resource paths this tool serves.
- * Both the tool `description` and the "Unknown path" error render from this
- * list, so the two cannot drift.
- */
-const EXECUTION_PATH_CATALOG: ReadonlyArray<{ path: string; summary: string }> =
-  [
-    {
-      path: '/executions',
-      summary: 'List executions (paginated; use offset/limit for pages)',
-    },
-    {
-      path: '/executions/{id}',
-      summary:
-        'Execution summary (agent, model, timestamp, status, children, todos)',
-    },
-    { path: '/executions/{id}/config', summary: 'Agent configuration JSON' },
-    {
-      path: '/executions/{id}/conversation',
-      summary: 'Full message history (subagents)',
-    },
-    {
-      path: '/executions/{id}/todos',
-      summary: 'Task list (tool-use subagents)',
-    },
-    {
-      path: '/executions/{id}/report',
-      summary: 'Result report (persists after context compaction)',
-    },
-    {
-      path: '/executions/{id}/result',
-      summary:
-        'Final result envelope (JSON) for chaining; process result for background commands',
-    },
-    {
-      path: '/executions/{id}/output',
-      summary:
-        'stdout/stderr of a background command, readable WHILE IT RUNS (report/result only exist once it finishes)',
-    },
-    { path: '/executions/{id}/children', summary: 'Child executions' },
-    {
-      path: '/executions/{id}/files',
-      summary: 'Generated files (workflows only)',
-    },
-    {
-      path: '/executions/{id}/files/{path}',
-      summary: 'Read specific generated file (workflows only)',
-    },
-    {
-      path: '/executions/{id}/workspace-files',
-      summary: 'Workspace files edited by tool-use runs',
-    },
-    {
-      path: '/executions/{id}/workspace-files/{path}',
-      summary: 'Read a workspace file edited by a tool-use run',
-    },
-  ];
-
-/** Renders the catalog as a bulleted `- <path> - <summary>` list. */
-const EXECUTION_PATH_LIST = EXECUTION_PATH_CATALOG.map(
-  ({ path: resourcePath, summary }) => `- ${resourcePath} - ${summary}`,
-).join('\n');
 
 function getRunningTodos(
   session: SessionHandle,
@@ -183,40 +105,6 @@ function getRunningTodos(
 ): TodoEntry[] {
   return session.snapshots.getWorkPlan(handle.childStreamId).todos;
 }
-
-/**
- * One-line attribution note for /report and /result when a newer turn was
- * accepted but never persisted a result (#9531): without it, the single
- * latest-value slots would silently present the previous turn as current.
- * Reads "still running" while the execution is live and "was interrupted"
- * once it has terminalized. Returns null when the slots reflect the latest
- * accepted turn (or the execution has no turn identity at all).
- */
-async function turnAttributionNote(
-  store: ExecutionKVStore,
-): Promise<string | null> {
-  const [turnState, meta] = await Promise.all([
-    store.readTurnState(),
-    store.readMeta(),
-  ]);
-  const active = turnState?.activeTurn;
-  const completed = turnState?.lastCompletedTurn?.token;
-  if (!active || active.token === completed) {
-    return null;
-  }
-  const fate =
-    meta?.outcome === undefined
-      ? `turn ${active.token} is still running`
-      : `turn ${active.token} was interrupted before producing a result`;
-  const showing = completed
-    ? `showing the latest completed turn (${completed}).`
-    : 'no turn has completed yet.';
-  return `[Note: ${fate}; ${showing}]`;
-}
-
-// ============================================================================
-// Run-directory listing and config serialization
-// ============================================================================
 
 interface SizedEntry {
   readonly path: string;
@@ -236,448 +124,6 @@ function formatSizedEntryLines(entries: readonly SizedEntry[]): string[] {
     return `${sizeStr.padStart(8)}  ${entry.path}`;
   });
 }
-
-/**
- * Per-category config-field exclusions: `toolUse` hides the workflow-only
- * file fields, `workflow` hides the toolUse-only `toolConfig`. Unknown
- * categories get no filtering.
- */
-const HIDDEN_CONFIG_FIELDS_BY_CATEGORY: Readonly<
-  Record<string, ReadonlySet<string>>
-> = {
-  toolUse: new Set([
-    'inputFile',
-    'inputFiles',
-    'contextFile',
-    'contextFiles',
-    'mediaFile',
-    'mediaFiles',
-    'outputFiles',
-    'editedFile',
-    'editedFiles',
-  ]),
-  workflow: new Set(['toolConfig']),
-};
-
-/**
- * Serialize a run record to pretty JSON, dropping agent-config fields
- * irrelevant to the resolved display category so the serialized config the
- * orchestrator reads stays relevant. Records without an agent execution mode
- * are honest by construction and serialize unchanged.
- */
-function serializeFilteredConfig(
-  record: RunRecord,
-  category: string | undefined,
-): string {
-  const excludeSet = category
-    ? HIDDEN_CONFIG_FIELDS_BY_CATEGORY[category]
-    : undefined;
-  if (!excludeSet) {
-    return JSON.stringify(record, null, 2);
-  }
-  const filtered = Object.fromEntries(
-    Object.entries(record).filter(([key]) => !excludeSet.has(key)),
-  );
-  return JSON.stringify(filtered, null, 2);
-}
-
-// ============================================================================
-// Background command output
-// ============================================================================
-
-/** Lines returned by /executions/{id}/output when no view_range is given. */
-const OUTPUT_TAIL_LINES = 200;
-
-/** Hard ceiling on lines a single /output read returns, view_range included. */
-const OUTPUT_MAX_LINES = 1_000;
-
-/** Marks a projected line that the command wrote to stderr. */
-const OUTPUT_STDERR_PREFIX = 'err: ';
-
-const WORKFLOW_SUMMARY_MAX_ENTRIES = 8;
-const WORKFLOW_SUMMARY_MAX_ATTEMPTS = 2;
-const WORKFLOW_SUMMARY_MAX_FILES_PER_KIND = 3;
-const WORKFLOW_SUMMARY_TEXT_LENGTH = 160;
-
-function compactWorkflowText(value: string | undefined): string | undefined {
-  return value?.slice(0, WORKFLOW_SUMMARY_TEXT_LENGTH);
-}
-
-function workflowStageView(
-  stage: WorkflowExecutionSnapshot['stages'][number],
-): unknown {
-  return {
-    id: compactWorkflowText(stage.id),
-    title: compactWorkflowText(stage.title),
-    order: stage.order,
-    lifecycle: stage.lifecycle,
-    startedAt: stage.startedAt,
-    completedAt: stage.completedAt,
-  };
-}
-
-function workflowAttemptView(
-  attempt: WorkflowExecutionSnapshot['calls'][number]['attempts'][number],
-): unknown {
-  return {
-    number: attempt.number,
-    id: compactWorkflowText(attempt.id),
-    childStreamId: compactWorkflowText(attempt.childStreamId),
-    model: compactWorkflowText(attempt.model),
-    costUsd: attempt.costUsd,
-    startedAt: attempt.startedAt,
-    completedAt: attempt.completedAt,
-  };
-}
-
-function workflowCallFailurePriority(status: string): number {
-  // Within terminal calls, elevate failed/cancelled so the bounded projection
-  // keeps the outcomes that matter for debugging (matches stage ranking).
-  if (
-    status === WORKFLOW_CALL_STATUS.FAILED ||
-    status === WORKFLOW_CALL_STATUS.CANCELLED
-  ) {
-    return 0;
-  }
-  return 1;
-}
-
-function workflowExecutionView(snapshot: WorkflowExecutionSnapshot): unknown {
-  const byPriority = snapshot.calls.toSorted(
-    (left, right) =>
-      Number(TERMINAL_WORKFLOW_CALL_STATUSES.has(left.status)) -
-        Number(TERMINAL_WORKFLOW_CALL_STATUSES.has(right.status)) ||
-      workflowCallFailurePriority(left.status) -
-        workflowCallFailurePriority(right.status) ||
-      Number(left.stageId !== snapshot.currentStageId) -
-        Number(right.stageId !== snapshot.currentStageId) ||
-      right.timestamps.updatedAt.localeCompare(left.timestamps.updatedAt),
-  );
-  const stages = snapshot.stages
-    .toSorted((left, right) => {
-      const priority = (stage: (typeof snapshot.stages)[number]): number => {
-        if (stage.id === snapshot.currentStageId) return 0;
-        if (stage.lifecycle === 'failed' || stage.lifecycle === 'cancelled') {
-          return 1;
-        }
-        return 2;
-      };
-      return priority(left) - priority(right) || right.order - left.order;
-    })
-    .slice(0, WORKFLOW_SUMMARY_MAX_ENTRIES)
-    .map(workflowStageView);
-  const calls = byPriority
-    .slice(0, WORKFLOW_SUMMARY_MAX_ENTRIES)
-    .map((call) => {
-      const compactFiles = (files: readonly string[]) => ({
-        sample: files
-          .slice(0, WORKFLOW_SUMMARY_MAX_FILES_PER_KIND)
-          .map((file) => compactWorkflowText(file)!),
-        ...(files.length > WORKFLOW_SUMMARY_MAX_FILES_PER_KIND && {
-          omitted: files.length - WORKFLOW_SUMMARY_MAX_FILES_PER_KIND,
-        }),
-      });
-      return {
-        id: compactWorkflowText(call.id),
-        label: compactWorkflowText(call.label),
-        stageId: compactWorkflowText(call.stageId),
-        stageTitle: compactWorkflowText(stageTitleFor(snapshot, call)),
-        agent: compactWorkflowText(call.agent),
-        model: compactWorkflowText(call.model),
-        files: {
-          input: compactFiles(call.files.input),
-          context: compactFiles(call.files.context),
-          media: compactFiles(call.files.media),
-        },
-        childExecutionId: compactWorkflowText(call.childExecutionId),
-        childStreamId: compactWorkflowText(call.childStreamId),
-        attempts: call.attempts
-          .slice(-WORKFLOW_SUMMARY_MAX_ATTEMPTS)
-          .map(workflowAttemptView),
-        ...(call.attempts.length > WORKFLOW_SUMMARY_MAX_ATTEMPTS && {
-          omittedAttempts: call.attempts.length - WORKFLOW_SUMMARY_MAX_ATTEMPTS,
-        }),
-        status: call.status,
-        blockedReason: compactWorkflowText(call.blockedReason),
-        error: compactWorkflowText(call.error),
-        costUsd: call.costUsd,
-        timestamps: call.timestamps,
-      };
-    });
-  const currentStage = snapshot.stages.find(
-    (stage) => stage.id === snapshot.currentStageId,
-  );
-  return {
-    aggregate: {
-      lifecycle: snapshot.lifecycle,
-      error: compactWorkflowText(snapshot.error),
-      counts: deriveWorkflowCounts(snapshot.calls),
-      timestamps: snapshot.timestamps,
-      responseBounds: {
-        maxStages: WORKFLOW_SUMMARY_MAX_ENTRIES,
-        maxCalls: WORKFLOW_SUMMARY_MAX_ENTRIES,
-        maxAttemptsPerCall: WORKFLOW_SUMMARY_MAX_ATTEMPTS,
-        maxFilesPerKind: WORKFLOW_SUMMARY_MAX_FILES_PER_KIND,
-      },
-    },
-    currentStage: currentStage ? workflowStageView(currentStage) : null,
-    stages,
-    calls,
-    ...(snapshot.stages.length > stages.length && {
-      omittedStages: snapshot.stages.length - stages.length,
-    }),
-    ...(snapshot.calls.length > calls.length && {
-      omittedCalls: snapshot.calls.length - calls.length,
-    }),
-  };
-}
-
-/**
- * Line break in captured terminal output. A bare CR counts: progress bars
- * (curl, pip, docker) redraw with `\r` and no newline, so splitting on LF
- * alone would collapse a whole build's progress into one enormous "line" and
- * hand the caller the entire log however small the requested window was.
- */
-const OUTPUT_LINE_BREAK = /\r\n|\r|\n/;
-
-interface ProcessOutputProjection {
-  readonly lines: readonly string[];
-  readonly chars: number;
-}
-
-/**
- * Flatten a background command's transcript rows into display lines.
- *
- * Tagged stdout/stderr chunks stay in append order and concatenate only while
- * their source remains compatible, so chunk-split lines are reconstructed
- * without crossing a stream switch. Untagged lifecycle and legacy rows flush
- * any pending command fragment and render standalone. Structured rows (usage,
- * context state, tool frames) carry a non-default `messageType` and are
- * dropped: this endpoint projects command output, not run bookkeeping.
- */
-function projectProcessOutput(
-  entries: readonly StreamLogEntry[],
-): ProcessOutputProjection {
-  const lines: string[] = [];
-  let chars = 0;
-  let pendingText = '';
-  let pendingSource: BackgroundBashOutputSource | undefined;
-
-  const emitText = (text: string, stderr: boolean): void => {
-    // A trailing break terminates the last line rather than opening an empty
-    // one; blank lines inside the text still survive the split.
-    const normalized = text.replace(/\r\n$|[\r\n]$/, '');
-    for (const line of normalized.split(OUTPUT_LINE_BREAK)) {
-      lines.push(stderr ? `${OUTPUT_STDERR_PREFIX}${line}` : line);
-    }
-  };
-  const flushPending = (): void => {
-    if (pendingText && pendingSource) {
-      emitText(pendingText, pendingSource === 'stderr');
-    }
-    pendingText = '';
-    pendingSource = undefined;
-  };
-
-  for (const entry of entries) {
-    if (entry.type !== STREAM_LOG_ENTRY_TYPES.LOG) continue;
-    if ((entry.messageType ?? MESSAGE_TYPES.DEFAULT) !== MESSAGE_TYPES.DEFAULT)
-      continue;
-    const text = entry.text;
-    if (!text) continue;
-
-    chars += text.length;
-    const source = getBackgroundBashOutputSource(entry.data);
-    if (!source) {
-      flushPending();
-      emitText(
-        text,
-        entry.level === LOG_LEVELS.WARN || entry.level === LOG_LEVELS.ERROR,
-      );
-      continue;
-    }
-
-    if (pendingSource && pendingSource !== source) flushPending();
-    pendingSource = source;
-    pendingText += text;
-  }
-  flushPending();
-
-  return { lines, chars };
-}
-
-// ============================================================================
-// Schema
-// ============================================================================
-
-/** Virtual path: /executions, /executions/{id}, /executions/{id}/files, /executions/{id}/workspace-files/{path} */
-const PathFieldSchema = z.string().describe('Path starting with /executions');
-
-const ViewActionSchema = z.strictObject({
-  path: PathFieldSchema,
-  // Optional + defaulted, NOT .nullish() (unlike every other nullish field in
-  // this file): 'view' is the common no-op-preamble call, so omitting
-  // `action` must both dispatch to this branch and keep `action` out of the
-  // JSON-schema `required` list, matching the pre-refactor `.prefault('view')`
-  // and AGENTS.md's "design for the model's first call" rule.
-  // `.optional().default('view')` keeps the emitted per-branch JSON schema a
-  // clean single-value `const` (not an `anyOf` with `null`) — required so
-  // `convertToolSchema`'s `flattenTopLevelUnion`/`schemaLiteralValue` (which
-  // only recognizes a bare `const`/one-item `enum` as a discriminator
-  // literal) still merges all five actions into one enum for the
-  // OpenAI/Anthropic/Google-facing schema. `.nullish()` here produces an
-  // `anyOf` that flattening can't read as a literal, silently dropping
-  // wait/kill/subscribe/unsubscribe from the advertised schema instead.
-  // The explicit-`null` case AGENTS.md's rule calls out (a structured-output
-  // provider representing an omitted optional field as `null` rather than
-  // absent) is handled separately below by ExecutionsToolInputSchema's
-  // preprocess, which strips a `null` action down to omitted before this
-  // branch's own default runs — so the type stays a plain optional literal.
-  action: z
-    .literal('view')
-    .optional()
-    .default('view')
-    .describe('Read execution data (returns immediately). Default action.'),
-
-  /** Optional line range [start, end] for large outputs. */
-  view_range: ViewRangeSchema.nullish().describe(
-    'Line range [start, end] for paginating file and background-command output. Conversation pagination uses offset and limit.',
-  ),
-
-  /** Zero-based offset for list or conversation pagination. */
-  offset: z
-    .int()
-    .min(0)
-    .nullish()
-    .describe(
-      'Zero-based offset into the executions list or conversation messages. Use with limit on /executions or /executions/{id}/conversation. Default: 0.',
-    ),
-
-  /** Maximum list entries or conversation messages to return. */
-  limit: z
-    .int()
-    .min(1)
-    .max(200)
-    .nullish()
-    .describe(
-      'Max entries or conversation messages to return. Use on /executions or /executions/{id}/conversation. Default: 100, max: 200.',
-    ),
-});
-
-const WaitActionSchema = z.strictObject({
-  path: PathFieldSchema,
-  action: z
-    .literal('wait')
-    .describe(
-      'Wait for a status change on /executions or /executions/{id}, then return the same data as view (avoids sleep-poll loops).',
-    ),
-
-  /** Execution IDs to wait on (with /executions only; ignored on /executions/{id}). */
-  ids: z
-    .array(ExecutionIdSchema)
-    .min(1)
-    .max(50)
-    .nullish()
-    .describe(
-      'List of execution IDs to wait on (with /executions only). ' +
-        'Waits for any of the listed executions to change status. ' +
-        'If omitted, waits for any active execution.',
-    ),
-
-  /** Max seconds to wait. Default: 300. */
-  timeout: z
-    .number()
-    .finite()
-    .nullish()
-    // Clamp in the schema so input.timeout is always a ready-to-use number:
-    // an out-of-range or missing value becomes a value inside the wait window.
-    .transform((v) =>
-      clamp(
-        v ?? EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
-        EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
-        EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
-      ),
-    )
-    .describe(
-      `Max seconds to wait for a status change. Default: ${EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS}; finite values are clamped to the ${EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS}-${EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS} range.`,
-    ),
-
-  /** Zero-based offset for the /executions listing returned once the wait resolves. */
-  offset: z
-    .int()
-    .min(0)
-    .nullish()
-    .describe(
-      'Zero-based offset into the executions list returned once the wait resolves (with /executions only). Default: 0.',
-    ),
-
-  /** Maximum list entries in the /executions listing returned once the wait resolves. */
-  limit: z
-    .int()
-    .min(1)
-    .max(200)
-    .nullish()
-    .describe(
-      'Max entries in the executions list returned once the wait resolves (with /executions only). Default: 100, max: 200.',
-    ),
-});
-
-const KillActionSchema = z.strictObject({
-  path: PathFieldSchema,
-  action: z
-    .literal('kill')
-    .describe('Terminate a running execution by ID (use on /executions/{id}).'),
-});
-
-const SubscribeActionSchema = z.strictObject({
-  path: PathFieldSchema,
-  action: z
-    .literal('subscribe')
-    .describe(
-      'Receive future status changes for /executions/{id} as <execution-activity> follow-ups; auto-disposes when the execution finishes or this stream is released.',
-    ),
-});
-
-const UnsubscribeActionSchema = z.strictObject({
-  path: PathFieldSchema,
-  action: z
-    .literal('unsubscribe')
-    .describe(
-      'Stop receiving <execution-activity> follow-ups for /executions/{id}.',
-    ),
-});
-
-const ExecutionsToolActionSchema = z.discriminatedUnion('action', [
-  ViewActionSchema,
-  WaitActionSchema,
-  KillActionSchema,
-  SubscribeActionSchema,
-  UnsubscribeActionSchema,
-]);
-
-// A structured-output provider represents an omitted optional field as an
-// explicit `action: null` rather than leaving the key absent (AGENTS.md's
-// tool-input-schema rule). z.discriminatedUnion reads the raw `action` value
-// to pick a branch before any field-level default runs, and `null` isn't one
-// of the branch literals, so strip it down to "key absent" here — the view
-// branch's own `.optional().default('view')` then takes over exactly as it
-// does for a truly omitted key. A genuinely absent key needs no help: Zod
-// already matches that against the one branch whose discriminator accepts
-// undefined.
-const ExecutionsToolInputSchema = z.preprocess((value) => {
-  if (
-    value &&
-    typeof value === 'object' &&
-    'action' in value &&
-    value.action === null
-  ) {
-    const { action: _null, ...rest } = value;
-    return rest;
-  }
-  return value;
-}, ExecutionsToolActionSchema);
-
-type ExecutionsToolInput = z.infer<typeof ExecutionsToolActionSchema>;
 
 export class ExecutionsTool extends defineTool({
   name: 'executions',

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -8,6 +8,7 @@ import { getGitignoreMatcher } from '@tools/gitignore';
 import { formatToolOutput } from '@tools/formatting';
 import { wrapApiCall } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
+import { nullishWithDefault } from '@tools/core/inputSchema';
 import { executed } from '@tools/core/result';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -42,16 +43,13 @@ async function listExtractedEntries(dirFsPath: string): Promise<string> {
 
 const ArxivDownloadInputSchema = z.strictObject({
   id: z.string().describe('arXiv identifier or URL for the source archive.'),
-  autoIndent: z
-    .boolean()
-    .nullish()
-    .transform((v) => v ?? true)
-    .describe('Auto-indent extracted TeX files after downloading source.'),
-  destination: z
-    .enum(['root', 'references'])
-    .nullish()
-    .transform((v) => v ?? ('references' as const))
-    .describe('Where to extract the source: workspace root or References/.'),
+  autoIndent: nullishWithDefault(z.boolean(), true).describe(
+    'Auto-indent extracted TeX files after downloading source.',
+  ),
+  destination: nullishWithDefault(
+    z.enum(['root', 'references']),
+    'references',
+  ).describe('Where to extract the source: workspace root or References/.'),
 });
 
 export type ArxivDownloadInput = z.infer<typeof ArxivDownloadInputSchema>;

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -13,15 +13,14 @@ import {
 import { ARXIV_CONSTANTS } from '@tools/citation/constants';
 import { rateLimitedApiCall } from '@tools/citation/rateLimiter';
 import { defineTool } from '@tools/core/define';
+import { nullishWithDefault } from '@tools/core/inputSchema';
 import { executed } from '@tools/core/result';
 
 const ArxivMetadataInputSchema = z.strictObject({
   id: z.string().describe('arXiv identifier or URL for the paper.'),
-  includeAbstract: z
-    .boolean()
-    .nullish()
-    .transform((v) => v ?? true)
-    .describe('Include the paper abstract in the metadata response.'),
+  includeAbstract: nullishWithDefault(z.boolean(), true).describe(
+    'Include the paper abstract in the metadata response.',
+  ),
   maxAuthors: z
     .int()
     .positive()

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -17,6 +17,7 @@ import { requireNonEmptyString } from '@tools/utils';
 import { ARXIV_CONSTANTS } from '@tools/citation/constants';
 import { rateLimitedApiCall } from '@tools/citation/rateLimiter';
 import { defineTool } from '@tools/core/define';
+import { nullishWithDefault } from '@tools/core/inputSchema';
 import {
   type ArxivSearchResult,
   createArxivClient,
@@ -35,28 +36,20 @@ const ArxivSearchInputSchema = z.strictObject({
   query: z
     .string()
     .describe('Search query terms, title text, or author names.'),
-  field: SearchFieldSchema.nullish()
-    .transform((v) => v ?? 'all')
-    .describe(
-      'Search field: "author" for author names, "title" for paper titles, "abstract" for abstracts, "all" (default) for all fields',
-    ),
+  field: nullishWithDefault(SearchFieldSchema, 'all').describe(
+    'Search field: "author" for author names, "title" for paper titles, "abstract" for abstracts, "all" (default) for all fields',
+  ),
   categories: z
     .array(z.string())
     .nullish()
     .describe('Optional arXiv category filters such as "math.NT" or "cs.AI".'),
-  maxResults: z
-    .int()
-    .positive()
-    .max(ARXIV_CONSTANTS.MAX_RESULTS)
-    .nullish()
-    .transform((v) => v ?? ARXIV_CONSTANTS.DEFAULT_RESULTS)
-    .describe('Maximum number of papers to return.'),
-  start: z
-    .int()
-    .min(0)
-    .nullish()
-    .transform((v) => v ?? 0)
-    .describe('Zero-based result offset for pagination.'),
+  maxResults: nullishWithDefault(
+    z.int().positive().max(ARXIV_CONSTANTS.MAX_RESULTS),
+    ARXIV_CONSTANTS.DEFAULT_RESULTS,
+  ).describe('Maximum number of papers to return.'),
+  start: nullishWithDefault(z.int().min(0), 0).describe(
+    'Zero-based result offset for pagination.',
+  ),
   sortBy: SortBySchema.nullish().describe('arXiv sort field to use.'),
   sortOrder: SortOrderSchema.nullish().describe('Sort direction for results.'),
 });

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -60,6 +60,7 @@ import { appendHead, appendTail } from '@utils/text/appendTail';
 
 // Local file imports
 import { defineTool } from './core/define';
+import { nullishWithDefault } from './core/inputSchema';
 import {
   childStreamDescription,
   createChildStream,
@@ -245,13 +246,9 @@ const BashInputSchema = z.strictObject({
     .describe(
       'Timeout in milliseconds (max 600,000 ms / 10 min, default 120,000 ms / 2 min).',
     ),
-  run_in_background: z
-    .boolean()
-    .nullish()
-    .transform((v) => v ?? false)
-    .describe(
-      'Run command in background. Returns immediately with execution ID and a background task tab. Result delivered as follow-up when complete.',
-    ),
+  run_in_background: nullishWithDefault(z.boolean(), false).describe(
+    'Run command in background. Returns immediately with execution ID and a background task tab. Result delivered as follow-up when complete.',
+  ),
 });
 
 type BashInput = z.infer<typeof BashInputSchema>;

--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -11,6 +11,7 @@ import { z } from 'zod';
 import { ToolError, type ToolResult } from '@shared/schemas';
 import { requireNonEmptyString } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
+import { nullishWithDefault } from '@tools/core/inputSchema';
 import { executed } from '@tools/core/result';
 import { pluralize } from '@utils/text/stringUtils';
 
@@ -20,13 +21,10 @@ import { rateLimitedApiCall } from './rateLimiter';
 
 const CROSSREF_SEARCH_FIELDS = {
   query: z.string().describe('Bibliographic search query for Crossref works.'),
-  rows: z
-    .int()
-    .positive()
-    .max(CROSSREF_CONSTANTS.MAX_ROWS)
-    .nullish()
-    .transform((v) => v ?? CROSSREF_CONSTANTS.DEFAULT_ROWS)
-    .describe('Maximum number of works to return.'),
+  rows: nullishWithDefault(
+    z.int().positive().max(CROSSREF_CONSTANTS.MAX_ROWS),
+    CROSSREF_CONSTANTS.DEFAULT_ROWS,
+  ).describe('Maximum number of works to return.'),
   offset: z
     .int()
     .min(0)

--- a/src/tools/core/inputSchema.ts
+++ b/src/tools/core/inputSchema.ts
@@ -1,0 +1,25 @@
+/**
+ * Field spellings shared by tool input schemas.
+ */
+
+// Third-party imports
+import type { z } from 'zod';
+
+/**
+ * An optional tool-input field whose absence resolves to `fallback` before
+ * `execute` ever sees it.
+ *
+ * The wrapping is `.nullish()`, deliberately not `.optional()` and not
+ * `.prefault()`. OpenAI-compatible providers (DeepSeek, Kimi, …) represent an
+ * omitted optional field as an explicit `null` in structured output, so the
+ * field must be nullable as well as optional; `.prefault()` substitutes only
+ * for `undefined` and would hand `null` straight through. The `?? fallback`
+ * covers both, which is why the resulting field's output type is not nullable
+ * and use sites need no `== null` check of their own.
+ */
+export function nullishWithDefault<Schema extends z.ZodType>(
+  schema: Schema,
+  fallback: z.output<Schema>,
+) {
+  return schema.nullish().transform((value) => value ?? fallback);
+}

--- a/src/tools/delegation/detachedChildRun.ts
+++ b/src/tools/delegation/detachedChildRun.ts
@@ -5,23 +5,73 @@
  * starts with the same lifecycle: hold the owned-execution lease launch guard
  * while starting the child run loop, and attach a completion error trace so a
  * late loop failure is diagnosed. Callers keep their own execution-id
- * derivation, registration, approval wiring, and result shaping; this module
- * owns only the guard-and-trace skeleton so its invariant (a throw inside the
- * guard releases the lease; a late loop failure is surfaced) lives in one
- * place.
+ * derivation, approval wiring, and result shaping; this module owns the
+ * guard-and-trace skeleton so its invariant (a throw inside the guard releases
+ * the lease; a late loop failure is surfaced) lives in one place, plus the
+ * native-agent registration that mints the child's stream id.
  */
 
 // Local imports
-import { runWithOwnedExecutionLeaseLaunchGuard } from '@agent/storage/executionLease';
+import {
+  runWithOwnedExecutionLeaseLaunchGuard,
+  type OwnedExecutionLeaseScope,
+} from '@agent/storage/executionLease';
+import { registerOwnedExecution } from '@agent/storage/executionLifecycle';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import {
   startChildRunLoop,
   type ChildRunLoopParams,
   type ChildRunStrategy,
 } from '@agent/runtime/childRunLoop';
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import { getStreamTabId } from '@agent/runtime/streamTab';
+import type {
+  ExecutionId,
+  StreamTabId,
+  UserFollowUpSupport,
+} from '@shared/schemas';
 
 // Local file imports
 import type { ChildStream } from './childStream';
+
+/**
+ * Register a native agent child and take its owned-execution lease, minting
+ * the one stream id the child is addressed by.
+ *
+ * That id must match the one `buildAgentLaunchContext` reserves for this
+ * executionId (AgentLaunchContext.ts's `reservedStreamId`), or the loop
+ * acquires the wrong follow-up queue/interrupt slot. The reservation derives
+ * from the canonical config's `agent` — never from `agentName`, which callers
+ * resolve differently (an approved override's display name vs. its registry
+ * name) and which reaches only the durable child row. Minting it here is what
+ * keeps the two in step: while each launch site derived its own, the
+ * invariant could only be stated as a comment asking the copies to agree.
+ */
+export async function registerChildExecution(input: {
+  readonly executionId: ExecutionId;
+  /** Canonical config, already parsed by the launch site. */
+  readonly config: AgentConfig;
+  readonly agentName: string;
+  readonly userFollowUpSupport: UserFollowUpSupport;
+  readonly parentExecutionId?: ExecutionId;
+}): Promise<{
+  readonly childStreamId: StreamTabId;
+  readonly runWithOwnership: OwnedExecutionLeaseScope;
+}> {
+  const { executionId, config } = input;
+  const childStreamId = getStreamTabId(config.agent, { executionId });
+  const runWithOwnership = await registerOwnedExecution(
+    executionId,
+    config,
+    input.agentName,
+    {
+      streamId: childStreamId,
+      identity: { kind: 'agent', agent: config.agent },
+      userFollowUpSupport: input.userFollowUpSupport,
+      parentExecutionId: input.parentExecutionId,
+    },
+  );
+  return { childStreamId, runWithOwnership };
+}
 
 /** The strategy + stream wiring a launch site supplies inside the guard. */
 interface DetachedChildRunLaunch<TTurn> {

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -14,7 +14,6 @@
 
 // Local imports
 import { getExecutionStore, type ResultMeta } from '@agent/storage';
-import { registerOwnedExecution } from '@agent/storage/executionLifecycle';
 import {
   ExecutionLeaseLostError,
   runWithInactiveExecutionLease,
@@ -25,12 +24,12 @@ import {
   type AgentConfigPayload,
 } from '@agent/core/definition/AgentConfig';
 import type { AgentFinalResult } from '@agent/runtime/AgentFinalResult';
-import { getStreamTabId } from '@agent/runtime/streamTab';
 import { createLog } from '@logger/logUtils';
 import {
   RUN_OUTCOME,
   USER_FOLLOW_UP_SUPPORT,
   type ExecutionId,
+  type StreamTabId,
   type SubagentProgressUpdate,
 } from '@shared/schemas';
 import { generateExecutionId, KeyedMutex } from '@utils/core';
@@ -39,6 +38,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local file imports
 import {
+  registerChildExecution,
   startDetachedChildRunLoop,
   type DetachedChildRunInput,
 } from './detachedChildRun';
@@ -376,22 +376,18 @@ async function executeInBand(
   const config = AgentConfigSchema.parse(options.configPayload);
   const startedAt = Date.now();
   const workingDirectory = config.workingDirectory ?? undefined;
-  const childStreamId = getStreamTabId(config.agent, { executionId });
   const store = getExecutionStore(executionId);
 
+  let childStreamId: StreamTabId;
   let runWithOwnership: OwnedExecutionLeaseScope;
   try {
-    runWithOwnership = await registerOwnedExecution(
+    ({ childStreamId, runWithOwnership } = await registerChildExecution({
       executionId,
       config,
-      options.agentName,
-      {
-        streamId: childStreamId,
-        identity: { kind: 'agent', agent: config.agent },
-        userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
-        parentExecutionId: options.parentExecutionId,
-      },
-    );
+      agentName: options.agentName,
+      userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
+      parentExecutionId: options.parentExecutionId,
+    }));
   } catch (cause) {
     if (mode === 'required-result') {
       throw new SubagentDurabilityError(

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -8,7 +8,6 @@
  */
 
 // Local imports
-import { registerOwnedExecution } from '@agent/storage/executionLifecycle';
 import {
   AgentConfigSchema,
   type AgentConfigPayload,
@@ -19,7 +18,6 @@ import {
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
-import { getStreamTabId } from '@agent/runtime/streamTab';
 import { createLog } from '@logger/logUtils';
 import {
   AgentCategory,
@@ -36,7 +34,10 @@ import { generateExecutionId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local file imports
-import { startDetachedChildRunLoop } from './detachedChildRun';
+import {
+  registerChildExecution,
+  startDetachedChildRunLoop,
+} from './detachedChildRun';
 import { executeSubagentForDeliveryInBand } from './inBandSubagentExecution';
 import { createNativeSubagentStrategy } from './nativeSubagentStrategy';
 
@@ -185,30 +186,16 @@ export async function executeSubagent(
   const executionId = generateExecutionId();
   const startedAt = Date.now();
   const config = AgentConfigSchema.parse(childConfigPayload);
-  // Must match the id `buildAgentLaunchContext` actually reserves for this
-  // executionId (see AgentLaunchContext.ts's `reservedStreamId`), or the
-  // loop acquires the wrong follow-up queue/interrupt slot. That reservation
-  // uses the canonical config's agent/model — not the `agentName` parameter,
-  // which callers may resolve differently
-  // (e.g. an approved agent override's display name vs. its registry name).
-  // Derive from the exact same fields, not a parallel formula.
-  const childStreamId = getStreamTabId(config.agent, {
-    executionId,
-  });
-  const runWithOwnership = await registerOwnedExecution(
+  const { childStreamId, runWithOwnership } = await registerChildExecution({
     executionId,
     config,
     agentName,
-    {
-      streamId: childStreamId,
-      identity: { kind: 'agent', agent: config.agent },
-      userFollowUpSupport:
-        config.agentCategory === AgentCategory.ToolUse
-          ? USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE
-          : USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
-      parentExecutionId,
-    },
-  );
+    userFollowUpSupport:
+      config.agentCategory === AgentCategory.ToolUse
+        ? USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE
+        : USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
+    parentExecutionId,
+  });
 
   return await runWithOwnership(async () => {
     const isToolUse = config.agentCategory === AgentCategory.ToolUse;

--- a/src/tools/executions/configView.ts
+++ b/src/tools/executions/configView.ts
@@ -1,0 +1,50 @@
+/**
+ * Serialization of a run's stored config for `/executions/{id}/config`.
+ */
+
+// Local imports
+import type { RunRecord } from '@agent/core/definition/RunRecord';
+
+/**
+ * Per-category config-field exclusions: `toolUse` hides the workflow-only
+ * file fields, `workflow` hides the toolUse-only `toolConfig`. Unknown
+ * categories get no filtering.
+ */
+const HIDDEN_CONFIG_FIELDS_BY_CATEGORY: Readonly<
+  Record<string, ReadonlySet<string>>
+> = {
+  toolUse: new Set([
+    'inputFile',
+    'inputFiles',
+    'contextFile',
+    'contextFiles',
+    'mediaFile',
+    'mediaFiles',
+    'outputFiles',
+    'editedFile',
+    'editedFiles',
+  ]),
+  workflow: new Set(['toolConfig']),
+};
+
+/**
+ * Serialize a run record to pretty JSON, dropping agent-config fields
+ * irrelevant to the resolved display category so the serialized config the
+ * orchestrator reads stays relevant. Records without an agent execution mode
+ * are honest by construction and serialize unchanged.
+ */
+export function serializeFilteredConfig(
+  record: RunRecord,
+  category: string | undefined,
+): string {
+  const excludeSet = category
+    ? HIDDEN_CONFIG_FIELDS_BY_CATEGORY[category]
+    : undefined;
+  if (!excludeSet) {
+    return JSON.stringify(record, null, 2);
+  }
+  const filtered = Object.fromEntries(
+    Object.entries(record).filter(([key]) => !excludeSet.has(key)),
+  );
+  return JSON.stringify(filtered, null, 2);
+}

--- a/src/tools/executions/pathCatalog.ts
+++ b/src/tools/executions/pathCatalog.ts
@@ -1,0 +1,63 @@
+/**
+ * Single source of truth for the virtual resource paths the executions tool
+ * serves. Both the tool `description` and its "Unknown path" error render from
+ * this list, so the two cannot drift.
+ */
+
+const EXECUTION_PATH_CATALOG: ReadonlyArray<{ path: string; summary: string }> =
+  [
+    {
+      path: '/executions',
+      summary: 'List executions (paginated; use offset/limit for pages)',
+    },
+    {
+      path: '/executions/{id}',
+      summary:
+        'Execution summary (agent, model, timestamp, status, children, todos)',
+    },
+    { path: '/executions/{id}/config', summary: 'Agent configuration JSON' },
+    {
+      path: '/executions/{id}/conversation',
+      summary: 'Full message history (subagents)',
+    },
+    {
+      path: '/executions/{id}/todos',
+      summary: 'Task list (tool-use subagents)',
+    },
+    {
+      path: '/executions/{id}/report',
+      summary: 'Result report (persists after context compaction)',
+    },
+    {
+      path: '/executions/{id}/result',
+      summary:
+        'Final result envelope (JSON) for chaining; process result for background commands',
+    },
+    {
+      path: '/executions/{id}/output',
+      summary:
+        'stdout/stderr of a background command, readable WHILE IT RUNS (report/result only exist once it finishes)',
+    },
+    { path: '/executions/{id}/children', summary: 'Child executions' },
+    {
+      path: '/executions/{id}/files',
+      summary: 'Generated files (workflows only)',
+    },
+    {
+      path: '/executions/{id}/files/{path}',
+      summary: 'Read specific generated file (workflows only)',
+    },
+    {
+      path: '/executions/{id}/workspace-files',
+      summary: 'Workspace files edited by tool-use runs',
+    },
+    {
+      path: '/executions/{id}/workspace-files/{path}',
+      summary: 'Read a workspace file edited by a tool-use run',
+    },
+  ];
+
+/** The catalog as a bulleted `- <path> - <summary>` list. */
+export const EXECUTION_PATH_LIST = EXECUTION_PATH_CATALOG.map(
+  ({ path: resourcePath, summary }) => `- ${resourcePath} - ${summary}`,
+).join('\n');

--- a/src/tools/executions/processOutput.ts
+++ b/src/tools/executions/processOutput.ts
@@ -1,0 +1,99 @@
+/**
+ * Projection of a background command's transcript rows into the display lines
+ * `/executions/{id}/output` serves, plus the window bounds that read applies.
+ */
+
+// Local imports
+import {
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  type StreamLogEntry,
+} from '@shared/schemas';
+import {
+  type BackgroundBashOutputSource,
+  getBackgroundBashOutputSource,
+} from '@shared/toolUse';
+
+/** Lines returned by /executions/{id}/output when no view_range is given. */
+export const OUTPUT_TAIL_LINES = 200;
+
+/** Hard ceiling on lines a single /output read returns, view_range included. */
+export const OUTPUT_MAX_LINES = 1_000;
+
+/** Marks a projected line that the command wrote to stderr. */
+const OUTPUT_STDERR_PREFIX = 'err: ';
+
+/**
+ * Line break in captured terminal output. A bare CR counts: progress bars
+ * (curl, pip, docker) redraw with `\r` and no newline, so splitting on LF
+ * alone would collapse a whole build's progress into one enormous "line" and
+ * hand the caller the entire log however small the requested window was.
+ */
+const OUTPUT_LINE_BREAK = /\r\n|\r|\n/;
+
+export interface ProcessOutputProjection {
+  readonly lines: readonly string[];
+  readonly chars: number;
+}
+
+/**
+ * Flatten a background command's transcript rows into display lines.
+ *
+ * Tagged stdout/stderr chunks stay in append order and concatenate only while
+ * their source remains compatible, so chunk-split lines are reconstructed
+ * without crossing a stream switch. Untagged lifecycle and legacy rows flush
+ * any pending command fragment and render standalone. Structured rows (usage,
+ * context state, tool frames) carry a non-default `messageType` and are
+ * dropped: this endpoint projects command output, not run bookkeeping.
+ */
+export function projectProcessOutput(
+  entries: readonly StreamLogEntry[],
+): ProcessOutputProjection {
+  const lines: string[] = [];
+  let chars = 0;
+  let pendingText = '';
+  let pendingSource: BackgroundBashOutputSource | undefined;
+
+  const emitText = (text: string, stderr: boolean): void => {
+    // A trailing break terminates the last line rather than opening an empty
+    // one; blank lines inside the text still survive the split.
+    const normalized = text.replace(/\r\n$|[\r\n]$/, '');
+    for (const line of normalized.split(OUTPUT_LINE_BREAK)) {
+      lines.push(stderr ? `${OUTPUT_STDERR_PREFIX}${line}` : line);
+    }
+  };
+  const flushPending = (): void => {
+    if (pendingText && pendingSource) {
+      emitText(pendingText, pendingSource === 'stderr');
+    }
+    pendingText = '';
+    pendingSource = undefined;
+  };
+
+  for (const entry of entries) {
+    if (entry.type !== STREAM_LOG_ENTRY_TYPES.LOG) continue;
+    if ((entry.messageType ?? MESSAGE_TYPES.DEFAULT) !== MESSAGE_TYPES.DEFAULT)
+      continue;
+    const text = entry.text;
+    if (!text) continue;
+
+    chars += text.length;
+    const source = getBackgroundBashOutputSource(entry.data);
+    if (!source) {
+      flushPending();
+      emitText(
+        text,
+        entry.level === LOG_LEVELS.WARN || entry.level === LOG_LEVELS.ERROR,
+      );
+      continue;
+    }
+
+    if (pendingSource && pendingSource !== source) flushPending();
+    pendingSource = source;
+    pendingText += text;
+  }
+  flushPending();
+
+  return { lines, chars };
+}

--- a/src/tools/executions/toolInput.ts
+++ b/src/tools/executions/toolInput.ts
@@ -1,0 +1,189 @@
+/**
+ * Input schema for the executions tool: one action per branch of a
+ * discriminated union, plus the provider-quirk normalization that keeps the
+ * union readable to structured-output providers.
+ */
+
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports
+import { ExecutionIdSchema } from '@shared/schemas';
+import {
+  EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
+  EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
+  EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
+} from '@shared/toolUse';
+import { clamp } from '@utils/core';
+
+// Local file imports
+import { ViewRangeSchema } from '../formatting';
+
+/** Virtual path: /executions, /executions/{id}, /executions/{id}/files, /executions/{id}/workspace-files/{path} */
+const PathFieldSchema = z.string().describe('Path starting with /executions');
+
+const ViewActionSchema = z.strictObject({
+  path: PathFieldSchema,
+  // Optional + defaulted, NOT .nullish() (unlike every other nullish field in
+  // this file): 'view' is the common no-op-preamble call, so omitting
+  // `action` must both dispatch to this branch and keep `action` out of the
+  // JSON-schema `required` list, matching the pre-refactor `.prefault('view')`
+  // and AGENTS.md's "design for the model's first call" rule.
+  // `.optional().default('view')` keeps the emitted per-branch JSON schema a
+  // clean single-value `const` (not an `anyOf` with `null`) — required so
+  // `convertToolSchema`'s `flattenTopLevelUnion`/`schemaLiteralValue` (which
+  // only recognizes a bare `const`/one-item `enum` as a discriminator
+  // literal) still merges all five actions into one enum for the
+  // OpenAI/Anthropic/Google-facing schema. `.nullish()` here produces an
+  // `anyOf` that flattening can't read as a literal, silently dropping
+  // wait/kill/subscribe/unsubscribe from the advertised schema instead.
+  // The explicit-`null` case AGENTS.md's rule calls out (a structured-output
+  // provider representing an omitted optional field as `null` rather than
+  // absent) is handled separately below by ExecutionsToolInputSchema's
+  // preprocess, which strips a `null` action down to omitted before this
+  // branch's own default runs — so the type stays a plain optional literal.
+  action: z
+    .literal('view')
+    .optional()
+    .default('view')
+    .describe('Read execution data (returns immediately). Default action.'),
+
+  /** Optional line range [start, end] for large outputs. */
+  view_range: ViewRangeSchema.nullish().describe(
+    'Line range [start, end] for paginating file and background-command output. Conversation pagination uses offset and limit.',
+  ),
+
+  /** Zero-based offset for list or conversation pagination. */
+  offset: z
+    .int()
+    .min(0)
+    .nullish()
+    .describe(
+      'Zero-based offset into the executions list or conversation messages. Use with limit on /executions or /executions/{id}/conversation. Default: 0.',
+    ),
+
+  /** Maximum list entries or conversation messages to return. */
+  limit: z
+    .int()
+    .min(1)
+    .max(200)
+    .nullish()
+    .describe(
+      'Max entries or conversation messages to return. Use on /executions or /executions/{id}/conversation. Default: 100, max: 200.',
+    ),
+});
+
+const WaitActionSchema = z.strictObject({
+  path: PathFieldSchema,
+  action: z
+    .literal('wait')
+    .describe(
+      'Wait for a status change on /executions or /executions/{id}, then return the same data as view (avoids sleep-poll loops).',
+    ),
+
+  /** Execution IDs to wait on (with /executions only; ignored on /executions/{id}). */
+  ids: z
+    .array(ExecutionIdSchema)
+    .min(1)
+    .max(50)
+    .nullish()
+    .describe(
+      'List of execution IDs to wait on (with /executions only). ' +
+        'Waits for any of the listed executions to change status. ' +
+        'If omitted, waits for any active execution.',
+    ),
+
+  /** Max seconds to wait. Default: 300. */
+  timeout: z
+    .number()
+    .finite()
+    .nullish()
+    // Clamp in the schema so input.timeout is always a ready-to-use number:
+    // an out-of-range or missing value becomes a value inside the wait window.
+    .transform((v) =>
+      clamp(
+        v ?? EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
+        EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
+        EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
+      ),
+    )
+    .describe(
+      `Max seconds to wait for a status change. Default: ${EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS}; finite values are clamped to the ${EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS}-${EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS} range.`,
+    ),
+
+  /** Zero-based offset for the /executions listing returned once the wait resolves. */
+  offset: z
+    .int()
+    .min(0)
+    .nullish()
+    .describe(
+      'Zero-based offset into the executions list returned once the wait resolves (with /executions only). Default: 0.',
+    ),
+
+  /** Maximum list entries in the /executions listing returned once the wait resolves. */
+  limit: z
+    .int()
+    .min(1)
+    .max(200)
+    .nullish()
+    .describe(
+      'Max entries in the executions list returned once the wait resolves (with /executions only). Default: 100, max: 200.',
+    ),
+});
+
+const KillActionSchema = z.strictObject({
+  path: PathFieldSchema,
+  action: z
+    .literal('kill')
+    .describe('Terminate a running execution by ID (use on /executions/{id}).'),
+});
+
+const SubscribeActionSchema = z.strictObject({
+  path: PathFieldSchema,
+  action: z
+    .literal('subscribe')
+    .describe(
+      'Receive future status changes for /executions/{id} as <execution-activity> follow-ups; auto-disposes when the execution finishes or this stream is released.',
+    ),
+});
+
+const UnsubscribeActionSchema = z.strictObject({
+  path: PathFieldSchema,
+  action: z
+    .literal('unsubscribe')
+    .describe(
+      'Stop receiving <execution-activity> follow-ups for /executions/{id}.',
+    ),
+});
+
+const ExecutionsToolActionSchema = z.discriminatedUnion('action', [
+  ViewActionSchema,
+  WaitActionSchema,
+  KillActionSchema,
+  SubscribeActionSchema,
+  UnsubscribeActionSchema,
+]);
+
+// A structured-output provider represents an omitted optional field as an
+// explicit `action: null` rather than leaving the key absent (AGENTS.md's
+// tool-input-schema rule). z.discriminatedUnion reads the raw `action` value
+// to pick a branch before any field-level default runs, and `null` isn't one
+// of the branch literals, so strip it down to "key absent" here — the view
+// branch's own `.optional().default('view')` then takes over exactly as it
+// does for a truly omitted key. A genuinely absent key needs no help: Zod
+// already matches that against the one branch whose discriminator accepts
+// undefined.
+export const ExecutionsToolInputSchema = z.preprocess((value) => {
+  if (
+    value &&
+    typeof value === 'object' &&
+    'action' in value &&
+    value.action === null
+  ) {
+    const { action: _null, ...rest } = value;
+    return rest;
+  }
+  return value;
+}, ExecutionsToolActionSchema);
+
+export type ExecutionsToolInput = z.infer<typeof ExecutionsToolActionSchema>;

--- a/src/tools/executions/turnAttribution.ts
+++ b/src/tools/executions/turnAttribution.ts
@@ -1,0 +1,36 @@
+/**
+ * Turn attribution for the executions tool's single latest-value slots.
+ */
+
+// Local imports
+import type { ExecutionKVStore } from '@agent/storage';
+
+/**
+ * One-line attribution note for /report and /result when a newer turn was
+ * accepted but never persisted a result (#9531): without it, the single
+ * latest-value slots would silently present the previous turn as current.
+ * Reads "still running" while the execution is live and "was interrupted"
+ * once it has terminalized. Returns null when the slots reflect the latest
+ * accepted turn (or the execution has no turn identity at all).
+ */
+export async function turnAttributionNote(
+  store: ExecutionKVStore,
+): Promise<string | null> {
+  const [turnState, meta] = await Promise.all([
+    store.readTurnState(),
+    store.readMeta(),
+  ]);
+  const active = turnState?.activeTurn;
+  const completed = turnState?.lastCompletedTurn?.token;
+  if (!active || active.token === completed) {
+    return null;
+  }
+  const fate =
+    meta?.outcome === undefined
+      ? `turn ${active.token} is still running`
+      : `turn ${active.token} was interrupted before producing a result`;
+  const showing = completed
+    ? `showing the latest completed turn (${completed}).`
+    : 'no turn has completed yet.';
+  return `[Note: ${fate}; ${showing}]`;
+}

--- a/src/tools/executions/workflowSummaryView.ts
+++ b/src/tools/executions/workflowSummaryView.ts
@@ -1,0 +1,158 @@
+/**
+ * Bounded projection of a workflow run's execution snapshot for the executions
+ * tool's `/executions/{id}` summary.
+ *
+ * A live workflow snapshot is unbounded in stages, calls, attempts, and file
+ * lists; this renders the slice worth a model's context — current stage first,
+ * then failed/cancelled outcomes — and reports what it omitted so the reader
+ * knows the view is truncated rather than complete.
+ */
+
+// Local imports
+import {
+  deriveWorkflowCounts,
+  stageTitleFor,
+  TERMINAL_WORKFLOW_CALL_STATUSES,
+  type WorkflowExecutionSnapshot,
+  WORKFLOW_CALL_STATUS,
+} from '@shared/schemas';
+
+const WORKFLOW_SUMMARY_MAX_ENTRIES = 8;
+const WORKFLOW_SUMMARY_MAX_ATTEMPTS = 2;
+const WORKFLOW_SUMMARY_MAX_FILES_PER_KIND = 3;
+const WORKFLOW_SUMMARY_TEXT_LENGTH = 160;
+
+function compactWorkflowText(value: string | undefined): string | undefined {
+  return value?.slice(0, WORKFLOW_SUMMARY_TEXT_LENGTH);
+}
+
+function workflowStageView(
+  stage: WorkflowExecutionSnapshot['stages'][number],
+): unknown {
+  return {
+    id: compactWorkflowText(stage.id),
+    title: compactWorkflowText(stage.title),
+    order: stage.order,
+    lifecycle: stage.lifecycle,
+    startedAt: stage.startedAt,
+    completedAt: stage.completedAt,
+  };
+}
+
+function workflowAttemptView(
+  attempt: WorkflowExecutionSnapshot['calls'][number]['attempts'][number],
+): unknown {
+  return {
+    number: attempt.number,
+    id: compactWorkflowText(attempt.id),
+    childStreamId: compactWorkflowText(attempt.childStreamId),
+    model: compactWorkflowText(attempt.model),
+    costUsd: attempt.costUsd,
+    startedAt: attempt.startedAt,
+    completedAt: attempt.completedAt,
+  };
+}
+
+function workflowCallFailurePriority(status: string): number {
+  // Within terminal calls, elevate failed/cancelled so the bounded projection
+  // keeps the outcomes that matter for debugging (matches stage ranking).
+  if (
+    status === WORKFLOW_CALL_STATUS.FAILED ||
+    status === WORKFLOW_CALL_STATUS.CANCELLED
+  ) {
+    return 0;
+  }
+  return 1;
+}
+
+export function workflowExecutionView(
+  snapshot: WorkflowExecutionSnapshot,
+): unknown {
+  const byPriority = snapshot.calls.toSorted(
+    (left, right) =>
+      Number(TERMINAL_WORKFLOW_CALL_STATUSES.has(left.status)) -
+        Number(TERMINAL_WORKFLOW_CALL_STATUSES.has(right.status)) ||
+      workflowCallFailurePriority(left.status) -
+        workflowCallFailurePriority(right.status) ||
+      Number(left.stageId !== snapshot.currentStageId) -
+        Number(right.stageId !== snapshot.currentStageId) ||
+      right.timestamps.updatedAt.localeCompare(left.timestamps.updatedAt),
+  );
+  const stages = snapshot.stages
+    .toSorted((left, right) => {
+      const priority = (stage: (typeof snapshot.stages)[number]): number => {
+        if (stage.id === snapshot.currentStageId) return 0;
+        if (stage.lifecycle === 'failed' || stage.lifecycle === 'cancelled') {
+          return 1;
+        }
+        return 2;
+      };
+      return priority(left) - priority(right) || right.order - left.order;
+    })
+    .slice(0, WORKFLOW_SUMMARY_MAX_ENTRIES)
+    .map(workflowStageView);
+  const calls = byPriority
+    .slice(0, WORKFLOW_SUMMARY_MAX_ENTRIES)
+    .map((call) => {
+      const compactFiles = (files: readonly string[]) => ({
+        sample: files
+          .slice(0, WORKFLOW_SUMMARY_MAX_FILES_PER_KIND)
+          .map((file) => compactWorkflowText(file)!),
+        ...(files.length > WORKFLOW_SUMMARY_MAX_FILES_PER_KIND && {
+          omitted: files.length - WORKFLOW_SUMMARY_MAX_FILES_PER_KIND,
+        }),
+      });
+      return {
+        id: compactWorkflowText(call.id),
+        label: compactWorkflowText(call.label),
+        stageId: compactWorkflowText(call.stageId),
+        stageTitle: compactWorkflowText(stageTitleFor(snapshot, call)),
+        agent: compactWorkflowText(call.agent),
+        model: compactWorkflowText(call.model),
+        files: {
+          input: compactFiles(call.files.input),
+          context: compactFiles(call.files.context),
+          media: compactFiles(call.files.media),
+        },
+        childExecutionId: compactWorkflowText(call.childExecutionId),
+        childStreamId: compactWorkflowText(call.childStreamId),
+        attempts: call.attempts
+          .slice(-WORKFLOW_SUMMARY_MAX_ATTEMPTS)
+          .map(workflowAttemptView),
+        ...(call.attempts.length > WORKFLOW_SUMMARY_MAX_ATTEMPTS && {
+          omittedAttempts: call.attempts.length - WORKFLOW_SUMMARY_MAX_ATTEMPTS,
+        }),
+        status: call.status,
+        blockedReason: compactWorkflowText(call.blockedReason),
+        error: compactWorkflowText(call.error),
+        costUsd: call.costUsd,
+        timestamps: call.timestamps,
+      };
+    });
+  const currentStage = snapshot.stages.find(
+    (stage) => stage.id === snapshot.currentStageId,
+  );
+  return {
+    aggregate: {
+      lifecycle: snapshot.lifecycle,
+      error: compactWorkflowText(snapshot.error),
+      counts: deriveWorkflowCounts(snapshot.calls),
+      timestamps: snapshot.timestamps,
+      responseBounds: {
+        maxStages: WORKFLOW_SUMMARY_MAX_ENTRIES,
+        maxCalls: WORKFLOW_SUMMARY_MAX_ENTRIES,
+        maxAttemptsPerCall: WORKFLOW_SUMMARY_MAX_ATTEMPTS,
+        maxFilesPerKind: WORKFLOW_SUMMARY_MAX_FILES_PER_KIND,
+      },
+    },
+    currentStage: currentStage ? workflowStageView(currentStage) : null,
+    stages,
+    calls,
+    ...(snapshot.stages.length > stages.length && {
+      omittedStages: snapshot.stages.length - stages.length,
+    }),
+    ...(snapshot.calls.length > calls.length && {
+      omittedCalls: snapshot.calls.length - calls.length,
+    }),
+  };
+}

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -15,6 +15,7 @@ import { splitOutputLines } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
+import { nullishWithDefault } from './core/inputSchema';
 
 const OUTPUT_MODES = ['content', 'files_with_matches', 'count'] as const;
 
@@ -27,13 +28,9 @@ const GrepInputSchema = z.strictObject({
     .string()
     .nullish()
     .describe('Glob filter for file names (e.g. "*.tex").'),
-  output_mode: z
-    .enum(OUTPUT_MODES)
-    .nullish()
-    .transform((v) => v ?? 'content')
-    .describe(
-      'Must be "content", "files_with_matches", or "count". For context lines around matches, use -C instead.',
-    ),
+  output_mode: nullishWithDefault(z.enum(OUTPUT_MODES), 'content').describe(
+    'Must be "content", "files_with_matches", or "count". For context lines around matches, use -C instead.',
+  ),
   '-B': z
     .int()
     .min(0)

--- a/src/tools/texcount/TexcountTool.ts
+++ b/src/tools/texcount/TexcountTool.ts
@@ -6,6 +6,7 @@ import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionCo
 import { getTeXCount } from '@latex/texcount';
 import { ToolError, type ToolResult } from '@shared/schemas';
 import { defineTool } from '@tools/core/define';
+import { nullishWithDefault } from '@tools/core/inputSchema';
 import { executed } from '@tools/core/result';
 import { ensureArray } from '@utils/core';
 import { formatResultCount } from '@utils/text/stringUtils';
@@ -14,11 +15,10 @@ const TexcountInputSchema = z.strictObject({
   files: z
     .union([z.string(), z.array(z.string()).min(1)])
     .describe('LaTeX file path or non-empty list of LaTeX files to count.'),
-  mode: z
-    .enum(['separate', 'include', 'sum'])
-    .nullish()
-    .transform((v) => v ?? 'separate')
-    .describe('How texcount should combine files: separate, include, or sum.'),
+  mode: nullishWithDefault(
+    z.enum(['separate', 'include', 'sum']),
+    'separate',
+  ).describe('How texcount should combine files: separate, include, or sum.'),
   format: z
     .enum(['raw', 'stats'])
     .nullish()

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -12,6 +12,7 @@ import {
   toFetchToolError,
 } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
+import { nullishWithDefault } from '@tools/core/inputSchema';
 import { executed } from '@tools/core/result';
 
 const DDG_TIMEOUT_MS = 15_000; // 15 s
@@ -21,13 +22,9 @@ const WebSearchInputSchema = z.strictObject({
   query: z
     .string()
     .describe('Search query to send to the web search provider.'),
-  max_results: z
-    .number()
-    .min(1)
-    .max(5)
-    .nullish()
-    .transform((v) => v ?? 3)
-    .describe('Maximum number of search results to return, up to 5.'),
+  max_results: nullishWithDefault(z.number().min(1).max(5), 3).describe(
+    'Maximum number of search results to return, up to 5.',
+  ),
 });
 
 export type WebSearchInput = z.infer<typeof WebSearchInputSchema>;


### PR DESCRIPTION
## Summary

Three related tool-layer cleanups. Behavior-preserving throughout; no new tests.

**(a) Split `src/tools/ExecutionsTool.ts`.** It was 1532 lines (3x the next-largest tool) mixing action dispatch, store reads, and five self-contained projections. The projections move verbatim into `src/tools/executions/*`, joining the `executionKvFiles.ts` / `runGeneratedFiles.ts` / `conversationFormat.ts` / `waitCoordination.ts` already there and following their shape:

| new module | what moved |
| --- | --- |
| `executions/pathCatalog.ts` | resource-path catalog + rendered list |
| `executions/toolInput.ts` | the five-branch Zod action union + `null`-action preprocess |
| `executions/workflowSummaryView.ts` | bounded workflow-snapshot projection |
| `executions/processOutput.ts` | background-command transcript projection + window bounds |
| `executions/configView.ts` | per-category config field filter |
| `executions/turnAttribution.ts` | `/report`+`/result` turn-attribution note |

Router: **1532 -> 978 lines**. No barrel added — the router imports each defining file (CLAUDE.md "No convenience barrels").

**(b) One owner for the child-execution stream-id formula.** Two delegation launch sites each re-derived the child's stream id and hand-assembled the same `registerOwnedExecution` options. The duplication was load-bearing enough to carry this warning in `subagentExecution.ts`, now deleted:

> ```
> // Must match the id `buildAgentLaunchContext` actually reserves for this
> // executionId (see AgentLaunchContext.ts's `reservedStreamId`), or the
> // loop acquires the wrong follow-up queue/interrupt slot. That reservation
> // uses the canonical config's agent/model — not the `agentName` parameter,
> // which callers may resolve differently
> // (e.g. an approved agent override's display name vs. its registry name).
> // Derive from the exact same fields, not a parallel formula.
> ```

A formula whose correctness condition is "please keep the copies identical" has no owner. `registerChildExecution` (in `delegation/detachedChildRun.ts`) now mints it once; the warning becomes a statement about a single call site rather than a request to two.

**(c) `.nullish()` default triplet.** `.nullish().transform((v) => v ?? DEFAULT)` appeared verbatim at 11 tool input fields across 8 files. `nullishWithDefault` (`src/tools/core/inputSchema.ts`) states once *why* the wrapping is `.nullish()`: `.prefault()` substitutes only for `undefined`, and OpenAI-compatible providers (DeepSeek, Kimi, ...) send an explicit `null` for an omitted optional field — a fact this repo had already learned the hard way in `LoogleTool.ts`. Verified the change is a no-op: emitted JSON Schema is byte-identical and parse results match for absent / `null` / `undefined` input across number, boolean, enum, and int cases.

## Issue acceptance gates

No issue. Maintainer-requested sweep.

## Single source of truth

- `delegation/detachedChildRun.ts` -> `registerChildExecution` owns the native child's stream-id derivation and registration options.
- `tools/core/inputSchema.ts` -> `nullishWithDefault` owns the "optional tool-input field with a default" spelling and the `.nullish()`-not-`.prefault()` reason.
- `executions/pathCatalog.ts` / `toolInput.ts` / `workflowSummaryView.ts` / `processOutput.ts` / `configView.ts` / `turnAttribution.ts` each own one projection previously interleaved in the router.

## Duplication and abstraction budget

Removed: 2 copies of the child stream-id formula + registration options block; 11 copies of the nullish-default triplet. Two names added, each deleting >= 2 hand-rolled equivalents (§5b); no name was added for a single caller.

Two abstractions the maintainer proposed were **refuted** rather than built:

1. **The search-tool result envelope.** Described as copy-pasted across arxiv/crossref/zotero. It is actually 2 sites, not 3: `ZoteroSearchTool` returns joined display lines, never a JSON payload, and uses `formatResultCount` rather than `pluralize`. The two real sites (`ArxivSearchTool`, `CrossrefSearchTool`) share 5 lines but diverge in payload keys (arxiv adds `field`/`start`; crossref has neither) and summary (arxiv appends a field label). Folding them needs a parameter bag wider than the code it replaces — a net-add for 2 callers, which is the extract-shared-abstraction trap. Left alone.
2. **A third delegation ceremony.** `WorkflowScriptTool` was named as the third copy. It is not the same ceremony: no `AgentConfigSchema.parse` (it registers a *fabricated* container record built from `meta.name`/`runModel`), a `multiAgentWorkflow` identity rather than `agent`, a stream id from `getChildStreamId(runExecutionId, STREAM_PREFIX)` rather than `getStreamTabId`, and an `ExecutionLeaseActiveError` branch with a bespoke "already running" result. It keeps its own registration.

Also corrected from the brief: the triplet is 11 occurrences, not ~12. The 12th match is `ExecutionsTool`'s `timeout` field, which is `clamp(v ?? DEFAULT, MIN, MAX)` — a different transform, left as-is.

## Net elements (R6)

Files: 19 changed, **+762 / -677 = +85 net LoC**; 6 new files under `src/tools/executions/`, 1 under `src/tools/core/`, 0 deleted. Exported symbols: **+12 / -0** — all are module-local symbols that became cross-module exports as a consequence of the split, each with a same-PR consumer (`check:dead-code-ratchet` green, 8 findings vs 8 baselined). Classes/interfaces/enums: +0 classes, +1 interface (`ProcessOutputProjection`, moved), -1 interface (`ChildExecutionRegistration` inlined into the signature rather than exported).

Per item:

| item | net LoC | note |
| --- | --- | --- |
| (a) split | **+41** | `ExecutionsTool.ts` -554; six new modules +595 (module doc headers + import blocks) |
| (b) stream-id owner | **+33** | `detachedChildRun.ts` +50; call sites -17 |
| (c) nullish default | **+4** | helper +25; 8 tool files -21 |

Honest shape: this is a **relocation**, not a shrink. The win in (a) is a 978-line router instead of a 1532-line one and six independently testable projections; the win in (b) is deleting a documented footgun; the win in (c) is one documented home for a rule the codebase repeats 11 times without explanation. LoC is the wrong scoreboard for all three and I am not claiming it.

## Consumer counts (R8)

No emit path or public export was deleted or re-routed. `registerOwnedExecution` keeps all 3 call sites (2 now via `registerChildExecution`, 1 in `WorkflowScriptTool`) — `SubagentExecutionChildStreamId.vitest.ts`, `DelegationHeadless.vitest.ts`, and `WorkflowScriptTool.vitest.ts` all mock it at that boundary and still pass unchanged. Every symbol moved out of `ExecutionsTool.ts` had exactly its previous in-file callers and no external ones (grepped: no test or host imports any of them).

## Host impact

Extension: none (behavior-preserving).

Desktop: none.

CLI: none.

## Scheduled refactoring

None. `ExecutionsTool.ts` remains 978 lines; the residue is action dispatch plus per-endpoint store reads, which is what the router should be. Further shrinking would mean moving `showSummary`'s store choreography, which is dispatch, not formatting.

## Validation

- `npm run typecheck` — clean
- `FORCE_COLOR=0 npx vitest run src/test-kernel/tools src/test-kernel/agent src/test-kernel/architecture` — 3996 passed, 1 failed: `subsystemEdgeRatchet` hit its 10s `testTimeout` under 40-worker parallel load. Re-run in isolation: **3 passed**. No new subsystem edge — expected, since every move is within `src/tools/`.
- `npm run format:check` — clean
- `npx eslint <19 changed files>` — clean
- `npm run check:dead-code-ratchet` — 8 current vs 8 baselined, no new findings, baseline untouched
- Zod parity harness: JSON Schema byte-identical and parse-equal for absent/`null`/`undefined` across all four `nullishWithDefault` shapes used

🤖 Generated with [Claude Code](https://claude.com/claude-code)
