### PR TITLE
refactor: retire leftover auth/shim/id-spelling shims (#10922, #10913, #10870, #10868)

### DIFF
--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -243,8 +243,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
       agentItems: buildCliAgentItems(toolUseAgents),
       teamItems: buildCliTeamItems(presetPlanSet.plans, {
         includeLoginHint: !presetPlanSet.remoteCatalogRefreshAttempted,
-        remoteAgentCatalogAvailable:
-          await SupabaseClient.canAccessRemoteAgentCatalog(),
+        remoteAgentCatalogAvailable: await SupabaseClient.isAuthenticated(),
         launchBlockReason: presetLaunchBlockReason,
       }),
       accountItems: buildCliAccountItems(accountStatus),
@@ -284,8 +283,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
           ]),
           remoteCatalogRefreshAttempted:
             presetPlanSet.remoteCatalogRefreshAttempted,
-          canAccessRemoteCatalog: () =>
-            SupabaseClient.canAccessRemoteAgentCatalog(),
+          canAccessRemoteCatalog: () => SupabaseClient.isAuthenticated(),
           choose: async (names) => {
             writeTextStderr(
               `Team ${action.preset} has unavailable TeXRA-hosted members: ${names.join(', ')}.`,
@@ -308,7 +306,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
             );
             return (
               code === CliExitCode.Success &&
-              (await SupabaseClient.canAccessRemoteAgentCatalog())
+              (await SupabaseClient.isAuthenticated())
             );
           },
           refresh: async () =>

--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -180,10 +180,7 @@ export async function resolveCliAgent(
     return lookupCliAgent(name, lookupCategory);
   }
 
-  if (
-    name.includes(':') ||
-    !(await SupabaseClient.canAccessRemoteAgentCatalog())
-  ) {
+  if (name.includes(':') || !(await SupabaseClient.isAuthenticated())) {
     return agent;
   }
 

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -375,7 +375,7 @@ export async function initCliPlatform(
     host: 'cli',
     signIn: async () => {
       await signInCliSupabase({ openBrowser: true });
-      return SupabaseClient.canAccessRemoteAgentCatalog();
+      return SupabaseClient.isAuthenticated();
     },
   });
 

--- a/packages/cli/src/runtime/multiAgentRunPlan.ts
+++ b/packages/cli/src/runtime/multiAgentRunPlan.ts
@@ -109,7 +109,7 @@ async function reloadRemoteAgentsForGaps<T>(
   readonly remoteCatalogRefreshAttempted: boolean;
 }> {
   return refreshRemoteCatalogForGaps(value, hasGaps, replan, {
-    canAccessRemoteCatalog: () => SupabaseClient.canAccessRemoteAgentCatalog(),
+    canAccessRemoteCatalog: () => SupabaseClient.isAuthenticated(),
     refreshRemote: () => refresh({ includeRemote: true }),
   });
 }

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -859,8 +859,6 @@ export class DesktopProgressBridge {
         showInfo: (message) => this.options.host.showInfoMessage(message),
       },
       session: this.session,
