### PR TITLE
fix(platform): degrade a broken project config on every host; one composition root for all three

### DIFF
--- a/config/ratchets/host-agent-import-baseline.json
+++ b/config/ratchets/host-agent-import-baseline.json
@@ -32,7 +32,6 @@
       "@agent/followUp",
       "@agent/implementations/agentCreator/agentCreatorFlow",
       "@agent/index",
-      "@agent/index/AgentDirectorySync",
       "@agent/index/platformAgentDirectories",
       "@agent/review/reviewDiff",
       "@agent/review/reviewIssues",

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -28,7 +28,7 @@ import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { createLog } from '@logger/logUtils';
 import { initPlatform, tryPlatform, type Platform } from '@platform/platform';
-import { initNodeAgentRuntime } from '@platform/defaults/nodeHost';
+import { initNodeAgentRuntime } from '@platform/defaults/nodeAgentRuntime';
 import type { ProgressPermissionKind as PendingInteractionKind } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas';
 import {

--- a/packages/agent/src/node.ts
+++ b/packages/agent/src/node.ts
@@ -5,18 +5,14 @@ import type { Platform } from '@platform/platform';
 import type { PlatformSecrets } from '@platform/secrets';
 
 // Local imports - platform defaults
-import { NO_TOOL_AVAILABILITY_HOST } from '@platform/interfaces';
-import { UNAVAILABLE_LANGUAGE_MODEL_PORT } from '@platform/languageModel';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
 import { MemoryConfigProvider } from '@platform/defaults/memoryConfigProvider';
 import { MemoryStateStore } from '@platform/defaults/memoryState';
-import { nodeFileLocks } from '@platform/defaults/fileLocks';
-import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { createNodePlatform } from '@platform/defaults/nodeHost';
 import {
   createNodeStorageProvider,
   DEFAULT_NODE_STORAGE_ROOT,
 } from '@platform/defaults/nodeStorage';
-import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 
 /** Filesystem locations used by the default Node platform. */
 export interface NodePlatformOptions {
@@ -46,25 +42,18 @@ const environmentSecrets: PlatformSecrets = {
  */
 export function nodePlatform(options: NodePlatformOptions): Platform {
   const workspaceDir = options.workspaceDir ?? process.cwd();
-  const storageDir = options.storageDir ?? DEFAULT_NODE_STORAGE_ROOT;
-  const globalState = new MemoryStateStore();
-  const workspaceState = new MemoryStateStore();
-  const storage = createNodeStorageProvider({
-    storageRoot: storageDir,
-    workspacePath: workspaceDir,
-  });
-  const lifecycle = createLifecycleHost();
-
-  return {
+  return createNodePlatform({
+    // Process-local configuration: an embedder's settings must not be read
+    // from, or written to, the user's `.texra/config.json`.
     config: new MemoryConfigProvider(),
-    globalState,
-    workspaceState,
-    fs: nodeFilesystem,
-    workspace: createNodeWorkspace(() => workspaceDir),
-    storage,
-    fileLocks: nodeFileLocks,
+    globalState: new MemoryStateStore(),
+    workspaceState: new MemoryStateStore(),
+    storage: createNodeStorageProvider({
+      storageRoot: options.storageDir ?? DEFAULT_NODE_STORAGE_ROOT,
+      workspacePath: workspaceDir,
+    }),
     secrets: environmentSecrets,
-    lifecycle,
+    lifecycle: createLifecycleHost(),
     agentResume: {
       tryResumeStream: async () => false,
     },
@@ -73,7 +62,6 @@ export function nodePlatform(options: NodePlatformOptions): Platform {
       builtIn: async () => '',
       builtInToolUse: async () => '',
     },
-    languageModel: UNAVAILABLE_LANGUAGE_MODEL_PORT,
-    toolAvailability: NO_TOOL_AVAILABILITY_HOST,
-  };
+    getWorkspacePath: () => workspaceDir,
+  });
 }

--- a/packages/cli/src/runtime/cliStateStores.ts
+++ b/packages/cli/src/runtime/cliStateStores.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 
 import type { StateStore, StorageProvider } from '@platform/interfaces';
 import { JsonStore } from '@platform/defaults/jsonStore';
+import { openNodeWorkspaceStateStore } from '@platform/defaults/nodeStores';
 import { createNodeStorageProvider } from '@platform/defaults/nodeStorage';
 
 export interface CliStateStores {
@@ -36,7 +37,7 @@ export async function createCliStateStores(
   });
   const [globalStore, workspaceStore] = await Promise.all([
     openCliGlobalStateStore(storage),
-    JsonStore.open(path.join(storage.getStoragePath(), 'state.json')),
+    openNodeWorkspaceStateStore(storage),
   ]);
 
   return {

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -1,6 +1,3 @@
-// Node imports
-import * as nodePath from 'node:path';
-
 // Local imports
 import {
   initializeBundledPrompts,
@@ -16,7 +13,6 @@ import { refreshModelListStateIfNeeded } from '@model/modelListRefresh';
 import { SHUTDOWN_PHASE } from '@platform/interfaces';
 import { initPlatform, platform, tryPlatform } from '@platform/platform';
 import type { LifecycleHost } from '@platform/interfaces';
-import { JsonStore } from '@platform/defaults/jsonStore';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
 import {
   bootstrapNodeAgentDirectories,
@@ -24,10 +20,7 @@ import {
   initNodeAgentRuntime,
   initializeNodeRuntimeSkills,
 } from '@platform/defaults/nodeHost';
-import {
-  TEXRA_CONFIG_FILE_NAME,
-  workspaceTexraConfigPath,
-} from '@platform/defaults/nodeStorage';
+import { openTexraConfigStores } from '@platform/defaults/nodeStores';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { UsageLogService } from '@telemetry/UsageLogService';
 import { registerAgentShutdownHandlers } from '@tools/agentCliSessionStores';
@@ -226,22 +219,20 @@ export async function initCliPlatform(
   );
 
   if (!tryPlatform()) {
-    const configStore = await JsonStore.open(
-      workspaceTexraConfigPath(cliWorkspaceCwd),
-    );
     const stateStores = await createCliStateStores({
       storageRoot: context.storageRoot,
       workspacePath: () => cliWorkspaceCwd,
     });
-    // User-level config (`~/.texra/global-storage/config.json`, the same file
-    // chatDefaults reads) backs the global target, mirroring the desktop host:
-    // workspace values shadow global on read and `update(..., 'global')` has
-    // somewhere to write instead of throwing.
-    const globalConfigStore = await JsonStore.open(
-      nodePath.join(
-        stateStores.storage.getGlobalStoragePath(),
-        TEXRA_CONFIG_FILE_NAME,
-      ),
+    // The project `.texra/config.json` backs the workspace target and
+    // user-level config (`~/.texra/global-storage/config.json`, the same file
+    // chatDefaults reads) backs the global target — the same pair of stores
+    // the extension and desktop hosts open, including the fallback to the
+    // internal workspace store when the project file cannot be read or its
+    // directory cannot be written.
+    const configStores = await openTexraConfigStores(
+      stateStores.storage,
+      cliWorkspaceCwd,
+      (message) => logAt('warn', 'cli.config', message),
     );
     // Same severity and wording as the extension/desktop hosts: a shutdown
     // handler failure is an error everywhere, not a warning in one host.
@@ -260,7 +251,7 @@ export async function initCliPlatform(
     });
     initPlatform(
       createNodePlatform({
-        configStores: { workspace: configStore, global: globalConfigStore },
+        configStores,
         globalState: stateStores.globalState,
         workspaceState: stateStores.workspaceState,
         storage: stateStores.storage,

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -14,10 +14,10 @@ import { SHUTDOWN_PHASE } from '@platform/interfaces';
 import { initPlatform, platform, tryPlatform } from '@platform/platform';
 import type { LifecycleHost } from '@platform/interfaces';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
+import { initNodeAgentRuntime } from '@platform/defaults/nodeAgentRuntime';
 import {
   bootstrapNodeAgentDirectories,
   createNodePlatform,
-  initNodeAgentRuntime,
   initializeNodeRuntimeSkills,
 } from '@platform/defaults/nodeHost';
 import { openTexraConfigStores } from '@platform/defaults/nodeStores';
@@ -251,7 +251,7 @@ export async function initCliPlatform(
     });
     initPlatform(
       createNodePlatform({
-        configStores,
+        config: configStores,
         globalState: stateStores.globalState,
         workspaceState: stateStores.workspaceState,
         storage: stateStores.storage,

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -11,10 +11,10 @@ import { SHUTDOWN_PHASE } from '@platform/interfaces';
 import type { AgentResumePort, LifecycleHost } from '@platform/interfaces';
 import { JsonStore } from '@platform/defaults/jsonStore';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
+import { initNodeAgentRuntime } from '@platform/defaults/nodeAgentRuntime';
 import {
   bootstrapNodeAgentDirectories,
   createNodePlatform,
-  initNodeAgentRuntime,
   initializeNodeRuntimeSkills,
 } from '@platform/defaults/nodeHost';
 import {
@@ -91,7 +91,7 @@ export async function initializeElectronPlatform(
   });
   initPlatform(
     createNodePlatform({
-      configStores,
+      config: configStores,
       globalState: globalStateStore,
       workspaceState: workspaceStateStore,
       storage,

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -1,9 +1,7 @@
-import { access, constants } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { app } from 'electron';
 import { initializeBundledPrompts } from '@agent/runtime';
 import { createPlatformAgentDirectories } from '@agent/index/platformAgentDirectories';
-import { isFileNotFoundError } from '@common/errors';
 import { installTexraAccountProbes } from '@controllers/modelAccess/installTexraAccountProbes';
 import { DESKTOP_WORKSPACE_PATH_STATE_KEY } from '@desktop/shared/workspacePath.js';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
@@ -19,12 +17,14 @@ import {
   initNodeAgentRuntime,
   initializeNodeRuntimeSkills,
 } from '@platform/defaults/nodeHost';
-import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
+import {
+  openNodeWorkspaceStateStore,
+  openTexraConfigStores,
+} from '@platform/defaults/nodeStores';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { UsageLogService } from '@telemetry/UsageLogService';
 import { seedDisabledToolDefaults } from '@tools/toolAvailability';
-import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local file imports
 import { ElectronSecrets } from './electronSecrets.js';
@@ -54,29 +54,6 @@ export interface ElectronPlatformInitResult {
   resourcesPath: string;
 }
 
-/**
- * Whether a write through a `JsonStore` at `filePath` could succeed:
- * `flush()` creates the containing directory on demand and then writes a
- * temp file into it, so the deepest existing ancestor of `filePath` must be
- * writable and traversable. Answers false for e.g. a read-only checkout
- * without ever creating the directory in the project tree.
- */
-async function canCreateOrWrite(filePath: string): Promise<boolean> {
-  let dir = dirname(filePath);
-  // Walk up to the deepest existing ancestor; the workspace root exists, so
-  // this terminates after a step or two.
-  for (;;) {
-    try {
-      await access(dir, constants.W_OK | constants.X_OK);
-      return true;
-    } catch (error) {
-      const parent = dirname(dir);
-      if (!isFileNotFoundError(error) || parent === dir) return false;
-      dir = parent;
-    }
-  }
-}
-
 export async function initializeElectronPlatform(
   mainDirname: string,
   agentResume: AgentResumePort,
@@ -97,33 +74,11 @@ export async function initializeElectronPlatform(
   // shows one history.
   const dataRoot = resolveDesktopDataRoot(userDataPath);
   const storage = new WorkspaceStorageProvider(dataRoot, workspacePath);
-  const workspaceStateStore = await JsonStore.open(
-    join(storage.getStoragePath(), 'state.json'),
-  );
-  const globalConfigStore = await JsonStore.open(
-    join(storage.getGlobalStoragePath(), 'config.json'),
-  );
-  // A workspace uses its `.texra/config.json`, shared with the CLI. Sessions
-  // without a workspace, and read-only projects without an existing config,
-  // use the internal workspace store so settings remain writable.
-  let workspaceConfigStore: JsonStore | undefined;
-  if (workspacePath) {
-    const projectConfigPath = workspaceTexraConfigPath(workspacePath);
-    try {
-      const projectConfigStore = await JsonStore.open(projectConfigPath);
-      const hasProjectConfig =
-        Object.keys(projectConfigStore.snapshot()).length > 0;
-      if (hasProjectConfig || (await canCreateOrWrite(projectConfigPath))) {
-        workspaceConfigStore = projectConfigStore;
-      }
-    } catch (error) {
-      console.warn(
-        `[desktop] Cannot open project .texra/config.json; using the internal workspace config store. Cause: ${toErrorMessage(error)}`,
-      );
-    }
-  }
-  workspaceConfigStore ??= await JsonStore.open(
-    join(storage.getStoragePath(), 'config.json'),
+  const workspaceStateStore = await openNodeWorkspaceStateStore(storage);
+  const configStores = await openTexraConfigStores(
+    storage,
+    workspacePath,
+    (message) => console.warn(`[desktop] ${message}`),
   );
   const secretsStore = await JsonStore.open(join(userDataPath, 'secrets.json'));
 
@@ -136,10 +91,7 @@ export async function initializeElectronPlatform(
   });
   initPlatform(
     createNodePlatform({
-      configStores: {
-        workspace: workspaceConfigStore,
-        global: globalConfigStore,
-      },
+      configStores,
       globalState: globalStateStore,
       workspaceState: workspaceStateStore,
       storage,

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -25,6 +25,7 @@ import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { UsageLogService } from '@telemetry/UsageLogService';
 import { seedDisabledToolDefaults } from '@tools/toolAvailability';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local file imports
 import { ElectronSecrets } from './electronSecrets.js';

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -36,7 +36,6 @@ import { installTexraAccountProbes } from '@controllers/modelAccess/installTexra
 import { appSignals } from '@eventBus/AppSignals';
 import { SecretManager } from '@frontend/secretManager';
 import {
-  copyDefaultAgents,
   initializeLatexSupport,
   registerAgentDirectoryRoots,
 } from '@frontend/setup';
@@ -72,18 +71,17 @@ import { redactSecrets } from '@logger/redaction';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { refreshModelListStateIfNeeded } from '@model/modelListRefresh';
 import { invalidateRuntimeModelRegistry } from '@model/runtimeModelRegistry';
-import {
-  NO_TOOL_AVAILABILITY_HOST,
-  SHUTDOWN_PHASE,
-  type LifecycleHost,
-} from '@platform/interfaces';
+import { SHUTDOWN_PHASE, type LifecycleHost } from '@platform/interfaces';
 import { initPlatform, platform } from '@platform/platform';
-import { nodeFileLocks } from '@platform/defaults/fileLocks';
+import {
+  bootstrapNodeAgentDirectories,
+  createNodePlatform,
+  initializeNodeRuntimeSkills,
+} from '@platform/defaults/nodeHost';
 import { createNodeStorageProvider } from '@platform/defaults/nodeStorage';
 import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
-import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import {
   formatTexraApprovalPolicy,
   readPersistedTexraApprovalPolicy,
@@ -91,8 +89,6 @@ import {
 } from '@shared/approvalPolicy';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { backfillFirstRunDone } from '@shared/state/onboardingState';
-import { setRuntimeSkillSources } from '@skills/runtimeSkills';
-import { defaultSkillSources } from '@skills/skillSources';
 import { UsageLogService } from '@telemetry/UsageLogService';
 import { registerAgentShutdownHandlers } from '@tools/agentCliSessionStores';
 import { setSetupPlatform } from '@tools/setup';
@@ -232,35 +228,35 @@ export async function activate(context: vscode.ExtensionContext) {
   // extensions port, which both answer the same question.
   const isVscodeExtensionInstalled = (id: string) =>
     vscode.extensions.getExtension(id) !== undefined;
-  initPlatform({
-    config,
-    globalState: context.globalState,
-    workspaceState: workspaceSM,
-    fs: nodeFilesystem,
-    workspace,
-    storage,
-    fileLocks: nodeFileLocks,
-    secrets: new VscodeSecrets(context),
-    lifecycle,
-    agentDirectories,
-    agentResume: {
-      tryResumeStream: tryResumeFromResumeData,
-    },
-    toolAvailability: {
-      ...NO_TOOL_AVAILABILITY_HOST,
-      isVscodeExtensionInstalled,
-    },
-    languageModel,
-    toolMissingHandler: async (message, openDocsCommand) => {
-      const actions = openDocsCommand ? ['View Installation Guide'] : [];
-      log.error(message);
-      const choice = await vscode.window.showErrorMessage(message, ...actions);
-      if (choice === 'View Installation Guide' && openDocsCommand) {
-        const [command, ...args] = openDocsCommand.split(',');
-        void vscode.commands.executeCommand(command, ...args);
-      }
-    },
-  });
+  initPlatform(
+    createNodePlatform({
+      config,
+      globalState: context.globalState,
+      workspaceState: workspaceSM,
+      getWorkspacePath: rawWorkspacePath,
+      storage,
+      secrets: new VscodeSecrets(context),
+      lifecycle,
+      agentDirectories,
+      agentResume: {
+        tryResumeStream: tryResumeFromResumeData,
+      },
+      toolAvailability: { isVscodeExtensionInstalled },
+      languageModel,
+      toolMissingHandler: async (message, openDocsCommand) => {
+        const actions = openDocsCommand ? ['View Installation Guide'] : [];
+        log.error(message);
+        const choice = await vscode.window.showErrorMessage(
+          message,
+          ...actions,
+        );
+        if (choice === 'View Installation Guide' && openDocsCommand) {
+          const [command, ...args] = openDocsCommand.split(',');
+          void vscode.commands.executeCommand(command, ...args);
+        }
+      },
+    }),
+  );
   // TeXRA's account probes (Codex/xAI subscription eligibility). Without this
   // the model layer is bring-your-own-key. See installTexraAccountProbes.
   installTexraAccountProbes();
@@ -296,19 +292,16 @@ export async function activate(context: vscode.ExtensionContext) {
     ),
   );
   registerAgentFeatures();
-  // Mirrors the CLI/desktop Node-host wiring (`nodeHost.ts`'s
-  // `initializeNodeRuntimeSkills`, inlined here rather than imported so the
-  // extension bundle doesn't also pull in that module's Lean direct-adapter
-  // import) so `AVAILABLE_SKILLS` is actually populated for tool-use agents in
-  // VS Code — without this call `loadRuntimeSkillCatalog` always sees zero
-  // sources and `texra.skills.enabled` has no observable effect (issue #7751
-  // FS5).
-  setRuntimeSkillSources(
-    defaultSkillSources({
-      cwd: workspaceRoot,
-      resourcesPath: path.join(context.extensionPath, 'resources'),
-    }),
-  );
+  // The same Node-host skill wiring the CLI and desktop use, so
+  // `AVAILABLE_SKILLS` is actually populated for tool-use agents in VS Code —
+  // without this call `loadRuntimeSkillCatalog` always sees zero sources and
+  // `texra.skills.enabled` has no observable effect (issue #7751 FS5).
+  // (`initNodeAgentRuntime`, which registers the direct Lean adapter, stays
+  // out: VS Code drives Lean through its own integration.)
+  initializeNodeRuntimeSkills({
+    cwd: workspaceRoot,
+    resourcesPath: path.join(context.extensionPath, 'resources'),
+  });
   // `disposeStatusListener` and `statusBarItem` are owned solely by
   // `context.subscriptions` (see the push near the end of `activate`), matching
   // `apiKeyStatusBarItem`. Registering them here too would double-dispose.
@@ -364,11 +357,18 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // The following startup steps touch independent state, so they run
   // concurrently to shorten activation. Within the agent branch the order
-  // still matters: copyDefaultAgents populates the built-in directories,
-  // registerAgentDirectoryRoots exposes them, and loadAgents scans them.
+  // still matters: the bundled-agent reconciliation populates the built-in
+  // directories, registerAgentDirectoryRoots exposes them, and loadAgents
+  // scans them.
   await Promise.all([
     (async () => {
-      await copyDefaultAgents(context);
+      await bootstrapNodeAgentDirectories({
+        channel: 'extension',
+        resourcesPath: path.join(context.extensionPath, 'resources'),
+        currentVersion: vscode.extensions.getExtension(context.extension.id)
+          ?.packageJSON.version,
+        versionStateKey: GlobalStateKey.LAST_KNOWN_VERSION,
+      });
       await registerAgentDirectoryRoots(context);
       try {
         await loadAgents({ includeRemote: false });

--- a/packages/extension/src/frontend/setup.ts
+++ b/packages/extension/src/frontend/setup.ts
@@ -2,56 +2,15 @@ import * as path from 'node:path';
 
 import * as vscode from 'vscode';
 
-import {
-  BundledAgentDirectorySync,
-  GlobalStorageAgentDirectoryStorage,
-  PathAgentDirectoryBundleSource,
-} from '@agent/index/AgentDirectorySync';
-import { globalSM } from '@common/state';
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { promptExtensionInstall } from '@frontend/ui/instruction';
 import { createLog } from '@logger/logUtils';
-import { GlobalStateKey } from '@shared/state/stateKeys';
 import { LATEX_WORKSHOP_EXT_ID } from '@shared/constants/latexToolchain';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { registerExternalRoot } from '@utils/files/externalRoots';
 import { extendEnvPath } from '@utils/system/platformPaths';
 
 const log = createLog('extension');
-
-/**
- * Reconciles bundled agents in global storage from packaged resources.
- *
- * Built-in agent directories are generated cache; user-owned edits belong in
- * custom agent directories.
- */
-export async function copyDefaultAgents(
-  context: vscode.ExtensionContext,
-): Promise<void> {
-  const currentVersion = vscode.extensions.getExtension(context.extension.id)
-    ?.packageJSON.version;
-  const sync = new BundledAgentDirectorySync({
-    bundleSource: new PathAgentDirectoryBundleSource(
-      path.join(context.extensionPath, 'resources'),
-    ),
-    storage: new GlobalStorageAgentDirectoryStorage(),
-    versionStore: {
-      get: () => globalSM.get<string>(GlobalStateKey.LAST_KNOWN_VERSION),
-      update: (version) =>
-        globalSM.update(GlobalStateKey.LAST_KNOWN_VERSION, version),
-    },
-    logger: {
-      info: (message, data) => log.info(message, { data }),
-      warn: (message, data) => log.warn(message, { data }),
-    },
-  });
-
-  try {
-    await sync.reconcile(currentVersion);
-  } catch (err) {
-    log.error(`Error copying default agents: ${toErrorMessage(err)}`);
-  }
-}
 
 /** External-root registration options for the custom agents directory. */
 const CUSTOM_AGENT_ROOT_OPTIONS = {

--- a/packages/extension/src/frontend/vscode/texraConfig.ts
+++ b/packages/extension/src/frontend/vscode/texraConfig.ts
@@ -15,8 +15,10 @@ import { createLog } from '@logger/logUtils';
 
 // Local imports - platform
 import type { ConfigTarget, StorageProvider } from '@platform/interfaces';
-import { JsonConfigProvider } from '@platform/defaults/jsonConfigProvider';
-import type { JsonStore } from '@platform/defaults/jsonStore';
+import {
+  JsonConfigProvider,
+  type ConfigStore,
+} from '@platform/defaults/jsonConfigProvider';
 import {
   openTexraConfigStores,
   openTexraWorkspaceConfigStore,
@@ -34,8 +36,8 @@ export class ExtensionTexraConfig extends JsonConfigProvider {
 
   constructor(
     private readonly storage: StorageProvider,
-    workspaceStore: JsonStore,
-    globalStore: JsonStore,
+    workspaceStore: ConfigStore,
+    globalStore: ConfigStore,
   ) {
     super({ workspace: workspaceStore, global: globalStore });
   }
@@ -76,7 +78,7 @@ export class ExtensionTexraConfig extends JsonConfigProvider {
         return;
       }
 
-      let previousStore: JsonStore | undefined;
+      let previousStore: ConfigStore | undefined;
       let finalized = false;
       const seedSessionApprovalPolicy = (): void => {
         // No default session exists yet during activation's own config setup,

--- a/packages/extension/src/frontend/vscode/texraConfig.ts
+++ b/packages/extension/src/frontend/vscode/texraConfig.ts
@@ -1,7 +1,3 @@
-// Node imports
-import { access, constants } from 'node:fs/promises';
-import * as path from 'node:path';
-
 // Third-party imports
 import PQueue from 'p-queue';
 
@@ -10,9 +6,6 @@ import {
   tryDefaultSession,
   type WorkspaceStorageTransitionHooks,
 } from '@agent/runtime';
-
-// Local imports - common
-import { isFileNotFoundError } from '@common/errors';
 
 // Local imports - eventBus
 import { appSignals } from '@eventBus/AppSignals';
@@ -23,55 +16,16 @@ import { createLog } from '@logger/logUtils';
 // Local imports - platform
 import type { ConfigTarget, StorageProvider } from '@platform/interfaces';
 import { JsonConfigProvider } from '@platform/defaults/jsonConfigProvider';
-import { JsonStore } from '@platform/defaults/jsonStore';
+import type { JsonStore } from '@platform/defaults/jsonStore';
 import {
-  TEXRA_CONFIG_FILE_NAME,
-  workspaceTexraConfigPath,
-} from '@platform/defaults/nodeStorage';
+  openTexraConfigStores,
+  openTexraWorkspaceConfigStore,
+} from '@platform/defaults/nodeStores';
 import { readPersistedTexraApprovalPolicy } from '@shared/approvalPolicy';
-
-// Local imports - utilities
-import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const log = createLog('extension');
 
-/** Whether JsonStore can create its file beneath the deepest existing directory. */
-async function canCreateOrWrite(filePath: string): Promise<boolean> {
-  let dir = path.dirname(filePath);
-  for (;;) {
-    try {
-      await access(dir, constants.W_OK | constants.X_OK);
-      return true;
-    } catch (error) {
-      const parent = path.dirname(dir);
-      if (!isFileNotFoundError(error) || parent === dir) return false;
-      dir = parent;
-    }
-  }
-}
-
-async function openWorkspaceConfigStore(
-  workspaceRoot: string | undefined,
-  internalConfigPath: string,
-): Promise<JsonStore> {
-  if (workspaceRoot) {
-    const projectConfigPath = workspaceTexraConfigPath(workspaceRoot);
-    try {
-      const projectStore = await JsonStore.open(projectConfigPath);
-      if (
-        Object.keys(projectStore.snapshot()).length > 0 ||
-        (await canCreateOrWrite(projectConfigPath))
-      ) {
-        return projectStore;
-      }
-    } catch (error) {
-      log.warn(
-        `Cannot open project .texra/config.json; using the internal workspace config store. Cause: ${toErrorMessage(error)}`,
-      );
-    }
-  }
-  return JsonStore.open(internalConfigPath);
-}
+const warnConfigDegradation = (message: string): void => log.warn(message);
 
 export class ExtensionTexraConfig extends JsonConfigProvider {
   private transitionGeneration = 0;
@@ -148,9 +102,10 @@ export class ExtensionTexraConfig extends JsonConfigProvider {
         await reloadStorage({
           workspacePath: workspaceRoot,
           afterStorageCommit: async () => {
-            const workspaceStore = await openWorkspaceConfigStore(
+            const workspaceStore = await openTexraWorkspaceConfigStore(
+              this.storage,
               workspaceRoot,
-              path.join(this.storage.getStoragePath(), TEXRA_CONFIG_FILE_NAME),
+              warnConfigDegradation,
             );
             previousStore = this.replaceWorkspaceStore(workspaceStore);
             seedSessionApprovalPolicy();
@@ -184,13 +139,11 @@ export async function createExtensionTexraConfig(
   storage: StorageProvider,
   workspaceRoot: string | undefined,
 ): Promise<ExtensionTexraConfig> {
-  const workspaceStore = await openWorkspaceConfigStore(
+  const stores = await openTexraConfigStores(
+    storage,
     workspaceRoot,
-    path.join(storage.getStoragePath(), TEXRA_CONFIG_FILE_NAME),
-  );
-  const globalStore = await JsonStore.open(
-    path.join(storage.getGlobalStoragePath(), TEXRA_CONFIG_FILE_NAME),
+    warnConfigDegradation,
   );
 
-  return new ExtensionTexraConfig(storage, workspaceStore, globalStore);
+  return new ExtensionTexraConfig(storage, stores.workspace, stores.global);
 }

--- a/src/agent/index/platformAgentDirectories.ts
+++ b/src/agent/index/platformAgentDirectories.ts
@@ -4,6 +4,7 @@ import {
 } from '@common/errors/errorPredicates';
 import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
   AgentDirectoryService,
   type AgentDirectoryIssueReporter,
@@ -79,5 +80,13 @@ export async function bootstrapPlatformAgentDirectories(
     },
   });
 
-  await sync.reconcile(options.currentVersion);
+  try {
+    await sync.reconcile(options.currentVersion);
+  } catch (error) {
+    // An unreadable or partially written agent directory must not abort host
+    // startup — VS Code activation in particular has to survive it. Loud, not
+    // silent: the cause is logged at error and the host continues with
+    // whatever bundled agents already reconciled.
+    log.error(`Error copying default agents: ${toErrorMessage(error)}`);
+  }
 }

--- a/src/platform/defaults/jsonConfigProvider.ts
+++ b/src/platform/defaults/jsonConfigProvider.ts
@@ -1,26 +1,36 @@
 import { getCoreSettingDefault } from '@shared/schemas';
 import { canonicalConfigKey } from '@shared/config/configKeys';
 
-import type { JsonStore } from './jsonStore';
 import type {
   ConfigInspection,
   ConfigProvider,
   ConfigTarget,
 } from '../interfaces';
 
+/**
+ * The store surface one config target needs. `JsonStore` satisfies it; so does
+ * the in-memory twin behind `MemoryConfigProvider`, which is why the
+ * layered-resolution rule below has exactly one implementation.
+ */
+export interface ConfigStore {
+  get<T>(key: string): T | undefined;
+  has(key: string): boolean;
+  set(key: string, value: unknown): Promise<void>;
+}
+
 export interface JsonConfigProviderOptions {
-  workspace: JsonStore;
-  global: JsonStore;
+  workspace: ConfigStore;
+  global: ConfigStore;
 }
 
 /**
- * File-backed {@link ConfigProvider}. Keys are stored flat with the canonical
+ * Store-backed {@link ConfigProvider}. Keys are stored flat with the canonical
  * `texra.*` prefix. Workspace values shadow global values on read and
  * `update()` routes writes by {@link ConfigTarget}.
  */
 export class JsonConfigProvider implements ConfigProvider {
-  private workspaceStore: JsonStore;
-  private readonly globalStore: JsonStore;
+  private workspaceStore: ConfigStore;
+  private readonly globalStore: ConfigStore;
 
   constructor({ workspace, global }: JsonConfigProviderOptions) {
     this.workspaceStore = workspace;
@@ -38,7 +48,7 @@ export class JsonConfigProvider implements ConfigProvider {
   }
 
   /** Switch workspace scope while retaining global values. */
-  replaceWorkspaceStore(workspaceStore: JsonStore): JsonStore {
+  replaceWorkspaceStore(workspaceStore: ConfigStore): ConfigStore {
     const previousStore = this.workspaceStore;
     this.workspaceStore = workspaceStore;
     return previousStore;

--- a/src/platform/defaults/memoryConfigProvider.ts
+++ b/src/platform/defaults/memoryConfigProvider.ts
@@ -1,57 +1,40 @@
-import { getCoreSettingDefault } from '@shared/schemas';
-import { canonicalConfigKey } from '@shared/config/configKeys';
+import { JsonConfigProvider, type ConfigStore } from './jsonConfigProvider';
 
-import type {
-  ConfigInspection,
-  ConfigProvider,
-  ConfigTarget,
-} from '../interfaces';
+/** Process-local {@link ConfigStore}, the in-memory twin of a `JsonStore`. */
+class MemoryConfigStore implements ConfigStore {
+  private readonly values = new Map<string, unknown>();
+
+  get<T>(key: string): T | undefined {
+    return this.values.get(key) as T | undefined;
+  }
+
+  has(key: string): boolean {
+    return this.values.has(key);
+  }
+
+  async set(key: string, value: unknown): Promise<void> {
+    // `JsonStore.set` treats `undefined` as a delete; match it so
+    // `isExplicitlySet` agrees across backings.
+    if (value === undefined) {
+      this.values.delete(key);
+    } else {
+      this.values.set(key, value);
+    }
+  }
+}
 
 /**
  * In-memory {@link ConfigProvider} for process-local hosts (the default Node
- * platform, tests). Resolves settings exactly like the file-backed
- * {@link JsonConfigProvider}: workspace values shadow global values, then the
- * core-schema default, then the caller's fallback — so embedders observe the
- * same effective settings as every host.
+ * platform, tests). Settings resolve exactly as they do for a file-backed
+ * host — workspace shadows global, then the core-schema default, then the
+ * caller's fallback — because it is the same provider over in-memory stores,
+ * not a second implementation of the same rule.
  */
-export class MemoryConfigProvider implements ConfigProvider {
-  private readonly global = new Map<string, unknown>();
-  private readonly workspace = new Map<string, unknown>();
-
-  get<T>(key: string, defaultValue?: T): T {
-    const storedKey = canonicalConfigKey(key);
-    const workspaceValue = this.workspace.get(storedKey) as T | undefined;
-    if (workspaceValue !== undefined) return workspaceValue;
-    const globalValue = this.global.get(storedKey) as T | undefined;
-    if (globalValue !== undefined) return globalValue;
-    const schemaDefault = getCoreSettingDefault(storedKey) as T | undefined;
-    return schemaDefault === undefined ? (defaultValue as T) : schemaDefault;
-  }
-
-  async update<T>(
-    key: string,
-    value: T,
-    target: ConfigTarget = 'workspace',
-  ): Promise<void> {
-    const values = target === 'global' ? this.global : this.workspace;
-    const storedKey = canonicalConfigKey(key);
-    if (value === undefined) {
-      values.delete(storedKey);
-    } else {
-      values.set(storedKey, value);
-    }
-  }
-
-  inspect<T = unknown>(key: string): ConfigInspection<T> {
-    const storedKey = canonicalConfigKey(key);
-    return {
-      globalValue: this.global.get(storedKey) as T | undefined,
-      workspaceValue: this.workspace.get(storedKey) as T | undefined,
-    };
-  }
-
-  isExplicitlySet(key: string): boolean {
-    const storedKey = canonicalConfigKey(key);
-    return this.workspace.has(storedKey) || this.global.has(storedKey);
+export class MemoryConfigProvider extends JsonConfigProvider {
+  constructor() {
+    super({
+      workspace: new MemoryConfigStore(),
+      global: new MemoryConfigStore(),
+    });
   }
 }

--- a/src/platform/defaults/nodeAgentRuntime.ts
+++ b/src/platform/defaults/nodeAgentRuntime.ts
@@ -1,0 +1,35 @@
+/**
+ * Post-`initPlatform` agent-runtime registration for the two Node process
+ * hosts (the `texra` CLI runtime and the Electron desktop main process).
+ *
+ * Split out of `nodeHost.ts` so that module stays free of the direct Lean LSP
+ * adapter: the VS Code extension composes its platform from the same
+ * `nodeHost` helpers but drives Lean through its own integration, and pulling
+ * the adapter into the extension bundle is what previously forced the
+ * extension to inline copies of those helpers instead of importing them.
+ */
+
+// Local imports
+import { registerAgentFeatures } from '@agent/features';
+import { registerDirectLeanLanguageServices } from '@tools/lean/direct/directLspAdapter';
+
+// Local file imports
+import type { LifecycleHost } from '../interfaces';
+
+/**
+ * Register the singleton agent runtime for a Node host after `initPlatform`.
+ *
+ * Both Node hosts share this exact post-init sequence: the conditional
+ * tool-injection features (memory + goal) and the direct Lean language
+ * services. Centralized so the hosts cannot drift; the CLI previously skipped
+ * `registerAgentFeatures`, silently losing the memory and goal tool
+ * injections.
+ *
+ * Call exactly once per process: `registerAgentFeatures` and
+ * `registerDirectLeanLanguageServices` register a singleton / shutdown handler
+ * that throws or double-registers on a second call.
+ */
+export function initNodeAgentRuntime(lifecycle: LifecycleHost): void {
+  registerAgentFeatures();
+  registerDirectLeanLanguageServices(lifecycle);
+}

--- a/src/platform/defaults/nodeHost.ts
+++ b/src/platform/defaults/nodeHost.ts
@@ -1,20 +1,21 @@
 /**
  * Node host composition helpers.
  *
- * The two Node composition roots (the `texra` CLI runtime and the Electron
- * desktop main process) wire the same platform skeleton and the same
- * post-`initPlatform` agent-runtime registration. This module owns the shared
- * ingredients so the hosts cannot drift; each host still performs the actual
- * `initPlatform(...)` call in its own composition root.
+ * All three composition roots (the `texra` CLI runtime, the Electron desktop
+ * main process, and the VS Code extension host) wire the same platform
+ * skeleton from the same ingredients. This module owns them so the hosts
+ * cannot drift; each host still performs the actual `initPlatform(...)` call
+ * in its own composition root.
  *
  * This file is a composition helper, not a core platform abstraction: it
- * deliberately reaches "up" into `@agent` and `@tools` for the registration
+ * deliberately reaches "up" into `@agent` and `@skills` for the registration
  * helpers, mirroring what each host's composition root would otherwise inline.
- * Nothing in `@agent` / `@tools` imports it back, so there is no cycle.
+ * Nothing in `@agent` / `@skills` imports it back, so there is no cycle. The
+ * direct Lean LSP registration lives in `nodeAgentRuntime.ts` instead, so that
+ * adapter stays out of hosts that only need the composition helpers.
  */
 
 // Local imports
-import { registerAgentFeatures } from '@agent/features';
 import { PathAgentDirectoryBundleSource } from '@agent/index/AgentDirectorySync';
 import { bootstrapPlatformAgentDirectories } from '@agent/index/platformAgentDirectories';
 import { setRuntimeSkillSources } from '@skills/runtimeSkills';
@@ -22,27 +23,27 @@ import {
   defaultSkillSources,
   type SkillSourceOptions,
 } from '@skills/skillSources';
-import { registerDirectLeanLanguageServices } from '@tools/lean/direct/directLspAdapter';
 
 // Local file imports
-import {
-  JsonConfigProvider,
-  type JsonConfigProviderOptions,
-} from './jsonConfigProvider';
 import { nodeFileLocks } from './fileLocks';
+import { JsonConfigProvider } from './jsonConfigProvider';
 import { nodeFilesystem } from './nodeFilesystem';
 import { createNodeWorkspace } from './nodeWorkspace';
 import { NO_TOOL_AVAILABILITY_HOST } from '../interfaces';
 import { UNAVAILABLE_LANGUAGE_MODEL_PORT } from '../languageModel';
 import { platform } from '../platform';
+import type { JsonConfigProviderOptions } from './jsonConfigProvider';
 import type {
   AgentDirectoriesPort,
   AgentResumePort,
+  ConfigProvider,
   LifecycleHost,
   StateStore,
   StorageProvider,
   ToolAvailabilityHost,
+  ToolMissingHandler,
 } from '../interfaces';
+import type { LanguageModelPort } from '../languageModel';
 import type { Platform } from '../platform';
 import type { PlatformSecrets } from '../secrets';
 
@@ -52,8 +53,13 @@ import type { PlatformSecrets } from '../secrets';
  * the no-op tool-availability host) are filled in by the helper.
  */
 export interface NodePlatformServices {
-  /** Workspace + optional global config stores backing the config provider. */
-  readonly configStores: JsonConfigProviderOptions;
+  /**
+   * Config source: the workspace + global stores to build the file-backed
+   * provider from, or an already-constructed provider for hosts that resolve
+   * configuration some other way (the SDK's process-local memory provider, the
+   * extension's transition-aware subclass).
+   */
+  readonly config: JsonConfigProviderOptions | ConfigProvider;
   readonly globalState: StateStore;
   readonly workspaceState: StateStore;
   readonly storage: StorageProvider;
@@ -65,6 +71,16 @@ export interface NodePlatformServices {
   readonly getWorkspacePath: () => string | undefined;
   /** Host-specific availability overrides merged over the no-op defaults. */
   readonly toolAvailability?: Partial<ToolAvailabilityHost>;
+  /** Editor-host subscription models; defaults to the unavailable port. */
+  readonly languageModel?: LanguageModelPort;
+  /** Optional process-host capability; absent means no-op (see `Platform`). */
+  readonly toolMissingHandler?: ToolMissingHandler;
+}
+
+function toConfigProvider(
+  config: JsonConfigProviderOptions | ConfigProvider,
+): ConfigProvider {
+  return 'workspace' in config ? new JsonConfigProvider(config) : config;
 }
 
 export interface NodeAgentDirectoryBootstrapOptions {
@@ -83,16 +99,18 @@ export interface NodeRuntimeSkillOptions {
 const bootstrappedAgentDirectoryResources = new Map<string, string>();
 
 /**
- * Assemble the platform services for a Node host (CLI, desktop).
+ * Assemble the platform services for a Node-family host (CLI, desktop,
+ * extension) or an SDK embedder.
  *
- * Centralizes the default building blocks both hosts pass to `initPlatform`
- * (`nodeFilesystem`, `createNodeWorkspace`, `JsonConfigProvider`, the no-op
- * tool-availability host) while preserving the rule that only composition
- * roots call `initPlatform(...)`.
+ * Centralizes the default building blocks every host would otherwise restate
+ * in its own `initPlatform` literal (`nodeFilesystem`, `createNodeWorkspace`,
+ * `nodeFileLocks`, the config provider, the no-op tool-availability host)
+ * while preserving the rule that only composition roots call
+ * `initPlatform(...)`.
  */
 export function createNodePlatform(services: NodePlatformServices): Platform {
   return {
-    config: new JsonConfigProvider(services.configStores),
+    config: toConfigProvider(services.config),
     globalState: services.globalState,
     workspaceState: services.workspaceState,
     fs: nodeFilesystem,
@@ -103,41 +121,24 @@ export function createNodePlatform(services: NodePlatformServices): Platform {
     lifecycle: services.lifecycle,
     agentResume: services.agentResume,
     agentDirectories: services.agentDirectories,
-    languageModel: UNAVAILABLE_LANGUAGE_MODEL_PORT,
+    languageModel: services.languageModel ?? UNAVAILABLE_LANGUAGE_MODEL_PORT,
     toolAvailability: {
       ...NO_TOOL_AVAILABILITY_HOST,
       ...services.toolAvailability,
     },
-    // Missing-tool reporting remains an optional process-host capability.
-    // Neither Node host has a corresponding UI, so omission is the no-op.
+    // Missing-tool reporting remains an optional process-host capability;
+    // omitting it is the no-op, which is what both Node hosts want.
+    toolMissingHandler: services.toolMissingHandler,
   };
 }
 
 /**
- * Register the singleton agent runtime for a Node host after `initPlatform`.
+ * Register runtime skill sources for a host.
  *
- * Both Node hosts share this exact post-init sequence: the conditional
- * tool-injection features (memory + goal) and the direct Lean language
- * services. Centralized so the hosts cannot drift; the CLI previously skipped
- * `registerAgentFeatures`, silently losing the memory and goal tool
- * injections.
- *
- * Call exactly once per process: `registerAgentFeatures` and
- * `registerDirectLeanLanguageServices` register a singleton / shutdown handler
- * that throws or double-registers on a second call.
- */
-export function initNodeAgentRuntime(lifecycle: LifecycleHost): void {
-  registerAgentFeatures();
-  registerDirectLeanLanguageServices(lifecycle);
-}
-
-/**
- * Register runtime skill sources for a Node host.
- *
- * The CLI and desktop hosts use the same precedence: explicit custom roots,
- * project skills, user skills, and bundled skills. The CLI supplies custom and
- * interop options from command-line flags; desktop uses the defaults so it
- * always gets project, user, and bundled runtime skills.
+ * All three hosts use the same precedence: explicit custom roots, project
+ * skills, user skills, and bundled skills. The CLI supplies custom and interop
+ * options from command-line flags; desktop and the extension use the defaults
+ * so they always get project, user, and bundled runtime skills.
  */
 export function initializeNodeRuntimeSkills(
   options: NodeRuntimeSkillOptions,
@@ -154,11 +155,13 @@ export function initializeNodeRuntimeSkills(
 }
 
 /**
- * Reconcile packaged agent directories for a Node host after `initPlatform`.
+ * Reconcile packaged agent directories for a host after `initPlatform`.
  *
- * The CLI and desktop hosts use different version-state keys, but the
- * resources-path re-entry rule is the same: a process only reconciles a given
- * host channel again when its active packaged resources path changes.
+ * Hosts use different version-state keys, but the resources-path re-entry rule
+ * is the same: a process only reconciles a given host channel again when its
+ * active packaged resources path changes. Reconciliation failures are reported
+ * and swallowed by `bootstrapPlatformAgentDirectories` — a broken agent
+ * directory must not abort startup.
  */
 export async function bootstrapNodeAgentDirectories(
   options: NodeAgentDirectoryBootstrapOptions,

--- a/src/platform/defaults/nodeStores.ts
+++ b/src/platform/defaults/nodeStores.ts
@@ -32,13 +32,6 @@ import type { StateStore, StorageProvider } from '../interfaces';
 const STATE_FILE_NAME = 'state.json';
 
 /**
- * Reports why the project config store could not be used. Falling back to the
- * internal store is a degradation, so every host has to say so out loud rather
- * than swallow the cause.
- */
-export type ConfigStoreWarn = (message: string) => void;
-
-/**
  * Whether a write through a `JsonStore` at `filePath` could succeed:
  * `flush()` creates the containing directory on demand and then writes a temp
  * file into it, so the deepest existing ancestor of `filePath` must be
@@ -64,6 +57,10 @@ async function canCreateOrWrite(filePath: string): Promise<boolean> {
 /**
  * Open the store backing the workspace config target.
  *
+ * `warn` reports why the project store could not be used: falling back to the
+ * internal store is a degradation, so every host says so out loud rather than
+ * swallowing the cause.
+ *
  * A workspace uses its `.texra/config.json`, shared by all three hosts.
  * Sessions without a workspace, read-only projects without an existing
  * config, and projects whose config file cannot be read (missing permissions,
@@ -73,7 +70,7 @@ async function canCreateOrWrite(filePath: string): Promise<boolean> {
 export async function openTexraWorkspaceConfigStore(
   storage: StorageProvider,
   workspaceRoot: string | undefined,
-  warn: ConfigStoreWarn,
+  warn: (message: string) => void,
 ): Promise<JsonStore> {
   if (workspaceRoot) {
     const projectConfigPath = workspaceTexraConfigPath(workspaceRoot);
@@ -100,7 +97,7 @@ export async function openTexraWorkspaceConfigStore(
 export async function openTexraConfigStores(
   storage: StorageProvider,
   workspaceRoot: string | undefined,
-  warn: ConfigStoreWarn,
+  warn: (message: string) => void,
 ): Promise<JsonConfigProviderOptions> {
   const [workspace, global] = await Promise.all([
     openTexraWorkspaceConfigStore(storage, workspaceRoot, warn),

--- a/src/platform/defaults/nodeStores.ts
+++ b/src/platform/defaults/nodeStores.ts
@@ -1,0 +1,123 @@
+/**
+ * The JSON stores a Node-family host (CLI, desktop, extension) opens before
+ * `initPlatform`.
+ *
+ * Every host resolves the same files from the same {@link StorageProvider},
+ * so the derivations live here once: which store backs workspace
+ * configuration (the project `.texra/config.json` when it is usable, the
+ * internal workspace store otherwise), where global configuration lives, and
+ * where workspace state lives.
+ */
+
+// Node imports
+import { access, constants } from 'node:fs/promises';
+import * as path from 'node:path';
+
+// Local imports - common
+import { isFileNotFoundError } from '@common/errors';
+
+// Local imports - utilities
+import { toErrorMessage } from '@utils/errors/errorMessage';
+
+// Local file imports
+import { JsonStore } from './jsonStore';
+import {
+  TEXRA_CONFIG_FILE_NAME,
+  workspaceTexraConfigPath,
+} from './nodeStorage';
+import type { JsonConfigProviderOptions } from './jsonConfigProvider';
+import type { StateStore, StorageProvider } from '../interfaces';
+
+/** File name of a state store inside a storage directory. */
+const STATE_FILE_NAME = 'state.json';
+
+/**
+ * Reports why the project config store could not be used. Falling back to the
+ * internal store is a degradation, so every host has to say so out loud rather
+ * than swallow the cause.
+ */
+export type ConfigStoreWarn = (message: string) => void;
+
+/**
+ * Whether a write through a `JsonStore` at `filePath` could succeed:
+ * `flush()` creates the containing directory on demand and then writes a temp
+ * file into it, so the deepest existing ancestor of `filePath` must be
+ * writable and traversable. Answers false for e.g. a read-only checkout
+ * without ever creating the directory in the project tree.
+ */
+async function canCreateOrWrite(filePath: string): Promise<boolean> {
+  let dir = path.dirname(filePath);
+  // Walk up to the deepest existing ancestor; the workspace root exists, so
+  // this terminates after a step or two.
+  for (;;) {
+    try {
+      await access(dir, constants.W_OK | constants.X_OK);
+      return true;
+    } catch (error) {
+      const parent = path.dirname(dir);
+      if (!isFileNotFoundError(error) || parent === dir) return false;
+      dir = parent;
+    }
+  }
+}
+
+/**
+ * Open the store backing the workspace config target.
+ *
+ * A workspace uses its `.texra/config.json`, shared by all three hosts.
+ * Sessions without a workspace, read-only projects without an existing
+ * config, and projects whose config file cannot be read (missing permissions,
+ * malformed JSON) fall back to the internal workspace store so settings stay
+ * readable and writable — degraded, never fatal.
+ */
+export async function openTexraWorkspaceConfigStore(
+  storage: StorageProvider,
+  workspaceRoot: string | undefined,
+  warn: ConfigStoreWarn,
+): Promise<JsonStore> {
+  if (workspaceRoot) {
+    const projectConfigPath = workspaceTexraConfigPath(workspaceRoot);
+    try {
+      const projectStore = await JsonStore.open(projectConfigPath);
+      if (
+        Object.keys(projectStore.snapshot()).length > 0 ||
+        (await canCreateOrWrite(projectConfigPath))
+      ) {
+        return projectStore;
+      }
+    } catch (error) {
+      warn(
+        `Cannot open project .texra/config.json; using the internal workspace config store. Cause: ${toErrorMessage(error)}`,
+      );
+    }
+  }
+  return JsonStore.open(
+    path.join(storage.getStoragePath(), TEXRA_CONFIG_FILE_NAME),
+  );
+}
+
+/** Open both stores backing a host's {@link JsonConfigProvider}. */
+export async function openTexraConfigStores(
+  storage: StorageProvider,
+  workspaceRoot: string | undefined,
+  warn: ConfigStoreWarn,
+): Promise<JsonConfigProviderOptions> {
+  const [workspace, global] = await Promise.all([
+    openTexraWorkspaceConfigStore(storage, workspaceRoot, warn),
+    JsonStore.open(
+      path.join(storage.getGlobalStoragePath(), TEXRA_CONFIG_FILE_NAME),
+    ),
+  ]);
+  return { workspace, global };
+}
+
+/**
+ * Open the workspace state store. The CLI and desktop hosts address the same
+ * physical `<storageRoot>/workspace-storage/<id>/state.json` in production, so
+ * the path is derived once here.
+ */
+export async function openNodeWorkspaceStateStore(
+  storage: StorageProvider,
+): Promise<StateStore> {
+  return JsonStore.open(path.join(storage.getStoragePath(), STATE_FILE_NAME));
+}

--- a/src/test-kernel/agent/AgentPackage.vitest.ts
+++ b/src/test-kernel/agent/AgentPackage.vitest.ts
@@ -88,7 +88,7 @@ vi.mock('@tools/agentCliSessionStores', () => ({
   }),
 }));
 
-vi.mock('@platform/defaults/nodeHost', () => ({
+vi.mock('@platform/defaults/nodeAgentRuntime', () => ({
   initNodeAgentRuntime: mocks.initNodeAgentRuntime,
 }));
 

--- a/src/test-kernel/cli/CliInitPlatform.vitest.ts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.ts
@@ -125,8 +125,11 @@ vi.mock('@platform/platform', () => ({
 vi.mock('@platform/defaults/nodeHost', () => ({
   bootstrapNodeAgentDirectories: mocks.bootstrapNodeAgentDirectories,
   createNodePlatform: mocks.createNodePlatform,
-  initNodeAgentRuntime: mocks.initNodeAgentRuntime,
   initializeNodeRuntimeSkills: mocks.initializeNodeRuntimeSkills,
+}));
+
+vi.mock('@platform/defaults/nodeAgentRuntime', () => ({
+  initNodeAgentRuntime: mocks.initNodeAgentRuntime,
 }));
 
 vi.mock('@telemetry/UsageLogService', () => ({

--- a/src/test-kernel/cli/CliInitPlatform.vitest.ts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.ts
@@ -146,12 +146,13 @@ vi.mock('@platform/defaults/lifecycleHost', () => ({
   }),
 }));
 
-vi.mock('@platform/defaults/jsonStore', () => ({
-  JsonStore: { open: vi.fn().mockResolvedValue({}) },
-}));
-
-vi.mock('@platform/defaults/jsonConfigProvider', () => ({
-  JsonConfigProvider: vi.fn(),
+// The workspace/global config store pair (and its degrade-to-internal-store
+// rule) is shared with the extension and desktop hosts; stubbed here so this
+// test exercises only the CLI-specific wiring.
+vi.mock('@platform/defaults/nodeStores', () => ({
+  openTexraConfigStores: vi
+    .fn()
+    .mockResolvedValue({ workspace: {}, global: {} }),
 }));
 
 vi.mock('@platform/defaults/nodeFilesystem', () => ({ nodeFilesystem: {} }));

--- a/src/test-kernel/platform/WorkspaceStorage.vitest.ts
+++ b/src/test-kernel/platform/WorkspaceStorage.vitest.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 // Local imports - platform
 import { WORKSPACE_SIDECAR_FILE } from '@common/storage/storageLayout';
 import { createNodeStorageProvider } from '@platform/defaults/nodeStorage';
+import { openTexraConfigStores } from '@platform/defaults/nodeStores';
 import {
   MEMORY_STORAGE_DIR,
   WorkspaceStorageProvider,
@@ -181,6 +182,32 @@ describe('workspace storage defaults', () => {
 
     expect(provider.getStoragePath()).toBe(storagePath);
     await expect(pathExists(storagePath)).resolves.toBe(false);
+  });
+
+  // Regression pin (#C4): a malformed project config used to fail CLI startup
+  // outright — `JsonStore.open` throws and only the GUI hosts caught it. Every
+  // host now degrades to the internal workspace store, loudly.
+  it('degrades to the internal workspace config store when the project config is malformed', async () => {
+    const root = await makeStorageRoot();
+    const workspacePath = await makeTempDir('texra-project-', tempDirs);
+    await mkdir(join(workspacePath, '.texra'), { recursive: true });
+    await writeFile(join(workspacePath, '.texra', 'config.json'), '{ broken');
+    const storage = createNodeStorageProvider({
+      storageRoot: root,
+      workspacePath,
+    });
+    const warnings: string[] = [];
+
+    const stores = await openTexraConfigStores(storage, workspacePath, (m) =>
+      warnings.push(m),
+    );
+    await stores.workspace.set('texra.files.exclude', ['dist']);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('Cannot open project .texra/config.json');
+    await expect(
+      pathExists(join(storage.getStoragePath(), 'config.json')),
+    ).resolves.toBe(true);
   });
 
   it('uses the same workspace storage rule for node hosts', async () => {


### PR DESCRIPTION
## Summary

**Lead fix (C4, a live user-facing defect).** All three hosts open the same
project config store, but only the two GUI hosts guarded it. The VS Code
extension (`frontend/vscode/texraConfig.ts`) and the Electron main process
(`main/platform/index.ts`) each carried their own copy of the same walk-up —
same `constants.W_OK | X_OK` loop, same `isFileNotFoundError`, same
`parent === dir` termination, same `hasProjectConfig || canCreateOrWrite(path)`
rule, same internal-store fallback, near-identical warning text; only the log
sink differed. The CLI had **neither** copy: `initPlatform.ts` opened
`workspaceTexraConfigPath(cwd)` unguarded.

`JsonStore.open()` only reads, so a *missing* file was already an empty store.
But a **malformed or unreadable** `.texra/config.json` threw straight out of CLI
initialization — so every `texra` command hard-failed on the one host that has no
settings UI to fix the file with. An **unwritable** project directory failed later,
on the first command that persisted configuration. The GUI hosts degraded both
cases to the internal workspace store; the CLI degraded neither.

`openTexraConfigStores(storage, workspaceRoot, warn)` in
`src/platform/defaults/nodeStores.ts` now owns the rule once, with three call
sites. The degradation is loud, never silent: the host-supplied `warn` sink
carries the cause (`log.warn` in the extension, `console.warn('[desktop] …')` in
Electron, `[warn] [cli.config]` on stderr in the CLI). Folding the desktop copy
in also retired its hard-coded `'config.json'` literal in favour of
`TEXRA_CONFIG_FILE_NAME`.

Then, on the same plane:

- **C15** — desktop re-derived `join(storage.getStoragePath(), 'state.json')`
  that `createCliStateStores` already owned, and in production both hosts write
  the *same* `~/.texra/workspace-storage/<id>/state.json`. Now
  `openNodeWorkspaceStateStore(storage)`, two callers. The *global*-state path
  divergence is untouched — that is §3 V1, a ruling with a data migration.
- **C5** — `MemoryConfigProvider` restated `JsonConfigProvider`'s entire
  layered-resolution rule (workspace shadows global → `getCoreSettingDefault` →
  caller default) byte for byte; only the store accessor differed.
  `JsonConfigProvider` now reads through a three-method `ConfigStore` surface
  that both a `JsonStore` and a `Map` satisfy, and `MemoryConfigProvider` *is*
  that provider over in-memory stores.
- **C7** — the extension re-implemented two shared bootstrap helpers by
  admission. `copyDefaultAgents` duplicated `bootstrapNodeAgentDirectories`
  minus the re-entry guard, and the runtime-skills block carried a comment
  saying it was inlined so the extension bundle would not also pull the Lean
  direct-adapter import that `nodeHost.ts` carried. That blocker was a
  module-boundary artifact: `initNodeAgentRuntime` — the only Lean importer —
  moved to `nodeAgentRuntime.ts`, `nodeHost.ts` became Lean-free, and both
  inline copies died.
- **C8** — three near-identical `Platform` literals became one
  `createNodePlatform` call each.

**C6 (secrets) is refuted, not deferred** — see "Duplication and abstraction
budget".

## Issue acceptance gates

Rows C4/V10, C5, C7, C8, C15 of
`docs/proposals/2026-08-15-cross-host-consolidation.md` §2c. Re-verified at HEAD;
two §2c citations were stale and are corrected here:

- §2c cites `nodeHost.ts` at a path that has moved — the module is
  `src/platform/defaults/nodeHost.ts`, not `src/hosts/`.
- C5 lists `watch` among the duplicated members. Neither provider has a `watch`
  method; the real overlap is `get` / `inspect` / `isExplicitlySet`.

C6 is deliberately not landed (below). C14 is out of scope for this PR.

## Single source of truth

| Fact | Owner now |
| --- | --- |
| Which store backs the workspace config target, and when the project file is unusable | `openTexraWorkspaceConfigStore` (`src/platform/defaults/nodeStores.ts`) |
| Where global config lives | `openTexraConfigStores`, same module |
| Where workspace state lives | `openNodeWorkspaceStateStore`, same module |
| Layered config resolution (workspace → global → schema default → caller default) | `JsonConfigProvider` (`MemoryConfigProvider` is now an instance of it, not a peer) |
| The `Platform` skeleton a Node-family host assembles | `createNodePlatform` (`src/platform/defaults/nodeHost.ts`) |
| Bundled-agent reconciliation, incl. its failure policy | `bootstrapPlatformAgentDirectories` / `bootstrapNodeAgentDirectories` |
| Runtime skill-source precedence | `initializeNodeRuntimeSkills` |
| Direct Lean language-service registration | `initNodeAgentRuntime` (`src/platform/defaults/nodeAgentRuntime.ts`) |

## Duplication and abstraction budget

Removed: two hand-rolled `canCreateOrWrite` walk-ups → one; two project-config
selection blocks → one (and the CLI, which had zero, now shares it); two
workspace-state path derivations → one; one drifted `'config.json'` literal;
`MemoryConfigProvider`'s three duplicated resolution methods; `copyDefaultAgents`;
the extension's inlined `setRuntimeSkillSources(defaultSkillSources(…))`; two
hand-assembled `Platform` literals.

New names, each meeting the §5b bar (a name is legitimate only when the same
change deletes ≥2 hand-rolled equivalents):

- `openTexraConfigStores` / `openTexraWorkspaceConfigStore` — deletes the
  extension's and desktop's copies of the selection walk-up.
- `openNodeWorkspaceStateStore` — deletes the CLI's and desktop's copies of the
  path derivation.
- `ConfigStore` — the seam that lets one provider replace two.
- `nodeAgentRuntime.ts` is a *file split*, not a new layer: the function moved
  verbatim so `nodeHost.ts` could stop dragging the Lean adapter into every
  importer. That deleted two inline copies in `extension.ts`.

`createNodePlatform`'s config input widened to *stores-or-provider*. Widening the
declared type of `configStores` would not have been enough: the factory
unconditionally constructed a `JsonConfigProvider`, while the SDK deliberately
supplies a `MemoryConfigProvider`, so the SDK's process-local semantics only
survive if the factory can take an already-constructed provider. `packages/agent`'s
exported signature is unchanged — `nodePlatform(options): Platform` — and its
build validates the identical 716 declarations.

**Rider (review-caught) honoured.** `copyDefaultAgents` *caught* reconciliation
errors so VS Code activation survived an unreadable agent directory, while the
shared `bootstrapPlatformAgentDirectories` *propagated*. The shared helper gained
catch-and-report (`log.error` with the cause) **before** the extension copy was
deleted, so a broken agent dir still cannot fail activation — and desktop and CLI
startup gain the same survival, which they did not have.

**C6 (secrets) refuted, not landed.** The review had already refuted its headline
bug (Electron's "missing PQueue" is not a race: `JsonStore.set()` synchronously
enqueues flushes into a module-wide per-path `PQueue` and the flush takes a
cross-process file lock; the CLI needs its outer queue only because it re-opens a
fresh store per mutation). What remains does not clear the net-≤0 bar this
§5b-FLAGGED extraction was conditioned on. Re-measured at HEAD: the genuinely
shared code between `CliSecrets` and `ElectronSecrets` is four trivial lines
(`get` = env ?? stored, `delete`, `listStoredKeys`, `getEnv`), while `getStored`
and `set` diverge completely (Electron carries a keychain-disabled shim, a
decrypt-failure latch, a `safeStorage` mode machine, and a warn-once dialog). A
`JsonStoreSecrets` base would have to abstract the store accessor as well, since
the CLI re-opens per operation and Electron holds one. `withEnvOverride(store)`
would wrap 1–3 lines per site across three real sites (the fourth,
`packages/agent`'s `environmentSecrets`, has no store at all) and would hide the
env-priority rule behind an indirection. Both come out net-positive. Not landed.

Platform ports were not touched — 14 ports / ~49 methods remain a never-collapse
fence row.

## Net elements (R6)

- **Files:** 17 changed, +2 added (`src/platform/defaults/nodeStores.ts`,
  `src/platform/defaults/nodeAgentRuntime.ts`), 0 deleted.
- **Exported symbols** (`^[+-]export` over the diff): +7 / −3. Two of the seven
  are relocations, not additions (`initNodeAgentRuntime` moved file;
  `MemoryConfigProvider` re-declared as a subclass). Net *new* exports: **+5**
  (`ConfigStore`, `openTexraConfigStores`, `openTexraWorkspaceConfigStore`,
  `openNodeWorkspaceStateStore`, and the moved `initNodeAgentRuntime`);
  net *deleted*: **−1** (`copyDefaultAgents`).
- **Classes/interfaces:** +1 interface (`ConfigStore`), +1 private class
  (`MemoryConfigStore`), −0 classes; `MemoryConfigProvider` went from a full
  `ConfigProvider` implementation (57 L) to a 3-line subclass.
- **Net LoC:** +416 / −380 = **+36** overall; **+5 in production code**, +31 in
  tests. The production figure is flat because ~110 of the added lines are the
  doc comments on the two new modules that replace the comments deleted from the
  four call sites; the win here is element count (nine duplicated
  implementations removed, one missing degradation path added), not line count.
- **Ratchet:** `config/ratchets/host-agent-import-baseline.json` **shrinks by
  one** — deleting the extension's `copyDefaultAgents` removed its last
  `@agent/index/AgentDirectorySync` import, and `hostAgentDeepImportRatchet`'s
  stale-headroom check required the baseline entry to go.

## Consumer counts (R8)

| Symbol | Consumers before → after |
| --- | --- |
| `copyDefaultAgents` | 1 (`extension.ts`) → 0, deleted; re-routed to `bootstrapNodeAgentDirectories` |
| `initNodeAgentRuntime` | 3 (`cli/runtime/initPlatform.ts`, `desktop/main/platform/index.ts`, `packages/agent/src/index.ts`) → same 3, new module path |
| `createNodePlatform` | 2 (CLI, desktop) → 4 (+ extension, + `packages/agent/src/node.ts`) |
| `initializeNodeRuntimeSkills` | 2 (CLI, desktop) → 3 (+ extension) |
| `bootstrapNodeAgentDirectories` | 2 (CLI, desktop) → 3 (+ extension) |
| `MemoryConfigProvider` | 1 (`packages/agent/src/node.ts`) → 1, unchanged construction |
| `openTexraConfigStores` | new → 3 (extension, desktop, CLI) |
| `openTexraWorkspaceConfigStore` | new → 2 (`openTexraConfigStores`, the extension's workspace transition) |
| `openNodeWorkspaceStateStore` | new → 2 (desktop, `createCliStateStores`) |

No emit path or event key was added, removed, or re-routed.

## Host impact

**Extension:** no user-visible change to config selection (it already had the
guard). Its `Platform` literal, its inlined skills wiring, and `copyDefaultAgents`
are gone in favour of the shared helpers; the bundle still does not pull the Lean
direct adapter, which is what the file split existed to preserve.
`bootstrapNodeAgentDirectories` supplies the re-entry guard the extension copy
lacked, and the shared reconciliation now catches failures the way the deleted
copy did, so activation survives a broken agent directory exactly as before.

**Desktop:** same config selection, now from the shared helper; the hard-coded
`'config.json'` for the global store becomes `TEXRA_CONFIG_FILE_NAME` (same
filename, no migration). Bundled-agent reconciliation failures now warn instead
of rejecting startup. Global-state path untouched.

**CLI:** the fix. A malformed or unreadable `.texra/config.json` no longer aborts
`texra`; it warns on stderr with the cause and degrades to the internal workspace
store, as the GUI hosts always did. An unwritable project directory likewise
degrades instead of failing the first command that persists a setting. No change
when the project config is present and well-formed.

## Scheduled refactoring

C6 is refuted above and should be struck from §2c rather than re-queued. C14
(`registerCoreShutdownHandlers`) remains open on this plane and is not addressed
here.

## Validation

- `npm run typecheck` — clean.
- `FORCE_COLOR=0 npx vitest run src/test-kernel/architecture src/test-kernel/cli
  src/test-kernel/settings src/test-kernel/platform src/test-kernel/desktop
  src/test-kernel/frontend src/test-kernel/skills` — 279 files, 3469 passed,
  1 skipped, 0 failed.
- `npm run format:check` — clean.
- `NODE_OPTIONS=--max-old-space-size=8192 npx eslint <changed files>` — clean.
- `npm run check:dead-code-ratchet` — 8 current vs 8 baselined, no new findings.
- `npm run check:tsconfig-paths` — in sync.
- `packages/agent` `npm run build` — 716 declarations and 69 external packages
  validated (identical to `origin/main`), confirming the frozen SDK surface did
  not move.
- One new test, the regression pin for the C4 defect
  (`WorkspaceStorage.vitest.ts`: a malformed project config degrades to the
  internal store and warns with the cause). No other tests added; the obsolete
  `jsonStore` / `jsonConfigProvider` mocks in `CliInitPlatform.vitest.ts` were
  deleted rather than adapted.
- Pre-existing, not caused here: `DesktopAgentExecution.vitest.ts` has 3 failures
  when run as a single file in isolation. Reproduced identically on a clean
  `origin/main` worktree; passes in the full-suite run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
