### PR TITLE
refactor(errors): build quota-limit copy from the fallback catalog

### DIFF
--- a/src/common/errors/sdkError/chatgptSubscriptionDetection.ts
+++ b/src/common/errors/sdkError/chatgptSubscriptionDetection.ts
@@ -1,7 +1,3 @@
-import prettyMilliseconds from 'pretty-ms';
-
-import { capitalize } from '@utils/text/stringUtils';
-
 import {
   errorBodyCandidates,
   pickNumberField,
@@ -45,43 +41,4 @@ export function parseChatGptSubscriptionLimit(
     };
   }
   return null;
-}
-
-/**
- * Format a coarse "1d 20h" / "20h 22m" / "5m" duration from a second count.
- * Day+hour, hour+minute, or minute granularity is plenty for a reset-window
- * hint; sub-minute collapses to a friendly phrase. Pure (no clock read), so it
- * stays usable from the synchronous error formatter. Backed by `pretty-ms`
- * (top 2 units) rather than hand-rolled day/hour/minute math — minutes are
- * truncated once the duration reaches a day, matching the "day granularity
- * drops minutes" rule of the original hand-rolled formatter (pretty-ms would
- * otherwise back-fill a zero hour component with minutes, e.g. "1d 58m").
- * Shared with {@link describeGlmCodingPlanLimit}, which formats its reset
- * hint identically.
- */
-export function formatResetDuration(totalSeconds: number): string {
-  const wholeMinutes = Math.floor(Math.max(0, totalSeconds) / 60);
-  if (wholeMinutes === 0) return 'less than a minute';
-  const flooredMinutes =
-    wholeMinutes >= 1440 ? wholeMinutes - (wholeMinutes % 60) : wholeMinutes;
-  return prettyMilliseconds(flooredMinutes * 60_000, { unitCount: 2 });
-}
-
-/**
- * Human-readable message for a subscription usage-limit error: plan name (when
- * present), how long until the quota resets (from `resets_in_seconds`, no clock
- * read needed), and the actionable next step.
- */
-export function describeChatGptSubscriptionLimit(
-  info: ChatGptSubscriptionLimit,
-): string {
-  const plan = info.planType ? ` (${capitalize(info.planType)} plan)` : '';
-  const reset =
-    info.resetsInSeconds !== undefined
-      ? ` Resets in ${formatResetDuration(info.resetsInSeconds)}.`
-      : '';
-  return (
-    `ChatGPT subscription usage limit reached${plan}.${reset}` +
-    ' Switch to your own OpenAI API key to keep working, or wait until the limit resets.'
-  );
 }

