### PR TITLE
fix(desktop): repair settings and palette regressions

### DIFF
--- a/packages/desktop/src/main/desktopCredentialSettingsController.ts
+++ b/packages/desktop/src/main/desktopCredentialSettingsController.ts
@@ -264,6 +264,18 @@ export class DefaultDesktopCredentialSettingsController implements DesktopCreden
    * failure so the shared flow can retry with a device code, which this host
    * shows in its own dialog.
    */
+  private reportSignInPresentationFailure(
+    displayName: string,
+    error: unknown,
+  ): void {
+    this.options.onError(error);
+    void this.options.notifications
+      .showErrorMessage(
+        `Failed to display ${displayName} sign-in instructions: ${toErrorMessage(error)}`,
+      )
+      .catch(this.options.onError);
+  }
+
   private signInPresenter(displayName: string): SubscriptionSignInPresenter {
     return {
       presentDeviceCode: (prompt) => {
@@ -273,7 +285,9 @@ export class DefaultDesktopCredentialSettingsController implements DesktopCreden
             prompt,
             displayName,
           ),
-        ).catch(this.options.onError);
+        ).catch((error: unknown) =>
+          this.reportSignInPresentationFailure(displayName, error),
+        );
       },
       presentSignInUrl: async (url) => {
         try {
@@ -290,7 +304,9 @@ export class DefaultDesktopCredentialSettingsController implements DesktopCreden
             url,
             displayName,
           ),
-        ).catch(this.options.onError);
+        ).catch((error: unknown) =>
+          this.reportSignInPresentationFailure(displayName, error),
+        );
       },
     };
   }

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -268,13 +268,18 @@ export function createDesktopSettingsIpc(
       stateSettingSnapshotPosters,
     );
     if (result.kind !== 'applied') return;
-    if (result.entry.onWrite?.invalidatesModelOptions) {
+    const invalidatesModelOptions =
+      result.entry.onWrite?.invalidatesModelOptions === true;
+    if (invalidatesModelOptions) {
       invalidateModelOptionsCache();
       await options.credentialSettingsController.refreshAfterProviderSettingChange(
         key,
       );
     }
-    if (codingPlanForUsageSetting(key) !== undefined) {
+    if (
+      !invalidatesModelOptions &&
+      codingPlanForUsageSetting(key) !== undefined
+    ) {
       await options.credentialSettingsController.postSubscriptionUsage();
     }
   }

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -10,6 +10,7 @@ import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import type { ConfigProvider } from '@platform/interfaces';
 import { platform } from '@platform/platform';
 import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
+import { codingPlanForUsageSetting } from '@shared/codingPlanSubscriptions';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   dispatchSettingsViewInbound,
@@ -272,6 +273,9 @@ export function createDesktopSettingsIpc(
       await options.credentialSettingsController.refreshAfterProviderSettingChange(
         key,
       );
+    }
+    if (codingPlanForUsageSetting(key) !== undefined) {
+      await options.credentialSettingsController.postSubscriptionUsage();
     }
   }
 

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -818,7 +818,10 @@ function createWindow(options: {
       onCredentialChanged: async () => {
         await onboardingIpcRef.current?.refreshOnboardingFunnel();
       },
-      onError: reportAsyncError,
+      // Credential operations already show their specific failure dialog. Keep
+      // the shared callback log-only so one failure never opens a second,
+      // generic desktop-operation dialog.
+      onError: reportBackgroundError,
     });
   const toolingSettingsController = new DefaultDesktopToolingSettingsController(
     {

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -400,14 +400,13 @@ function dispatchDesktopPaletteCommand(
 function toStreamPaletteEntry(stream: StreamTabInfo): CommandPaletteEntry {
   return {
     id: buildSwitchStreamCommandId(stream.name),
-    label: `Switch to ${stream.label}`,
-    // `label` is `runIdentityDisplayName(identity)` by construction
+    label: `Switch to ${stream.label || stream.name}`,
+    // `label` is normally `runIdentityDisplayName(identity)` by construction
     // (`buildStreamTabInfo`), so the subtitle reads the same cleaned name the
-    // title shows instead of re-deriving it from the raw identity fields —
+    // title shows instead of re-deriving it from the raw identity fields,
     // which printed a source-prefixed id ('custom:reviewer') beside the
-    // cleaned title. `command` exists only on process streams; the terminal
-    // 'Stream' covers an unresolved-empty label, which the schema does not
-    // forbid.
+    // cleaned title. The schema still permits an empty label, so both title and
+    // subtitle retain a fallback for that edge case.
     description:
       stream.description ||
       stream.command ||

--- a/packages/extension/src/progressView/frontend/utils.ts
+++ b/packages/extension/src/progressView/frontend/utils.ts
@@ -3,18 +3,15 @@
 import type { StreamTabInfo } from '@shared/schemas';
 
 /**
- * The single accessor for a stream's user-facing display label. Every
- * `StreamTabInfo.label` is guaranteed non-empty by `buildStreamTabInfo()`
- * (`src/controllers/session/streamTabInfo.ts`) — this function exists so no
- * call site is tempted to add its own `?? info.name` / `?? streamId`
- * fallback on top of it. `.label` itself may still equal the stream's own
- * opaque id for a stream whose identity hasn't resolved yet — deliberately:
- * that id's prefix already is the clean agent name (`getStreamTabId()`,
- * `src/agent/runtime/streamTab.ts`), so it's the best available label, not a
- * fallback to avoid. Returns undefined only when there's no entry to read
- * from at all (e.g. a lookup by id came back empty because that stream's
- * tab was evicted) — callers decide their own placeholder or omit the label
- * entirely.
+ * The single accessor for a stream's user-facing display label.
+ * `buildStreamTabInfo()` normally supplies the cleaned identity name, and may
+ * deliberately use the stream's opaque id while identity is unresolved. The
+ * schema still permits an empty string, for example from a custom identity
+ * with no name after its source prefix, so a surface that requires non-empty
+ * copy must provide its own available fallback. Returns undefined only when
+ * there's no entry to read from at all (for example, a lookup by id came back
+ * empty because that stream's tab was evicted); callers decide their own
+ * placeholder or omit the label entirely.
  */
 export function streamDisplayLabel(info: Pick<StreamTabInfo, 'label'>): string;
 export function streamDisplayLabel(


### PR DESCRIPTION
Closes #10992. Closes #10942. Closes #11144.

## What

- use the desktop credential controller's existing specific failure dialogs while routing its shared error callback to the log-only reporter, preventing a second generic dialog for provider-key and subscription operations
- refresh subscription usage after any desktop state-setting write recognized by `codingPlanForUsageSetting`, matching the extension host and restoring GLM region-toggle refreshes
- fall back to the stream id when a validated stream still carries an empty display label, so the command-palette title never ends at `Switch to `

## Validation

- desktop typecheck passed
- targeted ESLint and Prettier checks passed
- existing `DesktopCredentialSettingsController`, `DesktopSettingsIpc`, and `DesktopCommandPalette` suites passed: 47 tests
- `git diff --check` passed

## Tests

Zero test files changed.
