### PR TITLE
refactor(agent): make the batched tool follow-up the single handler contract

### DIFF
--- a/src/agent/implementations/flows/tooluse/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/implementations/flows/tooluse/toolUseRound/ToolUseDispatchNode.ts
@@ -596,8 +596,7 @@ export class ToolUseDispatchNode<C> extends Node<
     }));
     if (
       toolResults.length > 1 &&
-      modelHandler.requiresBatchedParallelToolResults &&
-      modelHandler.createBatchedToolUseFollowUpMessages
+      modelHandler.requiresBatchedParallelToolResults
     ) {
       const followUpMsgs =
         await modelHandler.createBatchedToolUseFollowUpMessages(

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -1684,23 +1684,55 @@ export abstract class ModelHandler<
   abstract extractToolUse(responseObject: Resp): T[];
 
   /**
-   * Build a provider-specific follow-up message containing a tool result.
+   * Build provider-specific follow-up messages carrying the results of one
+   * model turn's tool calls.
    *
-   * @param client - Provider client (for file uploads if supported)
-   * @param call - Parsed tool call object
-   * @param result - Tool result payload (binary data stripped, properly typed)
-   * @param attachments - Extracted file attachments (for upload/inline if supported)
-   * @param workspaceState - Optional workspace state
-   * @param text - Optional text to include before tool call
+   * This is the single follow-up contract: handlers implement the batched
+   * shape and get the single-call path for free from
+   * {@link createToolUseFollowUpMessages} below. Providers that must keep
+   * parallel calls in one assistant turn (thought signatures, DeepSeek-style
+   * `reasoning_content`) assemble them here; providers that never batch
+   * concatenate per entry.
+   *
+   * @param entries - One entry per tool call, in original model-response order.
+   *   Each entry bundles the call with its own result and attachments, so
+   *   alignment is structural rather than three positionally-zipped arrays.
+   * @param workspaceState - Optional workspace state (reasoning / server-tool
+   *   content to replay, reset once consumed)
+   * @param text - Assistant text emitted before the tool calls, if any
+   * @param client - Provider client bound to the current run and credential
+   *   route (for tool-result file uploads, where supported)
    */
-  abstract createToolUseFollowUpMessages(
+  abstract createBatchedToolUseFollowUpMessages(
+    entries: Array<{
+      call: T;
+      result: ToolResult;
+      attachments: ToolFileAttachment[];
+    }>,
+    workspaceState: AgentWorkspaceState | undefined,
+    text: string | undefined,
+    client: C | undefined,
+  ): Promise<M[]>;
+
+  /**
+   * Build a provider-specific follow-up message containing a single tool
+   * result — the batched contract applied to one entry.
+   */
+  async createToolUseFollowUpMessages(
     client: C | undefined,
     call: T,
     result: ToolResult,
     attachments: ToolFileAttachment[],
     workspaceState?: AgentWorkspaceState,
     text?: string,
-  ): Promise<M[]>;
+  ): Promise<M[]> {
+    return this.createBatchedToolUseFollowUpMessages(
+      [{ call, result, attachments }],
+      workspaceState,
+      text,
+      client,
+    );
+  }
 
   /**
    * Append a simple text follow-up from the user.

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -1638,34 +1638,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return content;
   }
 
-  async createToolUseFollowUpMessages(
-    client: Anthropic,
-    call: AnthropicToolCall,
-    result: ToolResult,
-    attachments: ToolFileAttachment[],
-    workspaceState?: AgentWorkspaceState,
-    text?: string,
-  ): Promise<MessageParam[]> {
-    const content = this.buildToolCallAssistantContent(workspaceState, text);
-    content.push({
-      type: 'tool_use',
-      id: call.callId,
-      name: call.name,
-      input: call.raw.input ?? {},
-    });
-
-    const resultBlock = await this.buildToolResultBlock(
-      client,
-      call,
-      result,
-      attachments,
-    );
-    return [
-      { role: 'assistant', content },
-      { role: 'user', content: [resultBlock] },
-    ];
-  }
-
   /**
    * Batched variant for parallel tool calls: one assistant message carrying
    * the original response content plus ALL tool_use blocks, then ONE user

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -752,29 +752,6 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     ];
   }
 
-  /**
-   * Follow-up for a SINGLE tool call, built by delegating to the batched
-   * path with a one-entry array so both call sites share one assembly.
-   */
-  async createToolUseFollowUpMessages(
-    _client: GoogleGenAI | undefined,
-    call: GoogleToolCall,
-    result: ToolResult,
-    attachments: ToolFileAttachment[],
-    workspaceState?: AgentWorkspaceState,
-    text?: string,
-  ): Promise<Step[]> {
-    if (!call.callId) {
-      throw new Error('Function call id is required for follow-up messages');
-    }
-
-    return this.createBatchedToolUseFollowUpMessages(
-      [{ call, result, attachments }],
-      workspaceState,
-      text,
-    );
-  }
-
   // ===========================================================================
   // Capability getters / auth (REUSE / PORT from the chat handler)
   // ===========================================================================

--- a/src/agent/modelHandlers/modelHandlerValidation.ts
+++ b/src/agent/modelHandlers/modelHandlerValidation.ts
@@ -283,23 +283,23 @@ export class ModelHandlerValidation extends ModelHandler<
     return responseObject.toolCalls ?? [];
   }
 
-  async createToolUseFollowUpMessages(
-    _client: unknown,
-    _call: SdkToolCall,
-    result: ToolResult,
-    _attachments: ToolFileAttachment[],
-    _workspaceState?: AgentWorkspaceState,
-    text?: string,
+  async createBatchedToolUseFollowUpMessages(
+    entries: Array<{
+      call: SdkToolCall;
+      result: ToolResult;
+      attachments: ToolFileAttachment[];
+    }>,
+    _workspaceState: AgentWorkspaceState | undefined,
+    text: string | undefined,
   ): Promise<ChatCompletionMessageParam[]> {
-    return [
-      {
-        role: 'tool',
-        tool_call_id: 'validation-tool-call',
-        content: text
+    return entries.map(({ result }, index) => ({
+      role: 'tool',
+      tool_call_id: 'validation-tool-call',
+      content:
+        index === 0 && text
           ? `${text}\n${JSON.stringify(result)}`
           : JSON.stringify(result),
-      },
-    ];
+    }));
   }
 
   async createUserFollowUpMessages(

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -1137,23 +1137,6 @@ export class ModelHandlerOpenAI<
     return callMsg;
   }
 
-  async createToolUseFollowUpMessages(
-    _client: OpenAI | undefined,
-    call: TCall,
-    result: ToolResult,
-    attachments: ToolFileAttachment[],
-    workspaceState?: AgentWorkspaceState,
-    text?: string,
-  ): Promise<ChatCompletionMessageParam[]> {
-    // The single-call path is batched-of-one: identical assistant-turn
-    // construction, tool result formatting, and reasoning reset.
-    return this.createBatchedToolUseFollowUpMessages(
-      [{ call, result, attachments }],
-      workspaceState,
-      text,
-    );
-  }
-
   /**
    * Creates batched tool-use follow-up messages for multiple parallel tool calls.
    *

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -2646,7 +2646,39 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
     return { webSearchResults, webFetchResults: [], contentBlocks };
   }
 
-  async createToolUseFollowUpMessages(
+  /**
+   * The Responses surface never batches parallel tool results
+   * (`requiresBatchedParallelToolResults` stays false), so a multi-call turn is
+   * exactly the per-call items concatenated, with the assistant text carried on
+   * the first entry only.
+   */
+  async createBatchedToolUseFollowUpMessages(
+    entries: Array<{
+      call: OpenAIResponseToolCall;
+      result: ToolResult;
+      attachments: ToolFileAttachment[];
+    }>,
+    workspaceState: AgentWorkspaceState | undefined,
+    text: string | undefined,
+    client: OpenAI | undefined,
+  ): Promise<ResponseInputItem[]> {
+    const messages: ResponseInputItem[] = [];
+    for (const [index, { call, result, attachments }] of entries.entries()) {
+      messages.push(
+        ...(await this.buildSingleToolUseFollowUp(
+          client,
+          call,
+          result,
+          attachments,
+          workspaceState,
+          index === 0 ? text : undefined,
+        )),
+      );
+    }
+    return messages;
+  }
+
+  private async buildSingleToolUseFollowUp(
     client: OpenAI | undefined,
     call: OpenAIResponseToolCall,
     result: ToolResult,

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -634,23 +634,6 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
       }));
   }
 
