### PR TITLE
refactor(transcript, modelHandlers): dedup StreamSnapshotStore plumbing + align Google streaming failures

### DIFF
--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -34,14 +34,12 @@ import type {
 } from '@agent/types/ModelHandlerContracts';
 import type { MediaEntry } from '@agent/types/mediaTypes';
 import { detectStatusCode } from '@common/errors/sdkError/errorInspection';
-import {
-  attachManualRetryOnlyError,
-  attachPartialText,
-} from '@common/errors/sdkError/errorMetadata';
+import { attachManualRetryOnlyError } from '@common/errors/sdkError/errorMetadata';
 import {
   PARTIAL_TEXT_TAIL_MAX,
   takeTail,
 } from '@common/errors/sdkError/errorPatterns';
+import { handleStreamingFailure } from '@common/errors/sdkError/streamFailure';
 import { composeLongRunningModelDispatcher } from '@platform/defaults/longRunningModelTransport';
 import {
   type FileLocation,
@@ -1705,13 +1703,12 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
         this.chainState.invalidateChain();
         return this.createResponseImpl(options);
       }
-      if (aggregatedText) {
-        attachPartialText(
-          error,
-          takeTail(aggregatedText, PARTIAL_TEXT_TAIL_MAX),
-        );
-      }
-      throw error;
+      return handleStreamingFailure(error, {
+        // No `finalizeOnError` hook: a streaming call's own `finally` already
+        // finalized the progress streams before this outer catch ever runs.
+        partialTail: () =>
+          aggregatedText ? takeTail(aggregatedText, PARTIAL_TEXT_TAIL_MAX) : '',
+      });
     }
   }
 

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -2086,6 +2086,9 @@ export class StreamSnapshotStore {
     consumeOverlay(overlays, 'compileFailures', sidecarsToWrite, (patch) =>
       this.applyRoundPatch((r) => r.compileFailures, record, patch),
     );
+    // Pre-await snapshot, not `patch`: deltas that landed during the hydration
+    // await were already applied to the refreshed record.usage, so replaying
+    // the merged overlay would count them twice.
     consumeOverlay(overlays, 'usage', sidecarsToWrite, () => {
       for (const [storageKey, delta] of usageOverlayToReplay) {
         this.applyUsageDeltaMemory(record, storageKey, delta);

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -842,15 +842,15 @@ export class StreamSnapshotStore {
 
   // Shallow copy: each write is queued, so the record is snapshotted at call
   // time rather than letting later round mutations leak into a pending write.
+  // The sidecar key is derived from OVERLAY_TO_SIDECAR_KEY rather than taken
+  // as a separate param, so a caller can't pass a field/key pair that disagree.
   private writeRoundKeyedField(
     stream: StreamTabId,
-    key:
-      | typeof STREAM_DATA_KEYS.OUTPUT_FILES
-      | typeof STREAM_DATA_KEYS.MISSING_OUTPUTS
-      | typeof STREAM_DATA_KEYS.COMPILE_FAILURES,
     field: 'outputFiles' | 'missingOutputs' | 'compileFailures',
   ): void {
-    this.write(stream, key, { ...this.records.get(stream)?.[field] });
+    this.write(stream, OVERLAY_TO_SIDECAR_KEY[field], {
+      ...this.records.get(stream)?.[field],
+    });
   }
 
   private applyUsageDeltaMemory(
@@ -944,12 +944,7 @@ export class StreamSnapshotStore {
           this.getOrCreateRecord(stream),
           patch,
         ),
-      () =>
-        this.writeRoundKeyedField(
-          stream,
-          STREAM_DATA_KEYS.OUTPUT_FILES,
-          'outputFiles',
-        ),
+      () => this.writeRoundKeyedField(stream, 'outputFiles'),
     );
   }
 
@@ -973,12 +968,7 @@ export class StreamSnapshotStore {
           this.getOrCreateRecord(stream),
           patch,
         ),
-      () =>
-        this.writeRoundKeyedField(
-          stream,
-          STREAM_DATA_KEYS.MISSING_OUTPUTS,
-          'missingOutputs',
-        ),
+      () => this.writeRoundKeyedField(stream, 'missingOutputs'),
     );
   }
 
@@ -1005,12 +995,7 @@ export class StreamSnapshotStore {
           this.getOrCreateRecord(stream),
           patch,
         ),
-      () =>
-        this.writeRoundKeyedField(
-          stream,
-          STREAM_DATA_KEYS.COMPILE_FAILURES,
-          'compileFailures',
-        ),
+      () => this.writeRoundKeyedField(stream, 'compileFailures'),
     );
   }
 
