### PR TITLE
refactor(webview): share pasted image chip assembly

### DIFF
--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -15,6 +15,7 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { UnsupportedCommandsMixin } from '@shared/wa/unsupportedCommandsMixin';
 import { RecordingButtonController } from '@shared/litControllers/RecordingButtonController';
+import { appendClipboardImageChips } from '@shared/utils/clipboard';
 import { getTextareaValue, insertTextAtCursor } from '@shared/utils/textarea';
 import {
   clipboardImageFiles,
@@ -208,7 +209,7 @@ export class FollowUpInput extends UnsupportedCommandsMixin(LitElement) {
   ): Promise<void> {
     const target = this.textAreaEl;
     if (!target) return;
-    let insertText = event.clipboardData?.getData('text/plain') || '';
+    const pastedText = event.clipboardData?.getData('text/plain') || '';
     const added = (
       await Promise.all(
         files.map(
@@ -229,11 +230,10 @@ export class FollowUpInput extends UnsupportedCommandsMixin(LitElement) {
     ).filter(filterNotNullish);
     if (pasteRevision !== transientState.imagePasteRevision) return;
     if (added.length === 0) return;
-    const chipText = added.map(({ fileName }) => `[${fileName}]`).join(' ');
-    if (insertText && !insertText.endsWith(' ') && !insertText.endsWith('\n')) {
-      insertText += ' ';
-    }
-    insertText += chipText;
+    const insertText = appendClipboardImageChips(
+      pastedText,
+      added.map(({ fileName }) => fileName),
+    );
     transientState.pendingImages = [...transientState.pendingImages, ...added];
     if (
       this.isConnected &&

--- a/packages/extension/src/webview/frontend/pasteHandler.ts
+++ b/packages/extension/src/webview/frontend/pasteHandler.ts
@@ -1,6 +1,7 @@
 // Local imports - shared utilities
 import { postMessage } from '@shared/hostBridge';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
+import { appendClipboardImageChips } from '@shared/utils/clipboard';
 import { insertTextAtCursor } from '@shared/utils/textarea';
 import {
   clipboardImageFiles,
@@ -24,7 +25,7 @@ export async function handleImagePaste(
   // async yield, so read plain text before the file reads below.
   const pastedText = event.clipboardData?.getData('text/plain') || '';
 
-  const pastedImageText = await Promise.all(
+  const pastedImageNames = await Promise.all(
     images.map(async ({ file, type }) => {
       const fileName = generatePastedImageName(getExtensionFromMimeType(type));
       const base64 = await readFileAsBase64(file);
@@ -39,18 +40,14 @@ export async function handleImagePaste(
         mediaType: type,
         fileName,
       });
-      return `[${fileName}]`;
+      return fileName;
     }),
   );
 
-  const imageChips = pastedImageText.filter(Boolean).join(' ');
-  let insertText = pastedText;
-  if (imageChips) {
-    if (insertText && !insertText.endsWith(' ') && !insertText.endsWith('\n')) {
-      insertText += ' ';
-    }
-    insertText += imageChips;
-  }
+  const insertText = appendClipboardImageChips(
+    pastedText,
+    pastedImageNames.filter(Boolean),
+  );
 
   if (insertText) {
     insertTextAtCursor(target, insertText);

--- a/src/shared/utils/clipboard.ts
+++ b/src/shared/utils/clipboard.ts
@@ -2,6 +2,16 @@ import { normalizeLineEndings } from '@utils/text/stringUtils';
 
 export const COPY_RESET_DELAY_MS = 2000;
 
+export function appendClipboardImageChips(
+  text: string,
+  fileNames: readonly string[],
+): string {
+  if (fileNames.length === 0) return text;
+  const boundary =
+    text && !text.endsWith(' ') && !text.endsWith('\n') ? ' ' : '';
+  return `${text}${boundary}${fileNames.map((name) => `[${name}]`).join(' ')}`;
+}
+
 /**
  * Copy text to clipboard with LF-normalized line endings.
  */


### PR DESCRIPTION
Closes #11224.

## Summary

- Add one shared pure helper for clipboard-image chip formatting and text-boundary spacing.
- Route both the main webview paste handler and progress-view follow-up input through that owner.
- Preserve each flow's distinct image transport, failure, stale-paste, pending-state, and insertion behavior.

## Issue acceptance gates

- One owner formats pasted image filenames as `[name]`: satisfied by `appendClipboardImageChips`.
- One owner applies the existing trailing space/newline boundary rule: satisfied without broadening whitespace semantics.
- Main-view and progress-view paste flows use the same owner: satisfied with two direct production consumers.
- No test files changed: satisfied.

## Single source of truth

`src/shared/utils/clipboard.ts` now owns clipboard-image chip text assembly and the boundary separator rule.

## Duplication and abstraction budget

The helper replaces two character-for-character implementations of the same formatting policy. It has two direct production consumers and no wrapper or pass-through layer. The two stateful paste flows remain separate because their image delivery and state ownership differ.

## Net elements (R6)

- Files: 3 modified, 0 added, 0 deleted.
- Exported symbols: 1 added (`appendClipboardImageChips`).
- Classes/interfaces/enums: 0 added or deleted.
- Functions: 1 added, replacing two inline policy copies.
- LoC: +23/-16, net +7.

## Consumer counts (R8)

- Before: 2 independent production implementations of chip formatting and boundary spacing.
- After: 1 exported owner with 2 direct production consumers.
- No event, IPC, upload, image-read, pending-state, or insertion path was deleted or rerouted.

## Host impact

Extension: Main webview and progress-view image paste now share formatting policy. Runtime output is unchanged.

Desktop: No native-host change. The bundled extension webviews use the shared helper as before.

CLI: No impact.

## Scheduled refactoring

None.

## Validation

- Prettier and ESLint on all 3 changed production files
- `corepack pnpm run typecheck:workspace`
- `node scripts/check-browser-safe-utils.mjs`
- Focused unchanged tests: `PasteHandler.vitest.ts`, `FollowUpInputStreamSwitch.vitest.ts`, and `ClipboardImages.vitest.ts` (3 files, 11 tests passed)
- Independent code review found no issues
- `git diff --check`

No test files changed. Manual browser paste verification was not available in this unattended environment; CI webview smoke remains required before merge.
