### PR TITLE
consolidate: use shared signal watcher, native array methods

### DIFF
--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -17,7 +17,7 @@ import type {
   StreamLifecycleStatus,
   StreamTabId,
 } from '@shared/schemas';
-import { Signal, SignalWatcher } from '@shared/signals';
+import { SignalWatcher, subscribeToSignalChanges } from '@shared/signals';
 import {
   designTokens,
   viewTabStyles,
@@ -106,17 +106,11 @@ export class ProgressApp extends ProgressAppBase {
   > = new Map();
 
   /**
-   * Watcher callback runs during signal invalidation, where reading a signal
-   * is not allowed — so the diff runs on a microtask, which also coalesces a
-   * burst of `.set()` calls from one handler into one announcement pass.
-   * Same pattern as webview/frontend/persistence.ts.
+   * Diff runs on a microtask (via `subscribeToSignalChanges`), which also
+   * coalesces a burst of `.set()` calls from one handler into one
+   * announcement pass. Same pattern as webview/frontend/persistence.ts.
    */
-  private readonly announcementWatcher = new Signal.subtle.Watcher(() => {
-    queueMicrotask(() => {
-      this.announcementWatcher.watch();
-      this.updateStatusAnnouncement();
-    });
-  });
+  private unwatchAnnouncements: (() => void) | undefined;
 
   private readonly resizeObserver = new ResizeObserver((entries) => {
     const width = entries[0]?.contentRect.width ?? this.clientWidth;
@@ -131,7 +125,10 @@ export class ProgressApp extends ProgressAppBase {
   override connectedCallback(): void {
     super.connectedCallback();
     this.resizeObserver.observe(this);
-    this.announcementWatcher.watch(permissions$, streamStates$, streamById$);
+    this.unwatchAnnouncements = subscribeToSignalChanges(
+      [permissions$, streamStates$, streamById$],
+      () => this.updateStatusAnnouncement(),
+    );
     // Baseline pass: announce anything already pending at mount (the old
     // computed did so on first read) and seed the status memos so
     // already-finished runs never announce.
@@ -139,7 +136,7 @@ export class ProgressApp extends ProgressAppBase {
   }
 
   override disconnectedCallback(): void {
-    this.announcementWatcher.unwatch(permissions$, streamStates$, streamById$);
+    this.unwatchAnnouncements?.();
     this.resizeObserver.disconnect();
     super.disconnectedCallback();
   }

--- a/packages/extension/src/progressView/frontend/components/messageIndex.ts
+++ b/packages/extension/src/progressView/frontend/components/messageIndex.ts
@@ -503,9 +503,8 @@ export class TranscriptIndex {
       return;
     }
 
-    for (let i = this.timeline.length - 1; i >= 0; i--) {
-      const item = this.timeline[i];
-      if (!item || !('row' in item)) continue;
+    for (const item of this.timeline) {
+      if (!('row' in item)) continue;
       const ungroupedIndex = this.rowLocations.get(item.key)?.ungroupedIndex;
       const fresh =
         ungroupedIndex === undefined

--- a/packages/extension/src/webview/frontend/persistence.ts
+++ b/packages/extension/src/webview/frontend/persistence.ts
@@ -35,7 +35,7 @@ import {
   type MainViewPersistedState,
   type StateRestoreMessage,
 } from '@shared/schemas';
-import { Signal } from '@shared/signals';
+import { Signal, subscribeToSignalChanges } from '@shared/signals';
 import {
   createWebviewStorage,
   PersistedState,
@@ -166,23 +166,10 @@ function writeIfChanged(): void {
 }
 
 /**
- * Watcher callback runs during signal invalidation, where reading a signal is
- * not allowed — so the projection is inspected on a microtask, which also
- * coalesces a burst of `.set()` calls from one handler into one write.
+ * Watch callback runs on a microtask (via `subscribeToSignalChanges`), which
+ * also coalesces a burst of `.set()` calls from one handler into one write.
  */
-const watcher = new Signal.subtle.Watcher(() => {
-  queueMicrotask(() => {
-    watcher.watch();
-    if (lastWritten === undefined) return;
-    const changed = changedFields(persistedSnapshot$.get());
-    if (changed.length === 0) return;
-    if (changed.every((field) => DRAFT_FIELDS.has(field))) {
-      draftSaveDebounce.schedule();
-      return;
-    }
-    writeIfChanged();
-  });
-});
+let unwatchPersistedSnapshot: (() => void) | undefined;
 
 export function restorePersistedState(): void {
   // The extension-local schema provides defaults and reads the retired VS Code
@@ -194,7 +181,19 @@ export function restorePersistedState(): void {
   // and persisted by the user's next real change), and every later change is
   // measured against the state the user is actually looking at.
   lastWritten = persistedSnapshot$.get();
-  watcher.watch(persistedSnapshot$);
+  unwatchPersistedSnapshot = subscribeToSignalChanges(
+    [persistedSnapshot$],
+    () => {
+      if (lastWritten === undefined) return;
+      const changed = changedFields(persistedSnapshot$.get());
+      if (changed.length === 0) return;
+      if (changed.every((field) => DRAFT_FIELDS.has(field))) {
+        draftSaveDebounce.schedule();
+        return;
+      }
+      writeIfChanged();
+    },
+  );
 }
 
 /**
@@ -304,7 +303,7 @@ export function flushPendingSave(): void {
  */
 export function resetPersistenceRuntime(): void {
   draftSaveDebounce.cancel();
-  watcher.unwatch(persistedSnapshot$);
+  unwatchPersistedSnapshot?.();
   lastWritten = undefined;
   stateManager.reload();
 }

--- a/packages/extension/src/webview/frontend/persistence.ts
+++ b/packages/extension/src/webview/frontend/persistence.ts
@@ -181,6 +181,11 @@ export function restorePersistedState(): void {
   // and persisted by the user's next real change), and every later change is
   // measured against the state the user is actually looking at.
   lastWritten = persistedSnapshot$.get();
+  // connectedCallback (which calls this) can fire more than once per
+  // MainApp instance without an intervening resetPersistenceRuntime — that
+  // only runs from the constructor — so a stale subscription from an
+  // earlier connect must be torn down before arming a new one.
+  unwatchPersistedSnapshot?.();
   unwatchPersistedSnapshot = subscribeToSignalChanges(
     [persistedSnapshot$],
     () => {

--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -324,7 +324,7 @@ export async function runLatexdiffViaWorkspaceScan(params: {
   const operations: DiffOperation[] = [];
 
   for (const [baseFile, roundOutputs] of inputToOutputsMap.entries()) {
-    const sorted = [...roundOutputs].sort((a, b) => a.round - b.round);
+    const sorted = roundOutputs.toSorted((a, b) => a.round - b.round);
 
     for (const { round, outputPath } of sorted) {
       const resolvedOutput = toAbsolute(outputPath);


### PR DESCRIPTION
## Summary

A scheduled sweep for consolidation and native-method opportunities (three parallel domain surveys: hand-rolled builtin reimplementations, webview-tree duplication, model-handler/tools duplication) turned up one real duplication and two small ES2023+ idiom gaps. This PR is the batch of concrete, verified fixes; nothing else in the surveyed domains met the bar for a change (model handlers/tools were already fully consolidated onto shared retry/error/usage/streaming helpers, and the rest of the three webview trees route through the existing shared modules).

1. **`webview/frontend/persistence.ts`** and **`progressView/frontend/ProgressApp.ts`** each hand-rolled the identical `Signal.subtle.Watcher` + `queueMicrotask` re-arm loop. `@shared/signals` already exports `subscribeToSignalChanges(signals, notify)` implementing the same pattern once; both sites now call it instead of maintaining their own copy.
2. **`src/latex/latexdiff/diffOperations.ts:327`**: `[...roundOutputs].sort(...)` → `roundOutputs.toSorted(...)`. `roundOutputs` here is the plain-array value from `inputToOutputsMap.entries()`, not a Set/Map that needs the spread.
3. **`progressView/frontend/components/messageIndex.ts:506`**: a backward index loop (`for (let i = length - 1; i >= 0; i--)`) that fully scans the timeline with no early exit and no order-dependent mutation, simplified to `for...of` — which also drops the now-dead `!item` guard (array iteration values are never `undefined`).

## Issue acceptance gates

n/a — proactive consolidation sweep, not tied to a filed issue.

## Single source of truth

`subscribeToSignalChanges` in `src/shared/signals.ts` is now the sole implementation of the watch/coalesce-on-microtask/re-arm pattern for these two call sites (it already was for other consumers in the codebase).

## Duplication and abstraction budget

Removed: one duplicated ~13-line `Signal.subtle.Watcher` + `queueMicrotask` re-arm block (kept once, in `@shared/signals`, instead of twice). No new abstraction added — this only routes two existing call sites onto an existing shared helper.

## Net elements (R6)

4 files changed, +31/-36 LoC (`git diff origin/main --stat`). No exported symbols added or removed (`^[+-]export` diff is empty for the touched files). No new classes/interfaces/enums; one private field (`ProgressApp.announcementWatcher`) replaced by a narrower one (`unwatchAnnouncements`), one module-level `const watcher` replaced by a narrower `let unwatchPersistedSnapshot`.

## Consumer counts (R8)

n/a — no emit path or public export was deleted or re-routed; both changed watcher fields/module bindings are private/module-local with no external consumers.

## Host impact

Extension: both webview watcher changes are extension-only frontend code (`packages/extension/src/webview/frontend/`, `packages/extension/src/progressView/frontend/`); behavior is unchanged (same signals watched, same coalesced-microtask timing), verified by the existing `MainAppPersistenceRestore.vitest.ts` and the broader `webview`/`progressView` suites.

Desktop: no changes.

CLI: no changes.

## Scheduled refactoring

None — the other two survey domains (model handlers/tools, and the rest of the three webview trees) found no further candidates meeting the duplication bar.

## Validation

- `npm run typecheck` — full workspace (workspace, test-kernel, agent, cli, trace-viewer, desktop) — clean
- `npm run lint` — clean
- `npm run format` — no changes needed
- `npx vitest run src/test-kernel/latex/DiffOperations.vitest.ts src/test-kernel/webview/MainAppPersistenceRestore.vitest.ts src/test-kernel/progressView/TaskGroupListIndex.vitest.ts` — 33/33 passed
- `npx vitest run src/test-kernel/shared src/test-kernel/progressView src/test-kernel/webview` — 1012/1012 passed (109 files)

---
_Generated by [Claude Code](https://claude.ai/code/session_013gucz2twzurNyATu49rdEr)_