### PR TITLE
fix(agent): retry failed directory bootstrap

### DIFF
--- a/src/agent/index/platformAgentDirectories.ts
+++ b/src/agent/index/platformAgentDirectories.ts
@@ -178,7 +178,7 @@ async function reconcileUnlocked(
 async function reconcileBundledAgentDirectories(
   options: BundledAgentReconcileOptions,
   log: Log,
-): Promise<void> {
+): Promise<boolean> {
   let operationStarted = false;
 
   try {
@@ -201,6 +201,7 @@ async function reconcileBundledAgentDirectories(
           !operationStarted && isLockContentionError(error),
       },
     );
+    return true;
   } catch (error) {
     // A live or stale owner must not make startup fail. If ownership remains
     // unavailable, leave the shared cache untouched and try again next run.
@@ -208,7 +209,7 @@ async function reconcileBundledAgentDirectories(
       log.warn(
         'Skipping bundled agent refresh because another process still owns the sync lock',
       );
-      return;
+      return false;
     }
     throw error;
   }
@@ -223,8 +224,7 @@ export async function bootstrapPlatformAgentDirectories(
 ): Promise<boolean> {
   const log = createLog(options.channel);
   try {
-    await reconcileBundledAgentDirectories(options, log);
-    return true;
+    return await reconcileBundledAgentDirectories(options, log);
   } catch (error) {
     // An unreadable or partially written agent directory must not abort host
     // startup — VS Code activation in particular has to survive it. Loud, not

--- a/src/agent/index/platformAgentDirectories.ts
+++ b/src/agent/index/platformAgentDirectories.ts
@@ -220,15 +220,17 @@ async function reconcileBundledAgentDirectories(
  */
 export async function bootstrapPlatformAgentDirectories(
   options: BundledAgentReconcileOptions,
-): Promise<void> {
+): Promise<boolean> {
   const log = createLog(options.channel);
   try {
     await reconcileBundledAgentDirectories(options, log);
+    return true;
   } catch (error) {
     // An unreadable or partially written agent directory must not abort host
     // startup — VS Code activation in particular has to survive it. Loud, not
     // silent: the cause is logged at error and the host continues with
     // whatever bundled agents already reconciled.
     log.error(`Error copying default agents: ${toErrorMessage(error)}`);
+    return false;
   }
 }

--- a/src/platform/defaults/nodeHost.ts
+++ b/src/platform/defaults/nodeHost.ts
@@ -157,10 +157,10 @@ export function initializeNodeRuntimeSkills(
  * Reconcile packaged agent directories for a host after `initPlatform`.
  *
  * Hosts use different version-state keys, but the resources-path re-entry rule
- * is the same: a process only reconciles a given host channel again when its
- * active packaged resources path changes. Reconciliation failures are reported
- * and swallowed by `bootstrapPlatformAgentDirectories` — a broken agent
- * directory must not abort startup.
+ * is the same: after a successful reconcile, a process only reconciles a given
+ * host channel again when its active packaged resources path changes. Failures
+ * are reported and swallowed by `bootstrapPlatformAgentDirectories` so a broken
+ * agent directory does not abort startup, and a later call can retry.
  */
 export async function bootstrapNodeAgentDirectories(
   options: NodeAgentDirectoryBootstrapOptions,
@@ -172,6 +172,7 @@ export async function bootstrapNodeAgentDirectories(
     return;
   }
 
-  await bootstrapPlatformAgentDirectories(options);
-  bootstrappedAgentDirectoryResources.set(guardKey, options.resourcesPath);
+  if (await bootstrapPlatformAgentDirectories(options)) {
+    bootstrappedAgentDirectoryResources.set(guardKey, options.resourcesPath);
+  }
 }

--- a/src/platform/defaults/nodeHost.ts
+++ b/src/platform/defaults/nodeHost.ts
@@ -96,6 +96,7 @@ export interface NodeRuntimeSkillOptions {
 }
 
 const bootstrappedAgentDirectoryResources = new Map<string, string>();
+const agentDirectoryBootstrapQueues = new Map<string, Promise<void>>();
 
 /**
  * Assemble the platform services for a Node-family host (CLI, desktop,
@@ -166,13 +167,27 @@ export async function bootstrapNodeAgentDirectories(
   options: NodeAgentDirectoryBootstrapOptions,
 ): Promise<void> {
   const guardKey = `${options.channel}:${options.versionStateKey}`;
-  if (
-    bootstrappedAgentDirectoryResources.get(guardKey) === options.resourcesPath
-  ) {
-    return;
-  }
+  const queuedBootstrap = (
+    agentDirectoryBootstrapQueues.get(guardKey) ?? Promise.resolve()
+  ).then(async () => {
+    if (
+      bootstrappedAgentDirectoryResources.get(guardKey) ===
+      options.resourcesPath
+    ) {
+      return;
+    }
 
-  if (await bootstrapPlatformAgentDirectories(options)) {
-    bootstrappedAgentDirectoryResources.set(guardKey, options.resourcesPath);
+    if (await bootstrapPlatformAgentDirectories(options)) {
+      bootstrappedAgentDirectoryResources.set(guardKey, options.resourcesPath);
+    }
+  });
+  agentDirectoryBootstrapQueues.set(guardKey, queuedBootstrap);
+
+  try {
+    await queuedBootstrap;
+  } finally {
+    if (agentDirectoryBootstrapQueues.get(guardKey) === queuedBootstrap) {
+      agentDirectoryBootstrapQueues.delete(guardKey);
+    }
   }
 }

--- a/src/platform/defaults/nodeHost.ts
+++ b/src/platform/defaults/nodeHost.ts
@@ -167,9 +167,10 @@ export async function bootstrapNodeAgentDirectories(
   options: NodeAgentDirectoryBootstrapOptions,
 ): Promise<void> {
   const guardKey = `${options.channel}:${options.versionStateKey}`;
-  const queuedBootstrap = (
-    agentDirectoryBootstrapQueues.get(guardKey) ?? Promise.resolve()
-  ).then(async () => {
+  const predecessor =
+    agentDirectoryBootstrapQueues.get(guardKey) ?? Promise.resolve();
+  const settledPredecessor = predecessor.catch(() => undefined);
+  const queuedBootstrap = settledPredecessor.then(async () => {
     if (
       bootstrappedAgentDirectoryResources.get(guardKey) ===
       options.resourcesPath

--- a/src/test-kernel/agent/PlatformAgentDirectories.vitest.ts
+++ b/src/test-kernel/agent/PlatformAgentDirectories.vitest.ts
@@ -149,7 +149,7 @@ describe('bootstrapPlatformAgentDirectories', () => {
 
     const bootstrapped = bootstrap();
     await vi.runAllTimersAsync();
-    await bootstrapped;
+    await expect(bootstrapped).resolves.toBe(false);
 
     expect(runExclusive).toHaveBeenCalledTimes(21);
     expect(logs.warn).toHaveBeenCalledWith(

--- a/src/test-kernel/agent/PlatformAgentDirectories.vitest.ts
+++ b/src/test-kernel/agent/PlatformAgentDirectories.vitest.ts
@@ -97,8 +97,9 @@ describe('bootstrapPlatformAgentDirectories', () => {
       },
     );
 
-    await Promise.all([bootstrap(), bootstrap(), bootstrap()]);
+    const results = await Promise.all([bootstrap(), bootstrap(), bootstrap()]);
 
+    expect(results).toEqual([true, true, true]);
     expect(maxActiveCopies).toBe(1);
     expect(copied).toEqual([
       'agents',
@@ -194,10 +195,10 @@ describe('bootstrapPlatformAgentDirectories', () => {
     expect(logs.error).not.toHaveBeenCalled();
   });
 
-  it('logs a copy failure instead of aborting host startup', async () => {
+  it('reports a copy failure without aborting host startup', async () => {
     vi.spyOn(platform().fs, 'copy').mockRejectedValue(new Error('copy failed'));
 
-    await expect(bootstrap()).resolves.toBeUndefined();
+    await expect(bootstrap()).resolves.toBe(false);
 
     expect(logs.error).toHaveBeenCalledWith(
       expect.stringContaining('copy failed'),

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve, sep } from 'node:path';
+import { setImmediate as nextTurn } from 'node:timers/promises';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -242,6 +243,30 @@ describe('desktop agent directory bootstrap', () => {
     expect(copy).toHaveBeenCalledTimes(2);
   });
 
+  it('runs a queued bootstrap after its predecessor rejects', async () => {
+    const { bootstrapNodeAgentDirectories, resourcesPath } =
+      await createHarness();
+    const copy = vi.spyOn(nodeFilesystem, 'copy').mockResolvedValue(undefined);
+    const first = bootstrapNodeAgentDirectories({
+      channel: 'desktop',
+      get resourcesPath(): string {
+        throw new Error('unexpected bootstrap failure');
+      },
+      currentVersion: '1.2.3',
+      versionStateKey: GlobalStateKey.LAST_KNOWN_VERSION,
+    });
+    const second = bootstrapNodeAgentDirectories({
+      channel: 'desktop',
+      resourcesPath,
+      currentVersion: '1.2.3',
+      versionStateKey: GlobalStateKey.LAST_KNOWN_VERSION,
+    });
+
+    await expect(first).rejects.toThrow('unexpected bootstrap failure');
+    await expect(second).resolves.toBeUndefined();
+    expect(copy).toHaveBeenCalledTimes(2);
+  });
+
   it('serializes overlapping resource paths in request order', async () => {
     const { bootstrapNodeAgentDirectories, resourcesPath } =
       await createHarness();
@@ -250,20 +275,21 @@ describe('desktop agent directory bootstrap', () => {
     const firstCopyBlocked = new Promise<void>((resolve) => {
       releaseFirstCopy = resolve;
     });
-    const copy = vi
-      .spyOn(nodeFilesystem, 'copy')
-      .mockImplementationOnce(() => firstCopyBlocked)
-      .mockResolvedValue(undefined);
-    vi.spyOn(nodeFileLocks, 'runExclusive').mockImplementation(
-      (_lockPath, operation) => operation(),
-    );
+    const copiedSources: string[] = [];
+    vi.spyOn(nodeFilesystem, 'copy').mockImplementation(async (source) => {
+      copiedSources.push(source);
+      if (copiedSources.length === 1) await firstCopyBlocked;
+    });
+    const runExclusive = vi
+      .spyOn(nodeFileLocks, 'runExclusive')
+      .mockImplementation((_lockPath, operation) => operation());
     const first = bootstrapNodeAgentDirectories({
       channel: 'desktop',
       resourcesPath,
       currentVersion: '1.2.3',
       versionStateKey: GlobalStateKey.LAST_KNOWN_VERSION,
     });
-    await vi.waitFor(() => expect(copy).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(copiedSources).toHaveLength(1));
     const secondOptions = {
       channel: 'desktop',
       resourcesPath: nextResourcesPath,
@@ -271,16 +297,22 @@ describe('desktop agent directory bootstrap', () => {
       versionStateKey: GlobalStateKey.LAST_KNOWN_VERSION,
     };
     const second = bootstrapNodeAgentDirectories(secondOptions);
-    const fallback = setTimeout(() => releaseFirstCopy(), 50);
-    const releaseAfterSecond = second.then(() => {
-      clearTimeout(fallback);
-      releaseFirstCopy();
-    });
 
-    await Promise.all([first, second, releaseAfterSecond]);
+    await nextTurn();
+    expect(runExclusive).toHaveBeenCalledOnce();
+    expect(copiedSources).toEqual([join(resourcesPath, 'agents')]);
+
+    releaseFirstCopy();
+    await Promise.all([first, second]);
+    expect(copiedSources).toEqual([
+      join(resourcesPath, 'agents'),
+      join(resourcesPath, 'tool_use_agents'),
+      join(nextResourcesPath, 'agents'),
+      join(nextResourcesPath, 'tool_use_agents'),
+    ]);
+
     await bootstrapNodeAgentDirectories(secondOptions);
-
-    expect(copy).toHaveBeenCalledTimes(4);
+    expect(copiedSources).toHaveLength(4);
   });
 
   it('uses the configured version-state key', async () => {

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
@@ -187,6 +187,41 @@ describe('desktop agent directory bootstrap', () => {
     await expect(readFile(copiedAgent, 'utf8')).resolves.toBe('name: next\n');
   });
 
+  it('retries a failed reconcile and guards the resource path after success', async () => {
+    const { bootstrapNodeAgentDirectories, resourcesPath, storage } =
+      await createHarness();
+    const copy = vi
+      .spyOn(nodeFilesystem, 'copy')
+      .mockRejectedValueOnce(new Error('copy failed'));
+    const options = {
+      channel: 'desktop',
+      resourcesPath,
+      currentVersion: '1.2.3',
+      versionStateKey: GlobalStateKey.LAST_KNOWN_VERSION,
+    };
+
+    await expect(
+      bootstrapNodeAgentDirectories(options),
+    ).resolves.toBeUndefined();
+    expect(copy).toHaveBeenCalledOnce();
+
+    await bootstrapNodeAgentDirectories(options);
+    expect(copy).toHaveBeenCalledTimes(3);
+
+    const copiedAgent = join(
+      storage.getGlobalStoragePath(),
+      'agents',
+      'writer.yaml',
+    );
+    await writeFile(copiedAgent, 'name: locally-edited\n');
+
+    await bootstrapNodeAgentDirectories(options);
+    expect(copy).toHaveBeenCalledTimes(3);
+    await expect(readFile(copiedAgent, 'utf8')).resolves.toBe(
+      'name: locally-edited\n',
+    );
+  });
+
   it('uses the configured version-state key', async () => {
     const { bootstrapNodeAgentDirectories, globalStateStore, resourcesPath } =
       await createHarness();

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
@@ -31,6 +31,7 @@ describe('desktop agent directory bootstrap', () => {
   const tempDirs = useTempDirs();
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.resetModules();
   });
 
@@ -220,6 +221,66 @@ describe('desktop agent directory bootstrap', () => {
     await expect(readFile(copiedAgent, 'utf8')).resolves.toBe(
       'name: locally-edited\n',
     );
+  });
+
+  it('coalesces concurrent bootstraps for the same resource path', async () => {
+    const { bootstrapNodeAgentDirectories, resourcesPath } =
+      await createHarness();
+    const copy = vi.spyOn(nodeFilesystem, 'copy').mockResolvedValue(undefined);
+    const options = {
+      channel: 'desktop',
+      resourcesPath,
+      currentVersion: '1.2.3',
+      versionStateKey: GlobalStateKey.LAST_KNOWN_VERSION,
+    };
+
+    await Promise.all([
+      bootstrapNodeAgentDirectories(options),
+      bootstrapNodeAgentDirectories(options),
+    ]);
+
+    expect(copy).toHaveBeenCalledTimes(2);
+  });
+
+  it('serializes overlapping resource paths in request order', async () => {
+    const { bootstrapNodeAgentDirectories, resourcesPath } =
+      await createHarness();
+    const nextResourcesPath = join(dirname(resourcesPath), 'resources-next');
+    let releaseFirstCopy!: () => void;
+    const firstCopyBlocked = new Promise<void>((resolve) => {
+      releaseFirstCopy = resolve;
+    });
+    const copy = vi
+      .spyOn(nodeFilesystem, 'copy')
+      .mockImplementationOnce(() => firstCopyBlocked)
+      .mockResolvedValue(undefined);
+    vi.spyOn(nodeFileLocks, 'runExclusive').mockImplementation(
+      (_lockPath, operation) => operation(),
+    );
+    const first = bootstrapNodeAgentDirectories({
+      channel: 'desktop',
+      resourcesPath,
+      currentVersion: '1.2.3',
+      versionStateKey: GlobalStateKey.LAST_KNOWN_VERSION,
+    });
+    await vi.waitFor(() => expect(copy).toHaveBeenCalledOnce());
+    const secondOptions = {
+      channel: 'desktop',
+      resourcesPath: nextResourcesPath,
+      currentVersion: '1.2.4',
+      versionStateKey: GlobalStateKey.LAST_KNOWN_VERSION,
+    };
+    const second = bootstrapNodeAgentDirectories(secondOptions);
+    const fallback = setTimeout(() => releaseFirstCopy(), 50);
+    const releaseAfterSecond = second.then(() => {
+      clearTimeout(fallback);
+      releaseFirstCopy();
+    });
+
+    await Promise.all([first, second, releaseAfterSecond]);
+    await bootstrapNodeAgentDirectories(secondOptions);
+
+    expect(copy).toHaveBeenCalledTimes(4);
   });
 
   it('uses the configured version-state key', async () => {


### PR DESCRIPTION
## Summary
- return reconciliation success from the bundled-agent bootstrap while retaining its catch-and-report ownership
- treat exhausted sync-lock contention as unsuccessful so the resources-path guard remains retryable
- serialize bootstrap requests per host guard key, rechecking the successful path in request order to coalesce same-path calls and preserve later different-path requests
- settle each predecessor before starting the next queued request, preserving the original rejection without poisoning later callers
- cover failure reporting, lock abandonment, retry, queue rejection recovery, same-path concurrency, deterministic different-path ordering, and post-success guard behavior in existing tests

Closes #11000

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/PlatformAgentDirectories.vitest.ts src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts` (14 passed)
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- `corepack pnpm eslint src/platform/defaults/nodeHost.ts src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts`
- `corepack pnpm prettier --check src/platform/defaults/nodeHost.ts src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts`
- `git diff --check`