### PR TITLE
refactor(shared): one spelling and one position rule for workflow phase headings

### DIFF
--- a/src/shared/copy/workflowCall.ts
+++ b/src/shared/copy/workflowCall.ts
@@ -109,20 +109,22 @@ export interface WorkflowPhaseHeading {
 }
 
 /**
- * Canonical heading copy for one workflow phase (`Reduce (2/3)`), shared by
- * every surface that names a phase: the transcript's `◆` divider, the live
- * run-status band, and the focused run's child-list group headers. The leading
- * glyph is left to the caller — the band deliberately carries none. The index
- * is 0-based on the wire and 1-based in the copy.
+ * Canonical heading copy for one workflow phase, shared by every surface that
+ * names a phase: the transcript's `◆` divider, the live run-status band, the
+ * status bar's stage slot, and the focused run's child-list group headers. The
+ * leading glyph is left to the caller — the band deliberately carries none.
+ * The index is 0-based on the wire and 1-based in the copy.
+ *
+ * `Reduce (2/3)` with a position and a planned total, `Reduce (2)` with only a
+ * position — a phase appended after the declared list keeps its position rather
+ * than losing it — and the bare label for a dynamically opened phase.
  */
 export function formatWorkflowPhaseHeading(
   phase: WorkflowPhaseHeading,
 ): string {
-  const counts =
-    phase.phaseIndex !== undefined && phase.phaseTotal !== undefined
-      ? ` (${phase.phaseIndex + 1}/${phase.phaseTotal})`
-      : '';
-  return `${phase.phaseLabel}${counts}`;
+  if (phase.phaseIndex === undefined) return phase.phaseLabel;
+  const total = phase.phaseTotal !== undefined ? `/${phase.phaseTotal}` : '';
+  return `${phase.phaseLabel} (${phase.phaseIndex + 1}${total})`;
 }
 
 /**

--- a/src/shared/streams/streamStatusDisplay.ts
+++ b/src/shared/streams/streamStatusDisplay.ts
@@ -8,6 +8,7 @@ import {
   type StreamStage,
   type StreamSubstate,
 } from '@shared/schemas';
+import { formatWorkflowPhaseHeading } from '@shared/copy/workflowCall';
 
 export type StreamStatusDisplayKey =
   | Exclude<StreamLifecycleStatus, typeof STREAM_STATUS.READY>
@@ -146,18 +147,19 @@ export function formatRoundStageLabel(
   return stage.total !== undefined ? `${current}/${stage.total}` : current;
 }
 
-/** Compact phase progress label for a workflow-script run: `Reduce 2/3` when
- *  the phase was declared with a position and a planned total, `Reduce 2` with
- *  only a position, and the bare title for a dynamically opened phase.
- *  Zero-based `index` renders one-based. Occupies the same row slot as
+/** Phase progress label for a workflow-script run, spelled by the one owner of
+ *  phase heading copy so this slot cannot drift from the transcript divider and
+ *  the run-status band that render beside it. Occupies the same row slot as
  *  `formatRoundStageLabel` — a run opens phases or rounds, never both. */
 export function formatPhaseStageLabel(
   stage: Readonly<PhaseStage> | undefined,
 ): string | undefined {
   if (stage === undefined) return undefined;
-  if (stage.index === undefined) return stage.label;
-  const current = `${stage.label} ${stage.index + 1}`;
-  return stage.total !== undefined ? `${current}/${stage.total}` : current;
+  return formatWorkflowPhaseHeading({
+    phaseLabel: stage.label,
+    phaseIndex: stage.index,
+    phaseTotal: stage.total,
+  });
 }
 
 /** Label for the one stage slot a stream fills: a workflow-script run advances

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -691,10 +691,10 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    const segment = display.left.find((item) => item.text === 'Reduce 2/3');
+    const segment = display.left.find((item) => item.text === 'Reduce (2/3)');
     expect(segment).toBeDefined();
     // Narrow terminals degrade to the bare current phase, not to nothing.
-    expect(segment?.compactText).toBe('Reduce 2');
+    expect(segment?.compactText).toBe('Reduce (2)');
   });
 
   it('prefixes the running label with the current spin frame', () => {

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -1069,12 +1069,12 @@ describe('CLI child list display model', () => {
       // One line per row at every width — the phase takes the round's slot
       // rather than adding one.
       expect(
-        output.split('\n').filter((line) => line.includes('Reduce 2/3')),
+        output.split('\n').filter((line) => line.includes('Reduce (2/3)')),
       ).toHaveLength(1);
-      expect(output).toContain('workflow-script running · Reduce 2/3');
+      expect(output).toContain('workflow-script running · Reduce (2/3)');
       expect(output).toContain('reflect running · r2/3');
-      expect(output).not.toContain('Reduce 2/3 · r2/3');
-      expect(output).not.toContain('r2/3 · Reduce 2/3');
+      expect(output).not.toContain('Reduce (2/3) · r2/3');
+      expect(output).not.toContain('r2/3 · Reduce (2/3)');
     },
   );
 

--- a/src/test-kernel/progressView/BackgroundTasksPanel.vitest.ts
+++ b/src/test-kernel/progressView/BackgroundTasksPanel.vitest.ts
@@ -166,9 +166,9 @@ describe('background-tasks-panel', () => {
       (node) => node.textContent,
     );
     // Only the run carries a phase; a stream without one gains no span.
-    expect(phases).toEqual(['Reduce 2/3']);
+    expect(phases).toEqual(['Reduce (2/3)']);
     const rows = [...shadow.querySelectorAll('.task-header')];
-    expect(rows[0]?.textContent).toContain('Reduce 2/3');
+    expect(rows[0]?.textContent).toContain('Reduce (2/3)');
     expect(rows[1]?.textContent).not.toContain('Reduce');
 
     container.remove();

--- a/src/test-kernel/progressView/StreamHeader.vitest.ts
+++ b/src/test-kernel/progressView/StreamHeader.vitest.ts
@@ -254,7 +254,7 @@ describe('stream-header', () => {
             stage: { kind: 'phase', label: 'Reduce', index: 1, total: 3 },
           }),
         },
-        text: 'Reduce 2/3',
+        text: 'Reduce (2/3)',
         tooltip: 'Phase 2 of 3: Reduce',
       },
       {
@@ -273,7 +273,7 @@ describe('stream-header', () => {
             conversationProgress: { toolCallCount: 4 },
           }),
         },
-        text: 'Reduce 2/3, 4 tool calls',
+        text: 'Reduce (2/3), 4 tool calls',
         tooltip: 'Phase 2 of 3: Reduce, Tool calls: 4',
       },
     ])('$name', async ({ props, text, tooltip }) => {

--- a/src/test-kernel/shared/SharedStreams.vitest.ts
+++ b/src/test-kernel/shared/SharedStreams.vitest.ts
@@ -163,13 +163,13 @@ describe('formatRoundStageLabel', () => {
 describe('formatPhaseStageLabel', () => {
   it('renders the one-based phase over the declared total', () => {
     expect(formatPhaseStageLabel({ label: 'Reduce', index: 1, total: 3 })).toBe(
-      'Reduce 2/3',
+      'Reduce (2/3)',
     );
   });
 
   it('renders the bare position when no total was declared', () => {
     expect(formatPhaseStageLabel({ label: 'Reduce', index: 1 })).toBe(
-      'Reduce 2',
+      'Reduce (2)',
     );
   });
 
@@ -192,7 +192,7 @@ describe('formatStageLabel', () => {
   it('labels a phase stage through the phase formatter', () => {
     expect(
       formatStageLabel({ kind: 'phase', label: 'Reduce', index: 1, total: 3 }),
-    ).toBe('Reduce 2/3');
+    ).toBe('Reduce (2/3)');
   });
 
   it('passes undefined through for a stream with no stage open', () => {


### PR DESCRIPTION
## Summary

One fact — a workflow phase's `{label, index, total}` — was formatted by two
functions that both live in `src/shared/` and produced two different spellings:

- `formatWorkflowPhaseHeading` (`src/shared/copy/workflowCall.ts`) emitted
  `Reduce (2/3)`; its ternary required **both** index and total or dropped the
  position entirely. 8 call sites.
- `formatPhaseStageLabel` (`src/shared/streams/streamStatusDisplay.ts`),
  reached via `formatStageLabel`, emitted `Reduce 2/3`, or `Reduce 2` when the
  total was missing. 4 call sites.

Both render for the **same focused stream in one frame**. `ConversationRegion.tsx`
renders `<ConversationPane>` (`:255`), `renderFooterChrome()` (`:284`, which carries
the status bar) and `<SubagentList>` (`:287`) together, so the status bar read
`Reduce 2/3` while the band one region above read `Reduce (2/3)` and the transcript
divider above that read `◆ Reduce (2/3)`.

The degradation also differed, and that half is a real defect. The emitter at
`src/tools/delegation/workflowScriptRun.ts:432-439` gives a phase appended after the
first folded snapshot an index and **no** total:

```ts
declaredStageTotal ??= snapshot.stages.length;
const phase = phaseFor(
  stage.title,
  stage.order,
  stage.order < declaredStageTotal ? declaredStageTotal : undefined,
);
```

On that phase the status bar read `Reduce 5` while the band and the divider read a
bare `Reduce` — the position present on one surface and silently gone on the two
above it. The repo has already ruled this class of loss a bug:
`src/shared/transcript/projectTranscriptRow.ts:326-332` carries code and a comment
saying `(2/3)` must not vanish when a phase ends, and the extension's
`stageBadgeTitle` handles index-without-total too (`Phase 2: Reduce`).
`formatWorkflowPhaseHeading` was the sole outlier.

After this PR `formatWorkflowPhaseHeading` owns the position rule for all three
cases (`Reduce (2/3)`, `Reduce (2)`, bare `Reduce`), and `formatPhaseStageLabel`
keeps its name and its `PhaseStage` signature as a ~5-line adapter over it.
**Zero call sites move.**

**Accepted, deliberate cost:** the status bar's narrow-terminal degradation
(`statusBarDisplay.ts:300-304`, which strips `total` on purpose) goes `Reduce 2` →
`Reduce (2)` — two columns wider in a width-constrained slot. This is *not* papered
over with a `parens?: boolean` option; that would reintroduce two spellings behind
one name. Parens win 8 call sites to 4.

## Issue acceptance gates

No issue. This came out of a verified collapse sweep over `workflow-script-engine`
(candidate C1), scouted and then adversarially re-verified.

## Single source of truth

`formatWorkflowPhaseHeading` in `src/shared/copy/workflowCall.ts` is now the only
place that decides how a phase's position renders. `formatPhaseStageLabel` is a
`PhaseStage → WorkflowPhaseHeading` key rename and nothing else;
`formatStageLabel` keeps its `kind` dispatch to the round formatter unchanged.

## Duplication and abstraction budget

Removed: the second position-formatting rule (index+total / index-only / neither)
and the second spelling of the same heading. **No new abstraction, no new export,
no new file, no wrapper layer** — one existing function's body became a delegation
to another existing function in the same package.

Deliberately *not* done: deleting `formatPhaseStageLabel` and repointing its four
callers (the scout's original proposal). Two blockers refute it —
`BackgroundTasksPanel.ts:429` reads a `PhaseStage` that has no `kind` field (it only
gains one inside `StreamStageSchema`), so it would need a synthetic
`{kind: 'phase', …}` spread at the call site; and `formatStageLabel` must keep
dispatching rounds either way.

## Net elements (R6)

**This change is LoC-neutral — it does not reduce line count, and I am not selling
it as a reduction.** The payoff is one spelling and one position-formatting rule.

| | Δ |
|---|---|
| Files | 0 added, 0 deleted (7 modified) |
| Exported symbols (`^[+-]export` over the diff) | 0 added, 0 removed |
| Classes / interfaces / enums / types | 0 |
| Production LoC | **+3** (`workflowCall.ts` +12/−10, `streamStatusDisplay.ts` +9/−7) |
| Test LoC | **0** (5 files, +15/−15, all pinned-string updates) |

The `+3` production lines are entirely doc comment: the function bodies shrank
(`formatWorkflowPhaseHeading` 9→7 lines, `formatPhaseStageLabel` 8→9 with one
import), while the JSDoc grew to state all three cases and the drift invariant in
one place. Deleting the now-redundant half of `formatPhaseStageLabel`'s doc did not
cover it.

## Consumer counts (R8)

Nothing was deleted or re-routed — every call site is untouched — but here is the
grep that proves it:

```
$ grep -rn "formatPhaseStageLabel\|formatStageLabel\|formatWorkflowPhaseHeading" src packages
```

- `formatWorkflowPhaseHeading` — 8 production call sites
  (`projectTranscriptRow.ts:336`, `transcriptEntryLayout.ts:341`,
  `StaticConversationTranscript.tsx:154`, `ConversationPane.tsx:196`,
  `SubagentList.tsx:108,443,567`, `workflowPhase.ts:70`,
  `workflowPlainOutput.ts:96`, `TaskGroupList.ts:454`) — all unchanged, plus one
  new internal caller (`formatPhaseStageLabel`).
- `formatStageLabel` — 4 call sites (`statusBarDisplay.ts:297,304`,
  `SubagentList.tsx:157`, `progressBadgeFormatter.ts:14`) — unchanged.
- `formatPhaseStageLabel` — 1 direct external caller
  (`BackgroundTasksPanel.ts:429`) plus `formatStageLabel` — unchanged, still
  exported, still takes `PhaseStage`.

Layering: `@shared/streams/*` → `@shared/copy/*` is intra-`src/shared`;
`eslint.config.mjs` has no rule between them and no ratchet in `config/ratchets/`
names `shared/copy`. `workflowCall.ts` is already webview-reachable
(`TaskGroupList.ts:24`) and imports only `@shared/schemas` and
`@utils/text/stringUtils` (one of the seven browser-safe modules), so
`streamStatusDisplay.ts` gains no non-browser-safe dependency.

## Host impact

**Extension:** the progress-view stage badge and the background-tasks panel phase
span now read `Reduce (2/3)` instead of `Reduce 2/3`, matching the phase headings
the same view already renders through `TaskGroupList`. A phase with an index but no
declared total now shows `Reduce (5)` where it previously showed a bare `Reduce` in
the task-group heading.

**Desktop:** no direct change (shares the CLI/extension surfaces).

**CLI:** the status-bar stage slot reads `Reduce (2/3)`, matching the run-status
band and the `◆` transcript divider rendered in the same frame. Narrow-terminal
compact text goes `Reduce 2` → `Reduce (2)`, two columns wider — accepted, see
Summary.

## Scheduled refactoring

None from this PR. Two neighbours found by the same sweep are deliberately left
alone: the run-scoped `done/total` counter in `SubagentList.tsx:459-462` (a real
divergence, but it needs a maintainer ruling on which scope the heading is for —
not a collapse), and the raw `'◆'` literals in `workflowPlainOutput.ts:96,112` that
duplicate `STATUS_DIAMOND` (3 lines, zero observable effect — below the bar for its
own PR).

## Validation

- `npm run typecheck` — pass (root + agent + extension + **cli, including
  `tsconfig.scripts.json`** + trace-viewer + desktop).
- `npm run lint` — pass, no warnings.
- `npx vitest run` over the 7 suites that touch this copy —
  `SharedStreams`, `StatusBar`, `SubagentListDisplay`, `BackgroundTasksPanel`,
  `StreamHeader`, `ConversationTranscript`, `WorkflowPlainOutput` — **7 files /
  269 tests passed**.
- `check:dead-code-ratchet` **not run**: no export was added or removed.
- **Zero new tests.** Five suites had pinned strings updated in place
  (`SharedStreams.vitest.ts`, `StatusBar.vitest.ts`, `SubagentListDisplay.vitest.ts`,
  `BackgroundTasksPanel.vitest.ts`, `StreamHeader.vitest.ts`); the last two were not
  in the brief and were found by grepping for the paren-free spelling repo-wide.
