### PR TITLE
refactor: unexport 7 production-dead view helpers, shrink knip baseline (#11253)

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1352,48 +1352,6 @@
       "name": "resolveCommonRootFromGitdir"
     },
     {
-      "file": "packages/extension/src/progressView/frontend/components/TerminalOutput.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "countTerminalRows"
-    },
-    {
-      "file": "packages/extension/src/progressView/frontend/components/TerminalOutput.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "nextTerminalRowCount"
-    },
-    {
-      "file": "packages/extension/src/progressView/frontend/components/TerminalOutput.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "planTerminalTextUpdate"
-    },
-    {
-      "file": "packages/extension/src/webview/frontend/fileDropHandler.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "extractDroppedFilePaths"
-    },
-    {
-      "file": "packages/extension/src/webview/frontend/fileDropHandler.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "hasDroppedFilePayload"
-    },
-    {
-      "file": "packages/extension/src/webview/frontend/mainViewActions.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "announce"
-    },
-    {
-      "file": "packages/extension/src/webview/frontend/mainViewActions.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "buildExecuteMessage"
-    },
-    {
       "file": "packages/trace-viewer/src/traceDataSchema.ts",
       "category": "production-dead",
       "kind": "exports",

--- a/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
@@ -30,7 +30,7 @@ interface TerminalTextUpdatePlan {
   textToWrite: string;
 }
 
-export function planTerminalTextUpdate(
+function planTerminalTextUpdate(
   renderedText: string,
   nextText: string,
 ): TerminalTextUpdatePlan {
@@ -47,7 +47,7 @@ export function planTerminalTextUpdate(
   };
 }
 
-export function countTerminalRows(text: string): number {
+function countTerminalRows(text: string): number {
   let rows = 1;
   for (const char of text) {
     if (char === '\n') rows += 1;
@@ -55,7 +55,7 @@ export function countTerminalRows(text: string): number {
   return rows;
 }
 
-export function nextTerminalRowCount(
+function nextTerminalRowCount(
   previousRowCount: number,
   updatePlan: TerminalTextUpdatePlan,
 ): number {
@@ -247,10 +247,9 @@ export class TerminalOutput extends LitElement {
         );
         const scrollback = Math.max(MIN_SCROLLBACK, rowCount);
         if (terminal.options.scrollback !== scrollback) {
-          terminal.options = {
-            ...terminal.options,
-            scrollback,
-          };
+          // xterm rejects whole-object options assignment ('cols'/'rows' are
+          // constructor-only); set the single option instead.
+          terminal.options.scrollback = scrollback;
         }
 
         if (updatePlan.reset) {

--- a/packages/extension/src/webview/frontend/fileDropHandler.ts
+++ b/packages/extension/src/webview/frontend/fileDropHandler.ts
@@ -67,9 +67,7 @@ function hasFileUri(dataTransfer: DataTransfer, type: string): boolean {
 }
 
 /** Return true when the drag payload appears to contain files or file URIs. */
-export function hasDroppedFilePayload(
-  dataTransfer: DataTransfer | null,
-): boolean {
+function hasDroppedFilePayload(dataTransfer: DataTransfer | null): boolean {
   if (!dataTransfer) return false;
   const types = [...(dataTransfer.types ?? [])];
   return (
@@ -81,9 +79,7 @@ export function hasDroppedFilePayload(
 }
 
 /** Extract absolute paths or file URIs from a drop payload. */
-export function extractDroppedFilePaths(
-  dataTransfer: DataTransfer | null,
-): string[] {
+function extractDroppedFilePaths(dataTransfer: DataTransfer | null): string[] {
   if (!dataTransfer) return [];
 
   const paths = new Set<string>();

--- a/packages/extension/src/webview/frontend/mainViewActions.ts
+++ b/packages/extension/src/webview/frontend/mainViewActions.ts
@@ -101,7 +101,7 @@ export function refreshInstructionPlaceholder(): void {
  * commits before the set render (Lit flushes updates in a microtask queued
  * ahead of ours), so assistive tech observes a removal + insertion.
  */
-export function announce(message: string): void {
+function announce(message: string): void {
   statusAnnouncement$.set('');
   queueMicrotask(() => statusAnnouncement$.set(message));
 }
@@ -345,7 +345,7 @@ export function changeAgent(sessionType: SessionType, value: string): void {
 // Execute / panel actions
 // ---------------------------------------------------------------------------
 
-export function buildExecuteMessage(): MainViewExecuteMessage {
+function buildExecuteMessage(): MainViewExecuteMessage {
   const sessionType = sessionType$.get();
   const launchTarget =
     sessionType === SESSION_TYPES.WORKFLOW ? 'agent' : launchTarget$.get();

--- a/src/test-kernel/progressView/TerminalOutput.vitest.ts
+++ b/src/test-kernel/progressView/TerminalOutput.vitest.ts
@@ -1,5 +1,6 @@
 // Third-party imports
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Terminal } from '@xterm/xterm';
 
 // Local imports - test utilities
 import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
@@ -10,45 +11,107 @@ useLitComponentTestDom(
 
 // Loaded after useLitComponentTestDom's beforeAll installs the jsdom globals
 // this module touches at import time.
-let planTerminalTextUpdate: typeof import('@progressView/frontend/components/TerminalOutput').planTerminalTextUpdate;
-let countTerminalRows: typeof import('@progressView/frontend/components/TerminalOutput').countTerminalRows;
-let nextTerminalRowCount: typeof import('@progressView/frontend/components/TerminalOutput').nextTerminalRowCount;
+type TerminalOutputElement =
+  import('@progressView/frontend/components/TerminalOutput').TerminalOutput;
+
+// xterm is stubbed at the prototype: opening a renderer needs layout jsdom
+// does not have, and what these tests pin is what the element writes and how
+// it sizes scrollback, not xterm's own rendering.
+let writes: string[];
+let resetCount: number;
+let terminals: Terminal[];
 
 beforeAll(async () => {
-  ({ planTerminalTextUpdate, countTerminalRows, nextTerminalRowCount } =
-    await import('@progressView/frontend/components/TerminalOutput'));
+  await import('@progressView/frontend/components/TerminalOutput');
+  vi.spyOn(Terminal.prototype, 'open').mockImplementation(function (
+    this: Terminal,
+  ) {
+    terminals.push(this);
+  });
+  vi.spyOn(Terminal.prototype, 'write').mockImplementation(
+    (data: string | Uint8Array, callback?: () => void) => {
+      writes.push(String(data));
+      callback?.();
+    },
+  );
+  vi.spyOn(Terminal.prototype, 'reset').mockImplementation(() => {
+    resetCount += 1;
+  });
 });
 
-describe('terminal-output text update planning', () => {
-  it('writes only the appended suffix when output grows', () => {
-    expect(planTerminalTextUpdate('alpha\n', 'alpha\nbeta\n')).toEqual({
-      reset: false,
-      textToWrite: 'beta\n',
-    });
+beforeEach(() => {
+  writes = [];
+  resetCount = 0;
+  terminals = [];
+});
+
+/** Flush the element's async write loop (kicked from `updated()`). */
+async function flushTerminal(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function mountTerminal(): Promise<TerminalOutputElement> {
+  const element = document.createElement(
+    'terminal-output',
+  ) as TerminalOutputElement;
+  document.body.appendChild(element);
+  await element.updateComplete;
+  return element;
+}
+
+describe('terminal-output text updates', () => {
+  it('writes only the appended suffix when output grows', async () => {
+    const element = await mountTerminal();
+
+    element.text = 'alpha\n';
+    await flushTerminal();
+    element.text = 'alpha\nbeta\n';
+    await flushTerminal();
+
+    expect(writes).toEqual(['alpha\n', 'beta\n']);
+    expect(resetCount).toBe(0);
   });
 
-  it('falls back to a reset when retained output is replaced', () => {
-    expect(planTerminalTextUpdate('alpha\nbeta\n', 'beta\n')).toEqual({
-      reset: true,
-      textToWrite: 'beta\n',
-    });
+  it('resets and rewrites everything when retained output is replaced', async () => {
+    const element = await mountTerminal();
+
+    element.text = 'alpha\nbeta\n';
+    await flushTerminal();
+    element.text = 'beta\n';
+    await flushTerminal();
+
+    expect(resetCount).toBe(1);
+    expect(writes).toEqual(['alpha\nbeta\n', 'beta\n']);
   });
 
-  it('counts terminal rows without allocating split arrays', () => {
-    expect(countTerminalRows('')).toBe(1);
-    expect(countTerminalRows('one')).toBe(1);
-    expect(countTerminalRows('one\ntwo\n')).toBe(3);
+  it('keeps the minimum scrollback for small output', async () => {
+    const element = await mountTerminal();
+
+    element.text = 'one\ntwo\n';
+    await flushTerminal();
+
+    expect(terminals[0]?.options.scrollback).toBe(4_000);
   });
 
-  it('updates row count incrementally for appended output', () => {
-    const updatePlan = planTerminalTextUpdate('alpha\n', 'alpha\nbeta\ngamma');
+  it('grows scrollback with the rendered row count', async () => {
+    const element = await mountTerminal();
 
-    expect(nextTerminalRowCount(2, updatePlan)).toBe(3);
+    element.text = 'a\n'.repeat(4_001);
+    await flushTerminal();
+
+    // 4_002 rendered rows, just past the 4_000 minimum.
+    expect(terminals[0]?.options.scrollback).toBe(4_002);
   });
 
-  it('recounts rows when output is reset after trimming', () => {
-    const updatePlan = planTerminalTextUpdate('alpha\nbeta\n', 'beta\ngamma\n');
+  it('accumulates the row count across appended writes', async () => {
+    const element = await mountTerminal();
 
-    expect(nextTerminalRowCount(3, updatePlan)).toBe(3);
+    element.text = 'a\n'.repeat(2_000);
+    await flushTerminal();
+    element.text = `${'a\n'.repeat(2_000)}${'b\n'.repeat(2_000)}`;
+    await flushTerminal();
+
+    // 2_001 rows plus 2_000 appended rows (the trailing newline shares a row).
+    expect(terminals[0]?.options.scrollback).toBe(4_001);
   });
 });

--- a/src/test-kernel/webview/MainViewLaunchTarget.vitest.ts
+++ b/src/test-kernel/webview/MainViewLaunchTarget.vitest.ts
@@ -4,15 +4,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // Local imports - shared IPC and schemas
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import { MainViewPersistedStateSchema, AgentCategory } from '@shared/schemas';
-import type { SessionType, TeamOptionData } from '@shared/schemas';
+import type {
+  MainViewExecuteMessage,
+  SessionType,
+  TeamOptionData,
+} from '@shared/schemas';
 
 // Local imports - main-view actions, catalog slice, state, and test utilities
 import {
-  buildExecuteMessage,
   changeLaunchTarget,
   changeSessionType,
   changeTeam,
   changeWorkingDirectory,
+  sendExecuteMessage,
   validateTeamSelection,
 } from '@webview/frontend/mainViewActions';
 import { catalogHandlers } from '@webview/frontend/slices/catalogSlice';
@@ -65,6 +69,14 @@ const OPEN_ROOTS = [
 /** Flush the microtask queue so `announce`'s clear-then-set lands. */
 async function flushAnnouncements(): Promise<void> {
   await Promise.resolve();
+}
+
+/** Post the current form state and return the EXECUTE payload the host gets. */
+function captureExecuteMessage(): MainViewExecuteMessage {
+  sendExecuteMessage();
+  const call = mocks.postMessage.mock.calls.at(-1);
+  expect(call?.[0]).toBe(MAIN_VIEW_COMMANDS.EXECUTE);
+  return call?.[1] as MainViewExecuteMessage;
 }
 
 function stashDraft(sessionType: SessionType, text: string): void {
@@ -436,7 +448,7 @@ describe('main-view launch target', () => {
     });
   });
 
-  describe('buildExecuteMessage', () => {
+  describe('sendExecuteMessage', () => {
     it('sends only launchTarget and teamId as team identity', () => {
       sessionType$.set('toolUse');
       launchTarget$.set('team');
@@ -444,7 +456,7 @@ describe('main-view launch target', () => {
       agent$.set({ ...agent$.get(), toolUse: 'orchestrator' });
       model$.set('gpt-5.4');
 
-      const message = buildExecuteMessage();
+      const message = captureExecuteMessage();
 
       expect(message.session).toEqual({
         launchTarget: 'team',
@@ -459,7 +471,7 @@ describe('main-view launch target', () => {
     it('sends the selected working directory through the existing session payload', () => {
       workingDirectory$.set('/workspace/paper');
 
-      expect(buildExecuteMessage().session).toMatchObject({
+      expect(captureExecuteMessage().session).toMatchObject({
         launchTarget: 'agent',
         workingDirectory: '/workspace/paper',
       });
@@ -470,7 +482,7 @@ describe('main-view launch target', () => {
       launchTarget$.set('agent');
       selectedTeamId$.set('physicist');
 
-      expect(buildExecuteMessage().session).toEqual({
+      expect(captureExecuteMessage().session).toEqual({
         launchTarget: 'agent',
         teamId: undefined,
       });
@@ -481,7 +493,7 @@ describe('main-view launch target', () => {
       launchTarget$.set('team');
       selectedTeamId$.set('physicist');
 
-      expect(buildExecuteMessage().session).toEqual({
+      expect(captureExecuteMessage().session).toEqual({
         launchTarget: 'agent',
         teamId: undefined,
       });
@@ -492,7 +504,7 @@ describe('main-view launch target', () => {
       launchTarget$.set('team');
       selectedTeamId$.set('');
 
-      expect(buildExecuteMessage().session).toEqual({
+      expect(captureExecuteMessage().session).toEqual({
         launchTarget: 'team',
         teamId: undefined,
       });

--- a/src/test-kernel/webview/fileDropHandler.vitest.ts
+++ b/src/test-kernel/webview/fileDropHandler.vitest.ts
@@ -1,12 +1,16 @@
-import { describe, expect, it } from 'vitest';
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+import { FileDropController } from '@webview/frontend/fileDropHandler';
+import type { ReactiveControllerHost } from 'lit';
 
-import {
-  extractDroppedFilePaths,
-  hasDroppedFilePayload,
-} from '@webview/frontend/fileDropHandler';
+// Local imports - component under test
 
 type FakeFile = {
   path?: string;
+};
+
+type FakeDragEvent = DragEvent & {
+  readonly preventDefault: ReturnType<typeof vi.fn>;
 };
 
 function dataTransfer(
@@ -21,75 +25,131 @@ function dataTransfer(
   } as unknown as DataTransfer;
 }
 
-describe('fileDropHandler', () => {
-  it('detects file drop payloads without treating plain text as a file', () => {
-    expect(hasDroppedFilePayload(dataTransfer(['Files']))).toBe(true);
-    expect(
-      hasDroppedFilePayload(
-        dataTransfer(['text/uri-list'], {
-          'text/uri-list': 'file:///Users/a/project/main.tex',
-        }),
-      ),
-    ).toBe(true);
-    expect(hasDroppedFilePayload(dataTransfer(['text/plain']))).toBe(false);
-    expect(
-      hasDroppedFilePayload(
-        dataTransfer(['text/uri-list'], {
-          'text/uri-list': 'https://example.com/paper',
-        }),
-      ),
-    ).toBe(false);
+function dragEvent(transfer: DataTransfer): FakeDragEvent {
+  return {
+    dataTransfer: transfer,
+    preventDefault: vi.fn(),
+  } as unknown as FakeDragEvent;
+}
+
+function createDropTarget(): {
+  controller: FileDropController;
+  onDrop: ReturnType<typeof vi.fn<(paths: string[]) => void>>;
+} {
+  const host: ReactiveControllerHost = {
+    addController: () => {},
+    removeController: () => {},
+    requestUpdate: () => {},
+    updateComplete: Promise.resolve(true),
+  };
+  const onDrop = vi.fn<(paths: string[]) => void>();
+  return { controller: new FileDropController(host, onDrop), onDrop };
+}
+
+describe('FileDropController', () => {
+  it('activates for file payloads without treating plain text as a file', () => {
+    const { controller } = createDropTarget();
+
+    const filesEvent = dragEvent(dataTransfer(['Files']));
+    controller.handleDragEnter(filesEvent);
+    expect(controller.isDragActive).toBe(true);
+    expect(filesEvent.preventDefault).toHaveBeenCalled();
+
+    const uriEvent = dragEvent(
+      dataTransfer(['text/uri-list'], {
+        'text/uri-list': 'file:///Users/a/project/main.tex',
+      }),
+    );
+    controller.handleDragEnter(uriEvent);
+    expect(uriEvent.preventDefault).toHaveBeenCalled();
+
+    const textEvent = dragEvent(dataTransfer(['text/plain']));
+    controller.handleDragEnter(textEvent);
+    expect(textEvent.preventDefault).not.toHaveBeenCalled();
+
+    const linkEvent = dragEvent(
+      dataTransfer(['text/uri-list'], {
+        'text/uri-list': 'https://example.com/paper',
+      }),
+    );
+    controller.handleDragEnter(linkEvent);
+    expect(linkEvent.preventDefault).not.toHaveBeenCalled();
   });
 
   it('accepts a uri-list payload during dragover when the data store is protected', () => {
+    const { controller } = createDropTarget();
+
     // While dragging, `getData()` returns '' (protected mode); only `types` is
-    // readable. We must still report the payload as droppable so the dragover
-    // handler calls preventDefault() and the drop event can fire.
-    expect(hasDroppedFilePayload(dataTransfer(['text/uri-list']))).toBe(true);
+    // readable. The payload must still count as droppable so the handler calls
+    // preventDefault() and the drop event can fire.
+    const event = dragEvent(dataTransfer(['text/uri-list']));
+    controller.handleDragOver(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
   });
 
   it('extracts file paths from dropped File objects', () => {
-    const paths = extractDroppedFilePaths(
-      dataTransfer(['Files'], {}, [{ path: '/Users/a/project/main.tex' }]),
+    const { controller, onDrop } = createDropTarget();
+
+    controller.handleDrop(
+      dragEvent(
+        dataTransfer(['Files'], {}, [{ path: '/Users/a/project/main.tex' }]),
+      ),
     );
 
-    expect(paths).toEqual(['/Users/a/project/main.tex']);
+    expect(onDrop).toHaveBeenCalledWith(['/Users/a/project/main.tex']);
   });
 
   it('extracts and deduplicates file URIs from text payloads', () => {
-    const paths = extractDroppedFilePaths(
-      dataTransfer(['text/uri-list'], {
-        'text/uri-list': [
-          'file:///Users/a/project/My%20Paper/main.tex',
-          '# Finder comment',
-          'file:///Users/a/project/refs.bib',
-          'file:///Users/a/project/refs.bib',
-        ].join('\n'),
-      }),
+    const { controller, onDrop } = createDropTarget();
+
+    controller.handleDrop(
+      dragEvent(
+        dataTransfer(['text/uri-list'], {
+          'text/uri-list': [
+            'file:///Users/a/project/My%20Paper/main.tex',
+            '# Finder comment',
+            'file:///Users/a/project/refs.bib',
+            'file:///Users/a/project/refs.bib',
+          ].join('\n'),
+        }),
+      ),
     );
 
-    expect(paths).toEqual([
+    expect(onDrop).toHaveBeenCalledWith([
       '/Users/a/project/My Paper/main.tex',
       '/Users/a/project/refs.bib',
     ]);
   });
 
   it('ignores malformed percent-encoded file URIs', () => {
+    const { controller, onDrop } = createDropTarget();
     const transfer = dataTransfer(['text/uri-list'], {
       'text/uri-list': 'file:///tmp/%E0%A4%A',
     });
 
-    expect(hasDroppedFilePayload(transfer)).toBe(false);
-    expect(extractDroppedFilePaths(transfer)).toEqual([]);
+    const enterEvent = dragEvent(transfer);
+    controller.handleDragEnter(enterEvent);
+    expect(controller.isDragActive).toBe(false);
+    expect(enterEvent.preventDefault).not.toHaveBeenCalled();
+
+    const dropEvent = dragEvent(transfer);
+    controller.handleDrop(dropEvent);
+    expect(onDrop).not.toHaveBeenCalled();
+    expect(dropEvent.preventDefault).not.toHaveBeenCalled();
   });
 
   it('preserves hosts when extracting UNC-style file URIs', () => {
-    const paths = extractDroppedFilePaths(
-      dataTransfer(['text/uri-list'], {
-        'text/uri-list': 'file://server/share/main.tex',
-      }),
+    const { controller, onDrop } = createDropTarget();
+
+    controller.handleDrop(
+      dragEvent(
+        dataTransfer(['text/uri-list'], {
+          'text/uri-list': 'file://server/share/main.tex',
+        }),
+      ),
     );
 
-    expect(paths).toEqual(['//server/share/main.tex']);
+    expect(onDrop).toHaveBeenCalledWith(['//server/share/main.tex']);
   });
 });


### PR DESCRIPTION
Closes #11253.

## Summary

Drops `export` on seven helpers that had zero production consumers outside their defining files — `planTerminalTextUpdate`, `countTerminalRows`, `nextTerminalRowCount` (TerminalOutput.ts), `hasDroppedFilePayload`, `extractDroppedFilePaths` (fileDropHandler.ts), `announce`, `buildExecuteMessage` (mainViewActions.ts) — and deletes their 7 resolved `production-dead` entries from `config/ratchets/knip-baseline.json` (429 → 422 production-dead findings). The three vitest suites now pin the same behaviors through each module's public surface instead of importing the helpers directly.

The public-surface rework exposed a **latent production defect**, fixed here: crossing the 4000-row scrollback threshold assigned the whole xterm options object (`terminal.options = {...terminal.options, scrollback}`), which xterm 6 rejects (`Option "cols" can only be set in the constructor`). The flush loop died before the write, so any terminal output past 4000 rows threw an unhandled rejection and never rendered. Now assigns the single option (verified in node: whole-object assign throws, single-key assign works).

## Issue acceptance gates

- [x] `export` dropped on all seven symbols.
- [x] 7 knip-baseline entries removed; ratchet OK (no new findings).
- [x] Three suites reworked to public surfaces with the pinned behaviors preserved: update planning/reset via `TerminalOutput.text` + prototype-stubbed xterm (`write`/`reset`/`options.scrollback` observed); drop-payload detection/extraction via `FileDropController` drag events against an `onDrop` spy; execute-message shape via `sendExecuteMessage` against the `@shared/hostBridge` mock.

## Single source of truth

Unchanged: `TerminalOutput` owns terminal update planning, `FileDropController` owns drop-payload validation, `sendExecuteMessage` owns EXECUTE payload assembly. The exports were test affordances, not an API.

## Duplication and abstraction budget

No new abstraction. Test rework routes through existing public surfaces; one file-local `captureExecuteMessage` helper in the launch-target suite.

## Net elements (R6)

- Files: 7 changed (+226/-138), net **+88 LoC** (component-level test scaffolding replaces direct unit calls; production is -13)
- Exported symbols: **-7**, +0
- Classes/interfaces/enums: 0
- knip baseline: **-7 entries**

## Consumer counts (R8)

All seven symbols: production consumers **0** (issue's adversarial grep, re-verified: hits were definition sites + the three test files only). Non-production consumers were the three suites, now rewired to public surfaces.

## Host impact

Extension: one behavior fix (terminal scrollback growth no longer throws past 4000 rows); otherwise none.
Desktop: none.
CLI: none.

## Scheduled refactoring

None. (The blind-spot class is tracked by `docs/proposals/2026-08-19-dead-code-gate-blind-spots.md`.)

## Validation

- `npx vitest run` on the three reworked suites: 41/41 pass; `ToolUseFormatter.vitest.ts` (also mounts `terminal-output`): 22/22 pass
- `npm run typecheck` passes
- eslint + prettier clean on all touched files
- `npm run check:dead-code-ratchet`: OK, baseline burned down 437 → 430 combined
