### PR TITLE
refactor(agent): collapse the retrying Node class into ModelInvocationNode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -495,11 +495,11 @@ Agent flows follow the PocketFlow pattern in `src/agent/implementations/flows/`:
   - `FlowTransition.CONTINUE` - loop back to flow entry
   - `FlowTransition.FINALIZE` - exit flow after finalization
   - `FlowTransition.COMPLETE` - return control to caller
-- **Node lifecycle**: `prep(shared) → exec(prepRes) → post(shared, prepRes, execRes)`. Retries are configured through the `Node` constructor — `super(maxRetries, wait)` (see `ModelInvocationNode.ts`), not by overriding getters. Customize retry behaviour with the `shouldAutoRetry(error)`, `retryPrompt(prepRes, error)`, and `execFallback(prepRes, error)` hooks, and set `node.signal` to abort in-flight retries.
+- **Node lifecycle**: `prep(shared) → exec(prepRes) → post(shared, prepRes, execRes)`. A failing `exec()` goes to `execFallback(prepRes, error)`, which by default rethrows; override it to convert the failure into something `post()` can route on. Retries are **not** a `BaseNode` feature: the manual-retry loop and its `shouldAutoRetry(error)` / `retryPrompt(prepRes, error)` / `signal` hooks live on `ModelInvocationNode` (`src/agent/core/flows/ModelInvocationNode.ts`), the only node that invokes a model. Do not re-add retry machinery to the kernel for a node that does not call a provider.
 - **Agent owns lifecycle**: Agents handle init/finalize; flows handle only execution logic. Nodes should throw errors directly (agent.run() catches).
 
-The engine is local to this repo: `src/agent/node/index.ts` defines `BaseNode`,
-`Node`, and `Flow` — read it for the authoritative semantics. It is a trimmed
+The engine is local to this repo: `src/agent/node/index.ts` defines `BaseNode`
+and `Flow` — read it for the authoritative semantics. It is a trimmed
 descendant of upstream PocketFlow and does **not** implement the upstream
 `BatchNode`/`BatchFlow`, `ParallelBatchNode`/`ParallelBatchFlow`, or the
 `params`/`setParams` channel; do not write code against them. State slices that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,10 +159,13 @@ services/shared-store split: AGENTS.md "Patterns across the codebase"
 (PocketFlow architecture) and `docs/architecture/pocketflow-state.md`.
 
 **The flow engine is local, not upstream PocketFlow.** `src/agent/node/index.ts`
-(~250 lines, built on `p-retry`) is the only definition of `BaseNode`, `Node`,
-and `Flow`. Upstream's `BatchNode`/`BatchFlow`,
-`ParallelBatchNode`/`ParallelBatchFlow`, and the `params`/`setParams` channel do
-not exist here — read the file rather than upstream docs.
+(~150 lines) is the only definition of `BaseNode` and `Flow`. Upstream's
+`BatchNode`/`BatchFlow`, `ParallelBatchNode`/`ParallelBatchFlow`, and the
+`params`/`setParams` channel do not exist here — read the file rather than
+upstream docs. There is no retrying `Node` class: the manual-retry loop
+(automatic `p-retry` batch → `retryPrompt` → one approved attempt at a time →
+`execFallback`) lives on `ModelInvocationNode`, its only implementor. A node
+that just needs a failure hook overrides `BaseNode.execFallback`.
 
 ## Design guardrails
 

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -2,10 +2,15 @@
  * The model invocation node and everything its retry lifecycle owns: node-level
  * retry configuration, the shared-route recovery gate, the manual retry
  * prompt, and the cancelled/failed fallbacks — one deep module behind the
- * plain `Node` interface the cycle flows compose.
+ * plain `BaseNode` interface the cycle flows compose. It is the flow kernel's
+ * only retrying node: the manual-retry loop below (automatic p-retry batch →
+ * `retryPrompt` → one approved attempt at a time → `execFallback`) lives here
+ * because `ModelInvocationNode` is its only implementor.
  */
 
