### PR TITLE
refactor(extension): drop unused content provider contract

### DIFF
--- a/packages/extension/src/common/webview/BaseWebviewProvider.ts
+++ b/packages/extension/src/common/webview/BaseWebviewProvider.ts
@@ -14,9 +14,6 @@ export abstract class BaseWebviewProvider {
   protected readonly _disposables = new DisposableStore();
   protected _viewDisposables = new DisposableStore();
 
-  protected abstract contentProvider: {
-    getHtmlContent(webview: vscode.Webview): string;
-  };
   protected abstract messageHandler: {
     handleMessage(
       message: unknown,


### PR DESCRIPTION
## Summary

- remove the unused abstract `contentProvider` member from `BaseWebviewProvider`
- keep concrete providers' directly consumed content-provider fields unchanged
- retain the abstract `messageHandler` contract used during cleanup

Closes #11182.

## Validation

- Prettier
- ESLint
- `npm run typecheck:workspace`
- dead-code ratchet
- focused progress/settings tests: 12 passed
- independent code review found no issues
- `git diff --check`

No tests were modified or added.
