### PR TITLE
fix(agent): name media attachments the way documents are named

### DIFF
--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -1263,7 +1263,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
             media_type: 'application/pdf',
             data: media.data,
           },
-          title: media.file_name,
+          // `file_name` may be workspace-relative; the title is a filename.
+          title: basename(media.file_name),
         } satisfies BetaRequestDocumentBlock;
         return [descriptionBlock, documentBlock];
       }

--- a/src/agent/modelHandlers/google/googleHandlerShared.ts
+++ b/src/agent/modelHandlers/google/googleHandlerShared.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'node:buffer';
+import { basename } from 'node:path';
 
 import { GoogleGenAI, type File } from '@google/genai';
 
@@ -157,7 +158,8 @@ export async function uploadGoogleMediaEntries<T>(
       );
       const uploaded: File = await client.files.upload({
         file: uploadPath,
-        config: { mimeType, displayName: fileName },
+        // `fileName` may be workspace-relative; displayName is a filename.
+        config: { mimeType, displayName: basename(fileName) },
       });
       const fileUri = uploaded.uri;
       if (!fileUri) {

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -1,3 +1,6 @@
+// Standard library imports
+import { basename } from 'node:path';
+
 // Third-party imports
 import { ModelProvider } from 'llm-zoo';
 import OpenAI, { OpenAIError } from 'openai';
@@ -1245,7 +1248,8 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
           {
             type: 'input_file',
             file_data: toDataUrl(mediaType, media.data),
-            filename: media.file_name,
+            // `file_name` may be workspace-relative; this field is a filename.
+            filename: basename(media.file_name),
           },
         ];
       }

--- a/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
+++ b/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
@@ -1,6 +1,3 @@
-// Standard library imports
-import * as path from 'node:path';
-
 // Third-party imports
 import pMap from 'p-map';
 
