### PR TITLE
refactor(approvals): collapse the three per-kind ancestry graphs into one

### DIFF
--- a/src/agent/runtime/streamApprovalQueue.ts
+++ b/src/agent/runtime/streamApprovalQueue.ts
@@ -17,7 +17,7 @@ import type { StreamTabId } from '@shared/schemas';
 
 import { SessionHostInteractions } from './HostInteractions';
 
-/** The three independently-tracked bypass kinds `SessionApprovals` owns. */
+/** The three independently-tracked bypass values `SessionApprovals` owns. */
 type BypassAncestryKind = 'toolEdit' | 'bash' | 'proposal';
 
 const ALL_BYPASS_ANCESTRY_KINDS: readonly BypassAncestryKind[] = [
@@ -220,26 +220,21 @@ export interface SessionApprovals {
    */
   setDelegatedWorkBypasses(streamId: StreamTabId, enabled: boolean): void;
   /**
-   * Record that `childStreamId` descends from `parentStreamId` for bypass
-   * resolution purposes: each bypass kind named in `kinds` will defer to the
-   * parent's bypass state whenever the child has no explicit value of its
-   * own. Ancestry is tracked separately per kind — linking `bash` does NOT
-   * also let the child inherit `toolEdit` or `proposal` bypass — so a
-   * delegation that only wants some kinds to follow the parent cannot grant
-   * unrelated approvals accidentally.
+   * Record that `childStreamId` descends from `parentStreamId`: every bypass
+   * kind defers to the parent's state whenever the child has no explicit
+   * value of its own.
    *
-   * Used for delegated subagent streams (parent = the orchestrator stream,
-   * all kinds, so complete delegated-task approval remains effective through
-   * nested orchestrators; see `configureDelegatedChildApprovals`) and, in the
-   * CLI, successive conversation rounds (parent = the previous round's root
-   * stream, all kinds — a CLI round should carry forward whichever bypasses
-   * were on) — both mint a fresh `StreamTabId` that would otherwise start
-   * every bypass kind ungated.
+   * Used for delegated subagent streams (parent = the orchestrator stream, so
+   * complete delegated-task approval remains effective through nested
+   * orchestrators; see `configureDelegatedChildApprovals`) and, in the CLI,
+   * successive conversation rounds (parent = the previous round's root
+   * stream, so a round carries forward whichever bypasses were on) — both
+   * mint a fresh `StreamTabId` that would otherwise start every bypass kind
+   * ungated.
    */
   registerStreamParent(
     childStreamId: StreamTabId,
     parentStreamId: StreamTabId,
-    kinds?: readonly BypassAncestryKind[],
   ): void;
   /**
    * Promote a stream out of its approval ancestry while preserving each
@@ -247,8 +242,8 @@ export interface SessionApprovals {
    */
   detachStreamFromParent(streamId: StreamTabId): void;
   /**
-   * Drop `streamId` from the ancestry graph (all kinds). Direct children are
-   * first promoted through {@link detachStreamFromParent}, preserving their
+   * Drop `streamId` from the ancestry graph. Direct children are first
+   * promoted through {@link detachStreamFromParent}, preserving their
    * effective values before the torn-down parent's own values are cleared.
    */
   forgetStreamAncestry(streamId: StreamTabId): void;
@@ -264,54 +259,49 @@ export function createSessionApprovals(
     'setApprovalBypassState'
   > = new SessionHostInteractions(),
 ): SessionApprovals {
-  // One ancestry graph per bypass kind — deliberately NOT shared — so that
-  // e.g. linking `bash` ancestry for a delegated subagent can never let it
-  // also inherit `toolEdit` or `proposal` bypass from the same parent.
-  const parentOf: Record<BypassAncestryKind, Map<StreamTabId, StreamTabId>> = {
-    toolEdit: new Map(),
-    bash: new Map(),
-    proposal: new Map(),
-  };
-  const resolveParentFor =
-    (kind: BypassAncestryKind) =>
-    (streamId: StreamTabId): StreamTabId | undefined =>
-      parentOf[kind].get(streamId);
-  const resolveDescendantsFor =
-    (kind: BypassAncestryKind) =>
-    (streamId: StreamTabId): readonly StreamTabId[] => {
-      const graph = parentOf[kind];
-      const descendants: StreamTabId[] = [];
-      const pending = [streamId];
-      const seen = new Set(pending);
-      for (let index = 0; index < pending.length; index += 1) {
-        const parent = pending[index];
-        for (const [child, directParent] of graph) {
-          if (directParent !== parent || seen.has(child)) continue;
-          seen.add(child);
-          descendants.push(child);
-          pending.push(child);
-        }
+  // One ancestry graph shared by every bypass kind. The sole delegation entry
+  // point (`configureDelegatedChildApprovals`) and the CLI's round linking
+  // both register all kinds at once, so a per-kind subset link is not
+  // representable — the bypass *values* stay independent per kind, only the
+  // parent edge is shared.
+  const parentOf = new Map<StreamTabId, StreamTabId>();
+  const resolveParent = (streamId: StreamTabId): StreamTabId | undefined =>
+    parentOf.get(streamId);
+  const resolveDescendants = (
+    streamId: StreamTabId,
+  ): readonly StreamTabId[] => {
+    const descendants: StreamTabId[] = [];
+    const pending = [streamId];
+    const seen = new Set(pending);
+    for (let index = 0; index < pending.length; index += 1) {
+      const parent = pending[index];
+      for (const [child, directParent] of parentOf) {
+        if (directParent !== parent || seen.has(child)) continue;
+        seen.add(child);
+        descendants.push(child);
+        pending.push(child);
       }
-      return descendants;
-    };
+    }
+    return descendants;
+  };
 
   const toolEdit = createStreamApprovalController({
     kind: 'toolEdit',
     interactions,
-    resolveParent: resolveParentFor('toolEdit'),
-    resolveDescendants: resolveDescendantsFor('toolEdit'),
+    resolveParent,
+    resolveDescendants,
   });
   const bash = createStreamApprovalController({
     kind: 'bash',
     interactions,
-    resolveParent: resolveParentFor('bash'),
-    resolveDescendants: resolveDescendantsFor('bash'),
+    resolveParent,
+    resolveDescendants,
   });
   const proposal = createStreamApprovalBypass(
     'superYolo',
     interactions,
-    resolveParentFor('proposal'),
-    resolveDescendantsFor('proposal'),
+    resolveParent,
+    resolveDescendants,
   );
   const bypassByKind: Record<BypassAncestryKind, StreamApprovalBypass> = {
     toolEdit: toolEdit.bypass,
@@ -319,21 +309,16 @@ export function createSessionApprovals(
     proposal,
   };
 
-  function detachKindFromParent(
-    kind: BypassAncestryKind,
-    streamId: StreamTabId,
-  ): void {
-    const graph = parentOf[kind];
-    if (!graph.has(streamId)) return;
-    const bypass = bypassByKind[kind];
-    const effectiveValue = bypass.isBypassed(streamId);
-    graph.delete(streamId);
-    bypass.setBypass(streamId, effectiveValue, { silent: true });
-  }
-
   function detachStreamFromParent(streamId: StreamTabId): void {
-    for (const kind of ALL_BYPASS_ANCESTRY_KINDS) {
-      detachKindFromParent(kind, streamId);
+    if (!parentOf.has(streamId)) return;
+    // Capture every kind's inherited value before the edge goes away, then
+    // pin each one as the stream's own explicit value.
+    const effectiveValues = ALL_BYPASS_ANCESTRY_KINDS.map(
+      (kind) => [kind, bypassByKind[kind].isBypassed(streamId)] as const,
+    );
+    parentOf.delete(streamId);
+    for (const [kind, effectiveValue] of effectiveValues) {
+      bypassByKind[kind].setBypass(streamId, effectiveValue, { silent: true });
     }
   }
 
@@ -350,31 +335,22 @@ export function createSessionApprovals(
       toolEdit.bypass.setBypass(streamId, enabled);
       bash.bypass.setBypass(streamId, enabled);
     },
-    registerStreamParent(
-      childStreamId,
-      parentStreamId,
-      kinds = ALL_BYPASS_ANCESTRY_KINDS,
-    ) {
-      for (const kind of kinds) {
-        parentOf[kind].set(childStreamId, parentStreamId);
-      }
+    registerStreamParent(childStreamId, parentStreamId) {
+      parentOf.set(childStreamId, parentStreamId);
     },
     detachStreamFromParent,
     forgetStreamAncestry(streamId) {
-      for (const kind of ALL_BYPASS_ANCESTRY_KINDS) {
-        const graph = parentOf[kind];
-        const directChildren = [...graph]
-          .filter(([, parent]) => parent === streamId)
-          .map(([child]) => child);
-        for (const child of directChildren) detachKindFromParent(kind, child);
-        graph.delete(streamId);
-      }
+      const directChildren = [...parentOf]
+        .filter(([, parent]) => parent === streamId)
+        .map(([child]) => child);
+      for (const child of directChildren) detachStreamFromParent(child);
+      parentOf.delete(streamId);
     },
     clearAll() {
       toolEdit.bypass.clearAll();
       bash.bypass.clearAll();
       proposal.clearAll();
-      for (const kind of ALL_BYPASS_ANCESTRY_KINDS) parentOf[kind].clear();
+      parentOf.clear();
     },
   };
 }

--- a/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
@@ -221,26 +221,6 @@ describe('child subagent stream approval inheritance', () => {
     expect(isApprovalBypassedForStream(child)).toBe(true);
   });
 
-  it('preserves independent ancestry when one kind loses its parent', () => {
-    const editParent = 'stream:edit-parent-cleanup' as StreamTabId;
-    const bashParent = 'stream:bash-parent-survives' as StreamTabId;
-    const child = 'stream:split-ancestry-child' as StreamTabId;
-    setToolEditApprovalSessionBypass(editParent, true, { silent: true });
-    setBashApprovalSessionBypass(bashParent, true, { silent: true });
-    currentSession().approvals.registerStreamParent(child, editParent, [
-      'toolEdit',
-    ]);
-    currentSession().approvals.registerStreamParent(child, bashParent, [
-      'bash',
-    ]);
-
-    cleanupApprovalsForStream(editParent);
-    setBashApprovalSessionBypass(bashParent, false, { silent: true });
-
-    expect(isApprovalBypassedForStream(child)).toBe(true);
-    expect(isBashApprovalBypassedForStream(child)).toBe(false);
-  });
-
   it('super-YOLO on an inheriting child pins its own edit bypass', () => {
     // `setDelegatedWorkBypasses` must write the child's own explicit
     // tool-edit entry even when `isBypassed` already reports true via
@@ -269,22 +249,5 @@ describe('child subagent stream approval inheritance', () => {
     expect(proposalApprovals().isBypassed(parent)).toBe(true);
     expect(proposalApprovals().isBypassed(child)).toBe(true);
     expect(proposalApprovals().isBypassed(grandchild)).toBe(true);
-  });
-
-  it('keeps ancestry graphs independent per bypass kind', () => {
-    // Ancestry used to be one shared graph for all three bypass kinds, so
-    // linking a child for bash inheritance silently let it inherit tool-edit
-    // YOLO too whenever the parent had it on. Each kind must resolve through
-    // its own graph: a bash-only link must not leak tool-edit bypass.
-    const { parent, child } = streamPair('split-kinds');
-    setToolEditApprovalSessionBypass(parent, true, { silent: true });
-    setBashApprovalSessionBypass(parent, true, { silent: true });
-
-    currentSession().approvals.registerStreamParent(child, parent, ['bash']);
-
-    expect(isBashApprovalBypassedForStream(child)).toBe(true);
-    // No ancestry link was registered for 'toolEdit', so the child stays
-    // gated even though the parent has tool-edit YOLO on.
-    expect(isApprovalBypassedForStream(child)).toBe(false);
   });
 });

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -1764,9 +1764,7 @@ describe('executionRegistry', () => {
 
     try {
       approvals.toolEdit.bypass.setBypass(parentStreamId, true);
-      approvals.registerStreamParent(childStreamId, parentStreamId, [
-        'toolEdit',
-      ]);
+      approvals.registerStreamParent(childStreamId, parentStreamId);
       registry.track(handle);
 
       registry.detachActiveChildren(parentStreamId);

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -39,10 +39,10 @@ export function proposalApprovals(
  * should do the same — and should keep following the parent when either
  * bypass is toggled *after* the child stream already started, since this
  * registers live ancestry links rather than copying the parent's values once
- * at child creation (see `registerStreamParent`). Ancestry is tracked per
- * bypass kind, so the CLI's distinct AUTO-BASH / AUTO-APPROVE grants are
- * respected: a parent with AUTO-BASH but edits still gated propagates only
- * bash, and fresh streams default to gated either way. Delegation-proposal
+ * at child creation (see `registerStreamParent`). Bypass values stay
+ * independent per kind, so the CLI's distinct AUTO-BASH / AUTO-APPROVE grants
+ * are respected: a parent with AUTO-BASH but edits still gated propagates
+ * only bash, and fresh streams default to gated either way. Delegation-proposal
  * bypass is linked as well, so complete delegated-task approval remains
  * effective when an orchestrator delegates to another orchestrator. A child
  * may still override any inherited approval explicitly.


### PR DESCRIPTION
## Summary

`createSessionApprovals` (`src/agent/runtime/streamApprovalQueue.ts`) kept **three**
separate `Map<StreamTabId, StreamTabId>` ancestry graphs — one per bypass kind
(`toolEdit`, `bash`, `proposal`) — so that a delegation could link only *some* kinds to
a parent. Nothing can construct such a link. This collapses them to one `Map`.

Removed along with the split:

- `resolveParentFor` / `resolveDescendantsFor`, two curried factories, become two plain
  functions closing over the single graph.
- `detachKindFromParent` folds into `detachStreamFromParent`.
- The `kinds` parameter on `registerStreamParent` and its 16-line JSDoc.

## Irreducibility — subset linking is unreachable by construction

This is not "an unused optional parameter". The capability has **no reachable caller
shape**:

- The sole delegation entry point, `configureDelegatedChildApprovals`
  (`src/tools/approval/index.ts:50-58`), takes no `kinds` parameter at all. It is fanned
  out from `subagentExecution.ts:140`, `WorkflowScriptTool.ts:531`, and
  `workflowScriptAgentRunner.ts:329` — all three verified in this branch.
- #9093 ("fix: inherit delegation approval in suborchestrators", merged **2026-07-23**)
  deleted the last production subset call, replacing
  `registerStreamParent(child, parent, ['bash', 'toolEdit'])` with the all-kinds form.
- The only other production caller, `packages/cli/src/chat/chatSessionController.ts:457`
  (round-to-round linking), also passes no `kinds`.
- `tsc` proves exactly four call sites in the tree — two production, two test. No fifth.

After the collapse, the leak the split guarded against — linking `bash` silently letting
a child inherit `toolEdit` — becomes **unrepresentable** rather than merely unguarded.
That is the stronger property.

## Overturning the docs non-goal

`docs/prds/2026-08-03-prd-approval-policy-unification.md:194-198` fences this file off:

> No change to the per-stream scoped-bypass machinery (`streamApprovalQueue.ts`), its
> ancestry inheritance, or its dispatch-time re-check.

A reviewer will cite it, so, verified in this branch:

- That PRD is dated **2026-08-03** — **eleven days after** #9093 (merged 2026-07-23)
  removed the last subset caller. The fence was written over machinery that had already
  become unreachable; it froze a shape, not a live requirement.
- Its tracking issue **#9597 ("Tracking: unify TeXRA approval policy across CLI, desktop,
  and extension") is CLOSED**, closed 2026-08-05. The non-goal has no live owner.

The **second half** of that same paragraph — "the `'proposal'` ancestry key vs
`'superYolo'` host-facing label split is intentional and documented" — still holds and is
**untouched here**. So are `BypassAncestryKind`, `ALL_BYPASS_ANCESTRY_KINDS`,
`bypassByKind`, and every per-kind bypass *value* map (`byStream`). Only the **parent
edge** is shared now; the bypass values remain independent per kind, which is what
actually makes the CLI's distinct AUTO-BASH / AUTO-APPROVE grants work (a parent with
AUTO-BASH on and edits gated still propagates only bash, because `toolEdit`'s own value
map answers `false` for the parent). The stale comment in `src/tools/approval/index.ts`
that credited this to per-kind *ancestry* is corrected to say per-kind *values*.

## Behavior preservation

`detachStreamFromParent` still captures every kind's inherited value **before** deleting
the edge, then pins each as an explicit silent value — so a detached child, or a child
orphaned by `forgetStreamAncestry`, keeps exactly the effective bypasses it had.
`forgetStreamAncestry` and `clearAll` reduce to single-graph operations.

## Tests

Two tests deleted, none added. Both constructed subset links by hand:

- `'preserves independent ancestry when one kind loses its parent'` — calls
  `registerStreamParent(child, editParent, ['toolEdit'])` then
  `registerStreamParent(child, bashParent, ['bash'])`.
- `'keeps ancestry graphs independent per bypass kind'` — calls
  `registerStreamParent(child, parent, ['bash'])`.

Production can no longer make either call, so both are tautological rather than reduced
coverage. `ExecutionRegistry.vitest.ts:1767` drops a now-redundant `['toolEdit']`
argument; all its assertions are unchanged and still pass.

## Net elements (R6)

| | before | after |
|---|---|---|
| ancestry graphs | 3 | 1 |
| curried factories | 2 (`resolveParentFor`, `resolveDescendantsFor`) | 0 |
| helper functions | 2 (`detachKindFromParent`, `detachStreamFromParent`) | 1 |
| public parameters | `registerStreamParent(child, parent, kinds?)` | `registerStreamParent(child, parent)` |

Net production LoC: **−24** (`streamApprovalQueue.ts` +60/−84, `approval/index.ts`
+4/−4). Total diff **+65/−128**. Nothing added; no new abstraction, no new export.

## Consumer counts (R8)

| symbol | production callers | test callers |
|---|---|---|
| `registerStreamParent` | 2 (`approval/index.ts:57`, `chatSessionController.ts:457`) | 2 before / 1 after |
| `kinds` parameter | **0** (since #9093, 2026-07-23) | 3 before / 0 after |
| `configureDelegatedChildApprovals` | 3 (`subagentExecution.ts:140`, `WorkflowScriptTool.ts:531`, `workflowScriptAgentRunner.ts:329`) | mocked |
| `detachKindFromParent` | 1 (file-local, now inlined) | 0 |

## Gates

Run from an isolated worktree at `origin/main` (`941e36404b`):

- `FORCE_COLOR=0 npx tsc --noEmit --checkers 8` — clean
- `FORCE_COLOR=0 npx tsc --noEmit --checkers 8 -p tsconfig.test-kernel.json` — clean
- `FORCE_COLOR=0 npx vitest run src/test-kernel/agent/followUp/ src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/tools/approval` — **223/223 pass, 22 files**
- `FORCE_COLOR=0 npx vitest run src/test-kernel/tools src/test-kernel/cli/chatSessionController.vitest.ts src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts src/test-kernel/architecture` — **983/983 pass, 118 files** (includes `approvalPolicyAuthorityRatchet`)
- `npx eslint` on the four changed files — clean
- `npx prettier --check` on the four changed files — clean
- `node scripts/check-dead-code-ratchet.mjs` — OK, 8 current vs 8 baselined, no new unused exports

`pnpm-lock.yaml` was reverted after install and is not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175CfQ2d7cLghAS23avg3Qp
