### PR TITLE
docs: list the work page in the Reference sidebar

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -177,6 +177,7 @@ const baseConfig = {
             { text: 'Troubleshooting', link: '/guide/troubleshooting' },
             { text: 'Acknowledgments', link: '/guide/acknowledgments.md' },
             { text: 'Open Source Projects', link: '/guide/open-source' },
+            { text: 'Work produced with TeXRA', link: '/work-using-texra' },
           ],
         },
       ],

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -109,78 +109,8 @@ const baseConfig = {
       { text: 'GitHub', link: 'https://github.com/LionSR/TeXRA' },
     ],
     sidebar: {
-      '/guide/': [
-        {
-          text: 'Getting Started',
-          items: [
-            { text: 'Introduction', link: '/guide/' },
-            { text: 'Installation', link: '/guide/installation' },
-            { text: 'First Run', link: '/guide/first-run' },
-            { text: 'Quick Start', link: '/guide/quick-start' },
-          ],
-        },
-        {
-          text: 'Agent System',
-          items: [
-            { text: 'Built-in Agents', link: '/guide/built-in-agents.md' },
-            {
-              text: 'Workflow Agents',
-              link: '/guide/agent-architecture.md',
-            },
-            { text: 'Custom Agents', link: '/guide/custom-agents' },
-            { text: 'Remote Agents', link: '/guide/remote-agents' },
-            {
-              text: 'Multi-agent workflows',
-              link: '/guide/multi-agent-workflows',
-            },
-            { text: 'Memory', link: '/guide/memory' },
-            { text: 'Models', link: '/guide/models' },
-          ],
-        },
-        {
-          text: 'Workflows',
-          items: [
-            { text: 'Polish a Draft', link: '/guide/workflows/polish-a-draft' },
-            { text: 'LaTeX Diff', link: '/guide/latex-diff' },
-            { text: 'Intelligent Merge', link: '/guide/intelligent-merge' },
-            { text: 'Research Tools', link: '/guide/research-tools' },
-            { text: 'Lean 4 Proofs', link: '/guide/lean' },
-            { text: 'LaTeX Tools', link: '/guide/latex-tools' },
-            {
-              text: 'Working with Figures',
-              link: '/guide/working-with-figures.md',
-            },
-            { text: 'TikZ Figures', link: '/guide/tikz-figures' },
-            { text: 'Multiple Output', link: '/guide/multiple-output' },
-          ],
-        },
-        {
-          text: 'Integrations',
-          items: [
-            {
-              text: 'Working with Overleaf',
-              link: '/guide/working-with-overleaf',
-            },
-            { text: 'TeXRA CLI', link: '/guide/texra-cli' },
-            { text: 'Code Review', link: '/guide/code-review' },
-            { text: 'Agent Integrations', link: '/guide/agent-integrations' },
-            { text: 'File Management', link: '/guide/file-management' },
-            { text: 'ProgressBoard', link: '/guide/progress-board' },
-          ],
-        },
-        {
-          text: 'Reference',
-          items: [
-            { text: 'Configuration', link: '/guide/configuration' },
-            { text: 'LaTeX Compilation', link: '/guide/latex-compilation.md' },
-            { text: 'Best Practices', link: '/guide/best-practices.md' },
-            { text: 'Troubleshooting', link: '/guide/troubleshooting' },
-            { text: 'Acknowledgments', link: '/guide/acknowledgments.md' },
-            { text: 'Open Source Projects', link: '/guide/open-source' },
-            { text: 'Work produced with TeXRA', link: '/work-using-texra' },
-          ],
-        },
-      ],
+      '/guide/': guideSidebar,
+      '/work-using-texra': guideSidebar,
     },
     socialLinks: [{ icon: 'github', link: 'https://github.com/texra-ai' }],
     search: {
@@ -229,6 +159,81 @@ const baseConfig = {
     },
   },
 };
