### PR TITLE
fix(cli): one resolver for which subscription serves a model

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -2349,7 +2349,6 @@ function appendHarnessStatus(): void {
       model: meta.model,
       teamName: meta.teamName,
       modelAccess: resolveCliModelAccessRoute({
-        subscriptionActive: false,
         usageRoute: slice?.usage?.usageRoute,
       }),
       approval: formatTexraApprovalPolicy(harnessRuntimeSession.approvalPolicy),

--- a/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
@@ -34,11 +34,7 @@ import {
   projectStreamArtifacts,
   type StreamArtifactReader,
 } from '@controllers/session/StreamArtifactProjection';
-import {
-  isCodexSubscriptionActive,
-  isKimiCodeSubscriptionActive,
-  isXaiSubscriptionActive,
-} from '@model/providerCapabilities';
+import { activeSubscriptionUsageRoute } from '@model/codingPlanSubscriptions';
 import { formatTexraApprovalPolicy } from '@shared/approvalPolicy';
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { isActivePhase } from '@shared/streams/streamStatus';
@@ -141,22 +137,15 @@ export async function showCliSessionStatus(
       ? streamMetadataFor(activeStreamId)?.config?.model
       : undefined) ??
     (meta.model || context.initialModel);
-  const [subscriptionActive, grokSubscriptionActive, kimiCodeActive] =
-    await Promise.all([
-      isCodexSubscriptionActive(model),
-      isXaiSubscriptionActive(model),
-      isKimiCodeSubscriptionActive(model),
-    ]);
+  const prospectiveRoute = await activeSubscriptionUsageRoute(model);
   appendLocalAssistantTranscript(
     formatCliSessionStatus({
       agent: meta.agent || context.initialAgent,
       model,
       teamName: meta.teamName,
       modelAccess: resolveCliModelAccessRoute({
-        subscriptionActive,
-        grokSubscriptionActive,
-        kimiCodeActive,
         usageRoute: slice?.usage?.usageRoute,
+        prospectiveRoute,
       }),
       approval: formatTexraApprovalPolicy(context.getApprovalPolicy()),
       approvalBypasses: slice?.bypass,

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -180,8 +180,8 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const subscriptionUsageProvider = subscriptionUsageProviderForStatus({
     usageRoute: statusSlice?.usage?.usageRoute,
     modelAccess,
-    prospectiveCodingPlan: codingPlanForUsageRoute(prospectiveRoute)
-      ?.usageProvider,
+    prospectiveCodingPlan:
+      codingPlanForUsageRoute(prospectiveRoute)?.usageProvider,
   });
   const [subscriptionQuotaRead, setSubscriptionQuotaRead] = useState<{
     readonly provider: SubscriptionUsageProvider;

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -8,14 +8,12 @@ import { COLOR_ERROR } from '@cli/tui/ui/colors';
 import { useLiveNowMsSince } from '@cli/tui/useLiveNowMs';
 import { usePollingInterval } from '@cli/tui/usePollingInterval';
 import { SubscriptionUsageService } from '@controllers/modelAccess/subscriptionUsage/SubscriptionUsageService';
-import { activeCodingPlanForModel } from '@model/codingPlanSubscriptions';
-import {
-  isCodexSubscriptionActive,
-  isXaiSubscriptionActive,
-} from '@model/providerCapabilities';
+import { activeSubscriptionUsageRoute } from '@model/codingPlanSubscriptions';
+import { codingPlanForUsageRoute } from '@shared/codingPlanSubscriptions';
 import type {
   SubscriptionUsageProvider,
   SubscriptionUsageSnapshot,
+  UsageRoute,
 } from '@shared/schemas';
 import { isActivePhase } from '@shared/streams/streamStatus';
 
@@ -114,35 +112,26 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
       ? undefined
       : streamMetadataFor(displayStreamId)?.config?.model) ?? sessionMeta.model;
 
-  // Whether the selected stream's model would currently route through
-  // ChatGPT, Grok, or Kimi Code subscription access. The completed usage
-  // snapshot supersedes this prospective value in the display. Polling
-  // re-reads external config changes; an in-process access change also bumps
-  // `codexPreferenceVersion` for an immediate refresh.
+  // Which subscription, if any, would serve the selected stream's model on its
+  // next request. The completed usage snapshot supersedes this prospective
+  // value in the display. Polling re-reads external config changes; an
+  // in-process access change also bumps `codexPreferenceVersion` for an
+  // immediate refresh.
   const codexPreferenceVersion = useSignal(codexPreferenceVersionSignal);
   const [subscriptionResolution, setSubscriptionResolution] = useState<{
     readonly model: string;
     readonly preferenceVersion: number;
-    readonly active: boolean;
-    readonly grokActive: boolean;
-    readonly kimiCodeActive: boolean;
-    readonly glmCodingPlanActive: boolean;
-    readonly codingPlanUsageProvider?: SubscriptionUsageProvider;
+    readonly route?: UsageRoute;
   }>();
   const resolutionCurrent =
     subscriptionResolution?.model === accessModel &&
     subscriptionResolution.preferenceVersion === codexPreferenceVersion;
-  const resolution = resolutionCurrent ? subscriptionResolution : undefined;
-  const subscriptionActive = resolution?.active ?? false;
-  const grokSubscriptionActive = resolution?.grokActive ?? false;
-  const kimiCodeActive = resolution?.kimiCodeActive ?? false;
-  const glmCodingPlanActive = resolution?.glmCodingPlanActive ?? false;
+  const prospectiveRoute = resolutionCurrent
+    ? subscriptionResolution?.route
+    : undefined;
   const modelAccess = resolveCliModelAccessRoute({
-    subscriptionActive,
-    grokSubscriptionActive,
-    kimiCodeActive,
-    glmCodingPlanActive,
     usageRoute: statusSlice?.usage?.usageRoute,
+    prospectiveRoute,
   });
 
   // Both periodic reads run on the shared poll registry (`usePollingInterval`)
@@ -162,21 +151,13 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
       const readKey = `${accessModel}:${codexPreferenceVersion}`;
       if (subscriptionInFlightKeyRef.current === readKey) return;
       subscriptionInFlightKeyRef.current = readKey;
-      void Promise.all([
-        isCodexSubscriptionActive(accessModel),
-        isXaiSubscriptionActive(accessModel),
-        activeCodingPlanForModel(accessModel),
-      ])
-        .then(([active, grokActive, codingPlan]) => {
+      void activeSubscriptionUsageRoute(accessModel)
+        .then((route) => {
           if (subscriptionDesiredKeyRef.current !== readKey) return;
           setSubscriptionResolution({
             model: accessModel,
             preferenceVersion: codexPreferenceVersion,
-            active,
-            grokActive,
-            kimiCodeActive: codingPlan?.descriptor.id === 'kimiCode',
-            glmCodingPlanActive: codingPlan?.descriptor.id === 'glmCodingPlan',
-            codingPlanUsageProvider: codingPlan?.descriptor.usageProvider,
+            route,
           });
         })
         .catch(() => {
@@ -184,10 +165,6 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
           setSubscriptionResolution({
             model: accessModel,
             preferenceVersion: codexPreferenceVersion,
-            active: false,
-            grokActive: false,
-            kimiCodeActive: false,
-            glmCodingPlanActive: false,
           });
         })
         .finally(() => {
@@ -203,7 +180,8 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const subscriptionUsageProvider = subscriptionUsageProviderForStatus({
     usageRoute: statusSlice?.usage?.usageRoute,
     modelAccess,
-    prospectiveCodingPlan: resolution?.codingPlanUsageProvider,
+    prospectiveCodingPlan: codingPlanForUsageRoute(prospectiveRoute)
+      ?.usageProvider,
   });
   const [subscriptionQuotaRead, setSubscriptionQuotaRead] = useState<{
     readonly provider: SubscriptionUsageProvider;

--- a/packages/cli/src/runtime/modelAccessRoute.ts
+++ b/packages/cli/src/runtime/modelAccessRoute.ts
@@ -109,47 +109,40 @@ export function parseCliModelAccessSelection(
   }
 }
 
-/** Prefer the route that produced usage; otherwise describe the next request. */
+/**
+ * Label a route for the CLI. Both inputs speak `UsageRoute`, so this is a
+ * total map with one precedence rule and no per-provider knowledge of its own:
+ * a completed request's route cannot change, so it always wins over the
+ * prospective route `activeSubscriptionUsageRoute` reports for the next one.
+ */
 export function resolveCliModelAccessRoute({
-  subscriptionActive,
-  grokSubscriptionActive,
-  kimiCodeActive,
-  glmCodingPlanActive,
   usageRoute,
+  prospectiveRoute,
 }: {
-  /** Whether the current model would route through ChatGPT/Codex. */
-  readonly subscriptionActive: boolean;
-  /** Whether the current model would route through Grok/xAI OAuth. */
-  readonly grokSubscriptionActive?: boolean;
-  readonly kimiCodeActive?: boolean;
-  readonly glmCodingPlanActive?: boolean;
+  /** Route stamped on completed usage, when the stream has any. */
   readonly usageRoute?: UsageRoute;
+  /** Route that would serve the next request (`activeSubscriptionUsageRoute`). */
+  readonly prospectiveRoute?: UsageRoute;
 }): CliModelAccessRoute {
-  if (usageRoute !== undefined) {
-    switch (usageRoute) {
-      case 'chatgpt-subscription':
-        return 'chatgpt';
-      case 'xai-subscription':
-        return 'grok';
-      case 'kimi-code-subscription':
-        return 'kimi-code';
-      case 'glm-coding-plan-subscription':
-        return 'glm-code';
-      case 'relay':
-        return 'included';
-      case 'api-key':
-        // A completed request's route cannot change, so never relabel ordinary
-        // API-key usage from live preferences.
-        return 'personal';
-      default:
-        return usageRoute satisfies never;
-    }
+  const route = usageRoute ?? prospectiveRoute;
+  switch (route) {
+    case undefined:
+      return 'personal';
+    case 'chatgpt-subscription':
+      return 'chatgpt';
+    case 'xai-subscription':
+      return 'grok';
+    case 'kimi-code-subscription':
+      return 'kimi-code';
+    case 'glm-coding-plan-subscription':
+      return 'glm-code';
+    case 'relay':
+      return 'included';
+    case 'api-key':
+      return 'personal';
+    default:
+      return route satisfies never;
   }
-  if (subscriptionActive) return 'chatgpt';
-  if (grokSubscriptionActive === true) return 'grok';
-  if (kimiCodeActive === true) return 'kimi-code';
-  if (glmCodingPlanActive === true) return 'glm-code';
-  return 'personal';
 }
 
 /** Status-bar form of the access route. Width-critical, so every arm is a

--- a/src/model/codingPlanSubscriptions.ts
+++ b/src/model/codingPlanSubscriptions.ts
@@ -1,14 +1,20 @@
 import { ModelProvider } from 'llm-zoo';
 
 import { hasUsableApiKey } from '@model/apiProviders';
+import {
+  isKimiCodeRoute,
+  resolveKimiCodeRoutingFacts,
+} from '@model/kimiCodeSubscriptionRouting';
 import { shouldRouteModelThroughOpenRouter } from '@model/openRouterRouting';
-import { isKimiCodeSubscriptionActive } from '@model/providerCapabilities';
+import { oauthSubscriptionUsageRoute } from '@model/providerCapabilities';
 import { resolveRuntimeModelConfig } from '@model/runtimeModelRegistry';
 import { platform } from '@platform/platform';
 import {
   CODING_PLAN_SUBSCRIPTIONS,
   type CodingPlanSubscription,
 } from '@shared/codingPlanSubscriptions';
+import type { UsageRoute } from '@shared/schemas';
+import { isKimiSubscriptionEligible } from '@shared/model/kimiCodeRetryGate';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import {
   getGLMCodingPlan,
@@ -40,6 +46,21 @@ async function isGlmCodingPlanActive(modelId: string): Promise<boolean> {
     return false;
   }
   return hasUsableApiKey(platform().secrets, 'glm');
+}
+
+/**
+ * Whether the model currently routes through the Kimi Code coding endpoint
+ * (Moonshot coding subscription, authenticated by the Kimi Code API key).
+ * Mirrors ModelFactory's dispatch facts: registry eligibility, the OpenRouter
+ * toggle, a stored key, and the "Prefer Kimi Code" switch.
+ */
+async function isKimiCodeSubscriptionActive(modelId: string): Promise<boolean> {
+  const config = await resolveRuntimeModelConfig(modelId);
+  if (!config || !isKimiSubscriptionEligible(config)) return false;
+  return isKimiCodeRoute(
+    config,
+    await resolveKimiCodeRoutingFacts(getUseOpenRouter()),
+  );
 }
 
 const RUNTIME_BY_ID = {
@@ -90,4 +111,27 @@ export async function activeCodingPlanForModel(
     })),
   );
   return active.find((candidate) => candidate.active)?.runtime;
+}
+
+/**
+ * The subscription route that would serve this model's next request, or
+ * undefined when it would be paid for with the user's own API key.
+ *
+ * Single owner of "which subscription serves this model next": the OAuth
+ * subscriptions answer from their capability profile's `usageRoute`, the
+ * coding plans from their catalog descriptor. Callers get a `UsageRoute` — the
+ * same vocabulary completed usage is stamped with — so no surface has to
+ * re-order per-provider booleans to reach the same answer. At most one arm can
+ * resolve: each subscription requires its own `config.provider`.
+ *
+ * Lives here rather than in `@model/providerCapabilities` so the OAuth-only
+ * module stays free of the coding-plan runtime, which reads stored keys.
+ */
+export async function activeSubscriptionUsageRoute(
+  modelId: string,
+): Promise<UsageRoute | undefined> {
+  return (
+    (await oauthSubscriptionUsageRoute(modelId)) ??
+    (await activeCodingPlanForModel(modelId))?.descriptor.usageRoute
+  );
 }

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -6,13 +6,8 @@ import { isPreferCodexSubscription } from '@model/codex/codexPreference';
 import { isPreferXaiSubscription } from '@model/xai/xaiPreference';
 import { isXaiSignedIn } from '@model/xai/xaiSignedIn';
 import type { UsageRoute } from '@shared/schemas';
-import { isKimiSubscriptionEligible } from '@shared/model/kimiCodeRetryGate';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
 
-import {
-  isKimiCodeRoute,
-  resolveKimiCodeRoutingFacts,
-} from './kimiCodeSubscriptionRouting';
 import { resolveRuntimeModelConfig } from './runtimeModelRegistry';
 
 type ProviderAuthMode = 'chatgpt-subscription' | 'xai-subscription';
@@ -157,32 +152,60 @@ export function resolveCodexSubscriptionCapabilities(
  * Shared signed-in-subscription probe: resolve the model config, ask the
  * per-provider capability resolver whether the subscription route is active
  * under the live OpenRouter toggle, and confirm the provider is signed in.
- * The Kimi probe cannot share this (it has no sign-in probe and adds the
- * key-set + included-access facts), so it stays standalone.
+ * Returns the profile's own `usageRoute` so callers never restate which route
+ * a provider serves. The coding plans cannot share this (they have no sign-in
+ * probe and add key-set facts), so they answer from their catalog descriptor
+ * in `@model/codingPlanSubscriptions`.
  */
-async function isSignedInSubscriptionActive(
+async function signedInSubscriptionUsageRoute(
   modelId: string,
   resolveCapabilities: (
     config: ModelConfig,
     useOpenRouter: boolean,
   ) => ProviderCapabilityProfile | null,
   isSignedIn: () => boolean | Promise<boolean>,
-): Promise<boolean> {
+): Promise<UsageRoute | undefined> {
   const config = await resolveRuntimeModelConfig(modelId);
-  if (!config) return false;
+  if (!config) return undefined;
   const capabilities = resolveCapabilities(config, getUseOpenRouter());
-  if (!capabilities) return false;
-  return isSignedIn();
+  if (!capabilities) return undefined;
+  return (await isSignedIn()) ? capabilities.usageRoute : undefined;
+}
+
+/**
+ * The OAuth-subscription route serving this model's next request, if any.
+ *
+ * Pairing each capability resolver with its own sign-in probe stays inside
+ * this module — the one that owns those profiles. `activeSubscriptionUsageRoute`
+ * (`@model/codingPlanSubscriptions`) unions this with the API-key coding plans.
+ */
+export async function oauthSubscriptionUsageRoute(
+  modelId: string,
+): Promise<UsageRoute | undefined> {
+  return (
+    (await signedInSubscriptionUsageRoute(
+      modelId,
+      resolveCodexSubscriptionCapabilities,
+      isCodexSignedIn,
+    )) ??
+    (await signedInSubscriptionUsageRoute(
+      modelId,
+      resolveXaiSubscriptionCapabilities,
+      isXaiSignedIn,
+    ))
+  );
 }
 
 /** Whether the model currently routes through a signed-in ChatGPT subscription. */
 export async function isCodexSubscriptionActive(
   modelId: string,
 ): Promise<boolean> {
-  return isSignedInSubscriptionActive(
-    modelId,
-    resolveCodexSubscriptionCapabilities,
-    isCodexSignedIn,
+  return (
+    (await signedInSubscriptionUsageRoute(
+      modelId,
+      resolveCodexSubscriptionCapabilities,
+      isCodexSignedIn,
+    )) !== undefined
   );
 }
 
@@ -211,26 +234,11 @@ export function resolveXaiSubscriptionCapabilities(
 export async function isXaiSubscriptionActive(
   modelId: string,
 ): Promise<boolean> {
-  return isSignedInSubscriptionActive(
-    modelId,
-    resolveXaiSubscriptionCapabilities,
-    isXaiSignedIn,
-  );
-}
-
-/**
- * Whether the model currently routes through the Kimi Code coding endpoint
- * (Moonshot coding subscription, authenticated by the Kimi Code API key).
- * Mirrors ModelFactory's dispatch facts: registry eligibility, the OpenRouter
- * toggle, a stored key, and the "Prefer Kimi Code" switch.
- */
-export async function isKimiCodeSubscriptionActive(
-  modelId: string,
-): Promise<boolean> {
-  const config = await resolveRuntimeModelConfig(modelId);
-  if (!config || !isKimiSubscriptionEligible(config)) return false;
-  return isKimiCodeRoute(
-    config,
-    await resolveKimiCodeRoutingFacts(getUseOpenRouter()),
+  return (
+    (await signedInSubscriptionUsageRoute(
+      modelId,
+      resolveXaiSubscriptionCapabilities,
+      isXaiSignedIn,
+    )) !== undefined
   );
 }

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.ts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.ts
@@ -12,6 +12,7 @@ import {
   resolveCliModelAccessRoute,
   shortCliModelAccessRoute,
 } from '@cli/runtime/modelAccessRoute';
+import type { UsageRoute } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 
@@ -199,62 +200,36 @@ describe('CLI model access routes', () => {
     expect(parseCliModelAccessSelection(input)).toEqual(expected);
   });
 
-  it('uses observed access before prospective access preferences', () => {
+  it('uses observed access before the prospective route', () => {
     expect(
       resolveCliModelAccessRoute({
-        subscriptionActive: true,
         usageRoute: 'relay',
+        prospectiveRoute: 'chatgpt-subscription',
       }),
     ).toBe('included');
-    expect(
-      resolveCliModelAccessRoute({
-        subscriptionActive: true,
-      }),
-    ).toBe('chatgpt');
-    expect(
-      resolveCliModelAccessRoute({
-        subscriptionActive: false,
-      }),
-    ).toBe('personal');
-  });
-
-  it('never relabels recorded api-key usage from live preferences', () => {
     // A completed request's route cannot change — ordinary `api-key` usage
     // stays personal even while the Kimi Code route is currently active.
     expect(
       resolveCliModelAccessRoute({
-        subscriptionActive: false,
-        kimiCodeActive: true,
         usageRoute: 'api-key',
+        prospectiveRoute: 'kimi-code-subscription',
       }),
     ).toBe('personal');
   });
 
-  it('recognizes observed Kimi Code subscription usage', () => {
-    expect(
-      resolveCliModelAccessRoute({
-        subscriptionActive: false,
-        usageRoute: 'kimi-code-subscription',
-      }),
-    ).toBe('kimi-code');
-  });
-
-  it('describes a prospective exclusive Kimi Code route', () => {
-    expect(
-      resolveCliModelAccessRoute({
-        subscriptionActive: false,
-        kimiCodeActive: true,
-      }),
-    ).toBe('kimi-code');
-  });
-
-  it('reports an active GLM plan', () => {
-    expect(
-      resolveCliModelAccessRoute({
-        subscriptionActive: false,
-        glmCodingPlanActive: true,
-      }),
-    ).toBe('glm-code');
+  it.each<[UsageRoute | undefined, AccessRoute]>([
+    ['chatgpt-subscription', 'chatgpt'],
+    ['xai-subscription', 'grok'],
+    ['kimi-code-subscription', 'kimi-code'],
+    ['glm-coding-plan-subscription', 'glm-code'],
+    ['relay', 'included'],
+    ['api-key', 'personal'],
+    [undefined, 'personal'],
+  ])('labels %s the same observed or prospective', (route, expected) => {
+    expect(resolveCliModelAccessRoute({ usageRoute: route })).toBe(expected);
+    expect(resolveCliModelAccessRoute({ prospectiveRoute: route })).toBe(
+      expected,
+    );
   });
 
   it('formats the shared access routes for detailed and compact surfaces', () => {

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -758,8 +758,8 @@ describe('CLI StatusBar display model', () => {
         buildStatusBarDisplay(
           statusInput({
             modelAccess: resolveCliModelAccessRoute({
-              subscriptionActive: true,
               usageRoute,
+              prospectiveRoute: 'chatgpt-subscription',
             }),
             usage: {
               inputTokens: 1_000,


### PR DESCRIPTION
## Summary

**Live bug.** "Which subscription serves this model next?" had two answers in
one CLI. The status bar assembled four booleans
(`StatusBar.tsx:140-146`) and `/status` assembled three
(`sessionCommands.ts:136-141`) — `glmCodingPlanActive` was never passed. With a
GLM Coding Plan active and no observed usage yet, the status bar said
`GLM Coding Plan` while `/status` said `Your own API keys`, at the same instant,
for the same model. Same for the Kimi row in any future caller that forgets an
argument: the shape invites it.

Underneath, the routes are already catalogued — `resolveCodexSubscriptionCapabilities`
and `resolveXaiSubscriptionCapabilities` carry a `usageRoute`, and every coding
plan's descriptor carries one — but `resolveCliModelAccessRoute` re-derived the
same conclusion from a hand-written boolean if-chain (:148-152) that each caller
had to populate correctly.

This gives the question one owner, `activeSubscriptionUsageRoute`, and deletes
the if-chain. Callers now pass a `UsageRoute`, not a bag of booleans, so a
caller **cannot** express the old bug: there is no argument left to forget.

## Issue acceptance gates

n/a — no issue; sweep item C2 from the dual-systems (model-truth) sweep.

## Single source of truth

`activeSubscriptionUsageRoute(modelId)` in `src/model/codingPlanSubscriptions.ts`
owns "which subscription serves this model's next request", answering in
`UsageRoute` — the same vocabulary a completed request is stamped with.

- OAuth half: `oauthSubscriptionUsageRoute` in `src/model/providerCapabilities.ts`
  returns the capability profile's own `usageRoute` (the shared private probe
  `isSignedInSubscriptionActive` became `signedInSubscriptionUsageRoute` and
  returns the route instead of a boolean).
- Coding-plan half: `activeCodingPlanForModel(...)?.descriptor.usageRoute`.

The union lives in `codingPlanSubscriptions.ts`, not in `providerCapabilities.ts`:
the coding-plan runtime reads stored API keys, and putting it on the OAuth
module's import path dragged that weight into the onboarding/setup paths
(`setupLaunch` → `setupModelDefaults` → `providerCapabilities`). I tried that
direction first and reverted it — `SetupLaunch.vitest.ts` failed at import,
which is the import graph telling the truth.

`resolveCliModelAccessRoute` is now a total `UsageRoute | undefined →
CliModelAccessRoute` map plus one precedence rule (observed usage beats
prospective), and knows nothing per-provider.

## Duplication and abstraction budget

Removed: the boolean quartet + 5-line if-chain, three ad-hoc call-site
assemblies of the same question (status bar, `/status`, harness), and six
derived state fields/locals in `StatusBar`. `prospectiveCodingPlan` is now
derived via the already-exported `codingPlanForUsageRoute(route)?.usageProvider`
instead of being carried as a second field.

Moved, not added: `isKimiCodeSubscriptionActive` moves from
`providerCapabilities.ts` to `codingPlanSubscriptions.ts` and becomes private —
after this change its only consumer is the `kimiCode` runtime row two lines
below it. That is the export the `-export` in the accounting refers to.

No new abstraction layer: `oauthSubscriptionUsageRoute` is the OAuth module
publishing its own half (it keeps the resolver↔sign-in-probe pairing inside the
module that owns those profiles), and the union is one two-line function.

## Net elements (R6)

Production (`src/model`, `packages/cli`):

- Files: **±0** (6 modified)
- Exported symbols: **+1 net** — `+activeSubscriptionUsageRoute`,
  `+oauthSubscriptionUsageRoute`, `-isKimiCodeSubscriptionActive`
- Functions: **±0** (2 added, 1 unexported-and-moved, 0 deleted)
- Parameters on `resolveCliModelAccessRoute`: **5 → 2**
- React state fields / derived locals in `StatusBar`: **−7**
- Concurrent subscription probes per poll: **3 → 1** (status bar),
  **3 → 1** (`/status`)
- Net LoC: **+139 / −128 = +11**. Plainly: this is **not** a LoC reduction.
  Code lines are **−17**; doc-comments are **+28** (why the union lives where it
  does, and that the walk order is not a precedence rule). The win is the
  deleted second decision site, not size.

Tests: **+18 / −43 = −25 LoC**, 0 files added, 0 added test cases net (five
single-assertion cases collapse into one `it.each` table over all seven routes,
asserted identically for observed and prospective input).

## Consumer counts (R8)

```
grep -rn "resolveCliModelAccessRoute" packages src | grep -v node_modules
```
→ 3 production/script call sites (`StatusBar.tsx`, `sessionCommands.ts`,
`packages/cli/scripts/tui-harness.tsx`) + 8 test call sites. All rewritten.

```
grep -rn "isKimiCodeSubscriptionActive" packages src | grep -v node_modules
```
→ before: 2 real consumers (`codingPlanSubscriptions.ts:65`,
`sessionCommands.ts:148`). The second is deleted by this PR, so the remaining
one is in the file it moved to. No test mocks it by module path.

```
grep -rn "isCodexSubscriptionActive\|isXaiSubscriptionActive" packages src
```
→ both keep their other consumers (`src/tools/setup/platform.ts`,
`src/model/setupCredentialAccess.ts`, `src/controllers/onboarding/setupLaunch.ts`,
`packages/cli/src/runtime/credentialStatus.ts`); they now express themselves as
`(await signedInSubscriptionUsageRoute(...)) !== undefined`, unchanged in
behavior.

```
grep -rln "@model/providerCapabilities\|@model/codingPlanSubscriptions" src/test-kernel packages/*/src
```
→ 18 files; every test file among them was run (see Validation).

## Host impact

Extension: none — no extension surface calls the CLI resolver, and
`isCodex/isXaiSubscriptionActive` behavior is unchanged.

Desktop: none, same reason.

CLI: `/status` now reports an active GLM Coding Plan or Kimi Code subscription
instead of "Your own API keys" — this is the bug fix. The status bar renders the
same as before. `texra` help/flags unchanged.

## Scheduled refactoring

None. Noted but deliberately not done (pre-existing, out of subject):

- `StatusBar`'s `.catch(() => setSubscriptionResolution({...}))` still swallows
  the probe error and renders "no subscription". It is a silent degradation that
  predates this PR; I kept the shape rather than widening the diff into logging
  policy for a TUI pane.
- `subscriptionUsageProviderForStatus` (`statusBarDisplay.ts:69-88`) still
  re-derives the quota owner from `modelAccess` + a coding-plan hint rather than
  straight from the route. It is one caller, so it is not a dual system, but it
  is the obvious next collapse on this axis.

## Validation

- `npm run typecheck` — clean (root, cli, **including `packages/cli/tsconfig.scripts.json`**,
  trace-viewer, desktop, agent declarations).
- **Refuted from the brief:** the claim that `npm run typecheck` does not cover
  `packages/cli/scripts/tui-harness.tsx`. It does: `typecheck:cli` runs
  `tsc -p tsconfig.json && tsc -p tsconfig.scripts.json`, and the scripts project
  includes `scripts/**/*.tsx`. Proven by leaving the stale `subscriptionActive`
  argument in the harness and watching `typecheck` fail on
  `scripts/tui-harness.tsx(2352,9)`, then fixing it.
- `npx vitest run` over all 14 suites that touch `@model/providerCapabilities`,
  `@model/codingPlanSubscriptions`, or the CLI access route —
  `ModelAccessSelection`, `StatusBar`, `ProviderCapabilities`,
  `CodingPlanSubscriptionsRuntime`, `CredentialStatus`, `DefaultSetupPlatform`,
  `CodexPkce`, `CodexSubscriptionFallback`, `SetupCredentialAccess`,
  `SetupModelDefaults`, `SetupLaunch`, `ComputeModelOptions`,
  `ModelHandlerOpenAIResponseBackground`, `OpenAIResponseCompaction` —
  **237 passed**.
- `npx vitest run src/test-kernel/architecture` — 17 files, 104 passed (a first
  run showed one failure under concurrent CPU load; green in isolation).
- Bug fixed, proven by execution: a throwaway vitest (written, run, deleted —
  tree is clean) with the GLM plan on, a GLM key stored, OpenRouter off:
  `activeSubscriptionUsageRoute('glm52')` → `'glm-coding-plan-subscription'`,
  and the `/status` call shape now formats `GLM Coding Plan`. Before this PR the
  same shape formatted `Your own API keys`.
- **No regression test added.** The divergence is now unrepresentable — both
  surfaces call one resolver and the resolver takes no per-provider booleans —
  so a test would pin a seam rather than guard a behavior. Per the repo's
  testing budget, the five rewritten cases already cover the mapping.
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — OK (8 findings vs 8 baselined).
