### PR TITLE
fix(git): make the clone env strip actually strip

### DIFF
--- a/packages/cli/src/commands/clone.ts
+++ b/packages/cli/src/commands/clone.ts
@@ -20,7 +20,7 @@ import {
   type OverleafRemote,
 } from '@latex/overleafProject';
 import { executeCommandSync } from '@utils/system/execUtils';
-import { extendEnvPath } from '@utils/system/platformPaths';
+import { makeMachineGitEnv } from '@utils/system/gitEnv';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local imports - runtime
@@ -117,7 +117,10 @@ function buildOverleafClonePorts(
       canonicalWorkspacePath = await realpath(workspacePath);
       await execa('git', ['clone', remoteUrl, '.'], {
         cwd: canonicalWorkspacePath,
-        env: { GIT_TERMINAL_PROMPT: '0', PATH: extendEnvPath() },
+        // extendEnv: false is required — makeMachineGitEnv omits the
+        // helper-invoking keys, and execa's default merge re-adds them.
+        env: makeMachineGitEnv(),
+        extendEnv: false,
       });
     },
     showCloneSucceeded: (label) => {

--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -24,7 +24,7 @@ import { COMMIT_HASH_PATTERN } from '@utils/git/commitHashPattern';
 import { COMMIT_LABEL_FORMAT } from '@utils/git/commitLogFormat';
 import { readRecentCommitLabels } from '@utils/git/repositoryOverview';
 import { executeCommandSync } from '@utils/system/execUtils';
-import { extendEnvPath } from '@utils/system/platformPaths';
+import { makeMachineGitEnv } from '@utils/system/gitEnv';
 import { isGitRepository } from '@utils/git/isGitRepository';
 
 const CHANNEL = 'gitCommands';
@@ -232,7 +232,10 @@ function buildOverleafClonePorts(
             cwd: workspacePath,
             // Same extended PATH as the executeCommandSync preflight above, so
             // the probe can't pass while the clone misses git (bot review).
-            env: { GIT_TERMINAL_PROMPT: '0', PATH: extendEnvPath() },
+            // extendEnv: false is required — makeMachineGitEnv omits the
+            // helper-invoking keys, and execa's default merge re-adds them.
+            env: makeMachineGitEnv(),
+            extendEnv: false,
           }),
       );
     },

--- a/src/test-kernel/cli/OverleafCloneCommand.vitest.ts
+++ b/src/test-kernel/cli/OverleafCloneCommand.vitest.ts
@@ -10,7 +10,7 @@ import { CliExitCode } from '@cli/runtime/exitCodes';
 import { canonicalizeWorkspacePath } from '@platform/defaults/nodeWorkspace';
 import { spyOnStreamWrite } from '@test/cli/fixtures/streamWriteSpy';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
