### PR TITLE
refactor(ui): drop the compaction tick the UI cannot know

### DIFF
--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -257,11 +257,13 @@ function formatUsage(
   // tokens are the generated response, not part of the context, which is why
   // the handler reports `inputTokens` here.
   const { inputTokens: used, contextWindow, utilizationPercent } = contextState;
-  const ratio = used / contextWindow;
   const percent = Math.max(1, Math.round(utilizationPercent));
+  // Bands match the progress view's context gauge (`fillColor` in UsagePanel),
+  // and read the handler's own `utilizationPercent` rather than re-dividing
+  // used/contextWindow — the same number told two ways drifts.
   let color: StatusBarColor;
-  if (ratio >= 0.9) color = COLOR_ERROR;
-  else if (ratio >= 0.6) color = COLOR_WARNING;
+  if (utilizationPercent > 80) color = COLOR_ERROR;
+  else if (utilizationPercent > 65) color = COLOR_WARNING;
   else color = 'dim';
   return {
     ...base,

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -16,7 +16,6 @@ import type {
   UsageRoute,
 } from '@shared/schemas';
 import { designTokens } from '@shared/styles';
-import { DEFAULT_COMPACTION_THRESHOLD_PERCENT } from '@shared/constants/contextManagement';
 import { usageRouteBadge } from '@shared/copy/modelAccess';
 
 // Local imports - shared icons and utils
@@ -135,10 +134,7 @@ export class UsagePanel extends LitElement {
       }
 
       .context-gauge__track {
-        position: relative;
         width: 80px;
-        /* Pins the tick mark's height to the bar regardless of
-           wa-progress-bar's internal box model. */
         height: var(--gauge-height);
       }
 
@@ -146,16 +142,6 @@ export class UsagePanel extends LitElement {
         width: 100%;
         --track-height: var(--gauge-height);
         --track-color: var(--wa-color-surface-border);
-      }
-
-      /* Compaction threshold tick mark */
-      .context-gauge__tick {
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        width: var(--border-thin);
-        background: var(--wa-color-text-normal);
-        opacity: var(--opacity-separator);
       }
 
       .run-summary {
@@ -317,14 +303,6 @@ export class UsagePanel extends LitElement {
             label="${clamped.toFixed(0)}% context used"
             style=${styleMap({ '--indicator-color': fillColor(clamped) })}
           ></wa-progress-bar>
-          <span
-            id="usage-compaction-tick"
-            class="context-gauge__tick"
-            style=${styleMap({ left: `${DEFAULT_COMPACTION_THRESHOLD_PERCENT}%` })}
-          ></span>
-          <wa-tooltip for="usage-compaction-tick"
-            >Compaction at ${DEFAULT_COMPACTION_THRESHOLD_PERCENT}%</wa-tooltip
-          >
         </span>
         <span class="context-state__value">
           ${formatCompactTokenCount(inputTokens)} /


### PR DESCRIPTION
## Summary

The progress view's context gauge drew a tick mark and a tooltip reading **"Compaction at 75%"**,
positioned from the compile-time constant `DEFAULT_COMPACTION_THRESHOLD_PERCENT`. That assertion
is wrong on five distinct routes, and no single constant the UI can hold is ever right:

1. **The setting overrides it.** `texra.model.compactionThresholdPercent` is user-facing
   (`SettingsProfileController.ts`, `coreSettings.ts`). Set it to 50 and the tooltip still says 75%.
2. **Tool-use only.** `ModelHandler.shouldCompactByInputTokens` returns `false` outside tool-use
   mode (`src/agent/modelHandlers/ModelHandler.ts:1317`) — a reflection run never compacts at any
   percentage, but the tick is still drawn.
3. **`<= 0` disables compaction entirely** (`ModelHandler.ts:1320`) — the tick then marks a
   threshold that does not exist.
4. **OpenAI Responses hands the decision to a live pre-flight count.**
   `modelHandlerOpenAIResponse.shouldCompact` returns `false` for counting-capable models and lets
   `createResponseImpl` decide from the current request
   (`src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts:670-694`), with a separate
   OpenRouter exclusion. Its threshold is also computed against
   `getEffectiveInputTokenLimit()`, not the `contextWindow` the gauge is drawn from.
5. **Anthropic recomputes it server-side.** `setupContextManagement` builds its own
   `compact_20260112` trigger as `Math.floor((thresholdPercent / 100) * contextWindow)` floored by
   `MIN_COMPACTION_TRIGGER_TOKENS`, again tool-use-only and eligible-model-only
   (`src/agent/modelHandlers/anthropic/anthropicContextManagement.ts:100-140`).

So the UI was asserting a number it does not have and cannot derive. This PR deletes the
assertion rather than inventing a sixth derivation of it. The gauge itself (fill percentage,
colour band, `x / y` token counts) is unchanged — that data really is reported by the handler.

While there, the CLI status bar's colour bands are made to agree with the panel's, and it now
reads the `utilizationPercent` the handler already reported instead of re-deriving
`used / contextWindow` from the same record.

## Issue acceptance gates

No issue — found by a collapse sweep over context-pressure UI. Gate: remove the wrong assertion
without changing any wire contract, without adding a field to a persisted schema, and without
adding tests.

## Single source of truth

The handler stays the single owner of the compaction decision; there was never a path publishing
that decision to the UI, so the UI stops claiming to know it. `ContextStateData` keeps exactly
the three facts the handler actually stamps (`inputTokens`, `contextWindow`,
`utilizationPercent`), and `utilizationPercent` is now the only source of the CLI band — the
status bar no longer computes a second opinion of the same ratio.

## Duplication and abstraction budget

Removed: one UI-side re-derivation of a runtime decision, and one re-derivation of
`utilizationPercent` in the CLI.

**Deliberately NOT added: a shared colour-band module.** The two hosts use incompatible colour
vocabularies (`'var(--color-success)'` / `'var(--color-warning)'` CSS custom properties in the
Lit panel vs `'dim'` / `COLOR_WARNING` / `COLOR_ERROR` status-bar enums in the Ink TUI), so a
shared owner could only return a band enum and each host would still need its own mapping — net
**+5 lines and a new module** for zero removed logic. That is the extract-shared net-add trap
this repo has been burned by. The two band lists are now numerically identical (65 / 80) with a
comment pointing each at the other; if they drift again, that is when a shared owner earns its
keep.

**Deliberately NOT done: publishing `compactionThresholdPercent` on `ContextStateData` and
re-drawing the tick from it.** That is the correct single-owner shape *only if* the maintainer
wants the tick to exist at all, and it net-adds: it would have to fold all five gates above into
one effective-threshold override chain, and any new field on that persisted schema
(`TexraTranscriptRecorder` re-reads it) must be `.optional()`/`.prefault()` anyway. Left for an
explicit ruling.

## Net elements (R6)

| | + | − | net |
|---|---|---|---|
| Files | 0 | 0 | 0 |
| Exported symbols | 0 | 0 | 0 |
| Imports | 0 | 1 (`DEFAULT_COMPACTION_THRESHOLD_PERCENT` in `UsagePanel`) | −1 |
| DOM elements rendered | 0 | 2 (tick `<span>`, its `<wa-tooltip>`) | −2 |
| CSS rules | 0 | 1 (`.context-gauge__tick`) | −1 |
| Local variables | 0 | 1 (`ratio`) | −1 |
| LoC | +5 | −25 | **−20** |

Per file:
- `packages/extension/src/progressView/frontend/components/UsagePanel.ts` +0/−22
- `packages/cli/src/chat/tui/panes/statusBarDisplay.ts` +5/−3

The CLI file is +2 on its own: the `ratio` line goes, but a 3-line comment recording that the
bands are deliberately shared with the panel comes in. Naming it, since the accounting should be
honest: the reduction lives entirely in the extension file.

`.context-gauge__track` keeps its `width`/`height` but loses `position: relative` and the comment
explaining it ("Pins the tick mark's height to the bar") — both existed only for the absolutely
positioned tick. The wrapper `<span>` itself survives; collapsing it into the progress bar would
change layout, which I cannot verify headlessly and is not worth the risk here.

## Consumer counts (R8)

```
$ grep -rn "Compaction at\|usage-compaction-tick\|context-gauge__tick" src packages --include="*.ts" --include="*.tsx"
(after the change: no results — before, only the four lines deleted here)

$ grep -rn "DEFAULT_COMPACTION_THRESHOLD_PERCENT" src packages --include="*.ts"
src/shared/constants/contextManagement.ts:7        definition (kept)
src/agent/modelHandlers/ModelHandler.ts:82,1305    the real consumer (kept — this is the authority)
```

The constant is **not** deleted; it remains the handler-side default. Only the UI's copy of it
goes. `styleMap` is still used in `UsagePanel` (the fill colour), so its import stays.

No emit path, event key, or export was removed — nothing on the wire changed, so there is no
subscriber count to report.

## Host impact

Extension: the context gauge loses the tick mark and its "Compaction at 75%" tooltip. Bar fill,
colour band, and the `187k / 400k` counts are unchanged, as is the gauge's own
"N% context used" tooltip.

Desktop: same progress-view component, same change.

CLI: status-bar context segment turns amber above 65% (was 60%) and red above 80% (was 90%),
matching the panel. Text is unchanged.

## Scheduled refactoring

None filed. The open question — should the gauge show an effective compaction threshold at all,
and if so via a `getEffectiveCompactionThresholdPercent()` override chain folding all five gates
plus an optional field on `ContextStateData` — is a maintainer call, deliberately not started
here. If the answer is "no tick", this PR already closed it.

## Validation

- `npm run typecheck` — clean across the whole workspace (exit 0).
- `corepack pnpm --filter @texra-ai/cli typecheck` — clean (this is the only thing that compiles
  `packages/cli/tsconfig.scripts.json`).
- `npx vitest run src/test-kernel/cli/StatusBar.vitest.ts` — **91 passed**. Its `contextState`
  fixtures sit at 8% and 46.8% utilization, i.e. `dim` under both the old and the new bands, and
  it asserts on segment text rather than colour — so the band change is invisible to it.
- `npx vitest run src/test-kernel/progressView/UsagePanel.vitest.ts` — **5 passed**. Nothing in it
  referenced the tick.
- `npx eslint` and `npx prettier --check` on both changed files — clean.
- `check:dead-code-ratchet` not run: no export added or removed.

Zero new tests, zero tests deleted, zero tests modified.
