### PR TITLE
fix: honor current Codex install layout and extra-high reasoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 - **Google background responses are off by default** — Gemini workflow
   generations stay on the live request unless you turn them on in the Google
   provider settings. OpenAI's background setting is unchanged.
+- **Codex runs use the installed runtime consistently** — TeXRA recognizes the
+  current Codex installation layout, honors Extra high reasoning when that
+  runtime accepts it, and retains the High fallback for older installs.
 
 ## [0.40.4] - 2026-08-23
 

--- a/docs/guide/agent-integrations.md
+++ b/docs/guide/agent-integrations.md
@@ -59,11 +59,11 @@ TeXRA spawns each CLI binary directly in the same environment as the extension h
 
 ### Settings
 
-| Setting              | Options                                                                     | Default           | What it controls                                                           |
-| -------------------- | --------------------------------------------------------------------------- | ----------------- | -------------------------------------------------------------------------- |
-| **Sandbox mode**     | `read-only`, `workspace-write`, `danger-full-access`                        | `workspace-write` | File-system access. Agents may override per call via `sandbox_mode`.       |
-| **Reasoning effort** | `low`, `medium`, `high`, `xhigh`                                            | `high`            | How deeply Codex deliberates. `xhigh` is capped to `high` before hand-off. |
-| **Approval policy**  | `auto approve`, `ask when requested`, `ask for untrusted`, `ask on failure` | `auto approve`    | When the Codex child process may stop to ask before running commands.      |
+| Setting              | Options                                                                     | Default           | What it controls                                                                                                          |
+| -------------------- | --------------------------------------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **Sandbox mode**     | `read-only`, `workspace-write`, `danger-full-access`                        | `workspace-write` | File-system access. Agents may override per call via `sandbox_mode`.                                                      |
+| **Reasoning effort** | `low`, `medium`, `high`, `xhigh`                                            | `high`            | How deeply Codex deliberates. Extra high is used when the installed runtime accepts it; older installs fall back to High. |
+| **Approval policy**  | `auto approve`, `ask when requested`, `ask for untrusted`, `ask on failure` | `auto approve`    | When the Codex child process may stop to ask before running commands.                                                     |
 
 TeXRA pins Codex to the `gpt-5.5` model. Providers, MCP servers, and custom instructions come from Codex's own `~/.codex/config.toml`.
 

--- a/src/test-kernel/tools/CodexResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/CodexResumeFallback.vitest.ts
@@ -93,6 +93,7 @@ vi.mock('@tools/codexConfig', () => ({
 }));
 
 vi.mock('@tools/codexImport', () => ({
+  codexBinarySupportsXhigh: async () => false,
   importCodexClass: mocks.importCodexClass,
   findCodexBinaryPath: mocks.findCodexBinaryPath,
 }));

