### PR TITLE
fix(session): bound stream identity projection

### DIFF
--- a/src/controllers/session/streamTabInfo.ts
+++ b/src/controllers/session/streamTabInfo.ts
@@ -3,7 +3,11 @@ import { getStreamTabDisplayName } from '@agent/runtime/streamTab';
 import type { SessionStreamMetadata } from '@controllers/session/SessionState';
 import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import type { StreamTabInfo, WorktreeInfo } from '@shared/schemas';
-import { getCleanAgentName, runIdentityDisplayName } from '@shared/schemas';
+import {
+  getCleanAgentName,
+  projectStreamIdentityFields,
+  runIdentityDisplayName,
+} from '@shared/schemas';
 
 interface StreamTabInfoInputs {
   streamId: string;
@@ -30,7 +34,8 @@ interface StreamTabInfoInputs {
  */
 export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
   const { streamId, metadata } = inputs;
-  const { config, ...identityFields } = metadata;
+  const { config } = metadata;
+  const identityFields = projectStreamIdentityFields(metadata);
   const { identity } = identityFields;
 
   // A stream whose identity hasn't resolved yet (no `run.start` seen, no

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -266,6 +266,25 @@ const StreamIdentityFieldsSchema = z.object({
 });
 export type StreamIdentityFields = z.infer<typeof StreamIdentityFieldsSchema>;
 
+const STREAM_IDENTITY_FIELD_KEYS = Object.keys(
+  StreamIdentityFieldsSchema.shape,
+) as readonly (keyof StreamIdentityFields)[];
+
+/**
+ * Project a wider session record onto the canonical identity/pointer shape.
+ * Seed every declared key so optional `undefined` fields retain the stable wire
+ * shape that existing host patches expose, while Zod strips undeclared fields.
+ */
+export function projectStreamIdentityFields(
+  source: StreamIdentityFields,
+): StreamIdentityFields {
+  return StreamIdentityFieldsSchema.parse(
+    Object.fromEntries(
+      STREAM_IDENTITY_FIELD_KEYS.map((key) => [key, source[key]]),
+    ),
+  );
+}
+
 /**
  * One flat wire shape per stream tab. The parsed {@link RunIdentitySchema}
  * struct travels verbatim — renderers key on `identity.kind` instead of


### PR DESCRIPTION
Follow-up to #11230 and #10917.

## Summary
- project session metadata through one schema-derived field-key list instead of copying every runtime property except `config`
- strip future session-only or unexpected properties at the canonical `StreamIdentityFieldsSchema` boundary
- preserve explicit `undefined` optional fields in the established host patch shape
- preserve the explicit `isRemote` override and the builder consolidation landed in #11230

The original PR merged concurrently while its review fix was being prepared. Its CI later exposed that a direct Zod projection omitted absent optional keys. This follow-up now derives the field set from the schema while seeding every declared key, preserving the unchanged test contract without hand-maintained copies.

## Validation
- Prettier and ESLint on both changed files
- `npm run typecheck:workspace`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/progressView/streamInfoUtils.vitest.ts src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts` (35 passed)
- `npm run check:dead-code-ratchet`
- `git diff --check`

No test files changed.