### PR TITLE
refactor(model): one definition of supportsReasoningLevel

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -51,7 +51,7 @@ import type {
   TokenValidationResult,
 } from '@agent/types/ModelHandlerContracts';
 import { createNeutralResponseTextProcessing } from '@agent/runtime/responseTextProcessing';
-import { hasConfigurableReasoningEffort } from '@agent/modelHandlers/support/reasoningEffort';
+import { supportsReasoningLevel } from '@agent/modelHandlers/support/reasoningEffort';
 import type { ServerToolExtractionResult } from '@agent/types/ServerTools';
 import {
   attachContextWindowError,
@@ -712,11 +712,7 @@ export abstract class ModelHandler<
    * see that predicate's own #7101 note on `requiresPerCallSystemPrompt`).
    */
   get supportsReasoningLevelOverride(): boolean {
-    return (
-      hasConfigurableReasoningEffort(this.config.capabilities) ||
-      (this.config.provider === ModelProvider.DEEPSEEK &&
-        this.config.capabilities.supportsReasoning)
-    );
+    return supportsReasoningLevel(this.config);
   }
 
   /**

--- a/src/agent/modelHandlers/support/reasoningEffort.ts
+++ b/src/agent/modelHandlers/support/reasoningEffort.ts
@@ -1,4 +1,9 @@
-import { ReasoningEffort, type ModelCapabilities } from 'llm-zoo';
+import {
+  ModelProvider,
+  ReasoningEffort,
+  type ModelCapabilities,
+  type ModelConfig,
+} from 'llm-zoo';
 
 import type { ReasoningEffort as OpenAIReasoningEffort } from 'openai/resources/shared';
 
@@ -18,7 +23,7 @@ export const LEVEL_TO_EFFORT: Readonly<Record<string, ReasoningEffort>> = {
 type NonNullOpenAIReasoningEffort = Exclude<OpenAIReasoningEffort, null>;
 
 /** Whether the model exposes a genuine user-selectable effort range. */
-export function hasConfigurableReasoningEffort(
+function hasConfigurableReasoningEffort(
   capabilities: ModelCapabilities,
 ): boolean {
   return (
@@ -27,6 +32,25 @@ export function hasConfigurableReasoningEffort(
       capabilities.reasoningEffort === ReasoningEffort.MAX &&
       capabilities.maxReasoningEffort === undefined
     )
+  );
+}
+
+/**
+ * Whether the model exposes a user-selectable reasoning level. This is the one
+ * definition behind both the handler getter (`ModelHandler
+ * .supportsReasoningLevelOverride`, read on every handler construction) and the
+ * Settings Models rows, so the control and the runtime can never disagree.
+ *
+ * DeepSeek is the extra term: its models declare `supportsReasoning` without a
+ * configurable effort range, yet still honour a level override.
+ */
+export function supportsReasoningLevel(
+  config: Pick<ModelConfig, 'provider' | 'capabilities'>,
+): boolean {
+  return (
+    hasConfigurableReasoningEffort(config.capabilities) ||
+    (config.provider === ModelProvider.DEEPSEEK &&
+      config.capabilities.supportsReasoning)
   );
 }
 

--- a/src/controllers/settingsView/SettingsModelSelectionController.ts
+++ b/src/controllers/settingsView/SettingsModelSelectionController.ts
@@ -1,8 +1,8 @@
 import { ModelProvider, type ModelConfig, ReasoningEffort } from 'llm-zoo';
 
 import {
-  hasConfigurableReasoningEffort,
   LEVEL_TO_EFFORT,
+  supportsReasoningLevel,
 } from '@agent/modelHandlers/support/reasoningEffort';
 import { preferredCopilotRouteModels } from '@model/copilotRouting';
 import { resolveModelSource } from '@model/openRouterRouting';
@@ -283,12 +283,4 @@ export class SettingsModelSelectionController {
       item.reasoningLevel = parsed.data;
     }
   }
-}
-
-function supportsReasoningLevel(config: ModelConfig): boolean {
-  return (
-    hasConfigurableReasoningEffort(config.capabilities) ||
-    (config.provider === ModelProvider.DEEPSEEK &&
-      config.capabilities.supportsReasoning)
-  );
 }


