### PR TITLE
refactor(transcript): remove readerless row metadata

### DIFF
--- a/src/shared/copy/accountAuth.ts
+++ b/src/shared/copy/accountAuth.ts
@@ -53,8 +53,6 @@ export const RESEARCHER_ACCESS_AUTH = {
   logoutDescription: `Sign out of your ${RESEARCHER_ACCESS.label} account`,
   /** `/login` slash-command description. */
   slashLoginDescription: `Sign in to ${CHATGPT_AUTH.label} or ${RESEARCHER_ACCESS.label}`,
-  /** Compact launcher /api action hint. */
-  actionHintLogin: `\`texra login\` signs in with ${RESEARCHER_ACCESS.label}`,
   /** Longer launcher action hint when keys are also an option. */
   actionHintLoginOrKey: `choose Model access below, add a provider key, or sign in with ${RESEARCHER_ACCESS.label}`,
   startingDevice: `Starting ${RESEARCHER_ACCESS.label} device-code sign-in.`,

--- a/src/shared/transcript/projectTranscriptRow.ts
+++ b/src/shared/transcript/projectTranscriptRow.ts
@@ -454,7 +454,6 @@ export function projectTranscriptRow(
       return {
         ...rowBase(entry),
         kind: 'fileList',
-        category: entry.text ?? '',
         files,
         counts,
         summary,

--- a/src/shared/transcript/toolRowModel.ts
+++ b/src/shared/transcript/toolRowModel.ts
@@ -52,7 +52,6 @@ import {
   stringifyPayload,
   transcriptText,
   type PayloadLanguage,
-  type TextMetrics,
   type TranscriptText,
 } from './transcriptText';
 
@@ -173,14 +172,6 @@ type ToolOutputSuppression =
   | 'file-link'
   | 'trivial-write';
 
-interface ToolRowElision {
-  /** Length of the untruncated single-line header preview. */
-  readonly headerPreview: TextMetrics;
-  readonly output?: TextMetrics;
-  readonly error?: TextMetrics;
-  readonly userInstruction?: TextMetrics;
-}
-
 export interface ToolRowModel {
   /** Tool name as a user reads it (`MCP fs/read`, `Multi-agent workflow`). */
   readonly headerLabel: string;
@@ -202,7 +193,6 @@ export interface ToolRowModel {
   readonly isInProgress: boolean;
   readonly exitCode?: number;
   readonly spillPath?: string;
-  readonly elision: ToolRowElision;
 }
 
 export interface ToolRowModelContext {
@@ -914,10 +904,6 @@ function outputSuppression(
 // Fold
 // ---------------------------------------------------------------------------
 
-function metricsOf(text: TranscriptText): TextMetrics {
-  return { lineCount: text.lineCount, charCount: text.charCount };
-}
-
 export function toolRowModel(
   normalized: NormalizedToolUse,
   ctx: ToolRowModelContext = {},
@@ -949,7 +935,6 @@ export function toolRowModel(
   const userInstruction = normalized.userInstructionText
     ? transcriptText(normalized.userInstructionText)
     : undefined;
-  const previewText = transcriptText(headerPreview);
 
   return {
     headerLabel: displayToolName(normalized.toolName),
@@ -968,13 +953,5 @@ export function toolRowModel(
       ? { exitCode: normalized.exitCode }
       : {}),
     ...(normalized.spillPath ? { spillPath: normalized.spillPath } : {}),
-    elision: {
-      headerPreview: metricsOf(previewText),
-      ...(output ? { output: metricsOf(output) } : {}),
-      ...(errorPreview ? { error: metricsOf(errorPreview) } : {}),
-      ...(userInstruction
-        ? { userInstruction: metricsOf(userInstruction) }
-        : {}),
-    },
   };
 }

--- a/src/shared/transcript/transcriptRow.ts
+++ b/src/shared/transcript/transcriptRow.ts
@@ -165,8 +165,6 @@ export interface LoadedMediaRef {
 
 export interface FileListRow extends TranscriptRowBase {
   readonly kind: 'fileList';
-  /** Which category of attachment this load reported (`input`, `media`, …). */
-  readonly category: string;
   /** Every entry the loader reported, loaded and failed alike. */
   readonly files: readonly FileListEntry[];
   readonly counts: {

--- a/src/shared/transcript/transcriptText.ts
+++ b/src/shared/transcript/transcriptText.ts
@@ -13,15 +13,10 @@ import yaml from 'yaml';
 
 import { collapseWhitespace, splitContentLines } from '@utils/text/stringUtils';
 
-export interface TextMetrics {
+/** One text-bearing field of a transcript row. */
+export interface TranscriptText {
   /** Lines in the untruncated text; a trailing newline is not a line. */
   readonly lineCount: number;
-  /** UTF-16 length of the untruncated text. */
-  readonly charCount: number;
-}
-
-/** One text-bearing field of a transcript row. */
-export interface TranscriptText extends TextMetrics {
   /** The complete text, exactly as the producer wrote it. */
   readonly full: string;
   /** Whitespace-collapsed single line — still untruncated. For one-line
@@ -33,7 +28,6 @@ const EMPTY_TRANSCRIPT_TEXT: TranscriptText = {
   full: '',
   oneLine: '',
   lineCount: 0,
-  charCount: 0,
 };
 
 export function transcriptText(raw: string): TranscriptText {
@@ -42,7 +36,6 @@ export function transcriptText(raw: string): TranscriptText {
     full: raw,
     oneLine: collapseWhitespace(raw),
     lineCount: splitContentLines(raw).length,
-    charCount: raw.length,
   };
 }
 


### PR DESCRIPTION
## What

Remove only verified-readerless production metadata from the shared transcript model and account-auth copy:

- `FileListRow.category` and its projector write
- `ToolRowModel.elision`, `ToolRowElision`, and the dead `metricsOf` helper
- the now-dead `previewText` computation left after elision removal
- `TextMetrics.charCount`, folding the remaining `lineCount` field directly into `TranscriptText`
- `RESEARCHER_ACCESS_AUTH.actionHintLogin`

`FileListRow.counts`, the projector `counts` property, and the `fileListSummary` result/type shape are retained exactly as current `main` because the unchanged CLI contract consumes them.

## Tests

Zero test files changed. `src/test-kernel/cli/TuiStateAndFocus.vitest.ts` is byte-for-byte inherited from current `main`.

## Validation

- Focused suites: `TuiStateAndFocus`, `TranscriptRowProjection`, progress-view `FileList`, and `ToolUseFormatter`: 221 tests passed before the final clean rebase
- Post-rebase affected suites: `TranscriptRowProjection`, progress-view `FileList`, and `ToolUseFormatter`: 31 tests passed
- Workspace typecheck: passed
- Test-kernel typecheck: passed
- Targeted ESLint: passed before and after rebase
- Targeted Prettier check: passed before and after rebase
- Dead-code ratchet: passed, 8 current findings versus 8 baselined
- `git diff --check`: passed

Rebased onto `ba17d9d039` (`origin/main`, including #11168).