### PR TITLE
refactor(streams): make StreamTabInfo.label the only display-name reader

### DIFF
--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -16,7 +16,6 @@ import {
   DEFAULT_STREAM_METADATA_STATUS,
   STREAM_PHASE,
   STREAM_SUBSTATE,
-  runIdentityDisplayName,
   type StreamLifecycleStatus,
   type StreamState,
   type StreamSubstate,
@@ -85,12 +84,9 @@ function buildTooltip(
   const worktreeDisplay = info.worktree
     ? `Worktree: ${info.worktree.branch}${info.worktree.pr ? ` (#${info.worktree.pr.number})` : ''}`
     : undefined;
-  // Prefer the declared RunIdentity over the derived tab label.
-  const identityDisplay = info.identity
-    ? runIdentityDisplayName(info.identity)
-    : undefined;
   const mainLine = [
-    identityDisplay || streamDisplayLabel(info),
+    // `label` already is the identity display name (`buildStreamTabInfo`).
+    streamDisplayLabel(info),
     `Status: ${statusLabel}`,
     modelDisplay && `Model: ${modelDisplay}`,
     worktreeDisplay,
@@ -201,7 +197,7 @@ class StreamTab extends LitElement {
     // repeating it in the meta line underneath would just echo the title.
     const metaAgentName =
       stream.identity?.kind === 'agent' && stream.description
-        ? runIdentityDisplayName(stream.identity)
+        ? stream.label
         : undefined;
 
     return html`

--- a/packages/trace-viewer/src/main.ts
+++ b/packages/trace-viewer/src/main.ts
@@ -18,7 +18,7 @@ import {
 
 import type { TraceDocument } from '@transcript';
 import { toErrorMessage } from '@utils/errors/errorMessage';
-import { recordName, replayTrace } from './replayTrace';
+import { replayTrace, traceDisplayName } from './replayTrace';
 import { parseTraceData } from './traceDataSchema';
 
 const rootElement = document.querySelector<HTMLElement>('#app');
@@ -108,7 +108,7 @@ loadTrace()
     replayTrace(trace);
     // Landmark + title carry the run's identity once known, so AT users and
     // browser tabs can tell exported traces apart.
-    const label = `Trace: ${recordName(trace.config)}`;
+    const label = `Trace: ${traceDisplayName(trace)}`;
     root.setAttribute('aria-label', label);
     document.title = label;
   })

--- a/packages/trace-viewer/src/replayTrace.ts
+++ b/packages/trace-viewer/src/replayTrace.ts
@@ -12,6 +12,7 @@ import {
   STREAM_PHASE,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_STATUS,
+  runIdentityDisplayName,
 } from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { buildStreamContentRender } from '@shared/streams/streamContentSync';
@@ -135,8 +136,9 @@ function toStreamLifecycleStatus(trace: TraceDocument): StreamLifecycleStatus {
   return trace.snapshot.status ?? STREAM_STATUS.READY;
 }
 
-/** The record's display name across both arms of the config union. */
-export function recordName(config: TraceDocument['config']): string {
+/** The raw configured name across both arms of the config union. Not a display
+ *  name — it still carries any source prefix. */
+function recordName(config: TraceDocument['config']): string {
   return 'agentCategory' in config ? config.agent : config.name;
 }
 
@@ -159,6 +161,24 @@ function legacyTraceIdentity(trace: TraceDocument): RunIdentity {
 }
 
 /**
+ * The run's identity. The embedded ExecutionMeta carries it; pre-migration
+ * exports have none and are NOT all agent runs (bash process and
+ * workflow-script traces exist), so those classify from the trace's stream-id
+ * prefix. An exported trace file is immutable, so unlike the storage-side
+ * readers retired in #9590 Stage 7 this fallback is permanent: it is the only
+ * place a stream-id prefix may be read as evidence.
+ */
+function traceIdentity(trace: TraceDocument): RunIdentity {
+  return trace.meta?.identity ?? legacyTraceIdentity(trace);
+}
+
+/** The run's display name — the same identity rule every host's stream tab
+ *  labels with, so the page title and the tab cannot disagree. */
+export function traceDisplayName(trace: TraceDocument): string {
+  return runIdentityDisplayName(traceIdentity(trace));
+}
+
+/**
  * Replays one finished execution through the REAL `dispatchMessage` pipeline
  * as a short synthetic message sequence — the same reducer logic a live host
  * uses, just fed once instead of over time. Order matters: `LOG_DELTA` is a
@@ -169,9 +189,13 @@ export function replayTrace(trace: TraceDocument): void {
   const { snapshot } = trace;
   const agentConfig =
     'agentCategory' in trace.config ? trace.config : undefined;
+  const identity = traceIdentity(trace);
   const streamTabBase = {
     name: trace.streamId,
-    label: recordName(trace.config),
+    // The identity owns the label everywhere else (`buildStreamTabInfo`), so
+    // it owns it here too — `recordName` keeps any source prefix, which would
+    // render `custom:polish` in this viewer and `polish` in every host.
+    label: runIdentityDisplayName(identity),
     agentCategory: agentConfig?.agentCategory,
     // Empty-entries traces have nothing to derive a creation time from;
     // fall back to "now" rather than the Unix epoch, which would render
@@ -180,14 +204,6 @@ export function replayTrace(trace: TraceDocument): void {
     executionId: trace.executionId,
     description: trace.meta?.description,
   };
-  // The embedded ExecutionMeta carries the run's identity. Pre-migration
-  // exports have no identity and are NOT all agent runs (bash process and
-  // workflow-script traces exist), so classify from the trace's stream-id
-  // prefix. An exported trace file is immutable, so unlike the storage-side
-  // readers retired in #9590 Stage 7 this fallback is permanent: it is the
-  // only place a stream-id prefix may be read as evidence.
-  const identity: RunIdentity =
-    trace.meta?.identity ?? legacyTraceIdentity(trace);
   const streamTabInfo: StreamTabInfo =
     identity.kind === 'process'
       ? { ...streamTabBase, identity, command: trace.config.instruction }

--- a/src/shared/copy/workflowRunContext.ts
+++ b/src/shared/copy/workflowRunContext.ts
@@ -1,7 +1,6 @@
 import {
   fileLocationAddressPath,
   roundIndexedEntries,
-  runIdentityDisplayName,
   type CompileFailure,
   type OutputFileInfo,
   type RoundIndexed,
@@ -35,9 +34,8 @@ export function formatWorkflowRunContext(
   if (!hasOutputs && !hasFailures) return '';
 
   const { stream } = input;
-  const agent = stream.identity
-    ? runIdentityDisplayName(stream.identity)
-    : stream.label;
+  // `label` already is the identity display name (`buildStreamTabInfo`).
+  const agent = stream.label;
   const model = stream.modelLabel ?? stream.model;
 
   const lines: (string | undefined)[] = [

--- a/src/test-kernel/progressView/StreamHeader.vitest.ts
+++ b/src/test-kernel/progressView/StreamHeader.vitest.ts
@@ -352,6 +352,9 @@ describe('stream-header', () => {
     it('writes the run context and dispatches no toolbar command', async () => {
       const element = await mount({
         stream: baseStream({
+          // What buildStreamTabInfo emits for this identity — the copy path
+          // reads the label, never re-derives it from the identity.
+          label: 'stream-a',
           model: 'gemini31p',
           modelLabel: 'Gemini 3.1 Pro',
           executionId: 'a1b2c3d4',

--- a/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.ts
+++ b/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.ts
@@ -225,29 +225,6 @@ describe('stream-tab expand chevron', () => {
     );
   });
 
-  it('reads the inline agent name from RunIdentity, not the derived tab label', async () => {
-    const tabs = await mountTabs({
-      streams: [
-        {
-          identity: { kind: 'agent', agent: 'custom:engineer' },
-          name: 'custom:engineer#abc',
-          // Deliberately stale/wrong derived label — identity is authoritative.
-          label: 'stale-label',
-          agentCategory: AgentCategory.ToolUse,
-          description: 'Removing Supabase migrations from remote...',
-          creationTimestamp: 1,
-        },
-      ],
-    });
-
-    expect(
-      tabs.shadowRoot
-        ?.querySelector('stream-tab')
-        ?.shadowRoot?.querySelector('.agent-name')
-        ?.textContent?.trim(),
-    ).toBe('engineer');
-  });
-
   it('keeps the opaque stream id out of row text but in its accessible name', async () => {
     const tabs = await mountTabs({
       streams: [

--- a/src/test-kernel/shared/WorkflowRunContextCopy.vitest.ts
+++ b/src/test-kernel/shared/WorkflowRunContextCopy.vitest.ts
@@ -11,7 +11,9 @@ import { formatWorkflowRunContext } from '@shared/copy/workflowRunContext';
 function baseStream(overrides: Partial<StreamTabInfo> = {}): StreamTabInfo {
   return {
     name: 'stream-a',
-    label: 'Stream A',
+    // What buildStreamTabInfo emits for this identity — a producer never
+    // ships an arbitrary label beside a resolved identity.
+    label: 'writer',
     identity: { kind: 'agent', agent: 'writer' },
     agentCategory: AgentCategory.Workflow,
     model: 'gemini31p',
@@ -169,18 +171,6 @@ describe('formatWorkflowRunContext', () => {
     expect(text).not.toContain('Execution:');
     expect(text).not.toContain('Goal:');
     expect(text.startsWith('Workflow run: writer (Gemini 3.1 Pro)')).toBe(true);
-  });
-
-  it('falls back to the tab label when the run has no identity', () => {
-    const text = formatWorkflowRunContext({
-      stream: baseStream({ identity: undefined }),
-      files: { 2: [output()] },
-      compileFailures: {},
-    });
-
-    expect(text.startsWith('Workflow run: Stream A (Gemini 3.1 Pro)')).toBe(
-      true,
-    );
   });
 
   it('drops the model parenthetical when the run has no model', () => {


### PR DESCRIPTION
## Summary

`StreamTabInfo.label` is defined by `buildStreamTabInfo` (`src/controllers/session/streamTabInfo.ts:42-44`)
as exactly `identity ? runIdentityDisplayName(identity) : getStreamTabDisplayName(streamId)`.
Three consumers re-derived one or both arms from the identity sitting right beside the label, and the
trace-viewer producer got its label from a *different* rule. This PR makes `label` the only display-name
anyone reads, and fixes the one producer that violated that.

Consumers collapsed:

- **`StreamTabs.ts:88-93`** — `identityDisplay || streamDisplayLabel(info)` reproduced both arms of the
  builder; the tooltip now reads `streamDisplayLabel(info)`.
- **`StreamTabs.ts:202-205`** — `metaAgentName` called `runIdentityDisplayName` where the builder's own
  output was already on the object. The `kind === 'agent' && description` gate is untouched; only the
  call is replaced by `stream.label`. The `runIdentityDisplayName` import is now dead and removed.
- **`workflowRunContext.ts:38-40`** — `stream.identity ? runIdentityDisplayName(...) : stream.label` was
  literally the builder's two arms; `agent` is now `stream.label` (same import removal).

Producer fixed (**this is the one user-visible change, and it is a divergence repair, not a refactor**):
`packages/trace-viewer/src/replayTrace.ts:174` built `label: recordName(trace.config)`, which returns
`config.agent` raw — skipping `getCleanAgentName`. A `custom:polish` agent therefore rendered as
`custom:polish` in the trace-viewer and `polish` in every host, and a `bash@` legacy trace (identity
`{kind:'process', tool:'bash'}`) was labelled with `config.agent` instead of `bash`. The identity is
resolved from the same trace four lines below, so the label now uses it. The page title
(`main.ts:111`) had no identity in scope, so a small exported `traceDisplayName(trace)` replaces
`recordName` there — fixing the tab without fixing the title would leave the two disagreeing, which is
the bug in a different font. `recordName` is now module-private and documented as not-a-display-name.

## Issue acceptance gates

No issue — collapse sweep, `double-projection` track, candidate 1.

## Single source of truth

`buildStreamTabInfo` is now the only place the identity→label rule lives, for both producers
(`streamInfoUtils.ts:39`, CLI `streamViews.ts:126`, and the trace-viewer literal, which now applies the
same rule) and every consumer.

## Duplication and abstraction budget

Three re-derivations of one rule deleted; one producer's divergent copy of the rule fixed to match.
Added `traceDisplayName` (+1 export) because `main.ts` needs the display name outside the replay call —
it has a consumer in this PR. No new layer.

## Net elements (R6)

**Read this as two changes with opposite signs.** The consumer collapse deletes; the producer fix
adds (it replaces a wrong rule with the right one, and needs `traceDisplayName` because the page title
has no identity in scope). Stated plainly:

| file | +/− | net |
|---|---|---|
| `packages/extension/.../StreamTabs.ts` | +3 / −7 | −4 |
| `packages/trace-viewer/src/main.ts` | +2 / −2 | 0 |
| `packages/trace-viewer/src/replayTrace.ts` | +27 / −11 | **+16** (≈+11 of it comments relocated into `traceIdentity`/`traceDisplayName` doc blocks; ≈+5 code) |
| `src/shared/copy/workflowRunContext.ts` | +2 / −4 | −2 |
| **production total** | **+34 / −24** | **+10** |
| tests (3 files) | +6 / −36 | −30 |
| **overall** | **+40 / −60** | **−20** |

Exports: −1 (`recordName` made private) / +1 (`traceDisplayName`), functions +1 (`traceIdentity`
extraction, same logic moved), imports −3 (`runIdentityDisplayName` ×2, `recordName`).

So the pure-collapse half is −6 production LoC and the divergence repair costs +16; the repair is the
reason this PR exists, and it is not sold as a reduction.

## Consumer counts (R8)

```
grep -rn "runIdentityDisplayName" --include="*.ts" --include="*.tsx" src packages (non-test)
```
→ remaining uses are `streamTabInfo.ts` (the SSOT builder, intended), `BackgroundTasksPanel.ts:435`,
CLI `childExecutions.ts:238` and `SubagentList.tsx:458` — all four operate on `ActiveChildInfo` roster
rows, which have no `label` field, so they are not re-derivations of `StreamTabInfo.label`. (They are a
separate, known three-copy finding, held pending a behaviour ruling; not touched here.)

```
grep -rn "recordName" → main.ts:111 and replayTrace.ts internal only; both updated.
grep -rn "buildStreamTabInfo" → two prod callers + the trace-viewer literal, as inventoried.
```

## Host impact

Extension: tooltip and meta-line text now read the label the builder already computed — byte-identical
output for every stream a real producer emits.

Desktop: same webview code, same result.

CLI: untouched (its `streamViews.ts` already routes through `buildStreamTabInfo`).

Trace-viewer: **visible change** — labels and the page title for prefixed agent ids (`custom:*`) and
legacy process traces now match what every host shows.

## Scheduled refactoring

None. The three `ActiveChildInfo` label copies named above are tracked separately and blocked on a
process-child membership ruling, not on this PR.

## Validation

- `npm run typecheck` — 0 errors across workspace, test-kernel, agent, cli (incl.
  `tsconfig.scripts.json`), trace-viewer, desktop.
- `npx vitest run src/test-kernel/traceViewer/ src/test-kernel/progressView/ src/test-kernel/shared/`
  — 97 files, 914 tests, all passing.
- `npm run lint`, `npx prettier --check .`, `npm run check:dead-code-ratchet` (8 vs 8) — all clean.

**Tests (0 added, 3 corrected, 1 deleted):** the failing pair were fixtures asserting the old
behaviour. `StreamTabsExpandChevron.vitest.ts:228` mounted a *deliberately stale* label beside a
resolved identity — a state no producer can emit — to assert "identity wins"; with the rule owned by
the builder, that defence has no subject, and the adjacent test already asserts `.agent-name` renders
the cleaned name. `WorkflowRunContextCopy.vitest.ts` and `StreamHeader.vitest.ts` shipped
`label: 'Stream A'` beside `identity: {agent: 'writer'}` — same impossible combination; the fixtures
now carry what the builder emits, and all pre-existing assertions stand unchanged.
