### PR TITLE
fix: unify extension team prompts

### DIFF
--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -318,8 +318,9 @@ export class AgentHandlers {
                 void vscode.window.showInformationMessage(message);
                 return Promise.resolve();
               },
-              showErrorMessage: async (message) => {
-                await showLoggedMessage(this.ctx.channel, message);
+              showErrorMessage: (message) => {
+                void showLoggedMessage(this.ctx.channel, message);
+                return Promise.resolve();
               },
             },
             refreshAfterApply: (selectedToolUseAgent) =>
@@ -389,12 +390,17 @@ export class AgentHandlers {
   // ── Private helpers ──
 
   private async chooseTeamAvailability(prompt: TeamAvailabilityPrompt) {
+    const items = prompt.actions.map((action) => ({
+      title: action.label,
+      isCloseAffordance: action.choice === 'cancel',
+    }));
     const choice = await vscode.window.showWarningMessage(
       prompt.message,
       { modal: true },
-      ...prompt.actions.map((action) => action.label),
+      ...items,
     );
-    return prompt.actions.find((action) => action.label === choice)?.choice;
+    return prompt.actions.find((action) => action.label === choice?.title)
+      ?.choice;
   }
 
   private async createAgentFromTemplate(

--- a/packages/extension/src/webview/managers/executionHandlers.ts
+++ b/packages/extension/src/webview/managers/executionHandlers.ts
@@ -3,12 +3,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 import { AUTH_COMMANDS } from '@auth/constants';
-import {
-  formatUnavailableTeamMembersMessage,
-  TEAM_LAUNCH_CANCEL_LABEL,
-  TEAM_LAUNCH_CONTINUE_LABEL,
-  TEAM_LAUNCH_SIGN_IN_LABEL,
-} from '@common/teams/TeamPlan';
+import { teamAvailabilityPrompt } from '@common/teams/TeamPlan';
 import { prepareMainViewExecutionLaunch } from '@controllers/mainView/backend/MainViewExecutionLaunchController';
 import { logErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { createLog } from '@logger/logUtils';
@@ -59,15 +54,15 @@ export async function handleExecute(
 
   const launch = await prepareMainViewExecutionLaunch(message, {
     chooseTeamAvailability: async (unavailableNames) => {
+      const prompt = teamAvailabilityPrompt(unavailableNames);
       const choice = await vscode.window.showWarningMessage(
-        formatUnavailableTeamMembersMessage(unavailableNames),
-        TEAM_LAUNCH_SIGN_IN_LABEL,
-        TEAM_LAUNCH_CONTINUE_LABEL,
-        TEAM_LAUNCH_CANCEL_LABEL,
+        prompt.message,
+        ...prompt.actions.map((action) => action.label),
       );
-      if (choice === TEAM_LAUNCH_SIGN_IN_LABEL) return 'sign-in';
-      if (choice === TEAM_LAUNCH_CONTINUE_LABEL) return 'continue';
-      return 'cancel';
+      return (
+        prompt.actions.find((action) => action.label === choice)?.choice ??
+        'cancel'
+      );
     },
     signInForRemoteAgentCatalog: async () =>
       Boolean(

--- a/src/common/teams/TeamPlan.ts
+++ b/src/common/teams/TeamPlan.ts
@@ -393,11 +393,7 @@ export async function refreshRemoteCatalogForGaps<T>(
 // (VS Code vs Electron native); keeping the literals here stops them drifting.
 // ---------------------------------------------------------------------------
 
-/** Button labels for the unavailable-members choice, in display order. */
-export const TEAM_LAUNCH_SIGN_IN_LABEL = 'Sign In to TeXRA';
-export const TEAM_LAUNCH_CONTINUE_LABEL = 'Continue with Available Members';
-export const TEAM_LAUNCH_CANCEL_LABEL = 'Cancel';
-
+/** Host-neutral unavailable-members prompt, including action order. */
 export interface TeamAvailabilityPrompt {
   readonly severity: 'warning';
   readonly message: string;
@@ -417,9 +413,9 @@ export function teamAvailabilityPrompt(
     severity: 'warning',
     message: formatUnavailableTeamMembersMessage(unavailableNames, teamId),
     actions: [
-      { choice: 'sign-in', label: TEAM_LAUNCH_SIGN_IN_LABEL },
-      { choice: 'continue', label: TEAM_LAUNCH_CONTINUE_LABEL },
-      { choice: 'cancel', label: TEAM_LAUNCH_CANCEL_LABEL },
+      { choice: 'sign-in', label: 'Sign In to TeXRA' },
+      { choice: 'continue', label: 'Continue with Available Members' },
+      { choice: 'cancel', label: 'Cancel' },
     ],
   };
 }
@@ -451,7 +447,7 @@ export function formatTeamUnavailableMessage(
  * context: the main-view launch path already displays the team being launched,
  * while the settings path names it inline.
  */
-export function formatUnavailableTeamMembersMessage(
+function formatUnavailableTeamMembersMessage(
   unavailableNames: readonly string[],
   teamId?: string,
 ): string {

--- a/src/test-kernel/settings/ExtensionAgentHandlers.vitest.ts
+++ b/src/test-kernel/settings/ExtensionAgentHandlers.vitest.ts
@@ -10,6 +10,7 @@ import { installPlatform } from '@test/support/setupPlatform';
 type AgentCatalog = Record<AgentCategory, AgentEntry[]>;
 
 const host = vi.hoisted(() => ({
+  showErrorMessage: vi.fn(),
   showInformationMessage: vi.fn(),
   showWarningMessage: vi.fn(),
   executeCommand: vi.fn(),
@@ -21,6 +22,7 @@ vi.mock('vscode', async () => {
     ...actual,
     window: {
       ...actual.window,
+      showErrorMessage: host.showErrorMessage,
       showInformationMessage: host.showInformationMessage,
       showWarningMessage: host.showWarningMessage,
     },
@@ -95,6 +97,7 @@ interface HandlerFixtureOptions {
   readonly catalog?: AgentCatalog;
   /** Button label returned by the modal "members unavailable" prompt. */
   readonly modalChoice?: string | undefined;
+  readonly errorMessageResult?: Promise<string | undefined>;
   readonly infoMessageResult?: Promise<string | undefined>;
 }
 
@@ -110,9 +113,10 @@ async function createHandlerFixture(options: HandlerFixtureOptions = {}) {
     notifications.push(message);
     return options.infoMessageResult;
   });
+  host.showErrorMessage.mockReturnValue(options.errorMessageResult);
   host.showWarningMessage.mockImplementation(async (message: string) => {
     modalPrompts.push(message);
-    return options.modalChoice;
+    return options.modalChoice ? { title: options.modalChoice } : undefined;
   });
 
   const refreshAfterAgentMutation = vi.fn(
@@ -211,6 +215,17 @@ describe('extension settings AgentHandlers', () => {
     ]);
   });
 
+  it('does not await an error notification before releasing refresh work', async () => {
+    const { handlers } = await createHandlerFixture({
+      errorMessageResult: new Promise(() => {}),
+    });
+
+    await expect(
+      applyPreset(handlers, 'missing-team'),
+    ).resolves.toBeUndefined();
+    expect(host.showErrorMessage).toHaveBeenCalledOnce();
+  });
+
   it('signs in before one forced remote refresh and commits the team once', async () => {
     const workspaceState = new FakeStateStore(REMOTE_TEAM_STATE);
     const order: string[] = [];
@@ -268,9 +283,12 @@ describe('extension settings AgentHandlers', () => {
     expect(host.showWarningMessage).toHaveBeenCalledWith(
       modalPrompts[0],
       { modal: true },
-      'Sign In to TeXRA',
-      'Continue with Available Members',
-      'Cancel',
+      { title: 'Sign In to TeXRA', isCloseAffordance: false },
+      {
+        title: 'Continue with Available Members',
+        isCloseAffordance: false,
+      },
+      { title: 'Cancel', isCloseAffordance: true },
     );
     expect(registry.refreshAgents).not.toHaveBeenCalled();
     expect(refreshAfterAgentMutation).not.toHaveBeenCalled();

--- a/src/test-kernel/webview/ExecutionHandlers.vitest.ts
+++ b/src/test-kernel/webview/ExecutionHandlers.vitest.ts
@@ -32,12 +32,17 @@ vi.mock('@common/teams/TeamPlan', () => ({
   formatPartialTeamLaunchMessage: vi.fn(),
   formatTeamLaunchBlockedMessage: vi.fn(),
   formatTeamUnavailableMessage: vi.fn(),
-  formatUnavailableTeamMembersMessage: vi.fn(),
   formatUnknownTeamMessage: vi.fn(),
   resolveTeamLaunch: vi.fn(),
-  TEAM_LAUNCH_CANCEL_LABEL: 'Cancel',
-  TEAM_LAUNCH_CONTINUE_LABEL: 'Continue',
-  TEAM_LAUNCH_SIGN_IN_LABEL: 'Sign in',
+  teamAvailabilityPrompt: vi.fn(() => ({
+    severity: 'warning',
+    message: 'Unavailable members',
+    actions: [
+      { choice: 'sign-in', label: 'Sign in' },
+      { choice: 'continue', label: 'Continue' },
+      { choice: 'cancel', label: 'Cancel' },
+    ],
+  })),
   TEAM_SELECTION_REQUIRED_MESSAGE: 'Select a team',
 }));
 vi.mock('@controllers/mainView/teamCatalogPorts', () => ({


### PR DESCRIPTION
## Summary

The extension now consumes the same `teamAvailabilityPrompt()` result as the desktop and settings paths. The shared builder is the sole owner of the unavailable-member message, action labels, action order, and choices.

The settings modal now marks its Cancel action as the native close affordance, so VS Code does not add a second Cancel button. Error notifications are launched without holding the agent-catalog refresh deferral open until the user dismisses the notification.

## Issue acceptance gates

- #11307: error notification dismissal no longer blocks deferred catalog refresh work; the settings modal has one Cancel action and identifies it as the close affordance.
- #11357: the extension launch path consumes `teamAvailabilityPrompt()` instead of reconstructing its message and labels.

No acceptance gate remains incomplete.

## Single source of truth

`src/common/teams/TeamPlan.ts` and its `teamAvailabilityPrompt()` builder own the prompt text and ordered action definitions for every host.

## Duplication and abstraction budget

Removed the extension launch path's parallel prompt construction and four exports that no external consumer needs: three label constants and the underlying message formatter. No new abstraction or forwarding layer was added.

## Net elements (R6)

- Files: 5 modified; no files added or deleted.
- Diff: 54 additions, 34 deletions; net +20 lines, including one regression test for the notification-lifecycle defect and the updated modal-shape assertion.
- Exported symbols: four removed; none added.
- No classes, interfaces, or enums added or removed.

## Consumer counts (R8)

- The four removed exports have zero production consumers after the launch path adopts `teamAvailabilityPrompt()`.
- No event key, subscriber, or message route is deleted or rerouted.

## Host impact

Extension: uses the shared launch prompt, presents one native Cancel action, and does not block refresh work on notification dismissal.

Desktop: no behavior change.

CLI: no behavior change.

## Scheduled refactoring

None.

## Validation

- `npm run check:dead-code-ratchet`
- `npm run lint`
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- `npm run compile:fast`
- `vitest run src/test-kernel/settings/ExtensionAgentHandlers.vitest.ts src/test-kernel/webview/ExecutionHandlers.vitest.ts` (9 assertions)
- pre-commit and pre-push checks

Closes #11307
Closes #11357
