### PR TITLE
refactor(cli): delete relay-era model-access and auth-profile residue

### DIFF
--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -285,10 +285,7 @@ const authStatusCommand = defineCliCommand({
     emitCliResult(context, {
       json: profile,
       ndjson: { kind: 'auth-status', ...profile },
-      text: [
-        formatAuthStatusLine(profile),
-        ...(profile.note ? [profile.note] : []),
-      ].join('\n'),
+      text: [formatAuthStatusLine(profile)].join('\n'),
     });
     return CliExitCode.Success;
   },

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -183,16 +183,12 @@ async function runOrchestration(context: CliContext): Promise<number> {
       grokSignedIn: modelAccess.grokSignedIn,
       grokAccountLabel: modelAccess.grokAccountLabel,
     };
-    const launcherModelAccess = {
-      ...modelAccess,
-      texraSignedIn: authProfile.authenticated,
-    };
     const items = buildCliOrchestrationItems({
       presetPlans: presetPlanSet.plans,
       history,
       toolUseAgents,
       includeMultiAgentLoginHint: !presetPlanSet.remoteCatalogRefreshAttempted,
-      modelAccess: launcherModelAccess,
+      modelAccess,
       account: accountStatus,
       presetLaunchBlockReason,
     });
@@ -219,7 +215,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
         launchBlockReason: presetLaunchBlockReason,
       }),
       accountItems: buildCliAccountItems(accountStatus),
-      modelAccess: launcherModelAccess,
+      modelAccess: modelAccess,
       version: context.version,
       statusLines,
       allowDefaultModelLaunch,

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -89,9 +89,8 @@ export async function loadCliModelAccessOverview(): Promise<CliModelAccessOvervi
       profile.accountLabel,
     ),
   ];
-  if (profile.note) lines.push(profile.note);
   return {
-    access: { ...access, texraSignedIn: profile.authenticated },
+    access,
     lines,
   };
 }
@@ -158,7 +157,6 @@ export async function loadCliApiStatus(
     `api: ${formatCliModelAccessRouteInline('personal')}`,
     ...(personalKeysLine ? [personalKeysLine] : []),
     authLine,
-    ...(profile.note ? [profile.note] : []),
     ...(actionHint ? [actionHint] : []),
   ];
 }
@@ -281,6 +279,5 @@ export async function loadCliDetailedAccountStatusLines(
     'Other API keys',
   );
   if (otherPersonalKeys) lines.push(otherPersonalKeys);
-  if (profile.note) lines.push(profile.note);
   return lines;
 }

