### PR TITLE
refactor: dedupe terminal-title timer and chart-orange fallback

### DIFF
--- a/packages/cli/src/chat/tui/terminalTitle.ts
+++ b/packages/cli/src/chat/tui/terminalTitle.ts
@@ -1,6 +1,8 @@
 import { writeSync } from 'node:fs';
 import { basename } from 'node:path';
 
+import { loadingFrameAt } from '@cli/tui/ui/LoadingIndicator';
+import { subscribeToSharedTick } from '@cli/tui/useLiveNowMs';
 import {
   formatSessionTitle,
   type SessionTitleState,
@@ -21,8 +23,6 @@ import { terminalCapabilities } from './state/terminalCapabilities';
 // can't inject terminal escape sequences into the title.
 // eslint-disable-next-line no-control-regex -- stripping C0/C1 controls
 const TITLE_INVALID_CHARS = /[\x00-\x1f\x7f-\x9f]/g;
-const RUNNING_TITLE_FRAMES = ['-', '/', '\\'] as const;
-const RUNNING_TITLE_INTERVAL_MS = 500;
 
 /** Project-aware terminal title, optionally annotated with live TUI state. */
 export function terminalTitleText(
@@ -77,34 +77,32 @@ export function installTerminalTitleUpdates(
   let disposed = false;
   let suspended = false;
   let lastTitle: string | undefined;
-  let runningFrame = 0;
-  let runningTimer: ReturnType<typeof setInterval> | undefined;
+  let stopSharedTick: (() => void) | undefined;
   const stopRunningAnimation = (): void => {
-    if (runningTimer === undefined) return;
-    clearInterval(runningTimer);
-    runningTimer = undefined;
+    stopSharedTick?.();
+    stopSharedTick = undefined;
   };
   const updateTitle = (title: string): void => {
     if (title === lastTitle) return;
     lastTitle = title;
     writeTerminalTitle(title);
   };
+  // Frame is derived from wall time via `loadingFrameAt`, the same 1 Hz
+  // rotation `LoadingIndicator` and the status bar use, so the tab title
+  // joins the shared clock instead of running its own interval.
   const runningTitle = (): string =>
-    terminalTitleText(cwd, 'running', RUNNING_TITLE_FRAMES[runningFrame]);
+    terminalTitleText(cwd, 'running', loadingFrameAt(Date.now()));
   const startRunningAnimation = (): void => {
-    if (runningTimer !== undefined) return;
+    if (stopSharedTick !== undefined) return;
     if (!terminalCapabilities.get().oscColorReports) return;
-    runningFrame = 0;
     updateTitle(runningTitle());
-    runningTimer = setInterval(() => {
+    stopSharedTick = subscribeToSharedTick(() => {
       if (!terminalCapabilities.get().oscColorReports) {
         stopRunningAnimation();
         return;
       }
-      runningFrame = (runningFrame + 1) % RUNNING_TITLE_FRAMES.length;
       updateTitle(runningTitle());
-    }, RUNNING_TITLE_INTERVAL_MS);
-    runningTimer.unref?.();
+    });
   };
   const synchronize = (): void => {
     if (suspended) return;

--- a/packages/cli/src/tui/useLiveNowMs.ts
+++ b/packages/cli/src/tui/useLiveNowMs.ts
@@ -9,7 +9,11 @@ type SharedTickSubscriber = () => void;
 const tickSubscribers = new Set<SharedTickSubscriber>();
 let tickTimer: ReturnType<typeof setInterval> | undefined;
 
-function subscribeToSharedTick(subscriber: SharedTickSubscriber): () => void {
+// Exported so non-React callers (e.g. the terminal-title updater) can join
+// the same 1 Hz registry instead of running a private setInterval.
+export function subscribeToSharedTick(
+  subscriber: SharedTickSubscriber,
+): () => void {
   tickSubscribers.add(subscriber);
   tickTimer ??= setInterval(() => {
     for (const tick of tickSubscribers) tick();

--- a/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
@@ -52,7 +52,7 @@ export const streamTabStyles = css`
   /* Pending approval — solid orange start rail. */
   .tab-container.has-pending-approval {
     --stream-status-color: var(--color-warning);
-    --stream-status-rail-color: var(--wa-color-chart-orange, #d18616);
+    --stream-status-rail-color: var(--color-chart-orange);
   }
 
   .tab-select-tooltip-anchor {

--- a/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
+++ b/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
@@ -102,7 +102,7 @@ export class WorktreeChip extends LitElement {
         width: 6px;
         height: 6px;
         border-radius: 50%;
-        background-color: var(--wa-color-chart-orange, #d18616);
+        background-color: var(--color-chart-orange);
         flex-shrink: 0;
       }
 
@@ -149,7 +149,7 @@ export class WorktreeChip extends LitElement {
 
       .ci-icon.ci-pending,
       .ci-icon.ci-running {
-        color: var(--wa-color-chart-orange, #d18616);
+        color: var(--color-chart-orange);
       }
 
       .ci-icon.ci-unknown {

--- a/src/shared/styles/litStyles.ts
+++ b/src/shared/styles/litStyles.ts
@@ -20,6 +20,7 @@ export const designTokens: CSSResult = css`
     --color-info: var(--wa-color-chart-blue, #3794ff);
     --color-added: var(--wa-color-chart-green, #4caf50);
     --color-removed: var(--wa-color-chart-red, #f44336);
+    --color-chart-orange: var(--wa-color-chart-orange, #d18616);
 
     /* Status indicators (dependency installed/missing, tool available/missing).
        Distinct from --color-success/--color-error: these use the editor

--- a/src/test-kernel/cli/TerminalCleanup.vitest.ts
+++ b/src/test-kernel/cli/TerminalCleanup.vitest.ts
@@ -111,28 +111,34 @@ describe('installTerminalTitleUpdates', () => {
   };
 
   it('shows root launch as running before the first stream status arrives', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
     enableOscTitles();
     const updates = installTerminalTitleUpdates('/work/coauthor');
     rootRunPending.set(true);
 
     await flushTitleUpdate();
 
-    expectLastTitle('TeXRA — - — coauthor');
+    expectLastTitle('TeXRA — | — coauthor');
     updates.dispose();
   });
 
   it('stays running after the root id is published but before its status arrives', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
     enableOscTitles();
     rootRunPending.set(true);
     rootRunStreamId.set('status-pending-root');
 
     const updates = installTerminalTitleUpdates('/work/coauthor');
 
-    expectLastTitle('TeXRA — - — coauthor');
+    expectLastTitle('TeXRA — | — coauthor');
     updates.dispose();
   });
 
   it('uses every stream phase and gives queued approval precedence', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
     enableOscTitles();
     const updates = installTerminalTitleUpdates('/work/coauthor');
     rootRunPending.set(true);
@@ -146,7 +152,7 @@ describe('installTerminalTitleUpdates', () => {
       status: STREAM_PHASE.RUNNING,
     });
     await flushTitleUpdate();
-    expectLastTitle('TeXRA — - — coauthor');
+    expectLastTitle('TeXRA — | — coauthor');
 
     queueTitleApproval('title-transition');
     await flushTitleUpdate();
@@ -154,7 +160,7 @@ describe('installTerminalTitleUpdates', () => {
 
     clearApprovals();
     await flushTitleUpdate();
-    expectLastTitle('TeXRA — - — coauthor');
+    expectLastTitle('TeXRA — | — coauthor');
 
     setStreamStatusInCliState({
       streamId: 'transition-child',
@@ -167,6 +173,7 @@ describe('installTerminalTitleUpdates', () => {
 
   it('animates running titles and stops the timer outside the running state', async () => {
     vi.useFakeTimers();
+    vi.setSystemTime(0);
     enableOscTitles();
     const updates = installTerminalTitleUpdates('/work/coauthor');
     setStreamStatusInCliState({
@@ -175,11 +182,15 @@ describe('installTerminalTitleUpdates', () => {
     });
     await flushTitleUpdate();
 
-    expectLastTitle('TeXRA — - — coauthor');
-    vi.advanceTimersByTime(500);
+    // Frame comes from `loadingFrameAt(Date.now())` on the shared 1 Hz tick
+    // (see LOADING_FRAMES in LoadingIndicator.tsx), not a private timer, so
+    // each check advances a full second and the frame is whatever wall time
+    // projects to — not reset to index 0 on each animation restart.
+    expectLastTitle('TeXRA — | — coauthor');
+    vi.advanceTimersByTime(1000);
     expectLastTitle('TeXRA — / — coauthor');
-    vi.advanceTimersByTime(500);
-    expectLastTitle('TeXRA — \\ — coauthor');
+    vi.advanceTimersByTime(1000);
+    expectLastTitle('TeXRA — - — coauthor');
 
     queueTitleApproval('animated-root');
     await flushTitleUpdate();
@@ -188,13 +199,13 @@ describe('installTerminalTitleUpdates', () => {
 
     clearApprovals();
     await flushTitleUpdate();
-    expectLastTitle('TeXRA — - — coauthor');
+    expectLastTitle('TeXRA — \\ — coauthor');
     updates.suspend();
     expectLastTitle('TeXRA — coauthor');
     expectNoTitleWrites();
 
     updates.resume();
-    expectLastTitle('TeXRA — - — coauthor');
+    expectLastTitle('TeXRA — / — coauthor');
     setStreamStatusInCliState({
       streamId: 'animated-root',
       status: STREAM_PHASE.WAITING,


### PR DESCRIPTION
## Summary

Two small dedup fixes surfaced by a scheduled UI-consistency audit:

1. **CLI**: `installTerminalTitleUpdates` (`packages/cli/src/chat/tui/terminalTitle.ts`) hand-rolled its own `setInterval`-based frame cycle (`['-','/','\\']` at 500ms) to spin the terminal tab title while a run is active. This duplicated both the frame set and the private-timer pattern that the app's shared 1 Hz clock exists specifically to avoid (see `LoadingIndicator.tsx`'s doc comment). It now subscribes to the same shared tick registry (`subscribeToSharedTick`, newly exported from `useLiveNowMs.ts`) and reuses `loadingFrameAt` for the frame character, so the tab title joins the same clock the status bar and loading indicators already use.
2. **Webview**: the `--wa-color-chart-orange` fallback literal `#d18616` was hand-copied in three places (`WorktreeChip.ts` x2, `StreamTab.styles.ts`). Hoisted into a single `--color-chart-orange` alias in the shared design-token sheet (`src/shared/styles/litStyles.ts`), following the same pattern already used there for `--color-info`, `--color-added`, `--color-removed`.

## Issue acceptance gates

No tracked issue — ad hoc cleanup from a scheduled UI-audit routine. Both findings: (a) terminal-title timer duplication, (b) chart-orange fallback duplication — are fixed.

## Single source of truth

- The shared 1 Hz tick registry in `packages/cli/src/tui/useLiveNowMs.ts` (`subscribeToSharedTick`) is now the one place a "tick every second" subscription is created; `terminalTitle.ts` no longer runs a private interval.
- `--color-chart-orange` in `src/shared/styles/litStyles.ts` is now the one place the `--wa-color-chart-orange` fallback literal is defined; the three consuming stylesheets reference the alias.

## Duplication and abstraction budget

Removed: a private `setInterval`/`clearInterval` pair, a private 3-frame constant, and a private frame-index counter in `terminalTitle.ts` (replaced by joining the existing shared-tick subscription and existing `loadingFrameAt` helper — no new abstraction, reuses two exports that already existed). Removed: three copies of the literal `#d18616` (replaced by one alias declaration reused at the three call sites — no new abstraction beyond a one-line addition to the existing token sheet).

## Net elements (R6)

Files: 5 production files changed (no files added/removed) + 1 test file updated for the new deterministic frame timing.
Exported symbols: `+1` (`subscribeToSharedTick` in `useLiveNowMs.ts`, promoted from module-private to exported so the non-React `terminalTitle.ts` caller can join it); `0` removed.
Classes/interfaces/enums: none added or removed.
Net LoC (production files only): +21 / -18.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed; `subscribeToSharedTick` gained one new consumer (`terminalTitle.ts`) alongside its existing internal use in `useLiveNowMs` itself.

## Host impact

Extension: `WorktreeChip.ts` and `StreamTab.styles.ts` now read `--color-chart-orange` instead of repeating the hex fallback; no visual change (same computed color).

Desktop: no direct changes; the shared litStyles.ts token sheet also applies to the desktop host, same no-visual-change guarantee (desktop already defines `--wa-color-chart-orange` in `themeTokens.css`, so the alias resolves to the theme value there too).

CLI: `installTerminalTitleUpdates` now ticks the terminal-tab spinner off the shared 1 Hz clock instead of its own 500ms timer — the animation now advances once per second (previously twice per second) and no longer resets to a fixed start frame on each restart; the frame is derived from wall time, same as `LoadingIndicator`/the status bar.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — passes (workspace, test-kernel, agent, cli, trace-viewer, desktop).
- `npx eslint` on all touched files — clean.
- `npm run check:dead-code-ratchet` — no new findings (437 baselined, 437 found).
- `npx vitest run src/test-kernel/cli/ src/test-kernel/progressView/WorktreeChip.vitest.ts src/test-kernel/shared/BadgeStyleContracts.vitest.ts` — 146 files, 2547 passed, 1 skipped (pre-existing, unrelated).
- Updated `src/test-kernel/cli/TerminalCleanup.vitest.ts` for the new shared-clock-driven frame timing (1000ms cadence instead of 500ms, frame derived from wall time rather than reset to index 0 per animation start).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xn1EGm51v85sR7gXa2TFV8)_