+
+// Shared by every page that should show the guide navigation, including the
+// root-level work page, which would otherwise render with no sidebar.
+const guideSidebar = [
+  {
+    text: 'Getting Started',
+    items: [
+      { text: 'Introduction', link: '/guide/' },
+      { text: 'Installation', link: '/guide/installation' },
+      { text: 'First Run', link: '/guide/first-run' },
+      { text: 'Quick Start', link: '/guide/quick-start' },
+    ],
+  },
+  {
+    text: 'Agent System',
+    items: [
+      { text: 'Built-in Agents', link: '/guide/built-in-agents.md' },
+      {
+        text: 'Workflow Agents',
+        link: '/guide/agent-architecture.md',
+      },
+      { text: 'Custom Agents', link: '/guide/custom-agents' },
+      { text: 'Remote Agents', link: '/guide/remote-agents' },
+      {
+        text: 'Multi-agent workflows',
+        link: '/guide/multi-agent-workflows',
+      },
+      { text: 'Memory', link: '/guide/memory' },
+      { text: 'Models', link: '/guide/models' },
+    ],
+  },
+  {
+    text: 'Workflows',
+    items: [
+      { text: 'Polish a Draft', link: '/guide/workflows/polish-a-draft' },
+      { text: 'LaTeX Diff', link: '/guide/latex-diff' },
+      { text: 'Intelligent Merge', link: '/guide/intelligent-merge' },
+      { text: 'Research Tools', link: '/guide/research-tools' },
+      { text: 'Lean 4 Proofs', link: '/guide/lean' },
+      { text: 'LaTeX Tools', link: '/guide/latex-tools' },
+      {
+        text: 'Working with Figures',
+        link: '/guide/working-with-figures.md',
+      },
+      { text: 'TikZ Figures', link: '/guide/tikz-figures' },
+      { text: 'Multiple Output', link: '/guide/multiple-output' },
+    ],
+  },
+  {
+    text: 'Integrations',
+    items: [
+      {
+        text: 'Working with Overleaf',
+        link: '/guide/working-with-overleaf',
+      },
+      { text: 'TeXRA CLI', link: '/guide/texra-cli' },
+      { text: 'Code Review', link: '/guide/code-review' },
+      { text: 'Agent Integrations', link: '/guide/agent-integrations' },
+      { text: 'File Management', link: '/guide/file-management' },
+      { text: 'ProgressBoard', link: '/guide/progress-board' },
+    ],
+  },
+  {
+    text: 'Reference',
+    items: [
+      { text: 'Configuration', link: '/guide/configuration' },
+      { text: 'LaTeX Compilation', link: '/guide/latex-compilation.md' },
+      { text: 'Best Practices', link: '/guide/best-practices.md' },
+      { text: 'Troubleshooting', link: '/guide/troubleshooting' },
+      { text: 'Acknowledgments', link: '/guide/acknowledgments.md' },
+      { text: 'Open Source Projects', link: '/guide/open-source' },
+      { text: 'Work produced with TeXRA', link: '/work-using-texra' },
+    ],
+  },
+];
 
 export default withMermaid(baseConfig, {
   mermaid: {},

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -4,6 +4,81 @@ import { srcExclude } from './publicDocs.js';
 
 const base = '/';
 
+// Shared by every page that should show the guide navigation, including the
+// root-level work page, which would otherwise render with no sidebar.
+const guideSidebar = [
+  {
+    text: 'Getting Started',
+    items: [
+      { text: 'Introduction', link: '/guide/' },
+      { text: 'Installation', link: '/guide/installation' },
+      { text: 'First Run', link: '/guide/first-run' },
+      { text: 'Quick Start', link: '/guide/quick-start' },
+    ],
+  },
+  {
+    text: 'Agent System',
+    items: [
+      { text: 'Built-in Agents', link: '/guide/built-in-agents.md' },
+      {
+        text: 'Workflow Agents',
+        link: '/guide/agent-architecture.md',
+      },
+      { text: 'Custom Agents', link: '/guide/custom-agents' },
+      { text: 'Remote Agents', link: '/guide/remote-agents' },
+      {
+        text: 'Multi-agent workflows',
+        link: '/guide/multi-agent-workflows',
+      },
+      { text: 'Memory', link: '/guide/memory' },
+      { text: 'Models', link: '/guide/models' },
+    ],
+  },
+  {
+    text: 'Workflows',
+    items: [
+      { text: 'Polish a Draft', link: '/guide/workflows/polish-a-draft' },
+      { text: 'LaTeX Diff', link: '/guide/latex-diff' },
+      { text: 'Intelligent Merge', link: '/guide/intelligent-merge' },
+      { text: 'Research Tools', link: '/guide/research-tools' },
+      { text: 'Lean 4 Proofs', link: '/guide/lean' },
+      { text: 'LaTeX Tools', link: '/guide/latex-tools' },
+      {
+        text: 'Working with Figures',
+        link: '/guide/working-with-figures.md',
+      },
+      { text: 'TikZ Figures', link: '/guide/tikz-figures' },
+      { text: 'Multiple Output', link: '/guide/multiple-output' },
+    ],
+  },
+  {
+    text: 'Integrations',
+    items: [
+      {
+        text: 'Working with Overleaf',
+        link: '/guide/working-with-overleaf',
+      },
+      { text: 'TeXRA CLI', link: '/guide/texra-cli' },
+      { text: 'Code Review', link: '/guide/code-review' },
+      { text: 'Agent Integrations', link: '/guide/agent-integrations' },
+      { text: 'File Management', link: '/guide/file-management' },
+      { text: 'ProgressBoard', link: '/guide/progress-board' },
+    ],
+  },
+  {
+    text: 'Reference',
+    items: [
+      { text: 'Configuration', link: '/guide/configuration' },
+      { text: 'LaTeX Compilation', link: '/guide/latex-compilation.md' },
+      { text: 'Best Practices', link: '/guide/best-practices.md' },
+      { text: 'Troubleshooting', link: '/guide/troubleshooting' },
+      { text: 'Acknowledgments', link: '/guide/acknowledgments.md' },
+      { text: 'Open Source Projects', link: '/guide/open-source' },
+      { text: 'Work produced with TeXRA', link: '/work-using-texra' },
+    ],
+  },
+];
+
 const baseConfig = {
   title: 'TeXRA',
   base,
@@ -159,81 +234,6 @@ const baseConfig = {
     },
   },
 };
-
-// Shared by every page that should show the guide navigation, including the
-// root-level work page, which would otherwise render with no sidebar.
-const guideSidebar = [
-  {
-    text: 'Getting Started',
-    items: [
-      { text: 'Introduction', link: '/guide/' },
-      { text: 'Installation', link: '/guide/installation' },
-      { text: 'First Run', link: '/guide/first-run' },
-      { text: 'Quick Start', link: '/guide/quick-start' },
-    ],
-  },
-  {
-    text: 'Agent System',
-    items: [
-      { text: 'Built-in Agents', link: '/guide/built-in-agents.md' },
-      {
-        text: 'Workflow Agents',
-        link: '/guide/agent-architecture.md',
-      },
-      { text: 'Custom Agents', link: '/guide/custom-agents' },
-      { text: 'Remote Agents', link: '/guide/remote-agents' },
-      {
-        text: 'Multi-agent workflows',
-        link: '/guide/multi-agent-workflows',
-      },
-      { text: 'Memory', link: '/guide/memory' },
-      { text: 'Models', link: '/guide/models' },
-    ],
-  },
-  {
-    text: 'Workflows',
-    items: [
-      { text: 'Polish a Draft', link: '/guide/workflows/polish-a-draft' },
-      { text: 'LaTeX Diff', link: '/guide/latex-diff' },
-      { text: 'Intelligent Merge', link: '/guide/intelligent-merge' },
-      { text: 'Research Tools', link: '/guide/research-tools' },
-      { text: 'Lean 4 Proofs', link: '/guide/lean' },
-      { text: 'LaTeX Tools', link: '/guide/latex-tools' },
-      {
-        text: 'Working with Figures',
-        link: '/guide/working-with-figures.md',
-      },
-      { text: 'TikZ Figures', link: '/guide/tikz-figures' },
-      { text: 'Multiple Output', link: '/guide/multiple-output' },
-    ],
-  },
-  {
-    text: 'Integrations',
-    items: [
-      {
-        text: 'Working with Overleaf',
-        link: '/guide/working-with-overleaf',
-      },
-      { text: 'TeXRA CLI', link: '/guide/texra-cli' },
-      { text: 'Code Review', link: '/guide/code-review' },
-      { text: 'Agent Integrations', link: '/guide/agent-integrations' },
-      { text: 'File Management', link: '/guide/file-management' },
-      { text: 'ProgressBoard', link: '/guide/progress-board' },
-    ],
-  },
-  {
-    text: 'Reference',
-    items: [
-      { text: 'Configuration', link: '/guide/configuration' },
-      { text: 'LaTeX Compilation', link: '/guide/latex-compilation.md' },
-      { text: 'Best Practices', link: '/guide/best-practices.md' },
-      { text: 'Troubleshooting', link: '/guide/troubleshooting' },
-      { text: 'Acknowledgments', link: '/guide/acknowledgments.md' },
-      { text: 'Open Source Projects', link: '/guide/open-source' },
-      { text: 'Work produced with TeXRA', link: '/work-using-texra' },
-    ],
-  },
-];
 
 export default withMermaid(baseConfig, {
   mermaid: {},

--- a/docs/guide/acknowledgments.md
+++ b/docs/guide/acknowledgments.md
@@ -17,7 +17,7 @@ If TeXRA helps you push a derivation through, check a proof, or get a result out
 
 ## Research produced with TeXRA
 
-TeXRA grew out of research, and it is built to produce more of it. A selection of work by the TeXRA team and collaborators that uses these multi-agent workflows:
+TeXRA grew out of research, and it is built to produce more of it. A selection of work by the TeXRA team and collaborators that uses these multi-agent workflows (the fuller list is on [Work produced with TeXRA](/work-using-texra)):
 
 - **Lu, S., Jin, Z., Zhang, T. J., Kos, P., Cirac, J. I., & Schölkopf, B.** (2026). [_Can Theoretical Physics Research Benefit from Language Agents?_](https://arxiv.org/abs/2506.06214) International Conference on Machine Learning (ICML 2026).
   A position paper on how language agents can accelerate theoretical and computational physics, the motivation behind TeXRA.

--- a/docs/guide/acknowledgments.md
+++ b/docs/guide/acknowledgments.md
@@ -17,7 +17,7 @@ If TeXRA helps you push a derivation through, check a proof, or get a result out
 
 ## Research produced with TeXRA
 
-TeXRA grew out of research, and it is built to produce more of it. A selection of work by the TeXRA team and collaborators that uses these multi-agent workflows (the fuller list is on [Work produced with TeXRA](/work-using-texra)):
+TeXRA grew out of research, and it is built to produce more of it. A selection of work by the TeXRA team and collaborators that uses these multi-agent workflows (more projects and papers are listed on [Work produced with TeXRA](/work-using-texra)):
 
 - **Lu, S., Jin, Z., Zhang, T. J., Kos, P., Cirac, J. I., & Schölkopf, B.** (2026). [_Can Theoretical Physics Research Benefit from Language Agents?_](https://arxiv.org/abs/2506.06214) International Conference on Machine Learning (ICML 2026).
   A position paper on how language agents can accelerate theoretical and computational physics, the motivation behind TeXRA.

--- a/docs/work-using-texra.md
+++ b/docs/work-using-texra.md
@@ -12,6 +12,9 @@ A non-exhaustive list of public projects and papers that used TeXRA. To add your
 
 ## Papers
 
+- [**Can Theoretical Physics Research Benefit from Language Agents?**](https://arxiv.org/abs/2506.06214),
+  Sirui Lu, Zhuo Jin, Tian-Jun Zhang, Pavel Kos, J. Ignacio Cirac, and Bernhard
+  Schölkopf (ICML 2026). The position paper behind TeXRA.
 - [**Quantum computer architecture with ions in tweezer arrays**](https://arxiv.org/abs/2606.27249),
   Benjamin F. Schiffer, Christopher Monroe, Peter Zoller, and J. Ignacio Cirac
   (2026).

--- a/docs/work-using-texra.md
+++ b/docs/work-using-texra.md
@@ -1,6 +1,6 @@
-# Work Produced with TeXRA
+# Work produced with TeXRA
 
-This non-exhaustive list records public projects and papers that used TeXRA.
+A non-exhaustive list of public projects and papers that used TeXRA. To add yours, open an issue or a pull request on the [TeXRA repository](https://github.com/LionSR/TeXRA).
 
 ## Projects
 


### PR DESCRIPTION
The work page was only reachable from the top nav as "Work"; the guide sidebar's Reference group now lists it too. Heading sentence-cased to match the rest of the site, a one-line invitation to submit work, and a cross-link from the acknowledgments research list.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)