### PR TITLE
fix(session): align roster and transcript lifecycles

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -859,7 +859,7 @@ function seedLiveToolOnlyTranscript(): void {
     });
   }
   writer.close();
-  syncStreamLog(STREAM_ID);
+  syncStreamLog(defaultSession(), STREAM_ID);
 }
 
 function makeRejectedBashToolEntries(): TranscriptRow[] {
@@ -915,7 +915,7 @@ function seedSubagentFollowupTranscript(): void {
     });
   }
   writer.close();
-  syncStreamLog(STREAM_ID);
+  syncStreamLog(defaultSession(), STREAM_ID);
 }
 
 function makeChildEntries(agent: string, action: string): TranscriptRow[] {
@@ -1352,7 +1352,7 @@ function seedWorkflowTimeline(): void {
   });
   secondRoundStage.end('completed');
   runStage.end('completed');
-  syncStreamLog(childStreamId);
+  syncStreamLog(defaultSession(), childStreamId);
   transitionStreamTerminal(childStreamId);
   emitChildRoster(STREAM_ID, []);
   runTrace.dispose();
@@ -1452,7 +1452,7 @@ function seedRunningWorkflow(): void {
   // Focus before projection: background workflow streams intentionally keep
   // only operational rows, while the focused stream owns the task transcript.
   activeStreamIdSignal.set(childStreamId);
-  syncStreamLog(childStreamId);
+  syncStreamLog(defaultSession(), childStreamId);
 
   const workflowChildren = [
     {

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -473,7 +473,9 @@ export function createChatSessionController(
             },
             onIdle: () => {
               if (!session.streamId) return;
-              syncStreamLog(session.streamId, { forceFinal: true });
+              syncStreamLog(runtimeSession, session.streamId, {
+                forceFinal: true,
+              });
             },
           },
         ),
@@ -481,7 +483,7 @@ export function createChatSessionController(
       .then((result) => {
         session.runExitCode = runOutcomeExitCode(result.outcome);
         if (result.streamId) {
-          syncStreamLog(result.streamId, { forceFinal: true });
+          syncStreamLog(runtimeSession, result.streamId, { forceFinal: true });
         }
         notify('agentFinished');
       })
@@ -574,7 +576,7 @@ export function createChatSessionController(
       // the slice and drops the retired mark so `syncStreamLog` and
       // `focusStream` accept it again.
       patchStream(resolution.streamId, (slice) => ({ ...slice }));
-      syncStreamLog(resolution.streamId);
+      syncStreamLog(runtimeSession, resolution.streamId);
       focusStream(resolution.streamId);
       // Re-reconcile now that focus has moved: a stale in-flight preload for the
       // previous stream that re-added it during the awaited load above is cleared
@@ -640,7 +642,7 @@ export function createChatSessionController(
    */
   const settleResumedTurn = (outcome: TurnOutcome): void => {
     if (session.streamId) {
-      syncStreamLog(session.streamId, { forceFinal: true });
+      syncStreamLog(runtimeSession, session.streamId, { forceFinal: true });
     }
     session.runExitCode = runOutcomeExitCode(outcome);
     if (outcome !== STREAM_PHASE.WAITING) {

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -336,7 +336,7 @@ export async function runChat(
   // navigate. Keep the project name while surfacing live attention state.
   const terminalTitleUpdates = installTerminalTitleUpdates(context.cwd);
   disposables.add(terminalTitleUpdates.dispose);
-  disposables.add(subscribeStreamLog());
+  disposables.add(subscribeStreamLog(runtimeSession));
   disposables.add(subscribeStreamArtifacts(runtimeSession.snapshots));
 
   const session = new TuiSession();

--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -21,7 +21,7 @@ import { formatCostUsd } from '@utils/text/stringUtils';
 
 import {
   childExecutionLabel,
-  retainedChildStreamsFor,
+  visibleSubagentRows,
   type ChildRosters,
 } from './childExecutions';
 import { streamPreferredUsage } from './subscribeStreamArtifacts';
@@ -163,7 +163,7 @@ export function collectResumeTargets({
   }
 
   for (const streamId of streams.keys()) {
-    for (const child of retainedChildStreamsFor(streamId, childRosters)) {
+    for (const child of visibleSubagentRows(streamId, childRosters)) {
       if (seen.has(child.executionId) || child.resumeEligible !== true) {
         continue;
       }

--- a/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
+++ b/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
@@ -222,9 +222,9 @@ export function attachSessionSignalsAdapter({
   bindChildStreamState(state);
   const renderer = new TuiSessionRenderer(state, snapshots, session);
   const applier = new SessionFactApplier(state, renderer, {
-    // Removal fires no renderer-port callback by design; the CLI is the
-    // delete executor in-process, so the roster/tombstone snapshots
-    // re-derive here, same-tick with the applier's removal barrier.
+    // The shared applier pushes any roster changes through the renderer. The
+    // CLI is also the delete executor in-process, so refresh tombstone-derived
+    // topology here in the same tick as the removal barrier.
     deleteStream: (streamId: StreamTabId) => {
       removeStream(streamId);
       invalidateChildStreams();
@@ -248,10 +248,11 @@ export function attachSessionSignalsAdapter({
       });
       if (recognized) {
         syncStreamLog(
+          session,
           fact.streamId,
           isTranscriptSettlementPhase(fact.phase) ? { forceFinal: true } : {},
         );
-        releaseInactiveStreamTranscript(fact.streamId);
+        releaseInactiveStreamTranscript(session.transcripts, fact.streamId);
       }
       // A completed or user-stopped child returns manual focus to that
       // child's immediate owner. WAITING, repair events, unrelated streams,

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -20,7 +20,6 @@
 // remain only to cover rows persisted before that landed; they are idempotent
 // on already-redacted text.
 
-import { defaultSession } from '@agent/runtime';
 import {
   AgentCategory,
   MESSAGE_TYPES,
@@ -31,7 +30,7 @@ import {
   isActivePhase,
   isTranscriptSettlementPhase,
 } from '@shared/streams/streamStatus';
-import { StreamLogDeltaBuffer } from '@transcript';
+import { StreamLogDeltaBuffer, type StreamLogStore } from '@transcript';
 import { createFlushableDebounce } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { transcriptRowHeadline } from '../panes/transcriptEntries';
@@ -65,6 +64,11 @@ import {
 // can land before the first sync fires); one animation frame is enough
 // to batch chunks and keeps the transcript feeling live.
 const STREAM_SYNC_THROTTLE_MS = 16;
+
+interface StreamLogSession {
+  readonly transcripts: StreamLogStore;
+  flushPendingTraces(): void;
+}
 
 /**
  * Store-emitted deltas awaiting the next batched sync, coalesced per stream.
@@ -127,9 +131,12 @@ export function streamRenderCacheSizesForTest(): {
 // Subscription + sync entry points
 // ---------------------------------------------------------------------------
 
-function trySyncStreamLog(streamId: StreamTabId): void {
+function trySyncStreamLog(
+  session: StreamLogSession,
+  streamId: StreamTabId,
+): void {
   try {
-    syncStreamLog(streamId);
+    syncStreamLog(session, streamId);
   } catch (error) {
     setTransientNotice(
       `Could not update transcript: ${toErrorMessage(error)}`,
@@ -138,8 +145,8 @@ function trySyncStreamLog(streamId: StreamTabId): void {
   }
 }
 
-export function subscribeStreamLog(): () => void {
-  const store = defaultSession().transcripts;
+export function subscribeStreamLog(session: StreamLogSession): () => void {
+  const store = session.transcripts;
   let previousActiveStreamId = activeStreamId.get();
 
   // One trailing timer shared by every stream: during a multi-subagent burst
@@ -153,7 +160,7 @@ export function subscribeStreamLog(): () => void {
         PENDING_DELTAS.delete(streamId);
         continue;
       }
-      trySyncStreamLog(streamId);
+      trySyncStreamLog(session, streamId);
     }
   }, STREAM_SYNC_THROTTLE_MS);
 
@@ -183,10 +190,10 @@ export function subscribeStreamLog(): () => void {
     previousActiveStreamId = nextActiveStreamId;
 
     if (previous && previous !== nextActiveStreamId) {
-      trySyncStreamLog(previous);
+      trySyncStreamLog(session, previous);
       // Terminal status normally requests eviction immediately. This focus
       // boundary remains a backstop when that status event was not observed.
-      releaseInactiveStreamTranscript(previous);
+      releaseInactiveStreamTranscript(session.transcripts, previous);
     }
     if (!nextActiveStreamId || nextActiveStreamId === previous) return;
 
@@ -195,7 +202,7 @@ export function subscribeStreamLog(): () => void {
       .ensureLoaded(nextActiveStreamId)
       .then(() => {
         if (generation === getCliStateGeneration()) {
-          trySyncStreamLog(nextActiveStreamId);
+          trySyncStreamLog(session, nextActiveStreamId);
         }
       })
       .catch((error: unknown) => {
@@ -220,6 +227,7 @@ export function subscribeStreamLog(): () => void {
 }
 
 export function syncStreamLog(
+  session: StreamLogSession,
   streamId: StreamTabId,
   options: {
     /** Treat the stream as final for settled-prefix promotion, even when its
@@ -239,7 +247,6 @@ export function syncStreamLog(
   // an in-memory buffer and never reaches the transcript. Force any
   // pending flushers to materialize before we read — their emissions land
   // in this stream's pending buffer and are folded below.
-  const session = defaultSession();
   session.flushPendingTraces();
   const store = session.transcripts;
   const log = store.get(streamId);
@@ -493,7 +500,10 @@ export function syncStreamLog(
  * from scratch — through the shared resync path — the next time this
  * stream syncs (e.g. if it's reactivated).
  */
-export function releaseInactiveStreamTranscript(streamId: StreamTabId): void {
+export function releaseInactiveStreamTranscript(
+  store: StreamLogStore,
+  streamId: StreamTabId,
+): void {
   const currentActiveStreamId = activeStreamId.get();
   if (
     currentActiveStreamId === undefined ||
@@ -503,7 +513,7 @@ export function releaseInactiveStreamTranscript(streamId: StreamTabId): void {
   }
   const slice = streams.get().get(streamId);
   if (slice?.status === undefined || isActivePhase(slice.status)) return;
-  defaultSession().transcripts.requestEviction(streamId);
+  store.requestEviction(streamId);
   const fold = slice.transcriptFold;
   if (fold) {
     resetTranscriptFoldState(fold);

--- a/src/controllers/progressView/backend/LitSessionRenderer.ts
+++ b/src/controllers/progressView/backend/LitSessionRenderer.ts
@@ -340,8 +340,11 @@ export class LitSessionRenderer implements SessionRendererPort {
       state.getStreamMetadata(stream).agentCategory ?? existingState?.category;
     if (category === undefined) return undefined;
 
+    if (includeActiveState) {
+      state.getOrCreateStreamState(stream, category);
+    }
     const executionState = includeActiveState
-      ? state.getOrCreateStreamState(stream, category)
+      ? state.getStreamState(stream)
       : undefined;
     return buildStreamContentRender(stream, category, {
       runUsage: mapToRecord(state.snapshots.getRunUsage(stream)),

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -292,7 +292,10 @@ export class SessionFactApplier {
       // The fresh attachment is the first delivery for the new incarnation,
       // even when a prior host delete left this applier's registry untouched.
       this.registeredWithRenderer.delete(fact.payload.streamId);
-      this.state.claimStreamIdentity(fact.payload.streamId);
+      const { changedRosterParents } = this.state.claimStreamIdentity(
+        fact.payload.streamId,
+      );
+      this.notifyRosterParents(changedRosterParents);
     }
     if (
       fact.type !== 'removeStream' &&
@@ -461,7 +464,7 @@ export class SessionFactApplier {
     // the re-claim lives in `handleSessionFact`, on the workflow attachment that
     // carries live-execution evidence for the new incarnation.
     if (this.state.isStreamRemoved(streamId)) {
-      this.deferRunFact(streamId, streamId, event);
+      this.deferRunFact(streamId, event);
       return;
     }
     this.applyRunFact(streamId, event);
@@ -529,11 +532,10 @@ export class SessionFactApplier {
 
   /** Buffer a refused run fact for a provisional barrier, or drop it. */
   private deferRunFact(
-    removedStreamId: StreamTabId,
     streamId: StreamTabId,
     event: SessionRunFactEvent,
   ): void {
-    const pending = this.pendingDeletions.get(removedStreamId);
+    const pending = this.pendingDeletions.get(streamId);
     if (pending) pending.facts.push({ kind: 'run', streamId, event });
   }
 

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -373,13 +373,16 @@ export class SessionFactApplier {
             // presentation repair fails; any other rejection leaves the
             // barrier in place and is logged by the event-error wrapper,
             // because the stream may have deleted.
-            const { incarnation: expectedIncarnation } =
+            const { incarnation: expectedIncarnation, changedRosterParents } =
               this.state.beginStreamRemoval(streamId);
             this.registeredWithRenderer.delete(streamId);
             const { pending, created } = this.beginPendingDeletion(
               streamId,
               expectedIncarnation,
             );
+            // Establish tombstone and pending-fact ownership first. Renderer
+            // delivery is best-effort and cannot prevent durable deletion.
+            this.notifyRosterParents(changedRosterParents);
             let settled = false;
             const settleDeletion = (
               outcome: void | DeleteStreamResult | undefined,
@@ -390,11 +393,25 @@ export class SessionFactApplier {
               if (!created || settled) return;
               settled = true;
               this.finishPendingDeletion(streamId, pending);
-              const retired =
-                (outcome === 'active' ||
-                  outcome === 'failed' ||
-                  outcome === 'superseded') &&
-                this.state.retireStreamTombstone(streamId, expectedIncarnation);
+              const retained = outcome === 'active' || outcome === 'failed';
+              const retirement =
+                retained || outcome === 'superseded'
+                  ? this.state.retireStreamTombstone(
+                      streamId,
+                      expectedIncarnation,
+                    )
+                  : { retired: false, changedRosterParents: [] };
+              const commitment =
+                !retained && outcome !== 'superseded'
+                  ? this.state.commitStreamTombstone(
+                      streamId,
+                      expectedIncarnation,
+                    )
+                  : { committed: false, changedRosterParents: [] };
+              this.notifyRosterParents([
+                ...retirement.changedRosterParents,
+                ...commitment.changedRosterParents,
+              ]);
               // A retained deletion still lives: replay the facts buffered
               // while it was provisional so status/stage/roster/metadata are
               // not stuck stale. Replay only when the retirement above
@@ -403,7 +420,7 @@ export class SessionFactApplier {
               // deletion B owns) must never replay through that newer
               // barrier. A committed deletion discards them (the stream is
               // gone).
-              if ((outcome === 'active' || outcome === 'failed') && retired) {
+              if (retained && retirement.retired) {
                 this.replayDeferredFacts(pending.facts);
               }
             };
@@ -436,15 +453,15 @@ export class SessionFactApplier {
   }
 
   handleRunFact(streamId: StreamTabId, event: SessionRunFactEvent): void {
-    // A run fact for a removed stream is stale by definition — for
-    // `child.activity` the fact's stream is the parent, so this also keeps a
-    // late roster from re-minting a removed parent's state. A delayed
-    // `run.start` therefore cannot reopen a committed tombstone; the re-claim
-    // lives in `handleSessionFact`, on the workflow attachment that carries
-    // live-execution evidence for the new incarnation. A provisional barrier
-    // buffers the fact so a retained deletion can replay it.
+    // A run fact for a removed stream is stale by definition. A
+    // `child.activity` snapshot is authoritative for its parent even when some
+    // listed children are tombstoned: canonical state accepts the whole fact,
+    // while SessionState's shared read projection hides those child rows until
+    // settlement. A delayed `run.start` cannot reopen a committed tombstone;
+    // the re-claim lives in `handleSessionFact`, on the workflow attachment that
+    // carries live-execution evidence for the new incarnation.
     if (this.state.isStreamRemoved(streamId)) {
-      this.deferRunFact(streamId, event);
+      this.deferRunFact(streamId, streamId, event);
       return;
     }
     this.applyRunFact(streamId, event);
@@ -512,10 +529,11 @@ export class SessionFactApplier {
 
   /** Buffer a refused run fact for a provisional barrier, or drop it. */
   private deferRunFact(
+    removedStreamId: StreamTabId,
     streamId: StreamTabId,
     event: SessionRunFactEvent,
   ): void {
-    const pending = this.pendingDeletions.get(streamId);
+    const pending = this.pendingDeletions.get(removedStreamId);
     if (pending) pending.facts.push({ kind: 'run', streamId, event });
   }
 
@@ -548,9 +566,11 @@ export class SessionFactApplier {
     incarnation: number;
     created: boolean;
   } {
-    const { incarnation, created } = this.state.beginStreamRemoval(streamId);
+    const { incarnation, created, changedRosterParents } =
+      this.state.beginStreamRemoval(streamId);
     this.registeredWithRenderer.delete(streamId);
     if (created) this.beginPendingDeletion(streamId, incarnation);
+    this.notifyRosterParents(changedRosterParents);
     return { incarnation, created };
   }
 
@@ -572,10 +592,21 @@ export class SessionFactApplier {
     if (pending && pending.incarnation === incarnation) {
       this.finishPendingDeletion(streamId, pending);
     }
-    const retired =
-      outcome !== 'deleted' &&
-      this.state.retireStreamTombstone(streamId, incarnation);
-    if (retired && (outcome === 'active' || outcome === 'failed') && pending) {
+    const retained =
+      outcome === 'active' || outcome === 'failed' || outcome === undefined;
+    const retirement =
+      outcome !== 'deleted'
+        ? this.state.retireStreamTombstone(streamId, incarnation)
+        : { retired: false, changedRosterParents: [] };
+    const commitment =
+      outcome === 'deleted'
+        ? this.state.commitStreamTombstone(streamId, incarnation)
+        : { committed: false, changedRosterParents: [] };
+    this.notifyRosterParents([
+      ...retirement.changedRosterParents,
+      ...commitment.changedRosterParents,
+    ]);
+    if (retirement.retired && retained && pending) {
       this.replayDeferredFacts(pending.facts);
     }
   }
@@ -717,13 +748,6 @@ export class SessionFactApplier {
     parentStreamId: StreamTabId,
     next: StreamExecutionState['subagents'],
   ): void {
-    // Rows naming a removed child stay removed: a stale roster cannot put a
-    // tombstoned identity back. Both the incoming snapshot and the previously
-    // stored roster are filtered, so the retention step below cannot re-add a
-    // removed child as a finished row.
-    next = next.filter(
-      (child) => !this.state.isStreamRemoved(child.childStreamId),
-    );
     // Roster facts can arrive before RUNNING/config creates the parent state
     // (TUI child-event-order `roster-first`). Provision a ToolUse bucket so
     // retention still runs; a later run.config refreshes the real category.
@@ -732,9 +756,7 @@ export class SessionFactApplier {
     this.state.getOrCreateStreamState(parentStreamId, category);
 
     this.state.updateStreamState(parentStreamId, (prev) => {
-      const previous = prev.subagents.filter(
-        (child) => !this.state.isStreamRemoved(child.childStreamId),
-      );
+      const previous = prev.subagents;
       const liveBefore = previous.filter(
         (child) => child.finishedAt === undefined,
       );
@@ -784,6 +806,28 @@ export class SessionFactApplier {
     });
   }
 
+  private notifyRosterParents(parents: readonly StreamTabId[]): void {
+    withEventErrorHandling(
+      'SessionFacts',
+      'failed to notify roster changes',
+      () => {
+        if (!this.renderer.isAvailable()) return;
+        for (const parent of parents) {
+          const parentState = this.state.getStreamState(parent);
+          if (!parentState) continue;
+          withEventErrorHandling(
+            'SessionFacts',
+            `failed to notify roster changes for ${parent}`,
+            () =>
+              this.renderer.onBadgesChanged(parent, {
+                subagents: parentState.subagents,
+              }),
+          );
+        }
+      },
+    );
+  }
+
   /**
    * Apply a stream status transition into session state and notify the
    * renderer. Awaitable so callers that need rehydrate to finish (tests,
@@ -807,10 +851,8 @@ export class SessionFactApplier {
     // rehydrate can never overwrite a later phase.
     //
     // This pre-await write is deliberately residual: a removal landing during
-    // the rehydrate await below cannot undo it. That is safe because the child
-    // untrack path emits `child.activity` before `removeStream`, so the parent
-    // roster drop supersedes any status this row carries, and
-    // `updateChildRoster` filters tombstoned children before retention.
+    // the rehydrate await below hides the child through the shared roster
+    // projection, and a committed deletion later scrubs its canonical rows.
     const rosterParents = this.state.recordChildPhase(streamId, status);
 
     // Active phases keep the full log resident for runtime writes. Terminal
@@ -847,13 +889,7 @@ export class SessionFactApplier {
     if (!this.renderer.isAvailable()) return;
 
     // Push the rows just written whenever the parent holding them is on screen.
-    for (const parent of rosterParents) {
-      const parentState = this.state.getStreamState(parent);
-      if (!parentState) continue;
-      this.renderer.onBadgesChanged(parent, {
-        subagents: parentState.subagents,
-      });
-    }
+    this.notifyRosterParents(rosterParents);
 
     const isNewStream = !this.state.streamLogs.has(streamId);
     this.state.streamLogs.ensureStream(streamId);

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -380,8 +380,20 @@ export class SessionState {
     }
   }
 
+  /**
+   * Read host-facing execution state. Parent rosters remain canonical while a
+   * child deletion is provisional; this shared projection hides tombstoned
+   * children from every host until that deletion settles.
+   */
   getStreamState(stream: StreamTabId): StreamExecutionState | undefined {
-    return this._streamStates.get(stream);
+    const state = this._streamStates.get(stream);
+    if (!state) return undefined;
+    const subagents = state.subagents.filter(
+      (child) => !this.isStreamRemoved(child.childStreamId),
+    );
+    return subagents.length === state.subagents.length
+      ? state
+      : { ...state, subagents };
   }
 
   /**
@@ -428,19 +440,32 @@ export class SessionState {
    * incarnation is returned with `created === false`, so a caller that finds
    * one can avoid starting a second deletion or touching/retiring a barrier
    * it does not own.
+   *
+   * Canonical parent rosters remain untouched while deletion is provisional.
+   * The shared read projection hides matching rows from every host.
    */
   beginStreamRemoval(stream: StreamTabId): {
     incarnation: number;
     created: boolean;
+    changedRosterParents: StreamTabId[];
   } {
     const existing = this._removedStreams.get(stream);
     if (existing !== undefined) {
-      return { incarnation: existing, created: false };
+      return {
+        incarnation: existing,
+        created: false,
+        changedRosterParents: [],
+      };
     }
     const incarnation = this.incarnationOf(stream);
     this._removedStreams.set(stream, incarnation);
     this._streamMetadataCache.delete(stream);
-    return { incarnation, created: true };
+
+    return {
+      incarnation,
+      created: true,
+      changedRosterParents: this.rosterParentsContaining(stream),
+    };
   }
 
   /**
@@ -454,6 +479,9 @@ export class SessionState {
   claimStreamIdentity(stream: StreamTabId): number {
     const next = this.incarnationOf(stream) + 1;
     this._streamIncarnations.set(stream, next);
+    // Rows from the prior incarnation must not become visible when dropping its
+    // tombstone. A fresh authoritative roster can add the new identity back.
+    this.scrubStreamFromRosters(stream);
     this._removedStreams.delete(stream);
     // A re-claimed identity starts a fresh run: drop any ephemeral session and
     // execution state the previous incarnation left behind (a provisional
@@ -483,25 +511,62 @@ export class SessionState {
 
   /**
    * Drop the tombstone only if it still belongs to `expectedIncarnation`.
-   * Used when a removal's durable delete ended in retention
-   * (`active`/`failed`/`superseded`): the stream still lives, so its facts
-   * must flow again. A fresh deletion B may already have installed its own
-   * barrier for a newer incarnation; this retirement must never remove that.
-   * Returns whether it actually removed the barrier: callers that buffer facts
-   * across a provisional deletion must replay them only when this returns
-   * true, so a superseded deletion A can never replay through deletion B's
-   * newer barrier.
+   * Canonical rosters already contain the newest authoritative rows, so retiring
+   * the projection barrier reveals them in their original order. A fresh claim
+   * or newer deletion invalidates this settlement through the incarnation check.
    */
   retireStreamTombstone(
     stream: StreamTabId,
     expectedIncarnation: number,
-  ): boolean {
-    if (this._removedStreams.get(stream) === expectedIncarnation) {
-      this._removedStreams.delete(stream);
-      this._streamMetadataCache.delete(stream);
-      return true;
+  ): { retired: boolean; changedRosterParents: StreamTabId[] } {
+    if (this._removedStreams.get(stream) !== expectedIncarnation) {
+      return { retired: false, changedRosterParents: [] };
     }
-    return false;
+
+    const changedRosterParents = this.rosterParentsContaining(stream);
+    this._removedStreams.delete(stream);
+    this._streamMetadataCache.delete(stream);
+    return { retired: true, changedRosterParents };
+  }
+
+  /**
+   * Finalize this incarnation's tombstone and scrub its canonical roster rows.
+   * Returns the parents whose host-facing projection must be refreshed.
+   */
+  commitStreamTombstone(
+    stream: StreamTabId,
+    expectedIncarnation: number,
+  ): { committed: boolean; changedRosterParents: StreamTabId[] } {
+    if (this._removedStreams.get(stream) !== expectedIncarnation) {
+      return { committed: false, changedRosterParents: [] };
+    }
+    return {
+      committed: true,
+      changedRosterParents: this.scrubStreamFromRosters(stream),
+    };
+  }
+
+  private rosterParentsContaining(stream: StreamTabId): StreamTabId[] {
+    const parents: StreamTabId[] = [];
+    for (const [parent, state] of this._streamStates) {
+      if (state.subagents.some((child) => child.childStreamId === stream)) {
+        parents.push(parent);
+      }
+    }
+    return parents;
+  }
+
+  private scrubStreamFromRosters(stream: StreamTabId): StreamTabId[] {
+    const changedParents: StreamTabId[] = [];
+    for (const [parent, state] of this._streamStates) {
+      const subagents = state.subagents.filter(
+        (child) => child.childStreamId !== stream,
+      );
+      if (subagents.length === state.subagents.length) continue;
+      this._streamStates.set(parent, { ...state, subagents });
+      changedParents.push(parent);
+    }
+    return changedParents;
   }
 
   private incarnationOf(stream: StreamTabId): number {
@@ -589,6 +654,7 @@ export class SessionState {
       this._sessionState.delete(stream);
       this._streamStates.delete(stream);
       this._streamMetadataCache.delete(stream);
+      this.scrubStreamFromRosters(stream);
       this._removedStreams.set(stream, this.incarnationOf(stream));
     };
     for (const stream of deletion.deleted) clearIdentity(stream);

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -476,12 +476,15 @@ export class SessionState {
    * claim — never from a bare `run.start`, which a delayed stale event could
    * replay after the deletion committed.
    */
-  claimStreamIdentity(stream: StreamTabId): number {
-    const next = this.incarnationOf(stream) + 1;
-    this._streamIncarnations.set(stream, next);
+  claimStreamIdentity(stream: StreamTabId): {
+    incarnation: number;
+    changedRosterParents: StreamTabId[];
+  } {
+    const incarnation = this.incarnationOf(stream) + 1;
+    this._streamIncarnations.set(stream, incarnation);
     // Rows from the prior incarnation must not become visible when dropping its
     // tombstone. A fresh authoritative roster can add the new identity back.
-    this.scrubStreamFromRosters(stream);
+    const changedRosterParents = this.scrubStreamFromRosters(stream);
     this._removedStreams.delete(stream);
     // A re-claimed identity starts a fresh run: drop any ephemeral session and
     // execution state the previous incarnation left behind (a provisional
@@ -490,7 +493,7 @@ export class SessionState {
     this._sessionState.delete(stream);
     this._streamStates.delete(stream);
     this._streamMetadataCache.delete(stream);
-    return next;
+    return { incarnation, changedRosterParents };
   }
 
   /** Whether `stream` was removed this session and must not be resurrected. */

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -365,7 +365,7 @@ describe('App foreground Escape ownership', () => {
         },
       });
     }
-    syncStreamLog(ROOT);
+    syncStreamLog(defaultSession(), ROOT);
     seedChildRoster(ROOT, [
       runningChild('workflow-child-execution', 'duplicate', CHILD),
       runningChild('workflow-review-execution', 'duplicate', GRANDCHILD),
@@ -384,7 +384,7 @@ describe('App foreground Escape ownership', () => {
       await waitFor(() => stdout.output.includes('Inspect · Running'));
       stdin.write('\r');
       await waitFor(() => activeStreamId.get() === CHILD);
-      syncStreamLog(ROOT);
+      syncStreamLog(defaultSession(), ROOT);
       expect(
         streams
           .get()

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -339,7 +339,7 @@ describe('CLI conversation transcript', () => {
       ],
     }));
 
-    syncStreamLog(STREAM_ID, { forceFinal: true });
+    syncStreamLog(defaultSession(), STREAM_ID, { forceFinal: true });
 
     expect(streams.get().get(STREAM_ID)?.finalizedFrontier).toBe(2);
     const split = splitSliceEntries(STREAM_ID, STREAM_PHASE.WAITING);
@@ -452,7 +452,7 @@ describe('CLI conversation transcript', () => {
     expect(split.finalized).toHaveLength(0);
     expect(split.pending.map((e) => e.id)).toEqual(['a1', 't1']);
 
-    syncStreamLog(streamId, { forceFinal: true });
+    syncStreamLog(defaultSession(), streamId, { forceFinal: true });
 
     split = splitSliceEntries(streamId, STREAM_PHASE.WAITING);
     expect(split.finalized.map((e) => e.id)).toEqual(['a1', 't1']);

--- a/src/test-kernel/cli/ResumeHint.vitest.ts
+++ b/src/test-kernel/cli/ResumeHint.vitest.ts
@@ -71,7 +71,7 @@ describe('collectResumeTargets', () => {
     ).toEqual([{ executionId: 'root', label: 'main', isRoot: true }]);
   });
 
-  it('lists resume-eligible subagents and excludes ineligible children', () => {
+  it('lists running and finished resume-eligible subagents', () => {
     const root = makeSlice({ streamId: 'main@m#root' });
     const reviewer = makeSlice({ streamId: 'reviewer@m#rev' });
     const builder = makeSlice({ streamId: 'builder@m#flow' });
@@ -83,6 +83,7 @@ describe('collectResumeTargets', () => {
           agentName: 'reviewer',
           identity: { kind: 'agent', agent: 'reviewer' },
           childStreamId: 'reviewer@m#rev' as StreamTabId,
+          finishedAt: undefined,
         }),
         child({
           executionId: 'flow',

--- a/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
+++ b/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
@@ -384,10 +384,10 @@ function syncBothAndCompare(
   // whichever mirrored stream synced first — restore the entering focus
   // around each sync (unset ⇒ both project the full transcript).
   const active = activeStreamId.get();
-  syncStreamLog(FOLD_STREAM, options);
+  syncStreamLog(defaultSession(), FOLD_STREAM, options);
   activeStreamId.set(active);
   invalidateTranscriptFoldForTest(ORACLE_STREAM);
-  syncStreamLog(ORACLE_STREAM, options);
+  syncStreamLog(defaultSession(), ORACLE_STREAM, options);
   activeStreamId.set(active);
   const fold = projectedView(streams.get().get(FOLD_STREAM));
   const oracle = projectedView(streams.get().get(ORACLE_STREAM));
@@ -410,7 +410,7 @@ function configureStreams(config: StreamConfig): void {
 
 /** Subscribe for the duration of `fn`, disposing even if an assertion throws. */
 function withStreamSubscription(fn: () => void): void {
-  const dispose = subscribeStreamLog();
+  const dispose = subscribeStreamLog(defaultSession());
   try {
     fn();
   } finally {
@@ -519,7 +519,7 @@ describe('transcript fold vs from-scratch oracle', () => {
         data: { kind: 'workflowAttempt', attemptId: 'current-attempt' },
       });
 
-      syncStreamLog(FOLD_STREAM);
+      syncStreamLog(defaultSession(), FOLD_STREAM);
 
       const slice = streams.get().get(FOLD_STREAM);
       expect(slice?.workflowAttemptId).toBe('current-attempt');
@@ -535,7 +535,7 @@ describe('transcript fold vs from-scratch oracle', () => {
         text: '',
         data: { kind: 'otherInternalRecord' },
       });
-      syncStreamLog(FOLD_STREAM);
+      syncStreamLog(defaultSession(), FOLD_STREAM);
       expect(streams.get().get(FOLD_STREAM)?.workflowAttemptId).toBe(
         'current-attempt',
       );
@@ -549,7 +549,7 @@ describe('transcript fold vs from-scratch oracle', () => {
         text: '',
         data: { kind: 'workflowAttempt', attemptId: '' },
       });
-      syncStreamLog(FOLD_STREAM);
+      syncStreamLog(defaultSession(), FOLD_STREAM);
       const invalidSlice = streams.get().get(FOLD_STREAM);
       expect(invalidSlice?.workflowAttemptId).toBeUndefined();
       expect(invalidSlice?.workflowAttemptBoundaryDeclared).toBe(true);
@@ -592,7 +592,7 @@ describe('transcript fold vs from-scratch oracle', () => {
         messageType: MESSAGE_TYPES.DEFAULT,
         text: 'Survey complete: 0/32 areas reported, 0 raw candidates',
       });
-      syncStreamLog(FOLD_STREAM);
+      syncStreamLog(defaultSession(), FOLD_STREAM);
       expect(
         streams
           .get()
@@ -623,7 +623,7 @@ describe('transcript fold vs from-scratch oracle', () => {
           attemptId: 'attempt-new',
         },
       });
-      syncStreamLog(FOLD_STREAM);
+      syncStreamLog(defaultSession(), FOLD_STREAM);
 
       const ids =
         streams
@@ -721,7 +721,7 @@ describe('transcript fold vs from-scratch oracle', () => {
 
   it('recovers from a delta gap by rebuilding through the oracle path', () => {
     const store = defaultSession().transcripts;
-    const first = subscribeStreamLog();
+    const first = subscribeStreamLog(defaultSession());
     appendTranscriptEntry(store, FOLD_STREAM, {
       id: 'u1',
       type: STREAM_LOG_ENTRY_TYPES.LOG,
@@ -730,7 +730,7 @@ describe('transcript fold vs from-scratch oracle', () => {
       messageType: MESSAGE_TYPES.USER_MESSAGE,
       text: 'first',
     });
-    syncStreamLog(FOLD_STREAM);
+    syncStreamLog(defaultSession(), FOLD_STREAM);
     expect(
       streams
         .get()
@@ -751,7 +751,7 @@ describe('transcript fold vs from-scratch oracle', () => {
       });
     }
 
-    const second = subscribeStreamLog();
+    const second = subscribeStreamLog(defaultSession());
     appendTranscriptEntry(store, FOLD_STREAM, {
       id: 'u4',
       type: STREAM_LOG_ENTRY_TYPES.LOG,
@@ -761,7 +761,7 @@ describe('transcript fold vs from-scratch oracle', () => {
       text: 'fourth',
     });
     const before = transcriptFoldCountersForTest();
-    syncStreamLog(FOLD_STREAM);
+    syncStreamLog(defaultSession(), FOLD_STREAM);
     const after = transcriptFoldCountersForTest();
 
     // The buffered delta's base does not match the fold state: the sync must

--- a/src/test-kernel/cli/SubscribeStreamLogDispose.vitest.ts
+++ b/src/test-kernel/cli/SubscribeStreamLogDispose.vitest.ts
@@ -60,7 +60,7 @@ function appendUserMessage(
 describe('subscribeStreamLog batching and dispose', () => {
   beforeEach(async () => {
     // No separate default-store export to swap in anymore (#7694) —
-    // `subscribeStreamLog()` reads the default session's own `transcripts`
+    // `subscribeStreamLog(defaultSession())` reads the default session's own `transcripts`
     // store, so clear it in place instead.
     await defaultSession().transcripts.clear();
     // Twice: the first reset retires the ids this suite reuses across tests,
@@ -75,7 +75,7 @@ describe('subscribeStreamLog batching and dispose', () => {
   });
 
   it('coalesces multiple store changes within the batch window into a single sync pass', () => {
-    const dispose = subscribeStreamLog();
+    const dispose = subscribeStreamLog(defaultSession());
     const store = defaultSession().transcripts;
 
     appendUserMessage(store, streamA, 'a-1', 'hello');
@@ -96,7 +96,7 @@ describe('subscribeStreamLog batching and dispose', () => {
   });
 
   it('dispose cancels a pending batch instead of flushing it', () => {
-    const dispose = subscribeStreamLog();
+    const dispose = subscribeStreamLog(defaultSession());
     const store = defaultSession().transcripts;
 
     appendUserMessage(store, streamA, 'a-1', 'hello');
@@ -109,10 +109,10 @@ describe('subscribeStreamLog batching and dispose', () => {
   });
 
   it('a later subscribeStreamLog call still batches normally after a prior dispose', () => {
-    const firstDispose = subscribeStreamLog();
+    const firstDispose = subscribeStreamLog(defaultSession());
     firstDispose();
 
-    const secondDispose = subscribeStreamLog();
+    const secondDispose = subscribeStreamLog(defaultSession());
     const store = defaultSession().transcripts;
     appendUserMessage(store, streamA, 'a-1', 'hello again');
     vi.advanceTimersByTime(16);
@@ -146,7 +146,7 @@ describe('subscribeStreamLog batching and dispose', () => {
       if (streamId === streamA) await loadGate;
     });
     const requestEviction = vi.spyOn(store, 'requestEviction');
-    const dispose = subscribeStreamLog();
+    const dispose = subscribeStreamLog(defaultSession());
 
     activeStreamId.set(streamA);
     await Promise.resolve();
@@ -171,8 +171,8 @@ describe('subscribeStreamLog batching and dispose', () => {
     activeStreamId.set(streamA);
     const requestEviction = vi.spyOn(store, 'requestEviction');
 
-    syncStreamLog(streamB);
-    releaseInactiveStreamTranscript(streamB);
+    syncStreamLog(defaultSession(), streamB);
+    releaseInactiveStreamTranscript(defaultSession().transcripts, streamB);
 
     expect(streams.get().get(streamB)).toMatchObject({
       latestLine: 'starting',
@@ -192,7 +192,7 @@ describe('subscribeStreamLog batching and dispose', () => {
     activeStreamId.set(streamA);
     const requestEviction = vi.spyOn(store, 'requestEviction');
 
-    releaseInactiveStreamTranscript(streamB);
+    releaseInactiveStreamTranscript(defaultSession().transcripts, streamB);
 
     expect(requestEviction).toHaveBeenCalledWith(streamB);
   });
@@ -211,10 +211,10 @@ describe('subscribeStreamLog batching and dispose', () => {
 
     // No focused stream: every stream projects the full transcript.
     activeStreamId.set(undefined);
-    releaseInactiveStreamTranscript(streamA);
+    releaseInactiveStreamTranscript(defaultSession().transcripts, streamA);
     // Focused: the active stream keeps its residency even when terminal.
     activeStreamId.set(streamA);
-    releaseInactiveStreamTranscript(streamA);
+    releaseInactiveStreamTranscript(defaultSession().transcripts, streamA);
 
     expect(requestEviction).not.toHaveBeenCalled();
   });
@@ -225,7 +225,7 @@ describe('subscribeStreamLog batching and dispose', () => {
     activeStreamId.set(streamA);
 
     // This sync is what seeds streamB's per-stream projection state.
-    syncStreamLog(streamB);
+    syncStreamLog(defaultSession(), streamB);
     expect(streamRenderCacheSizesForTest()).toEqual({
       taskGroups: 1,
       compaction: 1,
@@ -240,7 +240,7 @@ describe('subscribeStreamLog batching and dispose', () => {
       streamId: streamB,
       status: STREAM_PHASE.COMPLETED,
     });
-    releaseInactiveStreamTranscript(streamB);
+    releaseInactiveStreamTranscript(defaultSession().transcripts, streamB);
 
     expect(streamRenderCacheSizesForTest()).toEqual({
       taskGroups: 0,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -628,7 +628,11 @@ describe('cliState stream, focus, and child-edge fields', () => {
   it('removes stale child rows when a stream is removed', () => {
     withRunFacts((hub, session) => {
       activeStreamId.set(root);
-      trackStreams(session, root, child1);
+      trackStreams(session, root, child1, child2);
+      emitChildRoster(hub, root, [
+        childRosterRow('critic', child1, STREAM_PHASE.RUNNING, 'agent-1'),
+        childRosterRow('reviewer', child2, STREAM_PHASE.COMPLETED, 'agent-2'),
+      ]);
       emitChildRoster(hub, root, [
         childRosterRow('critic', child1, STREAM_PHASE.RUNNING, 'agent-1'),
       ]);
@@ -637,15 +641,13 @@ describe('cliState stream, focus, and child-edge fields', () => {
 
       expect(orderedSessionDescendants(root)[0]).toBe(child1);
 
-      // Production ordering: the untrack path drops the child from the
-      // roster before the removal fact lands, so removal never has to scrub
-      // the roster itself.
-      emitChildRoster(hub, root, []);
+      // Removal owns roster cleanup even if no preceding activity snapshot
+      // dropped the child.
       emitRemoveStream(hub, child1);
 
       expect(isChildStreamRemoved(child1)).toBe(true);
       expect(activeRows(root)).toEqual([]);
-      expect(orderedSessionDescendants(root)[0]).toBeUndefined();
+      expect(orderedSessionDescendants(root)).not.toContain(child1);
 
       // A stale roster cannot resurrect the tombstoned child — not even as a
       // retained history row: the applier filters removed children at write
@@ -653,9 +655,13 @@ describe('cliState stream, focus, and child-edge fields', () => {
       emitChildRoster(hub, root, [
         childRosterRow('critic', child1, STREAM_PHASE.RUNNING, 'agent-1'),
       ]);
-      expect(retainedRows(root)).toEqual([]);
+      expect(retainedRows(root)).toEqual([
+        expect.objectContaining({ childStreamId: child2 }),
+      ]);
       expect(activeRows(root)).toEqual([]);
-      expect(visibleRows(root)).toEqual([]);
+      expect(visibleRows(root)).toEqual([
+        expect.objectContaining({ childStreamId: child2 }),
+      ]);
     });
   });
 
@@ -2056,8 +2062,8 @@ describe('CLI transcript state', () => {
       },
     });
 
-    syncStreamLog(root);
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
+    syncStreamLog(defaultSession(), root);
 
     const entries = streamEntries(root);
     expect(entries).toHaveLength(1);
@@ -2093,7 +2099,7 @@ describe('CLI transcript state', () => {
       '<subagent-result id="abc" agent="review" category="toolUse" status="completed">\nDone.\n</subagent-result>',
     );
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     expect(entryTexts(root)).toEqual([
       'Please solve the problem.',
@@ -2114,7 +2120,7 @@ describe('CLI transcript state', () => {
       ].join('\n'),
     );
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     const entries = streamEntries(root);
     expect(entryTexts(root)).toEqual([
@@ -2135,7 +2141,7 @@ describe('CLI transcript state', () => {
       '<h3>Verification Report</h3>The proof is <b>fully verified</b>.',
     );
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     const entries = streamEntries(root);
     expect(entryTexts(root)).toEqual([
@@ -2164,7 +2170,7 @@ describe('CLI transcript state', () => {
       ].join('\n'),
     );
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     const entries = streamEntries(root);
     expect(entries).toHaveLength(1);
@@ -2182,7 +2188,7 @@ describe('CLI transcript state', () => {
     const logger = runTrace(root);
     logModelError(logger, 'Model request failed');
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     const entries = streamEntries(root);
     expect(entries).toHaveLength(1);
@@ -2200,7 +2206,7 @@ describe('CLI transcript state', () => {
       rawErrorBody: { apiKey: 'secret-must-not-render' },
     });
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     const entries = streamEntries(root);
     expect(entries).toHaveLength(1);
@@ -2230,7 +2236,7 @@ describe('CLI transcript state', () => {
       userRetryable: false,
     });
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     const lines = transcriptEntryLayout(streamEntries(root)[0]!, {
       width: 200,
@@ -2261,7 +2267,7 @@ describe('CLI transcript state', () => {
       },
     );
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     const entry = streamEntries(root)[0]!;
     expect(transcriptRowHeadline(entry)).toContain(
@@ -2286,7 +2292,7 @@ describe('CLI transcript state', () => {
       },
     });
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     const entries = streamEntries(root);
     expect(entries).toHaveLength(1);
@@ -2309,7 +2315,7 @@ describe('CLI transcript state', () => {
 
     // Opening the stream alone marks the phase — hidden reasoning (e.g.
     // gpt-5 without summaries) may never produce a text delta.
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     let slice = streams.get().get(root);
     expect(slice?.thinkingActive).toBe(true);
@@ -2318,7 +2324,7 @@ describe('CLI transcript state', () => {
 
     thinking.append('private reasoning summary');
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     slice = streams.get().get(root);
     expect(slice?.thinkingActive).toBe(true);
@@ -2327,7 +2333,7 @@ describe('CLI transcript state', () => {
     expect(entryTexts(root)).toEqual(['Thinking']);
 
     thinking.finalize();
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     slice = streams.get().get(root);
     expect(slice?.thinkingActive).toBe(false);
@@ -2335,7 +2341,7 @@ describe('CLI transcript state', () => {
     const output = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
     output.append('Visible answer.');
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     slice = streams.get().get(root);
     expect(slice?.thinkingActive).toBe(false);
@@ -2382,7 +2388,7 @@ describe('CLI transcript state', () => {
       ],
     }));
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     const slice = streams.get().get(root);
     expect(slice?.entries.map(({ kind }) => kind)).toEqual([
@@ -2411,7 +2417,7 @@ describe('CLI transcript state', () => {
     );
     logModelResponse(logger, 'raw workflow model response');
 
-    syncStreamLog(child1);
+    syncStreamLog(defaultSession(), child1);
 
     let slice = streams.get().get(child1);
     expect(slice?.latestLine).toBe('Preparing proof audit API_KEY=[redacted]');
@@ -2435,7 +2441,7 @@ describe('CLI transcript state', () => {
       summary: `Checking with Bearer ${ansiSplitSecret}\u0085`,
       status: 'completed',
     });
-    syncStreamLog(child1);
+    syncStreamLog(defaultSession(), child1);
     const toolDescription = streams.get().get(child1)?.latestLine;
     expect(toolDescription).toBe('Checking with Bearer [redacted]');
     expect(toolDescription).not.toContain(secret);
@@ -2449,7 +2455,7 @@ describe('CLI transcript state', () => {
       summary: '\u001b[31m\u001b[0m\u0007',
       status: 'completed',
     });
-    syncStreamLog(child1);
+    syncStreamLog(defaultSession(), child1);
     expect(streams.get().get(child1)?.latestLine).toBe('read_file');
 
     logger.openStage('Review lemmas', {
@@ -2458,11 +2464,11 @@ describe('CLI transcript state', () => {
       index: 1,
       total: 2,
     });
-    syncStreamLog(child1);
+    syncStreamLog(defaultSession(), child1);
     expect(streams.get().get(child1)?.latestLine).toBe('Review lemmas');
 
     logModelError(logger, 'Proof audit failed');
-    syncStreamLog(child1);
+    syncStreamLog(defaultSession(), child1);
 
     slice = streams.get().get(child1);
     expect(slice?.latestLine).toBe('Proof audit failed');
@@ -2493,7 +2499,7 @@ describe('CLI transcript state', () => {
       messageType: MESSAGE_TYPES.DEFAULT,
     });
 
-    syncStreamLog(child1);
+    syncStreamLog(defaultSession(), child1);
 
     expect(streams.get().get(child1)).toMatchObject({
       latestLine: 'Preparing dormant audit',
@@ -2507,7 +2513,7 @@ describe('CLI transcript state', () => {
       summary: 'Scanning proof obligations',
       status: 'completed',
     });
-    syncStreamLog(child1);
+    syncStreamLog(defaultSession(), child1);
 
     expect(streams.get().get(child1)).toMatchObject({
       latestLine: 'Scanning proof obligations',
@@ -2518,7 +2524,7 @@ describe('CLI transcript state', () => {
       id: 'dormant-review-phase',
       kind: 'phase',
     });
-    syncStreamLog(child1);
+    syncStreamLog(defaultSession(), child1);
 
     expect(streams.get().get(child1)).toMatchObject({
       latestLine: 'Checking dormant lemmas',
@@ -2532,7 +2538,7 @@ describe('CLI transcript state', () => {
     });
 
     logModelError(logger, 'Dormant audit failed');
-    syncStreamLog(child1);
+    syncStreamLog(defaultSession(), child1);
 
     const slice = streams.get().get(child1);
     expect(slice).toMatchObject({
@@ -2600,7 +2606,7 @@ describe('CLI transcript state', () => {
       kind: 'phase',
     });
 
-    syncStreamLog(child1);
+    syncStreamLog(defaultSession(), child1);
 
     const entries = streamEntries(child1);
     const dashboardEntries = entries.filter(
@@ -2652,7 +2658,7 @@ describe('CLI transcript state', () => {
       logUserMessage(logger, 'Check the second lemma.');
       logModelResponse(logger, 'The second lemma is valid.');
 
-      syncStreamLog(child1);
+      syncStreamLog(defaultSession(), child1);
 
       expect(streamMetadataFor(child1)?.description).toBe(
         'Audit the compactness lemma.',
@@ -2667,7 +2673,7 @@ describe('CLI transcript state', () => {
     const logger = runTrace(root);
     const activity = startCompactionActivity(logger);
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     let slice = streams.get().get(root);
     expect(slice?.compactingActive).toBe(true);
@@ -2681,7 +2687,7 @@ describe('CLI transcript state', () => {
     expect(entryFinalizedFlags(root)).toEqual([false]);
 
     activity.finish('completed');
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     slice = streams.get().get(root);
     expect(slice?.compactingActive).toBe(false);
@@ -2701,7 +2707,7 @@ describe('CLI transcript state', () => {
     const output = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
     output.append('Visible answer');
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     let entries = streamEntries(root);
     expect(entries).toMatchObject([
@@ -2716,7 +2722,7 @@ describe('CLI transcript state', () => {
     expect(entryFinalizedFlags(root)).toEqual([false, false]);
 
     activity.finish('completed');
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     entries = streamEntries(root);
     expect(entries).toMatchObject([
@@ -2742,11 +2748,11 @@ describe('CLI transcript state', () => {
     const logger = runTrace(root);
 
     const activity = startCompactionActivity(logger);
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
     expect(streams.get().get(root)?.compactingActive).toBe(true);
 
     logUserMessage(logger, 'A later turn started.');
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     let slice = streams.get().get(root);
     expect(slice?.compactingActive).toBe(false);
@@ -2762,7 +2768,7 @@ describe('CLI transcript state', () => {
     );
 
     activity.finish('completed');
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     slice = streams.get().get(root);
     expect(slice?.entries).toContainEqual(
@@ -2780,10 +2786,10 @@ describe('CLI transcript state', () => {
   it('finalizes unmatched compaction when the transcript settles', () => {
     const logger = runTrace(root);
     const activity = startCompactionActivity(logger);
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     setStatus(root, STREAM_PHASE.WAITING);
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     expect(streams.get().get(root)?.entries).toContainEqual(
       expect.objectContaining({
@@ -2799,7 +2805,7 @@ describe('CLI transcript state', () => {
     );
 
     activity.finish('completed');
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     expect(streams.get().get(root)?.entries).toContainEqual(
       expect.objectContaining({
@@ -2819,14 +2825,14 @@ describe('CLI transcript state', () => {
     const logger = runTrace(root);
     logModelResponse(logger, '');
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     let slice = streams.get().get(root);
     expect(slice?.entries ?? []).toEqual([]);
 
     logModelResponse(logger, 'Visible answer.');
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     slice = streams.get().get(root);
     expect(entryTexts(root)).toEqual(['Visible answer.']);
@@ -2837,7 +2843,7 @@ describe('CLI transcript state', () => {
     logUserMessage(logger, 'Why?');
     logModelResponse(logger, '\n\n  The answer starts here.');
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     expect(entryTexts(root)).toEqual(['Why?', '  The answer starts here.']);
   });
@@ -2853,15 +2859,15 @@ describe('CLI transcript state', () => {
     // only come from the frontier — the flag this regression is about.
     const output = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
     output.append('streaming assistant chunk');
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
     expect(entryFinalizedFlags(root)).toEqual([false]);
 
     // The turn-boundary finalize promotes the deferred-finalization entries.
-    syncStreamLog(root, { forceFinal: true });
+    syncStreamLog(defaultSession(), root, { forceFinal: true });
     expect(entryFinalizedFlags(root)).toEqual([true]);
 
     // A later ordinary sync must not regress the frontier behind them.
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     const entries = streamEntries(root);
     expect(entries).toHaveLength(1);
@@ -2886,7 +2892,7 @@ describe('CLI transcript state', () => {
     // The flow boundary's authoritative (replacement-cleaned) text.
     logger.responseFinalized('Done \\checkmark');
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     const entries = streamEntries(root);
     expect(entries).toHaveLength(1);
@@ -2899,7 +2905,7 @@ describe('CLI transcript state', () => {
     const logger = runTrace(root);
     logger.responseFinalized('The answer is 2.');
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     const entries = streamEntries(root);
     expect(entries).toHaveLength(1);
@@ -2915,7 +2921,7 @@ describe('CLI transcript state', () => {
     logModelResponse(logger, 'The second lemma is valid.');
     setStatus(child1, STREAM_PHASE.WAITING);
 
-    syncStreamLog(child1);
+    syncStreamLog(defaultSession(), child1);
 
     expect(streams.get().get(child1)).toMatchObject({
       latestLine: 'The second lemma is valid.',
@@ -2930,12 +2936,12 @@ describe('CLI transcript state', () => {
     logUserMessage(logger, 'Check the second lemma.');
     logModelResponse(logger, 'The second lemma is valid.');
     setStatus(child1, STREAM_PHASE.WAITING);
-    syncStreamLog(child1);
+    syncStreamLog(defaultSession(), child1);
 
     // Focusing the dormant stream is what requests the exact transcript:
     // the sync projects the full transcript for the active stream.
     activeStreamId.set(child1);
-    syncStreamLog(child1);
+    syncStreamLog(defaultSession(), child1);
 
     expect(
       streamEntries(child1).map((row) => [
@@ -2962,7 +2968,7 @@ describe('CLI transcript state', () => {
     logger.responseFinalized('Final answer.');
     round1.end();
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     const entries = streamEntries(root);
     expect(entryTexts(root)).toEqual(['Let me check that.', 'Final answer.']);
@@ -2974,7 +2980,7 @@ describe('CLI transcript state', () => {
     logUserMessage(logger, 'What is 1 + 1?');
     logModelResponse(logger, '2');
 
-    syncStreamLog(root, { forceFinal: true });
+    syncStreamLog(defaultSession(), root, { forceFinal: true });
 
     const entries = streamEntries(root);
     expect(entryTexts(root)).toEqual(['What is 1 + 1?', '2']);
@@ -3099,7 +3105,7 @@ describe('CLI transcript state', () => {
     const stream = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
     stream.append('A short final answer.');
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     expect(entryTexts(root)).toEqual(['A short final answer.']);
   });
@@ -3109,7 +3115,7 @@ describe('CLI transcript state', () => {
     logModelResponse(logger, 'A delayed final answer.');
     setStatus(root, STREAM_PHASE.WAITING);
 
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     const entries = streamEntries(root);
     expect(entries).toHaveLength(1);
@@ -3124,15 +3130,15 @@ describe('CLI transcript state', () => {
   it('keeps repeated local slash-command responses after stream-log syncs', () => {
     const logger = runTrace(root);
     logUserMessage(logger, 'prompt');
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
     activeStreamId.set(root);
 
     appendLocalAssistantTranscript('Available commands: /help');
     logModelResponse(logger, 'partial response');
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     appendLocalAssistantTranscript('Available commands: /help');
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     expect(
       streamEntries(root)
@@ -3237,11 +3243,11 @@ describe('CLI transcript state', () => {
   it('preserves the finalized response across later log syncs', () => {
     const logger = runTrace(root);
     logUserMessage(logger, '1+1');
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
     logger.responseFinalized('The answer is 2.');
 
     logUserMessage(logger, 'next prompt');
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     expect(entryTexts(root)).toEqual([
       '1+1',
@@ -3253,15 +3259,15 @@ describe('CLI transcript state', () => {
   it('orders multiple finalized responses relative to the turns around them', () => {
     const logger = runTrace(root);
     logUserMessage(logger, 'first prompt');
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
     logger.responseFinalized('first answer');
 
     logUserMessage(logger, 'second prompt');
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
     logger.responseFinalized('second answer');
 
     logUserMessage(logger, 'third prompt');
-    syncStreamLog(root);
+    syncStreamLog(defaultSession(), root);
 
     const entries = streamEntries(root);
     expect(entryTexts(root)).toEqual([

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
@@ -214,7 +214,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       id: 'sdk-session',
       kind: 'session',
     });
-    syncStreamLog(sdkStreamId);
+    syncStreamLog(defaultSession(), sdkStreamId);
 
     expect(
       streams.get().get(sdkStreamId)?.entries.map(transcriptRowHeadline),
@@ -233,7 +233,7 @@ describe('CLI workflow-script child-stream transcript', () => {
         call: { id, label, status: 'planned' },
       });
     }
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
 
     const plannedEntries = streamEntries();
     expect(plannedEntries).toMatchObject([
@@ -263,7 +263,7 @@ describe('CLI workflow-script child-stream transcript', () => {
         model: 'deepseekT',
       },
     });
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
 
     const updatedEntries = streamEntries();
     expect(updatedEntries).toMatchObject([
@@ -307,7 +307,7 @@ describe('CLI workflow-script child-stream transcript', () => {
     // This exercises both terminal-status finalization entry points:
     // syncStreamLog's settled-prefix promotion and the explicit
     // end-of-stream projection used by the controller.
-    syncStreamLog(STREAM_ID, { forceFinal: true });
+    syncStreamLog(defaultSession(), STREAM_ID, { forceFinal: true });
 
     const runningEntries = streamEntries();
     expect(runningEntries.at(0)).toMatchObject({
@@ -328,7 +328,7 @@ describe('CLI workflow-script child-stream transcript', () => {
         error: 'The workflow ended before this call completed.',
       },
     });
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
 
     const settledEntries = streamEntries();
     expect(settledEntries).toHaveLength(1);
@@ -343,8 +343,8 @@ describe('CLI workflow-script child-stream transcript', () => {
     ]);
     expect(finalizedFlags(settledEntries)).toEqual([true]);
     staticItems = appendItems(staticItems);
-    syncStreamLog(STREAM_ID, { forceFinal: true });
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID, { forceFinal: true });
+    syncStreamLog(defaultSession(), STREAM_ID);
     staticItems = appendItems(staticItems);
     expect(entryTexts(staticItems)).toEqual([
       'Failed: Audit cancellation — The workflow ended before this call completed.',
@@ -377,7 +377,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       streamId: STREAM_ID,
       status: STREAM_PHASE.CANCELLED,
     });
-    syncStreamLog(STREAM_ID, { forceFinal: true });
+    syncStreamLog(defaultSession(), STREAM_ID, { forceFinal: true });
 
     const plannedEntries = streamEntries();
     expect(plannedEntries.at(0)).toMatchObject({
@@ -398,7 +398,7 @@ describe('CLI workflow-script child-stream transcript', () => {
         reason: 'not-reached',
       },
     });
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
 
     const settledEntries = streamEntries();
     expect(settledEntries).toHaveLength(1);
@@ -414,8 +414,8 @@ describe('CLI workflow-script child-stream transcript', () => {
     ]);
     expect(finalizedFlags(settledEntries)).toEqual([true]);
     staticItems = appendItems(staticItems);
-    syncStreamLog(STREAM_ID, { forceFinal: true });
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID, { forceFinal: true });
+    syncStreamLog(defaultSession(), STREAM_ID);
     staticItems = appendItems(staticItems);
     expect(entryTexts(staticItems)).toEqual([
       'Skipped: Audit later — The workflow ended before this call was reached.',
@@ -435,7 +435,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       kind: 'phase',
     });
     appendLocalAssistantTranscript('Local cancellation checkpoint', STREAM_ID);
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
     let liveItems = appendItems();
     expect(entryIds(liveItems)).toEqual([
       'cancel-phase',
@@ -476,7 +476,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       streamId: STREAM_ID,
       status: STREAM_PHASE.CANCELLED,
     });
-    syncStreamLog(STREAM_ID, { forceFinal: true });
+    syncStreamLog(defaultSession(), STREAM_ID, { forceFinal: true });
 
     liveItems = appendItems(liveItems);
     expect(entryIds(liveItems)).toEqual([
@@ -526,7 +526,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       },
     });
     phase.end('cancelled');
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
 
     liveItems = appendItems(liveItems);
     expect(entryIds(liveItems)).toEqual([
@@ -548,7 +548,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       streamId: STREAM_ID,
       status: STREAM_PHASE.CANCELLED,
     });
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
     const coldItems = appendItems();
 
     expect(entryIds(coldItems)).toEqual(entryIds(liveItems));
@@ -583,7 +583,7 @@ describe('CLI workflow-script child-stream transcript', () => {
         },
       });
     }
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
 
     runTrace.trace.info('Preparing repository audit', {
       messageType: MESSAGE_TYPES.DEFAULT,
@@ -593,7 +593,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       id: 'audit-phase',
       kind: 'phase',
     });
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
 
     const buildState = (repaintEpoch = 0) =>
       buildStaticTranscriptState({
@@ -639,7 +639,7 @@ describe('CLI workflow-script child-stream transcript', () => {
         model: 'deepseekT',
       },
     });
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
     state = advance(state);
     expect(entryIds(state.items)).toEqual(['core-task']);
     const liveOutput = await renderStaticTranscript();
@@ -649,7 +649,7 @@ describe('CLI workflow-script child-stream transcript', () => {
     expect(liveOutput).not.toContain('Repository audit');
 
     phase.end('completed');
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
     state = advance(state);
     expect(entryIds(state.items)).toEqual(['core-task']);
 
@@ -666,7 +666,7 @@ describe('CLI workflow-script child-stream transcript', () => {
         },
       });
     }
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
     state = advance(state);
 
     const settledSlice = streamSlice();
@@ -707,7 +707,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       id: 'dynamic-phase',
       kind: 'phase',
     });
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
 
     runTrace.trace.emit({
       type: 'workflow.call',
@@ -720,7 +720,7 @@ describe('CLI workflow-script child-stream transcript', () => {
         status: 'running',
       },
     });
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
     const runningOutput = await renderStaticTranscript();
     expect(runningOutput).toContain('◆ Dynamic audit');
     expect(runningOutput).not.toContain('Finished: Inspect generated target');
@@ -738,7 +738,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       },
     });
     phase.end('completed');
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
 
     const output = await renderStaticTranscript();
     expect(output.indexOf('◆ Dynamic audit')).toBeLessThan(
@@ -846,7 +846,7 @@ describe('CLI workflow-script child-stream transcript', () => {
     runTrace.trace.info('Tool checkpoint recorded', {
       messageType: MESSAGE_TYPES.DEFAULT,
     });
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
 
     let incrementalItems = appendItems();
     expect(entryIds(incrementalItems)).not.toContain('audit-tool');
@@ -860,7 +860,7 @@ describe('CLI workflow-script child-stream transcript', () => {
         output: '/tmp/project',
       },
     });
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
     incrementalItems = appendItems(incrementalItems);
     const coldItems = appendItems();
 
@@ -896,7 +896,7 @@ describe('CLI workflow-script child-stream transcript', () => {
         ],
       },
     });
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
 
     const heldSplit = splitTranscriptEntries(
       streamEntries(),
@@ -923,7 +923,7 @@ describe('CLI workflow-script child-stream transcript', () => {
         output: '/tmp/project',
       },
     });
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
     incrementalItems = appendItems(incrementalItems);
     const coldItems = appendItems();
     expect(staticEntries(incrementalItems).map((entry) => entry.kind)).toEqual([
@@ -946,11 +946,11 @@ describe('CLI workflow-script child-stream transcript', () => {
     runTrace.trace.info('Round work completed', {
       messageType: MESSAGE_TYPES.DEFAULT,
     });
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
 
     const incrementalItems = appendItems();
     round.end('completed');
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
     const coldItems = appendItems();
     expect(entryTexts(incrementalItems)).toEqual(['Round work completed']);
     expect(entryTexts(coldItems)).toEqual(entryTexts(incrementalItems));
@@ -979,7 +979,7 @@ describe('CLI workflow-script child-stream transcript', () => {
         status: 'planned',
       },
     });
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
     expect(
       streamEntries()
         .filter((entry) => entry.id === 'introduction-task')
@@ -1017,7 +1017,7 @@ describe('CLI workflow-script child-stream transcript', () => {
     });
     phase.end('completed');
 
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
 
     const entries = streamEntries();
     const texts = entries.map(transcriptRowHeadline);
@@ -1044,7 +1044,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       streamId: STREAM_ID,
       status: STREAM_PHASE.COMPLETED,
     });
-    syncStreamLog(STREAM_ID);
+    syncStreamLog(defaultSession(), STREAM_ID);
 
     const finalized = streamEntries();
     expect(

--- a/src/test-kernel/cli/chatSessionController.vitest.ts
+++ b/src/test-kernel/cli/chatSessionController.vitest.ts
@@ -1218,17 +1218,23 @@ describe('createChatSessionController', () => {
     // this harness's storage-less platform now fails loudly (KVStore no
     // longer converts I/O errors into misses), which resume() treats as a
     // rehydration failure by contract.
-    const ctrl = createChatSessionController(
-      makeInit({ session, snapshotStore: makeResumeSnapshotStore({}) }),
-    );
+    const init = makeInit({
+      session,
+      snapshotStore: makeResumeSnapshotStore({}),
+    });
+    const ctrl = createChatSessionController(init);
 
     await ctrl.resume('exec-resume' as ExecutionId, makeResolvedResume());
     await session.runPromise;
 
     expect(session.runExitCode).toBe(CliExitCode.Success);
-    expect(mocks.syncStreamLog).toHaveBeenCalledWith('stream-resume', {
-      forceFinal: true,
-    });
+    expect(mocks.syncStreamLog).toHaveBeenCalledWith(
+      init.runtimeSession,
+      'stream-resume',
+      {
+        forceFinal: true,
+      },
+    );
     expect(mocks.notify).not.toHaveBeenCalledWith('agentFinished');
   });
 
@@ -1513,9 +1519,8 @@ describe('createChatSessionController', () => {
         return true;
       },
     );
-    const ctrl = createChatSessionController(
-      makeInit({ session, snapshotStore }),
-    );
+    const init = makeInit({ session, snapshotStore });
+    const ctrl = createChatSessionController(init);
 
     await expect(ctrl.tryResumeStream('stream-1')).resolves.toBe(true);
 
@@ -1532,9 +1537,11 @@ describe('createChatSessionController', () => {
     expect(resumeOptions?.canAcquireResumeLease?.()).toBe(true);
     session.stopRequested = true;
     expect(resumeOptions?.canAcquireResumeLease?.()).toBe(false);
-    expect(mocks.syncStreamLog).toHaveBeenCalledWith('stream-1', {
-      forceFinal: true,
-    });
+    expect(mocks.syncStreamLog).toHaveBeenCalledWith(
+      init.runtimeSession,
+      'stream-1',
+      { forceFinal: true },
+    );
     expect(rootStreamId.get()).toBe('stream-1');
     expect(mocks.notify).not.toHaveBeenCalledWith('agentFinished');
     expect(sessionMeta.get().cliMultiAgentPresetId).toBeUndefined();

--- a/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
@@ -1313,24 +1313,50 @@ describe('ProgressBackend', () => {
     ).toMatchObject({ name: stream, creationTimestamp: 100 });
   });
 
-  it('omits a provisionally removed stream from the selectable rail', () => {
-    const { backend } = createRecordingBackend();
-    const retained = 'retained-stream' as StreamTabId;
+  it('omits a provisionally removed stream from host projections', () => {
+    const { backend, messages } = createRecordingBackend();
+    const parent = 'retained-stream' as StreamTabId;
     const removing = 'removing-stream' as StreamTabId;
+    const child: ActiveChildInfo = {
+      executionId: 'exec:removing' as ExecutionId,
+      childStreamId: removing,
+      agentName: 'orchestrator',
+      identity: { kind: 'agent', agent: 'orchestrator' },
+      status: STREAM_PHASE.RUNNING,
+      startedAt: 1,
+    };
 
-    backend.state.streamLogs.ensureStream(retained);
+    backend.state.streamLogs.ensureStream(parent);
     backend.state.streamLogs.ensureStream(removing);
+    backend.state.updateStreamMetadata(parent, {
+      agentCategory: AgentCategory.ToolUse,
+    });
+    backend.state.getOrCreateStreamState(parent, AgentCategory.ToolUse);
+    backend.state.updateStreamState(parent, (state) => ({
+      ...state,
+      subagents: [child],
+    }));
     backend.state.beginStreamRemoval(removing);
+    backend.renderer.syncStreamContent(parent, { includeActiveState: true });
 
-    // The durable transcript stays resident until the guarded deletion
-    // commits, but the removal barrier is already the live membership
-    // authority for every stream-tab projection.
+    // The durable transcript and canonical parent roster stay resident until
+    // guarded deletion commits, but the removal barrier is already the live
+    // membership authority for every host-facing projection.
     expect(backend.state.streamLogs.has(removing)).toBe(true);
-    expect(backend.state.selectableStreamNames()).toContain(retained);
+    expect(backend.state.selectableStreamNames()).toContain(parent);
     expect(backend.state.selectableStreamNames()).not.toContain(removing);
     expect(
       buildStreamInfos(backend.state).map((stream) => stream.name),
     ).not.toContain(removing);
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        command: PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
+        stream: parent,
+        activeState: expect.objectContaining({
+          badges: { subagents: [] },
+        }),
+      }),
+    );
   });
 
   it('keeps a dated tab dated after its transcript is released', () => {

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -24,6 +24,7 @@ import * as logger from '@logger/logUtils';
 import {
   AgentCategory,
   STREAM_PHASE,
+  type ActiveChildInfo,
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
@@ -57,6 +58,29 @@ function emitRemoveStream(
     scope: 'session',
     event: { type: 'removeStream', payload: { streamId } },
   });
+}
+
+function childRosterRow(
+  childStreamId: StreamTabId,
+  executionId = `execution:${childStreamId}` as ExecutionId,
+): ActiveChildInfo {
+  return {
+    executionId,
+    childStreamId,
+    agentName: 'orchestrator',
+    identity: { kind: 'agent', agent: 'orchestrator' },
+    status: STREAM_PHASE.RUNNING,
+    startedAt: 1,
+  };
+}
+
+function setChildRoster(
+  backend: RecordingTarget['backend'],
+  parent: StreamTabId,
+  subagents: ActiveChildInfo[],
+): void {
+  backend.state.getOrCreateStreamState(parent, AgentCategory.ToolUse);
+  backend.state.updateStreamState(parent, (state) => ({ ...state, subagents }));
 }
 
 function stubClearAll(
@@ -205,51 +229,148 @@ describe('ProgressBackend', () => {
     const { backend } = target;
     backend.setupEventListeners();
     const streamId = 'desktop-child-stream' as StreamTabId;
+    const parent = 'desktop-parent-stream' as StreamTabId;
+    const before = childRosterRow('desktop-before' as StreamTabId);
+    const child = childRosterRow(streamId);
+    const after = childRosterRow('desktop-after' as StreamTabId);
 
     try {
       backend.state.streamLogs.ensureStream(streamId);
       backend.state.getOrCreateStreamState(streamId, AgentCategory.ToolUse);
+      setChildRoster(backend, parent, [before, child, after]);
+      const badgesChanged = vi.spyOn(backend.renderer, 'onBadgesChanged');
 
       emitRemoveStream(target, streamId);
 
       await vi.waitFor(() => expect(deletedStreams).toEqual([streamId]));
       expect(backend.state.streamLogs.has(streamId)).toBe(false);
       expect(backend.state.getStreamState(streamId)).toBeUndefined();
+      expect(backend.state.getStreamState(parent)?.subagents).toEqual([
+        before,
+        after,
+      ]);
+      expect(badgesChanged).toHaveBeenLastCalledWith(parent, {
+        subagents: [before, after],
+      });
     } finally {
       await backend.state.clearAll();
     }
   });
 
-  it('retires a retained fact removal before rebuilding the selectable rail', async () => {
-    const backendRef: { current?: RecordingTarget['backend'] } = {};
-    const selectableAtRebuild: StreamTabId[][] = [];
-    const lifecycle = createLifecycleOptions({
-      rebuildRenderedStreams: vi.fn(async () => {
-        selectableAtRebuild.push(
-          backendRef.current?.state.selectableStreamNames() ?? [],
-        );
-      }),
+  it('projects simultaneous removals from the newest roster and settles them out of order', () => {
+    const { backend } = createIsolatedRecordingBackend();
+    const activeStream = 'retained-active-stream' as StreamTabId;
+    const failedStream = 'retained-failed-stream' as StreamTabId;
+    const deletedStream = 'committed-deleted-stream' as StreamTabId;
+    const parent = 'retained-fact-parent' as StreamTabId;
+    const before = childRosterRow('retained-before' as StreamTabId);
+    const activeChild = childRosterRow(activeStream);
+    const failedChild = childRosterRow(failedStream);
+    const deletedChild = childRosterRow(deletedStream);
+    const after = childRosterRow('retained-after' as StreamTabId);
+    setChildRoster(backend, parent, [
+      before,
+      activeChild,
+      failedChild,
+      deletedChild,
+      after,
+    ]);
+
+    const activeRemoval = backend.state.beginStreamRemoval(activeStream);
+    const failedRemoval = backend.state.beginStreamRemoval(failedStream);
+    const deletedRemoval = backend.state.beginStreamRemoval(deletedStream);
+    expect(backend.state.getStreamState(parent)?.subagents).toEqual([
+      before,
+      after,
+    ]);
+
+    const newestActive = { ...activeChild, agentName: 'reviewer' };
+    const newestFailed = { ...failedChild, agentName: 'researcher' };
+    const newestDeleted = { ...deletedChild, agentName: 'implementer' };
+    backend.applyRunFact(parent, {
+      type: 'child.activity',
+      parentStreamId: parent,
+      items: [after, newestFailed, newestDeleted, before, newestActive],
     });
-    const target = createIsolatedRecordingBackend(
-      createTestSession(),
-      lifecycle,
-    );
-    const { backend } = target;
-    backendRef.current = backend;
-    backend.setupEventListeners();
-    const streamId = 'retained-fact-stream' as StreamTabId;
-    backend.state.streamLogs.ensureStream(streamId);
-    vi.spyOn(backend.state, 'clearStream').mockResolvedValueOnce('failed');
+    expect(backend.state.getStreamState(parent)?.subagents).toEqual([
+      after,
+      before,
+    ]);
 
-    emitRemoveStream(target, streamId);
+    expect(
+      backend.state.retireStreamTombstone(
+        failedStream,
+        failedRemoval.incarnation,
+      ),
+    ).toEqual({ retired: true, changedRosterParents: [parent] });
+    expect(backend.state.getStreamState(parent)?.subagents).toEqual([
+      after,
+      newestFailed,
+      before,
+    ]);
 
-    await vi.waitFor(() =>
-      expect(lifecycle.rebuildRenderedStreams).toHaveBeenCalledWith({
-        syncActiveStream: true,
-      }),
+    expect(
+      backend.state.commitStreamTombstone(
+        deletedStream,
+        deletedRemoval.incarnation,
+      ),
+    ).toEqual({ committed: true, changedRosterParents: [parent] });
+    expect(backend.state.getStreamState(parent)?.subagents).toEqual([
+      after,
+      newestFailed,
+      before,
+    ]);
+
+    expect(
+      backend.state.retireStreamTombstone(
+        activeStream,
+        activeRemoval.incarnation,
+      ),
+    ).toEqual({ retired: true, changedRosterParents: [parent] });
+    expect(backend.state.getStreamState(parent)?.subagents).toEqual([
+      after,
+      newestFailed,
+      before,
+      newestActive,
+    ]);
+  });
+
+  it('keeps superseded settlements from revealing rows across parent and child reclaims', () => {
+    const { backend } = createIsolatedRecordingBackend();
+    const parent = 'reclaimed-parent' as StreamTabId;
+    const childStream = 'reclaimed-child' as StreamTabId;
+    const oldChild = childRosterRow(
+      childStream,
+      'old-execution' as ExecutionId,
     );
-    expect(selectableAtRebuild).toContainEqual([streamId]);
-    expect(backend.state.isStreamRemoved(streamId)).toBe(false);
+    setChildRoster(backend, parent, [oldChild]);
+
+    const childRemoval = backend.state.beginStreamRemoval(childStream);
+    const parentRemoval = backend.state.beginStreamRemoval(parent);
+    expect(backend.state.getStreamState(parent)?.subagents).toEqual([]);
+
+    backend.state.claimStreamIdentity(parent);
+    backend.state.claimStreamIdentity(childStream);
+    const newChild = childRosterRow(
+      childStream,
+      'new-execution' as ExecutionId,
+    );
+    backend.applyRunFact(parent, {
+      type: 'child.activity',
+      parentStreamId: parent,
+      items: [newChild],
+    });
+
+    expect(
+      backend.state.retireStreamTombstone(
+        childStream,
+        childRemoval.incarnation,
+      ),
+    ).toEqual({ retired: false, changedRosterParents: [] });
+    expect(
+      backend.state.retireStreamTombstone(parent, parentRemoval.incarnation),
+    ).toEqual({ retired: false, changedRosterParents: [] });
+    expect(backend.state.getStreamState(parent)?.subagents).toEqual([newChild]);
   });
 
   it('handles removeStream session facts before backend load', async () => {
@@ -271,12 +392,18 @@ describe('ProgressBackend', () => {
   it('refuses reserved stream identifiers before durable cleanup', async () => {
     const { backend } = createIsolatedRecordingBackend();
     const clearStream = vi.spyOn(backend.state, 'clearStream');
+    const stream = '' as StreamTabId;
+    const parent = 'reserved-command-parent' as StreamTabId;
+    const child = childRosterRow(stream);
+    setChildRoster(backend, parent, [child]);
 
-    await backend.deleteStream('' as StreamTabId);
+    await backend.deleteStream(stream);
     await backend.deleteStream('.' as StreamTabId);
     await backend.deleteStream('..' as StreamTabId);
 
     expect(clearStream).not.toHaveBeenCalled();
+    expect(backend.state.isStreamRemoved(stream)).toBe(false);
+    expect(backend.state.getStreamState(parent)?.subagents).toEqual([child]);
   });
 
   it('clears retry UI when stopping without deleting', async () => {
@@ -1134,17 +1261,38 @@ describe('ProgressBackend', () => {
     );
     backendRef.current = backend;
     const stream = 'retained-stream' as StreamTabId;
+    const parent = 'retained-command-parent' as StreamTabId;
+    const child = childRosterRow(stream);
+    const before = childRosterRow('retained-before' as StreamTabId);
+    const after = childRosterRow('retained-after' as StreamTabId);
+    const roster = [before, child, after];
     backend.state.streamLogs.ensureStream(stream);
-    vi.spyOn(backend.state, 'clearStream').mockResolvedValueOnce('failed');
+    setChildRoster(backend, parent, roster);
+    const badgesChanged = vi
+      .spyOn(backend.renderer, 'onBadgesChanged')
+      .mockImplementationOnce(() => {
+        throw new Error('renderer unavailable during roster scrub');
+      });
+    const clearStream = vi
+      .spyOn(backend.state, 'clearStream')
+      .mockResolvedValueOnce('failed');
 
     await backend.deleteStream(stream);
 
+    expect(clearStream).toHaveBeenCalledWith(stream, {
+      expectedIncarnation: 0,
+    });
     expect(lifecycle.cleanupDeletedStream).not.toHaveBeenCalled();
     expect(lifecycle.rebuildRenderedStreams).toHaveBeenCalledWith({
       syncActiveStream: true,
     });
     expect(selectableAtRebuild).toContainEqual([stream]);
     expect(backend.state.isStreamRemoved(stream)).toBe(false);
+    expect(backend.state.getStreamState(parent)?.subagents).toEqual(roster);
+    expect(badgesChanged).toHaveBeenCalledWith(parent, {
+      subagents: [before, after],
+    });
+    expect(badgesChanged).toHaveBeenCalledWith(parent, { subagents: roster });
     expect(lifecycle.notifyDeletionRetained).toHaveBeenCalledWith(0, 1);
   });
 

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -43,6 +43,7 @@ import {
   createRecordingBackend,
   emitActiveStream,
   emitRunConfig,
+  emitRunEvent,
   stubStreamControls,
   toolUseConfig,
   track,
@@ -333,6 +334,40 @@ describe('ProgressBackend', () => {
       before,
       newestActive,
     ]);
+  });
+
+  it('notifies a parent roster when a workflow attachment reclaims a child identity', () => {
+    const target = createIsolatedRecordingBackend();
+    const { backend, session } = target;
+    const parent = 'workflow-reclaim-parent' as StreamTabId;
+    const childStream = 'workflow-reclaimed-child' as StreamTabId;
+    const child = childRosterRow(childStream);
+    setChildRoster(backend, parent, [child]);
+    backend.state.beginStreamRemoval(childStream);
+    backend.setupEventListeners();
+
+    emitRunEvent(target, childStream, {
+      type: 'run.start',
+      streamId: childStream,
+      executionId: 'workflow-reclaim' as ExecutionId,
+      identity: {
+        kind: 'multiAgentWorkflow',
+        workflowName: 'workflow-reclaim',
+      },
+    });
+    vi.spyOn(session.executions, 'getAgentHandleByStream').mockReturnValue(
+      {} as never,
+    );
+    const badgesChanged = vi.spyOn(backend.renderer, 'onBadgesChanged');
+
+    expect(
+      backend.applySessionFact({
+        type: 'setActiveStream',
+        payload: { streamId: childStream },
+      }),
+    ).toBe(true);
+    expect(backend.state.getStreamState(parent)?.subagents).toEqual([]);
+    expect(badgesChanged).toHaveBeenCalledWith(parent, { subagents: [] });
   });
 
   it('keeps superseded settlements from revealing rows across parent and child reclaims', () => {


### PR DESCRIPTION
## Summary

- keep canonical child rosters intact during provisional removal and filter tombstoned rows through the shared `SessionState` read projection
- scrub canonical rows only when deletion commits, reveal current canonical rows when retention wins, and fence identity reclaim against old-incarnation rows
- make renderer roster notifications best-effort so presentation failures cannot strand deletion settlement
- include active resume-eligible children in exit hints
- route CLI transcript sync and eviction through the injected session instead of `defaultSession()`

## Validation

- 348 targeted tests across 7 suites
- workspace, CLI, and test-kernel typechecks
- `git diff --check`
- independent code review found no blocking or should-fix findings

Closes #10903
Closes #10904
Closes #10905