-import { Node } from '@agent/node';
+import pRetry, { AbortError } from 'p-retry';
+
+import { BaseNode } from '@agent/node';
 import { logErrorData, logProgressStatus, type AgentTrace } from '@agent/trace';
 import type { AgentCore } from '@agent/core/flows/BaseFlowServices';
 import {
@@ -59,7 +64,12 @@ const EMPTY_RESPONSE_ERROR_MESSAGE =
  */
 const RETRY_BACKOFF_MS = 1000;
 
-/** One initial attempt plus the configured number of automatic retries. */
+/**
+ * One initial attempt plus the configured number of automatic retries.
+ * `ModelRetryMaxAttemptsSchema` bounds the setting to [0, 5] and falls back to
+ * the default on anything else, so the result is always >= 1 — the retry loop
+ * needs no lower-bound guard on it.
+ */
 function getNodeMaxRetries(): number {
   return (
     1 +
@@ -160,13 +170,27 @@ type InvocationServices = Pick<
 export class ModelInvocationNode<
   TShared extends BaseCycleFields,
   TServices extends InvocationServices = InvocationServices,
-> extends Node<TShared, TServices> {
+> extends BaseNode<TShared, TServices> {
   private readonly _config: ModelInvocationConfig<TShared, TServices>;
   protected _userCancelled = false;
   private _retryLifecycle: RetryLifecycleState | undefined;
 
+  /** One initial attempt plus automatic retries. Re-read on every `_exec`. */
+  maxRetries: number;
+  /** Seconds between automatic retries. Re-read on every `_exec`. */
+  wait: number;
+  /**
+   * The run's abort signal. When it fires, the retry loop skips the remaining
+   * retries and goes straight to `execFallback()`, so a cancelled run makes no
+   * further provider calls. `_exec` reassigns it from the run scope on every
+   * execution, so it needs no reset on clone.
+   */
+  signal?: AbortSignal;
+
   constructor(config: ModelInvocationConfig<TShared, TServices>) {
-    super(getNodeMaxRetries(), RETRY_BACKOFF_MS / 1000);
+    super();
+    this.maxRetries = getNodeMaxRetries();
+    this.wait = RETRY_BACKOFF_MS / 1000;
     this._config = config;
   }
 
@@ -370,9 +394,96 @@ export class ModelInvocationNode<
     // handling; an interrupt is read back off the same signal in
     // `getFallbackResult`, so there is nothing to register or clear here.
     this.signal = this.services.runScope.signal;
-    return super._exec(prepRes);
+    return this.execWithRetries(prepRes);
   }
 
+  /**
+   * Run `exec()` through the automatic retry batch, then one manually approved
+   * attempt at a time, and hand the last failure to `execFallback()`.
+   */
+  protected async execWithRetries(prepRes: unknown): Promise<unknown> {
+    // `_run` hands `prep()`'s result through the kernel untyped; this node's
+    // `exec`/`execFallback` narrow it, so widen it back once here.
+    const prep = prepRes as BaseInvocationPrepResult;
+    // Track the last exec error so we can forward it to execFallback when
+    // the abort signal fires during the inter-retry delay (p-retry would
+    // otherwise rethrow signal.reason, discarding the original failure).
+    let lastExecError: Error | undefined;
+    let attemptThrew = false;
+    const runAttempts = async (retries: number): Promise<unknown> => {
+      attemptThrew = false;
+      return await pRetry(
+        async () => {
+          // Throw AbortError at each attempt start so p-retry surfaces it
+          // immediately (before any delay) and skips onFailedAttempt.
+          if (this.signal?.aborted)
+            throw new AbortError('Operation cancelled by user');
+          try {
+            return await this.exec(prep);
+          } catch (error) {
+            attemptThrew = true;
+            throw error;
+          }
+        },
+        {
+          retries,
+          minTimeout: this.wait * 1000,
+          factor: 1, // linear (fixed) delay to preserve existing behaviour
+          randomize: false, // explicit: default is false; no jitter on fixed delays
+          signal: this.signal, // aborts an attempt or inter-retry delay early
+          shouldRetry: ({ error }) => {
+            lastExecError = error;
+            if (this.signal?.aborted) return false;
+            return this.shouldAutoRetry(error);
+          },
+        },
+      );
+    };
+
+    let retryError: Error;
+    try {
+      return await runAttempts(this.maxRetries - 1);
+    } catch (e) {
+      // User cancellation surfaces here as p-retry's aborted-delay rejection
+      // (signal.reason) or as the unwrapped error from our pre-attempt check
+      // (p-retry rethrows an AbortError's originalError, not the AbortError).
+      // Forward the recorded exec failure when one exists.
+      if (this.signal?.aborted) {
+        return await this.execFallback(prep, lastExecError ?? (e as Error));
+      }
+      retryError = e as Error;
+    }
+
+    for (;;) {
+      const shouldRetry = await this.retryPrompt(prep, retryError);
+      if (!shouldRetry || this.signal?.aborted) {
+        return await this.execFallback(prep, retryError);
+      }
+
+      try {
+        return await runAttempts(0);
+      } catch (e) {
+        const approvedError = e as Error;
+        if (this.signal?.aborted) {
+          return await this.execFallback(
+            prep,
+            attemptThrew ? approvedError : retryError,
+          );
+        }
+        retryError = approvedError;
+      }
+    }
+  }
+
+  /**
+   * Called when the automatic retry batch is exhausted or declined. Returns
+   * true to grant one more attempt, false to proceed to `execFallback`. A
+   * failed approved attempt calls this again.
+   *
+   * NOTE: keep this a regular method, not an arrow-function property.
+   * `BaseNode.clone()` uses Object.assign, which copies instance properties;
+   * an arrow function would capture the original instance's `this`.
+   */
   async retryPrompt(_prepRes: unknown, error: Error): Promise<boolean> {
     if (isUserAbort(error)) return false;
     // A missing credential cannot be fixed by retrying; fail immediately.

--- a/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
@@ -1,4 +1,4 @@
-import { Node } from '@agent/node';
+import { BaseNode } from '@agent/node';
 import { logUserMessage } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
@@ -15,7 +15,7 @@ interface PrepInput {
   currentRound: number;
 }
 
-export class MediaExtractionNode<C = unknown> extends Node<
+export class MediaExtractionNode<C = unknown> extends BaseNode<
   ReflectionFlowShared,
   ReflectionServices<C>
 > {

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -1,4 +1,4 @@
-import { Node } from '@agent/node';
+import { BaseNode } from '@agent/node';
 import { emitRunFact } from '@agent/runtime/runFactEvents';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import {
@@ -50,7 +50,7 @@ interface OutputExecResult {
   emitCompileFailures: boolean;
 }
 
-export class OutputNode<C = unknown> extends Node<
+export class OutputNode<C = unknown> extends BaseNode<
   ReflectionFlowShared,
   ReflectionServices<C>
 > {

--- a/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
@@ -1,4 +1,4 @@
-import { Node } from '@agent/node';
+import { BaseNode } from '@agent/node';
 import { ConversationRoundStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
@@ -16,7 +16,7 @@ interface PrepInput {
   compileFailureContext?: string;
 }
 
-export class PrepareContextNode<C = unknown> extends Node<
+export class PrepareContextNode<C = unknown> extends BaseNode<
   ReflectionFlowShared,
   ReflectionServices<C>
 > {

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -1,4 +1,4 @@
-import { Node } from '@agent/node';
+import { BaseNode } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { recordRound } from '@agent/core/state/AgentState';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
@@ -35,7 +35,7 @@ type CycleOutcome =
   | { outcome: 'cancelled' }
   | { outcome: 'failed'; lastError: RetryErrorInfo };
 
-export class ResponseCycleNode<C = unknown> extends Node<
+export class ResponseCycleNode<C = unknown> extends BaseNode<
   ReflectionFlowShared,
   ReflectionServices<C>
 > {

--- a/src/agent/implementations/flows/reflection/nodes/TeXCountNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/TeXCountNode.ts
@@ -1,4 +1,4 @@
-import { Node } from '@agent/node';
+import { BaseNode } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { getTeXCountStats } from '@latex/texcount';
 import type { FileLocation } from '@shared/schemas';
@@ -7,7 +7,7 @@ import { getFilesForRound } from '../helpers';
 import type { ReflectionFlowShared } from '../ReflectionFlowState';
 import type { ReflectionServices } from '../ReflectionServices';
 
-export class TeXCountNode<C = unknown> extends Node<
+export class TeXCountNode<C = unknown> extends BaseNode<
   ReflectionFlowShared,
   ReflectionServices<C>
 > {

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -1,4 +1,4 @@
-import { Node } from '@agent/node';
+import { BaseNode } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { emitRunFact } from '@agent/runtime/runFactEvents';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
@@ -28,7 +28,7 @@ type ToolUseCycleOutcome =
   | { outcome: 'cancelled'; response?: string }
   | { outcome: 'failed'; lastError: RetryErrorInfo; response?: string };
 
-export class ToolUseCycleNode<C> extends Node<
+export class ToolUseCycleNode<C> extends BaseNode<
   ToolUseRunShared,
   ToolUseServices<C>
 > {

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -1,4 +1,4 @@
-import { Node } from '@agent/node';
+import { BaseNode } from '@agent/node';
 import { logUserMessage } from '@agent/trace';
 import { buildInitialToolUsePrompts } from '@agent/prompt/PromptBuilder';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
@@ -19,7 +19,7 @@ import type { ToolUseRunShared, CyclePrepResult } from './types';
  * `../toolUseRound/`, which is the inner per-LLM-call prep node that
  * runs at the start of every model invocation inside `ToolUseRoundFlow`.
  */
-export class ToolUsePrepareNode<C> extends Node<
+export class ToolUsePrepareNode<C> extends BaseNode<
   ToolUseRunShared,
   ToolUseServices<C>
 > {

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -1,4 +1,4 @@
-import { Node } from '@agent/node';
+import { BaseNode } from '@agent/node';
 import { maybeBuildGoalContinuation } from '@agent/goal/maybeBuildGoalContinuation';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { emitRunFact } from '@agent/runtime/runFactEvents';
@@ -21,7 +21,7 @@ interface WaitPrepResult {
   afterError: boolean;
 }
 
-export class ToolUseWaitNode<C> extends Node<
+export class ToolUseWaitNode<C> extends BaseNode<
   ToolUseRunShared,
   ToolUseServices<C>
 > {

--- a/src/agent/implementations/flows/tooluse/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/implementations/flows/tooluse/toolUseRound/ToolUseDispatchNode.ts
@@ -146,9 +146,10 @@ export class ToolUseDispatchNode<C> extends BaseNode<
    * duplicates filled from their primary's result afterwards. Results keep
    * the original call order; skipped/interrupted slots stay null.
    *
-   * Bypasses Node._exec's per-item retry machinery on purpose: tool calls
-   * are never auto-retried (default maxRetries, exec never throws), and
-   * cancellation runs through the run's abort signal, not `this.signal`.
+   * Owns its own batching instead of deferring to `BaseNode._exec`: tool
+   * calls are never auto-retried (exec never throws), and cancellation runs
+   * through the run's abort signal. Retry lives on `ModelInvocationNode`,
+   * which this node does not extend.
    */
   async _exec(calls: SdkToolCall[]): Promise<(ToolExecutionResult | null)[]> {
     if (calls.length === 0) return [];

--- a/src/agent/implementations/flows/tooluse/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/implementations/flows/tooluse/toolUseRound/ToolUseDispatchNode.ts
@@ -2,7 +2,7 @@
 import PQueue from 'p-queue';
 
 // Local imports
-import { Node } from '@agent/node';
+import { BaseNode } from '@agent/node';
 import {
   emitToolUseCard,
   endToolUseCard,
@@ -89,7 +89,7 @@ function endsToolUseTurn(result: ToolExecutionResult | null): boolean {
  *
  * Batches follow-up messages for Google/DeepSeek handlers to preserve thought signatures.
  */
-export class ToolUseDispatchNode<C> extends Node<
+export class ToolUseDispatchNode<C> extends BaseNode<
   ToolUseRoundShared,
   ToolUseRoundServices<C>
 > {

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -1,5 +1,3 @@
-import pRetry, { AbortError } from 'p-retry';
-
 import { createLog } from '@logger/logUtils';
 
 /** Flow transition action - typically 'default' or a custom action name */
@@ -44,7 +42,29 @@ class BaseNode<S = unknown, Svc = unknown> {
   }
 
   protected async _exec(prepRes: unknown): Promise<unknown> {
-    return await this.exec(prepRes);
+    try {
+      return await this.exec(prepRes);
+    } catch (error) {
+      // execFallback's contract is `error: Error`. Normalize exactly as
+      // p-retry does, so a node that throws a non-Error still reaches its
+      // fallback with something that has `.message`.
+      return await this.execFallback(
+        prepRes,
+        error instanceof Error
+          ? error
+          : new TypeError(
+              `Non-error was thrown: "${error}". You should only throw errors.`,
+            ),
+      );
+    }
+  }
+  /**
+   * Handle a failed exec(). The default rethrows, so a node that does not
+   * override this fails its flow. Override to convert the failure into a
+   * value the node's post() can route on.
+   */
+  async execFallback(_prepRes: unknown, error: Error): Promise<unknown> {
+    throw error;
   }
   async prep(_shared: S): Promise<unknown> {
     return;
@@ -106,149 +126,6 @@ class BaseNode<S = unknown, Svc = unknown> {
     return clonedNode;
   }
 }
-class Node<S = unknown, Svc = unknown> extends BaseNode<S, Svc> {
-  maxRetries: number;
-  wait: number;
-  /**
-   * Optional abort signal for cancellation support.
-   * When set and aborted, the retry loop will skip remaining retries
-   * and go directly to execFallback(). This prevents unnecessary API
-   * calls when the user has intentionally cancelled the operation.
-   */
-  signal?: AbortSignal;
-  constructor(maxRetries: number = 1, wait: number = 0) {
-    super();
-    if (maxRetries < 1) {
-      throw new RangeError(`Node maxRetries must be >= 1, got ${maxRetries}.`);
-    }
-    this.maxRetries = maxRetries;
-    this.wait = wait;
-  }
-
-  async execFallback(prepRes: unknown, error: Error): Promise<unknown> {
-    throw error;
-  }
-  /**
-   * Hook called when the automatic retry batch is exhausted or declined.
-   * Return true to grant one additional attempt, false to proceed to execFallback.
-   * A failed additional attempt calls this hook again.
-   *
-   * Default implementation returns false (no manual retry).
-   * Override this for manual retry prompts (e.g., showing UI to user).
-   *
-   * NOTE: Override this as a regular method (not an arrow function property)
-   * because Node.clone() uses Object.assign, which copies instance properties.
-   * Arrow functions capture `this` lexically, so they would reference the
-   * original instance after cloning. Regular methods on the prototype work
-   * correctly because they get `this` from the call site.
-   *
-   * @example
-   * ```typescript
-   * class MyNode extends Node<S> {
-   *   async retryPrompt(prepRes: unknown, error: Error): Promise<boolean> {
-   *     const result = await showRetryDialog(error.message);
-   *     return result === 'retry';
-   *   }
-   * }
-   * ```
-   */
-  async retryPrompt(_prepRes: unknown, _error: Error): Promise<boolean> {
-    return false;
-  }
-  /**
-   * Whether this error should be auto-retried (silent retries with backoff).
-   * Return false to skip auto-retries and go straight to retryPrompt().
-   * Useful for errors that need human attention (e.g., auth errors).
-   *
-   * Default: true (all errors are auto-retried).
-   */
-  shouldAutoRetry(_error: Error): boolean {
-    return true;
-  }
-  /**
-   * Override clone to reset execution-specific state.
-   * Prevents stale signal/retry state from affecting new executions.
-   *
-   * NOTE: BaseNode.clone() uses Object.assign for shallow copy. Subclasses
-   * adding object/array properties must override clone() to deep-copy them,
-   * otherwise the original and clone will share the same references.
-   */
-  clone(): this {
-    const cloned = super.clone();
-    cloned.signal = undefined;
-    return cloned;
-  }
-  async _exec(prepRes: unknown): Promise<unknown> {
-    // Track the last exec error so we can forward it to execFallback when
-    // the abort signal fires during the inter-retry delay (p-retry would
-    // otherwise rethrow signal.reason, discarding the original failure).
-    let lastExecError: Error | undefined;
-    let attemptThrew = false;
-    const runAttempts = async (retries: number): Promise<unknown> => {
-      attemptThrew = false;
-      return await pRetry(
-        async () => {
-          // Throw AbortError at each attempt start so p-retry surfaces it
-          // immediately (before any delay) and skips onFailedAttempt.
-          if (this.signal?.aborted)
-            throw new AbortError('Operation cancelled by user');
-          try {
-            return await this.exec(prepRes);
-          } catch (error) {
-            attemptThrew = true;
-            throw error;
-          }
-        },
-        {
-          retries,
-          minTimeout: this.wait * 1000,
-          factor: 1, // linear (fixed) delay to preserve existing behaviour
-          randomize: false, // explicit: default is false; no jitter on fixed delays
-          signal: this.signal, // aborts an attempt or inter-retry delay early
-          shouldRetry: ({ error }) => {
-            lastExecError = error;
-            if (this.signal?.aborted) return false;
-            return this.shouldAutoRetry(error);
-          },
-        },
-      );
-    };
-
-    let retryError: Error;
-    try {
-      return await runAttempts(this.maxRetries - 1);
-    } catch (e) {
-      // User cancellation surfaces here as p-retry's aborted-delay rejection
-      // (signal.reason) or as the unwrapped error from our pre-attempt check
-      // (p-retry rethrows an AbortError's originalError, not the AbortError).
-      // Forward the recorded exec failure when one exists.
-      if (this.signal?.aborted) {
-        return await this.execFallback(prepRes, lastExecError ?? (e as Error));
-      }
-      retryError = e as Error;
-    }
-
-    for (;;) {
-      const shouldRetry = await this.retryPrompt(prepRes, retryError);
-      if (!shouldRetry || this.signal?.aborted) {
-        return await this.execFallback(prepRes, retryError);
-      }
-
-      try {
-        return await runAttempts(0);
-      } catch (e) {
-        const approvedError = e as Error;
-        if (this.signal?.aborted) {
-          return await this.execFallback(
-            prepRes,
-            attemptThrew ? approvedError : retryError,
-          );
-        }
-        retryError = approvedError;
-      }
-    }
-  }
-}
 class Flow<S = unknown, Svc = unknown> extends BaseNode<S, Svc> {
   start: BaseNode;
   constructor(start: BaseNode) {
@@ -273,4 +150,4 @@ class Flow<S = unknown, Svc = unknown> extends BaseNode<S, Svc> {
     throw new Error("Flow can't exec.");
   }
 }
-export { BaseNode, Node, Flow };
+export { BaseNode, Flow };

--- a/src/test-kernel/agent/PocketFlowNode.vitest.ts
+++ b/src/test-kernel/agent/PocketFlowNode.vitest.ts
@@ -1,7 +1,12 @@
 import { AbortError } from 'p-retry';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { BaseNode, Node } from '@agent/node';
+import { BaseNode } from '@agent/node';
+import type { BaseCycleFields } from '@agent/core/flows/CommonCycleTypes';
+import {
+  ModelInvocationNode,
+  type InvocationResult,
+} from '@agent/core/flows/ModelInvocationNode';
 import * as logger from '@logger/logUtils';
 
 class TestNode extends BaseNode<Record<string, never>> {}
@@ -59,7 +64,18 @@ function failureSequence(count: number): Error[] {
   return Array.from({ length: count }, (_, i) => new Error(`failure ${i + 1}`));
 }
 
-class ScriptedRetryNode extends Node {
+/** The scripted node reports every result as an invocation success payload. */
+function scriptedResult(response: string): InvocationResult {
+  return { kind: 'success', response };
+}
+
+/**
+ * `ModelInvocationNode` is the flow kernel's only retrying node, so these
+ * scenarios script it directly. They drive `execWithRetries` rather than
+ * `_exec`, which would overwrite the scripted attempt budget and abort signal
+ * with the ones read from settings and the run scope.
+ */
+class ScriptedRetryNode extends ModelInvocationNode<BaseCycleFields> {
   calls = 0;
   prompts = 0;
   fallbackError?: Error;
@@ -74,18 +90,28 @@ class ScriptedRetryNode extends Node {
     private readonly onPrompt?: () => void,
     private readonly onExec?: (call: number) => void,
   ) {
-    super(maxRetries, 0);
+    super({
+      operationName: 'Scripted request',
+      streaming: false,
+      storeResponse: () => {},
+    });
+    this.maxRetries = maxRetries;
+    this.wait = 0;
   }
 
-  override async exec(): Promise<string> {
+  runRetries(): Promise<unknown> {
+    return this.execWithRetries(undefined);
+  }
+
+  override async exec(): Promise<InvocationResult> {
     this.calls += 1;
     this.events.push(`exec:${this.calls}`);
     this.onExec?.(this.calls);
     const outcome = this.outcomes[this.calls - 1];
     if (outcome instanceof Error) throw outcome;
-    if (typeof outcome === 'function') return await outcome();
+    if (typeof outcome === 'function') return scriptedResult(await outcome());
     if (typeof outcome === 'object') throw outcome.thrown;
-    return outcome;
+    return scriptedResult(outcome);
   }
 
   override shouldAutoRetry(): boolean {
@@ -106,23 +132,20 @@ class ScriptedRetryNode extends Node {
   override async execFallback(
     _prepRes: unknown,
     error: Error,
-  ): Promise<string> {
+  ): Promise<InvocationResult> {
     this.fallbackError = error;
     this.events.push(`fallback:${error.message}`);
-    return 'fallback';
+    return scriptedResult('fallback');
   }
 }
 
-describe('Node manual retry', () => {
-  it('rejects an invalid retry limit at construction', () => {
-    expect(() => new ScriptedRetryNode(0, [], [])).toThrow(RangeError);
-    expect(() => new ScriptedRetryNode(-1, [], [])).toThrow(RangeError);
-  });
-
+describe('ModelInvocationNode manual retry', () => {
   it('grants one attempt after an exhausted automatic retry batch', async () => {
     const node = new ScriptedRetryNode(3, failureSequence(4), [true, false]);
 
-    await expect(node._exec(undefined)).resolves.toBe('fallback');
+    await expect(node.runRetries()).resolves.toEqual(
+      scriptedResult('fallback'),
+    );
     expect(node.calls).toBe(4);
     expect(node.events).toEqual([
       'exec:1',
@@ -143,7 +166,9 @@ describe('Node manual retry', () => {
       false,
     ]);
 
-    await expect(node._exec(undefined)).resolves.toBe('fallback');
+    await expect(node.runRetries()).resolves.toEqual(
+      scriptedResult('fallback'),
+    );
     expect(node.calls).toBe(4);
     expect(node.prompts).toBe(3);
     expect(node.events).toEqual([
@@ -166,7 +191,9 @@ describe('Node manual retry', () => {
       false,
     );
 
-    await expect(node._exec(undefined)).resolves.toBe('completed');
+    await expect(node.runRetries()).resolves.toEqual(
+      scriptedResult('completed'),
+    );
     expect(node.events).toEqual(['exec:1', 'prompt:not automatic', 'exec:2']);
   });
 
@@ -177,7 +204,9 @@ describe('Node manual retry', () => {
       [true],
     );
 
-    await expect(node._exec(undefined)).resolves.toBe('completed');
+    await expect(node.runRetries()).resolves.toEqual(
+      scriptedResult('completed'),
+    );
     expect(node.calls).toBe(4);
     expect(node.prompts).toBe(1);
   });
@@ -193,7 +222,9 @@ describe('Node manual retry', () => {
     );
     node.signal = controller.signal;
 
-    await expect(node._exec(undefined)).resolves.toBe('fallback');
+    await expect(node.runRetries()).resolves.toEqual(
+      scriptedResult('fallback'),
+    );
     expect(node.events).toEqual([
       'exec:1',
       'prompt:original failure',
@@ -216,7 +247,9 @@ describe('Node manual retry', () => {
     );
     node.signal = controller.signal;
 
-    await expect(node._exec(undefined)).resolves.toBe('fallback');
+    await expect(node.runRetries()).resolves.toEqual(
+      scriptedResult('fallback'),
+    );
     expect(node.events).toEqual([
       'exec:1',
       'prompt:original failure',
@@ -240,12 +273,12 @@ describe('Node manual retry', () => {
     );
     node.signal = controller.signal;
 
-    const result = node._exec(undefined);
+    const result = node.runRetries();
     await vi.waitFor(() => expect(node.calls).toBe(2));
     controller.abort();
     resolveApprovedAttempt('late success');
 
-    await expect(result).resolves.toBe('fallback');
+    await expect(result).resolves.toEqual(scriptedResult('fallback'));
     expect(node.events).toEqual([
       'exec:1',
       'prompt:original failure',
@@ -263,7 +296,9 @@ describe('Node manual retry', () => {
       [true, false],
     );
 
-    await expect(node._exec(undefined)).resolves.toBe('fallback');
+    await expect(node.runRetries()).resolves.toEqual(
+      scriptedResult('fallback'),
+    );
     expect(node.promptErrors[1]).toBe(originalError);
     expect(node.fallbackError).toBe(originalError);
   });
@@ -275,7 +310,9 @@ describe('Node manual retry', () => {
       [true, false],
     );
 
-    await expect(node._exec(undefined)).resolves.toBe('fallback');
+    await expect(node.runRetries()).resolves.toEqual(
+      scriptedResult('fallback'),
+    );
     expect(node.promptErrors[1]).toBeInstanceOf(TypeError);
     expect(node.promptErrors[1]?.message).toBe(
       'Non-error was thrown: "raw failure". You should only throw errors.',
@@ -293,7 +330,9 @@ describe('Node manual retry', () => {
       Array.from({ length: 101 }, () => true),
     );
 
-    await expect(node._exec(undefined)).resolves.toBe('completed');
+    await expect(node.runRetries()).resolves.toEqual(
+      scriptedResult('completed'),
+    );
     expect(node.calls).toBe(102);
     expect(node.prompts).toBe(101);
   });

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.ts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.ts
@@ -22,7 +22,8 @@ vi.mock('@cli/runtime/approval/approvalSummaries', async (importOriginal) => {
   };
 });
 
-import { Node } from '@agent/node';
+import type { BaseCycleFields } from '@agent/core/flows/CommonCycleTypes';
+import { ModelInvocationNode } from '@agent/core/flows/ModelInvocationNode';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import type {
   HostInteractions,
@@ -442,7 +443,7 @@ describe('requestRetry classification (#7331)', () => {
   });
 });
 
-class RepresentativeFailingProviderNode extends Node {
+class RepresentativeFailingProviderNode extends ModelInvocationNode<BaseCycleFields> {
   providerCalls = 0;
   readonly providerError = new Error('permanent provider failure');
 
@@ -450,12 +451,31 @@ class RepresentativeFailingProviderNode extends Node {
     private readonly interactions: HostInteractions,
     private readonly streamId: StreamTabId,
   ) {
-    super(3, 0);
+    super({
+      operationName: 'Model invocation',
+      streaming: false,
+      storeResponse: () => {},
+    });
+    this.maxRetries = 3;
+    this.wait = 0;
+  }
+
+  /**
+   * Drive the retry loop directly; `_exec` would replace the scripted attempt
+   * budget with the one read from settings.
+   */
+  runRetries(): Promise<unknown> {
+    return this.execWithRetries(undefined);
   }
 
   override async exec(): Promise<never> {
     this.providerCalls += 1;
     throw this.providerError;
+  }
+
+  /** Rethrow, as the kernel's default does: this scenario asserts the failure. */
+  override async execFallback(_prepRes: unknown, error: Error): Promise<never> {
+    throw error;
   }
 
   override async retryPrompt(): Promise<boolean> {
@@ -485,8 +505,8 @@ describe('bounded yolo retry batches (#9532)', () => {
       'representative-b' as StreamTabId,
     );
 
-    await expect(first._exec(undefined)).rejects.toBe(first.providerError);
-    await expect(second._exec(undefined)).rejects.toBe(second.providerError);
+    await expect(first.runRetries()).rejects.toBe(first.providerError);
+    await expect(second.runRetries()).rejects.toBe(second.providerError);
 
     expect(first.providerCalls).toBe(3);
     expect(second.providerCalls).toBe(3);


### PR DESCRIPTION
## Summary

`src/agent/node/index.ts` defined three classes: `BaseNode` (prep/exec/post +
the successor graph), `Node` (`BaseNode` + a manual-retry loop), and `Flow`.
Ten production classes extended `Node`. **Exactly one of them implements any of
its hooks.**

Every `retryPrompt` / `shouldAutoRetry` / `this.signal =` / `this.maxRetries =`
/ `this.wait =` across `src/` and all four packages resolves to
`ModelInvocationNode` (plus the kernel defaults and two test subclasses). The
other nine — `ToolUseWaitNode`, `MediaExtractionNode`, `PrepareContextNode`,
`ResponseCycleNode`, `TeXCountNode`, `ToolUseCycleNode`, `ToolUsePrepareNode`,
`ToolUseDispatchNode`, `OutputNode` — run at the default `maxRetries = 1` and
never set a signal, so for them the loop was one attempt followed by a
`retryPrompt` that returns `false` followed by `execFallback`. p-retry does not
even call `shouldRetry` when `retries === 0` (`index.js:161` throws before the
`shouldRetry` call at `:168`), so the `lastExecError` / abort forwarding was
provably dead code for nine of the ten.

This deletes `Node` and puts each half where its one user is:

- **`BaseNode`** gains `execFallback(prepRes, error)` (default: rethrow) and an
  `_exec` that catches, normalizes, and calls it. Seven production classes
  override `execFallback`, so it has to live on the shared base.
- **`ModelInvocationNode`** takes the retry loop as `execWithRetries`, plus
  `maxRetries` / `wait` / `signal`, and now `extends BaseNode`.
- `p-retry` leaves the flow kernel (it stays a repo dependency —
  `agentCreatorFlow.ts` and `src/tools/*` still use it).

An SDK-readiness audit reached the same conclusion independently:
`docs/dev/audits/2026-07-29-agent-sdk-readiness-checkpoint.md` §New-3 — "the
generic `Node` should be the ~50-line prep/exec/post + basic p-retry, with the
retry-prompt behavior on `RetryableInvocationNode`".

## Issue acceptance gates

n/a — collapse sweep, no issue.

## Single source of truth

The manual-retry policy (attempt budget, backoff, auto-retry classification,
manual-retry prompt, abort forwarding, fallback) now has one owner:
`ModelInvocationNode`, the only node that invokes a model. Before, the policy
lived in the kernel base class and the *inputs* to it lived in
`ModelInvocationNode`, which reached back up through `super._exec` after
assigning `this.maxRetries` / `this.wait` / `this.signal` on the base.

## Duplication and abstraction budget

Removes one class and one layer of inheritance for nine nodes. No new
abstraction: `execWithRetries` is not an extraction for reuse — it is the
second half of an execution that now has two distinct responsibilities on the
same class (resolve this execution's retry budget from settings and services;
then run the loop), and it is the seam the retry scenarios drive so they do not
have to stand up a `ModelCell` and `RunScope` to script an attempt budget.

**Behavior preserved deliberately — three traps:**

1. **p-retry normalizes non-`Error` throws** (`index.js:106-108`), so every
   node's `execFallback` has always received a real `Error` even when `exec()`
   threw a string. The new `BaseNode._exec` reproduces that normalization
   verbatim (`new TypeError('Non-error was thrown: "…". You should only throw
   errors.')`) rather than passing the raw value through and silently violating
   the `execFallback(prepRes, error: Error)` signature.
2. **`Node.clone()` reset `signal` to `undefined`**, and `Flow._orchestrate`
   clones every node on every pass. Dropped, because
   `ModelInvocationNode._exec` reassigns `signal` from `services.runScope` on
   *every* execution before the loop runs — verified at the assignment site.
   Nothing can observe a stale signal.
3. **The constructor's `RangeError` guard** on `maxRetries < 1` is removed
   rather than re-homed. **This is not "deleting a safety check" — it is making
   the invalid state unrepresentable instead of guarding it at runtime**, which
   is the house rule: before handling an edge, remove the state that produces
   it.

   The guard existed to defend `Node`'s *public* `(maxRetries, wait)`
   constructor against an arbitrary caller. That constructor no longer exists.
   After this change there is exactly one producer of `maxRetries`:
   `getNodeMaxRetries()` = `1 + getValidatedConfig('texra.model.retry.maxAttempts',
   ModelRetryMaxAttemptsSchema, 2)`, where the schema is `.int().min(0).max(5)`
   and `getValidatedConfig` falls back to the default on anything that fails it.
   So the value is always in [1, 6]; background mode only ever raises it, via
   `Math.max`. There is no input left for the guard to catch.

   Keeping it would have meant keeping a test that constructs an impossible node
   purely to reach an unreachable branch — a guard with no irreducibility
   argument behind it. **This is a deliberate departure from the brief, which
   asked for the guard to be re-homed in `_exec`.**

## Net elements (R6)

| | delta |
|---|---|
| files | 0 |
| classes | **−1** (`Node`) |
| exported symbols | **−1** (`Node` off `@agent/node`) |
| kernel members removed from the shared base | **−8**: `maxRetries`, `wait`, `signal`, the `(maxRetries, wait)` constructor and its `RangeError` guard, `retryPrompt`, `shouldAutoRetry`, the `clone()` override, the retrying `_exec` |
| members added to the shared base | **+1** (`execFallback`; `_exec` was already there) |
| dependency edges | `p-retry` leaves `src/agent/node/index.ts`; **0** repo dependencies removed (`agentCreatorFlow.ts` and `src/tools/*` still import it) |
| `src/agent/node/index.ts` | 276 → 153 LoC (**−45%**) |

**Net LoC, stated plainly:**

- Production: **−12** (`index.ts` −123, `ModelInvocationNode.ts` +111, the nine
  `extends Node` → `extends BaseNode` edits are net zero).
- Tests: **+59** (`PocketFlowNode.vitest.ts` +39, `ApprovalAdapter.vitest.ts`
  +20) — the scripted subclasses now need a three-line `ModelInvocationConfig`
  and must return `InvocationResult` instead of a bare string.
- Docs: +3.
- **Total: +50 LoC. This change net-ADDS lines.** The win is structural, not
  LoC: one fewer class, one fewer inheritance layer for nine nodes, the retry
  machinery next to its only beneficiary, and a 45% smaller flow kernel. If the
  reviewer does not accept that trade, it should be rejected on those terms
  rather than on a claimed reduction.

## Consumer counts (R8)

```
$ grep -rn "extends Node\b\|extends Node<" src packages --include="*.ts" --include="*.tsx" | grep -v dist/
$ grep -rn "retryPrompt\|shouldAutoRetry\|this\.signal =\|this\.maxRetries =\|this\.wait =\|execFallback" src packages --include="*.ts" | grep -v dist/
$ grep "agent/node" config/ratchets/*.json
```

- `extends Node`: 10 production (all listed above) + 2 test subclasses. All 12
  retargeted; the grep now returns zero hits.
- Hook implementors: `ModelInvocationNode.ts` only, plus the kernel defaults
  and the two test subclasses. `this.signal` is read only inside
  `src/agent/node/index.ts` and assigned only at `ModelInvocationNode._exec`.
- `execFallback` overrides that depend on it moving to `BaseNode`: **7** —
  `ModelInvocationNode`, `ToolUseWaitNode`, `ToolUseCycleNode`,
  `ResponseCycleNode`, `OutputNode`, `MediaExtractionNode`, `TeXCountNode`.
- Ratchets: `grep "agent/node" config/ratchets/*.json` → zero hits. `@agent/node`
  is in no host list and not in the `agent` SDK list of
  `host-agent-import-baseline.json`, so no baseline moves.
  (`packages/agent/src/node.ts` is the *Node.js platform* factory — unrelated.)

## Host impact

Extension: none — no host imports `@agent/node`.

Desktop: none.

CLI: none (one test-only subclass in `ApprovalAdapter.vitest.ts` retargeted).

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean. **This is the only gate that catches the nine
  `extends` edits**; esbuild/Vite strip types and would have gone green while
  broken.
- `npx vitest run src/test-kernel/agent` — **200 files passed, 3094 tests
  passed**, 1 file / 4 tests skipped (pre-existing). This is the whole agent
  suite, run deliberately rather than a subset, because the change touches the
  base class every flow node inherits.
- `npx vitest run src/test-kernel/cli/ApprovalAdapter.vitest.ts` — 40 passed
- `npm run lint` — clean
- `npm run check:dead-code-ratchet` — 8 current vs 8 baselined, OK
- `npx prettier --write` on the touched files

### Test changes

No new tests. `PocketFlowNode.vitest.ts` keeps both describes:

- `describe('BaseNode.getNextNode')` (lines 9-52) is unchanged — it tests
  `BaseNode` and stays.
- `describe('Node manual retry')` → `describe('ModelInvocationNode manual
  retry')`. `ScriptedRetryNode` now extends `ModelInvocationNode<BaseCycleFields>`
  and drives `execWithRetries` directly (calling `_exec` would overwrite the
  scripted attempt budget and signal with the ones read from settings and the
  run scope). Its `exec`/`execFallback` return `InvocationResult` instead of a
  bare string; assertions changed shape accordingly. All twelve scenarios —
  including the abort-during-approval, cancellation-wins-the-race, AbortError
  unwrapping, non-Error normalization, and past-100-approvals cases — are
  preserved and pass.

One test was **deleted**: `'rejects an invalid retry limit at construction'`.
It constructed `new ScriptedRetryNode(0, …)` / `(-1, …)` to reach the
`RangeError` guard. With `Node`'s public constructor gone, the only producer of
`maxRetries` is schema-bounded to >= 1, so both the guard and the test pinned an
unrepresentable state.

`ApprovalAdapter.vitest.ts`'s `RepresentativeFailingProviderNode` was retargeted
the same way, and now overrides `execFallback` to rethrow — restoring exactly
what it previously inherited from `Node`'s default, since
`ModelInvocationNode.execFallback` maps failures through `getFallbackResult`.

### Docs

`CLAUDE.md` and `AGENTS.md` both stated that `src/agent/node/index.ts` defines
`BaseNode`, `Node`, and `Flow`, and `AGENTS.md` told contributors to configure
retries through `super(maxRetries, wait)`. Both updated; the dated
`docs/dev/audits/` and `docs/proposals/` records are left as written.
