### PR TITLE
refactor(tools): use which.sync for the strategy-4 PATH lookup

### DIFF
--- a/src/tools/support/externalBinaryUtils.ts
+++ b/src/tools/support/externalBinaryUtils.ts
@@ -20,9 +20,10 @@
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
 
-import { AbsoluteFS } from '@utils/files/absoluteFS';
+import which from 'which';
+
 import { executeCommandSync } from '@utils/system/execUtils';
-import { IS_WINDOWS } from '@utils/system/platformPaths';
+import { IS_WINDOWS, extendEnvPath } from '@utils/system/platformPaths';
 
 type ElectronProcess = NodeJS.Process & {
   defaultApp?: boolean;
@@ -175,33 +176,21 @@ async function resolveBinary(
 
   // Strategy 4: PATH lookup (native installer, Homebrew, manual install)
   // Fallback — may find an older version that doesn't match the SDK.
-  {
-    const lookupResult = executeCommandSync(
-      [IS_WINDOWS ? 'where' : 'which', config.pathCommand],
-      {
-        timeout: 5000,
-      },
-    );
-    const pathHits = lookupResult.success
-      ? lookupResult.stdout.split(/\r?\n/)
-      : [];
-
-    for (const hit of pathHits) {
-      const p = hit.trim();
-      if (!p) continue;
-      // The SDK spawns the binary directly, so only a real executable is
-      // usable. `npm install -g` writes three shims next to each other —
-      // `claude`, `claude.cmd` and `claude.ps1` — and none of them can be
-      // spawned on Windows: the first is a POSIX sh script for Git Bash, and
-      // the other two need a shell. Requiring .exe rejects all three, so the
-      // tool reports "not found" with its install guide instead of resolving
-      // to a path that fails at spawn time.
-      if (IS_WINDOWS && !/\.exe$/i.test(p)) continue;
-      if (await AbsoluteFS.exists(p)) return p;
-    }
-  }
-
-  return undefined;
+  //
+  // The SDK spawns the binary directly, so only a real executable is usable.
+  // `npm install -g` writes three shims next to each other — `claude`,
+  // `claude.cmd` and `claude.ps1` — and none of them can be spawned on Windows:
+  // the first is a POSIX sh script for Git Bash, and the other two need a
+  // shell. Restricting PATHEXT to `.EXE` rejects all three, so the tool reports
+  // "not found" with its install guide instead of resolving to a path that
+  // fails at spawn time.
+  return (
+    which.sync(config.pathCommand, {
+      nothrow: true,
+      path: extendEnvPath(),
+      ...(IS_WINDOWS ? { pathExt: '.EXE' } : {}),
+    }) ?? undefined
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

`resolveBinary`'s strategy 4 (`src/tools/support/externalBinaryUtils.ts:176-202`)
did a PATH lookup by shelling out:

```ts
executeCommandSync([IS_WINDOWS ? 'where' : 'which', config.pathCommand], …)
```

then split stdout by line, dropped anything not ending in `.exe` on Windows, and
re-checked each surviving hit with `AbsoluteFS.exists`.

`src/utils/system/platformPaths.ts:343` already carries the ruling for exactly
this problem, in a comment:

> PATH lookup via npm `which` (in-process; honors PATHEXT on Windows, so no
> `where`/`which` subprocess is needed).

This is that lookup's twin, collapsed onto the same call. `which` is already a
declared dependency (root `package.json:186`, `packages/agent/package.json:114`)
and already has an ambient module declaration carrying `pathExt`
(`src/types/ambient.d.ts:143-156`) — no ambient change, no new dependency.

### On the motivation — what this is *not*

This is **not** "stops blocking the event loop". Strategy 3, on the same code
path immediately above, does a synchronous `npm prefix -g` (`:163`) and is not
removed by this PR. Any resolution that reaches strategy 4 has already blocked
the host on one `execaSync`. The honest claim is narrower: one fewer subprocess,
one fewer hand-rolled stdout parse, and the `where`/`which` lookup now lives at
its documented owner instead of in a second, differently-shaped copy.

### Behaviour preservation

- **The `.exe` filter is preserved, not dropped** — it becomes `pathExt: '.EXE'`
  instead of a post-filter over `where` output. Checked line by line against the
  installed **which@5.0.0** (`node_modules/which/lib/index.js:31-37`): the option
  is split and `flatMap`ped to `['.EXE', '.exe']`, and `''` is unshifted only
  `if (cmd.includes('.'))`. `config.pathCommand` is `'claude'`
  (`claudeAgentImport.ts:129`) or `'codex'` (`codexImport.ts:136`) — neither
  contains a dot — so nothing but a real `.exe` can match. The 7-line rationale
  for why only `.exe` is spawnable on Windows survives verbatim.
- **Same search path.** `extendEnvPath()` defaults `basePath` to
  `process.env.PATH` (`platformPaths.ts:247-249`); the old path went through
  `commandEnv`, which sets `env.PATH = extendEnvPath(env.PATH)` from
  `process.env.PATH` (`execUtils.ts:90`). Same input, same memoized
  `cachedExtendedPaths` output.
- **Same first-hit selection.** `where` returns every match and the old loop took
  the first that passed the `.exe` filter and existed; `which.sync` walks the
  same directories in order and returns the first executable match.
- **Windows cwd, noted so it is not mistaken for a regression later:** which@5
  unshifts `process.cwd()` into the search path on Windows
  (`lib/index.js:26`). That matches `where.exe`'s cwd-first behaviour, so a
  `claude.exe` in the workspace root wins today and still wins after this PR.
- The `AbsoluteFS.exists` re-check goes: `which` verifies executability itself
  (via `isexe`), so it was a second stat of a path the lookup had just
  confirmed.

Sanity-checked `which.sync(cmd, { nothrow: true, path })` against the `which`
binary on this machine for `node` / `git` / `npm` / a missing command —
byte-identical results, `null` on the miss.

## Issue acceptance gates

n/a — found by a collapse sweep over `process-spawn` sites, no issue.

## Single source of truth

`which.sync` is now the only PATH-lookup mechanism in the repo.
`rg "'where'|where\.exe"` over `src/` and `packages/` returns only a
word-list entry in `src/replacement/maxRules.ts:517` after this change; `platformPaths.ts:347` and this site are the two `which.sync` callers.

## Duplication and abstraction budget

Removed a second, differently-shaped copy of a lookup the codebase had already
ruled on. No new abstraction, no new helper (the two call sites want different
options — `candidates` looping and kpsewhich fallback there, `pathExt` gating
here — so a shared wrapper would be a 2-caller pass-through with a union of
parameters).

## Net elements (R6)

**Net −11 LoC.** Modest — most of the removed block was comment that had to be
kept.

| | files | exports | functions | LoC |
|---|---|---|---|---|
| production | 1 changed | ±0 | ±0 | +18 / −29 = **−11** |
| tests | 0 | — | — | 0 |

Imports: `AbsoluteFS` removed (its only use in the file was the redundant
existence check), `which` added, `extendEnvPath` added to the existing
`platformPaths` import. `executeCommandSync` stays — strategy 3 still uses it.
`IS_WINDOWS` stays — it gates the `pathExt` branch.

## Consumer counts (R8)

No export added or removed; `resolveBinary` is module-private. Greps run:

- `rg 'externalBinaryUtils|resolveBinary|createCachedBinaryResolver' src packages -g '*.ts'`
  (excluding `dist`) → `claudeAgentImport.ts`, `codexImport.ts`,
  `externalToolDefs.ts`, and the file itself. No test file references it.
- `rg 'pathCommand'` → the two config sites plus the interface field.
- `rg "from 'which'"` → `platformPaths.ts:9` and now this file.
- `rg '"which"' */package.json` → declared at root and in `packages/agent`; the
  new import is inside `packages/agent`'s fenced surface and its manifest
  already covers it.

`src/tools/` is not browser-reachable, so
`scripts/check-browser-safe-utils.mjs`'s 7-of-63 count is unaffected.

## Host impact

Extension / Desktop / CLI: identical — all three reach this through the Claude
Code and Codex vendor tools' binary resolution. One fewer child process spawned
when resolution falls through to PATH.

## Scheduled refactoring

None. Strategy 3's synchronous `npm prefix -g` is deliberately left alone — it is
a different lookup (global npm prefix, not PATH) with no in-process equivalent,
and folding it in would be a behaviour change, not a collapse.

## Validation

- `npm run typecheck` — clean.
- `npx vitest run src/test-kernel/tools/codexImport.vitest.ts
  src/test-kernel/tools/externalToolDefs.vitest.ts
  src/test-kernel/tools/ClaudeAgentConfig.vitest.ts` — 3 files, 16/16 pass.
  **No new test** — a behaviour-preserving refactor gets none, and there is no
  existing suite that exercises strategy 4.
- `npx eslint` + `npx prettier --check` on the changed file — clean.
- which@5 `pathExt` semantics read from the installed source, and `which.sync`
  compared against the `which` binary on a real PATH.
