### PR TITLE
refactor(test-kernel): share TS parse and module-specifier scanning across the architecture ratchets

### DIFF
--- a/src/test-kernel/agent/AgentPromptContracts.vitest.ts
+++ b/src/test-kernel/agent/AgentPromptContracts.vitest.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from 'vitest';
 import * as yaml from 'yaml';
 
 // Local imports
-import { REPO_ROOT } from '@test/support/repoScan';
+import { parseSourceFile, REPO_ROOT } from '@test/support/repoScan';
 
 /** A tool-use agent: declares the tool roster its prompt refers to. */
 interface ToolUseAgentYaml {
@@ -214,12 +214,7 @@ function workflowRounds(parsed: Record<string, unknown>): string[] {
 }
 
 function typeScriptStrings(relativePath: string): string[] {
-  const sourceFile = ts.createSourceFile(
-    relativePath,
-    readFileSync(resolve(REPO_ROOT, relativePath), 'utf8'),
-    ts.ScriptTarget.Latest,
-    true,
-  );
+  const sourceFile = parseSourceFile(resolve(REPO_ROOT, relativePath));
   const strings: string[] = [];
 
   function visit(node: ts.Node): void {

--- a/src/test-kernel/architecture/agentRuntimeProgressEventsBoundary.vitest.ts
+++ b/src/test-kernel/architecture/agentRuntimeProgressEventsBoundary.vitest.ts
@@ -3,11 +3,12 @@ import { existsSync, readFileSync } from 'node:fs';
 import { basename, dirname, join, resolve } from 'node:path';
 
 // Third-party imports
-import * as ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 import {
   ALL_HOST_PRODUCTION_ROOTS,
+  collectModuleSpecifiers,
+  parseSourceFile,
   REPO_ROOT,
   SOURCE_FILE,
   sourceFilesUnder,
@@ -55,51 +56,6 @@ const PRODUCTION_FILES = scanFiles(true);
 const ALL_SOURCE_FILES = scanFiles(false);
 const SOURCE_TEXT_BY_FILE = new Map<string, string>();
 const MODULE_SPECIFIERS_BY_FILE = new Map<string, string[]>();
-
-function literalText(node: ts.Expression | undefined): string | null {
-  return node != null && ts.isStringLiteralLike(node) ? node.text : null;
-}
-
-function moduleSpecifierFromImportEquals(
-  node: ts.ImportEqualsDeclaration,
-): string | null {
-  const reference = node.moduleReference;
-  if (!ts.isExternalModuleReference(reference)) return null;
-  return literalText(reference.expression);
-}
-
-function moduleSpecifierFromCall(node: ts.CallExpression): string | null {
-  const [firstArg] = node.arguments;
-  if (
-    node.expression.kind === ts.SyntaxKind.ImportKeyword ||
-    (ts.isIdentifier(node.expression) && node.expression.text === 'require')
-  ) {
-    return literalText(firstArg);
-  }
-  return null;
-}
-
-function collectModuleSpecifiers(sourceFile: ts.SourceFile): string[] {
-  const specifiers: string[] = [];
-
-  function visit(node: ts.Node): void {
-    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
-      const specifier = literalText(node.moduleSpecifier);
-      if (specifier != null) specifiers.push(specifier);
-    } else if (ts.isImportEqualsDeclaration(node)) {
-      const specifier = moduleSpecifierFromImportEquals(node);
-      if (specifier != null) specifiers.push(specifier);
-    } else if (ts.isCallExpression(node)) {
-      const specifier = moduleSpecifierFromCall(node);
-      if (specifier != null) specifiers.push(specifier);
-    }
-
-    ts.forEachChild(node, visit);
-  }
-
-  visit(sourceFile);
-  return specifiers;
-}
 
 function resolveAgentAlias(specifier: string): string | null {
   if (specifier === OLD_AGENT_RUNTIME_ALIAS) return OLD_AGENT_RUNTIME_MODULE;
@@ -151,13 +107,9 @@ function importsModule(file: string, targetModule: string): boolean {
 
   let moduleSpecifiers = MODULE_SPECIFIERS_BY_FILE.get(file);
   if (moduleSpecifiers === undefined) {
-    const sourceFile = ts.createSourceFile(
-      file,
-      sourceText,
-      ts.ScriptTarget.Latest,
-      true,
+    moduleSpecifiers = collectModuleSpecifiers(
+      parseSourceFile(file, { text: sourceText }),
     );
-    moduleSpecifiers = collectModuleSpecifiers(sourceFile);
     MODULE_SPECIFIERS_BY_FILE.set(file, moduleSpecifiers);
   }
 

--- a/src/test-kernel/architecture/hostAgentDeepImportRatchet.vitest.ts
+++ b/src/test-kernel/architecture/hostAgentDeepImportRatchet.vitest.ts
@@ -21,10 +21,14 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 // Third-party imports
-import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
-import { REPO_ROOT, sourceFilesUnder } from '../support/repoScan';
+import {
+  collectModuleSpecifiers,
+  parseSourceFile,
+  REPO_ROOT,
+  sourceFilesUnder,
+} from '../support/repoScan';
 
 const HOSTS = ['cli', 'desktop', 'extension', 'agent'] as const;
 
@@ -51,62 +55,10 @@ function sortedSpecifiers(specifiers: Iterable<string>): string[] {
   return [...specifiers].toSorted((a, b) => a.localeCompare(b));
 }
 
-function moduleSpecifiers(node: ts.Node): string[] {
-  if (
-    (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
-    node.moduleSpecifier != null &&
-    ts.isStringLiteralLike(node.moduleSpecifier)
-  ) {
-    return [node.moduleSpecifier.text];
-  }
-  if (
-    ts.isImportEqualsDeclaration(node) &&
-    ts.isExternalModuleReference(node.moduleReference) &&
-    node.moduleReference.expression != null &&
-    ts.isStringLiteralLike(node.moduleReference.expression)
-  ) {
-    return [node.moduleReference.expression.text];
-  }
-  if (
-    ts.isImportTypeNode(node) &&
-    ts.isLiteralTypeNode(node.argument) &&
-    ts.isStringLiteralLike(node.argument.literal)
-  ) {
-    return [node.argument.literal.text];
-  }
-  if (ts.isCallExpression(node) && node.arguments.length === 1) {
-    const [argument] = node.arguments;
-    const isDynamicImport =
-      node.expression.kind === ts.SyntaxKind.ImportKeyword;
-    const isRequire =
-      ts.isIdentifier(node.expression) && node.expression.text === 'require';
-    if ((isDynamicImport || isRequire) && ts.isStringLiteralLike(argument)) {
-      return [argument.text];
-    }
-  }
-  return [];
-}
-
 function collectAgentDeepImportSpecifiers(file: string): string[] {
-  const sourceFile = ts.createSourceFile(
-    file,
-    readFileSync(file, 'utf8'),
-    ts.ScriptTarget.Latest,
-    true,
-    file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  return collectModuleSpecifiers(parseSourceFile(file)).filter((specifier) =>
+    AGENT_DEEP_IMPORT.test(specifier),
   );
-
-  const specifiers: string[] = [];
-  const visit = (node: ts.Node): void => {
-    for (const specifier of moduleSpecifiers(node)) {
-      if (AGENT_DEEP_IMPORT.test(specifier)) {
-        specifiers.push(specifier);
-      }
-    }
-    ts.forEachChild(node, visit);
-  };
-  visit(sourceFile);
-  return specifiers;
 }
 
 function collectHostAgentDeepImportSpecifiers(host: Host): string[] {

--- a/src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts
+++ b/src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts
@@ -21,7 +21,12 @@ import { resolve } from 'node:path';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
-import { REPO_ROOT, sourceFilesUnder, toRepoPath } from '../support/repoScan';
+import {
+  parseSourceFile,
+  REPO_ROOT,
+  sourceFilesUnder,
+  toRepoPath,
+} from '../support/repoScan';
 
 const MOCK_FORMS = ['mock', 'doMock'] as const;
 
@@ -88,13 +93,7 @@ function mockFormFromCall(
 }
 
 function collectAgentMockSites(file: string): MockSite[] {
-  const sourceFile = ts.createSourceFile(
-    file,
-    readFileSync(file, 'utf8'),
-    ts.ScriptTarget.Latest,
-    true,
-    file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
-  );
+  const sourceFile = parseSourceFile(file);
 
   const sites: MockSite[] = [];
   const visit = (node: ts.Node): void => {

--- a/src/test-kernel/architecture/hostedAuthImportBoundary.vitest.ts
+++ b/src/test-kernel/architecture/hostedAuthImportBoundary.vitest.ts
@@ -3,10 +3,15 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
 // Third-party imports
-import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
-import { REPO_ROOT, sourceFilesUnder, toRepoPath } from '../support/repoScan';
+import {
+  collectModuleSpecifiers,
+  parseSourceFile,
+  REPO_ROOT,
+  sourceFilesUnder,
+  toRepoPath,
+} from '../support/repoScan';
 
 const SCAN_ROOTS = [
   'src/model',
@@ -22,72 +27,6 @@ const PERMITTED_THIRD_PARTY_OAUTH_PATHS = [
   'src/auth/codex',
   'src/auth/xai',
 ] as const;
-
-function parseSourceFile(file: string, source: string): ts.SourceFile {
-  return ts.createSourceFile(
-    file,
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
-  );
-}
-
-function stringLiteralText(node: ts.Node): string | null {
-  return ts.isStringLiteralLike(node) ? node.text : null;
-}
-
-function unwrapExpression(node: ts.Expression): ts.Expression {
-  while (
-    ts.isParenthesizedExpression(node) ||
-    ts.isAsExpression(node) ||
-    ts.isTypeAssertionExpression(node) ||
-    ts.isSatisfiesExpression(node)
-  ) {
-    node = node.expression;
-  }
-  return node;
-}
-
-function moduleSpecifier(node: ts.Node): string | null {
-  if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
-    return node.moduleSpecifier == null
-      ? null
-      : stringLiteralText(node.moduleSpecifier);
-  }
-  if (ts.isImportEqualsDeclaration(node)) {
-    const reference = node.moduleReference;
-    return ts.isExternalModuleReference(reference)
-      ? stringLiteralText(reference.expression)
-      : null;
-  }
-  if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument)) {
-    return stringLiteralText(node.argument.literal);
-  }
-  if (ts.isCallExpression(node)) {
-    const [argument] = node.arguments;
-    const loadsModule =
-      node.expression.kind === ts.SyntaxKind.ImportKeyword ||
-      (ts.isIdentifier(node.expression) && node.expression.text === 'require');
-    return loadsModule && argument != null
-      ? stringLiteralText(unwrapExpression(argument))
-      : null;
-  }
-  return null;
-}
-
-function collectModuleSpecifiers(sourceFile: ts.SourceFile): string[] {
-  const specifiers: string[] = [];
-
-  const visit = (node: ts.Node): void => {
-    const specifier = moduleSpecifier(node);
-    if (specifier != null) specifiers.push(specifier);
-    ts.forEachChild(node, visit);
-  };
-
-  visit(sourceFile);
-  return specifiers;
-}
 
 function authRoot(specifier: string): string | null {
   if (specifier === '@auth') return '@auth';
@@ -130,9 +69,9 @@ function isForbiddenAuthImport(file: string, specifier: string): boolean {
 }
 
 function findForbiddenAuthImports(file: string, source: string): string[] {
-  return collectModuleSpecifiers(parseSourceFile(file, source)).filter(
-    (specifier) => isForbiddenAuthImport(file, specifier),
-  );
+  return collectModuleSpecifiers(
+    parseSourceFile(file, { text: source }),
+  ).filter((specifier) => isForbiddenAuthImport(file, specifier));
 }
 
 describe('hosted auth import boundary', () => {
@@ -188,6 +127,24 @@ describe('hosted auth import boundary', () => {
         `,
       ),
     ).toEqual(['../../auth/SupabaseClient', '../../auth/sessionToken']);
+  });
+
+  // Regression: the collector this suite shares with the other ratchets grew
+  // its `ts.isImportTypeNode` branch unevenly — agentRuntimeProgressEventsBoundary
+  // had none, so a `typeof import(…)` reference slipped past a
+  // single-permitted-importer guard while two siblings caught the same form.
+  // Nothing else in the repo exercises a type position, so pin it here.
+  it('rejects typeof-import type positions, aliased and relative', () => {
+    expect(
+      findForbiddenAuthImports(
+        resolve(REPO_ROOT, 'src/agent/runtime/fixture.ts'),
+        `
+          type Client = typeof import('@auth/SupabaseClient');
+          type Session = import('../../auth/sessionToken').Session;
+          type Codex = typeof import('@auth/codex/oauth');
+        `,
+      ),
+    ).toEqual(['@auth/SupabaseClient', '../../auth/sessionToken']);
   });
 
   it('rejects asserted module arguments and dynamic imports with options', () => {

--- a/src/test-kernel/architecture/sharedSchemasDeepImportRatchet.vitest.ts
+++ b/src/test-kernel/architecture/sharedSchemasDeepImportRatchet.vitest.ts
@@ -28,7 +28,12 @@ import { dirname, join, relative, resolve } from 'node:path';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
-import { REPO_ROOT, sourceFilesUnder, toRepoPath } from '../support/repoScan';
+import {
+  parseSourceFile,
+  REPO_ROOT,
+  sourceFilesUnder,
+  toRepoPath,
+} from '../support/repoScan';
 
 const BASELINE_FILE =
   'config/ratchets/shared-schemas-deep-import-baseline.json';
@@ -77,20 +82,9 @@ interface SchemasBaseline {
   gratuitous: DeepImports;
 }
 
-function parseSourceFile(
-  file: string,
-  text = readFileSync(file, 'utf8'),
-): ts.SourceFile {
-  // No parent pointers: nothing here walks upward, and setting them roughly
-  // doubles the parse cost across ~2k files.
-  return ts.createSourceFile(
-    file,
-    text,
-    ts.ScriptTarget.Latest,
-    false,
-    file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
-  );
-}
+// No parent pointers: nothing here walks upward, and setting them roughly
+// doubles the parse cost across ~2k files.
+const NO_PARENT_NODES = { setParentNodes: false } as const;
 
 function resolveRelative(
   fromFile: string,
@@ -332,7 +326,7 @@ function schemaModuleExports(
   }
   active.add(file);
   const exports: ModuleExports = new Map();
-  const sourceFile = parseSourceFile(file);
+  const sourceFile = parseSourceFile(file, NO_PARENT_NODES);
 
   for (const statement of sourceFile.statements) {
     if (!hasExportModifier(statement)) continue;
@@ -574,7 +568,7 @@ function collectCurrent(documentedFloors: DeepImports = {}): CollectedSchemas {
       const text = readFileSync(file, 'utf8');
       if (!text.includes(DEEP_IMPORT_PREFIX)) continue;
       for (const reference of deepImportReferences(
-        parseSourceFile(file, text),
+        parseSourceFile(file, { ...NO_PARENT_NODES, text }),
       )) {
         const resolvedSpaces = reference.bindings?.map((binding) =>
           reachableSpace(fullSurface, reference.specifier, binding, moduleMemo),
@@ -675,9 +669,9 @@ function contractedSurface(
 
 describe('@shared/schemas deep-import ratchet', () => {
   it('finds every TypeScript module-loading form', () => {
-    const source = parseSourceFile(
-      'probe.ts',
-      `
+    const source = parseSourceFile('probe.ts', {
+      ...NO_PARENT_NODES,
+      text: `
         import { AgentCategory } from '@shared/schemas/agent';
         export { AgentCategory } from '@shared/schemas/agent';
         import defaultAgent from '@shared/schemas/agent';
@@ -693,7 +687,7 @@ describe('@shared/schemas deep-import ratchet', () => {
         const importPath = import.meta.resolve('@shared/schemas/agent');
         type Category = import('@shared/schemas/agent').AgentCategory;
       `,
-    );
+    });
 
     const specifier = '@shared/schemas/agent';
     const named = (

--- a/src/test-kernel/architecture/storePublicSurfaceRatchet.vitest.ts
+++ b/src/test-kernel/architecture/storePublicSurfaceRatchet.vitest.ts
@@ -19,7 +19,7 @@ import { resolve } from 'node:path';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
-import { REPO_ROOT } from '../support/repoScan';
+import { parseSourceFile, REPO_ROOT } from '../support/repoScan';
 
 const BASELINE_FILE = 'config/ratchets/store-public-surface-baseline.json';
 const BASELINE_PATH = resolve(REPO_ROOT, BASELINE_FILE);
@@ -51,13 +51,7 @@ function isPublicMethod(
 }
 
 function storeSourceFile(store: StoreName): ts.SourceFile {
-  const file = resolve(REPO_ROOT, STORES[store]);
-  return ts.createSourceFile(
-    file,
-    readFileSync(file, 'utf8'),
-    ts.ScriptTarget.Latest,
-    true,
-  );
+  return parseSourceFile(resolve(REPO_ROOT, STORES[store]));
 }
 
 /** Public (static + instance) method names of one store class, sorted. */

--- a/src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts
+++ b/src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts
@@ -7,6 +7,7 @@ import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 import {
+  parseSourceFile,
   REPO_ROOT,
   sourceFilesUnder,
   toRepoPath as repoRelative,
@@ -277,14 +278,7 @@ function collectSubsystemEdges(): SubsystemEdge[] {
       continue;
     }
 
-    const sourceFile = ts.createSourceFile(
-      file,
-      readFileSync(file, 'utf8'),
-      ts.ScriptTarget.Latest,
-      true,
-      file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
-    );
-    visitImports(sourceFile, file, from, edges);
+    visitImports(parseSourceFile(file), file, from, edges);
   }
 
   return [...edges.entries()]

--- a/src/test-kernel/architecture/supportMockImportOrder.vitest.ts
+++ b/src/test-kernel/architecture/supportMockImportOrder.vitest.ts
@@ -6,7 +6,12 @@ import { resolve } from 'node:path';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
-import { REPO_ROOT, sourceFilesUnder, toRepoPath } from '../support/repoScan';
+import {
+  parseSourceFile,
+  REPO_ROOT,
+  sourceFilesUnder,
+  toRepoPath,
+} from '../support/repoScan';
 
 /**
  * Architecture guard for the shared mock modules extracted by #10361.
@@ -63,13 +68,7 @@ function declarationIsTypeOnly(
 }
 
 function collectImportsFromSource(file: string, source: string): ImportSite[] {
-  const sourceFile = ts.createSourceFile(
-    file,
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
-  );
+  const sourceFile = parseSourceFile(file, { text: source });
 
   const imports: ImportSite[] = [];
   for (const statement of sourceFile.statements) {

--- a/src/test-kernel/support/repoScan.ts
+++ b/src/test-kernel/support/repoScan.ts
@@ -1,12 +1,15 @@
 /**
- * Repo file-discovery shared by the architecture ratchet tests under
- * src/test-kernel/architecture/. Each ratchet keeps its own baseline-diff and
- * AST logic; only the file-scanning plumbing lives here.
+ * Repo file-discovery and TypeScript-parsing plumbing shared by the
+ * architecture ratchet tests under src/test-kernel/architecture/. Each ratchet
+ * keeps its own baseline-diff logic and any richer AST extraction it needs
+ * (edge kinds, per-binding type-space); the file walk, the parse call, and the
+ * plain "which modules does this file load" scan live here.
  */
-import { readdirSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import ts from 'typescript';
 import { expect } from 'vitest';
 
 export const REPO_ROOT = resolve(
@@ -74,6 +77,91 @@ export function expectRealCoverage(roots: readonly string[], min = 100): void {
     0,
   );
   expect(scanned).toBeGreaterThan(min);
+}
+
+export function parseSourceFile(
+  file: string,
+  opts?: {
+    /** Source text, when the caller already read it or is parsing a fixture. */
+    readonly text?: string;
+    /**
+     * Parent pointers roughly double the parse cost; pass `false` when nothing
+     * walks upward and the scan covers thousands of files.
+     */
+    readonly setParentNodes?: boolean;
+  },
+): ts.SourceFile {
+  // No ScriptKind argument: ts.createSourceFile derives it from the file name,
+  // so a .tsx path already parses as TSX.
+  return ts.createSourceFile(
+    file,
+    opts?.text ?? readFileSync(file, 'utf8'),
+    ts.ScriptTarget.Latest,
+    opts?.setParentNodes ?? true,
+  );
+}
+
+function stringLiteralText(node: ts.Node): string | null {
+  return ts.isStringLiteralLike(node) ? node.text : null;
+}
+
+function unwrapExpression(node: ts.Expression): ts.Expression {
+  while (
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isTypeAssertionExpression(node) ||
+    ts.isSatisfiesExpression(node)
+  ) {
+    node = node.expression;
+  }
+  return node;
+}
+
+/** The module `node` loads, across every form that loads one. */
+function moduleSpecifier(node: ts.Node): string | null {
+  if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+    return node.moduleSpecifier == null
+      ? null
+      : stringLiteralText(node.moduleSpecifier);
+  }
+  if (ts.isImportEqualsDeclaration(node)) {
+    const reference = node.moduleReference;
+    return ts.isExternalModuleReference(reference)
+      ? stringLiteralText(reference.expression)
+      : null;
+  }
+  if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument)) {
+    return stringLiteralText(node.argument.literal);
+  }
+  if (ts.isCallExpression(node)) {
+    const [argument] = node.arguments;
+    const loadsModule =
+      node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+      (ts.isIdentifier(node.expression) && node.expression.text === 'require');
+    return loadsModule && argument != null
+      ? stringLiteralText(unwrapExpression(argument))
+      : null;
+  }
+  return null;
+}
+
+/**
+ * Every module specifier `sourceFile` loads, in source order: static
+ * import/export, `import x = require(…)`, `typeof import(…)` type positions,
+ * and dynamic `import(…)` / `require(…)` calls (import attributes and asserted
+ * arguments included).
+ */
+export function collectModuleSpecifiers(sourceFile: ts.SourceFile): string[] {
+  const specifiers: string[] = [];
+
+  const visit = (node: ts.Node): void => {
+    const specifier = moduleSpecifier(node);
+    if (specifier != null) specifiers.push(specifier);
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return specifiers;
 }
 
 /** Drop comments so a prose mention like "do not import from 'vscode'" can't


### PR DESCRIPTION
## Summary

Nine architecture ratchets each hand-rolled "parse a TypeScript file and collect the module
specifiers it loads". `src/test-kernel/support/repoScan.ts` already declares itself the home for
exactly this scanning plumbing and already owns the file-walking half, so the parse call and the
plain specifier scan move there.

**The justification is not LoC — the copies had drifted, and the drift is a live hole.**
`agentRuntimeProgressEventsBoundary.vitest.ts` had **no `ts.isImportTypeNode` branch at all**, while
`hostedAuthImportBoundary`, `hostAgentDeepImportRatchet`, `subsystemEdgeRatchet` and
`sharedSchemasDeepImportRatchet` all have one. That boundary guards
`packages/cli/src/runtime/cliNdjsonProgressEvents.ts` with exactly **one** permitted production
importer — so a second production file writing `typeof import('…/cliNdjsonProgressEvents')` passed
the guard untouched today, while the identical form was caught by two sibling ratchets. The shape is
live, not hypothetical: 15 production `typeof import(...)` sites already exist, including relative
ones in `src/tools/claudeAgent.ts`, `src/tools/codex.ts` and
`src/tools/delegation/nativeSubagentStrategy.ts`. Demonstrated by execution against the two
collectors:

```
OLD collector sees: []
NEW collector sees: ["@cli/runtime/cliNdjsonProgressEvents",
                     "../../packages/cli/src/runtime/cliNdjsonProgressEvents"]
```

**That probe is now a fixture.** Review flagged that the closed hole shipped with no assertion
pinning it — no existing fixture exercised a `typeof import(…)` type position, and no production file
in the scanned zones contains one, so the branch could be silently deleted again. One case added to
`hostedAuthImportBoundary`'s existing fixture block (the suite the superset body came from), covering
both spellings in that suite's own auth vocabulary. Mutation-checked: deleting the
`ts.isImportTypeNode` branch from `repoScan` fails exactly that case, and fails it with
`expected [] to deeply equal [ '@auth/SupabaseClient', … ]` — the same empty result the probe showed.

Second hole closed on the way: `hostAgentDeepImportRatchet` gated dynamic imports on
`node.arguments.length === 1`, so `import('x', { with: … })` was invisible to it — a form
`hostedAuthImportBoundary` had already written a fixture for (`:186`). The superset never had that
gate; it is dropped.

Third finding, which shrinks the change rather than growing it: the
`file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS` ternary is **itself reinvented**.
`ts.createSourceFile` derives ScriptKind from the file name when the fifth argument is omitted
(verified by execution: 4-arg on a `.tsx` file containing JSX yields 0 parse diagnostics; forcing
`ScriptKind.TS` yields 5). So six copies of that ternary **delete outright** rather than relocating,
and the shared helper carries no ternary and no `.tsx` branch.

## Issue acceptance gates

No issue — verified collapse-sweep candidate.

## Single source of truth

`src/test-kernel/support/repoScan.ts` now owns the TypeScript **parse call** and the plain
**"which modules does this file load"** scan for the architecture ratchets, alongside the file walk
it already owned. Two exports:

- `parseSourceFile(file, { text?, setParentNodes? })` — four-arg `ts.createSourceFile`, no
  ScriptKind. 9 consumers.
- `collectModuleSpecifiers(sourceFile)` — `hostedAuthImportBoundary`'s body **relocated** (not
  duplicated), the strict superset: `ImportDeclaration`, `ExportDeclaration`, `import =`,
  `ts.isImportTypeNode`, dynamic `import()`/`require()`, plus the `unwrapExpression` helper for
  asserted/parenthesised arguments. 3 consumers.

Each ratchet keeps its own baseline-diff logic.

## Duplication and abstraction budget

Removed: 9 copies of the parse call (3 shapes), 3 copies of the specifier collector (3 drifted
variants), 6 copies of the ScriptKind ternary. No new layer — `repoScan.ts` is an existing module
whose header already scoped it to this plumbing.

**Deliberately NOT folded** (verified as genuinely richer returns, not drift):

- `subsystemEdgeRatchet.vitest.ts` `moduleReference` — returns specifier **+ `EdgeKind`**
  (type-only vs value), which the shared collector has no place for.
- `sharedSchemasDeepImportRatchet.vitest.ts` `deepImportReferences` — returns per-binding
  `ImportBinding[]` with requested type-space, plus `module.require` / `require.resolve` /
  `import.meta.resolve` callees the shared collector does not model.
- `supportMockImportOrder.vitest.ts` — must stay non-recursive over `sourceFile.statements` (import
  *order* at top level is the invariant); it takes `parseSourceFile` but not the collector.
- `storePublicSurfaceRatchet.vitest.ts` / `AgentPromptContracts.vitest.ts` — not import scans at all
  (class members, string literals); they take `parseSourceFile` only.

All five take the shared parse and keep their own extraction. `sharedSchemasDeepImportRatchet`
keeps its documented `setParentNodes: false` perf choice, now as an option with the comment intact.

## Net elements (R6)

**This is a net reduction, and a modest one.**

| | |
|---|---|
| Files | 10 modified, **0 added, 0 deleted** |
| Exported symbols | **+2** (`parseSourceFile`, `collectModuleSpecifiers`), −0 |
| Module-local functions | −11 deleted, +4 added in `repoScan` (`stringLiteralText`, `unwrapExpression`, `moduleSpecifier`, and the two exports) → **net −6** |
| Module-local consts | +1 (`NO_PARENT_NODES` in `sharedSchemasDeepImportRatchet`, carrying its perf comment) |
| Classes/interfaces/enums | 0 added, 0 deleted |
| Test cases | **+1** (the `typeof import(…)` regression fixture, 18 lines incl. its comment) |
| **Net LoC** | **+167 / −243 = −76** |

`git diff --numstat HEAD~1 -- src | awk '{a+=$1;d+=$2} END {print a, d}'` → `167 243`.

This is a mechanical dedup, not an extract-shared-abstraction: the deleted bodies are
byte-comparable modulo the three variants, which is why it lands negative instead of the usual
net-add.

## Consumer counts (R8)

No emit path or public export was deleted — every removed helper was module-local.

```
$ grep -rn "createSourceFile" src packages/*/src
src/test-kernel/support/repoScan.ts:94:  // No ScriptKind argument: ts.createSourceFile derives …
src/test-kernel/support/repoScan.ts:96:  return ts.createSourceFile(
```
(the only remaining site; `scripts/check-browser-safe-utils.mjs` is a separate `.mjs` tool outside
the test tree and is untouched)

```
$ grep -rn "moduleSpecifierFromImportEquals\|moduleSpecifierFromCall\|literalText\b" src packages/*/src
(no matches — all three deleted helpers were local to agentRuntimeProgressEventsBoundary)
```

New exports, consumers in this PR:
```
$ grep -rln "parseSourceFile" src        → 10 files (repoScan + 9 ratchets)
$ grep -rln "collectModuleSpecifiers" src → 4 files (repoScan + 3 ratchets)
```

## Host impact

Extension: none — test-only.

Desktop: none — test-only.

CLI: none — test-only. No file outside `src/test-kernel/` is touched.

## Scheduled refactoring

None.

## Validation

**No ratchet baseline was regenerated or widened.** The concern that the superset collector would
surface `@agent/*` specifiers absent from `config/ratchets/host-agent-import-baseline.json` was
tested by executing the narrow (current) and wide (new) collectors over all four host trees:

Before (main checkout, older `main` @ `d8ab49acd1`):
```
cli narrow 11 wide 11 ADDED [] LOST []
desktop narrow 10 wide 10 ADDED [] LOST []
extension narrow 13 wide 13 ADDED [] LOST []
agent narrow 7 wide 7 ADDED [] LOST []
```

After (this branch @ `eb120bff13` + the change):
```
cli narrow 11 wide 11 ADDED [] LOST []
desktop narrow 10 wide 10 ADDED [] LOST []
extension narrow 12 wide 12 ADDED [] LOST []
agent narrow 7 wide 7 ADDED [] LOST []
```

`ADDED [] LOST []` in every host on both trees — the collectors agree exactly. (The extension 13→12
delta is between the two *commits*, not between the two collectors: this PR touches no production
file, so the scanned trees are identical before and after by construction —
`git diff --name-only HEAD~1` lists only `src/test-kernel/**`.) The checked-in baseline is unchanged
and the ratchet suite passes against it.

Ran, from the branch worktree:

- `tsc --noEmit --checkers 8` — clean (exit 0)
- `tsc --noEmit --checkers 8 -p tsconfig.test-kernel.json` — clean (exit 0)
- `npx eslint` over the 10 touched files — clean
- `npx prettier --check` over the 10 touched files — clean
- `node scripts/check-dead-code-ratchet.mjs` — `8 current vs 8 baselined`, OK (both new exports have
  consumers in this PR)
- `vitest run` over all 9 touched suites — **9 files, 771 tests, all passing**
- Mutation check on the new fixture: with the `ts.isImportTypeNode` branch deleted from
  `repoScan.ts`, `hostedAuthImportBoundary` reports `1 failed | 5 passed` and the failure is exactly
  the new case. Branch restored, 6 passed.

Not run and why: `typecheck:agent` / `:cli` / `:trace-viewer` / `:desktop` (per-package builds) —
this PR changes no file outside `src/test-kernel/`, which `tsconfig.test-kernel.json` fully covers,
and the workspace `corepack pnpm` wrapper cannot run in this worktree without rewriting
`pnpm-lock.yaml` (a pnpm 10 vs 11 `patchedDependencies` format difference; the lockfile is
deliberately not committed). Full `vitest run` skipped per sweep charter — other tracks are
contending for CPU.

**One new test**, added on review: a single regression case for the fixed collector hole, extending
an existing suite's fixture block rather than adding a file. That is the repo's bug-fix budget
exactly ("at most one regression test"), and it sits on the durable boundary — the shared collector
— not on a churning seam. No existing assertion changed, no test deleted. The refactor half of this
PR adds none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
