### PR TITLE
refactor(settings): separate reader and writer evidence

### DIFF
--- a/packages/cli/src/schemas/knownKeys.ts
+++ b/packages/cli/src/schemas/knownKeys.ts
@@ -8,14 +8,15 @@ import { CLI_SETTING_PATHS } from './cliSettings';
  * Authoritative set of canonical `texra.*` keys recognized by the CLI for
  * unknown-key detection in `.texra/config.json`.
  *
- * Derived from the two catalog facts that decide it — the CLI's runtime honors
- * the row (`honoredBy.cli`) and the CLI's slot for it is `config` — plus the
- * CLI-only paths (`agent`, `model`, etc.). Keys the CLI doesn't read from
- * `.texra/config.json` are excluded by that same derivation, so they still warn
- * as unknown:
+ * Derived from config-backed catalog rows that the CLI runtime honors
+ * (`honoredBy.cli`) or an exceptional CLI path writes (`writtenBy.cli`), plus
+ * the CLI-only paths (`agent`, `model`, etc.). Keys with neither CLI runtime
+ * behavior nor a recorded CLI writer are excluded by that derivation, so they
+ * still warn as unknown:
  *
- * - Settings no CLI reader honors (`agentReview.*`). Other hosts may write them
- *   to the shared TeXRA config, but they have no CLI behavior.
+ * - Settings no CLI reader honors and no exceptional CLI path writes
+ *   (`agentReview.*`). Other hosts may write them to the shared TeXRA config,
+ *   but they have no CLI behavior.
  * - Settings the CLI reads from its `state.json` store (workflow/latexdiff):
  *   putting those in `config.json` is a no-op.
  */

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -298,15 +298,6 @@ function everyHost(
   };
 }
 
-/** Every host can write the setting through one host-neutral module. */
-function everyHostWriter(writer: string): SettingWrittenBy {
-  return {
-    vscode: { writer },
-    desktop: { writer },
-    cli: { writer },
-  };
-}
-
 /**
  * Only the webview hosts honor the setting — the reader exists in shared code
  * but its effect has no headless counterpart. The row must say why.
@@ -622,7 +613,9 @@ const CORE_SETTING_ROWS: Record<CoreSettingPath, CoreRowSpec> = {
         reader: 'packages/extension/src/commands/git/gitCommands.ts',
       },
     },
-    writtenBy: everyHostWriter('src/tools/setup/ConfigTools.ts'),
+    writtenBy: {
+      cli: { writer: 'src/tools/setup/ConfigTools.ts' },
+    },
   },
   'agentReview.runOnCommit': {
     honoredBy: {

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -77,7 +77,7 @@ export const DEFAULT_TOOL_PATH_PROTECTION_ENABLED = true;
  * Host-neutral catalog for every TeXRA setting a host can store, honor, or
  * render.
  *
- * One row answers all four questions that used to be answered in six places:
+ * One row carries the catalog facts that used to be answered in six places:
  *
  * - **`slots`** — where each host stores the value (`config` /
  *   `workspaceState` / `globalState`). Replaces the old `store` + `cliStore`
@@ -86,6 +86,9 @@ export const DEFAULT_TOOL_PATH_PROTECTION_ENABLED = true;
  *   file as evidence. Replaces `CLI_CORE_SETTING_PATHS`,
  *   `EXTENSION_ONLY_CORE_SETTING_PATHS`, and the reader-file registry that
  *   used to live in the guardrail suite as a third copy of the same knowledge.
+ * - **`writtenBy`** — exceptional host write evidence when a host must recognize
+ *   a config key that its runtime does not honor. This is not an exhaustive
+ *   writer catalog.
  * - **`surfaces`** — which catalog-driven *UI* renders the row (settings view,
  *   CLI `/config`, the Models tab's per-provider controls). Replaces the
  *   display half of the old `hosts` field, `settingsViewSnapshot`, and the
@@ -152,6 +155,15 @@ interface SettingHonor {
 /** Which hosts' runtimes honor the setting, and how that is known. */
 type SettingHonoredBy = {
   readonly [H in SettingHost]?: SettingHonor;
+};
+
+/** Evidence for an exceptional host write to a setting it does not honor. */
+interface SettingWriter {
+  readonly writer: string;
+}
+
+type SettingWrittenBy = {
+  readonly [H in SettingHost]?: SettingWriter;
 };
 
 /** One provider's control group in the Models tab. */
@@ -221,6 +233,11 @@ export interface StateSettingEntry {
   readonly configTarget?: 'global' | 'workspace';
   /** Which hosts' runtimes read the value, with the reading file as evidence. */
   readonly honoredBy: SettingHonoredBy;
+  /**
+   * Exceptional host writes that require config-key recognition even though
+   * that host's runtime does not honor the value. Not an exhaustive writer list.
+   */
+  readonly writtenBy?: SettingWrittenBy;
   /** Which catalog-driven UIs render the row. */
   readonly surfaces?: SettingSurfaces;
   /** Write-time consequences applied by every write path. */
@@ -278,6 +295,15 @@ function everyHost(
     cli: cliReachability
       ? { reader, reachability: cliReachability }
       : { reader },
+  };
+}
+
+/** Every host can write the setting through one host-neutral module. */
+function everyHostWriter(writer: string): SettingWrittenBy {
+  return {
+    vscode: { writer },
+    desktop: { writer },
+    cli: { writer },
   };
 }
 
