### PR TITLE
fix(arch): close VS Code-free-zone gap for src/common and src/utils

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,8 @@ repo and the first thing to check on any diff.
 **VS Code-free zones** — must NOT import `vscode`:
 `src/agent/`, `src/model/`, `src/latex/`, `src/tools/`, `src/controllers/`,
 `src/shared/`, `src/replacement/`, `src/eventBus/`, `src/hosts/`,
-`src/common/`, `src/utils/`, and the webview frontends —
-`packages/extension/src/webview/frontend/`,
+`src/common/`, `src/utils/`, `packages/agent/src/`, and the webview
+frontends — `packages/extension/src/webview/frontend/`,
 `packages/extension/src/progressView/frontend/`, and
 `packages/extension/src/settingsView/frontend/`. Do not confuse
 `src/common/` and `src/utils/` (repo-root, host-neutral, enforced VS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,19 +81,28 @@ repo and the first thing to check on any diff.
 
 **VS Code-free zones** — must NOT import `vscode`:
 `src/agent/`, `src/model/`, `src/latex/`, `src/tools/`, `src/controllers/`,
-`src/shared/`, `src/replacement/`, `src/eventBus/`, `src/hosts/`, and the
-webview frontends — `packages/extension/src/webview/frontend/`,
+`src/shared/`, `src/replacement/`, `src/eventBus/`, `src/hosts/`,
+`src/common/`, `src/utils/`, and the webview frontends —
+`packages/extension/src/webview/frontend/`,
 `packages/extension/src/progressView/frontend/`, and
-`packages/extension/src/settingsView/frontend/`. Do not confuse these with
-`packages/extension/src/frontend/` (no view-name segment), which is the
-top-level extension-host frontend below and is VS Code-allowed.
+`packages/extension/src/settingsView/frontend/`. Do not confuse
+`src/common/` and `src/utils/` (repo-root, host-neutral, enforced VS
+Code-free) with `packages/extension/src/common/` below (extension-only,
+VS Code-allowed), or `packages/extension/src/frontend/` (no view-name
+segment, the top-level extension-host frontend, VS Code-allowed) with the
+VS Code-free webview frontends above. This list is enforced by
+`VSCODE_FREE_ZONE_DIRS` in `eslint.config.mjs` and mirrored in
+`src/test-kernel/architecture/dependencyDirection.vitest.ts` — keep both in
+sync with this list and with each other.
 
 **VS Code-allowed zones** — platform wiring belongs here:
 `packages/extension/src/extension.ts` (calls `initPlatform()` exactly once),
 `packages/extension/src/commands/`, `packages/extension/src/frontend/`,
 `packages/extension/src/common/`, `src/platform/` interface definitions, and
-`src/auth/`. Code under `src/utils/` remains host-agnostic; do not add `vscode`
-imports there merely because a utility is not browser-reachable.
+`src/auth/`. Within `src/utils/`, a browser-reachable module additionally
+stays free of Node built-ins — see the browser-safe note above; that is a
+stricter constraint layered on top of the VS Code-free rule, not a
+substitute for it.
 
 Reach host services through `platform()` from `@platform/platform` (config,
 state, log, fs, workspace, storage, secrets). When agnostic code needs a

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -67,6 +67,8 @@ const VSCODE_FREE_ZONE_DIRS = [
   'src/replacement',
   'src/eventBus',
   'src/hosts',
+  'src/common',
+  'src/utils',
   'packages/agent/src',
   'packages/extension/src/webview/frontend',
   'packages/extension/src/progressView/frontend',

--- a/src/test-kernel/architecture/dependencyDirection.vitest.ts
+++ b/src/test-kernel/architecture/dependencyDirection.vitest.ts
@@ -35,6 +35,8 @@ const VSCODE_FREE_ZONES = [
   'src/replacement',
   'src/eventBus',
   'src/hosts',
+  'src/common',
+  'src/utils',
   'packages/agent/src',
   'packages/extension/src/webview/frontend',
   'packages/extension/src/progressView/frontend',


### PR DESCRIPTION
## Summary

A scheduled structural-debt audit of the repo (using this repo's `debt-audit` workflow) looked for confusing or overlapped responsibilities across modules. Most seams checked out healthy — `src/model` vs `src/agent/modelHandlers`, session/execution registries, the extension IPC/controller split, and the three webview message-dispatch stacks are all genuinely single-owner. The one confirmed, on-target finding was a **single-source-of-truth gap in the "VS Code-free zone" invariant**:

- The zone list is independently declared in three places: `eslint.config.mjs` (`VSCODE_FREE_ZONE_DIRS`, the enforced lint rule), `src/test-kernel/architecture/dependencyDirection.vitest.ts` (`VSCODE_FREE_ZONES`, a belt-and-braces test that can't be bypassed by a stray `eslint-disable`), and `CLAUDE.md`'s prose list.
- `AGENTS.md` documents `src/common/` (line 131: "host-neutral, cross-cutting logic") and `src/utils/` (line 135: "host-agnostic utilities") as belonging to this invariant, and `CLAUDE.md` even said as much in a stray sentence — but neither directory was actually present in any of the three enforcement/documentation lists.
- Net effect: a stray `import 'vscode'` landing in `src/common/` or `src/utils/` today would pass lint *and* the architecture test, surfacing only as a CLI/desktop build or runtime failure. That's exactly the silent-degradation class of gap `CLAUDE.md`'s own "Error discipline" guardrail warns against.

This PR closes the gap rather than restructuring the (intentionally duplicated, for independent-enforcement reasons) list mechanism itself.

## Issue acceptance gates

No filed issue — this is the output of a scheduled codebase-responsibility audit. Acceptance gate (self-imposed): `src/common/` and `src/utils/` are enforced VS Code-free by both the lint rule and the architecture test, and the two enforcement lists plus `CLAUDE.md`'s prose stay mutually consistent.

## Single source of truth

`eslint.config.mjs`'s `VSCODE_FREE_ZONE_DIRS` remains the canonical enforced list (per `src/README.md`, which already deferred to it rather than restating it). `dependencyDirection.vitest.ts`'s `VSCODE_FREE_ZONES` is a deliberate independent second gate (documented in its own file header) — not merged into one shared module, since collapsing lint-time and test-time enforcement into a single import would remove the "an `eslint-disable` can't bypass the test too" property that's the entire point of the duplication. `CLAUDE.md` now names both files explicitly and asks future edits to keep them in sync with each other.

## Duplication and abstraction budget

No new abstraction added. Two existing parallel arrays gained two entries each (4 lines total); `CLAUDE.md` prose was corrected to match reality and cross-reference both enforcement points. Zero pass-through layers introduced.

## Net elements (R6)

+4 LoC across two array literals, ~13 net lines of corrected/expanded prose in `CLAUDE.md`. No new files, exports, classes, or interfaces.

## Consumer counts (R8)

n/a — no emit path, export, or public symbol was deleted or re-routed.

## Host impact

Extension: none (config/test/doc only; `packages/extension/src/common/` — the extension-only, VS Code-*allowed* directory — is unaffected and now explicitly disambiguated from repo-root `src/common/` in `CLAUDE.md`).

Desktop: none.

CLI: none.

## Scheduled refactoring

None — verified zero existing `vscode` imports in `src/common/` and `src/utils/` (`grep -rn "from 'vscode'|require('vscode')|import \* as vscode" src/common src/utils` → no hits), so this is a pure gap-closing change with no follow-up cleanup required.

## Validation

- `npx eslint src/common src/utils --max-warnings=0` → clean (confirms no existing violations under the newly-added rule).
- `npx eslint eslint.config.mjs src/test-kernel/architecture/dependencyDirection.vitest.ts` → clean.
- `npx vitest run src/test-kernel/architecture/dependencyDirection.vitest.ts` → 21/21 passed.
- `npx vitest run src/test-kernel/architecture` (full architecture suite) → 106/106 passed.
- `node scripts/check-browser-safe-utils.mjs` → drift guard OK (unaffected by this change, confirms the adjacent browser-safety invariant is unrelated and still correct).
- `npm run typecheck` (workspace + test-kernel + agent + cli + trace-viewer + desktop) → all clean.
- `npx prettier --check CLAUDE.md eslint.config.mjs src/test-kernel/architecture/dependencyDirection.vitest.ts` → all formatted correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BPMjfxnVhkq5rnTMcHqoGH)_