### PR TITLE
fix(cli): render the model handler's context window, not a registry guess

### DIFF
--- a/config/ratchets/host-agent-import-baseline.json
+++ b/config/ratchets/host-agent-import-baseline.json
@@ -10,7 +10,6 @@
       "@agent/followUp",
       "@agent/index",
       "@agent/index/platformAgentDirectories",
-      "@agent/modelHandlers/support/contextUtilization",
       "@agent/runtime",
       "@agent/storage",
       "@agent/trace"

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -242,6 +242,11 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
       ? subscriptionQuotaRead.snapshot
       : undefined;
 
+  // Shared execution record for the displayed stream: stage and the model
+  // handler's context-occupancy snapshot both come from it.
+  const displayStreamState =
+    displayStreamId === undefined ? undefined : streamStateFor(displayStreamId);
+
   const runStartedAt = isActivePhase(statusSlice?.status)
     ? statusSlice?.runStartedAt
     : undefined;
@@ -270,15 +275,12 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     queuedFollowUpMessages:
       displayStreamId === undefined ? [] : queuedFollowUpsFor(displayStreamId),
     usage: statusSlice?.usage,
-    stage:
-      displayStreamId === undefined
-        ? undefined
-        : streamStateFor(displayStreamId)?.stage,
+    contextState: displayStreamState?.contextState,
+    stage: displayStreamState?.stage,
     subagents: subagentCount,
     runningSessions: props.runningSessions ?? 0,
     approvalDepth: approvals.depth,
     approvalKind: approvals.kind,
