### PR TITLE
refactor(progressView): drop the hand-written PermissionState mirror

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BaseBypassApprovalPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseBypassApprovalPanel.ts
@@ -1,6 +1,7 @@
 /** Approval panel capability for edit and bash session bypass. */
 
 // Local imports - shared copy
+import type { PermissionPayload } from '@shared/schemas';
 import { DELEGATION_APPROVAL_COPY } from '@shared/copy/delegationApproval';
 
 // Local imports - base class
@@ -10,17 +11,16 @@ import { BaseApprovalPanel } from './BaseApprovalPanel';
 import { APPROVE_SESSION_ACTION } from '../events';
 
 // Local imports - progress view state
-import type { PermissionState } from '../permissionState';
 
 type BypassPermissionKind = 'toolEdit' | 'bash';
 type BypassPermission = Extract<
-  PermissionState,
+  PermissionPayload,
   { kind: BypassPermissionKind }
 >;
 
-// `this.permission` is `Extract<PermissionState, { kind: K }>` for the
+// `this.permission` is `Extract<PermissionPayload, { kind: K }>` for the
 // generic `K`; TS cannot distribute that conditional type over the
-// `PermissionState` union while `K` is unresolved, so direct property access
+// `PermissionPayload` union while `K` is unresolved, so direct property access
 // on `this.permission` fails to typecheck. Passing it through this
 // concretely-typed helper (bound to the literal `BypassPermissionKind`, not
 // the generic `K`) gives the compiler a resolvable type to check against.

--- a/packages/extension/src/progressView/frontend/components/BaseRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseRequestPanel.ts
@@ -5,6 +5,9 @@ import { LitElement } from 'lit';
 import { consume } from '@lit/context';
 import { property } from 'lit/decorators.js';
 
