### PR TITLE
fix(extension): drain lifecycle after activation failure

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -118,6 +118,29 @@ let apiKeyStatusBarItem: vscode.StatusBarItem | undefined;
 // idempotency flag, so a stale module-level instance would silently swallow
 // handlers registered by a second activate() in the same process.
 let lifecycleHost: LifecycleHost | undefined;
+let extensionShutdownPromise: Promise<void> | undefined;
+
+function shutdownExtension(): Promise<void> {
+  if (extensionShutdownPromise) return extensionShutdownPromise;
+
+  const host = lifecycleHost;
+  const shutdownPromise = (async () => {
+    try {
+      await host?.runShutdown();
+    } finally {
+      if (lifecycleHost === host) lifecycleHost = undefined;
+      teardownDefaultSession();
+    }
+  })();
+  extensionShutdownPromise = shutdownPromise;
+  const clearShutdownPromise = () => {
+    if (extensionShutdownPromise === shutdownPromise) {
+      extensionShutdownPromise = undefined;
+    }
+  };
+  void shutdownPromise.then(clearShutdownPromise, clearShutdownPromise);
+  return shutdownPromise;
+}
 
 function installUnhandledRejectionSurface(
   subscriptions: vscode.Disposable[],
@@ -172,6 +195,23 @@ async function refreshApiKeyStatus() {
 }
 
 export async function activate(context: vscode.ExtensionContext) {
+  try {
+    await activateExtension(context);
+  } catch (activationError) {
+    if (lifecycleHost !== undefined) {
+      try {
+        await shutdownExtension();
+      } catch (cleanupError) {
+        log.error('Extension cleanup after failed activation failed', {
+          data: cleanupError,
+        });
+      }
+    }
+    throw activationError;
+  }
+}
+
+async function activateExtension(context: vscode.ExtensionContext) {
   installUnhandledRejectionSurface(context.subscriptions);
   const workspaceFolders = vscode.workspace.workspaceFolders;
 
@@ -223,6 +263,7 @@ export async function activate(context: vscode.ExtensionContext) {
       }),
   });
   lifecycleHost = lifecycle;
+  lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => clearVscodeLeanServerEntries());
   const languageModel = createLanguageModelPort(context);
   // Shared `~/.texra` storage root (one history across CLI/desktop/extension,
   // #8622).
@@ -294,6 +335,15 @@ export async function activate(context: vscode.ExtensionContext) {
       agentResponseTextConnector,
     ),
   });
+  // `disposeStatusListener` and `statusBarItem` are owned solely by
+  // `context.subscriptions` (see the push near the end of `activate`), matching
+  // `apiKeyStatusBarItem`. Registering them here too would double-dispose.
+  registerAgentShutdownHandlers(lifecycle);
+  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => killActiveRecording());
+  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => UsageLogService.dispose());
+  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
+    runtimeSession.flushArtifacts(),
+  );
   await runtimeSession.waitUntilReady();
   runtimeSession.setApprovalPolicy(
     readPersistedTexraApprovalPolicy((key, fallback) =>
@@ -311,18 +361,9 @@ export async function activate(context: vscode.ExtensionContext) {
     cwd: workspaceRoot,
     resourcesPath: path.join(context.extensionPath, 'resources'),
   });
-  // `disposeStatusListener` and `statusBarItem` are owned solely by
-  // `context.subscriptions` (see the push near the end of `activate`), matching
-  // `apiKeyStatusBarItem`. Registering them here too would double-dispose.
-  registerAgentShutdownHandlers(lifecycle);
-  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => killActiveRecording());
-  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => UsageLogService.dispose());
-  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
-    runtimeSession.flushArtifacts(),
-  );
-  // First ON handler: every BEFORE handler above has had its turn at the runs
-  // it owns, so this settles what closing the window left mid-run — a durable
-  // CANCELLED outcome and a released lease instead of a record the next
+  // First settling ON handler: every BEFORE handler above has had its turn at
+  // the runs it owns, so this settles what closing the window left mid-run: a
+  // durable CANCELLED outcome and a released lease instead of a record the next
   // activation has to repair.
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, (signal) =>
     settleLiveSessionExecutions(signal),
