### PR TITLE
refactor(settings): collapse the duplicated template-agent flow and account-outcome copy

### DIFF
--- a/config/ratchets/host-agent-import-baseline.json
+++ b/config/ratchets/host-agent-import-baseline.json
@@ -23,7 +23,6 @@
       "@agent/index/platformAgentDirectories",
       "@agent/runtime",
       "@agent/storage",
-      "@agent/templates/agentTemplateRenderer",
       "@agent/trace"
     ],
     "extension": [

--- a/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
@@ -29,6 +29,7 @@ import {
 import { formatCliDeviceAuthMessage } from '@cli/runtime/supabaseAuthDeviceCode';
 import type { SubscriptionProviderId } from '@controllers/modelAccess/subscriptionProviders';
 import {
+  ACCOUNT_OUTCOME,
   CHATGPT_AUTH,
   GROK_AUTH,
   RESEARCHER_ACCESS_AUTH,
@@ -192,10 +193,13 @@ export async function logoutFromChat(
   if (target === 'texra' || target === 'all') {
     try {
       await signOutCliSupabase();
-      lines.push(`Signed out of ${RESEARCHER_ACCESS.label}.`);
+      lines.push(ACCOUNT_OUTCOME.signedOut(RESEARCHER_ACCESS.label));
     } catch (error: unknown) {
       lines.push(
-        `${RESEARCHER_ACCESS.label} sign-out failed: ${toErrorMessage(error)}`,
+        ACCOUNT_OUTCOME.signOutFailedWithReason(
+          RESEARCHER_ACCESS.label,
+          toErrorMessage(error),
+        ),
       );
     }
   }
@@ -207,10 +211,12 @@ export async function logoutFromChat(
     try {
       const update = await signOutCliSubscription(providerId);
       refreshSubscriptionPreferenceViews();
-      lines.push(`Signed out of ${label}.`);
+      lines.push(ACCOUNT_OUTCOME.signedOut(label));
       lines.push(subscriptionSignOutPreferenceMessage(providerId, update));
     } catch (error: unknown) {
-      lines.push(`${label} sign-out failed: ${toErrorMessage(error)}`);
+      lines.push(
+        ACCOUNT_OUTCOME.signOutFailedWithReason(label, toErrorMessage(error)),
+      );
     }
   }
 

--- a/packages/cli/src/commands/_helpers/subscriptionAuthCommand.ts
+++ b/packages/cli/src/commands/_helpers/subscriptionAuthCommand.ts
@@ -15,6 +15,7 @@ import {
   type SubscriptionProviderId,
 } from '@controllers/modelAccess/subscriptionProviders';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
+import { ACCOUNT_OUTCOME } from '@shared/copy/accountAuth';
 
 import { withCliAuthError } from './cliAuthError';
 import { defineCliCommand } from './defineCliCommand';
@@ -75,7 +76,10 @@ export function defineSubscriptionAuthCommand(
       ...options.loginPayloadExtras?.(account),
       preferSubscription: update.effective,
     };
-    const signedIn = `Signed in with ${provider.displayName} as ${account.label}.`;
+    const signedIn = ACCOUNT_OUTCOME.signedInAs(
+      provider.displayName,
+      account.label,
+    );
     emitCliResult(context, {
       json: payload,
       ndjson: { kind: options.ndjsonKind, ...payload },
@@ -157,7 +161,7 @@ export function defineSubscriptionAuthCommand(
         json: status,
         ndjson: { kind: `${options.ndjsonKind}-status`, ...status },
         text: status.signedIn
-          ? `Signed in with ${provider.displayName} as ${label}.`
+          ? ACCOUNT_OUTCOME.signedInAs(provider.displayName, label)
           : `Not signed in with ${provider.displayName}.`,
       });
       return CliExitCode.Success;

--- a/packages/cli/src/runtime/subscriptionLogin.ts
+++ b/packages/cli/src/runtime/subscriptionLogin.ts
@@ -11,6 +11,7 @@ import {
   type SubscriptionSignInPresenter,
 } from '@controllers/modelAccess/subscriptionProviders';
 import type { ConfigTarget } from '@platform/interfaces';
+import { ACCOUNT_OUTCOME } from '@shared/copy/accountAuth';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { tryOpenBrowser } from './browser';
@@ -165,5 +166,5 @@ export function subscriptionSignOutOutcomeMessage(
   result: CliSubscriptionSignOutResult,
 ): string {
   const { displayName } = subscriptionProvider(providerId);
-  return `Signed out of ${displayName}.\n${subscriptionSignOutPreferenceMessage(providerId, result)}`;
+  return `${ACCOUNT_OUTCOME.signedOut(displayName)}\n${subscriptionSignOutPreferenceMessage(providerId, result)}`;
 }

--- a/packages/desktop/src/main/desktopAgentSettingsController.ts
+++ b/packages/desktop/src/main/desktopAgentSettingsController.ts
@@ -11,16 +11,16 @@ import type {
   loadAgents,
   refresh,
 } from '@agent/index/agentRegistry';
-import {
-  AGENT_TEMPLATE_FILES,
-  DEFAULT_AGENT_TEMPLATE_TOOLS_YAML,
-  renderAgentTemplateString,
-} from '@agent/templates/agentTemplateRenderer';
 import type { TeamAvailabilityChoice } from '@common/teams/TeamAvailabilityPreflight';
 import { loadTeamOptions } from '@common/teams/TeamPlan';
 import { applyTeamRosterWithPreflight } from '@common/teams/TeamRosterApplication';
 import { createTeamCatalogPorts } from '@controllers/mainView/teamCatalogPorts';
 import { createSettingsAgentActions } from '@controllers/settingsView/backend/SettingsAgentActions';
+import {
+  templateAgentCategoryLabel,
+  templateAgentNamePrompt,
+  writeTemplateAgentFile,
+} from '@controllers/settingsView/backend/templateAgentCreation';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
 import { MAIN_VIEW_COMMANDS, SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
@@ -187,10 +187,6 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
         }),
       showInfoMessage: notifications.showInfoMessage,
       showErrorMessage: notifications.showErrorMessage,
-      formatOpenAgentYamlError: (reason, name) =>
-        reason === 'missingAgent'
-          ? `Agent not found: ${name}`
-          : `No configuration file found for agent: ${name}`,
       refreshAfterMutation: () => this.refreshAfterAgentMutation(),
       run: async (command, failureMessage, action) => {
         if (
@@ -373,10 +369,9 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
       return;
     }
 
-    const categoryLabel = data.category === 'toolUse' ? 'Tool Use' : 'Workflow';
     const name = await this.prompts.promptText({
-      title: `New ${categoryLabel} agent`,
-      prompt: `Enter a name for the new ${categoryLabel} agent (without .yaml extension)`,
+      title: `New ${templateAgentCategoryLabel(data.category)} agent`,
+      prompt: templateAgentNamePrompt(data.category),
     });
     if (!name) return;
 
@@ -396,28 +391,11 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
         customDir,
       });
 
-      if (await AbsoluteFS.exists(plan.filePath)) {
-        await this.notifications.showErrorMessage(
-          `A file named "${plan.fileName}" already exists in the custom agents folder.`,
-        );
+      const written = await writeTemplateAgentFile(plan, this.resourcesPath);
+      if (!written.ok) {
+        await this.notifications.showErrorMessage(written.message);
         return;
       }
-
-      const raw = await AbsoluteFS.read(
-        path.join(
-          this.resourcesPath,
-          'templates',
-          AGENT_TEMPLATE_FILES[plan.templateKind],
-        ),
-      );
-      await AbsoluteFS.write(
-        plan.filePath,
-        renderAgentTemplateString(raw, {
-          AGENT_NAME: plan.baseName,
-          DESCRIPTION: plan.description,
-          TOOLS_YAML: DEFAULT_AGENT_TEMPLATE_TOOLS_YAML,
-        }),
-      );
 
       await this.directory.openPath(plan.filePath);
       await this.notifications.showInfoMessage(

--- a/packages/desktop/src/main/desktopCredentialSettingsController.ts
+++ b/packages/desktop/src/main/desktopCredentialSettingsController.ts
@@ -34,6 +34,7 @@ import {
   type SettingsViewInboundHandlerRegistry,
   type SubscriptionUsageSnapshots,
 } from '@shared/schemas';
+import { ACCOUNT_OUTCOME } from '@shared/copy/accountAuth';
 import { buildAuthStatusMessage } from '@shared/settingsView/handlers/authStatusMessage';
 import type { SettingsStatePorts } from '@shared/settingsView/types';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -318,7 +319,7 @@ export class DefaultDesktopCredentialSettingsController implements DesktopCreden
       });
       await provider.setPreferSubscription(true);
       await this.options.notifications.showInfoMessage(
-        `Signed in with ${provider.displayName} as ${account.label}.`,
+        ACCOUNT_OUTCOME.signedInAs(provider.displayName, account.label),
       );
     } catch (error) {
       await this.options.notifications.showErrorMessage(
@@ -406,11 +407,14 @@ export class DefaultDesktopCredentialSettingsController implements DesktopCreden
     try {
       await provider.signOut();
       await this.options.notifications.showInfoMessage(
-        `Signed out of ${provider.displayName}.`,
+        ACCOUNT_OUTCOME.signedOut(provider.displayName),
       );
     } catch (error) {
       await this.options.notifications.showErrorMessage(
-        `${provider.displayName} sign-out failed: ${toErrorMessage(error)}`,
+        ACCOUNT_OUTCOME.signOutFailedWithReason(
+          provider.displayName,
+          toErrorMessage(error),
+        ),
       );
       this.options.onError(error);
     } finally {

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -3,6 +3,7 @@ import { formatError } from '@common/errors';
 import { SettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
 import {
   listGitHubSubscriptionEntries,
+  noActiveGitHubSubscriptionMessage,
   unsubscribeGitHubKey,
 } from '@controllers/settingsView/githubSubscriptions';
 import { appSignals } from '@eventBus/AppSignals';
@@ -35,6 +36,7 @@ import {
   GITHUB_TOKEN_REMOVED_MESSAGE,
   GITHUB_TOKEN_SAVED_MESSAGE,
   GITHUB_TOKEN_STORAGE_KEY,
+  gitHubTokenRejectedMessage,
   resolveGitHubTokenSource,
 } from '@tools/github/githubAuth';
 import { StorageFS } from '@utils/files/storageFS';
@@ -358,7 +360,7 @@ export function createDesktopSettingsIpc(
     // Marking a stored token as rejected would need a new status on the wire.
     appSignals.on('githubTokenInvalid', ({ message }) =>
       runAsync(
-        options.ui.showErrorMessage(`GitHub token rejected: ${message}`),
+        options.ui.showErrorMessage(gitHubTokenRejectedMessage(message)),
       ),
     ),
   );
@@ -381,7 +383,7 @@ export function createDesktopSettingsIpc(
     const removed = unsubscribeGitHubKey(data.key);
     if (removed === 0) {
       await options.ui.showInfoMessage(
-        `No active subscription for ${data.key}.`,
+        noActiveGitHubSubscriptionMessage(data.key),
       );
       return;
     }

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -97,6 +97,7 @@ import {
   refreshToolAvailability,
   seedDisabledToolDefaults,
 } from '@tools/toolAvailability';
+import { gitHubTokenRejectedMessage } from '@tools/github/githubAuth';
 import { killActiveRecording } from '@tools/media/audio';
 import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
 import { setInlineCommentProvider } from '@tools/comment/InlineCommentTool';
@@ -603,12 +604,10 @@ export async function activate(context: vscode.ExtensionContext) {
   const disposeGitHubAuthListener = appSignals.on(
     'githubTokenInvalid',
     ({ message }) => {
-      log.error(`GitHub token rejected: ${message}`);
+      const rejected = gitHubTokenRejectedMessage(message);
+      log.error(rejected);
       void vscode.window
-        .showErrorMessage(
-          `GitHub token rejected: ${message}`,
-          'Open Git settings',
-        )
+        .showErrorMessage(rejected, 'Open Git settings')
         .then((choice) => {
           if (choice === 'Open Git settings') {
             void vscode.commands.executeCommand('texra.showGitSettings');

--- a/packages/extension/src/frontend/auth/subscriptionSignIn.ts
+++ b/packages/extension/src/frontend/auth/subscriptionSignIn.ts
@@ -11,6 +11,7 @@ import {
 } from '@controllers/modelAccess/subscriptionProviders';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
+import { ACCOUNT_OUTCOME } from '@shared/copy/accountAuth';
 
 const OPEN_DEFAULT_BROWSER = 'Open in Default Browser';
 const COPY_SIGN_IN_LINK = 'Copy Sign-in Link';
@@ -121,7 +122,7 @@ export async function signInWithSubscription(
 
   if (update.effective) {
     void vscode.window.showInformationMessage(
-      `Signed in with ${displayName} as ${account.label}. ${displayName} subscription is enabled for ${modelFamily}.`,
+      `${ACCOUNT_OUTCOME.signedInAs(displayName, account.label)} ${displayName} subscription is enabled for ${modelFamily}.`,
     );
     return true;
   }

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -15,16 +15,15 @@ import {
   loadAgents,
   refresh as refreshAgents,
 } from '@agent/index';
-import {
-  AGENT_TEMPLATE_FILES,
-  DEFAULT_AGENT_TEMPLATE_TOOLS_YAML,
-  renderAgentTemplateString,
-} from '@agent/templates/agentTemplateRenderer';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { applyTeamRosterWithPreflight } from '@common/teams/TeamRosterApplication';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
 import { createSettingsAgentActions } from '@controllers/settingsView/backend/SettingsAgentActions';
+import {
+  templateAgentNamePrompt,
+  writeTemplateAgentFile,
+} from '@controllers/settingsView/backend/templateAgentCreation';
 import type { SettingsRemoteAgentPromptController } from '@controllers/settingsView/SettingsRemoteAgentPromptController';
 import type { SettingsAgentDirectoryController } from '@controllers/settingsView/SettingsAgentDirectoryController';
 import type { SettingsAgentCatalogController } from '@controllers/settingsView/SettingsAgentCatalogController';
@@ -99,10 +98,6 @@ export class AgentHandlers {
       showErrorMessage: async (message) => {
         await showLoggedMessage(this.ctx.channel, message);
       },
-      formatOpenAgentYamlError: (reason, name) =>
-        reason === 'missingAgent'
-          ? `Agent "${name}" could not be found. It may have been removed or renamed. Check the Agents tab in Settings to see available agents.`
-          : `No configuration file found for agent "${name}". The agent definition may be incomplete — try re-creating it from the Agents tab.`,
       refreshAfterMutation: () => this.refreshAfterAgentMutation(),
       run: (_command, failureMessage, action) =>
         withHandlerErrorHandling(this.ctx, failureMessage, action),
@@ -435,9 +430,8 @@ export class AgentHandlers {
       this.ctx,
       'Failed to create agent from template',
       async () => {
-        const categoryLabel = category === 'toolUse' ? 'Tool Use' : 'Workflow';
         const name = await vscode.window.showInputBox({
-          prompt: `Enter a name for the new ${categoryLabel} agent (without .yaml extension)`,
+          prompt: templateAgentNamePrompt(category),
           placeHolder: 'my_agent',
           validateInput: (value) =>
             this.directoryController.validateTemplateName(value),
@@ -453,27 +447,15 @@ export class AgentHandlers {
           customDir,
         });
 
-        if (await AbsoluteFS.exists(templatePlan.filePath)) {
-          await vscode.window.showWarningMessage(
-            `A file named "${templatePlan.fileName}" already exists in the custom agents folder.`,
-          );
+        const written = await writeTemplateAgentFile(
+          templatePlan,
+          path.join(this.ctx.extensionContext.extensionPath, 'resources'),
+        );
+        if (!written.ok) {
+          await vscode.window.showWarningMessage(written.message);
           return;
         }
 
-        const templatePath = path.join(
-          this.ctx.extensionContext.extensionPath,
-          'resources',
-          'templates',
-          AGENT_TEMPLATE_FILES[templatePlan.templateKind],
-        );
-        const templateRaw = await AbsoluteFS.read(templatePath);
-        const template = renderAgentTemplateString(templateRaw, {
-          AGENT_NAME: templatePlan.baseName,
-          DESCRIPTION: templatePlan.description,
-          TOOLS_YAML: DEFAULT_AGENT_TEMPLATE_TOOLS_YAML,
-        });
-
-        await AbsoluteFS.write(templatePlan.filePath, template);
         const doc = await vscode.workspace.openTextDocument(
           vscode.Uri.file(templatePlan.filePath),
         );

--- a/packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 
 import {
   listGitHubSubscriptionEntries,
+  noActiveGitHubSubscriptionMessage,
   unsubscribeGitHubKey,
 } from '@controllers/settingsView/githubSubscriptions';
 import { SecretManager } from '@frontend/secretManager';
@@ -93,7 +94,7 @@ export class GitHubSubscriptionHandlers {
     const removed = unsubscribeGitHubKey(data.key);
     if (removed === 0) {
       void vscode.window.showInformationMessage(
-        `No active subscription for ${data.key}.`,
+        noActiveGitHubSubscriptionMessage(data.key),
       );
     }
   }

--- a/packages/extension/src/settingsView/handlers/subscriptionHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/subscriptionHandlers.ts
@@ -20,6 +20,7 @@ import type {
   UpdateChatGptAuthStatusMessage,
   UpdateGrokAuthStatusMessage,
 } from '@shared/schemas';
+import { ACCOUNT_OUTCOME } from '@shared/copy/accountAuth';
 
 import {
   withHandlerErrorHandling,
@@ -64,11 +65,11 @@ export class SubscriptionHandlers {
     const { displayName } = this.provider;
     await withHandlerErrorHandling(
       this.ctx,
-      `${displayName} sign-out failed`,
+      ACCOUNT_OUTCOME.signOutFailed(displayName),
       async () => {
         await this.provider.signOut();
         void vscode.window.showInformationMessage(
-          `Signed out of ${displayName}.`,
+          ACCOUNT_OUTCOME.signedOut(displayName),
         );
         await this.refreshState();
       },

--- a/src/controllers/settingsView/backend/SettingsAgentActions.ts
+++ b/src/controllers/settingsView/backend/SettingsAgentActions.ts
@@ -52,16 +52,27 @@ interface SettingsAgentActionsOptions {
   ) => Promise<boolean>;
   readonly showInfoMessage: (message: string) => Promise<void>;
   readonly showErrorMessage: (message: string) => Promise<void>;
-  readonly formatOpenAgentYamlError: (
-    reason: 'missingAgent' | 'missingPath',
-    agentName: string,
-  ) => string;
   readonly refreshAfterMutation: () => Promise<void>;
   readonly run: (
     command: AgentFileCommand,
     failureMessage: string,
     action: () => Promise<void>,
   ) => Promise<void>;
+}
+
+/**
+ * Why an agent's YAML could not be opened. The lookup and both failure modes
+ * are host-neutral — `planOpenAgentYaml` decides them — so the sentence lives
+ * beside the sibling `Agent not found or has no file` messages below rather
+ * than being a port each host answers in its own words.
+ */
+function openAgentYamlErrorMessage(
+  reason: 'missingAgent' | 'missingPath',
+  agentName: string,
+): string {
+  return reason === 'missingAgent'
+    ? `Agent "${agentName}" could not be found. It may have been removed or renamed. Check the Agents tab in Settings to see available agents.`
+    : `No configuration file found for agent "${agentName}". The agent definition may be incomplete — try re-creating it from the Agents tab.`;
 }
 
 /**
@@ -86,7 +97,7 @@ export function createSettingsAgentActions(
         });
         if (!result.ok) {
           await options.showErrorMessage(
-            options.formatOpenAgentYamlError(result.reason, message.agentName),
+            openAgentYamlErrorMessage(result.reason, message.agentName),
           );
           return;
         }

--- a/src/controllers/settingsView/backend/templateAgentCreation.ts
+++ b/src/controllers/settingsView/backend/templateAgentCreation.ts
@@ -1,0 +1,80 @@
+// Standard library imports
+import * as path from 'node:path';
+
+// Local imports - agent
+import {
+  AGENT_TEMPLATE_FILES,
+  DEFAULT_AGENT_TEMPLATE_TOOLS_YAML,
+  renderAgentTemplateString,
+} from '@agent/templates/agentTemplateRenderer';
+// Local imports - shared
+import type { AgentCategory } from '@shared/schemas';
+// Local imports - utilities
+import { AbsoluteFS } from '@utils/files/absoluteFS';
+
+/**
+ * "Create an agent from a bundled template" is one operation with one set of
+ * rules — the same plan, the same template file, the same collision check, the
+ * same rendered substitutions — and only the prompt widget and the editor that
+ * opens the result differ per host. The extension's settings handlers and the
+ * desktop's settings controller each carried their own copy of the whole
+ * sequence; this module owns it, and each host keeps only its dialog.
+ */
+
+/** The user-facing name of an agent category, as both pickers spell it. */
+export function templateAgentCategoryLabel(category: AgentCategory): string {
+  return category === 'toolUse' ? 'Tool Use' : 'Workflow';
+}
+
+/** Prompt for the name field of the create-from-template dialog. */
+export function templateAgentNamePrompt(category: AgentCategory): string {
+  return `Enter a name for the new ${templateAgentCategoryLabel(
+    category,
+  )} agent (without .yaml extension)`;
+}
+
+/** Plan fields this module needs; a superset lives on the directory controller's plan. */
+interface TemplateAgentFilePlan {
+  readonly fileName: string;
+  readonly filePath: string;
+  readonly baseName: string;
+  readonly description: string;
+  readonly templateKind: 'toolUse' | 'workflowSingle';
+}
+
+/**
+ * Render a planned template agent into its file.
+ *
+ * Refuses rather than overwrites when the file already exists, and reports the
+ * refusal as a message instead of a code, matching `planOpenAgentYaml` and the
+ * rest of this directory: the condition is host-neutral, so the sentence is too.
+ * `resourcesRoot` is the packaged `…/resources` directory that holds
+ * `templates/<kind>.yaml`.
+ */
+export async function writeTemplateAgentFile(
+  plan: TemplateAgentFilePlan,
+  resourcesRoot: string,
+): Promise<{ ok: true } | { ok: false; message: string }> {
+  if (await AbsoluteFS.exists(plan.filePath)) {
+    return {
+      ok: false,
+      message: `A file named "${plan.fileName}" already exists in the custom agents folder.`,
+    };
+  }
+  const raw = await AbsoluteFS.read(
+    path.join(
+      resourcesRoot,
+      'templates',
+      AGENT_TEMPLATE_FILES[plan.templateKind],
+    ),
+  );
+  await AbsoluteFS.write(
+    plan.filePath,
+    renderAgentTemplateString(raw, {
+      AGENT_NAME: plan.baseName,
+      DESCRIPTION: plan.description,
+      TOOLS_YAML: DEFAULT_AGENT_TEMPLATE_TOOLS_YAML,
+    }),
+  );
+  return { ok: true };
+}

--- a/src/controllers/settingsView/backend/templateAgentCreation.ts
+++ b/src/controllers/settingsView/backend/templateAgentCreation.ts
@@ -45,9 +45,9 @@ interface TemplateAgentFilePlan {
 /**
  * Render a planned template agent into its file.
  *
- * Refuses rather than overwrites when the file already exists, and reports the
- * refusal as a message instead of a code, matching `planOpenAgentYaml` and the
- * rest of this directory: the condition is host-neutral, so the sentence is too.
+ * Refuses rather than overwrites when the file already exists. Unlike the
+ * `reason` codes returned by `planOpenAgentYaml`, this reports a host-neutral
+ * sentence that both settings hosts can present directly.
  * `resourcesRoot` is the packaged `…/resources` directory that holds
  * `templates/<kind>.yaml`.
  */

--- a/src/controllers/settingsView/githubSubscriptions.ts
+++ b/src/controllers/settingsView/githubSubscriptions.ts
@@ -49,6 +49,15 @@ export function listGitHubSubscriptionEntries(
 }
 
 /**
+ * What both Git tabs say when {@link unsubscribeGitHubKey} matched nothing —
+ * the key was already unbound, or never had this shape. The condition is
+ * decided here, so the sentence is too.
+ */
+export function noActiveGitHubSubscriptionMessage(key: string): string {
+  return `No active subscription for ${key}.`;
+}
+
+/**
  * Removes every binding for a GitHub URL-shaped subscription key.
  * Repo keys are exactly `owner/repo`; a malformed, legacy, or future key
  * shape must not silently default to the repo registry (a destructive unbind),

--- a/src/shared/copy/accountAuth.ts
+++ b/src/shared/copy/accountAuth.ts
@@ -53,6 +53,31 @@ export const GROK_AUTH = {
 } as const;
 
 /**
+ * Sign-in / sign-out outcome sentences that read the same for any account,
+ * parameterized by the provider's display name.
+ *
+ * All three hosts drive these from the one `subscriptionProvider(id)`
+ * descriptor and reported the outcome in their own words: the CLI auth command
+ * and launcher, the desktop credential controller, and the extension's
+ * settings handlers. One outcome of one operation on one account gets one
+ * sentence.
+ */
+export const ACCOUNT_OUTCOME = {
+  signedInAs: (providerDisplayName: string, accountLabel: string): string =>
+    `Signed in with ${providerDisplayName} as ${accountLabel}.`,
+  signedOut: (providerDisplayName: string): string =>
+    `Signed out of ${providerDisplayName}.`,
+  /** Prefix only — the extension appends the reason through its own logger. */
+  signOutFailed: (providerDisplayName: string): string =>
+    `${providerDisplayName} sign-out failed`,
+  signOutFailedWithReason: (
+    providerDisplayName: string,
+    reason: string,
+  ): string =>
+    `${ACCOUNT_OUTCOME.signOutFailed(providerDisplayName)}: ${reason}`,
+} as const;
+
+/**
  * Researcher Access fields that only the account surfaces need. The program
  * name itself stays on {@link RESEARCHER_ACCESS} in `onboarding.ts`.
  */
@@ -70,5 +95,5 @@ export const RESEARCHER_ACCESS_AUTH = {
   startingBrowser: (provider: string): string =>
     `Opening browser for ${RESEARCHER_ACCESS.label} ${provider} sign-in...`,
   signedIn: (accountLabel: string): string =>
-    `Signed in with ${RESEARCHER_ACCESS.label} as ${accountLabel}.`,
+    ACCOUNT_OUTCOME.signedInAs(RESEARCHER_ACCESS.label, accountLabel),
 } as const;

--- a/src/tools/github/githubAuth.ts
+++ b/src/tools/github/githubAuth.ts
@@ -36,6 +36,14 @@ export const GITHUB_TOKEN_SAVED_MESSAGE = 'GitHub token saved.';
 /** Confirmation after the token is cleared from the host secret store. */
 export const GITHUB_TOKEN_REMOVED_MESSAGE = 'GitHub token removed.';
 
+/**
+ * What every host says when the `githubTokenInvalid` signal fires: GitHub
+ * rejected the stored token. One signal, one sentence.
+ */
+export function gitHubTokenRejectedMessage(reason: string): string {
+  return `GitHub token rejected: ${reason}`;
+}
+
 /** Environment variables accepted by GitHub tools, in precedence order. */
 const GITHUB_TOKEN_ENV_VARS = ['GH_TOKEN', 'GITHUB_TOKEN'] as const;
 


### PR DESCRIPTION
## Summary

Round 2 of the desktop / CLI / extension parity sweep (round 1 was #11187). The first pass only
searched single-quoted literals, so it missed every **template literal** — re-running the
detector over backtick strings surfaced 19 more desktop↔extension, 5 CLI↔extension, and 3
CLI↔desktop duplicates. The strongest of those turned out not to be copy at all: two hosts were
carrying the same *sequence*, not just the same sentence.

### 1. Template-agent creation was duplicated end to end

`createAgentFromTemplate` (extension `agentHandlers.ts`) and `createAgent` (desktop
`desktopAgentSettingsController.ts`) each ran the same seven steps — category label → name
prompt → `validateTemplateName` → `ensureDir` → `planTemplateAgent` → collision check →
read the bundled template → `renderAgentTemplateString` with the same three substitutions →
write. Only the prompt widget, the resources root, and how the result is opened actually differ.

New `@controllers/settingsView/backend/templateAgentCreation` owns
`templateAgentCategoryLabel`, `templateAgentNamePrompt`, and `writeTemplateAgentFile`. Each host
keeps its dialog and its editor; the sequence between them is written once.
`writeTemplateAgentFile` returns `{ ok: false, message }` rather than the `reason` code used by
`planOpenAgentYaml`; the collision sentence is host-neutral, so both hosts can present it directly.

**This shrinks a ratchet.** With the template read/render/write gone, the desktop no longer
imports `@agent/templates/agentTemplateRenderer` at all, so
`config/ratchets/host-agent-import-baseline.json` loses a desktop entry (10 → 9). The
architecture test caught it as stale headroom, which is the ratchet working as designed.

### 2. `formatOpenAgentYamlError` was an over-built port

`createSettingsAgentActions` required every host to supply a formatter for a failure *it*
decides (`planOpenAgentYaml` returns `missingAgent` / `missingPath`). The two hosts gave
materially different answers to the same question:

- desktop: `Agent not found: <name>`
- extension: `Agent "<name>" could not be found. It may have been removed or renamed. Check the Agents tab in Settings to see available agents.`

The port is deleted and the sentence moves into `SettingsAgentActions.ts`, which already owns
the sibling `Agent not found or has no file` message for the reveal and customize paths.
The extension's wording wins — it is the more useful one, and the desktop settings panel has
the same Agents tab it points at. **Net −1 port, −2 implementations.**

### 3. Account sign-in / sign-out outcomes, across all three hosts

Every host drives these from the same `subscriptionProvider(id).displayName` and then reported
the outcome in its own words. New `ACCOUNT_OUTCOME` on `@shared/copy/accountAuth`:

| sentence | was in |
|---|---|
| `Signed in with X as Y.` | CLI `subscriptionAuthCommand` ×2, desktop credential controller, extension `subscriptionSignIn` (as its first clause) |
| `Signed out of X.` | CLI `subscriptionLogin`, CLI `loginCommands`, desktop, extension `subscriptionHandlers` |
| `X sign-out failed[: reason]` | CLI `loginCommands` ×2, desktop, extension (prefix form) |

`RESEARCHER_ACCESS_AUTH.signedIn` was the same rule with the brand baked in; it is now defined
in terms of `ACCOUNT_OUTCOME.signedInAs` instead of restating it. The extension's sign-out
prefix and the CLI/desktop's `: <reason>` form are two entries (`signOutFailed`,
`signOutFailedWithReason`) because the extension appends the reason through its own logger —
the prefix is genuinely the shared part.

### 4. The last two GitHub sentences

`No active subscription for <key>.` moves next to `unsubscribeGitHubKey`, which decides that
condition; `GitHub token rejected: <reason>` moves to `@tools/github/githubAuth` beside the
three token sentences #11187 put there. The extension spelled the latter twice in one handler
(log line and dialog) — now once.

## Behavior changes

One: the desktop's "open agent YAML failed" messages become the extension's longer, more
actionable wording. Stated above; it is an upgrade, not a regression, and the tab it names
exists on both hosts.

## Single source of truth

- Create-from-template sequence: `@controllers/settingsView/backend/templateAgentCreation`.
- Agent-file failure sentences: `SettingsAgentActions.ts` — all of them, now that the port is gone.
- Account outcome sentences: `ACCOUNT_OUTCOME` on `@shared/copy/accountAuth`.
- GitHub subscription/token sentences: `githubSubscriptions.ts` and `githubAuth.ts`.

## Duplication and abstraction budget

Removed: one duplicated 7-step flow (both copies), one port and its two implementations, two
now-dead `@agent/templates/agentTemplateRenderer` host imports, one baseline entry, and 14
duplicate spellings. Added: 1 file, 7 exports. No new ports bag — `writeTemplateAgentFile`
takes a plan and a path, and the hosts keep their own dialogs, so this is not another
dependency-injection layer.

## Net elements (R6)

- 17 files (16 modified, 1 added), `+200 / −89` (net **+111**), of which the new shared module
  is +80. The two hosts lost 82 lines of duplicated flow between them.
- `^[+-]export` symbols: +7 (`templateAgentCategoryLabel`, `templateAgentNamePrompt`,
  `writeTemplateAgentFile`, `ACCOUNT_OUTCOME`, `noActiveGitHubSubscriptionMessage`,
  `gitHubTokenRejectedMessage`, and the `TemplateAgentFilePlan` interface is module-private so
  it does not count). −1: `formatOpenAgentYamlError` leaves the `SettingsAgentActionsOptions`
  interface.
- Interfaces: +1 module-private (`TemplateAgentFilePlan`), −1 interface **field**
  (`formatOpenAgentYamlError`).
- Ratchet: `host-agent-import-baseline.json` desktop list 10 → 9.

## Consumer counts (R8)

- `writeTemplateAgentFile`, `templateAgentNamePrompt` — 2 each (desktop controller, extension handlers)
- `templateAgentCategoryLabel` — 2 (desktop dialog title, and via `templateAgentNamePrompt`)
- `ACCOUNT_OUTCOME.signedInAs` — 5 (CLI ×2, desktop, extension, `RESEARCHER_ACCESS_AUTH.signedIn`)
- `ACCOUNT_OUTCOME.signedOut` — 5 (CLI ×3, desktop, extension)
- `ACCOUNT_OUTCOME.signOutFailed` / `signOutFailedWithReason` — 1 / 3
- `noActiveGitHubSubscriptionMessage` — 2 (desktop, extension)
- `gitHubTokenRejectedMessage` — 2 (desktop, extension — the latter uses it twice)
- `openAgentYamlErrorMessage` — module-private, 1 call site, replacing a 2-implementation port.

No emit path or subscriber was deleted.

## Testing

Zero new tests. The one test interaction is `hostAgentDeepImportRatchet.vitest.ts` failing on
stale baseline headroom, fixed by shrinking the baseline in this PR — no test file changed.

## Validation

Rebased onto current `origin/main` (`4d5008b6c`) after #11185/#11193 landed, and re-run from scratch:

- `npm run typecheck` — all six projects: passed.
- `npm test` — **842 files passed / 1 skipped; 10,305 tests passed / 5 skipped.**
- `npx eslint` on all changed files: clean.
- `npx prettier --check` on all changed files: clean. `git diff --check`: clean.
- `npm run check:dead-code-ratchet`: `8 current vs 8 baselined`.

