### PR TITLE
refactor(session): share stream identity assembly

### DIFF
--- a/src/controllers/session/streamTabInfo.ts
+++ b/src/controllers/session/streamTabInfo.ts
@@ -30,7 +30,8 @@ interface StreamTabInfoInputs {
  */
 export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
   const { streamId, metadata } = inputs;
-  const { identity, config } = metadata;
+  const { config, ...identityFields } = metadata;
+  const { identity } = identityFields;
 
   // A stream whose identity hasn't resolved yet (no `run.start` seen, no
   // durable record hydrated) has no RunIdentity to name it by. Its id's
@@ -72,19 +73,13 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
   const model = identity?.kind === 'agent' ? config?.model : undefined;
 
   return {
+    ...identityFields,
     name: streamId,
     label: identityName,
-    identity,
-    userFollowUpSupport: metadata.userFollowUpSupport,
-    agentCategory: metadata.agentCategory,
     model,
     modelLabel: model ? getRuntimeModelLabel(model) : undefined,
     command,
     isRemote,
-    creationTimestamp: metadata.creationTimestamp,
-    executionId: metadata.executionId,
-    parentStreamId: metadata.parentStreamId,
-    description: metadata.description,
     worktree,
   };
 }


### PR DESCRIPTION
Closes #10917.

## Summary
- export the canonical `StreamIdentityFieldsSchema` and use it to project `SessionStreamMetadata` into the tab wire shape
- remove eight hand-maintained field copies while stripping unknown and session-only fields at the shared schema boundary
- keep tab-only display derivation explicit and preserve the registry fallback override for `isRemote`

`SessionState.getStreamMetadata` already preserves stored metadata generically, and `StreamSnapshotStore.RunMetadata` is a distinct execution projection with a different contract, so neither is changed.

## Validation
- Prettier and ESLint on both changed files
- `npm run typecheck:workspace`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/progressView/streamInfoUtils.vitest.ts` (12 passed)
- `npm run check:dead-code-ratchet`
- `git diff --check`

No test files changed.