### PR TITLE
refactor: fold duplicate path-separator-variant helpers in desktop main (#11254)

### DIFF
--- a/packages/desktop/src/main/desktopAppLog.ts
+++ b/packages/desktop/src/main/desktopAppLog.ts
@@ -18,8 +18,9 @@ import {
 } from 'electron';
 
 import { redactSecrets } from '@logger/redaction';
-import { normalizeFilePath, unique } from '@utils/core';
+import { normalizeFilePath } from '@utils/core';
 
+import { pathSeparatorVariants } from './desktopPathVariants.js';
 import type { DesktopLogSnapshot } from '../shared/desktopLogMessages.js';
 
 const LOG_FILE_NAME = 'texra-desktop.log';
@@ -171,20 +172,13 @@ function redactDesktopLogText(
   );
 }
 
-/** Both separator spellings of a prefix, so mixed-separator log text redacts. */
-function separatorVariants(prefix: string): string[] {
-  const forward = normalizeFilePath(prefix);
-  const backward = forward === '/' ? forward : forward.replaceAll('/', '\\');
-  return unique([prefix, forward, backward]);
-}
-
 function redactPathPrefixes(
   text: string,
   ...prefixes: readonly (string | undefined)[]
 ): string {
   return prefixes
     .filter((prefix): prefix is string => Boolean(prefix))
-    .flatMap(separatorVariants)
+    .flatMap(pathSeparatorVariants)
     .toSorted((a, b) => b.length - a.length)
     .reduce((redacted, prefix) => {
       if (prefix === '/') {

--- a/packages/desktop/src/main/desktopCrashEventScrubber.ts
+++ b/packages/desktop/src/main/desktopCrashEventScrubber.ts
@@ -1,16 +1,8 @@
 import escapeRegExp from 'escape-string-regexp';
-import { unique } from '@utils/core';
+import { pathSeparatorVariants } from './desktopPathVariants.js';
 import type { ErrorEvent } from '@sentry/electron/main';
 
 const REDACTED_PATH = '<redacted-path>';
-
-function pathVariants(path: string): string[] {
-  const trimmed = path.trim();
-  if (!trimmed) return [];
-  const forward = trimmed.replaceAll('\\', '/');
-  const backward = forward.replaceAll('/', '\\');
-  return unique([trimmed, forward, backward]);
-}
 
 function scrubValue(value: unknown, scrubbers: readonly RegExp[]): unknown {
   if (typeof value === 'string') {
@@ -40,7 +32,7 @@ export function createDesktopCrashEventScrubber(
   sensitivePaths: readonly (string | undefined)[],
 ): (event: ErrorEvent) => ErrorEvent | null {
   const scrubbers = sensitivePaths
-    .flatMap((path) => (path ? pathVariants(path) : []))
+    .flatMap((path) => (path ? pathSeparatorVariants(path) : []))
     .filter((path) => path.length > 1)
     .sort((a, b) => b.length - a.length)
     .map((path) => new RegExp(escapeRegExp(path), 'gi'));

--- a/packages/desktop/src/main/desktopPathVariants.ts
+++ b/packages/desktop/src/main/desktopPathVariants.ts
@@ -1,0 +1,16 @@
+// Local imports - shared utilities
+import { normalizeFilePath, unique } from '@utils/core';
+
+/**
+ * Every separator spelling of a sensitive filesystem path — the trimmed raw
+ * form, forward-slash, and back-slash — so redaction matches mixed-separator
+ * text. Returns [] for blank input. The root path '/' keeps its single
+ * spelling: turning it into '\' would never match real log or crash text.
+ */
+export function pathSeparatorVariants(path: string): string[] {
+  const trimmed = path.trim();
+  if (!trimmed) return [];
+  const forward = normalizeFilePath(trimmed);
+  const backward = forward === '/' ? forward : forward.replaceAll('/', '\\');
+  return unique([trimmed, forward, backward]);
+}


### PR DESCRIPTION
Closes #11254.

## Summary

`desktopAppLog.ts`'s `separatorVariants` (added by #11157, whose commit message admits it "mirrors the crash scrubber's pathVariants") and `desktopCrashEventScrubber.ts`'s `pathVariants` computed the same three-way separator-spelling set (raw / forward-slash / back-slash) via the same `unique()` helper, for the same purpose: redacting one sensitive path across mixed-separator text. One shared `pathSeparatorVariants` in the new `desktopPathVariants.ts` now owns the computation for both.

## Issue acceptance gates

- [x] One shared helper with two callers (meets the multi-caller bar).
- [x] **Superset behavior preserved**: the merged helper keeps the scrubber's trim + blank-input `[]` guard *and* the log redactor's root-path guard (`forward === '/'` keeps its single spelling instead of producing `'\'`), so the fold does not regress the #11157 fix. (`normalizeFilePath` is exactly `replaceAll('\\', '/')`, so the forward-slash forms were already identical.)

## Single source of truth

`packages/desktop/src/main/desktopPathVariants.ts` owns separator-variant expansion for desktop-main redaction; both redactors (log text, Sentry crash events) consume it.

## Duplication and abstraction budget

Removes one of two admitted-duplicate implementations. The new export's invariant: a sensitive path must match every separator spelling it can appear with in emitted text.

## Net elements (R6)

- Files: 3 changed (+21/-19), net **+2 LoC** (one new documented module replacing two inline copies)
- Exported symbols: **+1** (`pathSeparatorVariants`), -0 (both folded helpers were unexported)
- Classes/interfaces/enums: 0

## Consumer counts (R8)

- `separatorVariants` (deleted): 1 caller (`redactPathPrefixes` `.flatMap`), same file.
- `pathVariants` (deleted): 1 caller (`createDesktopCrashEventScrubber` `.flatMap`), same file.
- No dynamic wiring references either name.

## Host impact

Extension: none.
Desktop: log redaction and crash-event scrubbing behavior unchanged (superset semantics: blank input now also yields `[]` for the log path, and `'/'` no longer yields a `'\'` variant for the scrubber — both unreachable in practice: blank prefixes are pre-filtered, and the scrubber already drops length-≤1 variants downstream).
CLI: none.

## Scheduled refactoring

None.

## Validation

- `DesktopAppLog.vitest.ts` + `DesktopCrashReporting.vitest.ts`: 8/8 pass (includes the back-slash workspace redaction case from #11157)
- `npm run typecheck` passes
- eslint + prettier clean on all three files
- `npm run check:dead-code-ratchet`: OK, no new findings
