### PR TITLE
refactor(copy): one usage-cost sentence rule for CLI and extension

### DIFF
--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -15,9 +15,7 @@ import {
   type StreamTabId,
   type TokenUsageStats,
 } from '@shared/schemas';
-import { usageRouteBadge } from '@shared/copy/modelAccess';
-
-import { formatCostUsd } from '@utils/text/stringUtils';
+import { usageCostLabel } from '@shared/copy/modelAccess';
 
 import {
   childExecutionLabel,
@@ -95,18 +93,10 @@ function usageHasTokens(usage: TokenUsageStats): boolean {
   );
 }
 
-/** Session-level cost line — reuses the shared usage-route badge so the
- *  CLI and extension attribute payment the same way. Empty when there is no
- *  cost to report and no known route to attribute. */
+/** Session-level cost line. Empty when there is no cost to report and no
+ *  known route to attribute. */
 function formatSessionCost(usage: TokenUsageStats): string | undefined {
-  const badge = usageRouteBadge(usage.usageRoute);
-  if (badge) {
-    if (badge.subscription && usage.cost === 0) {
-      return `free via ${badge.label}`;
-    }
-    return `${formatCostUsd(usage.cost)} via ${badge.label}`;
-  }
-  return usage.cost > 0 ? formatCostUsd(usage.cost) : undefined;
+  return usageCostLabel(usage.cost, usage.usageRoute);
 }
 
 export function collectResumeUsage(

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -16,7 +16,7 @@ import type {
   UsageRoute,
 } from '@shared/schemas';
 import { designTokens } from '@shared/styles';
-import { usageRouteBadge } from '@shared/copy/modelAccess';
+import { usageCostLabel, usageRouteBadge } from '@shared/copy/modelAccess';
 
 // Local imports - shared icons and utils
 import type { TeXRAIconName } from '@shared/wa/iconNames';
@@ -53,8 +53,9 @@ function fillColor(percent: number): string {
  * Single owner of the free-tier decision for a usage route: `null` when the
  * route has no badge (plain cost), otherwise `free` (subscription route with
  * zero cost) plus the two label forms the summary and the visible footer use.
- * Both {@link usageCostLabel} and {@link UsagePanel.renderCostRoute} consume
- * this, so changing a subscription route touches one place.
+ * Both the shared {@link usageCostLabel} and
+ * {@link UsagePanel.renderCostRoute} consume this, so changing a subscription
+ * route touches one place.
  */
 function usageRouteDecision(
   cost: number,
@@ -67,13 +68,6 @@ function usageRouteDecision(
     label: badge.label,
     compactLabel: badge.compactLabel,
   };
-}
-
-function usageCostLabel(cost: number, route: UsageRoute | undefined): string {
-  const decision = usageRouteDecision(cost, route);
-  if (!decision) return formatCostUsd(cost);
-  if (decision.free) return `Free via ${decision.label}`;
-  return `${formatCostUsd(cost)} via ${decision.label}`;
 }
 
 @customElement('usage-panel')
@@ -318,7 +312,10 @@ export class UsagePanel extends LitElement {
   private buildUsageLabel(): string {
     if (!this.usage) return '';
     const { inputTokens, outputTokens, cost } = this.usage;
-    const costLabel = usageCostLabel(cost, this.usage.usageRoute);
+    // The shared rule omits a zero-cost unknown route; the aria summary
+    // still states it as "$0.00".
+    const costLabel =
+      usageCostLabel(cost, this.usage.usageRoute) ?? formatCostUsd(cost);
     return `Total usage: ${formatCompactTokenCount(inputTokens)} input tokens, ${formatCompactTokenCount(outputTokens)} output tokens, ${costLabel}`;
   }
 }

--- a/src/shared/copy/modelAccess.ts
+++ b/src/shared/copy/modelAccess.ts
@@ -13,6 +13,7 @@
 import type { UsageRoute } from '@shared/schemas';
 import { codingPlanForUsageRoute } from '@shared/codingPlanSubscriptions';
 import { assertNever } from '@utils/core';
+import { formatCostUsd } from '@utils/text/stringUtils';
 
 /** Model calls paid for by your own provider accounts. */
 export const OWN_API_KEYS = {
@@ -81,4 +82,22 @@ export function usageRouteBadge(
     default:
       return assertNever(route, 'Unhandled usage route');
   }
+}
+
+/**
+ * One sentence stating what a usage record cost and who paid for it.
+ *
+ * Three outcomes: subscription routes with zero cost are free, a known route
+ * is billed "via" its payment name, and an unknown route with no cost has
+ * nothing to say (`undefined`) so callers can omit the line entirely rather
+ * than print "$0.00" for a session that never reached a model.
+ */
+export function usageCostLabel(
+  cost: number,
+  route: UsageRoute | undefined,
+): string | undefined {
+  const badge = usageRouteBadge(route);
+  if (!badge) return cost > 0 ? formatCostUsd(cost) : undefined;
+  if (badge.subscription && cost === 0) return `Free via ${badge.label}`;
+  return `${formatCostUsd(cost)} via ${badge.label}`;
 }

--- a/src/test-kernel/cli/ResumeHint.vitest.ts
+++ b/src/test-kernel/cli/ResumeHint.vitest.ts
@@ -374,7 +374,7 @@ describe('formatResumeUsage', () => {
       }),
     ).toBe(
       'Token usage: total=120 input=100 output=20\n' +
-        'Session cost: free via ChatGPT',
+        'Session cost: Free via ChatGPT',
     );
   });
 


