### PR TITLE
fix(auth): bind extension OAuth callbacks

### DIFF
--- a/docs/supabase/AUTH_OPERATIONS.md
+++ b/docs/supabase/AUTH_OPERATIONS.md
@@ -44,6 +44,35 @@ For Google, check:
    Google but no user appears, inspect the provider console and consent-screen
    status before assuming a Supabase hook or database problem.
 
+## Extension OAuth bridge release gate
+
+Any extension release that sends the callback nonce as the third
+`auth-bridge` path segment requires the matching `auth-bridge` Edge Function in
+production first. The old bridge does not append `app_nonce` to the editor deep
+link, so releasing the extension first would make desktop OAuth callbacks fail
+closed.
+
+Before publishing that extension build:
+
+1. Deploy the bridge without JWT verification:
+
+   ```sh
+   supabase functions deploy auth-bridge \
+     --no-verify-jwt \
+     --project-ref <production-project-ref>
+   ```
+
+2. Confirm the Auth redirect allow-list still contains
+   `https://remote.texra.ai/functions/v1/auth-bridge**`.
+3. Verify that the two-segment route without a nonce returns HTTP 400, a valid
+   three-segment route emits exactly one matching `app_nonce`, and malformed or
+   extra nonce segments also return HTTP 400.
+4. Only then publish the extension build and verify one desktop OAuth sign-in
+   and one VS Code web or Codespaces sign-in end to end.
+
+Do not reverse steps 1 and 4, and do not deploy the bridge from unreviewed local
+changes.
+
 ## Email first response checklist
 
 1. In Supabase Dashboard, open **Project Settings** -> **Authentication** ->

--- a/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
+++ b/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
@@ -1,4 +1,9 @@
+import { randomBytes } from 'node:crypto';
+
+import PQueue from 'p-queue';
 import * as vscode from 'vscode';
+import { z } from 'zod';
+
 import { invalidateRemoteAgentsAfterSignOut } from '@agent/index';
 import { refreshRemoteAgentCatalogAfterSignOut } from '@auth/authFlowEffects';
 import { SupabaseClient } from '@auth/SupabaseClient';
@@ -20,6 +25,7 @@ import { classifyAuthFailureStatus } from '@auth/TokenProvider';
 import * as logger from '@logger/logUtils';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { platform } from '@platform/platform';
+import type { PlatformSecrets } from '@platform/secrets';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import type { SupabaseUriHandler } from './UriHandler';
 
@@ -28,6 +34,26 @@ const log = logger.createLog(CHANNEL);
 
 const AUTH_URI_HANDLER_NOT_INITIALIZED =
   'OAuth handler not initialized. Restart the extension.';
