### PR TITLE
refactor(agent): collapse dead compat-inference, RoundSummary, and tool-conversion surface

### DIFF
--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -13,7 +13,6 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
   hasCompileFailures,
   hasRoundOutputs,
-  getStorageKey,
   roundsToPersisted,
   setCompileFailures,
 } from '../output/outputState';
@@ -22,11 +21,7 @@ import { extractFilesFromXml } from '../output/outputFileExtraction';
 import { traceFileLineage } from '../output/lineageMapping';
 import { resolveBaseFilesForDiff } from '../output/snapshotResolution';
 import { checkExpectedOutputs } from '../output/outputValidation';
-import {
-  blankRoundSummary,
-  summarizeRound,
-  type RoundSummary,
-} from '../output/roundSummary';
+import { summarizeRound, type RoundSummary } from '../output/roundSummary';
 import { formatCompileFailureRoundContext } from '../output/compileFailureRoundContext';
 import { tryOperation } from '../output/outputOperations';
 import type { LatexDiffManager } from '../output/LatexDiffManager';
@@ -197,12 +192,7 @@ export class OutputNode<C = unknown> extends BaseNode<
         `Output fallback summary failed; output files may be dropped: ${toErrorMessage(summaryError)}`,
         { data: summaryError },
       );
-      summary = blankRoundSummary({
-        storageKey: getStorageKey(outputState),
-        currRound: currentRound,
-        outputFile: outputLocation,
-        endTurn,
-      });
+      summary = { fileInfos: [], filesToOpen: [] };
     }
 
     outputState.rounds.set(currentRound, {

--- a/src/agent/implementations/flows/reflection/output/roundSummary.ts
+++ b/src/agent/implementations/flows/reflection/output/roundSummary.ts
@@ -24,28 +24,9 @@ import {
 import type { RoundFileMapping } from './types';
 
 export interface RoundSummary {
-  storageKey: StorageKey;
-  currRound: number;
   fileInfos: OutputFileInfo[];
   filesToOpen: FileLocation[];
-  outputFile: FileLocation;
-  endTurn: boolean;
   stage?: StageHandle;
-}
-
-/**
- * Constructs a round summary with no file info — the double-fault fallback
- * used when summarizing has itself thrown. Built here rather than as a bare
- * literal at the call site so a new {@link RoundSummary} field is surfaced
- * by the factory instead of silently omitted.
- */
-export function blankRoundSummary(options: {
-  storageKey: StorageKey;
-  currRound: number;
-  outputFile: FileLocation;
-  endTurn: boolean;
-}): RoundSummary {
-  return { ...options, fileInfos: [], filesToOpen: [] };
 }
 
 export async function summarizeRound(
@@ -98,15 +79,7 @@ export async function summarizeRound(
         messageType: MESSAGE_TYPES.INTERNAL,
       });
 
-      return {
-        storageKey,
-        currRound,
-        fileInfos,
-        filesToOpen,
-        outputFile,
-        endTurn: options.endTurn,
-        stage: scope,
-      };
+      return { fileInfos, filesToOpen, stage: scope };
     },
   );
 }

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -697,9 +697,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     if (tools?.length) {
       options.tools = toAnthropicTools(tools, {
+        // Web fetch ships on the same Anthropic models as native web search.
         supportsNativeWebSearch: this.capabilities.supportsNativeWebSearch,
-        // Web fetch is available on the same Anthropic models that support native web search
-        supportsNativeWebFetch: this.capabilities.supportsNativeWebSearch,
       });
 
       options.tool_choice =

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -532,7 +532,6 @@ interface AnthropicToolOptions {
   /** Whether the model supports native web search. Defaults to false. */
   supportsNativeWebSearch?: boolean;
   /** Whether the model supports native web fetch. Defaults to false. */
-  supportsNativeWebFetch?: boolean;
 }
 
 /**
@@ -542,13 +541,12 @@ export function toAnthropicTools(
   defs: ToolDefinition[],
   options: AnthropicToolOptions = {},
 ): ToolUnion[] {
-  const { supportsNativeWebSearch = false, supportsNativeWebFetch = false } =
-    options;
+  const { supportsNativeWebSearch = false } = options;
 
   /** Tools that require an explicit capability flag to use as native. */
   const CONDITIONAL_NATIVE_TOOLS: Record<string, boolean> = {
     web_search: supportsNativeWebSearch,
-    web_fetch: supportsNativeWebFetch,
+    web_fetch: supportsNativeWebSearch,
   };
 
   return defs.map<ToolUnion>((d) => {

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -529,9 +529,9 @@ export function toOpenAIResponseTools(
  * Options for Anthropic tool conversion.
  */
 interface AnthropicToolOptions {
-  /** Whether the model supports native web search. Defaults to false. */
+  /** Whether the model supports native web search and fetch. Defaults to
+   *  false; Anthropic ships the two on the same model set. */
   supportsNativeWebSearch?: boolean;
-  /** Whether the model supports native web fetch. Defaults to false. */
 }
 
 /**

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -21,10 +21,7 @@ import {
 import { createLog } from '@logger/logUtils';
 import type { StreamTabId, ExecutionId } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas';
-import {
-  inferAndLogPersistedModelHandlerCompatibilityKey,
-  inferPersistedModelHandlerCompatibilityKey,
-} from './modelHandlerCompatibilityInference';
+import { inferPersistedModelHandlerCompatibilityKey } from './modelHandlerCompatibilityInference';
 import {
   ModelHandlerCompatibilityKeySchema,
   type ModelHandlerCompatibilityKey,
@@ -196,10 +193,7 @@ async function retrieveToolUseResumeData(
     };
     const modelHandlerCompatibilityKey =
       parsedShared.data.modelHandlerCompatibilityKey ??
-      inferAndLogPersistedModelHandlerCompatibilityKey(
-        currentConfig.model,
-        logger,
-      );
+      inferPersistedModelHandlerCompatibilityKey(currentConfig.model);
 
     const shared: PreparedShared = {
       ...parsedShared.data,

--- a/src/agent/runtime/modelHandlerCompatibilityInference.ts
+++ b/src/agent/runtime/modelHandlerCompatibilityInference.ts
@@ -1,24 +1,11 @@
 import { ModelProvider } from 'llm-zoo';
 
-import type { AgentTrace } from '@agent/trace';
 import { getRuntimeModelConfig } from '@model/runtimeModelRegistry';
 import { isObject } from '@utils/core';
 import {
   ModelHandlerCompatibilityKeySchema,
   type ModelHandlerCompatibilityKey,
 } from './modelHandlerCompatibilityKey';
-
-/**
- * Narrow an arbitrary value to a plain-object record, or `undefined` if it
- * isn't one. `isObject` already narrows its own parameter, but narrowing
- * `message: ProviderMessage` (a union of provider SDK types with no common
- * shape) through it still leaves per-property access needing a cast — this
- * wraps that once for every shape-sniffing call site below instead of each
- * repeating `isObject(x) ? (x as Record<string, unknown>) : ...` by hand.
- */
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return isObject(value) ? value : undefined;
-}
 
 export function inferPersistedModelHandlerCompatibilityKey(
   model: string,
@@ -33,28 +20,12 @@ export function inferPersistedModelHandlerCompatibilityKey(
   return undefined;
 }
 
-export function inferAndLogPersistedModelHandlerCompatibilityKey(
-  model: string,
-  logger: Pick<AgentTrace, 'info'>,
-): ModelHandlerCompatibilityKey | undefined {
-  const compatibilityKey = inferPersistedModelHandlerCompatibilityKey(model);
-  if (compatibilityKey) {
-    logger.info(
-      'Inferred model-handler compatibility for keyless persisted run',
-      {
-        data: { model, compatibilityKey },
-      },
-    );
-  }
-  return compatibilityKey;
-}
-
 export function inferPersistedFlowModelHandlerCompatibilityKey(
   model: string,
   shared: unknown,
 ): ModelHandlerCompatibilityKey | undefined {
-  const record = asRecord(shared);
-  if (!record) return undefined;
+  if (!isObject(shared)) return undefined;
+  const record = shared;
 
   const parsedKey = ModelHandlerCompatibilityKeySchema.nullish().safeParse(
     record.modelHandlerCompatibilityKey,

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -284,7 +284,6 @@ export type DeleteExecutionResult =
 
 export interface DeleteAllExecutionsResult {
   readonly deleted: ExecutionId[];
-  readonly notFound: ExecutionId[];
   readonly active: ExecutionId[];
   readonly failed: readonly {
     readonly executionId: ExecutionId;
@@ -379,9 +378,6 @@ export async function deleteAllExecutions(
   return {
     deleted: results.flatMap((result) =>
       result.status === 'deleted' ? [result.executionId] : [],
-    ),
-    notFound: results.flatMap((result) =>
-      result.status === 'not-found' ? [result.executionId] : [],
     ),
     active: results.flatMap((result) =>
       result.status === 'active' ? [result.executionId] : [],

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -345,7 +345,7 @@ export interface DeleteAllExecutionsOptions {
 }
 
 /**
- * Delete every unleased execution and report deleted, raced-away, and active
+ * Delete every unleased execution and report deleted, active, and failed
  * execution IDs separately.
  */
 export async function deleteAllExecutions(

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerCompatibilityInference.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerCompatibilityInference.vitest.ts
@@ -1,18 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import type { AgentTrace } from '@agent/trace';
 import { inferPersistedFlowModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityInference';
-
-const info = vi.fn<AgentTrace['info']>();
 
 const GOOGLE_KEYLESS_ERROR =
   'Persisted Google sessions without a model-handler identity cannot be resumed.';
 
 describe('model handler compatibility inference', () => {
-  beforeEach(() => {
-    info.mockClear();
-  });
-
   it('rejects keyless Google transcripts without inspecting their format', () => {
     expect(() =>
       inferPersistedFlowModelHandlerCompatibilityKey('gemini35f', {
@@ -24,7 +17,6 @@ describe('model handler compatibility inference', () => {
         ],
       }),
     ).toThrow(GOOGLE_KEYLESS_ERROR);
-    expect(info).not.toHaveBeenCalled();
   });
 
   it('honors an explicitly persisted flow compatibility key', () => {
@@ -39,6 +31,5 @@ describe('model handler compatibility inference', () => {
         ],
       }),
     ).toBe('ModelHandlerOpenRouterNative');
-    expect(info).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerCompatibilityInference.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerCompatibilityInference.vitest.ts
@@ -1,13 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentTrace } from '@agent/trace';
-import {
-  inferAndLogPersistedModelHandlerCompatibilityKey,
-  inferPersistedFlowModelHandlerCompatibilityKey,
-} from '@agent/runtime/modelHandlerCompatibilityInference';
+import { inferPersistedFlowModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityInference';
 
 const info = vi.fn<AgentTrace['info']>();
-const logger: Pick<AgentTrace, 'info'> = { info };
 
 const GOOGLE_KEYLESS_ERROR =
   'Persisted Google sessions without a model-handler identity cannot be resumed.';
@@ -43,13 +39,6 @@ describe('model handler compatibility inference', () => {
         ],
       }),
     ).toBe('ModelHandlerOpenRouterNative');
-    expect(info).not.toHaveBeenCalled();
-  });
-
-  it('does not log when inference is inconclusive', () => {
-    expect(
-      inferAndLogPersistedModelHandlerCompatibilityKey('gpt54', logger),
-    ).toBeUndefined();
     expect(info).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -197,12 +197,8 @@ describe('output progress events', () => {
         },
         {
           summary: {
-            storageKey: 'run:output-node' as StorageKey,
-            currRound: 2,
             fileInfos: [fileInfo],
             filesToOpen: [openedLocation],
-            outputFile: outputLocation,
-            endTurn: false,
           },
           compileFailures: [],
           compiledArtifacts: [],
@@ -295,7 +291,7 @@ describe('output progress events', () => {
         endTurn: false,
       },
       {
-        summary: { ...fixture.summary, currRound: 1 },
+        summary: fixture.summary,
         compileFailures: [],
         compileResult,
         compiledArtifacts: [],

--- a/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
@@ -545,7 +545,6 @@ describe('cross-process execution leases', () => {
 
     await expect(deleteAllExecutions({ beforeDelete })).resolves.toEqual({
       deleted: [deletedId],
-      notFound: [],
       active: [activeId],
       failed: [],
     });
@@ -585,7 +584,6 @@ describe('cross-process execution leases', () => {
 
     await expect(deleteAllExecutions()).resolves.toEqual({
       deleted: [deletedId],
-      notFound: [],
       active: [],
       failed: [{ executionId: failedId, message: 'permission denied' }],
     });

--- a/src/test-kernel/cli/History.vitest.ts
+++ b/src/test-kernel/cli/History.vitest.ts
@@ -236,7 +236,6 @@ async function seedSidecarOnlySnapshots(
 function mockBulkDelete(deleted: string[]): void {
   mocks.deleteAllExecutions.mockResolvedValue({
     deleted,
-    notFound: [],
     active: [],
     failed: [],
   });


### PR DESCRIPTION
## What

Four verified-dead pieces of `src/agent`, all left behind by the 2026-08-17→19 campaign. Each is dead **at HEAD**, re-derived after `origin/main` moved 17 commits during this work.

## The four

**1. The compat-inference module no longer infers anything.**
`e4f35c87c3` deleted the `ModelProvider.COPILOT` arm — the only branch that ever returned a key. `inferPersistedModelHandlerCompatibilityKey` can now only `throw` (Google) or `return undefined`, which makes `if (compatibilityKey)` in the logging wrapper statically unreachable and its `logger` parameter dead. Drops the wrapper; `SessionResumeRetrieval` calls the guard directly.

Also drops `asRecord`, a single-caller helper whose docstring still described "every shape-sniffing call site below" and a `message: ProviderMessage` narrowing — neither exists in the file any more.

**2. `RoundSummary` carried four write-only fields.**
`storageKey`, `currRound`, `outputFile`, `endTurn` are never read: `post()` reads the same four facts off `prepRes` (`OutputNode.ts:229`). With them gone, `blankRoundSummary` degenerates to `{ fileInfos: [], filesToOpen: [] }`, and the reason its docstring gives for existing — surfacing new fields to the double-fault fallback — goes with them.

**3. `supportsNativeWebFetch` is one option with one value.**
Its single caller passes `capabilities.supportsNativeWebSearch`, with a comment stating the two always agree. There is no `capabilities.supportsNativeWebFetch` anywhere in the corpus.

**4. `DeleteAllExecutionsResult.notFound`** was built on every call and read by none. `DeleteExecutionResult.status: 'not-found'` **stays** — the single-delete path reads it.

## Deliberately not included

`getAgentsBySource` (`agentRegistry.ts:312`) is production-dead and was in scope. Deleting 4 LoC would force rewriting **6 assertions** across three tests that pin remote-agent invalidation after sign-out — real behavior with no other coverage. That is the churn §14 R5 bans, so it stays.

It remains valuable as the specimen for the test-as-consumer blind spot recorded in #11165.

## Net elements (R6)

- Files: 11 changed (7 production, 4 test)
- `^[+-]export` symbols: **−1** (`inferAndLogPersistedModelHandlerCompatibilityKey`)
- Functions: **−3** (that wrapper, `asRecord`, `blankRoundSummary`)
- Fields/options: **−6**
- Net LoC: **−97** (`12 insertions(+), 109 deletions(-)` vs `origin/main`)

## Consumer counts (R8)

Grepped with `--no-ignore-vcs` (a global gitignore hides tracked files from plain `rg` here — #11165):

- `inferAndLogPersistedModelHandlerCompatibilityKey` — 1 production caller, rerouted to the guard
- `asRecord` — 1 caller, same file
- `RoundSummary` — 1 production consumer (`OutputNode.ts`); `storageKey`/`currRound`/`outputFile`/`endTurn` readers: **0**
- `blankRoundSummary` — 1 caller
- `supportsNativeWebFetch` — 4 occurrences, all within the two touched files
- `DeleteAllExecutionsResult.notFound` — 0 readers (`.notFound` returns 0 hits across production)

## Checks

`typecheck` ✅ (exit 0) · `lint` ✅ (exit 0) · `format` ✅

`vitest run src/test-kernel/agent` ✅ — **200 files, 3094 tests, 0 failures**, plus `History.vitest.ts`.

Rebased onto current `origin/main` (`a841b2727c`); an earlier push of this branch briefly contained unrelated files from a concurrent agent in the same checkout and was corrected by force-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJmSeJm4wocNwc7AFMrJBU