### PR TITLE
fix(model): one owner for the enabled-models list

### DIFF
--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -1,10 +1,10 @@
 import { defineCommand } from 'citty';
 
+import { getEnabledModels } from '@model/computeModelOptions';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { knownCliModelIds } from '../runtime/cliConfig';
 import {
-  getCliEnabledModels,
   listCliEnabledModelCatalog,
   setCliModelEnabled,
 } from '../runtime/enabledModels';
@@ -145,7 +145,7 @@ async function listEnabledModels(context: CliContext): Promise<number> {
     return CliExitCode.ModelOrNetworkError;
   }
   const catalog = listCliEnabledModelCatalog();
-  const enabled = getCliEnabledModels();
+  const enabled = getEnabledModels();
   emitCliResult(
     context,
     {

--- a/packages/cli/src/runtime/enabledModels.ts
+++ b/packages/cli/src/runtime/enabledModels.ts
@@ -1,22 +1,15 @@
 /**
- * CLI access to the enabled-models catalog (`GlobalStateKey.ENABLED_MODELS`).
- *
- * Session pickers (`/model`, lead model) only offer enabled + runnable models.
- * VS Code Settings → Models already toggles this list; these helpers give the
- * CLI and TUI the same surface so users are not stuck with defaults alone.
+ * CLI projection of the enabled-models catalog. The list itself
+ * (`GlobalStateKey.ENABLED_MODELS`) is owned by `@model/computeModelOptions` —
+ * `getEnabledModels` reads it, `setModelEnabled` writes it and enforces the
+ * "at least one enabled" and "never enable a retired model" invariants for
+ * every host. This module only resolves CLI argument spellings and shapes the
+ * rows `texra models enabled` and the `/models` form print.
  */
 import { MODEL_CONFIGS } from 'llm-zoo';
 
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
-import { resolveEffectiveHelperModel } from '@model/helperModelSelection';
-import {
-  DEFAULT_MODELS,
-  isDeprecatedModel,
-  isRetiredModel,
-} from '@model/modelOptionsBasic';
-import { platform } from '@platform/platform';
-import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
-import { GlobalStateKey } from '@shared/state/stateKeys';
+import { getEnabledModels, setModelEnabled } from '@model/computeModelOptions';
+import { isDeprecatedModel, isRetiredModel } from '@model/modelOptionsBasic';
 
 import {
   isCliSupportedModelId,
@@ -32,18 +25,6 @@ export interface CliEnabledModelRow {
   readonly deprecated: boolean;
 }
 
-function readStoredEnabledModels(): readonly string[] | undefined {
-  return platform().globalState.get<readonly string[]>(
-    GlobalStateKey.ENABLED_MODELS,
-  );
-}
-
-/** Models currently shown in pickers (never empty — falls back to defaults). */
-export function getCliEnabledModels(): readonly string[] {
-  const enabled = readStoredEnabledModels();
-  return enabled?.length ? enabled : DEFAULT_MODELS;
-}
-
 function modelLabel(id: string): string {
   const config = MODEL_CONFIGS[id];
   return config?.label ?? config?.fullName ?? id;
@@ -54,7 +35,7 @@ function modelLabel(id: string): string {
  * marked with whether it is currently enabled.
  */
 export function listCliEnabledModelCatalog(): readonly CliEnabledModelRow[] {
-  const enabled = new Set(getCliEnabledModels());
+  const enabled = new Set(getEnabledModels());
   return knownCliModelIds()
     .filter((id) => !isRetiredModel(id))
     .map((id) => {
@@ -73,16 +54,9 @@ export function listCliEnabledModelCatalog(): readonly CliEnabledModelRow[] {
     });
 }
 
-async function persistEnabledModels(models: readonly string[]): Promise<void> {
-  await platform().globalState.update(GlobalStateKey.ENABLED_MODELS, [
-    ...models,
-  ]);
-  invalidateModelOptionsCache();
-}
-
 /**
- * Enable or disable one model in the shared catalog. Resolves common aliases
- * (`grok-4.5` → `grok45`). Keeps at least one model enabled.
+ * Enable or disable one model from a CLI argument, resolving common spellings
+ * (`grok-4.5` → `grok45`) before handing the id to the shared writer.
  */
 export async function setCliModelEnabled(
   modelInput: string,
@@ -98,37 +72,7 @@ export async function setCliModelEnabled(
       `Unknown model "${modelInput}". Use an id from \`texra models list --all\`.`,
     );
   }
-  if (isRetiredModel(model)) {
-    throw new Error(`Model "${model}" is retired and cannot be enabled.`);
-  }
 
-  const current = [...getCliEnabledModels()];
-  let next: string[];
-  if (enabled) {
-    next = current.includes(model) ? current : [...current, model];
-  } else {
-    next = current.filter((id) => id !== model);
-    if (next.length === 0) {
-      throw new Error(
-        'At least one model must stay enabled. Enable another model before disabling this one.',
-      );
-    }
-  }
-
-  await persistEnabledModels(next);
-
-  // If the helper model was just removed, pin the built-in default (matches
-  // Settings → Models behavior). Do not fall back to the first remaining
-  // picker model — that is a premium default, not the cheap auxiliary.
-  const helper = platform().globalState.get<string>(
-    GlobalStateKey.HELPER_MODEL,
-  );
-  if (!enabled && resolveEffectiveHelperModel(helper, current) === model) {
-    await platform().globalState.update(
-      GlobalStateKey.HELPER_MODEL,
-      DEFAULT_HELPER_MODEL,
-    );
-  }
-
-  return { model, enabled: next.includes(model), list: next };
+  const list = await setModelEnabled({ model, enabled });
+  return { model, enabled: list.includes(model), list };
 }

--- a/packages/desktop/src/main/desktopCredentialSettingsController.ts
+++ b/packages/desktop/src/main/desktopCredentialSettingsController.ts
@@ -17,6 +17,7 @@ import {
 import type { ExternalOpener, PromptHost } from '@hosts/uiHosts';
 import {
   computeModelOptionsData,
+  getEnabledModels,
   invalidateModelOptionsCache,
 } from '@model/computeModelOptions';
 import {
@@ -242,7 +243,7 @@ export class DefaultDesktopCredentialSettingsController implements DesktopCreden
   }
 
   async postMainModelOptionsData(): Promise<void> {
-    const visibleModels = this.modelSelectionController.getVisibleModels();
+    const visibleModels = getEnabledModels(this.options.globalState);
     const modelOptions = await computeModelOptionsData(visibleModels);
     this.options.renderer.postToRenderer({
       command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -219,7 +219,7 @@ export function createDesktopSettingsIpc(
     enabled: boolean;
   }): Promise<void> {
     await settingsHost.setModelEnabled(input, {
-      afterUpdate: () => invalidateModelOptionsCache(),
+      // The options cache is invalidated by the writer itself.
       afterPost: () =>
         options.credentialSettingsController.postMainModelOptionsData(),
     });

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -811,7 +811,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     await this.settingsHost.setModelEnabled(
       { modelName, enabled },
       {
-        afterUpdate: () => invalidateModelOptionsCache(),
+        // The options cache is invalidated by the writer itself.
         respond: (message) => this.postMessageToActiveWebview(message),
         afterPost: () =>
           safeExecuteCommand('texra.refreshAllOptions', [], this.viewName),

--- a/src/agent/runtime/helperModelName.ts
+++ b/src/agent/runtime/helperModelName.ts
@@ -23,7 +23,7 @@ export function getHelperModelName(): string {
   // The only runtime-specific divergence from the shared precedence chain: an
   // empty/unset enabled-model list means "no restriction" here, so the
   // configured model is accepted as-is. This differs from the Settings UI,
-  // whose candidate list (`getVisibleModels()`) already substitutes
+  // whose candidate list (`getEnabledModels()`) already substitutes
   // `DEFAULT_MODELS` before it ever reaches `resolveEffectiveHelperModel`, so
   // it never sees an empty list. Everything else (empty/whitespace config, the
   // built-in default, validate-against-candidates, else fall back) defers to

--- a/src/controllers/settingsView/SettingsModelSelectionController.ts
+++ b/src/controllers/settingsView/SettingsModelSelectionController.ts
@@ -12,9 +12,12 @@ import {
   type CopilotModelRoute,
 } from '@model/runtimeModelRegistry';
 import { resolveEffectiveHelperModel } from '@model/helperModelSelection';
-import { DEFAULT_MODELS } from '@model/modelOptionsBasic';
 import { isGpt5ModelName } from '@model/modelNames';
-import { computeModelOptionsData } from '@model/computeModelOptions';
+import {
+  computeModelOptionsData,
+  getEnabledModels,
+  setModelEnabled,
+} from '@model/computeModelOptions';
 import type { StateStore } from '@platform/interfaces';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
@@ -26,17 +29,12 @@ import {
   ReasoningLevelSchema,
 } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
-import {
-  DEFAULT_HELPER_MODEL,
-  MODEL_SOURCE_ORDER,
-  isFastFirstResponseModel,
-} from '@shared/constants/providers';
+import { isFastFirstResponseModel } from '@shared/constants/providers';
 import { byName } from '@utils/core';
 
 export interface SettingsModelSelectionControllerDeps {
   /** Persisted picker state: enabled models, helper model, reasoning levels. */
   globalState: StateStore;
-  modelSources?: readonly string[];
   getCopilotRoutes?: () => Promise<ReadonlyMap<string, CopilotModelRoute>>;
   getPreferredCopilotRouteModels?: () => readonly string[];
   /**
@@ -72,25 +70,10 @@ const EFFORT_TO_LEVEL = new Map<ReasoningEffort, ReasoningLevel>(
 );
 
 export class SettingsModelSelectionController {
-  private readonly modelSources: Set<string>;
-
-  constructor(private readonly deps: SettingsModelSelectionControllerDeps) {
-    this.modelSources = new Set(deps.modelSources ?? MODEL_SOURCE_ORDER);
-  }
-
-  getVisibleModels(): readonly string[] {
-    // Normalize at the single read boundary: an empty persisted list (e.g. the
-    // user disabled every model) falls back to defaults so downstream consumers
-    // — including the helper-model dropdown — never see an empty model set.
-    const enabled = this.deps.globalState.get<readonly string[]>(
-      GlobalStateKey.ENABLED_MODELS,
-      DEFAULT_MODELS,
-    );
-    return enabled && enabled.length > 0 ? enabled : DEFAULT_MODELS;
-  }
+  constructor(private readonly deps: SettingsModelSelectionControllerDeps) {}
 
   async buildSelectionData(): Promise<SettingsModelSelectionData> {
-    const visibleModels = this.getVisibleModels();
+    const visibleModels = getEnabledModels(this.deps.globalState);
     const routes = await (
       this.deps.getCopilotRoutes ?? discoveredCopilotRoutes
     )();
@@ -142,25 +125,11 @@ export class SettingsModelSelectionController {
     modelName: string;
     enabled: boolean;
   }): Promise<void> {
-    const current = this.getVisibleModels();
-
-    let updated: readonly string[];
-    if (!input.enabled) {
-      updated = current.filter((modelName) => modelName !== input.modelName);
-    } else if (current.includes(input.modelName)) {
-      updated = current;
-    } else {
-      updated = [...current, input.modelName];
-    }
-
-    const wasHelper =
-      !input.enabled &&
-      this.getEffectiveHelperModel(current) === input.modelName;
-
-    await this.deps.globalState.update(GlobalStateKey.ENABLED_MODELS, updated);
-    if (wasHelper) {
-      await this.setHelperModel(DEFAULT_HELPER_MODEL);
-    }
+    await setModelEnabled({
+      model: input.modelName,
+      enabled: input.enabled,
+      state: this.deps.globalState,
+    });
   }
 
   async setHelperModel(modelName: string): Promise<void> {
@@ -194,7 +163,7 @@ export class SettingsModelSelectionController {
     copilotRoutes: ReadonlyMap<string, CopilotModelRoute>,
     preferredCopilotModels: ReadonlySet<string>,
   ): Promise<ModelSelectionItem[]> {
-    const enabledSet = new Set(this.getVisibleModels());
+    const enabledSet = new Set(getEnabledModels(this.deps.globalState));
     const reasoningOverrides = this.getReasoningLevelOverrides();
 
     // Resolve availability (personal-key, subscription) once for the
@@ -204,11 +173,7 @@ export class SettingsModelSelectionController {
     // candidates: they are transports for the canonical base models (#9635).
     const configs = new Map<string, ModelConfig>(staticModelConfigEntries());
     const candidates = [...configs.values()]
-      .filter(
-        (config) =>
-          config.provider !== ModelProvider.COPILOT &&
-          this.modelSources.has(resolveModelSource(config) ?? config.provider),
-      )
+      .filter((config) => config.provider !== ModelProvider.COPILOT)
       .map((config) => config.name);
     const resolveModelOptions =
       this.deps.resolveModelOptions ?? computeModelOptionsData;

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -8,7 +8,10 @@ import type { StateStore } from '@platform/interfaces';
 import { platform } from '@platform/platform';
 import type { PlatformSecrets } from '@platform/secrets';
 import type { ModelAvailabilityKind, ModelOptionData } from '@shared/schemas';
-import { providerDisplayName } from '@shared/constants/providers';
+import {
+  DEFAULT_HELPER_MODEL,
+  providerDisplayName,
+} from '@shared/constants/providers';
 import {
   isKimiCodeExclusiveModel,
   isKimiSubscriptionEligible,
@@ -30,10 +33,12 @@ import {
   resolveXaiSubscriptionCapabilities,
 } from './providerCapabilities';
 import { kimiCodeEffectiveConfig } from './kimiCodeSubscriptionRouting';
+import { resolveEffectiveHelperModel } from './helperModelSelection';
 import {
   buildBaseModelOption,
   buildBasicModelOptionsData,
   DEFAULT_MODELS,
+  isRetiredModel,
 } from './modelOptionsBasic';
 import {
   isOpenRouterRoutingUnsupported,
@@ -391,18 +396,82 @@ async function buildAvailabilityContext(
   };
 }
 
-/** Read the enabled model list from host state at the composition boundary. */
-function getVisibleModels(state: Pick<StateStore, 'get'>): readonly string[] {
-  return state.get<readonly string[]>(
+/**
+ * The models the pickers show — the single reader of
+ * `GlobalStateKey.ENABLED_MODELS` for every host.
+ *
+ * Normalizes an empty persisted list to {@link DEFAULT_MODELS}: `.get`'s
+ * fallback only fires on `undefined`, so a stored `[]` would otherwise survive
+ * all the way to an empty picker with no way back out from the UI.
+ */
+export function getEnabledModels(
+  state: Pick<StateStore, 'get'> = platform().globalState,
+): readonly string[] {
+  const enabled = state.get<readonly string[]>(
     GlobalStateKey.ENABLED_MODELS,
     DEFAULT_MODELS,
   );
+  return enabled.length > 0 ? enabled : DEFAULT_MODELS;
+}
+
+/**
+ * Enable or disable one model, and invalidate the options cache derived from
+ * the list. The only writer of `GlobalStateKey.ENABLED_MODELS` outside the
+ * startup reconciliation in `modelListRefresh.ts`.
+ *
+ * Two invariants, previously enforced only on the CLI path:
+ *  - at least one model stays enabled — an empty list leaves the user with an
+ *    empty picker and (for non-Codex users) no way to re-enable anything;
+ *  - a retired model can be removed but never enabled — removal has to stay
+ *    possible so a model retired while enabled is not stuck in the list.
+ *
+ * Throws on either violation; callers surface the message.
+ */
+export async function setModelEnabled(input: {
+  readonly model: string;
+  readonly enabled: boolean;
+  readonly state?: StateStore;
+}): Promise<readonly string[]> {
+  const state = input.state ?? platform().globalState;
+  if (input.enabled && isRetiredModel(input.model)) {
+    throw new Error(`Model "${input.model}" is retired and cannot be enabled.`);
+  }
+
+  const current = getEnabledModels(state);
+  let next: readonly string[];
+  if (input.enabled) {
+    next = current.includes(input.model) ? current : [...current, input.model];
+  } else {
+    next = current.filter((model) => model !== input.model);
+    if (next.length === 0) {
+      throw new Error(
+        'At least one model must stay enabled. Enable another model before disabling this one.',
+      );
+    }
+  }
+  await state.update(GlobalStateKey.ENABLED_MODELS, [...next]);
+
+  // If the helper model was just removed, pin the built-in default. Do not
+  // fall back to the first remaining picker model — that is a premium default,
+  // not the cheap auxiliary.
+  if (
+    !input.enabled &&
+    resolveEffectiveHelperModel(
+      state.get<string | undefined>(GlobalStateKey.HELPER_MODEL),
+      current,
+    ) === input.model
+  ) {
+    await state.update(GlobalStateKey.HELPER_MODEL, DEFAULT_HELPER_MODEL);
+  }
+
+  invalidateModelOptionsCache();
+  return next;
 }
 
 function buildDefaultModelOptionsAccess(): ModelOptionsAccess {
   const host = platform();
   return {
-    visibleModels: getVisibleModels(host.globalState),
+    visibleModels: getEnabledModels(host.globalState),
     secrets: host.secrets,
     useOpenRouter: getUseOpenRouter(),
   };
@@ -419,7 +488,7 @@ function buildDefaultModelOptionsAccess(): ModelOptionsAccess {
  * that is a pure registry fact needing no secret.
  */
 export function buildVisibleBasicModelOptionsData(
-  visibleModels: readonly string[] = getVisibleModels(platform().globalState),
+  visibleModels: readonly string[] = getEnabledModels(),
 ): ModelOptionData[] {
   return buildBasicModelOptionsData(visibleModels);
 }

--- a/src/test-kernel/agent/runtime/helperModelName.vitest.ts
+++ b/src/test-kernel/agent/runtime/helperModelName.vitest.ts
@@ -85,7 +85,7 @@ describe('#7582 runtime vs Settings UI helper-model divergence', () => {
     // configured model is accepted as-is.
     expect(getHelperModelName()).toBe(configuredModel);
 
-    // Settings UI: `getVisibleModels()` substitutes DEFAULT_MODELS when the
+    // Settings UI: `getEnabledModels()` substitutes DEFAULT_MODELS when the
     // persisted enabled list is empty/unset, and `getEffectiveHelperModel`
     // requires membership in that substituted list -- so it falls back
     // instead of accepting the configured model as-is. This is a deliberate,

--- a/src/test-kernel/cli/EnabledModels.vitest.ts
+++ b/src/test-kernel/cli/EnabledModels.vitest.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { DEFAULT_MODELS } from '@model/modelOptionsBasic';
-import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
 const state = new Map<string, unknown>();
@@ -20,11 +18,7 @@ vi.mock('@platform/platform', () => ({
   }),
 }));
 
-vi.mock('@model/computeModelOptions', () => ({
-  invalidateModelOptionsCache: vi.fn(),
-}));
-
-const { getCliEnabledModels, setCliModelEnabled, listCliEnabledModelCatalog } =
+const { setCliModelEnabled, listCliEnabledModelCatalog } =
   await import('@cli/runtime/enabledModels');
 
 describe('CLI enabled models catalog', () => {
@@ -32,35 +26,18 @@ describe('CLI enabled models catalog', () => {
     state.clear();
   });
 
-  it('falls back to DEFAULT_MODELS when nothing is stored', () => {
-    expect(getCliEnabledModels()).toEqual(DEFAULT_MODELS);
-  });
-
-  it('enables a model that is not yet in the list', async () => {
+  it('resolves a CLI spelling and reports the resulting list', async () => {
     state.set(GlobalStateKey.ENABLED_MODELS, ['deepseekproT']);
-    const result = await setCliModelEnabled('grok45', true);
+    const result = await setCliModelEnabled('grok-4.5', true);
     expect(result.model).toBe('grok45');
     expect(result.enabled).toBe(true);
     expect(result.list).toEqual(['deepseekproT', 'grok45']);
-    expect(getCliEnabledModels()).toContain('grok45');
   });
 
-  it('pins a disabled helper to the built-in default', async () => {
-    state.set(GlobalStateKey.ENABLED_MODELS, ['deepseekproT', 'grok45']);
-    state.set(GlobalStateKey.HELPER_MODEL, 'deepseekproT');
-
-    await setCliModelEnabled('deepseekproT', false);
-
-    expect(state.get(GlobalStateKey.HELPER_MODEL)).toBe(DEFAULT_HELPER_MODEL);
-    expect(getCliEnabledModels()).toEqual(['grok45']);
-  });
-
-  it('refuses to disable the last remaining model', async () => {
-    state.set(GlobalStateKey.ENABLED_MODELS, ['deepseekproT']);
-    await expect(setCliModelEnabled('deepseekproT', false)).rejects.toThrow(
-      /at least one model/i,
+  it('rejects an id no CLI model answers to', async () => {
+    await expect(setCliModelEnabled('nonexistent-xyz', true)).rejects.toThrow(
+      /Unknown model/,
     );
-    expect(getCliEnabledModels()).toEqual(['deepseekproT']);
   });
 
   it('lists catalog rows with enabled flags', () => {

--- a/src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts
@@ -135,6 +135,18 @@ describe('SettingsModelSelectionController', () => {
     );
   });
 
+  it('refuses to disable the last remaining model', async () => {
+    const globalState = new FakeStateStore({
+      [GlobalStateKey.ENABLED_MODELS]: ['gpt55'],
+    });
+    const controller = createController({ globalState });
+
+    await expect(
+      controller.setModelEnabled({ modelName: 'gpt55', enabled: false }),
+    ).rejects.toThrow(/at least one model/i);
+    expect(globalState.get(GlobalStateKey.ENABLED_MODELS)).toEqual(['gpt55']);
+  });
+
   it('falls back to default models when the persisted enabled list is empty', async () => {
     const controller = createController({
       globalState: new FakeStateStore({ [GlobalStateKey.ENABLED_MODELS]: [] }),


### PR DESCRIPTION
## Summary

Which models a user has enabled was decided in three places and written in two,
and the three did not agree.

**Readers**

| site | empty persisted list `[]` |
| --- | --- |
| `computeModelOptions.getVisibleModels` (CLI + desktop pickers, availability) | stays `[]` |
| `SettingsModelSelectionController.getVisibleModels` | substitutes `DEFAULT_MODELS` |
| `enabledModels.getCliEnabledModels` (CLI) | substitutes `DEFAULT_MODELS` |

`StateStore.get(key, fallback)` only falls back on `undefined`
(`jsonStore.ts:122-125`), so a stored `[]` survives the first reader intact.

**Writers**

| site | floor | retired guard |
| --- | --- | --- |
| `SettingsModelSelectionController.setModelEnabled` | none | none |
| `setCliModelEnabled` (CLI) | throws | throws (both directions) |

**The reachable bug.** The Settings → Models switch has no last-model guard
(`ModelSelectionList.ts:179-186`) and neither did its controller, so a user can
turn every model off. That persists `[]`. Startup reconciliation does not
recover it — `refreshModelListStateIfNeeded` treats `[]` as a present list and,
with the version unchanged, computes `added=[]`, `removed=[]`, `reordered=false`
and writes nothing. On the next launch the CLI/desktop picker reads the raw `[]`
and shows **no models at all**, with no UI path back (a Codex-signed-in user is
the exception: `visibleModelsForAccess` re-adds Codex-eligible rows).

This gives the list one reader and one writer.

## Issue acceptance gates

n/a — no issue; sweep item C1 from the dual-systems (model-truth) sweep.

## Single source of truth

`src/model/computeModelOptions.ts` owns the enabled-models list:

- `getEnabledModels(state?)` — the only reader. Normalizes `[]` → `DEFAULT_MODELS`
  (the controller's old semantics, now applied to every host), which also
  un-sticks anyone already persisted into the empty state.
- `setModelEnabled({model, enabled, state?})` — the only writer outside the
  startup reconciliation, carrying the two invariants the CLI used to hold
  alone, plus the helper-model reset both writers had implemented separately,
  plus the options-cache invalidation all three call sites had to remember.

That module was chosen over a new one because it already owned the reader, the
`DEFAULT_MODELS` import, and the derived options cache the writer must
invalidate; a separate module would have created an import cycle with it.

`SettingsModelSelectionController` and the CLI's `enabledModels.ts` now call it.
The CLI file keeps only what is genuinely CLI-specific: argument-spelling
resolution (`grok-4.5` → `grok45`) and the 5-field row projection behind
`texra models enabled --json`.

## Duplication and abstraction budget

Removed: two of three readers, one of two writers, two copies of the
helper-model reset rule, the `getVisibleModels()` method on the controller, and
the `afterUpdate: () => invalidateModelOptionsCache()` hook both hosts had to
pass on this one mutation (the writer does it).

Also removed: `SettingsModelSelectionControllerDeps.modelSources` and the
`this.modelSources.has(...)` clause it fed. `grep -rn modelSources src packages`
returned only the four lines inside the controller itself — no production or
test injection ever set it, so the clause always evaluated against
`MODEL_SOURCE_ORDER` and was pure speculative generality.

No new abstraction: two functions in an existing module, no new file, no new
parameter object, no injection.

## Net elements (R6)

Production:

- Files: **±0** (8 modified, 0 added, 0 deleted)
- Exported symbols: **+1 net** — `+getEnabledModels`, `+setModelEnabled`,
  `-getCliEnabledModels`
- Public methods: **−1** (`SettingsModelSelectionController.getVisibleModels`)
- Constructor deps / fields: **−2** (`modelSources` option, `this.modelSources`)
- Readers of `ENABLED_MODELS`: **3 → 1**; writers: **2 → 1**
- Net LoC: **+110 / −131 = −21** (code lines −33, doc-comments +19)

Tests: **+19 / −30 = −11 LoC**; 3 files touched, 0 added, 0 deleted; test cases
net **−2** (three CLI cases that pinned rules now owned elsewhere are gone; one
case is added on the controller to pin the newly ported floor on the settings
path, and the CLI keeps the id-resolution and catalog cases).

## Consumer counts (R8)

```
grep -rn "ENABLED_MODELS" src packages | grep -v node_modules | grep -v /dist/
```
→ after this change, the only production readers/writers are
`computeModelOptions.ts` (reader + writer), `modelListRefresh.ts` (startup
reconciliation, untouched), `helperModelName.ts`, and the CLI TUI harness
fixture.

`helperModelName.ts:19` is a **deliberate** fourth reader and stays: it treats
an unset/empty list as "no restriction" and accepts the configured helper as-is,
the opposite of the `DEFAULT_MODELS` substitution. That divergence is documented
in the function and pinned by `helperModelName.vitest.ts`; I updated both
comments to name `getEnabledModels()`.

```
grep -rn "getVisibleModels" src packages    → 0 call sites remain (2 comments updated)
grep -rn "getCliEnabledModels" src packages → 0 remain
grep -rn "modelSources" src packages        → 0 remain
```

`invalidateModelOptionsCache` keeps 6 other call sites in the extension handler
and 2 in the desktop IPC; only the two `afterUpdate` hooks on this mutation are
dropped.

## Host impact

Extension: Settings → Models now refuses to disable the last enabled model. The
message reaches the user as the generic settings-message error toast plus an
error-level log (`BaseViewMessageHandler.dispatchInbound`) — loud, not silent,
but generic. Adding a webview-side guard that disables the last "on" switch is
the natural follow-up and is **not** in this PR (different subject, webview
frontend). Enabling a retired model is likewise refused; retired rows stay
listed and stay removable, which is why the guard is enable-only.

Desktop: same two guards; `postMainModelOptionsData` reads the shared reader
with the same `globalState` it always used.

CLI: unchanged behavior. `texra models enable/disable` keeps its error messages
(they moved to the shared writer verbatim), its `{model, enabled, list}` JSON
shape, and its 5-field catalog rows — I deliberately did **not** rebuild those
rows from `ModelOptionData`, because that would change the `provider` column
from the registry provider (`moonshot`) to the effective source (`kimiCode`) in
a machine-readable contract.

**Reconcile-loop note (asked for explicitly):** this PR does not touch
`modelListRefresh.ts`, `MODEL_LIST_VERSION`, or `computeModelListVersion`. It
does not change how often the startup reconcile fires, what triggers it, or what
it restamps — it only prevents a user from persisting the empty list that the
reconcile provably cannot repair, and normalizes that state on read for anyone
already in it. The list's storage location is untouched.

## Scheduled refactoring

None filed. Noted, not done:

- The webview last-model guard described above.
- The candidate lists still differ by one filter: the CLI catalog hides retired
  models, the Settings list shows them as `availability: 'retired'` so they can
  be turned off. That difference is deliberate per host and unifying it would
  regress one of them, so it stays.

## Validation

- `npm run typecheck` — clean (root, cli incl. `tsconfig.scripts.json`,
  trace-viewer, desktop, agent declarations).
- `npx vitest run` on the 8 suites covering both sides —
  `cli/EnabledModels`, `controllers/SettingsModelSelectionController`,
  `controllers/SettingsViewHost`, `model/ComputeModelOptions`,
  `model/ModelListRefresh`, `agent/runtime/helperModelName`,
  `desktop/DesktopSettingsIpc`, `settings/ModelSelectionProviderKeys` —
  **84 passed**.
- `npx vitest run src/test-kernel/architecture` — 17 files, 104 passed.
- `npm run lint` — clean. `npx prettier --check` on the diff — clean.
- `npm run check:dead-code-ratchet` — OK (8 findings vs 8 baselined).