@@ -2147,16 +2132,16 @@ export class StreamSnapshotStore {
     for (const key of keys) {
       switch (key) {
         case STREAM_DATA_KEYS.OUTPUT_FILES:
-          this.writeRoundKeyedField(stream, key, 'outputFiles');
+          this.writeRoundKeyedField(stream, 'outputFiles');
           break;
         case STREAM_DATA_KEYS.USAGE_STATS:
           this.writeUsage(stream);
           break;
         case STREAM_DATA_KEYS.MISSING_OUTPUTS:
-          this.writeRoundKeyedField(stream, key, 'missingOutputs');
+          this.writeRoundKeyedField(stream, 'missingOutputs');
           break;
         case STREAM_DATA_KEYS.COMPILE_FAILURES:
-          this.writeRoundKeyedField(stream, key, 'compileFailures');
+          this.writeRoundKeyedField(stream, 'compileFailures');
           break;
         case STREAM_DATA_KEYS.WORK_PLAN:
           this.writeWorkPlan(stream, record.workPlan);

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -230,6 +230,25 @@ const OVERLAY_TO_SIDECAR_KEY = {
 type OverlaySidecarKey =
   (typeof OVERLAY_TO_SIDECAR_KEY)[keyof typeof OVERLAY_TO_SIDECAR_KEY];
 
+/**
+ * Apply one pending overlay patch, mark its sidecar for the merged write, and
+ * clear it. Factors out the check/apply/track/clear shape every
+ * {@link OverlayPatches} field replays through in `applyStreamData`; each
+ * field's own apply logic stays with its caller.
+ */
+function consumeOverlay<K extends keyof OverlayPatches>(
+  overlays: Partial<OverlayPatches>,
+  key: K,
+  sidecarsToWrite: Set<OverlaySidecarKey>,
+  apply: (patch: OverlayPatches[K]) => void,
+): void {
+  const patch = overlays[key];
+  if (patch === undefined) return;
+  apply(patch);
+  sidecarsToWrite.add(OVERLAY_TO_SIDECAR_KEY[key]);
+  overlays[key] = undefined;
+}
+
 /** Later unseeded todos/plan patches win per field. */
 function mergeWorkPlanOverlay(
   existing: WorkPlanOverlay | undefined,
@@ -821,24 +840,17 @@ export class StreamSnapshotStore {
     return rounds;
   }
 
-  // Shallow copies: each write is queued, so snapshot the record at call time
-  // rather than letting later round mutations leak into a pending write.
-  private writeOutputFiles(stream: StreamTabId): void {
-    this.write(stream, STREAM_DATA_KEYS.OUTPUT_FILES, {
-      ...this.records.get(stream)?.outputFiles,
-    });
-  }
-
-  private writeMissingOutputs(stream: StreamTabId): void {
-    this.write(stream, STREAM_DATA_KEYS.MISSING_OUTPUTS, {
-      ...this.records.get(stream)?.missingOutputs,
-    });
-  }
-
-  private writeCompileFailures(stream: StreamTabId): void {
-    this.write(stream, STREAM_DATA_KEYS.COMPILE_FAILURES, {
-      ...this.records.get(stream)?.compileFailures,
-    });
+  // Shallow copy: each write is queued, so the record is snapshotted at call
+  // time rather than letting later round mutations leak into a pending write.
+  private writeRoundKeyedField(
+    stream: StreamTabId,
+    key:
+      | typeof STREAM_DATA_KEYS.OUTPUT_FILES
+      | typeof STREAM_DATA_KEYS.MISSING_OUTPUTS
+      | typeof STREAM_DATA_KEYS.COMPILE_FAILURES,
+    field: 'outputFiles' | 'missingOutputs' | 'compileFailures',
+  ): void {
+    this.write(stream, key, { ...this.records.get(stream)?.[field] });
   }
 
   private applyUsageDeltaMemory(
@@ -932,7 +944,12 @@ export class StreamSnapshotStore {
           this.getOrCreateRecord(stream),
           patch,
         ),
-      () => this.writeOutputFiles(stream),
+      () =>
+        this.writeRoundKeyedField(
+          stream,
+          STREAM_DATA_KEYS.OUTPUT_FILES,
+          'outputFiles',
+        ),
     );
   }
 
@@ -956,7 +973,12 @@ export class StreamSnapshotStore {
           this.getOrCreateRecord(stream),
           patch,
         ),
-      () => this.writeMissingOutputs(stream),
+      () =>
+        this.writeRoundKeyedField(
+          stream,
+          STREAM_DATA_KEYS.MISSING_OUTPUTS,
+          'missingOutputs',
+        ),
     );
   }
 
@@ -983,7 +1005,12 @@ export class StreamSnapshotStore {
           this.getOrCreateRecord(stream),
           patch,
         ),
-      () => this.writeCompileFailures(stream),
+      () =>
+        this.writeRoundKeyedField(
+          stream,
+          STREAM_DATA_KEYS.COMPILE_FAILURES,
+          'compileFailures',
+        ),
     );
   }
 
@@ -2064,39 +2091,22 @@ export class StreamSnapshotStore {
     }
 
     const { overlays } = record;
-    if (overlays.outputFiles) {
-      this.applyRoundPatch((r) => r.outputFiles, record, overlays.outputFiles);
-      sidecarsToWrite.add(OVERLAY_TO_SIDECAR_KEY.outputFiles);
-      overlays.outputFiles = undefined;
-    }
-    if (overlays.missingOutputs) {
-      if (overlays.missingOutputs.reset) record.missingOutputs = {};
-      this.applyRoundPatch(
-        (r) => r.missingOutputs,
-        record,
-        overlays.missingOutputs.patch,
-      );
-      sidecarsToWrite.add(OVERLAY_TO_SIDECAR_KEY.missingOutputs);
-      overlays.missingOutputs = undefined;
-    }
-    if (overlays.compileFailures) {
-      this.applyRoundPatch(
-        (r) => r.compileFailures,
-        record,
-        overlays.compileFailures,
-      );
-      sidecarsToWrite.add(OVERLAY_TO_SIDECAR_KEY.compileFailures);
-      overlays.compileFailures = undefined;
-    }
-    if (overlays.usage) {
+    consumeOverlay(overlays, 'outputFiles', sidecarsToWrite, (patch) =>
+      this.applyRoundPatch((r) => r.outputFiles, record, patch),
+    );
+    consumeOverlay(overlays, 'missingOutputs', sidecarsToWrite, (patch) => {
+      if (patch.reset) record.missingOutputs = {};
+      this.applyRoundPatch((r) => r.missingOutputs, record, patch.patch);
+    });
+    consumeOverlay(overlays, 'compileFailures', sidecarsToWrite, (patch) =>
+      this.applyRoundPatch((r) => r.compileFailures, record, patch),
+    );
+    consumeOverlay(overlays, 'usage', sidecarsToWrite, () => {
       for (const [storageKey, delta] of usageOverlayToReplay) {
         this.applyUsageDeltaMemory(record, storageKey, delta);
       }
-      sidecarsToWrite.add(OVERLAY_TO_SIDECAR_KEY.usage);
-      overlays.usage = undefined;
-    }
-    if (overlays.workPlan) {
-      const overlay = overlays.workPlan;
+    });
+    consumeOverlay(overlays, 'workPlan', sidecarsToWrite, (overlay) => {
       if (overlay.todos !== undefined) {
         record.workPlan = { ...record.workPlan, todos: [...overlay.todos] };
       }
@@ -2109,9 +2119,7 @@ export class StreamSnapshotStore {
             : null,
         };
       }
-      sidecarsToWrite.add(OVERLAY_TO_SIDECAR_KEY.workPlan);
-      overlays.workPlan = undefined;
-    }
+    });
     record.diskState = provenance;
     this.writeMergedSidecars(stream, record, sidecarsToWrite);
     // Hydration republishes the metadata mirror: the deep-equal gate makes an
