### PR TITLE
fix(latex): one definition of "a LaTeX compiler is available"

### DIFF
--- a/packages/cli/src/runtime/doctor.ts
+++ b/packages/cli/src/runtime/doctor.ts
@@ -261,7 +261,7 @@ async function checkLatex(
           'latex.compiler',
           'LaTeX compiler',
           'No supported LaTeX compiler was found on PATH.',
-          'Install latexmk, pdflatex, xelatex, or lualatex.',
+          'Install latexmk or pdflatex.',
         ),
       );
     }

--- a/src/controllers/settingsView/LatexToolingController.ts
+++ b/src/controllers/settingsView/LatexToolingController.ts
@@ -9,6 +9,7 @@ import {
   HOMEBREW_INSTALL_COMMAND,
   IMAGE_TOOLS,
   SCOOP_INSTALL_COMMAND,
+  SUPPORTED_LATEX_COMPILERS,
   type OSPlatform,
 } from '@shared/constants/latexToolchain';
 
@@ -57,7 +58,9 @@ export class LatexToolingController {
       const installed = await this.checkTools();
       return {
         ...this.deps.getRecommendedStatus(),
-        texDistributionInstalled: installed.pdflatex || installed.latexmk,
+        texDistributionInstalled: SUPPORTED_LATEX_COMPILERS.some(
+          (compiler) => installed[compiler],
+        ),
         latexWorkshopInstalled: this.deps.isLatexWorkshopInstalled(),
         latexdiffInstalled: installed.latexdiff,
         latexindentInstalled: installed.latexindent && installed.perl,

--- a/src/latex/latexToolchain.ts
+++ b/src/latex/latexToolchain.ts
@@ -44,6 +44,20 @@ const TOOL_PURPOSES: Record<LatexToolName, string> = {
   latexindent: 'LaTeX formatting',
 };
 
+/**
+ * Tools whose absence `texra doctor` reports as a failing row (and therefore a
+ * nonzero exit), not a warning.
+ *
+ * Known residual, stated rather than hidden: `latexmk` is required here even
+ * though {@link SUPPORTED_LATEX_COMPILERS} accepts a pdflatex-only machine and
+ * `compileLatex2Pdf` falls back to a single pdflatex pass on it (degraded —
+ * bibliography, cross-references, and index may be incomplete). So a
+ * pdflatex-only install passes the `latex.compiler` check and still exits
+ * nonzero on the `latex.latexmk` row. That predates this list becoming the
+ * single compiler definition and is deliberately left alone: demoting latexmk
+ * to a warning changes `doctorExitCode` for a real machine configuration,
+ * which is a product decision, not a consolidation.
+ */
 const REQUIRED_TOOLS = new Set<LatexToolName>(['latexmk']);
 
 /** Probe the LaTeX tools used by both the extension and CLI surfaces. */

--- a/src/latex/latexToolchain.ts
+++ b/src/latex/latexToolchain.ts
@@ -1,4 +1,7 @@
-import { CORE_LATEX_TOOLS } from '@shared/constants/latexToolchain';
+import {
+  CORE_LATEX_TOOLS,
+  SUPPORTED_LATEX_COMPILERS,
+} from '@shared/constants/latexToolchain';
 import { checkToolInstalled } from '@utils/system/toolUtils';
 
 // Kept in sync with @shared/constants/latex's CORE_LATEX_TOOLS SSOT: if one
@@ -28,8 +31,6 @@ interface LatexToolStatus {
 export interface LatexToolchainProbe {
   readonly tools: readonly LatexToolStatus[];
   readonly hasCompiler: boolean;
-  readonly hasBibliographyTool: boolean;
-  readonly hasLatexmk: boolean;
 }
 
 const TOOL_PURPOSES: Record<LatexToolName, string> = {
@@ -42,13 +43,6 @@ const TOOL_PURPOSES: Record<LatexToolName, string> = {
   latexdiff: 'LaTeX diff generation',
   latexindent: 'LaTeX formatting',
 };
-
-const COMPILER_TOOLS: readonly LatexToolName[] = [
-  'latexmk',
-  'pdflatex',
-  'xelatex',
-  'lualatex',
-];
 
 const REQUIRED_TOOLS = new Set<LatexToolName>(['latexmk']);
 
@@ -68,15 +62,13 @@ export async function probeLatexToolchain(): Promise<LatexToolchainProbe> {
   );
   return {
     tools,
-    hasCompiler: COMPILER_TOOLS.some((name) => installed.has(name)),
-    hasBibliographyTool: installed.has('bibtex') || installed.has('biber'),
-    hasLatexmk: installed.has('latexmk'),
+    hasCompiler: SUPPORTED_LATEX_COMPILERS.some((name) => installed.has(name)),
   };
 }
 
-/** Returns true when a supported LaTeX-to-PDF compiler is available. */
+/** Returns true when a compiler {@link compileLatex2Pdf} can drive is on PATH. */
 export async function hasLatexCompiler(): Promise<boolean> {
-  for (const tool of COMPILER_TOOLS) {
+  for (const tool of SUPPORTED_LATEX_COMPILERS) {
     if (await checkToolInstalled(tool, false)) return true;
   }
   return false;

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 // Local imports
 import { createLog } from '@logger/logUtils';
 import type { ExecResult, FileLocation } from '@shared/schemas';
+import { SUPPORTED_LATEX_COMPILERS } from '@shared/constants/latexToolchain';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { runToolWithCheck } from '@utils/system/toolUtils';
@@ -26,7 +27,7 @@ const LOG_TAIL_LINES = 200;
 const LaTeXCompileOptionsSchema = z.object({
   channel: z.string().optional(),
   outputDirectory: z.string().optional(),
-  compiler: z.enum(['pdflatex', 'latexmk']).default('latexmk'),
+  compiler: z.enum(SUPPORTED_LATEX_COMPILERS).default('latexmk'),
   /** Millisecond timeout per compiler invocation. Kills the child on expiry. */
   timeout: z.int().positive().optional(),
   /**

--- a/src/shared/constants/latexToolchain.ts
+++ b/src/shared/constants/latexToolchain.ts
@@ -34,6 +34,20 @@ export const CORE_LATEX_TOOLS = Object.freeze([
 
 export const IMAGE_TOOLS = Object.freeze(['gm', 'magick'] as const);
 
+/**
+ * The LaTeX-to-PDF compilers TeXRA can actually drive: `compileLatex2Pdf` runs
+ * `latexmk` and falls back to `pdflatex`. Nothing here can invoke `xelatex` or
+ * `lualatex` and no setting selects a compiler, so they must not count as "a
+ * compiler is available". Single source for that answer — the doctor probe,
+ * the compile-check guard, the compile option enum, and the settings view's
+ * TeX-distribution row — so none of them can disagree with the advice text.
+ * Lives beside {@link CORE_LATEX_TOOLS} for the same LAY-1 cycle reason.
+ */
+export const SUPPORTED_LATEX_COMPILERS = Object.freeze([
+  'latexmk',
+  'pdflatex',
+] as const);
+
 /** Supported OS platform keys for install guides. */
 export type OSPlatform = 'darwin' | 'win32' | 'linux';
 

--- a/src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts
+++ b/src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts
@@ -9,6 +9,7 @@ import { STATUS_DISPLAY, STATUS_ICONS, TODO_STATUS } from '@shared/schemas';
 import {
   CORE_LATEX_TOOLS,
   IMAGE_TOOLS,
+  SUPPORTED_LATEX_COMPILERS,
 } from '@shared/constants/latexToolchain';
 import { API_KEY_PROVIDER_IDS } from '@shared/constants/providers';
 import { TOOL_JSON_SCHEMA_OPTIONS } from '@shared/tools/toolJsonSchema';
@@ -38,6 +39,7 @@ const SHARED_LITERALS = [
   ['LEAN_PROJECT_COMMANDS entry', LEAN_PROJECT_COMMANDS.build],
   ['CORE_LATEX_TOOLS', CORE_LATEX_TOOLS],
   ['IMAGE_TOOLS', IMAGE_TOOLS],
+  ['SUPPORTED_LATEX_COMPILERS', SUPPORTED_LATEX_COMPILERS],
   [
     'LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS',
     LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS,

--- a/src/test-kernel/cli/Doctor.vitest.ts
+++ b/src/test-kernel/cli/Doctor.vitest.ts
@@ -39,8 +39,6 @@ const latexProbe = {
     },
   ],
   hasCompiler: true,
-  hasBibliographyTool: false,
-  hasLatexmk: false,
 } as const;
 
 const availableModels = [


### PR DESCRIPTION
## Summary

"Is a LaTeX compiler available?" had three answers in this repo, and they did
not agree:

1. `src/latex/latexToolchain.ts` — `COMPILER_TOOLS = ['latexmk', 'pdflatex',
   'xelatex', 'lualatex']`, feeding both `probeLatexToolchain().hasCompiler`
   and `hasLatexCompiler()`.
2. `src/latex/texTools.ts` — `compiler: z.enum(['pdflatex', 'latexmk'])`, the
   only compilers `compileLatex2Pdf` can actually invoke (`latexmk`, falling
   back to `pdflatex`).
3. `src/controllers/settingsView/LatexToolingController.ts` — `installed.pdflatex
   || installed.latexmk`, spelled out inline.

There is no setting that selects a compiler (`grep compiler src/shared/schemas`
returns nothing); the Zod enum is a per-call option whose only non-default
caller is `TikzPictureManager` passing `'pdflatex'`. So `xelatex` and
`lualatex` are unreachable as compilers — the only other repo mentions are a
tool-probe config and a doctor advice string.

The visible symptom is that **the guard and its own error message contradict
each other**: `compileCheck.ts:129` logs "neither latexmk nor pdflatex is
installed", `desktopPreviewHost.ts:112` says "Install latexmk or pdflatex",
and the CLI doctor said "Install latexmk, pdflatex, xelatex, or lualatex" —
all immediately after consulting a four-element list.

**Honest framing:** to actually mis-report, a machine needs xelatex or lualatex
present with *both* latexmk and pdflatex absent. In TeX Live / MacTeX / MiKTeX
`pdflatex` ships in the base and `xelatex` is the add-on, so that configuration
is close to unreachable in practice. This is sold as removing a contradiction
and a dead field, not as fixing a live user-facing bug.

## Issue acceptance gates

No issue — found by the latex-pipeline collapse sweep.

## Single source of truth

`SUPPORTED_LATEX_COMPILERS` in `src/shared/constants/latexToolchain.ts`, beside
`CORE_LATEX_TOOLS`. Three consumers in this PR: the toolchain probe
(`hasCompiler` + `hasLatexCompiler`), the `compileLatex2Pdf` option enum, and
`LatexToolingController.texDistributionInstalled`.

Home rationale: **not** `texTools.ts`. That module pulls in zod, `WorkspaceFS`,
and `configUtils`; importing it from `latexToolchain` would drag all of that
into the CLI `doctor` and desktop preview paths that today load a two-import
module. `@shared/constants/latexToolchain`'s own doc comment already states it
exists so `latex`, `tools`, and `controllers` can share tool-name facts without
the cross-subsystem cycle the LAY-1 edge ratchet forbids.

## Duplication and abstraction budget

Removed: one four-element list that disagreed with reality, one inline
two-element restatement, one hardcoded four-engine advice string, and two
probe fields no production code read. Added: one frozen shared constant. No new
module, class, or function.

## Net elements (R6)

- Files: 5 production modified, 2 test modified. 0 added, 0 deleted.
- Exported symbols: **+1** (`SUPPORTED_LATEX_COMPILERS`, consumed by three
  modules in this PR). Module-level constants: **−1** (`COMPILER_TOOLS`).
- Interfaces: `LatexToolchainProbe` **−2 fields** (`hasBibliographyTool`,
  `hasLatexmk`) and the two `Set` lookups that computed them on every probe.
- **Net LoC: +28 production** (+42 / −14), **±0 test** (+2 / −2).

Stated plainly: **this PR net-adds production lines.** The code shrinks (−8
lines of logic and dead fields); every added line is comment — 8 lines on the
new shared constant explaining why xelatex/lualatex are excluded (without it,
the next reader re-adds them) and 14 lines recording the known residual below.
The win here is one fewer contradictory definition and two fewer dead fields,
not a line count.

## Known residual (deliberate)

`REQUIRED_TOOLS = new Set(['latexmk'])` makes `checkLatex` emit a **failing**
`latex.latexmk` row whenever latexmk is absent, so a **pdflatex-only machine
passes the `latex.compiler` check this PR unified and still exits nonzero** —
the doctor dissents from the three surfaces that now agree, and from the
advice text this PR changed to "Install latexmk or pdflatex."

That predates this PR. It is **not** fixed here: demoting `latexmk` to a
warning (or rescoping the advice) changes `doctorExitCode` for a real machine
configuration, which is a product decision for the maintainer, not something to
slip into a consolidation PR. `compileLatex2Pdf` does compile on such a machine
but degrades to a single pdflatex pass — bibliography, cross-references, and
index may be incomplete — which is a defensible reason to keep failing it.

So the divergence is made loud instead of silent: it is documented at
`REQUIRED_TOOLS` itself, naming the consequence (`doctorExitCode`) so anyone
changing it knows what they are changing.

## Consumer counts (R8)

`grep -rn "hasCompiler\|hasBibliographyTool\|hasLatexmk\|probeLatexToolchain\|hasLatexCompiler\|COMPILER_TOOLS" src packages --include='*.ts' --include='*.tsx'`:

- `hasBibliographyTool` — 2 hits total: the definition and
  `src/test-kernel/cli/Doctor.vitest.ts:42`. **Zero production readers.**
- `hasLatexmk` — 2 hits total: the definition and `Doctor.vitest.ts:43`.
  **Zero production readers.** (`texra doctor` still reports latexmk via the
  `tools` array and `REQUIRED_TOOLS`, which are untouched — `latex.latexmk`
  remains a fail row for a pdflatex-only user.)
- `hasCompiler` — 1 production reader, `packages/cli/src/runtime/doctor.ts:258`.
- `hasLatexCompiler` — 2 production readers (`compileCheck.ts:127`,
  `desktopPreviewHost.ts:110`), both unchanged in behavior except that
  xelatex/lualatex-only now correctly report "no compiler".
- `COMPILER_TOOLS` — was file-local; all uses migrated.

`Doctor.vitest.ts` has exactly one `latex.*` assertion (`:189`,
`latex.latexmk` → fail), unaffected.

## Host impact

Extension: settings-view TeX-distribution row now derives from the shared
constant (same two tools, same result).

Desktop: `hasLatexCompiler()` no longer answers "yes" for an xelatex-only
machine, so the preview dialog's "Install latexmk or pdflatex" fires in the one
case where it used to compile and fail instead.

CLI: `texra doctor`'s `latex.compiler` advice is now "Install latexmk or
pdflatex." xelatex/lualatex keep their own warn rows via `TOOL_PURPOSES` /
`DOCTOR_ONLY_TOOLS` — deliberately left in place.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean.
- `pnpm --filter @texra-ai/cli typecheck` — clean (doctor.ts is CLI).
- `npx vitest run src/test-kernel/cli/Doctor.vitest.ts
  src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts
  src/test-kernel/latex src/test-kernel/controllers` — 54 files, 504 tests
  passing. The immutability ratchet gains one entry for the new frozen
  constant (an entry in the existing `it.each` table, not a new test).
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — run from the worktree (an export was
  added): 8 current vs 8 baselined, OK.
