### PR TITLE
fix(cli): keep probe warning visible when narrow

### DIFF
--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -221,7 +221,7 @@ function accessModeSegment(access: CliModelAccessRoute): StatusBarSegment {
 function subscriptionProbeFailureSegment(): StatusBarSegment {
   return {
     text: 'subscription status unavailable',
-    compactText: 'subscription unknown',
+    compactText: 'sub unknown',
     color: COLOR_WARNING,
     compactPriority: STATUS_BAR_COMPACT_PRIORITY.accessMode,
   };


### PR DESCRIPTION
Closes #11221.

## Summary
- shorten the subscription-probe warning compact label from `subscription unknown` to `sub unknown`
- preserve the warning through narrower status-bar layouts

## Validation
- `npx prettier --check packages/cli/src/chat/tui/panes/statusBarDisplay.ts`
- `npx eslint packages/cli/src/chat/tui/panes/statusBarDisplay.ts`
- `npm run typecheck:cli`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/StatusBar.vitest.ts` (91 passed)

No test files changed.