### PR TITLE
test: clear residue the campaign's deletions left in fixtures and assertions

### DIFF
--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -77,8 +77,8 @@ async function withOpenRouterFlagOn<T>(fn: () => Promise<T>): Promise<T> {
  * Pre-flight uses the shared host-neutral predicate (adapter-level checks, so
  * blank env keys do not count as credentials and then fail later as "No model
  * is available") so this host can't drift from desktop's credential gate. The
- * CLI has its own apiMode-aware policy and doesn't call this predicate — see
- * the note on `hasUsableSetupCredential`.
+ * CLI has its own policy and doesn't call this predicate — see the note on
+ * `hasUsableSetupCredential`.
  */
 export async function hasAnyUsableSetupCredential(): Promise<boolean> {
   return hasUsableSetupCredential(platform().secrets);

--- a/src/test-kernel/agent/AgentWorkspaceWorkPlanState.vitest.ts
+++ b/src/test-kernel/agent/AgentWorkspaceWorkPlanState.vitest.ts
@@ -10,7 +10,6 @@ import {
 describe('agent workspace work-plan state', () => {
   it.each([
     ['a snapshot without workPlan', {}],
-    ['a retired todo/plan snapshot', { todos: [], plan: null }],
     ['a null workPlan', { workPlan: null }],
     [
       'invalid current workPlan entries',

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -99,7 +99,6 @@ const SESSION_META = {
   model: 'deepseekT',
   modelSource: 'builtin-default',
   cwd: '/tmp/project',
-  apiMode: 'personal',
   approvalPolicy: 'ask',
   canDelegate: false,
   transcriptMode: 'persistent',

--- a/src/test-kernel/cli/Doctor.vitest.ts
+++ b/src/test-kernel/cli/Doctor.vitest.ts
@@ -224,7 +224,6 @@ describe('CLI doctor', () => {
         '     Run `texra models list --all` to inspect access, sign in with `texra login`, or add a provider API key with `texra setup`.',
       ].join('\n'),
     );
-    expect(text).not.toContain('/api personal');
     expect(text).toContain('SKIP Config: No workspace CLI config file found.');
   });
 

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
@@ -64,7 +64,6 @@ const SESSION_META = {
   model: 'deepseekT',
   modelSource: 'builtin-default',
   cwd: '/tmp/project',
-  apiMode: 'personal',
   approvalPolicy: 'yolo',
   canDelegate: true,
   transcriptMode: 'persistent',

--- a/src/test-kernel/common/SdkErrorUtils.vitest.ts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.ts
@@ -872,7 +872,6 @@ describe('provider error schemas', () => {
     const errorLog = ErrorLogDataSchema.parse({
       message: 'old persisted error',
       retryable: false,
-      isRelayError: false,
     });
     const retryInfo = RetryErrorInfoSchema.parse({
       message: 'old retry state',

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.ts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.ts
@@ -242,7 +242,6 @@ return { papers, question: args.question };`;
     // A shell call is described by its command (the shared row model's
     // header rule), so streamed stdout can reach neither the title nor it.
     expect(title?.textContent).toBe('bash — lake build');
-    expect(title?.textContent).not.toContain('Built Mathlib');
     expect(body?.textContent).toContain('Built Mathlib.Example.Module19');
 
     // Element-name pin (#8156): tool-use banners render through <wa-details>,

--- a/src/test-kernel/settings/AgentHandlersDelete.vitest.ts
+++ b/src/test-kernel/settings/AgentHandlersDelete.vitest.ts
@@ -35,7 +35,7 @@ vi.mock('@agent/remote/remoteAgentConfigClient', () => ({
   fetchRemoteAgentConfigYaml: vi.fn(),
 }));
 vi.mock('@auth/SupabaseClient', () => ({
-  SupabaseClient: { getAccessToken: vi.fn(), getUserTier: vi.fn() },
+  SupabaseClient: { getAccessToken: vi.fn() },
 }));
 vi.mock('@common/teams/TeamRosterApplication', () => ({
   applyTeamRosterWithPreflight: vi.fn(),

--- a/src/test-kernel/settings/ExtensionAgentHandlers.vitest.ts
+++ b/src/test-kernel/settings/ExtensionAgentHandlers.vitest.ts
@@ -48,7 +48,6 @@ vi.mock('@auth/SupabaseClient', async () => ({
   )),
   SupabaseClient: {
     isAuthenticated,
-    getUserTier: () => undefined,
     getAccessToken: async () => undefined,
   },
 }));


### PR DESCRIPTION
## What

Seven single-line survivors of the 2026-08-17→19 campaign, each verified inert at HEAD. Small, but each one currently misleads a reader into thinking a deleted thing still matters.

| Where | What | Why inert |
|---|---|---|
| `SdkErrorUtils.vitest.ts:875` | `isRelayError: false` | not a field on any schema in `shared/schemas/errors.ts`; the window scrubbed this identifier from **four other sites in the same file** and missed this one. The only relay residue left in the suite. |
| `WorkflowScriptStreamTranscript.vitest.ts:67`, `ConversationTranscript.vitest.ts:102` | `apiMode: 'personal'` | `SessionMeta` no longer has the field. `368ee4f601` removed the identical line from `ConfigForm.vitest.ts` and missed these two. |
| `setupAssistantCommand.ts:80` | doc comment | credits the CLI with an "apiMode-aware policy" for a mode with **zero** production hits |
| `AgentHandlersDelete.vitest.ts:38`, `ExtensionAgentHandlers.vitest.ts:51` | `getUserTier` | the static went with `368ee4f601` |
| `ToolUseFormatter.vitest.ts:245` | `not.toContain('Built Mathlib')` | sits directly under an exact `toBe` on the same value |
| `Doctor.vitest.ts:227` | `not.toContain('/api personal')` | pins a subcommand the grammar dropped |
| `AgentWorkspaceWorkPlanState.vitest.ts:13` | `a retired todo/plan snapshot` row | schema became `z.looseObject`, so it now fails for the same reason as the row above it |

## Why typecheck did not catch these

Two distinct reasons, both worth knowing for the next sweep:

- **The `apiMode` fixtures** are unannotated object literals passed by variable reference. TypeScript's excess-property check applies to literals assigned directly to a typed target, not to a variable that is later passed — so a stale key survives indefinitely.
- **The `getUserTier` mocks** sit in `vi.mock` factory returns, which are not excess-property-checked at all.

The one *production* line here (`setupAssistantCommand.ts:80`) is a comment, so nothing could have caught it.

## Scope note

This is the narrow, high-confidence slice of a larger test-kernel survey. The broader findings — tests that were *rewritten* to keep passing when the behavior they pinned was deleted — are deliberately **not** in this PR. They need per-case judgment about whether the surviving assertion still earns its place, which is a different review than "this line is inert".

## Net elements (R6)

- Files: 9 changed (1 production comment, 8 test)
- `^[+-]export` symbols: 0
- Net LoC: **−7** (`3 insertions(+), 10 deletions(-)` vs `origin/main`)

No new tests, per AGENTS.md's zero-new-tests default.

## Consumer counts (R8)

Grepped with `--no-ignore-vcs` (a global gitignore hides tracked files from plain `rg` here — #11165):

- `isRelayError` — 1 occurrence repo-wide, the line removed here
- `apiMode` — 3 occurrences, all removed here; 0 production readers
- `getUserTier` — 2 occurrences, both mocks
- `OUTPUT_PREVIEW_MAX`, `truncateHeaderSummary` — 0 occurrences (already gone; their assertions are what remained)

## Checks

`typecheck` ✅ (exit 0) · `lint` ✅ (exit 0) · `format` ✅

Targeted suites ✅ — all 9 touched files plus `test-kernel/settings`: **38 files, 308 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJmSeJm4wocNwc7AFMrJBU