### PR TITLE
refactor(cli): derive quota provider from usage route

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -9,7 +9,6 @@ import { useLiveNowMsSince } from '@cli/tui/useLiveNowMs';
 import { usePollingInterval } from '@cli/tui/usePollingInterval';
 import { SubscriptionUsageService } from '@controllers/modelAccess/subscriptionUsage/SubscriptionUsageService';
 import { activeSubscriptionUsageRoute } from '@model/codingPlanSubscriptions';
-import { codingPlanForUsageRoute } from '@shared/codingPlanSubscriptions';
 import type {
   SubscriptionUsageProvider,
   SubscriptionUsageSnapshot,
@@ -212,9 +211,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
 
   const subscriptionUsageProvider = subscriptionUsageProviderForStatus({
     usageRoute: statusSlice?.usage?.usageRoute,
-    modelAccess,
-    prospectiveCodingPlan:
-      codingPlanForUsageRoute(prospectiveRoute)?.usageProvider,
+    prospectiveRoute,
   });
   const [subscriptionQuotaRead, setSubscriptionQuotaRead] = useState<{
     readonly provider: SubscriptionUsageProvider;

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -15,10 +15,7 @@ import { STATUS_DIAMOND } from '@cli/tui/ui/glyphs';
 import { KEY_HINT_SEPARATOR, keyHintText } from '@cli/tui/ui/KeyHints';
 import { STATUS_BAR_HORIZONTAL_PADDING } from '@cli/tui/ui/theme';
 import type { TexraApprovalPolicy } from '@shared/approvalPolicy';
-import {
-  codingPlanForUsageRoute,
-  CODING_PLAN_SUBSCRIPTIONS,
-} from '@shared/codingPlanSubscriptions';
+import { codingPlanForUsageRoute } from '@shared/codingPlanSubscriptions';
 import {
   type ContextStateData,
   type SubscriptionUsageSnapshot,
@@ -68,23 +65,14 @@ type CtrlCAction = 'exit' | 'stop' | 'stop root';
 /** Choose the quota owner, preferring the route of completed usage. */
 export function subscriptionUsageProviderForStatus({
   usageRoute,
-  modelAccess,
-  prospectiveCodingPlan,
+  prospectiveRoute,
 }: {
   readonly usageRoute: UsageRoute | undefined;
-  readonly modelAccess: CliModelAccessRoute;
-  readonly prospectiveCodingPlan?: SubscriptionUsageProvider;
+  readonly prospectiveRoute: UsageRoute | undefined;
 }): SubscriptionUsageProvider | undefined {
-  if (usageRoute === 'chatgpt-subscription') return 'chatgpt';
-  const completedCodingPlan = codingPlanForUsageRoute(usageRoute);
-  if (completedCodingPlan) return completedCodingPlan.usageProvider;
-  if (usageRoute !== undefined) return undefined;
-  if (modelAccess === 'chatgpt') return 'chatgpt';
-  return CODING_PLAN_SUBSCRIPTIONS.find(
-    (plan) =>
-      plan.usageProvider === prospectiveCodingPlan &&
-      plan.cliProvider === modelAccess,
-  )?.usageProvider;
+  const route = usageRoute ?? prospectiveRoute;
+  if (route === 'chatgpt-subscription') return 'chatgpt';
+  return codingPlanForUsageRoute(route)?.usageProvider;
 }
 
 interface StatusBarSegment {

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -103,28 +103,41 @@ function heavyUsage(usageRoute: UsageRoute): TokenUsage {
 }
 
 describe('CLI StatusBar display model', () => {
-  it('does not show prospective plan quota after completed API-key usage', () => {
+  it.each([
+    {
+      name: 'completed API-key usage over a prospective coding plan',
+      usageRoute: 'api-key',
+      prospectiveRoute: 'glm-coding-plan-subscription',
+      expected: undefined,
+    },
+    {
+      name: 'completed coding-plan usage over a prospective ChatGPT route',
+      usageRoute: 'kimi-code-subscription',
+      prospectiveRoute: 'chatgpt-subscription',
+      expected: 'kimiCode',
+    },
+    {
+      name: 'prospective ChatGPT route before completed usage exists',
+      usageRoute: undefined,
+      prospectiveRoute: 'chatgpt-subscription',
+      expected: 'chatgpt',
+    },
+    {
+      name: 'prospective coding-plan route before completed usage exists',
+      usageRoute: undefined,
+      prospectiveRoute: 'glm-coding-plan-subscription',
+      expected: 'glmCodingPlan',
+    },
+    {
+      name: 'prospective route without a quota provider',
+      usageRoute: undefined,
+      prospectiveRoute: 'xai-subscription',
+      expected: undefined,
+    },
+  ] as const)('$name', ({ usageRoute, prospectiveRoute, expected }) => {
     expect(
-      subscriptionUsageProviderForStatus({
-        usageRoute: 'api-key',
-        modelAccess: 'personal',
-        prospectiveCodingPlan: 'glmCodingPlan',
-      }),
-    ).toBeUndefined();
-    expect(
-      subscriptionUsageProviderForStatus({
-        usageRoute: undefined,
-        modelAccess: 'personal',
-        prospectiveCodingPlan: 'glmCodingPlan',
-      }),
-    ).toBeUndefined();
-    expect(
-      subscriptionUsageProviderForStatus({
-        usageRoute: undefined,
-        modelAccess: 'glm-code',
-        prospectiveCodingPlan: 'glmCodingPlan',
-      }),
-    ).toBe('glmCodingPlan');
+      subscriptionUsageProviderForStatus({ usageRoute, prospectiveRoute }),
+    ).toBe(expected);
   });
 
   it('uses clear compact labels for API access mode', () => {


### PR DESCRIPTION
## Summary

- simplify `subscriptionUsageProviderForStatus` from `{ usageRoute, modelAccess, prospectiveCodingPlan }` to `{ usageRoute, prospectiveRoute }`
- preserve completed-route precedence while mapping both completed and prospective routes through `codingPlanForUsageRoute`, with the existing ChatGPT special case
- pass the full route from `activeSubscriptionUsageRoute` into quota selection without collapsing it into a provider hint
- cover completed-route precedence and prospective ChatGPT, coding-plan, and unsupported quota routes

## Tests

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/StatusBar.vitest.ts` (95 passed)
- changed-file Prettier and ESLint
- `corepack pnpm run typecheck:cli`
- `corepack pnpm run typecheck:test-kernel`
- `git diff --check`

Closes #11141
