### PR TITLE
fix(cli): preserve external artifact paths

### DIFF
--- a/packages/cli/src/chat/tui/panes/WorkflowRunDetails.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkflowRunDetails.tsx
@@ -24,6 +24,7 @@ import {
 import {
   STREAM_PHASE,
   WORKFLOW_TASK_STATUS_LABEL,
+  fileLocationDisplayPath,
   outputDiffCounts,
   outputDisplayName,
   roundIndexedEntries,
@@ -188,7 +189,11 @@ function workflowRunDetailGroups(
           key: `output:${round}:${file.location.absolutePath}:${index}`,
           // Neutral bullet, not `›` — POINTER means "focused row / your
           // input" everywhere else, and these are static file rows.
-          text: `    • ${safeTerminalText(outputDisplayName(file))}${diff}`,
+          text: `    • ${safeTerminalText(
+            file.location.kind === 'external'
+              ? fileLocationDisplayPath(file.location)
+              : outputDisplayName(file),
+          )}${diff}`,
           tone: 'neutral',
           role: 'output',
         });

--- a/src/test-kernel/cli/WorkflowRunDetails.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunDetails.vitest.ts
@@ -161,6 +161,35 @@ describe('selectWorkflowRunDetailLines', () => {
     ]);
   });
 
+  it('shows the full path for external generated files', () => {
+    const lines = selectWorkflowRunDetailLines(
+      {
+        taskGroups: [completedRound(0, 1, 0, 1)],
+        outputFilesByRound: {
+          0: [
+            {
+              source: 'paper.tex',
+              round: 0,
+              location: {
+                kind: 'external',
+                absolutePath: '/tmp/external-output/paper.tex',
+              },
+              lineage: null,
+              diff: null,
+            },
+          ],
+        },
+        missingOutputsByRound: {},
+        compileFailuresByRound: {},
+      },
+      100,
+    );
+
+    expect(lines.map((line) => line.text)).toContain(
+      '    • /tmp/external-output/paper.tex',
+    );
+  });
+
   it('renders a typed round and sanitizes terminal controls', () => {
     const lines = selectWorkflowRunDetailLines(
       {


### PR DESCRIPTION
## Summary

- show the full location path for external artifacts in CLI run details
- keep shared short display names for workspace and run-storage artifacts
- preserve diff-count rendering and terminal sanitization

## Validation

- WorkflowRunDetails suite: 9 passed
- workspace, CLI, and test-kernel typechecks
- targeted ESLint
- `git diff --check`

Closes #10934