+// Local imports - shared schemas
+import type { PermissionPayload } from '@shared/schemas';
+
 // Local imports - progress view events
 import {
   ProgressEvents,
@@ -16,13 +19,12 @@ import {
 import { archivedContext } from '../streamContexts';
 
 // Local imports - progress view component types
-import type { PermissionState } from '../permissionState';
 
 export abstract class BaseRequestPanel<
   K extends PermissionKind = PermissionKind,
 > extends LitElement {
   @property({ attribute: false }) permission!: Extract<
-    PermissionState,
+    PermissionPayload,
     { kind: K }
   >;
 

--- a/packages/extension/src/progressView/frontend/components/BaseStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseStreamContent.ts
@@ -16,7 +16,11 @@ import { consume } from '@lit/context';
 import { state } from 'lit/decorators.js';
 
 // Local imports - shared schemas
-import type { ContextStateData, TokenUsageStats } from '@shared/schemas';
+import type {
+  ContextStateData,
+  PermissionPayload,
+  TokenUsageStats,
+} from '@shared/schemas';
 
 // Local imports - progress view
 import { filterPermissionsForStream, totalRunUsage } from '../stateUtils';
@@ -28,7 +32,6 @@ import {
 } from '../streamContexts';
 
 // Local imports - types
-import type { PermissionState } from '../permissionState';
 
 // Side-effect imports - sibling components shared by both stream-content
 // containers (registered once, consumed by the render helpers below)
@@ -43,10 +46,10 @@ export abstract class BaseStreamContent extends LitElement {
 
   @consume({ context: permissionsContext, subscribe: true })
   @state()
-  protected permissionContext: PermissionState[] = [];
+  protected permissionContext: PermissionPayload[] = [];
 
   // Derived values - recomputed in willUpdate() before render.
-  protected filteredPermissions: PermissionState[] = [];
+  protected filteredPermissions: PermissionPayload[] = [];
 
   protected override willUpdate(changedProperties: PropertyValues): void {
     if (

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -30,6 +30,7 @@ import { postMessage } from '@shared/hostBridge';
 import type {
   ExternalInquiryPermission,
   InquiryDraft,
+  PermissionPayload,
   InquiryTranscriptTurn,
 } from '@shared/schemas';
 import {
@@ -54,10 +55,9 @@ import {
   REDIRECT_FEEDBACK_PROMPT,
 } from './BaseFeedbackPanel';
 import { externalInquiryPanelStyles } from './ExternalInquiryPanel.styles';
-import type { PermissionState } from '../permissionState';
 
 type ExternalInquiryPermissionState = Extract<
-  PermissionState,
+  PermissionPayload,
   { kind: typeof PERMISSION_KIND.EXTERNAL_INQUIRY }
 >;
 

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -27,6 +27,7 @@ import {
 // Local imports - shared utils
 import type {
   AgentProposalPermission,
+  PermissionPayload,
   WorkflowAgentProposalPermission,
 } from '@shared/schemas';
 import { AgentCategory, getProposalFileGroups } from '@shared/schemas';
@@ -50,10 +51,9 @@ import { proposalRequestPanelStyles } from './ProposalRequestPanel.styles';
 import { APPROVE_ALL_DELEGATED_WORK_ACTION } from '../events';
 import { processMarkdownContent } from '../formatters/markdownRenderer';
 import { getComposedPathElement } from '../utils';
-import type { PermissionState } from '../permissionState';
 
 function proposalRequestIdOf(
-  p: PermissionState | null | undefined,
+  p: PermissionPayload | null | undefined,
 ): string | undefined {
   return p?.kind === PERMISSION_KIND.PROPOSAL ? p.data.requestId : undefined;
 }
@@ -83,7 +83,7 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
     super.willUpdate(changed);
     if (!changed.has('permission')) return;
     const previous = changed.get('permission') as
-      PermissionState | null | undefined;
+      PermissionPayload | null | undefined;
     if (
       proposalRequestIdOf(previous) !== proposalRequestIdOf(this.permission)
     ) {
@@ -116,8 +116,8 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
 
   override render(): TemplateResult {
     const data = this.permission.data;
-    const modelOptions = this.permission.modelOptions ?? [];
-    const agentOptions = this.permission.agentOptions ?? [];
+    const modelOptions = this.permission.modelOptionsData ?? [];
+    const agentOptions = this.permission.agentOptionsData ?? [];
     const isWorkflow = data.agentCategory === AgentCategory.Workflow;
     const workflowScript = isWorkflow ? data.workflowScript : undefined;
     let categoryLabel = 'Tool-Use';

--- a/packages/extension/src/progressView/frontend/components/RequestPanels.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanels.ts
@@ -40,7 +40,7 @@ import {
 } from '@shared/styles';
 
 // Local imports - shared schemas
-import type { StreamTabId } from '@shared/schemas';
+import type { PermissionPayload, StreamTabId } from '@shared/schemas';
 
 // Local imports - shared utilities
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
@@ -50,7 +50,7 @@ import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { groupBy } from '@utils/core';
 import { isTextInput, selectExternalInquiryKey } from './RequestPanelsState';
-import { getPermissionKey, type PermissionState } from '../permissionState';
+import { getPermissionKey } from '../permissionState';
 import { streamDisplayLabel } from '../utils';
 
 // Local imports - progress view contexts
@@ -76,7 +76,7 @@ import './UserQuestionPanel';
 
 /** One section per permission kind: its chrome and the element rendering it. */
 interface SectionConfig {
-  readonly kind: PermissionState['kind'];
+  readonly kind: PermissionPayload['kind'];
   readonly tag: ReturnType<typeof literal>;
   readonly cssClass: string;
   readonly icon: TeXRAIconName;
@@ -144,7 +144,7 @@ const PANEL_MARKER_SELECTOR = '[data-request-panel]';
 
 function renderPanel(
   section: SectionConfig,
-  permission: PermissionState,
+  permission: PermissionPayload,
   armed: boolean,
 ): TemplateResult {
   // `armed` marks the panel the y/n accelerators will act on. Sections render
@@ -160,7 +160,7 @@ function renderPanel(
 }
 
 function externalInquiryKeys(
-  permissions: readonly PermissionState[],
+  permissions: readonly PermissionPayload[],
 ): string[] {
   return permissions
     .filter(
@@ -186,7 +186,7 @@ export class RequestPanels extends LitElement {
     `,
   ];
 
-  @property({ attribute: false }) permissions: PermissionState[] = [];
+  @property({ attribute: false }) permissions: PermissionPayload[] = [];
 
   /** Canonical selection for the external-inquiry carousel. */
   @state() private selectedExternalInquiryKey: string | null = null;
@@ -203,12 +203,12 @@ export class RequestPanels extends LitElement {
    */
   @consume({ context: permissionsContext, subscribe: true })
   @state()
-  private allPermissions: PermissionState[] = [];
+  private allPermissions: PermissionPayload[] = [];
 
   /** Memoized permission groups - recomputed in willUpdate() when permissions change. */
   private permissionsByKind: ReadonlyMap<
-    PermissionState['kind'],
-    PermissionState[]
+    PermissionPayload['kind'],
+    PermissionPayload[]
   > = new Map();
 
   /** True when pending requests belong to more than one identified run. */
@@ -221,7 +221,7 @@ export class RequestPanels extends LitElement {
     if (changedProperties.has('permissions')) {
       const previousKeys = externalInquiryKeys(
         (changedProperties.get('permissions') as
-          PermissionState[] | undefined) ?? [],
+          PermissionPayload[] | undefined) ?? [],
       );
       this.permissionsByKind = groupBy(this.permissions, (p) => p.kind);
       this.selectedExternalInquiryKey = selectExternalInquiryKey(
@@ -265,7 +265,7 @@ export class RequestPanels extends LitElement {
    * carousel does not even render, while the keypress landed on the visible
    * one.
    */
-  private get armedPermission(): PermissionState | null {
+  private get armedPermission(): PermissionPayload | null {
     const newest = this.permissions[0];
     if (!newest) return null;
     return (
@@ -293,7 +293,7 @@ export class RequestPanels extends LitElement {
     `;
   }
 
-  private permissionsFor(kind: PermissionState['kind']): PermissionState[] {
+  private permissionsFor(kind: PermissionPayload['kind']): PermissionPayload[] {
     return this.permissionsByKind.get(kind) ?? [];
   }
 
@@ -320,7 +320,7 @@ export class RequestPanels extends LitElement {
 
   private renderSection(
     config: SectionConfig,
-    permissions: PermissionState[],
+    permissions: PermissionPayload[],
   ): TemplateResult | typeof nothing {
     if (permissions.length === 0) return nothing;
 
@@ -348,7 +348,7 @@ export class RequestPanels extends LitElement {
    */
   private renderRequest(
     config: SectionConfig,
-    permission: PermissionState,
+    permission: PermissionPayload,
     armed: boolean,
   ): TemplateResult {
     const panel = renderPanel(config, permission, armed);
@@ -377,7 +377,7 @@ export class RequestPanels extends LitElement {
    */
   private renderExternalInquirySection(
     config: SectionConfig,
-    perms: PermissionState[],
+    perms: PermissionPayload[],
   ): TemplateResult | typeof nothing {
     if (perms.length === 0) return nothing;
 
@@ -433,7 +433,7 @@ export class RequestPanels extends LitElement {
     `;
   }
 
-  private get externalInquiries(): PermissionState[] {
+  private get externalInquiries(): PermissionPayload[] {
     return this.permissionsFor(PERMISSION_KIND.EXTERNAL_INQUIRY);
   }
 
@@ -529,7 +529,7 @@ export class RequestPanels extends LitElement {
    * (approval → bash → retry → proposal) and would target the wrong panel
    * when mixed kinds are pending.
    */
-  private findPanelFor(permission: PermissionState): BaseRequestPanel | null {
+  private findPanelFor(permission: PermissionPayload): BaseRequestPanel | null {
     const panels = this.renderRoot.querySelectorAll<BaseRequestPanel>(
       PANEL_MARKER_SELECTOR,
     );

--- a/packages/extension/src/progressView/frontend/components/StreamConversation.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamConversation.ts
@@ -6,7 +6,10 @@ import { provide } from '@lit/context';
 import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports - shared
-import type { InquiryThreadUpdatedEvent } from '@shared/schemas';
+import type {
+  InquiryThreadUpdatedEvent,
+  PermissionPayload,
+} from '@shared/schemas';
 import { SignalWatcher } from '@shared/signals';
 
 // Local imports - progress view
@@ -38,7 +41,6 @@ import {
   type StreamContextValue,
   type StreamLogContextValue,
 } from '../streamContexts';
-import type { PermissionState } from '../permissionState';
 
 // Side-effect imports - body components rendered below.
 import './ToolUseStreamContent';
@@ -90,7 +92,7 @@ export class StreamConversation extends SignalWatcher(LitElement) {
 
   @provide({ context: permissionsContext })
   @state()
-  private permissionsContextValue: PermissionState[] = [];
+  private permissionsContextValue: PermissionPayload[] = [];
 
   @provide({ context: streamByIdContext })
   @state()

--- a/packages/extension/src/progressView/frontend/events.ts
+++ b/packages/extension/src/progressView/frontend/events.ts
@@ -5,12 +5,11 @@
 
 import type {
   GettingStartedActionDetail,
+  PermissionPayload,
   UserQuestionAnswers,
 } from '@shared/schemas';
 import { createEvent } from '@shared/utils/events';
 import type { ExtractedClipboardImage } from '@shared/utils/clipboardImages';
-
-import type { PermissionState } from './permissionState';
 
 // =============================================================================
 // Event Detail Types
@@ -145,7 +144,7 @@ export type ApprovalDecision<K extends ApprovalPermissionKind> = Extract<
 /** A permission and the only decisions valid for that permission kind. */
 export type PermissionActionDetail<K extends PermissionKind = PermissionKind> =
   {
-    [P in K]: Extract<PermissionState, { kind: P }> & {
+    [P in K]: Extract<PermissionPayload, { kind: P }> & {
       decision: PermissionDecision<P>;
     };
   }[K];
@@ -189,7 +188,7 @@ export const ProgressEvents = {
   compileFixerRun: () => createEvent('compile-fixer-run', undefined),
 
   permissionAction: <K extends PermissionKind>(
-    permission: Extract<PermissionState, { kind: K }>,
+    permission: Extract<PermissionPayload, { kind: K }>,
     decision: PermissionDecision<K>,
   ) => createEvent('permission-action', { ...permission, decision }),
 

--- a/packages/extension/src/progressView/frontend/permissionState.ts
+++ b/packages/extension/src/progressView/frontend/permissionState.ts
@@ -1,59 +1,28 @@
 /**
- * Permission prompt state — the discriminated union of every pending
- * permission/approval kind the progress view can display.
+ * Identity helpers for the pending permission/approval prompts the progress
+ * view displays. The prompts themselves are the wire payloads
+ * (`PermissionPayload`) — the frontend stores what the backend sent, with no
+ * parallel view model to keep in sync.
  *
  * Lives in its own leaf module (not `components/PermissionCard.ts`) so state
- * files (store, contexts, slices, dispatcher) can type against it without
- * importing the Lit component and its side-effect imports.
+ * files (store, contexts, slices, dispatcher) can use them without importing
+ * the Lit component and its side-effect imports.
  */
-import type {
-  AgentOptionData,
-  AgentProposalPermission,
-  BashPermission,
-  ExternalInquiryPermission,
-  ModelOptionData,
-  PlanApprovalPermission,
-  RetryPermission,
-  ToolEditPermission,
-  UserQuestionPermission,
-} from '@shared/schemas';
+import type { PermissionPayload } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
-
-export type PermissionState =
-  | { kind: typeof PERMISSION_KIND.TOOL_EDIT; data: ToolEditPermission }
-  | { kind: typeof PERMISSION_KIND.BASH; data: BashPermission }
-  | { kind: typeof PERMISSION_KIND.RETRY; data: RetryPermission }
-  | {
-      kind: typeof PERMISSION_KIND.PROPOSAL;
-      data: AgentProposalPermission;
-      modelOptions?: ModelOptionData[];
-      agentOptions?: AgentOptionData[];
-    }
-  | {
-      kind: typeof PERMISSION_KIND.PLAN_APPROVAL;
-      data: PlanApprovalPermission;
-    }
-  | {
-      kind: typeof PERMISSION_KIND.EXTERNAL_INQUIRY;
-      data: ExternalInquiryPermission;
-    }
-  | {
-      kind: typeof PERMISSION_KIND.USER_QUESTION;
-      data: UserQuestionPermission;
-    };
 
 /**
  * Every permission kind's wire schema carries `requestId`; retry is the one
  * kind not *keyed* by it — retry is keyed by `streamId` instead (one pending
  * retry per stream, a new request replaces the old one).
  */
-export function permissionId(permission: PermissionState): string {
+export function permissionId(permission: PermissionPayload): string {
   return permission.kind === PERMISSION_KIND.RETRY
     ? permission.data.streamId
     : permission.data.requestId;
 }
 
 /** Stable identity key for a pending permission, used for selection/dedup. */
-export function getPermissionKey(permission: PermissionState): string {
+export function getPermissionKey(permission: PermissionPayload): string {
   return `${permission.kind}:${permissionId(permission)}`;
 }

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -17,6 +17,7 @@ import {
   createStreamState,
   isToolUseState,
   STREAM_STATUS,
+  type PermissionPayload,
   type ProgressViewPlacement,
   type InquiryThreadUpdatedEvent,
   type PhaseStage,
@@ -46,7 +47,7 @@ import {
   type StreamContextValue,
   type StreamLogContextValue,
 } from './streamContexts';
-import { getPermissionKey, type PermissionState } from './permissionState';
+import { getPermissionKey } from './permissionState';
 
 // ---------------------------------------------------------------------------
 // Stable empty references — avoid allocating new arrays/maps per read.
@@ -86,7 +87,7 @@ export const placement = trackedSignal<ProgressViewPlacement>(() => 'sidebar');
 export const narrowLayout = trackedSignal(() => false);
 
 /** Pending approval requests; drives permission UI and tab pulse indicator. */
-export const permissions$ = trackedSignal<PermissionState[]>(() => []);
+export const permissions$ = trackedSignal<PermissionPayload[]>(() => []);
 
 /**
  * Progress-view commands the active host's inbound registry declares
@@ -179,15 +180,16 @@ export const pendingApprovalIds$ = new Signal.Computed(() => {
  * titles but lives here because that component module registers custom
  * elements on import — a state leaf module cannot touch it.
  */
-const PERMISSION_ANNOUNCEMENT_NOUN: Record<PermissionState['kind'], string> = {
-  [PERMISSION_KIND.TOOL_EDIT]: 'file edit',
-  [PERMISSION_KIND.BASH]: 'shell command',
-  [PERMISSION_KIND.RETRY]: 'retry',
-  [PERMISSION_KIND.PROPOSAL]: 'agent proposal',
-  [PERMISSION_KIND.PLAN_APPROVAL]: 'plan approval',
-  [PERMISSION_KIND.EXTERNAL_INQUIRY]: 'external inquiry',
-  [PERMISSION_KIND.USER_QUESTION]: 'user question',
-};
+const PERMISSION_ANNOUNCEMENT_NOUN: Record<PermissionPayload['kind'], string> =
+  {
+    [PERMISSION_KIND.TOOL_EDIT]: 'file edit',
+    [PERMISSION_KIND.BASH]: 'shell command',
+    [PERMISSION_KIND.RETRY]: 'retry',
+    [PERMISSION_KIND.PROPOSAL]: 'agent proposal',
+    [PERMISSION_KIND.PLAN_APPROVAL]: 'plan approval',
+    [PERMISSION_KIND.EXTERNAL_INQUIRY]: 'external inquiry',
+    [PERMISSION_KIND.USER_QUESTION]: 'user question',
+  };
 
 /** One announcement diff pass: the text plus the memos for the next pass. */
 interface StatusAnnouncement {
@@ -215,7 +217,7 @@ interface StatusAnnouncement {
 export function diffStatusAnnouncement(
   previousKeys: ReadonlySet<string>,
   previousStatuses: ReadonlyMap<StreamTabId, StreamLifecycleStatus>,
-  permissions: readonly PermissionState[],
+  permissions: readonly PermissionPayload[],
   streamStates: ReadonlyMap<StreamTabId, StreamState>,
   streamById: ReadonlyMap<StreamTabId, StreamTabInfo>,
 ): StatusAnnouncement {

--- a/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
@@ -8,7 +8,10 @@
 import { create } from 'mutative';
 
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import type { ProgressViewOutboundHandlerRegistry } from '@shared/schemas';
+import type {
+  PermissionPayload,
+  ProgressViewOutboundHandlerRegistry,
+} from '@shared/schemas';
 import { deriveGoalState } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { createBoundedIdSet } from '@utils/core/boundedIdSet';
@@ -16,7 +19,7 @@ import { createBoundedIdSet } from '@utils/core/boundedIdSet';
 import { clearInquiryDraft } from './inquiryDraftState';
 import { permissions$ } from '../progressState';
 import { goalToStateFields, updateToolUseState } from '../stateUtils';
-import { permissionId, type PermissionState } from '../permissionState';
+import { permissionId } from '../permissionState';
 
 // ============================================================
 // Module state
@@ -48,7 +51,7 @@ export function addResolvedProposalId(id: string): void {
  * to preserve ordering. Otherwise prepend as a new permission.
  */
 function upsertProposalPermission(
-  permission: PermissionState & { kind: typeof PERMISSION_KIND.PROPOSAL },
+  permission: Extract<PermissionPayload, { kind: 'proposal' }>,
 ): void {
   const permissions = permissions$.get();
   const idx = permissions.findIndex(
@@ -66,7 +69,7 @@ function upsertProposalPermission(
 }
 
 export function removePrompt(
-  kind: PermissionState['kind'],
+  kind: PermissionPayload['kind'],
   idValue: string,
 ): boolean {
   const current = permissions$.get();
@@ -122,12 +125,7 @@ export const permissionHandlers = {
       if (permission.kind === PERMISSION_KIND.PROPOSAL) {
         // Drop if this proposal was already resolved (out-of-order messages)
         if (resolvedProposalIds.delete(permission.data.requestId)) return;
-        upsertProposalPermission({
-          kind: PERMISSION_KIND.PROPOSAL,
-          data: permission.data,
-          modelOptions: permission.modelOptionsData,
-          agentOptions: permission.agentOptionsData,
-        });
+        upsertProposalPermission(permission);
       } else {
         // Prepend newest permissions so keyboard shortcuts target the latest request.
         // Deduplicate by id to prevent duplicate UI when replay() re-sends

--- a/packages/extension/src/progressView/frontend/stateUtils.ts
+++ b/packages/extension/src/progressView/frontend/stateUtils.ts
@@ -5,6 +5,7 @@ import {
   isToolUseState,
   isWorkflowState,
   sumUsageStats,
+  type PermissionPayload,
   type StreamTabId,
   type TokenUsageStats,
   type ToolUseStreamState,
@@ -15,7 +16,6 @@ import {
 
 // Local imports
 import { setStreamStateForId } from './progressState';
-import type { PermissionState } from './permissionState';
 
 /**
  * Update a per-round record. Handles full reset and merge semantics.
@@ -56,9 +56,9 @@ export function goalToStateFields(goal: GoalState): {
  * Keeps permissions that have no streamId or match the given streamId.
  */
 export function filterPermissionsForStream(
-  permissions: PermissionState[],
+  permissions: PermissionPayload[],
   streamId: string | undefined,
-): PermissionState[] {
+): PermissionPayload[] {
   if (!streamId) return [];
   return permissions.filter(
     (permission) =>
@@ -71,9 +71,9 @@ export function filterPermissionsForStream(
  * Keeps permissions that have no streamId (global) or belong to a different stream.
  */
 export function removePermissionsForStream(
-  permissions: PermissionState[],
+  permissions: PermissionPayload[],
   streamId: string,
-): PermissionState[] {
+): PermissionPayload[] {
   return permissions.filter(
     (permission) => permission.data.streamId !== streamId,
   );

--- a/packages/extension/src/progressView/frontend/streamContexts.ts
+++ b/packages/extension/src/progressView/frontend/streamContexts.ts
@@ -10,6 +10,7 @@ import { createContext } from '@lit/context';
 // Local imports - progress view
 import type {
   InquiryThreadUpdatedEvent,
+  PermissionPayload,
   PhaseStage,
   StreamLifecycleStatus,
   StreamLogEntry,
@@ -21,7 +22,6 @@ import type {
 import type { TranscriptRow } from '@shared/transcript';
 
 // Local imports - progress view components
-import type { PermissionState } from './permissionState';
 
 /** Context value for stream state, providing all data needed by stream content components. */
 export interface StreamContextValue {
@@ -98,7 +98,7 @@ export const streamLogContext = createContext<StreamLogContextValue>(
   'progress-stream-log',
 );
 
-export const permissionsContext = createContext<PermissionState[]>(
+export const permissionsContext = createContext<PermissionPayload[]>(
   'progress-permissions',
 );
 

--- a/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
@@ -18,7 +18,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ZodError } from 'zod';
 
-import type { PermissionState } from '@progressView/frontend/permissionState';
 import {
   appState,
   permissions$,
@@ -30,7 +29,11 @@ import {
   logListStateKey,
   webviewStorage,
 } from '@progressView/frontend/webviewStorage';
-import { AgentCategory, type StreamTabId } from '@shared/schemas';
+import {
+  AgentCategory,
+  type PermissionPayload,
+  type StreamTabId,
+} from '@shared/schemas';
 import { MAIN_VIEW_COMMANDS, PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   dispatchProgressViewOutbound,
@@ -190,7 +193,7 @@ describe('progressView dispatchMessage (createDispatcher migration)', () => {
           plan: { objective: 'Do the thing.' },
           goalEnabled: false,
         },
-      } as PermissionState,
+      } as PermissionPayload,
     ]);
     const onError = vi.fn();
 

--- a/src/test-kernel/progressView/ProposalRequestPanel.vitest.ts
+++ b/src/test-kernel/progressView/ProposalRequestPanel.vitest.ts
@@ -136,11 +136,11 @@ describe('proposal-request-panel file-name keyboard activation', () => {
 
   it('attaches selected overrides only to approval decisions', async () => {
     const permission = createPermission();
-    permission.modelOptions = [
+    permission.modelOptionsData = [
       { value: 'sonnet', label: 'Sonnet' },
       { value: 'opus', label: 'Opus' },
     ];
-    permission.agentOptions = [
+    permission.agentOptionsData = [
       { value: 'writer', label: 'Writer' },
       { value: 'reviewer', label: 'Reviewer' },
     ];
@@ -188,8 +188,8 @@ describe('proposal-request-panel file-name keyboard activation', () => {
         { id: 'merge', label: 'Merge findings', phase: 'Synthesize' },
       ],
     };
-    permission.modelOptions = [{ value: 'sonnet', label: 'Sonnet' }];
-    permission.agentOptions = [{ value: 'writer', label: 'Writer' }];
+    permission.modelOptionsData = [{ value: 'sonnet', label: 'Sonnet' }];
+    permission.agentOptionsData = [{ value: 'writer', label: 'Writer' }];
 
     const element = await mountPanel(permission);
     const summary = element.shadowRoot?.querySelector(


### PR DESCRIPTION
## Summary

`packages/extension/src/progressView/frontend/permissionState.ts` declared
`PermissionState`, a hand-written seven-arm discriminated union that restated
`PermissionPayloadSchema` (`src/shared/schemas/progressView/outbound.ts:172-204`)
arm for arm. The only difference was in the proposal arm, where the wire's
`modelOptionsData` / `agentOptionsData` were re-spelled `modelOptions` /
`agentOptions`.

The two types were already conflated at runtime: `permissionSlice.ts:141` does
`permissions$.set([permission, ...existing])` — the **raw wire object** assigned
into a `PermissionState[]` — for six of the seven kinds. TypeScript accepted that
only because the shapes were structurally identical. The seventh kind was rebuilt
field by field purely to perform the rename.

So this is a mirror with no owner: a field added to the permission wire schema had
to be added again here before any panel could read it. The frontend now types
against `PermissionPayload` (already on the `@shared/schemas` barrel, which this
module and every consumer already import from), the proposal rebuild collapses to
`upsertProposalPermission(permission)`, and `ProposalRequestPanel` reads the wire
names.

`permissionState.ts` keeps exactly what is real frontend logic and has no wire
counterpart: the identity rule that retry is keyed by `streamId` while every other
kind is keyed by `requestId` (`permissionId` / `getPermissionKey`).

## Issue acceptance gates

n/a — verified collapse-sweep finding, no tracking issue.

## Single source of truth

`PermissionPayloadSchema` in `src/shared/schemas/progressView/outbound.ts` is now
the only definition of what a pending permission prompt looks like, on the wire and
in the progress view's state.

## Duplication and abstraction budget

Removes a 22-line hand-maintained type mirror and its per-message field rebuild. No
abstraction added; no alias or re-export shim left behind (`PermissionState` has no
remaining occurrence in the tree).

## Net elements (R6)

Net **−22 LoC** (95 insertions, 117 deletions across 15 files). The insertion count
is mostly import-line churn: 12 consumers swap a local type import for
`PermissionPayload` on their existing `@shared/schemas` import, and prettier expands
several of those single-line imports to multi-line.

- Files: ±0.
- Exported symbols: **−1** (`PermissionState`). `permissionId` and
  `getPermissionKey` survive with their parameter retyped.
- Types/interfaces: −1 union (7 arms).
- Functions: ±0; `upsertProposalPermission`'s parameter becomes
  `Extract<PermissionPayload, { kind: 'proposal' }>`.
- Runtime behaviour: unchanged except that the proposal arm is no longer rebuilt —
  the same object now flows through, as it already did for the other six kinds.
- Tests: 0 added. Two existing files updated mechanically
  (`ProgressViewMessageDispatcher.vitest.ts` cast, `ProposalRequestPanel.vitest.ts`
  field names).

## Consumer counts (R8)

```
$ grep -rn 'PermissionState' src packages --include='*.ts' --include='*.tsx' | grep -v node_modules | grep -v '/dist/'
```
Before: 12 importing modules (+2 test files). After: 0 hits for the type — the only
remaining matches are the unrelated local alias `ExternalInquiryPermissionState` in
`ExternalInquiryPanel.ts` and the two surviving value imports from
`./permissionState`.

```
$ grep -rn 'modelOptions\|agentOptions' packages/extension/src src --include='*.ts' --include='*.tsx'
```
Permission-scoped read sites are confined to `ProposalRequestPanel.ts:119-120`
(feeding `hasModelOptions` / `hasAgentOptions` / `renderModelOptions` /
`renderAgentOptions`) and its vitest; every other match is the unrelated main-view /
follow-up model-option plumbing.

No `@shared/schemas` deep import introduced (all imports go through the barrel, so
`shared-schemas-deep-import` is untouched); no `@agent/*` import added.

## Host impact

Extension: the progress view stores and renders the wire payload directly. No
visible change — `ProposalRequestPanel` reads the same two arrays under their wire
names.

Desktop: none directly; the desktop renderer drives the same `appState` and is
unaffected because the stored object is byte-identical to what it already received.

CLI: none. The CLI already consumed `PermissionPayload` from the barrel
(`approvalQueue.ts:19-25`).

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean (workspace, test-kernel, agent, cli, trace-viewer,
  desktop).
- `npx vitest run src/test-kernel/progressView/` — 60 files, 562 tests, all pass.
- `npm run lint` — clean. `npx prettier --check` — clean.
- `npm run check:dead-code-ratchet` — 8 current vs 8 baselined, OK.
