### PR TITLE
refactor: drop write-only FileListEntry fields and dead terminal styles; fix stale doc comments

### DIFF
--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -50,12 +50,13 @@ function fillColor(percent: number): string {
 }
 
 /**
- * Single owner of the free-tier decision for a usage route: `null` when the
- * route has no badge (plain cost), otherwise `free` (subscription route with
- * zero cost) plus the two label forms the summary and the visible footer use.
- * Both the shared {@link usageCostLabel} and
- * {@link UsagePanel.renderCostRoute} consume this, so changing a subscription
- * route touches one place.
+ * Free-tier decision for the visible footer badge: `null` when the route has
+ * no badge (plain cost), otherwise `free` (subscription route with zero
+ * cost) plus the badge's label forms. Only
+ * {@link UsagePanel.renderCostRoute} consumes this; the aria summary's shared
+ * {@link usageCostLabel} re-derives the same `subscription && cost === 0`
+ * predicate from `usageRouteBadge`, so changing a subscription route touches
+ * both.
  */
 function usageRouteDecision(
   cost: number,
@@ -317,7 +318,7 @@ export class UsagePanel extends LitElement {
     if (!this.usage) return '';
     const { inputTokens, outputTokens, cost } = this.usage;
     // The shared rule omits a zero-cost unknown route; the aria summary
-    // still states it as "$0.00".
+    // still states it as "$0.000".
     const costLabel =
       usageCostLabel(cost, this.usage.usageRoute) ?? formatCostUsd(cost);
     return `Total usage: ${formatCompactTokenCount(inputTokens)} input tokens, ${formatCompactTokenCount(outputTokens)} output tokens, ${costLabel}`;

--- a/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -277,10 +277,9 @@ export function buildFileListRender(
     const loaded = mediaByPath.get(filePath);
 
     // The one rule for a loaded file's source label, shared with the CLI
-    // (transcriptRowLines): paint `sourceDisplay`, nothing else. Raw `source`
-    // is a producer-side code identifier (`requiredFilesInternal`, a tool
-    // name) and must never reach a user — an entry worth labelling sets
-    // `sourceDisplay`, so no host needs a fallback to spell it out.
+    // (transcriptRowLines): paint `sourceDisplay`, nothing else — an entry
+    // worth labelling sets `sourceDisplay`, so no host needs a fallback to
+    // spell it out.
     // prettier-ignore
     return html`<li class="detail-item" title=${filePath}>${waIcon(iconName)} ${buildFileLinkSpan(filePath, fileName)}${file.varName ? html` <span class="file-var">[${file.varName}]</span>` : ''}${file.sourceDisplay ? html` <span class="file-source">(${file.sourceDisplay})</span>` : ''}${loaded ? html` <span class="file-media">[${loaded.kind}, ${formatBytes(loaded.sizeBytes)}]</span>` : ''}</li>`;
   })}`;

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -468,36 +468,10 @@ export const logEntryStyles = css`
     overflow: hidden;
   }
 
