### PR TITLE
refactor(tools): route run-root containment through the symlink-aware owner

### DIFF
--- a/src/tools/pathResolution.ts
+++ b/src/tools/pathResolution.ts
@@ -6,6 +6,7 @@ import {
   getRunContextWorkingDirectory,
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
+import { relativeToRoot } from '@platform/defaults/nodeWorkspace';
 import { ToolError } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { normalizeFilePath } from '@utils/core';
@@ -16,11 +17,7 @@ import {
 } from '@utils/files/externalRoots';
 import { locatePathInRoot } from '@utils/files/workspaceRoot';
 import { readPlatformSetting } from '@utils/config/platformSettings';
-import {
-  getPathSegments,
-  isPathWithin,
-  toPosixPath,
-} from '@utils/core/pathCore';
+import { getPathSegments, toPosixPath } from '@utils/core/pathCore';
 
 export interface WorkspacePathResolution {
   relative: string;
@@ -131,16 +128,20 @@ export function resolveWorkspaceRelativePath(
   if (root) {
     // Absolute paths need special handling — locatePathInRoot only works with relative paths.
     if (input && path.isAbsolute(input)) {
-      if (!isPathWithin(root, input)) {
+      // `relativeToRoot` owns containment for the whole repo: a lexical pass
+      // first, then a realpath comparison, so a root and a path that name the
+      // same directory through different symlink spellings resolve rather than
+      // being rejected. Re-deriving it here with a bare `isPathWithin` made
+      // this branch the only containment check in the repo that answers on
+      // spelling instead of identity.
+      const relative = relativeToRoot(root, input);
+      if (relative === undefined) {
         return resolveOutsideRoot(
           input,
           findExternalRoot(input),
           'Path must stay within the working directory.',
         );
       }
-      // Normalize to POSIX separators so .relative is consistent across platforms
-      // (locatePathInRoot and WorkspaceFS.locatePath already do this).
-      const relative = path.relative(root, input).replaceAll('\\', '/');
       return annotateExternalPermission({
         relative: relative || '.',
         absolute: input,

--- a/src/tools/pathResolution.ts
+++ b/src/tools/pathResolution.ts
@@ -128,12 +128,10 @@ export function resolveWorkspaceRelativePath(
   if (root) {
     // Absolute paths need special handling — locatePathInRoot only works with relative paths.
     if (input && path.isAbsolute(input)) {
-      // `relativeToRoot` owns containment for the whole repo: a lexical pass
-      // first, then a realpath comparison, so a root and a path that name the
-      // same directory through different symlink spellings resolve rather than
-      // being rejected. Re-deriving it here with a bare `isPathWithin` made
-      // this branch the only containment check in the repo that answers on
-      // spelling instead of identity.
+      // `relativeToRoot` is the shared symlink-aware absolute-path containment
+      // helper: it tries a lexical pass, then compares realpaths, so a root and
+      // path that name the same directory through different symlink spellings
+      // resolve rather than being rejected.
       const relative = relativeToRoot(root, input);
       if (relative === undefined) {
         return resolveOutsideRoot(


### PR DESCRIPTION
> **Land this last.** It is the only user-visible change in the sweep batch, and it moves a security boundary — in the widening direction.

`resolveWorkspaceRelativePath`'s absolute-path-with-explicit-root branch re-derived path containment with a bare `isPathWithin` + `path.relative` instead of calling `relativeToRoot`, the owner every other containment check in the repo goes through. `relativeToRoot` does a lexical pass **and then** falls back to comparing realpaths. The hand-rolled copy had only the lexical half.

The function's own JSDoc calls it a *"thin policy wrapper around `WorkspaceFS.locatePath()` / `locatePathInRoot()`"* — this branch called neither. Unintended drift, not policy.

## Executed, not asserted

With `root` = `/tmp/p/link/proj`, where `link` → `real`:

| input | hand-rolled | `relativeToRoot` |
|---|---|---|
| `/tmp/p/real/proj/main.tex` | **THROWS** | `"main.tex"` |
| `/tmp/p/link/proj/main.tex` | `"main.tex"` | `"main.tex"` |

Same file, same root, two answers depending on how the caller spelled the path. Both spellings are reachable in practice: bash re-derives `$PWD` from `getcwd()` and hands back the **physical** path, while an interactive shell's `pwd` builtin returns the **logical** one.

## This widens protection; it never narrows

The lexical fast pass is preserved verbatim *inside* `relativeToRoot`, so **every path that resolved before still resolves**. What changes is that a path lexically outside the root but canonically inside now resolves instead of throwing — which is already the shipped behavior on desktop, where no explicit root is passed and the call goes through `WorkspaceFS.locatePath`.

External-root registry lookups and the `TOOL_PATH_PROTECTION_ENABLED` gate are untouched. A path outside **both** spellings takes exactly the same rejection path as before.

## Scope

Only this branch. Canonicalizing `parseWorkingDirectory` was considered and **rejected**: it is unnecessary once this branch agrees, and it would silently change four other production sites — including `delegation/inputFields.ts:161`, whose value is *persisted* into `RunRecord.workingDirectory` and shown to users in approval summaries.

Net **−1 line** after rebasing onto current `main`; the `isPathWithin` import drops out. No call sites change.

## Verified

- `npx tsc --noEmit --checkers 8` and the test-kernel config — both clean.
- `PathResolution`, `grep`, `GlobTool`, `ProgressAgentProposalController` suites — **29 tests passed**.
- `eslint` and `prettier` — clean.

## Unrelated flake worth filing separately

While gating this I chased an intermittent failure in `src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts` ("does not introduce new top-level src subsystem edge types"). It is **not caused by this change** — measured isolated, it runs 1579ms with the change vs 1754ms without. The real cause: the test takes **5946ms inside a directory run against a 10000ms `testTimeout`**, so it times out whenever the machine is under parallel load. It will flake in CI. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175CfQ2d7cLghAS23avg3Qp

## Net elements (R6)

- One production file changed, with 8 additions and 9 deletions, for a net reduction of one line.
- No exported declarations are added or removed. One duplicated containment implementation and its `isPathWithin` import are removed in favor of the existing `relativeToRoot` owner.
- No test files are changed.

## Consumer counts (R8)

- `resolveWorkspaceRelativePath` keeps its existing consumers and public contract.
- `relativeToRoot` already had multiple production consumers through the node workspace and desktop path surfaces; this change adds one direct consumer.
- No event, subscription, or output path is deleted or re-routed.
