### PR TITLE
fix(auth): allow Antigravity IDE OAuth callback

### DIFF
--- a/supabase/functions/auth-bridge/index.ts
+++ b/supabase/functions/auth-bridge/index.ts
@@ -247,7 +247,8 @@ function bridgePageHtml(ext: string, id: string): string {
     'codium': 'VSCodium',
     'trae': 'Trae',
     'positron': 'Positron',
-    'pearai': 'PearAI'
+    'pearai': 'PearAI',
+    'antigravity-ide': 'Antigravity IDE'
   };
 
   // PKCE puts the one-time code (and any error) in the query string; read

--- a/supabase/functions/auth-bridge/index.ts
+++ b/supabase/functions/auth-bridge/index.ts
@@ -56,6 +56,8 @@ const ALLOWED_EXT_SCHEMES = [
   'trae',
   'positron',
   'pearai',
+  // Verified from Antigravity IDE 2.5.5's macOS bundle URL declaration.
+  'antigravity-ide',
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary

Allow the verified `antigravity-ide` URI scheme in the auth-bridge deep-link allowlist. Antigravity IDE 2.5.5 is a VS Code OSS fork and declares this custom scheme in its macOS bundle, so the bridge can now return its PKCE callback to `antigravity-ide://texra-ai.<extension>/auth-callback`.

This remains a fixed allowlist; unrecognized schemes are still rejected. The newer Antigravity 2.0 application declares a distinct `antigravity` scheme and is deliberately out of scope until its VS Code-style callback contract is confirmed.

## Validation

- `corepack pnpm exec prettier --check supabase/functions/auth-bridge/index.ts`
- `git diff --check`