### PR TITLE
refactor: delete dead injection seams, fields, barrel re-exports, and resource roots

### DIFF
--- a/packages/desktop/src/main/desktopViewStateIpc.ts
+++ b/packages/desktop/src/main/desktopViewStateIpc.ts
@@ -9,11 +9,6 @@ import {
   type DesktopRenderer,
 } from './desktopIpcTypes.js';
 
-export interface DesktopViewStateIpcOptions {
-  debugMode?: boolean;
-  getTheme?: () => DesktopThemeKind;
-}
-
 export interface DesktopViewStateIpc extends DesktopMessageHandler {
   dispose(): void;
 }
@@ -29,22 +24,18 @@ function getNativeTheme(): DesktopThemeKind {
 
 export function createDesktopViewStateIpc(
   renderer: DesktopRenderer,
-  options: DesktopViewStateIpcOptions = {},
 ): DesktopViewStateIpc {
-  const getTheme = options.getTheme ?? getNativeTheme;
-  const debugMode = options.debugMode ?? false;
-
   function postTheme() {
     renderer.postToRenderer({
       command: COMMON_COMMANDS.THEME_SET,
-      theme: getTheme(),
+      theme: getNativeTheme(),
     });
   }
 
   function postDebugMode() {
     renderer.postToRenderer({
       command: COMMON_COMMANDS.DEBUG_MODE_SET,
-      debugMode,
+      debugMode: false,
     });
   }
 

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -3,7 +3,7 @@ import type {
   MainViewStartupOptions,
 } from '@controllers/mainView/MainViewStartupController';
 import type { StateStore } from '@platform/interfaces';
-import type { DesktopThemeKind, MainViewExecuteMessage } from '@shared/schemas';
+import type { MainViewExecuteMessage } from '@shared/schemas';
 import { installDesktopHostBridge } from './hostBridge.js';
 import { createDesktopExecutionIpc } from './desktopExecutionIpc.js';
 import {
@@ -27,8 +27,6 @@ import type { DesktopSettingsIpc } from './desktopSettingsIpc.js';
 import type { DesktopFileSelection } from './desktopFileSelection.js';
 
 export interface DesktopMainViewIpcOptions {
-  debugMode?: boolean;
-  getTheme?: () => DesktopThemeKind;
   fileSelection: DesktopFileSelection;
   prompt: DesktopPromptIpc;
   settings: DesktopSettingsIpc;
@@ -76,10 +74,7 @@ export function installDesktopMainViewIpc(
   const bridge = installDesktopHostBridge(window, {
     onRendererMessage: handleRendererMessage,
   });
-  const viewState = createDesktopViewStateIpc(bridge, {
-    debugMode: options.debugMode,
-    getTheme: options.getTheme,
-  });
+  const viewState = createDesktopViewStateIpc(bridge);
   const shell = createDesktopShellIpc(options.shellActions);
   const execution = createDesktopExecutionIpc({
     handleExecuteMessage: options.handleExecuteMessage,

--- a/packages/extension/src/common/webview/resourceRoots.ts
+++ b/packages/extension/src/common/webview/resourceRoots.ts
@@ -10,12 +10,7 @@ export function getSharedLocalResourceRoots(
   return [
     vscode.Uri.joinPath(extensionUri, 'src', viewFolder),
     vscode.Uri.joinPath(extensionUri, 'dist', viewFolder),
-    vscode.Uri.joinPath(extensionUri, 'dist', 'shared'),
     vscode.Uri.joinPath(extensionUri, 'src', 'common', 'styles'),
-    vscode.Uri.joinPath(extensionUri, 'src', 'shared', 'styles'),
-    vscode.Uri.joinPath(extensionUri, 'src', 'common', 'modules'),
-    vscode.Uri.joinPath(extensionUri, 'src', 'common', 'webview'),
-    vscode.Uri.joinPath(extensionUri, 'src', 'common', 'constants'),
   ];
 }
 

--- a/packages/extension/src/frontend/setupTerminalRunner.ts
+++ b/packages/extension/src/frontend/setupTerminalRunner.ts
@@ -47,14 +47,11 @@ export async function runTerminalCommand(
  * user closes them; treat those as gone.
  */
 function revealTerminal(request: TerminalRunRequest): vscode.Terminal {
-  const { name, cwd, env } = request;
-  const hasLaunchOverrides = cwd !== undefined || env !== undefined;
-  const existing = hasLaunchOverrides
-    ? undefined
-    : vscode.window.terminals.find(
-        (t) => t.name === name && t.exitStatus === undefined,
-      );
-  const terminal = existing ?? vscode.window.createTerminal({ name, cwd, env });
+  const { name } = request;
+  const existing = vscode.window.terminals.find(
+    (t) => t.name === name && t.exitStatus === undefined,
+  );
+  const terminal = existing ?? vscode.window.createTerminal({ name });
   terminal.show();
   return terminal;
 }

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -4,16 +4,9 @@
 
 export type { AgentSource } from '@shared/schemas';
 
-/** All built-in delegating team roots (remote-catalog + bundled). */
-export { BUILTIN_TEAM_ROOT_AGENT_NAMES } from '@shared/constants/agents';
-
 export {
   AgentDirectoryService,
-  type AbsoluteDirectoryAccess,
   type AgentDirectoryEntry,
-  type AgentDirectoryIssueReporter,
-  type AgentDirectoryPathStorage,
-  type AgentDirectoryServiceLogger,
 } from './AgentDirectoryService';
 
 export {
@@ -24,14 +17,12 @@ export {
 export {
   // Types
   type AgentEntry,
-  type ResolvedAgent,
 } from './agentEntry';
 
 export {
   // Core functions
   loadAgents,
   registerInlineAgents,
-  clearInlineAgents,
   getAgent,
   resolveAgent,
   resolveAgentForLaunch,

--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -225,10 +225,7 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
   }
 
   private hasConfiguredSubscriptionProfile(): boolean {
-    return (
-      this.configuredSubscriptionCapabilities()?.authMode ===
-      'chatgpt-subscription'
-    );
+    return this.configuredSubscriptionCapabilities() != null;
   }
 
   /**
@@ -242,9 +239,7 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
   protected override prepareWireParams(
     params: ResponseCreateParamsBase,
   ): ResponseCreateParamsBase {
-    if (
-      this.getActiveProviderCapabilities()?.authMode !== 'chatgpt-subscription'
-    ) {
+    if (this.getActiveProviderCapabilities() == null) {
       return params;
     }
     // `rewriteCodexRequestBody` works on the parsed JSON body (a plain record),
@@ -284,7 +279,7 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
       selection === 'configured'
         ? this.configuredSubscriptionCapabilities()
         : null;
-    if (subscriptionCapabilities?.authMode !== 'chatgpt-subscription') {
+    if (subscriptionCapabilities == null) {
       // Preference switched off (e.g. after a usage limit) — route this request
       // through the user's OpenAI API key via the standard Responses client.
       this.logger.debug(

--- a/src/agent/modelHandlers/openai/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerXAI.ts
@@ -70,8 +70,8 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
   ): boolean {
     if (selection !== 'configured') return false;
     return (
-      resolveXaiSubscriptionCapabilities(this.config, getUseOpenRouter())
-        ?.authMode === 'xai-subscription'
+      resolveXaiSubscriptionCapabilities(this.config, getUseOpenRouter()) !=
+      null
     );
   }
 

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -3,11 +3,7 @@ import * as path from 'node:path';
 import { ZodError } from 'zod';
 import { ModelProvider, type ModelConfig } from 'llm-zoo';
 
-import {
-  isRemoteAgent,
-  resolveAgentForLaunch,
-  type ResolvedAgent,
-} from '@agent/index';
+import { isRemoteAgent, resolveAgentForLaunch } from '@agent/index';
 import {
   logSdkError,
   logUserMessage,
@@ -15,6 +11,7 @@ import {
   type StageHandle,
 } from '@agent/trace';
 import { getExecutionStore } from '@agent/storage';
+import type { ResolvedAgent } from '@agent/index/agentEntry';
 import {
   createToolPolicy,
   type AgentCore,

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -9,11 +9,8 @@
  * - Workflow: agentConfig + executionId + transcript-format key
  */
 
-import {
-  deriveResumability,
-  RESUMABILITY_CAUSE,
-  type ResumabilityDecision,
-} from '@agent/storage';
+import { deriveResumability, type ResumabilityDecision } from '@agent/storage';
+import { RESUMABILITY_CAUSE } from '@agent/storage/resumability';
 import type { FlowRecord } from '@agent/node/persistedFlow';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { ReflectionFlowStateSchema } from '@agent/implementations/flows/reflection/ReflectionFlowState';

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -1,6 +1,7 @@
 import * as path from 'node:path';
 
-import { resolveAgent, type ResolvedAgent } from '@agent/index';
+import { resolveAgent } from '@agent/index';
+import type { ResolvedAgent } from '@agent/index/agentEntry';
 import {
   AgentPromptSchema,
   AgentDefinitionSchema,

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -11,14 +11,13 @@
 
 import PQueue from 'p-queue';
 
-import {
-  getExecutionStore,
-  type ChildTurnRef,
-  type ChildTurnState,
-  type ResultMeta,
-} from '@agent/storage';
+import { getExecutionStore, type ResultMeta } from '@agent/storage';
 import type { AgentTrace, StageHandle } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
+import type {
+  ChildTurnRef,
+  ChildTurnState,
+} from '@agent/storage/ExecutionKVStore';
 import {
   onOwnedExecutionLeaseLost,
   captureOwnedExecutionLease,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -100,10 +100,7 @@ export { resumeQueuedToolUseFromResumeData } from './resumeQueuedToolUse';
 export type { ManualCompactionRequestResult } from './executionRegistry';
 
 // executeAgent
-export {
-  resumeToolUseFromResumeData,
-  ResumeSessionUnavailableError,
-} from './executeAgent';
+export { resumeToolUseFromResumeData } from './executeAgent';
 
 // textEnhancement
 export { polishTextWithAI } from './textEnhancement';
@@ -114,7 +111,6 @@ export { selectAutoOpenFinalOutput } from './selectAutoOpenFinalOutput';
 
 // modelHandlerCompatibilityKey
 export { ModelHandlerCompatibilityKeySchema } from './modelHandlerCompatibilityKey';
-export type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKey';
 
 // helperModelName
 export { getHelperModelName } from './helperModelName';

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -24,7 +24,6 @@ import type { ToolUseResumeData } from './SessionResumeRetrieval';
 export interface ResumeQueuedToolUseOptions extends Pick<
   SubagentRunOptions,
   | 'session'
-  | 'tools'
   | 'approvalPromptsUnavailable'
   | 'onApprovalPolicyDenial'
   | 'runtimeUnavailableTools'
@@ -139,7 +138,6 @@ export async function resumeQueuedToolUseFromResumeData(
     // cursor accepts either route; the handoff works for both.
     const result = await resumeToolUseFromResumeData(resume, {
       session: options.session,
-      tools: options.tools,
       approvalPromptsUnavailable: options.approvalPromptsUnavailable,
       onApprovalPolicyDenial: options.onApprovalPolicyDenial,
       runtimeUnavailableTools: options.runtimeUnavailableTools,

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -8,7 +8,7 @@
  */
 
 import { resolveAgentForLaunch } from '@agent/index';
-import { writeSessionDescription } from '@agent/storage';
+import { writeSessionDescription } from '@agent/storage/executionLifecycle';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import {

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -17,8 +17,6 @@ export {
   type ExecutionKVStore,
   type TodoEntry,
   type ChildRecord,
-  type ChildTurnRef,
-  type ChildTurnState,
   getExecutionStore,
   clearStoreCache,
   isReservedKvKeyName,
@@ -36,8 +34,6 @@ export {
   finalizeExecution,
   registerExecution,
   type FinalizeExecutionInput,
-  type FinalizeExecutionResult,
-  writeSessionDescription,
   writeWorkflowExecutionSnapshot,
 } from './executionLifecycle';
 export {
@@ -50,7 +46,6 @@ export {
   isUserVisibleExecution,
 } from './executionListing';
 export {
-  RESUMABILITY_CAUSE,
   deriveOfferableResumability,
   deriveResumability,
   type ResumabilityDecision,

--- a/src/controllers/settingsView/SettingsAgentCatalogController.ts
+++ b/src/controllers/settingsView/SettingsAgentCatalogController.ts
@@ -54,7 +54,6 @@ export interface SettingsAgentCatalogState {
 
 interface SettingsAgentCatalogControllerDeps {
   state: SettingsAgentCatalogState;
-  builtInOrchestratorAgentNames?: readonly string[];
   now?: () => number;
 }
 
@@ -82,7 +81,7 @@ export class SettingsAgentCatalogController implements TeamRosterCatalog {
   }
 
   getOrchestratorAgentNames(): string[] {
-    const names = new Set(this.deps.builtInOrchestratorAgentNames ?? []);
+    const names = new Set<string>(BUILTIN_TEAM_ROOT_AGENT_NAMES);
     for (const agent of this.deps.state.getAgents('toolUse')) {
       if (hasDelegationTool(agent.tools)) names.add(agent.name);
     }
@@ -241,10 +240,7 @@ export class SettingsAgentCatalogController implements TeamRosterCatalog {
     toolUseAgents: readonly string[],
     catalogAgents: readonly SettingsAgentCatalogEntry[],
   ): SettingsAgentCatalogEntry[] {
-    const knownBuiltInRoots = new Set([
-      ...BUILTIN_TEAM_ROOT_AGENT_NAMES,
-      ...(this.deps.builtInOrchestratorAgentNames ?? []),
-    ]);
+    const knownBuiltInRoots = new Set<string>(BUILTIN_TEAM_ROOT_AGENT_NAMES);
     return [...knownBuiltInRoots]
       .filter(
         (name) =>

--- a/src/controllers/settingsView/SettingsAgentControllerFactory.ts
+++ b/src/controllers/settingsView/SettingsAgentControllerFactory.ts
@@ -8,7 +8,6 @@
  */
 import {
   AgentRosterController,
-  BUILTIN_TEAM_ROOT_AGENT_NAMES,
   getAgent,
   getAgentsByCategory,
   getRosterAgent,
@@ -42,7 +41,6 @@ interface AgentControllerFactoryOptions extends SettingsStatePorts {
   ) => Promise<string | undefined>;
   readonly getAgents?: (category: AgentCategory) => AgentEntry[];
   readonly getVisibleAgents?: (category: AgentCategory) => AgentEntry[];
-  readonly builtInOrchestratorAgentNames?: readonly string[];
 }
 
 export interface SettingsAgentControllers {
@@ -97,8 +95,6 @@ export function createSettingsAgentControllers(
 
   const catalog = new SettingsAgentCatalogController({
     state,
-    builtInOrchestratorAgentNames:
-      options.builtInOrchestratorAgentNames ?? BUILTIN_TEAM_ROOT_AGENT_NAMES,
   });
   const directory = new SettingsAgentDirectoryController({
     state: {

--- a/src/hosts/uiHosts.ts
+++ b/src/hosts/uiHosts.ts
@@ -78,8 +78,6 @@ export interface PromptHost {
 
 export interface TerminalRunRequest {
   name: string;
-  cwd?: string;
-  env?: Record<string, string | undefined>;
   command: string;
   /** Hard cap on how long to wait for captured execution. */
   timeoutMs: number;

--- a/src/housekeeping/utils.ts
+++ b/src/housekeeping/utils.ts
@@ -63,9 +63,9 @@ function getFilePatterns(
   }
 
   for (let round = 0; round < numRounds; round++) {
-    // Legacy flat layout: `<base>_<chunk>_r{round}_<normalizedModel>.*`
+    // Legacy flat layout: `<base>_<chunk>_r{round}_<model>.*`
     const legacyStem = workflowOutputCopyStem({ base, agent, model, round });
-    // Legacy stem already includes `_<normalizedModel>`; for suffix variants
+    // Legacy stem already includes `_<model>`; for suffix variants
     // we reconstruct the prefix (everything up to the model token).
     const legacyPrefix = legacyStem.slice(0, -(model.length + 1));
     patterns.push(

--- a/src/housekeeping/utils.ts
+++ b/src/housekeeping/utils.ts
@@ -10,7 +10,6 @@ import { createLog } from '@logger/logUtils';
 import {
   workflowOutputCopyStem,
   midEraWorkflowOutputStem,
-  normalizeLegacyModel,
 } from '@shared/constants/workflowOutput';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { getConfig } from '@utils/config/configUtils';
@@ -44,7 +43,6 @@ function getFilePatterns(
   numRounds: number,
 ): string[] {
   const patterns: string[] = [];
-  const legacyModel = normalizeLegacyModel(model);
 
   // Mid-era layout: files live under `r{round}/<base>_<cleanAgent>_<model>.*`.
   // These files can still be present in workspaces for users who upgraded
@@ -69,38 +67,32 @@ function getFilePatterns(
     const legacyStem = workflowOutputCopyStem({ base, agent, model, round });
     // Legacy stem already includes `_<normalizedModel>`; for suffix variants
     // we reconstruct the prefix (everything up to the model token).
-    const legacyPrefix = legacyStem.slice(0, -(legacyModel.length + 1));
+    const legacyPrefix = legacyStem.slice(0, -(model.length + 1));
     patterns.push(
       legacyStem,
       `${legacyStem}_diff`,
-      `${legacyPrefix}_full_${legacyModel}`,
-      `${legacyPrefix}_full_${legacyModel}_diff`,
+      `${legacyPrefix}_full_${model}`,
+      `${legacyPrefix}_full_${model}_diff`,
       `${legacyStem}_thinking`,
     );
     if (round > 0) {
       const diffSuffix = buildBetweenRoundDiffSuffix(round, round - 1);
       patterns.push(
         `${legacyStem}${diffSuffix}`,
-        `${legacyPrefix}_full_${legacyModel}${diffSuffix}`,
+        `${legacyPrefix}_full_${model}${diffSuffix}`,
       );
     }
   }
   // Legacy merge output lived next to the input and was named after the
   // edited file (`<editedBase>_full_<model>.tex`). Requiring the `_` after
   // `<base>` keeps siblings like `paper2_…` from matching when the target
-  // is `paper.tex`. Emit both raw and normalized-model variants so legacy
-  // merge files written with the dot-stripped model token
-  // (`paper_full_gpt45`) are discovered alongside current-legacy files
-  // (`paper_full_gpt-4.5`).
-  const mergeModels = legacyModel === model ? [model] : [model, legacyModel];
-  for (const m of mergeModels) {
-    patterns.push(
-      `${base}_full_${m}`,
-      `${base}_full_${m}_diff`,
-      `${base}_*_full_${m}`,
-      `${base}_*_full_${m}_diff`,
-    );
-  }
+  // is `paper.tex`.
+  patterns.push(
+    `${base}_full_${model}`,
+    `${base}_full_${model}_diff`,
+    `${base}_*_full_${model}`,
+    `${base}_*_full_${model}_diff`,
+  );
   return patterns;
 }
 

--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -233,7 +233,7 @@ export async function runLatexdiffViaWorkspaceScan(params: {
     const roundOutputs = new Map<number, string>();
 
     // Legacy flat layout: files sit directly under outputDirPath as
-    // `<base>_<chunk>_r{round}_<normalizedModel>.tex`.
+    // `<base>_<chunk>_r{round}_<model>.tex`.
     const legacyPattern = legacyWorkflowOutputRoundRegex(
       baseInputName,
       agent,

--- a/src/model/codex/codexSignedIn.ts
+++ b/src/model/codex/codexSignedIn.ts
@@ -8,10 +8,10 @@ import { createSignedInProbe, type SignedInProbe } from '../signedInProbe';
 const signedIn = createSignedInProbe();
 
 /**
- * Install the app's ChatGPT sign-in probe, or pass `null` to restore the
- * signed-out default. Called once per process from the host composition root.
+ * Install the app's ChatGPT sign-in probe. Called once per process from the
+ * host composition root.
  */
-export function setCodexSignedInProbe(next: SignedInProbe | null): void {
+export function setCodexSignedInProbe(next: SignedInProbe): void {
   signedIn.setProbe(next);
 }
 

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -15,8 +15,6 @@ import {
 } from './kimiCodeSubscriptionRouting';
 import { resolveRuntimeModelConfig } from './runtimeModelRegistry';
 
-type ProviderAuthMode = 'chatgpt-subscription' | 'xai-subscription';
-
 export interface OpenAIResponseProviderCapabilities {
   readonly backgroundMode: 'base' | 'disabled';
   readonly streaming: 'base' | 'forced';
@@ -31,7 +29,6 @@ export interface OpenAIResponseProviderCapabilities {
 }
 
 export interface ProviderCapabilityProfile {
-  readonly authMode: ProviderAuthMode;
   readonly contextWindow: number;
   readonly inputTokenLimit?: number;
   readonly inputPrice: number;
@@ -116,7 +113,6 @@ export function resolveCodexSubscriptionProfile({
   );
 
   return {
-    authMode: 'chatgpt-subscription',
     ...zeroCostAccessOverrides(contextWindow),
     inputTokenLimit,
     usageRoute: 'chatgpt-subscription',
@@ -201,7 +197,6 @@ export function resolveXaiSubscriptionCapabilities(
   if (config.provider !== ModelProvider.XAI) return null;
   if (config.openRouterOnly) return null;
   return {
-    authMode: 'xai-subscription',
     ...zeroCostAccessOverrides(config.contextWindow),
     usageRoute: 'xai-subscription',
   };

--- a/src/model/signedInProbe.ts
+++ b/src/model/signedInProbe.ts
@@ -14,8 +14,8 @@
 export type SignedInProbe = () => Promise<boolean>;
 
 export interface SignedInProbeSlot {
-  /** Install the app's sign-in probe, or pass `null` to restore the default. */
-  setProbe(next: SignedInProbe | null): void;
+  /** Install the app's sign-in probe. */
+  setProbe(next: SignedInProbe): void;
   isSignedIn(): Promise<boolean>;
 }
 
@@ -25,7 +25,7 @@ export function createSignedInProbe(): SignedInProbeSlot {
   let probe: SignedInProbe = SIGNED_OUT;
   return {
     setProbe(next) {
-      probe = next ?? SIGNED_OUT;
+      probe = next;
     },
     isSignedIn() {
       return probe();

--- a/src/model/xai/xaiSignedIn.ts
+++ b/src/model/xai/xaiSignedIn.ts
@@ -7,10 +7,10 @@ import { createSignedInProbe, type SignedInProbe } from '../signedInProbe';
 const signedIn = createSignedInProbe();
 
 /**
- * Install the app's Grok sign-in probe, or pass `null` to restore the
- * signed-out default. Called once per process from the host composition root.
+ * Install the app's Grok sign-in probe. Called once per process from the host
+ * composition root.
  */
-export function setXaiSignedInProbe(next: SignedInProbe | null): void {
+export function setXaiSignedInProbe(next: SignedInProbe): void {
   signedIn.setProbe(next);
 }
 

--- a/src/shared/constants/workflowOutput.ts
+++ b/src/shared/constants/workflowOutput.ts
@@ -61,11 +61,6 @@ export function workflowOutputPath(params: {
 // "Save as copy" action still consume this grammar — the last of those still
 // writes it.
 
-/** Normalize a model name to the filename-era form (dots stripped). */
-export function normalizeLegacyModel(model: string): string {
-  return model.replaceAll('.', '');
-}
-
 /** First-name chunk used in the `<base>_<chunk>_r{round}_<model>` grammar. */
 function getAgentFirstNameChunk(agent: string): string {
   const cleanAgent = getCleanAgentName(agent);
@@ -89,7 +84,7 @@ export function workflowOutputCopyStem(params: {
   model: string;
   round: number;
 }): string {
-  return `${params.base}_${getAgentFirstNameChunk(params.agent)}_r${params.round}_${normalizeLegacyModel(params.model)}`;
+  return `${params.base}_${getAgentFirstNameChunk(params.agent)}_r${params.round}_${params.model}`;
 }
 
 /**
@@ -113,6 +108,6 @@ export function legacyWorkflowOutputRoundRegex(
   model: string,
 ): RegExp {
   return new RegExp(
-    `${escapeRegExp(base)}_${escapeRegExp(getAgentFirstNameChunk(agent))}_r(\\d+)_${escapeRegExp(normalizeLegacyModel(model))}`,
+    `${escapeRegExp(base)}_${escapeRegExp(getAgentFirstNameChunk(agent))}_r(\\d+)_${escapeRegExp(model)}`,
   );
 }

--- a/src/shared/constants/workflowOutput.ts
+++ b/src/shared/constants/workflowOutput.ts
@@ -74,7 +74,7 @@ function getAgentFirstNameChunk(agent: string): string {
 }
 
 /**
- * The `<base>_<chunk>_r{round}_<normalizedModel>` stem: the name filename-era
+ * The `<base>_<chunk>_r{round}_<model>` stem: the name filename-era
  * runs wrote, and the one "Save as copy" still writes beside a base file
  * today. Every reader of that layout composes its names from here.
  */

--- a/src/test-kernel/agent/AgentDirectoryService.vitest.ts
+++ b/src/test-kernel/agent/AgentDirectoryService.vitest.ts
@@ -12,7 +12,7 @@ import type {
   AgentDirectoryIssueReporter,
   AgentDirectoryPathStorage,
   AgentDirectoryServiceLogger,
-} from '@agent/index';
+} from '@agent/index/AgentDirectoryService';
 
 const STORAGE_BASE_PATH = path.resolve('/global-storage');
 const VALID_PARENT_PATH = path.resolve('/valid-parent');

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts
@@ -95,7 +95,6 @@ class ClientSideCompactionHandler extends ModelHandlerOpenAIResponse {
 
   protected override getActiveProviderCapabilities(): ProviderCapabilityProfile {
     return {
-      authMode: 'chatgpt-subscription',
       contextWindow: this.profileContextWindow,
       inputPrice: 0,
       outputPrice: 0,

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -2,8 +2,8 @@ import '@test/support/defaultSessionTestSetup';
 
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 
-import type { FinalizeExecutionResult } from '@agent/storage';
 import { noopTrace, TraceEmitter, type StatusEvent } from '@agent/trace';
+import type { FinalizeExecutionResult } from '@agent/storage/executionLifecycle';
 import {
   acquireResumedExecutionLease,
   ExecutionLeaseLostError,

--- a/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
@@ -27,7 +27,7 @@ vi.mock('@agent/runtime/helperModel', async (importActual) => ({
   createHelperModelKit: mocks.createHelperModelKit,
 }));
 
-vi.mock('@agent/storage', () => ({
+vi.mock('@agent/storage/executionLifecycle', () => ({
   writeSessionDescription: mocks.writeSessionDescription,
 }));
 

--- a/src/test-kernel/agent/runtime/agentLoad.vitest.ts
+++ b/src/test-kernel/agent/runtime/agentLoad.vitest.ts
@@ -13,15 +13,15 @@ import {
 import { z } from 'zod';
 
 import {
-  clearInlineAgents,
   getAgent,
   loadAgents,
   refresh,
   registerInlineAgents,
   resolveAgent,
   resolveAgentForLaunch,
-  type ResolvedAgent,
 } from '@agent/index';
+import type { ResolvedAgent } from '@agent/index/agentEntry';
+import { clearInlineAgents } from '@agent/index/agentRegistry';
 import {
   loadAgentSettingAndPrompts,
   validateAgentYamlContent,

--- a/src/test-kernel/agent/runtime/resumeQueuedToolUse.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeQueuedToolUse.vitest.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { ITool } from '@agent/core/tools/ToolTypes';
 import type { ResumeToolUseFromResumeDataOptions } from '@agent/runtime/executeAgent';
 import { resumeQueuedToolUseFromResumeData } from '@agent/runtime/resumeQueuedToolUse';
 import type { StreamTabId } from '@shared/schemas';
@@ -69,15 +68,11 @@ describe('resumeQueuedToolUseFromResumeData ownership', () => {
   it('claims recovery before draining and preserves ordered raced input', async () => {
     const session = createSession();
     seedRecoverable(session, 'first');
-    const tools = [
-      { definition: { name: 'run_scoped' }, call: vi.fn() },
-    ] as unknown as readonly ITool[];
 
     await expect(
       resumeQueuedToolUseFromResumeData(STREAM, snapshot(), {
         session,
         isCancellationRequested,
-        tools,
         onFollowUpQueueReady: () => {
           expect(
             session.followUps.submit(STREAM, { text: 'second' }, 'recoverable'),
@@ -89,7 +84,6 @@ describe('resumeQueuedToolUseFromResumeData ownership', () => {
 
     const options = resumeToolUseFromResumeDataMock.mock
       .calls[0]?.[1] as ResumeToolUseFromResumeDataOptions;
-    expect(options.tools).toBe(tools);
     expect(options.drainedFollowUps?.map((item) => item.text)).toEqual([
       'first',
       'second',

--- a/src/test-kernel/agent/storage/Resumability.vitest.ts
+++ b/src/test-kernel/agent/storage/Resumability.vitest.ts
@@ -5,8 +5,8 @@ import {
   deriveResumability,
   finalizeExecution,
   getExecutionStore,
-  RESUMABILITY_CAUSE,
 } from '@agent/storage';
+import { RESUMABILITY_CAUSE } from '@agent/storage/resumability';
 import { detectWaitingStreams } from '@agent/storage/detectWaitingStreams';
 import {
   FLOW_RECORD_SCHEMA_VERSION,

--- a/src/test-kernel/cli/AgentResolution.vitest.ts
+++ b/src/test-kernel/cli/AgentResolution.vitest.ts
@@ -2,7 +2,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { agentCatalogMock } from '@test/support/agentCatalogMock';
-import type { AgentEntry, ResolvedAgent } from '@agent/index';
+import type { AgentEntry } from '@agent/index';
+import type { ResolvedAgent } from '@agent/index/agentEntry';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import {
   assertCliAgentLaunch,

--- a/src/test-kernel/cli/RunChatConfig.vitest.ts
+++ b/src/test-kernel/cli/RunChatConfig.vitest.ts
@@ -1,10 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  resolveAgentForLaunch,
-  type AgentEntry,
-  type ResolvedAgent,
-} from '@agent/index';
+import { resolveAgentForLaunch, type AgentEntry } from '@agent/index';
+import type { ResolvedAgent } from '@agent/index/agentEntry';
 import {
   applyInitialCliAgentSelection,
   chatToolUseAgentUsageError,

--- a/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
+++ b/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
@@ -93,7 +93,7 @@ vi.mock('@frontend/secretManager', () => ({
 // time (`SessionHandle.ts`) and later calls `debug`/`warn` on it, while this
 // suite's minimal `@logger/logUtils` mock gives `createLog` a warn-only
 // return. No other module in this test's import graph (all deps otherwise
-// mocked away, and `apiKeyCommands`/`codexSubscriptionSignIn` don't import
+// mocked away, and `apiKeyCommands`/`subscriptionSignIn` don't import
 // SessionHandle) touches this module's other exports.
 vi.mock('@agent/runtime/SessionHandle', () => ({
   defaultSession: () => ({

--- a/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
@@ -65,7 +65,6 @@ function createController(options?: {
   enabled?: Partial<Record<AgentCategory, string[] | undefined>>;
   visible?: Partial<Record<AgentCategory, SettingsAgentCatalogEntry[]>>;
   customPresets?: unknown;
-  builtInOrchestratorAgentNames?: readonly string[];
   now?: number;
 }): {
   controller: SettingsAgentCatalogController;
@@ -77,7 +76,6 @@ function createController(options?: {
   return {
     controller: new SettingsAgentCatalogController({
       now: () => options?.now ?? 123,
-      builtInOrchestratorAgentNames: options?.builtInOrchestratorAgentNames,
       state: {
         getEnabledAgentKeys: (category) => enabled[category],
         setEnabledAgentKeys: async (category, enabledKeys) => {
@@ -234,19 +232,18 @@ describe('SettingsAgentCatalogController', () => {
           },
         ],
       },
-      builtInOrchestratorAgentNames: ['orchestrator'],
     });
 
     assert.deepEqual(controller.getOrchestratorAgentNames(), [
+      'engineer',
+      'leanOrchestrator',
       'orchestrator',
       'teamLead',
     ]);
   });
 
   it('selects preset roots without matching arbitrary orchestrator substrings', () => {
-    const { controller } = createController({
-      builtInOrchestratorAgentNames: ['engineer'],
-    });
+    const { controller } = createController();
 
     assert.equal(
       controller.getPresetToolUseRoot([

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.ts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.ts
@@ -133,10 +133,7 @@ describe('desktop IPC adapters', () => {
       '@desktop/main/desktopViewStateIpc',
     );
     const postToRenderer = vi.fn();
-    const stateIpc = createDesktopViewStateIpc(
-      { postToRenderer },
-      { debugMode: true },
-    );
+    const stateIpc = createDesktopViewStateIpc({ postToRenderer });
 
     // WEBVIEW_READY is a broadcast every webview posts on mount; only the
     // main webview's readiness should sync theme/debug-mode here.
@@ -160,7 +157,7 @@ describe('desktop IPC adapters', () => {
     });
     expect(postToRenderer).toHaveBeenCalledWith({
       command: COMMON_COMMANDS.DEBUG_MODE_SET,
-      debugMode: true,
+      debugMode: false,
     });
 
     nativeTheme.shouldUseHighContrastColors = true;

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts
@@ -51,8 +51,6 @@ interface MainViewIpcModule {
       };
     },
     options: {
-      debugMode?: boolean;
-      getTheme?: () => 'dark' | 'light' | 'high-contrast';
       fileSelection: { handleMessage(message: { command: string }): boolean };
       prompt: {
         handleMessage(message: { command: string }): boolean;
@@ -310,7 +308,7 @@ describe('desktop main-view IPC', () => {
     const harness = await createMainViewHarness({
       shouldUseDarkColors: true,
     });
-    installMainView(harness, { debugMode: true });
+    installMainView(harness);
     const { sends, sendFromRenderer } = harness;
 
     sendFromRenderer({ command: MAIN_VIEW_COMMANDS.GET_THEME }, {});
@@ -341,7 +339,7 @@ describe('desktop main-view IPC', () => {
       },
       {
         channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
-        message: { command: COMMON_COMMANDS.DEBUG_MODE_SET, debugMode: true },
+        message: { command: COMMON_COMMANDS.DEBUG_MODE_SET, debugMode: false },
       },
     ]);
   });
@@ -430,9 +428,9 @@ describe('desktop main-view IPC', () => {
     ]);
   });
 
-  it('answers GET_DEBUG_MODE with the configured flag', async () => {
+  it('answers GET_DEBUG_MODE with debug mode disabled', async () => {
     const harness = await createMainViewHarness();
-    installMainView(harness, { debugMode: true });
+    installMainView(harness);
     const { sends, sendFromRenderer } = harness;
 
     sendFromRenderer({
@@ -445,7 +443,7 @@ describe('desktop main-view IPC', () => {
     expect(sends).toEqual([
       {
         channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
-        message: { command: COMMON_COMMANDS.DEBUG_MODE_SET, debugMode: true },
+        message: { command: COMMON_COMMANDS.DEBUG_MODE_SET, debugMode: false },
       },
     ]);
   });

--- a/src/test-kernel/model/ProviderCapabilities.vitest.ts
+++ b/src/test-kernel/model/ProviderCapabilities.vitest.ts
@@ -76,7 +76,6 @@ describe('provider capabilities', () => {
     });
 
     expect(capabilities).toMatchObject({
-      authMode: 'chatgpt-subscription',
       contextWindow:
         CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT + gpt55Config.maxOutputTokens,
       inputTokenLimit: CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,

--- a/src/test-kernel/shared/LegacyWorkflowOutput.vitest.ts
+++ b/src/test-kernel/shared/LegacyWorkflowOutput.vitest.ts
@@ -17,7 +17,6 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import {
   legacyWorkflowOutputRoundRegex,
   midEraWorkflowOutputStem,
-  normalizeLegacyModel,
   workflowOutputCopyStem,
 } from '@shared/constants/workflowOutput';
 import { installPlatform } from '@test/support/setupPlatform';
@@ -43,10 +42,6 @@ describe('filename-era workflow output grammar', () => {
     await rm(workspacePath, { recursive: true, force: true });
   });
 
-  it('preserves the dotted-model normalization used by flat filenames', () => {
-    expect(normalizeLegacyModel('gpt-4.5.preview')).toBe('gpt-45preview');
-  });
-
   it.each([
     ['builtInWorkflow:write-polish', 'polish'],
     ['custom:alpha_beta', 'alpha'],
@@ -67,11 +62,11 @@ describe('filename-era workflow output grammar', () => {
     const stem = workflowOutputCopyStem({
       base: 'paper[1]',
       agent: 'builtInWorkflow:write-polish',
-      model: 'gpt-4.5',
+      model: 'gpt-4',
       round: 12,
     });
 
-    expect(`${stem}.tex`).toBe('paper[1]_polish_r12_gpt-45.tex');
+    expect(`${stem}.tex`).toBe('paper[1]_polish_r12_gpt-4.tex');
   });
 
   it('preserves the mid-era workspace filename', () => {
@@ -88,33 +83,33 @@ describe('filename-era workflow output grammar', () => {
     const pattern = legacyWorkflowOutputRoundRegex(
       'paper[1]',
       'builtInWorkflow:write-polish',
-      'gpt-4.5',
+      'gpt-4',
     );
 
-    expect(pattern.exec('prefix-paper[1]_polish_r12_gpt-45-suffix')?.[1]).toBe(
+    expect(pattern.exec('prefix-paper[1]_polish_r12_gpt-4-suffix')?.[1]).toBe(
       '12',
     );
-    expect(pattern.test('paper1_polish_r12_gpt-45')).toBe(false);
+    expect(pattern.test('paper1_polish_r12_gpt-4')).toBe(false);
   });
 
   it('matches flat and mid-era housekeeping files without matching siblings', async () => {
     await mkdir(path.join(workspacePath, 'r1'));
     const matching = [
-      'paper_polish_r0_gpt-45.tex',
-      'paper_polish_r0_gpt-45_diff.tex',
-      'paper_polish_r0_full_gpt-45.tex',
-      'r1/paper_polish_long_gpt-4.5.tex',
+      'paper_polish_r0_gpt-4.tex',
+      'paper_polish_r0_gpt-4_diff.tex',
+      'paper_polish_r0_full_gpt-4.tex',
+      'r1/paper_polish_long_gpt-4.tex',
     ];
     const nonMatching = [
-      'paper2_polish_r0_gpt-45.tex',
-      'r1/paper2_polish_long_gpt-4.5.tex',
+      'paper2_polish_r0_gpt-4.tex',
+      'r1/paper2_polish_long_gpt-4.tex',
     ];
     for (const relativePath of [...matching, ...nonMatching]) {
       await writeFile(path.join(workspacePath, relativePath), 'fixture');
     }
 
     const targets = resolveHousekeepingTargets(
-      'gpt-4.5',
+      'gpt-4',
       'paper.tex',
       'custom:polish_long',
     );
@@ -137,16 +132,14 @@ describe('filename-era workflow output grammar', () => {
     }
   });
 
-  it('packs a flat XML round output written for a dotted model', async () => {
-    // The on-disk name normalizes the model's dots, so a packer that spells
-    // the raw model silently leaves the file behind.
-    const xmlRelativePath = 'paper_polish_r0_gpt-45.xml';
+  it('packs a flat XML round output', async () => {
+    const xmlRelativePath = 'paper_polish_r0_gpt-4.xml';
     await writeFile(path.join(workspacePath, 'paper.tex'), 'source');
     await writeFile(path.join(workspacePath, 'paper2.tex'), 'source');
     await writeFile(path.join(workspacePath, xmlRelativePath), '<xml/>');
 
     const result = await runPackMultiple(
-      'gpt-4.5',
+      'gpt-4',
       'paper.tex',
       'custom:polish_long',
       ['paper2.tex'],
@@ -165,13 +158,13 @@ describe('filename-era workflow output grammar', () => {
 
   it('deletes a file matched by overlapping legacy patterns only once', async () => {
     const inputPath = path.join(workspacePath, 'paper.tex');
-    const relativePath = 'paper_polish_r0_full_gpt-45.tex';
+    const relativePath = 'paper_polish_r0_full_gpt-4.tex';
     const absolutePath = path.join(workspacePath, relativePath);
     await writeFile(inputPath, 'source');
     await writeFile(absolutePath, 'fixture');
 
     await expect(
-      runCleanSingle('gpt-4.5', 'paper.tex', 'custom:polish_long'),
+      runCleanSingle('gpt-4', 'paper.tex', 'custom:polish_long'),
     ).resolves.toEqual({ status: 'success' });
     await expect(access(absolutePath)).rejects.toMatchObject({
       code: 'ENOENT',

--- a/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
@@ -22,12 +22,13 @@ vi.mock('@agent/runtime/ModelFactory', async (importActual) => ({
 }));
 
 // Local imports - agent runtime
-import { clearInlineAgents, registerInlineAgents } from '@agent/index';
+import { registerInlineAgents } from '@agent/index';
 import {
   clearStoreCache,
   getExecutionStore,
   registerExecution,
 } from '@agent/storage';
+import { clearInlineAgents } from '@agent/index/agentRegistry';
 import {
   captureOwnedExecutionLease,
   releaseOwnedExecutionLease,

--- a/src/test-kernel/webview/MainViewMessageHandler.vitest.ts
+++ b/src/test-kernel/webview/MainViewMessageHandler.vitest.ts
@@ -59,9 +59,6 @@ vi.mock('@frontend/agents/AgentDirectoryManager', () => ({
 }));
 
 vi.mock('@frontend/agents/optionsLoader', () => ({ loadOptions: vi.fn() }));
-vi.mock('@frontend/auth/codexSubscriptionSignIn', () => ({
-  signInWithChatGptSubscription: vi.fn(),
-}));
 vi.mock('@frontend/media/RecordingManager', () => ({
   RecordingManager: class RecordingManager {},
 }));


### PR DESCRIPTION
## Summary

Six-issue dead-surface sweep from the 2026-08-19 simplification survey. Every claim re-verified against the tree before deleting; every deletion followed by a survivor grep. 41 files, +91/−199. No new tests — only minimal migration/deletion of test code pinning now-impossible shapes.

### #11013 — five dead injection seams (item 5 of the issue intentionally out of scope — medium-risk test-isolation change, separately actionable)
1. `builtInOrchestratorAgentNames` option/dep: computed `X ∪ X`; 0 production passers. Deleted option, dep, fallback import, and the self-union.
2. `TerminalRunRequest.cwd`/`.env`: sole producer passes neither → `hasLaunchOverrides` permanently false. Deleted fields, flag, and the unreachable fresh-terminal branch.
3. Desktop `debugMode`/`getTheme`: composition root passes neither. Deleted the options interfaces, fallbacks, and pass-throughs (`postTheme` calls `getNativeTheme` directly, `postDebugMode` sends `false` — both were the permanent values).
4. `ResumeQueuedToolUseOptions` residual `'tools'`: 0 of 3 production callers set it. Removed from the `Pick` and the forward.
6. `SignedInProbeSlot.setProbe(null)` restore arm: 0 null-passers anywhere. `setProbe` is non-nullable now; re-export docs fixed.

### #11011 — `ProviderCapabilityProfile.authMode`
A discriminant that never discriminated: both producers are single-valued, every read compared against the only emittable value. Field + module-private `ProviderAuthMode` alias deleted; the 4 reads are now `!= null`/`== null` on the resolver result (verified exact: the Codex handler's override can only return a Codex profile or null).

### #11010 — `normalizeLegacyModel`
Identity function for all 147 llm-zoo registry ids (0 dotted keys, re-verified); no user-entered model-id path exists. Deleted the function and every `legacyModel !== model` dual-variant arm in housekeeping pattern generation (the `mergeModels` loop and its 8-line rationale included). The enclosing filename grammar's own dated horizon (2027-04-21, `midEraWorkflowOutputStem`) is untouched per the issue's scope boundary.

### #11009 — 13 host-less barrel re-exports
Deleted from `@agent/runtime` (2), `@agent/storage` (5), `@agent/index` (6) — each verified to have zero importers outside `src/agent/**`. Underlying symbols stay. 13 internal/test modules that imported through the barrels switched to deep imports. One more line (`BUILTIN_TEAM_ROOT_AGENT_NAMES`) deleted at the knip ratchet's direction (orphaned by #11013 item 1). `@agent/trace` untouched per the issue.

### #11012 — 5 dead webview `localResourceRoots`
`src/shared/styles`, `src/common/modules`, `src/common/constants`, `src/common/webview`, `dist/shared` — nonexistent or never shipped (VSIX invariants pinned; fetched URIs re-verified). `src/<viewFolder>` held back per the issue. A CSP/permission tightening as well as a cleanup.

### #10986 — stale `codexSubscriptionSignIn` mock
`vi.mock` of the module deleted in #10975 removed; stale sibling comment fixed. No other survivors (`subscriptionSignIn` siblings are live desktop surfaces).

## Issue acceptance gates

- Each deleted name greps to zero survivors repo-wide (outside `packages/agent/dist` build output). ✅
- #11013 item 5 (`toolInjections`) deliberately not done — the issue itself marks it medium-risk/droppable; it remains open for its own change. ✅ (all other items complete)

## Single source of truth

- Team-root agent names: `BUILTIN_TEAM_ROOT_AGENT_NAMES` alone (no injectable overlay).
- Terminal launch identity: `{ name, command, timeoutMs }` alone.
- Subscription-capability presence: resolver result nullness alone.
- Housekeeping filename patterns: raw registry ids alone.

## Duplication and abstraction budget

Removed: 5 injection seams (~12 interface members), 1 pseudo-discriminant + private alias, 1 identity normalization + dual-variant arms, 14 barrel re-export lines, 5 permission grants, 1 dead `vi.mock`. Added: 0 exports, 0 files, 0 layers.

## Net elements (R6)

- 41 files, +91/−199 (net −108).
- Deleted symbols: 1 exported function (`normalizeLegacyModel`), 1 type alias (`ProviderAuthMode`), 14 barrel re-export lines, ~15 interface members across the six issues.
- Added: 0 new exports.

## Consumer counts (R8)

- `builtInOrchestratorAgentNames`: 0 production / 2 test passers.
- `TerminalRunRequest.cwd/.env`: 0/0.
- desktop `debugMode`: 0/2 test files; `getTheme`: 0/0.
- residual `tools`: 0 of 3 production callers / 1 test pin.
- `setProbe(null)`: 0/0 null-passers.
- `authMode`: 4 production reads / 2 production writes / 2 test writes.
- `normalizeLegacyModel`: 2 production files / 1 test file.
- 13 barrel re-exports: 0 host importers each; 13 internal consumers rerouted to deep imports.
- 5 resource roots: 2 production call sites of the getter (list shrinks; no consumer reads the removed entries).

## Host impact

Extension: dead branch removed in `setupTerminalRunner.ts`; resource-root grant tightened; agentHandlers untouched.
Desktop: IPC option surface shrinks (theme/debugMode now direct); desktopAgentSettingsController untouched.
CLI: none.

## Scheduled refactoring

#11013 item 5 (`toolInjections` two-hop port) remains as its own follow-up inside #11013.

## Validation

- `npm run typecheck:workspace`, `typecheck:test-kernel`, `@texra-ai/cli typecheck`, `@texra/desktop typecheck` — pass.
- Targeted vitest: 17 touched files (224 tests) + 22 seam-covering suites (396 tests) + 17 architecture-ratchet suites (102 tests) — all pass.
- ESLint clean on all 41 files; Prettier clean.
- `check:dead-code-ratchet` (knip): OK, no baseline sync needed.

Closes #11011. Closes #11010. Closes #11009. Closes #11012. Closes #10986. Refs #11013 (item 5 intentionally left).