-    model: accessModel,
     modelAccess,
     subscriptionQuota,
     transcriptMode: sessionMeta.transcriptMode,

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -1,6 +1,3 @@
-import { MODEL_CONFIGS } from 'llm-zoo';
-
-import { roundedUtilizationPercent } from '@agent/modelHandlers/support/contextUtilization';
 import {
   shortCliModelAccessRoute,
   type CliModelAccessRoute,
@@ -17,14 +14,13 @@ import { COLOR_ERROR, COLOR_HINT, COLOR_WARNING } from '@cli/tui/ui/colors';
 import { STATUS_DIAMOND } from '@cli/tui/ui/glyphs';
 import { KEY_HINT_SEPARATOR, keyHintText } from '@cli/tui/ui/KeyHints';
 import { STATUS_BAR_HORIZONTAL_PADDING } from '@cli/tui/ui/theme';
-import { getRuntimeModelConfig } from '@model/runtimeModelRegistry';
-import { resolveCodexSubscriptionProfile } from '@model/providerCapabilities';
 import type { TexraApprovalPolicy } from '@shared/approvalPolicy';
 import {
   codingPlanForUsageRoute,
   CODING_PLAN_SUBSCRIPTIONS,
 } from '@shared/codingPlanSubscriptions';
 import {
+  type ContextStateData,
   type SubscriptionUsageSnapshot,
   type SubscriptionUsageProvider,
   type StreamPhase,
@@ -122,7 +118,12 @@ export interface StatusBarDisplayInput {
   readonly thinkingActive?: boolean;
   readonly compactingActive?: boolean;
   readonly queuedFollowUpMessages: readonly string[];
+  /** Latest usage snapshot — read for `usageRoute` (which subscription quota
+   *  to show), never for context occupancy: that is `contextState`. */
   readonly usage: TokenUsageStats | undefined;
+  /** Model-handler-authoritative context occupancy for the displayed stream
+   *  (`StreamExecutionState.contextState`). */
+  readonly contextState: ContextStateData | undefined;
   readonly stage: StreamStage | undefined;
   /** Retained and active direct subagents owned by the displayed stream. */
   readonly subagents: number;
@@ -130,7 +131,6 @@ export interface StatusBarDisplayInput {
   readonly runningSessions: number;
   readonly approvalDepth: number;
   readonly approvalKind?: ApprovalQueueStatusKind;
-  readonly model: string;
   readonly modelAccess: CliModelAccessRoute;
   /** Latest quota snapshot for the subscription serving this model. */
   readonly subscriptionQuota?: SubscriptionUsageSnapshot;
@@ -200,27 +200,6 @@ interface StatusBarDisplay {
   readonly bindings: string;
 }
 
-// ChatGPT/Codex-subscription turns run under a smaller enforced context
-// window than the model's raw API contextWindow (see providerCapabilities.ts).
-// `usage.usageRoute` is stamped by the handler that produced this specific
-// snapshot, so it's ground truth for *this* usage regardless of what the CLI
-// is currently configured to use — and resolveCodexSubscriptionProfile() only
-// ever stamps 'chatgpt-subscription' when useOpenRouter was false for that
-// turn, so passing `false` here isn't an assumption, it's already implied.
-function effectiveContextWindow(
-  usage: TokenUsageStats,
-  model: string,
-): number | undefined {
-  if (usage.usageRoute === 'chatgpt-subscription') {
-    const config = getRuntimeModelConfig(model);
-    return config
-      ? resolveCodexSubscriptionProfile({ model: config, useOpenRouter: false })
-          ?.contextWindow
-      : undefined;
-  }
-  return MODEL_CONFIGS[model]?.contextWindow;
-}
-
 function accessModeSegment(access: CliModelAccessRoute): StatusBarSegment {
   const label = shortCliModelAccessRoute(access);
   return label === 'subscription'
@@ -257,30 +236,29 @@ function subscriptionQuotaSegment(
   };
 }
 
+// The gauge renders `StreamExecutionState.contextState` — the model handler's
+// own reading of the window it served the last response under, which is the
+// only value that stays right across subscription caps and compaction. The
+// `usage` fallback covers the pre-first-response window, where the handler has
+// reported no occupancy yet: show the input-token count bare rather than
+// substituting a registry window the run may never have used.
 function formatUsage(
+  contextState: ContextStateData | undefined,
   usage: TokenUsageStats | undefined,
-  model: string,
 ): StatusBarSegment | undefined {
-  if (!usage) return undefined;
-  // Context-window occupancy is input tokens only — the prompt that fills the
-  // window. Output tokens are the generated response, not part of the context,
-  // so they must not inflate the gauge. This matches every other surface
-  // (ModelHandler utilizationPercent, trace, transcript recorder, the extension
-  // UsagePanel), which all compute inputTokens / contextWindow.
-  const used = usage.inputTokens;
-  if (used <= 0) return undefined;
-
   const base = { compactPriority: STATUS_BAR_COMPACT_PRIORITY.usage };
-  const contextWindow = effectiveContextWindow(usage, model);
-  if (!contextWindow || contextWindow <= 0) {
-    return { ...base, text: formatCompactTokenCount(used), color: 'dim' };
+  if (!contextState) {
+    const reported = usage?.inputTokens ?? 0;
+    if (reported <= 0) return undefined;
+    return { ...base, text: formatCompactTokenCount(reported), color: 'dim' };
   }
 
+  // Occupancy is input tokens only — the prompt that fills the window. Output
+  // tokens are the generated response, not part of the context, which is why
+  // the handler reports `inputTokens` here.
+  const { inputTokens: used, contextWindow, utilizationPercent } = contextState;
   const ratio = used / contextWindow;
-  const percent = Math.max(
-    1,
-    roundedUtilizationPercent(used, contextWindow, 0),
-  );
+  const percent = Math.max(1, Math.round(utilizationPercent));
   let color: StatusBarColor;
   if (ratio >= 0.9) color = COLOR_ERROR;
   else if (ratio >= 0.6) color = COLOR_WARNING;
@@ -1072,7 +1050,7 @@ export function buildStatusBarDisplay(
       approvalPolicySegment(input.approvalPolicy),
       locationSegment(input.location),
       stageSegment(input.stage),
-      formatUsage(input.usage, input.model),
+      formatUsage(input.contextState, input.usage),
       queuedFollowUpsCountSegment(input.queuedFollowUpMessages),
       subagentsSegment(input.subagents),
       runningSessionsSegment(input.runningSessions),

--- a/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
+++ b/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
@@ -96,9 +96,11 @@ class TuiSessionRenderer implements SessionRendererPort {
         return markArtifactStreamHydrated(streamId);
       case 'parentStreamId':
       case 'queuedFollowUps':
-        // The applier already landed the edge / the session-owned queue on
-        // `SessionState`; the CLI's topology snapshot and `queuedFollowUpsFor`
-        // re-derive from there at paint.
+      case 'contextState':
+        // The applier already landed the edge / the session-owned queue /
+        // the model handler's context snapshot on `SessionState`; the CLI's
+        // topology snapshot, `queuedFollowUpsFor`, and the status bar's
+        // `streamStateFor` read re-derive from there at paint.
         return invalidateChildStreams();
       case 'goalPaused':
         return appendLocalAssistantTranscript(

--- a/packages/cli/src/runtime/sessionProgressSubscription.ts
+++ b/packages/cli/src/runtime/sessionProgressSubscription.ts
@@ -100,8 +100,8 @@ function projectCliSessionFact(
 
 /**
  * Project run facts onto the frozen NDJSON progress-event vocabulary.
- * `run.start` is intentionally unprojected: the public wire shape carries no
- * run-start record.
+ * `run.start` and `context.state` are intentionally unprojected: the public
+ * wire shape carries neither a run-start nor a context-occupancy record.
  */
 function projectCliRunFact(
   streamId: StreamTabId,
@@ -112,6 +112,10 @@ function projectCliRunFact(
       return undefined;
     case 'usage':
       return { event: 'updateStreamUsage', payload: event.payload };
+    case 'context.state':
+      // The frozen public wire carries no context-state record; occupancy is
+      // an interactive-surface gauge, not a scriptable progress event.
+      return undefined;
     case 'run.config':
       return {
         event: 'setTaskState',

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -405,6 +405,7 @@ export const RUN_FACT_EVENT_TYPES = Object.freeze([
   'run.start',
   'run.config',
   'usage',
+  'context.state',
   'stage.start',
   'child.activity',
 ] as const satisfies readonly AgentEvent['type'][]);

--- a/src/controllers/progressView/backend/LitSessionRenderer.ts
+++ b/src/controllers/progressView/backend/LitSessionRenderer.ts
@@ -183,6 +183,12 @@ export class LitSessionRenderer implements SessionRendererPort {
         // Parent edge rides `StreamTabInfo.parentStreamId` on the metadata wire.
         if (!this.isAvailable()) return;
         return this.updateStreamMetadata(streamId);
+      case 'contextState':
+        // Lit's usage footer restores the same snapshot from the transcript
+        // rail's `contextState` log entry (`logSlice`), which — unlike this
+        // session-scoped record — also repopulates a stream reopened from
+        // disk. Nothing to push here.
+        return;
       case 'goalPaused':
         // Lit surfaces pause via the goal chip (`goalStateChanged`); no
         // transcript notice, unlike the TUI.

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -1,5 +1,6 @@
 import type { DeleteStreamResult } from '@agent/storage';
 import { RUN_FACT_EVENT_TYPES, type AgentEvent } from '@agent/trace';
+import { roundedUtilizationPercent } from '@agent/modelHandlers/support/contextUtilization';
 import type { SessionFact } from '@agent/runtime/SessionEventHub';
 import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
 import type { SessionRendererPort } from '@controllers/session/SessionRendererPort';
@@ -170,6 +171,24 @@ export class SessionFactApplier {
       // accumulate per-key; hosts read cumulative totals from the store.
       const { streamId, storageKey, usage } = event.payload;
       this.renderer.onRunUsageChanged(streamId, storageKey, usage);
+    },
+    'context.state': (streamId, event) => {
+      // The handler that produced the response is the only authority on the
+      // window it actually used (subscription caps and compaction both move
+      // it), so the substrate stores its number verbatim and every host reads
+      // this one record instead of re-deriving from a model registry.
+      this.state.updateStreamState(streamId, (prev) => ({
+        ...prev,
+        contextState: {
+          inputTokens: event.inputTokens,
+          contextWindow: event.contextWindow,
+          utilizationPercent: roundedUtilizationPercent(
+            event.inputTokens,
+            event.contextWindow,
+          ),
+        },
+      }));
+      this.renderer.invalidate(streamId, 'contextState');
     },
     'run.start': (_streamId, event) => this.handleRunConfig(event.streamId),
     'run.config': (_streamId, event) => this.handleRunConfig(event.streamId),

--- a/src/controllers/session/SessionRendererPort.ts
+++ b/src/controllers/session/SessionRendererPort.ts
@@ -20,7 +20,8 @@ export type PresentedStreamId = StreamTabId | '';
  * A projection slice whose new value the host re-reads from the shared state
  * rather than receiving on the wire. Each key names the field the host reads
  * (`outputs.files`, `outputs.compileFailures`, `workPlan.queuedFollowUps`,
- * `SessionStreamMetadata.parentStreamId`) or the fact it reacts to
+ * `SessionStreamMetadata.parentStreamId`,
+ * `StreamExecutionState.contextState`) or the fact it reacts to
  * (`goalPaused`); nothing here is new vocabulary. Slices whose notification
  * carries real delta semantics — `onMissingOutputsChanged`'s `reset`,
  * `onStageChanged`'s phase-vs-round split — keep their own method.
@@ -30,6 +31,7 @@ export type SessionRenderSlice =
   | 'compileFailures'
   | 'queuedFollowUps'
   | 'parentStreamId'
+  | 'contextState'
   | 'goalPaused';
 
 /**

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -13,6 +13,7 @@ import { createSessionStores } from '@controllers/session/sessionStores';
 import { createLog } from '@logger/logUtils';
 import {
   type ActiveChildInfo,
+  type ContextStateData,
   type ConversationProgress,
   type StreamStage,
   type StreamIdentityFields,
@@ -75,6 +76,15 @@ export interface StreamExecutionState {
   category: (typeof AgentCategory)[keyof typeof AgentCategory];
   conversationProgress: ConversationProgress;
   stage?: StreamStage;
+  /**
+   * Latest context-window occupancy reported by the model handler that served
+   * this stream's last response — the only authority on the window actually
+   * used, which a static model-registry lookup cannot reproduce for
+   * subscription-capped or compacted turns. Absent until a response reports
+   * input tokens against a known window; carried across runs on the same
+   * stream, like the latest usage gauge it sits beside.
+   */
+  contextState?: ContextStateData;
   /** Live children plus the finished ones retained for display (`finishedAt`
    *  set). */
   subagents: ActiveChildInfo[];

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -50,11 +50,11 @@ function statusInput(
     bypass: NO_BYPASS,
     queuedFollowUpMessages: [],
     usage: undefined,
+    contextState: undefined,
     stage: undefined,
     subagents: 0,
     runningSessions: 0,
     approvalDepth: 0,
-    model: 'deepseekT',
     modelAccess: 'personal',
     ...rest,
     foreground: { ...foreground },
@@ -477,7 +477,6 @@ describe('CLI StatusBar display model', () => {
   it('advertises root agent selection while setup can still change it', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        model: 'gpt54',
         width: 80,
         shortcuts: { agentSelectionAvailable: true },
       }),
@@ -491,7 +490,6 @@ describe('CLI StatusBar display model', () => {
   it('does not let setup bindings hide full output when it fits', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        model: 'gpt54',
         width: 100,
         shortcuts: { agentSelectionAvailable: true, transcriptAvailable: true },
       }),
@@ -534,7 +532,6 @@ describe('CLI StatusBar display model', () => {
   it('keeps root agent selection visible when setup bindings get narrow', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        model: 'gpt54',
         width: 50,
         shortcuts: { agentSelectionAvailable: true },
       }),
@@ -641,7 +638,11 @@ describe('CLI StatusBar display model', () => {
           'Keep the proof under one page.',
           'Also mention the finite monoid argument.',
         ],
-        usage: { inputTokens: 80_000, outputTokens: 25_000, cost: 0 },
+        contextState: {
+          inputTokens: 80_000,
+          contextWindow: 1_000_000,
+          utilizationPercent: 8,
+        },
         stage: { kind: 'round', index: 1 },
         subagents: 2,
         approvalDepth: 3,
@@ -712,51 +713,29 @@ describe('CLI StatusBar display model', () => {
     expect(leftTexts(display).some((text) => text.includes('/'))).toBe(false);
   });
 
-  it.each(['relay', 'api-key'] as const)(
-    'shows the raw registry context window for %s usage',
-    (usageRoute) => {
-      const display = buildStatusBarDisplay(
-        statusInput({
-          status: STREAM_PHASE.RUNNING,
-          model: 'gpt56',
-          usage: heavyUsage(usageRoute),
-        }),
-      );
-      expect(leftTexts(display)).toContain('187k/1.1M (18%)');
-    },
-  );
-
-  it('caps the context window to the subscription budget for chatgpt-subscription usage', () => {
+  it('reports the window the model handler served, not a registry lookup', () => {
+    // gpt-5.6's raw registry window is 1.05M, but a Codex-subscription turn
+    // runs under a 400k budget — and a compacted turn under something else
+    // again. The handler stamps what it used; the bar renders that verbatim.
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        model: 'gpt56',
         usage: heavyUsage('chatgpt-subscription'),
-      }),
-    );
-
-    // gpt-5.6's Codex subscription budget caps to 400k (272k input plus its
-    // 128k output allowance), not the raw 1.05M API window.
-    expect(leftTexts(display)).toContain('187k/400k (47%)');
-  });
-
-  it('uses the default 400k subscription budget for earlier Codex models', () => {
-    const display = buildStatusBarDisplay(
-      statusInput({
-        status: STREAM_PHASE.RUNNING,
-        model: 'gpt55',
-        usage: heavyUsage('chatgpt-subscription'),
+        contextState: {
+          inputTokens: 187_000,
+          contextWindow: 400_000,
+          utilizationPercent: 46.8,
+        },
       }),
     );
 
     expect(leftTexts(display)).toContain('187k/400k (47%)');
   });
 
-  it('does not substitute a raw context window for unknown subscription models', () => {
+  it('shows a bare token count until the handler reports a window', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        model: 'unknown-subscription-model',
         usage: heavyUsage('chatgpt-subscription'),
       }),
     );
@@ -1623,7 +1602,11 @@ describe('CLI StatusBar display model', () => {
   it('compacts token usage to a percentage before dropping it on narrow widths', () => {
     const input = statusInput({
       status: STREAM_PHASE.RUNNING,
-      usage: { inputTokens: 80_000, outputTokens: 25_000, cost: 0 },
+      contextState: {
+        inputTokens: 80_000,
+        contextWindow: 1_000_000,
+        utilizationPercent: 8,
+      },
     });
 
     // Wide: the full usage segment fits.


### PR DESCRIPTION
## Summary

**This is a correctness fix, not a refactor.** The CLI status bar's context
gauge did not read the context window — it *reconstructed* one
(`statusBarDisplay.ts:210-222`) from two proxies: a model **id** and a
`usage.usageRoute` tag, fed through `MODEL_CONFIGS` /
`resolveCodexSubscriptionProfile`. The model handler is the only authority on
the window it actually served the turn under
(`ModelHandler.getEffectiveContextWindow()`, overridden in
`ModelHandlerOpenAIResponse` by `getActiveProviderCapabilities()?.contextWindow`),
and it already publishes it: `logger.contextState({ inputTokens, contextWindow:
modelHandler.getEffectiveContextWindow() })` (`CommonCycleTypes.ts:167`) → the
`context.state` `AgentEvent` → the transcript recorder → the extension's
UsagePanel. `packages/cli` had **zero** references to it.

Where the reconstruction is wrong, verified at HEAD:

1. **Wrong model.** `formatUsage(input.usage, input.model)` divided the
   *displayed stream's* usage by the window of `accessModel`, which falls back
   to the **root session's** model whenever the displayed stream's config has
   not resolved yet (`StatusBar.tsx:112-115`). A subagent running a different
   model than the root — the normal case — was gauged against the wrong window
   until its metadata landed.
2. **Missing route tag.** `usageRoute` is optional on `TokenUsageStats`
   (`extractModelResponse` sets it only when the usage or the handler supplies
   one). A ChatGPT-subscription turn whose snapshot carries no route tag fell
   through to the raw registry window — 1.05M for gpt-5.6 instead of the 400k
   budget the handler enforced, so the bar read ~18% where the handler was at
   ~47%.
3. **Hand-maintained parity.** The handler's override is general
   (`getActiveProviderCapabilities()?.contextWindow`); the CLI hard-coded only
   the one Codex branch, so any capability profile that narrows the window in
   future diverges silently and nothing fails.

This promotes the handler's own snapshot onto the shared substrate so the
terminal renders the same fact the extension and desktop already render, and
deletes the reconstruction.

**Refuted while verifying:** the doc's "wrong on subscription *and compaction*
routes" — the compaction half does not reproduce. Compaction moves token
counts, not `getEffectiveContextWindow()`, and both surfaces read the
post-compaction `inputTokens` from the same normalized usage. The subscription
half is real but narrower than stated: the Codex case *with* a stamped route
tag was reproduced correctly by the CLI (that is what the four deleted tests
pinned); the live defects are the three above.

Source: `2026-08-15-single-substrate-hosts-as-renderers.md` §4 (the
`contextState` promotion row) and §3 (`statusBarDisplay.ts` context gauge —
"a correctness fix wearing a refactor");
`2026-08-15-cross-host-consolidation.md` §4(c).

### The rail (R4 compliance — no new mechanism)

`context.state` is **already** an `AgentEvent` arm. It was simply absent from
`RUN_FACT_EVENT_TYPES`, the frozen tuple every host's `subscribeRunFacts`
filter admits. This PR adds that one string, so the event flows down the
existing run-fact rail into the existing `SessionFactApplier`, which lands it
on `StreamExecutionState.contextState` and notifies hosts through the existing
`SessionRendererPort.invalidate(streamId, slice)` — the port's documented
"payload-free change; the host re-reads the field from shared state" verb, the
same shape `parentStreamId` and `queuedFollowUps` already use.

No new bus. No new subscribe surface. No new `SessionFact` arm. No new IPC
literal. `SessionFact` was the wrong home: this is per-run execution state,
which is exactly what `StreamExecutionState` is for and what the run-fact rail
already carries — `usage`, `stage.start`, and `conversation.progress` are its
neighbours in the same dispatch table.

### One refutation, stated because the docs predict otherwise

`2026-08-15-shared-contracts-and-retirement.md` §7.4 revival row 2 says
`contextState` should "become backend-written", i.e. move off the webview's
log fold (`logSlice.ts:141-146`) onto the metadata wire. **Not done, and it
should not be:** the log fold is how the webview repopulates a stream reopened
from disk, and how `packages/trace-viewer` renders an archived trace at all
(`replayTrace.ts:213` dispatches `LOG_DELTA` with the trace's entries — there
is no live `SessionState` in that process). `StreamExecutionState` is
session-ephemeral, so making it the webview's only source would silently drop
the context footer for every completed run reopened after an extension-host
restart and for every replayed trace. That trades one correctness bug for
another, and it is the kind of transcript-rail/fact-rail merge the
2026-08-03 §0.1 item 8 ruling keeps separate on purpose.

The invariant that matters holds without it: **one authority** (the model
handler), **one emission** (`context.state`), and two transports of that same
number — the transcript rail for durable replay, the fact rail for live
session state. What this PR deletes is the only place that computed a
*different* number.

Citations re-verified at HEAD and corrected: `streamState.ts:159` is the
progress-view frontend `BaseStreamStateSchema`, **not** `StreamExecutionState`
as §4 states — the real promotion target was `SessionState.ts:74`. The
recorder's `CONTEXT_STATE` emission is `TexraTranscriptRecorder.ts:650-665`,
not `:506`. There are also two distinct `ContextStateData` types — the trace
SDK's `{inputTokens, contextWindow}` (`events.ts:49`) and the schema's
`{…, utilizationPercent}` (`contextManagement.ts:61`) — which is why the
applier rounds at the same boundary the recorder does, through the same
`roundedUtilizationPercent` helper.

## Issue acceptance gates

No issue; this executes the §4 `contextState` promotion row and the §3
`statusBarDisplay.ts` context-gauge row under the maintainer's 2026-08-15
directive ("TUI should render the same state extension/desktop have").

- [x] `contextState` promoted to `StreamExecutionState`, written by the shared
      applier from an existing rail.
- [x] CLI re-derivation deleted; the CLI is the fact's first-ever reader.
- [x] No new vocabulary or mechanism (R4).
- [x] `host-agent-import-baseline` pruned in the same commit — the CLI's last
      `@agent/modelHandlers/*` deep import goes away, and a stale entry would
      fail the ratchet as unused headroom.

## Single source of truth

`ModelHandler.getEffectiveContextWindow()` is the authority; the
`context.state` `AgentEvent` is its single emission.
`StreamExecutionState.contextState` (`src/controllers/session/SessionState.ts`)
is the single session-scoped record of it, written only by
`SessionFactApplier`'s `context.state` handler. `roundedUtilizationPercent`
remains the single rounding rule — the applier and the transcript recorder both
call it, and the CLI now consumes the rounded value instead of re-rounding raw
inputs.

## Duplication and abstraction budget

Removed: `effectiveContextWindow()` in `statusBarDisplay.ts` — a second
derivation of the context window (static registry lookup plus Codex
subscription-profile resolution) that could and did disagree with the handler.
With it go four imports (`llm-zoo`'s `MODEL_CONFIGS`,
`@agent/modelHandlers/support/contextUtilization`,
`@model/runtimeModelRegistry`, `@model/providerCapabilities`) and the
now-unreferenced `StatusBarDisplayInput.model` field.

Added: no new module, class, factory, or indirection. One optional field on an
existing interface, one arm in an existing dispatch table, one member of an
existing string union, and one-line arms in the three existing
`SessionRendererPort` implementations.

## Net elements (R6)

- **Files:** 0 added, 0 deleted, 10 modified (9 production + 1 test).
- **Exported symbols:** **+0 / −0.** `git show <sha> | grep -E '^[+-]export'`
  is empty — every change sits inside an already-exported declaration.
- **Classes/interfaces/enums:** **+0 / −0.** One module-private function
  deleted (`effectiveContextWindow`); one union member added
  (`SessionRenderSlice.'contextState'`); one optional interface field added
  (`StreamExecutionState.contextState`); one interface field deleted
  (`StatusBarDisplayInput.model`).
- **Net LoC, production:** +80 / −56 = **+24.** The gauge itself is **−22**
  (`statusBarDisplay.ts`: +23 / −45); the promotion costs +46 across the
  substrate and the three ports. Roughly two thirds of the added lines are the
  comments the rail choice needs; declaration-only the add is ≈ +14. This is
  the §7.4 revival ledger's expected shape — a promotion is a net-add offset by
  the host copy it deletes — and here it buys a wrong number becoming a right
  one.
- **Net LoC, tests:** +20 / −39 = **−19.** Four obsolete re-derivation blocks
  deleted (`it.each(['relay','api-key'])`, the two Codex-budget cases, and the
  unknown-model case), replaced by one regression pin for the corrected gauge
  and the preserved no-window fallback.
- **Ratchet:** `config/ratchets/host-agent-import-baseline.json` shrinks by one
  CLI entry.

## Consumer counts (R8)

- **`RUN_FACT_EVENT_TYPES` gains `'context.state'`** — 4 `subscribeRunFacts`
  filter sites consume the tuple: `ProgressBackend.ts:913`,
  `sessionSignalsAdapter.ts:305`, `runProgressRenderer.ts:190`,
  `sessionProgressSubscription.ts:215`. Two exhaustive switches over the
  vocabulary needed a new arm and got one: `SessionFactApplier.runFactHandlers`
  (the promotion) and `projectCliRunFact` (returns `undefined` — the frozen
  public NDJSON wire gains **no** new event, matching the existing `run.start`
  arm). The other two sites forward straight to the applier and needed no edit.
- **`SessionRenderSlice` gains `'contextState'`** — 3 implementers, all
  updated: `LitSessionRenderer` (no-op plus the reason), `TuiSessionRenderer`
  (joins the existing `invalidateChildStreams()` group), `HeadlessPort`
  (already a blanket no-op `invalidate`).
- **`effectiveContextWindow`** — 1 consumer (`formatUsage`, same module).
  Module-private, never exported; both are now gone/rewritten.
- **`StatusBarDisplayInput.model`** — 2 consumers before (`formatUsage` and the
  `StatusBar.tsx` producer) plus the test fixture; **0** after. Deleted.
- **`@agent/modelHandlers/support/contextUtilization` from `packages/cli`** —
  1 → 0 (`grep -rn '@agent/modelHandlers' packages/cli/src` returns 0), so the
  baseline entry is pruned in the same commit.
- **`roundedUtilizationPercent`** — 12 call sites before, 12 after (the CLI
  drops one, `SessionFactApplier` adds one). No other caller changes.
- **`getRuntimeModelConfig` / `resolveCodexSubscriptionProfile`** — 39 combined
  references remain repo-wide after the CLI drops its two; both exports keep
  their consumers, matching the retirement doc's "shared model symbols keep"
  note for this row.
- **`logSlice.ts` `CONTEXT_STATE` branch / `UsagePanel`** — untouched;
  subscriber count unchanged. See the refutation above.

## Host impact

**Extension:** No user-visible change. The UsagePanel keeps reading
`streamState.contextState` from the log fold — the same number, from the same
emission. The only backend change is a `case 'contextState': return;` arm in
`LitSessionRenderer.invalidate` documenting why nothing is pushed.

**Desktop:** Same as the extension — both drive `LitSessionRenderer` through
`ProgressBackend`. No user-visible change.

**CLI:** The context gauge now shows the window the handler served the turn
under, so it is right for a subagent whose config has not resolved yet, for a
snapshot with no `usageRoute` tag, and for any future capability profile that
narrows the window. Before the first response reports occupancy the bar shows
the bare input-token count — unchanged behaviour, previously reached via the
"unknown model" path, and the reason the `usage` argument survives. Headless
NDJSON output is unchanged: the frozen wire gains no context-state record.

## Scheduled refactoring

None. `thinkingActive` — §4's remaining CLI-only promotion row — genuinely has
no fact-rail writer today and stays out of scope, as §7.4 row 1 flags.

## Validation

- `npm run typecheck` — green across workspace, test-kernel, agent, cli,
  trace-viewer, desktop.
- `FORCE_COLOR=0 npx vitest run src/test-kernel/cli src/test-kernel/controllers
  src/test-kernel/progressView` — 240 files / 3452 tests. Three
  `TranscriptSessionPolicy.vitest.ts` cases and one `subsystemEdgeRatchet` case
  hit the 10 s default timeout under machine load; both files pass with
  `--testTimeout=120000` and neither touches this diff.
- `FORCE_COLOR=0 npx vitest run src/test-kernel/architecture` — green, i.e. the
  host-agent deep-import ratchet accepts the pruned baseline.
- `npm run format:check` — green.
- `NODE_OPTIONS=--max-old-space-size=8192 npx eslint <changed files>` — clean.
- `npm run check:dead-code-ratchet` — 8 findings vs 8 baselined; no new.
- `node packages/cli/scripts/validate-tui.mjs` — run on both sides of the same
  merge-base (`e00b9317f7`), full 164-scenario suite. Baseline (detached at the
  merge-base, before any edit): **142 pass / 22 fail**. Branch: **136 pass /
  28 fail**. Set-diff of the failure names: **6 apparent new, 0 fixed** —
  `approval-form`, `approval-policy-status-bar`, `single-run-liveness`,
  `tools-form`, `uninterruptible-running-status-bar`, `workflow-script-toggle`.
  Five of the six report `input prompt never rendered (boot timeout)` and the
  sixth (`workflow-script-toggle`) shows the toggle keystroke not landing right
  after `tools-form` timed out — all six are contention artefacts: a second
  worktree was running its own `validate-tui` suite concurrently. **Re-run in
  isolation on this branch: all 6 pass** (`--no-build approval-form
  approval-policy-status-bar single-run-liveness tools-form
  uninterruptible-running-status-bar workflow-script-toggle` →
  "all 6 scenario(s) passed"). So the owned delta is **zero**, and the 22
  baseline failures (model-form family, focused-stopped-subagent family,
  composer-hidden pair, escape family) are pre-existing.

  No expectation frame needed updating, which is itself checkable: the harness
  never emits a `context.state` event and never sets `usage` on the displayed
  root stream, so the context gauge does not appear in any scenario frame. Its
  only `usage` fixture drives the SubagentList row's `↓40k` column, which this
  diff does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
