### PR TITLE
refactor(identity): one minter per derived identity string

### DIFF
--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -277,8 +277,9 @@ export interface ChildRunLoopParams<TTurn> {
   readonly childStream?: ChildStreamPort;
   /**
    * The child's stream id, known deterministically upfront by every caller
-   * (agent-CLI: `createChildStream`'s own id; native: `getStreamTabId` — the
-   * same formula `buildAgentLaunchContext` derives internally) — never
+   * (one `getStreamTabId` formula either way — agent-CLI passes the launching
+   * tool's stream prefix, native passes the clean agent name, which is what
+   * `buildAgentLaunchContext` derives internally) — never
    * discovered mid-flight, so the loop can acquire the follow-up queue and
    * attach its interrupt handler before the first turn ever runs when a handle
    * already exists.

--- a/src/agent/runtime/streamTab.ts
+++ b/src/agent/runtime/streamTab.ts
@@ -4,16 +4,24 @@ import { getCleanAgentName } from '@shared/schemas';
 /**
  * Mint the opaque stream tab id for a new run: `${name}#${executionId}`.
  *
- * The id is an opaque handle — nothing parses it back. Uniqueness comes from
- * the executionId suffix; the name prefix is human-orienting only. Existing
- * runs are addressed by the `streamId` stamped on their execution metadata
- * at registration, never by re-deriving this format.
+ * Single owner of the format for every run that gets a tab: a native run
+ * passes its agent identifier, a child run launched by a tool passes that
+ * tool's stream prefix (e.g. {@link BASH_CHILD_STREAM_PREFIX}). Disjoint
+ * namespaces, one wire format — the one {@link getStreamTabDisplayName} below
+ * reads back. `getCleanAgentName` normalizes an `<source>:<agent>` identifier
+ * and returns anything else, tool prefixes included, unchanged.
+ *
+ * The id is an opaque handle — nothing parses it back to address a run.
+ * Uniqueness comes from the executionId suffix; the name prefix is
+ * human-orienting only. Existing runs are addressed by the `streamId` stamped
+ * on their execution metadata at registration, never by re-deriving this
+ * format.
  */
 export function getStreamTabId(
-  agent: string,
+  name: string,
   options: { executionId: ExecutionId },
 ): StreamTabId {
-  return `${getCleanAgentName(agent)}#${options.executionId}`;
+  return `${getCleanAgentName(name)}#${options.executionId}`;
 }
 
 /**

--- a/src/shared/schemas/diffResult.ts
+++ b/src/shared/schemas/diffResult.ts
@@ -4,6 +4,7 @@ import { getBasename } from '@utils/core';
 import {
   type FileLocation,
   FileLocationSchema,
+  fileLocationShortDisplayPath,
   type OutputFileInfo,
   OutputFileInfoSchema,
 } from './output';
@@ -77,23 +78,17 @@ function getDisplayName(
   revised: OutputFileInfo,
   baseLocation: FileLocation | null,
 ): string {
-  // Prefer original path from lineage
+  // Prefer the original file's own name, from lineage.
   const original = revised.lineage?.original;
   if (original) {
-    const path =
-      ('relativePath' in original ? original.relativePath : null) ||
-      original.absolutePath;
-    const basename = getBasename(path);
+    const basename = getBasename(fileLocationShortDisplayPath(original));
     if (basename) return basename;
   }
 
-  // Fall back to base location
+  // Fall back to how the base location reads.
   if (baseLocation) {
-    if ('relativePath' in baseLocation && baseLocation.relativePath) {
-      return baseLocation.relativePath;
-    }
-    const basename = getBasename(baseLocation.absolutePath);
-    if (basename) return basename;
+    const basePath = fileLocationShortDisplayPath(baseLocation);
+    if (basePath) return basePath;
   }
 
   return 'unknown';

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -81,8 +81,6 @@ vi.mock('@utils/files/taskRunStorage', () => ({
 vi.mock('@tools/delegation/childStream', () => ({
   createChildStream: mocks.createChildStream,
   childStreamDescription: (raw: string) => raw,
-  getChildStreamId: (executionId: string, prefix: string) =>
-    `${prefix}#${executionId}`,
 }));
 
 vi.mock('@agent/runtime/childRunLoop', () => ({

--- a/src/test-kernel/tools/CodexResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/CodexResumeFallback.vitest.ts
@@ -75,8 +75,6 @@ vi.mock('@utils/files/taskRunStorage', () => ({
 vi.mock('@tools/delegation/childStream', () => ({
   createChildStream: mocks.createChildStream,
   childStreamDescription: (raw: string) => raw,
-  getChildStreamId: (executionId: string, prefix: string) =>
-    `${prefix}#${executionId}`,
 }));
 
 vi.mock('@agent/runtime/childRunLoop', () => ({

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -95,8 +95,6 @@ vi.mock('@agent/runtime/childRunLoop', () => ({
 vi.mock('@tools/delegation/childStream', () => ({
   createRehydratedChildStream: mocks.createRehydratedChildStream,
   childStreamDescription: (raw: string) => raw,
-  getChildStreamId: (executionId: string, prefix: string) =>
-    `${prefix}#${executionId}`,
 }));
 
 vi.mock('@tools/approval', () => ({

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -192,9 +192,9 @@ describe('assembleTrace', () => {
 
   it('resolves a tool-format child stream through its stamped metadata, not name derivation', async () => {
     // Background child streams (bash/codex/claude subagents, see
-    // @tools/delegation/childStream.createChildStream) use a tool-specific
-    // "${streamPrefix}#executionId" id, not getStreamTabId's format — the
-    // stamped meta.streamId is the only mapping that reaches them.
+    // @tools/delegation/childStream.createChildStream) share getStreamTabId's
+    // format but carry a tool-specific prefix, disjoint from any agent name —
+    // the stamped meta.streamId is the only mapping that reaches them.
     const executionId = 'exec-child-1' as ExecutionId;
     const executionConfig = config({
       agent: 'orchestrator',

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -13,6 +13,7 @@ import {
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
 import type { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
+import { getStreamTabId } from '@agent/runtime/streamTab';
 import {
   startChildRunLoop,
   type ChildRunPorts,
@@ -48,7 +49,6 @@ import { truncateWithEllipsis } from '@utils/text/stringUtils';
 import {
   childStreamDescription,
   createChildStream,
-  getChildStreamId,
   type ChildStream,
 } from './delegation/childStream';
 import type {
@@ -206,7 +206,7 @@ export async function launchAgentCliSession(
   params: AgentCliLaunchParams,
 ): Promise<ToolResult> {
   const executionId = generateExecutionId();
-  const childStreamId = getChildStreamId(executionId, params.streamPrefix);
+  const childStreamId = getStreamTabId(params.streamPrefix, { executionId });
   // An external CLI drives this agent: the CLI is both the agent name and the
   // driving tool, and `identity.tool` is what gates native-only affordances
   // (resume/rerun) off for this cohort.

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -26,7 +26,10 @@ import {
   getRunContextWorkingDirectory,
 } from '@agent/runtime/RunContext';
 import { currentSession } from '@agent/runtime/SessionHandle';
-import { BASH_CHILD_STREAM_PREFIX } from '@agent/runtime/streamTab';
+import {
+  BASH_CHILD_STREAM_PREFIX,
+  getStreamTabId,
+} from '@agent/runtime/streamTab';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { platform } from '@platform/platform';
 import {
@@ -64,7 +67,6 @@ import { nullishWithDefault } from './core/inputSchema';
 import {
   childStreamDescription,
   createChildStream,
-  getChildStreamId,
   type ChildStream,
 } from './delegation/childStream';
 import { parseWorkingDirectory } from './pathResolution';
@@ -420,7 +422,7 @@ export class BashTool extends defineTool({
       { name: 'bash', instruction: command },
       'bash',
       {
-        streamId: getChildStreamId(executionId, BASH_CHILD_STREAM_PREFIX),
+        streamId: getStreamTabId(BASH_CHILD_STREAM_PREFIX, { executionId }),
         identity: { kind: 'process', tool: 'bash' },
         userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
         parentExecutionId,

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -20,6 +20,7 @@ import {
   AgentConfigSchema,
   type AgentConfigPayload,
 } from '@agent/core/definition/AgentConfig';
+import { getStreamTabId } from '@agent/runtime/streamTab';
 import { getCurrentToolContexts } from '@agent/followUp/ToolFileInteractionContext';
 import type {
   ToolResult,
@@ -49,7 +50,6 @@ import { deriveExecutionId } from '@utils/core/idHash';
 import {
   childStreamDescription,
   createRehydratedChildStream,
-  getChildStreamId,
 } from './childStream';
 
 // Local file imports
@@ -350,7 +350,9 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
     // anchor and resume still replays completed calls (#8712). The journal
     // itself stays on the orchestrator store, where the checkpoint lives.
     const runExecutionId = deriveExecutionId({ checkpointId });
-    const runStreamId = getChildStreamId(runExecutionId, STREAM_PREFIX);
+    const runStreamId = getStreamTabId(STREAM_PREFIX, {
+      executionId: runExecutionId,
+    });
 
     // Captured now, while the launching tool call's ALS frame is live, so the
     // detached run can still roll its cost into the parent after this call

--- a/src/tools/delegation/childStream.ts
+++ b/src/tools/delegation/childStream.ts
@@ -11,6 +11,7 @@ import {
   currentSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
+import { getStreamTabId } from '@agent/runtime/streamTab';
 import { classifyAgentError } from '@common/errors';
 import { RUN_OUTCOME, STREAM_PHASE, type AgentCategory } from '@shared/schemas';
 import type {
@@ -82,14 +83,6 @@ export interface ChildStream {
   finalize: (options?: FinalizeChildStreamOptions) => Promise<void>;
 }
 
-/** Derive the durable stream identity shared by registration and creation. */
-export function getChildStreamId(
-  executionId: ExecutionId,
-  streamPrefix: string,
-): StreamTabId {
-  return `${streamPrefix}#${executionId}` as StreamTabId;
-}
-
 /**
  * Normalize a child task's raw label to the ≤80-char display description.
  * Single owner of that cap for both the durable authority write
@@ -107,7 +100,7 @@ export function createChildStream(
   parentStreamId: StreamTabId,
   options: CreateChildStreamOptions,
 ): ChildStream {
-  const childStreamId = getChildStreamId(executionId, options.streamPrefix);
+  const childStreamId = getStreamTabId(options.streamPrefix, { executionId });
 
   // Capture the run's session at creation (inside the parent run's ALS); the
   // status-update and finalize closures below fire later, possibly outside it.
@@ -276,7 +269,7 @@ export async function createRehydratedChildStream(
   options: CreateChildStreamOptions,
 ): Promise<ChildStream> {
   const session = currentSession();
-  const childStreamId = getChildStreamId(executionId, options.streamPrefix);
+  const childStreamId = getStreamTabId(options.streamPrefix, { executionId });
   const writer = await session.transcripts.loadAndAcquireWriter(
     childStreamId,
     executionId,


### PR DESCRIPTION
## Summary

Two identity strings in this repo were each hand-derived in two places. This
gives each one minter.

**1. Stream tab id.** `getStreamTabId` (`src/agent/runtime/streamTab.ts:12`) and
`getChildStreamId` (`src/tools/delegation/childStream.ts:86`) were the same
template with the arguments reversed — `` `${name}#${executionId}` ``.
`src/tools/bash.ts` showed the split most plainly: line 29 imported
`BASH_CHILD_STREAM_PREFIX` from the module that owns the format *and* its
parser (`getStreamTabDisplayName`), then line 67 imported the minter that
consumes that prefix from a different module. `getChildStreamId` is deleted;
its five call sites mint through `getStreamTabId`.

Produced strings are byte-identical. `getCleanAgentName` only strips a valid
`<source>:` prefix and returns everything else unchanged, and none of the four
live stream prefixes (`bash@tool`, `codex@codex-sdk`, `claude@agent-sdk`,
`workflow-script`) contains a colon. No id on disk changes, and
`getStreamTabDisplayName`'s first-`#` split is unaffected.

**2. Diff-panel display name.** `getDisplayName` in
`src/shared/schemas/diffResult.ts` hand-rolled "how does this `FileLocation`
read as text" twice, via two `'relativePath' in x` structural probes that
bypass the `kind` discriminant. Both branches are exactly
`fileLocationShortDisplayPath` (`src/shared/schemas/output.ts:81`), which
already owns that derivation next to the schema:

- lineage branch: `getBasename(('relativePath' in o ? o.relativePath : null) || o.absolutePath)`
  ≡ `getBasename(fileLocationShortDisplayPath(o))` — for an external location
  `getBasename` of an already-basenamed string is identity.
- base branch: `'relativePath' in b && b.relativePath ? b.relativePath : getBasename(b.absolutePath)`
  ≡ `fileLocationShortDisplayPath(b)` exactly.

The truthiness guards stay — `getAbsolutePath` yields `''` for a null location.

## Issue acceptance gates

No issue. Findings from a verified dual-systems sweep; both were independently
found and verified by two sweeps run on different axes with different scouts
and verifiers.

## Single source of truth

- `getStreamTabId` (`src/agent/runtime/streamTab.ts`) is the only definition of
  the stream-tab id format, co-located with `getStreamTabDisplayName`, the only
  reader of it, and with `BASH_CHILD_STREAM_PREFIX`.
- `fileLocationShortDisplayPath` (`src/shared/schemas/output.ts`) is the only
  definition of `FileLocation` → short display text.

## Duplication and abstraction budget

Two duplicated derivations removed, one exported function deleted, no new
abstraction and no wrapper. Deliberately **not** done: `getStreamTabId` keeps
`getCleanAgentName` inside rather than pushing it to the four native call
sites. Pushing it out was the brief's prescribed shape; measured, it turns this
into a **+17-line production net-add** (four call sites gain a wrapped,
prettier-multilined call) and spreads one invariant across four owners for zero
behavioral gain, since the cleaner is identity on every tool prefix. Recorded
here rather than sold as a reduction.

`getDisplayName` and `outputDisplayName` were examined for merging and that is
**refuted** — different inputs (diff pair vs single artifact), a `baseLocation`
parameter the shared namer has no notion of, a `source`/generic-stem branch
`getDisplayName` lacks, and different sentinels. Only the shared
`FileLocation` → text primitive was on the table; this closes it.

## Net elements (R6)

Files: 11 changed, **0 added, 0 deleted**.
Exported symbols: **−1** (`getChildStreamId`); 0 added.
Classes/interfaces/enums: 0 net.

LoC, honestly:

| | + | − | net |
|---|---|---|---|
| production | 32 | 33 | **−1** |
| test | 3 | 9 | **−6** |
| **total** | **35** | **42** | **−7** |

Production splits into **−10 net code lines and +9 net comment lines**: the
`getStreamTabId` docstring grew to state both namespaces and the
`getCleanAgentName` identity property, and `childRunLoop.ts:280` had a comment
asserting the two formats were different. That is a net-neutral-to-slightly-
negative production diff, not a big reduction — the win is one definition, not
LoC.

Behavior change: **none intended**. One edge is representable but not reachable
through the schemas in practice, and it applies **symmetrically to both
branches** of `getDisplayName` (thanks to the review bot for catching that the
first draft of this section described only one of them): a
`workspace`/`runStorage` location with `relativePath: ''` previously fell back
to `getBasename(absolutePath)` — via `|| original.absolutePath` in the lineage
branch, and via the `&& baseLocation.relativePath` guard in the base branch —
and now reads as `''` in both, falling through to the next guard (base
location, then `'unknown'`). `FileLocationSchema` declares `relativePath` as a
plain `z.string()`, so an empty one is representable but means a workspace file
with no path within the workspace. The new reading matches every other consumer
of `fileLocationShortDisplayPath`, which is the point of having one owner.

## Consumer counts (R8)

```
$ grep -rn -e getStreamTabId -e getChildStreamId src packages config docs
```

- `getChildStreamId`: 5 production call sites (`bash.ts:423`,
  `agentCliShared.ts:209`, `WorkflowScriptTool.ts:353`, `childStream.ts:110`,
  `childStream.ts:279`) — all redirected; 3 vitest `vi.mock` stubs
  (`CodexResumeFallback`, `ClaudeAgentResumeFallback`, `WorkflowScriptTool`) —
  all deleted, so those suites now exercise the real minter. `grep -rn
  getChildStreamId src packages` returns nothing after the change.
- No `packages/**` file imported either symbol (only a prose mention at
  `packages/extension/src/progressView/frontend/utils.ts:12`), so
  `host-agent-import-baseline` is untouched.
- `fileLocationShortDisplayPath` gains one consumer inside `src/shared/schemas`
  (`diffResult.ts` already imports from `./output`).

Ratchets: `architecture-edges-baseline.json:76` already carries
`{from: tools, to: agent, kind: value}`, so no edge is widened;
`childStream.ts` already imported four other `@agent/runtime/*` modules.
`knip-baseline.json` has no entry for `getChildStreamId` (verified by JSON
search) — no baseline regenerated.

## Host impact

Extension: none — no minted id changes; the latexdiff results panel renders the
same strings.

Desktop: none.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean (full workspace, test-kernel, agent, cli,
  trace-viewer, desktop).
- `npx vitest run src/test-kernel/schemas/DiffResultTransforms.vitest.ts
  src/test-kernel/agent/runtime/ src/test-kernel/tools/
  src/test-kernel/transcript/` — 150 files, 1604 tests, all passing.
  `DiffResultTransforms.vitest.ts` passes **unedited**, which was the
  acceptance criterion for the second half.
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` not run: an export was removed, and knip's
  baseline contains no entry for it (searched the JSON directly). Happy to run
  it if a reviewer wants it.
- Zero new tests, per the repo's test budget. Test edits are deletions of the
  three now-dead mock stubs plus one comment in
  `traceAssembler.vitest.ts:196` that claimed child streams use "not
  `getStreamTabId`'s format" — restated as "disjoint prefixes, one format".
  That test's actual assertion (resolve via stamped metadata, not name
  derivation) is unchanged and still passes.
