### PR TITLE
refactor(copy): give six cross-host sentences one owner each

### DIFF
--- a/packages/cli/src/runtime/cliPresentationHost.ts
+++ b/packages/cli/src/runtime/cliPresentationHost.ts
@@ -9,7 +9,7 @@ import {
 } from '@agent/runtime';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 import type { ApprovalBypassKind } from '@shared/approvalBypassKind';
-import { INSTRUCTION_ACTION, type InstructionAction } from '@shared/schemas';
+import { formatInstructionActionHint } from '@shared/copy/instructionActionHint';
 
 // Local imports - CLI runtime
 import {
@@ -42,22 +42,6 @@ const ApprovalBypassNdjsonEvent = {
   toolEdit: 'updateToolEditApprovalBypassState',
   superYolo: 'updateSuperYoloBypassState',
 } as const satisfies Record<ApprovalBypassKind, string>;
-
-/**
- * Human-readable phrasing for {@link InstructionAction} tokens printed to
- * stderr in text mode. Mirrors what the VS Code extension's
- * `INSTRUCTION_ACTION_VIEW` (packages/extension/src/frontend/events/
- * agentEventListeners.ts) conveys via its button titles, translated to CLI
- * phrasing since there's no button to click here. The `satisfies` clause keeps
- * the table exhaustive at compile time, but the lookup type stays partial: an
- * action token can arrive from a newer producer over the wire, and those fall
- * back to the raw token rather than printing an empty hint.
- */
-const INSTRUCTION_ACTION_HINT: Partial<Record<InstructionAction, string>> = {
-  [INSTRUCTION_ACTION.SET_API_KEY]: 'set your API key (texra setup)',
-  [INSTRUCTION_ACTION.OPEN_CONFIGURATION_GUIDE]: 'see the configuration guide',
-  [INSTRUCTION_ACTION.OPEN_MODELS_DOC]: 'see the model documentation',
-} satisfies Record<InstructionAction, string>;
 
 /**
  * Builds the NDJSON-mode handler map. `requestOpenFile` and
@@ -134,11 +118,7 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
         // an actionable instruction (e.g. missing API key), not routine
         // progress noise.
         runProgress?.preserve();
-        const hint = payload.actions?.length
-          ? ` (${payload.actions
-              .map((action) => INSTRUCTION_ACTION_HINT[action] ?? action)
-              .join(', ')})`
-          : '';
+        const hint = formatInstructionActionHint(payload.actions, 'cli');
         ensureLogger().info(`${payload.message}${hint}`);
         return true;
       },

--- a/packages/cli/src/runtime/modelAccessRoute.ts
+++ b/packages/cli/src/runtime/modelAccessRoute.ts
@@ -4,6 +4,7 @@ import {
   type CodingPlanSubscription,
   type CodingPlanSubscriptionId,
 } from '@shared/codingPlanSubscriptions';
+import { CHATGPT_AUTH, GROK_AUTH } from '@shared/copy/accountAuth';
 import { OWN_API_KEYS } from '@shared/copy/modelAccess';
 
 // Kept to one rendered row: the /api form and the orchestration header both
@@ -168,9 +169,9 @@ export function shortCliModelAccessRoute(route: CliModelAccessRoute): string {
 export function formatCliModelAccessRoute(route: CliModelAccessRoute): string {
   switch (route) {
     case 'chatgpt':
-      return 'ChatGPT subscription';
+      return CHATGPT_AUTH.subscriptionLabel;
     case 'grok':
-      return 'Grok subscription';
+      return GROK_AUTH.subscriptionLabel;
     case 'kimi-code':
       return 'Kimi Code subscription';
     case 'glm-code':
@@ -263,13 +264,13 @@ const oauthSubscriptionAccessItems = [
   {
     provider: 'chatgpt',
     preference: 'chatGpt',
-    label: 'Prefer ChatGPT subscription',
+    label: CHATGPT_AUTH.preferLabel,
     formatDescription: formatCliChatGptPreference,
   },
   {
     provider: 'grok',
     preference: 'grok',
-    label: 'Prefer Grok subscription',
+    label: GROK_AUTH.preferLabel,
     formatDescription: formatCliGrokPreference,
   },
 ] as const satisfies ReadonlyArray<{

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -6,6 +6,7 @@ import {
 import type { ExecutionId } from '@shared/schemas';
 import { agentKeyOf, agentName } from '@shared/schemas';
 import { implicitDefaultToolUseAgents } from '@shared/constants/agents';
+import { CHATGPT_AUTH, GROK_AUTH } from '@shared/copy/accountAuth';
 import { formatResultCount } from '@utils/text/stringUtils';
 
 import {
@@ -244,8 +245,8 @@ export function buildCliAccountItems(
         provider: 'chatgpt',
         operation: 'sign-out',
       },
-      label: 'Sign out of ChatGPT',
-      description: status.chatGptAccountLabel ?? 'ChatGPT subscription',
+      label: CHATGPT_AUTH.signOutLabel,
+      description: status.chatGptAccountLabel ?? CHATGPT_AUTH.subscriptionLabel,
     });
   } else {
     items.push({
@@ -254,7 +255,7 @@ export function buildCliAccountItems(
         provider: 'chatgpt',
         operation: 'sign-in',
       },
-      label: 'Sign in with ChatGPT',
+      label: CHATGPT_AUTH.signInLabel,
       description: 'Use a ChatGPT subscription',
     });
   }
@@ -266,8 +267,8 @@ export function buildCliAccountItems(
         provider: 'grok',
         operation: 'sign-out',
       },
-      label: 'Sign out of Grok',
-      description: status.grokAccountLabel ?? 'Grok subscription',
+      label: GROK_AUTH.signOutLabel,
+      description: status.grokAccountLabel ?? GROK_AUTH.subscriptionLabel,
     });
   } else {
     items.push({
@@ -276,7 +277,7 @@ export function buildCliAccountItems(
         provider: 'grok',
         operation: 'sign-in',
       },
-      label: 'Sign in with Grok',
+      label: GROK_AUTH.signInLabel,
       description: 'Use a Grok / SuperGrok subscription',
     });
   }

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -74,24 +74,31 @@ import {
 import type {
   ExecutionId,
   FileOpResult,
-  InstructionAction,
   MainViewExecuteMessage,
   MainViewPersistedState,
   RequestOpenFilePayload,
   SettingsTabPanelName,
   StreamTabId,
 } from '@shared/schemas';
-import { INSTRUCTION_ACTION } from '@shared/schemas';
 import { unsupported, unsupportedCommands } from '@shared/utils/dispatcher';
 import {
   formatActiveStreamRetention,
   formatStreamDeletionRetention,
 } from '@shared/copy/executionHistory';
-import { SESSION_DISPOSED_CAUSE } from '@shared/copy/interactionCancellation';
+import { formatInstructionActionHint } from '@shared/copy/instructionActionHint';
+import {
+  ALL_STREAMS_DELETED_CAUSE,
+  RETRY_REQUEST_CLEARED_CAUSE,
+  SESSION_DISPOSED_CAUSE,
+} from '@shared/copy/interactionCancellation';
 import { cleanupUnscopedApprovals } from '@tools/approval';
 import { startRecording, stopRecordingAndTranscribe } from '@tools/media/audio';
 import type { RunMetadata } from '@transcript/StreamSnapshotStore';
-import { findTranscriptSpillFile } from '@transcript/spillArtifacts';
+import {
+  findTranscriptSpillFile,
+  spillArtifactOpenFailedMessage,
+  SPILL_ARTIFACT_DELETED_MESSAGE,
+} from '@transcript/spillArtifacts';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -129,20 +136,6 @@ function operationLabel(operation: WorkflowFileOperation) {
  * hosts instead of silently doing nothing.
  */
 export type DesktopStreamRevealResult = 'revealed' | 'missing';
-
-/**
- * Desktop phrasing for the {@link InstructionAction} tokens the agent core
- * emits. The extension turns each token into a command button and the CLI into
- * a stderr hint; the desktop dialog has no buttons, so it reads as a hint too.
- * The `satisfies` clause keeps the table exhaustive at compile time while the
- * lookup type stays partial, so a token from a newer producer falls back to the
- * raw token rather than printing nothing.
- */
-const INSTRUCTION_ACTION_HINT: Partial<Record<InstructionAction, string>> = {
-  [INSTRUCTION_ACTION.SET_API_KEY]: 'set your API key in Settings',
-  [INSTRUCTION_ACTION.OPEN_CONFIGURATION_GUIDE]: 'see the configuration guide',
-  [INSTRUCTION_ACTION.OPEN_MODELS_DOC]: 'see the model documentation',
-} satisfies Record<InstructionAction, string>;
 
 export interface DesktopAgentExecutionOptions {
   postToRenderer(message: unknown): boolean | void;
@@ -232,11 +225,10 @@ export class DesktopProgressBridge {
         // the info dialog. The desktop dialog carries no buttons, so the
         // action tokens the extension renders as buttons become trailing
         // hint text and `showSuppress` has no affordance to attach to.
-        const hint = instruction.actions?.length
-          ? ` (${instruction.actions
-              .map((action) => INSTRUCTION_ACTION_HINT[action] ?? action)
-              .join(', ')})`
-          : '';
+        const hint = formatInstructionActionHint(
+          instruction.actions,
+          'desktop',
+        );
         return this.settleHostDialog(
           this.options.host.showInfoMessage(`${instruction.message}${hint}`),
           'Failed to present the instruction dialog',
@@ -285,7 +277,7 @@ export class DesktopProgressBridge {
             this.session.interactions.cancel({
               streamId: stream,
               kind: 'retry',
-              cause: 'Retry request cleared.',
+              cause: RETRY_REQUEST_CLEARED_CAUSE,
             });
           }
           this.session.executions.stopAgentStream(stream, {
@@ -299,7 +291,9 @@ export class DesktopProgressBridge {
         cleanupDeletedStreams: ({ allDeleted }) => {
           if (!allDeleted) return;
           cleanupUnscopedApprovals(this.session);
-          this.session.interactions.cancel({ cause: 'All streams deleted.' });
+          this.session.interactions.cancel({
+            cause: ALL_STREAMS_DELETED_CAUSE,
+          });
           this.clearDesktopPresentationState();
           this.workflowFileActions.clearAllBackups();
         },
@@ -768,13 +762,13 @@ export class DesktopProgressBridge {
             file = await findTranscriptSpillFile(spillPath);
           } catch (error) {
             await this.options.host.showErrorMessage(
-              `Full output could not be opened: ${toErrorMessage(error)}`,
+              spillArtifactOpenFailedMessage(toErrorMessage(error)),
             );
             return;
           }
           if (!file) {
             await this.options.host.showErrorMessage(
-              'Full output is unavailable because this run artifact was deleted.',
+              SPILL_ARTIFACT_DELETED_MESSAGE,
             );
             return;
           }

--- a/packages/desktop/src/main/desktopProgressFileActions.ts
+++ b/packages/desktop/src/main/desktopProgressFileActions.ts
@@ -7,6 +7,11 @@ import { appSignals } from '@eventBus/AppSignals';
 import { acceptEditedFileReplace } from '@latex/acceptedFileTarget';
 import { openFirstLabelMatch } from '@latex/labelSearch';
 import { LaTeXdiffService } from '@latex/latexdiff';
+import {
+  latexdiffAllFailedMessage,
+  LATEXDIFF_GENERATE_FAILED_MESSAGE,
+  NO_LATEXDIFF_OPERATIONS_MESSAGE,
+} from '@latex/latexdiff/latexdiffCopy';
 import { DEFAULT_MATH_MARKUP } from '@latex/latexdiff/mathMarkup';
 import { runLatexdiffForExecution } from '@latex/latexdiff/runLatexdiff';
 import type {
@@ -155,16 +160,14 @@ export class DesktopProgressFileActions {
   ): Promise<void> {
     const outcome = await this.runSharedLatexdiff(runContext);
     if (!outcome || outcome.results.length === 0) {
-      await this.ui.showInfoMessage(
-        'No LaTeX diff operations available for this run.',
-      );
+      await this.ui.showInfoMessage(NO_LATEXDIFF_OPERATIONS_MESSAGE);
       return;
     }
 
     if (await this.openSharedLatexdiffResults(outcome)) return;
 
     await this.ui.showErrorMessage(
-      `All LaTeX diff operations failed (math markup: "${DEFAULT_MATH_MARKUP}").`,
+      latexdiffAllFailedMessage(DEFAULT_MATH_MARKUP),
     );
   }
 
@@ -179,7 +182,7 @@ export class DesktopProgressFileActions {
 
     if (!result.success || !result.diffPath) {
       await this.ui.showErrorMessage(
-        result.message ?? 'Failed to generate diff file.',
+        result.message ?? LATEXDIFF_GENERATE_FAILED_MESSAGE,
       );
       return;
     }

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -30,6 +30,9 @@ import { GoalStore, subscribeGoalStateChanges } from '@tools/goal';
 import { refreshToolAvailability } from '@tools/toolAvailability';
 import {
   GITHUB_TOKEN_CREATE_URL,
+  GITHUB_TOKEN_PROMPT,
+  GITHUB_TOKEN_REMOVED_MESSAGE,
+  GITHUB_TOKEN_SAVED_MESSAGE,
   GITHUB_TOKEN_STORAGE_KEY,
   resolveGitHubTokenSource,
 } from '@tools/github/githubAuth';
@@ -309,19 +312,18 @@ export function createDesktopSettingsIpc(
   async function setGitHubToken(): Promise<void> {
     const token = await options.ui.promptForSecret?.({
       title: 'GitHub token',
-      prompt:
-        'Paste a GitHub personal access token (repo or public_repo scope)',
+      prompt: GITHUB_TOKEN_PROMPT,
     });
     if (!token?.trim()) return;
     await platform().secrets.set(GITHUB_TOKEN_STORAGE_KEY, token.trim());
-    await options.ui.showInfoMessage('GitHub token saved.');
+    await options.ui.showInfoMessage(GITHUB_TOKEN_SAVED_MESSAGE);
     await postGitHubTokenStatus();
     await refreshToolAvailability();
   }
 
   async function removeGitHubToken(): Promise<void> {
     await platform().secrets.delete(GITHUB_TOKEN_STORAGE_KEY);
-    await options.ui.showInfoMessage('GitHub token removed.');
+    await options.ui.showInfoMessage(GITHUB_TOKEN_REMOVED_MESSAGE);
     await postGitHubTokenStatus();
     await refreshToolAvailability();
   }

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -26,6 +26,11 @@ import {
   normalizeRunLatexdiffOutputsByRound,
   runLatexdiffForExecution,
 } from '@latex/latexdiff/runLatexdiff';
+import {
+  latexdiffAllFailedMessage,
+  LATEXDIFF_GENERATE_FAILED_MESSAGE,
+  NO_LATEXDIFF_OPERATIONS_MESSAGE,
+} from '@latex/latexdiff/latexdiffCopy';
 import { CHANNEL, latexdiffService } from '@latex/latexdiff/service';
 import {
   DEFAULT_MATH_MARKUP,
@@ -249,7 +254,7 @@ async function runDiffAndOpen(
 
   const result = await runDiff(mathMarkup);
   if (!result.success || !result.diffPath) {
-    throw new Error(result.message ?? 'Failed to generate diff file');
+    throw new Error(result.message ?? LATEXDIFF_GENERATE_FAILED_MESSAGE);
   }
   await openLatexdiffResult(result.diffPath);
 }
@@ -424,19 +429,14 @@ async function handleRunLatexdiff(
       const { results } = outcome;
 
       if (results.length === 0) {
-        vscode.window.showInformationMessage(
-          'No LaTeX diff operations available for this run.',
-        );
+        vscode.window.showInformationMessage(NO_LATEXDIFF_OPERATIONS_MESSAGE);
         return;
       }
 
       const successCount = results.filter((r) => r.success).length;
 
       if (successCount === 0) {
-        await showLoggedMessage(
-          CHANNEL,
-          `All LaTeX diff operations failed (math markup: "${mathMarkup}")`,
-        );
+        await showLoggedMessage(CHANNEL, latexdiffAllFailedMessage(mathMarkup));
       } else if (successCount < results.length) {
         vscode.window.showWarningMessage(
           `${successCount} of ${results.length} LaTeX diff operations completed successfully (math markup: "${mathMarkup}")`,

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -52,12 +52,20 @@ import {
   GETTING_STARTED_COMMANDS,
 } from '@shared/schemas';
 import { COMMON_COMMANDS, PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import {
+  ALL_STREAMS_DELETED_CAUSE,
+  RETRY_REQUEST_CLEARED_CAUSE,
+} from '@shared/copy/interactionCancellation';
 import { unsupportedCommands } from '@shared/utils/dispatcher';
 import {
   cleanupUnscopedApprovals,
   releaseStreamResources,
 } from '@tools/approval';
-import { findTranscriptSpillFile } from '@transcript';
+import {
+  findTranscriptSpillFile,
+  spillArtifactOpenFailedMessage,
+  SPILL_ARTIFACT_DELETED_MESSAGE,
+} from '@transcript';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { pathToLocation } from '@utils/files/fileLocation';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
@@ -165,7 +173,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       this.interactions.cancel({
         streamId: stream,
         kind: 'retry',
-        cause: 'Retry request cleared.',
+        cause: RETRY_REQUEST_CLEARED_CAUSE,
       });
     }
     // Deletion must stop if the command fails; safeExecuteCommand intentionally
@@ -181,7 +189,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   public cleanupDeletedStreams(options: { allDeleted: boolean }): void {
     if (!options.allDeleted) return;
     cleanupUnscopedApprovals();
-    this.interactions.cancel({ cause: 'All streams deleted.' });
+    this.interactions.cancel({ cause: ALL_STREAMS_DELETED_CAUSE });
   }
 
   /** Execute a VS Code command, routing failures through this view's error channel. */
@@ -546,9 +554,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
             await defaultSession().flushArtifacts();
             const file = await findTranscriptSpillFile(spillPath);
             if (!file) {
-              await this.host.error(
-                'Full output is unavailable because this run artifact was deleted.',
-              );
+              await this.host.error(SPILL_ARTIFACT_DELETED_MESSAGE);
               return;
             }
             const document = await vscode.workspace.openTextDocument(
@@ -557,7 +563,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
             await vscode.window.showTextDocument(document, { preview: true });
           } catch (error) {
             await this.host.error(
-              `Full output could not be opened: ${toErrorMessage(error)}`,
+              spillArtifactOpenFailedMessage(toErrorMessage(error)),
             );
           }
         },

--- a/packages/extension/src/settingsView/frontend/components/profile/SubscriptionSection.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/SubscriptionSection.ts
@@ -23,6 +23,7 @@ import type {
   GrokAuthStatus,
   SubscriptionUsageSnapshot,
 } from '@shared/schemas';
+import { CHATGPT_AUTH, GROK_AUTH } from '@shared/copy/accountAuth';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import {
   renderSettingsSectionHeading,
@@ -169,16 +170,16 @@ export class SubscriptionSection extends LitElement {
 export const CHATGPT_SUBSCRIPTION_SECTION: SubscriptionSectionProvider =
   Object.freeze({
     sectionId: 'chatgpt-subscription',
-    title: 'ChatGPT subscription',
+    title: CHATGPT_AUTH.subscriptionLabel,
     description:
       'Use OpenAI models through your ChatGPT Plus, Pro, or Team subscription. No OpenAI API key is needed.',
     note: 'The subscription currently uses a 272,000-token Codex context cap, not the full 1,000,000-token API context.',
-    preferLabel: 'Prefer ChatGPT subscription',
+    preferLabel: CHATGPT_AUTH.preferLabel,
     preferDescription: 'Use the subscription for eligible Codex models.',
     accountTitle: 'ChatGPT account',
     connectDescription:
       'Connect the ChatGPT account that owns your subscription.',
-    signInText: 'Sign in with ChatGPT',
+    signInText: CHATGPT_AUTH.signInLabel,
     commands: Object.freeze({
       setPreferSubscription:
         SETTINGS_VIEW_COMMANDS.SET_CHATGPT_PREFER_SUBSCRIPTION,
@@ -196,16 +197,16 @@ export const CHATGPT_SUBSCRIPTION_SECTION: SubscriptionSectionProvider =
 export const GROK_SUBSCRIPTION_SECTION: SubscriptionSectionProvider =
   Object.freeze({
     sectionId: 'grok-subscription',
-    title: 'Grok subscription',
+    title: GROK_AUTH.subscriptionLabel,
     description:
       'Use xAI Grok models through your SuperGrok / xAI account. No xAI API key is needed.',
     note: 'Uses the public Grok CLI OAuth client. xAI may change or revoke that registration without notice.',
-    preferLabel: 'Prefer Grok subscription',
+    preferLabel: GROK_AUTH.preferLabel,
     preferDescription: 'Use the subscription instead of an xAI API key.',
     accountTitle: 'Grok account',
     connectDescription:
       'Connect the xAI account that owns your SuperGrok plan.',
-    signInText: 'Sign in with Grok',
+    signInText: GROK_AUTH.signInLabel,
     commands: Object.freeze({
       setPreferSubscription:
         SETTINGS_VIEW_COMMANDS.SET_GROK_PREFER_SUBSCRIPTION,

--- a/packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts
@@ -22,6 +22,9 @@ import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { SETTINGS_VIEW_CMD, type SettingsMessageFor } from '@shared/schemas';
 import {
   GITHUB_TOKEN_CREATE_URL,
+  GITHUB_TOKEN_PROMPT,
+  GITHUB_TOKEN_REMOVED_MESSAGE,
+  GITHUB_TOKEN_SAVED_MESSAGE,
   GITHUB_TOKEN_STORAGE_KEY,
 } from '@tools/github/githubAuth';
 import {
@@ -43,8 +46,7 @@ export class GitHubSubscriptionHandlers {
 
   async handleSetGitHubToken(): Promise<void> {
     const token = await vscode.window.showInputBox({
-      prompt:
-        'Paste a GitHub personal access token (repo or public_repo scope)',
+      prompt: GITHUB_TOKEN_PROMPT,
       password: true,
       placeHolder: 'ghp_…',
       ignoreFocusOut: true,
@@ -56,7 +58,7 @@ export class GitHubSubscriptionHandlers {
       'Failed to save GitHub token',
       async () => {
         await platform().secrets.set(GITHUB_TOKEN_STORAGE_KEY, trimmed);
-        void vscode.window.showInformationMessage('GitHub token saved.');
+        void vscode.window.showInformationMessage(GITHUB_TOKEN_SAVED_MESSAGE);
         await this.ctx.withActiveWebview((w) => this.sendGitHubTokenStatus(w));
       },
     );
@@ -68,7 +70,7 @@ export class GitHubSubscriptionHandlers {
       'Failed to remove GitHub token',
       async () => {
         await platform().secrets.delete(GITHUB_TOKEN_STORAGE_KEY);
-        void vscode.window.showInformationMessage('GitHub token removed.');
+        void vscode.window.showInformationMessage(GITHUB_TOKEN_REMOVED_MESSAGE);
         await this.ctx.withActiveWebview((w) => this.sendGitHubTokenStatus(w));
       },
     );

--- a/src/auth/codex/codexSessionTypes.ts
+++ b/src/auth/codex/codexSessionTypes.ts
@@ -7,6 +7,8 @@
  */
 import { z } from 'zod';
 
+import { CHATGPT_AUTH } from '@shared/copy/accountAuth';
+
 import {
   SubscriptionOAuthError,
   type SubscriptionOAuthErrorKind,
@@ -93,8 +95,9 @@ export class CodexAuthError extends SubscriptionOAuthError {
 export function formatCodexAuthUnavailableMessage(
   error: CodexAuthError,
 ): string {
+  const turnOff = `turn off "${CHATGPT_AUTH.preferLabel}".`;
   const action = error.needsReauth
-    ? 'Sign in with ChatGPT again, or turn off "Prefer ChatGPT subscription".'
-    : 'Try again in a moment, or turn off "Prefer ChatGPT subscription".';
-  return `ChatGPT subscription unavailable: ${error.message} ${action}`;
+    ? `${CHATGPT_AUTH.signInLabel} again, or ${turnOff}`
+    : `Try again in a moment, or ${turnOff}`;
+  return `${CHATGPT_AUTH.subscriptionLabel} unavailable: ${error.message} ${action}`;
 }

--- a/src/auth/xai/xaiSessionTypes.ts
+++ b/src/auth/xai/xaiSessionTypes.ts
@@ -4,6 +4,8 @@
  */
 import { z } from 'zod';
 
+import { GROK_AUTH } from '@shared/copy/accountAuth';
+
 import { XAI_DEFAULT_EXPIRES_IN_SEC } from './xaiConstants';
 import {
   SubscriptionOAuthError,
@@ -70,8 +72,9 @@ export class XaiAuthError extends SubscriptionOAuthError {
 }
 
 export function formatXaiAuthUnavailableMessage(error: XaiAuthError): string {
+  const turnOff = `turn off "${GROK_AUTH.preferLabel}".`;
   const action = error.needsReauth
-    ? 'Sign in with Grok again, or turn off "Prefer Grok subscription".'
-    : 'Try again in a moment, or turn off "Prefer Grok subscription".';
-  return `Grok subscription unavailable: ${error.message} ${action}`;
+    ? `${GROK_AUTH.signInLabel} again, or ${turnOff}`
+    : `Try again in a moment, or ${turnOff}`;
+  return `${GROK_AUTH.subscriptionLabel} unavailable: ${error.message} ${action}`;
 }

--- a/src/latex/latexdiff/latexdiffCopy.ts
+++ b/src/latex/latexdiff/latexdiffCopy.ts
@@ -1,0 +1,31 @@
+/**
+ * User-facing sentences for a latexdiff run's outcome.
+ *
+ * The VS Code command and the desktop stream-toolbar action drive the same
+ * `runLatexdiffForExecution` and report the same outcomes; they differ only in
+ * which dialog they route them through and how much detail they show (the
+ * extension also reports partial success, which has one caller and stays
+ * there). Keeping the sentences here is what stops the two hosts from
+ * disagreeing about the wording of an outcome they compute identically.
+ */
+
+import type { MathMarkupOption } from './mathMarkup';
+
+/** The run produced no diff operation to report on at all. */
+export const NO_LATEXDIFF_OPERATIONS_MESSAGE =
+  'No LaTeX diff operations available for this run.';
+
+/** A single `runDiff` call returned no usable diff path. */
+export const LATEXDIFF_GENERATE_FAILED_MESSAGE =
+  'Failed to generate diff file.';
+
+/**
+ * Every operation in a run failed. No trailing period: this sentence belongs to
+ * the markup-annotated family the extension also uses for its partial-success
+ * and all-succeeded lines.
+ */
+export function latexdiffAllFailedMessage(
+  mathMarkup: MathMarkupOption,
+): string {
+  return `All LaTeX diff operations failed (math markup: "${mathMarkup}")`;
+}

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -8,6 +8,7 @@ import type { StateStore } from '@platform/interfaces';
 import { platform } from '@platform/platform';
 import type { PlatformSecrets } from '@platform/secrets';
 import type { ModelAvailabilityKind, ModelOptionData } from '@shared/schemas';
+import { CHATGPT_AUTH, GROK_AUTH } from '@shared/copy/accountAuth';
 import {
   DEFAULT_HELPER_MODEL,
   providerDisplayName,
@@ -107,7 +108,7 @@ const AVAILABILITY_STATUS_FIELDS = {
     requiresKey: true,
   },
   'subscription-access': {
-    label: 'ChatGPT subscription',
+    label: CHATGPT_AUTH.subscriptionLabel,
     available: true,
     requiresKey: false,
   },
@@ -348,7 +349,7 @@ async function resolveModelAvailability(
     if (subscriptionCapabilities) {
       return {
         ...availabilityStatus('subscription-access'),
-        label: 'Grok subscription',
+        label: GROK_AUTH.subscriptionLabel,
         providerCapabilities: subscriptionCapabilities,
       };
     }

--- a/src/shared/copy/accountAuth.ts
+++ b/src/shared/copy/accountAuth.ts
@@ -2,9 +2,11 @@
  * Canonical user-facing copy for account sign-in and sign-out surfaces.
  *
  * Account brand names and the outcome sentences that mention them live here so
- * the CLI login form, logout form, slash-command descriptions, and login
- * handlers cannot paraphrase each other. "Researcher Access" itself is owned
- * by `onboarding.ts` — this module imports it rather than restating the name.
+ * the CLI login form, logout form, slash-command descriptions, login handlers,
+ * the extension's subscription settings section, and the auth-failure hints
+ * that quote a toggle by name cannot paraphrase each other. "Researcher Access"
+ * itself is owned by `onboarding.ts` — this module imports it rather than
+ * restating the name.
  *
  * Wire identifiers (`texra`, `chatgpt`, `grok`) stay internal.
  */
@@ -20,6 +22,9 @@ export const CHATGPT_AUTH = {
   label: 'ChatGPT',
   subscriptionLabel: 'ChatGPT subscription',
   subscriptionDescription: 'Codex via ChatGPT Plus/Pro/Team',
+  signInLabel: 'Sign in with ChatGPT',
+  signOutLabel: 'Sign out of ChatGPT',
+  preferLabel: 'Prefer ChatGPT subscription',
   deviceCodeLabel: 'ChatGPT device code',
   logoutDescription: 'Sign out and disable subscription preference',
   startingDevice: 'Starting ChatGPT device-code sign-in.',
@@ -34,6 +39,10 @@ export const CHATGPT_AUTH = {
 /** Grok / xAI subscription account. */
 export const GROK_AUTH = {
   label: 'Grok',
+  subscriptionLabel: 'Grok subscription',
+  signInLabel: 'Sign in with Grok',
+  signOutLabel: 'Sign out of Grok',
+  preferLabel: 'Prefer Grok subscription',
   startingDevice: 'Starting Grok device-code sign-in.',
   startingNoBrowser: 'Starting Grok sign-in.',
   startingBrowser: 'Opening browser for Grok sign-in...',

--- a/src/shared/copy/instructionActionHint.ts
+++ b/src/shared/copy/instructionActionHint.ts
@@ -1,0 +1,49 @@
+/**
+ * Trailing hint text for the {@link InstructionAction} tokens the agent core
+ * attaches to an instruction.
+ *
+ * A host that can render each token as a button (the VS Code extension, via
+ * `INSTRUCTION_ACTION_VIEW`) keeps its own command table, because the token →
+ * `texra.*` command mapping is what the core must stay free of. The hosts with
+ * no button to click — the CLI's stderr line and the desktop's button-less
+ * dialog — render the same tokens as one parenthesized phrase appended to the
+ * message, and that phrasing is the same on both except for where the user
+ * goes to set a key. One rule, two styles, like
+ * `formatStreamStatusLabel`.
+ */
+
+import { INSTRUCTION_ACTION, type InstructionAction } from '@shared/schemas';
+
+// The two styles share every phrase except SET_API_KEY, so `desktop` is
+// derived from `cli` rather than hand-synced.
+const cliInstructionActionHints = {
+  [INSTRUCTION_ACTION.SET_API_KEY]: 'set your API key (texra setup)',
+  [INSTRUCTION_ACTION.OPEN_CONFIGURATION_GUIDE]: 'see the configuration guide',
+  [INSTRUCTION_ACTION.OPEN_MODELS_DOC]: 'see the model documentation',
+} as const satisfies Record<InstructionAction, string>;
+
+const INSTRUCTION_ACTION_HINTS = {
+  cli: cliInstructionActionHints,
+  desktop: {
+    ...cliInstructionActionHints,
+    [INSTRUCTION_ACTION.SET_API_KEY]: 'set your API key in Settings',
+  },
+} as const;
+
+export type InstructionActionHintStyle = keyof typeof INSTRUCTION_ACTION_HINTS;
+
+/**
+ * The ` (hint, hint)` suffix for an instruction's action tokens, or `''` when
+ * it carries none. The lookup stays partial: a token from a newer producer can
+ * arrive over the wire, and those fall back to the raw token rather than
+ * dropping out of the sentence.
+ */
+export function formatInstructionActionHint(
+  actions: readonly InstructionAction[] | undefined,
+  style: InstructionActionHintStyle,
+): string {
+  if (!actions?.length) return '';
+  const hints: Partial<Record<InstructionAction, string>> =
+    INSTRUCTION_ACTION_HINTS[style];
+  return ` (${actions.map((action) => hints[action] ?? action).join(', ')})`;
+}

--- a/src/shared/copy/interactionCancellation.ts
+++ b/src/shared/copy/interactionCancellation.ts
@@ -9,3 +9,9 @@ export const SESSION_DISPOSED_CAUSE = 'Session disposed.';
 
 /** A newer request took the pending request's slot before the user answered. */
 export const APPROVAL_REPLACED_CAUSE = 'Approval request was replaced.';
+
+/** The user cleared a pending retry request from the stream toolbar. */
+export const RETRY_REQUEST_CLEARED_CAUSE = 'Retry request cleared.';
+
+/** Every stream was deleted, so no interaction has an owner left to answer it. */
+export const ALL_STREAMS_DELETED_CAUSE = 'All streams deleted.';

--- a/src/shared/quotaFallbackRoutes.ts
+++ b/src/shared/quotaFallbackRoutes.ts
@@ -1,3 +1,4 @@
+import { CHATGPT_AUTH, GROK_AUTH } from './copy/accountAuth';
 import {
   CODING_PLAN_SUBSCRIPTIONS,
   type CodingPlanSubscriptionId,
@@ -41,14 +42,14 @@ const OAUTH_QUOTA_FALLBACK_ROUTES = Object.freeze([
     exhaustionReason: 'chatgpt-subscription',
     fallbackApiProvider: 'openai',
     retryFallbackName: 'your own OpenAI API key',
-    retrySourceName: 'ChatGPT subscription',
+    retrySourceName: CHATGPT_AUTH.subscriptionLabel,
   }),
   Object.freeze({
     id: 'grok',
     exhaustionReason: 'xai-subscription',
     fallbackApiProvider: 'xai',
     retryFallbackName: 'your own xAI API key',
-    retrySourceName: 'Grok subscription',
+    retrySourceName: GROK_AUTH.subscriptionLabel,
   }),
 ] as const satisfies readonly QuotaFallbackRoute[]);
 

--- a/src/tools/github/githubAuth.ts
+++ b/src/tools/github/githubAuth.ts
@@ -22,6 +22,20 @@ export const GITHUB_TOKEN_STORAGE_KEY = 'github.token';
 export const GITHUB_TOKEN_CREATE_URL =
   'https://github.com/settings/tokens/new?description=TeXRA%20PR%20subscription&scopes=repo';
 
+/**
+ * Prompt shown by the Git settings tab when asking for the token. The scope
+ * wording has to agree with what {@link GITHUB_TOKEN_CREATE_URL} pre-fills, so
+ * the two live together.
+ */
+export const GITHUB_TOKEN_PROMPT =
+  'Paste a GitHub personal access token (repo or public_repo scope)';
+
+/** Confirmation after the token is written to the host secret store. */
+export const GITHUB_TOKEN_SAVED_MESSAGE = 'GitHub token saved.';
+
+/** Confirmation after the token is cleared from the host secret store. */
+export const GITHUB_TOKEN_REMOVED_MESSAGE = 'GitHub token removed.';
+
 /** Environment variables accepted by GitHub tools, in precedence order. */
 const GITHUB_TOKEN_ENV_VARS = ['GH_TOKEN', 'GITHUB_TOKEN'] as const;
 

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -22,7 +22,12 @@ export {
   type StreamLogDelta,
 } from './StreamLog';
 export { createRunTrace, type RunTrace } from './runTrace';
-export { findTranscriptSpillFile, readTranscriptSpill } from './spillArtifacts';
+export {
+  findTranscriptSpillFile,
+  readTranscriptSpill,
+  spillArtifactOpenFailedMessage,
+  SPILL_ARTIFACT_DELETED_MESSAGE,
+} from './spillArtifacts';
 export { streamDataDir } from './streamDataPaths';
 export { StreamSnapshotStore } from './StreamSnapshotStore';
 export { assembleTrace, type AssembleTraceResult } from './traceAssembler';

--- a/src/transcript/spillArtifacts.ts
+++ b/src/transcript/spillArtifacts.ts
@@ -53,3 +53,17 @@ export async function findTranscriptSpillFile(
   if (!resolved || !(await StorageFS.isFile(resolved))) return undefined;
   return StorageFS.fullPath(resolved);
 }
+
+/**
+ * What the two native hosts say when {@link findTranscriptSpillFile} finds
+ * nothing. Both the progress view's "open full output" action and the desktop
+ * task shell's run the same lookup against the same store; a run whose
+ * artifacts were reaped is one fact, so it gets one sentence.
+ */
+export const SPILL_ARTIFACT_DELETED_MESSAGE =
+  'Full output is unavailable because this run artifact was deleted.';
+
+/** Companion for the failure path — the lookup or the open itself threw. */
+export function spillArtifactOpenFailedMessage(reason: string): string {
+  return `Full output could not be opened: ${reason}`;
+}


### PR DESCRIPTION
## Summary

A three-host render-parity sweep in the spirit of #11105, #11117, #11118, and #11164: find a
fact that two hosts each spell for themselves, and give it one owner. Every fact here already
had a module that owns the surrounding concept, so nothing new is invented — six sentences (or
sentence families) move to the module that was already the answer.

| fact | was spelled in | now owned by |
|---|---|---|
| retry-cleared / all-streams-deleted cancellation causes | desktop `desktopAgentExecution.ts`, ext `ProgressViewMessageHandler.ts` | `@shared/copy/interactionCancellation` |
| instruction-action hint table **and** the `(a, b)` fold rule | CLI `cliPresentationHost.ts`, desktop `desktopAgentExecution.ts` | new `@shared/copy/instructionActionHint` |
| latexdiff run-outcome sentences | desktop `desktopProgressFileActions.ts`, ext `latexdiffCommands.ts` | new `@latex/latexdiff/latexdiffCopy` |
| spill-artifact deleted / open-failed sentences | desktop `desktopAgentExecution.ts`, ext `ProgressViewMessageHandler.ts` | `@transcript/spillArtifacts` |
| GitHub-token prompt + saved/removed confirmations | desktop `desktopSettingsIpc.ts`, ext `githubSubscriptionHandlers.ts` | `@tools/github/githubAuth` |
| `Sign in with X` / `Sign out of X` / `Prefer X subscription` / `X subscription` | CLI `orchestration.ts` + `modelAccessRoute.ts`, ext `SubscriptionSection.ts`, `@auth/{codex,xai}SessionTypes`, `@model/computeModelOptions`, `@shared/quotaFallbackRoutes` | `@shared/copy/accountAuth` |

Two of these were live drift risks rather than tidiness:

- **`@shared/copy/interactionCancellation` exists to say "one event gets one explanation across
  every host"** — and two of the four causes had escaped it as per-host literals. These strings
  reach the *model* verbatim, so a divergence is something an agent has to reconcile.
- **`formatCodexAuthUnavailableMessage` / `formatXaiAuthUnavailableMessage` quote a settings
  toggle by name** (`turn off "Prefer Grok subscription"`) while the toggle's label lived in the
  extension's `SubscriptionSection.ts` and the CLI's `modelAccessRoute.ts`. Renaming the toggle
  would have left the error hint pointing at a control that no longer exists under that name.

The CLI and desktop instruction-hint tables were the same table minus one entry, and the
`` ` (${actions.map(...).join(', ')})` `` fold beside them was byte-identical. The new module
derives `desktop` from `cli` the way `streamStatusDisplay` derives `cliCompact` from `cli`,
so the two styles cannot drift on the entries they share.

## Behavior changes

Two, both punctuation, both fixing an existing disagreement:

- `All LaTeX diff operations failed (math markup: "…")` — the desktop's copy had a trailing
  period, the extension's did not. Canonicalized **without** the period, because the extension
  renders three sentences in this markup-annotated family (all-failed, partial-success,
  all-succeeded) and the other two have no period; adding one would have made that trio
  inconsistent to make the desktop match.
- `Failed to generate diff file` — the extension's `throw new Error(...)` had no period, the
  desktop's dialog did. Canonicalized **with** the period, matching its standalone-sentence
  sibling `No LaTeX diff operations available for this run.`

Nothing else renders differently. Every other move is a literal-for-constant substitution.

## Single source of truth

- Cancellation causes that reach the agent: `@shared/copy/interactionCancellation`, now all four.
- Button-less instruction hints: `@shared/copy/instructionActionHint` (the extension keeps
  `INSTRUCTION_ACTION_VIEW`, because the token → `texra.*` command mapping is exactly what the
  core must stay free of).
- latexdiff outcome sentences shared by both hosts: `@latex/latexdiff/latexdiffCopy`. The
  extension's partial-success and all-succeeded lines have one caller and stayed there.
- Spill-artifact failure sentences: `@transcript/spillArtifacts`, beside the lookup that
  produces the condition.
- GitHub token copy: `@tools/github/githubAuth`, beside `GITHUB_TOKEN_CREATE_URL` whose
  pre-filled scopes the prompt's wording has to agree with.
- Subscription account names, sign-in/out labels, and the prefer-toggle label:
  `@shared/copy/accountAuth`.

## Duplication and abstraction budget

Removed: 2 module-private hint tables, 2 copies of the hint-fold expression, 19 duplicate
literal spellings of 12 facts, and 2 long JSDoc blocks that each explained the same rule to a
different host. Added: 2 files, 12 exports, 7 fields on the two existing frozen `*_AUTH`
objects. No new layer, no new indirection at any call site — every consumer reads a constant
where it previously wrote a literal.

Deliberately **not** collapsed: `'ChatGPT subscription'` as a *credential probe name*
(`credentialStatus.ts`) and as an internal attribution string (`openAIChatHelpers.ts`). Those
are a different fact from the account's display name, and conflating them is how a UI rename
silently changes a log line.

## Net elements (R6)

- 21 files (19 modified, 2 added), `+233 / −107` from `git diff --stat origin/main` — **net +126 LoC**.
- Net-positive is the honest number and it is mostly prose: the two new modules are 31 and 49
  lines, of which 25 are the doc comments that state each owner's rule, and 9 of the modified
  files grew only because a one-line import became a multi-line named import. The element that
  actually shrank is the count of places a sentence is written: 12 facts × 2–5 sites → 12 sites.
- `^[+-]export` symbols: +12 (`formatInstructionActionHint`, `InstructionActionHintStyle`,
  `NO_LATEXDIFF_OPERATIONS_MESSAGE`, `LATEXDIFF_GENERATE_FAILED_MESSAGE`,
  `latexdiffAllFailedMessage`, `RETRY_REQUEST_CLEARED_CAUSE`, `ALL_STREAMS_DELETED_CAUSE`,
  `SPILL_ARTIFACT_DELETED_MESSAGE`, `spillArtifactOpenFailedMessage`, `GITHUB_TOKEN_PROMPT`,
  `GITHUB_TOKEN_SAVED_MESSAGE`, `GITHUB_TOKEN_REMOVED_MESSAGE`), −0.
- Class/interface/enum declarations: 0 added, 0 removed.

## Consumer counts (R8)

Every added export has ≥2 production consumers in this PR:

- `formatInstructionActionHint` — 2 (CLI `cliPresentationHost.ts`, desktop `desktopAgentExecution.ts`)
- `RETRY_REQUEST_CLEARED_CAUSE`, `ALL_STREAMS_DELETED_CAUSE` — 2 each (desktop, extension)
- `SPILL_ARTIFACT_DELETED_MESSAGE`, `spillArtifactOpenFailedMessage` — 2 each (desktop, extension)
- `NO_LATEXDIFF_OPERATIONS_MESSAGE`, `LATEXDIFF_GENERATE_FAILED_MESSAGE`,
  `latexdiffAllFailedMessage` — 2 each (desktop, extension)
- `GITHUB_TOKEN_PROMPT`, `GITHUB_TOKEN_SAVED_MESSAGE`, `GITHUB_TOKEN_REMOVED_MESSAGE` — 2 each
  (desktop, extension)
- `CHATGPT_AUTH.preferLabel` / `GROK_AUTH.preferLabel` — 3 each (CLI picker, extension toggle,
  auth-failure hint)
- `CHATGPT_AUTH.signInLabel` / `GROK_AUTH.signInLabel` — 3 each (CLI account picker, extension
  section, auth-failure hint)
- `CHATGPT_AUTH.subscriptionLabel` — 6 (CLI orchestration, CLI route name, extension section
  title, `computeModelOptions`, `quotaFallbackRoutes`, auth-failure hint)
- `GROK_AUTH.subscriptionLabel` — 6 (same set)
- `CHATGPT_AUTH.signOutLabel` / `GROK_AUTH.signOutLabel` — 1 each (CLI account picker); these
  are the fourth field of a four-field label set whose other three are shared, and splitting the
  set so one label lives elsewhere is the drift this PR removes.

No emit path or subscriber was deleted.

## Testing

Zero new tests, per AGENTS.md "Testing discipline" — this is a behavior-preserving substitution
plus two punctuation corrections, and no existing assertion pinned either spelling.

## Validation

- `npm run typecheck` — all six projects (workspace, test-kernel, agent, CLI, trace-viewer, desktop): passed.
- `npm test` — **842 files passed / 1 skipped; 10,316 tests passed / 5 skipped.**
- `npx eslint` on all 21 changed files: clean.
- `npm run format`; `git diff --check`: clean.
- `npm run check:dead-code-ratchet`: `8 current vs 8 baselined` — no new unused exports.