--- a/src/test-kernel/tools/codexImport.vitest.ts
+++ b/src/test-kernel/tools/codexImport.vitest.ts
@@ -77,7 +77,7 @@ describe('findCodexBinaryPath', () => {
       ...platformPackage.pkg.split('/'),
       'vendor',
       platformPackage.triple,
-      'codex',
+      'bin',
       platformPackage.binaryName,
     );
     fs.mkdirSync(path.dirname(binaryPath), { recursive: true });

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -460,14 +460,20 @@ async function createCodexThread(
     workingDir || !input.thread_id
       ? buildAgentWorkspaceOptions(workingDir)
       : {};
+  // Probe Extra High support only when that tier is selected so other
+  // efforts do not wait on a slow or hung Codex binary.
+  const requestedEffort = config.getCodexCliReasoningEffort(true);
   const threadOptions: ThreadOptions = {
     ...workspace,
     sandboxMode,
     approvalPolicy: config.getCodexApprovalPolicy(),
     model: config.CODEX_CLI_MODEL,
-    modelReasoningEffort: config.getCodexCliReasoningEffort(
-      await codexBinarySupportsXhigh(codexPath),
-    ),
+    modelReasoningEffort:
+      requestedEffort === 'xhigh'
+        ? config.getCodexCliReasoningEffort(
+            await codexBinarySupportsXhigh(codexPath),
+          )
+        : requestedEffort,
     skipGitRepoCheck: true as const,
   };
   return input.thread_id

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -51,7 +51,11 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 // Local file imports
 import { defineTool } from './core/define';
 import { buildAgentWorkspaceOptions } from './agentWorkspaceOptions';
-import { importCodexClass, findCodexBinaryPath } from './codexImport';
+import {
+  codexBinarySupportsXhigh,
+  importCodexClass,
+  findCodexBinaryPath,
+} from './codexImport';
 import { type ChildStream } from './delegation/childStream';
 import { codexThreadsFor } from './agentCliSessionStores';
 import {
@@ -446,8 +450,9 @@ async function createCodexThread(
   workingDir?: string,
 ): Promise<Thread> {
   const CodexClass = await importCodexClass();
+  const codexPath = await findCodexBinaryPath();
   const codex = new CodexClass({
-    codexPathOverride: await findCodexBinaryPath(),
+    codexPathOverride: codexPath,
   });
   const config = await getCodexConfig();
   // Resumed threads keep their stored workspace unless explicitly overridden.
@@ -460,7 +465,9 @@ async function createCodexThread(
     sandboxMode,
     approvalPolicy: config.getCodexApprovalPolicy(),
     model: config.CODEX_CLI_MODEL,
-    modelReasoningEffort: config.getCodexCliReasoningEffort(),
+    modelReasoningEffort: config.getCodexCliReasoningEffort(
+      await codexBinarySupportsXhigh(codexPath),
+    ),
     skipGitRepoCheck: true as const,
   };
   return input.thread_id

--- a/src/tools/codexConfig.ts
+++ b/src/tools/codexConfig.ts
@@ -42,24 +42,26 @@ const getCodexReasoningEffort = createEnumStateGetter(
 );
 
 /**
- * Codex CLI's Rust-side config deserializer only accepts a subset of the
- * reasoning effort tiers TeXRA exposes. TeXRA's 'xhigh' tier is a UI-only
- * extension used by providers like Anthropic Opus 'max'; cap it to 'high'
- * before handing the value to the Codex SDK.
+ * Older Codex CLI runtimes reject `xhigh` even though it is present in the SDK
+ * type. Preserve the requested level only after the resolved binary has been
+ * checked; otherwise cap it to `high`.
  */
 export type CodexCliReasoningEffort = Extract<
   ModelReasoningEffort,
-  'low' | 'medium' | 'high'
+  'low' | 'medium' | 'high' | 'xhigh'
 >;
 
 export function toCodexCliReasoningEffort(
   effort: CodexReasoningEffort,
+  supportsXhigh = false,
 ): CodexCliReasoningEffort {
-  return effort === 'xhigh' ? 'high' : effort;
+  return effort === 'xhigh' && !supportsXhigh ? 'high' : effort;
 }
 
-export function getCodexCliReasoningEffort(): CodexCliReasoningEffort {
-  return toCodexCliReasoningEffort(getCodexReasoningEffort());
+export function getCodexCliReasoningEffort(
+  supportsXhigh = false,
+): CodexCliReasoningEffort {
+  return toCodexCliReasoningEffort(getCodexReasoningEffort(), supportsXhigh);
 }
 
 // ============================================================================

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -14,15 +14,24 @@
  *    are cached for the session.
  */
 
+import { createRequire } from 'node:module';
 import * as path from 'node:path';
 
 import { isModuleNotFoundError } from '@common/errors';
+import { createLog } from '@logger/logUtils';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
+import { executeCommand } from '@utils/system/execUtils';
 import { IS_WINDOWS } from '@utils/system/platformPaths';
+
+import { CODEX_CLI_MODEL } from './codexConfig';
 import {
   createCachedBinaryResolver,
   resolveSdkExport,
 } from './support/externalBinaryUtils';
+
+const log = createLog('codexImport');
+const codexXhighSupportByBinary = new Map<string, boolean>();
+const codexXhighProbes = new Map<string, Promise<boolean>>();
 
 // The native `Codex` class value; `typeof` gives its construct signature
 // (`new (options?: CodexOptions) => Codex`) so construction stays type-checked.
@@ -96,21 +105,125 @@ const PLATFORM_INFO: Record<string, PlatformInfo> = {
 const CODEX_BINARY_NAME = IS_WINDOWS ? 'codex.exe' : 'codex';
 
 /**
- * Locate the native Codex binary inside a resolved platform-package directory.
- * The binary nests under `vendor/<triple>/codex/<binaryName>`.
+ * Locate the native Codex binary inside a resolved package directory.
+ * Current packages use `vendor/<triple>/bin/<binaryName>`; the second
+ * candidate keeps older installs usable. When `platformPkgDir` is the
+ * `@openai/codex` meta-package, follow its nested platform package.
  */
 async function codexBinaryInPlatformPackage(
   platformPkgDir: string,
   platformInfo: PlatformInfo,
 ): Promise<string | undefined> {
-  const binary = path.join(
-    platformPkgDir,
-    'vendor',
-    platformInfo.triple,
-    'codex',
-    CODEX_BINARY_NAME,
-  );
-  return (await AbsoluteFS.exists(binary)) ? binary : undefined;
+  const findInPlatformPackage = async (
+    packageDir: string,
+  ): Promise<string | undefined> => {
+    const vendorDir = path.join(packageDir, 'vendor', platformInfo.triple);
+    const candidates = [
+      path.join(vendorDir, 'bin', CODEX_BINARY_NAME),
+      path.join(vendorDir, 'codex', CODEX_BINARY_NAME),
+    ];
+    for (const candidate of candidates) {
+      if (await AbsoluteFS.exists(candidate)) return candidate;
+    }
+    return undefined;
+  };
+
+  const direct = await findInPlatformPackage(platformPkgDir);
+  if (direct) return direct;
+
+  try {
+    const nestedPackageJson = createRequire(
+      path.join(platformPkgDir, 'package.json'),
+    ).resolve(`${platformInfo.pkg}/package.json`);
+    return await findInPlatformPackage(path.dirname(nestedPackageJson));
+  } catch {
+    // Platform package not resolvable
+    return undefined;
+  }
+}
+
+type BundledCodexModel = {
+  slug?: string;
+  supported_reasoning_levels?: Array<{ effort?: string }>;
+};
+
+function catalogSupportsXhigh(
+  stdout: string,
+  model: string,
+): boolean | undefined {
+  try {
+    const parsed: unknown = JSON.parse(stdout);
+    if (typeof parsed !== 'object' || parsed == null || !('models' in parsed)) {
+      return undefined;
+    }
+    const models = (parsed as { models: unknown }).models;
+    if (!Array.isArray(models)) return undefined;
+    const entry = models.find(
+      (item): item is BundledCodexModel =>
+        typeof item === 'object' &&
+        item != null &&
+        (item as BundledCodexModel).slug === model,
+    );
+    if (entry == null) return false;
+    return (entry.supported_reasoning_levels ?? []).some(
+      (level) => level.effort === 'xhigh',
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Probe whether the resolved Codex runtime reports `xhigh` for the pinned
+ * CLI model. Timeouts and spawn failures are not cached so a later call
+ * retries instead of permanently capping Extra High to High.
+ */
+export async function codexBinarySupportsXhigh(
+  binaryPath: string | undefined,
+): Promise<boolean> {
+  if (!binaryPath) return false;
+
+  const cached = codexXhighSupportByBinary.get(binaryPath);
+  if (cached != null) return cached;
+
+  const inflight = codexXhighProbes.get(binaryPath);
+  if (inflight) return inflight;
+
+  const probe = (async (): Promise<boolean> => {
+    const result = await executeCommand(
+      [binaryPath, 'debug', 'models', '--bundled'],
+      { quiet: true, timeout: 5_000, cwd: process.cwd() },
+    );
+    if (result.timedOut || result.exitCode === 127) {
+      log.warn('Codex xhigh capability probe failed; not caching the result', {
+        data: {
+          binaryPath,
+          timedOut: result.timedOut,
+          exitCode: result.exitCode,
+          stderr: result.stderr,
+        },
+      });
+      return false;
+    }
+    if (!result.success) {
+      codexXhighSupportByBinary.set(binaryPath, false);
+      return false;
+    }
+    const supported = catalogSupportsXhigh(result.stdout, CODEX_CLI_MODEL);
+    if (supported == null) {
+      log.warn('Codex xhigh capability probe returned unreadable catalog', {
+        data: { binaryPath },
+      });
+      return false;
+    }
+    codexXhighSupportByBinary.set(binaryPath, supported);
+    return supported;
+  })().finally(() => {
+    codexXhighProbes.delete(binaryPath);
+  });
+
+  codexXhighProbes.set(binaryPath, probe);
+  return probe;
 }
 
 /**
@@ -125,7 +238,7 @@ export const findCodexBinaryPath = createCachedBinaryResolver(() => {
   if (!info) return undefined;
 
   return {
-    platformPackages: [info.pkg],
+    platformPackages: [info.pkg, '@openai/codex'],
     binaryInPlatformPackage: (dir) => codexBinaryInPlatformPackage(dir, info),
     // The npm global prefix hosts the `@openai/codex` meta-package; the
     // platform package is resolved relative to those roots.

--- a/src/tools/support/externalBinaryUtils.ts
+++ b/src/tools/support/externalBinaryUtils.ts
@@ -106,7 +106,8 @@ export interface ResolveBinaryConfig {
   /**
    * Locate the binary inside a resolved platform-package directory, returning
    * its path if present or `undefined`. Codex nests the binary under
-   * `vendor/<triple>/codex/`; Claude places it directly in the package dir.
+   * `vendor/<triple>/bin/` (older packages: `vendor/<triple>/codex/`); Claude
+   * places it directly in the package dir.
    */
   binaryInPlatformPackage(platformPkgDir: string): Promise<string | undefined>;
   /**


### PR DESCRIPTION
## Summary

Current Codex packages nest the native binary under `vendor/<triple>/bin` and may only expose it through the `@openai/codex` meta-package. TeXRA now resolves that layout, passes Extra high reasoning through when the resolved runtime reports it for `gpt-5.5`, and keeps the High fallback for older installs.

The Extra-high probe uses `codex debug models --bundled` (not `features list --strict-config`, which current CLIs reject) and runs asynchronously so the first thread does not block the host.

## Issue acceptance gates

No tracking issue. The working-tree Codex runtime mismatch is the gate: current installs resolve, Extra high is used when the binary's bundled catalog lists `xhigh` for `gpt-5.5`, and older installs still fall back to High.

## Single source of truth

`src/tools/codexImport.ts` owns binary discovery and the Extra-high capability probe. `src/tools/codexConfig.ts` maps TeXRA's reasoning tier onto what that runtime accepts. `src/tools/codex.ts` is the only dispatch site.

## Duplication and abstraction budget

No new pass-through layer. The Extra-high probe is cached per resolved binary so thread creation does not re-exec the CLI on every call. Timeouts and spawn failures are not cached.

## Net elements (R6)

n/a — bug fix, not a refactor/simplify/extract PR.

## Consumer counts (R8)

n/a — no emit path or existing export was deleted or re-routed. `codexBinarySupportsXhigh` is a new export consumed in this PR by `createCodexThread`.

## Host impact

Extension: Codex runs use the current installed runtime and Extra high when supported.

Desktop: same; packaged-app lookup follows the platform package or the `@openai/codex` meta-package into the native binary.

CLI: same shared Codex tool path.

## Scheduled refactoring

None.

## Validation

- `npx vitest run --config vitest.config.mjs src/test-kernel/tools/codexConfig.vitest.ts src/test-kernel/tools/codexImport.vitest.ts src/test-kernel/tools/CodexResumeFallback.vitest.ts` (26 passed)
- ESLint on the changed TypeScript files
- `npx tsc --noEmit -p tsconfig.json`
- Confirmed on Codex CLI 0.149.0: `--strict-config features list` exits 1; `debug models --bundled` lists `xhigh` for `gpt-5.5`