### PR TITLE
fix(agent): stop writing scratchpad drafts to the user's .tex file

### DIFF
--- a/src/agent/implementations/flows/reflection/output/XmlOutputManager.ts
+++ b/src/agent/implementations/flows/reflection/output/XmlOutputManager.ts
@@ -62,7 +62,6 @@ const XML_PARSER_OPTIONS = {
 const EXTRACTION_METHOD_MESSAGES: Record<string, string> = {
   simple: 'using fallback method',
   latex_document: 'from legacy <latex_document> tag',
-  markdown: 'from markdown code block',
   latex: 'from \\documentclass block',
 };
 
@@ -310,41 +309,49 @@ export class XmlOutputManager {
       }
     }
 
-    if (
-      !documents &&
-      this.agentConfig.outputFiles.length === 1 &&
-      soleExpectedFile
-    ) {
+    if (!documents && soleExpectedFile) {
       // This fully unlabeled tier is intentionally stricter than
       // filename-header recovery: without a trusted file label, only fences
-      // explicitly marked latex/tex are treated as output.
+      // explicitly marked latex/tex are treated as output. It owns every
+      // fenced-block recovery, including the single-block case, because it is
+      // the only reader that strips the thinking tag first — a scratchpad
+      // that drafts inside a ```latex fence would otherwise be written to the
+      // user's file as if it were the answer.
       const fencedBlocks = this.collectLatexFencedBlocks(
         rawOutputContent,
         thinkingTag,
       );
-      if (fencedBlocks.length > 1) {
+      // A single-artifact agent (ocr/paper2slide: one declared output, many
+      // inputs) emits one fence per input, so all of them belong to the
+      // output. An edit agent reusing its input name emits the revised
+      // document first, and any later fence is explanatory prose.
+      const blocks =
+        this.agentConfig.outputFiles.length === 1
+          ? fencedBlocks
+          : fencedBlocks.slice(0, 1);
+      if (blocks.length > 0) {
         documents = [
           {
             name: soleExpectedFile,
-            content: fencedBlocks.join('\n\n'),
+            content: blocks.join('\n\n'),
           },
         ];
         logInternal(
           this.logger,
-          `Recovered ${OUTPUT_DOCUMENTS_TAG} by concatenating ` +
-            `unlabeled fenced blocks under ${soleExpectedFile} (${formatResultCount(fencedBlocks.length, 'block')})`,
+          `Recovered ${OUTPUT_DOCUMENTS_TAG} from ` +
+            `unlabeled fenced blocks under ${soleExpectedFile} (${formatResultCount(blocks.length, 'block')})`,
         );
       }
     }
 
     if (!documents && soleExpectedFile) {
       // Agents expected to write exactly one file whose model regressed to a
-      // legacy single-doc shape (<latex_document>, ```latex fence, or bare
-      // \documentclass) can still be recovered: pass that filename so the
-      // fallback can synthesize a named document. Agents with several
-      // expected files cannot safely recover — without per-document names
-      // there's no way to route content (and without a preferredName this
-      // call would just repeat the earlier one).
+      // legacy single-doc shape (<latex_document> or a bare \documentclass)
+      // can still be recovered: pass that filename so the fallback can
+      // synthesize a named document. Agents with several expected files
+      // cannot safely recover — without per-document names there's no way to
+      // route content (and without a preferredName this call would just
+      // repeat the earlier one).
       // Keep the relative path verbatim — getExtractedDocOutputFileName
       // preserves subdirectories so `Draft/Draft1.tex` lands at the right
       // workspace location instead of collapsing to the round root.

--- a/src/agent/implementations/flows/reflection/output/XmlOutputManager.ts
+++ b/src/agent/implementations/flows/reflection/output/XmlOutputManager.ts
@@ -22,6 +22,7 @@ import {
   DOCUMENT_NAME_REGEX,
   extractContentFromXMLbyTagMultiple,
   extractDocuments,
+  extractTextFromTag,
 } from '@utils/text/xmlExtraction';
 
 import {
@@ -309,14 +310,26 @@ export class XmlOutputManager {
       }
     }
 
-    if (!documents && soleExpectedFile) {
+    // A response that carries an explicit <latex_document> has named its final
+    // answer, and an untagged fence has not — a model may well emit an example
+    // or a draft fence before the tagged answer. So the tagged tier below wins
+    // outright and this one stands down, exactly as it did before fence
+    // recovery moved here. Reads the raw response, which agrees with the
+    // cdataWrapped text the tagged tier parses: addCdataToTagsMultiple only
+    // wraps the thinking and document tags, never <latex_document>.
+    const taggedLatexDocument = extractTextFromTag(
+      rawOutputContent,
+      'latex_document',
+    );
+
+    if (!documents && soleExpectedFile && !taggedLatexDocument) {
       // This fully unlabeled tier is intentionally stricter than
       // filename-header recovery: without a trusted file label, only fences
-      // explicitly marked latex/tex are treated as output. It owns every
-      // fenced-block recovery, including the single-block case, because it is
-      // the only reader that strips the thinking tag first — a scratchpad
-      // that drafts inside a ```latex fence would otherwise be written to the
-      // user's file as if it were the answer.
+      // explicitly marked latex/tex are treated as output. It handles the
+      // single-block case too (rather than leaving it to the legacy tier)
+      // because it strips the thinking tag first — a scratchpad that drafts
+      // inside a ```latex fence would otherwise be written to the user's file
+      // as if it were the answer.
       const fencedBlocks = this.collectLatexFencedBlocks(
         rawOutputContent,
         thinkingTag,

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -1198,6 +1198,28 @@ Appendix.
     await expectWritten('paper.tex', 'Revised paper body.\n');
   });
 
+  it('ignores scratchpad fenced blocks when recovering a single-input edit', async () => {
+    const outputs = await writeAndSplitDocuments(
+      [
+        '<scratchpad>',
+        'Draft attempt before I settled on the real revision:',
+        '```latex',
+        '\\section{Scratch}',
+        'Rejected draft.',
+        '```',
+        '</scratchpad>',
+        '```latex',
+        '\\section{Final}',
+        'Accepted revision.',
+        '```',
+      ],
+      ['paper.tex'],
+    );
+
+    expectSources(outputs, ['paper.tex']);
+    await expectWritten('paper.tex', '\\section{Final}\nAccepted revision.\n');
+  });
+
   it('leaves an unlabeled block unmatched when identical base files make the match ambiguous', async () => {
     const stub = '\\section{Stub}\nShared template content.\n';
     await AbsoluteFS.write('/tmp/run/a.tex', stub);

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -1220,6 +1220,39 @@ Appendix.
     await expectWritten('paper.tex', '\\section{Final}\nAccepted revision.\n');
   });
 
+  // A tagged <latex_document> is the model's declared final answer; an
+  // untagged fence before it is an example or a draft. Both agent shapes must
+  // prefer the tag, or fence recovery would overwrite the answer with a draft.
+  it.each([
+    ['single-input edit agents', ['paper.tex'], {} satisfies XmlManagerOptions],
+    [
+      'single-artifact agents',
+      ['page1.png'],
+      { outputFiles: ['paper.tex'] } satisfies XmlManagerOptions,
+    ],
+  ] satisfies readonly (readonly [
+    string,
+    readonly string[],
+    XmlManagerOptions,
+  ])[])(
+    'prefers a tagged <latex_document> over an earlier untagged fence for %s',
+    async (_name, inputFiles, options) => {
+      const outputs = await writeAndSplitDocuments(
+        [
+          '```latex',
+          '\\section{Draft}',
+          '```',
+          '<latex_document>\\section{Final}\\end{document}</latex_document>',
+        ],
+        [...inputFiles],
+        options,
+      );
+
+      expectSources(outputs, ['paper.tex']);
+      await expectWritten('paper.tex', '\\section{Final}\n');
+    },
+  );
+
   it('leaves an unlabeled block unmatched when identical base files make the match ambiguous', async () => {
     const stub = '\\section{Stub}\nShared template content.\n';
     await AbsoluteFS.write('/tmp/run/a.tex', stub);

--- a/src/test-kernel/utils/text/ExtractDocumentsLegacyFallback.vitest.ts
+++ b/src/test-kernel/utils/text/ExtractDocumentsLegacyFallback.vitest.ts
@@ -33,23 +33,6 @@ describe('extractDocuments legacy fallback', () => {
     ]);
   });
 
-  it('recovers a single doc from a ```latex fenced block', () => {
-    const xml =
-      'Looking at this...\n```latex\n\\documentclass{article}\n' +
-      '\\begin{document}Body\\end{document}\n```\n';
-
-    const result = extractDocuments(xml, 'documents', 'Draft1.tex');
-
-    expect(result.method).toBe('markdown');
-    expect(result.documents).toEqual([
-      {
-        name: 'Draft1.tex',
-        content:
-          '\\documentclass{article}\n\\begin{document}Body\\end{document}',
-      },
-    ]);
-  });
-
   it('recovers a single doc from a bare \\documentclass block', () => {
     const xml =
       'No wrapper at all. \\documentclass[prl]{revtex4-2}\n' +

--- a/src/utils/text/xmlExtraction.ts
+++ b/src/utils/text/xmlExtraction.ts
@@ -193,8 +193,9 @@ export interface MultipleExtractionResult {
  * function reads the whole response including the model's thinking tag, so a
  * fence inside the scratchpad would win over the real answer. Fence recovery
  * belongs to `collectLatexFencedBlocks`, which strips the thinking tag first
- * and parses fences per CommonMark; `XmlOutputManager` runs that tier before
- * this one.
+ * and parses fences per CommonMark. `XmlOutputManager` runs that tier ahead of
+ * this one, except when the response carries an explicit <latex_document>:
+ * a tagged final answer outranks an untagged fence, so this tier keeps it.
  *
  * @param outputContent The raw output content to extract from
  * @param containerTag The container tag to look for documents within

--- a/src/utils/text/xmlExtraction.ts
+++ b/src/utils/text/xmlExtraction.ts
@@ -175,7 +175,7 @@ export async function extractScratchpad(
 
 export interface MultipleExtractionResult {
   documents: { content: string; name: string }[] | null;
-  method: 'simple' | 'latex_document' | 'markdown' | 'latex' | 'none';
+  method: 'simple' | 'latex_document' | 'latex' | 'none';
 }
 
 /**
@@ -184,10 +184,17 @@ export interface MultipleExtractionResult {
  * Primary path looks for <document name="..."> children inside the unified
  * <documents> container. When that finds nothing and a single-file recovery
  * hint is supplied, the extractor falls back through the legacy single-doc
- * shapes (<latex_document>, fenced ```latex block, bare \documentclass) and
- * synthesizes a one-document result named after the hint. Without a hint,
- * recovery is skipped because a synthesized document with no name has no
- * unambiguous destination.
+ * shapes (<latex_document>, bare \documentclass) and synthesizes a
+ * one-document result named after the hint. Without a hint, recovery is
+ * skipped because a synthesized document with no name has no unambiguous
+ * destination.
+ *
+ * Fenced ```latex/```tex blocks are deliberately NOT recovered here: this
+ * function reads the whole response including the model's thinking tag, so a
+ * fence inside the scratchpad would win over the real answer. Fence recovery
+ * belongs to `collectLatexFencedBlocks`, which strips the thinking tag first
+ * and parses fences per CommonMark; `XmlOutputManager` runs that tier before
+ * this one.
  *
  * @param outputContent The raw output content to extract from
  * @param containerTag The container tag to look for documents within
@@ -211,14 +218,6 @@ export function extractDocuments(
       return {
         documents: [{ content: tagged, name: preferredName }],
         method: 'latex_document',
-      };
-    }
-
-    const fenced = outputContent.match(/```(?:latex|tex)\n([\s\S]*?)\n```/i);
-    if (fenced?.[1]) {
-      return {
-        documents: [{ content: fenced[1], name: preferredName }],
-        method: 'markdown',
       };
     }
 


### PR DESCRIPTION
## Summary

"Recover a LaTeX document from a ` ```latex ` fenced block in a model response" was
implemented twice, and the common case was routed to the weak copy — which had a
wrong-content defect.

- **(A)** `xmlExtraction.ts` `extractDocuments`: one unanchored regex
  `/```(?:latex|tex)\n([\s\S]*?)\n```/i` inside the `preferredName` legacy fallback.
- **(B)** `collectLatexFencedBlocks` (`extraction/contentSimilarity.ts`): a real
  CommonMark fence reader — strips the thinking tag, normalizes CRLF/CR, anchors per
  line, accepts `` `{3,} ``/`~{3,}` openers and trimmed opener lines.

**The defect.** (A) reads the whole response, thinking tag included, and `.match`
without `/g` returns the *first* hit. The scratchpad precedes the output, so a response
whose scratchpad drafts inside a ` ```latex ` fence wrote the **rejected draft** to the
user's `.tex` file and logged it as a successful recovery
(`Recovered documents from markdown code block (1 document)`).

**Why the common case hit it.** Tier (B) was gated on `agentConfig.outputFiles.length === 1`.
`resolveOutputFiles` (`src/agent/prompt/userVars.ts:601-605`) sets
`outputFiles = defaultOutputFiles`, and only `ocr.yaml`, `transcribe_audio.yaml`,
`write/paper2slide.yaml` and `write/paper2poster.yaml` declare `defaultOutputFiles`. So
`polish`, `correct`, `merge` and the rest of `write/` run with `outputFiles === []` —
tier (B) never ran for them and (A) was the live recovery path for every single-file
edit agent.

**The fix.** The fence tier is now gated on `soleExpectedFile != null` (which already
falls back to `inputFiles` when `outputFiles` is empty) and fires on one block instead of
two, so `collectLatexFencedBlocks` is the single owner of fence recovery. (A)'s fence
branch is deleted. (A) keeps `<latex_document>` and bare-`\documentclass` recovery, which
have no second implementation.

**This is a deliberate behaviour change, not a no-op.** `git log -S "fencedBlocks.length > 1"`
returns only the B7 move commit (#10612); no origin commit establishes why `> 1` was
there. Relaxing it means the fence tier now claims a single fenced block that previously
fell through to (A). That is the point: for the shapes that reach it, (B) returns the same
block as (A) *except* when (A) would have returned scratchpad content.

## Priorities this preserves

Reordering recovery tiers is where this change can do harm, so both orderings that
mattered are now pinned by tests.

**1. A tagged `<latex_document>` outranks an untagged fence.** Caught in review — the
first revision of this PR moved fence recovery ahead of the legacy tier unconditionally,
which re-introduced the very defect class the PR exists to fix:

```
```latex
\section{Draft}
```
<latex_document>\section{Final}\end{document}</latex_document>
```

wrote `\section{Draft}`. `<latex_document>` is the model's *declared* final answer and an
untagged fence is not; a model emitting an example or draft fence before its tagged
answer is an ordinary response shape. The fence tier now stands down whenever the
response carries a `<latex_document>`, restoring the original priority. The guard sits on
the tier itself, so it covers **both** shapes — the inversion also reached
single-artifact agents (`outputFiles.length === 1`) whenever exactly one fence was
present. The bare `\documentclass` fallback still runs *after* fence recovery, as before.
The scratchpad fix is untouched: the fence tier still strips the thinking tag first.

**2. An edit agent's trailing explanatory fence is not part of the document.** The brief
this PR was written from proposed an unconditional `fencedBlocks.length > 0`. That is also
wrong: it breaks the pinned case "does not concatenate later explanatory fences for
single-input edits", which then writes
`Revised paper body.\n\n\LaTeX{} example, not output.`. Verified by trying it. The two
agent shapes genuinely differ and the tier now says so explicitly:

- `outputFiles.length === 1` (ocr/paper2slide: one declared artifact, many input pages) →
  every fence belongs to the output, concatenate them (unchanged).
- otherwise (edit agent reusing its input name) → the first fence is the revised document,
  later fences are prose (`slice(0, 1)`) — which is what (A)'s first-match regex already
  did, minus the scratchpad bug.

## Issue acceptance gates

n/a — no tracking issue; found by a verified collapse sweep over `text-markdown-latex`.

## Single source of truth

`collectLatexFencedBlocks` (`.../reflection/output/extraction/contentSimilarity.ts`) is
now the only reader that recovers a LaTeX document from a markdown fence.
`extractDocuments` documents the exclusion and why (it cannot see the thinking-tag
boundary), and names the one case where it still wins (a tagged `<latex_document>`).

## Duplication and abstraction budget

Removed: one duplicate fence parser (the regex in `extractDocuments`) plus its
`'markdown'` extraction-method arm and log-message entry. No new abstraction, no new
module, no new export, no ratchet touched.

## Net elements (R6)

**This PR net-adds lines. It is a defect fix, not a size reduction, and is not offered as
one.** Executable production code is only −3; the collapse removed 18 code lines and the
two priority guards plus the comments recording *why* the ordering is what it is added 15
code lines and 23 comment lines.

| | + | − | net |
|---|---|---|---|
| Files | 0 | 0 | 0 |
| Exported symbols (`^[+-]export` over the diff) | 0 | 0 | 0 |
| Classes / interfaces / enums | 0 | 0 | 0 |
| Union members (`MultipleExtractionResult['method']`) | 0 | 1 (`'markdown'`) | −1 |
| Production code lines (non-comment, non-blank) | 15 | 18 | **−3** |
| Production comment/blank lines | 35 | 12 | +23 |
| Production lines total | 50 | 30 | **+20** |
| Test lines | 55 | 17 | +38 |

Test budget: three cases in the existing suite (one scratchpad-hijack regression, two
tagged-vs-fence ordering cases via `it.each`), one dead test deleted
(`ExtractDocumentsLegacyFallback.vitest.ts` "recovers a single doc from a ```latex fenced
block" — it pinned the deleted branch; deleted, not repaired). No new test file; the other
five cases in that file survive unchanged.

## Consumer counts (R8)

Greps run on the worktree (`grep -rn <pat> src packages docs | grep -v node_modules`):

- `extractDocuments` → 2 production call sites, both `XmlOutputManager.ts:81` (reached
  without a hint and with `soleExpectedFile`); 1 test file. Both production callers still
  compile and are covered.
- `method === 'markdown'` / `"markdown"` extraction method → **0** consumers outside
  `EXTRACTION_METHOD_MESSAGES` and the one deleted test. `EXTRACTION_METHOD_MESSAGES` has
  exactly 1 consumer (`XmlOutputManager.ts:88`), which reads it through
  `Record<string, string>` with a `?? 'using fallback method'` default, so removing a key
  cannot throw.
- `collectLatexFencedBlocks` → 1 exporting site, 1 importer (`XmlOutputManager.ts:29`),
  2 call sites inside the manager (similarity tier + fence tier). No orphan.
- `extractTextFromTag` (newly imported here) → already exported and consumed elsewhere;
  no export added.
- `MultipleExtractionResult` → declared and used only in `xmlExtraction.ts`.

## Host impact

Extension: fenced-block recovery for single-file edit agents (`polish`, `correct`,
`merge`, most of `write/`) no longer writes scratchpad content, and a tagged
`<latex_document>` still wins over an untagged fence. Same code path in all three hosts.

Desktop: same.

CLI: same.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — exit 0, zero `error TS` (workspace, test-kernel, agent build, cli,
  trace-viewer, desktop).
- `npx vitest run src/test-kernel/agent/output/ src/test-kernel/utils/text/` — 15 files,
  194 tests, all pass. Covers `XmlOutputManager.vitest.ts` (76 cases incl. the ocr
  concatenation cases, the single-input non-concatenation case, and the three new ones),
  `filenameHeaders.vitest.ts`, `OutputProgressEvents.vitest.ts`, and
  `ExtractDocumentsLegacyFallback.vitest.ts`.
- Scratchpad defect reproduced *before* the fix: the new test failed with
  `expected '\section{Scratch}\nRejected draft.\n' to be '\section{Final}\nAccepted revision.\n'`.
- Priority inversion reproduced *before* its guard: with the `!taggedLatexDocument`
  condition removed, **both** new ordering cases fail with
  `expected '\section{Draft}\n' to be '\section{Final}\n'` — confirming the guard is load
  bearing for edit agents and single-artifact agents alike.
- Counter-check: the brief's unconditional `> 0` shape was tried and rejected because it
  fails "does not concatenate later explanatory fences for single-input edits".
- `npm run lint` — exit 0; `eslint` and `prettier --check` clean on all touched files.
- `npm run check:dead-code-ratchet` — not run: no export added or removed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
