### PR TITLE
fix(prompt): surface primary file read failures

### DIFF
--- a/src/agent/prompt/userVars.ts
+++ b/src/agent/prompt/userVars.ts
@@ -430,8 +430,14 @@ async function getFileVars(
         ? await getXmlFormatFromReadableFiles(allFiles)
         : { xml: null, readableFiles: [], skipped: [] };
     const primaryFile = readableFiles[0];
-    if (primaryFile != null) {
-      await setVarFromFile(primaryFile, prefix, userVars);
+    const primaryFileOk =
+      primaryFile == null
+        ? false
+        : await setVarFromFile(primaryFile, prefix, userVars);
+    if (primaryFile != null && !primaryFileOk) {
+      logger.warn(
+        `Failed to load primary file into prompt variables: ${primaryFile}`,
+      );
     }
 
     // A dropped file changes what the model sees, so report it on the run's own
@@ -442,14 +448,9 @@ async function getFileVars(
       );
     }
 
-    // The card is derived from the same read that fills the list vars
-    // (`ALL_*S`, `*_FILES`, `LIST_OF_ALL_*S`), so a row's `ok` and that file's
-    // presence in the prompt XML come from one probe and cannot disagree.
-    //
-    // NOT closed here: `setVarFromFile` above re-reads the primary file to fill
-    // `*_FILE`/`*_CONTENT`, and swallows its own failure on a module channel.
-    // A row can therefore still read `ok` while that one pair is null. Separate
-    // probe, separate call path — it needs its own change.
+    // The list rows use the read that fills the list vars. The primary row also
+    // reflects the second read that fills its `*_FILE`/`*_CONTENT` pair, so the
+    // card cannot report success while those prompt variables remain null.
     //
     // Tool-use agents get no card. Media files are excluded: they have no user
     // vars (display-only in Init) and MediaExtractionNode already logs them
@@ -463,7 +464,10 @@ async function getFileVars(
       logFileCategory(
         logger,
         cardLabel,
-        allFiles.map((file) => ({ path: file, ok: readable.has(file) })),
+        allFiles.map((file) => ({
+          path: file,
+          ok: file === primaryFile ? primaryFileOk : readable.has(file),
+        })),
       );
     }
 


### PR DESCRIPTION
## Summary

- capture the primary file's second-read result when filling prompt variables
- warn on the run trace when that read fails
- make the files-loaded card reflect that failure instead of reporting a false success

## Issue acceptance gates

Closes #11039.

- `getFileVars` now consumes `setVarFromFile`'s boolean result.
- A failed primary-file read is reported through the run's `AgentTrace`.
- The primary files-loaded row is marked failed when `*_FILE` and `*_CONTENT` could not be populated.
- Other callers and `setVarFromFile`'s absolute mode are unchanged.

## Single source of truth

`setVarFromFile`'s return value now owns the success state for the primary `*_FILE`/`*_CONTENT` read and its card row.

## Duplication and abstraction budget

No abstraction added. The existing read result is consumed directly instead of deriving success from the earlier list read.

## Net elements (R6)

- 1 production file changed
- 15 lines added, 11 removed, net +4
- no exports, classes, interfaces, or enums added or removed

## Consumer counts (R8)

n/a. No emit path or export was deleted or rerouted. The existing card emission now receives the captured primary-read result.

## Host impact

Extension: Shared prompt construction reports accurate primary-file state.

Desktop: Shared prompt construction reports accurate primary-file state.

CLI: Shared prompt construction reports accurate primary-file state.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --check src/agent/prompt/userVars.ts`
- ESLint on `src/agent/prompt/userVars.ts`
- `npm run typecheck:workspace`
- `git diff --check`
- independent code review found no issues

No tests were modified or added, per task constraints.
