### PR TITLE
refactor(tools): run background bash through childRunLoop

### DIFF
--- a/docs/proposals/2026-08-15-lifecycle-ownership.md
+++ b/docs/proposals/2026-08-15-lifecycle-ownership.md
@@ -221,8 +221,10 @@ its dormant `clearInlineAgents` export), desktop UsageLogService absence
 ## 4. Child work: subagents, background tasks, bash — the consistency matrix
 
 Second workflow, separately verified. The substrate is **consistent by
-construction**: one driver (`childRunLoop`) for all four child types
-(native detached, in-band/grandchild, workflow-script, agent-CLI), one
+construction**: one driver (`childRunLoop`) for all five child types
+(native detached, in-band/grandchild, workflow-script, agent-CLI, background
+shell — the fifth was a hand-rolled driver until it was folded in; the same
+wake-after-finalize bug had to be fixed twice, once in each copy), one
 lease protocol with three-layer double-ownership defense and working
 cross-host orphan adoption, host-invariant terminal persistence and
 parent-wake-after-finalize ordering, `registerAgentShutdownHandlers` wired

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -310,10 +310,10 @@ export class AgentExecutionHandle {
    * Interrupt this handle's attached background OS process, if any — the
    * case shutdown drain needs, distinct from `interrupt()`'s general stop
    * (which also covers a loop-level or in-flight-turn interrupt handler that
-   * must stay untouched on shutdown so restart recovery can find it). A
-   * background bash run (`BashBackgroundSession`, see `tools/bash.ts`) is the
-   * only handler that currently sets `ownsBackgroundProcess`. Returns whether
-   * a background-process interrupt handler was attached and interrupted.
+   * must stay untouched on shutdown so restart recovery can find it). Only a
+   * child-run loop whose strategy declares `ownsBackgroundProcess` sets this —
+   * background bash is the one that does. Returns whether a background-process
+   * interrupt handler was attached and interrupted.
    */
   interruptBackgroundProcess(): boolean {
     if (this.interruptHandler?.ownsBackgroundProcess !== true) return false;

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -1,7 +1,7 @@
 // One driver for every child-run type (agent-CLI codex/claude sessions, native
-// subagents of either category, workflow-script runs). Each turn source
-// supplies an AgentCliSessionStrategy-shaped ChildRunStrategy; this loop is the
-// single owner of everything a driver does NOT vary: follow-up queue
+// subagents of either category, workflow-script runs, background shells). Each
+// turn source supplies a ChildRunStrategy; this loop is the single owner of
+// everything a driver does NOT vary: follow-up queue
 // acquire/drain, one run-handle interrupt target for the child's whole
 // lifetime, per-turn delivery choreography (format → persist report → optional
 // manifest → deliver with wake), and the terminal call into the shared
@@ -21,6 +21,7 @@ import type {
 import {
   onOwnedExecutionLeaseLost,
   captureOwnedExecutionLease,
+  markOwnedExecutionLeaseUndurable,
 } from '@agent/storage/executionLease';
 import {
   currentSession,
@@ -138,8 +139,10 @@ interface ChildStreamPort {
     outcome?: ChildRunOutcome;
     /** Session stage closed with the derived outcome (the loop's stage). */
     stage?: Pick<StageHandle, 'end'>;
-    /** Durable execution-state action; background bash owns its richer block. */
+    /** Durable execution-state action. */
     persistence?: RunTerminalPersistence;
+    /** Drop the child's tab once finalized (ephemeral process children). */
+    autoClose?: boolean;
   }): Promise<void>;
 }
 
@@ -165,6 +168,32 @@ interface ChildStreamPort {
 export interface ChildRunStrategy<TTurn> {
   /** Stage label opened on the child trace (e.g. "Codex session"). */
   readonly stageLabel: string;
+
+  /**
+   * This child's turns drive a live OS process, so the loop's interrupt
+   * handler tears one down. Shutdown drain reads it off the handle to reach a
+   * leaked process (`ExecutionRegistry.killBackgroundProcesses`) without
+   * disturbing agent children that are deliberately left running for restart
+   * recovery — see `ExecutionInterruptHandler.ownsBackgroundProcess`.
+   */
+  readonly ownsBackgroundProcess?: boolean;
+
+  /**
+   * Drop the child's stream tab when the run finalizes. For a child whose tab
+   * is ephemeral by construction (a background shell), the tab exists only
+   * while the process does; every other child type keeps its tab for reading
+   * back.
+   */
+  readonly autoCloseChildStream?: boolean;
+
+  /**
+   * Deliver a settled turn to the parent even when the loop was interrupted.
+   * Default (and right for every agent child) is not to: an interrupted turn
+   * has no result to report. A killed OS process is the exception — it still
+   * reports a complete result (exit code plus the output it produced), and a
+   * parent suspended on that job would otherwise never be told it ended.
+   */
+  readonly deliverAfterInterrupt?: boolean;
 
   /**
    * `persistOnly` records the terminal report without routing it to a parent.
@@ -356,6 +385,12 @@ class ChildRunInterruptible implements ExecutionInterruptHandler {
   constructor(
     private readonly session: SessionHandle,
     private readonly childStreamId: StreamTabId,
+    /**
+     * Only a strategy that declares `ownsBackgroundProcess` sets this: a
+     * loop-level handler for an agent child must stay invisible to shutdown
+     * drain so restart recovery still finds it (#8155).
+     */
+    readonly ownsBackgroundProcess: boolean,
   ) {}
 
   interrupt(): void {
@@ -489,6 +524,12 @@ function resolveLoopTerminationCause(
  * logical identity, the follow-up queue owner/generation, and the interruption
  * cause into one event so a resumed/interrupted child's state is auditable.
  * Emitted at turn acceptance, delivery, and loop termination.
+ *
+ * Debug level: this is the loop's own bookkeeping, not the child's narrative.
+ * A child stream tab renders what its provider produced — for a background
+ * shell that tab IS the terminal, and `/executions/{id}/output` states that it
+ * projects command output rather than run bookkeeping. Debug mode keeps the
+ * audit trail for the case that motivated it.
  */
 function emitTurnDiagnostic(
   logger: AgentTrace,
@@ -501,7 +542,7 @@ function emitTurnDiagnostic(
   },
 ): void {
   const { executionId, turnRef, queueOwner, interruptionCause } = params;
-  logger.info(`childRunLoop ${event}`, {
+  logger.debug(`childRunLoop ${event}`, {
     data: {
       executionId,
       ...(turnRef
@@ -746,7 +787,11 @@ export function startChildRunLoop<TTurn>(
   // progress or results from this child must not enter the replacement queue.
   const parentDeliveryGenerationId =
     runSession.followUps.currentGenerationId(parentStreamId);
-  const loop = new ChildRunInterruptible(runSession, childStreamId);
+  const loop = new ChildRunInterruptible(
+    runSession,
+    childStreamId,
+    strategy.ownsBackgroundProcess === true,
+  );
   let activationDetached = false;
   const releaseChildActivation = childStream
     ? () => undefined
@@ -983,7 +1028,7 @@ export function startChildRunLoop<TTurn>(
             if (activationDetached) return false;
             if (loop.isInterrupted()) {
               releaseSessionOwnershipOnce();
-              return false;
+              return strategy.deliverAfterInterrupt === true;
             }
             if (turnFailed) {
               releaseSessionOwnershipOnce();
@@ -1038,6 +1083,16 @@ export function startChildRunLoop<TTurn>(
         runner = (ac) => nextRunTurn(batch.items, ports, ac);
         childStream?.beginTurn();
       }
+    } catch (error) {
+      // A throw from the loop body itself — delivery formatting, report
+      // persistence, the queue wait — is this run's failure. Without this the
+      // terminal block below would finalize a child that never delivered as
+      // COMPLETED, and the abandoned generation would still look durably
+      // released.
+      sawTurnFailure = true;
+      lastTurnErr ??= error;
+      markOwnedExecutionLeaseUndurable(executionId);
+      throw error;
     } finally {
       // A retry may reuse this execution ID as soon as its lease is released.
       // Drain the prior attempt's queued attribution writes first so an old
@@ -1086,6 +1141,7 @@ export function startChildRunLoop<TTurn>(
             outcome: loopOutcome,
             stage: sessionStage,
             persistence: { kind: 'finalize', flowRecord: 'delete' },
+            ...(strategy.autoCloseChildStream === true && { autoClose: true }),
           });
         } else {
           // Native: every GENUINE terminal turn already finalized its own

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -341,7 +341,7 @@ describe('executionRegistry', () => {
   it('drains a background-bash AgentExecutionHandle on shutdown without disturbing a resumable agent execution (issue #8155)', () => {
     // A background `bash` run is registered as an AgentExecutionHandle (see
     // createChildStream in tools/bash.ts) with its OS-process kill reachable
-    // only via the interrupt handler BashBackgroundSession attaches. The two
+    // only via the interrupt handler a background-process child attaches. The two
     // AgentExecutionHandles below are tracked concurrently, mirroring the real
     // interleaving at shutdown: a background bash child stream alongside an
     // ordinary resumable agent execution (e.g. a native subagent loop, whose
@@ -362,7 +362,7 @@ describe('executionRegistry', () => {
 
     try {
       // Background bash: an AgentExecutionHandle whose attached interrupt
-      // handler owns a live OS process (mirrors BashBackgroundSession).
+      // handler owns a live OS process (mirrors background bash's child run).
       const bashHandle = createHandle(
         bashExecutionId,
         bashParentStreamId,

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -224,8 +224,8 @@ describe('ExecutionsTool /executions/{id}/output', () => {
     const result = await readOutput(run.executionId);
     const output = result.output ?? '';
 
-    assert.ok(output.includes('tail without newline\nCompleted in '));
-    assert.ok(!output.includes('tail without newlineCompleted in '));
+    assert.ok(output.includes('tail without newline\nTurn completed in '));
+    assert.ok(!output.includes('tail without newlineTurn completed in '));
   });
 
   it('joins chunks that split a line and pages the projection with view_range', async () => {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -2,14 +2,8 @@
 import { z } from 'zod';
 
 // Local imports
-import { registerExecution } from '@agent/storage';
-import { persistChildRunDeliveryBestEffort } from '@agent/storage/childRunDeliveryPersistence';
-import {
-  captureOwnedExecutionLease,
-  markOwnedExecutionLeaseUndurable,
-  onOwnedExecutionLeaseLost,
-  runWithOwnedExecutionLeaseLaunchGuard,
-} from '@agent/storage/executionLease';
+import type { AgentTrace } from '@agent/trace';
+import { registerOwnedExecution } from '@agent/storage/executionLifecycle';
 import {
   TOOL_RESULT_TRUNCATION_HEAD_CHARS,
   TOOL_RESULT_TRUNCATION_TAIL_CHARS,
@@ -18,14 +12,11 @@ import {
   getCurrentToolContexts,
   type ToolCallContext,
 } from '@agent/followUp/ToolFileInteractionContext';
-import { deliverChildRunFollowUp } from '@agent/followUp/childRunDelivery';
-import type { RunTerminalPersistence } from '@agent/runtime/AgentRunLifecycle';
-import type { ExecutionInterruptHandler } from '@agent/runtime/ExecutionHandle';
+import type { ChildRunStrategy } from '@agent/runtime/childRunLoop';
 import {
   getRunContextExecutionId,
   getRunContextWorkingDirectory,
 } from '@agent/runtime/RunContext';
-import { currentSession } from '@agent/runtime/SessionHandle';
 import {
   BASH_CHILD_STREAM_PREFIX,
   getStreamTabId,
@@ -40,6 +31,7 @@ import {
 import {
   AgentCategory,
   ToolError,
+  type ExecResult,
   type ExecutionId,
   type StreamTabId,
   type ToolResult,
@@ -67,8 +59,8 @@ import { nullishWithDefault } from './core/inputSchema';
 import {
   childStreamDescription,
   createChildStream,
-  type ChildStream,
 } from './delegation/childStream';
+import { startDetachedChildRunLoop } from './delegation/detachedChildRun';
 import { parseWorkingDirectory } from './pathResolution';
 
 const BACKGROUND_OUTPUT_TAIL_CHARS = 12_000;
@@ -87,18 +79,6 @@ const SHELL_BACKGROUNDING_PATTERN =
 const SHELL_BACKGROUNDING_MESSAGE =
   'This command uses shell-level backgrounding (`nohup ... &`) inside a foreground bash tool call. ' +
   'Do not emulate background execution inside the shell; call the bash tool again with `run_in_background: true` and the command without `nohup` or a trailing `&`.';
-
-/**
- * A background command's durable terminal state is written by the shared
- * finalizer, from the outcome the stream phase resolved. Deriving it here from
- * the process exit alone would record ERROR for a command the user killed:
- * the kill lands CANCELLED on the phase and only then does the process exit
- * non-zero. There is no flow to resume, so the record is always dropped.
- */
-const BACKGROUND_TERMINAL_PERSISTENCE: RunTerminalPersistence = {
-  kind: 'finalize',
-  flowRecord: 'delete',
-};
 
 interface BoundedOutputCapture {
   append(chunk: string): void;
@@ -256,23 +236,123 @@ const BashInputSchema = z.strictObject({
 type BashInput = z.infer<typeof BashInputSchema>;
 
 /**
- * Interrupt handle for a background bash run. Termination is delegated to
- * `executeCommand`'s own abort-signal path (SIGTERM → SIGKILL escalation,
- * stream cleanup) rather than duplicating a kill ladder here — see
- * `executeCommand`'s `terminateSubprocess`.
+ * The child-run strategy for one background shell command: a single terminal
+ * turn that runs the process, streams its output into the child's tab, and
+ * hands the loop the formatted delivery and result manifest. Everything else a
+ * background child needs — the follow-up queue claim, the wake-aware parent
+ * delivery, report persistence, the interrupt target, and terminal
+ * finalization — is the loop's, exactly as it is for every other child type.
  */
-class BashBackgroundSession implements ExecutionInterruptHandler {
-  /** Shutdown drain reaches this handler via `interruptBackgroundProcess()`. */
-  readonly ownsBackgroundProcess = true;
-  private readonly abortController = new AbortController();
+function createBackgroundBashStrategy(params: {
+  executionId: ExecutionId;
+  command: string;
+  timeoutMs: number;
+  cwd: string | undefined;
+  logger: AgentTrace;
+}): ChildRunStrategy<ExecResult> {
+  const { executionId, command, logger } = params;
+  // Whitespace normalization is off here: a background log is delivered
+  // verbatim, and its head/tail budgets are its own (see the constants above)
+  // rather than the foreground tool-result ones.
+  const captureOptions = { normalizeWhitespace: false };
+  const stdout = createBoundedOutputCapture(
+    BACKGROUND_OUTPUT_HEAD_CHARS,
+    BACKGROUND_OUTPUT_TAIL_CHARS,
+    captureOptions,
+  );
+  const stderr = createBoundedOutputCapture(
+    BACKGROUND_OUTPUT_HEAD_CHARS,
+    BACKGROUND_OUTPUT_TAIL_CHARS,
+    captureOptions,
+  );
+  let loggedChars = 0;
+  let logCapReached = false;
+  const logChunk = (chunk: string, level: 'info' | 'warn'): void => {
+    if (logCapReached) return;
+    loggedChars += chunk.length;
+    if (loggedChars > BASH_BACKGROUND_LOG_CAP_CHARS) {
+      logCapReached = true;
+      logger.warn(
+        `[Stream log truncated at ${(BASH_BACKGROUND_LOG_CAP_CHARS / 1000).toFixed(0)}k chars: tail available in follow-up result]`,
+      );
+      return;
+    }
+    logger[level](chunk, {
+      data: backgroundBashOutputData(level === 'warn' ? 'stderr' : 'stdout'),
+    });
+  };
 
-  get signal(): AbortSignal {
-    return this.abortController.signal;
-  }
+  let startedAt = Date.now();
+  const delivery = (result: ExecResult, wallTimeMs: number): string =>
+    formatBashDelivery(
+      executionId,
+      command,
+      wallTimeMs,
+      result,
+      toDeliveryExcerpt(stdout),
+      toDeliveryExcerpt(stderr),
+    );
 
-  interrupt(): void {
-    this.abortController.abort();
-  }
+  return {
+    stageLabel: 'Background command',
+    // A background shell is the one child type that owns a live OS process and
+    // whose tab is ephemeral, and the one whose result survives its own kill.
+    ownsBackgroundProcess: true,
+    autoCloseChildStream: true,
+    deliverAfterInterrupt: true,
+
+    launch: (_ports, abortController) => {
+      startedAt = Date.now();
+      return executeCommand(command, {
+        ...(params.cwd !== undefined && { cwd: params.cwd }),
+        timeout: params.timeoutMs,
+        buffer: false,
+        // String form + explicit shell teardown: abort/timeout signal the
+        // whole process group so backgrounded jobs and piped children are
+        // torn down rather than left running.
+        mode: 'shell',
+        signal: abortController.signal,
+        onStdout: (chunk) => {
+          stdout.append(chunk);
+          logChunk(chunk, 'info');
+        },
+        onStderr: (chunk) => {
+          stderr.append(chunk);
+          logChunk(chunk, 'warn');
+        },
+      });
+    },
+
+    isTerminal: () => true,
+    // `executeCommand` never rejects on a non-zero exit — it resolves with the
+    // exit code, so the failure is an application-level one.
+    isTurnError: (turn) => !turn.success,
+    onTurnError: (turn, turnLogger) =>
+      turnLogger.error(
+        `Background bash failed with exit code ${turn.exitCode}.`,
+      ),
+
+    formatDelivery: (turn, wallTimeMs) => delivery(turn, wallTimeMs),
+    // A failed exit still produced real output: deliver the full excerpt, not
+    // the bare error form. `formatBashError` is only for a throw, where there
+    // is no result to report.
+    formatError: (turn, err) =>
+      turn
+        ? delivery(turn, Date.now() - startedAt)
+        : formatBashError(executionId, command, err),
+
+    buildResultMeta: (turn, _isError, wallTimeMs) =>
+      turn
+        ? {
+            producer: 'backgroundBash' as const,
+            exitCode: turn.exitCode,
+            wallTimeMs,
+            success: turn.success,
+            timedOut: turn.timedOut,
+            command,
+          }
+        : undefined,
+  };
 }
 
 export class BashTool extends defineTool({
@@ -405,8 +485,10 @@ export class BashTool extends defineTool({
     cwd?: string,
   ): Promise<ToolResult> {
     const executionId = generateExecutionId();
-
     const preview = truncateWithEllipsis(command, 60);
+    const childStreamId = getStreamTabId(BASH_CHILD_STREAM_PREFIX, {
+      executionId,
+    });
 
     const syntheticConfig = AgentConfigSchema.parse({
       agent: 'bash',
@@ -417,237 +499,58 @@ export class BashTool extends defineTool({
     // The durable record states only what a shell command has: no execution
     // mode, no model. The synthetic AgentConfig above feeds the ephemeral
     // live wire only.
-    await registerExecution(
+    const runWithOwnership = await registerOwnedExecution(
       executionId,
       { name: 'bash', instruction: command },
       'bash',
       {
-        streamId: getStreamTabId(BASH_CHILD_STREAM_PREFIX, { executionId }),
+        streamId: childStreamId,
         identity: { kind: 'process', tool: 'bash' },
         userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
         parentExecutionId,
         description: childStreamDescription(command),
       },
     );
-    const runWithOwnership = captureOwnedExecutionLease(executionId);
 
-    let childStream!: ChildStream;
-    await runWithOwnedExecutionLeaseLaunchGuard(executionId, () => {
-      runWithOwnership(() => {
-        childStream = createChildStream(executionId, parentStreamId, {
-          streamPrefix: BASH_CHILD_STREAM_PREFIX,
-          run: { kind: 'process', tool: 'bash' },
-          userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
-          description: command,
-          config: syntheticConfig,
-        });
-      });
-    });
-    const { childStreamId, logger } = childStream;
-    // Whitespace normalization is off here: a background log is delivered
-    // verbatim, and its head/tail budgets are its own (see the constants
-    // above) rather than the foreground tool-result ones.
-    const stdout = createBoundedOutputCapture(
-      BACKGROUND_OUTPUT_HEAD_CHARS,
-      BACKGROUND_OUTPUT_TAIL_CHARS,
-      { normalizeWhitespace: false },
-    );
-    const stderr = createBoundedOutputCapture(
-      BACKGROUND_OUTPUT_HEAD_CHARS,
-      BACKGROUND_OUTPUT_TAIL_CHARS,
-      { normalizeWhitespace: false },
-    );
-    let loggedChars = 0;
-    let logCapReached = false;
-    // Capture the run's session inside the tool's ALS; deliverAndFinalize below
-    // unregisters after the process ends, possibly outside the ALS.
-    const runSession = currentSession();
-    const parentDeliveryGenerationId =
-      runSession.followUps.currentGenerationId(parentStreamId);
-    const session = new BashBackgroundSession();
-    const stopWatchingLease = onOwnedExecutionLeaseLost(executionId, () => {
-      logger.error('Execution lease was lost; stopping background command', {
-        data: { executionId, childStreamId },
-      });
-      session.interrupt();
-    });
-    const detachInterruptHandler =
-      runSession.executions
-        .getAgentHandleByStream(childStreamId)
-        ?.attachInterruptHandler(session) ?? (() => {});
-
-    const logChunk = (chunk: string, level: 'info' | 'warn'): void => {
-      if (logCapReached) return;
-      loggedChars += chunk.length;
-      if (loggedChars > BASH_BACKGROUND_LOG_CAP_CHARS) {
-        logCapReached = true;
-        logger.warn(
-          `[Stream log truncated at ${(BASH_BACKGROUND_LOG_CAP_CHARS / 1000).toFixed(0)}k chars: tail available in follow-up result]`,
-        );
-        return;
-      }
-      logger[level](chunk, {
-        data: backgroundBashOutputData(level === 'warn' ? 'stderr' : 'stdout'),
-      });
-    };
-
-    const startedAt = Date.now();
-    const promise = Promise.resolve(
-      runWithOwnership(() =>
-        executeCommand(command, {
-          cwd,
-          timeout: timeoutMs,
-          buffer: false,
-          // String form + explicit shell teardown: abort/timeout signal the
-          // whole process group so backgrounded jobs and piped children are
-          // torn down rather than left running.
-          mode: 'shell',
-          signal: session.signal,
-          onStdout: (chunk) => {
-            stdout.append(chunk);
-            logChunk(chunk, 'info');
-          },
-          onStderr: (chunk) => {
-            stderr.append(chunk);
-            logChunk(chunk, 'warn');
-          },
-        }),
-      ),
-    );
-
-    const logBackgroundFailure = (action: string, err: unknown): void => {
-      logger.error(`Failed to ${action} background bash result`, {
-        data: err,
-      });
-    };
-    const logPersistFailure = (
-      kind: 'report' | 'result manifest',
-      err: unknown,
-    ): void => logBackgroundFailure(`persist ${kind}`, err);
-
-    let childFinalized = false;
-    const finalizeChild = async (
-      finalizeOptions: Parameters<typeof childStream.finalize>[0],
-    ): Promise<void> => {
-      // The child is terminal before the continuation is submitted, so a
-      // synchronously claimed parent recovery can never observe it as running.
-      detachInterruptHandler();
-      await childStream.finalize(finalizeOptions);
-      childFinalized = true;
-    };
-
-    const deliverAndFinalize = async (
-      text: string,
-      finalizeOptions: Parameters<typeof childStream.finalize>[0],
-    ): Promise<void> => {
-      await finalizeChild(finalizeOptions);
-      try {
-        const delivery = await deliverChildRunFollowUp({
-          targetStreamId: parentStreamId,
-          followUp: { text, origin: 'subagent_result' },
-          session: runSession,
-          expectedGenerationId: parentDeliveryGenerationId,
-        });
-        if (delivery.kind !== 'delivered') {
-          logger.warn(
-            'Background bash follow-up dropped: parent stream is unavailable.',
-            { data: { parentStreamId } },
-          );
-        }
-      } catch (err: unknown) {
-        logBackgroundFailure('delivery', err);
-      }
-    };
-
-    void runWithOwnership(async () => {
-      try {
-        const outcome = await promise.then(
-          (result) => ({ ok: true as const, result }),
-          (error: unknown) => ({ ok: false as const, error }),
-        );
-
-        if (outcome.ok) {
-          const { result } = outcome;
-          const wallTimeMs = Date.now() - startedAt;
-          const error = result.success
-            ? undefined
-            : new ToolError(
-                `Background bash failed with exit code ${result.exitCode}.`,
-              );
-
-          const msg = formatBashDelivery(
-            executionId,
-            command,
-            wallTimeMs,
-            result,
-            toDeliveryExcerpt(stdout),
-            toDeliveryExcerpt(stderr),
-          );
-
-          await persistChildRunDeliveryBestEffort(
-            executionId,
-            msg,
-            {
-              producer: 'backgroundBash',
-              exitCode: result.exitCode,
-              wallTimeMs,
-              success: result.success,
-              timedOut: result.timedOut,
-              command,
-            },
-            logPersistFailure,
-          );
-
-          await deliverAndFinalize(msg, {
-            wallTimeMs,
-            outcome: error ? { kind: 'failed', error } : { kind: 'completed' },
-            persistence: BACKGROUND_TERMINAL_PERSISTENCE,
-            autoClose: true,
+    await runWithOwnership(() =>
+      startDetachedChildRunLoop({
+        executionId,
+        parentStreamId,
+        childStreamId,
+        agentName: 'bash',
+        // A background shell is an external process on no model budget, like
+        // the agent-CLI children (see the child-run concurrency budget note).
+        budgeted: false,
+        buildLaunch: async () => {
+          const childStream = createChildStream(executionId, parentStreamId, {
+            streamPrefix: BASH_CHILD_STREAM_PREFIX,
+            run: { kind: 'process', tool: 'bash' },
+            userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
+            description: command,
+            config: syntheticConfig,
           });
-          return;
-        }
-
-        const { error } = outcome;
-        const msg = formatBashError(executionId, command, error);
-        await persistChildRunDeliveryBestEffort(
-          executionId,
-          msg,
-          undefined,
-          logPersistFailure,
-        );
-
-        await deliverAndFinalize(msg, {
-          outcome: { kind: 'failed', error },
-          persistence: BACKGROUND_TERMINAL_PERSISTENCE,
-          autoClose: true,
-        });
-      } catch (err: unknown) {
-        markOwnedExecutionLeaseUndurable(executionId);
-        logBackgroundFailure('complete', err);
-        // Nothing else finalizes a background child, so an unexpected throw
-        // before the normal finalize would leave the stream RUNNING forever
-        // and its interrupt handler attached to a dead process.
-        if (!childFinalized) {
-          try {
-            await finalizeChild({
-              outcome: { kind: 'failed', error: err },
-              persistence: BACKGROUND_TERMINAL_PERSISTENCE,
-              autoClose: true,
-            });
-          } catch (finalizeError: unknown) {
-            logBackgroundFailure('finalize after failure', finalizeError);
-          }
-        }
-      } finally {
-        try {
-          await runSession.releaseExecutionLease(executionId);
-        } catch (err: unknown) {
-          logBackgroundFailure('persist final artifacts', err);
-        } finally {
-          stopWatchingLease();
-        }
-      }
-    });
+          return {
+            childStream,
+            strategy: createBackgroundBashStrategy({
+              executionId,
+              command,
+              timeoutMs,
+              cwd,
+              logger: childStream.logger,
+            }),
+            // Nobody awaits this run: own late loop failures here as trace
+            // diagnostics, since the loop already owns its one user-facing
+            // result delivery.
+            onLoopFailed: (error: unknown): void => {
+              childStream.logger.error(
+                'Background command run loop failed after launch',
+                { data: error },
+              );
+            },
+          };
+        },
+      }),
+    );
 
     return executed(
       [

--- a/src/tools/delegation/childStream.ts
+++ b/src/tools/delegation/childStream.ts
@@ -59,7 +59,7 @@ interface FinalizeChildStreamOptions {
   outcome?: ChildStreamOutcome;
   /** Session stage closed with the derived outcome (agent-CLI loop's stage). */
   stage?: Pick<StageHandle, 'end'>;
-  /** Durable execution-state action; background bash owns its richer block. */
+  /** Durable execution-state action. */
   persistence?: RunTerminalPersistence;
   /** Remove the child stream tab from the progress view once finalized. */
   autoClose?: boolean;


### PR DESCRIPTION
> Was stacked on #11053, which has since merged. Rebased onto `main` with
> `--onto`, replaying only this PR's commit so the merged identity change is
> taken from `main` rather than reconciled against a second copy of itself.
> The resulting patch is **content-identical** to the pre-rebase one — the only
> difference is hunk line offsets in `childRunLoop.ts` (all −1, from an
> unrelated import deletion upstream). Gates re-run after the rebase, not
> assumed.

## Summary

Background bash is a fifth child-run type living outside `childRunLoop`. It
registers its own execution (`bash.ts:418`), captures its own owned lease
(`:430`), opens its own child stream tab (`:435`), delivers its own parent
follow-up (`:543`), persists its own report and result manifest (`:585`),
finalizes itself (`:533`) and releases its own lease (`:641`). Every other
child type — native detached, in-band/grandchild, workflow-script, agent-CLI —
gets all of that from the loop.

The cost of that duplication is in git, not in inference: **one bug, fixed
twice, in two files, in one commit.**

```
ab42235d8f 2026-07-12  fix(agent): finalize child before waking resumed parent turn
  src/agent/runtime/childRunLoop.ts   |  97 +++++---
  src/tools/bash.ts                   |  86 ++++-----
581f9e7b7c 2026-07-11  fix(tools): wake WAITING parent on background bash delivery
  src/tools/bash.ts                   |  30 +++---
```

The first commit hand-ported the loop's wake step into bash; the next day's
commit hand-ported the loop's #8093 ordering into bash. The test at
`BashTool.vitest.ts:697-702` says so in prose: *"background bash delivery used
a bespoke sendFollowUp call with no wake step … every other child-run type
routes through the shared wake-aware `deliverChildRunFollowUp` path."*

`executeBackground` now does exactly what `WorkflowScriptTool.ts:493-580`
does: `registerOwnedExecution` (which is literally the `registerExecution` +
`captureOwnedExecutionLease` pair bash inlined), then
`startDetachedChildRunLoop` with a terminal-only strategy, then return the
"launched" `ToolResult` immediately. Launch stays non-blocking —
`startDetachedChildRunLoop` awaits only `buildLaunch`.

## Issue acceptance gates

No issue. A finding from a verified dual-systems sweep; independently found and
verified by a second sweep on a different axis.

## Single source of truth

`childRunLoop` is now the only child-run driver, for all five child types.
`docs/proposals/2026-08-15-lifecycle-ownership.md:224` asserted "one driver for
all **four** child types" while the code had five — corrected in this PR, since
a doc asserting an invariant the code violates is how this stayed unnoticed.

## Duplication and abstraction budget

**Removed** from `bash.ts`: `class BashBackgroundSession`;
`BACKGROUND_TERMINAL_PERSISTENCE` (diffed against `childRunLoop.ts:1088` —
byte-identical `{kind:'finalize', flowRecord:'delete'}`, so the port comment
calling bash's block "richer" was provably stale and is deleted too);
`logBackgroundFailure`/`logPersistFailure`/`finalizeChild`/`deliverAndFinalize`;
the `childFinalized` latch; the `parentDeliveryGenerationId` capture; the
lease-lost watch; the interrupt-handler attach/detach; the outer
`void runWithOwnership(async () => …)` try/catch/finally; the lease release.
Nine imports drop.

**Kept, moved into the strategy**: `toDeliveryExcerpt`, the head/tail budgets,
the stream-log cap logic, and `bashDelivery.ts` (untouched — announcing it
stays where it is, for the concurrent sweep looking at `src/tools/delegation/`).

**Added**: three optional `ChildRunStrategy` fields, each naming a real
capability difference rather than special-casing bash inside the loop:

| Field | Why bash needs it | Default |
|---|---|---|
| `ownsBackgroundProcess` | shutdown drain must reach a live OS process (`ExecutionRegistry.killBackgroundProcesses`); an agent child must stay untouched so restart recovery finds it (#8155) | off |
| `autoCloseChildStream` | a shell tab is ephemeral by construction (`SessionStores.ts:675`); every other child keeps its tab | off |
| `deliverAfterInterrupt` | a killed shell still reports a complete result — exit code plus its output | off |

`ChildStreamPort.finalize` gains `autoClose?: boolean` (the concrete
`ChildStream` already supported it; only the port lacked it).

**Not done, deliberately** — the adjacent `launchAgentCliSession` →
`startDetachedChildRunLoop` routing. It is refuted on its own merits: agent-CLI
children mint their stream id from a tool prefix precisely because they have no
`buildAgentLaunchContext` reservation to match, so the divergence is deserved,
and the payload is ~−15 LOC across three files.

## Two loop fixes that ride along

Both were exposed by folding bash in; both apply to all five child types.

1. **A throw from the loop body is now this run's failure — a pre-existing
   latent defect, not one this fold introduces.** `deliverTurn`, report
   persistence and the queue wait sit inside a `try/finally` with **no
   `catch`**. `sawTurnFailure` is only set on the `turnFailed` break path, so a
   `strategy.formatDelivery` (or `persistChildRunDeliveryBestEffort`, or
   `queue.waitAndDrainAll`) that throws reaches the terminal block with
   `sawTurnFailure === false` and finalizes the child as **COMPLETED** — a
   silent wrong-state outcome for a run that never delivered anything.

   **This is true on `main` today for workflow-script and agent-CLI children.**
   It is not a regression created here; folding bash in is only what exposed
   it, because `BashTool.vitest.ts:819` pins FAILED for exactly this case and
   bash got that guarantee from its own `childFinalized` latch — the very latch
   this PR deletes. Had the loop been left alone, that test would have gone red
   and the fold would have shipped a silent regression; fixing the loop is what
   keeps it honest.

   Note this contradicts a claim made during verification of this candidate,
   which asserted that "the loop's `finally` guarantees finalize even when
   `strategy.formatDelivery` throws, which is exactly what
   `BashTool.vitest.ts:819` pins". The loop does finalize — but as COMPLETED.
   Recorded here so the claim is not re-derived.

   The loop now records the throw as the failure and marks the lease undurable
   (`markOwnedExecutionLeaseUndurable`, which bash did and the loop did not),
   then rethrows. Net effect for the other four child types: a workflow-script
   or agent-CLI child whose delivery formatting or report write throws now
   reports FAILED with its cause instead of COMPLETED with none.

2. **`childRunLoop turn.*` diagnostics drop from info to debug.** They are the
   loop's own bookkeeping. `processOutput.ts:41-48` states that
   `/executions/{id}/output` "projects command output, not run bookkeeping" —
   at info level these lines rendered *as command output* in a shell tab and
   shifted every line count (6 `ExecutionsToolOutput` tests caught it). Debug
   mode still keeps the #9531 audit trail.

## Behavior changes, stated plainly

- **Uniform now, different before**: a background bash child gains a
  `deliveryId` on its follow-up (admission-controlled), a persisted turn ledger
  (`lastCompletedTurn`), a follow-up queue claim, a `Background command` stage
  in its tab, and the loop's `Turn completed in Xs` instead of bash's
  `Completed in Xs` (one `ExecutionsToolOutput` assertion updated for the
  wording; it pins the newline separation, which is unchanged).
- **A non-throwing failed turn's finalize error message** becomes the loop's
  generic `Background command reported a failed turn without throwing.` The
  precise cause — `Background bash failed with exit code N.` — is still logged
  into the same tab by the strategy's `onTurnError`, and is still carried in
  the delivered follow-up.
- **Delivery on kill is preserved**, via `deliverAfterInterrupt`. Without the
  opt-in the loop's `prepareParentDelivery` hard-returns false while
  interrupted, and since `executions.kill(childId)` kills only the child, a
  parent suspended on that job would have stalled with no notification. This
  was the one behavior ruling both verifications flagged; preserving today's
  behavior was chosen over aligning, and the alternative is a one-line change
  if a maintainer prefers it.
- `budgeted: false` is passed explicitly, reproducing today's unbudgeted
  behavior (`docs/proposals/2026-08-15-child-run-concurrency-budget.md:112`:
  "No cap on root runs or agent-CLI children").

## Net elements (R6)

Files: 7 changed, **0 added, 0 deleted**. No new module, no new export
(`createBackgroundBashStrategy` is module-local with one caller).
Exported symbols: **0 net**. Classes: **−1** (`BashBackgroundSession`).
Module constants: −1. Local functions: −4, +1.
Interface fields: **+4** (3 on `ChildRunStrategy`, 1 on `ChildStreamPort`).

LoC:

| | + | − | net |
|---|---|---|---|
| `src/tools/bash.ts` | 161 | 258 | **−97** |
| `src/agent/runtime/childRunLoop.ts` | 63 | 7 | **+56** |
| `ExecutionHandle.ts`, `childStream.ts` (comments) | 5 | 5 | 0 |
| **production total** | | | **−41** |
| tests (2 assertions/comments retargeted) | 4 | 4 | 0 |
| docs | 4 | 2 | +2 |

`childRunLoop.ts`'s +56 is roughly 40 lines of doc comment on the three new
strategy fields and the two fixes above; the executable addition is ~16 lines.
Honest read: this is a **−41 LoC** change, not the −120 to −180 a first pass
might suggest, because the strategy body is re-expressed rather than deleted.
The value is one driver and one copy of the wake/ordering choreography, not the
line count.

## Consumer counts (R8)

```
$ grep -rn "\.executeBackground\|BashBackgroundSession" src packages   # 1 caller, 0 after
$ grep -rn "BACKGROUND_TERMINAL_PERSISTENCE" src packages              # 0 after
$ grep -rn "markOwnedExecutionLeaseUndurable" src packages             # 7 production sites
$ grep -rn "ownsBackgroundProcess" src packages                        # 1 setter (the loop), 2 readers
$ grep -rn "autoClose" src packages                                    # childStream emit + 1 opt-in
$ grep -rn "bashDelivery" src packages                                 # 1 production consumer, unchanged
```

- `markOwnedExecutionLeaseUndurable` keeps six other production consumers
  (`executionRegistry.ts` ×2, `runAgent.ts`, `childRunDeliveryPersistence.ts`,
  `terminalPersistence.ts`, `packages/cli/src/runtime/executionFinalization.ts`)
  and gains one in `childRunLoop.ts`. No export removed anywhere.
- `killBackgroundProcesses`'s two callers (`SessionHandle`'s
  `killAllSessionBackgroundProcesses`, `packages/agent/src/index.ts:310`) still
  reach a live background shell — via the loop's interrupt handler now, which
  is what `ownsBackgroundProcess` on the strategy exists for.
- `producer: 'backgroundBash'` is already a first-class `ResultMeta` variant
  (`resultMeta.ts:16-23`) and `deliverTurn` only stamps `turnToken` when
  `producer === 'subagent'`, so the manifest passes through unchanged. No
  schema work.
- `getStreamTabId(BASH_CHILD_STREAM_PREFIX, {executionId})` = `bash@tool#<id>`,
  which satisfies `ToolUseFollowUpQueueManager`'s
  `endsWith('#'+executionId)` claim assertion.

Ratchets: nothing widened. `grep` over `config/` returns zero hits for
`bashDelivery`, `formatBashDelivery`, `formatBashError`, `backgroundBash`.
`src/tools → @agent/runtime/childRunLoop` already exists
(`agentCliShared.ts`), and `architecture-edges-baseline.json` is
subsystem-granular with `{from: tools, to: agent}` already `value`. No host
(`packages/**`) import added, so `host-agent-import-baseline` is untouched.
`npm run check:dead-code-ratchet`: 8 current vs 8 baselined, OK.

## Host impact

Extension: a background bash tab now opens a `Background command` stage and
auto-closes on completion exactly as before. Progress-view line counts for
`/executions/{id}/output` are unchanged (the diagnostics demotion is what keeps
them unchanged).

Desktop: same as extension.

CLI: same. `packages/agent` (SDK): `killBackgroundProcesses` in `runAgent`'s
per-run `finally` still reaches the shell.

## Scheduled refactoring

Two co-located findings deliberately **not** fixed here, to keep this diff to
the fold:

1. **`bash run_in_background` under `stopAfterCycle: true` strands its
   result.** Every other child type has an answer — agent-CLI refuses
   (`agentCliShared.ts:291`), native subagents degrade to the parent trace
   (`subagentExecution.ts:154`), workflow-script uses `persistOnly` + await
   (`WorkflowScriptTool.ts:552/582`). `bash.ts` has none. In the SDK case it is
   worse than stranded: `packages/agent/src/index.ts:296` sets it and its
   `finally` at `:310` calls `killBackgroundProcesses`, so the shell is
   launched and then killed with nothing delivered. Reachable callers:
   `AgentReviewService.ts:318`, `agentsRun.ts:83`, `multiAgent.ts:263`,
   `nativeSubagentStrategy.ts:310`. The guard belongs in `bash.ts`'s caller,
   not the loop — a separate, small PR that earns one regression test.
2. **`runWithOwnedExecutionLeaseLaunchGuard` releases the lease and nothing
   else** (`executionLease.ts:707-716`), so a `ChildStream` created inside
   `buildLaunch` is abandoned un-finalized if anything after its creation
   throws, leaving a stuck-RUNNING tab. `launchAgentCliSession:243-259` handles
   this case and is the more correct of the two. Reachable through
   `WorkflowScriptTool`'s `createRehydratedChildStream`. Better shape than a
   catch: have the guard own stream creation so the creation→handoff window
   stops existing.

## Validation

- `npm run typecheck` — clean (workspace, test-kernel, agent, cli,
  trace-viewer, desktop).
- `npm run lint` — clean. `npx prettier --check` on both rewritten files —
  clean.
- `npx vitest run src/test-kernel/tools/` — 99 files, 805 tests, all passing.
  This includes all six background-lifecycle cases in `BashTool.vitest.ts`
  (`:623` head/tail retention, `:697` wake a WAITING parent, `:735` the #8093
  finalize-before-wake ordering, `:797` finalize when `writeResultMeta`
  rejects, `:819` finalize when the completion path throws, `:849` a killed
  command persists as CANCELLED) — **all pass unedited**, which is the
  acceptance criterion for the fold.
- `npx vitest run src/test-kernel/agent/ src/test-kernel/transcript/
  src/test-kernel/cli/` — 354 files, 5900 tests, all passing. Includes
  `ChildRunLoop`, `ExecutionRegistry.vitest.ts:344-400` (the
  `ownsBackgroundProcess` invariant), codex/claude resume suites.
- `npx vitest run src/test-kernel/architecture/ src/test-kernel/controllers/
  src/test-kernel/progressView/` — 112 files, 1012 tests, all passing.
- `npm run check:dead-code-ratchet` — OK, no new findings.
- **Zero new tests.** Two existing assertions retargeted (a wording change and
  two stale comments naming the deleted class). The six background cases above
  become largely redundant with `ChildRunLoop.vitest.ts`; they are left in
  place rather than deleted, since they are the regression record for #8093.
