### PR TITLE
chore(progressView): drop comment residue from the PermissionState removal

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BaseBypassApprovalPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseBypassApprovalPanel.ts
@@ -10,8 +10,6 @@ import { BaseApprovalPanel } from './BaseApprovalPanel';
 // Local imports - progress view events
 import { APPROVE_SESSION_ACTION } from '../events';
 
-// Local imports - progress view state
-
 type BypassPermissionKind = 'toolEdit' | 'bash';
 type BypassPermission = Extract<
   PermissionPayload,

--- a/packages/extension/src/progressView/frontend/components/BaseRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseRequestPanel.ts
@@ -18,8 +18,6 @@ import {
 // Local imports - progress view contexts
 import { archivedContext } from '../streamContexts';
 
-// Local imports - progress view component types
-
 export abstract class BaseRequestPanel<
   K extends PermissionKind = PermissionKind,
 > extends LitElement {

--- a/packages/extension/src/progressView/frontend/permissionState.ts
+++ b/packages/extension/src/progressView/frontend/permissionState.ts
@@ -4,9 +4,9 @@
  * (`PermissionPayload`) — the frontend stores what the backend sent, with no
  * parallel view model to keep in sync.
  *
- * Lives in its own leaf module (not `components/PermissionCard.ts`) so state
- * files (store, contexts, slices, dispatcher) can use them without importing
- * the Lit component and its side-effect imports.
+ * Lives in its own leaf module so state files (store, contexts, slices,
+ * dispatcher) can use them without importing a Lit component and its
+ * side-effect imports.
  */
 import type { PermissionPayload } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';

--- a/packages/extension/src/progressView/frontend/streamContexts.ts
+++ b/packages/extension/src/progressView/frontend/streamContexts.ts
@@ -21,8 +21,6 @@ import type {
 } from '@shared/schemas';
 import type { TranscriptRow } from '@shared/transcript';
 
-// Local imports - progress view components
-
 /** Context value for stream state, providing all data needed by stream content components. */
 export interface StreamContextValue {
   streamInfo: StreamTabInfo | null;


### PR DESCRIPTION
## Summary

Closes #11113 — comment residue left behind by #11104 (drop the hand-written
`PermissionState` mirror), which merged before the review's two nits were
addressed.

- Three `// Local imports - ...` section headers were left grouping nothing after
  the type import they grouped was deleted:
  - `components/BaseBypassApprovalPanel.ts` (`// Local imports - progress view state`)
  - `components/BaseRequestPanel.ts` (`// Local imports - progress view component types`)
  - `streamContexts.ts` (`// Local imports - progress view components`)
- `permissionState.ts` justified its leaf placement by contrast with
  `components/PermissionCard.ts`, which does not exist in the tree — the path was
  carried over from the pre-#11104 comment. The sentence now states the actual
  reason (leaf placement keeps state modules off Lit components and their
  side-effect imports) without naming a phantom file.

Comment-only; no code, type, or behaviour change.

## Issue acceptance gates

Closes #11113. Both bullets in that issue are addressed.

## Single source of truth

n/a — comment-only.

## Duplication and abstraction budget

n/a — no code change.

## Net elements (R6)

Net **−6 LoC** (3 insertions, 9 deletions across 4 files). Zero code elements
changed: no exports, no functions, no types, no behaviour.

## Consumer counts (R8)

n/a — comments only.

```
$ grep -rn 'PermissionCard' src packages
```
0 hits after this PR (the only occurrence was the stale doc reference).

## Host impact

Extension: none (comments only).
Desktop: none.
CLI: none.

## Scheduled refactoring

None — this closes the follow-up rather than scheduling one.

## Validation

- `npm run typecheck` — clean.
- `npx vitest run src/test-kernel/progressView/` — 60 files, 562 tests pass.
- `npx prettier --check .` — clean (whole tree).
