### PR TITLE
refactor(cli): make a silently-dropped option unrepresentable; clear stale doc references

### DIFF
--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -53,7 +53,13 @@ export interface CliModelAccessListOptions {
   readonly models?: readonly string[];
 }
 
-export interface CliModelAccessEntryOptions extends CliModelAccessListOptions {
+/**
+ * Deliberately does NOT extend {@link CliModelAccessListOptions}:
+ * `loadCliModelAccessList` calls `getCliModelAccessList()` with no arguments,
+ * so a `models` filter passed here would be silently dropped. Keeping the
+ * field off the type makes that unrepresentable rather than ignored.
+ */
+export interface CliModelAccessEntryOptions {
   /** Optional preloaded list, used by commands that already fetched access. */
   readonly accessList?: readonly CliModelAccess[];
 }

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -64,10 +64,10 @@ export interface CliLoginOptions {
   signal?: AbortSignal;
 }
 
-export const CLI_MANUAL_AUTH_URL_PROMPT =
+const CLI_MANUAL_AUTH_URL_PROMPT =
   'Open this URL in a browser that can reach this terminal session:';
 
-export const CLI_MANUAL_AUTH_REMOTE_HINT =
+const CLI_MANUAL_AUTH_REMOTE_HINT =
   'Remote SSH/container users may need to forward the callback port.';
 
 export function formatCliManualAuthUrlMessage(url: string): string {

--- a/packages/extension/.vscodeignore
+++ b/packages/extension/.vscodeignore
@@ -28,7 +28,7 @@ CLAUDE.md
 # Multi-file, external-assets trace-viewer build (shared-assets/site-hosting
 # export mode) — CLI-only (packages/cli/src/runtime/history.ts), never
 # referenced by the extension host. resources/traceViewer (the single-file
-# build historyHandlers.ts actually loads) is unaffected.
+# build ProgressViewMessageHandler.ts actually loads) is unaffected.
 #
 # No `!resources/**` line exists in this file (deliberately — see below), so
 # this plain ignore line works: vsce applies every `!`-negated line *after*

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.styles.ts
@@ -46,7 +46,7 @@ export const userQuestionPanelStyles: CSSResult = css`
   /* wa-radio-group has no exposed "radios" CSS part in the pinned
      @awesome.me/webawesome build (only form-control/form-control-label/
      form-control-input/hint are rendered) — style the host directly, same
-     technique as ApiAccessSection.styles.ts's wa-radio-group.api-access-options. */
+     technique used for any themed wa-radio-group. */
   wa-radio-group {
     display: flex;
     flex-direction: column;

--- a/src/model/modelListRefresh.ts
+++ b/src/model/modelListRefresh.ts
@@ -95,9 +95,9 @@ function reconcileEnabledModels(
  * in runtimeModelRegistry.ts) deliberately excludes both kinds of config, so
  * the preference can never resolve to a route. Leaving it persisted would
  * strand the model behind the hard no-fallthrough error (#9635) on every
- * launch. Unlike the version-gated enabled-list deprecated sweep above, this
- * runs unconditionally: affected users may already have persisted the current
- * MODEL_LIST_VERSION before this migration shipped.
+ * launch. Like the retired-model sweep above, this runs unconditionally:
+ * affected users may already have persisted the current MODEL_LIST_VERSION
+ * before this migration shipped.
  */
 function reconcileCopilotRoutePreferences(
   currentModels: readonly string[],


### PR DESCRIPTION
## Constraint

**Production-only.** No test file is added, deleted, or modified. 216 test files / 3221 tests pass **unchanged**.

## 1. A silently-dropped option — the one real defect here

`CliModelAccessEntryOptions extends CliModelAccessListOptions`, so it advertises a `models` filter. But `loadCliModelAccessList` — the function that consumes it — calls `getCliModelAccessList()` with **no arguments**:

```ts
async function loadCliModelAccessList(
  options: CliModelAccessEntryOptions,
): Promise<readonly CliModelAccess[]> {
  return options.accessList ?? getCliModelAccessList();   // options.models dropped
}
```

So `loadCliModelAccessEntry({ models: [...] })` type-checks and silently ignores the filter. `selectCliRunnableModel` already narrows its options to `accessList`, so it never accepted this field. No caller passes the ignored field today, which is the only reason this has not bitten.

Dropping the `extends` makes the field **unsupplied rather than ignored** — the state stops being representable instead of being handled. `getCliModelAccessList` keeps its own `models` option; that path genuinely reads it in `getCliModelAccessList`.

Worth noting against the original survey note on this: it claimed `loadCliModelAccessList` "silently drops" a `models` field that nothing reads. Half right — `CliModelAccessListOptions.models` **is** read, on the other entry point. Only the inherited copy is dead.

## 2. Two constants that are no longer external

`CLI_MANUAL_AUTH_URL_PROMPT` and `CLI_MANUAL_AUTH_REMOTE_HINT` lost their only external consumer when `368ee4f601` deleted the relay onboarding step (`runOnboarding.tsx:65-66,712,724`). Both are now used once, in their own file. Drop the `export`.

## 3. Three doc references to things that no longer exist

| Where | Cites | Reality |
|---|---|---|
| `UserQuestionPanel.styles.ts:49` | `ApiAccessSection.styles.ts`'s `wa-radio-group.api-access-options` | deleted with the relay plane; 0 occurrences repo-wide |
| `.vscodeignore:30-31` | `historyHandlers.ts` loads `resources/traceViewer` | that file is gone; the loader is `ProgressViewMessageHandler.ts:280` |
| `modelListRefresh.ts:98` | "Unlike the version-gated enabled-list deprecated sweep above" | the comment **eleven lines earlier** states that sweep is "deliberately *not* gated behind a version threshold" — the contrast was with something that does not exist |

The `.vscodeignore` ignore logic itself is correct; only the attribution was stale.

## What this round did *not* find

Two exhaustive scans came back empty, which is worth recording so the next pass skips them:

- **3128 exported functions** — none is production-dead with zero test references.
- **2976 exported consts/interfaces/types** — same.

And the knip baseline **cannot shrink under this constraint**: all five remaining `unusedExports` rows (`DESKTOP_COMMAND_IDS`, `isAllowedExternalUrl`, `getDesktopWarningParentWindow`, `getSecretStorageMode`, `LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE`) have test consumers — 2 to 22 each — so de-exporting any of them requires touching tests.

## Net elements (R6)

- Files: 5 changed, **all production** (2 code, 3 doc/comment)
- `^[+-]export` symbols: **−2**
- Interface `extends` clauses: **−1**
- Net LoC: **+6** (`14 insertions(+), 8 deletions(-)`) — net-positive by design: the removed `extends` is replaced by a doc comment explaining why the field must stay off the type, so the next contributor does not re-add it.

## Consumer counts (R8)

Grepped with `--no-ignore-vcs` (a global gitignore hides tracked files from plain `rg` here — #11165):

| Symbol | production | test |
|---|---|---|
| `CliModelAccessEntryOptions.models` (inherited) | 0 readers, 0 passers | **0** |
| `CliModelAccessListOptions.models` | 1 reader — **retained** | 0 |
| `CLI_MANUAL_AUTH_URL_PROMPT` | 1, in-file | **0** |
| `CLI_MANUAL_AUTH_REMOTE_HINT` | 1, in-file | **0** |
| `ApiAccessSection` | 0 | **0** |
| `historyHandlers` | 0 | **0** |

## Checks

`typecheck` ✅ (exit 0) · `lint` ✅ (exit 0) · `format` ✅ · `vitest` ✅ 216 files / 3221 tests, **no test file touched**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJmSeJm4wocNwc7AFMrJBU
