### PR TITLE
refactor: consolidate six script directory walkers onto one primitive

### DIFF
--- a/scripts/check-browser-safe-utils.mjs
+++ b/scripts/check-browser-safe-utils.mjs
@@ -16,11 +16,13 @@
 // a type-only edge all classify the way the compiler sees them. The ungated
 // guidance-references CI job installs devDependencies before running it.
 
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import ts from 'typescript';
+
+import { walkFiles } from './walkFiles.mjs';
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const utilsDir = join(rootDir, 'src', 'utils');
@@ -57,19 +59,9 @@ const WORD_TO_NUMBER = {
 
 /** Recursive list of TypeScript source files under a directory. */
 function listSourceFiles(dir) {
-  const results = [];
-  const walk = (current) => {
-    for (const entry of readdirSync(current, { withFileTypes: true })) {
-      const full = join(current, entry.name);
-      if (entry.isDirectory()) {
-        walk(full);
-      } else if (entry.isFile() && /\.tsx?$/.test(entry.name)) {
-        results.push(full);
-      }
-    }
-  };
-  walk(dir);
-  return results;
+  return walkFiles(dir, { include: (file) => /\.tsx?$/.test(file) }).map(
+    (entry) => entry.absolutePath,
+  );
 }
 
 /**

--- a/scripts/check-guidance-refs.mjs
+++ b/scripts/check-guidance-refs.mjs
@@ -22,6 +22,8 @@ import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { walkFiles } from './walkFiles.mjs';
+
 // The optional root argument keeps fixture tests hermetic without duplicating
 // the production path-prefix configuration.
 const repoRoot = process.argv[2]
@@ -108,15 +110,10 @@ const BUILD_OUTPUT = /(^|\/)(dist|out|releases|node_modules)(\/|$)/;
 function markdownFilesIn(dir) {
   const abs = join(repoRoot, dir);
   if (!existsSync(abs)) return [];
-  const found = [];
-  for (const entry of readdirSync(abs, { withFileTypes: true })) {
-    const rel = `${dir}/${entry.name}`;
-    if (entry.isDirectory()) {
-      if (ARCHIVAL_DIRS.includes(rel)) continue;
-      found.push(...markdownFilesIn(rel));
-    } else if (entry.name.endsWith('.md')) found.push(rel);
-  }
-  return found;
+  return walkFiles(abs, {
+    include: (relativePath) => relativePath.endsWith('.md'),
+    prune: (relativePath) => ARCHIVAL_DIRS.includes(`${dir}/${relativePath}`),
+  }).map((entry) => `${dir}/${entry.relativePath}`);
 }
 
 /** Strip fenced code blocks — those are examples, not live references. */

--- a/scripts/extension-package-utils.mjs
+++ b/scripts/extension-package-utils.mjs
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { walkFiles } from './walkFiles.mjs';
+
 export const vscodeRuntimeImportPattern =
   /\b(?:import\s*\(\s*['"]vscode['"]\s*\)|import\s+[^;]*\s+from\s+['"]vscode['"]|(?:__require|require|requireFn)(?:\?\.)?\(\s*['"]vscode['"]\s*\))/;
 
@@ -52,23 +54,9 @@ export function readJson(filePath) {
 
 /** Return recursive file paths with stable VSIX-compatible separators. */
 export function collectRelativeFiles(directory) {
-  const visit = (currentDirectory, prefix) => {
-    const files = [];
-    for (const entry of fs.readdirSync(currentDirectory, {
-      withFileTypes: true,
-    })) {
-      const relativePath = path.posix.join(prefix, entry.name);
-      const absolutePath = path.join(currentDirectory, entry.name);
-      if (entry.isDirectory()) {
-        files.push(...visit(absolutePath, relativePath));
-      } else if (entry.isFile()) {
-        files.push(relativePath);
-      }
-    }
-    return files;
-  };
-
-  return visit(directory, '').sort();
+  return walkFiles(directory)
+    .map((entry) => entry.relativePath)
+    .sort();
 }
 
 function stable(value) {

--- a/scripts/sync-remote-agents.mjs
+++ b/scripts/sync-remote-agents.mjs
@@ -9,7 +9,6 @@ import { spawnSync } from 'node:child_process';
 import {
   existsSync,
   mkdtempSync,
-  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -20,6 +19,8 @@ import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 
 import YAML from 'yaml';
+
+import { walkFiles } from './walkFiles.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 // Tests point TEXRA_REMOTE_AGENTS_ROOT at a fixture checkout so --apply never
@@ -46,18 +47,9 @@ function loadPlacementConfig() {
 }
 
 function discoverYamlFiles(dir) {
-  const files = [];
-
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const path = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...discoverYamlFiles(path));
-    } else if (entry.isFile() && entry.name.endsWith('.yaml')) {
-      files.push(path);
-    }
-  }
-
-  return files;
+  return walkFiles(dir, {
+    include: (relativePath) => relativePath.endsWith('.yaml'),
+  }).map((entry) => entry.absolutePath);
 }
 
 function readAgentYaml(filePath) {

--- a/scripts/verify-desktop-build-artifacts.mjs
+++ b/scripts/verify-desktop-build-artifacts.mjs
@@ -11,6 +11,7 @@ import {
   vscodeBackedStateImportPattern,
   vscodeRuntimeImportPattern,
 } from './extension-package-utils.mjs';
+import { walkFiles } from './walkFiles.mjs';
 
 const rootDir = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -32,16 +33,9 @@ function fileExists(filePath) {
 }
 
 function collectFiles(dir) {
-  const files = [];
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const entryPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...collectFiles(entryPath));
-    } else if (entry.isFile()) {
-      files.push(entryPath);
-    }
-  }
-  return files.sort();
+  return walkFiles(dir)
+    .map((entry) => entry.absolutePath)
+    .sort();
 }
 
 const packageJson = readJson(path.join(desktopDir, 'package.json'));

