### PR TITLE
refactor(extension): collapse the agent-directory watcher registry to one callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,6 @@
     "markdown-it": "^15.0.0",
     "markdown-it-texmath": "^1.0.0",
     "mime-types": "^3.0.1",
-    "minimatch": "^10.2.6",
     "monaco-editor": "^0.56.0",
     "mutative": "^1.3.0",
     "nanoid": "^6.0.1",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1088,7 +1088,6 @@
     "markdown-it": "^15.0.0",
     "markdown-it-texmath": "^1.0.0",
     "mime-types": "^3.0.1",
-    "minimatch": "^10.2.6",
     "mutative": "^1.3.0",
     "nanoid": "^6.0.1",
     "openai": "^7.4.0",

--- a/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
+++ b/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
@@ -4,7 +4,6 @@ import * as path from 'node:path';
 
 // Third-party imports
 import * as vscode from 'vscode';
-import { minimatch } from 'minimatch';
 import PQueue from 'p-queue';
 
 // Local imports
@@ -26,29 +25,12 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 const CHANNEL = 'AgentLoad';
 const log = createLog(CHANNEL);
 
-type AgentDirectoryEventType = 'create' | 'change' | 'delete';
-
-interface AgentDirectoryWatcherEvent extends AgentDirectoryEntry {
-  type: AgentDirectoryEventType;
-  uri: vscode.Uri;
-  relativePath: string;
-}
-
-interface AgentDirectoryWatcherOptions {
-  pattern?: string;
-  onEvent: (event: AgentDirectoryWatcherEvent) => void;
-}
-
-interface AgentDirectoryWatcherSubscription {
-  pattern: string;
-  handleEvent: (event: AgentDirectoryWatcherEvent) => void;
-}
-
 class AgentDirectoryManager {
   private context: vscode.ExtensionContext | undefined;
   private directoryService: AgentDirectoryService | undefined;
   private watcherDisposables: vscode.Disposable[] = [];
-  private watcherSubscriptions = new Set<AgentDirectoryWatcherSubscription>();
+  /** The single watcher subscriber; `undefined` means nobody is listening. */
+  private onAgentYamlChange: (() => void) | undefined;
   private externalWatcherDirectoryPaths = new Set<string>();
   private watcherDirectories: AgentDirectoryEntry[] | null = null;
   private readonly watcherRebuilds = new PQueue({ concurrency: 1 });
@@ -117,30 +99,20 @@ class AgentDirectoryManager {
     return selectedPath;
   }
 
-  watchAgentDirectories(
-    options: AgentDirectoryWatcherOptions,
-  ): vscode.Disposable {
+  /**
+   * Watch every local agent directory and call `onChange` whenever an agent
+   * YAML file is created, changed or deleted. One subscriber at a time —
+   * re-subscribing replaces the previous callback.
+   */
+  watchAgentDirectories(onChange: () => void): vscode.Disposable {
     this.getDirectoryService();
-    const pattern = options.pattern ?? '**/*';
-    const subscription: AgentDirectoryWatcherSubscription = {
-      pattern,
-      handleEvent: (event) => {
-        // relativePath is already normalized to forward slashes in dispatchAgentEvent
-        if (minimatch(event.relativePath, pattern, { dot: true })) {
-          options.onEvent(event);
-        }
-      },
-    };
-
-    this.watcherSubscriptions.add(subscription);
+    this.onAgentYamlChange = onChange;
     this.scheduleAgentWatcherSetup();
 
     return {
       dispose: () => {
-        this.watcherSubscriptions.delete(subscription);
-        if (this.watcherSubscriptions.size === 0) {
-          this.disposeAgentWatchers();
-        }
+        this.onAgentYamlChange = undefined;
+        this.disposeAgentWatchers();
       },
     };
   }
@@ -150,7 +122,7 @@ class AgentDirectoryManager {
    * Called by the settings view after updating CUSTOM_AGENT_DIR in globalSM.
    */
   async refreshAfterDirChange(): Promise<void> {
-    if (this.watcherSubscriptions.size > 0) {
+    if (this.onAgentYamlChange) {
       await this.ensureAgentWatchers();
     }
   }
@@ -175,7 +147,7 @@ class AgentDirectoryManager {
    * it: a request arriving while a rebuild runs is answered by the waiting
    * one, which reads the directory list after the running rebuild has settled.
    * Disposal never discards queued rebuilds, so every caller awaiting one
-   * settles; a rebuild that starts with no subscriptions left has nothing to
+   * settles; a rebuild that starts with no subscriber left has nothing to
    * watch and returns.
    */
   private async ensureAgentWatchers(): Promise<void> {
@@ -185,12 +157,12 @@ class AgentDirectoryManager {
     }
 
     await this.watcherRebuilds.add(async () => {
-      if (this.watcherSubscriptions.size === 0) {
+      if (!this.onAgentYamlChange) {
         return;
       }
 
       const directories = await this.getAllLocal();
-      if (this.watcherSubscriptions.size === 0) {
+      if (!this.onAgentYamlChange) {
         return;
       }
       const cached = this.watcherDirectories;
@@ -200,7 +172,7 @@ class AgentDirectoryManager {
       }
 
       await this.buildAgentWatchers(directories);
-      if (this.watcherSubscriptions.size === 0) {
+      if (!this.onAgentYamlChange) {
         this.disposeAgentWatchers();
       }
     });
@@ -225,7 +197,7 @@ class AgentDirectoryManager {
       const workspaceFolder = vscode.workspace.getWorkspaceFolder(directoryUri);
 
       if (workspaceFolder) {
-        this.watchDirectoryTree(entry, directoryUri, '**/*');
+        this.watchDirectoryTree(directoryUri, '**/*');
         watchedDirectories.push(entry.directory);
         continue;
       }
@@ -236,7 +208,6 @@ class AgentDirectoryManager {
       }
 
       await this.watchExternalCustomDirectory(
-        entry,
         directoryUri,
         previousExternalWatcherDirectoryPaths,
       );
@@ -254,8 +225,12 @@ class AgentDirectoryManager {
     }
   }
 
+  /**
+   * The watcher pattern stays unfiltered: directory create/delete events must
+   * keep reaching `onCreateOrDelete`, which is what drives the rebuild. The
+   * `.yaml` filter belongs at the subscriber edge, in `notifyAgentYamlChange`.
+   */
   private watchDirectoryTree(
-    entry: AgentDirectoryEntry,
     directoryUri: vscode.Uri,
     pattern: string,
     onCreateOrDelete?: (
@@ -272,18 +247,17 @@ class AgentDirectoryManager {
     this.watcherDisposables.push(watcher);
 
     watcher.onDidCreate((uri) => {
-      this.dispatchAgentEvent(entry, 'create', uri);
+      this.notifyAgentYamlChange(uri);
       void onCreateOrDelete?.('create', uri);
     });
-    watcher.onDidChange((uri) => this.dispatchAgentEvent(entry, 'change', uri));
+    watcher.onDidChange((uri) => this.notifyAgentYamlChange(uri));
     watcher.onDidDelete((uri) => {
-      this.dispatchAgentEvent(entry, 'delete', uri);
+      this.notifyAgentYamlChange(uri);
       void onCreateOrDelete?.('delete', uri);
     });
   }
 
   private async watchExternalCustomDirectory(
-    entry: AgentDirectoryEntry,
     directoryUri: vscode.Uri,
     previousDirectoryPaths: ReadonlySet<string>,
   ): Promise<void> {
@@ -299,12 +273,12 @@ class AgentDirectoryManager {
         newlyWatchedDirectories.push(dirUri);
       }
       this.externalWatcherDirectoryPaths.add(normalizedDirectoryPath);
-      this.watchDirectoryTree(entry, dirUri, '*', (type, uri) =>
+      this.watchDirectoryTree(dirUri, '*', (type, uri) =>
         this.handleExternalDirectoryTreeChange(type, uri),
       );
     }
 
-    await this.dispatchExistingYamlFiles(entry, newlyWatchedDirectories);
+    await this.dispatchExistingYamlFiles(newlyWatchedDirectories);
   }
 
   private async collectDirectoryUris(root: vscode.Uri): Promise<vscode.Uri[]> {
@@ -372,7 +346,6 @@ class AgentDirectoryManager {
   }
 
   private async dispatchExistingYamlFiles(
-    entry: AgentDirectoryEntry,
     directories: readonly vscode.Uri[],
   ): Promise<void> {
     for (const directory of directories) {
@@ -388,11 +361,7 @@ class AgentDirectoryManager {
 
       for (const [name, type] of files) {
         if ((type & vscode.FileType.File) !== 0 && name.endsWith('.yaml')) {
-          this.dispatchAgentEvent(
-            entry,
-            'create',
-            vscode.Uri.joinPath(directory, name),
-          );
+          this.onAgentYamlChange?.();
         }
       }
     }
@@ -427,33 +396,15 @@ class AgentDirectoryManager {
     return path.resolve(fsPath);
   }
 
-  private dispatchAgentEvent(
-    entry: AgentDirectoryEntry,
-    type: AgentDirectoryEventType,
-    uri: vscode.Uri,
-  ): void {
-    // Normalize to forward slashes for cross-platform consistency.
-    // path.relative() returns backslashes on Windows, but minimatch
-    // and downstream consumers expect forward slashes.
-    const relativePath = path
-      .relative(entry.directory, uri.fsPath)
-      .replaceAll('\\', '/');
-    const event: AgentDirectoryWatcherEvent = {
-      type,
-      uri,
-      relativePath,
-      directory: entry.directory,
-      source: entry.source,
-    };
-
-    for (const subscription of this.watcherSubscriptions) {
-      subscription.handleEvent(event);
+  private notifyAgentYamlChange(uri: vscode.Uri): void {
+    if (uri.fsPath.endsWith('.yaml')) {
+      this.onAgentYamlChange?.();
     }
   }
 
   /**
    * Dispose all file system watchers.
-   * Used when all subscriptions are removed.
+   * Used when the subscription is removed.
    */
   private disposeAgentWatchers(): void {
     this.watcherDisposables.forEach((watcher) => watcher.dispose());

--- a/packages/extension/src/webview/MainViewProvider.ts
+++ b/packages/extension/src/webview/MainViewProvider.ts
@@ -306,10 +306,9 @@ export class MainViewProvider
 
   private setupAgentWatcher() {
     this.context.subscriptions.push(
-      agentDirectories.watchAgentDirectories({
-        pattern: '**/*.yaml',
-        onEvent: () => this.debouncedRefreshAgentOptions(),
-      }),
+      agentDirectories.watchAgentDirectories(() =>
+        this.debouncedRefreshAgentOptions(),
+      ),
     );
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,9 +168,6 @@ importers:
       mime-types:
         specifier: ^3.0.1
         version: 3.0.2
-      minimatch:
-        specifier: ^10.2.6
-        version: 10.2.6
       monaco-editor:
         specifier: ^0.56.0
         version: 0.56.0
@@ -886,9 +883,6 @@ importers:
       mime-types:
         specifier: ^3.0.1
         version: 3.0.2
-      minimatch:
-        specifier: ^10.2.6
-        version: 10.2.6
       mutative:
         specifier: ^1.3.0
         version: 1.3.0

--- a/src/test-kernel/frontend/agents/AgentDirectoryWatchers.vitest.ts
+++ b/src/test-kernel/frontend/agents/AgentDirectoryWatchers.vitest.ts
@@ -158,9 +158,7 @@ describe('agent directory watcher rebuilds', () => {
   });
 
   function subscribe(): vscode.Disposable {
-    subscription = agentDirectories.watchAgentDirectories({
-      onEvent: () => {},
-    });
+    subscription = agentDirectories.watchAgentDirectories(() => {});
     return subscription;
   }
 
@@ -175,17 +173,15 @@ describe('agent directory watcher rebuilds', () => {
     return firstRead;
   }
 
-  it('builds the watcher set once for subscriptions racing the same directory read', async () => {
+  it('builds the watcher set once for rebuilds racing the same directory read', async () => {
     const firstRead = parkFirstRead(directoryList('/agents/builtin'));
 
     subscribe();
-    const second = agentDirectories.watchAgentDirectories({
-      onEvent: () => {},
-    });
+    const refreshed = agentDirectories.refreshAfterDirChange();
 
     firstRead.resolve(directoryList('/agents/builtin'));
+    await refreshed;
     await settle();
-    second.dispose();
 
     expect(mocks.watchedDirectories).toEqual(['/agents/builtin']);
   });


### PR DESCRIPTION
## Summary

`AgentDirectoryManager` carried a general-purpose watcher **subscription registry**: a `Set` of `{pattern, handleEvent}` records, a five-field `AgentDirectoryWatcherEvent` (`type`, `uri`, `relativePath`, `directory`, `source`), per-subscription glob matching via `minimatch`, and refcounted disposal.

It has exactly one subscriber, and that subscriber uses none of it:

```ts
// MainViewProvider.ts:309 — the only non-test call site
agentDirectories.watchAgentDirectories({
  pattern: '**/*.yaml',
  onEvent: () => this.debouncedRefreshAgentOptions(),
});
```

A zero-arg arrow — all five event fields discarded — and the one pattern ever passed. So the registry collapses to a single nullable callback and the glob engine collapses to `uri.fsPath.endsWith('.yaml')`.

**Filter placement.** The `.yaml` test stays at the *subscriber edge* (`notifyAgentYamlChange`), never in the `RelativePattern`. The watchers are deliberately unfiltered so directory create/delete events keep reaching `handleExternalDirectoryTreeChange`, which is what drives the watcher rebuild. A comment now records that constraint on `watchDirectoryTree`.

**Filter equivalence.** `minimatch(rel, '**/*.yaml', {dot: true})` vs `fsPath.endsWith('.yaml')`: `**/` matches zero segments in minimatch, both are case-sensitive, and directories never end in `.yaml`. `dispatchExistingYamlFiles` already hand-filtered with `name.endsWith('.yaml')` — the duplicate filter is the proof the two agreed.

**Cascade.** With `relativePath` gone, the Windows `path.relative(...).replaceAll('\\','/')` normalization dies (its own comment said it existed only to feed minimatch), and the `entry: AgentDirectoryEntry` parameter becomes unused in three private methods and drops out of each.

**`minimatch` leaves the repo.** After this it has zero imports repo-wide, and it was declared in **two** manifests. `knip.json` sets `"ignoreDependencies": [".*"]`, so nothing would have told us — both declarations are removed by hand and the lockfile regenerated in the same commit (6 lines, both importer entries, nothing else).

The four `watcherSubscriptions.size === 0` reads are **not** deletions — they are the "a rebuild that starts with no subscriber has nothing to watch" invariant documented on `ensureAgentWatchers`. They become `!this.onAgentYamlChange`.

## R6 net-element accounting

| Element | Delta |
|---|---|
| Files | 0 |
| Exports | 0 (`agentDirectories` unchanged; all removed symbols were module-private) |
| Interfaces | **−3** (`AgentDirectoryWatcherEvent`, `AgentDirectoryWatcherOptions`, `AgentDirectoryWatcherSubscription`) |
| Type aliases | **−1** (`AgentDirectoryEventType`) |
| Methods | **−1** (`dispatchAgentEvent` → replaced by the 3-line `notifyAgentYamlChange`) |
| Fields | **−1** net (`watcherSubscriptions: Set<…>` → `onAgentYamlChange: (() => void) \| undefined`) |
| Parameters | **−4** (`entry` from `watchDirectoryTree`, `watchExternalCustomDirectory`, `dispatchExistingYamlFiles`; `pattern` option from the public API) |
| npm dependency declarations | **−2** (`package.json`, `packages/extension/package.json`) |
| Production LoC | **−80** (+37 / −117 across `AgentDirectoryManager.ts` and `MainViewProvider.ts`) |
| Test LoC | **−8** (one existing case converted, none added, none deleted) |
| Lockfile | −6 |
| Ratchets | none widened; `knip-baseline.json` unchanged (verified by running the ratchet) |

Net reduction across every column.

## R8 consumer grep

```
git grep -n "watchAgentDirectories"
  → 1 production call site: packages/extension/src/webview/MainViewProvider.ts:309
  → 2 test sites (AgentDirectoryWatchers.vitest.ts, and a signature-agnostic
    `() => ({dispose(){}})` stub in SidebarSurfaceOwnership.vitest.ts:70 that
    needs no change)
  → remaining hits are prose in docs/prds/2026-01-30-dual-logic-infrastructure.md

git grep -rn "minimatch" -- . ':!pnpm-lock.yaml'      # before: 1 import + 1 call in
  AgentDirectoryManager.ts, 2 manifest declarations, and prose/comments elsewhere
  (src/tools/gitignore.ts:105 is a comment about a parser that no longer uses it)
git grep -rn "from 'minimatch'"                        # after: 0 hits

git grep -n "dispatchAgentEvent\|AgentDirectoryWatcherEvent\|AgentDirectoryWatcherOptions\|AgentDirectoryWatcherSubscription\|AgentDirectoryEventType"
  → after: 0 hits repo-wide

git grep -n "new MainViewProvider"  # 1 production construction (commands.ts:47),
  i.e. `setupAgentWatcher` runs once per activation — a single subscriber is not
  a narrowing of any live behaviour
```

No consumer orphaned.

## Not done (deliberately)

The five forwarding methods on `AgentDirectoryManager` (`builtIn`, `builtInToolUse`, `getDirectory`, `getAllLocal`, `custom`) look like the same species but are **not** bundled here:

- `getAllLocal` is not a forwarder — it has an internal caller in `ensureAgentWatchers`.
- `getDirectory` cannot move to `platform().agentDirectories`: `src/platform/interfaces.ts:257-261` declares only `custom()`/`builtIn()`/`builtInToolUse()`, and `getDirectory` has two live callers in `settingsView/handlers/agentHandlers.ts`. Removing it needs a **port widening**, which this sweep does not do.
- `custom()` alone has 6 extension call sites. That is a host-wiring migration, and bundling it here would bury a clean −80 inside a contested change.

## Verified

- `npm run typecheck` — clean (full workspace).
- `npx vitest run src/test-kernel/frontend/agents/AgentDirectoryWatchers.vitest.ts src/test-kernel/webview/SidebarSurfaceOwnership.vitest.ts` — **2 files / 8 tests passed**.
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — `8 current vs 8 baselined`, OK, baseline unchanged.
- `node scripts/sync-package-contributes.mjs` — no drift after the manifest edit.
- `pnpm install` after the manifest edit — lockfile diff is 6 lines, both minimatch importer entries and nothing else.
- Every line cited in the brief re-opened at `origin/main` (`3637d6797d`) before editing; all matched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