@@ -587,11 +613,16 @@ const CORE_SETTING_ROWS: Record<CoreSettingPath, CoreRowSpec> = {
   'latexdiff.tempFileLocation': {
     honoredBy: everyHost('src/tools/approval/latexPreview.ts'),
   },
-  // Only the extension's git commands read the commit count, but the setup
-  // assistant's `update_config` tool writes it from any host, so a CLI-written
-  // value must not then be reported as unknown.
+  // Only the extension's git commands read the commit count. The setup
+  // assistant's host-neutral `update_config` writer is recorded separately so
+  // a CLI-written value is recognized without mislabeling the writer as a reader.
   'git.numberOfCommitsToShow': {
-    honoredBy: everyHost('src/tools/setup/ConfigTools.ts'),
+    honoredBy: {
+      vscode: {
+        reader: 'packages/extension/src/commands/git/gitCommands.ts',
+      },
+    },
+    writtenBy: everyHostWriter('src/tools/setup/ConfigTools.ts'),
   },
   'agentReview.runOnCommit': {
     honoredBy: {
@@ -1538,12 +1569,14 @@ export const CLI_STATE_SETTINGS: readonly SurfacedSettingEntry[] =
   SURFACED_SETTINGS.filter((entry) => entry.surfaces.cliConfig === true);
 
 /**
- * Canonical `texra.*` keys the CLI reads from `.texra/config.json` — the
- * unknown-key whitelist's catalog half. Derived from the two facts that decide
- * it: the CLI's runtime honors the row, and the CLI's slot for it is `config`.
+ * Canonical `texra.*` keys the CLI reads or writes in `.texra/config.json` —
+ * the unknown-key whitelist's catalog half. A config-backed row belongs when
+ * the CLI runtime honors it or the catalog records an exceptional CLI writer.
  */
 export const CLI_CONFIG_SLOT_KEYS: readonly string[] = ALL_SETTINGS.filter(
-  (entry) => entry.honoredBy.cli !== undefined && entry.slots.cli === 'config',
+  (entry) =>
+    entry.slots.cli === 'config' &&
+    (entry.honoredBy.cli !== undefined || entry.writtenBy?.cli !== undefined),
 ).map((entry) => entry.key);
 
 /** Models tab controls for one provider, in catalog order. */


### PR DESCRIPTION
Closes #10945.

## Summary

- Record the real VS Code runtime reader for `git.numberOfCommitsToShow`.
- Add narrowly documented, non-exhaustive `writtenBy` evidence for a config key the CLI writes but does not honor.
- Keep the setup assistant's host-neutral writer separate from runtime reader evidence.
- Derive the CLI known-config-key list from either CLI runtime honor or an exceptional CLI writer.

Desktop is deliberately not listed as a reader. Current desktop code uses `DESKTOP_RECENT_COMMIT_LIMIT = 20` and does not read this setting.

## Issue acceptance gates

- `honoredBy.reader` names the actual runtime reader: satisfied for VS Code.
- Writer allowlist evidence no longer masquerades as reader evidence: satisfied through the separate `writtenBy` field.
- CLI-written values remain recognized by the unknown-key guardrail: satisfied by including exceptional CLI writer evidence in `CLI_CONFIG_SLOT_KEYS`.
- Desktop reader evidence: omitted because the current desktop implementation uses a constant rather than this setting.

## Single source of truth

`src/shared/schemas/stateSettings.ts` remains the single catalog for setting storage, runtime readers, exceptional writer evidence, and surfaced controls.

## Duplication and abstraction budget

The change separates two facts that were previously collapsed into one misleading field. The `writtenBy` shape owns only exceptional writer evidence needed for config-key recognition. Its single row is inline, with no single-caller helper or pass-through layer.

## Net elements (R6)

- Files: 2 modified, 0 added, 0 deleted.
- Exported symbols: 0 added, 0 deleted.
- Interfaces: 1 added (`SettingWriter`).
- Type aliases: 1 added (`SettingWrittenBy`).
- Functions/classes/enums: 0 net.
- LoC: +43/-16, net +27.

The net increase documents and types reader and writer evidence separately while preserving catalog-derived CLI key recognition. No parallel catalog or new module is added.

## Consumer counts (R8)

n/a. No emit path or export is deleted or rerouted. The existing `CLI_CONFIG_SLOT_KEYS` export remains the consumer-facing projection.

## Host impact

Extension: Reader evidence now points to `packages/extension/src/commands/git/gitCommands.ts`.

Desktop: No runtime behavior change. The desktop still uses its fixed recent-commit limit and is not labeled as a reader.

CLI: `git.numberOfCommitsToShow` remains a known config key through explicit exceptional writer evidence.

## Scheduled refactoring

None.

## Validation

- Prettier and ESLint on `src/shared/schemas/stateSettings.ts` and `packages/cli/src/schemas/knownKeys.ts`
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- `npm run typecheck:cli`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/shared/stateSettings.vitest.ts src/test-kernel/tools/setup/ConfigTools.vitest.ts` (36 passed)
- `npm run check:dead-code-ratchet`
- `git diff --check`

No test files changed.

