### PR TITLE
fix(copy): retire delegation API-mode errors

### DIFF
--- a/src/test-kernel/tools/DelegationModelAvailability.vitest.ts
+++ b/src/test-kernel/tools/DelegationModelAvailability.vitest.ts
@@ -85,7 +85,7 @@ describe('delegation model availability', () => {
         availableModels: ['sonnet46T', 'deepseekT'],
       }),
     ).toThrow(
-      'Model "opus48T" is not currently available for delegation in the active API mode. Available models: sonnet46T, deepseekT.',
+      'Model "opus48T" is not currently available for delegation through a configured provider API key or subscription. Available models: sonnet46T, deepseekT.',
     );
   });
 
@@ -112,7 +112,7 @@ describe('delegation model availability', () => {
         availableModels: [],
       }),
     ).toThrow(
-      'No models are currently available for delegation in the active API mode. Switch API mode or configure a provider API key before delegating.',
+      'No models are currently available for delegation. Add a provider API key or sign in with a supported provider subscription before delegating.',
     );
   });
 });

--- a/src/test-kernel/tools/DelegationModelAvailability.vitest.ts
+++ b/src/test-kernel/tools/DelegationModelAvailability.vitest.ts
@@ -85,7 +85,7 @@ describe('delegation model availability', () => {
         availableModels: ['sonnet46T', 'deepseekT'],
       }),
     ).toThrow(
-      'Model "opus48T" is not currently available for delegation through a configured provider API key or subscription. Available models: sonnet46T, deepseekT.',
+      'Model "opus48T" is not currently available for delegation with the currently configured model access. Available models: sonnet46T, deepseekT.',
     );
   });
 
@@ -112,7 +112,7 @@ describe('delegation model availability', () => {
         availableModels: [],
       }),
     ).toThrow(
-      'No models are currently available for delegation. Add a provider API key or sign in with a supported provider subscription before delegating.',
+      'No models are currently available for delegation. Review or configure model access before delegating.',
     );
   });
 });

--- a/src/tools/delegation/delegationAvailability.ts
+++ b/src/tools/delegation/delegationAvailability.ts
@@ -203,7 +203,7 @@ export function withDelegationAgentAvailability(
 const AVAILABLE_MODELS_LINE = /^Available models:.*$/m;
 
 const NO_DELEGATION_MODELS_MESSAGE =
-  'No models are currently available for delegation in the active API mode. Switch API mode or configure a provider API key before delegating.';
+  'No models are currently available for delegation. Add a provider API key or sign in with a supported provider subscription before delegating.';
 
 export function availableModelNamesFromOptions(
   models: readonly ModelOptionData[],
@@ -253,7 +253,7 @@ export function selectDelegationModelFromAvailableNames(input: {
   if (decision.unavailable) {
     const requestedModel = input.requestedModel?.trim() || null;
     throw new Error(
-      `Model "${requestedModel}" is not currently available for delegation in the active API mode. Available models: ${availableModels.join(', ')}.`,
+      `Model "${requestedModel}" is not currently available for delegation through a configured provider API key or subscription. Available models: ${availableModels.join(', ')}.`,
     );
   }
   return decision.model;

--- a/src/tools/delegation/delegationAvailability.ts
+++ b/src/tools/delegation/delegationAvailability.ts
@@ -203,7 +203,7 @@ export function withDelegationAgentAvailability(
 const AVAILABLE_MODELS_LINE = /^Available models:.*$/m;
 
 const NO_DELEGATION_MODELS_MESSAGE =
-  'No models are currently available for delegation. Add a provider API key or sign in with a supported provider subscription before delegating.';
+  'No models are currently available for delegation. Review or configure model access before delegating.';
 
 export function availableModelNamesFromOptions(
   models: readonly ModelOptionData[],
@@ -253,7 +253,7 @@ export function selectDelegationModelFromAvailableNames(input: {
   if (decision.unavailable) {
     const requestedModel = input.requestedModel?.trim() || null;
     throw new Error(
-      `Model "${requestedModel}" is not currently available for delegation through a configured provider API key or subscription. Available models: ${availableModels.join(', ')}.`,
+      `Model "${requestedModel}" is not currently available for delegation with the currently configured model access. Available models: ${availableModels.join(', ')}.`,
     );
   }
   return decision.model;


### PR DESCRIPTION
## Summary
- replace the two remaining relay-era active API mode delegation errors
- direct users to provider API keys or supported provider subscriptions
- keep unavailable-model listings and delegation selection behavior unchanged
- update the exact-string test assertions

## Verification
- `npm test -- src/test-kernel/tools/DelegationModelAvailability.vitest.ts`
- `npx eslint src/tools/delegation/delegationAvailability.ts src/test-kernel/tools/DelegationModelAvailability.vitest.ts`
- `npx prettier --check src/tools/delegation/delegationAvailability.ts src/test-kernel/tools/DelegationModelAvailability.vitest.ts`
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- `git diff --check`

Closes #11172