### PR TITLE
fix(copy): retire relay-era "included access" vocabulary from live surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project will be documented in this file.
 
 ### Shared (all surfaces)
 
+#### Breaking Changes
+
+- **TeXRA-hosted "included" model access has been retired** — model calls now
+  run on your own provider API key, a ChatGPT or Grok sign-in subscription, or
+  the API key for a Kimi Code or GLM Coding Plan subscription. Signing in with
+  GitHub or Google still unlocks the hosted remote-agent catalog, including the
+  orchestrator, and remains free for academics through the Researcher Access
+  Program — but the agents it unlocks run on your configured model credential,
+  so sign-in alone is no longer enough to start a run. Onboarding and setup
+  guidance now reflect that distinction.
+
 #### Features
 
 - **Export a conversation from the progress toolbar** — Markdown, HTML, and

--- a/README.md
+++ b/README.md
@@ -26,17 +26,18 @@ npm install -g @texra-ai/cli
 brew install texra-ai/tap/texra
 ```
 
-Sign in with GitHub or Google for hosted access (no key management
-required), or set `<PROVIDER>_API_KEY` to use your own credentials.
+Set `<PROVIDER>_API_KEY` to use your own credentials, sign in with a
+ChatGPT or Grok subscription, or add the API key for a Kimi Code or
+GLM Coding Plan subscription.
 
 ### Researcher Access Program
 
-Academic researchers can sign in for complimentary hosted access to
-a curated set of budget-friendly models — enough to run the
-Orchestrator and the full roster of hosted specialists on real work,
-without managing provider keys or paying per-token rates. Sign in
-through the Profile view in VS Code, or `texra login` in the
-terminal.
+Academic researchers can sign in with GitHub or Google for
+complimentary access to the hosted agent catalog — the Orchestrator
+and the full roster of hosted specialists. Sign in through the
+Profile view in VS Code, or `texra login` in the terminal. The agents
+are free; their model calls run on your configured model credential,
+the same as your built-in agents.
 
 The program is sustained by the community. If TeXRA helps your
 research, consider supporting it via

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -965,7 +965,7 @@ function createWindow(options: {
         const message = await buildDesktopSetupExecuteMessage();
         if (!message) {
           await showErrorMessage(
-            'No model is available for your current credentials. Sign in with ChatGPT, add a provider API key, or check your Researcher Access tier, then try setup again.',
+            'No model is available for your current credentials. Sign in with ChatGPT or add a provider or coding-plan API key in Models, then try setup again.',
           );
           // Throw so the onboarding IPC clears its kickoff guard and a later
           // credential change can re-trigger the auto-start.

--- a/packages/extension/resources/tool_use_agents/setup.yaml
+++ b/packages/extension/resources/tool_use_agents/setup.yaml
@@ -139,9 +139,9 @@ prompts:
          ~/.zshrc`. The user's normal bash approval dialog is the gate; do
          not bypass it. Tell the user to open a new terminal afterward.
       D. Credentials: see "Setting up credentials" below. This phase
-         MUST complete (Researcher Access sign-in OR at least one usable
-         API key) before phase I. If the probe shows no credential, do
-         not skip ahead.
+         MUST complete (active ChatGPT subscription access OR at least
+         one usable provider or coding-plan key) before phase I. If the
+         probe shows no credential, do not skip ahead.
       E. Roster: ask, if their intro didn't already tell you, what
          they're working on, then apply the matching team with
          `apply_team`: `mathematician`, `physicist`, `cs-ml`,
@@ -168,17 +168,11 @@ prompts:
 
     ## Setting up credentials (phase D: required)
 
-    TeXRA needs one credential path: Researcher Access, ChatGPT
-    subscription for Codex models, or a real API key for a supported
-    provider. Pick the path that fits the user; don't push more than one.
+    TeXRA needs one runnable-model credential path: active ChatGPT
+    subscription access for Codex models, or a usable provider or
+    coding-plan key. Pick the path that fits the user; don't push more
+    than one.
 
-      - **Researcher Access (recommended, free):** extension:
-        `invoke_command` with `texra.auth.signIn`; CLI: tell the user
-        to use `/login texra`; desktop: direct them to Account. The
-        browser flow handles the rest. Afterwards re-run
-        `probe_environment` to confirm `auth.authenticated` flipped to
-        `true`. Mention that signing in also unlocks remote agents like
-        the orchestrator.
       - **ChatGPT subscription for Codex models:** for users who already
         have ChatGPT Plus/Pro/Team and want Codex models. Extension:
         `invoke_command` with `texra.showModels`; CLI: `/login chatgpt`;
