### PR TITLE
fix(tools): preserve Claude task tools after SDK bump

### DIFF
--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -226,7 +226,7 @@ export async function runStreamedTurn(params: {
     model: params.model,
     permissionMode: params.permissionMode,
     effort: params.effort,
-    env: params.env,
+    env: { ...params.env, CLAUDE_CODE_ENABLE_TODO_TOOLS: '1' },
     systemPrompt: { type: 'preset', preset: 'claude_code' },
     settingSources: ['user', 'project', 'local'],
   };

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -226,7 +226,7 @@ export async function runStreamedTurn(params: {
     model: params.model,
     permissionMode: params.permissionMode,
     effort: params.effort,
-    env: { ...params.env, CLAUDE_CODE_ENABLE_TODO_TOOLS: '1' },
+    env: params.env,
     systemPrompt: { type: 'preset', preset: 'claude_code' },
     settingSources: ['user', 'project', 'local'],
   };

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -204,6 +204,7 @@ export async function buildClaudeAgentEnv(
 ): Promise<NodeJS.ProcessEnv> {
   const env: NodeJS.ProcessEnv = { ...process.env };
   env.CLAUDE_AGENT_SDK_CLIENT_APP = 'texra';
+  env.CLAUDE_CODE_ENABLE_TODO_TOOLS = '1';
   const oauthToken = env.CLAUDE_CODE_OAUTH_TOKEN?.trim();
   if (oauthToken) {
     env.CLAUDE_CODE_OAUTH_TOKEN = oauthToken;


### PR DESCRIPTION
## Summary

- preserve Claude Code task and todo tools after the Agent SDK 0.3.233 default-surface change
- use the SDK's documented compatibility environment flag instead of replacing the default tool list or changing permission semantics
- retain every caller-provided subprocess environment value

Closes #11243

## Release review

Reviewed all six dependency updates from #11241 against TeXRA's actual consumers:

- `@anthropic-ai/claude-agent-sdk`: found and fixed the task-tool regression for newer Claude model families
- `@anthropic-ai/sdk`: streamed message accumulation changes are compatible and improve final reasoning-token accounting
- `@google/genai`: removed deprecated Turn types and structured speech config are not used by TeXRA
- `@openrouter/sdk`: changed generated Responses/subagent shapes are outside TeXRA's chat API usage
- `@cantoo/pdf-lib`: load and page-count paths remain compatible
- `fast-xml-parser`: configured XMLParser path remains compatible

## Validation

- `npm run typecheck`
- 264 focused tests across Claude Agent SDK, Anthropic, Google, OpenRouter, PDF, and XML paths
- additional focused Claude agent config/adapter tests: 18 passed
- independent dependency/API review: no other compatibility defect found
- `npx eslint src/tools/claudeAgent.ts`
- `git diff --check`

No test files were changed.