### PR DESCRIPTION
## Summary

`supportsReasoningLevel` — "does this model expose a user-selectable reasoning
level?" — was written out twice, character-identical apart from the receiver:

- `ModelHandler.supportsReasoningLevelOverride` (`ModelHandler.ts:714-720`),
  read by `ModelFactory.ts:163` on **every handler construction**;
- a module-private `supportsReasoningLevel(config)` in
  `SettingsModelSelectionController.ts:288-294`, read at :271 for **every row of
  the Settings → Models list**.

Two copies of the predicate that decides whether the runtime honours a reasoning
override and whether the UI offers the control. A drift between them shows up as
a control the user can set that the handler ignores (or the reverse), silently.

This folds both onto one definition in
`@agent/modelHandlers/support/reasoningEffort.ts` — the module both files were
already importing from. Pure dedup, no behavior change.

## Issue acceptance gates

n/a — no issue; sweep item C4 from the dual-systems (model-truth) sweep.

## Single source of truth

`supportsReasoningLevel(config)` in
`src/agent/modelHandlers/support/reasoningEffort.ts` now owns the predicate. It
takes `Pick<ModelConfig, 'provider' | 'capabilities'>` (the DeepSeek term needs
`provider`, so `ModelCapabilities` alone is not enough). The handler getter is a
one-line delegation; the controller calls it directly.

`hasConfigurableReasoningEffort` had exactly these two cross-module consumers,
so it is now module-private inside `reasoningEffort.ts`.

## Duplication and abstraction budget

Removed: one of two identical implementations. No new abstraction — the shared
predicate lands in the existing `reasoningEffort.ts` support module next to
`hasConfigurableReasoningEffort`, which it wraps; no new file, no new layer, no
new import edge (`controllers → agent` is already `value` in
`architecture-edges-baseline.json`).

## Net elements (R6)

- Files: **±0** (3 modified, 0 added, 0 deleted)
- Exported symbols: **±0** — `+export function supportsReasoningLevel`,
  `-export` on `hasConfigurableReasoningEffort` (now private)
- Functions: **−1** (the controller's private duplicate is deleted; the shared
  one replaces the handler's inline body)
- Implementations of the predicate: **2 → 1**
- Net LoC: **+29 / −17 = +12**, and I am not selling that as a reduction. The
  predicate body itself is −8; the +20 is a doc-comment explaining what the DeepSeek
  term is doing and that this is the single definition behind both the runtime
  and the settings control. The payoff is the closed drift hazard, not LoC.
- Tests: **0 added, 0 deleted** (behavior-preserving refactor).

## Consumer counts (R8)

```
grep -rn "supportsReasoningLevelOverride" src packages | grep -v node_modules
```
→ 13 hits: 8 in tests, 1 doc-comment in `IModelHandler.ts`, 2 in
`ModelFactory.ts` (:158 comment, :163 the read), the getter itself, and the new
doc-comment. All still resolve; the getter keeps its name and type.

```
grep -rn "hasConfigurableReasoningEffort" src packages | grep -v node_modules
```
→ after this change, 2 hits, both inside `reasoningEffort.ts` (definition + the
one call). No `packages/agent/src` re-export; the only other hits were built
`packages/agent/dist/` artifacts. Un-exporting orphans nobody, and
`check:dead-code-ratchet` is green (8 findings vs 8 baselined — it flagged the
now-unused export before I made it private, which is how I found it).

```
grep -rn "supportsReasoningLevel" src/controllers | grep -v node_modules
```
→ the controller's one call site at :271, now bound to the shared import.

## Host impact

Extension: none (Settings → Models rows compute identically).

Desktop: none (same controller).

CLI: none (does not read either site).

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean (full workspace: root, cli, trace-viewer, desktop,
  agent declarations).
- `npx vitest run src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
  src/test-kernel/agent/modelHandlers/ModelHandlerOpenRouterNative.vitest.ts` —
  80 passed. These are the suites that assert `supportsReasoningLevelOverride`
  directly (8 assertions across both).
- `npx vitest run src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts` —
  10 passed.
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — OK, no new unused exports.
