### PR TITLE
fix(latex): one citation-macro list for extraction and latexdiff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ All notable changes to this project will be documented in this file.
   previously never applied, and xAI models without documented long-context
   rates now warn instead of silently billing flat. Rare request edge cases
   also no longer drop a request's body, headers, or cancellation.
+- **latexdiff no longer rewrites citations as changed prose** — `\citealp`,
+  `\citeauthor`, `\citeyear`, `\supercite`, `\smartcite`, `\nocite`, and
+  their capitalized forms are now recognized wherever citations are, so a diff
+  marks up the surrounding sentence instead of the bibliography key, and
+  citation-key extraction sees the same macros latexdiff does.
 - **A placeholder API key is rejected everywhere** — pasting a masked or
   example value such as `sk-xxxxxx` or `your-api-key` into Settings → Profile
   is now refused with an explanation, the way `texra` already refused it.

--- a/src/latex/extractBibliography.ts
+++ b/src/latex/extractBibliography.ts
@@ -14,32 +14,16 @@ import { WorkspaceFS } from '@utils/files/workspaceFS';
 import {
   collectBibliographyPaths,
   collectCommaSeparatedMatches,
+  LATEX_CITATION_COMMANDS,
   stripLatexComments,
 } from './latexParsingUtils';
 
 // Third-party imports - types
 import type { BibEntry } from 'bibtex';
 
-const CITE_COMMANDS = [
-  'cite',
-  'citet',
-  'citep',
-  'textcite',
-  'parencite',
-  'footcite',
-  'autocite',
-  'nocite',
-  'Cite',
-  'Citet',
-  'Citep',
-  'Textcite',
-  'Parencite',
-  'Footcite',
-];
-
 // Compiled regex patterns (matchAll clones the regex, so module-level is safe)
 const CITATION_PATTERN = new RegExp(
-  `\\\\(?:${CITE_COMMANDS.join('|')})\\*?(?:\\[[^\\]]*\\])*\\{([^}]*)\\}`,
+  `\\\\(?:${LATEX_CITATION_COMMANDS.join('|')})\\*?(?:\\[[^\\]]*\\])*\\{([^}]*)\\}`,
   'g',
 );
 

--- a/src/latex/latexParsingUtils.ts
+++ b/src/latex/latexParsingUtils.ts
@@ -15,6 +15,43 @@ import { ensureExtension, joinLatexPath } from '@utils/core/pathCore';
 
 const log = createLog('LatexParsing');
 
+/**
+ * Every citation macro TeXRA recognizes, natbib and biblatex alike, in both
+ * lowercase and sentence-case (`\Citep`) spellings. Single source for the two
+ * consumers that used to keep disjoint lists — citation-key extraction
+ * (`extractBibliography`) and latexdiff's `--exclude-textcmd`
+ * (`diffCommandExecutor`) — where a macro known to one but not the other means
+ * either a citation key silently missed or a bibliography marked up as prose.
+ *
+ * Sentence-case forms are generated, not listed: the ones no package defines
+ * (`\Nocite`) are inert in both consumers, an unmatched regex alternative and
+ * an unknown `--exclude-textcmd` entry respectively.
+ */
+const CITATION_COMMAND_STEMS = [
+  'cite',
+  'citet',
+  'citep',
+  'citealp',
+  'citealt',
+  'citeauthor',
+  'citeyear',
+  'citeyearpar',
+  'textcite',
+  'parencite',
+  'footcite',
+  'autocite',
+  'supercite',
+  'smartcite',
+  'nocite',
+] as const;
+
+export const LATEX_CITATION_COMMANDS: readonly string[] = Object.freeze([
+  ...CITATION_COMMAND_STEMS,
+  ...CITATION_COMMAND_STEMS.map(
+    (name) => `${name[0].toUpperCase()}${name.slice(1)}`,
+  ),
+]);
+
 /** Strips everything after an unescaped % on each line. */
 const COMMENT_PATTERN = /(^|[^\\])%.*$/gm;
 

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -6,6 +6,7 @@ import { executeCommand } from '@utils/system/execUtils';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 
 // Local file imports
