### PR TITLE
fix(cli): state the executions header rule once

### DIFF
--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -25,16 +25,14 @@ import {
 } from '@cli/tui/ui/glyphs';
 import { TOOL_USE_STATUS } from '@shared/schemas';
 import {
+  toolHeaderPreview,
   transcriptText,
   type ToolRow,
   type ToolSection,
   type ToolSectionFile,
   type TranscriptText,
 } from '@shared/transcript';
-import {
-  executionsSubagentSummary,
-  type ExecutionLabels,
-} from '@shared/tools/executionsDisplay';
+import { type ExecutionLabels } from '@shared/tools/executionsDisplay';
 import {
   isMcpToolName,
   normalizeToolName,
@@ -313,14 +311,11 @@ function patchTextLines(
 function buildStyledLines(
   { model, toolUse }: ToolRow,
   options: DisplayLineOptions,
-  executionSummary: string | undefined,
+  headerPreview: string,
 ): readonly ToolDisplayLine[] {
   const elide = options.elide !== false;
   const isBashKind = toolDisplayKind(toolUse.toolName) === 'bash';
 
-  // Subagent labels exist only at paint time (they name live executions), so
-  // the labeled summary is applied over the model's own header preview.
-  const headerPreview = executionSummary ?? model.headerPreview;
   const budget =
     options.width === undefined
       ? MAX_HEADER_PREVIEW
@@ -425,16 +420,21 @@ export function toolUseStyledLines(
   options: DisplayLineOptions = {},
 ): readonly ToolDisplayLine[] {
   const { toolUse } = toolRow;
-  const executionSummary =
+  // Subagent execution labels name live executions, so they only exist at
+  // paint time and the shared model was built without them. Re-derive the
+  // preview through the shared rule rather than restating its precedence here.
+  const headerPreview =
     normalizeToolName(toolUse.toolName) === 'executions' &&
     options.executionLabels
-      ? executionsSubagentSummary(toolUse.input, options.executionLabels)
-      : undefined;
-  const key = `${options.elide === false ? 'f' : 'e'}|${options.compactOutput ?? 'n'}|${options.width ?? 'd'}|${executionSummary ?? ''}`;
+      ? toolHeaderPreview(toolUse, {
+          executionLabels: options.executionLabels,
+        })
+      : toolRow.model.headerPreview;
+  const key = `${options.elide === false ? 'f' : 'e'}|${options.compactOutput ?? 'n'}|${options.width ?? 'd'}|${headerPreview}`;
   let cached = styledLinesCache.get(toolRow);
   const hit = cached?.get(key);
   if (hit) return hit;
-  const lines = buildStyledLines(toolRow, options, executionSummary);
+  const lines = buildStyledLines(toolRow, options, headerPreview);
   if (!cached) {
     cached = new Map();
     styledLinesCache.set(toolRow, cached);

--- a/src/shared/transcript/index.ts
+++ b/src/shared/transcript/index.ts
@@ -36,6 +36,7 @@ export {
   type WorkflowTaskRow,
 } from './transcriptRow';
 export {
+  toolHeaderPreview,
   toolRowModel,
   type ToolChecklistSection,
   type ToolFileGroupsSection,

--- a/src/shared/transcript/toolRowModel.ts
+++ b/src/shared/transcript/toolRowModel.ts
@@ -235,12 +235,17 @@ function headerSummaryText(summary: string): string {
 }
 
 /**
- * The header preview both hosts show. A shell call is described by its
- * command, so `bash`-kind tools prefer the input preview; every other tool
- * reports its own summary first and falls back to the input preview while it
- * is still in flight.
+ * The header preview both hosts show, and the only statement of its
+ * precedence: a shell call is described by its command, so `bash`-kind tools
+ * prefer the input preview; every other tool reports its own summary first and
+ * falls back to the input preview while it is still in flight.
+ *
+ * Exported because subagent execution labels exist only at paint time in the
+ * terminal (they name live executions), so the CLI re-derives the preview once
+ * the labels are known rather than restating the precedence over the model's
+ * already-computed value.
  */
-function toolHeaderPreview(
+export function toolHeaderPreview(
   normalized: NormalizedToolUse,
   ctx: ToolRowModelContext,
 ): string {

--- a/src/test-kernel/cli/ToolRenderers.vitest.ts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.ts
@@ -193,6 +193,23 @@ describe('CLI tool display lines', () => {
     expect(header.spans.at(-1)).toMatchObject({ color: 'cyan' });
   });
 
+  it('lets a completed executions summary outrank its labels, matching the progress view', () => {
+    const entry = toolUse(
+      'executions',
+      { action: 'wait', path: '/executions', ids: ['sub-1'] },
+      { headerSummary: 'finished waiting' },
+    );
+
+    expect(
+      toolUseDisplayLines(entry, {
+        executionLabels: new Map([['sub-1', 'reviewer']]),
+      }),
+    ).toEqual([
+      '● executions (finished waiting)',
+      '⎿ Action: wait (timeout: 300s)',
+    ]);
+  });
+
   it('renders executions targets with retained subagent labels', () => {
     const entry = toolUse('executions', {
       action: 'wait',


### PR DESCRIPTION
## Summary

The header preview a tool row leads with has one rule, stated in
`toolHeaderPreview` (`src/shared/transcript/toolRowModel.ts`): a `bash`-kind
tool is described by its command so the input preview wins, and every other
tool reports its own summary first, falling back to the input preview while it
is still in flight.

`executions` is not in `TOOL_DISPLAY_KIND` (`src/shared/tools/toolKind.ts:26-34`),
so `toolDisplayKind('executions')` is `undefined` and the shared rule gives the
tool's own `headerSummary` priority over the subagent labels.

The CLI restated that precedence a second way at paint time —
`executionSummary ?? model.headerPreview` (`toolRenderers.tsx:323`) — under
which the labels always win. So a completed `executions` call that reports a
`headerSummary` read one way in the progress view and another in the TUI. This
PR deletes the second copy.

What is *not* a duplicate, and stays: the CLI applies the labels at paint time
rather than at projection time. Subagent execution labels name live executions,
so they do not exist when `transcriptFold.ts:682` calls `projectTranscriptRow`
(it passes only `previousRow` and `projectLifecycleToTaskGroups`). The
extension can pass them at projection (`logSlice.ts:59`); the CLI cannot. So
the CLI still re-derives the preview once the labels are known — it just now
does so *through* `toolHeaderPreview` instead of overriding the value
`toolHeaderPreview` produced.

## Issue acceptance gates

No issue. Found by a verified CLI transcript-render audit.

## Single source of truth

`toolHeaderPreview` (`src/shared/transcript/toolRowModel.ts`) is now the only
statement of header-preview precedence. Both hosts reach it: the extension via
`toolRowModel` at projection time, the CLI directly at paint time.

## Duplication and abstraction budget

Removes one duplicated precedence rule. No new abstraction: the function
already existed and already had the right signature — `ToolRow.toolUse` is
`NormalizedToolUse` (`transcriptRow.ts:137`), exactly its first parameter, and
`ToolRowModelContext.executionLabels` is already optional
(`toolRowModel.ts:212-219`), so the call compiles with no shape change.

The one widening: `toolHeaderPreview` becomes an export on the 990-LoC
`toolRowModel` surface (+1 export, re-exported from the `@shared/transcript`
barrel). It has a consumer in this PR, so the dead-code ratchet is satisfied
(verified: `npm run check:dead-code-ratchet` → 8 current vs 8 baselined).

## Net elements (R6)

**This change is net-neutral in LoC and net-adds one export. It is a
correctness fix, not a reduction — I am not selling it as one.**

- Files: 3 changed, 0 added, 0 deleted.
- Net LoC: **+6** (`24 insertions(+), 18 deletions(-)`). Most of the addition
  is the comment explaining why the export exists and why paint-time
  application is not itself a duplicate.
- Exported symbols: **+1** (`toolHeaderPreview`, plus its barrel re-export).
  No exports deleted.
- Functions: 0 net. `buildStyledLines` keeps its arity; its third parameter
  changes from `executionSummary: string | undefined` to
  `headerPreview: string`, moving the last `??` out of the painter.
- Classes/interfaces/enums: 0 net.
- Imports: `executionsSubagentSummary` is no longer imported by
  `toolRenderers.tsx`.

## Consumer counts (R8)

- `executionsSubagentSummary` — not deleted, still exported. Production
  consumers after this PR: **1** (`toolRowModel.ts:255`), plus
  `src/test-kernel/shared/ExecutionsDisplay.vitest.ts`. Grep:
  `grep -rn "executionsSubagentSummary" --include='*.ts' --include='*.tsx' src/ packages/`
- `toolHeaderPreview` — new export, **2** production call sites: its existing
  internal use in `toolRowModel` and the new one in `toolRenderers.tsx`.
- `model.headerPreview` — unchanged; still the value used for every non-
  `executions` tool and for `executions` calls with no labels.

Cache behaviour: the `styledLinesCache` key at `toolRenderers.tsx:433` now
carries the full preview instead of the labeled fragment. Within a single
`ToolRow` the tool's own summary is fixed, so the key varies over exactly the
same input (the labels) and hit/miss behaviour is equivalent.

`executionsSubagentSummary` returns `string | undefined` and never `''`
(`executionsDisplay.ts:44, 55, 64`), so no path can blank a header that
previously rendered.

## Host impact

Extension: none — `logSlice` already passed labels at projection time and
already got the shared precedence.

Desktop: none.

CLI: a completed `executions` call that reports its own `headerSummary` now
shows that summary in the TUI header, matching the progress view. While the
call is in flight (`headerSummary` empty) the labeled summary still wins, as
before.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean (workspace, test-kernel, agent, cli incl.
  `tsconfig.scripts.json`, trace-viewer, desktop).
- `npx vitest run src/test-kernel/cli/ToolRenderers.vitest.ts
  src/test-kernel/shared/ExecutionsDisplay.vitest.ts
  src/test-kernel/cli/ConversationTranscript.vitest.ts
  src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts` —
  4 files, 114 tests, all passing.
- `npm run lint` — clean.
- `npx prettier --check .` — clean.
- `npm run check:dead-code-ratchet` — OK (8 current vs 8 baselined).
- Tests: one regression test added (reviewer request) —
  `lets a completed executions summary outrank its labels, matching the
  progress view` in the existing `ToolRenderers` suite. The pre-existing
  executions cases all use the default empty `headerSummary`, so they pinned
  only the label path; this is the one test at the durable boundary for the
  defect being fixed. `npx vitest run src/test-kernel/cli/ToolRenderers.vitest.ts`
  — 26 tests, all passing.
