### PR TITLE
test(cli): restore transcript media ordering check

### DIFF
--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
@@ -925,7 +925,7 @@ describe('CLI workflow-script child-stream transcript', () => {
     ]);
     expect(entryIds(coldItems)).toEqual(entryIds(incrementalItems));
     const output = await renderStaticTranscript();
-    expect(output.indexOf('[image] /private/tmp/loaded.png')).toBeLessThan(
+    expect(output.indexOf('/private/tmp/loaded.png')).toBeLessThan(
       output.indexOf('bash'),
     );
   });


### PR DESCRIPTION
Closes #10958.

The media row renderer now produces `✓ <path> [image, …]`; the prior assertion searched for the obsolete `[image] <path>` form, yielding `-1` and passing vacuously. Assert on the stable rendered path instead, preserving the media-before-tool ordering contract.

Validation: `corepack pnpm vitest run src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts`.