-      getRunConfig: (stream) =>
-        this.state.snapshots.getRunMetadata(stream).config,
       restoreRunConfig: async (config) => {
         const restored = this.restoreRunConfig(config);
         if (!restored) {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -499,7 +499,7 @@ function createWindow(options: {
     try {
       return (
         (await desktopAuth.signInAndWaitForSession(provider)) &&
-        (await SupabaseClient.canAccessRemoteAgentCatalog())
+        (await SupabaseClient.isAuthenticated())
       );
     } finally {
       teamSignInPending = false;
@@ -734,7 +734,7 @@ function createWindow(options: {
         chooseTeamAvailability(unavailableNames, presetName),
     },
     remoteCatalog: {
-      canAccess: () => SupabaseClient.canAccessRemoteAgentCatalog(),
+      canAccess: () => SupabaseClient.isAuthenticated(),
       signIn: signInForRemoteAgentCatalog,
     },
     notifications: { showInfoMessage, showErrorMessage },

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -202,8 +202,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       followUpPolish: this.followUpPolishController,
       host: { showInfo: this.showInfo },
       session: defaultSession(),
-      getRunConfig: (stream) =>
-        this.provider.state.snapshots.getRunMetadata(stream).config,
       restoreRunConfig: async (config) => {
         await this.runViewCommand('texra.restoreState', [config]);
       },

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -315,8 +315,7 @@ export class AgentHandlers {
           applyTeamRosterWithPreflight(data.presetId, {
             catalog: this.catalogController,
             loadLocalCatalog: () => loadAgents({ includeRemote: false }),
-            canAccessRemoteCatalog: () =>
-              SupabaseClient.canAccessRemoteAgentCatalog(),
+            canAccessRemoteCatalog: () => SupabaseClient.isAuthenticated(),
             choose: async (preset, unavailableNames) => {
               const choice = await vscode.window.showInformationMessage(
                 `The "${preset.name}" team includes TeXRA-hosted members that are unavailable: ${unavailableNames.join(', ')}.`,

--- a/scripts/capture-walkthrough-media.mjs
+++ b/scripts/capture-walkthrough-media.mjs
@@ -448,7 +448,7 @@ function progressMessages() {
       permission: {
         kind: 'proposal',
         data: {
-          proposalId: 'proposal-polish-intro',
+          requestId: 'proposal-polish-intro',
           streamId: stream,
           agent: 'polish',
           model: 'gemini31p',

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -286,14 +286,6 @@ export class SupabaseClient {
   }
 
   /**
-   * Whether PostgREST-backed remote agent definitions can be queried.
-   * Requires a normal GoTrue session access token.
-   */
-  static async canAccessRemoteAgentCatalog(): Promise<boolean> {
-    return (await this.getAccessToken()) !== null;
-  }
-
-  /**
    * Health of the stored GoTrue session. This is the canonical
    * classification for account UI and commands.
    */

--- a/src/controllers/mainView/teamCatalogPorts.ts
+++ b/src/controllers/mainView/teamCatalogPorts.ts
@@ -24,7 +24,7 @@ export function createTeamCatalogPorts(): {
     ),
     ensureCatalogLoaded: loadAgents,
     getAgents: getAgentsByCategory,
-    canAccessRemoteCatalog: () => SupabaseClient.canAccessRemoteAgentCatalog(),
+    canAccessRemoteCatalog: () => SupabaseClient.isAuthenticated(),
     refreshRemote: () => refresh({ includeRemote: true }),
   };
 }

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -370,8 +370,6 @@ export interface ProgressViewSecondTierActions {
   readonly session: SessionHandle;
   /** Look up one coherent run record for operations that need several facts. */
   readonly getRunMetadata: (stream: StreamTabId) => RunMetadata;
-  /** Single-field lookup used only by follow-up polishing. */
-  readonly getRunConfig: (stream: StreamTabId) => AgentConfig | undefined;
   /**
    * Warm a webview-selected stream before the synchronous metadata and
    * artifact readers above run. Production hosts always provide it.
@@ -548,7 +546,7 @@ export function createProgressViewSecondTierHandlers(
     // ── Follow-up polish ──
     [CMD.POLISH_FOLLOW_UP]: async (data) => {
       await deps.preload?.(data.stream);
-      const config = deps.getRunConfig(data.stream);
+      const config = deps.getRunMetadata(data.stream).config;
       if (!config) return;
       try {
         deps.onPolishProgress?.('Sending to AI for polishing...');

--- a/src/test-kernel/cli/AgentResolution.vitest.ts
+++ b/src/test-kernel/cli/AgentResolution.vitest.ts
@@ -12,10 +12,6 @@ import {
 import { AgentCategory } from '@shared/schemas';
 
 const isAuthenticatedSpy = vi.spyOn(SupabaseClient, 'isAuthenticated');
-const canAccessRemoteAgentCatalogSpy = vi.spyOn(
-  SupabaseClient,
-  'canAccessRemoteAgentCatalog',
-);
 
 function agent(
   name: string,
@@ -38,7 +34,6 @@ describe('CLI agent resolution', () => {
   beforeEach(() => {
     for (const mock of Object.values(agentCatalogMock)) mock.mockReset();
     isAuthenticatedSpy.mockReset().mockResolvedValue(false);
-    canAccessRemoteAgentCatalogSpy.mockReset().mockResolvedValue(false);
   });
 
   it('loads the local registry and returns a local agent for signed-out users', async () => {
@@ -51,7 +46,7 @@ describe('CLI agent resolution', () => {
     expect(agentCatalogMock.loadAgents).toHaveBeenCalledWith({
       includeRemote: false,
     });
-    expect(canAccessRemoteAgentCatalogSpy).toHaveBeenCalledOnce();
+    expect(isAuthenticatedSpy).toHaveBeenCalledOnce();
   });
 
   it('does a full registry load when the local registry misses', async () => {
@@ -66,13 +61,13 @@ describe('CLI agent resolution', () => {
       includeRemote: false,
     });
     expect(agentCatalogMock.loadAgents).toHaveBeenNthCalledWith(2);
-    expect(canAccessRemoteAgentCatalogSpy).not.toHaveBeenCalled();
+    expect(isAuthenticatedSpy).not.toHaveBeenCalled();
   });
 
   it('uses launch target category for authenticated remote-priority reloads', async () => {
     const local = agent('lean');
     const remote = agent('lean', 'remote');
-    canAccessRemoteAgentCatalogSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockResolvedValue(true);
     agentCatalogMock.resolveAgentForLaunch
       .mockReturnValueOnce(resolution(local))
       .mockReturnValueOnce(resolution(remote));
@@ -99,7 +94,7 @@ describe('CLI agent resolution', () => {
 
   it('does not apply remote priority to source-qualified agent names', async () => {
     const local = agent('local:lean');
-    canAccessRemoteAgentCatalogSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockResolvedValue(true);
     agentCatalogMock.getAgent.mockReturnValue(local);
 
     await expect(resolveCliAgent('local:lean')).resolves.toBe(local);
@@ -108,7 +103,7 @@ describe('CLI agent resolution', () => {
     expect(agentCatalogMock.loadAgents).toHaveBeenCalledWith({
       includeRemote: false,
     });
-    expect(canAccessRemoteAgentCatalogSpy).not.toHaveBeenCalled();
+    expect(isAuthenticatedSpy).not.toHaveBeenCalled();
   });
 
   it('uses launch target category for local and remote-fallback lookups', async () => {
@@ -150,7 +145,7 @@ describe('CLI agent resolution', () => {
       'builtInToolUse:review',
       'builtInToolUse',
     );
-    expect(canAccessRemoteAgentCatalogSpy).not.toHaveBeenCalled();
+    expect(isAuthenticatedSpy).not.toHaveBeenCalled();
   });
 
   it('reports launch-specific missing-agent messages', async () => {

--- a/src/test-kernel/cli/CliInitPlatform.vitest.ts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.ts
@@ -178,12 +178,8 @@ vi.mock('@tools/lean/direct/directLspAdapter', () => ({
   registerDirectLeanLanguageServices: vi.fn(),
 }));
 
-// Installed so startup never reaches a real auth check; no test reads it.
-vi.spyOn(SupabaseClient, 'isAuthenticated');
-const canAccessRemoteAgentCatalogSpy = vi.spyOn(
-  SupabaseClient,
-  'canAccessRemoteAgentCatalog',
-);
+// Installed so startup never reaches a real auth check.
+const isAuthenticatedSpy = vi.spyOn(SupabaseClient, 'isAuthenticated');
 
 function cliContext(
   overrides: Partial<Parameters<typeof initCliPlatform>[0]> = {},
@@ -241,7 +237,7 @@ describe('CLI platform init', () => {
     mocks.tryPlatform.mockReset();
     mocks.tryPlatform.mockReturnValue({ globalState: stubGlobalState() });
     mocks.bootstrapNodeAgentDirectories.mockResolvedValue(undefined);
-    canAccessRemoteAgentCatalogSpy.mockResolvedValue(false);
+    isAuthenticatedSpy.mockResolvedValue(false);
   });
 
   it('uses the configured storage root for CLI secrets', async () => {
@@ -495,7 +491,7 @@ describe('CLI platform init', () => {
   });
 
   it('wires setup sign-in to the existing CLI login implementation', async () => {
-    canAccessRemoteAgentCatalogSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockResolvedValue(true);
     mocks.signInCliSupabase.mockResolvedValue({ account: { label: 'User' } });
 
     await initCliPlatform(cliContext());

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
@@ -88,10 +88,6 @@ vi.mock('@cli/runtime/workflowInputs', () => ({
 }));
 
 const isAuthenticatedSpy = vi.spyOn(SupabaseClient, 'isAuthenticated');
-const canAccessRemoteAgentCatalogSpy = vi.spyOn(
-  SupabaseClient,
-  'canAccessRemoteAgentCatalog',
-);
 
 const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
 const { loadCliMultiAgentPresetPlanSet, loadCliMultiAgentRunPlan } =
@@ -251,7 +247,6 @@ describe('CLI multi-agent run command', () => {
     );
     mocks.planTeamRun.mockReturnValue(teamPlan());
     isAuthenticatedSpy.mockResolvedValue(false);
-    canAccessRemoteAgentCatalogSpy.mockResolvedValue(false);
     mocks.executeCliToolUseConfig.mockResolvedValue({
       ok: true,
       result: {
@@ -342,7 +337,7 @@ describe('CLI multi-agent run command', () => {
 
   it('marks run-plan resolution when authenticated gaps triggered a remote load', async () => {
     mocks.teamPlanHasGaps.mockReturnValueOnce(true);
-    canAccessRemoteAgentCatalogSpy.mockResolvedValueOnce(true);
+    isAuthenticatedSpy.mockResolvedValueOnce(true);
 
     const result = await loadCliMultiAgentRunPlan({
       preset: 'mathematician',
@@ -363,7 +358,7 @@ describe('CLI multi-agent run command', () => {
 
   it('marks preset-list resolution when authenticated gaps triggered a remote load', async () => {
     mocks.teamPlanHasGaps.mockReturnValueOnce(true);
-    canAccessRemoteAgentCatalogSpy.mockResolvedValueOnce(true);
+    isAuthenticatedSpy.mockResolvedValueOnce(true);
 
     const result = await loadCliMultiAgentPresetPlanSet([
       {
@@ -393,7 +388,7 @@ describe('CLI multi-agent run command', () => {
     const remoteLoadMessage =
       'Preset mathematician loaded remote agents before launch. Run `texra multi-agent show mathematician` to view the resolved team.';
     mocks.teamPlanHasGaps.mockReturnValueOnce(true).mockReturnValueOnce(false);
-    canAccessRemoteAgentCatalogSpy.mockResolvedValueOnce(true);
+    isAuthenticatedSpy.mockResolvedValueOnce(true);
 
     const exitCode = await runPreset({
       inputFiles: ['problem.tex'],

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -141,7 +141,6 @@ function createSecondTierActions(
     getRunMetadata: vi.fn(() => ({
       identity: { kind: 'agent' as const, agent: 'chat' },
     })),
-    getRunConfig: vi.fn(),
     restoreRunConfig: vi.fn(),
     applyFollowUpPlan: vi.fn(),
     applyPolishResult: vi.fn(),
@@ -1022,7 +1021,7 @@ describe('createProgressViewSecondTierHandlers', () => {
 
   it('skips polishing when the stream has no run config', async () => {
     const actions = createSecondTierActions({
-      getRunConfig: vi.fn().mockReturnValue(undefined),
+      getRunMetadata: vi.fn().mockReturnValue({}),
     });
     const handlers = createProgressViewSecondTierHandlers(actions);
 
@@ -1040,7 +1039,7 @@ describe('createProgressViewSecondTierHandlers', () => {
     const polishFailure = new Error('polish failed');
     const reportingFailure = new Error('reporting failed');
     const actions = createSecondTierActions({
-      getRunConfig: vi.fn().mockReturnValue({}),
+      getRunMetadata: vi.fn().mockReturnValue({ config: {} }),
       followUpPolish: {
         polishFollowUp: vi.fn().mockRejectedValue(polishFailure),
       } as unknown as ProgressViewSecondTierActions['followUpPolish'],
@@ -1065,7 +1064,7 @@ describe('createProgressViewSecondTierHandlers', () => {
     const order: string[] = [];
     const polishResult = { kind: 'skipped' };
     const actions = createSecondTierActions({
-      getRunConfig: vi.fn().mockReturnValue({}),
+      getRunMetadata: vi.fn().mockReturnValue({ config: {} }),
       followUpPolish: {
         polishFollowUp: vi.fn(async () => {
           order.push('polish');
@@ -1099,7 +1098,7 @@ describe('createProgressViewSecondTierHandlers', () => {
   it('polishes without a progress reporter when the host has none', async () => {
     const polishResult = { kind: 'skipped' };
     const actions = createSecondTierActions({
-      getRunConfig: vi.fn().mockReturnValue({}),
+      getRunMetadata: vi.fn().mockReturnValue({ config: {} }),
       followUpPolish: {
         polishFollowUp: vi.fn().mockResolvedValue(polishResult),
       } as unknown as ProgressViewSecondTierActions['followUpPolish'],

--- a/src/test-kernel/settings/ExtensionAgentHandlers.vitest.ts
+++ b/src/test-kernel/settings/ExtensionAgentHandlers.vitest.ts
@@ -40,14 +40,14 @@ vi.mock('@agent/index', async () => ({
   getVisibleAgents: (category: AgentCategory) => registry.catalog[category],
 }));
 
-const canAccessRemoteAgentCatalog = vi.hoisted(() => vi.fn(async () => false));
+const isAuthenticated = vi.hoisted(() => vi.fn(async () => false));
 
 vi.mock('@auth/SupabaseClient', async () => ({
   ...(await vi.importActual<typeof import('@auth/SupabaseClient')>(
     '@auth/SupabaseClient',
   )),
   SupabaseClient: {
-    canAccessRemoteAgentCatalog,
+    isAuthenticated,
     getUserTier: () => undefined,
     getAccessToken: async () => undefined,
   },
@@ -159,7 +159,7 @@ describe('extension settings AgentHandlers', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     registry.refreshAgents.mockImplementation(async () => {});
-    canAccessRemoteAgentCatalog.mockResolvedValue(false);
+    isAuthenticated.mockResolvedValue(false);
     resetAgentCatalogAuthRefreshScopeForTests();
   });
 

--- a/src/test-kernel/tools/setup/ApplyTeamTool.vitest.ts
+++ b/src/test-kernel/tools/setup/ApplyTeamTool.vitest.ts
@@ -48,9 +48,8 @@ function expectNoTeamState(): void {
   expect(getDefaultTeamId(platform().globalState)).toBeUndefined();
 }
 
-function mockSignedInCatalogAccess(canAccessCatalog: boolean): void {
-  vi.spyOn(SupabaseClient, 'isAuthenticated').mockResolvedValue(true);
-  vi.spyOn(SupabaseClient, 'canAccessRemoteAgentCatalog').mockResolvedValue(
+function mockCatalogAccess(canAccessCatalog: boolean): void {
+  vi.spyOn(SupabaseClient, 'isAuthenticated').mockResolvedValue(
     canAccessCatalog,
   );
   vi.spyOn(SupabaseClient, 'getUser').mockResolvedValue(null);
@@ -176,7 +175,7 @@ describe('apply_team', () => {
   });
 
   it('honors an explicit continuation when catalog access is available', async () => {
-    mockSignedInCatalogAccess(true);
+    mockCatalogAccess(true);
 
     const result = await applyTeam({
       teamId: 'starter',
@@ -191,7 +190,7 @@ describe('apply_team', () => {
 
   it('uses the host setup sign-in capability before its forced retry', async () => {
     const signIn = vi.fn(async () => true);
-    mockSignedInCatalogAccess(false);
+    mockCatalogAccess(false);
     setSetupPlatform(createFakeSetupPlatform({ signIn }));
 
     const result = await applyTeam({

--- a/src/test-kernel/tools/setup/DefaultSetupPlatform.vitest.ts
+++ b/src/test-kernel/tools/setup/DefaultSetupPlatform.vitest.ts
@@ -74,16 +74,13 @@ describe('shared setup capabilities', () => {
     await expect(setupSecrets.storedApiKeyExists('openai')).resolves.toBe(true);
   });
 
-  it('reports a signed-in account without remote-catalog access', async () => {
+  it('reports a signed-in account with remote-catalog access', async () => {
     vi.spyOn(SupabaseClient, 'isAuthenticated').mockResolvedValue(true);
-    vi.spyOn(SupabaseClient, 'canAccessRemoteAgentCatalog').mockResolvedValue(
-      false,
-    );
     vi.spyOn(SupabaseClient, 'getUser').mockResolvedValue(null);
 
     await expect(getSetupAuthStatus()).resolves.toEqual({
       authenticated: true,
-      remoteAgentCatalogAvailable: false,
+      remoteAgentCatalogAvailable: true,
       email: undefined,
     });
   });

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -118,13 +118,10 @@ export async function getSetupAuthStatus(): Promise<{
     return { authenticated: false, remoteAgentCatalogAvailable: false };
   }
 
-  const [user, remoteAgentCatalogAvailable] = await Promise.all([
-    SupabaseClient.getUser(),
-    SupabaseClient.canAccessRemoteAgentCatalog(),
-  ]);
+  const user = await SupabaseClient.getUser();
   return {
     authenticated: true,
-    remoteAgentCatalogAvailable,
+    remoteAgentCatalogAvailable: true,
     email: user?.email,
   };
 }


### PR DESCRIPTION
## Summary

Four small, verified deletion/retirement leftovers in one sweep. No behavior change (details per item below).

### #10922 — collapse `canAccessRemoteAgentCatalog` onto `isAuthenticated`
The relay that justified the distinction was removed in #10896; the two methods had byte-identical bodies. Deleted `SupabaseClient.canAccessRemoteAgentCatalog` and migrated all callers to `isAuthenticated()`: `platform.ts` (also collapsed the now-duplicate `Promise.all` — in the authenticated branch the catalog check was always `true`), `teamCatalogPorts.ts` (capability-named port field kept, rebound), `agentHandlers.ts`, desktop `index.ts` (2 sites), CLI `agents.ts`/`initPlatform.ts`/`multiAgentRunPlan.ts`/`orchestrate.ts` (3 sites). Test doubles migrated to spy on `isAuthenticated` only (pure migration, no new coverage; the impossible signed-in-but-no-catalog-access mock state was removed).

### #10913 — stale `proposalId` fixture in walkthrough script
`scripts/capture-walkthrough-media.mjs`: `proposalId:` → `requestId:`. `ProposalPermissionBaseSchema` requires `requestId` and validation is real, so the proposal panel never rendered in the captured screenshot. Verified only survivor under `scripts/`.

### #10870 leftover — delete the `getRunConfig` port field
`ProgressViewSecondTierActions.getRunConfig` was a single-field lookup used only by follow-up polishing, duplicating `getRunMetadata(stream).config`. Deleted the port field + both host implementations (extension, desktop — each was literally `getRunMetadata(stream).config`); the polish consumer now reads `getRunMetadata` directly. Test mocks migrated (factory entry deleted, 4 scenario overrides rebound to `getRunMetadata`).

### #10868 leftover — investigated, correctly left unchanged
The optional follow-up (formatter reads folded `toolConfig.autoExtract*`) is obsolete: the delegation-section formatter moved to `src/shared/transcript/toolRowModel.ts` in #10948, and its input is the raw model-facing tool-call args (`NormalizedToolUse.input`), where only the shorthand exists — the fold in `extractionShorthandToolConfig` runs downstream in `DelegationTools.execute`/`parseDelegationToolInput`. Reading folded flags there would silently drop the Extract badges on every real delegation. The issue's core (one shared mapping) already landed in #10891.

## Issue acceptance gates

- #10922: method deleted; zero repo references remain; all former callers use `isAuthenticated()`. ✅
- #10913: fixture uses `requestId`; zero `proposalId`/`approvalId` under `scripts/`. ✅
- #10870: banner fallback and restore-wrapper items were already executed by #10891/#10871 (verified on main); this PR lands the issue's remaining optional leftover (`getRunConfig` port deletion). ✅
- #10868: `attachDiagnostics` deletion and single-mapping unification already landed in #10891 (verified on main); the optional formatter follow-up is documented above as obsolete. ✅

## Single source of truth

- Session/catalog access: `SupabaseClient.isAuthenticated` (one method; the capability-named port `canAccessRemoteCatalog` in `teamCatalogPorts.ts` now binds to it).
- Run config on the progress-view command path: `RunMetadata.config` via `getRunMetadata(stream)`.
- Extraction shorthand fold: `extractionShorthandToolConfig` (`src/shared/schemas/proposalInput.ts`) — unchanged, already single.

## Duplication and abstraction budget

Removed: 1 duplicate static method, 1 duplicate port field (+2 duplicate host implementations), 1 duplicate `Promise.all` arm, 1 retired fixture key, 6 duplicate test-double spies. Added: no new abstractions, exports, or layers.

## Net elements (R6)

- 20 files changed, +40/−82 (net −42 LoC).
- Deleted symbols: 1 static method (`SupabaseClient.canAccessRemoteAgentCatalog`), 1 interface field (`ProgressViewSecondTierActions.getRunConfig`).
- Added: 0 new exports, 0 new files, 0 new classes/interfaces.

## Consumer counts (R8)

- `canAccessRemoteAgentCatalog`: 12 production call sites (1 platform, 1 teamCatalogPorts, 1 extension agentHandlers, 2 desktop, 7 CLI) + 6 test-double files → all migrated; 0 remaining references repo-wide (only a historical mention in the dated `docs/proposals/2026-08-01-backend-decoupling-plan.md`).
- `getRunConfig`: 1 production consumer (follow-up polish) + 2 host implementations + test mocks → deleted/rebound; 0 remaining references.
- `proposalId` in `scripts/`: 1 fixture → 0.

## Host impact

Extension: `agentHandlers.ts` call site, `ProgressViewMessageHandler.ts` port implementation deleted.
Desktop: `index.ts` (2 call sites), `desktopAgentExecution.ts` port implementation deleted.
CLI: `agents.ts`, `initPlatform.ts`, `multiAgentRunPlan.ts`, `orchestrate.ts` call sites.

## Scheduled refactoring

None. Dated proposal docs referencing the deleted symbols (`2026-08-01-backend-decoupling-plan.md`) are historical records, intentionally not rewritten.

## Validation

- `npm run typecheck:workspace`, `@texra-ai/cli typecheck`, `@texra/desktop typecheck` — all pass.
- Targeted vitest: 8 files (`ExtensionAgentHandlers`, `ApplyTeamTool`, `DefaultSetupPlatform`, `AgentResolution`, `MultiAgentRunCommand`, `CliInitPlatform`, `ProgressViewCommandHandlers`, `ToolUseFormatter`) — 145/145 pass. Full suite left to CI.
- ESLint clean on changed files (3 pre-existing `no-undef` in `capture-walkthrough-media.mjs` are byte-identical on unmodified HEAD).
- Prettier applied to all changed files.

Closes #10922. Closes #10913. Closes #10870. Closes #10868.