### PR TITLE
docs(cli): note the transcript confirmation on the /config approval port

### DIFF
--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -704,7 +704,10 @@ export function registerBuiltinSlashCommands(options?: {
           stores={stores}
           availableRows={props.availableRows}
           // Same hook `/approval` drives, so the approval-policy row updates the
-          // live session and the status bar from whichever surface set it.
+          // live session and the status bar from whichever surface set it —
+          // including its "Approval mode: …" transcript line, which is the
+          // confirmation that the change reached the running session and not
+          // just the config file.
           onApprovalPolicyChanged={options?.onApprovalPolicySelect}
           openExternalForm={(formName) => openCliSlashCommandForm(formName, '')}
           onClose={() => props.onDone(undefined)}


### PR DESCRIPTION
## Summary

Comment-only follow-up to #11015, which merged before this landed.

#11015 wired the CLI `/config` approval-policy row to the same
`onApprovalPolicySelect` hook `/approval` drives. The review asked whether the
extra `Approval mode: …` transcript line that hook emits is intended for the
`/config` surface. It is: that line is the user-visible proof the change reached
the running session rather than only `.texra/config.json` — precisely the
failure #11015 fixed. Splitting the port to suppress it would re-create two
policy-change paths that differ. This records that at the wiring site so the
next reader does not have to re-derive it.

## Issue acceptance gates

n/a — review follow-up, no issue.

## Single source of truth

Unchanged: `applyStateSettingUpdate` owns the write, and one CLI closure
(`onApprovalPolicySelect`) owns the live policy change for both `/approval` and
`/config`.

## Duplication and abstraction budget

None added or removed — comment only.

## Net elements (R6)

Files 1 changed (`+4 / −1`); exported symbols 0/0; classes/interfaces/enums 0/0;
net LoC +3, all comment.

## Consumer counts (R8)

n/a — no emit path, export, or call site changed.

## Host impact

Extension: none.

Desktop: none.

CLI: none — comment only, no behavior change.

## Scheduled refactoring

None.

## Validation

`npx prettier --check` on the touched file. No code changed, so the typecheck
and test gates from #11015 still apply unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)