### PR TITLE
refactor(runtime): delete the cancellationScope selector dimension

### DIFF
--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -75,12 +75,7 @@ export type ReportReviewIssueSink = (report: ReviewIssueReport) => {
   readonly reason?: string;
 };
 
-export interface HostInteractionOptions {
-  /** Internal identity used to cancel one forwarded presentation request. */
-  readonly cancellationScope?: object;
-}
-
-export interface HostRetryInteractionOptions extends HostInteractionOptions {
+export interface HostRetryInteractionOptions {
   /**
    * Rebuild the caller's model client after a host-side credential change.
    * A host that calls this successfully has prepared the next attempt; a
@@ -313,8 +308,6 @@ export interface HostInteractionCancelSelector {
   readonly streamId?: StreamTabId | null;
   readonly kind?: PendingInteractionKind;
   readonly cause?: string;
-  /** Internal identity for one forwarded presentation request. */
-  readonly cancellationScope?: object;
 }
 
 /** Shared selector predicate for the ports' pending registries. */
@@ -322,17 +315,10 @@ export function matchesCancelSelector(
   pending: {
     readonly kind: PendingInteractionKind;
     readonly streamId?: StreamTabId;
-    readonly cancellationScope?: object;
   },
   selector: HostInteractionCancelSelector,
 ): boolean {
   if (selector.kind !== undefined && pending.kind !== selector.kind) {
-    return false;
-  }
-  if (
-    selector.cancellationScope !== undefined &&
-    pending.cancellationScope !== selector.cancellationScope
-  ) {
     return false;
   }
   if (selector.streamId === undefined) return true;
@@ -370,19 +356,15 @@ export interface HostInteractions {
   showInfoMessage?(message: string): Promise<void> | void;
   requestToolEditApproval?(
     request: ToolEditApprovalRequest,
-    options?: HostInteractionOptions,
   ): Promise<ToolEditApprovalResult> | undefined;
   requestBashApproval?(
     request: HostBashApprovalRequest,
-    options?: HostInteractionOptions,
   ): Promise<BashSettlement> | undefined;
   requestPlanApproval?(
     request: HostPlanApprovalRequest,
-    options?: HostInteractionOptions,
   ): Promise<PlanApprovalResult> | undefined;
   requestAgentProposal?(
     request: HostAgentProposalRequest,
-    options?: HostInteractionOptions,
   ): Promise<ProposalResult> | undefined;
   requestRetry?(
     request: HostRetryRequest,
@@ -390,7 +372,6 @@ export interface HostInteractions {
   ): Promise<RetryResult> | undefined;
   askUserQuestion?(
     request: HostUserQuestionRequest,
-    options?: HostInteractionOptions,
   ): Promise<UserQuestionSettlement> | undefined;
   openExternalInquiry?(
     request: HostExternalInquiryRequest,
@@ -561,49 +542,44 @@ export class SessionHostInteractions implements HostInteractions {
 
   requestToolEditApproval(
     request: ToolEditApprovalRequest,
-    options?: HostInteractionOptions,
   ): Promise<ToolEditApprovalResult> {
     return this.enqueue<ToolEditApprovalResult>(
       'toolEdit',
       request.streamId,
-      (interactions) =>
-        interactions.requestToolEditApproval?.(request, options),
+      (interactions) => interactions.requestToolEditApproval?.(request),
       (cause) => cancellationResultFor('toolEdit', cause),
     );
   }
 
   requestBashApproval(
     request: HostBashApprovalRequest,
-    options?: HostInteractionOptions,
   ): Promise<BashSettlement> {
     return this.enqueue<BashSettlement>(
       'bash',
       request.streamId ?? undefined,
-      (interactions) => interactions.requestBashApproval?.(request, options),
+      (interactions) => interactions.requestBashApproval?.(request),
       (cause) => cancellationResultFor('bash', cause),
     );
   }
 
   requestPlanApproval(
     request: HostPlanApprovalRequest,
-    options?: HostInteractionOptions,
   ): Promise<PlanApprovalResult> {
     return this.enqueue<PlanApprovalResult>(
       'planApproval',
       request.streamId,
-      (interactions) => interactions.requestPlanApproval?.(request, options),
+      (interactions) => interactions.requestPlanApproval?.(request),
       (cause) => cancellationResultFor('planApproval', cause),
     );
   }
 
   requestAgentProposal(
     request: HostAgentProposalRequest,
-    options?: HostInteractionOptions,
   ): Promise<ProposalResult> {
     return this.enqueue<ProposalResult>(
       'proposal',
       request.streamId,
-      (interactions) => interactions.requestAgentProposal?.(request, options),
+      (interactions) => interactions.requestAgentProposal?.(request),
       (cause) => cancellationResultFor('proposal', cause),
     );
   }
@@ -622,12 +598,11 @@ export class SessionHostInteractions implements HostInteractions {
 
   askUserQuestion(
     request: HostUserQuestionRequest,
-    options?: HostInteractionOptions,
   ): Promise<UserQuestionSettlement> {
     return this.enqueue<UserQuestionSettlement>(
       'userQuestion',
       request.streamId || undefined,
-      (interactions) => interactions.askUserQuestion?.(request, options),
+      (interactions) => interactions.askUserQuestion?.(request),
       (cause) => cancellationResultFor('userQuestion', cause),
     );
   }

--- a/src/controllers/approval/ToolEditApprovalController.ts
+++ b/src/controllers/approval/ToolEditApprovalController.ts
@@ -14,7 +14,6 @@ import {
   cancellationResultFor,
   matchesCancelSelector,
   type HostInteractionCancelSelector,
-  type HostInteractionOptions,
 } from '@agent/runtime/HostInteractions';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { isLatexFile } from '@common/files/fileTypeUtils';
@@ -115,7 +114,6 @@ export interface ToolEditApprovalControllerOptions {
 interface InitializingToolEditApproval {
   readonly phase: 'initializing';
   readonly request: ToolEditApprovalRequest;
-  readonly cancellationScope?: object;
   /** The result an approve or cancel produced while staging was still running. */
   resolution?: ToolEditApprovalResult;
 }
@@ -127,7 +125,6 @@ interface PendingToolEditApproval extends LatexPreviewEntry {
   readonly request: ToolEditApprovalRequest;
   readonly relativePath: string;
   readonly preview: ToolEditPreview;
-  readonly cancellationScope?: object;
   settle: (result: ToolEditApprovalResult) => void;
 }
 
@@ -146,7 +143,6 @@ export class ToolEditApprovalController {
 
   async requestApproval(
     request: ToolEditApprovalRequest,
-    options?: HostInteractionOptions,
   ): Promise<ToolEditApprovalResult> {
     if (this.disposed) {
       throw new Error('Tool edit approval controller is disposed.');
@@ -157,7 +153,6 @@ export class ToolEditApprovalController {
     const initialization: InitializingToolEditApproval = {
       phase: 'initializing',
       request,
-      cancellationScope: options?.cancellationScope,
     };
     this.requests.set(requestId, initialization);
 
@@ -186,7 +181,6 @@ export class ToolEditApprovalController {
       request,
       relativePath,
       preview,
-      cancellationScope: initialization.cancellationScope,
       originalUri: { fsPath: preview.originalPath },
       proposedUri: { fsPath: preview.proposedPath },
       originalContent: request.originalContent,
@@ -284,11 +278,7 @@ export class ToolEditApprovalController {
     for (const state of [...this.requests.values()]) {
       if (
         !matchesCancelSelector(
-          {
-            kind: 'toolEdit',
-            streamId: state.request.streamId ?? undefined,
-            cancellationScope: state.cancellationScope,
-          },
+          { kind: 'toolEdit', streamId: state.request.streamId ?? undefined },
           selector,
         )
       ) {

--- a/src/controllers/progressView/backend/ApprovalRequestHandler.ts
+++ b/src/controllers/progressView/backend/ApprovalRequestHandler.ts
@@ -8,7 +8,6 @@ type PendingPresentation<T> = {
 type PendingInteraction<T, Result> = {
   readonly mode: 'interaction';
   readonly item: T;
-  readonly cancellationScope?: object;
   readonly cancellationResult: (cause?: string) => Result;
   readonly complete: (result: Result) => void;
 };
@@ -17,14 +16,8 @@ type PendingRequest<T, Result> =
   PendingPresentation<T> | PendingInteraction<T, Result>;
 
 interface ApprovalInteractionOptions<Result> {
-  cancellationScope?: object;
   cancellationResult: (cause?: string) => Result;
 }
-
-type InteractionPredicate<T> = (
-  item: T,
-  cancellationScope: object | undefined,
-) => boolean;
 
 /**
  * Owns the complete lifecycle of one progress-view request kind: payload,
@@ -68,7 +61,6 @@ export class ApprovalRequestHandler<
       this.register(id, {
         mode: 'interaction',
         item,
-        cancellationScope: options.cancellationScope,
         cancellationResult: options.cancellationResult,
         complete,
       });
@@ -115,12 +107,12 @@ export class ApprovalRequestHandler<
   }
 
   /** Cancel every matching response-bearing request. */
-  cancelWhere(predicate: InteractionPredicate<T>, cause?: string): number {
+  cancelWhere(predicate: (item: T) => boolean, cause?: string): number {
     let cancelled = 0;
     for (const [id, entry] of [...this.pending]) {
       if (
         entry.mode === 'interaction' &&
-        predicate(entry.item, entry.cancellationScope) &&
+        predicate(entry.item) &&
         this.completeEntry(id, entry, entry.cancellationResult(cause), true)
       ) {
         cancelled += 1;

--- a/src/controllers/progressView/backend/progressBackendUiConfig.ts
+++ b/src/controllers/progressView/backend/progressBackendUiConfig.ts
@@ -65,10 +65,7 @@ export interface ApprovalRequestHandlerSet {
  *  indexed by interaction kind without narrowing to a concrete payload type. */
 interface CancellableApprovalRequestHandler {
   cancelWhere(
-    predicate: (
-      item: { readonly streamId: string },
-      cancellationScope?: object,
-    ) => boolean,
+    predicate: (item: { readonly streamId: string }) => boolean,
     cause?: string,
   ): number;
 }
@@ -83,13 +80,9 @@ export function cancelApprovalRequestHandlers(
   for (const kind of kinds) {
     const handler: CancellableApprovalRequestHandler = handlers[kind];
     cancelled += handler.cancelWhere(
-      (item, cancellationScope) =>
+      (item) =>
         matchesCancelSelector(
-          {
-            kind,
-            streamId: item.streamId || undefined,
-            cancellationScope,
-          },
+          { kind, streamId: item.streamId || undefined },
           selector,
         ),
       selector.cause,

--- a/src/controllers/progressView/backend/progressHostInteractions.ts
+++ b/src/controllers/progressView/backend/progressHostInteractions.ts
@@ -11,7 +11,6 @@ import {
   type HostApprovalBypassStateUpdate,
   type HostBashApprovalRequest,
   type HostInteractionCancelSelector,
-  type HostInteractionOptions,
   type HostInteractions,
   type HostPlanApprovalRequest,
   type HostRetryInteractionOptions,
@@ -125,7 +124,6 @@ export function createProgressHostInteractions(
       HostRetryInteractionOptions['prepareRetry']
     >;
     readonly controller: AbortController;
-    readonly cancellationScope?: object;
     settling: boolean;
     selection?: 'configured' | 'personal';
     settlement?: Promise<boolean>;
@@ -260,16 +258,7 @@ export function createProgressHostInteractions(
     }
     if (selector.kind == null || selector.kind === 'retry') {
       for (const [streamId, preparation] of retryPreparations) {
-        if (
-          matchesCancelSelector(
-            {
-              kind: 'retry',
-              streamId,
-              cancellationScope: preparation.cancellationScope,
-            },
-            selector,
-          )
-        ) {
+        if (matchesCancelSelector({ kind: 'retry', streamId }, selector)) {
           preparation.controller.abort();
         }
       }
@@ -374,34 +363,25 @@ export function createProgressHostInteractions(
 
     requestToolEditApproval(
       request: ToolEditApprovalRequest,
-      interactionOptions?: HostInteractionOptions,
     ): Promise<ToolEditApprovalResult> {
-      return options
-        .getToolEditApprovals()
-        .requestApproval(request, interactionOptions);
+      return options.getToolEditApprovals().requestApproval(request);
     },
 
     requestBashApproval(
       request: HostBashApprovalRequest,
-      interactionOptions?: HostInteractionOptions,
     ): Promise<BashSettlement> {
       revealStream(request.streamId);
       return handlers().bash.request(
         prepareBashApprovalPrompt(request, options.session),
-        {
-          cancellationScope: interactionOptions?.cancellationScope,
-          cancellationResult: (cause) => cancellationResultFor('bash', cause),
-        },
+        { cancellationResult: (cause) => cancellationResultFor('bash', cause) },
       );
     },
 
     requestPlanApproval(
       request: HostPlanApprovalRequest,
-      interactionOptions?: HostInteractionOptions,
     ): Promise<PlanApprovalResult> {
       revealStream(request.streamId);
       return handlers().planApproval.request(request, {
-        cancellationScope: interactionOptions?.cancellationScope,
         cancellationResult: (cause) =>
           cancellationResultFor('planApproval', cause),
       });
@@ -409,11 +389,9 @@ export function createProgressHostInteractions(
 
     requestAgentProposal(
       request: AgentProposalPermission,
-      interactionOptions?: HostInteractionOptions,
     ): Promise<ProposalResult> {
       revealStream(request.streamId);
       return handlers().proposal.request(request, {
-        cancellationScope: interactionOptions?.cancellationScope,
         cancellationResult: (cause) => cancellationResultFor('proposal', cause),
       });
     },
@@ -438,25 +416,21 @@ export function createProgressHostInteractions(
           requestId: request.requestId,
           prepareRetry: interactionOptions.prepareRetry,
           controller: new AbortController(),
-          cancellationScope: interactionOptions.cancellationScope,
           settling: false,
         });
       } else {
         retryPreparations.delete(request.streamId);
       }
       return handlers().retry.request(request, {
-        cancellationScope: interactionOptions?.cancellationScope,
         cancellationResult: (cause) => cancellationResultFor('retry', cause),
       });
     },
 
     askUserQuestion(
       request: Parameters<NonNullable<HostInteractions['askUserQuestion']>>[0],
-      interactionOptions?: HostInteractionOptions,
     ): Promise<UserQuestionSettlement> {
       revealStream(request.streamId || undefined);
       return handlers().userQuestion.request(request, {
-        cancellationScope: interactionOptions?.cancellationScope,
         cancellationResult: (cause) =>
           cancellationResultFor('userQuestion', cause),
       });

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -4,7 +4,6 @@ import { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   type BashSettlement,
   matchesCancelSelector,
-  type HostInteractionOptions,
   HostInteractions,
   type HostPlanApprovalRequest,
   type PlanApprovalResult,
@@ -166,7 +165,6 @@ function createControllablePlanAdapter(
     string,
     {
       readonly request: HostPlanApprovalRequest;
-      readonly cancellationScope?: object;
       readonly settle: (result: PlanApprovalResult) => void;
     }
   >();
@@ -176,25 +174,17 @@ function createControllablePlanAdapter(
     pending.clear();
   });
   const interactions: HostInteractions = {
-    requestPlanApproval(request, requestOptions?: HostInteractionOptions) {
+    requestPlanApproval(request) {
       requests.push(request);
       return new Promise((settle) =>
-        pending.set(request.requestId, {
-          request,
-          cancellationScope: requestOptions?.cancellationScope,
-          settle,
-        }),
+        pending.set(request.requestId, { request, settle }),
       );
     },
     cancel(selector = {}) {
       for (const [requestId, entry] of pending) {
         if (
           !matchesCancelSelector(
-            {
-              kind: 'planApproval',
-              streamId: entry.request.streamId,
-              cancellationScope: entry.cancellationScope,
-            },
+            { kind: 'planApproval', streamId: entry.request.streamId },
             selector,
           )
         )

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.ts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.ts
@@ -226,11 +226,8 @@ describe('createDesktopHostInteractions', () => {
       interactions.requestToolEditApproval(request),
     ).resolves.toEqual({ action: 'apply', appliedContent: 'new' });
     // The controller owns its window session (options.session), so the call
-    // carries only the request and the caller's interaction options.
-    expect(toolEditApprovals.requestApproval).toHaveBeenCalledWith(
-      request,
-      undefined,
-    );
+    // carries only the request.
+    expect(toolEditApprovals.requestApproval).toHaveBeenCalledWith(request);
   });
 
   it('rejects a plan decision for a pending bash request', async () => {

--- a/src/test-kernel/progressView/ApprovalRequestHandler.vitest.ts
+++ b/src/test-kernel/progressView/ApprovalRequestHandler.vitest.ts
@@ -194,26 +194,18 @@ describe('ApprovalRequestHandler', () => {
     expect(sendShow).toHaveBeenCalledTimes(2);
   });
 
-  it('cancels only interactions matching both stream and cancellation scope', async () => {
+  it('cancels only interactions matching the stream', async () => {
     const { handler } = createHandler();
-    const targetScope = {};
-    const otherScope = {};
     const target = handler.request(request('target', 'stream-a'), {
-      cancellationScope: targetScope,
-      cancellationResult,
-    });
-    const wrongScope = handler.request(request('wrong-scope', 'stream-a'), {
-      cancellationScope: otherScope,
       cancellationResult,
     });
     const wrongStream = handler.request(request('wrong-stream', 'stream-b'), {
-      cancellationScope: targetScope,
       cancellationResult,
     });
 
     expect(
       handler.cancelWhere(
-        (item, scope) => item.streamId === 'stream-a' && scope === targetScope,
+        (item) => item.streamId === 'stream-a',
         'Scoped cleanup.',
       ),
     ).toBe(1);
@@ -221,14 +213,9 @@ describe('ApprovalRequestHandler', () => {
       action: 'cancel',
       cause: 'Scoped cleanup.',
     });
-    expect(handler.get('wrong-scope')).toBeDefined();
     expect(handler.get('wrong-stream')).toBeDefined();
 
     handler.clear();
-    await expect(wrongScope).resolves.toEqual({
-      action: 'cancel',
-      cause: undefined,
-    });
     await expect(wrongStream).resolves.toEqual({
       action: 'cancel',
       cause: undefined,

--- a/src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts
+++ b/src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts
@@ -20,7 +20,6 @@ function spyHandlerSet(
 
 describe('ApprovalRequestHandlerSet helpers', () => {
   it('routes cancellation through the handler named by the interaction kind', () => {
-    const cancellationScope = {};
     const request = { streamId: 'stream-1' };
     const cancelWhere = {
       bash: vi.fn(),
@@ -32,7 +31,7 @@ describe('ApprovalRequestHandlerSet helpers', () => {
     for (const cancel of Object.values(cancelWhere)) {
       cancel.mockImplementation((predicate, cause) => {
         expect(cause).toBe('Session closed.');
-        return predicate(request, cancellationScope) ? 1 : 0;
+        return predicate(request) ? 1 : 0;
       });
     }
     const handlers = spyHandlerSet('cancelWhere', cancelWhere);
@@ -49,7 +48,6 @@ describe('ApprovalRequestHandlerSet helpers', () => {
         cancelApprovalRequestHandlers(handlers, [kind], {
           kind,
           streamId: 'stream-1',
-          cancellationScope,
           cause: 'Session closed.',
         }),
       ).toBe(1);

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
@@ -685,58 +685,6 @@ describe('createExtensionHostInteractions', () => {
     expect(handlers.transport.retry.dismiss).toHaveBeenCalledWith('stream-a');
   });
 
-  it('does not abort preparations outside the cancellation scope', async () => {
-    const { interactions } = createInteractions({
-      session: createTestSession(),
-    });
-    const scopeA = {};
-    const scopeB = {};
-    const preparationA = createDeferredPreparation();
-    const preparationB = createDeferredPreparation();
-
-    const resultA = interactions.requestRetry?.(
-      {
-        requestId: 'retry:scope-a',
-        streamId: STREAM_A,
-        operation: 'Scoped A',
-      },
-      { prepareRetry: preparationA.prepareRetry, cancellationScope: scopeA },
-    );
-    const resultB = interactions.requestRetry?.(
-      {
-        requestId: 'retry:scope-b',
-        streamId: STREAM_B,
-        operation: 'Scoped B',
-      },
-      { prepareRetry: preparationB.prepareRetry, cancellationScope: scopeB },
-    );
-    expect(
-      interactions.submitRetryDecision(STREAM_A, 'retry:scope-a', {
-        action: 'retry',
-      }),
-    ).toBe(true);
-    expect(
-      interactions.submitRetryDecision(STREAM_B, 'retry:scope-b', {
-        action: 'retry',
-      }),
-    ).toBe(true);
-    await vi.waitFor(() =>
-      expect(preparationA.prepareRetry).toHaveBeenCalledOnce(),
-    );
-    await vi.waitFor(() =>
-      expect(preparationB.prepareRetry).toHaveBeenCalledOnce(),
-    );
-
-    interactions.cancel({ cancellationScope: scopeA });
-
-    await expect(resultA).resolves.toEqual({ action: 'cancel' });
-    expect(preparationA.signal()?.aborted).toBe(true);
-    expect(preparationB.signal()?.aborted).toBe(false);
-
-    preparationB.deferred.resolve();
-    await expect(resultB).resolves.toEqual({ action: 'retry' });
-  });
-
   it('cancels pending retry requests for a removed stream', async () => {
     const presentationSink = createPresentationSink();
     const { handlers, interactions } = createInteractions({
@@ -965,9 +913,6 @@ describe('createExtensionHostInteractions', () => {
     await expect(interactions.requestToolEditApproval?.(request)).resolves.toBe(
       approvalResult,
     );
-    expect(toolEditApprovals.requestApproval).toHaveBeenCalledWith(
-      request,
-      undefined,
-    );
+    expect(toolEditApprovals.requestApproval).toHaveBeenCalledWith(request);
   });
 });


### PR DESCRIPTION
## Summary

`cancellationScope` was an `object` identity threaded through the host-interaction
port so one *forwarded presentation request* could be cancelled without touching its
peers. It was introduced by #8301 (`fix(desktop): preserve approvals across
rebinding`, Jul 2026) for the desktop rebinding path — a path since removed by
`fe0b67c36e` (desktop owns the process session directly) and `4037a7ef73`
(centralize interaction ownership).

At HEAD **nothing produces a scope**. Every occurrence is a declaration or a forward
of `undefined`:

- every request call site passes the request alone (`bashApproval.ts:125`,
  `toolEditApproval.ts:232`, `PlanTool.ts:244`, `proposalFlow.ts:193`,
  `UserQuestionTool.ts:72`, `ExternalInquiryTool.ts:373`); the only two-argument
  call is `ModelInvocationNode.ts:564`, which passes `{ prepareRetry }`;
- every `interactions.cancel(...)` passes `{ streamId?, kind?, cause? }` only
  (`src/tools/approval/index.ts:75,119`, `AgentRunLifecycle.ts:492,799`,
  `runToolUseFlow.ts:365`, `chatSessionController.ts:863`,
  `ProgressViewMessageHandler.ts:165,184`, `desktopAgentExecution.ts:286,303`,
  `HostInteractions.ts` internal).

So this is retired machinery, not speculative generality: the two live cancel
dimensions (`streamId`, `kind`) already select exactly what every caller wants.

Deleting the field collapses the things that existed only to carry it:
`HostInteractionOptions` (it held nothing else), the now-empty `options?` parameter
on the five non-retry request methods of `HostInteractions` /
`SessionHostInteractions`, `ApprovalRequestHandler`'s two-argument cancel predicate
(now identical to `completeWhere`'s), and the per-entry scope fields on
`ToolEditApprovalController`'s two request states and on the progress view's retry
preparations. `HostRetryInteractionOptions` stays — it still carries `prepareRetry`
— it just no longer extends a deleted interface.

## Issue acceptance gates

n/a — verified collapse-sweep finding, no tracking issue.

## Single source of truth

`HostInteractionCancelSelector` in `src/agent/runtime/HostInteractions.ts` remains
the single selector shape, now with exactly the three dimensions production uses;
`matchesCancelSelector` remains its single predicate, shared by the session port,
the tool-edit controller, and the progress backend handler set.

## Duplication and abstraction budget

No abstraction added. One inert type (`HostInteractionOptions`), one inert selector
dimension, one inert predicate parameter, and four inert state fields removed.

## Net elements (R6)

Net **−156 LoC** (22 insertions, 178 deletions across 9 files), of which −86 is
production and −70 is test.

- Files: ±0 (no file added or deleted).
- Exported symbols: **−1** (`HostInteractionOptions`). `HostRetryInteractionOptions`
  is preserved (declared standalone instead of extending).
- Types/interfaces: −2 (`HostInteractionOptions`, `InteractionPredicate<T>`).
- Functions/methods: ±0; six method signatures lose a parameter, one predicate loses
  an argument.
- Tests: one obsolete case deleted (`ExtensionHostInteractions.vitest.ts` "does not
  abort preparations outside the cancellation scope" — it pinned the deleted seam);
  one case trimmed to the surviving stream dimension
  (`ApprovalRequestHandler.vitest.ts`); no test added.

This is a straight reduction.

## Consumer counts (R8)

```
$ grep -rn --include='*.ts' --include='*.tsx' -e 'cancellationScope' -e 'HostInteractionOptions' src packages | grep -v node_modules | grep -v '/dist/'
```
Before: 30 hits over 9 files (5 production, 4 test). After: 0.

- `HostInteractionOptions` was **not** on the `@agent/runtime` barrel
  (`src/agent/runtime/index.ts:41-56` exports `HostRetryInteractionOptions` only) and
  is **not** re-exported by `packages/agent/src/index.ts` (which declares its own
  minimal `HostInteractionCancelSelector`). No SDK surface change, no
  `host-agent-import-baseline` entry, no `knip-baseline` entry
  (`grep -rn 'HostInteractionOptions\|cancellationScope' config/ratchets/` → empty).
- `HostRetryInteractionOptions` *is* barrel-exported and *is* imported by the CLI
  (`subscribeApprovals.ts:25`) — kept, unchanged shape apart from the dead field.

## Host impact

Extension: none observable. `cancel({ streamId, kind, cause })` selects exactly the
same pending set it did before, because no caller ever narrowed by scope.

Desktop: none. `packages/desktop` references `cancellationScope` nowhere at HEAD.

CLI: none. The CLI never read or produced the field.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean (workspace, test-kernel, agent, cli, trace-viewer,
  desktop).
- `npx vitest run src/test-kernel/progressView/ src/test-kernel/agent/runtime/SessionInteractions.vitest.ts`
  — 61 files, 592 tests, all pass.
- `npx vitest run src/test-kernel/controllers/ToolEditApprovalController.vitest.ts src/test-kernel/frontend/VscodeToolEditApproval.vitest.ts src/test-kernel/desktop/DesktopToolEditApproval.vitest.ts`
  — 26 tests pass.
- `npm run lint` — clean. `npx prettier --check` — clean.
- `npm run check:dead-code-ratchet` — 8 current vs 8 baselined, OK.
