### PR TITLE
refactor(cli): type the approval settlement mapper as BashSettlement

### DIFF
--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -59,16 +59,10 @@ export function toToolEditResult(
   decision: CliApprovalDecision,
   proposedContent: string,
 ): ToolEditApprovalResult {
-  if (decision.accepted) {
-    return { action: 'apply', appliedContent: proposedContent };
-  }
-  if (decision.rejectionCause !== undefined) {
-    return { action: 'reject', cause: decision.rejectionCause };
-  }
-  return {
-    action: 'reject',
-    ...(decision.userMessage && { feedback: decision.userMessage }),
-  };
+  const settled = toApprovalSettlement(decision);
+  return settled.action === 'approve'
+    ? { action: 'apply', appliedContent: proposedContent }
+    : settled;
 }
 
 async function decideToolEdit(
@@ -135,21 +129,20 @@ async function decideApprovalEvent(
   return { decision, prompted: true };
 }
 
-/** Approve/reject settlement shared by the bash, plan, and proposal ports of
- *  both CLI hosts — none of them offers the extra actions their result unions
- *  allow, except the TUI's plan `approve_and_goal`, which the TUI overlays on
- *  the approve branch. A rejection without a user message omits `feedback`
- *  rather than sending an explicit `undefined`. */
+/** Approve/reject settlement shared by the bash, plan, proposal, and tool-edit
+ *  ports of both CLI hosts — none of them offers the extra actions their result
+ *  unions allow, except the TUI's plan `approve_and_goal`, which the TUI
+ *  overlays on the approve branch. `BashSettlement` is the narrowest of those
+ *  unions (`approve` plus a `RejectionProvenance` reject), so it is assignable
+ *  to every one of them and the CLI does not re-declare the provenance channels
+ *  that `RejectionProvenance` already owns. A rejection without a user message
+ *  omits `feedback` rather than sending an explicit `undefined`. */
 export function toApprovalSettlement(
   decision: ApprovalDecision & {
     readonly rejectionCause?: string;
     readonly rejectionReason?: string;
   },
-):
-  | { action: 'approve' }
-  | { action: 'reject'; feedback?: string }
-  | { action: 'reject'; reason: string }
-  | { action: 'reject'; cause: string | undefined } {
+): BashSettlement {
   if (decision.accepted) return { action: 'approve' };
   if (decision.rejectionCause !== undefined) {
     return { action: 'reject', cause: decision.rejectionCause };
@@ -166,7 +159,7 @@ export function toApprovalSettlement(
 function toPromptedApprovalSettlement(
   decision: ApprovalDecision & { readonly rejectionCause?: string },
   prompted: boolean,
-): ReturnType<typeof toApprovalSettlement> {
+): BashSettlement {
   if (prompted || decision.accepted) return toApprovalSettlement(decision);
   return toApprovalSettlement({
     ...decision,


### PR DESCRIPTION
## Summary

`toApprovalSettlement` in the CLI's `approvalAdapter.ts` declared its own
four-member return union (`{action:'approve'} | {action:'reject';feedback?} |
{action:'reject';reason} | {action:'reject';cause}`). That union is a hand-rolled
restatement of `BashSettlement` — which is `approve` plus a `reject` carrying
`RejectionProvenance`, the type whose whole purpose (`HostInteractions.ts:105-116`)
is to own the three rejection channels exactly once so a new channel cannot reach
one settlement kind and miss another.

This types the mapper as `BashSettlement` and routes `toToolEditResult` through
it instead of re-deriving the same three branches a second time.

Behaviour-preserving:

- `BashSettlement` is assignable to `PlanApprovalResult`, `ProposalResult`, and
  the `reject` arm of `ToolEditApprovalResult` — all three declare their reject
  arm as `({action:'reject'} & RejectionProvenance)`. Verified by `npm run typecheck`.
- `toToolEditResult` took `CliApprovalDecision`, which is
  `ApprovalDecision & { rejectionCause?: string }` (`approvalPrompts.ts:54-56`) —
  it carries no `rejectionReason`, so the `reason` branch of `toApprovalSettlement`
  is unreachable from that call and the emitted arms are identical
  (`accepted` → `apply`, `rejectionCause` → `{reject, cause}`, otherwise
  `{reject, feedback?}` with `feedback` omitted rather than explicitly `undefined`).

## Issue acceptance gates

n/a — collapse sweep finding C-B, no issue.

## Single source of truth

`RejectionProvenance` / `BashSettlement` in `src/agent/runtime/HostInteractions.ts`
now own the CLI settlement shape. The adapter no longer restates the provenance
channels, and `toToolEditResult` no longer re-derives the approve/cause/feedback
split.

## Duplication and abstraction budget

Removed: one ad-hoc 4-member union type (a restatement of `BashSettlement`) and
one duplicated three-branch settlement derivation. No new abstraction, no new
export, no new file.

## Net elements (R6)

| | + | − |
|---|---|---|
| files | 0 | 0 |
| exported symbols | 0 | 0 |
| functions | 0 | 0 |
| types/interfaces | 0 | 1 (the inline return union) |
| LoC | +14 | −21 |

**Net −7 LoC.** This is a small reduction, not a large one — the win is the
deleted type, not the line count.

## Consumer counts (R8)

No export was added, removed, or renamed. Greps run over the whole tree
(`--exclude-dir=node_modules`):

```
grep -rn "toApprovalSettlement\|toBashApprovalSettlement\|toToolEditResult" --include='*.ts' --include='*.tsx' .
```

- `toApprovalSettlement`: 3 external call sites, all in
  `packages/cli/src/chat/tui/state/subscribeApprovals.ts` (:334, :353 and the
  import) — signature unchanged, return type only narrowed to a named type they
  already accept (`BashSettlement` at :318's port, `PlanApprovalResult` /
  `ProposalResult` at :334/:353).
- `toToolEditResult`: 2 call sites (`subscribeApprovals.ts:187`,
  `approvalAdapter.ts:84`) — signature unchanged.
- `ReturnType<typeof toApprovalSettlement>` had exactly 1 use
  (`toPromptedApprovalSettlement`), now spelled `BashSettlement`.
- Zero test files import any of the three functions.

## Host impact

Extension: none.

Desktop: none.

CLI: none at runtime — types only.

## Scheduled refactoring

`toBashApprovalSettlement` (`approvalAdapter.ts:179`) is now provably redundant:
its only distinguishing behaviour is checking `rejectionCause` *before*
`accepted`, and all three `rejectionCause` producers (`approvalPrompts.ts:300-304`,
`subscribeApprovals.ts:287-291`, `approvalQueue.ts:204-207`) set `accepted:false`,
so the divergent state is unrepresentable. Deleting it is a two-line consumer edit
in `packages/cli/src/chat/tui/state/subscribeApprovals.ts` (import list + :318),
which a concurrent track owns; left for whoever lands next in that file.

## Validation

- `npm run typecheck` (root; covers the workspace, test-kernel, agent, cli
  including `tsconfig.scripts.json`, trace-viewer and desktop projects) — clean.
- `npx vitest run src/test-kernel/cli/ApprovalAdapter.vitest.ts
  src/test-kernel/cli/ApprovalQueue.vitest.ts
  src/test-kernel/cli/TuiApprovalRetry.vitest.ts
  src/test-kernel/cli/AppInteractionPolicy.vitest.ts` — 4 files, 113 tests passed.
- `npx prettier --check` on the changed file — clean.
- Dead-code ratchet not run: no export added or removed.
