### PR TITLE
fix(desktop): close refresh coalescing gap

### DIFF
--- a/packages/desktop/src/renderer/editorPane.ts
+++ b/packages/desktop/src/renderer/editorPane.ts
@@ -497,13 +497,15 @@ export function createEditorPane(callbacks: EditorPaneCallbacks): EditorPane {
       return refreshPromise;
     }
     refreshPromise = (async () => {
-      do {
-        refreshQueued = false;
-        await refreshOnce();
-      } while (refreshQueued);
-    })().finally(() => {
-      refreshPromise = undefined;
-    });
+      try {
+        do {
+          refreshQueued = false;
+          await refreshOnce();
+        } while (refreshQueued);
+      } finally {
+        refreshPromise = undefined;
+      }
+    })();
     return refreshPromise;
   }
 


### PR DESCRIPTION
## Summary

- clear the editor refresh owner inside the coalescing coroutine
- make the final queued check and owner cleanup atomic within one JavaScript job
- preserve shared-promise and failure cleanup behavior

Closes #11207.

## Validation

- Prettier
- ESLint
- `npm run typecheck:desktop`
- focused desktop control and editor-tree tests: 16 passed
- independent code review found no issues
- `git diff --check`

No tests were modified or added.