@@ -2139,16 +2147,16 @@ export class StreamSnapshotStore {
     for (const key of keys) {
       switch (key) {
         case STREAM_DATA_KEYS.OUTPUT_FILES:
-          this.writeOutputFiles(stream);
+          this.writeRoundKeyedField(stream, key, 'outputFiles');
           break;
         case STREAM_DATA_KEYS.USAGE_STATS:
           this.writeUsage(stream);
           break;
         case STREAM_DATA_KEYS.MISSING_OUTPUTS:
-          this.writeMissingOutputs(stream);
+          this.writeRoundKeyedField(stream, key, 'missingOutputs');
           break;
         case STREAM_DATA_KEYS.COMPILE_FAILURES:
-          this.writeCompileFailures(stream);
+          this.writeRoundKeyedField(stream, key, 'compileFailures');
           break;
         case STREAM_DATA_KEYS.WORK_PLAN:
           this.writeWorkPlan(stream, record.workPlan);


### PR DESCRIPTION
## Summary

An automated codebase-debt audit (four parallel subagents scanning model handlers, transcript/streaming, agent runtime, and a repo-wide breadth pass) flagged several candidate duplication areas. Each was investigated hands-on before touching code, and most turned out to be either genuinely divergent per-host/per-provider behavior or deliberate, documented design decisions rather than safe-to-collapse duplication (details below, under "Scheduled refactoring"). This PR contains the two changes that verified as real, safe, and behavior-preserving:

**1. `StreamSnapshotStore.ts` plumbing dedup**
- `writeOutputFiles` / `writeMissingOutputs` / `writeCompileFailures` — three near-identical 6-line methods differing only by field name and sidecar key — become one `writeRoundKeyedField(stream, key, field)`.
- The five `if (overlays.X) { apply…; sidecarsToWrite.add(KEY); overlays.X = undefined; }` blocks in `applyStreamData`'s overlay replay collapse into calls to a shared `consumeOverlay(overlays, key, sidecarsToWrite, apply)` helper. Each field's own apply logic (round-patch merge, the `missingOutputs` reset flag, the pre-await `usageOverlayToReplay` snapshot replay, the work-plan todo/plan merge) is untouched and stays with its caller — only the repeated check/apply/track/clear wrapper around it moved.

**2. Google Interactions streaming-failure alignment**
- `modelHandlerGoogleInteractions.ts`'s `createResponseImpl` catch hand-rolled the same tail-attach-and-rethrow that OpenAI Responses and Anthropic already run through the shared `handleStreamingFailure` skeleton. Swapped it in: no `finalizeOnError` hook, since the streaming call's own `finally` already finalizes progress streams before this outer catch ever runs; `attachPartialText`'s existing truthy guard on the tail keeps the empty-`aggregatedText` case a no-op, identical to the removed `if (aggregatedText)` check.

## Issue acceptance gates

No linked issue — self-directed from a scheduled codebase-debt audit. Acceptance gate: remove verified duplication without changing any observable behavior.

## Single source of truth

`consumeOverlay` is now the single place that knows the check/apply/track/clear sequence for a `StreamSnapshotStore` overlay field. `writeRoundKeyedField` is the single place that knows how to shallow-copy-and-persist a round-keyed accumulator field. `handleStreamingFailure` is now the single mid-stream-failure skeleton all three provider handlers (OpenAI, Anthropic, Google) route through, instead of two of three.

## Duplication and abstraction budget

Removed: 3 near-identical write-wrapper method bodies → 1 parameterized method; 5 near-identical overlay check/apply/track/clear blocks → 1 shared helper (5 call sites); 1 hand-rolled tail-attach-and-rethrow → the existing shared skeleton (0 new abstractions, reuses code already established by 2 other providers). No generic descriptor-table or config-driven dispatch was introduced for the overlay fields, since their per-field apply logic is genuinely different (round-patch merge vs. usage-map replay vs. work-plan sub-field merge) and forcing it through one generic shape would trade real duplication for speculative generality.

## Net elements (R6)

Files: 2 changed (`src/transcript/StreamSnapshotStore.ts`, `src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts`), no files added/removed.
Exported symbols: 0 changed (`grep -E "^[+-].*export"` over the diff is empty in both files).
Classes/interfaces/enums: unchanged.
Methods: -3 (`writeOutputFiles`, `writeMissingOutputs`, `writeCompileFailures`) / +1 (`writeRoundKeyedField`, private) / +1 module-level function (`consumeOverlay`) in the transcript file; 0 net in the Google file (one catch block rewritten in place).
Net LoC: transcript file +65/-57 (+8 net, flat — call sites gained explicit field-name args); Google file +8/-11 (-3 net).

## Consumer counts (R8)

n/a — no emit path, export, or public method signature changed in either file. Both touched transcript methods are `private`/module-private with all call sites inside that one file (verified via `grep -rn` across `src/` and `packages/` for the removed method names — zero remaining references). The Google change only rewrites the body of an existing private method's catch block.

## Host impact

Extension: none — both files are host-agnostic (`src/transcript/`, `src/agent/modelHandlers/`); behavior consumed identically by every host.

Desktop: none — same.

CLI: none — same.

## Scheduled refactoring

None filed. Larger candidates from the same audit were investigated and found not safe/valuable to force in this pass:
- **Settings-view host glue** (extension vs. desktop): checked three independent handler pairs (agent settings, memory settings, subscription sign-in). Each showed genuine per-host behavioral divergence — different OAuth transports, different confirmation/error UX, different cache-invalidation and refresh sequencing — layered on top of already-shared domain controllers (`createSettingsAgentControllers`, `subscriptionProvider(...)`, etc.). A safe merge needs a proposal-first design pass defining a host-neutral port, not an opportunistic refactor.
- **`executionRegistry.ts` "duplicate" terminal-finalization path**: on inspection, `finishWaitingTermination` is a deliberately documented divergent path from `finalizeRunTerminal` — it exists specifically because a suspended (WAITING) run has no live usage monitor to read, which `finalizeRunTerminal` assumes. Not an accidental duplicate authority.
- **Batched tool-use follow-up assembly** (OpenAI/Anthropic/Google): the bulk of each provider's implementation (e.g. Anthropic's ~125-line `buildToolResultBlock`) is genuinely provider-specific wire-format and attachment-upload logic (base64 image/document blocks, PDF page-budget tracking, Google's interaction-step model) — not boilerplate. A generic assembler would mostly wrap, not remove, this logic.
- **Cross-cutting "silent catch" audit**: spot-checked the flagged example (`src/utils/system/platformPaths.ts`'s `// ignore command errors` / `// ignore resolution errors`) and found it to be correct, intentional best-effort tool-probing code (trying several candidate binary names, where a miss is the expected common case) — not a masked failure. The ~241-catch estimate from the automated scan appears to substantially over-count; a real audit here needs per-site judgment, not a batch fix.

## Validation

- `npm run typecheck:workspace` — clean (both commits).
- `npm run typecheck:test-kernel` — clean.
- `npx eslint` on both changed files — clean.
- `npx prettier --check` on both changed files — clean.
- `npx vitest run src/test-kernel/transcript/` — 268 tests passed (10 files), including the dedicated 97-test `StreamSnapshotStore.vitest.ts` suite.
- `npx vitest run src/test-kernel/schemas/StreamDataRoundMaps.vitest.ts` — passed.
- `npx vitest run src/test-kernel/agent/modelHandlers/GoogleInteractions*.vitest.ts src/test-kernel/agent/modelHandlers/GoogleClientRefresh.vitest.ts` — 82 passed, 4 skipped (pre-existing skips, unrelated to this change).