### PR TITLE
fix(media): label Google and VS Code attachments per entry

### DIFF
--- a/src/agent/modelHandlers/google/googleHandlerShared.ts
+++ b/src/agent/modelHandlers/google/googleHandlerShared.ts
@@ -96,6 +96,7 @@ interface UploadGoogleMediaEntriesOptions<T> {
   inlineLimit: number;
   logger: AgentTrace;
   buildMedia: (source: GoogleMediaSource, mimeType: string) => T;
+  buildLabel: (media: T, fileName: string) => T;
   onInsertedEntry?: (entry: MediaEntry) => void;
 }
 
@@ -112,10 +113,20 @@ export async function uploadGoogleMediaEntries<T>(
     return [];
   }
 
-  const { getClient, inlineLimit, logger, buildMedia, onInsertedEntry } =
-    options;
+  const {
+    getClient,
+    inlineLimit,
+    logger,
+    buildMedia,
+    buildLabel,
+    onInsertedEntry,
+  } = options;
   const client = await getClient();
   const parts: T[] = [];
+  const appendMedia = (entry: MediaEntry, media: T): void => {
+    parts.push(buildLabel(media, entry.file_name), media);
+    onInsertedEntry?.(entry);
+  };
   let hadFailure = false;
   const failures: string[] = [];
 
@@ -130,8 +141,8 @@ export async function uploadGoogleMediaEntries<T>(
         logger.debug(
           `Attaching media entry ${fileName} inline (${payloadBytes} bytes).`,
         );
-        parts.push(buildMedia({ data: inlinePayload }, mimeType));
-        onInsertedEntry?.(entry);
+        const media = buildMedia({ data: inlinePayload }, mimeType);
+        appendMedia(entry, media);
         continue;
       }
       logger.debug(
@@ -171,8 +182,8 @@ export async function uploadGoogleMediaEntries<T>(
       }
       const resolvedMimeType =
         uploaded.mimeType || entry.media_type || DEFAULT_ATTACHMENT_MIME_TYPE;
-      parts.push(buildMedia({ uri: fileUri }, resolvedMimeType));
-      onInsertedEntry?.(entry);
+      const media = buildMedia({ uri: fileUri }, resolvedMimeType);
+      appendMedia(entry, media);
     } catch (error) {
       hadFailure = true;
       failures.push(`${fileName}: ${getSdkErrorMessage(error)}`);

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -44,7 +44,6 @@ import {
 } from '@common/errors/sdkError/errorPatterns';
 import { composeLongRunningModelDispatcher } from '@platform/defaults/longRunningModelTransport';
 import {
-  fileLocationShortDisplayPath,
   type FileLocation,
   type MediaAttachmentKind,
   type ToolDefinition,
@@ -53,7 +52,7 @@ import {
 } from '@shared/schemas';
 import { filterNotNull, generateShortId, isNonEmptyString } from '@utils/core';
 import { isImageMimeType } from '@utils/files/mimeUtils';
-import { joinNonEmpty, pluralize } from '@utils/text/stringUtils';
+import { joinNonEmpty } from '@utils/text/stringUtils';
 import { getConfig } from '@utils/config/configUtils';
 
 // Local file imports
@@ -721,6 +720,10 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       inlineLimit: this.getInlineUploadLimitBytes(),
       logger: this.logger,
       buildMedia: (source, mimeType) => this.buildMedia(source, mimeType),
+      buildLabel: (media, fileName) =>
+        this.textMedia(
+          `${media.type[0].toUpperCase()}${media.type.slice(1)}: ${fileName}`,
+        ),
       onInsertedEntry: (entry) => insertedEntries.push(entry),
     });
     this.setCreatedMediaEntriesForAttachmentLog(insertedEntries);
@@ -736,21 +739,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       return [];
     }
 
-    const media = await this.createMediaForRound(mediaFiles, context);
-    if (media.length === 0) {
-      return [];
-    }
-
-    const label = mediaFiles
-      .map((loc) => fileLocationShortDisplayPath(loc))
-      .join(', ');
-    const verb = context === 'initial' ? 'Attached' : 'Processing';
-    return [
-      this.textMedia(
-        `\n${verb} ${pluralize(mediaFiles.length, 'file')}: ${label}`,
-      ),
-      ...media,
-    ];
+    return this.createMediaForRound(mediaFiles, context);
   }
 
   // ===========================================================================

--- a/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
+++ b/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
@@ -50,6 +50,7 @@ import { toVscodeLmTools } from '../toolConversion';
 import { formatToolResultTextWithAttachments } from '../utils/toolAttachmentUtils';
 
 type VscodeLmUsage = undefined;