--- a/src/common/errors/sdkError/glmCodingPlanDetection.ts
+++ b/src/common/errors/sdkError/glmCodingPlanDetection.ts
@@ -1,4 +1,3 @@
-import { formatResetDuration } from './chatgptSubscriptionDetection';
 import {
   errorBodyCandidates,
   pickNumberField,
@@ -112,20 +111,5 @@ export function describeGlmCodingPlanRateLimit(): string {
   return (
     'GLM Coding Plan rate limit reached. Wait a moment and retry; the plan is ' +
     'still active.'
-  );
-}
-
-/**
- * Human-readable message for a GLM Coding Plan usage-limit error: how long
- * until the quota resets (when reported) and the actionable next step.
- */
-export function describeGlmCodingPlanLimit(info: GlmCodingPlanLimit): string {
-  const reset =
-    info.resetsInSeconds !== undefined
-      ? ` Resets in ${formatResetDuration(info.resetsInSeconds)}.`
-      : '';
-  return (
-    `GLM Coding Plan usage limit reached.${reset}` +
-    ' Switch to the regular GLM endpoint to keep working, or wait until the limit resets.'
   );
 }

--- a/src/common/errors/sdkError/kimiCodeSubscriptionDetection.ts
+++ b/src/common/errors/sdkError/kimiCodeSubscriptionDetection.ts
@@ -1,6 +1,5 @@
 import { KIMI_CODE_BASE_URL } from '@shared/constants/providers';
 
-import { formatResetDuration } from './chatgptSubscriptionDetection';
 import {
   firstBodyNumberField,
   firstBodyStringField,
@@ -62,23 +61,4 @@ export function parseKimiCodeSubscriptionLimit(
   return {
     resetsInSeconds: firstBodyNumberField(rawErrorBody, 'resets_in_seconds'),
   };
-}
-
-/**
- * Human-readable message for a Kimi Code usage-limit error: how long until the
- * quota resets (when reported) and the actionable next step.
- */
-export function describeKimiCodeSubscriptionLimit(
-  info: KimiCodeSubscriptionLimit,
-): string {
-  // Shared with the ChatGPT and GLM detectors so all three providers render the
-  // same reset-window format for the same `resets_in_seconds` field.
-  const reset =
-    info.resetsInSeconds !== undefined
-      ? ` Resets in ${formatResetDuration(info.resetsInSeconds)}.`
-      : '';
-  return (
-    `Kimi Code subscription usage limit reached.${reset}` +
-    ' Switch to your own Moonshot API key to keep working, or wait until the limit resets.'
-  );
 }

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -1,7 +1,12 @@
 import stableStringify from 'fast-json-stable-stringify';
 import { StatusCodes } from 'http-status-codes';
+import prettyMilliseconds from 'pretty-ms';
 
 import { safeParseJson } from '@common/parsing/safeParseJson';
+import {
+  type QuotaFallbackExhaustionReason,
+  QUOTA_FALLBACK_ROUTES,
+} from '@shared/quotaFallbackRoutes';
 import {
   type ErrorContext,
   type ErrorLogData,
@@ -15,6 +20,7 @@ import {
   extractErrorMessage,
   toErrorMessage,
 } from '@utils/errors/errorMessage';
+import { capitalize } from '@utils/text/stringUtils';
 
 import {
   causeChain,
@@ -44,24 +50,14 @@ import {
   isUpstreamCreditDepletedBody,
   safeGetReasonPhrase,
 } from './errorInspection';
+import { parseChatGptSubscriptionLimit } from './chatgptSubscriptionDetection';
+import { parseKimiCodeSubscriptionLimit } from './kimiCodeSubscriptionDetection';
 import {
-  describeChatGptSubscriptionLimit,
-  parseChatGptSubscriptionLimit,
-} from './chatgptSubscriptionDetection';
-import {
-  describeKimiCodeSubscriptionLimit,
-  parseKimiCodeSubscriptionLimit,
-} from './kimiCodeSubscriptionDetection';
-import {
-  describeGlmCodingPlanLimit,
   describeGlmCodingPlanRateLimit,
   isGlmCodingPlanRateLimit,
   parseGlmCodingPlanLimit,
 } from './glmCodingPlanDetection';
-import {
-  describeXaiSubscriptionLimit,
-  parseXaiSubscriptionLimit,
-} from './xaiSubscriptionDetection';
+import { parseXaiSubscriptionLimit } from './xaiSubscriptionDetection';
 import {
   type SdkErrorEntry,
   SDK_ERRORS,
@@ -77,41 +73,72 @@ interface QuotaLimitMatch {
   readonly message: string;
 }
 
+/** What a quota-limit body can report; only ChatGPT carries a plan name. */
+interface QuotaLimitInfo {
+  readonly planType?: string;
+  readonly resetsInSeconds?: number;
+}
+
 /**
- * First matching quota-fallback detector. Order is the catalog's: ChatGPT,
- * Grok, then coding plans. Reasons are mutually exclusive, so the first hit
- * is the only hit.
+ * Quota-limit body parsers, keyed by the catalog's exhaustion reason. Total
+ * over {@link QuotaFallbackExhaustionReason}, so a fifth `QUOTA_FALLBACK_ROUTES`
+ * entry fails to compile until its detector lands rather than shipping a
+ * switchable route with no error copy.
+ */
+const QUOTA_LIMIT_PARSERS: Record<
+  QuotaFallbackExhaustionReason,
+  (err: unknown, rawErrorBody: unknown) => QuotaLimitInfo | null
+> = {
+  'chatgpt-subscription': (_err, rawErrorBody) =>
+    parseChatGptSubscriptionLimit(rawErrorBody),
+  'xai-subscription': parseXaiSubscriptionLimit,
+  'kimi-code-subscription': parseKimiCodeSubscriptionLimit,
+  'glm-coding-plan': (_err, rawErrorBody) =>
+    parseGlmCodingPlanLimit(rawErrorBody),
+};
+
+/**
+ * Format a coarse "1d 20h" / "20h 22m" / "5m" duration from a second count.
+ * Day+hour, hour+minute, or minute granularity is plenty for a reset-window
+ * hint; sub-minute collapses to a friendly phrase. Pure (no clock read), so it
+ * stays usable from this synchronous formatter. Backed by `pretty-ms` (top 2
+ * units) rather than hand-rolled day/hour/minute math — minutes are truncated
+ * once the duration reaches a day, matching the "day granularity drops
+ * minutes" rule of the original hand-rolled formatter (pretty-ms would
+ * otherwise back-fill a zero hour component with minutes, e.g. "1d 58m").
+ */
+function formatResetDuration(totalSeconds: number): string {
+  const wholeMinutes = Math.floor(Math.max(0, totalSeconds) / 60);
+  if (wholeMinutes === 0) return 'less than a minute';
+  const flooredMinutes =
+    wholeMinutes >= 1440 ? wholeMinutes - (wholeMinutes % 60) : wholeMinutes;
+  return prettyMilliseconds(flooredMinutes * 60_000, { unitCount: 2 });
+}
+
+/**
+ * First matching quota-fallback detector, walked in catalog order (ChatGPT,
+ * Grok, then coding plans). Reasons are mutually exclusive, so the first hit is
+ * the only hit. The sentence is built from the matched route's own noun
+ * phrases, so the retry copy can never name a different source or fallback
+ * than the preference switch the user is about to accept.
  */
 function detectQuotaLimit(
   err: unknown,
   rawErrorBody: unknown,
 ): QuotaLimitMatch | undefined {
-  const chatgpt = parseChatGptSubscriptionLimit(rawErrorBody);
-  if (chatgpt) {
+  for (const route of QUOTA_FALLBACK_ROUTES) {
+    const info = QUOTA_LIMIT_PARSERS[route.exhaustionReason](err, rawErrorBody);
+    if (!info) continue;
+    const plan = info.planType ? ` (${capitalize(info.planType)} plan)` : '';
+    const reset =
+      info.resetsInSeconds !== undefined
+        ? ` Resets in ${formatResetDuration(info.resetsInSeconds)}.`
+        : '';
     return {
-      exhaustionReason: 'chatgpt-subscription',
-      message: describeChatGptSubscriptionLimit(chatgpt),
-    };
-  }
-  const grok = parseXaiSubscriptionLimit(err, rawErrorBody);
-  if (grok) {
-    return {
-      exhaustionReason: 'xai-subscription',
-      message: describeXaiSubscriptionLimit(grok),
-    };
-  }
-  const kimi = parseKimiCodeSubscriptionLimit(err, rawErrorBody);
-  if (kimi) {
-    return {
-      exhaustionReason: 'kimi-code-subscription',
-      message: describeKimiCodeSubscriptionLimit(kimi),
-    };
-  }
-  const glm = parseGlmCodingPlanLimit(rawErrorBody);
-  if (glm) {
-    return {
-      exhaustionReason: 'glm-coding-plan',
-      message: describeGlmCodingPlanLimit(glm),
+      exhaustionReason: route.exhaustionReason,
+      message:
+        `${route.retrySourceName} usage limit reached${plan}.${reset}` +
+        ` Switch to ${route.retryFallbackName} to keep working, or wait until the limit resets.`,
     };
   }
   return undefined;

--- a/src/common/errors/sdkError/xaiSubscriptionDetection.ts
+++ b/src/common/errors/sdkError/xaiSubscriptionDetection.ts
@@ -1,4 +1,3 @@
-import { formatResetDuration } from './chatgptSubscriptionDetection';
 import {
   firstBodyNumberField,
   firstBodyStringField,
@@ -44,18 +43,4 @@ export function parseXaiSubscriptionLimit(
   return {
     resetsInSeconds: firstBodyNumberField(rawErrorBody, 'resets_in_seconds'),
   };
-}
-
-/** Human-readable message for a Grok-subscription usage-limit error. */
-export function describeXaiSubscriptionLimit(
-  info: XaiSubscriptionLimit,
-): string {
-  const reset =
-    info.resetsInSeconds !== undefined
-      ? ` Resets in ${formatResetDuration(info.resetsInSeconds)}.`
-      : '';
-  return (
-    `Grok subscription usage limit reached.${reset}` +
-    ' Switch to your own xAI API key to keep working, or wait until the limit resets.'
-  );
 }

--- a/src/shared/quotaFallbackRoutes.ts
+++ b/src/shared/quotaFallbackRoutes.ts
@@ -17,7 +17,7 @@ type OauthQuotaFallbackRouteId = 'chatgpt' | 'grok';
 export type QuotaFallbackRouteId =
   OauthQuotaFallbackRouteId | CodingPlanSubscriptionId;
 
-type QuotaFallbackExhaustionReason = Extract<
+export type QuotaFallbackExhaustionReason = Extract<
   ExhaustionReason,
   | 'chatgpt-subscription'
   | 'xai-subscription'

--- a/src/test-kernel/common/ChatGptSubscriptionDetection.vitest.ts
+++ b/src/test-kernel/common/ChatGptSubscriptionDetection.vitest.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  describeChatGptSubscriptionLimit,
-  parseChatGptSubscriptionLimit,
-} from '@common/errors/sdkError/chatgptSubscriptionDetection';
+import { parseChatGptSubscriptionLimit } from '@common/errors/sdkError/chatgptSubscriptionDetection';
 import { formatProviderHttpError } from '@common/errors/sdkError/providerErrorFormat';
 
 const USAGE_LIMIT_BODY = {
@@ -37,44 +34,45 @@ describe('parseChatGptSubscriptionLimit', () => {
     expect(parseChatGptSubscriptionLimit(undefined)).toBe(null);
     expect(parseChatGptSubscriptionLimit({ message: 'nope' })).toBe(null);
   });
-
-  it('formats a human-readable reset hint', () => {
-    const text = describeChatGptSubscriptionLimit({
-      planType: 'pro',
-      resetsInSeconds: 159728,
-    });
-    expect(text).toContain('Pro plan');
-    expect(text).toContain('Resets in 1d 20h');
-    expect(text).toContain('OpenAI API key');
-  });
-
-  it('drops minutes once the reset window reaches a day, even with a zero hour component', () => {
-    // 1 day + 58 minutes, 0 whole hours — regression case for the pretty-ms
-    // swap: without flooring to the hour once days >= 1, pretty-ms back-fills
-    // the zero hour unit with minutes ("1d 58m") instead of "1d".
-    const text = describeChatGptSubscriptionLimit({
-      resetsInSeconds: 86_400 + 58 * 60,
-    });
-    expect(text).toContain('Resets in 1d.');
-    expect(text).not.toContain('58m');
-  });
 });
+
+/** Codex-shaped error carrying `body` as its SDK error payload. */
+function codexError(body: unknown): Error {
+  const error = new Error('codex backend rejected the request') as Error & {
+    error: unknown;
+    provider?: string;
+  };
+  error.error = body;
+  error.provider = 'openai';
+  return error;
+}
 
 describe('formatProviderHttpError for ChatGPT subscription limits', () => {
   it('classifies a usage-limit error as a switchable credential exhaustion', () => {
-    const error = new Error('codex backend rejected the request') as Error & {
-      error: unknown;
-      provider?: string;
-    };
-    error.error = USAGE_LIMIT_BODY;
-    error.provider = 'openai';
-
-    const providerError = formatProviderHttpError(error);
+    const providerError = formatProviderHttpError(codexError(USAGE_LIMIT_BODY));
 
     expect(providerError.exhaustionReason).toBe('chatgpt-subscription');
     // The stored OpenAI key is NOT the broken credential, so no key change is
     // forced (that reason is reserved for upstream credit depletion).
     expect(providerError.userRetryable).toBe(true);
     expect(providerError.message).toContain('ChatGPT subscription usage limit');
+    // ChatGPT is the only route with a plan slot.
+    expect(providerError.message).toContain('(Pro plan)');
+    expect(providerError.message).toContain('Resets in 1d 20h');
+    expect(providerError.message).toContain('your own OpenAI API key');
+  });
+
+  it('drops minutes once the reset window reaches a day, even with a zero hour component', () => {
+    // 1 day + 58 minutes, 0 whole hours — regression case for the pretty-ms
+    // swap: without flooring to the hour once days >= 1, pretty-ms back-fills
+    // the zero hour unit with minutes ("1d 58m") instead of "1d".
+    const { message } = formatProviderHttpError(
+      codexError({
+        type: 'usage_limit_reached',
+        resets_in_seconds: 86_400 + 58 * 60,
+      }),
+    );
+    expect(message).toContain('Resets in 1d.');
+    expect(message).not.toContain('58m');
   });
 });

--- a/src/test-kernel/common/GlmCodingPlanDetection.vitest.ts
+++ b/src/test-kernel/common/GlmCodingPlanDetection.vitest.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  describeGlmCodingPlanLimit,
   describeGlmCodingPlanRateLimit,
   isGlmCodingPlanRateLimit,
   parseGlmCodingPlanLimit,
@@ -115,12 +114,6 @@ describe('parseGlmCodingPlanLimit', () => {
   it('does not treat quota exhaustion as a rate limit', () => {
     expect(isGlmCodingPlanRateLimit(WEEKLY_LIMIT_BODY)).toBe(false);
   });
-
-  it('formats a human-readable reset hint', () => {
-    const text = describeGlmCodingPlanLimit({ resetsInSeconds: 3600 });
-    expect(text).toContain('GLM Coding Plan usage limit');
-    expect(text).toContain('regular GLM endpoint');
-  });
 });
 
 describe('formatProviderHttpError for GLM Coding Plan limits', () => {
@@ -136,7 +129,12 @@ describe('formatProviderHttpError for GLM Coding Plan limits', () => {
 
     expect(providerError.exhaustionReason).toBe('glm-coding-plan');
     expect(providerError.userRetryable).toBe(true);
-    expect(providerError.message).toContain('GLM Coding Plan usage limit');
+    expect(providerError.message).toContain(
+      'GLM Coding Plan usage limit reached',
+    );
+    expect(providerError.message).toContain(
+      'Switch to the regular GLM endpoint',
+    );
   });
 
   it('does not classify a GLM rate limit as a coding-plan exhaustion', () => {

--- a/src/test-kernel/common/KimiCodeSubscriptionDetection.vitest.ts
+++ b/src/test-kernel/common/KimiCodeSubscriptionDetection.vitest.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  describeKimiCodeSubscriptionLimit,
-  parseKimiCodeSubscriptionLimit,
-} from '@common/errors/sdkError/kimiCodeSubscriptionDetection';
+import { parseKimiCodeSubscriptionLimit } from '@common/errors/sdkError/kimiCodeSubscriptionDetection';
 import { formatProviderHttpError } from '@common/errors/sdkError/providerErrorFormat';
 import { KIMI_CODE_BASE_URL } from '@shared/constants/providers';
 
@@ -81,12 +78,6 @@ describe('parseKimiCodeSubscriptionLimit', () => {
       ),
     ).toBeNull();
   });
-
-  it('formats a human-readable reset hint', () => {
-    const text = describeKimiCodeSubscriptionLimit({ resetsInSeconds: 3600 });
-    expect(text).toContain('Kimi Code subscription usage limit');
-    expect(text).toContain('Moonshot API key');
-  });
 });
 
 describe('formatProviderHttpError for Kimi Code subscription limits', () => {
@@ -100,8 +91,10 @@ describe('formatProviderHttpError for Kimi Code subscription limits', () => {
     // The stored Moonshot key is NOT the broken credential, so no key change
     // is forced (that reason is reserved for upstream credit depletion).
     expect(providerError.userRetryable).toBe(true);
+    // Copy comes from the quota-fallback catalog, so the sentence names the
+    // same fallback the preference switch offers ("Moonshot API keys").
     expect(providerError.message).toContain(
-      'Kimi Code subscription usage limit',
+      'Kimi Code subscription usage limit reached. Switch to your own Moonshot API keys',
     );
   });
 

--- a/src/test-kernel/common/XaiSubscriptionDetection.vitest.ts
+++ b/src/test-kernel/common/XaiSubscriptionDetection.vitest.ts
@@ -5,10 +5,7 @@ import {
   attachSdkCredentialRoute,
   detectSdkCredentialRoute,
 } from '@common/errors/sdkError/sdkRequestEndpoint';
-import {
-  describeXaiSubscriptionLimit,
-  parseXaiSubscriptionLimit,
-} from '@common/errors/sdkError/xaiSubscriptionDetection';
+import { parseXaiSubscriptionLimit } from '@common/errors/sdkError/xaiSubscriptionDetection';
 
 const USAGE_LIMIT_BODY = {
   message: "You've reached your weekly usage limit.",
@@ -47,12 +44,6 @@ describe('parseXaiSubscriptionLimit', () => {
       }),
     ).toBeNull();
   });
-
-  it('formats a human-readable reset hint', () => {
-    expect(describeXaiSubscriptionLimit({ resetsInSeconds: 3600 })).toContain(
-      'Resets in 1h',
-    );
-  });
 });
 
 describe('formatProviderHttpError for Grok subscription limits', () => {
@@ -62,5 +53,8 @@ describe('formatProviderHttpError for Grok subscription limits', () => {
     expect(providerError.exhaustionReason).toBe('xai-subscription');
     expect(providerError.userRetryable).toBe(true);
     expect(providerError.message).toContain('Grok subscription usage limit');
+    expect(providerError.message).toContain(
+      'Resets in 1h. Switch to your own xAI API key',
+    );
   });
 });


### PR DESCRIPTION
## Summary

Four provider detection modules each hand-wrote the same sentence —
`<source> usage limit reached[ (Plan plan)][ Resets in X.] Switch to <fallback> to keep working, or wait until the limit resets.` — while `QUOTA_FALLBACK_ROUTES` (`src/shared/quotaFallbackRoutes.ts`) already owns both noun phrases (`retrySourceName` / `retryFallbackName`) for exactly those four `ExhaustionReason` values, and already drives the CLI retry hint (`approvalPrompts.ts`) and the preference switch (`quotaFallbackRouteForExhaustion`).

Nothing tied a describer to its catalog entry, and the copy had already drifted. A Kimi Code quota exhaustion renders **both** strings in the same retry prompt, two lines apart:

```
Kimi Code subscription usage limit reached. Switch to your own Moonshot API key to keep working, ...   <- hand-written, singular
Accepting will switch from your Kimi Code subscription to your own Moonshot API keys.                  <- catalog, plural
```

This PR makes the catalog the single owner of that copy:

- Deletes `describeChatGptSubscriptionLimit`, `describeXaiSubscriptionLimit`, `describeKimiCodeSubscriptionLimit`, `describeGlmCodingPlanLimit`.
- `detectQuotaLimit` becomes the catalog loop its own comment already claimed it was ("Order is the catalog's" — the four parse calls were in catalog order, written out by hand), formatting the sentence from the matched route's fields.
- The parse table is a **total** `Record<QuotaFallbackExhaustionReason, …>`, so a fifth `QUOTA_FALLBACK_ROUTES` entry cannot ship a working preference switch with no error copy — it fails to compile until its detector lands. That structural hazard is the reason this is a type-level table and not a `Map`.
- `formatResetDuration` had no consumer left outside the four describers, so it moves next to its single caller in `providerErrorFormat.ts` and stops being exported (removing 3 cross-module import lines).
- ChatGPT's `(Pro plan)` slot is the only per-route variation and is preserved.

**Only user-visible change:** the Kimi sentence now says "your own Moonshot API keys", matching the switch it offers. The other three routes' strings are byte-identical to before.

## Issue acceptance gates

No issue — found by a verified collapse sweep.

## Single source of truth

`QUOTA_FALLBACK_ROUTES` (`src/shared/quotaFallbackRoutes.ts`) now owns the source/fallback noun phrases for *all three* consumers: route resolution, the CLI retry hint, and the provider error message. `detectQuotaLimit` (`src/common/errors/sdkError/providerErrorFormat.ts`) owns the one sentence template and the reset-window formatting.

## Duplication and abstraction budget

Removed: 4 copies of one sentence template + 4 copies of the `Resets in …` clause. No new abstraction, no new layer, no new module. The catalog it collapses onto pre-existed with 4 non-test importers. The one new *type* export (`QuotaFallbackExhaustionReason`) is an existing local type; its consumer (`QUOTA_LIMIT_PARSERS`) lands in this PR.

## Net elements (R6)

**Genuinely net-negative.**

| | value |
|---|---|
| Files added / deleted | 0 / 0 |
| Prod LoC | **+69 / −136 = net −67** |
| Test LoC | **+45 / −62 = net −17** |
| Exported symbols | −5 (4 `describeX*Limit`, `formatResetDuration`), +1 (`QuotaFallbackExhaustionReason`, type) → **net −4** |
| Top-level prod functions | −5 exported, +1 module-private (`formatResetDuration` moved) → **net −4** |
| Interfaces added | +1 (`QuotaLimitInfo`, module-private, 4 lines) |
| Consts added | +1 (`QUOTA_LIMIT_PARSERS`, module-private) |
| Test cases (`it`) | −5, +1 (see below) → **net −4** |

Diffstat:

```
 src/common/errors/sdkError/chatgptSubscriptionDetection.ts     |  0 +  43 -
 src/common/errors/sdkError/glmCodingPlanDetection.ts           |  0 +  16 -
 src/common/errors/sdkError/kimiCodeSubscriptionDetection.ts    |  0 +  20 -
 src/common/errors/sdkError/xaiSubscriptionDetection.ts         |  0 +  15 -
 src/common/errors/sdkError/providerErrorFormat.ts              | 68 + 41 -
 src/shared/quotaFallbackRoutes.ts                              |  1 +  1 -
 src/test-kernel/common/*.vitest.ts (4 files)                   | 45 + 62 -
```

### Tests

Zero net new tests. Each of the four suites had a direct unit test of the deleted describer (`'formats a human-readable reset hint'`) **and** a `formatProviderHttpError` integration `describe` covering the same copy end to end. The four unit tests are deleted rather than repaired — the seam they pinned is gone. The surviving integration assertions were tightened in place (no new `it`) so the per-route copy is still pinned at the durable boundary, including the Kimi plural.

One exception, called out honestly: `ChatGptSubscriptionDetection.vitest.ts` also carried a *regression* case for the `pretty-ms` swap (1 day + 58 minutes must render `1d`, not `1d 58m`). That behavior is real and subtle, and `formatResetDuration` is now module-private, so the case was re-pointed at `formatProviderHttpError` instead of deleted. It is the same test, one call site over — not a new one. That is the `+1 it` in the table above (plus a 9-line `codexError` helper that also absorbs the boilerplate of the existing integration test).

## Consumer counts (R8)

```
$ grep -rnE "describeChatGptSubscriptionLimit|describeXaiSubscriptionLimit|\
describeKimiCodeSubscriptionLimit|describeGlmCodingPlanLimit|formatResetDuration" \
  --include='*.ts' --include='*.tsx' --include='*.mjs' --include='*.json' . \
  | grep -v 'packages/agent/dist' | grep -v node_modules
```

Before: the four describers had **zero** consumers outside `providerErrorFormat.ts` and their own 4 vitest files (`packages/agent/dist/types/**` hits are build artifacts). `formatResetDuration` had **zero** consumers outside those same four describers. None appears in `config/ratchets/knip-baseline.json`. After: zero hits for all five names outside the moved private definition.

Copy-string sweep, to prove no other surface pinned the old strings:

```
$ grep -rnE "Moonshot API key|usage limit reached|regular GLM endpoint|own xAI API key|own OpenAI API key" \
  --include='*.ts' --include='*.tsx' src packages --exclude-dir=dist
```

The only other hits are CLI tests that construct their own `errorMessage` fixtures (`TuiApprovalRetry`, `RetryRequest`) and `ApprovalAdapter.vitest.ts`, which already asserts the **catalog** strings (`'Moonshot API keys'`, `'regular GLM endpoint'`) — i.e. it was already pinning the side this PR converges on. All pass unchanged.

## Host impact

Extension: quota-exhaustion retry copy for Kimi Code changes "API key" → "API keys". No other change.

Desktop: same.

CLI: same. The retry prompt's two lines (message + hint) now agree for Kimi.

## Scheduled refactoring

None. Deliberately **not** done, though the sweep brief offered it as a free fold-in: the context-window remedy sentence at `providerErrorFormat.ts:358-363` and `src/agent/runtime/terminalResultToast.ts:80-84`. The two strings are not identical (the classifier's carries an extra "Retrying would resend the same oversized request." clause; the toast's is a *fallback* for the rarer provider-reported overflow that arrives without a message), and collapsing them would need a new exported constant crossing `src/agent` → `src/common` to save ~4 LoC. Not mechanical, no net gain — skipped.

## Validation

- `npm run typecheck` — clean (workspace, test-kernel, agent build, cli incl. `tsconfig.scripts.json`, trace-viewer, desktop).
- `npx vitest run` on the 7 affected suites: `ChatGptSubscriptionDetection`, `XaiSubscriptionDetection`, `KimiCodeSubscriptionDetection`, `GlmCodingPlanDetection`, `ApprovalAdapter`, `TuiApprovalRetry`, `RetryRequest` — **7 files / 118 tests passed**.
- `npx vitest run` on the architecture ratchets that could plausibly move (`subsystemEdgeRatchet`, `dependencyDirection`, `sharedSchemasDeepImportRatchet`, `hostAgentDeepImportRatchet`) — **4 files / 38 tests passed**. `common → shared` is an existing `value` edge and `@shared/quotaFallbackRoutes` is not a `@shared/schemas` deep import, so no baseline widens.
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` (run from the worktree) — `8 current vs 8 baselined`, OK.
- `npx prettier --check` on every changed file — clean.
