### PR TITLE
docs: update public project and paper listings

### DIFF
--- a/docs/work-using-texra.md
+++ b/docs/work-using-texra.md
@@ -7,6 +7,9 @@ A non-exhaustive list of public projects and papers that used TeXRA. To add your
 - [**TNLean**](https://github.com/LionSR/TNLean): Lean 4 formalization of
   tensor-network theory, including matrix-product states and their canonical
   forms.
+- [**QICLean**](https://github.com/LionSR/QICLean): Lean 4 formalization of
+  quantum information and channels, including states, entanglement, channel
+  representations, and entropy.
 - [**MIPStarRE**](https://github.com/LionSR/MIPStarRE): Lean formalization of
   mathematics around $\mathrm{MIP}^* = \mathrm{RE}$.
 

--- a/docs/work-using-texra.md
+++ b/docs/work-using-texra.md
@@ -13,8 +13,8 @@ A non-exhaustive list of public projects and papers that used TeXRA. To add your
 ## Papers
 
 - [**Can Theoretical Physics Research Benefit from Language Agents?**](https://arxiv.org/abs/2506.06214),
-  Sirui Lu, Zhuo Jin, Tian-Jun Zhang, Pavel Kos, J. Ignacio Cirac, and Bernhard
-  Schölkopf (ICML 2026). The position paper behind TeXRA.
+  Sirui Lu, Zhijing Jin, Terry Jingchen Zhang, Pavel Kos, J. Ignacio Cirac, and
+  Bernhard Schölkopf (ICML 2026). The position paper behind TeXRA.
 - [**Quantum computer architecture with ions in tweezer arrays**](https://arxiv.org/abs/2606.27249),
   Benjamin F. Schiffer, Christopher Monroe, Peter Zoller, and J. Ignacio Cirac
   (2026).


### PR DESCRIPTION
## Summary

Adds QICLean to the public list of projects using TeXRA and corrects the full names of Zhijing Jin and Terry Jingchen Zhang in the entry for “Can Theoretical Physics Research Benefit from Language Agents?”.

## Issue acceptance gates

No linked issue. The public work list now includes QICLean and agrees with the cited paper metadata.

## Single source of truth

The project and paper entries remain owned by docs/work-using-texra.md.

## Duplication and abstraction budget

No duplication or abstraction is introduced; this is a documentation-only update to the canonical public work list.

## Net elements (R6)

Not applicable to this documentation-only update. One file changes by five insertions and two deletions.

## Consumer counts (R8)

Not applicable; no code, export, or event path changes.

## Host impact

Extension: None.

Desktop: None.

CLI: None.

## Scheduled refactoring

None.

## Validation

- corepack pnpm exec prettier --check docs/work-using-texra.md
- corepack pnpm --dir docs run check:content
- Commit hooks: staged Prettier, documentation boundary, and guidance-reference checks.
- Pre-push checks.