### PR TITLE
docs(progressView): state the webview's lifecycle-row rule where it is enforced

### DIFF
--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
@@ -120,9 +120,10 @@ export function formatErrorTemplate(row: ErrorRow): FormatResult {
 }
 
 /**
- * Format a plain log line as TemplateResult. Phase headings share the shape:
- * on this host they only reach the transcript when a stream keeps its
- * lifecycle inline rather than in the task-group surface.
+ * Format a plain log line as TemplateResult. `PhaseRow` shares the shape and is
+ * in the union to keep the row dispatch exhaustive; this host routes every
+ * phase heading to its task-group surface (see `logSlice`), so that arm is
+ * unreachable here today.
  */
 export function formatDefaultLogMessageTemplate(
   row: LogRow | PhaseRow,

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -57,10 +57,7 @@ function syncRow(
   entry: StreamLogEntry,
   executionLabels: ExecutionLabels,
 ): Pick<EntryResult, 'logChanged' | 'updatedIndices'> {
-  const row = projectTranscriptRow(entry, {
-    executionLabels,
-    projectLifecycleToTaskGroups: true,
-  });
+  const row = projectTranscriptRow(entry, { executionLabels });
   const existingIndex = streamLogs.rowIndex.get(entry.id);
 
   if (!row) {
@@ -158,8 +155,12 @@ function applyEntry(
     stateChanged = true;
   }
 
-  // Run/round/phase headings are this host's task-group surface, not
-  // transcript rows.
+  // Every non-`LOG` entry stops here: run/round/session lifecycle *and* phase
+  // headings are this host's task-group surface, which `upsertTaskGroupFromStreamLog`
+  // above has already fed. That is a stronger rule than the projector's
+  // `projectLifecycleToTaskGroups`, which the CLI needs because it keeps phase
+  // rows inline — so this host never reaches row projection for them and never
+  // passes that flag.
   if (entry.type !== STREAM_LOG_ENTRY_TYPES.LOG) {
     return { ...compactionResult, stateChanged };
   }


### PR DESCRIPTION
## Summary

Follow-up to #10948 (transcript row model). Two comments in the progress view
described the row-membership rule inaccurately, and one call site passed a
field that cannot be read. Comments and one unread field only.

## Issue acceptance gates

n/a — self-review finding from #10948, caught after that PR merged.

## Single source of truth

Unchanged, and that is the point: `projectTranscriptRow` in
`@shared/transcript` owns which entries become rows. This PR makes the two
progress-view comments say what the code enforces instead of contradicting it.

- `logSlice.applyEntry` stops **every** non-`LOG` entry before row projection —
  run/round/session lifecycle *and* phase headings, all of which
  `upsertTaskGroupFromStreamLog` has already fed into this host's task-group
  surface. The old comment ("Run/round/phase headings are this host's
  task-group surface, not transcript rows") read as if the projector decided.
- That gate is strictly stronger than the projector's
  `projectLifecycleToTaskGroups`, which exists because the **CLI** keeps phase
  rows inline. So `syncRow` passing `projectLifecycleToTaskGroups: true` was
  dead: the early return guarantees the projector never sees those entries on
  this host. Removed.
- `formatDefaultLogMessageTemplate` claimed phase headings "only reach the
  transcript when a stream keeps its lifecycle inline". No stream does on this
  host. `PhaseRow` stays in the parameter union to keep the row dispatch
  exhaustive; the comment now says so.

## Duplication and abstraction budget

Removes one duplicated statement of the rule (a dead argument restating what
the guard above it already enforces). No abstraction added.

## Net elements (R6)

Files 2 changed, 0 added, 0 deleted. +11 / −9 lines, net +2 — three comment
lines gained, one object field and its two braces lost. Exported symbols: 0
added, 0 removed. Classes/interfaces/enums: 0 added, 0 removed.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed. The one removed field is
an argument at a single call site
(`packages/extension/src/progressView/frontend/slices/logSlice.ts`, 1
occurrence), and the parameter it fed is `readonly` + optional on
`TranscriptRowContext`, whose only remaining passer is the CLI
(`packages/cli/src/chat/tui/state/transcriptFold.ts`, 1 occurrence).

## Host impact

Extension: none — the removed argument was unreachable; every rendered row is
byte-identical.

Desktop: none — shares the progress-view frontend, same reasoning.

CLI: none — untouched.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — 0 errors.
- `FORCE_COLOR=0 npx vitest run src/test-kernel/progressView` — 61 files, 570
  passed, 0 failed.
- `npm run format:check` — clean.
- `npx eslint` on both changed files — clean.

No test added: this is a comment change plus the removal of an argument that no
code path reads, so there is no behavior for a test to pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
