### PR TITLE
refactor(session): give the status machine the run-start stamp and the roster its own elapsed

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -1227,7 +1227,7 @@ if (HARNESS_INITIAL_STREAM_STATUS) {
     streamId: STREAM_ID,
     status: HARNESS_INITIAL_STREAM_STATUS,
     // Backdated so the status bar shows a plausible elapsed time.
-    ...(HARNESS_RUN_ACTIVE ? { nowMs: Date.now() - 42_000 } : {}),
+    ...(HARNESS_RUN_ACTIVE ? { runStartedAt: Date.now() - 42_000 } : {}),
   });
 }
 
@@ -1436,7 +1436,6 @@ function seedRunningWorkflow(): void {
       identity: { kind: 'agent', agent: 'correct' },
       agentName: 'correct',
       childStreamId: firstAgentStreamId,
-      elapsed: '18s',
       workflowPhase: 'Proofread',
     },
     {
@@ -1444,7 +1443,6 @@ function seedRunningWorkflow(): void {
       identity: { kind: 'agent', agent: 'correct' },
       agentName: 'correct',
       childStreamId: secondAgentStreamId,
-      elapsed: '17s',
       workflowPhase: 'Proofread',
     },
   ] as const satisfies readonly ActiveChildInfo[];
@@ -1496,8 +1494,8 @@ function seedRunningProcessChild(): void {
 // in `attachSessionSignalsAdapter` wiring must be able to fail these
 // scenarios, matching the "PTY ordering tests" section of
 // docs/proposals/2026-07-10-cli-child-stream-state-consolidation.md.
-// No `startedAt` is set on the roster row, so `childElapsed` returns the
-// static `elapsed` string instead of a live-ticking duration
+// No `startedAt` is set on the roster row, so `childElapsed` reports no
+// duration at all rather than a live-ticking one
 // (packages/cli/src/chat/tui/state/childControls.ts); `setActiveStream`
 // always sets `suppressViewSwitch: true` so the harness's own active/focused
 // stream (and its live wall-clock `runStartedAt` elapsed display) stays on
@@ -1525,7 +1523,6 @@ function childEventOrderRosterRow(): ActiveChildInfo {
     identity: { kind: 'agent', agent: CHILD_EVENT_ORDER_AGENT_NAME },
     agentName: CHILD_EVENT_ORDER_AGENT_NAME,
     childStreamId: CHILD_EVENT_ORDER_STREAM_ID,
-    elapsed: '1m 4s',
   };
 }
 
@@ -1805,7 +1802,7 @@ if (SHOW_CHILDREN) {
       agentName: 'leanSolver',
       childStreamId: 'harness-child-lean-stream',
       status: STREAM_PHASE.WAITING,
-      elapsed: '2m 3s',
+      startedAt: startedAt - 123_000,
     },
     {
       executionId: 'harness-child-review',
@@ -1821,7 +1818,6 @@ if (SHOW_CHILDREN) {
           ...child,
           status: STREAM_PHASE.FAILED,
           startedAt: undefined,
-          elapsed: null,
         }
       : child,
   );
