### PR TITLE
refactor(settings): drop the orchestrator name heuristic in MultiAgentTab

### DIFF
--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -227,13 +227,7 @@ export class MultiAgentTab extends LitElement {
   }
 
   private isOrchestratorAgent(name: string): boolean {
-    // Prefer the capability-based list (catches roots like `engineer` that
-    // don't carry "orchestrator" in their name); keep the name heuristic as a
-    // fallback for presets referencing agents the registry hasn't loaded.
-    return (
-      this.orchestratorAgents.includes(name) ||
-      name.toLowerCase().includes('orchestrator')
-    );
+    return this.orchestratorAgents.includes(name);
   }
 
   private renderPresetCard(


### PR DESCRIPTION
## What

`MultiAgentTab.isOrchestratorAgent` split preset members into orchestrators vs teammates with:

```ts
this.orchestratorAgents.includes(name) || name.toLowerCase().includes('orchestrator')
```

The name-substring disjunct was the **only name-based capability heuristic repo-wide**, and its comment's stated fallback purpose ("agents the registry hasn't loaded") is stale:

- **Built-in roots**: the wire owner, `SettingsAgentCatalogController.getOrchestratorAgentNames()`, seeds `BUILTIN_TEAM_ROOT_AGENT_NAMES` **unconditionally** (before adding `hasDelegationTool` matches over loaded catalog agents), so built-ins are in the wire list whether or not the registry has loaded them.
- **Unloaded custom agents**: a name match cannot detect delegation capability — a custom agent named `foo-orchestrator` without a delegation tool would be mislabeled, and a delegating agent not named "orchestrator" would be missed. Launch semantics are capability-based throughout.

## Change

Delete the disjunct and its 3 comment lines. The method stays (two call sites in `renderPresetCard`). No test pinned the heuristic — all `orchestrator` hits in `src/test-kernel/settings/` are wire-list/roster tests; `MultiAgentTab.vitest.ts` never references it.

## Behavior delta

A preset member whose name merely *contains* "orchestrator" but is not in the capability-based wire list now renders as a teammate instead of an orchestrator in preset cards. This is the label agreeing with launch semantics.

## Net LoC

**−6 prod LoC** (1 insertion, 7 deletions). Zero new tests.

## Gates

- `npm run typecheck` — clean, 0 errors (main is green again after the #11111 revert)
- `vitest run src/test-kernel/settings/MultiAgentTab.vitest.ts` — 3/3 pass
- `npx prettier --check .` — clean
- `npm run lint` — clean
- dead-code ratchet: N/A (private method, no exports moved)