### PR TITLE
fix(cli): honor the user-level texra.approvalPolicy at startup

### DIFF
--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import * as path from 'node:path';
 
 import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
 import { z } from 'zod';
@@ -6,8 +7,15 @@ import { z } from 'zod';
 import { isFileNotFoundError } from '@common/errors';
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import { JsonStore } from '@platform/defaults/jsonStore';
-import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import {
+  DEFAULT_NODE_STORAGE_ROOT,
+  TEXRA_CONFIG_FILE_NAME,
+  workspaceTexraConfigPath,
+} from '@platform/defaults/nodeStorage';
+import { resolveGlobalStoragePath } from '@platform/defaults/workspaceStorage';
+import {
+  parseTexraApprovalPolicy,
+  TEXRA_APPROVAL_POLICY_CONFIG_KEY,
   TexraApprovalPolicySchema,
   type TexraApprovalPolicy,
 } from '@shared/approvalPolicy';
@@ -271,6 +279,71 @@ export async function loadWorkspaceCliConfig(
     values: parseCliConfigValues(parsed),
     warnings: collectValidationWarnings(filePath, parsed),
   };
+}
+
+/**
+ * The user-level layer of `texra.approvalPolicy`
+ * (`~/.texra/global-storage/config.json`).
+ *
+ * The extension and desktop hosts resolve this row through `platform().config`,
+ * which layers the project `.texra/config.json` over the user file. The CLI
+ * resolves its approval policy in `buildCliContext`, before `initCliPlatform`
+ * creates that provider, so it reads the user layer here rather than standing
+ * up a second config provider — otherwise a policy set once in `/config` (or
+ * by the extension) is honored by two hosts and silently ignored by the third.
+ *
+ * Only this one key is read. The other CLI config fields are either
+ * workspace-scoped or already resolve their own user layer (`chatDefaults`),
+ * and unknown keys are not reported: the file is shared by all three hosts and
+ * holds rows the CLI does not honor.
+ */
+export async function loadUserApprovalPolicy(
+  storageRoot: string = DEFAULT_NODE_STORAGE_ROOT,
+): Promise<{
+  readonly value?: TexraApprovalPolicy;
+  readonly warnings: readonly string[];
+}> {
+  const filePath = path.join(
+    resolveGlobalStoragePath(storageRoot),
+    TEXRA_CONFIG_FILE_NAME,
+  );
+  let raw: string;
+  try {
+    raw = await readFile(filePath, 'utf8');
+  } catch (error: unknown) {
+    if (isFileNotFoundError(error)) return { warnings: [] };
+    return {
+      warnings: [`Could not read ${filePath}: ${toErrorMessage(error)}`],
+    };
+  }
+
+  const parseResult = safeParseJson(raw);
+  if (parseResult.isErr()) {
+    return {
+      warnings: [
+        `Could not parse ${filePath}: ${toErrorMessage(parseResult.error)}`,
+      ],
+    };
+  }
+  const parsed = parseResult.value;
+  if (!isObject(parsed)) {
+    return { warnings: [`Ignoring ${filePath}; expected a JSON object.`] };
+  }
+
+  const stored = parsed[TEXRA_APPROVAL_POLICY_CONFIG_KEY];
+  if (stored === undefined) return { warnings: [] };
+  // Same normalization the catalog row applies for every other host, so a
+  // hand-edited " Yolo" reads the same way in all three.
+  const policy =
+    typeof stored === 'string' ? parseTexraApprovalPolicy(stored) : undefined;
+  if (!policy) {
+    return {
+      warnings: [
+        `Ignoring invalid ${filePath} key "${TEXRA_APPROVAL_POLICY_CONFIG_KEY}".`,
+      ],
+    };
+  }
+  return { value: policy, warnings: [] };
 }
 
 /**

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -19,6 +19,7 @@ import {
 } from '../schemas/cliSettings';
 import {
   isCliSupportedModelId,
+  loadUserApprovalPolicy,
   loadWorkspaceCliConfig,
   type CliConfigValues,
 } from './cliConfig';
@@ -292,6 +293,12 @@ export interface BuildCliContextInit {
   readonly globalArgs: CliGlobalArgs;
   readonly ambient?: CliAmbientState;
   readonly env?: Record<string, string | undefined>;
+  /**
+   * Root of the shared TeXRA storage directory. Production leaves this unset
+   * (`~/.texra`); tests point it at a scratch directory so the developer's own
+   * user-level config cannot decide an assertion.
+   */
+  readonly storageRoot?: string;
 }
 
 function envValue(
@@ -364,8 +371,16 @@ export async function buildCliContext(
   const ambient = init.ambient ?? readCliAmbientState();
   const env = init.env ?? process.env;
   const cwd = await resolveCliCwd(init.globalArgs.cwd);
-  const loadedConfig = await loadWorkspaceCliConfig(cwd);
-  const configWarnings = [...loadedConfig.warnings];
+  // Workspace file first, user file second — the same order
+  // `platform().config` gives the extension and desktop hosts.
+  const [loadedConfig, userApprovalPolicy] = await Promise.all([
+    loadWorkspaceCliConfig(cwd),
+    loadUserApprovalPolicy(init.storageRoot),
+  ]);
+  const configWarnings = [
+    ...loadedConfig.warnings,
+    ...userApprovalPolicy.warnings,
+  ];
   const envModel = pickEnvModel(env, configWarnings);
   // `--no-color` is an explicit force-disable: layer it onto the ambient
   // per-stream gates rather than recomputing them, so `NO_COLOR`/`FORCE_COLOR`/
@@ -383,6 +398,7 @@ export async function buildCliContext(
         init.globalArgs.approvalPolicy,
         envValue(env, 'TEXRA_APPROVAL_POLICY'),
         loadedConfig.values.approvalPolicy,
+        userApprovalPolicy.value,
       ];
   let approvalPolicy = approvalPolicyFallback;
   for (const candidate of approvalPolicyCandidates) {

--- a/src/test-kernel/cli/CliContext.vitest.ts
+++ b/src/test-kernel/cli/CliContext.vitest.ts
@@ -14,10 +14,13 @@ import {
   resolveCliCwd,
   resolveCliCommandName,
   resolveStreamColor,
+  type BuildCliContextInit,
   type CliAmbientState,
+  type CliContext,
 } from '@cli/runtime/cliContext';
 import { loadWorkspaceCliConfig } from '@cli/runtime/cliConfig';
 import { canonicalizeWorkspacePath } from '@platform/defaults/nodeWorkspace';
+import { resolveGlobalStoragePath } from '@platform/defaults/workspaceStorage';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 const ambient = {
@@ -42,6 +45,18 @@ function ttyAmbient(overrides: Partial<CliAmbientState> = {}): CliAmbientState {
 }
 
 const tempDirs = useTempDirs();
+
+/**
+ * Every `buildCliContext` call here gets an empty user-level storage root: the
+ * developer's own `~/.texra/global-storage/config.json` must never decide an
+ * assertion. Tests that exercise the user layer pass their own `storageRoot`.
+ */
+async function cliContext(init: BuildCliContextInit): Promise<CliContext> {
+  return buildCliContext({
+    storageRoot: await makeTempDir('texra-cli-storage-', tempDirs),
+    ...init,
+  });
+}
 
 async function workspaceWithConfig(config: string): Promise<string> {
   const workspace = await makeTempDir('texra-cli-context-', tempDirs);
@@ -104,7 +119,7 @@ describe('CLI context config defaults', () => {
     );
 
     await expect(
-      buildCliContext({
+      cliContext({
         ambient,
         env: { TEXRA_OUTPUT_FORMAT: 'ndjson' },
         globalArgs: { cwd: workspace },
@@ -115,7 +130,7 @@ describe('CLI context config defaults', () => {
     });
 
     await expect(
-      buildCliContext({
+      cliContext({
         ambient,
         env: { TEXRA_OUTPUT_FORMAT: 'ndjson' },
         globalArgs: { cwd: workspace, outputFormat: 'text' },
@@ -126,7 +141,7 @@ describe('CLI context config defaults', () => {
     });
 
     await expect(
-      buildCliContext({
+      cliContext({
         ambient,
         env: {},
         globalArgs: { cwd: tmpdir() },
@@ -135,6 +150,40 @@ describe('CLI context config defaults', () => {
       outputFormat: 'text',
       approvalPolicy: 'ask',
     });
+  });
+
+  it('honors a user-level approval policy the workspace config leaves unset', async () => {
+    const storageRoot = await makeTempDir('texra-cli-user-config-', tempDirs);
+    const globalStorage = resolveGlobalStoragePath(storageRoot);
+    await mkdir(globalStorage, { recursive: true });
+    await writeFile(
+      join(globalStorage, 'config.json'),
+      JSON.stringify({ 'texra.approvalPolicy': 'yolo' }),
+    );
+
+    // The workspace file still wins when it sets the row...
+    const workspace = await workspaceWithConfig(
+      JSON.stringify({ 'texra.approvalPolicy': 'never' }),
+    );
+    await expect(
+      cliContext({
+        ambient,
+        env: {},
+        globalArgs: { cwd: workspace },
+        storageRoot,
+      }),
+    ).resolves.toMatchObject({ approvalPolicy: 'never' });
+
+    // ...and the user file decides when it does not, as it already does for
+    // the extension and desktop hosts through `platform().config`.
+    await expect(
+      cliContext({
+        ambient,
+        env: {},
+        globalArgs: { cwd: tmpdir() },
+        storageRoot,
+      }),
+    ).resolves.toMatchObject({ approvalPolicy: 'yolo' });
   });
 
   it('reports unknown and invalid workspace config fields without failing', async () => {
@@ -203,7 +252,7 @@ describe('CLI context config defaults', () => {
     );
     await symlink(workspace, link, 'dir');
 
-    const context = await buildCliContext({
+    const context = await cliContext({
       ambient,
       env: {},
       globalArgs: { cwd: link },
@@ -237,7 +286,7 @@ describe('CLI context config defaults', () => {
   });
 
   it('ignores unknown TEXRA_MODEL values before they reach runtime', async () => {
-    const context = await buildCliContext({
+    const context = await cliContext({
       ambient,
       env: { TEXRA_MODEL: 'claude-opus-4-7' },
       globalArgs: { cwd: tmpdir() },
@@ -295,7 +344,7 @@ describe('CLI --cwd validation', () => {
     const missing = join(tmpdir(), 'texra-cli-cwd-missing-' + Date.now());
 
     await expect(
-      buildCliContext({ ambient, env: {}, globalArgs: { cwd: missing } }),
+      cliContext({ ambient, env: {}, globalArgs: { cwd: missing } }),
     ).rejects.toBeInstanceOf(CliUsageError);
   });
 });
@@ -387,7 +436,7 @@ describe('CLI per-stream color resolution', () => {
 
 describe('CLI color/no-input flag wiring', () => {
   it('keeps the ambient per-stream gates by default', async () => {
-    const context = await buildCliContext({
+    const context = await cliContext({
       ambient: ttyAmbient({
         stdoutColorEnabled: true,
         stderrColorEnabled: false,
@@ -400,7 +449,7 @@ describe('CLI color/no-input flag wiring', () => {
   });
 
   it('--no-color force-disables both stream gates', async () => {
-    const context = await buildCliContext({
+    const context = await cliContext({
       ambient: ttyAmbient(),
       env: {},
       globalArgs: { cwd: tmpdir(), noColor: true },
@@ -410,7 +459,7 @@ describe('CLI color/no-input flag wiring', () => {
   });
 
   it('--no-input forces headless mode and defaults approval policy to never', async () => {
-    const context = await buildCliContext({
+    const context = await cliContext({
       // stdin is a TTY, so without --no-input this would be interactive.
       ambient: ttyAmbient(),
       env: {},
@@ -421,7 +470,7 @@ describe('CLI color/no-input flag wiring', () => {
   });
 
   it('--no-input preserves explicit approval policy', async () => {
-    const context = await buildCliContext({
+    const context = await cliContext({
       ambient: ttyAmbient(),
       env: {},
       globalArgs: { cwd: tmpdir(), noInput: true, approvalPolicy: 'yolo' },
@@ -434,7 +483,7 @@ describe('CLI color/no-input flag wiring', () => {
     const workspace = await workspaceWithConfig(
       JSON.stringify({ approvalPolicy: 'yolo' }),
     );
-    const context = await buildCliContext({
+    const context = await cliContext({
       ambient: ttyAmbient(),
       env: { TEXRA_APPROVAL_POLICY: 'yolo' },
       globalArgs: { cwd: workspace, noInput: true },
@@ -444,7 +493,7 @@ describe('CLI color/no-input flag wiring', () => {
   });
 
   it('leaves approval policy alone when --no-input is absent', async () => {
-    const context = await buildCliContext({
+    const context = await cliContext({
       ambient: ttyAmbient(),
       env: {},
       globalArgs: { cwd: tmpdir(), approvalPolicy: 'yolo' },


### PR DESCRIPTION
## Summary

`texra.approvalPolicy` is **one catalog row** — `slots: sameSlot('config')`, `honoredBy` all three hosts (`src/shared/schemas/stateSettings.ts:650-676`). Two hosts read it the layered way:

```
extension.ts:291          readPersistedTexraApprovalPolicy((k, f) => platform().config.get(k, f))
desktop/src/main/index.ts:1306   ditto
```

which resolves the project `.texra/config.json`, then `~/.texra/global-storage/config.json`, then the schema default. The CLI built its candidate list in `buildCliContext` from `loadWorkspaceCliConfig(cwd)` alone:

```ts
const approvalPolicyCandidates = [
  init.globalArgs.approvalPolicy,
  envValue(env, 'TEXRA_APPROVAL_POLICY'),
  loadedConfig.values.approvalPolicy,   // <- workspace file only
];
```

`git grep approvalPolicy packages/cli/src` confirms the CLI never touches the layered reader on the startup path. So a policy stored at the user level was honored by two hosts and **silently ignored by the third** — on the setting that decides whether a Bash command runs without asking.

The CLI was also inconsistent with itself. `src/shared/settingsView/handlers/stateSettingWrite.ts:137-145` — the shared write path the CLI's `/config` panel uses — resolves a *reset* of this row through `readPersistedTexraApprovalPolicy((k, f) => ports.stores.config.get(k, f))`, i.e. layered. `/config` reset applied the user value to the running session; the next `texra` invocation ignored it.

**Fix.** `buildCliContext` runs before `initCliPlatform` creates the config provider, so it reads the user layer directly via a new `loadUserApprovalPolicy` in `cliConfig.ts` (the file the catalog row already names as the CLI's reader) rather than standing up a second config provider. Precedence is unchanged apart from the new lowest tier:

```
--approval-policy > TEXRA_APPROVAL_POLICY > workspace config > user config > default
```

`--no-input` still narrows the candidate list to the explicit flag alone, so a persisted or env `yolo` cannot auto-approve a headless run nobody is watching — the invariant documented on `TEXRA_APPROVAL_POLICY_NO_INPUT_DEFAULT`.

### Deliberately narrow

Only this one key is layered. The remaining CLI config fields are either workspace-scoped or already resolve their own user layer: `chatDefaults.ts:177-181` documents a **four-tier per-field** contract ("a workspace that only sets `agent` still falls through to user/history for `model`", citing `docs/prds/cli-tui-ink/2026-05-14-10-architecture.md#entrypoint-default`). `texra.chat` is stored as one flat key holding a nested object, so flat-key layering would erase the user's `model` the moment a workspace set `agent`. That merge stays where it is.

Unknown keys are **not** reported from the user file. It is shared by all three hosts and holds rows the CLI does not honor (`KNOWN_TEXRA_KEYS` is derived from `honoredBy.cli !== undefined && slots.cli === 'config'` plus the CLI-only paths), so running the CLI's unknown-key sweep over it would emit a warning per foreign key. Invalid values *are* reported, with the file path.

Normalization matches the catalog row: the row carries `normalizePersisted: raw => raw.trim().toLowerCase()`, so the user layer parses through the shared `parseTexraApprovalPolicy`, and a hand-edited `" Yolo"` reads the same in all three hosts.

## Issue acceptance gates

No issue. Sweep item C2 of the `dual-persistence-and-fs` axis, landed as the narrow correctness fix the verification pass approved — **not** as the proposed three-reader consolidation, which it put on HOLD. Recorded here so the consolidation is not re-proposed on the numbers it was pitched with:

- *"Two private key catalogs parallel to `coreSettings.ts`"* — **false**. `packages/cli/src/schemas/knownKeys.ts:24-27` is already derived from `CLI_CONFIG_SLOT_KEYS` (`stateSettings.ts:1522-1524`). The claimed −53 LoC does not exist.
- *"`writeInitFileAtomic` can be deleted"* — **false**. It has two callers; `ensureTexraGitignored` (`initConfig.ts:110`) writes `.gitignore`, not JSON, not a `JsonStore`.
- *"`texra init` clobbers concurrent settings writes"* — **mischaracterized**. `init.ts:171-173` refuses to overwrite an existing config and tells the user to pass `--force`; whole-file replacement under `--force` is the documented intent of that command.
- Net for the full consolidation is ≈ −60 LoC, not −180: all three Zod tables, every `pick*`/`parseOptional`, and the ~55-line warning pass are **retained**, because the replacement returns raw `unknown` and has no warning channel.

## Single source of truth

`src/shared/approvalPolicy.ts` remains the vocabulary and parser owner (`parseTexraApprovalPolicy`), and the `stateSettings.ts` row remains the single declaration of where the value lives. What changes is that all three hosts now resolve that row over the same two-file layering. `packages/cli/src/runtime/cliConfig.ts` stays the CLI's reader, exactly as `honoredBy.cli.reader` already declares.

## Duplication and abstraction budget

No new abstraction and no new config machinery — `loadUserApprovalPolicy` is a reader for one declared key, and it does not duplicate `JsonConfigProvider` because it cannot use it (the provider does not exist yet at that point in startup). No parallel evaluator, no second `setApprovalPolicy` seed: `src/test-kernel/architecture/approvalPolicyAuthorityRatchet.vitest.ts` passes unchanged, both allowlists untouched.

## Net elements (R6)

**This PR net-adds LoC. Stating that plainly: it is a correctness fix, not a reduction.**

| | + | − | net |
|---|---|---|---|
| `packages/cli/src/runtime/cliConfig.ts` | 74 | 1 | +73 |
| `packages/cli/src/runtime/cliContext.ts` | 18 | 2 | +16 |
| `src/test-kernel/cli/CliContext.vitest.ts` | 61 | 12 | +49 |
| **Total** | **153** | **15** | **+138** |

- **Files:** 0 added, 0 deleted.
- **Exported symbols:** +1 (`loadUserApprovalPolicy`), consumed by `cliContext.ts` in this PR. +1 optional interface field (`BuildCliContextInit.storageRoot`).
- **Classes/interfaces/enums:** 0 net.
- **Tests:** +1 `it` (the regression at the durable boundary) and one 12-call-site helper that gives the whole suite an empty user-level storage root.

## Consumer counts (R8)

Not deleting or re-routing an export. The one behavioral re-route is the candidate list in `buildCliContext`; its consumers:

```
$ git grep -n "context.approvalPolicy\|\.approvalPolicy" -- packages/cli/src | grep -v vitest
```
`runInstructions.ts:83,91`, `multiAgent.ts:175,229`, `orchestrate.ts:170`, `resumeExecution.ts:123`, `runChatTui.tsx:186` (`setApprovalPolicy` seed), `chatSessionController.ts:411` — all read the same `CliContext.approvalPolicy` field, whose type and precedence rules are unchanged. Nothing is orphaned.

```
$ git grep -n "readPersistedTexraApprovalPolicy" -- src packages | grep -v vitest
```
3 sites, all in the two hosts that already layered — untouched by this PR.

## Host impact

**CLI:** `texra.approvalPolicy` in `~/.texra/global-storage/config.json` is now honored when nothing more specific sets it. A user who had set it there and did not realize the CLI ignored it will see the CLI start following it — that is the fix, and it can tighten as well as loosen (a stored `never` now denies where the CLI previously defaulted to `ask`).

**Extension / Desktop:** none. No shared file touched.

## Scheduled refactoring

None required. The three-reader consolidation (`loadWorkspaceCliConfig` + `chatDefaults.loadUserDefaults` + `JsonConfigProvider`) stays on HOLD; if it is ever revisited, it must go through `inspect()` rather than `get()` so `texra.chat`'s per-field fallthrough survives, and it must carry the warning pass across, because the winner has no warning channel.

## Validation

- `npm run typecheck` — clean (exit 0, 0 `error TS`).
- `corepack pnpm --filter @texra-ai/cli typecheck` — clean (this is the only thing that compiles `packages/cli/tsconfig.scripts.json`).
- `npm run lint` — clean. `npm run format` — applied.
- `npm run check:dead-code-ratchet` — `8 current vs 8 baselined`, no new findings.
- `npx vitest run src/test-kernel/cli src/test-kernel/architecture/approvalPolicyAuthorityRatchet.vitest.ts` — **145 files / 2539 passed, 1 skipped**.

One thing the new test surfaced while being written: the pre-existing `CliContext` suite never actually proved the *workspace* `approvalPolicy` is honored — every assertion in it happens to equal the built-in default (`ask`) or is taken under `--no-input`, which ignores config entirely. The regression test added here pins both layers (workspace `never` wins over user `yolo`; user `yolo` decides when the workspace is silent), so that gap closes as a side effect.

The suite-wide `cliContext(...)` helper is not cosmetic: without an explicit scratch `storageRoot`, `buildCliContext` would read the developer's real `~/.texra/global-storage/config.json`, and any maintainer who had set a global policy would see the existing `approvalPolicy: 'ask'` assertions fail on their machine only.
