### PR TITLE
fix(extension): normalize the main-worktree git common root

### DIFF
--- a/packages/extension/src/frontend/git/resolveGitRoot.ts
+++ b/packages/extension/src/frontend/git/resolveGitRoot.ts
@@ -56,7 +56,7 @@ export async function resolveGitCommonRoot(
     const stat = await vscode.workspace.fs.stat(gitEntryUri);
 
     if (isDirectory(stat.type)) {
-      return repo.rootUri.fsPath;
+      return normalizeFilePath(repo.rootUri.fsPath);
     }
 
     if (!isFile(stat.type)) {


### PR DESCRIPTION
## Summary

`resolveGitCommonRoot` (`packages/extension/src/frontend/git/resolveGitRoot.ts`)
returned `repo.rootUri.fsPath` **un-normalized** in its directory-`.git`
branch — the main-worktree case — while both of its other return paths, in
`resolveCommonRootFromGitdir`, return `normalizeFilePath(...)`.

Its single consumer is `packages/extension/src/extension.ts:205`, which passes
the value to `WorktreeStateStore` as `repoRoot`. That store builds the global
namespace `worktree:<repoRoot>:<key>`. On Windows the main worktree therefore
keyed

```
worktree:C:\dev\repo:<key>
```

while every *linked* worktree of the same repository — whose root arrives via
the gitdir path and is normalized — keyed

```
worktree:C:/dev/repo:<key>
```

The two never met, so the twelve repository-level keys the store exists to
share (`AGENT_ROSTER_SELECTION`, `CUSTOM_AGENT_PRESETS`, the three Codex keys,
the three Claude-agent keys, `GIT_MARK_COMMITS`, `GIT_AUTHOR_NAME`,
`GIT_AUTHOR_EMAIL`, `GIT_WORKTREE_SUPPORT`) silently did not share between a
Windows main worktree and its linked worktrees. The worktree-sharing feature
was, on Windows, inert in exactly the configuration it was built for.

One line: wrap the outlier return in `normalizeFilePath`.

## Irreducibility

The namespace string **is** the shared key — sharing is nothing but two
producers agreeing on one spelling of the repository root. Nothing downstream
can recover it once they disagree, and the canonical spelling is already
established here by the two sibling return paths in the same function; the
un-normalized one is an outlier, not a second convention. There is no smaller
fix, and no fix at another layer (normalizing inside `WorktreeStateStore`, say)
that does not create a second normalization owner for a value the resolver
already claims to normalize.

Ordinary POSIX workspace paths are unaffected because their separators are already `/`. This is a Windows correctness fix aligned with the repository’s existing canonical-path convention.

## Migration note — silent abandon, stated plainly

On Windows this **abandons** previously stored `worktree:C:\...` global values.
I checked: nothing logs the transition, and nothing can — after the fix the
store has no view of the pre-fix spelling, so it cannot know a value was
orphaned, and a loud abandon would require reading both spellings, i.e. exactly
the compatibility reader the repo's intermediate-data ruling says not to add.
So the abandon is silent, and affected Windows users see those twelve
repository settings fall back to their defaults once, after which they persist
normally.

I judged that acceptable rather than dropping the change: this is not cosmetic
— the feature does not function at all on Windows today — and the cost is a
single one-time reset of settings that are cheap to re-select. Flagging it here
so the owner can judge; if the reset is unacceptable the right move is to close
this rather than to add a dual-spelling reader.

## Provenance

This finding was the **verifier's**, not the scout's — it was found inside a
candidate that was itself refuted, and survived that refutation on its own
merits. That is unusually strong provenance for a one-liner.

## Dropped: the desktop window-title half of this batch

This PR was filed as a two-change batch. The other item — aligning
`packages/desktop/src/main/desktopWindowTitle.ts:39` (`node:path` `basename`)
with the in-window shell header
(`packages/desktop/src/shared/desktopTaskShell.ts:476`, `getBasename(p) || p`)
so a `/` workspace stops showing `TeXRA` in the title while the header shows
`/` — **is dropped as refuted**, per the standing instruction to drop it if it
contradicts closed issue #9008.

It does contradict it. #9008 specifies verbatim: *"Omit the project segment
when no workspace basename exists."* `basename('/')` is `''`, and
`formatSessionTitle` filters empty segments, so `/` → `TeXRA` **is** the
adjudicated spec for the window title. The proposed `getBasename(p) || p`
would render `TeXRA — /`, i.e. re-litigate #9008 rather than align to it.

The only variant that does *not* contradict #9008 — swapping `basename` for
`getBasename` with no `|| workspacePath` fallback — changes no user-visible
output except making the window title *newly wrong* for a POSIX directory
literally named `my\proj` (`getBasename` normalizes backslashes), matching the
header's existing wrongness there. That is churn with negative value, so it is
not included either. The two surfaces each carry a deliberate, separately
documented decision for the degenerate `/` root; they are inconsistent by
construction, not by oversight.

## Testing

All from inside an isolated worktree at `origin/main`:

- `FORCE_COLOR=0 npx tsc --noEmit --checkers 8` — pass
- `FORCE_COLOR=0 npx tsc --noEmit --checkers 8 -p tsconfig.test-kernel.json` — pass
- `FORCE_COLOR=0 npx vitest run src/test-kernel/frontend/ResolveGitRoot.vitest.ts src/test-kernel/platform/WorktreeStateStore.vitest.ts` — 2 files, 6 tests, pass
- `FORCE_COLOR=0 npx eslint packages/extension/src/frontend/git/resolveGitRoot.ts` — clean
- `npx prettier --check packages/extension/src/frontend/git/resolveGitRoot.ts` — clean

No new tests: the existing `ResolveGitRoot` suite exercises
`resolveCommonRootFromGitdir` (the already-normalized paths), and the changed
branch requires a live VS Code git-extension repository object, so a test for
it would pin a mock of the host seam rather than the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175CfQ2d7cLghAS23avg3Qp

