### PR TITLE
fix(desktop): redact mixed-separator paths in log-viewer text

### DIFF
--- a/packages/desktop/src/main/desktopAppLog.ts
+++ b/packages/desktop/src/main/desktopAppLog.ts
@@ -18,7 +18,7 @@ import {
 } from 'electron';
 
 import { redactSecrets } from '@logger/redaction';
-import { normalizeFilePath } from '@utils/core';
+import { normalizeFilePath, unique } from '@utils/core';
 
 import type { DesktopLogSnapshot } from '../shared/desktopLogMessages.js';
 
@@ -62,9 +62,10 @@ export function readDesktopLogSnapshot(options: {
 }): DesktopLogSnapshot {
   const path = getDesktopLogFilePath();
   const maxBytes = Math.max(0, options.maxBytes ?? MAX_VIEWER_LOG_BYTES);
-  const workspacePath = options.workspacePath;
-  const displayWorkspacePath =
-    workspacePath == null ? undefined : normalizeFilePath(workspacePath);
+  const workspacePath =
+    options.workspacePath == null
+      ? undefined
+      : normalizeFilePath(options.workspacePath);
   try {
     const buffer = readFileSync(path);
     const truncated = buffer.length > maxBytes;
@@ -72,13 +73,13 @@ export function readDesktopLogSnapshot(options: {
       ? buffer.subarray(buffer.length - maxBytes)
       : buffer;
     return {
-      path: redactDesktopLogPath(normalizeFilePath(path), displayWorkspacePath),
+      path: redactDesktopLogText(normalizeFilePath(path), workspacePath),
       truncated,
       text: redactDesktopLogText(excerpt.toString('utf8'), workspacePath),
     };
   } catch (error) {
     return {
-      path: redactDesktopLogPath(normalizeFilePath(path), displayWorkspacePath),
+      path: redactDesktopLogText(normalizeFilePath(path), workspacePath),
       truncated: false,
       text: redactDesktopLogText(
         format('Desktop log is not available: %s', error),
@@ -165,16 +166,16 @@ function redactDesktopLogText(
   text: string,
   workspacePath: string | undefined,
 ): string {
-  return redactSecrets(redactPathPrefixes(text, workspacePath, homedir()));
+  return redactSecrets(
+    redactPathPrefixes(text, workspacePath, normalizeFilePath(homedir())),
+  );
 }
 
-function redactDesktopLogPath(
-  path: string,
-  workspacePath: string | undefined,
-): string {
-  return redactSecrets(
-    redactPathPrefixes(path, workspacePath, normalizeFilePath(homedir())),
-  );
+/** Both separator spellings of a prefix, so mixed-separator log text redacts. */
+function separatorVariants(prefix: string): string[] {
+  const forward = normalizeFilePath(prefix);
+  const backward = forward === '/' ? forward : forward.replaceAll('/', '\\');
+  return unique([prefix, forward, backward]);
 }
 
 function redactPathPrefixes(
@@ -183,6 +184,7 @@ function redactPathPrefixes(
 ): string {
   return prefixes
     .filter((prefix): prefix is string => Boolean(prefix))
+    .flatMap(separatorVariants)
     .toSorted((a, b) => b.length - a.length)
     .reduce((redacted, prefix) => {
       if (prefix === '/') {


### PR DESCRIPTION
## What

`readDesktopLogSnapshot` (`packages/desktop/src/main/desktopAppLog.ts`) had a raw-vs-normalized asymmetry: the snapshot's **path field** was scrubbed against normalized prefixes while the **log text** was scrubbed against raw ones, and `redactPathPrefixes` matched only the exact separator spelling it was handed.

On Windows this leaks: log text that spells the workspace or home directory with forward slashes (`C:/Users/alice` — common in forwarded URIs, POSIX-style tooling output, git paths) slipped past log-viewer redaction when the prefix came back from the OS backslash-spelled (`C:\Users\alice`).

## Fix

- `redactPathPrefixes` now expands every prefix into both separator variants, mirroring the crash engine's `pathVariants` in `desktopCrashEventScrubber.ts` (no shared compiler extracted — that consolidation was considered and rejected: ~zero LoC payoff, re-litigates #10604, silently widens unpinned behavior).
- The snapshot's path and text surfaces now share **one** redaction helper over normalized prefixes (the raw-vs-normalized asymmetry is gone); the now-identical `redactDesktopLogPath` wrapper is deleted.

## Test

One regression test (the charter's earned single test): forward-slash log text under a backslash-spelled workspace redacts to `[path]`. **Verified it fails on the old code and passes with the fix.**

Brief deviation, with evidence: the brief said to add the pin to `DesktopLogRedaction.vitest.ts` because "nothing pins `[path]` today" — that suite scopes to `redactSecrets` from `@logger/redaction` and has no electron harness; the `[path]` pins (5 tests) and the electron-stub harness live in `DesktopAppLog.vitest.ts`, so the case lands there.

## Net LoC

**+1 prod LoC** (15 insertions, 14 deletions), +9 test LoC. Net-positive, stated honestly — this is a hardening fix, not a deletion.

## Gates

- `npm run typecheck` — clean, 0 errors
- `vitest run` DesktopAppLog + DesktopLogRedaction — 11/11 pass (new test verified red on old code)
- `npx prettier --check .` — clean
- `npm run lint` — clean
- dead-code ratchet: N/A (deleted wrapper was file-local)