-  async createToolUseFollowUpMessages(
-    _client: OpenRouter | undefined,
-    call: OpenRouterToolCall,
-    result: ToolResult,
-    attachments: ToolFileAttachment[],
-    workspaceState?: AgentWorkspaceState,
-    text?: string,
-  ): Promise<ChatMessages[]> {
-    // The single-call path is batched-of-one: identical assistant/tool
-    // message construction and tool result formatting.
-    return this.createBatchedToolUseFollowUpMessages(
-      [{ call, result, attachments }],
-      workspaceState,
-      text,
-    );
-  }
-
   async createBatchedToolUseFollowUpMessages(
     entries: Array<{
       call: OpenRouterToolCall;

--- a/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
+++ b/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
@@ -421,20 +421,6 @@ export class ModelHandlerVscodeLm extends ModelHandler<
     }));
   }
 
-  async createToolUseFollowUpMessages(
-    _client: LanguageModelPort | undefined,
-    call: VscodeLmToolCall,
-    result: ToolResult,
-    attachments: ToolFileAttachment[],
-    _workspaceState?: AgentWorkspaceState,
-    text?: string,
-  ): Promise<LanguageModelMessage[]> {
-    return this.buildToolUseFollowUpMessages(
-      [{ call, result, attachments }],
-      text,
-    );
-  }
-
   async createBatchedToolUseFollowUpMessages(
     entries: Array<{
       call: VscodeLmToolCall;
@@ -444,17 +430,6 @@ export class ModelHandlerVscodeLm extends ModelHandler<
     _workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<LanguageModelMessage[]> {
-    return this.buildToolUseFollowUpMessages(entries, text);
-  }
-
-  private buildToolUseFollowUpMessages(
-    entries: Array<{
-      call: VscodeLmToolCall;
-      result: ToolResult;
-      attachments: ToolFileAttachment[];
-    }>,
-    text?: string,
-  ): LanguageModelMessage[] {
     if (entries.length === 0) return [];
 
     const assistantContent: Array<

--- a/src/agent/types/IModelHandler.ts
+++ b/src/agent/types/IModelHandler.ts
@@ -1,26 +1,20 @@
 // Local imports - agent components
-import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import type { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
-import type { ToolFileAttachment, ToolResult } from '@shared/schemas';
 import type { ProviderMessage } from './ProviderMessage';
 
 /**
  * Common port implemented by all model handlers.
  *
- * Derived from {@link ModelHandler} via `Pick` so the port surface can never
- * drift from the base class: adding, renaming, or retyping a member there is
- * automatically reflected here, and a base-class signature change breaks
- * exactly one place (the class) instead of two. Only members consumers
+ * Derived from {@link ModelHandler} via `Pick` alone — the port adds nothing
+ * of its own, so it can never drift from the base class: adding, renaming, or
+ * retyping a member there is automatically reflected here, and a base-class
+ * signature change breaks exactly one place (the class) instead of two. Only
+ * members consumers
  * actually call through this port are picked. Omitted members are reached
  * through the concrete class instead: this includes internal-only helpers
  * such as `computePrice` and `supportsReasoningLevelOverride`, plus
  * `extractResponse`, which `helperModel` calls on its concrete handler.
- *
- * `createBatchedToolUseFollowUpMessages` is the one thing this port expresses
- * that the class doesn't: it's an interface-only optional extension that
- * `ToolUseDispatchNode` feature-detects for providers requiring batched
- * parallel tool-result messages (e.g. Google, DeepSeek, Kimi, MiniMax).
  *
  * @template M - Message type specific to the provider (e.g., MessageParam for Anthropic,
  *               ChatCompletionMessageParam for OpenAI). Must extend ProviderMessage.
@@ -71,6 +65,7 @@ export type IModelHandler<
   | 'extractToolUse'
   | 'extractServerToolData'
   | 'createToolUseFollowUpMessages'
+  | 'createBatchedToolUseFollowUpMessages'
   | 'createUserFollowUpMessages'
   | 'createAssistantMessageFromResponse'
   | 'isEndTurnStop'
@@ -80,35 +75,4 @@ export type IModelHandler<
   | 'addMediaToUserMessage'
   | 'consumeInsertedAttachmentKinds'
   | 'dispose'
-> & {
-  /**
-   * Create provider-specific messages for MULTIPLE parallel tool calls.
-   *
-   * This is optional and primarily used by Google handlers to properly structure
-   * parallel function calls with thought signatures (required for Gemini 3 models).
-   *
-   * When implemented:
-   * - All function calls go in ONE model message (first call has thoughtSignature)
-   * - All function responses go in ONE user message
-   *
-   * @param entries - One entry per tool call, in original model-response order.
-   *   Each entry bundles the call with its own result and attachments, so
-   *   alignment is structural rather than three positionally-zipped arrays.
-   * @param workspaceState - Workspace state for reasoning blocks, if any
-   * @param text - Text to include before the function calls, if any
-   * @param client - Client bound to the current run and credential route.
-   *   Required: the caller already holds the run's client, so a handler that
-   *   uploads tool-result attachments uses that one rather than resolving a
-   *   second credential route of its own.
-   */
-  createBatchedToolUseFollowUpMessages?(
-    entries: Array<{
-      call: T;
-      result: ToolResult;
-      attachments: ToolFileAttachment[];
-    }>,
-    workspaceState: AgentWorkspaceState | undefined,
-    text: string | undefined,
-    client: C,
-  ): Promise<M[]>;
-};
+>;

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
@@ -336,7 +336,7 @@ describe('ModelHandlerGoogleInteractions tool use', () => {
       { type: 'thinking', thinking: 'plan', signature: 'sig_b' },
     ];
 
-    const followUp = await handler.createBatchedToolUseFollowUpMessages!(
+    const followUp = await handler.createBatchedToolUseFollowUpMessages(
       calls.map((call, index) => ({
         call,
         result: results[index],

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerVscodeLm.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerVscodeLm.vitest.ts
@@ -372,7 +372,7 @@ describe('ModelHandlerVscodeLm streaming and tools', () => {
       ],
     });
 
-    const followUp = await handler.createBatchedToolUseFollowUpMessages!(
+    const followUp = await handler.createBatchedToolUseFollowUpMessages(
       [
         {
           call: calls[0],


### PR DESCRIPTION
## Summary

The tool-result follow-up contract was inverted. `ModelHandler` declared
`createToolUseFollowUpMessages` (one call) as the abstract method, and the batched
multi-call variant lived only as an **optional interface-only extension** bolted onto
`IModelHandler` with a 32-line `& { … }` block. Seven handlers therefore each defined a
single-result method that was byte-identical to their own batched method applied to a
one-entry array, and `ToolUseDispatchNode` feature-detected the optional member at runtime.

This flips it: **`createBatchedToolUseFollowUpMessages` is now the abstract method on
`ModelHandler`, and the single-call path is one concrete base delegate** that wraps its
arguments into a one-entry array. Every per-handler single-result pass-through is deleted,
`IModelHandler` becomes a pure `Pick<ModelHandler, …>` with nothing of its own, and the
dispatch feature-detect goes away.

The feature-detect was already dead code: every handler with
`requiresBatchedParallelToolResults === true` (Google, VscodeLm, Anthropic, OpenRouter,
`ReasoningModelHandlerOpenAI`) already implemented the batched method, and
`ModelHandlerOpenAIResponse` / `ModelHandlerCodex` inherit the base `false`. No handler could
reach the batched branch without the method.

Two handlers had no batched method to promote, and both are permanently non-batching:

- **`ModelHandlerOpenAIResponse`** — its 150-line single-call body (attachment upload,
  combined text, inline-base64 fallback) is renamed unchanged to a private
  `buildSingleToolUseFollowUp`, with a 12-line `createBatchedToolUseFollowUpMessages` that
  concatenates per entry and passes `text` only at `index === 0`. That is byte-for-byte the
  semantics of the loop `ToolUseDispatchNode` runs for this handler today. It is deliberately
  **not** re-indented into a `for…of` over the substantive body: Responses never batches, so
  that would create a never-exercised `n > 1` path plus a 110-line pure-re-indent diff.
- **`ModelHandlerValidation`** — same treatment via `entries.map(...)`.

`ModelHandlerVscodeLm` had *three* methods here (single, batched, and a private
`buildToolUseFollowUpMessages` both delegated to); the private now has one caller and is
inlined into the batched method.

### Behavior deltas (both intentional)

- **Google error wording.** The single-call path threw
  `'Function call id is required for follow-up messages'` on a missing `callId`; the batched
  path (which now serves both) throws
  `` `Function call at index ${index} (${call.name}) is missing callId` ``. Strictly more
  informative, same throw condition. No test asserted the old literal
  (`git grep 'Function call id is required'` → the one production site only).
- **Anthropic** keeps its narrowed `client: Anthropic` on the batched override, matching what
  its deleted single-call method already declared. No runtime change.

## Issue acceptance gates

n/a — no issue; verified collapse-sweep candidate.

## Single source of truth

`ModelHandler.createBatchedToolUseFollowUpMessages` is now the single follow-up assembly
contract. The single-call shape is derived from it in exactly one place
(`ModelHandler.createToolUseFollowUpMessages`) instead of seven. `IModelHandler` owns nothing
of its own any more — it is a pure `Pick`, so the port can no longer drift from the class.

## Duplication and abstraction budget

Removed: seven per-handler batched-of-one wrappers, one optional interface extension that
duplicated a class member's signature, one runtime feature-detect for a method that is now
required, and one single-caller private helper in VscodeLm. No new abstraction added — the
base delegate replaces the abstract declaration it sits next to.

## Net elements (R6)

| | |
|---|---|
| Files added / deleted | **0 / 0** (12 modified) |
| Exported symbols | **0** (`^[+-]export` over the diff → no hits) |
| Classes / interfaces / enums | **0** |
| Method declarations | **15 → 10 (−5)** |
| Production LoC | **+97 / −180 = net −83** |
| Test LoC | **+2 / −2 = net 0** |
| Total LoC | **+99 / −182 = net −83** |

Method-declaration accounting — before: 1 abstract single, 7 single definitions, 5 batched
definitions, 1 VscodeLm private, 1 `IModelHandler` optional member = 15. After: 1 abstract
batched, 1 concrete base single, 7 batched definitions, 1 Responses private = 10.

Three now-unused type imports were dropped from `IModelHandler.ts`
(`AgentWorkspaceState`, `ToolFileAttachment`, `ToolResult`).

This is a genuine reduction. Honest note: the pre-implementation estimate was −96; the real
figure is **−83**, because the promoted abstract carries a real doc block and the Responses
concatenator costs more than the wrapper it replaces at that one site.

## Consumer counts (R8)

`git grep -n 'createToolUseFollowUpMessages\|createBatchedToolUseFollowUpMessages' src packages`
(excluding `packages/agent/dist`, which is untracked build output):

- **Production callers of `createToolUseFollowUpMessages`: 1** —
  `ToolUseDispatchNode.ts:615` (the non-batched loop). Still present, still resolves; it now
  binds the base class's concrete method instead of a per-handler override.
- **Production callers of `createBatchedToolUseFollowUpMessages`: 1** —
  `ToolUseDispatchNode.ts:603`. Plus the base delegate. The four former in-handler self-calls
  are gone with their wrappers.
- **`super.createToolUseFollowUpMessages` call sites: 0** — making the base concrete orphans
  no subclass.
- **Subclass coverage of the new abstract:** every concrete `ModelHandler` subclass reaches a
  definition. `ModelHandlerXAI`/`DashScope` → `ModelHandlerOpenAI`;
  `Kimi`/`DeepSeek`/`GLM`/`MiniMax` → `ReasoningModelHandlerOpenAI` → `ModelHandlerOpenAI`;
  `ModelHandlerCodex` → `ModelHandlerOpenAIResponse`; Anthropic, Google Interactions,
  OpenRouter Native, VscodeLm, Validation define their own. Confirmed by `npm run typecheck`
  passing — an uncovered subclass would be a hard error on the abstract.
- **Test consumers: 0 edits needed.** The five fake-handler suites
  (`ToolUseDispatchParallel`, `SessionResumeRetrieval`, `followUp/*`) build handlers through
  `testModelCell(handler: unknown, …)` / `roundModelHandler(overrides: Record<string, unknown>)`
  and cast `as unknown as ToolUseRoundServices<unknown>`, so requiring the port member never
  reaches them. The only test change is dropping two now-unnecessary `!` non-null assertions
  on `createBatchedToolUseFollowUpMessages` that existed solely because the port member used
  to be optional.

## Host impact

Extension: none — all edits are under `src/agent/`, no host file touched, no new `@agent/*`
deep import, no `vscode` import moved.

Desktop: none.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — **PASS** (full workspace: root, test-kernel, `@texra-ai/agent`
  declaration build + 725 declarations validated, cli incl. `tsconfig.scripts.json`,
  trace-viewer, desktop main/preload/renderer). This change is entirely type-contract
  surgery, so this is the load-bearing gate — `compile:fast` would prove nothing.
- `npx vitest run` over the full blast radius — **PASS, 30 files / 446 tests** (1 file, 4
  tests skipped, pre-existing): `ModelHandlerAnthropic`, `ModelHandlerOpenAIToolUse`,
  `GoogleInteractionsToolUse`, `GoogleInteractionsLive`, `ModelHandlerDeepSeek`,
  `ModelHandlerVscodeLm`, `ModelHandlerOpenAIResponse`, `tools/BashToolErrorFeedback`,
  `tools/BashTool`, `ToolUseDispatchParallel`, `SessionResumeRetrieval`, `agent/followUp/**`.
- Second run — **PASS, 39 tests**: `ModelHandlerOpenRouterNative`,
  `GoogleInteractionsMessages`.
- `npm run lint` — **PASS** (clean).
- `npm run check:dead-code-ratchet` — **PASS**, 8 current vs 8 baselined, no new findings.
- No lockfile churn: `git status` after `CI=true corepack pnpm install` shows only the 12
  intended source files.

**Zero new tests**, per the repo's testing budget: this is a behavior-preserving refactor.
