### PR TITLE
fix(cli): label task groups with the stream vocabulary; floor the webview context percent

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -203,17 +203,17 @@ const SCENARIOS = [
     bootExpect: 'Tab sessions',
     keys: ['\t', DOWN, '\r'],
     expect: [
-      'Repository audit Finished',
+      'Repository audit Completed',
       'Generated files',
       'paper.tex',
       'Compile check failed',
       'paper.log',
     ],
-    expectPatterns: [/r1\/2.*Finished/, /r2\/2.*Finished/],
+    expectPatterns: [/r1\/2.*Completed/, /r2\/2.*Completed/],
     ordered: [
-      { before: 'r1/2 Finished', after: 'Generated files' },
+      { before: 'r1/2 Completed', after: 'Generated files' },
       { before: 'Generated files', after: 'Compile check failed' },
-      { before: 'Compile check failed', after: 'r2/2 Finished' },
+      { before: 'Compile check failed', after: 'r2/2 Completed' },
     ],
   },
   {

--- a/packages/cli/src/chat/tui/panes/WorkflowRunDetails.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkflowRunDetails.tsx
@@ -34,7 +34,10 @@ import {
   type TaskGroup,
   type TaskGroupStatus,
 } from '@shared/schemas';
-import { formatRoundStageLabel } from '@shared/streams/streamStatusDisplay';
+import {
+  formatRoundStageLabel,
+  formatStreamStatusLabel,
+} from '@shared/streams/streamStatusDisplay';
 import { filterNotNullish, formatCompactDuration } from '@utils/core';
 
 type WorkflowRunDetailTone =
@@ -87,7 +90,12 @@ function taskGroupLine(group: TaskGroup, label: string): WorkflowRunDetailLine {
       : '';
   return {
     key: `group:${group.id}`,
-    text: `${appearance.marker} ${safeTerminalText(label)} ${WORKFLOW_TASK_STATUS_LABEL[group.status]}${duration}`,
+    // A task group's status is a StreamPhase, so it is worded with the stream
+    // vocabulary — the same one the progress view's group icon announces.
+    // WORKFLOW_TASK_STATUS_LABEL words a workflow *call* ('Finished',
+    // 'Saved result'), which is a different thing that happens to share four
+    // key names with this one.
+    text: `${appearance.marker} ${safeTerminalText(label)} ${formatStreamStatusLabel(group.status)}${duration}`,
     tone: appearance.tone,
     role: 'lifecycle',
   };

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -291,7 +291,13 @@ export class UsagePanel extends LitElement {
     if (!this.contextState) return nothing;
     const { inputTokens, contextWindow, utilizationPercent } =
       this.contextState;
+    // The bar is a widget that cannot overflow its own track, so it takes the
+    // clamped value. The *text* states what the handler measured, floored at
+    // 1% so a window that is genuinely in use never reads as `0% context
+    // used` — the rule `formatSubscriptionUsagePercent` sets and the CLI
+    // status bar already applies to this same number.
     const clamped = clamp(utilizationPercent, 0, 100);
+    const percentLabel = `${Math.max(1, Math.round(utilizationPercent))}% context used`;
 
     return html`
       <span id="usage-context-gauge" class="context-gauge">
@@ -300,7 +306,7 @@ export class UsagePanel extends LitElement {
           <wa-progress-bar
             class="context-gauge__bar"
             value=${clamped}
-            label="${clamped.toFixed(0)}% context used"
+            label=${percentLabel}
             style=${styleMap({ '--indicator-color': fillColor(clamped) })}
           ></wa-progress-bar>
         </span>
@@ -309,9 +315,7 @@ export class UsagePanel extends LitElement {
           ${formatCompactTokenCount(contextWindow)}
         </span>
       </span>
-      <wa-tooltip for="usage-context-gauge"
-        >${clamped.toFixed(0)}% context used</wa-tooltip
-      >
+      <wa-tooltip for="usage-context-gauge">${percentLabel}</wa-tooltip>
     `;
   }
 

--- a/src/test-kernel/cli/WorkflowRunDetails.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunDetails.vitest.ts
@@ -142,8 +142,8 @@ describe('selectWorkflowRunDetailLines', () => {
     );
 
     expect(lines.map((line) => line.text)).toEqual([
-      '✓ Repository audit Finished · 9s',
-      '✓ r1/2 Finished · 7s',
+      '✓ Repository audit Completed · 9s',
+      '✓ r1/2 Completed · 7s',
       '  Generated files',
       '    • paper.tex (+12 -3)',
       '  ⚠ r1 · Missing expected output: appendix.tex',
@@ -269,7 +269,9 @@ describe('selectWorkflowRunDetailLines', () => {
       100,
     );
 
-    expect(lines.map((line) => line.text)).toEqual(['✓ Round 3 Finished · 1s']);
+    expect(lines.map((line) => line.text)).toEqual([
+      '✓ Round 3 Completed · 1s',
+    ]);
   });
 
   it('budgets detail rows together with the live transcript viewport', async () => {
@@ -330,7 +332,7 @@ describe('selectWorkflowRunDetailLines', () => {
     );
 
     expect(lines.map((line) => line.text)).toEqual([
-      '✓ r1/2 Finished · 0s',
+      '✓ r1/2 Completed · 0s',
       '  ✗ r1 · Compile check failed: paper.pdf · paper.log',
       '□ r2/2 Planned',
     ]);


### PR DESCRIPTION
## Summary

Two places where a host renders a shared number or status in its own words, and
the words are wrong.

**1. `WorkflowRunDetails` wore the workflow-*call* vocabulary on a task-*group*
status.** `TaskGroupStatus` (`src/shared/schemas/stream.ts:146-152`) is the
four-value `StreamPhase` subset — `running`/`completed`/`cancelled`/`failed`. It
was being labeled through `WORKFLOW_TASK_STATUS_LABEL`, the map for
`WorkflowCallProgress['status']` (`planned`, `cached`/`Saved result`, …). Four
of that map's key names happen to collide with the phase names, so it typechecks
and never yields `undefined` — it just says the wrong word. The CLI printed
`✓ r1/2 Finished`; the progress view announces the very same group as
`Completed` (`TaskGroupList.ts:462`, `formatStreamStatusLabel(group.status)` on
the icon's a11y label). It now goes through `formatStreamStatusLabel` too, so
both hosts read one map:

| group status | before (CLI) | after (both hosts) |
|---|---|---|
| `completed` | Finished | **Completed** |
| `cancelled` | Cancelled | **Stopped** |
| `failed` | Failed | **Error** |
| `running` | Running | Running |

Default (`progressHeader`) style deliberately, **not** `{ style: 'cli' }` — the
`cli` style is the lowercase status-bar vocabulary and `✓ Repository audit
completed · 9s` reads wrong in a detail line.

**2. The context gauge's percentage text could say `0% context used` for a
window that is in use.** `UsagePanel.renderContext` rendered both text labels
from `clamp(...).toFixed(0)`, so `0.4%` printed as `0%`.
`formatSubscriptionUsagePercent` (`src/shared/subscriptionUsagePresentation.ts:33-38`)
already states the house rule for this repo — a nonzero value never renders as
zero — and the CLI status bar already applies it to this exact number
(`statusBarDisplay.ts:260`, `Math.max(1, Math.round(utilizationPercent))`). The
CLI was right; the webview's label was the defect. The **bar's `value` keeps the
clamp** — a progress bar genuinely cannot exceed its track, and that clamp is a
widget constraint, not a rounding decision.

## Issue acceptance gates

n/a — from a three-host render-parity audit, not a filed issue.

## Single source of truth

- Task-group status wording now has one owner for both hosts:
  `formatStreamStatusLabel` in `@shared/streams/streamStatusDisplay`.
  `WORKFLOW_TASK_STATUS_LABEL` keeps its five other call-status callers and is
  still used in this same file for `.planned`, which has no phase equivalent
  (there is no group yet for a planned round).
- The context-percent rounding rule now reads the same in both hosts:
  floor at 1 on the text, clamp on the widget.

## Duplication and abstraction budget

No new abstraction, no new export, no new helper. One import swapped, one
expression rewritten, one label expression hoisted so the bar's `label` and the
tooltip cannot drift from each other (they were two independent `.toFixed(0)`
calls on the same number).

## Net elements (R6)

Net **+12 LoC**, and most of that is two comments explaining *why* each map is
the right one. This PR is a correctness fix; it is **not** a reduction and is
not offered as one.

| | +/- |
|---|---|
| Files | +0 / -0 (3 modified, one of them a test) |
| Exported symbols | +0 / -0 |
| LoC (production) | +14 / -6 |
| LoC (test) | +4 / -2 (four asserted strings) |

## Consumer counts (R8)

```
grep -rn "WORKFLOW_TASK_STATUS_LABEL" src packages --include=*.ts --include=*.tsx
```
7 production call sites before, 6 after. The remaining ones all label a
*workflow call*, which is what the map is for:
`src/shared/transcript/projectTranscriptRow.ts:583`,
`src/shared/copy/workflowCall.ts:164`,
`packages/cli/src/chat/tui/panes/SubagentList.tsx:320`,
`packages/cli/src/runtime/workflowPlainOutput.ts:33`, plus
`WorkflowRunDetails.tsx:170` (`.planned`) and one test. The export is not
orphaned.

```
grep -rn "Finished" src/test-kernel/cli/    # 4 assertions, all in WorkflowRunDetails.vitest.ts, all updated
grep -rn "context used" src/test-kernel/    # 0 assertions
```

## Host impact

**Extension:** the context-gauge tooltip and the progress bar's accessibility
label now floor at 1%. No visual layout change. Task-group wording was already
`Completed`/`Stopped`/`Error` here — this PR moves the *other* host onto it.

**Desktop:** same as Extension (shared renderer).

**CLI:** the workflow run-details panel now says `Completed` / `Stopped` /
`Error` where it said `Finished` / `Cancelled` / `Failed`. This is the
user-visible half of the PR.

## Scheduled refactoring

None. Noted but deliberately untouched: `WorkflowRunDetails.tsx:170` still
reaches into `WORKFLOW_TASK_STATUS_LABEL` for the single word `Planned` on a
round that has no group yet. `planned` has no `StreamPhase` equivalent, so
there is nothing to move it to; inventing one would be a bigger change than
this PR argues for.

## Validation

- `npm run typecheck` — exit 0 (workspace, test-kernel, agent, cli including
  `tsconfig.scripts.json`, trace-viewer, desktop).
- `npx vitest run src/test-kernel/cli/WorkflowRunDetails.vitest.ts
  src/test-kernel/cli/SubagentListDisplay.vitest.ts
  src/test-kernel/progressView/UsagePanel.vitest.ts` — 3 files, 54 passed.
  `SubagentListDisplay` is in the set because it is the other consumer of the
  call-status map and had to be proved unaffected.
- `npm run lint` — clean.
- `npx prettier --check .` — clean.
- **Zero new tests.** The four existing `WorkflowRunDetails` assertions were
  *updated*, not added to — they already pinned this string, which is exactly
  what made the change safe to make.

### Eyeball checklist — no automated gate can verify a TUI or webview render

**CLI (`texra`):**
1. Run a multi-round workflow to completion and open the workflow run details
   panel. Finished rounds must read `✓ r1/2 Completed · 7s` — **not**
   `Finished`. A cancelled run must read `Stopped`, a failed one `Error`.
2. A round that has not started yet must still read `□ r2/2 Planned` —
   unchanged by this PR, and the one place the call vocabulary is still correct.
3. Check the glyph/tone pairing is untouched: `✓` green on completed, `✗` red on
   failed, dimmed circle on cancelled.

**Progress view (VS Code or desktop):**
4. Start a run and let the context gauge appear. With a small prompt (well under
   1% of the window) the tooltip must read `1% context used`, **not**
   `0% context used`. Hover to confirm, and check the bar itself is still a
   thin-but-present sliver rather than jumping to 1% of width — the bar takes
   the unfloored clamped value.
5. Fill the context past 80% and confirm the bar's fill color still crosses into
   the warning/error band at the same point it did before (the color reads the
   clamped value; that path is unchanged).
6. Confirm the same run's CLI status bar and the webview gauge now agree on the
   integer percent.
