### PR TITLE
fix(openai): handle websocket handshake auth errors

### DIFF
--- a/src/agent/modelHandlers/openai/OpenAIResponseWebSocketTransport.ts
+++ b/src/agent/modelHandlers/openai/OpenAIResponseWebSocketTransport.ts
@@ -12,6 +12,7 @@ import { ResponsesWS } from 'openai/resources/responses/ws';
 import { WebSocketError } from 'openai/resources/responses/internal-base';
 
 import type { AgentTrace } from '@agent/trace';
+import { detectStatusCode } from '@common/errors/sdkError/errorInspection';
 import {
   attachPartialText,
   attachSdkErrorMetadata,
@@ -20,6 +21,7 @@ import {
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkError/errorPatterns';
+import { sdkErrorKindFromStatusCode } from '@common/errors/sdkError/sdkErrorKinds';
 
 import { wrapResponseError } from './openAIResponseErrors';
 import { ResponseStreamProcessor } from './ResponseStreamProcessor';
@@ -42,6 +44,26 @@ const WS_MAX_AGE_MS = 55 * 60 * 1000;
 const WS_KEEPALIVE_INTERVAL_MS = 30_000;
 /** WebSocket readyState value for an open connection. */
 const WS_OPEN = 1;
+
+/** Recover an HTTP status from the narrow error shape emitted by `ws` when an
+ *  upgrade is rejected. Structured SDK fields take precedence; the message
+ *  fallback accepts only `ws`'s complete canonical text. */
+function detectHandshakeStatusCode(error: Error): number | undefined {
+  const structuredStatusCode = detectStatusCode(error);
+  if (
+    structuredStatusCode !== undefined &&
+    structuredStatusCode >= 400 &&
+    structuredStatusCode <= 599
+  ) {
+    return structuredStatusCode;
+  }
+
+  const match = /^Unexpected server response: ([0-9]{3})$/.exec(error.message);
+  if (!match) return undefined;
+
+  const statusCode = Number(match[1]);
+  return statusCode >= 400 && statusCode <= 599 ? statusCode : undefined;
+}
 
 /** Close a socket during cleanup; an already-closed socket must not mask the original failure path. */
 function closeQuietly(connection: ResponsesWS): void {
@@ -134,6 +156,21 @@ export class OpenAIResponseWebSocketTransport {
 
     this.logger.debug('Opening WebSocket connection to Responses API');
     const ws = new ResponsesWS(client);
+    // The SDK forwards raw socket failures through this top-level emitter before
+    // our raw handshake listener runs. Bind the persistent guard immediately so
+    // a rejected HTTP upgrade cannot take the SDK's unhandled-rejection path.
+    // Capturing `ws` also prevents a late orphan error from invalidating a newer
+    // connection. During a request, its listener owns settlement and this guard
+    // deliberately stays passive.
+    ws.on('error', (error) => {
+      if (this.wsConnection !== ws || this.activeRequestSocket === ws) {
+        return;
+      }
+      this.logger.debug('WebSocket connection error: invalidating', {
+        data: { message: error.message },
+      });
+      this.closeWebSocket();
+    });
 
     // Wait for the socket to open, fail on error, or abort on signal.
     // If the handshake fails or is aborted, close the orphaned socket
@@ -144,25 +181,44 @@ export class OpenAIResponseWebSocketTransport {
         return;
       }
 
+      let settled = false;
       const cleanup = (): void => {
         ws.socket.off('open', onOpen);
         ws.socket.off('error', onError);
+        ws.off('error', onTopLevelError);
         signal?.removeEventListener('abort', onAbort);
       };
       const onOpen = (): void => {
+        if (settled) return;
+        settled = true;
         cleanup();
         resolve();
       };
-      const onError = (err: Error): void => {
+      const failHandshake = (err: Error): void => {
+        if (settled) return;
+        settled = true;
         cleanup();
         closeQuietly(ws);
+        const statusCode = detectHandshakeStatusCode(err);
         attachSdkErrorMetadata(err, {
           provider: 'openai',
-          kind: 'connection',
+          kind:
+            statusCode === undefined
+              ? 'connection'
+              : sdkErrorKindFromStatusCode(statusCode),
+          ...(statusCode === undefined ? {} : { statusCode }),
         });
         reject(err);
       };
+      const onError = (err: Error): void => {
+        failHandshake(err);
+      };
+      const onTopLevelError = (err: WebSocketError): void => {
+        failHandshake(err.cause instanceof Error ? err.cause : err);
+      };
       const onAbort = (): void => {
+        if (settled) return;
+        settled = true;
         cleanup();
         closeQuietly(ws);
         reject(new DOMException('The operation was aborted', 'AbortError'));
@@ -170,24 +226,12 @@ export class OpenAIResponseWebSocketTransport {
 
       ws.socket.once('open', onOpen);
       ws.socket.once('error', onError);
+      ws.on('error', onTopLevelError);
       signal?.addEventListener('abort', onAbort, { once: true });
     });
 
     this.wsConnection = ws;
     this.wsConnectionCreatedAt = Date.now();
-    // The SDK rejects globally when an error has no listener, so every socket
-    // keeps this guard even after it leaves the pool. Capturing `ws` prevents a
-    // late orphan error from invalidating a newer connection. During a request,
-    // its listener owns settlement and this guard deliberately stays passive.
-    ws.on('error', (error) => {
-      if (this.wsConnection !== ws || this.activeRequestSocket === ws) {
-        return;
-      }
-      this.logger.debug('WebSocket connection error: invalidating', {
-        data: { message: error.message },
-      });
-      this.closeWebSocket();
-    });
     this.startWsKeepalive(ws);
 
     this.logger.debug('WebSocket connection established');

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseWebSocketTransport.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseWebSocketTransport.vitest.ts
@@ -37,6 +37,15 @@ class FakeResponsesWS extends EventEmitter {
   socket = new FakeSocket();
   send = vi.fn();
   close = vi.fn();
+
+  constructor() {
+    super();
+    this.socket.on('error', (cause: Error) => {
+      const error = new WebSocketError(cause.message, null);
+      error.cause = cause;
+      this.emit('error', error);
+    });
+  }
 }
 
 vi.mock('openai/resources/responses/ws', () => ({
@@ -96,14 +105,56 @@ describe('OpenAIResponseWebSocketTransport idle connection errors', () => {
     socketControl.nextReadyState = WS_OPEN;
   });
 
-  it('tags a failed handshake as a connection failure', async () => {
+  it('handles a forwarded 401 handshake error as non-retryable authentication', async () => {
     socketControl.nextReadyState = 0;
     const transport = createTransport();
     const connection = internals(transport).getOrCreateWebSocket(fakeClient);
     const ws = createdSockets[0]!;
-    const error = new Error('TLS handshake failed');
+    const error = new Error('Unexpected server response: 401');
+
+    // The SDK's raw-socket listener runs first and forwards the failure to the
+    // top-level emitter. The transport must already guard that emitter so this
+    // raw event still reaches its handshake listener instead of escaping.
+    expect(() => ws.socket.emit('error', error)).not.toThrow();
+
+    await expect(connection).rejects.toBe(error);
+    expect(detectSdkErrorMetadata(error)).toMatchObject({
+      kind: 'authentication',
+      statusCode: 401,
+    });
+    expect(normalizeProviderError(error)).toMatchObject({
+      statusCode: 401,
+      userRetryable: false,
+    });
+    expect(ws.close).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to the canonical response status when structured data is out of range', async () => {
+    socketControl.nextReadyState = 0;
+    const transport = createTransport();
+    const connection = internals(transport).getOrCreateWebSocket(fakeClient);
+    const ws = createdSockets[0]!;
+    const error = Object.assign(new Error('Unexpected server response: 401'), {
+      code: 1006,
+    });
 
     ws.socket.emit('error', error);
+
+    await expect(connection).rejects.toBe(error);
+    expect(detectSdkErrorMetadata(error)).toMatchObject({
+      kind: 'authentication',
+      statusCode: 401,
+    });
+  });
+
+  it('rejects when only the top-level emitter reports a handshake error', async () => {
+    socketControl.nextReadyState = 0;
+    const transport = createTransport();
+    const connection = internals(transport).getOrCreateWebSocket(fakeClient);
+    const ws = createdSockets[0]!;
+    const error = new WebSocketError('handshake failed', null);
+
+    ws.emit('error', error);
 
     await expect(connection).rejects.toBe(error);
     expect(detectSdkErrorMetadata(error)?.kind).toBe('connection');


### PR DESCRIPTION
## Summary
- attach the OpenAI Responses WebSocket top-level error guard before handshake/open events can forward a raw socket failure
- recover only the canonical `ws` HTTP-upgrade status message when no structured status is available
- classify HTTP 401 handshakes as authentication failures, not retryable connection failures

## Validation
- `corepack pnpm exec vitest run src/test-kernel/common/SdkErrorUtils.vitest.ts src/test-kernel/agent/modelHandlers/OpenAIResponseWebSocketTransport.vitest.ts src/test-kernel/progressView/RetryRequestPanel.vitest.ts` (76 tests)
- `corepack pnpm typecheck:workspace`
- `corepack pnpm typecheck:test-kernel`
- changed-file ESLint and Prettier checks

Fixes texra-ai/texra-issues#5.