+type VscodeLmMediaPart = LanguageModelTextPart | LanguageModelDataPart;
 
 interface VscodeLmResponse {
   readonly text: string;
@@ -190,7 +191,7 @@ export class ModelHandlerVscodeLm extends ModelHandler<
   VscodeLmToolCall,
   LanguageModelPort,
   VscodeLmResponse,
-  LanguageModelDataPart
+  VscodeLmMediaPart
 > {
   constructor(
     config: ModelConfig,
@@ -331,8 +332,8 @@ export class ModelHandlerVscodeLm extends ModelHandler<
     ];
   }
 
-  createMediaContent(mediaMessage: MediaEntry[]): LanguageModelDataPart[] {
-    return mediaMessage.map((media) => {
+  createMediaContent(mediaMessage: MediaEntry[]): VscodeLmMediaPart[] {
+    return mediaMessage.flatMap((media): VscodeLmMediaPart[] => {
       if (
         media.media_category !== 'image' ||
         !isImageMimeType(media.media_type)
@@ -346,11 +347,14 @@ export class ModelHandlerVscodeLm extends ModelHandler<
       // this is the only consumer of raw bytes, so keeping both forms on every
       // entry would double the memory held for media the other handlers send
       // as base64.
-      return {
-        kind: 'data' as const,
-        data: Buffer.from(media.data, 'base64'),
-        mimeType: media.media_type,
-      };
+      return [
+        textPart(`Image: ${media.file_name}`),
+        {
+          kind: 'data',
+          data: Buffer.from(media.data, 'base64'),
+          mimeType: media.media_type,
+        },
+      ];
     });
   }
 

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
@@ -197,15 +197,8 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
     expect(steps).toHaveLength(1);
     const content = (steps[0] as Interactions.UserInputStep).content ?? [];
     expect(content.some((c) => c.type === 'image')).toBe(true);
-    // prefix + attached-files label + image + request, in order.
     expect((content[0] as Interactions.TextContent).text).toContain('PREFIX');
-    expect(
-      content.some(
-        (c) =>
-          c.type === 'text' &&
-          /Attached/.test((c as Interactions.TextContent).text),
-      ),
-    ).toBe(true);
+    expect(textOf(steps[0])).not.toContain('Attached');
     expect(textOf(steps[0])).toContain('REQUEST');
   });
 
@@ -225,9 +218,11 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
     let uploadCalls = 0;
     handler.setClient({
       files: {
-        upload: async () => {
+        upload: async ({ file }: { file: string }) => {
           uploadCalls += 1;
-          return { uri: 'files/abc', mimeType: 'image/png' };
+          return file === '/x/big.png'
+            ? { uri: 'files/abc', mimeType: 'image/png' }
+            : { mimeType: 'image/png' };
         },
       },
     } as unknown as GoogleGenAI);
@@ -249,23 +244,34 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
         source_path: '/x/big.png',
         bytes_match_source: true,
       },
+      {
+        file_name: 'failed.png',
+        media_type: 'image/png',
+        media_category: 'image',
+        data: Buffer.from('also too big').toString('base64'),
+        source_path: '/x/failed.png',
+        bytes_match_source: true,
+      },
     ];
 
     const content = await handler.uploadEntries(entries);
 
-    expect(content).toHaveLength(2);
-    const inline = content[0] as Interactions.ImageContent;
+    expect(content).toHaveLength(4);
+    expect(content[0]).toEqual({ type: 'text', text: 'Image: small.png' });
+    const inline = content[1] as Interactions.ImageContent;
     expect(inline.type).toBe('image');
     expect(inline.data).toBeTruthy();
     expect(inline.uri).toBeUndefined();
     expect(inline.resolution).toBe('high');
 
-    const uploaded = content[1] as Interactions.ImageContent;
+    expect(content[2]).toEqual({ type: 'text', text: 'Image: big.png' });
+    const uploaded = content[3] as Interactions.ImageContent;
     expect(uploaded.type).toBe('image');
     expect(uploaded.uri).toBe('files/abc');
     expect(uploaded.data).toBeUndefined();
     expect(uploaded.resolution).toBe('high');
-    expect(uploadCalls).toBe(1);
+    expect(textOf({ type: 'user_input', content })).not.toContain('failed.png');
+    expect(uploadCalls).toBe(2);
   });
 
   it('builds typed Interactions media content for audio, video, and documents', async () => {
@@ -279,6 +285,20 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
     } as unknown as GoogleGenAI);
 
     const entries: MediaEntry[] = [
+      {
+        file_name: 'paper.pdf_page_1',
+        media_type: 'image/png',
+        media_category: 'image',
+        data: Buffer.from('page 1').toString('base64'),
+        bytes_match_source: false,
+      },
+      {
+        file_name: 'paper.pdf_page_2',
+        media_type: 'image/png',
+        media_category: 'image',
+        data: Buffer.from('page 2').toString('base64'),
+        bytes_match_source: false,
+      },
       {
         file_name: 'sound.mp3',
         media_type: 'audio/mp3',
@@ -302,16 +322,33 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
     const content = await handler.uploadEntries(entries);
 
     expect(content).toEqual([
+      { type: 'text', text: 'Image: paper.pdf_page_1' },
+      {
+        type: 'image',
+        data: Buffer.from('page 1').toString('base64'),
+        mime_type: 'image/png',
+        resolution: 'high',
+      },
+      { type: 'text', text: 'Image: paper.pdf_page_2' },
+      {
+        type: 'image',
+        data: Buffer.from('page 2').toString('base64'),
+        mime_type: 'image/png',
+        resolution: 'high',
+      },
+      { type: 'text', text: 'Audio: sound.mp3' },
       {
         type: 'audio',
         data: Buffer.from('audio').toString('base64'),
         mime_type: 'audio/mp3',
       },
+      { type: 'text', text: 'Video: clip.mp4' },
       {
         type: 'video',
         data: Buffer.from('video').toString('base64'),
         mime_type: 'video/mp4',
       },
+      { type: 'text', text: 'Document: paper.pdf' },
       {
         type: 'document',
         data: Buffer.from('pdf').toString('base64'),

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerVscodeLm.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerVscodeLm.vitest.ts
@@ -176,6 +176,7 @@ describe('ModelHandlerVscodeLm messages', () => {
         role: 'user',
         content: [
           { kind: 'text', text: 'system\n\nprefix\n\nrequest' },
+          { kind: 'text', text: 'Image: figure.png' },
           { kind: 'data', data, mimeType: 'image/png' },
         ],
       },
@@ -188,6 +189,7 @@ describe('ModelHandlerVscodeLm messages', () => {
       role: 'user',
       content: [
         { kind: 'text', text: 'next question' },
+        { kind: 'text', text: 'Image: figure.png' },
         { kind: 'data', data, mimeType: 'image/png' },
       ],
     });
@@ -199,11 +201,10 @@ describe('ModelHandlerVscodeLm messages', () => {
     await expect(
       handler.addMediaToUserMessage(withTrailingAssistant, [IMAGE_LOCATION]),
     ).resolves.toEqual(['image']);
-    expect(withTrailingAssistant.at(-2)?.content.at(-1)).toEqual({
-      kind: 'data',
-      data,
-      mimeType: 'image/png',
-    });
+    expect(withTrailingAssistant.at(-2)?.content.slice(-2)).toEqual([
+      { kind: 'text', text: 'Image: figure.png' },
+      { kind: 'data', data, mimeType: 'image/png' },
+    ]);
     expect(loadEntries).toHaveBeenCalledTimes(3);
   });
 
@@ -219,6 +220,25 @@ describe('ModelHandlerVscodeLm messages', () => {
     await expect(
       visionHandler.initializeMessages('', 'question', [AUDIO_LOCATION]),
     ).rejects.toThrow('audio and other native file inputs are not supported');
+
+    const brokenHandler = new ModelHandlerVscodeLm(modelConfig());
+    mockMediaEntries(brokenHandler, [
+      {
+        file_name: 'broken.png',
+        data: '',
+        media_type: 'image/png',
+        media_category: 'image',
+      },
+    ]);
+    const messages: LanguageModelMessage[] = [
+      { role: 'user', content: [{ kind: 'text', text: 'question' }] },
+    ];
+    await expect(
+      brokenHandler.addMediaToUserMessage(messages, [IMAGE_LOCATION]),
+    ).resolves.toEqual([]);
+    expect(messages).toEqual([
+      { role: 'user', content: [{ kind: 'text', text: 'question' }] },
+    ]);
   });
 
   it('does not insert empty text before a tool result', () => {


### PR DESCRIPTION
## Summary
- expose each successful Google attachment name immediately before its media part
- remove Google’s aggregate requested-file label, which could name failed uploads
- expose each VS Code LM image name immediately before its data part
- reuse `MediaEntry.file_name` across both paths

## Validation
- focused Google/VS Code media suites (29 tests)
- workspace and test-kernel type checks
- changed-file ESLint and Prettier checks

Fixes #11031.