### PR TITLE
refactor(core): sweep simplification leftovers since v0.40.2

### DIFF
--- a/src/agent/implementations/flows/reflection/RoundPersistedFlow.ts
+++ b/src/agent/implementations/flows/reflection/RoundPersistedFlow.ts
@@ -117,9 +117,8 @@ export class RoundPersistedFlow<
       parentStage?: StageHandle | null;
       sharedSchema?: z.ZodType<S>;
     },
-    runId?: string,
   ) {
-    super(start, kv, runId, options?.sharedSchema);
+    super(start, kv, undefined, options?.sharedSchema);
     this.callbacks = options?.callbacks ?? {};
     this.parentStage = options?.parentStage ?? null;
   }

--- a/src/agent/implementations/flows/reflection/output/LatexDiffManager.ts
+++ b/src/agent/implementations/flows/reflection/output/LatexDiffManager.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
 
-import type { AgentTrace, StageHandle } from '@agent/trace';
+import type { AgentTrace } from '@agent/trace';
 import { AgentWorkflowSetting } from '@agent/core/definition/AgentDataclass';
 import { LaTeXdiffResult, LaTeXdiffService } from '@latex/latexdiff';
 import { compileLatex2Pdf } from '@latex/texTools';
@@ -113,7 +113,6 @@ export class LatexDiffManager {
   async handleLatexdiffOfOutput(
     currRound: number,
     mapping: RoundFileMapping,
-    stage?: StageHandle,
   ): Promise<CompiledPdfArtifact[]> {
     const execute = async (): Promise<CompiledPdfArtifact[]> => {
       if (!(await checkToolInstalled('latexdiff'))) {
@@ -255,7 +254,7 @@ export class LatexDiffManager {
 
       return artifacts;
     };
-    return tryOperation(() => (stage ? stage.within(execute) : execute()), {
+    return tryOperation(execute, {
       logger: this.logger,
       level: 'error',
       label: 'Error during latexdiff processing',

--- a/src/agent/implementations/flows/reflection/output/outputFileExtraction.ts
+++ b/src/agent/implementations/flows/reflection/output/outputFileExtraction.ts
@@ -9,7 +9,6 @@
  * parsing. Low-level XML text utilities live in @utils/text/xmlExtraction.
  */
 
-import type { StageHandle } from '@agent/trace';
 import { reportMissingOutputs } from '@agent/runtime/runFactEvents';
 import {
   fileLocationDisplayPath,
@@ -183,12 +182,11 @@ export async function extractFilesFromXml(
   xmlManager: XmlOutputManager,
   outputLocation: FileLocation,
   currRound: number,
-  stage?: StageHandle,
 ): Promise<void> {
   await withOutputStage(
     deps,
     `Process files r${currRound}`,
-    stage,
+    undefined,
     async () => {
       await prepareRunWorkspaceIfNeeded(state, deps);
 

--- a/src/agent/index/agentEntry.ts
+++ b/src/agent/index/agentEntry.ts
@@ -19,8 +19,7 @@ export interface AgentEntry {
 }
 
 /**
- * Result of resolving an agent. Replaces the old AgentPathResolution interface.
- * Simple, flat, no redundant fields.
+ * Result of resolving an agent. Simple, flat, no redundant fields.
  */
 export interface ResolvedAgent {
   /** The full agent entry from the registry. */

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -545,7 +545,7 @@ function deduplicateByName(entries: AgentEntry[]): AgentEntry[] {
 // TYPED OPTIONS BUILDER (Lit-native)
 // =============================================================================
 
-export interface AgentOptionsDataPayload {
+interface AgentOptionsDataPayload {
   workflow: AgentOptionData[];
   toolUse: AgentOptionData[];
 }

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -1062,11 +1062,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const userMessageContent: ContentBlockParam[] = [];
 
     if (trimmedPrefix) {
-      userMessageContent.push({
-        type: 'text',
-        text: trimmedPrefix,
-        citations: null,
-      });
+      userMessageContent.push(textBlock(trimmedPrefix));
     }
 
     // Add media if provided (images and native PDFs)
@@ -1080,11 +1076,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     // Add user request with optional caching
     if (trimmedRequest) {
-      userMessageContent.push({
-        type: 'text',
-        text: trimmedRequest,
-        citations: null,
-      });
+      userMessageContent.push(textBlock(trimmedRequest));
     }
 
     // Note: Anthropic handles system prompts differently via createResponse()
@@ -1112,11 +1104,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     // Add message text with optional caching
     const trimmedMessage = userMessage.trim();
     if (trimmedMessage) {
-      roundContent.push({
-        type: 'text',
-        text: trimmedMessage,
-        citations: null,
-      });
+      roundContent.push(textBlock(trimmedMessage));
     }
 
     if (roundContent.length === 0) {
@@ -1144,7 +1132,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
     messages.push({
       role: 'user',
-      content: [{ type: 'text', text: trimmedMessage, citations: null }],
+      content: [textBlock(trimmedMessage)],
     });
 
     return messages;
@@ -1153,7 +1141,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
   createAssistantMessage(text: string): MessageParam {
     return {
       role: 'assistant',
-      content: [{ type: 'text', text, citations: null }],
+      content: [textBlock(text)],
     };
   }
 
@@ -1249,11 +1237,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
       // Check for native PDF support
       const isPdf =
         classification === 'pdf' && this.capabilities.supportsNativePdf;
-      const descriptionBlock = {
-        type: 'text',
-        text: `${isPdf ? 'Document' : 'Image'}: ${media.file_name}`,
-        citations: null,
-      } satisfies TextBlockParam;
+      const descriptionBlock = textBlock(
+        `${isPdf ? 'Document' : 'Image'}: ${media.file_name}`,
+      );
 
       if (isPdf) {
         const documentBlock = {

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -803,15 +803,14 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
   ): Promise<ResponseInputItem[]> {
     const tokensBefore = this.chainState.getCumulativeInputTokens();
     const contextWindow = this.getEffectiveContextWindow();
-    const utilizationBefore = roundedUtilizationPercent(
-      tokensBefore,
-      contextWindow,
-    );
 
     this.logger.debug('Compacting conversation', {
       data: {
         inputTokens: tokensBefore,
-        utilizationPercent: utilizationBefore,
+        utilizationPercent: roundedUtilizationPercent(
+          tokensBefore,
+          contextWindow,
+        ),
         contextWindow,
       },
     });
@@ -1081,7 +1080,7 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
     // non-text items contribute nothing to the estimate.
     const text = messages
       .map((message) =>
-        contentToText((message as { content?: unknown }).content, ''),
+        isMessageItem(message) ? contentToText(message.content, '') : '',
       )
       .join('\n');
     return Math.max(1, estimateTokensFromText(text));
@@ -2148,22 +2147,11 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
         if (!responseId || !isUnhandledStreamEventError(streamError)) {
           throw streamError;
         }
-        if (!this.storesResponsesServerSide) {
-          this.logger.debug(
-            "OpenAI stream emitted an event outside the SDK's typed union for a stateless response; polling fallback is unavailable",
-            {
-              data: {
-                responseId,
-                ...buildErrorLogData(streamError, {
-                  operation: 'unhandled stream event',
-                }),
-              },
-            },
-          );
-          throw streamError;
-        }
+        const canPollById = this.storesResponsesServerSide;
         this.logger.debug(
-          "OpenAI stream emitted an event outside the SDK's typed union: falling back to polling",
+          canPollById
+            ? "OpenAI stream emitted an event outside the SDK's typed union: falling back to polling"
+            : "OpenAI stream emitted an event outside the SDK's typed union for a stateless response; polling fallback is unavailable",
           {
             data: {
               responseId,
@@ -2173,6 +2161,7 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
             },
           },
         );
+        if (!canPollById) throw streamError;
         return this.backgroundLifecycle.retrieveAndRemember(
           client,
           responseId,

--- a/src/agent/remote/remoteAgentList.ts
+++ b/src/agent/remote/remoteAgentList.ts
@@ -39,10 +39,7 @@ interface RemoteAgentListRow {
 }
 
 const RemoteAgentListQueryErrorSchema = z.object({
-  code: z.string().nullish(),
   message: z.string().nullish(),
-  details: z.string().nullish(),
-  hint: z.string().nullish(),
 });
 type RemoteAgentListQueryError = z.infer<
   typeof RemoteAgentListQueryErrorSchema

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -116,7 +116,7 @@ export type RunTerminalPersistence =
       readonly flowRecord: FlowRecordRetention;
     };
 
-export interface FinalizeRunTerminalParams {
+interface FinalizeRunTerminalParams {
   /** Live handle for this terminal attempt; its settled flag is the exactly-once guard. */
   readonly handle: AgentExecutionHandle;
   /** Registry tracking the handle; untracked after the delivery hook runs. */
@@ -165,7 +165,7 @@ export interface FinalizeRunTerminalParams {
   readonly deliver?: (outcome: RunOutcome) => void | Promise<void>;
 }
 
-export interface FinalizeRunTerminalResult {
+interface FinalizeRunTerminalResult {
   readonly event: ResultEvent;
   readonly outcomePersisted: boolean;
 }

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -39,7 +39,7 @@ const logger = createLog('SessionHostInteractions');
  */
 const MAX_PENDING_PRESENTATION_REPLAYS = 256;
 
-export type DiagnosticsReader = (path: string) => Promise<GenericDiagnostic[]>;
+type DiagnosticsReader = (path: string) => Promise<GenericDiagnostic[]>;
 
 export interface ManualCriticismEntry {
   /** Absolute path resolved by the diagnostics tool. */
@@ -53,7 +53,7 @@ export interface ManualCriticismEntry {
   readonly confidence: number;
 }
 
-export type AddCriticismSink = (input: ManualCriticismEntry) => {
+type AddCriticismSink = (input: ManualCriticismEntry) => {
   readonly accepted: boolean;
   readonly resolvedPath: string;
 };
@@ -63,7 +63,7 @@ export interface OpenPdfRequest {
   readonly preserveFocus: boolean;
 }
 
-export type OpenPdfOpener = (request: OpenPdfRequest) => Promise<void> | void;
+type OpenPdfOpener = (request: OpenPdfRequest) => Promise<void> | void;
 
 /**
  * Collects one agent-review finding. Returns `accepted: false` with a reason
@@ -197,7 +197,7 @@ export type HostRetryRequest = RetryPermission;
 
 export type HostUserQuestionRequest = UserQuestionPermission;
 
-export interface HostInteractionResultByKind {
+interface HostInteractionResultByKind {
   readonly bash: BashSettlement;
   readonly planApproval: PlanApprovalResult;
   readonly proposal: ProposalResult;
@@ -206,9 +206,9 @@ export interface HostInteractionResultByKind {
   readonly userQuestion: UserQuestionSettlement;
 }
 
-export type HostExternalInquiryRequest = ExternalInquiryPermission;
+type HostExternalInquiryRequest = ExternalInquiryPermission;
 
-export interface HostExternalInquiryHandle {
+interface HostExternalInquiryHandle {
   readonly threadId: string;
 }
 

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -25,10 +25,7 @@ import {
   inferAndLogPersistedModelHandlerCompatibilityKey,
   inferPersistedModelHandlerCompatibilityKey,
 } from './modelHandlerCompatibilityInference';
-import {
-  ModelHandlerCompatibilityKeySchema,
-  type ModelHandlerCompatibilityKey,
-} from './modelHandlerCompatibilityKey';
+import type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKey';
 
 const logger = createLog('SessionResumeRetrieval');
 

--- a/src/agent/runtime/UsageMonitor.ts
+++ b/src/agent/runtime/UsageMonitor.ts
@@ -181,7 +181,7 @@ export class UsageMonitor {
           reasoningTokens: roundReasoningTokens,
         }),
         ...(toolUseTokens > 0 && { toolUseTokens }),
-        ...(usageRoute != null && { usageRoute }),
+        usageRoute,
       };
 
       // One typed trace event feeds both transcript and progress projections.
@@ -270,7 +270,7 @@ export class UsageMonitor {
         responseTimeMs: Math.round(totalResponseTimeMs),
         cachedInputTokens,
         reasoningTokens: usage.reasoningTokens ?? 0,
-        ...(usage.usageRoute != null && { usageRoute: usage.usageRoute }),
+        usageRoute: usage.usageRoute,
         streamId: this.context.streamId,
       });
     } catch (error) {

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -51,7 +51,7 @@ const logger = createChannelTrace('executionRegistry');
  * cascades. Omitting the field means cascade — the conservative reading, since
  * a child left running has no owner to report to.
  */
-export interface ExecutionStopOptions {
+interface ExecutionStopOptions {
   readonly detachActiveChildren?: boolean;
 }
 

--- a/src/agent/templates/agentTemplateRenderer.ts
+++ b/src/agent/templates/agentTemplateRenderer.ts
@@ -3,7 +3,7 @@ import nunjucks from 'nunjucks';
 import { buildUserVarPassthrough } from '@agent/prompt/userVars';
 import { createTexraNunjucksEnvironment } from '@utils/prompt';
 
-export type AgentTemplateKind = 'toolUse' | 'workflowSingle';
+type AgentTemplateKind = 'toolUse' | 'workflowSingle';
 
 export const AGENT_TEMPLATE_FILES: Record<AgentTemplateKind, string> = {
   toolUse: 'agentTemplate-toolUse.yaml',

--- a/src/agent/types/ServerTools.ts
+++ b/src/agent/types/ServerTools.ts
@@ -53,7 +53,7 @@ export const WebSearchResultEntrySchema = z.object({
 });
 
 /** A single web search result entry - derived from schema. */
-export type WebSearchResultEntry = z.infer<typeof WebSearchResultEntrySchema>;
+type WebSearchResultEntry = z.infer<typeof WebSearchResultEntrySchema>;
 
 /**
  * Schema for unified web search result across all providers.

--- a/src/common/teams/TeamRoster.ts
+++ b/src/common/teams/TeamRoster.ts
@@ -9,7 +9,7 @@ import {
   type ByCategory,
 } from '@shared/schemas';
 
-export interface TeamRosterState {
+interface TeamRosterState {
   getAgents(category: AgentCategory): { name: string; source: AgentSource }[];
   setEnabledAgentKeys(
     category: AgentCategory,

--- a/src/common/teams/TeamRosterApplication.ts
+++ b/src/common/teams/TeamRosterApplication.ts
@@ -15,7 +15,7 @@ interface ResolvedTeam {
   readonly resolution: TeamRosterResolution;
 }
 
-export type TeamRosterApplicationResult =
+type TeamRosterApplicationResult =
   | { readonly status: 'unknown' }
   | { readonly status: 'cancelled'; readonly preset: AgentModePreset }
   | {

--- a/src/controllers/modelAccess/subscriptionUsage/SubscriptionUsageService.ts
+++ b/src/controllers/modelAccess/subscriptionUsage/SubscriptionUsageService.ts
@@ -65,7 +65,7 @@ export interface SubscriptionUsageCredentials {
   useGlmChina?(): boolean | Promise<boolean>;
 }
 
-export interface SubscriptionUsageServiceInit {
+interface SubscriptionUsageServiceInit {
   readonly http?: SubscriptionUsageHttp;
   readonly credentials?: SubscriptionUsageCredentials;
   readonly now?: () => number;

--- a/src/controllers/onboarding/setupLaunch.ts
+++ b/src/controllers/onboarding/setupLaunch.ts
@@ -55,7 +55,7 @@ export async function selectSetupCredentialModelExcludingOpenRouter(
   return null;
 }
 
-export interface SetupModelResolution {
+interface SetupModelResolution {
   model: string;
   reason: RunModelDecisionReason;
 }

--- a/src/controllers/progressView/ProgressFollowUpController.ts
+++ b/src/controllers/progressView/ProgressFollowUpController.ts
@@ -12,8 +12,8 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { formatRoundStageLabel } from '@shared/streams/streamStatusDisplay';
-import type { RunMetadata } from '@transcript/StreamSnapshotStore';
 import { pluralize } from '@utils/text/stringUtils';
+import type { StreamOutputsSource } from './streamOutputs';
 
 export interface ProgressFollowUpModelOption {
   value: string;
@@ -35,12 +35,8 @@ export interface ProgressFollowUpControllerDeps {
   workspace: ProgressFollowUpWorkspace;
 }
 
-export interface ProgressFollowUpState {
-  getRunMetadata(stream: StreamTabId): RunMetadata;
-  getOutputFiles(stream: StreamTabId): RoundIndexed<OutputFileInfo>;
+export interface ProgressFollowUpState extends StreamOutputsSource {
   getCompileFailures(stream: StreamTabId): RoundIndexed<CompileFailure>;
-  /** Warm this stream's sidecars before the plan's synchronous readers run. */
-  preload?(stream: StreamTabId): Promise<void>;
 }
 
 interface CompileFixerTarget {

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -67,7 +67,7 @@ interface PendingDeletion {
   readonly facts: DeferredFact[];
 }
 
-export type SessionFactApplierOptions = {
+type SessionFactApplierOptions = {
   /**
    * Host durable-delete for a removed stream. The resolved outcome decides
    * the removal barrier's fate: `active`/`failed` mean the stream was

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -716,6 +716,4 @@ export class SessionState {
     this.session.flushPendingTraces();
     await Promise.all([this.streamLogs.flush(), this.snapshots.flush()]);
   }
-
-  // -- Private helpers --------------------------------------------------------
 }

--- a/src/controllers/session/streamInfoUtils.ts
+++ b/src/controllers/session/streamInfoUtils.ts
@@ -10,7 +10,7 @@ export type StreamInfoSource = Pick<
 >;
 
 /** The state the full tab list is built from. */
-export type StreamInfoListSource = StreamInfoSource &
+type StreamInfoListSource = StreamInfoSource &
   Pick<SessionState, 'selectableStreamNames'>;
 
 /** Build a StreamTabInfo object for a single stream ID. */

--- a/src/controllers/session/streamTabInfo.ts
+++ b/src/controllers/session/streamTabInfo.ts
@@ -5,7 +5,7 @@ import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import type { StreamTabInfo, WorktreeInfo } from '@shared/schemas';
 import { getCleanAgentName, runIdentityDisplayName } from '@shared/schemas';
 
-export interface StreamTabInfoInputs {
+interface StreamTabInfoInputs {
   streamId: string;
   metadata: Readonly<SessionStreamMetadata>;
   /** Pre-resolved worktree context (branch, dirty, PR). Callers that have

--- a/src/model/codex/codexPreference.ts
+++ b/src/model/codex/codexPreference.ts
@@ -5,16 +5,11 @@
  * ChatGPT, Codex-eligible OpenAI models route through the subscription instead
  * of the user's API key.
  */
-import {
-  createSubscriptionPreference,
-  type SubscriptionPreferenceUpdate,
-} from '../subscriptionPreference';
+import { createSubscriptionPreference } from '../subscriptionPreference';
 
 /** Config key for the "prefer my ChatGPT subscription" switch (off by default). */
 export const CODEX_PREFER_SUBSCRIPTION_KEY =
   'texra.chatgptCodex.preferSubscription';
-
-export type CodexSubscriptionPreferenceUpdate = SubscriptionPreferenceUpdate;
 
 const preference = createSubscriptionPreference(CODEX_PREFER_SUBSCRIPTION_KEY);
 

--- a/src/shared/commands/catalog.ts
+++ b/src/shared/commands/catalog.ts
@@ -411,7 +411,7 @@ export type CommandId = (typeof commandCatalog)[number]['id'];
  * A `contributes.commands` row in `packages/extension/package.json`. Field
  * order mirrors the manifest so the codegen script writes a stable diff.
  */
-export interface PackageCommandContribution {
+interface PackageCommandContribution {
   command: string;
   title: string;
   shortTitle?: string;

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -49,8 +49,8 @@ export type ProviderEndpointStateEntry = ProviderStateEntry & {
 
 /**
  * Canonical provider registry. Registry-derived lists (MODEL_SOURCE_ORDER,
- * SERVER_SIDE_PROVIDER_IDS, PROVIDER_DISPLAY_NAMES, PROVIDER_URLS,
- * API_KEY_PROVIDER_IDS) are derived from this — no manual sync needed.
+ * PROVIDER_DISPLAY_NAMES, PROVIDER_URLS, API_KEY_PROVIDER_IDS) are derived
+ * from this — no manual sync needed.
  * Order here determines display order for direct model providers.
  *
  * To add a new provider that has a ModelProvider enum value: add a single entry

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -43,8 +43,7 @@ export const CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY =
 /** Canonical config key for the usage-telemetry opt-in. */
 export const TELEMETRY_ENABLED_KEY = 'texra.telemetry.enabled';
 
-export type LatexdiffTempFileLocation =
-  (typeof LATEXDIFF_TEMP_FILE_LOCATIONS)[number];
+type LatexdiffTempFileLocation = (typeof LATEXDIFF_TEMP_FILE_LOCATIONS)[number];
 
 /**
  * Bounds, default, and copy for `model.retry.maxAttempts`. The value is the
@@ -437,7 +436,7 @@ const CoreSettingsSchema = z
   .strictObject(CoreSettingsShape)
   .prefault(DEFAULT_CORE_SETTINGS);
 
-export type CoreSettings = z.infer<typeof CoreSettingsSchema>;
+type CoreSettings = z.infer<typeof CoreSettingsSchema>;
 
 /** True for an index-signature record, false for a fixed-key settings group. */
 type IsRecord<T> = string extends keyof T ? true : false;

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -136,7 +136,7 @@ const FileLineageSchema = z.strictObject({
   diffBase: FileLocationSchema.nullable(),
   diffFile: FileLocationSchema.nullable(),
 });
-export type FileLineage = z.infer<typeof FileLineageSchema>;
+type FileLineage = z.infer<typeof FileLineageSchema>;
 
 /**
  * The file location a diff should render against: the explicit `diffBase`

--- a/src/shared/schemas/workflowExecutionSnapshot.ts
+++ b/src/shared/schemas/workflowExecutionSnapshot.ts
@@ -28,7 +28,7 @@ export const WORKFLOW_CALL_STATUS = {
   CACHED: 'cached',
 } as const;
 const WorkflowExecutionCallStatusSchema = z.enum(WORKFLOW_CALL_STATUS);
-export type WorkflowExecutionCallStatus = z.infer<
+type WorkflowExecutionCallStatus = z.infer<
   typeof WorkflowExecutionCallStatusSchema
 >;
 

--- a/src/shared/transcript/transcriptText.ts
+++ b/src/shared/transcript/transcriptText.ts
@@ -84,7 +84,7 @@ export function elideText(
 /** Serialization format {@link stringifyPayload} chose for a value. */
 export type PayloadLanguage = 'yaml' | 'plaintext';
 
-export interface PayloadText {
+interface PayloadText {
   readonly text: TranscriptText;
   readonly language: PayloadLanguage;
 }

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -63,14 +63,6 @@ export const TEXRA_CLI_SUPPORTED_NODE_RANGE_DISPLAY = (() => {
 })();
 
 const ZOTERO_PROBE_TIMEOUT_MS = 2000;
-const TEXRA_CLI_CHECK = {
-  command: 'texra --version',
-  errorMessage: 'TeXRA CLI is not installed or not on PATH.',
-} as const;
-const TEXRA_LOCAL_CLI_CHECK = {
-  command: 'texra-local --version',
-  errorMessage: 'TeXRA local CLI is not installed or not on PATH.',
-} as const;
 
 // ============================================================
 // Type
@@ -178,8 +170,8 @@ function resolveGitHubPRPrerequisites(
 
 async function probeTexraCli(): Promise<boolean> {
   if (platform().toolAvailability.isTexraCliEntrypoint()) return true;
-  if (await checkToolInstalled(TEXRA_CLI_CHECK, false)) return true;
-  return checkToolInstalled(TEXRA_LOCAL_CLI_CHECK, false);
+  if (await checkToolInstalled('texra', false)) return true;
+  return checkToolInstalled('texra-local', false);
 }
 
 interface Lean4Prerequisites {

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -83,12 +83,10 @@ interface SetupExtensionAdapter {
  */
 export type { TerminalRunResult };
 
-export type SetupHost = ToolHost;
-
 /** Host-varying setup capabilities. */
 export interface SetupPlatform {
   /** Product surface currently running the shared setup agent. */
-  host: SetupHost;
+  host: ToolHost;
   /** Start the host's existing TeXRA account sign-in flow. */
   signIn: () => Promise<boolean>;
   /** VS Code-only command invocation. */

--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -25,7 +25,6 @@ import {
   getZoteroPort,
   BbtLibrarySchema,
   type BbtCollection,
-  type BbtLibrary,
 } from './bbtClient';
 
 const ZoteroCollectionsInputSchema = z.strictObject({

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -97,7 +97,6 @@ export const BbtLibrarySchema = z.object({
   name: z.string(),
   collections: z.array(BbtCollectionSchema).nullish(),
 });
-export type BbtLibrary = z.infer<typeof BbtLibrarySchema>;
 
 /**
  * Collection with nested parent chain, returned by `item.collections(citekeys, true)`.

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -688,20 +688,6 @@ export class StreamSnapshotStore {
   }
 
   /**
-   * Run a mutation only once the stream's disk provenance is established;
-   * otherwise queue it behind the per-stream seed chain so it merges onto the
-   * real sidecar state instead of an empty base. Eager memory application in
-   * the overlay mutators keeps read-back immediate either way.
-   */
-  private mutate<T>(stream: StreamTabId, apply: () => T): T | undefined {
-    const version = this.streamVersion(stream);
-    if (this.hasDiskProvenance(stream)) return apply();
-
-    this.queueAfterSeed(stream, version, apply);
-    return undefined;
-  }
-
-  /**
    * Queue a mutation onto the stream's seed lane: the lane's single-flight
    * FIFO order (concurrency 1, shared with `refreshSeed`) is what guarantees
    * this runs after every unit of work queued ahead of it, seed reads
@@ -1335,11 +1321,19 @@ export class StreamSnapshotStore {
   ): void {
     this.patchMetaMemory(stream, patch);
     this.getOrCreateRecord(stream).metaOverlay = true;
-    const applied = this.mutate(stream, () => {
+    const applyMeta = (): void => {
       this.writeMeta(stream, this.patchMetaMemory(stream, patch));
-      return true;
-    });
-    if (applied) this.getOrCreateRecord(stream).metaOverlay = false;
+    };
+    // Persist immediately once the stream's disk provenance is established;
+    // otherwise queue behind the per-stream seed chain so it merges onto the
+    // real sidecar state instead of an empty base, leaving `metaOverlay` set
+    // for `applyStreamData`/`persistEagerOverlays` to reconcile.
+    if (this.hasDiskProvenance(stream)) {
+      applyMeta();
+      this.getOrCreateRecord(stream).metaOverlay = false;
+    } else {
+      this.queueAfterSeed(stream, this.streamVersion(stream), applyMeta);
+    }
   }
 
   // ==========================================================================
@@ -1586,18 +1580,10 @@ export class StreamSnapshotStore {
     // A staged deletion owns the stream's namespace, so it takes the value
     // into its transactional buffer instead of letting it reach disk.
     if (this.deletions.bufferWrite(stream, key, value)) return;
-    this.writeUnbuffered(stream, key, value);
-  }
-
-  private writeUnbuffered(
-    stream: StreamTabId,
-    key: string,
-    value: unknown,
-  ): void {
     const chainKey = `${stream}::${key}`;
-    const write = { stream, key, value } satisfies DirtySidecarWrite;
-    this.dirtyWrites.set(chainKey, write);
-    void this.persistDirtyWrite(chainKey, write).catch((err: unknown) =>
+    const dirty = { stream, key, value } satisfies DirtySidecarWrite;
+    this.dirtyWrites.set(chainKey, dirty);
+    void this.persistDirtyWrite(chainKey, dirty).catch((err: unknown) =>
       log.warn(
         `Failed to persist ${key}.json for stream ${stream}; sidecar remains dirty.`,
         { data: err },

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -157,7 +157,6 @@ interface StreamSinkState {
   ended: boolean;
   enabled: boolean;
   groupId: string | undefined;
-  level: LogLevel;
   messageType: MessageType;
   updateDebounce: FlushableDebounce;
 }
@@ -370,7 +369,7 @@ export function attachTranscriptRecorder(
       const entry = {
         id,
         type: STREAM_LOG_ENTRY_TYPES.LOG,
-        level: state.level,
+        level: 'info',
         timestamp: Date.now(),
         groupId: state.groupId,
         messageType: state.messageType,
@@ -674,7 +673,6 @@ export function attachTranscriptRecorder(
             ended: false,
             enabled: true,
             groupId: event.stageId,
-            level: 'info',
             messageType: asMessageType(event.kind),
             updateDebounce: createFlushableDebounce(() => {
               try {

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -330,16 +330,6 @@ function streamLogEntriesToConversation(
   );
 }
 
-/** Reconstruct one stream's conversation; `[]` when the log is absent/empty. */
-async function conversationFromStream(
-  streamLogStore: StreamLogStore,
-  streamId: StreamTabId,
-): Promise<unknown[]> {
-  return streamLogEntriesToConversation(
-    await streamLogStore.readEntries(streamId),
-  );
-}
-
 /**
  * Read the archived conversation for a completed run from the transcript
  * sidecar (`streamLogs/{stream}.json`), reconstructed into provider-agnostic
@@ -356,7 +346,9 @@ export async function readCompletedRunConversation(
   // reader neither reloads a live store nor scans the whole streamLogs
   // directory, and never mutates persistence.
   const streamLogStore = await StreamLogStore.openReadOnlyForStream(streamId);
-  const conversation = await conversationFromStream(streamLogStore, streamId);
+  const conversation = streamLogEntriesToConversation(
+    await streamLogStore.readEntries(streamId),
+  );
   return conversation.length > 0
     ? { conversation, source: 'streamLog', streamId }
     : { conversation: null, source: 'none', streamId };

--- a/src/transcript/streamSnapshotRead.ts
+++ b/src/transcript/streamSnapshotRead.ts
@@ -23,6 +23,7 @@ import {
   WorkPlanSnapshotShape,
   type CompileFailure,
   type OutputFileInfo,
+  type ParsedUsageData,
   type RoundIndexed,
   type StreamSnapshot,
   type StreamTabId,
@@ -250,9 +251,7 @@ export async function readStreamData(kv: KVStore): Promise<StreamData> {
  * I/O errors and JSON `SyntaxError` propagate, and a present non-object value
  * is rejected instead of being silently treated as empty.
  */
-export async function readUsageData(
-  kv: KVStore,
-): Promise<ReturnType<typeof parseUsageData>> {
+export async function readUsageData(kv: KVStore): Promise<ParsedUsageData> {
   const raw = await kv.read(STREAM_DATA_KEYS.USAGE_STATS);
   if (raw === undefined) return parseUsageData(undefined);
   if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {

--- a/src/utils/files/runStorageFs.ts
+++ b/src/utils/files/runStorageFs.ts
@@ -53,7 +53,7 @@ export async function findRunDir(id: ExecutionId): Promise<string | undefined> {
   return rel ? StorageFS.fullPath(rel) : undefined;
 }
 
-export type RunStorageEntryInspection =
+type RunStorageEntryInspection =
   | { readonly kind: 'file'; readonly location: RunStorageFileLocation }
   | {
       readonly kind: 'symlink' | 'directory' | 'unsupported';

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -55,16 +55,13 @@ export class TaskRunFileService {
     baseFiles: FileLocation[],
     options: {
       linkFiles?: FileLocation[];
-      mirrorBaseFiles?: boolean;
     } = {},
   ): Promise<void> {
     if (this.hasPreparedSnapshot) return;
 
     await ensureRunDir(this.executionId);
 
-    const linkTargets = new Set<FileLocation>(
-      options.mirrorBaseFiles !== false ? baseFiles : [],
-    );
+    const linkTargets = new Set<FileLocation>(baseFiles);
 
     // Add extra link files, filtering out any null/undefined entries
     for (const extra of options.linkFiles ?? []) {

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -139,6 +139,14 @@ const TOOL_CONFIGS: Record<string, ToolConfig> = {
 
   // Document conversion tools
   pandoc: withDocs(featureTool('pandoc', PANDOC_INSTRUCTIONS), { docs: false }),
+
+  // TeXRA's own CLI entrypoints
+  texra: withDocs('TeXRA CLI is not installed or not on PATH.', {
+    docs: false,
+  }),
+  'texra-local': withDocs('TeXRA local CLI is not installed or not on PATH.', {
+    docs: false,
+  }),
 };
 
 /**
@@ -244,37 +252,27 @@ async function executeWithFallback(
 
 /**
  * Generic function to check if a tool is installed
- * @param toolOrConfig Tool name (string) or tool configuration object
+ * @param toolName Tool name (looked up in TOOL_CONFIGS)
  * @param showError Whether to show an error message if the tool is not installed
  * @returns Promise<boolean> True if the tool is installed
  */
 export async function checkToolInstalled(
-  toolOrConfig: string | ToolConfig,
+  toolName: string,
   showError: boolean = true,
 ): Promise<boolean> {
-  const toolName = typeof toolOrConfig === 'string' ? toolOrConfig : null;
-  const config: ToolConfig | undefined =
-    typeof toolOrConfig === 'string'
-      ? TOOL_CONFIGS[toolOrConfig]
-      : toolOrConfig;
+  const config = TOOL_CONFIGS[toolName];
 
   if (!config) {
     if (showError) {
-      await reportMissingTool(`Unknown tool: ${toolOrConfig}`);
+      await reportMissingTool(`Unknown tool: ${toolName}`);
     }
     return false;
   }
 
   // Generate default command if not specified
-  const command = config.command || (toolName ? `${toolName} --version` : null);
+  const command = config.command || `${toolName} --version`;
 
   try {
-    if (!command) {
-      throw new Error(
-        'No command specified and tool name could not be determined',
-      );
-    }
-
     let isInstalled = false;
 
     const extendedPath = extendEnvPath();
@@ -317,9 +315,7 @@ export async function checkToolInstalled(
   } catch (err) {
     // The user-facing message is always the tool's own install guidance, so
     // log the underlying cause instead of dropping it.
-    log.warn(
-      `Tool check for '${toolName ?? 'custom config'}' failed: ${toErrorMessage(err)}`,
-    );
+    log.warn(`Tool check for '${toolName}' failed: ${toErrorMessage(err)}`);
     if (showError) {
       await reportMissingTool(config.errorMessage);
     }

--- a/src/utils/text/xmlExtraction.ts
+++ b/src/utils/text/xmlExtraction.ts
@@ -2,9 +2,9 @@
  * XML content extraction utilities.
  * Functions for extracting content from XML tags and documents.
  *
- * The extraction result shapes (ExtractionResult / MultipleExtractionResult)
- * are plain types: they describe internal return values, not a parsed or
- * validated boundary, so no Zod schema backs them.
+ * The extraction result shape (MultipleExtractionResult) is a plain type: it
+ * describes an internal return value, not a parsed or validated boundary, so
+ * no Zod schema backs it.
  */
 
 // Local imports - utils


### PR DESCRIPTION
## What

Fifty `our-code-simplifier` agents (Sonnet 5, high effort) swept the **618
host-agnostic files under `src/` and `packages/agent` that changed since release
`v0.40.2`** (2026-08-12) — ~149k LOC — one disjoint, directory-local slice each.
Every edit is behavior-preserving; the yield is leftovers from eight days of very
heavy refactoring churn.

**42 files, +98 / −188.**

## What it found

| Category | Count | Examples |
| --- | --- | --- |
| Dead exports / dead types | 19 | symbols with no consumer outside their declaring file lose `export`, or the declaration entirely (`BbtLibrary`, `AgentOptionsDataPayload`, …) |
| Pass-through collapse | 3 | `StreamSnapshotStore.mutate` and `writeUnbuffered` each had one caller and made no decision — inlined into it |
| Dead parameters / fields | 5 | ctor and function params that every live call site left `undefined`; Zod fields nothing reads |
| Union-arm removal | 1 | `checkToolInstalled(string \| ToolConfig)` → `checkToolInstalled(string)` |
| Repeated-literal folding | 8 | `textBlock(…)` in the Anthropic handler replaces 6 hand-written `{ type: 'text', citations: null }` literals |
| Stale comments | 3 | comments describing machinery that a prior PR already deleted |

The one non-mechanical change: `checkToolInstalled` accepted either a tool name or
an ad-hoc `ToolConfig`. Only two call sites used the config arm, both with literals
declared next to them in `externalToolDefs.ts`. Those move into `TOOL_CONFIGS` as
`texra` / `texra-local`, so every caller now goes through the one registry and the
`config === null` branch disappears.

## Honest scope note

Net −90 lines from 50 agents over 149k LOC is a small return, and that is the
finding: core `src/` has already absorbed ~200 simplification PRs plus the recent
collapse campaign. Roughly half the bins reported **zero** edits after reading their
slice in full and grepping consumers repo-wide — "already coherent" was the
dominant verdict, not a shortage of effort. The agents also recorded **306
candidates they deliberately did not take**, mostly needing a caller outside their
own slice; those are captured for a follow-up wave rather than forced in here.

A companion sweep over the host packages (`extension` / `cli` / `desktop`,
391 files) is running separately.

## Verified

Run locally on a clean `origin/main` worktree, all green:

- `typecheck` — all six projects (workspace, test-kernel, agent, cli, trace-viewer, desktop)
- `eslint` on every changed file, `prettier --check`
- `check:dead-code-ratchet` (8 findings, matches baseline — no widening)
- `check:browser-safe-utils`, `check:guidance-refs`, `check:tsconfig-paths`, `check:package-contributes`
- full `vitest run` — **842 files, 10,316 tests passed**, 0 failures
- `src/test-kernel/architecture` ratchets — 104 tests passed

Three agent proposals were **rejected during integration** and reverted rather than
shipped: a deleted `AgentRosterController.allPresets()` that the CLI roster form
actually calls, a nested ternary that violates `no-nested-ternary`, and the dead
`BbtLibrary` type was finished off properly instead of left to trip the ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UQRwTBAasoZuFhCm42mrZ


## Net elements (R6)

- 42 production files changed, with 98 additions and 188 deletions, for a net reduction of 90 lines.
- 29 exported declarations were removed or made file-private, and one exported declaration was added, for a net reduction of 28 exported declarations.
- No test files are changed.
- The six Anthropic `textBlock(...)` substitutions are request-equivalent rather than byte-identical: they omit the optional `citations: null` field, matching the existing helper and the other call sites in that handler.

## Consumer counts (R8)

- Every removed export was searched repo-wide. Each had zero consumers outside its declaring file.
- Every inlined helper had one caller. The consolidated tool configuration entries replace the only two production callers that used the removed ad hoc `ToolConfig` union arm.
- No event, subscription, or output path is deleted or re-routed.