@@ -211,9 +205,16 @@ prompts:
         access (`moonshot`, `MOONSHOT_API_KEY`) from Kimi Code
         membership (`kimiCode`, `KIMI_CODE_API_KEY`).
         Never suggest `KIMI_API_KEY` as a TeXRA credential name.
-      - After either path, re-probe and tell the user which credential
-        is now active. If neither sign-in nor a usable key is present,
-        do not advance to phase I.
+      - After either model-credential path, re-probe and tell the user
+        which credential is now active. If neither ChatGPT subscription
+        access nor a usable key is present, do not advance to phase I.
+      - **Researcher Access (optional remote-agent catalog):** this does
+        not provide model access or satisfy phase D. Once a runnable-model
+        credential is in place, offer it when the user wants hosted remote
+        agents such as the orchestrator. Extension: `invoke_command` with
+        `texra.auth.signIn`; CLI: `/login texra`; desktop: Account. After
+        the browser flow, re-run `probe_environment` to confirm
+        `auth.authenticated` flipped to `true`.
 
     ## Touching settings (read first, then update)
 

--- a/packages/extension/resources/walkthroughs/getting-started.md
+++ b/packages/extension/resources/walkthroughs/getting-started.md
@@ -8,9 +8,11 @@ The shortest path is: choose a credential, run setup once, then let the orchestr
 
 A credential is the one step no agent can do for you. Three ways in:
 
-- **Use ChatGPT subscription** -- ChatGPT Plus/Pro/Team can route Codex models through your ChatGPT plan.
-- **Sign in with Researcher Access** -- Free for academics; no API key needed. Signing in also unlocks remote agents, including the orchestrator.
-- **Use your own provider API key** -- Anthropic, OpenAI, Google, and more. Except for Codex through ChatGPT subscription, chat subscriptions (Claude Pro, ChatGPT for non-Codex models, etc.) do not include API access; you need a key from the provider's developer platform.
+- **Sign in with ChatGPT** -- ChatGPT Plus/Pro/Team routes Codex models through your ChatGPT plan.
+- **Add a coding-plan key** -- Kimi Code and GLM Coding Plan use membership or subscription API keys from their provider consoles.
+- **Use your own provider API key** -- Anthropic, OpenAI, Google, and more. Other chat subscriptions, including Claude Pro, do not include API access; you need a key from the provider's developer platform.
+
+Signing in with GitHub or Google (free for academics through the Researcher Access Program) unlocks the hosted remote-agent catalog, including the orchestrator. It is not a credential on its own -- remote agents run on the same credential as your built-in agents.
 
 You can also pick **Skip for now** and come back later, but nothing below runs without a credential.
 
@@ -30,7 +32,7 @@ It asks before every command and explains what it's about to do. You stay in con
 
 ## 3. Meet the orchestrator
 
-After setup, the **orchestrator** is the habit. You don't pick from 23 agents -- give it your paper, it figures out what needs work, and hands each task to the right agent. You just approve the proposals as they come in. On your own API key, start with **assistant** instead; the orchestrator is served through Researcher Access.
+After setup, the **orchestrator** is the habit. You don't pick from 23 agents -- give it your paper, it figures out what needs work, and hands each task to the right agent. You just approve the proposals as they come in. The orchestrator is a hosted remote agent -- sign in to unlock it; it then runs on your own credential, same as any built-in agent. Not signed in? Start with **assistant** instead.
 
 You can still run any single agent yourself when you want one specific thing -- fix grammar, draw a diagram, get a review.
 

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -150,14 +150,15 @@ async function refreshApiKeyStatus() {
   }
 
   // Use the same credential predicate as the setup assistant and onboarding
