### PR TITLE
fix(desktop): log provider-key failures alongside the dialog

### DIFF
--- a/packages/desktop/src/main/desktopCredentialSettingsController.ts
+++ b/packages/desktop/src/main/desktopCredentialSettingsController.ts
@@ -168,6 +168,7 @@ export class DefaultDesktopCredentialSettingsController implements DesktopCreden
         await options.notifications.showErrorMessage(
           `${message}: ${toErrorMessage(error)}`,
         );
+        options.onError(error);
         await this.postProfileData();
       },
     });

--- a/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
+++ b/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
@@ -84,7 +84,6 @@ vi.mock('@frontend/secretManager', () => ({
   SecretManager: {
     hasUsableApiKey: mocks.hasUsableApiKey,
     API_PROVIDERS: MOCK_API_PROVIDERS,
-    getApiKeySecretName: (provider: string) => `apiKey.${provider}`,
   },
 }));
 


### PR DESCRIPTION
## Summary

Two review findings from #10953 that arrived after it merged. #10953 landed at
`d01ac495` while these fixes were still local, so they need their own PR.

1. `packages/desktop/src/main/desktopCredentialSettingsController.ts` — the
   `reportFailure` that PR introduced showed the error in a dialog but skipped
   `options.onError(error)`, which is what actually reaches the log
   (`createDesktopErrorReporter` → `console.error`). Every sibling handler in
   the file (`signInSubscription`, `signOutSubscription`,
   `setSubscriptionPreference`) calls it. Without this, a rejected placeholder
   key was visible to the user but invisible in the logs.
2. `src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts` — its
   `vi.mock('@frontend/secretManager', …)` still listed `getApiKeySecretName`,
   which #10953 deleted from the real `SecretManager`. Harmless (mock factories
   are not structurally checked) but dead.

## Issue acceptance gates

n/a — post-merge review follow-up to #10953.

## Single source of truth

Unchanged. `SettingsProfileKeyController` still owns provider-key mutation;
this only makes the desktop's injected `reportFailure` complete, matching how
the file's other error handlers report.

## Duplication and abstraction budget

Nothing added. One dead mock entry removed.

## Net elements (R6)

2 files, +1 / −1. No files, exports, classes, interfaces, or enums added or
removed.

## Consumer counts (R8)

n/a — no emit path or export is deleted or re-routed. The removed mock entry
had 0 consumers within its suite (the real
`SecretManager.getApiKeySecretName` was already deleted in #10953, and the
tree has no remaining reference).

## Host impact

Extension: none. CLI: none.

Desktop: a failed provider-key set or remove is now logged as well as shown.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean.
- `FORCE_COLOR=0 npx vitest run src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts src/test-kernel/desktop/DesktopCredentialSettingsController.vitest.ts` — 18 passed.
- `npx prettier --check` on both files — clean.
- `NODE_OPTIONS=--max-old-space-size=8192 npx eslint` on both files — clean.
- `npm run check:dead-code-ratchet` — 8 current vs 8 baselined, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