+const OAUTH_NONCE_PATTERN = /^[0-9a-f]{32}$/;
+const PKCE_FLOW_ID_PATTERN = /^[a-zA-Z0-9_-]{8,64}$/;
+const PENDING_OAUTH_STATE_PREFIX = 'texra.extension.pendingOAuthState.';
+
+const PendingOAuthStateSchema = z.strictObject({
+  nonce: z.string().regex(OAUTH_NONCE_PATTERN),
+  createdAt: z.number().finite(),
+  flowId: z.string().regex(PKCE_FLOW_ID_PATTERN).optional(),
+});
+type PendingOAuthState = z.infer<typeof PendingOAuthStateSchema>;
+
+interface ExtensionAuthAttempt {
+  readonly nonce: string;
+  cancel(): void;
+}
+
+interface ClaimedAuthCallback {
+  attempt: ExtensionAuthAttempt;
+  flowId: string;
+}
 
 /** Notification operations injected at construction so tests can stub them. */
 export interface AuthNotifier {
@@ -50,15 +76,18 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   private uriHandler: SupabaseUriHandler | null = null;
   private uriHandlerSubscription: vscode.Disposable | null = null;
   private readonly sessionCoordinator: SupabaseSessionCoordinator;
-  /** Prevent concurrent callback handlers from storing competing sessions. */
-  private isProcessingCallback = false;
+  private readonly secrets: PlatformSecrets;
+  private readonly authCommitQueue = new PQueue({ concurrency: 1 });
+  private activeAttempt: ExtensionAuthAttempt | undefined;
 
   private readonly notifier: AuthNotifier;
 
   constructor(notifier: AuthNotifier) {
     this.notifier = notifier;
+    const hostPlatform = platform();
+    this.secrets = hostPlatform.secrets;
     this.sessionCoordinator = createHostAuthCoordinator({
-      secrets: platform().secrets,
+      secrets: hostPlatform.secrets,
       whenReady: async () => {
         if (!this.uriHandler) {
           throw new Error(AUTH_URI_HANDLER_NOT_INITIALIZED);
@@ -72,6 +101,134 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   /** Get singleton instance for sign out operations. */
   static getInstance(): SupabaseAuthProvider | null {
     return this.instance;
+  }
+
+  private pendingStateKey(nonce: string): string {
+    return `${PENDING_OAUTH_STATE_PREFIX}${nonce}`;
+  }
+
+  private async readPendingOAuthState(
+    nonce: string,
+  ): Promise<PendingOAuthState | null> {
+    const stored = await this.secrets.getStored(this.pendingStateKey(nonce));
+    if (!stored) return null;
+    try {
+      const parsed = PendingOAuthStateSchema.safeParse(JSON.parse(stored));
+      return parsed.success ? parsed.data : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private isPendingStateValid(state: PendingOAuthState): boolean {
+    const age = Date.now() - state.createdAt;
+    return age >= 0 && age <= AUTH_CALLBACK_TIMEOUT_MS;
+  }
+
+  private async persistPendingState(state: PendingOAuthState): Promise<void> {
+    await this.secrets.set(
+      this.pendingStateKey(state.nonce),
+      JSON.stringify(state),
+    );
+  }
+
+  private async beginAuthAttempt(attempt: ExtensionAuthAttempt): Promise<void> {
+    await this.persistPendingState({
+      nonce: attempt.nonce,
+      createdAt: Date.now(),
+    });
+  }
+
+  private async bindPkceFlow(
+    nonce: string,
+    flowId: string | null | undefined,
+  ): Promise<void> {
+    if (!flowId || !PKCE_FLOW_ID_PATTERN.test(flowId)) {
+      throw new Error('OAuth initialization did not return a valid PKCE flow.');
+    }
+    const pending = await this.readPendingOAuthState(nonce);
+    if (!pending || !this.isPendingStateValid(pending)) {
+      throw new Error(
+        'Authentication attempt is no longer pending. Try again.',
+      );
+    }
+    await this.persistPendingState({ ...pending, flowId });
+  }
+
+  private async clearPendingAttempt(nonce: string): Promise<void> {
+    await this.secrets.delete(this.pendingStateKey(nonce));
+  }
+
+  private callbackNonce(query: string): string | null {
+    const values = new URLSearchParams(query).getAll('app_nonce');
+    if (values.length !== 1 || !OAUTH_NONCE_PATTERN.test(values[0])) {
+      return null;
+    }
+    return values[0];
+  }
+
+  private async claimCallback(
+    query: string,
+    expectedAttempt?: ExtensionAuthAttempt,
+  ): Promise<ClaimedAuthCallback | null> {
+    const nonce = this.callbackNonce(query);
+    if (!nonce || (expectedAttempt && expectedAttempt.nonce !== nonce)) {
+      log.warn('OAuth callback rejected: invalid or stale attempt binding');
+      return null;
+    }
+
+    const pending = await this.readPendingOAuthState(nonce);
+    if (
+      !pending ||
+      !pending.flowId ||
+      pending.nonce !== nonce ||
+      !this.isPendingStateValid(pending)
+    ) {
+      if (pending && !this.isPendingStateValid(pending)) {
+        await this.clearPendingAttempt(nonce);
+      }
+      log.warn('OAuth callback rejected: invalid or stale attempt binding');
+      return null;
+    }
+
+    if (expectedAttempt && this.activeAttempt !== expectedAttempt) {
+      log.debug(
+        'OAuth callback ignored after its sign-in attempt was superseded',
+      );
+      return null;
+    }
+
+    const attempt = expectedAttempt ?? {
+      nonce,
+      cancel: () => {},
+    };
+    if (!expectedAttempt) {
+      if (this.activeAttempt) {
+        log.debug('OAuth callback ignored while another sign-in is active');
+        return null;
+      }
+      this.activeAttempt = attempt;
+    }
+
+    await this.clearPendingAttempt(nonce);
+    if (this.activeAttempt !== attempt) return null;
+    return { attempt, flowId: pending.flowId };
+  }
+
+  private invalidateActiveAttempt(): void {
+    const attempt = this.activeAttempt;
+    this.activeAttempt = undefined;
+    attempt?.cancel();
+  }
+
+  private async cancelPendingAttempt(): Promise<void> {
+    const pendingNonce = this.activeAttempt?.nonce;
+    this.invalidateActiveAttempt();
+    if (pendingNonce) await this.clearPendingAttempt(pendingNonce);
+  }
+
+  private async runAuthCommit<T>(commit: () => Promise<T>): Promise<T> {
+    return this.authCommitQueue.add(commit) as Promise<T>;
   }
 
   /**
@@ -109,6 +266,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
    * Dispose resources when provider is deactivated.
    */
   dispose(): void {
+    this.invalidateActiveAttempt();
     this.uriHandlerSubscription?.dispose();
     this._onDidChangeSessions.dispose();
   }
@@ -119,23 +277,24 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
    * and no OAuth flow is currently active.
    */
   private async handleLateAuthCallback(uri: vscode.Uri): Promise<void> {
-    // Atomically claim processing - must be first check to prevent race
-    if (this.isProcessingCallback) {
-      return;
-    }
-    this.isProcessingCallback = true;
+    // The active attempt owns its callback through waitForSession. This listener
+    // exists only for a callback that arrives after extension-host restart.
+    if (this.activeAttempt) return;
+
+    const claimed = await this.claimCallback(uri.query);
+    if (!claimed) return;
+    const { attempt, flowId } = claimed;
 
     try {
-      // Check if we already have a session (after claiming the lock)
       const existingSession = await this.sessionCoordinator.loadSession();
-      if (existingSession) {
-        return;
-      }
+      if (existingSession || this.activeAttempt !== attempt) return;
 
-      const result = await this.sessionCoordinator.createSessionFromCallback({
-        path: uri.path,
-        query: uri.query,
-      });
+      const result = await SupabaseClient.runPkceOperation(() =>
+        this.sessionCoordinator.createSessionFromCallback(
+          { path: uri.path, query: uri.query },
+          flowId,
+        ),
+      );
 
       if (!result.success) {
         if (result.isAuthError) {
@@ -147,14 +306,21 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
         return;
       }
 
-      await this.storeSession(result.session);
-      this.notifier.showInfo(`Signed in as ${result.session.account.label}`);
-      log.info(`Late sign-in successful for ${result.session.account.label}`);
+      await this.runAuthCommit(async () => {
+        if (this.activeAttempt !== attempt) return;
+        await this.storeSession(result.session);
+        if (this.activeAttempt !== attempt) {
+          await this.sessionCoordinator.clearSessionIfCurrent(result.session);
+          return;
+        }
+        this.notifier.showInfo(`Signed in as ${result.session.account.label}`);
+        log.info(`Late sign-in successful for ${result.session.account.label}`);
+      });
     } catch (error) {
       log.error(`Error processing auth callback: ${toErrorMessage(error)}`);
       this.notifier.showError(`Sign-in failed: ${toErrorMessage(error)}`);
     } finally {
-      this.isProcessingCallback = false;
+      if (this.activeAttempt === attempt) this.activeAttempt = undefined;
     }
   }
 
@@ -217,10 +383,11 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
     }
   }
 
-  private async buildOAuthOptions(): Promise<{ redirectTo: string }> {
+  private async buildOAuthOptions(
+    nonce: string,
+  ): Promise<{ redirectTo: string }> {
     if (vscode.env.uiKind === vscode.UIKind.Web) {
       const callbackInfo = await getExternalAuthCallbackInfo();
-      log.info(`OAuth callback URI (web): ${callbackInfo.fullUrl}`);
       // In Codespaces/web the tunnel routing token must ride on redirect_to
       // (fullUrl already carries ?state=TUNNEL). Passing it as queryParams.state
       // instead overwrites GoTrue's own OAuth state on /authorize, which makes
@@ -229,19 +396,21 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       // so this is also correct for plain web.
       // PKCE flow: the callback carries a one-time ?code= (query), which the
       // shared createSessionFromCallback exchanges for a session.
-      return { redirectTo: callbackInfo.fullUrl };
+      const separator = callbackInfo.fullUrl.includes('?') ? '&' : '?';
+      return {
+        redirectTo: `${callbackInfo.fullUrl}${separator}app_nonce=${nonce}`,
+      };
     }
 
     // Desktop: redirect GoTrue to the https bridge page instead of straight to
     // the raw vscode:// deep link, which Firefox on Linux drops (bad_oauth_state).
     // With PKCE the bridge only ever sees a one-time ?code= (no tokens); it
     // forwards that to ${scheme}://${id}/auth-callback for a real-click handoff.
-    // ext/id ride in the PATH (not a query) so redirect_to carries no '?' that an
-    // OAuth round-trip could mangle into the function name.
+    // ext/id/nonce ride in the PATH (not a query) so redirect_to carries no '?'
+    // that an OAuth round-trip could mangle into the function name.
     const redirectTo =
       `${AUTH_BRIDGE_URL}/${encodeURIComponent(vscode.env.uriScheme)}` +
-      `/${encodeURIComponent(getExtensionId())}`;
-    log.info(`OAuth callback URI (desktop): ${redirectTo}`);
+      `/${encodeURIComponent(getExtensionId())}/${nonce}`;
     return { redirectTo };
   }
 
@@ -275,57 +444,99 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   private async createSessionViaSupabaseOAuth(
     provider: OAuthProvider,
   ): Promise<vscode.AuthenticationSession> {
-    try {
-      const { data, error } =
-        await SupabaseClient.getClient().auth.signInWithOAuth({
-          provider,
-          options: await this.buildOAuthOptions(),
-        });
+    return vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: 'TeXRA Authentication',
+        cancellable: true,
+      },
+      async (progress, token) => {
+        this.invalidateActiveAttempt();
+        const attempt: ExtensionAuthAttempt = {
+          nonce: randomBytes(16).toString('hex'),
+          cancel: () => {},
+        };
+        this.activeAttempt = attempt;
+        const callback = this.waitForSession(attempt, token);
 
-      if (error || !data.url) {
-        throw new Error(
-          `OAuth initialization failed: ${error?.message || 'Unknown error'}. Try again.`,
-        );
-      }
-
-      // Set flag BEFORE opening URL to prevent race with fast callbacks
-      this.isProcessingCallback = true;
-
-      await vscode.env.openExternal(vscode.Uri.parse(data.url));
-      await vscode.window.withProgress(
-        {
-          location: vscode.ProgressLocation.Notification,
-          title: 'TeXRA Authentication',
-          cancellable: true,
-        },
-        async (progress, token) => {
+        try {
           progress.report({ message: 'Waiting for authentication...' });
+          // Finish any callback commit owned by the superseded attempt before
+          // publishing this attempt's pending state.
+          await this.runAuthCommit(async () => {});
+          if (this.activeAttempt !== attempt) {
+            throw new Error(
+              'Authentication attempt was superseded. Try again.',
+            );
+          }
 
-          const session = await this.waitForSession(token);
+          await this.beginAuthAttempt(attempt);
+          if (this.activeAttempt !== attempt) {
+            throw new Error(
+              'Authentication attempt was superseded. Try again.',
+            );
+          }
 
+          const options = await this.buildOAuthOptions(attempt.nonce);
+          const { data, error } = await SupabaseClient.runPkceOperation(() =>
+            SupabaseClient.getClient().auth.signInWithOAuth({
+              provider,
+              options,
+            }),
+          );
+
+          if (error || !data.url) {
+            throw new Error(
+              `OAuth initialization failed: ${error?.message || 'Unknown error'}. Try again.`,
+            );
+          }
+          if (this.activeAttempt !== attempt) {
+            throw new Error(
+              'Authentication attempt was superseded. Try again.',
+            );
+          }
+          await this.bindPkceFlow(attempt.nonce, data.flowId);
+
+          // The callback listener is already armed before the browser can send a
+          // fast redirect back to the extension host.
+          await vscode.env.openExternal(vscode.Uri.parse(data.url));
+          const session = await callback;
           if (!session) {
             throw new Error(
               'Authentication cancelled or timed out. Try again.',
             );
           }
-          await this.storeSession(session);
-        },
-      );
 
-      const sessions = await this.getSessions();
-      if (sessions.length === 0) {
-        throw new Error('Session creation failed. Try signing in again.');
-      }
-      return sessions[0];
-    } catch (error) {
-      this.notifier.showError(
-        `Authentication failed: ${toErrorMessage(error)}`,
-      );
-      throw error;
-    } finally {
-      // Reset flag after entire OAuth flow completes (success or failure)
-      this.isProcessingCallback = false;
-    }
+          await this.runAuthCommit(async () => {
+            if (this.activeAttempt !== attempt) return;
+            await this.storeSession(session);
+            if (this.activeAttempt !== attempt) {
+              await this.sessionCoordinator.clearSessionIfCurrent(session);
+            }
+          });
+          if (this.activeAttempt !== attempt) {
+            throw new Error(
+              'Authentication attempt was superseded. Try again.',
+            );
+          }
+
+          const sessions = await this.getSessions();
+          if (sessions.length === 0) {
+            throw new Error('Session creation failed. Try signing in again.');
+          }
+          return sessions[0];
+        } catch (error) {
+          this.notifier.showError(
+            `Authentication failed: ${toErrorMessage(error)}`,
+          );
+          throw error;
+        } finally {
+          attempt.cancel();
+          if (this.activeAttempt === attempt) this.activeAttempt = undefined;
+          await this.clearPendingAttempt(attempt.nonce);
+        }
+      },
+    );
   }
 
   /**
@@ -337,6 +548,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
    * device's refresh tokens with its default global scope.
    */
   async removeSession(sessionId: string): Promise<void> {
+    await this.cancelPendingAttempt();
     await this.clearLocalSession(sessionId);
   }
 
@@ -356,9 +568,10 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
   /** Remove the currently stored session without resolving it. */
   async removeStoredSession(): Promise<boolean> {
+    await this.cancelPendingAttempt();
     const session = await this.sessionCoordinator.loadSession();
     if (!session) return false;
-    await this.removeSession(session.id);
+    await this.clearLocalSession(session.id);
     return true;
   }
 
@@ -397,12 +610,9 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
     });
   }
 
-  /**
-   * Wait for OAuth callback from URI handler.
-   * Note: isProcessingCallback must be set by caller before invoking this method.
-   * @param cancellationToken - Token to cancel the wait
-   */
+  /** Wait for the callback owned by one OAuth attempt. */
   private async waitForSession(
+    attempt: ExtensionAuthAttempt,
     cancellationToken: vscode.CancellationToken,
   ): Promise<SupabaseSession | null> {
     const uriHandler = this.uriHandler;
@@ -412,26 +622,34 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
     return new Promise((resolve, reject) => {
       let isCleanedUp = false;
-      let cancellationListener: vscode.Disposable | undefined = undefined;
+      const cancellationListeners: vscode.Disposable[] = [];
 
       const cleanupListeners = () => {
         if (isCleanedUp) return;
         isCleanedUp = true;
         clearTimeout(timeoutHandle);
         subscription.dispose();
-        cancellationListener?.dispose();
+        for (const listener of cancellationListeners) listener.dispose();
       };
-
-      // Flag reset is handled by createSession's finally block
-      const subscription = uriHandler.onDidReceiveCallback(async (uri) => {
+      const cancel = () => {
         cleanupListeners();
+        if (this.activeAttempt === attempt) this.activeAttempt = undefined;
+        resolve(null);
+      };
+      attempt.cancel = cancel;
 
+      const subscription = uriHandler.onDidReceiveCallback(async (uri) => {
         try {
-          const result =
-            await this.sessionCoordinator.createSessionFromCallback({
-              path: uri.path,
-              query: uri.query,
-            });
+          const claimed = await this.claimCallback(uri.query, attempt);
+          if (!claimed) return;
+          cleanupListeners();
+
+          const result = await SupabaseClient.runPkceOperation(() =>
+            this.sessionCoordinator.createSessionFromCallback(
+              { path: uri.path, query: uri.query },
+              claimed.flowId,
+            ),
+          );
 
           if (!result.success) {
             if (result.error === 'Missing authorization code in callback') {
@@ -443,8 +661,13 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
             return;
           }
 
+          if (this.activeAttempt !== attempt) {
+            resolve(null);
+            return;
+          }
           resolve(result.session);
         } catch (error) {
+          cleanupListeners();
           log.error(
             `Error processing OAuth callback: ${toErrorMessage(error)}`,
           );
@@ -458,15 +681,13 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       }, AUTH_CALLBACK_TIMEOUT_MS);
 
       if (cancellationToken.isCancellationRequested) {
-        cleanupListeners();
-        resolve(null);
+        cancel();
         return;
       }
 
-      cancellationListener = cancellationToken.onCancellationRequested(() => {
-        cleanupListeners();
-        resolve(null);
-      });
+      const listener = cancellationToken.onCancellationRequested(cancel);
+      if (isCleanedUp) listener.dispose();
+      else cancellationListeners.push(listener);
     });
   }
 

--- a/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
+++ b/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
@@ -47,6 +47,7 @@ type PendingOAuthState = z.infer<typeof PendingOAuthStateSchema>;
 
 interface ExtensionAuthAttempt {
   readonly nonce: string;
+  readonly createdAt: number;
   cancel(): void;
 }
 
@@ -78,6 +79,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   private readonly sessionCoordinator: SupabaseSessionCoordinator;
   private readonly secrets: PlatformSecrets;
   private readonly authCommitQueue = new PQueue({ concurrency: 1 });
+  private readonly callbackClaimQueue = new PQueue({ concurrency: 1 });
   private activeAttempt: ExtensionAuthAttempt | undefined;
 
   private readonly notifier: AuthNotifier;
@@ -114,10 +116,12 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
     if (!stored) return null;
     try {
       const parsed = PendingOAuthStateSchema.safeParse(JSON.parse(stored));
-      return parsed.success ? parsed.data : null;
+      if (parsed.success) return parsed.data;
     } catch {
-      return null;
+      // The fixed diagnostic below deliberately excludes stored secret content.
     }
+    log.warn('Stored OAuth callback state is malformed and will be ignored');
+    return null;
   }
 
   private isPendingStateValid(state: PendingOAuthState): boolean {
@@ -132,27 +136,46 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
     );
   }
 
-  private async beginAuthAttempt(attempt: ExtensionAuthAttempt): Promise<void> {
-    await this.persistPendingState({
-      nonce: attempt.nonce,
-      createdAt: Date.now(),
-    });
+  private async sweepPendingOAuthStates(): Promise<void> {
+    let keys: readonly string[];
+    try {
+      keys = await this.secrets.listStoredKeys();
+    } catch {
+      log.warn('Unable to inspect stored OAuth callback state for cleanup');
+      return;
+    }
+
+    for (const key of keys) {
+      if (!key.startsWith(PENDING_OAUTH_STATE_PREFIX)) continue;
+      const nonce = key.slice(PENDING_OAUTH_STATE_PREFIX.length);
+      try {
+        const state = await this.readPendingOAuthState(nonce);
+        if (!state?.flowId || !this.isPendingStateValid(state)) {
+          await this.secrets.delete(key);
+        }
+      } catch {
+        log.warn('Unable to clean up stored OAuth callback state');
+      }
+    }
   }
 
   private async bindPkceFlow(
-    nonce: string,
+    attempt: ExtensionAuthAttempt,
     flowId: string | null | undefined,
   ): Promise<void> {
     if (!flowId || !PKCE_FLOW_ID_PATTERN.test(flowId)) {
       throw new Error('OAuth initialization did not return a valid PKCE flow.');
     }
-    const pending = await this.readPendingOAuthState(nonce);
-    if (!pending || !this.isPendingStateValid(pending)) {
+    if (!this.isPendingStateValid(attempt)) {
       throw new Error(
         'Authentication attempt is no longer pending. Try again.',
       );
     }
-    await this.persistPendingState({ ...pending, flowId });
+    await this.persistPendingState({
+      nonce: attempt.nonce,
+      createdAt: attempt.createdAt,
+      flowId,
+    });
   }
 
   private async clearPendingAttempt(nonce: string): Promise<void> {
@@ -171,48 +194,48 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
     query: string,
     expectedAttempt?: ExtensionAuthAttempt,
   ): Promise<ClaimedAuthCallback | null> {
-    const nonce = this.callbackNonce(query);
-    if (!nonce || (expectedAttempt && expectedAttempt.nonce !== nonce)) {
-      log.warn('OAuth callback rejected: invalid or stale attempt binding');
-      return null;
-    }
-
-    const pending = await this.readPendingOAuthState(nonce);
-    if (
-      !pending ||
-      !pending.flowId ||
-      pending.nonce !== nonce ||
-      !this.isPendingStateValid(pending)
-    ) {
-      if (pending && !this.isPendingStateValid(pending)) {
-        await this.clearPendingAttempt(nonce);
-      }
-      log.warn('OAuth callback rejected: invalid or stale attempt binding');
-      return null;
-    }
-
-    if (expectedAttempt && this.activeAttempt !== expectedAttempt) {
-      log.debug(
-        'OAuth callback ignored after its sign-in attempt was superseded',
-      );
-      return null;
-    }
-
-    const attempt = expectedAttempt ?? {
-      nonce,
-      cancel: () => {},
-    };
-    if (!expectedAttempt) {
-      if (this.activeAttempt) {
-        log.debug('OAuth callback ignored while another sign-in is active');
+    return this.callbackClaimQueue.add(async () => {
+      const nonce = this.callbackNonce(query);
+      if (!nonce || (expectedAttempt && expectedAttempt.nonce !== nonce)) {
+        log.warn('OAuth callback rejected: invalid or stale attempt binding');
         return null;
       }
-      this.activeAttempt = attempt;
-    }
 
-    await this.clearPendingAttempt(nonce);
-    if (this.activeAttempt !== attempt) return null;
-    return { attempt, flowId: pending.flowId };
+      try {
+        const pending = await this.readPendingOAuthState(nonce);
+        if (
+          !pending?.flowId ||
+          pending.nonce !== nonce ||
+          !this.isPendingStateValid(pending)
+        ) {
+          if (pending && !this.isPendingStateValid(pending)) {
+            await this.clearPendingAttempt(nonce);
+          }
+          log.warn('OAuth callback rejected: invalid or stale attempt binding');
+          return null;
+        }
+
+        if (expectedAttempt && this.activeAttempt !== expectedAttempt) {
+          log.debug(
+            'OAuth callback ignored after its sign-in attempt was superseded',
+          );
+          return null;
+        }
+
+        const attempt = expectedAttempt ?? {
+          nonce,
+          createdAt: pending.createdAt,
+          cancel: () => {},
+        };
+        await this.clearPendingAttempt(nonce);
+        if (expectedAttempt && this.activeAttempt !== attempt) return null;
+        return { attempt, flowId: pending.flowId };
+      } catch {
+        throw new Error(
+          'OAuth callback state could not be verified. Try again.',
+        );
+      }
+    }) as Promise<ClaimedAuthCallback | null>;
   }
 
   private invalidateActiveAttempt(): void {
@@ -271,28 +294,22 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
     this._onDidChangeSessions.dispose();
   }
 
-  /**
-   * Handle a late PKCE auth callback URI.
-   * This runs for all auth callbacks, but only processes if no session exists
-   * and no OAuth flow is currently active.
-   */
+  /** Handle a persisted callback not owned by this window's active attempt. */
   private async handleLateAuthCallback(uri: vscode.Uri): Promise<void> {
-    // The active attempt owns its callback through waitForSession. This listener
-    // exists only for a callback that arrives after extension-host restart.
-    if (this.activeAttempt) return;
-
-    const claimed = await this.claimCallback(uri.query);
-    if (!claimed) return;
-    const { attempt, flowId } = claimed;
+    const nonce = this.callbackNonce(uri.query);
+    if (nonce && this.activeAttempt?.nonce === nonce) return;
 
     try {
+      const claimed = await this.claimCallback(uri.query);
+      if (!claimed) return;
+
       const existingSession = await this.sessionCoordinator.loadSession();
-      if (existingSession || this.activeAttempt !== attempt) return;
+      if (existingSession) return;
 
       const result = await SupabaseClient.runPkceOperation(() =>
         this.sessionCoordinator.createSessionFromCallback(
           { path: uri.path, query: uri.query },
-          flowId,
+          claimed.flowId,
         ),
       );
 
@@ -307,20 +324,14 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       }
 
       await this.runAuthCommit(async () => {
-        if (this.activeAttempt !== attempt) return;
         await this.storeSession(result.session);
-        if (this.activeAttempt !== attempt) {
-          await this.sessionCoordinator.clearSessionIfCurrent(result.session);
-          return;
-        }
         this.notifier.showInfo(`Signed in as ${result.session.account.label}`);
         log.info(`Late sign-in successful for ${result.session.account.label}`);
       });
     } catch (error) {
-      log.error(`Error processing auth callback: ${toErrorMessage(error)}`);
-      this.notifier.showError(`Sign-in failed: ${toErrorMessage(error)}`);
-    } finally {
-      if (this.activeAttempt === attempt) this.activeAttempt = undefined;
+      const message = toErrorMessage(error);
+      log.error(`Error processing auth callback: ${message}`);
+      this.notifier.showError(`Sign-in failed: ${message}`);
     }
   }
 
@@ -454,28 +465,28 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
         this.invalidateActiveAttempt();
         const attempt: ExtensionAuthAttempt = {
           nonce: randomBytes(16).toString('hex'),
+          createdAt: Date.now(),
           cancel: () => {},
         };
         this.activeAttempt = attempt;
         const callback = this.waitForSession(attempt, token);
+        void callback.catch(() => {});
+        const interruptedError = () =>
+          new Error(
+            token.isCancellationRequested
+              ? 'Authentication cancelled. Try again.'
+              : 'Authentication attempt was superseded. Try again.',
+          );
 
         try {
           progress.report({ message: 'Waiting for authentication...' });
           // Finish any callback commit owned by the superseded attempt before
-          // publishing this attempt's pending state.
+          // initializing this attempt's PKCE flow.
           await this.runAuthCommit(async () => {});
-          if (this.activeAttempt !== attempt) {
-            throw new Error(
-              'Authentication attempt was superseded. Try again.',
-            );
-          }
+          if (this.activeAttempt !== attempt) throw interruptedError();
 
-          await this.beginAuthAttempt(attempt);
-          if (this.activeAttempt !== attempt) {
-            throw new Error(
-              'Authentication attempt was superseded. Try again.',
-            );
-          }
+          await this.sweepPendingOAuthStates();
+          if (this.activeAttempt !== attempt) throw interruptedError();
 
           const options = await this.buildOAuthOptions(attempt.nonce);
           const { data, error } = await SupabaseClient.runPkceOperation(() =>
@@ -490,12 +501,8 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
               `OAuth initialization failed: ${error?.message || 'Unknown error'}. Try again.`,
             );
           }
-          if (this.activeAttempt !== attempt) {
-            throw new Error(
-              'Authentication attempt was superseded. Try again.',
-            );
-          }
-          await this.bindPkceFlow(attempt.nonce, data.flowId);
+          if (this.activeAttempt !== attempt) throw interruptedError();
+          await this.bindPkceFlow(attempt, data.flowId);
 
           // The callback listener is already armed before the browser can send a
           // fast redirect back to the extension host.
@@ -514,11 +521,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
               await this.sessionCoordinator.clearSessionIfCurrent(session);
             }
           });
-          if (this.activeAttempt !== attempt) {
-            throw new Error(
-              'Authentication attempt was superseded. Try again.',
-            );
-          }
+          if (this.activeAttempt !== attempt) throw interruptedError();
 
           const sessions = await this.getSessions();
           if (sessions.length === 0) {
@@ -533,7 +536,11 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
         } finally {
           attempt.cancel();
           if (this.activeAttempt === attempt) this.activeAttempt = undefined;
-          await this.clearPendingAttempt(attempt.nonce);
+          try {
+            await this.clearPendingAttempt(attempt.nonce);
+          } catch {
+            log.warn('Unable to clean up stored OAuth callback state');
+          }
         }
       },
     );

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -41,8 +41,8 @@ const log = createLog('SupabaseClient');
  * Extension OAuth stores the flow id beside its application nonce and passes it
  * directly to code exchange, so concurrent attempts select separate verifier
  * slots without adding another callback query parameter. Hosts that omit a flow
- * id retain auth-js's fixed-verifier fallback. The numbered slot ring is capped
- * at five, so abandoned verifier state remains bounded.
+ * id retain auth-js's fixed-verifier fallback. Flow-id slots are tracked in a
+ * five-entry index; concurrent starts in separate hosts can race that index.
  */
 function gotrueStorage(secrets: SessionSecretStore): SupportedStorage {
   // Writes are mirrored here so a secret-store failure degrades to the old

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -1,3 +1,4 @@
+import PQueue from 'p-queue';
 import {
   createClient,
   SupabaseClient as Client,
@@ -37,11 +38,11 @@ const log = createLog('SupabaseClient');
  * This is the one shape `@supabase/auth-js` accepts, and it is only consulted
  * when `persistSession` is true — hence that flag below.
  *
- * A callback that carries no flow id (TeXRA's does not: the auth-bridge deep
- * link keeps `redirect_to` free of query parameters) clears the fixed verifier
- * key on exchange but leaves its numbered slot behind. GoTrue caps those at
- * five and evicts the oldest, so the leftovers are bounded and hold spent
- * verifiers, which are worthless without their single-use auth code.
+ * Extension OAuth stores the flow id beside its application nonce and passes it
+ * directly to code exchange, so concurrent attempts select separate verifier
+ * slots without adding another callback query parameter. Hosts that omit a flow
+ * id retain auth-js's fixed-verifier fallback. The numbered slot ring is capped
+ * at five, so abandoned verifier state remains bounded.
  */
 function gotrueStorage(secrets: SessionSecretStore): SupportedStorage {
   // Writes are mirrored here so a secret-store failure degrades to the old
@@ -98,6 +99,7 @@ export class SupabaseClient {
   private static instance: Client | null = null;
   private static config: { url: string; publicKey: string } | null = null;
   private static authProvider: AuthTokenProvider | null = null;
+  private static pkceOperations = new PQueue({ concurrency: 1 });
 
   /**
    * Error that occurred during initialization, if any.
@@ -121,6 +123,16 @@ export class SupabaseClient {
     this.authProvider = null;
     this.initError = null;
     this.readinessError = null;
+    this.pkceOperations = new PQueue({ concurrency: 1 });
+  }
+
+  /**
+   * Serialize PKCE callback exchange with OAuth initialization. Auth-js keeps
+   * each verifier in a flow-specific slot, while this queue prevents an older
+   * exchange from racing initialization in the same extension host.
+   */
+  static async runPkceOperation<T>(operation: () => Promise<T>): Promise<T> {
+    return this.pkceOperations.add(operation) as Promise<T>;
   }
 
   /**

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -189,19 +189,21 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
   /** Convert a PKCE OAuth callback into a host-neutral session record. */
   async createSessionFromCallback(
     uri: AuthCallbackUriParts,
+    flowId?: string,
   ): Promise<SupabaseCallbackResult> {
     const parsedCode = parseAuthCallbackCode(uri);
     return parsedCode.success
-      ? this.createSessionViaCodeExchange(parsedCode.code)
+      ? this.createSessionViaCodeExchange(parsedCode.code, flowId)
       : parsedCode;
   }
 
   private async createSessionViaCodeExchange(
     code: string,
+    flowId?: string,
   ): Promise<SupabaseCallbackResult> {
     const { data, error } = await this.options
       .getClient()
-      .auth.exchangeCodeForSession(code);
+      .auth.exchangeCodeForSession(code, flowId ? { flowId } : undefined);
 
     if (error || !data.session) {
       // A missing verifier means this callback belongs to a sign-in attempt

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -51,9 +51,9 @@ export const DEVICE_AUTH_BASE_URL = `https://${SUPABASE_CUSTOM_DOMAIN}/functions
  * deep link from the URL and offers a real-click "Open in your editor" button.
  * With PKCE the page only ever carries a one-time ?code= (no tokens).
  *
- * The editor scheme and extension id ride as PATH segments
- * (/auth-bridge/<scheme>/<id>) so redirect_to carries no '?' that an OAuth
- * round-trip could mangle. The Supabase Redirect URLs allow-list entry is the
+ * The editor scheme, extension id, and callback nonce ride as PATH segments
+ * (/auth-bridge/<scheme>/<id>/<nonce>) so redirect_to carries no '?'
+ * that an OAuth round-trip could mangle. The Redirect URLs allow-list entry is the
  * globstar https://remote.texra.ai/functions/v1/auth-bridge** (it must span the
  * '/' and '.' in the path, which a single '*' cannot).
  */

--- a/src/test-kernel/auth/SupabaseAuthProvider.vitest.ts
+++ b/src/test-kernel/auth/SupabaseAuthProvider.vitest.ts
@@ -15,6 +15,11 @@ const providerMocks = vi.hoisted(() => ({
     );
     return result;
   }),
+  secretDelete: vi.fn(async (key: string) => {
+    testDoubles.secrets.delete(key);
+  }),
+  secretGetStored: vi.fn(async (key: string) => testDoubles.secrets.get(key)),
+  secretListStoredKeys: vi.fn(async () => [...testDoubles.secrets.keys()]),
   signInWithOAuth: vi.fn(),
   signOut: vi.fn(async () => {}),
 }));
@@ -69,13 +74,12 @@ vi.mock('@platform/platform', () => ({
   platform: () => ({
     secrets: {
       get: async (key: string) => testDoubles.secrets.get(key),
-      getStored: async (key: string) => testDoubles.secrets.get(key),
+      getStored: providerMocks.secretGetStored,
       set: async (key: string, value: string) => {
         testDoubles.secrets.set(key, value);
       },
-      delete: async (key: string) => {
-        testDoubles.secrets.delete(key);
-      },
+      delete: providerMocks.secretDelete,
+      listStoredKeys: providerMocks.secretListStoredKeys,
     },
   }),
 }));
@@ -107,7 +111,10 @@ vi.mock('@model/computeModelOptions', () => ({
 }));
 
 // Local imports
-import { setExternalAuthCallbackResolver } from '@auth/config';
+import {
+  AUTH_CALLBACK_TIMEOUT_MS,
+  setExternalAuthCallbackResolver,
+} from '@auth/config';
 import type { SupabaseSession } from '@auth/SupabaseSession';
 import type { StoredSessionState } from '@auth/TokenProvider';
 import { SupabaseAuthProvider } from '@frontend/auth/SupabaseAuthProvider';
@@ -145,12 +152,14 @@ function createProvider(options: {
   fire: ReturnType<typeof vi.fn>;
   clearSessionIfCurrent: ReturnType<typeof vi.fn>;
   getStoredSessionState: ReturnType<typeof vi.fn>;
+  showError: ReturnType<typeof vi.fn>;
   showSignInPrompt: ReturnType<typeof vi.fn>;
 } {
   const clearSessionIfCurrent = vi.fn(async () => true);
   const getStoredSessionState = vi.fn<() => Promise<StoredSessionState>>(
     async () => 'invalid',
   );
+  const showError = vi.fn();
   const showSignInPrompt = vi.fn();
   const session: SupabaseSession = {
     id: 'user-id',
@@ -172,7 +181,7 @@ function createProvider(options: {
   testDoubles.coordinator = coordinator;
   testDoubles.emitters.length = 0;
   const provider = new SupabaseAuthProvider({
-    showError: vi.fn(),
+    showError,
     showInfo: vi.fn(),
     showSignInPrompt,
   });
@@ -186,6 +195,7 @@ function createProvider(options: {
     fire: emitter.fire,
     clearSessionIfCurrent,
     getStoredSessionState,
+    showError,
     showSignInPrompt,
   };
 }
@@ -653,7 +663,9 @@ describe('SupabaseAuthProvider OAuth callback binding', () => {
     });
 
     const secondSignIn = second.provider.createSession([]);
-    await Promise.resolve();
+    await vi.waitFor(() =>
+      expect(providerMocks.runPkceOperation).toHaveBeenCalledTimes(2),
+    );
     expect(providerMocks.signInWithOAuth).not.toHaveBeenCalled();
 
     finishExchange();
@@ -738,6 +750,195 @@ describe('SupabaseAuthProvider OAuth callback binding', () => {
       },
       TEST_FLOW_ID,
     );
+  });
+
+  it('accepts another window callback while its own attempt remains live', async () => {
+    const ownFlowId = '1234567890abcdef1234567890abcdef';
+    seedPendingOAuthAttempt();
+    const { provider, session, coordinator } = createUnexpiredProvider();
+    const uriHandler = createUriHandlerHarness();
+    provider.setUriHandler(uriHandler.handler);
+    coordinator.loadSession.mockResolvedValue(null);
+    coordinator.createSessionFromCallback.mockResolvedValue({
+      success: true,
+      session,
+    });
+    providerMocks.signInWithOAuth.mockResolvedValue({
+      data: {
+        url: 'https://provider.example/authorize',
+        flowId: ownFlowId,
+      },
+      error: null,
+    });
+    let browserOpened!: () => void;
+    const browserLaunch = new Promise<void>((resolve) => {
+      browserOpened = resolve;
+    });
+    providerMocks.openExternal.mockImplementation(async () => {
+      browserOpened();
+      return true;
+    });
+
+    const ownSignIn = provider.createSession([]).catch(() => null);
+    await browserLaunch;
+    await uriHandler.fire({
+      path: '/auth-callback',
+      query: `code=other-window&app_nonce=${TEST_NONCE}`,
+    });
+    await uriHandler.fire({
+      path: '/auth-callback',
+      query: `code=replay&app_nonce=${TEST_NONCE}`,
+    });
+
+    expect(coordinator.createSessionFromCallback).toHaveBeenCalledOnce();
+    expect(coordinator.createSessionFromCallback).toHaveBeenCalledWith(
+      {
+        path: '/auth-callback',
+        query: expect.stringContaining('code=other-window'),
+      },
+      TEST_FLOW_ID,
+    );
+    provider.dispose();
+    await ownSignIn;
+  });
+
+  it.each(['read', 'delete'] as const)(
+    'contains a secret-store %s claim failure and accepts a later callback',
+    async (operation) => {
+      const secondNonce = 'ffffffffffffffffffffffffffffffff';
+      seedPendingOAuthAttempt();
+      seedPendingOAuthAttempt(secondNonce);
+      const { provider, session, coordinator, showError } =
+        createUnexpiredProvider();
+      const uriHandler = createUriHandlerHarness();
+      provider.setUriHandler(uriHandler.handler);
+      coordinator.loadSession.mockResolvedValue(null);
+      coordinator.createSessionFromCallback.mockResolvedValue({
+        success: true,
+        session,
+      });
+      const failure = new Error('secret backend unavailable: private detail');
+      if (operation === 'read') {
+        providerMocks.secretGetStored.mockRejectedValueOnce(failure);
+      } else {
+        providerMocks.secretDelete.mockRejectedValueOnce(failure);
+      }
+
+      await expect(
+        uriHandler.fire({
+          path: '/auth-callback',
+          query: `code=first&app_nonce=${TEST_NONCE}`,
+        }),
+      ).resolves.toBeUndefined();
+      await uriHandler.fire({
+        path: '/auth-callback',
+        query: `code=second&app_nonce=${secondNonce}`,
+      });
+
+      expect(coordinator.createSessionFromCallback).toHaveBeenCalledOnce();
+      expect(showError).toHaveBeenCalledWith(
+        'Sign-in failed: OAuth callback state could not be verified. Try again.',
+      );
+    },
+  );
+
+  it('sweeps malformed, expired, and flowless pending OAuth records', async () => {
+    const expiredNonce = '11111111111111111111111111111111';
+    const flowlessNonce = '22222222222222222222222222222222';
+    const malformedNonce = '33333333333333333333333333333333';
+    const validNonce = '44444444444444444444444444444444';
+    seedPendingOAuthAttempt(
+      expiredNonce,
+      Date.now() - AUTH_CALLBACK_TIMEOUT_MS - 1,
+    );
+    testDoubles.secrets.set(
+      `${PENDING_STATE_PREFIX}${flowlessNonce}`,
+      JSON.stringify({ nonce: flowlessNonce, createdAt: Date.now() }),
+    );
+    testDoubles.secrets.set(`${PENDING_STATE_PREFIX}${malformedNonce}`, '{');
+    seedPendingOAuthAttempt(validNonce);
+    testDoubles.secrets.set('unrelated', 'keep');
+    const { provider } = createUnexpiredProvider();
+    const uriHandler = createUriHandlerHarness();
+    provider.setUriHandler(uriHandler.handler);
+    providerMocks.signInWithOAuth.mockResolvedValue({
+      data: {
+        url: 'https://provider.example/authorize',
+        flowId: TEST_FLOW_ID,
+      },
+      error: null,
+    });
+    let browserOpened!: () => void;
+    const browserLaunch = new Promise<void>((resolve) => {
+      browserOpened = resolve;
+    });
+    providerMocks.openExternal.mockImplementation(async () => {
+      browserOpened();
+      return true;
+    });
+
+    const signIn = provider.createSession([]).catch(() => null);
+    await browserLaunch;
+
+    expect(
+      testDoubles.secrets.has(`${PENDING_STATE_PREFIX}${expiredNonce}`),
+    ).toBe(false);
+    expect(
+      testDoubles.secrets.has(`${PENDING_STATE_PREFIX}${flowlessNonce}`),
+    ).toBe(false);
+    expect(
+      testDoubles.secrets.has(`${PENDING_STATE_PREFIX}${malformedNonce}`),
+    ).toBe(false);
+    expect(
+      testDoubles.secrets.has(`${PENDING_STATE_PREFIX}${validNonce}`),
+    ).toBe(true);
+    expect(testDoubles.secrets.get('unrelated')).toBe('keep');
+    provider.dispose();
+    await signIn;
+  });
+
+  it('handles callback rejection while browser launch is still pending', async () => {
+    const { provider, coordinator } = createUnexpiredProvider();
+    const uriHandler = createUriHandlerHarness();
+    provider.setUriHandler(uriHandler.handler);
+    coordinator.createSessionFromCallback.mockResolvedValue({
+      success: false,
+      error: 'exchange failed',
+      isAuthError: true,
+    });
+    providerMocks.signInWithOAuth.mockResolvedValue({
+      data: {
+        url: 'https://provider.example/authorize',
+        flowId: TEST_FLOW_ID,
+      },
+      error: null,
+    });
+    let releaseBrowser!: () => void;
+    let browserOpened!: () => void;
+    const browserLaunch = new Promise<void>((resolve) => {
+      browserOpened = resolve;
+    });
+    providerMocks.openExternal.mockImplementation(async () => {
+      browserOpened();
+      await new Promise<void>((resolve) => {
+        releaseBrowser = resolve;
+      });
+      return true;
+    });
+
+    const signIn = provider.createSession([]);
+    await browserLaunch;
+    const redirectTo = providerMocks.signInWithOAuth.mock.calls[0][0].options
+      .redirectTo as string;
+    const nonce = redirectTo.split('/').at(-1);
+    await uriHandler.fire({
+      path: '/auth-callback',
+      query: `code=test&app_nonce=${nonce}`,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    releaseBrowser();
+
+    await expect(signIn).rejects.toThrow('OAuth error: exchange failed');
   });
 
   it('rejects missing, duplicate, malformed, mismatched, expired, and replayed callbacks', async () => {

--- a/src/test-kernel/auth/SupabaseAuthProvider.vitest.ts
+++ b/src/test-kernel/auth/SupabaseAuthProvider.vitest.ts
@@ -1,10 +1,21 @@
 // Third-party imports
+import * as vscode from 'vscode';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const providerMocks = vi.hoisted(() => ({
   getUser: vi.fn(),
   invalidateModelOptionsCache: vi.fn(),
   invalidateRemoteAgentsAfterSignOut: vi.fn(async () => {}),
+  openExternal: vi.fn(async () => true),
+  runPkceOperation: vi.fn((operation: () => Promise<unknown>) => {
+    const result = testDoubles.pkceTail.then(operation);
+    testDoubles.pkceTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }),
+  signInWithOAuth: vi.fn(),
   signOut: vi.fn(async () => {}),
 }));
 
@@ -14,21 +25,59 @@ const providerMocks = vi.hoisted(() => ({
 const testDoubles = vi.hoisted(() => ({
   coordinator: null as Record<string, ReturnType<typeof vi.fn>> | null,
   emitters: [] as Array<{ fire: ReturnType<typeof vi.fn> }>,
+  pkceTail: Promise.resolve<unknown>(undefined),
+  secrets: new Map<string, string>(),
 }));
 
 vi.mock('vscode', () => ({
   EventEmitter: class {
-    readonly event = vi.fn();
-    dispose = vi.fn();
-    fire = vi.fn();
+    private readonly listeners = new Set<(value: unknown) => unknown>();
+    readonly event = vi.fn((listener: (value: unknown) => unknown) => {
+      this.listeners.add(listener);
+      return { dispose: () => this.listeners.delete(listener) };
+    });
+    dispose = vi.fn(() => this.listeners.clear());
+    fire = vi.fn((value: unknown) => {
+      for (const listener of this.listeners) void listener(value);
+    });
     constructor() {
       testDoubles.emitters.push(this);
     }
   },
+  env: {
+    uiKind: 1,
+    uriScheme: 'vscode',
+    openExternal: providerMocks.openExternal,
+  },
+  ProgressLocation: { Notification: 15 },
+  UIKind: { Desktop: 1, Web: 2 },
+  Uri: { parse: (value: string) => ({ value }) },
+  window: {
+    withProgress: vi.fn(async (_options, task) =>
+      task(
+        { report: vi.fn() },
+        {
+          isCancellationRequested: false,
+          onCancellationRequested: vi.fn(() => ({ dispose: vi.fn() })),
+        },
+      ),
+    ),
+  },
 }));
 
 vi.mock('@platform/platform', () => ({
-  platform: () => ({ secrets: {} }),
+  platform: () => ({
+    secrets: {
+      get: async (key: string) => testDoubles.secrets.get(key),
+      getStored: async (key: string) => testDoubles.secrets.get(key),
+      set: async (key: string, value: string) => {
+        testDoubles.secrets.set(key, value);
+      },
+      delete: async (key: string) => {
+        testDoubles.secrets.delete(key);
+      },
+    },
+  }),
 }));
 
 vi.mock('@auth/SupabaseAuthCoordinator', () => ({
@@ -37,9 +86,11 @@ vi.mock('@auth/SupabaseAuthCoordinator', () => ({
 
 vi.mock('@auth/SupabaseClient', () => ({
   SupabaseClient: {
+    runPkceOperation: providerMocks.runPkceOperation,
     getClient: () => ({
       auth: {
         getUser: providerMocks.getUser,
+        signInWithOAuth: providerMocks.signInWithOAuth,
         signOut: providerMocks.signOut,
       },
     }),
@@ -56,10 +107,33 @@ vi.mock('@model/computeModelOptions', () => ({
 }));
 
 // Local imports
+import { setExternalAuthCallbackResolver } from '@auth/config';
 import type { SupabaseSession } from '@auth/SupabaseSession';
 import type { StoredSessionState } from '@auth/TokenProvider';
 import { SupabaseAuthProvider } from '@frontend/auth/SupabaseAuthProvider';
 import type { SupabaseUriHandler } from '@frontend/auth/UriHandler';
+
+const PENDING_STATE_PREFIX = 'texra.extension.pendingOAuthState.';
+const TEST_NONCE = '0123456789abcdef0123456789abcdef';
+const TEST_FLOW_ID = 'abcdef0123456789abcdef0123456789';
+
+function seedPendingOAuthAttempt(
+  nonce = TEST_NONCE,
+  createdAt = Date.now(),
+  flowId = TEST_FLOW_ID,
+): void {
+  testDoubles.secrets.set(
+    `${PENDING_STATE_PREFIX}${nonce}`,
+    JSON.stringify({ nonce, createdAt, flowId }),
+  );
+}
+
+afterEach(() => {
+  testDoubles.secrets.clear();
+  testDoubles.pkceTail = Promise.resolve(undefined);
+  setExternalAuthCallbackResolver(null);
+  Object.assign(vscode.env, { uiKind: vscode.UIKind.Desktop });
+});
 
 function createProvider(options: {
   expiresAt: number;
@@ -127,6 +201,34 @@ function createExpiredProvider(
 
 function createUnexpiredProvider(): ReturnType<typeof createProvider> {
   return createProvider({ expiresAt: Date.now() + 60_000 });
+}
+
+function createUriHandlerHarness(): {
+  handler: SupabaseUriHandler;
+  fire(uri: { path: string; query: string }): Promise<void>;
+  listenerCount(): number;
+} {
+  const listeners = new Set<
+    (uri: { path: string; query: string }) => void | Promise<void>
+  >();
+  return {
+    handler: {
+      onDidReceiveCallback: (
+        listener: (uri: {
+          path: string;
+          query: string;
+        }) => void | Promise<void>,
+      ) => {
+        listeners.add(listener);
+        return { dispose: () => listeners.delete(listener) };
+      },
+      handleUri: vi.fn(),
+    } as unknown as SupabaseUriHandler,
+    async fire(uri) {
+      await Promise.all([...listeners].map((listener) => listener(uri)));
+    },
+    listenerCount: () => listeners.size,
+  };
 }
 
 describe('SupabaseAuthProvider expired-session refresh', () => {
@@ -224,6 +326,7 @@ describe('SupabaseAuthProvider model availability', () => {
   // Listeners recompute model options from the session-change event, so an
   // event published ahead of the invalidation serves the stale option list.
   it('invalidates model availability before publishing a new session', async () => {
+    seedPendingOAuthAttempt();
     const { provider, session, coordinator, fire } = createUnexpiredProvider();
 
     // Drive the login path through its public seams: a late OAuth callback
@@ -246,7 +349,10 @@ describe('SupabaseAuthProvider model availability', () => {
     } as unknown as SupabaseUriHandler;
     provider.setUriHandler(handler);
 
-    await authCallback?.({ path: '/auth-callback', query: 'code=test' });
+    await authCallback?.({
+      path: '/auth-callback',
+      query: `code=test&app_nonce=${TEST_NONCE}`,
+    });
 
     expect(providerMocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
     expect(
@@ -276,5 +382,405 @@ describe('SupabaseAuthProvider model availability', () => {
 
     expect(coordinator.clearSession).toHaveBeenCalledOnce();
     expect(providerMocks.signOut).not.toHaveBeenCalled();
+  });
+
+  it('clears its pending OAuth attempt when signing out without a session', async () => {
+    const { provider, coordinator } = createUnexpiredProvider();
+    const uriHandler = createUriHandlerHarness();
+    provider.setUriHandler(uriHandler.handler);
+    coordinator.loadSession.mockResolvedValue(null);
+    let redirectTo = '';
+    providerMocks.signInWithOAuth.mockImplementation(async (input) => {
+      redirectTo = input.options.redirectTo;
+      return {
+        data: {
+          url: 'https://provider.example/authorize',
+          flowId: TEST_FLOW_ID,
+        },
+        error: null,
+      };
+    });
+    let browserOpened!: () => void;
+    const browserLaunch = new Promise<void>((resolve) => {
+      browserOpened = resolve;
+    });
+    providerMocks.openExternal.mockImplementation(async () => {
+      browserOpened();
+      return true;
+    });
+    const signIn = provider.createSession([]).catch(() => null);
+    await browserLaunch;
+
+    await expect(provider.removeStoredSession()).resolves.toBe(false);
+    await signIn;
+
+    const nonce = redirectTo.split('/').at(-1);
+    expect(
+      testDoubles.secrets.get(`${PENDING_STATE_PREFIX}${nonce}`),
+    ).toBeUndefined();
+  });
+});
+
+describe('SupabaseAuthProvider OAuth callback binding', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persists and consumes a desktop nonce with the waiter armed before browser launch', async () => {
+    const { provider, session, coordinator } = createUnexpiredProvider();
+    const uriHandler = createUriHandlerHarness();
+    provider.setUriHandler(uriHandler.handler);
+    coordinator.createSessionFromCallback.mockResolvedValue({
+      success: true,
+      session,
+    });
+    providerMocks.getUser.mockResolvedValue({
+      data: { user: { id: session.id } },
+      error: null,
+    });
+
+    let redirectTo = '';
+    providerMocks.signInWithOAuth.mockImplementation(async (input) => {
+      redirectTo = input.options.redirectTo;
+      return {
+        data: {
+          url: 'https://provider.example/authorize',
+          flowId: TEST_FLOW_ID,
+        },
+        error: null,
+      };
+    });
+    providerMocks.openExternal.mockImplementation(async () => {
+      const nonce = redirectTo.split('/').at(-1);
+      expect(nonce).toMatch(/^[0-9a-f]{32}$/);
+      expect(uriHandler.listenerCount()).toBe(2);
+      expect(
+        JSON.parse(
+          testDoubles.secrets.get(`${PENDING_STATE_PREFIX}${nonce}`) ?? '',
+        ),
+      ).toEqual({
+        nonce,
+        createdAt: expect.any(Number),
+        flowId: TEST_FLOW_ID,
+      });
+      await uriHandler.fire({
+        path: '/auth-callback',
+        query: `code=one-time-code&app_nonce=${nonce}`,
+      });
+      return true;
+    });
+
+    await expect(provider.createSession([])).resolves.toMatchObject({
+      id: session.id,
+    });
+
+    expect(redirectTo).toMatch(
+      /\/auth-bridge\/vscode\/texra-ai\.texra\/[0-9a-f]{32}$/,
+    );
+    expect(coordinator.createSessionFromCallback).toHaveBeenCalledOnce();
+    const nonce = redirectTo.split('/').at(-1);
+    expect(
+      testDoubles.secrets.get(`${PENDING_STATE_PREFIX}${nonce}`),
+    ).toBeUndefined();
+  });
+
+  it('preserves web routing state bytes while carrying the application nonce separately', async () => {
+    Object.assign(vscode.env, { uiKind: vscode.UIKind.Web });
+    const callbackUrl =
+      'https://example.github.dev/extension-auth-callback?state=a%2Bb%2F%3D';
+    setExternalAuthCallbackResolver(async () => ({ fullUrl: callbackUrl }));
+    const { provider, session, coordinator } = createUnexpiredProvider();
+    const uriHandler = createUriHandlerHarness();
+    provider.setUriHandler(uriHandler.handler);
+    coordinator.createSessionFromCallback.mockResolvedValue({
+      success: true,
+      session,
+    });
+    providerMocks.getUser.mockResolvedValue({
+      data: { user: { id: session.id } },
+      error: null,
+    });
+
+    let redirectTo = '';
+    providerMocks.signInWithOAuth.mockImplementation(async (input) => {
+      redirectTo = input.options.redirectTo;
+      return {
+        data: {
+          url: 'https://provider.example/authorize',
+          flowId: TEST_FLOW_ID,
+        },
+        error: null,
+      };
+    });
+    providerMocks.openExternal.mockImplementation(async () => {
+      const nonce = new URL(redirectTo).searchParams.get('app_nonce');
+      await uriHandler.fire({
+        path: '/extension-auth-callback',
+        query: `code=one-time-code&app_nonce=${nonce}`,
+      });
+      return true;
+    });
+
+    await provider.createSession([]);
+
+    expect(redirectTo).toMatch(
+      new RegExp(
+        `^${callbackUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}&app_nonce=[0-9a-f]{32}$`,
+      ),
+    );
+  });
+
+  it('allows another live extension window to claim an attempt started by the first', async () => {
+    const first = createUnexpiredProvider();
+    const second = createUnexpiredProvider();
+    const firstHandler = createUriHandlerHarness();
+    const secondHandler = createUriHandlerHarness();
+    first.provider.setUriHandler(firstHandler.handler);
+    second.provider.setUriHandler(secondHandler.handler);
+    second.coordinator.loadSession.mockResolvedValue(null);
+    second.coordinator.createSessionFromCallback.mockResolvedValue({
+      success: true,
+      session: second.session,
+    });
+
+    const redirects: string[] = [];
+    providerMocks.signInWithOAuth.mockImplementation(async (input) => {
+      redirects.push(input.options.redirectTo);
+      return {
+        data: {
+          url: 'https://provider.example/authorize',
+          flowId:
+            redirects.length === 1
+              ? TEST_FLOW_ID
+              : '1234567890abcdef1234567890abcdef',
+        },
+        error: null,
+      };
+    });
+    let firstBrowserOpened!: () => void;
+    const firstBrowserLaunch = new Promise<void>((resolve) => {
+      firstBrowserOpened = resolve;
+    });
+    let secondBrowserOpened!: () => void;
+    const secondBrowserLaunch = new Promise<void>((resolve) => {
+      secondBrowserOpened = resolve;
+    });
+    providerMocks.openExternal.mockImplementation(async () => {
+      if (redirects.length === 1) firstBrowserOpened();
+      else secondBrowserOpened();
+      return true;
+    });
+
+    const firstSignIn = first.provider.createSession([]).catch(() => null);
+    await firstBrowserLaunch;
+    const firstNonce = redirects[0].split('/').at(-1);
+    await secondHandler.fire({
+      path: '/auth-callback',
+      query: `code=second-window&app_nonce=${firstNonce}`,
+    });
+    expect(second.coordinator.createSessionFromCallback).toHaveBeenCalledOnce();
+
+    const secondSignIn = second.provider.createSession([]).catch(() => null);
+    await secondBrowserLaunch;
+    const secondNonce = redirects[1].split('/').at(-1);
+    first.provider.dispose();
+    await firstSignIn;
+
+    expect(
+      testDoubles.secrets.get(`${PENDING_STATE_PREFIX}${secondNonce}`),
+    ).toBeDefined();
+    second.provider.dispose();
+    await secondSignIn;
+  });
+
+  it('waits for a claimed callback exchange before initializing the next PKCE flow', async () => {
+    seedPendingOAuthAttempt();
+    const first = createUnexpiredProvider();
+    const firstHandler = createUriHandlerHarness();
+    first.provider.setUriHandler(firstHandler.handler);
+    first.coordinator.loadSession.mockResolvedValue(null);
+
+    let exchangeStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      exchangeStarted = resolve;
+    });
+    let finishExchange!: () => void;
+    const exchangeGate = new Promise<void>((resolve) => {
+      finishExchange = resolve;
+    });
+    first.coordinator.createSessionFromCallback.mockImplementation(async () => {
+      exchangeStarted();
+      await exchangeGate;
+      throw new Error('first exchange failed');
+    });
+
+    const firstCallback = firstHandler.fire({
+      path: '/auth-callback',
+      query: `code=first&app_nonce=${TEST_NONCE}`,
+    });
+    await started;
+
+    const second = createUnexpiredProvider();
+    const secondHandler = createUriHandlerHarness();
+    second.provider.setUriHandler(secondHandler.handler);
+    second.coordinator.createSessionFromCallback.mockResolvedValue({
+      success: true,
+      session: second.session,
+    });
+    providerMocks.getUser.mockResolvedValue({
+      data: { user: { id: second.session.id } },
+      error: null,
+    });
+    const secondFlowId = '1234567890abcdef1234567890abcdef';
+    let redirectTo = '';
+    providerMocks.signInWithOAuth.mockImplementation(async (input) => {
+      redirectTo = input.options.redirectTo;
+      return {
+        data: {
+          url: 'https://provider.example/authorize',
+          flowId: secondFlowId,
+        },
+        error: null,
+      };
+    });
+    let browserOpened!: () => void;
+    const browserLaunch = new Promise<void>((resolve) => {
+      browserOpened = resolve;
+    });
+    providerMocks.openExternal.mockImplementation(async () => {
+      browserOpened();
+      return true;
+    });
+
+    const secondSignIn = second.provider.createSession([]);
+    await Promise.resolve();
+    expect(providerMocks.signInWithOAuth).not.toHaveBeenCalled();
+
+    finishExchange();
+    await firstCallback;
+    await browserLaunch;
+    expect(providerMocks.signInWithOAuth).toHaveBeenCalledOnce();
+
+    const secondNonce = redirectTo.split('/').at(-1);
+    await secondHandler.fire({
+      path: '/auth-callback',
+      query: `code=second&app_nonce=${secondNonce}`,
+    });
+    await expect(secondSignIn).resolves.toMatchObject({
+      id: second.session.id,
+    });
+    expect(second.coordinator.createSessionFromCallback).toHaveBeenCalledWith(
+      {
+        path: '/auth-callback',
+        query: expect.stringContaining('code=second'),
+      },
+      secondFlowId,
+    );
+  });
+
+  it('prevents a superseded callback from committing or clearing the newer attempt', async () => {
+    const { provider, session, coordinator } = createUnexpiredProvider();
+    const uriHandler = createUriHandlerHarness();
+    provider.setUriHandler(uriHandler.handler);
+    coordinator.createSessionFromCallback.mockResolvedValue({
+      success: true,
+      session,
+    });
+    providerMocks.getUser.mockResolvedValue({
+      data: { user: { id: session.id } },
+      error: null,
+    });
+
+    const redirects: string[] = [];
+    providerMocks.signInWithOAuth.mockImplementation(async (input) => {
+      redirects.push(input.options.redirectTo);
+      return {
+        data: {
+          url: 'https://provider.example/authorize',
+          flowId: TEST_FLOW_ID,
+        },
+        error: null,
+      };
+    });
+    let firstOpened!: () => void;
+    const firstBrowserLaunch = new Promise<void>((resolve) => {
+      firstOpened = resolve;
+    });
+    providerMocks.openExternal.mockImplementation(async () => {
+      if (redirects.length === 1) {
+        firstOpened();
+        return true;
+      }
+      const oldNonce = redirects[0].split('/').at(-1);
+      const newNonce = redirects[1].split('/').at(-1);
+      await uriHandler.fire({
+        path: '/auth-callback',
+        query: `code=old&app_nonce=${oldNonce}`,
+      });
+      await uriHandler.fire({
+        path: '/auth-callback',
+        query: `code=new&app_nonce=${newNonce}`,
+      });
+      return true;
+    });
+
+    const first = provider.createSession([]).catch(() => null);
+    await firstBrowserLaunch;
+    const second = provider.createSession([]);
+
+    await expect(first).resolves.toBeNull();
+    await expect(second).resolves.toMatchObject({ id: session.id });
+    expect(coordinator.createSessionFromCallback).toHaveBeenCalledOnce();
+    expect(coordinator.createSessionFromCallback).toHaveBeenCalledWith(
+      {
+        path: '/auth-callback',
+        query: expect.stringContaining('code=new'),
+      },
+      TEST_FLOW_ID,
+    );
+  });
+
+  it('rejects missing, duplicate, malformed, mismatched, expired, and replayed callbacks', async () => {
+    seedPendingOAuthAttempt();
+    const { provider, session, coordinator } = createUnexpiredProvider();
+    const uriHandler = createUriHandlerHarness();
+    provider.setUriHandler(uriHandler.handler);
+    coordinator.loadSession.mockResolvedValue(null);
+    coordinator.createSessionFromCallback.mockResolvedValue({
+      success: true,
+      session,
+    });
+
+    for (const query of [
+      'code=test',
+      `code=test&app_nonce=${TEST_NONCE}&app_nonce=${TEST_NONCE}`,
+      'code=test&app_nonce=not-a-nonce',
+      'code=test&app_nonce=ffffffffffffffffffffffffffffffff',
+    ]) {
+      await uriHandler.fire({ path: '/auth-callback', query });
+    }
+    expect(coordinator.createSessionFromCallback).not.toHaveBeenCalled();
+
+    await uriHandler.fire({
+      path: '/auth-callback',
+      query: `code=test&app_nonce=${TEST_NONCE}`,
+    });
+    await uriHandler.fire({
+      path: '/auth-callback',
+      query: `code=test&app_nonce=${TEST_NONCE}`,
+    });
+    expect(coordinator.createSessionFromCallback).toHaveBeenCalledOnce();
+
+    seedPendingOAuthAttempt(TEST_NONCE, Date.now() - 10 * 60 * 1000 - 1);
+    const expired = createUnexpiredProvider();
+    const expiredHandler = createUriHandlerHarness();
+    expired.provider.setUriHandler(expiredHandler.handler);
+    await expiredHandler.fire({
+      path: '/auth-callback',
+      query: `code=test&app_nonce=${TEST_NONCE}`,
+    });
+    expect(
+      expired.coordinator.createSessionFromCallback,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/auth/UriHandler.vitest.ts
+++ b/src/test-kernel/auth/UriHandler.vitest.ts
@@ -1,0 +1,38 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('vscode', () => ({
+  EventEmitter: class<T> {
+    private listener: ((value: T) => void) | undefined;
+    readonly event = (listener: (value: T) => void) => {
+      this.listener = listener;
+      return { dispose: vi.fn() };
+    };
+    fire(value: T): void {
+      this.listener?.(value);
+    }
+  },
+}));
+
+// Local imports
+import { SupabaseUriHandler } from '@frontend/auth/UriHandler';
+
+describe('SupabaseUriHandler', () => {
+  it('forwards desktop and web auth callbacks without rewriting their query', () => {
+    const handler = new SupabaseUriHandler();
+    const received: Array<{ path: string; query: string }> = [];
+    handler.onDidReceiveCallback((uri) => received.push(uri));
+    const query =
+      'state=a%2Bb%2F%3D&code=one-time-code&app_nonce=0123456789abcdef0123456789abcdef';
+
+    for (const path of ['/auth-callback', '/extension-auth-callback']) {
+      handler.handleUri({ path, query } as never);
+    }
+    handler.handleUri({ path: '/unrelated', query } as never);
+
+    expect(received).toStrictEqual([
+      { path: '/auth-callback', query },
+      { path: '/extension-auth-callback', query },
+    ]);
+  });
+});

--- a/supabase/functions/auth-bridge/index.ts
+++ b/supabase/functions/auth-bridge/index.ts
@@ -13,14 +13,14 @@
  * query string (or ?error= on failure). No access/refresh token ever reaches
  * the bridge; the editor exchanges the code using a verifier it never shared.
  *
- * The editor scheme and extension id ride as PATH segments
- * (/auth-bridge/<ext>/<id>) so redirect_to carries no '?' that an OAuth
+ * The editor scheme, extension id, and application nonce ride as PATH segments
+ * (/auth-bridge/<ext>/<id>/<nonce>) so redirect_to carries no '?' that an OAuth
  * round-trip could mangle into the function name. The page reconstructs
- * `${ext}://${id}/auth-callback` + the original query so the extension's
- * callback handler reads the code exactly as it would from the raw redirect.
+ * `${ext}://${id}/auth-callback` + the original query, replacing any inbound
+ * app_nonce with the validated path nonce.
  *
  * Routes:
- * - GET /auth-bridge/<ext>/<id> - The bridge HTML page (no auth header).
+ * - GET /auth-bridge/<ext>/<id>/<nonce> - The bridge HTML page (no auth header).
  *
  * Security:
  * - ext is validated server-side AND in client JS against a fixed allowlist of
@@ -66,6 +66,7 @@ const ALLOWED_EXT_SCHEMES = [
  * scheme://publisher.name that an attacker could place in redirect_to.
  */
 const EXTENSION_ID_PATTERN = /^texra-ai\.[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+const APP_NONCE_PATTERN = /^[0-9a-f]{32}$/;
 
 // =============================================================================
 // Validation
@@ -79,6 +80,10 @@ function isAllowedExtScheme(value: string | null): value is string {
 
 function isValidExtensionId(value: string | null): value is string {
   return value !== null && EXTENSION_ID_PATTERN.test(value);
+}
+
+function isValidAppNonce(value: string | null): value is string {
+  return value !== null && APP_NONCE_PATTERN.test(value);
 }
 
 /** Percent-decode a single path segment, returning null on malformed input. */
@@ -95,33 +100,49 @@ function decodeSegment(value: string | undefined): string | null {
 // Server
 // =============================================================================
 
-Deno.serve((req: Request): Response => {
+export function handleRequest(req: Request): Response {
   if (req.method !== 'GET') {
     return htmlResponse(errorPageHtml('This page only responds to GET.'), 405);
   }
 
-  // ext/id are the two path segments after "auth-bridge"
-  // (/functions/v1/auth-bridge/<ext>/<id>). Read them from the path, never a
-  // query, so redirect_to carries no '?'.
+  // ext/id/nonce are path segments after "auth-bridge"
+  // (/functions/v1/auth-bridge/<ext>/<id>/<nonce>). Read them from the path,
+  // never a query, so redirect_to carries no '?'.
   const segments = new URL(req.url).pathname
     .split('/')
     .filter((segment) => segment.length > 0);
   const anchor = segments.lastIndexOf('auth-bridge');
   const ext = anchor >= 0 ? decodeSegment(segments[anchor + 1]) : null;
   const id = anchor >= 0 ? decodeSegment(segments[anchor + 2]) : null;
+  const nonceSegment = anchor >= 0 ? segments[anchor + 3] : undefined;
+  const nonce = decodeSegment(nonceSegment);
+  const hasExtraSegment = anchor >= 0 && segments[anchor + 4] !== undefined;
 
-  // Reject unknown editors / malformed ids before rendering anything. The raw
-  // value is never echoed into the HTML, so an invalid request gets a generic
-  // error page (no reflection).
-  if (!isAllowedExtScheme(ext) || !isValidExtensionId(id)) {
+  if (nonceSegment === undefined) {
+    return htmlResponse(
+      errorPageHtml('This sign-in link is missing its security nonce.'),
+      400,
+    );
+  }
+
+  // Require and validate the nonce before rendering anything. Raw values are
+  // never reflected into the HTML.
+  if (
+    !isAllowedExtScheme(ext) ||
+    !isValidExtensionId(id) ||
+    !isValidAppNonce(nonce) ||
+    hasExtraSegment
+  ) {
     return htmlResponse(
       errorPageHtml('This sign-in link is invalid or unsupported.'),
       400,
     );
   }
 
-  return htmlResponse(bridgePageHtml(ext, id), 200);
-});
+  return htmlResponse(bridgePageHtml(ext, id, nonce), 200);
+}
+
+if (import.meta.main) Deno.serve(handleRequest);
 
 // =============================================================================
 // Response helpers
@@ -220,7 +241,7 @@ ${bodyHtml}
  * script; both are also re-validated client-side before building the href, so a
  * mismatched or tampered URL never produces a javascript:/data: link.
  */
-function bridgePageHtml(ext: string, id: string): string {
+function bridgePageHtml(ext: string, id: string, nonce: string): string {
   return htmlDocument(`<h1 id="heading">Finish signing in to TeXRA</h1>
 <p id="lede" class="muted">Click the button below to return to your editor and complete sign-in.</p>
 <div class="actions">
@@ -235,8 +256,10 @@ function bridgePageHtml(ext: string, id: string): string {
   // tampered or reused URL can never inject a non-editor scheme into the href.
   var EXT = ${JSON.stringify(ext)};
   var ID = ${JSON.stringify(id)};
+  var APP_NONCE = ${JSON.stringify(nonce)};
   var ALLOWED = ${JSON.stringify(ALLOWED_EXT_SCHEMES)};
   var ID_RE = new RegExp(${JSON.stringify(EXTENSION_ID_PATTERN.source)});
+  var NONCE_RE = new RegExp(${JSON.stringify(APP_NONCE_PATTERN.source)});
   var DISPLAY = {
     'vscode': 'VS Code',
     'vscode-insiders': 'VS Code Insiders',
@@ -283,7 +306,11 @@ function bridgePageHtml(ext: string, id: string): string {
     linkCode.parentElement.hidden = true;
   }
 
-  if (ALLOWED.indexOf(EXT) === -1 || !ID_RE.test(ID)) {
+  if (
+    ALLOWED.indexOf(EXT) === -1 ||
+    !ID_RE.test(ID) ||
+    !NONCE_RE.test(APP_NONCE)
+  ) {
     fail('This sign-in link is invalid or unsupported.');
   } else {
     // Reconstruct the editor deep link: ${'$'}{EXT}://${'$'}{ID}/auth-callback plus
@@ -315,6 +342,14 @@ function bridgePageHtml(ext: string, id: string): string {
     } else if (hash && hash.length > 1) {
       tail = hash; // already starts with '#'
     }
+    var marker = tail.charAt(0) === '#' ? '#' : '?';
+    var callbackParams = new URLSearchParams(
+      tail.length > 1 ? tail.slice(1) : ''
+    );
+    // Ignore any inbound app_nonce and append the validated path nonce once.
+    callbackParams.delete('app_nonce');
+    callbackParams.append('app_nonce', APP_NONCE);
+    tail = marker + callbackParams.toString();
 
     var deepLink = base + tail;
     openLink.setAttribute('href', deepLink);

--- a/supabase/functions/auth-bridge/index_test.ts
+++ b/supabase/functions/auth-bridge/index_test.ts
@@ -1,0 +1,41 @@
+import { match, strictEqual } from 'node:assert/strict';
+
+import { handleRequest } from './index.ts';
+
+const NONCE = '0123456789abcdef0123456789abcdef';
+
+Deno.test('auth bridge requires and binds the callback nonce', async () => {
+  const missingNonce = handleRequest(
+    new Request(
+      'https://remote.texra.ai/functions/v1/auth-bridge/vscode/texra-ai.texra?code=test',
+    ),
+  );
+  strictEqual(missingNonce.status, 400);
+  match(
+    await missingNonce.text(),
+    /This sign-in link is missing its security nonce\./,
+  );
+
+  const bound = handleRequest(
+    new Request(
+      `https://remote.texra.ai/functions/v1/auth-bridge/vscode/texra-ai.texra/${NONCE}?code=test&app_nonce=attacker`,
+    ),
+  );
+  strictEqual(bound.status, 200);
+  const html = await bound.text();
+  match(html, new RegExp(`var APP_NONCE = "${NONCE}";`));
+  match(html, /callbackParams\.delete\('app_nonce'\);/);
+  match(html, /callbackParams\.append\('app_nonce', APP_NONCE\);/);
+});
+
+Deno.test('auth bridge rejects malformed nonce and extra path segments', () => {
+  for (const path of [
+    '/functions/v1/auth-bridge/vscode/texra-ai.texra/not-a-nonce',
+    `/functions/v1/auth-bridge/vscode/texra-ai.texra/${NONCE}/extra`,
+  ]) {
+    const response = handleRequest(
+      new Request(`https://remote.texra.ai${path}`),
+    );
+    strictEqual(response.status, 400);
+  }
+});


### PR DESCRIPTION
## Summary
- bind extension OAuth callbacks to persisted, expiring, single-use application nonces
- carry app nonce separately from VS Code web routing state and through a backward-compatible auth-bridge nonce path
- bind nonce attempts to auth-js PKCE flow IDs and serialize PKCE operations across superseding sign-ins
- document the required auth-bridge-first rollout gate

## Validation
- auth, URI-handler, and Supabase client storage suites (140 tests)
- full typecheck, ESLint, fast compile, formatting, and bridge route probe

## Release gate
Deploy and verify the backward-compatible `auth-bridge` before releasing an extension that requires nonce-bound callbacks.

Fixes #10988.