-import { extendEnvPath } from '@utils/system/platformPaths';
+import { makeMachineGitEnv } from '@utils/system/gitEnv';
 
 const mocks = vi.hoisted(() => ({
   deleteSecret: vi.fn(),
@@ -124,7 +124,8 @@ describe('CLI Overleaf clone command', () => {
       ],
       {
         cwd: workspacePath,
-        env: { GIT_TERMINAL_PROMPT: '0', PATH: extendEnvPath() },
+        env: makeMachineGitEnv(),
+        extendEnv: false,
       },
     );
     expect(JSON.parse(stdout)).toEqual({
@@ -159,7 +160,8 @@ describe('CLI Overleaf clone command', () => {
       ],
       {
         cwd: destination,
-        env: { GIT_TERMINAL_PROMPT: '0', PATH: extendEnvPath() },
+        env: makeMachineGitEnv(),
+        extendEnv: false,
       },
     );
     expect(JSON.parse(stdout)).toMatchObject({

--- a/src/utils/system/gitEnv.ts
+++ b/src/utils/system/gitEnv.ts
@@ -29,9 +29,15 @@ const GIT_UNSAFE_ENV_KEYS = new Set([
 /**
  * Build an environment for a non-interactive git subprocess: the current
  * environment with the helper-invoking keys in {@link GIT_UNSAFE_ENV_KEYS}
- * removed and `PATH` extended via {@link extendEnvPath} so GUI-launched hosts
- * (whose minimal PATH may omit Homebrew / /usr/local/bin) can still resolve
- * the `git` binary.
+ * removed, `GIT_TERMINAL_PROMPT=0` so git never blocks on a tty prompt, and
+ * `PATH` extended via {@link extendEnvPath} so GUI-launched hosts (whose
+ * minimal PATH may omit Homebrew / /usr/local/bin) can still resolve the `git`
+ * binary.
+ *
+ * This omits the unsafe keys rather than setting them to `undefined`, so it
+ * only strips anything when it fully replaces the child environment. With
+ * `execa` that means passing `extendEnv: false` alongside it — execa's default
+ * merges `process.env` back in and every stripped key returns.
  */
 export function makeMachineGitEnv(): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {};
@@ -39,6 +45,7 @@ export function makeMachineGitEnv(): NodeJS.ProcessEnv {
     if (GIT_UNSAFE_ENV_KEYS.has(key.toLowerCase())) continue;
     env[key] = value;
   }
+  env.GIT_TERMINAL_PROMPT = '0';
   env.PATH = extendEnvPath(env.PATH);
   return env;
 }


### PR DESCRIPTION
## Summary

Three places build an environment for a non-interactive `git` subprocess, and
they did not agree:

- `reviewDiff.ts` → `makeMachineGitEnv()` (`src/utils/system/gitEnv.ts`), which
  strips the 16 env keys that let git invoke a helper program (`GIT_ASKPASS`,
  `GIT_EXTERNAL_DIFF`, `GIT_PAGER`, `GIT_SEQUENCE_EDITOR`, `EDITOR`, …).
- `packages/cli/src/commands/clone.ts:120` and
  `packages/extension/src/commands/git/gitCommands.ts:235` → an inline
  `{ GIT_TERMINAL_PROMPT: '0', PATH: extendEnvPath() }`.

`GIT_TERMINAL_PROMPT=0` suppresses git's own tty prompting. It does **not** stop
an inherited askpass program. So a clone that declares itself non-interactive
could still pop a GUI credential dialog, while `reviewDiff` on the same machine
correctly refuses.

This collapses both clone sites onto `makeMachineGitEnv()`, which now sets
`GIT_TERMINAL_PROMPT = '0'` itself.

**The load-bearing half is `extendEnv: false`.** `makeMachineGitEnv()` *omits*
the unsafe keys rather than setting them to `undefined`, and execa's `extendEnv`
defaults to `true` — so `env: makeMachineGitEnv()` on its own merges
`process.env` back in and re-adds every key that was just stripped. Verified by
execution against the installed execa 10.0.1:

```
env: processEnvMinusGitAskpass                    → GIT_ASKPASS=/tmp/evil-askpass
env: processEnvMinusGitAskpass, extendEnv: false  → GIT_ASKPASS=<unset>
```

Without the second line this PR would have been a no-op that reads as a security
fix — the silent-degradation class CLAUDE.md forbids. Both call sites carry a
comment saying so, and the `makeMachineGitEnv()` doc comment states the
requirement at the definition.

Concrete scenario: running `texra clone` from the VS Code integrated terminal
inherits VS Code's exported `GIT_ASKPASS`.

## Issue acceptance gates

n/a — found by a collapse sweep over `process-spawn` sites, no issue.

## Single source of truth

`makeMachineGitEnv()` in `src/utils/system/gitEnv.ts` is now the only definition
of "the environment for a git subprocess TeXRA drives on the user's behalf".
Three call sites, zero inline literals.

## Duplication and abstraction budget

Removed: two inline env literals plus their `extendEnvPath` imports. Added: no
new abstraction — `makeMachineGitEnv()` already existed with one caller and now
has three.

## Net elements (R6)

**This PR net-ADDS 15 lines. It is a correctness fix, not a reduction — do not
read it as one.** The added lines are all comment: the `extendEnv: false`
requirement has to be stated where it can be dropped by accident.

| | files | exports | functions | LoC |
|---|---|---|---|---|
| production | 3 changed, 0 added, 0 deleted | ±0 | ±0 | +20 / −7 = **+13** |
| tests | 1 changed | ±0 | ±0 | +5 / −3 = **+2** |

Per file:

```
 5  2  packages/cli/src/commands/clone.ts
 5  2  packages/extension/src/commands/git/gitCommands.ts
10  3  src/utils/system/gitEnv.ts
 5  3  src/test-kernel/cli/OverleafCloneCommand.vitest.ts
```

Behaviour delta at the two clone sites: the child no longer inherits the 16
helper-invoking keys. Everything else about the environment is unchanged —
`extendEnv: true` previously produced `process.env` + the two overrides;
`makeMachineGitEnv()` produces `process.env` − 16 keys + the same two overrides.

## Consumer counts (R8)

No export added or removed. Greps run:

- `rg 'GIT_TERMINAL_PROMPT|extendEnvPath|makeMachineGitEnv' src packages -g '*.ts'`
  — before: two inline `GIT_TERMINAL_PROMPT` literals (both changed here) plus
  the test's copy; after: zero outside `gitEnv.ts`.
- `makeMachineGitEnv` consumers: `reviewDiff.ts:74` (unchanged, simple-git
  `.env()` replaces the environment, so it needs no `extendEnv` equivalent),
  `clone.ts`, `gitCommands.ts`, and the clone test.
- `extendEnvPath` keeps 9 other consumers; its export stays live.

## Host impact

Extension: the Overleaf/ShareLaTeX clone command no longer inherits helper env
keys. Desktop: none directly (no clone site). CLI: `texra clone` likewise.

## Scheduled refactoring

None. Adjacent finding deliberately **not** done: the `runClone` /
`isGitAvailable` host ports look collapsible into `src/latex/overleafClone.ts`,
but `clone.ts`'s `runClone` also assigns `canonicalWorkspacePath` (read later to
build the emitted result), so moving the spawn strands that assignment. Left
alone.

## Validation

- `npm run typecheck` — clean (includes `@texra-ai/cli` `tsconfig.scripts.json`
  via `typecheck:cli`).
- `npx vitest run src/test-kernel/cli/OverleafCloneCommand.vitest.ts` — 10/10
  pass. Its two `execa` call assertions were updated to the new shape; they now
  pin `extendEnv: false`, which is the regression guard for this fix. **No new
  test file.**
- `npx eslint` on the four changed files — clean.
- `npx prettier --check` on the four changed files — clean.
- execa `extendEnv` semantics reproduced by execution (output above) rather than
  read from docs.
