### PR TITLE
refactor(runtime): one serial lane per execution; three follow-up outcomes

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1586,18 +1586,6 @@
       "name": "ExecutionLeaseSchema"
     },
     {
-      "file": "src/agent/storage/executionLease.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "ownsExecutionLease"
-    },
-    {
-      "file": "src/agent/storage/executionLease.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "resetExecutionLeaseCoordinationForTests"
-    },
-    {
       "file": "src/agent/trace/events.ts",
       "category": "production-dead",
       "kind": "types",

--- a/docs/proposals/2026-08-23-single-owner-sessions.md
+++ b/docs/proposals/2026-08-23-single-owner-sessions.md
@@ -193,8 +193,11 @@ existing `.then/.catch` in `desktopAgentExecution.ts:1169-1200` posts it
 already runs.
 
 **D6. Three outcomes, not thirty.** `SubmitFollowUpResult` becomes
-`sent | queued | failed{reason}` where `reason` is a short enum the UI can
-word: `finished`, `owned_elsewhere`, `not_resumable`, `resume_failed`.
+`sent | queued{wake?} | failed{reason}` where `reason` is a short enum the
+UI can word: `finished`, `owned_elsewhere`, `not_resumable`. A queued input
+whose recovery resume did not reach the run is `queued` with
+`wake: 'failed'`: it was admitted and an explicit Resume delivers it, so no
+consumer hands the draft back or re-offers it.
 Internal submission kinds may survive inside the queue manager, but the
 generation-fence restore (`ToolUseFollowUp.ts:108-167`, six diagnostics)
 and `existing_recoverable` admission exist only because foreign or stale

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -701,6 +701,7 @@ export function createChatSessionController(
           resolveAndResumeStream(
             streamId,
             {
+              executions: runtimeSession.executions,
               isCancellationRequested,
               resolveResumeState: async () => ({
                 status: 'resolved',

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -701,7 +701,6 @@ export function createChatSessionController(
           resolveAndResumeStream(
             streamId,
             {
-              streamStatus: runtimeSession.status,
               isCancellationRequested,
               resolveResumeState: async () => ({
                 status: 'resolved',
@@ -741,7 +740,6 @@ export function createChatSessionController(
                     resumedOutcome = result.outcome;
                   },
                   onError: reportRunFailure,
-                  canAcquireResumeLease: () => !isCancellationRequested(),
                 }),
               executeWorkflow: async () => {
                 throw new Error(

--- a/packages/cli/src/chat/tui/chatSubmitDriver.ts
+++ b/packages/cli/src/chat/tui/chatSubmitDriver.ts
@@ -9,7 +9,7 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import PQueue from 'p-queue';
 
 import type { SessionHandle } from '@agent/runtime';
-import { presentFollowUpResult, submitFollowUp } from '@agent/followUp';
+import { describeFollowUpFailure, submitFollowUp } from '@agent/followUp';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { setCliHelperModel } from '@cli/runtime/initPlatform';
 import {
@@ -53,9 +53,6 @@ import {
 } from './state/transcript';
 import type { ChatSessionController } from '../chatSessionController';
 import type { SkillActivation } from './forms/SkillsListForm';
-
-const FOLLOW_UP_NOT_ACCEPTED =
-  'No active session accepted that message; it has been restored to the input.';
 
 interface PreparedChatInstruction {
   readonly instruction: string;
@@ -305,28 +302,24 @@ export function createChatSubmitDriver(
           mediaFiles,
           displayText: prepared.displayInstruction,
         });
-        if (result.status === 'sent') {
+        if (result.status !== 'failed') {
           emitQueuedFollowUpsChanged(followUpTarget);
           delivered = true;
-        } else if (result.status === 'queued') {
+        } else if (result.reason === 'resume_failed') {
+          // The input is in the stream's queue; only its wake failed.
           emitQueuedFollowUpsChanged(followUpTarget);
-          const presentation = presentFollowUpResult(result);
-          if (presentation.severity !== 'none') {
-            if (presentation.refreshQueuedFollowUps) {
-              emitQueuedFollowUpsChanged(followUpTarget);
-            }
-            appendLocalAssistantTranscript(
-              presentation.message,
-              followUpTarget,
-            );
-          }
-          delivered = result.continuation !== 'resume_failed';
-        }
-        if (result.status === 'no_session' || result.status === 'dropped') {
+          appendLocalAssistantTranscript(
+            describeFollowUpFailure(result.reason),
+            followUpTarget,
+          );
+        } else {
           // The draft is the user's until admitted: hand it back before any
           // notice, so a refused send never costs a retype.
           requestDraftRestore(line);
-          setTransientNotice(FOLLOW_UP_NOT_ACCEPTED, { ttlMs: Infinity });
+          setTransientNotice(
+            `${describeFollowUpFailure(result.reason)} The message has been restored to the input.`,
+            { ttlMs: Infinity },
+          );
           // Child stream ids are keys in parentStream; the root session id is not.
           if (followUpTarget === session.streamId) {
             session.stopRequested = true;

--- a/packages/cli/src/chat/tui/chatSubmitDriver.ts
+++ b/packages/cli/src/chat/tui/chatSubmitDriver.ts
@@ -9,7 +9,11 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import PQueue from 'p-queue';
 
 import type { SessionHandle } from '@agent/runtime';
-import { describeFollowUpFailure, submitFollowUp } from '@agent/followUp';
+import {
+  describeFollowUpFailure,
+  presentFollowUpResult,
+  submitFollowUp,
+} from '@agent/followUp';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { setCliHelperModel } from '@cli/runtime/initPlatform';
 import {
@@ -305,13 +309,14 @@ export function createChatSubmitDriver(
         if (result.status !== 'failed') {
           emitQueuedFollowUpsChanged(followUpTarget);
           delivered = true;
-        } else if (result.reason === 'resume_failed') {
-          // The input is in the stream's queue; only its wake failed.
-          emitQueuedFollowUpsChanged(followUpTarget);
-          appendLocalAssistantTranscript(
-            describeFollowUpFailure(result.reason),
-            followUpTarget,
-          );
+          const presentation = presentFollowUpResult(result);
+          if (presentation.severity !== 'none') {
+            // The input is in the stream's queue; only its wake failed.
+            appendLocalAssistantTranscript(
+              presentation.message,
+              followUpTarget,
+            );
+          }
         } else {
           // The draft is the user's until admitted: hand it back before any
           // notice, so a refused send never costs a retype.

--- a/packages/cli/src/commands/resumeExecution.ts
+++ b/packages/cli/src/commands/resumeExecution.ts
@@ -179,7 +179,6 @@ export async function runResumeExecution(
   let failed = false;
   let failureExitCode: CliExitCode = CliExitCode.AgentError;
   const resumed = await resolveAndResumeStream(streamId, {
-    streamStatus: session.status,
     resolveResumeState: async () => ({
       status: 'resolved',
       state: { runState: config, executionId: id },

--- a/packages/cli/src/commands/resumeExecution.ts
+++ b/packages/cli/src/commands/resumeExecution.ts
@@ -197,6 +197,7 @@ export async function runResumeExecution(
   let failed = false;
   let failureExitCode: CliExitCode = CliExitCode.AgentError;
   const resumed = await resolveAndResumeStream(streamId, {
+    executions: session.executions,
     resolveResumeState: async () => ({
       status: 'resolved',
       state: { runState: config, executionId: id },

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -10,7 +10,6 @@ import {
   deriveResumability,
   ExecutionLeaseLostError,
   inspectExecutionLease,
-  type OwnedExecutionLeaseScope,
   type ResumabilityDecision,
 } from '@agent/storage';
 import { validateExecutionRequest } from '@agent/core/state/executionRequests';
@@ -311,14 +310,12 @@ export async function executeCliRequest(
     shutdownFinalizationFailureReported = true;
     reportFinalizationFailure(error);
   };
-  let settleLeaseScope: (
-    scope: OwnedExecutionLeaseScope | undefined,
+  let settleLeaseAcquired: (
+    executionId: ExecutionId | undefined,
   ) => void = () => undefined;
-  const leaseScopeReady = new Promise<OwnedExecutionLeaseScope | undefined>(
-    (resolve) => {
-      settleLeaseScope = resolve;
-    },
-  );
+  const leaseAcquired = new Promise<ExecutionId | undefined>((resolve) => {
+    settleLeaseAcquired = resolve;
+  });
   let settleShutdownFinalization: () => void = () => undefined;
   const shutdownFinalizationDone = new Promise<void>((resolve) => {
     settleShutdownFinalization = resolve;
@@ -338,20 +335,16 @@ export async function executeCliRequest(
   const finalizeShutdownStatus = (): Promise<boolean> => {
     if (!shutdownInterrupted) return Promise.resolve(false);
     shutdownStatusFinalized ??= (async () => {
-      const runWithOwnership = await leaseScopeReady;
-      const executionId = ownedExecutionId;
-      if (!runWithOwnership || !executionId) return false;
+      const executionId = await leaseAcquired;
+      if (!executionId) return false;
       try {
-        let terminalStatusPersisted = false;
-        await runWithOwnership(async () => {
-          terminalStatusPersisted = await finalizeCliExecution(
-            executionId,
-            RUN_OUTCOME.CANCELLED,
-            'preserve',
-            reportShutdownFinalizationFailure,
-          );
-          await session.releaseExecutionLease(executionId);
-        });
+        const terminalStatusPersisted = await finalizeCliExecution(
+          executionId,
+          RUN_OUTCOME.CANCELLED,
+          'preserve',
+          reportShutdownFinalizationFailure,
+        );
+        await session.releaseExecutionLease(executionId);
         const resumability = terminalStatusPersisted
           ? await deriveResumability(executionId)
           : undefined;
@@ -473,9 +466,9 @@ export async function executeCliRequest(
           }
           return handled;
         },
-        onExecutionLeaseAcquired: (runWithOwnership, executionId) => {
+        onExecutionLeaseAcquired: (executionId) => {
           ownedExecutionId = executionId;
-          settleLeaseScope(runWithOwnership);
+          settleLeaseAcquired(executionId);
         },
         stopAfterCycle: options.stopAfterCycle,
         approvalPromptsUnavailable: cliApprovalPromptsUnavailable(
@@ -492,7 +485,7 @@ export async function executeCliRequest(
     } finally {
       // Unblock an in-flight shutdown when acquisition failed before a scope
       // became available. Promise resolution is one-shot after success.
-      settleLeaseScope(undefined);
+      settleLeaseAcquired(undefined);
     }
   };
 

--- a/packages/desktop/src/main/desktopAgentLaunch.ts
+++ b/packages/desktop/src/main/desktopAgentLaunch.ts
@@ -13,8 +13,6 @@ import {
 
 export interface DesktopAgentLaunchContext {
   readonly session: SessionHandle;
-  /** Resume-only canonical admission checked under the execution lease lock. */
-  readonly canAcquireResumeLease?: () => boolean | Promise<boolean>;
 }
 
 export type DesktopAgentLaunchOptions = Pick<
@@ -42,9 +40,6 @@ export async function launchDesktopAgent(
     ...(options.preferHelperModel && { preferHelperModel: true }),
     onRun: options.onRun,
     suppressErrorNotification: options.suppressErrorNotification,
-    ...(context.canAcquireResumeLease && {
-      canAcquireResumeLease: context.canAcquireResumeLease,
-    }),
     openWorkflowOutput: async (result) => {
       const output = selectAutoOpenFinalOutput(result);
       if (!output) return;

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -67,27 +67,11 @@ async function resumeDesktopStream(
     (event) => event.streamId === streamId,
   );
   let transcriptMissing = false;
-  let authoritativeStreamMissing = false;
   const isResumeInvalidated = (): boolean => {
     if (!transcriptMissing && !context.session.transcripts.has(streamId)) {
       transcriptMissing = true;
     }
-    return (
-      context.isCancellationRequested() ||
-      transcriptMissing ||
-      authoritativeStreamMissing
-    );
-  };
-  // Desktop-only durable multi-window resume fence: extension/CLI must not copy
-  // it because their resume admission is owned by one in-process transcript
-  // store, while desktop must fence stream identity across windows/processes.
-  const canAcquireResumeLease = async (): Promise<boolean> => {
-    if (isResumeInvalidated()) return false;
-    if (!(await context.session.transcripts.hasAuthoritativeStream(streamId))) {
-      authoritativeStreamMissing = true;
-      return false;
-    }
-    return !isResumeInvalidated();
+    return context.isCancellationRequested() || transcriptMissing;
   };
   const reportUnhandledFailure = (id: StreamTabId, error: unknown): void => {
     context.logger.error(`Failed to resume desktop stream ${id}`, {
@@ -104,7 +88,6 @@ async function resumeDesktopStream(
   return resolveAndResumeStream(
     streamId,
     {
-      streamStatus: context.session.status,
       resolveResumeState: (id) =>
         resolveResumeStateFromSnapshots(context.session.snapshots, id),
       reportResumeStateResolution: async (id, resolution) => {
@@ -128,7 +111,6 @@ async function resumeDesktopStream(
           session: context.session,
           recovery: claimedRecovery,
           runtimeUnavailableTools: getDefaultUnavailableToolNames('desktop'),
-          canAcquireResumeLease,
           isCancellationRequested: isResumeInvalidated,
           onError: (error) => reportUnhandledFailure(streamId, error),
         });
@@ -136,7 +118,7 @@ async function resumeDesktopStream(
       executeWorkflow: (config, executionId, modelHandlerCompatibilityKey) =>
         launchDesktopAgent(
           { kind: 'resume', config, executionId },
-          { session: context.session, canAcquireResumeLease },
+          { session: context.session },
           { modelHandlerCompatibilityKey, suppressErrorNotification: true },
         ),
       reportNoResumableSession: () =>

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -85,9 +85,19 @@ async function resumeDesktopStream(
       ),
     );
   };
+  // The resident transcript index is a cache of this process; the stream may
+  // have been deleted from the durable transcript store by another process
+  // since it was loaded. Read the store before resuming: neither the lease
+  // (a deleted stream holds none) nor the execution lane (in-process only)
+  // sees that fact.
+  if (!(await context.session.transcripts.hasAuthoritativeStream(streamId))) {
+    return false;
+  }
+  if (isResumeInvalidated()) return false;
   return resolveAndResumeStream(
     streamId,
     {
+      executions: context.session.executions,
       resolveResumeState: (id) =>
         resolveResumeStateFromSnapshots(context.session.snapshots, id),
       reportResumeStateResolution: async (id, resolution) => {

--- a/packages/desktop/src/main/desktopProcessStores.ts
+++ b/packages/desktop/src/main/desktopProcessStores.ts
@@ -50,7 +50,7 @@ export async function initializeDesktopProcessStores(session: SessionHandle) {
             return;
           }
           void stores
-            .deleteStreamAfterOwnedExecutionRelease(streamId, {
+            .deleteStreamAfterExecutionQuiescence(streamId, {
               shouldDelete: () =>
                 (streamIncarnations.get(streamId) ?? 0) === expectedIncarnation,
               expectedIncarnation,

--- a/packages/desktop/src/main/desktopProcessStores.ts
+++ b/packages/desktop/src/main/desktopProcessStores.ts
@@ -50,7 +50,7 @@ export async function initializeDesktopProcessStores(session: SessionHandle) {
             return;
           }
           void stores
-            .deleteStreamAfterExecutionQuiescence(streamId, {
+            .deleteStream(streamId, {
               shouldDelete: () =>
                 (streamIncarnations.get(streamId) ?? 0) === expectedIncarnation,
               expectedIncarnation,

--- a/packages/extension/src/commands/agent/executeCommand.ts
+++ b/packages/extension/src/commands/agent/executeCommand.ts
@@ -33,10 +33,7 @@ interface WrappedExecuteInput {
  *
  * Tool-use sessions resume through `tryResumeFromResumeData` instead.
  */
-export async function runExecuteCommand(
-  input: unknown,
-  options: Pick<RunAgentOptions, 'canAcquireResumeLease'> = {},
-): Promise<void> {
+export async function runExecuteCommand(input: unknown): Promise<void> {
   try {
     const wrapped =
       input !== null && typeof input === 'object' && 'config' in input
@@ -64,10 +61,6 @@ export async function runExecuteCommand(
       modelHandlerCompatibilityKey,
       copilotRouteOverride,
       onRun: wrapped?.onRun,
-      // In-process-only resume admission guard. It is never serialized: the
-      // VS Code command action still receives a single `input` argument
-      // across the registry/dispatch boundary.
-      canAcquireResumeLease: options.canAcquireResumeLease,
     });
   } catch (error) {
     if (error instanceof ZodError) {

--- a/packages/extension/src/commands/agent/resumeFromResumeData.ts
+++ b/packages/extension/src/commands/agent/resumeFromResumeData.ts
@@ -34,8 +34,7 @@ export function tryResumeFromResumeData(
       );
       // Per-attempt monotone cancellation latch: once an observed transcript
       // absence invalidates the attempt, re-creating the same stream id cannot
-      // make it admissible again. `canAcquireResumeLease` rechecks the same
-      // latch under the execution-lease lock.
+      // make it admissible again.
       let cancellationRequested = false;
       const isCancellationRequested = (): boolean => {
         if (!cancellationRequested && !session.transcripts.has(streamId)) {
@@ -43,7 +42,6 @@ export function tryResumeFromResumeData(
         }
         return cancellationRequested;
       };
-      const canAcquireResumeLease = () => !isCancellationRequested();
       const reportResumeFailure = async (error: unknown): Promise<void> => {
         logger.error(`Failed to resume stream: ${streamId}`, { data: error });
         await terminalResult.reportUnhandled(() =>
@@ -55,7 +53,6 @@ export function tryResumeFromResumeData(
       return resolveAndResumeStream(
         streamId,
         {
-          streamStatus: session.status,
           isCancellationRequested,
           resolveResumeState: (id) =>
             resolveResumeStateFromSnapshots(session.snapshots, id),
@@ -83,7 +80,6 @@ export function tryResumeFromResumeData(
             resumeQueuedToolUseFromResumeData(resume.streamId, resume, {
               session,
               recovery: claimedRecovery,
-              canAcquireResumeLease,
               isCancellationRequested,
               onError: reportResumeFailure,
             }),
@@ -92,14 +88,11 @@ export function tryResumeFromResumeData(
             executionId,
             modelHandlerCompatibilityKey,
           ) =>
-            runExecuteCommand(
-              {
-                config,
-                executionId,
-                modelHandlerCompatibilityKey,
-              },
-              { canAcquireResumeLease },
-            ),
+            runExecuteCommand({
+              config,
+              executionId,
+              modelHandlerCompatibilityKey,
+            }),
           reportNoResumableSession: async (id) => {
             logger.warn(`No resumable session state for stream: ${id}`);
             await session.interactions.showInfoMessage(

--- a/packages/extension/src/commands/agent/resumeFromResumeData.ts
+++ b/packages/extension/src/commands/agent/resumeFromResumeData.ts
@@ -53,6 +53,7 @@ export function tryResumeFromResumeData(
       return resolveAndResumeStream(
         streamId,
         {
+          executions: session.executions,
           isCancellationRequested,
           resolveResumeState: (id) =>
             resolveResumeStateFromSnapshots(session.snapshots, id),

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -4,7 +4,11 @@ import * as vscode from 'vscode';
 
 import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
-import { attachTerminalResultToast, defaultSession } from '@agent/runtime';
+import {
+  attachTerminalResultToast,
+  defaultSession,
+  StorageRootChangeRefusedError,
+} from '@agent/runtime';
 import {
   BaseWebviewProvider,
   BundledViewContentProvider,
@@ -207,7 +211,9 @@ export class ProgressViewProvider extends BaseWebviewProvider {
               { data: error },
             );
             void vscode.window.showErrorMessage(
-              'TeXRA could not reload settings and transcripts after the workspace changed. Retry the workspace change or restart TeXRA.',
+              error instanceof StorageRootChangeRefusedError
+                ? error.message
+                : 'TeXRA could not reload settings and transcripts after the workspace changed. Retry the workspace change or restart TeXRA.',
             );
           },
         );

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 import { deriveResumability } from '@agent/storage/resumability';
-import { type ToolUseFollowUpQueueReason } from '@agent/runtime/executionRegistry';
+import { classifyRun } from '@agent/runtime/runClassification';
 import {
   currentSession,
   defaultSession,
@@ -16,30 +16,33 @@ import type { StreamTabId } from '@shared/schemas';
 import type { FollowUpQueueInput } from './FollowUpQueue';
 import type { FollowUpRecoveryLease } from './ToolUseFollowUpQueueManager';
 
+/**
+ * Why a submission could not be admitted, worded for the user by
+ * {@link presentFollowUpResult}.
+ *
+ * - `finished`: the run has no checkpoint left to continue from.
+ * - `owned_elsewhere`: another TeXRA process holds the run.
+ * - `not_resumable`: the stream has no live flow here and the submission was
+ *   refused (a replaced continuation generation, a disposed session, a run
+ *   this process cannot classify).
+ * - `resume_failed`: the input was queued, but the recovery resume it
+ *   triggered did not reach the run; an explicit Resume delivers it.
+ */
+export type FollowUpFailureReason =
+  'finished' | 'owned_elsewhere' | 'not_resumable' | 'resume_failed';
+
+/**
+ * Three outcomes: the input reached a live flow, it waits in the stream's
+ * queue for the next turn, or it was not admitted for a worded reason. A
+ * delivery the admission boundary had already accepted (#9531) is `sent`.
+ */
 export type SubmitFollowUpResult =
   | { status: 'sent' }
-  | {
-      status: 'queued';
-      reason: ToolUseFollowUpQueueReason;
-      continuation: 'live' | 'recovering' | 'resumed' | 'resume_failed';
-    }
-  | {
-      /**
-       * The admission boundary already accepted this exact delivery id
-       * (#9531): nothing was appended and no wake/resume was triggered.
-       */
-      status: 'duplicate';
-    }
-  | { status: 'no_session'; streamStatus: string | undefined }
-  | { status: 'dropped' };
+  | { status: 'queued' }
+  | { status: 'failed'; reason: FollowUpFailureReason };
 
 export type FollowUpPresentation =
-  | { severity: 'none' }
-  | {
-      severity: 'info' | 'warning';
-      message: string;
-      refreshQueuedFollowUps: boolean;
-    };
+  { severity: 'none' } | { severity: 'info' | 'warning'; message: string };
 
 export interface SubmitFollowUpOptions {
   readonly session?: SessionHandle;
@@ -60,26 +63,29 @@ export interface SubmitFollowUpOptions {
   readonly onAdmitted?: (admitted: boolean) => void;
 }
 
+const FAILURE_MESSAGES: Record<FollowUpFailureReason, string> = {
+  finished: 'This run has finished. Start a new agent task to continue.',
+  owned_elsewhere:
+    'This run is live in another TeXRA window. Send the message there.',
+  not_resumable:
+    'This run cannot accept messages right now. Resume it, or start a new agent task.',
+  resume_failed:
+    'Message queued, but the run could not be resumed automatically. Resume it to deliver the message, or start a new agent task.',
+};
+
+/** The one wording of each refusal, shared by every host and tool output. */
+export function describeFollowUpFailure(reason: FollowUpFailureReason): string {
+  return FAILURE_MESSAGES[reason];
+}
+
 export function presentFollowUpResult(
   result: SubmitFollowUpResult,
 ): FollowUpPresentation {
-  if (result.status === 'dropped') {
-    return {
-      severity: 'warning',
-      message:
-        'Message dropped because no session was available to receive it. Start a new agent task to continue.',
-      refreshQueuedFollowUps: true,
-    };
-  }
-  if (result.status === 'queued' && result.continuation === 'resume_failed') {
-    return {
-      severity: 'info',
-      message:
-        'Message queued, but the run could not be resumed automatically. Resume it to deliver the message, or start a new agent task.',
-      refreshQueuedFollowUps: false,
-    };
-  }
-  return { severity: 'none' };
+  if (result.status !== 'failed') return { severity: 'none' };
+  return {
+    severity: result.reason === 'resume_failed' ? 'info' : 'warning',
+    message: describeFollowUpFailure(result.reason),
+  };
 }
 
 const logger = createLog('ToolUseFollowUp');
@@ -189,8 +195,10 @@ export function notifyFollowUpSent(
 interface PendingResume {
   readonly resume: Promise<boolean>;
   readonly recovery: FollowUpRecoveryLease;
-  readonly reason: ToolUseFollowUpQueueReason;
 }
+
+type Admission =
+  SubmitFollowUpResult | PendingResume | { status: 'no_session' };
 
 /**
  * Route and admit one submission. Synchronous from the registry snapshot to
@@ -206,7 +214,7 @@ function admitFollowUp(
   item: FollowUpQueueInput,
   options: SubmitFollowUpOptions,
   ownerSession: SessionHandle,
-): SubmitFollowUpResult | PendingResume {
+): Admission {
   const target = ownerSession.executions.getToolUseFollowUpTarget(streamId);
 
   if (target.kind === 'active') {
@@ -218,28 +226,18 @@ function admitFollowUp(
       'live_owner',
       options.expectedGenerationId,
     );
-    if (submission.kind === 'duplicate') {
-      return { status: 'duplicate' };
-    }
+    if (submission.kind === 'duplicate') return { status: 'sent' };
     if (submission.kind === 'live_flow') {
-      if (options.mode === 'live_notification') {
-        return {
-          status: 'queued',
-          reason: 'waiting',
-          continuation: 'live',
-        };
-      }
+      if (options.mode === 'live_notification') return { status: 'queued' };
       notifyFollowUpSent(streamId, ownerSession);
       return { status: 'sent' };
     }
     if (submission.kind === 'live' || submission.kind === 'queued') {
-      return {
-        status: 'queued',
-        reason: 'waiting',
-        continuation: 'live',
-      };
+      return { status: 'queued' };
     }
-    if (submission.kind !== 'not_owned') return { status: 'dropped' };
+    if (submission.kind !== 'not_owned') {
+      return { status: 'failed', reason: 'not_resumable' };
+    }
     target.context.session.appendFollowUp(item);
     notifyFollowUpSent(streamId, ownerSession);
     return { status: 'sent' };
@@ -249,10 +247,9 @@ function admitFollowUp(
     logger.warn(
       `No active session for follow-up on stream ${streamId}. Status: ${target.streamStatus}`,
     );
-    return { status: 'no_session', streamStatus: target.streamStatus };
+    return { status: 'no_session' };
   }
 
-  const reason = target.reason;
   const admission =
     options.mode === 'live_notification' ? 'live_owner' : 'recoverable';
   const submission = ownerSession.followUps.submit(
@@ -261,26 +258,44 @@ function admitFollowUp(
     admission,
     options.expectedGenerationId,
   );
-  if (submission.kind === 'duplicate') {
-    return { status: 'duplicate' };
-  }
+  if (submission.kind === 'duplicate') return { status: 'sent' };
   if (submission.kind === 'unavailable' || submission.kind === 'not_owned') {
-    return { status: 'dropped' };
+    return { status: 'failed', reason: 'not_resumable' };
   }
-  if (submission.kind !== 'recovery') {
-    return {
-      status: 'queued',
-      reason,
-      continuation: submission.kind === 'recovering' ? 'recovering' : 'live',
-    };
-  }
+  if (submission.kind !== 'recovery') return { status: 'queued' };
 
   const recovery = submission.lease;
   const resume = (options.resumePort ?? platform().agentResume).tryResumeStream(
     streamId,
     recovery,
   );
-  return { resume, recovery, reason };
+  return { resume, recovery };
+}
+
+/**
+ * Word the refusal of a stream with no live flow here from the persisted
+ * facts: who holds the run, and whether a checkpoint is left. Read only on
+ * the failure path; an unreadable fact is `not_resumable`.
+ */
+async function classifyRefusal(
+  streamId: StreamTabId,
+  session: SessionHandle,
+): Promise<FollowUpFailureReason> {
+  const executionId = session.snapshots.getRunMetadata(streamId, {
+    quiet: true,
+  }).executionId;
+  if (!executionId) return 'not_resumable';
+  const classification = await classifyRun(executionId);
+  switch (classification.kind) {
+    case 'held_elsewhere':
+      return 'owned_elsewhere';
+    case 'finished':
+      return 'finished';
+    case 'resumable':
+    case 'owned_here':
+    case 'unclassified':
+      return 'not_resumable';
+  }
 }
 
 export async function submitFollowUp(
@@ -315,24 +330,23 @@ export async function submitFollowUp(
     !(await restorePersistedGeneration(streamId, ownerSession))
   ) {
     notifyAdmitted(false);
-    return { status: 'dropped' };
+    return { status: 'failed', reason: 'not_resumable' };
   }
   const dispatch = admitFollowUp(streamId, item, options, ownerSession);
-  if (!('resume' in dispatch)) {
-    notifyAdmitted(
-      dispatch.status !== 'no_session' && dispatch.status !== 'dropped',
-    );
-    return dispatch;
-  }
-  notifyAdmitted(true);
-
-  const resumed = await dispatch.resume;
-  if (!resumed) {
+  if ('resume' in dispatch) {
+    notifyAdmitted(true);
+    const resumed = await dispatch.resume;
+    if (resumed) return { status: 'queued' };
     ownerSession.followUps.release(dispatch.recovery, 'recoverable');
+    return { status: 'failed', reason: 'resume_failed' };
   }
-  return {
-    status: 'queued',
-    reason: dispatch.reason,
-    continuation: resumed ? 'resumed' : 'resume_failed',
-  };
+  if (dispatch.status === 'no_session') {
+    notifyAdmitted(false);
+    return {
+      status: 'failed',
+      reason: await classifyRefusal(streamId, ownerSession),
+    };
+  }
+  notifyAdmitted(dispatch.status !== 'failed');
+  return dispatch;
 }

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -12,7 +12,7 @@ import {
 import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import type { AgentResumePort } from '@platform/interfaces';
-import type { StreamTabId } from '@shared/schemas';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import type { FollowUpQueueInput } from './FollowUpQueue';
 import type { FollowUpRecoveryLease } from './ToolUseFollowUpQueueManager';
 
@@ -25,20 +25,21 @@ import type { FollowUpRecoveryLease } from './ToolUseFollowUpQueueManager';
  * - `not_resumable`: the stream has no live flow here and the submission was
  *   refused (a replaced continuation generation, a disposed session, a run
  *   this process cannot classify).
- * - `resume_failed`: the input was queued, but the recovery resume it
- *   triggered did not reach the run; an explicit Resume delivers it.
  */
 export type FollowUpFailureReason =
-  'finished' | 'owned_elsewhere' | 'not_resumable' | 'resume_failed';
+  'finished' | 'owned_elsewhere' | 'not_resumable';
 
 /**
  * Three outcomes: the input reached a live flow, it waits in the stream's
  * queue for the next turn, or it was not admitted for a worded reason. A
  * delivery the admission boundary had already accepted (#9531) is `sent`.
+ * A queued input whose recovery resume did not reach the run is still
+ * queued (`wake: 'failed'`): the input belongs to the stream, and an
+ * explicit Resume delivers it.
  */
 export type SubmitFollowUpResult =
   | { status: 'sent' }
-  | { status: 'queued' }
+  | { status: 'queued'; wake?: 'failed' }
   | { status: 'failed'; reason: FollowUpFailureReason };
 
 export type FollowUpPresentation =
@@ -69,9 +70,10 @@ const FAILURE_MESSAGES: Record<FollowUpFailureReason, string> = {
     'This run is live in another TeXRA window. Send the message there.',
   not_resumable:
     'This run cannot accept messages right now. Resume it, or start a new agent task.',
-  resume_failed:
-    'Message queued, but the run could not be resumed automatically. Resume it to deliver the message, or start a new agent task.',
 };
+
+export const FOLLOW_UP_WAKE_FAILED_MESSAGE =
+  'Message queued, but the run could not be resumed automatically. Resume it to deliver the message, or start a new agent task.';
 
 /** The one wording of each refusal, shared by every host and tool output. */
 export function describeFollowUpFailure(reason: FollowUpFailureReason): string {
@@ -81,11 +83,16 @@ export function describeFollowUpFailure(reason: FollowUpFailureReason): string {
 export function presentFollowUpResult(
   result: SubmitFollowUpResult,
 ): FollowUpPresentation {
-  if (result.status !== 'failed') return { severity: 'none' };
-  return {
-    severity: result.reason === 'resume_failed' ? 'info' : 'warning',
-    message: describeFollowUpFailure(result.reason),
-  };
+  if (result.status === 'failed') {
+    return {
+      severity: 'warning',
+      message: describeFollowUpFailure(result.reason),
+    };
+  }
+  if (result.status === 'queued' && result.wake === 'failed') {
+    return { severity: 'info', message: FOLLOW_UP_WAKE_FAILED_MESSAGE };
+  }
+  return { severity: 'none' };
 }
 
 const logger = createLog('ToolUseFollowUp');
@@ -93,33 +100,43 @@ const PersistedContinuationGenerationSchema = z.looseObject({
   continuationGenerationId: z.uuid(),
 });
 
+/**
+ * The stream's execution id. Prefer the resident snapshot record for a live
+ * session: `run.start` updates it synchronously while the sidecar FK write is
+ * still queued. A stream whose run metadata is not resident (after a host
+ * restart, or evicted by a storage-root change) falls back to the persisted
+ * sidecar, then the summary mirror. Throws when the persisted read fails.
+ */
+async function lookupExecutionId(
+  streamId: StreamTabId,
+  session: SessionHandle,
+): Promise<ExecutionId | undefined> {
+  return (
+    session.snapshots.getRunMetadata(streamId, { quiet: true }).executionId ??
+    (await session.snapshots.readPersistedExecutionId(streamId)) ??
+    session.transcripts.getSummaryMeta(streamId)?.executionId
+  );
+}
+
 async function restorePersistedGeneration(
   streamId: StreamTabId,
   session: SessionHandle,
 ): Promise<boolean> {
-  // Prefer the resident snapshot record for a live session: `run.start`
-  // updates it synchronously while the sidecar FK write is still queued.
-  let executionId = session.snapshots.getRunMetadata(streamId, {
-    quiet: true,
-  }).executionId;
-  if (!executionId) {
-    try {
-      executionId =
-        (await session.snapshots.readPersistedExecutionId(streamId)) ??
-        session.transcripts.getSummaryMeta(streamId)?.executionId;
-    } catch (error) {
-      logger.warn(
-        `Cannot restore continuation generation for ${streamId}: persisted execution identity is unreadable.`,
-        {
-          data: {
-            streamId,
-            cause: 'execution_id_read_failed',
-            error,
-          },
+  let executionId: ExecutionId | undefined;
+  try {
+    executionId = await lookupExecutionId(streamId, session);
+  } catch (error) {
+    logger.warn(
+      `Cannot restore continuation generation for ${streamId}: persisted execution identity is unreadable.`,
+      {
+        data: {
+          streamId,
+          cause: 'execution_id_read_failed',
+          error,
         },
-      );
-      return false;
-    }
+      },
+    );
+    return false;
   }
   if (!executionId) {
     logger.warn(
@@ -281,9 +298,16 @@ async function classifyRefusal(
   streamId: StreamTabId,
   session: SessionHandle,
 ): Promise<FollowUpFailureReason> {
-  const executionId = session.snapshots.getRunMetadata(streamId, {
-    quiet: true,
-  }).executionId;
+  let executionId: ExecutionId | undefined;
+  try {
+    executionId = await lookupExecutionId(streamId, session);
+  } catch (error) {
+    logger.warn(
+      `Cannot classify the refusal for ${streamId}: persisted execution identity is unreadable.`,
+      { data: { streamId, error } },
+    );
+    return 'not_resumable';
+  }
   if (!executionId) return 'not_resumable';
   const classification = await classifyRun(executionId);
   switch (classification.kind) {
@@ -338,7 +362,7 @@ export async function submitFollowUp(
     const resumed = await dispatch.resume;
     if (resumed) return { status: 'queued' };
     ownerSession.followUps.release(dispatch.recovery, 'recoverable');
-    return { status: 'failed', reason: 'resume_failed' };
+    return { status: 'queued', wake: 'failed' };
   }
   if (dispatch.status === 'no_session') {
     notifyAdmitted(false);

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -45,8 +45,9 @@ export interface SubmitFollowUpOptions {
   readonly session?: SessionHandle;
   readonly resumePort?: Pick<AgentResumePort, 'tryResumeStream'>;
   /**
-   * Notifications never revive a persisted cursor. Child delivery may revive
-   * only a recoverable queue retained while that child was active.
+   * Notifications never revive a persisted cursor. A child delivery is an
+   * ordinary continuation: its parent counts the child as active until the
+   * delivery has landed, so it always finds a live or recoverable queue.
    */
   readonly mode?: 'continuation' | 'live_notification' | 'child_delivery';
   /** Reject a detached producer if its originating continuation was replaced. */
@@ -185,27 +186,28 @@ export function notifyFollowUpSent(
   });
 }
 
-/**
- * Submit visible input or an automatic notification through the stream's sole
- * continuation boundary. Routing, enqueue, live-owner detection, and persisted
- * recovery admission are serialized by the session-owned per-stream lock;
- * callers never perform a separate wake. A resumed model turn completes after
- * that lock is released, so it cannot block later input from joining its queue.
- */
 interface PendingResume {
   readonly resume: Promise<boolean>;
   readonly recovery: FollowUpRecoveryLease;
   readonly reason: ToolUseFollowUpQueueReason;
 }
 
-async function submitFollowUpSerialized(
+/**
+ * Route and admit one submission. Synchronous from the registry snapshot to
+ * the enqueue: two submissions to one stream cannot interleave between the
+ * target lookup and the admission, which is what keeps the recovery claim
+ * single-owner without a per-stream lock. Only the generation restore above
+ * reads disk, and it runs before the snapshot is taken. A resumed model turn
+ * completes after this returns, so it cannot block later input from joining
+ * its queue.
+ */
+function admitFollowUp(
   streamId: StreamTabId,
-  followUp: FollowUpQueueInput | string,
+  item: FollowUpQueueInput,
   options: SubmitFollowUpOptions,
   ownerSession: SessionHandle,
-): Promise<SubmitFollowUpResult | PendingResume> {
+): SubmitFollowUpResult | PendingResume {
   const target = ownerSession.executions.getToolUseFollowUpTarget(streamId);
-  const item = typeof followUp === 'string' ? { text: followUp } : followUp;
 
   if (target.kind === 'active') {
     // A child loop remains the owner during active inner turns, so input joins
@@ -243,30 +245,16 @@ async function submitFollowUpSerialized(
     return { status: 'sent' };
   }
 
-  if (target.kind === 'no_session' && options.mode !== 'child_delivery') {
+  if (target.kind === 'no_session') {
     logger.warn(
       `No active session for follow-up on stream ${streamId}. Status: ${target.streamStatus}`,
     );
     return { status: 'no_session', streamStatus: target.streamStatus };
   }
 
-  const reason = target.kind === 'queue' ? target.reason : 'children_running';
-  let admission: 'live_owner' | 'recoverable' | 'existing_recoverable' =
-    'recoverable';
-  if (options.mode === 'live_notification') {
-    admission = 'live_owner';
-  } else if (target.kind === 'no_session') {
-    admission = 'existing_recoverable';
-  }
-  if (
-    admission === 'recoverable' &&
-    options.expectedGenerationId !== undefined &&
-    ownerSession.followUps.currentGenerationId(streamId) !==
-      options.expectedGenerationId
-  ) {
-    const restored = await restorePersistedGeneration(streamId, ownerSession);
-    if (!restored) return { status: 'dropped' };
-  }
+  const reason = target.reason;
+  const admission =
+    options.mode === 'live_notification' ? 'live_owner' : 'recoverable';
   const submission = ownerSession.followUps.submit(
     streamId,
     item,
@@ -301,10 +289,7 @@ export async function submitFollowUp(
   options: SubmitFollowUpOptions = {},
 ): Promise<SubmitFollowUpResult> {
   const ownerSession = options.session ?? currentSession();
-  const dispatch = await ownerSession.followUps.runSubmissionExclusive(
-    streamId,
-    () => submitFollowUpSerialized(streamId, followUp, options, ownerSession),
-  );
+  const item = typeof followUp === 'string' ? { text: followUp } : followUp;
   // A host callback must not be able to strand the recovery lease below:
   // its failure is the host's to log, never this boundary's to propagate.
   const notifyAdmitted = (admitted: boolean): void => {
@@ -316,6 +301,23 @@ export async function submitFollowUp(
       });
     }
   };
+  // A detached producer bound to a generation the session no longer holds in
+  // memory (a persisted inquiry answered after a host restart) is checked
+  // against the flow record on disk before a recovery admission; the check
+  // is idempotent, so concurrent submissions restoring one record agree.
+  if (
+    options.expectedGenerationId !== undefined &&
+    options.mode !== 'live_notification' &&
+    ownerSession.followUps.currentGenerationId(streamId) !==
+      options.expectedGenerationId &&
+    ownerSession.executions.getToolUseFollowUpTarget(streamId).kind ===
+      'queue' &&
+    !(await restorePersistedGeneration(streamId, ownerSession))
+  ) {
+    notifyAdmitted(false);
+    return { status: 'dropped' };
+  }
+  const dispatch = admitFollowUp(streamId, item, options, ownerSession);
   if (!('resume' in dispatch)) {
     notifyAdmitted(
       dispatch.status !== 'no_session' && dispatch.status !== 'dropped',

--- a/src/agent/followUp/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/followUp/ToolUseFollowUpQueueManager.ts
@@ -68,15 +68,19 @@ export type FollowUpSubmission =
  * Session-owned continuation boundary indexed by stream ID.
  *
  * Lifecycle is explicit: an owned entry is `live` or `recovering`, an unowned
- * persisted cursor is `recoverable`, and a terminal entry is simply gone. A
- * parent counts every child as active until the child's final delivery has
- * landed, and a stream with no live flow, no children and a terminal phase
- * refuses submission before it reaches this boundary, so nothing needs to
- * remember which streams went terminal.
+ * persisted cursor is `recoverable`, and a terminal entry is gone. A stream
+ * whose queue was ended by {@link terminalize} (its stream deleted, or its
+ * parked run torn down) is marked so that a producer that is not an owner,
+ * such as a child whose activation outlives its parent's teardown, cannot
+ * recreate the queue and trigger a resume of a run that is gone; only an
+ * explicit claim reopens the stream. Stream ids embed their execution id, so
+ * the mark never collides with a later run, and a session accrues one per
+ * ended stream.
  */
 export class ToolUseFollowUpQueue {
   static readonly DELIVERY_ID_CAP = 1000;
   private readonly entries = new Map<StreamTabId, QueueEntry>();
+  private readonly terminalized = new Set<StreamTabId>();
   private readonly releaseObservers = new Set<
     (streamId: StreamTabId) => void
   >();
@@ -97,6 +101,7 @@ export class ToolUseFollowUpQueue {
     generationId?: string,
   ): FollowUpConsumerLease | undefined {
     if (this.disposed) return undefined;
+    this.terminalized.delete(streamId);
     const entry =
       this.entries.get(streamId) ?? this.createEntry(streamId, generationId);
     if (generationId !== undefined && entry.generationId !== generationId) {
@@ -126,6 +131,7 @@ export class ToolUseFollowUpQueue {
       entry.generationProvisional = false;
       return 'restored';
     }
+    if (this.terminalized.has(streamId)) return 'unavailable';
     this.createEntry(streamId, generationId);
     return 'restored';
   }
@@ -144,6 +150,7 @@ export class ToolUseFollowUpQueue {
         `Child stream ${streamId} does not belong to execution ${executionId}.`,
       );
     }
+    this.terminalized.delete(streamId);
     const retained = this.entries.get(streamId);
     if (retained) return this.claim(retained, streamId, 'child');
     return this.claim(this.createEntry(streamId), streamId, 'child');
@@ -155,6 +162,7 @@ export class ToolUseFollowUpQueue {
     createIfMissing = false,
   ): FollowUpRecoveryLease | undefined {
     if (this.disposed) return undefined;
+    if (createIfMissing) this.terminalized.delete(streamId);
     const entry =
       this.entries.get(streamId) ??
       (createIfMissing
@@ -200,6 +208,9 @@ export class ToolUseFollowUpQueue {
     if (admission === 'live_owner') {
       if (!entry) return { kind: 'not_owned' };
     } else {
+      if (!entry && this.terminalized.has(streamId)) {
+        return { kind: 'unavailable' };
+      }
       entry ??= this.createEntry(streamId, undefined, true);
       if (!entry.owner) entry.lifecycle = 'recoverable';
     }
@@ -291,12 +302,16 @@ export class ToolUseFollowUpQueue {
     return true;
   }
 
-  /** Terminalize a stream; any outstanding lease becomes stale immediately. */
+  /**
+   * End a stream's queue: any outstanding lease becomes stale immediately, and
+   * no producer can recreate the queue until an explicit claim reopens it.
+   */
   terminalize(streamId: StreamTabId): boolean {
     if (this.disposed) return false;
     const entry = this.entries.get(streamId);
     entry?.queue.dispose();
     this.entries.delete(streamId);
+    this.terminalized.add(streamId);
     this.notifyReleaseObservers(streamId);
     return true;
   }
@@ -322,6 +337,7 @@ export class ToolUseFollowUpQueue {
       }
     } finally {
       this.entries.clear();
+      this.terminalized.clear();
       this.releaseObservers.clear();
     }
     throwAggregated(failures, 'Multiple follow-up queues failed to dispose');

--- a/src/agent/followUp/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/followUp/ToolUseFollowUpQueueManager.ts
@@ -1,11 +1,9 @@
 import { randomUUID } from 'node:crypto';
 
-import { LRUCache } from 'lru-cache';
 import { createLog } from '@logger/logUtils';
 import type { RecoveryContinuation } from '@platform/interfaces';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { throwAggregated } from '@utils/core';
-import { KeyedMutex } from '@utils/core/keyedMutex';
 import {
   createBoundedIdSet,
   type BoundedIdSet,
@@ -32,7 +30,6 @@ interface QueueEntry {
    */
   readonly admittedDeliveryIds: BoundedIdSet<string>;
   lifecycle: QueueLifecycle;
-  generation: number;
   owner?: FollowUpConsumerLease;
 }
 
@@ -40,14 +37,13 @@ interface QueueEntry {
  * Exclusive authority to consume one stream's follow-up queue.
  *
  * The manager issues at most one lease per entry. Claims and releases are
- * synchronous, and every lease carries the entry generation it claimed. A
- * release from an older flow/child therefore cannot clear or terminalize a
- * successor recovery generation. Only the lease may wait, drain, or dispose;
- * producers submit through the manager and cannot manufacture a consumer.
+ * synchronous, and a lease is valid only while it is the entry's owner, so a
+ * release from an older flow/child cannot clear or terminalize a successor.
+ * Only the lease may wait, drain, or dispose; producers submit through the
+ * manager and cannot manufacture a consumer.
  */
 export interface FollowUpConsumerLease {
   readonly streamId: StreamTabId;
-  readonly generation: number;
   /** Opaque identity of this session-owned queue generation. */
   readonly generationId: string;
   readonly kind: FollowUpConsumerKind;
@@ -72,18 +68,15 @@ export type FollowUpSubmission =
  * Session-owned continuation boundary indexed by stream ID.
  *
  * Lifecycle is explicit: an owned entry is `live` or `recovering`, an unowned
- * persisted cursor is `recoverable`, and terminal stream ids are retained in a
- * bounded tombstone cache. Delivery and ordinary live claims cannot reopen a
- * terminal entry; a newly authorized child run may begin a new generation.
+ * persisted cursor is `recoverable`, and a terminal entry is simply gone. A
+ * parent counts every child as active until the child's final delivery has
+ * landed, and a stream with no live flow, no children and a terminal phase
+ * refuses submission before it reaches this boundary, so nothing needs to
+ * remember which streams went terminal.
  */
 export class ToolUseFollowUpQueue {
-  static readonly TERMINAL_CAP = 500;
   static readonly DELIVERY_ID_CAP = 1000;
   private readonly entries = new Map<StreamTabId, QueueEntry>();
-  private readonly submissionMutex = new KeyedMutex<StreamTabId>();
-  private readonly terminal = new LRUCache<StreamTabId, true>({
-    max: ToolUseFollowUpQueue.TERMINAL_CAP,
-  });
   private readonly releaseObservers = new Set<
     (streamId: StreamTabId) => void
   >();
@@ -97,14 +90,6 @@ export class ToolUseFollowUpQueue {
     };
   }
 
-  /** Serialize routing and admission for one stream within this session. */
-  runSubmissionExclusive<Result>(
-    streamId: StreamTabId,
-    operation: () => Promise<Result>,
-  ): Promise<Result> {
-    return this.submissionMutex.runExclusive(streamId, operation);
-  }
-
   /** Claim a live flow/child consumer. A competing owner is rejected. */
   claimLive(
     streamId: StreamTabId,
@@ -112,7 +97,6 @@ export class ToolUseFollowUpQueue {
     generationId?: string,
   ): FollowUpConsumerLease | undefined {
     if (this.disposed) return undefined;
-    if (this.terminal.has(streamId)) return undefined;
     const entry =
       this.entries.get(streamId) ?? this.createEntry(streamId, generationId);
     if (generationId !== undefined && entry.generationId !== generationId) {
@@ -123,15 +107,14 @@ export class ToolUseFollowUpQueue {
 
   /**
    * Restore a generation read from the stream's authoritative flow record.
-   * Distinguishes session dispose from terminal/mismatch rejection so callers
-   * can label diagnostics accurately.
+   * Distinguishes session dispose from mismatch rejection so callers can
+   * label diagnostics accurately.
    */
   restorePersistedGeneration(
     streamId: StreamTabId,
     generationId: string,
   ): 'restored' | 'disposed' | 'unavailable' {
     if (this.disposed) return 'disposed';
-    if (this.terminal.has(streamId)) return 'unavailable';
     const entry = this.entries.get(streamId);
     if (entry) {
       if (entry.generationId === generationId) {
@@ -148,10 +131,8 @@ export class ToolUseFollowUpQueue {
   }
 
   /**
-   * Begin a separately authorized child run, replacing a terminal generation
-   * when the deterministic child stream ID is reused. The caller must already
-   * own the execution lease; producers and ordinary live flows cannot cross
-   * this boundary, so late delivery remains rejected.
+   * Begin a separately authorized child run. The caller must already own the
+   * execution lease.
    */
   claimChildRun(
     streamId: StreamTabId,
@@ -165,8 +146,6 @@ export class ToolUseFollowUpQueue {
     }
     const retained = this.entries.get(streamId);
     if (retained) return this.claim(retained, streamId, 'child');
-
-    this.terminal.delete(streamId);
     return this.claim(this.createEntry(streamId), streamId, 'child');
   }
 
@@ -176,7 +155,6 @@ export class ToolUseFollowUpQueue {
     createIfMissing = false,
   ): FollowUpRecoveryLease | undefined {
     if (this.disposed) return undefined;
-    if (this.terminal.has(streamId)) return undefined;
     const entry =
       this.entries.get(streamId) ??
       (createIfMissing
@@ -202,18 +180,15 @@ export class ToolUseFollowUpQueue {
    * flow or child consumer, or enqueues without claiming when the entry has no
    * live owner (so live notifications can reach a WAITING parent queue).
    * `recoverable` admits a registry-approved persisted cursor and creates its
-   * queue when needed. `existing_recoverable` admits only an already-retained
-   * recoverable queue, which lets a final child result survive child untracking
-   * without reopening an otherwise terminal parent.
+   * queue when needed.
    */
   submit(
     streamId: StreamTabId,
     followUp: FollowUpQueueInput,
-    admission: 'live_owner' | 'recoverable' | 'existing_recoverable',
+    admission: 'live_owner' | 'recoverable',
     expectedGenerationId?: string,
   ): FollowUpSubmission {
     if (this.disposed) return { kind: 'unavailable' };
-    if (this.terminal.has(streamId)) return { kind: 'unavailable' };
 
     let entry = this.entries.get(streamId);
     if (
@@ -225,9 +200,6 @@ export class ToolUseFollowUpQueue {
     if (admission === 'live_owner') {
       if (!entry) return { kind: 'not_owned' };
     } else {
-      if (!entry && admission === 'existing_recoverable') {
-        return { kind: 'unavailable' };
-      }
       entry ??= this.createEntry(streamId, undefined, true);
       if (!entry.owner) entry.lifecycle = 'recoverable';
     }
@@ -314,7 +286,6 @@ export class ToolUseFollowUpQueue {
     }
     entry.queue.dispose();
     this.entries.delete(lease.streamId);
-    this.terminal.set(lease.streamId, true);
     logger.debug(`Terminalized follow-up queue for stream ${lease.streamId}.`);
     this.notifyReleaseObservers(lease.streamId);
     return true;
@@ -326,18 +297,16 @@ export class ToolUseFollowUpQueue {
     const entry = this.entries.get(streamId);
     entry?.queue.dispose();
     this.entries.delete(streamId);
-    this.terminal.set(streamId, true);
     this.notifyReleaseObservers(streamId);
     return true;
   }
 
   /**
    * Dispose the session-owned boundary: every live entry queue, then the
-   * entry map, terminal tombstones, and release observers. The state clears
-   * in a `finally` so one queue's disposal failure cannot leave the map,
-   * tombstones, or observers behind. Entry-creating paths refuse to rebuild
-   * afterwards, so a late detached producer cannot leak a queue nobody will
-   * drain.
+   * entry map and release observers. The state clears in a `finally` so one
+   * queue's disposal failure cannot leave the map or observers behind.
+   * Entry-creating paths refuse to rebuild afterwards, so a late detached
+   * producer cannot leak a queue nobody will drain.
    */
   dispose(): void {
     if (this.disposed) return;
@@ -353,7 +322,6 @@ export class ToolUseFollowUpQueue {
       }
     } finally {
       this.entries.clear();
-      this.terminal.clear();
       this.releaseObservers.clear();
     }
     throwAggregated(failures, 'Multiple follow-up queues failed to dispose');
@@ -400,7 +368,6 @@ export class ToolUseFollowUpQueue {
         ToolUseFollowUpQueue.DELIVERY_ID_CAP,
       ),
       lifecycle: 'recoverable',
-      generation: 0,
     };
     this.entries.set(streamId, entry);
     return entry;
@@ -412,10 +379,8 @@ export class ToolUseFollowUpQueue {
     kind: FollowUpConsumerKind,
   ): FollowUpConsumerLease | undefined {
     if (entry.owner) return undefined;
-    entry.generation += 1;
     const lease: FollowUpConsumerLease = {
       streamId,
-      generation: entry.generation,
       get generationId() {
         return entry.generationId;
       },
@@ -439,10 +404,6 @@ export class ToolUseFollowUpQueue {
   /** The entry `lease` still owns, or `undefined` if it has gone stale. */
   private entryForLease(lease: FollowUpConsumerLease): QueueEntry | undefined {
     const entry = this.entries.get(lease.streamId);
-    return entry &&
-      entry.owner === lease &&
-      entry.generation === lease.generation
-      ? entry
-      : undefined;
+    return entry?.owner === lease ? entry : undefined;
   }
 }

--- a/src/agent/followUp/childRunDelivery.ts
+++ b/src/agent/followUp/childRunDelivery.ts
@@ -2,13 +2,11 @@
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas';
 
-import { submitFollowUp } from './ToolUseFollowUp';
+import { submitFollowUp, type FollowUpFailureReason } from './ToolUseFollowUp';
 import type { FollowUpQueueInput } from './FollowUpQueue';
 
 export type ChildRunDeliveryResult =
-  | { kind: 'delivered' }
-  | { kind: 'no_session'; streamStatus: string | undefined }
-  | { kind: 'dropped' };
+  { kind: 'delivered' } | { kind: 'failed'; reason: FollowUpFailureReason };
 
 export async function deliverChildRunFollowUp(params: {
   readonly targetStreamId: StreamTabId;
@@ -23,10 +21,7 @@ export async function deliverChildRunFollowUp(params: {
     mode: params.mode ?? 'child_delivery',
     expectedGenerationId: params.expectedGenerationId,
   });
-  if (result.status === 'no_session') {
-    return { kind: 'no_session', streamStatus: result.streamStatus };
-  }
-  return result.status === 'dropped'
-    ? { kind: 'dropped' }
+  return result.status === 'failed'
+    ? { kind: 'failed', reason: result.reason }
     : { kind: 'delivered' };
 }

--- a/src/agent/followUp/childRunDelivery.ts
+++ b/src/agent/followUp/childRunDelivery.ts
@@ -5,8 +5,10 @@ import type { StreamTabId } from '@shared/schemas';
 import { submitFollowUp, type FollowUpFailureReason } from './ToolUseFollowUp';
 import type { FollowUpQueueInput } from './FollowUpQueue';
 
+/** `wake: 'failed'`: the result is in the parent's queue; only its wake failed. */
 export type ChildRunDeliveryResult =
-  { kind: 'delivered' } | { kind: 'failed'; reason: FollowUpFailureReason };
+  | { kind: 'delivered'; wake?: 'failed' }
+  | { kind: 'failed'; reason: FollowUpFailureReason };
 
 export async function deliverChildRunFollowUp(params: {
   readonly targetStreamId: StreamTabId;
@@ -21,7 +23,10 @@ export async function deliverChildRunFollowUp(params: {
     mode: params.mode ?? 'child_delivery',
     expectedGenerationId: params.expectedGenerationId,
   });
-  return result.status === 'failed'
-    ? { kind: 'failed', reason: result.reason }
+  if (result.status === 'failed') {
+    return { kind: 'failed', reason: result.reason };
+  }
+  return result.status === 'queued' && result.wake === 'failed'
+    ? { kind: 'delivered', wake: 'failed' }
     : { kind: 'delivered' };
 }

--- a/src/agent/followUp/index.ts
+++ b/src/agent/followUp/index.ts
@@ -3,8 +3,8 @@
  *
  * One curated barrel the hosts (CLI, desktop, extension) import instead of
  * deep-reaching each follow-up module by path: submitting a follow-up to a
- * live or resumable stream (`submitFollowUp`), presenting the admission
- * outcome (`presentFollowUpResult`), and notifying that a queued follow-up
+ * live or resumable stream (`submitFollowUp`), wording a refusal
+ * (`describeFollowUpFailure`, `presentFollowUpResult`), and notifying that a queued follow-up
  * was sent (`notifyFollowUpSent`), plus the queue-input and recovery-lease
  * types hosts name at their session seams — decoupling host code from the
  * follow-up internals' file layout, per the module-level barrel pattern set
@@ -19,6 +19,7 @@
  */
 
 export {
+  describeFollowUpFailure,
   notifyFollowUpSent,
   presentFollowUpResult,
   submitFollowUp,

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -6,10 +6,6 @@ import {
   type StageHandle,
 } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
-import {
-  onOwnedExecutionLeaseLost,
-  captureOwnedExecutionLeaseIfPresent,
-} from '@agent/storage/executionLease';
 import { persistTerminalExecution } from '@agent/storage/terminalPersistence';
 import {
   AGENT_ERROR_OUTCOME,
@@ -425,14 +421,12 @@ async function closeSuspendedTranscriptGroup(
   handle: AgentExecutionHandle,
   parentStageId: string | undefined,
 ): Promise<void> {
-  if (handle.executionLeaseLost) return;
   if (!parentStageId) return;
   const writer = await session.transcripts.loadAndAcquireWriter(
     streamId,
     handle.executionId,
   );
   try {
-    if (handle.executionLeaseLost) return;
     writer.update(parentStageId, {
       type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
       data: {
@@ -478,10 +472,6 @@ export async function runFlowWithLifecycle(
     parentStreamId,
     ctx.logger,
   );
-  const executionLeaseScope = captureOwnedExecutionLeaseIfPresent(executionId);
-  if (executionLeaseScope) {
-    handle.attachExecutionLeaseScope(executionLeaseScope);
-  }
   // Roster display fields must be on the handle BEFORE it is tracked:
   // `track()` emits `child.activity` synchronously, so anything assigned
   // later (e.g. from `onRun`) misses the parent's first roster snapshot.
@@ -497,16 +487,9 @@ export async function runFlowWithLifecycle(
   };
   const detachRunInterrupt = handle.attachInterruptHandler(runInterruptHandler);
   session.executions.track(handle);
-  let leaseLost = false;
-  let keepLeaseWatcher = false;
-  const stopWatchingLease = onOwnedExecutionLeaseLost(executionId, () => {
-    leaseLost = true;
-    handle.markExecutionLeaseLost();
-    logger.error('Execution lease was lost; interrupting the former owner', {
-      data: { executionId, streamId },
-    });
-    handle.interrupt();
-  });
+  // A lease record removed out from under this run is not watched: the next
+  // fenced write throws `ExecutionLeaseLostError` and the run aborts dirty.
+  let suspended = false;
   let flowRecordDisposition: FlowRecordDisposition | undefined;
   const lifecycleControl: FlowLifecycleControl = {
     setFlowRecordDisposition(disposition): void {
@@ -544,19 +527,17 @@ export async function runFlowWithLifecycle(
       stage: ctx.parentStage,
       trace: ctx.logger,
       flushArtifacts: () => session.flushArtifacts(handle.executionId),
-      persistence: leaseLost
-        ? { kind: 'skip' }
-        : {
-            kind: 'finalize',
-            // Tool-use flows report the exact recovery decision through the
-            // private lifecycle control. Other flows retain the historical
-            // policy, read against the outcome finalization resolves rather
-            // than this arm's report.
-            flowRecord:
-              flowRecordDisposition ??
-              ((resolved) =>
-                resolved === RUN_OUTCOME.COMPLETED ? 'delete' : 'preserve'),
-          },
+      persistence: {
+        kind: 'finalize',
+        // Tool-use flows report the exact recovery decision through the
+        // private lifecycle control. Other flows retain the historical
+        // policy, read against the outcome finalization resolves rather
+        // than this arm's report.
+        flowRecord:
+          flowRecordDisposition ??
+          ((resolved) =>
+            resolved === RUN_OUTCOME.COMPLETED ? 'delete' : 'preserve'),
+      },
       ...arm,
     });
   /**
@@ -715,7 +696,7 @@ export async function runFlowWithLifecycle(
       detachRunInterrupt();
     }
     if (isWaitingFlowResult(result)) {
-      keepLeaseWatcher = true;
+      suspended = true;
       logger.debug(`Task suspended with outcome: ${result.outcome}`);
       // The handle stays tracked (correct for resume) but the live tool-use
       // session and its interrupt handler are already gone by the time
@@ -786,7 +767,6 @@ export async function runFlowWithLifecycle(
     return await finalizeFailedRun(err, undefined);
   } finally {
     detachRunInterrupt();
-    if (!keepLeaseWatcher) stopWatchingLease();
     // Settle every host interaction this run left pending. The lifecycle owns
     // it for both flows: a run that ends with an approval still on screen must
     // release the host whether it completed, failed, was stopped, or parked at
@@ -810,7 +790,7 @@ export async function runFlowWithLifecycle(
     // result this run already published. A WAITING suspension is not a run
     // end, so its return skips this and leaves the stop to the suspended-handle
     // teardown if a later kill actually ends the run.
-    if (!keepLeaseWatcher) {
+    if (!suspended) {
       await runOnRunEnd();
     }
     // Release long-lived resources (e.g., WebSocket connections, keepalive

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -9,7 +9,6 @@
 import pDefer from 'p-defer';
 
 import type { AgentTrace, ResultEvent } from '@agent/trace';
-import type { OwnedExecutionLeaseScope } from '@agent/storage/executionLease';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { ToolUseFlowContext } from '@agent/implementations/flows/tooluse/runToolUseFlow';
 import type {
@@ -122,8 +121,6 @@ export class AgentExecutionHandle {
   private toolUseFlowContext?: LiveToolUseFlowContext;
   private detachToolUseAbortListener?: () => void;
   private suspension?: RunSuspension;
-  private _executionLeaseLost = false;
-  private executionLeaseScope?: OwnedExecutionLeaseScope;
 
   /**
    * Workflow-script phase owning this run, when it is an `agent()` grandchild
@@ -282,28 +279,6 @@ export class AgentExecutionHandle {
       return true;
     }
     return false;
-  }
-
-  markExecutionLeaseLost(): void {
-    this._executionLeaseLost = true;
-  }
-
-  get executionLeaseLost(): boolean {
-    return this._executionLeaseLost;
-  }
-
-  /** Bind deferred handle-owned work to the lease generation that created it. */
-  attachExecutionLeaseScope(scope: OwnedExecutionLeaseScope): void {
-    this.executionLeaseScope = scope;
-  }
-
-  /** Re-enter the creating lease generation from an external lifecycle call. */
-  runWithExecutionLease<T>(operation: () => T | Promise<T>): T | Promise<T> {
-    // Some in-memory/embedder runs deliberately have no durable lease. Their
-    // storage writes still pass through the execution-store write fence.
-    return this.executionLeaseScope
-      ? this.executionLeaseScope(operation)
-      : operation();
   }
 
   /**

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -37,11 +37,9 @@ import type { AgentEvent, AgentTrace, ResultEvent } from '@agent/trace';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import {
   abandonOwnedExecutionLease,
-  captureOwnedExecutionLeaseIfPresent,
   completeOwnedExecutionLease,
   isOwnedExecutionLeaseDurable,
-  type OwnedExecutionLeaseScope,
-  runWithOwnedExecutionLeaseQuiescence,
+  ownsExecutionLease,
   validateOwnedExecutionLease,
 } from '@agent/storage/executionLease';
 import { finalizeExecution } from '@agent/storage/executionLifecycle';
@@ -131,6 +129,19 @@ export interface WorkspaceStorageTransitionHooks {
   afterStorageCommit(): Promise<void>;
   afterStorageRollback(): void;
   afterStorageFinalize(): void;
+}
+
+/**
+ * A storage-root change was refused because executions are live in this
+ * session. Nothing was changed; the caller retries once they have finished.
+ */
+export class StorageRootChangeRefusedError extends Error {
+  constructor(readonly liveExecutionIds: readonly string[]) {
+    super(
+      `TeXRA cannot change its storage location while ${liveExecutionIds.length} ${liveExecutionIds.length === 1 ? 'run is' : 'runs are'} live in this window. Stop or finish them, then retry the workspace change.`,
+    );
+    this.name = 'StorageRootChangeRefusedError';
+  }
 }
 
 export class SessionHandle {
@@ -363,13 +374,20 @@ export class SessionHandle {
     try {
       if (this.restartRepairAbort.signal.aborted) return false;
       if (reloadTranscripts) {
-        return await runWithOwnedExecutionLeaseQuiescence(async () => {
-          if (this.restartRepairAbort.signal.aborted) return false;
-          return this.replaceStoresAfterStorageRootChange(
+        // A storage-root change is refused, not queued, while any execution
+        // is live: a run writes under the root it was claimed in, so the two
+        // may not overlap. The hold also refuses launches for the duration.
+        const releaseHold = this.executions.holdLifecycle(
+          (live) => new StorageRootChangeRefusedError(live),
+        );
+        try {
+          return await this.replaceStoresAfterStorageRootChange(
             generation,
             transitionHooks,
           );
-        });
+        } finally {
+          releaseHold();
+        }
       }
       if (generation !== this.storageGeneration) return false;
       await this.snapshots.preload([...this.computeStartupSeedSet()]);
@@ -941,43 +959,30 @@ export async function settleLiveSessionExecutions(
       );
       continue;
     }
-    let runWithOwnership: OwnedExecutionLeaseScope | undefined;
+    // Skips both a run whose driver already settled it and one this process
+    // never owned (an adopted or foreign execution).
+    if (!ownsExecutionLease(executionId)) continue;
     try {
-      // Skips both a run whose driver already settled it and one this
-      // process never owned (an adopted or foreign execution).
-      runWithOwnership = captureOwnedExecutionLeaseIfPresent(executionId);
-    } catch (error) {
-      // Ownership moved between the registry read and this turn — a release
-      // in flight, or a later generation of the same id. Nothing to settle.
-      logger.debug(
-        `Execution ${executionId} is no longer settleable at host exit: ${String(error)}`,
-      );
-      continue;
-    }
-    if (!runWithOwnership) continue;
-    try {
-      await runWithOwnership(() =>
-        session.releaseExecutionLease(executionId, async () => {
-          const finalization = await finalizeExecution({
-            executionId,
-            outcome: RUN_OUTCOME.CANCELLED,
-            flowRecord: 'preserve',
-            // A driver that reached its own terminal write between the
-            // registry read above and this one owns the result: this drain
-            // records what the exit interrupted, never what already finished.
-            keepExistingOutcome: true,
-          });
-          if (finalization.status === 'failed') {
-            // Rejecting here is what keeps the lease record: an execution
-            // whose terminal outcome never reached disk must not look
-            // settled to the next launch.
-            throw new Error(
-              `Failed to persist the CANCELLED outcome for execution ${executionId}`,
-              { cause: finalization.error },
-            );
-          }
-        }),
-      );
+      await session.releaseExecutionLease(executionId, async () => {
+        const finalization = await finalizeExecution({
+          executionId,
+          outcome: RUN_OUTCOME.CANCELLED,
+          flowRecord: 'preserve',
+          // A driver that reached its own terminal write between the
+          // registry read above and this one owns the result: this drain
+          // records what the exit interrupted, never what already finished.
+          keepExistingOutcome: true,
+        });
+        if (finalization.status === 'failed') {
+          // Rejecting here is what keeps the lease record: an execution
+          // whose terminal outcome never reached disk must not look
+          // settled to the next launch.
+          throw new Error(
+            `Failed to persist the CANCELLED outcome for execution ${executionId}`,
+            { cause: finalization.error },
+          );
+        }
+      });
     } catch (error) {
       logger.warn(
         `Failed to settle execution ${executionId} at host exit; its record is repaired on a later launch`,

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -328,10 +328,28 @@ export class SessionHandle {
         hooks && { workspacePath: hooks.workspacePath },
       );
     if (hasPendingStorageChange === false) return Promise.resolve(false);
+    // A storage-root change is refused, not queued, while any execution is
+    // live: a run writes under the root it was claimed in, so the two may not
+    // overlap. The hold is taken before any session state moves, so a refusal
+    // changes nothing; while it is held, launches and resumes are refused.
+    let releaseHold: () => void;
+    try {
+      releaseHold = this.executions.holdLifecycle(
+        (live) => new StorageRootChangeRefusedError(live),
+        () =>
+          new Error(
+            'TeXRA is changing its storage location. Start this run again in a moment.',
+          ),
+      );
+    } catch (error) {
+      return Promise.reject(error);
+    }
     this.storageGeneration += 1;
     const generation = this.storageGeneration;
     const repair = this.enqueueRestartRepair(() =>
-      this.repairStoresAfterRestart(generation, true, hooks),
+      this.repairStoresAfterRestart(generation, true, hooks).finally(
+        releaseHold,
+      ),
     );
     this.restartRepairPromise = repair;
     return repair;
@@ -375,20 +393,10 @@ export class SessionHandle {
     try {
       if (this.restartRepairAbort.signal.aborted) return false;
       if (reloadTranscripts) {
-        // A storage-root change is refused, not queued, while any execution
-        // is live: a run writes under the root it was claimed in, so the two
-        // may not overlap. The hold also refuses launches for the duration.
-        const releaseHold = this.executions.holdLifecycle(
-          (live) => new StorageRootChangeRefusedError(live),
+        return await this.replaceStoresAfterStorageRootChange(
+          generation,
+          transitionHooks,
         );
-        try {
-          return await this.replaceStoresAfterStorageRootChange(
-            generation,
-            transitionHooks,
-          );
-        } finally {
-          releaseHold();
-        }
       }
       if (generation !== this.storageGeneration) return false;
       await this.snapshots.preload([...this.computeStartupSeedSet()]);

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -332,10 +332,6 @@ export class StreamStatusMachine {
     return values;
   }
 
-  isActiveOrResuming(stream: StreamTabId): boolean {
-    return isActivePhase(this.get(stream));
-  }
-
   isInFlight(stream: StreamTabId): boolean {
     return isInFlightPhase(this.get(stream));
   }

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -20,6 +20,7 @@ import type {
 } from '@agent/storage/ExecutionKVStore';
 import {
   assertOwnedExecutionLease,
+  ExecutionLeaseLostError,
   markOwnedExecutionLeaseUndurable,
 } from '@agent/storage/executionLease';
 import {
@@ -744,6 +745,11 @@ async function submitPendingDelivery(
         },
       },
     );
+  } else if (delivery.wake === 'failed') {
+    logger.warn(
+      'Turn result queued for the parent, but the parent could not be resumed; an explicit Resume delivers it.',
+      { data: { executionId, parentStreamId: pending.targetStreamId } },
+    );
   }
 }
 
@@ -817,6 +823,33 @@ export function startChildRunLoop<TTurn>(
     detachLoopInterrupt = handle.attachInterruptHandler(loop);
   };
   let sessionStage: StageHandle | undefined;
+  // Preserve the setup error while unwinding every resource acquired so far.
+  // Used when setup throws and when the lane refuses the run before it
+  // starts; in both cases `run` never executes, so nothing else unwinds.
+  const unwindSetup = (error: unknown): unknown => {
+    const cleanupErrors: unknown[] = [];
+    const cleanup = (operation: () => void): void => {
+      try {
+        operation();
+      } catch (cleanupError) {
+        cleanupErrors.push(cleanupError);
+      }
+    };
+    cleanup(() => sessionStage?.end(RUN_OUTCOME.FAILED));
+    cleanup(() => detachLoopInterrupt?.());
+    cleanup(() => {
+      if (queueLease) runSession.followUps.release(queueLease, 'terminal');
+    });
+    cleanup(releaseChildActivation);
+    cleanup(releaseSessionOwnershipOnce);
+    // The primary error always heads the list, so a single throw covers both
+    // shapes: `error` unwrapped when rollback was clean, an AggregateError when
+    // cleanup also failed.
+    return aggregateError(
+      [error, ...cleanupErrors],
+      `Child run ${executionId} setup failed and rollback was incomplete`,
+    );
+  };
 
   try {
     strategy.onLoopStart?.(runSession);
@@ -836,29 +869,7 @@ export function startChildRunLoop<TTurn>(
       ? logger.openStage(strategy.stageLabel)
       : undefined;
   } catch (error) {
-    // Preserve the setup error while unwinding every resource acquired so far.
-    const cleanupErrors: unknown[] = [];
-    const cleanup = (operation: () => void): void => {
-      try {
-        operation();
-      } catch (cleanupError) {
-        cleanupErrors.push(cleanupError);
-      }
-    };
-    cleanup(() => sessionStage?.end(RUN_OUTCOME.FAILED));
-    cleanup(() => detachLoopInterrupt?.());
-    cleanup(() => {
-      if (queueLease) runSession.followUps.release(queueLease, 'terminal');
-    });
-    cleanup(releaseChildActivation);
-    cleanup(releaseSessionOwnershipOnce);
-    // The primary error always heads the list, so a single throw covers both
-    // shapes: `error` unwrapped when rollback was clean, an AggregateError when
-    // cleanup also failed.
-    throw aggregateError(
-      [error, ...cleanupErrors],
-      `Child run ${executionId} setup failed and rollback was incomplete`,
-    );
+    throw unwindSetup(error);
   }
 
   const childRunGenerationId = queueLease.generationId;
@@ -927,7 +938,9 @@ export function startChildRunLoop<TTurn>(
             { signal: ac.signal },
           ) as Promise<TTurn>;
 
+  let runStarted = false;
   const run = async (): Promise<void> => {
+    runStarted = true;
     // A release failure after a clean run must reach awaited callers: the
     // child's artifacts did not drain and its lease was abandoned, so a
     // required-result parent must not journal the turn as durably settled.
@@ -1076,6 +1089,10 @@ export function startChildRunLoop<TTurn>(
       // released.
       sawTurnFailure = true;
       lastTurnErr ??= error;
+      // A fenced write found the lease gone: another owner holds this
+      // execution now, so the loop stops here instead of delivering or
+      // accepting anything further on the former owner's behalf.
+      if (error instanceof ExecutionLeaseLostError) loop.interrupt();
       markOwnedExecutionLeaseUndurable(executionId);
       throw error;
     } finally {
@@ -1211,7 +1228,18 @@ export function startChildRunLoop<TTurn>(
   // The loop is this execution's generation: it starts on the execution's
   // lane once any earlier generation of the id has disposed, and later steps
   // (a resume, a delete) wait for its completion.
+  let completion: Promise<void>;
+  try {
+    completion = runSession.executions.launchExecution(executionId, run);
+  } catch (error) {
+    throw unwindSetup(error);
+  }
   return {
-    completion: runSession.executions.launchExecution(executionId, run),
+    completion: completion.catch((error: unknown) => {
+      // Refused before `run` began (the registry disposed, or a storage-root
+      // change holds the lifecycle): `run`'s own unwinding never ran.
+      if (runStarted) throw error;
+      throw unwindSetup(error);
+    }),
   };
 }

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -733,16 +733,14 @@ async function submitPendingDelivery(
       ? { expectedGenerationId: pending.expectedGenerationId }
       : {}),
   });
-  if (delivery.kind !== 'delivered') {
+  if (delivery.kind === 'failed') {
     logger.warn(
-      'Turn result not delivered: parent stream is unavailable. The result remains in the execution report.',
+      `Turn result not delivered: parent stream is unavailable (${delivery.reason}). The result remains in the execution report.`,
       {
         data: {
           executionId,
           parentStreamId: pending.targetStreamId,
-          ...(delivery.kind === 'no_session' && {
-            streamStatus: delivery.streamStatus ?? 'unknown',
-          }),
+          reason: delivery.reason,
         },
       },
     );

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -19,8 +19,7 @@ import type {
   ChildTurnState,
 } from '@agent/storage/ExecutionKVStore';
 import {
-  onOwnedExecutionLeaseLost,
-  captureOwnedExecutionLease,
+  assertOwnedExecutionLease,
   markOwnedExecutionLeaseUndurable,
 } from '@agent/storage/executionLease';
 import {
@@ -548,12 +547,7 @@ function emitTurnDiagnostic(
       ...(turnRef
         ? { turnToken: turnRef.token, deliveryId: turnRef.deliveryId }
         : {}),
-      ...(queueOwner
-        ? {
-            queueGeneration: queueOwner.generation,
-            queueOwner: queueOwner.kind,
-          }
-        : {}),
+      ...(queueOwner ? { queueOwner: queueOwner.kind } : {}),
       ...(interruptionCause ? { interruptionCause } : {}),
     },
   });
@@ -778,9 +772,9 @@ export function startChildRunLoop<TTurn>(
   // own run trace inside `runFlowWithLifecycle`), so this is a channel-only
   // fallback for the loop's own turn-summary/warning lines.
   const logger = childStream?.logger ?? createChannelTrace('childRunLoop');
-  // The code below is synchronous until the scoped loop task is spawned, so a
-  // lost generation fails before any queue, listener, stage, or loop exists.
-  captureOwnedExecutionLease(executionId);
+  // The code below is synchronous until the loop task is spawned, so a run
+  // that does not own its lease fails before any queue, stage, or loop exists.
+  assertOwnedExecutionLease(executionId);
   const runSession = currentSession();
   // Parent delivery belongs to the continuation generation under which this
   // producer started. A terminal retry may reuse the same stream ID, but late
@@ -792,19 +786,20 @@ export function startChildRunLoop<TTurn>(
     childStreamId,
     strategy.ownsBackgroundProcess === true,
   );
+  // The parent counts this child as active from here until the final delivery
+  // below has landed, whatever turn handles come and go in between: a child
+  // result can therefore never reach a parent whose queue already went terminal.
   let activationDetached = false;
-  const releaseChildActivation = childStream
-    ? () => undefined
-    : runSession.executions.reserveChildActivation({
-        executionId,
-        parentStreamId,
-        childStreamId,
-        interrupt: () => loop.interrupt(),
-        detach: () => {
-          activationDetached = true;
-        },
-        isDetached: () => activationDetached,
-      });
+  const releaseChildActivation = runSession.executions.reserveChildActivation({
+    executionId,
+    parentStreamId,
+    childStreamId,
+    interrupt: () => loop.interrupt(),
+    detach: () => {
+      activationDetached = true;
+    },
+    isDetached: () => activationDetached,
+  });
   let sessionOwnershipReleased = false;
   const releaseSessionOwnershipOnce = (): void => {
     if (sessionOwnershipReleased) return;
@@ -812,7 +807,6 @@ export function startChildRunLoop<TTurn>(
     strategy.releaseSessionOwnership?.();
   };
 
-  let stopWatchingLease: (() => void) | undefined;
   let queue!: FollowUpQueue;
   let queueLease: FollowUpConsumerLease | undefined;
   let attachedHandle: AgentExecutionHandle | undefined;
@@ -828,15 +822,9 @@ export function startChildRunLoop<TTurn>(
 
   try {
     strategy.onLoopStart?.(runSession);
-    stopWatchingLease = onOwnedExecutionLeaseLost(executionId, () => {
-      logger.error('Execution lease was lost; interrupting the former owner', {
-        data: { executionId, childStreamId },
-      });
-      loop.interrupt();
-    });
     // Revalidate at the state transition itself: setup hooks above may run
     // arbitrary synchronous code after the early fail-fast lease check.
-    captureOwnedExecutionLease(executionId);
+    assertOwnedExecutionLease(executionId);
     queueLease = runSession.followUps.claimChildRun(childStreamId, executionId);
     if (!queueLease) {
       throw new Error(
@@ -864,7 +852,6 @@ export function startChildRunLoop<TTurn>(
     cleanup(() => {
       if (queueLease) runSession.followUps.release(queueLease, 'terminal');
     });
-    cleanup(() => stopWatchingLease?.());
     cleanup(releaseChildActivation);
     cleanup(releaseSessionOwnershipOnce);
     // The primary error always heads the list, so a single throw covers both
@@ -1215,7 +1202,6 @@ export function startChildRunLoop<TTurn>(
           });
           releaseFailure = error;
         } finally {
-          stopWatchingLease?.();
           releaseChildActivation();
         }
       }
@@ -1224,13 +1210,10 @@ export function startChildRunLoop<TTurn>(
     // threw: the lease drain failure is then the run's failure.
     if (releaseFailure !== undefined) throw releaseFailure;
   };
-  try {
-    const completion = Promise.resolve(
-      captureOwnedExecutionLease(executionId)(run),
-    );
-    return { completion };
-  } catch (error) {
-    releaseChildActivation();
-    throw error;
-  }
+  // The loop is this execution's generation: it starts on the execution's
+  // lane once any earlier generation of the id has disposed, and later steps
+  // (a resume, a delete) wait for its completion.
+  return {
+    completion: runSession.executions.launchExecution(executionId, run),
+  };
 }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -18,7 +18,7 @@ import {
 } from '@agent/storage/executionLifecycle';
 import {
   acquireResumedExecutionLease,
-  captureOwnedExecutionLease,
+  assertOwnedExecutionLease,
   releaseOwnedExecutionLeaseAfterFailure,
 } from '@agent/storage/executionLease';
 import { AgentError } from '@common/errors';
@@ -64,20 +64,12 @@ import {
   retrieveSessionResumeData,
   type ToolUseResumeData,
 } from './SessionResumeRetrieval';
+import { defaultSession, type SessionHandle } from './SessionHandle';
 import type { AgentExecutionHandle, AgentRunHandle } from './ExecutionHandle';
 import type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKey';
-import type { SessionHandle } from './SessionHandle';
 
 const CHANNEL = 'executeAgent';
 const logger = createLog(CHANNEL);
-
-/** A resumed execution lost its canonical admission race with deletion. */
-export class ResumeAdmissionCancelledError extends Error {
-  constructor(readonly executionId: ExecutionId) {
-    super(`Resume cancelled before launch for execution ${executionId}.`);
-    this.name = 'ResumeAdmissionCancelledError';
-  }
-}
 
 /** A claimed execution no longer has the persisted tool-use state to resume. */
 export class ResumeSessionUnavailableError extends Error {
@@ -412,115 +404,111 @@ export async function executeAgent(
   executionId: ExecutionId,
   options: ExecuteAgentOptions,
 ): Promise<AgentRuntimeFlowResult> {
-  const runWithOwnership = captureOwnedExecutionLease(executionId);
-  return await runWithOwnership(async () => {
-    const ctx = await buildAgentLaunchContext({
-      config,
-      executionId,
-      streamTabIdOverride: options.streamTabIdOverride,
-      onBeforeActivation: options.onStreamResolved,
-      suppressViewSwitch: options.isSubagent,
-      enforceCategory: options.enforceCategory,
-      suppressErrorNotification:
-        options.suppressErrorNotification ?? options.isSubagent,
-      session: options.session,
-      modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
-      copilotRouteOverride: options.copilotRouteOverride,
-      signal: options.launchSignal,
-      toolPolicy: {
-        approvalPromptsUnavailable: options.approvalPromptsUnavailable,
-        runtimeUnavailableTools: options.runtimeUnavailableTools,
-        stopAfterCycle: options.stopAfterCycle,
-      },
-    });
-    return withExecutionRunContext(
-      ctx,
-      { onApprovalPolicyDenial: options.onApprovalPolicyDenial },
-      async () => {
-        const { setting, config } = ctx;
-        const {
-          streamId: runStreamId,
-          executionId: runExecutionId,
-          session: runSession,
-        } = ctx.runScope;
-        const { isSubagent } = options;
-
-        // Start description generation concurrently with the run, but join it
-        // before the owner can release its execution lease. This prevents the
-        // metadata write from recreating an execution deleted by another host.
-        const sessionDescription = generateSessionDescription(
-          runExecutionId,
-          runStreamId,
-          config,
-          runSession,
-          ctx.runScope.signal,
-        );
-        try {
-          const result = await runFlowWithLifecycle(
-            ctx,
-            async (handle, lifecycle) => {
-              // Pre-execution UI setup (RUNNING is set by runFlowWithLifecycle)
-              await ensureRunDir(executionId);
-              logger.info(`Starting task execution (streamId: ${runStreamId})`);
-              logger.info(`Input file: ${config.inputFiles[0] ?? '(none)'}`);
-              logger.debug('Task execution details', {
-                data: {
-                  streamId: runStreamId,
-                  agent: config.agent,
-                  model: config.model,
-                },
-              });
-              logger.debug(`Output files: ${config.outputFiles?.length ?? 0}`);
-              // Subagents don't need to force-open the progress board or show notifications —
-              // the orchestrator's stream is already visible.
-              if (!isSubagent) {
-                runSession.interactions.emit(
-                  'requestEnsureProgressView',
-                  { fallbackNotification: buildFallbackNotification(config) },
-                  { replayWhenAttached: true },
-                );
-              }
-              logger.info('Executing agent', {
-                data: { agent: config.agent, model: config.model },
-              });
-
-              if (setting.agentCategory === AgentCategory.ToolUse) {
-                return launchToolUseRun(
-                  ctx,
-                  handle,
-                  lifecycle,
-                  { ...options, setting, isSubagent },
-                  { kind: 'fresh', onIdle: options.onIdle },
-                );
-              }
-              const result = await runReflectionAgent(ctx, setting);
-              if (result.error) return result;
-              const outputOutcome = await options.openWorkflowOutput?.(result);
-              return outputOutcome === undefined
-                ? result
-                : { ...result, outcome: outputOutcome };
-            },
-            buildLifecycleOptions(options, isSubagent),
-          );
-          if (isWaitingFlowResult(result) && !options.allowWaitingResult) {
-            throw new Error(
-              'executeAgent received a non-terminal WAITING result without allowWaitingResult.',
-            );
-          }
-          return result;
-        } finally {
-          await sessionDescription;
-        }
-      },
-    );
+  assertOwnedExecutionLease(executionId);
+  const ctx = await buildAgentLaunchContext({
+    config,
+    executionId,
+    streamTabIdOverride: options.streamTabIdOverride,
+    onBeforeActivation: options.onStreamResolved,
+    suppressViewSwitch: options.isSubagent,
+    enforceCategory: options.enforceCategory,
+    suppressErrorNotification:
+      options.suppressErrorNotification ?? options.isSubagent,
+    session: options.session,
+    modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
+    copilotRouteOverride: options.copilotRouteOverride,
+    signal: options.launchSignal,
+    toolPolicy: {
+      approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+      runtimeUnavailableTools: options.runtimeUnavailableTools,
+      stopAfterCycle: options.stopAfterCycle,
+    },
   });
+  return withExecutionRunContext(
+    ctx,
+    { onApprovalPolicyDenial: options.onApprovalPolicyDenial },
+    async () => {
+      const { setting, config } = ctx;
+      const {
+        streamId: runStreamId,
+        executionId: runExecutionId,
+        session: runSession,
+      } = ctx.runScope;
+      const { isSubagent } = options;
+
+      // Start description generation concurrently with the run, but join it
+      // before the owner can release its execution lease. This prevents the
+      // metadata write from recreating an execution deleted by another host.
+      const sessionDescription = generateSessionDescription(
+        runExecutionId,
+        runStreamId,
+        config,
+        runSession,
+        ctx.runScope.signal,
+      );
+      try {
+        const result = await runFlowWithLifecycle(
+          ctx,
+          async (handle, lifecycle) => {
+            // Pre-execution UI setup (RUNNING is set by runFlowWithLifecycle)
+            await ensureRunDir(executionId);
+            logger.info(`Starting task execution (streamId: ${runStreamId})`);
+            logger.info(`Input file: ${config.inputFiles[0] ?? '(none)'}`);
+            logger.debug('Task execution details', {
+              data: {
+                streamId: runStreamId,
+                agent: config.agent,
+                model: config.model,
+              },
+            });
+            logger.debug(`Output files: ${config.outputFiles?.length ?? 0}`);
+            // Subagents don't need to force-open the progress board or show notifications —
+            // the orchestrator's stream is already visible.
+            if (!isSubagent) {
+              runSession.interactions.emit(
+                'requestEnsureProgressView',
+                { fallbackNotification: buildFallbackNotification(config) },
+                { replayWhenAttached: true },
+              );
+            }
+            logger.info('Executing agent', {
+              data: { agent: config.agent, model: config.model },
+            });
+
+            if (setting.agentCategory === AgentCategory.ToolUse) {
+              return launchToolUseRun(
+                ctx,
+                handle,
+                lifecycle,
+                { ...options, setting, isSubagent },
+                { kind: 'fresh', onIdle: options.onIdle },
+              );
+            }
+            const result = await runReflectionAgent(ctx, setting);
+            if (result.error) return result;
+            const outputOutcome = await options.openWorkflowOutput?.(result);
+            return outputOutcome === undefined
+              ? result
+              : { ...result, outcome: outputOutcome };
+          },
+          buildLifecycleOptions(options, isSubagent),
+        );
+        if (isWaitingFlowResult(result) && !options.allowWaitingResult) {
+          throw new Error(
+            'executeAgent received a non-terminal WAITING result without allowWaitingResult.',
+          );
+        }
+        return result;
+      } finally {
+        await sessionDescription;
+      }
+    },
+  );
 }
 
 export interface ResumeToolUseFromResumeDataOptions extends SubagentRunOptions {
   /** Fires when the resumed tool-use session consumes queued follow-ups. */
   readonly onFollowUpConsumed?: () => void;
-  /** Recheck canonical admission atomically while acquiring the resumed lease. */
-  readonly canAcquireResumeLease?: () => boolean | Promise<boolean>;
   /**
    * Take messages queued after the initial drain. The flow invokes this once
    * after attaching its live context and before resuming the persisted cursor.
@@ -651,53 +639,68 @@ async function resumeToolUseWithOwnedLease(
 }
 
 /**
- * Resume a persisted tool-use session after claiming its execution lease.
- * Whether the run is a subagent — and can therefore legitimately resolve
- * WAITING again — comes from persisted lineage (`hasPersistedParent`), never
- * from the caller.
+ * One resumed turn of a persisted tool-use session: claim its execution lease,
+ * reload the persisted snapshot under that lease, and run. Whether the run is
+ * a subagent — and can therefore legitimately resolve WAITING again — comes
+ * from persisted lineage (`hasPersistedParent`), never from the caller.
+ *
+ * This is the inner, unserialized turn: a native child loop runs it for every
+ * turn inside the child's own generation, which already holds the child's
+ * execution lane. Hosts resume through {@link resumeToolUseFromResumeData}.
  */
-export async function resumeToolUseFromResumeData(
+async function resumeToolUseTurn(
   resume: ToolUseResumeData,
   options: ResumeToolUseFromResumeDataOptions = {},
 ): Promise<AgentRuntimeFlowResult> {
-  const lease = await acquireResumedExecutionLease(
-    resume.executionId,
-    options.canAcquireResumeLease,
-  );
-  if (lease === 'cancelled') {
-    throw new ResumeAdmissionCancelledError(resume.executionId);
-  }
-  return await captureOwnedExecutionLease(resume.executionId)(async () => {
-    let leasedResume: ToolUseResumeData;
-    try {
-      // The caller's lookup only decides whether a resume may be attempted.
-      // Its shared state is never launched: reload after the lease is owned so
-      // this process has a single authoritative persisted snapshot.
-      const retrievedResume = await retrieveSessionResumeData(
-        resume.streamId,
-        resume.executionId,
-        resume.agentConfig,
-        { parentStreamId: resume.parentStreamId },
-      );
-      if (retrievedResume?.type !== 'toolUse') {
-        throw new ResumeSessionUnavailableError(resume.executionId);
-      }
-      leasedResume = retrievedResume;
-    } catch (error) {
-      throw await releaseOwnedExecutionLeaseAfterFailure(
-        resume.executionId,
-        error,
-      );
+  await acquireResumedExecutionLease(resume.executionId);
+  let leasedResume: ToolUseResumeData;
+  try {
+    // The caller's lookup only decides whether a resume may be attempted.
+    // Its shared state is never launched: reload after the lease is owned so
+    // this process has a single authoritative persisted snapshot.
+    const retrievedResume = await retrieveSessionResumeData(
+      resume.streamId,
+      resume.executionId,
+      resume.agentConfig,
+      { parentStreamId: resume.parentStreamId },
+    );
+    if (retrievedResume?.type !== 'toolUse') {
+      throw new ResumeSessionUnavailableError(resume.executionId);
     }
-    // `resumeToolUseWithOwnedLease` owns release after its launch boundary,
-    // including its own setup failures. Keep it outside the retrieval guard so
-    // a run failure is not released twice by nested rollback paths.
-    return await resumeToolUseWithOwnedLease(leasedResume, options);
-  });
+    leasedResume = retrievedResume;
+  } catch (error) {
+    throw await releaseOwnedExecutionLeaseAfterFailure(
+      resume.executionId,
+      error,
+    );
+  }
+  // `resumeToolUseWithOwnedLease` owns release after its launch boundary,
+  // including its own setup failures. Keep it outside the retrieval guard so
+  // a run failure is not released twice by nested rollback paths.
+  return await resumeToolUseWithOwnedLease(leasedResume, options);
+}
+
+/**
+ * Resume a persisted tool-use session as a new generation of its execution:
+ * the turn starts on the execution's serial lane, after any previous
+ * generation of the same id has fully disposed, so two generations never
+ * hold the lease at once.
+ */
+export function resumeToolUseFromResumeData(
+  resume: ToolUseResumeData,
+  options: ResumeToolUseFromResumeDataOptions = {},
+): Promise<AgentRuntimeFlowResult> {
+  const session = options.session ?? defaultSession();
+  return session.executions.launchExecution(resume.executionId, () =>
+    resumeToolUseTurn(resume, options),
+  );
 }
 
 // Close the delegation recursion: the delegation tools drive child runs
 // through `nativeSubagentStrategy`, whose engine calls are provided here —
 // the one direction that cannot be a static import, because this module's
 // flow drivers statically import the tool registry that includes those tools.
-provideAgentEngine({ executeAgent, resumeToolUseFromResumeData });
+provideAgentEngine({
+  executeAgent,
+  resumeToolUseFromResumeData: resumeToolUseTurn,
+});

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -702,5 +702,5 @@ export function resumeToolUseFromResumeData(
 // flow drivers statically import the tool registry that includes those tools.
 provideAgentEngine({
   executeAgent,
-  resumeToolUseFromResumeData: resumeToolUseTurn,
+  resumeToolUseTurn,
 });

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -258,22 +258,63 @@ export class ExecutionRegistry {
 
   /**
    * Refuse new lifecycle steps (launches, resumes, deletes) until the
-   * returned release runs. Throws `refusal(live)` instead, changing nothing,
-   * when any execution is live: session maintenance that would pull the
-   * storage out from under a run is refused, never queued behind it.
+   * returned release runs; each refused step rejects with `blocked()`. Throws
+   * `refusal(live)` instead, changing nothing, when any execution is live:
+   * session maintenance that would pull the storage out from under a run is
+   * refused, never queued behind it. Live means tracked, a generation not yet
+   * disposed, a lane step admitted but not yet finished, or a child loop whose
+   * activation is still reserved: every one of them writes under the current
+   * storage root.
    */
-  holdLifecycle(refusal: (liveExecutionIds: string[]) => Error): () => void {
+  holdLifecycle(
+    refusal: (liveExecutionIds: string[]) => Error,
+    blocked: () => Error,
+  ): () => void {
     this.assertActive();
-    const live = [
-      ...new Set([...this.handles.keys(), ...this.liveGenerations.keys()]),
-    ];
+    const live = this.liveExecutionIds();
     if (live.length > 0) throw refusal(live);
-    if (this.lifecycleHold) throw this.lifecycleHold;
-    const hold = refusal([]);
+    if (this.lifecycleHold) {
+      throw new Error(
+        'A storage location change is already in progress. Retry once it finishes.',
+      );
+    }
+    const hold = blocked();
     this.lifecycleHold = hold;
     return () => {
       if (this.lifecycleHold === hold) this.lifecycleHold = undefined;
     };
+  }
+
+  private liveExecutionIds(): string[] {
+    const live = new Set<string>([
+      ...this.handles.keys(),
+      ...this.liveGenerations.keys(),
+      ...this.childActivations.keys(),
+    ]);
+    for (const [executionId, lane] of this.lanes) {
+      if (
+        lane.queue.size > 0 ||
+        lane.queue.pending > 0 ||
+        lane.waiting.size > 0
+      ) {
+        live.add(executionId);
+      }
+    }
+    return [...live];
+  }
+
+  /**
+   * Whether `streamId` is running, resuming, or parked with a live flow in this
+   * process: the states in which a resume must be refused outright rather than
+   * queued on the execution lane, since it would otherwise start a fresh
+   * generation of a run that just finished.
+   */
+  isActiveOrResuming(streamId: StreamTabId): boolean {
+    return (
+      isActivePhase(this.streamStatus.get(streamId)) ||
+      this.streamStatus.getSubstate(streamId) === STREAM_SUBSTATE.RESUMING ||
+      this.getToolUseFlowContext(streamId) !== undefined
+    );
   }
 
   /**
@@ -1015,9 +1056,16 @@ export class ExecutionRegistry {
     // The teardown releases the execution lease: it is the tail of the
     // suspended generation, so the lane waits for it before a resume can
     // claim the execution again.
+    // A child loop's generation stays the lane's live promise until the loop
+    // ends; the turn's teardown chains onto it rather than replacing it.
     const lane = this.lanes.get(handle.executionId) ?? this.createLane();
     this.lanes.set(handle.executionId, lane);
-    this.setLiveGeneration(lane, handle.executionId, termination);
+    const previous = lane.live;
+    this.setLiveGeneration(
+      lane,
+      handle.executionId,
+      previous ? Promise.all([previous, termination]) : termination,
+    );
     this.forgetIdleLane(handle.executionId, lane);
     return true;
   }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -5,6 +5,8 @@
  * notification, and subagent lineage tracking in a single module.
  */
 
+import PQueue from 'p-queue';
+
 import { createChannelTrace, type ResultEvent } from '@agent/trace';
 import {
   ExecutionLeaseLostError,
@@ -56,8 +58,12 @@ interface ExecutionStopOptions {
 }
 
 /**
- * A child loop that has started synchronously but whose first run handle is
- * still being constructed.
+ * A child loop's lineage for the loop's whole life: from the synchronous start
+ * of the loop, across every turn handle it tracks and untracks, until its
+ * final result has been delivered to the parent. The parent counts it as an
+ * active child throughout, so the parent's continuation stays recoverable
+ * until the last delivery has landed and a child result can never arrive
+ * after the parent's queue went terminal.
  */
 export interface ChildExecutionActivation {
   readonly executionId: ExecutionId;
@@ -70,6 +76,29 @@ export interface ChildExecutionActivation {
 
 interface TerminateOptions {
   readonly cascadeChildren?: boolean;
+}
+
+/**
+ * The serial lifecycle lane of one execution id. Launch, resume, delete and
+ * any other lifecycle step run through `queue` one at a time, and each step
+ * first waits for `live`, the generation the last launch started, to dispose.
+ * Generations of one execution therefore never coexist: a resume cannot mint
+ * a lease while the previous run still holds one, and a delete cannot run
+ * under a live run. Stop is a signal to the live generation, not a step.
+ */
+interface ExecutionLane {
+  readonly queue: PQueue;
+  live: Promise<void> | undefined;
+  /** Steps admitted but not yet started; rejected if the session disposes. */
+  readonly waiting: Set<(error: Error) => void>;
+}
+
+/** Resolve when `promise` settles either way; a lane waits, it never fails. */
+function settled(promise: Promise<unknown>): Promise<void> {
+  return promise.then(
+    () => undefined,
+    () => undefined,
+  );
 }
 
 export type ToolUseFollowUpQueueReason =
@@ -169,6 +198,11 @@ export class ExecutionRegistry {
   private readonly childActivationListeners: ListenerSet<
     (activation: ChildExecutionActivation, active: boolean) => void
   > = createListenerSet();
+  private readonly lanes = new Map<string, ExecutionLane>();
+  /** Generations started on a lane that have not yet disposed. */
+  private readonly liveGenerations = new Map<string, Promise<void>>();
+  /** While set, every new lifecycle step is refused with this error. */
+  private lifecycleHold: Error | undefined;
 
   constructor(options: ExecutionRegistryInit) {
     this.events = options.events;
@@ -198,6 +232,16 @@ export class ExecutionRegistry {
     if (this.disposed) return;
     this.disposed = true;
     this.disposeStatusSubscription();
+    const disposal = new Error(
+      'Cannot register execution work after session disposal.',
+    );
+    for (const lane of this.lanes.values()) {
+      lane.queue.clear();
+      for (const reject of lane.waiting) reject(disposal);
+      lane.waiting.clear();
+    }
+    this.lanes.clear();
+    this.liveGenerations.clear();
     const executionIds = [...this.handles.keys()];
     this.handles.clear();
     for (const executionId of executionIds) {
@@ -211,6 +255,128 @@ export class ExecutionRegistry {
     this.listeners.clear();
     this.registrationListeners.clear();
     this.childActivationListeners.clear();
+  }
+
+  /**
+   * Refuse new lifecycle steps (launches, resumes, deletes) until the
+   * returned release runs. Throws `refusal(live)` instead, changing nothing,
+   * when any execution is live: session maintenance that would pull the
+   * storage out from under a run is refused, never queued behind it.
+   */
+  holdLifecycle(refusal: (liveExecutionIds: string[]) => Error): () => void {
+    this.assertActive();
+    const live = [
+      ...new Set([...this.handles.keys(), ...this.liveGenerations.keys()]),
+    ];
+    if (live.length > 0) throw refusal(live);
+    if (this.lifecycleHold) throw this.lifecycleHold;
+    const hold = refusal([]);
+    this.lifecycleHold = hold;
+    return () => {
+      if (this.lifecycleHold === hold) this.lifecycleHold = undefined;
+    };
+  }
+
+  /**
+   * Run one lifecycle step of `executionId` after every earlier step has
+   * returned and the generation the last launch started has disposed.
+   */
+  runExecutionStep<T>(executionId: string, step: () => Promise<T>): Promise<T> {
+    return this.enqueueLaneStep(executionId, () => {
+      const result = step();
+      return { result, hold: result };
+    });
+  }
+
+  /**
+   * Launch a generation of `executionId` as a lifecycle step: `start` begins
+   * once the previous generation has disposed, and its promise becomes the
+   * generation later steps wait on. The step itself returns as soon as the run
+   * has begun, so a parent launching a child is never held by the child's
+   * lifetime and a step never waits on a run for which it holds the lane.
+   */
+  launchExecution<T>(executionId: string, start: () => Promise<T>): Promise<T> {
+    return this.enqueueLaneStep(executionId, (lane) => {
+      const result = start();
+      this.setLiveGeneration(lane, executionId, result);
+      return { result, hold: undefined };
+    });
+  }
+
+  private setLiveGeneration(
+    lane: ExecutionLane,
+    executionId: string,
+    generation: Promise<unknown>,
+  ): void {
+    const live = settled(generation);
+    lane.live = live;
+    this.liveGenerations.set(executionId, live);
+    void live.then(() => {
+      if (this.liveGenerations.get(executionId) === live) {
+        this.liveGenerations.delete(executionId);
+      }
+    });
+  }
+
+  private enqueueLaneStep<T>(
+    executionId: string,
+    step: (lane: ExecutionLane) => {
+      readonly result: Promise<T>;
+      /** What the lane stays held for; `undefined` releases it at once. */
+      readonly hold: Promise<unknown> | undefined;
+    },
+  ): Promise<T> {
+    this.assertActive();
+    if (this.lifecycleHold) return Promise.reject(this.lifecycleHold);
+    const lane = this.lanes.get(executionId) ?? this.createLane();
+    this.lanes.set(executionId, lane);
+    let settle!: (result: Promise<T>) => void;
+    let refuse!: (error: Error) => void;
+    const handedOut = new Promise<Promise<T>>((resolve, reject) => {
+      settle = resolve;
+      refuse = reject;
+    });
+    lane.waiting.add(refuse);
+    void lane.queue
+      .add(async () => {
+        await lane.live;
+        // A disposal during the wait already refused this step.
+        if (!lane.waiting.delete(refuse)) return;
+        let run: ReturnType<typeof step>;
+        try {
+          run = step(lane);
+        } catch (error) {
+          settle(Promise.reject(error));
+          return;
+        }
+        settle(run.result);
+        if (run.hold) await settled(run.hold);
+      })
+      .finally(() => this.forgetIdleLane(executionId, lane));
+    return handedOut.then((result) => result);
+  }
+
+  private createLane(): ExecutionLane {
+    return {
+      queue: new PQueue({ concurrency: 1 }),
+      live: undefined,
+      waiting: new Set(),
+    };
+  }
+
+  private forgetIdleLane(executionId: string, lane: ExecutionLane): void {
+    if (lane.queue.size !== 0 || lane.queue.pending !== 0) return;
+    if (this.lanes.get(executionId) !== lane) return;
+    const live = lane.live;
+    if (live === undefined) {
+      this.lanes.delete(executionId);
+      return;
+    }
+    void live.then(() => {
+      if (lane.live !== live) return;
+      lane.live = undefined;
+      this.forgetIdleLane(executionId, lane);
+    });
   }
 
   /** Register an execution handle. */
@@ -235,7 +401,6 @@ export class ExecutionRegistry {
       });
     }
     this.notifyRegistrationListeners(handle.executionId, handle);
-    this.releaseChildActivation(handle.executionId);
     this.notifyWaiters(handle.executionId);
   }
 
@@ -529,9 +694,13 @@ export class ExecutionRegistry {
     visited: Set<string>,
     options: TerminateOptions,
   ): void {
+    // A loop between turns has no handle to interrupt; a loop inside a turn
+    // also gets its turn handle terminated below. The activation is keyed
+    // apart from the handle so each is interrupted once per stop.
     for (const activation of this.activeChildActivations(parentStreamId)) {
-      if (visited.has(activation.executionId)) continue;
-      visited.add(activation.executionId);
+      const key = `activation:${activation.executionId}`;
+      if (visited.has(key)) continue;
+      visited.add(key);
       activation.interrupt();
     }
     for (const handle of this.handles.values()) {
@@ -638,16 +807,12 @@ export class ExecutionRegistry {
   }
 
   /**
-   * Retain lineage while a newly started child loop is constructing its first
-   * execution handle. Tracking that handle promotes the activation
-   * automatically; the returned disposer covers startup failure.
+   * Retain a child loop's lineage until the returned disposer runs, which the
+   * loop does only after its final delivery to the parent.
    */
   reserveChildActivation(activation: ChildExecutionActivation): () => void {
     this.assertActive();
-    if (
-      this.handles.has(activation.executionId) ||
-      this.childActivations.has(activation.executionId)
-    ) {
+    if (this.childActivations.has(activation.executionId)) {
       return () => {};
     }
     this.childActivations.set(activation.executionId, activation);
@@ -735,6 +900,17 @@ export class ExecutionRegistry {
     if (options.cascadeChildren === true) {
       this.interruptActiveChildren(handle.childStreamId, visited, options);
     }
+    // A child execution is its loop, not only the turn this handle runs:
+    // stopping it ends the loop too, so the interrupted turn is not delivered
+    // to the parent as a completed one.
+    const activation = this.childActivations.get(handle.executionId);
+    if (activation && !activation.isDetached()) {
+      const key = `activation:${activation.executionId}`;
+      if (!visited.has(key)) {
+        visited.add(key);
+        activation.interrupt();
+      }
+    }
     if (handle.interrupt()) {
       this.cancelStreamStatus(handle.childStreamId);
       return true;
@@ -795,52 +971,59 @@ export class ExecutionRegistry {
       category: handle.category,
       isSubagent: handle.isChildExecution,
     };
-    void this.finishWaitingTermination(handle, teardown, cancelledResult).catch(
-      async (error: unknown) => {
-        const recoveryFailures = [error];
-        if (!(error instanceof ExecutionLeaseLostError)) {
-          try {
-            await handle.runWithExecutionLease(async () => {
-              markOwnedExecutionLeaseUndurable(handle.executionId);
-              const untracked = this.settleTerminal(handle, cancelledResult, {
-                publish: false,
-                untrackMode: 'ifCurrent',
-              });
-              if (untracked && !handle.isChildExecution) {
-                await this.releaseRootExecutionLease(handle.executionId);
-              }
-            });
-            logger.warn(
-              'Waiting-execution termination failed; recovered under the execution lease',
-              { data: { executionId: handle.executionId, recoveryFailures } },
-            );
-            return;
-          } catch (recoveryError) {
-            recoveryFailures.push(recoveryError);
+    const termination = this.finishWaitingTermination(
+      handle,
+      teardown,
+      cancelledResult,
+    ).catch(async (error: unknown) => {
+      const recoveryFailures = [error];
+      if (!(error instanceof ExecutionLeaseLostError)) {
+        try {
+          markOwnedExecutionLeaseUndurable(handle.executionId);
+          const untracked = this.settleTerminal(handle, cancelledResult, {
+            publish: false,
+            untrackMode: 'ifCurrent',
+          });
+          if (untracked && !handle.isChildExecution) {
+            await this.releaseRootExecutionLease(handle.executionId);
           }
+          logger.warn(
+            'Waiting-execution termination failed; recovered under the execution lease',
+            { data: { executionId: handle.executionId, recoveryFailures } },
+          );
+          return;
+        } catch (recoveryError) {
+          recoveryFailures.push(recoveryError);
         }
+      }
 
-        // A former generation owns only its private result. It must not mark,
-        // release, untrack, or cancel a locally reacquired successor.
-        try {
-          handle.settleResult(cancelledResult);
-        } catch (recoveryError) {
-          recoveryFailures.push(recoveryError);
+      // A former generation owns only its private result. It must not mark,
+      // release, untrack, or cancel a locally reacquired successor.
+      try {
+        handle.settleResult(cancelledResult);
+      } catch (recoveryError) {
+        recoveryFailures.push(recoveryError);
+      }
+      try {
+        const untracked = this.untrackIfCurrent(handle);
+        if (untracked) {
+          this.cancelStreamStatus(handle.childStreamId);
         }
-        try {
-          const untracked = this.untrackIfCurrent(handle);
-          if (untracked) {
-            this.cancelStreamStatus(handle.childStreamId);
-          }
-        } catch (recoveryError) {
-          recoveryFailures.push(recoveryError);
-        }
-        logger.warn(
-          'Waiting-execution termination failed; settled the run without durable finalization',
-          { data: { executionId: handle.executionId, recoveryFailures } },
-        );
-      },
-    );
+      } catch (recoveryError) {
+        recoveryFailures.push(recoveryError);
+      }
+      logger.warn(
+        'Waiting-execution termination failed; settled the run without durable finalization',
+        { data: { executionId: handle.executionId, recoveryFailures } },
+      );
+    });
+    // The teardown releases the execution lease: it is the tail of the
+    // suspended generation, so the lane waits for it before a resume can
+    // claim the execution again.
+    const lane = this.lanes.get(handle.executionId) ?? this.createLane();
+    this.lanes.set(handle.executionId, lane);
+    this.setLiveGeneration(lane, handle.executionId, termination);
+    this.forgetIdleLane(handle.executionId, lane);
     return true;
   }
 
@@ -849,69 +1032,54 @@ export class ExecutionRegistry {
     teardown: Promise<void>,
     cancelledResult: ResultEvent,
   ): Promise<void> {
-    return await handle.runWithExecutionLease(async () => {
-      try {
-        await teardown;
-      } catch (error) {
-        // Transcript closure and terminal execution metadata are independent
-        // durable facts. Preserve the failed artifact fence, but still give the
-        // terminal status its own opportunity to reach disk.
-        markOwnedExecutionLeaseUndurable(handle.executionId);
-        logger.warn(
-          'Waiting-execution cleanup failed; continuing terminal persistence',
-          { data: { executionId: handle.executionId, error } },
-        );
-      }
+    try {
+      await teardown;
+    } catch (error) {
+      // Transcript closure and terminal execution metadata are independent
+      // durable facts. Preserve the failed artifact fence, but still give the
+      // terminal status its own opportunity to reach disk.
+      markOwnedExecutionLeaseUndurable(handle.executionId);
+      logger.warn(
+        'Waiting-execution cleanup failed; continuing terminal persistence',
+        { data: { executionId: handle.executionId, error } },
+      );
+    }
 
-      if (this.handles.get(handle.executionId) !== handle) {
-        // `track` transfers the pending stop to a resumed successor. The old
-        // handle still needs its private result settled, but it no longer owns
-        // the shared stream, execution metadata, or lease.
-        handle.settleResult(cancelledResult);
-        return;
-      }
+    if (this.handles.get(handle.executionId) !== handle) {
+      // `track` transfers the pending stop to a resumed successor. The old
+      // handle still needs its private result settled, but it no longer owns
+      // the shared stream, execution metadata, or lease.
+      handle.settleResult(cancelledResult);
+      return;
+    }
 
-      if (handle.executionLeaseLost) {
-        logger.warn('Discarding a stopped waiting execution after lease loss', {
-          data: { executionId: handle.executionId },
-        });
-        // Settle the in-memory result only: the former owner must not publish or
-        // persist a terminal event, but this promise must resolve on every exit.
-        this.settleTerminal(handle, cancelledResult, {
-          publish: false,
-          untrackMode: 'unconditional',
-        });
-        return;
-      }
+    // Cleanup closes the suspended run's transcript group. Publish the
+    // terminal state only after that owned artifact is settled so every host
+    // observes one coherent cancellation boundary.
+    this.settleTerminal(handle, cancelledResult, {
+      publish: true,
+      untrackMode: 'unconditional',
+    });
 
-      // Cleanup closes the suspended run's transcript group. Publish the
-      // terminal state only after that owned artifact is settled so every host
-      // observes one coherent cancellation boundary.
-      this.settleTerminal(handle, cancelledResult, {
-        publish: true,
-        untrackMode: 'unconditional',
+    try {
+      await persistTerminalExecution({
+        executionId: handle.executionId,
+        outcome: RUN_OUTCOME.CANCELLED,
+        flowRecord: 'delete',
+        logger,
+        failedMessage: 'Failed to finalize stopped waiting execution',
       });
-
-      try {
-        await persistTerminalExecution({
-          executionId: handle.executionId,
-          outcome: RUN_OUTCOME.CANCELLED,
-          flowRecord: 'delete',
-          logger,
-          failedMessage: 'Failed to finalize stopped waiting execution',
-        });
-      } finally {
-        if (!handle.isChildExecution) {
-          try {
-            await this.releaseRootExecutionLease(handle.executionId);
-          } catch (error) {
-            logger.warn('Waiting-execution artifact flush failed', {
-              data: { executionId: handle.executionId, error },
-            });
-          }
+    } finally {
+      if (!handle.isChildExecution) {
+        try {
+          await this.releaseRootExecutionLease(handle.executionId);
+        } catch (error) {
+          logger.warn('Waiting-execution artifact flush failed', {
+            data: { executionId: handle.executionId, error },
+          });
         }
       }
-    });
+    }
   }
 
   /**

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -101,18 +101,17 @@ function settled(promise: Promise<unknown>): Promise<void> {
   );
 }
 
-export type ToolUseFollowUpQueueReason =
-  'resuming' | 'waiting' | 'children_running';
-
+/**
+ * Where a follow-up for a stream goes: a live flow context, the stream's
+ * retained queue (a WAITING or resuming cursor, or a parent whose children
+ * are still active), or nowhere in this process.
+ */
 export type ToolUseFollowUpTarget =
   | {
       readonly kind: 'active';
       readonly context: LiveToolUseFlowContext;
     }
-  | {
-      readonly kind: 'queue';
-      readonly reason: ToolUseFollowUpQueueReason;
-    }
+  | { readonly kind: 'queue' }
   | {
       readonly kind: 'no_session';
       readonly streamStatus: StreamPhase | undefined;
@@ -559,23 +558,19 @@ export class ExecutionRegistry {
     const hasActiveChildren = this.hasActiveChildren(streamId);
 
     if (status !== undefined && !isInFlightPhase(status)) {
-      if (hasActiveChildren) {
-        return { kind: 'queue', reason: 'children_running' };
-      }
+      if (hasActiveChildren) return { kind: 'queue' };
       return { kind: 'no_session', streamStatus: status };
     }
 
     const context = this.getToolUseFlowContext(streamId);
     if (context) return { kind: 'active', context };
 
-    if (this.streamStatus.getSubstate(streamId) === STREAM_SUBSTATE.RESUMING) {
-      return { kind: 'queue', reason: 'resuming' };
-    }
-    if (status === STREAM_PHASE.WAITING) {
-      return { kind: 'queue', reason: 'waiting' };
-    }
-    if (hasActiveChildren) {
-      return { kind: 'queue', reason: 'children_running' };
+    if (
+      this.streamStatus.getSubstate(streamId) === STREAM_SUBSTATE.RESUMING ||
+      status === STREAM_PHASE.WAITING ||
+      hasActiveChildren
+    ) {
+      return { kind: 'queue' };
     }
     return { kind: 'no_session', streamStatus: status };
   }

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -20,6 +20,7 @@
 // SessionHandle
 export {
   SessionHandle,
+  StorageRootChangeRefusedError,
   currentSession,
   defaultSession,
   initializeDefaultSession,

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -11,6 +11,7 @@ import {
   type ToolUseResumeData,
 } from './SessionResumeRetrieval';
 import { ResumeSessionUnavailableError } from './executeAgent';
+import type { ExecutionRegistry } from './executionRegistry';
 import type { SessionHandle } from './SessionHandle';
 import type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKey';
 
@@ -126,6 +127,12 @@ export async function resolveResumeStateFromSnapshots(
 }
 
 export interface ResumeStreamPorts {
+  /**
+   * The registry of the session that owns this stream. A resume is refused,
+   * not queued, while the stream is running or resuming in this process; the
+   * lane below only keeps admitted generations from overlapping.
+   */
+  readonly executions: Pick<ExecutionRegistry, 'isActiveOrResuming'>;
   /** Monotone per-attempt cancellation signal: once true it stays true. */
   readonly isCancellationRequested?: () => boolean;
   resolveResumeState(streamId: StreamTabId): Promise<ResumeStateResolution>;
@@ -150,10 +157,11 @@ export interface ResumeStreamPorts {
 /**
  * Attempt to resume a WAITING / children-running stream from persisted state.
  *
- * Admission is the recovery claim the caller made on the stream's follow-up
- * queue: a stream with a live consumer cannot be claimed, and the resume
- * itself starts on the execution's serial lane, so no stream-status check is
- * needed here to keep two resumes, or a resume and a launch, apart.
+ * The execution lane keeps the resumed generation from overlapping the one
+ * before it; admission is decided here. A stream that is already running or
+ * resuming in this process is refused, because a workflow run holds no
+ * follow-up queue consumer and a queued resume would otherwise rerun it
+ * after it finishes.
  */
 export async function resolveAndResumeStream(
   streamId: StreamTabId,
@@ -163,7 +171,11 @@ export async function resolveAndResumeStream(
   const isCancellationRequested = (): boolean =>
     ports.isCancellationRequested?.() === true;
 
-  if (isCancellationRequested()) return false;
+  if (
+    isCancellationRequested() ||
+    ports.executions.isActiveOrResuming(streamId)
+  )
+    return false;
 
   try {
     const resolution = await ports.resolveResumeState(streamId);
@@ -189,6 +201,9 @@ export async function resolveAndResumeStream(
       await ports.reportNoResumableSession?.(streamId);
       return false;
     }
+    // Re-check after the retrieval await: a launch of this stream may have
+    // been admitted meanwhile, and the lane would queue, not refuse, this one.
+    if (ports.executions.isActiveOrResuming(streamId)) return false;
 
     if (resume.type === 'toolUse') {
       return await ports.resumeToolUse(resume, recovery);

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -10,12 +10,8 @@ import {
   retrieveSessionResumeData,
   type ToolUseResumeData,
 } from './SessionResumeRetrieval';
-import {
-  ResumeAdmissionCancelledError,
-  ResumeSessionUnavailableError,
-} from './executeAgent';
+import { ResumeSessionUnavailableError } from './executeAgent';
 import type { SessionHandle } from './SessionHandle';
-import type { StreamStatusMachine } from './StreamStatusService';
 import type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKey';
 
 interface ResolvedResumeState {
@@ -130,13 +126,6 @@ export async function resolveResumeStateFromSnapshots(
 }
 
 export interface ResumeStreamPorts {
-  /**
-   * The status machine of the session that owns this stream. The active/resuming
-   * guards must read the machine the run actually writes; reading the
-   * process-global default left both guards permanently false in multi-session
-   * hosts.
-   */
-  readonly streamStatus: Pick<StreamStatusMachine, 'isActiveOrResuming'>;
   /** Monotone per-attempt cancellation signal: once true it stays true. */
   readonly isCancellationRequested?: () => boolean;
   resolveResumeState(streamId: StreamTabId): Promise<ResumeStateResolution>;
@@ -158,7 +147,14 @@ export interface ResumeStreamPorts {
   reportFailure?(streamId: StreamTabId, error: unknown): void | Promise<void>;
 }
 
-/** Attempt to resume a WAITING / children-running stream from persisted state. */
+/**
+ * Attempt to resume a WAITING / children-running stream from persisted state.
+ *
+ * Admission is the recovery claim the caller made on the stream's follow-up
+ * queue: a stream with a live consumer cannot be claimed, and the resume
+ * itself starts on the execution's serial lane, so no stream-status check is
+ * needed here to keep two resumes, or a resume and a launch, apart.
+ */
 export async function resolveAndResumeStream(
   streamId: StreamTabId,
   ports: ResumeStreamPorts,
@@ -167,12 +163,7 @@ export async function resolveAndResumeStream(
   const isCancellationRequested = (): boolean =>
     ports.isCancellationRequested?.() === true;
 
-  if (
-    isCancellationRequested() ||
-    ports.streamStatus.isActiveOrResuming(streamId)
-  ) {
-    return false;
-  }
+  if (isCancellationRequested()) return false;
 
   try {
     const resolution = await ports.resolveResumeState(streamId);
@@ -199,11 +190,6 @@ export async function resolveAndResumeStream(
       return false;
     }
 
-    // Re-check after the async retrieval window: `resumeInFlight` blocks only a
-    // second resume entry, not a concurrent non-resume run launch that flips
-    // this stream active/resuming while retrieval is awaited.
-    if (ports.streamStatus.isActiveOrResuming(streamId)) return false;
-
     if (resume.type === 'toolUse') {
       return await ports.resumeToolUse(resume, recovery);
     }
@@ -219,12 +205,6 @@ export async function resolveAndResumeStream(
     return true;
   } catch (error) {
     if (isCancellationRequested()) return false;
-    // Shipped hosts that pass the lease guard share this attempt's monotone
-    // cancellation latch, so the preceding check handles their lost-admission
-    // path. Keep this fallback for a future host that supplies the lease guard
-    // without the optional cancellation port: it must still fail silently
-    // rather than toast.
-    if (error instanceof ResumeAdmissionCancelledError) return false;
     try {
       await ports.reportFailure?.(streamId, error);
     } catch {

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -15,7 +15,6 @@ import {
 } from '@shared/schemas';
 import {
   resumeToolUseFromResumeData,
-  ResumeAdmissionCancelledError,
   type SubagentRunOptions,
 } from './executeAgent';
 import { defaultSession } from './SessionHandle';
@@ -30,8 +29,6 @@ export interface ResumeQueuedToolUseOptions extends Pick<
 > {
   /** Recovery ownership synchronously claimed by the submission boundary. */
   readonly recovery?: RecoveryContinuation;
-  /** Recheck canonical admission atomically while acquiring the resumed lease. */
-  readonly canAcquireResumeLease?: () => boolean | Promise<boolean>;
   /** Query a caller-owned stop request at the resumed flow attachment boundary. */
   readonly isCancellationRequested: () => boolean;
   /**
@@ -101,7 +98,6 @@ export async function resumeQueuedToolUseFromResumeData(
   const seed = options.extraFollowUps ?? [];
   let followUps: readonly FollowUpQueueInput[] = seed;
   let cancelledAtFlowAttachment = false;
-  let cancelledBeforeLaunch = false;
   let followUpsRestored = false;
   let resumeError: { error: unknown } | undefined;
   let runResult: AgentRuntimeFlowResult | undefined;
@@ -145,9 +141,6 @@ export async function resumeQueuedToolUseFromResumeData(
       onFollowUpConsumed: () => {
         followUps = [];
       },
-      ...(options.canAcquireResumeLease && {
-        canAcquireResumeLease: options.canAcquireResumeLease,
-      }),
       isCancellationRequested: options.isCancellationRequested,
       onCancellationAtFlowAttachment: () => {
         cancelledAtFlowAttachment = true;
@@ -168,28 +161,19 @@ export async function resumeQueuedToolUseFromResumeData(
     if (followUps.length > 0) restoreFollowUps();
     options.onResult?.(result);
   } catch (error) {
-    cancelledBeforeLaunch = error instanceof ResumeAdmissionCancelledError;
-    if (!cancelledBeforeLaunch) resumeError = { error };
+    resumeError = { error };
     // A rejection before the wait node acknowledges consumption must replay
     // the drained batch. A callback failure after that acknowledgement must
     // not enqueue the same user input again.
-    if (
-      followUps.length > 0 &&
-      (!cancelledBeforeLaunch || session.transcripts.has(streamId))
-    ) {
-      restoreFollowUps();
-    }
+    if (followUps.length > 0) restoreFollowUps();
   } finally {
     // Early failures leave the stream RESUMING. Startup cancellation can
     // instead reach lifecycle terminalization before the queue owner regains
     // control. In both cases, restored input makes WAITING the durable state.
-    // Guarded admission lost to deletion only after canonical removal, whose
-    // process-session cleanup owns status; do not recreate either here.
     if (
-      (!cancelledBeforeLaunch || session.transcripts.has(streamId)) &&
-      (cancelledAtFlowAttachment ||
-        followUpsRestored ||
-        streamStatus.getSubstate(streamId) === STREAM_SUBSTATE.RESUMING)
+      cancelledAtFlowAttachment ||
+      followUpsRestored ||
+      streamStatus.getSubstate(streamId) === STREAM_SUBSTATE.RESUMING
     ) {
       streamStatus.transitionToWaiting(streamId, 'wait');
     }
@@ -201,7 +185,6 @@ export async function resumeQueuedToolUseFromResumeData(
     );
   }
 
-  if (cancelledBeforeLaunch) return false;
   if (!resumeError) {
     return !cancelledAtFlowAttachment && !followUpsRestored;
   }

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -2,9 +2,7 @@ import { registerExecution } from '@agent/storage';
 import { clearTerminalExecutionState } from '@agent/storage/executionLifecycle';
 import {
   acquireResumedExecutionLease,
-  captureOwnedExecutionLease,
   markOwnedExecutionLeaseUndurable,
-  type OwnedExecutionLeaseScope,
 } from '@agent/storage/executionLease';
 import { finalizeExecutionWithLease } from '@agent/storage/terminalPersistence';
 
@@ -19,11 +17,7 @@ import {
 } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core';
 import { applyHelperModelPreference } from './helperModelPreference';
-import {
-  executeAgent,
-  ResumeAdmissionCancelledError,
-  type ExecuteAgentOptions,
-} from './executeAgent';
+import { executeAgent, type ExecuteAgentOptions } from './executeAgent';
 import { AgentExecutionHandle } from './ExecutionHandle';
 import { getStreamTabId } from './streamTab';
 import { defaultSession } from './SessionHandle';
@@ -57,13 +51,8 @@ export interface RunAgentOptions extends Pick<
    * true when the hook already drained artifacts and disposed of ownership.
    */
   beforeLeaseRelease?: () => Promise<boolean | void>;
-  /** Bind host callbacks that may run outside the agent's async context. */
-  onExecutionLeaseAcquired?: (
-    scope: OwnedExecutionLeaseScope,
-    executionId: ExecutionId,
-  ) => void;
-  /** Recheck canonical admission atomically while acquiring a resumed lease. */
-  canAcquireResumeLease?: () => boolean | Promise<boolean>;
+  /** Fires once this run owns its execution lease. */
+  onExecutionLeaseAcquired?: (executionId: ExecutionId) => void;
   /**
    * Opt-in set by the "fix LaTeX" VS Code actions (Fix-Compilation command, the
    * progress-view compile fixer): run the launched agent on the configured
@@ -107,7 +96,6 @@ export async function runAgent(
   const {
     beforeLeaseRelease,
     onExecutionLeaseAcquired,
-    canAcquireResumeLease,
     preferHelperModel,
     ...executeAgentOptions
   } = options;
@@ -139,140 +127,141 @@ export async function runAgent(
   });
   if (launchHandle) runSession.executions.track(launchHandle);
 
+  // The launch handle above is tracked synchronously so a stop can reach the
+  // launch; the generation itself starts on the execution's lane, after any
+  // previous generation of this id has disposed.
   try {
-    // Resolved before registerExecution so the stored record and the run agree
-    // on the model.
-    const config = preferHelperModel
-      ? await applyHelperModelPreference(request.config)
-      : request.config;
+    return await runSession.executions.launchExecution(
+      executionId,
+      async () => {
+        // Resolved before registerExecution so the stored record and the run agree
+        // on the model.
+        const config = preferHelperModel
+          ? await applyHelperModelPreference(request.config)
+          : request.config;
 
-    const userFollowUpSupport =
-      config.agentCategory === AgentCategory.ToolUse &&
-      executeAgentOptions.stopAfterCycle !== true
-        ? USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE
-        : USER_FOLLOW_UP_SUPPORT.UNSUPPORTED;
+        const userFollowUpSupport =
+          config.agentCategory === AgentCategory.ToolUse &&
+          executeAgentOptions.stopAfterCycle !== true
+            ? USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE
+            : USER_FOLLOW_UP_SUPPORT.UNSUPPORTED;
 
-    if (shouldRegister) {
-      await registerExecution(executionId, config, config.agent, {
-        streamId: getStreamTabId(config.agent, { executionId }),
-        identity: { kind: 'agent', agent: config.agent },
-        userFollowUpSupport,
-      });
-    } else {
-      const lease = await acquireResumedExecutionLease(
-        executionId,
-        canAcquireResumeLease,
-      );
-      if (lease === 'cancelled') {
-        throw new ResumeAdmissionCancelledError(executionId);
-      }
-    }
-
-    const runWithOwnership = captureOwnedExecutionLease(executionId);
-    onExecutionLeaseAcquired?.(runWithOwnership, executionId);
-    return await runWithOwnership(async () => {
-      let lifecycleStarted = false;
-      let runResult: AgentFlowResult | undefined;
-      let runFailure: { error: unknown } | undefined;
-      let finalArtifactsHandled = false;
-      let previousTerminalOutcome: RunOutcome | undefined;
-      let resumedStreamId: StreamTabId | undefined;
-      const callerOnRun = executeAgentOptions.onRun;
-      try {
-        // A resumed execution is no longer described by the terminal facts its
-        // previous run persisted; drop them before this run writes anything a
-        // reader would project them onto.
-        if (!shouldRegister) {
-          const cleared = await clearTerminalExecutionState(executionId);
-          resumedStreamId = cleared.streamId;
-          previousTerminalOutcome = cleared.previousOutcome;
-        }
-        const result = await executeAgent(config, executionId, {
-          ...executeAgentOptions,
-          launchSignal,
-          // Forward the session resolved above: without it the launch context
-          // redefaults to the ambient `currentSession()`, which can disagree
-          // with the lease handling's `runSession` inside another run's async
-          // context.
-          session: runSession,
-          streamTabIdOverride: resumedStreamId,
-          userFollowUpSupport,
-          onRun: async (handle) => {
-            lifecycleStarted = true;
-            await callerOnRun?.(handle);
-          },
-        });
-        runResult = result;
-      } catch (error) {
-        runFailure = { error };
-        const restoredOutcome = shouldRegister
-          ? RUN_OUTCOME.FAILED
-          : previousTerminalOutcome;
-        if (!lifecycleStarted && restoredOutcome !== undefined) {
-          // finalizeExecutionWithLease already marks the owned lease undurable
-          // when the terminal status did not reach disk; this site only needs
-          // to fold the persistence error into the run failure.
-          const finalization = await finalizeExecutionWithLease({
-            executionId,
-            outcome: restoredOutcome,
-            flowRecord: shouldRegister ? 'delete' : 'preserve',
+        if (shouldRegister) {
+          await registerExecution(executionId, config, config.agent, {
+            streamId: getStreamTabId(config.agent, { executionId }),
+            identity: { kind: 'agent', agent: config.agent },
+            userFollowUpSupport,
           });
-          if (finalization.status === 'failed') {
-            runFailure = {
-              error: new AggregateError(
-                [error, finalization.error],
-                `Execution ${executionId} failed before lifecycle startup and its terminal status could not be persisted`,
-              ),
-            };
+        } else {
+          await acquireResumedExecutionLease(executionId);
+        }
+
+        onExecutionLeaseAcquired?.(executionId);
+        let lifecycleStarted = false;
+        let runResult: AgentFlowResult | undefined;
+        let runFailure: { error: unknown } | undefined;
+        let finalArtifactsHandled = false;
+        let previousTerminalOutcome: RunOutcome | undefined;
+        let resumedStreamId: StreamTabId | undefined;
+        const callerOnRun = executeAgentOptions.onRun;
+        try {
+          // A resumed execution is no longer described by the terminal facts its
+          // previous run persisted; drop them before this run writes anything a
+          // reader would project them onto.
+          if (!shouldRegister) {
+            const cleared = await clearTerminalExecutionState(executionId);
+            resumedStreamId = cleared.streamId;
+            previousTerminalOutcome = cleared.previousOutcome;
+          }
+          const result = await executeAgent(config, executionId, {
+            ...executeAgentOptions,
+            launchSignal,
+            // Forward the session resolved above: without it the launch context
+            // redefaults to the ambient `currentSession()`, which can disagree
+            // with the lease handling's `runSession` inside another run's async
+            // context.
+            session: runSession,
+            streamTabIdOverride: resumedStreamId,
+            userFollowUpSupport,
+            onRun: async (handle) => {
+              lifecycleStarted = true;
+              await callerOnRun?.(handle);
+            },
+          });
+          runResult = result;
+        } catch (error) {
+          runFailure = { error };
+          const restoredOutcome = shouldRegister
+            ? RUN_OUTCOME.FAILED
+            : previousTerminalOutcome;
+          if (!lifecycleStarted && restoredOutcome !== undefined) {
+            // finalizeExecutionWithLease already marks the owned lease undurable
+            // when the terminal status did not reach disk; this site only needs
+            // to fold the persistence error into the run failure.
+            const finalization = await finalizeExecutionWithLease({
+              executionId,
+              outcome: restoredOutcome,
+              flowRecord: shouldRegister ? 'delete' : 'preserve',
+            });
+            if (finalization.status === 'failed') {
+              runFailure = {
+                error: new AggregateError(
+                  [error, finalization.error],
+                  `Execution ${executionId} failed before lifecycle startup and its terminal status could not be persisted`,
+                ),
+              };
+            }
           }
         }
-      }
 
-      const artifactFailures: unknown[] = [];
-      try {
-        finalArtifactsHandled = (await beforeLeaseRelease?.()) === true;
-      } catch (error) {
-        artifactFailures.push(error);
-        // Host-owned final state failed to persist: poison the lease so the
-        // drain below completes as abandon rather than releasing a record
-        // whose host-side artifacts are not durable.
-        markOwnedExecutionLeaseUndurable(executionId);
-      }
-      if (!finalArtifactsHandled) {
-        // A failed host hook may already have abandoned ownership. Still try
-        // the ordinary drain: callbacks can also fail before touching session
-        // artifacts, and preserving those artifacts is worth the attempt. If
-        // ownership is gone, the resulting lease-lost error remains secondary
-        // to the host hook's original failure in the aggregate below.
+        const artifactFailures: unknown[] = [];
         try {
-          await runSession.releaseExecutionLease(executionId);
+          finalArtifactsHandled = (await beforeLeaseRelease?.()) === true;
         } catch (error) {
           artifactFailures.push(error);
+          // Host-owned final state failed to persist: poison the lease so the
+          // drain below completes as abandon rather than releasing a record
+          // whose host-side artifacts are not durable.
+          markOwnedExecutionLeaseUndurable(executionId);
         }
-      }
+        if (!finalArtifactsHandled) {
+          // A failed host hook may already have abandoned ownership. Still try
+          // the ordinary drain: callbacks can also fail before touching session
+          // artifacts, and preserving those artifacts is worth the attempt. If
+          // ownership is gone, the resulting lease-lost error remains secondary
+          // to the host hook's original failure in the aggregate below.
+          try {
+            await runSession.releaseExecutionLease(executionId);
+          } catch (error) {
+            artifactFailures.push(error);
+          }
+        }
 
-      if (artifactFailures.length > 0) {
-        const artifactFailure =
-          artifactFailures.length === 1
-            ? artifactFailures[0]
-            : new AggregateError(
-                artifactFailures,
-                `Execution ${executionId} has multiple final artifact failures`,
-              );
-        if (runFailure) {
-          throw new AggregateError(
-            [runFailure.error, artifactFailure],
-            `Execution ${executionId} failed and its final artifacts could not be persisted`,
+        if (artifactFailures.length > 0) {
+          const artifactFailure =
+            artifactFailures.length === 1
+              ? artifactFailures[0]
+              : new AggregateError(
+                  artifactFailures,
+                  `Execution ${executionId} has multiple final artifact failures`,
+                );
+          if (runFailure) {
+            throw new AggregateError(
+              [runFailure.error, artifactFailure],
+              `Execution ${executionId} failed and its final artifacts could not be persisted`,
+            );
+          }
+          throw artifactFailure;
+        }
+        if (runFailure) throw runFailure.error;
+        if (!runResult) {
+          throw new Error(
+            `Execution ${executionId} finished without a result.`,
           );
         }
-        throw artifactFailure;
-      }
-      if (runFailure) throw runFailure.error;
-      if (!runResult) {
-        throw new Error(`Execution ${executionId} finished without a result.`);
-      }
-      return runResult;
-    });
+        return runResult;
+      },
+    );
   } finally {
     detachLaunchInterrupt?.();
     if (

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -30,7 +30,7 @@ interface GoalEntryStore {
   forget(stream: StreamTabId): Promise<void>;
 }
 
-/** The one execution-lifecycle step a stream deletion needs: wait its turn. */
+/** The execution-lifecycle lane a stream deletion runs on as its own step. */
 export interface ExecutionLifecycleLane {
   runExecutionStep<T>(executionId: string, step: () => Promise<T>): Promise<T>;
 }
@@ -39,10 +39,11 @@ export interface SessionStoresOptions {
   streamLogs: StreamLogStore;
   snapshots: StreamSnapshotStore;
   /**
-   * The session's per-execution lifecycle lanes. A deletion takes a step on
-   * the stream's execution lane before it touches storage, so it cannot run
-   * under a live or still-disposing generation of that execution. Absent only
-   * for stores with no registry to serialize against.
+   * The session's per-execution lifecycle lanes. A deletion runs as a step on
+   * the stream's execution lane, so it cannot run under a live or
+   * still-disposing generation of that execution and no generation starts
+   * until it has landed. Absent only for stores with no registry to serialize
+   * against.
    */
   executions?: ExecutionLifecycleLane;
   deleteExecution?: DeleteExecutionFn;
@@ -130,18 +131,6 @@ export class SessionStores {
   }
 
   /**
-   * Take the next step on the stream's execution lane: resolves once every
-   * earlier lifecycle step of that execution has returned and its live
-   * generation, if any, has disposed. A stream with no execution resolves at
-   * once.
-   */
-  async waitForExecutionQuiescence(stream: StreamTabId): Promise<void> {
-    const executionId = await this.executionIdForStream(stream);
-    if (!executionId || !this.executions) return;
-    await this.executions.runExecutionStep(executionId, async () => undefined);
-  }
-
-  /**
    * Claim presentation ownership before deletion preparation reaches its
    * first await. The process-level desktop fallback uses this synchronous
    * signal to distinguish a live projection from a genuinely headless run.
@@ -180,6 +169,14 @@ export class SessionStores {
     return !!this.streamDeletionClaims.get(stream)?.size;
   }
 
+  /**
+   * Delete a stream as a lifecycle step of its execution's lane: the deletion
+   * starts once every earlier step has returned and the live generation, if
+   * any, has disposed, and no generation can start until it has landed. A
+   * stream with no execution is deleted without a lane. The lane is taken
+   * before the deletion queue, so a deletion waiting on a disposing generation
+   * does not hold up the queue's other work (`deleteAll`, the snapshot flush).
+   */
   deleteStream(
     stream: StreamTabId,
     options?: {
@@ -187,10 +184,42 @@ export class SessionStores {
       readonly expectedIncarnation?: number;
     },
   ): Promise<DeleteStreamResult> {
-    return this.trackStreamDeletion(stream, options?.expectedIncarnation, () =>
-      this.enqueueDeletion(() =>
-        this.deleteStreamAndNotify(stream, options?.shouldDelete),
-      ),
+    return this.trackStreamDeletion(
+      stream,
+      options?.expectedIncarnation,
+      async () => {
+        let executionId: ExecutionId | undefined;
+        try {
+          executionId = await this.executionIdForStream(stream);
+        } catch (error) {
+          log.warn(
+            `Stream ${stream} was retained because its execution ownership could not be read: ${toErrorMessage(error)}`,
+            { data: error },
+          );
+          return 'failed';
+        }
+        const deletion = (): Promise<DeleteStreamResult> =>
+          this.enqueueDeletion(() =>
+            this.deleteStreamAndNotify(
+              stream,
+              executionId,
+              options?.shouldDelete,
+            ),
+          );
+        if (!executionId || !this.executions) return deletion();
+        try {
+          return await this.executions.runExecutionStep(executionId, deletion);
+        } catch (error) {
+          // `deleteStreamAndNotify` reports through its result, so a throw is
+          // the lane refusing the step: the session disposed, or a storage-root
+          // change holds the lifecycle.
+          log.warn(
+            `Stream ${stream} was retained because its execution lane refused the deletion: ${toErrorMessage(error)}`,
+            { data: error },
+          );
+          return 'failed';
+        }
+      },
     );
   }
 
@@ -206,38 +235,6 @@ export class SessionStores {
       await this.deleteStreamSidecars(stream);
       if (hadCanonicalStream) await this.notifyDeleted(stream);
     });
-  }
-
-  deleteStreamAfterExecutionQuiescence(
-    stream: StreamTabId,
-    options?: {
-      readonly shouldDelete?: () => boolean;
-      readonly expectedIncarnation?: number;
-    },
-  ): Promise<DeleteStreamResult> {
-    return this.trackStreamDeletion(
-      stream,
-      options?.expectedIncarnation,
-      async () => {
-        // Track the whole wait so a presentation attaching during terminal
-        // artifact persistence cannot replay a stream already marked removed.
-        // If the ownership read fails here, report `failed` immediately rather
-        // than enqueueing a second read that could decide the stream has no
-        // execution and delete it.
-        try {
-          await this.waitForExecutionQuiescence(stream);
-        } catch (error) {
-          log.warn(
-            `Stream ${stream} was retained because its execution ownership could not be read: ${toErrorMessage(error)}`,
-            { data: error },
-          );
-          return 'failed';
-        }
-        return this.enqueueDeletion(() =>
-          this.deleteStreamAndNotify(stream, options?.shouldDelete),
-        );
-      },
-    );
   }
 
   private trackStreamDeletion(
@@ -261,11 +258,16 @@ export class SessionStores {
 
   private async deleteStreamAndNotify(
     stream: StreamTabId,
+    executionId: ExecutionId | undefined,
     shouldDelete?: () => boolean,
   ): Promise<DeleteStreamResult> {
     if (shouldDelete?.() === false) return 'superseded';
     const hadCanonicalStream = this.streamLogs.has(stream);
-    const result = await this.deleteStreamOnce(stream, shouldDelete);
+    const result = await this.deleteStreamOnce(
+      stream,
+      executionId,
+      shouldDelete,
+    );
     if (result === 'deleted' && hadCanonicalStream) {
       // Re-check immediately before the canonical-deleted notify: a re-claim
       // landing during the goal-forget await (inside `deleteStreamOnce`) must
@@ -356,22 +358,10 @@ export class SessionStores {
 
   private async deleteStreamOnce(
     stream: StreamTabId,
+    executionId: ExecutionId | undefined,
     shouldDelete?: () => boolean,
   ): Promise<DeleteStreamResult> {
     if (!canUseStreamDataDir(stream)) return 'deleted';
-    if (shouldDelete?.() === false) return 'superseded';
-
-    let executionId: ExecutionId | undefined;
-    try {
-      executionId = await this.executionIdForStream(stream);
-    } catch (error) {
-      log.warn(
-        `Stream ${stream} was retained because its execution ownership could not be read: ${toErrorMessage(error)}`,
-        { data: error },
-      );
-      return 'failed';
-    }
-
     if (shouldDelete?.() === false) return 'superseded';
 
     if (!executionId) {

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -9,7 +9,6 @@ import {
   type DeleteExecutionResult,
   type ExecutionStreamReference,
 } from '@agent/storage/executionListing';
-import { waitForOwnedExecutionLeaseRelease } from '@agent/storage/executionLease';
 import { createLog } from '@logger/logUtils';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import type { StreamLogStore, StreamSnapshotStore } from '@transcript';
@@ -32,9 +31,21 @@ interface GoalEntryStore {
   forget(stream: StreamTabId): Promise<void>;
 }
 
+/** The one execution-lifecycle step a stream deletion needs: wait its turn. */
+export interface ExecutionLifecycleLane {
+  runExecutionStep<T>(executionId: string, step: () => Promise<T>): Promise<T>;
+}
+
 export interface SessionStoresOptions {
   streamLogs: StreamLogStore;
   snapshots: StreamSnapshotStore;
+  /**
+   * The session's per-execution lifecycle lanes. A deletion takes a step on
+   * the stream's execution lane before it touches storage, so it cannot run
+   * under a live or still-disposing generation of that execution. Absent only
+   * for stores with no registry to serialize against.
+   */
+  executions?: ExecutionLifecycleLane;
   deleteExecution?: DeleteExecutionFn;
   listExecutionStreamReferences?: ListExecutionStreamReferencesFn;
   goalEntries?: GoalEntryStore;
@@ -78,6 +89,7 @@ type ExecutionDeletionOutcome =
 export class SessionStores {
   private readonly streamLogs: StreamLogStore;
   private readonly snapshots: StreamSnapshotStore;
+  private readonly executions: ExecutionLifecycleLane | undefined;
   private readonly deleteExecution: DeleteExecutionFn;
   private readonly listExecutionStreamReferences: ListExecutionStreamReferencesFn;
   private readonly goalEntries: GoalEntryStore | undefined;
@@ -109,6 +121,7 @@ export class SessionStores {
   constructor(options: SessionStoresOptions) {
     this.streamLogs = options.streamLogs;
     this.snapshots = options.snapshots;
+    this.executions = options.executions;
     this.deleteExecution = options.deleteExecution ?? deleteStoredExecution;
     this.listExecutionStreamReferences =
       options.listExecutionStreamReferences ?? listExecutionStreamReferences;
@@ -117,9 +130,16 @@ export class SessionStores {
     this.onChildrenDetached = options.onChildrenDetached;
   }
 
-  async waitForOwnedExecutionRelease(stream: StreamTabId): Promise<void> {
+  /**
+   * Take the next step on the stream's execution lane: resolves once every
+   * earlier lifecycle step of that execution has returned and its live
+   * generation, if any, has disposed. A stream with no execution resolves at
+   * once.
+   */
+  async waitForExecutionQuiescence(stream: StreamTabId): Promise<void> {
     const executionId = await this.executionIdForStream(stream);
-    if (executionId) await waitForOwnedExecutionLeaseRelease(executionId);
+    if (!executionId || !this.executions) return;
+    await this.executions.runExecutionStep(executionId, async () => undefined);
   }
 
   /**
@@ -189,7 +209,7 @@ export class SessionStores {
     });
   }
 
-  deleteStreamAfterOwnedExecutionRelease(
+  deleteStreamAfterExecutionQuiescence(
     stream: StreamTabId,
     options?: {
       readonly shouldDelete?: () => boolean;
@@ -206,7 +226,7 @@ export class SessionStores {
         // than enqueueing a second read that could decide the stream has no
         // execution and delete it.
         try {
-          await this.waitForOwnedExecutionRelease(stream);
+          await this.waitForExecutionQuiescence(stream);
         } catch (error) {
           log.warn(
             `Stream ${stream} was retained because its execution ownership could not be read: ${toErrorMessage(error)}`,

--- a/src/agent/storage/childRunDeliveryPersistence.ts
+++ b/src/agent/storage/childRunDeliveryPersistence.ts
@@ -1,11 +1,18 @@
-/** Best-effort persistence of the artifacts delivered by a child run. */
+/**
+ * Best-effort persistence of the artifacts delivered by a child run. A lost
+ * execution lease is not a best-effort failure: the run has been displaced
+ * and must stop, so that one error propagates.
+ */
 import type { ExecutionId } from '@shared/schemas';
 
 import {
   persistChildRunReport,
   persistChildRunResultMeta,
 } from './childRunPersistence';
-import { markOwnedExecutionLeaseUndurable } from './executionLease';
+import {
+  ExecutionLeaseLostError,
+  markOwnedExecutionLeaseUndurable,
+} from './executionLease';
 import type { ResultMeta } from './resultMeta';
 
 export async function persistChildRunDeliveryBestEffort(
@@ -25,6 +32,7 @@ export async function persistChildRunDeliveryBestEffort(
     ['result manifest', manifest],
   ] as const) {
     if (result.kind !== 'failed') continue;
+    if (result.err instanceof ExecutionLeaseLostError) throw result.err;
     markOwnedExecutionLeaseUndurable(executionId);
     onFailure(kind, result.err);
   }

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -2,8 +2,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { randomUUID } from 'node:crypto';
 import * as path from 'node:path';
 
-import pDefer, { type DeferredPromise } from 'p-defer';
-import PQueue from 'p-queue';
+import pDefer from 'p-defer';
 import { z } from 'zod';
 
 import { isFileExistsError, isFileNotFoundError } from '@common/errors';
@@ -67,7 +66,6 @@ interface OwnedExecutionLease {
   readonly storageRoot: string;
   readonly released: Promise<void>;
   readonly resolveReleased: () => void;
-  readonly lossListeners: Set<() => void>;
   releasing: boolean;
   durabilityFailed: boolean;
 }
@@ -112,10 +110,6 @@ export type OwnedExecutionLeaseCompletion =
       readonly error: unknown;
     };
 
-export type OwnedExecutionLeaseScope = <T>(
-  operation: () => T | Promise<T>,
-) => T | Promise<T>;
-
 export class ExecutionLeaseActiveError extends Error {
   constructor(
     readonly executionId: ExecutionId,
@@ -140,104 +134,7 @@ export class ExecutionLeaseLostError extends Error {
 }
 
 const ownedLeases = new Map<string, OwnedExecutionLease>();
-const executionOwnership = new AsyncLocalStorage<ReadonlyMap<string, string>>();
 const maintenanceExecutions = new AsyncLocalStorage<ReadonlySet<string>>();
-
-class ExecutionLeaseCoordination {
-  private acquisitionsInFlight = 0;
-  private readonly acquisitionIdleWaiters = new Set<() => void>();
-  private readonly maintenanceQueue = new PQueue({ concurrency: 1 });
-  private pendingMaintenanceCount = 0;
-  private maintenanceBarrier: DeferredPromise<void> | undefined;
-
-  async enterAcquisition(nested: boolean): Promise<void> {
-    if (!nested) {
-      while (this.maintenanceBarrier) await this.maintenanceBarrier.promise;
-    }
-    this.acquisitionsInFlight += 1;
-  }
-
-  leaveAcquisition(): void {
-    this.acquisitionsInFlight -= 1;
-    if (this.acquisitionsInFlight !== 0) return;
-    for (const resolve of this.acquisitionIdleWaiters) resolve();
-    this.acquisitionIdleWaiters.clear();
-  }
-
-  async waitForAcquisitions(): Promise<void> {
-    if (this.acquisitionsInFlight === 0) return;
-    await new Promise<void>((resolve) =>
-      this.acquisitionIdleWaiters.add(resolve),
-    );
-  }
-
-  runMaintenance<T>(
-    waitForQuiescence: () => Promise<void>,
-    operation: () => T | Promise<T>,
-  ): Promise<T> {
-    this.pendingMaintenanceCount += 1;
-    if (!this.maintenanceBarrier) {
-      this.maintenanceBarrier = pDefer<void>();
-    }
-    // `add` widens to `T | void` for abort/timeout options; neither is used.
-    const queued = this.maintenanceQueue.add(async () => {
-      await waitForQuiescence();
-      return operation();
-    }) as Promise<T>;
-    return queued.finally(() => {
-      this.pendingMaintenanceCount -= 1;
-      if (this.pendingMaintenanceCount !== 0) return;
-      const barrier = this.maintenanceBarrier;
-      this.maintenanceBarrier = undefined;
-      barrier?.resolve();
-    });
-  }
-
-  assertIdle(): void {
-    if (
-      this.acquisitionsInFlight !== 0 ||
-      this.pendingMaintenanceCount !== 0 ||
-      this.maintenanceQueue.pending !== 0 ||
-      this.maintenanceQueue.size !== 0 ||
-      this.acquisitionIdleWaiters.size !== 0
-    ) {
-      throw new Error('Execution lease coordination is still active.');
-    }
-  }
-}
-
-let leaseCoordination = new ExecutionLeaseCoordination();
-
-/** Replace tested coordination state after every isolated test case. */
-export function resetExecutionLeaseCoordinationForTests(): void {
-  leaseCoordination.assertIdle();
-  leaseCoordination = new ExecutionLeaseCoordination();
-}
-
-async function waitForOwnedLeaseQuiescence(): Promise<void> {
-  for (;;) {
-    await leaseCoordination.waitForAcquisitions();
-    const releases = [...ownedLeases.values()].map((lease) => lease.released);
-    if (releases.length === 0) return;
-    await Promise.all(releases);
-  }
-}
-
-/**
- * Run storage-root maintenance after all execution artifacts are durable.
- *
- * New root executions wait outside the barrier. Nested work already owned by
- * a live execution remains admitted so maintenance cannot deadlock a parent
- * waiting for its child; the loop includes every such acquisition and lease.
- */
-export function runWithOwnedExecutionLeaseQuiescence<T>(
-  operation: () => T | Promise<T>,
-): Promise<T> {
-  return leaseCoordination.runMaintenance(
-    waitForOwnedLeaseQuiescence,
-    operation,
-  );
-}
 
 function storageRoot(): string {
   return platform().storage.getStoragePath();
@@ -245,16 +142,6 @@ function storageRoot(): string {
 
 function ownershipKey(root: string, executionId: ExecutionId): string {
   return `${root}\0${executionId}`;
-}
-
-/** Prevent an execution-owned continuation from acting on a later generation. */
-function currentScopeOwnsLease(lease: OwnedExecutionLease): boolean {
-  const ownership = executionOwnership.getStore();
-  return (
-    ownership === undefined ||
-    ownership.get(ownershipKey(lease.storageRoot, lease.executionId)) ===
-      lease.ownerToken
-  );
 }
 
 function leaseDir(root: string): string {
@@ -378,7 +265,6 @@ async function retireLegacyLease(
 
 type ClaimOutcome =
   | { readonly status: 'claimed'; readonly record: ExecutionLeaseRecord }
-  | { readonly status: 'cancelled' }
   | LeaseHeld;
 
 /**
@@ -386,25 +272,12 @@ type ClaimOutcome =
  * lost race: nothing present means create; a dead owner means retire then
  * create; a retired-protocol record means retire and look again. An owner
  * that is alive, or whose liveness cannot be proven, refuses the claim
- * outright. `admit` runs at most once, just before the first create attempt,
- * so an admission that is withdrawn never leaves a record behind — a claim
- * made without one can therefore never be cancelled.
+ * outright.
  */
-function claimLease(
-  executionId: ExecutionId,
-  root: string,
-): Promise<Exclude<ClaimOutcome, { readonly status: 'cancelled' }>>;
-function claimLease(
-  executionId: ExecutionId,
-  root: string,
-  admit: (() => boolean | Promise<boolean>) | undefined,
-): Promise<ClaimOutcome>;
 async function claimLease(
   executionId: ExecutionId,
   root: string,
-  admit?: () => boolean | Promise<boolean>,
 ): Promise<ClaimOutcome> {
-  let admitted = admit === undefined;
   for (let round = 0; round < MAX_CLAIM_ROUNDS; round += 1) {
     const current = await readStoredLease(executionId, root);
     if (current === 'tombstone') {
@@ -420,10 +293,6 @@ async function claimLease(
           provable: liveness === 'alive',
         };
       }
-    }
-    if (!admitted) {
-      if ((await admit?.()) === false) return { status: 'cancelled' };
-      admitted = true;
     }
     if (
       current &&
@@ -469,26 +338,11 @@ async function unlinkOwnRecord(
   await StorageFS.delete(leasePath(root, executionId));
 }
 
-function forgetOwnedLease(
-  lease: OwnedExecutionLease,
-  options: { notifyLoss?: boolean } = {},
-): void {
+function forgetOwnedLease(lease: OwnedExecutionLease): void {
   const key = ownershipKey(lease.storageRoot, lease.executionId);
   if (ownedLeases.get(key) === lease) {
     ownedLeases.delete(key);
     lease.resolveReleased();
-    if (options.notifyLoss) {
-      for (const listener of lease.lossListeners) {
-        try {
-          listener();
-        } catch (error) {
-          log.warn('Execution lease-loss listener failed', {
-            data: { executionId: lease.executionId, error },
-          });
-        }
-      }
-    }
-    lease.lossListeners.clear();
   }
 }
 
@@ -504,37 +358,35 @@ function rememberOwnership(
     storageRoot: root,
     released,
     resolveReleased,
-    lossListeners: new Set(),
     releasing: false,
     durabilityFailed: false,
   });
 }
 
-/** Interrupt a live runtime if its ownership record is found displaced. */
-export function onOwnedExecutionLeaseLost(
-  executionId: ExecutionId,
-  listener: () => void,
-): () => void {
-  const leases = [...ownedLeases.values()].filter(
-    (lease) => lease.executionId === executionId,
-  );
-  for (const lease of leases) lease.lossListeners.add(listener);
-  return () => {
-    for (const lease of leases) lease.lossListeners.delete(listener);
-  };
+/** Whether this process owns the lease in the active storage root. */
+export function ownsExecutionLease(executionId: ExecutionId): boolean {
+  const lease = ownedLeases.get(ownershipKey(storageRoot(), executionId));
+  return lease !== undefined && !lease.releasing;
 }
 
-/** Whether this process still owns the lease in the active storage root. */
-export function ownsExecutionLease(executionId: ExecutionId): boolean {
-  const key = ownershipKey(storageRoot(), executionId);
-  const lease = ownedLeases.get(key);
-  return lease !== undefined && currentScopeOwnsLease(lease);
+/**
+ * Fail fast when this process does not own `executionId`, or is giving it up.
+ * Generations of one execution are serialized by the registry's per-execution
+ * lane, so the owned record for an id is always the generation doing the
+ * asking; no async-context capture is needed to tell generations apart.
+ */
+export function assertOwnedExecutionLease(executionId: ExecutionId): void {
+  if (!ownsExecutionLease(executionId)) {
+    throw new ExecutionLeaseLostError(executionId);
+  }
 }
 
 /**
  * The write fence: the in-process token is compared against the on-disk
  * record before the operation runs. A record that names anyone else means
- * this process was displaced and must not write.
+ * this process was displaced and must not write. A record removed out of
+ * band under a live run is accepted as tampering: the run learns of it here,
+ * at its next fenced write, and aborts dirty; nothing watches the file.
  */
 async function runWithValidatedOwnership<T>(
   lease: OwnedExecutionLease,
@@ -542,56 +394,10 @@ async function runWithValidatedOwnership<T>(
 ): Promise<T> {
   const current = await readStoredLease(lease.executionId, lease.storageRoot);
   if (current === 'tombstone' || current?.ownerToken !== lease.ownerToken) {
-    forgetOwnedLease(lease, { notifyLoss: true });
+    forgetOwnedLease(lease);
     throw new ExecutionLeaseLostError(lease.executionId);
   }
   return operation();
-}
-
-/**
- * Carry this process's exact lease generation through asynchronous run work,
- * so a delayed lifecycle root cannot borrow its successor. A continuation from
- * a displaced owner keeps its original token and cannot borrow a later local
- * owner's lease for the same execution id.
- */
-export function captureOwnedExecutionLease(
-  executionId: ExecutionId,
-): OwnedExecutionLeaseScope {
-  const root = storageRoot();
-  const key = ownershipKey(root, executionId);
-  const lease = ownedLeases.get(key);
-  if (!lease || lease.releasing) {
-    throw new ExecutionLeaseLostError(executionId);
-  }
-  const currentOwnership = executionOwnership.getStore();
-  const currentOwnerToken = currentOwnership?.get(key);
-  if (
-    currentOwnerToken !== undefined &&
-    currentOwnerToken !== lease.ownerToken
-  ) {
-    throw new ExecutionLeaseLostError(executionId);
-  }
-  const ownerToken = lease.ownerToken;
-  return <T>(operation: () => T | Promise<T>): T | Promise<T> => {
-    const currentLease = ownedLeases.get(key);
-    if (currentLease?.ownerToken !== ownerToken || currentLease.releasing) {
-      throw new ExecutionLeaseLostError(executionId);
-    }
-    const ownership = new Map(executionOwnership.getStore());
-    ownership.set(key, ownerToken);
-    return executionOwnership.run(ownership, operation);
-  };
-}
-
-/** Return undefined only for an unleased run; stale ambient ownership throws. */
-export function captureOwnedExecutionLeaseIfPresent(
-  executionId: ExecutionId,
-): OwnedExecutionLeaseScope | undefined {
-  const key = ownershipKey(storageRoot(), executionId);
-  const hasAmbientOwnership = executionOwnership.getStore()?.has(key) ?? false;
-  return hasAmbientOwnership || ownsExecutionLease(executionId)
-    ? captureOwnedExecutionLease(executionId)
-    : undefined;
 }
 
 /**
@@ -603,7 +409,7 @@ export async function validateOwnedExecutionLease(
 ): Promise<void> {
   const key = ownershipKey(storageRoot(), executionId);
   const lease = ownedLeases.get(key);
-  if (!lease || lease.releasing || !currentScopeOwnsLease(lease)) {
+  if (!lease || lease.releasing) {
     throw new ExecutionLeaseLostError(executionId);
   }
   await runWithValidatedOwnership(lease, async () => undefined);
@@ -627,16 +433,7 @@ export async function runWithExecutionLeaseWriteFence<T>(
   const key = ownershipKey(root, executionId);
   if (maintenanceExecutions.getStore()?.has(key)) return operation();
   const lease = ownedLeases.get(key);
-  const ownerToken = executionOwnership.getStore()?.get(key);
-  if (lease && ownerToken === undefined) {
-    throw new ExecutionLeaseLostError(executionId);
-  }
-  if (
-    ownerToken !== undefined &&
-    (lease?.ownerToken !== ownerToken || lease.releasing)
-  ) {
-    throw new ExecutionLeaseLostError(executionId);
-  }
+  if (lease?.releasing) throw new ExecutionLeaseLostError(executionId);
   if (lease) return runWithValidatedOwnership(lease, operation);
   const current = await readStoredLease(executionId, root);
   if (current === 'tombstone') await retireLegacyLease(executionId, root);
@@ -644,68 +441,42 @@ export async function runWithExecutionLeaseWriteFence<T>(
   return operation();
 }
 
-function acquireExecutionLease(
-  executionId: ExecutionId,
-  mode: 'fresh',
-): Promise<'acquired' | 'existing'>;
-function acquireExecutionLease(
-  executionId: ExecutionId,
-  mode: 'resume',
-  canAcquire?: () => boolean | Promise<boolean>,
-): Promise<'acquired' | 'existing' | 'cancelled'>;
 async function acquireExecutionLease(
   executionId: ExecutionId,
   mode: 'fresh' | 'resume',
-  canAcquire?: () => boolean | Promise<boolean>,
-): Promise<'acquired' | 'existing' | 'cancelled'> {
-  // An existing owned run may need to launch a child before it can settle.
-  // Root launches wait; nested launches remain admitted and are included in
-  // the dynamic quiescence check in waitForOwnedLeaseQuiescence.
-  await leaseCoordination.enterAcquisition(
-    (executionOwnership.getStore()?.size ?? 0) > 0,
-  );
-  try {
-    const root = storageRoot();
-    const key = ownershipKey(root, executionId);
-    const existingOwnership = ownedLeases.get(key);
-    if (mode === 'resume' && existingOwnership) {
-      if (existingOwnership.releasing) {
-        // A release in flight settles the record either way; re-acquire from
-        // persisted state below instead of resurrecting the closing lease.
-        await existingOwnership.released;
-      } else {
-        const current = await readStoredLease(executionId, root);
-        if (
-          current !== 'tombstone' &&
-          current?.ownerToken === existingOwnership.ownerToken
-        ) {
-          if ((await canAcquire?.()) === false) return 'cancelled';
-          return 'existing';
-        }
-        forgetOwnedLease(existingOwnership, { notifyLoss: true });
+): Promise<'acquired' | 'existing'> {
+  const root = storageRoot();
+  const key = ownershipKey(root, executionId);
+  const existingOwnership = ownedLeases.get(key);
+  if (mode === 'resume' && existingOwnership) {
+    if (existingOwnership.releasing) {
+      // A release in flight settles the record either way; re-acquire from
+      // persisted state below instead of resurrecting the closing lease.
+      await existingOwnership.released;
+    } else {
+      const current = await readStoredLease(executionId, root);
+      if (
+        current !== 'tombstone' &&
+        current?.ownerToken === existingOwnership.ownerToken
+      ) {
+        return 'existing';
       }
+      forgetOwnedLease(existingOwnership);
     }
-
-    const claim = await claimLease(executionId, root, canAcquire);
-    switch (claim.status) {
-      case 'cancelled':
-        return 'cancelled';
-      case 'active':
-        throw new ExecutionLeaseActiveError(
-          executionId,
-          claim.owner,
-          claim.provable,
-        );
-      case 'claimed': {
-        const stale = ownedLeases.get(key);
-        if (stale) forgetOwnedLease(stale);
-        rememberOwnership(executionId, claim.record.ownerToken, root);
-        return 'acquired';
-      }
-    }
-  } finally {
-    leaseCoordination.leaveAcquisition();
   }
+
+  const claim = await claimLease(executionId, root);
+  if (claim.status === 'active') {
+    throw new ExecutionLeaseActiveError(
+      executionId,
+      claim.owner,
+      claim.provable,
+    );
+  }
+  const stale = ownedLeases.get(key);
+  if (stale) forgetOwnedLease(stale);
+  rememberOwnership(executionId, claim.record.ownerToken, root);
+  return 'acquired';
 }
 
 /** Acquire a new execution before any execution-scoped data becomes writable. */
@@ -718,9 +489,8 @@ export function acquireFreshExecutionLease(
 /** Establish ownership before a persisted execution is resumed. */
 export function acquireResumedExecutionLease(
   executionId: ExecutionId,
-  canAcquire?: () => boolean | Promise<boolean>,
-): Promise<'acquired' | 'existing' | 'cancelled'> {
-  return acquireExecutionLease(executionId, 'resume', canAcquire);
+): Promise<'acquired' | 'existing'> {
+  return acquireExecutionLease(executionId, 'resume');
 }
 
 /** Release this process's lease, but never remove a later owner's record. */
@@ -733,8 +503,7 @@ export async function releaseOwnedExecutionLease(
 
 function currentOwnedLeases(executionId: ExecutionId): OwnedExecutionLease[] {
   return [...ownedLeases.values()].filter(
-    (lease) =>
-      lease.executionId === executionId && currentScopeOwnsLease(lease),
+    (lease) => lease.executionId === executionId,
   );
 }
 
@@ -818,19 +587,6 @@ export async function runWithOwnedExecutionLeaseLaunchGuard<T>(
   } catch (error) {
     throw await releaseOwnedExecutionLeaseAfterFailure(executionId, error);
   }
-}
-
-/**
- * Wait until this process has released every lease it owns for an execution.
- * Foreign ownership never blocks this local lifecycle boundary.
- */
-export async function waitForOwnedExecutionLeaseRelease(
-  executionId: ExecutionId,
-): Promise<void> {
-  const releases = [...ownedLeases.values()]
-    .filter((lease) => lease.executionId === executionId)
-    .map((lease) => lease.released);
-  await Promise.all(releases);
 }
 
 async function releaseOwnership(ownership: OwnedExecutionLease): Promise<void> {
@@ -929,7 +685,7 @@ export async function runWithInactiveExecutionLease<T>(
         provable: true,
       };
     }
-    forgetOwnedLease(local, { notifyLoss: true });
+    forgetOwnedLease(local);
   }
   const claim = await claimLease(executionId, root);
   if (claim.status === 'active') return claim;

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -28,8 +28,6 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getExecutionStore } from './ExecutionKVStore';
 import {
   acquireFreshExecutionLease,
-  captureOwnedExecutionLease,
-  type OwnedExecutionLeaseScope,
   releaseOwnedExecutionLease,
 } from './executionLease';
 
@@ -128,74 +126,53 @@ export async function registerExecution(
     description,
   } = options;
   await acquireFreshExecutionLease(executionId);
-  const runWithOwnership = captureOwnedExecutionLease(executionId);
-  await runWithOwnership(async () => {
-    try {
-      const timestamp = new Date().toISOString();
-      const store = getExecutionStore(executionId);
-      const meta: RegisteredExecutionMeta = {
-        schemaVersion: 1,
-        timestamp,
-        streamId,
-        identity,
-        userFollowUpSupport:
-          userFollowUpSupport ?? USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
-        parentExecutionId,
-        ...(description ? { description } : {}),
-      };
-      const persistedRecord = pinExecutionWorkingDirectory(record);
+  try {
+    const timestamp = new Date().toISOString();
+    const store = getExecutionStore(executionId);
+    const meta: RegisteredExecutionMeta = {
+      schemaVersion: 1,
+      timestamp,
+      streamId,
+      identity,
+      userFollowUpSupport:
+        userFollowUpSupport ?? USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
+      parentExecutionId,
+      ...(description ? { description } : {}),
+    };
+    const persistedRecord = pinExecutionWorkingDirectory(record);
 
-      const writes: Promise<void>[] = [
-        store.writeRunRecord(persistedRecord),
-        store.writeMeta(meta),
-      ];
-      if (parentExecutionId) {
-        writes.push(
-          getExecutionStore(parentExecutionId).writeChild(executionId, {
-            agent: agentName,
-            timestamp,
-          }),
-        );
-      }
-
-      const results = await Promise.allSettled(writes);
-      const errors = results.flatMap((result) =>
-        result.status === 'rejected' ? [result.reason] : [],
+    const writes: Promise<void>[] = [
+      store.writeRunRecord(persistedRecord),
+      store.writeMeta(meta),
+    ];
+    if (parentExecutionId) {
+      writes.push(
+        getExecutionStore(parentExecutionId).writeChild(executionId, {
+          agent: agentName,
+          timestamp,
+        }),
       );
-      throwAggregated(
-        errors,
-        `Multiple execution registration writes failed for ${executionId}`,
-      );
-    } catch (error) {
-      try {
-        await releaseOwnedExecutionLease(executionId);
-      } catch (releaseError) {
-        throw new AggregateError(
-          [error, releaseError],
-          `Execution registration and lease rollback failed for ${executionId}`,
-        );
-      }
-      throw error;
     }
-  });
-}
 
-/**
- * Register a detached child execution and capture its fresh lease as the
- * caller's ownership scope — the register → capture pair every detached
- * launch site shares, owned here so the launch failure path has one home.
- * Wrap the pre-handoff launch work in `runWithOwnedExecutionLeaseLaunchGuard`
- * (from `./executionLease`) inside the returned scope so a failed launch
- * releases the lease instead of stranding it until the stale horizon.
- */
-export async function registerOwnedExecution(
-  executionId: ExecutionId,
-  record: RunRecord,
-  agentName: string,
-  options: RegisterExecutionOptions,
-): Promise<OwnedExecutionLeaseScope> {
-  await registerExecution(executionId, record, agentName, options);
-  return captureOwnedExecutionLease(executionId);
+    const results = await Promise.allSettled(writes);
+    const errors = results.flatMap((result) =>
+      result.status === 'rejected' ? [result.reason] : [],
+    );
+    throwAggregated(
+      errors,
+      `Multiple execution registration writes failed for ${executionId}`,
+    );
+  } catch (error) {
+    try {
+      await releaseOwnedExecutionLease(executionId);
+    } catch (releaseError) {
+      throw new AggregateError(
+        [error, releaseError],
+        `Execution registration and lease rollback failed for ${executionId}`,
+      );
+    }
+    throw error;
+  }
 }
 
 /**

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -52,7 +52,6 @@ export {
   inspectExecutionLease,
   markOwnedExecutionLeaseUndurable,
   reclaimExecutionLease,
-  type OwnedExecutionLeaseScope,
 } from './executionLease';
 export { persistChildRunResultMeta } from './childRunPersistence';
 export { resolveChildRunOutput } from './childRunOutput';

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -574,10 +574,10 @@ export class ProgressBackend {
 
   /**
    * Per-stream prepare shared by single- and all-delete: stop an in-flight
-   * stream we own locally, then wait for the execution-lease release. The
-   * `waitForOwnedExecutionRelease` no-ops for streams with no owned execution,
-   * so the all-delete path can run it over every stream without changing
-   * behavior.
+   * stream we own locally, then take a step on its execution lane so the
+   * deletion lands after the stopped generation has disposed. The wait no-ops
+   * for streams with no execution, so the all-delete path can run it over
+   * every stream without changing behavior.
    */
   private async prepareStreamDeletionCore(
     stream: StreamTabId,
@@ -592,7 +592,7 @@ export class ProgressBackend {
     // execution lease. Auto-close can land in that interval, so the handle is
     // not a reliable indication that local durable writes have finished.
     try {
-      await this.state.stores.waitForOwnedExecutionRelease(stream);
+      await this.state.stores.waitForExecutionQuiescence(stream);
       return false;
     } catch (error) {
       log.warn(

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -3,9 +3,10 @@ import PQueue from 'p-queue';
 import { RUN_FACT_EVENT_TYPES } from '@agent/trace';
 import type { DeleteStreamResult, SessionStores } from '@agent/storage';
 import type { HostApprovalBypassStateUpdate } from '@agent/runtime/HostInteractions';
-import type {
-  SessionHandle,
-  WorkspaceStorageTransitionHooks,
+import {
+  StorageRootChangeRefusedError,
+  type SessionHandle,
+  type WorkspaceStorageTransitionHooks,
 } from '@agent/runtime/SessionHandle';
 import {
   WebviewBridge,
@@ -574,10 +575,9 @@ export class ProgressBackend {
 
   /**
    * Per-stream prepare shared by single- and all-delete: stop an in-flight
-   * stream we own locally, then take a step on its execution lane so the
-   * deletion lands after the stopped generation has disposed. The wait no-ops
-   * for streams with no execution, so the all-delete path can run it over
-   * every stream without changing behavior.
+   * stream we own locally. The deletion itself runs as a step on the stream's
+   * execution lane (`SessionStores.deleteStream`), so it lands only after the
+   * stopped generation has disposed; nothing here needs to wait for it.
    */
   private async prepareStreamDeletionCore(
     stream: StreamTabId,
@@ -587,20 +587,7 @@ export class ProgressBackend {
     if (ownedLocally && isInFlightPhase(this.session.status.get(stream))) {
       await this.lifecycle.stopStream(stream);
     }
-
-    // A terminal child is untracked before its artifact flush releases the
-    // execution lease. Auto-close can land in that interval, so the handle is
-    // not a reliable indication that local durable writes have finished.
-    try {
-      await this.state.stores.waitForExecutionQuiescence(stream);
-      return false;
-    } catch (error) {
-      log.warn(
-        `Stream ${stream} was retained because its execution ownership could not be read`,
-        { data: error },
-      );
-      return true;
-    }
+    return false;
   }
 
   private async prepareStreamDeletion(stream: StreamTabId): Promise<boolean> {
@@ -744,9 +731,8 @@ export class ProgressBackend {
     // Runs the per-stream prepare over every known stream — deliberately
     // without the single-delete guards, so in-flight reserved-segment streams
     // are still stopped before clearAll() exactly as before the shared core.
-    // Ownership-read failures are already converted to a per-stream result by
-    // `prepareStreamDeletionCore`; `clearAll` reports those streams through
-    // its own failed set.
+    // `clearAll` reports ownership-read and lane refusals through its own
+    // failed set.
     await Promise.all(
       this.state.streamLogs
         .keys()
@@ -814,6 +800,8 @@ export class ProgressBackend {
           ? await this.session.reloadAfterStorageRootChange(transitionHooks)
           : await this.session.reloadAfterStorageRootChange();
       } catch (error) {
+        // A refused change touched nothing, so there is nothing to reload.
+        if (error instanceof StorageRootChangeRefusedError) throw error;
         sessionReloadError = error;
       }
       if (sessionReloadError || storageRootReplaced) {

--- a/src/controllers/progressView/progressFollowUpSubmit.ts
+++ b/src/controllers/progressView/progressFollowUpSubmit.ts
@@ -11,9 +11,6 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const logger = createLog('ProgressFollowUpSubmit');
 
-const NO_ACTIVE_SESSION_MESSAGE =
-  'No active session. Start a new agent task to continue.';
-
 export interface ProgressFollowUpSubmitArgs {
   readonly session: SessionHandle;
   readonly streamId: StreamTabId;
@@ -30,8 +27,8 @@ export interface ProgressFollowUpSubmitArgs {
 /**
  * One follow-up submission path for the extension and desktop progress views:
  * admission, the composer ack, the queued-follow-ups refresh, and outcome
- * presentation. Hosts supply only their ports. Sending never starts a
- * resume: a stream with no live flow in this process refuses the draft.
+ * presentation. Hosts supply only their ports. A stream with no live flow in
+ * this process refuses the draft with a worded reason.
  *
  * Resolves at admission with whether the draft was accepted. Anything after
  * admission (a recovery resume may run a whole model turn, then present its
@@ -77,36 +74,15 @@ export function submitProgressFollowUp(
         return;
       }
 
-      switch (result.status) {
-        case 'sent':
-          acknowledge(true);
-          emitQueuedFollowUpsChanged();
-          return;
-        case 'queued': {
-          acknowledge(true);
-          emitQueuedFollowUpsChanged();
-          const presentation = presentFollowUpResult(result);
-          if (presentation.severity !== 'none') {
-            await showInfo(presentation.message);
-          }
-          return;
-        }
-        case 'duplicate':
-          acknowledge(true);
-          return;
-        case 'no_session':
-        case 'dropped':
-          acknowledge(false);
-          await showInfo(NO_ACTIVE_SESSION_MESSAGE);
-          return;
-        default:
-          // A result this switch does not know must not leave the composer
-          // frozen: hand the draft back and make the gap loud.
-          acknowledge(false);
-          logger.warn(
-            `Unhandled follow-up result for stream ${streamId}: ${JSON.stringify(result)}`,
-          );
-          return;
+      // A failed recovery resume still queued the input; every other
+      // failure hands the draft back.
+      acknowledge(
+        result.status !== 'failed' || result.reason === 'resume_failed',
+      );
+      emitQueuedFollowUpsChanged();
+      const presentation = presentFollowUpResult(result);
+      if (presentation.severity !== 'none') {
+        await showInfo(presentation.message);
       }
     })().catch((error: unknown) => {
       acknowledge(false);

--- a/src/controllers/progressView/progressFollowUpSubmit.ts
+++ b/src/controllers/progressView/progressFollowUpSubmit.ts
@@ -1,4 +1,5 @@
 import {
+  describeFollowUpFailure,
   presentFollowUpResult,
   submitFollowUp,
   type SubmitFollowUpResult,
@@ -74,15 +75,31 @@ export function submitProgressFollowUp(
         return;
       }
 
-      // A failed recovery resume still queued the input; every other
-      // failure hands the draft back.
-      acknowledge(
-        result.status !== 'failed' || result.reason === 'resume_failed',
-      );
-      emitQueuedFollowUpsChanged();
-      const presentation = presentFollowUpResult(result);
-      if (presentation.severity !== 'none') {
-        await showInfo(presentation.message);
+      switch (result.status) {
+        case 'sent':
+        case 'queued': {
+          // A queued input whose wake failed still belongs to the stream.
+          acknowledge(true);
+          emitQueuedFollowUpsChanged();
+          const presentation = presentFollowUpResult(result);
+          if (presentation.severity !== 'none') {
+            await showInfo(presentation.message);
+          }
+          return;
+        }
+        case 'failed':
+          acknowledge(false);
+          emitQueuedFollowUpsChanged();
+          await showInfo(describeFollowUpFailure(result.reason));
+          return;
+        default:
+          // A result this switch does not know must not leave the composer
+          // frozen: hand the draft back and make the gap loud.
+          acknowledge(false);
+          logger.warn(
+            `Unhandled follow-up result for stream ${streamId}: ${JSON.stringify(result)}`,
+          );
+          return;
       }
     })().catch((error: unknown) => {
       acknowledge(false);

--- a/src/controllers/session/sessionStores.ts
+++ b/src/controllers/session/sessionStores.ts
@@ -19,6 +19,7 @@ export function createSessionStores(session: SessionHandle): SessionStores {
   return new SessionStores({
     streamLogs: session.transcripts,
     snapshots: session.snapshots,
+    executions: session.executions,
     goalEntries: {
       forget: (stream) => GoalStore.forget(stream, session),
     },

--- a/src/platform/interfaces.ts
+++ b/src/platform/interfaces.ts
@@ -297,7 +297,6 @@ export interface AgentDirectoriesPort {
  */
 export interface RecoveryContinuation {
   readonly streamId: StreamTabId;
-  readonly generation: number;
   readonly kind: 'recovery';
 }
 

--- a/src/shared/schemas/inquiry.ts
+++ b/src/shared/schemas/inquiry.ts
@@ -48,7 +48,6 @@ export type InquiryThreadSummary = z.infer<typeof InquiryThreadSummarySchema>;
 const InquiryResumeOutcomeSchema = z.enum([
   'sent',
   'queued',
-  'resumed',
   'parent_finished',
 ]);
 export type InquiryResumeOutcome = z.infer<typeof InquiryResumeOutcomeSchema>;

--- a/src/test-kernel/agent/followUp/FollowUpQueue.vitest.ts
+++ b/src/test-kernel/agent/followUp/FollowUpQueue.vitest.ts
@@ -148,15 +148,15 @@ describe('ToolUseFollowUpQueue ownership', () => {
     ).toEqual(['b']);
   });
 
-  it('never reopens a terminal stream', () => {
+  it('forgets a terminal stream so a late live-owner submission finds no owner', () => {
     const queues = new ToolUseFollowUpQueue();
     const id = stream('stream:terminal');
     const lease = queues.claimLive(id, 'flow')!;
     queues.release(lease, 'terminal');
 
-    expect(queues.claimLive(id, 'flow')).toBeUndefined();
-    expect(queues.submit(id, { text: 'late' }, 'recoverable')).toEqual({
-      kind: 'unavailable',
+    expect(queues.hasLiveOwner(id)).toBe(false);
+    expect(queues.submit(id, { text: 'late' }, 'live_owner')).toEqual({
+      kind: 'not_owned',
     });
   });
 
@@ -167,9 +167,8 @@ describe('ToolUseFollowUpQueue ownership', () => {
     const first = queues.claimChildRun(id, executionId)!;
     queues.release(first, 'terminal');
 
-    expect(queues.claimLive(id, 'flow')).toBeUndefined();
     expect(queues.submit(id, { text: 'late' }, 'live_owner')).toEqual({
-      kind: 'unavailable',
+      kind: 'not_owned',
     });
 
     const retry = queues.claimChildRun(id, executionId);
@@ -243,7 +242,7 @@ describe('ToolUseFollowUpQueue ownership', () => {
     expect(queues.queue(live).drainItems()).toEqual([]);
   });
 
-  it('does not reopen a terminal stream for an unrelated execution', () => {
+  it('refuses a child claim for an unrelated execution', () => {
     const queues = new ToolUseFollowUpQueue();
     const executionId = 'owned-execution' as ExecutionId;
     const id = stream(`stream#${executionId}`);
@@ -253,7 +252,6 @@ describe('ToolUseFollowUpQueue ownership', () => {
     expect(() =>
       queues.claimChildRun(id, 'unrelated-execution' as ExecutionId),
     ).toThrow('does not belong to execution');
-    expect(queues.claimLive(id, 'flow')).toBeUndefined();
   });
 
   it('restores only the authoritative persisted generation', () => {
@@ -309,15 +307,15 @@ describe('ToolUseFollowUpQueue ownership', () => {
     expect(queues.currentGenerationId(id)).toBe('persisted-generation');
   });
 
-  it('deletion invalidates a live generation and rejects late input', () => {
+  it('deletion invalidates a live generation', () => {
     const queues = new ToolUseFollowUpQueue();
     const id = stream('stream:deleted');
     const lease = queues.claimLive(id, 'child')!;
 
     expect(queues.terminalize(id)).toBe(true);
     expect(queues.release(lease, 'recoverable')).toBe(false);
-    expect(queues.submit(id, { text: 'late' }, 'recoverable')).toEqual({
-      kind: 'unavailable',
+    expect(queues.submit(id, { text: 'late' }, 'live_owner')).toEqual({
+      kind: 'not_owned',
     });
   });
 

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -472,7 +472,7 @@ describe('presentFollowUpResult', () => {
       severity: 'none',
     });
     expect(
-      presentFollowUpResult({ status: 'failed', reason: 'resume_failed' }),
+      presentFollowUpResult({ status: 'queued', wake: 'failed' }),
     ).toMatchObject({ severity: 'info' });
     expect(
       presentFollowUpResult({ status: 'failed', reason: 'owned_elsewhere' }),

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -275,36 +275,6 @@ describe('submitFollowUp', () => {
     expect(tryResumeStream).toHaveBeenCalledTimes(1);
   });
 
-  it('delivers a final child result through the retained queue after child untracking', async () => {
-    const streamId = id('stream:final-child-delivery');
-    const session = fakeSession({
-      kind: 'no_session',
-      streamStatus: 'completed',
-    });
-    const parentFlow = session.followUps.claimLive(streamId, 'flow')!;
-    session.followUps.release(parentFlow, 'recoverable');
-    const tryResumeStream = mockTryResume();
-
-    await expect(
-      submitFollowUp(
-        streamId,
-        { text: 'final child result', origin: 'subagent_result' },
-        {
-          session,
-          resumePort: { tryResumeStream },
-          mode: 'child_delivery',
-        },
-      ),
-    ).resolves.toEqual({
-      status: 'queued',
-      reason: 'children_running',
-      continuation: 'resumed',
-    });
-
-    expect(tryResumeStream).toHaveBeenCalledTimes(1);
-    expect(session.followUps.getAll(streamId)).toEqual(['final child result']);
-  });
-
   it('trusts a matching retained generation after the parent completes', async () => {
     const streamId = id('stream:retained-child-generation');
     const generationId = 'a98f8f0a-b61a-4913-a88e-a934da14d4e5';
@@ -336,7 +306,7 @@ describe('submitFollowUp', () => {
     ]);
   });
 
-  it('does not let child delivery reopen a terminal parent queue', async () => {
+  it('refuses child delivery to a parent with no session', async () => {
     const streamId = id('stream:terminal-child-delivery');
     const session = fakeSession({
       kind: 'no_session',
@@ -354,7 +324,7 @@ describe('submitFollowUp', () => {
           mode: 'child_delivery',
         },
       ),
-    ).resolves.toEqual({ status: 'dropped' });
+    ).resolves.toEqual({ status: 'no_session', streamStatus: 'completed' });
     expect(tryResumeStream).not.toHaveBeenCalled();
   });
 
@@ -392,77 +362,7 @@ describe('submitFollowUp', () => {
     expect(session.followUps.getAll(streamId)).toEqual(['child result']);
   });
 
-  it('rejects terminal queues and never invokes recovery', async () => {
-    const streamId = id('stream:terminal');
-    const session = fakeSession({ kind: 'queue', reason: 'waiting' });
-    const lease = session.followUps.claimLive(streamId, 'flow')!;
-    session.followUps.release(lease, 'terminal');
-    const tryResumeStream = mockTryResume();
-
-    await expect(
-      submitFollowUp(streamId, 'late', {
-        session,
-        resumePort: { tryResumeStream },
-      }),
-    ).resolves.toEqual({ status: 'dropped' });
-    expect(tryResumeStream).not.toHaveBeenCalled();
-  });
-
-  it('restores the persisted generation before admitting a durable producer', async () => {
-    const streamId = id('stream:persisted-generation');
-    const session = fakeSession({ kind: 'queue', reason: 'waiting' });
-    const generationId = 'e63883b0-0fe0-48c7-9888-a2daeaab30a5';
-    mockPersistedExecution(session);
-    vi.spyOn(resumability, 'deriveResumability').mockResolvedValue(
-      durableResumabilityDecision(generationId),
-    );
-    const tryResumeStream = mockTryResume();
-
-    await expect(
-      submitFollowUp(streamId, 'answer after reload', {
-        session,
-        resumePort: { tryResumeStream },
-        expectedGenerationId: generationId,
-      }),
-    ).resolves.toMatchObject({
-      status: 'queued',
-      continuation: 'resumed',
-    });
-    expect(session.followUps.currentGenerationId(streamId)).toBe(generationId);
-  });
-
-  it('prefers quiet resident ownership before the persisted sidecar FK', async () => {
-    const streamId = id('stream:resident-generation');
-    const residentExecutionId = 'resident-execution' as ExecutionId;
-    const session = fakeSession({ kind: 'queue', reason: 'waiting' });
-    session.snapshots.getRunMetadata = vi.fn(() => ({
-      executionId: residentExecutionId,
-    }));
-    vi.spyOn(session.snapshots, 'readPersistedExecutionId').mockResolvedValue(
-      'persisted-execution' as ExecutionId,
-    );
-    const generationId = '04d3201e-5df0-45a8-9f8b-76b2097ce574';
-    const deriveResumability = vi
-      .spyOn(resumability, 'deriveResumability')
-      .mockResolvedValue(durableResumabilityDecision(generationId));
-    const tryResumeStream = mockTryResume();
-
-    await expect(
-      submitFollowUp(streamId, 'resident generation answer', {
-        session,
-        resumePort: { tryResumeStream },
-        expectedGenerationId: generationId,
-      }),
-    ).resolves.toMatchObject({
-      status: 'queued',
-      continuation: 'resumed',
-    });
-
-    expect(deriveResumability).toHaveBeenCalledWith(residentExecutionId);
-    expect(session.snapshots.readPersistedExecutionId).not.toHaveBeenCalled();
-  });
-
-  it('serializes durable generation lookup before later ordinary admission', async () => {
+  it('does not hold ordinary admission behind a durable generation lookup', async () => {
     const streamId = id('stream:serialized-generation-lookup');
     const session = fakeSession({ kind: 'queue', reason: 'waiting' });
     const generationId = '5038fe96-7113-449a-82a9-3e58f292d1ba';
@@ -487,26 +387,26 @@ describe('submitFollowUp', () => {
       resumePort: { tryResumeStream },
     });
 
+    // Admission is synchronous: the ordinary submission is in the queue and
+    // owns the recovery before the durable producer's disk lookup settles.
     await vi.waitFor(() => expect(deriveResumability).toHaveBeenCalledOnce());
-    expect(tryResumeStream).not.toHaveBeenCalled();
-    expect(session.followUps.getAll(streamId)).toEqual([]);
+    expect(tryResumeStream).toHaveBeenCalledOnce();
+    expect(session.followUps.getAll(streamId)).toEqual(['ordinary follow-up']);
 
     lookup.resolve(durableResumabilityDecision(generationId));
 
-    await vi.waitFor(() =>
-      expect(session.followUps.getAll(streamId)).toEqual([
-        'durable inquiry',
-        'ordinary follow-up',
-      ]),
-    );
-    await expect(second).resolves.toMatchObject({
+    await expect(first).resolves.toMatchObject({
       status: 'queued',
       continuation: 'recovering',
     });
+    expect(session.followUps.getAll(streamId)).toEqual([
+      'ordinary follow-up',
+      'durable inquiry',
+    ]);
     expect(tryResumeStream).toHaveBeenCalledOnce();
 
     resumeBarrier.resolve(true);
-    await expect(first).resolves.toMatchObject({
+    await expect(second).resolves.toMatchObject({
       status: 'queued',
       continuation: 'resumed',
     });

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -80,7 +80,7 @@ describe('submitFollowUp', () => {
 
   it('uses the live child owner while waiting, between turns, and during a turn', async () => {
     const streamId = id('stream:live-child');
-    const session = fakeSession({ kind: 'queue', reason: 'waiting' });
+    const session = fakeSession({ kind: 'queue' });
     const child = session.followUps.claimLive(streamId, 'child')!;
     const tryResumeStream = mockTryResume();
 
@@ -90,10 +90,7 @@ describe('submitFollowUp', () => {
           session,
           resumePort: { tryResumeStream },
         }),
-      ).resolves.toMatchObject({
-        status: 'queued',
-        continuation: 'live',
-      });
+      ).resolves.toMatchObject({ status: 'queued' });
     }
 
     expect(tryResumeStream).not.toHaveBeenCalled();
@@ -143,11 +140,7 @@ describe('submitFollowUp', () => {
         session,
         mode: 'live_notification',
       }),
-    ).resolves.toEqual({
-      status: 'queued',
-      reason: 'waiting',
-      continuation: 'live',
-    });
+    ).resolves.toEqual({ status: 'queued' });
 
     expect(session.followUps.queue(flow).drainItems()).toMatchObject([
       { text: 'child progress' },
@@ -157,7 +150,7 @@ describe('submitFollowUp', () => {
 
   it('enqueues live notifications for a waiting parent without child owner', async () => {
     const streamId = id('stream:waiting-notification');
-    const session = fakeSession({ kind: 'queue', reason: 'waiting' });
+    const session = fakeSession({ kind: 'queue' });
     const tryResumeStream = mockTryResume();
 
     // Create a child-owned entry (simulates a running child loop), then
@@ -175,18 +168,14 @@ describe('submitFollowUp', () => {
       mode: 'live_notification',
     });
 
-    expect(result).toMatchObject({
-      status: 'queued',
-      reason: 'waiting',
-      continuation: 'live',
-    });
+    expect(result).toMatchObject({ status: 'queued' });
     expect(tryResumeStream).not.toHaveBeenCalled();
     expect(session.followUps.getAll(streamId)).toEqual(['child progress']);
   });
 
   it('claims one recovery and orders repeated submissions once', async () => {
     const streamId = id('stream:recovery');
-    const session = fakeSession({ kind: 'queue', reason: 'waiting' });
+    const session = fakeSession({ kind: 'queue' });
     const barrier = createDeferred<boolean>();
     const claimed: unknown[] = [];
     const tryResumeStream = vi.fn((_: StreamTabId, recovery: unknown) => {
@@ -211,17 +200,17 @@ describe('submitFollowUp', () => {
       expect(tryResumeStream).toHaveBeenCalledTimes(1);
       expect(claimed).toHaveLength(1);
     });
-    await expect(second).resolves.toMatchObject({ continuation: 'recovering' });
-    await expect(third).resolves.toMatchObject({ continuation: 'recovering' });
+    await expect(second).resolves.toEqual({ status: 'queued' });
+    await expect(third).resolves.toEqual({ status: 'queued' });
     expect(session.followUps.getAll(streamId)).toEqual(['one', 'two', 'three']);
 
     barrier.resolve(true);
-    await expect(first).resolves.toMatchObject({ continuation: 'resumed' });
+    await expect(first).resolves.toEqual({ status: 'queued' });
   });
 
   it('starts recovery after the child generation releases', async () => {
     const streamId = id('stream:child-release');
-    const session = fakeSession({ kind: 'queue', reason: 'waiting' });
+    const session = fakeSession({ kind: 'queue' });
     const child = session.followUps.claimLive(streamId, 'child')!;
     session.followUps.release(child, 'recoverable');
     const tryResumeStream = mockTryResume();
@@ -231,16 +220,13 @@ describe('submitFollowUp', () => {
         session,
         resumePort: { tryResumeStream },
       }),
-    ).resolves.toMatchObject({ continuation: 'resumed' });
+    ).resolves.toEqual({ status: 'queued' });
     expect(tryResumeStream).toHaveBeenCalledTimes(1);
   });
 
   it('enqueues live notifications for children-running parent without recovery', async () => {
     const streamId = id('stream:children-running-notification');
-    const session = fakeSession({
-      kind: 'queue',
-      reason: 'children_running',
-    });
+    const session = fakeSession({ kind: 'queue' });
     // Create a child-owned entry to simulate the parent having active children.
     const child = session.followUps.claimLive(streamId, 'child')!;
     // Release the child so the queue stays but loses its owner.
@@ -253,18 +239,14 @@ describe('submitFollowUp', () => {
       mode: 'live_notification',
     });
 
-    expect(result).toMatchObject({
-      status: 'queued',
-      reason: 'children_running',
-      continuation: 'live',
-    });
+    expect(result).toMatchObject({ status: 'queued' });
     expect(tryResumeStream).not.toHaveBeenCalled();
     expect(session.followUps.getAll(streamId)).toEqual(['child update']);
   });
 
   it('keeps children-running explicitly recoverable after child untracking', async () => {
     const streamId = id('stream:children-running');
-    const session = fakeSession({ kind: 'queue', reason: 'children_running' });
+    const session = fakeSession({ kind: 'queue' });
     const tryResumeStream = mockTryResume();
 
     await submitFollowUp(streamId, 'child result', {
@@ -278,10 +260,7 @@ describe('submitFollowUp', () => {
   it('trusts a matching retained generation after the parent completes', async () => {
     const streamId = id('stream:retained-child-generation');
     const generationId = 'a98f8f0a-b61a-4913-a88e-a934da14d4e5';
-    const session = fakeSession({
-      kind: 'queue',
-      reason: 'children_running',
-    });
+    const session = fakeSession({ kind: 'queue' });
     const parent = session.followUps.claimLive(streamId, 'flow', generationId)!;
     session.followUps.release(parent, 'recoverable');
     const deriveSpy = vi.spyOn(resumability, 'deriveResumability');
@@ -298,7 +277,7 @@ describe('submitFollowUp', () => {
           expectedGenerationId: generationId,
         },
       ),
-    ).resolves.toMatchObject({ status: 'queued', continuation: 'resumed' });
+    ).resolves.toEqual({ status: 'queued' });
 
     expect(deriveSpy).not.toHaveBeenCalled();
     expect(session.followUps.getAll(streamId)).toEqual([
@@ -324,13 +303,13 @@ describe('submitFollowUp', () => {
           mode: 'child_delivery',
         },
       ),
-    ).resolves.toEqual({ status: 'no_session', streamStatus: 'completed' });
+    ).resolves.toEqual({ status: 'failed', reason: 'not_resumable' });
     expect(tryResumeStream).not.toHaveBeenCalled();
   });
 
   it('admits a replayed child delivery at most once and wakes at most once', async () => {
     const streamId = id('stream:replay-child-delivery');
-    const session = fakeSession({ kind: 'queue', reason: 'children_running' });
+    const session = fakeSession({ kind: 'queue' });
     const tryResumeStream = mockTryResume();
     const delivery = {
       text: 'child result',
@@ -344,7 +323,7 @@ describe('submitFollowUp', () => {
         resumePort: { tryResumeStream },
         mode: 'child_delivery',
       }),
-    ).resolves.toMatchObject({ status: 'queued', continuation: 'resumed' });
+    ).resolves.toEqual({ status: 'queued' });
     expect(tryResumeStream).toHaveBeenCalledTimes(1);
 
     // A producer repeating the same logical result callback must not append
@@ -356,7 +335,7 @@ describe('submitFollowUp', () => {
           resumePort: { tryResumeStream },
           mode: 'child_delivery',
         }),
-      ).resolves.toEqual({ status: 'duplicate' });
+      ).resolves.toEqual({ status: 'sent' });
     }
     expect(tryResumeStream).toHaveBeenCalledTimes(1);
     expect(session.followUps.getAll(streamId)).toEqual(['child result']);
@@ -364,7 +343,7 @@ describe('submitFollowUp', () => {
 
   it('does not hold ordinary admission behind a durable generation lookup', async () => {
     const streamId = id('stream:serialized-generation-lookup');
-    const session = fakeSession({ kind: 'queue', reason: 'waiting' });
+    const session = fakeSession({ kind: 'queue' });
     const generationId = '5038fe96-7113-449a-82a9-3e58f292d1ba';
     mockPersistedExecution(session);
     const lookup =
@@ -395,10 +374,7 @@ describe('submitFollowUp', () => {
 
     lookup.resolve(durableResumabilityDecision(generationId));
 
-    await expect(first).resolves.toMatchObject({
-      status: 'queued',
-      continuation: 'recovering',
-    });
+    await expect(first).resolves.toEqual({ status: 'queued' });
     expect(session.followUps.getAll(streamId)).toEqual([
       'ordinary follow-up',
       'durable inquiry',
@@ -406,15 +382,12 @@ describe('submitFollowUp', () => {
     expect(tryResumeStream).toHaveBeenCalledOnce();
 
     resumeBarrier.resolve(true);
-    await expect(second).resolves.toMatchObject({
-      status: 'queued',
-      continuation: 'resumed',
-    });
+    await expect(second).resolves.toEqual({ status: 'queued' });
   });
 
   it('fails closed when the persisted execution identity cannot be read', async () => {
     const streamId = id('stream:unreadable-persisted-execution');
-    const session = fakeSession({ kind: 'queue', reason: 'waiting' });
+    const session = fakeSession({ kind: 'queue' });
     vi.spyOn(
       session.snapshots,
       'readPersistedExecutionId',
@@ -427,14 +400,14 @@ describe('submitFollowUp', () => {
         resumePort: { tryResumeStream },
         expectedGenerationId: 'b7f001b0-02e7-4135-967f-5f43d7bb1aa5',
       }),
-    ).resolves.toEqual({ status: 'dropped' });
+    ).resolves.toEqual({ status: 'failed', reason: 'not_resumable' });
     expect(tryResumeStream).not.toHaveBeenCalled();
     expect(session.followUps.getAll(streamId)).toEqual([]);
   });
 
   it('rebinds a provisional recovery before admitting a durable producer', async () => {
     const streamId = id('stream:provisional-recovery');
-    const session = fakeSession({ kind: 'queue', reason: 'waiting' });
+    const session = fakeSession({ kind: 'queue' });
     const generationId = 'a2047268-908c-4ac5-8194-71fb377bd7f3';
     mockPersistedExecution(session);
     vi.spyOn(resumability, 'deriveResumability').mockResolvedValue(
@@ -455,7 +428,7 @@ describe('submitFollowUp', () => {
 
   it('rebinds a released provisional recovery before durable admission', async () => {
     const streamId = id('stream:released-provisional-recovery');
-    const session = fakeSession({ kind: 'queue', reason: 'waiting' });
+    const session = fakeSession({ kind: 'queue' });
     const generationId = '51c54412-e977-48ab-8304-53007cc0bb7a';
     mockPersistedExecution(session);
     vi.spyOn(resumability, 'deriveResumability').mockResolvedValue(
@@ -470,7 +443,7 @@ describe('submitFollowUp', () => {
         resumePort: { tryResumeStream: mockTryResume() },
         expectedGenerationId: generationId,
       }),
-    ).resolves.toMatchObject({ status: 'queued', continuation: 'resumed' });
+    ).resolves.toEqual({ status: 'queued' });
     expect(provisional.generationId).toBe(generationId);
   });
 });
@@ -491,19 +464,21 @@ describe('ToolUseFollowUpQueue claim exclusivity', () => {
 });
 
 describe('presentFollowUpResult', () => {
-  it('maps merged host outcomes without ownership checks', () => {
+  it('words only refusals, with a failed wake as information', () => {
     expect(presentFollowUpResult({ status: 'sent' })).toEqual({
       severity: 'none',
     });
+    expect(presentFollowUpResult({ status: 'queued' })).toEqual({
+      severity: 'none',
+    });
     expect(
-      presentFollowUpResult({
-        status: 'queued',
-        reason: 'waiting',
-        continuation: 'resume_failed',
-      }),
+      presentFollowUpResult({ status: 'failed', reason: 'resume_failed' }),
     ).toMatchObject({ severity: 'info' });
-    expect(presentFollowUpResult({ status: 'dropped' })).toMatchObject({
+    expect(
+      presentFollowUpResult({ status: 'failed', reason: 'owned_elsewhere' }),
+    ).toMatchObject({
       severity: 'warning',
+      message: expect.stringContaining('another TeXRA window'),
     });
   });
 });

--- a/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
@@ -216,10 +216,7 @@ describe('tool-use follow-up progress events', () => {
 
     const result = await submitFollowUp(streamId, 'late follow-up');
 
-    expect(result).toEqual({
-      status: 'no_session',
-      streamStatus: STREAM_PHASE.COMPLETED,
-    });
+    expect(result).toEqual({ status: 'failed', reason: 'not_resumable' });
     expect(appendFollowUp).not.toHaveBeenCalled();
   });
 
@@ -234,10 +231,7 @@ describe('tool-use follow-up progress events', () => {
         { session },
       );
 
-      expect(result).toEqual({
-        status: 'no_session',
-        streamStatus: undefined,
-      });
+      expect(result).toEqual({ status: 'failed', reason: 'not_resumable' });
       expect(recorded.events).toEqual([]);
     } finally {
       recorded.detach();
@@ -258,11 +252,9 @@ describe('tool-use follow-up progress events', () => {
         'queued while resuming',
       );
 
-      expect(result).toEqual({
-        status: 'queued',
-        reason: 'resuming',
-        continuation: 'resume_failed',
-      });
+      // The fake platform's resume port refuses, so the input stays queued
+      // behind a failed wake.
+      expect(result).toEqual({ status: 'failed', reason: 'resume_failed' });
       expect(defaultSession().followUps.getAll(resumingStreamId)).toEqual([
         'queued while resuming',
       ]);
@@ -290,11 +282,7 @@ describe('tool-use follow-up progress events', () => {
     try {
       const result = await submitFollowUp(parentStreamId, 'continue child');
 
-      expect(result).toEqual({
-        status: 'queued',
-        reason: 'children_running',
-        continuation: 'resume_failed',
-      });
+      expect(result).toEqual({ status: 'failed', reason: 'resume_failed' });
       expect(defaultSession().followUps.getAll(parentStreamId)).toEqual([
         'continue child',
       ]);

--- a/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
@@ -254,7 +254,7 @@ describe('tool-use follow-up progress events', () => {
 
       // The fake platform's resume port refuses, so the input stays queued
       // behind a failed wake.
-      expect(result).toEqual({ status: 'failed', reason: 'resume_failed' });
+      expect(result).toEqual({ status: 'queued', wake: 'failed' });
       expect(defaultSession().followUps.getAll(resumingStreamId)).toEqual([
         'queued while resuming',
       ]);
@@ -282,7 +282,7 @@ describe('tool-use follow-up progress events', () => {
     try {
       const result = await submitFollowUp(parentStreamId, 'continue child');
 
-      expect(result).toEqual({ status: 'failed', reason: 'resume_failed' });
+      expect(result).toEqual({ status: 'queued', wake: 'failed' });
       expect(defaultSession().followUps.getAll(parentStreamId)).toEqual([
         'continue child',
       ]);

--- a/src/test-kernel/agent/runtime/AgentLaunchActivation.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchActivation.vitest.ts
@@ -39,9 +39,7 @@ vi.mock('@agent/storage/executionLifecycle', () => ({
 vi.mock('@agent/storage/executionLease', () => ({
   abandonOwnedExecutionLease: vi.fn(),
   acquireResumedExecutionLease: mocks.acquireResumedExecutionLease,
-  captureOwnedExecutionLease:
-    (_executionId: ExecutionId) => (operation: () => unknown) =>
-      operation(),
+  assertOwnedExecutionLease: vi.fn(),
   completeOwnedExecutionLease: mocks.completeOwnedExecutionLease,
   releaseOwnedExecutionLeaseAfterFailure:
     mocks.releaseOwnedExecutionLeaseAfterFailure,

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -239,35 +239,6 @@ function seedOpenRunGroup(
 }
 
 describe('runFlowWithLifecycle', () => {
-  it('interrupts and suppresses terminal persistence after lease takeover', async () => {
-    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'lifecycle-lease-takeover',
-    );
-    await acquireResumedExecutionLease(executionId);
-
-    try {
-      const result = await runFlowWithLifecycle(ctx, async (handle) => {
-        await writeForeignLease(executionId);
-        // Displacement is discovered at the next fencing boundary, not on a
-        // clock: the failed validation notifies loss and interrupts the run.
-        await expect(
-          validateOwnedExecutionLease(executionId),
-        ).rejects.toBeInstanceOf(ExecutionLeaseLostError);
-
-        expect(handle.executionLeaseLost).toBe(true);
-        expect(ctx.runScope.signal.aborted).toBe(true);
-        return toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED);
-      });
-
-      expect(result.outcome).toBe(RUN_OUTCOME.COMPLETED);
-      expect(storageMocks.finalizeExecution).not.toHaveBeenCalled();
-    } finally {
-      await releaseOwnedExecutionLease(executionId);
-      await StorageFS.delete(executionLeasePath(executionId)).catch(() => {});
-      clearStreamStatusForTest(streamStatus, streamId);
-    }
-  });
-
   // The run's category reaches the handle and the terminal `result` through
   // the one descriptor the lifecycle builds, so a workflow run reports
   // `workflow` on both without either side re-deriving the string.
@@ -1061,77 +1032,6 @@ describe('runFlowWithLifecycle', () => {
     }
   });
 
-  it('does not close a waiting transcript group after lease loss', async () => {
-    const { executionId, streamId, ctx } = lifecycleFixture(
-      'lifecycle-waiting-cleanup-lease-loss',
-    );
-    const transcripts = ctx.runScope.session.transcripts;
-    const originalLoadAndAcquireWriter =
-      transcripts.loadAndAcquireWriter.bind(transcripts);
-    let markWriterLoadStarted = (): void => undefined;
-    const writerLoadStarted = new Promise<void>((resolve) => {
-      markWriterLoadStarted = resolve;
-    });
-    let releaseWriterLoad = (): void => undefined;
-    const writerLoadGate = new Promise<void>((resolve) => {
-      releaseWriterLoad = resolve;
-    });
-    vi.spyOn(transcripts, 'loadAndAcquireWriter').mockImplementationOnce(
-      async (requestedStreamId, ownerKey) => {
-        markWriterLoadStarted();
-        await writerLoadGate;
-        return originalLoadAndAcquireWriter(requestedStreamId, ownerKey);
-      },
-    );
-
-    try {
-      const result = await runFlowWithLifecycle(
-        ctx,
-        async () => waitingResult(executionId, streamId),
-        { isSubagent: true },
-      );
-      expect(result.outcome).toBe(STREAM_PHASE.WAITING);
-      const waitingHandle = takeWaitingHandle(executionId);
-
-      // Seed the open run-group row so a wrongly-run close would be visible
-      // as a GROUP_END settle on this exact row (mirrors the kill test).
-      const parentStageId = seedOpenRunGroup(ctx, streamId);
-
-      expect(defaultSession().executions.kill(executionId)).toBe(true);
-      await writerLoadStarted;
-      waitingHandle.markExecutionLeaseLost();
-      releaseWriterLoad();
-      await waitingHandle.result;
-
-      // The waiting group must stay open: the seeded row is still the
-      // running GROUP_START, and no run GROUP_END row exists.
-      const rows = transcripts.get(streamId)?.toJSON() ?? [];
-      expect(rows).toContainEqual(
-        expect.objectContaining({
-          id: parentStageId,
-          type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
-        }),
-      );
-      expect(rows).not.toContainEqual(
-        expect.objectContaining({
-          type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
-          data: expect.objectContaining({ kind: 'run' }),
-        }),
-      );
-      expect(storageMocks.finalizeExecution).not.toHaveBeenCalled();
-    } finally {
-      releaseWriterLoad();
-      defaultSession().executions.untrack(executionId);
-      clearStreamStatusForTest(defaultSession().status, streamId);
-    }
-  });
-
-  // The canonical outcome is decided once and projected three ways. This
-  // matrix pins the projections for every terminal path — in particular that
-  // a user stop (the no-throw `cancelled` exit, the dominant stop path)
-  // persists `interrupted` and ends the stage with the literal `cancelled`
-  // outcome. `stage.end()` writes the native `RunOutcome`, so
-  // completed/cancelled/failed stay distinct on the transcript row.
   it('projects returned outcomes to terminal status, stage end, and stream status', async () => {
     const cases = [
       {

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -20,10 +20,7 @@ const mocks = vi.hoisted(() => ({
   releaseExecutionLeaseAfterArtifacts: vi.fn(
     async (_session: unknown, _executionId: ExecutionId) => {},
   ),
-  captureOwnedExecutionLease: vi.fn(
-    (_executionId: ExecutionId) => (operation: () => unknown) => operation(),
-  ),
-  leaseLossListener: undefined as (() => void) | undefined,
+  assertOwnedExecutionLease: vi.fn((_executionId: ExecutionId) => undefined),
 }));
 
 // Turn-state persistence runs against the real (memfs-backed) execution store:
@@ -43,17 +40,7 @@ vi.mock('@agent/storage/executionLifecycle', async (importOriginal) => ({
 vi.mock('@agent/storage/executionLease', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@agent/storage/executionLease')>()),
   markOwnedExecutionLeaseUndurable: vi.fn(),
-  captureOwnedExecutionLease: mocks.captureOwnedExecutionLease,
-  onOwnedExecutionLeaseLost: vi.fn(
-    (_executionId: ExecutionId, listener: () => void) => {
-      mocks.leaseLossListener = listener;
-      return () => {
-        if (mocks.leaseLossListener === listener) {
-          mocks.leaseLossListener = undefined;
-        }
-      };
-    },
-  ),
+  assertOwnedExecutionLease: mocks.assertOwnedExecutionLease,
 }));
 
 vi.mock('@agent/storage/childRunPersistence', () => ({
@@ -276,7 +263,6 @@ beforeEach(() => {
   vi.spyOn(session, 'releaseExecutionLease').mockImplementation((executionId) =>
     mocks.releaseExecutionLeaseAfterArtifacts(session, executionId),
   );
-  mocks.leaseLossListener = undefined;
   mocks.finalizeExecution.mockResolvedValue({
     status: 'durable',
     terminalStatusPersisted: true,
@@ -300,7 +286,7 @@ describe('childRunLoop E2E fixtures', () => {
   it('validates the captured lease before registering loop resources', () => {
     const { childStreamId, executionId } = loopIds('lost-before-setup');
     const { strategy, callCount } = createFakeStrategy();
-    mocks.captureOwnedExecutionLease.mockImplementationOnce(() => {
+    mocks.assertOwnedExecutionLease.mockImplementationOnce(() => {
       throw new Error('lease generation lost');
     });
 
@@ -309,7 +295,6 @@ describe('childRunLoop E2E fixtures', () => {
     );
 
     expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false);
-    expect(mocks.leaseLossListener).toBeUndefined();
     expect(callCount()).toBe(0);
   });
 
@@ -317,10 +302,8 @@ describe('childRunLoop E2E fixtures', () => {
     const { childStreamId, executionId } = loopIds('lost-during-setup');
     const { strategy, callCount } = createFakeStrategy();
     const claimChildRun = vi.spyOn(session.followUps, 'claimChildRun');
-    mocks.captureOwnedExecutionLease
-      .mockImplementationOnce(
-        (_id) => (operation: () => unknown) => operation(),
-      )
+    mocks.assertOwnedExecutionLease
+      .mockImplementationOnce(() => undefined)
       .mockImplementationOnce(() => {
         throw new Error('lease generation lost during setup');
       });
@@ -331,7 +314,6 @@ describe('childRunLoop E2E fixtures', () => {
 
     expect(claimChildRun).not.toHaveBeenCalled();
     expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false);
-    expect(mocks.leaseLossListener).toBeUndefined();
     expect(callCount()).toBe(0);
   });
 
@@ -375,7 +357,6 @@ describe('childRunLoop E2E fixtures', () => {
 
       expect(releaseSessionOwnership).toHaveBeenCalledOnce();
       expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false);
-      expect(mocks.leaseLossListener).toBeUndefined();
       expect(handle.interrupt()).toBe(false);
       interruptHandle.mockClear();
       registry.interruptAll();
@@ -462,8 +443,13 @@ describe('childRunLoop E2E fixtures', () => {
           agentName: name,
         });
 
-        expect(events).toEqual(['registered', 'launch']);
+        expect(events).toEqual(['registered']);
         expect(session.followUps.hasLiveOwner(childStreamId)).toBe(true);
+        // The loop body is a generation on the execution's lane: it starts
+        // once the lane admits it, not inside `startChildRunLoop`.
+        await vi.waitFor(() =>
+          expect(events).toEqual(['registered', 'launch']),
+        );
         interruptAll();
 
         await vi.waitFor(() => {
@@ -477,21 +463,6 @@ describe('childRunLoop E2E fixtures', () => {
       }
     },
   );
-
-  it('interrupts an in-flight child when its execution lease is lost', async () => {
-    const { childStreamId, executionId } = loopIds('lease-loss');
-    const { strategy, rejectTurn } = createFakeStrategy();
-
-    startLoop({ childStreamId, executionId }, strategy);
-    expect(mocks.captureOwnedExecutionLease).toHaveBeenCalledTimes(3);
-    await vi.waitFor(() => expect(mocks.leaseLossListener).toBeDefined());
-
-    mocks.leaseLossListener?.();
-    await rejectTurn(1, createAbortError());
-
-    await waitForLoopEnd(childStreamId);
-    expect(mocks.deliverChildRunFollowUp).not.toHaveBeenCalled();
-  });
 
   it('drains accepted-turn attribution before releasing the execution lease', async () => {
     const { childStreamId, executionId } = loopIds('turn-state-drain');
@@ -509,7 +480,10 @@ describe('childRunLoop E2E fixtures', () => {
     try {
       const handle = startLoop({ childStreamId, executionId }, strategy);
       await writeStarted.promise;
-      mocks.leaseLossListener?.();
+      // Interrupt the loop through its parent lineage: no turn handle is
+      // tracked in this fixture, so the stop reaches the loop via its
+      // child activation.
+      session.executions.stopAgentStream(PARENT_STREAM_ID);
       await rejectTurn(1, createAbortError());
 
       await vi.waitFor(() =>
@@ -1006,7 +980,7 @@ describe('childRunLoop E2E fixtures', () => {
     // the loop's finalize, so the loop reports an interrupted run for a stream
     // whose phase already carries the failure.
     const interruptAfterFailure = vi.fn(() => {
-      mocks.leaseLossListener?.();
+      session.executions.kill(executionId);
     });
 
     startLoop({ childStreamId, executionId }, strategy, {

--- a/src/test-kernel/agent/runtime/ExecutionInteractionOwnership.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionInteractionOwnership.vitest.ts
@@ -111,11 +111,11 @@ describe('execution interaction ownership', () => {
     expect(registry.interactionOwnership.ownerOf('grandchild')).toBe(scope);
   });
 
-  it('holds the owner across the gap between a child activation and its handle', () => {
+  it('holds the owner for the whole life of a child activation', () => {
     const { registry, onRelease, scope, rootStream } = openRootScope();
     const childStream = 'child-stream' as StreamTabId;
 
-    registry.reserveChildActivation({
+    const releaseActivation = registry.reserveChildActivation({
       executionId: 'child',
       parentStreamId: rootStream,
       childStreamId: childStream,
@@ -127,12 +127,15 @@ describe('execution interaction ownership', () => {
     scope.finish();
     expect(onRelease).not.toHaveBeenCalled();
 
-    // Tracking the child's first handle promotes the reservation; the run it
-    // promoted into is what now holds the owner open.
+    // The activation holds the owner for the loop's whole life: across the
+    // child's turn handles and the gaps between them, until the loop's own
+    // disposer runs after its final delivery.
     trackRun(registry, 'child', rootStream, childStream);
     expect(onRelease).not.toHaveBeenCalled();
-
     registry.untrack('child');
+    expect(onRelease).not.toHaveBeenCalled();
+
+    releaseActivation();
     expect(onRelease).toHaveBeenCalledOnce();
   });
 

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -1589,7 +1589,6 @@ describe('executionRegistry', () => {
       });
       expect(registry.getToolUseFollowUpTarget(resumingStreamId)).toEqual({
         kind: 'queue',
-        reason: 'resuming',
       });
 
       seedStreamStatusForTest(streamStatus, waitingStreamId, {
@@ -1597,7 +1596,6 @@ describe('executionRegistry', () => {
       });
       expect(registry.getToolUseFollowUpTarget(waitingStreamId)).toEqual({
         kind: 'queue',
-        reason: 'waiting',
       });
 
       seedStreamStatusForTest(streamStatus, stoppedStreamId, {
@@ -1620,7 +1618,6 @@ describe('executionRegistry', () => {
       );
       expect(registry.getToolUseFollowUpTarget(parentStreamId)).toEqual({
         kind: 'queue',
-        reason: 'children_running',
       });
     } finally {
       registry.dispose();

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -4,10 +4,6 @@ import { describe, expect, it, vi } from 'vitest';
 // Local imports
 import { getExecutionStore } from '@agent/storage';
 import type { AgentTrace, ResultEvent } from '@agent/trace';
-import {
-  ExecutionLeaseLostError,
-  type OwnedExecutionLeaseScope,
-} from '@agent/storage/executionLease';
 import type {
   AgentExecutionHandle,
   LiveToolUseFlowContext,
@@ -91,7 +87,6 @@ type HandleOverrides = {
   agentName?: string;
   category?: AgentCategory;
   trace?: AgentTrace;
-  leaseScope?: OwnedExecutionLeaseScope;
 };
 
 /** Builds an `AgentExecutionHandle` for a toolUse test-subagent, the shape most tests need. */
@@ -109,9 +104,6 @@ function createHandle(
     category: overrides.category,
     trace: overrides.trace,
   });
-  handle.attachExecutionLeaseScope(
-    overrides.leaseScope ?? ((operation) => operation()),
-  );
   return handle;
 }
 
@@ -202,7 +194,7 @@ function trackSuspendedWaitingHandle(
 }
 
 describe('executionRegistry', () => {
-  it('promotes a pending child activation without an ownership gap', () => {
+  it('retains a child activation across handle tracking until its disposer runs', () => {
     const { registry } = createRegistry();
     const activationEvents: boolean[] = [];
     const executionId = 'pending-child-exec' as ExecutionId;
@@ -223,8 +215,10 @@ describe('executionRegistry', () => {
       });
       expect(activationEvents).toEqual([true]);
 
+      // The activation is the child's lineage for the loop's whole life:
+      // tracking a turn handle does not release it, the loop's disposer does.
       registry.track(createHandle(executionId, parentStreamId, childStreamId));
-      expect(activationEvents).toEqual([true, false]);
+      expect(activationEvents).toEqual([true]);
 
       release();
       expect(activationEvents).toEqual([true, false]);
@@ -291,32 +285,6 @@ describe('executionRegistry', () => {
     cleanupFinished.resolve();
     await observation;
     expect(observedCompletion).toBe(true);
-  });
-
-  it('settles without persisting a stopped waiting handle after lease loss', async () => {
-    const { streamStatus, registry } = createRegistry();
-    const executionId = 'exec-waiting-lease-lost' as ExecutionId;
-    const streamId = 'stream-waiting-lease-lost' as StreamTabId;
-    storageMocks.finalizeExecution.mockClear();
-
-    try {
-      const handle = trackSuspendedWaitingHandle(registry, streamStatus, {
-        executionId,
-        childStreamId: streamId,
-      });
-      handle.markExecutionLeaseLost();
-
-      expect(registry.kill(executionId)).toBe(true);
-      await expect(handle.result).resolves.toMatchObject({
-        type: 'result',
-        outcome: RUN_OUTCOME.CANCELLED,
-        executionId,
-      });
-      expect(storageMocks.finalizeExecution).not.toHaveBeenCalled();
-      expect(registry.getHandle(executionId)).toBeUndefined();
-    } finally {
-      registry.dispose();
-    }
   });
 
   it('observes handle replacements and removal in order', () => {
@@ -497,23 +465,17 @@ describe('executionRegistry', () => {
     const childStreamId =
       'child-waiting-kill-publish-result-test' as StreamTabId;
     const trace = spiedTrace({ emit: vi.fn() }, { strict: true });
-    const leaseScopeInvoked = vi.fn();
-    const leaseScope: OwnedExecutionLeaseScope = (operation) => {
-      leaseScopeInvoked();
-      return operation();
-    };
 
     try {
       const handle = trackSuspendedWaitingHandle(registry, streamStatus, {
         executionId,
         parentStreamId,
         childStreamId,
-        overrides: { trace, leaseScope },
+        overrides: { trace },
       });
 
       expect(registry.kill(executionId)).toBe(true);
       await handle.result;
-      expect(leaseScopeInvoked).toHaveBeenCalledOnce();
 
       expect(publishResult).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({
@@ -625,37 +587,6 @@ describe('executionRegistry', () => {
       expect(publishResult).not.toHaveBeenCalled();
       expect(storageMocks.finalizeExecution).not.toHaveBeenCalled();
       expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.WAITING);
-    } finally {
-      registry.dispose();
-    }
-  });
-
-  it('does not let lost-generation recovery mutate a successor handle or lease', async () => {
-    const releaseLease = vi.fn(async () => undefined);
-    const { streamStatus, registry } = createRegistry({
-      releaseRootExecutionLease: releaseLease,
-    });
-    const executionId = 'exec-waiting-lost-generation' as ExecutionId;
-    const streamId = 'stream-waiting-lost-generation' as StreamTabId;
-    const lostScope: OwnedExecutionLeaseScope = () => {
-      throw new ExecutionLeaseLostError(executionId);
-    };
-
-    try {
-      const previous = trackSuspendedWaitingHandle(registry, streamStatus, {
-        executionId,
-        childStreamId: streamId,
-        overrides: { leaseScope: lostScope },
-      });
-
-      expect(registry.kill(executionId)).toBe(true);
-      const successor = createHandle(executionId, streamId, streamId);
-      registry.track(successor);
-
-      await previous.result;
-      expect(registry.getHandle(executionId)).toBe(successor);
-      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.WAITING);
-      expect(releaseLease).not.toHaveBeenCalled();
     } finally {
       registry.dispose();
     }

--- a/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
+++ b/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
@@ -24,18 +24,12 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@agent/storage/executionLease', () => ({
   abandonOwnedExecutionLease: mocks.abandonOwnedExecutionLease,
   acquireResumedExecutionLease: mocks.acquireResumedExecutionLease,
-  captureOwnedExecutionLease:
-    (_executionId: ExecutionId) => (operation: () => unknown) =>
-      operation(),
+  assertOwnedExecutionLease: vi.fn(),
   completeOwnedExecutionLease: mocks.completeOwnedExecutionLease,
   validateOwnedExecutionLease: mocks.validateOwnedExecutionLease,
   runWithExecutionLeaseWriteFence: mocks.runWithExecutionLeaseWriteFence,
   releaseOwnedExecutionLeaseAfterFailure:
     mocks.releaseOwnedExecutionLeaseAfterFailure,
-  runWithOwnedExecutionLease: (
-    _executionId: ExecutionId,
-    operation: () => unknown,
-  ) => operation(),
 }));
 
 vi.mock('@agent/runtime/AgentLaunchContext', () => ({
@@ -73,9 +67,9 @@ vi.mock('@agent/runtime/SessionResumeRetrieval', () => ({
 import type { ITool } from '@agent/core/tools/ToolTypes';
 import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
 import {
-  resumeToolUseFromResumeData,
-  ResumeAdmissionCancelledError,
+  resumeToolUseFromResumeData as resumeOnLane,
   ResumeSessionUnavailableError,
+  type ResumeToolUseFromResumeDataOptions,
 } from '@agent/runtime/executeAgent';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
@@ -101,6 +95,24 @@ interface TestFlowContext {
 
 interface ModelSwitchingFlowInput {
   onModelChanged: (model: string) => void;
+}
+
+/**
+ * The session whose execution lane admits the resume. No competing generation
+ * exists in this fixture, so the lane is a passthrough.
+ */
+const LANE_SESSION = {
+  executions: {
+    launchExecution: (_executionId: ExecutionId, start: () => unknown) =>
+      start(),
+  },
+} as never;
+
+function resumeToolUseFromResumeData(
+  resume: Parameters<typeof resumeOnLane>[0],
+  options: ResumeToolUseFromResumeDataOptions = {},
+): ReturnType<typeof resumeOnLane> {
+  return resumeOnLane(resume, { session: LANE_SESSION, ...options });
 }
 
 /** Minimal launch context for a resumed tool-use run that reaches the flow. */
@@ -280,25 +292,6 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
     expect(mocks.releaseOwnedExecutionLeaseAfterFailure).toHaveBeenCalledTimes(
       1,
     );
-  });
-
-  it('does not build a launch context when canonical admission is withdrawn under the lease lock', async () => {
-    const snapshot = createToolUseResumeData();
-    let canonical = true;
-    mocks.acquireResumedExecutionLease.mockImplementationOnce(
-      async (_executionId: ExecutionId, canAcquire: () => boolean) => {
-        canonical = false;
-        return canAcquire() ? 'acquired' : 'cancelled';
-      },
-    );
-
-    await expect(
-      resumeToolUseFromResumeData(snapshot, {
-        canAcquireResumeLease: () => canonical,
-      }),
-    ).rejects.toBeInstanceOf(ResumeAdmissionCancelledError);
-
-    expect(mocks.buildAgentLaunchContext).not.toHaveBeenCalled();
   });
 
   it('reports a reloaded session that is no longer resumable distinctly', async () => {

--- a/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
@@ -21,9 +21,6 @@ vi.mock('@agent/storage/executionLease', () => ({
   abandonOwnedExecutionLease: mocks.abandonOwnedExecutionLease,
   acquireResumedExecutionLease: mocks.acquireResumedExecutionLease,
   completeOwnedExecutionLease: mocks.completeOwnedExecutionLease,
-  captureOwnedExecutionLease:
-    (_executionId: ExecutionId) => (operation: () => unknown) =>
-      operation(),
   markOwnedExecutionLeaseUndurable: mocks.markOwnedExecutionLeaseUndurable,
   validateOwnedExecutionLease: mocks.validateOwnedExecutionLease,
 }));
@@ -66,6 +63,10 @@ const SESSION = {
     untrack: vi.fn((executionId) => {
       if (trackedHandle?.executionId === executionId) trackedHandle = undefined;
     }),
+    // No competing generation exists in this fixture; the lane is a passthrough.
+    launchExecution: vi.fn((_executionId: ExecutionId, start: () => unknown) =>
+      start(),
+    ),
   },
   flushArtifacts,
   releaseExecutionLease: SessionHandle.prototype.releaseExecutionLease,
@@ -163,7 +164,6 @@ describe('runAgent execution ownership', () => {
     expect(mocks.registerExecution).not.toHaveBeenCalled();
     expect(mocks.acquireResumedExecutionLease).toHaveBeenCalledWith(
       EXECUTION_ID,
-      undefined,
     );
     expect(mocks.completeOwnedExecutionLease).toHaveBeenCalledWith(
       EXECUTION_ID,
@@ -206,26 +206,6 @@ describe('runAgent execution ownership', () => {
     await launch({ kind: 'fresh' });
 
     expect(mocks.clearTerminalExecutionState).not.toHaveBeenCalled();
-  });
-
-  it('abandons a resume whose canonical admission is withdrawn under the lease lock', async () => {
-    let canonical = true;
-    mocks.acquireResumedExecutionLease.mockImplementationOnce(
-      async (_executionId: ExecutionId, canAcquire: () => boolean) => {
-        canonical = false;
-        return canAcquire() ? 'acquired' : 'cancelled';
-      },
-    );
-
-    await expect(
-      launch({ canAcquireResumeLease: () => canonical }),
-    ).rejects.toThrow();
-
-    expect(mocks.acquireResumedExecutionLease).toHaveBeenCalledWith(
-      EXECUTION_ID,
-      expect.any(Function),
-    );
-    expect(mocks.executeAgent).not.toHaveBeenCalled();
   });
 
   it('persists an early launch error before releasing ownership', async () => {

--- a/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
@@ -5,7 +5,6 @@ import { flowKey } from '@agent/node/persistedFlow';
 import {
   acquireFreshExecutionLease,
   completeOwnedExecutionLease,
-  resetExecutionLeaseCoordinationForTests,
 } from '@agent/storage/executionLease';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { submitFollowUp } from '@agent/followUp/ToolUseFollowUp';
@@ -26,6 +25,7 @@ import {
   writeForeignLease,
   writeOrphanedLease,
 } from '@test/support/executionLeaseFixtures';
+import { testExecutionHandle } from '@test/support/executionHandleFixtures';
 import { setupPlatform } from '@test/support/setupPlatform';
 import {
   appendTranscriptEntry,
@@ -157,7 +157,6 @@ afterEach(async () => {
     );
   }
   clearStoreCache();
-  resetExecutionLeaseCoordinationForTests();
 });
 
 describe('SessionHandle restart repair', () => {
@@ -530,59 +529,40 @@ describe('SessionHandle restart repair', () => {
     ).toBeUndefined();
   });
 
-  it('waits for execution artifacts before replacing workspace stores', async () => {
+  it('refuses a storage-root change while an execution is live and changes nothing', async () => {
     const liveExecutionId = 'workspace-live' as ExecutionId;
-    const transcripts = await StreamLogStore.open();
-    const session = openDeferredSession(transcripts);
-    await acquireFreshExecutionLease(liveExecutionId);
-    const reload = vi.spyOn(transcripts, 'reload').mockResolvedValue();
-
-    try {
-      const replacement = session.reloadAfterStorageRootChange();
-      await Promise.resolve();
-
-      expect(reload).not.toHaveBeenCalled();
-      await completeOwnedExecutionLease(liveExecutionId);
-      await replacement;
-
-      expect(reload).toHaveBeenCalledOnce();
-    } finally {
-      await completeOwnedExecutionLease(liveExecutionId);
-    }
-  });
-
-  it('keeps the old storage root pinned until execution artifacts finish', async () => {
-    const liveExecutionId = 'workspace-root-pinned' as ExecutionId;
     const transcripts = await StreamLogStore.open();
     const session = openDeferredSession(transcripts);
     const storage = platform().storage;
     let activeRoot = '/workspace/old-storage';
     vi.spyOn(storage, 'getStoragePath').mockImplementation(() => activeRoot);
+    const commit = vi.fn(() => {
+      activeRoot = '/workspace/new-storage';
+      return true;
+    });
     Object.assign(storage, {
       hasPendingWorkspaceStorageChange: () => true,
-      commitWorkspaceStorageChange: () => {
-        activeRoot = '/workspace/new-storage';
-        return true;
-      },
+      commitWorkspaceStorageChange: commit,
     });
-    await acquireFreshExecutionLease(liveExecutionId);
     const reload = vi.spyOn(transcripts, 'reload').mockResolvedValue();
+    const flush = vi.spyOn(transcripts, 'flush');
+    session.executions.track(
+      testExecutionHandle({
+        executionId: liveExecutionId,
+        parentStreamId: 'workspace-live-stream' as StreamTabId,
+        childStreamId: 'workspace-live-stream' as StreamTabId,
+        agent: 'assistant',
+      }),
+    );
 
-    try {
-      const replacement = session.reloadAfterStorageRootChange();
-      await Promise.resolve();
+    await expect(session.reloadAfterStorageRootChange()).rejects.toThrow(
+      'cannot change its storage location while 1 run is live',
+    );
 
-      expect(storage.getStoragePath()).toBe('/workspace/old-storage');
-      expect(reload).not.toHaveBeenCalled();
-
-      await completeOwnedExecutionLease(liveExecutionId);
-      await replacement;
-
-      expect(storage.getStoragePath()).toBe('/workspace/new-storage');
-      expect(reload).toHaveBeenCalledOnce();
-    } finally {
-      await completeOwnedExecutionLease(liveExecutionId);
-    }
+    expect(flush).not.toHaveBeenCalled();
+    expect(commit).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+    expect(storage.getStoragePath()).toBe('/workspace/old-storage');
   });
 
   it('flushes old-root stores before committing the new storage root', async () => {
@@ -807,7 +787,7 @@ describe('SessionHandle restart repair', () => {
     }
   });
 
-  it('holds new root executions outside the workspace replacement', async () => {
+  it('refuses a launch while the workspace replacement is in flight', async () => {
     const queuedExecutionId = 'workspace-queued' as ExecutionId;
     const transcripts = await StreamLogStore.open();
     const session = openDeferredSession(transcripts);
@@ -816,26 +796,19 @@ describe('SessionHandle restart repair', () => {
       finishReload = resolve;
     });
     vi.spyOn(transcripts, 'reload').mockReturnValue(reloadBlocked);
+    const start = vi.fn(async () => undefined);
 
-    try {
-      const replacement = session.reloadAfterStorageRootChange();
-      await Promise.resolve();
-      const acquisition = acquireFreshExecutionLease(queuedExecutionId);
-      let acquired = false;
-      void acquisition.then(() => {
-        acquired = true;
-      });
-      await Promise.resolve();
+    const replacement = session.reloadAfterStorageRootChange();
+    await Promise.resolve();
+    await expect(
+      session.executions.launchExecution(queuedExecutionId, start),
+    ).rejects.toThrow('cannot change its storage location');
+    expect(start).not.toHaveBeenCalled();
 
-      expect(acquired).toBe(false);
-      finishReload?.();
-      await replacement;
-      await acquisition;
-
-      expect(acquired).toBe(true);
-    } finally {
-      await completeOwnedExecutionLease(queuedExecutionId);
-    }
+    finishReload?.();
+    await replacement;
+    await session.executions.launchExecution(queuedExecutionId, start);
+    expect(start).toHaveBeenCalledOnce();
   });
 
   it('surfaces a repair write failure at the readiness boundary', async () => {

--- a/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
@@ -396,7 +396,8 @@ describe('SessionHandle restart repair', () => {
 
     // Owner proven dead, checkpoint present: the interruption is recorded,
     // the checkpoint stays, and nothing is adopted. The explicit Resume
-    // affordance is the only way to continue; a follow-up is handed back.
+    // affordance is the only way to continue; a follow-up is handed back
+    // with the reason that points there.
     expect(session.status.get(resumableStreamId)).toBe(STREAM_PHASE.CANCELLED);
     expect(session.status.holdState(resumableStreamId)).toBeUndefined();
     await expect(executionStore.readMeta()).resolves.toMatchObject({
@@ -413,10 +414,7 @@ describe('SessionHandle restart repair', () => {
         session,
         onAdmitted,
       }),
-    ).resolves.toEqual({
-      status: 'no_session',
-      streamStatus: STREAM_PHASE.CANCELLED,
-    });
+    ).resolves.toEqual({ status: 'failed', reason: 'not_resumable' });
     expect(onAdmitted).toHaveBeenCalledExactlyOnceWith(false);
   });
 

--- a/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
@@ -25,6 +25,7 @@ import {
   writeForeignLease,
   writeOrphanedLease,
 } from '@test/support/executionLeaseFixtures';
+import { createDeferred } from '@test/support/asyncTestUtils';
 import { testExecutionHandle } from '@test/support/executionHandleFixtures';
 import { setupPlatform } from '@test/support/setupPlatform';
 import {
@@ -571,6 +572,38 @@ describe('SessionHandle restart repair', () => {
     expect(storage.getStoragePath()).toBe('/workspace/old-storage');
   });
 
+  it('refuses a storage-root change while a lane step is admitted but not started, leaving the session as it was', async () => {
+    const executionId = 'workspace-queued' as ExecutionId;
+    const transcripts = await StreamLogStore.open();
+    const session = openDeferredSession(transcripts);
+    const storage = platform().storage;
+    const commit = vi.fn(() => true);
+    Object.assign(storage, {
+      hasPendingWorkspaceStorageChange: () => true,
+      commitWorkspaceStorageChange: commit,
+    });
+    const flush = vi.spyOn(transcripts, 'flush');
+    const generationBefore = Reflect.get(session, 'storageGeneration');
+    const gate = createDeferred();
+    // Admitted synchronously; its body has not run yet.
+    const step = session.executions.runExecutionStep(executionId, async () => {
+      await gate.promise;
+      return 'ran';
+    });
+
+    await expect(session.reloadAfterStorageRootChange()).rejects.toThrow(
+      'cannot change its storage location while 1 run is live',
+    );
+
+    expect(flush).not.toHaveBeenCalled();
+    expect(commit).not.toHaveBeenCalled();
+    expect(Reflect.get(session, 'storageGeneration')).toBe(generationBefore);
+    // The readiness promise was not replaced by the refused change.
+    await expect(session.waitUntilReady()).resolves.toBeUndefined();
+    gate.resolve();
+    await expect(step).resolves.toBe('ran');
+  });
+
   it('flushes old-root stores before committing the new storage root', async () => {
     const transcripts = await StreamLogStore.open();
     const session = openDeferredSession(transcripts);
@@ -809,7 +842,9 @@ describe('SessionHandle restart repair', () => {
     await Promise.resolve();
     await expect(
       session.executions.launchExecution(queuedExecutionId, start),
-    ).rejects.toThrow('cannot change its storage location');
+    ).rejects.toThrow(
+      'TeXRA is changing its storage location. Start this run again in a moment.',
+    );
     expect(start).not.toHaveBeenCalled();
 
     finishReload?.();

--- a/src/test-kernel/agent/runtime/SessionScope.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionScope.vitest.ts
@@ -180,18 +180,14 @@ describe('sendFollowUp host-path session routing', () => {
           session: processSession,
           resumePort: { tryResumeStream: async () => false },
         }),
-      ).resolves.toEqual({
-        status: 'queued',
-        reason: 'children_running',
-        continuation: 'resume_failed',
-      });
+      ).resolves.toEqual({ status: 'failed', reason: 'resume_failed' });
 
       // Without the session it falls back to the default session, which does
       // not track this run — this is the dropped-follow-up regression the
       // session parameter prevents on desktop.
       await expect(submitFollowUp(parentStream, 'continue')).resolves.toEqual({
-        status: 'no_session',
-        streamStatus: undefined,
+        status: 'failed',
+        reason: 'not_resumable',
       });
     } finally {
       processSession.followUps.terminalize(parentStream);

--- a/src/test-kernel/agent/runtime/SessionScope.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionScope.vitest.ts
@@ -180,7 +180,7 @@ describe('sendFollowUp host-path session routing', () => {
           session: processSession,
           resumePort: { tryResumeStream: async () => false },
         }),
-      ).resolves.toEqual({ status: 'failed', reason: 'resume_failed' });
+      ).resolves.toEqual({ status: 'queued', wake: 'failed' });
 
       // Without the session it falls back to the default session, which does
       // not track this run — this is the dropped-follow-up regression the

--- a/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
+++ b/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
@@ -16,8 +16,15 @@ import {
 } from '@agent/runtime/resolveAndResumeStream';
 import { ResumeSessionUnavailableError } from '@agent/runtime/executeAgent';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { type ExecutionId, type StreamTabId } from '@shared/schemas';
-import { clearStreamStatusForTest } from '@test/support/streamStatusTestUtils';
+import {
+  STREAM_PHASE,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
+import {
+  clearStreamStatusForTest,
+  seedStreamStatusForTest,
+} from '@test/support/streamStatusTestUtils';
 import { createDeferred } from '@test/support/asyncTestUtils';
 import { createToolUseResumeData } from '@test/support/toolUseResumeTestUtils';
 
@@ -35,6 +42,7 @@ function basePorts(
   overrides: Partial<ResumeStreamPorts> = {},
 ): ResumeStreamPorts {
   return {
+    executions: { isActiveOrResuming: () => false },
     resolveResumeState: vi.fn(async () => RESOLVED_STATE),
     resumeToolUse: vi.fn(async () => true),
     executeWorkflow: vi.fn(async () => {}),
@@ -147,6 +155,36 @@ describe('resolveAndResumeStream', () => {
       'exec-1',
       'key-1',
     );
+  });
+
+  it('refuses, rather than queues, a resume of a stream that is live in this process', async () => {
+    const session = defaultSession();
+    seedStreamStatusForTest(session.status, STREAM, {
+      phase: STREAM_PHASE.RUNNING,
+    });
+    retrieveSessionResumeDataMock.mockResolvedValue(
+      createToolUseResumeData({ streamId: STREAM }),
+    );
+    const ports = basePorts({ executions: session.executions });
+
+    await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
+    expect(ports.resolveResumeState).not.toHaveBeenCalled();
+    expect(ports.resumeToolUse).not.toHaveBeenCalled();
+    expect(ports.executeWorkflow).not.toHaveBeenCalled();
+
+    // A launch admitted while resume data was being read is refused too:
+    // the lane would queue this resume behind it, not refuse it.
+    clearStreamStatusForTest(session.status, STREAM);
+    retrieveSessionResumeDataMock.mockImplementation(async () => {
+      seedStreamStatusForTest(session.status, STREAM, {
+        phase: STREAM_PHASE.RUNNING,
+      });
+      return createToolUseResumeData({ streamId: STREAM });
+    });
+
+    await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
+    expect(ports.resolveResumeState).toHaveBeenCalledOnce();
+    expect(ports.resumeToolUse).not.toHaveBeenCalled();
   });
 
   it('skips resume when cancellation was already requested', async () => {

--- a/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
+++ b/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
@@ -15,18 +15,9 @@ import {
   type ResumeStreamPorts,
 } from '@agent/runtime/resolveAndResumeStream';
 import { ResumeSessionUnavailableError } from '@agent/runtime/executeAgent';
-import { SessionEventHub } from '@agent/runtime/SessionEventHub';
-import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import {
-  STREAM_PHASE,
-  type ExecutionId,
-  type StreamTabId,
-} from '@shared/schemas';
-import {
-  clearStreamStatusForTest,
-  seedStreamStatusForTest,
-} from '@test/support/streamStatusTestUtils';
+import { type ExecutionId, type StreamTabId } from '@shared/schemas';
+import { clearStreamStatusForTest } from '@test/support/streamStatusTestUtils';
 import { createDeferred } from '@test/support/asyncTestUtils';
 import { createToolUseResumeData } from '@test/support/toolUseResumeTestUtils';
 
@@ -44,7 +35,6 @@ function basePorts(
   overrides: Partial<ResumeStreamPorts> = {},
 ): ResumeStreamPorts {
   return {
-    streamStatus: defaultSession().status,
     resolveResumeState: vi.fn(async () => RESOLVED_STATE),
     resumeToolUse: vi.fn(async () => true),
     executeWorkflow: vi.fn(async () => {}),
@@ -159,34 +149,6 @@ describe('resolveAndResumeStream', () => {
     );
   });
 
-  it('abandons resume when the stream becomes active during retrieval', async () => {
-    // A concurrent non-resume run flips the stream active while we await KV.
-    // `resumeInFlight` (held here) cannot catch that, so the post-retrieval
-    // re-check must bail before touching the resume ports.
-    retrieveSessionResumeDataMock.mockImplementation(async () => {
-      seedStreamStatusForTest(defaultSession().status, STREAM, {
-        phase: STREAM_PHASE.RUNNING,
-      });
-      return createToolUseResumeData({ streamId: STREAM });
-    });
-    const ports = basePorts();
-
-    await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
-    expect(ports.resumeToolUse).not.toHaveBeenCalled();
-    expect(ports.executeWorkflow).not.toHaveBeenCalled();
-  });
-
-  it('skips resume without resolving when the stream is already active', async () => {
-    seedStreamStatusForTest(defaultSession().status, STREAM, {
-      phase: STREAM_PHASE.RUNNING,
-    });
-    const ports = basePorts();
-
-    await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
-    expect(ports.resolveResumeState).not.toHaveBeenCalled();
-    expect(retrieveSessionResumeDataMock).not.toHaveBeenCalled();
-  });
-
   it('skips resume when cancellation was already requested', async () => {
     const ports = basePorts({ isCancellationRequested: () => true });
 
@@ -224,39 +186,6 @@ describe('resolveAndResumeStream', () => {
     await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
     expect(ports.resumeToolUse).not.toHaveBeenCalled();
     expect(ports.executeWorkflow).not.toHaveBeenCalled();
-  });
-
-  it('guards against the injected session machine, not the process default (#7640)', async () => {
-    // Desktop scenario: the window's own session machine has the stream
-    // active while the process-global default is empty. The guard must read
-    // the injected machine — before #7640 it read the global and never fired.
-    const windowStatus = new StreamStatusMachine(new SessionEventHub());
-    seedStreamStatusForTest(windowStatus, STREAM, {
-      phase: STREAM_PHASE.RUNNING,
-    });
-    const ports = basePorts({ streamStatus: windowStatus });
-
-    await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
-    expect(ports.resolveResumeState).not.toHaveBeenCalled();
-
-    clearStreamStatusForTest(windowStatus, STREAM);
-  });
-
-  it('ignores activity recorded only on a different session machine', async () => {
-    // The inverse: activity on the process default must not block a resume in
-    // a session whose own machine says the stream is idle.
-    seedStreamStatusForTest(defaultSession().status, STREAM, {
-      phase: STREAM_PHASE.RUNNING,
-    });
-    retrieveSessionResumeDataMock.mockResolvedValue(
-      createToolUseResumeData({ streamId: STREAM }),
-    );
-    const ports = basePorts({
-      streamStatus: new StreamStatusMachine(new SessionEventHub()),
-    });
-
-    await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(true);
-    expect(ports.resumeToolUse).toHaveBeenCalled();
   });
 
   it('reports a persisted-state read failure separately from missing resume data', async () => {

--- a/src/test-kernel/agent/runtime/resumeQueuedToolUse.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeQueuedToolUse.vitest.ts
@@ -11,10 +11,6 @@ import { createToolUseResumeData } from '@test/support/toolUseResumeTestUtils';
 const resumeToolUseFromResumeDataMock = vi.hoisted(() => vi.fn());
 vi.mock('@agent/runtime/executeAgent', () => ({
   resumeToolUseFromResumeData: resumeToolUseFromResumeDataMock,
-  // The module under test narrows admission cancellation by `instanceof`; the
-  // mocked launcher never throws one, so a stand-in class keeps that branch
-  // false without pulling the real engine module into this test.
-  ResumeAdmissionCancelledError: class extends Error {},
 }));
 
 const STREAM = 'stream:resume-ownership' as StreamTabId;

--- a/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
@@ -18,21 +18,19 @@ import {
   abandonOwnedExecutionLease,
   acquireFreshExecutionLease,
   acquireResumedExecutionLease,
-  captureOwnedExecutionLease,
   completeOwnedExecutionLease,
   inspectExecutionLease,
   isOwnedExecutionLeaseDurable,
   markOwnedExecutionLeaseUndurable,
-  onOwnedExecutionLeaseLost,
   ownsExecutionLease,
   reclaimExecutionLease,
   releaseOwnedExecutionLease,
-  resetExecutionLeaseCoordinationForTests,
   runWithInactiveExecutionLease,
-  captureOwnedExecutionLeaseIfPresent,
   validateOwnedExecutionLease,
-  waitForOwnedExecutionLeaseRelease,
 } from '@agent/storage/executionLease';
+import { ExecutionRegistry } from '@agent/runtime/executionRegistry';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
 import { platform } from '@platform/platform';
 import { RUN_OUTCOME, type ExecutionId } from '@shared/schemas';
@@ -91,7 +89,6 @@ afterEach(async () => {
   }).catch(() => {});
   await StorageFS.delete('executions', { recursive: true }).catch(() => {});
   clearStoreCache();
-  resetExecutionLeaseCoordinationForTests();
 });
 
 beforeEach(() => {
@@ -301,62 +298,53 @@ describe('cross-process execution leases', () => {
     ).rejects.toBeInstanceOf(ExecutionLeaseActiveError);
   });
 
-  it('does not create a resumed lease when canonical admission is withdrawn', async () => {
-    const executionId = 'd8644e' as ExecutionId;
-
-    await expect(
-      acquireResumedExecutionLease(executionId, () => false),
-    ).resolves.toBe('cancelled');
-    expect(ownsExecutionLease(executionId)).toBe(false);
-    await expect(inspectExecutionLease(executionId)).resolves.toEqual({
-      status: 'missing',
+  it('starts a resume only after the previous generation has released its lease', async () => {
+    const executionId = 'd8645a' as ExecutionId;
+    const events = new SessionEventHub();
+    const registry = new ExecutionRegistry({
+      streamStatus: new StreamStatusMachine(events),
+      events,
+      releaseRootExecutionLease: async () => undefined,
     });
-  });
-
-  it('claims nothing while canonical resume admission is pending', async () => {
-    const executionId = 'd8644f' as ExecutionId;
-    const admissionStarted = createDeferred();
-    const admission = createDeferred<boolean>();
-    const acquisition = acquireResumedExecutionLease(executionId, () => {
-      admissionStarted.resolve();
-      return admission.promise;
-    });
-    await admissionStarted.promise;
-
-    // Nothing is claimed before admission, so maintenance proceeds and a
-    // withdrawn admission leaves no record behind.
-    await expect(
-      runWithInactiveExecutionLease(executionId, async () => 'swept'),
-    ).resolves.toEqual({ status: 'performed', value: 'swept' });
-
-    admission.resolve(false);
-    await expect(acquisition).resolves.toBe('cancelled');
-    await expect(inspectExecutionLease(executionId)).resolves.toEqual({
-      status: 'missing',
-    });
-  });
-
-  it('timestamps a resumed lease after asynchronous admission completes', async () => {
-    vi.useFakeTimers({ now: new Date('2026-07-25T12:00:00.000Z') });
-    const admissionDelayMs = 90_000;
-    const executionId = 'd86450' as ExecutionId;
-    const expectedAcquiredAt = Date.now() + admissionDelayMs;
+    const readToken = async (): Promise<string> =>
+      (
+        JSON.parse(await StorageFS.read(executionLeasePath(executionId))) as {
+          ownerToken: string;
+        }
+      ).ownerToken;
+    const disposing = createDeferred();
+    let resumeStarted = false;
 
     try {
-      await expect(
-        acquireResumedExecutionLease(executionId, async () => {
-          await vi.advanceTimersByTimeAsync(admissionDelayMs);
-          return true;
-        }),
-      ).resolves.toBe('acquired');
-      ownedExecutionIds.add(executionId);
+      const first = registry.launchExecution(executionId, async () => {
+        await acquireFreshExecutionLease(executionId);
+        await disposing.promise;
+        await releaseOwnedExecutionLease(executionId);
+      });
+      await vi.waitFor(() =>
+        expect(ownsExecutionLease(executionId)).toBe(true),
+      );
+      const firstToken = await readToken();
 
-      const persisted = JSON.parse(
-        await StorageFS.read(executionLeasePath(executionId)),
-      ) as { acquiredAt: number };
-      expect(persisted).toMatchObject({ acquiredAt: expectedAcquiredAt });
+      const second = registry.launchExecution(executionId, async () => {
+        resumeStarted = true;
+        return acquireResumedExecutionLease(executionId);
+      });
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // The first generation is still disposing: the resume waits and the
+      // record on disk is still the first generation's, so no second lease
+      // was minted under it.
+      expect(resumeStarted).toBe(false);
+      await expect(readToken()).resolves.toBe(firstToken);
+
+      disposing.resolve();
+      await first;
+      await expect(second).resolves.toBe('acquired');
+      ownedExecutionIds.add(executionId);
+      await expect(readToken()).resolves.not.toBe(firstToken);
     } finally {
-      vi.useRealTimers();
+      registry.dispose();
     }
   });
 
@@ -367,9 +355,9 @@ describe('cross-process execution leases', () => {
       new Error('temporary filesystem failure'),
     );
 
-    await expect(
-      acquireResumedExecutionLease(executionId, () => true),
-    ).rejects.toThrow('temporary filesystem failure');
+    await expect(acquireResumedExecutionLease(executionId)).rejects.toThrow(
+      'temporary filesystem failure',
+    );
     expect(ownsExecutionLease(executionId)).toBe(true);
   });
 
@@ -392,23 +380,6 @@ describe('cross-process execution leases', () => {
     await expect(inspectExecutionLease(executionId)).resolves.toEqual({
       status: 'missing',
     });
-  });
-
-  it('settles local release waiters when the matching owner releases', async () => {
-    const executionId = 'd86441' as ExecutionId;
-    await acquire(executionId);
-    let settled = false;
-    const waiting = waitForOwnedExecutionLeaseRelease(executionId).then(() => {
-      settled = true;
-    });
-
-    await Promise.resolve();
-    expect(settled).toBe(false);
-    await releaseOwnedExecutionLease(executionId);
-    ownedExecutionIds.delete(executionId);
-
-    await waiting;
-    expect(settled).toBe(true);
   });
 
   it('stops claiming but preserves the lease after durability failure', async () => {
@@ -481,89 +452,22 @@ describe('cross-process execution leases', () => {
   it('fences an execution-store write immediately after takeover', async () => {
     const executionId = 'e86440' as ExecutionId;
     await acquire(executionId);
-    const onLeaseLost = vi.fn();
-    onOwnedExecutionLeaseLost(executionId, onLeaseLost);
-    await captureOwnedExecutionLease(executionId)(async () => {
-      await writeForeignLease(
-        executionId,
-        '00000000-0000-4000-8000-000000000004',
-      );
-
-      await expect(writeExecution(executionId)).rejects.toBeInstanceOf(
-        ExecutionLeaseLostError,
-      );
-
-      expect(onLeaseLost).toHaveBeenCalledOnce();
-      expect(ownsExecutionLease(executionId)).toBe(false);
-      await expect(
-        getExecutionStore(executionId).writeMeta({
-          timestamp: '2026-07-16T12:01:00.000Z',
-        }),
-      ).rejects.toBeInstanceOf(ExecutionLeaseLostError);
-    });
-    ownedExecutionIds.delete(executionId);
-  });
-
-  it('does not let a displaced continuation borrow a successor lease', async () => {
-    const executionId = 'e86444' as ExecutionId;
-    await acquire(executionId);
-    const lateWriteGate = createDeferred();
-    const lateWrite = Promise.resolve(
-      captureOwnedExecutionLease(executionId)(async () => {
-        await lateWriteGate.promise;
-        expect(ownsExecutionLease(executionId)).toBe(false);
-        markOwnedExecutionLeaseUndurable(executionId);
-        abandonOwnedExecutionLease(executionId);
-        await completeOwnedExecutionLease(executionId);
-        expect(() =>
-          captureOwnedExecutionLease(executionId)(() => undefined),
-        ).toThrow(ExecutionLeaseLostError);
-        await writeExecution(executionId);
-      }),
-    );
-    await writeOrphanedLease(
+    await writeForeignLease(
       executionId,
-      '00000000-0000-4000-8000-000000000006',
+      '00000000-0000-4000-8000-000000000004',
     );
-    await acquireResumedExecutionLease(executionId);
 
-    lateWriteGate.resolve();
-    await expect(lateWrite).rejects.toBeInstanceOf(ExecutionLeaseLostError);
+    await expect(writeExecution(executionId)).rejects.toBeInstanceOf(
+      ExecutionLeaseLostError,
+    );
 
-    await captureOwnedExecutionLease(executionId)(() =>
+    expect(ownsExecutionLease(executionId)).toBe(false);
+    await expect(
       getExecutionStore(executionId).writeMeta({
         timestamp: '2026-07-16T12:01:00.000Z',
       }),
-    );
-    await expect(
-      getExecutionStore(executionId).readMeta(),
-    ).resolves.toMatchObject({
-      timestamp: '2026-07-16T12:01:00.000Z',
-    });
-  });
-
-  it('does not let a delayed lifecycle root capture a successor lease', async () => {
-    const executionId = 'e86445' as ExecutionId;
-    await acquire(executionId);
-    const runWithFirstOwner = captureOwnedExecutionLease(executionId);
-    const firstOwnerPaused = createDeferred();
-    const delayedCapture = Promise.resolve(
-      runWithFirstOwner(async () => {
-        await firstOwnerPaused.promise;
-        return captureOwnedExecutionLeaseIfPresent(executionId);
-      }),
-    );
-    await writeOrphanedLease(
-      executionId,
-      '00000000-0000-4000-8000-000000000007',
-    );
-    await acquireResumedExecutionLease(executionId);
-
-    firstOwnerPaused.resolve();
-    await expect(delayedCapture).rejects.toBeInstanceOf(
-      ExecutionLeaseLostError,
-    );
-    expect(ownsExecutionLease(executionId)).toBe(true);
+    ).rejects.toBeInstanceOf(ExecutionLeaseLostError);
+    ownedExecutionIds.delete(executionId);
   });
 
   it('rejects unscoped writes while another owner has a lease', async () => {

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -223,13 +223,13 @@ describe('SessionStores deletion coordination', () => {
       const leaseReleased = new Promise<void>((resolve) => {
         releaseLease = resolve;
       });
-      vi.spyOn(stores, 'waitForOwnedExecutionRelease').mockReturnValue(
+      vi.spyOn(stores, 'waitForExecutionQuiescence').mockReturnValue(
         leaseReleased,
       );
       const flush = vi.spyOn(snapshots, 'flush');
 
       try {
-        const deletion = stores.deleteStreamAfterOwnedExecutionRelease(stream);
+        const deletion = stores.deleteStreamAfterExecutionQuiescence(stream);
         const drain = stores.waitForPendingStreamDeletions();
         let drainFinished = false;
         void drain.then(() => {
@@ -263,13 +263,13 @@ describe('SessionStores deletion coordination', () => {
       const leaseReleased = new Promise<void>((resolve) => {
         releaseLease = resolve;
       });
-      vi.spyOn(stores, 'waitForOwnedExecutionRelease').mockReturnValue(
+      vi.spyOn(stores, 'waitForExecutionQuiescence').mockReturnValue(
         leaseReleased,
       );
       const deleteTranscript = vi.spyOn(session.transcripts, 'delete');
 
       try {
-        const processDeletion = stores.deleteStreamAfterOwnedExecutionRelease(
+        const processDeletion = stores.deleteStreamAfterExecutionQuiescence(
           stream,
           {
             shouldDelete: () => true,

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -221,26 +221,30 @@ describe('SessionStores deletion coordination', () => {
     });
   });
 
-  it('tracks lease-gated deletion without blocking its artifact flush', async () => {
+  it('tracks lane-gated deletion without blocking its artifact flush', async () => {
     await withSession(async (session) => {
       const stream = 'lease-gated-delete' as StreamTabId;
       session.transcripts.ensureStream(stream);
       const snapshots = new StreamSnapshotStore();
-      const stores = new SessionStores({
-        streamLogs: session.transcripts,
-        snapshots,
-      });
+      ownExecution(snapshots, stream, 'exec-lane' as ExecutionId);
       let releaseLease!: () => void;
       const leaseReleased = new Promise<void>((resolve) => {
         releaseLease = resolve;
       });
-      vi.spyOn(stores, 'waitForExecutionQuiescence').mockReturnValue(
-        leaseReleased,
-      );
+      const stores = new SessionStores({
+        streamLogs: session.transcripts,
+        snapshots,
+        executions: {
+          runExecutionStep: async (_executionId, step) => {
+            await leaseReleased;
+            return step();
+          },
+        },
+      });
       const flush = vi.spyOn(snapshots, 'flush');
 
       try {
-        const deletion = stores.deleteStreamAfterExecutionQuiescence(stream);
+        const deletion = stores.deleteStream(stream);
         const drain = stores.waitForPendingStreamDeletions();
         let drainFinished = false;
         void drain.then(() => {
@@ -266,27 +270,29 @@ describe('SessionStores deletion coordination', () => {
     await withSession(async (session) => {
       const stream = 'shared-incarnation-delete' as StreamTabId;
       session.transcripts.ensureStream(stream);
-      const stores = new SessionStores({
-        streamLogs: session.transcripts,
-        snapshots: new StreamSnapshotStore(),
-      });
+      const snapshots = new StreamSnapshotStore();
+      ownExecution(snapshots, stream, 'exec-shared' as ExecutionId);
       let releaseLease!: () => void;
       const leaseReleased = new Promise<void>((resolve) => {
         releaseLease = resolve;
       });
-      vi.spyOn(stores, 'waitForExecutionQuiescence').mockReturnValue(
-        leaseReleased,
-      );
+      const stores = new SessionStores({
+        streamLogs: session.transcripts,
+        snapshots,
+        executions: {
+          runExecutionStep: async (_executionId, step) => {
+            await leaseReleased;
+            return step();
+          },
+        },
+      });
       const deleteTranscript = vi.spyOn(session.transcripts, 'delete');
 
       try {
-        const processDeletion = stores.deleteStreamAfterExecutionQuiescence(
-          stream,
-          {
-            shouldDelete: () => true,
-            expectedIncarnation: 4,
-          },
-        );
+        const processDeletion = stores.deleteStream(stream, {
+          shouldDelete: () => true,
+          expectedIncarnation: 4,
+        });
         const presentationDeletion = stores.deleteStream(stream, {
           shouldDelete: () => true,
           expectedIncarnation: 4,

--- a/src/test-kernel/cli/CliInitPlatform.vitest.ts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.ts
@@ -455,7 +455,6 @@ describe('CLI platform init', () => {
         });
     });
     const pendingResume = resolveAndResumeStream(streamId, {
-      streamStatus: { isActiveOrResuming: () => false },
       resolveResumeState: () => pendingResumeState,
       resumeToolUse: vi.fn(async () => false),
       executeWorkflow: vi.fn(async () => {}),

--- a/src/test-kernel/cli/CliInitPlatform.vitest.ts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.ts
@@ -455,6 +455,7 @@ describe('CLI platform init', () => {
         });
     });
     const pendingResume = resolveAndResumeStream(streamId, {
+      executions: { isActiveOrResuming: () => false },
       resolveResumeState: () => pendingResumeState,
       resumeToolUse: vi.fn(async () => false),
       executeWorkflow: vi.fn(async () => {}),

--- a/src/test-kernel/cli/ResumeCommand.vitest.ts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.ts
@@ -139,7 +139,6 @@ describe('runResumeExecution', () => {
     mocks.initializeHeadlessTranscriptSession.mockResolvedValue({
       session: {
         interactions: {},
-        status: { isActiveOrResuming: () => false },
       },
     });
     mocks.readConfig.mockResolvedValue(TOOL_USE_CONFIG);

--- a/src/test-kernel/cli/ResumeCommand.vitest.ts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.ts
@@ -139,6 +139,7 @@ describe('runResumeExecution', () => {
     mocks.initializeHeadlessTranscriptSession.mockResolvedValue({
       session: {
         interactions: {},
+        executions: { isActiveOrResuming: () => false },
       },
     });
     mocks.readConfig.mockResolvedValue(TOOL_USE_CONFIG);

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -159,10 +159,7 @@ type LeaseOptions = {
   onRun?: () => void;
   launchSignal?: AbortSignal;
   session?: SessionHandle;
-  onExecutionLeaseAcquired?: (
-    scope: (operation: () => unknown) => unknown,
-    executionId: ExecutionId,
-  ) => void;
+  onExecutionLeaseAcquired?: (executionId: ExecutionId) => void;
 };
 
 /**
@@ -208,11 +205,6 @@ async function spyOnTranscriptFlush() {
   const store = defaultSession().transcripts;
   const flushSpy = vi.spyOn(store, 'flush').mockResolvedValue(undefined);
   return { store, flushSpy };
-}
-
-/** Lease-scope runner for tests that don't need to observe the wrapper. */
-function runOperationSync(operation: () => unknown): unknown {
-  return operation();
 }
 
 async function stubRunExecutionDeps(): Promise<void> {
@@ -263,10 +255,7 @@ async function stubRunExecutionDeps(): Promise<void> {
     flowRecord: 'deleted',
   });
   mocks.runAgent.mockImplementation(async (_request, options) => {
-    options.onExecutionLeaseAcquired?.(
-      runOperationSync,
-      'exec-1' as ExecutionId,
-    );
+    options.onExecutionLeaseAcquired?.('exec-1' as ExecutionId);
     return COMPLETED_RUN;
   });
 }
@@ -798,10 +787,7 @@ describe('executeCliRequest', () => {
     const request = baseRequest();
     const context = cliContext();
     mocks.runAgent.mockImplementationOnce(async (_request, options) => {
-      options.onExecutionLeaseAcquired?.(
-        runOperationSync,
-        'exec-1' as ExecutionId,
-      );
+      options.onExecutionLeaseAcquired?.('exec-1' as ExecutionId);
       options.onApprovalPolicyDenial?.();
       return COMPLETED_RUN;
     });
@@ -867,7 +853,6 @@ describe('executeCliRequest', () => {
       mocks.releaseExecutionLeaseAfterArtifacts.mockImplementationOnce(
         async (session, executionId) => session.flushArtifacts(executionId),
       );
-      const runWithOwnership = vi.fn((operation: () => unknown) => operation());
       let settleRecoveryWrite!: () => void;
       const recoveryWrite = new Promise<void>((resolve) => {
         settleRecoveryWrite = resolve;
@@ -887,7 +872,7 @@ describe('executeCliRequest', () => {
       const shutdown = platform.lifecycle.runShutdown();
       await Promise.resolve();
       expect(mocks.finalizeExecution).not.toHaveBeenCalled();
-      publishLeaseScope?.(runWithOwnership, 'exec-1' as ExecutionId);
+      publishLeaseScope?.('exec-1' as ExecutionId);
       publishRun?.();
       await Promise.resolve();
       expect(killSpy).toHaveBeenCalledExactlyOnceWith('exec-1', {
@@ -908,7 +893,6 @@ describe('executeCliRequest', () => {
       expect(shutdownResolved).toBe(false);
       settleRecoveryWrite();
       await shutdown;
-      expect(runWithOwnership).toHaveBeenCalledOnce();
       expect(mocks.releaseExecutionLeaseAfterArtifacts).toHaveBeenCalledOnce();
       expect(flushSpy).toHaveBeenCalled();
       expect(mocks.finalizeExecution).toHaveBeenCalledWith({
@@ -963,7 +947,7 @@ describe('executeCliRequest', () => {
     });
     await vi.waitFor(() => expect(publishLeaseScope).toBeDefined());
     const shutdown = platform.lifecycle.runShutdown();
-    publishLeaseScope?.(runOperationSync, 'exec-1' as ExecutionId);
+    publishLeaseScope?.('exec-1' as ExecutionId);
     publishRun?.();
     mockCancelledOutcome();
     hangingRun.resolve(COMPLETED_RUN);
@@ -1014,7 +998,7 @@ describe('executeCliRequest', () => {
       });
       await vi.waitFor(() => expect(publishLeaseScope).toBeDefined());
       const shutdown = platform.lifecycle.runShutdown();
-      publishLeaseScope?.(runOperationSync, 'exec-1' as ExecutionId);
+      publishLeaseScope?.('exec-1' as ExecutionId);
       publishRun?.();
       mockCancelledOutcome();
       hangingRun.resolve(COMPLETED_RUN);
@@ -1042,7 +1026,6 @@ describe('executeCliRequest', () => {
     const { platform, executeCliRequest } = await installFakePlatform();
     const drainError = new Error('snapshot drain failed');
     mocks.releaseExecutionLeaseAfterArtifacts.mockRejectedValueOnce(drainError);
-    const runWithOwnership = vi.fn((operation: () => unknown) => operation());
     let leaseOptions: LeaseOptions | undefined;
     const hangingRun = stubHangingRun((options) => {
       leaseOptions = options;
@@ -1050,10 +1033,7 @@ describe('executeCliRequest', () => {
 
     const run = executeCliRequest(baseRequest(), cliContext(), {});
     await vi.waitFor(() => expect(leaseOptions).toBeDefined());
-    leaseOptions?.onExecutionLeaseAcquired?.(
-      runWithOwnership,
-      'exec-1' as ExecutionId,
-    );
+    leaseOptions?.onExecutionLeaseAcquired?.('exec-1' as ExecutionId);
     const shutdown = platform.lifecycle.runShutdown();
 
     await expect(leaseOptions?.beforeLeaseRelease?.()).rejects.toBe(drainError);
@@ -1101,10 +1081,7 @@ describe('executeCliRequest', () => {
     });
     const run = executeCliRequest(baseRequest(), cliContext(), {});
     await vi.waitFor(() => expect(leaseOptions).toBeDefined());
-    leaseOptions?.onExecutionLeaseAcquired?.(
-      runOperationSync,
-      'exec-1' as ExecutionId,
-    );
+    leaseOptions?.onExecutionLeaseAcquired?.('exec-1' as ExecutionId);
     leaseOptions?.onRun?.();
 
     const shutdown = platform.lifecycle.runShutdown();
@@ -1131,10 +1108,7 @@ describe('executeCliRequest', () => {
     await vi.waitFor(() => expect(leaseOptions).toBeDefined());
 
     const shutdown = platform.lifecycle.runShutdown();
-    leaseOptions?.onExecutionLeaseAcquired?.(
-      runOperationSync,
-      'exec-1' as ExecutionId,
-    );
+    leaseOptions?.onExecutionLeaseAcquired?.('exec-1' as ExecutionId);
     leaseOptions?.onRun?.();
     await leaseOptions?.openWorkflowOutput?.(COMPLETED_WORKFLOW_RUN);
     mockCancelledOutcome();
@@ -1168,10 +1142,7 @@ describe('executeCliRequest', () => {
       },
     });
     await vi.waitFor(() => expect(leaseOptions).toBeDefined());
-    leaseOptions?.onExecutionLeaseAcquired?.(
-      runOperationSync,
-      'exec-1' as ExecutionId,
-    );
+    leaseOptions?.onExecutionLeaseAcquired?.('exec-1' as ExecutionId);
     leaseOptions?.onRun?.();
     await leaseOptions?.openWorkflowOutput?.(COMPLETED_WORKFLOW_RUN);
 
@@ -1196,7 +1167,6 @@ describe('executeCliRequest', () => {
     // earlier test's `vi.resetModules()` in this file.
     const { AgentError: RuntimeAgentError } = await import('@common/errors');
     const killSpy = vi.spyOn(defaultSession().executions, 'kill');
-    const runWithOwnership = vi.fn((operation: () => unknown) => operation());
     const outputFailure = new Error(
       'Workflow completed without generated outputs; nothing was copied to out.',
     );
@@ -1208,10 +1178,7 @@ describe('executeCliRequest', () => {
     });
     mocks.runAgent.mockImplementationOnce(
       async (_request: unknown, options: LeaseOptions) => {
-        options.onExecutionLeaseAcquired?.(
-          runWithOwnership,
-          'exec-1' as ExecutionId,
-        );
+        options.onExecutionLeaseAcquired?.('exec-1' as ExecutionId);
         options.onRun?.();
         try {
           await options.openWorkflowOutput?.(COMPLETED_WORKFLOW_RUN);
@@ -1254,29 +1221,29 @@ describe('executeCliRequest', () => {
     });
   });
 
-  it('does not finalize shutdown through a captured lease that is already lost', async () => {
+  it('does not report a shutdown drain that fails because the lease is already lost', async () => {
     const { platform, executeCliRequest } = await installFakePlatform();
     // Imported dynamically (matching the module above) so the `instanceof`
     // check in runExecution.ts sees the same module instance even after an
     // earlier test's `vi.resetModules()` in this file.
-    const { ExecutionLeaseLostError } =
-      await import('@agent/storage/executionLease');
+    const { ExecutionLeaseLostError } = await import('@agent/storage');
+    mocks.releaseExecutionLeaseAfterArtifacts.mockRejectedValueOnce(
+      new ExecutionLeaseLostError('exec-1' as ExecutionId),
+    );
+    let leaseOptions: LeaseOptions | undefined;
     const hangingRun = stubHangingRun((options) => {
-      options.onExecutionLeaseAcquired?.(() => {
-        throw new ExecutionLeaseLostError('exec-1');
-      }, 'exec-1' as ExecutionId);
+      leaseOptions = options;
     });
 
     const run = executeCliRequest(baseRequest(), cliContext(), {});
-    await vi.waitFor(() => expect(mocks.runAgent).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(leaseOptions).toBeDefined());
+    leaseOptions?.onExecutionLeaseAcquired?.('exec-1' as ExecutionId);
     const shutdown = platform.lifecycle.runShutdown();
-    await Promise.resolve();
-    expect(mocks.finalizeExecution).not.toHaveBeenCalled();
 
+    await expect(leaseOptions?.beforeLeaseRelease?.()).resolves.toBe(false);
     hangingRun.resolve(COMPLETED_RUN);
     await shutdown;
     await run;
-    expect(mocks.finalizeExecution).not.toHaveBeenCalled();
   });
 
   it('closes the runtime host when shutdown finalization fails', async () => {
@@ -1289,10 +1256,7 @@ describe('executeCliRequest', () => {
       outcomePersisted: false,
     });
     const hangingRun = stubHangingRun((options) => {
-      options.onExecutionLeaseAcquired?.(
-        runOperationSync,
-        'exec-1' as ExecutionId,
-      );
+      options.onExecutionLeaseAcquired?.('exec-1' as ExecutionId);
     });
 
     const onInterruptedExecutionFinalized = vi.fn();
@@ -1392,7 +1356,7 @@ describe('executeCliConfig', () => {
     });
     await vi.waitFor(() => expect(publishLeaseScope).toBeDefined());
     const shutdown = platform.lifecycle.runShutdown();
-    publishLeaseScope?.(runOperationSync, 'exec-1' as ExecutionId);
+    publishLeaseScope?.('exec-1' as ExecutionId);
     publishRun?.();
     mockCancelledOutcome();
     hangingRun.resolve(COMPLETED_RUN);
@@ -1432,7 +1396,7 @@ describe('executeCliConfig', () => {
     });
     await vi.waitFor(() => expect(publishLeaseScope).toBeDefined());
     const shutdown = platform.lifecycle.runShutdown();
-    publishLeaseScope?.(runOperationSync, 'exec-1' as ExecutionId);
+    publishLeaseScope?.('exec-1' as ExecutionId);
     publishRun?.();
     mockCancelledOutcome();
     hangingRun.resolve(COMPLETED_RUN);

--- a/src/test-kernel/cli/chatSessionController.vitest.ts
+++ b/src/test-kernel/cli/chatSessionController.vitest.ts
@@ -20,7 +20,6 @@ const mocks = vi.hoisted(() => ({
   createCliRuntimeHost: vi.fn(),
   presentationHostClose: vi.fn(),
   defaultSession: vi.fn(),
-  streamIsActiveOrResuming: vi.fn(),
   getActiveExecutionIds: vi.fn(),
   getExecutionHandle: vi.fn(),
   addExecutionRegistrationListener: vi.fn(),
@@ -345,7 +344,6 @@ function installSession(overrides: Record<string, unknown> = {}): void {
       }),
     },
     approvals: { registerStreamParent: vi.fn() },
-    status: { isActiveOrResuming: mocks.streamIsActiveOrResuming },
     executions: {
       ...executions,
       // The stubbed registry still answers the three surfaces the real
@@ -587,7 +585,6 @@ describe('createChatSessionController', () => {
       close: mocks.presentationHostClose,
       emit: vi.fn(),
     });
-    mocks.streamIsActiveOrResuming.mockReturnValue(false);
     mocks.getActiveExecutionIds.mockReturnValue([]);
     mocks.addExecutionRegistrationListener.mockReturnValue(vi.fn());
     mocks.addChildActivationListener.mockReturnValue(vi.fn());
@@ -601,7 +598,6 @@ describe('createChatSessionController', () => {
         const options = args[2] as ResumeQueuedToolUseOptions;
         options.onFollowUpQueueReady?.({
           streamId: 'stream:test' as StreamTabId,
-          generation: 1,
           generationId: 'recovery-generation',
           kind: 'recovery',
         });
@@ -982,6 +978,7 @@ describe('createChatSessionController', () => {
     const rootStream = 'activation-root' as StreamTabId;
     const childStream = 'activation-child' as StreamTabId;
     const childExecutionId = 'activation-child-exec' as ExecutionId;
+    let releaseChildActivation = (): void => undefined;
 
     mocks.createCliRuntimeHost.mockReturnValue(presentationHost);
     mocks.createTuiHostInteractions.mockReturnValue({
@@ -1002,7 +999,7 @@ describe('createChatSessionController', () => {
           'root',
         );
         options.onStreamResolved?.(rootStream);
-        executions.reserveChildActivation({
+        releaseChildActivation = executions.reserveChildActivation({
           executionId: childExecutionId,
           parentStreamId: rootStream,
           childStreamId: childStream,
@@ -1037,7 +1034,11 @@ describe('createChatSessionController', () => {
     );
     expect(presentationHost.close).not.toHaveBeenCalled();
 
+    // The activation outlives the child's turn handles; the host is held
+    // until the loop's own disposer runs.
     executions.untrack(childExecutionId);
+    expect(presentationHost.close).not.toHaveBeenCalled();
+    releaseChildActivation();
     await vi.waitFor(() => {
       expect(presentationHost.close).toHaveBeenCalledOnce();
       expect(disposeAdapter).toHaveBeenCalledOnce();
@@ -1533,15 +1534,14 @@ describe('createChatSessionController', () => {
       'stream-1',
       makeAutoResumeData(),
       expect.objectContaining({
-        canAcquireResumeLease: expect.any(Function),
         isCancellationRequested: expect.any(Function),
       }),
     );
     const resumeOptions = mocks.resumeQueuedToolUseFromResumeData.mock
       .calls[0]?.[2] as ResumeQueuedToolUseOptions | undefined;
-    expect(resumeOptions?.canAcquireResumeLease?.()).toBe(true);
+    expect(resumeOptions?.isCancellationRequested()).toBe(false);
     session.stopRequested = true;
-    expect(resumeOptions?.canAcquireResumeLease?.()).toBe(false);
+    expect(resumeOptions?.isCancellationRequested()).toBe(true);
     expect(mocks.syncStreamLog).toHaveBeenCalledWith(
       init.runtimeSession,
       'stream-1',
@@ -1572,7 +1572,7 @@ describe('createChatSessionController', () => {
         resumeOptions = options;
         leaseCheckStarted.resolve();
         await releaseLeaseCheck.promise;
-        return options.canAcquireResumeLease?.() ?? true;
+        return !options.isCancellationRequested();
       },
     );
     const ctrl = createChatSessionController(
@@ -1581,7 +1581,6 @@ describe('createChatSessionController', () => {
 
     const resume = ctrl.tryResumeStream('stream-1', {
       streamId: 'stream-1' as StreamTabId,
-      generation: 1,
       kind: 'recovery',
     });
     await leaseCheckStarted.promise;
@@ -1589,7 +1588,7 @@ describe('createChatSessionController', () => {
     ctrl.stop();
     session.clearRunState();
     expect(session.stopRequested).toBe(false);
-    expect(resumeOptions?.canAcquireResumeLease?.()).toBe(false);
+    expect(resumeOptions?.isCancellationRequested()).toBe(true);
 
     releaseLeaseCheck.resolve();
     await expect(resume).resolves.toBe(false);
@@ -1635,7 +1634,6 @@ describe('createChatSessionController', () => {
     await expect(
       ctrl.tryResumeStream('stream-1', {
         streamId: 'stream-1' as StreamTabId,
-        generation: 1,
         kind: 'recovery',
       }),
     ).resolves.toBe(false);
@@ -1651,7 +1649,6 @@ describe('createChatSessionController', () => {
     await expect(
       ctrl.tryResumeStream('stream-1', {
         streamId: 'stream-1' as StreamTabId,
-        generation: 2,
         kind: 'recovery',
       }),
     ).resolves.toBe(true);
@@ -1690,7 +1687,6 @@ describe('createChatSessionController', () => {
     await expect(
       ctrl.tryResumeStream('stream-1', {
         streamId: 'stream-1' as StreamTabId,
-        generation: 1,
         kind: 'recovery',
       }),
     ).resolves.toBe(false);
@@ -1701,7 +1697,6 @@ describe('createChatSessionController', () => {
     await expect(
       ctrl.tryResumeStream('stream-1', {
         streamId: 'stream-1' as StreamTabId,
-        generation: 2,
         kind: 'recovery',
       }),
     ).resolves.toBe(true);
@@ -1797,7 +1792,6 @@ describe('createChatSessionController', () => {
         const options = args[2] as ResumeQueuedToolUseOptions;
         options.onFollowUpQueueReady?.({
           streamId: 'stream:test' as StreamTabId,
-          generation: 1,
           generationId: 'recovery-generation',
           kind: 'recovery',
         });

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -3636,10 +3636,15 @@ describe('DesktopProgressBridge', () => {
       owner.processSession.transcripts.ensureStream(childStreamId);
       owner.close();
 
+      // The deletion is pending while its ownership read is in flight: the
+      // child stream has no resident run metadata, so the read goes to disk.
       const leaseReleased = createDeferred();
       const waitForRelease = vi
-        .spyOn(owner.sessionStores, 'waitForExecutionQuiescence')
-        .mockReturnValue(leaseReleased.promise);
+        .spyOn(owner.progressSnapshotStore, 'readPersistedExecutionId')
+        .mockImplementation(async () => {
+          await leaseReleased.promise;
+          return undefined;
+        });
 
       try {
         owner.processSession.events.emit({
@@ -3698,14 +3703,18 @@ describe('DesktopProgressBridge', () => {
       });
       const firstRelease = createDeferred();
       const secondRelease = createDeferred();
+      // The deletion runs as a step on the execution lane; gate the lane.
       const waitForRelease = vi
-        .spyOn(owner.sessionStores, 'waitForExecutionQuiescence')
-        .mockReturnValueOnce(firstRelease.promise)
-        .mockReturnValueOnce(secondRelease.promise);
-      const processFallback = vi.spyOn(
-        owner.sessionStores,
-        'deleteStreamAfterExecutionQuiescence',
-      );
+        .spyOn(owner.processSession.executions, 'runExecutionStep')
+        .mockImplementationOnce(async (_executionId, step) => {
+          await firstRelease.promise;
+          return step();
+        })
+        .mockImplementationOnce(async (_executionId, step) => {
+          await secondRelease.promise;
+          return step();
+        });
+      const deleteStream = vi.spyOn(owner.sessionStores, 'deleteStream');
 
       try {
         emitSessionFact(owner.bridgeA, 'removeStream', {
@@ -3756,7 +3765,12 @@ describe('DesktopProgressBridge', () => {
         await vi.waitFor(() => expect(waitForRelease).toHaveBeenCalledTimes(2));
         await settleProgressEvents();
 
-        expect(processFallback).not.toHaveBeenCalled();
+        // Both deletions are the presentation's (incarnations 0 and 1); a
+        // process fallback would have issued a third.
+        expect(deleteStream).toHaveBeenCalledTimes(2);
+        expect(
+          deleteStream.mock.calls.map(([, o]) => o?.expectedIncarnation),
+        ).toEqual([0, 1]);
         expect(owner.processSession.transcripts.has(streamId)).toBe(true);
       } finally {
         firstRelease.resolve();

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -388,10 +388,6 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
   mocks.doMock('@agent/runtime/executeAgent', () => ({
     resumeToolUseFromResumeData:
       options.resumeToolUseFromResumeData ?? vi.fn(async () => {}),
-    // `resumeQueuedToolUse` narrows admission cancellation by `instanceof`
-    // against this module's error; the stubbed launcher never throws one, so a
-    // stand-in class keeps that branch false.
-    ResumeAdmissionCancelledError: class extends Error {},
   }));
   mocks.doMock('@agent/runtime/runAgent', () => ({
     runAgent: options.runAgent ?? vi.fn(),
@@ -2119,23 +2115,6 @@ describe('DesktopProgressBridge', () => {
     );
   });
 
-  it('does not resume a stream deleted in this desktop session', async () => {
-    const retrieveSessionResumeData = vi.fn(async () =>
-      searchToolUseResumeData(),
-    );
-    const bridge = await createBridge([], {
-      canonicalStreamIds: ['stream-1'],
-      retrieveSessionResumeData,
-    });
-
-    emitSearchRunConfig(bridge);
-
-    await deleteStreamViaInbound(bridge, 'stream-1');
-    emitSearchRunConfig(bridge);
-    await expect(tryResumeStream('stream-1')).resolves.toBe(false);
-    expect(retrieveSessionResumeData).not.toHaveBeenCalled();
-  });
-
   it('forgets desktop goal records when deleting a stream', async () => {
     const stream = 'goal-stream' as StreamTabId;
     const bridge = await createBridge([]);
@@ -3658,7 +3637,7 @@ describe('DesktopProgressBridge', () => {
 
       const leaseReleased = createDeferred();
       const waitForRelease = vi
-        .spyOn(owner.sessionStores, 'waitForOwnedExecutionRelease')
+        .spyOn(owner.sessionStores, 'waitForExecutionQuiescence')
         .mockReturnValue(leaseReleased.promise);
 
       try {
@@ -3719,12 +3698,12 @@ describe('DesktopProgressBridge', () => {
       const firstRelease = createDeferred();
       const secondRelease = createDeferred();
       const waitForRelease = vi
-        .spyOn(owner.sessionStores, 'waitForOwnedExecutionRelease')
+        .spyOn(owner.sessionStores, 'waitForExecutionQuiescence')
         .mockReturnValueOnce(firstRelease.promise)
         .mockReturnValueOnce(secondRelease.promise);
       const processFallback = vi.spyOn(
         owner.sessionStores,
-        'deleteStreamAfterOwnedExecutionRelease',
+        'deleteStreamAfterExecutionQuiescence',
       );
 
       try {

--- a/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.ts
@@ -90,10 +90,6 @@ async function createExecution(options: {
   }));
   mocks.doMock('@agent/runtime/executeAgent', () => ({
     resumeToolUseFromResumeData: vi.fn(async () => {}),
-    // `resumeQueuedToolUse` narrows admission cancellation by `instanceof`
-    // against this module's error; the stubbed launcher never throws one, so a
-    // stand-in class keeps that branch false.
-    ResumeAdmissionCancelledError: class extends Error {},
   }));
   mocks.doMock('@agent/runtime/runAgent', () => ({
     runAgent: options.runAgent ?? vi.fn(async () => {}),

--- a/src/test-kernel/desktop/DesktopAgentResume.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentResume.vitest.ts
@@ -12,7 +12,6 @@ import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import * as SessionResumeRetrieval from '@agent/runtime/SessionResumeRetrieval';
 import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
 import * as AgentRunner from '@agent/runtime/runAgent';
-import { ResumeAdmissionCancelledError } from '@agent/runtime/executeAgent';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { DesktopProcessResumeOwner } from '@desktop/main/desktopAgentResume';
 import {
@@ -320,26 +319,5 @@ describe('desktop process resume owner', () => {
     await expect(resume).resolves.toBe(false);
     expect(runAgent).not.toHaveBeenCalled();
     expect(harness.session.transcripts.has(stream)).toBe(false);
-  });
-
-  it('rejects a stale process store after another process deletes the stream', async () => {
-    mockWorkflowResume();
-    const harness = createResumeHarness();
-    vi.spyOn(
-      harness.session.transcripts,
-      'hasAuthoritativeStream',
-    ).mockResolvedValue(false);
-    runAgent.mockImplementation(async (_request, options) => {
-      if ((await options.canAcquireResumeLease?.()) === false) {
-        throw new ResumeAdmissionCancelledError(executionId);
-      }
-      return completedRunResult();
-    });
-
-    await expect(harness.owner.tryResumeStream(stream)).resolves.toBe(false);
-    expect(harness.session.transcripts.has(stream)).toBe(true);
-
-    const presenter = attachResultPresenter(harness.session);
-    expect(presenter.emit).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/desktop/DesktopAgentResume.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentResume.vitest.ts
@@ -320,4 +320,18 @@ describe('desktop process resume owner', () => {
     expect(runAgent).not.toHaveBeenCalled();
     expect(harness.session.transcripts.has(stream)).toBe(false);
   });
+
+  it('rejects a stale process store after another process deletes the stream', async () => {
+    mockWorkflowResume();
+    const harness = createResumeHarness();
+    vi.spyOn(
+      harness.session.transcripts,
+      'hasAuthoritativeStream',
+    ).mockResolvedValue(false);
+
+    await expect(harness.owner.tryResumeStream(stream)).resolves.toBe(false);
+    expect(runAgent).not.toHaveBeenCalled();
+    expect(retrieveSessionResumeData).not.toHaveBeenCalled();
+    expect(harness.session.transcripts.has(stream)).toBe(true);
+  });
 });

--- a/src/test-kernel/progressView/ProgressBackendPresentation.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendPresentation.vitest.ts
@@ -124,10 +124,6 @@ async function expectDeletionReleasesEarlierRootReplacement(
   vi.spyOn(session.executions, 'getAgentHandleByStream').mockReturnValue(
     {} as never,
   );
-  vi.spyOn(
-    backend.state.stores,
-    'waitForExecutionQuiescence',
-  ).mockResolvedValue();
   mockSuccessfulClear(backend, deletionKind, async () => {
     operations.push('delete');
   });

--- a/src/test-kernel/progressView/ProgressBackendPresentation.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendPresentation.vitest.ts
@@ -126,7 +126,7 @@ async function expectDeletionReleasesEarlierRootReplacement(
   );
   vi.spyOn(
     backend.state.stores,
-    'waitForOwnedExecutionRelease',
+    'waitForExecutionQuiescence',
   ).mockResolvedValue();
   mockSuccessfulClear(backend, deletionKind, async () => {
     operations.push('delete');

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -473,35 +473,45 @@ describe('ProgressBackend', () => {
     expect(lifecycle.cleanupDeletedStream).not.toHaveBeenCalled();
   });
 
-  it('waits for a terminal child lease after its handle is untracked', async () => {
-    const { backend, session } = createIsolatedRecordingBackend();
+  it('deletes a terminal child on its execution lane after its handle is untracked', async () => {
+    const target = createIsolatedRecordingBackend();
+    const { backend, session } = target;
     const stream = 'completed-background-bash' as StreamTabId;
+    const executionId = 'c40009' as ExecutionId;
     let releaseLease!: () => void;
     const leaseReleased = new Promise<void>((resolve) => {
       releaseLease = resolve;
     });
-    const waitForRelease = vi
-      .spyOn(backend.state.stores, 'waitForExecutionQuiescence')
-      .mockReturnValue(leaseReleased);
-    const clearStream = vi.spyOn(backend.state, 'clearStream');
+    const laneStep = vi
+      .spyOn(session.executions, 'runExecutionStep')
+      .mockImplementation(async (_executionId, step) => {
+        await leaseReleased;
+        return step();
+      });
 
     try {
       backend.state.streamLogs.ensureStream(stream);
+      emitRunConfig(
+        target,
+        stream,
+        executionId,
+        toolUseConfig('search', 'deepseekproT'),
+      );
       expect(session.executions.getAgentHandleByStream(stream)).toBeUndefined();
 
       const deletion = backend.deleteStream(stream);
       expect(backend.state.stores.hasStreamDeletionClaim(stream)).toBe(true);
       await vi.waitFor(() =>
-        expect(waitForRelease).toHaveBeenCalledWith(stream),
+        expect(laneStep).toHaveBeenCalledWith(
+          executionId,
+          expect.any(Function),
+        ),
       );
-      expect(clearStream).not.toHaveBeenCalled();
+      expect(backend.state.streamLogs.has(stream)).toBe(true);
 
       releaseLease();
       await deletion;
 
-      expect(clearStream).toHaveBeenCalledWith(stream, {
-        expectedIncarnation: 0,
-      });
       expect(backend.state.stores.hasStreamDeletionClaim(stream)).toBe(false);
       expect(backend.state.streamLogs.has(stream)).toBe(false);
     } finally {
@@ -1191,17 +1201,12 @@ describe('ProgressBackend', () => {
     vi.spyOn(session.executions, 'getAgentHandleByStream').mockReturnValue(
       {} as never,
     );
-    const waitForRelease = vi
-      .spyOn(backend.state.stores, 'waitForExecutionQuiescence')
-      .mockResolvedValue(undefined);
     stubClearAll(backend);
 
     await backend.deleteAllStreams();
 
     expect(lifecycle.stopStream).toHaveBeenCalledWith(first);
     expect(lifecycle.stopStream).toHaveBeenCalledWith(second);
-    expect(waitForRelease).toHaveBeenCalledWith(first);
-    expect(waitForRelease).toHaveBeenCalledWith(second);
   });
 
   it('aborts bulk cleanup when stopping an owned stream fails', async () => {
@@ -1223,16 +1228,11 @@ describe('ProgressBackend', () => {
     vi.spyOn(session.executions, 'getAgentHandleByStream').mockReturnValue(
       {} as never,
     );
-    const waitForRelease = vi.spyOn(
-      backend.state.stores,
-      'waitForExecutionQuiescence',
-    );
     const clearAll = vi.spyOn(backend.state, 'clearAll');
 
     await expect(backend.deleteAllStreams()).rejects.toBe(stopError);
 
     expect(lifecycle.stopStream).toHaveBeenCalledWith(stream);
-    expect(waitForRelease).not.toHaveBeenCalled();
     expect(clearAll).not.toHaveBeenCalled();
     expect(lifecycle.cleanupDeletedStream).not.toHaveBeenCalled();
     expect(lifecycle.cleanupDeletedStreams).not.toHaveBeenCalled();

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -481,7 +481,7 @@ describe('ProgressBackend', () => {
       releaseLease = resolve;
     });
     const waitForRelease = vi
-      .spyOn(backend.state.stores, 'waitForOwnedExecutionRelease')
+      .spyOn(backend.state.stores, 'waitForExecutionQuiescence')
       .mockReturnValue(leaseReleased);
     const clearStream = vi.spyOn(backend.state, 'clearStream');
 
@@ -1192,7 +1192,7 @@ describe('ProgressBackend', () => {
       {} as never,
     );
     const waitForRelease = vi
-      .spyOn(backend.state.stores, 'waitForOwnedExecutionRelease')
+      .spyOn(backend.state.stores, 'waitForExecutionQuiescence')
       .mockResolvedValue(undefined);
     stubClearAll(backend);
 
@@ -1225,7 +1225,7 @@ describe('ProgressBackend', () => {
     );
     const waitForRelease = vi.spyOn(
       backend.state.stores,
-      'waitForOwnedExecutionRelease',
+      'waitForExecutionQuiescence',
     );
     const clearAll = vi.spyOn(backend.state, 'clearAll');
 

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
@@ -90,7 +90,7 @@ function createProgressViewProvider(): ProgressViewProviderFake {
     streamLogs: new Map<StreamTabId, unknown>(),
     snapshots,
     pickValidActiveStream: vi.fn(() => ''),
-    waitForOwnedExecutionRelease: vi.fn(async () => undefined),
+    waitForExecutionQuiescence: vi.fn(async () => undefined),
   };
   return {
     state,

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
@@ -90,7 +90,6 @@ function createProgressViewProvider(): ProgressViewProviderFake {
     streamLogs: new Map<StreamTabId, unknown>(),
     snapshots,
     pickValidActiveStream: vi.fn(() => ''),
-    waitForExecutionQuiescence: vi.fn(async () => undefined),
   };
   return {
     state,

--- a/src/test-kernel/settings/ExtensionWorkspaceTransition.vitest.ts
+++ b/src/test-kernel/settings/ExtensionWorkspaceTransition.vitest.ts
@@ -81,6 +81,7 @@ vi.mock('@agent/trace', () => ({
   createChannelTrace: () => ({ debug: vi.fn(), error: vi.fn() }),
 }));
 vi.mock('@agent/runtime/SessionHandle', () => ({
+  StorageRootChangeRefusedError: class extends Error {},
   defaultSession: () => ({
     interactions: {},
     useHostInteractions: () => () => {},

--- a/src/test-kernel/tools/ChildRunDelivery.vitest.ts
+++ b/src/test-kernel/tools/ChildRunDelivery.vitest.ts
@@ -63,11 +63,7 @@ describe('child run delivery', () => {
 
   it('submits delivery and recovery as one operation', async () => {
     const session = { tag: 'owner' };
-    mocks.submitFollowUp.mockResolvedValue({
-      status: 'queued',
-      reason: 'waiting',
-      continuation: 'resumed',
-    });
+    mocks.submitFollowUp.mockResolvedValue({ status: 'queued' });
 
     await expect(
       deliverChildRunFollowUp({
@@ -88,7 +84,7 @@ describe('child run delivery', () => {
     );
   });
 
-  it('classifies missing and terminal parents', async () => {
+  it('carries the refusal reason for a parent that did not accept delivery', async () => {
     function deliverToParent(followUp: {
       text: string;
     }): ReturnType<typeof deliverChildRunFollowUp> {
@@ -100,17 +96,21 @@ describe('child run delivery', () => {
     }
 
     mocks.submitFollowUp.mockResolvedValueOnce({
-      status: 'no_session',
-      streamStatus: 'completed',
+      status: 'failed',
+      reason: 'finished',
     });
     await expect(deliverToParent({ text: 'done' })).resolves.toEqual({
-      kind: 'no_session',
-      streamStatus: 'completed',
+      kind: 'failed',
+      reason: 'finished',
     });
 
-    mocks.submitFollowUp.mockResolvedValueOnce({ status: 'dropped' });
+    mocks.submitFollowUp.mockResolvedValueOnce({
+      status: 'failed',
+      reason: 'not_resumable',
+    });
     await expect(deliverToParent({ text: 'late' })).resolves.toEqual({
-      kind: 'dropped',
+      kind: 'failed',
+      reason: 'not_resumable',
     });
   });
 });

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -69,9 +69,7 @@ vi.mock('@agent/storage', () => ({
 }));
 
 vi.mock('@agent/storage/executionLease', () => ({
-  captureOwnedExecutionLease:
-    (_executionId: ExecutionId) => (operation: () => unknown) =>
-      operation(),
+  assertOwnedExecutionLease: vi.fn(),
 }));
 
 vi.mock('@utils/files/taskRunStorage', () => ({

--- a/src/test-kernel/tools/CodexResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/CodexResumeFallback.vitest.ts
@@ -63,9 +63,7 @@ vi.mock('@agent/storage', () => ({
 }));
 
 vi.mock('@agent/storage/executionLease', () => ({
-  captureOwnedExecutionLease:
-    (_executionId: ExecutionId) => (operation: () => unknown) =>
-      operation(),
+  assertOwnedExecutionLease: vi.fn(),
 }));
 
 vi.mock('@utils/files/taskRunStorage', () => ({

--- a/src/test-kernel/tools/DelegationHeadless.vitest.ts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.ts
@@ -76,25 +76,19 @@ vi.mock('@agent/storage', () => ({
   registerExecution: mocks.registerExecution,
 }));
 
-// The launch sites register through `registerOwnedExecution`, which calls
-// `registerExecution` module-internally; route the spy through it the same way.
+// The launch sites register through `registerExecution`; route the spy through it.
 vi.mock('@agent/storage/executionLifecycle', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('@agent/storage/executionLifecycle')>();
   return {
     ...actual,
-    registerOwnedExecution: async (...args: unknown[]) => {
-      await mocks.registerExecution(...args);
-      return (operation: () => unknown) => operation();
-    },
+    registerExecution: mocks.registerExecution,
   };
 });
 
 vi.mock('@agent/storage/executionLease', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@agent/storage/executionLease')>()),
-  captureOwnedExecutionLease:
-    (_executionId: ExecutionId) => (operation: () => unknown) =>
-      operation(),
+  assertOwnedExecutionLease: vi.fn(),
   inspectExecutionLease: mocks.inspectExecutionLease,
   markOwnedExecutionLeaseUndurable: vi.fn((executionId: ExecutionId) => {
     mocks.undurableExecutionIds.add(executionId);

--- a/src/test-kernel/tools/DelegationHeadless.vitest.ts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.ts
@@ -43,7 +43,7 @@ import {
 const mocks = vi.hoisted(() => ({
   configureDelegatedChildApprovals: vi.fn(),
   executeAgent: vi.fn(),
-  resumeToolUseFromResumeData: vi.fn(),
+  resumeToolUseTurn: vi.fn(),
   getExecutionStore: vi.fn(),
   getVisibleAgents: vi.fn(),
   inspectExecutionLease: vi.fn(),
@@ -406,7 +406,7 @@ describe('headless delegation', () => {
     mocks.undurableExecutionIds.clear();
     restoreAgentEngine = provideAgentEngine({
       executeAgent: mocks.executeAgent,
-      resumeToolUseFromResumeData: mocks.resumeToolUseFromResumeData,
+      resumeToolUseTurn: mocks.resumeToolUseTurn,
     } as unknown as AgentEngine);
     mocks.getVisibleAgents.mockReturnValue([
       {

--- a/src/test-kernel/tools/DelegationTools.vitest.ts
+++ b/src/test-kernel/tools/DelegationTools.vitest.ts
@@ -200,8 +200,8 @@ describe('DelegateAgentTool resume ownership', () => {
 
   it('reports a merged recovery failure to the parent', async () => {
     mocks.submitFollowUp.mockResolvedValue({
-      status: 'failed',
-      reason: 'resume_failed',
+      status: 'queued',
+      wake: 'failed',
     });
 
     await new DelegateAgentTool().call({

--- a/src/test-kernel/tools/DelegationTools.vitest.ts
+++ b/src/test-kernel/tools/DelegationTools.vitest.ts
@@ -25,7 +25,8 @@ vi.mock('@agent/runtime/SessionHandle', () => ({
   currentSession: mocks.currentSession,
 }));
 
-vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
+vi.mock('@agent/followUp/ToolUseFollowUp', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@agent/followUp/ToolUseFollowUp')>()),
   submitFollowUp: mocks.submitFollowUp,
 }));
 
@@ -185,11 +186,7 @@ describe('DelegateAgentTool resume ownership', () => {
   });
 
   it('uses the merged submission result without a caller-local owner check', async () => {
-    mocks.submitFollowUp.mockResolvedValue({
-      status: 'queued',
-      reason: 'waiting',
-      continuation: 'live',
-    });
+    mocks.submitFollowUp.mockResolvedValue({ status: 'queued' });
 
     const result = await new DelegateAgentTool().call({
       execution_id: executionId,
@@ -203,9 +200,8 @@ describe('DelegateAgentTool resume ownership', () => {
 
   it('reports a merged recovery failure to the parent', async () => {
     mocks.submitFollowUp.mockResolvedValue({
-      status: 'queued',
-      reason: 'waiting',
-      continuation: 'resume_failed',
+      status: 'failed',
+      reason: 'resume_failed',
     });
 
     await new DelegateAgentTool().call({

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -13,7 +13,6 @@ import {
   registerExecution,
   writeWorkflowExecutionSnapshot,
 } from '@agent/storage';
-import { captureOwnedExecutionLease } from '@agent/storage/executionLease';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { FileInteractionState } from '@agent/core/state/AgentWorkspaceState';
 import * as toolUseFollowUp from '@agent/followUp/ToolUseFollowUp';
@@ -439,67 +438,65 @@ describe('ExecutionsTool /executions/{id}/output', () => {
       { length: 513 },
       (_, index) => `${'f'.repeat(600)}-${index}-file-tail.tex`,
     );
-    await captureOwnedExecutionLease(executionId)(() =>
-      writeWorkflowExecutionSnapshot(executionId, {
-        lifecycle: 'active',
-        currentStageId: longStageId,
-        stages: [
-          {
-            id: longStageId,
-            title: longTitle,
-            order: 0,
-            lifecycle: 'active',
-            startedAt: timestamp,
-          },
-        ],
-        calls: [
-          {
-            id: longCallId,
-            label: '   ',
-            stageId: longStageId,
-            agent: 'writer',
-            files: { input: longFiles, context: [], media: [] },
-            childExecutionId: 'abcdef123456',
-            attempts: [
-              {
-                number: 1,
-                id: '111111111111',
-                startedAt: timestamp,
-                completedAt: timestamp,
-              },
-              {
-                number: 2,
-                id: '222222222222',
-                childStreamId: 'writer#222222222222',
-                model: 'historical-model',
-                costUsd: 0.2,
-                startedAt: timestamp,
-                completedAt: timestamp,
-              },
-              {
-                number: 3,
-                id: 'abcdef123456',
-                childStreamId: 'writer#abcdef123456',
-                model: 'replacement-model',
-                costUsd: 0.3,
-                startedAt: timestamp,
-                completedAt: timestamp,
-              },
-            ],
-            status: 'failed',
-            error: longError,
-            timestamps: {
-              createdAt: timestamp,
-              queuedAt: timestamp,
+    await writeWorkflowExecutionSnapshot(executionId, {
+      lifecycle: 'active',
+      currentStageId: longStageId,
+      stages: [
+        {
+          id: longStageId,
+          title: longTitle,
+          order: 0,
+          lifecycle: 'active',
+          startedAt: timestamp,
+        },
+      ],
+      calls: [
+        {
+          id: longCallId,
+          label: '   ',
+          stageId: longStageId,
+          agent: 'writer',
+          files: { input: longFiles, context: [], media: [] },
+          childExecutionId: 'abcdef123456',
+          attempts: [
+            {
+              number: 1,
+              id: '111111111111',
               startedAt: timestamp,
-              updatedAt: timestamp,
               completedAt: timestamp,
             },
+            {
+              number: 2,
+              id: '222222222222',
+              childStreamId: 'writer#222222222222',
+              model: 'historical-model',
+              costUsd: 0.2,
+              startedAt: timestamp,
+              completedAt: timestamp,
+            },
+            {
+              number: 3,
+              id: 'abcdef123456',
+              childStreamId: 'writer#abcdef123456',
+              model: 'replacement-model',
+              costUsd: 0.3,
+              startedAt: timestamp,
+              completedAt: timestamp,
+            },
+          ],
+          status: 'failed',
+          error: longError,
+          timestamps: {
+            createdAt: timestamp,
+            queuedAt: timestamp,
+            startedAt: timestamp,
+            updatedAt: timestamp,
+            completedAt: timestamp,
           },
-        ],
-        timestamps: { createdAt: timestamp, updatedAt: timestamp },
-      }),
-    );
+        },
+      ],
+      timestamps: { createdAt: timestamp, updatedAt: timestamp },
+    });
 
     const result = await new ExecutionsTool().call({
       path: `/executions/${executionId}`,
@@ -545,54 +542,52 @@ describe('ExecutionsTool /executions/{id}/output', () => {
       };
     });
     const failedAt = new Date(base).toISOString();
-    await captureOwnedExecutionLease(executionId)(() =>
-      writeWorkflowExecutionSnapshot(executionId, {
-        lifecycle: 'active',
-        currentStageId: 'stage-2',
-        stages: [
-          {
-            id: 'stage-1',
-            title: 'Earlier stage',
-            order: 0,
-            lifecycle: 'failed',
-            startedAt: failedAt,
-            completedAt: failedAt,
-          },
-          {
-            id: 'stage-2',
-            title: 'Current stage',
-            order: 1,
-            lifecycle: 'active',
-            startedAt: failedAt,
-          },
-        ],
-        calls: [
-          {
-            id: 'older-failed',
-            label: 'Older failed',
-            stageId: 'stage-1',
-            files: { input: [], context: [], media: [] },
-            attempts: [
-              {
-                number: 1,
-                startedAt: failedAt,
-                completedAt: failedAt,
-              },
-            ],
-            status: 'failed',
-            error: 'expected failure',
-            timestamps: {
-              createdAt: failedAt,
+    await writeWorkflowExecutionSnapshot(executionId, {
+      lifecycle: 'active',
+      currentStageId: 'stage-2',
+      stages: [
+        {
+          id: 'stage-1',
+          title: 'Earlier stage',
+          order: 0,
+          lifecycle: 'failed',
+          startedAt: failedAt,
+          completedAt: failedAt,
+        },
+        {
+          id: 'stage-2',
+          title: 'Current stage',
+          order: 1,
+          lifecycle: 'active',
+          startedAt: failedAt,
+        },
+      ],
+      calls: [
+        {
+          id: 'older-failed',
+          label: 'Older failed',
+          stageId: 'stage-1',
+          files: { input: [], context: [], media: [] },
+          attempts: [
+            {
+              number: 1,
               startedAt: failedAt,
-              updatedAt: failedAt,
               completedAt: failedAt,
             },
+          ],
+          status: 'failed',
+          error: 'expected failure',
+          timestamps: {
+            createdAt: failedAt,
+            startedAt: failedAt,
+            updatedAt: failedAt,
+            completedAt: failedAt,
           },
-          ...completedCalls,
-        ],
-        timestamps: { createdAt: failedAt, updatedAt: failedAt },
-      }),
-    );
+        },
+        ...completedCalls,
+      ],
+      timestamps: { createdAt: failedAt, updatedAt: failedAt },
+    });
 
     const result = await new ExecutionsTool().call({
       path: `/executions/${executionId}`,
@@ -621,47 +616,45 @@ describe('ExecutionsTool /executions/{id}/output', () => {
         completedAt: timestamp,
       },
     }));
-    await captureOwnedExecutionLease(executionId)(() =>
-      writeWorkflowExecutionSnapshot(executionId, {
-        lifecycle: 'active',
-        currentStageId: 'stage-2',
-        stages: [
-          {
-            id: 'stage-1',
-            title: 'Earlier stage',
-            order: 0,
-            lifecycle: 'completed',
+    await writeWorkflowExecutionSnapshot(executionId, {
+      lifecycle: 'active',
+      currentStageId: 'stage-2',
+      stages: [
+        {
+          id: 'stage-1',
+          title: 'Earlier stage',
+          order: 0,
+          lifecycle: 'completed',
+          startedAt: timestamp,
+          completedAt: timestamp,
+        },
+        {
+          id: 'stage-2',
+          title: 'Current stage',
+          order: 1,
+          lifecycle: 'active',
+          startedAt: timestamp,
+        },
+      ],
+      calls: [
+        ...terminalCalls,
+        {
+          id: 'earlier-live',
+          label: 'Earlier live',
+          stageId: 'stage-1',
+          files: { input: [], context: [], media: [] },
+          attempts: [{ number: 1, startedAt: timestamp }],
+          status: 'running',
+          timestamps: {
+            createdAt: timestamp,
+            queuedAt: timestamp,
             startedAt: timestamp,
-            completedAt: timestamp,
+            updatedAt: timestamp,
           },
-          {
-            id: 'stage-2',
-            title: 'Current stage',
-            order: 1,
-            lifecycle: 'active',
-            startedAt: timestamp,
-          },
-        ],
-        calls: [
-          ...terminalCalls,
-          {
-            id: 'earlier-live',
-            label: 'Earlier live',
-            stageId: 'stage-1',
-            files: { input: [], context: [], media: [] },
-            attempts: [{ number: 1, startedAt: timestamp }],
-            status: 'running',
-            timestamps: {
-              createdAt: timestamp,
-              queuedAt: timestamp,
-              startedAt: timestamp,
-              updatedAt: timestamp,
-            },
-          },
-        ],
-        timestamps: { createdAt: timestamp, updatedAt: timestamp },
-      }),
-    );
+        },
+      ],
+      timestamps: { createdAt: timestamp, updatedAt: timestamp },
+    });
 
     const result = await new ExecutionsTool().call({
       path: `/executions/${executionId}`,

--- a/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
+++ b/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
@@ -277,11 +277,7 @@ describe('external inquiry continuation session routing', () => {
   ])(
     'delegates queued wake decisions to the follow-up owner ($name)',
     async ({ session }) => {
-      submitFollowUpMock.mockResolvedValueOnce({
-        status: 'queued',
-        reason: 'waiting',
-        continuation: 'resumed' as const,
-      });
+      submitFollowUpMock.mockResolvedValueOnce({ status: 'queued' });
 
       const outcome = await injectContinuationForAnsweredThread(
         THREAD,
@@ -289,13 +285,14 @@ describe('external inquiry continuation session routing', () => {
         session,
       );
 
-      expect(outcome).toBe('resumed');
+      expect(outcome).toBe('queued');
     },
   );
 
-  it('archives inquiries when the follow-up owner drops a stale queue', async () => {
+  it('archives inquiries when the follow-up owner refuses a stale queue', async () => {
     submitFollowUpMock.mockResolvedValueOnce({
-      status: 'dropped' as const,
+      status: 'failed' as const,
+      reason: 'not_resumable' as const,
     });
 
     const outcome = await injectContinuationForAnsweredThread(

--- a/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
@@ -30,9 +30,9 @@ import {
 } from '@agent/storage';
 import { clearInlineAgents } from '@agent/index/agentRegistry';
 import {
-  captureOwnedExecutionLease,
+  assertOwnedExecutionLease,
+  ownsExecutionLease,
   releaseOwnedExecutionLease,
-  waitForOwnedExecutionLeaseRelease,
 } from '@agent/storage/executionLease';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
@@ -223,13 +223,24 @@ async function waitForCompletedResumes(count: number): Promise<void> {
   });
 }
 
+type ParentOwnerRunner = <T>(operation: () => T) => T;
+
+/**
+ * Wait for the child's lease release. The loop's lane stays held past that
+ * point while its final delivery wakes the parent, so the lease, not the
+ * lane, is the durable boundary these assertions read against.
+ */
+function waitForLeaseRelease(executionId: ExecutionId): Promise<void> {
+  return vi.waitFor(() => expect(ownsExecutionLease(executionId)).toBe(false));
+}
+
 /**
  * Queue the second-assertion follow-up onto a WAITING child through the real
  * DelegateAgentTool path, asserting the queue accepted it.
  */
 async function queueSecondAssertionFollowUp(
   parentContext: ReturnType<typeof createRunContext>,
-  runAsParentOwner: ReturnType<typeof captureOwnedExecutionLease>,
+  runAsParentOwner: ParentOwnerRunner,
   executionId: ExecutionId,
   instruction = 'Now prove the second assertion.',
 ) {
@@ -261,7 +272,7 @@ async function launchWaitingChild(options: {
 }): Promise<{
   readonly executionId: ExecutionId;
   readonly parentContext: ReturnType<typeof createRunContext>;
-  readonly runAsParentOwner: ReturnType<typeof captureOwnedExecutionLease>;
+  readonly runAsParentOwner: ParentOwnerRunner;
   readonly observedFollowUps: ObservedFollowUp[];
 }> {
   const observedFollowUps: ObservedFollowUp[] = [];
@@ -308,7 +319,10 @@ async function launchWaitingChild(options: {
     modelCell: new ModelCell({} as never, PARENT_MODEL),
     session,
   });
-  const runAsParentOwner = captureOwnedExecutionLease(PARENT_EXECUTION_ID);
+  const runAsParentOwner: ParentOwnerRunner = (operation) => {
+    assertOwnedExecutionLease(PARENT_EXECUTION_ID);
+    return operation();
+  };
   const launch = await runAsParentOwner(() =>
     withRunContext(parentContext, () =>
       executeSubagent(
@@ -352,7 +366,7 @@ describe('native subagent production delivery path', { retry: 2 }, () => {
 
   afterEach(async () => {
     interruptActiveExecutions(session);
-    if (childId) await waitForOwnedExecutionLeaseRelease(childId);
+    if (childId) await waitForLeaseRelease(childId);
     await releaseOwnedExecutionLease(PARENT_EXECUTION_ID);
     session.dispose();
     clearInlineAgents();
@@ -666,10 +680,12 @@ describe('native subagent production delivery path', { retry: 2 }, () => {
       result: { response: 'Result A.' },
     });
 
-    // Interrupt turn 2 before it persists any result.
-    interruptActiveExecutions(session);
+    // Stop the child before turn 2 persists any result. The registry stop
+    // reaches the loop as well as the turn, so the turn is interrupted rather
+    // than delivered as a cancelled completion.
+    expect(session.executions.kill(executionId)).toBe(true);
     releaseTurn2(new Error('interrupted before result persistence'));
-    await waitForOwnedExecutionLeaseRelease(executionId);
+    await waitForLeaseRelease(executionId);
 
     // Turn 1 stays the latest completed turn; turn 2 remains on record as
     // the interrupted active turn instead of turn 1 posing as current.

--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -25,7 +25,7 @@ const mocks = vi.hoisted(() => ({
   persistChildRunResultMeta: vi.fn(),
   readConfig: vi.fn(),
   writeTurnState: vi.fn(),
-  resumeToolUseFromResumeData: vi.fn(),
+  resumeToolUseTurn: vi.fn(),
   retrieveSessionResumeData: vi.fn(),
   throwDeliveryFormatting: false,
   throwErrorFormatting: false,
@@ -184,7 +184,7 @@ describe('NativeSubagentStrategy', () => {
     vi.resetAllMocks();
     restoreAgentEngine = provideAgentEngine({
       executeAgent: mocks.executeAgent,
-      resumeToolUseFromResumeData: mocks.resumeToolUseFromResumeData,
+      resumeToolUseTurn: mocks.resumeToolUseTurn,
     } as unknown as AgentEngine);
     mocks.throwDeliveryFormatting = false;
     mocks.throwErrorFormatting = false;
@@ -421,22 +421,20 @@ describe('NativeSubagentStrategy', () => {
     const ready = new Promise<void>((resolve) => {
       replacementReady = resolve;
     });
-    mocks.resumeToolUseFromResumeData.mockImplementationOnce(
-      async (_resume, options) => {
-        options.onRun?.({
-          childStreamId,
-          deliveryTargetStreamId: params.parentStreamId,
-          interrupt: replacementInterrupt,
-        } as never);
-        replacementReady();
-        await new Promise<void>((resolve) =>
-          turn.signal.addEventListener('abort', () => resolve(), {
-            once: true,
-          }),
-        );
-        return toolUseTurnResult('cancelled', params.executionId);
-      },
-    );
+    mocks.resumeToolUseTurn.mockImplementationOnce(async (_resume, options) => {
+      options.onRun?.({
+        childStreamId,
+        deliveryTargetStreamId: params.parentStreamId,
+        interrupt: replacementInterrupt,
+      } as never);
+      replacementReady();
+      await new Promise<void>((resolve) =>
+        turn.signal.addEventListener('abort', () => resolve(), {
+          once: true,
+        }),
+      );
+      return toolUseTurnResult('cancelled', params.executionId);
+    });
 
     const resumed = strategy.runTurn!([], fakePorts(), turn);
     await ready;
@@ -569,7 +567,7 @@ describe('NativeSubagentStrategy', () => {
     });
     mocks.readConfig.mockResolvedValue(config);
     mocks.retrieveSessionResumeData.mockResolvedValue(snapshot);
-    mocks.resumeToolUseFromResumeData.mockResolvedValueOnce(
+    mocks.resumeToolUseTurn.mockResolvedValueOnce(
       toolUseTurnResult('completed', params.executionId, { response: 'done' }),
     );
 
@@ -584,7 +582,7 @@ describe('NativeSubagentStrategy', () => {
       params.executionId,
       config,
     );
-    expect(mocks.resumeToolUseFromResumeData).toHaveBeenCalledWith(
+    expect(mocks.resumeToolUseTurn).toHaveBeenCalledWith(
       snapshot,
       expect.objectContaining({
         approvalPromptsUnavailable: true,
@@ -615,7 +613,7 @@ describe('NativeSubagentStrategy', () => {
       createToolUseResumeData({ executionId: params.executionId }),
     );
     const resumeError = new Error('resume storage unreadable');
-    mocks.resumeToolUseFromResumeData.mockRejectedValueOnce(resumeError);
+    mocks.resumeToolUseTurn.mockRejectedValueOnce(resumeError);
 
     await expect(
       strategy.runTurn!([], fakePorts(), new AbortController()),
@@ -677,15 +675,13 @@ describe('NativeSubagentStrategy', () => {
     });
     mocks.readConfig.mockResolvedValue(config);
     mocks.retrieveSessionResumeData.mockResolvedValue(resume);
-    mocks.resumeToolUseFromResumeData.mockImplementation(
-      async (_snapshot, options) => {
-        options.onRun?.(handle);
-        session.status.transitionToWaiting(childStreamId, 'wait');
-        return waitingTurn(
-          `follow-up response ${mocks.resumeToolUseFromResumeData.mock.calls.length}`,
-        );
-      },
-    );
+    mocks.resumeToolUseTurn.mockImplementation(async (_snapshot, options) => {
+      options.onRun?.(handle);
+      session.status.transitionToWaiting(childStreamId, 'wait');
+      return waitingTurn(
+        `follow-up response ${mocks.resumeToolUseTurn.mock.calls.length}`,
+      );
+    });
 
     const strategy = createNativeSubagentStrategy(params);
     try {
@@ -712,7 +708,7 @@ describe('NativeSubagentStrategy', () => {
       ).toEqual({ kind: 'live' });
 
       await vi.waitFor(() =>
-        expect(mocks.resumeToolUseFromResumeData).toHaveBeenCalledTimes(1),
+        expect(mocks.resumeToolUseTurn).toHaveBeenCalledTimes(1),
       );
       await vi.waitFor(() =>
         expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(2),
@@ -730,19 +726,19 @@ describe('NativeSubagentStrategy', () => {
       ).toEqual({ kind: 'live' });
 
       await vi.waitFor(() =>
-        expect(mocks.resumeToolUseFromResumeData).toHaveBeenCalledTimes(2),
+        expect(mocks.resumeToolUseTurn).toHaveBeenCalledTimes(2),
       );
       await vi.waitFor(() =>
         expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(3),
       );
       await sleep(50);
 
-      expect(mocks.resumeToolUseFromResumeData).toHaveBeenCalledTimes(2);
+      expect(mocks.resumeToolUseTurn).toHaveBeenCalledTimes(2);
+      expect(mocks.resumeToolUseTurn.mock.calls.map((call) => call[0])).toEqual(
+        [resume, resume],
+      );
       expect(
-        mocks.resumeToolUseFromResumeData.mock.calls.map((call) => call[0]),
-      ).toEqual([resume, resume]);
-      expect(
-        mocks.resumeToolUseFromResumeData.mock.calls.map(
+        mocks.resumeToolUseTurn.mock.calls.map(
           (call) => call[1].drainedFollowUps,
         ),
       ).toEqual([
@@ -876,7 +872,7 @@ describe('NativeSubagentStrategy', () => {
         expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false),
       );
 
-      expect(mocks.resumeToolUseFromResumeData).not.toHaveBeenCalled();
+      expect(mocks.resumeToolUseTurn).not.toHaveBeenCalled();
       expect(mocks.retrieveSessionResumeData).not.toHaveBeenCalled();
     } finally {
       session.followUps.terminalize(childStreamId);

--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -65,9 +65,7 @@ vi.mock('@agent/storage', () => ({
 
 vi.mock('@agent/storage/executionLease', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@agent/storage/executionLease')>()),
-  captureOwnedExecutionLease:
-    (_executionId: ExecutionId) => (operation: () => unknown) =>
-      operation(),
+  assertOwnedExecutionLease: vi.fn(),
   validateOwnedExecutionLease: vi.fn(async () => {}),
   abandonOwnedExecutionLease: vi.fn(),
   completeOwnedExecutionLease: vi.fn(async () => ({

--- a/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
+++ b/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
@@ -45,24 +45,18 @@ vi.mock('@agent/storage', () => ({
   registerExecution: mocks.registerExecution,
 }));
 
-// `executeSubagent` registers through `registerOwnedExecution`, which calls
-// `registerExecution` module-internally; route the spy through it the same way.
+// `executeSubagent` registers through `registerExecution`; route the spy through it.
 vi.mock('@agent/storage/executionLifecycle', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('@agent/storage/executionLifecycle')>();
   return {
     ...actual,
-    registerOwnedExecution: async (...args: unknown[]) => {
-      await mocks.registerExecution(...args);
-      return (operation: () => unknown) => operation();
-    },
+    registerExecution: mocks.registerExecution,
   };
 });
 
 vi.mock('@agent/storage/executionLease', () => ({
-  captureOwnedExecutionLease:
-    (_executionId: string) => (operation: () => unknown) =>
-      operation(),
+  assertOwnedExecutionLease: vi.fn(),
   runWithOwnedExecutionLeaseLaunchGuard: (
     _executionId: string,
     operation: () => unknown,

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -50,17 +50,13 @@ vi.mock('@agent/storage', async (importOriginal) => {
   return { ...actual, registerExecution: mocks.registerExecution };
 });
 
-// The launch sites register through `registerOwnedExecution`, which calls
-// `registerExecution` module-internally; route the spy through it the same way.
+// The launch sites register through `registerExecution`; route the spy through it.
 vi.mock('@agent/storage/executionLifecycle', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('@agent/storage/executionLifecycle')>();
   return {
     ...actual,
-    registerOwnedExecution: async (...args: unknown[]) => {
-      await mocks.registerExecution(...args);
-      return (operation: () => unknown) => operation();
-    },
+    registerExecution: mocks.registerExecution,
   };
 });
 
@@ -83,9 +79,7 @@ vi.mock('@tools/delegation/workflowScriptStrategy', async (importOriginal) => {
 
 vi.mock('@agent/storage/executionLease', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@agent/storage/executionLease')>()),
-  captureOwnedExecutionLease:
-    (_executionId: ExecutionId) => (operation: () => unknown) =>
-      operation(),
+  assertOwnedExecutionLease: vi.fn(),
 }));
 
 vi.mock('@agent/runtime/childRunLoop', () => ({

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -49,9 +49,7 @@ vi.mock('@agent/storage/executionLifecycle', async (importActual) => ({
 vi.mock('@agent/storage/executionLease', async (importActual) => ({
   ...(await importActual<typeof import('@agent/storage/executionLease')>()),
   acquireResumedExecutionLease: launchMocks.acquireResumedExecutionLease,
-  captureOwnedExecutionLease:
-    (_executionId: ExecutionId) => (operation: () => unknown) =>
-      operation(),
+  assertOwnedExecutionLease: vi.fn(),
   releaseOwnedExecutionLeaseAfterFailure:
     launchMocks.releaseOwnedExecutionLeaseAfterFailure,
 }));
@@ -457,7 +455,6 @@ describe('completedRunArchive facade', () => {
     try {
       await expect(
         resolveAndResumeStream(streamId, {
-          streamStatus: session.status,
           resolveResumeState,
           resumeToolUse: async (resume) => {
             await resumeToolUseFromResumeData(resume, { session });

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -455,6 +455,7 @@ describe('completedRunArchive facade', () => {
     try {
       await expect(
         resolveAndResumeStream(streamId, {
+          executions: session.executions,
           resolveResumeState,
           resumeToolUse: async (resume) => {
             await resumeToolUseFromResumeData(resume, { session });

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -3,10 +3,7 @@
 
 import { registerExecution } from '@agent/storage';
 import { type AgentTrace } from '@agent/trace';
-import {
-  captureOwnedExecutionLease,
-  releaseOwnedExecutionLeaseAfterFailure,
-} from '@agent/storage/executionLease';
+import { releaseOwnedExecutionLeaseAfterFailure } from '@agent/storage/executionLease';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import {
   currentSession,
@@ -226,47 +223,43 @@ export async function launchAgentCliSession(
   } catch {
     throw new ToolError(params.registerFailedMessage);
   }
-  const runWithOwnership = captureOwnedExecutionLease(executionId);
-
-  return runWithOwnership(async () => {
-    let childStream: ChildStream | undefined;
-    try {
-      childStream = createChildStream(executionId, params.parentStreamId, {
-        streamPrefix: params.streamPrefix,
-        run: identity,
-        userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.TERMINAL_BACKED,
-        description: params.description,
-        config: params.config,
-      });
-      await params.startLoop({ childStream, executionId });
-    } catch (error) {
-      let failure = error;
-      if (childStream) {
-        try {
-          await childStream.finalize({
-            outcome: { kind: 'failed', error },
-            persistence: { kind: 'finalize', flowRecord: 'delete' },
-          });
-        } catch (finalizeError) {
-          failure = new AggregateError(
-            [error, finalizeError],
-            `Agent CLI execution ${executionId} failed and its child stream could not be finalized`,
-          );
-        }
+  let childStream: ChildStream | undefined;
+  try {
+    childStream = createChildStream(executionId, params.parentStreamId, {
+      streamPrefix: params.streamPrefix,
+      run: identity,
+      userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.TERMINAL_BACKED,
+      description: params.description,
+      config: params.config,
+    });
+    await params.startLoop({ childStream, executionId });
+  } catch (error) {
+    let failure = error;
+    if (childStream) {
+      try {
+        await childStream.finalize({
+          outcome: { kind: 'failed', error },
+          persistence: { kind: 'finalize', flowRecord: 'delete' },
+        });
+      } catch (finalizeError) {
+        failure = new AggregateError(
+          [error, finalizeError],
+          `Agent CLI execution ${executionId} failed and its child stream could not be finalized`,
+        );
       }
-      throw await releaseOwnedExecutionLeaseAfterFailure(executionId, failure);
     }
+    throw await releaseOwnedExecutionLeaseAfterFailure(executionId, failure);
+  }
 
-    return executed(
-      [
-        params.launchedLine,
-        `Execution ID: ${executionId}`,
-        `Stream tab: ${childStream.childStreamId}`,
-        params.followUpLine,
-      ].join('\n'),
-      params.summary,
-    );
-  });
+  return executed(
+    [
+      params.launchedLine,
+      `Execution ID: ${executionId}`,
+      `Stream tab: ${childStream.childStreamId}`,
+      params.followUpLine,
+    ].join('\n'),
+    params.summary,
+  );
 }
 
 /**

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -19,6 +19,7 @@ import {
 import { getCurrentToolContexts } from '@agent/followUp/ToolFileInteractionContext';
 import {
   describeFollowUpFailure,
+  FOLLOW_UP_WAKE_FAILED_MESSAGE,
   submitFollowUp,
 } from '@agent/followUp/ToolUseFollowUp';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
@@ -127,9 +128,14 @@ async function queueAgentCliFollowUp(
   }
 
   const preview = truncateWithEllipsis(prompt, 60);
+  // A queued follow-up whose wake failed is still queued: it is delivered
+  // when the agent is resumed, so the caller must not offer it again.
+  const wakeFailed = result.status === 'queued' && result.wake === 'failed';
   return executed(
     [
-      `Follow-up instruction queued for ${labels.queuedLabel} '${id}'. The agent will process it and deliver a new result automatically.`,
+      wakeFailed
+        ? `Follow-up instruction queued for ${labels.queuedLabel} '${id}', but the agent could not be resumed. ${FOLLOW_UP_WAKE_FAILED_MESSAGE}`
+        : `Follow-up instruction queued for ${labels.queuedLabel} '${id}'. The agent will process it and deliver a new result automatically.`,
       `Execution ID: ${stored.executionId}`,
     ].join('\n'),
     `Follow-up queued for ${labels.summaryLabel}: ${preview}`,

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -17,7 +17,10 @@ import {
   type ChildRunStrategy,
 } from '@agent/runtime/childRunLoop';
 import { getCurrentToolContexts } from '@agent/followUp/ToolFileInteractionContext';
-import { submitFollowUp } from '@agent/followUp/ToolUseFollowUp';
+import {
+  describeFollowUpFailure,
+  submitFollowUp,
+} from '@agent/followUp/ToolUseFollowUp';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import {
   getRunContextExecutionId,
@@ -117,9 +120,9 @@ async function queueAgentCliFollowUp(
   const result = await submitFollowUp(stored.childStreamId, prompt, {
     session: currentSession(),
   });
-  if (result.status === 'no_session' || result.status === 'dropped') {
+  if (result.status === 'failed') {
     throw new ToolError(
-      `${labels.notActiveLabel} '${id}' no longer has a resumable continuation.`,
+      `${labels.notActiveLabel} '${id}' did not accept the follow-up (${result.reason}): ${describeFollowUpFailure(result.reason)}`,
     );
   }
 

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 // Local imports
 import type { AgentTrace } from '@agent/trace';
-import { registerOwnedExecution } from '@agent/storage/executionLifecycle';
+import { registerExecution } from '@agent/storage/executionLifecycle';
 import {
   TOOL_RESULT_TRUNCATION_HEAD_CHARS,
   TOOL_RESULT_TRUNCATION_TAIL_CHARS,
@@ -515,7 +515,7 @@ export class BashTool extends defineTool({
     // The durable record states only what a shell command has: no execution
     // mode, no model. The synthetic AgentConfig above feeds the ephemeral
     // live wire only.
-    const runWithOwnership = await registerOwnedExecution(
+    await registerExecution(
       executionId,
       { name: 'bash', instruction: command },
       'bash',
@@ -528,45 +528,43 @@ export class BashTool extends defineTool({
       },
     );
 
-    await runWithOwnership(() =>
-      startDetachedChildRunLoop({
-        executionId,
-        parentStreamId,
-        childStreamId,
-        agentName: 'bash',
-        // A background shell is an external process on no model budget, like
-        // the agent-CLI children (see the child-run concurrency budget note).
-        budgeted: false,
-        createChildStream: () =>
-          createChildStream(executionId, parentStreamId, {
-            streamPrefix: BASH_CHILD_STREAM_PREFIX,
-            run: { kind: 'process', tool: 'bash' },
-            userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
-            description: command,
-            config: syntheticConfig,
+    await startDetachedChildRunLoop({
+      executionId,
+      parentStreamId,
+      childStreamId,
+      agentName: 'bash',
+      // A background shell is an external process on no model budget, like
+      // the agent-CLI children (see the child-run concurrency budget note).
+      budgeted: false,
+      createChildStream: () =>
+        createChildStream(executionId, parentStreamId, {
+          streamPrefix: BASH_CHILD_STREAM_PREFIX,
+          run: { kind: 'process', tool: 'bash' },
+          userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
+          description: command,
+          config: syntheticConfig,
+        }),
+      buildLaunch: async (childStream) => {
+        return {
+          strategy: createBackgroundBashStrategy({
+            executionId,
+            command,
+            timeoutMs,
+            cwd,
+            logger: childStream.logger,
           }),
-        buildLaunch: async (childStream) => {
-          return {
-            strategy: createBackgroundBashStrategy({
-              executionId,
-              command,
-              timeoutMs,
-              cwd,
-              logger: childStream.logger,
-            }),
-            // Nobody awaits this run: own late loop failures here as trace
-            // diagnostics, since the loop already owns its one user-facing
-            // result delivery.
-            onLoopFailed: (error: unknown): void => {
-              childStream.logger.error(
-                'Background command run loop failed after launch',
-                { data: error },
-              );
-            },
-          };
-        },
-      }),
-    );
+          // Nobody awaits this run: own late loop failures here as trace
+          // diagnostics, since the loop already owns its one user-facing
+          // result delivery.
+          onLoopFailed: (error: unknown): void => {
+            childStream.logger.error(
+              'Background command run loop failed after launch',
+              { data: error },
+            );
+          },
+        };
+      },
+    });
 
     return executed(
       [

--- a/src/tools/delegation/DelegationTools.ts
+++ b/src/tools/delegation/DelegationTools.ts
@@ -22,7 +22,10 @@ import {
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
-import { submitFollowUp } from '@agent/followUp/ToolUseFollowUp';
+import {
+  describeFollowUpFailure,
+  submitFollowUp,
+} from '@agent/followUp/ToolUseFollowUp';
 import { deliverChildRunFollowUp } from '@agent/followUp/childRunDelivery';
 import { createLog } from '@logger/logUtils';
 import {
@@ -319,57 +322,49 @@ Git worktree support: resolved from the active workspace at runtime.`,
         session,
       },
     );
-    if (
-      result.status === 'dropped' ||
-      (result.status === 'queued' && result.continuation === 'resume_failed')
-    ) {
-      void deliverResumeWakeFailure(
-        handle,
-        session,
-        executionId,
-        new Error(
-          'The subagent follow-up could not be delivered to a live or recovered continuation.',
-        ),
-        parentDeliveryGenerationId,
+    if (result.status === 'failed') {
+      const worded = describeFollowUpFailure(result.reason);
+      if (result.reason === 'resume_failed') {
+        // The instruction is in the subagent's queue; only its wake failed.
+        // The parent learns of that through its own follow-up queue as well,
+        // the same way a child's turn failure reaches it.
+        void deliverResumeWakeFailure(
+          handle,
+          session,
+          executionId,
+          new Error(
+            'The subagent could not be resumed to process the follow-up.',
+          ),
+          parentDeliveryGenerationId,
+        );
+        return executed(
+          [
+            `Follow-up instruction queued for '${handle.agentName}', but the subagent could not be resumed (${result.reason}). ${worded}`,
+            `Execution ID: ${executionId}`,
+          ].join('\n'),
+          `Follow-up queued for '${handle.agentName}' (resume failed)`,
+        );
+      }
+      throw new Error(
+        `Follow-up for '${handle.agentName}' was not accepted (${result.reason}): ${worded}`,
       );
     }
 
-    switch (result.status) {
-      case 'sent':
-        return executed(
-          [
-            `Follow-up instruction sent to '${handle.agentName}'. The subagent will process it and deliver a new result automatically.`,
-            `Execution ID: ${executionId}`,
-          ].join('\n'),
-          `Follow-up sent to '${handle.agentName}'`,
-        );
-      case 'queued':
-        return executed(
-          [
-            `Follow-up instruction queued for '${handle.agentName}' (${result.reason}). The subagent will process it and deliver a new result automatically.`,
-            `Execution ID: ${executionId}`,
-          ].join('\n'),
-          `Follow-up queued for '${handle.agentName}'`,
-        );
-      case 'no_session':
-        throw new Error(
-          `No active session for '${handle.agentName}' (stream status: ${result.streamStatus ?? 'unknown'}). The subagent may have stopped or its session expired.`,
-        );
-      case 'dropped':
-        throw new Error(
-          `No continuation owner is available for '${handle.agentName}'.`,
-        );
-      case 'duplicate':
-        // resumeAgent instructions carry no delivery id, so the admission
-        // boundary never flags them; reachable only if a future caller adds
-        // one — in which case the instruction was already admitted once.
-        return executed(
-          [
-            `The identical follow-up was already delivered to '${handle.agentName}'.`,
-            `Execution ID: ${executionId}`,
-          ].join('\n'),
-          `Follow-up already delivered to '${handle.agentName}'`,
-        );
+    if (result.status === 'sent') {
+      return executed(
+        [
+          `Follow-up instruction sent to '${handle.agentName}'. The subagent will process it and deliver a new result automatically.`,
+          `Execution ID: ${executionId}`,
+        ].join('\n'),
+        `Follow-up sent to '${handle.agentName}'`,
+      );
     }
+    return executed(
+      [
+        `Follow-up instruction queued for '${handle.agentName}'. The subagent will process it and deliver a new result automatically.`,
+        `Execution ID: ${executionId}`,
+      ].join('\n'),
+      `Follow-up queued for '${handle.agentName}'`,
+    );
   }
 }

--- a/src/tools/delegation/DelegationTools.ts
+++ b/src/tools/delegation/DelegationTools.ts
@@ -24,6 +24,7 @@ import {
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import {
   describeFollowUpFailure,
+  FOLLOW_UP_WAKE_FAILED_MESSAGE,
   submitFollowUp,
 } from '@agent/followUp/ToolUseFollowUp';
 import { deliverChildRunFollowUp } from '@agent/followUp/childRunDelivery';
@@ -323,30 +324,29 @@ Git worktree support: resolved from the active workspace at runtime.`,
       },
     );
     if (result.status === 'failed') {
-      const worded = describeFollowUpFailure(result.reason);
-      if (result.reason === 'resume_failed') {
-        // The instruction is in the subagent's queue; only its wake failed.
-        // The parent learns of that through its own follow-up queue as well,
-        // the same way a child's turn failure reaches it.
-        void deliverResumeWakeFailure(
-          handle,
-          session,
-          executionId,
-          new Error(
-            'The subagent could not be resumed to process the follow-up.',
-          ),
-          parentDeliveryGenerationId,
-        );
-        return executed(
-          [
-            `Follow-up instruction queued for '${handle.agentName}', but the subagent could not be resumed (${result.reason}). ${worded}`,
-            `Execution ID: ${executionId}`,
-          ].join('\n'),
-          `Follow-up queued for '${handle.agentName}' (resume failed)`,
-        );
-      }
       throw new Error(
-        `Follow-up for '${handle.agentName}' was not accepted (${result.reason}): ${worded}`,
+        `Follow-up for '${handle.agentName}' was not accepted (${result.reason}): ${describeFollowUpFailure(result.reason)}`,
+      );
+    }
+    if (result.status === 'queued' && result.wake === 'failed') {
+      // The instruction is in the subagent's queue; only its wake failed.
+      // The parent learns of that through its own follow-up queue as well,
+      // the same way a child's turn failure reaches it.
+      void deliverResumeWakeFailure(
+        handle,
+        session,
+        executionId,
+        new Error(
+          'The subagent could not be resumed to process the follow-up.',
+        ),
+        parentDeliveryGenerationId,
+      );
+      return executed(
+        [
+          `Follow-up instruction queued for '${handle.agentName}', but the subagent could not be resumed. ${FOLLOW_UP_WAKE_FAILED_MESSAGE}`,
+          `Execution ID: ${executionId}`,
+        ].join('\n'),
+        `Follow-up queued for '${handle.agentName}' (resume failed)`,
       );
     }
 

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -11,11 +11,8 @@ import {
   parseWorkflowScript,
   readWorkflowScriptCheckpoint,
 } from '@agent/workflowScript';
-import { registerOwnedExecution } from '@agent/storage/executionLifecycle';
-import {
-  ExecutionLeaseActiveError,
-  type OwnedExecutionLeaseScope,
-} from '@agent/storage/executionLease';
+import { registerExecution } from '@agent/storage/executionLifecycle';
+import { ExecutionLeaseActiveError } from '@agent/storage/executionLease';
 import {
   AgentConfigSchema,
   type AgentConfigPayload,
@@ -442,12 +439,11 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
       );
     }
 
-    let runWithOwnership: OwnedExecutionLeaseScope;
     try {
       // The durable record states only what the container run has: the
       // workflow's name and the real model its agent steps will use. The
       // fabricated AgentConfig above feeds the ephemeral live wire only.
-      runWithOwnership = await registerOwnedExecution(
+      await registerExecution(
         runExecutionId,
         {
           name: meta.name,
@@ -492,7 +488,7 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
       );
     }
 
-    const runResult = runWithOwnership(async () => {
+    const runResult = (async () => {
       // Attempt-scoped setup runs inside the lease launch guard: it runs after
       // the deterministic run lease is held, so a throw here must release the
       // lease - otherwise the record survives for this process's lifetime and
@@ -613,7 +609,7 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
         ),
         scriptPath,
       );
-    });
+    })();
     return await runPhase(() => runResult);
   }
 }

--- a/src/tools/delegation/childStream.ts
+++ b/src/tools/delegation/childStream.ts
@@ -1,7 +1,6 @@
 // Local imports
 import type { AgentTrace, StageHandle } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { captureOwnedExecutionLeaseIfPresent } from '@agent/storage/executionLease';
 import {
   finalizeRunTerminal,
   type RunTerminalPersistence,
@@ -171,11 +170,6 @@ export function createChildStream(
       parentStreamId,
       runTrace.trace,
     );
-    const executionLeaseScope =
-      captureOwnedExecutionLeaseIfPresent(executionId);
-    if (executionLeaseScope) {
-      handle.attachExecutionLeaseScope(executionLeaseScope);
-    }
     // The process-owned snapshot listener persists both facts before handle
     // tracking; a later presentation replays them from the snapshot store during
     // canonical state loading (#8258).

--- a/src/tools/delegation/detachedChildRun.ts
+++ b/src/tools/delegation/detachedChildRun.ts
@@ -12,11 +12,8 @@
  */
 
 // Local imports
-import {
-  runWithOwnedExecutionLeaseLaunchGuard,
-  type OwnedExecutionLeaseScope,
-} from '@agent/storage/executionLease';
-import { registerOwnedExecution } from '@agent/storage/executionLifecycle';
+import { runWithOwnedExecutionLeaseLaunchGuard } from '@agent/storage/executionLease';
+import { registerExecution } from '@agent/storage/executionLifecycle';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import {
   startChildRunLoop,
@@ -53,24 +50,16 @@ export async function registerChildExecution(input: {
   readonly agentName: string;
   readonly userFollowUpSupport: UserFollowUpSupport;
   readonly parentExecutionId?: ExecutionId;
-}): Promise<{
-  readonly childStreamId: StreamTabId;
-  readonly runWithOwnership: OwnedExecutionLeaseScope;
-}> {
+}): Promise<{ readonly childStreamId: StreamTabId }> {
   const { executionId, config } = input;
   const childStreamId = getStreamTabId(config.agent, { executionId });
-  const runWithOwnership = await registerOwnedExecution(
-    executionId,
-    config,
-    input.agentName,
-    {
-      streamId: childStreamId,
-      identity: { kind: 'agent', agent: config.agent },
-      userFollowUpSupport: input.userFollowUpSupport,
-      parentExecutionId: input.parentExecutionId,
-    },
-  );
-  return { childStreamId, runWithOwnership };
+  await registerExecution(executionId, config, input.agentName, {
+    streamId: childStreamId,
+    identity: { kind: 'agent', agent: config.agent },
+    userFollowUpSupport: input.userFollowUpSupport,
+    parentExecutionId: input.parentExecutionId,
+  });
+  return { childStreamId };
 }
 
 /** The strategy wiring a launch site supplies inside the guard. */

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -17,7 +17,6 @@ import { getExecutionStore, type ResultMeta } from '@agent/storage';
 import {
   ExecutionLeaseLostError,
   runWithInactiveExecutionLease,
-  type OwnedExecutionLeaseScope,
 } from '@agent/storage/executionLease';
 import {
   AgentConfigSchema,
@@ -379,9 +378,8 @@ async function executeInBand(
   const store = getExecutionStore(executionId);
 
   let childStreamId: StreamTabId;
-  let runWithOwnership: OwnedExecutionLeaseScope;
   try {
-    ({ childStreamId, runWithOwnership } = await registerChildExecution({
+    ({ childStreamId } = await registerChildExecution({
       executionId,
       config,
       agentName: options.agentName,
@@ -398,7 +396,7 @@ async function executeInBand(
     throw cause;
   }
   let stableCompletionCommitted = false;
-  const completed = await runWithOwnership(async () => {
+  const completed = await (async () => {
     let settledTurn: SettledInBandTurn | undefined;
     const { completion } = await startDetachedChildRunLoop({
       executionId,
@@ -593,7 +591,7 @@ async function executeInBand(
       result,
       ...(mode === 'best-effort-delivery' && { delivery: turnMessage }),
     };
-  });
+  })();
 
   // Post-run cancellation deliberately observes a terminal record: stable
   // success was committed inside the post-drain/pre-release lease boundary,

--- a/src/tools/delegation/nativeSubagentStrategy.ts
+++ b/src/tools/delegation/nativeSubagentStrategy.ts
@@ -12,7 +12,7 @@
  * those callers. `runTurn` is every following interactive turn: resolve the
  * persisted flow-record cursor for this execution
  * (`retrieveSessionResumeData`) and drive it to the next WAITING/terminal
- * boundary via `resumeToolUseFromResumeData`, handing it the batch already
+ * boundary via `resumeToolUseTurn`, handing it the batch already
  * consumed by `childRunLoop`. `runTurn` is unreachable for a workflow child —
  * a workflow flow never produces a WAITING result, so `isTerminal` is always
  * true on its first (and only) turn, and `childRunLoop.ts`'s loop breaks on a
@@ -32,7 +32,11 @@ import {
   type AgentFlowResult,
   type AgentRuntimeFlowResult,
 } from '@agent/runtime/AgentFlowResult';
-import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
+import {
+  retrieveSessionResumeData,
+  type ToolUseResumeData,
+} from '@agent/runtime/SessionResumeRetrieval';
+import type { ResumeToolUseFromResumeDataOptions } from '@agent/runtime/executeAgent';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { AgentRunHandle } from '@agent/runtime/ExecutionHandle';
 import type {
@@ -71,7 +75,16 @@ import {
  */
 export interface AgentEngine {
   readonly executeAgent: typeof import('@agent/runtime/executeAgent').executeAgent;
-  readonly resumeToolUseFromResumeData: typeof import('@agent/runtime/executeAgent').resumeToolUseFromResumeData;
+  /**
+   * The unlaned turn (`executeAgent`'s `resumeToolUseTurn`): a child loop
+   * already holds its execution's lane, so the laned
+   * `resumeToolUseFromResumeData` would park the turn behind the loop's own
+   * generation.
+   */
+  readonly resumeToolUseTurn: (
+    resume: ToolUseResumeData,
+    options?: ResumeToolUseFromResumeDataOptions,
+  ) => Promise<AgentRuntimeFlowResult>;
 }
 
 let agentEngine: AgentEngine | undefined;
@@ -188,7 +201,7 @@ export function createNativeSubagentStrategy(
 } {
   let runHandle: AgentRunHandle | undefined;
   // Captured for the turn currently in flight; read once the call resolves.
-  // `executeAgent`/`resumeToolUseFromResumeData` never reject for a
+  // `executeAgent`/`resumeToolUseTurn` never reject for a
   // subagent's own application-level failure (runFlowWithLifecycle returns a
   // terminal failed result instead) — the real underlying error is only
   // observable through this callback.
@@ -367,7 +380,7 @@ export function createNativeSubagentStrategy(
           STREAM_TRANSITION_CAUSE.RESUME,
           { substate: STREAM_SUBSTATE.RESUMING },
         );
-        return await engine().resumeToolUseFromResumeData(resume, {
+        return await engine().resumeToolUseTurn(resume, {
           session: params.session,
           approvalPromptsUnavailable: params.approvalPromptsUnavailable,
           onApprovalPolicyDenial: params.onApprovalPolicyDenial,

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -186,7 +186,7 @@ export async function executeSubagent(
   const executionId = generateExecutionId();
   const startedAt = Date.now();
   const config = AgentConfigSchema.parse(childConfigPayload);
-  const { childStreamId, runWithOwnership } = await registerChildExecution({
+  const { childStreamId } = await registerChildExecution({
     executionId,
     config,
     agentName,
@@ -197,66 +197,64 @@ export async function executeSubagent(
     parentExecutionId,
   });
 
-  return await runWithOwnership(async () => {
-    const isToolUse = config.agentCategory === AgentCategory.ToolUse;
-    const strategyParams = {
-      config,
-      agentCategoryExplicit: childConfigPayload.agentCategory !== undefined,
-      executionId,
-      parentExecutionId,
-      agentName,
-      parentStreamId,
-      session: parentSession,
-      startedAt,
-      workingDirectory,
-      approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
-      onApprovalPolicyDenial: parentContext.onApprovalPolicyDenial,
-      runtimeUnavailableTools: parentContext.runtimeUnavailableTools,
-      onStreamResolved: inheritChildStreamApprovals,
-    };
+  const isToolUse = config.agentCategory === AgentCategory.ToolUse;
+  const strategyParams = {
+    config,
+    agentCategoryExplicit: childConfigPayload.agentCategory !== undefined,
+    executionId,
+    parentExecutionId,
+    agentName,
+    parentStreamId,
+    session: parentSession,
+    startedAt,
+    workingDirectory,
+    approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
+    onApprovalPolicyDenial: parentContext.onApprovalPolicyDenial,
+    runtimeUnavailableTools: parentContext.runtimeUnavailableTools,
+    onStreamResolved: inheritChildStreamApprovals,
+  };
 
-    await startDetachedChildRunLoop({
-      executionId,
-      parentStreamId,
-      childStreamId,
-      agentName,
-      recordCost,
-      buildLaunch: async () => ({
-        strategy: createNativeSubagentStrategy(strategyParams),
-        onLoopFailed: (error: unknown): void => {
-          log.error(`Subagent '${agentName}' run loop failed after launch`, {
-            data: error,
-          });
-        },
-      }),
-    });
-
-    const meta = options?.approvalMeta;
-    const metaLines: string[] = [];
-    if (meta) {
-      const modelInfo = meta.modelOverride
-        ? `Model: ${meta.modelOverride} (overridden from ${meta.requestedModel ?? 'default'})`
-        : `Model: ${childConfigPayload.model}`;
-      const agentInfo = meta.agentOverride
-        ? ` Agent: ${meta.agentOverride} (overridden from ${meta.requestedAgent ?? 'default'}).`
-        : '';
-      metaLines.push(
-        `Approval: ${meta.autoApproved ? 'auto-approved' : 'user-approved'}. ${modelInfo}.${agentInfo}`,
-      );
-    }
-    return executed(
-      [
-        `Subagent '${agentName}' launched. Result will be delivered automatically as a follow-up message when complete.`,
-        `Execution ID: ${executionId}`,
-        ...metaLines,
-        `The result arrives automatically. Continue other work meanwhile. To check progress: executions tool with path=/executions/${executionId}; use action=wait only when you cannot proceed without it.`,
-        ...(isToolUse
-          ? [
-              `To send follow-up instructions after delivery: use delegate_agent with execution_id set to this ID.`,
-            ]
-          : []),
-      ].join('\n'),
-      `Launched '${agentName}' (async)`,
-    );
+  await startDetachedChildRunLoop({
+    executionId,
+    parentStreamId,
+    childStreamId,
+    agentName,
+    recordCost,
+    buildLaunch: async () => ({
+      strategy: createNativeSubagentStrategy(strategyParams),
+      onLoopFailed: (error: unknown): void => {
+        log.error(`Subagent '${agentName}' run loop failed after launch`, {
+          data: error,
+        });
+      },
+    }),
   });
+
+  const meta = options?.approvalMeta;
+  const metaLines: string[] = [];
+  if (meta) {
+    const modelInfo = meta.modelOverride
+      ? `Model: ${meta.modelOverride} (overridden from ${meta.requestedModel ?? 'default'})`
+      : `Model: ${childConfigPayload.model}`;
+    const agentInfo = meta.agentOverride
+      ? ` Agent: ${meta.agentOverride} (overridden from ${meta.requestedAgent ?? 'default'}).`
+      : '';
+    metaLines.push(
+      `Approval: ${meta.autoApproved ? 'auto-approved' : 'user-approved'}. ${modelInfo}.${agentInfo}`,
+    );
+  }
+  return executed(
+    [
+      `Subagent '${agentName}' launched. Result will be delivered automatically as a follow-up message when complete.`,
+      `Execution ID: ${executionId}`,
+      ...metaLines,
+      `The result arrives automatically. Continue other work meanwhile. To check progress: executions tool with path=/executions/${executionId}; use action=wait only when you cannot proceed without it.`,
+      ...(isToolUse
+        ? [
+            `To send follow-up instructions after delivery: use delegate_agent with execution_id set to this ID.`,
+          ]
+        : []),
+    ].join('\n'),
+    `Launched '${agentName}' (async)`,
+  );
 }

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -44,7 +44,7 @@ import {
 
 const logger = createLog('inquiryContinuation');
 
-export type InjectionOutcome = 'sent' | 'queued' | 'resumed' | 'archived';
+export type InjectionOutcome = 'sent' | 'queued' | 'archived';
 
 const QUESTION_TRUNCATION = 400;
 const ANSWER_TRUNCATION = 2000;
@@ -140,13 +140,10 @@ function mapSubmissionToInquiryOutcome(
   result: SubmitFollowUpResult,
 ): InjectionOutcome {
   if (result.status === 'sent') return 'sent';
-  if (result.status === 'dropped' || result.status === 'no_session') {
-    return 'archived';
-  }
-  // Inquiry continuations carry no delivery id, so 'duplicate' is
-  // unreachable; it maps to 'queued' (already admitted) by construction.
-  if (result.status === 'duplicate') return 'queued';
-  return result.continuation === 'resumed' ? 'resumed' : 'queued';
+  if (result.status === 'queued') return 'queued';
+  // A failed recovery resume still queued the continuation; an explicit
+  // Resume delivers it. Every other refusal has nothing left to continue.
+  return result.reason === 'resume_failed' ? 'queued' : 'archived';
 }
 
 async function deliverContinuation(params: {
@@ -161,20 +158,17 @@ async function deliverContinuation(params: {
     expectedGenerationId: params.parentGenerationId,
   });
 
-  if (result.status === 'no_session') {
+  const outcome = mapSubmissionToInquiryOutcome(result);
+  if (outcome === 'archived') {
     logger.warn(
-      `Inquiry continuation for ${params.threadId}: parent stream ${params.parentStreamId} has no session.`,
+      `Inquiry continuation for ${params.threadId}: parent stream ${params.parentStreamId} refused it (${result.status === 'failed' ? result.reason : result.status}).`,
     );
     return archiveAsParentFinished(params.threadId, params.session);
   }
 
-  const outcome = mapSubmissionToInquiryOutcome(result);
-
   await emitInquiryThreadUpdate(
     params.threadId,
-    {
-      resumeOutcome: outcome === 'archived' ? 'parent_finished' : outcome,
-    },
+    { resumeOutcome: outcome },
     params.session,
   );
   return outcome;

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -140,10 +140,10 @@ function mapSubmissionToInquiryOutcome(
   result: SubmitFollowUpResult,
 ): InjectionOutcome {
   if (result.status === 'sent') return 'sent';
+  // A queued continuation whose wake failed is still queued; an explicit
+  // Resume delivers it. A refusal has nothing left to continue.
   if (result.status === 'queued') return 'queued';
-  // A failed recovery resume still queued the continuation; an explicit
-  // Resume delivers it. Every other refusal has nothing left to continue.
-  return result.reason === 'resume_failed' ? 'queued' : 'archived';
+  return 'archived';
 }
 
 async function deliverContinuation(params: {

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -563,9 +563,9 @@ export class StreamLogStore {
 
   /**
    * Recheck the authoritative transcript source rather than this instance's
-   * cached summary. Resume admission uses this while holding the execution
-   * lease lock, so another process cannot delete a stream and have a stale
-   * in-memory store recreate it afterwards.
+   * cached summary. Desktop resume admission reads this before resuming, so a
+   * stream another process deleted is not recreated from a stale in-memory
+   * store.
    */
   async hasAuthoritativeStream(streamId: StreamTabId): Promise<boolean> {
     if (this.mode.kind === 'ephemeral') return this.has(streamId);


### PR DESCRIPTION
## Summary

Steps 5 and 6 (D10 rules 1, 3, 4 and D6) of `docs/proposals/2026-08-23-single-owner-sessions.md`. Stacked on #11316.

**One serial lane per execution.** `ExecutionRegistry` owns a `p-queue` (concurrency 1) per execution id, disposed with the registry. Launch, host tool-use resume, child run loops, the teardown of a stopped WAITING handle, and stream deletion all run as lane steps; a resume cannot start until the previous generation's run has fully disposed, so generations never coexist. A storage-root change is refused while any execution is live (`StorageRootChangeRefusedError`, shown by the progress view) instead of queued behind a quiescence barrier.

**Guards deleted because the overlap they guarded can no longer happen:** the `captureOwnedExecutionLease`/`IfPresent` ALS scoping (15 sites, now a direct lookup by execution id), `ExecutionLeaseCoordination` + `runWithOwnedExecutionLeaseQuiescence`, `onOwnedExecutionLeaseLost` + both watchers (the next fenced write throws `ExecutionLeaseLostError`; a dirty abort on out-of-band tampering is accepted), `waitForOwnedExecutionLeaseRelease`, `ResumeAdmissionCancelledError` and the `isActiveOrResuming` double-check, the desktop `hasAuthoritativeStream` resume fence, the follow-up `KeyedMutex`/`runSubmissionExclusive`, `existing_recoverable`, the terminal tombstone LRU, and the `generation` claim counter. Child activation now lives for the whole loop through final delivery, which is what makes the last two unnecessary.

**Guards kept, each with the overlap it still guards (in the commit body):** `restorePersistedGeneration` (a persisted detached producer has no in-memory generation), `generationId`/`generationProvisional`/`admittedDeliveryIds` (detached producers, replayed deliveries), `runWithInactiveExecutionLease` (cross-process delete vs claim), the wait on an in-flight release of the same id (host-exit settlement releases off the lane).

**Three follow-up outcomes (D6).** `SubmitFollowUpResult = sent | queued | failed{reason: finished | owned_elsewhere | not_resumable | resume_failed}`; the reason is classified via `classifyRun` only on refusal, and each is worded once. `ToolUseFollowUpQueueReason`, the `queued.reason × continuation` cross-product, `duplicate`, `no_session{streamStatus}`, `dropped`, and the two "No active session" strings are gone; every consumer (progress view, CLI, delegation tool output, agent-CLI follow-up, inquiry continuation, child delivery, live notifications) updated.

LoC: production net −334 (−297 + −37); tests net −644; knip baseline −2.

## Verified

- `npm run typecheck` clean; eslint/prettier; `check:dead-code-ratchet` OK (429 vs 429)
- After merging #11316: `agent/controllers/progressView/desktop/architecture` 4597 passing; before the merge, broad kernel run 8215 passing with branch base at 7863/7863
- Two regression tests by extension: a resume issued while the previous generation is still disposing waits and mints no second lease; a storage-root change while a run is live is refused and changes nothing

Not live-tested in a running host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)