### PR TITLE
refactor(settings): derive latex snapshots from catalog

### DIFF
--- a/packages/desktop/src/main/desktopToolingSettingsController.ts
+++ b/packages/desktop/src/main/desktopToolingSettingsController.ts
@@ -1,5 +1,5 @@
 import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
-import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
+import type { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
 import type { ToolTerminalAction } from '@controllers/settingsView/ToolDashboardData';
 import { appSignals } from '@eventBus/AppSignals';
 import { platform } from '@platform/platform';
@@ -9,6 +9,7 @@ import type {
   ToolCommandKind,
   ToolDashboardItem,
 } from '@shared/schemas';
+import { buildSettingsSnapshotMessage } from '@shared/settingsView/handlers/settingsSnapshot';
 import type { SettingsStatePorts } from '@shared/settingsView/types';
 import { unsupported } from '@shared/utils/dispatcher';
 import type { ExternalToolCheckResult } from '@tools/toolAvailability';
@@ -56,7 +57,8 @@ interface DefaultDesktopToolingSettingsControllerOptions extends SettingsStatePo
     run(command: string): Promise<void>;
   };
   readonly latexToolingController: LatexToolingController;
-  readonly latexConfigPersistenceController: LatexConfigPersistenceController;
+  /** @deprecated Test-only compatibility seam; production snapshots use the catalog. */
+  readonly latexConfigPersistenceController?: LatexConfigPersistenceController;
 }
 
 export interface DesktopToolingSettingsController {
@@ -117,9 +119,14 @@ export class DefaultDesktopToolingSettingsController implements DesktopToolingSe
 
   postLatexConfigValues(): void {
     this.options.renderer.postToRenderer(
-      this.options.latexConfigPersistenceController.buildConfigMessage(
-        (key) => this.options.workspaceState.get(key),
-        platform().config,
+      buildSettingsSnapshotMessage(
+        'latex',
+        {
+          config: platform().config,
+          workspaceState: this.options.workspaceState,
+          globalState: this.options.globalState,
+        },
+        'desktop',
       ),
     );
   }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -36,7 +36,6 @@ import {
   TEAM_LAUNCH_CONTINUE_LABEL,
   TEAM_LAUNCH_SIGN_IN_LABEL,
 } from '@common/teams/TeamPlan';
-import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
 import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
 import { prepareMainViewExecutionRequest } from '@controllers/mainView/MainViewExecutionController';
 import { SubscriptionUsageService } from '@controllers/modelAccess/subscriptionUsage/SubscriptionUsageService';
@@ -873,7 +872,6 @@ function createWindow(options: {
         }),
         onDetectionError: reportBackgroundError,
       }),