+import { LATEX_CITATION_COMMANDS } from '../latexParsingUtils';
 import type { MathMarkupOption } from './mathMarkup';
 
 const LATEXDIFF_PICTURE_ENVIRONMENTS =
@@ -18,22 +19,12 @@ const BIBLIOGRAPHY_ERROR_PATTERNS = [
   'Running bibtex to generate',
 ] as const;
 
-export const LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS = Object.freeze([
-  'cite\\*?',
-  'citep\\*?',
-  'citet\\*?',
-  'citealp\\*?',
-  'citealt\\*?',
-  'citeauthor\\*?',
-  'citeyear\\*?',
-  'citeyearpar\\*?',
-  'parencite\\*?',
-  'textcite\\*?',
-  'autocite\\*?',
-  'footcite\\*?',
-  'supercite\\*?',
-  'smartcite\\*?',
-] as const);
+/**
+ * `--exclude-textcmd` argument: every citation macro, starred forms included,
+ * whose argument latexdiff must leave alone instead of marking up as prose.
+ */
+export const LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS: readonly string[] =
+  Object.freeze(LATEX_CITATION_COMMANDS.map((name) => `${name}\\*?`));
 
 export const LATEXDIFF_CHANGES_ONLY_SUBTYPE = 'ONLYCHANGEDPAGE';
 

--- a/src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts
+++ b/src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports
 import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
+import { LATEX_CITATION_COMMANDS } from '@latex/latexParsingUtils';
 import { LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS } from '@latex/latexdiff/diffCommandExecutor';
 import { MATH_MARKUP_OPTIONS } from '@latex/latexdiff/mathMarkup';
 import { STATUS_DISPLAY, STATUS_ICONS, TODO_STATUS } from '@shared/schemas';
@@ -42,6 +43,7 @@ const SHARED_LITERALS = [
     'LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS',
     LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS,
   ],
+  ['LATEX_CITATION_COMMANDS', LATEX_CITATION_COMMANDS],
   ['MATH_MARKUP_OPTIONS', MATH_MARKUP_OPTIONS],
   ['API_KEY_PROVIDER_IDS', API_KEY_PROVIDER_IDS],
   ['TOOL_JSON_SCHEMA_OPTIONS', TOOL_JSON_SCHEMA_OPTIONS],


### PR DESCRIPTION
## Summary

Two modules kept independent answers to "which LaTeX macros are citations",
and neither was a superset of the other:

- `src/latex/extractBibliography.ts` — `CITE_COMMANDS`, 14 names: the six
  common ones, `nocite`, and six capitalized variants.
- `src/latex/latexdiff/diffCommandExecutor.ts` —
  `LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS`, 14 fragments: the common ones
  plus `citealp`, `citealt`, `citeauthor`, `citeyear`, `citeyearpar`,
  `supercite`, `smartcite` — and no capitalized forms at all.

So `\citeauthor{Knuth1984}` was invisible to citation-key extraction, and
`\Citep{…}` was invisible to latexdiff's `--exclude-textcmd`, which means
latexdiff treated the bibliography key as prose and marked it up inside the
diff. Both lists claim to describe the same fact about LaTeX.

They now derive from one list. `LATEX_CITATION_COMMANDS` holds 15 lowercase
stems and generates the sentence-case spellings; extraction joins it into its
alternation, and the latexdiff flag maps it to `name\*?` fragments.

**This is a quality fix, not a refactor: it changes generated diff output** for
any document using the seven newly-excluded macros or a capitalized form. That
is the point — `\citeauthor{…}`'s argument stops being rewritten as changed
text. Capitalized forms no package defines (`\Nocite`, `\Citeyearpar`) are
inert: an unmatched regex alternative on one side, an unknown
`--exclude-textcmd` entry on the other.

