### PR TITLE
refactor(desktop): use shared extractErrorMessage for bootstrap failures

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -69,6 +69,7 @@ import {
 } from '@shared/wa/actionButtons';
 import { renderEmptyState } from '@shared/wa/emptyState';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
+import { extractErrorMessage } from '@utils/errors/errorMessage';
 
 import { type DesktopLayoutPanel } from '../shared/desktopShellMessages';
 import {
@@ -1129,14 +1130,9 @@ function rerenderShell(): void {
   observeSurfaceResizes();
 }
 
-function toBootstrapErrorMessage(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  if (typeof error === 'string') return error;
-  return 'TeXRA could not finish starting up.';
-}
-
 function renderBootstrapFallback(error: unknown): void {
-  const message = toBootstrapErrorMessage(error);
+  const message =
+    extractErrorMessage(error) ?? 'TeXRA could not finish starting up.';
   const reload = () => window.location.reload();
   render(
     html`
@@ -1169,7 +1165,7 @@ function renderBootstrapFallback(error: unknown): void {
 
 function reportRuntimeFailure(error: unknown): void {
   const shouldReload = window.confirm(
-    `TeXRA encountered an unexpected error.\n\n${toBootstrapErrorMessage(error)}\n\nReload TeXRA now?`,
+    `TeXRA encountered an unexpected error.\n\n${extractErrorMessage(error) ?? 'TeXRA could not finish starting up.'}\n\nReload TeXRA now?`,
   );
   if (shouldReload) window.location.reload();
 }


### PR DESCRIPTION
## What

Deletes the file-local `toBootstrapErrorMessage` helper in `packages/desktop/src/renderer/main.ts` and routes both call sites through the shared `extractErrorMessage` from `@utils/errors/errorMessage` (already in the browser-safe utils allowlist):

1. **Bootstrap failure screen** (`renderBootstrapFallback`)
2. **Runtime-failure confirm dialog** (`reportRuntimeFailure`)

The desktop-owned fallback sentence (`'TeXRA could not finish starting up.'`) is kept via `??` — deliberately *not* `toErrorMessage`, which would `String()`-coerce objects/numbers into user-facing copy where today they get the friendly sentence.

## Behavior deltas (verified, all in the shared helper's favor)

- Empty/whitespace-only `Error.message` or string rejections now fall through to the fallback sentence instead of rendering a blank `<p>` / empty dialog line.
- Messages are trimmed. No input class regresses.

## Net LoC

**−4 prod LoC** (4 insertions, 8 deletions), zero new tests (helper behavior already covered by the shared util's contract; no test pinned the local helper).

## Gates

- `npm run typecheck` — main is currently red with 38 pre-existing errors in `src/test-kernel/cli/StatusBar.vitest.ts`; error list with this change is **byte-identical** to pristine origin/main (no new errors)
- `vitest run src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.ts` — 12/12 pass
- `npx prettier --check .` — clean
- `npm run lint` — clean
- dead-code ratchet: N/A (deleted helper was file-local, no exports moved)