### PR TITLE
fix(tools): one HTML→Markdown Turndown config for web_fetch and .eml

### DIFF
--- a/src/tools/emlParser.ts
+++ b/src/tools/emlParser.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import PostalMime from 'postal-mime';
-import TurndownService from 'turndown';
+
+// Local imports
+import { createHtmlToMarkdown } from '@tools/htmlToMarkdown';
+
 import type { Address, Attachment, Email } from 'postal-mime';
 
 /** An image extracted from the email (inline or attached). */
@@ -27,10 +30,7 @@ interface AttachmentPartition {
 
 const IMAGE_MIME_PREFIX = 'image/';
 
-const turndownService = new TurndownService({ headingStyle: 'atx' }).remove([
-  'style',
-  'script',
-]);
+const turndownService = createHtmlToMarkdown();
 
 /**
  * Parse an EML file's raw text content into a human-readable representation,

--- a/src/tools/htmlToMarkdown.ts
+++ b/src/tools/htmlToMarkdown.ts
@@ -1,0 +1,29 @@
+// Third-party imports
+import TurndownService from 'turndown';
+import { gfm } from 'turndown-plugin-gfm';
+
+/**
+ * The one HTML→Markdown converter configuration for tools that feed fetched or
+ * parsed HTML into the model's context.
+ *
+ * `.remove(['style', 'script'])` matters for correctness, not tidiness:
+ * Turndown's default rules keep the *text* of `<style>` and `<script>`
+ * elements, so without it every inline CSS rule and every line of inline
+ * JavaScript on a page is handed to the model as prose. The GFM plugin is what
+ * keeps a `<table>` a table instead of a run of orphan cells.
+ *
+ * Returns a fresh service per call rather than a shared singleton: `.remove()`
+ * and `.addRule()` mutate the instance, so a shared one lets any consumer
+ * silently reconfigure every other consumer.
+ */
+export function createHtmlToMarkdown(): TurndownService {
+  return new TurndownService({
+    bulletListMarker: '-',
+    codeBlockStyle: 'fenced',
+    emDelimiter: '*',
+    headingStyle: 'atx',
+    strongDelimiter: '**',
+  })
+    .remove(['style', 'script'])
+    .use(gfm);
+}

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -4,7 +4,6 @@ import { isIP } from 'node:net';
 // Third-party imports
 import ky from 'ky';
 import { AbortError } from 'p-retry';
-import TurndownService from 'turndown';
 import { z } from 'zod';
 
 // Local imports - core
@@ -15,6 +14,7 @@ import {
   retryTransientFetch,
   toFetchToolError,
 } from '@tools/timeouts';
+import { createHtmlToMarkdown } from '@tools/htmlToMarkdown';
 import { defineTool } from '@tools/core/define';
 import { executed } from '@tools/core/result';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -101,7 +101,7 @@ export class WebFetchTool extends defineTool({
     'Fetch content from a URL and return it as clean text. Uses the native provider fetch tool when available; falls back to fetching HTML and converting to Markdown locally. Include an optional prompt to explain what context you need so the fetched content can be interpreted correctly.',
   schema: WebFetchInputSchema,
 }) {
-  private readonly turndown = new TurndownService({ headingStyle: 'atx' });
+  private readonly turndown = createHtmlToMarkdown();
 
   protected async execute(input: WebFetchInput): Promise<ToolResult> {
     const { url, prompt } = input;


### PR DESCRIPTION
## Summary

`web_fetch` and the `.eml` reader each constructed their own `TurndownService`, and the two
configurations had drifted apart. Neither had all three behaviors that matter, so each shipped a
different defect into the model's context.

I ran both live configurations against one input (`<h1>` + `<style>` + `<script>` + `<table>` +
`<del>` + `<ul>`). Before:

```
web_fetch (WebFetchTool.ts:104)  "# T\n\n.a{color:red}var x=1;\n\nA\n\nB\n\n1\n\n2\n\ngone and\n\n*   x"
.eml      (emlParser.ts:30)      "# T\n\nA\n\nB\n\n1\n\n2\n\ngone and\n\n*   x"
```

After (both):

```
"# T\n\n| A | B |\n| --- | --- |\n| 1 | 2 |\n\n~gone~ and\n\n-   x"
```

Three concrete defects fixed:

- **`web_fetch` shipped inline CSS and inline JavaScript to the model as prose.** It lacked
  `.remove(['style', 'script'])`; Turndown's default rules keep the *text* of those elements.
  `.eml` already removed them.
- **Both flattened every `<table>` into a run of orphan cells** (`A\n\nB\n\n1\n\n2`) and dropped
  `<del>` markup, because neither loaded `turndown-plugin-gfm`.
- **Both emitted Turndown's default `*` bullet marker** while the third Turndown configuration in
  the repo (`xmlConversion.ts:91`) uses `-`.

The new config is the union of all three configurations in the tree, so the surviving owner is
already correct if `xmlConversion.ts`'s copy is ever retired.

## Issue acceptance gates

No issue. Found by a dual-systems sweep over the text/render axis.

## Single source of truth

`createHtmlToMarkdown()` in `src/tools/htmlToMarkdown.ts` now owns the HTML→Markdown converter
configuration for tools that feed fetched or parsed HTML into the model's context.

It returns a **fresh service per call**, not a shared singleton: `.remove()` and `.addRule()`
mutate a `TurndownService`, so a shared exported instance would let any future consumer silently
reconfigure `web_fetch`. Runtime construction count is unchanged (2), only the configuration is
shared.

## Duplication and abstraction budget

Removed: two drifted copies of the same converter configuration. `TurndownService` constructions
in the tree drop from 3 to 2 (`htmlToMarkdown.ts` and the still-separate `xmlConversion.ts`, which
this PR deliberately does not touch — its own test pins its `-   ` output and its config belongs to
a separate, held candidate).

New abstraction: one exported factory with two real consumers (`WebFetchTool.ts:104`,
`emlParser.ts:32`). It owns the invariant "HTML entering the model's context does not carry
stylesheet or script text, and keeps tables as tables."

## Net elements (R6)

**This is a correctness merge, not an LoC reduction. It net-ADDS 29 lines. Stated plainly.**

| | delta |
|---|---|
| Files | **+1** (`src/tools/htmlToMarkdown.ts`) |
| Exported symbols | **+1** (`createHtmlToMarkdown`) |
| Classes / interfaces / enums | 0 |
| `new TurndownService(...)` sites | **3 → 2** |
| Net LoC | **+29** (`36 insertions(+), 7 deletions(-)`) |

Diffstat:

```
 src/tools/emlParser.ts        | 10 +++++-----
 src/tools/htmlToMarkdown.ts   | 29 +++++++++++++++++++++++++++++
 src/tools/web/WebFetchTool.ts |  4 ++--
 3 files changed, 36 insertions(+), 7 deletions(-)
```

The +29 buys three behavior fixes and a documented rationale comment; the shared config itself is
7 option lines that previously existed as 2 divergent copies.

## Consumer counts (R8)

No export deleted or re-routed. Greps run:

- `grep -rn "new TurndownService" src packages --include="*.ts" --include="*.tsx"` → 2 hits after
  the change (`htmlToMarkdown.ts:20`, `xmlConversion.ts:91`); 3 before.
- `grep -rn "turndown" src packages --include="*.ts" --include="*.tsx" --include="*.json"` → no
  remaining `import TurndownService` in `WebFetchTool.ts` or `emlParser.ts`.
- `grep -rn "emlParser\|parseEml" src packages` → consumers are `ReadTool.ts:15,161` and
  `EmlParser.vitest.ts`; both unaffected.
- New export has 2 consumers in this PR, satisfying exports-are-contracts.

## Host impact

Extension: `web_fetch` and `read_file` on `.eml` produce cleaner Markdown. No API change.

Desktop: same as extension (shares `src/tools/`).

CLI: same. No CLI-specific code touched.

**Manifests:** none changed. `turndown` and `turndown-plugin-gfm` are already declared together in
every manifest that carries either (root `package.json:182-183`, `packages/agent:110-111`,
`packages/extension:1105-1106`), so adding the GFM plugin to this path needs no new dependency.

**Ratchets:** none move. `config/ratchets/knip-baseline.json` contains none of these files;
`npm run check:dead-code-ratchet` reports 8 current vs 8 baselined.

## Scheduled refactoring

`src/utils/text/xmlConversion.ts:91` still holds a third `TurndownService` configuration. It is
deliberately left alone: it belongs to a separate candidate that needs a product ruling first (does
a LaTeX agent's scratchpad keep rendering `\section{X}` as `## X`, or start showing LaTeX source
verbatim?). The union config landed here is what that candidate would inherit.

## Validation

- `npm run typecheck` — clean (all projects: root, extension, cli, trace-viewer, desktop).
- `npx vitest run src/test-kernel/tools/EmlParser.vitest.ts src/test-kernel/utils/text/xmlUtils.vitest.ts`
  — 2 files, 12 tests, all passed, **unchanged**. `EmlParser.vitest.ts` asserts with regexes and has
  no bullet-marker assertion, so the marker change is invisible to it; `xmlUtils.vitest.ts` pins
  `xmlConversion`'s own config, which this PR does not change.
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — OK (run from the worktree), 8 current vs 8 baselined.
- `npm run format` — no changes.
- Behavioral evidence above produced by executing the real configurations against the installed
  `turndown@7.2.4` / `turndown-plugin-gfm@1.0.2`.

**Zero new tests**, per the testing budget: this is a small behavior fix whose evidence is in the
PR body, and the existing suite covers the style/script-suppression invariant already
(`EmlParser.vitest.ts:33-34`), which now holds for `web_fetch` too.
