### PR TITLE
consolidate: replace hand-rolled queue/sort/basename with existing utilities

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -43,6 +43,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 import { parseArgs as parseCittyArgs } from 'citty';
+import PQueue from 'p-queue';
 
 const ESC = String.fromCharCode(27);
 const ETX = String.fromCharCode(3); // Ctrl-C
@@ -4287,7 +4288,7 @@ async function runScenarioWithResources(scenario, fakeClipboard, index) {
   let exited = null;
   let rawOutput = '';
   const childEventFrames = new Map();
-  let writeQueue = Promise.resolve();
+  const writeQueue = new PQueue({ concurrency: 1 });
   if (scenario.env?.HARNESS_CHILD_EVENT_ORDER) {
     term.parser.registerOscHandler(CHILD_EVENT_ORDER_MARKER_OSC, (data) => {
       if (!data.startsWith(CHILD_EVENT_ORDER_MARKER_PREFIX)) return false;
@@ -4297,7 +4298,7 @@ async function runScenarioWithResources(scenario, fakeClipboard, index) {
     });
   }
   const frameSnapshot = async () => {
-    await writeQueue;
+    await writeQueue.onIdle();
     return renderFrame(term);
   };
   const childEnv = scenarioChildEnv(scenario, cols, rows);
@@ -4334,9 +4335,7 @@ async function runScenarioWithResources(scenario, fakeClipboard, index) {
   child.onData((d) => {
     lastData = Date.now();
     rawOutput += d;
-    writeQueue = writeQueue.then(
-      () => new Promise((resolve) => term.write(d, resolve)),
-    );
+    writeQueue.add(() => new Promise((resolve) => term.write(d, resolve)));
   });
 
   // boot: wait for the interactive input/status area to settle. Static

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -27,6 +27,7 @@ import { getLightweightMd } from '@shared/highlighting/lightweightMd';
 import { renderIconActionButtonParts } from '@shared/wa/actionButtons';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { metaStripStyles, renderDotMeta } from '@shared/wa/metaStrip';
+import { getBasename } from '@utils/core';
 import {
   formatBytes,
   formatResultCount,
@@ -200,7 +201,7 @@ export class MemoryItem extends LitElement {
    */
   private renderActionGroup(): TemplateResult {
     const pinned = this.item?.pinned === true;
-    const memoryName = this.item?.displayPath?.split('/').pop() ?? '';
+    const memoryName = getBasename(this.item?.displayPath);
     const actions = [
       {
         id: 'memory-pin-button',

--- a/src/shared/markdown/createMarkdownProcessor.ts
+++ b/src/shared/markdown/createMarkdownProcessor.ts
@@ -475,7 +475,7 @@ function applyEnvironmentShields(
 ): string {
   if (matches.length === 0) return content;
   const { lineStarts, lineEnds } = lineBoundaries(content);
-  const sorted = [...matches].sort((a, b) => a.start - b.start);
+  const sorted = matches.toSorted((a, b) => a.start - b.start);
   const pieces: string[] = [];
   let copiedUntil = 0;
   for (const match of sorted) {


### PR DESCRIPTION
## Summary

Scheduled codebase audit for consolidation opportunities and native-method
replacements for hand-rolled logic (see skill `find-simplification`). The
survey covered promise-chain queues, array sort/dedup helpers, and duplicated
logic across the three webview trees and the model-handler providers. Most of
the codebase already follows the intended patterns (`p-queue`, `p-retry`,
`nanoid`, `crypto.randomUUID`, `structuredClone`, `perfect-debounce`, shared
dispatcher/persistence mechanisms) — this PR fixes the three genuine, isolated
outliers found:

1. `packages/cli/scripts/validate-tui.mjs` used a hand-rolled
   `chain = chain.then(...)` promise queue to serialize PTY frame writes —
   exactly the pattern `AGENTS.md`/the review checklist ban in favor of
   `p-queue` (already a dependency in `packages/cli`, and the sanctioned
   pattern used in `src/agent/runtime/streamApprovalQueue.ts`). Replaced with
   `new PQueue({ concurrency: 1 })`.
2. `src/shared/markdown/createMarkdownProcessor.ts` spread a plain array
   before sorting (`[...matches].sort(...)`) where `matches` is already a
   real array — replaced with `Array.prototype.toSorted()`.
3. `packages/extension/.../settingsView/frontend/components/memory/MemoryItem.ts`
   derived a display name via manual `displayPath?.split('/').pop()` instead
   of the existing `getBasename()` helper from `@utils/core`, which is already
   the established pattern in the webview and progressView trees and correctly
   handles trailing slashes / backslash-style paths that the manual split does
   not.

A fourth candidate — duplicated clipboard-image "chip text" assembly between
`webview/frontend/pasteHandler.ts` and `progressView/frontend/components/FollowUpInput.ts`
— was found but deliberately **not** implemented here: it's a thin (~4
duplicate lines per site) change inside stateful async paste UX in two hosts,
and this session couldn't do the in-browser verification the paste flow
deserves. Filed as #11224 for a follow-up PR with manual verification.

## Issue acceptance gates

No pre-existing issue; this PR originates from a scheduled consolidation
audit. Follow-up candidate tracked in #11224.

## Single source of truth

- Write serialization in `validate-tui.mjs` now goes through the same
  `p-queue` primitive already used elsewhere in the runtime, instead of a
  second bespoke chaining mechanism.
- Basename derivation in `MemoryItem.ts` now goes through the same
  `getBasename()` helper already used throughout `webview/` and
  `progressView/`, instead of a third manual implementation.

## Duplication and abstraction budget

Removed one bespoke promise-chain implementation and one bespoke basename
implementation in favor of existing, already-adopted utilities. No new
abstractions added.

## Net elements (R6)

3 files changed, 7 insertions(+), 7 deletions(-), net 0 LoC. No exported
symbols, classes, interfaces, or enums added or removed (`git diff
origin/main...HEAD | grep -E '^[+-]export'` → no matches).

## Consumer counts (R8)

n/a — no emit path or exported/public symbol was deleted or re-routed; all
three changes are internal-implementation swaps at their existing single call
sites.

## Host impact

Extension: `MemoryItem.ts` (settingsView memory tab) — internal display-name
derivation only, same rendered output for all normal paths, corrects a
trailing-slash/backslash edge case.

Desktop: none.

CLI: `validate-tui.mjs` is CLI dev/validation tooling (not shipped in the
`texra` binary) — frame-write serialization now goes through `p-queue`
instead of a hand-rolled chain; behavior is equivalent (still
concurrency-1, still awaited via `onIdle()` before each frame snapshot).

## Scheduled refactoring

Follow-up: #11224 (clipboard-image chip-text consolidation between webview
and progressView paste handlers — needs browser verification).

## Validation

- `npm run typecheck` — clean (all packages: workspace, test-kernel, agent,
  cli, trace-viewer, desktop).
- `npm run lint` — clean.
- `npx prettier --check` on the three edited files — clean.
- `npm test` (full vitest suite) — 842 files / 10,303 tests passed, 1 file /
  6 tests skipped (pre-existing skips), 0 failures.
- `npm run check:dead-code-ratchet` — clean, no new unused exports.
- `node -c packages/cli/scripts/validate-tui.mjs` — syntax check passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_015Hr7uuTSccKFbS4nb3hPyT)_