### PR TITLE
fix(cli): apply /config approval-policy writes to the live session

### DIFF
--- a/packages/cli/src/chat/tui/commands/handlers/approvalCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/approvalCommand.ts
@@ -10,6 +10,12 @@ import { type SlashCommandContext } from './slashContext';
 const APPROVAL_USAGE = 'Usage: /approval [ask | never | yolo]';
 export const YOLO_USAGE = 'Usage: /yolo [ask | never | yolo]';
 
+/**
+ * `/approval` is a session-scoped override, like `--approval-policy`: it moves
+ * the live policy for this session only and never writes `.texra/config.json`.
+ * The persisted default is `/config`'s row, which applies its new value to this
+ * same session through the shared write path's approval-policy port.
+ */
 export function applyCliApprovalPolicySelection(
   input: string,
   context: SlashCommandContext,

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -703,6 +703,9 @@ export function registerBuiltinSlashCommands(options?: {
         <CliConfigForm
           stores={stores}
           availableRows={props.availableRows}
+          // Same hook `/approval` drives, so the approval-policy row updates the
+          // live session and the status bar from whichever surface set it.
+          onApprovalPolicyChanged={options?.onApprovalPolicySelect}
           openExternalForm={(formName) => openCliSlashCommandForm(formName, '')}
           onClose={() => props.onDone(undefined)}
           onError={async (error) => {

--- a/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
@@ -13,14 +13,15 @@ import {
   saveProviderApiKey,
 } from '@cli/runtime/providerApiKey';
 import type { ApiKeyStatus, ApiProvider } from '@model/apiProviders';
-import { CLI_STATE_SETTINGS } from '@shared/schemas';
+import type { TexraApprovalPolicy } from '@shared/approvalPolicy';
+import { CLI_STATE_SETTINGS, type SurfacedSettingEntry } from '@shared/schemas';
 import {
   readSetting,
-  resetSetting,
-  writeSetting,
   type SettingsStores,
 } from '@shared/config/settingsAccess';
+import { applyStateSettingUpdate } from '@shared/settingsView/handlers/stateSettingWrite';
 import { GlobalStateKey } from '@shared/state/stateKeys';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { refreshSubscriptionPreferenceViews } from '../state/subscriptionPreference';
 import { AgentRosterForm } from './AgentRosterForm';
@@ -43,6 +44,12 @@ export interface CliConfigFormProps {
   readonly onClose: () => void;
   readonly onError?: (error: unknown) => void;
   readonly openExternalForm?: (formName: string) => void;
+  /**
+   * Applies the approval-policy side effect when that row is written here — the
+   * chat TUI's live-session hook, identical to the one `/approval` drives.
+   * Omitted by `texra config edit`, whose process holds no session to update.
+   */
+  readonly onApprovalPolicyChanged?: (policy: TexraApprovalPolicy) => void;
 }
 
 export interface CreateCliConfigFormPropsInput extends CliConfigFormProps {
@@ -145,28 +152,53 @@ export function createCliConfigFormProps(
   const githubTokenStatusView =
     props.githubTokenStatusView ??
     (INITIAL_STATUS_VIEW as GitHubTokenStatusView);
+  // The one CLI write path for a `/config` row: the same
+  // `applyStateSettingUpdate` the extension and desktop settings views call, so
+  // a row that carries a live side effect (approval policy) cannot be persisted
+  // from here while the running session keeps enforcing the old value. The
+  // catalog row still owns the write consequences below it — `writeSetting`
+  // applies the declared mutual exclusions (Kimi Code clears OpenRouter) and
+  // `onWrite.invalidatesModelOptions` marks the rows whose change re-routes
+  // models — so this form keeps no key list of its own. `null` is the shared
+  // reset convention (delete the key so the schema default reappears).
+  const applyUpdate = async (
+    entry: SurfacedSettingEntry,
+    value: unknown,
+  ): Promise<void> => {
+    const result = await applyStateSettingUpdate(entry.key, value, {
+      host: 'cli',
+      stores,
+      onApprovalPolicyChanged: props.onApprovalPolicyChanged,
+    });
+    const label = entry.title ?? entry.key;
+    switch (result.kind) {
+      case 'applied':
+        break;
+      case 'rejected':
+      case 'failed':
+        // ConfigForm rolls its optimistic value back on a rejection and reports
+        // it, so a refused write must throw rather than read as applied.
+        throw new Error(
+          `Failed to update "${label}": ${toErrorMessage(result.error)}`,
+          { cause: result.error },
+        );
+      case 'ignored':
+      case 'workspace-required':
+        throw new Error(
+          `Setting "${label}" is not writable from /config (${result.kind}).`,
+        );
+    }
+    if (entry.category === 'git') applyCliGitAuthorConfig(stores.config);
+    if (entry.onWrite?.invalidatesModelOptions) {
+      refreshSubscriptionPreferenceViews();
+    }
+  };
   return {
     availableRows: props.availableRows,
     entries: CLI_STATE_SETTINGS,
     readValue: (entry) => readSetting(entry, stores, 'cli'),
-    // The catalog row owns write consequences: `writeSetting` applies the
-    // declared mutual exclusions (Kimi Code clears OpenRouter) and
-    // `onWrite.invalidatesModelOptions` marks the rows whose change re-routes
-    // models, so this form no longer keeps its own key list.
-    writeValue: async (entry, value) => {
-      await writeSetting(entry, value, stores, 'cli');
-      if (entry.category === 'git') applyCliGitAuthorConfig(stores.config);
-      if (entry.onWrite?.invalidatesModelOptions) {
-        refreshSubscriptionPreferenceViews();
-      }
-    },
-    resetValue: async (entry) => {
-      await resetSetting(entry, stores, 'cli');
-      if (entry.category === 'git') applyCliGitAuthorConfig(stores.config);
-      if (entry.onWrite?.invalidatesModelOptions) {
-        refreshSubscriptionPreferenceViews();
-      }
-    },
+    writeValue: (entry, value) => applyUpdate(entry, value),
+    resetValue: (entry) => applyUpdate(entry, null),
     formLinks: [
       {
         name: 'agents',

--- a/src/shared/approvalPolicy.ts
+++ b/src/shared/approvalPolicy.ts
@@ -7,6 +7,14 @@ export const TEXRA_APPROVAL_POLICIES = ['never', 'ask', 'yolo'] as const;
 export const TexraApprovalPolicySchema = z.enum(TEXRA_APPROVAL_POLICIES);
 export type TexraApprovalPolicy = z.infer<typeof TexraApprovalPolicySchema>;
 export const TEXRA_APPROVAL_POLICY_DEFAULT: TexraApprovalPolicy = 'ask';
+/**
+ * The policy a `--no-input` run falls back to. Deliberately divergent from
+ * {@link TEXRA_APPROVAL_POLICY_DEFAULT}: a run that cannot present a prompt
+ * denies instead of hanging, and `buildCliContext` narrows the candidate list
+ * to the explicit `--approval-policy` flag alone — a persisted or env-provided
+ * `yolo` must not silently auto-approve a headless run that nobody is watching.
+ * Changing that requires changing headless discipline, not just this constant.
+ */
 export const TEXRA_APPROVAL_POLICY_NO_INPUT_DEFAULT: TexraApprovalPolicy =
   'never';
 /** Canonical persisted spelling in `.texra/config.json` for every host. */

--- a/src/shared/settingsView/handlers/stateSettingWrite.ts
+++ b/src/shared/settingsView/handlers/stateSettingWrite.ts
@@ -1,8 +1,10 @@
-// Shared routing decision for the generic `UPDATE_STATE_SETTING` command.
+// Shared routing decision for the generic `UPDATE_STATE_SETTING` command, and
+// the one write path every settings surface goes through — the extension and
+// desktop settings views plus the CLI `/config` panel.
 //
-// The extension and desktop hosts share persistence through settingsAccess and
-// own only the post-write side effects for each outbound snapshot. This
-// resolver owns the subtle boundary rules once:
+// The hosts share persistence through settingsAccess and own only the
+// post-write side effects for each outbound snapshot. This resolver owns the
+// subtle boundary rules once:
 //   - a value-less message is a no-op (the catalog schemas `.prefault()`, so
 //     parsing `undefined` would silently write a default),
 //   - null explicitly resets a setting while an omitted value remains a no-op,
@@ -103,10 +105,13 @@ export interface StateSettingUpdatePorts {
 }
 
 /**
- * Host-neutral write path for a generic `UPDATE_STATE_SETTING` message:
- * resolve, guard, persist, and apply the approval-policy side effect. Callers
- * own all UI feedback and the outbound snapshot rebroadcast — this performs
- * only the decision and the write.
+ * Host-neutral write path for a catalog-backed setting: resolve, guard,
+ * persist, and apply the approval-policy side effect. Every surface that
+ * changes one of these rows calls this — the extension and desktop
+ * `UPDATE_STATE_SETTING` boundaries and the CLI `/config` panel — so a row with
+ * a runtime side effect cannot be persisted by one surface without the running
+ * session being told. Callers own all UI feedback and the outbound snapshot
+ * rebroadcast — this performs only the decision and the write.
  */
 export async function applyStateSettingUpdate(
   key: string,

--- a/src/test-kernel/cli/ConfigForm.vitest.ts
+++ b/src/test-kernel/cli/ConfigForm.vitest.ts
@@ -41,6 +41,10 @@ import {
   type ApiProvider,
 } from '@model/apiProviders';
 import {
+  TEXRA_APPROVAL_POLICY_CONFIG_KEY,
+  type TexraApprovalPolicy,
+} from '@shared/approvalPolicy';
+import {
   ALL_SETTINGS,
   CLI_STATE_SETTINGS,
   DEFAULT_GIT_AUTHOR_NAME,
@@ -698,6 +702,30 @@ describe('/config slash command wiring', () => {
 
     const markCommits = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);
     expect(props.readValue?.(markCommits)).toBe(false);
+  });
+
+  // Regression: `/config` used to persist `texra.approvalPolicy` with a bare
+  // `writeSetting`, so the stored value changed while the running session and
+  // the status bar kept enforcing the old policy.
+  it('applies an approval-policy write to the live session, not just the store', async () => {
+    const { stores, config } = makeFakeSettingsStores();
+    const applied: TexraApprovalPolicy[] = [];
+    registerBuiltinSlashCommands({
+      getConfigStores: () => stores,
+      onApprovalPolicySelect: (policy) => {
+        applied.push(policy);
+      },
+    });
+    openCliSlashCommandForm('config', '');
+    const props = renderConfigFormProps();
+
+    await props.writeValue?.(
+      entryByKey(TEXRA_APPROVAL_POLICY_CONFIG_KEY),
+      'yolo',
+    );
+
+    expect(config.get(TEXRA_APPROVAL_POLICY_CONFIG_KEY, 'ask')).toBe('yolo');
+    expect(applied).toEqual(['yolo']);
   });
 
   it('persists writes through the accessor to the CLI store', async () => {


### PR DESCRIPTION
## Summary

**Symptom:** in a `texra chat` session, changing **Approval policy** from the
in-chat `/config` panel appeared to be accepted, but the running session kept
enforcing the old policy — the status bar still showed the previous mode and
Bash/tool-edit approvals still used it. Only the next process picked the new
value up.

**Cause:** `/config` wrote every catalog row with a bare `writeSetting`,
bypassing `applyStateSettingUpdate` and its `onApprovalPolicyChanged` port that
the extension and desktop settings views go through. One setting, two write
paths, only one of which notifies. The bypass was **general** — every `/config`
row skipped the shared update path — but `texra.approvalPolicy` is the only row
that carries a live side effect today, so it was the only user-visible break.

**Fix:** the CLI `/config` write/reset now go through the same
`applyStateSettingUpdate`, with the chat TUI supplying the port that `/approval`
already drives (`setApprovalPolicy` on the session + `patchSessionMeta` for the
status bar). Non-`applied` outcomes throw, so `ConfigForm` rolls its optimistic
value back and surfaces the failure instead of a write silently reading as
applied.

`texra config edit` (standalone process, no live session) supplies no port and
persists only, as before — documented on the prop.

Verified at HEAD before fixing: with the new pin against the pre-fix files, the
store assertion passed while the live-policy hook never fired (`[]` vs
`['yolo']`).

### Sibling-surface audit

Four CLI ways to set the policy; they now agree on which one notifies:

| Surface | Persists | Updates live session |
| --- | --- | --- |
| `/config` row | yes | **yes (this PR)** |
| `/approval`, `/yolo` | no (session-scoped override) | yes |
| `--approval-policy` flag | no | yes (session seed) |
| `--no-input` fallback | no | yes (session seed) |

The `/approval` split (live-only, no persistence — same shape as the flag) is
deliberate and now documented in `approvalCommand.ts` rather than changed.
Audit item **V12**, the `--no-input` → `'never'` divergence, is likewise
**documented, not changed**: `TEXRA_APPROVAL_POLICY_NO_INPUT_DEFAULT` now
carries the headless-discipline rationale (a headless run denies rather than
hangs, and `buildCliContext` deliberately drops the persisted/env candidates so
a stored `yolo` cannot auto-approve an unwatched run).

## Issue acceptance gates

No issue — bug found during a fencing pass on a neighbouring track and confirmed
at HEAD before this change.

## Single source of truth

`applyStateSettingUpdate` (`src/shared/settingsView/handlers/stateSettingWrite.ts`)
is now the single write path for catalog-backed settings across all three hosts,
and therefore the single site that fires the approval-policy change port. The
CLI's live-session hook stays one closure (`onApprovalPolicySelect` in
`runChatTui`), shared by `/approval` and `/config`.

## Duplication and abstraction budget

Removed a duplicate write path rather than adding a notifier: `/config`'s
hand-rolled `writeSetting` / `resetSetting` pair (with its duplicated
git-author + model-invalidation tail) collapses into one `applyUpdate` closure
(2 call sites) that delegates to the shared function. No new module, no new
type, no pass-through layer; the one new prop is a port the host fills with an
existing closure.

## Net elements (R6)

- Files: 6 changed, 0 added, 0 deleted (`+111 / −29`).
- Exported symbols: 0 added, 0 removed (`^[+-]export` over the diff = 0).
- Classes/interfaces/enums: 0 added, 0 removed (one optional field added to the
  existing `CliConfigFormProps`).
- Net LoC: +82 total; production +74, of which 46 lines are explanatory comments
  and doc blocks (`stateSettingWrite.ts` header, the `--no-input` rationale, the
  `/approval` scope note). Net non-comment production lines: ≈ +28, for the
  result-handling switch that replaces two throw-on-reject calls.
- Test: +28 (one regression pin, extended into the existing suite).

## Consumer counts (R8)

Re-routed one write path; no emit path or export deleted.

- `writeSetting` / `resetSetting` from `@shared/config/settingsAccess`:
  production callers before = 3 (`CliConfigForm`, `stateSettingWrite`,
  `platformSettings`); after = 2 — the CLI now reaches them through
  `stateSettingWrite`. No export removed (both still have callers).
- `applyStateSettingUpdate`: production callers 2 → 3 (extension settings view,
  desktop settings IPC, CLI `/config`).
- `onApprovalPolicyChanged` port implementations: 2 → 3 (vscode, desktop, cli).
- `setApprovalPolicy` call sites: unchanged — the CLI reuses the existing
  `runChatTui` closure, so `approvalPolicyAuthorityRatchet`'s
  `SEED_CALL_ALLOWLIST` needs no widening.

## Host impact

Extension: none (doc comments only).

Desktop: none (doc comments only).

CLI: `/config` approval-policy changes now take effect in the running session
(policy + status bar) as well as being persisted, and a `/config` write that the
shared path refuses now surfaces as an error with the optimistic value rolled
back instead of appearing to succeed. `texra config edit` unchanged.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean (includes `packages/cli` `tsconfig.scripts.json`).
- `FORCE_COLOR=0 npx vitest run src/test-kernel/cli src/test-kernel/settings src/test-kernel/shared/stateSettings.vitest.ts src/test-kernel/architecture` — 179 files, 2688 passed, 1 skipped.
- Reproduction check: the new pin fails against the pre-fix files
  (`applied` = `[]`) and passes after.
- `npm run format:check` — clean.
- `NODE_OPTIONS=--max-old-space-size=8192 npx eslint <6 changed files>` — clean.
- `npm run check:dead-code-ratchet` — 8 current vs 8 baselined, OK.
- `npm run check:package-contributes`, `check:browser-safe-utils`,
  `check:guidance-refs` — all OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
