### PR TITLE
fix: collapse relativeDisplayPath port; restore five sweep regressions (#10990, #10886, #10983)

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
@@ -38,8 +38,9 @@ import { subscribeToSignalChanges } from './signalSubscription';
 export const streamArtifactRevision = signal<number>(0);
 
 /** Streams whose artifacts have established provenance this session: a
- *  completed preload, or a live artifact write the adapter marked hydrated
- *  (see `readStreamArtifacts`). A stream absent here has no established disk
+ *  completed preload, an authoritative `load` (resume reconciliation), or a
+ *  live artifact write the adapter marked hydrated (see
+ *  `readStreamArtifacts`). A stream absent here has no established disk
  *  provenance yet, so render-time reads return `undefined` — callers fall
  *  back to empty defaults — instead of hitting unseeded getters (and their
  *  `warnIfUnseeded` noise) mid-preload (#10730). */
@@ -110,7 +111,7 @@ export function beginLoadedStreamsReconcile(retained: readonly StreamTabId[]): {
 /** Read the canonical artifact projection for one stream from the live session.
  *  Returns `undefined` when no default session exists yet (harness/tests) or
  *  when the stream has no established provenance this session: no completed
- *  preload and no live artifact write. `sessionSignalsAdapter` marks a stream
+ *  preload or resume `load`, and no live artifact write. `sessionSignalsAdapter` marks a stream
  *  hydrated on every live files, missing-outputs, compile-failures, usage,
  *  todos, or plan write, so a never-focused stream with live writes projects
  *  here too; callers default to empty values (`artifacts?.todos ?? []`) while

--- a/packages/desktop/src/main/desktopToolEditApproval.ts
+++ b/packages/desktop/src/main/desktopToolEditApproval.ts
@@ -7,7 +7,6 @@
  */
 
 import { readFile, rm } from 'node:fs/promises';
-import path from 'node:path';
 
 import type {
   ToolEditApprovalHost,
@@ -17,7 +16,6 @@ import type {
 import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 import { writeApprovalTempFiles } from '@tools/approval/tempFileManager';
 import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
-import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { createTexraTempDir } from '@utils/files/tempDir';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -60,14 +58,6 @@ export class DesktopToolEditApprovalHost implements ToolEditApprovalHost {
       originalPath,
       proposedPath,
     });
-  }
-
-  relativeDisplayPath(filePath: string): string {
-    try {
-      return WorkspaceFS.relativePath(filePath);
-    } catch {
-      return path.basename(filePath);
-    }
   }
 
   /**

--- a/packages/extension/src/frontend/approval/VscodeToolEditApprovalHost.ts
+++ b/packages/extension/src/frontend/approval/VscodeToolEditApprovalHost.ts
@@ -31,7 +31,6 @@ import {
   firstChangedLine,
   type ToolEditApprovalRequest,
 } from '@tools/approval/toolEditApproval';
-import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { pluralize } from '@utils/text/stringUtils';
 
 const CHANNEL = 'ToolEditApproval';
@@ -61,10 +60,6 @@ export class VscodeToolEditApprovalHost implements ToolEditApprovalHost {
       context,
       staged,
     );
-  }
-
-  relativeDisplayPath(filePath: string): string {
-    return vscode.workspace.asRelativePath(WorkspaceFS.fullPath(filePath));
   }
 
   async revealApprovalSurface(): Promise<void> {

--- a/packages/extension/src/webview/managers/FileManager.ts
+++ b/packages/extension/src/webview/managers/FileManager.ts
@@ -177,11 +177,8 @@ export class FileManager extends BaseWebviewManager {
     currentOpenFile: string,
   ): Promise<void> {
     if (plan.log) {
-      if (plan.log.level === 'info') {
-        log.info(plan.log.message);
-      } else {
-        log.warn(plan.log.message);
-      }
+      const logFn = plan.log.level === 'info' ? log.info : log.warn;
+      logFn(plan.log.message);
     }
 
     if (plan.notification) {

--- a/src/agent/implementations/flows/reflection/output/XmlOutputManager.ts
+++ b/src/agent/implementations/flows/reflection/output/XmlOutputManager.ts
@@ -430,9 +430,16 @@ export class XmlOutputManager {
     const roundDir = getFileDirectory(outputLocation);
 
     for (const doc of latexDocuments) {
-      const source = doc.name.trim();
-      if (!source || doc.name === 'unknown' || !doc.content) {
+      if (!doc.name || doc.name === 'unknown' || !doc.content) {
         this.logger.debug(`Skipping document with empty name or content`);
+        continue;
+      }
+
+      const source = doc.name.trim();
+      if (!source) {
+        this.logger.debug(
+          `Skipping document with empty source name after trimming`,
+        );
         continue;
       }
 

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -569,10 +569,14 @@ function sortAgentEntries(
   entries: AgentEntry[],
   preferredNames: readonly string[],
 ): AgentEntry[] {
-  const preferredIndex = new Map(preferredNames.map((name, i) => [name, i]));
+  const preferredSet = new Map(
+    preferredNames
+      .map((name, i) => [entries.find((e) => e.name === name), i] as const)
+      .filter(([entry]) => entry != null),
+  );
   return entries.toSorted((a, b) => {
-    const aIdx = preferredIndex.get(a.name);
-    const bIdx = preferredIndex.get(b.name);
+    const aIdx = preferredSet.get(a);
+    const bIdx = preferredSet.get(b);
     if (aIdx != null && bIdx != null) return aIdx - bIdx;
     if (aIdx != null) return -1;
     if (bIdx != null) return 1;

--- a/src/agent/runtime/restartRepair.ts
+++ b/src/agent/runtime/restartRepair.ts
@@ -108,21 +108,6 @@ function livenessCacheKey(owner: InstanceOwnerRecord): string {
   return `${owner.hostname}\0${owner.instanceId}\0${owner.socketPath}`;
 }
 
-function createCachedLivenessProbe(
-  probeOwner: (owner: InstanceOwnerRecord) => Promise<InstanceLiveness>,
-): (owner: InstanceOwnerRecord) => Promise<InstanceLiveness> {
-  const ownerLiveness = new Map<string, Promise<InstanceLiveness>>();
-  return (owner) => {
-    const key = livenessCacheKey(owner);
-    let liveness = ownerLiveness.get(key);
-    if (!liveness) {
-      liveness = probeOwner(owner);
-      ownerLiveness.set(key, liveness);
-    }
-    return liveness;
-  };
-}
-
 type ExecutionSettlement =
   | { readonly kind: 'unsettled' }
   | { readonly kind: 'settled'; readonly outcome: RunOutcome };
@@ -238,8 +223,18 @@ export async function repairRestartedStreams(
 ): Promise<RestartRepairResult> {
   const result: RestartRepairResult = { activeOwners: [] };
   const now = options.now ?? Date.now();
+  const probeOwner = options.probeOwner ?? probeInstance;
+  const ownerLiveness = new Map<string, Promise<InstanceLiveness>>();
   const inactiveLeaseOptions: InactiveExecutionLeaseOptions = {
-    probeOwner: createCachedLivenessProbe(options.probeOwner ?? probeInstance),
+    probeOwner: (owner) => {
+      const key = livenessCacheKey(owner);
+      let liveness = ownerLiveness.get(key);
+      if (!liveness) {
+        liveness = probeOwner(owner);
+        ownerLiveness.set(key, liveness);
+      }
+      return liveness;
+    },
   };
 
   for (const streamId of repairCandidates(

--- a/src/controllers/approval/ToolEditApprovalController.ts
+++ b/src/controllers/approval/ToolEditApprovalController.ts
@@ -7,6 +7,8 @@
  * what the user edited — lives behind {@link ToolEditApprovalHost}.
  */
 
+import path from 'node:path';
+
 import type { SessionHostInteractions } from '@agent/runtime/HostInteractions';
 import {
   cancellationResultFor,
@@ -35,9 +37,23 @@ import {
 } from '@tools/approval/toolEditApproval';
 import { generateShortId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { normalizeLineEndings } from '@utils/text/stringUtils';
 
 const CHANNEL = 'ToolEditApproval';
+
+/**
+ * Path shown to the user, relative to the workspace when there is one.
+ * A host without an initialized platform falls back to the basename rather
+ * than failing the request.
+ */
+function relativeDisplayPath(filePath: string): string {
+  try {
+    return WorkspaceFS.relativePath(filePath);
+  } catch {
+    return path.basename(filePath);
+  }
+}
 
 /** The host view of one staged request, live until the approval settles. */
 export interface ToolEditPreview {
@@ -75,8 +91,6 @@ export interface ToolEditApprovalHost {
     request: ToolEditApprovalRequest,
     context: ToolEditPreviewContext,
   ): Promise<ToolEditPreview>;
-  /** Path shown to the user, relative to the workspace when there is one. */
-  relativeDisplayPath(filePath: string): string;
   /**
    * Resolve once the surface that renders approval prompts is visible.
    * Awaiting it is what keeps a request cancelled while that surface opens
@@ -139,7 +153,7 @@ export class ToolEditApprovalController {
     }
 
     const requestId = `approval-${generateShortId()}`;
-    const relativePath = this.options.host.relativeDisplayPath(request.path);
+    const relativePath = relativeDisplayPath(request.path);
     const initialization: InitializingToolEditApproval = {
       phase: 'initializing',
       request,

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -52,13 +52,13 @@ export type LatexdiffTempFileLocation =
  * {@link ModelRetryMaxAttemptsSchema} and the settings-view reliability row so
  * the schema and the UI cannot disagree about the range.
  */
-export const MODEL_RETRY_MAX_ATTEMPTS_SETTING = {
+export const MODEL_RETRY_MAX_ATTEMPTS_SETTING = Object.freeze({
   defaultValue: 2,
   min: 0,
   max: 5,
   description:
     'Additional automatic retries after the initial model request (0–5). Long-running background requests retain at least two recovery retries.',
-} as const;
+} as const);
 
 /**
  * Bounds, default, and copy for `childRunConcurrencyBudget`. The value caps the
@@ -67,13 +67,13 @@ export const MODEL_RETRY_MAX_ATTEMPTS_SETTING = {
  * settings-view Multi-Agent tab so the schema, runtime, and UI cannot disagree
  * about the range.
  */
-export const CHILD_RUN_CONCURRENCY_BUDGET_SETTING = {
+export const CHILD_RUN_CONCURRENCY_BUDGET_SETTING = Object.freeze({
   defaultValue: 16,
   min: 1,
   max: 100,
   description:
     'Maximum number of live native child model conversations one session may run at once. Detached subagents beyond this wait for a slot to free.',
-} as const;
+} as const);
 
 export const DEFAULT_CORE_SETTINGS = {
   agentOutputs: {

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -132,7 +132,6 @@ function createPortSession(): {
       stagePreview: async () => {
         throw new Error('tool-edit approvals are not exercised here');
       },
-      relativeDisplayPath: (filePath) => filePath,
       revealApprovalSurface: async () => {},
       openBuildDisplay: async () => {},
       reportError: () => {},

--- a/src/test-kernel/controllers/ToolEditApprovalController.vitest.ts
+++ b/src/test-kernel/controllers/ToolEditApprovalController.vitest.ts
@@ -59,7 +59,6 @@ function createTestHost() {
         await staging.promise;
         return preview;
       },
-      relativeDisplayPath: (filePath: string) => filePath,
       revealApprovalSurface: async () => {},
       openBuildDisplay: async () => {},
       reportError: vi.fn(),


### PR DESCRIPTION
## Summary

Three small follow-up clusters, each verified against the current tree:

### #10983 — hydration provenance docs count the resume `load`
Follow-up to #10976: the two provenance enumerations in `packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts` omitted a real membership source — `beginLoadedStreamsReconcile(...).reconcile()` marks retained streams hydrated after an authoritative `load` on the resume path (`chatSessionController.ts`), which is neither a completed `preload` nor a live artifact write. Both doc blocks now say so. (This commit was review feedback on #10976 that landed after auto-merge had already fired; cherry-picked here.)

### #10990 — collapse `ToolEditApprovalHost.relativeDisplayPath` onto one derivation
The port was consumed at exactly one site. Verified the two host derivations are equivalent modulo the desktop fallback: `request.path` is always absolute (produced by `resolveWritableTarget`), both spellings agree for absolute paths, and they diverge only on uninitialized-platform — which the desktop `try/catch → basename` covers. `WorkspaceFS.relativePath` is host-neutral. The port field is deleted; a module-level `relativeDisplayPath()` helper in the controller (`WorkspaceFS.relativePath` + basename fallback) serves the single consumer. No new layer; no CLI implementation of the port exists.

### #10886 — restore five #10875-sweep regressions (claude-review inline findings)
1. **`Object.freeze` restored** on `CHILD_RUN_CONCURRENCY_BUDGET_SETTING` (pre-sweep spelling proven via `git log -L`) and added to sibling `MODEL_RETRY_MAX_ATTEMPTS_SETTING` — AGENTS.md:653 mandates `as const` + `Object.freeze` on shared literals crossing module boundaries.
2. **`sortAgentEntries` object keying restored.** Duplicate-named entries ARE possible: source-qualified identifiers (`custom:foo`, `remote:foo`) resolve to specific entries and dedup is by (source, name), so a selection/preset can deliver same-named entries from two sources. The name-string re-key would have sorted all of them first; the restored object keying pins exactly one physical entry per preferred name, as before the sweep.
3. **`XmlOutputManager` guard order restored**: `!doc.name || 'unknown' || !doc.content` (with its "empty name or content" debug) again precedes `doc.name.trim()`, and the distinct "empty source name after trimming" guard/message is back after it. Unreachable via today's producers, but `doc.name` traces to parsed LLM/XML output.
4. **`createCachedLivenessProbe` inlined** back into its single caller `repairRestartedStreams` (single-caller extraction rule).
5. **`FileManager` log ternary restored** (`createLog()\) returns bound closures, so the expansion was pure loss).

## Issue acceptance gates

- #10983: both provenance enumerations name the resume `load` path. ✅
- #10990: port deleted; one shared derivation at the single consumer; zero `relativeDisplayPath` port implementations remain. ✅
- #10886: all five verified findings restored to pre-sweep behavior/spelling. ✅ (The issue's "unverified UI surface" item is a manual-visual check, out of scope.)

## Single source of truth

- Approval-prompt display path: `relativeDisplayPath()` in `ToolEditApprovalController.ts` (was: two host derivations of the same fact).
- Liveness-probe memoization: one closure inside `repairRestartedStreams` (unchanged semantics, no factory).

## Duplication and abstraction budget

Removed: 1 port field (+2 host implementations +2 test-mock fields), 1 single-caller factory. Restored defensive guards/freeze the sweep had collapsed. No new abstractions.

## Net elements (R6)

- 11 files, +54/−53 (net +1; the restores re-add guards the sweep removed).
- Deleted symbols: 1 interface member (`relativeDisplayPath`), 1 function (`createCachedLivenessProbe`).
- Added: 1 module-private helper (single consumer). 0 new exports/files.

## Consumer counts (R8)

- `relativeDisplayPath` port: 1 consumer (controller) + 2 host implementations + 2 test mocks → 0 remain.
- `createCachedLivenessProbe`: 1 call site → inlined.
- `sortAgentEntries`: 1 call site (`agentRegistry.ts` internal); behavior for unique names unchanged, duplicate-name case restored to pre-sweep.

## Host impact

Extension: approval host method deleted; FileManager ternary.
Desktop: approval host method deleted (fallback preserved in the shared helper).
CLI: none (never implemented the port).

## Scheduled refactoring

None.

## Validation

- `npm run typecheck:workspace`, `typecheck:test-kernel`, `@texra/desktop typecheck`, `@texra-ai/cli typecheck` — pass.
- Targeted vitest: 23 suites / 399 tests pass (approval, agentRegistry, XmlOutputManager, restartRepair, coreSettings, FileManager, CLI approval-adjacent).
- ESLint clean on all 10 changed files; Prettier clean.

Closes #10990. Closes #10886. Closes #10983.