### PR TITLE
refactor(cli): route model-access copy through UsageRoute and usageRouteBadge

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -64,6 +64,7 @@ import {
   transcriptText,
   type TranscriptRow,
 } from '@shared/transcript';
+import { OWN_API_KEYS } from '@shared/copy/modelAccess';
 import { FOCUSED_BACKGROUND_TASK } from '@shared/copy/nestedRuns';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import {
@@ -135,10 +136,7 @@ import { resolveLocalTranscriptStreamId } from '../src/chat/tui/state/transcript
 import { clearTerminalScrollback } from '../src/tui/terminalCleanup';
 import { defaultShortcutModifierLabel } from '../src/runtime/shortcutLabels';
 import { OrchestrationApp } from '../src/orchestration/runOrchestrationTui';
-import {
-  formatCliModelAccessRouteInline,
-  resolveCliModelAccessRoute,
-} from '../src/runtime/modelAccessRoute';
+import { resolveCliModelAccessRoute } from '../src/runtime/modelAccessRoute';
 import { updateCliModelAccess } from '../src/runtime/modelAccessSelection';
 import {
   formatCliApiStatusActionHint,
@@ -634,7 +632,7 @@ function harnessOrchestrationStatusLines(): readonly string[] {
     accountLabel: authenticated ? 'harness@example.edu' : undefined,
   };
   return [
-    `api: ${formatCliModelAccessRouteInline('personal')}`,
+    `api: ${OWN_API_KEYS.inline}`,
     formatCliAuthStatusLine(profile),
     formatCliApiStatusActionHint(profile),
   ];

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -1,8 +1,4 @@
 import {
-  shortCliModelAccessRoute,
-  type CliModelAccessRoute,
-} from '@cli/runtime/modelAccessRoute';
-import {
   defaultShortcutModifierLabel,
   metaChordLabel,
 } from '@cli/runtime/shortcutLabels';
@@ -30,6 +26,7 @@ import {
   type TokenUsageStats,
   type UsageRoute,
 } from '@shared/schemas';
+import { usageRouteBadge } from '@shared/copy/modelAccess';
 import {
   FOREGROUND_OWNERSHIP,
   RUNNING_SESSION,
@@ -72,18 +69,18 @@ export function subscriptionUsageProviderForStatus({
   prospectiveCodingPlan,
 }: {
   readonly usageRoute: UsageRoute | undefined;
-  readonly modelAccess: CliModelAccessRoute;
+  readonly modelAccess: UsageRoute;
   readonly prospectiveCodingPlan?: SubscriptionUsageProvider;
 }): SubscriptionUsageProvider | undefined {
   if (usageRoute === 'chatgpt-subscription') return 'chatgpt';
   const completedCodingPlan = codingPlanForUsageRoute(usageRoute);
   if (completedCodingPlan) return completedCodingPlan.usageProvider;
   if (usageRoute !== undefined) return undefined;
-  if (modelAccess === 'chatgpt') return 'chatgpt';
+  if (modelAccess === 'chatgpt-subscription') return 'chatgpt';
   return CODING_PLAN_SUBSCRIPTIONS.find(
     (plan) =>
       plan.usageProvider === prospectiveCodingPlan &&
-      plan.cliProvider === modelAccess,
+      plan.usageRoute === modelAccess,
   )?.usageProvider;
 }
 
@@ -131,7 +128,7 @@ export interface StatusBarDisplayInput {
   readonly runningSessions: number;
   readonly approvalDepth: number;
   readonly approvalKind?: ApprovalQueueStatusKind;
-  readonly modelAccess: CliModelAccessRoute;
+  readonly modelAccess: UsageRoute;
   /** Latest quota snapshot for the subscription serving this model. */
   readonly subscriptionQuota?: SubscriptionUsageSnapshot;
   /** Ephemeral transcripts cannot be resumed and require a persistent warning. */
@@ -200,17 +197,21 @@ interface StatusBarDisplay {
   readonly bindings: string;
 }
 
-function accessModeSegment(access: CliModelAccessRoute): StatusBarSegment {
-  const label = shortCliModelAccessRoute(access);
-  return label === 'subscription'
+function accessModeSegment(access: UsageRoute): StatusBarSegment {
+  // `usageRouteBadge` is undefined only for an unset route; the bar always
+  // resolves one through `resolveCliModelAccessRoute`.
+  const badge = usageRouteBadge(access)!;
+  // The bar names how the call is paid for, not which subscription; the /api
+  // form and /status name the subscription itself.
+  return badge.subscription
     ? {
-        text: label,
+        text: 'subscription',
         color: COLOR_HINT,
         compactText: 'sub',
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.accessMode,
       }
     : {
-        text: label,
+        text: badge.compactLabel,
         color: 'dim',
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.accessMode,
       };

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -1,10 +1,7 @@
-import {
-  formatCliModelAccessRoute,
-  type CliModelAccessRoute,
-} from '@cli/runtime/modelAccessRoute';
+import { formatCliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
 import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import type { TexraApprovalPolicy } from '@shared/approvalPolicy';
-import type { StreamPhase, StreamSubstate } from '@shared/schemas';
+import type { StreamPhase, StreamSubstate, UsageRoute } from '@shared/schemas';
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
 import { BACKGROUND_TASK } from '@shared/copy/nestedRuns';
 import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
@@ -25,7 +22,7 @@ export interface CliSessionStatusInput {
   readonly agent: string;
   readonly model: string;
   readonly teamName?: string;
-  readonly modelAccess: CliModelAccessRoute;
+  readonly modelAccess: UsageRoute;
   readonly approval: string;
   readonly approvalBypasses?: Partial<BypassState>;
   readonly status: StreamPhase | undefined;

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -16,8 +16,6 @@ import {
   formatCliChatGptPreference,
   formatCliGrokPreference,
   formatCliCodingPlanPreference,
-  formatCliModelAccessRoute,
-  formatCliModelAccessRouteInline,
   cliCodingPlanStatus,
   type CliModelAccessStatus,
 } from './modelAccessRoute';
@@ -82,7 +80,7 @@ export async function loadCliModelAccessOverview(): Promise<CliModelAccessOvervi
       (plan) =>
         `${plan.displayName} preference: ${formatCliCodingPlanPreference(access, plan)}`,
     ),
-    `Otherwise: ${formatCliModelAccessRoute('personal')}`,
+    `Otherwise: ${OWN_API_KEYS.label}`,
     formatAccountStatusLine(
       RESEARCHER_ACCESS.label,
       profile.authenticated,
@@ -155,7 +153,7 @@ export async function loadCliApiStatus(
   );
 
   return [
-    `api: ${formatCliModelAccessRouteInline('personal')}`,
+    `api: ${OWN_API_KEYS.inline}`,
     ...(personalKeysLine ? [personalKeysLine] : []),
     authLine,
     ...(profile.note ? [profile.note] : []),
@@ -269,7 +267,7 @@ export async function loadCliDetailedAccountStatusLines(
     if (line) lines.push(withUsage(line, codingPlanUsage.get(plan.id)));
   }
 
-  lines.push(`Otherwise: ${formatCliModelAccessRoute('personal')}`);
+  lines.push(`Otherwise: ${OWN_API_KEYS.label}`);
 
   const otherPersonalKeys = formatPersonalApiKeysLine(
     providers.filter(

--- a/packages/cli/src/runtime/modelAccessRoute.ts
+++ b/packages/cli/src/runtime/modelAccessRoute.ts
@@ -11,16 +11,6 @@ import { OWN_API_KEYS } from '@shared/copy/modelAccess';
 export const CLI_MODEL_ACCESS_DESCRIPTION =
   'Set subscription preferences and how the rest is paid for.';
 
-export type CliModelAccessRoute =
-  | 'chatgpt'
-  | 'grok'
-  | 'kimi-code'
-  | 'glm-code'
-  // LEGACY: renders historical usage recorded on the retired relay route
-  // (removed 2026-08; see docs/proposals/2026-08-18-relay-removal-and-recovery.md).
-  | 'included'
-  | 'personal';
-
 type CliSubscriptionPreferenceState = 'off' | 'on';
 type CliSubscriptionProvider =
   'chatgpt' | 'grok' | CodingPlanSubscription['cliProvider'];
@@ -123,79 +113,32 @@ export function resolveCliModelAccessRoute({
   readonly usageRoute?: UsageRoute;
   /** Route that would serve the next request (`activeSubscriptionUsageRoute`). */
   readonly prospectiveRoute?: UsageRoute;
-}): CliModelAccessRoute {
-  const route = usageRoute ?? prospectiveRoute;
+}): UsageRoute {
+  return usageRoute ?? prospectiveRoute ?? 'api-key';
+}
+
+/** Detailed CLI phrasing for an access route — `/status` and the `/api` form
+ *  name the subscription itself, unlike the width-constrained badge copy in
+ *  `usageRouteBadge`. */
+export function formatCliModelAccessRoute(route: UsageRoute): string {
   switch (route) {
-    case undefined:
-      return 'personal';
     case 'chatgpt-subscription':
-      return 'chatgpt';
-    case 'xai-subscription':
-      return 'grok';
-    case 'kimi-code-subscription':
-      return 'kimi-code';
-    case 'glm-coding-plan-subscription':
-      return 'glm-code';
-    case 'relay':
-      return 'included';
-    case 'api-key':
-      return 'personal';
-    default:
-      return route satisfies never;
-  }
-}
-
-/** Status-bar form of the access route. Width-critical, so every arm is a
- *  short display phrase; the enum value itself never reaches the screen. */
-export function shortCliModelAccessRoute(route: CliModelAccessRoute): string {
-  switch (route) {
-    case 'chatgpt':
-    case 'grok':
-    case 'kimi-code':
-    case 'glm-code':
-      // The bar names how the call is paid for, not which provider; the /api
-      // form and /status name the subscription itself.
-      return 'subscription';
-    case 'included':
-      return 'Included';
-    case 'personal':
-      return OWN_API_KEYS.compactLabel;
-    default:
-      return route satisfies never;
-  }
-}
-
-export function formatCliModelAccessRoute(route: CliModelAccessRoute): string {
-  switch (route) {
-    case 'chatgpt':
       return 'ChatGPT subscription';
-    case 'grok':
+    case 'xai-subscription':
       return 'Grok subscription';
-    case 'kimi-code':
+    case 'kimi-code-subscription':
       return 'Kimi Code subscription';
-    case 'glm-code':
+    case 'glm-coding-plan-subscription':
       return 'GLM Coding Plan';
-    case 'included':
+    // LEGACY: renders historical usage recorded on the retired relay route
+    // (removed 2026-08; see docs/proposals/2026-08-18-relay-removal-and-recovery.md).
+    case 'relay':
       return 'Included access';
-    case 'personal':
+    case 'api-key':
       return OWN_API_KEYS.label;
     default:
       return route satisfies never;
   }
-}
-
-/** Sentence-fragment form derived from the canonical access label. */
-export function formatCliModelAccessRouteInline(
-  route: CliModelAccessRoute,
-): string {
-  const label = formatCliModelAccessRoute(route);
-  // Proper-noun labels keep their casing; plain labels lowercase like prose.
-  return route === 'chatgpt' ||
-    route === 'grok' ||
-    route === 'kimi-code' ||
-    route === 'glm-code'
-    ? label
-    : label.charAt(0).toLowerCase() + label.slice(1);
 }
 
 function formatCliSubscriptionPreference(
@@ -338,5 +281,5 @@ export function formatCliModelAccessSummary(
     const label = plan.displayName.split(' ')[0];
     return `${label} ${cliCodingPlanStatus(status, plan).preferred ? 'On' : 'Off'}`;
   });
-  return `ChatGPT ${chatGpt} · Grok ${grok} · ${codingPlans.join(' · ')} · otherwise: ${formatCliModelAccessRouteInline('personal')}`;
+  return `ChatGPT ${chatGpt} · Grok ${grok} · ${codingPlans.join(' · ')} · otherwise: ${OWN_API_KEYS.inline}`;
 }

--- a/packages/cli/src/runtime/modelAccessSelection.ts
+++ b/packages/cli/src/runtime/modelAccessSelection.ts
@@ -13,6 +13,7 @@ import {
 } from '@model/codingPlanSubscriptions';
 import { platform } from '@platform/platform';
 import { providerDisplayName } from '@shared/constants/providers';
+import { OWN_API_KEYS } from '@shared/copy/modelAccess';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
 import {
@@ -21,7 +22,6 @@ import {
   type CliSubscriptionLoginOptions,
 } from './subscriptionLogin';
 import {
-  formatCliModelAccessRouteInline,
   type CliModelAccessSelection,
   type CliModelAccessStatus,
 } from './modelAccessRoute';
@@ -151,7 +151,7 @@ async function updateKeyedCliModelAccess(
   await runtime.setEnabled(true);
   invalidateModelOptionsCache();
   return {
-    message: `${plan.preferenceLabel} enabled for ${plan.modelFamily} · other models still use ${formatCliModelAccessRouteInline('personal')}.`,
+    message: `${plan.preferenceLabel} enabled for ${plan.modelFamily} · other models still use ${OWN_API_KEYS.inline}.`,
   };
 }
 


### PR DESCRIPTION
## Summary

The CLI carried its own six-member enum for "how this model call is paid for" —
`CliModelAccessRoute` (`'chatgpt' | 'grok' | 'kimi-code' | 'glm-code' |
'included' | 'personal'`) — whose first four members were a rename of the
shared `UsageRoute` members, plus `'included'`/`'personal'` renames of
`'relay'`/`'api-key'`. Three formatters re-derived shared copy over that
renamed enum:

- `resolveCliModelAccessRoute`'s `usageRoute` branch was a total, exhaustive
  rename switch (`chatgpt-subscription → chatgpt`, …, `api-key → personal`) with
  a `satisfies never` default.
- `shortCliModelAccessRoute` was provably
  `badge.subscription ? 'subscription' : badge.compactLabel` of
  `usageRouteBadge` — verified arm-by-arm, including the coding-plan arms
  (`codingPlanForUsageRoute` short-circuits before the `throw` in
  `usageRouteBadge`, returning `{subscription: true}` for both plans).
- `formatCliModelAccessRouteInline` had exactly one non-literal caller; every
  production call site passed the literal `'personal'`, and the call sites are
  copy constants (`'your own API keys'`, `'Your own API keys'`) that
  `OWN_API_KEYS.inline` / `OWN_API_KEYS.label` already publish.

This deletes the enum and its two redundant formatters, routes
`resolveCliModelAccessRoute` onto `UsageRoute` directly (the prospective
boolean arms map to the corresponding subscription routes), routes the status
bar's access-mode segment onto `usageRouteBadge`, and replaces the four
inline-formatter call sites with the copy constants they always printed.

Rendered output is unchanged on every reachable input — the test expectations
that moved are the enum spellings, not the strings.

## Issue acceptance gates

n/a — collapse sweep finding C-A, no issue.

## Single source of truth

`UsageRoute` (`src/shared/schemas/usage.ts`) is now the only route enum the CLI
holds, and `usageRouteBadge` / `OWN_API_KEYS` (`src/shared/copy/modelAccess.ts`)
are the only badge/inline copy owners. `formatCliModelAccessRoute` remains the
CLI's *detailed* phrasing (`/status`, `/api`) — `usageRouteBadge.label` is not
a substitute for it (badge labels are `ChatGPT`/`Grok`/`GLM Coding Plan`; the
CLI detail lines say `ChatGPT subscription`/`GLM Coding Plan`/…), so that
formatter is rekeyed to `UsageRoute`, not deleted.

## Duplication and abstraction budget

Removed: one enum, one rename switch, one badge re-derivation, one
inline-casing formatter. Added: nothing — no new export, no new module, no new
helper.

## Net elements (R6)

| | + | − |
|---|---|---|
| files | 0 | 0 |
| exported symbols | 0 | 3 (`CliModelAccessRoute`, `shortCliModelAccessRoute`, `formatCliModelAccessRouteInline`) |
| functions | 0 | 2 |
| types | 0 | 1 |
| LoC (production) | +23 | −94 |
| LoC (tests) | +57 | −66 |

**Net −80 LoC total (−71 production).** See below for what the two non-saving
edits were: `formatCliModelAccessRoute` is rekeyed, not deleted (six arms in,
six arms out), and `subscriptionUsageProviderForStatus` is a rekey, not a
reduction.

## Consumer counts (R8)

Greps run over the whole tree (`--exclude-dir=node_modules`):

```
grep -rn "CliModelAccessRoute\|shortCliModelAccessRoute\|formatCliModelAccessRouteInline\|resolveCliModelAccessRoute" --include='*.ts' --include='*.tsx' .
```

- `CliModelAccessRoute`: 5 references, all in `modelAccessRoute.ts` + the two
  field declarations that now say `UsageRoute` (`statusBarDisplay.ts`,
  `sessionStatus.ts`) + their test literals.
- `shortCliModelAccessRoute`: 1 production caller (`accessModeSegment`) → now
  `usageRouteBadge`; test constants inlined to the strings they printed.
- `formatCliModelAccessRouteInline`: 4 call sites, all passing `'personal'`
  (`apiStatus.ts:158`, `modelAccessRoute.ts:348`, `modelAccessSelection.ts:154`,
  `scripts/tui-harness.tsx:637`) → `OWN_API_KEYS.inline`.
- `formatCliModelAccessRoute('personal')` → `OWN_API_KEYS.label` at the two
  `Otherwise:` lines (`apiStatus.ts:85,272`).
- `resolveCliModelAccessRoute`: signature widened to return `UsageRoute`;
  callers unchanged except for the enum spelling.

## Host impact

Extension: none.

Desktop: none.

CLI: no rendered-string change. The status-bar access segment, the `/status`
model-access line, the `/api` summary lines, and the selection messages print
byte-identical output; the wire enum they read is now the shared one.

## Scheduled refactoring

`StatusBar.tsx` flattens the coding-plan resolution into four booleans
(`grokSubscriptionActive`/`kimiCodeActive`/`glmCodingPlanActive`/…), and
`resolveCliModelAccessRoute` re-expands them into a route — a lossy round-trip
this PR leaves intact. Collapsing them into one `prospectiveRoute?: UsageRoute`
touches `StatusBar.tsx`, which a concurrent audit owns; left as a follow-up
rather than bundled.

## Validation

- `npm run typecheck` — clean (covers the workspace, test-kernel, agent, cli
  including `tsconfig.scripts.json`, trace-viewer and desktop projects).
- `npm run lint` — clean.
- `npx prettier --check .` — clean.
- `npx vitest run src/test-kernel/cli/StatusBar.vitest.ts
  src/test-kernel/cli/SessionStatus.vitest.ts
  src/test-kernel/cli/ModelAccessSelection.vitest.ts
  src/test-kernel/cli/ApiStatusLoad.vitest.ts
  src/test-kernel/cli/Orchestration.vitest.ts
  src/test-kernel/cli/Doctor.vitest.ts` — 6 files, 216 tests passed.
- Dead-code ratchet not run: three exports deleted with zero remaining
  references (grep above), none added.
