### PR TITLE
Expose reliability settings in CLI config

### DIFF
--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -515,14 +515,24 @@ const CORE_SETTING_ROWS: Record<CoreSettingPath, CoreRowSpec> = {
   'model.compactionThresholdPercent': {
     title: 'Compaction threshold',
     category: 'model',
-    honoredBy: everyHost('src/agent/modelHandlers/ModelHandler.ts'),
-    surfaces: { settingsView: 'multi-agent' },
+    honoredBy: everyHost('src/agent/modelHandlers/ModelHandler.ts', {
+      command:
+        'texra agents run <tool-use-agent> --instruction "answer a short question"',
+      through:
+        'packages/cli/src/commands/agentsRun.ts -> packages/cli/src/runtime/runExecution.ts -> src/agent/runtime/ModelFactory.ts -> src/agent/modelHandlers/ModelHandler.ts',
+    }),
+    surfaces: { settingsView: 'multi-agent', cliConfig: true },
   },
   'model.retry.maxAttempts': {
     title: 'Automatic retries',
     category: 'model',
-    honoredBy: everyHost('src/agent/core/flows/ModelInvocationNode.ts'),
-    surfaces: { settingsView: 'multi-agent' },
+    honoredBy: everyHost('src/agent/core/flows/ModelInvocationNode.ts', {
+      command:
+        'texra agents run <tool-use-agent> --instruction "answer a short question"',
+      through:
+        'packages/cli/src/commands/agentsRun.ts -> packages/cli/src/runtime/runExecution.ts -> src/agent/implementations/flows/tooluse/ToolUseRoundFlow.ts -> src/agent/core/flows/ModelInvocationNode.ts',
+    }),
+    surfaces: { settingsView: 'multi-agent', cliConfig: true },
   },
   // Thin provider modules own the public prefer-switch surface; the shared
   // factory in subscriptionPreference.ts is not a separate consumer key.

--- a/src/test-kernel/cli/ConfigForm.vitest.ts
+++ b/src/test-kernel/cli/ConfigForm.vitest.ts
@@ -258,6 +258,8 @@ describe('ConfigForm helpers', () => {
     [WorkspaceStateKey.GIT_AUTHOR_NAME, 'string'],
     [WorkspaceStateKey.LATEX_FORMATTER, 'enum'],
     [GlobalStateKey.DISABLED_TOOLS, 'form'],
+    ['texra.model.compactionThresholdPercent', 'number'],
+    ['texra.model.retry.maxAttempts', 'number'],
     [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS, 'number'],
   ])('classifies %s as a %s edit kind', (key, kind) => {
     expect(settingEditKind(entryByKey(key))).toBe(kind);

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -433,6 +433,8 @@ describe('state settings catalog', () => {
     //    chat TUI stops the root run (Ctrl-C) or kills a subagent execution.
     //  - allow-orchestrator-kill is read by ExecutionsTool when an
     //    orchestrator asks to kill one of its own child executions.
+    //  - compaction threshold and retry attempts are read by the shared model
+    //    handler and invocation node used by headless CLI runs.
     // auto-open-pdf (no CLI opener), latexdiff, and the formatter are
     // intentionally excluded. Changing the CLI roster must be a deliberate edit
     // here, not an accident of flipping `honoredBy.cli` or `surfaces.cliConfig`.
@@ -468,6 +470,8 @@ describe('state settings catalog', () => {
         GlobalStateKey.GLM_CODING_PLAN,
         GlobalStateKey.DISABLED_TOOLS,
         AGENT_SKILLS_CONFIG_KEY,
+        MODEL_COMPACTION_THRESHOLD_SETTING.configKey,
+        MODEL_RETRY_MAX_ATTEMPTS_SETTING.configKey,
         TEXRA_APPROVAL_POLICY_CONFIG_KEY,
       ].sort(),
     );


### PR DESCRIPTION
## Summary
- expose `texra.model.compactionThresholdPercent` in CLI `/config`
- expose `texra.model.retry.maxAttempts` in CLI `/config`
- document and guard their headless CLI runtime reachability

## Tests
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/shared/stateSettings.vitest.ts src/test-kernel/cli/ConfigForm.vitest.ts`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- `corepack pnpm run typecheck:cli`
- `corepack pnpm exec prettier --check src/shared/schemas/stateSettings.ts src/test-kernel/shared/stateSettings.vitest.ts src/test-kernel/cli/ConfigForm.vitest.ts`
- `git diff --check`

Closes #11128