### PR TITLE
refactor(progress-view): drop five write-only timestamp DOM attributes

### DIFF
--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/bannerFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/bannerFormatters.ts
@@ -81,8 +81,9 @@ export function formatBannerContentTemplate(
   if (!trimmedContent) return null;
 
   const config = BANNER_CONFIG[kind];
-  const { fullTimestamp, timeDisplay, tooltipTimestamp } =
-    formatDisplayTimestamp(new Date(timestamp));
+  const { timeDisplay, tooltipTimestamp } = formatDisplayTimestamp(
+    new Date(timestamp),
+  );
   // Auto-expand while streaming in, so the block is visibly "live" instead
   // of hiding the growing text behind a closed summary row; collapses back
   // once finalized (mirrors the "thought for Xs, tap to expand" pattern
@@ -104,7 +105,7 @@ export function formatBannerContentTemplate(
     : html`<div class="banner-content markdown-content log-entry-content ${contentClass}">${unsafeHTML(processMarkdownContent(trimmedContent))}</div>`;
 
   // prettier-ignore
-  return html`<wa-details appearance="plain" icon-placement="start" class="banner-details" ?open=${shouldOpen} data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)} data-timestamp=${ifDefined(fullTimestamp)}>${buildDetailsSummary({
+  return html`<wa-details appearance="plain" icon-placement="start" class="banner-details" ?open=${shouldOpen} data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)}>${buildDetailsSummary({
     iconName: config.iconName,
     label: config.labelText,
     timestamp: config.showTimestamp && verbose

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
@@ -59,8 +59,9 @@ export function formatProgressStatusTemplate(
   row: ProgressStatusRow,
 ): FormatResult {
   const { level, id, groupId, timestamp } = row;
-  const { fullTimestamp, timeDisplay, tooltipTimestamp } =
-    formatDisplayTimestamp(new Date(timestamp));
+  const { timeDisplay, tooltipTimestamp } = formatDisplayTimestamp(
+    new Date(timestamp),
+  );
 
   const summaryText = row.summary.full;
   const detailText = row.detail?.full ?? '';
@@ -70,7 +71,6 @@ export function formatProgressStatusTemplate(
   return html`<div
       data-log-id=${ifDefined(id)}
       data-group-id=${ifDefined(groupId)}
-      data-timestamp=${ifDefined(fullTimestamp)}
     ><div class="log-line"><span class="timestamp" title=${tooltipTimestamp}>${levelIcon} [${timeDisplay}]</span> <span class=${`message-${level}`}>${summaryText}</span></div>${when(
         detailText,
         () => html`<pre class=${`log-line message-${level}`}>${detailText}</pre>`,
@@ -83,8 +83,9 @@ export function formatProgressStatusTemplate(
  */
 export function formatErrorTemplate(row: ErrorRow): FormatResult {
   const { id, groupId, timestamp } = row;
-  const { fullTimestamp, timeDisplay, tooltipTimestamp } =
-    formatDisplayTimestamp(new Date(timestamp));
+  const { timeDisplay, tooltipTimestamp } = formatDisplayTimestamp(
+    new Date(timestamp),
+  );
 
   const summaryText = row.summary.full.trim() || 'Error occurred';
   const detailText = row.detailText.full;
@@ -115,7 +116,7 @@ export function formatErrorTemplate(row: ErrorRow): FormatResult {
     'banner-details': true,
     'banner-details--error': true,
     'banner-details--no-toggle': !hasDetails,
-  })} data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)} data-timestamp=${ifDefined(fullTimestamp)}>${summaryTemplate}${contentTemplate}</wa-details>`;
+  })} data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)}>${summaryTemplate}${contentTemplate}</wa-details>`;
 }
 
 /**
@@ -130,8 +131,9 @@ export function formatDefaultLogMessageTemplate(
   const { id, level, timestamp, groupId, verbose } = row;
   const text = row.kind === 'phase' ? row.heading : row.text.full;
   const levelIcon = buildLevelIcon(level);
-  const { fullTimestamp, timeDisplay, tooltipTimestamp } =
-    formatDisplayTimestamp(new Date(timestamp));
+  const { timeDisplay, tooltipTimestamp } = formatDisplayTimestamp(
+    new Date(timestamp),
+  );
 
   const timestampContent = verbose
     ? html`${levelIcon} [${timeDisplay}]`
@@ -142,7 +144,6 @@ export function formatDefaultLogMessageTemplate(
       class="log-line"
       data-log-id=${id}
       data-group-id=${ifDefined(groupId)}
-      data-full-timestamp=${fullTimestamp}
     ><span class="timestamp" title=${tooltipTimestamp}>${timestampContent}</span>${when(
         verbose,
         () => html` <span class=${`level-${level}`}>${level.toUpperCase().padEnd(8)}</span>`,

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
@@ -94,7 +94,6 @@ export function buildToolUseDetails(opts: {
   extraClasses?: ClassInfo;
   extraContent?: TemplateResult;
 }): TemplateResult {
-  const fullTimestamp = new Date(opts.row.timestamp).toISOString();
   const classes: ClassInfo = {
     'banner-details': true,
     'tool-use-details': true,
@@ -102,7 +101,7 @@ export function buildToolUseDetails(opts: {
     ...opts.extraClasses,
   };
   // prettier-ignore
-  return html`<wa-details appearance="plain" icon-placement="start" class=${classMap(classes)} ?open=${opts.defaultOpen ?? false}>${buildDetailsSummary({ iconName: opts.iconName, label: opts.label, labelClass: 'tool-use-title', extraContent: opts.extraContent })}<div class="banner-content log-entry-content" data-log-id=${ifDefined(opts.row.id)} data-group-id=${ifDefined(opts.row.groupId)} data-timestamp=${ifDefined(fullTimestamp)}>${opts.content}</div></wa-details>`;
+  return html`<wa-details appearance="plain" icon-placement="start" class=${classMap(classes)} ?open=${opts.defaultOpen ?? false}>${buildDetailsSummary({ iconName: opts.iconName, label: opts.label, labelClass: 'tool-use-title', extraContent: opts.extraContent })}<div class="banner-content log-entry-content" data-log-id=${ifDefined(opts.row.id)} data-group-id=${ifDefined(opts.row.groupId)}>${opts.content}</div></wa-details>`;
 }
 
 type ToolSectionOptions = {

--- a/packages/extension/src/progressView/frontend/formatters/timestampUtils.ts
+++ b/packages/extension/src/progressView/frontend/formatters/timestampUtils.ts
@@ -32,7 +32,6 @@ export function getTimeFormatter(): Intl.DateTimeFormat {
 
 /** Format a timestamp for display. */
 export function formatDisplayTimestamp(date: Date): {
-  fullTimestamp: string;
   timeDisplay: string;
   tooltipTimestamp: string;
 } {
@@ -41,7 +40,6 @@ export function formatDisplayTimestamp(date: Date): {
     DATETIME_FORMAT_OPTIONS,
   );
   return {
-    fullTimestamp: date.toISOString(),
     timeDisplay: getTimeFormatter().format(date),
     tooltipTimestamp: DATE_TIME_FORMATTER.format(date),
   };


### PR DESCRIPTION
## Summary

The progress view stamped five write-only DOM attributes with an ISO timestamp
on every rendered log entry: four `data-timestamp` (progress-status, error,
default-log, banner/tool shells) and one `data-full-timestamp` (default log
line), all fed by a `fullTimestamp` field on `formatDisplayTimestamp`'s return
and a local `new Date(...).toISOString()` in the tool-card helper.

Nothing ever read them. The value is deleted from the formatter's return shape
and all five attribute bindings with it. The visible timestamp affordances —
the `[hh:mm:ss]` time display and the `title` tooltip with the full date — are
untouched; only the invisible machine attribute goes.

## Issue acceptance gates

No issue. Audit candidate C3 (`extension-formatters` track).

## Single source of truth

Unchanged. `formatDisplayTimestamp` keeps returning exactly the two strings a
host can paint; it no longer also produces a third that nobody consumed.

## Duplication and abstraction budget

Pure deletion: one return-shape field, one local derivation, five DOM
attributes. No new abstraction.

## Net elements (R6)

| | + | − |
|---|---|---|
| Files | 0 | 0 |
| Exported symbols | 0 | 0 |
| Return-shape fields | 0 | 1 (`fullTimestamp`) |
| DOM attributes | 0 | 5 |
| LoC | 15 | 16 (**−1**) |

Stated plainly: this is a **net −1 LoC**, not a meaningful line-count win.
Three of the five bindings sat inside single-line `// prettier-ignore`
templates, where removing an attribute removes no line, and the four
destructure sites reflow to one line longer each to stay under the 80-column
print width. The change earns its place on two non-LoC grounds: a per-row
`new Date(...).toISOString()` allocation gone from every repaint, and five
machine attributes gone from every entry's DOM — attributes that implied a
contract no code honoured.