@@ -16,6 +13,7 @@ import {
 
 // Local imports - utils
 import { ensureArray } from '@utils/core';
+import { getPromptFileName } from '@utils/prompt';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { getMimeType } from '@utils/files/mimeUtils';
 import { getExtensionLowercase } from '@utils/core/pathCore';
@@ -296,7 +294,10 @@ export class MediaAttachmentProcessor {
     fileExtension: string,
     processed: ProcessedMediaResult,
   ): MediaEntry | MediaEntry[] {
-    const baseName = path.basename(mediaFile);
+    // Same rule as a text document's <document name="…">: workspace-relative,
+    // so figures/setup/panel.pdf and figures/results/panel.pdf stay distinct to
+    // the model. Provider filename fields basename it at their own call site.
+    const baseName = getPromptFileName(absolutePath);
     const isPdf = processed.kind === 'image' && fileExtension === '.pdf';
 
     if (

--- a/src/agent/types/mediaTypes.ts
+++ b/src/agent/types/mediaTypes.ts
@@ -3,7 +3,12 @@
  * multi-modal messages before provider-specific formatting.
  */
 export interface MediaEntry {
-  /** File name for reference, typically without directory */
+  /**
+   * Name the model sees for this attachment. Follows `getPromptFileName`, the
+   * same rule as a text document's `<document name="…">`: workspace-relative
+   * for workspace files, bare basename otherwise. Provider fields that require
+   * a filename (`filename`, `title`, `displayName`) basename it themselves.
+   */
   file_name: string;
   /** Base64 encoded media content */
   data: string;


### PR DESCRIPTION
## Summary

Two attachments in the same prompt were named to the model by two different rules:

- A **text document** is named by `getPromptFileName` (`src/utils/prompt.ts`), which keeps
  workspace files workspace-relative. Its doc block spells out why: "Keep workspace files
  workspace-relative so sibling documents with the same basename remain distinct."
- A **media attachment** was named by bare `path.basename`
  (`MediaAttachmentProcessor.createEntriesForProcessedMedia`), deliberately flattening the
  workspace-relative `displayPath` it was handed.

The collision is reachable, not theoretical. `LatexMediaManager` resolves every
`\includegraphics` target against the real LaTeX dir and calls
`workspaceState.media.addMediaFiles(existingLocations)`; `AgentWorkspaceState.addMediaFiles`
dedupes on `location.absolutePath`, **not** on basename. So `figures/setup/panel.pdf` and
`figures/results/panel.pdf` both enter the attachment list and the model is told
`Document: panel.pdf` **twice** — in the same prompt where sibling
`<document name="chapter/main.tex">` blocks *are* disambiguated. The model has no way to tell
which figure a statement refers to.

Fix: name a media attachment by the same rule as a text document.

## Issue acceptance gates

No issue — found by a collapse sweep over prompt assembly. Gate: one naming rule for everything
the model is shown, no new schema field, no change to prompt bytes on paths that do not attach
media.

## Single source of truth

`getPromptFileName` is now the single owner of "what name does the model see for this file",
covering text documents (`<document name="…">`, `*_FILES`, `LIST_OF_ALL_*S`) and media
attachments alike. `MediaEntry.file_name`'s doc comment is updated to state that rule, since it
was previously documented as "typically without directory".

Provider fields that genuinely require a bare filename basename it at their own call site —
the format requirement belongs to the wire field, not to the prompt-facing name.

## Duplication and abstraction budget

No new abstraction. The scout's original proposal added a second `prompt_name` field to
`MediaEntry` alongside `file_name`; that is **refuted and not done**. Because
`getPromptFileName` returns either a workspace-relative path or a basename,
`basename(getPromptFileName(abs))` is byte-identical to today's value at every
provider-filename site — including the paged form, since
`basename('figures/setup/panel.pdf_page_1') === 'panel.pdf_page_1'`. One field stays one field.

## What changed

1. `MediaAttachmentProcessor.createEntriesForProcessedMedia`:
   `path.basename(mediaFile)` → `getPromptFileName(absolutePath)`. (`@utils/prompt` is already
   imported from `src/agent/**` at five sites, and `getPromptFileName` tolerates being called
   before host init, falling back to the basename rule.) The now-unused `node:path` import goes.
2. `basename(...)` wrapped at the **three** real provider-filename fields:
   - `openai/modelHandlerOpenAIResponse.ts` — `input_file.filename`
   - `anthropic/modelHandlerAnthropic.ts` — document block `title` (belt-and-braces:
     `sanitizeAnthropicFilename` already basenames on the Files-API path)
   - `google/googleHandlerShared.ts` — `files.upload` `config.displayName`
3. The **seven text-label sites** (`Image: ${media.file_name}` / `Document: …` in
   `modelHandlerOpenAI`, `modelHandlerOpenRouterNative`, `modelHandlerAnthropic`,
   `modelHandlerOpenAIResponse`) need **zero edits** — they inherit the fix, which is the whole
   point of putting it at the source.
4. `MediaEntry.file_name` doc comment updated to the new rule.

**Dropped from scope:** adding text labels to the Google and VS Code LM paths, which today push
media parts with no name at all. That changes prompt bytes for every Gemini and Copilot run —
a behaviour decision, not a collapse. Not touched here.

## Net elements (R6)

**This PR net-ADDS lines. Saying so plainly: it is bought with the defect, not with the line
count.**

| | + | − | net |
|---|---|---|---|
| Files | 0 | 0 | 0 |
| Exported symbols | 0 | 0 | 0 |
| Schema/interface fields | 0 | 0 | 0 |
| Imports | 3 (`@utils/prompt`, 2× `node:path` `basename`) | 1 (`node:path` in the processor) | +2 |
| LoC | +21 | −8 | **+13** |

Per file: `MediaAttachmentProcessor.ts` +5/−4, `modelHandlerOpenAIResponse.ts` +5/−1,
`modelHandlerAnthropic.ts` +2/−1, `googleHandlerShared.ts` +3/−1, `mediaTypes.ts` +6/−1.

Of the +13, **9 lines are comments/doc** (the `MediaEntry.file_name` doc block, and one line at
each site recording why it basenames). Code-only net is about **+4**, essentially the two new
`node:path` imports.

## Consumer counts (R8)

```
$ grep -rn "file_name" src packages --include="*.ts" --include="*.tsx" | grep -v test-kernel
src/agent/types/mediaTypes.ts:7                      the field definition
src/agent/modelHandlers/openai/modelHandlerOpenAI.ts:738,773,781             text labels + a warn
src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts:1222,1237,1244,1248,1255
                                                     text labels, warns, and `filename:` (wrapped)
src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts:468,482,487   text labels + a warn
src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts:1228,1244,1254,1266,1281
                                                     warns, text label, `title:` (wrapped), log data
src/agent/modelHandlers/google/googleHandlerShared.ts:122                    → displayName (wrapped)
src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts:343                 error message only
```

Every non-log use is a label, `title`, `filename`, or `displayName` — **nothing keys identity,
dedup, caching, or lookup on `file_name`**, so changing its value cannot break a match. The
three sites that hand it to a provider as a filename are exactly the three wrapped here.

The `_page_N` suffix is unaffected: it is appended after the name, and `basename` of a
suffixed relative path still yields the suffixed basename.

## Host impact

Extension / Desktop / CLI: identical — this is shared agent code. For a workspace media file
inside a subdirectory, the model now sees `Document: figures/setup/panel.pdf` instead of
`Document: panel.pdf`. External (non-workspace) media is unchanged: `getPromptFileName` returns
the basename for absolute external paths, deliberately, so host filesystem paths do not leak
into the prompt. Bytes sent to provider `filename` / `title` / `displayName` fields are
unchanged everywhere.

## Scheduled refactoring

None filed. Noted but deliberately not done: the Google and VS Code LM paths attach media with
no text label at all, so those models never learn any filename. That is a prompt-content change
for two whole providers and wants its own decision.

## Validation

- `npm run typecheck` — clean across the whole workspace (exit 0).
- `npx vitest run src/test-kernel/agent/modelHandlers/` — **61 files passed, 1 skipped;
  756 tests passed, 4 skipped**. This covers `support/MediaAttachmentProcessor.vitest.ts`,
  which asserts on the `filesLoaded` event rather than on `file_name`.
- `npx vitest run src/test-kernel/architecture` — **17 files / 101 tests passed** (the new
  `@utils/prompt` edge from `src/agent/modelHandlers/support/` does not widen any ratchet;
  `src/agent → @utils` edges already exist in that very file).
- Pre-checked the fixtures the brief flagged: `'Image: cat.png'` in `OpenAIMessageUtils.vitest.ts`
  and the `file_name` fixtures in `ModelHandlerOpenAIResponse`, `GoogleInteractionsMessages`, and
  `ModelHandlerVscodeLm` all supply bare basenames already, so the `basename` wraps are no-ops
  for them.
- `npx eslint` and `npx prettier --check` on all five changed files — clean.
- `check:dead-code-ratchet` not run: no export added or removed.

Zero new tests, zero tests modified, zero tests deleted.
