### PR TITLE
fix: bound the webview inline diff; restore global scope for provider toggles (#11093, #10943)

### DIFF
--- a/packages/extension/src/progressView/frontend/formatters/constants.ts
+++ b/packages/extension/src/progressView/frontend/formatters/constants.ts
@@ -97,6 +97,16 @@ export const DIFF_DETECTION_LINE_LIMIT = 20;
 export const DIFF_MARKER_THRESHOLD = 2;
 
 /**
+ * Upper bound on the inline word diff, which runs synchronously inside Lit's
+ * render on the webview's main thread over LLM-authored edit text.
+ *
+ * Deliberately far below `unifiedDiff`'s 5s Node-side bound rather than shared
+ * with it: this budget is the frame the user is waiting on, so the two are
+ * different policies for different threads, not one value written twice.
+ */
+export const INLINE_DIFF_TIMEOUT_MS = 250;
+
+/**
  * Tool icon mapping for different tool types.
  * Maps tool names to wa-icon names (codicon-style aliases supported via the
  * shared TeXRA icon library).

--- a/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -34,6 +34,7 @@ import {
   TOOL_ICON_MAP,
   DIFF_DETECTION_LINE_LIMIT,
   DIFF_MARKER_THRESHOLD,
+  INLINE_DIFF_TIMEOUT_MS,
 } from './constants';
 
 /** Build a tool-use section template. Empty label omits the label element. */
@@ -424,9 +425,26 @@ export function buildExecutionsPathDisplay(
  * can scan, and they come from the same engine as every other diff in the
  * product. The webview highlights inline spans while the terminal renders
  * unified hunks — two correct paints of one payload for two media.
+ *
+ * Bounded because this runs inside Lit's render on the main thread: on
+ * timeout jsdiff returns `undefined`, and the fallback paints the edit as a
+ * whole replacement — "all of it changed" is true, if verbose, where an
+ * unbounded run would freeze the panel instead.
  */
 function generateInlineDiff(oldText: string, newText: string): TemplateResult {
-  const parts = diffWordsWithSpace(oldText, newText);
+  const parts = diffWordsWithSpace(oldText, newText, {
+    timeout: INLINE_DIFF_TIMEOUT_MS,
+  });
+
+  if (!parts) {
+    console.warn(
+      `[progressView] Inline diff exceeded ${INLINE_DIFF_TIMEOUT_MS}ms ` +
+        `(${oldText.length} → ${newText.length} chars); ` +
+        `painting it as a whole replacement.`,
+    );
+    // prettier-ignore
+    return html`<span class="diff-inline-del">${oldText}</span><span class="diff-inline-add">${newText}</span>`;
+  }
 
   return html`${parts.map((part) => {
     if (part.removed) {

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -388,7 +388,16 @@ const CORE_SETTING_ROWS: Record<CoreSettingPath, CoreRowSpec> = {
   'goal.enabled': {
     honoredBy: everyHost('src/tools/goal/goalFeatureFlag.ts'),
   },
+  // The five Models-tab provider toggles below are `configTarget: 'global'`:
+  // they describe how you talk to a provider, not a property of one project,
+  // and that is the scope they were written at before the catalog collapse
+  // routed them through the shared write path. The target restores global
+  // writes and exempts them from the extension's open-workspace write guard,
+  // while Models-tab and runtime reads both keep merged-config semantics. A
+  // workspace override therefore remains visible and honored; cleanup of values
+  // stranded by the regression window is tracked separately in #11173.
   'model.gpt5ReasoningSummary': {
+    configTarget: 'global',
     title: 'GPT-5 reasoning summary',
     category: 'model',
     honoredBy: everyHost(
@@ -412,6 +421,7 @@ const CORE_SETTING_ROWS: Record<CoreSettingPath, CoreRowSpec> = {
     },
   },
   'model.useOpenAIResponsesAPI': {
+    configTarget: 'global',
     title: 'Use the Responses API',
     category: 'model',
     honoredBy: everyHost('src/agent/runtime/ModelFactory.ts'),
@@ -428,6 +438,7 @@ const CORE_SETTING_ROWS: Record<CoreSettingPath, CoreRowSpec> = {
     },
   },
   'model.useGoogleInteractionsServerState': {
+    configTarget: 'global',
     title: 'Server-side conversation state',
     category: 'model',
     honoredBy: everyHost(
@@ -446,6 +457,7 @@ const CORE_SETTING_ROWS: Record<CoreSettingPath, CoreRowSpec> = {
     },
   },
   'model.useBackgroundResponses': {
+    configTarget: 'global',
     title: 'Background responses',
     category: 'model',
     honoredBy: everyHost(
@@ -470,6 +482,7 @@ const CORE_SETTING_ROWS: Record<CoreSettingPath, CoreRowSpec> = {
     },
   },
   'model.openaiParallelToolCalls': {
+    configTarget: 'global',
     title: 'Parallel tool calls',
     category: 'model',
     honoredBy: everyHost(


### PR DESCRIPTION
Closes #11093. Closes #10943.

Two review findings that merged unaddressed, each a user-visible regression left by an otherwise behavior-preserving refactor.

## 1. Unbounded diff on the webview main thread (#11093)

#11075 moved the progress-view inline edit diff from diff-match-patch to jsdiff's `diffWordsWithSpace`. dmp carried an implicit `Diff_Timeout = 1.0` on every path; jsdiff has none. The sibling `buildDiffHunks` added in that same PR passes `timeout: DIFF_TIMEOUT_MS` for exactly this reason; `generateInlineDiff` did not.

That call runs synchronously inside Lit's render, on the browser main thread, over `old_string`/`new_string` content that originates from LLM tool calls. A large or pathologically dissimilar pair could hang the panel with no bound. Two review bots flagged it as blocking before merge.

**Fix.** Pass a timeout, and handle jsdiff's `undefined` return by painting the edit as a whole replacement, with a `console.warn` naming the cause so the degraded render is never silent, matching the contract `buildDiffHunks` already uses for its timeout path.

**On the constant.** The bound is the webview's own (`INLINE_DIFF_TIMEOUT_MS = 250`), not a share of `unifiedDiff`'s 5s:

- They are different policies for different threads. 5s bounds a Node-side hunk build; this one is the frame the user is waiting on, where 5s of frozen panel is itself the bug.
- `src/utils/text/unifiedDiff.ts` is not browser-reachable. Importing it from the webview frontend would widen the browser-safe utils set that `scripts/check-browser-safe-utils.mjs` pins.

## 2. Provider toggles silently changed persistence scope (#10943)

The five config-backed Models-tab toggles, `gpt5ReasoningSummary`, `useOpenAIResponsesAPI`, `useGoogleInteractionsServerState`, `useBackgroundResponses`, and `openaiParallelToolCalls`, moved from `SET_PROVIDER_SETTING` (which wrote with target `'global'`) onto the shared `UPDATE_STATE_SETTING` path in #10925. None carried `configTarget`, and `writeSetting` resolves `target ?? entry.configTarget ?? 'workspace'`.

Two consequences were verified on the merged tree:

- values began persisting into workspace `.texra/config.json` instead of the global store;
- the extension's open-workspace guard began rejecting the write with no folder open, so the toggles became unusable in that state.

**Fix.** Restore `configTarget: 'global'` on the five rows. This restores the original write scope and exempts those rows from the open-workspace guard through the existing catalog write machinery.

The Models-tab controller and all five runtime readers resolve merged config, independent of `configTarget`. Keeping that read behavior preserves UI/runtime agreement and continues honoring deliberate workspace overrides. It also means a workspace value written during the #10925 regression window can shadow a later global write. This PR does not blindly delete such values because they cannot be safely distinguished from intentional workspace overrides. Focused cleanup is tracked in #11173.

The catalog comment now states that actual architecture instead of claiming these profile rows read `inspect().globalValue`.

## Validation

Run after rebasing onto current `origin/main`:

- workspace and test-kernel TypeScript checks passed;
- focused settings suites: 43 files, 245 tests passed;
- focused progress-view and webview suites: 73 files, 672 tests passed;
- ESLint and Prettier passed on all three changed production files;
- `git diff --check origin/main...HEAD` passed.

**Not validated:** the rendered timeout fallback. It requires a pathological edit pair in a running extension host to observe; the fallback is exercised only when jsdiff returns `undefined`.

## Tests

0 added or modified, per the repo's testing budget and review constraint. The existing focused suites above cover the affected settings and progress-view surfaces.
