### PR TITLE
refactor(desktop): render onboarding work-type icons from the shared presets

### DIFF
--- a/packages/desktop/src/renderer/desktopOnboarding.ts
+++ b/packages/desktop/src/renderer/desktopOnboarding.ts
@@ -23,10 +23,9 @@ import { html, nothing, type TemplateResult } from 'lit';
 
 import { postMessage } from '@shared/hostBridge';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import { AGENT_MODE_PRESETS, type AgentModePreset } from '@shared/schemas';
+import { AGENT_MODE_PRESETS } from '@shared/schemas';
 import { OWN_API_KEYS } from '@shared/copy/modelAccess';
 import { formatDesktopAccelerator } from '@shared/commands/accelerators';
-import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 import { desktopCommandPaletteShortcut } from './desktopShortcutRegistry';
@@ -51,43 +50,39 @@ export interface DesktopStartupTeamPanelOptions {
  * The work-type question. Each choice maps to a built-in team id from
  * {@link AGENT_MODE_PRESETS} — this is a friendlier phrasing of the same
  * choice, not a second taxonomy. `presetId` values must exist there; the
- * lookup below drops any that don't rather than applying a bad id.
+ * resolution below drops any that don't rather than applying a bad id. The
+ * icon comes from the resolved preset, the same source the settings team
+ * grid renders, so the two surfaces cannot drift.
  */
 const WORK_TYPES: ReadonlyArray<{
   readonly presetId: string;
   readonly question: string;
   readonly detail: string;
-  readonly icon: TeXRAIconName;
 }> = [
   {
     presetId: 'physicist',
     question: 'Writing a physics paper',
     detail: 'Derivations, numerical checks, literature search, slides, review.',
-    icon: 'cube',
   },
   {
     presetId: 'mathematician',
     question: 'Doing mathematics',
     detail: 'Open problems, proofs, Lean formalization, LaTeX correction.',
-    icon: 'hashtag',
   },
   {
     presetId: 'cs-ml',
     question: 'Writing a CS or ML paper',
     detail: 'Algorithms, experiments and ablations, tests, review.',
-    icon: 'cube',
   },
   {
     presetId: 'lean-project',
     question: 'Formalizing in Lean 4',
     detail: 'Theorem search, tactic simplification, blueprints.',
-    icon: 'diagram-project',
   },
   {
     presetId: 'software-engineer',
     question: 'Building software',
     detail: 'Implementation, review, debugging, and tests across a team.',
-    icon: 'screwdriver-wrench',
   },
 ];
 
@@ -101,13 +96,12 @@ function nextPanelTitleId(): string {
   return `startup-team-title-${panelTitleCounter}`;
 }
 
-function presetById(presetId: string): AgentModePreset | undefined {
-  return AGENT_MODE_PRESETS.find((preset) => preset.id === presetId);
-}
-
-const VISIBLE_WORK_TYPES = WORK_TYPES.filter((entry) =>
-  presetById(entry.presetId),
-);
+const VISIBLE_WORK_TYPES = WORK_TYPES.flatMap((entry) => {
+  const preset = AGENT_MODE_PRESETS.find(
+    (preset) => preset.id === entry.presetId,
+  );
+  return preset ? [{ ...entry, preset }] : [];
+});
 
 export function createStartupTeamPanel({
   dismiss: postDismissed,
@@ -127,7 +121,7 @@ export function createStartupTeamPanel({
   let visible = false;
   let hideAtStartup = false;
   let step: TourStep = 'work';
-  let chosenPresetId: string | undefined;
+  let chosenWorkType: (typeof VISIBLE_WORK_TYPES)[number] | undefined;
 
   function closePanel(): void {
     visible = false;
@@ -140,11 +134,13 @@ export function createStartupTeamPanel({
     onVisibilityChanged();
   }
 
-  function chooseWorkType(presetId: string): void {
-    chosenPresetId = presetId;
+  function chooseWorkType(entry: (typeof VISIBLE_WORK_TYPES)[number]): void {
+    chosenWorkType = entry;
     // Apply immediately through the same command the Settings team picker
     // uses, so the roster is live even if the user dismisses the panel here.
-    postMessage(SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET, { presetId });
+    postMessage(SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET, {
+      presetId: entry.presetId,
+    });
     goTo('roster');
   }
 
@@ -169,13 +165,13 @@ export function createStartupTeamPanel({
               class="desktop-onboarding-choice"
               appearance="outlined"
               size="l"
-              @click=${() => chooseWorkType(entry.presetId)}
+              @click=${() => chooseWorkType(entry)}
             >
               <span
                 slot="start"
                 class="desktop-onboarding-choice-icon icon-surface is-size-l"
               >
-                ${waIcon(entry.icon)}
+                ${waIcon(entry.preset.icon)}
               </span>
               <span class="desktop-onboarding-choice-text">
                 <strong>${entry.question}</strong>
@@ -199,13 +195,13 @@ export function createStartupTeamPanel({
   }
 
   function rosterStepTemplate(): TemplateResult {
-    const preset = chosenPresetId ? presetById(chosenPresetId) : undefined;
-    if (!preset) {
-      // Defensive: chooseWorkType only advances for ids that resolve, so this
-      // is unreachable in practice. Bail to the work step rather than render an
-      // empty roster.
+    // Defensive: chooseWorkType only advances for entries whose preset
+    // resolved, so this is unreachable in practice. Bail to the work step
+    // rather than render an empty roster.
+    if (!chosenWorkType) {
       return workStepTemplate();
     }
+    const { preset } = chosenWorkType;
     const agentCount =
       preset.agents.workflow.length + preset.agents.toolUse.length;
     return html`


### PR DESCRIPTION
## Summary

The desktop startup panel (`desktopOnboarding.ts`) hardcoded an icon per work
type — `cube`/`hashtag`/`cube`/`diagram-project`/`screwdriver-wrench` — while
the same renderer's settings team grid (`MultiAgentTab.tsx`) renders the icon
from the shared preset (`waIcon(preset.icon)` out of `agentPresets.ts`). Two
surfaces of one app, one holding its own copy of a fact the preset already
publishes, with no mechanism that would ever flag a change to either side.

The panel now resolves each work type to its `AgentModePreset` once and renders
`preset.icon`, so the startup choices and the settings grid draw from the same
source. The resolution keeps the documented drop-any-that-don't-resolve
contract: `WORK_TYPES.flatMap` drops an entry whose `presetId` has no preset
rather than applying a bad id, exactly as the previous `filter` did — no
non-null assertion on the lookup.

`chooseWorkType` now carries the resolved entry (id + preset) instead of a bare
id, which deletes `presetById` and lets `rosterStepTemplate` read the preset
off the stored choice. The defensive bail in `rosterStepTemplate` stays: it
guards `chosenWorkType === undefined` (never chosen / not yet advanced), which
a resolved-entry flow does not eliminate.

Rendered output is unchanged today — the five hardcoded literals happened to
match the five presets byte-for-byte.

## Issue acceptance gates

n/a — collapse sweep finding (desktop-projections B), no issue.

## Single source of truth

`AGENT_MODE_PRESETS[*].icon` (`src/shared/schemas/agentPresets.ts`) now owns
the work-type icon for both the startup panel and the settings team grid.

## Duplication and abstraction budget

Removed: five icon literals and the `presetById` indirection. Added: nothing —
the resolution is a `flatMap` over data the module already imported, no new
export, no new module.

## Net elements (R6)

| | + | − |
|---|---|---|
| files | 0 | 0 |
| exported symbols | 0 | 0 |
| functions | 0 | 1 (`presetById`) |
| interfaces/type fields | 0 | 2 (`WORK_TYPES.icon`, the `TeXRAIconName` import) |
| LoC | +23 | −27 |

**Net −4 LoC.** A small reduction; the value is the deleted drift surface, not
the line count.

## Consumer counts (R8)

```
grep -rn "WORK_TYPES\|VISIBLE_WORK_TYPES\|presetById" --include='*.ts' --include='*.tsx' src packages
```

- `presetById` had zero references outside this file (grep before the change);
  its two in-file call sites are the `VISIBLE_WORK_TYPES` filter (now the
  `flatMap` resolve) and `rosterStepTemplate` (now reads the stored entry).
- `WORK_TYPES` / `VISIBLE_WORK_TYPES`: module-private, zero external references
  confirmed.
- `createStartupTeamPanel` (the file's only export): unchanged, still consumed
  by `main.ts`.

## Host impact

Extension: none.

Desktop: startup panel icons now come from the shared presets; visually
identical today, and they follow any future preset icon change.

CLI: none.

## Scheduled refactoring

None — the drift this closed was the only preset-copy in the desktop renderer
found by the sweep.

## Validation

- `npm run typecheck` — 0 errors.
- `npm run lint` — clean.
- `npx prettier --check` on the changed file — clean.
- `npx vitest run src/test-kernel/desktop/` — 58 files, 582 tests passed
  (includes `DesktopCommandPalette.vitest.ts`, `DesktopOnboarding` coverage,
  and the kernel preset tests).
- Dead-code ratchet not run: no export added or removed (`presetById` was
  module-private).
