### PR TITLE
refactor(cli): run the three hand-promisified spawns through execa

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -72,6 +72,7 @@
     "cli-truncate": "^6.1.1",
     "diff": "^9.0.0",
     "esbuild": "^0.28.2",
+    "execa": "^10.0.1",
     "ink": "^7.1.1",
     "is-network-error": "^1.3.2",
     "lru-cache": "^11.5.2",

--- a/packages/cli/src/commands/tools.ts
+++ b/packages/cli/src/commands/tools.ts
@@ -1,6 +1,5 @@
-import { spawn } from 'node:child_process';
-
 import { defineCommand } from 'citty';
+import { execa } from 'execa';
 import { parse as shellParse } from 'shell-quote';
 
 import { CliExitCode } from '../runtime/exitCodes';
@@ -106,36 +105,33 @@ async function toggleTool(
 // provide. `command` always comes from the static EXTERNAL_TOOL_DEFS registry,
 // never from user or LLM input. POSIX commands run as argv; Windows uses the
 // shell so npm/gh `.cmd` shims resolve through PATHEXT.
-function shellRun(command: string): Promise<number> {
-  return new Promise((resolve) => {
-    const wireChild = (child: ReturnType<typeof spawn>) => {
-      child.on('error', () => resolve(CliExitCode.AgentError));
-      child.on('exit', (code) => resolve(code ?? CliExitCode.AgentError));
-    };
-
-    let parts: string[];
-    try {
-      const parsed = shellParse(command);
-      if (!parsed.every((arg): arg is string => typeof arg === 'string')) {
-        resolve(CliExitCode.AgentError);
-        return;
-      }
-      parts = parsed;
-    } catch {
-      resolve(CliExitCode.AgentError);
-      return;
+async function shellRun(command: string): Promise<number> {
+  // reject: false — a spawn failure and a non-zero exit both map to an exit
+  // code here, never to a throw. The parse gates both branches: on Windows the
+  // parts are discarded, but a command carrying shell operators still parses to
+  // non-strings and is refused before it reaches the shell.
+  let parts: string[];
+  try {
+    const parsed = shellParse(command);
+    if (!parsed.every((arg): arg is string => typeof arg === 'string')) {
+      return CliExitCode.AgentError;
     }
-    if (process.platform === 'win32') {
-      wireChild(spawn(command, { shell: true, stdio: 'inherit' }));
-      return;
-    }
-    const [cmd, ...args] = parts;
-    if (!cmd) {
-      resolve(CliExitCode.AgentError);
-      return;
-    }
-    wireChild(spawn(cmd, args, { stdio: 'inherit' }));
-  });
+    parts = parsed;
+  } catch {
+    return CliExitCode.AgentError;
+  }
+  if (process.platform === 'win32') {
+    const result = await execa(command, {
+      shell: true,
+      stdio: 'inherit',
+      reject: false,
+    });
+    return result.exitCode ?? CliExitCode.AgentError;
+  }
+  const [cmd, ...args] = parts;
+  if (!cmd) return CliExitCode.AgentError;
+  const result = await execa(cmd, args, { stdio: 'inherit', reject: false });
+  return result.exitCode ?? CliExitCode.AgentError;
 }
 
 function toolGuideResult(

--- a/packages/cli/src/runtime/browser.ts
+++ b/packages/cli/src/runtime/browser.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from 'node:child_process';
+import { execa } from 'execa';
 
 import { extractErrorMessage } from '@utils/errors/errorMessage';
 
@@ -36,36 +36,22 @@ export function resolveBrowserLaunch(
   }
 }
 
-function launchBrowser(url: string): Promise<void> {
+async function launchBrowser(url: string): Promise<void> {
   const launch = resolveBrowserLaunch(url);
-  return new Promise((resolve, reject) => {
-    let child: ChildProcess;
-    try {
-      child = spawn(launch.command, launch.args, {
-        stdio: 'ignore',
-      });
-    } catch (error) {
-      rejectBrowserLaunch(error);
-      return;
-    }
-
-    child.once('close', (code) => {
-      if (code === 0) {
-        resolve();
-        return;
-      }
-      rejectBrowserLaunch(
-        new Error(`${launch.command} exited with code ${code ?? 'unknown'}`),
-      );
-    });
-    child.once('error', rejectBrowserLaunch);
-
-    function rejectBrowserLaunch(error: unknown): void {
-      const message =
-        extractErrorMessage(error) ?? 'unknown browser launch error';
-      reject(new Error(`Could not open the browser automatically: ${message}`));
-    }
+  // reject: false — a spawn failure (no `xdg-open` on a headless box) and a
+  // non-zero exit are the same "could not open a browser" outcome here.
+  const result = await execa(launch.command, launch.args, {
+    stdio: 'ignore',
+    reject: false,
   });
+  if (!result.failed) return;
+  // `cause` carries the spawn error ("spawn xdg-open ENOENT"); execa's own
+  // `message` is not used because it embeds the argv, and the argv is the
+  // sign-in URL.
+  const message =
+    extractErrorMessage(result.cause) ??
+    `${launch.command} exited with code ${result.exitCode ?? 'unknown'}`;
+  throw new Error(`Could not open the browser automatically: ${message}`);
 }
 
 export function openBrowser(

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -1,6 +1,6 @@
-import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
+import { execa } from 'execa';
 import { z } from 'zod';
 
 import { parseJsonWith } from '@common/parsing/safeParseJson';
@@ -233,16 +233,18 @@ export async function fetchLatestHomebrewFormulaVersion(options?: {
   };
 }
 
-function runCliUpdate(method: InstallMethod): Promise<boolean> {
+async function runCliUpdate(method: InstallMethod): Promise<boolean> {
   const { command, args } = buildUpdateCommand(method);
-  return new Promise<boolean>((resolve) => {
-    // Needs true stdio:'inherit' — the package manager may print an
-    // interactive prompt or password request, which executeCommand's
-    // buffered/streamed output cannot forward.
-    const child = spawn(command, args, { stdio: 'inherit', shell: true });
-    child.on('error', () => resolve(false));
-    child.on('close', (code) => resolve(code === 0));
+  // Needs true stdio:'inherit' — the package manager may print an
+  // interactive prompt or password request, which executeCommand's
+  // buffered/streamed output cannot forward. `shell: true` with an args array
+  // concatenates unquoted, which the brew case relies on for its `&&` chain.
+  const result = await execa(command, args, {
+    stdio: 'inherit',
+    shell: true,
+    reject: false,
   });
+  return !result.failed;
 }
 
 export interface CheckCliUpdateAvailableOptions {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -672,6 +672,9 @@ importers:
       esbuild:
         specifier: ^0.28.2
         version: 0.28.2
+      execa:
+        specifier: ^10.0.1
+        version: 10.0.1
       ink:
         specifier: ^7.1.1
         version: 7.1.1(patch_hash=db8f5740efe4e780f6517316175dfed1e68d62e76e533c06bf0b8f5e94b48aa6)(@types/react@19.2.18)(react@19.2.8)

--- a/src/test-kernel/cli/ToolsCommand.vitest.ts
+++ b/src/test-kernel/cli/ToolsCommand.vitest.ts
@@ -6,12 +6,12 @@ const mocks = vi.hoisted(() => ({
   initCliPlatform: vi.fn(),
   readCliToolGuide: vi.fn(),
   setCliToolEnabled: vi.fn(),
-  spawn: vi.fn(),
+  execa: vi.fn(),
 }));
 
-vi.mock('node:child_process', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('node:child_process')>()),
-  spawn: mocks.spawn,
+vi.mock('execa', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('execa')>()),
+  execa: mocks.execa,
 }));
 
 vi.mock('@cli/runtime/initPlatform', () => ({
@@ -50,7 +50,7 @@ describe('CLI tools command', () => {
       command: 'echo install',
     });
     mocks.setCliToolEnabled.mockReset().mockResolvedValue(true);
-    mocks.spawn.mockReset();
+    mocks.execa.mockReset();
     stdoutSpy = spyOnStreamWrite(process.stdout, (chunk) => {
       stdout += chunk;
     });
@@ -111,7 +111,7 @@ describe('CLI tools command', () => {
 
     expect(result.exitCode).toBe(0);
     expect(stderr).toBe('');
-    expect(mocks.spawn).not.toHaveBeenCalled();
+    expect(mocks.execa).not.toHaveBeenCalled();
     expect(JSON.parse(stdout)).toEqual({
       id: 'codex',
       operation: 'install',
@@ -132,7 +132,7 @@ describe('CLI tools command', () => {
     expect(result.exitCode).toBe(2);
     expect(stdout).toBe('');
     expect(stderr).toContain('Cannot combine --output-format json|ndjson');
-    expect(mocks.spawn).not.toHaveBeenCalled();
+    expect(mocks.execa).not.toHaveBeenCalled();
   });
 
   it('reports missing install commands before structured --run conflicts', async () => {
@@ -153,7 +153,7 @@ describe('CLI tools command', () => {
     expect(stderr).toContain(
       'No install command is registered for github-pr-subscription.',
     );
-    expect(mocks.spawn).not.toHaveBeenCalled();
+    expect(mocks.execa).not.toHaveBeenCalled();
   });
 
   it('rejects POSIX guide commands with shell operators instead of dropping them', async () => {
@@ -166,7 +166,7 @@ describe('CLI tools command', () => {
 
     expect(result.exitCode).toBe(1);
     expect(stdout).toBe('Install help\n');
-    expect(mocks.spawn).not.toHaveBeenCalled();
+    expect(mocks.execa).not.toHaveBeenCalled();
   });
 
   it('emits structured auth guides without launching the external login', async () => {
@@ -184,7 +184,7 @@ describe('CLI tools command', () => {
 
     expect(result.exitCode).toBe(0);
     expect(stderr).toBe('');
-    expect(mocks.spawn).not.toHaveBeenCalled();
+    expect(mocks.execa).not.toHaveBeenCalled();
     expect(JSON.parse(stdout)).toMatchObject({
       kind: 'tool-guide',
       guide: {


### PR DESCRIPTION
## Summary

Three CLI call sites each wrapped `child_process.spawn` in a hand-rolled
`new Promise` with `error` + `close`/`exit` listeners, only to turn the child
into "did it succeed" or "what exit code":

- `runtime/browser.ts` `launchBrowser` — 29 lines, including a hoisted
  `rejectBrowserLaunch` function declaration referenced before its own
  definition.
- `runtime/updateChecker.ts` `runCliUpdate` — 9 lines.
- `commands/tools.ts` `shellRun` — 29 lines with a `wireChild` closure and four
  separate `resolve()` early-outs.

`execa(..., { reject: false })` resolves with exactly that information, so each
collapses to a single `await` plus the mapping.

**Semantics verified by execution, not by reading docs.** Against the installed
execa 10.0.1:

```
exit 3            → { exitCode: 3,         failed: true }
ENOENT            → { exitCode: undefined, failed: true, code: 'ENOENT',
                      cause.message: 'spawn <cmd> ENOENT' }
SIGKILL           → { exitCode: undefined, failed: true, signal: 'SIGKILL' }
shell:true + args → concatenated unquoted; `echo one && echo two` → "one\ntwo",
                    byte-identical to node's spawn with the same options
```

So `code ?? AgentError` on the `exit` event becomes `exitCode ?? AgentError`
with identical results for every case including a signal kill (old: `code` is
`null`; new: `exitCode` is `undefined`), and brew's
`brew update && brew upgrade texra` still runs as a shell chain rather than
`brew` receiving `&&` as a literal argument.

Two things deliberately preserved:

1. `browser.ts` still builds its own failure message from `result.cause`
   (`'spawn xdg-open ENOENT'`) and `result.exitCode`. execa's own `message`
   embeds the argv — and the argv is the OAuth sign-in URL. Message text is
   unchanged from before.
2. `shellRun` keeps the `shell-quote` parse **ahead of** the win32 branch. The
   parsed parts are discarded on Windows (the raw string goes to the shell), but
   the parse is what refuses a command carrying shell operators before it
   reaches the shell — pinned by
   `'rejects POSIX guide commands with shell operators instead of dropping them'`.
   Reordering it to the "obvious" place would have been a silent behaviour
   change.

The two `// Not routed through executeCommand` comments are accurate and stay:
these three sites need real `stdio: 'inherit'`/`'ignore'`, which
`executeCommand`'s buffered output cannot provide.

## Issue acceptance gates

n/a — found by a collapse sweep over `process-spawn` sites, no issue.

## Single source of truth

No new owner introduced. `execa` (already the repo's spawn substrate — 3 other
CLI/extension sites, plus `packages/agent`) now covers the remaining
hand-promisified CLI spawns. `pager.ts` correctly stays on `spawnSync` and is
untouched.

## Duplication and abstraction budget

Removed three copies of the same promisify-a-child pattern. No new abstraction —
there is no shared helper here, each site awaits `execa` directly. (A
`runInherit()` helper would have been a 3-caller wrapper over one library call;
not worth it, and each site's failure mapping differs.)

## Net elements (R6)

**Net −15 production LoC.** Smaller than a pure line-for-line swap would give,
because three of the removed lines were replaced by comments recording facts
that were previously only implicit (the `&&`-chain dependence on unquoted
concatenation, the argv-in-message hazard, the parse-gates-Windows ordering).
Stating that plainly rather than quoting a bigger number.

| | files | exports | functions | LoC |
|---|---|---|---|---|
| production | 3 changed | ±0 | −2 (`rejectBrowserLaunch`, `wireChild` closures) | +53 / −69 = **−16** |
| manifest | `packages/cli/package.json` | — | — | **+1** |
| lockfile | `pnpm-lock.yaml` | — | — | +3 (generated) |
| tests | 1 changed (mock retarget only) | ±0 | ±0 | +10 / −10 = **0** |

```
 1  0  packages/cli/package.json
27 31  packages/cli/src/commands/tools.ts
15 29  packages/cli/src/runtime/browser.ts
11  9  packages/cli/src/runtime/updateChecker.ts
 3  0  pnpm-lock.yaml
10 10  src/test-kernel/cli/ToolsCommand.vitest.ts
```

**Dependency decision, made consciously rather than left to hoisting:** `execa`
is now declared in `packages/cli` devDependencies (where every other bundled dep
lives — `citty`, `ink`, `semver`, …). It was already imported by
`packages/cli/src/commands/clone.ts` and resolved only through root hoisting, so
this fixes a pre-existing phantom rather than creating one. Lockfile delta is
the 3 generated lines above and nothing else. `shell-quote` is still a phantom
in this package; not touched here.

## Consumer counts (R8)

No export added or removed — all three changed functions are module-private
(`launchBrowser`, `runCliUpdate`, `shellRun`). Greps run:

- `rg "from 'execa'|from 'shell-quote'" packages/cli/src` — execa now in 4 files.
- `rg "node:child_process" src/test-kernel/cli` — mocks live in
  `ClipboardText.vitest.ts`, `Pager.vitest.ts`, `ToolsCommand.vitest.ts`. Only
  the last one mocked `spawn` for a path this PR moves; retargeted to mock
  `execa`. Its five assertions are all `not.toHaveBeenCalled()`, so they carry
  over unchanged. `Pager.vitest.ts` mocks `spawnSync` and is unaffected.
- `rg 'runCliUpdate'` — one caller (`updateChecker.ts:380`).
- `rg 'launchBrowser|openBrowser|tryOpenBrowser'` — `UpdateChecker.vitest.ts`
  and `BrowserLaunch.vitest.ts` mock neither spawn nor execa;
  `BrowserLaunch.vitest.ts` exercises only the pure `resolveBrowserLaunch`.

## Host impact

Extension: none. Desktop: none. CLI: `texra tools install|auth --run`, the
update prompt's "update now" path, and every browser launch (sign-in,
`texra install-github-action`) now go through execa. Observable behaviour and
error message text are unchanged.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean (includes `@texra-ai/cli` `tsconfig.json` **and**
  `tsconfig.scripts.json` via `typecheck:cli`).
- `npx vitest run` on `ToolsCommand`, `BrowserLaunch`, `UpdateChecker`, `Pager`,
  `InstallGithubAction`, `ChatgptLoginBrowser`, `CliSupabaseAuth` — 7 files,
  75/75 pass. **No new test.**
- `npx eslint` + `npx prettier --check` on the four changed source files and
  `packages/cli/package.json` — clean.
- `CI=true corepack pnpm install --no-frozen-lockfile` under pnpm 11.5.2 (the
  project's pinned version) — lockfile delta reviewed line by line.
- execa semantics reproduced by a standalone script (outputs quoted above).
