### PR TITLE
fix(progress-view): stop advertising a codex timeout that does not exist

### DIFF
--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
@@ -21,11 +21,10 @@ import type { TranscriptRowBase } from '@shared/transcript';
 import {
   BASH_TOOL_DEFAULT_TIMEOUT_MS,
   EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
-  EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
-  EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
+  executionsWaitTimeoutSeconds,
 } from '@shared/toolUse';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
-import { clamp, isObject } from '@utils/core';
+import { isObject } from '@utils/core';
 
 // Side-effect import to register <tool-timer> custom element
 import '@progressView/frontend/components/ToolTimer';
@@ -35,11 +34,15 @@ import '@progressView/frontend/components/TerminalOutput';
 import '@awesome.me/webawesome/dist/components/badge/badge.js';
 import '@awesome.me/webawesome/dist/components/details/details.js';
 
-/** Known per-tool default timeouts (ms) for display in the running timer. */
+/**
+ * Known per-tool default timeouts (ms) for display in the running timer.
+ * Every entry must be a timeout the tool actually enforces: a tool with no
+ * timeout belongs nowhere in this map, so its card shows a bare elapsed timer
+ * rather than a limit it will never hit.
+ */
 const TOOL_DEFAULT_TIMEOUTS: Record<string, number> = {
   bash: BASH_TOOL_DEFAULT_TIMEOUT_MS,
   executions: EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS * 1000,
-  codex: 300_000, // generous default — Codex turns can be slow
 };
 
 /**
@@ -49,16 +52,6 @@ const TOOL_DEFAULT_TIMEOUTS: Record<string, number> = {
 const TIMEOUT_GATED_BY_ACTION: Record<string, string> = {
   executions: 'wait',
 };
-
-function executionsWaitTimeoutSeconds(timeout: unknown): number {
-  return typeof timeout === 'number' && Number.isFinite(timeout)
-    ? clamp(
-        timeout,
-        EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
-        EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
-      )
-    : EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS;
-}
 
 /**
  * Extract the effective timeout for a tool call from its input.

--- a/src/shared/toolUse.ts
+++ b/src/shared/toolUse.ts
@@ -14,7 +14,7 @@ import {
   type NormalizedToolUse,
   type ToolUseStatus,
 } from '@shared/schemas';
-import { isObject } from '@utils/core';
+import { clamp, isObject } from '@utils/core';
 import { truncateSummary } from '@utils/text/stringUtils';
 
 function trimmedOrNull(value: unknown): string | null {
@@ -270,3 +270,19 @@ export const EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS = 60;
 
 /** Maximum `executions wait` timeout (seconds). */
 export const EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS = 1800;
+
+/**
+ * The `executions wait` timeout the tool will actually honour, in seconds.
+ * Sole owner of the clamp: the tool's own input schema normalizes through it,
+ * and both transcript surfaces read it back so no host can invent a different
+ * number than the one the wait enforces.
+ */
+export function executionsWaitTimeoutSeconds(timeout: unknown): number {
+  return typeof timeout === 'number' && Number.isFinite(timeout)
+    ? clamp(
+        timeout,
+        EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
+        EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
+      )
+    : EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS;
+}

--- a/src/shared/transcript/toolRowModel.ts
+++ b/src/shared/transcript/toolRowModel.ts
@@ -28,11 +28,7 @@ import {
   type ProposalFileGroup,
   type ToolUseStatus,
 } from '@shared/schemas';
