### PR TITLE
fix(desktop): read stream labels from the cleaned tab info, not raw identity

### DIFF
--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -7,6 +7,7 @@ import '@awesome.me/webawesome/dist/components/dialog/dialog.js';
 import '@awesome.me/webawesome/dist/components/input/input.js';
 import { html, nothing, render } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
+import { streamDisplayLabel } from '@progressView/frontend/utils';
 import type { StreamTabId, StreamTabInfo } from '@shared/schemas';
 import {
   formatDesktopAccelerator,
@@ -399,18 +400,18 @@ function dispatchDesktopPaletteCommand(
 function toStreamPaletteEntry(stream: StreamTabInfo): CommandPaletteEntry {
   return {
     id: buildSwitchStreamCommandId(stream.name),
-    label: `Switch to ${stream.label || stream.name}`,
+    label: `Switch to ${stream.label}`,
+    // `label` is `runIdentityDisplayName(identity)` by construction
+    // (`buildStreamTabInfo`), so the subtitle reads the same cleaned name the
+    // title shows instead of re-deriving it from the raw identity fields —
+    // which printed a source-prefixed id ('custom:reviewer') beside the
+    // cleaned title. `command` exists only on process streams; the terminal
+    // 'Stream' covers an unresolved-empty label, which the schema does not
+    // forbid.
     description:
       stream.description ||
-      (stream.identity?.kind === 'multiAgentWorkflow'
-        ? stream.identity.workflowName
-        : undefined) ||
-      (stream.identity?.kind === 'agent'
-        ? stream.identity.agent || stream.modelLabel
-        : undefined) ||
-      (stream.identity?.kind === 'process'
-        ? stream.command || stream.identity.tool
-        : undefined) ||
+      stream.command ||
+      streamDisplayLabel(stream) ||
       'Stream',
     icon: 'terminal',
     category: 'Streams',

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -45,10 +45,12 @@ import {
   displayedActiveStreamId$,
   hasAnyStreams$,
   pendingApprovalIds$,
+  streamById$,
   streamStates$,
   streams$,
   topLevelStreams$,
 } from '@progressView/frontend/progressState';
+import { streamDisplayLabel } from '@progressView/frontend/utils';
 import { COMMON_COMMANDS } from '@shared/ipc';
 import '@settingsView/frontend';
 import '@webview/frontend';
@@ -600,9 +602,14 @@ function workbenchTemplate(
 }
 
 function currentTaskTitle(): string {
+  // The confirmed stream id, not `displayedActiveStreamId$`: the header names
+  // the content that is actually active while the rail highlights the pending
+  // switch (see `progressState.ts`). `streamDisplayLabel` reads the label
+  // `buildStreamTabInfo` already cleaned, so a source-prefixed agent id never
+  // reaches the header.
   const activeId = activeStreamId$.get();
-  const stream = streams$.get().find((entry) => entry.name === activeId);
-  return stream?.label || stream?.name || 'New task';
+  const stream = activeId ? streamById$.get().get(activeId) : undefined;
+  return streamDisplayLabel(stream) || 'New task';
 }
 
 function environmentPopoverTemplate(


### PR DESCRIPTION
## Summary

**Fixes a user-visible bug, then removes the re-derivation that caused it.**

The desktop command palette and the task header both re-derived a stream's
label from the raw `RunIdentity` fields instead of reading the label
`buildStreamTabInfo` had already cleaned:

- `toStreamPaletteEntry`'s subtitle used `stream.identity.agent` directly.
  `RunIdentitySchema` declares `agent: z.string().min(1)` "possibly
  source-qualified (`custom:name`)", and `buildStreamTabInfo` sets
  `label = runIdentityDisplayName(identity)` = `getCleanAgentName(...)`, which
  strips a validated source prefix. So for a custom agent the palette rendered
  title **"Switch to reviewer"** over subtitle **"custom:reviewer"** — an
  inconsistency inside one row.
- `currentTaskTitle` re-found the stream by linear scan over `streams$` and
  read `label || name`, where `name` is the opaque `agent#executionId` handle.

Both now read the shared idiom already used by the extension's own stream
surfaces (`StreamTabs.ts:175` is literally `stream.description ||
streamDisplayLabel(stream)`): the palette subtitle becomes
`stream.description || stream.command || streamDisplayLabel(stream) || 'Stream'`,
and the header reads `streamById$` directly. The 14-line per-kind identity
ladder collapses because for every `kind`, `runIdentityDisplayName(identity)
=== stream.label` by construction and `command` is set only for `process`
streams — a one-line comment names that invariant so a future change to
`buildStreamTabInfo` knows the collapse depends on it.

Also deleted as provably dead: the `identity.agent || stream.modelLabel` rung —
`agent` is `.min(1)`, so the right operand was unreachable.

## Issue acceptance gates

n/a — collapse sweep finding (desktop-projections A), no issue.

## Single source of truth

`StreamTabInfo.label`, produced once by `buildStreamTabInfo`
(`src/controllers/session/streamTabInfo.ts`) via `runIdentityDisplayName`, is
now the only label source for the desktop palette row and the task header.
`streamDisplayLabel` (`@progressView/frontend/utils`) is the read idiom.

## Duplication and abstraction budget

Removed: one per-kind identity re-derivation (the raw-`agent` ladder), one
linear-scan stream lookup. Added: nothing — no new export, no new helper; two
imports of an existing shared function.

## Net elements (R6)

| | + | − |
|---|---|---|
| files | 0 | 0 |
| exported symbols | 0 | 0 |
| functions | 0 | 0 |
| LoC | +20 | −12 |

**Net +8 LoC.** Not a reduction: the deleted ladder buys fewer lines than the
comments that name the invariant and the confirmed-vs-pending id distinction
cost. Sold for the bug fix and the single label owner, not the line count.

## Consumer counts (R8)

```
grep -rn "toStreamPaletteEntry\|currentTaskTitle\|streams\$\|streamById\$" --include='*.ts' packages/desktop/src
```

- `toStreamPaletteEntry`: module-private, callers unchanged.
- `currentTaskTitle`: 1 caller (the task header template); behaviour change is
  the fix itself.
- `streams$`: still imported and still used at `main.ts` (`streamCount`,
  `getStreams` for the palette) — import kept.
- `streamById$` (`progressState.ts:108`): joins `streams$` as a consumer; the
  unexported `activeStreamInfo$` was deliberately **not** used — exporting it
  would need a same-PR consumer and trip the dead-code ratchet.

## Host impact

Extension: none (its surfaces already read the cleaned label).

Desktop: palette subtitles for custom agents change from the source-prefixed id
(`custom:reviewer`) to the cleaned name (`reviewer`), matching the row title
and the stream rail; the task header no longer falls back to the opaque
`agent#executionId` handle. All other rows are byte-identical.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — 0 errors.
- `npm run lint` — clean.
- `npx prettier --check` on both changed files — clean.
- `npx vitest run src/test-kernel/desktop/DesktopCommandPalette.vitest.ts` —
  7 tests passed (the suite supplies `label` + `description` and asserts
  command ids and `showStream` dispatch, so it covers the wiring, not the
  removed ladder).
- Dead-code ratchet not run: no export added or removed.
