### PR TITLE
refactor: consolidate test temp directories

### DIFF
--- a/src/test-kernel/agent/AgentYamlScanner.vitest.ts
+++ b/src/test-kernel/agent/AgentYamlScanner.vitest.ts
@@ -3,15 +3,15 @@ import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 // Third-party imports
-import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 // Local imports
 import { scanDirectory } from '@agent/index/agentYamlScanner';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { installPlatform } from '@test/support/setupPlatform';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 
 /** Create a temp agent directory holding the given YAML files, given as lines. */
 async function createAgentDir(
@@ -36,10 +36,6 @@ function toolUseAgent(name: string, systemPrompt: string): string[] {
 
 describe('agent YAML scanner', () => {
   beforeAll(() => installPlatform({}, { fs: nodeFilesystem }));
-
-  afterEach(async () => {
-    await cleanupTempDirs(tempDirs);
-  });
 
   it('derives workflow round counts from inherited settings and prompts', async () => {
     const agentDir = await createAgentDir({

--- a/src/test-kernel/agent/BundledPrompts.vitest.ts
+++ b/src/test-kernel/agent/BundledPrompts.vitest.ts
@@ -4,7 +4,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 
 // Third-party imports
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import * as yaml from 'yaml';
 
 // Local imports
@@ -16,7 +16,7 @@ import {
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { REPO_ROOT } from '@test/support/repoScan';
 import { setupPlatform } from '@test/support/setupPlatform';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 interface GoalPromptsYaml {
   continuation: { template: string };
@@ -35,11 +35,7 @@ const goalYaml = yaml.parse(
 describe('bundled prompt loader', () => {
   setupPlatform({}, { fs: nodeFilesystem });
 
-  const tempDirs: string[] = [];
-
-  afterEach(async () => {
-    await cleanupTempDirs(tempDirs);
-  });
+  const tempDirs = useTempDirs();
 
   /** A resources root whose two prompt files are both unparseable YAML. */
   async function makeBrokenResources(): Promise<string> {

--- a/src/test-kernel/agent/WorkflowScriptSandboxBundle.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptSandboxBundle.vitest.ts
@@ -1,25 +1,16 @@
 import { execFile } from 'node:child_process';
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
 import { build } from 'esbuild';
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { REPO_ROOT } from '@test/support/repoScan';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 const execFileAsync = promisify(execFile);
 const sandboxPath = path.join(REPO_ROOT, 'src/agent/workflowScript/sandbox.ts');
-const temporaryDirectories: string[] = [];
-
-afterEach(async () => {
-  await Promise.all(
-    temporaryDirectories
-      .splice(0)
-      .map((directory) => rm(directory, { recursive: true, force: true })),
-  );
-});
+const temporaryDirectories = useTempDirs();
 
 describe('workflow sandbox host bundles', () => {
   it.each([
@@ -28,10 +19,10 @@ describe('workflow sandbox host bundles', () => {
   ] as const)(
     'instantiates embedded QuickJS from the $host bundle shape',
     async ({ format, extension }) => {
-      const directory = await mkdtemp(
-        path.join(tmpdir(), 'texra-workflow-sandbox-'),
+      const directory = await makeTempDir(
+        'texra-workflow-sandbox-',
+        temporaryDirectories,
       );
-      temporaryDirectories.push(directory);
       const outfile = path.join(directory, `smoke.${extension}`);
 
       await build({

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -45,7 +45,7 @@ import {
 } from '@platform/languageModel';
 import { installPlatform } from '@test/support/setupPlatform';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 // This file calls vi.resetModules(), which desyncs the statically-imported
 // factory from a freshly-imported @platform copy. Blocks that must agree with
@@ -104,11 +104,7 @@ function signedInCodexSession(): CodexSession {
   };
 }
 
-const tempDirs: string[] = [];
-
-afterEach(async () => {
-  await cleanupTempDirs(tempDirs);
-});
+const tempDirs = useTempDirs();
 
 describe('Copilot model handler routing', () => {
   const copilotConfig = modelConfig(ModelProvider.COPILOT, {

--- a/src/test-kernel/agent/prompt/userVars.vitest.ts
+++ b/src/test-kernel/agent/prompt/userVars.vitest.ts
@@ -33,7 +33,7 @@ import { setRuntimeSkillSources } from '@skills/runtimeSkills';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { spiedTrace } from '@test/support/spiedTrace';
 import { writeSkill } from '@test/support/skillFixtures';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import {
   createFakePlatform,
   FakeConfigProvider,
@@ -105,7 +105,7 @@ describe('getToolFlags', () => {
 
 describe('buildUserVars runtime skill diagnostics', () => {
   const missingSource = '/missing/runtime-skill-source';
-  const tempRoots: string[] = [];
+  const tempRoots = useTempDirs();
 
   beforeEach(() => {
     fakeConfig.set('texra.skills.enabled', true);
@@ -122,7 +122,6 @@ describe('buildUserVars runtime skill diagnostics', () => {
   afterEach(async () => {
     setRuntimeSkillSources([]);
     await fakeConfig.update('texra.skills.enabled', undefined);
-    await cleanupTempDirs(tempRoots);
   });
 
   it('emits catalog load issues and the exact accepted snapshot through the agent trace', async () => {

--- a/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
+++ b/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
@@ -3,7 +3,7 @@ import { mkdir, realpath, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
 // Third-party imports
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 // Local imports
 import {
@@ -15,8 +15,8 @@ import {
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { setupPlatform } from '@test/support/setupPlatform';
 import {
-  cleanupTempDirs,
   makeTempDir,
+  useTempDirs,
   withTempDir,
 } from '@test/support/tempDirPlatform';
 import { executeCommand } from '@utils/system/execUtils';
@@ -35,7 +35,7 @@ describe('isPathInChangeSet', () => {
 });
 
 describe('collectReviewDiff (real git repository)', () => {
-  const tempDirs: string[] = [];
+  const tempDirs = useTempDirs();
   let repo: string;
 
   async function git(...args: string[]): Promise<string> {
@@ -57,10 +57,6 @@ describe('collectReviewDiff (real git repository)', () => {
     await writeFile(path.join(repo, 'paper.tex'), 'original line\n');
     await git('add', '.');
     await git('commit', '-m', 'initial');
-  });
-
-  afterEach(async () => {
-    await cleanupTempDirs(tempDirs);
   });
 
   async function collectDiff(options: Partial<CollectReviewDiffOptions> = {}) {
@@ -94,7 +90,7 @@ describe('collectReviewDiff (real git repository)', () => {
     expect(value.diff).not.toContain('untracked content');
     expect(value.changedFiles).toEqual(['paper.tex']);
     expect(value.truncated).toBe(false);
-    expect(await realpath(value.repoRoot)).toBe(await realpath(repo));
+    expect(await realpath(value.repoRoot)).toBe(repo);
   });
 
   it('ignores inherited interactive git environment variables', async () => {
@@ -139,7 +135,7 @@ describe('collectReviewDiff (real git repository)', () => {
     const value = await collectDiffOrFail({
       cwd: path.join(repo, 'sub'),
     });
-    expect(await realpath(value.repoRoot)).toBe(await realpath(repo));
+    expect(await realpath(value.repoRoot)).toBe(repo);
     expect(value.changedFiles).toEqual(['sub/note.txt']);
   });
 

--- a/src/test-kernel/frontend/VscodeToolEditApproval.vitest.ts
+++ b/src/test-kernel/frontend/VscodeToolEditApproval.vitest.ts
@@ -1,5 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { rm } from 'node:fs/promises';
 import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -14,6 +13,7 @@ import { VscodeToolEditApprovalHost } from '@frontend/approval/VscodeToolEditApp
 import type { ToolEditPermission } from '@shared/schemas';
 import { SESSION_DISPOSED_CAUSE } from '@shared/copy/interactionCancellation';
 import { createTestSession } from '@test/support/sessionTestUtils';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import type { ToolEditApprovalResult } from '@tools/approval/toolEditApproval';
 
 interface TestUri {
@@ -123,6 +123,7 @@ type ApprovalPrompts = Pick<
 >;
 
 const sessions: SessionHandle[] = [];
+const tempDirs = useTempDirs();
 const activeApprovals: Promise<ToolEditApprovalResult>[] = [];
 let storageRoot: string;
 
@@ -228,7 +229,7 @@ beforeEach(async () => {
       return undefined;
     },
   );
-  storageRoot = await mkdtemp(path.join(tmpdir(), 'texra-native-approval-'));
+  storageRoot = await makeTempDir('texra-native-approval-', tempDirs);
 });
 
 afterEach(async () => {
@@ -236,7 +237,6 @@ afterEach(async () => {
     session.dispose();
   }
   await Promise.allSettled(activeApprovals.splice(0));
-  await rm(storageRoot, { recursive: true, force: true });
 });
 
 describe('VS Code tool edit approval', () => {

--- a/src/test-kernel/latex/ArxivProcessor.vitest.ts
+++ b/src/test-kernel/latex/ArxivProcessor.vitest.ts
@@ -8,15 +8,14 @@ import {
   resolveArxivPaperDirectoryRelative,
 } from '@latex/arxivProcessor';
 import * as logger from '@logger/logUtils';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 const SOURCE_URL = 'https://arxiv.org/src/2404.12175';
 
 afterEach(async () => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
-  await cleanupTempDirs(tempDirs);
 });
 
 async function tempSourceBase(): Promise<string> {

--- a/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
+++ b/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
@@ -16,7 +16,7 @@ import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import type { FileLocation, ToolConfig } from '@shared/schemas';
 import { installPlatform } from '@test/support/setupPlatform';
 import { spiedTrace } from '@test/support/spiedTrace';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import {
   createExternalLocation,
   createWorkspaceLocation,
@@ -58,11 +58,10 @@ const compilePdfConfig: ToolConfig = {
 
 const logger: LatexTrace = spiedTrace();
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 
 afterEach(async () => {
   vi.clearAllMocks();
-  await cleanupTempDirs(tempDirs);
 });
 
 describe('DiffFileProcessor line formatting', () => {
@@ -167,14 +166,7 @@ describe('LatexMediaManager figure baseDir resolution (issue #7228)', () => {
     texPath: string;
     figurePath: string;
   }> {
-    // Canonicalize up front: on macOS os.tmpdir() lives under a /tmp -> /private/tmp
-    // symlink, and resolveLatexDir follows real paths. Without this, the
-    // workspace root and the realpath'd baseDir it computes would disagree,
-    // and mirrorWorkspaceFile would (correctly, but confusingly for this test)
-    // classify the figure as external and skip mirroring it.
-    const tempDir = await realpath(
-      await makeTempDir('texra-latex-media-', tempDirs),
-    );
+    const tempDir = await makeTempDir('texra-latex-media-', tempDirs);
     const workspaceDir = path.join(tempDir, 'workspace');
     const storageRoot = path.join(tempDir, 'storage');
     const figureDir = path.join(workspaceDir, 'figures');

--- a/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
+++ b/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
@@ -10,7 +10,7 @@ import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import type { ExecutionId, OutputFileInfo } from '@shared/schemas';
 import { installPlatform } from '@test/support/setupPlatform';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import {
   createExternalLocation,
   createRunStorageLocation,
@@ -32,7 +32,7 @@ vi.mock('@utils/config/configUtils', () => ({
 }));
 
 describe('LaTeXdiffService shadow output', () => {
-  const tempDirs: string[] = [];
+  const tempDirs = useTempDirs();
 
   function installNodeBackedPlatform(
     workspaceDir: string,
@@ -93,7 +93,6 @@ describe('LaTeXdiffService shadow output', () => {
 
   afterEach(async () => {
     vi.clearAllMocks();
-    await cleanupTempDirs(tempDirs);
   });
 
   it('writes generated diff sources to the requested output directory', async () => {

--- a/src/test-kernel/latex/OutputDiscovery.vitest.ts
+++ b/src/test-kernel/latex/OutputDiscovery.vitest.ts
@@ -10,7 +10,7 @@ import type {
 import * as logger from '@logger/logUtils';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { installPlatform } from '@test/support/setupPlatform';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 // `discoverLatestExecutionOutputs` matches a run by agent/model/input and then
 // reads its per-round outputs. Headless `texra run` executions persist those
@@ -73,7 +73,7 @@ const MATCHING_QUERY = {
 } as const;
 
 describe('discoverLatestExecutionOutputs', () => {
-  const tempDirs: string[] = [];
+  const tempDirs = useTempDirs();
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -83,7 +83,6 @@ describe('discoverLatestExecutionOutputs', () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
-    await cleanupTempDirs(tempDirs);
   });
 
   it('falls back to an on-disk run-dir scan when the stream-tab snapshot is empty', async () => {
@@ -154,7 +153,7 @@ describe('discoverLatestExecutionOutputs', () => {
 });
 
 describe('outputDiscovery logger seam', () => {
-  const tempDirs: string[] = [];
+  const tempDirs = useTempDirs();
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -166,7 +165,6 @@ describe('outputDiscovery logger seam', () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
-    await cleanupTempDirs(tempDirs);
   });
 
   // #10634: a failed persisted-state read degrades the invocation to the

--- a/src/test-kernel/platform/FileLocks.vitest.ts
+++ b/src/test-kernel/platform/FileLocks.vitest.ts
@@ -2,19 +2,15 @@ import { stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { setImmediate, setTimeout as sleep } from 'node:timers/promises';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   createNodeFileLocks,
   nodeFileLocks,
 } from '@platform/defaults/fileLocks';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
-const tempDirs: string[] = [];
-
-afterEach(async () => {
-  await cleanupTempDirs(tempDirs);
-});
+const tempDirs = useTempDirs();
 
 describe('nodeFileLocks', () => {
   it('refreshes a lock while a long critical section is still held', async () => {

--- a/src/test-kernel/platform/NodeWorkspace.vitest.ts
+++ b/src/test-kernel/platform/NodeWorkspace.vitest.ts
@@ -4,21 +4,17 @@ import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
 // Third-party imports
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 // Local imports - platform
 import {
   canonicalizeWorkspacePath,
   createNodeWorkspace,
 } from '@platform/defaults/nodeWorkspace';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 describe('Node workspace identity', () => {
-  const tempDirs: string[] = [];
-
-  afterEach(async () => {
-    await cleanupTempDirs(tempDirs);
-  });
+  const tempDirs = useTempDirs();
 
   it('uses the physical directory for a symlinked workspace', async () => {
     const root = await makeTempDir('texra-node-workspace-', tempDirs);

--- a/src/test-kernel/platform/WorkspaceStorage.vitest.ts
+++ b/src/test-kernel/platform/WorkspaceStorage.vitest.ts
@@ -3,7 +3,7 @@ import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 // Third-party imports
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 // Local imports - platform
 import { WORKSPACE_SIDECAR_FILE } from '@common/storage/storageLayout';
@@ -21,7 +21,7 @@ import {
   workspaceStorageId,
 } from '@platform/defaults/workspaceStorage';
 import { pathExists } from '@test/support/fsTestUtils';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 async function readWorkspaceMarker(
   storagePath: string,
@@ -34,15 +34,11 @@ async function readWorkspaceMarker(
 }
 
 describe('workspace storage defaults', () => {
-  const tempDirs: string[] = [];
+  const tempDirs = useTempDirs();
 
   function makeStorageRoot(): Promise<string> {
     return makeTempDir('texra-workspace-storage-', tempDirs);
   }
-
-  afterEach(async () => {
-    await cleanupTempDirs(tempDirs);
-  });
 
   it('computes a stable workspace storage identity', () => {
     expect(workspaceStorageId('/workspace/a')).toMatch(/^a-[0-9a-f]{8}$/);

--- a/src/test-kernel/progressView/ChatExportControllerHtml.vitest.ts
+++ b/src/test-kernel/progressView/ChatExportControllerHtml.vitest.ts
@@ -1,8 +1,7 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
-import * as os from 'node:os';
+import { writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { getExecutionStore } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
@@ -21,6 +20,7 @@ import {
 } from '@shared/schemas';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { createFakePlatform } from '@test/support/FakePlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import {
   appendTranscriptEntry,
   snapshotFacts,
@@ -33,11 +33,10 @@ const TEMPLATE =
   '<script type="module" crossorigin src="./index.js"></script>' +
   '</head><body></body></html>';
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 
 async function installStoragePlatform(): Promise<void> {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-html-export-'));
-  tempDirs.push(tempDir);
+  const tempDir = await makeTempDir('texra-html-export-', tempDirs);
   const workspaceDir = path.join(tempDir, 'workspace');
   const storageRoot = path.join(tempDir, 'storage');
   const { initPlatform } = await import('@platform/platform');
@@ -56,8 +55,7 @@ async function installStoragePlatform(): Promise<void> {
 }
 
 async function writeTemplate(): Promise<string> {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-template-'));
-  tempDirs.push(tempDir);
+  const tempDir = await makeTempDir('texra-template-', tempDirs);
   const templatePath = path.join(tempDir, 'index.html');
   await writeFile(templatePath, TEMPLATE, 'utf8');
   return templatePath;
@@ -116,14 +114,6 @@ describe('ChatExportController.exportAsHtml', () => {
   }
 
   beforeEach(installStoragePlatform);
-
-  afterEach(async () => {
-    await Promise.all(
-      tempDirs
-        .splice(0)
-        .map((dir) => rm(dir, { recursive: true, force: true })),
-    );
-  });
 
   it('returns config_missing when nothing is stored', async () => {
     const templatePath = await writeTemplate();

--- a/src/test-kernel/settings/ExtensionTexraConfig.vitest.ts
+++ b/src/test-kernel/settings/ExtensionTexraConfig.vitest.ts
@@ -1,23 +1,16 @@
 // Node imports
-import {
-  access,
-  mkdtemp,
-  mkdir,
-  readFile,
-  rm,
-  writeFile,
-} from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 // Third-party imports
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - extension
 import { createExtensionTexraConfig } from '@frontend/vscode/texraConfig';
 
 // Local imports - platform
 import type { StorageProvider } from '@platform/interfaces';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 function createStorage(
   workspaceStorage: string,
@@ -30,19 +23,15 @@ function createStorage(
 }
 
 describe.skipIf(process.platform === 'win32')('extension TeXRA config', () => {
+  const tempDirs = useTempDirs();
   let tempDir: string | undefined;
-
-  afterEach(async () => {
-    if (tempDir) await rm(tempDir, { recursive: true, force: true });
-    tempDir = undefined;
-  });
 
   async function createTempLayout(): Promise<{
     workspace: string;
     internalStorage: string;
     globalStorage: string;
   }> {
-    tempDir = await mkdtemp(join(tmpdir(), 'texra-extension-config-'));
+    tempDir = await makeTempDir('texra-extension-config-', tempDirs);
     const workspace = join(tempDir, 'project');
     const internalStorage = join(tempDir, 'internal');
     const globalStorage = join(tempDir, 'global');
@@ -94,7 +83,7 @@ describe.skipIf(process.platform === 'win32')('extension TeXRA config', () => {
   });
 
   it('rebinds reads and writes when the workspace folder changes', async () => {
-    tempDir = await mkdtemp(join(tmpdir(), 'texra-extension-config-'));
+    tempDir = await makeTempDir('texra-extension-config-', tempDirs);
     const firstWorkspace = join(tempDir, 'first');
     const secondWorkspace = join(tempDir, 'second');
     const firstConfig = join(firstWorkspace, '.texra', 'config.json');

--- a/src/test-kernel/settings/ExtensionTexraConfig.vitest.ts
+++ b/src/test-kernel/settings/ExtensionTexraConfig.vitest.ts
@@ -24,14 +24,13 @@ function createStorage(
 
 describe.skipIf(process.platform === 'win32')('extension TeXRA config', () => {
   const tempDirs = useTempDirs();
-  let tempDir: string | undefined;
 
   async function createTempLayout(): Promise<{
     workspace: string;
     internalStorage: string;
     globalStorage: string;
   }> {
-    tempDir = await makeTempDir('texra-extension-config-', tempDirs);
+    const tempDir = await makeTempDir('texra-extension-config-', tempDirs);
     const workspace = join(tempDir, 'project');
     const internalStorage = join(tempDir, 'internal');
     const globalStorage = join(tempDir, 'global');
@@ -83,7 +82,7 @@ describe.skipIf(process.platform === 'win32')('extension TeXRA config', () => {
   });
 
   it('rebinds reads and writes when the workspace folder changes', async () => {
-    tempDir = await makeTempDir('texra-extension-config-', tempDirs);
+    const tempDir = await makeTempDir('texra-extension-config-', tempDirs);
     const firstWorkspace = join(tempDir, 'first');
     const secondWorkspace = join(tempDir, 'second');
     const firstConfig = join(firstWorkspace, '.texra', 'config.json');

--- a/src/test-kernel/settings/ExtensionWorkspaceTransition.vitest.ts
+++ b/src/test-kernel/settings/ExtensionWorkspaceTransition.vitest.ts
@@ -1,6 +1,5 @@
 // Node imports
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 // Third-party imports
@@ -9,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Type imports
 import type { WorkspaceStorageTransitionHooks } from '@agent/runtime/SessionHandle';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import type * as vscode from 'vscode';
 
 const mocks = vi.hoisted(() => ({
@@ -205,6 +205,7 @@ async function expectConfigContains(
 describe.skipIf(process.platform === 'win32')(
   'extension workspace transition integration',
   () => {
+    const tempDirs = useTempDirs();
     let tempDir: string;
     let workspaceRoot: string | undefined;
     let provider: InstanceType<typeof ProgressViewProvider> | undefined;
@@ -214,13 +215,12 @@ describe.skipIf(process.platform === 'win32')(
       mocks.showErrorMessage.mockReset();
       mocks.workspaceListeners.length = 0;
       mocks.setApprovalPolicy.mockReset();
-      tempDir = await mkdtemp(join(tmpdir(), 'texra-workspace-transition-'));
+      tempDir = await makeTempDir('texra-workspace-transition-', tempDirs);
     });
 
     afterEach(async () => {
       provider?.dispose();
       provider = undefined;
-      await rm(tempDir, { recursive: true, force: true });
     });
 
     /** Wire storage + config + the progress view provider over `tempDir`. */

--- a/src/test-kernel/shared/LegacyWorkflowOutput.vitest.ts
+++ b/src/test-kernel/shared/LegacyWorkflowOutput.vitest.ts
@@ -1,6 +1,5 @@
 // Node imports
-import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { access, mkdir, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
 // Third-party imports
@@ -20,13 +19,16 @@ import {
   workflowOutputCopyStem,
 } from '@shared/constants/workflowOutput';
 import { installPlatform } from '@test/support/setupPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 describe('filename-era workflow output grammar', () => {
+  const tempDirs = useTempDirs();
   let workspacePath: string;
 
   beforeEach(async () => {
-    workspacePath = await mkdtemp(
-      path.join(tmpdir(), 'texra-legacy-workflow-output-'),
+    workspacePath = await makeTempDir(
+      'texra-legacy-workflow-output-',
+      tempDirs,
     );
     await installPlatform(
       {
@@ -39,7 +41,6 @@ describe('filename-era workflow output grammar', () => {
 
   afterEach(async () => {
     await installPlatform();
-    await rm(workspacePath, { recursive: true, force: true });
   });
 
   it.each([

--- a/src/test-kernel/skills/LoadSkills.vitest.ts
+++ b/src/test-kernel/skills/LoadSkills.vitest.ts
@@ -2,21 +2,17 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { discoverSkills, discoverSkillSources } from '@skills/loadSkills';
 import { writeSkill } from '@test/support/skillFixtures';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
-const tempRoots: string[] = [];
+const tempRoots = useTempDirs();
 
 async function createTempRoot(): Promise<string> {
   return makeTempDir('texra-skills-', tempRoots);
 }
-
-afterEach(async () => {
-  await cleanupTempDirs(tempRoots);
-});
 
 type DiscoveryOutcome = {
   skills: Array<{ skill: { name: string } }>;

--- a/src/test-kernel/skills/RuntimeSkills.vitest.ts
+++ b/src/test-kernel/skills/RuntimeSkills.vitest.ts
@@ -17,11 +17,11 @@ import {
 } from '@skills/runtimeSkills';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { writeSkill } from '@test/support/skillFixtures';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { attachTranscriptRecorder } from '@transcript/TexraTranscriptRecorder';
 import { StreamLogStore } from '@transcript/StreamLogStore';
 
-const tempRoots: string[] = [];
+const tempRoots = useTempDirs();
 
 async function createTempRoot(): Promise<string> {
   return makeTempDir('texra-runtime-skills-', tempRoots);
@@ -35,7 +35,6 @@ setupPlatform({ workspacePath: '/workspace' });
 
 afterEach(async () => {
   setRuntimeSkillSources([]);
-  await cleanupTempDirs(tempRoots);
 });
 
 describe('runtime skills', () => {

--- a/src/test-kernel/support/tempDirPlatform.ts
+++ b/src/test-kernel/support/tempDirPlatform.ts
@@ -23,8 +23,9 @@ import { createFakePlatform } from './FakePlatform';
  *
  * Resolves the realpath so the returned path is canonical: on Windows CI the
  * 8.3 short-name form of the temp dir (`RUNNER~1`) differs from the resolved
- * long form (`runneradmin`), and production code that realpaths the temp dir
- * would otherwise produce a path that never equals the one returned here.
+ * long form (`runneradmin`), while on macOS the temporary root may traverse
+ * the `/tmp` to `/private/tmp` symlink. Production code that resolves either
+ * path would otherwise produce a path that never equals the one returned here.
  */
 export async function makeTempDir(
   prefix: string,

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -5,7 +5,7 @@ import '@test/support/defaultSessionTestSetup';
 import { mkdir, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { flowKey } from '@agent/node/persistedFlow';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
@@ -16,8 +16,8 @@ import { STREAM_PHASE, DEFAULT_TOOL_CONFIG } from '@shared/schemas';
 import type { ExecutionId, StreamTabId, TodoItem } from '@shared/schemas';
 import { testExecutionHandle } from '@test/support/executionHandleFixtures';
 import {
-  cleanupTempDirs,
   createTempDirPlatform,
+  useTempDirs,
 } from '@test/support/tempDirPlatform';
 import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 import { seedStreamStatusForTest } from '@test/support/streamStatusTestUtils';
@@ -28,7 +28,7 @@ import { ExecutionsTool } from '@tools/ExecutionsTool';
 import { StreamSnapshotStore, streamDataDir } from '@transcript';
 import { StorageFS } from '@utils/files/storageFS';
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 
 const mocks = vi.hoisted(() => ({
   readConfig: vi.fn(),
@@ -126,10 +126,6 @@ describe('ExecutionsTool', () => {
     mocks.readReport.mockResolvedValue(null);
     mocks.readResultMeta.mockResolvedValue(null);
     mocks.readWorkspaceFiles.mockResolvedValue([]);
-  });
-
-  afterEach(async () => {
-    await cleanupTempDirs(tempDirs);
   });
 
   it.each([

--- a/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
@@ -54,8 +54,8 @@ import {
   AgentCategory,
 } from '@shared/schemas';
 import {
-  cleanupTempDirs,
   createTempDirPlatform,
+  useTempDirs,
 } from '@test/support/tempDirPlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { roundModelHandler } from '@test/agent/toolUseRoundTestUtils';
@@ -74,7 +74,7 @@ const PARENT_MODEL = 'gpt54';
 const CHILD_MODEL = 'gpt55';
 const MODEL_HANDLER_KEY = 'ModelHandlerOpenAIResponse';
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 let session: SessionHandle;
 let childId: ExecutionId | undefined;
 let resumedStreams: StreamTabId[];
@@ -366,7 +366,6 @@ describe('native subagent production delivery path', { retry: 2 }, () => {
     clearInlineAgents();
     clearStoreCache();
     vi.restoreAllMocks();
-    await cleanupTempDirs(tempDirs);
   });
 
   it('resumes one persisted child through the real queue and archives both turns once', async () => {

--- a/src/test-kernel/traceViewer/replayTrace.vitest.ts
+++ b/src/test-kernel/traceViewer/replayTrace.vitest.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { getExecutionStore } from '@agent/storage';
 import { getStreamTabId } from '@agent/runtime/streamTab';
@@ -23,8 +23,8 @@ import {
 } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 import {
-  cleanupTempDirs,
   createTempDirPlatform,
+  useTempDirs,
 } from '@test/support/tempDirPlatform';
 import {
   appendTranscriptEntry,
@@ -38,7 +38,7 @@ import { assembleTrace, StreamLogStore } from '@transcript';
 // so a plain relative import is the simplest way to reach it.
 import { replayTrace } from '../../../packages/trace-viewer/src/replayTrace';
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 
 setupPlatform(() => createTempDirPlatform('texra-replay-trace-', tempDirs));
 
@@ -46,10 +46,6 @@ beforeEach(() => {
   // replayTrace's slices write the shared progressState singletons directly;
   // reset them so each test starts from a clean slate.
   resetProgressState();
-});
-
-afterEach(async () => {
-  await cleanupTempDirs(tempDirs);
 });
 
 type TraceEntry = TraceDocument['entries'][number];

--- a/src/test-kernel/transcript/StagedDeletionCoordinator.vitest.ts
+++ b/src/test-kernel/transcript/StagedDeletionCoordinator.vitest.ts
@@ -2,13 +2,13 @@
 import * as path from 'node:path';
 
 // Third-party imports
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 // Local imports
 import type { StreamTabId } from '@shared/schemas';
 import {
-  cleanupTempDirs,
   createTempDirPlatform,
+  useTempDirs,
 } from '@test/support/tempDirPlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
 import {
@@ -29,7 +29,7 @@ import { StorageFS } from '@utils/files/storageFS';
  * StreamSnapshotStore.vitest.ts; these cases pin the port itself.
  */
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 const STREAM = 'polish@gpt#abc123def' as StreamTabId;
 const PLAN_KEY = 'workPlan';
 
@@ -103,10 +103,6 @@ describe('StagedDeletionCoordinator', () => {
   setupPlatform(() =>
     createTempDirPlatform('texra-staged-deletion-', tempDirs),
   );
-
-  afterEach(async () => {
-    await cleanupTempDirs(tempDirs);
-  });
 
   it('cancels and invalidates queued writes before the staging rename', async () => {
     const { calls, coordinator } = setupCoordinator();

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -29,8 +29,8 @@ import type {
   WorkPlanSnapshot,
 } from '@shared/schemas';
 import {
-  cleanupTempDirs,
   createTempDirPlatform,
+  useTempDirs,
 } from '@test/support/tempDirPlatform';
 import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 import { snapshotFacts } from '@test/support/storeTestDrivers';
@@ -43,7 +43,7 @@ import {
 } from '@transcript/streamDataPaths';
 import { StorageFS } from '@utils/files/storageFS';
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 
 const STREAM = 'polish@gpt#abc123def' as StreamTabId;
 const OTHER_STREAM = 'review@gpt#fed321cba' as StreamTabId;
@@ -189,7 +189,6 @@ describe('StreamSnapshotStore', () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
-    await cleanupTempDirs(tempDirs);
   });
 
   it('persists todos/plan/usage from direct mutators and reassembles them on a fresh store', async () => {
@@ -2818,7 +2817,6 @@ describe('StreamSnapshotStore loud unhydrated access (#9947)', () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
-    await cleanupTempDirs(tempDirs);
   });
 
   function unseededWarnings(warnSpy: {

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { TraceEmitter, type StatusEvent } from '@agent/trace';
 import {
@@ -14,8 +14,8 @@ import {
 import { STREAM_TRANSITION_CAUSE } from '@shared/streams/streamStatus';
 import { setupPlatform } from '@test/support/setupPlatform';
 import {
-  cleanupTempDirs,
   createTempDirPlatform,
+  useTempDirs,
 } from '@test/support/tempDirPlatform';
 import { attachTranscriptRecorder } from '@transcript/TexraTranscriptRecorder';
 import { StreamLogStore } from '@transcript/StreamLogStore';
@@ -785,12 +785,8 @@ describe('attachTranscriptRecorder spill artifacts', () => {
 });
 
 describe('attachTranscriptRecorder active skills', () => {
-  const tempDirs: string[] = [];
+  const tempDirs = useTempDirs();
   setupPlatform(() => createTempDirPlatform('texra-recorder-', tempDirs));
-
-  afterEach(async () => {
-    await cleanupTempDirs(tempDirs);
-  });
 
   it('persists only sanitized summaries and lets the latest empty snapshot clear state', () => {
     const { trace, rows } = attachRecorder();

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -71,8 +71,8 @@ import {
 } from '@shared/schemas';
 import type { ExecutionId, StreamTabId, TodoItem } from '@shared/schemas';
 import {
-  cleanupTempDirs,
   createTempDirPlatform,
+  useTempDirs,
 } from '@test/support/tempDirPlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { createTestSession } from '@test/support/sessionTestUtils';
@@ -91,7 +91,7 @@ import {
 } from '@transcript';
 import type { TranscriptWriter } from '@transcript/StreamLogStore';
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 
 function runConfig(agent: string, model = 'deepseekproT'): AgentConfig {
   return AgentConfigSchema.parse({
@@ -264,7 +264,6 @@ describe('completedRunArchive facade', () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
-    await cleanupTempDirs(tempDirs);
   });
 
   it('serves conversation, chat export, and todos from the sidecars alone (projections gone)', async () => {

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -19,8 +19,8 @@ import {
   AgentCategory,
 } from '@shared/schemas';
 import {
-  cleanupTempDirs,
   createTempDirPlatform,
+  useTempDirs,
 } from '@test/support/tempDirPlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
 import {
@@ -33,7 +33,7 @@ import {
   StreamSnapshotStore,
 } from '@transcript';
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 
 /** Persists a single stream-log entry so the stream is discoverable on disk. */
 async function appendLogEntry(
@@ -90,7 +90,6 @@ describe('assembleTrace', () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
-    await cleanupTempDirs(tempDirs);
   });
 
   it('resolves a registered execution from its metadata without any sidecar scan (#9590 A1)', async () => {

--- a/src/test-kernel/transcript/traceViewerSchema.vitest.ts
+++ b/src/test-kernel/transcript/traceViewerSchema.vitest.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { getExecutionStore } from '@agent/storage';
 import { getStreamTabId } from '@agent/runtime/streamTab';
@@ -16,8 +16,8 @@ import {
 } from '@shared/schemas';
 import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
 import {
-  cleanupTempDirs,
   createTempDirPlatform,
+  useTempDirs,
 } from '@test/support/tempDirPlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { appendTranscriptEntry } from '@test/support/storeTestDrivers';
@@ -27,7 +27,7 @@ import {
   TraceDataSchema,
 } from '../../../packages/trace-viewer/src/traceDataSchema';
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 
 function config(overrides: Partial<AgentConfig> = {}): AgentConfig {
   return AgentConfigSchema.parse({
@@ -62,10 +62,6 @@ function expectTraceRejected(payload: unknown): void {
 
 describe('trace-viewer TraceDataSchema', () => {
   setupPlatform(() => createTempDirPlatform('texra-trace-viewer-', tempDirs));
-
-  afterEach(async () => {
-    await cleanupTempDirs(tempDirs);
-  });
 
   it('accepts a real trace document produced by assembleTrace', async () => {
     const executionId = 'abc12345' as ExecutionId;

--- a/src/test-kernel/utils/RoundDirOwnership.vitest.ts
+++ b/src/test-kernel/utils/RoundDirOwnership.vitest.ts
@@ -9,20 +9,20 @@ import {
 } from 'node:fs/promises';
 import * as path from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { MemoryStateStore } from '@platform/defaults/memoryState';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { createWorkspaceLocation } from '@utils/files/fileLocation';
 import { getOriginalSnapshotPath, getRunDir } from '@utils/files/runStorageFs';
 import { TaskRunFileService } from '@utils/files/taskRunStorage';
 
-const tempDirs: string[] = [];
+const tempDirs = useTempDirs();
 
 /**
  * Creates a temp workspace + storage pair backed by the real node filesystem
@@ -60,10 +60,6 @@ async function expectSymlinkTargeting(
 }
 
 describe('round-dir ownership and editable .tex inheritance', () => {
-  afterEach(async () => {
-    await cleanupTempDirs(tempDirs);
-  });
-
   it('snapshots editable .tex on mirror, points r<N>/ symlinks at the snapshot, and the round-output write replaces the symlink with a real file leaving snapshot and workspace untouched', async () => {
     const workspaceDir = await installTempWorkspace('texra-round-ownership-');
     const draftDir = path.join(workspaceDir, 'Draft');

--- a/src/test-kernel/utils/git/IsGitRepository.vitest.ts
+++ b/src/test-kernel/utils/git/IsGitRepository.vitest.ts
@@ -1,21 +1,17 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { isGitRepository } from '@utils/git/isGitRepository';
 
 const execFileAsync = promisify(execFile);
 
 describe('isGitRepository', () => {
-  const tempDirs: string[] = [];
-
-  afterEach(async () => {
-    await cleanupTempDirs(tempDirs);
-  });
+  const tempDirs = useTempDirs();
 
   function tempRepoDir(): Promise<string> {
     return makeTempDir('texra-is-git-repo-', tempDirs);

--- a/src/test-kernel/utils/system/SystemUtils.vitest.ts
+++ b/src/test-kernel/utils/system/SystemUtils.vitest.ts
@@ -7,13 +7,13 @@ import { join } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 
 // Third-party imports
-import { afterEach, describe, expect, expectTypeOf, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
 // Local imports
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
-import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 import { executeCommand, executeCommandSync } from '@utils/system/execUtils';
 import { buildWorkspaceInfoBlock } from '@utils/system/workspaceInfo';
 import { BinaryResolverService } from '@utils/system/binaryResolver';
@@ -67,15 +67,11 @@ type ExecuteCommandOptions = NonNullable<Parameters<typeof executeCommand>[1]>;
 const SLEEPER_SCRIPT = 'sleep 60 & echo $! > "$PID_FILE"; wait';
 
 describe('executeCommand', () => {
-  const tempDirs: string[] = [];
+  const tempDirs = useTempDirs();
 
   // executeCommand resolves its cwd from the workspace; point the fake
   // platform at a directory that exists on disk so spawning succeeds.
   setupPlatform({ workspacePath: process.cwd() });
-
-  afterEach(async () => {
-    await cleanupTempDirs(tempDirs);
-  });
 
   it('exposes only text encodings and non-transform output modes', () => {
     expectTypeOf<ExecuteCommandOptions['encoding']>().toEqualTypeOf<
@@ -338,7 +334,7 @@ describe('executeCommand', () => {
 // ---------------------------------------------------------------------------
 
 describe('executeCommandSync', () => {
-  const tempDirs: string[] = [];
+  const tempDirs = useTempDirs();
 
   setupPlatform(async () => {
     const storageRoot = await makeTempDir('texra-exec-utils-', tempDirs);
@@ -350,10 +346,6 @@ describe('executeCommandSync', () => {
       },
       { fs: nodeFilesystem },
     );
-  });
-
-  afterEach(async () => {
-    await cleanupTempDirs(tempDirs);
   });
 
   it('returns normalized stdout for successful commands', () => {
@@ -394,11 +386,7 @@ describe('executeCommandSync', () => {
 // ---------------------------------------------------------------------------
 
 describe('buildWorkspaceInfoBlock', () => {
-  const tempDirs: string[] = [];
-
-  afterEach(async () => {
-    await cleanupTempDirs(tempDirs);
-  });
+  const tempDirs = useTempDirs();
 
   it('tells agents when the workspace is not a git repository', async () => {
     const workspace = await makeTempDir('texra-workspace-info-', tempDirs);


### PR DESCRIPTION
## Summary

- migrate 32 remaining per-test temporary-directory suites to the shared `useTempDirs()` registry
- replace direct `mkdtemp` calls with canonicalizing `makeTempDir()` where the suite owns per-test fixtures
- remove redundant path canonicalization and the obsolete explanatory comment
- preserve the documented suite-lifetime, dynamic-import, helper-test, synchronous-fixture, and `onTestFinished` exclusions

This removes 225 lines while retaining the existing test lifetimes.

Closes #11037

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`
- `npm test` — 838 files passed, 10,230 tests passed
- focused changed-suite run — 32 files passed, 430 tests passed