### PR TITLE
consolidate: share isImageMimeType and getBasename instead of re-deriving them per call site

### DIFF
--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -33,7 +33,7 @@ import { isKnownUnsupported } from '@shared/utils/dispatcher';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
-import { normalizeFilePath } from '@utils/core';
+import { getBasename, normalizeFilePath } from '@utils/core';
 import { ELEMENT_IDS } from '../constants';
 import { ProgressEvents } from '../events';
 import { getComposedPathElement } from '../utils';
@@ -100,12 +100,12 @@ interface ParsedPath {
 /** Parse a path into directory and basename components */
 function parsePath(path: string): ParsedPath {
   const normalized = normalizeFilePath(path);
-  // With no slash, lastIndexOf is -1 and both slices already yield the
-  // fallbacks: '' for dir, the whole path for basename.
+  // With no slash, lastIndexOf is -1 and the dir slice already yields the
+  // fallback: '' for dir.
   const lastSlash = normalized.lastIndexOf('/');
   return {
     dir: normalized.slice(0, lastSlash + 1),
-    basename: normalized.slice(lastSlash + 1),
+    basename: getBasename(normalized),
   };
 }
 

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -33,9 +33,10 @@ import {
 } from '@shared/wa/actionButtons';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
+import { isKnownUnsupported } from '@shared/utils/dispatcher';
+import { getBasename } from '@utils/core';
 
 // Local imports - shared schemas and events
-import { isKnownUnsupported } from '@shared/utils/dispatcher';
 import { pluralize } from '@utils/text/stringUtils';
 import { agentSelectionPanelStyles } from './AgentSelectionPanel.styles';
 
@@ -458,7 +459,7 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
         ${
           agent.filePath
             ? html`<div class="agent-detail-path" title=${agent.filePath}>
-                ${agent.filePath.split(/[/\\]/).pop() ?? agent.filePath}
+                ${getBasename(agent.filePath)}
               </div>`
             : nothing
         }

--- a/src/agent/export/normalizeConversation.ts
+++ b/src/agent/export/normalizeConversation.ts
@@ -32,6 +32,7 @@ import {
   WebSearchResultEntrySchema,
 } from '@agent/types/ServerTools';
 import { assertNever, isObject } from '@utils/core';
+import { isImageMimeType } from '@utils/files/mimeUtils';
 import type { Part } from '@google/genai';
 import type {
   ChatCompletionMessageParam,
@@ -229,7 +230,7 @@ function googlePartToBlocks(part: Part): ContentBlock[] {
   const blob = part.inlineData ?? part.fileData;
   if (blob && typeof blob === 'object') {
     const { mimeType } = blob as { mimeType?: string };
-    return mimeType?.startsWith('image/')
+    return isImageMimeType(mimeType)
       ? [{ type: 'image' }]
       : [{ type: 'document' }];
   }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -84,6 +84,7 @@ import {
   ModelCompactionThresholdPercentSchema,
 } from '@shared/schemas';
 import { isObject } from '@utils/core';
+import { isImageMimeType } from '@utils/files/mimeUtils';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { extractScratchpad } from '@utils/text/xmlExtraction';
 import {
@@ -159,7 +160,7 @@ function mediaAttachmentKindsFromEntries(
   entries: readonly MediaEntry[],
 ): MediaAttachmentKind[] {
   return entries.map((entry) =>
-    entry.media_category === 'image' && entry.media_type.startsWith('image/')
+    entry.media_category === 'image' && isImageMimeType(entry.media_type)
       ? 'image'
       : 'document',
   );

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -52,6 +52,7 @@ import {
   type ToolResult,
 } from '@shared/schemas';
 import { filterNotNull, generateShortId, isNonEmptyString } from '@utils/core';
+import { isImageMimeType } from '@utils/files/mimeUtils';
 import { joinNonEmpty, pluralize } from '@utils/text/stringUtils';
 import { getConfig } from '@utils/config/configUtils';
 
@@ -765,7 +766,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   } {
     // Interactions DocumentContent currently has no resolution field, so PDF
     // resolution cannot be selected until the SDK exposes it.
-    if (this.isGemini3Model() && mimeType.startsWith('image/')) {
+    if (this.isGemini3Model() && isImageMimeType(mimeType)) {
       return { resolution: 'high' };
     }
     return {};
@@ -1028,7 +1029,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
    * both sources — the only difference is the data/uri field.)
    */
   protected buildMedia(source: GoogleMediaSource, mimeType: string): Content {
-    if (mimeType.startsWith('image/')) {
+    if (isImageMimeType(mimeType)) {
       return {
         type: 'image',
         ...source,

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -56,6 +56,7 @@ import {
   DEFAULT_CORE_SETTINGS,
 } from '@shared/schemas';
 import { clamp, filterNotNullish } from '@utils/core';
+import { isImageMimeType } from '@utils/files/mimeUtils';
 import { getWebSocketEnabled } from '@utils/config/providerConfig';
 import { getConfig } from '@utils/config/configUtils';
 
@@ -1219,7 +1220,7 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
       const mediaType = media.media_type ?? '';
       const classification = classifyMediaEntry(media);
 
-      if (classification === 'image' && mediaType.startsWith('image/')) {
+      if (classification === 'image' && isImageMimeType(mediaType)) {
         return [
           createInputText(`Image: ${media.file_name}`),
           {

--- a/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
@@ -19,7 +19,7 @@ import type { AgentTrace } from '@agent/trace';
 import { buildErrorLogData } from '@common/errors/sdkError/providerErrorFormat';
 import type { ToolFileAttachment } from '@shared/schemas';
 import { isNonEmptyString } from '@utils/core';
-import { OFFICE_MIME_TYPES } from '@utils/files/mimeUtils';
+import { isImageMimeType, OFFICE_MIME_TYPES } from '@utils/files/mimeUtils';
 
 import { loadAttachmentBuffer, wipeBuffer } from '../utils/toolAttachmentUtils';
 import { toDataUrl } from '../support/dataUrl';
@@ -198,7 +198,7 @@ export async function uploadToolAttachments(
       uploaded.push({
         attachment,
         fileId: uploadedFile.id,
-        isImage: mimeType.startsWith('image/'),
+        isImage: isImageMimeType(mimeType),
       });
     } catch (err) {
       reportMediaAttachmentFailure(
@@ -235,7 +235,7 @@ export async function buildInlineAttachmentParts(
 
   for (const attachment of attachments) {
     const mimeType = attachment.mimeType ?? 'application/octet-stream';
-    const isImage = mimeType.startsWith('image/');
+    const isImage = isImageMimeType(mimeType);
     const isFileInput = INLINEABLE_FILE_MIME_TYPES.has(mimeType);
 
     if (!isImage && !isFileInput) {

--- a/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
+++ b/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
@@ -15,7 +15,7 @@ import {
 import { ensureArray } from '@utils/core';
 import { getPromptFileName } from '@utils/prompt';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
-import { getMimeType } from '@utils/files/mimeUtils';
+import { getMimeType, isImageMimeType } from '@utils/files/mimeUtils';
 import { getExtensionLowercase } from '@utils/core/pathCore';
 import {
   countPdfPages,
@@ -88,7 +88,7 @@ export class MediaAttachmentProcessor {
   ): Promise<ProcessImageResult> {
     if (ext !== '.pdf') {
       const mimeType = getMimeType(mediaFile);
-      if (!mimeType?.startsWith('image/')) {
+      if (!mimeType || !isImageMimeType(mimeType)) {
         throw new Error(
           `Unsupported image extension: ${ext}. Image support: ${this.capabilities.supportsVision}`,
         );

--- a/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
+++ b/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
@@ -42,7 +42,7 @@ import type {
   ToolFileAttachment,
   ToolResult,
 } from '@shared/schemas';
-import { getMimeType } from '@utils/files/mimeUtils';
+import { getMimeType, isImageMimeType } from '@utils/files/mimeUtils';
 
 // Local file imports
 import { ModelHandler } from '../ModelHandler';
@@ -167,7 +167,7 @@ function requireSupportedMedia(
 
   const unsupported = mediaFiles.find(({ absolutePath }) => {
     const mimeType = getMimeType(absolutePath);
-    return mimeType !== 'application/pdf' && !mimeType?.startsWith('image/');
+    return mimeType !== 'application/pdf' && !isImageMimeType(mimeType);
   });
   if (unsupported) throw new Error(IMAGE_INPUT_ONLY_ERROR);
 }
@@ -335,7 +335,7 @@ export class ModelHandlerVscodeLm extends ModelHandler<
     return mediaMessage.map((media) => {
       if (
         media.media_category !== 'image' ||
-        !media.media_type.startsWith('image/')
+        !isImageMimeType(media.media_type)
       ) {
         throw new Error(IMAGE_INPUT_ONLY_ERROR);
       }

--- a/src/agent/storage/conversationFormat.ts
+++ b/src/agent/storage/conversationFormat.ts
@@ -29,6 +29,7 @@ import {
 } from '@agent/types/ConversationBlockTypes';
 import { extractWebFetchResultFields } from '@agent/types/ServerTools';
 import { assertNever, isObject } from '@utils/core';
+import { isImageMimeType } from '@utils/files/mimeUtils';
 
 const HIDDEN_PROVIDER_REASONING_MARKER = '[provider reasoning hidden]';
 
@@ -228,7 +229,7 @@ function formatConversationBlock(
       objectStringField(block.fileData, 'mime_type') ||
       objectStringField(block.image_url, 'mime_type') ||
       objectStringField(block.source, 'media_type');
-    return mimeType.startsWith('image/')
+    return isImageMimeType(mimeType)
       ? '[image attachment]'
       : '[document attachment]';
   }

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -18,6 +18,7 @@ import { hasExtension, getExtensionLowercase } from '@utils/core/pathCore';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import {
   getMimeType,
+  isImageMimeType,
   OFFICE_EXTENSIONS,
   OFFICE_MIME_TYPES,
 } from '@utils/files/mimeUtils';
@@ -212,7 +213,7 @@ export class ReadFileTool extends defineTool({
 
     // Treat SVG as an image attachment so vision-capable models can inspect its rendered appearance
     // even though the underlying file is XML text.
-    if (mimeType?.startsWith('image/') || IMAGE_EXTENSIONS.has(extension)) {
+    if (isImageMimeType(mimeType) || IMAGE_EXTENSIONS.has(extension)) {
       return 'image';
     }
 

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -9,7 +9,7 @@ import {
 } from '@tools/pathResolution';
 import { wrapApiCall } from '@tools/utils';
 import { isNonEmptyString } from '@utils/core';
-import { getMimeType } from '@utils/files/mimeUtils';
+import { getMimeType, isImageMimeType } from '@utils/files/mimeUtils';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { toPosixPath } from '@utils/core/pathCore';
 
@@ -73,7 +73,7 @@ export function buildBytesAttachment({
   bytes,
   description,
 }: BuildBytesAttachmentOptions): ToolFileAttachment {
-  if (mimeType.startsWith('image/') && isOversizedImage(bytes)) {
+  if (isImageMimeType(mimeType) && isOversizedImage(bytes)) {
     return {
       path,
       mimeType,

--- a/src/utils/files/mimeUtils.ts
+++ b/src/utils/files/mimeUtils.ts
@@ -51,6 +51,11 @@ export function getMimeType(filePath: string): string | null {
   return mime.lookup(filePath) || null;
 }
 
+/** True when the MIME type is in the `image/*` family. */
+export function isImageMimeType(mimeType: string | null | undefined): boolean {
+  return mimeType?.startsWith('image/') ?? false;
+}
+
 /** File extensions for binary office document formats (case-insensitive, with leading dot). */
 export const OFFICE_EXTENSIONS: ReadonlySet<string> = new Set([
   // Word processing

--- a/src/utils/media/img.ts
+++ b/src/utils/media/img.ts
@@ -10,7 +10,7 @@ import { fromPath } from 'pdf2pic';
 import { createLog } from '@logger/logUtils';
 import { generateShortId } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
-import { getMimeType } from '@utils/files/mimeUtils';
+import { getMimeType, isImageMimeType } from '@utils/files/mimeUtils';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { createTexraTempDir } from '@utils/files/tempDir';
 import { getConfig } from '@utils/config/configUtils';
@@ -121,7 +121,7 @@ export async function getBase64EncodedMedia(
   let tempPath: string | null = null;
 
   try {
-    if (mimeType?.startsWith('image/')) {
+    if (isImageMimeType(mimeType)) {
       const resizedPath = await resizeImageIfNeeded(absolutePath);
       if (resizedPath !== absolutePath) {
         tempPath = resizedPath;


### PR DESCRIPTION
## Summary

Scheduled tech-debt survey (native-method/duplication sweep) turned up two small, real duplications that had no shared owner. This repo already runs a continuous tech-debt tournament (900+ closed `tech-debt` issues, near-daily proposals through 2026-08-20), so most of the classic duplication classes (array dedup, deep clone, UUIDs, `hasOwnProperty`, mutex, promise-chain queues, per-provider model-handler helpers, webview manager/slice logic) are already consolidated — three parallel background surveys confirmed this and found almost nothing left. These two survived:

1. `mimeType.startsWith('image/')` (or its nullable/negated variants) was repeated verbatim at 14 call sites across `src/tools/` and `src/agent/modelHandlers/`, even though `mimeUtils.ts` already owns MIME-type resolution for the same files. Added `isImageMimeType(mimeType)` there and swapped in every site.
2. Two webview files reinvented basename extraction instead of using the existing `getBasename` from `@utils/core`: a manual `lastIndexOf('/')` slice in `progressView/FileList.ts`, and a manual `split(/[/\\]/).pop()` in `settingsView/AgentSelectionPanel.ts`. Both reimplementations were narrower than `getBasename` (neither handled `\` the same way `normalizeFilePath` does), and both files already import from `@utils/core` for other path helpers.

## Issue acceptance gates

No tracking issue — filed directly as a PR per the scheduled task's "propose PR" instruction. Acceptance gate: replace all identified duplicate sites with the shared helper, behavior-preserving, with green typecheck/lint/tests.

## Single source of truth

`isImageMimeType` in `src/utils/files/mimeUtils.ts` now owns the `image/*` MIME-family check. `getBasename` in `src/utils/core/index.ts` (pre-existing) now owns basename extraction for the two webview files that previously reinvented it.

## Duplication and abstraction budget

Removed: 14 inline repeats of the same MIME-prefix check, 2 inline repeats of basename-splitting logic that both silently dropped `getBasename`'s backslash handling. No new abstraction layer — `isImageMimeType` is a single pure function with 14 real call sites in files that already imported from the same module; `getBasename` already existed and had other consumers, this just adds 2 more.

## Net elements (R6)

- Files: 14 changed, 0 added, 0 deleted
- Exported symbols (`^[+-]export` over the diff): +1 (`isImageMimeType`), 0 deleted
- Classes/interfaces/enums: 0 added, 0 deleted
- Net LoC: `git diff --stat origin/main` → 14 files changed, 37 insertions(+), 25 deletions(-) → **net +12 LoC** (the one new 4-line helper function, offset by the deleted duplicate one-liners)

## Consumer counts (R8)

`isImageMimeType` — 14 call sites across 11 files, all verified live production call sites via `rg`:
`src/utils/media/img.ts`, `src/tools/ReadTool.ts`, `src/tools/attachments.ts`, `src/agent/storage/conversationFormat.ts`, `src/agent/export/normalizeConversation.ts`, `src/agent/modelHandlers/openai/openAIResponseFileUploads.ts` (2 sites), `src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts`, `src/agent/modelHandlers/support/MediaAttachmentProcessor.ts`, `src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts` (2 sites), `src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts` (2 sites), `src/agent/modelHandlers/ModelHandler.ts`.

`getBasename` — not a new export (pre-existing, already has other consumers e.g. `FileSelectGroup.ts`); this PR adds 2 more call sites (`FileList.ts`, `AgentSelectionPanel.ts`).

## Host impact

Extension: `FileList.ts` (progressView) and `AgentSelectionPanel.ts` (settingsView) now render basenames identically to how the webview tree already does via `getBasename` — cosmetic only, no behavior change for the paths these display (file/agent display names never carry a trailing slash).

Desktop: no changes.

CLI: none of the touched model-handler/tools files are CLI-specific; behavior is shared across all hosts through the host-agnostic `src/agent/` and `src/tools/` layers.

## Scheduled refactoring

None — this is the full scope of the two candidates found.

## Validation

- `npm run format` — clean (only intended files reformatted; unrelated prettier-drift changes from the fresh `pnpm install` in this session were reverted before commit)
- `npm run typecheck` — passes across workspace, test-kernel, agent, CLI, trace-viewer, desktop
- `npm run lint` — clean (one import-order autofix applied)
- `npm run check:dead-code-ratchet` — OK, no new findings
- Targeted `vitest`: `FileList.vitest.ts`, `ModelHandlerVscodeLm.vitest.ts`, `OpenAIResponseFileUploads.vitest.ts`, `ModelHandlerOpenAIResponse.vitest.ts`, `MediaAttachmentProcessor.vitest.ts`, `normalizeConversation.vitest.ts`, `AgentSelectionPanelToggle.vitest.ts`, `Attachments.vitest.ts`, `ExecutionsConversationFormat.vitest.ts`, `ReadToolRange.vitest.ts`, `FilesUtils.vitest.ts`, and all `GoogleInteractions*`/`GoogleClient*` suites — 247 tests, all passing.
