### PR TITLE
docs(automation): tighten issue-tracker filing bar to cut nitpick issues

### DIFF
--- a/.github/prompts/issue-tracker-prompt.md
+++ b/.github/prompts/issue-tracker-prompt.md
@@ -67,15 +67,16 @@ Do not create issues for:
 - Bot suggestions already addressed or dismissed.
 - Test-coverage suggestions ("add tests for X", "increase coverage", missing
   test remarks from reviewers or bots). This repository deliberately keeps its
-  test surface small because internal interfaces break often — see `AGENTS.md`
-  "Testing discipline". A missing test is the *default*, expected state of a
-  merged PR here, not a gap. File a test follow-up only when **both**: (a) the
-  gap is a reproduced, user-visible defect (not a refactor, not a comment or
-  doc fix) that shipped without a regression test, and (b) the PR body or a
-  reviewer explicitly weighed adding that test and chose not to for a stated
-  reason. "The fix works but nobody happened to write a test" is not
-  sufficient by itself — that describes most merged PRs in this repo by
-  design and is not follow-up-worthy on its own.
+  test surface small because internal interfaces break often. See `AGENTS.md`
+  "Testing discipline". The post-merge filing bar here is intentionally
+  stricter than that policy's review-time bar: a missing test is the _default_,
+  expected state of a merged PR, not a gap. File a test follow-up only when
+  **both**: (a) the gap is a reproduced, user-visible defect (not a refactor,
+  comment, or doc fix) that shipped without a regression test, and (b) the PR
+  body or a reviewer explicitly weighed adding that test and chose not to for
+  a stated reason. "The fix works but nobody happened to write a test" is not
+  sufficient by itself. That describes most merged PRs in this repo by design
+  and is not follow-up-worthy on its own.
 - Wording, precision, or clarity fixes to internal docs (proposals, PRDs,
   ADRs, planning docs) that change no code and no user-facing behavior —
   including bot-flagged "this claim is imprecise" or "this section is
@@ -84,8 +85,8 @@ Do not create issues for:
   which implementation decision would go wrong); otherwise skip.
 - Stale in-code comments or JSDoc that reference a renamed or deleted symbol
   but do not misdescribe current runtime behavior in a way that could cause a
-  future bug. Fix these inline in the same PR if trivial. They are not worth
-  a standing issue.
+  future bug. Leave these for an incidental cleanup rather than creating a
+  standing issue.
 - A finding whose only proposed action is itself "file more issues" or
   "survey X and open tickets" — meta-tracking work that adds process overhead
   without doing anything. Either do the survey now and file the results
@@ -102,9 +103,8 @@ to the maintainer in a single sentence, would they say "yes, file that" or
 where every unaddressed nitpick becomes a permanent open issue is worse than
 one that occasionally lets a nitpick go unfiled — err toward silence.
 
-When several minor findings from the same review are individually below the
-filing bar but related (e.g., two stale-comment fixes in the same file),
-prefer folding them into one issue over filing one each.
+When several related findings from the same review each pass the filing bar,
+prefer folding them into one coherent issue over filing one issue per finding.
 
 For each genuine follow-up, create an issue with:
 

--- a/.github/prompts/issue-tracker-prompt.md
+++ b/.github/prompts/issue-tracker-prompt.md
@@ -68,10 +68,43 @@ Do not create issues for:
 - Test-coverage suggestions ("add tests for X", "increase coverage", missing
   test remarks from reviewers or bots). This repository deliberately keeps its
   test surface small because internal interfaces break often — see `AGENTS.md`
