### PR TITLE
fix(runtime): finalize failed child launches

### DIFF
--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -537,16 +537,16 @@ export class BashTool extends defineTool({
         // A background shell is an external process on no model budget, like
         // the agent-CLI children (see the child-run concurrency budget note).
         budgeted: false,
-        buildLaunch: async () => {
-          const childStream = createChildStream(executionId, parentStreamId, {
+        createChildStream: () =>
+          createChildStream(executionId, parentStreamId, {
             streamPrefix: BASH_CHILD_STREAM_PREFIX,
             run: { kind: 'process', tool: 'bash' },
             userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
             description: command,
             config: syntheticConfig,
-          });
+          }),
+        buildLaunch: async (childStream) => {
           return {
-            childStream,
             strategy: createBackgroundBashStrategy({
               executionId,
               command,

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -504,7 +504,7 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
           childStreamId: runStreamId,
           agentName: meta.name,
           recordCost,
-          buildLaunch: async () => {
+          createChildStream: async () => {
             // A deterministic execution id may retain the prior attempt's report.
             // Clear it before starting this attempt so an interruption before
             // delivery cannot be mistaken for a newly persisted result.
@@ -513,7 +513,7 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
             // meta.name deliberately reuses one deterministic stream across
             // launches. Reserve its writer while rehydrating so transcript
             // eviction cannot race a resumed run.
-            const childStream = await createRehydratedChildStream(
+            return createRehydratedChildStream(
               runExecutionId,
               runScope.streamId,
               {
@@ -524,7 +524,8 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
                 config: runConfig,
               },
             );
-
+          },
+          buildLaunch: async (childStream) => {
             // A proposal-bypass approval carries the same explicit child edit
             // grant as delegate_agent/delegate_workflow. A human one-off approval
             // inherits only the parent's ordinary per-kind bypass state.
@@ -536,7 +537,6 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
             );
 
             return {
-              childStream,
               strategy: createWorkflowScriptStrategy({
                 executionId: runExecutionId,
                 logger: childStream.logger,

--- a/src/tools/delegation/detachedChildRun.ts
+++ b/src/tools/delegation/detachedChildRun.ts
@@ -3,12 +3,12 @@
  *
  * Every detached child run (delegate_agent/subagent, delegate_multi_agents)
  * starts with the same lifecycle: hold the owned-execution lease launch guard
- * while starting the child run loop, and attach a completion error trace so a
- * late loop failure is diagnosed. Callers keep their own execution-id
- * derivation, approval wiring, and result shaping; this module owns the
- * guard-and-trace skeleton so its invariant (a throw inside the guard releases
- * the lease; a late loop failure is surfaced) lives in one place, plus the
- * native-agent registration that mints the child's stream id.
+ * from child-stream creation through child-run-loop handoff, and attach a
+ * completion error trace so a late loop failure is diagnosed. Callers keep
+ * their own execution-id derivation, approval wiring, and result shaping; this
+ * module owns the guard-and-trace skeleton so its invariant (a throw inside
+ * the guard releases the lease; a late loop failure is surfaced) lives in one
+ * place, plus native-agent registration that mints the child's stream id.
  */
 
 // Local imports
@@ -73,13 +73,8 @@ export async function registerChildExecution(input: {
   return { childStreamId, runWithOwnership };
 }
 
-/** The strategy + stream wiring a launch site supplies inside the guard. */
+/** The strategy wiring a launch site supplies inside the guard. */
 interface DetachedChildRunLaunch<TTurn> {
-  /**
-   * Pre-reserved child stream for the loop to own/finalize. Native strategies
-   * omit this — `executeAgent` already owns handle creation for every turn.
-   */
-  readonly childStream?: ChildStream;
   /** Provider-specific run strategy for the child loop. */
   readonly strategy: ChildRunStrategy<TTurn>;
   /**
@@ -89,7 +84,7 @@ interface DetachedChildRunLaunch<TTurn> {
   readonly onLoopFailed?: (error: unknown) => void;
 }
 
-export interface DetachedChildRunInput<TTurn> {
+interface DetachedChildRunInputBase {
   readonly executionId: ExecutionId;
   readonly parentStreamId: StreamTabId;
   /** The child stream tab id the run is registered under. */
@@ -109,45 +104,86 @@ export interface DetachedChildRunInput<TTurn> {
   readonly onTurnSettled?: ChildRunLoopParams<never>['onTurnSettled'];
   /** Publish caller-owned state after final artifacts drain, before lease release. */
   readonly afterArtifactsDrained?: ChildRunLoopParams<never>['afterArtifactsDrained'];
-  /**
-   * Build the strategy (and any attempt-scoped setup) INSIDE the lease launch
-   * guard: a throw here must release the owned-execution lease. A function
-   * (rather than a pre-built value) so the build runs lazily inside the guard.
-   */
-  readonly buildLaunch: () => Promise<DetachedChildRunLaunch<TTurn>>;
 }
+
+export type DetachedChildRunInput<TTurn> = DetachedChildRunInputBase &
+  (
+    | {
+        /** Create the stream inside the lease guard, before any stream-dependent setup. */
+        readonly createChildStream: () => ChildStream | Promise<ChildStream>;
+        /** Build attempt-scoped setup around the stream retained by the launch guard. */
+        readonly buildLaunch: (
+          childStream: ChildStream,
+        ) => Promise<DetachedChildRunLaunch<TTurn>>;
+      }
+    | {
+        /** Native strategies let `executeAgent` own handle creation for every turn. */
+        readonly createChildStream?: undefined;
+        /**
+         * Build the strategy (and any attempt-scoped setup) inside the lease launch
+         * guard so a throw releases the owned-execution lease.
+         */
+        readonly buildLaunch: () => Promise<DetachedChildRunLaunch<TTurn>>;
+      }
+  );
 
 /**
  * Run the shared detached-child launch choreography: hold the owned-execution
- * lease launch guard while starting the child run loop, and attach the
- * completion error trace. Returns the launched loop's stream id and completion
- * so in-band callers can await it.
+ * lease launch guard while creating any child stream and handing it to the run
+ * loop, then attach the completion error trace. Returns the launched loop's
+ * stream id and completion so in-band callers can await it.
  */
 export async function startDetachedChildRunLoop<TTurn>(
   input: DetachedChildRunInput<TTurn>,
 ): Promise<{ childStreamId: StreamTabId; completion: Promise<void> }> {
   return runWithOwnedExecutionLeaseLaunchGuard(input.executionId, async () => {
-    const { childStream, strategy, onLoopFailed } = await input.buildLaunch();
-    const { completion } = startChildRunLoop({
-      ...(childStream !== undefined && { childStream }),
-      childStreamId: input.childStreamId,
-      parentStreamId: input.parentStreamId,
-      executionId: input.executionId,
-      agentName: input.agentName,
-      strategy,
-      ...(input.recordCost !== undefined && { recordCost: input.recordCost }),
-      ...(input.notify !== undefined && { notify: input.notify }),
-      ...(input.onTurnSettled !== undefined && {
-        onTurnSettled: input.onTurnSettled,
-      }),
-      ...(input.afterArtifactsDrained !== undefined && {
-        afterArtifactsDrained: input.afterArtifactsDrained,
-      }),
-      // Every detached native/workflow child takes one shared-budget slot per
-      // turn; an awaited in-band child rides its idle parent's slot instead.
-      budgeted: input.budgeted ?? true,
-    });
-    if (onLoopFailed) void completion.catch(onLoopFailed);
+    let childStream: ChildStream | undefined;
+    let launch: DetachedChildRunLaunch<TTurn>;
+    let completion: Promise<void>;
+    try {
+      if (input.createChildStream) {
+        childStream = await input.createChildStream();
+        launch = await input.buildLaunch(childStream);
+      } else {
+        launch = await input.buildLaunch();
+      }
+      ({ completion } = startChildRunLoop({
+        ...(childStream !== undefined && { childStream }),
+        childStreamId: input.childStreamId,
+        parentStreamId: input.parentStreamId,
+        executionId: input.executionId,
+        agentName: input.agentName,
+        strategy: launch.strategy,
+        ...(input.recordCost !== undefined && { recordCost: input.recordCost }),
+        ...(input.notify !== undefined && { notify: input.notify }),
+        ...(input.onTurnSettled !== undefined && {
+          onTurnSettled: input.onTurnSettled,
+        }),
+        ...(input.afterArtifactsDrained !== undefined && {
+          afterArtifactsDrained: input.afterArtifactsDrained,
+        }),
+        // Every detached native/workflow child takes one shared-budget slot per
+        // turn; an awaited in-band child rides its idle parent's slot instead.
+        budgeted: input.budgeted ?? true,
+      }));
+    } catch (error) {
+      if (childStream) {
+        try {
+          await childStream.finalize({
+            outcome: { kind: 'failed', error },
+            persistence: { kind: 'finalize', flowRecord: 'delete' },
+          });
+        } catch (finalizeError) {
+          throw new AggregateError(
+            [error, finalizeError],
+            `Detached child execution ${input.executionId} failed and its child stream could not be finalized`,
+          );
+        }
+      }
+      throw error;
+    }
+
+    if (launch.onLoopFailed) void completion.catch(launch.onLoopFailed);
     return {
       childStreamId: childStream?.childStreamId ?? input.childStreamId,
       completion,

--- a/src/tools/delegation/detachedChildRun.ts
+++ b/src/tools/delegation/detachedChildRun.ts
@@ -139,6 +139,7 @@ export async function startDetachedChildRunLoop<TTurn>(
   return runWithOwnedExecutionLeaseLaunchGuard(input.executionId, async () => {
     let childStream: ChildStream | undefined;
     let launch: DetachedChildRunLaunch<TTurn>;
+    let autoCloseOnLaunchFailure = false;
     let completion: Promise<void>;
     try {
       if (input.createChildStream) {
@@ -147,6 +148,7 @@ export async function startDetachedChildRunLoop<TTurn>(
       } else {
         launch = await input.buildLaunch();
       }
+      autoCloseOnLaunchFailure = launch.strategy.autoCloseChildStream === true;
       ({ completion } = startChildRunLoop({
         ...(childStream !== undefined && { childStream }),
         childStreamId: input.childStreamId,
@@ -172,6 +174,7 @@ export async function startDetachedChildRunLoop<TTurn>(
           await childStream.finalize({
             outcome: { kind: 'failed', error },
             persistence: { kind: 'finalize', flowRecord: 'delete' },
+            ...(autoCloseOnLaunchFailure && { autoClose: true }),
           });
         } catch (finalizeError) {
           throw new AggregateError(


### PR DESCRIPTION
## Summary

- split optional child-stream creation from stream-dependent launch setup
- keep the created stream inside the owned-execution launch guard until loop handoff succeeds
- finalize failed pre-handoff streams with their flow record deleted
- aggregate setup and finalization failures without changing native streamless launches

Closes #11099.

## Validation

- Prettier
- ESLint
- `npm run typecheck:workspace`
- `npm run typecheck:cli`
- `npm run typecheck:test-kernel`
- focused unchanged child-run, delivery, Bash, and delegation tests: 65 passed
- independent lifecycle review found no correctness issues after one obsolete return property was removed
- simplification review reduced the input type without runtime changes
- `git diff --check`

No tests were modified or added.
