### PR TITLE
docs: clarify delegation parser location

### DIFF
--- a/src/shared/schemas/proposalInput.ts
+++ b/src/shared/schemas/proposalInput.ts
@@ -9,8 +9,8 @@
  * It lives in the schema layer (not the renderer) because it encodes domain
  * knowledge rather than presentation: which delegation tools map to which agent
  * category and the `extractFigures` / `extractTikz` shorthand → `toolConfig`
- * mapping. The renderer parses the delegation input directly via
- * `parseDelegationToolInput` (in `toolFormatters.ts`).
+ * mapping. The renderer calls `parseDelegationToolInput` from
+ * `toolFormatters.ts`.
  *
  * The schemas here are deliberately lenient: the LLM may omit fields the
  * canonical proposal schema requires, so display-only defaults


### PR DESCRIPTION
## Summary

Correct the schema-layer comment merged in #11146: `parseDelegationToolInput` is defined in `proposalInput.ts` and called from `toolFormatters.ts`. No runtime behavior changes.

## Validation

- Targeted Prettier check
- Targeted ESLint
- `git diff --check`

No tests added or modified.