### PR TITLE
docs(stream): pin tab label identity invariant

### DIFF
--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -277,6 +277,11 @@ export type StreamIdentityFields = z.infer<typeof StreamIdentityFieldsSchema>;
  */
 export const StreamTabInfoSchema = StreamIdentityFieldsSchema.extend({
   name: z.string(),
+  /**
+   * Canonical display name. When `identity` is present, every producer must
+   * set this to `runIdentityDisplayName(identity)`. Only identity-less legacy
+   * or pending streams may use the stream-id-derived fallback.
+   */
   label: z.string(),
   model: z.string().optional(),
   modelLabel: z.string().optional(),


### PR DESCRIPTION
## Summary

- document the identity-derived label contract at `StreamTabInfoSchema`
- reserve the stream-id-derived fallback for identity-less legacy or pending streams
- keep the wire schema and runtime behavior unchanged

Closes #11137.

## Validation

- Prettier
- ESLint
- `npm run typecheck:workspace`
- `git diff --check`

No tests were modified or added.
