### PR TITLE
fix(delegation): guard recursive lead delegation

### DIFF
--- a/src/agent/prompt/userVars.ts
+++ b/src/agent/prompt/userVars.ts
@@ -270,19 +270,13 @@ function getBasicVars(
   providerFlags: ModelProviderFlags,
   options: BuildUserVarsOptions,
 ): BasicVars {
-  // Filter out the current agent so it doesn't see itself as a delegation target
-  const selfName = agentConfig.agent;
   const scope = options.delegationAgentScope ?? undefined;
   const workflowAgentsList = formatAgentList(
-    getDelegationAgents(AgentCategory.Workflow, scope).filter(
-      (agent) => agent.name !== selfName,
-    ),
+    getDelegationAgents(AgentCategory.Workflow, scope),
     { tools: 'none', collapseDescriptionNewlines: false },
   );
   const toolUseAgentsList = formatAgentList(
-    getDelegationAgents(AgentCategory.ToolUse, scope).filter(
-      (agent) => agent.name !== selfName,
-    ),
+    getDelegationAgents(AgentCategory.ToolUse, scope),
     { tools: 'inline', collapseDescriptionNewlines: false },
   );
 

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -52,6 +52,7 @@ import type {
 } from '@shared/schemas';
 import {
   AgentCategory,
+  agentKeyOf,
   INSTRUCTION_ACTION,
   RUN_OUTCOME,
   STREAM_PHASE,
@@ -115,6 +116,8 @@ interface AgentLaunchInput {
   copilotRouteOverride?: CopilotRouteOverride;
   /** Cancel launch preparation and the resulting live run. */
   signal?: AbortSignal;
+  /** Whether persisted or fresh execution lineage marks this run as delegated. */
+  isSubagent?: boolean;
   /** Immutable per-run tool policy carried on the launch context for cycle flows. */
   toolPolicy?: ToolPolicy;
 }
@@ -482,24 +485,38 @@ async function assembleAgentLaunchContext(
     streamId,
     executionId,
     agentName: config.agent,
+    agentKey: agentKeyOf(resolution.entry),
+    isSubagent: input.isSubagent === true,
     workingDirectory,
     delegationAgentScope: fullConfig.delegationAgentScope,
     session,
     signal: runSignal,
   });
+  const toolPolicy = createToolPolicy(input.toolPolicy);
   const buildVars = () =>
-    buildUserVars(
-      config,
-      setting,
-      prompt,
-      agentPath,
-      {
-        isOpenai: modelHandler.config.provider === ModelProvider.OPENAI,
-        isAnthropic: modelHandler.config.provider === ModelProvider.ANTHROPIC,
-        isGoogle: modelHandler.config.provider === ModelProvider.GOOGLE,
-      },
-      agentLogger,
-      { delegationAgentScope: runScope.delegationAgentScope },
+    withRunContext(
+      createRunContext({
+        runScope,
+        modelCell,
+        approvalPromptsUnavailable: toolPolicy.approvalPromptsUnavailable,
+        runtimeUnavailableTools: toolPolicy.runtimeUnavailableTools,
+        stopAfterCycle: toolPolicy.stopAfterCycle,
+      }),
+      () =>
+        buildUserVars(
+          config,
+          setting,
+          prompt,
+          agentPath,
+          {
+            isOpenai: modelHandler.config.provider === ModelProvider.OPENAI,
+            isAnthropic:
+              modelHandler.config.provider === ModelProvider.ANTHROPIC,
+            isGoogle: modelHandler.config.provider === ModelProvider.GOOGLE,
+          },
+          agentLogger,
+          { delegationAgentScope: runScope.delegationAgentScope },
+        ),
     );
 
   const baseVars =
@@ -527,7 +544,7 @@ async function assembleAgentLaunchContext(
     setting,
     prompt,
     modelCell,
-    toolPolicy: createToolPolicy(input.toolPolicy),
+    toolPolicy,
     logger: agentLogger,
     parentStage,
     storageKey,

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -27,7 +27,13 @@ export interface LaunchRunContext extends RunContextCommon {
 type BareRunIdentity = Partial<
   Pick<
     RunScope,
-    'streamId' | 'executionId' | 'agentName' | 'workingDirectory' | 'session'
+    | 'streamId'
+    | 'executionId'
+    | 'agentName'
+    | 'agentKey'
+    | 'isSubagent'
+    | 'workingDirectory'
+    | 'session'
   >
 >;
 
@@ -129,6 +135,8 @@ export function createRunContext(options: CreateRunContextOptions): RunContext {
     streamId: options.streamId,
     executionId: options.executionId,
     agentName: options.agentName,
+    agentKey: options.agentKey,
+    isSubagent: options.isSubagent,
     workingDirectory: options.workingDirectory,
     session: options.session,
     get model() {

--- a/src/agent/runtime/RunScope.ts
+++ b/src/agent/runtime/RunScope.ts
@@ -16,8 +16,12 @@ import type { SessionHandle } from './SessionHandle';
 export interface RunScope {
   readonly streamId: StreamTabId;
   readonly executionId: ExecutionId;
-  /** Agent name (e.g. "orchestrator", "search-agent"). */
+  /** Launch identifier, retained for display and compatibility. */
   readonly agentName: string;
+  /** Canonical `source:name` identity resolved for this launch. */
+  readonly agentKey?: string;
+  /** Immutable execution lineage; true when this run was delegated. */
+  readonly isSubagent?: boolean;
   readonly workingDirectory?: string;
   readonly delegationAgentScope?: AgentDelegationScope | null;
   readonly session: SessionHandle;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -420,6 +420,7 @@ export async function executeAgent(
       streamTabIdOverride: options.streamTabIdOverride,
       onBeforeActivation: options.onStreamResolved,
       suppressViewSwitch: options.isSubagent,
+      isSubagent: options.isSubagent,
       enforceCategory: options.enforceCategory,
       suppressErrorNotification:
         options.suppressErrorNotification ?? options.isSubagent,
@@ -570,6 +571,7 @@ async function resumeToolUseWithOwnedLease(
       // for this exact record; do not re-infer here.
       modelHandlerCompatibilityKey: resume.shared.modelHandlerCompatibilityKey,
       suppressViewSwitch: isSubagent,
+      isSubagent,
       // Host resume callers surface their own warning toast on failure;
       // skip the bus-level error to avoid double-notifying.
       suppressErrorNotification: true,

--- a/src/test-kernel/agent/prompt/UserVarsDelegationScope.vitest.ts
+++ b/src/test-kernel/agent/prompt/UserVarsDelegationScope.vitest.ts
@@ -31,6 +31,45 @@ const roster = vi.hoisted(() => ({
       description: 'Out-of-scope tool-use agent',
       path: '/agents/outside-reviewer.yaml',
     },
+    {
+      category: 'toolUse',
+      source: 'custom',
+      name: 'child',
+      description: 'Current delegated child',
+      tools: ['delegate_agent'],
+      path: '/agents/child.yaml',
+    },
+    {
+      category: 'toolUse',
+      source: 'remote',
+      name: 'child',
+      description: 'Same-name leaf specialist',
+      tools: ['read_file'],
+      path: '/agents/remote-child.yaml',
+    },
+    {
+      category: 'toolUse',
+      source: 'custom',
+      name: 'coder',
+      description: 'Leaf specialist',
+      tools: ['read_file'],
+      path: '/agents/coder.yaml',
+    },
+    {
+      category: 'toolUse',
+      source: 'custom',
+      name: 'lead',
+      description: 'Delegation-capable lead',
+      tools: ['delegate_agent'],
+      path: '/agents/lead.yaml',
+    },
+    {
+      category: 'workflow',
+      source: 'custom',
+      name: 'child',
+      description: 'Same-name workflow agent',
+      path: '/agents/child-workflow.yaml',
+    },
   ],
 }));
 
@@ -57,9 +96,13 @@ import { noopTrace } from '@agent/trace';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import {
   AgentPromptSchema,
+  AgentToolUseSettingSchema,
   AgentWorkflowSettingSchema,
 } from '@agent/core/definition/AgentDataclass';
 import { buildUserVars } from '@agent/prompt/userVars';
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { createRunScope } from '@agent/runtime/RunScope';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { AgentCategory } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 
@@ -90,5 +133,46 @@ describe('buildUserVars delegation scope', () => {
     );
     expect(vars.WORKFLOW_AGENTS).not.toContain('outside-writer');
     expect(vars.TOOL_USE_AGENTS).not.toContain('outside-reviewer');
+  });
+
+  it('builds a fresh child prompt from immutable identity and lineage before a handle exists', async () => {
+    const delegationAgentScope = {
+      workflow: ['custom:child'],
+      toolUse: ['custom:child', 'remote:child', 'custom:coder', 'custom:lead'],
+    };
+    const runScope = createRunScope({
+      streamId: 'child-stream',
+      executionId: 'child-execution',
+      agentName: 'child',
+      agentKey: 'custom:child',
+      isSubagent: true,
+      delegationAgentScope,
+      session: {} as SessionHandle,
+      signal: new AbortController().signal,
+    });
+
+    const vars = await withRunContext(createRunContext({ runScope }), () =>
+      buildUserVars(
+        AgentConfigSchema.parse({ agent: 'child', model: 'test-model' }),
+        AgentToolUseSettingSchema.parse({
+          agentCategory: AgentCategory.ToolUse,
+        }),
+        AgentPromptSchema.parse({}),
+        '/agents/child',
+        { isOpenai: false, isAnthropic: false, isGoogle: false },
+        noopTrace,
+        { delegationAgentScope },
+      ),
+    );
+
+    expect(vars.TOOL_USE_AGENTS).toContain(
+      '- child: Same-name leaf specialist [read_file]',
+    );
+    expect(vars.TOOL_USE_AGENTS).toContain(
+      '- coder: Leaf specialist [read_file]',
+    );
+    expect(vars.TOOL_USE_AGENTS).not.toContain('Current delegated child');
+    expect(vars.TOOL_USE_AGENTS).not.toContain('Delegation-capable lead');
+    expect(vars.WORKFLOW_AGENTS).toBe('- child: Same-name workflow agent');
   });
 });

--- a/src/test-kernel/agent/runtime/AgentLaunchActivation.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchActivation.vitest.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   acquireResumedExecutionLease: vi.fn(),
   buildVars: vi.fn(),
+  buildVarsRunScope: undefined as
+    { agentName: string; agentKey?: string; isSubagent?: boolean } | undefined,
   clearTerminalExecutionState: vi.fn(),
   completeOwnedExecutionLease: vi.fn(),
   createHandler: vi.fn(),
@@ -52,6 +54,7 @@ vi.mock('@agent/runtime/SessionResumeRetrieval', () => ({
 
 import { noopTrace } from '@agent/trace';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import { useRunContext } from '@agent/runtime/RunContext';
 import {
   executeAgent,
   resumeToolUseFromResumeData,
@@ -92,7 +95,12 @@ async function captureActivation(
   };
 
   mocks.resolve.mockReturnValueOnce({
-    entry: { path: '/agents/chat.yaml' },
+    entry: {
+      category: 'toolUse',
+      source: 'custom',
+      name: 'chat',
+      path: '/agents/chat.yaml',
+    },
   });
   mocks.load.mockResolvedValueOnce([
     { agentCategory: AgentCategory.ToolUse },
@@ -100,7 +108,12 @@ async function captureActivation(
   ]);
   mocks.createHandler.mockResolvedValueOnce(handler);
   mocks.createTrace.mockReturnValueOnce({ trace, dispose: vi.fn() });
-  mocks.buildVars.mockRejectedValueOnce(LAUNCH_FAILURE);
+  mocks.buildVars.mockImplementationOnce(() => {
+    const context = useRunContext();
+    mocks.buildVarsRunScope =
+      context.kind === 'launch' ? context.runScope : undefined;
+    throw LAUNCH_FAILURE;
+  });
 
   try {
     await expect(run(session)).rejects.toBe(LAUNCH_FAILURE);
@@ -134,6 +147,7 @@ function expectActivation(
 describe('native agent launch activation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.buildVarsRunScope = undefined;
     mocks.acquireResumedExecutionLease.mockResolvedValue('existing');
     mocks.clearTerminalExecutionState.mockResolvedValue(undefined);
     mocks.getPersistedUserFollowUpSupport.mockResolvedValue(
@@ -146,13 +160,29 @@ describe('native agent launch activation', () => {
   });
 
   it.each([
-    { label: 'child', isSubagent: true, suppressViewSwitch: true },
-    { label: 'root', isSubagent: undefined, suppressViewSwitch: false },
+    {
+      label: 'child with a bare identifier',
+      agent: 'chat',
+      isSubagent: true,
+      suppressViewSwitch: true,
+    },
+    {
+      label: 'root with a bare identifier',
+      agent: 'chat',
+      isSubagent: undefined,
+      suppressViewSwitch: false,
+    },
+    {
+      label: 'root with a source-qualified identifier',
+      agent: 'custom:chat',
+      isSubagent: undefined,
+      suppressViewSwitch: false,
+    },
   ])(
     'emits the expected activation payload for a fresh $label launch',
-    async ({ isSubagent, suppressViewSwitch }) => {
+    async ({ agent, isSubagent, suppressViewSwitch }) => {
       const payload = await captureActivation((session) =>
-        executeAgent(config, 'fresh-launch' as ExecutionId, {
+        executeAgent({ ...config, agent }, 'fresh-launch' as ExecutionId, {
           session,
           isSubagent,
           modelHandlerCompatibilityKey: MODEL_HANDLER_KEY,
@@ -160,6 +190,11 @@ describe('native agent launch activation', () => {
       );
 
       expectActivation(payload, suppressViewSwitch);
+      expect(mocks.buildVarsRunScope).toMatchObject({
+        agentName: agent,
+        agentKey: 'custom:chat',
+        isSubagent: isSubagent === true,
+      });
     },
   );
 
@@ -186,6 +221,10 @@ describe('native agent launch activation', () => {
 
       expectActivation(payload, suppressViewSwitch);
       expect(payload.streamId).toBe(streamId);
+      expect(mocks.buildVarsRunScope).toMatchObject({
+        agentKey: 'custom:chat',
+        isSubagent,
+      });
     },
   );
 });

--- a/src/test-kernel/tools/DelegationAgentAvailability.vitest.ts
+++ b/src/test-kernel/tools/DelegationAgentAvailability.vitest.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { withRunContext } from '@agent/runtime/RunContext';
 import type { ToolDefinition } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
@@ -279,6 +280,40 @@ describe('resolveAgentTools delegation roster annotation', () => {
     // The models line is refreshed in the same pass.
     expect(delegateAgent?.description).toContain('Available models: deepseekT');
     expect(mocks.getVisibleAgents).toHaveBeenCalledWith('toolUse');
+  });
+
+  it('annotates a delegated child with leaf agents but not delegation-capable leads', async () => {
+    mocks.getVisibleAgents.mockReturnValue([
+      {
+        category: 'toolUse',
+        source: 'custom',
+        name: 'lead',
+        path: '/agents/lead.yaml',
+        description: 'Delegate implementation work.',
+        tools: ['delegate_agent'],
+      },
+      {
+        category: 'toolUse',
+        source: 'custom',
+        name: 'coder',
+        path: '/agents/coder.yaml',
+        description: 'Implement focused changes.',
+        tools: ['read_file'],
+      },
+    ]);
+
+    const delegateAgent = await withRunContext(
+      {
+        kind: 'bare',
+        agentName: 'child',
+        agentKey: 'custom:child',
+        isSubagent: true,
+      } as never,
+      resolveDelegateAgent,
+    );
+
+    expect(delegateAgent?.description).toContain('- coder:');
+    expect(delegateAgent?.description).not.toContain('- lead:');
   });
 
   it('does not annotate a roster line onto non-delegation tools', async () => {

--- a/src/test-kernel/tools/DelegationAgentScope.vitest.ts
+++ b/src/test-kernel/tools/DelegationAgentScope.vitest.ts
@@ -14,12 +14,40 @@ const customReview = {
   name: 'review',
   path: '/agents/custom-review.yaml',
 } as const;
+const lead = {
+  category: 'toolUse',
+  source: 'custom',
+  name: 'lead',
+  path: '/agents/lead.yaml',
+  tools: ['delegate_agent'],
+} as const;
+const remoteLead = {
+  category: 'toolUse',
+  source: 'remote',
+  name: 'lead',
+  path: '/agents/remote-lead.yaml',
+  tools: ['read_file'],
+} as const;
+const leaf = {
+  category: 'toolUse',
+  source: 'custom',
+  name: 'leaf',
+  path: '/agents/leaf.yaml',
+  tools: ['read_file'],
+} as const;
+const workflow = {
+  category: 'workflow',
+  source: 'custom',
+  name: 'child',
+  path: '/agents/child-workflow.yaml',
+} as const;
 const remoteReviewScope = {
   workflow: [],
   toolUse: ['remote:review'],
 };
 const mocks = vi.hoisted(() => ({
   context: undefined as unknown,
+  agents: [] as unknown[],
 }));
 
 vi.mock('@agent/runtime/RunContext', () => ({
@@ -39,10 +67,11 @@ vi.mock('@agent/index/agentRegistry', () => {
       scope: { toolUse: readonly string[] } | undefined,
       category: string,
     ) => {
-      if (!scope) return [customReview];
+      if (!scope)
+        return mocks.agents.length > 0 ? mocks.agents : [customReview];
       return category === 'toolUse' && scope.toolUse.includes('remote:review')
         ? [remoteReview]
-        : [];
+        : mocks.agents.filter((agent: any) => agent.category === category);
     },
     findAgentByIdentifier: (
       entries: Array<{ source: string; name: string }>,
@@ -56,6 +85,7 @@ const { getDelegationAgent, getDelegationAgents } =
 
 describe('execution-scoped delegation agents', () => {
   beforeEach(() => {
+    mocks.agents = [];
     mocks.context = {
       kind: 'launch',
       runScope: {
@@ -89,5 +119,48 @@ describe('execution-scoped delegation agents', () => {
 
     expect(getDelegationAgents('toolUse')).toEqual([customReview]);
     expect(getDelegationAgent('toolUse', 'review')).toBe(customReview);
+  });
+
+  it.each(['lead', 'custom:lead'])(
+    'excludes only the exact current identity for launch identifier %s',
+    (agentName) => {
+      mocks.agents = [lead, remoteLead, leaf];
+      mocks.context = {
+        kind: 'launch',
+        runScope: {
+          agentName,
+          agentKey: 'custom:lead',
+          delegationAgentScope: {
+            workflow: [],
+            toolUse: ['custom:lead', 'remote:lead', 'custom:leaf'],
+          },
+          isSubagent: false,
+        },
+      };
+
+      expect(getDelegationAgents('toolUse')).toEqual([remoteLead, leaf]);
+      expect(getDelegationAgent('toolUse', 'custom:lead')).toBeUndefined();
+      expect(getDelegationAgent('toolUse', 'remote:lead')).toBe(remoteLead);
+    },
+  );
+
+  it('keeps leaf and workflow agents while excluding tool-use leads for a child', () => {
+    mocks.agents = [lead, leaf, workflow];
+    mocks.context = {
+      kind: 'launch',
+      runScope: {
+        agentName: 'child',
+        delegationAgentScope: {
+          workflow: ['child'],
+          toolUse: ['lead', 'leaf'],
+        },
+        agentKey: 'custom:child',
+        isSubagent: true,
+      },
+    };
+
+    expect(getDelegationAgents('toolUse')).toEqual([leaf]);
+    expect(getDelegationAgent('toolUse', 'lead')).toBeUndefined();
+    expect(getDelegationAgents('workflow')).toEqual([workflow]);
   });
 });

--- a/src/test-kernel/tools/DelegationTools.vitest.ts
+++ b/src/test-kernel/tools/DelegationTools.vitest.ts
@@ -9,6 +9,13 @@ const mocks = vi.hoisted(() => ({
   currentSession: vi.fn(),
   submitFollowUp: vi.fn(),
   deliverChildRunFollowUp: vi.fn(),
+  delegationAgents: [] as Array<{
+    category: string;
+    source: string;
+    name: string;
+    path: string;
+    tools?: string[];
+  }>,
 }));
 
 vi.mock('@agent/runtime/RunContext', () => {
@@ -23,6 +30,15 @@ vi.mock('@agent/runtime/RunContext', () => {
 
 vi.mock('@agent/runtime/SessionHandle', () => ({
   currentSession: mocks.currentSession,
+}));
+
+vi.mock('@agent/index/agentRegistry', () => ({
+  resolveDelegationScopeAgents: (_scope: unknown, category: string) =>
+    mocks.delegationAgents.filter((agent) => agent.category === category),
+  findAgentByIdentifier: (
+    entries: Array<{ name: string }>,
+    identifier: string,
+  ) => entries.find((entry) => entry.name === identifier),
 }));
 
 vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
@@ -151,6 +167,36 @@ describe('DelegationTools', () => {
     expect(`${fieldDescriptions.join('\n')}\n${authoredHandoff}`).not.toContain(
       '\u2014',
     );
+  });
+});
+
+describe('DelegateAgentTool candidate enforcement', () => {
+  it('rejects a direct delegated-child call to a delegation-capable lead', async () => {
+    mocks.delegationAgents = [
+      {
+        category: 'toolUse',
+        source: 'custom',
+        name: 'lead',
+        path: '/agents/lead.yaml',
+        tools: ['delegate_agent'],
+      },
+    ];
+    mocks.tryUseRunContext.mockReturnValue({
+      kind: 'bare',
+      agentName: 'child',
+      agentKey: 'custom:child',
+      isSubagent: true,
+    });
+
+    const result = await new DelegateAgentTool().call({
+      agent: 'lead',
+      instruction: 'Delegate this again.',
+    });
+
+    expect(result).toMatchObject({
+      status: 'error',
+      error: "Unknown toolUse agent 'lead'. Available:",
+    });
   });
 });
 

--- a/src/tools/delegation/delegationAvailability.ts
+++ b/src/tools/delegation/delegationAvailability.ts
@@ -37,8 +37,11 @@ import type {
   ModelOptionData,
   ToolDefinition,
 } from '@shared/schemas';
-import { isModelOptionAvailable } from '@shared/schemas';
-import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import { agentKeyOf, isModelOptionAvailable } from '@shared/schemas';
+import {
+  DELEGATION_TOOLS,
+  hasDelegationTool,
+} from '@shared/constants/delegationTools';
 import { unique } from '@utils/core';
 import { isWorktreeSupportEnabled } from '@utils/config/worktreeConfig';
 
@@ -154,14 +157,24 @@ function activeDelegationScope(): AgentDelegationScope | undefined {
 /**
  * Resolve delegation targets from an explicitly captured scope, or — when none
  * is supplied — the active run scope, falling back to the durable roster.
+ * Tool-use candidates also honor the active execution's recursion guard.
  */
 export function getDelegationAgents(
   category: AgentCategory,
   scope?: AgentDelegationScope,
 ): AgentEntry[] {
-  return resolveDelegationScopeAgents(
+  const agents = resolveDelegationScopeAgents(
     scope ?? activeDelegationScope(),
     category,
+  );
+  const context = tryUseRunContext();
+  const run = context?.kind === 'launch' ? context.runScope : context;
+  if (category !== 'toolUse') return agents;
+
+  return agents.filter(
+    (agent) =>
+      agentKeyOf(agent) !== run?.agentKey &&
+      !(run?.isSubagent && hasDelegationTool(agent.tools)),
   );
 }
 


### PR DESCRIPTION
## Summary
- prevent an agent from delegating to its own canonical source-qualified identity
- prevent delegated child leads from recursively selecting other delegation-capable tool-use leads
- preserve root orchestration plus delegated leaf and workflow specialist targets
- use immutable launch identity and lineage so prompts, descriptions, and tool resolution agree before execution handles exist

## Validation
- focused delegation, team, child-lineage, prompt, launch-context, and run-context suites (114 tests)
- full project typecheck
- changed-file ESLint and Prettier checks

Fixes texra-ai/texra-issues#8.