### PR TITLE
refactor(cli): read facts the projection already built; collapse constant apparatus

### DIFF
--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -7,7 +7,6 @@ import { COLOR_WARNING } from '@cli/tui/ui/colors';
 import { AgentCategory } from '@shared/schemas';
 import type { TranscriptRow } from '@shared/transcript';
 import {
-  formatWorkflowPhaseHeading,
   latestWorkflowCallsById,
   workflowCallFailureTally,
   workflowPhaseCallProgress,
@@ -193,7 +192,7 @@ export function workflowRunStatusSummary(
   );
   const segments: WorkflowStatusSegment[] = [];
   if (phase) {
-    segments.push({ text: formatWorkflowPhaseHeading(phase), tone: 'muted' });
+    segments.push({ text: phase.heading, tone: 'muted' });
   }
   if (total > 0) {
     segments.push({ text: `${done}/${total} done`, tone: 'muted' });

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -13,7 +13,6 @@ import { COLOR_HINT } from '@cli/tui/ui/colors';
 import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import type { StreamPhase, StreamTabId } from '@shared/schemas';
 import type { TranscriptRow } from '@shared/transcript';
-import { formatWorkflowPhaseHeading } from '@shared/copy/workflowCall';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { safeHomedir } from '@utils/system/platformPaths';
 
@@ -151,7 +150,7 @@ export function sessionHeaderIdentityLine(
       streamId: context.streamId,
       streams: context.streams,
     });
-    const phaseText = phase ? formatWorkflowPhaseHeading(phase) : undefined;
+    const phaseText = phase?.heading;
     return phaseText
       ? `${streamKind}: ${view.label} · ${phaseText} · parent: ${view.parentLabel} · model: ${model}`
       : `${streamKind}: ${view.label} · parent: ${view.parentLabel} · model: ${model}`;

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -284,7 +284,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
               parentStream,
               streamId: target.displayStreamId,
               streams,
-            }),
+            })?.heading,
     }),
     foreground: {
       inputActive: props.foregroundInputActive,

--- a/packages/cli/src/chat/tui/state/workflowPhase.ts
+++ b/packages/cli/src/chat/tui/state/workflowPhase.ts
@@ -2,10 +2,6 @@
 
 import { AgentCategory, type StreamTabId } from '@shared/schemas';
 import type { TranscriptRowOf } from '@shared/transcript';
-import {
-  formatWorkflowPhaseHeading,
-  type WorkflowPhaseHeading,
-} from '@shared/copy/workflowCall';
 
 import { currentWorkflowAttemptId, type StreamSlice } from './cliState';
 
@@ -17,7 +13,7 @@ import { currentWorkflowAttemptId, type StreamSlice } from './cliState';
 export function currentWorkflowPhaseHeading(
   slice: StreamSlice | undefined,
   category: AgentCategory | undefined,
-): WorkflowPhaseHeading | undefined {
+): TranscriptRowOf<'phase'> | undefined {
   if (!slice || category !== AgentCategory.Workflow) return undefined;
   const currentAttemptId = currentWorkflowAttemptId(
     slice.workflowAttemptId,
@@ -30,12 +26,7 @@ export function currentWorkflowPhaseHeading(
       (currentAttemptId === undefined ||
         (currentAttemptId !== null && row.attemptId === currentAttemptId)),
   );
-  if (!phase) return undefined;
-  return {
-    phaseLabel: phase.phaseLabel,
-    phaseIndex: phase.phaseIndex,
-    phaseTotal: phase.phaseTotal,
-  };
+  return phase;
 }
 
 /** Nearest workflow-script ancestor's current phase, walking parent links. */
@@ -44,16 +35,16 @@ export function ancestorWorkflowPhaseHeading(init: {
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly streamId: StreamTabId;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
-}): WorkflowPhaseHeading | undefined {
+}): TranscriptRowOf<'phase'> | undefined {
   let id: StreamTabId | undefined = init.streamId;
   const seen = new Set<StreamTabId>();
   while (id && !seen.has(id)) {
     seen.add(id);
-    const heading = currentWorkflowPhaseHeading(
+    const phase = currentWorkflowPhaseHeading(
       init.streams.get(id),
       init.categoryOf(id),
     );
-    if (heading) return heading;
+    if (phase) return phase;
     id = init.parentStream.get(id);
   }
   return undefined;
@@ -63,10 +54,10 @@ export function ancestorWorkflowPhaseHeading(init: {
 export function focusedSessionLocationText(init: {
   readonly isChildStream: boolean;
   readonly label: string;
-  readonly phaseHeading?: WorkflowPhaseHeading;
+  readonly phaseHeading?: string;
 }): string | undefined {
   if (!init.isChildStream) return undefined;
   return init.phaseHeading
-    ? `${formatWorkflowPhaseHeading(init.phaseHeading)} › ${init.label}`
+    ? `${init.phaseHeading} › ${init.label}`
     : init.label;
 }

--- a/packages/cli/src/commands/_helpers/subscriptionAuthCommand.ts
+++ b/packages/cli/src/commands/_helpers/subscriptionAuthCommand.ts
@@ -23,13 +23,10 @@ import { cliProgressWriter, emitCliResult } from './output';
 
 export interface DefineSubscriptionAuthCommandOptions {
   readonly providerId: SubscriptionProviderId;
-  readonly commandName: string;
   readonly rootDescription: string;
   readonly loginDescription: string;
   readonly logoutDescription: string;
   readonly statusDescription: string;
-  /** Registered ndjson discriminator; the status record appends '-status'. */
-  readonly ndjsonKind: 'chatgpt-auth' | 'grok-auth';
   /**
    * Provider-specific login payload fields (Codex carries `accountId`; Grok
    * does not). Kept as explicit configuration so the difference stays visible
@@ -50,6 +47,8 @@ export function defineSubscriptionAuthCommand(
   options: DefineSubscriptionAuthCommandOptions,
 ): CommandDef<typeof GLOBAL_ARGS> {
   const provider = subscriptionProvider(options.providerId);
+  /** Registered ndjson discriminator; the status record appends '-status'. */
+  const ndjsonKind = `${options.providerId}-auth` as const;
 
   async function runLogin(
     context: CliContext,
@@ -78,7 +77,7 @@ export function defineSubscriptionAuthCommand(
     const signedIn = `Signed in with ${provider.displayName} as ${account.label}.`;
     emitCliResult(context, {
       json: payload,
-      ndjson: { kind: options.ndjsonKind, ...payload },
+      ndjson: { kind: ndjsonKind, ...payload },
       text: update.effective
         ? `${signedIn}\n${provider.displayName} subscription enabled for ${provider.modelFamily}.`
         : `${signedIn}\n${provider.displayName} subscription preference could not be enabled because a more specific setting overrides the config.`,
@@ -135,7 +134,7 @@ export function defineSubscriptionAuthCommand(
       };
       emitCliResult(context, {
         json: payload,
-        ndjson: { kind: options.ndjsonKind, ...payload },
+        ndjson: { kind: ndjsonKind, ...payload },
         text: subscriptionSignOutOutcomeMessage(options.providerId, update),
       });
       return CliExitCode.Success;
@@ -155,7 +154,7 @@ export function defineSubscriptionAuthCommand(
       const { label, ...status } = statusResult.value;
       emitCliResult(context, {
         json: status,
-        ndjson: { kind: `${options.ndjsonKind}-status`, ...status },
+        ndjson: { kind: `${ndjsonKind}-status`, ...status },
         text: status.signedIn
           ? `Signed in with ${provider.displayName} as ${label}.`
           : `Not signed in with ${provider.displayName}.`,
@@ -166,7 +165,7 @@ export function defineSubscriptionAuthCommand(
 
   return defineCommand({
     meta: {
-      name: options.commandName,
+      name: options.providerId,
       description: options.rootDescription,
     },
     args: { ...GLOBAL_ARGS },

--- a/packages/cli/src/commands/chatgptAuth.ts
+++ b/packages/cli/src/commands/chatgptAuth.ts
@@ -2,11 +2,9 @@ import { defineSubscriptionAuthCommand } from './_helpers/subscriptionAuthComman
 
 export const chatgptAuthCommand = defineSubscriptionAuthCommand({
   providerId: 'chatgpt',
-  commandName: 'chatgpt',
   rootDescription: 'Sign in with your ChatGPT subscription to use Codex models',
   loginDescription: 'Sign in with your ChatGPT subscription',
   logoutDescription: 'Sign out of your ChatGPT subscription',
   statusDescription: 'Show ChatGPT subscription sign-in status',
-  ndjsonKind: 'chatgpt-auth',
   loginPayloadExtras: (account) => ({ accountId: account.accountId ?? null }),
 });

--- a/packages/cli/src/commands/grokAuth.ts
+++ b/packages/cli/src/commands/grokAuth.ts
@@ -2,11 +2,9 @@ import { defineSubscriptionAuthCommand } from './_helpers/subscriptionAuthComman
 
 export const grokAuthCommand = defineSubscriptionAuthCommand({
   providerId: 'grok',
-  commandName: 'grok',
   rootDescription:
     'Sign in with your Grok (xAI SuperGrok) account to use xAI models via subscription',
   loginDescription: 'Sign in with your Grok (xAI SuperGrok) account',
   logoutDescription: 'Sign out of your Grok subscription',
   statusDescription: 'Show Grok subscription sign-in status',
-  ndjsonKind: 'grok-auth',
 });

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -188,7 +188,6 @@ async function runOrchestration(context: CliContext): Promise<number> {
       presetPlans: presetPlanSet.plans,
       history,
       toolUseAgents,
-      includeMultiAgentLoginHint: !presetPlanSet.remoteCatalogRefreshAttempted,
       modelAccess: launcherModelAccess,
       account: accountStatus,
       presetLaunchBlockReason,

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -205,7 +205,6 @@ async function runOnboardingFlow(options: {
   readonly firstRun: boolean;
   readonly colorEnabled?: boolean;
 }): Promise<CliOnboardingResult> {
-  const picker = onboardingPicker(options);
   // `interactive`: both callers reject non-TTY output before reaching this
   // flow. Keep that product boundary authoritative when a real PTY also has CI
   // set; Ink otherwise disables interactive rendering from its CI heuristic.
@@ -214,8 +213,11 @@ async function runOnboardingFlow(options: {
   const chosen = await renderCliPrompt<OnboardingResolution>(
     (resolve) => (
       <OnboardingApp
-        pickerSubtitle={picker.subtitle}
-        pickerItems={picker.items}
+        pickerSubtitle={
+          options.firstRun
+            ? 'No provider API key is configured. Choose how to power model calls:'
+            : 'Choose how to power model calls:'
+        }
         onResolve={resolve}
       />
     ),
@@ -260,7 +262,6 @@ type Screen = 'picker' | 'chatgpt-progress' | 'key-provider' | 'key-entry';
 
 interface OnboardingAppProps {
   readonly pickerSubtitle: string;
-  readonly pickerItems: readonly OnboardingPickerItem[];
   readonly onResolve: (resolution: OnboardingResolution) => void;
 }
 
@@ -282,7 +283,7 @@ function OnboardingApp(props: OnboardingAppProps): React.JSX.Element {
     return (
       <PickerStep
         subtitle={props.pickerSubtitle}
-        items={props.pickerItems}
+        items={ONBOARDING_PICKER_ITEMS}
         error={error}
         onSelect={(choice) => {
           if (choice === 'skip') {
@@ -394,48 +395,24 @@ type OnboardingChoice = 'chatgpt' | 'key' | 'skip';
 type OnboardingSetupPath = Exclude<OnboardingChoice, 'skip'>;
 type OnboardingPickerItem = SelectItem<OnboardingChoice>;
 
-const SETUP_PATH_PICKER_ITEMS: Record<
-  OnboardingSetupPath,
-  OnboardingPickerItem
-> = {
-  chatgpt: {
+/** Every entry point offers the same credential paths, in this order. */
+const ONBOARDING_PICKER_ITEMS: readonly OnboardingPickerItem[] = [
+  {
     value: 'chatgpt',
     label: ONBOARDING_CHOICE_CHATGPT.label,
     description: ONBOARDING_CHOICE_CHATGPT.description,
   },
-  key: {
+  {
     value: 'key',
     label: ONBOARDING_CHOICE_API_KEY.label,
     description: ONBOARDING_CHOICE_API_KEY.description,
   },
-};
-
-const SKIP_PICKER_ITEM: OnboardingPickerItem = {
-  value: 'skip',
-  label: ONBOARDING_CHOICE_SKIP_LABEL,
-  description: 'Set up later with `texra setup`',
-};
-
-interface OnboardingPicker {
-  readonly subtitle: string;
-  readonly items: readonly OnboardingPickerItem[];
-}
-
-/** Picker copy for one entry point; both offer the same credential paths. */
-function onboardingPicker(props: {
-  readonly firstRun: boolean;
-}): OnboardingPicker {
-  return {
-    subtitle: props.firstRun
-      ? 'No provider API key is configured. Choose how to power model calls:'
-      : 'Choose how to power model calls:',
-    items: [
-      SETUP_PATH_PICKER_ITEMS.chatgpt,
-      SETUP_PATH_PICKER_ITEMS.key,
-      SKIP_PICKER_ITEM,
-    ],
-  };
-}
+  {
+    value: 'skip',
+    label: ONBOARDING_CHOICE_SKIP_LABEL,
+    description: 'Set up later with `texra setup`',
+  },
+];
 
 /** Screen each non-skip picker choice opens (skip resolves the gate instead). */
 const PICKER_CHOICE_SCREENS: Record<OnboardingSetupPath, Screen> = {

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -89,7 +89,6 @@ export interface BuildCliOrchestrationItemsInput {
    */
   readonly history: readonly CliHistoryEntry[];
   readonly toolUseAgents: readonly AgentEntry[];
-  readonly includeMultiAgentLoginHint?: boolean;
   readonly modelAccess?: CliModelAccessStatus;
   readonly account?: CliAccountStatus;
   readonly presetLaunchBlockReason?: CliPresetLaunchBlockReason;


### PR DESCRIPTION
## Constraint

**Production-only.** No test file is added, deleted, or modified — `git diff --name-only origin/main HEAD` matches no test path. The full CLI + shared suites pass **unchanged**: 180 files, 2879 tests.

That is also the correctness argument. Every change here is behavior-preserving, and the existing tests prove it without being adjusted to agree.

## 1. The phase heading was computed twice

`projectTranscriptRow` already stores `heading` on every `PhaseRow` — a **required** field (`transcriptRow.ts:241`), built by `formatWorkflowPhaseHeading` over `{phaseLabel, phaseIndex, phaseTotal}`. The selectors then threw it away, rebuilt those same three fields, and three consumers re-ran the formatter over them.

`efb1a4ef28` ("read the phase heading the projection already built") fixed **one of four** sites in a 3-line commit and left the argument written in-tree at `transcriptEntryLayout.ts:342`:

> `row.heading` is `formatWorkflowPhaseHeading` over the same three fields, computed once by `projectTranscriptRow`.

The selectors now return the phase row itself, so callers read `row.heading`. `ConversationPane` still reads `phase.phaseLabel` for call filtering — the row carries both.

The six other `formatWorkflowPhaseHeading` call sites (`SubagentList` ×3, `workflowPlainOutput`, `streamStatusDisplay`, `TaskGroupList`) operate on dashboard groups and StreamLog stages, not transcript rows, and stay.

## 2. The onboarding picker computed a constant

`db5a8c1a57` collapsed the inner closure and the branching but left the shape. Both entry points offer the identical `['chatgpt', 'key']`, so `SETUP_PATH_PICKER_ITEMS` (a `Record` keyed to select from), `SKIP_PICKER_ITEM`, the `OnboardingPicker` interface, and `onboardingPicker()` existed to pick from a one-element space and thread the result through two component props.

One module-level `ONBOARDING_PICKER_ITEMS` replaces all of it. `firstRun` still decides the subtitle — the only thing it ever varied. Item order and every copy string are preserved exactly.

## 3. `commandName` and `ndjsonKind` restate `providerId`

At both call sites they are pure functions of the sibling `providerId` (`'chatgpt'` → `'chatgpt'` / `'chatgpt-auth'`). `SubscriptionProviderId` is exactly `'chatgpt' | 'grok'`, so `` `${providerId}-auth` `` types to the same `'chatgpt-auth' | 'grok-auth'` union `cliOutput.ts:47-53` expects, and the emitted `kind` strings are byte-identical.

This also removes a hand-maintained list a third provider would have had to remember to extend.

## 4. One one-liner

- `includeMultiAgentLoginHint` — a declaration and one writer, **no reader**. Its live twin computes the same expression for `buildCliTeamItems`, which *does* read it.

*(An earlier draft of this description also claimed a `launchContext` alias removal. That is not in this diff — upstream `db5a8c1a57` had already removed it, so my rebase made that edit a no-op. Caught in review; the claim and its element count are withdrawn.)*

## Net elements (R6)

- Files: 10 changed, **all production**
- `^[+-]export` symbols: 0
- Interface members: **−3** · consts: **−2** · interfaces: **−1** · functions: **−1** · component props: **−1** · imports: **−2**
- Net LoC: **−41** (`32 insertions(+), 73 deletions(-)` vs `origin/main`)

## Consumer counts (R8)

Grepped with `--no-ignore-vcs` (a global gitignore hides tracked files from plain `rg` here — #11165). Test-consumer counts matter under the constraint, so both are listed:

| Symbol | production | test |
|---|---|---|
| `currentWorkflowPhaseHeading` | 2 | **0** |
| `ancestorWorkflowPhaseHeading` | 2 | **0** |
| `SETUP_PATH_PICKER_ITEMS` / `onboardingPicker` | in-file only | **0** |
| `includeMultiAgentLoginHint` | 1 writer, 0 readers | **0** |
| `ndjsonKind` | 3 reads, derived | **0** |

## Checks

`typecheck` ✅ (exit 0) · `lint` ✅ (exit 0) · `format` ✅ · `vitest` ✅ 180 files / 2879 tests, **no test file touched**

Rebased onto `origin/main`; resolved a conflict with `db5a8c1a57`, which had independently inlined `emitLogin` and partially collapsed the picker. Upstream's structure was kept and these changes re-applied on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJmSeJm4wocNwc7AFMrJBU