### PR TITLE
refactor(platform): serialize agent-directory bootstrap with KeyedMutex

### DIFF
--- a/src/platform/defaults/nodeHost.ts
+++ b/src/platform/defaults/nodeHost.ts
@@ -22,6 +22,7 @@ import {
   defaultSkillSources,
   type SkillSourceOptions,
 } from '@skills/skillSources';
+import { KeyedMutex } from '@utils/core/keyedMutex';
 
 // Local file imports
 import { nodeFileLocks } from './fileLocks';
@@ -96,7 +97,7 @@ export interface NodeRuntimeSkillOptions {
 }
 
 const bootstrappedAgentDirectoryResources = new Map<string, string>();
-const agentDirectoryBootstrapQueues = new Map<string, Promise<void>>();
+const agentDirectoryBootstrapMutex = new KeyedMutex<string>();
 
 /**
  * Assemble the platform services for a Node-family host (CLI, desktop,
@@ -167,10 +168,8 @@ export async function bootstrapNodeAgentDirectories(
   options: NodeAgentDirectoryBootstrapOptions,
 ): Promise<void> {
   const guardKey = `${options.channel}:${options.versionStateKey}`;
-  const predecessor =
-    agentDirectoryBootstrapQueues.get(guardKey) ?? Promise.resolve();
-  const settledPredecessor = predecessor.catch(() => undefined);
-  const queuedBootstrap = settledPredecessor.then(async () => {
+
+  await agentDirectoryBootstrapMutex.runExclusive(guardKey, async () => {
     if (
       bootstrappedAgentDirectoryResources.get(guardKey) ===
       options.resourcesPath
@@ -182,13 +181,4 @@ export async function bootstrapNodeAgentDirectories(
       bootstrappedAgentDirectoryResources.set(guardKey, options.resourcesPath);
     }
   });
-  agentDirectoryBootstrapQueues.set(guardKey, queuedBootstrap);
-
-  try {
-    await queuedBootstrap;
-  } finally {
-    if (agentDirectoryBootstrapQueues.get(guardKey) === queuedBootstrap) {
-      agentDirectoryBootstrapQueues.delete(guardKey);
-    }
-  }
 }


### PR DESCRIPTION
## What

#11082 (merged yesterday) added a hand-rolled `chain = chain.then(...)` queue to serialize agent-directory bootstrap per host channel. AGENTS.md:659 bans that idiom by name. This swaps it for `KeyedMutex`.

## Why this is a regression, not old debt

The rule exists because every hand-rolled copy re-solves error isolation and map-entry cleanup differently — the 2026-07-18 coupling audit found exactly that, and the 2026-07-25 sweep migrated all existing copies onto the shared primitive. One of the copies it migrated was `writeChains` in `src/platform/defaults/jsonStore.ts`, in this same directory.

The new copy reproduced all three hand-rolled parts: a module-level `Map<string, Promise<void>>`, a `.catch(() => undefined)` rejection swallow, and a `try/finally` identity check to clean up the map entry.

## Single ownership

Serialization was being re-derived at this call site from three cooperating pieces. `KeyedMutex` (`src/utils/core/keyedMutex.ts`, 10 production consumers) already owns FIFO ordering, per-caller rejection isolation, and map-entry cleanup. After this change there is one owner of "only one bootstrap per key runs at a time", not a local restatement of it.

`bootstrappedAgentDirectoryResources` stays — it owns a different fact (which resources path was last reconciled), and it is only read and written inside the critical section.

## Behavior

Unchanged. `async-mutex` acquires FIFO synchronously inside `runExclusive`, so ordering and isolation match the hand-rolled queue. The three properties the existing tests pin — request coalescing, resumption after a rejected predecessor, and request-order serialization — all hold.

## Net elements (R6)

- Files: 1 changed
- `^[+-]export` symbols: 0
- Class/interface/enum declarations: 0
- Net LoC: **−10** (`4 insertions(+), 14 deletions(-)` vs `origin/main`)
- Removed: 1 module-level `Map`, 1 rejection swallow, 1 try/finally cleanup block

## Consumer counts (R8)

- `bootstrapNodeAgentDirectories` — 3 production callers, all unchanged: `packages/cli/src/runtime/initPlatform.ts:390`, `packages/desktop/src/main/platform/index.ts:168`, `packages/extension/src/extension.ts:379`
- `agentDirectoryBootstrapQueues` (deleted) — 0 consumers outside the function
- `KeyedMutex` — 10 existing production consumers

## Checks

`typecheck` ✅ (exit 0) · `lint` ✅ (exit 0) · `format` ✅

Targeted suites ✅ — `ElectronAgentDirectories.vitest.ts` + `PlatformAgentDirectories.vitest.ts`, 14/14.

Full suite: 841 files / 10,315 tests pass, **1 unrelated flake** — `TranscriptSessionPolicy.vitest.ts` timed out at 10s under full-suite contention and passes 4/4 in isolation. It exercises CLI transcript session policy and shares no code with this change.

Note for reviewers: `node_modules` was missing `diff@^9.0.0` on my machine, which produced pre-existing typecheck errors on `origin/main` too. A `corepack pnpm install` fixed it; unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJmSeJm4wocNwc7AFMrJBU