### PR TITLE
fix(settings): emit apiKey banner from the usable-credential check

### DIFF
--- a/packages/extension/src/frontend/secretManager.ts
+++ b/packages/extension/src/frontend/secretManager.ts
@@ -35,13 +35,6 @@ export class SecretManager {
     return resolveGitHubTokenSource(platform().secrets);
   }
 
-  public static async anyApiKeyExists(): Promise<boolean> {
-    const keyChecks = await Promise.all(
-      this.API_PROVIDERS.map((provider) => this.hasUsableApiKey(provider)),
-    );
-    return keyChecks.some(Boolean);
-  }
-
   /** Usable-key check, delegated to `@model/apiProviders`'s `hasUsableApiKey`. */
   public static async hasUsableApiKey(provider: ApiProvider): Promise<boolean> {
     return resolvedHasUsableApiKey(platform().secrets, provider);

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -53,6 +53,7 @@ import {
 } from '@model/runtimeModelRegistry';
 import { setCopilotRoutePreference } from '@model/copilotRouting';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
+import { hasUsableSetupCredential } from '@model/setupCredentialAccess';
 import {
   LANGUAGE_MODEL_PORT_ERROR_CODE,
   LanguageModelPortError,
@@ -642,11 +643,11 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     const usageProvider = codingPlanForApiProvider(provider)?.usageProvider;
     const mainView = await getMainWebview(this.viewName);
     if (mainView) {
-      const anyKeyExists = await SecretManager.anyApiKeyExists();
+      const setupComplete = await hasUsableSetupCredential(platform().secrets);
       mainView.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.SET_BANNER,
         banner: 'apiKey',
-        visible: !anyKeyExists,
+        visible: !setupComplete,
       });
     }
     await this.refreshCredentialDependentSurfaces({


### PR DESCRIPTION
## What

`SettingsViewMessageHandler.refreshAfterProviderKeyChange` emitted the `SET_BANNER apiKey` visibility predicate from `SecretManager.anyApiKeyExists` — API keys only. This was the single repo-wide emission of the banner predicate, and `anyApiKeyExists` had exactly one caller (this site).

Every other setup-completeness surface uses the usable-credential check:

- status pill (`extension.ts`)
- onboarding gate (`extension.ts`)
- funnel (`MainViewProvider.ts`)
- desktop (`main/index.ts`, which carries a "single source of truth … can't drift" comment this emission violated)

## Behavior change (intentional)

A **subscription-only user** (Codex/ChatGPT subscription, no API keys) previously got `visible: true` on the apiKey banner after any key-related refresh, while pill/onboarding/funnel/desktop all said setup was complete. The banner now agrees with every other surface: setup complete means no banner.

## Change

- Emit from `hasUsableSetupCredential(platform().secrets)` (`@model/setupCredentialAccess`) — the same policy the desktop/pill surfaces use. Deliberately *not* the `hasAnyUsableSetupCredential()` wrapper from `@commands/setup/setupAssistantCommand` (a settings-view handler importing a commands module inverts the layer, and that wrapper is itself slated for inlining).
- Delete `SecretManager.anyApiKeyExists` (sole caller replaced). The `SecretManager` import in the handler stays (`API_PROVIDERS`).

## Net LoC

**−6 prod LoC** (3 insertions, 9 deletions). Zero new tests — nothing pinned the predicate.

## Gates

- `npm run typecheck` — error list byte-identical to pristine origin/main (38 pre-existing errors in `StatusBar.vitest.ts`, none from this change)
- `vitest run` on SubscriptionUsageExtensionLifecycle, SetupCredentialAccess, MainViewMessageHandler — 15/15 pass
- `npx prettier --check .` — clean
- `npm run lint` — clean
- `npm run check:dead-code-ratchet` — OK (8 vs 8 baseline)