### PR TITLE
fix(progress): gate elapsed time by running phase

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -526,14 +526,16 @@ function renderSectionDetails(options: {
 /**
  * Elapsed reading for one roster row, derived from the row's own timestamps —
  * the roster carries no rendered duration. A live row hands its start stamp to
- * the shared `<tool-timer>`, which owns the tick; a retained row's window is
- * closed by `finishedAt`, so its reading is fixed and needs no clock read.
+ * the shared `<tool-timer>`, which owns the tick; paused rows show no elapsed
+ * reading, matching the CLI. A retained row's window is closed by `finishedAt`,
+ * so its reading is fixed and needs no clock read.
  */
 function renderChildElapsed(
   child: ActiveChildInfo,
 ): TemplateResult | typeof nothing {
   if (child.startedAt === undefined) return nothing;
   if (child.finishedAt === undefined) {
+    if (child.status !== STREAM_PHASE.RUNNING) return nothing;
     return html`<span class="task-elapsed"
       >(<tool-timer .startTime=${child.startedAt}></tool-timer>)</span
     >`;

--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -242,6 +242,9 @@ export const streamLifecycleHandlers = {
         } else {
           delete draft.substate;
         }
+        if (status !== STREAM_PHASE.RUNNING) {
+          delete draft.runStartedAt;
+        }
         draft.lastTimestamp = lastTimestamp ?? current.lastTimestamp;
         if (isToolUseState(current) && shouldFocus) {
           (draft as typeof current).ui.shouldFocusFollowUp = true;

--- a/packages/extension/src/progressView/frontend/slices/streamStateMerge.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamStateMerge.ts
@@ -58,5 +58,8 @@ export function mergeBackendOwnedState(
     if (!Object.hasOwn(metadata, 'substate')) {
       delete draft.substate;
     }
+    if (!Object.hasOwn(metadata, 'runStartedAt')) {
+      delete draft.runStartedAt;
+    }
   });
 }

--- a/src/agent/core/flows/postCompactionContext.ts
+++ b/src/agent/core/flows/postCompactionContext.ts
@@ -4,10 +4,11 @@
  * compacted (summarized) mid-run.
  */
 
-import type {
-  ActiveChildInfo,
-  TodoItem,
-  WorkPlanSnapshot,
+import {
+  STREAM_PHASE,
+  type ActiveChildInfo,
+  type TodoItem,
+  type WorkPlanSnapshot,
 } from '@shared/schemas';
 import { childElapsedMs } from '@shared/streams/childElapsed';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
@@ -52,7 +53,12 @@ export function formatPostCompactionContext(
     lines.push(`<active-subagents count="${subagents.length}">`);
     for (const sa of subagents) {
       const statusAttr = sa.status ? ` status="${escapeAttr(sa.status)}"` : '';
-      const elapsedMs = childElapsedMs(sa, Date.now());
+      // Paused and settled children have no live elapsed reading. This mirrors
+      // the CLI child list and avoids presenting pause time as execution time.
+      const elapsedMs =
+        sa.status === STREAM_PHASE.RUNNING
+          ? childElapsedMs(sa, Date.now())
+          : undefined;
       const elapsedAttr =
         elapsedMs === undefined
           ? ''


### PR DESCRIPTION
## Summary
- clear stale progress-view `runStartedAt` state when status leaves `RUNNING` and when authoritative metadata omits the field
- render a live child elapsed timer only for `RUNNING` children
- omit elapsed from post-compaction subagent context for paused and other non-running phases

Closes #11003
Closes #11004

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/progressView/StreamMetaState.vitest.ts src/test-kernel/progressView/BackgroundTasksPanel.vitest.ts` (23 passed)
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- `corepack pnpm exec eslint packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts packages/extension/src/progressView/frontend/slices/streamStateMerge.ts src/agent/core/flows/postCompactionContext.ts`
- `corepack pnpm exec prettier --check packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts packages/extension/src/progressView/frontend/slices/streamStateMerge.ts src/agent/core/flows/postCompactionContext.ts`
- `git diff --check`

No tests were added or modified.