### PR TITLE
fix(agent): preserve resumed flow after read failure

### DIFF
--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -347,7 +347,7 @@ export async function runToolUseFlow<C = unknown>(
   // is attached, before the flow is interruptible. An async cancellation racing
   // in during the recovery read must not erase follow-ups appended to the
   // now-live session after attachment, so this window asks the lifecycle to
-  // preserve the queue, matching `preserveResumeRecord`'s finally guard.
+  // preserve the queue, matching the startup preservation guard below.
   // Cleared once the flow has passed both guards and moved into real work, so a
   // later mid-run cancellation asks for the normal destructive clear. Whether
   // that clear actually happens is the lifecycle's call: it alone knows whether
@@ -381,7 +381,8 @@ export async function runToolUseFlow<C = unknown>(
   let files: string[] | undefined;
   let totalCostUsd: number | undefined;
   let attachmentFollowUps: readonly FollowUpQueueBatchItem[] = [];
-  let preserveResumeRecord = false;
+  let resumeStartupPreservation:
+    'cancellation' | 'initial-read-failure' | undefined;
   let persistenceRecoveryPending = false;
   let flowRunStarted = false;
   let primaryFailure: { readonly error: unknown } | undefined;
@@ -435,7 +436,7 @@ export async function runToolUseFlow<C = unknown>(
     // A host can hand off a cancellation synchronously during setup. Observe
     // it before touching the persisted resume record.
     if (signal.aborted) {
-      preserveResumeRecord = input.resume !== undefined;
+      if (input.resume) resumeStartupPreservation = 'cancellation';
       earlyResult = { outcome };
       throw startupInterruption;
     }
@@ -504,10 +505,14 @@ export async function runToolUseFlow<C = unknown>(
           await store.writeWorkspaceFiles(currentTouchedFiles);
         }
       });
+      const firstFlowRun = !flowRunStarted;
       flowRunStarted = true;
       try {
         finalAction = await pf.run(shared);
       } catch (error: unknown) {
+        if (input.resume && firstFlowRun && pf.isInitialReadFailure(error)) {
+          resumeStartupPreservation = 'initial-read-failure';
+        }
         if (signal.aborted) {
           shared = (await pf.getShared()) ?? shared;
           await pf.prepareForFollowUp(shared);
@@ -578,9 +583,12 @@ export async function runToolUseFlow<C = unknown>(
     activePersistedFlow = undefined;
     attemptTeardown('detaching the live flow', () => liveAttachment.detach());
     let preservationReason: string | undefined;
-    if (preserveResumeRecord) {
+    if (resumeStartupPreservation === 'cancellation') {
       preservationReason =
         'Flow record preserved after resume startup cancellation';
+    } else if (resumeStartupPreservation === 'initial-read-failure') {
+      preservationReason =
+        'Flow record preserved after initial resumed flow read failure';
     } else if (persistenceRecoveryPending) {
       preservationReason =
         'Flow record preserved after persistence recovery failure';

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -231,6 +231,8 @@ export class PersistedFlow<
    * stepWithResult that immediately follows the previous step's write).
    */
   private cachedRecord: FlowRecord | null = null;
+  private initialReadAttempted = false;
+  private initialReadFailure: PersistedFlowStateError | undefined;
 
   /**
    * Whether `cachedRecord.shared` is already a validated `S`. Records this
@@ -296,9 +298,25 @@ export class PersistedFlow<
    */
   private async loadRecord(): Promise<FlowRecord | undefined> {
     if (this.cachedRecord) return this.cachedRecord;
-    const flow = await this.kv.read<FlowRecord>(flowKey(this.runId));
+    const initialRead = !this.initialReadAttempted;
+    this.initialReadAttempted = true;
+    let flow: FlowRecord | undefined;
+    try {
+      flow = await this.kv.read<FlowRecord>(flowKey(this.runId));
+    } catch (cause) {
+      const error = new PersistedFlowStateError(this.runId, 'read-failed', {
+        cause,
+      });
+      if (initialRead) this.initialReadFailure = error;
+      throw error;
+    }
     this.cachedSharedTrusted = false;
     return flow;
+  }
+
+  /** Whether `error` is this instance's failed first raw record read. */
+  isInitialReadFailure(error: unknown): boolean {
+    return error === this.initialReadFailure;
   }
 
   /** Register a write-through projection that fires after each persist. */

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -16,6 +16,7 @@ import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import {
   FLOW_RECORD_SCHEMA_VERSION,
+  PersistedFlow,
   PersistedFlowStateError,
   flowKey,
   type FlowRecord,
@@ -1047,6 +1048,96 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       readSpy.mockRestore();
       deleteSpy.mockRestore();
       session.followUps.terminalize(streamId);
+    }
+  });
+
+  it('preserves a resumed record when its first in-flow read fails', async () => {
+    const executionId = 'abc-flow-read-failure-resumed' as ExecutionId;
+    const streamId = 'chat@gpt54#abc-flow-read-failure-resumed' as StreamTabId;
+    const snapshot = buildToolUseResumeData(executionId, streamId);
+    const store = getExecutionStore(executionId);
+    await writeFlowRecord(executionId, snapshot.shared);
+    const readFailure = new Error('flow storage unavailable');
+    const readSpy = vi.spyOn(store, 'read').mockRejectedValueOnce(readFailure);
+    const dispositions: Array<'preserve' | 'delete'> = [];
+
+    try {
+      await expect(
+        runPersistedFlow(executionId, streamId, snapshot, {
+          onFlowRecordDisposition: (value) => dispositions.push(value),
+        }),
+      ).rejects.toMatchObject({
+        name: PersistedFlowStateError.name,
+        reason: 'read-failed',
+        cause: readFailure,
+      });
+      expect(dispositions).toEqual(['preserve']);
+    } finally {
+      readSpy.mockRestore();
+    }
+    expect(await readFlowRecord(executionId)).toMatchObject({
+      shared: snapshot.shared,
+    });
+  });
+
+  it('does not preserve a read failure from a later in-flow cycle', async () => {
+    const executionId = 'abc-flow-later-read-failure' as ExecutionId;
+    const streamId = 'chat@gpt54#abc-flow-later-read-failure' as StreamTabId;
+    const snapshot = buildToolUseResumeData(executionId, streamId);
+    const store = getExecutionStore(executionId);
+    await writeFlowRecord(executionId, snapshot.shared, WAITING_AT_START);
+    const readFailure = new Error('flow storage unavailable');
+    const realRead = store.read.bind(store);
+    let flowReads = 0;
+    const readSpy = vi.spyOn(store, 'read').mockImplementation(async (key) => {
+      if (key === flowKey(executionId) && ++flowReads === 2) {
+        throw readFailure;
+      }
+      return realRead(key);
+    });
+    const takePendingFollowUps = vi
+      .fn<NonNullable<RunToolUseFlowInput['takePendingFollowUps']>>()
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([{ text: 'Continue.', origin: 'user' }]);
+    const dispositions: Array<'preserve' | 'delete'> = [];
+
+    try {
+      await expect(
+        runPersistedFlow(executionId, streamId, snapshot, {
+          takePendingFollowUps,
+          onFlowRecordDisposition: (value) => dispositions.push(value),
+        }),
+      ).rejects.toMatchObject({
+        name: PersistedFlowStateError.name,
+        reason: 'read-failed',
+        cause: readFailure,
+      });
+      expect(dispositions).toEqual(['delete']);
+    } finally {
+      readSpy.mockRestore();
+    }
+  });
+
+  it('does not preserve an unrelated read-failed flow error', async () => {
+    const executionId = 'abc-flow-unrelated-read-failure' as ExecutionId;
+    const streamId =
+      'chat@gpt54#abc-flow-unrelated-read-failure' as StreamTabId;
+    const snapshot = buildToolUseResumeData(executionId, streamId);
+    const runFailure = new PersistedFlowStateError(executionId, 'read-failed');
+    const runSpy = vi
+      .spyOn(PersistedFlow.prototype, 'run')
+      .mockRejectedValueOnce(runFailure);
+    const dispositions: Array<'preserve' | 'delete'> = [];
+
+    try {
+      await expect(
+        runPersistedFlow(executionId, streamId, snapshot, {
+          onFlowRecordDisposition: (value) => dispositions.push(value),
+        }),
+      ).rejects.toBe(runFailure);
+      expect(dispositions).toEqual(['delete']);
+    } finally {
+      runSpy.mockRestore();
     }
   });
 


### PR DESCRIPTION
## Summary

- classify raw persisted-flow KV read failures as `PersistedFlowStateError('read-failed')` without changing record validation semantics
- identify the exact first record-read failure for each persisted-flow instance
- preserve a resumed flow record only when the invocation's first in-flow read fails, while later and nested failures keep their existing deletion policy
- log the correct resume-startup preservation reason

## Validation

- `SessionResumeRetrieval.vitest.ts` and `PersistedFlow.vitest.ts`: 61 passed
- test-kernel typecheck
- targeted ESLint
- `git diff --check`
- independent code review found no blocking or should-fix findings

Closes #10901
