### PR TITLE
fix(inquiry): write turn payloads atomically

### DIFF
--- a/src/test-kernel/tools/InquiryStorage.vitest.ts
+++ b/src/test-kernel/tools/InquiryStorage.vitest.ts
@@ -119,10 +119,12 @@ describe('InquiryStorage', () => {
   });
 
   it('opens, answers, and resolves a thread end-to-end', async () => {
+    const atomicWriteSpy = vi.spyOn(platform().fs, 'writeFileAtomic');
     const opened = await recordOpenQuestion({
       parentStreamId: STREAM_A,
       parentGenerationId: GENERATION_A,
       question: 'What is the Sobolev constant?',
+      context: 'Use the sharp Euclidean inequality.',
       suggestSearch: false,
     });
 
@@ -144,6 +146,15 @@ describe('InquiryStorage', () => {
     expect(answered!.manifest.status).toBe('answered');
     expect(answered!.turn.parentGenerationId).toBe(GENERATION_A);
     expect(answered!.turn.answer).toBe('C = (n(n-2))^{-1} * ω_n^{2/n}');
+
+    const turnDir = path.join(threadDirFor(opened.threadId), 't1');
+    expect(atomicWriteSpy.mock.calls.map(([target]) => target)).toEqual(
+      expect.arrayContaining([
+        path.join(turnDir, 'question.txt'),
+        path.join(turnDir, 'context.txt'),
+        path.join(turnDir, 'answer.txt'),
+      ]),
+    );
 
     const stillOpen = await listThreadsByStatus({
       status: 'open',

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -365,14 +365,14 @@ export async function recordOpenQuestion(params: {
       : undefined;
 
     const writeOps: Promise<void>[] = [
-      GlobalStorageFS.write(
+      GlobalStorageFS.writeAtomic(
         path.join(turnPath, 'question.txt'),
         params.question,
       ),
     ];
     if (trimmedContext) {
       writeOps.push(
-        GlobalStorageFS.write(
+        GlobalStorageFS.writeAtomic(
           path.join(turnPath, 'context.txt'),
           trimmedContext,
         ),
@@ -427,7 +427,7 @@ export async function recordAnswerForOpenTurn(params: {
       const answerRelativePath = normalizeFilePath(path.join(td, 'answer.txt'));
       const sessionLinks = normalizeSessionLinks(params.sessionLinks);
 
-      await GlobalStorageFS.write(
+      await GlobalStorageFS.writeAtomic(
         path.join(turnPath, 'answer.txt'),
         params.answer,
       );


### PR DESCRIPTION
## Summary
- route external-inquiry question, context, and answer payloads through `writeAtomic`
- preserve the existing payload-before-manifest ordering and propagated write failures
- pin atomic routing for every persisted turn payload without asserting internal call counts

## Validation
- `pnpm vitest run src/test-kernel/tools/InquiryStorage.vitest.ts src/test-kernel/platform/NodeFilesystemAtomicWrite.vitest.ts` (20 passed)
- `pnpm exec prettier --check src/tools/inquiry/externalInquiryStorage.ts src/test-kernel/tools/InquiryStorage.vitest.ts`
- `pnpm exec eslint src/tools/inquiry/externalInquiryStorage.ts src/test-kernel/tools/InquiryStorage.vitest.ts`
- `pnpm run typecheck:workspace`
- `pnpm run typecheck:test-kernel`
- `pnpm run typecheck:agent`
- `git diff --check origin/main...HEAD`

Closes #11035