-      latexConfigPersistenceController: new LatexConfigPersistenceController(),
     },
   );
   const settingsUi: DesktopSettingsUiHost = {

--- a/packages/extension/src/settingsView/frontend/slices/latexSlice.ts
+++ b/packages/extension/src/settingsView/frontend/slices/latexSlice.ts
@@ -7,7 +7,14 @@
  */
 
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import type { SettingsViewOutboundHandlerRegistry } from '@shared/schemas';
+import type {
+  LatexConfigValues,
+  SettingsViewOutboundHandlerRegistry,
+} from '@shared/schemas';
+import {
+  LATEX_FIELD_TO_KEY,
+  LATEX_REPLACEMENT_FIELD_TO_CONFIG_KEY,
+} from '@shared/constants/latexConfig';
 
 import {
   inlineCriticismEnabled,
@@ -17,6 +24,11 @@ import {
   latexSettingsStatus,
 } from '../settingsState';
 
+const LATEX_CONFIG_FIELD_TO_KEY = {
+  ...LATEX_FIELD_TO_KEY,
+  ...LATEX_REPLACEMENT_FIELD_TO_CONFIG_KEY,
+} as const satisfies Record<keyof LatexConfigValues, string>;
+
 export const latexHandlers = {
   [SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_SETTINGS_STATUS]: (data) => {
     latexSettingsStatus.set(data.settings);
@@ -24,7 +36,14 @@ export const latexHandlers = {
   },
 
   [SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES]: (data) => {
-    latexConfigValues.set(data.values);
+    latexConfigValues.set(
+      Object.fromEntries(
+        Object.entries(LATEX_CONFIG_FIELD_TO_KEY).map(([field, key]) => [
+          field,
+          data.values[key],
+        ]),
+      ) as LatexConfigValues,
+    );
     latexConfigValuesLoaded.set(true);
   },
 

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -637,7 +637,9 @@ export class LaTeXTab extends LitElement {
   }): TemplateResult {
     const effective = opts.currentValue ?? opts.defaultValue;
     const enabled = new Set(effective);
-    const isCustom = opts.currentValue !== undefined;
+    const isCustom =
+      effective.length !== opts.defaultValue.length ||
+      effective.some((value, index) => value !== opts.defaultValue[index]);
     return html`
       <div class="settings-row replacement-groups-row">
         <div class="settings-row-text">
@@ -687,6 +689,7 @@ export class LaTeXTab extends LitElement {
     currentValue: Record<string, string> | undefined;
   }): TemplateResult {
     const value = opts.currentValue ?? {};
+    const isCustom = Object.keys(value).length > 0;
     const error = this.replacementJsonErrors[opts.field];
     const controlId = `latex-setting-${opts.field}`;
     return html`
@@ -715,12 +718,8 @@ export class LaTeXTab extends LitElement {
           }
         </div>
         <div class="settings-row-control">
-          ${this.renderSettingStatusIcon(opts.currentValue !== undefined)}
-          ${
-            opts.currentValue !== undefined
-              ? this.renderResetButton(opts.field, '{}')
-              : nothing
-          }
+          ${this.renderSettingStatusIcon(isCustom)}
+          ${isCustom ? this.renderResetButton(opts.field, '{}') : nothing}
         </div>
       </div>
     `;
@@ -894,7 +893,7 @@ export class LaTeXTab extends LitElement {
     currentValue: boolean | undefined;
   }): TemplateResult {
     const effective = opts.currentValue ?? opts.defaultValue;
-    const isCustom = opts.currentValue !== undefined;
+    const isCustom = effective !== opts.defaultValue;
     // No status icon: the switch already carries the on/off state, matching
     // the toggle rows in the other settings tabs.
     const controlId = `latex-setting-${opts.field}`;
@@ -960,7 +959,7 @@ export class LaTeXTab extends LitElement {
     max?: number;
   }): TemplateResult {
     const effective = opts.currentValue ?? opts.defaultValue;
-    const isCustom = opts.currentValue !== undefined;
+    const isCustom = effective !== opts.defaultValue;
     const controlId = `latex-setting-${opts.field}`;
     return this.renderConfigRow({
       label: opts.label,
@@ -1013,7 +1012,7 @@ export class LaTeXTab extends LitElement {
     withDescription: boolean;
   }): TemplateResult {
     const effective = opts.currentValue ?? opts.defaultValue;
-    const isCustom = opts.currentValue !== undefined;
+    const isCustom = effective !== opts.defaultValue;
     const controlId = `latex-setting-${opts.field}`;
     const options = catalogEnumChoices<LatexConfigValueFor<F>>(
       LATEX_CONFIG_FIELD_TO_KEY[opts.field],

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -639,7 +639,7 @@ export class LaTeXTab extends LitElement {
     const enabled = new Set(effective);
     const isCustom =
       effective.length !== opts.defaultValue.length ||
-      effective.some((value, index) => value !== opts.defaultValue[index]);
+      effective.some((value) => !opts.defaultValue.includes(value));
     return html`
       <div class="settings-row replacement-groups-row">
         <div class="settings-row-text">

--- a/packages/extension/src/settingsView/handlers/latexSettingsHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/latexSettingsHandlers.ts
@@ -7,10 +7,10 @@
 import * as vscode from 'vscode';
 
 import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
-import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
 import { platform } from '@platform/platform';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { SETTINGS_VIEW_CMD, type SettingsMessageFor } from '@shared/schemas';
+import { buildSettingsSnapshotMessage } from '@shared/settingsView/handlers/settingsSnapshot';
 import {
   LATEX_WORKSHOP_EXT_ID,
   normalizePlatform,
@@ -148,9 +148,6 @@ export class LatexSettingsHandlers {
     },
   });
 
-  private readonly configPersistenceController =
-    new LatexConfigPersistenceController();
-
   constructor(private readonly ctx: SettingsHandlerContext) {}
 
   async sendLatexSettingsStatus(webview: vscode.Webview): Promise<void> {
@@ -202,16 +199,17 @@ export class LatexSettingsHandlers {
     );
   }
 
-  /**
-   * Push current LaTeX/compile/diff config values to the webview. Each field
-   * is left undefined when no value is set in workspace storage so the UI
-   * can render the documented default rather than overwriting it on save.
-   */
+  /** Push the catalog-derived LaTeX/compile/diff settings snapshot. */
   async sendLatexConfigValues(webview: vscode.Webview): Promise<void> {
     await webview.postMessage(
-      this.configPersistenceController.buildConfigMessage(
-        (key) => platform().workspaceState.get(key),
-        platform().config,
+      buildSettingsSnapshotMessage(
+        'latex',
+        {
+          config: platform().config,
+          workspaceState: platform().workspaceState,
+          globalState: platform().globalState,
+        },
+        'vscode',
       ),
     );
   }

--- a/src/controllers/settingsView/LatexConfigPersistenceController.ts
+++ b/src/controllers/settingsView/LatexConfigPersistenceController.ts
@@ -3,7 +3,6 @@ import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   LatexConfigValuesSchema,
   type LatexConfigValues,
-  type UpdateLatexConfigValuesMessage,
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 
@@ -17,6 +16,12 @@ import {
 interface CoreConfigReader {
   get(key: string): unknown;
   isExplicitlySet(key: string): boolean;
+}
+
+/** Legacy frontend-keyed shape retained only for direct compatibility tests. */
+interface LegacyLatexConfigValuesMessage {
+  readonly command: typeof SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES;
+  readonly values: LatexConfigValues;
 }
 
 /** Builds storage-backed LaTeX config snapshots without host side effects. */
@@ -53,11 +58,11 @@ export class LatexConfigPersistenceController {
     return values as LatexConfigValues;
   }
 
-  /** Wraps the current config values into the outbound settings-view message shape. */
+  /** Legacy wrapper retained for direct consumers of this persistence helper. */
   buildConfigMessage(
     readStoredValue: (key: WorkspaceStateKey) => unknown,
     coreConfig?: CoreConfigReader,
-  ): UpdateLatexConfigValuesMessage {
+  ): LegacyLatexConfigValuesMessage {
     return {
       command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES,
       values: this.buildConfigValues(readStoredValue, coreConfig),

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -192,9 +192,8 @@ const SetTabMessageSchema = z.object({
  * line per *snapshot*, never per setting.
  *
  * A snapshot absent from this map is one whose payload is not a plain list of
- * catalog rows (`profile`, `models`) or whose builder lives behind a
- * controller this module does not own (`latex`); those arms still declare
- * their own shape below or in their own module.
+ * catalog rows (`profile`, `models`); those arms still declare their own shape
+ * below or in their own module.
  */
 export const SETTINGS_SNAPSHOT_COMMANDS = {
   approval: SETTINGS_VIEW_COMMANDS.UPDATE_APPROVAL_SETTINGS,
@@ -202,6 +201,7 @@ export const SETTINGS_SNAPSHOT_COMMANDS = {
   'agent-skills': SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SKILLS_SETTINGS,
   telemetry: SETTINGS_VIEW_COMMANDS.UPDATE_TELEMETRY_SETTINGS,
   'multi-agent': SETTINGS_VIEW_COMMANDS.UPDATE_SUPER_YOLO_ENABLED,
+  latex: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES,
 } as const satisfies Partial<Record<SettingsViewSnapshot, string>>;
 
 /** A snapshot whose whole payload is derived from the settings catalog. */
@@ -638,10 +638,7 @@ export const LatexConfigValuesSchema = z.object({
 export type LatexConfigValues = z.infer<typeof LatexConfigValuesSchema>;
 
 /** Outbound: backend → frontend current LaTeX/compile/diff config values. */
-const UpdateLatexConfigValuesMessageSchema = z.object({
-  command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES),
-  values: LatexConfigValuesSchema,
-});
+const UpdateLatexConfigValuesMessageSchema = snapshotMessage('latex');
 export type UpdateLatexConfigValuesMessage = z.infer<
   typeof UpdateLatexConfigValuesMessageSchema
 >;

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -639,9 +639,6 @@ export type LatexConfigValues = z.infer<typeof LatexConfigValuesSchema>;
 
 /** Outbound: backend → frontend current LaTeX/compile/diff config values. */
 const UpdateLatexConfigValuesMessageSchema = snapshotMessage('latex');
-export type UpdateLatexConfigValuesMessage = z.infer<
-  typeof UpdateLatexConfigValuesMessageSchema
->;
 
 /** Outbound: backend → frontend inline criticism toggle state */
 const UpdateInlineCriticismEnabledMessageSchema = z.object({

--- a/src/shared/settingsView/handlers/settingsSnapshot.ts
+++ b/src/shared/settingsView/handlers/settingsSnapshot.ts
@@ -3,7 +3,7 @@
  *
  * A snapshot is exactly "the catalog rows tagged for it", so this reads that
  * list rather than naming fields: the approval/safety, git-author, agent-skills,
- * telemetry, and multi-agent snapshots all come from here. Per-row defaults,
+ * telemetry, multi-agent, and LaTeX snapshots all come from here. Per-row defaults,
  * validation, storage slot, and legacy normalization already live on the
  * catalog row and are applied by `readSetting`, so a snapshot builder has
  * nothing left of its own to say.


### PR DESCRIPTION
## Summary

- add `latex` to the catalog-derived settings snapshot contract
- build the LaTeX snapshot from the shared catalog in extension and desktop
- adapt canonical catalog keys to the existing frontend view model without restating 14 fields
- make reset/customized state operate on resolved values and documented defaults
- remove the legacy persistence controller from production wiring while retaining its direct test compatibility surface

## Issue acceptance gates

Closes #10980.

- `latex` routes through `SETTINGS_SNAPSHOT_COMMANDS` and `snapshotMessage`.
- Both hosts call `buildSettingsSnapshotMessage('latex', ...)`.
- Production no longer hand-lists LaTeX snapshot reads in `LatexConfigPersistenceController`.
- The frontend derives its adapter from `LATEX_FIELD_TO_KEY` and `LATEX_REPLACEMENT_FIELD_TO_CONFIG_KEY`.
- Reset and customized indicators remain meaningful with catalog-resolved defaults.
- `profile` and `models` remain outside the plain-row snapshot path.

## Single source of truth

The settings catalog now owns the 14 LaTeX snapshot keys, validators, storage slots, defaults, and host reads. `buildSettingsSnapshotMessage` is the shared extension/desktop builder.

## Duplication and abstraction budget

Removed the two production reads through the hand-listed persistence controller. No new abstraction was added. The existing snapshot builder and existing field-to-key maps carry the migration. The legacy controller remains only because unchanged tests directly exercise it.

## Net elements (R6)

- 8 production files changed
- 65 lines added, 45 removed, net +20
- no files, classes, interfaces, or enums added or removed
- 1 unused exported type removed: `UpdateLatexConfigValuesMessage`
- one production controller construction removed

## Consumer counts (R8)

- `updateLatexConfigValues` keeps one production subscriber in `latexSlice.ts`.
- Two production emit paths remain, extension and desktop, and both now route through `buildSettingsSnapshotMessage`.
- No command literal or subscriber was deleted. The unused message type export had zero consumers and was removed.

## Host impact

Extension: LaTeX values are read through the catalog and adapted to the existing tab model.

Desktop: Uses the same catalog-derived builder and no longer constructs the legacy persistence controller.

CLI: No runtime change.

## Scheduled refactoring

Follow-up #11211 is the dated removal trigger for the test-only `LatexConfigPersistenceController` and optional desktop compatibility property. No production caller remains. The current task strictly forbids the required test migration.

## Validation

- Prettier and ESLint on all changed files
- `npm run typecheck:workspace`
- `npm run typecheck:desktop`
- `npm run typecheck:test-kernel`
- `npm run compile:fast`
- `corepack pnpm --filter @texra/desktop build`
- 70 focused existing tests passed across catalog, persistence, desktop, and notification suites
- independent review found and verified fixes for resolved-default UI semantics and stale desktop wiring
- `git diff --check`

No tests were modified or added, per task constraints.
