### PR TITLE
refactor: delete dead mappers, returns, and imports; restore getEnabledModels null guard

### DIFF
--- a/docs/proposals/2026-08-03-run-classification-consolidation.md
+++ b/docs/proposals/2026-08-03-run-classification-consolidation.md
@@ -236,12 +236,12 @@ gates workflow affordances on `AgentCategory.Workflow`
    `bash.ts:415` (`'process'`) and `runAgent.ts:102` (`config.agentCategory`).
    That is why no execution on disk is ever tagged `workflowScript`.
 3. **The progress-view Resume button relaunches borrowed identity.**
-   `ProgressViewHost.resumeStream` (`ProgressViewHost.ts:62-79`) branches only
+   `resumeStream` (`ProgressViewCommandHandlers.ts:109-133`) branches only
    on `config.agentCategory`; for a workflow-script stream the persisted
    category is `Workflow`, so Resume re-executes the _borrowed default agent's
    config_ as a plain workflow run — not the script. Post-demotion
    bash/codex/claude streams take the same branch. `RESTORE_STATE`
-   (`ProgressViewCommandHandlers.ts:457-459`) similarly pushes a synthetic
+   (`ProgressViewCommandHandlers.ts:575-585`) similarly pushes a synthetic
    bash config into the main-view launcher form.
 
 ### Two prior beliefs that did not survive checking
@@ -712,8 +712,8 @@ _Ephemeral._ **Add:** `ProgressFactApplier` consumes `run.start` identity at
 stream birth; `StreamTabInfo.identity` (struct verbatim, display fields
 beside it); explicit category naming on `StreamMetadata`/`SYNC_STREAM_CONTENT`;
 resume/rerun/restore gated on `identity.kind === 'agent'`
-(`ProgressViewHost.ts:62-88`, `ProgressViewCommandHandlers.ts:457-459` —
-fixes live defect 3).
+(`resumeStream`/`runNewStream`, `ProgressViewCommandHandlers.ts:109-150`;
+`RESTORE_STATE`, `:575-585` — fixes live defect 3).
 **Delete:** `ProgressStreamRunDetails`; the `streamId.split('@')` parse and
 `isProcessAgent` in `buildStreamTabInfo` and `ProgressViewState.ts:320-323`;
 `StreamHeader.ts:521-527` parent-label string parsing; the `?? Workflow`

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -32,7 +32,6 @@ import {
 } from '@agent/runtime';
 import {
   toApprovalSettlement,
-  toBashApprovalSettlement,
   toToolEditResult,
 } from '@cli/runtime/approvalAdapter';
 import {
@@ -315,7 +314,7 @@ async function requestBashInteraction(
   if (decision.accepted && decision.bypass === 'bash' && request.streamId) {
     setBashApprovalSessionBypass(request.streamId, true);
   }
-  return toBashApprovalSettlement(decision);
+  return toApprovalSettlement(decision);
 }
 
 async function requestPlanInteraction(

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -168,16 +168,6 @@ function toPromptedApprovalSettlement(
   });
 }
 
