### PR TITLE
refactor(google): inline interactions media round helper

### DIFF
--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -730,18 +730,6 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     return media;
   }
 
-  /** Labelled media for a round, or empty when there is nothing to attach. */
-  protected async buildLabelledMedia(
-    mediaFiles: FileLocation[] | undefined,
-    context: 'initial' | 'followUp',
-  ): Promise<Content[]> {
-    if (!mediaFiles?.length || !this.supportsFileUploads()) {
-      return [];
-    }
-
-    return this.createMediaForRound(mediaFiles, context);
-  }
-
   // ===========================================================================
   // Capability getters / auth (REUSE / PORT from the chat handler)
   // ===========================================================================
@@ -931,14 +919,14 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   async initializeMessages(
     userPrefix: string,
     userRequest: string,
-    mediaFiles?: FileLocation[],
+    mediaFiles: FileLocation[] = [],
     _systemPrompt?: string,
   ): Promise<Step[]> {
     // System prompt is NOT a step — it rides on request-level system_instruction
     // (resent on every create, spec §6.2).
     const content: Content[] = [
       ...(userPrefix.trim() ? [this.textMedia(userPrefix)] : []),
-      ...(await this.buildLabelledMedia(mediaFiles, 'initial')),
+      ...(await this.createMediaForRound(mediaFiles, 'initial')),
     ];
     if (userRequest.trim()) {
       const separator = content.length > 0 ? '\n' : '';
@@ -957,10 +945,10 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   async createRoundMessages(
     messages: Step[],
     userMessage: string,
-    mediaFiles?: FileLocation[],
+    mediaFiles: FileLocation[] = [],
   ): Promise<Step[]> {
     const content: Content[] = [
-      ...(await this.buildLabelledMedia(mediaFiles, 'followUp')),
+      ...(await this.createMediaForRound(mediaFiles, 'followUp')),
       ...(userMessage.trim() ? [this.textMedia(userMessage)] : []),
     ];
 

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -692,10 +692,16 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     }
   }
 
+  private hasSupportedMedia(
+    mediaFiles: FileLocation[] | undefined,
+  ): mediaFiles is FileLocation[] {
+    return Boolean(mediaFiles?.length) && this.supportsFileUploads();
+  }
+
   protected override async createMediaMessage(
     mediaFiles: FileLocation[],
   ): Promise<Content[]> {
-    if (!mediaFiles?.length || !this.supportsFileUploads()) {
+    if (!this.hasSupportedMedia(mediaFiles)) {
       return [];
     }
 
@@ -919,14 +925,17 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   async initializeMessages(
     userPrefix: string,
     userRequest: string,
-    mediaFiles: FileLocation[] = [],
+    mediaFiles?: FileLocation[],
     _systemPrompt?: string,
   ): Promise<Step[]> {
     // System prompt is NOT a step — it rides on request-level system_instruction
     // (resent on every create, spec §6.2).
+    const media = this.hasSupportedMedia(mediaFiles)
+      ? await this.createMediaForRound(mediaFiles, 'initial')
+      : [];
     const content: Content[] = [
       ...(userPrefix.trim() ? [this.textMedia(userPrefix)] : []),
-      ...(await this.createMediaForRound(mediaFiles, 'initial')),
+      ...media,
     ];
     if (userRequest.trim()) {
       const separator = content.length > 0 ? '\n' : '';
@@ -945,10 +954,13 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   async createRoundMessages(
     messages: Step[],
     userMessage: string,
-    mediaFiles: FileLocation[] = [],
+    mediaFiles?: FileLocation[],
   ): Promise<Step[]> {
+    const media = this.hasSupportedMedia(mediaFiles)
+      ? await this.createMediaForRound(mediaFiles, 'followUp')
+      : [];
     const content: Content[] = [
-      ...(await this.createMediaForRound(mediaFiles, 'followUp')),
+      ...media,
       ...(userMessage.trim() ? [this.textMedia(userMessage)] : []),
     ];
 


### PR DESCRIPTION
## Summary

Removes the vestigial Google Interactions `buildLabelledMedia` forwarding wrapper and calls the existing media-round pipeline at the two real call sites.

## Issue acceptance gates

Addresses #11298: the wrapper is deleted and its two initial/follow-up callers use the underlying round helper directly. Empty, undefined, and unsupported media still bypass the overridable media seam.

## Single source of truth

`createMediaForRound` remains the single owner of round-aware media construction. `hasSupportedMedia` owns the shared precondition required before entering the overridable pipeline.

## Duplication and abstraction budget

Deletes a forwarding wrapper. The small shared predicate avoids duplicating the compatibility-critical early guard across initial and follow-up call sites; it preserves the existing subclass seam behavior rather than adding a new layer.

## Net elements (R6)

No files or exports added/deleted. Diff is +15/-15 lines (net 0): 12 lines of forwarding wrapper were removed and replaced with a shared precondition plus two explicit call sites.

## Consumer counts (R8)

n/a — no emit path or exported API was deleted; the removed method was an internal helper with two direct callers.

## Host impact

Extension: Google Interactions media behavior unchanged.

Desktop: Google Interactions media behavior unchanged.

CLI: Google Interactions media behavior unchanged.

## Scheduled refactoring

None.

## Validation

- `npx vitest run --config vitest.config.mjs src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts` (16 passed)
- `npx eslint src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts`
- `npm run typecheck:workspace`
- `git diff --check`