## Issue acceptance gates

No issue — found by the latex-pipeline collapse sweep.

## Single source of truth

`LATEX_CITATION_COMMANDS` in `src/latex/latexParsingUtils.ts`.

Home rationale (not `diffCommandExecutor.ts`, where the longer list lived):
`extractBibliography.ts` already imports from `latexParsingUtils`, and
`latexParsingUtils` imports nothing from `latexdiff/` — so no cycle. Putting a
parsing fact in `diffCommandExecutor` would force `extractBibliography` to
import a module that pulls in `executeCommand` and `readPlatformSetting`.

A repo-wide grep for `citep|citet|autocite|parencite` confirms there is no
third owner: the only other hits are a `~\citep{` spacing rule in
`src/replacement/rules.ts` and a Zotero URL in a comment.

## Duplication and abstraction budget

Removed: two hand-maintained macro lists (14 + 14 entries) that had drifted
apart in both directions, and 6 hand-written capitalized spellings. Added: one
frozen shared constant, generated sentence-case variants, and a one-line
`.map()` at the latexdiff consumer. No new module, class, or function.

## Net elements (R6)

- Files: 3 production modified, 1 test modified, 1 changelog. 0 added, 0
  deleted.
- Exported symbols: **+1** (`LATEX_CITATION_COMMANDS`, two consumers in this
  PR). `LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS` keeps its name and its
  export — it is now derived rather than literal, so no consumer moves.
- Module-level literals: **−2** (`CITE_COMMANDS`, the 14-fragment exclusion
  array) **+1** (`CITATION_COMMAND_STEMS`, file-local).
- **Net LoC: +12 production** (+46 / −34), **+2 test**, **+5 changelog**.

Stated plainly: **this PR net-adds production lines.** Data shrinks (34 hand
written entries down to 15 stems plus a generator) but the shared constant
carries an 11-line doc comment stating the invariant and why the sentence-case
forms are generated. The win is that two lists cannot disagree again, plus
seven macros that citation extraction never saw; it is not a line-count
reduction.

## Consumer counts (R8)

`grep -rn "LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS\|CITE_COMMANDS\|CITATION_PATTERN" src packages --include='*.ts'`:

- `CITE_COMMANDS` — 2 hits, both inside `extractBibliography.ts` (definition
  and the `CITATION_PATTERN` build). No external consumer orphaned.
- `CITATION_PATTERN` — 2 hits, both in `extractBibliography.ts` (`:41`, `:83`).
  Unchanged apart from the name it joins.
- `LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS` — 1 production reader
  (`diffCommandExecutor.ts:116`, the `--exclude-textcmd` flag) and 1 test
  (`SharedLiteralImmutability.vitest.ts`). Both keep working: the export name,
  its frozen-ness, and its element shape are unchanged.
- `grep -rn "exclude-textcmd" src/test-kernel` — zero hits, so no test pins the
  flag's contents.

## Host impact

Extension / Desktop / CLI: identical. This is core `src/latex/` behavior shared
by all three — every latexdiff run gets the wider `--exclude-textcmd`, and
every bibliography extraction sees the wider macro set.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean.
- `npx vitest run src/test-kernel/latex
  src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts
  src/test-kernel/agent/output` — 274 tests passing. The immutability ratchet
  gains one entry (a row in the existing `it.each` table) for the new frozen
  export; the derived exclusions array is frozen too.
- `npm run lint` — clean.
- Behavior spot-check outside the suite: built the generated regex and flag
  string in a scratch script and confirmed `\citet{a}`, `\citep[see][p.2]{b}`,
  `\Citep{c}`, `\cite*{d}`, `\citeauthor{e}`, `\nocite{f}`, `\autocite{g}` all
  extract their key while `\notacite{h}` does not — i.e. the alternation
  backtracks correctly and needs no longest-first ordering.
- `npm run check:dead-code-ratchet` — run from the worktree (an export was
  added): 8 current vs 8 baselined, OK.
