### PR TITLE
refactor(settings): share team roster orchestration

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1922,6 +1922,12 @@
       "name": "SettingsAgentDirectoryEntry"
     },
     {
+      "file": "src/controllers/settingsView/SettingsTeamRosterController.ts",
+      "category": "unused",
+      "kind": "types",
+      "name": "SettingsTeamRosterPresentation"
+    },
+    {
       "file": "src/eventBus/AppSignals.ts",
       "category": "production-dead",
       "kind": "types",

--- a/packages/desktop/src/main/desktopAgentSettingsController.ts
+++ b/packages/desktop/src/main/desktopAgentSettingsController.ts
@@ -9,9 +9,7 @@ import {
   type loadAgents,
   type refresh,
 } from '@agent/index';
-import type { TeamAvailabilityChoice } from '@common/teams/TeamAvailabilityPreflight';
 import { loadTeamOptions } from '@common/teams/TeamPlan';
-import { applyTeamRosterWithPreflight } from '@common/teams/TeamRosterApplication';
 import { createTeamCatalogPorts } from '@controllers/mainView/teamCatalogPorts';
 import { createSettingsAgentActions } from '@controllers/settingsView/backend/SettingsAgentActions';
 import {
@@ -20,6 +18,10 @@ import {
   writeTemplateAgentFile,
 } from '@controllers/settingsView/backend/templateAgentCreation';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
+import {
+  applySettingsTeamRoster,
+  type SettingsTeamAvailabilityPrompt,
+} from '@controllers/settingsView/SettingsTeamRosterController';
 import { MAIN_VIEW_COMMANDS, SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   agentKey,
@@ -38,7 +40,6 @@ import type { SettingsStatePorts } from '@shared/settingsView/types';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { createTexraTempDir } from '@utils/files/tempDir';
 import { toErrorMessage } from '@utils/errors/errorMessage';
-import { formatResultCount } from '@utils/text/stringUtils';
 
 type AgentCommand = SettingsViewInboundMessage['command'];
 type AgentMessage<C extends AgentCommand> = SettingsMessageFor<C>;
@@ -94,10 +95,9 @@ export interface DefaultDesktopAgentSettingsControllerOptions extends SettingsSt
       title: string;
       message: string;
     }) => Promise<boolean>;
-    readonly chooseTeamAvailability: (input: {
-      presetName: string;
-      unavailableNames: readonly string[];
-    }) => Promise<TeamAvailabilityChoice>;
+    readonly chooseTeamAvailability: (
+      prompt: SettingsTeamAvailabilityPrompt,
+    ) => Promise<'sign-in' | 'continue' | 'cancel' | undefined>;
   };
   /**
    * Root of the packaged resources tree, used to read the bundled agent
@@ -442,48 +442,26 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
       typeof SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET
     >,
   ): Promise<void> {
-    const { presetId } = message;
-    const result = await applyTeamRosterWithPreflight(presetId, {
+    await applySettingsTeamRoster(message.presetId, {
       catalog: this.catalogController,
       loadLocalCatalog: () =>
         this.registry.loadAgents({ includeRemote: false }),
       canAccessRemoteCatalog: this.remoteCatalog.canAccess,
-      choose: (preset, unavailableNames) =>
-        this.prompts.chooseTeamAvailability({
-          presetName: preset.name,
-          unavailableNames,
-        }),
       signIn: this.remoteCatalog.signIn,
       forceRefreshRemoteCatalog: () =>
         this.registry.refreshAgents({ includeRemote: true }),
+      presentation: {
+        chooseTeamAvailability: this.prompts.chooseTeamAvailability,
+        showInfoMessage: this.notifications.showInfoMessage,
+        showErrorMessage: this.notifications.showErrorMessage,
+      },
+      refreshAfterApply: async (selectedToolUseAgent) => {
+        await Promise.all([
+          this.postAgentSelectionData(),
+          this.postMainAgentAndTeamOptionsData(selectedToolUseAgent),
+        ]);
+      },
     });
-    if (result.status === 'unknown') {
-      await this.notifications.showErrorMessage(`Unknown team: ${presetId}`);
-      return;
-    }
-    if (result.status === 'cancelled' || result.status === 'choice-required')
-      return;
-    if (result.status === 'unavailable') {
-      await this.notifications.showErrorMessage(
-        `Team "${result.preset.name}" is still unavailable: ${result.unavailableNames.join(', ')}`,
-      );
-      return;
-    }
-    await Promise.all([
-      this.postAgentSelectionData(),
-      this.postMainAgentAndTeamOptionsData(
-        this.catalogController.getPresetToolUseRoot(
-          result.preset.agents.toolUse,
-          result.preset.id,
-        ),
-      ),
-    ]);
-    const unresolvedCount = result.resolution.unresolvedNames.length;
-    await this.notifications.showInfoMessage(
-      unresolvedCount === 0
-        ? `Applied "${result.preset.name}" team`
-        : `Applied "${result.preset.name}" with ${formatResultCount(unresolvedCount, 'member')} still unavailable`,
-    );
   }
 
   private async saveAgentModePreset(): Promise<void> {

--- a/packages/desktop/src/main/desktopAgentSettingsController.ts
+++ b/packages/desktop/src/main/desktopAgentSettingsController.ts
@@ -9,6 +9,7 @@ import {
   type loadAgents,
   type refresh,
 } from '@agent/index';
+import type { TeamAvailabilityChoice } from '@common/teams/TeamAvailabilityPreflight';
 import { loadTeamOptions } from '@common/teams/TeamPlan';
 import { createTeamCatalogPorts } from '@controllers/mainView/teamCatalogPorts';
 import { createSettingsAgentActions } from '@controllers/settingsView/backend/SettingsAgentActions';
@@ -97,7 +98,7 @@ export interface DefaultDesktopAgentSettingsControllerOptions extends SettingsSt
     }) => Promise<boolean>;
     readonly chooseTeamAvailability: (
       prompt: SettingsTeamAvailabilityPrompt,
-    ) => Promise<'sign-in' | 'continue' | 'cancel' | undefined>;
+    ) => Promise<TeamAvailabilityChoice | undefined>;
   };
   /**
    * Root of the packaged resources tree, used to read the bundled agent

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -37,6 +37,7 @@ import {
   TEAM_LAUNCH_SIGN_IN_LABEL,
 } from '@common/teams/TeamPlan';
 import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
+import type { SettingsTeamAvailabilityPrompt } from '@controllers/settingsView/SettingsTeamRosterController';
 import { prepareMainViewExecutionRequest } from '@controllers/mainView/MainViewExecutionController';
 import { SubscriptionUsageService } from '@controllers/modelAccess/subscriptionUsage/SubscriptionUsageService';
 import { createTexraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
@@ -380,33 +381,34 @@ function createWindow(options: {
     });
     return result.response === 0;
   };
-  /**
-   * Sole owner of the "team has unavailable hosted members" prompt. Both the
-   * main-view launch path and the settings path route here so the two can't
-   * drift apart in wording or button labels again.
-   */
-  const chooseTeamAvailability = async (
-    unavailableNames: readonly string[],
-    presetName?: string,
+  const presentTeamAvailabilityPrompt = async (
+    prompt: SettingsTeamAvailabilityPrompt,
   ): Promise<'sign-in' | 'continue' | 'cancel'> => {
     const { response } = await dialog.showMessageBox(window, {
-      type: 'warning',
+      type: prompt.severity,
+      message: prompt.message,
+      buttons: prompt.actions.map((action) => action.label),
+      defaultId: 0,
+      cancelId: 2,
+    });
+    return prompt.actions[response]?.choice ?? 'cancel';
+  };
+  const chooseTeamAvailability = (
+    unavailableNames: readonly string[],
+    presetName?: string,
+  ) =>
+    presentTeamAvailabilityPrompt({
+      severity: 'warning',
       message: formatUnavailableTeamMembersMessage(
         unavailableNames,
         presetName,
       ),
-      buttons: [
-        TEAM_LAUNCH_SIGN_IN_LABEL,
-        TEAM_LAUNCH_CONTINUE_LABEL,
-        TEAM_LAUNCH_CANCEL_LABEL,
+      actions: [
+        { choice: 'sign-in', label: TEAM_LAUNCH_SIGN_IN_LABEL },
+        { choice: 'continue', label: TEAM_LAUNCH_CONTINUE_LABEL },
+        { choice: 'cancel', label: TEAM_LAUNCH_CANCEL_LABEL },
       ],
-      defaultId: 0,
-      cancelId: 2,
     });
-    if (response === 0) return 'sign-in';
-    if (response === 1) return 'continue';
-    return 'cancel';
-  };
   // Lightweight update check: at most once/day, notifies at most once per
   // release via a native dialog linking to the GitHub release page. Not a full
   // updater: no download, no install, no feed files. Disable with
@@ -728,8 +730,7 @@ function createWindow(options: {
       promptText: (input) => promptController.request(input),
       confirm: ({ title, message }) =>
         confirmDialog({ title, message, confirmLabel: 'Continue' }),
-      chooseTeamAvailability: ({ presetName, unavailableNames }) =>
-        chooseTeamAvailability(unavailableNames, presetName),
+      chooseTeamAvailability: presentTeamAvailabilityPrompt,
     },
     remoteCatalog: {
       canAccess: () => SupabaseClient.isAuthenticated(),

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -381,6 +381,11 @@ function createWindow(options: {
     });
     return result.response === 0;
   };
+  /**
+   * Sole owner of the native unavailable-member prompt. Both the main-view
+   * launch path and settings path route here so wording and button labels
+   * cannot drift.
+   */
   const presentTeamAvailabilityPrompt = async (
     prompt: SettingsTeamAvailabilityPrompt,
   ): Promise<'sign-in' | 'continue' | 'cancel'> => {

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -17,8 +17,11 @@ import {
 } from '@agent/index';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { SupabaseClient } from '@auth/SupabaseClient';
-import { applyTeamRosterWithPreflight } from '@common/teams/TeamRosterApplication';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
+import {
+  applySettingsTeamRoster,
+  type SettingsTeamAvailabilityPrompt,
+} from '@controllers/settingsView/SettingsTeamRosterController';
 import { createSettingsAgentActions } from '@controllers/settingsView/backend/SettingsAgentActions';
 import {
   templateAgentNamePrompt,
@@ -43,7 +46,6 @@ import {
   buildAgentModePresetsMessage,
 } from '@shared/settingsView/handlers/agentSelectionHandlers';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
-import { formatResultCount } from '@utils/text/stringUtils';
 
 import {
   withHandlerErrorHandling,
@@ -300,66 +302,31 @@ export class AgentHandlers {
       this.ctx,
       'Failed to apply agent team',
       async () => {
-        const result = await withAgentCatalogAuthRefreshDeferred(() =>
-          applyTeamRosterWithPreflight(data.presetId, {
+        await withAgentCatalogAuthRefreshDeferred(() =>
+          applySettingsTeamRoster(data.presetId, {
             catalog: this.catalogController,
             loadLocalCatalog: () => loadAgents({ includeRemote: false }),
             canAccessRemoteCatalog: () => SupabaseClient.isAuthenticated(),
-            choose: async (preset, unavailableNames) => {
-              const choice = await vscode.window.showInformationMessage(
-                `The "${preset.name}" team includes TeXRA-hosted members that are unavailable: ${unavailableNames.join(', ')}.`,
-                { modal: true },
-                'Sign in to TeXRA',
-                'Continue with available members',
-              );
-              if (choice === 'Sign in to TeXRA') return 'sign-in';
-              if (choice === 'Continue with available members') {
-                return 'continue';
-              }
-              return 'cancel';
-            },
             signIn: async () =>
               (await vscode.commands.executeCommand<boolean>(
                 AUTH_COMMANDS.SIGN_IN,
               )) === true,
             forceRefreshRemoteCatalog: () =>
               refreshAgents({ includeRemote: true }),
+            presentation: {
+              chooseTeamAvailability: (prompt) =>
+                this.chooseTeamAvailability(prompt),
+              showInfoMessage: (message) => {
+                void vscode.window.showInformationMessage(message);
+                return Promise.resolve();
+              },
+              showErrorMessage: async (message) => {
+                await showLoggedMessage(this.ctx.channel, message);
+              },
+            },
+            refreshAfterApply: (selectedToolUseAgent) =>
+              this.refreshAfterAgentMutation(selectedToolUseAgent, true),
           }),
-        );
-
-        if (result.status === 'unknown') {
-          await showLoggedMessage(
-            this.ctx.channel,
-            `Unknown team: ${data.presetId}`,
-          );
-          return;
-        }
-        if (
-          result.status === 'choice-required' ||
-          result.status === 'cancelled'
-        )
-          return;
-        if (result.status === 'unavailable') {
-          await showLoggedMessage(
-            this.ctx.channel,
-            `The "${result.preset.name}" team is unavailable because these TeXRA-hosted members could not be loaded: ${result.unavailableNames.join(', ')}.`,
-          );
-          return;
-        }
-
-        await this.refreshAfterAgentMutation(
-          this.catalogController.getPresetToolUseRoot(
-            result.preset.agents.toolUse,
-            result.preset.id,
-          ),
-          true,
-        );
-
-        const unresolvedCount = result.resolution.unresolvedNames.length;
-        void vscode.window.showInformationMessage(
-          unresolvedCount === 0
-            ? `Applied "${result.preset.name}" team`
-            : `Applied "${result.preset.name}" with ${formatResultCount(unresolvedCount, 'member')} still unavailable`,
         );
       },
     );
@@ -422,6 +389,15 @@ export class AgentHandlers {
   }
 
   // ── Private helpers ──
+
+  private async chooseTeamAvailability(prompt: SettingsTeamAvailabilityPrompt) {
+    const choice = await vscode.window.showWarningMessage(
+      prompt.message,
+      { modal: true },
+      ...prompt.actions.map((action) => action.label),
+    );
+    return prompt.actions.find((action) => action.label === choice)?.choice;
+  }
 
   private async createAgentFromTemplate(
     category: 'workflow' | 'toolUse',

--- a/src/controllers/settingsView/SettingsTeamRosterController.ts
+++ b/src/controllers/settingsView/SettingsTeamRosterController.ts
@@ -1,0 +1,108 @@
+import type { TeamAvailabilityChoice } from '@common/teams/TeamAvailabilityPreflight';
+import {
+  formatTeamUnavailableMessage,
+  formatUnavailableTeamMembersMessage,
+  formatUnknownTeamMessage,
+  TEAM_LAUNCH_CANCEL_LABEL,
+  TEAM_LAUNCH_CONTINUE_LABEL,
+  TEAM_LAUNCH_SIGN_IN_LABEL,
+} from '@common/teams/TeamPlan';
+import {
+  applyTeamRosterWithPreflight,
+  type TeamRosterApplicationDeps,
+} from '@common/teams/TeamRosterApplication';
+import { assertNever } from '@utils/core';
+import { formatResultCount } from '@utils/text/stringUtils';
+
+type SettingsTeamRosterCatalog = TeamRosterApplicationDeps['catalog'] & {
+  getPresetToolUseRoot(
+    toolUseAgents: string[],
+    presetId?: string,
+  ): string | undefined;
+};
+
+export interface SettingsTeamAvailabilityPrompt {
+  readonly severity: 'warning';
+  readonly message: string;
+  readonly actions: readonly [
+    { readonly choice: 'sign-in'; readonly label: string },
+    { readonly choice: 'continue'; readonly label: string },
+    { readonly choice: 'cancel'; readonly label: string },
+  ];
+}
+
+export interface SettingsTeamRosterPresentation {
+  chooseTeamAvailability(
+    prompt: SettingsTeamAvailabilityPrompt,
+  ): Promise<TeamAvailabilityChoice | undefined>;
+  showInfoMessage(message: string): Promise<void>;
+  showErrorMessage(message: string): Promise<void>;
+}
+
+interface SettingsTeamRosterOptions extends Omit<
+  TeamRosterApplicationDeps,
+  'catalog' | 'choose'
+> {
+  readonly catalog: SettingsTeamRosterCatalog;
+  readonly presentation: SettingsTeamRosterPresentation;
+  readonly refreshAfterApply: (selectedToolUseAgent?: string) => Promise<void>;
+}
+
+/** Apply a settings team and present its outcome consistently across hosts. */
+export async function applySettingsTeamRoster(
+  presetId: string,
+  options: SettingsTeamRosterOptions,
+): Promise<void> {
+  const result = await applyTeamRosterWithPreflight(presetId, {
+    ...options,
+    choose: (preset, unavailableNames) =>
+      options.presentation.chooseTeamAvailability({
+        severity: 'warning',
+        message: formatUnavailableTeamMembersMessage(
+          unavailableNames,
+          preset.name,
+        ),
+        actions: [
+          { choice: 'sign-in', label: TEAM_LAUNCH_SIGN_IN_LABEL },
+          { choice: 'continue', label: TEAM_LAUNCH_CONTINUE_LABEL },
+          { choice: 'cancel', label: TEAM_LAUNCH_CANCEL_LABEL },
+        ],
+      }),
+  });
+
+  switch (result.status) {
+    case 'unknown':
+      await options.presentation.showErrorMessage(
+        formatUnknownTeamMessage(presetId),
+      );
+      return;
+    case 'choice-required':
+    case 'cancelled':
+      return;
+    case 'unavailable':
+      await options.presentation.showErrorMessage(
+        formatTeamUnavailableMessage(
+          result.preset.name,
+          result.unavailableNames,
+        ),
+      );
+      return;
+    case 'applied': {
+      const selectedToolUseAgent = options.catalog.getPresetToolUseRoot(
+        result.preset.agents.toolUse,
+        result.preset.id,
+      );
+      await options.refreshAfterApply(selectedToolUseAgent);
+
+      const unresolvedCount = result.resolution.unresolvedNames.length;
+      await options.presentation.showInfoMessage(
+        unresolvedCount === 0
+          ? `Applied "${result.preset.name}" team`
+          : `Applied "${result.preset.name}" with ${formatResultCount(unresolvedCount, 'member')} still unavailable`,
+      );
+      return;
+    }
+    default:
+      return assertNever(result, 'Unhandled settings team roster outcome');
+  }
+}

--- a/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.ts
@@ -519,7 +519,7 @@ describe('DefaultDesktopAgentSettingsController', () => {
 
     await applyAgentPreset(controller, 'missing-team');
 
-    expect(errorMessages).toEqual(['Unknown team: missing-team']);
+    expect(errorMessages).toEqual(['Unknown team "missing-team".']);
     expect(
       workspaceState.get(WorkspaceStateKey.AGENT_ROSTER_SELECTION),
     ).toBeUndefined();

--- a/src/test-kernel/settings/ExtensionAgentHandlers.vitest.ts
+++ b/src/test-kernel/settings/ExtensionAgentHandlers.vitest.ts
@@ -11,6 +11,7 @@ type AgentCatalog = Record<AgentCategory, AgentEntry[]>;
 
 const host = vi.hoisted(() => ({
   showInformationMessage: vi.fn(),
+  showWarningMessage: vi.fn(),
   executeCommand: vi.fn(),
 }));
 
@@ -21,6 +22,7 @@ vi.mock('vscode', async () => {
     window: {
       ...actual.window,
       showInformationMessage: host.showInformationMessage,
+      showWarningMessage: host.showWarningMessage,
     },
     commands: { ...actual.commands, executeCommand: host.executeCommand },
   };
@@ -93,6 +95,7 @@ interface HandlerFixtureOptions {
   readonly catalog?: AgentCatalog;
   /** Button label returned by the modal "members unavailable" prompt. */
   readonly modalChoice?: string | undefined;
+  readonly infoMessageResult?: Promise<string | undefined>;
 }
 
 async function createHandlerFixture(options: HandlerFixtureOptions = {}) {
@@ -103,18 +106,14 @@ async function createHandlerFixture(options: HandlerFixtureOptions = {}) {
 
   const notifications: string[] = [];
   const modalPrompts: string[] = [];
-  host.showInformationMessage.mockImplementation(
-    async (message: string, ...rest: unknown[]) => {
-      // The modal team-availability prompt passes options plus button labels;
-      // the plain confirmation toast passes only a message.
-      if (rest.length === 0) {
-        notifications.push(message);
-        return undefined;
-      }
-      modalPrompts.push(message);
-      return options.modalChoice;
-    },
-  );
+  host.showInformationMessage.mockImplementation((message: string) => {
+    notifications.push(message);
+    return options.infoMessageResult;
+  });
+  host.showWarningMessage.mockImplementation(async (message: string) => {
+    modalPrompts.push(message);
+    return options.modalChoice;
+  });
 
   const refreshAfterAgentMutation = vi.fn(
     async (_selectedToolUseAgent?: string, _catalogFresh?: boolean) => {},
@@ -160,7 +159,7 @@ describe('extension settings AgentHandlers', () => {
     resetAgentCatalogAuthRefreshScopeForTests();
   });
 
-  it('applies source-qualified teams and selects the tool-use root', async () => {
+  it('applies source-qualified teams without awaiting notification dismissal', async () => {
     const {
       handlers,
       notifications,
@@ -168,7 +167,8 @@ describe('extension settings AgentHandlers', () => {
       workspaceState,
     } = await createHandlerFixture({
       catalog: physicistCatalog(),
-      modalChoice: 'Continue with available members',
+      modalChoice: 'Continue with Available Members',
+      infoMessageResult: new Promise(() => {}),
     });
 
     await applyPreset(handlers, 'physicist');
@@ -232,7 +232,7 @@ describe('extension settings AgentHandlers', () => {
     });
     const { handlers } = await createHandlerFixture({
       workspaceState,
-      modalChoice: 'Sign in to TeXRA',
+      modalChoice: 'Sign In to TeXRA',
     });
     const update = vi.spyOn(workspaceState, 'update');
 
@@ -262,7 +262,16 @@ describe('extension settings AgentHandlers', () => {
 
     await applyPreset(handlers, 'remote-team');
 
-    expect(modalPrompts).toHaveLength(1);
+    expect(modalPrompts).toEqual([
+      'Team "Remote team" has unavailable TeXRA-hosted members: orchestrator.',
+    ]);
+    expect(host.showWarningMessage).toHaveBeenCalledWith(
+      modalPrompts[0],
+      { modal: true },
+      'Sign In to TeXRA',
+      'Continue with Available Members',
+      'Cancel',
+    );
     expect(registry.refreshAgents).not.toHaveBeenCalled();
     expect(refreshAfterAgentMutation).not.toHaveBeenCalled();
     expect(

--- a/src/test-kernel/settings/TeamRosterApplication.vitest.ts
+++ b/src/test-kernel/settings/TeamRosterApplication.vitest.ts
@@ -4,6 +4,7 @@ import {
   applyTeamRosterWithPreflight,
   type TeamRosterApplicationDeps,
 } from '@common/teams/TeamRosterApplication';
+import { applySettingsTeamRoster } from '@controllers/settingsView/SettingsTeamRosterController';
 import type { AgentModePreset } from '@shared/schemas';
 
 const preset: AgentModePreset = {
@@ -223,6 +224,90 @@ describe('team roster application', () => {
 
     expect(choose).toHaveBeenCalledWith(['generic', 'remoteSpecialist']);
     expect(legacyPreset).not.toHaveProperty('texraHostedAgents');
+  });
+
+  it('refreshes the host before presenting a successful settings application', async () => {
+    const calls: string[] = [];
+    const getPresetToolUseRoot = vi.fn(() => 'orchestrator');
+
+    await applySettingsTeamRoster('research', {
+      catalog: {
+        resolvePreset: () => ({ ok: true, preset, resolution: resolved }),
+        commitPresetResolution: async () => {
+          calls.push('apply');
+        },
+        getPresetToolUseRoot,
+      },
+      loadLocalCatalog: async () => {},
+      canAccessRemoteCatalog: async () => false,
+      signIn: async () => false,
+      forceRefreshRemoteCatalog: async () => {},
+      presentation: {
+        chooseTeamAvailability: async () => 'cancel',
+        showErrorMessage: async () => {},
+        showInfoMessage: async (message) => {
+          calls.push(`info:${message}`);
+        },
+      },
+      refreshAfterApply: async (selectedToolUseAgent) => {
+        calls.push(`refresh:${selectedToolUseAgent}`);
+      },
+    });
+
+    expect(getPresetToolUseRoot).toHaveBeenCalledWith(
+      ['orchestrator'],
+      'research',
+    );
+    expect(calls).toEqual([
+      'apply',
+      'refresh:orchestrator',
+      'info:Applied "Research" team',
+    ]);
+  });
+
+  it('presents canonical unavailable-member choices and errors', async () => {
+    const prompts: unknown[] = [];
+    const errors: string[] = [];
+
+    await applySettingsTeamRoster('research', {
+      catalog: {
+        resolvePreset: () => ({ ok: true, preset, resolution: unresolved }),
+        commitPresetResolution: vi.fn(),
+        getPresetToolUseRoot: vi.fn(),
+      },
+      loadLocalCatalog: async () => {},
+      canAccessRemoteCatalog: async () => false,
+      signIn: async () => true,
+      forceRefreshRemoteCatalog: async () => {},
+      presentation: {
+        chooseTeamAvailability: async (prompt) => {
+          prompts.push(prompt);
+          return 'sign-in';
+        },
+        showErrorMessage: async (message) => {
+          errors.push(message);
+        },
+        showInfoMessage: async () => {},
+      },
+      refreshAfterApply: async () => {},
+    });
+
+    expect(prompts).toEqual([
+      {
+        severity: 'warning',
+        message:
+          'Team "Research" has unavailable TeXRA-hosted members: orchestrator.',
+        actions: [
+          { choice: 'sign-in', label: 'Sign In to TeXRA' },
+          {
+            choice: 'continue',
+            label: 'Continue with Available Members',
+          },
+          { choice: 'cancel', label: 'Cancel' },
+        ],
+      },
+    ]);
+    expect(errors).toEqual(['Team "Research" is unavailable: orchestrator.']);
   });
 
   it('proceeds on a provided "continue" choice without prompting or signing in', async () => {


### PR DESCRIPTION
## Summary

Centralizes settings-team application outcomes so the extension and desktop use the same availability preflight, errors, success wording, and refresh-before-success ordering. Hosts retain only their presentation and refresh adapters. Extension success toasts remain fire-and-forget so auth-refresh deferral is released without waiting for dismissal.

## Issue acceptance gates

Addresses #11282: extension and desktop settings-team application behavior is consistent for unknown, unavailable, cancelled, and successfully applied teams; host-specific UX remains appropriate.

## Single source of truth

`src/controllers/settingsView/SettingsTeamRosterController.ts` owns settings-team outcome handling and its canonical prompt/error/success semantics. `TeamRosterApplication` remains the owner of roster preflight and commit.

## Duplication and abstraction budget

Removed duplicate settings outcome branches from both host adapters. The new coordinator owns a real two-host invariant: apply the roster, refresh the host, then present the outcome using the same canonical messages and availability choices. It does not own native UI, VS Code UI, auth, or renderer wiring.

## Net elements (R6)

Added 1 controller file and 3 exports; deleted no exports. Diff is +297/-128 lines (net +169), including focused existing-suite coverage and the required dead-code-ratchet entry for a root type consumed by the desktop package. The two host handlers are reduced by 22 and 24 lines respectively; the coordinator replaces their duplicated outcome orchestration rather than adding a parallel path.

## Consumer counts (R8)

n/a — no emit path or pre-existing export was deleted; the two settings hosts are the direct consumers of the new coordinator.

## Host impact

Extension: uses the shared coordinator, keeps VS Code warning and non-blocking success-toast behavior.

Desktop: uses the shared coordinator, keeps native modal availability UI, renderer refresh, and awaited native success notification.

CLI: none.

## Scheduled refactoring

None.

## Validation

- 26 focused roster/controller tests
- workspace, test-kernel, and desktop typechecks
- lint on changed source files
- `pnpm run check:dead-code-ratchet`
