### PR TITLE
fix(progressView): render exitCode, "(no output)", and file media; own the statistics label once

### DIFF
--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -121,7 +121,6 @@ function deriveTranscriptRowHeadline(row: TranscriptRow): string {
     case 'latexdiff':
       return `Latexdiff results (${row.entries.length})`;
     case 'statistics':
-      return 'Usage';
     case 'contextManagement':
     case 'compactionActivity':
       return row.label;

--- a/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -18,6 +18,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { diffWordsWithSpace } from 'diff';
 
 import type { FileListEntry } from '@shared/schemas';
+import type { FileListRow } from '@shared/transcript';
 import { hljs } from '@shared/highlighting/hljs';
 
 // Local imports - shared utilities
@@ -26,6 +27,7 @@ import { stopSpinnerMotion } from '@shared/wa/spinner';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { copyWithFeedback } from '@shared/utils/clipboard';
 import { getBasename } from '@utils/core';
+import { formatBytes } from '@utils/text/stringUtils';
 
 // Local imports - formatter helpers
 import {
@@ -259,10 +261,14 @@ export function buildFileLinkSpan(
 }
 
 /** Build the `<li>` rows for a file-list banner. The summary line above them
- *  is the row's (`FileListRow.summary`), not derived here. */
+ *  is the row's (`FileListRow.summary`), not derived here. `media` is the
+ *  row's own subset — a file that reached the model as an image or audio clip
+ *  reports its kind and size beside its name. */
 export function buildFileListRender(
   files: readonly FileListEntry[],
+  media: FileListRow['media'],
 ): TemplateResult {
+  const mediaByPath = new Map(media.map((ref) => [ref.path, ref.media]));
   // prettier-ignore
   return html`${files.map((file) => {
     const iconName = file.ok ? 'check' : 'triangle-exclamation';
@@ -272,9 +278,10 @@ export function buildFileListRender(
     const source = file.source ?? 'unknown';
     const showSource = source !== 'unknown';
     const sourceText = file.sourceDisplay ?? source;
+    const loaded = mediaByPath.get(filePath);
 
     // prettier-ignore
-    return html`<li class="detail-item" title=${filePath}>${waIcon(iconName)} ${buildFileLinkSpan(filePath, fileName)}${file.varName ? html` <span class="file-var">[${file.varName}]</span>` : ''}${showSource ? html` <span class="file-source">(${sourceText})</span>` : ''}</li>`;
+    return html`<li class="detail-item" title=${filePath}>${waIcon(iconName)} ${buildFileLinkSpan(filePath, fileName)}${file.varName ? html` <span class="file-var">[${file.varName}]</span>` : ''}${showSource ? html` <span class="file-source">(${sourceText})</span>` : ''}${loaded ? html` <span class="file-media">[${loaded.kind}, ${formatBytes(loaded.sizeBytes)}]</span>` : ''}</li>`;
   })}`;
 }
 

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
@@ -64,7 +64,7 @@ export function formatFileListTemplate(row: FileListRow): FormatResult {
     logId: row.id,
     iconName: 'file',
     label: row.summary,
-    items: buildFileListRender(row.files),
+    items: buildFileListRender(row.files, row.media),
   });
 }
 
@@ -132,20 +132,19 @@ const STAT_ICONS: Record<string, TeXRAIconName> = {
   cost: 'rocket',
 };
 
-/** Fixed header config for the statistics panel rendered via <context-management>. */
-const STATISTICS_CONFIG = Object.freeze({
-  icon: 'chart-line',
-  label: 'Statistics',
-  color: 'var(--wa-color-text-normal)',
-});
-
-/** Format statistics entry as TemplateResult. */
+/** Format statistics entry as TemplateResult. The heading is the row's
+ *  (`StatisticsRow.label`); only the glyph and color are this host's. */
 export function formatStatisticsTemplate(row: StatisticsRow): FormatResult {
   const items = row.items.map((item) => ({
     icon: STAT_ICONS[item.key] ?? 'chart-line',
     label: item.label,
     value: item.value,
   }));
+  const config = {
+    icon: 'chart-line',
+    label: row.label,
+    color: 'var(--wa-color-text-normal)',
+  };
   // prettier-ignore
-  return html`<context-management .logId=${row.id} .items=${items} .config=${STATISTICS_CONFIG}></context-management>`;
+  return html`<context-management .logId=${row.id} .items=${items} .config=${config}></context-management>`;
 }

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -17,7 +17,7 @@ import { html, nothing, type TemplateResult } from 'lit';
 
 // Local imports - shared utilities
 import type { ToolRow } from '@shared/transcript';
