### PR TITLE
refactor(test-kernel): give the temp-dir registry one owner (cli/desktop slice)

### DIFF
--- a/src/test-kernel/agent/output/CompiledPdfArtifacts.vitest.ts
+++ b/src/test-kernel/agent/output/CompiledPdfArtifacts.vitest.ts
@@ -1,6 +1,5 @@
 // Node imports
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
-import * as os from 'node:os';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
 // Third-party imports
@@ -10,6 +9,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { publishCompiledPdfArtifact } from '@agent/implementations/flows/reflection/output/compiledPdfArtifacts';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { setupPlatform } from '@test/support/setupPlatform';
+import {
+  makeTempDir as makeSharedTempDir,
+  useTempDirs,
+} from '@test/support/tempDirPlatform';
 import {
   createExternalLocation,
   createRunStorageLocation,
@@ -47,23 +50,16 @@ function runStorageSource(
 }
 
 describe('compiled PDF artifacts', () => {
-  const tempDirs: string[] = [];
+  const tempDirs = useTempDirs();
 
   setupPlatform({}, { fs: nodeFilesystem });
 
-  async function makeTempDir(): Promise<string> {
-    const dir = await mkdtemp(path.join(os.tmpdir(), 'texra-pdf-artifact-'));
-    tempDirs.push(dir);
-    return dir;
+  function makeTempDir(): Promise<string> {
+    return makeSharedTempDir('texra-pdf-artifact-', tempDirs);
   }
 
-  afterEach(async () => {
+  afterEach(() => {
     vi.restoreAllMocks();
-    await Promise.all(
-      tempDirs
-        .splice(0)
-        .map((dir) => rm(dir, { recursive: true, force: true })),
-    );
   });
 
   it('treats a missing compiled PDF as no artifact', async () => {

--- a/src/test-kernel/cli/ChatDefaults.vitest.ts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
 import { listExecutions } from '@agent/storage';
@@ -15,7 +15,7 @@ import { BUILTIN_DEFAULT_CHAT_AGENT } from '@cli/runtime/defaultAgents';
 import * as logSinks from '@cli/runtime/logSinks';
 import type { ExecutionId } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { GlobalStorageFS } from '@utils/files/storageFS';
 
 /** A cwd with no `.texra` directory, so the workspace tier finds nothing. */
@@ -87,11 +87,7 @@ beforeEach(() => {
   mockedReadJson.mockRejectedValue(enoentError());
 });
 
-const tempDirs: string[] = [];
-
-afterEach(async () => {
-  await cleanupTempDirs(tempDirs);
-});
+const tempDirs = useTempDirs();
 
 async function workspaceWithConfig(config: unknown): Promise<string> {
   const workspace = await makeTempDir('texra-chat-defaults-', tempDirs);

--- a/src/test-kernel/cli/CliContext.vitest.ts
+++ b/src/test-kernel/cli/CliContext.vitest.ts
@@ -2,7 +2,7 @@ import { mkdir, realpath, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   buildCliContext,
@@ -18,7 +18,7 @@ import {
 } from '@cli/runtime/cliContext';
 import { loadWorkspaceCliConfig } from '@cli/runtime/cliConfig';
 import { canonicalizeWorkspacePath } from '@platform/defaults/nodeWorkspace';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 const ambient = {
   isCi: true,
@@ -41,11 +41,7 @@ function ttyAmbient(overrides: Partial<CliAmbientState> = {}): CliAmbientState {
   };
 }
 
-const tempDirs: string[] = [];
-
-afterEach(async () => {
-  await cleanupTempDirs(tempDirs);
-});
+const tempDirs = useTempDirs();
 
 async function workspaceWithConfig(config: string): Promise<string> {
   const workspace = await makeTempDir('texra-cli-context-', tempDirs);

--- a/src/test-kernel/cli/CliRootArgs.vitest.ts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.ts
@@ -50,7 +50,11 @@ import { pickGlobalArgs } from '@cli/runtime/globalArgs';
 import { RUN_OUTCOME, AgentCategory } from '@shared/schemas';
 import { spyOnStreamWrite } from '@test/cli/fixtures/streamWriteSpy';
 import { createRunCommandCliContext } from '@test/cli/fixtures/cliContext';
-import { withTempDir } from '@test/support/tempDirPlatform';
+import {
+  makeTempDir,
+  useTempDirs,
+  withTempDir,
+} from '@test/support/tempDirPlatform';
 
 type StoredResumeConfig = Parameters<typeof resumeWorkflowOutputFile>[0];
 
@@ -1132,12 +1136,11 @@ describe('runCli usage output stream routing', () => {
   let stderrSpy: ReturnType<typeof vi.spyOn>;
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  const tempDirs = useTempDirs();
   let platformStorageRoot = '';
 
   beforeEach(async () => {
-    platformStorageRoot = await fs.mkdtemp(
-      path.join(os.tmpdir(), 'texra-cli-root-'),
-    );
+    platformStorageRoot = await makeTempDir('texra-cli-root-', tempDirs);
     await initNodeBackedPlatform({
       storagePath: path.join(platformStorageRoot, 'storage'),
       globalStoragePath: path.join(platformStorageRoot, 'global-storage'),
@@ -1168,10 +1171,6 @@ describe('runCli usage output stream routing', () => {
     stderrSpy.mockRestore();
     consoleLogSpy.mockRestore();
     consoleErrorSpy.mockRestore();
-    if (platformStorageRoot) {
-      await fs.rm(platformStorageRoot, { recursive: true, force: true });
-      platformStorageRoot = '';
-    }
     await initDefaultFakePlatform();
   });
 

--- a/src/test-kernel/cli/CliSkills.vitest.ts
+++ b/src/test-kernel/cli/CliSkills.vitest.ts
@@ -12,14 +12,9 @@ import {
 } from '@cli/runtime/skills';
 import { defaultSkillSources } from '@skills/skillSources';
 import { setRuntimeSkillSources } from '@skills/runtimeSkills';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
-const tempRoots: string[] = [];
-
-async function createTempRoot(): Promise<string> {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-skills-'));
-  tempRoots.push(root);
-  return root;
-}
+const tempRoots = useTempDirs();
 
 async function writeSkill(
   root: string,
@@ -34,13 +29,8 @@ async function writeSkill(
   );
 }
 
-afterEach(async () => {
+afterEach(() => {
   setRuntimeSkillSources([]);
-  await Promise.all(
-    tempRoots
-      .splice(0)
-      .map((root) => fs.rm(root, { recursive: true, force: true })),
-  );
 });
 
 describe('CLI skills runtime', () => {
@@ -161,8 +151,8 @@ describe('CLI skills runtime', () => {
   });
 
   it('lists custom duplicate names before bundled skills', async () => {
-    const resources = await createTempRoot();
-    const custom = await createTempRoot();
+    const resources = await makeTempDir('texra-cli-skills-', tempRoots);
+    const custom = await makeTempDir('texra-cli-skills-', tempRoots);
     await fs.mkdir(path.join(resources, 'skills'));
     await writeSkill(
       path.join(resources, 'skills'),
@@ -208,8 +198,8 @@ describe('CLI skills runtime', () => {
   });
 
   it('lists project duplicate names before bundled skills', async () => {
-    const project = await createTempRoot();
-    const resources = await createTempRoot();
+    const project = await makeTempDir('texra-cli-skills-', tempRoots);
+    const resources = await makeTempDir('texra-cli-skills-', tempRoots);
     await fs.mkdir(path.join(project, '.texra', 'skills'), {
       recursive: true,
     });
@@ -272,7 +262,7 @@ describe('CLI skills runtime', () => {
   });
 
   it('reports explicit custom skill sources that are not directories', async () => {
-    const root = await createTempRoot();
+    const root = await makeTempDir('texra-cli-skills-', tempRoots);
     const sourceFile = path.join(root, 'skills-file');
     await fs.writeFile(sourceFile, 'not a directory');
 
@@ -297,7 +287,7 @@ describe('CLI skills runtime', () => {
   });
 
   it('reads the runtime skill source registry used by prompt injection', async () => {
-    const root = await createTempRoot();
+    const root = await makeTempDir('texra-cli-skills-', tempRoots);
     await writeSkill(root, 'proof-audit', 'Review mathematical proof steps.');
     setRuntimeSkillSources([
       {

--- a/src/test-kernel/cli/CliStateStores.vitest.ts
+++ b/src/test-kernel/cli/CliStateStores.vitest.ts
@@ -1,15 +1,16 @@
-import * as fs from 'node:fs/promises';
-import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
 import { createCliStateStores } from '@cli/runtime/cliStateStores';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 describe('CLI state stores', () => {
+  const tempDirs = useTempDirs();
+
   it('persists workspace state across store instances', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-state-'));
+    const root = await makeTempDir('texra-cli-state-', tempDirs);
     const workspacePath = path.join(root, 'project');
     const preset = {
       id: 'custom-paper',
@@ -19,26 +20,21 @@ describe('CLI state stores', () => {
       agents: { workflow: ['polish'], toolUse: ['review'] },
     };
 
-    try {
-      const first = await createCliStateStores({
-        storageRoot: path.join(root, 'storage'),
-        workspacePath,
-      });
-      await first.workspaceState.update(
-        WorkspaceStateKey.CUSTOM_AGENT_PRESETS,
-        [preset],
-      );
+    const first = await createCliStateStores({
+      storageRoot: path.join(root, 'storage'),
+      workspacePath,
+    });
+    await first.workspaceState.update(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, [
+      preset,
+    ]);
 
-      const second = await createCliStateStores({
-        storageRoot: path.join(root, 'storage'),
-        workspacePath,
-      });
+    const second = await createCliStateStores({
+      storageRoot: path.join(root, 'storage'),
+      workspacePath,
+    });
 
-      expect(
-        second.workspaceState.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS),
-      ).toEqual([preset]);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    expect(
+      second.workspaceState.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS),
+    ).toEqual([preset]);
   });
 });

--- a/src/test-kernel/cli/History.vitest.ts
+++ b/src/test-kernel/cli/History.vitest.ts
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { createToolUseResumeData } from '@test/support/toolUseResumeTestUtils';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { KVStore } from '@common/storage/KVStore';
@@ -144,7 +144,7 @@ const config = AgentConfigSchema.parse({
   outputFiles: ['chapters/intro.tex'],
 });
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 
 // An internal tool-use agent config with no input/output files, built from
 // the base `config` with per-test field overrides.
@@ -289,10 +289,6 @@ describe('CLI history runtime', () => {
     mocks.exists.mockResolvedValue(false);
     mocks.readCliToolUseResumeData.mockResolvedValue(null);
     mocks.readCliResumeDataForListing.mockResolvedValue(null);
-  });
-
-  afterEach(async () => {
-    await cleanupTempDirs(tempDirs);
   });
 
   it('formats history list rows with the stable tab-separated text shape', async () => {

--- a/src/test-kernel/cli/InitCommand.vitest.ts
+++ b/src/test-kernel/cli/InitCommand.vitest.ts
@@ -45,7 +45,7 @@ import {
 import type { CliModelAccess } from '@cli/runtime/modelAccess';
 import { AgentCategory } from '@shared/schemas';
 import { spyOnStreamWrite } from '@test/cli/fixtures/streamWriteSpy';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 function modelAccess(
   value: string,
@@ -74,7 +74,7 @@ function expectUnavailableDefaultRecovery(output: string): void {
   );
 }
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 
 describe('CLI init command', () => {
   let stdout = '';
@@ -103,10 +103,9 @@ describe('CLI init command', () => {
     });
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     stdoutSpy.mockRestore();
     stderrSpy.mockRestore();
-    await cleanupTempDirs(tempDirs);
   });
 
   it('accepts global CLI flags while keeping init-specific cwd help', () => {
@@ -244,7 +243,6 @@ describe('CLI init command', () => {
 
   it('emits valid NDJSON for non-interactive init', async () => {
     const root = await makeTempDir('texra-init-test-', tempDirs);
-    const workspaceRoot = await fs.realpath(root);
     const result = await runInitPrint(root, ['--output-format', 'ndjson']);
 
     expect(result.exitCode).toBe(0);
@@ -269,7 +267,7 @@ describe('CLI init command', () => {
     expect(record).toMatchObject({
       kind: 'init-config',
       init: {
-        path: path.join(workspaceRoot, '.texra', 'config.json'),
+        path: path.join(root, '.texra', 'config.json'),
         agent: 'assistant',
         model: 'deepseekproT',
         approvalPolicy: 'ask',
@@ -291,14 +289,13 @@ describe('CLI init command', () => {
 
   it('keeps the legacy text init summary for human output', async () => {
     const root = await makeTempDir('texra-init-test-', tempDirs);
-    const workspaceRoot = await fs.realpath(root);
     const result = await runInitPrint(root);
 
     expect(result.exitCode).toBe(0);
     expect(stderr).toBe('');
     expect(stdout).toContain('Created .gitignore (.texra/ ignored).');
     expect(stdout).toContain(
-      `Wrote ${path.join(workspaceRoot, '.texra', 'config.json')}`,
+      `Wrote ${path.join(root, '.texra', 'config.json')}`,
     );
     expect(stdout).toContain('  agent: assistant');
     expect(stdout).toContain('Next: run `texra` for the launcher');

--- a/src/test-kernel/cli/InitConfig.vitest.ts
+++ b/src/test-kernel/cli/InitConfig.vitest.ts
@@ -16,7 +16,7 @@ import {
   setWorkspaceCliChatAgent,
 } from '@cli/runtime/cliConfig';
 import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>();
@@ -25,11 +25,10 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 
 const mockedReadFile = vi.mocked(nodeReadFile);
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 
 afterEach(async () => {
   mockedReadFile.mockClear();
-  await cleanupTempDirs(tempDirs);
 });
 
 const ANSWERS: InitAnswers = {

--- a/src/test-kernel/cli/InputHistory.vitest.ts
+++ b/src/test-kernel/cli/InputHistory.vitest.ts
@@ -1,14 +1,14 @@
 // Persistent ↑/↓ + Ctrl-R input history for the chat TUI input bar.
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { loadInputHistory } from '@cli/chat/tui/history/inputHistory';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 
 describe('CLI TUI input history', () => {
   // GlobalStorageFS resolves paths through the platform but writes with the
@@ -21,10 +21,6 @@ describe('CLI TUI input history', () => {
       { fs: nodeFilesystem },
     ),
   );
-
-  afterEach(async () => {
-    await cleanupTempDirs(tempDirs);
-  });
 
   it('exposes indexed entries for ↑/↓ history browsing', async () => {
     const history = await loadInputHistory();

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
@@ -1,6 +1,5 @@
 /* eslint-disable import/order -- Vitest mocks must be declared before importing the runtime under test. */
 import * as fs from 'node:fs/promises';
-import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -18,6 +17,7 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import type { CliContext } from '@cli/runtime/cliContext';
 import { RUN_OUTCOME } from '@shared/schemas';
 import { createRunCommandCliContext } from '@test/cli/fixtures/cliContext';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 const mocks = vi.hoisted(() => ({
   executeCliToolUseConfig: vi.fn(),
@@ -214,6 +214,7 @@ function mockMaterializedStdin(inputFiles: string[]): void {
 }
 
 describe('CLI multi-agent run command', () => {
+  const tempDirs = useTempDirs();
   const approvalUnavailableWarning =
     'WARN preset mathematician may run without subagent delegation because approval policy "never" denies approval-gated delegation tools. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.';
   const headlessAskError =
@@ -533,42 +534,38 @@ describe('CLI multi-agent run command', () => {
       inputFiles: [],
       contextFiles: [],
     });
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-agent-team-'));
-    try {
-      await fs.writeFile(
-        path.join(root, 'prompt.txt'),
-        'Read the prompt from disk.\n',
-      );
+    const root = await makeTempDir('texra-agent-team-', tempDirs);
+    await fs.writeFile(
+      path.join(root, 'prompt.txt'),
+      'Read the prompt from disk.\n',
+    );
 
-      const exitCode = await runPreset(
-        {
-          instruction: 'Then summarize the plan.',
-          instructionFile: 'prompt.txt',
-        },
-        createRunCommandCliContext({ cwd: root }),
-      );
+    const exitCode = await runPreset(
+      {
+        instruction: 'Then summarize the plan.',
+        instructionFile: 'prompt.txt',
+      },
+      createRunCommandCliContext({ cwd: root }),
+    );
 
-      expect(exitCode).toBe(0);
-      expect(mocks.withExpandedRunInputs).toHaveBeenCalledWith(
-        [],
-        [],
-        root,
-        {
-          allowEmptyInput: true,
-          requireWorkspaceFiles: true,
-          readStdinText: expect.any(Function),
-        },
-        expect.any(Function),
-      );
-      const config = mocks.executeCliToolUseConfig.mock.calls[0]?.[0];
-      expect(config?.inputFiles).toEqual([]);
-      expect(config?.instruction).toContain('User instruction:');
-      expect(config?.instruction).toContain(
-        'Read the prompt from disk.\n\nThen summarize the plan.',
-      );
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    expect(exitCode).toBe(0);
+    expect(mocks.withExpandedRunInputs).toHaveBeenCalledWith(
+      [],
+      [],
+      root,
+      {
+        allowEmptyInput: true,
+        requireWorkspaceFiles: true,
+        readStdinText: expect.any(Function),
+      },
+      expect.any(Function),
+    );
+    const config = mocks.executeCliToolUseConfig.mock.calls[0]?.[0];
+    expect(config?.inputFiles).toEqual([]);
+    expect(config?.instruction).toContain('User instruction:');
+    expect(config?.instruction).toContain(
+      'Read the prompt from disk.\n\nThen summarize the plan.',
+    );
   });
 
   it('reports missing instruction files before expanding inputs', async () => {

--- a/src/test-kernel/cli/OutputGuards.vitest.ts
+++ b/src/test-kernel/cli/OutputGuards.vitest.ts
@@ -2,7 +2,7 @@ import { mkdir, stat, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, win32 } from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { CliUsageError } from '@cli/runtime/cliContext';
 import {
@@ -11,13 +11,9 @@ import {
   probeOutputPathForTests,
 } from '@cli/runtime/workflowOutput';
 import { errnoError } from '@test/support/fsTestUtils';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
-const tempDirs: string[] = [];
-
-afterEach(async () => {
-  await cleanupTempDirs(tempDirs);
-});
+const tempDirs = useTempDirs();
 
 // Every probe case below starts from a stat that reports the target missing.
 function probeDeps(

--- a/src/test-kernel/cli/OverleafCloneCommand.vitest.ts
+++ b/src/test-kernel/cli/OverleafCloneCommand.vitest.ts
@@ -1,6 +1,5 @@
 // Node imports
-import { access, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { access, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
 // Third-party imports
@@ -10,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { canonicalizeWorkspacePath } from '@platform/defaults/nodeWorkspace';
 import { spyOnStreamWrite } from '@test/cli/fixtures/streamWriteSpy';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { extendEnvPath } from '@utils/system/platformPaths';
 
 const mocks = vi.hoisted(() => ({
@@ -58,6 +58,7 @@ async function withProcessCwd<T>(
 }
 
 describe('CLI Overleaf clone command', () => {
+  const tempDirs = useTempDirs();
   let workspacePath: string;
   let stdout: string;
   let stderr: string;
@@ -65,7 +66,7 @@ describe('CLI Overleaf clone command', () => {
   let stderrSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
-    workspacePath = await mkdtemp(path.join(tmpdir(), 'texra-clone-'));
+    workspacePath = await makeTempDir('texra-clone-', tempDirs);
     stdout = '';
     stderr = '';
     stdoutSpy = spyOnStreamWrite(process.stdout, (text) => {
@@ -99,11 +100,9 @@ describe('CLI Overleaf clone command', () => {
   afterEach(async () => {
     stdoutSpy.mockRestore();
     stderrSpy.mockRestore();
-    await rm(workspacePath, { recursive: true, force: true });
   });
 
   it('clones into --cwd with a stored token and emits structured output', async () => {
-    const canonicalWorkspacePath = await realpath(workspacePath);
     const result = await runCli([
       'clone',
       PROJECT_ID,
@@ -124,7 +123,7 @@ describe('CLI Overleaf clone command', () => {
         '.',
       ],
       {
-        cwd: canonicalWorkspacePath,
+        cwd: workspacePath,
         env: { GIT_TERMINAL_PROMPT: '0', PATH: extendEnvPath() },
       },
     );
@@ -132,7 +131,7 @@ describe('CLI Overleaf clone command', () => {
       cloned: true,
       provider: 'overleaf',
       host: 'git.overleaf.com',
-      destination: canonicalWorkspacePath,
+      destination: workspacePath,
     });
     expect(`${stdout}${stderr}`).not.toContain('olp_secret');
   });
@@ -149,7 +148,6 @@ describe('CLI Overleaf clone command', () => {
         '--no-input',
       ]),
     );
-    const canonicalDestination = await realpath(destination);
 
     expect(result.exitCode).toBe(CliExitCode.Success);
     expect(mocks.execa).toHaveBeenCalledWith(
@@ -160,13 +158,13 @@ describe('CLI Overleaf clone command', () => {
         '.',
       ],
       {
-        cwd: canonicalDestination,
+        cwd: destination,
         env: { GIT_TERMINAL_PROMPT: '0', PATH: extendEnvPath() },
       },
     );
     expect(JSON.parse(stdout)).toMatchObject({
       cloned: true,
-      destination: canonicalDestination,
+      destination: destination,
     });
   });
 

--- a/src/test-kernel/cli/ResourcesPath.vitest.ts
+++ b/src/test-kernel/cli/ResourcesPath.vitest.ts
@@ -1,17 +1,16 @@
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { resolveCliResourcesPath } from '@cli/runtime/resourcesPath';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
-const tempRoots: string[] = [];
+const tempRoots = useTempDirs();
 
 async function makeCliPackage() {
-  const root = await mkdtemp(path.join(tmpdir(), 'texra-cli-resources-'));
-  tempRoots.push(root);
+  const root = await makeTempDir('texra-cli-resources-', tempRoots);
   const cliRoot = path.join(root, 'packages', 'cli');
   await mkdir(cliRoot, { recursive: true });
   await writeFile(path.join(cliRoot, 'package.json'), '{}\n');
@@ -21,14 +20,6 @@ async function makeCliPackage() {
 function anchorUrl(filePath: string) {
   return pathToFileURL(filePath).href;
 }
-
-afterEach(async () => {
-  await Promise.all(
-    tempRoots
-      .splice(0)
-      .map((root) => rm(root, { recursive: true, force: true })),
-  );
-});
 
 describe('resolveCliResourcesPath', () => {
   it('prefers resources next to the executing validation bundle', async () => {

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -1,7 +1,3 @@
-import { mkdtemp } from 'node:fs/promises';
-import * as os from 'node:os';
-import * as path from 'node:path';
-
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { RunAgentOptions } from '@agent/runtime/runAgent';
@@ -10,10 +6,6 @@ import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { executeCliRequest } from '@cli/runtime/runExecution';
 import { AgentError } from '@common/errors';
-import { MemoryStateStore } from '@platform/defaults/memoryState';
-import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
-import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { RUN_OUTCOME } from '@shared/schemas';
 import type {
   ExecutionId,
@@ -23,7 +15,10 @@ import type {
 } from '@shared/schemas';
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { createTestCliContext as cliContext } from '@test/cli/fixtures/cliContext';
-import { cleanupTempDirs } from '@test/support/tempDirPlatform';
+import {
+  createTempDirPlatform,
+  useTempDirs,
+} from '@test/support/tempDirPlatform';
 import { getDefaultUnavailableToolNames } from '@tools/registry';
 
 const mocks = vi.hoisted(() => ({
@@ -48,7 +43,7 @@ const mocks = vi.hoisted(() => ({
   finalizeExecution: vi.fn(),
 }));
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 
 async function installFreshDefaultSession(): Promise<void> {
   const { installPlatform } = await import('@test/support/setupPlatform');
@@ -65,23 +60,8 @@ async function installFreshDefaultSession(): Promise<void> {
 }
 
 async function installStoragePlatform(): Promise<void> {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-run-'));
-  tempDirs.push(tempDir);
-  const workspaceDir = path.join(tempDir, 'workspace');
-  const storageRoot = path.join(tempDir, 'storage');
   const { initPlatform } = await import('@platform/platform');
-  initPlatform(
-    createFakePlatform(
-      { workspacePath: workspaceDir },
-      {
-        fs: nodeFilesystem,
-        workspace: createNodeWorkspace(() => workspaceDir),
-        storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
-        globalState: new MemoryStateStore(),
-        workspaceState: new MemoryStateStore(),
-      },
-    ),
-  );
+  initPlatform(await createTempDirPlatform('texra-run-', tempDirs));
 }
 
 vi.mock('@agent/runtime/runAgent', () => ({
@@ -301,9 +281,8 @@ describe('executeCliRequest', () => {
     await installFreshDefaultSession();
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     vi.restoreAllMocks();
-    await cleanupTempDirs(tempDirs);
   });
 
   it.each(['text', 'json'] as const)(

--- a/src/test-kernel/cli/WorkflowInputsLifecycle.vitest.ts
+++ b/src/test-kernel/cli/WorkflowInputsLifecycle.vitest.ts
@@ -1,9 +1,8 @@
 import * as fs from 'node:fs/promises';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
   createStdinWorkflowInputMaterializer,
@@ -11,16 +10,14 @@ import {
   withExpandedRunInputs,
 } from '@cli/runtime/workflowInputs';
 import { createFakePlatform } from '@test/support/FakePlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 describe('CLI workflow input lifecycle', () => {
+  const tempDirs = useTempDirs();
   let root: string;
 
   beforeEach(async () => {
-    root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-stdin-'));
-  });
-
-  afterEach(async () => {
-    await fs.rm(root, { recursive: true, force: true });
+    root = await makeTempDir('texra-cli-stdin-', tempDirs);
   });
 
   async function installFakePlatform() {

--- a/src/test-kernel/cli/WorkflowOutputResolution.vitest.ts
+++ b/src/test-kernel/cli/WorkflowOutputResolution.vitest.ts
@@ -1,8 +1,7 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import { tmpdir } from 'node:os';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   expectedOutputFilesForOutputDir,
@@ -13,22 +12,11 @@ import {
 import type { CliContext } from '@cli/runtime/cliContext';
 import { RUN_OUTCOME, type RunOutcome, AgentCategory } from '@shared/schemas';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 type WorkflowResult = Parameters<typeof resolveWorkflowOutput>[2];
 
-const tempDirs: string[] = [];
-
-afterEach(async () => {
-  await Promise.all(
-    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
-  );
-});
-
-async function makeTempDir(): Promise<string> {
-  const dir = await mkdtemp(join(tmpdir(), 'texra-workflow-output-'));
-  tempDirs.push(dir);
-  return dir;
-}
+const tempDirs = useTempDirs();
 
 /** Writes a generated file under `<cwd>/run/` and returns its absolute path. */
 async function writeRunFile(
@@ -79,7 +67,7 @@ function workflowResult(
 
 describe('CLI workflow output resolution', () => {
   it('fails --output-dir resolution when an expected multi-input output is missing', async () => {
-    const cwd = await makeTempDir();
+    const cwd = await makeTempDir('texra-workflow-output-', tempDirs);
     const runOutput = await writeRunFile(cwd, 'r1/a.tex', 'A');
 
     await expect(
@@ -97,7 +85,7 @@ describe('CLI workflow output resolution', () => {
   });
 
   it('does not publish cancelled workflow outputs to requested destinations', async () => {
-    const cwd = await makeTempDir();
+    const cwd = await makeTempDir('texra-workflow-output-', tempDirs);
     const runOutput = await writeRunFile(cwd, 'r0/paper.tex', 'provisional');
     const outputFile = join(cwd, 'out.tex');
     const outputDirectoryFile = join(cwd, 'out', 'paper.tex');
@@ -148,7 +136,7 @@ describe('CLI workflow output resolution', () => {
   });
 
   it('carries only the cancelled outcome for missing workflow outputs', async () => {
-    const cwd = await makeTempDir();
+    const cwd = await makeTempDir('texra-workflow-output-', tempDirs);
 
     const result = await resolveWorkflowOutput(
       'out.tex',
@@ -170,7 +158,7 @@ describe('CLI workflow output resolution', () => {
   });
 
   it('copies every expected --output-dir workflow output', async () => {
-    const cwd = await makeTempDir();
+    const cwd = await makeTempDir('texra-workflow-output-', tempDirs);
     const runA1 = await writeRunFile(cwd, 'r1/a.tex', 'A1');
     const runA2 = await writeRunFile(cwd, 'r2/a.tex', 'A2');
     const runB = await writeRunFile(cwd, 'r1/b.tex', 'B');
@@ -204,7 +192,7 @@ describe('CLI workflow output resolution', () => {
   });
 
   it('uses a stable output name for materialized stdin input', async () => {
-    const cwd = await makeTempDir();
+    const cwd = await makeTempDir('texra-workflow-output-', tempDirs);
     const runOutput = await writeRunFile(cwd, 'r1/stdin.tex', 'from stdin');
 
     const expectedOutputFiles = expectedOutputFilesForOutputDir(undefined, [
@@ -245,7 +233,7 @@ describe('CLI workflow output resolution', () => {
   });
 
   it('preserves expected nested input paths when copying flattened workflow outputs', async () => {
-    const cwd = await makeTempDir();
+    const cwd = await makeTempDir('texra-workflow-output-', tempDirs);
     const runMain = await writeRunFile(cwd, 'r1/main.tex', 'main');
     const runSeries = await writeRunFile(cwd, 'r1/series.tex', 'series');
 
@@ -293,7 +281,7 @@ describe('CLI workflow output resolution', () => {
   });
 
   it('uses original-path lineage before flat generated names when basenames collide', async () => {
-    const cwd = await makeTempDir();
+    const cwd = await makeTempDir('texra-workflow-output-', tempDirs);
     const runRoot = await writeRunFile(cwd, 'root/main.tex', 'root');
     const runNested = await writeRunFile(cwd, 'nested/main.tex', 'nested');
 
@@ -341,7 +329,7 @@ describe('CLI workflow output resolution', () => {
   });
 
   it('does not remap arbitrary same-source outputs to an expected input name', async () => {
-    const cwd = await makeTempDir();
+    const cwd = await makeTempDir('texra-workflow-output-', tempDirs);
     const runDerived = await writeRunFile(cwd, 'r1/derived.tex', 'derived');
 
     await expect(
@@ -365,7 +353,7 @@ describe('CLI workflow output resolution', () => {
   });
 
   it('derives safe expected --output-dir paths from relative and absolute inputs', async () => {
-    const external = await makeTempDir();
+    const external = await makeTempDir('texra-workflow-output-', tempDirs);
 
     expect(
       expectedOutputFilesForOutputDir(undefined, [
@@ -382,7 +370,7 @@ describe('CLI workflow output resolution', () => {
   });
 
   it('does not remap output paths on partial original-path segment matches', async () => {
-    const cwd = await makeTempDir();
+    const cwd = await makeTempDir('texra-workflow-output-', tempDirs);
     const runSeries = await writeRunFile(cwd, 'r1/series.tex', 'series');
 
     await expect(
@@ -412,7 +400,7 @@ describe('CLI workflow output resolution', () => {
   });
 
   it('uses the latest round when --output-dir workflow outputs arrive out of order', async () => {
-    const cwd = await makeTempDir();
+    const cwd = await makeTempDir('texra-workflow-output-', tempDirs);
     const runA1 = await writeRunFile(cwd, 'r1/a.tex', 'A1');
     const runA2 = await writeRunFile(cwd, 'r2/a.tex', 'A2');
 
@@ -436,7 +424,7 @@ describe('CLI workflow output resolution', () => {
   });
 
   it('uses the latest round when a single requested output arrives out of order', async () => {
-    const cwd = await makeTempDir();
+    const cwd = await makeTempDir('texra-workflow-output-', tempDirs);
     const runA1 = await writeRunFile(cwd, 'r1/a.tex', 'A1');
     const runA2 = await writeRunFile(cwd, 'r2/a.tex', 'A2');
 
@@ -463,7 +451,7 @@ describe('CLI workflow output resolution', () => {
   });
 
   it('copies the last output of the final round for a multi-document workflow', async () => {
-    const cwd = await makeTempDir();
+    const cwd = await makeTempDir('texra-workflow-output-', tempDirs);
     const runMain = await writeRunFile(cwd, 'r2/main.tex', 'MAIN2');
     const runAppendix = await writeRunFile(cwd, 'r2/appendix.tex', 'APPENDIX2');
     const runMain1 = await writeRunFile(cwd, 'r1/main.tex', 'MAIN1');

--- a/src/test-kernel/desktop/DesktopAppLog.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAppLog.vitest.ts
@@ -9,7 +9,7 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - test support
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import {
   configureElectronTestStub,
   resetElectronTestStub,
@@ -32,12 +32,11 @@ async function loadDesktopAppLogModule(): Promise<DesktopAppLogModule> {
 }
 
 describe('desktop app log', () => {
-  const tempDirs: string[] = [];
+  const tempDirs = useTempDirs();
 
   afterEach(async () => {
     resetElectronTestStub();
     vi.restoreAllMocks();
-    await cleanupTempDirs(tempDirs);
   });
 
   /** Writes a fresh desktop log and points the Electron stub at its dir. */

--- a/src/test-kernel/desktop/DesktopDiffHost.vitest.ts
+++ b/src/test-kernel/desktop/DesktopDiffHost.vitest.ts
@@ -9,7 +9,7 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 // Local imports - test support
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { loadSourceModule } from './loadSourceModule.ts';
 
 // `rm` keeps its real implementation by default; tests arm one-shot failures
@@ -84,13 +84,12 @@ function expectOpenedPatchFile(openedPaths: readonly string[]): void {
   expect(path.extname(openedPaths[0])).toBe('.diff');
 }
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 const hosts: DiffHost[] = [];
 
 afterEach(async () => {
   await Promise.all(hosts.map((host) => host.dispose()));
   hosts.length = 0;
-  await cleanupTempDirs(tempDirs);
 });
 
 type OpenDiffArgs = Parameters<DiffHost['openDiff']>;

--- a/src/test-kernel/desktop/DesktopPreviewHost.vitest.ts
+++ b/src/test-kernel/desktop/DesktopPreviewHost.vitest.ts
@@ -5,8 +5,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createModuleMocks } from '@test/support/moduleMocks';
 import {
-  cleanupTempDirs,
   makeTempDir as makeSharedTempDir,
+  useTempDirs,
 } from '@test/support/tempDirPlatform';
 import { createExternalLocation } from '@utils/files/fileLocation';
 
@@ -41,11 +41,10 @@ function makeShell(openPathResult = '') {
 }
 
 describe('desktop preview host', () => {
-  const tempDirs: string[] = [];
+  const tempDirs = useTempDirs();
 
   afterEach(async () => {
     vi.restoreAllMocks();
-    await cleanupTempDirs(tempDirs);
   });
 
   async function makeTempDir(): Promise<string> {

--- a/src/test-kernel/desktop/DesktopWorkspaceIpc.vitest.ts
+++ b/src/test-kernel/desktop/DesktopWorkspaceIpc.vitest.ts
@@ -1,13 +1,11 @@
 import {
   existsSync,
-  mkdtempSync,
   mkdirSync,
   readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -21,6 +19,7 @@ import { createDesktopWorkspaceIpc } from '@desktop/main/desktopWorkspaceIpc';
 import type { DesktopBrowserViews } from '@desktop/main/desktopBrowserViews';
 import type { DesktopPtyHost } from '@desktop/main/desktopPtyHost';
 import { appSignals } from '@eventBus/AppSignals';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { createFakePlatform } from '@test/support/FakePlatform';
 
 let fixtureRoot = '';
@@ -74,8 +73,10 @@ function createIpc(
 const liveWorkspaceIpcs: ReturnType<typeof createDesktopWorkspaceIpc>[] = [];
 
 describe('desktop workspace IPC', () => {
+  const tempDirs = useTempDirs();
+
   beforeEach(async () => {
-    fixtureRoot = mkdtempSync(join(tmpdir(), 'texra-workspace-ipc-'));
+    fixtureRoot = await makeTempDir('texra-workspace-ipc-', tempDirs);
     workspacePath = join(fixtureRoot, 'workspace');
     externalPath = join(fixtureRoot, 'external.txt');
     missingExternalPath = join(fixtureRoot, 'missing-external.txt');
@@ -111,7 +112,6 @@ describe('desktop workspace IPC', () => {
 
   afterEach(() => {
     for (const ipc of liveWorkspaceIpcs.splice(0)) ipc.dispose();
-    rmSync(fixtureRoot, { recursive: true, force: true });
   });
 
   // The file tree caches its listing and there is no filesystem watcher, so a

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
@@ -1,5 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve, sep } from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -19,6 +18,7 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { FakeConfigProvider, FakeSecrets } from '@test/support/FakePlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 import { loadSourceModule } from './loadSourceModule.ts';
 
@@ -28,13 +28,10 @@ async function writeText(filePath: string, content: string): Promise<void> {
 }
 
 describe('desktop agent directory bootstrap', () => {
-  let tempDir: string | undefined;
+  const tempDirs = useTempDirs();
 
-  afterEach(async () => {
+  afterEach(() => {
     vi.resetModules();
-    if (tempDir == null) return;
-    await rm(tempDir, { recursive: true, force: true });
-    tempDir = undefined;
   });
 
   async function createHarness(): Promise<{
@@ -45,7 +42,7 @@ describe('desktop agent directory bootstrap', () => {
     storage: StorageProvider;
   }> {
     vi.resetModules();
-    tempDir = await mkdtemp(join(tmpdir(), 'texra-electron-agents-'));
+    const tempDir = await makeTempDir('texra-electron-agents-', tempDirs);
     const resourcesPath = join(tempDir, 'resources');
     const userDataPath = join(tempDir, 'userData');
     const workspacePath = join(tempDir, 'workspace');

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
@@ -2,10 +2,10 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, relative } from 'node:path';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { sourceFilesUnder } from '@test/support/repoScan';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { normalizeFilePath } from '@utils/core';
 import {
   DESKTOP_SRC_DIR,
@@ -57,11 +57,7 @@ function expectOrderedAfter(
 }
 
 describe('desktop composition root and launch environment', () => {
-  const tempDirs: string[] = [];
-
-  afterEach(async () => {
-    await cleanupTempDirs(tempDirs);
-  });
+  const tempDirs = useTempDirs();
 
   async function createResourceTree(resourcesPath: string): Promise<void> {
     await Promise.all([

--- a/src/test-kernel/desktop/ElectronConfig.vitest.ts
+++ b/src/test-kernel/desktop/ElectronConfig.vitest.ts
@@ -1,26 +1,19 @@
 // Node imports
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 // Third-party imports
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 // Local imports - platform
 import type { JsonConfigProvider } from '@platform/defaults/jsonConfigProvider';
 import type { JsonStore } from '@platform/defaults/jsonStore';
 
 // Local imports - test support
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { loadSourceModule } from './loadSourceModule.ts';
 
 describe('desktop JsonConfigProvider (dual-store)', () => {
-  let tempDir: string | undefined;
-
-  afterEach(async () => {
-    if (tempDir == null) return;
-    await rm(tempDir, { recursive: true, force: true });
-    tempDir = undefined;
-  });
+  const tempDirs = useTempDirs();
 
   async function createProvider(): Promise<{
     provider: JsonConfigProvider;
@@ -31,7 +24,7 @@ describe('desktop JsonConfigProvider (dual-store)', () => {
       loadSourceModule('@platform/defaults/jsonStore'),
       loadSourceModule('@platform/defaults/jsonConfigProvider'),
     ]);
-    tempDir = await mkdtemp(join(tmpdir(), 'texra-electron-config-'));
+    const tempDir = await makeTempDir('texra-electron-config-', tempDirs);
     const globalStore = await JsonStore.open(join(tempDir, 'global.json'));
     const workspaceStore = await JsonStore.open(
       join(tempDir, 'workspace.json'),

--- a/src/test-kernel/desktop/ElectronFileSelection.vitest.ts
+++ b/src/test-kernel/desktop/ElectronFileSelection.vitest.ts
@@ -1,10 +1,10 @@
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import { tmpdir } from 'node:os';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 import { loadSourceModule } from './loadSourceModule.ts';
 
@@ -43,10 +43,11 @@ function flushAsyncWork(): Promise<void> {
  * desktop main delegates to its native picker elsewhere.
  */
 describe('desktop file selection', () => {
+  const tempDirs = useTempDirs();
   let workspacePath: string;
 
   beforeEach(async () => {
-    workspacePath = await mkdtemp(join(tmpdir(), 'texra-files-'));
+    workspacePath = await makeTempDir('texra-files-', tempDirs);
     const entries = [
       'main.tex',
       'notes.md',
@@ -64,10 +65,6 @@ describe('desktop file selection', () => {
         await writeFile(join(workspacePath, entry), '');
       }),
     );
-  });
-
-  afterEach(async () => {
-    await rm(workspacePath, { recursive: true, force: true });
   });
 
   async function createFileSelection(

--- a/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.ts
+++ b/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.ts
@@ -12,8 +12,8 @@ import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 // Local imports - test support
 import { pathExists } from '@test/support/fsTestUtils';
 import {
-  cleanupTempDirs,
   makeTempDir as makeSharedTempDir,
+  useTempDirs,
 } from '@test/support/tempDirPlatform';
 import {
   app as electronApp,
@@ -36,7 +36,7 @@ async function loadJsonStore(): Promise<
 }
 
 describe('desktop platform adapters', () => {
-  const tempDirs: string[] = [];
+  const tempDirs = useTempDirs();
   const originalEnv = { ...process.env };
   const testSecretKey = 'TEXRA_TEST_TOKEN';
 
@@ -46,7 +46,6 @@ describe('desktop platform adapters', () => {
     if (stubUserDataPath != null) tempDirs.push(stubUserDataPath);
     resetElectronTestStub();
     vi.restoreAllMocks();
-    await cleanupTempDirs(tempDirs);
   });
 
   async function makeTempDir(prefix: string): Promise<string> {

--- a/src/test-kernel/desktop/JsonStore.vitest.ts
+++ b/src/test-kernel/desktop/JsonStore.vitest.ts
@@ -1,24 +1,16 @@
 // Node imports
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
-import {
-  chmod,
-  mkdir,
-  mkdtemp,
-  readFile,
-  rm,
-  stat,
-  writeFile,
-} from 'node:fs/promises';
+import { chmod, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 // Third-party imports
 import { build } from 'esbuild';
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 // Local imports - test support
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { moduleFileUrl, repoPath } from './desktopTestPaths.ts';
 import { loadSourceModule } from './loadSourceModule.ts';
 
@@ -43,19 +35,14 @@ async function readStoredJson(filePath: string): Promise<unknown> {
 }
 
 describe('shared JsonStore', () => {
+  const tempDirs = useTempDirs();
   let tempDir: string | undefined;
-
-  afterEach(async () => {
-    if (tempDir == null) return;
-    await rm(tempDir, { recursive: true, force: true });
-    tempDir = undefined;
-  });
 
   async function createTempFile(
     name: string,
     contents: string,
   ): Promise<string> {
-    tempDir = await mkdtemp(join(tmpdir(), 'texra-json-store-'));
+    tempDir = await makeTempDir('texra-json-store-', tempDirs);
     const filePath = join(tempDir, name);
     await writeFile(filePath, contents);
     return filePath;
@@ -148,7 +135,7 @@ describe('shared JsonStore', () => {
   });
 
   it('keeps the lock function callable in a split ESM bundle', async () => {
-    tempDir = await mkdtemp(join(tmpdir(), 'texra-json-store-bundle-'));
+    tempDir = await makeTempDir('texra-json-store-bundle-', tempDirs);
     const outdir = join(tempDir, 'bundle');
     await build({
       entryPoints: {
@@ -266,7 +253,7 @@ describe('shared JsonStore', () => {
   it('opens read-only on unwritable storage; only the first write prepares the directory', async () => {
     if (process.platform === 'win32') return; // POSIX modes don't apply.
     const JsonStore = await loadJsonStore();
-    tempDir = await mkdtemp(join(tmpdir(), 'texra-json-store-'));
+    tempDir = await makeTempDir('texra-json-store-', tempDirs);
     const dir = join(tempDir, 'nested');
     const filePath = join(dir, 'secrets.json');
     // Unwritable parent: any open-time mkdir/chmod would throw (#8220).
@@ -293,7 +280,7 @@ describe('shared JsonStore', () => {
   it('restricts the store file and its directory to the owner when a mode is set', async () => {
     if (process.platform === 'win32') return; // POSIX modes don't apply.
     const JsonStore = await loadJsonStore();
-    tempDir = await mkdtemp(join(tmpdir(), 'texra-json-store-'));
+    tempDir = await makeTempDir('texra-json-store-', tempDirs);
     const filePath = join(tempDir, 'nested', 'secrets.json');
 
     const store = await JsonStore.open(filePath, {

--- a/src/test-kernel/desktop/JsonStoreLockCompromise.vitest.ts
+++ b/src/test-kernel/desktop/JsonStoreLockCompromise.vitest.ts
@@ -1,8 +1,7 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   lock: vi.fn(),
@@ -11,19 +10,14 @@ const mocks = vi.hoisted(() => ({
 vi.mock('proper-lockfile', () => ({ lock: mocks.lock }));
 
 // Local imports - test support
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { loadSourceModule } from './loadSourceModule.ts';
 
 describe('JsonStore lock compromise boundary', () => {
-  let tempDir: string | undefined;
-
-  afterEach(async () => {
-    if (tempDir == null) return;
-    await rm(tempDir, { recursive: true, force: true });
-    tempDir = undefined;
-  });
+  const tempDirs = useTempDirs();
 
   it('rejects set() through the compromise path instead of crashing the process', async () => {
-    tempDir = await mkdtemp(join(tmpdir(), 'texra-json-store-compromise-'));
+    const tempDir = await makeTempDir('texra-json-store-compromise-', tempDirs);
     const filePath = join(tempDir, 'state.json');
     await writeFile(filePath, '{}\n');
 

--- a/src/test-kernel/support/tempDirPlatform.ts
+++ b/src/test-kernel/support/tempDirPlatform.ts
@@ -3,6 +3,8 @@ import { mkdtemp, realpath, rm } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
+import { afterEach } from 'vitest';
+
 // Platform defaults
 
 // Local imports
@@ -74,6 +76,20 @@ export async function withTempDir<T>(
   } finally {
     await cleanupTempDirs(tempDirs);
   }
+}
+
+/**
+ * Returns a `tempDirs` registry for `makeTempDir` / `createTempDirPlatform`
+ * and registers the `afterEach` that empties it — the declaration form of the
+ * registry-plus-cleanup-hook pair every suite used to hand-write. Call it once
+ * at module scope, or inside a `describe` when the registry is suite-local.
+ */
+export function useTempDirs(): string[] {
+  const tempDirs: string[] = [];
+  afterEach(async () => {
+    await cleanupTempDirs(tempDirs);
+  });
+  return tempDirs;
 }
 
 /** Removes every directory recorded by `createTempDirPlatform` (or pushed manually), then clears the list. */


### PR DESCRIPTION
## Summary

`src/test-kernel/support/tempDirPlatform.ts` already owned `makeTempDir`,
`createTempDirPlatform`, `withTempDir`, and `cleanupTempDirs` — including the
realpath canonicalization at `:31` that keeps temp paths comparable on macOS
(`/var` → `/private/var`) and Windows CI (`RUNNER~1` → `runneradmin`). But the
suites still hand-wrote the registry-plus-cleanup-hook pair around it, and a
good number bypassed the module entirely with bare `mkdtemp`. So the
canonicalization was being re-applied by hand at assertion time in some files,
was flatly missing in others, and — worst — was applied *twice* in files that
already used `makeTempDir`.

This PR adds `useTempDirs()` to the same module (a hook-registering helper that
owns the registry and its `afterEach`, a sibling of the existing
`setupPlatform.ts`, which already registers vitest hooks for its caller) and
migrates the **first slice**: `src/test-kernel/cli/**` and
`src/test-kernel/desktop/**`, plus the one shadow implementation that lives
outside them (`agent/output/CompiledPdfArtifacts.vitest.ts`).

**There is no user-facing bug here.** The payoff is cross-platform CI robustness
plus deleting shadow implementations of a shared function.

Deleted shadow implementations:

| site | shadow |
|---|---|
| `cli/CliSkills.vitest.ts:18-22` | `createTempRoot` — `mkdtemp` + push + a hand-rolled copy of `cleanupTempDirs:81-84` |
| `cli/WorkflowOutputResolution.vitest.ts:27-31` | local function literally named `makeTempDir`, same hand-rolled teardown |
| `agent/output/CompiledPdfArtifacts.vitest.ts:54-67` | second local `makeTempDir`, same hand-rolled teardown (kept as a 3-line prefix-binding delegator, since 10 call sites take no arguments) |
| `cli/RunExecution.vitest.ts:67-85` | `installStoragePlatform` inlined `createTempDirPlatform`'s body verbatim (19 lines → 4) |

Deleted dead compensation (`makeTempDir` had already canonicalized the path):

- `cli/InitCommand.vitest.ts:247,294` — `await fs.realpath(root)` on a
  `makeTempDir` root, twice.
- `cli/OverleafCloneCommand.vitest.ts:106,152` — bypass site that re-`realpath`'d
  at assertion time; the root now comes from `makeTempDir`, so both are dead.

Also fixed in passing: `cli/RunExecution.vitest.ts` declared `tempDirs` at module
scope but only cleaned it in the first of two `describe`s, so temp dirs created
by `describe('executeCliConfig')` were never removed. Module-scope
`useTempDirs()` closes that leak.

## Issue acceptance gates

No issue — this is one track of the 2026-08-19 verified collapse sweep.

## Single source of truth

`src/test-kernel/support/tempDirPlatform.ts` is now the only place in
`cli/**`, `desktop/**`, and `agent/output/` that creates or removes a test temp
directory. Registry lifetime (`afterEach` + `splice`) is owned by
`useTempDirs()`; path canonicalization is owned by `makeTempDir`.

## Duplication and abstraction budget

Removed: 3 shadow implementations of `makeTempDir`/`cleanupTempDirs`, 1 inline
copy of `createTempDirPlatform`, 13 hand-written `afterEach` cleanup hooks, 11
hand-written registry declarations, 4 dead `realpath` calls.

Added: one export, `useTempDirs()` — 7 lines, 27 consumers in this PR. It is not
a pass-through: it owns the registry's lifetime (declaration + hook
registration), which is the thing that was being copied. The existing
`cleanupTempDirs` export stays; it still has 35 call sites in the directories
this slice does not touch.

## Net elements (R6)

- **Files:** 29 changed, **0 added, 0 deleted**.
- **Exported symbols:** `+1` (`useTempDirs`), `-0`. Net **+1 export**.
  `grep -c '^[+-]export' ` over the diff: 1 added, 0 removed.
- **Functions:** `-2` deleted outright (`createTempRoot`,
  `WorkflowOutputResolution`'s local `makeTempDir`), `+1` added
  (`useTempDirs`). Two more (`CompiledPdfArtifacts`' `makeTempDir`,
  `RunExecution`'s `installStoragePlatform`) survive as delegators with their
  bodies collapsed.
- **Classes/interfaces/enums:** unchanged.
- **`afterEach` hooks:** 27 → 14 across the touched suites (**-13**).
- **Net LoC: +197 / -314 = −117.**

This is a fraction of the whole job, as scoped. The verifier's honest estimate
for all 67 files was −180 to −220; this slice is the cli/desktop share of that,
and I am reporting the measured number for what is actually in this diff, not a
projection.

## Consumer counts (R8)

No export was deleted or re-routed. Greps run to prove nothing was orphaned:

```
$ grep -rn "cleanupTempDirs(" src | grep -v "support/tempDirPlatform.ts" | wc -l
35        # still-live call sites outside the helper, all in follow-up slices
$ grep -rn "createTempRoot\|makeCliPackage" src/test-kernel/cli
          # only the surviving fixture builder in ResourcesPath.vitest.ts
$ grep -rn "mkdtemp" src/test-kernel/cli src/test-kernel/desktop
          # 4 files remain, all deliberately skipped (see below)
$ grep -rn "tempDirPlatform" src packages scripts config | grep -v "^src/test-kernel"
          # empty — the module is test-kernel-only, no host imports it
$ npm run check:dead-code-ratchet
          # 8 current vs 8 baselined — OK
```

## Host impact

Extension: none (no extension suite touched).

Desktop: none at runtime — 11 desktop test suites migrated.

CLI: none at runtime — 16 CLI test suites migrated.

## Scheduled refactoring

Remaining slices, to be scheduled separately (67 files was too much concurrent
edit surface for one PR):

1. `agent/**` — 8 files with `cleanupTempDirs`, 5 with bare `mkdtemp`.
   Includes `agent/review/AgentReviewDiff.vitest.ts:97,142`, where only the
   **right** side of `expect(await realpath(value.repoRoot)).toBe(await
   realpath(repo))` is dead; the left side normalizes production output and must
   stay.
2. `latex/**` (4 files) — includes `LatexProcessingHelpers.vitest.ts:172-175`,
   which wraps `makeTempDir` in `await realpath(...)` under a five-line comment
   explaining why canonicalization is required. `makeTempDir` already did it;
   the comment actively misinforms.
3. `transcript/**` (6), `tools/**` (2), `skills/**` (2), `traceViewer/**` (1).
4. `utils/**` (3) — `utils/system/SystemUtils.vitest.ts` needs three separate
   `useTempDirs()` calls (`:70/:341/:397`), not one.
5. `platform/**` (3), `settings/**`, `frontend/**`, `progressView/**`,
   `shared/**`, `scripts/**` bare-`mkdtemp` files. **Leave
   `platform/FakePlatform.vitest.ts` alone** — it tests the fake platform
   `createTempDirPlatform` is built on; migrating it couples a helper's test to
   the helper.

Deliberately **not** done, with reasons:

- `cli/CliAgentShadow.vitest.ts` — creates its dir in `beforeAll` and cleans in
  `afterAll`. `useTempDirs` registers an `afterEach`, which would delete the
  directory out from under the later tests in the file. Different lifetime, left
  alone.
- `cli/TranscriptSessionPolicy.vitest.ts` — imports `tempDirPlatform`
  dynamically on purpose to survive `vi.resetModules()` + `vi.doMock` ordering.
  A static `useTempDirs` import would change what is in the module graph at
  reset time.
- `cli/Completion.vitest.ts`, `cli/InstallGithubAction.vitest.ts`,
  `desktop/electronTestStub.ts` — `mkdtempSync` inside synchronous fixtures.
  `makeTempDir` is async; converting means making the test bodies async for no
  correctness gain.
- `desktop/DesktopToolEditApproval.vitest.ts:82-86` — uses `onTestFinished`,
  which is a *tighter* per-test lifetime than a suite registry. Adopting
  `useTempDirs` would widen the cleanup scope. Left as is.
- The `writeSkill` / `skillFixtures.ts` unification was **not** bundled: the two
  signatures differ (`(root, dirName, {name, description?}, body?)` vs
  `(root, dirName, description)`), adopting it lengthens every call site, and it
  banks ~0 LoC.

## Validation

- `npm run typecheck` — clean (full workspace, after `CI=true corepack pnpm
  install` in the worktree).
- `npm run lint` — clean.
- `npx vitest run` over all 28 touched suites: **28 files passed, 478 passed |
  1 skipped**.
- `npm run check:dead-code-ratchet` — 8 current vs 8 baselined, OK.
- `npx prettier --write` over the diff.

Hook-ordering was checked by hand, per the verifier's caveat: `vitest.config.mjs`
sets no `sequence.hooks`, so the default `stack` order applies and `afterEach`
hooks run in reverse registration order. In every mixed file the `useTempDirs`
hook is registered *first*, so it runs *last* — after the suite's own
`vi.restoreAllMocks()` / `host.dispose()` / `ipc.dispose()` /
`resetElectronTestStub()`. That is the same relative order as before.
`desktop/ElectronPlatformAdapters.vitest.ts` was the one to watch: its own hook
pushes the Electron stub's userData path onto `tempDirs` before cleanup, and
that still happens first.