-  "Testing discipline". File a test follow-up only for a gap the pull request
-  acknowledged and deferred: a reproduced defect that merged without its
-  regression test, or a consequential contract (wire, schema, user-visible
-  output) the diff leaves unprotected.
+  "Testing discipline". A missing test is the *default*, expected state of a
+  merged PR here, not a gap. File a test follow-up only when **both**: (a) the
+  gap is a reproduced, user-visible defect (not a refactor, not a comment or
+  doc fix) that shipped without a regression test, and (b) the PR body or a
+  reviewer explicitly weighed adding that test and chose not to for a stated
+  reason. "The fix works but nobody happened to write a test" is not
+  sufficient by itself — that describes most merged PRs in this repo by
+  design and is not follow-up-worthy on its own.
+- Wording, precision, or clarity fixes to internal docs (proposals, PRDs,
+  ADRs, planning docs) that change no code and no user-facing behavior —
+  including bot-flagged "this claim is imprecise" or "this section is
+  ambiguous" findings. File one only if the doc is normative and the
+  imprecision would visibly mislead an implementer building against it (state
+  which implementation decision would go wrong); otherwise skip.
+- Stale in-code comments or JSDoc that reference a renamed or deleted symbol
+  but do not misdescribe current runtime behavior in a way that could cause a
+  future bug. Fix these inline in the same PR if trivial. They are not worth
+  a standing issue.
+- A finding whose only proposed action is itself "file more issues" or
+  "survey X and open tickets" — meta-tracking work that adds process overhead
+  without doing anything. Either do the survey now and file the results
+  directly, or skip it.
+- A finding that only asks someone to manually look at or visually confirm
+  something ("verify X still renders correctly", "confirm Y looks right")
+  with no concrete code change attached. These have no actionable owner and
+  rot forever unaddressed; if a real regression shows up later, it will be
+  reported on its own.
+
+Apply a one-line test before filing anything: if you described this finding
+to the maintainer in a single sentence, would they say "yes, file that" or
+"meh, don't bother"? If you cannot confidently predict "yes", skip it. A repo
+where every unaddressed nitpick becomes a permanent open issue is worse than
+one that occasionally lets a nitpick go unfiled — err toward silence.
+
+When several minor findings from the same review are individually below the
+filing bar but related (e.g., two stale-comment fixes in the same file),
+prefer folding them into one issue over filing one each.
 
 For each genuine follow-up, create an issue with:
 
@@ -134,9 +167,6 @@ Then add new issues to relevant tracking issue checklists:
 - For an umbrella, append `- [ ] #<umbrella> - Tracking: ...` as a single line.
 - Comment on the parent pull request: `Filed follow-ups from this PR:
 #<umbrella-or-issue>`.
-
-Be conservative. Only create issues for genuine, actionable follow-ups. When in
-doubt, skip it. False positives create noise.
 
 ## Playbook C: Pull Request Activity
 


### PR DESCRIPTION
## Summary

- Tighten the post-merge issue tracker so it does not file standing issues for tests omitted by default, harmless internal-doc wording, stale harmless comments, process-only meta-work, or manual-confirmation requests.
- Add a direct maintainer-value gate before filing.
- Permit consolidation only when every related finding independently clears the filing bar.
- Make the post-merge test-follow-up threshold explicitly stricter than the repository's review-time testing policy.

## Issue acceptance gates

- Reduce low-value automated follow-up issues: satisfied through explicit exclusion categories and the maintainer-value gate.
- Preserve actionable follow-ups: satisfied for reproduced user-visible defects with an explicitly deferred regression test and for other concrete findings that clear the filing bar.
- Keep instructions executable by the post-merge, read-only agent: satisfied after removing the instruction to edit an already-merged PR.
- Avoid contradictory consolidation guidance: satisfied by requiring each folded finding to pass the filing bar.

## Single source of truth

`.github/prompts/issue-tracker-prompt.md` remains the single behavior prompt for post-merge issue filing.

## Duplication and abstraction budget

No new abstraction or parallel prompt is added. The old generic conservative-filing paragraph is removed because the new explicit gate owns that decision.

## Net elements (R6)

- Files: 1 modified, 0 added, 0 deleted.
- Exported symbols/classes/interfaces/enums/functions: n/a.
- LoC: +38/-8, net +30 documentation lines.

The net increase is the explicit category and decision guidance needed to make issue filing reliably selective rather than relying on one generic sentence.

## Consumer counts (R8)

n/a. No runtime emit path or export is changed. The prompt has one workflow consumer, the post-merge issue tracker.

## Host impact

Extension: No runtime impact.

Desktop: No runtime impact.

CLI: No runtime impact.

## Scheduled refactoring

None.

## Validation

- Prettier passed on `.github/prompts/issue-tracker-prompt.md`.
- `git diff --check` passed.
- Automated prompt reviews completed, and all actionable findings were addressed in `e1c5447cba`.
- Docs CI rerun is required before merge.

No test files changed. This is a documentation-only automation prompt change.
