### PR TITLE
fix(cli): order the launcher agent menu by the shared default-agent priority

### DIFF
--- a/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
@@ -6,6 +6,7 @@ import { Text } from 'ink';
 import {
   listCliHistoryEntries,
   resumableCliHistoryEntries,
+  RESUME_LIST_LIMIT,
   type CliHistoryEntry,
 } from '@cli/runtime/history';
 import { formatCliHistoryResumeSummary } from '@cli/runtime/historyLabels';
@@ -29,7 +30,10 @@ export function ResumeListForm(props: ResumeListFormProps): React.JSX.Element {
       title="/resume"
       loadingLabel="Loading history..."
       load={async () =>
-        resumableCliHistoryEntries(await listCliHistoryEntries()).slice(0, 50)
+        resumableCliHistoryEntries(await listCliHistoryEntries()).slice(
+          0,
+          RESUME_LIST_LIMIT,
+        )
       }
       items={(entries) =>
         entries.map((entry) => ({

--- a/packages/cli/src/runtime/defaultAgents.ts
+++ b/packages/cli/src/runtime/defaultAgents.ts
@@ -8,8 +8,9 @@ export const BUILTIN_DEFAULT_CHAT_AGENT = 'assistant';
 
 // Priority for the implicit default: the built-in default first, then the shared
 // preferred order with the built-in removed so it isn't re-checked (it already
-// appears in PREFERRED_TOOL_USE_AGENTS). Built once at module load.
-const DEFAULT_AGENT_PRIORITY: readonly string[] = [
+// appears in PREFERRED_TOOL_USE_AGENTS). Built once at module load. Shared with
+// the launcher's agent menu so the first row is the agent a bare Enter starts.
+export const DEFAULT_AGENT_PRIORITY: readonly string[] = [
   BUILTIN_DEFAULT_CHAT_AGENT,
   ...PREFERRED_TOOL_USE_AGENTS.filter(
     (name) => name !== BUILTIN_DEFAULT_CHAT_AGENT,

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -116,6 +116,11 @@ type CliHistoryFile = RunGeneratedFile;
 
 export const CLI_HISTORY_RESUMABLE_STATUS = 'resumable';
 
+/** Rows the resume surfaces offer. Both the launcher's resume browser and the
+ *  `/resume` form read this, and the launcher's Resume row counts against it,
+ *  so the advertised count can never exceed the list it opens. */
+export const RESUME_LIST_LIMIT = 50;
+
 export function resumableCliHistoryEntries<
   T extends Pick<CliHistoryEntry, 'status'>,
 >(entries: readonly T[]): T[] {

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -4,7 +4,7 @@ import {
   teamTexraHostedMissingNames,
 } from '@common/teams/TeamPlan';
 import type { ExecutionId } from '@shared/schemas';
-import { agentKeyOf } from '@shared/schemas';
+import { agentKeyOf, agentName } from '@shared/schemas';
 import { implicitDefaultToolUseAgents } from '@shared/constants/agents';
 import { formatResultCount } from '@utils/text/stringUtils';
 
@@ -13,9 +13,16 @@ import {
   formatCliMultiAgentPresetLauncherSummary,
   type CliMultiAgentPresetRunPlan,
 } from './multiAgentPresets';
-import { pickDefaultToolUseAgent } from './defaultAgents';
+import {
+  DEFAULT_AGENT_PRIORITY,
+  pickDefaultToolUseAgent,
+} from './defaultAgents';
 import { formatCliHistoryResumeSummary } from './historyLabels';
-import { resumableCliHistoryEntries, type CliHistoryEntry } from './history';
+import {
+  resumableCliHistoryEntries,
+  RESUME_LIST_LIMIT,
+  type CliHistoryEntry,
+} from './history';
 import {
   modelAccessLaunchBlockDescription,
   modelSelectItemsForCli,
@@ -160,12 +167,18 @@ export function buildCliOrchestrationItems(
       disabled: launchBlocked,
     });
   }
-  const resumeItems = buildCliResumeItems(input.history);
-  if (resumeItems.length > 0) {
+  // Count only — the rows themselves are built when the browser opens, and
+  // the count is capped at the same limit so it never reports more sessions
+  // than the browser can list.
+  const resumableCount = Math.min(
+    resumableCliHistoryEntries(input.history).length,
+    RESUME_LIST_LIMIT,
+  );
+  if (resumableCount > 0) {
     items.push({
       value: { kind: 'browse-resumes' },
       label: 'Resume',
-      description: formatResultCount(resumeItems.length, 'session'),
+      description: formatResultCount(resumableCount, 'session'),
     });
   }
   if (implicitDefaultToolUseAgents(input.toolUseAgents).length > 0) {
@@ -287,14 +300,18 @@ export function buildCliAccountItems(
 export function buildCliAgentItems(
   toolUseAgents: readonly AgentEntry[],
 ): CliOrchestrationItem[] {
-  const priority = new Map([
-    ['assistant', 0],
-    ['orchestrator', 1],
-  ]);
+  // Order by the implicit-default priority (`pickDefaultToolUseAgent`) so the
+  // first row is the agent a bare Enter starts. Names are matched the way the
+  // default picker matches them — on the source-stripped `agentName`, not the
+  // raw entry name, so a custom agent carrying a source prefix still ranks.
+  const unprioritized = DEFAULT_AGENT_PRIORITY.length;
+  const priorityOf = (name: string): number => {
+    const index = DEFAULT_AGENT_PRIORITY.indexOf(agentName(name));
+    return index === -1 ? unprioritized : index;
+  };
   return implicitDefaultToolUseAgents(toolUseAgents)
     .toSorted((left, right) => {
-      const byPriority =
-        (priority.get(left.name) ?? 2) - (priority.get(right.name) ?? 2);
+      const byPriority = priorityOf(left.name) - priorityOf(right.name);
       return byPriority || left.name.localeCompare(right.name);
     })
     .map((agent) => ({
@@ -316,7 +333,7 @@ export function buildCliResumeItems(
   history: readonly CliHistoryEntry[],
 ): CliOrchestrationItem[] {
   return resumableCliHistoryEntries(history)
-    .slice(0, 50)
+    .slice(0, RESUME_LIST_LIMIT)
     .map((entry) => ({
       value: { kind: 'resume', id: entry.id },
       label: entry.id,


### PR DESCRIPTION
## Summary

Two launcher fixes in `packages/cli/src/runtime/orchestration.ts`, both about a
fact the shared modules already own:

1. **Agent-menu ordering (visible change).** `buildCliAgentItems` sorted its
   rows with a local 2-entry literal (`{assistant: 0, orchestrator: 1}`, else
   alphabetical), while `pickDefaultToolUseAgent` — the thing that decides what
   a bare Enter from the launcher starts — ranks by
   `DEFAULT_AGENT_PRIORITY` (`assistant`, then the shared
   `PREFERRED_TOOL_USE_AGENTS` order with `assistant` hoisted first). The menu
   now uses the same constant. Practical effect on a default roster: **none**
   (`assistant, orchestrator, research, review` sorts identically both ways —
   the existing order assertion passes unchanged). The difference shows on
   rosters with unlisted custom agents or non-preferred built-ins, which today
   outrank preferred agents whenever they sort alphabetically earlier; after
   this they rank behind every agent the default picker prefers. Matching also
   moves to the source-stripped `agentName`, matching the default picker, so a
   custom agent whose entry name carries a source prefix (`custom:foo`) now
   ranks instead of falling into the tail.

   Scope note, stated plainly: this does **not** make the launcher's Agent menu
   agree with `/agent`. `/agent` sorts by `PREFERRED_TOOL_USE_AGENTS` directly
   (orchestrators first) and shows a different roster (no
   `implicitDefaultToolUseAgents` filter). The claim here is only that the
   launcher's order is now owned by the shared default-agent priority constant
   rather than a private 2-entry literal.

2. **Resume-row count.** The launcher's Resume row built the full 50-item
   resume list (each row formatting a timestamp + summary) only to read
   `.length`. It now counts `resumableCliHistoryEntries(input.history).length`
   capped at the new `RESUME_LIST_LIMIT`. The 50 was also written twice —
   `buildCliResumeItems`'s `.slice(0, 50)` and `ResumeListForm`'s
   `.slice(0, 50)` — and is now one exported constant in `history.ts`, beside
   `resumableCliHistoryEntries`, with both surfaces reading it. Behaviour is
   unchanged: the cap still holds, and the advertised count still matches the
   list the browser opens.

## Issue acceptance gates

n/a — collapse sweep findings C-D and C-G-count, no issues.

## Single source of truth

`DEFAULT_AGENT_PRIORITY` (`packages/cli/src/runtime/defaultAgents.ts`) owns the
launcher agent-menu order; `RESUME_LIST_LIMIT`
(`packages/cli/src/runtime/history.ts`) owns the resume row cap for the count,
the resume browser, and the `/resume` form.

## Duplication and abstraction budget

Removed: one local priority map (a 2-entry restatement of the shared constant)
and one throwaway 50-row construction per launcher render. Added: one exported
constant (`RESUME_LIST_LIMIT`) with two production consumers, and one export
keyword on the existing `DEFAULT_AGENT_PRIORITY` (also two consumers). No new
functions, no new files, no new layer.

## Net elements (R6)

| | + | − |
|---|---|---|
| files | 0 | 0 |
| exported symbols | 2 (`DEFAULT_AGENT_PRIORITY` newly exported, `RESUME_LIST_LIMIT` new) | 0 |
| functions | 0 | 0 |
| LoC | +43 | −16 |

**Net +27 LoC.** This is not sold as a reduction: the change buys shared
ownership of two ordering/cap facts and pays for it with comments, a named
constant, and an explicit `priorityOf` normalizer (the source-prefix matching
the default picker already does). The deletions are the `Map` construction and
the two inline `50`s.

## Consumer counts (R8)

```
grep -rn "buildCliResumeItems\|resumableCliHistoryEntries\|DEFAULT_AGENT_PRIORITY" --include='*.ts' --include='*.tsx' src packages
```

- `buildCliResumeItems`: unchanged, still consumed by `orchestrate.ts:214`
  (`resumeItems` for the browser), `tui-harness.tsx:545`, and
  `Orchestration.vitest.ts`.
- `resumableCliHistoryEntries`: now 4 production consumers (the new count site
  joins `buildCliResumeItems`, `ResumeListForm`, `HistoryStatus` tests).
- `RESUME_LIST_LIMIT`: 2 production consumers (`orchestration.ts` ×2,
  `ResumeListForm.tsx`) — satisfies the same-PR consumer rule.
- `DEFAULT_AGENT_PRIORITY`: 2 production consumers (`pickDefaultToolUseAgent`,
  `buildCliAgentItems`).
- `DEFAULT_AGENT_PRIORITY` grep before the change: module-private, zero
  references outside `defaultAgents.ts`.

## Host impact

Extension: none.

Desktop: none.

CLI: the launcher's Agent submenu order can change for rosters containing
unlisted custom agents or non-preferred built-ins (see Summary). The Resume row
description is byte-identical.

## Scheduled refactoring

The `/agent` form (`AgentListForm` → `computeAgentOptionsData` →
`sortAgentEntries(getVisibleAgents('toolUse'), PREFERRED_TOOL_USE_AGENTS)`)
and the launcher's Agent menu still use two different orderings and two
different rosters (implicit-default filter vs full visible set). Unifying them
is a product decision (which order should the launcher show?), not a dedup —
left alone deliberately.

## Validation

- `npm run typecheck` — 0 errors (workspace, test-kernel, agent, cli incl.
  `tsconfig.scripts.json`, trace-viewer, desktop).
- `npm run lint` — clean.
- `npx prettier --check .` — clean.
- `npx vitest run src/test-kernel/cli/Orchestration.vitest.ts
  src/test-kernel/cli/HistoryStatus.vitest.ts
  src/test-kernel/cli/ResumeListForm.vitest.ts` — 3 files, 50 tests passed
  (the agent-order assertion passes unchanged; no test retarget was needed).
- `npm run check:dead-code-ratchet` — clean, 8 current vs 8 baselined.
