### PR TITLE
fix(desktop): make the onboarding Commands hint read the shortcut live

### DIFF
--- a/packages/desktop/src/renderer/desktopOnboarding.ts
+++ b/packages/desktop/src/renderer/desktopOnboarding.ts
@@ -25,11 +25,7 @@ import { postMessage } from '@shared/hostBridge';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { AGENT_MODE_PRESETS } from '@shared/schemas';
 import { OWN_API_KEYS } from '@shared/copy/modelAccess';
-import { formatDesktopAccelerator } from '@shared/commands/accelerators';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
-
-import { desktopCommandPaletteShortcut } from './desktopShortcutRegistry';
-import { getRendererPlatform } from './rendererPlatform';
 
 interface StartupPanelController {
   isVisible(): boolean;
@@ -44,6 +40,8 @@ export interface DesktopStartupTeamPanelOptions {
   showLauncher(): void;
   /** Opens the Settings tab focused on the team picker, for fine-tuning. */
   openMultiAgent(): void;
+  /** Returns the current display hint for the Commands shortcut. */
+  commandsHint(): string;
 }
 
 /**
@@ -108,16 +106,9 @@ export function createStartupTeamPanel({
   onVisibilityChanged,
   showLauncher,
   openMultiAgent,
+  commandsHint,
 }: DesktopStartupTeamPanelOptions): StartupPanelController {
   const titleId = nextPanelTitleId();
-  // The walkthrough names the Commands shortcut, so format it for the user's
-  // platform rather than hardcoding the macOS glyph.
-  const platform = getRendererPlatform(document.defaultView);
-  const commandsAccelerator = formatDesktopAccelerator(
-    desktopCommandPaletteShortcut(platform).accelerator,
-    platform,
-  );
-  const commandsHint = commandsAccelerator ? ` (${commandsAccelerator})` : '';
   let visible = false;
   let hideAtStartup = false;
   let step: TourStep = 'work';
@@ -307,7 +298,7 @@ export function createStartupTeamPanel({
             <strong>Tabs</strong>
             <span>
               Open a terminal, browser, or Settings from the buttons at the
-              bottom of the sidebar - or from Commands${commandsHint}. Open
+              bottom of the sidebar - or from Commands${commandsHint()}. Open
               files from the project list; everything stays open beside a
               running agent.
             </span>
@@ -318,8 +309,8 @@ export function createStartupTeamPanel({
           <div>
             <strong>Commands</strong>
             <span>
-              Open Commands${commandsHint} from the header for every action and
-              shortcut.
+              Open Commands${commandsHint()} from the header for every action
+              and shortcut.
             </span>
           </div>
         </li>

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -152,6 +152,24 @@ const startupTeamPanel = createStartupTeamPanel({
   onVisibilityChanged: rerenderShell,
   showLauncher: returnToLauncher,
   openMultiAgent: () => openSettingsTab('multi-agent'),
+  // Lazy by necessity: the panel is constructed above the shortcut registry's
+  // declaration (which lands much later at module scope), so an eager or
+  // captured read is a TDZ throw, and a bootstrap failure leaves the registry
+  // `undefined` forever. Reading at render time is also what lets a user
+  // override (registry `localStorage`) reach the hint; the construction-time
+  // default only ever printed cmd/ctrl+K.
+  commandsHint: () => {
+    const entry = shortcutRegistry
+      ?.entries()
+      .find((entry) => entry.id === DESKTOP_COMMAND_PALETTE_ID);
+    const accelerator = formatDesktopAccelerator(
+      entry
+        ? entry.accelerator
+        : desktopCommandPaletteShortcut(rendererPlatform).accelerator,
+      rendererPlatform,
+    );
+    return accelerator ? ` (${accelerator})` : '';
+  },
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary

The desktop startup panel's "…from Commands (⌘K)" hint was computed **once**
inside `createStartupTeamPanel` — which `main.ts` calls at module scope, ~1170
lines before the shortcut registry exists — and captured into the render
closure. It therefore always printed the *default* shortcut, while the two
other "Commands shortcut" consumers (the palette meta and the header tooltip)
both read the registry and are override-aware. Rebinding Commands in Settings
changed every hint except the onboarding panel's, and nothing re-rendered it —
the value was frozen at construction.

The panel now takes a `commandsHint(): string` callback it reads on every
render. `main.ts` supplies it as a lazy lookup:
`shortcutRegistry?.entries().find(id === DESKTOP_COMMAND_PALETTE_ID)` — the
override-merged list — falling back to the declared default
(`desktopCommandPaletteShortcut`) only when the registry is absent (a bootstrap
failure leaves it `undefined` forever; the default hint then stays correct).

Why lazy, stated in the code: the closure is constructed above the registry's
module-scope declaration, so an eager or captured read is a **TDZ throw**, not
`undefined`, on a first render — and re-rendering can reach the panel template
before the registry exists.

## Issue acceptance gates

n/a — collapse sweep finding (desktop-projections D, added by the verifier), no
issue.

## Single source of truth

The shortcut registry's `entries()` (override-merged) is now the hint's source
when it exists; `desktopCommandPaletteShortcut` remains the sole owner of the
*default* declaration and the fallback. The panel no longer holds a private
copy of the accelerator.

## Duplication and abstraction budget

Removed: one construction-time accelerator computation and its
`formatDesktopAccelerator`/`desktopCommandPaletteShortcut` imports from the
onboarding module. Added: one option field on
`DesktopStartupTeamPanelOptions` (which already carries four callbacks — no new
layer, no new module). The hint now re-derives on render; the derive is three
lines and lives in `main.ts` beside the registry it reads.

## Net elements (R6)

| | + | − |
|---|---|---|
| files | 0 | 0 |
| exported symbols | 0 | 0 |
| functions | 0 | 0 |
| LoC | +26 | −15 |

**Net +11 LoC.** Not sold as a reduction — it buys override-correctness and a
TDZ-safe read; the diff is mostly the lazy-callback comment, which earns its
place because an eager refactor of this line is an obvious future mistake.

## Consumer counts (R8)

```
grep -rn "createStartupTeamPanel" --include='*.ts' --include='*.tsx' src packages
```

- `createStartupTeamPanel`: 1 caller (`main.ts:148`), updated in this PR; no
  test constructs the panel directly.
- `commandsHint`: new required field, supplied by that one caller.
- `DesktopStartupTeamPanelOptions`: same file as its consumer.

## Host impact

Extension: none.

Desktop: the onboarding panel's Commands hint now reflects a user-rebound
shortcut (and re-renders to it via the existing registry subscription →
`rerenderShell`), and no longer risks a construction-time TDZ. With no
override and a healthy bootstrap the rendered text is byte-identical.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — 0 errors.
- `npm run lint` — clean.
- `npx prettier --check .` — clean.
- `npx vitest run src/test-kernel/desktop/DesktopCommandPalette.vitest.ts
  src/test-kernel/desktop/DesktopShortcutRegistry.vitest.ts` — 2 files, 10
  tests passed. No test constructs the panel, so no suite pins the deleted
  closure.
- Dead-code ratchet not run: no export added or removed.
