### PR TITLE
refactor(shared): use the StateStore port directly, delete its duplicate

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -653,9 +653,8 @@ export default tseslint.config(
     },
   },
 
-  // Production core code must not reach back into host-owned layers. The only
-  // intentional prose reference in this area is a JSDoc note in
-  // src/shared/state/PersistedState.ts; import declarations stay forbidden.
+  // Production core code must not reach back into host-owned layers; import
+  // declarations are forbidden.
   {
     files: ['src/**/*.{ts,tsx}', 'packages/agent/src/**/*.{ts,tsx}'],
     ignores: ['src/test-kernel/**'],

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -221,7 +221,7 @@ export class FileList extends UnsupportedCommandsMixin(LitElement) {
   }
 
   private handleDismissStorageHint = (): void => {
-    webviewStorage.set(STORAGE_HINT_DISMISS_KEY, true);
+    void webviewStorage.update(STORAGE_HINT_DISMISS_KEY, true);
     this.storageHintDismissed = true;
   };
 

--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -290,7 +290,7 @@ export const streamLifecycleHandlers = {
     clearCopyContentStore();
     clearProposalInputStore();
     deleteFollowUpInputTransientState(streamId);
-    webviewStorage.delete(logListStateKey(streamId));
+    void webviewStorage.update(logListStateKey(streamId), undefined);
 
     // Remove permissions for the deleted stream to prevent orphaned entries
     permissions$.set(removePermissionsForStream(permissions$.get(), streamId));
@@ -322,7 +322,7 @@ export const streamLifecycleHandlers = {
     // consumer here (the stream itself is about to disappear from
     // streamById below) — read the ids before the reset wipes them.
     for (const streamId of appState.get().streamById.keys()) {
-      webviewStorage.delete(logListStateKey(streamId));
+      void webviewStorage.update(logListStateKey(streamId), undefined);
     }
 
     appState.set(

--- a/src/controllers/progressView/backend/ProgressPresentationState.ts
+++ b/src/controllers/progressView/backend/ProgressPresentationState.ts
@@ -5,10 +5,7 @@ import type { StateStore } from '@platform/interfaces';
 // Local imports - shared
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import {
-  PersistedState,
-  createBackendStorage,
-} from '@shared/state/PersistedState';
+import { PersistedState } from '@shared/state/PersistedState';
 
 /** Selected progress-view stream, or an empty string when none is selected. */
 type ActiveProgressStream = StreamTabId | '';
@@ -36,7 +33,7 @@ export class ProgressPresentationState {
 
   constructor(storage: StateStore) {
     this.prefs = new PersistedState(
-      createBackendStorage(storage),
+      storage,
       WorkspaceStateKey.PROGRESS_VIEW_PREFS,
       ProgressPresentationPrefsSchema,
     );

--- a/src/shared/state/PersistedState.ts
+++ b/src/shared/state/PersistedState.ts
@@ -1,40 +1,15 @@
 import { z } from 'zod';
 
-/**
- * Minimal storage interface for state persistence.
- * Works with both backend (Memento) and frontend (webview) storage.
- */
-interface StateStorage {
-  get(key: string): unknown;
-  set(key: string, value: unknown): void;
-  delete(key: string): void;
-}
+import type { StateStore } from '@platform/interfaces';
 
 /**
- * Create storage adapter for backend (vscode.Memento wrapper).
+ * Create a {@link StateStore} over webview host state. All keys share a single
+ * state object, cached in memory to avoid repeated getState() calls on rapid
+ * updates.
  *
- * @example
- * import { workspaceSM } from '@common/state';
- * const storage = createBackendStorage(workspaceSM);
- */
-export function createBackendStorage(memento: {
-  get(key: string): unknown;
-  update(key: string, value: unknown): PromiseLike<void>;
-}): StateStorage {
-  return {
-    get: (key) => memento.get(key),
-    set: (key, value) => void memento.update(key, value),
-    // A Memento key is removed by updating it to `undefined`; there is no
-    // separate delete API.
-    delete: (key) => void memento.update(key, undefined),
-  };
-}
-
-/**
- * Create storage adapter for webview host state.
- * All keys share a single state object.
- *
- * Caches state in memory to avoid repeated getState() calls on rapid updates.
+ * A key is removed by updating it to `undefined`, as with a Memento. `update`
+ * returns an already-resolved promise because `setState` is synchronous and
+ * cannot fail — that is not a dropped write.
  *
  * @example
  * import { hostBridge } from '@shared/hostBridge';
@@ -43,19 +18,23 @@ export function createBackendStorage(memento: {
 export function createWebviewStorage(hostBridge: {
   getState(): unknown;
   setState(state: unknown): void;
-}): StateStorage {
+}): StateStore {
   // Cache full state - read once, update in memory
   const cache = (hostBridge.getState() as Record<string, unknown>) ?? {};
 
   return {
-    get: (key) => cache[key],
-    set: (key, value) => {
-      cache[key] = value;
-      hostBridge.setState(cache);
+    get<T>(key: string, defaultValue?: T): T {
+      const value = cache[key];
+      return value === undefined ? (defaultValue as T) : (value as T);
     },
-    delete: (key) => {
-      delete cache[key];
+    update(key, value) {
+      if (value === undefined) {
+        delete cache[key];
+      } else {
+        cache[key] = value;
+      }
       hostBridge.setState(cache);
+      return Promise.resolve();
     },
   };
 }
@@ -63,8 +42,8 @@ export function createWebviewStorage(hostBridge: {
 /**
  * Unified state persistence with Zod schema validation.
  *
- * Works identically for both backend and frontend - only the storage differs:
- * - Backend: `createBackendStorage(workspaceSM)` → workspace-scoped, persists across sessions
+ * Takes the platform `StateStore` port directly; only the implementation differs:
+ * - Backend: the host's own store → workspace-scoped, persists across sessions
  * - Frontend: `createWebviewStorage(hostBridge)` → webview-scoped, transient UI state
  *
  * Schemas should use .prefault() for fields to provide defaults — never
@@ -75,7 +54,7 @@ export function createWebviewStorage(hostBridge: {
  * @example
  * // Backend (user preferences - persist across sessions)
  * const prefs = new PersistedState(
- *   createBackendStorage(workspaceSM),
+ *   platform().workspaceState,
  *   WorkspaceStateKey.VIEW_PREFS,
  *   z.object({ filter: z.string().prefault('all') }),
  * );
@@ -98,7 +77,7 @@ export class PersistedState<T extends Record<string, unknown>> {
   private state: T;
 
   constructor(
-    private readonly storage: StateStorage,
+    private readonly storage: StateStore,
     private readonly key: string,
     private readonly schema: z.ZodType<T>,
   ) {
@@ -127,8 +106,25 @@ export class PersistedState<T extends Record<string, unknown>> {
       },
     );
     const defaults = this.resolveDefaults();
-    this.storage.set(this.key, defaults);
+    this.persist(defaults);
     return defaults;
+  }
+
+  /**
+   * Write through to storage. The promise is deliberately not awaited — every
+   * caller is a synchronous UI path — but a rejection must not escape as an
+   * unhandled rejection, which on the desktop main process is an uncaught
+   * error with no attribution to the failing key. Warn loudly instead.
+   */
+  private persist(value: T): void {
+    void Promise.resolve(this.storage.update(this.key, value)).catch(
+      (error: unknown) => {
+        console.warn(
+          `[PersistedState] Failed to persist ${this.key}; the in-memory value is now ahead of storage.`,
+          error,
+        );
+      },
+    );
   }
 
   /**
@@ -161,7 +157,7 @@ export class PersistedState<T extends Record<string, unknown>> {
   /** Replace entire state */
   setState(state: T): void {
     this.state = { ...state };
-    this.storage.set(this.key, this.state);
+    this.persist(this.state);
   }
 
   /** Reload current state from the backing storage. */
@@ -177,7 +173,7 @@ export class PersistedState<T extends Record<string, unknown>> {
   /** Reset to schema defaults */
   reset(): void {
     this.state = this.resolveDefaults();
-    this.storage.set(this.key, this.state);
+    this.persist(this.state);
   }
 }
 

--- a/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
@@ -157,7 +157,7 @@ function seedStreamWithLogListToggle(streamId: StreamTabId): void {
     agentCategory: AgentCategory.Workflow,
     creationTimestamp: 1,
   });
-  webviewStorage.set(logListStateKey(streamId), {
+  void webviewStorage.update(logListStateKey(streamId), {
     groupToggleStates: [['group-1', true]],
   });
 }

--- a/src/test-kernel/shared/PersistedState.vitest.ts
+++ b/src/test-kernel/shared/PersistedState.vitest.ts
@@ -20,8 +20,7 @@ const StateSchema = z.object({
 describe('PersistedState loading', () => {
   const storage = {
     get: vi.fn(),
-    set: vi.fn(),
-    delete: vi.fn(),
+    update: vi.fn<(key: string, value: unknown) => Promise<void>>(),
   };
 
   let warn: MockInstance<typeof console.warn>;
@@ -41,7 +40,7 @@ describe('PersistedState loading', () => {
     const state = new PersistedState(storage, 'viewPrefs', StateSchema);
 
     expect(state.getState()).toEqual({ density: 'comfortable' });
-    expect(storage.set).not.toHaveBeenCalled();
+    expect(storage.update).not.toHaveBeenCalled();
     expect(warn).not.toHaveBeenCalled();
   });
 
@@ -51,7 +50,7 @@ describe('PersistedState loading', () => {
     const state = new PersistedState(storage, 'viewPrefs', StateSchema);
 
     expect(state.getState()).toEqual({ density: 'comfortable' });
-    expect(storage.set).toHaveBeenCalledWith('viewPrefs', {
+    expect(storage.update).toHaveBeenCalledWith('viewPrefs', {
       density: 'comfortable',
     });
     expect(warn).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Summary

`src/shared/state/PersistedState.ts` declared its own storage interface:

```ts
interface StateStorage {
  get(key: string): unknown;
  set(key: string, value: unknown): void;
  delete(key: string): void;
}
```

That is a poorer, fully-synchronous second declaration of the platform
`StateStore` port (`src/platform/interfaces.ts:49-52`), which is implemented by
`JsonStore`, `MemoryStateStore`, and structurally by `vscode.Memento`. Bridging
the two was `createBackendStorage` — a 12-LoC adapter whose parameter type was
literally `StateStore` minus the generic, and which had **exactly one production
caller**: `ProgressPresentationState.ts:39`, which *already receives a
`StateStore`* (declared at `:37`). A single-caller factory whose only job is to
translate one interface into a near-identical one is the shape CLAUDE.md's
abstraction-discipline rule bans outright.

This PR **deletes `StateStorage` and `createBackendStorage` outright** and imports
the real port: `import type { StateStore } from '@platform/interfaces'`. One owner
per concept.

> **Corrected after review — credit to the `texra-ai` review for the catch.**
> An earlier revision of this PR kept `StateStorage` as a retyped structural twin
> of `StateStore`, justified in both the code and this body by the claim that
> *"`@shared/` must not import `@platform/*`"*. **That claim was false**, and it
> was the central premise of the PR. Keeping a second near-identical declaration
> alongside the real port — defended by a rule that does not exist — was precisely
> the duplication this change set out to delete. Verified at HEAD before acting on
> it, rather than taken on trust:
>
> - Three `src/shared/` modules already import the port:
>   `src/shared/state/onboardingState.ts:9`, `src/shared/settingsView/types.ts:8`,
>   and `src/shared/config/settingsAccess.ts:7`, each
>   `import type { StateStore } from '@platform/interfaces'`.
> - `eslint.config.mjs` has **no** `@platform/*` restriction. The host-layer block
>   restricts `@common/state`, `@common/webview`, `@webview/**`, `@commands/**`,
>   `@progressView/**`, `@settingsView/**`, `@frontend/**`, `@resources/**`,
>   `@cli/**`, `@desktop/**` — `@platform` appears in neither
>   `HOST_LAYER_RESTRICTED_IMPORT_PATHS` (`:76-87`) nor
>   `HOST_LAYER_RESTRICTED_IMPORT_PATTERNS` (`:89-106`).
> - Strongest evidence, which I went looking for rather than assuming:
>   `config/ratchets/architecture-edges-baseline.json:66` already records
>   `{ "from": "shared", "to": "platform", "kind": "type-only" }` as a sanctioned
>   edge. This import widens no baseline — the edge is pre-approved.
> - `@platform/interfaces` is type-only anyway (its sole import is
>   `import type { StreamTabId } from '@shared/schemas'`), so no runtime edge is
>   created and the notional cycle is fully erased at compile time.
>
> Confirmed empirically: `npm run lint` exit 0 and all 17 suites in
> `src/test-kernel/architecture/` (101 tests) pass, including
> `subsystemEdgeRatchet` and `dependencyDirection`. No layering rule bites.

### The removed crash vector

The adapter dropped its write promise:

```ts
set: (key, value) => void memento.update(key, value),
delete: (key) => void memento.update(key, undefined),
```

Floating, with no rejection handler, on all three write paths
(`setState`, `reset`, and `load`'s corruption-reset). This is not theoretical on
desktop:

- `platform().workspaceState` on desktop is
  `JsonStore.open(join(storagePath, 'state.json'))`
  (`packages/desktop/src/main/platform/index.ts`), threaded into
  `ProgressPresentationState` via `desktopAgentExecution.ts` -> `ProgressBackend`.
- `JsonStore.set` genuinely rejects — `readJsonRecord` throws `TypeError` when
  `state.json` holds an array or scalar, `ensureDir`'s `mkdir`/`chmod` throws on
  `EACCES`, and `fileLocks.runExclusive` re-throws or wraps in `AggregateError`.
- Desktop installs `process.on('unhandledRejection', ...)` **only for startup**:
  `installFatalStartupHandlers` returns a disposer that calls `process.off`. So a
  post-startup rejection reaches Node's default unhandled-rejection behaviour —
  at minimum an uncaught error in the Electron main process with **no attribution
  to the failing store write**.

The triggering gesture is mundane: selecting a progress-view tab
(`ProgressPresentationState.select` -> `prefs.update` -> the store write) against a
corrupt or unwritable `state.json`.

All three writes now funnel through one private `persist` method that keeps the
fire-and-forget call shape (every caller is a synchronous UI path) but attaches a
loud `console.warn` naming the key and the cause. `console.warn` is the file's own
existing idiom for its corruption paths — no new logging surface.

### Cost I am not hiding

`createWebviewStorage` now returns a real `StateStore`, so it implements the port
faithfully rather than a subset:

- `update` sits over the **synchronous** `hostBridge.setState` and returns an
  already-resolved promise. That is not a dropped write — `setState` is
  synchronous and cannot fail — and the code says so in a comment so a future
  reader does not "fix" it.
- `get` grows from a one-line lookup to the port's
  `get<T>(key, defaultValue?): T` shape, matching `JsonStore.get` exactly. Three
  lines more, and strictly more correct: the webview store now honours the
  `defaultValue` argument it previously ignored.
- Its `delete(k)` callers become `update(k, undefined)`, marginally noisier at
  three call sites, folding the clear-the-cache-entry logic into the
  `value === undefined` branch. This is exactly the Memento removal idiom the
  deleted adapter already implemented, so no concept is invented — it moves one
  layer down.

## Issue acceptance gates

n/a — no issue; found by a storage-layer collapse sweep.

## Single source of truth

`StateStore` (`src/platform/interfaces.ts:49-52`) is now the **only** declared
shape for "keyed state a host persists". There is no second declaration left to
drift: `PersistedState` names the port, `createWebviewStorage` returns the port,
and the backend passes the port it already held.

Within `PersistedState`, the private `persist` method is the single owner of
"write this key through to storage and handle failure". Previously the write was
duplicated at three sites and the failure was handled at none.

## Duplication and abstraction budget

**Removed:** one whole duplicated interface declaration (`StateStorage`, deleted
outright — not retyped), one single-caller adapter function
(`createBackendStorage`), and one dead method (`delete`, which `PersistedState`
never called — the test even stubbed it and never asserted it).

**Added:** one private method, `PersistedState.persist`, with three callers inside
the same class (`load`, `setState`, `reset`). Not a single-caller extraction, not
an exported surface, and it owns a real invariant: *a write rejection must be
warned, never floated*.

No pass-through layer added. Net one fewer seam between the host's state store and
`PersistedState`.

## Net elements (R6)

**Net LoC: −9.** Measured against the merge base
(`eb120bff1386b5df9ceb5369dac99ba5517c0a1f`), not the moving `origin/main`:

```
$ git diff eb120bff13...HEAD --stat
 eslint.config.mjs                                      |  5 +-
 .../progressView/frontend/components/FileList.ts       |  2 +-
 .../frontend/slices/streamLifecycleSlice.ts            |  4 +-
 .../backend/ProgressPresentationState.ts               |  7 +-
 src/shared/state/PersistedState.ts                     | 88 +++++++++-----------
 .../ProgressViewMessageDispatcher.vitest.ts            |  2 +-
 src/test-kernel/shared/PersistedState.vitest.ts        |  7 +-
 7 files changed, 53 insertions(+), 62 deletions(-)
```

| | delta |
| --- | --- |
| Files | 7 changed, **0 added, 0 deleted** |
| Exported symbols | **−1** (`createBackendStorage`) |
| Interfaces | **−1** (`StateStorage`, deleted outright) |
| Classes / enums | 0 |
| Functions | **−1** exported adapter, **+1** private method (`PersistedState.persist`) |
| Imports | **+1** type-only (`StateStore`), on a pre-ratcheted edge |
| Net LoC | **−9** |

`git diff eb120bff13...HEAD -U0 | grep -E '^[+-]export|^[+-]interface'` yields
exactly two lines, both deletions:

```
-interface StateStorage {
-export function createBackendStorage(memento: {
```

**Honest framing, unchanged by the improved number:** −9 lines is still small, and
volume was never the case for this PR. The case is one fewer declaration of the
same concept and one fewer crash vector. The earlier revision of this PR reported
**+2** — a net-add — and said so plainly; deleting `StateStorage` rather than
retyping it is what turned it negative, which is a fair argument that the reviewer's
correction made the change strictly better rather than merely more accurate.

## Consumer counts (R8)

Every grep run, verbatim results:

```
$ rg -n 'createBackendStorage' --glob '!node_modules' .
(before: src/shared/state/PersistedState.ts   definition + 3 docstring mentions
         src/controllers/progressView/backend/ProgressPresentationState.ts:10,39
                                              the ONE production caller)
(after:  no matches — nothing orphaned)
```

`createWebviewStorage` — 2 callers, both retained, both compile-only changes
(they pass the object into `new PersistedState(...)`):

```
$ rg -n 'createWebviewStorage' --glob '!node_modules' .
packages/extension/src/progressView/frontend/webviewStorage.ts:12
packages/extension/src/webview/frontend/persistence.ts:69
```

Every `webviewStorage` member access, i.e. every site touched by the
`set`/`delete` -> `update` change:

```
$ rg -n 'webviewStorage\.' --glob '!node_modules' .
packages/extension/src/progressView/frontend/components/FileList.ts:127   .get     (unchanged)
packages/extension/src/progressView/frontend/components/FileList.ts:224   .set     -> .update
packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts:293  .delete -> .update(k, undefined)
packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts:325  .delete -> .update(k, undefined)
src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts:160  .set     -> .update
src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts:211,219,232  .get (unchanged)
```

Note the line numbers: the two `.delete` sites are at **:293 and :325**, not the
:203/:235 an earlier survey of this code recorded — that survey was against a
stale revision. All four `.delete`/`.set` sites at HEAD are accounted for above.

`PersistedState` consumers (constructor arg type changed):

```
$ rg -n 'new PersistedState' --glob '!node_modules' .
src/controllers/progressView/backend/ProgressPresentationState.ts:35   now passes StateStore directly
packages/extension/src/progressView/frontend/components/LogList.ts:220 webviewStorage, compile-only
packages/extension/src/webview/frontend/persistence.ts:71              webviewStorage, compile-only
src/test-kernel/shared/PersistedState.vitest.ts:40,50                  mock bag, reshaped
(plus 2 docstring mentions inside PersistedState.ts itself)
```

Four construction sites, all accounted for; two are compile-only.

## Host impact

**Extension:** `webviewStorage.set/delete` become `update`. Behaviour identical —
the webview path was and remains synchronous, and `update(k, undefined)` deletes
the cache entry exactly as `delete(k)` did. Both `PersistedState` instances
(`LogList` per-stream toggles, main-view persisted state) are compile-only.

**Desktop:** the real win. A rejected `state.json` write from the progress view no
longer escapes as an unattributed unhandled rejection in the Electron main
process; it is caught and warned with the key and the cause. In-memory state still
advances (unchanged), and the warning now says so.

**CLI:** none — no CLI code constructs `PersistedState`.

## Scheduled refactoring

None. One adjacent cleanup was folded in rather than deferred: the comment above
the host-layer `no-restricted-imports` block in `eslint.config.mjs` claimed the
only intentional prose reference to a host layer was a JSDoc note in
`PersistedState.ts`. That note was the `@example import { workspaceSM } from
'@common/state'` on `createBackendStorage`, which this PR deletes — verified by
`rg -n '@common/|packages/extension' src/shared/state/PersistedState.ts` returning
nothing — so the sentence was left stale and is removed. No rule behaviour changes.

## Validation

All re-run **after** the correction, against the diff you are reviewing:

- `npm run typecheck` — **clean, all six projects** (workspace, test-kernel, agent
  build, cli, trace-viewer, desktop), exit 0.
- `npm run lint` — **exit 0**. Load-bearing here: it is what proves no
  `no-restricted-imports` rule covers `@platform/*` from `src/shared/**`.
- `npx vitest run src/test-kernel/architecture/` — **17 files, 101 tests passed**,
  including `subsystemEdgeRatchet`, `dependencyDirection`, and
  `sessionPresentationBoundary`. This is the check that the new type-only import
  widens no architecture baseline.
- `npx vitest run src/test-kernel/progressView/ src/test-kernel/webview/MainAppPersistenceRestore.vitest.ts src/test-kernel/shared/PersistedState.vitest.ts` — **63 files, 584 tests passed.** Run because the whole progress-view frontend sits downstream of `webviewStorage`.
- `npm run check:dead-code-ratchet` — run because an export was removed. `8 current
  vs 8 baselined`, "no new unused files/exports/types found", exit 0.
- `prettier` on all changed files — no further diff.
- Every factual claim in the review-correction block above was re-opened at HEAD
  and checked individually (the three `@shared/` importers, both eslint restriction
  arrays, the architecture-edges baseline line, and `@platform/interfaces`' own
  import list) rather than accepted on the reviewer's or the coordinator's word.

## Review notes deliberately left unactioned

Two residual notes from the `texra-ai` review need no change, and I agree with its
reasoning on both — recorded here so nobody re-opens them:

1. **A synchronous `throw` from `storage.update` would bypass `persist`'s
   `.catch`.** True in principle, but unreachable for every current implementer:
   `JsonStore.update` is `async` (a throw becomes a rejection),
   `MemoryStateStore` and `vscode.Memento` return promises, and
   `createWebviewStorage.update` cannot throw. Wrapping the call in `try/catch`
   to cover an implementer that does not exist is speculative generality.
2. **The rejection-warning path is untested.** Correct, and intentional. This is a
   sweep-found latent defect, not a reproduced regression, so under the repo's
   testing budget (bug fix earns *at most* one regression test, "and only if it
   earns its place") it stays untested rather than pinning a mock to a churning
   seam.

## Zero new tests

Per the repo's testing budget, this is a behaviour-preserving refactor plus one
loud-failure fix, so it adds **no new test file and no new test case**. Two
existing suites changed mechanically, both forced by the port adoption:

- `src/test-kernel/shared/PersistedState.vitest.ts` — mock bag `set` -> `update`
  (now returning a promise), and the dead `delete: vi.fn()` stub dropped. Nothing
  ever asserted `delete`, which is itself corroboration that it was dead.
- `src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts` — one
  `webviewStorage.set(...)` -> `update(...)` in a fixture helper. (An earlier
  survey predicted only the first file would change; the second is a real
  additional edit, noted here rather than glossed over.)