-import {
-  EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
-  EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
-  EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
-} from '@shared/toolUse';
+import { executionsWaitTimeoutSeconds } from '@shared/toolUse';
 import {
   DELEGATE_MULTI_AGENTS_TOOL_NAME,
   DELEGATION_TOOLS,
@@ -49,7 +45,7 @@ import {
 } from '@shared/tools/toolDisplayName';
 import { deriveToolInputPreview } from '@shared/tools/toolInputPreview';
 import { isEditLikeToolName, toolDisplayKind } from '@shared/tools/toolKind';
-import { clamp, filterNotNullish, formatDuration, isObject } from '@utils/core';
+import { filterNotNullish, formatDuration, isObject } from '@utils/core';
 import { collapseWhitespace } from '@utils/text/stringUtils';
 
 import {
@@ -439,17 +435,6 @@ function buildMemorySections(ctx: SectionContext): ToolSection[] {
     }
   }
   return sections;
-}
-
-/** Clamp of the `executions wait` timeout, matching what the tool enforces. */
-function executionsWaitTimeoutSeconds(timeout: unknown): number {
-  return typeof timeout === 'number' && Number.isFinite(timeout)
-    ? clamp(
-        timeout,
-        EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
-        EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
-      )
-    : EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS;
 }
 
 function buildExecutionsSections(ctx: SectionContext): ToolSection[] {

--- a/src/tools/executions/toolInput.ts
+++ b/src/tools/executions/toolInput.ts
@@ -13,8 +13,8 @@ import {
   EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
   EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
   EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
+  executionsWaitTimeoutSeconds,
 } from '@shared/toolUse';
-import { clamp } from '@utils/core';
 
 // Local file imports
 import { ViewRangeSchema } from '../formatting';
@@ -100,13 +100,7 @@ const WaitActionSchema = z.strictObject({
     .nullish()
     // Clamp in the schema so input.timeout is always a ready-to-use number:
     // an out-of-range or missing value becomes a value inside the wait window.
-    .transform((v) =>
-      clamp(
-        v ?? EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
-        EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
-        EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
-      ),
-    )
+    .transform((v) => executionsWaitTimeoutSeconds(v))
     .describe(
       `Max seconds to wait for a status change. Default: ${EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS}; finite values are clamped to the ${EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS}-${EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS} range.`,
     ),


### PR DESCRIPTION
## Summary

Two related defects in how the progress view decides a tool call's timeout.

**1. The codex tool card advertises a 5-minute limit that does not exist.**
`TOOL_DEFAULT_TIMEOUTS` in the webview's tool-card helper carried
`codex: 300_000, // generous default — Codex turns can be slow`. That number is
invented by the renderer: `src/tools/codex.ts` has no `timeout` handling at any
line, and `CodexInputSchema` has only `prompt`, `sandbox_mode`, and `thread_id`
— there is no timeout field to read and nothing enforces one. Every running
codex card therefore showed `1m 12s / 5m`, counting toward a deadline the tool
will never hit; past five minutes the card silently implied an overrun that
never happens. Deleting the entry makes `getToolTimeoutMs('codex', …)` return
`undefined`, `toolFormatters.ts` passes `?? 0`, and `ToolTimer.render` gates the
` / limit` span on `timeoutMs > 0` — so the card shows a bare elapsed timer,
which is the truth.

**2. The `executions wait` clamp was written out three times.** The webview
helper and `toolRowModel` held byte-identical copies of
`executionsWaitTimeoutSeconds`, and the tool's own Zod input schema held a third
spelling as a `.transform`. Two of those three are display surfaces re-deriving
a number the tool owns. This PR gives the clamp one owner in `@shared/toolUse`,
next to the min/max/default constants it reads, and routes all three sites
through it.

The schema's spelling was semantically equal, not merely similar, and I checked
the constants rather than the shape: `.number().finite()` already rejects
non-finite input, so `clamp(v ?? DEFAULT, MIN, MAX)` equals
`isFinite(v) ? clamp(v, MIN, MAX) : DEFAULT` exactly because
`EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS = 300` lies inside `[60, 1800]`. No
behavior changes for `executions`.

`bash` is left alone deliberately: `src/tools/bash.ts` really is
`input.timeout ?? BASH_TOOL_DEFAULT_TIMEOUT_MS`, so its card entry reflects an
enforced limit. Only codex was fabricated.

## Issue acceptance gates

No issue. Found by the projector audit of the extension formatter stack
(`extension-formatters` track), candidate C1.

## Single source of truth

`executionsWaitTimeoutSeconds` in `src/shared/toolUse.ts` is now the sole owner
of the `executions wait` clamp. The tool's input schema normalizes through it
and both transcript surfaces read it back, so no host can display a number
different from the one the wait enforces.

`TOOL_DEFAULT_TIMEOUTS` now carries a doc comment stating its entry rule: only
timeouts a tool actually enforces belong in it.

## Duplication and abstraction budget

Removed: three spellings of one clamp collapse to one function with three
callers (well past the ≥2-caller bar; no single-caller extraction). One
renderer-invented constant deleted outright. No new layer, no pass-through — the
new export replaces two identical private functions rather than wrapping them.

## Net elements (R6)

Honest accounting, net **−12 LoC**:

| | + | − |
|---|---|---|
| Files | 0 | 0 |
| Exported symbols | 1 (`executionsWaitTimeoutSeconds`) | 0 |
| Functions (incl. private) | 1 | 2 |
| Constants | 0 | 1 (`codex` timeout entry) |
| Import specifiers | 2 | 8 |
| LoC | 29 | 41 |

Six of the added lines are the new function's doc comment and the
`TOOL_DEFAULT_TIMEOUTS` entry rule, so the code shrinks by more than the LoC
suggests. Exports move +1 gross; three consumers land in this same PR.

## Consumer counts (R8)

- `grep -rn "300_000\|300000" src packages --include="*.ts" --include="*.tsx"`
  (node_modules and `dist/` excluded) → the deleted line was the only production
  hit outside `SendToTerminalTool.ts`'s own unrelated constant and two
  `RetryState`/`ModelHandler` test strings. Nothing else read the codex value.
- `grep -n "timeout" src/tools/codex.ts` → no matches, confirming there is no
  enforced codex timeout to display.
- `grep -rn "EXECUTIONS_WAIT_" src packages …` → after the change,
  `EXECUTIONS_WAIT_MIN/MAX` are read by `toolUse.ts` itself and by
  `toolInput.ts`'s `.describe()` string; `DEFAULT` additionally by
  `helpers.ts`. No export orphaned.
- `grep -rn "executionsWaitTimeoutSeconds" src packages …` → 1 definition, 3
  call sites.
- `grep -n "clamp"` in each touched file → the `@utils/core` import is dropped
  only where the last use went with it (`toolRowModel.ts`, `helpers.ts`,
  `toolInput.ts`); `toolUse.ts` gains it.
- `grep toolUse config/ratchets/*.json` → empty. `@shared/toolUse` is not under
  `@shared/schemas`, and both hosts already imported it, so no deep-import
  baseline moves.

## Host impact

Extension: **user-visible.** Running codex tool cards lose the ` / 5m` suffix
and show elapsed time only. Everything else unchanged.

Desktop: none — no consumer of the webview helper.

CLI: none. `toolRowModel`'s executions timeout is unchanged in value; only its
definition site moved.

## Eyeball checklist (no automated gate covers a webview render)

A human must open the progress view and confirm:

1. **Run a `codex` tool call.** While it is in progress the card's timer reads
   e.g. `0:42` with **no** ` / 5m` suffix. Let it run past five minutes if you
   can — the timer keeps counting normally and nothing turns red or looks
   overdue.
2. **Run `executions` with `action: wait` and `timeout: 3600`.** The card still
   reads `wait (timeout: 1800s)` and the timer still shows ` / 30m` — the clamp
   is unchanged, only relocated.
3. **Run `executions` with `action: wait` and no `timeout`.** Timer shows
   ` / 5m` (the 300s default), as before.
4. **Run a `bash` command.** Its timer still shows ` / 2m` (or whatever
   `timeout` was passed) — this PR must not have touched bash.
5. **Run `executions` with `action: view`.** No timeout suffix, as before —
   the action gate still works.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean (workspace, test-kernel, agent, cli,
  trace-viewer, desktop).
- `npx vitest run src/test-kernel/progressView/ToolUseFormatter.vitest.ts
  src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
  src/test-kernel/transcript/` — 12 files, 309 tests, all passing. The existing
  `caps executions wait timeout displays at the tool maximum` test asserts
  `getToolTimeoutMs` at both clamp ends and still passes unmodified, which is
  the equivalence check for the relocation.
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — 8 current vs 8 baselined, no new findings.
- `npx prettier --check .` — clean.
- Zero new tests, per the repo's testing budget: the codex deletion is covered
  by the eyeball checklist above (a webview render), and the clamp move is
  already pinned by the existing test.
