### PR TITLE
refactor(agent): type creator tool groups

### DIFF
--- a/src/agent/implementations/agentCreator/agentCreatorFlow.ts
+++ b/src/agent/implementations/agentCreator/agentCreatorFlow.ts
@@ -18,6 +18,7 @@ import { buildUserVarPassthrough } from '@agent/prompt/userVars';
 import { createLog } from '@logger/logUtils';
 import type { AgentCategory } from '@shared/schemas';
 import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
+import type { RegisteredToolName } from '@tools/registry';
 import { createTexraNunjucksEnvironment } from '@utils/prompt';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -54,7 +55,7 @@ interface AgentBlueprint {
 
 interface ToolGroup {
   description: string;
-  tools: string[];
+  tools: readonly RegisteredToolName[];
   keywords: string[];
 }
 


### PR DESCRIPTION
Closes #11229.

## Summary

Bind agent-creator tool groups to the canonical `RegisteredToolName` union instead of plain strings. Tool renames, removals, and typos in `TOOL_GROUPS` now fail at compile time. Runtime data and behavior are unchanged.

## Issue acceptance gates

- `ToolGroup.tools` uses the registry's canonical tool-name type: satisfied with `readonly RegisteredToolName[]`.
- Existing tool literals typecheck without correction: satisfied.
- Existing runtime catalog cross-check remains unchanged: satisfied.
- No test files changed: satisfied.

## Single source of truth

`RegisteredToolName` from `src/tools/registry.ts` remains the canonical compile-time set of registered tool identifiers.

## Duplication and abstraction budget

No abstraction is added. The existing field is narrowed directly to the canonical type through a type-only import.

## Net elements (R6)

- Files: 1 modified, 0 added, 0 deleted.
- Exported symbols/classes/interfaces/enums/functions: 0 added or deleted.
- LoC: +2/-1, net +1.

## Consumer counts (R8)

n/a. No emit path or export is deleted or rerouted. Existing consumers still read the same runtime arrays.

## Host impact

Extension: Compile-time protection only, no runtime change.

Desktop: Compile-time protection only, no runtime change.

CLI: Compile-time protection only, no runtime change.

## Scheduled refactoring

None.

## Validation

- Prettier and ESLint on `agentCreatorFlow.ts`
- `npm run typecheck:workspace`
- Unchanged `AgentCreatorOrchestration.vitest.ts` (17 passed)
- `git diff --check`

No test files changed.