--- a/scripts/verify-extension-package-invariants.mjs
+++ b/scripts/verify-extension-package-invariants.mjs
@@ -10,6 +10,7 @@ import {
   readJson,
   withoutCatalogDerivedContributes,
 } from './extension-package-utils.mjs';
+import { walkFiles } from './walkFiles.mjs';
 
 const rootDir = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -152,13 +153,7 @@ function isBuildTimePackagedPath(relativePath) {
 function hasFiles(relativeDir) {
   const absoluteDir = path.join(packageDir, relativeDir);
   if (!fs.existsSync(absoluteDir)) return false;
-  const entries = fs.readdirSync(absoluteDir, { withFileTypes: true });
-  for (const entry of entries) {
-    const child = path.join(relativeDir, entry.name);
-    if (entry.isFile()) return true;
-    if (entry.isDirectory() && hasFiles(child)) return true;
-  }
-  return false;
+  return walkFiles(absoluteDir, { limit: 1 }).length > 0;
 }
 
 function buildSnapshot() {

--- a/scripts/walkFiles.mjs
+++ b/scripts/walkFiles.mjs
@@ -1,0 +1,47 @@
+// Shared recursive file listing for the repo's build/CI scripts.
+//
+// One primitive behind the scripts that walk a directory tree: callers supply
+// an optional file filter and directory prune over the walk-relative path and
+// map the result to whatever shape (relative/absolute, sorted or not) they
+// report. Walk-relative paths are always '/'-joined so filters behave the
+// same on Windows and Linux CI.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Recursively list files under `startDir` in depth-first readdir order.
+ *
+ * @param {string} startDir Directory to walk (absolute or relative).
+ * @param {object} [options]
+ * @param {(relativePath: string) => boolean} [options.include] File filter;
+ *   defaults to keeping every file.
+ * @param {(relativePath: string) => boolean} [options.prune] Directory prune;
+ *   return true to skip descending into that directory.
+ * @param {number} [options.limit] Stop after this many files (short-circuit).
+ * @returns {Array<{ absolutePath: string, relativePath: string }>} Entries in
+ *   walk order; `relativePath` is '/'-joined from `startDir` on every OS.
+ */
+export function walkFiles(startDir, options = {}) {
+  const { include, prune, limit } = options;
+  const results = [];
+  const visit = (absoluteDir, relativeDir) => {
+    for (const entry of fs.readdirSync(absoluteDir, { withFileTypes: true })) {
+      if (limit !== undefined && results.length >= limit) return;
+      const absolutePath = path.join(absoluteDir, entry.name);
+      const relativePath = relativeDir
+        ? `${relativeDir}/${entry.name}`
+        : entry.name;
+      if (entry.isDirectory()) {
+        if (prune?.(relativePath)) continue;
+        visit(absolutePath, relativePath);
+      } else if (entry.isFile()) {
+        if (!include || include(relativePath)) {
+          results.push({ absolutePath, relativePath });
+        }
+      }
+    }
+  };
+  visit(startDir, '');
+  return results;
+}


### PR DESCRIPTION
## Summary

Six build/CI scripts under `scripts/` each reimplemented recursive `readdirSync(dir, { withFileTypes: true })` traversal with a slightly different filter. This PR routes all six through one new module, `scripts/walkFiles.mjs`, which owns walk order, the `/`-joined walk-relative path contract, and three options: `include` (file filter), `prune` (directory prune), `limit` (short-circuit).

Closes #11255.

## Issue acceptance gates

#11255 asks to consolidate walkers 2–6 onto one primitive parameterized by filter predicate, keeping `markdownFilesIn`'s mid-walk pruning explicit.

- One primitive: `walkFiles(startDir, { include, prune, limit })`; all six walkers folded onto it, including the previously-canonical `collectRelativeFiles`.
- Filter predicates: `include` per consumer (`.md`, `.ts`/`.tsx`, `.yaml`, all-files, existence).
- Pruning stays explicit: `check-guidance-refs.mjs` passes `prune: (rel) => ARCHIVAL_DIRS.includes(...)`; the POSIX-key comment stays because the helper guarantees `/`-joined relative paths on every OS.
- Risk mitigation (release/CI-gating scripts): every consolidated check re-run, per the issue's estimate note (see Validation).

## Single source of truth

`scripts/walkFiles.mjs` owns recursive traversal, readdir walk order, and the invariant that walk-relative paths are `/`-joined on every host (so filters and reported keys behave identically on Windows and Linux CI).

## Duplication and abstraction budget

Removes six hand-rolled recursion implementations. The new abstraction owns exactly one decision: how a directory tree is walked and how relative paths are spelled. No pass-through layers: each consumer maps `walkFiles` results directly to its own shape (absolute paths, root-relative keys, sorted or not).

## Net elements (R6)

Files: +1 (`scripts/walkFiles.mjs`, 47 LoC), 6 modified. Diffstat: 75 insertions, 70 deletions; net +5 LoC (consumers −42, shared helper +47). Exported symbols (`^[+-]export`): +1 (`walkFiles`). Classes/interfaces/enums: none.

## Consumer counts (R8)

- `collectRelativeFiles` (body re-routed, signature and sort order unchanged): 2 external consumers, `verify-vsix-contents.mjs` and `verify-extension-package-invariants.mjs`.
- The five deleted local walkers (`markdownFilesIn`, `listSourceFiles`, `discoverYamlFiles`, `collectFiles`, `hasFiles`): 0 external consumers each; file-local functions.
- `readdirSync` imports removed from `check-browser-safe-utils.mjs` and `sync-remote-agents.mjs`; kept in `check-guidance-refs.mjs` for its single-level glob expansion (not a tree walk).

## Host impact

Extension: none. Desktop: none. CLI: none. Build/CI scripts only.

## Scheduled refactoring

None.

## Validation

- `node --check` on all seven touched files.
- `check:guidance-refs`, `check:browser-safe-utils`, `sync:remote-agents` (default mode), `check:extension-package-invariants`: all green on the real tree.
- Vitest: GuidanceRefs (3), SyncRemoteAgents (14), DesktopPackagePayload (9): 26/26 pass.
- Behavioral equivalence for the untested `verify-desktop-build-artifacts` fold: old vs new `collectFiles` output byte-identical over `packages/extension`, `scripts/`, `src/utils`.
- `prettier --check` clean on all touched files.
- `check:dead-code-ratchet`: OK, no new findings. Raw knip findings (2 unused files, 6 unused exports) verified pre-existing on clean HEAD via stash.
- `check:desktop-build-artifacts` and `check:vsix-contents` not run locally: they require built desktop/VSIX artifacts; both exercise folded code paths in CI.