--- a/packages/cli/src/runtime/modelAccessRoute.ts
+++ b/packages/cli/src/runtime/modelAccessRoute.ts
@@ -51,9 +51,6 @@ export interface CliModelAccessStatus {
   readonly codingPlans: Readonly<
     Record<CodingPlanSubscriptionId, CliCodingPlanStatus>
   >;
-  readonly texraSignedIn?: boolean;
-  /** Display names of providers with configured API keys (e.g. `['DeepSeek']`). */
-  readonly personalKeyProviders?: readonly string[];
 }
 
 interface CliModelAccessItem {

--- a/packages/cli/src/runtime/modelAccessSelection.ts
+++ b/packages/cli/src/runtime/modelAccessSelection.ts
@@ -2,17 +2,13 @@ import {
   subscriptionProvider,
   type SubscriptionProviderId,
 } from '@controllers/modelAccess/subscriptionProviders';
-import {
-  configuredApiKeyProviders,
-  hasUsableApiKey,
-} from '@model/apiProviders';
+import { hasUsableApiKey } from '@model/apiProviders';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import {
   codingPlanSubscriptionRuntimes,
   type CodingPlanSubscriptionRuntime,
 } from '@model/codingPlanSubscriptions';
 import { platform } from '@platform/platform';
-import { providerDisplayName } from '@shared/constants/providers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
 import {
@@ -33,27 +29,25 @@ export interface CliModelAccessSelectionResult {
 
 export async function readCliModelAccessStatus(): Promise<CliModelAccessStatus> {
   const secrets = platform().secrets;
-  const [chatGpt, grok, configuredProviders, codingPlanEntries] =
-    await Promise.all([
-      subscriptionProvider('chatgpt').getStatus(),
-      subscriptionProvider('grok').getStatus(),
-      configuredApiKeyProviders(secrets),
-      Promise.all(
-        codingPlanSubscriptionRuntimes.map(
-          async (runtime) =>
-            [
-              runtime.descriptor.id,
-              {
-                preferred: runtime.getEnabled(),
-                keySet: await hasUsableApiKey(
-                  secrets,
-                  runtime.descriptor.apiProvider,
-                ),
-              },
-            ] as const,
-        ),
+  const [chatGpt, grok, codingPlanEntries] = await Promise.all([
+    subscriptionProvider('chatgpt').getStatus(),
+    subscriptionProvider('grok').getStatus(),
+    Promise.all(
+      codingPlanSubscriptionRuntimes.map(
+        async (runtime) =>
+          [
+            runtime.descriptor.id,
+            {
+              preferred: runtime.getEnabled(),
+              keySet: await hasUsableApiKey(
+                secrets,
+                runtime.descriptor.apiProvider,
+              ),
+            },
+          ] as const,
       ),
-    ]);
+    ),
+  ]);
   const codingPlans = Object.fromEntries(
     codingPlanEntries,
   ) as CliModelAccessStatus['codingPlans'];
@@ -63,9 +57,6 @@ export async function readCliModelAccessStatus(): Promise<CliModelAccessStatus> 
       : 'off',
     grok: subscriptionProvider('grok').isPreferSubscription() ? 'on' : 'off',
   } as const;
-  const personalKeyProviders = configuredProviders.map((provider) =>
-    providerDisplayName(provider),
-  );
   return {
     preferences,
     chatGptSignedIn: chatGpt.signedIn,
@@ -73,7 +64,6 @@ export async function readCliModelAccessStatus(): Promise<CliModelAccessStatus> 
     grokSignedIn: grok.signedIn,
     grokAccountLabel: grok.email,
     codingPlans,
-    personalKeyProviders,
   };
 }
 

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -50,8 +50,6 @@ export interface CliAuthProfile {
   sessionState?: StoredSessionState;
   accountLabel?: string;
   expiresAt?: string;
-  /** Extra status context. */
-  note?: string;
 }
 
 export interface CliLoginOptions {
@@ -200,11 +198,6 @@ export async function signOutCliSupabase(): Promise<void> {
     invalidateRemoteAgentsAfterSignOut,
     (message) => activeAuthLog?.warn('cli-auth', message),
   );
-}
-
-/** Fresh access token for the stored CLI session. */
-export async function getCliSessionAccessToken(): Promise<string | null> {
-  return initializeCliSupabaseAuth().ensureFreshToken();
 }
 
 export async function getCliAuthProfile(): Promise<CliAuthProfile> {

--- a/src/test-kernel/cli/ApiStatusLoad.vitest.ts
+++ b/src/test-kernel/cli/ApiStatusLoad.vitest.ts
@@ -131,25 +131,14 @@ describe('loadCliApiStatus', () => {
       }));
   });
 
-  it.each([
-    {
-      name: 'without a profile note',
-      profile: { authenticated: false },
-      lines: ['api: your own API keys', 'auth: signed out'],
-    },
-    {
-      name: 'with no profile note',
-      profile: { authenticated: false },
-      lines: ['api: your own API keys', 'auth: signed out'],
-    },
-  ])(
-    'preserves signed-out launcher details $name',
-    async ({ profile, lines }) => {
-      mocks.getCliAuthProfile.mockResolvedValue(profile);
+  it('preserves signed-out launcher details', async () => {
+    mocks.getCliAuthProfile.mockResolvedValue({ authenticated: false });
 
-      await expect(loadCliApiStatus()).resolves.toEqual(lines);
-    },
-  );
+    await expect(loadCliApiStatus()).resolves.toEqual([
+      'api: your own API keys',
+      'auth: signed out',
+    ]);
+  });
 
   it('groups personal keys with their route', async () => {
     mocks.getCliAuthProfile.mockResolvedValue({

--- a/src/test-kernel/cli/ApiStatusLoad.vitest.ts
+++ b/src/test-kernel/cli/ApiStatusLoad.vitest.ts
@@ -138,16 +138,9 @@ describe('loadCliApiStatus', () => {
       lines: ['api: your own API keys', 'auth: signed out'],
     },
     {
-      name: 'with a profile note',
-      profile: {
-        authenticated: false,
-        note: 'Account metadata may be stale.',
-      },
-      lines: [
-        'api: your own API keys',
-        'auth: signed out',
-        'Account metadata may be stale.',
-      ],
+      name: 'with no profile note',
+      profile: { authenticated: false },
+      lines: ['api: your own API keys', 'auth: signed out'],
     },
   ])(
     'preserves signed-out launcher details $name',
@@ -162,7 +155,6 @@ describe('loadCliApiStatus', () => {
     mocks.getCliAuthProfile.mockResolvedValue({
       authenticated: true,
       accountLabel: 'researcher@example.com',
-      note: 'Account metadata may be stale.',
     });
     setPersonalKeys('deepseek');
 
@@ -170,7 +162,6 @@ describe('loadCliApiStatus', () => {
       'api: your own API keys',
       'your own API keys: DeepSeek',
       'auth: signed in as researcher@example.com',
-      'Account metadata may be stale.',
     ]);
   });
 
@@ -450,18 +441,6 @@ describe('loadCliApiStatus', () => {
     expect(lines).toEqual(['Otherwise: Your own API keys']);
   });
 
-  it('preserves a profile note exactly once', async () => {
-    const profileNote = 'Account metadata may be stale.';
-    mocks.getCliAuthProfile.mockResolvedValue({
-      authenticated: false,
-      note: profileNote,
-    });
-
-    const lines = await accountStatusLines();
-
-    expect(lines.filter((line) => line === profileNote)).toHaveLength(1);
-  });
-
   it('reports the legacy model-access overview without reading key storage', async () => {
     mocks.readCliModelAccessStatus.mockResolvedValue({
       preferences: {
@@ -489,7 +468,6 @@ describe('loadCliApiStatus', () => {
         chatGptSignedIn: true,
         grokSignedIn: false,
         chatGptAccountLabel: 'chatgpt@example.com',
-        texraSignedIn: true,
       },
       lines: [
         'ChatGPT preference: On · chatgpt@example.com',

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.ts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.ts
@@ -143,7 +143,6 @@ function expectedAccessStatus(
     chatGptAccountLabel: undefined,
     grokSignedIn: false,
     grokAccountLabel: undefined,
-    personalKeyProviders: [],
     ...overrides,
     codingPlans: {
       glmCodingPlan: {
@@ -315,19 +314,6 @@ describe('CLI model access routes', () => {
     mocks.hasUsableApiKey.mockResolvedValue(false);
     await expect(readCliModelAccessStatus()).resolves.toMatchObject({
       codingPlans: { kimiCode: { preferred: true, keySet: false } },
-    });
-  });
-
-  it('reports configured provider keys as display names', async () => {
-    mocks.lookupApiKeyOrigin.mockImplementation(async (_secrets, provider) => {
-      if (provider === 'deepseek') return 'secret';
-      if (provider === 'moonshot') return 'env';
-      if (provider === 'kimiCode') return 'secret';
-      return 'none';
-    });
-
-    await expect(readCliModelAccessStatus()).resolves.toMatchObject({
-      personalKeyProviders: ['DeepSeek', 'Moonshot', 'Kimi Code'],
     });
   });
 


### PR DESCRIPTION
## What

Four leftovers of `368ee4f601` (relay client plane removal), which deleted the readers these fields fed but left the fields standing. **−66 net LoC.**

## 1. `CliModelAccessStatus.texraSignedIn` and `.personalKeyProviders`

Both write-only. Their readers were the "Included access" and "own API keys" rows in `buildCliModelAccessItems`, deleted by `368ee4f601`.

**Care needed here, and it is the reason this is worth stating:** `CliAccountStatus.texraSignedIn` (`orchestration.ts:101`) is a *different interface with the same field name*, and it **is** live — read at `:216` and `:284`. A field-name grep alone would have condemned both. Only the model-access copy goes; I confirmed the two reads take `CliAccountStatus` by their parameter types.

Dropping `personalKeyProviders` also removes a `configuredApiKeyProviders(secrets)` call — a secret-store scan on every status read.

## 2. `CliAuthProfile.note`

No writer. `getCliAuthProfile` never sets it; the three sites that did (relay-token warnings at `supabaseAuth.ts:300,316,341`) went with the same commit. Four `if (profile.note)` branches were unreachable.

Not an output contract: `cliOutput.ts:47` is `z.looseObject`, and `docs/guide/texra-cli.md:152-158` documents no `note`.

## 3. `getCliSessionAccessToken`

**One occurrence repo-wide — its own declaration.** Zero consumers in production, tests, scripts, or docs. Its caller `loadIncludedUsageLine` went with the relay plane.

This is the specimen for the `packages/cli` knip blind spot recorded in #11165: a provably dead export that the dead-code ratchet does not report.

## 4. `launcherModelAccess`

A local that existed only to graft `texraSignedIn` onto `modelAccess`. With the field gone the call site passes `modelAccess` directly.

## Tests

Deleted with the behavior they pinned, per AGENTS.md "Testing discipline": the two profile-note rows, `preserves a profile note exactly once`, and `reports configured provider keys as display names`. Three fixtures re-pinned.

## Net elements (R6)

- Files: 8 changed (6 production, 2 test)
- `^[+-]export` symbols: **−1** (`getCliSessionAccessToken`)
- Interface fields: **−3** · locals: **−1** · now-unused imports: **−2**
- Net LoC: **−66** (`26 insertions(+), 92 deletions(-)` vs `origin/main`)

## Consumer counts (R8)

Grepped with `--no-ignore-vcs` (a global gitignore hides tracked files from plain `rg` here — #11165):

- `CliModelAccessStatus.texraSignedIn` — 0 readers (the 2 `status.texraSignedIn` reads are `CliAccountStatus`)
- `CliModelAccessStatus.personalKeyProviders` — 0 readers
- `CliAuthProfile.note` — 0 writers, 4 dead reader branches
- `getCliSessionAccessToken` — 1 occurrence repo-wide, its declaration
- `CliAccountStatus.texraSignedIn` — 2 readers, **retained**

## Checks

`typecheck` ✅ (exit 0) · `lint` ✅ (exit 0) · `format` ✅

`vitest run src/test-kernel/cli` ✅ — **144 files, 2537 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJmSeJm4wocNwc7AFMrJBU