### PR TITLE
fix(latex): return the compiled PDF path from compileLatex2Pdf

### DIFF
--- a/packages/desktop/src/main/desktopPreviewHost.ts
+++ b/packages/desktop/src/main/desktopPreviewHost.ts
@@ -6,7 +6,6 @@ import { isLatexFile } from '@common/files/fileTypeUtils';
 import type { ExternalOpener } from '@hosts/uiHosts';
 import type { FileLocation } from '@shared/schemas';
 import type { BuildDisplayFn } from '@tools/approval/latexPreview';
-import { getFileStem } from '@utils/core';
 import { createExternalLocation } from '@utils/files/fileLocation';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -102,10 +101,6 @@ export function createDesktopPreviewHost(
     }
 
     const outputDirectory = path.dirname(sourcePath);
-    const pdfPath = path.join(
-      outputDirectory,
-      `${getFileStem(sourcePath)}.pdf`,
-    );
     const { hasLatexCompiler } = await import('@latex/latexToolchain');
     if (!(await hasLatexCompiler())) {
       await fail(
@@ -129,10 +124,12 @@ export function createDesktopPreviewHost(
       await fail(
         `LaTeX build failed for ${sourcePath}. See the LaTeX log next to the source for details.`,
       );
+      return;
     }
 
     // Confirm the PDF is on disk before rendering it (the iframe will
     // load nothing and present a blank surface otherwise).
+    const { pdfPath } = built;
     await ensurePathExists(pdfPath);
 
     if (tryShowPdfInRenderer(pdfPath, path.basename(pdfPath))) return;

--- a/src/agent/implementations/flows/reflection/output/LatexDiffManager.ts
+++ b/src/agent/implementations/flows/reflection/output/LatexDiffManager.ts
@@ -419,10 +419,6 @@ export class LatexDiffManager {
     }
 
     const { executionId, runDirectory } = this.fileService;
-    const compiledPdfPath = path.join(
-      buildDir,
-      `${path.basename(diffLocation.absolutePath).replace(/\.tex$/i, '')}.pdf`,
-    );
     try {
       const artifact = await publishCompiledPdfArtifact({
         runDirectory,
@@ -430,7 +426,7 @@ export class LatexDiffManager {
         round,
         displayName: path.basename(diffLocation.absolutePath),
         source: sourceLocation,
-        compiledPdfPath,
+        compiledPdfPath: compiled.pdfPath,
         pdfStemSuffix,
       });
       return { diffLocation, artifact };
@@ -440,7 +436,7 @@ export class LatexDiffManager {
         {
           data: {
             diffFile: diffLocation.absolutePath,
-            compiledPdfPath,
+            compiledPdfPath: compiled.pdfPath,
             error,
           },
         },

--- a/src/agent/implementations/flows/reflection/output/compileCheck.ts
+++ b/src/agent/implementations/flows/reflection/output/compileCheck.ts
@@ -254,9 +254,6 @@ async function compileOne(
   failureLogExcerpt: string;
   artifact: CompiledPdfArtifact | null;
 }> {
-  // compiledBasename is the actual on-disk filename LaTeX engines use when
-  // naming their .log; it may differ from displayName when file.source is set.
-  const compiledBasename = path.basename(outputFile.location.absolutePath);
   // Full relative path keeps two outputs sharing a basename distinct
   // (ch1/main.tex vs ch2/main.tex). Strip the leading r<N>/ segment because
   // it is already added explicitly as `r${currentRound}_` below — without
@@ -365,8 +362,7 @@ async function compileOne(
     await clearStaleLogs();
     const artifact = await tryPublishArtifact({
       ...target,
-      compiledBasename,
-      buildDir,
+      compiledPdfPath: compileResult.pdfPath,
     });
     return { failure: null, failureLogExcerpt: '', artifact };
   }
@@ -439,8 +435,7 @@ async function writeCompileFailure({
 }
 
 interface TryPublishArtifactArgs extends CompileTarget {
-  compiledBasename: string;
-  buildDir: string;
+  compiledPdfPath: string;
 }
 
 /**
@@ -454,14 +449,9 @@ async function tryPublishArtifact({
   displayName,
   currentRound,
   outputFile,
-  compiledBasename,
-  buildDir,
+  compiledPdfPath,
   executionId,
 }: TryPublishArtifactArgs): Promise<CompiledPdfArtifact | null> {
-  const compiledPdfPath = path.join(
-    buildDir,
-    `${compiledBasename.replace(/\.tex$/i, '')}.pdf`,
-  );
   try {
     const artifact = await publishCompiledPdfArtifact({
       runDirectory: opts.runDirectory,

--- a/src/controllers/progressView/ChatExportController.ts
+++ b/src/controllers/progressView/ChatExportController.ts
@@ -139,14 +139,10 @@ export class ChatExportController {
     const location = pathToLocation(absolutePath);
     const compiled = await compileLatex2Pdf(location);
 
-    const pdfPath = compiled.ok
-      ? absolutePath.replace(/\.tex$/, '.pdf')
-      : undefined;
-
     return {
       storagePath,
       absolutePath,
-      pdfPath,
+      pdfPath: compiled.ok ? compiled.pdfPath : undefined,
       logTail: compiled.ok ? undefined : compiled.logTail,
     };
   }

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -153,13 +153,19 @@ export class LatexMediaManager {
             return undefined;
           }
 
-          const pdfFile = path.join(
-            buildDir,
-            path.basename(file.absolutePath).replace(/\.tex$/, '.pdf'),
-          );
-          const pdfLocation = pathToLocation(pdfFile);
-          if (!(await AbsoluteFS.exists(pdfLocation.absolutePath)))
+          const pdfLocation = pathToLocation(compiled.pdfPath);
+          if (!(await AbsoluteFS.exists(pdfLocation.absolutePath))) {
+            this.logger.warn(
+              'LaTeX reported success but no PDF was written; skipping',
+              {
+                data: {
+                  sourceFile: file.absolutePath,
+                  pdfFile: pdfLocation.absolutePath,
+                },
+              },
+            );
             return undefined;
+          }
 
           // Stat failures are noisier than other compile failures because an
           // existing-but-unreadable PDF likely indicates a permissions/IO bug.

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -44,20 +44,11 @@ const LaTeXCompileOptionsSchema = z.object({
 type LaTeXCompileOptions = z.input<typeof LaTeXCompileOptionsSchema>;
 
 /**
- * Read the tail of the `.log` file a LaTeX engine drops next to its output
- * (`<basename-without-ext>.log` inside `outDir`). Shared by every
- * {@link compileLatex2Pdf} caller so a failed compile always comes with
- * enough context to act on, not just a boolean.
+ * Read the tail of the `.log` file a LaTeX engine drops next to its output.
+ * Shared by every {@link compileLatex2Pdf} caller so a failed compile always
+ * comes with enough context to act on, not just a boolean.
  */
-async function readCompileLogTail(
-  outDir: string,
-  latexFile: string,
-): Promise<string> {
-  // Strip whatever extension the source actually has (.tex/.ltx/.latex are
-  // all compilable, per isLatexFile) — the engine's .log file is always
-  // named after the source with its own extension removed, not just .tex.
-  const compiledBasename = path.basename(latexFile, path.extname(latexFile));
-  const logAbs = path.join(outDir, `${compiledBasename}.log`);
+async function readCompileLogTail(logAbs: string): Promise<string> {
   try {
     const full = await AbsoluteFS.read(logAbs);
     return splitContentLines(full).slice(-LOG_TAIL_LINES).join('\n');
@@ -142,19 +133,20 @@ export function buildLatexSearchParts(input: {
 /**
  * Result of a {@link compileLatex2Pdf} attempt. A discriminated union on `ok`
  * so the type system guarantees {@link LOG_TAIL_LINES}'s worth of the
- * engine's `.log` file tail is present whenever compilation fails, instead of
- * every caller needing a defensive fallback for a theoretically-missing
- * `logTail`.
+ * engine's `.log` file tail is present whenever compilation fails, and the
+ * path the engine wrote its PDF to whenever it succeeds — instead of every
+ * caller re-deriving that path from the source name with its own extension
+ * rule.
  */
 export type CompileLatex2PdfResult =
-  { ok: true } | { ok: false; logTail: string };
+  { ok: true; pdfPath: string } | { ok: false; logTail: string };
 
 /**
  * Compile a LaTeX file to PDF
  * @param latexLocation FileLocation for the LaTeX file
  * @param options Compilation options (channel defaults to module CHANNEL)
- * @returns `{ ok: true } | { ok: false, logTail }` -- `logTail` is always
- * populated on failure.
+ * @returns `{ ok: true, pdfPath } | { ok: false, logTail }` -- `pdfPath` is the
+ * absolute path the engine wrote to; `logTail` is always populated on failure.
  */
 export async function compileLatex2Pdf(
   latexLocation: FileLocation,
@@ -167,6 +159,13 @@ export async function compileLatex2Pdf(
   const { outputDirectory, compiler, timeout, extraInputDirs } = parsed;
   const latexFile = latexLocation.absolutePath;
   const outDir = outputDirectory ?? path.dirname(latexFile);
+  // Both engine outputs are named after the source with the source's own
+  // extension removed (.tex/.ltx/.latex are all compilable, per isLatexFile),
+  // so one stem owns both the `.log` we read back and the `.pdf` we report.
+  const outputStem = path.join(
+    outDir,
+    path.basename(latexFile, path.extname(latexFile)),
+  );
   try {
     await AbsoluteFS.ensureDir(outDir);
 
@@ -246,13 +245,16 @@ export async function compileLatex2Pdf(
 
     if (result && result.success) {
       log.debug(`Successfully compiled ${latexFile}`);
-      return { ok: true };
+      return { ok: true, pdfPath: `${outputStem}.pdf` };
     }
-    return { ok: false, logTail: await readCompileLogTail(outDir, latexFile) };
+    return {
+      ok: false,
+      logTail: await readCompileLogTail(`${outputStem}.log`),
+    };
   } catch (err) {
     const message = toErrorMessage(err);
     log.error(`Error compiling LaTeX: ${message}`);
-    const tail = await readCompileLogTail(outDir, latexFile);
+    const tail = await readCompileLogTail(`${outputStem}.log`);
     return {
       ok: false,
       logTail: `Error compiling LaTeX: ${message}\n\n${tail}`,

--- a/src/test-kernel/agent/output/CompileCheck.vitest.ts
+++ b/src/test-kernel/agent/output/CompileCheck.vitest.ts
@@ -26,12 +26,16 @@ interface FakeCompileOptions {
   outputDirectory?: string;
 }
 
+// The compiled PDF the fake engine reports; no test seeds it, so artifact
+// publication is a no-op — the path only has to be a plausible absolute one.
+const COMPILED_PDF = '/build/main.pdf';
+
 const mocks = vi.hoisted(() => ({
   compileLatex2Pdf: vi.fn(
     async (
       _location: FileLocation,
       _options?: FakeCompileOptions,
-    ): Promise<CompileLatex2PdfResult> => ({ ok: true }),
+    ): Promise<CompileLatex2PdfResult> => ({ ok: true, pdfPath: COMPILED_PDF }),
   ),
   hasLatexCompiler: vi.fn(async () => true),
 }));
@@ -75,7 +79,9 @@ function failedExcerpt(result: CompileCheckResult): string {
 
 describe('runCompileCheck', () => {
   beforeEach(() => {
-    mocks.compileLatex2Pdf.mockReset().mockResolvedValue({ ok: true });
+    mocks.compileLatex2Pdf
+      .mockReset()
+      .mockResolvedValue({ ok: true, pdfPath: COMPILED_PDF });
     mocks.hasLatexCompiler.mockReset().mockResolvedValue(true);
   });
 
@@ -211,7 +217,10 @@ describe('runCompileCheck', () => {
 
     // Re-run the same round (e.g. after a repaired retry); this time the
     // compile succeeds.
-    mocks.compileLatex2Pdf.mockResolvedValueOnce({ ok: true });
+    mocks.compileLatex2Pdf.mockResolvedValueOnce({
+      ok: true,
+      pdfPath: COMPILED_PDF,
+    });
     const secondResult = await runCompileCheck(ctx, 0);
     expect(secondResult.compileResult?.status).toBe('ok');
 

--- a/src/test-kernel/desktop/DesktopPreviewHost.vitest.ts
+++ b/src/test-kernel/desktop/DesktopPreviewHost.vitest.ts
@@ -14,8 +14,25 @@ import { loadSourceModule } from './loadSourceModule.ts';
 
 const mocks = createModuleMocks();
 
+type FakeCompile = (location: { absolutePath: string }) => Promise<{
+  ok: boolean;
+  pdfPath?: string;
+  logTail?: string;
+}>;
+
+/**
+ * Stand-in LaTeX engine: succeeds and reports the PDF it "wrote" next to the
+ * source, the way the real `compileLatex2Pdf` does.
+ */
+function fakeCompiler() {
+  return vi.fn(async (location: { absolutePath: string }) => ({
+    ok: true,
+    pdfPath: location.absolutePath.replace(/\.tex$/, '.pdf'),
+  }));
+}
+
 async function loadDesktopPreviewHost(
-  compileLatex2Pdf = vi.fn(async () => ({ ok: true })),
+  compileLatex2Pdf: FakeCompile = fakeCompiler(),
   access?: (filePath: string) => Promise<void>,
   checkToolInstalled = vi.fn(async () => true),
 ): Promise<typeof import('@desktop/main/desktopPreviewHost')> {
@@ -143,7 +160,7 @@ describe('desktop preview host', () => {
   });
 
   it('builds LaTeX previews and opens the generated PDF path', async () => {
-    const compileLatex2Pdf = vi.fn(async () => ({ ok: true }));
+    const compileLatex2Pdf = fakeCompiler();
     const { createDesktopPreviewHost } =
       await loadDesktopPreviewHost(compileLatex2Pdf);
     const { dir, texPath, pdfPath } = await makeTexFixture('preview');
@@ -160,7 +177,7 @@ describe('desktop preview host', () => {
   });
 
   it('opens compile-preview PDF targets without running LaTeX', async () => {
-    const compileLatex2Pdf = vi.fn(async () => ({ ok: true }));
+    const compileLatex2Pdf = fakeCompiler();
     const checkToolInstalled = vi.fn(async () => true);
     const { createDesktopPreviewHost } = await loadDesktopPreviewHost(
       compileLatex2Pdf,
@@ -181,7 +198,7 @@ describe('desktop preview host', () => {
   });
 
   it('reports missing LaTeX toolchains before compiling preview sources', async () => {
-    const compileLatex2Pdf = vi.fn(async () => ({ ok: true }));
+    const compileLatex2Pdf = fakeCompiler();
     const checkToolInstalled = vi.fn(async () => false);
     const { createDesktopPreviewHost } = await loadDesktopPreviewHost(
       compileLatex2Pdf,

--- a/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
+++ b/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
@@ -135,7 +135,7 @@ describe('LatexMediaManager PDF compilation', () => {
         const outputDirectory = options.outputDirectory!;
         await mkdir(outputDirectory, { recursive: true });
         await writeFile(compiledPdfPath, 'compiled pdf');
-        return { ok: true };
+        return { ok: true, pdfPath: compiledPdfPath };
       },
     );
 

--- a/src/test-kernel/latex/TexTools.vitest.ts
+++ b/src/test-kernel/latex/TexTools.vitest.ts
@@ -65,12 +65,15 @@ describe('compileLatex2Pdf structured return', () => {
     await installPlatform({ workspacePath });
   });
 
-  it('returns { ok: true } with no logTail on a successful compile', async () => {
+  it('returns { ok: true } with the engine PDF path and no logTail on success', async () => {
     mocks.runToolWithCheck.mockResolvedValue(execResult(true));
 
     const result = await compile();
 
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({
+      ok: true,
+      pdfPath: path.join(workspacePath, 'build', 'main.pdf'),
+    });
   });
 
   it('surfaces the last 200 lines of the engine log as logTail on a failed compile', async () => {
@@ -158,7 +161,7 @@ describe('compileLatex2Pdf logger seam', () => {
 
     const result = await compile();
 
-    expect(result).toEqual({ ok: true });
+    expect(result.ok).toBe(true);
     expect(warn).toHaveBeenCalledWith(
       LATEX_COMMANDS_CHANNEL,
       expect.stringContaining('latexmk not found'),
@@ -179,7 +182,7 @@ describe('compileLatex2Pdf logger seam', () => {
       },
     );
 
-    expect(result).toEqual({ ok: true });
+    expect(result.ok).toBe(true);
     expect(warn).toHaveBeenCalledWith(
       'pinnedCompile',
       expect.stringContaining('latexmk not found'),


### PR DESCRIPTION
## Summary

`compileLatex2Pdf` knows exactly where the LaTeX engine wrote its PDF — it
computes the same stem to find the engine's `.log` — and then threw that fact
away, returning a bare `{ ok: true }`. Every caller that wanted the PDF
re-derived the path from the source name, each with its own extension rule:

| site | rule |
|---|---|
| `compileCheck.ts` (`tryPublishArtifact`) | `basename.replace(/\.tex$/i, '')` + `buildDir` |
| `LatexDiffManager.ts` | `basename.replace(/\.tex$/i, '')` + `buildDir` |
| `LatexMediaManager.ts` | `basename.replace(/\.tex$/, '')` — case-**sensitive** |
| `ChatExportController.ts` | `absolutePath.replace(/\.tex$/, '.pdf')` — case-sensitive |
| `desktopPreviewHost.ts` | `getFileStem()`, computed *before* the compile |

One of those is a live defect. `LatexMediaManager` selects its inputs with
`hasExtension(file.absolutePath, '.tex')`, which is case-**in**sensitive by
contract (`src/utils/core/pathCore.ts`: `hasExtension('Paper.TEX', '.tex') //
true`), then strips the extension case-**sensitively**. `Paper.TEX` compiles to
`build/Paper.pdf`, the derived path is `build/Paper.TEX`, the `exists` probe
fails, and the function returns `undefined` — a successfully compiled PDF
dropped with no log line at all (§15 silent degradation).

The producer now returns `{ ok: true; pdfPath }` and the callers take it.

Two of the five sites were **not** latent bugs and are documented as such
rather than sold as fixes: `compileCheck` pre-filters with
`hasExtension(…, '.tex')` before its `/i` strip, and `LatexDiffManager`'s
name comes from its own writer. They are collapsed because the derivation is
redundant, not because they misbehave.

`TikzPictureManager.ts` also re-derives a PDF path, and is deliberately left
alone: it probes for the PDF *after a failed compile too* (pdflatex often
leaves a usable PDF on a nonzero exit), so routing it through the
success-only `pdfPath` would either change that behavior or need a ternary.
Its stem is generated by `createStandalone`, so the derivation is provably
correct there.

## Issue acceptance gates

No issue — found by the latex-pipeline collapse sweep.

## Single source of truth

`src/latex/texTools.ts` now owns the "what did the engine name its outputs"
rule for both files it produces: one `outputStem` local (source basename minus
whatever extension it actually had) feeds the `.log` read-back and the
returned `.pdf` path. `readCompileLogTail` now takes the resolved log path
instead of re-deriving the stem itself.

## Duplication and abstraction budget

Removed: 5 re-derivations of the PDF path across 3 hosts and 4 different
extension-stripping spellings; 1 duplicate stem derivation inside `texTools`
itself. Added: **no** new module, export, or helper — the stem is one local in
the function that already had every input for it.

`TryPublishArtifactArgs` loses two fields (`compiledBasename`, `buildDir`) and
gains one (`compiledPdfPath`). The stale comment claiming `compiledBasename`
was "the on-disk filename LaTeX engines use when naming their `.log`" is
deleted with the local — grep showed all three of its uses were PDF-path uses.

## Net elements (R6)

Honest accounting:

- Files: 6 production modified, 4 test modified. 0 added, 0 deleted.
- Exported symbols: ±0 (`^[+-]export` over the diff: one changed line, the
  `CompileLatex2PdfResult` type alias — widened, not added).
- Interfaces/classes/enums: ±0. `TryPublishArtifactArgs`: −2 fields, +1 field.
  `CompileLatex2PdfResult`: +1 field on the `ok: true` member.
  Imports: −1 (`getFileStem` in `desktopPreviewHost.ts`).
- Functions: ±0. `readCompileLogTail` loses a parameter.
- **Net LoC: −13 production** (+44 / −57), **+29 test** (+41 / −12).

The test line count goes **up**, and no new test case was added. The +29 is a
shared `fakeCompiler()` stub and its type in `DesktopPreviewHost.vitest.ts`
(replacing four copies of `vi.fn(async () => ({ ok: true }))`), a named
`COMPILED_PDF` constant in `CompileCheck.vitest.ts`, and widening one existing
`TexTools.vitest.ts` assertion to pin the new field. That is stub maintenance,
not test growth.

## Consumer counts (R8)

`grep -rn "compileLatex2Pdf" src packages --include='*.ts'` — 6 production call
sites, all inspected:

- `compileCheck.ts`, `LatexDiffManager.ts`, `LatexMediaManager.ts`,
  `ChatExportController.ts`, `desktopPreviewHost.ts` — all migrated to
  `pdfPath`.
- `TikzPictureManager.ts` — re-derives, deliberately unchanged (see Summary).
- `packages/extension/src/frontend/latex/openBuild.ts:206` — calls it, derives
  no PDF path (returns a boolean); untouched.

`grep -rn "compiledBasename\|getFileStem"` — no orphaned readers:
`compiledBasename` had exactly the three uses removed with it; `getFileStem`
had one use in `desktopPreviewHost.ts` and its import is deleted (the symbol
has other consumers elsewhere in the repo).

## Host impact

Extension: `ChatExportController` (LaTeX chat export) and the reflection-flow
compile check now open the path the engine actually wrote.

Desktop: `desktopPreviewHost` derives its preview PDF path *after* the compile
instead of before it. `outputDirectory` still has to be computed up front
because it is an input to the compile.

CLI: none (no CLI call site).

## Scheduled refactoring

None. `TikzPictureManager`'s post-failure PDF probe is left as-is on purpose.

## Validation

- `npm run typecheck` — clean (all six projects).
- `npx vitest run src/test-kernel/latex src/test-kernel/desktop
  src/test-kernel/agent/output src/test-kernel/frontend/OpenBuildDisplay.vitest.ts`
  — 87 files, 831 tests, all passing.
- `npx vitest run src/test-kernel/controllers/` — 40 files, 403 tests passing
  (covers `ChatExportController`).
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — not run: no export added or removed.
