### PR TITLE
refactor(progress-view): delete the approval-override seam

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -27,7 +27,6 @@ import {
 } from '@agent/core/state/executionRequests';
 import { prepareMainViewExecutionLaunch } from '@controllers/mainView/backend/MainViewExecutionLaunchController';
 import { ToolEditApprovalController } from '@controllers/approval/ToolEditApprovalController';
-import { createAgentProposalTransport } from '@controllers/progressView/backend/agentProposalTransport';
 import type { ProgressHostInteractions } from '@controllers/progressView/backend/progressHostInteractions';
 import { replayApprovalRequestHandlers } from '@controllers/progressView/backend/progressBackendUiConfig';
 import { buildStreamInfo } from '@controllers/session/streamInfoUtils';
@@ -276,30 +275,6 @@ export class DesktopProgressBridge {
         // The desktop renderer is always attached (no sidebar/editor re-target).
         canSend: () => true,
         logger: this.logger,
-        overrides: {
-          // Route retry requests to the renderer's RetryRequestPanel: a parked
-          // request blocks the run until the user answers it, so the card has
-          // to be shown. Both are arrow functions, so `this.backend` is already
-          // assigned by the time either runs.
-          retry: {
-            show: (permission) =>
-              this.backend.renderer.showPermission({
-                kind: PERMISSION_KIND.RETRY,
-                data: permission,
-              }),
-            dismiss: (id) =>
-              this.backend.renderer.resolvePermission(
-                PERMISSION_KIND.RETRY,
-                id,
-              ),
-          },
-          proposal: createAgentProposalTransport({
-            getRenderer: () => this.backend.renderer,
-            isPending: (requestId) =>
-              this.backend.approvalHandlers.proposal.get(requestId) !==
-              undefined,
-          }),
-        },
       },
       lifecycle: {
         stopStream: (stream, options) => {

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -14,7 +14,6 @@ import {
 } from '@common/webview';
 import { workspaceSM } from '@common/state';
 import { ToolEditApprovalController } from '@controllers/approval/ToolEditApprovalController';
-import { createAgentProposalTransport } from '@controllers/progressView/backend/agentProposalTransport';
 import { replayApprovalRequestHandlers } from '@controllers/progressView/backend/progressBackendUiConfig';
 import { ProgressBackend } from '@controllers/progressView/backend/ProgressBackend';
 import { getProgressStreamControls } from '@controllers/progressView/progressStreamControls';
@@ -119,23 +118,6 @@ export class ProgressViewProvider extends BaseWebviewProvider {
       approvals: {
         canSend: () => this.canSendToWebview(),
         logger: this.logger,
-        overrides: {
-          retry: {
-            show: (p) =>
-              this.renderer.showPermission({
-                kind: PERMISSION_KIND.RETRY,
-                data: p,
-              }),
-            dismiss: (id) =>
-              this.renderer.resolvePermission(PERMISSION_KIND.RETRY, id),
-          },
-          proposal: createAgentProposalTransport({
-            getRenderer: () => this.backend.renderer,
-            isPending: (requestId) =>
-              this.backend.approvalHandlers.proposal.get(requestId) !==
-              undefined,
-          }),
-        },
       },
       lifecycle: {
         stopStream: (stream, options) =>

--- a/src/controllers/progressView/backend/agentProposalTransport.ts
+++ b/src/controllers/progressView/backend/agentProposalTransport.ts
@@ -17,8 +17,9 @@ import type { LitSessionRenderer } from './LitSessionRenderer';
 const log = createLog('agentProposalTransport');
 
 /**
- * Show/dismiss transport for agent proposals, shared by every host that renders
- * the proposal card with model and agent dropdowns.
+ * Show/dismiss transport for the agent-proposal card with its model and agent
+ * dropdowns. Wired once by {@link buildApprovalRequestHandlerSet}; every host
+ * renders the card the same way.
  *
  * The card is shown twice: immediately with the static visible-model list so it
  * appears without waiting on the network, then again once the full option data
@@ -27,14 +28,13 @@ const log = createLog('agentProposalTransport');
  * handler and the late SHOW would re-create an undismissable ghost card.
  */
 export function createAgentProposalTransport(options: {
-  /** Read lazily: hosts wire this before their backend field is assigned. */
-  getRenderer(): LitSessionRenderer;
+  renderer: LitSessionRenderer;
   isPending(requestId: string): boolean;
 }): {
   show(proposal: AgentProposalPermission): void;
   dismiss(requestId: string): void;
 } {
-  const { getRenderer, isPending } = options;
+  const { renderer, isPending } = options;
 
   // Model options have a visible-model fallback, so the dropdown still
   // appears if availability loading fails. Agent options have no static
@@ -68,7 +68,7 @@ export function createAgentProposalTransport(options: {
       }),
     ]);
     if (!isPending(proposal.requestId)) return;
-    getRenderer().showPermission({
+    renderer.showPermission({
       kind: PERMISSION_KIND.PROPOSAL,
       data: proposal,
       modelOptionsData,
@@ -78,7 +78,7 @@ export function createAgentProposalTransport(options: {
 
   return {
     show(proposal) {
-      getRenderer().showPermission({
+      renderer.showPermission({
         kind: PERMISSION_KIND.PROPOSAL,
         data: proposal,
         modelOptionsData: buildVisibleBasicModelOptionsData(),
@@ -86,7 +86,7 @@ export function createAgentProposalTransport(options: {
       void sendResolvedOptions(proposal);
     },
     dismiss(requestId) {
-      getRenderer().resolvePermission(PERMISSION_KIND.PROPOSAL, requestId);
+      renderer.resolvePermission(PERMISSION_KIND.PROPOSAL, requestId);
     },
   };
 }

--- a/src/controllers/progressView/backend/progressBackendUiConfig.ts
+++ b/src/controllers/progressView/backend/progressBackendUiConfig.ts
@@ -23,15 +23,18 @@ import type {
 } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
+import { createAgentProposalTransport } from './agentProposalTransport';
 import { ApprovalRequestHandler } from './ApprovalRequestHandler';
 import { ExternalInquiryRequestHandler } from './ExternalInquiryRequestHandler';
 import type { LitSessionRenderer } from './LitSessionRenderer';
 
 /**
- * The seven pending-approval handlers a progress backend wires. Hosts build
- * each handler with their own show/dismiss transport (and `canSend` gate), then
- * hand the set to {@link createProgressBackendUiConfig}, which derives the
- * uniform UI callbacks and the pending-permissions guard from them.
+ * The seven pending-approval handlers a progress backend wires. Every one of
+ * them talks to the same {@link LitSessionRenderer}, so
+ * {@link buildApprovalRequestHandlerSet} owns the whole set and hosts supply
+ * only the renderer and the `canSend` gate. The set then goes to
+ * {@link createProgressBackendUiConfig}, which derives the uniform UI callbacks
+ * and the pending-permissions guard from it.
  */
 export interface ApprovalRequestHandlerSet {
   toolEdit: ApprovalRequestHandler<ToolEditPermission, 'requestId'>;
@@ -125,27 +128,11 @@ const APPROVAL_REQUEST_HANDLER_KEYS = Object.keys(
   APPROVAL_REQUEST_HANDLER_KEY_MAP,
 ) as Array<keyof ApprovalRequestHandlerSet>;
 
-/**
- * Host-specific show/dismiss transport for one approval kind. Every host
- * supplies retry behavior. A host may override agent proposals when it needs
- * richer presentation data than the built-in permission handler provides.
- */
-interface ApprovalHandlerTransport<T> {
-  show: (item: T) => void;
-  dismiss: (id: string) => void;
-}
-
-interface ApprovalRequestHandlerOverrides {
-  retry: ApprovalHandlerTransport<RetryPermission>;
-  proposal?: ApprovalHandlerTransport<AgentProposalPermission>;
-}
-
 export interface BuildApprovalRequestHandlerSetParams {
   renderer: LitSessionRenderer;
   /** Gate passed to every handler; an empty/false gate keeps it pending-only. */
   canSend: () => boolean;
   logger?: Pick<AgentTrace, 'debug'>;
-  overrides: ApprovalRequestHandlerOverrides;
 }
 
 type PermissionData<K extends PermissionPayload['kind']> = Extract<
@@ -178,8 +165,21 @@ function webviewPermissionHandler<
 export function buildApprovalRequestHandlerSet(
   params: BuildApprovalRequestHandlerSetParams,
 ): ApprovalRequestHandlerSet {
-  const { renderer, canSend, overrides } = params;
+  const { renderer, canSend } = params;
+  // The proposal transport asks its own handler whether a request is still
+  // pending (the RESOLVE-between-two-SHOWs guard). `proposal` is read only
+  // from inside that callback, which cannot run before the handler exists.
+  const proposalTransport = createAgentProposalTransport({
+    renderer,
+    isPending: (requestId) => proposal.get(requestId) !== undefined,
+  });
+  const proposal = new ApprovalRequestHandler<
+    AgentProposalPermission,
+    'requestId',
+    ProposalResult
+  >('requestId', proposalTransport.show, proposalTransport.dismiss, canSend);
   return {
+    proposal,
     toolEdit: webviewPermissionHandler(
       renderer,
       canSend,
@@ -213,28 +213,11 @@ export function buildApprovalRequestHandlerSet(
       'requestId',
       UserQuestionSettlement
     >(renderer, canSend, PERMISSION_KIND.USER_QUESTION, 'requestId'),
-    retry: new ApprovalRequestHandler<RetryPermission, 'streamId', RetryResult>(
+    retry: webviewPermissionHandler<
+      typeof PERMISSION_KIND.RETRY,
       'streamId',
-      overrides.retry.show,
-      overrides.retry.dismiss,
-      canSend,
-    ),
-    proposal: overrides.proposal
-      ? new ApprovalRequestHandler<
-          AgentProposalPermission,
-          'requestId',
-          ProposalResult
-        >(
-          'requestId',
-          overrides.proposal.show,
-          overrides.proposal.dismiss,
-          canSend,
-        )
-      : webviewPermissionHandler<
-          typeof PERMISSION_KIND.PROPOSAL,
-          'requestId',
-          ProposalResult
-        >(renderer, canSend, PERMISSION_KIND.PROPOSAL, 'requestId'),
+      RetryResult
+    >(renderer, canSend, PERMISSION_KIND.RETRY, 'streamId'),
   };
 }
 

--- a/src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts
+++ b/src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts
@@ -1,51 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { LitSessionRenderer } from '@controllers/progressView/backend/LitSessionRenderer';
+import type { LitSessionRenderer } from '@controllers/progressView/backend/LitSessionRenderer';
 import {
-  buildApprovalRequestHandlerSet,
   cancelApprovalRequestHandlers,
   createProgressBackendUiConfig,
   replayApprovalRequestHandlers,
   type ApprovalRequestHandlerSet,
 } from '@controllers/progressView/backend/progressBackendUiConfig';
-import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import {
-  AgentCategory,
-  type AgentProposalPermission,
-  type ProgressViewOutboundMessage,
-} from '@shared/schemas';
-import { PERMISSION_KIND } from '@shared/utils/uiConstants';
-
-const proposal = {
-  requestId: 'proposal-1',
-  streamId: 'stream-1',
-  agentCategory: AgentCategory.ToolUse,
-  agent: 'search',
-  model: 'deepseekproT',
-  instruction: 'Search for a reference.',
-  memories: [],
-} satisfies AgentProposalPermission;
-
-function recordingHandlers(
-  messages: ProgressViewOutboundMessage[],
-  overrides: Parameters<typeof buildApprovalRequestHandlerSet>[0]['overrides'],
-): ApprovalRequestHandlerSet {
-  // Permission delivery is the only half of the renderer these handlers use;
-  // its projection/snapshot/bridge collaborators are never reached.
-  const unused = undefined as unknown as never;
-  return buildApprovalRequestHandlerSet({
-    renderer: new LitSessionRenderer(
-      unused,
-      unused,
-      unused,
-      (message) => messages.push(message),
-      () => true,
-      () => '',
-    ),
-    canSend: () => true,
-    overrides,
-  });
-}
 
 /** A handler set whose only real member per kind is one spied method. */
 function spyHandlerSet(
@@ -58,46 +19,6 @@ function spyHandlerSet(
 }
 
 describe('ApprovalRequestHandlerSet helpers', () => {
-  it('uses the built-in permission transport for agent proposals by default', () => {
-    const messages: ProgressViewOutboundMessage[] = [];
-    const handlers = recordingHandlers(messages, {
-      retry: { show: vi.fn(), dismiss: vi.fn() },
-    });
-
-    handlers.proposal.show(proposal);
-    expect(messages).toContainEqual({
-      command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
-      action: 'show',
-      permission: { kind: PERMISSION_KIND.PROPOSAL, data: proposal },
-    });
-
-    expect(handlers.proposal.dismiss(proposal.requestId)).toBe(true);
-    expect(messages).toContainEqual({
-      command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
-      action: 'resolve',
-      kind: PERMISSION_KIND.PROPOSAL,
-      id: proposal.requestId,
-    });
-  });
-
-  it('uses an explicit agent proposal transport override when supplied', () => {
-    const messages: ProgressViewOutboundMessage[] = [];
-    const show = vi.fn();
-    const dismiss = vi.fn();
-    const handlers = recordingHandlers(messages, {
-      retry: { show: vi.fn(), dismiss: vi.fn() },
-      proposal: { show, dismiss },
-    });
-
-    handlers.proposal.show(proposal);
-    expect(show).toHaveBeenCalledWith(proposal);
-    expect(messages).toEqual([]);
-
-    expect(handlers.proposal.dismiss(proposal.requestId)).toBe(true);
-    expect(dismiss).toHaveBeenCalledWith(proposal.requestId);
-    expect(messages).toEqual([]);
-  });
-
   it('routes cancellation through the handler named by the interaction kind', () => {
     const cancellationScope = {};
     const request = { streamId: 'stream-1' };

--- a/src/test-kernel/progressView/ProgressThemeSync.vitest.ts
+++ b/src/test-kernel/progressView/ProgressThemeSync.vitest.ts
@@ -94,9 +94,6 @@ vi.mock('@controllers/approval/ToolEditApprovalController', () => ({
     dispose(): void {}
   },
 }));
-vi.mock('@controllers/progressView/backend/agentProposalTransport', () => ({
-  createAgentProposalTransport: () => ({}),
-}));
 vi.mock('@controllers/progressView/backend/progressBackendUiConfig', () => ({
   replayApprovalRequestHandlers: vi.fn(),
 }));

--- a/src/test-kernel/settings/ExtensionWorkspaceTransition.vitest.ts
+++ b/src/test-kernel/settings/ExtensionWorkspaceTransition.vitest.ts
@@ -108,9 +108,6 @@ vi.mock('@controllers/approval/ToolEditApprovalController', () => ({
     dispose(): void {}
   },
 }));
-vi.mock('@controllers/progressView/backend/agentProposalTransport', () => ({
-  createAgentProposalTransport: () => ({}),
-}));
 vi.mock('@controllers/progressView/backend/progressBackendUiConfig', () => ({
   replayApprovalRequestHandlers: vi.fn(),
 }));

--- a/src/test-kernel/support/ProgressControllerHarnesses.ts
+++ b/src/test-kernel/support/ProgressControllerHarnesses.ts
@@ -165,15 +165,9 @@ export function createProgressWorkflowActionsHarness(
   };
 }
 
-/** Approval transport a backend can send through, recording retry/proposal UI. */
+/** Approval transport a backend can send through. */
 export function createApprovalOptions(): ProgressBackendOptions['approvals'] {
-  return {
-    canSend: () => true,
-    overrides: {
-      retry: { show: vi.fn(), dismiss: vi.fn() },
-      proposal: { show: vi.fn(), dismiss: vi.fn() },
-    },
-  };
+  return { canSend: () => true };
 }
 
 /** Host lifecycle callbacks as spies, so a suite asserts on what the backend asked its host to do. */


### PR DESCRIPTION
## Summary

`buildApprovalRequestHandlerSet` accepted an `overrides` bag so a host could
supply its own show/dismiss transport for two of the seven approval kinds. Both
hosts supplied the same two things:

- **retry** — `packages/extension/src/progressView/ProgressViewProvider.ts:123-131`
  and `packages/desktop/src/main/desktopAgentExecution.ts:284-295` are, character
  for character, what `webviewPermissionHandler(renderer, canSend,
  PERMISSION_KIND.RETRY, 'streamId')` already generates
  (`progressBackendUiConfig.ts:156-176`).
- **proposal** — both hosts called `createAgentProposalTransport({ getRenderer:
  () => this.backend.renderer, isPending: (id) =>
  this.backend.approvalHandlers.proposal.get(id) !== undefined })`, identical
  down to the closure bodies.

A seam with no distinct implementations behind it is not a seam. The handler set
now builds all seven arms itself; hosts pass the renderer and the `canSend` gate
and nothing else. The `webviewPermissionHandler(PROPOSAL)` fallback arm — the
"no override supplied" branch — was unreachable in production and is deleted.

**Deliberately NOT absorbed: `agentProposalTransport.ts`.** Its 92 lines are
policy, not forwarding: a two-phase show (static visible-model list immediately,
resolved options after the network), two *different* per-source error fallbacks
(model options fall back to the static list; agent options fall back to
`undefined`, dropping the dropdown), and the `isPending` guard against the
RESOLVE-between-two-SHOWs race that would otherwise leave an undismissable ghost
card. Folding it into a handler-config builder would relocate 85 lines of policy,
not delete them. It keeps its file; its one caller is now internal.

Its lazy `getRenderer(): LitSessionRenderer` port collapses to a plain
`renderer`: the port existed only because hosts wired the transport before
`this.backend` was assigned. Inside `buildApprovalRequestHandlerSet` the
renderer already exists — `ProgressBackend.ts:148` assigns `this.renderer`
before `:158` builds the handler set.

## Issue acceptance gates

n/a — verified subsystem-elimination sweep, no issue.

## Single source of truth

`buildApprovalRequestHandlerSet` (`src/controllers/progressView/backend/progressBackendUiConfig.ts`)
is now the only place any of the seven approval transports is constructed. Before
this PR, retry and proposal were constructed in each host, twice.

## Duplication and abstraction budget

Removed: an override indirection with zero distinct implementations, plus the
duplicated retry and proposal wiring in two hosts. No abstraction added. The one
new local is `proposalTransport`, a `const` inside the builder.

The self-reference (`isPending` reads the handler the transport is passed to) is
expressed as a forward closure over a `const` declared below it — the same lazy
read the hosts did, one level in, and unreachable before the handler exists.

## Net elements (R6)

| | Δ |
|---|---|
| Production files | **0** (`agentProposalTransport.ts` keeps, deliberately) |
| Exports | **0** (`createAgentProposalTransport` keeps its single, now-internal caller) |
| Interfaces | **−2** (`ApprovalHandlerTransport<T>`, `ApprovalRequestHandlerOverrides`) |
| Params fields | **−1** (`BuildApprovalRequestHandlerSetParams.overrides`) |
| Port shape | **−1** (`getRenderer(): LitSessionRenderer` → `renderer: LitSessionRenderer`) |
| Dead branches | **−1** (the `webviewPermissionHandler(PROPOSAL)` ternary arm) |
| Host wiring blocks | **−2** (extension −18 L, desktop −25 L) |
| Host imports | **−2** (`createAgentProposalTransport` in both hosts) |
| Tests deleted | **−2 tests** (both pinned the deleted branch), **−2 `vi.mock` declarations** |
| Tests added | **0** |
| **Net LoC** | **+36 / −187 = −151** (prod ≈ −67, test ≈ −84) |

Honest note on the two deleted tests: the verifier of this candidate suggested
replacing them with one test asserting the proposal handler emits
`UPDATE_PERMISSION/show` carrying `modelOptionsData`. I did **not** add it —
that assertion needs `buildVisibleBasicModelOptionsData()`, which reads
`platform().globalState`, and this suite has no platform bootstrap. Adding one
would mean adding platform mocking to a suite that currently needs none, for a
behavior-preserving refactor whose test budget is zero. The proposal arm is
type-pinned by `ApprovalRequestHandlerSet['proposal']` and exercised through the
`ProgressBackend*` suites, which all construct the real handler set.

## Consumer counts (R8)

```
git grep -n "overrides" -- src/controllers/progressView packages/*/src   # after: 0 approval hits
git grep -n "createAgentProposalTransport"
    # before: 2 host imports + 2 vi.mock + the definition
    # after:  1 import (progressBackendUiConfig.ts) + the definition
git grep -n "ApprovalHandlerTransport\|ApprovalRequestHandlerOverrides"   # after: 0
git grep -n "getRenderer"                                                 # after: 0
git grep -rn "agentProposalTransport" -- src packages
    # after: definition + progressBackendUiConfig import only
grep -rn "agentProposalTransport\|progressBackendUiConfig\|contentStore" config/ratchets/*.json
    # 0 hits in all six baselines — no ratchet is engaged
```

`new ProgressBackend` sites re-checked: 2 production
(`ProgressViewProvider.ts:108`, `desktopAgentExecution.ts:262`) and 5 test
constructions, all five funnelling through `createApprovalOptions()`
(`src/test-kernel/support/ProgressControllerHarnesses.ts:169`), which is updated
in this PR.

## Host impact

Extension: `ProgressViewProvider` no longer hand-wires retry or proposal
transports. Same permission cards, same messages.

Desktop: `DesktopProgressBridge` likewise. The desktop comment claiming the
retry override exists "so the card has to be shown" was describing behavior the
shared `webviewPermissionHandler` already provides identically.

CLI: none — the CLI does not build an `ApprovalRequestHandlerSet`.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean (all six projects).
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — 8 current vs 8 baselined, OK.
- `npx vitest run src/test-kernel/progressView src/test-kernel/settings/ExtensionWorkspaceTransition.vitest.ts src/test-kernel/desktop/DesktopHostInteractions.vitest.ts src/test-kernel/agent/runtime/SessionInteractions.vitest.ts src/test-kernel/architecture/transcriptResidencyLeaseSites.vitest.ts`
  — 65 files, 613 tests, all pass.
- Re-ran the nine directly affected suites after the final edit — 9 files, 129
  tests, all pass.
- No webview render change: this PR touches only backend wiring; the permission
  payloads on the wire are byte-identical.