@@ -1839,7 +1835,10 @@ if (SHOW_CHILDREN) {
   setStreamStatusInCliState({
     streamId: STREAM_ID,
     status: STREAM_PHASE.RUNNING,
-    nowMs: startedAt,
+    // The status machine stamps a run window once and holds it across every
+    // later active phase, so a scenario that already seeded an initial RUNNING
+    // keeps that backdated start rather than restarting the clock here.
+    runStartedAt: streams.get().get(STREAM_ID)?.runStartedAt ?? startedAt,
   });
   for (const child of childStreams) {
     const streamId = child.childStreamId;
@@ -1862,7 +1861,7 @@ if (SHOW_CHILDREN) {
     setStreamStatusInCliState({
       streamId: streamId,
       status: child.status,
-      nowMs:
+      runStartedAt:
         child.status === STREAM_PHASE.RUNNING ? child.startedAt : undefined,
     });
   }
@@ -1886,7 +1885,7 @@ if (SHOW_CHILDREN) {
     setStreamStatusInCliState({
       streamId: 'harness-nested-local-checker-stream',
       status: STREAM_PHASE.RUNNING,
-      nowMs: nestedStartedAt,
+      runStartedAt: nestedStartedAt,
     });
   }
 }
@@ -2098,7 +2097,7 @@ function markHarnessInterrupted(): void {
   setStreamStatusInCliState({
     streamId: STREAM_ID,
     status: STREAM_PHASE.CANCELLED,
-    nowMs: undefined,
+    runStartedAt: undefined,
   });
   for (const streamId of childStreamIds) {
     defaultSession().status.transition(
@@ -2143,7 +2142,7 @@ function markHarnessStreamInterrupted(streamId: StreamTabId): void {
   setStreamStatusInCliState({
     streamId: streamId,
     status: STREAM_PHASE.CANCELLED,
-    nowMs: undefined,
+    runStartedAt: undefined,
   });
   defaultSession().status.transition(
     streamId,

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -6,6 +6,7 @@ import {
   type ActiveChildInfo,
   type StreamTabId,
 } from '@shared/schemas';
+import { childElapsedMs } from '@shared/streams/childElapsed';
 import { formatCompactDuration } from '@utils/core';
 
 // Local imports - CLI state
@@ -18,16 +19,18 @@ export interface ChildListTarget {
   readonly streamId: StreamTabId | undefined;
 }
 
+/** Compact elapsed reading for one child row, shown only while it is running:
+ *  a settled row's duration is reported by the task card that owns its
+ *  outcome, so repeating a frozen figure in the live list is noise. */
 export function childElapsed(
-  child: Pick<ActiveChildInfo, 'elapsed' | 'startedAt' | 'status'>,
+  child: Pick<ActiveChildInfo, 'startedAt' | 'finishedAt' | 'status'>,
   nowMs = Date.now(),
-): string | null | undefined {
-  const { startedAt, status } = child;
-  if (startedAt === undefined) return child.elapsed;
-  if (status !== undefined && status !== STREAM_PHASE.RUNNING) {
-    return child.elapsed;
+): string | undefined {
+  if (child.status !== undefined && child.status !== STREAM_PHASE.RUNNING) {
+    return undefined;
   }
-  return formatCompactDuration(nowMs - startedAt);
+  const elapsedMs = childElapsedMs(child, nowMs);
+  return elapsedMs === undefined ? undefined : formatCompactDuration(elapsedMs);
 }
 
 function hasChildListItems(

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -31,7 +31,6 @@ import type {
   CompactionActivityBlock,
   CompactionActivityProjection,
 } from '@shared/streams/compactionActivityProjection';
-import { isActivePhase } from '@shared/streams/streamStatus';
 import { isChildStreamRemoved } from './childExecutions';
 
 // ---------------------------------------------------------------------------
@@ -299,9 +298,10 @@ export interface StreamSlice {
   readonly workflowAttemptBoundaryDeclared: boolean;
   readonly status: StreamPhase | undefined;
   readonly substate?: StreamSubstate;
-  /** Epoch ms when this stream last entered `RUNNING`; cleared on any other
-   *  status. Drives the StatusBar's live elapsed-time segment so a long
-   *  token-less "thinking" turn still shows liveness. */
+  /** Run-window start mirrored verbatim from the `status` fact — the session
+   *  status machine stamps and clears it (`StreamPhaseState.runStartedAt`).
+   *  Drives the StatusBar's live elapsed-time segment so a long token-less
+   *  "thinking" turn still shows liveness. */
   readonly runStartedAt: number | undefined;
   /** CLI-only live status: the newest meaningful transcript line for this
    *  stream, recomputed on every log sync. Fills the stream-list summary slot
@@ -373,7 +373,7 @@ export function isCliStreamRetired(streamId: StreamTabId): boolean {
 }
 
 /** A stream slice minus the lifecycle triple. `status`, its `substate`, and
- *  the `runStartedAt` derived from them belong to
+ *  the `runStartedAt` the status machine stamps beside them belong to
  *  {@link setStreamStatusInCliState}, which is the only writer that enforces
  *  the removed/retired liveness rule. */
 type PatchableStreamSlice = Omit<
@@ -423,11 +423,8 @@ function streamSliceWithStatus(
   slice: StreamSlice,
   status: StreamPhase,
   substate: StreamSubstate | undefined,
-  nowMs: number,
+  runStartedAt: number | undefined,
 ): StreamSlice {
-  const runStartedAt = isActivePhase(status)
-    ? (slice.runStartedAt ?? nowMs)
-    : undefined;
   if (
     slice.status === status &&
     slice.substate === substate &&
@@ -450,12 +447,14 @@ function streamSliceWithStatus(
  * is ignored — removal is final for that stream identity.
  */
 export function setStreamStatusInCliState({
-  nowMs = Date.now(),
+  runStartedAt,
   status,
   substate,
   streamId,
 }: {
-  readonly nowMs?: number;
+  /** Run-window start stamped by the session status machine and carried on the
+   *  `status` fact; absent for any non-active phase. */
+  readonly runStartedAt?: number;
   readonly status: StreamPhase;
   readonly substate?: StreamSubstate;
   readonly streamId: StreamTabId;
@@ -469,7 +468,7 @@ export function setStreamStatusInCliState({
     existingSlice ?? emptySlice(streamId),
     status,
     substate,
-    nowMs,
+    runStartedAt,
   );
   if (targetSlice === existingSlice) return true;
   const out = new Map(current);

--- a/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
+++ b/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
@@ -15,9 +15,7 @@ import {
   type GoalStatus,
   type InquiryThreadUpdatedEvent,
   type Plan,
-  type StreamPhase,
   type StreamStage,
-  type StreamSubstate,
   type StreamTabId,
   type TodoItem,
 } from '@shared/schemas';
@@ -111,24 +109,13 @@ class TuiSessionRenderer implements SessionRendererPort {
     assertNever(slice, 'Unhandled session render slice');
   }
 
-  onStreamStatusChanged(
-    streamId: StreamTabId,
-    status: StreamPhase,
-    _logHead: number,
-    lastTimestamp?: number,
-    substate?: StreamSubstate,
-  ): void {
-    setStreamStatusInCliState({
-      streamId,
-      status,
-      substate,
-      // Use the backend's last-known timestamp for the stream (from its log
-      // entries) rather than Date.now() at render time, so `runStartedAt`
-      // reflects a backend timestamp instead of when the TUI received it.
-      ...(lastTimestamp !== undefined ? { nowMs: lastTimestamp } : {}),
-    });
-    // Roster rows carry phase (`recordChildPhase`); re-derive snapshots so
-    // child rows repaint on phase flips.
+  onStreamStatusChanged(): void {
+    // The slice already carries this transition: the CLI writes it from the
+    // `status` fact before handing the fact to the applier, and the fact
+    // carries the status machine's own `runStartedAt`, so there is nothing
+    // left for this callback to re-apply. Roster rows carry phase
+    // (`recordChildPhase`); re-derive snapshots so child rows repaint on
+    // phase flips.
     invalidateChildStreams();
   }
 
@@ -257,6 +244,7 @@ export function attachSessionSignalsAdapter({
         streamId: fact.streamId,
         status: fact.phase,
         substate: fact.substate,
+        runStartedAt: fact.runStartedAt,
       });
       if (recognized) {
         syncStreamLog(

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -40,13 +40,18 @@ import {
   type InquiryThreadUpdatedEvent,
 } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
+import { childElapsedMs } from '@shared/streams/childElapsed';
 import {
   formatPhaseStageLabel,
   formatStreamStatusLabel,
 } from '@shared/streams/streamStatusDisplay';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
+import { formatDuration } from '@utils/core';
 import { ProgressEvents } from '../events';
+
+// Side-effect import to register <tool-timer> custom element
+import '@progressView/frontend/components/ToolTimer';
 
 // Local imports - contexts
 import {
@@ -474,11 +479,7 @@ export class BackgroundTasksPanel extends LitElement {
                 >`
             : nothing
         }
-        ${
-          child.elapsed
-            ? html`<span class="task-elapsed">(${child.elapsed})</span>`
-            : nothing
-        }
+        ${renderChildElapsed(child)}
         <wa-badge
           class="task-status"
           variant=${badge.variant}
@@ -520,6 +521,27 @@ function renderSectionDetails(options: {
       ${options.content}
     </wa-details>
   `;
+}
+
+/**
+ * Elapsed reading for one roster row, derived from the row's own timestamps —
+ * the roster carries no rendered duration. A live row hands its start stamp to
+ * the shared `<tool-timer>`, which owns the tick; a retained row's window is
+ * closed by `finishedAt`, so its reading is fixed and needs no clock read.
+ */
+function renderChildElapsed(
+  child: ActiveChildInfo,
+): TemplateResult | typeof nothing {
+  if (child.startedAt === undefined) return nothing;
+  if (child.finishedAt === undefined) {
+    return html`<span class="task-elapsed"
+      >(<tool-timer .startTime=${child.startedAt}></tool-timer>)</span
+    >`;
+  }
+  const elapsedMs = childElapsedMs(child, child.finishedAt);
+  return elapsedMs === undefined
+    ? nothing
+    : html`<span class="task-elapsed">(${formatDuration(elapsedMs)})</span>`;
 }
 
 /** Pick the appropriate wa-icon name for a background task item. */

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -38,7 +38,8 @@ import { isKnownUnsupported } from '@shared/utils/dispatcher';
 import { renderIconActionButtonParts } from '@shared/wa/actionButtons';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
-// Side-effect imports - register WA icon component
+// Side-effect imports - register WA icon component and <tool-timer>
+import '@progressView/frontend/components/ToolTimer';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 import '@awesome.me/webawesome/dist/components/button-group/button-group.js';
@@ -531,6 +532,7 @@ export class StreamHeader extends UnsupportedCommandsMixin(LitElement) {
           <wa-tooltip for=${ELEMENT_IDS.STATUS_INDICATOR}>
             ${statusLabel}
           </wa-tooltip>
+          ${this.renderRunElapsed(state?.runStartedAt)}
           ${this.renderGoalChip(goalActive, goalStatus, goalObjective)}
           ${this.renderProgressBadge(progress, stage)}
         </div>
@@ -605,6 +607,22 @@ export class StreamHeader extends UnsupportedCommandsMixin(LitElement) {
         ${waIcon('compass')} ${label}
       </wa-badge>
       <wa-tooltip for=${ELEMENT_IDS.GOAL_CHIP}>${tooltip}</wa-tooltip>`;
+  }
+
+  /**
+   * Live elapsed time for the run in progress. `runStartedAt` is stamped and
+   * cleared by the session status machine, so its mere presence is the "a run
+   * is active" signal — the header neither re-derives it from the phase nor
+   * keeps a clock of its own; `<tool-timer>` owns the tick.
+   */
+  private renderRunElapsed(
+    runStartedAt: number | undefined,
+  ): TemplateResult | typeof nothing {
+    if (runStartedAt === undefined) return nothing;
+    return html`<tool-timer
+      id=${ELEMENT_IDS.RUN_ELAPSED}
+      .startTime=${runStartedAt}
+    ></tool-timer>`;
   }
 
   private renderProgressBadge(

--- a/packages/extension/src/progressView/frontend/constants.ts
+++ b/packages/extension/src/progressView/frontend/constants.ts
@@ -39,6 +39,7 @@ export const ELEMENT_IDS = {
   STATUS_INDICATOR: 'statusIndicator',
   GOAL_CHIP: 'goalChip',
   PROGRESS_BADGE: 'progressBadge',
+  RUN_ELAPSED: 'runElapsed',
   RUN_SUMMARY: 'runSummary',
   CONTEXT_STATE: 'contextState',
   TODO_LIST_CONTAINER: 'todoListContainer',

--- a/src/agent/core/flows/postCompactionContext.ts
+++ b/src/agent/core/flows/postCompactionContext.ts
@@ -9,7 +9,9 @@ import type {
   TodoItem,
   WorkPlanSnapshot,
 } from '@shared/schemas';
+import { childElapsedMs } from '@shared/streams/childElapsed';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
+import { formatDuration } from '@utils/core';
 
 /**
  * Format active execution state as context for the agent after compaction.
@@ -50,9 +52,11 @@ export function formatPostCompactionContext(
     lines.push(`<active-subagents count="${subagents.length}">`);
     for (const sa of subagents) {
       const statusAttr = sa.status ? ` status="${escapeAttr(sa.status)}"` : '';
-      const elapsedAttr = sa.elapsed
-        ? ` elapsed="${escapeAttr(sa.elapsed)}"`
-        : '';
+      const elapsedMs = childElapsedMs(sa, Date.now());
+      const elapsedAttr =
+        elapsedMs === undefined
+          ? ''
+          : ` elapsed="${escapeAttr(formatDuration(elapsedMs))}"`;
       lines.push(
         `  <subagent id="${escapeAttr(sa.executionId)}" agent="${escapeAttr(sa.agentName)}"${statusAttr}${elapsedAttr} />`,
       );

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -33,6 +33,13 @@ type TerminalTransitionCause = Extract<
 export interface StreamPhaseState {
   readonly phase: StreamPhase;
   readonly substate?: StreamSubstate;
+  /**
+   * Epoch ms when the stream entered its current active phase, held across
+   * substate changes and cleared the moment the phase stops being active.
+   * The one owner of "when did this run start" — hosts render elapsed time
+   * from it instead of each stamping a clock read of their own.
+   */
+  readonly runStartedAt?: number;
 }
 
 /**
@@ -43,15 +50,20 @@ export interface StreamPhaseState {
  */
 type StreamEntry =
   | { readonly kind: 'phase'; readonly state: StreamPhaseState }
-  | { readonly kind: 'reserved'; readonly rollbackTo?: StreamPhaseState };
-
-const RESERVED_STATE: StreamPhaseState = Object.freeze({
-  phase: STREAM_PHASE.RUNNING,
-  substate: STREAM_SUBSTATE.STARTING,
-});
+  | {
+      readonly kind: 'reserved';
+      readonly runStartedAt: number;
+      readonly rollbackTo?: StreamPhaseState;
+    };
 
 function effectiveState(entry: StreamEntry): StreamPhaseState {
-  return entry.kind === 'reserved' ? RESERVED_STATE : entry.state;
+  return entry.kind === 'reserved'
+    ? {
+        phase: STREAM_PHASE.RUNNING,
+        substate: STREAM_SUBSTATE.STARTING,
+        runStartedAt: entry.runStartedAt,
+      }
+    : entry.state;
 }
 
 export class StreamStatusMachine {
@@ -99,8 +111,12 @@ export class StreamStatusMachine {
     if (!canAcquireStreamReservation(previousPhase)) {
       return false;
     }
+    // A reservation is only acquirable from a non-active phase, so it always
+    // opens a fresh run window rather than extending an earlier one.
+    const runStartedAt = Date.now();
     this.streams.set(stream, {
       kind: 'reserved',
+      runStartedAt,
       ...(entry ? { rollbackTo: entry.state } : {}),
     });
     this.publishStatus(stream, STREAM_PHASE.RUNNING, {
@@ -108,6 +124,7 @@ export class StreamStatusMachine {
       cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
       ...(previousPhase ? { previousPhase } : {}),
       substate: STREAM_SUBSTATE.STARTING,
+      runStartedAt,
     });
     return true;
   }
@@ -169,11 +186,22 @@ export class StreamStatusMachine {
     ) {
       return true;
     }
+    // The run window opens on the first active phase and survives every
+    // substate change and active→active transition after it; anything that is
+    // not an active phase closes it. Stamped here because this is the only
+    // writer of the phase it derives from.
+    const previousRunStartedAt = fromReservation
+      ? entry.runStartedAt
+      : previousState?.runStartedAt;
+    const runStartedAt = isActivePhase(to)
+      ? (previousRunStartedAt ?? Date.now())
+      : undefined;
     this.streams.set(stream, {
       kind: 'phase',
       state: {
         phase: to,
         ...(options.substate ? { substate: options.substate } : {}),
+        ...(runStartedAt !== undefined ? { runStartedAt } : {}),
       },
     });
     const previousPhase = fromReservation ? STREAM_PHASE.RUNNING : from;
@@ -181,6 +209,7 @@ export class StreamStatusMachine {
       ...options,
       cause,
       ...(previousPhase ? { previousPhase } : {}),
+      ...(runStartedAt !== undefined ? { runStartedAt } : {}),
     });
     return true;
   }
@@ -286,6 +315,7 @@ export class StreamStatusMachine {
     options: StreamStatusEmitOptions & {
       cause: StreamTransitionCause;
       previousPhase?: StreamPhase;
+      runStartedAt?: number;
     },
   ): void {
     const event: StatusEvent = {
@@ -297,6 +327,9 @@ export class StreamStatusMachine {
         ? { previousPhase: options.previousPhase }
         : {}),
       ...(options.substate ? { substate: options.substate } : {}),
+      ...(options.runStartedAt !== undefined
+        ? { runStartedAt: options.runStartedAt }
+        : {}),
     };
     this.eventHub.emit({
       scope: 'session',

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -696,7 +696,7 @@ export class ExecutionRegistry {
     const result: ActiveChildInfo[] = [];
     for (const handle of this.handles.values()) {
       if (!isChildExecution(handle, parentStreamId)) continue;
-      const { status, elapsed } = this.getStatus(handle);
+      const { status } = this.getStatus(handle);
       result.push({
         executionId: handle.executionId,
         identity: handle.identity,
@@ -706,7 +706,6 @@ export class ExecutionRegistry {
         agentName: handle.agentName,
         status,
         startedAt: handle.startedAt,
-        elapsed,
         childStreamId: handle.childStreamId,
         ...(handle.workflowPhase
           ? { workflowPhase: handle.workflowPhase }

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -179,6 +179,14 @@ export interface StatusEvent extends StageStamp {
   readonly previousPhase?: StreamPhase;
   readonly cause: StreamTransitionCause;
   readonly substate?: StreamSubstate;
+  /**
+   * Epoch ms when this stream entered its current active phase, stamped by the
+   * status machine and held across substate changes; absent once the phase is
+   * no longer active. Travelling with the transition is what lets every host
+   * show the same run start instead of each deriving one from its own clock at
+   * the moment it happened to observe the fact.
+   */
+  readonly runStartedAt?: number;
 }
 
 /** Session-owned subagent activity for a parent run stream. */

--- a/src/controllers/progressView/backend/LitSessionRenderer.ts
+++ b/src/controllers/progressView/backend/LitSessionRenderer.ts
@@ -484,6 +484,7 @@ export class LitSessionRenderer implements SessionRendererPort {
       category: streamInfo.agentCategory,
       status: status?.phase,
       substate: status?.substate,
+      runStartedAt: status?.runStartedAt,
       userFollowUpSupport: streamInfo.userFollowUpSupport,
       lastTimestamp: this.state.streamLogs.getTimestampRange(streamInfo.name)
         .last,

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -353,6 +353,7 @@ export class SessionFactApplier {
               fact.phase,
               fact.previousPhase,
               fact.substate,
+              fact.runStartedAt,
             );
           case 'setParentStream':
             return this.handleSetParentStream(fact.payload);
@@ -794,6 +795,7 @@ export class SessionFactApplier {
     status: StreamPhase,
     previousPhase?: StreamPhase,
     substate?: StreamSubstate,
+    runStartedAt?: number,
   ): Promise<void> {
     // A status for a removed stream is stale: removal is final, so the
     // transition must not re-mint the transcript or execution state the
@@ -868,6 +870,7 @@ export class SessionFactApplier {
           streamId,
           status,
           substate,
+          runStartedAt,
         ),
       });
     } else {
@@ -897,12 +900,14 @@ export class SessionFactApplier {
     streamId: StreamTabId,
     status: StreamPhase,
     substate?: StreamSubstate,
+    runStartedAt?: number,
   ): Map<StreamTabId, StreamPhaseState> {
     const statesForRefresh = this.state.streamStatus.getAllStreamStates();
-    statesForRefresh.set(
-      streamId,
-      substate ? { phase: status, substate } : { phase: status },
-    );
+    statesForRefresh.set(streamId, {
+      phase: status,
+      ...(substate ? { substate } : {}),
+      ...(runStartedAt !== undefined ? { runStartedAt } : {}),
+    });
     return statesForRefresh;
   }
 }

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -48,8 +48,6 @@ export const ActiveChildInfoSchema = z.object({
    * drop, so it must never be used to decide list membership.
    */
   finishedAt: z.int().positive().optional(),
-  /** Formatted elapsed time (e.g. "1m 23s"). */
-  elapsed: z.string().nullish(),
   /**
    * Workflow-script phase that owns this child, when its parent is a
    * workflow-script run. This is the only join key between a grandchild's
@@ -129,6 +127,13 @@ export const DEFAULT_STREAM_METADATA_STATUS = STREAM_STATUS.READY;
 export const BackendOwnedFieldsSchema = z.object({
   status: StreamLifecycleStatusSchema.prefault(DEFAULT_STREAM_METADATA_STATUS),
   substate: StreamSubstateSchema.optional(),
+  /**
+   * Epoch ms when the stream entered its current active phase, stamped once by
+   * the session status machine (`StreamPhaseState.runStartedAt`). Absent while
+   * the phase is not active. Every host renders elapsed time from this one
+   * value; the tick rate and duration format stay host modality.
+   */
+  runStartedAt: z.int().positive().optional(),
   /** Runtime behavior declared by the launch source, not UI visibility. */
   userFollowUpSupport: UserFollowUpSupportSchema.optional(),
   lastTimestamp: z.number().optional(),

--- a/src/shared/streams/childElapsed.ts
+++ b/src/shared/streams/childElapsed.ts
@@ -1,0 +1,27 @@
+// Host-neutral "how long has this child run" derivation over a roster row.
+//
+// The roster carries timestamps, never a rendered duration: `startedAt` opens
+// the window and `finishedAt` closes it, so every surface answers elapsed time
+// from the same two numbers and differs only in how it formats and how often
+// it re-reads the clock. That is the whole point of this module — a formatted
+// string on the wire would make the emitter's clock read and format the
+// authority for readers that tick at their own rate.
+//
+// NO host imports here: a pure function over plain values.
+
+import type { ActiveChildInfo } from '@shared/schemas';
+
+/**
+ * Elapsed run duration in ms for one roster row, or `undefined` when the row
+ * carries no start stamp (legacy rows and hand-built fixtures). A retained
+ * (finished) row measures to its `finishedAt` retention stamp so its reading
+ * stops moving; a live row measures to `nowMs`.
+ */
+export function childElapsedMs(
+  child: Pick<ActiveChildInfo, 'startedAt' | 'finishedAt'>,
+  nowMs: number,
+): number | undefined {
+  const { startedAt, finishedAt } = child;
+  if (startedAt === undefined) return undefined;
+  return Math.max(0, (finishedAt ?? nowMs) - startedAt);
+}

--- a/src/shared/streams/streamMetadata.ts
+++ b/src/shared/streams/streamMetadata.ts
@@ -35,6 +35,7 @@ export function buildStreamMetadata(
       stage: inputs.stage ?? null,
     }),
     substate: inputs.substate,
+    runStartedAt: inputs.runStartedAt,
     userFollowUpSupport: inputs.userFollowUpSupport,
     lastTimestamp: inputs.lastTimestamp,
     category: inputs.category,

--- a/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
+++ b/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
@@ -100,6 +100,7 @@ describe('StreamStatusMachine', () => {
     expect(machine.getAllStreamStates().get(streamId)).toEqual({
       phase: STREAM_PHASE.RUNNING,
       substate: STREAM_SUBSTATE.STARTING,
+      runStartedAt: expect.any(Number),
     });
     expect(machine.tryAcquire(streamId)).toBe(false);
 
@@ -133,6 +134,7 @@ describe('StreamStatusMachine', () => {
         phase: STREAM_PHASE.RUNNING,
         previousPhase: STREAM_PHASE.CANCELLED,
         cause: 'resume',
+        runStartedAt: expect.any(Number),
       },
       {
         streamId,
@@ -166,6 +168,7 @@ describe('StreamStatusMachine', () => {
         phase: STREAM_PHASE.RUNNING,
         previousPhase: STREAM_PHASE.WAITING,
         cause: 'resume',
+        runStartedAt: expect.any(Number),
       },
       {
         streamId,
@@ -197,6 +200,7 @@ describe('StreamStatusMachine', () => {
         type: 'status',
         phase: STREAM_PHASE.RUNNING,
         cause: 'lifecycle',
+        runStartedAt: expect.any(Number),
       },
       {
         streamId,
@@ -252,6 +256,7 @@ describe('StreamStatusMachine', () => {
         phase: STREAM_PHASE.RUNNING,
         previousPhase: STREAM_PHASE.RUNNING,
         cause: 'resume',
+        runStartedAt: expect.any(Number),
       },
     ]);
   });
@@ -311,6 +316,7 @@ describe('StreamStatusMachine', () => {
         phase: STREAM_PHASE.RUNNING,
         cause: 'lifecycle',
         substate: STREAM_SUBSTATE.STARTING,
+        runStartedAt: expect.any(Number),
       },
       {
         streamId,
@@ -383,12 +389,14 @@ describe('StreamStatusMachine', () => {
         previousPhase: STREAM_PHASE.WAITING,
         cause: 'resume',
         substate: STREAM_SUBSTATE.RESUMING,
+        runStartedAt: expect.any(Number),
       },
     ]);
     expect(Object.keys(payloads[0] ?? {}).toSorted()).toEqual([
       'cause',
       'phase',
       'previousPhase',
+      'runStartedAt',
       'streamId',
       'substate',
       'type',

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -77,11 +77,16 @@ const WITHIN_CHORD_WINDOW_MS = Math.max(
 );
 const CHORD_WINDOW_EXPIRED_MS = ESC_META_CHORD_INTERRUPT_DELAY_MS + 100;
 
+// The status machine stamps a run window on every RUNNING transition and the
+// slice mirrors it verbatim, so a seeded RUNNING must state one too — the
+// status bar's live elapsed segment (and the 1 Hz repaint that drives these
+// layout assertions) exists only while it is set.
 function setRunning(...streamIds: StreamTabId[]): void {
   for (const streamId of streamIds) {
     setStreamStatusInCliState({
       streamId,
       status: STREAM_PHASE.RUNNING,
+      runStartedAt: Date.now(),
     });
   }
 }

--- a/src/test-kernel/cli/ChildControls.vitest.ts
+++ b/src/test-kernel/cli/ChildControls.vitest.ts
@@ -55,22 +55,11 @@ function streamMap(
 describe('CLI child controls', () => {
   it('updates live elapsed time only for running children', () => {
     expect(
-      childElapsed(
-        {
-          startedAt: 1_000,
-          status: STREAM_PHASE.RUNNING,
-          elapsed: undefined,
-        },
-        63_000,
-      ),
+      childElapsed({ startedAt: 1_000, status: STREAM_PHASE.RUNNING }, 63_000),
     ).toBe('1m 2s');
     expect(
-      childElapsed({
-        startedAt: 1_000,
-        status: STREAM_PHASE.COMPLETED,
-        elapsed: '9s',
-      }),
-    ).toBe('9s');
+      childElapsed({ startedAt: 1_000, status: STREAM_PHASE.COMPLETED }),
+    ).toBeUndefined();
   });
 
   it('resolves one child-list target and falls back to its immediate ancestor', () => {

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -891,7 +891,6 @@ describe('handleTuiSlashCommand', () => {
         agentName: 'critic',
         status: STREAM_PHASE.RUNNING,
         startedAt: 1,
-        elapsed: '1s',
         childStreamId,
       },
     ]);
@@ -943,7 +942,6 @@ describe('handleTuiSlashCommand', () => {
       agentName: `critic-${index}`,
       status,
       startedAt: index + 1,
-      elapsed: '1s',
       childStreamId,
     });
     seedChildRoster(rootStreamId, [
@@ -991,7 +989,6 @@ describe('handleTuiSlashCommand', () => {
         agentName: `critic-${index}`,
         status: index === 0 ? STREAM_PHASE.WAITING : STREAM_PHASE.COMPLETED,
         startedAt: index + 1,
-        elapsed: '1s',
         childStreamId,
       })),
     );
@@ -1024,7 +1021,6 @@ describe('handleTuiSlashCommand', () => {
         agentName: `critic-${index}`,
         status: STREAM_PHASE.RUNNING,
         startedAt: index + 1,
-        elapsed: '1s',
         childStreamId,
       })),
     );
@@ -1068,7 +1064,6 @@ describe('handleTuiSlashCommand', () => {
               ? STREAM_PHASE.RUNNING
               : STREAM_PHASE.WAITING,
           startedAt: index + 1,
-          elapsed: '1s',
           childStreamId,
         }),
       ),
@@ -1104,7 +1099,6 @@ describe('handleTuiSlashCommand', () => {
       agentName: `reviewer-${index}`,
       status: STREAM_PHASE.RUNNING,
       startedAt: index + 1,
-      elapsed: '1s',
       childStreamId,
     });
     seedChildRoster(

--- a/src/test-kernel/progressView/BackgroundTasksPanel.vitest.ts
+++ b/src/test-kernel/progressView/BackgroundTasksPanel.vitest.ts
@@ -38,7 +38,7 @@ function subagentRow(overrides: {
   childStreamId?: string;
   agentName?: string;
   status?: ActiveChildInfo['status'];
-  elapsed?: string;
+  startedAt?: number;
   finishedAt?: number;
   processTool?: string;
 }): ActiveChildInfo {
@@ -51,7 +51,7 @@ function subagentRow(overrides: {
       ? { kind: 'process', tool: overrides.processTool }
       : { kind: 'agent', agent: agentName },
     status: overrides.status ?? 'running',
-    elapsed: overrides.elapsed,
+    startedAt: overrides.startedAt,
     finishedAt: overrides.finishedAt,
   };
 }
@@ -103,13 +103,13 @@ describe('background-tasks-panel', () => {
 
   it('lists a retained finished subagent as a named row, not a count', async () => {
     const element = await mountPanel([
-      subagentRow({ executionId: 'exec-1', elapsed: '12s' }),
+      subagentRow({ executionId: 'exec-1', startedAt: 1_000 }),
       subagentRow({
         executionId: 'exec-2',
         agentName: 'polisher',
         status: 'completed',
-        elapsed: '1m 4s',
-        finishedAt: 1_000,
+        startedAt: 1_000,
+        finishedAt: 65_000,
       }),
     ]);
 

--- a/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
@@ -747,7 +747,6 @@ describe('ProgressBackend', () => {
       identity: { kind: 'agent' as const, agent: 'orchestrator' },
       status: 'running',
       startedAt: 1,
-      elapsed: null,
     };
     const inquiryThread = {
       threadId: 'ei_123456789abc',


### PR DESCRIPTION
## Summary

Two facts about a run's timing were computed by whichever host happened to need
them, so the hosts could not agree and one of them could not show the fact at
all. This PR gives each one a single owner in the substrate and deletes the host
copies.

**`runStartedAt`** was CLI-only. `streamSliceWithStatus` (`cliState.ts`) read a
clock on every status transition — `Date.now()`, or the stream log's last
timestamp when the applier's renderer callback supplied one — and folded the
result into `StreamSlice`. The webview had no run-start fact at all, and the
CLI's answer depended on when its own process observed the transition. It now
lives on `StreamPhaseState`, the session status machine's own record: stamped
when a stream enters an active phase, held across substate changes and
active→active transitions, cleared the moment the phase is no longer active. It
rides the canonical `status` fact and `BackendOwnedFieldsSchema`, so the
progress view gains a live elapsed segment in the stream header and the CLI
mirrors the value instead of deriving one.

**The child roster's `elapsed`** was the dual derivation audit C22 names.
`ExecutionRegistry` stamped a `formatDuration` string onto every
`ActiveChildInfo`; the webview rendered it verbatim while the CLI recomputed
from `startedAt` with a different formatter and a live tick. The roster now
carries timestamps only. `childElapsedMs` is the one derivation; format and
tick rate stay host modality. A retained row measures to its `finishedAt`,
which is exact — the stamped string froze at whatever the last active emission
read, which is why a finished row's figure was always slightly short.

### Refutations (verified at HEAD, not shipped)

- **D18, the CLI's dual exit teardown**
  (`docs/proposals/2026-08-16-define-out-of-existence.md` §1e) is **already
  landed** and needs no PR. #10800 replaced `exitNow` + the `exiting` re-entry
  guard with exactly the adjudicated shape: one cause-parameterized
  `beginTeardown(cause: ExitCause)` memoized through `teardownPromise ??=`
  (`sessionExitController.ts:312-385`). `exitNow` has no remaining occurrence in
  `packages/cli`. The load-bearing rider still holds — the signal arm does
  `ink.unmount()` + `cleanupTerminalModes()` + the resume hint synchronously
  before its first `await` (`:319-330`).
- **`plannedRounds` is not promotable to `SessionStreamConfigDetails`** without
  minting a second owner. The substrate already publishes planned rounds as
  `StreamStage.total`: `runReflectionFlow.ts:249` emits
  `total: computeRoundStageTotal(shared.totalRounds, roundIndex)` on
  `stage.start`, and `stage` is already on `BackendOwnedFieldsSchema`, so GUI
  hosts receive it. `runProgressRenderer`'s `config.plannedRounds` is a
  registry lookup (`getAgent(agent, Workflow)?.rounds`) filling the window
  before round 1 opens. Promoting it beside `StreamStage.total` is the same
  species as the `compactingActive` row the plan withdrew.
- **Run input files stop on the wire-vocabulary rule.** `SessionStreamConfigDetails`
  is written only by `SessionState.applySummaryMetadata` from
  `StreamSummaryMeta`, whose contract is "bounded scalars only" — an input-file
  list is neither, and it is persisted in every stream's always-resident
  `summary.json`. And landing it there closes nothing for the GUI on its own:
  `config` never reaches the webview, which sees the flattened
  `StreamTabInfoSchema` (`model`, `modelLabel`, `command`) — so the promotion
  additionally needs a new tab-info wire field. Per the stop rule, reported
  rather than invented.

## Issue acceptance gates

`docs/proposals/2026-08-15-single-substrate-hosts-as-renderers.md` §4, the
`runStartedAt` row: promoted to the substrate, host copy deleted, webview gains
the live elapsed source it did not have, and the `elapsed` dual derivation
(audit C22) collapses to one owner. The two rows the plan already withdrew
(`compactingActive`) or parked (`contextState`, `thinkingActive`) are untouched.

## Single source of truth

- **Run start**: `StreamPhaseState.runStartedAt`, owned by
  `StreamStatusMachine` (`src/agent/runtime/StreamStatusService.ts`) — the only
  writer of the phase it derives from. Published on `StatusEvent.runStartedAt`
  and `BackendOwnedFieldsSchema.runStartedAt`; every host reads, none stamps.
- **Child elapsed**: `childElapsedMs` (`src/shared/streams/childElapsed.ts`)
  over the roster row's own `startedAt`/`finishedAt`. No formatted duration on
  the roster wire.

## Duplication and abstraction budget

Removed: a per-host clock read for run start (CLI) plus the absence of one
(webview); a formatted-duration wire field with two divergent readers; and the
CLI's second write of every status transition — the applier's
`onStreamStatusChanged` callback re-applied a transition the fact path had
already written one call earlier in the same handler, and existed only to
supply the timestamp the machine now stamps.

Added: one 27-line pure module, `childElapsedMs`, with three consumers in this
PR. No pass-through layer, no new port, no new event channel; `runStartedAt`
extends the existing `status` fact rather than opening a rail.

## Net elements (R6)

- **Files**: 20 changed, 1 added (`src/shared/streams/childElapsed.ts`), 0
  removed.
- **Exported symbols** (`^[+-]export` over the diff): +1 (`childElapsedMs`),
  −0.
- **Classes / interfaces / enums**: 0 added, 0 removed. `StreamEntry`'s
  `reserved` arm gains a `runStartedAt` field and the `RESERVED_STATE` module
  constant is deleted (its value is now per-entry).
- **Wire/state fields**: +3 the same fact (`StreamPhaseState.runStartedAt`,
  `StatusEvent.runStartedAt`, `BackendOwnedFieldsSchema.runStartedAt`), −1
  (`ActiveChildInfoSchema.elapsed`). One `nowMs` parameter deleted from
  `setStreamStatusInCliState`, five parameters deleted from the CLI's
  `onStreamStatusChanged`.
- **Net LoC**: +197 / −102 across the diff; production-only, excluding the new
  module and its doc comment, is roughly net-flat — the additions are the one
  stamp site plus the webview render that closes the gap.

## Consumer counts (R8)

- **`ActiveChildInfo.elapsed` (deleted)** — grepped before deletion: 1 producer
  (`executionRegistry.getActiveChildren`, `executionRegistry.ts:692`), 2
  production readers (`BackgroundTasksPanel.ts:478`,
  `postCompactionContext.ts:53`). CLI readers: **0** — `childElapsed`'s
  `child.elapsed` fallbacks were unreachable, because its single production
  caller (`SubagentList.tsx:146`) passes `{ status, startedAt: slice.runStartedAt }`
  and never an `elapsed`. Both readers now derive through `childElapsedMs`.
  `ExecutionStatusInfo.elapsed` (`ExecutionHandle.ts:27`) is a different
  surface — tool-result status text with one producer and no second
  derivation — and is untouched.
- **`setStreamStatusInCliState` (one call site deleted)** — production callers
  before: 2, both in `sessionSignalsAdapter.ts` (the raw `status` fact
  subscription at `:254`, then the applier's renderer callback at `:119`, which
  fired for the same fact one call later). After: 1. Test callers: unchanged;
  `runStartedAt` is optional, so a fixture that omits it renders no elapsed
  segment exactly as a fixture that omitted `nowMs` did.
- **`SessionRendererPort.onStreamStatusChanged`** — 3 implementers
  (`LitSessionRenderer`, `TuiSessionRenderer`, the CLI headless port). The port
  signature is unchanged: the Lit renderer still consumes `logHead` and
  `lastTimestamp` for `UPDATE_STREAM_STATUS`. Only the CLI implementation's
  body shrinks to its roster invalidation.
- **`childElapsedMs` (new export)** — 3 consumers in this PR
  (`postCompactionContext.ts`, `BackgroundTasksPanel.ts`, `childControls.ts`).

## Host impact

Extension: gains a live elapsed segment in the stream header, driven by
`runStartedAt` through the existing `<tool-timer>`; a background-task row's
duration is now derived from its own timestamps, and a retained row reads
`finishedAt − startedAt` instead of the last figure the backend happened to
stamp while it was still active.

Desktop: same progress-view frontend, same gains.

CLI: no visible change. It stops reading a clock for `runStartedAt` and stops
re-applying every status transition a second time; the value it renders is now
the backend's transition stamp rather than the stream log's last entry
timestamp.

## Scheduled refactoring

None. The two §4 rows this PR could not take (`plannedRounds`, run input files)
are refuted above rather than deferred.

## Validation

- `npm run typecheck` — clean.
- `FORCE_COLOR=0 npx vitest run src/test-kernel/cli src/test-kernel/controllers
  src/test-kernel/architecture src/test-kernel/progressView
  src/test-kernel/shared` — the only failures are pre-existing on `origin/main`
  (`ResumeCommand`, `RunChatSignalOwnership` ×2, `TranscriptSessionPolicy`),
  confirmed by running the same files from a detached `origin/main` in this
  worktree; `AppEscapeRouting` / `RunExecution` failures appear only under full
  parallel load and pass in isolation on both revisions.
- `npm run format:check` — clean. `npx eslint` over the changed files — clean.
- `npm run check:dead-code-ratchet` — 8 findings vs 8 baselined, no new.
- `packages/cli` `node scripts/validate-tui.mjs` — baseline captured from a
  detached `origin/main` in this worktree (22/164 failing) and compared against
  the branch. Six scenarios differed; five re-ran green in isolation (the suite
  is load-flaky — two runs of identical branch code reported 23 and 28
  failures). The sixth, `subagents-with-todos-narrow-status`, was a real,
  deterministic delta and is fixed: the harness stamped the root run twice with
  different backdates, and the old CLI derivation happened to keep the first
  (`slice.runStartedAt ?? nowMs`) while the promoted value is taken verbatim.
  The harness now mirrors the status machine's own rule — stamp once, hold it
  across later active phases — so the frame is byte-identical again.

Obsolete test blocks were deleted rather than repaired: `childElapsed`'s
stamped-string assertion is gone with the branch it covered, and the
`elapsed:` roster fixtures across five suites and the TUI harness were dropped
with the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
