### PR TITLE
refactor: dedup LaTeX field-key map and Lean toolchain help string

### DIFF
--- a/packages/extension/src/settingsView/frontend/slices/latexSlice.ts
+++ b/packages/extension/src/settingsView/frontend/slices/latexSlice.ts
@@ -11,10 +11,7 @@ import type {
   LatexConfigValues,
   SettingsViewOutboundHandlerRegistry,
 } from '@shared/schemas';
-import {
-  LATEX_FIELD_TO_KEY,
-  LATEX_REPLACEMENT_FIELD_TO_CONFIG_KEY,
-} from '@shared/constants/latexConfig';
+import { LATEX_CONFIG_FIELD_TO_KEY } from '@shared/constants/latexConfig';
 
 import {
   inlineCriticismEnabled,
@@ -23,11 +20,6 @@ import {
   latexSettingsLoaded,
   latexSettingsStatus,
 } from '../settingsState';
-
-const LATEX_CONFIG_FIELD_TO_KEY = {
-  ...LATEX_FIELD_TO_KEY,
-  ...LATEX_REPLACEMENT_FIELD_TO_CONFIG_KEY,
-} as const satisfies Record<keyof LatexConfigValues, string>;
 
 export const latexHandlers = {
   [SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_SETTINGS_STATUS]: (data) => {

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -54,8 +54,7 @@ import {
 } from '@shared/constants/replacementCategories';
 import {
   LATEX_CONFIG_DEFAULTS,
-  LATEX_FIELD_TO_KEY,
-  LATEX_REPLACEMENT_FIELD_TO_CONFIG_KEY,
+  LATEX_CONFIG_FIELD_TO_KEY,
   LATEX_CONFIG_RANGES,
 } from '@shared/constants/latexConfig';
 
@@ -87,11 +86,6 @@ import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.
 import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 import type WaTextarea from '@awesome.me/webawesome/dist/components/textarea/textarea.js';
-
-const LATEX_CONFIG_FIELD_TO_KEY = {
-  ...LATEX_FIELD_TO_KEY,
-  ...LATEX_REPLACEMENT_FIELD_TO_CONFIG_KEY,
-} as const satisfies Record<keyof LatexConfigValues, string>;
 
 /** Path keys in LatexSettingsStatus for tool paths. */
 type ToolPathKey =

--- a/src/shared/constants/latexConfig.ts
+++ b/src/shared/constants/latexConfig.ts
@@ -1,3 +1,4 @@
+import type { LatexConfigValues } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 
 /**
@@ -86,3 +87,16 @@ export const LATEX_REPLACEMENT_FIELD_TO_CONFIG_KEY = {
   customReplacementsRegex: 'texra.latex.customReplacementsRegex',
   customReplacements: 'texra.latex.customReplacements',
 } as const;
+
+/**
+ * Every webview-facing LaTeX config field → its storage key, merging the
+ * WorkspaceState-backed {@link LATEX_FIELD_TO_KEY} and the core-config-backed
+ * {@link LATEX_REPLACEMENT_FIELD_TO_CONFIG_KEY}. The `satisfies` clause asserts
+ * the two maps together cover every `LatexConfigValues` field. Shared by the
+ * settings-view frontend (LaTeXTab, latexSlice) so the merged map is defined
+ * once rather than reassembled per consumer.
+ */
+export const LATEX_CONFIG_FIELD_TO_KEY = {
+  ...LATEX_FIELD_TO_KEY,
+  ...LATEX_REPLACEMENT_FIELD_TO_CONFIG_KEY,
+} as const satisfies Record<keyof LatexConfigValues, string>;

--- a/src/tools/lean/LspTools.ts
+++ b/src/tools/lean/LspTools.ts
@@ -116,6 +116,14 @@ const LeanInspectInputSchema = z.strictObject({
 
 type LeanInspectInput = z.infer<typeof LeanInspectInputSchema>;
 
+/**
+ * Setup guidance appended when Lean diagnostics fail for a reason that is
+ * plausibly a missing/misconfigured toolchain rather than a bad file. Shared by
+ * the `toolchain_unavailable` branch and the catch-all below so the two stay in
+ * sync.
+ */
+const LEAN_TOOLCHAIN_HELP = `In VS Code: install the Lean 4 extension (leanprover.lean4). In CLI/desktop: install elan so that \`lake\` is on PATH, and make sure the file is inside a Lake project (lakefile.lean / lakefile.toml).`;
+
 const NO_DIAGNOSTICS_HELP = `No errors, warnings, or hints for this file.
 
 If you expected errors:
@@ -155,7 +163,7 @@ Tips:
         // tool failure.
         if (result.kind === 'toolchain_unavailable') {
           return errorResult(
-            `Failed to get diagnostics for ${file}: ${result.message}\n\nIn VS Code: install the Lean 4 extension (leanprover.lean4). In CLI/desktop: install elan so that \`lake\` is on PATH, and make sure the file is inside a Lake project (lakefile.lean / lakefile.toml).`,
+            `Failed to get diagnostics for ${file}: ${result.message}\n\n${LEAN_TOOLCHAIN_HELP}`,
             { summary: 'Failed to get diagnostics' },
           );
         }
@@ -197,7 +205,7 @@ Tips:
       };
     } catch (error) {
       throw new ToolError(
-        `Error: ${toErrorMessage(error)}\n\nIn VS Code: install the Lean 4 extension (leanprover.lean4). In CLI/desktop: install elan so that \`lake\` is on PATH, and make sure the file is inside a Lake project (lakefile.lean / lakefile.toml).`,
+        `Error: ${toErrorMessage(error)}\n\n${LEAN_TOOLCHAIN_HELP}`,
         { cause: error, summary: 'Failed to get diagnostics' },
       );
     }


### PR DESCRIPTION
## Summary

Two small, behavior-preserving consolidations surfaced by a tech-debt scan of the codebase:

1. **LaTeX field → storage-key map.** The merged map `{...LATEX_FIELD_TO_KEY, ...LATEX_REPLACEMENT_FIELD_TO_CONFIG_KEY} satisfies Record<keyof LatexConfigValues, string>` was defined byte-for-byte identically in both `settingsView/frontend/slices/latexSlice.ts` and `settingsView/frontend/tabs/LaTeXTab.ts`. It is now defined once as `LATEX_CONFIG_FIELD_TO_KEY` in `@shared/constants/latexConfig`, which already owns the two source maps.
2. **Lean toolchain guidance string.** The setup-guidance string ("In VS Code: install the Lean 4 extension… In CLI/desktop: install elan…") was duplicated verbatim across the `toolchain_unavailable` branch and the catch-all in `LspTools.ts`. It is now a single `LEAN_TOOLCHAIN_HELP` module const so the two copies can't drift.

No runtime behavior changes.

### Scope note

This is the graceful, low-risk subset of a broader tech-debt scan. Most other flagged items were **deliberately not** taken here, because on close inspection they fought the repo's own guardrails rather than paying off:

- The 3-site cycle-failure converter, `addMediaToUserMessage` template method, and twin persisted-hydration gate each turned out to have genuinely divergent call sites (different log messages/options, different capability guards across 7 providers, different resume-vs-throw intent), so a shared helper would be a leaky/thin abstraction for ~0 net LOC.
- The larger LaTeX-settings SSOT consolidation touches the settings-catalog machinery that "fails silently if you forget them"; its numeric ranges/enums already come from `@shared/constants/latex`, so only the field list was duplicated — deferred as its own scoped change.
- The compaction-decision unification is behavior-changing (different denominators), and the god-file decompositions (`modelHandlerOpenAIResponse` 2957 LoC, `StreamSnapshotStore` 2200, `SessionHandle` 1352, `runToolUseFlow` 666-line fn) are ~0 net LoC and touch crash/resume-safety-critical paths — both warrant a design proposal first, not a drive-by.
- `ResponseCycleFlow` was already relocated out of the kernel `core/flows/` (the scan finding was stale).

## Issue acceptance gates

n/a — no tracking issue; opportunistic cleanup from a tech-debt scan.

## Single source of truth

- `LATEX_CONFIG_FIELD_TO_KEY` in `@shared/constants/latexConfig` now owns the merged webview-field → storage-key mapping (and the `satisfies Record<keyof LatexConfigValues, string>` completeness assertion).
- `LEAN_TOOLCHAIN_HELP` in `src/tools/lean/LspTools.ts` now owns the Lean toolchain setup-guidance prose.

## Duplication and abstraction budget

Removed two verbatim duplications (a map definition defined twice, a guidance string written twice). No new abstraction layer or indirection — both are plain module constants moved to the location that already owned the neighbouring data. No pass-through wrappers.

## Net elements (R6)

- Files: 4 modified (0 added, 0 deleted).
- Exported symbols: +1 (`LATEX_CONFIG_FIELD_TO_KEY`); the two frontend copies it replaces were non-exported locals. No exports removed.
- Classes/interfaces/enums: 0 net.
- Net LoC: +8 (26 insertions / 18 deletions) — slightly positive only because the two shared constants carry doc comments the inline copies lacked; the number of duplicated *definitions* drops 2→1 for each.

## Consumer counts (R8)

- New export `LATEX_CONFIG_FIELD_TO_KEY`: 2 consumers (`latexSlice.ts`, `LaTeXTab.ts`).
- No emit path or existing export was deleted or re-routed. `LATEX_FIELD_TO_KEY` and `LATEX_REPLACEMENT_FIELD_TO_CONFIG_KEY` remain exported and are still consumed by `controllers/settingsView/LatexConfigPersistenceController.ts` (backend read/write path); only their two frontend consumers now go through the merged const. Dead-code ratchet confirms no new findings.

## Host impact

Extension: LaTeX settings-view frontend now imports the shared merged map instead of rebuilding it locally (no behavior change). Lean tool change applies here too.

Desktop: Lean tool change applies (shared `src/tools`). No LaTeX-frontend code involved.

CLI: Lean tool change applies (shared `src/tools`). No LaTeX-frontend code involved.

## Scheduled refactoring

None required for this PR. The deferred scan items above (LaTeX-settings-catalog SSOT, compaction-decision unification, god-file decompositions) are candidates for separate, proposal-backed changes.

## Validation

- `npm run typecheck:workspace` — pass
- `npm run typecheck:agent` (agent build) — pass
- `npm run typecheck:cli` — pass
- `npx eslint` on all 4 changed files — pass (fixed one import/order)
- `npm run check:dead-code-ratchet` — pass (no new findings)
- `npx prettier --check` on changed files — pass
- `npx vitest run` on `LeanInspectTool.vitest.ts` + `AgentsCommand.vitest.ts` (the suites referencing the touched symbols) — 15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PL4r1PpZHosAHXgdMjLHq

---
_Generated by [Claude Code](https://claude.ai/code/session_019PL4r1PpZHosAHXgdMjLHq)_