### PR TITLE
refactor: dedupe replacement-layer rules and runtime restart-repair guards

### DIFF
--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -529,6 +529,18 @@ export class SessionHandle {
     return this.restartRepairPromise;
   }
 
+  /**
+   * Whether a repair pass started for `generation` may no longer mutate: a
+   * later storage generation owns the stores, or session teardown aborted
+   * repair. Both reads are pure, so every checkpoint below re-reads them.
+   */
+  private isRepairSuperseded(generation: number): boolean {
+    return (
+      generation !== this.storageGeneration ||
+      this.restartRepairAbort.signal.aborted
+    );
+  }
+
   private async repairStoresAfterRestart(
     generation: number,
     reloadTranscripts = false,
@@ -547,12 +559,7 @@ export class SessionHandle {
       }
       if (generation !== this.storageGeneration) return false;
       await this.snapshots.preload([...this.computeStartupSeedSet()]);
-      if (
-        generation !== this.storageGeneration ||
-        this.restartRepairAbort.signal.aborted
-      ) {
-        return false;
-      }
+      if (this.isRepairSuperseded(generation)) return false;
       this.markUnfinishedStreamsRunning();
       await this.runRestartRepair(generation);
       return true;
@@ -577,12 +584,7 @@ export class SessionHandle {
         flushError,
       );
     }
-    if (
-      generation !== this.storageGeneration ||
-      this.restartRepairAbort.signal.aborted
-    ) {
-      return false;
-    }
+    if (this.isRepairSuperseded(generation)) return false;
     const storage = platform().storage;
     const storageRootChanged = storage.commitWorkspaceStorageChange?.(
       transitionHooks && { workspacePath: transitionHooks.workspacePath },
@@ -707,12 +709,7 @@ export class SessionHandle {
   }
 
   private async runRestartRepair(generation: number): Promise<void> {
-    if (
-      generation !== this.storageGeneration ||
-      this.restartRepairAbort.signal.aborted
-    ) {
-      return;
-    }
+    if (this.isRepairSuperseded(generation)) return;
     // Resident snapshot records already resolved their execution id from the
     // sidecar when they were seeded, so skip the disk read for them — the
     // bounded-startup invariant keeps settled history lazy (#9947). Only
@@ -794,12 +791,7 @@ export class SessionHandle {
           ),
       );
     }
-    if (
-      generation !== this.storageGeneration ||
-      this.restartRepairAbort.signal.aborted
-    ) {
-      return;
-    }
+    if (this.isRepairSuperseded(generation)) return;
 
     // Parked WAITING streams were deliberately left out of the bounded
     // startup seed, so hydrate their usage now — before repair publishes their
@@ -825,12 +817,7 @@ export class SessionHandle {
       },
       { concurrency: RESTART_REPAIR_IO_CONCURRENCY },
     );
