### PR TITLE
docs: retarget historical issue links

### DIFF
--- a/docs/prds/2026-05-10-prd-cli-runcontext-logger-orchestration.manifest.json
+++ b/docs/prds/2026-05-10-prd-cli-runcontext-logger-orchestration.manifest.json
@@ -3,47 +3,47 @@
   "created": "2026-05-10",
   "updated": "2026-05-12",
   "status": "complete",
-  "trackingIssue": "https://github.com/LionSR/TeXRA/issues/3838",
+  "trackingIssue": "https://github.com/texra-ai/texra-issues/issues/3838",
   "primaryPrd": "docs/prds/2026-05-10-prd-cli-runcontext-logger-orchestration.md",
   "currentAudit": {
     "date": "2026-05-12",
-    "basePr": "https://github.com/LionSR/TeXRA/pull/3839",
+    "basePr": "https://github.com/texra-ai/texra-issues/pull/3839",
     "stack": [
       {
-        "pr": "https://github.com/LionSR/TeXRA/pull/3839",
+        "pr": "https://github.com/texra-ai/texra-issues/pull/3839",
         "scope": "scaffold CLI, RunContext, logger, and orchestration base",
         "state": "merged into main on 2026-05-12 as 69ac7bd891707fdf9b7b848938e71bd9cb6820f0"
       },
       {
-        "pr": "https://github.com/LionSR/TeXRA/pull/3843",
+        "pr": "https://github.com/texra-ai/texra-issues/pull/3843",
         "scope": "packaged texra run validation",
         "parentIssues": [3834],
         "followUpIssue": 3840,
         "state": "merged into main on 2026-05-12 as 942cf9885e8ac8191c2fea37f4f964b0f5e3d378"
       },
       {
-        "pr": "https://github.com/LionSR/TeXRA/pull/3844",
+        "pr": "https://github.com/texra-ai/texra-issues/pull/3844",
         "scope": "CLI ask approval prompts",
         "parentIssues": [3835],
         "followUpIssue": 3841,
         "state": "merged into main on 2026-05-12 as a4c53792b716fd454bdb864d276abee8bfcd9453"
       },
       {
-        "pr": "https://github.com/LionSR/TeXRA/pull/3845",
+        "pr": "https://github.com/texra-ai/texra-issues/pull/3845",
         "scope": "legacy host logs through structured logger sinks",
         "parentIssues": [3833],
         "followUpIssue": 3842,
         "state": "merged into main on 2026-05-12 as c4bb72b21fb8dbd5d612cbb958e3d65cec91f49c"
       },
       {
-        "pr": "https://github.com/LionSR/TeXRA/pull/3846",
+        "pr": "https://github.com/texra-ai/texra-issues/pull/3846",
         "scope": "texra chat loop and dependency-free richer terminal renderer",
         "parentIssues": [3836],
         "followUpIssue": 3848,
         "state": "merged into main on 2026-05-12 as 6bfb4d40e2ded447a27c764465e06176ca8d736e"
       },
       {
-        "pr": "https://github.com/LionSR/TeXRA/pull/3847",
+        "pr": "https://github.com/texra-ai/texra-issues/pull/3847",
         "scope": "ToolFileInteractionContext async storage and split run/call context views",
         "parentIssues": [3837],
         "followUpIssue": 3849,
@@ -74,7 +74,7 @@
     {
       "id": 3833,
       "title": "Logger v2",
-      "url": "https://github.com/LionSR/TeXRA/issues/3833",
+      "url": "https://github.com/texra-ai/texra-issues/issues/3833",
       "prd": "docs/prds/2026-05-06-prd-logger-v2.md",
       "implementationPrs": [3839, 3845],
       "sourceOfTruth": "src/logger/structuredLogger.ts: LogRecord schema and grouping semantics",
@@ -88,7 +88,7 @@
     {
       "id": 3834,
       "title": "CLI texra run",
-      "url": "https://github.com/LionSR/TeXRA/issues/3834",
+      "url": "https://github.com/texra-ai/texra-issues/issues/3834",
       "prd": "docs/prds/2026-05-04-prd-cli-app.md",
       "implementationPrs": [3839, 3843],
       "sourceOfTruth": "packages/cli/src/runtime/cliContext.ts for process data; packages/cli/src/runtime/exitCodes.ts for exit codes; shared executeAgent runtime for execution semantics",
@@ -104,7 +104,7 @@
     {
       "id": 3835,
       "title": "CLI approval policy",
-      "url": "https://github.com/LionSR/TeXRA/issues/3835",
+      "url": "https://github.com/texra-ai/texra-issues/issues/3835",
       "prd": "docs/prds/2026-05-04-prd-cli-app.md",
       "implementationPrs": [3839, 3844, 3846],
       "sourceOfTruth": "packages/cli/src/runtime/approvalAdapter.ts maps CliContext.approvalPolicy to gate decisions",
@@ -119,7 +119,7 @@
     {
       "id": 3836,
       "title": "CLI texra chat",
-      "url": "https://github.com/LionSR/TeXRA/issues/3836",
+      "url": "https://github.com/texra-ai/texra-issues/issues/3836",
       "prd": "docs/prds/2026-05-04-prd-cli-app.md",
       "implementationPrs": [3839, 3846],
       "sourceOfTruth": "shared tool-use session lifecycle owns conversation semantics; CLI chat owns terminal input and presentation",
@@ -139,7 +139,7 @@
     {
       "id": 3837,
       "title": "ToolFileInteractionContext ownership",
-      "url": "https://github.com/LionSR/TeXRA/issues/3837",
+      "url": "https://github.com/texra-ai/texra-issues/issues/3837",
       "prd": "docs/prds/2026-05-06-prd-runcontext-refactor.md",
       "implementationPrs": [3839, 3847],
       "sourceOfTruth": "RunContext owns run facts; ToolRunContext and ToolCallContext separate run-owned and call-owned tool facts",
@@ -173,7 +173,7 @@
     {
       "id": 3840,
       "title": "CLI follow-up: validate texra run packaged runtime path",
-      "url": "https://github.com/LionSR/TeXRA/issues/3840",
+      "url": "https://github.com/texra-ai/texra-issues/issues/3840",
       "parentIssues": [3834, 3838],
       "status": "closed after PR #3843 merged",
       "sourceOfTruth": "packages/cli/scripts/validate-run.mjs and src/agent/runtime/ModelFactory.ts validation guard",
@@ -189,7 +189,7 @@
     {
       "id": 3841,
       "title": "CLI follow-up: implement ask approval prompts and matrix validation",
-      "url": "https://github.com/LionSR/TeXRA/issues/3841",
+      "url": "https://github.com/texra-ai/texra-issues/issues/3841",
       "parentIssues": [3835, 3838],
       "status": "closed after PRs #3844 and #3846 merged",
       "sourceOfTruth": "packages/cli/src/runtime/approvalAdapter.ts maps CLI approval policy to decisions; shared coordinators own request identity and lifecycle",
@@ -205,7 +205,7 @@
     {
       "id": 3842,
       "title": "Logger v2 follow-up: wire host sinks and legacy shim",
-      "url": "https://github.com/LionSR/TeXRA/issues/3842",
+      "url": "https://github.com/texra-ai/texra-issues/issues/3842",
       "parentIssues": [3833, 3838],
       "status": "closed after PR #3845 merged",
       "sourceOfTruth": "src/logger/structuredLogger.ts for LogRecord schema and grouping semantics; host packages own sinks and renderers; compatibility shim owns migration from logUtils and AgentLogger",
@@ -221,7 +221,7 @@
     {
       "id": 3848,
       "title": "CLI follow-up: add richer texra chat terminal renderer",
-      "url": "https://github.com/LionSR/TeXRA/issues/3848",
+      "url": "https://github.com/texra-ai/texra-issues/issues/3848",
       "parentIssues": [3836, 3838],
       "recommendedOrderItem": "implement texra chat terminal renderer over existing session lifecycle",
       "sourceOfTruth": "shared tool-use session lifecycle owns conversation semantics; ChatTerminalRenderer owns terminal presentation only",
@@ -238,7 +238,7 @@
     {
       "id": 3849,
       "title": "RunContext follow-up: split ToolFileInteractionContext access paths",
-      "url": "https://github.com/LionSR/TeXRA/issues/3849",
+      "url": "https://github.com/texra-ai/texra-issues/issues/3849",
       "parentIssues": [3837, 3838],
       "recommendedOrderItem": "continue RunContext and ToolFileInteractionContext ownership cleanup",
       "sourceOfTruth": "RunContext owns ToolRunContext; ToolCallContext owns per-tool-call mutable state; mixed readers use an explicit mixed accessor",

--- a/docs/prds/2026-05-14-skills.md
+++ b/docs/prds/2026-05-14-skills.md
@@ -7,7 +7,7 @@ updated: 2026-06-08
 
 ## Status: Draft
 
-**Tracking issue:** [LionSR/TeXRA#4031](https://github.com/LionSR/TeXRA/issues/4031)
+**Tracking issue:** [LionSR/TeXRA#4031](https://github.com/texra-ai/texra-issues/issues/4031)
 **Last updated:** 2026-05-15
 
 ---
@@ -233,7 +233,7 @@ within interop precedence because it is the cross-client convention rather than 
 
 ### D7. Multi-round handling
 
-**Decision:** Skills are single-shot. Multi-round logic stays in YAML via `inherits_skill:` (M6). See [issue comment](https://github.com/LionSR/TeXRA/issues/4031#issuecomment-4454650473).
+**Decision:** Skills are single-shot. Multi-round logic stays in YAML via `inherits_skill:` (M6). See [issue comment](https://github.com/texra-ai/texra-issues/issues/4031#issuecomment-4454650473).
 
 ---
 
@@ -319,8 +319,8 @@ Once skills carry the prompt content, the legacy YAML files in `packages/extensi
 ## References
 
 - [Agent Skills specification](https://agentskills.io/specification)
-- [LionSR/TeXRA#4031 — tracking issue](https://github.com/LionSR/TeXRA/issues/4031)
+- [LionSR/TeXRA#4031 — tracking issue](https://github.com/texra-ai/texra-issues/issues/4031)
 - [pi `skills.ts`](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/src/core/skills.ts)
 - [Anthropic Claude Code Skills source](https://github.com/anthropics/claude-code) (`src/skills/`, `src/tools/SkillTool/`)
 - [OpenAI Codex Skills source](https://github.com/openai/codex) (`codex-rs/core-skills/`, `codex-rs/skills/`)
-- [LionSR/TeXRA#4031 — implementation notes & cross-implementation comparison](https://github.com/LionSR/TeXRA/issues/4031#issuecomment-4454571034) (issue comments capture the pi / Claude Code / Codex study findings underpinning §D1–§D6)
+- [LionSR/TeXRA#4031 — implementation notes & cross-implementation comparison](https://github.com/texra-ai/texra-issues/issues/4031#issuecomment-4454571034) (issue comments capture the pi / Claude Code / Codex study findings underpinning §D1–§D6)

--- a/docs/prds/2026-05-15-prd-external-inquiry-async.md
+++ b/docs/prds/2026-05-15-prd-external-inquiry-async.md
@@ -8,7 +8,7 @@ updated: 2026-06-20
 **Status:** Draft (v0.1)
 **Owner:** TBD
 **Date:** 2026-05-15
-**Related issue:** [#4023 — external_inquiry should not block](https://github.com/LionSR/TeXRA/issues/4023)
+**Related issue:** [#4023 — external_inquiry should not block](https://github.com/texra-ai/texra-issues/issues/4023)
 
 > **Naming.** The model-facing tool is renamed from `external_inquiry` to `inquiry` — shorter, parallel with `goal`/`memory`/`executions`, and "external" was implicit. Internal class/file names (`ExternalInquiryTool.ts`, `ExternalInquiryPanel.ts`, schema names like `ExternalInquiryThreadManifestSchema`) keep their current names for diff-locality; a mechanical rename pass is an independent follow-up.
 

--- a/docs/prds/2026-06-27-prd-runtime-host-decoupling.md
+++ b/docs/prds/2026-06-27-prd-runtime-host-decoupling.md
@@ -22,16 +22,16 @@ updated: 2026-08-01
 > `main` denotes the
 > unrelated persisted stream schema introduced in [#7164].
 
-[#7164]: https://github.com/LionSR/TeXRA/pull/7164
-[#7457]: https://github.com/LionSR/TeXRA/pull/7457
-[#7474]: https://github.com/LionSR/TeXRA/pull/7474
-[#7504]: https://github.com/LionSR/TeXRA/pull/7504
-[#7600]: https://github.com/LionSR/TeXRA/pull/7600
-[#7602]: https://github.com/LionSR/TeXRA/pull/7602
-[#7623]: https://github.com/LionSR/TeXRA/pull/7623
-[#7624]: https://github.com/LionSR/TeXRA/pull/7624
-[#7914]: https://github.com/LionSR/TeXRA/pull/7914
-[#8322]: https://github.com/LionSR/TeXRA/pull/8322
+[#7164]: https://github.com/texra-ai/texra-issues/pull/7164
+[#7457]: https://github.com/texra-ai/texra-issues/pull/7457
+[#7474]: https://github.com/texra-ai/texra-issues/pull/7474
+[#7504]: https://github.com/texra-ai/texra-issues/pull/7504
+[#7600]: https://github.com/texra-ai/texra-issues/pull/7600
+[#7602]: https://github.com/texra-ai/texra-issues/pull/7602
+[#7623]: https://github.com/texra-ai/texra-issues/pull/7623
+[#7624]: https://github.com/texra-ai/texra-issues/pull/7624
+[#7914]: https://github.com/texra-ai/texra-issues/pull/7914
+[#8322]: https://github.com/texra-ai/texra-issues/pull/8322
 [modelcell-ownership-ruling]: ../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell
 
 ## Overview

--- a/docs/prds/2026-06-29-prd-agent-sdk-boundary.md
+++ b/docs/prds/2026-06-29-prd-agent-sdk-boundary.md
@@ -24,16 +24,16 @@ updated: 2026-08-01
 > the source branch and is not part of this extraction; references to it below
 > are historical context, not documentation present on `main`.
 
-[#7164]: https://github.com/LionSR/TeXRA/pull/7164
-[#7457]: https://github.com/LionSR/TeXRA/pull/7457
-[#7474]: https://github.com/LionSR/TeXRA/pull/7474
-[#7504]: https://github.com/LionSR/TeXRA/pull/7504
-[#7600]: https://github.com/LionSR/TeXRA/pull/7600
-[#7602]: https://github.com/LionSR/TeXRA/pull/7602
-[#7623]: https://github.com/LionSR/TeXRA/pull/7623
-[#7624]: https://github.com/LionSR/TeXRA/pull/7624
-[#7914]: https://github.com/LionSR/TeXRA/pull/7914
-[#8322]: https://github.com/LionSR/TeXRA/pull/8322
+[#7164]: https://github.com/texra-ai/texra-issues/pull/7164
+[#7457]: https://github.com/texra-ai/texra-issues/pull/7457
+[#7474]: https://github.com/texra-ai/texra-issues/pull/7474
+[#7504]: https://github.com/texra-ai/texra-issues/pull/7504
+[#7600]: https://github.com/texra-ai/texra-issues/pull/7600
+[#7602]: https://github.com/texra-ai/texra-issues/pull/7602
+[#7623]: https://github.com/texra-ai/texra-issues/pull/7623
+[#7624]: https://github.com/texra-ai/texra-issues/pull/7624
+[#7914]: https://github.com/texra-ai/texra-issues/pull/7914
+[#8322]: https://github.com/texra-ai/texra-issues/pull/8322
 [modelcell-ownership-ruling]: ../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell
 
 Decided by an adversarial design pass (3 designs x 2 lenses, 2026-06-29). This is

--- a/docs/prds/2026-06-29-prd-runtime-gold-standard.md
+++ b/docs/prds/2026-06-29-prd-runtime-gold-standard.md
@@ -24,16 +24,16 @@ updated: 2026-08-01
 > not part of this extraction; references to them below are historical context,
 > not documentation present on `main`.
 
-[#7164]: https://github.com/LionSR/TeXRA/pull/7164
-[#7457]: https://github.com/LionSR/TeXRA/pull/7457
-[#7474]: https://github.com/LionSR/TeXRA/pull/7474
-[#7504]: https://github.com/LionSR/TeXRA/pull/7504
-[#7600]: https://github.com/LionSR/TeXRA/pull/7600
-[#7602]: https://github.com/LionSR/TeXRA/pull/7602
-[#7623]: https://github.com/LionSR/TeXRA/pull/7623
-[#7624]: https://github.com/LionSR/TeXRA/pull/7624
-[#7914]: https://github.com/LionSR/TeXRA/pull/7914
-[#8322]: https://github.com/LionSR/TeXRA/pull/8322
+[#7164]: https://github.com/texra-ai/texra-issues/pull/7164
+[#7457]: https://github.com/texra-ai/texra-issues/pull/7457
+[#7474]: https://github.com/texra-ai/texra-issues/pull/7474
+[#7504]: https://github.com/texra-ai/texra-issues/pull/7504
+[#7600]: https://github.com/texra-ai/texra-issues/pull/7600
+[#7602]: https://github.com/texra-ai/texra-issues/pull/7602
+[#7623]: https://github.com/texra-ai/texra-issues/pull/7623
+[#7624]: https://github.com/texra-ai/texra-issues/pull/7624
+[#7914]: https://github.com/texra-ai/texra-issues/pull/7914
+[#8322]: https://github.com/texra-ai/texra-issues/pull/8322
 [modelcell-ownership-ruling]: ../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell
 
 Decided by an adversarial design pass (4 designs x 3 lenses x 4 phases,

--- a/docs/prds/2026-08-03-prd-approval-policy-unification.md
+++ b/docs/prds/2026-08-03-prd-approval-policy-unification.md
@@ -8,7 +8,7 @@ updated: 2026-08-03
 **Status:** Draft (v1.1 — every factual claim re-verified against main @ `363e2941d4`, 2026-08-03)
 **Owner:** TBD
 **Date:** 2026-08-03
-**Tracking issue:** [#9597](https://github.com/LionSR/TeXRA/issues/9597)
+**Tracking issue:** [#9597](https://github.com/texra-ai/texra-issues/issues/9597)
 **Branch:** `claude/texra-9597-design-review-5tyyls`
 **Prior stages (merged):** #9610, #9673, #9687, #9689, #9692
 

--- a/docs/prds/2026-08-04-prd-xai-responses-previous-response-id.md
+++ b/docs/prds/2026-08-04-prd-xai-responses-previous-response-id.md
@@ -12,7 +12,7 @@ updated: 2026-08-13
 
 - xAI docs: [Generate text (Responses preferred)](https://docs.x.ai/developers/model-capabilities/text/generate-text), [Comparison vs Chat Completions](https://docs.x.ai/developers/model-capabilities/text/comparison), [REST inference](https://docs.x.ai/developers/rest-api-reference/inference/chat)
 - TeXRA OpenAI Responses proposal: `docs/proposals/2025-06-04-openai-responses-api.md`
-- Landed experimental SuperGrok OAuth route (separate concern): `docs/proposals/2026-08-04-xai-grok-oauth-subscription.md`, PR [#9709](https://github.com/LionSR/TeXRA/pull/9709)
+- Landed experimental SuperGrok OAuth route (separate concern): `docs/proposals/2026-08-04-xai-grok-oauth-subscription.md`, PR [#9709](https://github.com/texra-ai/texra-issues/pull/9709)
 - Difficulty notes: session audit 2026-08-04 (`ModelHandlerOpenAIResponse` ~2.9k lines; Codex already multi-backend via capability profiles)
 
 ## 1. Summary
@@ -185,11 +185,11 @@ Core chaining is protocol-shaped. Risk is **live compatibility**, not missing Te
 
 ## 9. Explicit non-consolidation with landed PRs
 
-| Landed PR                                                                   | Relationship                                                                         |
-| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| [#9709](https://github.com/LionSR/TeXRA/pull/9709) Grok OAuth               | **Auth only.** Responses routing remains separate and reuses the landed Bearer path. |
-| [#9708](https://github.com/LionSR/TeXRA/pull/9708) TypeScript 7             | **Toolchain only.** No product overlap with Responses routing.                       |
-| [#9706](https://github.com/LionSR/TeXRA/pull/9706) Agent SDK readiness docs | **Docs only.** It may be cross-linked but introduces no Responses implementation.    |
+| Landed PR                                                                            | Relationship                                                                         |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| [#9709](https://github.com/texra-ai/texra-issues/pull/9709) Grok OAuth               | **Auth only.** Responses routing remains separate and reuses the landed Bearer path. |
+| [#9708](https://github.com/texra-ai/texra-issues/pull/9708) TypeScript 7             | **Toolchain only.** No product overlap with Responses routing.                       |
+| [#9706](https://github.com/texra-ai/texra-issues/pull/9706) Agent SDK readiness docs | **Docs only.** It may be cross-linked but introduces no Responses implementation.    |
 
 See §10 for consolidation advice among current workstreams (not code from this PRD).
 

--- a/docs/proposals/2026-07-03-agent-runtime-ui-coupling-audit.md
+++ b/docs/proposals/2026-07-03-agent-runtime-ui-coupling-audit.md
@@ -30,7 +30,7 @@ The closest thing to a root cause is a **discoverability/naming mismatch**: the 
 
 ### 1. Desktop never force-closes crash-orphaned transcript groups or distinguishes resumable streams on restart
 
-**Issue:** [#6887](https://github.com/LionSR/TeXRA/issues/6887)
+**Issue:** [#6887](https://github.com/texra-ai/texra-issues/issues/6887)
 
 Desktop's `DesktopStreamSnapshotStore` (`packages/desktop/src/main/desktopStreamSnapshot.ts`) force-normalizes restored streams to `STOPPED` on relaunch — so it does _not_ show stuck-RUNNING ghosts (an earlier framing of this bug, sourced from a self-contradicting line in `2026-06-10-lifecycle-status-ownership.md`, overstated the symptom; this was corrected by direct re-investigation before filing). But the module's own docstring admits scope: _"Live re-establishment of agent runtimes is intentionally out of scope here — that's tracked as a Phase 2 follow-up."_ Concretely, desktop startup never calls `detectWaitingStreams` (can't tell resumable-from-flow-record from truly-dead — blanket-labels everything `STOPPED`) or `endRunningTaskGroups`/`StreamLogStore.endRunningGroups` (never force-closes a transcript log group left open by a crash — reopening that ghost stream renders a permanently incomplete `GROUP_START` with no `GROUP_END`). The extension calls this repair sequence once, from `packages/extension/src/extension.ts:499` (`await progressViewProvider.cleanupTasksAfterRestart()`). Desktop already instantiates the _identical_ host-neutral `ProgressBackend`/`ProgressEventHandler`/`StreamLogStore` graph (`packages/desktop/src/main/desktopAgentExecution.ts:232`) — it just never invokes the repair call on it.
 
@@ -42,7 +42,7 @@ Related closed work confirms this is a real, previously-tracked gap that was nev
 
 ### 2. CLI bypasses the shared `ProgressAgentProposalController` for approval/proposal orchestration
 
-**Issue:** [#6888](https://github.com/LionSR/TeXRA/issues/6888)
+**Issue:** [#6888](https://github.com/texra-ai/texra-issues/issues/6888)
 
 Extension and desktop both route every proposal action (`setup`/`approve`/`reject`) through one shared controller, `src/controllers/progressView/ProgressAgentProposalController.ts` (113 LOC). CLI reimplements this by hand in 2 places — `packages/cli/src/chat/tui/state/subscribeApprovals.ts:408-417` (`dispatchProposal`) and `packages/cli/src/runtime/approval/eventDispatch.ts:66-72` (`dispatchApprovalDecision`, case `showAgentProposal`) — calling `runCoordinatorBridge.resolveProposal` directly. Direct, confirmed consequence: the CLI cannot do `setup` proposal actions the other two hosts support.
 
@@ -52,7 +52,7 @@ This fits a well-established pattern the team has been actively closing: #6692 (
 
 ### 3. CLI's shared-bus usage is vestigial, and headless `texra run` silently never persists stream sidecars
 
-**Issue:** [#6889](https://github.com/LionSR/TeXRA/issues/6889)
+**Issue:** [#6889](https://github.com/texra-ai/texra-issues/issues/6889)
 
 `createCliRuntimeHost` (headless CLI's `AgentRuntimeHost`, `packages/cli/src/runtime/runtimeHost.ts`) never touches the shared `bus` — confirmed via full-file read and repo-wide grep (zero matches). `StreamSnapshotStore` (`src/transcript/StreamSnapshotStore.ts`) is the sole persister of todos/plan/usage/output-files sidecars, and its `subscribe(bus)` method has exactly one real production caller in the entire codebase: the CLI's interactive TUI (`packages/cli/src/chat/tui/runChatTui.tsx:413`). Extension and desktop populate the same store through _direct method calls_ inside their own bus handlers, never via `subscribe()`. Net effect: a stream driven through headless `texra run` produces empty todos/plan/usage if later viewed in desktop/extension/CLI-TUI. Degrades gracefully — execution state itself (the `getExecutionStore()`/TaskState checkpoint store, used by `texra resume`/`texra history`) is entirely unaffected; only _display_ state is empty on cross-host restore.
 
@@ -68,7 +68,7 @@ Separately: CLI TUI's `wrapRuntimeHost` mirrors events onto `bus` _purely_ to fe
 
 ### 4. `setToolEditApprovalHandler` — one of the remaining ambient-approval-ownership module globals
 
-**Issue:** [#6890](https://github.com/LionSR/TeXRA/issues/6890)
+**Issue:** [#6890](https://github.com/texra-ai/texra-issues/issues/6890)
 
 `docs/proposals/2026-06-07-dependency-injection-cleanup.md` (audited 2026-06-07, addendum 06-10, not fully implemented) documents 22 module-level `set*` singletons and a fat `AgentCore` context bag. PR #6883 (2026-07-02, landed during this audit) folded 4 of them — `setLinterProvider`, `setAddCriticismSink`, `setToolMissingHandler`, `setToolNotificationHandler` — into typed `Platform` ports, and de-duplicated 3 flow nodes' reads of `runtimeHost`/`streamId`/`executionId` via `RunContext`, both explicitly citing that doc. `setToolEditApprovalHandler` was **not** among them — re-verified at current `HEAD`: still a bare module-level singleton (`src/tools/approval/toolEditApproval.ts`), still written from 4 files across all 3 hosts (`packages/cli/src/chat/tui/state/subscribeApprovals.ts:153,175`, `packages/cli/src/runtime/approvalAdapter.ts:86,90`, `packages/desktop/src/main/desktopToolEditApproval.ts:66,150`, `packages/extension/src/frontend/approval/nativeToolEditApproval.ts:386`). The DI-cleanup doc's own description: _"the active session's approval channel, currently a single module global mutated by whichever host UI is active."_ This is the same disease as finding #2, one layer down the stack — ambient runtime state owned by "whichever UI happens to be running" instead of resolved once at a composition root.
 

--- a/docs/proposals/2026-07-10-cli-child-stream-state-consolidation.md
+++ b/docs/proposals/2026-07-10-cli-child-stream-state-consolidation.md
@@ -1,6 +1,6 @@
 # CLI child-stream state consolidation
 
-> **Status:** Design gate for [issue #7864](https://github.com/LionSR/TeXRA/issues/7864). This document is
+> **Status:** Design gate for [issue #7864](https://github.com/texra-ai/texra-issues/issues/7864). This document is
 > grounded on `origin/main` commit `4cd0881b4` (2026-07-10). It proposes no production change. Implementation
 > remains gated on maintainer review of this design.
 

--- a/docs/proposals/2026-07-12-fallback-audit.md
+++ b/docs/proposals/2026-07-12-fallback-audit.md
@@ -14,20 +14,20 @@
 The audit is descriptive; a finding remains open until its pull request is
 reviewed and merged. This ledger tracks the first high-impact batch:
 
-| Finding    | Change                                                         | Pull request                                       | Status     |
-| ---------- | -------------------------------------------------------------- | -------------------------------------------------- | ---------- |
-| `P0.S1/S4` | Require relay enforcement and distinguish unavailable spend    | [#8269](https://github.com/LionSR/TeXRA/pull/8269) | Merged     |
-| `P0.S2`    | Require a configured signup-hook verification secret           | [#8268](https://github.com/LionSR/TeXRA/pull/8268) | Merged     |
-| `P0.S3`    | Require an explicit boolean device-approval decision           | [#8266](https://github.com/LionSR/TeXRA/pull/8266) | Open draft |
-| `P0.1`     | Retry or quarantine every unacknowledged client usage batch    | [#8267](https://github.com/LionSR/TeXRA/pull/8267) | Open draft |
-| `P0.1`     | Validate usage batches atomically and mark permanent rejection | [#8270](https://github.com/LionSR/TeXRA/pull/8270) | Open draft |
-| `P0.2`     | Omit diagnostics when a host has no linter                     | [#8271](https://github.com/LionSR/TeXRA/pull/8271) | Merged     |
-| `P0.4`     | Require explicit persistent or ephemeral transcript stores     | [#8287](https://github.com/LionSR/TeXRA/pull/8287) | Open draft |
-| `P0.10`    | Fail closed when ignore policy cannot be read or applied       | [#8272](https://github.com/LionSR/TeXRA/pull/8272) | Merged     |
-| `P0.11`    | Preserve unreadable or invalid resumable flow state            | [#8277](https://github.com/LionSR/TeXRA/pull/8277) | Open draft |
-| `P0.12`    | Remove automatic delete-and-replace on circular symlinks       | [#8276](https://github.com/LionSR/TeXRA/pull/8276) | Merged     |
-| `P0.13`    | Refuse approval when current proposed content is unreadable    | [#8275](https://github.com/LionSR/TeXRA/pull/8275) | Merged     |
-| `P2.1`     | Keep one desktop project-configuration source after failures   | [#8237](https://github.com/LionSR/TeXRA/pull/8237) | Merged     |
+| Finding    | Change                                                         | Pull request                                                | Status     |
+| ---------- | -------------------------------------------------------------- | ----------------------------------------------------------- | ---------- |
+| `P0.S1/S4` | Require relay enforcement and distinguish unavailable spend    | [#8269](https://github.com/texra-ai/texra-issues/pull/8269) | Merged     |
+| `P0.S2`    | Require a configured signup-hook verification secret           | [#8268](https://github.com/texra-ai/texra-issues/pull/8268) | Merged     |
+| `P0.S3`    | Require an explicit boolean device-approval decision           | [#8266](https://github.com/texra-ai/texra-issues/pull/8266) | Open draft |
+| `P0.1`     | Retry or quarantine every unacknowledged client usage batch    | [#8267](https://github.com/texra-ai/texra-issues/pull/8267) | Open draft |
+| `P0.1`     | Validate usage batches atomically and mark permanent rejection | [#8270](https://github.com/texra-ai/texra-issues/pull/8270) | Open draft |
+| `P0.2`     | Omit diagnostics when a host has no linter                     | [#8271](https://github.com/texra-ai/texra-issues/pull/8271) | Merged     |
+| `P0.4`     | Require explicit persistent or ephemeral transcript stores     | [#8287](https://github.com/texra-ai/texra-issues/pull/8287) | Open draft |
+| `P0.10`    | Fail closed when ignore policy cannot be read or applied       | [#8272](https://github.com/texra-ai/texra-issues/pull/8272) | Merged     |
+| `P0.11`    | Preserve unreadable or invalid resumable flow state            | [#8277](https://github.com/texra-ai/texra-issues/pull/8277) | Open draft |
+| `P0.12`    | Remove automatic delete-and-replace on circular symlinks       | [#8276](https://github.com/texra-ai/texra-issues/pull/8276) | Merged     |
+| `P0.13`    | Refuse approval when current proposed content is unreadable    | [#8275](https://github.com/texra-ai/texra-issues/pull/8275) | Merged     |
+| `P2.1`     | Keep one desktop project-configuration source after failures   | [#8237](https://github.com/texra-ai/texra-issues/pull/8237) | Merged     |
 
 The two `P0.1` pull requests form one protocol change and should be reviewed
 and merged together. The server marks only permanent payload rejection as
@@ -178,7 +178,7 @@ unavailable, the relay should fail initialization or return `503` for every
 key-bearing request. Public metadata routes may remain available through a
 separate handler that does not forward provider requests.
 
-**Disposition:** Resolved on main by [#8269](https://github.com/LionSR/TeXRA/pull/8269).
+**Disposition:** Resolved on main by [#8269](https://github.com/texra-ai/texra-issues/pull/8269).
 Remove the fail-open configuration path before other fallback work.
 
 ### P0.S2 Missing signup-hook secret permits unsigned hook handling
@@ -196,7 +196,7 @@ different trust assumptions, selected by a missing environment variable.
 `503` until configured. Development should use an explicitly selected local
 adapter or emulator, not the production handler's missing-secret branch.
 
-**Disposition:** Resolved on main by [#8268](https://github.com/LionSR/TeXRA/pull/8268).
+**Disposition:** Resolved on main by [#8268](https://github.com/texra-ai/texra-issues/pull/8268).
 Remove unsigned production mode.
 
 ### P0.S3 Missing or malformed device-approval intent means approval
@@ -219,7 +219,7 @@ const approve = body?.approve !== false;
 missing or malformed intent with `400`. Approval and denial should both require
 an explicit boolean.
 
-**Disposition:** Draft implementation: [#8266](https://github.com/LionSR/TeXRA/pull/8266).
+**Disposition:** Draft implementation: [#8266](https://github.com/texra-ai/texra-issues/pull/8266).
 Remove the implicit-approval fallback.
 
 ### P0.S4 Spending-check failure becomes zero spend for paid tiers
@@ -238,7 +238,7 @@ makes the grace policy unbounded and difficult to audit.
 allowance using last-verified spend, an expiry, a maximum request/cost budget, and
 metrics. Never report unavailable spend as zero.
 
-**Disposition:** Resolved on main by [#8269](https://github.com/LionSR/TeXRA/pull/8269).
+**Disposition:** Resolved on main by [#8269](https://github.com/texra-ai/texra-issues/pull/8269).
 Remove synthetic zero; preserve availability only through an explicit grace
 policy.
 
@@ -283,8 +283,8 @@ owns restoring HTTP 422 after those clients age out. The client should retain or
 quarantine every entry not explicitly acknowledged. Missing legacy fields may
 use `.prefault(...)`; invalid present fields must not use `.catch(...)`.
 
-**Disposition:** Draft implementations: [#8267](https://github.com/LionSR/TeXRA/pull/8267)
-and [#8270](https://github.com/LionSR/TeXRA/pull/8270), deployed server first.
+**Disposition:** Draft implementations: [#8267](https://github.com/texra-ai/texra-issues/pull/8267)
+and [#8270](https://github.com/texra-ai/texra-issues/pull/8270), deployed server first.
 Remove the success fallback.
 
 ### P0.2 Unavailable diagnostics are reported as an empty successful result
@@ -323,7 +323,7 @@ Either provide a host-neutral linter for CLI and desktop, or omit the read
 capability from their tool roster. `diagnostics.add` must likewise distinguish
 "unsupported" from "supported but disabled."
 
-**Disposition:** Resolved on main by [#8271](https://github.com/LionSR/TeXRA/pull/8271);
+**Disposition:** Resolved on main by [#8271](https://github.com/texra-ai/texra-issues/pull/8271);
 the capability subsequently moved from the process-wide Platform object to the
 active session interaction adapter in #8508. The empty-result fallback remains
 removed.
@@ -406,7 +406,7 @@ fail when persistence cannot open unless the caller explicitly selects an
 ephemeral mode. Interactive hosts may continue with `ephemeral(reason)`, but must
 display that state.
 
-**Disposition:** Draft implementation: [#8287](https://github.com/LionSR/TeXRA/pull/8287).
+**Disposition:** Draft implementation: [#8287](https://github.com/texra-ai/texra-issues/pull/8287).
 
 ### P0.5 Invalid persisted snapshots become valid empty/current snapshots
 
@@ -625,7 +625,7 @@ context-building operation or require an explicit caller policy that excludes
 uncertain paths. Matcher failure should fail closed for that path and report the
 rule source.
 
-**Disposition:** Resolved on main by [#8272](https://github.com/LionSR/TeXRA/pull/8272).
+**Disposition:** Resolved on main by [#8272](https://github.com/texra-ai/texra-issues/pull/8272).
 Remove fail-open behavior at the model-context boundary.
 
 ### P0.11 Unreadable or invalid resumable flow state is deleted and restarted
@@ -663,7 +663,7 @@ const state = await readFlowState();
 An explicit restart should allocate or record a new attempt and preserve the old
 record for diagnosis. Automatic fresh start is valid only for confirmed absence.
 
-**Disposition:** Draft implementation: [#8277](https://github.com/LionSR/TeXRA/pull/8277).
+**Disposition:** Draft implementation: [#8277](https://github.com/texra-ai/texra-issues/pull/8277).
 Remove destructive recovery from both flow runners and place the policy in the
 persistence/resume facade.
 
@@ -685,7 +685,7 @@ may delete and replace only after the owning workflow explicitly selects that
 policy and records the affected path. Prefer preserving or renaming the link for
 diagnosis.
 
-**Disposition:** Resolved on main by [#8276](https://github.com/LionSR/TeXRA/pull/8276).
+**Disposition:** Resolved on main by [#8276](https://github.com/texra-ai/texra-issues/pull/8276).
 Remove destructive behavior from the general write primitive.
 
 ### P0.13 Diff approval falls back to stale proposed content
@@ -705,7 +705,7 @@ the same action.
 can be read. If recovery offers the original proposal, it must open it as a new
 explicit review revision rather than substituting it under the existing approval.
 
-**Disposition:** Resolved on main by [#8275](https://github.com/LionSR/TeXRA/pull/8275).
+**Disposition:** Resolved on main by [#8275](https://github.com/texra-ai/texra-issues/pull/8275).
 Remove stale-content approval fallback.
 
 ### P1.1 Process output read failures are swallowed before the logger can see them
@@ -1279,7 +1279,7 @@ configuration inaccessible/corrupt." Absence may select a documented default
 location. Failure should put configuration into a visible degraded read-only
 state until repaired.
 
-**Disposition:** Resolved on main by [#8237](https://github.com/LionSR/TeXRA/pull/8237),
+**Disposition:** Resolved on main by [#8237](https://github.com/texra-ai/texra-issues/pull/8237),
 which selects the configuration source once and preserves that choice after
 read or migration failures.
 

--- a/docs/proposals/2026-07-26-agent-sdk-foundation-gap.md
+++ b/docs/proposals/2026-07-26-agent-sdk-foundation-gap.md
@@ -350,7 +350,7 @@ silent-degradation rule; and the five `onDidChange` listeners are all legitimate
 consumers, one of them inside the runtime itself. **Restate the acceptance target as 10.**
 
 > **Corrected 2026-07-26 — "deleting the three projector trace-arms" is not the mechanism that
-> gets there; see [#9250 comment](https://github.com/LionSR/TeXRA/issues/9250#issuecomment-5084548544)
+> gets there; see [#9250 comment](https://github.com/texra-ai/texra-issues/issues/9250#issuecomment-5084548544)
 > and #9263.** `publishStatus` gates the session-fact emit on `options.events`, and no production
 > call site has ever passed `trace` and `events` together
 > (`ExecutionRegistry.streamStatusEmitOptions` returns one or the other; `AgentLaunchContext`
@@ -468,7 +468,7 @@ Orthogonal, each needing its own ruling: the reveal-stream fold (7) and the stat
 > silences status for every trace-owned transition (run start, terminal, manual-retry
 > WAITING/RESUME/CANCEL, restart repair) — the two do not compose into "one rail." See the
 > corrected acceptance-criteria row 5 note (§7) and
-> [#9250 comment](https://github.com/LionSR/TeXRA/issues/9250#issuecomment-5084548544) / #9263
+> [#9250 comment](https://github.com/texra-ai/texra-issues/issues/9250#issuecomment-5084548544) / #9263
 > for the mechanism that actually ships 13 → 10.
 
 ### Correction to a premise this doc previously carried

--- a/docs/proposals/2026-08-01-architecture-rulings-ledger.md
+++ b/docs/proposals/2026-08-01-architecture-rulings-ledger.md
@@ -101,7 +101,7 @@ it the assert is knowingly wrong for `LogList`.
 `ModelCell` ownership primitive now present on `main`?
 
 **Ruling.** No. The implementation merged in
-[#9547](https://github.com/LionSR/TeXRA/pull/9547) is authoritative for the
+[#9547](https://github.com/texra-ai/texra-issues/pull/9547) is authoritative for the
 narrow ownership and lifecycle guarantees below. It supersedes the retired
 PRD's top-level [historical-status clause](../prds/2026-06-29-prd-runtime-gold-standard.md),
 which says the listed designs “must not be implemented from this record,” and

--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -702,5 +702,5 @@ That's it! No Supabase URLs, API keys, or other configuration.
 ## Support
 
 - **Supabase Docs**: https://supabase.com/docs
-- **TeXRA GitHub**: https://github.com/LionSR/TeXRA
-- **Issues**: https://github.com/LionSR/TeXRA/issues
+- **TeXRA GitHub**: https://github.com/texra-ai/texra-issues
+- **Issues**: https://github.com/texra-ai/texra-issues/issues

--- a/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
@@ -169,7 +169,7 @@ function expectPairedToolResults(
 }
 
 /**
- * Regression test for https://github.com/LionSR/TeXRA/issues/7163.
+ * Regression test for https://github.com/texra-ai/texra-issues/issues/7163.
  *
  * An assistant turn persisted with N tool_use blocks but fewer than N
  * tool_result entries is unresumable: providers with strict tool-call pairing

--- a/src/test-kernel/tools/GitHubPrTypes.vitest.ts
+++ b/src/test-kernel/tools/GitHubPrTypes.vitest.ts
@@ -19,7 +19,8 @@ describe('GitHub REST response schemas', () => {
           user: { login: 'octocat', type: null },
           created_at: '2026-06-21T00:00:00Z',
           updated_at: null,
-          html_url: 'https://github.com/LionSR/TeXRA/issues/1#issuecomment-1',
+          html_url:
+            'https://github.com/texra-ai/texra-issues/issues/1#issuecomment-1',
           issue_url: null,
         },
       ]).success,
@@ -35,7 +36,8 @@ describe('GitHub REST response schemas', () => {
           line: null,
           original_line: null,
           in_reply_to_id: null,
-          html_url: 'https://github.com/LionSR/TeXRA/pull/1#discussion_r2',
+          html_url:
+            'https://github.com/texra-ai/texra-issues/pull/1#discussion_r2',
           created_at: '2026-06-21T00:00:00Z',
           updated_at: null,
         },
@@ -57,7 +59,7 @@ describe('GitHub REST response schemas', () => {
         state: 'open',
         state_reason: null,
         title: 'Issue',
-        html_url: 'https://github.com/LionSR/TeXRA/issues/1',
+        html_url: 'https://github.com/texra-ai/texra-issues/issues/1',
         user: null,
         pull_request: null,
       }).success,


### PR DESCRIPTION
## Summary

Retargets 97 historical issue and pull-request URLs from the TeXRA source repository to the public texra-ai/texra-issues tracking repository. The migration covers the 14 historical design documents and two URL-shaped test fixtures that still carried the former location.

Current source, release, and product links remain unchanged.

## Issue acceptance gates

No linked issue. Every LionSR/TeXRA URL in the identified 16-file historical-reference set now points to the public issue-tracking repository.

## Single source of truth

Historical issue discussions and pull-request records are referenced through texra-ai/texra-issues. The source repository remains the authority for code and releases.

## Duplication and abstraction budget

This is one mechanical prefix migration. It introduces no helper, compatibility path, or duplicate mapping.

## Net elements (R6)

Not applicable to this documentation-focused migration. Sixteen files change by 103 insertions and 101 deletions; the net two lines are Prettier wrapping for the longer URL.

## Consumer counts (R8)

Not applicable; no export, event, or production execution path changes.

## Host impact

Extension: None.

Desktop: None.

CLI: None.

## Scheduled refactoring

None.

## Validation

- Verified that all three source worktrees contained byte-identical versions of the 16 files.
- Verified that each source diff was exactly the LionSR/TeXRA to texra-ai/texra-issues prefix replacement: 97 changed lines in 16 files.
- Verified the current main branch contained the same 97 old-prefix occurrences in the same 16 files before migration and none afterward.
- Prettier check over all 16 changed files.
- Documentation root boundary check.
- Guidance-reference check.
- Vitest: ToolUseDispatchInterruption.vitest.ts and GitHubPrTypes.vitest.ts; 2 files and 3 tests passed.
- Commit hooks and changed-file pre-push lint passed.