### PR TITLE
revert(cli): restore model-access route resolver after #11111

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -64,7 +64,6 @@ import {
   transcriptText,
   type TranscriptRow,
 } from '@shared/transcript';
-import { OWN_API_KEYS } from '@shared/copy/modelAccess';
 import { FOCUSED_BACKGROUND_TASK } from '@shared/copy/nestedRuns';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import {
@@ -136,7 +135,10 @@ import { resolveLocalTranscriptStreamId } from '../src/chat/tui/state/transcript
 import { clearTerminalScrollback } from '../src/tui/terminalCleanup';
 import { defaultShortcutModifierLabel } from '../src/runtime/shortcutLabels';
 import { OrchestrationApp } from '../src/orchestration/runOrchestrationTui';
-import { resolveCliModelAccessRoute } from '../src/runtime/modelAccessRoute';
+import {
+  formatCliModelAccessRouteInline,
+  resolveCliModelAccessRoute,
+} from '../src/runtime/modelAccessRoute';
 import { updateCliModelAccess } from '../src/runtime/modelAccessSelection';
 import {
   formatCliApiStatusActionHint,
@@ -632,7 +634,7 @@ function harnessOrchestrationStatusLines(): readonly string[] {
     accountLabel: authenticated ? 'harness@example.edu' : undefined,
   };
   return [
-    `api: ${OWN_API_KEYS.inline}`,
+    `api: ${formatCliModelAccessRouteInline('personal')}`,
     formatCliAuthStatusLine(profile),
     formatCliApiStatusActionHint(profile),
   ];

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -1,4 +1,8 @@
 import {
+  shortCliModelAccessRoute,
+  type CliModelAccessRoute,
+} from '@cli/runtime/modelAccessRoute';
+import {
   defaultShortcutModifierLabel,
   metaChordLabel,
 } from '@cli/runtime/shortcutLabels';
@@ -26,7 +30,6 @@ import {
   type TokenUsageStats,
   type UsageRoute,
 } from '@shared/schemas';
-import { usageRouteBadge } from '@shared/copy/modelAccess';
 import {
   FOREGROUND_OWNERSHIP,
   RUNNING_SESSION,
@@ -69,18 +72,18 @@ export function subscriptionUsageProviderForStatus({
   prospectiveCodingPlan,
 }: {
   readonly usageRoute: UsageRoute | undefined;
-  readonly modelAccess: UsageRoute;
+  readonly modelAccess: CliModelAccessRoute;
   readonly prospectiveCodingPlan?: SubscriptionUsageProvider;
 }): SubscriptionUsageProvider | undefined {
   if (usageRoute === 'chatgpt-subscription') return 'chatgpt';
   const completedCodingPlan = codingPlanForUsageRoute(usageRoute);
   if (completedCodingPlan) return completedCodingPlan.usageProvider;
   if (usageRoute !== undefined) return undefined;
-  if (modelAccess === 'chatgpt-subscription') return 'chatgpt';
+  if (modelAccess === 'chatgpt') return 'chatgpt';
   return CODING_PLAN_SUBSCRIPTIONS.find(
     (plan) =>
       plan.usageProvider === prospectiveCodingPlan &&
-      plan.usageRoute === modelAccess,
+      plan.cliProvider === modelAccess,
   )?.usageProvider;
 }
 
@@ -128,7 +131,7 @@ export interface StatusBarDisplayInput {
   readonly runningSessions: number;
   readonly approvalDepth: number;
   readonly approvalKind?: ApprovalQueueStatusKind;
-  readonly modelAccess: UsageRoute;
+  readonly modelAccess: CliModelAccessRoute;
   /** Latest quota snapshot for the subscription serving this model. */
   readonly subscriptionQuota?: SubscriptionUsageSnapshot;
   /** Ephemeral transcripts cannot be resumed and require a persistent warning. */
@@ -197,21 +200,17 @@ interface StatusBarDisplay {
   readonly bindings: string;
 }
 
-function accessModeSegment(access: UsageRoute): StatusBarSegment {
-  // `usageRouteBadge` is undefined only for an unset route; the bar always
-  // resolves one through `resolveCliModelAccessRoute`.
-  const badge = usageRouteBadge(access)!;
-  // The bar names how the call is paid for, not which subscription; the /api
-  // form and /status name the subscription itself.
-  return badge.subscription
+function accessModeSegment(access: CliModelAccessRoute): StatusBarSegment {
+  const label = shortCliModelAccessRoute(access);
+  return label === 'subscription'
     ? {
-        text: 'subscription',
+        text: label,
         color: COLOR_HINT,
         compactText: 'sub',
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.accessMode,
       }
     : {
-        text: badge.compactLabel,
+        text: label,
         color: 'dim',
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.accessMode,
       };

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -1,7 +1,10 @@
-import { formatCliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
+import {
+  formatCliModelAccessRoute,
+  type CliModelAccessRoute,
+} from '@cli/runtime/modelAccessRoute';
 import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import type { TexraApprovalPolicy } from '@shared/approvalPolicy';
-import type { StreamPhase, StreamSubstate, UsageRoute } from '@shared/schemas';
+import type { StreamPhase, StreamSubstate } from '@shared/schemas';
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
 import { BACKGROUND_TASK } from '@shared/copy/nestedRuns';
 import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
@@ -22,7 +25,7 @@ export interface CliSessionStatusInput {
   readonly agent: string;
   readonly model: string;
   readonly teamName?: string;
-  readonly modelAccess: UsageRoute;
+  readonly modelAccess: CliModelAccessRoute;
   readonly approval: string;
   readonly approvalBypasses?: Partial<BypassState>;
   readonly status: StreamPhase | undefined;

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -16,6 +16,8 @@ import {
   formatCliChatGptPreference,
   formatCliGrokPreference,
   formatCliCodingPlanPreference,
+  formatCliModelAccessRoute,
+  formatCliModelAccessRouteInline,
   cliCodingPlanStatus,
   type CliModelAccessStatus,
 } from './modelAccessRoute';
@@ -80,7 +82,7 @@ export async function loadCliModelAccessOverview(): Promise<CliModelAccessOvervi
       (plan) =>
         `${plan.displayName} preference: ${formatCliCodingPlanPreference(access, plan)}`,
     ),
-    `Otherwise: ${OWN_API_KEYS.label}`,
+    `Otherwise: ${formatCliModelAccessRoute('personal')}`,
     formatAccountStatusLine(
       RESEARCHER_ACCESS.label,
       profile.authenticated,
@@ -153,7 +155,7 @@ export async function loadCliApiStatus(
   );
 
   return [
-    `api: ${OWN_API_KEYS.inline}`,
+    `api: ${formatCliModelAccessRouteInline('personal')}`,
     ...(personalKeysLine ? [personalKeysLine] : []),
     authLine,
     ...(profile.note ? [profile.note] : []),
@@ -267,7 +269,7 @@ export async function loadCliDetailedAccountStatusLines(
     if (line) lines.push(withUsage(line, codingPlanUsage.get(plan.id)));
   }
 
-  lines.push(`Otherwise: ${OWN_API_KEYS.label}`);
+  lines.push(`Otherwise: ${formatCliModelAccessRoute('personal')}`);
 
   const otherPersonalKeys = formatPersonalApiKeysLine(
     providers.filter(

--- a/packages/cli/src/runtime/modelAccessRoute.ts
+++ b/packages/cli/src/runtime/modelAccessRoute.ts
@@ -11,6 +11,16 @@ import { OWN_API_KEYS } from '@shared/copy/modelAccess';
 export const CLI_MODEL_ACCESS_DESCRIPTION =
   'Set subscription preferences and how the rest is paid for.';
 
+export type CliModelAccessRoute =
+  | 'chatgpt'
+  | 'grok'
+  | 'kimi-code'
+  | 'glm-code'
+  // LEGACY: renders historical usage recorded on the retired relay route
+  // (removed 2026-08; see docs/proposals/2026-08-18-relay-removal-and-recovery.md).
+  | 'included'
+  | 'personal';
+
 type CliSubscriptionPreferenceState = 'off' | 'on';
 type CliSubscriptionProvider =
   'chatgpt' | 'grok' | CodingPlanSubscription['cliProvider'];
@@ -113,32 +123,79 @@ export function resolveCliModelAccessRoute({
   readonly usageRoute?: UsageRoute;
   /** Route that would serve the next request (`activeSubscriptionUsageRoute`). */
   readonly prospectiveRoute?: UsageRoute;
-}): UsageRoute {
-  return usageRoute ?? prospectiveRoute ?? 'api-key';
+}): CliModelAccessRoute {
+  const route = usageRoute ?? prospectiveRoute;
+  switch (route) {
+    case undefined:
+      return 'personal';
+    case 'chatgpt-subscription':
+      return 'chatgpt';
+    case 'xai-subscription':
+      return 'grok';
+    case 'kimi-code-subscription':
+      return 'kimi-code';
+    case 'glm-coding-plan-subscription':
+      return 'glm-code';
+    case 'relay':
+      return 'included';
+    case 'api-key':
+      return 'personal';
+    default:
+      return route satisfies never;
+  }
 }
 
-/** Detailed CLI phrasing for an access route — `/status` and the `/api` form
- *  name the subscription itself, unlike the width-constrained badge copy in
- *  `usageRouteBadge`. */
-export function formatCliModelAccessRoute(route: UsageRoute): string {
+/** Status-bar form of the access route. Width-critical, so every arm is a
+ *  short display phrase; the enum value itself never reaches the screen. */
+export function shortCliModelAccessRoute(route: CliModelAccessRoute): string {
   switch (route) {
-    case 'chatgpt-subscription':
+    case 'chatgpt':
+    case 'grok':
+    case 'kimi-code':
+    case 'glm-code':
+      // The bar names how the call is paid for, not which provider; the /api
+      // form and /status name the subscription itself.
+      return 'subscription';
+    case 'included':
+      return 'Included';
+    case 'personal':
+      return OWN_API_KEYS.compactLabel;
+    default:
+      return route satisfies never;
+  }
+}
+
+export function formatCliModelAccessRoute(route: CliModelAccessRoute): string {
+  switch (route) {
+    case 'chatgpt':
       return 'ChatGPT subscription';
-    case 'xai-subscription':
+    case 'grok':
       return 'Grok subscription';
-    case 'kimi-code-subscription':
+    case 'kimi-code':
       return 'Kimi Code subscription';
-    case 'glm-coding-plan-subscription':
+    case 'glm-code':
       return 'GLM Coding Plan';
-    // LEGACY: renders historical usage recorded on the retired relay route
-    // (removed 2026-08; see docs/proposals/2026-08-18-relay-removal-and-recovery.md).
-    case 'relay':
+    case 'included':
       return 'Included access';
-    case 'api-key':
+    case 'personal':
       return OWN_API_KEYS.label;
     default:
       return route satisfies never;
   }
+}
+
+/** Sentence-fragment form derived from the canonical access label. */
+export function formatCliModelAccessRouteInline(
+  route: CliModelAccessRoute,
+): string {
+  const label = formatCliModelAccessRoute(route);
+  // Proper-noun labels keep their casing; plain labels lowercase like prose.
+  return route === 'chatgpt' ||
+    route === 'grok' ||
+    route === 'kimi-code' ||
+    route === 'glm-code'
+    ? label
+    : label.charAt(0).toLowerCase() + label.slice(1);
 }
 
 function formatCliSubscriptionPreference(
@@ -281,5 +338,5 @@ export function formatCliModelAccessSummary(
     const label = plan.displayName.split(' ')[0];
     return `${label} ${cliCodingPlanStatus(status, plan).preferred ? 'On' : 'Off'}`;
   });
-  return `ChatGPT ${chatGpt} · Grok ${grok} · ${codingPlans.join(' · ')} · otherwise: ${OWN_API_KEYS.inline}`;
+  return `ChatGPT ${chatGpt} · Grok ${grok} · ${codingPlans.join(' · ')} · otherwise: ${formatCliModelAccessRouteInline('personal')}`;
 }

--- a/packages/cli/src/runtime/modelAccessSelection.ts
+++ b/packages/cli/src/runtime/modelAccessSelection.ts
@@ -13,7 +13,6 @@ import {
 } from '@model/codingPlanSubscriptions';
 import { platform } from '@platform/platform';
 import { providerDisplayName } from '@shared/constants/providers';
-import { OWN_API_KEYS } from '@shared/copy/modelAccess';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
 import {
@@ -22,6 +21,7 @@ import {
   type CliSubscriptionLoginOptions,
 } from './subscriptionLogin';
 import {
+  formatCliModelAccessRouteInline,
   type CliModelAccessSelection,
   type CliModelAccessStatus,
 } from './modelAccessRoute';
@@ -151,7 +151,7 @@ async function updateKeyedCliModelAccess(
   await runtime.setEnabled(true);
   invalidateModelOptionsCache();
   return {
-    message: `${plan.preferenceLabel} enabled for ${plan.modelFamily} · other models still use ${OWN_API_KEYS.inline}.`,
+    message: `${plan.preferenceLabel} enabled for ${plan.modelFamily} · other models still use ${formatCliModelAccessRouteInline('personal')}.`,
   };
 }
 


### PR DESCRIPTION
## Urgent revert

Main is red after #11111 was squash-merged as `0ac1b80793038d7e5f56eb2dfaa8f1e3d97d6676` despite failed static checks and kernel checks. This PR reverts that single commit exactly.

The revert restores #11068’s `resolveCliModelAccessRoute({ usageRoute, prospectiveRoute })` contract, including completed-usage precedence, and restores the CLI-facing `CliModelAccessRoute` boundary expected by the test kernel. No test files were modified or added.

Compatibility wrappers were rejected because they would retain the incompatible route-type change from #11111 and mask the regression at consumers. An exact revert restores the last known-good resolver and type contract with no additional migration surface.

## Validation

- `npm run typecheck:test-kernel`
- `npm run typecheck:workspace`
- `npm run typecheck:cli`
- `git diff --exit-code 0ac1b80793038d7e5f56eb2dfaa8f1e3d97d6676^ HEAD` confirms the reverted tree exactly matches main immediately before #11111.
- No full suite was run, per the urgent revert scope.