### PR TITLE
refactor(transcript): one settlement authority, drop the dead contextState row

### DIFF
--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -4,7 +4,11 @@ import { ANSI_ESCAPE_START, ansiEscapeEnd } from '@cli/runtime/ansiEscapes';
 import { safeTerminalText } from '@cli/runtime/terminalText';
 import { redactSecrets } from '@logger/redaction';
 import { type StreamPhase } from '@shared/schemas';
-import type { TranscriptRow, TranscriptRowKind } from '@shared/transcript';
+import {
+  isSelfSettledRow,
+  type TranscriptRow,
+  type TranscriptRowKind,
+} from '@shared/transcript';
 import { isActivePhase } from '@shared/streams/streamStatus';
 
 import { normalizeKnownHtmlForCliMarkdown } from '../render/htmlMarkdownNormalize';
@@ -131,8 +135,6 @@ function deriveTranscriptRowHeadline(row: TranscriptRow): string {
       return row.line;
     case 'phase':
       return row.heading;
-    case 'contextState':
-      return '';
   }
 }
 
@@ -153,7 +155,6 @@ const ROW_KIND_IS_WIDGET = {
   user: false,
   workflowTask: false,
   contextManagement: true,
-  contextState: true,
   fileList: true,
   latexdiff: true,
   missingOutputs: true,
@@ -174,39 +175,11 @@ export function isRenderableTranscriptEntry(row: TranscriptRow): boolean {
 }
 
 /**
- * Rows whose content is fixed the moment they appear, independent of anything
- * around them — a durable settlement order assigned by the recorder, a host's
- * own local row, a compaction block that reached a terminal state, or a kind
- * that is complete on arrival.
- *
- * This is one half of "finalized"; the other half is the append-only promotion
- * cursor (`StreamSlice.finalizedFrontier`), which is the fold's alone.
- */
-const IMMEDIATELY_SETTLED_ROW_KINDS = new Set<TranscriptRowKind>([
-  'user',
-  'error',
-  'phase',
-  'fileList',
-  'missingOutputs',
-  'latexdiff',
-  'statistics',
-  'contextManagement',
-  'progressStatus',
-]);
-
-export function isSelfSettledRow(row: TranscriptRow): boolean {
-  if (row.kind === 'compactionActivity') return row.block.finalized;
-  return (
-    row.settlementSeqNo !== undefined ||
-    row.origin === 'local' ||
-    IMMEDIATELY_SETTLED_ROW_KINDS.has(row.kind)
-  );
-}
-
-/**
  * Whether the row at `index` may be printed into append-only scrollback: the
  * settled-prefix promotion has already reached it, or the row settles on its
- * own regardless of what precedes it.
+ * own regardless of what precedes it (`isSelfSettledRow`, the projector's
+ * half of "finalized"; this is the fold's half, the append-only promotion
+ * cursor `StreamSlice.finalizedFrontier`).
  */
 export function isFinalizedTranscriptRow(
   row: TranscriptRow,

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -24,7 +24,11 @@ import {
   USER_ENTRY_PREFIX,
 } from '@cli/tui/ui/glyphs';
 import type { WorkflowCallProgress } from '@shared/schemas';
-import type { TranscriptRow, TranscriptRowKind } from '@shared/transcript';
+import {
+  isSelfSettledRow,
+  type TranscriptRow,
+  type TranscriptRowKind,
+} from '@shared/transcript';
 import type { CompactionActivityStatus } from '@shared/streams/compactionActivityProjection';
 import { formatWorkflowPhaseHeading } from '@shared/copy/workflowCall';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
@@ -32,7 +36,6 @@ import { renderAnsiMarkdown } from '../render/ansiMarkdown';
 import { transcriptRowBodyLines } from '../render/transcriptRowLines';
 import {
   isInquiryContinuationText,
-  isSelfSettledRow,
   transcriptRowHeadline,
 } from './transcriptEntries';
 import { toolUseDisplayLines, toolUseMarginBottomRows } from './toolRenderers';
@@ -97,7 +100,6 @@ const ROW_GEOMETRY = {
   statistics: DETAIL_GEOMETRY,
   contextManagement: DETAIL_GEOMETRY,
   progressStatus: DETAIL_GEOMETRY,
-  contextState: DETAIL_GEOMETRY,
   error: {
     firstPrefix: ERROR_ENTRY_PREFIX,
     continuationPrefix: ' '.repeat(ERROR_ENTRY_PREFIX.length),

--- a/packages/cli/src/chat/tui/render/transcriptRowLines.ts
+++ b/packages/cli/src/chat/tui/render/transcriptRowLines.ts
@@ -140,7 +140,6 @@ export function transcriptRowBodyLines(
       case 'tool':
       case 'workflowTask':
       case 'compactionActivity':
-      case 'contextState':
       case 'phase':
       case 'log':
         return [];

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -47,7 +47,7 @@ import {
 import { isChildStreamRemoved, streamMetadataFor } from './childExecutions';
 import { subscribeToSignalChanges } from './signalSubscription';
 import {
-  advanceFinalizedFrontier,
+  advanceSettledPrefixIndex,
   applyStreamChanges,
   compactWorkflowEntries,
   createTranscriptFoldState,
@@ -259,8 +259,9 @@ export function syncStreamLog(
     // next rebuild inherits promotion from the slice rows.
     if (options.forceFinal === true) {
       patchStream(streamId, (slice) => {
-        const finalizedFrontier = advanceFinalizedFrontier(
-          slice.entries,
+        const finalizedFrontier = advanceSettledPrefixIndex(
+          (index) => slice.entries[index]!,
+          slice.entries.length,
           slice.finalizedFrontier,
           true,
         );

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -44,7 +44,6 @@ import { truncateSummary } from '@utils/text/stringUtils';
 import {
   isFinalizedTranscriptRow,
   isRenderableTranscriptEntry,
-  isSelfSettledRow,
   transcriptRowHeadline,
 } from '../panes/transcriptEntries';
 import type { TranscriptFoldItem, TranscriptFoldState } from './cliState';
@@ -151,18 +150,13 @@ export function logEntryStreamIsRunning(entry: StreamLogEntry): boolean {
  * The transcript row a projected row paints as, or `null` when the terminal
  * has no line for it.
  *
- * Two drops: context utilization is a status-bar fact, not a transcript line
- * (it reaches the CLI through the same projection so there is one derivation,
- * but has no inline row on either host); and a prose row whose text is
- * invisible in a terminal — an all-ANSI or zero-width chunk — never becomes a
- * row at all, so nothing downstream has to reserve space for it. Typed rows
- * keep their membership: the projector decided it, and the terminal does not
- * re-decide.
+ * One drop: a prose row whose text is invisible in a terminal — an all-ANSI or
+ * zero-width chunk — never becomes a row at all, so nothing downstream has to
+ * reserve space for it. Typed rows keep their membership: the projector
+ * decided it, and the terminal does not re-decide.
  */
 function transcriptRowForPaint(row: TranscriptRow): TranscriptRow | null {
   switch (row.kind) {
-    case 'contextState':
-      return null;
     case 'assistant':
     case 'log':
     case 'user':
@@ -201,11 +195,7 @@ export function advanceFinalizedFrontier(
 ): number {
   let index = Math.min(frontier, rows.length);
   while (index < rows.length) {
-    const row = rows[index]!;
-    if (
-      !isSelfSettledRow(row) &&
-      blocksSettledPrefix(row, index, rows.length, streamFinal)
-    ) {
+    if (blocksSettledPrefix(rows[index]!, index, rows.length, streamFinal)) {
       break;
     }
     index += 1;
@@ -815,12 +805,7 @@ function advanceSettledPrefix(
   let index = state.finalizedFrontier;
   while (index < items.length) {
     const row = items[index].rendered;
-    if (
-      !isSelfSettledRow(row) &&
-      blocksSettledPrefix(row, index, items.length, streamFinal)
-    ) {
-      break;
-    }
+    if (blocksSettledPrefix(row, index, items.length, streamFinal)) break;
     // A newly printed model reply becomes the stream's latest line.
     if (isResponseRow(row) && index > state.latestResponsePos) {
       state.latestResponsePos = index;

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -188,16 +188,23 @@ function blocksSettledPrefix(
 // round's earlier content). Only a contiguous prefix is promoted: `<Static>`
 // is append-only, so a row must not finalize while any earlier row is still
 // pending, or insertion order would reverse.
-export function advanceFinalizedFrontier(
-  rows: readonly TranscriptRow[],
-  frontier: number,
+//
+// Both holders of a frontier walk this same loop — the fold over its items,
+// and the no-resident-log turn boundary over the slice's rows — so the walk
+// (and its start clamp) is stated once. Positions below `start` are already
+// printed, so only the newly promotable tail is walked.
+export function advanceSettledPrefixIndex(
+  rowAt: (index: number) => TranscriptRow,
+  total: number,
+  start: number,
   streamFinal: boolean,
+  onAdvanced?: (index: number, row: TranscriptRow) => void,
 ): number {
-  let index = Math.min(frontier, rows.length);
-  while (index < rows.length) {
-    if (blocksSettledPrefix(rows[index]!, index, rows.length, streamFinal)) {
-      break;
-    }
+  let index = Math.min(start, total);
+  while (index < total) {
+    const row = rowAt(index);
+    if (blocksSettledPrefix(row, index, total, streamFinal)) break;
+    onAdvanced?.(index, row);
     index += 1;
   }
   return index;
@@ -794,25 +801,24 @@ function reconcileSynthetics(
   state.synthetics = current;
 }
 
-// Advance the contiguous settled-prefix promotion. Positions below the
-// frontier are already printed, so each application only walks the newly
-// promotable tail.
+// Advance the fold's settled-prefix promotion over its items.
 function advanceSettledPrefix(
   state: TranscriptFoldState,
   streamFinal: boolean,
 ): void {
   const items = state.items;
-  let index = state.finalizedFrontier;
-  while (index < items.length) {
-    const row = items[index].rendered;
-    if (blocksSettledPrefix(row, index, items.length, streamFinal)) break;
+  state.finalizedFrontier = advanceSettledPrefixIndex(
+    (index) => items[index]!.rendered,
+    items.length,
+    state.finalizedFrontier,
+    streamFinal,
     // A newly printed model reply becomes the stream's latest line.
-    if (isResponseRow(row) && index > state.latestResponsePos) {
-      state.latestResponsePos = index;
-    }
-    index += 1;
-  }
-  state.finalizedFrontier = index;
+    (index, row) => {
+      if (isResponseRow(row) && index > state.latestResponsePos) {
+        state.latestResponsePos = index;
+      }
+    },
+  );
 }
 
 /**

--- a/packages/extension/src/progressView/frontend/formatters/index.ts
+++ b/packages/extension/src/progressView/frontend/formatters/index.ts
@@ -61,8 +61,6 @@ const ROW_FORMATTERS: RowFormatters = {
   latexdiff: formatLatexdiffTemplate,
   statistics: formatStatisticsTemplate,
   contextManagement: formatContextManagementTemplate,
-  // Context utilization is folded into the usage panel, not the transcript.
-  contextState: () => null,
   progressStatus: formatProgressStatusTemplate,
   workflowTask: formatWorkflowCallTemplate,
   compactionActivity: formatCompactionActivityTemplate,

--- a/src/shared/transcript/index.ts
+++ b/src/shared/transcript/index.ts
@@ -11,6 +11,7 @@
 export { projectTranscriptRow } from './projectTranscriptRow';
 export {
   compactionActivityRow,
+  isSelfSettledRow,
   isSettledRow,
   promotesOnlyOnTypedTerminalState,
   type CompactionActivityRow,

--- a/src/shared/transcript/projectTranscriptRow.ts
+++ b/src/shared/transcript/projectTranscriptRow.ts
@@ -559,9 +559,6 @@ export function projectTranscriptRow(
       };
     }
 
-    case MESSAGE_TYPES.CONTEXT_STATE:
-      return { ...rowBase(entry), kind: 'contextState', data: entry.data };
-
     case MESSAGE_TYPES.PROGRESS_STATUS: {
       const detail = stringifyPayload(entry.data).text;
       return {
@@ -598,9 +595,12 @@ export function projectTranscriptRow(
     // `compactionActivityRow`. `activeSkills` is a per-run snapshot read on
     // demand from the log (the CLI's `/status`), not a transcript row, and
     // `internal` is a durable marker (the workflow-attempt boundary) that
-    // nothing renders.
+    // nothing renders. Context utilization is a status surface on both hosts —
+    // the CLI reads it off `StreamExecutionState.contextState` and the webview
+    // off the raw entry in `logSlice` — so it has no transcript row either.
     case MESSAGE_TYPES.CONTEXT_COMPACTION_ACTIVITY:
     case MESSAGE_TYPES.ACTIVE_SKILLS:
+    case MESSAGE_TYPES.CONTEXT_STATE:
     case MESSAGE_TYPES.INTERNAL:
       return undefined;
 

--- a/src/shared/transcript/transcriptRow.ts
+++ b/src/shared/transcript/transcriptRow.ts
@@ -20,7 +20,6 @@ import {
   TOOL_USE_STATUS,
   isTerminalWorkflowCallProgress,
   type ContextManagementData,
-  type ContextStateData,
   type DiffResultDisplay,
   type ErrorLogData,
   type ExtendedTokenUsageStats,
@@ -233,17 +232,6 @@ export interface ContextManagementRow extends TranscriptRowBase {
   readonly summary?: TranscriptText;
 }
 
-/**
- * Context utilization as the model handler actually measured it. Neither host
- * paints this inline: the webview folds it into the usage panel and the CLI
- * into its status bar. It is a row so the fact travels the same path as every
- * other one, with one owner instead of a second derivation per host.
- */
-interface ContextStateRow extends TranscriptRowBase {
-  readonly kind: 'contextState';
-  readonly data: ContextStateData;
-}
-
 export interface ProgressStatusRow extends TranscriptRowBase {
   readonly kind: 'progressStatus';
   readonly summary: TranscriptText;
@@ -295,7 +283,6 @@ export type TranscriptRow =
   | LatexdiffRow
   | StatisticsRow
   | ContextManagementRow
-  | ContextStateRow
   | ProgressStatusRow
   | WorkflowTaskRow
   | CompactionActivityRow
@@ -314,6 +301,42 @@ export type TranscriptRowOf<K extends TranscriptRowKind> = Extract<
 // ---------------------------------------------------------------------------
 
 /**
+ * Kinds whose content is complete the moment the row appears. A tool call or a
+ * workflow task is deliberately absent: it does reach a typed terminal state,
+ * but only in a position the producer chose, so it settles through
+ * {@link isSettledRow} rather than on its own.
+ */
+const IMMEDIATELY_SETTLED_ROW_KINDS = new Set<TranscriptRowKind>([
+  'user',
+  'error',
+  'phase',
+  'fileList',
+  'missingOutputs',
+  'latexdiff',
+  'statistics',
+  'contextManagement',
+  'progressStatus',
+]);
+
+/**
+ * Whether a row's content is fixed the moment it appears, independent of
+ * anything around it — the recorder assigned it a durable settlement order,
+ * the host synthesized it so no producer is still writing to it, a compaction
+ * block reached a terminal state, or the kind is complete on arrival.
+ *
+ * This is the position-independent half of {@link isSettledRow}, which a host
+ * with an append-only surface asks about a row it holds no position for.
+ */
+export function isSelfSettledRow(row: TranscriptRow): boolean {
+  if (row.kind === 'compactionActivity') return row.block.finalized;
+  return (
+    row.settlementSeqNo !== undefined ||
+    row.origin === 'local' ||
+    IMMEDIATELY_SETTLED_ROW_KINDS.has(row.kind)
+  );
+}
+
+/**
  * Whether a row's content can no longer change, so it is safe to print once
  * into append-only scrollback.
  *
@@ -325,8 +348,7 @@ export function isSettledRow(
   row: TranscriptRow,
   hasLaterRow: boolean,
 ): boolean {
-  // A host-synthesized row has no producer still writing to it.
-  if (row.origin === 'local') return true;
+  if (isSelfSettledRow(row)) return true;
   switch (row.kind) {
     case 'assistant':
       return !row.pendingEmbeddedFollowup && hasLaterRow;
@@ -353,7 +375,6 @@ export function isSettledRow(
     case 'latexdiff':
     case 'statistics':
     case 'contextManagement':
-    case 'contextState':
     case 'progressStatus':
     case 'phase':
     case 'log':

--- a/src/shared/transcript/transcriptRow.ts
+++ b/src/shared/transcript/transcriptRow.ts
@@ -340,6 +340,12 @@ export function isSelfSettledRow(row: TranscriptRow): boolean {
  * Whether a row's content can no longer change, so it is safe to print once
  * into append-only scrollback.
  *
+ * Opens with {@link isSelfSettledRow}: a row that is settled independent of
+ * position is settled full stop, without consulting `hasLaterRow` or the
+ * kind-specific terminal-state tests below. That containment
+ * (`isSettledRow` ⊇ `isSelfSettledRow`) is load-bearing — the promotion loop
+ * relies on it to treat both halves as one predicate.
+ *
  * `hasLaterRow` is the one positional fact the projector cannot answer: a
  * streaming text block is frozen when the producer has moved on to something
  * else. Hosts with no append-only surface may pass `true`.

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -54,7 +54,7 @@ import {
   visibleSubagentRows,
 } from '@cli/chat/tui/state/childExecutions';
 import { syncStreamLog } from '@cli/chat/tui/state/subscribeStreamLog';
-import { advanceFinalizedFrontier } from '@cli/chat/tui/state/transcriptFold';
+import { advanceSettledPrefixIndex } from '@cli/chat/tui/state/transcriptFold';
 import { transcriptViewportKey } from '@cli/chat/tui/state/transcriptViewportMode';
 import { attachSessionSignalsAdapter } from '@cli/chat/tui/state/sessionSignalsAdapter';
 import {
@@ -1922,9 +1922,22 @@ describe('CLI TUI row allocation', () => {
   });
 });
 
-describe('advanceFinalizedFrontier', () => {
+describe('advanceSettledPrefixIndex', () => {
   function tool(id: string, status: 'in_progress' | 'completed') {
     return toolEntry(id, 'Bash', {}, { status });
+  }
+
+  function frontier(
+    rows: readonly TranscriptRow[],
+    start: number,
+    streamFinal: boolean,
+  ): number {
+    return advanceSettledPrefixIndex(
+      (index) => rows[index]!,
+      rows.length,
+      start,
+      streamFinal,
+    );
   }
 
   function assistant(
@@ -1946,7 +1959,7 @@ describe('advanceFinalizedFrontier', () => {
     // a1 settled (later entry exists), t1 settled (completed), a2 is the
     // live tail and stays pending.
     expect(
-      advanceFinalizedFrontier(
+      frontier(
         [assistant('a1'), tool('t1', 'completed'), assistant('a2')],
         0,
         false,
@@ -1955,12 +1968,12 @@ describe('advanceFinalizedFrontier', () => {
   });
 
   it('keeps the in-flight tail pending while the stream runs', () => {
-    expect(advanceFinalizedFrontier([assistant('a1')], 0, false)).toBe(0);
+    expect(frontier([assistant('a1')], 0, false)).toBe(0);
   });
 
   it('keeps assistant entries with incomplete subagent blocks pending', () => {
     expect(
-      advanceFinalizedFrontier(
+      frontier(
         [assistant('a1', true), tool('t1', 'completed'), assistant('a2')],
         0,
         false,
@@ -1972,7 +1985,7 @@ describe('advanceFinalizedFrontier', () => {
     // t1 is still running: t2 must wait behind it even though it completed,
     // or it would print above t1 in append-only scrollback.
     expect(
-      advanceFinalizedFrontier(
+      frontier(
         [assistant('a1'), tool('t1', 'in_progress'), tool('t2', 'completed')],
         0,
         false,
@@ -1982,7 +1995,7 @@ describe('advanceFinalizedFrontier', () => {
 
   it('finalizes every remaining entry once the stream reaches a final status', () => {
     expect(
-      advanceFinalizedFrontier(
+      frontier(
         [assistant('a1'), tool('t1', 'in_progress'), assistant('a2')],
         0,
         true,


### PR DESCRIPTION
## Summary

Three independent cleanups in the shared transcript row model and the CLI
fold. They are in one PR because they all edit `src/shared/transcript/`
and/or `packages/cli/src/chat/tui/state/transcriptFold.ts` and would otherwise
have to be serialized; each is described separately below and can be reviewed
separately.

### 1. One settled-prefix advancement loop (commit 2)

`advanceFinalizedFrontier` (over a slice's rows, for the no-resident-log turn
boundary in `subscribeStreamLog.ts`) and the fold's private
`advanceSettledPrefix` (over fold items) were the same four-line walk around
`blocksSettledPrefix`, stated twice — and only one of the two clamped its
start, so a rebuild that left a frontier past the end of a shorter array would
have been the one place the clamp mattered. One loop,
`advanceSettledPrefixIndex(rowAt, total, start, streamFinal, onAdvanced?)`,
now serves both holders of a frontier; the clamp and the barrier rule live in
it once. The exported `advanceFinalizedFrontier` is deleted rather than turned
into a one-line pass-through over the new helper — it had exactly one
production caller, which now calls the shared loop directly.

### 2. One settlement authority (commit 1)

"Settled" was decided in two places:

- shared `isSettledRow(row, hasLaterRow)` (`src/shared/transcript/transcriptRow.ts`)
- the CLI's own `isSelfSettledRow` (`packages/cli/src/chat/tui/panes/transcriptEntries.ts`)

These are genuinely different predicates — `isSelfSettledRow` is the
position-independent half, so a completed tool row is settled by the first and
not by the second — but the fold had to combine them by hand, writing
`!isSelfSettledRow(row) && blocksSettledPrefix(...)` at **both** promotion
sites (`transcriptFold.ts:206` and `:819`). A third promotion site that forgot
the prefix would promote a row into append-only `<Static>` scrollback ahead of
an earlier pending row, and nothing would say so.

`isSelfSettledRow` now lives beside `isSettledRow` in the shared module, and
`isSettledRow` opens with it. The two call sites collapse to
`blocksSettledPrefix(...)` alone. The algebra is identical by De Morgan:

```
!self && !settled && (promotesOnly || !final)
  ==  !(self || settled) && (promotesOnly || !final)
```

Deliberately **not** done, and worth stating so a later reader does not "fix"
it: the two kind lists are not reconciled. `isSettledRow` returns `true` for
`kind: 'log'` unconditionally and dominates the `IMMEDIATELY_SETTLED_ROW_KINDS`
set, so making the lists agree would be a behaviour change dressed as tidying.
The code moved; nothing else changed. Every switch arm is kept, including
`compactionActivity` (which now duplicates the answer `isSelfSettledRow`
already gave) — the switch ends in `assertNever`, so removing an arm would
break exhaustiveness.

### 3. Drop the `contextState` row kind (commit 1)

No consumer anywhere in the repo reads `row.data` for `kind === 'contextState'`.
Both hosts spent a switch arm discarding it (`transcriptFold.ts` → `null`,
`progressView/frontend/formatters/index.ts` → `null`) plus three more table
arms each stating "this row has no headline / no geometry / no body lines".

The real consumers read the fact off other paths and are untouched:

- webview: `logSlice.ts:150-151` reads `entry.data` off the raw stream-log
  entry, not off a projected row.
- CLI: `SessionFactApplier.ts:182` → `StatusBar.tsx:278` →
  `statusBarDisplay.ts:239-259`, off `StreamExecutionState.contextState`
  (`src/shared/schemas/streamState.ts:163`) — the promotion the row was
  waiting on, which has landed.

`MESSAGE_TYPES.CONTEXT_STATE` itself **stays**. The wire entry, the completed-
run archive and the persisted schema are untouched; the message type moves into
`projectTranscriptRow`'s existing no-row group (alongside
`CONTEXT_COMPACTION_ACTIVITY` / `ACTIVE_SKILLS` / `INTERNAL`) instead of
producing a row nobody paints. It is *moved*, not deleted — that switch ends in
`assertNever`, so simply dropping the case would throw at runtime on every
context-state entry.

Left alone on purpose (they look like the row kind and are not):
`sessionSignalsAdapter.ts:97` and `LitSessionRenderer.ts:179` are
`SessionRenderSlice` invalidation reasons (`SessionRendererPort.ts:34`).

## Issue acceptance gates

No issue. Found by a verified CLI transcript-render audit.

## Single source of truth

- Settlement: `src/shared/transcript/transcriptRow.ts` now owns both halves.
  `isSelfSettledRow` is the position-independent test; `isSettledRow` is that
  plus the positional one. No host restates either.
- Context utilization: `StreamExecutionState.contextState` for the CLI and the
  raw `CONTEXT_STATE` log entry for the webview. It is no longer also a
  transcript row that four modules exist only to discard.

## Duplication and abstraction budget

Removed, not added. No new abstraction, no new layer, no wrapper: one existing
function moved next to the function that should have been calling it, and one
row kind deleted from the union it was never read out of.

## Net elements (R6)

**Net add overall, stated plainly.** Against this PR's real base (`ce08dcfb6c`)
the diff is **+116 / −111 = net +5 LoC across 10 files**, 0 added, 0 deleted.
Per commit:

- **Commit 1** (settlement authority + `contextState` removal): **−21 LoC**
  across 8 files.
- **Commit 2** (settled-prefix loop): **+26 LoC** across 4 files, which
  **cancels** commit 1's win — production +13 (of which ~12 is two doc blocks:
  the loop's contract and the `isSettledRow` containment note the reviewer
  asked for), test +13 (an 11-line adapter so the five existing
  `advanceFinalizedFrontier` tests call the generalized helper unchanged).

I am not selling this as a reduction. Commit 1 is a genuine deletion; commit 2
is a *correctness-of-invariant* consolidation — the start clamp and the barrier
rule are now stated once instead of once-per-caller with one of the two missing
the clamp — and it costs more lines than it deletes. If the bar for this PR is
net-negative LoC, the honest answer is that only commit 1 clears it and commit
2 should be dropped or re-scoped.

(The earlier "−21, 8 files" line in this body measured only commit 1, before
commit 2 was folded in — that is what the reviewer's "description numstat is
stale" note referred to. The numbers above are the true base→head diff.)

Exported symbols: **net 0**. `isSelfSettledRow` is deleted as a CLI export from
`transcriptEntries.ts` and added as a shared export in `transcriptRow.ts`
(plus one line in the `@shared/transcript` barrel — an existing host-imported
barrel, so no new deep-import specifier and no ratchet widening).
`advanceFinalizedFrontier` (exported from `transcriptFold.ts`) is deleted and
replaced by `advanceSettledPrefixIndex` on the same module, which picks up its
one production caller and its test file in the same PR.

Functions: net −1 (`advanceFinalizedFrontier` deleted; `isSelfSettledRow`
moved; `advanceSettledPrefixIndex` added; `advanceSettledPrefix` rewritten to
delegate). Constants: net 0 (`IMMEDIATELY_SETTLED_ROW_KINDS` moved with it).

Types/interfaces: **−1** (`ContextStateRow`) and **−1** `TranscriptRow` union
member.

Switch/table arms deleted: **9** — shared `isSettledRow` (1); CLI
`deriveTranscriptRowHeadline`, `ROW_KIND_IS_WIDGET`, `ROW_GEOMETRY`,
`transcriptRowBodyLines`, `transcriptRowForPaint` (5); extension
`formatters/index.ts` (1); plus `projectTranscriptRow`'s row-producing arm,
which is moved into the no-row group rather than deleted. All three CLI tables
are `satisfies Record<TranscriptRowKind, …>`, so a missed arm is a compile
error, not a runtime surprise — and typecheck did in fact catch the one arm I
missed on the first pass.

### Review note addressed

The first review round asked that `isSettledRow`'s JSDoc state the
short-circuit the consolidation made load-bearing. Its contract now says it
opens with `isSelfSettledRow`, so `isSettledRow` ⊇ `isSelfSettledRow`, and
that a future direct caller should not reason from the positional half alone.

## Consumer counts (R8)

Greps run over `src/` and `packages/` (excluding `node_modules` and `dist`):

- `grep -rn "isSettledRow\|isSelfSettledRow\|promotesOnlyOnTypedTerminalState"`
  — `isSettledRow` has **1** production consumer, `blocksSettledPrefix` in
  `transcriptFold.ts`, plus `TranscriptRowProjection.vitest.ts`.
  `isSelfSettledRow` has **3** production consumers after the move:
  `isSettledRow` itself, `isFinalizedTranscriptRow`
  (`transcriptEntries.ts`), and `transcriptEntryLayout.ts`. The two
  `transcriptFold.ts` call sites that hand-combined the two predicates are
  gone.
- `grep -rn "advanceFinalizedFrontier"` — **0** remain. Before: 1 production
  caller (`subscribeStreamLog.ts:262`, the no-resident-log `forceFinal` path)
  plus its test file. Both now use `advanceSettledPrefixIndex`, which has
  exactly those **2** production callers.
- `grep -rn "contextState"` — every surviving hit is one of: the
  `AgentTrace.contextState` emitter, `ContextStateData` on
  `StreamExecutionState` / `SessionState`, the `SessionRenderSlice`
  invalidation reason, the webview `UsagePanel`, or the CLI status bar. **Zero**
  hits read `row.data` off a `kind === 'contextState'` transcript row, before
  or after.
- `MESSAGE_TYPES.CONTEXT_STATE` — still produced and still consumed
  (`logSlice.ts:150`, `streamLogEntry.ts:124`, `SessionFactApplier`); only its
  transcript-row projection is gone.

## Host impact

Extension: one dead formatter arm removed. `logSlice` already read the fact off
the raw entry, so the usage panel is unaffected.

Desktop: none.

CLI: four dead arms removed; the two settled-prefix promotion sites now call
one predicate instead of hand-combining two. No behaviour change — verified by
the fold and transcript suites below, which pin promotion order and
`<Static>` membership.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean (workspace, test-kernel, agent, cli incl.
  `tsconfig.scripts.json`, trace-viewer, desktop).
- `npx vitest run` on the suites that pin this behaviour:
  `TranscriptRowProjection`, `ConversationTranscript`,
  `WorkflowScriptStreamTranscript`, `ToolRenderers`, `StreamLogDeltaFold`,
  `TuiStateAndFocus`, `SubscribeStreamLogDispose`, `TranscriptMarginCollapse`,
  `StatusBar` — all passing (414 tests across the first eight; 301 across the
  six re-run after commit 2, including the five repointed
  `advanceSettledPrefixIndex` tests).
- `npx vitest run src/test-kernel/progressView/
  src/test-kernel/architecture/dependencyDirection.vitest.ts` —
  61 files, 581 tests, all passing (covers the extension formatter arm).
- `npm run lint` — clean.
- `npx prettier --check .` — clean.
- `npm run check:dead-code-ratchet` — OK (8 current vs 8 baselined).
- Zero new tests: both halves are behaviour-preserving, and the existing
  suites already cover both paths unchanged.
