### PR TITLE
chore(shared): drop two transcript row fields no host reads

### DIFF
--- a/src/shared/transcript/projectTranscriptRow.ts
+++ b/src/shared/transcript/projectTranscriptRow.ts
@@ -118,8 +118,8 @@ const STREAMING_TEXT_ROW_KIND = {
  * field that quietly stops rendering.
  *
  * `streamDiagnostics` and `partialText` are deliberately absent: they are a
- * retry surface's material, not a transcript row's, and both remain reachable
- * through `ErrorRow.data`.
+ * retry surface's material, not a transcript row's. `RetryRequestPanel` reads
+ * them from the approval request's own payload, never from a projected row.
  */
 const ERROR_DETAIL_FIELDS = [
   'message',
@@ -170,7 +170,6 @@ function projectErrorRow(
     ...rowBase(entry),
     kind: 'error',
     summary: transcriptText(summary),
-    ...(data ? { data } : {}),
     details,
     detailText: transcriptText(
       details.map((detail) => `${detail.key}: ${detail.value}`).join('\n'),
@@ -386,9 +385,6 @@ export function projectTranscriptRow(
         summary: transcriptText(summarizeFollowupMessage(text.full)),
         ...(entry.data?.workflowSummary
           ? { workflowSummary: entry.data.workflowSummary }
-          : {}),
-        ...(entry.data?.attachments
-          ? { attachments: entry.data.attachments }
           : {}),
       };
     }

--- a/src/shared/transcript/transcriptRow.ts
+++ b/src/shared/transcript/transcriptRow.ts
@@ -25,7 +25,6 @@ import {
   type FileListEntry,
   type LoadedMediaMetadata,
   type LogLevel,
-  type MediaAttachmentKind,
   type MessageType,
   type NormalizedToolUse,
   type WorkflowCallProgress,
@@ -101,8 +100,6 @@ export interface UserRow extends TranscriptRowBase {
    *  truncation of `text`: hosts choose which of the two to paint. */
   readonly summary: TranscriptText;
   readonly workflowSummary?: WorkflowScriptDeliverySummary;
-  /** Media sent to the model with this message but never stored on the row. */
-  readonly attachments?: readonly MediaAttachmentKind[];
 }
 
 /**
@@ -118,9 +115,6 @@ export interface ErrorRow extends TranscriptRowBase {
   readonly kind: 'error';
   /** The failure headline. */
   readonly summary: TranscriptText;
-  /** The full typed payload, untouched — including the fields `details`
-   *  deliberately omits. */
-  readonly data?: ErrorLogData;
   /** Canonical detail field set, in display order. */
   readonly details: readonly ErrorRowDetail[];
   /** The detail block as one text, for copy affordances and full-output


### PR DESCRIPTION
## Summary

Remove two readerless fields from the shared transcript-row projection:

- **`ErrorRow.data`**: the whole typed error payload was carried beside the projected `details` / `detailText` view, but no host read it. `RetryRequestPanel` continues to read `streamDiagnostics` and `partialText` from the approval request's own `errorDetails` payload.
- **`UserRow.attachments`**: the projector copied wire attachment kinds onto the row, but no host read them. Completed-run archive reconstruction continues to read `entry.data?.attachments` directly from the persisted wire entry.

This branch was rebuilt as one commit from current `main` after #11115 merged. It drops the already-merged #11102 base commit and does not repeat #11115's `StatisticsRow.stats` deletion.

## Scope

Production-only deletion in two files:

- remove the two interface fields
- remove their two projector writes
- remove the now-unused `MediaAttachmentKind` import
- correct the stale `ERROR_DETAIL_FIELDS` comment to name the retry payload's actual owner

No tests were added or modified.

## Ownership checks

- Archive attachments: `src/transcript/completedRunArchive.ts:151` reads `entry.data?.attachments`, the persisted `StreamLogEntry` payload, not `UserRow.attachments`.
- Retry diagnostics: `packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts:174-199` reads `streamDiagnostics` and `partialText` from `this.permission.data.errorDetails`, not `ErrorRow.data`.

## Diff

- 2 production files changed
- 2 insertions, 12 deletions
- 2 interface fields removed
- 2 projector writes removed
- 1 unused type import removed

## Validation

- `npm run typecheck` (workspace, test-kernel, agent, CLI, trace-viewer, desktop): passed.
- `npx eslint src/shared/transcript/projectTranscriptRow.ts src/shared/transcript/transcriptRow.ts`: passed.
- `npx prettier --check src/shared/transcript/projectTranscriptRow.ts src/shared/transcript/transcriptRow.ts`: passed.
- `npx vitest run --config vitest.config.mjs src/test-kernel/shared/TranscriptRowProjection.vitest.ts src/test-kernel/transcript/completedRunArchive.vitest.ts src/test-kernel/progressView/RetryRequestPanel.vitest.ts`: 3 files passed, 27 tests passed.