-import { parseDelegationToolInput } from '@shared/schemas';
+import { parseDelegationToolInput, TOOL_USE_STATUS } from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { postMessage } from '@shared/hostBridge';
 import {
@@ -27,7 +27,10 @@ import {
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { toolDisplayKind } from '@shared/tools/toolKind';
-import { normalizeToolName } from '@shared/tools/toolDisplayName';
+import {
+  isMcpToolName,
+  normalizeToolName,
+} from '@shared/tools/toolDisplayName';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 // Local imports - formatter helpers
@@ -57,6 +60,7 @@ export function formatToolUseTemplate(row: ToolRow): FormatResult {
   const { toolUse, model } = row;
   const { toolName, input } = toolUse;
   const normalizedToolName = normalizeToolName(toolName);
+  const displayKind = toolDisplayKind(toolName);
   const showAsError = model.isError && !model.isUserFeedback;
 
   let iconName: TeXRAIconName | typeof SPINNER_ICON_NAME;
@@ -84,7 +88,6 @@ export function formatToolUseTemplate(row: ToolRow): FormatResult {
   // Output is shown unless the model suppressed it (empty, already said by
   // the header, the error, or the sections above).
   if (model.output) {
-    const displayKind = toolDisplayKind(toolName);
     sections.push(
       displayKind === 'bash' || normalizedToolName === 'codex'
         ? buildTerminalSection('', model.output.full)
@@ -93,6 +96,13 @@ export function formatToolUseTemplate(row: ToolRow): FormatResult {
             extraClass: 'tool-output-full',
           }),
     );
+  }
+
+  // The shell exit status a failed call reported. Only meaningful on failure:
+  // a successful command's `exit 0` says nothing the status icon does not.
+  if (model.isError && model.exitCode !== undefined) {
+    // prettier-ignore
+    sections.push(html`<div class="tool-use-section tool-exit-code">exit ${model.exitCode}</div>`);
   }
 
   if (model.errorPreview) {
@@ -111,6 +121,18 @@ export function formatToolUseTemplate(row: ToolRow): FormatResult {
         wrapInPre(model.userInstruction.full, 'tool-user-feedback'),
       ),
     );
+  }
+
+  // "It ran and printed nothing" is a result, not an absence — but only for a
+  // call whose output is the point: a shell command or an MCP call.
+  if (
+    model.outputSuppression === 'empty' &&
+    !model.isError &&
+    model.status === TOOL_USE_STATUS.COMPLETED &&
+    (displayKind === 'bash' || isMcpToolName(toolName))
+  ) {
+    // prettier-ignore
+    sections.push(html`<div class="tool-use-section tool-no-output">(no output)</div>`);
   }
 
   // Workflow scripts already have a compact live summary and can be very

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -191,8 +191,13 @@ export const logEntryStyles = css`
   }
 
   .file-list-content .file-var,
-  .file-list-content .file-source {
+  .file-list-content .file-source,
+  .file-list-content .file-media {
     color: var(--color-text-muted);
+  }
+
+  .file-list-content .file-media {
+    font-size: 0.85em;
   }
 
   .file-list-content .file-var {

--- a/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
@@ -31,6 +31,17 @@ export const toolUseStyles = css`
     font-size: var(--font-size-sm);
   }
 
+  /* Single-line facts the model carries beside the output block. */
+  .tool-exit-code {
+    color: var(--color-error);
+    font-size: var(--font-size-sm);
+  }
+
+  .tool-no-output {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-sm);
+  }
+
   :is(.tool-use-error, .banner-details--error)
     > .details-summary
     :is(.tool-use-title, .label, wa-icon),

