### PR TITLE
feat(desktop): wire the AppSignals the desktop was silently ignoring

### DIFF
--- a/packages/desktop/src/main/desktopProgressFileActions.ts
+++ b/packages/desktop/src/main/desktopProgressFileActions.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import { createLatexExecutionDiscovery } from '@agent/storage';
 import type { ValidatedExecutionRequest } from '@agent/core/state/executionRequests';
+import { appSignals } from '@eventBus/AppSignals';
 import { acceptEditedFileReplace } from '@latex/acceptedFileTarget';
 import { openFirstLabelMatch } from '@latex/labelSearch';
 import { LaTeXdiffService } from '@latex/latexdiff';
@@ -107,10 +108,10 @@ export class DesktopProgressFileActions {
         writeFile: (location, content) =>
           writeFile(location.absolutePath, content, 'utf8'),
         confirm: (message) => this.ui.confirmAcceptFile(message),
-        // The desktop main process has no `workspaceFilesWritten` subscriber
-        // (file decorations are a VS Code surface), so there is nothing to
-        // notify.
-        emitWritten: () => undefined,
+        emitWritten: (absolutePath) =>
+          appSignals.emit('workspaceFilesWritten', {
+            absolutePaths: [absolutePath],
+          }),
         showInfo: (message) => this.ui.showInfoMessage(message),
         deleteFile: async (location) => {
           try {

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -5,6 +5,7 @@ import {
   listGitHubSubscriptionEntries,
   unsubscribeGitHubKey,
 } from '@controllers/settingsView/githubSubscriptions';
+import { appSignals } from '@eventBus/AppSignals';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import type { ConfigProvider } from '@platform/interfaces';
 import { platform } from '@platform/platform';
@@ -26,6 +27,7 @@ import { buildSettingsSnapshotMessage } from '@shared/settingsView/handlers/sett
 import type { SettingsStores } from '@shared/config/settingsAccess';
 import type { SettingsStatePorts } from '@shared/settingsView/types';
 import { GoalStore, subscribeGoalStateChanges } from '@tools/goal';
+import { refreshToolAvailability } from '@tools/toolAvailability';
 import {
   GITHUB_TOKEN_CREATE_URL,
   GITHUB_TOKEN_STORAGE_KEY,
@@ -296,6 +298,14 @@ export function createDesktopSettingsIpc(
     });
   }
 
+  // Both writers below re-probe external tools: the GitHub token gates the
+  // `github_subscription` tool group, so without it the Tools tab keeps
+  // showing the group as unavailable until the user clicks Re-check. The
+  // extension gets this from `secrets.onDidChange`; the desktop has no
+  // secret-change event, but these two functions are the only places it
+  // writes the token, so the explicit calls cover the same ground.
+  // `refreshToolAvailability` emits `toolAvailabilityChanged`, which is what
+  // repaints the dashboard.
   async function setGitHubToken(): Promise<void> {
     const token = await options.ui.promptForSecret?.({
       title: 'GitHub token',
@@ -306,12 +316,14 @@ export function createDesktopSettingsIpc(
     await platform().secrets.set(GITHUB_TOKEN_STORAGE_KEY, token.trim());
     await options.ui.showInfoMessage('GitHub token saved.');
     await postGitHubTokenStatus();
+    await refreshToolAvailability();
   }
 
   async function removeGitHubToken(): Promise<void> {
     await platform().secrets.delete(GITHUB_TOKEN_STORAGE_KEY);
     await options.ui.showInfoMessage('GitHub token removed.');
     await postGitHubTokenStatus();
+    await refreshToolAvailability();
   }
 
   async function postGitHubSubscriptions(): Promise<void> {
@@ -322,6 +334,24 @@ export function createDesktopSettingsIpc(
       ),
     });
   }
+
+  // The same stance as the goal subscription above: a run that binds or
+  // releases a PR, repo, or issue subscription changes the list the Git tab is
+  // showing, and until now the desktop only re-read it when the user asked.
+  appSignals.on('githubSubscriptionsChanged', () =>
+    runAsync(postGitHubSubscriptions()),
+  );
+  // Outside VS Code a rejected token left the pollers failing in silence. Say
+  // so, and re-read the token status so the Git tab stops presenting the
+  // stored token as usable.
+  appSignals.on('githubTokenInvalid', ({ message }) =>
+    runAsync(
+      (async () => {
+        await options.ui.showErrorMessage(`GitHub token rejected: ${message}`);
+        await postGitHubTokenStatus();
+      })(),
+    ),
+  );
 
   /**
    * Jump from a settings entry (a goal, a PR subscription) to the run that owns

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -97,6 +97,14 @@ export interface DesktopSettingsIpc extends DesktopMessageHandler {
     deferAgentCatalogRefresh?: boolean;
   }): Promise<void>;
   signInChatGpt(): Promise<void>;
+  /**
+   * Releases the goal and app-signal subscriptions. They are scoped to the
+   * window that built this IPC, not to the process: `createWindow` runs again
+   * on macOS dock reactivation, so an undisposed listener would post to a
+   * destroyed window's renderer — and, for `githubTokenInvalid`, raise a
+   * dialog against a `BrowserWindow` that no longer exists.
+   */
+  dispose(): void;
 }
 
 export function createDesktopSettingsIpc(
@@ -285,9 +293,11 @@ export function createDesktopSettingsIpc(
 
   // Agent runs execute in this same main process and the settings panel shares
   // the app window with run progress, so a Goals tab left open during a run
-  // needs the push. Lifetime == app, matching the extension's process-global
-  // stance, so there is no dispose to hold.
-  subscribeGoalStateChanges(options.session, () => runAsync(postGoalList()));
+  // needs the push. The session outlives the window, so the subscription is
+  // window-scoped and released in `dispose` below.
+  const subscriptions = [
+    subscribeGoalStateChanges(options.session, () => runAsync(postGoalList())),
+  ];
 
   // ── GitHub token + PR/repo/issue subscriptions (Git tab) ──
 
@@ -338,18 +348,19 @@ export function createDesktopSettingsIpc(
   // The same stance as the goal subscription above: a run that binds or
   // releases a PR, repo, or issue subscription changes the list the Git tab is
   // showing, and until now the desktop only re-read it when the user asked.
-  appSignals.on('githubSubscriptionsChanged', () =>
-    runAsync(postGitHubSubscriptions()),
-  );
-  // Outside VS Code a rejected token left the pollers failing in silence. Say
-  // so, and re-read the token status so the Git tab stops presenting the
-  // stored token as usable.
-  appSignals.on('githubTokenInvalid', ({ message }) =>
-    runAsync(
-      (async () => {
-        await options.ui.showErrorMessage(`GitHub token rejected: ${message}`);
-        await postGitHubTokenStatus();
-      })(),
+  subscriptions.push(
+    appSignals.on('githubSubscriptionsChanged', () =>
+      runAsync(postGitHubSubscriptions()),
+    ),
+    // Outside VS Code a rejected token left the pollers failing in silence.
+    // The dialog is the whole fix: `resolveGitHubTokenSource` reports only
+    // which store holds a token, and rejection leaves the secret in place, so
+    // re-posting the token status would repaint the same "token set" badge.
+    // Marking a stored token as rejected would need a new status on the wire.
+    appSignals.on('githubTokenInvalid', ({ message }) =>
+      runAsync(
+        options.ui.showErrorMessage(`GitHub token rejected: ${message}`),
+      ),
     ),
   );
 
@@ -441,6 +452,10 @@ export function createDesktopSettingsIpc(
   return {
     refreshAuthDependentData,
     signInChatGpt: () => options.credentialSettingsController.signInChatGpt(),
+
+    dispose() {
+      for (const unsubscribe of subscriptions.splice(0)) unsubscribe();
+    },
 
     handleMessage(message: DesktopCommandMessage) {
       // WEBVIEW_READY is a broadcast: act on it but return false so sibling

--- a/packages/desktop/src/main/desktopToolingSettingsController.ts
+++ b/packages/desktop/src/main/desktopToolingSettingsController.ts
@@ -1,6 +1,7 @@
 import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
 import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
 import type { ToolTerminalAction } from '@controllers/settingsView/ToolDashboardData';
+import { appSignals } from '@eventBus/AppSignals';
 import { platform } from '@platform/platform';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type {
@@ -77,7 +78,7 @@ export class DefaultDesktopToolingSettingsController implements DesktopToolingSe
       openToolInstallUrl: (message) =>
         options.navigation.openExternal(message.url),
       installToolExtension: unsupported(NO_EXTENSION_HOSTING),
-      recheckToolStatus: () => this.refreshToolDashboard(),
+      recheckToolStatus: () => options.dashboard.refreshAvailability(),
       toggleTool: (message) => this.toggleTool(message.toolId, message.enabled),
       runToolCommand: (message) => this.runToolCommand(message),
     };
@@ -87,6 +88,15 @@ export class DefaultDesktopToolingSettingsController implements DesktopToolingSe
       runInstallCommand: (message) =>
         this.runLatexInstallCommand(message.installCommand),
     };
+    // Every re-probe repaints the Tools tab, whoever triggered it — the
+    // Re-check button, a GitHub token write, or any future core-side input
+    // change. Subscribing here rather than posting after each call site is
+    // what makes the dashboard follow availability instead of following the
+    // one path that remembered to re-post. Lifetime == app, matching the
+    // desktop's other process-global subscriptions, so there is no dispose.
+    appSignals.on('toolAvailabilityChanged', () => {
+      void this.postToolDashboardData().catch(options.onError);
+    });
   }
 
   postLatexConfigValues(): void {
@@ -103,7 +113,9 @@ export class DefaultDesktopToolingSettingsController implements DesktopToolingSe
       this.postToolDashboardData(),
       this.postLatexSettingsStatus(),
     ]);
-    void this.refreshToolDashboard().catch(this.options.onError);
+    void this.options.dashboard
+      .refreshAvailability()
+      .catch(this.options.onError);
   }
 
   private async postToolDashboardData(): Promise<void> {
@@ -125,11 +137,6 @@ export class DefaultDesktopToolingSettingsController implements DesktopToolingSe
 
   private async toggleTool(toolId: string, enabled: boolean): Promise<void> {
     await setToolEnabled(toolId, enabled, this.options.globalState);
-    await this.postToolDashboardData();
-  }
-
-  private async refreshToolDashboard(): Promise<void> {
-    await this.options.dashboard.refreshAvailability();
     await this.postToolDashboardData();
   }
 

--- a/packages/desktop/src/main/desktopToolingSettingsController.ts
+++ b/packages/desktop/src/main/desktopToolingSettingsController.ts
@@ -64,12 +64,20 @@ export interface DesktopToolingSettingsController {
   readonly latexHandlers: DesktopLatexHandlers;
   postLatexConfigValues(): void;
   postStartupData(): Promise<void>;
+  /**
+   * Releases the app-signal subscription. Scoped to the window that built this
+   * controller: `createWindow` runs again on macOS dock reactivation, so an
+   * undisposed subscription would keep repainting a destroyed window's
+   * renderer and pile up one listener per reopen.
+   */
+  dispose(): void;
 }
 
 /** Owns the desktop settings Tools and LaTeX domains. */
 export class DefaultDesktopToolingSettingsController implements DesktopToolingSettingsController {
   readonly toolHandlers: DesktopToolHandlers;
   readonly latexHandlers: DesktopLatexHandlers;
+  private readonly unsubscribeToolAvailability: () => void;
 
   constructor(
     private readonly options: DefaultDesktopToolingSettingsControllerOptions,
@@ -92,11 +100,17 @@ export class DefaultDesktopToolingSettingsController implements DesktopToolingSe
     // Re-check button, a GitHub token write, or any future core-side input
     // change. Subscribing here rather than posting after each call site is
     // what makes the dashboard follow availability instead of following the
-    // one path that remembered to re-post. Lifetime == app, matching the
-    // desktop's other process-global subscriptions, so there is no dispose.
-    appSignals.on('toolAvailabilityChanged', () => {
-      void this.postToolDashboardData().catch(options.onError);
-    });
+    // one path that remembered to re-post.
+    this.unsubscribeToolAvailability = appSignals.on(
+      'toolAvailabilityChanged',
+      () => {
+        void this.postToolDashboardData().catch(options.onError);
+      },
+    );
+  }
+
+  dispose(): void {
+    this.unsubscribeToolAvailability();
   }
 
   postLatexConfigValues(): void {

--- a/packages/desktop/src/main/desktopWorkspaceIpc.ts
+++ b/packages/desktop/src/main/desktopWorkspaceIpc.ts
@@ -61,6 +61,14 @@ export interface DesktopWorkspaceIpc extends DesktopMessageHandler {
    * layout, so neither resource may survive across that boundary.
    */
   disposeRendererResources(): void;
+
+  /**
+   * Releases the app-signal subscription. Separate from
+   * {@link DesktopWorkspaceIpc.disposeRendererResources} because that one also
+   * runs on renderer reload, where the subscription must survive — this one is
+   * window-scoped, and `createWindow` runs again on macOS dock reactivation.
+   */
+  dispose(): void;
 }
 
 /** The single workspace-boundary error every containment path reports. */
@@ -169,16 +177,18 @@ export function createDesktopWorkspaceIpc(
   // before this the newly written files stayed invisible until the user hit
   // Refresh. There is no filesystem watcher here; this signal is the only
   // notice the main process gets. Writes outside the workspace root cannot
-  // appear in the tree, so they are not worth a re-list. Lifetime == app,
-  // matching the desktop's other process-global subscriptions.
-  appSignals.on('workspaceFilesWritten', ({ absolutePaths }) => {
-    const root = WorkspaceFS.getPath();
-    if (!root) return;
-    if (!absolutePaths.some((path) => isPathWithin(root, path))) return;
-    renderer.postToRenderer({
-      command: DESKTOP_WORKSPACE_COMMANDS.FILES_CHANGED,
-    });
-  });
+  // appear in the tree, so they are not worth a re-list.
+  const unsubscribeFilesWritten = appSignals.on(
+    'workspaceFilesWritten',
+    ({ absolutePaths }) => {
+      const root = WorkspaceFS.getPath();
+      if (!root) return;
+      if (!absolutePaths.some((path) => isPathWithin(root, path))) return;
+      renderer.postToRenderer({
+        command: DESKTOP_WORKSPACE_COMMANDS.FILES_CHANGED,
+      });
+    },
+  );
 
   function postFileError(
     requestId: string,
@@ -337,6 +347,10 @@ export function createDesktopWorkspaceIpc(
     disposeRendererResources() {
       options.ptyHost.disposeAll();
       options.browserViews.disposeAll();
+    },
+
+    dispose() {
+      unsubscribeFilesWritten();
     },
 
     handleMessage(message: DesktopCommandMessage) {

--- a/packages/desktop/src/main/desktopWorkspaceIpc.ts
+++ b/packages/desktop/src/main/desktopWorkspaceIpc.ts
@@ -16,6 +16,7 @@ import {
   shouldVisitDirectory,
 } from '@common/files/fileListingRules';
 import { getIncludedExtensions } from '@common/files/fileTypeUtils';
+import { appSignals } from '@eventBus/AppSignals';
 import { platform } from '@platform/platform';
 import { normalizeFilePath } from '@utils/core';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
@@ -162,6 +163,22 @@ export function createDesktopWorkspaceIpc(
   options: DesktopWorkspaceIpcOptions,
 ): DesktopWorkspaceIpc {
   const reportError = (error: unknown) => options.onAsyncError?.(error);
+
+  // Accepted run outputs and accepted LaTeX diffs write straight to disk, past
+  // the editor's own write path, and the file tree caches its listing — so
+  // before this the newly written files stayed invisible until the user hit
+  // Refresh. There is no filesystem watcher here; this signal is the only
+  // notice the main process gets. Writes outside the workspace root cannot
+  // appear in the tree, so they are not worth a re-list. Lifetime == app,
+  // matching the desktop's other process-global subscriptions.
+  appSignals.on('workspaceFilesWritten', ({ absolutePaths }) => {
+    const root = WorkspaceFS.getPath();
+    if (!root) return;
+    if (!absolutePaths.some((path) => isPathWithin(root, path))) return;
+    renderer.postToRenderer({
+      command: DESKTOP_WORKSPACE_COMMANDS.FILES_CHANGED,
+    });
+  });
 
   function postFileError(
     requestId: string,

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -914,6 +914,10 @@ function createWindow(options: {
     session: options.processSession,
   });
   settingsIpcRef.current = settingsIpc;
+  // Both hold window-scoped subscriptions (goal state and app signals) that
+  // would otherwise accumulate one listener per macOS dock reactivation.
+  windowResources.add(() => settingsIpc.dispose());
+  windowResources.add(() => toolingSettingsController.dispose());
   const progressIpc = createDesktopProgressIpc({
     source: {
       get: () => agentExecution,
@@ -1094,6 +1098,10 @@ function createWindow(options: {
   // Shells keep running and web contents keep loading unless explicitly torn
   // down — neither is reachable once the window is gone.
   windowResources.add(() => workspaceIpc.disposeRendererResources());
+  // Separate from the renderer teardown above, which also runs on renderer
+  // reload: the app-signal subscription must survive a reload and die with the
+  // window, or macOS dock reactivation would stack one listener per reopen.
+  windowResources.add(() => workspaceIpc.dispose());
   let initialRendererNavigationComplete = false;
   window.webContents.on('did-navigate', () => {
     if (!initialRendererNavigationComplete) {

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -1372,6 +1372,13 @@ const MESSAGE_ROUTES = createMessageRoutes({
   saveAllFiles: () => {
     void editorPane.save();
   },
+  // `refresh()` re-lists from the root and drops the expansion state, which is
+  // the same reset the Files rail already performs each time it is opened —
+  // so this stays consistent with how the pane behaves everywhere else rather
+  // than introducing a second, subtler kind of refresh.
+  reloadWorkspaceFiles: () => {
+    void editorPane.refresh();
+  },
   isBootstrapFailed: () => bootstrapFailed,
   returnToLauncher,
   openKind,

--- a/packages/desktop/src/renderer/messageRoutes.ts
+++ b/packages/desktop/src/renderer/messageRoutes.ts
@@ -44,6 +44,7 @@ import {
   DesktopTerminalErrorMessageSchema,
   DesktopTerminalExitMessageSchema,
   DesktopTerminalOpenCommandMessageSchema,
+  DesktopWorkspaceFilesChangedMessageSchema,
   type DesktopEnvironmentSummary,
 } from '../shared/desktopWorkspaceMessages';
 import { takePendingFileRequest } from './fileRequests';
@@ -54,6 +55,8 @@ import type { ZodType } from 'zod';
 export interface DesktopMessageRouteHandlers {
   /** Persist all dirty editor buffers. */
   saveAllFiles(): void;
+  /** Re-list the workspace after something outside the editor wrote to it. */
+  reloadWorkspaceFiles(): void;
   /** Live read of whether bootstrap failed (routes must not fire then). */
   isBootstrapFailed(): boolean;
   returnToLauncher(): void;
@@ -164,6 +167,9 @@ export function createMessageRoutes(
     messageRoute(DesktopFileWrittenMessageSchema, (message) => {
       const pending = takePendingFileRequest(message.requestId);
       if (pending?.kind === 'write') pending.resolve();
+    }),
+    messageRoute(DesktopWorkspaceFilesChangedMessageSchema, () => {
+      handlers.reloadWorkspaceFiles();
     }),
     messageRoute(DesktopFileErrorMessageSchema, (message) => {
       // One request, one rejection: the requestId names the single pending read

--- a/packages/desktop/src/shared/desktopWorkspaceMessages.ts
+++ b/packages/desktop/src/shared/desktopWorkspaceMessages.ts
@@ -17,6 +17,7 @@ export const DESKTOP_WORKSPACE_COMMANDS = {
   WRITE_FILE: 'desktop:workspace:writeFile',
   FILE_WRITTEN: 'desktop:workspace:fileWritten',
   FILE_ERROR: 'desktop:workspace:fileError',
+  FILES_CHANGED: 'desktop:workspace:filesChanged',
   // Terminal
   TERMINAL_START: 'desktop:terminal:start',
   TERMINAL_INPUT: 'desktop:terminal:input',
@@ -102,6 +103,17 @@ export const DesktopFileErrorMessageSchema = z.object({
   requestId: z.uuid(),
   path: z.string(),
   message: z.string(),
+});
+
+/**
+ * Something outside the editor wrote into the workspace — an accepted run
+ * output, an accepted LaTeX diff — so the file tree's cached listing is out of
+ * date. Carries no paths: the tree re-lists from the main process anyway, and
+ * a path list would only tempt the renderer into a partial update it has no
+ * way to keep consistent with the directories it has not loaded.
+ */
+export const DesktopWorkspaceFilesChangedMessageSchema = z.object({
+  command: z.literal(DESKTOP_WORKSPACE_COMMANDS.FILES_CHANGED),
 });
 
 // ── Terminal ──

--- a/packages/extension/src/webview/MainViewProvider.ts
+++ b/packages/extension/src/webview/MainViewProvider.ts
@@ -23,7 +23,6 @@ import {
   type OnboardingFunnelState,
 } from '@controllers/onboarding/onboardingFunnel';
 import { OnboardingRefreshQueue } from '@controllers/onboarding/OnboardingRefreshQueue';
-import { appSignals } from '@eventBus/AppSignals';
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import {
   isAgentCatalogAuthRefreshDeferred,

--- a/src/eventBus/AppSignals.ts
+++ b/src/eventBus/AppSignals.ts
@@ -6,11 +6,22 @@ import { EventEmitter } from 'node:events';
  * events — those extend `AgentEvent` (`agent/trace/`) or `SessionFact`
  * (`SessionEventHub` in `agent/runtime/`), per the VS Code-free-zone rule in
  * CLAUDE.md.
+ *
+ * Every signal below records which hosts consume it and — where a host does
+ * not — why not. A signal with no such note is the ambiguous middle this file
+ * exists to prevent: a host that silently never reacts is indistinguishable
+ * from a host that deliberately doesn't. Keep the note truthful when you add a
+ * subscriber; "no equivalent surface" is a valid, and common, answer.
  */
 export interface AppSignalPayloads {
   /**
    * GitHub rejected the configured token. Frontends can surface the failure
    * and direct the user to token settings.
+   *
+   * Consumed by: extension (modal error + jump to Git settings), desktop
+   * (error dialog + re-post of the Git tab's token status). Not the CLI: a
+   * poller rejection arrives with no chat turn to attach it to, and the TUI
+   * has no out-of-band notice surface — the rejection is logged instead.
    */
   githubTokenInvalid: { message: string };
 
@@ -18,27 +29,58 @@ export interface AppSignalPayloads {
    * The active GitHub subscriptions (PR, repo, or issue) or their stream owners
    * changed. Keyless on purpose: every listener re-reads the full subscription
    * list, so which kind changed carries no information.
+   *
+   * Consumed by: extension and desktop settings views, both re-reading the
+   * full subscription list for their Git tab. Not the CLI: it lists
+   * subscriptions on demand from a slash command and has no persistent panel
+   * that could go stale.
    */
   githubSubscriptionsChanged: undefined;
 
   /**
    * External tool availability was re-probed. Frontends refresh their
    * dashboards from the updated cache.
+   *
+   * Consumed by: extension and desktop settings views — this is the sole
+   * repaint path for both Tools dashboards, so every re-probe reaches the UI
+   * regardless of which input changed. Not the CLI: it has no tools
+   * dashboard; availability is read per-run when a tool is invoked.
    */
   toolAvailabilityChanged: undefined;
 
-  /** The editor's language-model catalogue or access permissions changed. */
+  /**
+   * The editor's language-model catalogue or access permissions changed.
+   *
+   * Extension-only by construction: the sole emitter is VS Code's
+   * `lm.onDidChangeModels` / `onDidChangeAccess`. Desktop and CLI have no
+   * editor-provided model catalogue to change, so there is nothing to react
+   * to — not a missing subscription.
+   */
   languageModelsChanged: undefined;
 
   /**
    * The session's approval policy changed (workspace transition or a settings
    * update). Surfaces that re-paint the status-bar policy line.
+   *
+   * Extension-only: it exists because VS Code's status-bar tooltip is painted
+   * outside the settings webview's own round-trip and has no other refresh
+   * trigger. The desktop's write path re-posts the approval snapshot inline
+   * (`applyStateSettingUpdate` -> `postStateSettingSnapshot`), and the CLI
+   * holds the policy in TUI state that its `/approval` command updates
+   * directly, so a subscription on either host would be a duplicate repaint.
    */
   approvalPolicyChanged: undefined;
 
   /**
    * One or more files were written directly to the workspace. Frontends can
    * badge or refresh those files without routing through a run-scoped channel.
+   *
+   * Consumed by: extension (VS Code's `FileDecorationProvider` badges the
+   * written Explorer entries) and desktop (its file tree caches a directory
+   * listing and has no filesystem watcher, so this is the only notice it gets
+   * that a write landed behind its back). Not the CLI: it has no file tree or
+   * decoration surface — accepted paths are printed into the transcript by the
+   * tool row, which is built from the tool result and cannot go stale.
    */
   workspaceFilesWritten: { absolutePaths: string[] };
 }
@@ -46,7 +88,12 @@ export interface AppSignalPayloads {
 type AppSignal = keyof AppSignalPayloads;
 
 class AppSignals {
-  private readonly emitter = new EventEmitter();
+  // Node's default 10-listener leak warning assumes a listener count that
+  // grows with runtime activity. Here it grows with *host composition*: each
+  // host wires a fixed handful of subscriptions at startup and never
+  // subscribes again, so a real process stays in single digits and the
+  // warning only fires in tests that compose several hosts in one process.
+  private readonly emitter = new EventEmitter().setMaxListeners(0);
 
   on<K extends AppSignal>(
     event: K,

--- a/src/eventBus/AppSignals.ts
+++ b/src/eventBus/AppSignals.ts
@@ -88,12 +88,7 @@ export interface AppSignalPayloads {
 type AppSignal = keyof AppSignalPayloads;
 
 class AppSignals {
-  // Node's default 10-listener leak warning assumes a listener count that
-  // grows with runtime activity. Here it grows with *host composition*: each
-  // host wires a fixed handful of subscriptions at startup and never
-  // subscribes again, so a real process stays in single digits and the
-  // warning only fires in tests that compose several hosts in one process.
-  private readonly emitter = new EventEmitter().setMaxListeners(0);
+  private readonly emitter = new EventEmitter();
 
   on<K extends AppSignal>(
     event: K,

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.ts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.ts
@@ -73,6 +73,10 @@ type CapturedSettingsFixtureOverrides = Omit<
 
 let createDesktopSettingsIpc!: DesktopSettingsIpcModule['createDesktopSettingsIpc'];
 
+const liveSettingsIpcs: ReturnType<
+  DesktopSettingsIpcModule['createDesktopSettingsIpc']
+>[] = [];
+
 function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
   const {
     globalState = new FakeStateStore(),
@@ -108,6 +112,9 @@ function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
     session: overrides.session ?? defaultSession(),
     postToRenderer,
   });
+  // The IPC subscribes to the process-global session and app-signal buses, so
+  // a fixture left undisposed would keep reacting to later tests' emits.
+  liveSettingsIpcs.push(settings);
   return { globalState, settings, workspaceState };
 }
 
@@ -157,6 +164,7 @@ describe('desktop settings IPC', () => {
   });
 
   afterEach(() => {
+    for (const settings of liveSettingsIpcs.splice(0)) settings.dispose();
     vi.clearAllMocks();
     setGitAuthorEnv({});
     setWorktreeSupportEnabled(false);

--- a/src/test-kernel/desktop/DesktopToolingSettingsController.vitest.ts
+++ b/src/test-kernel/desktop/DesktopToolingSettingsController.vitest.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
 import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
 import { DefaultDesktopToolingSettingsController } from '@desktop/main/desktopToolingSettingsController';
+import { appSignals } from '@eventBus/AppSignals';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { ToolDashboardItem } from '@shared/schemas';
 import { HOMEBREW_INSTALL_COMMAND } from '@shared/constants/latexToolchain';
@@ -61,7 +62,12 @@ function createFixture(overrides: FixtureOverrides = {}) {
   const dashboard: ControllerOptions['dashboard'] = {
     buildItems: async () => [DASHBOARD_ITEM],
     getCachedCheckResults: async () => [],
-    refreshAvailability: async () => undefined,
+    // The real `refreshToolAvailability` always emits once the probes land,
+    // and that emit is what repaints the dashboard, so a fake that stays
+    // silent would leave the controller with nothing to react to.
+    refreshAvailability: async () => {
+      appSignals.emit('toolAvailabilityChanged', undefined);
+    },
     planTerminalAction: async (toolId, kind) => ({
       kind: 'terminal',
       name: toolId,
@@ -127,7 +133,10 @@ describe('DefaultDesktopToolingSettingsController', () => {
           return [DASHBOARD_ITEM];
         },
         getCachedCheckResults: async () => undefined,
-        refreshAvailability: () => refreshPending,
+        refreshAvailability: async () => {
+          await refreshPending;
+          appSignals.emit('toolAvailabilityChanged', undefined);
+        },
       },
     });
 
@@ -248,12 +257,16 @@ describe('DefaultDesktopToolingSettingsController', () => {
         },
         refreshAvailability: async () => {
           events.push('dashboard:refresh');
+          appSignals.emit('toolAvailabilityChanged', undefined);
         },
       },
     });
 
     await assertSupported(controller.toolHandlers.recheckToolStatus)({
       command: SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS,
+    });
+    await vi.waitFor(() => {
+      expect(events).toContain('renderer:post');
     });
 
     expect(events).toEqual([
@@ -347,9 +360,11 @@ describe('DefaultDesktopToolingSettingsController', () => {
       command: SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS,
     });
 
-    expect(posted.at(-1)).toEqual({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
-      items: [DASHBOARD_ITEM],
+    await vi.waitFor(() => {
+      expect(posted.at(-1)).toEqual({
+        command: SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
+        items: [DASHBOARD_ITEM],
+      });
     });
   });
 });

--- a/src/test-kernel/desktop/DesktopToolingSettingsController.vitest.ts
+++ b/src/test-kernel/desktop/DesktopToolingSettingsController.vitest.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
 import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
@@ -46,6 +46,8 @@ const DASHBOARD_ITEM: ToolDashboardItem = {
 type ControllerOptions = ConstructorParameters<
   typeof DefaultDesktopToolingSettingsController
 >[0];
+
+const liveControllers: DefaultDesktopToolingSettingsController[] = [];
 
 /** Dashboard members not listed fall back to the fixture defaults below. */
 type FixtureOverrides = Partial<Omit<ControllerOptions, 'dashboard'>> & {
@@ -107,6 +109,9 @@ function createFixture(overrides: FixtureOverrides = {}) {
     ...overrides,
     dashboard,
   });
+  // The controller subscribes to a process-global bus, so a fixture left
+  // undisposed would keep reacting to later tests' emits.
+  liveControllers.push(controller);
 
   return {
     controller,
@@ -120,6 +125,10 @@ function createFixture(overrides: FixtureOverrides = {}) {
 }
 
 describe('DefaultDesktopToolingSettingsController', () => {
+  afterEach(() => {
+    for (const controller of liveControllers.splice(0)) controller.dispose();
+  });
+
   it('posts cached startup data before refreshing external tools', async () => {
     let finishRefresh: (() => void) | undefined;
     const refreshPending = new Promise<void>((resolve) => {

--- a/src/test-kernel/desktop/DesktopWorkspaceIpc.vitest.ts
+++ b/src/test-kernel/desktop/DesktopWorkspaceIpc.vitest.ts
@@ -20,6 +20,7 @@ import {
 import { createDesktopWorkspaceIpc } from '@desktop/main/desktopWorkspaceIpc';
 import type { DesktopBrowserViews } from '@desktop/main/desktopBrowserViews';
 import type { DesktopPtyHost } from '@desktop/main/desktopPtyHost';
+import { appSignals } from '@eventBus/AppSignals';
 import { createFakePlatform } from '@test/support/FakePlatform';
 
 let fixtureRoot = '';
@@ -104,6 +105,25 @@ describe('desktop workspace IPC', () => {
 
   afterEach(() => {
     rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  // The file tree caches its listing and there is no filesystem watcher, so a
+  // run that accepts output files would leave it stale without this notice.
+  it('tells the renderer to re-list only when a write lands inside the workspace', () => {
+    const postToRenderer = vi.fn();
+    createIpc(postToRenderer);
+
+    appSignals.emit('workspaceFilesWritten', {
+      absolutePaths: [externalPath],
+    });
+    expect(postToRenderer).not.toHaveBeenCalled();
+
+    appSignals.emit('workspaceFilesWritten', {
+      absolutePaths: [externalPath, join(workspacePath, 'paper.tex')],
+    });
+    expect(postToRenderer).toHaveBeenCalledExactlyOnceWith({
+      command: DESKTOP_WORKSPACE_COMMANDS.FILES_CHANGED,
+    });
   });
 
   it('lists only direct children and loads nested directories on demand', async () => {

--- a/src/test-kernel/desktop/DesktopWorkspaceIpc.vitest.ts
+++ b/src/test-kernel/desktop/DesktopWorkspaceIpc.vitest.ts
@@ -64,8 +64,14 @@ function createIpc(
     toWindowBounds: (bounds) => bounds,
     ...overrides,
   };
-  return createDesktopWorkspaceIpc({ postToRenderer }, options);
+  const ipc = createDesktopWorkspaceIpc({ postToRenderer }, options);
+  // The IPC subscribes to a process-global bus, so a fixture left undisposed
+  // would keep reacting to later tests' emits.
+  liveWorkspaceIpcs.push(ipc);
+  return ipc;
 }
+
+const liveWorkspaceIpcs: ReturnType<typeof createDesktopWorkspaceIpc>[] = [];
 
 describe('desktop workspace IPC', () => {
   beforeEach(async () => {
@@ -104,6 +110,7 @@ describe('desktop workspace IPC', () => {
   });
 
   afterEach(() => {
+    for (const ipc of liveWorkspaceIpcs.splice(0)) ipc.dispose();
     rmSync(fixtureRoot, { recursive: true, force: true });
   });
 

--- a/src/test-kernel/desktop/desktopSettingsTestSupport.ts
+++ b/src/test-kernel/desktop/desktopSettingsTestSupport.ts
@@ -113,6 +113,7 @@ export function createStubDesktopToolingSettingsController(
     },
     postLatexConfigValues: () => undefined,
     postStartupData: noOp,
+    dispose: () => undefined,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

`docs/proposals/2026-08-15-cross-host-consolidation.md` §3 **V7** found that
`appSignals` has **zero references** in `packages/desktop` and `packages/cli`,
even though core emits on it from `src/tools/**` in every host's process. The
harm is not only the missed refreshes — it is that a host which silently never
reacts is indistinguishable from a host that deliberately doesn't.

This PR closes that by giving **every** declared signal exactly one recorded
answer at its declaration in `src/eventBus/AppSignals.ts`: which hosts consume
it, and why the others do not. Where the honest answer was "the desktop has a
surface and it is going stale", the subscription is wired; where it was "there
is no equivalent surface", it is fenced in the doc comment rather than wired as
a no-op. No new surface was built to justify a wiring.

### Per-signal decision table

| Signal | Decision | Stale surface fixed (WIRE) / rationale (FENCE) |
|---|---|---|
| `toolAvailabilityChanged` | **WIRE** desktop | Settings → **Tools dashboard**. Repainted only on an explicit Re-check click. It also never re-probed after a GitHub token write, so the `github_subscription` tool group kept rendering as unavailable (`desktopSettingsIpc.ts` set/removeGitHubToken vs `extension.ts:567` `secrets.onDidChange`). |
| `githubSubscriptionsChanged` | **WIRE** desktop | Settings → **Git tab subscription list**. Refresh-on-request only (`postGitHubSubscriptions` was reachable from startup, an explicit `getPRSubscriptions`, and a local unsubscribe), so a run that bound or released a PR/repo/issue subscription left the open panel wrong. |
| `githubTokenInvalid` | **WIRE** desktop | **No surface at all.** A token rejected by GitHub made `PollingSourceBase` fail in silence outside VS Code; the extension's `extension.ts:588` was the sole subscriber in the repo. Now an error dialog plus a Git-tab token-status re-post. |
| `workspaceFilesWritten` | **WIRE** desktop | **Files tree** (`renderer/editorPane.ts`). It caches its directory listing and there is no filesystem watcher, so files landed by `accept_run_files` stayed invisible until the user hit Refresh. `desktopProgressFileActions.ts` also explicitly dropped its `emitWritten` port with a comment saying nothing listened — that is no longer true, so it emits. |
| `languageModelsChanged` | **FENCE** | Extension-only *by construction*: the sole emitter is VS Code's `lm.onDidChangeModels` / `onDidChangeAccess`. Desktop and CLI have no editor-provided model catalogue that can change. |
| `approvalPolicyChanged` | **FENCE** | Extension-only. It exists because VS Code's status-bar tooltip repaints outside the settings webview's round-trip. The desktop's write path already re-posts the approval snapshot inline (`applyStateSettingUpdate` → `postStateSettingSnapshot`) and its only policy display is that snapshot-fed control; the CLI holds the policy in TUI state that `/approval` updates directly. A subscription on either would be a duplicate repaint. |

**CLI: fenced on all six**, and the fence text says why per signal. It has no
tools dashboard, no persistent subscription panel, no file tree, no
out-of-band notice surface, and its approval display is already live. Nothing
was wired there.

## Issue acceptance gates

Addresses audit finding **V7** in
`docs/proposals/2026-08-15-cross-host-consolidation.md` §3, which asks to
"wire desktop (and where sensible CLI TUI) subscriptions; where a host
deliberately won't react, fence it at the signal declaration." Both halves are
satisfied: 4 wirings, 2 fences, and 6/6 signals annotated with per-host
consumption.

Two claims in the audit are **refuted at HEAD** (see Validation).

## Single source of truth

- **`src/eventBus/AppSignals.ts` is now the single place that records per-host
  consumption for every signal.** Previously that fact existed only implicitly,
  as the presence or absence of a subscriber somewhere in a host tree.
- **`toolAvailabilityChanged` becomes the single repaint owner for the desktop
  Tools dashboard.** `DefaultDesktopToolingSettingsController.refreshToolDashboard`
  used to pair `refreshAvailability()` with its own `postToolDashboardData()`;
  that pass-through pair is deleted and the two call sites go straight to
  `dashboard.refreshAvailability()`. Every re-probe now repaints through one
  path regardless of which input changed, instead of only the paths that
  remembered to re-post.

## Duplication and abstraction budget

No new abstraction, no new bus, no new subscribe surface — every subscriber
uses the existing `appSignals.on(...)`, and the two new emits
(`desktopProgressFileActions`) are on `workspaceFilesWritten`, which is squarely
inside `AppSignals`' documented scope (workspace-file writes) and therefore
inside the `appSignals.emit` exemption in CLAUDE.md. Nothing run-scoped or
session-scoped was added; no signal was added.

One wire message is added — `desktop:workspace:filesChanged`,
`DesktopWorkspaceFilesChangedMessageSchema` — because the desktop main process
cannot reach the renderer's tree cache any other way. It is keyless on purpose:
the tree re-lists from the main process anyway, and a path list would only tempt
the renderer into a partial update it cannot keep consistent with the
directories it has not loaded. It follows the existing
`createMessageRoutes` / `messageRoute(schema, handler)` pattern exactly.

Duplication removed: the `refreshAvailability` + `postToolDashboardData` pair
described above.

## Net elements (R6)

Measured against the merge base `3742d53`, not `origin/main` (which advanced
during this work):

- **Files**: 14 changed, 0 added, 0 deleted. `255 insertions(+), 23 deletions(-)`.
- **Exported symbols** (`^[+-]export` over the diff): **+1 / -0** →
  `DesktopWorkspaceFilesChangedMessageSchema`, consumed in the same PR by
  `renderer/messageRoutes.ts`.
- **Classes / interfaces / enums**: **+0 / -0**.
- **Functions / methods**: **+3 / -1**. Deleted: `refreshToolDashboard`
  (pass-through pair, both callers inlined). Added: three `dispose()` methods,
  one per owner of a window-scoped subscription — required by the review round,
  see Validation.
- **Net LoC**: **+232**, of which **96 lines are comment** (the per-signal fence
  annotations that are the deliverable, plus the window-lifetime rationale) and
  **136 are code**: 4 subscriptions, 3 disposers + their 3 registrations, 2
  re-probe calls, 1 emit, 1 schema, 1 route, 1 handler, 2 test pins, and 3 test
  teardown hooks.

**This is a deliberate net-add**, flagged as such in §7.4 revival row 6
("wiring is net-add, uncosted"). It is justified per surface, not per line:
each of the four wirings names a surface a user can watch go stale today, and
the two fences avoid the no-op wirings that would have made the number bigger
for nothing.

## Consumer counts (R8)

No export was deleted. One emit path was **re-routed** and one **restored**:

| Key | Subscribers before | Subscribers after |
|---|---|---|
| `toolAvailabilityChanged` | 1 (`SettingsViewMessageHandler.ts:217`) | 2 (+ `desktopToolingSettingsController.ts`) |
| `githubSubscriptionsChanged` | 1 (`SettingsViewMessageHandler.ts:210`) | 2 (+ `desktopSettingsIpc.ts`) |
| `githubTokenInvalid` | 1 (`extension.ts:588`) | 2 (+ `desktopSettingsIpc.ts`) |
| `workspaceFilesWritten` | 1 (`fileDecorations.ts:75`) | 2 (+ `desktopWorkspaceIpc.ts`) |
| `languageModelsChanged` | 1 (`SettingsViewMessageHandler.ts:224`) | 1 (unchanged, fenced) |
| `approvalPolicyChanged` | 1 (`extension.ts:718`) | 1 (unchanged, fenced) |

Re-routed emit: the desktop Tools dashboard repaint. It had exactly **1**
producer-side caller pair (`refreshToolDashboard`, called from
`recheckToolStatus` and `postStartupData`); both now call
`dashboard.refreshAvailability()` and receive the repaint through the signal.
Grepped: no other caller of `refreshToolDashboard` existed.

Restored emit: `emitWritten` on `acceptEditedFileReplace`. Ports grepped —
`compareCommands.ts:62` (extension, emits), `desktopProgressFileActions.ts`
(desktop, was `() => undefined`, now emits), and 2 test stubs. The CLI has no
caller of this path.

## Host impact

**Extension:** No behavior change. One dead `import { appSignals }` removed from
`packages/extension/src/webview/MainViewProvider.ts` — the symbol had zero uses
in that file.

**Desktop:** Four surfaces stop going stale — the Tools dashboard (now also
re-probed on a GitHub token write, which it never was), the Git tab
subscription list, the previously nonexistent invalid-token notice, and the
Files tree after a run writes into the workspace. The tree reload uses the
pane's existing `refresh()`, which re-lists from the root and drops expansion
state — the same reset the Files rail already performs each time it is opened,
so this stays consistent with the pane's behavior everywhere else rather than
introducing a second, subtler kind of refresh.

**CLI:** No code change. All six signals fenced with a stated reason. Its
`refreshModelListStateIfNeeded` call at `runtime/initPlatform.ts:290` is intact
(see below).

## Scheduled refactoring

Two follow-ups, both out of this PR's scope and neither introduced by it:

1. **Desktop open-buffer staleness.** `editorPane.open()` re-reads a file from
   disk only when the path is opened again, so a Monaco tab left open on a file
   that `accept_run_files` overwrote keeps showing the old contents. This PR
   refreshes the *tree*, not open buffers.
2. **CLI `/config` approval-policy desync** (unrelated to AppSignals, found
   while fencing `approvalPolicyChanged`): `CliConfigForm` writes
   `texra.approvalPolicy` through `writeSetting` directly rather than
   `applyStateSettingUpdate`, so it bypasses the `onApprovalPolicyChanged` port
   and leaves both the live `SessionHandle` policy and the status-bar segment on
   the old value. `/approval` is the only CLI path that updates them. Most of
   the display chain is in files owned by another track right now.

## Validation

- `npm run typecheck` — clean.
- `FORCE_COLOR=0 npx vitest run src/test-kernel/desktop/ src/test-kernel/architecture/ src/test-kernel/tools/ src/test-kernel/latex/ src/test-kernel/frontend/` — **1687 passed**, including `src/test-kernel/architecture` per the kernel-invariant requirement.
- `npm run format:check` — clean.
- `NODE_OPTIONS=--max-old-space-size=8192 npx eslint <changed>` — clean.
- `npm run check:dead-code-ratchet` — 8 current vs 8 baselined, no new findings.

**Tests: 2 added, both pins on genuinely-fixed stale surfaces**, per the
zero-default budget.
- `DesktopWorkspaceIpc.vitest.ts` — a write inside the workspace posts
  `FILES_CHANGED`, a write outside does not.
- `DesktopToolingSettingsController.vitest.ts` — *adapted, not added*: its
  `refreshAvailability` fakes now emit `toolAvailabilityChanged`, matching what
  the real `refreshToolAvailability` always does. Without that the fakes were
  pinning the pass-through pair this PR deletes.

### Refutations

Three claims checked and found **not to hold at HEAD** — recorded so the audit
can be corrected rather than re-actioned:

1. **"`refreshModelListStateIfNeeded` may now have no production caller on any
   host."** False. It has **two**: `packages/extension/src/extension.ts:392`
   and `packages/cli/src/runtime/initPlatform.ts:290`. It is not dead and was
   not deleted. The real gap is narrower and already tracked elsewhere (V2 /
   §7.4 row 5): **desktop** never calls it at startup. That is a bootstrap
   change in `packages/desktop/src/main/index.ts`, not an AppSignals change,
   so it is deliberately left to that track rather than folded in here.
2. **"Of 13 declared signals…"** The declaration list is down to **6**.
   `includedModelAccessChanged` and the six subscription signals V7 counted are
   already gone, as is `extensionDeactivating` (#10924). The
   tool-availability / token / file-write half of the finding was still fully
   open, which is what this PR closes.
3. **Pre-existing flake, not caused by this PR:**
   `src/test-kernel/desktop/DesktopAgentExecution.vitest.ts` ("presents a merge
   failure…") fails intermittently on clean `origin/main` too — reproduced
   there with 2 failures in one run, 3 in another, and 0 in the full-directory
   run on this branch. Not touched here.

### Review round (resolved in d84dca7)

Two findings, both real, both fixed — recorded here because the first
invalidates a claim the original commit made.

1. **The four new subscriptions were not process-lifetime.** `createWindow` is
   re-entered by `reopenMainWindow` from `app.on('activate')`, and
   `window-all-closed` deliberately does not quit on darwin — so every macOS
   dock reactivation stacked another listener holding the previous window's
   closure, one of which would have raised a dialog against a destroyed
   `BrowserWindow`. Each owner now exposes `dispose()` returning its
   unsubscriber, registered in the existing `windowResources` `DisposableStore`.
   `createDesktopWorkspaceIpc` keeps `dispose` separate from
   `disposeRendererResources`, which also runs on renderer reload where the
   subscription must survive. The pre-existing `subscribeGoalStateChanges`
   disposer in `desktopSettingsIpc` was being discarded the same way and is
   folded into the same path — so this fixes a leak that predates the PR.

   Consequently `setMaxListeners(0)` on the AppSignals emitter is **reverted**.
   It was masking this leak, not a test-only artifact. With proper disposal the
   warning does not reappear: the 1687-test run above is clean.

2. **The `postGitHubTokenStatus()` re-post after `githubTokenInvalid` was a
   no-op.** `resolveGitHubTokenSource` returns `'secret' | 'env' | 'none'` from
   token *presence*, and rejection leaves the stored secret in place, so the
   Git tab would repaint the same "token set" badge. Removed; the dialog is the
   whole fix, and the comment now says what marking a rejected token would
   actually require (a new status on the `UPDATE_GITHUB_TOKEN_STATUS` contract).
