### PR TITLE
refactor(tools): shrink the prompt port, retire diffFileName, route executions defaults

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -754,7 +754,7 @@ function createWindow(options: {
       prompt: {
         input: (input) =>
           promptController.request({
-            title: input.title ?? input.prompt ?? 'Set API key',
+            title: input.prompt ?? 'Set API key',
             prompt: input.prompt ?? 'Enter API key',
             password: input.password,
           }),

--- a/src/agent/implementations/flows/reflection/output/LatexDiffManager.ts
+++ b/src/agent/implementations/flows/reflection/output/LatexDiffManager.ts
@@ -71,7 +71,7 @@ export class LatexDiffManager {
   ): void {
     if (result.success) {
       this.logger.debug('Successfully generated diff file', {
-        data: { operation, diffFileName: result.diffFileName },
+        data: { operation, diffPath: result.diffPath },
       });
       return;
     }
@@ -365,13 +365,14 @@ export class LatexDiffManager {
     diffLocation: FileLocation;
     artifact: CompiledPdfArtifact | null;
   } | null> {
-    if (!result.success || !result.diffFileName) {
+    if (!result.success || !result.diffPath) {
       return null;
     }
 
+    const diffFileName = path.basename(result.diffPath);
     const diffLocation = createRunStorageLocation(
-      path.join(diffDirectory.absolutePath, result.diffFileName),
-      path.join(diffDirectory.relativePath, result.diffFileName),
+      path.join(diffDirectory.absolutePath, diffFileName),
+      path.join(diffDirectory.relativePath, diffFileName),
       diffDirectory.executionId,
     );
 

--- a/src/hosts/uiHosts.ts
+++ b/src/hosts/uiHosts.ts
@@ -48,15 +48,9 @@ export interface PromptConfirmOptions {
 }
 
 export interface PromptInputOptions {
-  title?: string;
   prompt?: string;
   placeHolder?: string;
-  value?: string;
   password?: boolean;
-  ignoreFocusOut?: boolean;
-  validateInput?: (
-    value: string,
-  ) => string | undefined | null | Promise<string | undefined | null>;
 }
 
 export interface PromptHost {

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -22,12 +22,9 @@ export interface LaTeXdiffResult {
    * Absolute path of the generated diff `.tex`. The service picks the output
    * directory (an `outputDirectory` option, the input's folder, or the git
    * root for `runDiffVc`), so only it can name the file — consumers must not
-   * re-join {@link LaTeXdiffResult.diffFileName} against a directory of their
-   * own guessing.
+   * re-join a bare filename against a directory of their own guessing.
    */
   diffPath?: string;
-  /** Bare filename of the generated diff, for display and relative paths. */
-  diffFileName?: string;
   message?: string;
 }
 
@@ -151,7 +148,6 @@ export class LaTeXdiffService {
       return {
         success: true,
         diffPath: outputLocation.absolutePath,
-        diffFileName,
         message: `LaTeXdiff completed successfully: ${diffFileName}`,
       };
     } catch (err) {
@@ -204,7 +200,6 @@ export class LaTeXdiffService {
       return {
         success: true,
         diffPath: outputPath,
-        diffFileName,
         message: `LaTeXdiff VC completed successfully: ${diffFileName}`,
       };
     } catch (err) {

--- a/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
+++ b/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
@@ -75,7 +75,7 @@ function createDiffCompiler(executionId: ExecutionId, logger: AgentTrace) {
 
   return manager as unknown as {
     compileDiffIfSuccessful(
-      result: { success: boolean; diffFileName?: string },
+      result: { success: boolean; diffPath?: string },
       referenceLocation: FileLocation,
       diffDirectory: {
         absolutePath: string;
@@ -97,11 +97,12 @@ async function compileDiff(
   sourceLocation: FileLocation,
   trace: AgentTrace = spiedTrace(),
 ): Promise<unknown> {
+  const diffAbsoluteDir = path.join(runDir(executionId), 'diff', `r${round}`);
   return createDiffCompiler(executionId, trace).compileDiffIfSuccessful(
-    { success: true, diffFileName: 'main-diff.tex' },
+    { success: true, diffPath: path.join(diffAbsoluteDir, 'main-diff.tex') },
     referenceLocation,
     {
-      absolutePath: path.join(runDir(executionId), 'diff', `r${round}`),
+      absolutePath: diffAbsoluteDir,
       relativePath: path.join('diff', `r${round}`),
       executionId,
     },

--- a/src/test-kernel/hosts/FakeHosts.vitest.ts
+++ b/src/test-kernel/hosts/FakeHosts.vitest.ts
@@ -44,27 +44,6 @@ describe('FakeHosts', () => {
     ]);
   });
 
-  it('does not return queued input rejected by validation', async () => {
-    const hosts = createFakeUIHosts({ inputResponses: ['bad-name'] });
-    const validateInput = (value: string) =>
-      value.includes(' ') ? undefined : 'Enter at least two words';
-
-    const input = await hosts.prompt.input({
-      prompt: 'Name',
-      validateInput,
-    });
-
-    assert.equal(input, undefined);
-    assert.deepEqual(hosts.prompt.inputs, [
-      {
-        options: {
-          prompt: 'Name',
-          validateInput,
-        },
-      },
-    ]);
-  });
-
   it('records opener and diff effects', async () => {
     const hosts = createFakeUIHosts({
       proposedDiffContent: { '/tmp/proposed.tex': 'edited' },

--- a/src/test-kernel/latex/DiffOperations.vitest.ts
+++ b/src/test-kernel/latex/DiffOperations.vitest.ts
@@ -37,7 +37,6 @@ describe('diffOperations logger seam', () => {
     const runDiffForRound = vi.fn(async () => ({
       success: true,
       message: 'diff written',
-      diffFileName: 'paper_diff.tex',
     }));
     const base = createWorkspaceLocation('/workspace/paper.tex', 'paper.tex');
     const revised = createWorkspaceLocation(

--- a/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
+++ b/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
@@ -106,7 +106,7 @@ describe('LaTeXdiffService shadow output', () => {
     const result = await runShadowDiff(sourceDir, shadowDir);
 
     expect(result).toMatchObject({ success: true });
-    expect(result.diffFileName).toBe('revised_diff.tex');
+    expect(path.basename(result.diffPath ?? '')).toBe('revised_diff.tex');
     await expect(
       readFile(path.join(shadowDir, 'revised_diff.tex'), 'utf8'),
     ).resolves.toContain('changed');

--- a/src/test-kernel/support/FakeHosts.ts
+++ b/src/test-kernel/support/FakeHosts.ts
@@ -100,13 +100,7 @@ export class FakePromptHost implements PromptHost {
 
   async input(options: PromptInputOptions): Promise<string | undefined> {
     this.inputs.push({ options });
-    const response = this.inputResponses.shift();
-    if (response == null) {
-      return response;
-    }
-
-    const validationMessage = await options.validateInput?.(response);
-    return validationMessage == null ? response : undefined;
+    return this.inputResponses.shift();
   }
 
   private recordMessage<T extends string>(

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -168,7 +168,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       if (input.action === 'wait') {
         await this.waitForAnyChange(input.timeout, input.ids);
       }
-      return this.listExecutions(input.offset ?? 0, input.limit ?? 100);
+      return this.listExecutions(input.offset, input.limit);
     }
 
     const executionId = this.resolveExecutionId(id);
@@ -216,11 +216,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
             'Conversation pagination is message-based. Use offset and limit; view_range applies only to file and background-command output.',
           );
         }
-        return this.showConversation(
-          executionId,
-          input.offset ?? 0,
-          input.limit ?? 100,
-        );
+        return this.showConversation(executionId, input.offset, input.limit);
       }
       case 'todos':
         return this.showTodos(executionId);

--- a/src/tools/executions/toolInput.ts
+++ b/src/tools/executions/toolInput.ts
@@ -17,6 +17,7 @@ import {
 } from '@shared/toolUse';
 
 // Local file imports
+import { nullishWithDefault } from '../core/inputSchema';
 import { ViewRangeSchema } from '../formatting';
 
 /** Virtual path: /executions, /executions/{id}, /executions/{id}/files, /executions/{id}/workspace-files/{path} */
@@ -54,23 +55,14 @@ const ViewActionSchema = z.strictObject({
   ),
 
   /** Zero-based offset for list or conversation pagination. */
-  offset: z
-    .int()
-    .min(0)
-    .nullish()
-    .describe(
-      'Zero-based offset into the executions list or conversation messages. Use with limit on /executions or /executions/{id}/conversation. Default: 0.',
-    ),
+  offset: nullishWithDefault(z.int().min(0), 0).describe(
+    'Zero-based offset into the executions list or conversation messages. Use with limit on /executions or /executions/{id}/conversation.',
+  ),
 
   /** Maximum list entries or conversation messages to return. */
-  limit: z
-    .int()
-    .min(1)
-    .max(200)
-    .nullish()
-    .describe(
-      'Max entries or conversation messages to return. Use on /executions or /executions/{id}/conversation. Default: 100, max: 200.',
-    ),
+  limit: nullishWithDefault(z.int().min(1).max(200), 100).describe(
+    'Max entries or conversation messages to return. Use on /executions or /executions/{id}/conversation. Max: 200.',
+  ),
 });
 
 const WaitActionSchema = z.strictObject({
@@ -106,23 +98,14 @@ const WaitActionSchema = z.strictObject({
     ),
 
   /** Zero-based offset for the /executions listing returned once the wait resolves. */
-  offset: z
-    .int()
-    .min(0)
-    .nullish()
-    .describe(
-      'Zero-based offset into the executions list returned once the wait resolves (with /executions only). Default: 0.',
-    ),
+  offset: nullishWithDefault(z.int().min(0), 0).describe(
+    'Zero-based offset into the executions list returned once the wait resolves (with /executions only).',
+  ),
 
   /** Maximum list entries in the /executions listing returned once the wait resolves. */
-  limit: z
-    .int()
-    .min(1)
-    .max(200)
-    .nullish()
-    .describe(
-      'Max entries in the executions list returned once the wait resolves (with /executions only). Default: 100, max: 200.',
-    ),
+  limit: nullishWithDefault(z.int().min(1).max(200), 100).describe(
+    'Max entries in the executions list returned once the wait resolves (with /executions only). Max: 200.',
+  ),
 });
 
 const KillActionSchema = z.strictObject({

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -83,12 +83,10 @@ interface SetupExtensionAdapter {
  */
 export type { TerminalRunResult };
 
-export type SetupHost = ToolHost;
-
 /** Host-varying setup capabilities. */
 export interface SetupPlatform {
   /** Product surface currently running the shared setup agent. */
-  host: SetupHost;
+  host: ToolHost;
   /** Start the host's existing TeXRA account sign-in flow. */
   signIn: () => Promise<boolean>;
   /** VS Code-only command invocation. */


### PR DESCRIPTION
## What

Four campaign leftovers across the tool and host layers, each verified dead at HEAD.

## 1. `PromptInputOptions` — four members no caller sets

`PromptHost.input` has **one** production call site (`SettingsProfileKeyController.ts:36`), which passes `prompt`, `password`, `placeHolder`.

| Member | Status |
|---|---|
| `value` | no reader, no writer |
| `ignoreFocusOut` | no reader, no writer |
| `title` | one defensive reader in the desktop adapter, zero writers |
| `validateInput` | simulated only by the test fake |

A port member costs an implementation in every host, so this is a multi-host shrink. It is the survivor set of #10865 / #11013, which deleted `DiffOptions`, `ExternalOpener.openPath`, and `TerminalRunRequest.cwd`/`env` from this same file and stopped there.

`PromptInputOptions` stays structurally assignable to `vscode.InputBoxOptions`.

## 2. `LaTeXdiffResult.diffFileName`

#11046 moved the other three consumers onto `diffPath` and dropped the twin fields from `DiffRunResult`. One consumer survived — and it did precisely what the field's own doc forbids:

> consumers must not re-join `diffFileName` against a directory of their own guessing

`LatexDiffManager` now takes `path.basename(result.diffPath)`. Equivalence is exact: the manager passes `outputDirectory: diffDirectory.absolutePath`, and `latexdiff.ts:153` sets `diffPath` from that same directory.

## 3. Executions-tool pagination defaults

The defaults were stated in prose (`"Default: 0"`, `"Default: 100"`) and again as `?? 0` / `?? 100` at three call sites — across **both** the view and wait branches. `a7c6e293c0` introduced `nullishWithDefault` to end exactly this duplication and converted eleven fields across seven files; the same commit split `ExecutionsTool.ts` into `toolInput.ts` and carried these four over verbatim.

`.nullish()` semantics are preserved — that wrapper exists because OpenAI-compatible providers send an explicit `null` for an omitted field. The transform sits on non-discriminator fields, so the `z.discriminatedUnion('action', …)` and its `flattenTopLevelUnion` handling are untouched, and `.max(200)` survives inside the wrapped schema.

## 4. `SetupHost`

`= ToolHost` with no consumer outside its own file since #10806 replaced the real `'cli' | 'desktop' | 'extension'` union. Invisible to knip: an exported type referenced by another exported type counts as used.

## Considered and rejected

`UsageLogConfig` was in scope — all three hosts call `UsageLogService.initialize({}, …)`. But its only writer is a test that uses it to control batch size, which is a legitimate test seam, and the element delta is ≈0 (one interface and one const out, two scalar constants in). Not worth the churn.

## Net elements (R6)

- Files: 12 changed (7 production, 5 test)
- `^[+-]export` symbols: **−1** (`SetupHost`)
- Port members: **−4** · result fields: **−1** · redundant fallbacks: **−4** (across 2 call sites)
- Net LoC: **−60** (`29 insertions(+), 89 deletions(-)` vs `origin/main`)

## Consumer counts (R8)

Grepped with `--no-ignore-vcs` (a global gitignore hides tracked files from plain `rg` here — #11165):

- `PromptHost.input` — 1 production caller; implementations: `VscodePromptHost`, the desktop inline adapter, `FakePromptHost`. The CLI has no `PromptHost`.
- `diffFileName` — 1 production consumer before this change, 0 after (locals inside `latexdiff.ts` retained)
- `nullishWithDefault` — 11 existing fields, +4 here
- `SetupHost` — 0 consumers outside its own file

## Checks

`typecheck` ✅ (exit 0) · `lint` ✅ (exit 0) · `format` ✅

`vitest run` over `test-kernel/{tools,latex,hosts,agent/output}` ✅ — **128 files, 1060 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJmSeJm4wocNwc7AFMrJBU