### PR DESCRIPTION
## Summary

Two hosts spelled the same usage-cost sentence rule with two different results.

- CLI (`resumeHint.ts` `formatSessionCost`): `free via ChatGPT` (lowercase), and the
  line is **omitted** when the usage record has no route and no cost.
- Extension (`UsagePanel.ts` local `usageCostLabel`): `Free via ChatGPT`
  (capitalized), and the no-route/no-cost case prints `$0.00`.

Both already imported `usageRouteBadge` from `@shared/copy/modelAccess`, so the
sentence rule moves next to the badge it consumes:

```ts
export function usageCostLabel(
  cost: number,
  route: UsageRoute | undefined,
): string | undefined
```

The signature is `string | undefined` because the CLI's omit rule is the more
considered one — a usage record with no route and no cost means the session never
reached a model, so there is nothing to say. `UsagePanel.buildUsageLabel` keeps its
own one-token fallback (`?? formatCostUsd(cost)`) so its aria summary still states
`$0.00` exactly as before.

Canonical spelling is `Free via` (the extension's), so the CLI's resume hint now
capitalizes with the panel. The one golden assertion that pinned the old spelling is
updated in the same PR.

`UsagePanel.usageRouteDecision` stays local: it also feeds the visible
`Free · <compact label>` badge, which the CLI does not render.

## Issue acceptance gates

n/a — verified collapse-sweep finding, no tracking issue.

## Single source of truth

`@shared/copy/modelAccess` now owns both halves of payment attribution copy: the
route badge (`usageRouteBadge`, unchanged) and the cost sentence
(`usageCostLabel`).

## Duplication and abstraction budget

One duplicated three-branch decision collapses to a single function. Not a new
abstraction — the function already existed as `UsagePanel`'s local
`usageCostLabel`; it moved to the module both consumers already imported and
gained the omit outcome. No new file.

## Net elements (R6)

Net **+6 LoC** (32 insertions, 26 deletions across 4 files). **This is net-add,
not a reduction** — the purchase is one shared sentence rule, not LoC: the new
export carries a doc comment, and the panel keeps an explicit fallback plus a
comment naming why.

- Files: ±0.
- Exported symbols: +1 (`usageCostLabel` in `@shared/copy/modelAccess`), and the
  local non-exported `usageCostLabel` in `UsagePanel.ts` is deleted (the shared
  one replaces it 1:1 at the same call site).
- Functions: ±0 net (one moved + generalized, one collapsed to a one-line
  delegate).
- CLI `formatSessionCost` keeps its name and call sites; its body is now the
  shared call.

## Consumer counts (R8)

```
$ grep -rn 'usageCostLabel\|usageRouteBadge' src packages
```
`usageCostLabel`: 2 production consumers
(`packages/cli/src/chat/tui/state/resumeHint.ts:101`,
`packages/extension/src/progressView/frontend/components/UsagePanel.ts:318`).
`usageRouteBadge`: unchanged at 2 direct consumers
(`UsagePanel.ts:64` via `usageRouteDecision`, `modelAccess.ts` itself).

```
$ grep -rn 'free via\|Free via' src packages
```
Production matches before: `resumeHint.ts:105` (`free via`, now gone) and
`UsagePanel.ts:75` (`Free via`, now in the shared module). After: one production
spelling. Test pins: `UsagePanel.vitest.ts:50,62` (unchanged, still green);
`ResumeHint.vitest.ts:377` updated `free via ChatGPT` → `Free via ChatGPT`.

## Host impact

Extension: the visible `Free · <label>` badge and the aria summary are unchanged;
the summary's `$0.00` fallback now lives at the call site instead of inside the
rule.

Desktop: renders the same progress-view frontend — no change.

CLI: `texra` resume scrollback now prints `Session cost: Free via ChatGPT`
(capitalized). This is the one user-visible string change, and it is the point of
the PR.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean.
- `npx vitest run src/test-kernel/cli src/test-kernel/progressView` — 204 files,
  3097 pass / 1 skipped.
- `npx prettier --check .` — clean (whole tree).
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — 8 current vs 8 baselined, OK.