## Consumer counts (R8)

Greps run at HEAD (post-#11107) over `src` + `packages`, `node_modules` and
`dist/` excluded:

- `grep -rn "data-timestamp\|data-full-timestamp"` → exactly the five write
  sites deleted here; zero others.
- `grep -rn "fullTimestamp\|dataset.timestamp\|dataset.fullTimestamp"` → zero
  residual after the change.
- All `dataset.*` readers in the extension, enumerated:
  `sessionType, action, removeFile, moveIndex, moveDirection, file, fileLine,
  revealKind, revealScope, spillPath, label`. No timestamp key among them.
- `grep -rn "\[data-" packages/extension/src --include="*.css"` → **zero CSS
  attribute selectors exist anywhere in the extension**, so no stylesheet can
  be selecting on these.
- `grep -rn "querySelector.*timestamp\|getAttribute.*timestamp"` → zero.
- The chat-export path is a separate formatter (`src/agent/export/
  chatExportFormatter.ts`) that builds its own strings; it does not select on
  webview DOM attributes.

## Host impact

Extension: DOM-only change, visually identical. Each log entry carries five
fewer attributes and skips one `Date`→ISO conversion per render.

Desktop: none. CLI: none — the CLI transcript does not render these templates.

## Eyeball checklist (no automated gate covers a webview render)

A human must open the progress view and confirm:

1. **Timestamps still show.** A plain log line still renders `[hh:mm:ss]` (or
   the level icon, when not verbose) in the timestamp span, and hovering it
   still shows the full date/time tooltip.
2. **An error entry** still shows `[hh:mm:ss] message` in its summary row with
   the full-date tooltip on hover.
3. **A thinking/banner block** still shows its timestamp in the summary row
   (verbose mode) with the tooltip.
4. **A tool-use card** still renders; its summary row is unchanged.
5. **DevTools check (optional but decisive):** inspect any log entry and
   confirm it now has `data-log-id` / `data-group-id` but **no**
   `data-timestamp` or `data-full-timestamp` — and that nothing in the view
   regressed (no missing icons, no layout shift).

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean (workspace, test-kernel, agent, cli,
  trace-viewer, desktop).
- `npx vitest run src/test-kernel/progressView/` — 60 files, 562 tests, all
  passing, unmodified.
- `npm run lint` — clean.
- `npx prettier --check .` — clean.
- Zero new tests. No export was added or removed, so
  `check:dead-code-ratchet` was not re-run (its trigger did not fire); the
  previous run on this tree was 8 vs 8 baseline.
