### PR TITLE
fix(settings): lock the last active model switch

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -154,7 +154,16 @@ export class ModelSelectionList extends LitElement {
 
   private renderAvailabilityIcon(
     model: ModelSelectionItem,
+    isLastEnabledActiveModel: boolean,
   ): TemplateResult | typeof nothing {
+    if (isLastEnabledActiveModel) {
+      const title = 'At least one active model must stay enabled';
+      return waIcon('triangle-exclamation', {
+        className: 'model-row-icon model-row-icon--warning',
+        label: title,
+        title,
+      });
+    }
     if (!model.disabled) return nothing;
 
     // The backend resolves the label alongside `disabled`; the Models tab
@@ -173,7 +182,8 @@ export class ModelSelectionList extends LitElement {
   }
 
   private renderModelRow(model: ModelSelectionItem): TemplateResult {
-    const isLastEnabledModel =
+    // Retired rows remain removable and do not satisfy the usable-model floor.
+    const isLastEnabledActiveModel =
       model.enabled &&
       model.availability !== 'retired' &&
       this.models.filter(
@@ -185,7 +195,9 @@ export class ModelSelectionList extends LitElement {
       <div class="model-row">
         <wa-switch
           ?checked=${model.enabled}
-          ?disabled=${(model.disabled && !model.enabled) || isLastEnabledModel}
+          ?disabled=${
+            (model.disabled && !model.enabled) || isLastEnabledActiveModel
+          }
           @change=${(e: Event) => {
             const checked = (e.target as WaSwitch).checked;
             postMessage(SETTINGS_VIEW_COMMANDS.SET_MODEL_ENABLED, {
@@ -201,7 +213,7 @@ export class ModelSelectionList extends LitElement {
               ? html`<span class="model-route">· ${model.routeLabel}</span>`
               : nothing
           }
-          ${this.renderAvailabilityIcon(model)}
+          ${this.renderAvailabilityIcon(model, isLastEnabledActiveModel)}
           ${
             isExpensiveModel(model.provider, model.name)
               ? waIcon('triangle-exclamation', {

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -173,11 +173,19 @@ export class ModelSelectionList extends LitElement {
   }
 
   private renderModelRow(model: ModelSelectionItem): TemplateResult {
+    const isLastEnabledModel =
+      model.enabled &&
+      model.availability !== 'retired' &&
+      this.models.filter(
+        (candidate) =>
+          candidate.enabled && candidate.availability !== 'retired',
+      ).length === 1;
+
     return html`
       <div class="model-row">
         <wa-switch
           ?checked=${model.enabled}
-          ?disabled=${model.disabled && !model.enabled}
+          ?disabled=${(model.disabled && !model.enabled) || isLastEnabledModel}
           @change=${(e: Event) => {
             const checked = (e.target as WaSwitch).checked;
             postMessage(SETTINGS_VIEW_COMMANDS.SET_MODEL_ENABLED, {


### PR DESCRIPTION
## Summary

- disable the sole enabled non-retired model's switch in Settings → Models
- preserve removal for enabled retired rows
- explain the disabled active-model floor with the row's warning affordance
- keep the shared writer as the authoritative race-safe invariant

## Issue acceptance gates

Closes #11088.

- The final active model's on switch is disabled.
- The disabled switch explains that at least one active model must stay enabled.
- Enabled retired models remain removable and do not satisfy the usable-model floor.
- Disabled unavailable models remain impossible to enable.
- The backend writer still rejects invalid mutations from stale or non-UI callers.

## Single source of truth

`setModelEnabled` remains the authoritative enabled-list writer. `ModelSelectionList` adds the host-specific usable-model guard requested by #11088. It deliberately excludes retired rows because they cannot provide a usable picker choice and must remain removable; startup reconciliation removes retired entries from the persisted list.

## Duplication and abstraction budget

No abstraction or state added. The component derives the guard directly from its existing model snapshot and reuses the existing warning-icon convention.

## Net elements (R6)

- 1 production file changed
- 22 lines added, 2 removed, net +20
- no exports, classes, interfaces, or enums added or removed

## Consumer counts (R8)

n/a. No emit path or export was deleted or rerouted. The existing switch continues to send the same command when enabled.

## Host impact

Extension: Settings disables and explains the final active model switch.

Desktop: The shared Settings webview disables and explains the final active model switch.

CLI: No change. The shared writer continues to enforce its persisted-list invariant.

## Scheduled refactoring

None.

## Validation

- Prettier check on `ModelSelectionList.ts`
- ESLint on `ModelSelectionList.ts`
- `npm run typecheck:workspace`
- focused existing model-selection/controller tests: 16 passed
- independent code review found no issues
- `git diff --check`

No tests were modified or added, per task constraints.
