### PR TITLE
fix(progress-view): stop leaking the internal required-files source name

### DIFF
--- a/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -274,14 +274,15 @@ export function buildFileListRender(
     const iconName = file.ok ? 'check' : 'triangle-exclamation';
     const filePath = file.path;
     const fileName = getBasename(filePath);
-
-    const source = file.source ?? 'unknown';
-    const showSource = source !== 'unknown';
-    const sourceText = file.sourceDisplay ?? source;
     const loaded = mediaByPath.get(filePath);
 
+    // The one rule for a loaded file's source label, shared with the CLI
+    // (transcriptRowLines): paint `sourceDisplay`, nothing else. Raw `source`
+    // is a producer-side code identifier (`requiredFilesInternal`, a tool
+    // name) and must never reach a user — an entry worth labelling sets
+    // `sourceDisplay`, so no host needs a fallback to spell it out.
     // prettier-ignore
-    return html`<li class="detail-item" title=${filePath}>${waIcon(iconName)} ${buildFileLinkSpan(filePath, fileName)}${file.varName ? html` <span class="file-var">[${file.varName}]</span>` : ''}${showSource ? html` <span class="file-source">(${sourceText})</span>` : ''}${loaded ? html` <span class="file-media">[${loaded.kind}, ${formatBytes(loaded.sizeBytes)}]</span>` : ''}</li>`;
+    return html`<li class="detail-item" title=${filePath}>${waIcon(iconName)} ${buildFileLinkSpan(filePath, fileName)}${file.varName ? html` <span class="file-var">[${file.varName}]</span>` : ''}${file.sourceDisplay ? html` <span class="file-source">(${file.sourceDisplay})</span>` : ''}${loaded ? html` <span class="file-media">[${loaded.kind}, ${formatBytes(loaded.sizeBytes)}]</span>` : ''}</li>`;
   })}`;
 }
 


### PR DESCRIPTION
## Summary

The webview and the CLI used two different rules to label where a loaded file
came from, and they disagreed on exactly one producer — which leaked an
internal code name into the extension's UI.

- **Webview** (`htmlBuilders.ts`): `showSource = (file.source ?? 'unknown')
  !== 'unknown'`, then paint `file.sourceDisplay ?? file.source`. The `??
  source` fallback paints the raw producer-side identifier.
- **CLI** (`transcriptRowLines.ts`): paint `file.sourceDisplay` when present,
  otherwise nothing.

The producer that trips the difference is `getRequiredFileVars`
(`src/agent/prompt/userVars.ts`), which pushes entries with
`source: 'requiredFilesInternal'` and **no** `sourceDisplay`. Result today:

> webview: `✓ agentInstructions.md [MYVAR] (requiredFilesInternal)`
> CLI: `✓ MYVAR: /path/to/agentInstructions.md`

`requiredFilesInternal` is the settings key the file came from — an internal
code identifier, not something a user should read. The CLI already suppresses
it; the extension shows it as though it were a label.

This PR makes the webview use the CLI's rule: **paint `sourceDisplay`, nothing
else.** Three locals (`source`, `showSource`, `sourceText`) collapse into one
template condition. Every producer's rendering was enumerated before the
change:

| Producer | `source` | `sourceDisplay` | webview before | webview after |
|---|---|---|---|---|
| `userVars.getRequiredFileVars` | `requiredFilesInternal` | — | `(requiredFilesInternal)` | *(nothing — the fix)* |
| `trace/helpers.logFileCategory` | category | category | `(category)` | `(category)` — unchanged |
| `ToolUseDispatchNode` | `tool` | `Tool use` | `(Tool use)` | `(Tool use)` — unchanged |
| `MediaAttachmentProcessor.logResults` | — | — | *(nothing)* | *(nothing)* — unchanged |

So the `?? source` fallback only ever fired for the leaking producer. The
var-name chip (`[MYVAR]`) is untouched and still tells the user what the file
fed.

### Why this shape and not the alternative

The audit offered two cures and asked that the pick be made explicitly:

- **(b) honor `FileListEntry.internal`** — add `&& !file.internal` to
  `showSource`. The `internal` flag is set on exactly this entry and read by
  nothing, which suggests suppression was the original intent. Rejected: it
  patches the observed leak but leaves the leaking state representable — a
  future producer that sets `source` without `sourceDisplay` and without
  `internal` leaks again, and two independent wire fields would then mean
  "hide this label," one of them dead until it isn't.
- **(a, as landed) one rule** — never paint raw `source`. The leak becomes
  unrepresentable rather than suppressed: no producer configuration can put an
  unpainted identifier on screen, because the only field hosts read is the one
  producers write when they want a label. It is also literally the rule the
  CLI already implements, which is the point of the item.

A consequence worth an owner's eye, stated rather than hidden: after this PR
`FileListEntry.source` has **no readers** (its other grep hits —
`compileCheck.ts:71`, `workflowRunContext.ts:53` — read unrelated
`OutputFileInfo`/output-stream types), and `FileListEntry.internal` remains
write-only. Both are Zod schema members that survive persistence round-trips,
so deleting either is a wire-contract change deliberately **not** bundled here.

## Issue acceptance gates

No issue. Audit candidate C5 (`extension-formatters` track), which the verifier
upgraded from `low` to a real defect after locating the producer.

## Single source of truth

`FileListEntry.sourceDisplay` is now the single label field: present means
"show this," absent means "show nothing," in both hosts. `source` reverts to
being a producer-side provenance fact that no renderer interprets.

## Duplication and abstraction budget

Two host rules collapse to one shared rule, expressed identically in each
host's painter (`file.sourceDisplay` when present). No new abstraction, helper,
or shared module — the shared row model already landed and is not re-proposed
here.

## Net elements (R6)

| | + | − |
|---|---|---|
| Files | 0 | 0 |
| Exported symbols | 0 | 0 |
| Locals in `buildFileListRender` | 0 | 3 |
| LoC | 6 | 5 (**+1**) |

Stated plainly: **net +1 LoC**, entirely the five-line comment stating the
rule; the code itself is net −3 (three locals deleted, one template condition
inlined). This is a correctness fix bought with a comment, not a reduction.

## Consumer counts (R8)

- `grep -rn "buildFileListRender"` → two hits: its definition and its single
  caller (`dataFormatters.ts:67`), which passes `row.files` / `row.media`
  through — unaffected.
- `grep -rn "file\.source"` → the three painter sites discussed; the two
  non-`FileListEntry` hits verified as different types.
- `grep -rn "sourceDisplay"` → producers (`logFileCategory`,
  `ToolUseDispatchNode`), the two painters, the schema, and tests
  (`AgentTrace.vitest.ts:226-234` asserts both fields are written — still
  true). No test asserts the webview's `(requiredFilesInternal)` rendering.
- `grep -rn "filesLoaded"` → `TexraTranscriptRecorder.ts:774` forwards
  `data: entries` verbatim and paints no source label, so no third rule exists.

## Host impact

Extension: **user-visible fix** — the `(requiredFilesInternal)` suffix
disappears from files loaded from an agent's required-file variables. All other
file-list labels render identically.

Desktop: none. CLI: **no code change and no behavior change** — its painter
already implemented this rule; the two hosts now agree.

## Eyeball checklist (no automated gate covers a webview render)

A human must open the progress view and confirm:

1. **The fix.** Run an agent that has required-file variables configured
   (`requiredFilesInternal` in the agent setting). Its files-loaded card must
   list each file as `✓ name.tex [VARNAME]` with **no**
   `(requiredFilesInternal)` suffix. The `[VARNAME]` chip must still be there.
2. **Input files still labelled.** A card produced by `logFileCategory` (e.g.
   attached input files) must still show its category label, e.g.
   `✓ refs.bib (Input Files)`.
3. **Tool-written files still labelled.** Files loaded from a tool use must
   still show `✓ notes.md (Tool use)`.
4. **Media attachments.** An image/PDF load must still show
   `✓ fig.png [image, 1.2 MB]` with no source suffix, as before.
5. **CLI parity (same run if convenient).** `texra` transcript for the same run
   shows the same labels/no-labels as the webview — no host shows an identifier
   the other hides.

## Scheduled refactoring

Follow-up for the owner, not bundled: `FileListEntry.source` and
`FileListEntry.internal` are now both write-only. Deleting them is a
wire-schema change (they persist in logged runs) and deserves its own ruling.

## Validation

- `npm run typecheck` — clean (workspace, test-kernel, agent, cli,
  trace-viewer, desktop).
- `npx vitest run src/test-kernel/progressView/
  src/test-kernel/cli/TuiStateAndFocus.vitest.ts
  src/test-kernel/agent/trace/AgentTrace.vitest.ts` — 62 files, 767 tests, all
  passing, unmodified.
- `npm run lint` — clean.
- `npx prettier --check .` — clean.
- Zero new tests: the change is a one-painter display rule whose producer
  inventory is documented above; the durable boundary (both fields still
  written) is already pinned by `AgentTrace.vitest.ts`.