-/** Preserve a CLI host failure as a Bash cancellation, not user feedback. */
-export function toBashApprovalSettlement(
-  decision: CliApprovalDecision,
-): BashSettlement {
-  if (decision.rejectionCause !== undefined) {
-    return { action: 'reject', cause: decision.rejectionCause };
-  }
-  return toApprovalSettlement(decision);
-}
-
 function toRetryResult(
   decision: ApprovalDecision,
   humanInputAvailable: boolean,
@@ -262,7 +252,7 @@ export function createHeadlessCliHostInteractions(
         { summary: formatBashApprovalSummary(request) },
         hooks,
       );
-      return toBashApprovalSettlement(decision);
+      return toApprovalSettlement(decision);
     },
     async requestPlanApproval(request) {
       const { decision, prompted } = await decideApprovalEvent(

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -88,7 +88,6 @@ import {
   formatStreamDeletionRetention,
 } from '@shared/copy/executionHistory';
 import { SESSION_DISPOSED_CAUSE } from '@shared/copy/interactionCancellation';
-import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { cleanupUnscopedApprovals } from '@tools/approval';
 import { startRecording, stopRecordingAndTranscribe } from '@tools/media/audio';
 import type { RunMetadata } from '@transcript/StreamSnapshotStore';

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -34,7 +34,6 @@ import {
   formatStreamDeletionRetention,
 } from '@shared/copy/executionHistory';
 import { SESSION_DISPOSED_CAUSE } from '@shared/copy/interactionCancellation';
-import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { ProgressViewMessageHandler } from './ProgressViewMessageHandler';
 import { createExtensionHostInteractions } from './extensionHostInteractions';
 

--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -279,9 +279,9 @@ export class LogList extends LitElement {
 
   /**
    * Dispatch a spill-artifact / file-link / latex-ref activation from a click
-   * or keydown event. Returns true when one was handled.
+   * or keydown event.
    */
-  private activateLinkFromEvent(event: Event): boolean {
+  private activateLinkFromEvent(event: Event): void {
     const spillLink = getComposedPathElement<HTMLElement>(
       event,
       '.spill-artifact-link',
@@ -291,7 +291,7 @@ export class LogList extends LitElement {
       postMessage(PROGRESS_VIEW_COMMANDS.OPEN_SPILL_ARTIFACT, {
         spillPath: spillLink.dataset.spillPath,
       });
-      return true;
+      return;
     }
 
     const fileLink = getComposedPathElement<HTMLElement>(event, '.file-link');
@@ -302,7 +302,7 @@ export class LogList extends LitElement {
           line: Number(fileLink.dataset.fileLine),
         }),
       });
-      return true;
+      return;
     }
 
     const latexRef = getComposedPathElement<HTMLElement>(event, '.latex-ref');
@@ -310,10 +310,7 @@ export class LogList extends LitElement {
       postMessage(PROGRESS_VIEW_COMMANDS.OPEN_LABEL, {
         label: latexRef.dataset.label,
       });
-      return true;
     }
-
-    return false;
   }
 
   /** Handle file-click events from Shadow DOM components. */

--- a/packages/extension/src/webview/frontend/slices/documentSlice.ts
+++ b/packages/extension/src/webview/frontend/slices/documentSlice.ts
@@ -48,7 +48,7 @@ function handleSetMultipleFiles(message: SetMultipleFilesMessage): void {
   multiFiles$.set({ ...multiFiles$.get(), [list.key]: files });
 }
 
-// File-local (not exported): narrows a `CurrentFileType` to `DocumentFileType`
+// File-local (not exported): narrows a current-file value to `DocumentFileType`
 // via the schema itself, so a future addition to `DocumentFileTypeSchema`
 // takes effect here without a matching hand-written literal check.
 const DOCUMENT_FILE_TYPES = new Set<string>(DocumentFileTypeSchema.options);

--- a/packages/extension/src/webview/managers/FileManager.ts
+++ b/packages/extension/src/webview/managers/FileManager.ts
@@ -18,11 +18,7 @@ import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { parseVersionControlDiffFilename } from '@latex/latexdiff/diffFileNameManager';
 import { createLog } from '@logger/logUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
-import type {
-  CurrentFileType,
-  DocumentFileType,
-  MainViewInboundMessage,
-} from '@shared/schemas';
+import type { DocumentFileType, MainViewInboundMessage } from '@shared/schemas';
 import { isMultipleDocumentFileType } from '@shared/schemas';
 import { getFileStem } from '@utils/core';
 import { WorkspaceFS } from '@utils/files/workspaceFS';

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -400,9 +400,10 @@ async function buildAvailabilityContext(
  * The models the pickers show — the single reader of
  * `GlobalStateKey.ENABLED_MODELS` for every host.
  *
- * Normalizes an empty persisted list to {@link DEFAULT_MODELS}: `.get`'s
- * fallback only fires on `undefined`, so a stored `[]` would otherwise survive
- * all the way to an empty picker with no way back out from the UI.
+ * Normalizes an empty or `null` persisted list to {@link DEFAULT_MODELS}:
+ * `.get`'s fallback only fires on `undefined`, so a stored `[]` would
+ * otherwise survive all the way to an empty picker with no way back out from
+ * the UI, and a stored `null` would throw on `.length`.
  */
 export function getEnabledModels(
   state: Pick<StateStore, 'get'> = platform().globalState,
@@ -411,7 +412,7 @@ export function getEnabledModels(
     GlobalStateKey.ENABLED_MODELS,
     DEFAULT_MODELS,
   );
-  return enabled.length > 0 ? enabled : DEFAULT_MODELS;
+  return enabled != null && enabled.length > 0 ? enabled : DEFAULT_MODELS;
 }
 
 /**

--- a/src/shared/schemas/fileTypes.ts
+++ b/src/shared/schemas/fileTypes.ts
@@ -36,4 +36,3 @@ export const CurrentFileTypeSchema = z.union([
   DocumentFileTypeSchema,
   z.enum(['base', 'edited']),
 ]);
-export type CurrentFileType = z.infer<typeof CurrentFileTypeSchema>;

--- a/src/shared/schemas/proposalInput.ts
+++ b/src/shared/schemas/proposalInput.ts
@@ -9,8 +9,8 @@
  * It lives in the schema layer (not the renderer) because it encodes domain
  * knowledge rather than presentation: which delegation tools map to which agent
  * category and the `extractFigures` / `extractTikz` shorthand → `toolConfig`
- * mapping. The renderer-side
- * `proposalInputStore` is a thin registry over this parser.
+ * mapping. The renderer parses the delegation input directly via
+ * `parseDelegationToolInput` (in `toolFormatters.ts`).
  *
  * The schemas here are deliberately lenient: the LLM may omit fields the
  * canonical proposal schema requires, so display-only defaults


### PR DESCRIPTION
## Summary

Seven-issue dead-surface round 3 from the 2026-08-19 sweep. Every citation re-verified against the tree before editing; no claim proved false. 11 files, +19/−39. No tests added or migrated — none pinned the deleted shapes (verified by grep). #11113 and #11114 were dropped from this batch: already covered by open fleet PRs (#11122; #11123/#11115).

Closes #11112, closes #11089, closes #11083, closes #11081, closes #11091, closes #11087, closes #11100.

### #11112 — delete redundant `toBashApprovalSettlement`
All three `rejectionCause` producers (`approvalPrompts.ts`, `subscribeApprovals.ts`, `approvalQueue.ts`) set `accepted: false`, so the divergent branch was unrepresentable. Deleted the export from `packages/cli/src/runtime/approvalAdapter.ts`; both consumers (`requestBashApproval`, `subscribeApprovals.ts:318`) now call `toApprovalSettlement`. Zero refs remain.

### #11089 — `LogList.activateLinkFromEvent` returns `void`
Both call sites discarded the result. Dropped the three `return true` / trailing `return false` and the docstring claim.

### #11083 — dead `PERMISSION_KIND` imports
Deleted from `ProgressViewProvider.ts` and `desktopAgentExecution.ts` (grep -w: import line was the only occurrence in each).

### #11081 — dead `CurrentFileType` import (+ orphaned alias cascade)
Import removed from `FileManager.ts`. The dead-code ratchet then flagged the `CurrentFileType` alias itself (0 consumers; the zod `CurrentFileTypeSchema` stays alive via three mainView wire schemas) — alias deleted from `src/shared/schemas/fileTypes.ts`, one naming comment reworded in `documentSlice.ts`.

### #11091 — restore null guard in `getEnabledModels`
`JsonStore.get` substitutes the fallback only for `undefined` (verified `jsonStore.ts:122-124`), so persisted `null` reached `.length`. Restored `enabled != null && enabled.length > 0` (repo `!= null` idiom) in `computeModelOptions.ts`; docstring names the `null` throw.

### #11087 — stale `proposalInputStore` reference
`proposalInput.ts` comment now says the renderer parses delegation input directly via `parseDelegationToolInput` in `toolFormatters.ts` (live path verified: import at :20, call at :155). Zero `proposalInputStore` refs remain.

### #11100 — stale `ProgressViewHost` citations in run-classification proposal
Defect 3 now cites `resumeStream` (`ProgressViewCommandHandlers.ts:109-133`) and `RESTORE_STATE` (`:575-585`); Step 2 cites `resumeStream`/`runNewStream` (`:109-150`) and `RESTORE_STATE` (`:575-585`). All boundaries verified by numbered reads. Follow-up tracker filed as #11131; outcome commented on the issue.

## Issue acceptance gates

- Every deleted name greps to zero survivors. ✅
- #11091: `enabled != null && enabled.length > 0` guard restored at `computeModelOptions.ts:415`. ✅
- #11100: zero `ProgressViewHost` refs in the proposal; tracker #11131 filed for the follow-up. ✅

## Single source of truth

- Bash approval settlement: `toApprovalSettlement` alone.
- Enabled-model presence: the restored null guard in `getEnabledModels` (no implicit `.length` on nullable).
- Current-file typing: `CurrentFileTypeSchema` (zod) alone; the TS alias is gone.

## Duplication and abstraction budget

Removed: 1 divergent settlement mapper, 1 dead boolean return (4 return statements), 4 dead imports, 1 orphaned type alias, 2 stale comment blocks, 1 stale doc citation set. Added: 0 exports, 0 files, 0 layers (one null guard restored).

## Net elements (R6)

- 11 files, +19/−39 (net −20).
- Deleted symbols: `toBashApprovalSettlement` (function), `CurrentFileType` (type alias), 4 dead type/const imports.
- Added: 0 new exports.

## Consumer counts (R8)

- `toBashApprovalSettlement`: 2 production consumers → both rerouted to `toApprovalSettlement`; 0 survivors.
- `activateLinkFromEvent` return value: 0 of 2 call sites read it.
- `PERMISSION_KIND` in the 2 files: 0 uses beyond the import line each.
- `CurrentFileType` alias: 0 consumers (`CurrentFileTypeSchema`: 3 wire-schema consumers, untouched).
- `proposalInputStore`: 0 code refs (comment-only).

## Host impact

Extension: dead import removal, void return, comment fixes only.
Desktop: dead import removal only.
CLI: settlement mapper collapse; `getEnabledModels` null guard restored (shared `src/model`).

## Scheduled refactoring

#11131 (filed for the #11100 follow-up). #11013 item 5 remains the standing medium-risk exception from round 2.

## Validation

- `prettier --write` on all 11 files — clean.
- `typecheck:workspace`, `typecheck:test-kernel`, `@texra-ai/cli typecheck`, `@texra/desktop typecheck` — pass.
- Targeted vitest: ApprovalAdapter, ApprovalQueue, TuiApprovalRetry, BashApproval, PlanApproval, EditApproval, LogListKeyboard, ComputeModelOptions, ParseDelegationToolInput — 157/157; architecture ratchets + chatSessionController + TuiHostInteractionsCancelForStream — 157/157; post-alias architecture re-run 104/104.
- ESLint on changed files — exit 0. `check:dead-code-ratchet` — 8 current vs 8 baselined, OK.
- Full `npm test` not run locally (>10 min; CI shards cover it). transcriptRow/projectTranscriptRow suites not run — those files untouched after scope change.