### PR TITLE
refactor(agent): trim the write-only fields from FlowRecord

### DIFF
--- a/packages/desktop/tests/e2e/sessionLifecycle.spec.ts
+++ b/packages/desktop/tests/e2e/sessionLifecycle.spec.ts
@@ -76,11 +76,8 @@ function writeCanonicalStreamFixture(input: {
   if (input.resumable) {
     writeJson(join(executionDirectory, `flow_${input.executionId}.json`), {
       schemaVersion: 2,
-      flowName: 'texra',
       shared: { messages: [] },
-      createdAt: new Date(input.timestamp).toISOString(),
       cursor: { nextNodeId: 'start' },
-      nodes: [],
     });
   }
 }

--- a/src/agent/implementations/flows/reflection/RoundPersistedFlow.ts
+++ b/src/agent/implementations/flows/reflection/RoundPersistedFlow.ts
@@ -219,8 +219,8 @@ export class RoundPersistedFlow<
   }
 
   /**
-   * Transition to the next round: increment counter, reset state,
-   * reset node history so the flow starts from the beginning again.
+   * Transition to the next round: increment counter, reset state, and rewind
+   * the replay cursor so the flow starts from the beginning again.
    */
   private async transitionToNextRound(shared: S): Promise<void> {
     // End previous round stage
@@ -233,8 +233,8 @@ export class RoundPersistedFlow<
     // Reset state for next round
     this.callbacks.resetForNextRound?.(shared);
 
-    // Reset node history so next stepWithResult() starts from the beginning
-    await this.resetNodeHistory(shared);
+    // Rewind the cursor so the next stepWithResult() starts from the beginning
+    await this.rewindToStart(shared);
 
     // Create new stage
     this.createStage(shared.currentRound, shared);

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -153,7 +153,7 @@ class ToolUsePersistedFlow<C> extends PersistedFlow<
 > {
   async prepareForFollowUp(shared: ToolUseRunShared): Promise<void> {
     shared.shouldSkipCycle = true;
-    await this.resetNodeHistory(shared);
+    await this.rewindToStart(shared);
   }
 }
 

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -179,11 +179,14 @@ interface StepResult<S> {
  * This enables:
  * - Resume from any node on crash/restart
  * - Distributed execution (different processes can resume)
- * - Execution audit trail via node history
  *
  * Key design principles:
  * - Only shared state is persisted (not services - they're runtime dependencies)
- * - Node history tracks actions, not outputs (minimal storage)
+ * - `cursor` is the whole resume contract: the next graph-local node path plus
+ *   the last action. The record keeps no step history — nothing reads one.
+ * - `schemaVersion` gates readability: a record stamped newer than
+ *   FLOW_RECORD_SCHEMA_VERSION is rejected as `unsupported-record` rather than
+ *   parsed on a guess.
  * - Resume replays by navigating the graph, not re-executing nodes
  *
  * @template S - Shared state type (must be serializable via structuredClone)
@@ -229,7 +232,7 @@ export class PersistedFlow<
    * Optional write-through projection callback.
    *
    * Called (and awaited) after every persist (stepWithResult, setShared,
-   * resetNodeHistory) so derived views (todos, conversation) stay current.
+   * rewindToStart) so derived views (todos, conversation) stay current.
    * Errors are swallowed — the authoritative flow blob is already written.
    */
   private projection:
@@ -402,7 +405,7 @@ export class PersistedFlow<
    * beginning of the flow graph. Used by round-looping subclasses to restart
    * the graph without embedding loop edges in it.
    */
-  protected async resetNodeHistory(shared: S): Promise<void> {
+  protected async rewindToStart(shared: S): Promise<void> {
     await this.commitShared(shared, (flow) => {
       flow.cursor = { nextNodeId: this.idForNode(this.start) };
     });

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -28,11 +28,6 @@ const log = createLog('PersistedFlow');
 export const FLOW_RECORD_SCHEMA_VERSION = 2;
 const START_NODE_ID = 'start';
 
-interface NodeRecord {
-  action?: string;
-  nodeId?: string;
-}
-
 interface FlowCursor {
   /** The next graph-local node path, or null when the flow has reached a terminal edge. */
   nextNodeId: string | null;
@@ -42,22 +37,13 @@ interface FlowCursor {
 
 export interface FlowRecord {
   schemaVersion?: number;
-  flowName: string;
   shared: unknown;
-  createdAt: string;
   /**
-   * Authoritative replay cursor. `nodes[]` is only an audit log: it can be
-   * capped or moved later without changing resume semantics. Every write path
-   * stamps a cursor; a record without one is rejected as unsupported.
+   * Authoritative replay cursor — the whole of the resume contract. Every
+   * write path stamps one; a record without one is rejected as unsupported.
    */
   cursor: FlowCursor;
-  nodes: NodeRecord[];
 }
-
-const PersistedFlowNodeRecordSchema = z.looseObject({
-  action: z.string().optional(),
-  nodeId: z.string().optional(),
-});
 
 const PersistedFlowCursorSchema = z.looseObject({
   nextNodeId: z.string().nullable(),
@@ -66,11 +52,8 @@ const PersistedFlowCursorSchema = z.looseObject({
 
 const PersistedFlowRecordObjectSchema = z.looseObject({
   schemaVersion: z.int().min(1).max(FLOW_RECORD_SCHEMA_VERSION).optional(),
-  flowName: z.string(),
   shared: z.unknown(),
-  createdAt: z.string(),
   cursor: PersistedFlowCursorSchema,
-  nodes: z.array(PersistedFlowNodeRecordSchema),
 });
 
 /**
@@ -351,7 +334,7 @@ export class PersistedFlow<
     const key = flowKey(this.runId);
     const flow = await this.loadRecord();
 
-    if (!flow || !Array.isArray(flow.nodes)) {
+    if (!flow) {
       throw new Error('Invalid or corrupted flow record');
     }
 
@@ -377,13 +360,11 @@ export class PersistedFlow<
     const action = await cursor._run(shared);
     const waiting = action === FlowTransition.WAITING;
     const next = waiting ? cursor : cursor.getNextNode(action);
-    const cursorId = this.idForNode(cursor);
     const nextNodeId = next ? this.idForNode(next) : null;
 
     // Invalidate cache before mutation: if kv.write fails, the next read
     // falls through to KVStore which has the correct pre-mutation state.
     this.cachedRecord = null;
-    flow.nodes.push({ action, nodeId: cursorId });
     flow.cursor = {
       nextNodeId,
       ...(action !== undefined ? { lastAction: action } : {}),
@@ -417,13 +398,12 @@ export class PersistedFlow<
   }
 
   /**
-   * Reset the node history so the next stepWithResult() starts from the
+   * Rewind the replay cursor so the next stepWithResult() starts from the
    * beginning of the flow graph. Used by round-looping subclasses to restart
    * the graph without embedding loop edges in it.
    */
   protected async resetNodeHistory(shared: S): Promise<void> {
     await this.commitShared(shared, (flow) => {
-      flow.nodes = [];
       flow.cursor = { nextNodeId: this.idForNode(this.start) };
     });
   }
@@ -523,11 +503,8 @@ export class PersistedFlow<
 
     const record: FlowRecord = {
       schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
-      flowName: 'texra',
       shared: this.serializeShared(shared),
-      createdAt: new Date().toISOString(),
       cursor: { nextNodeId: this.idForNode(this.start) },
-      nodes: [],
     };
     await this.kv.write(flowKey(this.runId), record);
     this.cachedRecord = record;

--- a/src/test-kernel/agent/PersistedFlow.vitest.ts
+++ b/src/test-kernel/agent/PersistedFlow.vitest.ts
@@ -70,11 +70,10 @@ describe('PersistedFlow', () => {
     await expectStoredRecord(store, executionId, {
       schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
       cursor: { nextNodeId: null, lastAction: 'complete' },
-      nodes: [{ action: 'complete' }],
     });
   });
 
-  it('replays from the cursor rather than the audit node log', async () => {
+  it('replays from the persisted cursor, not from the start node', async () => {
     const executionId = 'abc127' as ExecutionId;
     const store = getExecutionStore(executionId);
     const first = new ContinueOnceNode();
@@ -84,11 +83,8 @@ describe('PersistedFlow', () => {
 
     await store.write(flowKey(executionId), {
       schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
-      flowName: 'texra',
       shared: { count: 0, continue: false },
-      createdAt: new Date().toISOString(),
       cursor: { nextNodeId: 'start/again', lastAction: 'again' },
-      nodes: [],
     } satisfies FlowRecord);
 
     await flow.run({ count: 999, continue: true });
@@ -96,11 +92,10 @@ describe('PersistedFlow', () => {
     await expectStoredRecord(store, executionId, {
       shared: { count: 1, continue: false },
       cursor: { nextNodeId: null, lastAction: 'complete' },
-      nodes: [{ action: 'complete', nodeId: 'start/again' }],
     });
   });
 
-  it('rejects a legacy no-cursor record loudly instead of replaying the node log', async () => {
+  it('rejects a legacy no-cursor record loudly', async () => {
     const executionId = 'abc128' as ExecutionId;
     const store = getExecutionStore(executionId);
     const first = new ContinueOnceNode();
@@ -111,10 +106,7 @@ describe('PersistedFlow', () => {
     // Deliberately invalid: pre-cursor records are no longer supported.
     await store.write(flowKey(executionId), {
       schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
-      flowName: 'texra',
       shared: { count: 1, continue: false },
-      createdAt: new Date().toISOString(),
-      nodes: [{ action: 'again' }],
     });
 
     await expect(flow.run({ count: 999, continue: true })).rejects.toThrow(
@@ -135,7 +127,6 @@ describe('PersistedFlow', () => {
         nextNodeId: 'start',
         lastAction: FlowTransition.WAITING,
       },
-      nodes: [{ action: FlowTransition.WAITING, nodeId: 'start' }],
     });
 
     await expect(flow.run({ count: 999 })).resolves.toBe(

--- a/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
+++ b/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
@@ -110,11 +110,8 @@ function recoveryCase(name: string) {
 
 function flowRecord(shared: unknown): FlowRecord {
   return {
-    flowName: 'texra',
     shared,
-    createdAt: '2026-01-01T00:00:00.000Z',
     cursor: { nextNodeId: null },
-    nodes: [],
   };
 }
 
@@ -160,11 +157,7 @@ describe('runReflectionFlow persisted-state recovery', () => {
     {
       name: 'missing shared state',
       reason: 'missing-shared',
-      stored: {
-        flowName: 'texra',
-        createdAt: '2026-01-01T00:00:00.000Z',
-        nodes: [],
-      },
+      stored: {},
     },
     {
       name: 'unsupported null record',
@@ -172,12 +165,10 @@ describe('runReflectionFlow persisted-state recovery', () => {
       stored: null,
     },
     {
-      name: 'valid shared state without nodes',
+      name: 'valid shared state without a replay cursor',
       reason: 'unsupported-record',
       stored: {
-        flowName: 'texra',
         shared: reflectionFlowShared({ totalRounds: 1, context: null }),
-        createdAt: '2026-01-01T00:00:00.000Z',
       },
     },
     {

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -107,10 +107,6 @@ type ToolUseSetupContext = Parameters<ToolUseFlowAttachment['attach']>[0];
 // A record parked on the wait node, as a resumable turn leaves it.
 const WAITING_AT_START = {
   cursor: { nextNodeId: WAIT_NODE_CURSOR },
-  nodes: [
-    { action: 'default', nodeId: 'start' },
-    { action: 'default', nodeId: 'start/default' },
-  ],
 };
 
 async function writeFlowRecord(
@@ -119,11 +115,8 @@ async function writeFlowRecord(
   overrides: Record<string, unknown> = {},
 ): Promise<void> {
   await getExecutionStore(executionId).write(flowKey(executionId), {
-    flowName: 'texra',
     shared,
-    createdAt: new Date().toISOString(),
     cursor: { nextNodeId: 'start' },
-    nodes: [],
     ...overrides,
   });
 }
@@ -1168,19 +1161,14 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       name: 'legacy record without a replay cursor',
       reason: 'unsupported-record',
       stored: {
-        flowName: 'texra',
         shared: VALID_TOOL_USE_SHARED,
-        createdAt: '2026-01-01T00:00:00.000Z',
-        nodes: [],
       },
     },
     {
       name: 'missing shared state',
       reason: 'missing-shared',
       stored: {
-        flowName: 'texra',
-        createdAt: '2026-01-01T00:00:00.000Z',
-        nodes: [],
+        cursor: { nextNodeId: 'start' },
       },
     },
     {
@@ -1189,25 +1177,13 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       stored: null,
     },
     {
-      name: 'valid shared state without nodes',
-      reason: 'unsupported-record',
-      stored: {
-        flowName: 'texra',
-        shared: VALID_TOOL_USE_SHARED,
-        createdAt: '2026-01-01T00:00:00.000Z',
-      },
-    },
-    {
       name: 'future envelope schema version',
       reason: 'unsupported-record',
       stored: {
         schemaVersion: FLOW_RECORD_SCHEMA_VERSION + 1,
-        flowName: 'texra',
         shared: VALID_TOOL_USE_SHARED,
-        createdAt: '2026-01-01T00:00:00.000Z',
         // Cursor present so the version bound is the only failing constraint.
         cursor: { nextNodeId: 'start' },
-        nodes: [],
       },
     },
     // Fresh launches only: a resume handoff over a malformed record is
@@ -1360,8 +1336,8 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     // Reject the flow's first node-step persist with the provider's abort:
     // the run then fails mid-flight through the public storage boundary, the
     // same way a real cancellation reaches `runToolUseFlow` out of the flow.
-    // Only step writes append to the nodes audit log, so any other write
-    // (nodes stays empty) passes through untouched.
+    // Only a step write stamps `cursor.lastAction` (the action the node just
+    // returned), so any other write passes through untouched.
     const realWrite = store.write.bind(store);
     let abortFired = false;
     const writeSpy = vi
@@ -1371,9 +1347,9 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
           !abortFired &&
           value !== null &&
           typeof value === 'object' &&
-          'nodes' in value &&
-          Array.isArray(value.nodes) &&
-          value.nodes.length > 0
+          'cursor' in value &&
+          (value.cursor as { lastAction?: string } | null)?.lastAction !==
+            undefined
         ) {
           abortFired = true;
           flowContext?.interrupt();

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -67,11 +67,8 @@ function durableResumabilityDecision(
     resumable: true,
     cause: resumability.RESUMABILITY_CAUSE.MISSING_TERMINAL_WITH_FLOW,
     flowRecord: {
-      flowName: 'texra',
       shared: { continuationGenerationId: generationId },
-      createdAt: '2026-08-13T12:00:00.000Z',
       cursor: { nextNodeId: 'start' },
-      nodes: [],
     },
   };
 }

--- a/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
@@ -40,11 +40,8 @@ const executionId = 'abc123' as ExecutionId;
 const streamId = `crashed#${executionId}` as StreamTabId;
 const META_TIMESTAMP = '2026-07-26T00:00:00.000Z';
 const validFlowRecord = {
-  flowName: 'texra',
   shared: { messages: [] },
-  createdAt: META_TIMESTAMP,
   cursor: { nextNodeId: 'start' },
-  nodes: [],
 };
 
 /** Sessions opened by a test, disposed in afterEach (dispose is idempotent). */

--- a/src/test-kernel/agent/storage/Resumability.vitest.ts
+++ b/src/test-kernel/agent/storage/Resumability.vitest.ts
@@ -23,11 +23,8 @@ import {
 import { setupPlatform } from '@test/support/setupPlatform';
 
 const BASE_FLOW_RECORD: FlowRecord = {
-  flowName: 'texra',
   shared: { messages: [] },
-  createdAt: '2026-07-05T00:00:00.000Z',
   cursor: { nextNodeId: 'start' },
-  nodes: [],
 };
 
 describe('deriveResumability', () => {

--- a/src/test-kernel/cli/HistoryStatus.vitest.ts
+++ b/src/test-kernel/cli/HistoryStatus.vitest.ts
@@ -53,11 +53,8 @@ async function seedFlowRecord(
   });
   await releaseOwnedExecutionLease(id);
   await getExecutionStore(id).write(flowKey(id), {
-    flowName: 'test',
     shared,
-    createdAt: new Date().toISOString(),
     cursor: { nextNodeId: 'start' },
-    nodes: [],
   });
 }
 

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
@@ -312,11 +312,8 @@ describe('CLI workflow run command', () => {
       resumable: true,
       cause: 'interrupted-with-flow',
       flowRecord: {
-        flowName: 'texra',
         shared: {},
-        createdAt: '2026-08-13T00:00:00.000Z',
         cursor: { nextNodeId: 'start' },
-        nodes: [],
       },
     });
     mocks.withExpandedRunInputs.mockImplementation(
@@ -975,11 +972,8 @@ describe('CLI workflow run command', () => {
         resumable: true,
         cause: 'interrupted-with-flow',
         flowRecord: {
-          flowName: 'texra',
           shared: { lastError: { message: 'provider failed' } },
-          createdAt: '2026-08-13T00:00:00.000Z',
           cursor: { nextNodeId: 'start' },
-          nodes: [],
         },
       }),
     ).toBe(false);

--- a/src/test-kernel/tools/ExecutionsToolResumability.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolResumability.vitest.ts
@@ -10,11 +10,8 @@ import { setupPlatform } from '@test/support/setupPlatform';
 import { ExecutionsTool } from '@tools/ExecutionsTool';
 
 const BASE_FLOW_RECORD: FlowRecord = {
-  flowName: 'texra',
   shared: { messages: [] },
-  createdAt: '2026-07-05T00:00:00.000Z',
   cursor: { nextNodeId: 'start' },
-  nodes: [],
 };
 
 async function writeRecord(

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -418,11 +418,8 @@ describe('completedRunArchive facade', () => {
       },
     });
     await getExecutionStore(executionId).write(flowKey(executionId), {
-      flowName: 'texra',
       shared: persistedResumeState.shared,
-      createdAt: new Date().toISOString(),
       cursor: { nextNodeId: 'start' },
-      nodes: [],
     });
 
     const session = createTestSession({ transcripts: logs });


### PR DESCRIPTION
## Summary

`FlowRecord` — the persisted `flow_<runId>.json` shape — carried three fields
that nothing reads:

- **`nodes[]`**, an audit log of every step. Three touch sites repo-wide, all
  inside `persistedFlow.ts`: an `Array.isArray` guard in `stepWithResult`, the
  push at the end of a step, and the clear in `resetNodeHistory`. **Zero
  production readers.** Its own docstring already said so: "`nodes[]` is only
  an audit log: it can be capped or moved later without changing resume
  semantics." The replay cursor is the resume contract.
- **`flowName`**, always the literal `'texra'` at the single write site.
- **`createdAt`**, never read; run timestamps come from the execution metadata
  record.

This deletes all three, plus the `NodeRecord` interface and
`PersistedFlowNodeRecordSchema` that existed only to type `nodes[]`.

`resetNodeHistory` keeps its method — it has two callers
(`RoundPersistedFlow` and `ToolUsePersistedFlow.prepareForFollowUp`) — and now
only rewinds the cursor.

## Issue acceptance gates

n/a — collapse sweep, no issue.

## Single source of truth

`FlowRecord.cursor` is now the sole record of where a persisted flow resumes.
Before this, the record carried two positional representations — the cursor
(authoritative) and the `nodes[]` step log (written every step, read by
nothing) — and one of them was already documented as non-authoritative.

## Duplication and abstraction budget

Removes the second, write-only positional representation and the type +
schema that described it. No new abstraction.

**Compatibility:** old records still parse. The envelope is
`z.looseObject`, so `flowName` / `createdAt` / `nodes` on records written by
earlier builds are simply ignored. The reverse direction is one-way by design
and is exactly what `schemaVersion` is for: a record from this build read by an
older build fails `flowName: z.string()` and lands in the existing
`unsupported-record` path, which preserves rather than deletes the record.
Flow records are per-run intermediate data, not an external export format.

## Net elements (R6)

| | delta |
|---|---|
| files | 0 |
| interfaces | **−1** (`NodeRecord`) |
| schema objects | **−1** (`PersistedFlowNodeRecordSchema`) |
| record fields | **−3** (`nodes`, `flowName`, `createdAt`) + their 3 schema lines |
| guard branches | **−1** (`!flow || !Array.isArray(flow.nodes)` → `!flow`) |
| exported symbols | 0 |
| net LoC | **−92** (14 insertions / 106 deletions) |

Production only: `src/agent/node/persistedFlow.ts` **−26 LoC** (31 changed
lines, 5 insertions). The remaining −66 is 11 test-fixture files that stopped
constructing the three dead fields.

## Consumer counts (R8)

```
$ grep -rn "\.nodes\b\|flowName\|createdAt" src/agent/node/persistedFlow.ts
$ grep -rn "flowName" src packages --include="*.ts" --include="*.tsx" | grep -v workflowName
$ grep -rn "PersistedFlowRecordEnvelopeSchema\|FlowRecord\b" src packages --include="*.ts" | grep -v test-kernel
```

- `flow.nodes`: 3 sites, all in `persistedFlow.ts` (`:354` guard, `:386` push,
  `:426` reset). **0 production reads.** (`chatExport/formatSpec.ts` and
  `desktop/editorTree.ts` have unrelated local `nodes` variables.)
- `flowName`: production hits were `persistedFlow.ts:45, 69, 526` only —
  declaration, schema, and the literal. Every other repo hit is `workflowName`,
  a different field, or a test fixture.
- `createdAt` on `FlowRecord`: `persistedFlow.ts:47, 71, 528` only.
- The four production `FlowRecord` consumers outside `persistedFlow.ts`
  (`SessionResumeRetrieval.ts`, `AgentLaunchContext.ts`, `resumability.ts`,
  `runToolUseFlow.ts`/`runReflectionFlow.ts`) read `shared` and `cursor`
  only — verified by opening each.

## Host impact

Extension: none.

Desktop: `packages/desktop/tests/e2e/sessionLifecycle.spec.ts` writes a
resumable flow-record fixture; the three dead fields were removed from it.
No product code change.

CLI: none (two `WorkflowRunCommand` fixtures updated).

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean
- `npx vitest run` over the 10 suites that construct or assert flow records:
  `PersistedFlow`, `SessionResumeRetrieval`, `ReflectionFlowStateRecovery`,
  `storage/Resumability`, `ExecutionsToolResumability`, `ToolUseFollowUp`,
  `SessionRestartRepair`, `cli/HistoryStatus`, `cli/WorkflowRunCommand`,
  `transcript/completedRunArchive` — **10 files, 184 tests passed**
- `npx vitest run RoundPersistedFlowCompileRepair` (the other
  `resetNodeHistory` caller) — 8 tests passed
- `npm run lint` — clean
- `npm run check:dead-code-ratchet` — 8 current vs 8 baselined, OK
- `npx prettier --write` on the touched files

### Test changes

Two `it.each` cases named "valid shared state without nodes" pinned the removed
`Array.isArray(flow.nodes)` guard:

- `SessionResumeRetrieval.vitest.ts` — became byte-identical to the existing
  "legacy record without a replay cursor" case, so it was deleted.
- `ReflectionFlowStateRecovery.vitest.ts` — renamed to "valid shared state
  without a replay cursor", which is what it now asserts.

`PersistedFlow.vitest.ts` dropped three `nodes:` assertions; the surrounding
cursor assertions in the same tests are unchanged.

The write spy in `SessionResumeRetrieval.vitest.ts` identified "the flow's
first node-step persist" by `value.nodes.length > 0`. It now keys on
`cursor.lastAction !== undefined`, which is stamped by exactly the same write
and by no other write path.

No new tests added.

### Follow-up commit: stale names and comments

Review caught that the `PersistedFlow` class docstring still advertised
"Execution audit trail via node history" and "Node history tracks actions, not
outputs (minimal storage)" — both describing the array this PR deletes. A
comment that describes removed machinery is worse than no comment, because the
next reader trusts it and may re-add the field. Both lines are rewritten to
state what the record actually carries: `cursor` as the whole resume contract,
`schemaVersion` as the readability gate.

Same defect, one level up: `resetNodeHistory` no longer resets any history — it
only rewinds the replay cursor — and its two call-site comments in
`RoundPersistedFlow.ts` and `runToolUseFlow.ts` still said "node history". The
method is renamed to `rewindToStart` and both comments corrected. Mechanical:
one declaration, two call sites, one projection docstring reference; typecheck
clean and all 11 flow-record suites re-run green (192 tests).
