### PR TITLE
revert: delegation recursion guard

### DIFF
--- a/src/agent/prompt/userVars.ts
+++ b/src/agent/prompt/userVars.ts
@@ -270,13 +270,19 @@ function getBasicVars(
   providerFlags: ModelProviderFlags,
   options: BuildUserVarsOptions,
 ): BasicVars {
+  // Filter out the current agent so it doesn't see itself as a delegation target
+  const selfName = agentConfig.agent;
   const scope = options.delegationAgentScope ?? undefined;
   const workflowAgentsList = formatAgentList(
-    getDelegationAgents(AgentCategory.Workflow, scope),
+    getDelegationAgents(AgentCategory.Workflow, scope).filter(
+      (agent) => agent.name !== selfName,
+    ),
     { tools: 'none', collapseDescriptionNewlines: false },
   );
   const toolUseAgentsList = formatAgentList(
-    getDelegationAgents(AgentCategory.ToolUse, scope),
+    getDelegationAgents(AgentCategory.ToolUse, scope).filter(
+      (agent) => agent.name !== selfName,
+    ),
     { tools: 'inline', collapseDescriptionNewlines: false },
   );
 

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -52,7 +52,6 @@ import type {
 } from '@shared/schemas';
 import {
   AgentCategory,
-  agentKeyOf,
   INSTRUCTION_ACTION,
   RUN_OUTCOME,
   STREAM_PHASE,
@@ -116,8 +115,6 @@ interface AgentLaunchInput {
   copilotRouteOverride?: CopilotRouteOverride;
   /** Cancel launch preparation and the resulting live run. */
   signal?: AbortSignal;
-  /** Whether persisted or fresh execution lineage marks this run as delegated. */
-  isSubagent?: boolean;
   /** Immutable per-run tool policy carried on the launch context for cycle flows. */
   toolPolicy?: ToolPolicy;
 }
@@ -485,38 +482,24 @@ async function assembleAgentLaunchContext(
     streamId,
     executionId,
     agentName: config.agent,
-    agentKey: agentKeyOf(resolution.entry),
-    isSubagent: input.isSubagent === true,
     workingDirectory,
     delegationAgentScope: fullConfig.delegationAgentScope,
     session,
     signal: runSignal,
   });
-  const toolPolicy = createToolPolicy(input.toolPolicy);
   const buildVars = () =>
-    withRunContext(
-      createRunContext({
-        runScope,
-        modelCell,
-        approvalPromptsUnavailable: toolPolicy.approvalPromptsUnavailable,
-        runtimeUnavailableTools: toolPolicy.runtimeUnavailableTools,
-        stopAfterCycle: toolPolicy.stopAfterCycle,
-      }),
-      () =>
-        buildUserVars(
-          config,
-          setting,
-          prompt,
-          agentPath,
-          {
-            isOpenai: modelHandler.config.provider === ModelProvider.OPENAI,
-            isAnthropic:
-              modelHandler.config.provider === ModelProvider.ANTHROPIC,
-            isGoogle: modelHandler.config.provider === ModelProvider.GOOGLE,
-          },
-          agentLogger,
-          { delegationAgentScope: runScope.delegationAgentScope },
-        ),
+    buildUserVars(
+      config,
+      setting,
+      prompt,
+      agentPath,
+      {
+        isOpenai: modelHandler.config.provider === ModelProvider.OPENAI,
+        isAnthropic: modelHandler.config.provider === ModelProvider.ANTHROPIC,
+        isGoogle: modelHandler.config.provider === ModelProvider.GOOGLE,
+      },
+      agentLogger,
+      { delegationAgentScope: runScope.delegationAgentScope },
     );
 
   const baseVars =
@@ -544,7 +527,7 @@ async function assembleAgentLaunchContext(
     setting,
     prompt,
     modelCell,
-    toolPolicy,
+    toolPolicy: createToolPolicy(input.toolPolicy),
     logger: agentLogger,
     parentStage,
     storageKey,

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -27,13 +27,7 @@ export interface LaunchRunContext extends RunContextCommon {
 type BareRunIdentity = Partial<
   Pick<
     RunScope,
-    | 'streamId'
-    | 'executionId'
-    | 'agentName'
-    | 'agentKey'
-    | 'isSubagent'
-    | 'workingDirectory'
-    | 'session'
+    'streamId' | 'executionId' | 'agentName' | 'workingDirectory' | 'session'
   >
 >;
 
@@ -135,8 +129,6 @@ export function createRunContext(options: CreateRunContextOptions): RunContext {
     streamId: options.streamId,
     executionId: options.executionId,
     agentName: options.agentName,
-    agentKey: options.agentKey,
-    isSubagent: options.isSubagent,
     workingDirectory: options.workingDirectory,
     session: options.session,
     get model() {

--- a/src/agent/runtime/RunScope.ts
+++ b/src/agent/runtime/RunScope.ts
@@ -16,12 +16,8 @@ import type { SessionHandle } from './SessionHandle';
 export interface RunScope {
   readonly streamId: StreamTabId;
   readonly executionId: ExecutionId;
-  /** Launch identifier, retained for display and compatibility. */
+  /** Agent name (e.g. "orchestrator", "search-agent"). */
   readonly agentName: string;
-  /** Canonical `source:name` identity resolved for this launch. */
-  readonly agentKey?: string;
-  /** Immutable execution lineage; true when this run was delegated. */
-  readonly isSubagent?: boolean;
   readonly workingDirectory?: string;
   readonly delegationAgentScope?: AgentDelegationScope | null;
   readonly session: SessionHandle;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -420,7 +420,6 @@ export async function executeAgent(
       streamTabIdOverride: options.streamTabIdOverride,
       onBeforeActivation: options.onStreamResolved,
       suppressViewSwitch: options.isSubagent,
-      isSubagent: options.isSubagent,
       enforceCategory: options.enforceCategory,
       suppressErrorNotification:
         options.suppressErrorNotification ?? options.isSubagent,
@@ -571,7 +570,6 @@ async function resumeToolUseWithOwnedLease(
       // for this exact record; do not re-infer here.
       modelHandlerCompatibilityKey: resume.shared.modelHandlerCompatibilityKey,
       suppressViewSwitch: isSubagent,
-      isSubagent,
       // Host resume callers surface their own warning toast on failure;
       // skip the bus-level error to avoid double-notifying.
       suppressErrorNotification: true,

--- a/src/test-kernel/agent/prompt/UserVarsDelegationScope.vitest.ts
+++ b/src/test-kernel/agent/prompt/UserVarsDelegationScope.vitest.ts
@@ -31,45 +31,6 @@ const roster = vi.hoisted(() => ({
       description: 'Out-of-scope tool-use agent',
       path: '/agents/outside-reviewer.yaml',
     },
-    {
-      category: 'toolUse',
-      source: 'custom',
-      name: 'child',
-      description: 'Current delegated child',
-      tools: ['delegate_agent'],
-      path: '/agents/child.yaml',
-    },
-    {
-      category: 'toolUse',
-      source: 'remote',
-      name: 'child',
-      description: 'Same-name leaf specialist',
-      tools: ['read_file'],
-      path: '/agents/remote-child.yaml',
-    },
-    {
-      category: 'toolUse',
-      source: 'custom',
-      name: 'coder',
-      description: 'Leaf specialist',
-      tools: ['read_file'],
-      path: '/agents/coder.yaml',
-    },
-    {
-      category: 'toolUse',
-      source: 'custom',
-      name: 'lead',
-      description: 'Delegation-capable lead',
-      tools: ['delegate_agent'],
-      path: '/agents/lead.yaml',
-    },
-    {
-      category: 'workflow',
-      source: 'custom',
-      name: 'child',
-      description: 'Same-name workflow agent',
-      path: '/agents/child-workflow.yaml',
-    },
   ],
 }));
 
@@ -96,13 +57,9 @@ import { noopTrace } from '@agent/trace';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import {
   AgentPromptSchema,
-  AgentToolUseSettingSchema,
   AgentWorkflowSettingSchema,
 } from '@agent/core/definition/AgentDataclass';
 import { buildUserVars } from '@agent/prompt/userVars';
-import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
-import { createRunScope } from '@agent/runtime/RunScope';
-import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { AgentCategory } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 
@@ -133,46 +90,5 @@ describe('buildUserVars delegation scope', () => {
     );
     expect(vars.WORKFLOW_AGENTS).not.toContain('outside-writer');
     expect(vars.TOOL_USE_AGENTS).not.toContain('outside-reviewer');
-  });
-
-  it('builds a fresh child prompt from immutable identity and lineage before a handle exists', async () => {
-    const delegationAgentScope = {
-      workflow: ['custom:child'],
-      toolUse: ['custom:child', 'remote:child', 'custom:coder', 'custom:lead'],
-    };
-    const runScope = createRunScope({
-      streamId: 'child-stream',
-      executionId: 'child-execution',
-      agentName: 'child',
-      agentKey: 'custom:child',
-      isSubagent: true,
-      delegationAgentScope,
-      session: {} as SessionHandle,
-      signal: new AbortController().signal,
-    });
-
-    const vars = await withRunContext(createRunContext({ runScope }), () =>
-      buildUserVars(
-        AgentConfigSchema.parse({ agent: 'child', model: 'test-model' }),
-        AgentToolUseSettingSchema.parse({
-          agentCategory: AgentCategory.ToolUse,
-        }),
-        AgentPromptSchema.parse({}),
-        '/agents/child',
-        { isOpenai: false, isAnthropic: false, isGoogle: false },
-        noopTrace,
-        { delegationAgentScope },
-      ),
-    );
-
-    expect(vars.TOOL_USE_AGENTS).toContain(
-      '- child: Same-name leaf specialist [read_file]',
-    );
-    expect(vars.TOOL_USE_AGENTS).toContain(
-      '- coder: Leaf specialist [read_file]',
-    );
-    expect(vars.TOOL_USE_AGENTS).not.toContain('Current delegated child');
-    expect(vars.TOOL_USE_AGENTS).not.toContain('Delegation-capable lead');
-    expect(vars.WORKFLOW_AGENTS).toBe('- child: Same-name workflow agent');
   });
 });

--- a/src/test-kernel/agent/runtime/AgentLaunchActivation.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchActivation.vitest.ts
@@ -3,8 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   acquireResumedExecutionLease: vi.fn(),
   buildVars: vi.fn(),
-  buildVarsRunScope: undefined as
-    { agentName: string; agentKey?: string; isSubagent?: boolean } | undefined,
   clearTerminalExecutionState: vi.fn(),
   completeOwnedExecutionLease: vi.fn(),
   createHandler: vi.fn(),
@@ -54,7 +52,6 @@ vi.mock('@agent/runtime/SessionResumeRetrieval', () => ({
 
 import { noopTrace } from '@agent/trace';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
-import { useRunContext } from '@agent/runtime/RunContext';
 import {
   executeAgent,
   resumeToolUseFromResumeData,
@@ -95,12 +92,7 @@ async function captureActivation(
   };
 
   mocks.resolve.mockReturnValueOnce({
-    entry: {
-      category: 'toolUse',
-      source: 'custom',
-      name: 'chat',
-      path: '/agents/chat.yaml',
-    },
+    entry: { path: '/agents/chat.yaml' },
   });
   mocks.load.mockResolvedValueOnce([
     { agentCategory: AgentCategory.ToolUse },
@@ -108,12 +100,7 @@ async function captureActivation(
   ]);
   mocks.createHandler.mockResolvedValueOnce(handler);
   mocks.createTrace.mockReturnValueOnce({ trace, dispose: vi.fn() });
-  mocks.buildVars.mockImplementationOnce(() => {
-    const context = useRunContext();
-    mocks.buildVarsRunScope =
-      context.kind === 'launch' ? context.runScope : undefined;
-    throw LAUNCH_FAILURE;
-  });
+  mocks.buildVars.mockRejectedValueOnce(LAUNCH_FAILURE);
 
   try {
     await expect(run(session)).rejects.toBe(LAUNCH_FAILURE);
@@ -147,7 +134,6 @@ function expectActivation(
 describe('native agent launch activation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.buildVarsRunScope = undefined;
     mocks.acquireResumedExecutionLease.mockResolvedValue('existing');
     mocks.clearTerminalExecutionState.mockResolvedValue(undefined);
     mocks.getPersistedUserFollowUpSupport.mockResolvedValue(
@@ -160,29 +146,13 @@ describe('native agent launch activation', () => {
   });
 
   it.each([
-    {
-      label: 'child with a bare identifier',
-      agent: 'chat',
-      isSubagent: true,
-      suppressViewSwitch: true,
-    },
-    {
-      label: 'root with a bare identifier',
-      agent: 'chat',
-      isSubagent: undefined,
-      suppressViewSwitch: false,
-    },
-    {
-      label: 'root with a source-qualified identifier',
-      agent: 'custom:chat',
-      isSubagent: undefined,
-      suppressViewSwitch: false,
-    },
+    { label: 'child', isSubagent: true, suppressViewSwitch: true },
+    { label: 'root', isSubagent: undefined, suppressViewSwitch: false },
   ])(
     'emits the expected activation payload for a fresh $label launch',
-    async ({ agent, isSubagent, suppressViewSwitch }) => {
+    async ({ isSubagent, suppressViewSwitch }) => {
       const payload = await captureActivation((session) =>
-        executeAgent({ ...config, agent }, 'fresh-launch' as ExecutionId, {
+        executeAgent(config, 'fresh-launch' as ExecutionId, {
           session,
           isSubagent,
           modelHandlerCompatibilityKey: MODEL_HANDLER_KEY,
@@ -190,11 +160,6 @@ describe('native agent launch activation', () => {
       );
 
       expectActivation(payload, suppressViewSwitch);
-      expect(mocks.buildVarsRunScope).toMatchObject({
-        agentName: agent,
-        agentKey: 'custom:chat',
-        isSubagent: isSubagent === true,
-      });
     },
   );
 
@@ -221,10 +186,6 @@ describe('native agent launch activation', () => {
 
       expectActivation(payload, suppressViewSwitch);
       expect(payload.streamId).toBe(streamId);
-      expect(mocks.buildVarsRunScope).toMatchObject({
-        agentKey: 'custom:chat',
-        isSubagent,
-      });
     },
   );
 });

--- a/src/test-kernel/tools/DelegationAgentAvailability.vitest.ts
+++ b/src/test-kernel/tools/DelegationAgentAvailability.vitest.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { withRunContext } from '@agent/runtime/RunContext';
 import type { ToolDefinition } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
@@ -280,40 +279,6 @@ describe('resolveAgentTools delegation roster annotation', () => {
     // The models line is refreshed in the same pass.
     expect(delegateAgent?.description).toContain('Available models: deepseekT');
     expect(mocks.getVisibleAgents).toHaveBeenCalledWith('toolUse');
-  });
-
-  it('annotates a delegated child with leaf agents but not delegation-capable leads', async () => {
-    mocks.getVisibleAgents.mockReturnValue([
-      {
-        category: 'toolUse',
-        source: 'custom',
-        name: 'lead',
-        path: '/agents/lead.yaml',
-        description: 'Delegate implementation work.',
-        tools: ['delegate_agent'],
-      },
-      {
-        category: 'toolUse',
-        source: 'custom',
-        name: 'coder',
-        path: '/agents/coder.yaml',
-        description: 'Implement focused changes.',
-        tools: ['read_file'],
-      },
-    ]);
-
-    const delegateAgent = await withRunContext(
-      {
-        kind: 'bare',
-        agentName: 'child',
-        agentKey: 'custom:child',
-        isSubagent: true,
-      } as never,
-      resolveDelegateAgent,
-    );
-
-    expect(delegateAgent?.description).toContain('- coder:');
-    expect(delegateAgent?.description).not.toContain('- lead:');
   });
 
   it('does not annotate a roster line onto non-delegation tools', async () => {

--- a/src/test-kernel/tools/DelegationAgentScope.vitest.ts
+++ b/src/test-kernel/tools/DelegationAgentScope.vitest.ts
@@ -14,40 +14,12 @@ const customReview = {
   name: 'review',
   path: '/agents/custom-review.yaml',
 } as const;
-const lead = {
-  category: 'toolUse',
-  source: 'custom',
-  name: 'lead',
-  path: '/agents/lead.yaml',
-  tools: ['delegate_agent'],
-} as const;
-const remoteLead = {
-  category: 'toolUse',
-  source: 'remote',
-  name: 'lead',
-  path: '/agents/remote-lead.yaml',
-  tools: ['read_file'],
-} as const;
-const leaf = {
-  category: 'toolUse',
-  source: 'custom',
-  name: 'leaf',
-  path: '/agents/leaf.yaml',
-  tools: ['read_file'],
-} as const;
-const workflow = {
-  category: 'workflow',
-  source: 'custom',
-  name: 'child',
-  path: '/agents/child-workflow.yaml',
-} as const;
 const remoteReviewScope = {
   workflow: [],
   toolUse: ['remote:review'],
 };
 const mocks = vi.hoisted(() => ({
   context: undefined as unknown,
-  agents: [] as unknown[],
 }));
 
 vi.mock('@agent/runtime/RunContext', () => ({
@@ -67,11 +39,10 @@ vi.mock('@agent/index/agentRegistry', () => {
       scope: { toolUse: readonly string[] } | undefined,
       category: string,
     ) => {
-      if (!scope)
-        return mocks.agents.length > 0 ? mocks.agents : [customReview];
+      if (!scope) return [customReview];
       return category === 'toolUse' && scope.toolUse.includes('remote:review')
         ? [remoteReview]
-        : mocks.agents.filter((agent: any) => agent.category === category);
+        : [];
     },
     findAgentByIdentifier: (
       entries: Array<{ source: string; name: string }>,
@@ -85,7 +56,6 @@ const { getDelegationAgent, getDelegationAgents } =
 
 describe('execution-scoped delegation agents', () => {
   beforeEach(() => {
-    mocks.agents = [];
     mocks.context = {
       kind: 'launch',
       runScope: {
@@ -119,48 +89,5 @@ describe('execution-scoped delegation agents', () => {
 
     expect(getDelegationAgents('toolUse')).toEqual([customReview]);
     expect(getDelegationAgent('toolUse', 'review')).toBe(customReview);
-  });
-
-  it.each(['lead', 'custom:lead'])(
-    'excludes only the exact current identity for launch identifier %s',
-    (agentName) => {
-      mocks.agents = [lead, remoteLead, leaf];
-      mocks.context = {
-        kind: 'launch',
-        runScope: {
-          agentName,
-          agentKey: 'custom:lead',
-          delegationAgentScope: {
-            workflow: [],
-            toolUse: ['custom:lead', 'remote:lead', 'custom:leaf'],
-          },
-          isSubagent: false,
-        },
-      };
-
-      expect(getDelegationAgents('toolUse')).toEqual([remoteLead, leaf]);
-      expect(getDelegationAgent('toolUse', 'custom:lead')).toBeUndefined();
-      expect(getDelegationAgent('toolUse', 'remote:lead')).toBe(remoteLead);
-    },
-  );
-
-  it('keeps leaf and workflow agents while excluding tool-use leads for a child', () => {
-    mocks.agents = [lead, leaf, workflow];
-    mocks.context = {
-      kind: 'launch',
-      runScope: {
-        agentName: 'child',
-        delegationAgentScope: {
-          workflow: ['child'],
-          toolUse: ['lead', 'leaf'],
-        },
-        agentKey: 'custom:child',
-        isSubagent: true,
-      },
-    };
-
-    expect(getDelegationAgents('toolUse')).toEqual([leaf]);
-    expect(getDelegationAgent('toolUse', 'lead')).toBeUndefined();
-    expect(getDelegationAgents('workflow')).toEqual([workflow]);
   });
 });

--- a/src/test-kernel/tools/DelegationTools.vitest.ts
+++ b/src/test-kernel/tools/DelegationTools.vitest.ts
@@ -9,13 +9,6 @@ const mocks = vi.hoisted(() => ({
   currentSession: vi.fn(),
   submitFollowUp: vi.fn(),
   deliverChildRunFollowUp: vi.fn(),
-  delegationAgents: [] as Array<{
-    category: string;
-    source: string;
-    name: string;
-    path: string;
-    tools?: string[];
-  }>,
 }));
 
 vi.mock('@agent/runtime/RunContext', () => {
@@ -30,15 +23,6 @@ vi.mock('@agent/runtime/RunContext', () => {
 
 vi.mock('@agent/runtime/SessionHandle', () => ({
   currentSession: mocks.currentSession,
-}));
-
-vi.mock('@agent/index/agentRegistry', () => ({
-  resolveDelegationScopeAgents: (_scope: unknown, category: string) =>
-    mocks.delegationAgents.filter((agent) => agent.category === category),
-  findAgentByIdentifier: (
-    entries: Array<{ name: string }>,
-    identifier: string,
-  ) => entries.find((entry) => entry.name === identifier),
 }));
 
 vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
@@ -167,36 +151,6 @@ describe('DelegationTools', () => {
     expect(`${fieldDescriptions.join('\n')}\n${authoredHandoff}`).not.toContain(
       '\u2014',
     );
-  });
-});
-
-describe('DelegateAgentTool candidate enforcement', () => {
-  it('rejects a direct delegated-child call to a delegation-capable lead', async () => {
-    mocks.delegationAgents = [
-      {
-        category: 'toolUse',
-        source: 'custom',
-        name: 'lead',
-        path: '/agents/lead.yaml',
-        tools: ['delegate_agent'],
-      },
-    ];
-    mocks.tryUseRunContext.mockReturnValue({
-      kind: 'bare',
-      agentName: 'child',
-      agentKey: 'custom:child',
-      isSubagent: true,
-    });
-
-    const result = await new DelegateAgentTool().call({
-      agent: 'lead',
-      instruction: 'Delegate this again.',
-    });
-
-    expect(result).toMatchObject({
-      status: 'error',
-      error: "Unknown toolUse agent 'lead'. Available:",
-    });
   });
 });
 

--- a/src/tools/delegation/delegationAvailability.ts
+++ b/src/tools/delegation/delegationAvailability.ts
@@ -37,11 +37,8 @@ import type {
   ModelOptionData,
   ToolDefinition,
 } from '@shared/schemas';
-import { agentKeyOf, isModelOptionAvailable } from '@shared/schemas';
-import {
-  DELEGATION_TOOLS,
-  hasDelegationTool,
-} from '@shared/constants/delegationTools';
+import { isModelOptionAvailable } from '@shared/schemas';
+import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { unique } from '@utils/core';
 import { isWorktreeSupportEnabled } from '@utils/config/worktreeConfig';
 
@@ -157,24 +154,14 @@ function activeDelegationScope(): AgentDelegationScope | undefined {
 /**
  * Resolve delegation targets from an explicitly captured scope, or — when none
  * is supplied — the active run scope, falling back to the durable roster.
- * Tool-use candidates also honor the active execution's recursion guard.
  */
 export function getDelegationAgents(
   category: AgentCategory,
   scope?: AgentDelegationScope,
 ): AgentEntry[] {
-  const agents = resolveDelegationScopeAgents(
+  return resolveDelegationScopeAgents(
     scope ?? activeDelegationScope(),
     category,
-  );
-  const context = tryUseRunContext();
-  const run = context?.kind === 'launch' ? context.runScope : context;
-  if (category !== 'toolUse') return agents;
-
-  return agents.filter(
-    (agent) =>
-      agentKeyOf(agent) !== run?.agentKey &&
-      !(run?.isSubagent && hasDelegationTool(agent.tools)),
   );
 }
 


### PR DESCRIPTION
Reverts #11290 exactly, per #11293 and the explicit maintainer decision to remove the guard rather than repair it.

The guard has fail-open remote-agent paths and changes scope/prompt behavior. This restore removes its runtime, launch-scope, and test changes without introducing an alternative policy.

Validation:
- affected delegation, prompt, and launch activation suites: 31 tests passed
- workspace and test-kernel typechecks passed
- diff whitespace check passed

Closes #11293.