-    if (
-      generation !== this.storageGeneration ||
-      this.restartRepairAbort.signal.aborted
-    ) {
-      return;
-    }
+    if (this.isRepairSuperseded(generation)) return;
 
     // The ownership scan, resumability detection, and usage preload are all
     // async. Refresh resident ownership once here so the map is current, then

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -12,7 +12,6 @@ import { withEventErrorHandling } from '@controllers/session/eventErrorHandling'
 import {
   STREAM_PHASE,
   isGoalInFlight,
-  type ConversationProgress,
   type SetActiveStreamPayload,
   type SetParentStreamPayload,
   type StreamPhase,

--- a/src/replacement/helpers.ts
+++ b/src/replacement/helpers.ts
@@ -50,14 +50,14 @@ export function generateXmlLatexConversions(
     // XML with end to LaTeX
     [`<end{${env}}>`, `\\end{${env}}`],
     [`</end{${env}}>`, `\\end{${env}}`],
-    // XML with braces to LaTeX
+    // XML with braces to LaTeX. Newline-suffixed spellings (`</env}\n`,
+    // `</begin{env}\n`) need no entry of their own: the entries below run
+    // first, rewrite the tag, and leave the trailing newline untouched.
     [`<${env}}`, `\\begin{${env}}`],
     [`</${env}}`, `\\end{${env}}`],
     [`</${env}\n`, `\\end{${env}}\n`],
-    [`</${env}}\n`, `\\end{${env}}\n`],
     // XML begin tags incorrectly closed with leading slash
     [`</begin{${env}}`, `\\begin{${env}}`],
-    [`</begin{${env}}\n`, `\\begin{${env}}\n`],
     [`</begin{${env}`, `\\begin{${env}}`],
     // LaTeX with incorrect XML ending
     [`\\end{${env}>}`, `\\end{${env}}`],

--- a/src/replacement/maxRules.ts
+++ b/src/replacement/maxRules.ts
@@ -368,8 +368,8 @@ const MAX_MANUAL_PATTERNS: Record<string, string> = {
   '\\boldsymbol{1}': '\\bone',
   '\\mathrm{d}': '\\dd',
 
-  // Fix specific cases
-  '\\boldsymbol{\\Sigma}': '\\bSig',
+  // Fix specific cases ('\boldsymbol{\Sigma}' is already generated above by the
+  // bold-Greek shortcuts, with the same destination).
   '\\bSigma': '\\bSig',
 
   // Special case for 'f' which uses 'bbf' instead of 'bf'

--- a/src/replacement/rules.ts
+++ b/src/replacement/rules.ts
@@ -27,8 +27,8 @@ export const CHARACTER_REPLACEMENTS: NonRegexReplacementCategory = {
     ansätze: 'ans{\\"a}tze',
     Rényi: "R{\\'e}nyi",
     Schrödinger: 'Schr{\\"o}dinger',
+    // Covers the plural too: the singular rewrite leaves the trailing 's'.
     'Schr{\\\\`o}dinger': 'Schr{\\"o}dinger',
-    'Schr{\\\\`o}dingers': 'Schr{\\"o}dingers',
   },
 };
 
@@ -211,8 +211,8 @@ export const GPTNESS_REPLACEMENTS: NonRegexReplacementCategory = {
     disseminates: 'distributes',
     disseminated: 'distributed',
     disseminating: 'distributing',
-    dissemination: 'distribution',
-    disseminations: 'distributions',
+    dissemination: 'distribution', // also covers the plural
+
     parsimonious: 'simple',
     embark: 'start',
     realm: 'area',
@@ -498,9 +498,9 @@ export const LATEX_XML_REPLACEMENTS: NonRegexReplacementCategory = {
       ]),
 
       // ===== 3. Special Case Handling =====
-      // Special cases for minipage
+      // Special cases for minipage. The literal `\n`-prefixed spelling needs no
+      // entry of its own: this rule rewrites the tag and leaves the prefix.
       '\\minipage}': '\\end{minipage}',
-      '\\n\\minipage}': '\\n\\end{minipage}',
 
       // Special case for item tag
       '<item>': '\\item',
@@ -592,17 +592,13 @@ export const PERSONAL_STYLE_REPLACEMENTS: NonRegexReplacementCategory = {
     'In~\\cref{': 'In \\cref{',
     'in~Sec': 'in Sec',
     'In~Sec': 'In Sec',
+    // The bare 'Eq' forms also cover 'Eqs'/'Eqs.': only the tilde is rewritten,
+    // so the trailing characters are carried through untouched.
     'by~Eq': 'by Eq',
-    'by~Eqs': 'by Eqs',
-    'by~Eqs.': 'by Eqs.',
     'see~Sec': 'see Sec',
     'See~Sec': 'See Sec',
     'from~Eq': 'from Eq',
     'From~Eq': 'From Eq',
-    'from~Eqs': 'from Eqs',
-    'From~Eqs': 'From Eqs',
-    'from~Eqs.': 'from Eqs.',
-    'From~Eqs.': 'From Eqs.',
     'cf.~Eq': 'cf. Eq',
     'to~App': 'to App',
     '~(\\ref{': ' (\\ref{',

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -367,7 +367,10 @@ export const EQUATION_STYLE_REPLACEMENTS: RegexReplacementCategory = {
     // Unescape underscores in reference commands. LaTeX label names don't
     // require escaped underscores. Matches the whole \ref{...}/\cref{...}/
     // \eqref{...} span and strips every escaped underscore inside it in one
-    // pass, so references with more than one underscore are fully fixed.
+    // pass, so references with more than one underscore are fully fixed. The
+    // body must be brace-free to match, so a label containing a raw `{`
+    // (never legitimate LaTeX) is left untouched rather than partially
+    // fixed.
     '\\\\(cref|ref|eqref)\\{([^{}]*)\\}': (match, cmd, content) =>
       `\\${cmd ?? ''}{${(content ?? '').replaceAll('\\_', '_')}}`,
 

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -364,20 +364,12 @@ export const EQUATION_STYLE_REPLACEMENTS: RegexReplacementCategory = {
     '([Aa]ppendix|[Pp]roblem|[Ss]olution|[Cc]hapter|[Aa]lgorithm|[Ff]igure|[Tt]able|[Ss]ection|[Ee]quation|[Ll]emma|[Cc]orollary|[Pp]roposition|[Tt]heorem|[Ee]qns\\.|[Ee]q\\.)~?\\s*\\ref':
       '$1~\\ref',
 
-    // Unescape underscores in reference commands
-    // LaTeX references (label names) don't require escaped underscores
-    // We use multiple unique patterns (with subtle regex variations) to handle multiple underscores
-    // Each pattern is applied sequentially, allowing iterative replacement
-    // Pass 1: Using non-greedy match
-    '(\\\\(?:cref|ref|eqref)\\{[^{}]*?)\\\\(_)': '$1$2',
-    // Pass 2: Using character class for 'r'
-    '(\\\\(?:c[r]ef|ref|eq[r]ef)\\{[^{}]*?)\\\\(_)': '$1$2',
-    // Pass 3: Using character class for 'e'
-    '(\\\\(?:cr[e]f|r[e]f|eqr[e]f)\\{[^{}]*?)\\\\(_)': '$1$2',
-    // Pass 4: Using character class for 'f'
-    '(\\\\(?:cre[f]|re[f]|eqre[f])\\{[^{}]*?)\\\\(_)': '$1$2',
-    // Pass 5: Using redundant grouping
-    '(\\\\(?:(?:cref)|(?:ref)|(?:eqref))\\{[^{}]*?)\\\\(_)': '$1$2',
+    // Unescape underscores in reference commands. LaTeX label names don't
+    // require escaped underscores. Matches the whole \ref{...}/\cref{...}/
+    // \eqref{...} span and strips every escaped underscore inside it in one
+    // pass, so references with more than one underscore are fully fixed.
+    '\\\\(cref|ref|eqref)\\{([^{}]*)\\}': (match, cmd, content) =>
+      `\\${cmd ?? ''}{${(content ?? '').replaceAll('\\_', '_')}}`,
 
     // Normalize blank lines immediately after equation environments begin
     [`\\\\begin\\{(${EQUATION_ENVIRONMENT_PATTERN})\\}([ \t]*\\r?\\n)(?:[ \t]*\\r?\\n)+`]:


### PR DESCRIPTION
## Summary

Follow-up to a codebase-wide tech-debt audit that flagged the largest areas of ad hoc/duplicated implementation (model handlers, transcript stores, cross-host settings/progress wiring, agent runtime, LaTeX replacement rules). This PR lands the subset that could be verified as behavior-preserving without live multi-provider or multi-host testing; the higher-risk areas are deliberately deferred (see "Scheduled refactoring").

Four independent, individually-verified changes:

1. **Replacement engine — ref-underscore unescape** (`src/replacement/rulesRegex.ts`): five near-identical regex passes existed only because object keys must be textually distinct — each pass was a copy of the same "unescape `\_` inside `\ref{...}`" logic, applied five times sequentially so multi-underscore references got fully fixed. Replaced with one pattern matching the whole `\ref{...}`/`\cref{...}`/`\eqref{...}` span and unescaping every underscore inside it in a single callback. Documented boundary (flagged by review, see below): the body must now be brace-free to match, so a label containing a raw `{` (never valid LaTeX) is left untouched rather than partially fixed — the old version was itself inconsistent here, only reaching an escaped underscore that happened to precede a nested brace, not one after it.
2. **Replacement engine — dead longer-suffix entries** (`src/replacement/helpers.ts`, `rules.ts`, `maxRules.ts`): these `NonRegexReplacementCategory` tables apply as sequential `.replaceAll` passes over one merged object, iterated in insertion order. Where a shorter key already precedes a longer key that is its textual superset (e.g. `by~Eq` before `by~Eqs.`), the shorter pass consumes the match first and leaves the remainder untouched — the longer entry can never see its own match text. Removed 12 such dead entries: 2 template-level entries in `generateXmlLatexConversions` (cascading to −120 runtime map entries across 60 environments), 9 individual entries across `CHARACTER_REPLACEMENTS`/`GPTNESS_REPLACEMENTS`/`LATEX_XML_REPLACEMENTS`/`PERSONAL_STYLE_REPLACEMENTS`, plus 1 manual pattern in `maxRules.ts` that a generator already produces identically.
3. **Agent runtime — restart-repair guard dedup** (`src/agent/runtime/SessionHandle.ts`): five call sites re-typed the identical `generation !== this.storageGeneration || abort.signal.aborted` guard; extracted to a private `isRepairSuperseded(generation)` predicate (both operands are pure property reads, so evaluation order and each site's own return value are unchanged).
4. **Dead import removal** (`src/controllers/session/SessionFactApplier.ts`): unused type-only `ConversationProgress` import.

## Issue acceptance gates

No linked issue — this is a proactive tech-debt cleanup from a scheduled audit. Self-imposed gate: every change ships with a proof of behavioral equivalence (see Validation), not just a plausible-looking diff.

## Single source of truth

- `isRepairSuperseded` is now the single definition of "this restart-repair pass may no longer mutate state" in `SessionHandle`.
- The ref-underscore unescape rule for reference commands has one definition instead of five copies standing in for a fixpoint loop.

## Duplication and abstraction budget

Removed duplication; added no new abstractions beyond the one private predicate method (`isRepairSuperseded`), which has 5 call sites (well above the 2-site threshold) and owns a real invariant (repair supersession), not a pass-through.

## Net elements (R6)

- Files touched: 6 (diffstat: `+38 / -62`, net **−24 LoC**)
- Exported symbols: 0 added, 0 removed (`git diff main...HEAD | grep -E '^[+-]export'` → empty)
- Classes/interfaces/enums: 0 added, 0 removed
- New symbols: 1 private method (`SessionHandle.isRepairSuperseded`)

## Consumer counts (R8)

n/a — no emit path, export, or public API was deleted or re-routed. All changes are internal to the modules they live in (private method extraction, dead literal-table entries, redundant regex passes).

## Host impact

Extension: none (no code in `packages/extension` touched).

Desktop: none (no code in `packages/desktop` touched).

CLI: none (no code in `packages/cli` touched).

## Scheduled refactoring

The originating audit found four larger areas that were investigated but deliberately **not** attempted in this PR, each for a specific, verified reason rather than just effort:

- **Cross-host settings/progress-view consolidation** (`packages/extension/src/settingsView/`, `packages/desktop/src/main/desktopAgentSettingsController.ts`, and the progress-view command-handler wiring): confirmed real duplication (both hosts independently orchestrate `applyTeamRosterWithPreflight` with near-identical status branching), but the two handlers differ in notification severity (error vs. info dialogs), exact user-facing copy, and post-apply refresh mechanics per host — unifying them safely needs live UI verification in both the VS Code extension host and Electron, which this environment cannot drive.
- **Twin stream-stores** (`StreamSnapshotStore.ts`/`StreamLogStore.ts`) and their eager-overlay/seed-replay machinery: touches crash-safety and staged-deletion invariants; the highest-risk area identified by the audit.
- **Model-handler phase-pipeline template** (`src/agent/modelHandlers/`): would need a base Template Method spanning all four provider handlers' retry/compaction state machines — needs live multi-provider testing to validate the retry and staleness invariants.
- **`PARENTHESES_REPLACEMENTS` and the `\DIFdel`/`\DIFadd` latexdiff tables** (`src/replacement/rulesRegex.ts`): both looked like clean cross-products at first glance but hide real asymmetries on close inspection — inconsistent brace escaping between symmetric/asymmetric delimiter groups, and `\DIFadd` covering only 6 of `\DIFdel`'s 9 sub-patterns. A generator would either have to special-case the asymmetry (losing most of the LOC benefit) or silently normalize it into a behavior change. Left as literal data.

No follow-up issue filed yet; flagging here per the audit for whoever picks these up next.

## Validation

- `npm run typecheck` (all workspaces: root, cli, desktop, extension, trace-viewer) — clean, run after each commit.
- `npx vitest run src/test-kernel/replacement/` — 68/68 passing (includes the multi-underscore reference test that exercises change #1).
- `npx vitest run src/test-kernel/agent/runtime src/test-kernel/agent/storage src/test-kernel/controllers/session` — 647/647 passing (covers `SessionRestartRepair`, `RestartRepair`, `SessionWaitingRepair`, `SessionHandle`, `ChildRunLoop`, `ExecutionRegistry` suites for change #3).
- `npx eslint` on every changed file — clean.
- Every "dead entry" removal in change #2 was verified empirically before deletion: a throwaway vitest case exercised the removed entry's original input directly through `applyReplacements`, confirming byte-identical output against the surviving shorter entry, then the scratch test was deleted. The `helpers.ts`/`rules.ts` batch additionally got a differential probe run (21,933 inputs — every old key/value plus adjacency framings) comparing the old and new merged pattern sequences: 0 mismatches.
- Two independent automated reviews (`claude[bot]`, `texra-ai[bot]`) verified every claim against the actual application semantics; the second caught a real narrow edge case (see change #1) and a description count error, both addressed in follow-up commits.
- No new persistent tests added, per this repo's default-zero-new-tests discipline for behavior-preserving refactors.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SMFQ9sMZuGz1Vt7V6RoptP)_