### PR TITLE
fix(cli): show config degradation in quiet mode

### DIFF
--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -73,6 +73,10 @@ function logAt(
   writeTextStderr(`[${level}] [${channel}] ${message}`);
 }
 
+function showPersistentConfigWarning(message: string): void {
+  writeTextStderr(`[warn] [cli.config] ${message}`);
+}
+
 const cliPlatformLog: LogBackend = {
   debug: (channel, message) => logAt('debug', channel, message),
   info: (channel, message) => logAt('info', channel, message),
@@ -233,7 +237,7 @@ export async function initCliPlatform(
     const configStores = await openTexraConfigStores(
       stateStores.storage,
       cliWorkspaceCwd,
-      (message) => logAt('warn', 'cli.config', message),
+      showPersistentConfigWarning,
     );
     // Same severity and wording as the extension/desktop hosts: a shutdown
     // handler failure is an error everywhere, not a warning in one host.

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -73,6 +73,8 @@ function logAt(
   writeTextStderr(`[${level}] [${channel}] ${message}`);
 }
 
+// Malformed project config is actionable degradation, not routine progress
+// noise, so this deliberately bypasses quietLogs.
 function showPersistentConfigWarning(message: string): void {
   writeTextStderr(`[warn] [cli.config] ${message}`);
 }

--- a/src/test-kernel/cli/CliInitPlatform.vitest.ts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.ts
@@ -72,6 +72,7 @@ const mocks = vi.hoisted(() => ({
   initializeNodeRuntimeSkills: vi.fn(),
   initNodeAgentRuntime: vi.fn(),
   getCliSecrets: vi.fn(() => ({ kind: 'cli-secrets' })),
+  openTexraConfigStores: vi.fn(),
   cliGlobalState: { get: vi.fn(), update: vi.fn() },
   invalidateModelOptionsCache: vi.fn(),
   tryPlatform: vi.fn(),
@@ -153,9 +154,7 @@ vi.mock('@platform/defaults/lifecycleHost', () => ({
 // rule) is shared with the extension and desktop hosts; stubbed here so this
 // test exercises only the CLI-specific wiring.
 vi.mock('@platform/defaults/nodeStores', () => ({
-  openTexraConfigStores: vi
-    .fn()
-    .mockResolvedValue({ workspace: {}, global: {} }),
+  openTexraConfigStores: mocks.openTexraConfigStores,
 }));
 
 vi.mock('@platform/defaults/nodeFilesystem', () => ({ nodeFilesystem: {} }));
@@ -241,6 +240,10 @@ describe('CLI platform init', () => {
     mocks.tryPlatform.mockReset();
     mocks.tryPlatform.mockReturnValue({ globalState: stubGlobalState() });
     mocks.bootstrapNodeAgentDirectories.mockResolvedValue(undefined);
+    mocks.openTexraConfigStores.mockResolvedValue({
+      workspace: {},
+      global: {},
+    });
     isAuthenticatedSpy.mockResolvedValue(false);
   });
 
@@ -365,6 +368,49 @@ describe('CLI platform init', () => {
       stderrWrite.mockRestore();
       mocks.cliGlobalState.get.mockReset();
       mocks.cliGlobalState.update.mockReset();
+    }
+  });
+
+  it('shows one project-config degradation warning with its cause in quiet mode', async () => {
+    mocks.tryPlatform.mockReturnValueOnce(undefined);
+    mocks.cliGlobalState.get.mockImplementation((key: string) => {
+      if (key === GlobalStateKey.MODEL_LIST_VERSION) return MODEL_LIST_VERSION;
+      if (key === GlobalStateKey.ENABLED_MODELS) return ['sonnet5T'];
+      if (key === GlobalStateKey.COPILOT_ROUTE_MODELS) {
+        return ['gemini36f', 'gemini31p'];
+      }
+      return undefined;
+    });
+    mocks.cliGlobalState.update.mockResolvedValue(undefined);
+    mocks.openTexraConfigStores.mockImplementationOnce(
+      async (
+        _storage: unknown,
+        _cwd: string,
+        warn: (message: string) => void,
+      ) => {
+        warn(
+          'Cannot open project .texra/config.json; using the internal workspace config store. Cause: Unexpected token } in JSON at position 0',
+        );
+        return { workspace: {}, global: {} };
+      },
+    );
+    const stderrWrite = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+
+    try {
+      await initCliPlatform(cliContext({ installSignalHandlers: false }));
+
+      expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
+      expect(stderrWrite).toHaveBeenCalledOnce();
+      expect(stderrWrite).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Cause: Unexpected token } in JSON at position 0',
+        ),
+        expect.any(Function),
+      );
+    } finally {
+      stderrWrite.mockRestore();
     }
   });
 


### PR DESCRIPTION
## Summary
- route project-config degradation through a dedicated persistent stderr warning callback
- keep ordinary platform logs gated by `quietLogs`
- cover quiet-mode visibility, once-only output, and underlying-cause preservation in the existing CLI platform test

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CliInitPlatform.vitest.ts src/test-kernel/cli/CliContext.vitest.ts src/test-kernel/platform/WorkspaceStorage.vitest.ts`
- `corepack pnpm run typecheck:cli`
- `corepack pnpm run typecheck:test-kernel`
- `corepack pnpm exec eslint packages/cli/src/runtime/initPlatform.ts src/test-kernel/cli/CliInitPlatform.vitest.ts`
- `git diff --check`

Closes #10999