-  :host([terminal]) .log-line {
-    padding: 0;
-    line-height: 1.35;
-    word-break: normal;
-    overflow-wrap: anywhere;
-  }
-
   @container (max-width: 640px) {
     .log-container {
       padding-inline: var(--wa-space-xs);
     }
-  }
-
-  /* Bullet/timestamp prefix is noisy for raw process output. */
-  :host([terminal]) .log-line .timestamp {
-    display: none;
-  }
-
-  /* stdout renders at terminal foreground; stderr keeps a warn tint. */
-  :host([terminal]) .message-info,
-  :host([terminal]) .message-debug {
-    color: inherit;
-  }
-
-  :host([terminal]) .message-warn {
-    color: var(--wa-color-terminal-ansi-yellow, var(--color-warning));
-  }
-
-  :host([terminal]) .message-error {
-    color: var(--wa-color-terminal-ansi-red, var(--color-error));
   }
 `;
 

--- a/src/agent/prompt/userVars.ts
+++ b/src/agent/prompt/userVars.ts
@@ -130,11 +130,10 @@ export function buildUserVarPassthrough(): Readonly<Record<string, string>> {
 
 /**
  * Information about a loaded file for prompt variable substitution.
- * Extends FileListEntry with required source and varName fields.
+ * Extends FileListEntry with a required varName field.
  * Compatible with FileListEntry (can be passed to AgentTrace.fileList).
  */
 type LoadedFileEntry = FileListEntry & {
-  source: string;
   varName: string;
 };
 
@@ -521,8 +520,6 @@ async function getRequiredFileVars(
       path: fullPath,
       ok,
       varName,
-      source: 'requiredFilesInternal',
-      internal: true,
     });
   }
   return { vars, files };

--- a/src/agent/trace/helpers.ts
+++ b/src/agent/trace/helpers.ts
@@ -200,8 +200,8 @@ export function logFilesLoaded(
 }
 
 /**
- * Files-loaded card built from path/ok pairs — the category becomes both
- * the source label and the display label.
+ * Files-loaded card built from path/ok pairs — the category becomes the
+ * display label.
  */
 export function logFileCategory(
   trace: AgentTrace,
@@ -213,7 +213,6 @@ export function logFileCategory(
   const entries: FileListEntry[] = files.map((f) => ({
     path: f.path,
     ok: f.ok === true,
-    source: category,
     sourceDisplay: category,
   }));
   logFilesLoaded(trace, category, entries, stageId);

--- a/src/shared/copy/modelAccess.ts
+++ b/src/shared/copy/modelAccess.ts
@@ -87,10 +87,11 @@ export function usageRouteBadge(
 /**
  * One sentence stating what a usage record cost and who paid for it.
  *
- * Three outcomes: subscription routes with zero cost are free, a known route
- * is billed "via" its payment name, and an unknown route with no cost has
- * nothing to say (`undefined`) so callers can omit the line entirely rather
- * than print "$0.00" for a session that never reached a model.
+ * Four outcomes: a subscription route with zero cost is free, a known route
+ * is billed "via" its payment name, an unknown route with a cost shows the
+ * bare amount, and an unknown route with no cost has nothing to say
+ * (`undefined`) so callers can omit the line entirely rather than print
+ * "$0.000" for a session that never reached a model.
  */
 export function usageCostLabel(
   cost: number,

--- a/src/shared/schemas/log.ts
+++ b/src/shared/schemas/log.ts
@@ -98,10 +98,8 @@ export type LoadedMediaMetadata = z.infer<typeof LoadedMediaMetadataSchema>;
 export const FileListEntrySchema = z.object({
   path: z.string(),
   ok: z.boolean(),
-  source: z.string().optional(),
   sourceDisplay: z.string().optional(),
   varName: z.string().optional(),
-  internal: z.boolean().optional(),
   /** Present only when this file was loaded through the media pipeline. */
   media: LoadedMediaMetadataSchema.optional(),
 });

--- a/src/shared/schemas/proposalFields.ts
+++ b/src/shared/schemas/proposalFields.ts
@@ -26,7 +26,9 @@ export const WorkflowSpecificFieldsSchema = FileFieldsSchema.extend({
   toolConfig: ToolConfigSchema,
 });
 
-/** File fields shape used by all three rendering sites (toolFormatters, RequestPanels, PermissionCard). */
+/** File fields shape consumed by {@link getProposalFileGroups} — the helper
+ *  behind every proposal file list (tool-row model, ProposalRequestPanel,
+ *  CLI approval summaries). */
 interface FileFields {
   readonly inputFiles?: readonly string[];
   readonly contextFiles?: readonly string[];

--- a/src/test-kernel/agent/trace/AgentTrace.vitest.ts
+++ b/src/test-kernel/agent/trace/AgentTrace.vitest.ts
@@ -223,14 +223,13 @@ describe('logFileCategory', () => {
     expect(messages[0].text).toBe(expected);
   });
 
-  it('includes source and sourceDisplay in entry data', () => {
+  it('includes sourceDisplay in entry data', () => {
     logFileCategory(logger, 'Input Files', [
       { path: '/path/file.tex', ok: true },
     ]);
 
     const entries = capturedMessages()[0].data;
     expect(entries).toHaveLength(1);
-    expect(entries[0].source).toBe('Input Files');
     expect(entries[0].sourceDisplay).toBe('Input Files');
     expect(entries[0].path).toBe('/path/file.tex');
     expect(entries[0].ok).toBe(true);


### PR DESCRIPTION
## Summary

Round 4 of the 2026-08-19 dead-surface sweep: two deletions + two comment corrections, all re-verified against live `origin/main` before editing (none stale). 9 files, +23/−53. No new tests; the only test edit is one assertion removal forced by the field deletion.

Closes #11147, closes #11134, closes #11132, closes #11138.

### #11147 — write-only `FileListEntry.source`/`.internal`
Zero production readers (both hosts paint only `sourceDisplay`; #11124's removal confirmed). Three writers deleted: the schema fields (`src/shared/schemas/log.ts:101,104`), `logFileCategory`'s `source: category` write, and the `source: 'requiredFilesInternal'` + `internal: true` writes in `userVars.ts` (`LoadedFileEntry.source` dropped too). Two comments naming the deleted field reworded. One existing test (`AgentTrace.vitest.ts`) asserted `entries[0].source` — assertion dropped, test renamed.

**Wire-compat ruling evidence:** `FileListEntrySchema` is a plain `z.object`, deliberately not strict (the same file uses `z.strictObject` at :111 where strictness is wanted); zod strips unknown keys without rejecting. Persisted logs parse per-entry via `StreamLogEntrySchema.safeParse` (`StreamLogStore.ts:1710`), whose FILE_LIST payload is `z.array(FileListEntrySchema)` — legacy entries carrying `source`/`internal` parse successfully; nothing re-writes whole persisted logs through the schema, so no silent drop/reject of legacy entries. The retired keys simply vanish from the typed view — the intended retirement semantics, since nothing reads them.

### #11134 — dead `:host([terminal])` rules
Terminal mode short-circuits to `renderTerminalOutput()` (bare `<terminal-output>`, joined raw text); no row formatter runs, so `.log-line`/`.timestamp`/`.message-*` elements never exist under it. Deleted the three rule groups; kept `:host([terminal]) .log-container` (supplies `--wa-color-terminal-*` custom properties + `overflow: hidden`).

### #11132 — stale `PermissionCard` rendering-site comment
`PermissionCard` exists nowhere; the bare `FileFields` interface is unexported with zero importers, and `RequestPanels.ts` consumes no file groups — the "three rendering sites" claim was entirely stale. Comment now names the real `getProposalFileGroups` consumers: `toolRowModel.ts` (shared fold → webview toolSections + CLI), `ProposalRequestPanel.ts`, CLI `approvalSummaries.ts`. Comment-only.

### #11138 — usage-copy doc comments
All three claims verified: (a) `usageCostLabel` has four observable outcomes (the `!badge && cost > 0 → formatCostUsd(cost)` branch was undocumented) and `formatCostUsd` renders `$0.000` (`.toFixed(3)`), not `$0.00` — JSDoc rewritten; (b) `UsagePanel.buildUsageLabel` figure corrected to `$0.000`; (c) `usageRouteDecision` JSDoc's "both consume / one place" claim was false — `usageCostLabel` calls `usageRouteBadge` directly and re-derives the predicate; only `renderCostRoute` consumes the decision. Comment-only.

## Issue acceptance gates

- #11147: zero readers; wire-compat evidence above; fixture needed no change (never set the fields). ✅
- #11134: no remaining selector under `:host([terminal])` references `.log-line`/`.message-*`. ✅
- #11132 / #11138: comment-only, claims re-verified against code. ✅

## Single source of truth

- File-list source labeling: `sourceDisplay` alone.
- Terminal-mode styling: `<terminal-output>` + the `.log-container` custom properties.
- Usage-cost sentence: `usageCostLabel`; route decision consumed by `renderCostRoute` alone (comments now say so).

## Duplication and abstraction budget

Removed: 2 schema fields + 3 write sites, 3 dead CSS rule groups, 3 stale comment blocks. Added: 0 exports, 0 files, 0 layers.

## Net elements (R6)

- 9 files, +23/−53 (net −30).
- Deleted symbols: `FileListEntrySchema.source`, `FileListEntrySchema.internal`, `LoadedFileEntry.source`. No exports removed (fields only).

## Consumer counts (R8)

- `FileListEntry.source`: 0 production readers / 3 writers deleted / 1 test assertion removed.
- `FileListEntry.internal`: 0 readers / 1 writer.
- Dead CSS selectors: 0 matching elements (terminal mode renders no `.log-line`).

## Host impact

Extension: dead CSS + comment fixes only.
Desktop: none.
CLI: comment fix in shared schema docs; no behavior change.

## Scheduled refactoring

`usageRouteDecision`'s returned `label` field is write-only (sole consumer reads only `free`/`compactLabel`) — micro-deletion candidate for a future round, not done here.

## Validation

- `prettier --write` on all 9 files — clean.
- `typecheck:workspace` — pass. `typecheck:test-kernel` on the branch base showed 38 errors from fleet PR #11111 (since reverted on main by #11151; this branch is rebased onto the revert — pristine-base reproduction confirmed the errors were not ours).
- Targeted vitest: AgentTrace, userVars, UserVarsDelegationScope, SubagentListDisplay, UsagePanel, StreamLogStoreLoad — 151/151; transcript + progressView suites — 823/823 (69 files); architecture ratchets — 104/104.
- ESLint on changed files — exit 0. `check:dead-code-ratchet` — 8 current vs 8 baselined, OK.
