### PR TITLE
refactor: delete orphaned deriveExtensionPaths machinery (#11252)

### DIFF
--- a/scripts/aliasUtils.mjs
+++ b/scripts/aliasUtils.mjs
@@ -44,46 +44,6 @@ export function loadRootPaths(rootDir) {
   return tsconfig.compilerOptions.paths;
 }
 
-// Aliases the root tsconfig defines that `packages/extension/tsconfig.json`
-// deliberately omits: each is only ever imported from repo-root `src/`
-// locations the extension's own tsconfig doesn't include (its `include` is
-// scoped to `packages/extension/src`), so adding them would widen what the
-// extension can *type-check* against without widening what it can actually
-// import at runtime. Verified by grepping for each alias's usage (2026-07):
-// `vscode-jsonrpc/node` and the rest below resolve only inside
-// `src/tools/lean/direct/jsonRpc.ts` and `src/test-kernel/**`.
-export const EXTENSION_EXCLUDED_ALIASES = [
-  'vscode-jsonrpc/node',
-  '@test/*',
-  '@cli/*',
-  '@desktop/*',
-];
-
-const EXTENSION_PREFIX = 'packages/extension/';
-
-/**
- * Derives `packages/extension/tsconfig.json`'s `paths` block from the root
- * map. Neither tsconfig sets `baseUrl`, so values resolve relative to the
- * file that declares them: root values under `packages/extension/` become
- * `./`-prefixed extension-relative values, and every other
- * (repo-root-relative) value gets a `./../../` prefix.
- */
-export function deriveExtensionPaths(rootPaths) {
-  return Object.fromEntries(
-    Object.entries(rootPaths)
-      .filter(([key]) => !EXTENSION_EXCLUDED_ALIASES.includes(key))
-      .map(([key, values]) => [
-        key,
-        values.map((value) => {
-          const repoRelative = value.replace(/^\.\//u, '');
-          return repoRelative.startsWith(EXTENSION_PREFIX)
-            ? `./${repoRelative.slice(EXTENSION_PREFIX.length)}`
-            : `./../../${repoRelative}`;
-        }),
-      ]),
-  );
-}
-
 /**
  * Derives `packages/desktop/tsconfig.paths.json`'s `paths` block from the
  * root map. With no `baseUrl`, desktop's values resolve relative to

--- a/src/test-kernel/scripts/AliasMapGeneration.vitest.ts
+++ b/src/test-kernel/scripts/AliasMapGeneration.vitest.ts
@@ -9,8 +9,6 @@ type TsconfigPaths = Record<string, string[]>;
 interface AliasUtilsModule {
   deriveBuildPaths(rootPaths: TsconfigPaths): TsconfigPaths;
   deriveDesktopPaths(rootPaths: TsconfigPaths): TsconfigPaths;
-  deriveExtensionPaths(rootPaths: TsconfigPaths): TsconfigPaths;
-  EXTENSION_EXCLUDED_ALIASES: readonly string[];
   loadRootPaths(rootDir: string): TsconfigPaths;
   parseJsonc(text: string): unknown;
   pathTargetExists(rootDir: string, target: string): boolean;
@@ -20,8 +18,6 @@ const rootDir = fileURLToPath(new URL('../../../', import.meta.url));
 const {
   deriveBuildPaths,
   deriveDesktopPaths,
-  deriveExtensionPaths,
-  EXTENSION_EXCLUDED_ALIASES,
   loadRootPaths,
   parseJsonc,
   pathTargetExists,
@@ -39,29 +35,6 @@ const SAMPLE_ROOT_PATHS = {
   '@desktop/*': ['./packages/desktop/src/*'],
 };
 
-describe('aliasUtils deriveExtensionPaths', () => {
-  const result = deriveExtensionPaths(SAMPLE_ROOT_PATHS);
-
-  it('rewrites packages/extension/-prefixed values as extension-relative', () => {
-    expect(result['@commands/*']).toEqual(['./src/commands/*']);
-  });
-
-  it('prepends ./../../ to repo-root-relative values', () => {
-    expect(result['@shared/*']).toEqual(['./../../src/shared/*']);
-  });
-
-  it('rewrites each entry of a multi-value alias independently', () => {
-    expect(result['@/*']).toEqual(['./src/*', './../../src/*']);
-  });
-
-  it('drops every deliberately excluded alias and keeps everything else', () => {
-    for (const excluded of EXTENSION_EXCLUDED_ALIASES) {
-      expect(result).not.toHaveProperty(excluded);
-    }
-    expect(Object.keys(result)).toEqual(['@/*', '@shared/*', '@commands/*']);
-  });
-});
-
 describe('aliasUtils deriveDesktopPaths', () => {
   const result = deriveDesktopPaths(SAMPLE_ROOT_PATHS);
 
@@ -73,10 +46,8 @@ describe('aliasUtils deriveDesktopPaths', () => {
     ]);
   });
 
-  it('excludes nothing, unlike deriveExtensionPaths', () => {
-    for (const excluded of EXTENSION_EXCLUDED_ALIASES) {
-      expect(result).toHaveProperty(excluded);
-    }
+  it('excludes nothing', () => {
+    expect(Object.keys(result)).toEqual(Object.keys(SAMPLE_ROOT_PATHS));
   });
 });
 


### PR DESCRIPTION
Closes #11252.

## Summary

Deletes `deriveExtensionPaths`, `EXTENSION_EXCLUDED_ALIASES`, and their private `EXTENSION_PREFIX` from `scripts/aliasUtils.mjs`, plus the `describe('aliasUtils deriveExtensionPaths')` block that pinned them. The TS7 extends-root migration (#9708) removed the only production caller: `packages/extension/tsconfig.json` now extends the root directly and inherits its paths (asserted by the retained case at `AliasMapGeneration.vitest.ts`). The desktop `excludes nothing` case now asserts key-set equality against the sample map instead of iterating the deleted constant.

## Issue acceptance gates

- [x] `deriveExtensionPaths` / `EXTENSION_EXCLUDED_ALIASES` / `EXTENSION_PREFIX` deleted with their comment blocks — full-repo grep now hits only the two historical doc mentions.
- [x] Test block pinning the retired derivation deleted with it (per "Testing discipline").
- [x] `npm run check:tsconfig-paths` (CI gate) unaffected and passing.

## Single source of truth

The root `tsconfig.json` `paths` map remains the single source; `packages/extension/tsconfig.json` inherits it via `"extends": "../../tsconfig.json"` with no override. No owner changed.

## Duplication and abstraction budget

Pure deletion; no abstraction added. Removes a derivation whose inputs and outputs no longer have any reader.

## Net elements (R6)

- Files: 2 changed (+2/-71), net **-69 LoC** (issue estimated -74; the desktop test keeps an equivalent assertion instead of dropping outright)
- Exported symbols: **-2** (`deriveExtensionPaths`, `EXTENSION_EXCLUDED_ALIASES`); +0
- Classes/interfaces/enums: 0; the test-local `AliasUtilsModule` interface loses the 2 corresponding member lines

## Consumer counts (R8)

- `deriveExtensionPaths`: production consumers **0** (only caller removed by #9708); non-production consumers were the 2 deleted test blocks.
- `EXTENSION_EXCLUDED_ALIASES`: production consumers **0**; non-production consumers were the same test file.
- Neither appears in `config/ratchets/knip-baseline.json` (0 `scripts/` entries), so no baseline change.

## Host impact

Extension: none (its tsconfig already inherits root).
Desktop: none.
CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run check:tsconfig-paths` passes
- `npx vitest run src/test-kernel/scripts/AliasMapGeneration.vitest.ts`: 7/7 pass
- `npm run check:dead-code-ratchet`: OK, no new findings
- eslint + prettier clean on both touched files
