### PR TITLE
fix(test-kernel): reduce subsystem ratchet parse cost

### DIFF
--- a/src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts
+++ b/src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts
@@ -278,7 +278,12 @@ function collectSubsystemEdges(): SubsystemEdge[] {
       continue;
     }
 
-    visitImports(parseSourceFile(file), file, from, edges);
+    visitImports(
+      parseSourceFile(file, { setParentNodes: false }),
+      file,
+      from,
+      edges,
+    );
   }
 
   return [...edges.entries()]


### PR DESCRIPTION
## Summary

- parse subsystem-edge source files without parent pointers because this ratchet only walks downward with `ts.forEachChild`
- preserve the existing edge collection and 10-second timeout without introducing cache state

## Measurements

Five isolated runs of the ratchet's expensive test on this machine:

- before: 740-810 ms, median 746 ms
- after: 670-731 ms, median 678 ms
- median reduction: 68 ms (9.1%)

Within the full architecture directory run, the test decreased from 992 ms to 919 ms (7.4%). The complete suite stayed at 104 passing tests.

## Verification

- 5 repeated isolated target runs: 3/3 tests passed each run
- architecture suite: 17 files, 104 tests passed
- `npm run typecheck:test-kernel`
- changed-file ESLint
- changed-file Prettier check
- `git diff --check`
- `pnpm run test --maxWorkers=2 --shard=1/2`: 420 files passed, 1 skipped; 5,565 tests passed, 5 skipped

Closes #11198
