### PR TITLE
refactor(auth): delete the expiry-probe vertical and two unpassed seams

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -680,7 +680,6 @@ if (HARNESS_AUTHENTICATED === '1' || HARNESS_AUTHENTICATED === '0') {
     getStoredSessionState: async () =>
       accessToken === null ? 'none' : 'authenticated',
     getStoredAccountLabel: async () => null,
-    isTokenExpiringSoon: () => false,
     getLastRefreshFailure: () => null,
   });
 }

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -186,9 +186,7 @@ export async function signInCliSupabaseDeviceCode(
   options.signal?.throwIfAborted();
   // The token endpoint mints a native GoTrue session (auth-github shape), so
   // standard Supabase refresh applies — no custom refresh flag.
-  const session = toStorableSupabaseSession(exchange, {
-    defaultExpiryMs: DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
-  });
+  const session = toStorableSupabaseSession(exchange);
   await authCoordinator.storeSession(session);
   return session;
 }

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -8,7 +8,6 @@ import {
 import { createHostAuthCoordinator } from '@auth/SupabaseAuthCoordinator';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import {
-  DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
   toStorableSupabaseSession,
   type SupabaseSession,
   type SupabaseSessionCoordinator,

--- a/packages/desktop/src/main/desktopCredentialSettingsController.ts
+++ b/packages/desktop/src/main/desktopCredentialSettingsController.ts
@@ -10,10 +10,7 @@ import {
 import { SubscriptionUsageService } from '@controllers/modelAccess/subscriptionUsage/SubscriptionUsageService';
 import { SettingsProfileKeyController } from '@controllers/settingsView/SettingsProfileKeyController';
 import { SettingsProfileController } from '@controllers/settingsView/SettingsProfileController';
-import {
-  SettingsModelSelectionController,
-  type ModelSelectionExtras,
-} from '@controllers/settingsView/SettingsModelSelectionController';
+import { SettingsModelSelectionController } from '@controllers/settingsView/SettingsModelSelectionController';
 import type { ExternalOpener, PromptHost } from '@hosts/uiHosts';
 import {
   computeModelOptionsData,
@@ -76,7 +73,6 @@ interface DesktopCredentialSettingsControllerOptions extends SettingsStatePorts 
     SubscriptionUsageService,
     'getUsage' | 'invalidate'
   >;
-  readonly modelSelectionExtras?: ModelSelectionExtras;
   readonly onCredentialChanged: () => Promise<void>;
   readonly onError: (error: unknown) => void;
 }
@@ -141,7 +137,6 @@ export class DefaultDesktopCredentialSettingsController implements DesktopCreden
     this.subscriptionUsage =
       options.subscriptionUsage ?? new SubscriptionUsageService();
     this.modelSelectionController = new SettingsModelSelectionController({
-      ...options.modelSelectionExtras,
       globalState: options.globalState,
     });
     this.profileController = new SettingsProfileController({

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -139,16 +139,6 @@ export class SupabaseClient {
   }
 
   /**
-   * Check whether the stored session's token is close enough to expiry that
-   * the auth provider would refresh it. Synchronous and in-memory — safe to
-   * call before every model invocation. Returns false when no auth provider is
-   * registered or it has observed no session.
-   */
-  static isTokenExpiringSoon(): boolean {
-    return this.authProvider?.isTokenExpiringSoon() ?? false;
-  }
-
-  /**
    * Check if auth system is fully initialized and ready for use.
    */
   static async isReady(): Promise<boolean> {

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -71,14 +71,6 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
   private readonly sessionMutex = new Mutex();
   private readonly log: Required<SupabaseSessionLog>;
 
-  /**
-   * Expiry (ms since epoch) of the session this coordinator last read or
-   * wrote, or null when the last observation was "no session". Every storage
-   * read and write updates it, so a session loaded cold at startup answers
-   * {@link isTokenExpiringSoon} without any host seeding it.
-   */
-  private tokenExpiresAt: number | null = null;
-
   constructor(private readonly options: SupabaseSessionCoordinatorOptions) {
     this.log = { ...NOOP_SUPABASE_SESSION_LOG, ...options.log };
   }
@@ -88,17 +80,10 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
   }
 
   async loadSession(): Promise<SupabaseSession | null> {
-    const versionBeforeLoad = this.sessionMutationVersion;
-    const session = parseStoredSupabaseSession(
-      await this.options.storage.get(),
-      { logSource: 'SupabaseSession', warn: this.log.warn },
-    );
-    // A mutation that committed during the read owns the newer expiry; this
-    // read observed the superseded session and must not overwrite it.
-    if (versionBeforeLoad === this.sessionMutationVersion) {
-      this.tokenExpiresAt = session?.expiresAt ?? null;
-    }
-    return session;
+    return parseStoredSupabaseSession(await this.options.storage.get(), {
+      logSource: 'SupabaseSession',
+      warn: this.log.warn,
+    });
   }
 
   async storeSession(session: SupabaseSession): Promise<void> {
@@ -109,19 +94,6 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
 
   async clearSession(): Promise<void> {
     await this.runSessionMutation(null, () => this.options.storage.delete());
-  }
-
-  /**
-   * Whether the last observed session expires within the configured refresh
-   * threshold. Synchronous in-memory check for the model-invocation path.
-   */
-  isTokenExpiringSoon(): boolean {
-    if (this.tokenExpiresAt === null) {
-      return false;
-    }
-    return (
-      this.tokenExpiresAt - Date.now() < this.options.tokenRefreshThresholdMs
-    );
   }
 
   /**
@@ -147,7 +119,6 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
       await this.options.storage.delete();
       this.lastStoredSession = null;
       this.lastStoredSessionVersion = mutationVersion;
-      this.tokenExpiresAt = null;
       cleared = true;
     });
 
@@ -372,7 +343,6 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
       await operation();
       this.lastStoredSession = session;
       this.lastStoredSessionVersion = mutationVersion;
-      this.tokenExpiresAt = session?.expiresAt ?? null;
     });
   }
 

--- a/src/auth/TokenProvider.ts
+++ b/src/auth/TokenProvider.ts
@@ -32,13 +32,6 @@ export interface AuthTokenProvider {
    */
   getStoredAccountLabel(): Promise<string | null>;
   /**
-   * Whether the stored session's access token is within the provider's refresh
-   * threshold, judged from the last session the provider read or wrote.
-   * Synchronous and in-memory, so it is safe before every model invocation;
-   * false when no session expiry has been observed.
-   */
-  isTokenExpiringSoon(): boolean;
-  /**
    * Classification of the most recent refresh failure. `invalid` means the
    * credential was authoritatively rejected; `transient` covers transport and
    * service failures for which reconnecting would be premature.

--- a/src/auth/supabaseSessionTypes.ts
+++ b/src/auth/supabaseSessionTypes.ts
@@ -72,16 +72,6 @@ interface SupabaseCallbackParseError {
 export type SupabaseCallbackResult =
   SupabaseCallbackParseResult | SupabaseCallbackParseError;
 
-function firstAccountLabel(
-  ...candidates: readonly (string | null | undefined)[]
-): string {
-  for (const candidate of candidates) {
-    const label = candidate?.trim();
-    if (label) return label;
-  }
-  return 'unknown';
-}
-
 /**
  * Parse and validate stored session data.
  * Returns null if session data is missing or invalid.
@@ -114,16 +104,13 @@ export function parseStoredSupabaseSession(
 
 export async function parseTokenExchangeResponse(
   response: Response,
-  log?: SupabaseSessionLog,
 ): Promise<GitHubTokenExchangeResponse> {
   const rawData = await response.json();
   const parsed = GitHubTokenExchangeSchema.safeParse(rawData);
   if (!parsed.success) {
-    log?.error?.(
-      'SupabaseSession',
-      `Token exchange response validation failed: ${z.prettifyError(parsed.error)}`,
+    throw new Error(
+      `Invalid response format from authentication server: ${z.prettifyError(parsed.error)}`,
     );
-    throw new Error('Invalid response format from authentication server');
   }
   return parsed.data;
 }
@@ -144,11 +131,10 @@ type StorableSessionInput = {
 function resolveExpiresAt(
   expiresAtSeconds: number | undefined,
   expiresInSeconds: number | undefined,
-  defaultExpiryMs: number,
 ): number {
   if (expiresAtSeconds) return expiresAtSeconds * 1000;
   if (expiresInSeconds) return Date.now() + expiresInSeconds * 1000;
-  return Date.now() + defaultExpiryMs;
+  return Date.now() + DEFAULT_SUPABASE_SESSION_EXPIRY_MS;
 }
 
 /**
@@ -157,10 +143,6 @@ function resolveExpiresAt(
  */
 export function toStorableSupabaseSession(
   nativeSession: StorableSessionInput,
-  options?: {
-    fallbackLabel?: string;
-    defaultExpiryMs?: number;
-  },
 ): SupabaseSession {
   return {
     id: nativeSession.user.id,
@@ -168,16 +150,11 @@ export function toStorableSupabaseSession(
     refreshToken: nativeSession.refresh_token,
     account: {
       id: nativeSession.user.id,
-      label: firstAccountLabel(
-        nativeSession.user.email,
-        options?.fallbackLabel,
-        nativeSession.user.id,
-      ),
+      label: nativeSession.user.email?.trim() || nativeSession.user.id,
     },
     expiresAt: resolveExpiresAt(
       nativeSession.expires_at,
       nativeSession.expires_in,
-      options?.defaultExpiryMs ?? DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
     ),
   };
 }

--- a/src/controllers/settingsView/SettingsModelSelectionController.ts
+++ b/src/controllers/settingsView/SettingsModelSelectionController.ts
@@ -50,15 +50,6 @@ export interface SettingsModelSelectionControllerDeps {
   ) => Promise<ModelOptionData[]>;
 }
 
-/**
- * The host-tunable deps: everything except the persisted-state store both
- * hosts already hold in their `SettingsStatePorts`.
- */
-export type ModelSelectionExtras = Omit<
-  SettingsModelSelectionControllerDeps,
-  'globalState'
->;
-
 interface SettingsModelSelectionData {
   models: ModelSelectionItem[];
   helperModel: string;

--- a/src/controllers/settingsView/SettingsViewHost.ts
+++ b/src/controllers/settingsView/SettingsViewHost.ts
@@ -7,10 +7,7 @@ import type {
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
 import { SettingsMemoryController } from './SettingsMemoryController';
-import {
-  SettingsModelSelectionController,
-  type ModelSelectionExtras,
-} from './SettingsModelSelectionController';
+import { SettingsModelSelectionController } from './SettingsModelSelectionController';
 
 type Awaitable<T> = T | PromiseLike<T>;
 type MemoryControllerOptions = ConstructorParameters<
@@ -34,7 +31,6 @@ interface SettingsViewHostOptions {
   readonly state: SettingsStatePorts;
   readonly memoryPrompt: MemoryControllerOptions['prompt'];
   readonly respond?: SettingsRespond;
-  readonly modelSelectionExtras?: ModelSelectionExtras;
   readonly controllers?: {
     readonly memory?: SettingsMemoryController;
     readonly modelSelection?: SettingsModelSelectionController;
@@ -70,7 +66,6 @@ export class SettingsViewHost {
     this.modelSelectionController =
       options.controllers?.modelSelection ??
       new SettingsModelSelectionController({
-        ...options.modelSelectionExtras,
         globalState: options.state.globalState,
       });
   }

--- a/src/test-kernel/auth/SupabaseClient.vitest.ts
+++ b/src/test-kernel/auth/SupabaseClient.vitest.ts
@@ -27,7 +27,6 @@ function createTokenProvider(
     getSessionTokens: async () => null,
     getStoredSessionState: async () => 'none',
     getStoredAccountLabel: async () => null,
-    isTokenExpiringSoon: () => false,
     getLastRefreshFailure: () => null,
     ...overrides,
   };
@@ -126,18 +125,6 @@ describe('SupabaseClient', () => {
       'SupabaseClient',
       expect.stringContaining('secret storage unavailable'),
     );
-  });
-
-  it('reports no expiry pressure when no token provider is registered', () => {
-    assert.equal(SupabaseClient.isTokenExpiringSoon(), false);
-  });
-
-  it('reports the token provider expiry verdict', () => {
-    SupabaseClient.setAuthProvider(
-      createTokenProvider({ isTokenExpiringSoon: () => true }),
-    );
-
-    assert.equal(SupabaseClient.isTokenExpiringSoon(), true);
   });
 });
 

--- a/src/test-kernel/auth/SupabaseSessionLifecycle.vitest.ts
+++ b/src/test-kernel/auth/SupabaseSessionLifecycle.vitest.ts
@@ -288,10 +288,6 @@ describe('SupabaseSession', () => {
           expires_at: 123,
           user: { id: 'user-id', email: 'user@example.com' },
         }),
-        {
-          fallbackLabel: 'fallback@example.com',
-          defaultExpiryMs: DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
-        },
       );
 
       assert.deepEqual(session, {
@@ -306,23 +302,12 @@ describe('SupabaseSession', () => {
       });
     });
 
-    it('trims whitespace from the exchange fallback label', () => {
-      const session = toStorableSupabaseSession(makeExchangeResponse(), {
-        fallbackLabel: '  github@example.com  ',
-        defaultExpiryMs: DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
-      });
-
-      assert.equal(session.account.label, 'github@example.com');
-    });
-
-    it('falls back to the supplied label and default expiry', () => {
+    it('falls back to the user id and the default expiry', () => {
       const earliestExpiry = Date.now() + DEFAULT_SUPABASE_SESSION_EXPIRY_MS;
-      const session = toStorableSupabaseSession(makeExchangeResponse(), {
-        fallbackLabel: 'fallback@example.com',
-        defaultExpiryMs: DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
-      });
+      const response = makeExchangeResponse();
+      const session = toStorableSupabaseSession(response);
 
-      assert.equal(session.account.label, 'fallback@example.com');
+      assert.equal(session.account.label, response.user.id);
       assert.ok(session.expiresAt >= earliestExpiry);
       assert.ok(
         session.expiresAt <= Date.now() + DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
@@ -343,46 +328,6 @@ describe('SupabaseSession', () => {
         refreshToken: 'refresh-token',
       });
       assert.equal(getReadCount(), 1);
-      assert.equal(coordinator.isTokenExpiringSoon(), false);
-    });
-
-    it('reports no expiry pressure before any session is observed', () => {
-      const { coordinator } = createCoordinator({
-        initialSession: soonExpiringSession(),
-      });
-
-      assert.equal(coordinator.isTokenExpiringSoon(), false);
-    });
-
-    it('answers expiry pressure from a session loaded cold', async () => {
-      const { coordinator } = createCoordinator({
-        initialSession: soonExpiringSession(),
-      });
-
-      await coordinator.loadSession();
-
-      assert.equal(coordinator.isTokenExpiringSoon(), true);
-    });
-
-    it('drops expiry pressure once the session is cleared', async () => {
-      const { coordinator } = createCoordinator({
-        initialSession: soonExpiringSession(),
-      });
-
-      await coordinator.loadSession();
-      await coordinator.clearSession();
-
-      assert.equal(coordinator.isTokenExpiringSoon(), false);
-    });
-
-    it('drops expiry pressure when a matched session is cleared', async () => {
-      const session = soonExpiringSession();
-      const { coordinator } = createCoordinator({ initialSession: session });
-
-      await coordinator.loadSession();
-      assert.equal(await coordinator.clearSessionIfCurrent(session), true);
-
-      assert.equal(coordinator.isTokenExpiringSoon(), false);
     });
 
     it('reads storage once when ensuring a cached fresh token', async () => {

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.ts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.ts
@@ -211,7 +211,6 @@ function installAuthenticatedSupabaseProvider() {
     getSessionTokens,
     getStoredSessionState,
     getStoredAccountLabel: vi.fn(async () => null),
-    isTokenExpiringSoon: vi.fn(() => false),
     getLastRefreshFailure: vi.fn(() => null),
   });
   vi.spyOn(SupabaseClient, 'getUser').mockResolvedValue({


### PR DESCRIPTION
## What

Three leftovers of the relay-plane removal (`368ee4f601`) and the compat-reader harvest (`063cc83ad1`). **−161 net LoC.**

## 1. The `isTokenExpiringSoon` vertical

Its only production consumer was `installTexraModelAccess.ts:76`, deleted by `368ee4f601`. The probe spanned three layers, all now removed:

- `SupabaseClient.isTokenExpiringSoon()` — a static pass-through
- `AuthTokenProvider.isTokenExpiringSoon()` — a port member (one implementor)
- `SupabaseSessionCoordinator.isTokenExpiringSoon()` — the implementation

…plus `tokenExpiresAt` and the mutation-version guard in `loadSession` that existed solely to keep that field consistent against a racing write. `loadSession` collapses to parse-and-return.

**This is not a security guard.** It was a *freshness probe* — a synchronous hint that a refresh was due. `getFreshSession` still refreshes unconditionally off `session.expiresAt` against the same `tokenRefreshThresholdMs`, which stays. Removing the probe changes no refresh behavior.

`sessionMutationVersion` stays — it has other readers (`lastStoredSessionVersion`, `storeRefreshIfCurrent`).

## 2. `toStorableSupabaseSession`'s options bag

Both members were unpassed in substance:

- `fallbackLabel` — 0 passers; its only caller was `refreshViaCustomEndpoint`, deleted by `063cc83ad1`. `firstAccountLabel` was variadic only to accept that candidate, so it inlines to `email?.trim() || user.id`.
- `defaultExpiryMs` — 1 passer (`packages/cli/src/runtime/supabaseAuth.ts:190`), passing `DEFAULT_SUPABASE_SESSION_EXPIRY_MS`, which is *literally the value the `??` already defaulted to*.

The `DEFAULT_SUPABASE_SESSION_EXPIRY_MS` fallback itself **stays** — `auth-device` `/token` responses can omit both `expires_at` and `expires_in`. Only the plumbing goes.

## 3. `parseTokenExchangeResponse`'s `log` parameter — a masking site, fixed loudly

No caller passed it, so `log?.error?.(...)` was a no-op and the Zod validation detail was being **thrown away** before a generic error surfaced. Per checklist §15 this is a masking site to fix, not elegance to delete: `z.prettifyError(parsed.error)` now folds into the thrown message, so the failure is *louder* than before.

## 4. `ModelSelectionExtras`

7 lines repo-wide, no supplier anywhere — not in `src/`, any `packages/*/src`, or `src/test-kernel/`. Both spreads were always `...undefined`. `368ee4f601` deleted the two suppliers and made the desktop field optional instead of removing it.

## Tests

Removed with the behavior they pinned, per AGENTS.md "Testing discipline": 2 cases in `SupabaseClient.vitest.ts`, 4 in `SupabaseSessionLifecycle.vitest.ts`, 1 in-test assertion, and 3 fake-object fields.

One test was **kept and re-pinned** rather than deleted: `falls back to the supplied label and default expiry` covered two facts, one removed (`fallbackLabel`) and one still live (the default-expiry fallback). It now asserts the surviving half against the user id.

## Net elements (R6)

- Files: 12 changed (9 production, 3 test)
- `^[+-]export` symbols: **−2** (`ModelSelectionExtras`, `firstAccountLabel`)
- Port members: **−1** · methods: **−3** · private fields: **−1** · parameter objects: **−1** · parameters: **−1**
- Net LoC: **−161** (`15 insertions(+), 176 deletions(-)` vs `origin/main`)

## Consumer counts (R8)

Grepped with `--no-ignore-vcs` (a global gitignore hides tracked files from plain `rg` here — #11165):

- `isTokenExpiringSoon` — 0 production consumers; 1 port implementor; 4 test/harness files, all updated
- `fallbackLabel` — 0 passers · `defaultExpiryMs` — 1 passer, value-identical to the default
- `parseTokenExchangeResponse` — 1 production caller, passes no logger
- `ModelSelectionExtras` — 0 suppliers
- `tokenRefreshThresholdMs` — **retained**, still read by `getFreshSession`

## Checks

`typecheck` ✅ (exit 0) · `lint` ✅ (exit 0) · `format` ✅

`vitest run` over `test-kernel/{auth,desktop,controllers}` + `CliSupabaseAuth` ✅ — **105 files, 1034 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJmSeJm4wocNwc7AFMrJBU