### PR TITLE
refactor(latex): return the diff path from latexdiff, not a bare filename

### DIFF
--- a/packages/desktop/src/main/desktopProgressFileActions.ts
+++ b/packages/desktop/src/main/desktopProgressFileActions.ts
@@ -177,15 +177,14 @@ export class DesktopProgressFileActions {
       DEFAULT_MATH_MARKUP,
     );
 
-    if (!result.success || !result.diffFileName) {
+    if (!result.success || !result.diffPath) {
       await this.ui.showErrorMessage(
         result.message ?? 'Failed to generate diff file.',
       );
       return;
     }
 
-    const diffFilePath = path.join(path.dirname(baseFile), result.diffFileName);
-    await this.openDiffOutput(diffFilePath);
+    await this.openDiffOutput(result.diffPath);
   }
 
   async findAndOpenLabel(label: string): Promise<boolean> {
@@ -250,18 +249,12 @@ export class DesktopProgressFileActions {
     outcome: DiffRunOutcome,
   ): Promise<boolean> {
     const successes = outcome.results.filter(
-      (
-        entry,
-      ): entry is DiffRunResult & { basePath: string; diffFileName: string } =>
-        entry.success && Boolean(entry.basePath) && Boolean(entry.diffFileName),
+      (entry): entry is DiffRunResult & { diffPath: string } =>
+        entry.success && Boolean(entry.diffPath),
     );
 
     for (const result of successes) {
-      const diffFilePath = path.join(
-        path.dirname(result.basePath),
-        result.diffFileName,
-      );
-      await this.openDiffOutput(diffFilePath);
+      await this.openDiffOutput(result.diffPath);
     }
 
     return successes.length > 0;

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -1,6 +1,3 @@
-// Node imports
-import * as path from 'node:path';
-
 // Third-party imports
 import * as vscode from 'vscode';
 
@@ -126,15 +123,9 @@ interface OpenedLatexdiffResult {
  * file whose PDF is not viewer-ready.
  */
 async function openLatexdiffResult(
-  base: FileLocation,
-  diffFileName: string,
+  diffFilePath: string,
   options: { scheduleViewer?: boolean } = {},
 ): Promise<OpenedLatexdiffResult | undefined> {
-  const baseDirectory = path.extname(base.absolutePath)
-    ? path.dirname(base.absolutePath)
-    : base.absolutePath;
-  const diffFilePath = path.join(baseDirectory, diffFileName);
-
   const diffLocation = pathToLocation(diffFilePath);
 
   if (!(await AbsoluteFS.exists(diffLocation.absolutePath))) {
@@ -206,12 +197,10 @@ async function prepareLatexdiffResultsAndScheduleViewer(
     for (const result of results) {
       const suffix = result.description ? ` (${result.description})` : '';
 
-      if (result.success && result.basePath && result.diffFileName) {
-        const opened = await openLatexdiffResult(
-          pathToLocation(result.basePath),
-          result.diffFileName,
-          { scheduleViewer: false },
-        );
+      if (result.success && result.diffPath) {
+        const opened = await openLatexdiffResult(result.diffPath, {
+          scheduleViewer: false,
+        });
         if (opened) {
           lastProcessedLocation = opened.diffLocation;
           log.debug(
@@ -260,10 +249,10 @@ async function runDiffAndOpen(
   log.info(`Running ${toolLabel} with math markup mode: ${mathMarkup}`);
 
   const result = await runDiff(mathMarkup);
-  if (!result.success || !result.diffFileName) {
+  if (!result.success || !result.diffPath) {
     throw new Error(result.message ?? 'Failed to generate diff file');
   }
-  await openLatexdiffResult(fileToUseLocation, result.diffFileName);
+  await openLatexdiffResult(result.diffPath);
 }
 
 // Turn pack/clean run results into user notifications. Folds the notification

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -240,7 +240,6 @@ async function prepareLatexdiffResultsAndScheduleViewer(
  * underlying diff call and the tool name used for logging.
  */
 async function runDiffAndOpen(
-  fileToUseLocation: FileLocation,
   toolLabel: string,
   runDiff: (mathMarkup: MathMarkupOption) => Promise<LaTeXdiffResult>,
 ): Promise<void> {
@@ -303,7 +302,7 @@ async function handleLatexdiff(
 
   await withLatexdiffTool('latexdiff', 'Error creating LaTeX diff', () => {
     const fileToUseLocation = pathToLocation(fileToUse);
-    return runDiffAndOpen(fileToUseLocation, 'latexdiff', (mathMarkup) =>
+    return runDiffAndOpen('latexdiff', (mathMarkup) =>
       latexdiffService.runDiff(
         fileToUseLocation,
         pathToLocation(editedFile),
@@ -322,7 +321,7 @@ async function handleLatexdiffvc(
   const fileToUse = baseFile ?? inputFile;
   await withLatexdiffTool('latexdiff-vc', 'Error creating LaTeX diff', () => {
     const fileToUseLocation = pathToLocation(fileToUse);
-    return runDiffAndOpen(fileToUseLocation, 'latexdiff-vc', (mathMarkup) =>
+    return runDiffAndOpen('latexdiff-vc', (mathMarkup) =>
       latexdiffService.runDiffVc(fileToUseLocation, commitHash, mathMarkup),
     );
   });

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -18,6 +18,15 @@ import type { MathMarkupOption } from './latexdiff/mathMarkup';
 
 export interface LaTeXdiffResult {
   success: boolean;
+  /**
+   * Absolute path of the generated diff `.tex`. The service picks the output
+   * directory (an `outputDirectory` option, the input's folder, or the git
+   * root for `runDiffVc`), so only it can name the file — consumers must not
+   * re-join {@link LaTeXdiffResult.diffFileName} against a directory of their
+   * own guessing.
+   */
+  diffPath?: string;
+  /** Bare filename of the generated diff, for display and relative paths. */
   diffFileName?: string;
   message?: string;
 }
@@ -141,6 +150,7 @@ export class LaTeXdiffService {
 
       return {
         success: true,
+        diffPath: outputLocation.absolutePath,
         diffFileName,
         message: `LaTeXdiff completed successfully: ${diffFileName}`,
       };
@@ -193,6 +203,7 @@ export class LaTeXdiffService {
 
       return {
         success: true,
+        diffPath: outputPath,
         diffFileName,
         message: `LaTeXdiff VC completed successfully: ${diffFileName}`,
       };

--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -92,8 +92,7 @@ async function executeDiffOperations(
     results.push({
       success: diffResult.success,
       message: diffResult.message,
-      basePath: operation.base.absolutePath,
-      diffFileName: diffResult.diffFileName,
+      diffPath: diffResult.diffPath,
       description: operation.description,
     });
   }

--- a/src/latex/latexdiff/types.ts
+++ b/src/latex/latexdiff/types.ts
@@ -39,8 +39,8 @@ export type RunLatexdiffCommandConfig = Pick<
 export interface DiffRunResult {
   success: boolean;
   message?: string;
-  basePath?: string;
-  diffFileName?: string;
+  /** Absolute path of the generated diff, as reported by the diff service. */
+  diffPath?: string;
   description?: string;
 }
 

--- a/src/test-kernel/commands/LatexdiffRunPreparation.vitest.ts
+++ b/src/test-kernel/commands/LatexdiffRunPreparation.vitest.ts
@@ -154,16 +154,8 @@ vi.mock('vscode', () => ({
 import { registerLatexdiffCommands } from '@commands/latex/latexdiffCommands';
 
 const mixedResults = [
-  {
-    success: true,
-    basePath: '/workspace/base.tex',
-    diffFileName: 'diff-1.tex',
-  },
-  {
-    success: true,
-    basePath: '/tmp/base.tex',
-    diffFileName: 'diff-2.tex',
-  },
+  { success: true, diffPath: '/workspace/diff-1.tex' },
+  { success: true, diffPath: '/tmp/diff-2.tex' },
 ];
 
 const runConfig = {

--- a/src/test-kernel/desktop/DesktopProgressFileActions.vitest.ts
+++ b/src/test-kernel/desktop/DesktopProgressFileActions.vitest.ts
@@ -14,8 +14,7 @@ type DiffOutcome = {
   results: Array<{
     success: boolean;
     message?: string;
-    basePath?: string;
-    diffFileName?: string;
+    diffPath?: string;
   }>;
   totalOperations: number;
 };
@@ -26,11 +25,15 @@ function absolutePath(...segments: string[]): string {
   return path.join(path.sep, ...segments);
 }
 
+/** A successful run whose diff landed beside `basePath`, as the service reports it. */
 function successResult(
   basePath: string,
   diffFileName = 'main_diff.tex',
 ): DiffResult {
-  return { success: true, basePath, diffFileName };
+  return {
+    success: true,
+    diffPath: path.join(path.dirname(basePath), diffFileName),
+  };
 }
 
 function expectOpenedDiff(
@@ -66,7 +69,7 @@ async function loadFileActions(options: {
   fallbackResult?: {
     success: boolean;
     message?: string;
-    diffFileName?: string;
+    diffPath?: string;
   };
 }): Promise<{
   actions: InstanceType<
@@ -93,7 +96,7 @@ async function loadFileActions(options: {
     async () =>
       options.fallbackResult ?? {
         success: true,
-        diffFileName: 'main_diff.tex',
+        diffPath: absolutePath('workspace', 'main_diff.tex'),
       },
   );
 
@@ -225,7 +228,10 @@ describe('DesktopProgressFileActions latexdiff', () => {
     const { actions, openBuildDisplay, runLatexdiffForExecution, runDiff } =
       await loadFileActions({
         outcome: { results: [], totalOperations: 0 },
-        fallbackResult: { success: true, diffFileName: 'fallback_diff.tex' },
+        fallbackResult: {
+          success: true,
+          diffPath: absolutePath('workspace', 'fallback_diff.tex'),
+        },
       });
 
     await actions.diffAcceptedFilePair(
@@ -284,7 +290,10 @@ describe('DesktopProgressFileActions latexdiff', () => {
   it('falls back to single-file latexdiff when the shared core throws', async () => {
     const { actions, openBuildDisplay, runDiff } = await loadFileActions({
       throws: true,
-      fallbackResult: { success: true, diffFileName: 'fallback_diff.tex' },
+      fallbackResult: {
+        success: true,
+        diffPath: absolutePath('workspace', 'fallback_diff.tex'),
+      },
     });
 
     await actions.diffAcceptedFilePair(
@@ -309,7 +318,10 @@ describe('DesktopProgressFileActions latexdiff', () => {
         results: [{ success: false, message: 'missing base' }],
         totalOperations: 1,
       },
-      fallbackResult: { success: true, diffFileName: 'fallback_diff.tex' },
+      fallbackResult: {
+        success: true,
+        diffPath: absolutePath('workspace', 'fallback_diff.tex'),
+      },
     });
 
     await actions.diffAcceptedFilePair(

--- a/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
+++ b/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
@@ -184,7 +184,7 @@ describe('LaTeXdiffService shadow output', () => {
         expect.objectContaining({
           success: true,
           description: 'paper.tex (r1→r2)',
-          diffFileName: 'paper_diffr2r1.tex',
+          diffPath: path.join(firstDir, 'paper_diffr2r1.tex'),
         }),
       ]),
     );

--- a/src/tools/approval/latexPreview.ts
+++ b/src/tools/approval/latexPreview.ts
@@ -266,25 +266,12 @@ export async function runLatexdiff(
       },
     );
 
-    if (!result.success || !result.diffFileName) {
+    if (!result.success || !result.diffPath) {
       entry.onError(result.message ?? 'Failed to generate LaTeXdiff');
       return;
     }
 
-    // Validate filename to prevent path traversal
-    if (
-      result.diffFileName.includes('/') ||
-      result.diffFileName.includes('\\') ||
-      result.diffFileName.includes('..')
-    ) {
-      entry.onError('LaTeXdiff failed: invalid output filename');
-      return;
-    }
-
-    const diffFilePath = path.join(
-      path.dirname(originalPath),
-      result.diffFileName,
-    );
+    const diffFilePath = result.diffPath;
     registerCleanup(entry, async () => {
       await silentUnlink(diffFilePath);
       await cleanupLatexAuxFiles(diffFilePath);


### PR DESCRIPTION
## Summary

`LaTeXdiffService.runDiff` computes the absolute output path
(`path.join(outputDirectory, diffFileName)`), writes the diff there, post
processes it — and then returns only the basename. Five consumers rebuilt the
path from that name plus a directory they guessed:

| consumer | guessed directory |
|---|---|
| `src/tools/approval/latexPreview.ts` | `path.dirname(originalPath)` |
| `packages/extension/.../latexdiffCommands.ts` (`openLatexdiffResult`) | `path.extname(base) ? dirname(base) : base` |
| same file, results loop | `pathToLocation(result.basePath)` |
| `packages/desktop/.../desktopProgressFileActions.ts` (single-file) | `path.dirname(baseFile)` |
| same file, shared-results loop | `path.dirname(result.basePath)` |

`DiffRunResult.basePath` existed only to carry a directory forward so a
consumer could redo the join.

Every guess rests on an unwritten precondition: that nobody passed
`outputDirectory`. That option is public on `runDiff`, `runDiffForRound`, and
`runDiffBetweenRounds`; `executeDiffOperations` happens to call the wrappers
with `{ cwd }` only, and the one caller that does pass `outputDirectory`
(`LatexDiffManager`) happens not to go through `DiffRunResult`. Nothing
enforces either fact.

For `runDiffVc` the guess is **already wrong**: latexdiff-vc writes its output
relative to the git root (`cwd`), while `openLatexdiffResult` joined the
basename onto the *active file's* directory. A `.tex` in a repo subdirectory
therefore resolved to a path that does not exist. That is fixed as a
side-effect of the producer reporting its own path.

## Issue acceptance gates

No issue — found by the latex-pipeline collapse sweep. Note this one is
otherwise a **pure tidy**: no other call site was broken before this PR.

## Single source of truth

`LaTeXdiffService` (`src/latex/latexdiff.ts`) — it picks the output directory,
so it is the only thing that can name the file. `LaTeXdiffResult.diffPath`
carries the absolute path; `DiffRunResult.diffPath` forwards it.

**Deliberately a `string`, not a `FileLocation`.** `LatexDiffManager` wraps the
result in a **run-storage** location via `createRunStorageLocation(absolute,
relative, executionId)`; a `FileLocation` minted inside `src/latex/` would have
to invent a `kind` and a relative path from run-storage concepts the LaTeX
subsystem knows nothing about, and would silently mis-address the artifact
downstream. Each consumer wraps the string with the location constructor its
own storage kind requires.

**`diffFileName` deliberately stays on `LaTeXdiffResult`** — `LatexDiffManager`
needs the bare name for the relative half of its run-storage location, and the
success message quotes it. Only `DiffRunResult` sheds it (together with
`basePath`).

## Duplication and abstraction budget

Removed: 5 re-joins of a directory + filename, one `basePath` field that
existed only to feed them, and the dead `extname(base) ? dirname(base) : base`
directory branch in `openLatexdiffResult` (both call sites pass files; deleting
it is not a behavior change). Added: one field on each of two existing result
types. No new module, function, or class.

**Security note on the deleted guard.** `latexPreview` validated
`result.diffFileName` for `/`, `\`, and `..` before joining it. That guard is
removed with the join. `generateDiffFileName`
(`src/latex/latexdiff/diffFileNameManager.ts`) builds every component through
`path.basename` / `path.parse().name`, so no separator can survive it; and with
the producer returning an absolute path there is no consumer-side `path.join`
left for a relative component to escape from. The value now flows straight to
`openBuildDisplay`, not into a join.

## Net elements (R6)

- Files: 5 production modified, 3 test modified. 0 added, 0 deleted.
- Exported symbols: ±0. Interfaces: `LaTeXdiffResult` **+1 field**
  (`diffPath`); `DiffRunResult` **−2 fields** (`basePath`, `diffFileName`)
  **+1 field** (`diffPath`).
- Functions: ±0. `openLatexdiffResult` loses a parameter (2 → 1 plus options),
  and `runDiffAndOpen` loses `fileToUseLocation`, which lost its only read when
  `openLatexdiffResult` started taking a path. Nothing in this repo catches
  that: `noUnusedParameters` does not flag it and eslint's `no-unused-vars`
  only flags args *after* the last used one, so a leading unused parameter
  lands silently. Both call sites still keep the local for the diff call
  itself. Imports: **−1** (`node:path` in `latexdiffCommands.ts`, now unused).
- **Net LoC: −22 production** (+28 / −52), **−1 test** (+23 / −24).

## Consumer counts (R8)

`grep -rn "basePath\|diffFileName" src packages --include='*.ts' --include='*.tsx'`
before and after:

- `DiffRunResult.basePath` — 4 production readers before
  (`latexdiffCommands.ts:209,211`, `desktopProgressFileActions.ts:255,256,261`),
  0 after. Field deleted; no orphan.
- `DiffRunResult.diffFileName` — 3 production readers before
  (`latexdiffCommands.ts:212`, `desktopProgressFileActions.ts:256,262`), 0
  after.
- `LaTeXdiffResult.diffFileName` — **kept**; remaining readers are
  `LatexDiffManager.ts:74,368,373,374` (run-storage location) and the service's
  own success message. Verified those still compile and pass.
- Test fixtures that constructed the old shape:
  `DesktopProgressFileActions.vitest.ts` (helper + stub type),
  `LatexdiffRunPreparation.vitest.ts:156-166`,
  `LatexdiffShadowStorage.vitest.ts:187`. All migrated to `diffPath`; no new
  test case added. `DiffOperations.vitest.ts:40` stubs a `LaTeXdiffResult`
  (not a `DiffRunResult`) and needs no change.
- `grep -rn "exclude" …` n/a.

## Host impact

Extension: `openLatexdiffResult` takes a path instead of a base location; the
latexdiff-vc path now opens the file latexdiff-vc actually wrote.

Desktop: both diff-opening paths take the reported path.

CLI: no direct consumer — the CLI drives the same
`runLatexdiffForExecution`/`DiffRunResult` core, which keeps working through
`diffPath`.

## Scheduled refactoring

None. `latexdiff.ts:191`'s `filePath.replace('.tex', …)` (first-occurrence,
case-sensitive, unanchored — unlike every other spelling in this family) is
deliberately left byte-identical: changing it would change `runDiffVc` output
names, which is a separate decision.

## Validation

- `npm run typecheck` — clean.
- `npx vitest run src/test-kernel/latex src/test-kernel/desktop
  src/test-kernel/commands src/test-kernel/tools src/test-kernel/agent` —
  387 files, 4708 tests, all passing (4 pre-existing skips). Re-ran
  `src/test-kernel/commands src/test-kernel/latex src/test-kernel/desktop`
  (87 files, 804 tests) after the dead-parameter removal.
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — not run: no export added or removed
  (both changed symbols are fields on already-exported interfaces).