--- a/src/shared/transcript/projectTranscriptRow.ts
+++ b/src/shared/transcript/projectTranscriptRow.ts
@@ -503,6 +503,7 @@ export function projectTranscriptRow(
         ...rowBase(entry),
         kind: 'statistics',
         stats: entry.data,
+        label: 'Statistics',
         items,
       };
     }

--- a/src/shared/transcript/transcriptRow.ts
+++ b/src/shared/transcript/transcriptRow.ts
@@ -221,6 +221,9 @@ export interface StatisticsRow extends TranscriptRowBase {
   /** Partial by contract: a run reports only the counters its provider
    *  returned. */
   readonly stats: Partial<ExtendedTokenUsageStats>;
+  /** `Statistics` — the panel heading, owned here so both hosts say the same
+   *  word. Mirrors {@link ContextManagementRow.label}. */
+  readonly label: string;
   readonly items: readonly StatItem[];
 }
 


### PR DESCRIPTION
## Summary

Three facts the shared transcript model already carries, that the VS Code /
desktop progress view silently dropped — plus one label hardcoded twice,
differently. Each is a one-host divergence, not a redesign: the CLI already
paints all three.

- **`exitCode`** — a failed shell call reports its exit status. The CLI prints
  `exit 137`; the progress view printed nothing. `grep -rn "exitCode"
  packages/extension/src/progressView/frontend/` returned zero hits before this
  change.
- **"It ran and printed nothing"** — `ToolRowModel.outputSuppression === 'empty'`
  on a completed, non-erroring `bash`/MCP call is a *result*, not an absence.
  The CLI paints `(no output)`; the progress view rendered an empty card
  indistinguishable from one still loading its output.
- **`FileListRow.media`** — the kind and byte size of a file that reached the
  model as an image or audio clip. The CLI paints `[image, 1.2 MB]`; the
  webview's `buildFileListRender` took `files` only and never saw `media`.
- **The statistics panel heading** was `'Usage'` in the CLI
  (`transcriptEntries.ts`) and `'Statistics'` in the webview
  (`dataFormatters.ts`) — two literals, one fact.

The webview's `exit N` and `(no output)` predicates are copied verbatim from
`packages/cli/src/chat/tui/panes/toolRenderers.tsx:347` and `:355-360`, so the
two hosts cannot drift again without someone editing both files.

**Naming decision that wants a maintainer's eye:** I picked **`Statistics`** as
the surviving word — the webview's spelling, matching the row kind, and free of
collision with the *subscription* usage panel. If you prefer the CLI's `Usage`,
it is now a one-line change in `projectTranscriptRow.ts` instead of two changes
in two hosts.

## Issue acceptance gates

n/a — from a three-host render-parity audit, not a filed issue.

## Single source of truth

- The statistics panel heading now has one owner: **`StatisticsRow.label`**,
  minted once in `projectTranscriptRow.ts`. Both hosts read it. This mirrors
  the existing `ContextManagementRow.label`, which was already the precedent
  for exactly this.
- `exitCode`, `outputSuppression`, and `FileListRow.media` already had a single
  owner (`toolRowModel` / `projectTranscriptRow`); this PR only makes the
  second host read what the owner already publishes.

## Duplication and abstraction budget

- Removed one duplicated literal (`'Usage'` / `'Statistics'`).
- No new abstraction, no new export, no new module. The `(no output)` predicate
  is *copied*, not extracted: two call sites, one a Lit template and one an Ink
  row array, is a single-fact extraction with no third caller in sight.
- `STATISTICS_CONFIG` (a frozen module const whose only variable part was the
  label) is inlined into its one caller now that the label comes from the row.

## Net elements (R6)

Net **+47 LoC**. This PR **net-adds** — it is a parity fix, not a reduction, and
nothing here should be read as one.

| | +/- |
|---|---|
| Files | +0 / -0 (8 modified) |
| Exported symbols | +0 / -0 |
| Module-level consts | +0 / -1 (`STATISTICS_CONFIG`, inlined) |
| Interface fields | +1 (`StatisticsRow.label`) |
| Function params | +1 (`buildFileListRender(files, media)`) |
| LoC | +64 / -17 |

