### PR TITLE
fix(shared): re-arm watcher after getter errors

### DIFF
--- a/src/shared/signals.ts
+++ b/src/shared/signals.ts
@@ -76,16 +76,16 @@ export function subscribeToSignalChanges(
     queueMicrotask(() => {
       notifyPending = false;
       if (disposed) return;
-      // Read every pending computed so the watcher re-tracks its dependencies.
-      // A watched `Signal.State` never reports pending, so this is a no-op for
-      // subscribers that watch state signals directly.
-      for (const pending of watcher.getPending()) pending.get();
       // Re-arm in `finally`: a Watcher fires once and stays dormant until
-      // `watch()` runs again, so letting a throw from `notify()` skip it
-      // silently kills this subscription for the rest of the process. For a
-      // React subscriber that means a component frozen on stale data with no
-      // error and no recovery.
+      // `watch()` runs again, so letting a throw from a pending getter or
+      // `notify()` skip it silently kills this subscription for the rest of the
+      // process. For a React subscriber that means a component frozen on stale
+      // data with no error and no recovery.
       try {
+        // Read every pending computed so the watcher re-tracks its dependencies.
+        // A watched `Signal.State` never reports pending, so this is a no-op for
+        // subscribers that watch state signals directly.
+        for (const pending of watcher.getPending()) pending.get();
         notify();
       } finally {
         watcher.watch();


### PR DESCRIPTION
## Summary

PR #11110 moved pending computed reads into the shared watcher flush, but left them outside the existing `try/finally`. If a computed getter throws, `watcher.watch()` is skipped and later notifications are silently suppressed.

Move the pending-get loop inside the `try`, before `notify()`, so the watcher is always re-armed. No tests were added or modified.

## Validation

- `npm run typecheck:workspace`
- `npx eslint src/shared/signals.ts`
- `npx prettier --check src/shared/signals.ts`
- `npx vitest run src/test-kernel/cli/RunChatSignalOwnership.vitest.ts` (2 passed)
- `npx vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.ts --reporter=dot` (190 passed)
- Direct regression reproduction: a throwing computed previously left notifications at 0 after a recovery update; the fixed code delivers 1 notification.
