### PR TITLE
fix(desktop): revive four dead keyboard shortcuts; collapse three host-command divergences

### DIFF
--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -19,7 +19,8 @@ import {
 import {
   buildDesktopMainViewResetMessage,
   DESKTOP_DOCS_URL,
-  DESKTOP_LOCAL_COMMANDS,
+  DESKTOP_SHELL_IPC_COMMANDS,
+  dispatchDesktopCommand,
   postDesktopSettingsView,
   vsCodeOnlyGettingStartedMessage,
   type DesktopCommandActions,
@@ -234,28 +235,6 @@ function dispatchMainViewInboundOnShell(
   }
 }
 
-function dispatchDesktopLocalOnShell(
-  message: DesktopCommandMessage,
-  actions: DesktopShellActions,
-): boolean {
-  switch (message.command) {
-    case DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER:
-      actions.openLogFolder();
-      return true;
-    case DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER:
-      actions.openWorkspaceFolder();
-      return true;
-    case DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH:
-      actions.showFirstRunWalkthrough();
-      return true;
-    case DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS:
-      actions.openDesktopDocs();
-      return true;
-    default:
-      return false;
-  }
-}
-
 export function createDesktopShellIpc(
   actions: DesktopShellActions,
 ): DesktopMessageHandler {
@@ -268,11 +247,18 @@ export function createDesktopShellIpc(
       if (parsed.success) {
         return dispatchMainViewInboundOnShell(parsed.data, actions);
       }
-      // Desktop-local commands (open log folder, walkthrough, docs) are
-      // not part of the main-view inbound union — they originate from the
-      // native menu, not the renderer schema — so they are handled
-      // separately as a fallback after the union parse fails.
-      return dispatchDesktopLocalOnShell(message, actions);
+      // Desktop-local commands (open log folder, walkthrough, docs) are not
+      // part of the main-view inbound union — they originate from the native
+      // menu, not the renderer schema — so after the union parse fails they go
+      // to the one command registry the menu also dispatches through.
+      const id = DESKTOP_SHELL_IPC_COMMANDS.find(
+        (candidate) => candidate === message.command,
+      );
+      if (id == null) return false;
+      // Every registry handler runs its action synchronously and returns
+      // `true`; `boolean | Promise<boolean>` is the shared dispatcher
+      // signature, so narrow it here rather than widening this contract.
+      return dispatchDesktopCommand(id, actions) === true;
     },
   };
 }

--- a/packages/desktop/src/renderer/desktopShortcutRegistry.ts
+++ b/packages/desktop/src/renderer/desktopShortcutRegistry.ts
@@ -10,7 +10,10 @@ import {
   keyboardEventToAccelerator,
 } from '@shared/commands/shortcutPreferences';
 
-import type { DesktopPlatform } from '@shared/commands/accelerators';
+import {
+  toElectronAccelerator,
+  type DesktopPlatform,
+} from '@shared/commands/accelerators';
 import {
   dispatchDesktopCommand,
   getDesktopCommandMenuEntries,
@@ -34,7 +37,10 @@ export function desktopCommandPaletteShortcut(
     id: DESKTOP_COMMAND_PALETTE_ID,
     label: 'Show Commands',
     category: 'TeXRA',
-    accelerator: platform === 'darwin' ? 'Command+K' : 'Control+K',
+    accelerator: toElectronAccelerator(
+      { key: 'ctrl+k', mac: 'cmd+k' },
+      platform,
+    ),
   };
 }
 

