### PR TITLE
fix(rendering): report syntax highlight failures

### DIFF
--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -17,6 +17,7 @@ import pico from 'picocolors';
 
 import { textDisplayWidth } from '@cli/runtime/terminalText';
 import { wrapAnsiToWidth } from '@cli/tui/ansiWrap';
+import { createLog } from '@logger/logUtils';
 import {
   createMarkdownProcessor,
   type MarkdownProcessorRenderEnv,
@@ -26,6 +27,7 @@ import {
   createMarkdownRenderer,
   type MarkdownItInstance,
 } from '@shared/markdown/createMarkdownRenderer';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import { normalizeKnownHtmlForCliMarkdown } from './htmlMarkdownNormalize';
 
 /** SGR open/close codes wrapped through String.fromCharCode so the ESC byte
@@ -33,6 +35,7 @@ import { normalizeKnownHtmlForCliMarkdown } from './htmlMarkdownNormalize';
  *  raw control chars). */
 const ESC = String.fromCharCode(27);
 const sgr = (code: number): string => `${ESC}[${code}m`;
+const log = createLog('cli.ansiMarkdown');
 
 interface AnsiMarkdownStyle {
   readonly enabled: boolean;
@@ -72,8 +75,10 @@ function highlightForTui(
   if (lang && supportsLanguage(lang)) {
     try {
       return highlight(trimmed, { language: lang, ignoreIllegals: true });
-    } catch {
-      // fall through to plain rendering
+    } catch (error) {
+      log.warn(
+        `Syntax highlighting failed for ${lang} (${trimmed.length} chars); rendering plain text: ${toErrorMessage(error)}`,
+      );
     }
   }
   return style.gray(trimmed);

--- a/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -27,6 +27,7 @@ import { stopSpinnerMotion } from '@shared/wa/spinner';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { copyWithFeedback } from '@shared/utils/clipboard';
 import { getBasename } from '@utils/core';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import { formatBytes } from '@utils/text/stringUtils';
 
 // Local imports - formatter helpers
@@ -320,7 +321,10 @@ function highlightCode(text: string, language: string): string {
   try {
     // Returns HTML with syntax highlighting spans
     return hljs.highlight(text, { language, ignoreIllegals: true }).value;
-  } catch {
+  } catch (error) {
+    console.warn(
+      `[progressView] Syntax highlighting failed for ${language} (${text.length} chars); rendering plain text: ${toErrorMessage(error)}`,
+    );
     return text;
   }
 }


### PR DESCRIPTION
## Summary

- warn when CLI syntax highlighting throws, including language, source length, and the formatted error
- warn with the same context in the progress webview before preserving its plain-text fallback
- keep source text out of logs and leave successful and fallback rendering unchanged

Closes #11096.

## Validation

- `npx prettier --check packages/cli/src/chat/tui/render/ansiMarkdown.ts packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts`
- `npx eslint packages/cli/src/chat/tui/render/ansiMarkdown.ts packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts`
- `npx tsc --noEmit --checkers 8`
- independent review confirmed browser-safe imports and unchanged fallback behavior
- no test files changed
