### PR TITLE
fix(cli): surface subscription probe failures

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -8,6 +8,7 @@ import { COLOR_ERROR } from '@cli/tui/ui/colors';
 import { useLiveNowMsSince } from '@cli/tui/useLiveNowMs';
 import { usePollingInterval } from '@cli/tui/usePollingInterval';
 import { SubscriptionUsageService } from '@controllers/modelAccess/subscriptionUsage/SubscriptionUsageService';
+import { createLog } from '@logger/logUtils';
 import { activeSubscriptionUsageRoute } from '@model/codingPlanSubscriptions';
 import { codingPlanForUsageRoute } from '@shared/codingPlanSubscriptions';
 import type {
@@ -16,6 +17,7 @@ import type {
   UsageRoute,
 } from '@shared/schemas';
 import { isActivePhase } from '@shared/streams/streamStatus';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { approvalQueueStatus } from '../state/approvalQueue';
 import { terminalCapabilities } from '../state/terminalCapabilities';
@@ -53,6 +55,7 @@ import {
 
 const CODEX_SUBSCRIPTION_REFRESH_MS = 10_000;
 const SUBSCRIPTION_QUOTA_REFRESH_MS = 30_000;
+const log = createLog('cli.tui');
 interface StatusBarProps {
   readonly agentSelectionAvailable?: boolean;
   /** True when the focused stream has a composer for slash commands and text. */
@@ -122,6 +125,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     readonly model: string;
     readonly preferenceVersion: number;
     readonly route?: UsageRoute;
+    readonly failed?: true;
   }>();
   const resolutionCurrent =
     subscriptionResolution?.model === accessModel &&
@@ -129,6 +133,10 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const prospectiveRoute = resolutionCurrent
     ? subscriptionResolution?.route
     : undefined;
+  const subscriptionProbeFailed =
+    resolutionCurrent &&
+    subscriptionResolution?.failed === true &&
+    statusSlice?.usage?.usageRoute === undefined;
   const modelAccess = resolveCliModelAccessRoute({
     usageRoute: statusSlice?.usage?.usageRoute,
     prospectiveRoute,
@@ -160,11 +168,15 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
             route,
           });
         })
-        .catch(() => {
+        .catch((error: unknown) => {
           if (subscriptionDesiredKeyRef.current !== readKey) return;
+          log.warn(
+            `subscription route probe failed for ${accessModel}: ${toErrorMessage(error)}`,
+          );
           setSubscriptionResolution({
             model: accessModel,
             preferenceVersion: codexPreferenceVersion,
+            failed: true,
           });
         })
         .finally(() => {
@@ -260,6 +272,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     approvalDepth: approvals.depth,
     approvalKind: approvals.kind,
     modelAccess,
+    subscriptionProbeFailed,
     subscriptionQuota,
     transcriptMode: sessionMeta.transcriptMode,
     approvalPolicy: sessionMeta.approvalPolicy,

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -132,6 +132,8 @@ export interface StatusBarDisplayInput {
   readonly approvalDepth: number;
   readonly approvalKind?: ApprovalQueueStatusKind;
   readonly modelAccess: CliModelAccessRoute;
+  /** The prospective subscription route could not be resolved. */
+  readonly subscriptionProbeFailed?: boolean;
   /** Latest quota snapshot for the subscription serving this model. */
   readonly subscriptionQuota?: SubscriptionUsageSnapshot;
   /** Ephemeral transcripts cannot be resumed and require a persistent warning. */
@@ -214,6 +216,15 @@ function accessModeSegment(access: CliModelAccessRoute): StatusBarSegment {
         color: 'dim',
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.accessMode,
       };
+}
+
+function subscriptionProbeFailureSegment(): StatusBarSegment {
+  return {
+    text: 'subscription status unavailable',
+    compactText: 'subscription unknown',
+    color: COLOR_WARNING,
+    compactPriority: STATUS_BAR_COMPACT_PRIORITY.accessMode,
+  };
 }
 
 function subscriptionQuotaSegment(
@@ -1047,7 +1058,9 @@ export function buildStatusBarDisplay(
   left.push(
     ...[
       rootActiveSegment(input),
-      accessModeSegment(input.modelAccess),
+      input.subscriptionProbeFailed
+        ? subscriptionProbeFailureSegment()
+        : accessModeSegment(input.modelAccess),
       subscriptionQuotaSegment(input.subscriptionQuota),
       approvalPolicySegment(input.approvalPolicy),
       locationSegment(input.location),


### PR DESCRIPTION
## Summary

- log current subscription-route probe failures with their cause
- retain an explicit keyed failure state instead of treating failure as no subscription
- show `subscription status unavailable` when no completed route can remain authoritative
- preserve stale-request guards, successful recovery, quota polling, and narrow-bar compaction

Closes #11140.

## Validation

- Prettier
- ESLint
- `npm run typecheck:cli`
- focused StatusBar suite: 91 passed
- independent code review found no issues
- `git diff --check`

No tests were modified or added.
