### PR TITLE
fix(settings): distinguish profile key refresh failures

### DIFF
--- a/src/controllers/settingsView/SettingsProfileKeyController.ts
+++ b/src/controllers/settingsView/SettingsProfileKeyController.ts
@@ -111,9 +111,9 @@ export class SettingsProfileKeyController {
     try {
       await this.deps.refreshAfterKeyChange(provider);
     } catch (error) {
-      const action = verb === 'set' ? 'setting' : 'removing';
+      const gerund = verb === 'set' ? 'setting' : 'removing';
       await this.deps.reportFailure(
-        `Failed to refresh after ${action} ${this.deps.getProviderDisplayName(provider)} API key`,
+        `Failed to refresh after ${gerund} ${this.deps.getProviderDisplayName(provider)} API key`,
         error,
       );
     }

--- a/src/controllers/settingsView/SettingsProfileKeyController.ts
+++ b/src/controllers/settingsView/SettingsProfileKeyController.ts
@@ -38,8 +38,8 @@ export class SettingsProfileKeyController {
         password: true,
         placeHolder: '************************************',
       });
-      if (apiKey == null) return;
-      await this.storeProviderKey(provider, apiKey);
+      if (apiKey == null) return false;
+      return this.storeProviderKey(provider, apiKey);
     });
   }
 
@@ -56,11 +56,11 @@ export class SettingsProfileKeyController {
         `Remove the ${displayName} API key? This cannot be undone.`,
         { confirmLabel: 'Remove', cancelLabel: 'Cancel', modal: false },
       );
-      if (!confirmed) return;
+      if (!confirmed) return false;
 
       await platform().secrets.delete(secretNameFor(provider));
       void this.deps.prompt.info(`${displayName} API key has been removed`);
-      await this.deps.refreshAfterKeyChange(provider);
+      return true;
     });
   }
 
@@ -74,9 +74,9 @@ export class SettingsProfileKeyController {
   private async storeProviderKey(
     provider: string,
     apiKey: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const normalizedApiKey = apiKey.trim();
-    if (!normalizedApiKey) return;
+    if (!normalizedApiKey) return false;
 
     const displayName = this.deps.getProviderDisplayName(provider);
     if (looksLikeCredentialPlaceholder(normalizedApiKey)) {
@@ -87,19 +87,33 @@ export class SettingsProfileKeyController {
 
     await platform().secrets.set(secretNameFor(provider), normalizedApiKey);
     void this.deps.prompt.info(`${displayName} API key has been set`);
-    await this.deps.refreshAfterKeyChange(provider);
+    return true;
   }
 
   private async run(
     provider: string,
     verb: 'set' | 'remove',
-    action: () => Promise<void>,
+    action: () => Promise<boolean>,
   ): Promise<void> {
+    let changed: boolean;
     try {
-      await action();
+      changed = await action();
     } catch (error) {
       await this.deps.reportFailure(
         `Failed to ${verb} ${this.deps.getProviderDisplayName(provider)} API key`,
+        error,
+      );
+      return;
+    }
+
+    if (!changed) return;
+
+    try {
+      await this.deps.refreshAfterKeyChange(provider);
+    } catch (error) {
+      const action = verb === 'set' ? 'setting' : 'removing';
+      await this.deps.reportFailure(
+        `Failed to refresh after ${action} ${this.deps.getProviderDisplayName(provider)} API key`,
         error,
       );
     }

--- a/src/test-kernel/controllers/SettingsProfileKeyController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsProfileKeyController.vitest.ts
@@ -14,6 +14,7 @@ async function createController(options?: {
   urls?: Record<string, string | undefined>;
   setError?: Error;
   deleteError?: Error;
+  refreshError?: Error;
 }): Promise<{
   controller: SettingsProfileKeyController;
   hosts: ReturnType<typeof createFakeUIHosts>;
@@ -53,6 +54,7 @@ async function createController(options?: {
       getProviderKeyUrl: (provider) => options?.urls?.[provider],
       refreshAfterKeyChange: async () => {
         refreshCount += 1;
+        if (options?.refreshError) throw options.refreshError;
       },
       reportFailure: async (message, error) => {
         failures.push(`${message}: ${String(error)}`);
@@ -219,5 +221,33 @@ describe('SettingsProfileKeyController', () => {
     assert.match(failures[0] ?? '', /Failed to remove OpenAI API key/);
     assert.deepEqual(deleted, []);
     assert.equal(refreshCount(), 0);
+  });
+
+  it('reports a refresh failure after storing the provider key', async () => {
+    const error = new Error('refresh failed');
+    const { controller, secrets, failures } = await createController({
+      refreshError: error,
+    });
+
+    await controller.commitProviderKey('openai', 'sk-real-openai-key');
+
+    assert.equal(await secrets.get('apiKey.openai'), 'sk-real-openai-key');
+    assert.deepEqual(failures, [
+      'Failed to refresh after setting OpenAI API key: Error: refresh failed',
+    ]);
+  });
+
+  it('reports a refresh failure after removing the provider key', async () => {
+    const error = new Error('refresh failed');
+    const { controller, deleted, failures } = await createController({
+      refreshError: error,
+    });
+
+    await controller.removeProviderKey('openai');
+
+    assert.deepEqual(deleted, ['apiKey.openai']);
+    assert.deepEqual(failures, [
+      'Failed to refresh after removing OpenAI API key: Error: refresh failed',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- separate credential mutation from the post-write refresh phase
- retain existing set/remove failure reporting for mutation errors
- report refresh-tail failures as refresh failures after the successful key action
- keep cancellation and empty-key paths as no-ops

## Validation

- 26 focused controller and desktop integration tests
- workspace and test-kernel typechecks
- targeted ESLint
- `git diff --check`
- independent code review found no blocking or should-fix findings

Closes #10969
