### PR TITLE
refactor(prompt): derive files-loaded card from the read, not a second stat

### DIFF
--- a/src/agent/prompt/userVars.ts
+++ b/src/agent/prompt/userVars.ts
@@ -368,6 +368,15 @@ const FILE_VAR_CATEGORIES: readonly FileCategoryPrefix[] = [
   'EDITED',
 ];
 
+/**
+ * Files-loaded card label per category. `EDITED` is absent because prompt
+ * assembly has never emitted a card for it.
+ */
+const FILE_CATEGORY_CARD_LABEL: Partial<Record<FileCategoryPrefix, string>> = {
+  INPUT: 'Input Files',
+  CONTEXT: 'Context Files',
+};
+
 /** Variables contributed by the readable file categories. */
 type FileCategoryVars = {
   [P in FileCategoryPrefix as `${P}_FILE`]: string | null;
@@ -414,27 +423,48 @@ async function getFileVars(
     MEDIA_CONTENT: null,
   };
 
-  const contextFiles = getCategoryFiles(agentConfig, 'CONTEXT');
-
-  // Log file categories being loaded (skip for tool-use agents).
-  // Media files are excluded: they have no user vars (display-only in Init)
-  // and are already logged with full load results by MediaExtractionNode in r0.
-  if (agentSetting.agentCategory !== AgentCategory.ToolUse) {
-    await logFileCategoriesWithExistence(logger, [
-      ['Input Files', getCategoryFiles(agentConfig, 'INPUT')],
-      ['Context Files', contextFiles],
-    ]);
-  }
-
   for (const prefix of FILE_VAR_CATEGORIES) {
     const allFiles = getCategoryFiles(agentConfig, prefix);
-    const { xml, readableFiles } =
+    const { xml, readableFiles, skipped } =
       allFiles.length > 0
         ? await getXmlFormatFromReadableFiles(allFiles)
-        : { xml: null, readableFiles: [] };
+        : { xml: null, readableFiles: [], skipped: [] };
     const primaryFile = readableFiles[0];
     if (primaryFile != null) {
       await setVarFromFile(primaryFile, prefix, userVars);
+    }
+
+    // A dropped file changes what the model sees, so report it on the run's own
+    // channel rather than leaving it on a module logger nobody reads.
+    for (const { file, reason } of skipped) {
+      logger.warn(
+        `Skipping unreadable file in prompt context: ${file} (${reason})`,
+      );
+    }
+
+    // The card is derived from the same read that fills the list vars
+    // (`ALL_*S`, `*_FILES`, `LIST_OF_ALL_*S`), so a row's `ok` and that file's
+    // presence in the prompt XML come from one probe and cannot disagree.
+    //
+    // NOT closed here: `setVarFromFile` above re-reads the primary file to fill
+    // `*_FILE`/`*_CONTENT`, and swallows its own failure on a module channel.
+    // A row can therefore still read `ok` while that one pair is null. Separate
+    // probe, separate call path — it needs its own change.
+    //
+    // Tool-use agents get no card. Media files are excluded: they have no user
+    // vars (display-only in Init) and MediaExtractionNode already logs them
+    // with full load results in r0.
+    const cardLabel = FILE_CATEGORY_CARD_LABEL[prefix];
+    if (
+      cardLabel != null &&
+      agentSetting.agentCategory !== AgentCategory.ToolUse
+    ) {
+      const readable = new Set(readableFiles);
+      logFileCategory(
+        logger,
+        cardLabel,
+        allFiles.map((file) => ({ path: file, ok: readable.has(file) })),
+      );
     }
 
     userVars[`ALL_${prefix}S`] = xml;
@@ -448,46 +478,6 @@ async function getFileVars(
   userVars.MEDIA_FILE = mediaFiles[0] ?? null;
 
   return userVars;
-}
-
-/**
- * Log file categories with existence checking.
- * Each category is logged separately with a VS Code native file list message.
- * Uses tuple array for explicit ordering guarantee.
- *
- * Processes all categories in parallel for better performance, but logs
- * them sequentially to preserve the expected UI display order.
- */
-async function logFileCategoriesWithExistence(
-  logger: AgentTrace,
-  categories: Array<[category: string, files: string[]]>,
-): Promise<void> {
-  // Process all categories in parallel for better performance
-  const results = await Promise.all(
-    categories.map(async ([category, files]) => {
-      if (files.length === 0) {
-        return { category, entries: [] };
-      }
-
-      const entries = await Promise.all(
-        files.map(async (filePath) => {
-          try {
-            return { path: filePath, ok: await WorkspaceFS.exists(filePath) };
-          } catch (_err) {
-            // Treat permission/access errors as non-existent
-            return { path: filePath, ok: false };
-          }
-        }),
-      );
-
-      return { category, entries };
-    }),
-  );
-
-  // Log sequentially to preserve UI display order
-  for (const { category, entries } of results) {
-    logFileCategory(logger, category, entries);
-  }
 }
 
 /**

--- a/src/test-kernel/utils/GetXmlFormatFromReadableFiles.vitest.ts
+++ b/src/test-kernel/utils/GetXmlFormatFromReadableFiles.vitest.ts
@@ -64,6 +64,9 @@ describe('getXmlFormatFromReadableFiles', () => {
     expect(result).toEqual({
       xml: '<document name="present.tex">\nbody of present.tex\n</document>',
       readableFiles: ['present.tex'],
+      skipped: [
+        { file: 'missing.tex', reason: expect.stringContaining('ENOENT') },
+      ],
     });
   });
 

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -1,14 +1,17 @@
 import * as path from 'node:path';
 
-import { createLog } from '@logger/logUtils';
 import { filterNotNull } from '@utils/core';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
-
-const log = createLog('promptUtils');
 
 export interface XmlFormatFromFilesResult {
   readonly xml: string | null;
   readonly readableFiles: string[];
+  /**
+   * Files dropped from the prompt because they could not be read. Order is
+   * unspecified — the reads settle concurrently — so do not build on it; each
+   * entry names its own file.
+   */
+  readonly skipped: ReadonlyArray<{ file: string; reason: string }>;
 }
 
 /**
@@ -40,10 +43,12 @@ export function getPromptFileName(file: string): string {
  * Get XML formatted string from multiple files
  *
  * Best-effort: a file that cannot be read (moved, renamed, or deleted since the
- * config was saved) is skipped with a warning rather than rejecting the whole
- * batch. This mirrors {@link setVarFromFile}, which already tolerates missing
- * files, and keeps prompt-var assembly from hard-failing an agent launch/resume
- * when an input no longer exists on disk.
+ * config was saved) is skipped rather than rejecting the whole batch. This
+ * mirrors {@link setVarFromFile}, which already tolerates missing files, and
+ * keeps prompt-var assembly from hard-failing an agent launch/resume when an
+ * input no longer exists on disk. The skip is reported back in `skipped` so the
+ * caller can surface it on the run's own channel — a module logger here would
+ * drop the reason outside the run that lost the file.
  *
  * @param files List of file paths
  * @returns XML formatted string of the readable files, or null if none are readable
@@ -52,9 +57,10 @@ export async function getXmlFormatFromReadableFiles(
   files: string[],
 ): Promise<XmlFormatFromFilesResult> {
   if (files.length === 0) {
-    return { xml: null, readableFiles: [] };
+    return { xml: null, readableFiles: [], skipped: [] };
   }
 
+  const skipped: { file: string; reason: string }[] = [];
   const xmlContents = await Promise.all(
     files.map(async (file) => {
       try {
@@ -64,9 +70,7 @@ export async function getXmlFormatFromReadableFiles(
           xml: `<document name="${getPromptFileName(file)}">\n${content}\n</document>`,
         };
       } catch (err) {
-        log.warn(
-          `Skipping unreadable file in prompt context: ${file} (${String(err)})`,
-        );
+        skipped.push({ file, reason: String(err) });
         return null;
       }
     }),
@@ -75,6 +79,7 @@ export async function getXmlFormatFromReadableFiles(
   return {
     xml: readable.length > 0 ? readable.map((doc) => doc.xml).join('\n') : null,
     readableFiles: readable.map((doc) => doc.file),
+    skipped,
   };
 }
 


### PR DESCRIPTION
## Summary

`buildUserVars` probed every attached input/context file **twice**:

1. `logFileCategoriesWithExistence` ran a `WorkspaceFS.exists` stat purely to build the
   "Input Files" / "Context Files" trace card, and
2. `getXmlFormatFromReadableFiles` then did the real `WorkspaceFS.read` that decides what
   actually enters the prompt.

Two independent opinions about the same fact. Where they disagree (`exists` true, `read` fails
— EISDIR, EACCES, a TOCTOU delete between the two awaits) the trace card shows the file as
loaded while the prompt silently lacks it. That window is narrow, and I want to be honest about
it: the common case (file deleted since the config was saved) already agrees.

The bigger problem is the second half. When a file *is* dropped, the reason was captured in
`src/utils/prompt.ts` and written to `createLog('promptUtils')` — a module channel that never
enters the run's `AgentTrace`. The user gets no warning in the run that lost the file. That is
the repo's silent-degradation rule (CLAUDE.md: "a fallback that masks a failure must be loud —
or not exist"), and it is the stronger justification for this change.

Fix: derive the trace card from the read that fills the prompt's list variables, the way
`MediaAttachmentProcessor.loadEntries` already derives `ok` from the real load, and route the
skip reason to the run's own channel.

## Issue acceptance gates

No issue — found by a collapse sweep over prompt assembly. Self-imposed gates: no `exists` probe
competing with the read that fills the list vars, skip reasons visible in the run, no behaviour
change to card content/ordering, zero new tests.

## Single source of truth

`getXmlFormatFromReadableFiles` (`src/utils/prompt.ts`) is now the single owner of "which
attached files reached the prompt **as documents**". The list variables (`ALL_*S`, `*_FILES`,
`LIST_OF_ALL_*S`) and the files-loaded trace card are both derived from its one result, so a
card row's `ok` and that file's presence in the prompt XML can no longer disagree.

**Scope of that claim, stated precisely** (thanks to the `texra-ai` review for catching the
overclaim in the first revision): this does **not** make the card agree with every prompt
variable. The primary file's `*_FILE`/`*_CONTENT` pair is still filled by a **second,
independent read** in `setVarFromFile` (`src/utils/files/varsUtils.ts`), which swallows its own
failure at `log.debug` on the `VarsUtils` module channel. A card row can therefore still read
`ok: true` while `INPUT_CONTENT` is null. That is a pre-existing window this PR does not close —
see Scheduled refactoring. The code comment at the card site names it explicitly rather than
implying it is closed.

## Duplication and abstraction budget

Removed: one duplicated per-file filesystem probe (`WorkspaceFS.exists`) and the helper built
around it. No new abstraction — the card is emitted inline in the existing
`FILE_VAR_CATEGORIES` loop. `FILE_CATEGORY_CARD_LABEL` is a 4-line data table, not a layer.

`AgentTrace` was deliberately **not** threaded into `@utils/prompt`; the function returns
`skipped: {file, reason}[]` and `userVars` decides how to surface it. `@utils` stays
logger-free and no host/agent coupling is added to a utils module. The `skipped` order is
documented as unspecified (the reads settle concurrently); each entry names its own file, which
is exactly as much ordering as the module logger it replaces offered.

## Net elements (R6)

| | + | − | net |
|---|---|---|---|
| Files | 0 | 0 | 0 |
| Exported symbols | 0 | 0 | 0 |
| Functions | 0 | 1 (`logFileCategoriesWithExistence`) | **−1** |
| Module-level consts | 1 (`FILE_CATEGORY_CARD_LABEL`) | 1 (`log` in `prompt.ts`) | 0 |
| Interface fields | 1 (`XmlFormatFromFilesResult.skipped`) | 0 | +1 |
| LoC — production | +60 | −65 | **−5** |
| LoC — test | +3 | 0 | +3 |
| LoC — total | +63 | −65 | **−2** |

Per file: `src/agent/prompt/userVars.ts` +44/−54, `src/utils/prompt.ts` +16/−11,
`src/test-kernel/utils/GetXmlFormatFromReadableFiles.vitest.ts` +3/−0.

**Saying this plainly: after the review fix this is barely a line reduction at all** (−2 total).
The revised comments — which now record what the shared probe does and does not guarantee, and
that `skipped` is unordered — cost 11 lines on top of the first revision's −13. The change is
worth taking for the behaviour (one fewer stat per file per launch, and a skipped file that is
now loud on the run's own channel instead of silent), not for the line count.

## Consumer counts (R8)

```
$ grep -rn "logFileCategoriesWithExistence" src packages --include="*.ts"
(no results after the change — the deleted helper had exactly one caller)

$ grep -rn "getXmlFormatFromReadableFiles" src packages --include="*.ts"
src/utils/prompt.ts:51                                          definition
src/agent/prompt/userVars.ts:430                                the single production caller
src/test-kernel/utils/GetXmlFormatFromReadableFiles.vitest.ts   4 call sites
src/test-kernel/utils/WorkflowPromptFileNames.vitest.ts:36      1 call site
```

`createLog`/`log` had exactly one use in `src/utils/prompt.ts` (the deleted `log.warn`), so the
import goes with it. `logFilesLoaded` and `WorkspaceFS` are still used elsewhere in
`userVars.ts`; their imports stay. No emit path or export was removed.

## Behaviour preserved

- Card order is still Input then Context — the loop visits `INPUT` before `CONTEXT`.
- Tool-use agents still get no card.
- `logFileCategory` early-returns on an empty list, so empty categories still emit nothing.
- `EDITED` still gets no card. `FILE_VAR_CATEGORIES` is `['INPUT','CONTEXT','EDITED']`, so a
  naive loop would have silently added a third card; `FILE_CATEGORY_CARD_LABEL` omits it on
  purpose.

## Host impact

Extension: files-loaded card in the progress view is now sourced from the read, not a stat.
Same rows, same order.

Desktop: same, shared code path.

CLI: same, shared code path. Skipped files now produce a `warn` line in the run transcript
where previously they produced nothing.

## Scheduled refactoring

**Not fixed here, deliberately: the `setVarFromFile` primary-content probe.**
`getFileVars` calls `setVarFromFile(primaryFile, prefix, userVars)` to fill `*_FILE`/`*_CONTENT`,
and that helper performs its own `WorkspaceFS.read` of a file the batch read has already read
successfully. On failure it returns `false`, which the caller ignores, and logs at `log.debug`
on the `VarsUtils` module channel — quieter than the `log.warn` this PR just removed. Net effect:
`INPUT_CONTENT` can be null in a prompt whose card row says `ok`.

It is a separate probe on a separate call path (`setVarFromFile` has other callers and an
`absolute` mode), the fix is not a comment change, and folding it in would make this PR two
changes. Left for its own change; no follow-up issue filed yet.

## Validation

- `npm run typecheck` — clean across the whole workspace (root, `@texra-ai/agent`, cli,
  trace-viewer, desktop, extension), exit 0. Re-run after the review fix.
- `npx vitest run src/test-kernel/utils/GetXmlFormatFromReadableFiles.vitest.ts src/test-kernel/utils/WorkflowPromptFileNames.vitest.ts src/test-kernel/agent/prompt/userVars.vitest.ts src/test-kernel/agent/trace/AgentTrace.vitest.ts`
  — **4 files / 40 tests passed**. Re-run after the review fix.
- `npx eslint` on the changed files — clean.
- `npx prettier --check` on the changed files — clean.
- `check:dead-code-ratchet` not run: no export added or removed.

Zero new tests. One existing assertion was **updated**, not added:
`GetXmlFormatFromReadableFiles.vitest.ts` pins the entire result object with `toEqual`, so the
new `skipped` field had to be spelled out (+3 lines). It now also pins that the skip reason
survives — the behaviour this PR exists for. `userVars.vitest.ts` asserts nothing about the
trace logger, and `AgentTrace.vitest.ts` tests `logFileCategory` directly with an unchanged
signature; both pass untouched.