`buildFileListRender` has exactly one caller, so `media` is a required second
parameter, not a speculative optional one.

## Consumer counts (R8)

Nothing was deleted or re-routed, but the greps that justified each edit:

```
# the two tool facts were genuinely unrendered on this host
grep -rn "exitCode\|outputSuppression" packages/extension/src/progressView/frontend/   # 0 hits before
# media was genuinely unrendered on this host
grep -rn "\.media\|LoadedMedia" packages/extension/src/progressView/frontend/          # 0 hits before
# buildFileListRender caller count (1 → the new param can be required)
grep -rn "buildFileListRender" packages src --include=*.ts --include=*.tsx            # decl + 1 import + 1 call
# nobody mints a second statistics row or asserts either literal
grep -rn "kind: 'statistics'" src packages                                            # 1 site (the projector)
grep -rn "'Usage'" src/test-kernel/                                                    # 0 hits
```

`StatisticsRow.stats` is untouched here — its zero-reader status is a separate
dead-field question and does not belong in a correctness PR.

## Host impact

**Extension:** all four changes land here. Tool cards gain an `exit N` line on
failure and a `(no output)` line on a silent successful shell/MCP call;
file-list rows gain `[kind, size]` for media attachments; the statistics panel
heading is now row-owned (rendered text unchanged — it already said
`Statistics`).

**Desktop:** identical, and for free —
`packages/desktop/src/renderer/main.ts:22` imports `@progressView/frontend`
wholesale. There is no second renderer to update.

**CLI:** one change only — the statistics headline now reads **`Statistics`**
where it read `Usage`. Everything else in this PR is the CLI's existing
behavior being ported to the other host.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — exit 0 (workspace, test-kernel, agent, cli including
  `tsconfig.scripts.json`, trace-viewer, desktop).
- `npx vitest run src/test-kernel/progressView/ToolUseFormatter.vitest.ts
  src/test-kernel/progressView/FileList.vitest.ts
  src/test-kernel/shared/TranscriptRowProjection.vitest.ts` — 3 files, 31 passed.
- `npx vitest run src/test-kernel/cli/` — 144 files, 2535 passed, 1 skipped
  (run in full because the `Usage` → row-owned label change touches the CLI
  headline path).
- `npm run lint` — clean.
- `npx prettier --check .` — clean.
- `node scripts/check-browser-safe-utils.mjs` — OK. The new `formatBytes`
  import is from `@utils/text/stringUtils`, already one of the
  browser-reachable modules; the reachable count is unchanged.
- **Zero new tests**, per the repo's testing budget. Three render additions at a
  churning painter seam do not earn pinned tests; the checklist below is the
  real gate.

### Eyeball checklist — no automated gate in this repo can verify a webview render

Open the **TeXRA progress view** in VS Code (or the desktop app — same renderer,
so checking one covers both):

1. **`exit N`** — run a tool-use agent and have it run a shell command that
   fails with a nonzero status (`bash -c 'exit 3'`). Expand the tool card.
   There must be a red `exit 3` line **between the output block and the
   `Error:` block**. A *successful* command must still show no exit line at all.
2. **`(no output)`** — have it run a shell command that succeeds and prints
   nothing (`true`). The card must show a muted `(no output)` line at the bottom
   of the expanded body. Confirm the same command in the CLI TUI shows the
   identical `(no output)`.
3. **No regression on a normal call** — a shell command with real stdout must
   look exactly as before: no `exit`, no `(no output)`, no extra blank row.
4. **File-list media** — attach an image to a run so the file-list banner
   appears. Each image row must end with a muted `[image, 240 KB]`-style chunk,
   **after** the `(source)` chunk. A non-media attachment in the same list must
   show no such chunk.
5. **Statistics heading** — finish a run so the statistics panel appears. It
   must read **Statistics** in the progress view *and* **Statistics** in the CLI
   transcript (the CLI said `Usage` before this PR). The neighbouring
   context-management panel heading must be unchanged.
6. **Both themes** — `exit N` uses `--color-error`; `(no output)` and
   `[kind, size]` use `--color-text-muted`. Glance at light and dark to confirm
   neither is invisible against its background.
