### PR TITLE
fix(diff): clamp trailing deletion line

### DIFF
--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -27,7 +27,7 @@ import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { getConfig } from '@utils/config/configUtils';
 import { applyPatchToText } from '@utils/text/diff';
 import { buildDiffHunks, unifiedDiffText } from '@utils/text/unifiedDiff';
-import { isNonEmptyString } from '@utils/text/stringUtils';
+import { countLines, isNonEmptyString } from '@utils/text/stringUtils';
 
 /**
  * Tool-edit approval request / result shapes.
@@ -170,16 +170,19 @@ export function firstChangedLine(
   const [hunk] = buildDiffHunks(original, proposed);
   if (!hunk) return null;
 
+  const lastProposedLine = Math.max(countLines(proposed) - 1, 0);
   let line = hunk.newStart;
   for (const text of hunk.lines) {
     const marker = text.at(0);
-    if (marker === '+') return line - 1;
+    if (marker === '+') return Math.min(line - 1, lastProposedLine);
     // A deletion has no line of its own in the proposed text; reveal the
     // position it was removed from.
-    if (marker === '-') return Math.max(line - 1, 0);
+    if (marker === '-') {
+      return Math.min(Math.max(line - 1, 0), lastProposedLine);
+    }
     line += 1;
   }
-  return Math.max(hunk.newStart - 1, 0);
+  return Math.min(Math.max(hunk.newStart - 1, 0), lastProposedLine);
 }
 
 // ============================================================================

--- a/src/utils/text/diff.ts
+++ b/src/utils/text/diff.ts
@@ -41,7 +41,7 @@ export function diffTextLevenshtein(oldText: string, newText: string): number {
  * Approximate added/removed line counts for run bookkeeping.
  *
  * Deliberately not the numbers shown beside a diff body: those come from
- * `hunkLineChanges` over the very hunks the reader sees.
+ * `computeLineChangeSummary`, folded over the very hunks the reader sees.
  */
 export function diffLineChanges(
   oldText: string,


### PR DESCRIPTION
## Summary
- clamp `firstChangedLine` results to the last valid proposed-text line using the shared `countLines` utility
- update the stale `hunkLineChanges` documentation reference to `computeLineChangeSummary`
- leave tests unchanged as requested

## Validation
- `corepack pnpm test -- src/test-kernel/utils/TextDiffCallers.vitest.ts` (the repository script ran the full suite: 846 files passed, 1 skipped; 10,336 tests passed, 6 skipped)
- `npm run typecheck:workspace`
- `node --max-old-space-size=6144 ./node_modules/eslint/bin/eslint.js src/tools/approval/toolEditApproval.ts src/utils/text/diff.ts`
- `corepack pnpm exec prettier --check src/tools/approval/toolEditApproval.ts src/utils/text/diff.ts`
- `git diff --check`
- bundled runtime check for trailing deletion into multi-line, single-line, and empty proposed text

Closes #11094
Closes #11095