@@ -505,11 +546,6 @@ export async function activate(context: vscode.ExtensionContext) {
             : undefined;
         const editorType = vscode.env.appName || undefined;
         UsageLogService.initialize({}, extensionVersion, editorType);
-        // Not redundant with the shutdown hook: VS Code skips deactivate()
-        // when activate() throws, but always disposes subscriptions.
-        context.subscriptions.push({
-          dispose: () => void UsageLogService.dispose(),
-        });
       } catch (usageError) {
         log.warn(
           `Usage logging service failed to initialize: ${toErrorMessage(usageError)}`,
@@ -778,12 +814,5 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 export async function deactivate() {
-  const host = lifecycleHost;
-  lifecycleHost = undefined;
-  try {
-    clearVscodeLeanServerEntries();
-    await host?.runShutdown();
-  } finally {
-    teardownDefaultSession();
-  }
+  await shutdownExtension();
 }


### PR DESCRIPTION
Closes #10676.

## Summary

- Route extension activation failures through the same lifecycle shutdown authority as normal deactivation.
- Share one in-flight extension shutdown promise so concurrent callers await one drain and default-session teardown runs once.
- Register failure-critical shutdown handlers as soon as the runtime session exists.
- Give VS Code Lean cache cleanup and UsageLog disposal one lifecycle owner each.

This closes the last clearly actionable production gap in the five-roots lifecycle migration. Remaining proposal ideas around recording ownership, inline-agent scope, and LaTeX cancellation require separate product or API decisions and are not mechanical teardown consolidation.

## Issue acceptance gates

- Activation failures after lifecycle ownership trigger orderly shutdown: satisfied.
- Cleanup failures do not replace the original activation error: satisfied.
- Normal deactivation and activation failure use one extension shutdown path: satisfied.
- Concurrent shutdown calls share the lifecycle drain: satisfied.
- Default-session teardown runs after lifecycle shutdown, including rejected drains: satisfied.
- UsageLog and VS Code Lean cleanup have one process-root owner: satisfied.
- No test files changed: satisfied.

## Single source of truth

`shutdownExtension()` owns extension process-root shutdown. `LifecycleHost` remains the ordered owner of BEFORE and ON cleanup handlers.

## Duplication and abstraction budget

The internal `activateExtension()` boundary keeps the existing activation body unchanged while the exported `activate()` owns failure cleanup. This avoids a 500-line indentation diff and gives the wrapper a distinct error-boundary responsibility. Duplicate UsageLog subscription cleanup and the direct Lean cleanup call are removed.

## Net elements (R6)

- Files: 1 modified, 0 added, 0 deleted.
- Exported symbols: 0 added or deleted.
- Functions: 2 net added (`shutdownExtension`, internal `activateExtension`).
- Classes/interfaces/enums: 0 added or deleted.
- LoC: +54/-25, net +29.

The net increase implements one shared asynchronous failure boundary and explicit in-flight shutdown coordination without adding a parallel lifecycle owner.

## Consumer counts (R8)

- Extension shutdown entry paths: 2 (`deactivate` and activation failure) now consume 1 owner.
- UsageLog shutdown registrations: 2 before, 1 after.
- VS Code Lean cleanup paths: 1 direct deactivation call before, 1 lifecycle registration after.
- No runtime event or public export is deleted.

## Host impact

Extension: Partial activation now drains lifecycle resources. Normal deactivation keeps the same ordered cleanup behavior.

Desktop: No code or behavior change.

CLI: No code or behavior change.

## Scheduled refactoring

None in this PR. Recording owner identity, public inline-agent scope, and LaTeX cancellation propagation need independent decisions before any implementation.

## Validation

- Prettier and ESLint on `packages/extension/src/extension.ts`
- `npm run typecheck:workspace`
- Unchanged focused suites: `LifecycleHost.vitest.ts`, `DefaultSessionLifecycle.vitest.ts`, `AgentShutdown.vitest.ts`, and `DirectLspAdapter.vitest.ts` (4 files, 39 tests passed)
- Independent review found no remaining issues after two fixes
- `git diff --check`

No test files changed.
