### PR TITLE
refactor(tests): repo-wide 104-batch test simplifier sweep

### DIFF
--- a/src/test-kernel/agent/RunScopedToolOverlay.vitest.ts
+++ b/src/test-kernel/agent/RunScopedToolOverlay.vitest.ts
@@ -44,6 +44,37 @@ function approvalGatedTool(name: string): ITool {
   return { ...tool(name), requiresApproval: true };
 }
 
+/**
+ * A model handler whose `createResponse` records the tools it was offered
+ * and then throws, stopping the flow right after tool assembly so the test
+ * can inspect exactly what the model saw.
+ */
+function stopAfterToolObservationHandler<T extends { name: string }>(
+  observedTools: T[][],
+) {
+  const stopAfterObservation = Object.assign(new Error('Tool list observed'), {
+    status: 401,
+  });
+  return {
+    capabilities: { supportsFunctionCalling: true, supportsVision: false },
+    config: { provider: 'test' },
+    supportsForcedToolChoice: false,
+    requiresPerCallSystemPrompt: false,
+    initializeMessages: async () => [{ role: 'user', content: 'test' }],
+    consumeInsertedAttachmentKinds: () => [],
+    getClient: async () => ({}),
+    getCredentialRouteForClient: () => undefined,
+    setOutputStreaming: () => {},
+    getWireRouteKey: () => 'test',
+    getModelRetryRouteKey: () => 'test:model',
+    extractAssistantText: () => undefined,
+    createResponse: async (options: { tools?: T[] }) => {
+      observedTools.push(options.tools ?? []);
+      throw stopAfterObservation;
+    },
+  };
+}
+
 describe('run-scoped tool overlay', () => {
   setupPlatform({ workspacePath: process.cwd() });
 
@@ -61,32 +92,7 @@ describe('run-scoped tool overlay', () => {
     const warn = vi.fn<typeof noopTrace.warn>();
     const logger = { ...noopTrace, warn };
     const observedTools: { name: string; forceFunctionCall?: boolean }[][] = [];
-    const stopAfterObservation = Object.assign(
-      new Error('Tool list observed'),
-      {
-        status: 401,
-      },
-    );
-    const modelHandler = {
-      capabilities: { supportsFunctionCalling: true, supportsVision: false },
-      config: { provider: 'test' },
-      supportsForcedToolChoice: false,
-      requiresPerCallSystemPrompt: false,
-      initializeMessages: async () => [{ role: 'user', content: 'test' }],
-      consumeInsertedAttachmentKinds: () => [],
-      getClient: async () => ({}),
-      getCredentialRouteForClient: () => undefined,
-      setOutputStreaming: () => {},
-      getWireRouteKey: () => 'test',
-      getModelRetryRouteKey: () => 'test:model',
-      extractAssistantText: () => undefined,
-      createResponse: async (options: {
-        tools?: { name: string; forceFunctionCall?: boolean }[];
-      }) => {
-        observedTools.push(options.tools ?? []);
-        throw stopAfterObservation;
-      },
-    };
+    const modelHandler = stopAfterToolObservationHandler(observedTools);
     const modelCell = testModelCell(modelHandler, CONFIG.model);
     // The run context reads the same cell the flow drives, as a launch does.
     const context = createRunContext({ runScope, modelCell });
@@ -149,28 +155,7 @@ describe('run-scoped tool overlay', () => {
       signal: new AbortController().signal,
     });
     const observedTools: { name: string }[][] = [];
-    const stopAfterObservation = Object.assign(
-      new Error('Tool list observed'),
-      { status: 401 },
-    );
-    const modelHandler = {
-      capabilities: { supportsFunctionCalling: true, supportsVision: false },
-      config: { provider: 'test' },
-      supportsForcedToolChoice: false,
-      requiresPerCallSystemPrompt: false,
-      initializeMessages: async () => [{ role: 'user', content: 'test' }],
-      consumeInsertedAttachmentKinds: () => [],
-      getClient: async () => ({}),
-      getCredentialRouteForClient: () => undefined,
-      setOutputStreaming: () => {},
-      getWireRouteKey: () => 'test',
-      getModelRetryRouteKey: () => 'test:model',
-      extractAssistantText: () => undefined,
-      createResponse: async (options: { tools?: { name: string }[] }) => {
-        observedTools.push(options.tools ?? []);
-        throw stopAfterObservation;
-      },
-    };
+    const modelHandler = stopAfterToolObservationHandler(observedTools);
     const modelCell = testModelCell(modelHandler, 'test-model');
     const config = AgentConfigSchema.parse({
       agent: 'chat',

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -394,6 +394,46 @@ async function runResumedFlowToWaiting(
   expect(result.outcome).toBe(STREAM_PHASE.WAITING);
 }
 
+/**
+ * Rejects the flow's first in-flight node-step write with an abort error,
+ * optionally queuing a follow-up first. Models a cancellation landing
+ * mid-turn at the only writes that carry a cursor. `onlyStepWrite` narrows
+ * that further to the write that stamps `cursor.lastAction`, for tests that
+ * must distinguish a step write from any other cursor-bearing write.
+ */
+function abortOnFirstFlowStepWrite(
+  store: ReturnType<typeof getExecutionStore>,
+  getFlowContext: () => ToolUseSetupContext | undefined,
+  options: { onlyStepWrite?: boolean; followUpText?: string } = {},
+): { writeSpy: ReturnType<typeof vi.spyOn>; abortError: DOMException } {
+  const abortError = createAbortError();
+  const realWrite = store.write.bind(store);
+  let fired = false;
+  const writeSpy = vi
+    .spyOn(store, 'write')
+    .mockImplementation(async (key, value) => {
+      const isCursorWrite =
+        value !== null && typeof value === 'object' && 'cursor' in value;
+      const isTargetWrite = options.onlyStepWrite
+        ? isCursorWrite &&
+          (value.cursor as { lastAction?: string } | null)?.lastAction !==
+            undefined
+        : isCursorWrite;
+      if (!fired && isTargetWrite) {
+        fired = true;
+        if (options.followUpText) {
+          getFlowContext()?.session.appendFollowUp({
+            text: options.followUpText,
+          });
+        }
+        getFlowContext()?.interrupt();
+        throw abortError;
+      }
+      return realWrite(key, value);
+    });
+  return { writeSpy, abortError };
+}
+
 describe('retrieveSessionResumeData', () => {
   setupPlatform({ workspacePath: '/workspace' });
 
@@ -1423,31 +1463,14 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const storedShared = activeHandlerShared();
     const snapshot = buildToolUseResumeData(executionId, streamId);
     await writeFlowRecord(executionId, storedShared);
-    const abortError = createAbortError();
     // Reject the flow's first node-step persist with the provider's abort:
     // the run then fails mid-flight through the public storage boundary, the
     // same way a real cancellation reaches `runToolUseFlow` out of the flow.
-    // Only a step write stamps `cursor.lastAction` (the action the node just
-    // returned), so any other write passes through untouched.
-    const realWrite = store.write.bind(store);
-    let abortFired = false;
-    const writeSpy = vi
-      .spyOn(store, 'write')
-      .mockImplementation(async (key, value) => {
-        if (
-          !abortFired &&
-          value !== null &&
-          typeof value === 'object' &&
-          'cursor' in value &&
-          (value.cursor as { lastAction?: string } | null)?.lastAction !==
-            undefined
-        ) {
-          abortFired = true;
-          flowContext?.interrupt();
-          throw abortError;
-        }
-        return realWrite(key, value);
-      });
+    const { writeSpy, abortError } = abortOnFirstFlowStepWrite(
+      store,
+      () => flowContext,
+      { onlyStepWrite: true },
+    );
     const deleteSpy = vi.spyOn(store, 'delete');
     const dispositions: Array<'preserve' | 'delete'> = [];
 
@@ -1525,29 +1548,13 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     expect(recovery).toBeDefined();
     const store = getExecutionStore(executionId);
     let flowContext: ToolUseSetupContext | undefined;
-    const abortError = createAbortError();
     // The late input lands while the cancelled turn is mid-flight, modelled at
     // the flow's first node-step persist (the only writes carrying a cursor).
-    const realWrite = store.write.bind(store);
-    let abortFired = false;
-    const writeSpy = vi
-      .spyOn(store, 'write')
-      .mockImplementation(async (key, value) => {
-        if (
-          !abortFired &&
-          value !== null &&
-          typeof value === 'object' &&
-          'cursor' in value
-        ) {
-          abortFired = true;
-          flowContext?.session.appendFollowUp({
-            text: 'late active-turn input',
-          });
-          flowContext?.interrupt();
-          throw abortError;
-        }
-        return realWrite(key, value);
-      });
+    const { writeSpy, abortError } = abortOnFirstFlowStepWrite(
+      store,
+      () => flowContext,
+      { followUpText: 'late active-turn input' },
+    );
 
     try {
       await expect(
@@ -1587,28 +1594,14 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     expect(childLease).toBeDefined();
     const store = getExecutionStore(executionId);
     let flowContext: ToolUseSetupContext | undefined;
-    const abortError = createAbortError();
     // The queued input lands while the interrupted turn is mid-flight,
     // modelled at the flow's first node-step persist (the only writes
     // carrying a cursor).
-    const realWrite = store.write.bind(store);
-    let abortFired = false;
-    const writeSpy = vi
-      .spyOn(store, 'write')
-      .mockImplementation(async (key, value) => {
-        if (
-          !abortFired &&
-          value !== null &&
-          typeof value === 'object' &&
-          'cursor' in value
-        ) {
-          abortFired = true;
-          flowContext?.session.appendFollowUp({ text: 'queued for next turn' });
-          flowContext?.interrupt();
-          throw abortError;
-        }
-        return realWrite(key, value);
-      });
+    const { writeSpy, abortError } = abortOnFirstFlowStepWrite(
+      store,
+      () => flowContext,
+      { followUpText: 'queued for next turn' },
+    );
 
     try {
       await expect(

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -79,6 +79,15 @@ function runScript(
   });
 }
 
+/** Collects activity-line strings reported through `onActivity`. */
+function collectActivities(): {
+  readonly activities: string[];
+  readonly onActivity: (line: string) => void;
+} {
+  const activities: string[] = [];
+  return { activities, onActivity: (line) => activities.push(line) };
+}
+
 /**
  * The current card set, one entry per `logId` — what a host progress tree
  * holds after applying every update.
@@ -200,7 +209,7 @@ return await agent('Inspect', { id: 'inspect' })`,
 
   it('marks declared tasks not reached by the script as skipped', async () => {
     const { trace, events } = recordingTrace();
-    const activities: string[] = [];
+    const { activities, onActivity } = collectActivities();
     await runScript(
       trace,
       'not-reached-plan',
@@ -215,7 +224,7 @@ return await agent('Inspect', { id: 'inspect' })`,
 }
 phase('Research')
 return await agent('Run one', { id: 'used' })`,
-      { onActivity: (line) => activities.push(line) },
+      { onActivity },
     );
 
     const unusedPlanned = workflowCallEvent(events, 'Unused task', 'planned');
@@ -583,7 +592,7 @@ return await agent('Second')`;
 
   it('enriches live finish lines with the reported model and duration', async () => {
     const { trace, events } = recordingTrace();
-    const activities: string[] = [];
+    const { activities, onActivity } = collectActivities();
     await runScript(
       trace,
       'model-duration',
@@ -598,7 +607,7 @@ return await agent('Draft')`,
           invocation.report?.({ costUsd: 0.02 });
           return 'done';
         },
-        onActivity: (line) => activities.push(line),
+        onActivity,
       },
     );
 
@@ -649,7 +658,7 @@ return await agent('Draft')`;
 
   it('preserves live metadata when the user skips a running call', async () => {
     const { trace, events } = recordingTrace();
-    const activities: string[] = [];
+    const { activities, onActivity } = collectActivities();
     let control!: WorkflowScriptControl;
     let markStarted: (() => void) | undefined;
     const started = new Promise<void>((resolve) => {
@@ -679,7 +688,7 @@ return await agent('Late skip')`,
         onControl: (handle) => {
           control = handle;
         },
-        onActivity: (line) => activities.push(line),
+        onActivity,
       },
     );
 
@@ -786,7 +795,7 @@ return await pending`,
 
   it('preserves the exact cause when a runner aborts a started phase', async () => {
     const { trace, events } = recordingTrace();
-    const activities: string[] = [];
+    const { activities, onActivity } = collectActivities();
     await expect(
       runScript(
         trace,
@@ -798,7 +807,7 @@ return await agent('Abort', { phase: 'Execution' })`,
             invocation.report?.({ model: 'abort-model', costUsd: 0.06 });
             throw new WorkflowRunAbortError('fatal runner error');
           },
-          onActivity: (line) => activities.push(line),
+          onActivity,
         },
       ),
     ).rejects.toThrow('fatal runner error');
@@ -829,7 +838,7 @@ return await agent('Abort', { phase: 'Execution' })`,
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
     try {
       const { trace, events } = recordingTrace();
-      const activities: string[] = [];
+      const { activities, onActivity } = collectActivities();
       let markStarted: (() => void) | undefined;
       const started = new Promise<void>((resolve) => {
         markStarted = resolve;
@@ -849,7 +858,7 @@ return 'guest success'`,
             markStarted?.();
             return await new Promise<never>(() => undefined);
           },
-          onActivity: (line) => activities.push(line),
+          onActivity,
         },
       );
 

--- a/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
@@ -26,10 +26,25 @@ import {
   PollingSourceBase,
   type BasePollSubscriptionState,
 } from '@tools/github/PollingSourceBase';
-import { StreamSubscriptionRegistry } from '@tools/github/StreamSubscriptionRegistry';
+import {
+  StreamSubscriptionRegistry,
+  type StreamSubscriptionRegistryOptions,
+} from '@tools/github/StreamSubscriptionRegistry';
 
 // Local file imports
 import { createRecordingHost } from '../progressTestUtils';
+
+function createTestRegistry(
+  source: RegistryTestSource,
+  overrides: Partial<StreamSubscriptionRegistryOptions<string, string>> = {},
+): StreamSubscriptionRegistry<string, string> {
+  return new StreamSubscriptionRegistry<string, string>({
+    name: 'test subscriptions',
+    source,
+    keyOf: (input) => input,
+    ...overrides,
+  });
+}
 
 function recordAppSignal<K extends keyof AppSignalPayloads>(
   event: K,
@@ -127,11 +142,7 @@ describe('GitHub subscription app signals and follow-ups', () => {
   it('publishes githubSubscriptionsChanged through app signals', () => {
     const signal = recordAppSignal('githubSubscriptionsChanged');
     const source = new RegistryTestSource();
-    const registry = new StreamSubscriptionRegistry<string, string>({
-      name: 'test subscriptions',
-      source,
-      keyOf: (input) => input,
-    });
+    const registry = createTestRegistry(source);
 
     try {
       registry.bind('stream-a' as StreamTabId, 'owner/repo');
@@ -205,11 +216,7 @@ describe('GitHub subscription app signals and follow-ups', () => {
     const host = createRecordingHost();
     const signal = recordAppSignal('githubSubscriptionsChanged');
     const source = new RegistryTestSource();
-    const registry = new StreamSubscriptionRegistry<string, string>({
-      name: 'test subscriptions',
-      source,
-      keyOf: (input) => input,
-    });
+    const registry = createTestRegistry(source);
 
     try {
       registry.bind('stream-a' as StreamTabId, 'owner/repo');
@@ -234,11 +241,7 @@ describe('GitHub subscription app signals and follow-ups', () => {
     const source = new RegistryTestSource();
     const session = createTestSession();
     const lease = session.followUps.claimLive(streamId, 'flow')!;
-    const registry = new StreamSubscriptionRegistry<string, string>({
-      name: 'test subscriptions',
-      source,
-      keyOf: (input) => input,
-    });
+    const registry = createTestRegistry(source);
 
     try {
       withRunContext(
@@ -272,11 +275,7 @@ describe('GitHub subscription app signals and follow-ups', () => {
     firstSession.followUps.claimLive(streamId, 'flow');
     const secondSession = createTestSession();
     const secondLease = secondSession.followUps.claimLive(streamId, 'flow')!;
-    const registry = new StreamSubscriptionRegistry<string, string>({
-      name: 'test subscriptions',
-      source,
-      keyOf: (input) => input,
-    });
+    const registry = createTestRegistry(source);
 
     try {
       withRunContext(
@@ -312,12 +311,7 @@ describe('GitHub subscription app signals and follow-ups', () => {
       info: vi.fn(),
       warn: vi.fn(),
     };
-    const registry = new StreamSubscriptionRegistry<string, string>({
-      name: 'test subscriptions',
-      logger,
-      source,
-      keyOf: (input) => input,
-    });
+    const registry = createTestRegistry(source, { logger });
     const unhandledRejection = vi.fn();
     submitFollowUpMock.mockRejectedValueOnce(new Error('delivery failed'));
 

--- a/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
@@ -46,6 +46,15 @@ function stubComposedDispatcher(): ComposedDispatcherStub {
   return stub;
 }
 
+/** Compose the dispatcher and queue one 204 response — the boilerplate every
+ * wire-shape assertion below needs before making its call. */
+function stubOkResponse(): void {
+  stubComposedDispatcher();
+  transportMocks.undiciFetch.mockResolvedValueOnce(
+    new Response(null, { status: 204 }),
+  );
+}
+
 describe('long-running model transport', () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -113,10 +122,7 @@ describe('long-running model transport', () => {
   });
 
   it('does not set duplex on a direct string body', async () => {
-    stubComposedDispatcher();
-    transportMocks.undiciFetch.mockResolvedValueOnce(
-      new Response(null, { status: 204 }),
-    );
+    stubOkResponse();
 
     await expect(
       longRunningModelFetch('https://api.example/v1/chat', {
@@ -132,10 +138,7 @@ describe('long-running model transport', () => {
   });
 
   it('does not set duplex on a direct ArrayBuffer body', async () => {
-    stubComposedDispatcher();
-    transportMocks.undiciFetch.mockResolvedValueOnce(
-      new Response(null, { status: 204 }),
-    );
+    stubOkResponse();
     const body = new TextEncoder().encode('{"prompt":"hello"}').buffer;
 
     await expect(
@@ -152,10 +155,7 @@ describe('long-running model transport', () => {
   });
 
   it('sets duplex: half when a caller sends a stream body without it', async () => {
-    stubComposedDispatcher();
-    transportMocks.undiciFetch.mockResolvedValueOnce(
-      new Response(null, { status: 204 }),
-    );
+    stubOkResponse();
     const body = new ReadableStream<Uint8Array>({
       start(controller) {
         controller.enqueue(new TextEncoder().encode('{"ok":true}'));
@@ -177,10 +177,7 @@ describe('long-running model transport', () => {
   });
 
   it('preserves an explicit duplex value on a streamed body', async () => {
-    stubComposedDispatcher();
-    transportMocks.undiciFetch.mockResolvedValueOnce(
-      new Response(null, { status: 204 }),
-    );
+    stubOkResponse();
     const body = new ReadableStream<Uint8Array>({
       start(controller) {
         controller.close();
@@ -199,10 +196,7 @@ describe('long-running model transport', () => {
   });
 
   it('sets duplex: half for a stream-like body that is not a same-realm ReadableStream', async () => {
-    stubComposedDispatcher();
-    transportMocks.undiciFetch.mockResolvedValueOnce(
-      new Response(null, { status: 204 }),
-    );
+    stubOkResponse();
     const body = {
       pipeTo: async () => undefined,
     };
@@ -237,10 +231,7 @@ describe('long-running model transport', () => {
   }
 
   it('rebuilds a cross-realm Request from primitives instead of forwarding it', async () => {
-    stubComposedDispatcher();
-    transportMocks.undiciFetch.mockResolvedValueOnce(
-      new Response(null, { status: 204 }),
-    );
+    stubOkResponse();
     const request = foreignRequest({});
     expect(request instanceof Request).toBe(false);
 
@@ -260,10 +251,7 @@ describe('long-running model transport', () => {
   });
 
   it('reads a cross-realm Request body through its own arrayBuffer', async () => {
-    stubComposedDispatcher();
-    transportMocks.undiciFetch.mockResolvedValueOnce(
-      new Response(null, { status: 204 }),
-    );
+    stubOkResponse();
     const bytes = new TextEncoder().encode('{"prompt":"hello"}').buffer;
     const request = foreignRequest({
       // The foreign stream itself cannot cross realms; its bytes can.
@@ -280,10 +268,7 @@ describe('long-running model transport', () => {
   });
 
   it('lets init fields win over a cross-realm Request', async () => {
-    stubComposedDispatcher();
-    transportMocks.undiciFetch.mockResolvedValueOnce(
-      new Response(null, { status: 204 }),
-    );
+    stubOkResponse();
     const request = foreignRequest({ method: 'GET' });
 
     await longRunningModelFetch(request, {
@@ -302,10 +287,7 @@ describe('long-running model transport', () => {
   });
 
   it('forwards the duplex hint when an init stream body overrides a Request', async () => {
-    stubComposedDispatcher();
-    transportMocks.undiciFetch.mockResolvedValueOnce(
-      new Response(null, { status: 204 }),
-    );
+    stubOkResponse();
     const body = new ReadableStream<Uint8Array>({
       start(controller) {
         controller.close();
@@ -323,10 +305,7 @@ describe('long-running model transport', () => {
   });
 
   it('passes array-form init headers through untransformed', async () => {
-    stubComposedDispatcher();
-    transportMocks.undiciFetch.mockResolvedValueOnce(
-      new Response(null, { status: 204 }),
-    );
+    stubOkResponse();
     const headers: [string, string][] = [
       ['content-type', 'application/json'],
       ['x-tuple', 'yes'],
@@ -341,10 +320,7 @@ describe('long-running model transport', () => {
   });
 
   it('keeps the input body when the init body is null', async () => {
-    stubComposedDispatcher();
-    transportMocks.undiciFetch.mockResolvedValueOnce(
-      new Response(null, { status: 204 }),
-    );
+    stubOkResponse();
     const bytes = new TextEncoder().encode('{"prompt":"kept"}').buffer;
     const request = foreignRequest({
       body: { pipeTo: async () => undefined },
@@ -381,10 +357,7 @@ describe('long-running model transport', () => {
   });
 
   it('replaces the input headers wholesale when init supplies headers', async () => {
-    stubComposedDispatcher();
-    transportMocks.undiciFetch.mockResolvedValueOnce(
-      new Response(null, { status: 204 }),
-    );
+    stubOkResponse();
     const request = foreignRequest({
       headers: new Headers({ 'x-input': 'dropped', 'x-also-input': 'gone' }),
     });

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -94,6 +94,16 @@ async function inspectHandler<T>(
   }
 }
 
+/** A signed-in Codex session with a token far from expiry. */
+function signedInCodexSession(): CodexSession {
+  return {
+    accessToken: 'access-token',
+    refreshToken: 'refresh-token',
+    expiresAtMs: Date.now() + 10 * 60_000,
+    accountId: 'account-id',
+  };
+}
+
 const tempDirs: string[] = [];
 
 afterEach(async () => {
@@ -299,12 +309,7 @@ describe('Copilot route preference on a canonical base model', () => {
         config: { 'texra.chatgptCodex.preferSubscription': true },
         globalState: { 'texra.copilotRouteModels': ['gpt56'] },
         secrets: {
-          [CODEX_SESSION_SECRET_KEY]: JSON.stringify({
-            accessToken: 'access-token',
-            refreshToken: 'refresh-token',
-            expiresAtMs: Date.now() + 10 * 60_000,
-            accountId: 'account-id',
-          }),
+          [CODEX_SESSION_SECRET_KEY]: JSON.stringify(signedInCodexSession()),
         },
       },
       {
@@ -534,15 +539,6 @@ describe('OpenAI model handler routing', () => {
     requiresResponsesAPI: true,
     codexSubscription: true,
   };
-
-  function signedInCodexSession(): CodexSession {
-    return {
-      accessToken: 'access-token',
-      refreshToken: 'refresh-token',
-      expiresAtMs: Date.now() + 10 * 60_000,
-      accountId: 'account-id',
-    };
-  }
 
   async function installSignedInCodexPlatform(
     globalState: Record<string, unknown> = {},

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -54,6 +54,41 @@ import { createRecordingHost } from '../progressTestUtils';
 
 const EXECUTION_ID = 'launch-context-test' as ExecutionId;
 
+/** Launches with an empty agent/model, asserting the shared missing-agent failure. */
+async function launchWithMissingAgent(
+  session: ReturnType<typeof createTestSession>,
+): Promise<void> {
+  await expect(
+    buildAgentLaunchContext({
+      config: AgentConfigSchema.parse({ agent: '', model: '' }),
+      executionId: EXECUTION_ID,
+      session,
+    }),
+  ).rejects.toThrow('Could not find agent');
+}
+
+/**
+ * Triggers `getAgentPath`'s queued (no live host attached) missing-agent
+ * failure and asserts the shared pending-presentation state, returning the
+ * thrown error so the caller can attach a host and assert on replay.
+ */
+async function triggerQueuedMissingAgentFailure(
+  owner: SessionHostInteractions,
+): Promise<unknown> {
+  let thrown: unknown;
+  await getAgentPath(
+    '__queued_missing_agent_for_launch_context_test__',
+    owner,
+    AgentCategory.ToolUse,
+  ).catch((error: unknown) => {
+    thrown = error;
+  });
+  expect(String(thrown)).toContain('Could not find agent');
+  expect(hasErrorPresentedMarker(thrown)).toBe(false);
+  expect(hasErrorPresentationPending(thrown)).toBe(true);
+  return thrown;
+}
+
 describe('AgentLaunchContext', () => {
   it('still rejects empty canonical values, now at agent resolution', async () => {
     // The pre-mint missing-field guard died with the model-keyed stream id
@@ -61,13 +96,7 @@ describe('AgentLaunchContext', () => {
     // dedicated field check, but it must still fail the launch.
     const session = createTestSession();
     try {
-      await expect(
-        buildAgentLaunchContext({
-          config: AgentConfigSchema.parse({ agent: '', model: '' }),
-          executionId: EXECUTION_ID,
-          session,
-        }),
-      ).rejects.toThrow('Could not find agent');
+      await launchWithMissingAgent(session);
     } finally {
       session.dispose();
     }
@@ -101,13 +130,7 @@ describe('AgentLaunchContext', () => {
     const session = createTestSession({ interactions: recording.host });
 
     try {
-      await expect(
-        buildAgentLaunchContext({
-          config: AgentConfigSchema.parse({ agent: '', model: '' }),
-          executionId: EXECUTION_ID,
-          session,
-        }),
-      ).rejects.toThrow('Could not find agent');
+      await launchWithMissingAgent(session);
     } finally {
       session.dispose();
     }
@@ -129,13 +152,7 @@ describe('AgentLaunchContext', () => {
     const session = createTestSession({ interactions: recording.host });
 
     try {
-      await expect(
-        buildAgentLaunchContext({
-          config: AgentConfigSchema.parse({ agent: '', model: '' }),
-          executionId: EXECUTION_ID,
-          session,
-        }),
-      ).rejects.toThrow('Could not find agent');
+      await launchWithMissingAgent(session);
     } finally {
       session.dispose();
     }
@@ -156,18 +173,7 @@ describe('AgentLaunchContext', () => {
     // actually renders on a live host.
     const recording = createRecordingHost({ emitDelivery: true });
     const owner = new SessionHostInteractions();
-    let thrown: unknown;
-
-    await getAgentPath(
-      '__queued_missing_agent_for_launch_context_test__',
-      owner,
-      AgentCategory.ToolUse,
-    ).catch((error: unknown) => {
-      thrown = error;
-    });
-    expect(String(thrown)).toContain('Could not find agent');
-    expect(hasErrorPresentedMarker(thrown)).toBe(false);
-    expect(hasErrorPresentationPending(thrown)).toBe(true);
+    const thrown = await triggerQueuedMissingAgentFailure(owner);
 
     owner.use(recording.interactions);
     await Promise.resolve();
@@ -188,18 +194,7 @@ describe('AgentLaunchContext', () => {
   it('emits the generic fallback when a queued missing-agent banner replay is not delivered', async () => {
     const recording = createRecordingHost({ emitDelivery: false });
     const owner = new SessionHostInteractions();
-    let thrown: unknown;
-
-    await getAgentPath(
-      '__queued_missing_agent_for_launch_context_test__',
-      owner,
-      AgentCategory.ToolUse,
-    ).catch((error: unknown) => {
-      thrown = error;
-    });
-    expect(String(thrown)).toContain('Could not find agent');
-    expect(hasErrorPresentedMarker(thrown)).toBe(false);
-    expect(hasErrorPresentationPending(thrown)).toBe(true);
+    const thrown = await triggerQueuedMissingAgentFailure(owner);
 
     owner.use(recording.interactions);
     await Promise.resolve();
@@ -224,18 +219,7 @@ describe('AgentLaunchContext', () => {
     // error stays presentation-pending and surfaces zero times (#10398).
     const events: Array<{ event: string; payload: unknown }> = [];
     const owner = new SessionHostInteractions();
-    let thrown: unknown;
-
-    await getAgentPath(
-      '__queued_missing_agent_for_launch_context_test__',
-      owner,
-      AgentCategory.ToolUse,
-    ).catch((error: unknown) => {
-      thrown = error;
-    });
-    expect(String(thrown)).toContain('Could not find agent');
-    expect(hasErrorPresentedMarker(thrown)).toBe(false);
-    expect(hasErrorPresentationPending(thrown)).toBe(true);
+    const thrown = await triggerQueuedMissingAgentFailure(owner);
 
     owner.use({
       emit: (event, payload) => {
@@ -304,13 +288,7 @@ describe('AgentLaunchContext', () => {
     const session = createTestSession({ interactions: owner });
 
     try {
-      await expect(
-        buildAgentLaunchContext({
-          config: AgentConfigSchema.parse({ agent: '', model: '' }),
-          executionId: EXECUTION_ID,
-          session,
-        }),
-      ).rejects.toThrow('Could not find agent');
+      await launchWithMissingAgent(session);
 
       // The launch catch saw the pending-replay marker and left the fallback
       // to the queued targeted event; it must not have queued a duplicate.

--- a/src/test-kernel/agent/runtime/ExecutionInteractionOwnership.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionInteractionOwnership.vitest.ts
@@ -44,19 +44,23 @@ function trackRun(
   );
 }
 
+/** A fresh registry with a scope that has claimed and tracked 'root'. */
+function openRootScope() {
+  const registry = createRegistry();
+  const onRelease = vi.fn();
+  const scope = registry.interactionOwnership.open(onRelease);
+  const rootStream = 'root-stream' as StreamTabId;
+
+  scope.claim('root');
+  trackRun(registry, 'root', rootStream, rootStream);
+
+  return { registry, onRelease, scope, rootStream };
+}
+
 describe('execution interaction ownership', () => {
   it('releases only once the owner finished and its last run was untracked', () => {
-    const registry = createRegistry();
-    const onRelease = vi.fn();
-    const scope = registry.interactionOwnership.open(onRelease);
+    const { registry, onRelease, scope } = openRootScope();
 
-    scope.claim('root');
-    trackRun(
-      registry,
-      'root',
-      'root-stream' as StreamTabId,
-      'root-stream' as StreamTabId,
-    );
     scope.finish();
     expect(onRelease).not.toHaveBeenCalled();
 
@@ -77,13 +81,8 @@ describe('execution interaction ownership', () => {
   });
 
   it('keeps a detached child of a finished root attached to its owner', () => {
-    const registry = createRegistry();
-    const onRelease = vi.fn();
-    const scope = registry.interactionOwnership.open(onRelease);
-    const rootStream = 'root-stream' as StreamTabId;
+    const { registry, onRelease, scope, rootStream } = openRootScope();
 
-    scope.claim('root');
-    trackRun(registry, 'root', rootStream, rootStream);
     // The child is never claimed by the host: it inherits through the stream
     // lineage of the root the host did claim.
     trackRun(registry, 'child', rootStream, 'child-stream' as StreamTabId);
@@ -98,13 +97,9 @@ describe('execution interaction ownership', () => {
   });
 
   it('inherits a grandchild through the child stream it already owns', () => {
-    const registry = createRegistry();
-    const scope = registry.interactionOwnership.open(vi.fn());
-    const rootStream = 'root-stream' as StreamTabId;
+    const { registry, scope, rootStream } = openRootScope();
     const childStream = 'child-stream' as StreamTabId;
 
-    scope.claim('root');
-    trackRun(registry, 'root', rootStream, rootStream);
     trackRun(registry, 'child', rootStream, childStream);
     trackRun(
       registry,
@@ -117,14 +112,9 @@ describe('execution interaction ownership', () => {
   });
 
   it('holds the owner across the gap between a child activation and its handle', () => {
-    const registry = createRegistry();
-    const onRelease = vi.fn();
-    const scope = registry.interactionOwnership.open(onRelease);
-    const rootStream = 'root-stream' as StreamTabId;
+    const { registry, onRelease, scope, rootStream } = openRootScope();
     const childStream = 'child-stream' as StreamTabId;
 
-    scope.claim('root');
-    trackRun(registry, 'root', rootStream, rootStream);
     registry.reserveChildActivation({
       executionId: 'child',
       parentStreamId: rootStream,
@@ -147,14 +137,9 @@ describe('execution interaction ownership', () => {
   });
 
   it('releases the owner when a reserved child activation fails to start', () => {
-    const registry = createRegistry();
-    const onRelease = vi.fn();
-    const scope = registry.interactionOwnership.open(onRelease);
-    const rootStream = 'root-stream' as StreamTabId;
+    const { registry, onRelease, scope, rootStream } = openRootScope();
     const childStream = 'child-stream' as StreamTabId;
 
-    scope.claim('root');
-    trackRun(registry, 'root', rootStream, rootStream);
     const releaseActivation = registry.reserveChildActivation({
       executionId: 'child',
       parentStreamId: rootStream,
@@ -232,13 +217,8 @@ describe('execution interaction ownership', () => {
   });
 
   it('stops observing the registry after an explicit release', () => {
-    const registry = createRegistry();
-    const onRelease = vi.fn();
-    const scope = registry.interactionOwnership.open(onRelease);
-    const rootStream = 'root-stream' as StreamTabId;
+    const { registry, onRelease, scope, rootStream } = openRootScope();
 
-    scope.claim('root');
-    trackRun(registry, 'root', rootStream, rootStream);
     scope.release();
     scope.release();
 

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -160,6 +160,21 @@ function trackInterruptibleHandle(
   return handle;
 }
 
+/** The `LiveToolUseFlowContext` fixture shared by the tool-use-admission tests. */
+function createLiveToolUseFlowContext(
+  overrides: Partial<LiveToolUseFlowContext> = {},
+): LiveToolUseFlowContext {
+  return {
+    session: { appendFollowUp: vi.fn() },
+    modelHandler: { supportsManualCompaction: true },
+    requestImmediateCompaction: vi.fn(),
+    modelSwitchDisabledReason: vi.fn(),
+    switchModel: vi.fn(),
+    interrupt: vi.fn(),
+    ...overrides,
+  };
+}
+
 /** Tracks a handle genuinely suspended at WAITING, the state every waiting-kill test starts from. */
 function trackSuspendedWaitingHandle(
   registry: ExecutionRegistry,
@@ -1523,18 +1538,7 @@ describe('executionRegistry', () => {
     const { registry } = createRegistry();
     const executionId = 'exec-live-flow-context-test';
     const streamId = 'stream-live-flow-context-test' as StreamTabId;
-    const context: LiveToolUseFlowContext = {
-      session: {
-        appendFollowUp: vi.fn(),
-      },
-      modelHandler: {
-        supportsManualCompaction: true,
-      },
-      requestImmediateCompaction: vi.fn(),
-      modelSwitchDisabledReason: vi.fn(),
-      switchModel: vi.fn(),
-      interrupt: vi.fn(),
-    };
+    const context = createLiveToolUseFlowContext();
 
     try {
       const handle = createHandle(executionId, streamId, streamId, {
@@ -1562,19 +1566,10 @@ describe('executionRegistry', () => {
       'stream-manual-compaction-unsupported-test' as StreamTabId;
     const requestImmediateCompaction = vi.fn();
     const ownerSession = {} as SessionHandle;
-    const context: LiveToolUseFlowContext = {
+    const context = createLiveToolUseFlowContext({
       ownerSession,
-      session: {
-        appendFollowUp: vi.fn(),
-      },
-      modelHandler: {
-        supportsManualCompaction: true,
-      },
       requestImmediateCompaction,
-      modelSwitchDisabledReason: vi.fn(),
-      switchModel: vi.fn(),
-      interrupt: vi.fn(),
-    };
+    });
     const unsupportedContext: LiveToolUseFlowContext = {
       ...context,
       modelHandler: {
@@ -1637,18 +1632,7 @@ describe('executionRegistry', () => {
     const stoppedStreamId = 'stream-follow-up-stopped-test' as StreamTabId;
     const parentStreamId = 'stream-follow-up-parent-test' as StreamTabId;
     const childStreamId = 'stream-follow-up-child-test' as StreamTabId;
-    const context: LiveToolUseFlowContext = {
-      session: {
-        appendFollowUp: vi.fn(),
-      },
-      modelHandler: {
-        supportsManualCompaction: true,
-      },
-      requestImmediateCompaction: vi.fn(),
-      modelSwitchDisabledReason: vi.fn(),
-      switchModel: vi.fn(),
-      interrupt: vi.fn(),
-    };
+    const context = createLiveToolUseFlowContext();
 
     try {
       const activeHandle = createHandle(

--- a/src/test-kernel/agent/runtime/ModelRetryGate.vitest.ts
+++ b/src/test-kernel/agent/runtime/ModelRetryGate.vitest.ts
@@ -14,7 +14,6 @@ import { ModelRetryGate } from '@agent/runtime/ModelRetryGate';
 import { createDeferred } from '@test/support/asyncTestUtils';
 
 const ROUTE = 'openai:subscription:gpt-5.6';
-const OTHER_ROUTE = 'anthropic:api-key:claude-opus';
 const MODEL_ROUTE = `${ROUTE}:model`;
 const OTHER_MODEL_ROUTE = 'openai:subscription:gpt-5.7:model';
 const TRANSIENT = new Error('temporary connection failure');

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -27,7 +27,6 @@ import type { ModelCell } from '@agent/runtime/ModelCell';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { createRunScope, type RunScope } from '@agent/runtime/RunScope';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
-import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import type {
   ModelCredentialRoute,
@@ -197,10 +196,7 @@ function createRetryNode(
   const requestRetry = vi.fn<RetryNodeKit['requestRetry']>();
   const session =
     sessionOverride ??
-    sessionWithInteractions(
-      { requestRetry, cancel: () => {} },
-      new StreamStatusMachine(new SessionEventHub()),
-    );
+    sessionWithInteractions({ requestRetry, cancel: () => {} });
   const streamStatus = session.status;
   const node = new ExposedRetryNode().setServices(
     retryServices(streamId, {
@@ -464,10 +460,10 @@ describe('ModelInvocationNode retry', () => {
       transcript.acquireWriter(streamId, streamId),
     );
     const requestRetry = vi.fn(async () => ({ action: 'retry' as const }));
-    const session = sessionWithInteractions(
-      { requestRetry, cancel: () => {} },
-      new StreamStatusMachine(new SessionEventHub()),
-    );
+    const session = sessionWithInteractions({
+      requestRetry,
+      cancel: () => {},
+    });
 
     class DiagnosticRetryNode extends ExposedRetryNode {
       attempts = 0;
@@ -596,16 +592,13 @@ describe('ModelInvocationNode retry', () => {
       .fn<() => Promise<unknown>>()
       .mockRejectedValueOnce(new Error('client preparation failed'))
       .mockResolvedValue({});
-    const session = sessionWithInteractions(
-      {
-        requestRetry: async () => ({
-          action: 'retry' as const,
-          decisionSource: 'automatic' as const,
-        }),
-        cancel: () => {},
-      },
-      new StreamStatusMachine(new SessionEventHub()),
-    );
+    const session = sessionWithInteractions({
+      requestRetry: async () => ({
+        action: 'retry' as const,
+        decisionSource: 'automatic' as const,
+      }),
+      cancel: () => {},
+    });
 
     class ClientPreparationRetryNode extends ExposedRetryNode {
       override async exec(): Promise<InvocationSuccess> {
@@ -1343,10 +1336,10 @@ describe('ModelInvocationNode retry', () => {
         await options?.prepareRetry?.('personal');
         return { action: 'retry' };
       });
-      const session = sessionWithInteractions(
-        { requestRetry, cancel: () => {} },
-        new StreamStatusMachine(new SessionEventHub()),
-      );
+      const session = sessionWithInteractions({
+        requestRetry,
+        cancel: () => {},
+      });
       const node = new ExposedRetryNode().setServices(
         retryServices(streamId, {
           config: { model, agentCategory: AgentCategory.ToolUse },

--- a/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
@@ -38,6 +38,7 @@ vi.mock('@agent/runtime/executeAgent', () => ({
 }));
 
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import type { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import { runAgent } from '@agent/runtime/runAgent';
 import { getStreamTabId } from '@agent/runtime/streamTab';
@@ -50,8 +51,7 @@ const CONFIG = AgentConfigSchema.parse({
   model: 'test-model',
 });
 const flushArtifacts = vi.fn();
-let trackedHandle:
-  import('@agent/runtime/ExecutionHandle').AgentExecutionHandle | undefined;
+let trackedHandle: AgentExecutionHandle | undefined;
 // The real exit choreography over the fake's flushArtifacts and the mocked
 // lease verbs, so the existing renew/flush/complete/abandon assertions keep
 // observing the same tree through its one owner.

--- a/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
@@ -105,6 +105,19 @@ async function seedSidecarFk(
   await snapshots.flush();
 }
 
+/** Writes a cancelled-but-resumable execution meta plus a valid flow record. */
+async function seedResumableExecution(
+  id: ExecutionId,
+): Promise<ReturnType<typeof getExecutionStore>> {
+  const executionStore = getExecutionStore(id);
+  await executionStore.writeMeta({
+    timestamp: META_TIMESTAMP,
+    outcome: RUN_OUTCOME.CANCELLED,
+  });
+  await executionStore.write(flowKey(id), validFlowRecord);
+  return executionStore;
+}
+
 /**
  * Mocks a pending workspace-storage root change, returning the commit mock so
  * callers can assert whether it was invoked.
@@ -301,13 +314,7 @@ describe('SessionHandle restart repair', () => {
     );
     await transcripts.flush();
     await seedSidecarFk(resumableStreamId, resumableExecutionId);
-
-    const executionStore = getExecutionStore(resumableExecutionId);
-    await executionStore.writeMeta({
-      timestamp: META_TIMESTAMP,
-      outcome: RUN_OUTCOME.CANCELLED,
-    });
-    await executionStore.write(flowKey(resumableExecutionId), validFlowRecord);
+    const executionStore = await seedResumableExecution(resumableExecutionId);
 
     const session = openDeferredSession(transcripts);
     await session.waitUntilReady();
@@ -377,13 +384,7 @@ describe('SessionHandle restart repair', () => {
     });
     await transcripts.flush();
     await seedSidecarFk(parkedStreamId, parkedExecutionId);
-
-    const executionStore = getExecutionStore(parkedExecutionId);
-    await executionStore.writeMeta({
-      timestamp: META_TIMESTAMP,
-      outcome: RUN_OUTCOME.CANCELLED,
-    });
-    await executionStore.write(flowKey(parkedExecutionId), validFlowRecord);
+    await seedResumableExecution(parkedExecutionId);
 
     const session = openDeferredSession(transcripts);
     vi.spyOn(
@@ -428,13 +429,7 @@ describe('SessionHandle restart repair', () => {
       executionId: summaryExecutionId,
     });
     await seedSidecarFk(settledStream, sidecarExecutionId);
-
-    const executionStore = getExecutionStore(sidecarExecutionId);
-    await executionStore.writeMeta({
-      timestamp: META_TIMESTAMP,
-      outcome: RUN_OUTCOME.CANCELLED,
-    });
-    await executionStore.write(flowKey(sidecarExecutionId), validFlowRecord);
+    await seedResumableExecution(sidecarExecutionId);
 
     const session = openDeferredSession(transcripts);
     await session.waitUntilReady();
@@ -452,13 +447,7 @@ describe('SessionHandle restart repair', () => {
     transcripts.ensureStream(parkedStreamId);
     await transcripts.flush();
     await seedSidecarFk(parkedStreamId, parkedExecutionId);
-
-    const executionStore = getExecutionStore(parkedExecutionId);
-    await executionStore.writeMeta({
-      timestamp: META_TIMESTAMP,
-      outcome: RUN_OUTCOME.CANCELLED,
-    });
-    await executionStore.write(flowKey(parkedExecutionId), validFlowRecord);
+    await seedResumableExecution(parkedExecutionId);
 
     const session = openDeferredSession(transcripts);
     const preload = vi.spyOn(session.snapshots, 'preload');
@@ -487,22 +476,8 @@ describe('SessionHandle restart repair', () => {
     await transcripts.flush();
     await seedSidecarFk(firstStreamId, firstExecutionId);
     await seedSidecarFk(secondStreamId, secondExecutionId);
-    await getExecutionStore(firstExecutionId).writeMeta({
-      timestamp: META_TIMESTAMP,
-      outcome: RUN_OUTCOME.CANCELLED,
-    });
-    await getExecutionStore(firstExecutionId).write(
-      flowKey(firstExecutionId),
-      validFlowRecord,
-    );
-    await getExecutionStore(secondExecutionId).writeMeta({
-      timestamp: META_TIMESTAMP,
-      outcome: RUN_OUTCOME.CANCELLED,
-    });
-    await getExecutionStore(secondExecutionId).write(
-      flowKey(secondExecutionId),
-      validFlowRecord,
-    );
+    await seedResumableExecution(firstExecutionId);
+    await seedResumableExecution(secondExecutionId);
     vi.spyOn(waitingDetection, 'detectWaitingStreams').mockResolvedValue(
       new Set([firstStreamId, secondStreamId]),
     );
@@ -551,13 +526,7 @@ describe('SessionHandle restart repair', () => {
     transcripts.ensureStream(parkedStreamId);
     await transcripts.flush();
     await seedSidecarFk(parkedStreamId, parkedExecutionId);
-
-    const executionStore = getExecutionStore(parkedExecutionId);
-    await executionStore.writeMeta({
-      timestamp: META_TIMESTAMP,
-      outcome: RUN_OUTCOME.CANCELLED,
-    });
-    await executionStore.write(flowKey(parkedExecutionId), validFlowRecord);
+    await seedResumableExecution(parkedExecutionId);
 
     let finishDetection: ((streams: Set<StreamTabId>) => void) | undefined;
     const detectionBlocked = new Promise<Set<StreamTabId>>((resolve) => {
@@ -595,13 +564,7 @@ describe('SessionHandle restart repair', () => {
     transcripts.ensureStream(parkedStreamId);
     await transcripts.flush();
     await seedSidecarFk(parkedStreamId, parkedExecutionId);
-
-    const executionStore = getExecutionStore(parkedExecutionId);
-    await executionStore.writeMeta({
-      timestamp: META_TIMESTAMP,
-      outcome: RUN_OUTCOME.CANCELLED,
-    });
-    await executionStore.write(flowKey(parkedExecutionId), validFlowRecord);
+    await seedResumableExecution(parkedExecutionId);
 
     const session = openDeferredSession(transcripts);
     const originalPreload = session.snapshots.preload.bind(session.snapshots);
@@ -631,13 +594,7 @@ describe('SessionHandle restart repair', () => {
       executionId: parkedExecutionId,
     });
     await transcripts.flush();
-
-    const executionStore = getExecutionStore(parkedExecutionId);
-    await executionStore.writeMeta({
-      timestamp: META_TIMESTAMP,
-      outcome: RUN_OUTCOME.CANCELLED,
-    });
-    await executionStore.write(flowKey(parkedExecutionId), validFlowRecord);
+    await seedResumableExecution(parkedExecutionId);
 
     const session = openDeferredSession(transcripts);
     await session.waitUntilReady();

--- a/src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts
@@ -89,13 +89,15 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
     });
   }
 
-  function mockDeferredProbe(deferred: DeferredResumability): void {
+  /** A single-implementation deferred probe, wired into the mock. */
+  function startDeferredProbe(): DeferredResumability {
+    const deferred = createDeferredResumability();
     deriveResumability.mockImplementation(() => deferred.promise);
+    return deferred;
   }
 
   it('does not overwrite status created during an absent-generation probe', async () => {
-    const deferred = createDeferredResumability();
-    mockDeferredProbe(deferred);
+    const deferred = startDeferredProbe();
 
     const pending = repair();
     session.status.transition(streamId, STREAM_PHASE.RUNNING, 'lifecycle');
@@ -212,8 +214,7 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
 
   it('collapses concurrent probes for one stream onto the first', async () => {
     seedCancelled();
-    const deferred = createDeferredResumability();
-    mockDeferredProbe(deferred);
+    const deferred = startDeferredProbe();
 
     const first = repair();
     const second = repair();
@@ -280,8 +281,7 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
 
   it('does not join a stale probe after resume starts', async () => {
     seedCancelled();
-    const deferred = createDeferredResumability();
-    mockDeferredProbe(deferred);
+    const deferred = startDeferredProbe();
 
     const first = repair();
     await vi.waitFor(() => expect(deriveResumability).toHaveBeenCalledTimes(1));
@@ -298,8 +298,7 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
 
   it('does not recreate a stream cleared during the probe', async () => {
     seedCancelled();
-    const deferred = createDeferredResumability();
-    mockDeferredProbe(deferred);
+    const deferred = startDeferredProbe();
 
     const pending = repair();
     await vi.waitFor(() => expect(deriveResumability).toHaveBeenCalledTimes(1));
@@ -314,8 +313,7 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
 
   it('does not repair a replacement execution', async () => {
     seedCancelled();
-    const deferred = createDeferredResumability();
-    mockDeferredProbe(deferred);
+    const deferred = startDeferredProbe();
 
     const pending = repair();
     await vi.waitFor(() => expect(deriveResumability).toHaveBeenCalledTimes(1));
@@ -362,8 +360,7 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
 
   it('does not repair a recreated terminal generation', async () => {
     seedCancelled();
-    const deferred = createDeferredResumability();
-    mockDeferredProbe(deferred);
+    const deferred = startDeferredProbe();
 
     const pending = repair();
     await vi.waitFor(() => expect(deriveResumability).toHaveBeenCalledTimes(1));
@@ -378,8 +375,7 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
   it('does not let a stale rejected probe poison the WAITING fast path', async () => {
     seedCancelled();
     const failure = new Error('resumability read failed');
-    const deferred = createDeferredResumability();
-    mockDeferredProbe(deferred);
+    const deferred = startDeferredProbe();
 
     const first = repair();
     await vi.waitFor(() => expect(deriveResumability).toHaveBeenCalledTimes(1));

--- a/src/test-kernel/auth/SupabaseSessionLifecycle.vitest.ts
+++ b/src/test-kernel/auth/SupabaseSessionLifecycle.vitest.ts
@@ -73,10 +73,6 @@ function expiredSession(): SupabaseSession {
   });
 }
 
-function soonExpiringSession(): SupabaseSession {
-  return makeSession({ expiresAt: Date.now() + 30_000 });
-}
-
 function replacementSession(): SupabaseSession {
   return makeSession({
     accessToken: 'replacement-access',

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -1201,32 +1201,60 @@ describe('App foreground Escape ownership', () => {
   });
 });
 
+// The two enqueue calls below recur across this describe block: a
+// stream-scoped approval on an unrelated stream (which must never satisfy an
+// assertion on its own) and a session-wide (streamId: '') approval that
+// should promote onto whatever stream ends up visible.
+function enqueueOtherStreamInquiry(
+  requestId: string,
+  question: string,
+  threadId: string,
+): void {
+  void enqueueApproval({
+    kind: 'externalInquiry',
+    data: {
+      requestId,
+      mode: 'followUp',
+      question,
+      threadId,
+      allowBypass: false,
+      streamId: 'other-stream',
+    },
+  });
+}
+
+function enqueueSessionInquiry(
+  requestId: string,
+  question: string,
+  threadId: string,
+): void {
+  void enqueueApproval({
+    kind: 'externalInquiry',
+    data: {
+      requestId,
+      mode: 'followUp',
+      question,
+      threadId,
+      allowBypass: false,
+      streamId: '',
+    },
+  });
+}
+
 describe('App approval surface ownership', () => {
   it('promotes a session-wide approval when a child becomes the scoped root', async () => {
     seedChildHierarchy();
     focusStream(ROOT);
-    void enqueueApproval({
-      kind: 'externalInquiry',
-      data: {
-        requestId: 'external-other-new-scope',
-        mode: 'followUp',
-        question: 'Wait outside the new scope.',
-        threadId: 'ei_000000000007',
-        allowBypass: false,
-        streamId: 'other-stream',
-      },
-    });
-    void enqueueApproval({
-      kind: 'externalInquiry',
-      data: {
-        requestId: 'external-session-new-scope',
-        mode: 'followUp',
-        question: 'Verify the newly scoped child.',
-        threadId: 'ei_000000000008',
-        allowBypass: false,
-        streamId: '',
-      },
-    });
+    enqueueOtherStreamInquiry(
+      'external-other-new-scope',
+      'Wait outside the new scope.',
+      'ei_000000000007',
+    );
+    enqueueSessionInquiry(
+      'external-session-new-scope',
+      'Verify the newly scoped child.',
+      'ei_000000000008',
+    );
     const { instance, stdin, stdout } = await renderApp(appProps(vi.fn()));
 
     try {
@@ -1282,17 +1310,11 @@ describe('App approval surface ownership', () => {
       ],
     }));
     focusStream(CHILD);
-    void enqueueApproval({
-      kind: 'externalInquiry',
-      data: {
-        requestId: 'external-other-dashboard',
-        mode: 'followUp',
-        question: 'Wait outside the dashboard root.',
-        threadId: 'ei_000000000009',
-        allowBypass: false,
-        streamId: 'other-stream',
-      },
-    });
+    enqueueOtherStreamInquiry(
+      'external-other-dashboard',
+      'Wait outside the dashboard root.',
+      'ei_000000000009',
+    );
     void enqueueApproval({
       kind: 'planApproval',
       data: {
@@ -1324,28 +1346,16 @@ describe('App approval surface ownership', () => {
   it('promotes a session-wide approval against the post-Escape root', async () => {
     seedChildHierarchy();
     focusStream(CHILD);
-    void enqueueApproval({
-      kind: 'externalInquiry',
-      data: {
-        requestId: 'external-other-after-escape',
-        mode: 'followUp',
-        question: 'Wait outside the destination root.',
-        threadId: 'ei_000000000005',
-        allowBypass: false,
-        streamId: 'other-stream',
-      },
-    });
-    void enqueueApproval({
-      kind: 'externalInquiry',
-      data: {
-        requestId: 'external-session-after-escape',
-        mode: 'followUp',
-        question: 'Verify the destination root.',
-        threadId: 'ei_000000000006',
-        allowBypass: false,
-        streamId: '',
-      },
-    });
+    enqueueOtherStreamInquiry(
+      'external-other-after-escape',
+      'Wait outside the destination root.',
+      'ei_000000000005',
+    );
+    enqueueSessionInquiry(
+      'external-session-after-escape',
+      'Verify the destination root.',
+      'ei_000000000006',
+    );
     const { instance, stdin, stdout } = await renderApp(appProps(vi.fn()));
 
     try {
@@ -1370,28 +1380,16 @@ describe('App approval surface ownership', () => {
   it('promotes a session-wide approval from a scoped-list root', async () => {
     seedChildHierarchy();
     focusStream(GRANDCHILD);
-    void enqueueApproval({
-      kind: 'externalInquiry',
-      data: {
-        requestId: 'external-other-scoped',
-        mode: 'followUp',
-        question: 'Wait outside the scoped list.',
-        threadId: 'ei_000000000003',
-        allowBypass: false,
-        streamId: 'other-stream',
-      },
-    });
-    void enqueueApproval({
-      kind: 'externalInquiry',
-      data: {
-        requestId: 'external-session-scoped',
-        mode: 'followUp',
-        question: 'Verify the scoped child session.',
-        threadId: 'ei_000000000004',
-        allowBypass: false,
-        streamId: '',
-      },
-    });
+    enqueueOtherStreamInquiry(
+      'external-other-scoped',
+      'Wait outside the scoped list.',
+      'ei_000000000003',
+    );
+    enqueueSessionInquiry(
+      'external-session-scoped',
+      'Verify the scoped child session.',
+      'ei_000000000004',
+    );
     const { instance, stdin, stdout } = await renderApp(appProps(vi.fn()));
 
     try {
@@ -1425,28 +1423,16 @@ describe('App approval surface ownership', () => {
       agentCategory: AgentCategory.Workflow,
     });
     patchStream(ROOT, (slice) => ({ ...slice, entries: [] }));
-    void enqueueApproval({
-      kind: 'externalInquiry',
-      data: {
-        requestId: 'external-other',
-        mode: 'followUp',
-        question: 'Wait outside the active stream.',
-        threadId: 'ei_000000000001',
-        allowBypass: false,
-        streamId: 'other-stream',
-      },
-    });
-    void enqueueApproval({
-      kind: 'externalInquiry',
-      data: {
-        requestId: 'external-session',
-        mode: 'followUp',
-        question: 'Verify the workflow before it emits rows.',
-        threadId: 'ei_000000000002',
-        allowBypass: false,
-        streamId: '',
-      },
-    });
+    enqueueOtherStreamInquiry(
+      'external-other',
+      'Wait outside the active stream.',
+      'ei_000000000001',
+    );
+    enqueueSessionInquiry(
+      'external-session',
+      'Verify the workflow before it emits rows.',
+      'ei_000000000002',
+    );
     const { instance, stdin, stdout } = await renderApp(appProps(vi.fn()));
 
     try {

--- a/src/test-kernel/cli/ChatDefaults.vitest.ts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.ts
@@ -21,6 +21,17 @@ import { GlobalStorageFS } from '@utils/files/storageFS';
 /** A cwd with no `.texra` directory, so the workspace tier finds nothing. */
 const NO_WORKSPACE = '/tmp/no-such-texra-workspace';
 
+/**
+ * Shared config layers exercised at both the workspace and user tiers: an
+ * unprefixed `texra.agent`/`texra.model` pair plus a prefixed `texra.chat`
+ * override, so tests can assert the command-specific layer wins.
+ */
+const CHAT_TIER_CONFIG = {
+  'texra.agent': 'generic',
+  'texra.model': 'gpt55',
+  'texra.chat': { agent: 'assistant', model: 'deepseekT' },
+};
+
 /** A missing user config, shaped like a genuine `fs` ENOENT rejection. */
 function enoentError(): NodeJS.ErrnoException {
   const error = new Error(
@@ -158,11 +169,7 @@ describe('CLI chat defaults', () => {
   });
 
   it('uses command-specific workspace defaults below environment overrides', async () => {
-    const workspace = await workspaceWithConfig({
-      'texra.agent': 'generic',
-      'texra.model': 'gpt55',
-      'texra.chat': { agent: 'assistant', model: 'deepseekT' },
-    });
+    const workspace = await workspaceWithConfig(CHAT_TIER_CONFIG);
 
     await expectChatDefaults(
       { cwd: workspace, envModel: 'sonnet46T' },
@@ -402,11 +409,7 @@ describe('CLI chat defaults', () => {
   });
 
   it('uses prefixed command-specific workspace defaults', async () => {
-    const workspace = await workspaceWithConfig({
-      'texra.agent': 'generic',
-      'texra.model': 'gpt55',
-      'texra.chat': { agent: 'assistant', model: 'deepseekT' },
-    });
+    const workspace = await workspaceWithConfig(CHAT_TIER_CONFIG);
 
     await expectChatDefaults(
       { cwd: workspace },
@@ -419,11 +422,7 @@ describe('CLI chat defaults', () => {
   });
 
   it('uses the shared config parser for prefixed user chat defaults', async () => {
-    mockedReadJson.mockResolvedValueOnce({
-      'texra.agent': 'generic',
-      'texra.model': 'gpt55',
-      'texra.chat': { agent: 'assistant', model: 'deepseekT' },
-    });
+    mockedReadJson.mockResolvedValueOnce(CHAT_TIER_CONFIG);
 
     await expectChatDefaults(
       { cwd: NO_WORKSPACE },

--- a/src/test-kernel/cli/CliInitPlatform.vitest.ts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.ts
@@ -203,6 +203,21 @@ function stubGlobalState(
   return { get: vi.fn(get), update: vi.fn() };
 }
 
+/** Stubs global-state reads so MODEL_LIST_VERSION is current, one model is
+ *  enabled, and two Copilot route models are stale — the fixture shared by
+ *  the Copilot-route-invalidation and project-config-degradation tests. */
+function stubStaleCopilotRouteModels(): void {
+  mocks.cliGlobalState.get.mockImplementation((key: string) => {
+    if (key === GlobalStateKey.MODEL_LIST_VERSION) return MODEL_LIST_VERSION;
+    if (key === GlobalStateKey.ENABLED_MODELS) return ['sonnet5T'];
+    if (key === GlobalStateKey.COPILOT_ROUTE_MODELS) {
+      return ['gemini36f', 'gemini31p'];
+    }
+    return undefined;
+  });
+  mocks.cliGlobalState.update.mockResolvedValue(undefined);
+}
+
 /**
  * Each signal-ownership test must observe installation from a clean slate:
  * `installCliShutdownSignalHandlers` guards on an idempotent, module-level
@@ -335,15 +350,7 @@ describe('CLI platform init', () => {
   it('invalidates and logs when only Copilot route preferences are cleared', async () => {
     expect(MODEL_CONFIGS.gemini36f?.deprecated).toBe(true);
     mocks.tryPlatform.mockReturnValueOnce(undefined);
-    mocks.cliGlobalState.get.mockImplementation((key: string) => {
-      if (key === GlobalStateKey.MODEL_LIST_VERSION) return MODEL_LIST_VERSION;
-      if (key === GlobalStateKey.ENABLED_MODELS) return ['sonnet5T'];
-      if (key === GlobalStateKey.COPILOT_ROUTE_MODELS) {
-        return ['gemini36f', 'gemini31p'];
-      }
-      return undefined;
-    });
-    mocks.cliGlobalState.update.mockResolvedValue(undefined);
+    stubStaleCopilotRouteModels();
     const stderrWrite = vi
       .spyOn(process.stderr, 'write')
       .mockImplementation(() => true);
@@ -373,15 +380,7 @@ describe('CLI platform init', () => {
 
   it('shows one project-config degradation warning with its cause in quiet mode', async () => {
     mocks.tryPlatform.mockReturnValueOnce(undefined);
-    mocks.cliGlobalState.get.mockImplementation((key: string) => {
-      if (key === GlobalStateKey.MODEL_LIST_VERSION) return MODEL_LIST_VERSION;
-      if (key === GlobalStateKey.ENABLED_MODELS) return ['sonnet5T'];
-      if (key === GlobalStateKey.COPILOT_ROUTE_MODELS) {
-        return ['gemini36f', 'gemini31p'];
-      }
-      return undefined;
-    });
-    mocks.cliGlobalState.update.mockResolvedValue(undefined);
+    stubStaleCopilotRouteModels();
     mocks.openTexraConfigStores.mockImplementationOnce(
       async (
         _storage: unknown,

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -19,6 +19,7 @@ import {
   orderedStaticTranscriptEntries,
   splitTranscriptEntries,
   terminalVisibleTranscriptText,
+  transcriptRowHeadline,
   trimAssistantTranscriptLead,
 } from '@cli/chat/tui/panes/transcriptEntries';
 import { hydratedTranscript } from '@cli/chat/tui/panes/TranscriptReader';
@@ -61,10 +62,6 @@ import { syncStreamLog } from '@cli/chat/tui/state/subscribeStreamLog';
 import { transcriptToLines } from '@cli/chat/tui/state/transcriptLines';
 import { CLI_LOCAL_STREAM_ID } from '@cli/chat/tui/state/transcript';
 import { attachSessionSignalsAdapter } from '@cli/chat/tui/state/sessionSignalsAdapter';
-import {
-  isFinalizedTranscriptRow,
-  transcriptRowHeadline,
-} from '@cli/chat/tui/panes/transcriptEntries';
 import { SessionState } from '@controllers/session/SessionState';
 import {
   AgentCategory,
@@ -77,11 +74,7 @@ import {
   type StreamTabId,
   type WorkflowCallProgress,
 } from '@shared/schemas';
-import {
-  transcriptText,
-  type ToolRow,
-  type TranscriptRow,
-} from '@shared/transcript';
+import type { ToolRow, TranscriptRow } from '@shared/transcript';
 import { formatWorkflowPhaseHeading } from '@shared/copy/workflowCall';
 import { buildChildRosters } from '@test/support/childRosters';
 import {

--- a/src/test-kernel/cli/RetryRequest.vitest.ts
+++ b/src/test-kernel/cli/RetryRequest.vitest.ts
@@ -99,9 +99,7 @@ describe('CLI retry request', () => {
 
   it('settles the approval queue from a real terminal k input', async () => {
     const { ink, React } = await loadInk();
-    const decision = enqueueApproval({
-      ...subscriptionLimitPayload(true),
-    });
+    const decision = enqueueApproval(subscriptionLimitPayload(true));
     const { instance, stdin } = renderInteractive(
       ink,
       React.createElement(ApprovalModal, {

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -1396,7 +1396,7 @@ describe('executeCliConfig', () => {
     });
     await vi.waitFor(() => expect(publishLeaseScope).toBeDefined());
     const shutdown = platform.lifecycle.runShutdown();
-    publishLeaseScope?.((operation) => operation(), 'exec-1' as ExecutionId);
+    publishLeaseScope?.(runOperationSync, 'exec-1' as ExecutionId);
     publishRun?.();
     mockCancelledOutcome();
     hangingRun.resolve(COMPLETED_RUN);
@@ -1436,7 +1436,7 @@ describe('executeCliConfig', () => {
     });
     await vi.waitFor(() => expect(publishLeaseScope).toBeDefined());
     const shutdown = platform.lifecycle.runShutdown();
-    publishLeaseScope?.((operation) => operation(), 'exec-1' as ExecutionId);
+    publishLeaseScope?.(runOperationSync, 'exec-1' as ExecutionId);
     publishRun?.();
     mockCancelledOutcome();
     hangingRun.resolve(COMPLETED_RUN);

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -210,6 +210,11 @@ async function spyOnTranscriptFlush() {
   return { store, flushSpy };
 }
 
+/** Lease-scope runner for tests that don't need to observe the wrapper. */
+function runOperationSync(operation: () => unknown): unknown {
+  return operation();
+}
+
 async function stubRunExecutionDeps(): Promise<void> {
   vi.clearAllMocks();
   mocks.close.mockResolvedValue(undefined);
@@ -259,10 +264,18 @@ async function stubRunExecutionDeps(): Promise<void> {
   });
   mocks.runAgent.mockImplementation(async (_request, options) => {
     options.onExecutionLeaseAcquired?.(
-      (operation: () => unknown) => operation(),
+      runOperationSync,
       'exec-1' as ExecutionId,
     );
     return COMPLETED_RUN;
+  });
+}
+
+/** Queues one cancelled, persisted outcome read for the next resolution. */
+function mockCancelledOutcome(): void {
+  mocks.readCliRunOutcomeState.mockResolvedValueOnce({
+    outcome: RUN_OUTCOME.CANCELLED,
+    outcomePersisted: true,
   });
 }
 
@@ -786,7 +799,7 @@ describe('executeCliRequest', () => {
     const context = cliContext();
     mocks.runAgent.mockImplementationOnce(async (_request, options) => {
       options.onExecutionLeaseAcquired?.(
-        (operation: () => unknown) => operation(),
+        runOperationSync,
         'exec-1' as ExecutionId,
       );
       options.onApprovalPolicyDenial?.();
@@ -882,10 +895,7 @@ describe('executeCliRequest', () => {
       });
       expect(mocks.releaseExecutionLeaseAfterArtifacts).not.toHaveBeenCalled();
 
-      mocks.readCliRunOutcomeState.mockResolvedValueOnce({
-        outcome: 'cancelled',
-        outcomePersisted: true,
-      });
+      mockCancelledOutcome();
       hangingRun.resolve(COMPLETED_RUN);
       await vi.waitFor(() =>
         expect(onInterruptedExecutionFinalized).toHaveBeenCalledOnce(),
@@ -953,15 +963,9 @@ describe('executeCliRequest', () => {
     });
     await vi.waitFor(() => expect(publishLeaseScope).toBeDefined());
     const shutdown = platform.lifecycle.runShutdown();
-    publishLeaseScope?.(
-      (operation: () => unknown) => operation(),
-      'exec-1' as ExecutionId,
-    );
+    publishLeaseScope?.(runOperationSync, 'exec-1' as ExecutionId);
     publishRun?.();
-    mocks.readCliRunOutcomeState.mockResolvedValueOnce({
-      outcome: 'cancelled',
-      outcomePersisted: true,
-    });
+    mockCancelledOutcome();
     hangingRun.resolve(COMPLETED_RUN);
 
     await shutdown;
@@ -1014,15 +1018,9 @@ describe('executeCliRequest', () => {
       });
       await vi.waitFor(() => expect(publishLeaseScope).toBeDefined());
       const shutdown = platform.lifecycle.runShutdown();
-      publishLeaseScope?.(
-        (operation: () => unknown) => operation(),
-        'exec-1' as ExecutionId,
-      );
+      publishLeaseScope?.(runOperationSync, 'exec-1' as ExecutionId);
       publishRun?.();
-      mocks.readCliRunOutcomeState.mockResolvedValueOnce({
-        outcome: 'cancelled',
-        outcomePersisted: true,
-      });
+      mockCancelledOutcome();
       hangingRun.resolve(COMPLETED_RUN);
 
       await shutdown;
@@ -1108,7 +1106,7 @@ describe('executeCliRequest', () => {
     const run = executeCliRequest(baseRequest(), cliContext(), {});
     await vi.waitFor(() => expect(leaseOptions).toBeDefined());
     leaseOptions?.onExecutionLeaseAcquired?.(
-      (operation: () => unknown) => operation(),
+      runOperationSync,
       'exec-1' as ExecutionId,
     );
     leaseOptions?.onRun?.();
@@ -1138,15 +1136,12 @@ describe('executeCliRequest', () => {
 
     const shutdown = platform.lifecycle.runShutdown();
     leaseOptions?.onExecutionLeaseAcquired?.(
-      (operation: () => unknown) => operation(),
+      runOperationSync,
       'exec-1' as ExecutionId,
     );
     leaseOptions?.onRun?.();
     await leaseOptions?.openWorkflowOutput?.(COMPLETED_WORKFLOW_RUN);
-    mocks.readCliRunOutcomeState.mockResolvedValueOnce({
-      outcome: RUN_OUTCOME.CANCELLED,
-      outcomePersisted: true,
-    });
+    mockCancelledOutcome();
     hangingRun.resolve(COMPLETED_WORKFLOW_RUN);
 
     await shutdown;
@@ -1178,7 +1173,7 @@ describe('executeCliRequest', () => {
     });
     await vi.waitFor(() => expect(leaseOptions).toBeDefined());
     leaseOptions?.onExecutionLeaseAcquired?.(
-      (operation: () => unknown) => operation(),
+      runOperationSync,
       'exec-1' as ExecutionId,
     );
     leaseOptions?.onRun?.();
@@ -1299,7 +1294,7 @@ describe('executeCliRequest', () => {
     });
     const hangingRun = stubHangingRun((options) => {
       options.onExecutionLeaseAcquired?.(
-        (operation: () => unknown) => operation(),
+        runOperationSync,
         'exec-1' as ExecutionId,
       );
     });
@@ -1312,10 +1307,7 @@ describe('executeCliRequest', () => {
     const shutdown = platform.lifecycle.runShutdown();
     await Promise.resolve();
     expect(mocks.emit).not.toHaveBeenCalled();
-    mocks.readCliRunOutcomeState.mockResolvedValueOnce({
-      outcome: 'cancelled',
-      outcomePersisted: true,
-    });
+    mockCancelledOutcome();
     hangingRun.resolve(COMPLETED_RUN);
     await shutdown;
     expect(mocks.emit).toHaveBeenCalledExactlyOnceWith('requestShowError', {
@@ -1406,10 +1398,7 @@ describe('executeCliConfig', () => {
     const shutdown = platform.lifecycle.runShutdown();
     publishLeaseScope?.((operation) => operation(), 'exec-1' as ExecutionId);
     publishRun?.();
-    mocks.readCliRunOutcomeState.mockResolvedValueOnce({
-      outcome: RUN_OUTCOME.CANCELLED,
-      outcomePersisted: true,
-    });
+    mockCancelledOutcome();
     hangingRun.resolve(COMPLETED_RUN);
 
     await vi.waitFor(() =>
@@ -1449,10 +1438,7 @@ describe('executeCliConfig', () => {
     const shutdown = platform.lifecycle.runShutdown();
     publishLeaseScope?.((operation) => operation(), 'exec-1' as ExecutionId);
     publishRun?.();
-    mocks.readCliRunOutcomeState.mockResolvedValueOnce({
-      outcome: RUN_OUTCOME.CANCELLED,
-      outcomePersisted: true,
-    });
+    mockCancelledOutcome();
     hangingRun.resolve(COMPLETED_RUN);
 
     await shutdown;

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.ts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.ts
@@ -5,10 +5,7 @@ import type {
   RuntimePresentationEvent,
   RuntimePresentationEventPayloads,
 } from '@agent/runtime/runtimePresentationEvents';
-import {
-  SessionEventHub,
-  type SessionEvent,
-} from '@agent/runtime/SessionEventHub';
+import type { SessionEvent } from '@agent/runtime/SessionEventHub';
 import { pickGlobalArgs } from '@cli/runtime/globalArgs';
 import {
   createRunProgressRenderer,

--- a/src/test-kernel/cli/SupabaseAuthCallbackServer.vitest.ts
+++ b/src/test-kernel/cli/SupabaseAuthCallbackServer.vitest.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { type SupabaseSessionCoordinator } from '@auth/SupabaseSession';
-import { startLoopbackCallbackServer } from '@cli/runtime/supabaseAuthCallbackServer';
-
-type LoopbackServer = Awaited<ReturnType<typeof startLoopbackCallbackServer>>;
+import {
+  startLoopbackCallbackServer,
+  type LoopbackCallbackServer,
+} from '@cli/runtime/supabaseAuthCallbackServer';
 
 function stubCoordinator(
   overrides: {
@@ -18,7 +19,9 @@ function stubCoordinator(
   } as unknown as SupabaseSessionCoordinator;
 }
 
-async function fetchCallbackNonce(server: LoopbackServer): Promise<string> {
+async function fetchCallbackNonce(
+  server: LoopbackCallbackServer,
+): Promise<string> {
   const callbackPage = await fetch(`${server.redirectTo}?code=oauth-code`);
   const nonce = (await callbackPage.text()).match(/nonce: "([^"]+)"/)?.[1];
   expect(nonce).toBeDefined();
@@ -26,7 +29,7 @@ async function fetchCallbackNonce(server: LoopbackServer): Promise<string> {
 }
 
 function postCallbackCompletion(
-  server: LoopbackServer,
+  server: LoopbackCallbackServer,
   nonce: string,
 ): Promise<Response> {
   return fetch(`${server.redirectTo}/complete`, {

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
@@ -146,7 +146,6 @@ function tui(
   contextOverrides: Partial<CliContext> = {},
 ): {
   readonly presentationHost: CliRuntimeHost;
-  readonly cliContext: CliContext;
   readonly interactions: HostInteractions;
   readonly prepareRetry: ReturnType<typeof vi.fn>;
   readonly dispose: () => void;
@@ -170,7 +169,6 @@ function tui(
   onTestFinished(detachInteractions);
   return {
     presentationHost,
-    cliContext,
     interactions,
     prepareRetry,
     dispose: detachInteractions,

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
@@ -45,6 +45,7 @@ import {
   STREAM_PHASE,
   TOOL_USE_STATUS,
   type StreamLogEntry,
+  type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
 import { transcriptText, type TranscriptRow } from '@shared/transcript';
@@ -155,6 +156,10 @@ function transcriptEntry(id: string): StreamLogEntry | undefined {
 
 function streamSlice() {
   return streams.get().get(STREAM_ID);
+}
+
+function setStatus(status: StreamPhase): void {
+  setStreamStatusInCliState({ streamId: STREAM_ID, status });
 }
 
 function streamEntries(): readonly TranscriptRow[] {
@@ -299,10 +304,7 @@ describe('CLI workflow-script child-stream transcript', () => {
         status: 'running',
       },
     });
-    setStreamStatusInCliState({
-      streamId: STREAM_ID,
-      status: STREAM_PHASE.CANCELLED,
-    });
+    setStatus(STREAM_PHASE.CANCELLED);
 
     // This exercises both terminal-status finalization entry points:
     // syncStreamLog's settled-prefix promotion and the explicit
@@ -373,10 +375,7 @@ describe('CLI workflow-script child-stream transcript', () => {
     // re-created (un-retiring the stream identity).
     resetCliState();
     patchStream(STREAM_ID, (slice) => ({ ...slice }));
-    setStreamStatusInCliState({
-      streamId: STREAM_ID,
-      status: STREAM_PHASE.CANCELLED,
-    });
+    setStatus(STREAM_PHASE.CANCELLED);
     syncStreamLog(defaultSession(), STREAM_ID, { forceFinal: true });
 
     const plannedEntries = streamEntries();
@@ -472,10 +471,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       phase: STREAM_PHASE.CANCELLED,
       cause: STREAM_TRANSITION_CAUSE.USER_STOP,
     });
-    setStreamStatusInCliState({
-      streamId: STREAM_ID,
-      status: STREAM_PHASE.CANCELLED,
-    });
+    setStatus(STREAM_PHASE.CANCELLED);
     syncStreamLog(defaultSession(), STREAM_ID, { forceFinal: true });
 
     liveItems = appendItems(liveItems);
@@ -544,10 +540,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       ...slice,
       entries: syntheticEntry ? [syntheticEntry] : [],
     }));
-    setStreamStatusInCliState({
-      streamId: STREAM_ID,
-      status: STREAM_PHASE.CANCELLED,
-    });
+    setStatus(STREAM_PHASE.CANCELLED);
     syncStreamLog(defaultSession(), STREAM_ID);
     const coldItems = appendItems();
 
@@ -1040,10 +1033,7 @@ describe('CLI workflow-script child-stream transcript', () => {
     expect(finalizedFlags(entries)[phaseIndex]).toBe(true);
 
     // Finalize the stream so the settled prefix promotes into scrollback.
-    setStreamStatusInCliState({
-      streamId: STREAM_ID,
-      status: STREAM_PHASE.COMPLETED,
-    });
+    setStatus(STREAM_PHASE.COMPLETED);
     syncStreamLog(defaultSession(), STREAM_ID);
 
     const finalized = streamEntries();

--- a/src/test-kernel/cli/chatSessionController.vitest.ts
+++ b/src/test-kernel/cli/chatSessionController.vitest.ts
@@ -248,6 +248,11 @@ type ToolUseRunResult<Outcome> = {
   streamId: StreamTabId;
 };
 
+/** The subset of `executeAgent`'s options every mock implementation below reads. */
+type ExecuteAgentMockOptions = {
+  readonly onStreamResolved?: (id: StreamTabId) => void;
+};
+
 function makeInit(
   overrides: Partial<ChatSessionControllerInit> = {},
 ): ChatSessionControllerInit {
@@ -781,7 +786,7 @@ describe('createChatSessionController', () => {
       async (
         _config: unknown,
         executionId: ExecutionId,
-        options: { readonly onStreamResolved?: (id: StreamTabId) => void },
+        options: ExecuteAgentMockOptions,
       ) => {
         const rootHandle = testExecutionHandle({
           executionId,
@@ -889,7 +894,7 @@ describe('createChatSessionController', () => {
         async (
           _config: unknown,
           executionId: ExecutionId,
-          options: { readonly onStreamResolved?: (id: StreamTabId) => void },
+          options: ExecuteAgentMockOptions,
         ) => {
           rootAExecutionId = executionId;
           childAExecutionId = 'child-a-exec' as ExecutionId;
@@ -915,7 +920,7 @@ describe('createChatSessionController', () => {
         async (
           _config: unknown,
           executionId: ExecutionId,
-          options: { readonly onStreamResolved?: (id: StreamTabId) => void },
+          options: ExecuteAgentMockOptions,
         ) => {
           rootBExecutionId = executionId;
           trackRunningExecution(
@@ -987,7 +992,7 @@ describe('createChatSessionController', () => {
       async (
         _config: unknown,
         executionId: ExecutionId,
-        options: { readonly onStreamResolved?: (id: StreamTabId) => void },
+        options: ExecuteAgentMockOptions,
       ) => {
         trackRunningExecution(
           executions,

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -190,6 +190,29 @@ type BridgeTestContext = {
 
 const bridgeContexts = new WeakMap<TestableBridge, BridgeTestContext>();
 
+/** Constructs a `DesktopProgressBridge` and records the test-side context it
+ * was built with, so `bridgeContext` and friends can look it up later. Used
+ * everywhere a bridge is instantiated: the single-window harness and both
+ * windows of the process-owner (reopen) harness. */
+function instantiateBridge(
+  bridgeModule: DesktopAgentExecutionModule,
+  onMessage: (message: unknown) => void,
+  bridgeOptions: DesktopProgressBridgeOptions,
+  context: { session: SessionHandle; snapshots: ProgressSnapshotStore },
+): TestableBridge {
+  const bridge = new bridgeModule.DesktopProgressBridge(
+    onMessage,
+    bridgeOptions,
+  ) as unknown as TestableBridge;
+  bridgeContexts.set(bridge, {
+    session: context.session,
+    snapshots: context.snapshots,
+    ctor: bridgeModule.DesktopProgressBridge,
+    options: bridgeOptions,
+  });
+  return bridge;
+}
+
 function bridgeContext(bridge: TestableBridge): BridgeTestContext {
   const context = bridgeContexts.get(bridge);
   if (!context) {
@@ -519,16 +542,15 @@ async function createBridge(
       ...(options.openPath ? { openPath: options.openPath } : {}),
     }),
   };
-  const bridge = new bridgeModule.DesktopProgressBridge((message) => {
-    options.observeRendererMessage?.(message);
-    messages.push(message);
-  }, bridgeOptions) as unknown as TestableBridge;
-  bridgeContexts.set(bridge, {
-    session,
-    snapshots: progressSnapshotStore,
-    ctor: bridgeModule.DesktopProgressBridge,
-    options: bridgeOptions,
-  });
+  const bridge = instantiateBridge(
+    bridgeModule,
+    (message) => {
+      options.observeRendererMessage?.(message);
+      messages.push(message);
+    },
+    bridgeOptions,
+    { session, snapshots: progressSnapshotStore },
+  );
   const waitForPresentation = bridge.waitUntilReady.bind(bridge);
   bridge.waitUntilReady = async () => {
     await sessionReady;
@@ -2758,15 +2780,14 @@ describe('DesktopProgressBridge', () => {
           },
         }),
       };
-      const bridgeA = new bridgeModule.DesktopProgressBridge((message) => {
-        messages.push(message);
-      }, bridgeAOptions) as unknown as TestableBridge;
-      bridgeContexts.set(bridgeA, {
-        session: processSession,
-        snapshots: progressSnapshotStore,
-        ctor: bridgeModule.DesktopProgressBridge,
-        options: bridgeAOptions,
-      });
+      const bridgeA = instantiateBridge(
+        bridgeModule,
+        (message) => {
+          messages.push(message);
+        },
+        bridgeAOptions,
+        { session: processSession, snapshots: progressSnapshotStore },
+      );
       await bridgeA.waitUntilReady();
       const presentationBridges = new Set([bridgeA]);
       const createHandle = (
@@ -2829,16 +2850,15 @@ describe('DesktopProgressBridge', () => {
             },
           }),
         };
-        const bridgeB = new bridgeModule.DesktopProgressBridge((message) => {
-          reopenedMessages.push(message);
-          observeRendererMessage?.(message);
-        }, bridgeBOptions) as unknown as TestableBridge;
-        bridgeContexts.set(bridgeB, {
-          session: processSession,
-          snapshots: progressSnapshotStore,
-          ctor: bridgeModule.DesktopProgressBridge,
-          options: bridgeBOptions,
-        });
+        const bridgeB = instantiateBridge(
+          bridgeModule,
+          (message) => {
+            reopenedMessages.push(message);
+            observeRendererMessage?.(message);
+          },
+          bridgeBOptions,
+          { session: processSession, snapshots: progressSnapshotStore },
+        );
         presentationBridges.add(bridgeB);
         await bridgeB.waitUntilReady();
         return { bridgeB, errorsB, infosB, progressSnapshotStore };

--- a/src/test-kernel/desktop/DesktopDiffHost.vitest.ts
+++ b/src/test-kernel/desktop/DesktopDiffHost.vitest.ts
@@ -84,6 +84,16 @@ function expectOpenedPatchFile(openedPaths: readonly string[]): void {
   expect(path.extname(openedPaths[0])).toBe('.diff');
 }
 
+/** A promise/resolver pair used to pause a mock implementation mid-flight
+ * until the test is ready to release it. */
+function createGate(): { promise: Promise<void>; release: () => void } {
+  let release!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+}
+
 const tempDirs = useTempDirs();
 const hosts: DiffHost[] = [];
 
@@ -310,24 +320,18 @@ describe('createDesktopDiffHost', () => {
     const [original, proposed] = await prepareDiffPair();
     const diffDirsBefore = listDiffTempDirs();
 
-    let markReadStarted!: () => void;
-    const readStarted = new Promise<void>((resolve) => {
-      markReadStarted = resolve;
-    });
-    let releaseRead!: () => void;
-    const readGate = new Promise<void>((resolve) => {
-      releaseRead = resolve;
-    });
+    const readStarted = createGate();
+    const readGate = createGate();
     vi.mocked(readFile).mockImplementationOnce(async () => {
-      markReadStarted();
-      await readGate;
+      readStarted.release();
+      await readGate.promise;
       return 'a\n';
     });
 
     const disposePromise = host.dispose();
     const openPromise = host.openDiff(original, proposed, 'Compare');
 
-    await readStarted;
+    await readStarted.promise;
     let disposeSettled = false;
     void disposePromise.then(() => {
       disposeSettled = true;
@@ -335,7 +339,7 @@ describe('createDesktopDiffHost', () => {
     await Promise.resolve();
     expect(disposeSettled).toBe(false);
 
-    releaseRead();
+    readGate.release();
     await expect(openPromise).rejects.toThrow(
       'Desktop window closed before the diff could be opened.',
     );
@@ -357,22 +361,16 @@ describe('createDesktopDiffHost', () => {
       const [original, proposed] = await prepareDiffPair();
       const diffDirsBefore = listDiffTempDirs();
 
-      let markReadStarted!: () => void;
-      const readStarted = new Promise<void>((resolve) => {
-        markReadStarted = resolve;
-      });
-      let releaseRead!: () => void;
-      const readGate = new Promise<void>((resolve) => {
-        releaseRead = resolve;
-      });
+      const readStarted = createGate();
+      const readGate = createGate();
       vi.mocked(readFile).mockImplementationOnce(async () => {
-        markReadStarted();
-        await readGate;
+        readStarted.release();
+        await readGate.promise;
         return 'a\n';
       });
 
       const openPromise = host.openDiff(original, proposed, 'Compare');
-      await readStarted;
+      await readStarted.promise;
 
       const disposePromise = host.dispose();
       let removalTarget: string | undefined;
@@ -381,7 +379,7 @@ describe('createDesktopDiffHost', () => {
         throw new Error('simulated EBUSY removal failure');
       });
 
-      releaseRead();
+      readGate.release();
 
       await expect(openPromise).rejects.toThrow(
         'Desktop window closed before the diff could be opened.',
@@ -472,10 +470,7 @@ describe('createDesktopDiffHost', () => {
     const [original, proposed] = await prepareDiffPair();
     const diffDirsBefore = listDiffTempDirs();
 
-    let releaseRemoval!: () => void;
-    const removalGate = new Promise<void>((resolve) => {
-      releaseRemoval = resolve;
-    });
+    const removalGate = createGate();
     let removalTarget: string | undefined;
     const actualFs =
       await vi.importActual<typeof import('node:fs/promises')>(
@@ -483,7 +478,7 @@ describe('createDesktopDiffHost', () => {
       );
     vi.mocked(rm).mockImplementationOnce(async (target, options) => {
       removalTarget = String(target);
-      await removalGate;
+      await removalGate.promise;
       await actualFs.rm(
         target as string,
         options as Parameters<typeof actualFs.rm>[1],
@@ -504,7 +499,7 @@ describe('createDesktopDiffHost', () => {
     await sleep(25);
     expect(disposeSettled).toBe(false);
 
-    releaseRemoval();
+    removalGate.release();
     await expect(openPromise).rejects.toThrow(
       'Desktop window closed before the diff could be opened.',
     );
@@ -523,10 +518,7 @@ describe('createDesktopDiffHost', () => {
     const { host, openPath } = createHost();
     openPath.mockRejectedValue(new Error('editor unavailable'));
 
-    let releaseRemoval!: () => void;
-    const removalGate = new Promise<void>((resolve) => {
-      releaseRemoval = resolve;
-    });
+    const removalGate = createGate();
     let removalTarget: string | undefined;
     const actualFs =
       await vi.importActual<typeof import('node:fs/promises')>(
@@ -534,7 +526,7 @@ describe('createDesktopDiffHost', () => {
       );
     vi.mocked(rm).mockImplementationOnce(async (target, options) => {
       removalTarget = String(target);
-      await removalGate;
+      await removalGate.promise;
       await actualFs.rm(
         target as string,
         options as Parameters<typeof actualFs.rm>[1],
@@ -556,7 +548,7 @@ describe('createDesktopDiffHost', () => {
       .mock.calls.filter(([target]) => String(target) === removalTarget);
     expect(targetCalls).toHaveLength(1);
 
-    releaseRemoval();
+    removalGate.release();
     await expect(openPromise).rejects.toThrow('editor unavailable');
     await disposePromise;
 
@@ -576,14 +568,11 @@ describe('createDesktopDiffHost', () => {
       const { host, openPath } = createHost();
       openPath.mockRejectedValue(new Error('editor unavailable'));
 
-      let releaseRemoval!: () => void;
-      const removalGate = new Promise<void>((resolve) => {
-        releaseRemoval = resolve;
-      });
+      const removalGate = createGate();
       let removalTarget: string | undefined;
       vi.mocked(rm).mockImplementationOnce(async (target) => {
         removalTarget = String(target);
-        await removalGate;
+        await removalGate.promise;
         throw new Error('simulated removal failure');
       });
 
@@ -593,7 +582,7 @@ describe('createDesktopDiffHost', () => {
       });
 
       const disposePromise = host.dispose();
-      releaseRemoval();
+      removalGate.release();
 
       await expect(openPromise).rejects.toThrow('editor unavailable');
       await disposePromise;
@@ -617,22 +606,16 @@ describe('createDesktopDiffHost', () => {
       const { host, openPath } = createHost();
       const [original, proposed] = await prepareDiffPair();
 
-      let markReadStarted!: () => void;
-      const readStarted = new Promise<void>((resolve) => {
-        markReadStarted = resolve;
-      });
-      let releaseRead!: () => void;
-      const readGate = new Promise<void>((resolve) => {
-        releaseRead = resolve;
-      });
+      const readStarted = createGate();
+      const readGate = createGate();
       vi.mocked(readFile).mockImplementationOnce(async () => {
-        markReadStarted();
-        await readGate;
+        readStarted.release();
+        await readGate.promise;
         return 'a\n';
       });
 
       const openPromise = host.openDiff(original, proposed, 'Compare');
-      await readStarted;
+      await readStarted.promise;
 
       const disposePromise = host.dispose();
       let disposeSettled = false;
@@ -648,7 +631,7 @@ describe('createDesktopDiffHost', () => {
 
       // The hung setup is abandoned after the bound. Once it resumes, the
       // `disposed` branch still removes its own temp directory.
-      releaseRead();
+      readGate.release();
       await expect(openPromise).rejects.toThrow(
         'Desktop window closed before the diff could be opened.',
       );

--- a/src/test-kernel/desktop/DesktopDiffHost.vitest.ts
+++ b/src/test-kernel/desktop/DesktopDiffHost.vitest.ts
@@ -94,6 +94,22 @@ function createGate(): { promise: Promise<void>; release: () => void } {
   return { promise, release };
 }
 
+/** Pauses the next `readFile` call so a test can hold `openDiff` mid-flight
+ * between the read starting and its result resolving. */
+function gateReadFile(): {
+  readStarted: ReturnType<typeof createGate>;
+  readGate: ReturnType<typeof createGate>;
+} {
+  const readStarted = createGate();
+  const readGate = createGate();
+  vi.mocked(readFile).mockImplementationOnce(async () => {
+    readStarted.release();
+    await readGate.promise;
+    return 'a\n';
+  });
+  return { readStarted, readGate };
+}
+
 const tempDirs = useTempDirs();
 const hosts: DiffHost[] = [];
 
@@ -320,13 +336,7 @@ describe('createDesktopDiffHost', () => {
     const [original, proposed] = await prepareDiffPair();
     const diffDirsBefore = listDiffTempDirs();
 
-    const readStarted = createGate();
-    const readGate = createGate();
-    vi.mocked(readFile).mockImplementationOnce(async () => {
-      readStarted.release();
-      await readGate.promise;
-      return 'a\n';
-    });
+    const { readStarted, readGate } = gateReadFile();
 
     const disposePromise = host.dispose();
     const openPromise = host.openDiff(original, proposed, 'Compare');
@@ -361,13 +371,7 @@ describe('createDesktopDiffHost', () => {
       const [original, proposed] = await prepareDiffPair();
       const diffDirsBefore = listDiffTempDirs();
 
-      const readStarted = createGate();
-      const readGate = createGate();
-      vi.mocked(readFile).mockImplementationOnce(async () => {
-        readStarted.release();
-        await readGate.promise;
-        return 'a\n';
-      });
+      const { readStarted, readGate } = gateReadFile();
 
       const openPromise = host.openDiff(original, proposed, 'Compare');
       await readStarted.promise;
@@ -606,13 +610,7 @@ describe('createDesktopDiffHost', () => {
       const { host, openPath } = createHost();
       const [original, proposed] = await prepareDiffPair();
 
-      const readStarted = createGate();
-      const readGate = createGate();
-      vi.mocked(readFile).mockImplementationOnce(async () => {
-        readStarted.release();
-        await readGate.promise;
-        return 'a\n';
-      });
+      const { readStarted, readGate } = gateReadFile();
 
       const openPromise = host.openDiff(original, proposed, 'Compare');
       await readStarted.promise;

--- a/src/test-kernel/desktop/DesktopDiffHost.vitest.ts
+++ b/src/test-kernel/desktop/DesktopDiffHost.vitest.ts
@@ -9,6 +9,7 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 // Local imports - test support
+import { createDeferred } from '@test/support/asyncTestUtils';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { loadSourceModule } from './loadSourceModule.ts';
 
@@ -87,11 +88,8 @@ function expectOpenedPatchFile(openedPaths: readonly string[]): void {
 /** A promise/resolver pair used to pause a mock implementation mid-flight
  * until the test is ready to release it. */
 function createGate(): { promise: Promise<void>; release: () => void } {
-  let release!: () => void;
-  const promise = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  return { promise, release };
+  const { promise, resolve } = createDeferred<void>();
+  return { promise, release: resolve };
 }
 
 /** Pauses the next `readFile` call so a test can hold `openDiff` mid-flight

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.ts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.ts
@@ -156,6 +156,13 @@ function flushAsyncWork(): Promise<void> {
   );
 }
 
+function newStatePorts() {
+  return {
+    globalState: new FakeStateStore(),
+    workspaceState: new FakeStateStore(),
+  };
+}
+
 describe('desktop settings IPC', () => {
   beforeAll(async () => {
     ({ createDesktopSettingsIpc } = await loadSourceModule(
@@ -227,13 +234,9 @@ describe('desktop settings IPC', () => {
     const postSubscriptionUsage = vi.fn(async () => undefined);
     const onError = vi.fn();
     const credentialSettingsController =
-      createStubDesktopCredentialSettingsController(
-        {
-          globalState: new FakeStateStore(),
-          workspaceState: new FakeStateStore(),
-        },
-        { postSubscriptionUsage },
-      );
+      createStubDesktopCredentialSettingsController(newStatePorts(), {
+        postSubscriptionUsage,
+      });
     const { settings } = createSettingsFixture({
       credentialSettingsController,
       ui: { onError },
@@ -274,13 +277,9 @@ describe('desktop settings IPC', () => {
     );
     const onError = vi.fn();
     const credentialSettingsController =
-      createStubDesktopCredentialSettingsController(
-        {
-          globalState: new FakeStateStore(),
-          workspaceState: new FakeStateStore(),
-        },
-        { postSubscriptionUsage },
-      );
+      createStubDesktopCredentialSettingsController(newStatePorts(), {
+        postSubscriptionUsage,
+      });
     const { settings } = createSettingsFixture({
       credentialSettingsController,
       ui: { onError },
@@ -659,10 +658,7 @@ describe('desktop settings IPC', () => {
   });
 
   it('delegates profile and ChatGPT commands to the credential controller', async () => {
-    const state = {
-      globalState: new FakeStateStore(),
-      workspaceState: new FakeStateStore(),
-    };
+    const state = newStatePorts();
     const setProviderKey = vi.fn(async () => undefined);
     const signIn = vi.fn(async () => undefined);
     const signOut = vi.fn(async () => undefined);
@@ -954,10 +950,7 @@ describe('desktop settings IPC', () => {
   });
 
   it('refreshes credentials before conditionally refreshing the agent catalog', async () => {
-    const state = {
-      globalState: new FakeStateStore(),
-      workspaceState: new FakeStateStore(),
-    };
+    const state = newStatePorts();
     const events: string[] = [];
     const refreshAuthDependentData = vi.fn(async () => {
       events.push('credentials');

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
@@ -146,13 +146,14 @@ describe('desktop agent directory bootstrap', () => {
   it('skips same-resource re-entry but refreshes when the resource path changes', async () => {
     const { bootstrapNodeAgentDirectories, resourcesPath, storage } =
       await createHarness();
-
-    await bootstrapNodeAgentDirectories({
+    const options = {
       channel: 'desktop',
       resourcesPath,
       currentVersion: '1.2.3',
       versionStateKey: GlobalStateKey.LAST_KNOWN_VERSION,
-    });
+    };
+
+    await bootstrapNodeAgentDirectories(options);
     const copiedAgent = join(
       storage.getGlobalStoragePath(),
       'agents',
@@ -160,12 +161,7 @@ describe('desktop agent directory bootstrap', () => {
     );
     await writeFile(copiedAgent, 'name: locally-edited\n');
 
-    await bootstrapNodeAgentDirectories({
-      channel: 'desktop',
-      resourcesPath,
-      currentVersion: '1.2.3',
-      versionStateKey: GlobalStateKey.LAST_KNOWN_VERSION,
-    });
+    await bootstrapNodeAgentDirectories(options);
     await expect(readFile(copiedAgent, 'utf8')).resolves.toBe(
       'name: locally-edited\n',
     );
@@ -181,10 +177,9 @@ describe('desktop agent directory bootstrap', () => {
     );
 
     await bootstrapNodeAgentDirectories({
-      channel: 'desktop',
+      ...options,
       resourcesPath: nextResourcesPath,
       currentVersion: '1.2.4',
-      versionStateKey: GlobalStateKey.LAST_KNOWN_VERSION,
     });
     await expect(readFile(copiedAgent, 'utf8')).resolves.toBe('name: next\n');
   });

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
@@ -74,19 +74,23 @@ function firstShowRequestId(show: ReturnType<typeof vi.fn>): string {
  * the same set on every call, because `cancel()` reaches all seven kinds and
  * has to find the requests `show()` recorded.
  */
-function createInteractions(options: {
-  presentationSink?: ReturnType<typeof createPresentationSink>;
-  setApprovalBypassState?: (update: HostApprovalBypassStateUpdate) => void;
-  session: SessionHandle;
-}) {
+function createInteractions(
+  options: {
+    presentationSink?: ReturnType<typeof createPresentationSink>;
+    setApprovalBypassState?: (update: HostApprovalBypassStateUpdate) => void;
+    session?: SessionHandle;
+  } = {},
+) {
   const handlers = createRecordingApprovalHandlers();
   const toolEditApprovals = createToolEditApprovals();
+  const session = options.session ?? createTestSession();
   return {
     handlers,
+    session,
     toolEditApprovals,
     interactions: createExtensionHostInteractions({
       interactions: options.presentationSink ?? createPresentationSink(),
-      session: options.session,
+      session,
       getApprovalHandlers: () => handlers,
       getToolEditApprovals: () =>
         toolEditApprovals as unknown as ReturnType<
@@ -127,8 +131,7 @@ function createDeferredPreparation() {
 describe('createExtensionHostInteractions', () => {
   it('forwards emit to the caller-supplied presentation host (#9251)', () => {
     const presentationSink = createPresentationSink();
-    const session = createTestSession();
-    const { interactions } = createInteractions({ presentationSink, session });
+    const { interactions } = createInteractions({ presentationSink });
 
     interactions.emit?.('requestShowError', { message: 'boom' });
 
@@ -139,10 +142,7 @@ describe('createExtensionHostInteractions', () => {
 
   it('forwards approval bypass state through the host port', () => {
     const setApprovalBypassState = vi.fn();
-    const { interactions } = createInteractions({
-      session: createTestSession(),
-      setApprovalBypassState,
-    });
+    const { interactions } = createInteractions({ setApprovalBypassState });
     const update = {
       streamId: 'stream:bypass',
       kind: 'bash',
@@ -155,8 +155,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('provides diagnostics and criticism capabilities', async () => {
-    const session = createTestSession();
-    const { interactions } = createInteractions({ session });
+    const { interactions } = createInteractions();
 
     await expect(
       interactions.readDiagnostics?.('/workspace/paper.tex'),
@@ -187,10 +186,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('approves already-pending delegated work only in the selected stream', async () => {
-    const session = createTestSession();
-    const { handlers, interactions, toolEditApprovals } = createInteractions({
-      session,
-    });
+    const { handlers, interactions, toolEditApprovals } = createInteractions();
 
     function requestProposal(requestId: string, instruction: string) {
       return interactions.requestAgentProposal?.({
@@ -260,12 +256,10 @@ describe('createExtensionHostInteractions', () => {
 
   it('shows and resolves plan approvals through existing handlers', async () => {
     const presentationSink = createPresentationSink();
-    const session = createTestSession();
-    const sessionEvents = recordSessionEvents(session);
-    const { handlers, interactions } = createInteractions({
+    const { handlers, interactions, session } = createInteractions({
       presentationSink,
-      session,
     });
+    const sessionEvents = recordSessionEvents(session);
 
     const resultPromise = interactions.requestPlanApproval?.({
       requestId: 'plan-a',
@@ -319,9 +313,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('rejects a request when its show transport fails synchronously', async () => {
-    const { handlers, interactions } = createInteractions({
-      session: createTestSession(),
-    });
+    const { handlers, interactions } = createInteractions();
     handlers.transport.planApproval.show.mockImplementationOnce(() => {
       throw new Error('Progress view transport unavailable.');
     });
@@ -381,9 +373,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('does not let an old retry action resolve its replacement', async () => {
-    const { interactions } = createInteractions({
-      session: createTestSession(),
-    });
+    const { interactions } = createInteractions();
     const first = interactions.requestRetry?.({
       requestId: 'retry:first',
       streamId: STREAM_A,
@@ -413,9 +403,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('prepares a progress-view retry before settling it', async () => {
-    const { interactions } = createInteractions({
-      session: createTestSession(),
-    });
+    const { interactions } = createInteractions();
     const prepareRetry = vi.fn(async () => undefined);
     const result = interactions.requestRetry?.(
       {
@@ -436,9 +424,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('prepares the personal route for the API-key retry switch', async () => {
-    const { interactions } = createInteractions({
-      session: createTestSession(),
-    });
+    const { interactions } = createInteractions();
     const prepareRetry = vi.fn(async () => undefined);
     const result = interactions.requestRetry?.(
       {
@@ -464,9 +450,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('denies a personal-credential retry when client preparation fails', async () => {
-    const { interactions } = createInteractions({
-      session: createTestSession(),
-    });
+    const { interactions } = createInteractions();
     const prepareRetry = vi.fn(async () => {
       throw new Error('replacement client failed');
     });
@@ -492,9 +476,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('does not let a stale preparation settle its replacement request', async () => {
-    const { interactions } = createInteractions({
-      session: createTestSession(),
-    });
+    const { interactions } = createInteractions();
     const first = createDeferredPreparation();
     const replacement = createDeferredPreparation();
 
@@ -539,9 +521,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('rejects a conflicting personal-credential selection while a plain retry prepares', async () => {
-    const { interactions } = createInteractions({
-      session: createTestSession(),
-    });
+    const { interactions } = createInteractions();
     const preparation = createDeferredPreparation();
 
     const result = interactions.requestRetry?.(
@@ -579,9 +559,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('aborts an in-flight personal preparation when the retry is dismissed', async () => {
-    const { interactions } = createInteractions({
-      session: createTestSession(),
-    });
+    const { interactions } = createInteractions();
     const preparation = createDeferredPreparation();
 
     const result = interactions.requestRetry?.(
@@ -664,9 +642,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('wraps cancel-path settlement when the dismiss transport throws', async () => {
-    const { handlers, interactions } = createInteractions({
-      session: createTestSession(),
-    });
+    const { handlers, interactions } = createInteractions();
     const result = interactions.requestRetry?.({
       requestId: 'retry:cancel-settlement',
       streamId: STREAM_A,
@@ -719,9 +695,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('forwards a bash cancellation cause without user provenance', async () => {
-    const { handlers, interactions } = createInteractions({
-      session: createTestSession(),
-    });
+    const { handlers, interactions } = createInteractions();
 
     const resultPromise = interactions.requestBashApproval?.({
       command: 'rm -rf build',
@@ -741,9 +715,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('rejects a resolution whose kind does not match the pending request', async () => {
-    const { handlers, interactions } = createInteractions({
-      session: createTestSession(),
-    });
+    const { handlers, interactions } = createInteractions();
 
     const resultPromise = interactions.requestBashApproval?.({
       command: 'echo hi',
@@ -766,9 +738,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('a retry-kind cancel clears only the retry, leaving the plan approval pending', async () => {
-    const { handlers, interactions } = createInteractions({
-      session: createTestSession(),
-    });
+    const { handlers, interactions } = createInteractions();
 
     const retryPromise = interactions.requestRetry?.({
       requestId: 'retry:scoped-cancel',
@@ -835,9 +805,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('cancels streamless user questions during unscoped cleanup', async () => {
-    const { handlers, interactions } = createInteractions({
-      session: createTestSession(),
-    });
+    const { handlers, interactions } = createInteractions();
 
     const resultPromise = interactions.askUserQuestion?.({
       requestId: 'question-a',
@@ -869,9 +837,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('settles submitted user questions with their answers', async () => {
-    const { handlers, interactions } = createInteractions({
-      session: createTestSession(),
-    });
+    const { handlers, interactions } = createInteractions();
 
     const resultPromise = interactions.askUserQuestion?.({
       requestId: 'question-submit',

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -950,12 +950,7 @@ describe('ProgressBackend', () => {
     backend.state.streamLogs.ensureStream(deleting);
     backend.presentation.select(deleting);
 
-    const deletion = backend.deleteStream(deleting);
-    await vi.waitFor(() =>
-      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting, {
-        expectedIncarnation: 0,
-      }),
-    );
+    const { deletion } = await beginGatedDeletion(backend, deleting);
     backend.presentation.select('');
     releaseClear();
     await deletion;
@@ -986,12 +981,7 @@ describe('ProgressBackend', () => {
     }
     backend.presentation.select(deleting);
 
-    const deletion = backend.deleteStream(deleting);
-    await vi.waitFor(() =>
-      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting, {
-        expectedIncarnation: 0,
-      }),
-    );
+    const { deletion } = await beginGatedDeletion(backend, deleting);
     const activation = backend.activateStream(requested, 'pending-request');
     await vi.waitFor(() =>
       expect(finishRequestedPreload).toBeTypeOf('function'),
@@ -1033,12 +1023,7 @@ describe('ProgressBackend', () => {
         }),
     );
 
-    const deletion = backend.deleteStream(deleting);
-    await vi.waitFor(() =>
-      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting, {
-        expectedIncarnation: 0,
-      }),
-    );
+    const { deletion } = await beginGatedDeletion(backend, deleting);
     const activation = backend.activateStream(requested, 'failed-request');
     await vi.waitFor(() =>
       expect(rejectRequestedPreload).toBeTypeOf('function'),
@@ -1078,12 +1063,7 @@ describe('ProgressBackend', () => {
     }
     backend.presentation.select(deleting);
 
-    const deletion = backend.deleteStream(deleting);
-    await vi.waitFor(() =>
-      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting, {
-        expectedIncarnation: 0,
-      }),
-    );
+    const { deletion } = await beginGatedDeletion(backend, deleting);
     await backend.activateStream(committed);
     vi.spyOn(backend.state.snapshots, 'preload').mockImplementationOnce(
       () =>

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -112,6 +112,28 @@ function gateClearStream(backend: RecordingTarget['backend']): () => void {
   return releaseClear;
 }
 
+/**
+ * Starts deleting `stream` (gated by `gateClearStream`) and waits until
+ * `clearStream` has been invoked for it, so the caller can interleave a
+ * second action while the deletion sits mid-flight. Returns the still-pending
+ * deletion wrapped in an object — an async function returning a bare promise
+ * would chain onto it and defeat the point of not awaiting it here.
+ */
+async function beginGatedDeletion(
+  backend: RecordingTarget['backend'],
+  stream: StreamTabId,
+): Promise<{
+  deletion: ReturnType<RecordingTarget['backend']['deleteStream']>;
+}> {
+  const deletion = backend.deleteStream(stream);
+  await vi.waitFor(() =>
+    expect(backend.state.clearStream).toHaveBeenCalledWith(stream, {
+      expectedIncarnation: 0,
+    }),
+  );
+  return { deletion };
+}
+
 describe('ProgressBackend', () => {
   it('projects every approval bypass kind through one backend port', () => {
     const { backend, messages } = createRecordingBackend();
@@ -907,12 +929,7 @@ describe('ProgressBackend', () => {
     backend.state.streamLogs.ensureStream(deleting);
     backend.presentation.select(fallback);
 
-    const deletion = backend.deleteStream(deleting);
-    await vi.waitFor(() =>
-      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting, {
-        expectedIncarnation: 0,
-      }),
-    );
+    const { deletion } = await beginGatedDeletion(backend, deleting);
     await backend.activateStream(deleting);
     releaseClear();
     await deletion;

--- a/src/test-kernel/progressView/RetryRequestPanel.vitest.ts
+++ b/src/test-kernel/progressView/RetryRequestPanel.vitest.ts
@@ -79,6 +79,16 @@ function tailLine(text: string): string {
   return text.split('\n').at(-1) ?? '';
 }
 
+/** Rendered action buttons' `data-action` ids, in DOM order. */
+function actionButtonIds(element: RetryRequestPanel): (string | null)[] {
+  const buttons = [
+    ...(element.shadowRoot?.querySelectorAll(
+      '.retry-request__actions wa-button',
+    ) ?? []),
+  ];
+  return buttons.map((button) => button.getAttribute('data-action'));
+}
+
 describe('retry-request-panel', () => {
   it('does not offer the API-key switch for a Kimi Code-exclusive model', async () => {
     const element = await mountPanel({
@@ -89,14 +99,7 @@ describe('retry-request-panel', () => {
       },
     });
 
-    const buttons = [
-      ...(element.shadowRoot?.querySelectorAll(
-        '.retry-request__actions wa-button',
-      ) ?? []),
-    ];
-    expect(buttons.map((button) => button.getAttribute('data-action'))).toEqual(
-      ['retry', 'cancel'],
-    );
+    expect(actionButtonIds(element)).toEqual(['retry', 'cancel']);
   });
 
   it('does not map the k shortcut to the API-key switch for exclusive models', async () => {
@@ -124,28 +127,21 @@ describe('retry-request-panel', () => {
       },
     });
 
-    const buttons = [
-      ...(element.shadowRoot?.querySelectorAll(
-        '.retry-request__actions wa-button',
-      ) ?? []),
-    ];
-    expect(buttons.map((button) => button.getAttribute('data-action'))).toEqual(
-      ['useOwnApiKey', 'retry', 'cancel'],
-    );
+    expect(actionButtonIds(element)).toEqual([
+      'useOwnApiKey',
+      'retry',
+      'cancel',
+    ]);
   });
 
   it('marks retry action buttons with action ids for shared sizing styles', async () => {
     const element = await mountPanel();
 
-    const buttons = [
-      ...(element.shadowRoot?.querySelectorAll(
-        '.retry-request__actions wa-button',
-      ) ?? []),
-    ];
-
-    expect(buttons.map((button) => button.getAttribute('data-action'))).toEqual(
-      ['useOwnApiKey', 'retry', 'cancel'],
-    );
+    expect(actionButtonIds(element)).toEqual([
+      'useOwnApiKey',
+      'retry',
+      'cancel',
+    ]);
   });
 
   it('distinguishes a fresh direct-model run from retrying Copilot', async () => {

--- a/src/test-kernel/progressView/StreamTabsStatus.vitest.ts
+++ b/src/test-kernel/progressView/StreamTabsStatus.vitest.ts
@@ -289,7 +289,7 @@ describe('stream-tab lifecycle distinction', () => {
       ]),
       compact: true,
     });
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await settleChildRender();
     const row = tabs.shadowRoot?.querySelector('stream-tab');
 
     expect(

--- a/src/test-kernel/replacement/ReplacementRules.vitest.ts
+++ b/src/test-kernel/replacement/ReplacementRules.vitest.ts
@@ -23,7 +23,6 @@ import {
   stripCriticizeAnnotations,
   wrapCritiqueInAlign,
 } from '@replacement/advanced';
-import type { ReplacementCategory } from '@replacement/types';
 import {
   NON_REGEX_REPLACEMENT_CATEGORIES,
   REGEX_REPLACEMENT_CATEGORIES,

--- a/src/test-kernel/scripts/FormatStaged.vitest.ts
+++ b/src/test-kernel/scripts/FormatStaged.vitest.ts
@@ -53,12 +53,11 @@ const MULTI_MERGED = MULTI_FORMATTED.replace(
 );
 
 let dir: string;
-let emptyGitConfig = '';
 let gitEnv = process.env;
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'format-staged-'));
-  emptyGitConfig = join(dir, 'empty-gitconfig');
+  const emptyGitConfig = join(dir, 'empty-gitconfig');
   writeFileSync(emptyGitConfig, '');
   // Isolate git from host global/system config so the fixture does not
   // inherit commit signing or a non-default core.hooksPath. This also keeps

--- a/src/test-kernel/shared/KatexMacroDrift.vitest.ts
+++ b/src/test-kernel/shared/KatexMacroDrift.vitest.ts
@@ -32,6 +32,24 @@ function runtimeMaxStyleShortcutTokens(): Set<string> {
 }
 
 /**
+ * Tokens in `tokens` not covered by `hasKey` or the allowlist ("unexplained"),
+ * and allowlist entries no longer present in `tokens` ("stale"). Both are
+ * empty when the two tables agree.
+ */
+function driftAgainst<T extends string>(
+  tokens: ReadonlySet<T>,
+  hasKey: (token: T) => boolean,
+  allowlist: readonly T[],
+): { unexplained: T[]; staleAllowlist: T[] } {
+  return {
+    unexplained: [...tokens]
+      .filter((token) => !hasKey(token) && !allowlist.includes(token))
+      .toSorted(),
+    staleAllowlist: allowlist.filter((token) => !tokens.has(token)),
+  };
+}
+
+/**
  * Shortcuts that KaTeX renders but max-style replacement does not emit.
  * Keep this list explicit: a new katex-only key must be added here or
  * given a max-style destination, so the two tables cannot drift silently.
@@ -112,38 +130,23 @@ describe('katexMacros vs maxRules shortcuts', () => {
 
   it('keeps KaTeX keys and max-style destinations from drifting', () => {
     const shortcuts = maxStyleShortcutTokens();
-    const katexKeys = Object.keys(katexMacros);
+    const katexKeys = new Set(Object.keys(katexMacros));
 
-    const unexplainedKatex = katexKeys
-      .filter(
-        (key) =>
-          !shortcuts.has(key) &&
-          !KATEX_ONLY_SHORTCUTS.includes(
-            key as (typeof KATEX_ONLY_SHORTCUTS)[number],
-          ),
-      )
-      .toSorted();
-    const staleKatexAllowlist = KATEX_ONLY_SHORTCUTS.filter(
-      (key) => !katexKeys.includes(key),
+    const katexDrift = driftAgainst(
+      katexKeys,
+      (key) => shortcuts.has(key),
+      KATEX_ONLY_SHORTCUTS,
+    );
+    const maxDrift = driftAgainst(
+      shortcuts,
+      (token) => Object.hasOwn(katexMacros, token),
+      MAX_ONLY_SHORTCUTS,
     );
 
-    const unexplainedMax = [...shortcuts]
-      .filter(
-        (token) =>
-          !Object.hasOwn(katexMacros, token) &&
-          !MAX_ONLY_SHORTCUTS.includes(
-            token as (typeof MAX_ONLY_SHORTCUTS)[number],
-          ),
-      )
-      .toSorted();
-    const staleMaxAllowlist = MAX_ONLY_SHORTCUTS.filter(
-      (token) => !shortcuts.has(token),
-    );
-
-    expect(unexplainedKatex).toEqual([]);
-    expect(staleKatexAllowlist).toEqual([]);
-    expect(unexplainedMax).toEqual([]);
-    expect(staleMaxAllowlist).toEqual([]);
+    expect(katexDrift.unexplained).toEqual([]);
+    expect(katexDrift.staleAllowlist).toEqual([]);
+    expect(maxDrift.unexplained).toEqual([]);
+    expect(maxDrift.staleAllowlist).toEqual([]);
   });
 
   it('maps bold Greek destinations to KaTeX short forms at runtime', () => {
@@ -246,20 +249,13 @@ describe('katexMacros vs maxRules shortcuts', () => {
 
   it('keeps runtime max-style output resolvable by the renderer macros', () => {
     const runtimeShortcuts = runtimeMaxStyleShortcutTokens();
-    const unexplainedRuntime = [...runtimeShortcuts]
-      .filter(
-        (token) =>
-          !Object.hasOwn(katexMacros, token) &&
-          !RUNTIME_ONLY_SHORTCUTS.includes(
-            token as (typeof RUNTIME_ONLY_SHORTCUTS)[number],
-          ),
-      )
-      .toSorted();
-    const staleRuntimeAllowlist = RUNTIME_ONLY_SHORTCUTS.filter(
-      (token) => !runtimeShortcuts.has(token),
+    const drift = driftAgainst(
+      runtimeShortcuts,
+      (token) => Object.hasOwn(katexMacros, token),
+      RUNTIME_ONLY_SHORTCUTS,
     );
 
-    expect(unexplainedRuntime).toEqual([]);
-    expect(staleRuntimeAllowlist).toEqual([]);
+    expect(drift.unexplained).toEqual([]);
+    expect(drift.staleAllowlist).toEqual([]);
   });
 });

--- a/src/test-kernel/support/prPollingSourceState.ts
+++ b/src/test-kernel/support/prPollingSourceState.ts
@@ -36,6 +36,13 @@ export function createPRCurrentShaState(
   };
 }
 
+function dedupedById<T extends { id: number }>(): DedupedResource<T> {
+  return new DedupedResource<T>({
+    getId: (item) => item.id,
+    maxSeenIds: MAX_SEEN_IDS,
+  });
+}
+
 export function createPRSubscriptionState(
   overrides: Partial<PRSubscriptionState> = {},
 ): PRSubscriptionState {
@@ -44,18 +51,9 @@ export function createPRSubscriptionState(
     slug: 'owner/repo',
     ...createBasePollState(),
     initialized: true,
-    issueComments: new DedupedResource<GhIssueComment>({
-      getId: (comment) => comment.id,
-      maxSeenIds: MAX_SEEN_IDS,
-    }),
-    reviewComments: new DedupedResource<GhReviewComment>({
-      getId: (comment) => comment.id,
-      maxSeenIds: MAX_SEEN_IDS,
-    }),
-    reviews: new DedupedResource<GhReview>({
-      getId: (review) => review.id,
-      maxSeenIds: MAX_SEEN_IDS,
-    }),
+    issueComments: dedupedById<GhIssueComment>(),
+    reviewComments: dedupedById<GhReviewComment>(),
+    reviews: dedupedById<GhReview>(),
     lastFailedCheckKeys: new Set(),
     lastAnnotationKeys: new Set(),
     annotationLevelByListener: new Map(),

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -259,6 +259,28 @@ function holdCommand(): (result: ExecResult) => void {
   return (result) => resolve?.(result);
 }
 
+/**
+ * Set up a run trace whose emitted events are captured for inspection, and
+ * return a `dispose` that undoes both the subscription and the trace itself.
+ */
+function traceWithEvents(streamId: StreamTabId): {
+  trace: ReturnType<typeof createRunTrace>['trace'];
+  events: AgentEvent[];
+  dispose: () => void;
+} {
+  const runTrace = createRunTrace(streamId, StreamLogStore.ephemeral('test'));
+  const events: AgentEvent[] = [];
+  const unsubscribe = runTrace.trace.subscribe((event) => events.push(event));
+  return {
+    trace: runTrace.trace,
+    events,
+    dispose: () => {
+      unsubscribe();
+      runTrace.dispose();
+    },
+  };
+}
+
 /** Shared teardown for background-launch cases. */
 function detachBackgroundRun(
   recorded: ReturnType<typeof recordSessionEvents>,
@@ -512,19 +534,14 @@ describe('BashTool', () => {
   });
 
   it('keeps result status out of visible tool log output', async () => {
-    const runTrace = createRunTrace(
+    const { trace, events, dispose } = traceWithEvents(
       'ToolStatusLogTest' as StreamTabId,
-      StreamLogStore.ephemeral('test'),
     );
-    const events: AgentEvent[] = [];
-    const unsubscribe = runTrace.trace.subscribe((event) => {
-      events.push(event);
-    });
 
     try {
       const options = roundServices({
         toolName: 'empty',
-        logger: runTrace.trace,
+        logger: trace,
         streamId: 'tool-status-log' as StreamTabId,
         toolRegistry: new MapToolRegistry({}),
       });
@@ -564,7 +581,7 @@ describe('BashTool', () => {
               editedFiles: [],
               logRef: {
                 logId: undefined,
-                groupId: runTrace.trace.activeStageId(),
+                groupId: trace.activeStageId(),
               },
             } as any,
           ],
@@ -586,8 +603,7 @@ describe('BashTool', () => {
       ) as any;
       assert.equal(toolOutputMessage?.output, 'OK');
     } finally {
-      unsubscribe();
-      runTrace.dispose();
+      dispose();
     }
   });
 
@@ -944,20 +960,15 @@ describe('BashTool', () => {
       },
     );
 
-    const runTrace = createRunTrace(
+    const { trace, events, dispose } = traceWithEvents(
       'BashToolAbortTest' as StreamTabId,
-      StreamLogStore.ephemeral('test'),
     );
-    const events: AgentEvent[] = [];
-    const unsubscribe = runTrace.trace.subscribe((event) => {
-      events.push(event);
-    });
 
     const node = new ToolUseDispatchNode<OpenAI>();
     const bashTool = new BashTool();
     const options = roundServices({
       toolName: 'bash',
-      logger: runTrace.trace,
+      logger: trace,
       streamId: 'bash-tool' as StreamTabId,
       toolRegistry: new MapToolRegistry({ bash: bashTool }),
       abortSignal: runController.signal,
@@ -1004,8 +1015,7 @@ describe('BashTool', () => {
         assert.equal(failedEvent.logId, startedLogId);
       }
     } finally {
-      unsubscribe();
-      runTrace.dispose();
+      dispose();
     }
   });
 });

--- a/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
+++ b/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
@@ -10,7 +10,7 @@ import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import { extractToolAttachments } from '@agent/core/tools/toolAttachmentExtraction';
 import type { OpenAIResponseToolCall } from '@agent/types/ModelHandlerContracts';
-import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas';
+import { BASH_APPROVAL_CONFIG_KEY, type ToolResult } from '@shared/schemas';
 import { BashTool } from '@tools/bash';
 import { requestBashApproval } from '@tools/approval/bashApproval';
 import * as execUtils from '@utils/system/execUtils';
@@ -65,6 +65,21 @@ function stubBashApprovalDisabled(): void {
   );
 }
 
+/** Round-trip a tool result through follow-up message construction and return
+ * the model-visible `function_call_output` text. */
+async function toolUseOutput(result: ToolResult) {
+  const { attachments, sanitizedResult } = extractToolAttachments(result);
+  const messages = await createHandler().createToolUseFollowUpMessages(
+    undefined,
+    createBashCall(),
+    sanitizedResult,
+    attachments,
+    AgentWorkspaceState.create(),
+  );
+  return messages.find((message) => message.type === 'function_call_output')
+    ?.output;
+}
+
 function createBashCall(): OpenAIResponseToolCall {
   return {
     provider: 'openai-response',
@@ -101,21 +116,11 @@ describe('BashTool error feedback', () => {
     expect(result.error).toContain('stderr failure details');
     expect(result.error).toContain('stdout failure guidance');
 
-    const { attachments, sanitizedResult } = extractToolAttachments(result);
-    const messages = await createHandler().createToolUseFollowUpMessages(
-      undefined,
-      createBashCall(),
-      sanitizedResult,
-      attachments,
-      AgentWorkspaceState.create(),
-    );
-    const toolResult = messages.find(
-      (message) => message.type === 'function_call_output',
-    );
+    const output = await toolUseOutput(result);
 
-    expect(toolResult?.output).toContain('Command failed');
-    expect(toolResult?.output).toContain('stderr failure details');
-    expect(toolResult?.output).toContain('stdout failure guidance');
+    expect(output).toContain('Command failed');
+    expect(output).toContain('stderr failure details');
+    expect(output).toContain('stdout failure guidance');
   });
 
   it.each([
@@ -199,20 +204,10 @@ describe('BashTool error feedback', () => {
     expect(rejected.error).toContain('Do not retry');
     expect(rejected.userInstruction).toBeUndefined();
 
-    const { attachments, sanitizedResult } = extractToolAttachments(rejected);
-    const messages = await createHandler().createToolUseFollowUpMessages(
-      undefined,
-      createBashCall(),
-      sanitizedResult,
-      attachments,
-      AgentWorkspaceState.create(),
-    );
-    const toolResult = messages.find(
-      (message) => message.type === 'function_call_output',
-    );
+    const output = await toolUseOutput(rejected);
 
-    expect(toolResult?.output).toContain('Do not retry');
-    expect(toolResult?.output).not.toContain('User feedback:');
+    expect(output).toContain('Do not retry');
+    expect(output).not.toContain('User feedback:');
   });
 
   it('does not present an approval-policy denial as user feedback', async () => {
@@ -228,20 +223,10 @@ describe('BashTool error feedback', () => {
     expect(rejected.error).not.toContain('User rejected command');
     expect(rejected.userInstruction).toBeUndefined();
 
-    const { attachments, sanitizedResult } = extractToolAttachments(rejected);
-    const messages = await createHandler().createToolUseFollowUpMessages(
-      undefined,
-      createBashCall(),
-      sanitizedResult,
-      attachments,
-      AgentWorkspaceState.create(),
-    );
-    const toolResult = messages.find(
-      (message) => message.type === 'function_call_output',
-    );
+    const output = await toolUseOutput(rejected);
 
-    expect(toolResult?.output).toContain('Denied by TeXRA approval policy.');
-    expect(toolResult?.output).not.toContain('User feedback:');
+    expect(output).toContain('Denied by TeXRA approval policy.');
+    expect(output).not.toContain('User feedback:');
   });
 
   it('preserves policy-denial provenance when its reason is blank', async () => {

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -135,6 +135,10 @@ function fakeToolContexts(extra: Record<string, unknown> = {}): unknown {
   };
 }
 
+function fakePorts(): ChildRunPorts {
+  return { notify: () => {}, recordCost: () => {} };
+}
+
 function captureStrategy(): { strategy?: ChildRunStrategy<unknown> } {
   const captured: { strategy?: ChildRunStrategy<unknown> } = {};
   mocks.startChildRunLoop.mockImplementation(
@@ -308,8 +312,7 @@ describe('claude_agent tool launch and resume fallback', () => {
     const [loopParams] = mocks.startChildRunLoop.mock.calls[0] as [
       { strategy: ChildRunStrategy<unknown> },
     ];
-    const ports: ChildRunPorts = { notify: () => {}, recordCost: () => {} };
-    await loopParams.strategy.launch(ports, new AbortController());
+    await loopParams.strategy.launch(fakePorts(), new AbortController());
 
     expect(mocks.query).toHaveBeenCalledTimes(1);
     const [callArgs] = mocks.query.mock.calls[0] as [
@@ -337,7 +340,7 @@ describe('claude_agent tool launch and resume fallback', () => {
 
     await new ClaudeAgentTool().call({ prompt: 'start Claude' });
     const turn = await captured.strategy?.launch?.(
-      { notify: () => {}, recordCost: () => {} },
+      fakePorts(),
       new AbortController(),
     );
     if (!turn) throw new Error('Expected a Claude turn result');
@@ -501,7 +504,7 @@ describe('claude_agent tool launch and resume fallback', () => {
     expect(result.status).toBe('executed');
     expect(mocks.submitFollowUp).not.toHaveBeenCalled();
     expect(mocks.startChildRunLoop).toHaveBeenCalledOnce();
-    const ports: ChildRunPorts = { notify: () => {}, recordCost: () => {} };
+    const ports = fakePorts();
     const firstTurn = await captured.strategy?.launch?.(
       ports,
       new AbortController(),
@@ -574,7 +577,7 @@ describe('claude_agent tool launch and resume fallback', () => {
     });
 
     expect(result.status).toBe('executed');
-    const ports: ChildRunPorts = { notify: () => {}, recordCost: () => {} };
+    const ports = fakePorts();
     const firstTurn = await captured.strategy?.launch?.(
       ports,
       new AbortController(),

--- a/src/test-kernel/tools/latex/ExtractBibliographyTool.vitest.ts
+++ b/src/test-kernel/tools/latex/ExtractBibliographyTool.vitest.ts
@@ -109,8 +109,6 @@ describe('ExtractBibliographyTool', () => {
   });
 
   it('includes explicit bibliography path when provided', async () => {
-    const calls: { paths: string[]; keys: string[] }[] = [];
-
     await installPlatform({
       '/workspace/thesis.tex': '\\documentclass{article}',
       '/workspace/extra.bib': '@article{alpha,...}',
@@ -119,53 +117,40 @@ describe('ExtractBibliographyTool', () => {
       context: { citationKeys: ['alpha'] },
       summary: ['@article{alpha,...}'],
     });
-    vi.mocked(bibliographyModule.loadBibliographyEntries).mockImplementation(
-      async (paths, keys) => {
-        calls.push({ paths, keys });
-        return {
-          entries: new Map([['alpha', '@article{alpha,...}']]),
-          missingKeys: [],
-        };
-      },
-    );
+    const loadEntries = vi
+      .mocked(bibliographyModule.loadBibliographyEntries)
+      .mockResolvedValue({
+        entries: new Map([['alpha', '@article{alpha,...}']]),
+        missingKeys: [],
+      });
 
     const result = await new ExtractBibliographyTool().call({
       texPath: 'thesis.tex',
       bibPath: 'extra.bib',
     });
 
-    expect(calls).toHaveLength(1);
-    expect(calls[0].paths).toEqual(['extra.bib']);
-    expect(calls[0].keys).toEqual(['alpha']);
+    expect(loadEntries).toHaveBeenCalledOnce();
+    expect(loadEntries.mock.calls[0]).toEqual([['extra.bib'], ['alpha']]);
     expect(result.summary).toContain('Resolved 1 bibliography entry');
   });
 
   it('falls back to wildcard when only a bibliography path is supplied', async () => {
-    const calls: { paths: string[]; keys: string[] }[] = [];
-
     await installPlatform({
       '/workspace/standalone.tex': '\\documentclass{article}',
       '/workspace/refs.bib': '@article{alpha,...}',
     });
     mockBibliography({});
-    vi.mocked(bibliographyModule.loadBibliographyEntries).mockImplementation(
-      async (paths, keys) => {
-        calls.push({ paths, keys });
-        return {
-          entries: new Map(),
-          missingKeys: [],
-        };
-      },
-    );
+    const loadEntries = vi
+      .mocked(bibliographyModule.loadBibliographyEntries)
+      .mockResolvedValue({ entries: new Map(), missingKeys: [] });
 
     const result = await new ExtractBibliographyTool().call({
       texPath: 'standalone.tex',
       bibPath: 'refs.bib',
     });
 
-    expect(calls).toHaveLength(1);
-    expect(calls[0].paths).toEqual(['refs.bib']);
-    expect(calls[0].keys).toEqual(['*']);
+    expect(loadEntries).toHaveBeenCalledOnce();
+    expect(loadEntries.mock.calls[0]).toEqual([['refs.bib'], ['*']]);
     expect(result.summary).toContain(
       'No matching bibliography entries found for 1 citation key in standalone.tex.',
     );

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -26,6 +26,7 @@ import type {
   StreamTabId,
   TodoItem,
   TokenUsageStats,
+  WorkPlanSnapshot,
 } from '@shared/schemas';
 import {
   cleanupTempDirs,
@@ -34,6 +35,7 @@ import {
 import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 import { snapshotFacts } from '@test/support/storeTestDrivers';
 import { StreamSnapshotStore, streamDataDir } from '@transcript';
+import type { StagedStreamSnapshotDeletion } from '@transcript/StagedDeletionCoordinator';
 import {
   stagedStreamDataDir,
   STREAM_DATA_DIR,
@@ -107,10 +109,8 @@ function toolUseConfig(agent = 'search', model = 'deepseekproT'): AgentConfig {
   });
 }
 
-type StagedDeletion = Awaited<
-  ReturnType<StreamSnapshotStore['stageDeleteStream']>
->;
-type WorkPlan = ReturnType<StreamSnapshotStore['getWorkPlan']>;
+type StagedDeletion = StagedStreamSnapshotDeletion;
+type WorkPlan = WorkPlanSnapshot;
 
 async function writeStreamFile(
   stream: StreamTabId,

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -652,6 +652,7 @@ describe('attachTranscriptRecorder spill artifacts', () => {
     const streamId = 'stream:spill' as StreamTabId;
     const store = StreamLogStore.ephemeral('test');
     store.ensureStream(streamId);
+    const rows = (): StreamLogEntry[] => store.get(streamId)?.getRange(0) ?? [];
     const writes: Array<{ path: string; content: string }> = [];
     const firstToolOutput = 'first tool snapshot'.repeat(4_000);
     const recorder = attachTranscriptRecorder(
@@ -682,12 +683,7 @@ describe('attachTranscriptRecorder spill artifacts', () => {
       result: { toolName: 'read', output: firstToolOutput },
     });
     const liveToolData = ToolUseLogSchema.parse(
-      dataOf(
-        store
-          .get(streamId)
-          ?.getRange(0)
-          .find((candidate) => candidate.id === 'tool:spill'),
-      ),
+      dataOf(rows().find((candidate) => candidate.id === 'tool:spill')),
     );
     expect(liveToolData.output).toContain(
       'truncated while the tool is running',
@@ -707,11 +703,8 @@ describe('attachTranscriptRecorder spill artifacts', () => {
     recorder.flushPending();
     await recorder.flushSpills();
 
-    const entry = store.get(streamId)?.getRange(0).at(-1);
-    const modelEntry = store
-      .get(streamId)
-      ?.getRange(0)
-      .find((candidate) => candidate.id === output.id);
+    const entry = rows().at(-1);
+    const modelEntry = rows().find((candidate) => candidate.id === output.id);
     expect(modelEntry?.text?.length).toBeLessThan(50 * 1024);
     expect(modelEntry?.text).toContain('retained in run artifacts');
     expect(dataOf(modelEntry).spillPath).toBe(


### PR DESCRIPTION
## Summary

Ultracode simplifier sweep over the entire test codebase: all 915 test files (~250k LoC) mechanically partitioned into 104 disjoint ~2.5k LoC batches, each reviewed by a Sonnet simplifier agent (52 by `our-code-simplifier`, 52 by the code-simplifier plugin persona). Behavior-preserving only: agents were barred from deleting/merging test cases, weakening assertions, or changing expected values. Net result: 44 files, **-299 lines** (+794/-1093).

Typical edits: dead/unused helpers and fixtures removed, duplicated in-file setup folded into small helpers (e.g. `RunExecution.vitest.ts` mock plumbing, `BashToolErrorFeedback.vitest.ts` follow-up round-trip), copy-paste blocks collapsed, stale comments dropped.

Flagged for human review (not changed): agents reported 7 candidate-redundant tests they were barred from touching, including a duplicated `AnsiMarkdown` assertion already covered by an `it.each` row, two near-identical `XmlOutputManager` LABELED_RECOVERY_CASES entries, unit-vs-integration overlaps in `DelegationAgentAvailability.vitest.ts`, and consolidatable `ChatDefaults` cases. Happy to file or fold these on request.

## Issue acceptance gates

No linked issue; test-only sweep PR.

## Single source of truth

Each extracted helper (`stopAfterToolObservationHandler`, `abortOnFirstFlowStepWrite`, `collectActivities`, `createTestRegistry`, `stubOkResponse`, `seedResumableExecution`, `runOperationSync`, `mockCancelledOutcome`, `newStatePorts`, `instantiateBridge`, `createGate`/`gateReadFile`, `beginGatedDeletion`, `actionButtonIds`, `dedupedById`, `traceWithEvents`, `toolUseOutput`, `fakePorts`, `driftAgainst`, `rows`, …) is file-local and owns one piece of repeated test plumbing inside its own suite file. No shared test module was created; no fact or decision changed hands.

## Duplication and abstraction budget

Removed duplication only: duplicated in-file setup/fixture blocks folded into per-file helpers, each with 2+ real call sites in the same file (verified caller counts per helper). No new cross-file abstractions; no pass-through layers; zero production code touched.

## Net elements (R6)

- Files: 44 changed (+794/-1093), net **-299 LoC**
- Exported symbols (`^[+-]export`): **+0/-0** (test-kernel-only sweep)
- Classes/interfaces/enums: 0; test-local type aliases +3/-3 (e.g. `StagedDeletion`/`WorkPlan` aliases now reuse shared snapshot types instead of re-deriving them)

## Consumer counts (R8)

n/a — zero exports added, deleted, or re-routed (`^[+-]export` over the diff is empty) and no emit path is touched; the diff is confined to `src/test-kernel/**`.

## Host impact

Extension: none (test-only).
Desktop: none (test-only).
CLI: none (test-only).

## Scheduled refactoring

Optional follow-up: the 7 agent-flagged candidate-redundant tests listed in the summary (barred from touching in this pass). None filed yet.

## Validation

- `npm run typecheck` passes (one agent-introduced return-annotation mismatch found and fixed in `BashToolErrorFeedback.vitest.ts`)
- `npm run lint` passes
- prettier clean
- All 46 edited/affected suites run isolated: **1267/1268 pass** (1 pre-existing skip)
- Agents' risky-flag list (shared-helper identity semantics in `RunExecution.vitest.ts`, generic inference in `RunScopedToolOverlay.vitest.ts`) verified by the typecheck + suite runs above
