### PR TITLE
refactor(schemas): drop the never-read executionId from the usage payload

### DIFF
--- a/src/shared/schemas/progressEvents.ts
+++ b/src/shared/schemas/progressEvents.ts
@@ -102,7 +102,6 @@ export interface ClearMissingOutputsPayload {
 export interface UpdateStreamUsagePayload {
   streamId: StreamTabId;
   storageKey: StorageKey;
-  executionId?: ExecutionId;
   usage: ExtendedTokenUsageStats;
 }
 

--- a/src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts
@@ -108,8 +108,9 @@ describe('codex progress events', () => {
       {
         payload: {
           streamId,
+          // Usage is keyed by storage key alone; an agent-CLI child's is its
+          // execution id.
           storageKey: executionId,
-          executionId,
           usage,
         },
       },

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -363,7 +363,6 @@ function emitUsage(
   streamId: StreamTabId,
   storageKey: StorageKey,
   usage: ExtendedTokenUsageStats,
-  executionId?: ExecutionId,
 ): void {
   hub.emit({
     scope: 'run',
@@ -373,7 +372,6 @@ function emitUsage(
       payload: {
         streamId,
         storageKey,
-        ...(executionId === undefined ? {} : { executionId }),
         usage,
       },
     },
@@ -3626,7 +3624,7 @@ describe('sessionSignalsAdapter run facts', () => {
         reasoningTokens: 7,
       };
 
-      emitUsage(hub, root, storageKey, usage, 'exec-direct');
+      emitUsage(hub, root, storageKey, usage);
 
       expect(streams.get().get(root)?.usage).toEqual(usage);
       // Cumulative usage is the snapshot store's per-run accumulator summed;
@@ -3901,8 +3899,8 @@ describe('sessionSignalsAdapter run facts', () => {
         reasoningTokens: 3,
       };
 
-      emitUsage(hub, root, storageKey, firstUsage, 'exec-direct-sequence');
-      emitUsage(hub, root, storageKey, secondUsage, 'exec-direct-sequence');
+      emitUsage(hub, root, storageKey, firstUsage);
+      emitUsage(hub, root, storageKey, secondUsage);
 
       expect(streams.get().get(root)?.usage).toEqual(secondUsage);
       // Summed from the store's per-run map — the one accumulator, which

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -76,7 +76,6 @@ export function publishAgentCliStreamUsage(
     {
       streamId: childStreamId,
       storageKey: executionId as StorageKey,
-      executionId,
       usage,
     },
     { recordTranscript: false },


### PR DESCRIPTION
## Summary

`UpdateStreamUsagePayload.executionId` (`src/shared/schemas/progressEvents.ts:104`)
is written by exactly one producer and read by nobody. Delete it.

**Needs an owner call.** `packages/cli/src/runtime/sessionProgressSubscription.ts:113-114`
forwards the `usage` payload verbatim into the frozen public NDJSON vocabulary,
so this field is *visible* on `--output-format ndjson` today — present for
codex/claude_code child streams, absent for native runs, because only the
agent-CLI emitter sets it. `cliNdjsonProgressEvents.ts:50-58` freezes that
vocabulary against **additions**; a removal is a judgement I should not make
silently, so it is flagged here rather than buried. Nothing reads it, and the
inconsistency itself is arguably the bug.

**There is a direct, merged precedent for exactly this removal.** #10801
("refactor: delete redundant defensive state", 2026-08-17) deleted
`executionId?: ExecutionId;` from `StreamScopedPayload` — the shared base of
the stream-scoped run-fact payloads in **this same file**:

```
$ git show 2bfd2489a9 -- src/shared/schemas/progressEvents.ts
 interface StreamScopedPayload {
   streamId: StreamTabId;
-  executionId?: ExecutionId;
 }
```

Three payloads extended that base and lost the field —
`AddOutputFilesPayload`, `UpdateMissingOutputsPayload`,
`UpdateCompileFailuresPayload` — and **all three are in the frozen NDJSON
table** (`addOutputFiles`, `updateMissingOutputs`, `updateCompileFailures`).
So the "removal from a frozen public surface" question already has a merged
answer from two days ago. #10875 then deleted the degenerate base.
`UpdateStreamUsagePayload` survived that sweep only because it declares its own
fields instead of extending the base — it is the leftover instance, not a new
proposal. That does not make the owner call unnecessary, but it does mean this
PR follows the direction of travel rather than setting it.

This is the one Zone-A-free slice carved out of a larger `StorageKey`-vs-
`ExecutionId` candidate. The rest of that candidate is **deliberately not
here** — see below.

## Issue acceptance gates

No issue. One carve-out from a verified dual-systems sweep.

## Single source of truth

The `usage` event already keys on `storageKey` alone
(`StreamSnapshotStore.addUsage`'s per-key map, `runTrackingSlice`'s per-key
assign, both totalled by every reader). Removing the second, never-consulted id
leaves one addressing key on the event instead of two.

## Duplication and abstraction budget

One dead field removed. No abstraction added.

**Deliberately not done in this PR**, and recorded so it is not re-proposed
piecemeal: collapsing the `StorageKey` (run-stage nanoid) / `ExecutionId` dual
itself. Two reasons, both verified:

1. `docs/prds/2026-08-18-session-event-journal.md:129` rules that usage events
   fold to totals with a periodic checkpoint — the journal deletes the keying
   entirely. The map, its key type and its ~8 annotation sites all live in
   `src/transcript/StreamSnapshotStore.ts` and persist through
   `StreamSnapshotSchema.runUsage`. Landing the collapse today means editing
   machinery an active PRD replaces, for a type rename.
2. `UsageMonitor.ts:199` (`stageId: logger.activeStageId() ?? storageKey`)
   lands at `TexraTranscriptRecorder.ts:640-648` as `groupId`. On the native
   path `storageKey` doubles as a **transcript group id**, so substituting an
   `executionId` there would group the "Usage — input: …" row under a group
   that does not exist. The correct shape is not "delete an id space" but
   "stop conflating a stage id with an accounting key", which belongs in the
   journal PRD's ratification, not in a sweep PR.

## Net elements (R6)

Files: 2 changed, 0 added, 0 deleted.
Exported symbols: 0 net. Classes/interfaces/enums: 0 net.
Interface fields: **−1**.
LoC: production **−2** (0 added, 2 deleted); tests **−4** (2 files: one
assertion line, one dead helper parameter and its 3 arguments — see R8).
Total **−6**.

No behavior change: no code path reads the field.

## Consumer counts (R8)

```
$ grep -rn "UpdateStreamUsagePayload" src packages          # 7 type refs, 0 field reads
$ grep -rn "case 'usage'" src packages                      # 3 handlers
$ grep -rn "\.usage(" src packages                          # 2 production emitters
```

- Emitters of the `usage` event: exactly two —
  `src/agent/runtime/UsageMonitor.ts:188` (never set the field) and
  `src/tools/agentCliShared.ts:75` (the sole writer, edited here).
- Handlers: `StreamSnapshotStore.ts:623` forwards
  `{streamId, storageKey, usage}`; `TexraTranscriptRecorder.ts:640` reads
  `payload.usage` and `event.stageId`; `sessionProgressSubscription.ts:113`
  forwards the whole payload. **No `payload.executionId` read anywhere** —
  `grep -rn "payload.executionId" src packages` finds no usage-event site.
- `packages/trace-viewer/src` contains no `usage` reference at all.
- Test fixtures — **correcting an earlier claim in this PR.** My first pass
  enumerated consumers of the *type* and handlers of the *event* and concluded
  no test needed editing. That grep was incomplete: it did not cover fixtures
  that *construct* the payload. CI caught one, and I then ran the grep I should
  have run first (`grep -rn "'usage'" src packages`, every payload-construction
  site). Two test-only sites carried the field:
  - `CodexProgressEvents.vitest.ts:107` — a `toMatchObject` (partial, not
    `toEqual`) listing `streamId`, `storageKey: executionId`, `executionId`,
    `usage`. It is an incidental mirror of the emitted payload, not a
    deliberate pin: no comment, no issue reference, the case is named
    "publishes todos and usage as run facts" (its subject is that the codex
    publisher routes facts onto the run channel), and the assertion encodes the
    **same value twice** — which is precisely the redundancy being deleted. The
    `executionId` line is dropped; `storageKey: executionId` stays, because
    that is the real contract the test should hold.
  - `TuiStateAndFocus.vitest.ts:361` — an `emitUsage` helper with an optional
    `executionId` parameter spread conditionally into the payload. A conditional
    spread bypasses TypeScript's excess-property check, so this compiled fine
    and silently passed a field the type no longer has. The dead parameter and
    its three arguments are removed.
  - Every other payload-construction fixture (`StatusBarSessionEvents`,
    `DesktopAgentExecution` ×2, `RunExecution`, `ProgressBackendFactProjection`,
    `StreamSnapshotStore`, `SessionEventHub`, `storeTestDrivers`,
    `CliSessionProgressSubscription`) already builds the payload without the
    field and needed no change.

## Host impact

Extension: none (the webview totals a per-`storageKey` map; the field never
reached it).

Desktop: none.

CLI: the `updateStreamUsage` NDJSON record stops carrying a stray
`executionId` on agent-CLI child streams. It was never documented and never
consistent — see the owner call above.

## Scheduled refactoring

The `usage` event's id vocabulary (which id the event carries, and splitting
the run-stage id out of `UsageMonitorContext`) should be a line item in the
session-event-journal PRD's ratification. Not filed as an issue.

## Validation

- `npm run typecheck` (workspace + test-kernel) — clean.
- `pnpm --filter @texra-ai/cli typecheck` — clean (both tsconfigs).
- `npx vitest run src/test-kernel/agent/ src/test-kernel/cli/
  src/test-kernel/transcript/ src/test-kernel/progressView/
  src/test-kernel/frontend/ src/test-kernel/desktop/` — 489 files, 7121 tests,
  all passing. (My first validation pass ran only three targeted files and
  missed `CodexProgressEvents.vitest.ts`; CI caught it. This is the broad run
  that should have happened first.)
- `npm run lint` — clean.
- Zero new tests. Two existing test edits, both deletions of now-dead
  scaffolding, neither weakening an invariant — the surviving
  `storageKey: executionId` assertion still pins the real contract.
