### PR TITLE
fix(trace): restore FileListEntry source contract after #11156

### DIFF
--- a/src/agent/prompt/userVars.ts
+++ b/src/agent/prompt/userVars.ts
@@ -130,10 +130,11 @@ export function buildUserVarPassthrough(): Readonly<Record<string, string>> {
 
 /**
  * Information about a loaded file for prompt variable substitution.
- * Extends FileListEntry with a required varName field.
+ * Extends FileListEntry with required source and varName fields.
  * Compatible with FileListEntry (can be passed to AgentTrace.fileList).
  */
 type LoadedFileEntry = FileListEntry & {
+  source: string;
   varName: string;
 };
 
@@ -520,6 +521,7 @@ async function getRequiredFileVars(
       path: fullPath,
       ok,
       varName,
+      source: 'requiredFilesInternal',
     });
   }
   return { vars, files };

--- a/src/agent/trace/helpers.ts
+++ b/src/agent/trace/helpers.ts
@@ -200,8 +200,8 @@ export function logFilesLoaded(
 }
 
 /**
- * Files-loaded card built from path/ok pairs — the category becomes the
- * display label.
+ * Files-loaded card built from path/ok pairs — the category becomes both
+ * the source label and the display label.
  */
 export function logFileCategory(
   trace: AgentTrace,
@@ -213,6 +213,7 @@ export function logFileCategory(
   const entries: FileListEntry[] = files.map((f) => ({
     path: f.path,
     ok: f.ok === true,
+    source: category,
     sourceDisplay: category,
   }));
   logFilesLoaded(trace, category, entries, stageId);

--- a/src/shared/schemas/log.ts
+++ b/src/shared/schemas/log.ts
@@ -98,6 +98,7 @@ export type LoadedMediaMetadata = z.infer<typeof LoadedMediaMetadataSchema>;
 export const FileListEntrySchema = z.object({
   path: z.string(),
   ok: z.boolean(),
+  source: z.string().optional(),
   sourceDisplay: z.string().optional(),
   varName: z.string().optional(),
   /** Present only when this file was loaded through the media pipeline. */

--- a/src/shared/schemas/proposalFields.ts
+++ b/src/shared/schemas/proposalFields.ts
@@ -28,7 +28,7 @@ export const WorkflowSpecificFieldsSchema = FileFieldsSchema.extend({
 
 /** File fields shape consumed by {@link getProposalFileGroups} — the helper
  *  behind every proposal file list (tool-row model, ProposalRequestPanel,
- *  CLI approval summaries). */
+ *  CLI AgentProposal modal, approval summaries). */
 interface FileFields {
   readonly inputFiles?: readonly string[];
   readonly contextFiles?: readonly string[];

--- a/src/test-kernel/agent/trace/AgentTrace.vitest.ts
+++ b/src/test-kernel/agent/trace/AgentTrace.vitest.ts
@@ -223,13 +223,14 @@ describe('logFileCategory', () => {
     expect(messages[0].text).toBe(expected);
   });
 
-  it('includes sourceDisplay in entry data', () => {
+  it('includes source and sourceDisplay in entry data', () => {
     logFileCategory(logger, 'Input Files', [
       { path: '/path/file.tex', ok: true },
     ]);
 
     const entries = capturedMessages()[0].data;
     expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('Input Files');
     expect(entries[0].sourceDisplay).toBe('Input Files');
     expect(entries[0].path).toBe('/path/file.tex');
     expect(entries[0].ok).toBe(true);


### PR DESCRIPTION
## Summary

Follow-up to #11156 after it merged before the requested repair:

- restore optional `FileListEntry.source` in the schema
- restore both production writers (`logFileCategory` and `requiredFilesInternal`) and the required `source` member on `LoadedFileEntry`
- restore `AgentTrace.vitest.ts` exactly to its pre-#11156 content, preserving the existing source contract without adding or changing tests
- name the CLI `AgentProposal` modal in the `getProposalFileGroups` consumer comment

The independent `FileListEntry.internal` deletion and the other valid dead-code/comment cleanup from #11156 remain intact.

## Checks

- `corepack pnpm exec prettier --check src/agent/prompt/userVars.ts src/agent/trace/helpers.ts src/shared/schemas/log.ts src/shared/schemas/proposalFields.ts src/test-kernel/agent/trace/AgentTrace.vitest.ts`
- `corepack pnpm exec eslint src/agent/prompt/userVars.ts src/agent/trace/helpers.ts src/shared/schemas/log.ts src/shared/schemas/proposalFields.ts src/test-kernel/agent/trace/AgentTrace.vitest.ts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/trace/AgentTrace.vitest.ts src/test-kernel/agent/prompt/userVars.vitest.ts` (34 passed)
- `corepack pnpm run typecheck`
- `corepack pnpm run check:dead-code-ratchet`
- `corepack pnpm run build:fast`