--- a/packages/desktop/src/shared/desktopCommandSurface.ts
+++ b/packages/desktop/src/shared/desktopCommandSurface.ts
@@ -7,13 +7,13 @@ import type {
 import { MAIN_VIEW_COMMANDS, SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   toElectronAccelerator,
-  toPlatformAccelerator,
   type DesktopPlatform,
 } from '@shared/commands/accelerators';
 import {
   commandCatalogById,
   settingsTabByCommand,
   type CommandId,
+  type CommandKeybinding,
   type SettingsTabCommandId,
 } from '@shared/commands/catalog';
 import {
@@ -177,9 +177,18 @@ export interface DesktopMainViewResetMessage {
   isResetOperation: true;
 }
 
+/**
+ * Desktop-only commands have no catalog row, so their label, category and
+ * keybinding live here. Keybindings use the same `CommandKeybinding` tokens the
+ * catalog uses so both branches of {@link getDesktopCommandMenuEntries} run
+ * through `toElectronAccelerator` — the one spelling the renderer's keydown
+ * comparison also produces.
+ */
 const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
   DesktopLocalCommandId,
-  Omit<DesktopCommandMenuEntry, 'icon'>
+  Omit<DesktopCommandMenuEntry, 'icon' | 'accelerator'> & {
+    keybinding?: CommandKeybinding;
+  }
 >([
   [
     DESKTOP_LOCAL_COMMANDS.SAVE_FILE,
@@ -187,7 +196,7 @@ const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
       id: DESKTOP_LOCAL_COMMANDS.SAVE_FILE,
       label: 'Save',
       category: 'File',
-      accelerator: 'CommandOrControl+S',
+      keybinding: { key: 'ctrl+s', mac: 'cmd+s' },
     },
   ],
   [
@@ -212,7 +221,7 @@ const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
       id: DESKTOP_LOCAL_COMMANDS.TOGGLE_BOTTOM_BAR,
       label: 'Toggle Bottom Bar',
       category: 'View',
-      accelerator: 'CommandOrControl+J',
+      keybinding: { key: 'ctrl+j', mac: 'cmd+j' },
     },
   ],
   [
@@ -221,7 +230,7 @@ const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
       id: DESKTOP_LOCAL_COMMANDS.TOGGLE_SIDE_PANEL,
       label: 'Toggle Side Panel',
       category: 'View',
-      accelerator: 'CommandOrControl+Alt+B',
+      keybinding: { key: 'ctrl+alt+b', mac: 'cmd+option+b' },
     },
   ],
   [
@@ -230,7 +239,7 @@ const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
       id: DESKTOP_LOCAL_COMMANDS.TOGGLE_SUMMARY_BAR,
       label: 'Toggle Summary Bar',
       category: 'View',
-      accelerator: 'CommandOrControl+Alt+S',
+      keybinding: { key: 'ctrl+alt+s', mac: 'cmd+option+s' },
     },
   ],
   [
@@ -239,7 +248,7 @@ const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
       id: DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
       label: 'Open Folder',
       category: 'File',
-      accelerator: 'CommandOrControl+O',
+      keybinding: { key: 'ctrl+o', mac: 'cmd+o' },
     },
   ],
   [
@@ -267,10 +276,13 @@ export function getDesktopCommandMenuEntries(
     if (isDesktopLocalCommandId(id)) {
       const localEntry = DESKTOP_LOCAL_COMMAND_ENTRIES.get(id);
       if (!localEntry) throw new Error(`Missing desktop command entry: ${id}`);
+      const { keybinding, ...entry } = localEntry;
       return {
-        ...localEntry,
+        ...entry,
         icon: DESKTOP_COMMAND_ICONS[id],
-        accelerator: toPlatformAccelerator(localEntry.accelerator, platform),
+        ...(keybinding && {
+          accelerator: toElectronAccelerator(keybinding, platform),
+        }),
       };
     }
 

--- a/packages/desktop/src/shared/desktopCommandSurface.ts
+++ b/packages/desktop/src/shared/desktopCommandSurface.ts
@@ -94,6 +94,19 @@ export const DESKTOP_FILE_COMMANDS = [
   DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
 ] as const satisfies readonly DesktopLocalCommandId[];
 
+/**
+ * The desktop-local commands the renderer is allowed to post over IPC. Narrower
+ * than `DESKTOP_LOCAL_COMMANDS` on purpose: the main-process actions for
+ * `SAVE_FILE` and the three `TOGGLE_*` commands post *back* to the renderer, so
+ * accepting them here would let a renderer message bounce.
+ */
+export const DESKTOP_SHELL_IPC_COMMANDS = [
+  DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER,
+  DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
+  DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH,
+  DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS,
+] as const satisfies readonly DesktopLocalCommandId[];
+
 export const DESKTOP_HELP_COMMANDS = [
   DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH,
   DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS,

--- a/packages/extension/src/commands/extensionCommandHandlers.ts
+++ b/packages/extension/src/commands/extensionCommandHandlers.ts
@@ -192,7 +192,7 @@ export interface ExtensionCommandActions {
   indentTeX(): Promise<void>;
   signIn(): Promise<boolean>;
   signInChatGpt(): Promise<void>;
-  signInGrok(): Promise<boolean>;
+  signInGrok(): Promise<void>;
   signOut(): Promise<void>;
   runSetupAssistant(): Promise<void>;
   openGettingStarted(): Thenable<unknown>;

--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -50,7 +50,6 @@ import { openGettingStarted as sysOpenGettingStarted } from '@commands/system/wa
 import { SIDEBAR_VIEWS, getActiveSidebarView } from '@common/webview';
 import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import { getMainWebview } from '@frontend/system/commandUtils';
-import { signInWithSubscription } from '@frontend/auth/subscriptionSignIn';
 import { runCleanBuild, runCleanOutput } from '@housekeeping/clean';
 import type { SettingsViewProvider } from '@settingsView/SettingsViewProvider';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
@@ -63,7 +62,6 @@ import {
 } from './extensionCommandHandlers';
 
 const RESET_CHANNEL = 'mainViewCommands';
-const GROK_SIGN_IN_CHANNEL = 'GrokSubscription';
 
 export function createExtensionCommandActions(
   context: vscode.ExtensionContext,
@@ -102,18 +100,8 @@ export function createExtensionCommandActions(
     acceptEdited: latexHandleAcceptEdited,
     indentTeX: handleIndentTeX,
     signIn: authSignIn,
-    signInChatGpt: settingsViewProvider.signInChatGpt,
-    async signInGrok() {
-      const signedIn = await signInWithSubscription(
-        GROK_SIGN_IN_CHANNEL,
-        'grok',
-      );
-      await Promise.all([
-        vscode.commands.executeCommand('texra.refreshApiKeyStatus'),
-        vscode.commands.executeCommand('texra.refreshAllOptions'),
-      ]);
-      return signedIn;
-    },
+    signInChatGpt: () => settingsViewProvider.signInSubscription('chatgpt'),
+    signInGrok: () => settingsViewProvider.signInSubscription('grok'),
     signOut: authSignOut,
     runSetupAssistant: async () => {
       await launchSetupAssistant();

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -19,6 +19,7 @@ import { SettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
 import { getChatGptAuthStatus } from '@controllers/modelAccess/chatGptAuthStatus';
 import { getGrokAuthStatus } from '@controllers/modelAccess/grokAuthStatus';
 import { SubscriptionUsageService } from '@controllers/modelAccess/subscriptionUsage/SubscriptionUsageService';
+import type { SubscriptionProviderId } from '@controllers/modelAccess/subscriptionProviders';
 import {
   buildToolDashboardItems,
   planToolTerminalAction,
@@ -120,7 +121,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private readonly profileController: SettingsProfileController;
   private readonly profileKeyController: SettingsProfileKeyController;
   private readonly subscriptionUsage: SubscriptionUsageReader;
-  public readonly signInChatGpt: () => Promise<void>;
 
   constructor(context: vscode.ExtensionContext) {
     super('SettingsView');
@@ -192,7 +192,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       ctx,
       () => this.refreshAfterSubscriptionAuthChange('chatgpt'),
     );
-    this.signInChatGpt = this.chatgptHandlers.handleSignIn;
     this.grokHandlers = new SubscriptionHandlers(
       'grok',
       () =>
@@ -232,6 +231,17 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       void this.withActiveWebview((w) => this.sendGoalList(w));
     });
     context.subscriptions.push({ dispose: unsubscribeGoals });
+  }
+
+  /**
+   * Sign in to a subscription provider from outside the settings webview.
+   * Routes to the same handler the Settings → Subscriptions button runs, so
+   * the command palette gets the status round-trip and credential refresh
+   * tail instead of a bespoke sign-in that leaves both stale.
+   */
+  public signInSubscription(providerId: SubscriptionProviderId): Promise<void> {
+    const handlers = { chatgpt: this.chatgptHandlers, grok: this.grokHandlers };
+    return handlers[providerId].handleSignIn();
   }
 
   private createHandlerRegistry(): SettingsViewInboundHandlerRegistry {
@@ -317,7 +327,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         this.githubHandlers.handleUnsubscribePR(message),
       openPRSubscriptionStream: (message) =>
         this.githubHandlers.handleOpenPRSubscriptionStream(message),
-      signInChatGpt: this.signInChatGpt,
+      signInChatGpt: () => this.chatgptHandlers.handleSignIn(),
       signOutChatGpt: () => this.chatgptHandlers.handleSignOut(),
       setChatGptPreferSubscription: (message) =>
         this.chatgptHandlers.handleSetPreferSubscription(message.enabled),

--- a/packages/extension/src/settingsView/SettingsViewProvider.ts
+++ b/packages/extension/src/settingsView/SettingsViewProvider.ts
@@ -6,6 +6,7 @@ import {
   BaseWebviewProvider,
   BundledViewContentProvider,
 } from '@common/webview';
+import type { SubscriptionProviderId } from '@controllers/modelAccess/subscriptionProviders';
 import { onTexraAuthSessionsChanged } from '@frontend/events/onTexraAuthSessionsChanged';
 import {
   isAgentCatalogAuthRefreshDeferred,
@@ -21,7 +22,6 @@ export class SettingsViewProvider extends BaseWebviewProvider {
   public static readonly viewType = 'texra.settingsView';
   protected contentProvider: BundledViewContentProvider;
   protected messageHandler: SettingsViewMessageHandler;
-  public readonly signInChatGpt: () => Promise<void>;
 
   constructor(protected readonly context: vscode.ExtensionContext) {
     super(context);
@@ -35,7 +35,6 @@ export class SettingsViewProvider extends BaseWebviewProvider {
       },
     );
     this.messageHandler = new SettingsViewMessageHandler(context);
-    this.signInChatGpt = this.messageHandler.signInChatGpt;
 
     // Listen for auth state changes to refresh all data
     onTexraAuthSessionsChanged(context, () => {
@@ -49,6 +48,11 @@ export class SettingsViewProvider extends BaseWebviewProvider {
         void this.messageHandler.sendAllData(this._view.webview);
       }
     });
+  }
+
+  /** Sign in to a subscription provider from a command, not the webview. */
+  public signInSubscription(providerId: SubscriptionProviderId): Promise<void> {
+    return this.messageHandler.signInSubscription(providerId);
   }
 
   /** Refresh every credential-dependent surface after any API-key mutation. */

--- a/src/shared/commands/accelerators.ts
+++ b/src/shared/commands/accelerators.ts
@@ -28,15 +28,6 @@ export function toElectronAccelerator(
   return key.split('+').map(toElectronAcceleratorPart).join('+');
 }
 
-export function toPlatformAccelerator(
-  accelerator: string | undefined,
-  platform: DesktopPlatform,
-): string | undefined {
-  if (!accelerator) return undefined;
-  if (platform !== 'darwin') return accelerator;
-  return accelerator.replaceAll('CommandOrControl', 'Command');
-}
-
 /**
  * Maps a browser `navigator.platform` string to a `DesktopPlatform` so
  * renderer code can share one platform rule instead of re-deriving it with
@@ -60,7 +51,6 @@ export function formatDesktopAccelerator(
   if (!accelerator) return undefined;
   const isMac = platform === 'darwin';
   const parts = accelerator
-    .replaceAll('CommandOrControl', isMac ? 'Command' : 'Control')
     .split('+')
     .map((part) => toDisplayAcceleratorPart(part, platform));
   return parts.join(isMac ? '' : '+');

--- a/src/test-kernel/commands/ExtensionCommandSurface.vitest.ts
+++ b/src/test-kernel/commands/ExtensionCommandSurface.vitest.ts
@@ -7,26 +7,32 @@ import { dispatchCommandFromRegistry } from '@shared/commands/registry';
 import type * as vscode from 'vscode';
 
 describe('extension command action wiring', () => {
-  it('routes the ChatGPT sign-in command through the Settings provider authority', async () => {
-    const signInChatGpt = vi.fn(async () => {});
-    const settingsViewProvider = {
-      signInChatGpt,
-      refreshAfterProviderKeyChange: vi.fn(),
-      showSettingsView: vi.fn(),
-    } as unknown as SettingsViewProvider;
+  it.each([
+    ['texra.auth.chatgpt.signIn', 'chatgpt'],
+    ['texra.auth.grok.signIn', 'grok'],
+  ] as const)(
+    'routes %s through the Settings provider authority',
+    async (commandId, providerId) => {
+      const signInSubscription = vi.fn(async () => {});
+      const settingsViewProvider = {
+        signInSubscription,
+        refreshAfterProviderKeyChange: vi.fn(),
+        showSettingsView: vi.fn(),
+      } as unknown as SettingsViewProvider;
 
-    const actions = createExtensionCommandActions(
-      {} as vscode.ExtensionContext,
-      settingsViewProvider,
-    );
-    const result = dispatchCommandFromRegistry(
-      'texra.auth.chatgpt.signIn',
-      EXTENSION_COMMAND_HANDLERS,
-      actions,
-      undefined,
-    );
+      const actions = createExtensionCommandActions(
+        {} as vscode.ExtensionContext,
+        settingsViewProvider,
+      );
+      const result = dispatchCommandFromRegistry(
+        commandId,
+        EXTENSION_COMMAND_HANDLERS,
+        actions,
+        undefined,
+      );
 
-    await expect(result).resolves.toBe(true);
-    expect(signInChatGpt).toHaveBeenCalledOnce();
-  });
+      await expect(result).resolves.toBe(true);
+      expect(signInSubscription).toHaveBeenCalledExactlyOnceWith(providerId);
+    },
+  );
 });

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.ts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.ts
@@ -135,14 +135,14 @@ describe('desktop command surface', () => {
           label: 'Toggle Side Panel',
           category: 'View',
           icon: 'picture-in-picture',
-          accelerator: 'Command+Alt+B',
+          accelerator: 'Command+Option+B',
         },
         {
           id: DESKTOP_LOCAL_COMMANDS.TOGGLE_SUMMARY_BAR,
           label: 'Toggle Summary Bar',
           category: 'View',
           icon: 'list-ul',
-          accelerator: 'Command+Alt+S',
+          accelerator: 'Command+Option+S',
         },
       ]),
     );
@@ -172,10 +172,7 @@ describe('desktop command surface', () => {
 
   it('formats accelerators for desktop tooltip display', () => {
     expect(formatDesktopAccelerator('Command+Option+M', 'darwin')).toBe('⌘⌥M');
-    expect(formatDesktopAccelerator('CommandOrControl+O', 'darwin')).toBe('⌘O');
-    expect(formatDesktopAccelerator('CommandOrControl+O', 'linux')).toBe(
-      'Ctrl+O',
-    );
+    expect(formatDesktopAccelerator('Control+O', 'linux')).toBe('Ctrl+O');
     expect(formatDesktopAccelerator('Control+Alt+Shift+C', 'linux')).toBe(
       'Ctrl+Alt+Shift+C',
     );

--- a/src/test-kernel/desktop/DesktopControlSystem.vitest.ts
+++ b/src/test-kernel/desktop/DesktopControlSystem.vitest.ts
@@ -257,7 +257,9 @@ describe('desktop control system', () => {
       "webContents.on('page-title-updated', republish)",
     );
     expect(commandSurface).toContain("SAVE_FILE: 'texra.desktop.saveFile'");
-    expect(commandSurface).toContain("accelerator: 'CommandOrControl+S'");
+    expect(commandSurface).toContain(
+      "keybinding: { key: 'ctrl+s', mac: 'cmd+s' }",
+    );
     expect(renderer).toContain('void editorPane.save()');
     expect(renderer).toContain('editorPane.hasUnsavedChanges()');
     expect(editorPane).toContain('model.getVersionId() !== savedVersion');

--- a/src/test-kernel/desktop/DesktopShortcutRegistry.vitest.ts
+++ b/src/test-kernel/desktop/DesktopShortcutRegistry.vitest.ts
@@ -20,6 +20,7 @@ interface ShortcutRegistryModule {
       showLauncher(): void;
       openWorkbench(kind: 'settings' | 'logs'): void;
       showSettings(tab?: string): void;
+      toggleSidePanel(): void;
     };
     openCommands(): void;
     platform?: NodeJS.Platform;
@@ -32,6 +33,10 @@ async function loadShortcutRegistry(): Promise<ShortcutRegistryModule> {
 
 async function createRegistry(
   openCommands: () => void = vi.fn(),
+  overrides: {
+    platform?: NodeJS.Platform;
+    toggleSidePanel?: () => void;
+  } = {},
 ): Promise<ShortcutRegistry> {
   const { createDesktopShortcutRegistry } = await loadShortcutRegistry();
   return createDesktopShortcutRegistry({
@@ -40,9 +45,10 @@ async function createRegistry(
       showLauncher: vi.fn(),
       openWorkbench: vi.fn(),
       showSettings: vi.fn(),
+      toggleSidePanel: overrides.toggleSidePanel ?? vi.fn(),
     },
     openCommands,
-    platform: 'darwin',
+    platform: overrides.platform ?? 'darwin',
   });
 }
 
@@ -73,6 +79,32 @@ describe('desktop shortcut registry', () => {
     );
     expect(openCommands).toHaveBeenCalledOnce();
     registry.dispose();
+  });
+
+  it('dispatches the Toggle Side Panel chord its menu advertises', async () => {
+    // Regression: the menu stored `CommandOrControl+Alt+B` while the keydown
+    // converter produces `Command+Option+B` on darwin and `Control+Alt+B`
+    // elsewhere, so the advertised shortcut dispatched nothing on any platform.
+    for (const platform of ['darwin', 'win32'] as const) {
+      const toggleSidePanel = vi.fn();
+      const registry = await createRegistry(vi.fn(), {
+        platform,
+        toggleSidePanel,
+      });
+
+      document.body.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          cancelable: true,
+          key: 'b',
+          altKey: true,
+          ...(platform === 'darwin' ? { metaKey: true } : { ctrlKey: true }),
+        }),
+      );
+
+      expect(toggleSidePanel).toHaveBeenCalledOnce();
+      registry.dispose();
+    }
   });
 
   it('installs one shared service and removes it on disposal', async () => {


### PR DESCRIPTION
## Summary

Three related host-command-surface fixes, in commit order.

**1. Four desktop keyboard shortcuts were dead (user-facing bug).**
"Give this command a keyboard shortcut" was spelled three ways, and two of the
spellings never matched the keypress. The desktop menu stored Electron
`CommandOrControl+...` literals; the renderer keydown registry — the *only*
dispatcher, since `desktopMenuTemplate.ts` emits `{label, click}` with no
`accelerator` and a repo-wide grep for `globalShortcut` returns zero hits —
compares against `keyboardEventToAccelerator`, which emits `Command`/`Control`
and `Option`/`Alt`.

Reproduced before the fix by driving the real `createDesktopShortcutRegistry`
with real `KeyboardEvent`s against a jsdom document:

| platform | chord | stored (before) | dispatches before | stored (after) | dispatches after |
|---|---|---|---|---|---|
| darwin | Cmd+S | `Command+S` | yes | `Command+S` | yes |
| darwin | Cmd+J | `Command+J` | yes | `Command+J` | yes |
| darwin | Cmd+O | `Command+O` | yes | `Command+O` | yes |
| darwin | Cmd+Opt+B | `Command+Alt+B` | **no** | `Command+Option+B` | yes |
| darwin | Cmd+Opt+S | `Command+Alt+S` | **no** | `Command+Option+S` | yes |
| win32/linux | Ctrl+S | `CommandOrControl+S` | **no** | `Control+S` | yes |
| win32/linux | Ctrl+J | `CommandOrControl+J` | **no** | `Control+J` | yes |
| win32/linux | Ctrl+O | `CommandOrControl+O` | **no** | `Control+O` | yes |
| win32/linux | Ctrl+Alt+B | `CommandOrControl+Alt+B` | **no** | `Control+Alt+B` | yes |
| win32/linux | Ctrl+Alt+S | `CommandOrControl+Alt+S` | **no** | `Control+Alt+S` | yes |

Toggle Side Panel and Toggle Summary Bar were dead on **every** platform; Save,
Toggle Bottom Bar and Open Folder were dead on win32 + linux. Display was
unaffected, which is what hid it: `formatDesktopAccelerator` normalized
`CommandOrControl`, so the command palette and Settings → Shortcuts happily
advertised keys that did nothing.

Fix: desktop-local rows now carry the same `CommandKeybinding` tokens the shared
catalog uses, so both branches of `getDesktopCommandMenuEntries` and the palette
shortcut produce accelerators through `toElectronAccelerator`.
`toPlatformAccelerator` and the `CommandOrControl` branch of
`formatDesktopAccelerator` are deleted **in the same commit** — splitting them
would leave a window where display breaks.

**Personal overrides are unaffected.** `DESKTOP_SHORTCUT_STORAGE_KEY` values are
always written by `keyboardEventToAccelerator` and were already canonical; only
`defaultAccelerator` changes spelling.

**2. Grok's palette sign-in skipped the refresh tail ChatGPT gets.**
`texra.auth.chatgpt.signIn` reached `SubscriptionHandlers.handleSignIn`, which
signs in and then posts the auth status to the live settings webview and
refreshes every credential-dependent surface (model-options cache, API-key
status, all-options, model-selection data, usage). `texra.auth.grok.signIn` ran a
bespoke inline body that called `signInWithSubscription` plus two refresh
commands, so signing in to Grok from the palette left Settings → Subscriptions
reading signed-out and the model-selection data stale. Both commands now route
through `SettingsViewProvider.signInSubscription(id)` to the same per-provider
`SubscriptionHandlers` instance the Settings buttons use.

**3. Desktop main dispatched renderer commands twice.**
`createDesktopShellIpc` carried its own `switch (message.command)` over four
`DESKTOP_LOCAL_COMMANDS` ids, duplicating rows `DESKTOP_COMMAND_HANDLERS`
already owns for the native menu — over the *same* actions object
(`DesktopShellActions extends DesktopCommandActions`, and
`buildDesktopMenuTemplate` is handed that instance). No live defect: all three
ids the renderer actually posts behaved identically on both paths.

## Issue acceptance gates

No issue. Found by a verified collapse sweep over the host command surfaces;
item 1 was confirmed by execution before any edit.

## Single source of truth

- Accelerator spelling: `toElectronAccelerator` over `CommandKeybinding` tokens
  is now the only producer of a desktop accelerator string. Nothing can emit
  `CommandOrControl` any more, so `formatDesktopAccelerator` no longer normalizes
  it.
- Subscription sign-in: `SubscriptionHandlers` (one instance per provider, held
  by `SettingsViewMessageHandler`) is the only owner of the sign-in + refresh
  sequence. The palette and the Settings button reach the same instance.
- Desktop command dispatch: `DESKTOP_COMMAND_HANDLERS` /
  `dispatchDesktopCommand` is the only dispatcher for desktop command ids; the
  shell IPC path is now a *filter* (`DESKTOP_SHELL_IPC_COMMANDS`), not a second
  dispatcher.

## Duplication and abstraction budget

Removed: one accelerator converter (`toPlatformAccelerator`) and one whole
spelling; one bespoke sign-in body; one duplicate `switch` dispatcher.

Added, with the invariant each owns:
- `DESKTOP_SHELL_IPC_COMMANDS` — the set of desktop-local ids the renderer may
  post. Deliberately 4, not all 9: the main-process actions for `SAVE_FILE` and
  the three `TOGGLE_*` post *back* to the renderer, so a broad
  `isDesktopLocalCommandId` guard would admit a ping-pong. Nothing posts them
  today, so this keeps the state unrepresentable rather than tolerating the edge.
- `signInSubscription(providerId)` on `SettingsViewMessageHandler` (and its
  pass-through on `SettingsViewProvider`, matching the existing
  `refreshAfterProviderKeyChange` shape, since `messageHandler` is protected) —
  owns "sign-in from outside the webview still runs the refresh tail". It indexes
  a `{chatgpt, grok}` literal so a third `SubscriptionProviderId` fails to
  compile rather than silently routing to Grok.

No branch collapse in `getDesktopCommandMenuEntries`: the catalog has no
`texra.desktop` ids (`grep -n "texra.desktop" src/shared/commands/catalog.ts` →
nothing), so `DESKTOP_LOCAL_COMMAND_ENTRIES` remains the only source of label and
category for those nine ids and the `isDesktopLocalCommandId` branch must stay.

## Net elements (R6)

**This PR net-ADDS lines. It is not a reduction and is not offered as one.** It
is worth landing because it fixes four dead keyboard shortcuts, one stale-settings
divergence, and deletes a converter and a duplicate dispatcher.

| | |
|---|---|
| files added / removed | 0 / 0 |
| files changed | 12 (8 production, 4 test) |
| production LoC | +78 / −69 = **net +9** |
| test LoC | +65 / −28 = **net +37** |
| **total LoC** | +143 / −97 = **net +46** |
| exported symbols | +1 (`DESKTOP_SHELL_IPC_COMMANDS`), −1 (`toPlatformAccelerator`) = **net 0** |
| functions/methods | −2 (`toPlatformAccelerator`, `dispatchDesktopLocalOnShell`), +2 (`signInSubscription` ×2) = **net 0** |
| public class fields | −2 (`signInChatGpt` on `SettingsViewProvider` and `SettingsViewMessageHandler`) |
| classes / interfaces / enums | 0 |

Most of the production `+` is explanatory comment on the three non-obvious
decisions (why keybinding tokens rather than accelerator strings; why the IPC set
is 4 and not 9; why the dispatcher's `boolean | Promise<boolean>` is narrowed
back at the call site). Code-only production delta is roughly net −4.

## Consumer counts (R8)

- `toPlatformAccelerator` (deleted) — `grep -rn "toPlatformAccelerator" src
  packages config scripts docs`: 1 call site (`desktopCommandSurface.ts:273`) plus
  its definition and one import. Zero test references. Zero hits in
  `config/ratchets/`.
- `CommandOrControl` (token retired) — same grep: 5 row literals, 1 branch in
  `formatDesktopAccelerator`, 1 branch in `toPlatformAccelerator`, and 3 test
  assertions. All updated or deleted; zero remain.
- `globalShortcut` — `grep -rn globalShortcut` over `src packages config scripts`:
  **zero hits** in code (one mention in an old PRD). Confirms the renderer keydown
  registry is the sole dispatcher and there is no fallback path that was masking
  the dead keys.
- `signInChatGpt` / `signInGrok` — grepped across all four packages plus
  `src/`. The VS Code `ExtensionCommandActions` members are kept (only their
  bodies re-routed); `signInGrok`'s `Promise<boolean>` narrowed to `Promise<void>`
  because its one caller is `awaitTrue(...)`, which discards the value. The
  desktop IPC members of the same name (`desktopSettingsIpc.ts`,
  `desktopCredentialSettingsController.ts`) are a **different** surface and are
  untouched.
- `dispatchDesktopLocalOnShell` — `grep -rn dispatchDesktopLocalOnShell`: only its
  definition and its one call site. No test asserts it by name.

## Host impact

Extension: `texra.auth.grok.signIn` now refreshes Settings → Subscriptions and
the model-selection data the way `texra.auth.chatgpt.signIn` already did. No wire
change; the webview button path is unchanged.

Desktop: five menu/palette accelerators change spelling (`CommandOrControl+X` →
`Command+X`/`Control+X`, `…+Alt+B` → `…+Option+B` on macOS). Displayed labels are
identical — `formatDesktopAccelerator` already rendered both spellings the same
way. Four previously dead shortcuts now fire. Saved personal overrides are
unaffected. Renderer→main IPC for the four desktop-local commands now goes
through the shared command registry; the accepted id set is unchanged.

CLI: none.

## Scheduled refactoring

None from this PR. One item was examined and deliberately **not** taken: keying
the subscription handler maps and status controllers by `SubscriptionProviderId`
across the settings wire. It requires a `usageProvider` field on the shared
`SubscriptionProvider` row (`SUBSCRIPTION_USAGE_PROVIDERS` excludes Grok, and the
asymmetry at the two `SubscriptionHandlers` constructions is deserved), an
exported provider-id list (`SUBSCRIPTION_PROVIDERS` is module-private), and a
decision about `label` leaking onto the wire via `provider.getStatus()`. It also
collides with `origin/refactor/local-simplification-sweep`, which is already
rewriting three of the four files. The user-visible benefit is entirely in this
PR.

## Validation

- **Reproduction before the fix**: drove the real `createDesktopShortcutRegistry`
  against a jsdom document with real `KeyboardEvent`s on both `darwin` and
  `win32`, for all five accelerator-bearing commands. 4 of 10 chords dispatched.
  After the fix, 10 of 10. Table above. The throwaway harness was deleted; the
  behavior it proved is pinned by the one regression test below.
- **One new regression test** (`DesktopShortcutRegistry.vitest.ts`): the Toggle
  Side Panel chord round-trips on darwin and win32. Verified it *fails* against
  the `mac: 'cmd+alt+b'` trap spelling — which type-checks, builds, and renders
  correctly while silently reproducing the original bug — and passes with
  `mac: 'cmd+option+b'`.
- `npm run typecheck` — clean (exit 0). Note `DesktopControlSystem.vitest.ts`
  asserts the *literal source text* of the accelerator row, so neither the type
  checker nor `compile:fast` would have caught that one; it is updated and
  covered by the vitest run below.
- `npx vitest run src/test-kernel/desktop src/test-kernel/commands
  src/test-kernel/settings` — 103 files, 807 tests, all passing.
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — 8 findings vs 8 baselined, no new unused
  exports (run from the worktree).
- Rebased onto current `origin/main` and re-ran typecheck, the three suites, lint,
  and the ratchet after the rebase.
