### PR TITLE
docs(agent): fix stale SessionHandle.executions ownership comment

### DIFF
--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -143,7 +143,11 @@ export interface WorkspaceStorageTransitionHooks {
 }
 
 export class SessionHandle {
-  /** Per-run execution handles; owns the process-output poller + status sub. */
+  /**
+   * Per-run execution handles: registration, lookup, change listeners, and
+   * subagent lineage. Owns the status subscription bound to the hub
+   * {@link status} publishes on.
+   */
   readonly executions: ExecutionRegistry;
   /** Execution-status subscriptions bound to agent stream lifecycles. */
   readonly subscriptions: ExecutionSubscriptionBinder;


### PR DESCRIPTION
## Summary

Scheduled routine: audit the codebase for confusing or overlapped module/class responsibilities and, for the most significant finding, draft a clarifying PR.

The audit (four parallel structural sweeps + a docs/ratchet sweep) checked the boundaries CLAUDE.md calls out explicitly — `eventBus`/`agent/trace`/`SessionEventHub`, `controllers`/`shared`/`agent/core`, `model`/`agent/modelHandlers`, cross-host duplication in `packages/{extension,desktop,cli}`, `tools`/`replacement`/`latex`, and the settings-schema split — and found all of them cleanly separated in current code, actively enforced by ESLint rules, ratchets, or documented one-way import DAGs.

The one concrete, still-open item is self-documented by the team's own 2026-08-15 lifecycle-ownership audit (`docs/proposals/2026-08-15-lifecycle-ownership.md`, §7 "Honest notes", reaffirmed in the 2026-08-19 reconciliation note): a stale comment on `SessionHandle.executions` claiming it "owns the process-output poller + status sub". No such poller exists anywhere in `ExecutionRegistry` (`src/agent/runtime/executionRegistry.ts`) — that class's own header already describes its real job as "registry of active executions and their change listeners", plus a status subscription bound to the hub it's constructed with. The stale comment is exactly the kind of thing that misleads a future reader about what a component actually owns, so this PR fixes it in place.

Everything else this initiative's own docs list as open (`docs/proposals/2026-08-15-lifecycle-ownership.md` fixes 5/7, step 6/8/9; `docs/proposals/2026-08-16-services-injection-audit.md`'s option-bag/threading residue; the frozen `host-agent-import-baseline`/`host-agent-mock-baseline` ratchets) is already tracked and staged by that ongoing, adjudicated initiative — not something a one-off PR should reach into without colliding with its explicit PR ordering (`docs/proposals/2026-08-15-lifecycle-ownership.md` §6).

## Issue acceptance gates

No linked issue — this is a scheduled codebase audit. Gate: identify overlapping/confusing responsibilities; for the most significant *unclaimed* one, ship a clarifying fix. Satisfied by the comment correction below.

## Single source of truth

`ExecutionRegistry`'s own class-level doc comment (`src/agent/runtime/executionRegistry.ts:127-131`) is the source of truth for what it owns; `SessionHandle`'s field comment now matches it instead of contradicting it.

## Duplication and abstraction budget

No duplication removed or added — doc-only correction, no new abstraction.

## Net elements (R6)

n/a — comment-only change, 1 file, +5/-1 lines, no exported symbols touched.

## Consumer counts (R8)

n/a — no emit path, export, or public API changed.

## Host impact

Extension: none (doc comment only)

Desktop: none (doc comment only)

CLI: none (doc comment only)

## Scheduled refactoring

None. The larger, already-tracked lifecycle-ownership and services-injection follow-ups remain owned by their existing proposal docs and staged PR plan.

## Validation

Comment-only change to `src/agent/runtime/SessionHandle.ts`; no behavior affected. Not run: `npm run typecheck`/`npm test` (no code paths changed, only a JSDoc comment).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Cewq4mDRDF1t4YJdwnC7eA)_