### PR TITLE
refactor(hosts): sweep simplification leftovers in extension/cli/desktop

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -46,7 +46,6 @@ import {
   MESSAGE_TYPES,
   STREAM_PHASE,
   STREAM_LOG_ENTRY_TYPES,
-  USER_FOLLOW_UP_SUPPORT,
   TODO_STATUS,
   TOOL_USE_STATUS,
   type ActiveChildInfo,
@@ -606,18 +605,12 @@ function harnessModelStatus(
   }
 }
 
-function harnessModel(fixture: HarnessModelFixture): CliModelAccess {
-  return {
+function harnessOrchestrationModels(): readonly CliModelAccess[] {
+  const models = HARNESS_ORCHESTRATION_MODEL_FIXTURES.map((fixture) => ({
     model: fixture,
     available: isHarnessModelAvailable(fixture.availability),
     status: harnessModelStatus(fixture.availability),
-  };
-}
-
-function harnessOrchestrationModels(): readonly CliModelAccess[] {
-  const models = HARNESS_ORCHESTRATION_MODEL_FIXTURES.map((fixture) =>
-    harnessModel(fixture),
-  );
+  }));
   return SHOW_NO_RUNNABLE_ORCHESTRATION_MODELS
     ? models.map((model) => ({
         ...model,
@@ -936,16 +929,6 @@ function makeChildEntries(agent: string, action: string): TranscriptRow[] {
     ),
     harnessTextRow(`${agent}-assistant`, 'assistant', assistantText, 2, false),
   ];
-}
-
-function harnessMessageEntry(
-  id: string,
-  text: string,
-  kind: 'assistant' | 'error' | 'user' = 'assistant',
-  seqNo = 1,
-  settled = true,
-): TranscriptRow {
-  return harnessTextRow(id, kind, text, seqNo, settled);
 }
 
 function makeEditApprovalRequest() {
@@ -2100,18 +2083,7 @@ function markHarnessInterrupted(): void {
   // applier retains each vanished row, and its displayed status comes from
   // the phase-merge of the real per-child transitions below.
   emitChildRoster(STREAM_ID, []);
-  patchStream(STREAM_ID, (slice) => ({
-    ...slice,
-    entries: [
-      ...slice.entries,
-      harnessMessageEntry(
-        'harness-interrupted',
-        'Harness interrupt requested.',
-        'assistant',
-        slice.entries.length + 1,
-      ),
-    ],
-  }));
+  appendHarnessAssistantTranscript('Harness interrupt requested.', STREAM_ID);
   setStreamStatusInCliState({
     streamId: STREAM_ID,
     status: STREAM_PHASE.CANCELLED,
@@ -2145,18 +2117,10 @@ function markHarnessStreamInterrupted(streamId: StreamTabId): void {
       ),
     );
   }
-  patchStream(streamId, (slice) => ({
-    ...slice,
-    entries: [
-      ...slice.entries,
-      harnessMessageEntry(
-        `harness-focused-interrupted-${streamId}`,
-        `Harness focused interrupt requested for ${streamId}.`,
-        'assistant',
-        slice.entries.length + 1,
-      ),
-    ],
-  }));
+  appendHarnessAssistantTranscript(
+    `Harness focused interrupt requested for ${streamId}.`,
+    streamId,
+  );
   setStreamStatusInCliState({
     streamId: streamId,
     status: STREAM_PHASE.CANCELLED,
@@ -2195,10 +2159,10 @@ function appendHarnessTranscript(
     ...slice,
     entries: [
       ...slice.entries,
-      harnessMessageEntry(
+      harnessTextRow(
         `harness-local-${Date.now()}-${slice.entries.length}`,
-        text,
         role,
+        text,
         slice.entries.length + 1,
         options.finalized,
       ),
@@ -2266,36 +2230,18 @@ function markHarnessExecutionStopped(executionId: string): void {
   );
   if (!executionRow) return;
 
-  const messageId = `harness-killed-${executionId}-${Date.now()}`;
   emitChildRoster(
     STREAM_ID,
     activeSubagentRows.filter((child) => child.executionId !== executionId),
   );
-  patchStream(STREAM_ID, (slice) => ({
-    ...slice,
-    entries: [
-      ...slice.entries,
-      harnessMessageEntry(
-        messageId,
-        `Harness kill requested for ${executionId}.`,
-        'assistant',
-        slice.entries.length + 1,
-      ),
-    ],
-  }));
-
-  patchStream(executionRow.childStreamId, (slice) => ({
-    ...slice,
-    entries: [
-      ...slice.entries,
-      harnessMessageEntry(
-        `${messageId}-${executionRow.childStreamId}`,
-        'Harness kill requested for this sub-workflow.',
-        'assistant',
-        slice.entries.length + 1,
-      ),
-    ],
-  }));
+  appendHarnessAssistantTranscript(
+    `Harness kill requested for ${executionId}.`,
+    STREAM_ID,
+  );
+  appendHarnessAssistantTranscript(
+    'Harness kill requested for this sub-workflow.',
+    executionRow.childStreamId,
+  );
   // The real transition stamps CANCELLED onto the retained roster row via
   // the adapter's phase-merge, and projects the slice status with it.
   defaultSession().status.transition(

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -250,22 +250,6 @@ export function createChatSessionController(
     return streamId ? { streamId, followUps } : undefined;
   };
 
-  const restoreRecoveryFollowUps = (
-    recovery: SupersededInterruptedRecovery | undefined,
-    lease: FollowUpRecoveryLease,
-  ): void => {
-    runtimeSession.followUps.queue(lease).restore(recovery?.followUps ?? []);
-    if (recovery?.followUps.length) {
-      runtimeSession.events.emit({
-        scope: 'session',
-        event: {
-          type: 'updateQueuedFollowUps',
-          payload: { streamId: lease.streamId },
-        },
-      });
-    }
-  };
-
   const restoreInterruptedRecovery = (
     recovery: SupersededInterruptedRecovery | undefined,
   ): void => {
@@ -736,9 +720,20 @@ export function createChatSessionController(
                   onFollowUpQueueReady: (lease) => {
                     if (options.onFollowUpQueueReady) {
                       options.onFollowUpQueueReady(lease);
-                    } else {
-                      const recovery = supersedeInterruptedRecovery();
-                      restoreRecoveryFollowUps(recovery, lease);
+                      return;
+                    }
+                    const recovery = supersedeInterruptedRecovery();
+                    runtimeSession.followUps
+                      .queue(lease)
+                      .restore(recovery?.followUps ?? []);
+                    if (recovery?.followUps.length) {
+                      runtimeSession.events.emit({
+                        scope: 'session',
+                        event: {
+                          type: 'updateQueuedFollowUps',
+                          payload: { streamId: lease.streamId },
+                        },
+                      });
                     }
                   },
                   isCancellationRequested,

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -632,6 +632,22 @@ export function App(props: AppProps): React.JSX.Element {
     pendingEscapeInterrupt.current = { parentStreamId, streamId, timer };
   };
 
+  // Shared tail of both bare-Escape trigger sites below: defer through the
+  // meta-chord disambiguation window when one may be in flight, otherwise
+  // handle the escape immediately.
+  const deferOrHandleBareEscape = (streamId: StreamTabId): void => {
+    if (
+      shouldDeferEscapeInterruptForMetaChord({
+        shortcutModifierLabel: defaultShortcutModifierLabel(),
+        streamFocusAvailable: sessionViews.length > 0,
+      })
+    ) {
+      scheduleBareEscape(streamId);
+    } else {
+      handleBareEscape(streamId);
+    }
+  };
+
   // Single App-level keyboard entry point. Ink broadcasts every keystroke to all
   // mounted useInput handlers, so keeping the App's shortcuts in one always-on
   // handler (gating internally) is clearer than several hooks racing on the same
@@ -654,16 +670,7 @@ export function App(props: AppProps): React.JSX.Element {
         ) {
           return;
         }
-        if (
-          shouldDeferEscapeInterruptForMetaChord({
-            shortcutModifierLabel: defaultShortcutModifierLabel(),
-            streamFocusAvailable: sessionViews.length > 0,
-          })
-        ) {
-          scheduleBareEscape(currentStreamId);
-        } else {
-          handleBareEscape(currentStreamId);
-        }
+        deferOrHandleBareEscape(currentStreamId);
         return;
       }
       const arrowInput =
@@ -757,16 +764,7 @@ export function App(props: AppProps): React.JSX.Element {
       activeStreamId !== undefined &&
       bareEscapeActive(activeStreamId)
     ) {
-      if (
-        shouldDeferEscapeInterruptForMetaChord({
-          shortcutModifierLabel: defaultShortcutModifierLabel(),
-          streamFocusAvailable: sessionViews.length > 0,
-        })
-      ) {
-        scheduleBareEscape(activeStreamId);
-      } else {
-        handleBareEscape(activeStreamId);
-      }
+      deferOrHandleBareEscape(activeStreamId);
     }
   });
 

--- a/packages/cli/src/chat/tui/appInteractionPolicy.ts
+++ b/packages/cli/src/chat/tui/appInteractionPolicy.ts
@@ -97,7 +97,7 @@ export function triggerEscapeInterrupt(
   return true;
 }
 
-export type AppCtrlCAction = 'clear-draft' | 'delegate' | 'interrupt' | 'exit';
+type AppCtrlCAction = 'clear-draft' | 'delegate' | 'interrupt' | 'exit';
 
 export interface AppCtrlCState {
   readonly discardDraft: () => boolean;

--- a/packages/cli/src/chat/tui/chatSubmitDriver.ts
+++ b/packages/cli/src/chat/tui/chatSubmitDriver.ts
@@ -52,7 +52,7 @@ import {
 import type { ChatSessionController } from '../chatSessionController';
 import type { SkillActivation } from './forms/SkillsListForm';
 
-export interface PreparedChatInstruction {
+interface PreparedChatInstruction {
   readonly instruction: string;
   readonly displayInstruction?: string;
   readonly reservedSkillActivations: readonly SkillActivation[];
@@ -109,7 +109,7 @@ export function chatTuiFocusedChildFollowUpRoute(): FocusedChildFollowUpRoute {
   });
 }
 
-export interface ChatSubmitDriverDeps {
+interface ChatSubmitDriverDeps {
   readonly session: TuiSession;
   readonly chatController: ChatSessionController;
   readonly followUpQueue: PQueue;
@@ -122,7 +122,7 @@ export interface ChatSubmitDriverDeps {
   readonly getSlashCommandContext: () => SlashCommandContext;
 }
 
-export interface ChatSubmitDriver {
+interface ChatSubmitDriver {
   readonly handleSubmittedLine: (
     line: string,
     mediaFiles?: readonly string[],

--- a/packages/cli/src/chat/tui/commands/handlers/modelAccessCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/modelAccessCommands.ts
@@ -5,10 +5,7 @@ import {
   parseCliModelAccessSelection,
   type CliModelAccessSelection,
 } from '@cli/runtime/modelAccessRoute';
-import {
-  type CliModelAccessSelectionResult,
-  updateCliModelAccess,
-} from '@cli/runtime/modelAccessSelection';
+import { updateCliModelAccess } from '@cli/runtime/modelAccessSelection';
 
 import type { ApiProvider } from '@model/apiProviders';
 import { collapseWhitespace } from '@utils/text/stringUtils';
@@ -21,14 +18,6 @@ import {
 
 const MODEL_ACCESS_USAGE =
   'Usage: /api chatgpt | grok | kimi-code | glm-code | status';
-
-/** Apply an access selection to the TUI and refresh dependent views. */
-function completeModelAccessSelection(
-  access: CliModelAccessSelectionResult,
-): string {
-  refreshSubscriptionPreferenceViews();
-  return collapseWhitespace(access.message);
-}
 
 /** Save a provider key and refresh access-dependent TUI views. */
 export async function applyCliProviderApiKey(
@@ -63,7 +52,8 @@ async function applyCliModelAccessSelectionWithSignal(
       output.writeProgress(message, { copyable: true }),
     signal,
   });
-  output.appendOutcome(completeModelAccessSelection(access));
+  refreshSubscriptionPreferenceViews();
+  output.appendOutcome(collapseWhitespace(access.message));
 }
 
 export function applyCliModelAccessSelection(

--- a/packages/cli/src/chat/tui/forms/ConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ConfigForm.tsx
@@ -33,10 +33,10 @@ import {
 } from './configCategories';
 import { FormFrame } from './_shared/FormFrame';
 
-export type SettingEditKind =
+type SettingEditKind =
   'form' | 'boolean' | 'enum' | 'string' | 'number' | 'readonly';
 
-export type SettingInputResult =
+type SettingInputResult =
   | { readonly ok: true; readonly value: unknown }
   | { readonly ok: false; readonly message: string };
 

--- a/packages/cli/src/chat/tui/forms/GitHubTokenForm.tsx
+++ b/packages/cli/src/chat/tui/forms/GitHubTokenForm.tsx
@@ -87,7 +87,11 @@ export function GitHubTokenForm(
 
   if (entering) {
     return (
-      <GitHubTokenEntryForm
+      <CredentialEntryForm
+        title="Set GitHub token"
+        helper={<Text dimColor>Get a token: {GITHUB_TOKEN_CREATE_URL}</Text>}
+        placeholder="enter your GitHub token (hidden)"
+        savedHint="Stored in TeXRA secrets on Enter — or set GH_TOKEN / GITHUB_TOKEN."
         error={error}
         saving={saving}
         onCancel={() => {
@@ -156,23 +160,6 @@ export function GitHubTokenForm(
         });
       }}
       onCancel={props.onCancel}
-    />
-  );
-}
-
-function GitHubTokenEntryForm(props: {
-  readonly error?: string;
-  readonly saving?: boolean;
-  readonly onSubmit: (token: string) => void;
-  readonly onCancel: () => void;
-}): React.JSX.Element {
-  return (
-    <CredentialEntryForm
-      title="Set GitHub token"
-      helper={<Text dimColor>Get a token: {GITHUB_TOKEN_CREATE_URL}</Text>}
-      placeholder="enter your GitHub token (hidden)"
-      savedHint="Stored in TeXRA secrets on Enter — or set GH_TOKEN / GITHUB_TOKEN."
-      {...props}
     />
   );
 }

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -36,7 +36,7 @@ const IMAGE_PASTE_TIMEOUT_MS = 15_000;
 
 const ESC_SLASH_PREFIX = '\u001B/';
 
-export interface BaseTextInputProps {
+interface BaseTextInputProps {
   readonly value: string;
   readonly placeholder?: string;
   readonly focus?: boolean;
@@ -87,7 +87,7 @@ export interface BaseTextInputProps {
   readonly masked?: boolean;
 }
 
-export interface TextInputDisplayWindow {
+interface TextInputDisplayWindow {
   readonly value: string;
   readonly cursor: number;
   readonly clipped: boolean;

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -1,4 +1,4 @@
-import { isEscapeInput } from '@cli/tui/inputKeys';
+import { isEscapeInput, type ReturnKeyInput } from '@cli/tui/inputKeys';
 import {
   KEY_HINT_SEPARATOR,
   keyHintText,
@@ -9,23 +9,19 @@ import { APPROVAL_PULSE_FRAMES } from '@cli/tui/ui/glyphs';
 import { textDisplayWidth } from '@cli/runtime/terminalText';
 import { DELEGATION_APPROVAL_COPY } from '@shared/copy/delegationApproval';
 
-export type ConfirmCardKeyAction =
+type ConfirmCardKeyAction =
   'approve' | 'reject' | 'approveAlways' | 'feedback' | 'ignore';
 
 export type ConfirmCardRejectionMode = 'feedback' | 'immediate';
 
-export interface ConfirmCardKey {
-  readonly escape?: boolean;
-  readonly ctrl?: boolean;
-  readonly meta?: boolean;
-}
+type ConfirmCardKey = Pick<ReturnKeyInput, 'escape' | 'ctrl' | 'meta'>;
 
-export interface ConfirmCardKeyOptions {
+interface ConfirmCardKeyOptions {
   readonly allowAlways: boolean;
   readonly rejectionMode: ConfirmCardRejectionMode;
 }
 
-export interface ConfirmCardHintOptions {
+interface ConfirmCardHintOptions {
   readonly approveLabel?: string;
   readonly rejectLabel?: string;
   readonly rejectionMode?: ConfirmCardRejectionMode;
@@ -33,16 +29,16 @@ export interface ConfirmCardHintOptions {
   readonly extraActions?: readonly KeyHint[];
 }
 
-export interface ConfirmCardHintWidthOptions extends ConfirmCardHintOptions {
+interface ConfirmCardHintWidthOptions extends ConfirmCardHintOptions {
   readonly maxColumns?: number;
 }
 
-export interface ConfirmCardCompactHintLayoutOptions extends ConfirmCardHintOptions {
+interface ConfirmCardCompactHintLayoutOptions extends ConfirmCardHintOptions {
   readonly title: string;
   readonly columns: number;
 }
 
-export interface ConfirmCardCompactHintLayout {
+interface ConfirmCardCompactHintLayout {
   readonly inlineHints: readonly KeyHint[];
   readonly stackedHints: readonly KeyHint[];
   readonly stack: boolean;

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -36,7 +36,7 @@ import {
 import { useScrollableOffset } from '../state/useScrollableOffset';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
-export interface ExternalInquiryProps {
+interface ExternalInquiryProps {
   readonly availableRows?: number;
   readonly payload: ExternalInquiryPermission;
   readonly onDecide: (decision: ApprovalDecision) => void;

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -36,13 +36,13 @@ import {
 import { BaseTextInput } from '../input/BaseTextInput';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
-export interface UserQuestionProps {
+interface UserQuestionProps {
   readonly availableRows?: number;
   readonly payload: UserQuestionPermission;
   readonly onDecide: (decision: ApprovalDecision) => void;
 }
 
-export interface UserQuestionPromptLine {
+interface UserQuestionPromptLine {
   readonly kind: 'context' | 'question' | 'overflow';
   readonly text: string;
 }

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -301,7 +301,11 @@ export function ConversationRegion({
               streams={snapshot.streams}
               activeSubagentExecutionIds={snapshot.activeSubagentExecutionIds}
             />
-            <TodosPlanPanel maxRows={todosPlanRows} />
+            <TodosPlanPanel
+              maxRows={todosPlanRows}
+              plan={activePlan}
+              todos={activeTodos}
+            />
           </Box>
         ) : null}
       </Box>

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -49,7 +49,7 @@ import type { InputHistory } from '../history/inputHistory';
 
 const CSI_SEQUENCE_TAIL_RE = /^\[[0-?]*[ -/]*[@-~]$/u;
 
-export interface InputBarProps {
+interface InputBarProps {
   /** Forwarded to BaseTextInput; called only on real (non-paste) Enter.
    *  `mediaFiles` carries absolute paths of any pasted-image attachments. */
   readonly onSubmit: (value: string, mediaFiles?: readonly string[]) => void;

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -339,16 +339,6 @@ function staticTranscriptItemMetrics(
   );
 }
 
-function staticTranscriptItemRowCount(
-  item: StaticTranscriptItem,
-  width?: number,
-  executionLabels?: ExecutionLabels,
-  previousItem?: StaticTranscriptItem,
-): number {
-  return staticTranscriptItemMetrics(item, width, executionLabels, previousItem)
-    .rows;
-}
-
 function staticTranscriptItemsTotals(
   items: readonly StaticTranscriptItem[],
   width?: number,
@@ -820,44 +810,30 @@ export function buildStaticTranscriptItems(
   }
 
   if (!seen.has(SESSION_HEADER_ID)) {
-    const header: StaticTranscriptItem = {
-      id: SESSION_HEADER_ID,
-      kind: 'header',
-      compact: maxRows !== undefined && maxRows < FULL_SESSION_HEADER_ROWS,
-      identityLine: sessionHeaderIdentityLine(meta, {
-        childRosters,
-        parentStream,
-        streamId: scrollbackStreamId,
-        streams,
-      }),
+    // Same insert-if-it-fits logic `advanceStaticTranscriptState` uses on
+    // ordinary ticks; the totals it needs are computed fresh here (this path
+    // has no running rowCount/byteCount to diff against), which costs the
+    // same one full-history walk the old inline reduce paid.
+    const totals = staticTranscriptItemsTotals(
+      currentItems,
+      width,
+      executionLabels,
+    );
+    const header = ensureStaticSessionHeader({
+      byteCount: totals.bytes,
+      childRosters,
+      executionLabels,
+      items: currentItems,
+      maxRows,
       meta,
-    };
-    // The row budget only applies on compact terminals (maxRows defined), and
-    // counting rows wraps every item's full text — O(history) — so it must
-    // stay behind the maxRows gate rather than run eagerly per tick.
-    const fitsBudget =
-      maxRows === undefined ||
-      currentItems.reduce(
-        (total, item, index) =>
-          total +
-          staticTranscriptItemRowCount(
-            item,
-            width,
-            executionLabels,
-            index === 0 ? header : currentItems[index - 1],
-          ),
-        staticTranscriptItemRowCount(header, width, executionLabels),
-      ) <= maxRows;
-    if (fitsBudget) {
-      nextItems = [...currentItems];
-      const firstEntryIndex = nextItems.findIndex(
-        (item) => item.kind !== 'header',
-      );
-      nextItems.splice(
-        firstEntryIndex < 0 ? nextItems.length : firstEntryIndex,
-        0,
-        header,
-      );
+      parentStream,
+      rowCount: totals.rows,
+      scrollbackStreamId,
+      streams,
+      width,
+    });
+    if (header.inserted) {
+      nextItems = [...header.items];
       seen.add(SESSION_HEADER_ID);
     }
   }
@@ -1075,42 +1051,34 @@ export function advanceStaticTranscriptState(
   const finalizedFrontier = slice?.finalizedFrontier ?? 0;
   const status = slice?.status;
 
+  // Rebuilds below share every render input; only the repaint epoch differs
+  // per call site.
+  const rebuildState = (repaintEpoch: number): StaticTranscriptState =>
+    buildStaticTranscriptState({
+      childRosters,
+      eraseRequest,
+      executionLabels,
+      maxRows,
+      meta,
+      ownerKey,
+      parentStream,
+      repaintEpoch,
+      ringBudgets,
+      scrollbackStreamId,
+      streams,
+      width,
+    });
+
   // An out-of-band terminal erase (`/clear`) forces a rebuild even when the
   // items are unchanged — the terminal no longer shows them. Running here,
   // after the reset state committed, keeps the remounted `<Static>` free of
   // stale rows.
   if (eraseRequest !== current.eraseRequest) {
-    return buildStaticTranscriptState({
-      childRosters,
-      eraseRequest,
-      executionLabels,
-      maxRows,
-      meta,
-      ownerKey,
-      parentStream,
-      repaintEpoch: current.repaintEpoch + 1,
-      ringBudgets,
-      scrollbackStreamId,
-      streams,
-      width,
-    });
+    return rebuildState(current.repaintEpoch + 1);
   }
 
   if (isHardReset) {
-    const rebuilt = buildStaticTranscriptState({
-      childRosters,
-      eraseRequest,
-      executionLabels,
-      maxRows,
-      meta,
-      ownerKey,
-      parentStream,
-      repaintEpoch: current.repaintEpoch + 1,
-      ringBudgets,
-      scrollbackStreamId,
-      streams,
-      width,
-    });
+    const rebuilt = rebuildState(current.repaintEpoch + 1);
     // A hard reset that rebuilds the current *render inputs* unchanged — the
     // normal startup path, where the initial useState build already ran with
     // no streams — must not bump the repaint epoch. The `<Static>` remount
@@ -1133,20 +1101,7 @@ export function advanceStaticTranscriptState(
   }
 
   if (current.ownerKey !== ownerKey) {
-    return buildStaticTranscriptState({
-      childRosters,
-      eraseRequest,
-      executionLabels,
-      maxRows,
-      meta,
-      ownerKey,
-      parentStream,
-      repaintEpoch: current.repaintEpoch,
-      ringBudgets,
-      scrollbackStreamId,
-      streams,
-      width,
-    });
+    return rebuildState(current.repaintEpoch);
   }
 
   if (
@@ -1195,20 +1150,7 @@ export function advanceStaticTranscriptState(
     current.scan,
   );
   if (plan.rebuild) {
-    return buildStaticTranscriptState({
-      childRosters,
-      eraseRequest,
-      executionLabels,
-      maxRows,
-      meta,
-      ownerKey,
-      parentStream,
-      repaintEpoch: current.repaintEpoch + 1,
-      ringBudgets,
-      scrollbackStreamId,
-      streams,
-      width,
-    });
+    return rebuildState(current.repaintEpoch + 1);
   }
 
   const header = ensureStaticSessionHeader({

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -811,9 +811,10 @@ export function buildStaticTranscriptItems(
 
   if (!seen.has(SESSION_HEADER_ID)) {
     // Same insert-if-it-fits logic `advanceStaticTranscriptState` uses on
-    // ordinary ticks; the totals it needs are computed fresh here (this path
-    // has no running rowCount/byteCount to diff against), which costs the
-    // same one full-history walk the old inline reduce paid.
+    // ordinary ticks. This path has no running rowCount/byteCount to diff
+    // against, so the totals are computed fresh with one full walk of
+    // `currentItems` — the whole history on a cold start, the newly appended
+    // tail once a previous render has already emitted rows.
     const totals = staticTranscriptItemsTotals(
       currentItems,
       width,

--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -16,16 +16,6 @@ import {
 import { assertNever } from '@utils/core';
 import { pluralize } from '@utils/text/stringUtils';
 
-import {
-  activeStreamId as activeStreamIdSignal,
-  streams as streamsSignal,
-} from '../state/cliState';
-import {
-  readStreamArtifacts,
-  streamArtifactRevision,
-} from '../state/subscribeStreamArtifacts';
-import { useSignal } from '../state/useSignal';
-
 // Marker glyph + color per todo status; statuses absent here (e.g. PENDING)
 // fall back to the default empty box with no color.
 const TODO_STATUS_DISPLAY: Partial<
@@ -161,26 +151,20 @@ function CompactRow({ row }: { row: CompactTodosPlanRow }): React.JSX.Element {
 
 export interface TodosPlanPanelProps {
   readonly maxRows: number;
+  readonly plan: Plan | null;
+  readonly todos: readonly TodoItem[];
 }
 
-export function TodosPlanPanel(
-  props: TodosPlanPanelProps,
-): React.JSX.Element | null {
-  const activeStreamId = useSignal(activeStreamIdSignal);
-  const streams = useSignal(streamsSignal);
-  useSignal(streamArtifactRevision);
-  const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
-  const artifacts = activeStreamId
-    ? readStreamArtifacts(activeStreamId)
-    : undefined;
-  if (!slice) return null;
-  const todos = artifacts?.todos ?? [];
-  const plan = artifacts?.plan ?? null;
+export function TodosPlanPanel({
+  maxRows,
+  plan,
+  todos,
+}: TodosPlanPanelProps): React.JSX.Element | null {
   if (todos.length === 0 && !plan) return null;
   // Like the child list above it, the panel owns one blank separator row so
   // the todo checklist never sits flush against its neighbor. If the gap and
   // one content row do not both fit, render nothing.
-  const rowBudget = Math.max(0, Math.floor(props.maxRows)) - 1;
+  const rowBudget = Math.max(0, Math.floor(maxRows)) - 1;
   if (rowBudget <= 0) return null;
 
   const { hiddenCount, rows } = compactTodosPlanRows({

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -75,7 +75,7 @@ export function toolHeaderPreviewBudget(
   return available >= MIN_HEADER_PREVIEW ? available : 0;
 }
 
-export interface DisplayLineOptions {
+interface DisplayLineOptions {
   /** When false, emit the full text of every block instead of the head+tail
    *  slice. The ctrl+t print path sets this to include everything. */
   readonly elide?: boolean;

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -111,11 +111,11 @@ import {
 } from './state/sessionRunState';
 import { createSessionExitController } from './sessionExitController';
 
-export interface ChatResult {
+interface ChatResult {
   exitCode: number;
 }
 
-export interface RunChatInit {
+interface RunChatInit {
   /** `--agent` override from the CLI; falls through `resolveChatDefaults`. */
   readonly agentOverride?: string;
   /** `--model` override from the CLI; falls through `resolveChatDefaults`. */

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -85,7 +85,6 @@ export interface ApprovalDecision extends Readonly<SharedApprovalDecision> {
   readonly rejectionReason?: string;
   /** Session bypass to activate before accepting this approval. */
   readonly bypass?: ApprovalBypassKind;
-  /** Credential mode to apply before accepting this approval. */
   /** Turn off the matching quota-fallback preference before accepting. */
   readonly disableQuotaRoute?: QuotaFallbackRouteId;
   /** Plan-only approval action when plain approve/reject is not specific enough. */
@@ -97,12 +96,12 @@ export interface PendingApproval {
   readonly decide: (decision: ApprovalDecision) => void;
 }
 
-export interface ApprovalQueueStatus {
+interface ApprovalQueueStatus {
   readonly depth: number;
   readonly kind: ApprovalQueueStatusKind;
 }
 
-export interface EnqueueApprovalOptions {
+interface EnqueueApprovalOptions {
   /** Called with the payload as presented, once, when the entry becomes the
    *  foreground modal. */
   readonly onPresent?: (payload: ApprovalPayload) => void;

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -507,12 +507,12 @@ export function closeInfoPane(): void {
 
 /** Passive reader target. Holding the captured stream id rather than a text
  * snapshot keeps each reader live even if transcript focus moves elsewhere. */
-export interface WorkPlanReaderRequest {
+interface WorkPlanReaderRequest {
   readonly revision: number;
   readonly streamId: StreamTabId;
 }
 
-export type ForegroundReaderTarget =
+type ForegroundReaderTarget =
   | { readonly kind: 'transcript'; readonly streamId: StreamTabId }
   | {
       readonly kind: 'workPlan';

--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -93,12 +93,6 @@ function usageHasTokens(usage: TokenUsageStats): boolean {
   );
 }
 
-/** Session-level cost line. Empty when there is no cost to report and no
- *  known route to attribute. */
-function formatSessionCost(usage: TokenUsageStats): string | undefined {
-  return usageCostLabel(usage.cost, usage.usageRoute);
-}
-
 export function collectResumeUsage(
   streams: ReadonlyMap<StreamTabId, StreamSlice>,
 ): TokenUsageStats | undefined {
@@ -131,7 +125,8 @@ export function formatResumeUsage(
   if (cached > 0) lines.push(`(+ ${formatInteger(cached)} cached)`);
   lines.push(`output=${formatInteger(usage.outputTokens)}`);
   if (reasoning > 0) lines.push(`(reasoning ${formatInteger(reasoning)})`);
-  const costLine = formatSessionCost(usage);
+  // Empty when there is no cost to report and no known route to attribute.
+  const costLine = usageCostLabel(usage.cost, usage.usageRoute);
   return costLine
     ? `Token usage: ${lines.join(' ')}\nSession cost: ${costLine}`
     : `Token usage: ${lines.join(' ')}`;

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -78,7 +78,7 @@ import {
 } from '@tools/approval/bashApproval';
 import { prepareToolEditApprovalPrompt } from '@tools/approval/toolEditApproval';
 import { handleExternalInquiryAction } from '@tools/inquiry/inquiryActions';
-import { generateShortId } from '@utils/core';
+import { generateShortId, onAbort } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 
@@ -237,25 +237,25 @@ function runRetryTask<T>(
 ): Promise<T> {
   signal.throwIfAborted();
   return new Promise<T>((resolve, reject) => {
-    const onAbort = () =>
+    const detach = onAbort(signal, () =>
       reject(
         signal.reason ??
           new DOMException('Retry preparation aborted.', 'AbortError'),
-      );
-    signal.addEventListener('abort', onAbort, { once: true });
+      ),
+    );
     try {
       start().then(
         (value) => {
-          signal.removeEventListener('abort', onAbort);
+          detach();
           resolve(value);
         },
         (error: unknown) => {
-          signal.removeEventListener('abort', onAbort);
+          detach();
           reject(error);
         },
       );
     } catch (error) {
-      signal.removeEventListener('abort', onAbort);
+      detach();
       reject(error);
     }
   });
@@ -557,42 +557,6 @@ function setTuiApprovalBypassState({
   }));
 }
 
-/** Undo one access-settings write that a failed retry had already applied.
- *
- *  Returns the contextualized failure instead of throwing, so a partially
- *  applied switch can report every setting it could not put back rather than
- *  losing all but the first. `restoredInMemory` separates "the value is back
- *  but the write may not have persisted" from "the value is still the one the
- *  user never asked for", because only the latter needs re-doing by hand.
- *
- *  Callers keep their own "did this write happen" guard rather than passing it
- *  in, so a skipped attempt costs no await — see the call site. */
-async function attemptRollback({
-  restore,
-  restoredInMemory,
-  memoryRestoredContext,
-  restoreFailedContext,
-}: {
-  /** Restore the previous value and verify it took effect. */
-  readonly restore: () => Promise<void>;
-  readonly restoredInMemory: () => boolean;
-  readonly memoryRestoredContext: string;
-  readonly restoreFailedContext: string;
-}): Promise<Error | undefined> {
-  try {
-    await restore();
-    return undefined;
-  } catch (rollbackError) {
-    const persistenceContext = restoredInMemory()
-      ? memoryRestoredContext
-      : restoreFailedContext;
-    return new Error(
-      `${persistenceContext}: ${toErrorMessage(rollbackError)}`,
-      { cause: rollbackError },
-    );
-  }
-}
-
 /**
  * Per-setting rollback config for {@link switchRetryToPersonalCredentials}.
  * `writeStarted` / `needsRollback` gate each setting; `restore` re-applies the
@@ -616,6 +580,12 @@ interface RetrySettingRollbackConfig {
  * the previous one, is skipped WITHOUT an await: this runs while the commit
  * queue still holds its slot, and the extra turns let a newer queued switch
  * commit ahead of the restores below.
+ *
+ * Each failure is contextualized rather than thrown, so a partially applied
+ * switch can report every setting it could not put back rather than losing
+ * all but the first. `restoredInMemory` separates "the value is back but the
+ * write may not have persisted" from "the value is still the one the user
+ * never asked for", because only the latter needs re-doing by hand.
  */
 async function rollbackChangedSettings(
   configs: readonly RetrySettingRollbackConfig[],
@@ -623,13 +593,18 @@ async function rollbackChangedSettings(
   const failures: Error[] = [];
   for (const config of configs) {
     if (!config.writeStarted || !config.needsRollback()) continue;
-    const failure = await attemptRollback({
-      restore: config.restore,
-      restoredInMemory: config.restoredInMemory,
-      memoryRestoredContext: config.memoryRestoredContext,
-      restoreFailedContext: config.restoreFailedContext,
-    });
-    if (failure) failures.push(failure);
+    try {
+      await config.restore();
+    } catch (rollbackError) {
+      const persistenceContext = config.restoredInMemory()
+        ? config.memoryRestoredContext
+        : config.restoreFailedContext;
+      failures.push(
+        new Error(`${persistenceContext}: ${toErrorMessage(rollbackError)}`, {
+          cause: rollbackError,
+        }),
+      );
+    }
   }
   return failures;
 }

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -16,9 +16,9 @@
 // subscription, batched drain, and the imperative sync/eviction/focus surface.
 //
 // Secrets are redacted at record time by TexraTranscriptRecorder, which is
-// what every host and the HTML export share. The `redactSecrets` calls below
-// remain only to cover rows persisted before that landed; they are idempotent
-// on already-redacted text.
+// what every host and the HTML export share. The `redactSecrets` call in
+// `./transcriptFold` remains only to cover rows persisted before that
+// landed; it is idempotent on already-redacted text.
 
 import {
   AgentCategory,

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -863,15 +863,10 @@ export function applyStreamChanges(
   if (ctx.promotedIds) {
     // Rebuild path: carry the promotion across the reset rather than
     // re-deriving it from a `streamFinal` that may since have gone false.
-    let frontier = 0;
-    while (
-      frontier < state.items.length &&
-      (state.items[frontier]!.rank === 2 ||
-        ctx.promotedIds.has(state.items[frontier]!.rendered.id))
-    ) {
-      frontier += 1;
-    }
-    state.finalizedFrontier = frontier;
+    state.finalizedFrontier = carriedPromotionFrontier(
+      state.items,
+      ctx.promotedIds,
+    );
     ctx.flags.responseRescan = true;
   }
   // Promote only after the merged order is final: "is there a later entry"

--- a/packages/cli/src/commands/_helpers/globalArgs.ts
+++ b/packages/cli/src/commands/_helpers/globalArgs.ts
@@ -232,7 +232,7 @@ export function booleanArg(args: object, name: string): boolean {
   return name.startsWith('no-') && record[name.slice(3)] === false;
 }
 
-export interface CommonAgentRunFlags {
+interface CommonAgentRunFlags {
   inputFiles: string[];
   contextFiles: string[];
   instruction: string;

--- a/packages/cli/src/commands/_helpers/subscriptionAuthCommand.ts
+++ b/packages/cli/src/commands/_helpers/subscriptionAuthCommand.ts
@@ -51,27 +51,6 @@ export function defineSubscriptionAuthCommand(
 ): CommandDef<typeof GLOBAL_ARGS> {
   const provider = subscriptionProvider(options.providerId);
 
-  function emitLogin(
-    context: CliContext,
-    account: SubscriptionAccount,
-    preferenceEffective: boolean,
-  ): void {
-    const payload = {
-      authenticated: true,
-      email: account.email ?? null,
-      ...options.loginPayloadExtras?.(account),
-      preferSubscription: preferenceEffective,
-    };
-    const signedIn = `Signed in with ${provider.displayName} as ${account.label}.`;
-    emitCliResult(context, {
-      json: payload,
-      ndjson: { kind: options.ndjsonKind, ...payload },
-      text: preferenceEffective
-        ? `${signedIn}\n${provider.displayName} subscription enabled for ${provider.modelFamily}.`
-        : `${signedIn}\n${provider.displayName} subscription preference could not be enabled because a more specific setting overrides the config.`,
-    });
-  }
-
   async function runLogin(
     context: CliContext,
     init: { device: boolean; noBrowser: boolean },
@@ -89,7 +68,21 @@ export function defineSubscriptionAuthCommand(
     if (!signInResult.ok) return CliExitCode.ModelOrNetworkError;
 
     const update = await provider.setPreferSubscription(true);
-    emitLogin(context, signInResult.value, update.effective);
+    const account = signInResult.value;
+    const payload = {
+      authenticated: true,
+      email: account.email ?? null,
+      ...options.loginPayloadExtras?.(account),
+      preferSubscription: update.effective,
+    };
+    const signedIn = `Signed in with ${provider.displayName} as ${account.label}.`;
+    emitCliResult(context, {
+      json: payload,
+      ndjson: { kind: options.ndjsonKind, ...payload },
+      text: update.effective
+        ? `${signedIn}\n${provider.displayName} subscription enabled for ${provider.modelFamily}.`
+        : `${signedIn}\n${provider.displayName} subscription preference could not be enabled because a more specific setting overrides the config.`,
+    });
     invalidateModelOptionsCache();
     return CliExitCode.Success;
   }

--- a/packages/cli/src/commands/installGithubAction.ts
+++ b/packages/cli/src/commands/installGithubAction.ts
@@ -1,6 +1,7 @@
 import { mkdir, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import type { ExecResult } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { CliExitCode } from '../runtime/exitCodes';
@@ -195,7 +196,7 @@ async function runInstallGithubAction(
     return CliExitCode.Usage;
   }
 
-  let checkout: ReturnType<typeof git>;
+  let checkout: ExecResult;
   if (branchExists) {
     checkout = git(root, 'checkout', branch);
   } else {

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -96,10 +96,6 @@ function formatMultiAgentDisplayInstruction(
     .join('\n\n');
 }
 
-function headlessAskMultiAgentMessage(presetId: string): string {
-  return `Cannot run multi-agent preset "${presetId}" with headless approval policy "ask": delegation prompts cannot be answered. Use an interactive run to answer prompts, pass --approval-policy never to deny approval-gated tools, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.`;
-}
-
 function writeMultiAgentRunResult(
   context: CliContext,
   plan: CliMultiAgentPresetRunPlan,
@@ -178,7 +174,9 @@ export async function runMultiAgentPreset(
       reloadRemoteAgents: !rejectsHeadlessAsk,
     });
   if (rejectsHeadlessAsk) {
-    writeTextStderr(headlessAskMultiAgentMessage(plan.preset.id));
+    writeTextStderr(
+      `Cannot run multi-agent preset "${plan.preset.id}" with headless approval policy "ask": delegation prompts cannot be answered. Use an interactive run to answer prompts, pass --approval-policy never to deny approval-gated tools, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.`,
+    );
     return CliExitCode.Usage;
   }
   if (remoteCatalogRefreshAttempted) {

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -165,11 +165,8 @@ async function runOrchestration(context: CliContext): Promise<number> {
     const history = await listCliHistoryEntries();
     const presets = readCliMultiAgentPresets();
     const presetPlanSet = await loadCliMultiAgentPresetPlanSet(presets);
-    const launchContext = context;
     const presetLaunchBlockReason =
-      launchContext.approvalPolicy === 'never'
-        ? 'delegation-denied'
-        : undefined;
+      context.approvalPolicy === 'never' ? 'delegation-denied' : undefined;
     const [modelAccess, authProfile] = await Promise.all([
       readCliModelAccessStatus(),
       getCliAuthProfile(),
@@ -204,7 +201,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
       loadCliApiStatus(),
     ]);
     const allowDefaultModelLaunch = await canLaunchWithDefaultModel(
-      launchContext,
+      context,
       models,
     );
     const { runOrchestrationTui } =
@@ -229,7 +226,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
     switch (action.kind) {
       case 'chat': {
         const { runChat } = await import('../chat/tui/runChatTui');
-        const result = await runChat(launchContext, {
+        const result = await runChat(context, {
           agentOverride: action.agent,
           modelOverride: action.model,
         });
@@ -272,10 +269,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
             return 'cancel';
           },
           signIn: async () => {
-            const code = await runLoginCommand(
-              launchContext,
-              loginInitFromArgs({}),
-            );
+            const code = await runLoginCommand(context, loginInitFromArgs({}));
             return (
               code === CliExitCode.Success &&
               (await SupabaseClient.isAuthenticated())
@@ -308,7 +302,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
         const rootAgent = plan.rootAgent;
         writeMissingPresetAgents(plan);
         const { runChat } = await import('../chat/tui/runChatTui');
-        const result = await runChat(launchContext, {
+        const result = await runChat(context, {
           agentOverride: rootAgent.name,
           teamName: plan.preset.name,
           modelOverride: action.model,
@@ -320,7 +314,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
         return result.exitCode;
       }
       case 'resume':
-        return runResumeExecution(launchContext, action.id);
+        return runResumeExecution(context, action.id);
       case 'browse-resumes':
       case 'configure-model-access':
       case 'browse-agents':
@@ -347,7 +341,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
               );
             } else {
               const result = await updateCliModelAccess(
-                launchContext,
+                context,
                 {
                   kind: 'subscription-preference',
                   provider: action.provider,
@@ -361,7 +355,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
             await signOutCliSupabase();
             writeTextStdout('Signed out of TeXRA.');
           } else {
-            await runLoginCommand(launchContext, loginInitFromArgs({}));
+            await runLoginCommand(context, loginInitFromArgs({}));
           }
           invalidateModelOptionsCache();
         } catch (error: unknown) {
@@ -371,11 +365,9 @@ async function runOrchestration(context: CliContext): Promise<number> {
       }
       case 'set-model-access': {
         try {
-          const result = await updateCliModelAccess(
-            launchContext,
-            action.access,
-            { writeProgress: writeTextStdout },
-          );
+          const result = await updateCliModelAccess(context, action.access, {
+            writeProgress: writeTextStdout,
+          });
           writeTextStdout(result.message);
         } catch (error: unknown) {
           writeErrorStderr(error);

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -421,28 +421,20 @@ interface OnboardingPicker {
   readonly items: readonly OnboardingPickerItem[];
 }
 
-/** Picker copy and the credential paths offered, for one entry point. */
+/** Picker copy for one entry point; both offer the same credential paths. */
 function onboardingPicker(props: {
   readonly firstRun: boolean;
 }): OnboardingPicker {
-  const picker = (
-    subtitle: string,
-    setupPaths: readonly OnboardingSetupPath[],
-  ): OnboardingPicker => ({
-    subtitle,
+  return {
+    subtitle: props.firstRun
+      ? 'No provider API key is configured. Choose how to power model calls:'
+      : 'Choose how to power model calls:',
     items: [
-      ...setupPaths.map((path) => SETUP_PATH_PICKER_ITEMS[path]),
+      SETUP_PATH_PICKER_ITEMS.chatgpt,
+      SETUP_PATH_PICKER_ITEMS.key,
       SKIP_PICKER_ITEM,
     ],
-  });
-
-  if (!props.firstRun) {
-    return picker('Choose how to power model calls:', ['chatgpt', 'key']);
-  }
-  return picker(
-    'No provider API key is configured. Choose how to power model calls:',
-    ['chatgpt', 'key'],
-  );
+  };
 }
 
 /** Screen each non-skip picker choice opens (skip resolves the gate instead). */
@@ -475,24 +467,6 @@ function PickerStep(props: {
         onCancel={() => props.onSelect('skip')}
       />
     </OnboardingFrame>
-  );
-}
-
-function ProgressFrame(props: {
-  readonly title: string;
-  readonly spinnerLabel: string;
-  readonly children: React.ReactNode;
-}): React.JSX.Element {
-  return (
-    <BorderedPanel
-      color={COLOR_HINT}
-      title={props.title}
-      footer={<LoadingIndicator label={props.spinnerLabel} />}
-    >
-      <Box marginTop={1} flexDirection="column">
-        {props.children}
-      </Box>
-    </BorderedPanel>
   );
 }
 
@@ -542,14 +516,19 @@ function ChatGptProgressStep(
   }, []);
 
   return (
-    <ProgressFrame
+    <BorderedPanel
+      color={COLOR_HINT}
       title={ONBOARDING_CHOICE_CHATGPT.label}
-      spinnerLabel="Waiting for ChatGPT sign-in… (Ctrl-C cancels)"
+      footer={
+        <LoadingIndicator label="Waiting for ChatGPT sign-in… (Ctrl-C cancels)" />
+      }
     >
-      {message.split('\n').map((line, index) => (
-        <Text key={`${index}:${line}`}>{line}</Text>
-      ))}
-    </ProgressFrame>
+      <Box marginTop={1} flexDirection="column">
+        {message.split('\n').map((line, index) => (
+          <Text key={`${index}:${line}`}>{line}</Text>
+        ))}
+      </Box>
+    </BorderedPanel>
   );
 }
 

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -26,7 +26,7 @@ import {
 } from '../runtime/apiStatus';
 import type { CliModelAccess } from '../runtime/modelAccess';
 
-export interface OrchestrationAppProps {
+interface OrchestrationAppProps {
   readonly items: readonly CliOrchestrationItem[];
   readonly resumeItems?: readonly CliOrchestrationItem[];
   readonly agentItems?: readonly CliOrchestrationItem[];
@@ -45,7 +45,7 @@ export interface OrchestrationAppProps {
   readonly onResolve: (action: CliOrchestrationAction) => void;
 }
 
-export type OrchestrationLauncherStep =
+type OrchestrationLauncherStep =
   | { readonly kind: 'launcher' }
   | {
       readonly kind: 'model';
@@ -118,7 +118,7 @@ export function orchestrationBlockRowCost(
   return 1 + orchestrationLinesRowCost(lines, columns);
 }
 
-export interface OrchestrationLauncherLayout {
+interface OrchestrationLauncherLayout {
   readonly statusLines: readonly string[];
   readonly footerHints: readonly string[];
   readonly maxVisibleItems: number | undefined;
@@ -499,7 +499,7 @@ export function OrchestrationApp(
   );
 }
 
-export interface RunOrchestrationTuiOptions extends Omit<
+interface RunOrchestrationTuiOptions extends Omit<
   OrchestrationAppProps,
   'items' | 'onResolve'
 > {

--- a/packages/cli/src/runtime/approval/approvalPrompts.ts
+++ b/packages/cli/src/runtime/approval/approvalPrompts.ts
@@ -100,8 +100,7 @@ export function warnApprovalDenied(context: CliContext, gate?: string): void {
  * switch decision, the retry request message, and the auto-switch) switch on
  * this instead of re-deriving precedence from overlapping predicates.
  */
-export type CliRetryAction =
-  `disable-quota-route:${QuotaFallbackRouteId}` | 'none';
+type CliRetryAction = `disable-quota-route:${QuotaFallbackRouteId}` | 'none';
 
 const DISABLE_QUOTA_ROUTE_PREFIX = 'disable-quota-route:';
 

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -309,22 +309,6 @@ function envValue(
   return isNonEmptyString(value) ? value : undefined;
 }
 
-function pickEnum<T extends string>(
-  candidates: readonly (string | undefined)[],
-  allowed: readonly T[],
-  fallback: T,
-  warnings: string[],
-  label: string,
-): T {
-  for (const candidate of candidates) {
-    if (!candidate) continue;
-    if ((allowed as readonly string[]).includes(candidate))
-      return candidate as T;
-    warnings.push(`Ignoring invalid ${label} "${candidate}".`);
-  }
-  return fallback;
-}
-
 function pickEnvModel(
   env: Record<string, string | undefined>,
   warnings: string[],
@@ -412,20 +396,23 @@ export async function buildCliContext(
       `Ignoring invalid TEXRA_APPROVAL_POLICY "${candidate}".`,
     );
   }
+  let outputFormat: CliOutputFormat = 'text';
+  for (const candidate of [
+    init.globalArgs.outputFormat,
+    envValue(env, 'TEXRA_OUTPUT_FORMAT'),
+    loadedConfig.values.outputFormat,
+  ]) {
+    if (!candidate) continue;
+    if ((CLI_OUTPUT_FORMATS as readonly string[]).includes(candidate)) {
+      outputFormat = candidate as CliOutputFormat;
+      break;
+    }
+    configWarnings.push(`Ignoring invalid TEXRA_OUTPUT_FORMAT "${candidate}".`);
+  }
   return {
     cwd,
     mode: cliMode(init.globalArgs, ambient),
-    outputFormat: pickEnum(
-      [
-        init.globalArgs.outputFormat,
-        envValue(env, 'TEXRA_OUTPUT_FORMAT'),
-        loadedConfig.values.outputFormat,
-      ],
-      CLI_OUTPUT_FORMATS,
-      'text',
-      configWarnings,
-      'TEXRA_OUTPUT_FORMAT',
-    ),
+    outputFormat,
     approvalPolicy,
     quietLogs: init.globalArgs.quiet === true,
     stdoutIsTty: ambient.stdoutIsTty,

--- a/packages/cli/src/runtime/credentialStatus.ts
+++ b/packages/cli/src/runtime/credentialStatus.ts
@@ -34,12 +34,6 @@ async function probeCredential(
   });
 }
 
-function hasProviderApiKey(): Promise<boolean> {
-  return probeCredential('Provider API key', () =>
-    hasAnyUsableProviderApiKey(platform().secrets),
-  );
-}
-
 /** Never rejects: every probe resolves to false with a logged reason. */
 export async function hasCliRunCredential(): Promise<boolean> {
   const hasChatGptSubscription = await probeCredential(
@@ -51,5 +45,7 @@ export async function hasCliRunCredential(): Promise<boolean> {
     isXaiSubscriptionActive(XAI_SETUP_MODEL),
   );
   if (hasGrokSubscription) return true;
-  return hasProviderApiKey();
+  return probeCredential('Provider API key', () =>
+    hasAnyUsableProviderApiKey(platform().secrets),
+  );
 }

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -334,22 +334,18 @@ export async function stageCliHistoryTraceViewerAssets(params: {
   return 'staged';
 }
 
-/**
- * A live session (rare for the one-shot `history` command, but not
- * impossible) supplies the canonical lifecycle callbacks for cleanup.
- */
-function liveStreamCleanup() {
-  const session = tryDefaultSession();
-  return session?.transcripts.mode.kind === 'persistent'
-    ? createSessionStores(session)
-    : undefined;
-}
-
 export async function deleteCliHistory(options: {
   id?: ExecutionId;
   all?: boolean;
 }): Promise<CliHistoryDeleteResult> {
-  const cleanup = resolveAdjacentStreamCleanup(liveStreamCleanup());
+  // A live session (rare for the one-shot `history` command, but not
+  // impossible) supplies the canonical lifecycle callbacks for cleanup.
+  const liveSession = tryDefaultSession();
+  const cleanup = resolveAdjacentStreamCleanup(
+    liveSession?.transcripts.mode.kind === 'persistent'
+      ? createSessionStores(liveSession)
+      : undefined,
+  );
   if (options.all) {
     const result = await deleteAllExecutions({
       beforeDelete: (executionId) =>
@@ -538,7 +534,8 @@ async function toCliHistoryEntry(
   entry: AgentExecutionListingEntry,
 ): Promise<CliHistoryEntry> {
   const config = entry.record;
-  const inputBasename = firstInputBasename(config);
+  const firstInputFile = config.inputFiles.at(0);
+  const inputBasename = firstInputFile ? path.basename(firstInputFile) : '-';
   const resumeData = await readCliResumeDataForListing(entry.id, config);
   return {
     id: entry.id,
@@ -562,9 +559,4 @@ async function toCliHistoryEntry(
 
 function teamPresetId(config: AgentConfig | null): string | undefined {
   return config?.cliMultiAgentPresetId?.trim() || undefined;
-}
-
-function firstInputBasename(config: AgentConfig): string {
-  const first = config.inputFiles.at(0);
-  return first ? path.basename(first) : '-';
 }

--- a/packages/cli/src/runtime/logSinks.ts
+++ b/packages/cli/src/runtime/logSinks.ts
@@ -12,11 +12,11 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
  * Previously lived in `@logger/structuredLogger`; inlined here because the
  * CLI is the only consumer.
  */
-export interface LogFields {
+interface LogFields {
   readonly [key: string]: unknown;
 }
 
-export interface LogRecord {
+interface LogRecord {
   readonly ts: string;
   readonly level: LogLevel;
   readonly message: string;

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -94,7 +94,7 @@ export function runnableCliModelAccessEntries(
   return models.filter((entry) => entry.available);
 }
 
-function formatCliNoRunnableModelsRecovery(
+export function formatCliNoAvailableModelsRecovery(
   options: CliNoAvailableModelsRecoveryOptions = {},
 ): string {
   const configureKeyAction =
@@ -105,7 +105,7 @@ function formatCliNoRunnableModelsRecovery(
 export function formatCliNoRunnableModelsMessage(
   options: CliNoAvailableModelsRecoveryOptions = {},
 ): string {
-  return `${NO_RUNNABLE_MODEL_ACCESS_COPY}. ${formatCliNoRunnableModelsRecovery(options)}`;
+  return `${NO_RUNNABLE_MODEL_ACCESS_COPY}. ${formatCliNoAvailableModelsRecovery(options)}`;
 }
 
 function formatModelAccessStatus(model: ModelOptionData): string {
@@ -163,12 +163,6 @@ export function emptyModelListMessage(
   options: CliNoAvailableModelsRecoveryOptions = {},
 ): string {
   return formatCliNoRunnableModelsMessage(options);
-}
-
-export function formatCliNoAvailableModelsRecovery(
-  options: CliNoAvailableModelsRecoveryOptions = {},
-): string {
-  return formatCliNoRunnableModelsRecovery(options);
 }
 
 function toCliModelAccess(model: ModelOptionData): CliModelAccess {

--- a/packages/cli/src/runtime/modelAccessRoute.ts
+++ b/packages/cli/src/runtime/modelAccessRoute.ts
@@ -25,7 +25,7 @@ type CliSubscriptionPreferenceState = 'off' | 'on';
 type CliSubscriptionProvider =
   'chatgpt' | 'grok' | CodingPlanSubscription['cliProvider'];
 
-export interface CliCodingPlanStatus {
+interface CliCodingPlanStatus {
   readonly preferred: boolean;
   readonly keySet: boolean;
 }

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -264,7 +264,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     return this.rootStreamId === streamId;
   }
 
-  isRootStream(streamId: StreamTabId): boolean {
+  private isRootStream(streamId: StreamTabId): boolean {
     return this.rootStreamId === streamId;
   }
 

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -202,11 +202,6 @@ export async function signOutCliSupabase(): Promise<void> {
   );
 }
 
-/** Fresh access token for the stored CLI session. */
-export async function getCliSessionAccessToken(): Promise<string | null> {
-  return initializeCliSupabaseAuth().ensureFreshToken();
-}
-
 export async function getCliAuthProfile(): Promise<CliAuthProfile> {
   const authCoordinator = initializeCliSupabaseAuth();
 

--- a/packages/cli/src/runtime/transcriptSession.ts
+++ b/packages/cli/src/runtime/transcriptSession.ts
@@ -112,9 +112,7 @@ export async function initializeInteractiveTranscriptSession(
 
   const session = initializeDefaultSession({
     transcripts,
-    responseTextProcessing: createTexraResponseTextProcessing(
-      agentResponseTextConnector,
-    ),
+    responseTextProcessing,
   });
   await session.waitUntilReady();
   return ephemeralSession(

--- a/packages/desktop/src/main/desktopCredentialSettingsController.ts
+++ b/packages/desktop/src/main/desktopCredentialSettingsController.ts
@@ -177,7 +177,7 @@ export class DefaultDesktopCredentialSettingsController implements DesktopCreden
     });
     this.profileHandlers = {
       signIn: () => options.auth.signIn(),
-      signOut: () => this.signOut(),
+      signOut: () => options.auth.signOut(),
       setProviderKey: (message) =>
         message.apiKey == null
           ? this.profileKeyController.setProviderKey(message.provider)
@@ -385,10 +385,6 @@ export class DefaultDesktopCredentialSettingsController implements DesktopCreden
     return this.refreshAfterSubscriptionAuthChange(() =>
       this.postGrokAuthStatus(),
     );
-  }
-
-  private async signOut(): Promise<void> {
-    await this.options.auth.signOut();
   }
 
   private async signOutSubscription(

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -132,12 +132,10 @@ export function createDesktopSettingsIpc(
     },
   });
 
-  function readCurrentGitAuthorSettings() {
-    return readGitAuthorSettingsFromState(workspaceState);
-  }
-
   function applyCurrentGitAuthorSettings() {
-    return applyGitAuthorSettings(readCurrentGitAuthorSettings());
+    return applyGitAuthorSettings(
+      readGitAuthorSettingsFromState(workspaceState),
+    );
   }
 
   const settingsStores: SettingsStores = {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -336,9 +336,11 @@ function createWindow(options: {
   const onboardingIpcRef: {
     current?: DesktopOnboardingIpc;
   } = {};
-  const showErrorMessage = async (message: string) => {
-    await dialog.showMessageBox(window, { message, type: 'error' });
-  };
+  const showMessageBoxOfType =
+    (type: 'error' | 'info' | 'warning') => async (message: string) => {
+      await dialog.showMessageBox(window, { type, message });
+    };
+  const showErrorMessage = showMessageBoxOfType('error');
   const reportAsyncError = (error: unknown) => {
     console.error('Desktop asynchronous operation failed:', error);
     void showErrorMessage(
@@ -356,12 +358,8 @@ function createWindow(options: {
   installDesktopNavigationPolicy(window.webContents, {
     onAsyncError: reportAsyncError,
   });
-  const showInfoMessage = async (message: string) => {
-    await dialog.showMessageBox(window, { type: 'info', message });
-  };
-  const showWarningMessage = async (message: string) => {
-    await dialog.showMessageBox(window, { type: 'warning', message });
-  };
+  const showInfoMessage = showMessageBoxOfType('info');
+  const showWarningMessage = showMessageBoxOfType('warning');
   // Shared shape for the "confirm this action" dialog: a warning with a
   // confirm button (defaulted, id 0) and a 'Cancel' button (id 1), collapsed
   // to a boolean. Used by confirmAcceptFile, the agent-settings confirm

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -143,7 +143,7 @@ import {
 } from './fileRequests';
 import { createMessageRoutes } from './messageRoutes';
 
-const appRoot = document.querySelector<HTMLElement>('#app');
+const appRoot = document.querySelector<HTMLElement>('#app')!;
 
 if (appRoot == null) {
   throw new Error('TeXRA desktop renderer root was not found.');

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -143,7 +143,7 @@ import {
 } from './fileRequests';
 import { createMessageRoutes } from './messageRoutes';
 
-const appRoot = document.querySelector<HTMLElement>('#app')!;
+const appRoot = document.querySelector<HTMLElement>('#app');
 
 if (appRoot == null) {
   throw new Error('TeXRA desktop renderer root was not found.');
@@ -833,10 +833,11 @@ function taskConversationTemplate(): TemplateResult {
   const sidebarToggleLabel = shellState.sidebarCollapsed
     ? 'Show sidebar'
     : 'Hide sidebar';
+  const workspacePath = window.texraDesktop?.workspacePath;
   // Names the button even when the ≤560px container query collapses it to the
   // icon: the shadow button then has no visible text, so only `title` reaches
   // its accessible name.
-  const environmentButtonLabel = `${workspaceName(window.texraDesktop?.workspacePath)} environment`;
+  const environmentButtonLabel = `${workspaceName(workspacePath)} environment`;
   return html`
     <main class="task-conversation" aria-label="Task conversation">
       <header class="task-header">
@@ -869,9 +870,7 @@ function taskConversationTemplate(): TemplateResult {
                   with-caret
                 >
                   ${waIcon('folder-open', { slot: 'start' })}
-                  <span
-                    >${workspaceName(window.texraDesktop?.workspacePath)}</span
-                  >
+                  <span>${workspaceName(workspacePath)}</span>
                 </wa-button>
               `
             : nothing
@@ -925,7 +924,7 @@ function taskConversationTemplate(): TemplateResult {
         </div>
         ${
           shellState.summaryBarVisible
-            ? environmentPopoverTemplate(window.texraDesktop?.workspacePath)
+            ? environmentPopoverTemplate(workspacePath)
             : nothing
         }
       </header>

--- a/packages/desktop/src/shared/desktopCommandSurface.ts
+++ b/packages/desktop/src/shared/desktopCommandSurface.ts
@@ -179,13 +179,13 @@ export interface DesktopCommandActions {
   toggleSummaryBar(): void;
 }
 
-export interface DesktopSettingsTabMessage {
+interface DesktopSettingsTabMessage {
   command: typeof SETTINGS_VIEW_COMMANDS.SET_TAB;
   tab: SettingsTabPanelName;
   agentSubTab?: AgentCategory;
 }
 
-export interface DesktopMainViewResetMessage {
+interface DesktopMainViewResetMessage {
   command: typeof MAIN_VIEW_COMMANDS.STATE_RESTORE;
   isResetOperation: true;
 }

--- a/packages/desktop/tests/e2e/electronApp.ts
+++ b/packages/desktop/tests/e2e/electronApp.ts
@@ -6,7 +6,6 @@ import { fileURLToPath } from 'node:url';
 import { _electron as electron } from 'playwright';
 import type { ElectronApplication, Page } from 'playwright';
 
-import type { DesktopWorkbenchKind } from '../../src/shared/desktopShellMessages.js';
 import { cleanupDirectory } from './workspaceStorageFixture.js';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -234,6 +233,8 @@ export async function showLauncher(launched: LaunchedApp): Promise<void> {
     { timeout: 5000 },
   );
 }
+
+export type DesktopWorkbenchKind = 'settings' | 'logs';
 
 export async function openWorkbench(
   launched: LaunchedApp,

--- a/packages/desktop/tests/e2e/electronApp.ts
+++ b/packages/desktop/tests/e2e/electronApp.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { _electron as electron } from 'playwright';
 import type { ElectronApplication, Page } from 'playwright';
 
+import type { DesktopWorkbenchKind } from '../../src/shared/desktopShellMessages.js';
 import { cleanupDirectory } from './workspaceStorageFixture.js';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -233,8 +234,6 @@ export async function showLauncher(launched: LaunchedApp): Promise<void> {
     { timeout: 5000 },
   );
 }
-
-export type DesktopWorkbenchKind = 'settings' | 'logs';
 
 export async function openWorkbench(
   launched: LaunchedApp,

--- a/packages/extension/src/commands/housekeeping/cleanCommands.ts
+++ b/packages/extension/src/commands/housekeeping/cleanCommands.ts
@@ -67,7 +67,7 @@ export async function handleClean(config: CleanConfig): Promise<void> {
   await runFileOp(config, {
     runSingle: runCleanSingle,
     runMultiple: runCleanMultiple,
-    runRunDir: (executionId) => runCleanRunDir(executionId),
+    runRunDir: runCleanRunDir,
     showResult: showCleanResult,
   });
 }

--- a/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
+++ b/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
@@ -76,14 +76,6 @@ class AgentDirectoryManager {
     return this.getDirectoryService().getDirectory(source);
   }
 
-  /**
-   * Get all local agent directories (excludes Remote).
-   * Returns directories in priority order: Custom, BuiltIn, BuiltInToolUse.
-   */
-  async getAllLocal(): Promise<AgentDirectoryEntry[]> {
-    return this.getDirectoryService().getAllLocal();
-  }
-
   async custom(): Promise<string> {
     return this.getDirectoryService().custom();
   }
@@ -166,7 +158,7 @@ class AgentDirectoryManager {
         return;
       }
 
-      const directories = await this.getAllLocal();
+      const directories = await this.getDirectoryService().getAllLocal();
       if (!this.onAgentYamlChange) {
         return;
       }

--- a/packages/extension/src/frontend/git/gitAuthorSetup.ts
+++ b/packages/extension/src/frontend/git/gitAuthorSetup.ts
@@ -9,12 +9,10 @@ import { platform } from '@platform/platform';
 import {
   applyGitAuthorSettings,
   readGitAuthorSettingsFromState,
-  type GitAuthorSettings,
 } from '@utils/system/gitAuthorSettings';
 
-/** Apply settings and return them so callers can forward without re-reading. */
-export function applyGitAuthorConfig(): GitAuthorSettings {
-  return applyGitAuthorSettings(
+export function applyGitAuthorConfig(): void {
+  applyGitAuthorSettings(
     readGitAuthorSettingsFromState(platform().workspaceState),
   );
 }

--- a/packages/extension/src/frontend/ui/errorHandlingUtils.ts
+++ b/packages/extension/src/frontend/ui/errorHandlingUtils.ts
@@ -5,7 +5,7 @@ import { createLog } from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 /** Valid documentation identifiers for error messages. */
-export type DocId = 'intelligent-merge' | 'custom-agents' | 'latex-diff';
+type DocId = 'intelligent-merge' | 'custom-agents' | 'latex-diff';
 
 /** Log a formatted error message and return it. */
 export function logErrorMessage(

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -107,15 +107,20 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     await this.host.info(message);
   };
 
+  /** Same discard-the-answer shape as `showInfo`, reused by the port bindings below. */
+  private readonly showWarning = async (message: string): Promise<void> => {
+    await this.host.warning(message);
+  };
+
+  private readonly showError = async (message: string): Promise<void> => {
+    await this.host.error(message);
+  };
+
   /** This host's bindings for the shared follow-up plan/polish interpreters. */
   private readonly followUpPorts: FollowUpApplyPorts = {
     showInfo: this.showInfo,
-    showWarning: async (message) => {
-      await this.host.warning(message);
-    },
-    showError: async (message) => {
-      await this.host.error(message);
-    },
+    showWarning: this.showWarning,
+    showError: this.showError,
     logError: (message, error) => {
       this.logger.error(this.channel, message, { data: error });
     },
@@ -254,17 +259,19 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         pickFormat: () => this.pickTranscriptExportFormat(),
         openPath: (filePath, kind) => this.openExportPath(filePath, kind),
         showInfo: this.showInfo,
-        showWarning: async (message) => {
-          await this.host.warning(message);
-        },
-        showError: async (message) => {
-          await this.host.error(message);
-        },
+        showWarning: this.showWarning,
+        showError: this.showError,
         reportDetail: (message, data) => {
           this.logger.error(this.channel, message, { data });
         },
         getController: () => Promise.resolve(this.getChatExportController()),
-        getTraceViewerTemplate: () => this.getTraceViewerTemplate(),
+        getTraceViewerTemplate: () =>
+          path.join(
+            this.provider.extensionPath,
+            'resources',
+            'traceViewer',
+            'index.html',
+          ),
       },
     };
 
@@ -431,9 +438,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           ]).then((result) => result ?? false),
         readFile: (file) => AbsoluteFS.read(file),
         showInfo: this.showInfo,
-        showError: async (message) => {
-          await this.host.error(message);
-        },
+        showError: this.showError,
         logError: (message, error) => {
           this.logger.error(this.channel, message, {
             data: error instanceof Error ? error : undefined,
@@ -587,15 +592,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private getChatExportController(): ChatExportController {
     this.chatExportController ??= new ChatExportController({ latexPreamble });
     return this.chatExportController;
-  }
-
-  private getTraceViewerTemplate(): string {
-    return path.join(
-      this.provider.extensionPath,
-      'resources',
-      'traceViewer',
-      'index.html',
-    );
   }
 
   private async pickTranscriptExportFormat(): Promise<

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -394,15 +394,21 @@ export class BackgroundTasksPanel extends LitElement {
   /**
    * Shared section shape: guard against an empty list, build the
    * `.section-content` rows, and either return them bare (single populated
-   * section under the outer panel) or wrap them in the counted disclosure
-   * header via {@link renderSectionDetails}.
+   * section under the outer panel) or wrap them in a counted nested quiet
+   * disclosure (`<wa-details class="collapsible-quiet">`) with the section
+   * label in the summary slot.
    */
   private renderSectionRows<T>(
     items: readonly T[],
     key: (item: T) => unknown,
     renderItem: (item: T, index: number) => TemplateResult,
     withHeader: boolean,
-    section: Omit<Parameters<typeof renderSectionDetails>[0], 'content'>,
+    section: {
+      icon: TeXRAIconName;
+      label: string;
+      counts: readonly string[];
+      open: boolean;
+    },
   ): TemplateResult | typeof nothing {
     if (items.length === 0) return nothing;
 
@@ -411,7 +417,19 @@ export class BackgroundTasksPanel extends LitElement {
     `;
     if (!withHeader) return content;
 
-    return renderSectionDetails({ ...section, content });
+    return html`
+      <wa-details class="collapsible-quiet" ?open=${section.open}>
+        <div slot="summary" class="section-label">
+          ${waIcon(section.icon)}
+          <span
+            >${section.label}${section.counts.map(
+              (count) => html` &middot; ${count}`,
+            )}</span
+          >
+        </div>
+        ${content}
+      </wa-details>
+    `;
   }
 
   private renderTaskItem(
@@ -498,29 +516,6 @@ export class BackgroundTasksPanel extends LitElement {
   private navigateToStream(streamId: string): void {
     this.dispatchEvent(ProgressEvents.streamSwitch({ streamId }));
   }
-}
-
-/** Nested quiet disclosure wrapping one section's rows, with a counted label. */
-function renderSectionDetails(options: {
-  icon: TeXRAIconName;
-  label: string;
-  counts: readonly string[];
-  open: boolean;
-  content: TemplateResult;
-}): TemplateResult {
-  return html`
-    <wa-details class="collapsible-quiet" ?open=${options.open}>
-      <div slot="summary" class="section-label">
-        ${waIcon(options.icon)}
-        <span
-          >${options.label}${options.counts.map(
-            (count) => html` &middot; ${count}`,
-          )}</span
-        >
-      </div>
-      ${options.content}
-    </wa-details>
-  `;
 }
 
 /**

--- a/packages/extension/src/progressView/frontend/components/RequestPanels.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanels.ts
@@ -142,23 +142,6 @@ const SECTIONS: readonly SectionConfig[] = [
  */
 const PANEL_MARKER_SELECTOR = '[data-request-panel]';
 
-function renderPanel(
-  section: SectionConfig,
-  permission: PermissionPayload,
-  armed: boolean,
-): TemplateResult {
-  // `armed` marks the panel the y/n accelerators will act on. Sections render
-  // in a fixed kind order while the accelerators target the newest request,
-  // so with mixed kinds pending the top panel on screen is not the one a
-  // keypress hits. Without a visible mark that divergence is invisible, and
-  // the action it triggers can be executing a shell command.
-  return staticHtml`<${section.tag}
-    data-request-panel
-    ?data-armed=${armed}
-    .permission=${permission}
-  ></${section.tag}>`;
-}
-
 function externalInquiryKeys(
   permissions: readonly PermissionPayload[],
 ): string[] {
@@ -351,7 +334,16 @@ export class RequestPanels extends LitElement {
     permission: PermissionPayload,
     armed: boolean,
   ): TemplateResult {
-    const panel = renderPanel(config, permission, armed);
+    // `armed` marks the panel the y/n accelerators will act on. Sections render
+    // in a fixed kind order while the accelerators target the newest request,
+    // so with mixed kinds pending the top panel on screen is not the one a
+    // keypress hits. Without a visible mark that divergence is invisible, and
+    // the action it triggers can be executing a shell command.
+    const panel = staticHtml`<${config.tag}
+      data-request-panel
+      ?data-armed=${armed}
+      .permission=${permission}
+    ></${config.tag}>`;
     if (!this.multiRunPending) return panel;
     const streamId = permission.data.streamId;
     if (!streamId) return panel;

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -43,7 +43,6 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
 
   override handleKeyboardShortcut(key: string): boolean {
     if (this.archived) return false;
-    const data = this.permission.data;
     switch (key) {
       case 'r':
         this.emitAction({ action: 'retry' });

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -39,7 +39,6 @@ import { VscodePromptHost } from '@frontend/hosts/VscodePromptHost';
 import { VscodeExternalOpener } from '@frontend/hosts/VscodeExternalOpener';
 import { applyGitAuthorConfig } from '@frontend/git/gitAuthorSetup';
 import {
-  logErrorMessage,
   showLoggedErrorMessage,
   showLoggedInfoMessage,
 } from '@frontend/ui/errorHandlingUtils';

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -21,7 +21,6 @@ import {
   dispatchSettingsViewOutbound,
   SETTINGS_TAB_PANEL_BY_NAME,
   type SettingsTabPanelName,
-  type SettingsViewOutboundHandlerRegistry,
 } from '@shared/schemas';
 import { isKnownUnsupported } from '@shared/utils/dispatcher';
 import {
@@ -177,12 +176,8 @@ export class SettingsApp extends SettingsAppBase {
     }, delay);
   }
 
-  /** Outbound message handlers composed from the settings state slices. */
-  private readonly messageHandlers: SettingsViewOutboundHandlerRegistry =
-    settingsViewHandlers;
-
   protected override handleMessage(raw: unknown): void {
-    dispatchSettingsViewOutbound(raw, this.messageHandlers, (error) => {
+    dispatchSettingsViewOutbound(raw, settingsViewHandlers, (error) => {
       this.logMessageSchemaError('[SettingsApp]', raw, error);
     });
   }

--- a/packages/extension/src/settingsView/frontend/settingsState.ts
+++ b/packages/extension/src/settingsView/frontend/settingsState.ts
@@ -71,16 +71,6 @@ interface ProviderKeyModalTarget {
   displayName: string;
 }
 
-const DEFAULT_CHATGPT_AUTH: ChatGptAuthStatus = {
-  signedIn: false,
-  preferSubscription: false,
-};
-
-const DEFAULT_GROK_AUTH: GrokAuthStatus = {
-  signedIn: false,
-  preferSubscription: false,
-};
-
 // ---------------------------------------------------------------------------
 // Reset registry — populated by `trackedSignal` as each signal below is
 // declared.
@@ -299,10 +289,12 @@ export const githubTokenStatus = trackedSignal<'secret' | 'env' | 'none'>(
   () => 'none',
 );
 export const chatgptAuth = trackedSignal<ChatGptAuthStatus>(() => ({
-  ...DEFAULT_CHATGPT_AUTH,
+  signedIn: false,
+  preferSubscription: false,
 }));
 export const grokAuth = trackedSignal<GrokAuthStatus>(() => ({
-  ...DEFAULT_GROK_AUTH,
+  signedIn: false,
+  preferSubscription: false,
 }));
 export const subscriptionUsage =
   trackedSignal<SubscriptionUsageSnapshots | null>(() => null);

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -122,7 +122,6 @@ const CATEGORY_ORDER: ToolCategory[] = [
   'workflow',
   'system',
 ];
-const TOOLS_TAB_CATEGORIES = new Set<ToolCategory>(CATEGORY_ORDER);
 
 @customElement('tools-tab')
 export class ToolsTab extends LitElement {
@@ -249,7 +248,7 @@ export class ToolsTab extends LitElement {
   }
 
   private visibleItems(): ToolDashboardItem[] {
-    return this.items.filter((item) => TOOLS_TAB_CATEGORIES.has(item.category));
+    return this.items.filter((item) => CATEGORY_ORDER.includes(item.category));
   }
 
   private renderSummary(


### PR DESCRIPTION
Companion to #11189 (which covers host-agnostic `src/`). Disjoint file sets — the two can merge in either order.

## What

Fifty `our-code-simplifier` agents (Sonnet 5, high effort) swept the **391 host-package
files that changed since release `v0.40.2`** (2026-08-12) — ~99k LOC across
`packages/extension`, `packages/cli`, `packages/desktop`, `packages/trace-viewer` —
one disjoint, directory-local slice each. Every edit is behavior-preserving.

**58 production files, +342 / −663.**

The prompt was stiffened relative to #11189 after that batch came back mostly
`export`-keyword removals: whole-module deletion put in scope, wrapper *chains*
targeted rather than single wrappers, "already coherent" rejected as an answer unless
it names the candidates examined, and cross-bin candidates reported explicitly. The
yield roughly tripled (−574 vs −92 net).

## What it found

| Category | Count | Notes |
| --- | --- | --- |
| Pass-through / wrapper inline | 26 | single-caller private helpers folded into their sole call site; argument-shuffling wrappers deleted; one JSX component that only re-rendered a single child collapsed |
| Dead exports / dead types | 19 | no consumer outside the declaring file |
| Dead code | 8 | including a function a maintainer proposal already named as dead |
| Duplication | 7 | repeated patch+push blocks routed through the helper already present in the same file; identical derivations given one owner |
| Type tightening | 4 | e.g. `Awaited<ReturnType<typeof …>>` chains replaced by the real type |
| Speculative generality | 2 | |

Two changes worth a reviewer's eye:

- **`StaticConversationTranscript`** (−58) — header insertion re-ran a full relayout
  `reduce` to learn how many rows it had added. It now derives the delta directly. The
  equivalence was hand-checked against the old reduce; the exported
  `buildStaticTranscriptItems` / `advanceStaticTranscriptState` signatures and return
  shapes are unchanged.
- **`TodosPlanPanel`** (−16) — the panel opened its own `useSignal` subscriptions to
  `activeStreamId` / `streams`, which its parent `ConversationRegion` already reads in
  the same render. It now takes them as props. Its parent already re-renders on
  `streamArtifactRevision`, so repaint timing is unchanged; the test file exercises the
  pure `compactTodosPlanRows` helper and never renders the component.

## Rejected during integration

Three agent proposals were reverted rather than shipped:

- A collapse of `messageDispatcher.dispatchMessage` into `ProgressApp`. It looked like a
  pass-through but is a partial application binding the handler registry, with **four**
  consumers (`ProgressApp`, trace-viewer's `replayTrace`, two kernel tests). Removing it
  would have forced all four to re-state the registry and added a new export to do it.
- A swap of a locally-derived type for `import type { AgentOptionsDataPayload } from
  '@agent/index/agentRegistry'` in `mainViewCommands.ts` — a **new** `@agent/*` deep
  import from the extension, which the `host-agent-import-baseline` ratchet rightly
  rejected. Never widen a baseline.
- Prettier drift in two CLI files (fixed rather than shipped).

One accepted trade to note: `tui-harness.tsx` now routes three fixed-id transcript
entries (`harness-interrupted`, …) through the existing `appendHarnessTranscript`, which
generates ids from `Date.now()`. Those ids are opaque React keys, never rendered and
never asserted on, and this is a dev harness rather than production UI — but it is a
determinism reduction in the harness, so it is called out rather than buried.

## Verified

Run locally on a clean `origin/main` worktree, all green:

- `typecheck` — all six projects (workspace, test-kernel, agent, cli, trace-viewer, desktop)
- repo-wide `npm run lint`, `prettier --check` on every changed file
- `check:dead-code-ratchet` (8 findings, matches baseline — no widening)
- `src/test-kernel/architecture` — 104 tests, including the host `@agent/*` deep-import ratchet
- `check:browser-safe-utils`, `check:guidance-refs`, `check:tsconfig-paths`, `check:package-contributes`
- full `vitest run` — **842 files, 10,316 tests passed**, 0 failures

The agents also recorded **371 candidates they deliberately did not take**, 33 of them
explicitly flagged as needing a caller outside their own slice. Those are captured for a
follow-up wave rather than forced in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UQRwTBAasoZuFhCm42mrZ


## Net elements (R6)

- 58 production files changed, with 342 additions and 663 deletions, for a net reduction of 321 lines.
- 41 exported declarations were removed or made file-private. Three exported declarations were added while consolidating shared ownership, for a net reduction of 38 exported declarations.
- The sole test-file diff from the original sweep was reverted in `ddb697f97b`; this PR now changes no tests.

## Consumer counts (R8)

- Every removed export and private helper was searched repo-wide before removal. Each removed export had zero consumers outside its declaring file; each inlined private helper had one caller unless the PR routes repeated logic through an existing multi-caller helper.
- The surviving extracted helpers have multiple consumers: `carriedPromotionFrontier` has two call sites, `deferOrHandleBareEscape` has two, and `showMessageBoxOfType` has three.
- The attempted `messageDispatcher.dispatchMessage` removal was rejected because it has four consumers. The attempted new `@agent/index/agentRegistry` import was also rejected because it would widen the host-agent deep-import baseline.
