### PR TITLE
fix(cli): write compacted input history atomically

### DIFF
--- a/packages/cli/src/chat/tui/history/inputHistory.ts
+++ b/packages/cli/src/chat/tui/history/inputHistory.ts
@@ -72,7 +72,10 @@ export async function loadInputHistory(): Promise<InputHistory> {
       if (records.length > MAX_LINES) {
         const drop = records.length - MAX_LINES;
         records.splice(0, drop);
-        await GlobalStorageFS.write(HISTORY_PATH, serializeRecords(records));
+        await GlobalStorageFS.writeAtomic(
+          HISTORY_PATH,
+          serializeRecords(records),
+        );
         return;
       }
       await GlobalStorageFS.appendFile(


### PR DESCRIPTION
## Summary

`packages/cli/src/chat/tui/history/inputHistory.ts` persists the TUI's input
history as JSONL, and its own header says why:

> File format: one `{"t": <ms>, "v": "<line>"}` record per line. We avoid a
> single-JSON-blob format so partial writes never corrupt the history.

The compaction branch in `push()` contradicted that. Once the ring hits
`MAX_LINES = 1000`, every subsequent submit takes the `records.length > MAX_LINES`
branch and rewrites the whole file through `GlobalStorageFS.write` — which is
`platform().fs.writeFile`, i.e. truncate-then-write. That is the whole-file
rewrite the JSONL format was chosen to avoid, it is steady state rather than a
corner case (it fires on *every* submit past the cap, not once), and the window
covers up to 1000 x `MAX_LINE_CHARS` (4000) ~ 4 MB. A crash or `SIGKILL` inside
it truncates the user's shell history.

`GlobalStorageFS.writeAtomic` is the crash-safe member of the same family
(`BaseFS.writeAtomic` -> `platform().fs.writeFileAtomic` -> `write-file-atomic`,
staged temp file + rename). It is already inherited at this exact call site with
no new import — `GlobalStorageFS extends RelativeFS extends BaseFS` and neither
subclass overrides it — and the sibling `externalInquiryStorage.writeThreadManifest`
already calls `writeAtomic` on the very same `GlobalStorageFS` class. This is the
straggler joining the family it already belongs to.

### What this does NOT fix (stated up front)

Atomicity is not mutual exclusion. Two `texra` TUIs share
`~/.texra/<global>/tui/input-history.jsonl`; a session at cap still rewrites from
its own stale in-memory ring and erases the other session's appends. `writeAtomic`
makes each such rewrite all-or-nothing, it does not serialise them.

The obvious fix for that — wrapping the compaction in
`platform().fileLocks.runExclusive` — is **deliberately not done here**. The port
exists and is wired for the CLI, but `nodeFileLocks` defaults to a `proper-lockfile`
acquire/release round trip (plus a `mkdir`) with `staleMs: 120_000` / `updateMs: 2_000`
and 8 retries, and paying that on **every message submit** in the TUI hot path once
the user is past the cap is an unpriced cost. If the concurrent-session clobber is
worth fixing, it deserves its own PR with that cost measured. No follow-up issue is
filed because the behaviour predates this PR and is unchanged by it.

### `HistoryRecordSchema.t` keeps `.catch(0)` — deliberately. Please do not re-open this.

An earlier revision of this PR also respelled `t: z.number().catch(0)` as
`.prefault(0)`, on the grounds that CLAUDE.md forbids `.catch` on persisted data
that feeds a later whole-file write. **That hunk has been reverted**, and the
reasoning is recorded here so the next reader does not redo it.

The load path is:

```ts
const rec = parseJsonWith(line, HistoryRecordSchema).unwrapOr(undefined);
if (rec && rec.v.length > 0) records.push(rec);
```

A parse failure drops the **whole line**, silently. So for a stored record like
`{"t":"abc","v":"git push --force-with-lease"}`:

| | `.catch(0)` (kept) | `.prefault(0)` (reverted) |
| --- | --- | --- |
| missing / `undefined` `t` | `0` | `0` — identical |
| numeric `t` | kept | kept — identical |
| **non-numeric `t`** | **`v` survives** with a cosmetic zeroed timestamp | parse fails, **the user's history entry is destroyed** |

That trade is backwards. The rule against `.catch` on persisted data exists
because `.catch` can launder corruption into a later whole-file write and make it
permanent — but here the laundered field is **display-only**: `t` is used for
ordering and display, never as a key, an identity, or a lifecycle value. The
alternative discards the actual payload to avoid a wrong display timestamp.

The file's header already documents the intended handling — *"the session reader
skips malformed lines silently"* — and that is meant for genuinely malformed
lines, not for a line whose payload is intact and whose only defect is a
non-numeric timestamp.

Worth recording, because it is the whole point: that hunk shipped in the same PR
that fixes a non-atomic whole-file rewrite, and it would have made that very
rewrite **persist the deletion** of the user's history lines. `.catch(0)` is the
correct spelling for this specific field.

## Issue acceptance gates

n/a — no issue; found by a storage-layer collapse sweep.

## Single source of truth

`BaseFS.writeAtomic` (`src/utils/files/baseFS.ts:101-110`) remains the single
owner of "durably replace a whole storage file". This PR removes the last
`GlobalStorageFS` caller in the CLI that bypassed it for durable state.

## Duplication and abstraction budget

No abstraction added, none removed. One call site re-pointed from
`write` to the `writeAtomic` sibling on the same class. No new export, no new
import, no interface change.

## Net elements (R6)

**Net LoC: +3** — and to be plain about it, this PR is a **net-add, not a
reduction**. It is bought with the defect, not with line count.

| | delta |
| --- | --- |
| Files changed | 1 (0 added, 0 deleted) |
| Exported symbols | 0 (`^[+-]export` over the diff: empty) |
| Classes / interfaces / enums | 0 |
| Functions | 0 |
| Net LoC | +3 (`1 file changed, 4 insertions(+), 1 deletion(-)`) |

The +3 is entirely Prettier reflow: `write(a, b)` -> `writeAtomic(a, b)` no longer
fits on one line. **The semantic change is one identifier.** The complete branch
diff is a single hunk:

```diff
-        await GlobalStorageFS.write(HISTORY_PATH, serializeRecords(records));
+        await GlobalStorageFS.writeAtomic(
+          HISTORY_PATH,
+          serializeRecords(records),
+        );
```

## Consumer counts (R8)

Nothing deleted or re-routed, but here is the grep output, verbatim.

Remaining `GlobalStorageFS.write` callers after this PR — I am **not** claiming
this was the last one:

```
$ rg -n 'GlobalStorageFS\.write\(' --glob '!node_modules' .
./src/agent/index/AgentDirectorySync.ts:88
./src/tools/inquiry/externalInquiryStorage.ts:425
./src/tools/inquiry/externalInquiryStorage.ts:432
./src/tools/inquiry/externalInquiryStorage.ts:491
```

All four are outside `packages/cli/` and are listed under "Scheduled refactoring"
rather than bundled here.

Consumers of the symbols in the changed file:

```
$ rg -n 'HistoryRecordSchema|serializeRecords|loadInputHistory' --glob '!node_modules' --glob '!docs' .
packages/cli/src/chat/tui/history/inputHistory.ts   definitions + internal uses
packages/cli/src/chat/tui/runChatTui.tsx:83,315     loadInputHistory (the one production caller)
src/test-kernel/cli/InputHistory.vitest.ts          loadInputHistory (real fs, the regression net)
src/test-kernel/cli/RunChatSignalOwnership.vitest.ts loadInputHistory (module-mocked, shape untouched)
```

`HistoryRecordSchema` and `serializeRecords` are module-private (no `export`); the
exported symbols (`InputHistory`, `loadInputHistory`) are untouched in signature
and in shape, so the `vi.fn()` mock in `RunChatSignalOwnership.vitest.ts` still
satisfies them. No consumer orphaned.

```
$ git diff HEAD~1 -U0 | grep -E '^[+-]export'
(no output — no exported symbol added or removed)
```

## Host impact

**Extension:** none — file is CLI-only.

**Desktop:** none — file is CLI-only.

**CLI:** compaction of `~/.texra/<global>/tui/input-history.jsonl` is now
crash-safe. `write-file-atomic` stages to a temp file in the same directory and
renames, so an interrupted compaction leaves the previous history intact rather
than a truncated file. No other observable behaviour changes — the file format,
the load path, and the append path are all untouched.

## Scheduled refactoring

None filed. Two things found and deliberately **not** bundled, reported here so
they are on the record — each is an independent one-line change and each deserves
its own review:

- `src/tools/memory/MemoryTool.ts:238` and `src/tools/memory/memoryFileSystem.ts:326`
  rewrite durable memory files with `StorageFS.write`.
- `src/agent/index/AgentDirectorySync.ts:88` — `GlobalStorageAgentDirectoryStorage.write`
  writes synced agent YAML through the non-atomic `write`. Lower stakes (the content
  is re-syncable from source), which is why it is reported rather than changed.
- `src/tools/inquiry/externalInquiryStorage.ts:425`, `:432`, `:491` write turn
  payloads (`question.txt`, `context.txt`, `answer.txt`) non-atomically while the
  sibling manifest **in the same module** goes through `writeAtomic` at `:216` — so
  a torn `answer.txt` can be referenced by a manifest that was itself committed
  atomically.

Plus the file-lock variant for the concurrent-session clobber, held for the cost
reason given in the Summary.

## Validation

- `npm run typecheck` — clean (all six projects, including
  `pnpm --filter @texra-ai/cli typecheck`, which is the only thing that compiles
  `packages/cli/tsconfig.scripts.json`).
- `npx vitest run src/test-kernel/cli/InputHistory.vitest.ts` — **1 file, 3 tests
  passed**. This is the regression net: it drives `loadInputHistory` against a real
  temp dir with `{ fs: nodeFilesystem }` injected, so it exercises the real
  `writeFileAtomic`, not a stub.
- `eslint packages/cli/src/chat/tui/history/inputHistory.ts` — clean.
- `prettier --check` on the changed file — clean.
- `check:dead-code-ratchet` not run — no export added or removed.

All of the above were re-run **after** the `.prefault(0)` revert, against the
single-hunk diff that is what you are reviewing.

The `.catch` / `.prefault` behaviour table above was verified empirically against
the repo's own Zod build rather than recalled, which is how the revert got
decided: `{"t":"abc","v":"..."}` parses to `FAIL` under `.prefault(0)` and the
line is then dropped by `unwrapOr(undefined)`.

## Zero new tests

Per the repo's testing budget: this is a one-identifier bug fix whose regression
net (`InputHistory.vitest.ts`) already exists and already passes. No new test file
and no new test case.
