### PR TITLE
refactor(extension): inline the leftover createOrShowPanel panel factory

### DIFF
--- a/packages/extension/src/common/webview/BaseWebviewProvider.ts
+++ b/packages/extension/src/common/webview/BaseWebviewProvider.ts
@@ -3,20 +3,11 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { DisposableStore } from '@platform/disposable';
-import { getSharedLocalResourceRoots } from './resourceRoots';
-
-export interface PanelOptions {
-  viewType: string;
-  title: string;
-  viewPath: string;
-  column?: vscode.ViewColumn;
-  retainContextWhenHidden?: boolean;
-  iconPath?: vscode.IconPath;
-}
 
 /**
  * Base class for webview providers.
- * Handles HTML assignment, message routing, and disposable management.
+ * Holds the active view, its message handler, and disposable management;
+ * each provider wires up its own view (sidebar or panel).
  */
 export abstract class BaseWebviewProvider {
   protected _view?: vscode.WebviewView | vscode.WebviewPanel;
@@ -35,61 +26,6 @@ export abstract class BaseWebviewProvider {
   };
 
   constructor(protected readonly context: vscode.ExtensionContext) {}
-
-  protected resolveWebviewViewInternal(
-    webviewView: vscode.WebviewView | vscode.WebviewPanel,
-  ): void {
-    this.cleanupView();
-    this._view = webviewView;
-
-    webviewView.webview.html = this.contentProvider.getHtmlContent(
-      webviewView.webview,
-    );
-
-    this._viewDisposables.add(
-      webviewView.webview.onDidReceiveMessage((message) =>
-        this.messageHandler.handleMessage(message, webviewView),
-      ),
-    );
-    this._viewDisposables.add(
-      webviewView.onDidDispose(this.cleanupView.bind(this)),
-    );
-  }
-
-  /**
-   * Create or reveal a webview panel.
-   * Common pattern for showing secondary views (History, Profile) as panels.
-   * @returns true if panel was created, false if existing panel was revealed
-   */
-  protected createOrShowPanel(options: PanelOptions): boolean {
-    // If we already have a panel (not a sidebar WebviewView), reveal it.
-    // Check for 'viewColumn' which is unique to WebviewPanel (WebviewView doesn't have it).
-    if (this._view && 'viewColumn' in this._view) {
-      this._view.reveal(options.column ?? vscode.ViewColumn.One);
-      return false;
-    }
-
-    // Otherwise, create a new panel
-    this._view = vscode.window.createWebviewPanel(
-      options.viewType,
-      options.title,
-      options.column ?? vscode.ViewColumn.One,
-      {
-        enableScripts: true,
-        retainContextWhenHidden: options.retainContextWhenHidden ?? true,
-        localResourceRoots: getSharedLocalResourceRoots(
-          this.context,
-          options.viewPath,
-        ),
-      },
-    );
-
-    if (options.iconPath) {
-      this._view.iconPath = options.iconPath;
-    }
-    this.resolveWebviewViewInternal(this._view);
-    return true;
-  }
 
   protected cleanupView(): void {
     const disposables = this._viewDisposables;

--- a/packages/extension/src/settingsView/SettingsViewProvider.ts
+++ b/packages/extension/src/settingsView/SettingsViewProvider.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import {
   BaseWebviewProvider,
   BundledViewContentProvider,
+  getSharedLocalResourceRoots,
 } from '@common/webview';
 import type { SubscriptionProviderId } from '@controllers/modelAccess/subscriptionProviders';
 import { onTexraAuthSessionsChanged } from '@frontend/events/onTexraAuthSessionsChanged';
@@ -69,15 +70,39 @@ export class SettingsViewProvider extends BaseWebviewProvider {
     tab?: SettingsTabPanelName,
     agentSubTab?: AgentCategory,
   ): Promise<void> {
-    const isNew = this.createOrShowPanel({
-      viewType: SettingsViewProvider.viewType,
-      title: 'TeXRA Dashboard',
-      viewPath: 'settingsView',
-      iconPath: new vscode.ThemeIcon('gear'),
-    });
+    // 'viewColumn' is unique to WebviewPanel; it narrows the view union and
+    // tells an already-open dashboard panel apart from a sidebar WebviewView.
+    if (this._view && 'viewColumn' in this._view) {
+      const panel = this._view;
+      panel.reveal(vscode.ViewColumn.One);
+      await this.messageHandler.sendAllData(panel.webview);
+    } else {
+      const panel = vscode.window.createWebviewPanel(
+        SettingsViewProvider.viewType,
+        'TeXRA Dashboard',
+        vscode.ViewColumn.One,
+        {
+          enableScripts: true,
+          retainContextWhenHidden: true,
+          localResourceRoots: getSharedLocalResourceRoots(
+            this.context,
+            'settingsView',
+          ),
+        },
+      );
+      panel.iconPath = new vscode.ThemeIcon('gear');
 
-    if (!isNew && this._view) {
-      await this.messageHandler.sendAllData(this._view.webview);
+      this.cleanupView();
+      this._view = panel;
+      panel.webview.html = this.contentProvider.getHtmlContent(panel.webview);
+      this._viewDisposables.add(
+        panel.webview.onDidReceiveMessage((message) =>
+          this.messageHandler.handleMessage(message, panel),
+        ),
+      );
+      this._viewDisposables.add(
+        panel.onDidDispose(this.cleanupView.bind(this)),
+      );
     }
 
     if (tab != null && this._view) {


### PR DESCRIPTION
## The argument: leftover + single-caller ban

`BaseWebviewProvider.createOrShowPanel` is a generic panel factory built for a
family of secondary views that no longer exists. This is **not** speculative
generality — it is an added-then-removed leftover. Run the grep:

```
$ git grep createOrShowPanel 5ce407e3fc~1
5ce407e3fc~1:docs/prd/settings-view-unified.md:1788:    const isNew = this.createOrShowPanel({
5ce407e3fc~1:src/common/webview/BaseWebviewProvider.ts:88:  protected createOrShowPanel(options: PanelOptions): boolean {
5ce407e3fc~1:src/historyView/HistoryViewProvider.ts:21:    const isNew = this.createOrShowPanel({
5ce407e3fc~1:src/memoryView/MemoryViewProvider.ts:33:    const isNew = this.createOrShowPanel({
5ce407e3fc~1:src/profileView/ProfileViewProvider.ts:30:    const isNew = this.createOrShowPanel({
```

Commit `5ce407e3fc` (2026-02-03, Dashboard consolidation) deleted all three
view folders. What survives is a factory with exactly one caller,
`SettingsViewProvider.showSettingsView` — and a doc comment at the old `:61`
that still advertises "History, Profile" as the views it serves.

### Irreducibility

CLAUDE.md bans single-caller extractions outright. Beyond the caller count, the
shape is actively wrong for the one caller that remains: two of `PanelOptions`'
six fields — `column` and `retainContextWhenHidden` — have **never** been passed
by any caller in repo history, including the three deleted ones. Every
`?? default` inside the factory therefore resolves to a compile-time constant.
There is no parameterization left to justify the parameter object.

`resolveWebviewViewInternal` is in the same position: its only call site is
`createOrShowPanel` itself. `MainViewProvider.resolveWebviewView`
(`MainViewProvider.ts:335-349`) hand-rolls the identical four steps rather than
calling the base method — so the "shared" resolve path was never shared either.

**Not the argument:** this is not "two systems produce different answers."
Routing `viewPath='progressView'` through the factory would diverge, but no code
makes that call — it is a counterfactual. The case here is leftover + the
single-caller ban.

## What changed

- Inlined `createOrShowPanel` + `resolveWebviewViewInternal` into
  `SettingsViewProvider.showSettingsView`.
- Deleted the `PanelOptions` interface — exported, zero importers, not even
  re-exported on the `@common/webview` barrel.
- Dropped the now-unused `getSharedLocalResourceRoots` import from the base
  class. The inlined call site imports it from the barrel; `ProgressViewProvider`
  still uses it, so the barrel export keeps a consumer.

`BaseWebviewProvider.ts`: 112 → 46 lines. Diff is **35 insertions, 74 deletions**
across 2 files — net −39 production LoC, no new abstractions, no new files.

## Behavior preservation

The reveal-vs-create branch, the cleanup-before-assign ordering (`cleanupView()`
ran inside `resolveWebviewViewInternal` after `this._view` was already
reassigned; `cleanupView` never reads `this._view`, so hoisting it above the
assignment is identical), and the `if (!isNew && this._view) sendAllData(...)`
condition are all reproduced exactly. Nothing was replaced by a quieter default;
no `throw` or `warn` was removed.

The `'viewColumn' in this._view` discriminant is **kept** — it is load-bearing TS
narrowing for the `WebviewView | WebviewPanel` union, not a stylistic check. It
is captured into a local `const panel` so the narrowing survives the `await`.

## Tests

Zero added, zero deleted — a behavior-preserving refactor. Verified no test
touches the removed symbols: `createOrShowPanel`, `PanelOptions`, and
`resolveWebviewViewInternal` appear nowhere under `src/test-kernel/`. The two
suites that `vi.mock('@common/webview')` stub `BaseWebviewProvider` as a bare
class and never invoke the real `showSettingsView`.

## Gates (all green, from a clean worktree off `origin/main`)

| Gate | Result |
| --- | --- |
| `npx tsc --noEmit --checkers 8` | pass |
| `npx tsc --noEmit --checkers 8 -p tsconfig.test-kernel.json` | pass |
| `npx vitest run` (ExtensionWorkspaceTransition, ExtensionCommandSurface, ProgressThemeSync) | 3 files / 10 tests pass |
| `npx eslint` (both changed files) | clean |
| `npx prettier --check` (both changed files) | clean |
| `node scripts/check-dead-code-ratchet.mjs` | 8 current vs 8 baselined — no regeneration needed |

## Follow-up, deliberately out of scope

`BaseWebviewProvider.ts:45` was the only base-class use of the abstract
`contentProvider` member; the base class now merely declares it. Collapsing that
would expand the blast radius from 2 files to 5 (`ProgressViewProvider`,
`MainViewProvider`, and their content providers), so it is left for a separate
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175CfQ2d7cLghAS23avg3Qp
