### PR TITLE
refactor(transcript): delete five readerless projector fields

### DIFF
--- a/src/shared/transcript/projectTranscriptRow.ts
+++ b/src/shared/transcript/projectTranscriptRow.ts
@@ -19,7 +19,6 @@ import {
 } from '@shared/schemas';
 import { normalizeToolUseForRender } from '@shared/toolUse';
 import {
-  deliveryTagOf,
   hasIncompleteEmbeddedSubagentFollowup,
   summarizeFollowupMessage,
 } from '@shared/subagentFollowup';
@@ -380,13 +379,11 @@ export function projectTranscriptRow(
 
     case MESSAGE_TYPES.USER_MESSAGE: {
       const text = entryText(entry);
-      const tag = deliveryTagOf(text.full);
       return {
         ...rowBase(entry),
         kind: 'user',
         text,
         summary: transcriptText(summarizeFollowupMessage(text.full)),
-        ...(tag ? { deliveryTag: tag } : {}),
         ...(entry.data?.workflowSummary
           ? { workflowSummary: entry.data.workflowSummary }
           : {}),
@@ -426,9 +423,7 @@ export function projectTranscriptRow(
         ...rowBase(entry),
         kind: 'webSearch',
         label: `${providerLabel} Search${query ? `: "${query}"` : ''}${suffix}`,
-        ...(query !== undefined ? { query } : {}),
         results: results ?? [],
-        ...(provider !== undefined ? { provider } : {}),
         ...(status !== undefined ? { status } : {}),
         failed: status === 'failed',
         inProgress: status === 'in_progress',
@@ -450,7 +445,6 @@ export function projectTranscriptRow(
         ...(url !== undefined ? { url } : {}),
         ...(title !== undefined ? { title } : {}),
         ...(status !== undefined ? { status } : {}),
-        ...(errorCode !== undefined ? { errorCode } : {}),
         ...(errorLabel !== undefined ? { errorLabel } : {}),
         ...(content ? { content: transcriptText(content) } : {}),
         failed,
@@ -502,7 +496,6 @@ export function projectTranscriptRow(
       return {
         ...rowBase(entry),
         kind: 'statistics',
-        stats: entry.data,
         label: 'Statistics',
         items,
       };

--- a/src/shared/transcript/transcriptRow.ts
+++ b/src/shared/transcript/transcriptRow.ts
@@ -22,7 +22,6 @@ import {
   type ContextManagementData,
   type DiffResultDisplay,
   type ErrorLogData,
-  type ExtendedTokenUsageStats,
   type FileListEntry,
   type LoadedMediaMetadata,
   type LogLevel,
@@ -32,7 +31,6 @@ import {
   type WorkflowCallProgress,
   type WorkflowScriptDeliverySummary,
 } from '@shared/schemas';
-import type { DeliveryTagName } from '@shared/deliveryTags';
 import {
   COMPACTION_ACTIVITY_LABEL,
   type CompactionActivityBlock,
@@ -102,7 +100,6 @@ export interface UserRow extends TranscriptRowBase {
   /** Collapsed presentation of a subagent/workflow delivery. Derived, never a
    *  truncation of `text`: hosts choose which of the two to paint. */
   readonly summary: TranscriptText;
-  readonly deliveryTag?: DeliveryTagName;
   readonly workflowSummary?: WorkflowScriptDeliverySummary;
   /** Media sent to the model with this message but never stored on the row. */
   readonly attachments?: readonly MediaAttachmentKind[];
@@ -147,9 +144,7 @@ export interface WebSearchRow extends TranscriptRowBase {
   readonly kind: 'webSearch';
   /** `Anthropic Search: "quantum error correction" (searching...)` */
   readonly label: string;
-  readonly query?: string;
   readonly results: readonly WebSearchResultRef[];
-  readonly provider?: string;
   readonly status?: string;
   readonly failed: boolean;
   readonly inProgress: boolean;
@@ -162,8 +157,7 @@ export interface WebFetchRow extends TranscriptRowBase {
   readonly url?: string;
   readonly title?: string;
   readonly status?: string;
-  readonly errorCode?: string;
-  /** Human-readable form of `errorCode`. */
+  /** Human-readable form of the wire payload's `errorCode`. */
   readonly errorLabel?: string;
   readonly content?: TranscriptText;
   readonly failed: boolean;
@@ -217,9 +211,6 @@ export interface StatItem {
 
 export interface StatisticsRow extends TranscriptRowBase {
   readonly kind: 'statistics';
-  /** Partial by contract: a run reports only the counters its provider
-   *  returned. */
-  readonly stats: Partial<ExtendedTokenUsageStats>;
   /** `Statistics` — the panel heading, owned here so both hosts say the same
    *  word. Mirrors {@link ContextManagementRow.label}. */
   readonly label: string;


### PR DESCRIPTION
## Summary

Delete five readerless fields from the shared transcript row projection:

| Field | Row | Retained representation |
|---|---|---|
| `deliveryTag` | `UserRow` | Re-derived from `text` where the host reads it |
| `query` | `WebSearchRow` | Included in `label` |
| `provider` | `WebSearchRow` | Included in `label` |
| `errorCode` | `WebFetchRow` | Converted to the painted `errorLabel` |
| `stats` | `StatisticsRow` | Converted to rendered `items` |

Each field is removed from the interface and from `projectTranscriptRow`. No test files are changed.

`FileListRow.counts` is deliberately retained in both the interface and projector. The existing CLI transcript contract in `TuiStateAndFocus.vitest.ts` consumes it, and deleting it caused the original PR's CI failure.

The previous web-search icon rewrite is also removed, keeping this PR limited to the proven readerless fields.

## Current-main overlap

Rebased onto current `origin/main`. Merged #11102 added `FileListRow.media` and `StatisticsRow.label` in the same shared files. Both additions are preserved; this PR only removes the five fields listed above.

## Validation

- `npm run typecheck` — clean across workspace, test kernel, agent, CLI, trace viewer, and desktop.
- `npx vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.ts` — 190 passed.
- `npx vitest run src/test-kernel/shared/TranscriptRowProjection.vitest.ts` — 8 passed.
- `npx eslint src/shared/transcript/projectTranscriptRow.ts src/shared/transcript/transcriptRow.ts` — clean.
- `npx prettier --check src/shared/transcript/projectTranscriptRow.ts src/shared/transcript/transcriptRow.ts` — clean.
