### PR TITLE
refactor: sweep the cold surface and work the recorded candidate queue

### DIFF
--- a/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
@@ -97,8 +97,8 @@ export async function showCliWorkPlan(
  * A tool-use run emits one ACTIVE_SKILLS snapshot at prompt-build time, so the
  * newest entry is the answer; older ones only exist across resumed lifetimes.
  * Read on demand rather than folded per delta — `/status` is a one-shot
- * command, and the projected `ConversationEntry[]` deliberately carries no row
- * for this message type (`projectTranscriptRow`), so the raw log is the source.
+ * command, and the transcript projection (`projectTranscriptRow`) deliberately
+ * carries no row for this message type, so the raw log is the source.
  */
 function activeSkillNamesFor(streamId: string | undefined): readonly string[] {
   if (streamId === undefined) return [];

--- a/packages/cli/src/runtime/cliPresentationHost.ts
+++ b/packages/cli/src/runtime/cliPresentationHost.ts
@@ -19,10 +19,7 @@ import {
   type Logger,
   type LogSink,
 } from './logSinks';
-import {
-  attachRunProgressRenderer,
-  createRunProgressRenderer,
-} from './runProgressRenderer';
+import { createRunProgressRenderer } from './runProgressRenderer';
 import { missingAgentMessage } from './agents';
 import type { CliContext } from './cliContext';
 
@@ -139,7 +136,7 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
 
   return {
     attachRunProgressRenderer: (session) =>
-      attachRunProgressRenderer(session, runProgress),
+      runProgress ? runProgress.attach(session) : () => undefined,
     prepareInteractivePrompt: () => runProgress?.preserve(),
     emitApprovalBypassState({ streamId, kind, bypassActive }) {
       if (closed || context.outputFormat !== 'ndjson') return;

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -98,13 +98,6 @@ export function createRunProgressRenderer(
   });
 }
 
-export function attachRunProgressRenderer(
-  session: SessionHandle,
-  renderer: RunProgressRenderer | undefined,
-): () => void {
-  return renderer ? renderer.attach(session) : () => undefined;
-}
-
 /**
  * Everything the live line needs that no shared record carries: the run's
  * `AgentConfig` never lands on `SessionState` (the summary mirror keeps only

--- a/packages/cli/src/tui/ui/Select.tsx
+++ b/packages/cli/src/tui/ui/Select.tsx
@@ -50,11 +50,9 @@ export interface SelectProps<T> {
   /** Disable direct 1-9/a-z activation for arrow-only lists. */
   readonly hotkeys?: boolean;
   /** Set false when this Select is a standalone focus target rather than a
-   *  cyclic menu: a move past either edge reports `onBoundaryEscape` instead
-   *  of wrapping. Defaults to true (existing wrap-around behavior). */
+   *  cyclic menu: a move past either edge clamps instead of wrapping.
+   *  Defaults to true (existing wrap-around behavior). */
   readonly wrap?: boolean;
-  /** Called when `wrap` is false and a move would cross the top/bottom edge. */
-  readonly onBoundaryEscape?: (direction: -1 | 1) => void;
   /** Defaults to `'single'`: hotkeys (1-9, then a-z) select-and-close via
    *  `onSelect`; Enter does the same on the highlighted row; Space is
    *  unhandled. In `'multi'`, Space and hotkeys instead toggle membership via
@@ -323,7 +321,6 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
       wrap: props.wrap,
     });
     if (props.wrap === false && next === current) {
-      props.onBoundaryEscape?.(direction);
       return;
     }
     highlightRef.current = next;

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -57,10 +57,6 @@ export interface DesktopCommandPaletteOptions {
   getStreams?: () => readonly StreamTabInfo[];
   getShortcuts?: () => readonly DesktopShortcutEntry[];
   platform?: DesktopPlatform;
-  // Returning false suppresses ALL palette opens — both the global
-  // Cmd/Ctrl+K shortcut and any direct `controller.open()` call (e.g. while
-  // a first-run walkthrough is visible).
-  canOpen?: () => boolean;
 }
 
 const DESKTOP_SWITCH_STREAM_COMMAND_PREFIX = 'texra.desktop.switchStream:';
@@ -139,7 +135,6 @@ export function createDesktopCommandPalette({
   getStreams,
   getShortcuts,
   platform = getRendererPlatform(document.defaultView),
-  canOpen,
 }: DesktopCommandPaletteOptions): CommandPaletteController {
   const getEntries = (): CommandPaletteEntry[] => {
     const streams = actions.showStream == null ? [] : (getStreams?.() ?? []);
@@ -362,7 +357,6 @@ export function createDesktopCommandPalette({
   };
 
   const open = (): void => {
-    if (canOpen?.() === false) return;
     if (dialog.open) return;
     allEntries = getEntries();
     applyQuery('');

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -1331,7 +1331,6 @@ const shortcutRegistry = bootstrapFailed
 if (shortcutRegistry) {
   commandPalette = createDesktopCommandPalette({
     document,
-    canOpen: () => true,
     actions: desktopRendererCommandActions,
     getStreams: () => streams$.get(),
     getShortcuts: () => shortcutRegistry.entries(),

--- a/packages/extension/src/commands/housekeeping/packCommands.ts
+++ b/packages/extension/src/commands/housekeeping/packCommands.ts
@@ -50,8 +50,7 @@ export async function handlePack(config: PackConfig): Promise<void> {
   await runFileOp(config, {
     runSingle: runPackSingle,
     runMultiple: runPackMultiple,
-    runRunDir: (executionId, agent, model, inputFile) =>
-      runPackRunDir(executionId, agent, model, inputFile),
+    runRunDir: runPackRunDir,
     showResult: showPackResult,
   });
 }

--- a/packages/extension/src/frontend/agents/register.ts
+++ b/packages/extension/src/frontend/agents/register.ts
@@ -13,7 +13,7 @@ const log = createLog('AgentRegister');
 export async function promptToAddAgentToConfig(
   agentName: string,
   source: AgentSource,
-  category: 'workflow' | 'toolUse' = 'workflow',
+  category: 'workflow' | 'toolUse',
 ): Promise<void> {
   const roster = createWorkspaceAgentRosterController();
   const current = roster.getVisibleAgents(category).map((entry) => entry.name);

--- a/packages/extension/src/frontend/vscode/vscodeEditor.ts
+++ b/packages/extension/src/frontend/vscode/vscodeEditor.ts
@@ -76,7 +76,6 @@ export async function openFileInEditor(
   filePath: string,
   options: {
     line?: number;
-    column?: number;
     preserveFocus?: boolean;
     save?: boolean;
     /** Reuse an already-visible editor without re-showing it. */
@@ -84,7 +83,7 @@ export async function openFileInEditor(
   } = {},
 ): Promise<{ editor: vscode.TextEditor; absolutePath: string } | undefined> {
   try {
-    const { line, column, save, reuseVisible } = options;
+    const { line, save, reuseVisible } = options;
     const uri = vscode.Uri.file(WorkspaceFS.toAbsolute(filePath));
     const existingEditor = findVisibleEditor(uri);
     const preserveFocus = options.preserveFocus ?? false;
@@ -95,10 +94,7 @@ export async function openFileInEditor(
         : await showDocument(uri, existingEditor, preserveFocus);
 
     if (line !== undefined) {
-      const position = new vscode.Position(
-        toZeroBasedLine(line),
-        column ? Math.max(0, column - 1) : 0,
-      );
+      const position = new vscode.Position(toZeroBasedLine(line), 0);
       editor.selection = new vscode.Selection(position, position);
       editor.revealRange(
         new vscode.Range(position, position),

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -101,25 +101,6 @@ function selectedAgentId(session: SessionContextValue): string {
   return session.agent[session.sessionType];
 }
 
-function getDesktopLaunchMode(session: SessionContextValue): DesktopLaunchMode {
-  if (session.sessionType === SESSION_TYPES.WORKFLOW) return 'workflow';
-  return session.launchTarget === 'team' ? 'team' : 'interactive';
-}
-
-function resolveSessionHintKey(session: SessionContextValue): SessionHintKey {
-  // The team hint describes the launcher, so it takes precedence over the
-  // orchestrator hint (which describes the selected agent). Workflows always
-  // use a single agent, even if stale restored state still says "team".
-  if (isTeamLaunch(session)) return 'team';
-  if (
-    session.sessionType === SESSION_TYPES.TOOL_USE &&
-    session.isOrchestratorSelected
-  ) {
-    return 'orchestrator';
-  }
-  return session.sessionType;
-}
-
 @customElement('instruction-panel')
 export class InstructionPanel extends LitElement {
   static override styles = [
@@ -158,7 +139,19 @@ export class InstructionPanel extends LitElement {
   private renderSessionHint(session: SessionContextValue): unknown {
     if (!this.showSessionHint) return nothing;
 
-    const hintKey = resolveSessionHintKey(session);
+    // The team hint describes the launcher, so it takes precedence over the
+    // orchestrator hint (which describes the selected agent). Workflows
+    // always use a single agent, even if stale restored state still says
+    // "team".
+    let hintKey: SessionHintKey = session.sessionType;
+    if (isTeamLaunch(session)) {
+      hintKey = 'team';
+    } else if (
+      session.sessionType === SESSION_TYPES.TOOL_USE &&
+      session.isOrchestratorSelected
+    ) {
+      hintKey = 'orchestrator';
+    }
     const copy = SESSION_HINT_COPY[hintKey];
     // `keyed` forces the wrapping div to be re-created when the hint key
     // changes, which restarts the `session-hint-fade` CSS animation defined
@@ -502,6 +495,12 @@ export class InstructionPanel extends LitElement {
   private renderDesktopLaunchMode(
     session: SessionContextValue,
   ): TemplateResult {
+    let launchMode: DesktopLaunchMode = 'interactive';
+    if (session.sessionType === SESSION_TYPES.WORKFLOW) {
+      launchMode = 'workflow';
+    } else if (session.launchTarget === 'team') {
+      launchMode = 'team';
+    }
     return html`
       <wa-select
         id="desktopLaunchMode"
@@ -509,7 +508,7 @@ export class InstructionPanel extends LitElement {
         aria-label="Run mode"
         size="xs"
         placement="top"
-        .value=${getDesktopLaunchMode(session)}
+        .value=${launchMode}
         @change=${this.handleDesktopLaunchModeChange}
       >
         ${waIcon('diagram-project', { slot: 'start' })}

--- a/packages/extension/src/webview/frontend/styles.ts
+++ b/packages/extension/src/webview/frontend/styles.ts
@@ -26,14 +26,6 @@ export const mainViewStyles: CSSResult = css`
     min-height: 0;
   }
 
-  .view-header {
-    display: flex;
-    align-items: center;
-    gap: var(--wa-space-2xs);
-    padding: 0 var(--wa-space-3xs) var(--wa-space-2xs);
-    flex-shrink: 0;
-  }
-
   .main-content {
     flex: 1;
     display: flex;

--- a/packages/extension/src/webview/frontend/styles.ts
+++ b/packages/extension/src/webview/frontend/styles.ts
@@ -26,6 +26,14 @@ export const mainViewStyles: CSSResult = css`
     min-height: 0;
   }
 
+  .view-header {
+    display: flex;
+    align-items: center;
+    gap: var(--wa-space-2xs);
+    padding: 0 var(--wa-space-3xs) var(--wa-space-2xs);
+    flex-shrink: 0;
+  }
+
   .main-content {
     flex: 1;
     display: flex;

--- a/src/agent/implementations/flows/reflection/output/roundSummary.ts
+++ b/src/agent/implementations/flows/reflection/output/roundSummary.ts
@@ -36,7 +36,6 @@ export async function summarizeRound(
   currRound: number,
   options: {
     endTurn: boolean;
-    stage?: StageHandle;
     mapping?: RoundFileMapping;
     isRewrite?: boolean;
     /** Snapshot-resolved base files. Required for in-place workflows so
@@ -49,7 +48,7 @@ export async function summarizeRound(
   return withOutputStage(
     deps,
     `Finalize r${currRound}`,
-    options.stage,
+    undefined,
     async (scope): Promise<RoundSummary> => {
       const data = ensureRoundData(state, currRound);
       data.rawOutput ??= outputFile;

--- a/src/agent/modelHandlers/google/googleHandlerShared.ts
+++ b/src/agent/modelHandlers/google/googleHandlerShared.ts
@@ -26,7 +26,7 @@ export interface GoogleClientCache {
 }
 
 interface ResolveGoogleClientParams {
-  /** SDK surface label used in debug logs, e.g. `'Native'` or `'Interactions'`. */
+  /** SDK surface label used in debug logs, e.g. `'Interactions'`. */
   sdkLabel: string;
   credential: ResolvedClientCredential;
   logger: AgentTrace;

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -598,7 +598,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   ): Promise<GoogleGenAI> {
     const credential = await this.resolveClientCredential(selection);
     return resolveGoogleClient({
-      sdkLabel: this.sdkLabel,
+      sdkLabel: 'Interactions',
       credential,
       logger: this.logger,
       cached: this.googleClient,
@@ -755,11 +755,6 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   // ===========================================================================
   // Capability getters / auth (REUSE / PORT from the chat handler)
   // ===========================================================================
-
-  /** `apiVersion` is left unset for v0 — see spec §6.4. */
-  protected get sdkLabel(): string {
-    return 'Interactions';
-  }
 
   /**
    * Optional `resolution` field for an Interactions media `Content`: Gemini 3

--- a/src/agent/modelHandlers/openai/openAIResponseErrors.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseErrors.ts
@@ -25,19 +25,15 @@ type OpenAIBackgroundTerminalState = Pick<
   'id' | 'status' | 'error' | 'incomplete_details'
 >;
 
-function setProviderHint(error: unknown, provider: string): void {
-  if (error && typeof error === 'object' && !('provider' in error)) {
-    (error as { provider?: string }).provider = provider;
-  }
-}
-
 /** Normalize OpenAI Responses errors at the provider boundary. */
 export function normalizeOpenAIResponseError(
   error: unknown,
   provider: string,
 ): ProviderError {
   tagOpenAISdkError(error, provider);
-  setProviderHint(error, provider);
+  if (error && typeof error === 'object' && !('provider' in error)) {
+    (error as { provider?: string }).provider = provider;
+  }
   return normalizeProviderError(error);
 }
 

--- a/src/agent/review/reviewIssues.ts
+++ b/src/agent/review/reviewIssues.ts
@@ -74,7 +74,7 @@ export function createReviewIssue(report: ReviewIssueReport): ReviewIssue {
   };
 }
 
-export interface ReviewInstructionInput {
+interface ReviewInstructionInput {
   /** Human-readable description of the diff base (e.g. "main branch (origin/main)"). */
   baseDescription: string;
   changedFiles: string[];

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -95,7 +95,7 @@ export interface AgentLaunchContext extends AgentCore {
   disposeTrace: () => void;
 }
 
-export interface AgentLaunchInput {
+interface AgentLaunchInput {
   config: AgentConfig;
   executionId: ExecutionId;
   streamTabIdOverride?: StreamTabId;

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -1257,7 +1257,7 @@ export async function settleLiveSessionExecutions(
 let cachedDefaultSession: SessionHandle | undefined;
 let defaultSessionFallbackWarned = false;
 
-export type DefaultSessionInit = Omit<SessionHandleInit, 'flushers'>;
+type DefaultSessionInit = Omit<SessionHandleInit, 'flushers'>;
 
 /** Install the process-default session after its transcript store is valid. */
 export function initializeDefaultSession(

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -44,9 +44,9 @@ interface WorkflowResumeData {
   readonly modelHandlerCompatibilityKey?: ModelHandlerCompatibilityKey | null;
 }
 
-export type SessionResumeData = ToolUseResumeData | WorkflowResumeData;
+type SessionResumeData = ToolUseResumeData | WorkflowResumeData;
 
-export interface SessionResumeRetrievalOptions {
+interface SessionResumeRetrievalOptions {
   readonly parentStreamId?: StreamTabId | undefined;
 }
 

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -16,7 +16,7 @@ import {
   type StreamTransitionCause,
 } from '@shared/streams/streamStatus';
 
-export interface StreamStatusEmitOptions {
+interface StreamStatusEmitOptions {
   substate?: StreamSubstate;
 }
 

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -22,7 +22,7 @@ import { resolveAgentSettingTools } from './agentSettingTools';
 
 const CHANNEL = 'agentLoad';
 
-export interface AgentYamlValidationResult {
+interface AgentYamlValidationResult {
   name: string;
   settings: AgentSettingInput;
   prompts: AgentPromptInput;

--- a/src/agent/runtime/agentToolResolution.ts
+++ b/src/agent/runtime/agentToolResolution.ts
@@ -48,7 +48,7 @@ import {
 
 const log = createLog('AgentToolResolution');
 
-export interface ResolveAgentToolsInput {
+interface ResolveAgentToolsInput {
   tools: AgentToolUseSetting['tools'];
   /** Registry to resolve tool definitions from. Defaults to the global registry. */
   registry?: IToolRegistry;

--- a/src/agent/runtime/executionInteractionOwnership.ts
+++ b/src/agent/runtime/executionInteractionOwnership.ts
@@ -24,7 +24,7 @@ import type {
  * {@link ExecutionInteractionOwnership.ownerOf} can answer with the scope
  * itself instead of a parallel identity.
  */
-export interface ExecutionInteractionScope {
+interface ExecutionInteractionScope {
   /**
    * Claim `executionId` and everything it goes on to spawn: once the run's
    * handle is tracked, its child stream is owned too, so descendants join this

--- a/src/agent/runtime/helperModel.ts
+++ b/src/agent/runtime/helperModel.ts
@@ -27,7 +27,7 @@ export interface HelperModelKit {
   modelName: string;
 }
 
-export type HelperModelResult =
+type HelperModelResult =
   { kit: HelperModelKit } | { kit: undefined; reason: string };
 
 /** Resolve the configured helper model, create a non-streaming handler, and obtain a client. */
@@ -61,7 +61,7 @@ export async function createHelperModelKit(
 }
 
 /** A single non-streaming helper-model text completion. */
-export interface HelperModelCompletion {
+interface HelperModelCompletion {
   /** User message content. */
   userPrompt: string;
   /** Optional system prompt. */

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -24,7 +24,7 @@ interface ResolvedResumeState {
   readonly parentStreamId?: StreamTabId;
 }
 
-export type ResumeStateResolution =
+type ResumeStateResolution =
   | { readonly status: 'resolved'; readonly state: ResolvedResumeState }
   | { readonly status: 'read-failed'; readonly error: unknown }
   | {

--- a/src/agent/runtime/restartRepair.ts
+++ b/src/agent/runtime/restartRepair.ts
@@ -74,13 +74,13 @@ export interface RestartRepairOptions {
 }
 
 /** One stream skipped because its execution's owner is provably alive. */
-export interface ActiveOwnerSkip {
+interface ActiveOwnerSkip {
   readonly streamId: StreamTabId;
   readonly executionId: ExecutionId;
   readonly owner: InstanceOwnerRecord;
 }
 
-export interface RestartRepairResult {
+interface RestartRepairResult {
   /**
    * Streams left untouched because a live owner holds their execution. The
    * caller watches each owner's instance exit and re-runs repair on that

--- a/src/agent/runtime/terminalResultToast.ts
+++ b/src/agent/runtime/terminalResultToast.ts
@@ -30,7 +30,7 @@ import {
 import type { SessionHostInteractions } from './HostInteractions';
 import type { SessionHandle } from './SessionHandle';
 
-export type TerminalResultToast =
+type TerminalResultToast =
   | {
       readonly type: 'instruction';
       readonly payload: RequestShowInstructionPayload;

--- a/src/agent/runtime/toolInjection.ts
+++ b/src/agent/runtime/toolInjection.ts
@@ -9,7 +9,7 @@ import type { RegisteredToolName } from '@tools/registry';
  * after `initPlatform()`. Core flow code iterates the registry — it doesn't
  * know which features are registered.
  */
-export interface ConditionalToolInjection {
+interface ConditionalToolInjection {
   readonly toolName: RegisteredToolName;
   shouldInject(): boolean;
 }

--- a/src/auth/oauth/formTokenClient.ts
+++ b/src/auth/oauth/formTokenClient.ts
@@ -41,7 +41,6 @@ export interface OAuthFormEndpoint<
   readonly ErrorType: ProviderAuthErrorCtor;
   readonly tokenResponseSchema: z.ZodType<TTokens>;
   readonly requestTimeoutMs?: number;
-  readonly formHeaders?: Readonly<Record<string, string>>;
 }
 
 /** Combine an optional caller signal with a request timeout. */
@@ -55,10 +54,7 @@ export function oauthRequestSignal(
 
 /** Form-urlencoded POST. Throws the provider error type on network failure. */
 export async function postOAuthForm(
-  endpoint: Pick<
-    OAuthFormEndpoint,
-    'ErrorType' | 'requestTimeoutMs' | 'formHeaders'
-  >,
+  endpoint: Pick<OAuthFormEndpoint, 'ErrorType' | 'requestTimeoutMs'>,
   url: string,
   body: URLSearchParams,
   signal?: AbortSignal,
@@ -66,7 +62,7 @@ export async function postOAuthForm(
   try {
     return await fetch(url, {
       method: 'POST',
-      headers: { ...DEFAULT_FORM_HEADERS, ...endpoint.formHeaders },
+      headers: DEFAULT_FORM_HEADERS,
       body,
       signal: oauthRequestSignal(
         endpoint.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,

--- a/src/auth/xai/xaiSessionTypes.ts
+++ b/src/auth/xai/xaiSessionTypes.ts
@@ -57,12 +57,10 @@ export const XaiDeviceCodeSchema = z.object({
 });
 export type XaiDeviceCode = z.infer<typeof XaiDeviceCodeSchema>;
 
-export type XaiAuthErrorKind = SubscriptionOAuthErrorKind;
-
 export class XaiAuthError extends SubscriptionOAuthError {
   constructor(
     message: string,
-    kind: XaiAuthErrorKind,
+    kind: SubscriptionOAuthErrorKind,
     status?: number,
     options?: ErrorOptions,
   ) {

--- a/src/controllers/settingsView/backend/SettingsAgentActions.ts
+++ b/src/controllers/settingsView/backend/SettingsAgentActions.ts
@@ -129,7 +129,7 @@ export function createSettingsAgentActions(
           ? path.relative(sourceDir, entryPath)
           : path.basename(entryPath);
         const targetPath = path.join(customDir, relativePath);
-        if (!isInside(customDir, targetPath)) {
+        if (!isStrictlyWithin(customDir, targetPath)) {
           await options.showErrorMessage(
             'Refusing to copy: target path escapes the custom agents directory.',
           );
@@ -166,7 +166,7 @@ export function createSettingsAgentActions(
         }
 
         const customDir = await options.getCustomAgentDirectory();
-        if (!isInside(customDir, entryPath)) {
+        if (!isStrictlyWithin(customDir, entryPath)) {
           await options.showErrorMessage(
             'Refusing to delete: file is not inside the custom agents directory.',
           );
@@ -197,7 +197,3 @@ const FAILURE_MESSAGES: Readonly<Record<AgentFileCommand, string>> = {
   deleteCustomAgent: 'Failed to delete custom agent',
   revealAgentFile: 'Failed to reveal agent file',
 };
-
-function isInside(parentDir: string, candidatePath: string): boolean {
-  return isStrictlyWithin(path.resolve(parentDir), path.resolve(candidatePath));
-}

--- a/src/shared/constants/latexConfig.ts
+++ b/src/shared/constants/latexConfig.ts
@@ -12,7 +12,7 @@ import { WorkspaceStateKey } from '@shared/state/stateKeys';
  */
 
 /** Numeric range for a setting (used by Zod schemas and UI inputs). */
-export interface NumericRange {
+interface NumericRange {
   readonly min: number;
   readonly max?: number;
 }
@@ -24,8 +24,7 @@ export const LATEXDIFF_MATH_MARKUP_VALUES = [
   'coarse',
   'fine',
 ] as const;
-export type LatexdiffMathMarkupValue =
-  (typeof LATEXDIFF_MATH_MARKUP_VALUES)[number];
+type LatexdiffMathMarkupValue = (typeof LATEXDIFF_MATH_MARKUP_VALUES)[number];
 
 /** Allowed values for the LaTeX formatter selector. */
 export const LATEX_FORMATTER_VALUES = [
@@ -33,7 +32,7 @@ export const LATEX_FORMATTER_VALUES = [
   'tex-fmt',
   'none',
 ] as const;
-export type LatexFormatterValue = (typeof LATEX_FORMATTER_VALUES)[number];
+type LatexFormatterValue = (typeof LATEX_FORMATTER_VALUES)[number];
 
 /** Documented defaults — match the values that used to live in package.json. */
 export const LATEX_CONFIG_DEFAULTS = {

--- a/src/shared/copy/instructionActionHint.ts
+++ b/src/shared/copy/instructionActionHint.ts
@@ -30,7 +30,7 @@ const INSTRUCTION_ACTION_HINTS = {
   },
 } as const;
 
-export type InstructionActionHintStyle = keyof typeof INSTRUCTION_ACTION_HINTS;
+type InstructionActionHintStyle = keyof typeof INSTRUCTION_ACTION_HINTS;
 
 /**
  * The ` (hint, hint)` suffix for an instruction's action tokens, or `''` when

--- a/src/shared/utils/clipboard.ts
+++ b/src/shared/utils/clipboard.ts
@@ -19,10 +19,7 @@ export async function copyTextToClipboard(text: string): Promise<boolean> {
 }
 
 interface CopyFeedbackOptions {
-  defaultTitle?: string;
-  successTitle?: string;
   successClass?: string;
-  resetDelay?: number;
 }
 
 /**
@@ -39,14 +36,9 @@ export async function copyWithFeedback(
   }
 
   const defaultTitle =
-    options.defaultTitle ??
-    button.dataset.defaultTitle ??
-    button.getAttribute('title') ??
-    'Copy text';
-  const successTitle =
-    options.successTitle ?? button.dataset.successTitle ?? 'Copied!';
+    button.dataset.defaultTitle ?? button.getAttribute('title') ?? 'Copy text';
+  const successTitle = button.dataset.successTitle ?? 'Copied!';
   const successClass = options.successClass ?? 'copy-success';
-  const resetDelay = options.resetDelay ?? COPY_RESET_DELAY_MS;
 
   function setButtonState(title: string, showSuccess: boolean): void {
     button.classList.toggle(successClass, showSuccess);
@@ -71,7 +63,7 @@ export async function copyWithFeedback(
   const timeoutId = window.setTimeout(() => {
     setButtonState(defaultTitle, false);
     delete button.dataset.copyResetTimeoutId;
-  }, resetDelay);
+  }, COPY_RESET_DELAY_MS);
 
   button.dataset.copyResetTimeoutId = String(timeoutId);
   button.dataset.defaultTitle = defaultTitle;

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -61,12 +61,10 @@ export class TaskRunFileService {
 
     await ensureRunDir(this.executionId);
 
-    const linkTargets = new Set<FileLocation>(baseFiles);
-
-    // Add extra link files, filtering out any null/undefined entries
-    for (const extra of options.linkFiles ?? []) {
-      if (extra) linkTargets.add(extra);
-    }
+    const linkTargets = new Set<FileLocation>([
+      ...baseFiles,
+      ...(options.linkFiles ?? []),
+    ]);
 
     await Promise.all(
       baseFiles.map((target) => this.captureOriginalSnapshot(target)),

--- a/supabase/functions/get-agent-config/index.ts
+++ b/supabase/functions/get-agent-config/index.ts
@@ -67,7 +67,7 @@ Deno.serve(async (req: Request) => {
     // Description comes from YAML (parsed client-side), not DB
     const { data: agent, error: agentError } = await userClient
       .from('remote_agents')
-      .select('id, name, storage_path, visibility, agent_category')
+      .select('name, storage_path, visibility, agent_category')
       .eq('name', body.agentName)
       .single();
 

--- a/supabase/functions/github-app-token-exchange/auth.ts
+++ b/supabase/functions/github-app-token-exchange/auth.ts
@@ -1,6 +1,6 @@
 import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'jose';
 
-export const GITHUB_OIDC_AUDIENCE = 'texra-github-action';
+const GITHUB_OIDC_AUDIENCE = 'texra-github-action';
 const GITHUB_OIDC_ISSUER = 'https://token.actions.githubusercontent.com';
 const GITHUB_OIDC_JWKS = createRemoteJWKSet(
   new URL(`${GITHUB_OIDC_ISSUER}/.well-known/jwks`),

--- a/supabase/functions/github-app-token-exchange/githubApp.ts
+++ b/supabase/functions/github-app-token-exchange/githubApp.ts
@@ -46,7 +46,7 @@ async function githubJson<T>(path: string, token: string): Promise<T> {
   return (await response.json()) as T;
 }
 
-export interface GitHubRepositoryIdentity {
+interface GitHubRepositoryIdentity {
   id: number;
   ownerId: number;
   defaultBranch: string;


### PR DESCRIPTION
Third and final round, after #11189 (core `src/`) and #11193 (host packages). **37 files, +71 / −128.**

Run in two phases, answering the two open questions left by rounds 1–2: *is there anything in the areas we didn't sweep*, and *was the declined-candidate queue worth working*.

## Phase A — the cold surface (38 agents)

Rounds 1–2 covered every production file that **changed** since `v0.40.2`. Phase A took the exact complement: the **612 files nobody had touched** during those eight days of heavy refactoring — 60k LOC, concentrated in `packages/extension` (135), `packages/cli` (98), `src/shared` (83), `src/agent` (75).

The prompt reframed the question for cold code. Not "is this tidy?" but *"does this still have a reason to exist?"* — a helper whose only caller the churn deleted, a compat reader whose writer is gone, a workaround whose cause was fixed elsewhere, a consolidation that stopped halfway.

**Result: 17 files, net −32.**

## Phase B — the recorded queue (12 agents, disjoint write scopes)

Rounds 1–2 declined 677 candidates, mostly because the fix needed a file outside the agent's own slice. I bucketed 372 of them by owning area into twelve non-overlapping write scopes so they could run concurrently without collision.

Agents were told explicitly that **a note is a lead, not evidence** — most entries are honest rejections, and the concrete ones were hours old with two PRs merged since. Re-verification was mandatory. **Twelve notes came back refuted or already fixed**, including a `preserveMarkdownPrefix` param that looked unused only because the original grep missed a multi-line call site, and a `workspaceFromSnapshot` "pass-through" that is a deliberately narrower entry point.

**Result: 20 files, net −25.**

## What it found

| Category | Count | Notes |
| --- | --- | --- |
| Dead exports / types | 18 | no consumer outside the declaring file |
| Pass-through inline | 7 | `attachRunProgressRenderer`, `setProviderHint`, two `InstructionPanel` helpers, and `packCommands`' `runRunDir` identity wrapper — whose sibling `cleanCommands` already passed the function directly, proving the wrapper was never needed |
| Dead params / options | 3 | see below |
| Speculative generality | 1 | `OAuthFormEndpoint.formHeaders`, set by neither of its two implementors |
| Stale comments | 2 | comments naming machinery a prior PR deleted |

The three dead options are the most interesting, because each had a plausible-looking reason to exist:

- `Select.onBoundaryEscape` — no caller ever supplied it, so `props.onBoundaryEscape?.(direction)` was always a no-op. Focus escape is routed through Tab at the App level instead, which the adjacent comment (also corrected) already said.
- `openFileInEditor`'s `column` — all three call sites omit it, so the cursor column was always 0.
- `DesktopCommandPaletteOptions.canOpen` — one caller, passing `() => true`. Its documented purpose (suppress the palette while a first-run walkthrough is visible) is not wired up anywhere, so the `if (canOpen?.() === false) return` guard was unreachable. **If that suppression is intended future work rather than an abandoned idea, this is the hunk to push back on.**

## Honest scope note

Net −57 from 50 agents. The notable result is that **the cold surface was cleaner than the churned surface, per file** — the opposite of the "untouched code accumulates debt" assumption. Phase A averaged one edit per 34 files; rounds 1–2 averaged one per 10. Untouched code here is untouched because it was already settled, not because it was neglected.

Taken with rounds 1–2, this closes the sweep: −92, −323, −57 across 1,621 production files. Per-file simplification of this codebase is exhausted; remaining value is in structural consolidation, not another pass.


## Post-review correction

The `texra-ai` review caught a real defect and it is reverted in 091150e: the sweep deleted `mainViewStyles`' `.view-header` rule as unreachable, on the strength of grepping `MainApp.ts`'s own template for the class name. The markup actually comes from the shared `renderViewHeader` helper (`@shared/wa/viewHeader`), which `MainApp` renders on the VS Code extension host (`!isDesktopHost`). Since `mainViewStyles` is last in that component's cascade, the rule was the only source of the header's `gap`, `padding`, and `flex-shrink` — `commonViewStyles` supplies only display/justify/align/margin. Deleting it changed the extension header's layout. I verified the reviewer's reading against the tree before reverting; the earlier "unreachable" claim in this description was wrong and is corrected above.

The review's second note is a non-defect I agree with: `taskRunStorage.ts` drops an `if (extra)` filter that was dead given `FileLocation[]` typing and the sole caller's own null-filtering. Worth remembering only if a future caller loosens that typing.

## Verified

Run locally on a clean `origin/main` worktree, all green:

- `typecheck` — all six projects, and **every per-package tsconfig** individually: desktop's `main`/`preload`/`renderer` and `packages/cli/tsconfig.scripts.json`. (#11193 shipped a renderer break because I had only run the top-level desktop config; that gap is closed.)
- repo-wide `npm run lint`, `prettier --check`
- `check:dead-code-ratchet` (8 findings, matches baseline — no widening)
- `check:browser-safe-utils`, `check:guidance-refs`, `check:tsconfig-paths`, `check:package-contributes`
- full `vitest run` — **842 files, 10,305 tests passed**, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UQRwTBAasoZuFhCm42mrZ


## Net elements (R6)

- 37 production files changed, with 71 additions and 128 deletions, for a net reduction of 57 lines.
- 24 exported declarations were removed or made file-private, with no exported declarations added.
- No test files are changed.

## Consumer counts (R8)

- Every removed export was searched repo-wide and had zero consumers outside its declaring file.
- Every inlined helper had one caller, while removed callback options and fields had zero passers or readers.
- No event, subscription, or output path is deleted or re-routed.
