### PR TITLE
fix(auth): report subscription device fallback cause

### DIFF
--- a/packages/desktop/src/main/desktopCredentialSettingsController.ts
+++ b/packages/desktop/src/main/desktopCredentialSettingsController.ts
@@ -48,6 +48,7 @@ interface DesktopCredentialSettingsControllerOptions extends SettingsStatePorts 
   };
   readonly prompt: Pick<PromptHost, 'input' | 'confirm'>;
   readonly externalOpener: Pick<ExternalOpener, 'openExternal'> & {
+    openSubscriptionSignInUrl(url: string): Promise<void>;
     presentSubscriptionSignInUrl(
       url: string,
       productName: string,
@@ -279,7 +280,7 @@ export class DefaultDesktopCredentialSettingsController implements DesktopCreden
       },
       presentSignInUrl: async (url) => {
         try {
-          await this.options.externalOpener.openExternal(url);
+          await this.options.externalOpener.openSubscriptionSignInUrl(url);
         } catch (error) {
           throw new LoopbackTransportUnavailableError(
             `Could not open a browser for ${displayName} sign-in.`,

--- a/packages/desktop/src/main/desktopPreviewHost.ts
+++ b/packages/desktop/src/main/desktopPreviewHost.ts
@@ -24,6 +24,10 @@ interface DesktopShellAdapter {
 }
 
 export interface DesktopPreviewHost extends ExternalOpener {
+  openExternal(
+    url: string,
+    options?: { readonly reportFailure?: boolean },
+  ): Promise<void>;
   /** Open a workspace file in the OS default application. */
   openPath(filePath: string): Promise<void>;
   openBuildDisplay: BuildDisplayFn;
@@ -69,10 +73,14 @@ export function createDesktopPreviewHost(
     }
   }
 
-  async function openExternal(url: string): Promise<void> {
+  async function openExternal(
+    url: string,
+    { reportFailure = true }: { readonly reportFailure?: boolean } = {},
+  ): Promise<void> {
     try {
       await options.shell.openExternal(url);
     } catch (error) {
+      if (!reportFailure) throw error;
       await fail(`Failed to open URL ${url}: ${toErrorMessage(error)}`);
     }
   }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -767,6 +767,8 @@ function createWindow(options: {
       },
       externalOpener: {
         openExternal: previewHost.openExternal,
+        openSubscriptionSignInUrl: (url) =>
+          previewHost.openExternal(url, { reportFailure: false }),
         presentSubscriptionSignInUrl: async (url, productName) => {
           const result = await dialog.showMessageBox(window, {
             type: 'info',

--- a/src/controllers/modelAccess/subscriptionProviders.ts
+++ b/src/controllers/modelAccess/subscriptionProviders.ts
@@ -195,6 +195,7 @@ function defineSubscriptionProvider<
       }
       log.warn(
         `${bindings.displayName} browser sign-in is unavailable, falling back to a one-time device code: ${toErrorMessage(error)}`,
+        { data: error },
       );
       return deviceCodeLogin(coordinator, options);
     }

--- a/src/controllers/modelAccess/subscriptionProviders.ts
+++ b/src/controllers/modelAccess/subscriptionProviders.ts
@@ -193,8 +193,12 @@ function defineSubscriptionProvider<
       ) {
         throw error;
       }
+      const causeMessage =
+        error.cause === undefined
+          ? ''
+          : ` Cause: ${toErrorMessage(error.cause)}`;
       log.warn(
-        `${bindings.displayName} browser sign-in is unavailable, falling back to a one-time device code: ${toErrorMessage(error)}`,
+        `${bindings.displayName} browser sign-in is unavailable, falling back to a one-time device code: ${toErrorMessage(error)}${causeMessage}`,
         { data: error },
       );
       return deviceCodeLogin(coordinator, options);

--- a/src/test-kernel/desktop/DesktopCredentialSettingsController.vitest.ts
+++ b/src/test-kernel/desktop/DesktopCredentialSettingsController.vitest.ts
@@ -497,7 +497,7 @@ describe('DefaultDesktopCredentialSettingsController', () => {
     );
     expect(warnSpy).toHaveBeenCalledExactlyOnceWith(
       'subscriptionProviders',
-      'ChatGPT browser sign-in is unavailable, falling back to a one-time device code: Could not open a browser for ChatGPT sign-in.',
+      'ChatGPT browser sign-in is unavailable, falling back to a one-time device code: Could not open a browser for ChatGPT sign-in. Cause: no browser handler',
       { data: expect.any(LoopbackTransportUnavailableError) },
     );
     const loggedError = warnSpy.mock.calls[0]?.[2]?.data;

--- a/src/test-kernel/desktop/DesktopCredentialSettingsController.vitest.ts
+++ b/src/test-kernel/desktop/DesktopCredentialSettingsController.vitest.ts
@@ -2,7 +2,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
+import { LoopbackTransportUnavailableError } from '@auth/oauth/loopbackLogin';
+import type { SubscriptionDeviceCodePrompt } from '@controllers/modelAccess/subscriptionProviders';
 import { DefaultDesktopCredentialSettingsController } from '@desktop/main/desktopCredentialSettingsController';
+import * as logger from '@logger/logUtils';
 import { apiKeySecretName } from '@model/apiProviders';
 import { MAIN_VIEW_COMMANDS, SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { assertSupported } from '@shared/utils/dispatcher';
@@ -21,7 +24,16 @@ const codexMocks = vi.hoisted(() => ({
     signedIn: false,
     preferSubscription: false,
   })),
-  login: vi.fn(async () => ({ email: 'user@example.com' })),
+  login: vi.fn(
+    async (_options: { openBrowser(url: string): void | Promise<void> }) => ({
+      email: 'user@example.com',
+    }),
+  ),
+  loginWithDeviceCode: vi.fn(
+    async (_options: {
+      onPrompt(prompt: SubscriptionDeviceCodePrompt): void;
+    }) => ({ email: 'user@example.com' }),
+  ),
   setPreferSubscription: vi.fn(async (enabled: boolean) => ({
     effective: enabled,
   })),
@@ -38,6 +50,7 @@ const modelMocks = vi.hoisted(() => ({
 vi.mock('@auth/codex', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@auth/codex')>()),
   codexCoordinator: () => ({ signOut: codexMocks.signOut }),
+  loginWithDeviceCode: codexMocks.loginWithDeviceCode,
   loginWithLoopback: codexMocks.login,
 }));
 
@@ -130,6 +143,7 @@ async function createFixture({
     },
     externalOpener: {
       openExternal: async () => undefined,
+      openSubscriptionSignInUrl: async () => undefined,
       presentSubscriptionSignInUrl: () => undefined,
       presentSubscriptionDeviceCode: () => undefined,
     },
@@ -178,6 +192,9 @@ describe('DefaultDesktopCredentialSettingsController', () => {
       preferSubscription: false,
     });
     codexMocks.login.mockResolvedValue({ email: 'user@example.com' });
+    codexMocks.loginWithDeviceCode.mockResolvedValue({
+      email: 'user@example.com',
+    });
     codexMocks.setPreferSubscription.mockImplementation(async (enabled) => ({
       effective: enabled,
     }));
@@ -427,6 +444,65 @@ describe('DefaultDesktopCredentialSettingsController', () => {
       'ChatGPT sign-in failed: authorization denied',
     ]);
     expect(fixture.onCredentialChanged).toHaveBeenCalledTimes(4);
+  });
+
+  it('falls back without reporting the browser-open failure twice and logs its cause', async () => {
+    const browserError = new Error('no browser handler');
+    const openExternal = vi.fn(async () => undefined);
+    const openSubscriptionSignInUrl = vi.fn(async () => {
+      throw browserError;
+    });
+    const presentSubscriptionSignInUrl = vi.fn();
+    const presentSubscriptionDeviceCode = vi.fn();
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const fixture = await createFixture({
+      externalOpener: {
+        openExternal,
+        openSubscriptionSignInUrl,
+        presentSubscriptionSignInUrl,
+        presentSubscriptionDeviceCode,
+      },
+    });
+    codexMocks.login.mockImplementationOnce(async ({ openBrowser }) => {
+      await openBrowser('https://auth.openai.com/authorize');
+      return { email: 'loopback@example.com' };
+    });
+    codexMocks.loginWithDeviceCode.mockImplementationOnce(
+      async ({ onPrompt }) => {
+        onPrompt({
+          userCode: 'ABCD-EFGH',
+          verificationUrl: 'https://auth.openai.com/device',
+        });
+        return { email: 'device@example.com' };
+      },
+    );
+
+    await fixture.controller.signInChatGpt();
+
+    expect(openSubscriptionSignInUrl).toHaveBeenCalledExactlyOnceWith(
+      'https://auth.openai.com/authorize',
+    );
+    expect(openExternal).not.toHaveBeenCalled();
+    expect(presentSubscriptionSignInUrl).not.toHaveBeenCalled();
+    expect(presentSubscriptionDeviceCode).toHaveBeenCalledExactlyOnceWith(
+      {
+        userCode: 'ABCD-EFGH',
+        verificationUrl: 'https://auth.openai.com/device',
+      },
+      'ChatGPT',
+    );
+    expect(fixture.errors).toEqual([]);
+    expect(fixture.infos).toContain(
+      'Signed in with ChatGPT as device@example.com.',
+    );
+    expect(warnSpy).toHaveBeenCalledExactlyOnceWith(
+      'subscriptionProviders',
+      'ChatGPT browser sign-in is unavailable, falling back to a one-time device code: Could not open a browser for ChatGPT sign-in.',
+      { data: expect.any(LoopbackTransportUnavailableError) },
+    );
+    const loggedError = warnSpy.mock.calls[0]?.[2]?.data;
+    expect(loggedError).toBeInstanceOf(LoopbackTransportUnavailableError);
+    expect((loggedError as Error).cause).toBe(browserError);
   });
 
   it('routes Codex through the subscription for a Settings-panel sign-in', async () => {

--- a/src/test-kernel/desktop/DesktopPreviewHost.vitest.ts
+++ b/src/test-kernel/desktop/DesktopPreviewHost.vitest.ts
@@ -261,6 +261,23 @@ describe('desktop preview host', () => {
     expect(shell.openExternal).toHaveBeenCalledWith('https://texra.ai');
   });
 
+  it('can preserve an external-open error without showing a dialog', async () => {
+    const { createDesktopPreviewHost } = await loadDesktopPreviewHost();
+    const browserError = new Error('no browser handler');
+    const shell = makeShell();
+    shell.openExternal.mockRejectedValueOnce(browserError);
+    const showErrorMessage = vi.fn();
+
+    const host = createDesktopPreviewHost({ shell, showErrorMessage });
+
+    await expect(
+      host.openExternal('https://auth.openai.com/authorize', {
+        reportFailure: false,
+      }),
+    ).rejects.toBe(browserError);
+    expect(showErrorMessage).not.toHaveBeenCalled();
+  });
+
   it('prefers the in-app PDF overlay when postToRenderer accepts the post', async () => {
     const { createDesktopPreviewHost } = await loadDesktopPreviewHost();
     const { texPath, pdfPath } = await makeTexFixture('paper');

--- a/src/test-kernel/desktop/DesktopSettingsCapabilityMarkers.vitest.ts
+++ b/src/test-kernel/desktop/DesktopSettingsCapabilityMarkers.vitest.ts
@@ -73,6 +73,7 @@ function realCredentialController(): DefaultDesktopCredentialSettingsController 
     },
     externalOpener: {
       openExternal: noOp,
+      openSubscriptionSignInUrl: noOp,
       presentSubscriptionSignInUrl: () => undefined,
       presentSubscriptionDeviceCode: () => undefined,
     },


### PR DESCRIPTION
## Summary

- attach the full loopback transport error as structured data on device-code fallback warnings
- route desktop subscription browser launch through an explicit non-reporting open path
- preserve ordinary URL and file-open dialogs
- keep device-code fallback as the single user-facing explanation when browser launch fails

## Validation

- 4 focused files, 44 tests passed
- workspace, desktop, and test-kernel typechecks
- targeted ESLint and Prettier
- `git diff --check`
- independent code review found no blocking or should-fix findings

Closes #10985
Closes #10987
