### PR TITLE
fix(memory): write durable rewrites atomically

### DIFF
--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -235,7 +235,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
       getRunContextExecutionId(ctx),
       existingMeta,
     );
-    await StorageFS.write(resolvedPath, buildFile(content, meta));
+    await StorageFS.writeAtomic(resolvedPath, buildFile(content, meta));
   }
 
   private resolveMemoryPath(inputPath: string): string {

--- a/src/tools/memory/memoryFileSystem.ts
+++ b/src/tools/memory/memoryFileSystem.ts
@@ -323,6 +323,6 @@ export async function setMemoryPinned(
   }
 
   const updatedMeta = setPinnedMeta(meta, pinned);
-  await StorageFS.write(storagePath, buildFile(content, updatedMeta));
+  await StorageFS.writeAtomic(storagePath, buildFile(content, updatedMeta));
   return { status: 'changed', pinnedCount };
 }


### PR DESCRIPTION
## Summary

- route memory content rewrites through `StorageFS.writeAtomic`
- route pin/unpin metadata rewrites through `StorageFS.writeAtomic`
- preserve the existing read/build/write ordering and error propagation while preventing crash-time truncation of durable memory files

Closes #11033

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CliMemory.vitest.ts src/test-kernel/controllers/SettingsMemoryController.vitest.ts src/test-kernel/settings/MemoryFileSystemConcurrency.vitest.ts src/test-kernel/settings/MemoryItemActionGroup.vitest.ts src/test-kernel/tools/MemoryFrontmatter.vitest.ts src/test-kernel/tools/MemoryTool.vitest.ts` (6 files, 41 tests passed)
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm exec eslint src/tools/memory/MemoryTool.ts src/tools/memory/memoryFileSystem.ts`
- `corepack pnpm exec prettier --check src/tools/memory/MemoryTool.ts src/tools/memory/memoryFileSystem.ts`
- `git diff --check`

No tests were added or modified.
