### PR TITLE
fix(desktop): echo banner updates to renderer

### DIFF
--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -3,6 +3,7 @@ import type {
   MainViewStartupOptions,
 } from '@controllers/mainView/MainViewStartupController';
 import type { StateStore } from '@platform/interfaces';
+import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import type { MainViewExecuteMessage } from '@shared/schemas';
 import { installDesktopHostBridge } from './hostBridge.js';
 import { createDesktopExecutionIpc } from './desktopExecutionIpc.js';
@@ -12,6 +13,7 @@ import {
 } from './desktopLogIpc.js';
 import { createDesktopMainViewStartup } from './desktopMainViewStartup.js';
 import {
+  createCommandHandler,
   isDesktopCommandMessage,
   type DesktopMessageHandler,
 } from './desktopIpcTypes.js';
@@ -74,6 +76,12 @@ export function installDesktopMainViewIpc(
   const bridge = installDesktopHostBridge(window, {
     onRendererMessage: handleRendererMessage,
   });
+  const banner = createCommandHandler({
+    // Banner state is frontend-owned, so renderer updates round-trip through
+    // the host just as they do in the extension.
+    [MAIN_VIEW_COMMANDS.SET_BANNER]: (message) =>
+      bridge.postToRenderer(message),
+  });
   const viewState = createDesktopViewStateIpc(bridge);
   const shell = createDesktopShellIpc(options.shellActions);
   const execution = createDesktopExecutionIpc({
@@ -92,6 +100,7 @@ export function installDesktopMainViewIpc(
     globalState: options.globalState,
   });
   const messageHandlers: DesktopMessageHandler[] = [
+    banner,
     startup,
     options.fileSelection,
     options.prompt,

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts
@@ -561,6 +561,26 @@ describe('desktop main-view IPC', () => {
     });
   });
 
+  it('echoes banner updates to the renderer exactly once', async () => {
+    const harness = await createMainViewHarness();
+    installMainView(harness);
+    const { sends, sendFromRenderer } = harness;
+    const message = {
+      command: MAIN_VIEW_COMMANDS.SET_BANNER,
+      banner: 'agentConfig',
+      visible: false,
+    };
+
+    sendFromRenderer(message);
+
+    expect(sends).toEqual([
+      {
+        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+        message,
+      },
+    ]);
+  });
+
   it('disposes listeners idempotently', async () => {
     let themeListener: (() => void) | undefined;
     const harness = await createMainViewHarness({


### PR DESCRIPTION
## Summary

- handle renderer-initiated `SET_BANNER` in the desktop main-view IPC chain
- echo the message through the existing renderer bridge exactly once
- keep banner visibility frontend-owned, matching the extension host contract

## Validation

- ElectronMainViewIpc suite: 15 passed
- workspace, desktop, and test-kernel typechecks
- targeted ESLint
- `git diff --check`

Closes #10910