-  // funnel. This keeps ChatGPT subscription, Researcher Access, and direct API
-  // keys in agreement about whether the first-run CTA should remain visible.
+  // funnel, so ChatGPT subscription and direct API keys agree about whether the
+  // first-run CTA should remain visible. Account sign-in is deliberately not in
+  // that set: it serves the remote-agent catalog, not model access.
   const exists = await hasAnyUsableSetupCredential();
   if (!exists) {
     statusBarItem?.hide();
     apiKeyStatusBarItem.text = '$(rocket) TeXRA: Get Started';
     apiKeyStatusBarItem.tooltip =
-      'Click to run the setup assistant — sign in, use ChatGPT, or add an API key';
+      'Click to run the setup assistant — use ChatGPT or add a provider key';
     apiKeyStatusBarItem.command = EXTENSION_COMMANDS.RUN_SETUP_ASSISTANT;
     apiKeyStatusBarItem.accessibilityInformation = {
       label: 'TeXRA setup, get started',

--- a/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
@@ -260,7 +260,7 @@ export class OnboardingWelcomeCard extends LitElement {
                 <span>1. Connect</span>
               </span>
               <p class="path-step__copy">
-                ChatGPT subscription, Researcher Access, or a provider API key.
+                A ChatGPT subscription or your own provider API key.
               </p>
             </div>
             <div class="path-step" role="listitem">

--- a/src/agent/runtime/helperModelPreference.ts
+++ b/src/agent/runtime/helperModelPreference.ts
@@ -19,7 +19,7 @@ import { getHelperModelName } from './helperModelName';
  * Swap `config`'s model for the configured helper model, or return it unchanged
  * when the helper model already equals it, a tool-use agent's helper model can't
  * call functions (the tool-use flow would strip its tools), or the helper model
- * is unavailable in the active API mode.
+ * is unavailable.
  */
 export async function applyHelperModelPreference(
   config: AgentConfig,

--- a/src/auth/authFlowEffects.ts
+++ b/src/auth/authFlowEffects.ts
@@ -12,12 +12,12 @@
  * resolver; onboarding is refreshed separately by the desktop session-change
  * handler. Ordinary CLI login and logout commands exit without consuming
  * model options. Persistent CLI callers own their subsequent transition before
- * reading credential-dependent state: onboarding applies its selected access
- * mode, the orchestration launcher invalidates its model list, and the chat TUI
- * updates its session API mode and views. Within that persistent CLI session,
- * setup-agent team sign-in immediately refreshes and rereads the remote agent
- * catalog before applying the selected team. Collapsing these effects would
- * either omit host refresh work or repeat it.
+ * reading credential-dependent state: onboarding invalidates its model-options
+ * cache, the orchestration launcher invalidates its model list, and the chat
+ * TUI refreshes its subscription-preference views. Within that persistent CLI
+ * session, setup-agent team sign-in immediately refreshes and rereads the
+ * remote agent catalog before applying the selected team. Collapsing these
+ * effects would either omit host refresh work or repeat it.
  */
 
 import { toErrorMessage } from '@utils/errors/errorMessage';

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -73,10 +73,9 @@ const ModelAvailabilityKindSchema = z.enum([
 export type ModelAvailabilityKind = z.infer<typeof ModelAvailabilityKindSchema>;
 
 /**
- * Resolved per-model access under the active API mode. Computed once by
- * `computeModelOptionsData` and shared verbatim across hosts (CLI picker,
- * extension Models tab) so availability and routing are never re-derived at
- * render time.
+ * Resolved per-model access. Computed once by `computeModelOptionsData` and
+ * shared verbatim across hosts (CLI picker, extension Models tab) so
+ * availability and routing are never re-derived at render time.
  */
 export const ModelAvailabilityFieldsSchema = z.object({
   availability: ModelAvailabilityKindSchema.optional(),

--- a/src/tools/delegation/DelegationTools.ts
+++ b/src/tools/delegation/DelegationTools.ts
@@ -114,7 +114,7 @@ Available agents: loaded from the active roster at runtime.
 
 Pick the agent whose description matches the task. Do not default to the first listed agent.
 
-Available models: loaded from the active API mode at runtime.
+Available models: loaded from the active credentials at runtime.
 Largest models for deep reasoning; long-context for lengthy tedious work; cost-effective for parallel routine work.
 
 Optional auto-attach from the input LaTeX:
@@ -226,7 +226,7 @@ Available agents: loaded from the active roster at runtime.
 
 Agent selection: choose the most specific agent whose description matches the task.
 
-Available models: loaded from the active API mode at runtime.
+Available models: loaded from the active credentials at runtime.
 Model selection: use the largest models for challenging tasks requiring deep reasoning; use cheaper long-context models for tedious but lengthy tasks; use cost-effective models for highly parallelizable routine work.
 
 Example (resume): execution_id=exec_abc123, instruction="Also fix the bibliography slide formatting."

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -364,7 +364,7 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
     };
 
     // Same availability gate as delegate_agent/delegate_workflow: a run model
-    // the active API mode cannot serve fails here, with the available list,
+    // the active credentials cannot serve fails here, with the available list,
     // instead of mid-run on the first provider call.
     const runModel = await runPhase(() =>
       selectAvailableDelegationModel({

--- a/src/tools/delegation/delegationAvailability.ts
+++ b/src/tools/delegation/delegationAvailability.ts
@@ -5,8 +5,8 @@
  * The delegate_agent / delegate_workflow descriptions ship with placeholder
  * "Available agents:", "Available models:", and "Git worktree support:" lines.
  * All three depend on state the user can change after the tool registry is
- * built (roster visibility, a multi-agent preset swap, API mode, the worktree
- * setting), so each line is resolved per run at the `resolveAgentTools`
+ * built (roster visibility, a multi-agent preset swap, model credentials, the
+ * worktree setting), so each line is resolved per run at the `resolveAgentTools`
  * boundary instead of being frozen into the tool definition at first access.
  *
  * Keeping the roster current is what lets the agent-native delegation
@@ -218,7 +218,7 @@ function formatAvailableModelsLine(
     return 'Available models: unavailable to load; omit model unless the user explicitly requested one.';
   }
   if (modelNames.length === 0) {
-    return 'Available models: none currently available. Ask the user to switch API mode or configure an API key before delegating.';
+    return 'Available models: none currently available. Ask the user to configure model access before delegating.';
   }
   return `Available models: ${modelNames.join(', ')}`;
 }

--- a/src/tools/delegation/proposalFlow.ts
+++ b/src/tools/delegation/proposalFlow.ts
@@ -232,10 +232,10 @@ export async function proposeAndExecute(
 
   // Every non-approve action returned above, so this is the approved path.
   // Route an approved model override through the same availability gate the
-  // initial delegation uses (selectAvailableDelegationModel), so a model that
-  // is unavailable in the active API mode fails synchronously here instead of
-  // launching and then failing asynchronously. Re-selecting the proposed model
-  // needs no re-check — it was already resolved when the proposal was built.
+  // initial delegation uses (selectAvailableDelegationModel), so an unavailable
+  // model fails synchronously here instead of launching and then failing
+  // asynchronously. Re-selecting the proposed model needs no re-check — it was
+  // already resolved when the proposal was built.
   let modelOverride: string | undefined;
   if (result.model && result.model !== proposal.model) {
     try {


### PR DESCRIPTION
## What this fixes

TeXRA-hosted "included" model access was retired in #10894, but setup and delegation copy still described that route.

### Retained scope

- Correct `README.md`, `CHANGELOG.md`, and the getting-started walkthrough:
  - ChatGPT and Grok use sign-in subscription routes where the host supports them.
  - The extension walkthrough only presents routes its setup assistant can launch with: ChatGPT, coding-plan keys, and provider API keys.
  - Kimi Code and GLM Coding Plan use provider-console membership/subscription API keys.
  - Claude has no TeXRA subscription route. Claude Pro does not include API access.
  - GitHub/Google Researcher Access unlocks the hosted agent catalog only. Remote agents use the same configured model credential as built-in agents.
- Make the extension's first-run CTA match `hasUsableSetupCredential`: "use ChatGPT or add a provider key".
- Remove Researcher Access from the onboarding card's credential choices.
- Replace the reachable empty-model annotation's "switch API mode" instruction with "configure model access".
- Clean stale production comments and delegation tool descriptions that refer to the deleted active API mode.
- Add the missing Unreleased breaking-change entry.

### Final review follow-up

- Make the setup agent require active ChatGPT subscription access or a usable provider/coding-plan key before running a task.
- Describe Researcher Access separately as optional hosted remote-agent catalog access, never as model access.
- Make the desktop setup failure guidance match its actual resolver: ChatGPT or a provider/coding-plan key in Models.
- Remove Grok subscription sign-in from the extension setup walkthrough because that setup gate does not launch from Grok auth.

### Intentionally omitted

All test-file edits from the original PR were removed. The two `delegationAvailability.ts` exception strings pinned exactly by `DelegationModelAvailability.vitest.ts` were also restored. Changing those runtime strings makes the unchanged suite fail, so that cleanup is deferred rather than weakening or modifying tests in this PR.

## Validation

- Unchanged setup/onboarding/relevant desktop suites: 20 files, 181 tests passed
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- `npm run typecheck:desktop`
- Targeted ESLint on `packages/desktop/src/main/index.ts`
- Targeted Prettier check on the three final-review files
- YAML parse validation for `setup.yaml`
- `git diff --check`
- No test files changed

Rebased onto current `origin/main` (`941e36404b15f62b84f1f8acede67fd171960aa3`) before the final push.
