### PR TITLE
fix(cli): preserve work plans through preload failures

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -517,6 +517,11 @@ export function App(props: AppProps): React.JSX.Element {
         return (
           <WorkPlanReader
             availableRows={availableRows}
+            authority={
+              foregroundReader.loading === true
+                ? undefined
+                : foregroundReader.authority
+            }
             loading={foregroundReader.loading === true}
             onClose={closeForegroundReader}
             streamId={foregroundReader.streamId}

--- a/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
@@ -30,10 +30,7 @@ import { hydrateStreamArtifacts } from '@cli/chat/tui/state/subscribeStreamArtif
 import { terminalCapabilities } from '@cli/chat/tui/state/terminalCapabilities';
 import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import { activeStreamParentOrSelfId } from '@cli/chat/tui/state/streamViews';
-import {
-  projectStreamArtifacts,
-  type StreamArtifactReader,
-} from '@controllers/session/StreamArtifactProjection';
+import type { StreamArtifactReader } from '@controllers/session/StreamArtifactProjection';
 import { activeSubscriptionUsageRoute } from '@model/codingPlanSubscriptions';
 import { formatTexraApprovalPolicy } from '@shared/approvalPolicy';
 import { MESSAGE_TYPES } from '@shared/schemas';
@@ -70,25 +67,44 @@ export async function showCliWorkPlan(
   }
   clearTransientNotice();
   const request = beginWorkPlanReaderRequest(streamId);
-  const hydrated = await hydrateStreamArtifacts(
-    snapshots,
-    streamId,
-    () => workPlanReaderRequestIsCurrent(request),
-    (error) => {
-      if (!cancelWorkPlanReaderRequest(request)) return;
-      setTransientNotice(
-        `Could not load workflow artifacts: ${toErrorMessage(error)}`,
-      );
-    },
+  const outcome = await hydrateStreamArtifacts(snapshots, streamId, () =>
+    workPlanReaderRequestIsCurrent(request),
   );
-  if (!hydrated || !workPlanReaderRequestIsCurrent(request)) return;
-  const projection = projectStreamArtifacts(snapshots, streamId);
-  if (projection.plan === null && projection.todos.length === 0) {
+  if (!outcome || !workPlanReaderRequestIsCurrent(request)) return;
+  if (outcome.kind === 'failed') {
+    if (!cancelWorkPlanReaderRequest(request)) return;
+    setTransientNotice(
+      `Could not load workflow artifacts: ${toErrorMessage(outcome.error)}`,
+    );
+    return;
+  }
+  const workPlan = snapshots.getWorkPlan(streamId);
+  if (outcome.kind === 'complete') {
+    if (workPlan.plan !== null || workPlan.todos.length > 0) {
+      finishWorkPlanReaderRequest(request);
+      return;
+    }
     if (!cancelWorkPlanReaderRequest(request)) return;
     setTransientNotice('The focused session has no work plan.');
     return;
   }
-  finishWorkPlanReaderRequest(request);
+  const { plan: planIsAuthoritative, todos: todosAreAuthoritative } =
+    outcome.authoritativeFields;
+  if (
+    (planIsAuthoritative && workPlan.plan !== null) ||
+    (todosAreAuthoritative && workPlan.todos.length > 0)
+  ) {
+    finishWorkPlanReaderRequest(request);
+    return;
+  }
+  if (!cancelWorkPlanReaderRequest(request)) return;
+  if (planIsAuthoritative && todosAreAuthoritative) {
+    setTransientNotice('The focused session has no work plan.');
+    return;
+  }
+  setTransientNotice(
+    `Could not load workflow artifacts: ${toErrorMessage(outcome.error)}`,
+  );
 }
 
 /**

--- a/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
@@ -79,26 +79,26 @@ export async function showCliWorkPlan(
     return;
   }
   const workPlan = snapshots.getWorkPlan(streamId);
-  if (outcome.kind === 'complete') {
-    if (workPlan.plan !== null || workPlan.todos.length > 0) {
-      finishWorkPlanReaderRequest(request);
-      return;
-    }
-    if (!cancelWorkPlanReaderRequest(request)) return;
-    setTransientNotice('The focused session has no work plan.');
-    return;
-  }
-  const { plan: planIsAuthoritative, todos: todosAreAuthoritative } =
-    outcome.authoritativeFields;
+  const authority = {
+    plan: outcome.kind === 'complete' || outcome.authoritativeFields.plan,
+    todos: outcome.kind === 'complete' || outcome.authoritativeFields.todos,
+  };
+  const { plan: planIsAuthoritative, todos: todosAreAuthoritative } = authority;
   if (
     (planIsAuthoritative && workPlan.plan !== null) ||
     (todosAreAuthoritative && workPlan.todos.length > 0)
   ) {
-    finishWorkPlanReaderRequest(request);
+    finishWorkPlanReaderRequest(
+      request,
+      outcome.kind === 'partial' ? authority : undefined,
+    );
     return;
   }
   if (!cancelWorkPlanReaderRequest(request)) return;
-  if (planIsAuthoritative && todosAreAuthoritative) {
+  if (
+    outcome.kind === 'complete' ||
+    (planIsAuthoritative && todosAreAuthoritative)
+  ) {
     setTransientNotice('The focused session has no work plan.');
     return;
   }

--- a/packages/cli/src/chat/tui/panes/WorkPlanReader.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkPlanReader.tsx
@@ -22,6 +22,7 @@ import {
   type TodoItem,
   type TodoStatus,
 } from '@shared/schemas';
+import type { StreamArtifactAuthority } from '@transcript';
 
 import { formFrameWidth } from '../forms/_shared/FormFrame';
 import { ScrollableModalText } from '../modals/ScrollableModalText';
@@ -45,6 +46,7 @@ function wrappedRows(text: string, width: number): number {
   return wrapAnsiToWidth(text, Math.max(1, width)).split('\n').length;
 }
 
+/** Compute a frame that fits the terminal. `bodyRows` may be zero. */
 export function workPlanReaderLayout({
   availableRows,
   contentWidth,
@@ -63,7 +65,7 @@ export function workPlanReaderLayout({
 } {
   const rows = Math.max(1, Math.floor(availableRows));
   const width = Math.max(1, Math.floor(contentWidth));
-  if (rows < 3) {
+  if (rows < 4) {
     return {
       bodyRows: rows - 1,
       showBorder: false,
@@ -97,25 +99,36 @@ export function workPlanReaderTitle(label: string | undefined): string {
 export function formatWorkPlanReaderText(
   plan: Plan | null,
   todos: readonly TodoItem[],
+  authority?: Pick<StreamArtifactAuthority, 'plan' | 'todos'>,
 ): string {
-  const objective = plan?.objective ?? '(no objective)';
-  const todoLines = todos.length
-    ? todos.map(
-        (todo, index) =>
-          `${index + 1}. [${TODO_STATUS_LABELS[todo.status]}] ${todo.content}`,
-      )
-    : ['(no todos)'];
+  const objective =
+    authority?.plan === false
+      ? '(objective unavailable)'
+      : (plan?.objective ?? '(no objective)');
+  let todoLines: string[];
+  if (authority?.todos === false) {
+    todoLines = ['(todos unavailable)'];
+  } else if (todos.length === 0) {
+    todoLines = ['(no todos)'];
+  } else {
+    todoLines = todos.map(
+      (todo, index) =>
+        `${index + 1}. [${TODO_STATUS_LABELS[todo.status]}] ${todo.content}`,
+    );
+  }
   return ['Objective', objective, '', 'Todos', ...todoLines].join('\n');
 }
 
 export function WorkPlanReader({
   availableRows,
+  authority,
   loading = false,
   onClose,
   streamId,
   title,
 }: {
   readonly availableRows: number;
+  readonly authority?: Pick<StreamArtifactAuthority, 'plan' | 'todos'>;
   readonly loading?: boolean;
   readonly onClose: () => void;
   readonly streamId: StreamTabId;
@@ -137,7 +150,11 @@ export function WorkPlanReader({
   });
   const text = loading
     ? WORK_PLAN_LOADING_TEXT
-    : formatWorkPlanReaderText(workPlan?.plan ?? null, workPlan?.todos ?? []);
+    : formatWorkPlanReaderText(
+        workPlan?.plan ?? null,
+        workPlan?.todos ?? [],
+        authority,
+      );
 
   useInput((input, key) => {
     if (isEscapeInput(input, key)) onClose();

--- a/packages/cli/src/chat/tui/panes/WorkPlanReader.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkPlanReader.tsx
@@ -1,6 +1,6 @@
 // Scrollable, read-only view of one stream's canonical plan and todos.
 
-import { useInput, useWindowSize } from 'ink';
+import { Box, Text, useInput, useWindowSize } from 'ink';
 
 import { wrapAnsiToWidth } from '@cli/tui/ansiWrap';
 import { isEscapeInput } from '@cli/tui/inputKeys';
@@ -59,11 +59,20 @@ export function workPlanReaderLayout({
   readonly title: string;
 }): {
   readonly bodyRows: number;
+  readonly showBorder: boolean;
   readonly showFooter: boolean;
   readonly showTitle: boolean;
 } {
   const rows = Math.max(1, Math.floor(availableRows));
   const width = Math.max(1, Math.floor(contentWidth));
+  if (rows < 3) {
+    return {
+      bodyRows: rows - 1,
+      showBorder: false,
+      showFooter: false,
+      showTitle: true,
+    };
+  }
   const footerRows = wrappedRows(
     hints.map(keyHintText).join(KEY_HINT_SEPARATOR),
     width,
@@ -77,6 +86,7 @@ export function workPlanReaderLayout({
       1,
       rows - BORDER_ROWS - footerFixedRows - (showTitle ? titleRows : 0),
     ),
+    showBorder: true,
     showFooter,
     showTitle,
   };
@@ -133,6 +143,36 @@ export function WorkPlanReader({
     if (isEscapeInput(input, key)) onClose();
   });
 
+  const body =
+    layout.bodyRows > 0 ? (
+      <ScrollableModalText
+        hiddenNoun="work plan rows"
+        marginWhenSpacious={false}
+        maxRows={layout.bodyRows}
+        minContentWidth={1}
+        resetKey={streamId}
+        scrollHint="scroll work plan"
+        showScrollHints={false}
+        text={text}
+        width={layout.showBorder ? width : frameWidth}
+      />
+    ) : null;
+
+  if (!layout.showBorder) {
+    return (
+      <Box
+        flexDirection="column"
+        height={Math.max(1, Math.floor(availableRows))}
+        width={frameWidth}
+      >
+        <Text bold color={COLOR_HINT} wrap="truncate-end">
+          {title}
+        </Text>
+        {body}
+      </Box>
+    );
+  }
+
   return (
     <BorderedPanel
       color={COLOR_HINT}
@@ -144,17 +184,7 @@ export function WorkPlanReader({
         ) : undefined
       }
     >
-      <ScrollableModalText
-        hiddenNoun="work plan rows"
-        marginWhenSpacious={false}
-        maxRows={layout.bodyRows}
-        minContentWidth={1}
-        resetKey={streamId}
-        scrollHint="scroll work plan"
-        showScrollHints={false}
-        text={text}
-        width={width}
-      />
+      {body}
     </BorderedPanel>
   );
 }

--- a/packages/cli/src/chat/tui/panes/WorkPlanReader.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkPlanReader.tsx
@@ -2,6 +2,7 @@
 
 import { Box, Text, useInput, useWindowSize } from 'ink';
 
+import { tryDefaultSession } from '@agent/runtime';
 import { wrapAnsiToWidth } from '@cli/tui/ansiWrap';
 import { isEscapeInput } from '@cli/tui/inputKeys';
 import { BorderedPanel } from '@cli/tui/ui/BorderedPanel';
@@ -24,10 +25,7 @@ import {
 
 import { formFrameWidth } from '../forms/_shared/FormFrame';
 import { ScrollableModalText } from '../modals/ScrollableModalText';
-import {
-  readStreamArtifacts,
-  streamArtifactRevision,
-} from '../state/subscribeStreamArtifacts';
+import { streamArtifactRevision } from '../state/subscribeStreamArtifacts';
 import { useSignal } from '../state/useSignal';
 
 const TODO_STATUS_LABELS: Record<TodoStatus, string> = {
@@ -125,7 +123,9 @@ export function WorkPlanReader({
 }): React.JSX.Element {
   const { columns } = useWindowSize();
   useSignal(streamArtifactRevision);
-  const artifacts = readStreamArtifacts(streamId);
+  const workPlan = loading
+    ? undefined
+    : tryDefaultSession()?.snapshots.getWorkPlan(streamId);
   const frameWidth = formFrameWidth(columns);
   const width = Math.max(1, frameWidth - CONFIRM_CARD_HORIZONTAL_DECORATION);
   const hints = loading ? WORK_PLAN_LOADING_HINTS : READER_SCROLL_HINTS;
@@ -137,7 +137,7 @@ export function WorkPlanReader({
   });
   const text = loading
     ? WORK_PLAN_LOADING_TEXT
-    : formatWorkPlanReaderText(artifacts?.plan ?? null, artifacts?.todos ?? []);
+    : formatWorkPlanReaderText(workPlan?.plan ?? null, workPlan?.todos ?? []);
 
   useInput((input, key) => {
     if (isEscapeInput(input, key)) onClose();

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -24,6 +24,7 @@ import type {
   CompactionActivityBlock,
   CompactionActivityProjection,
 } from '@shared/streams/compactionActivityProjection';
+import type { StreamArtifactAuthority } from '@transcript';
 import { isChildStreamRemoved } from './childExecutions';
 
 // ---------------------------------------------------------------------------
@@ -518,6 +519,7 @@ type ForegroundReaderTarget =
       readonly kind: 'workPlan';
       readonly streamId: StreamTabId;
       readonly loading?: false;
+      readonly authority?: Pick<StreamArtifactAuthority, 'plan' | 'todos'>;
     }
   | {
       readonly kind: 'workPlan';
@@ -565,9 +567,14 @@ export function workPlanReaderRequestIsCurrent(
 /** Resolve the loading reader without allowing an older request to replace it. */
 export function finishWorkPlanReaderRequest(
   request: WorkPlanReaderRequest,
+  authority?: Pick<StreamArtifactAuthority, 'plan' | 'todos'>,
 ): boolean {
   if (!workPlanReaderRequestIsCurrent(request)) return false;
-  FOREGROUND_READER.set({ kind: 'workPlan', streamId: request.streamId });
+  FOREGROUND_READER.set({
+    kind: 'workPlan',
+    streamId: request.streamId,
+    ...(authority ? { authority } : {}),
+  });
   return true;
 }
 

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -578,6 +578,38 @@ export function finishWorkPlanReaderRequest(
   return true;
 }
 
+/** Promote fields whose provenance was established after a partial `/plan`
+ * load. Live writes and later successful preloads must replace the reader's
+ * failure-time mask rather than leaving a now-current field unavailable. */
+export function establishWorkPlanReaderAuthority(
+  streamId: StreamTabId,
+  fields: readonly (keyof Pick<StreamArtifactAuthority, 'plan' | 'todos'>)[],
+): void {
+  const target = FOREGROUND_READER.get();
+  if (
+    target?.kind !== 'workPlan' ||
+    target.loading === true ||
+    target.streamId !== streamId ||
+    target.authority === undefined
+  ) {
+    return;
+  }
+  const authority = { ...target.authority };
+  let changed = false;
+  for (const field of fields) {
+    if (!authority[field]) {
+      authority[field] = true;
+      changed = true;
+    }
+  }
+  if (!changed) return;
+  FOREGROUND_READER.set(
+    authority.plan && authority.todos
+      ? { kind: 'workPlan', streamId }
+      : { ...target, authority },
+  );
+}
+
 export function cancelPendingWorkPlanReaderRequest(): void {
   const target = FOREGROUND_READER.get();
   if (target?.kind === 'workPlan' && target.loading === true) {

--- a/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
+++ b/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
@@ -38,7 +38,10 @@ import {
   isChildStreamRemoved,
   unbindChildStreamState,
 } from './childExecutions';
-import { markArtifactStreamHydrated } from './subscribeStreamArtifacts';
+import {
+  markArtifactStreamHydrated,
+  markWorkPlanArtifactHydrated,
+} from './subscribeStreamArtifacts';
 import {
   releaseInactiveStreamTranscript,
   syncStreamLog,
@@ -177,11 +180,11 @@ class TuiSessionRenderer implements SessionRendererPort {
   // (StreamSnapshotStore eager-apply overlay), so renderers read the store.
   // See `invalidate` for why the write marks the stream hydrated.
   onTodosChanged(streamId: StreamTabId, _todos: TodoItem[]): void {
-    markArtifactStreamHydrated(streamId);
+    markWorkPlanArtifactHydrated(streamId, 'todos');
   }
 
   onPlanChanged(streamId: StreamTabId, _plan: Plan | null): void {
-    markArtifactStreamHydrated(streamId);
+    markWorkPlanArtifactHydrated(streamId, 'plan');
   }
 
   onInquiryThreadUpdated(_thread: InquiryThreadUpdatedEvent): void {}

--- a/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
@@ -159,12 +159,7 @@ function streamCanReceiveArtifacts(
   );
 }
 
-/**
- * Preload one stream from the canonical artifact accumulator and invalidate
- * the artifact projection. Callers own request currentness: focus hydration
- * invalidates on a focus change, while `/plan` keeps the stream id it
- * captured before awaiting.
- */
+/** Complete, partially authoritative, and unusable preload outcomes. */
 type StreamArtifactHydrationOutcome =
   | { readonly kind: 'complete' }
   | {
@@ -174,6 +169,12 @@ type StreamArtifactHydrationOutcome =
     }
   | { readonly kind: 'failed'; readonly error: unknown };
 
+/**
+ * Preload one stream from the canonical artifact accumulator and invalidate
+ * the artifact projection. Callers own request currentness and error
+ * presentation. `undefined` means the request was superseded; a partial
+ * outcome is usable only for fields selected by `authoritativeFields`.
+ */
 export async function hydrateStreamArtifacts(
   store: StreamArtifactReader,
   streamId: StreamTabId,

--- a/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
@@ -28,6 +28,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import {
   activeStreamId,
+  establishWorkPlanReaderAuthority,
   getCliStateGeneration,
   isCliStreamRetired,
   registerCliStateResetHook,
@@ -77,6 +78,16 @@ export function markArtifactStreamHydrated(streamId: StreamTabId): void {
   bumpStreamArtifactRevision();
 }
 
+/** Record a live plan/todo write as authority for an already-open partial
+ * reader, then invalidate the canonical projection like any artifact write. */
+export function markWorkPlanArtifactHydrated(
+  streamId: StreamTabId,
+  field: 'plan' | 'todos',
+): void {
+  establishWorkPlanReaderAuthority(streamId, [field]);
+  markArtifactStreamHydrated(streamId);
+}
+
 /** Prepare reconciliation for an authoritative full-set `load` of `retained`.
  *  `load` evicts every other record, so capture the markers it will evict up
  *  front (plus the active stream, whose first focus preload may still be in
@@ -102,7 +113,10 @@ export function beginLoadedStreamsReconcile(retained: readonly StreamTabId[]): {
   const apply = (markRetained: boolean): void => {
     for (const streamId of stale) hydratedArtifactStreams.delete(streamId);
     if (markRetained) {
-      for (const streamId of retained) hydratedArtifactStreams.add(streamId);
+      for (const streamId of retained) {
+        hydratedArtifactStreams.add(streamId);
+        establishWorkPlanReaderAuthority(streamId, ['plan', 'todos']);
+      }
     }
     bumpStreamArtifactRevision();
   };
@@ -193,6 +207,12 @@ export async function hydrateStreamArtifacts(
       error instanceof StreamSnapshotPreloadError &&
       error.streamId === streamId
     ) {
+      establishWorkPlanReaderAuthority(
+        streamId,
+        (['plan', 'todos'] as const).filter(
+          (field) => error.authoritativeFields[field],
+        ),
+      );
       if (Object.values(error.authoritativeFields).every(Boolean)) {
         markArtifactStreamHydrated(streamId);
       }
@@ -207,6 +227,7 @@ export async function hydrateStreamArtifacts(
   if (!streamCanReceiveArtifacts(streamId, generation, requestIsCurrent)) {
     return undefined;
   }
+  establishWorkPlanReaderAuthority(streamId, ['plan', 'todos']);
   markArtifactStreamHydrated(streamId);
   return { kind: 'complete' };
 }

--- a/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
@@ -192,7 +192,7 @@ export async function hydrateStreamArtifacts(
       error instanceof StreamSnapshotPreloadError &&
       error.streamId === streamId
     ) {
-      if (Object.values(error.authoritativeFields).some(Boolean)) {
+      if (Object.values(error.authoritativeFields).every(Boolean)) {
         markArtifactStreamHydrated(streamId);
       }
       return {

--- a/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
@@ -20,6 +20,10 @@ import {
 } from '@controllers/session/StreamArtifactProjection';
 import { type StreamTabId, type TokenUsageStats } from '@shared/schemas';
 import { subscribeToSignalChanges } from '@shared/signals';
+import {
+  StreamSnapshotPreloadError,
+  type StreamArtifactAuthority,
+} from '@transcript';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import {
@@ -161,35 +165,49 @@ function streamCanReceiveArtifacts(
  * invalidates on a focus change, while `/plan` keeps the stream id it
  * captured before awaiting.
  */
+type StreamArtifactHydrationOutcome =
+  | { readonly kind: 'complete' }
+  | {
+      readonly kind: 'partial';
+      readonly authoritativeFields: StreamArtifactAuthority;
+      readonly error: unknown;
+    }
+  | { readonly kind: 'failed'; readonly error: unknown };
+
 export async function hydrateStreamArtifacts(
   store: StreamArtifactReader,
   streamId: StreamTabId,
   requestIsCurrent: () => boolean = () => true,
-  onError?: (error: unknown) => void,
-): Promise<boolean> {
+): Promise<StreamArtifactHydrationOutcome | undefined> {
   const generation = getCliStateGeneration();
   try {
     // `preload` warms only this stream. `load([streamId])` would incorrectly
     // claim an authoritative complete stream set and evict sibling state.
-    await store.preload([streamId]);
+    await store.preload([streamId], { reportArtifactAuthority: true });
   } catch (error) {
     if (!streamCanReceiveArtifacts(streamId, generation, requestIsCurrent)) {
-      return false;
+      return undefined;
     }
-    if (onError) {
-      onError(error);
-    } else {
-      setTransientNotice(
-        `Could not load workflow artifacts: ${toErrorMessage(error)}`,
-      );
+    if (
+      error instanceof StreamSnapshotPreloadError &&
+      error.streamId === streamId
+    ) {
+      if (Object.values(error.authoritativeFields).some(Boolean)) {
+        markArtifactStreamHydrated(streamId);
+      }
+      return {
+        kind: 'partial',
+        authoritativeFields: error.authoritativeFields,
+        error,
+      };
     }
-    return false;
+    return { kind: 'failed', error };
   }
   if (!streamCanReceiveArtifacts(streamId, generation, requestIsCurrent)) {
-    return false;
+    return undefined;
   }
   markArtifactStreamHydrated(streamId);
-  return true;
+  return { kind: 'complete' };
 }
 
 /**
@@ -210,7 +228,12 @@ export function subscribeStreamArtifacts(
       store,
       streamId,
       () => focusRevision === revision && activeStreamId.get() === streamId,
-    );
+    ).then((outcome) => {
+      if (!outcome || outcome.kind === 'complete') return;
+      setTransientNotice(
+        `Could not load workflow artifacts: ${toErrorMessage(outcome.error)}`,
+      );
+    });
   };
   if (previous) hydrate(previous);
 

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -68,6 +68,10 @@ import type { TranscriptRow } from '@shared/transcript';
 import { RESEARCHER_ACCESS } from '@shared/copy/onboarding';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import * as memoryFileSystem from '@tools/memory/memoryFileSystem';
+import {
+  StreamSnapshotPreloadError,
+  type StreamArtifactAuthority,
+} from '@transcript';
 
 // Child rosters and parent edges live on the adapter-bound `SessionState`;
 // /status resolves both its child counts and the root transcript target from
@@ -483,6 +487,79 @@ describe('handleTuiSlashCommand', () => {
       'Could not load workflow artifacts: historical sidecar unreadable',
     );
   });
+
+  it.each([
+    {
+      label: 'plan',
+      workPlan: {
+        plan: { objective: 'Use the accepted live plan.' },
+        todos: [],
+      },
+      authority: {
+        outputFiles: false,
+        missingOutputs: false,
+        compileFailures: false,
+        usage: false,
+        todos: false,
+        plan: true,
+      },
+    },
+    {
+      label: 'todos',
+      workPlan: {
+        plan: null,
+        todos: [
+          {
+            content: 'Use the accepted live todo',
+            activeForm: 'Using the accepted live todo',
+            status: 'in_progress',
+          },
+        ],
+      },
+      authority: {
+        outputFiles: false,
+        missingOutputs: false,
+        compileFailures: false,
+        usage: false,
+        todos: true,
+        plan: false,
+      },
+    },
+  ] satisfies readonly {
+    label: string;
+    workPlan: {
+      readonly plan: Plan | null;
+      readonly todos: readonly TodoItem[];
+    };
+    authority: StreamArtifactAuthority;
+  }[])(
+    'opens accepted in-memory $label state when historical preload fails',
+    async ({ workPlan, authority }) => {
+      const { promise: preload, reject: rejectPreload } = deferred<void>();
+      const streamId = 'live-plan-after-load-error' as StreamTabId;
+      registerBuiltinSlashCommands({
+        workPlanSnapshots: workPlanSnapshots(
+          () => workPlan,
+          () => preload,
+        ),
+      });
+      patchStream(streamId, (slice) => ({ ...slice }));
+      activeStreamId.set(streamId);
+
+      const dispatched = handleTuiSlashCommand('/plan', createContext());
+      rejectPreload(
+        new StreamSnapshotPreloadError(
+          new Error('historical sidecar unreadable'),
+          streamId,
+          authority,
+        ),
+      );
+      await dispatched;
+
+      expect(foregroundReader.get()).toEqual({ kind: 'workPlan', streamId });
+      expect(transientNotice.get()).toBeUndefined();
+    },
+  );
 
   it('opens memory list and preview output in the reference pane', async () => {
     vi.spyOn(memoryFileSystem, 'loadMemoryItems').mockResolvedValue([]);

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -556,7 +556,11 @@ describe('handleTuiSlashCommand', () => {
       );
       await dispatched;
 
-      expect(foregroundReader.get()).toEqual({ kind: 'workPlan', streamId });
+      expect(foregroundReader.get()).toEqual({
+        kind: 'workPlan',
+        streamId,
+        authority: { plan: authority.plan, todos: authority.todos },
+      });
       expect(transientNotice.get()).toBeUndefined();
     },
   );

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -44,6 +44,7 @@ import {
   invalidateChildStreams,
   unbindChildStreamState,
 } from '@cli/chat/tui/state/childExecutions';
+import { markWorkPlanArtifactHydrated } from '@cli/chat/tui/state/subscribeStreamArtifacts';
 import * as apiStatus from '@cli/runtime/apiStatus';
 import * as subscriptionLogin from '@cli/runtime/subscriptionLogin';
 import type { CliContext } from '@cli/runtime/cliContext';
@@ -562,6 +563,9 @@ describe('handleTuiSlashCommand', () => {
         authority: { plan: authority.plan, todos: authority.todos },
       });
       expect(transientNotice.get()).toBeUndefined();
+
+      markWorkPlanArtifactHydrated(streamId, authority.plan ? 'todos' : 'plan');
+      expect(foregroundReader.get()).toEqual({ kind: 'workPlan', streamId });
     },
   );
 

--- a/src/test-kernel/cli/SubscribeStreamArtifacts.vitest.ts
+++ b/src/test-kernel/cli/SubscribeStreamArtifacts.vitest.ts
@@ -1,19 +1,26 @@
 // Test composition imports
 import '@test/support/defaultSessionTestSetup';
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { defaultSession } from '@agent/runtime';
 import { resetCliState } from '@cli/chat/tui/state/cliState';
 import {
   beginLoadedStreamsReconcile,
+  hydrateStreamArtifacts,
   markArtifactStreamHydrated,
   readStreamArtifacts,
 } from '@cli/chat/tui/state/subscribeStreamArtifacts';
 import type { StreamTabId } from '@shared/schemas';
+import { StreamSnapshotPreloadError } from '@transcript';
 
 describe('stream artifact hydration reconciliation', () => {
   beforeEach(() => {
     resetCliState();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('drops evicted hydration before marking the retained set', () => {
@@ -31,5 +38,38 @@ describe('stream artifact hydration reconciliation', () => {
 
     expect(readStreamArtifacts(dropped)).toBeUndefined();
     expect(readStreamArtifacts(retained)).toBeDefined();
+  });
+
+  it('does not treat partial field authority as full-stream hydration', async () => {
+    const streamId = 'partial-authority@gpt#abc123def' as StreamTabId;
+    const snapshots = defaultSession().snapshots;
+    vi.spyOn(snapshots, 'preload').mockRejectedValueOnce(
+      new StreamSnapshotPreloadError(
+        new Error('historical sidecar unreadable'),
+        streamId,
+        {
+          outputFiles: false,
+          missingOutputs: false,
+          compileFailures: false,
+          usage: false,
+          todos: false,
+          plan: true,
+        },
+      ),
+    );
+
+    await expect(hydrateStreamArtifacts(snapshots, streamId)).resolves.toEqual({
+      kind: 'partial',
+      authoritativeFields: {
+        outputFiles: false,
+        missingOutputs: false,
+        compileFailures: false,
+        usage: false,
+        todos: false,
+        plan: true,
+      },
+      error: expect.any(StreamSnapshotPreloadError),
+    });
+    expect(readStreamArtifacts(streamId)).toBeUndefined();
   });
 });

--- a/src/test-kernel/cli/SubscribeStreamArtifacts.vitest.ts
+++ b/src/test-kernel/cli/SubscribeStreamArtifacts.vitest.ts
@@ -1,26 +1,19 @@
 // Test composition imports
 import '@test/support/defaultSessionTestSetup';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
-import { defaultSession } from '@agent/runtime';
 import { resetCliState } from '@cli/chat/tui/state/cliState';
 import {
   beginLoadedStreamsReconcile,
-  hydrateStreamArtifacts,
   markArtifactStreamHydrated,
   readStreamArtifacts,
 } from '@cli/chat/tui/state/subscribeStreamArtifacts';
 import type { StreamTabId } from '@shared/schemas';
-import { StreamSnapshotPreloadError } from '@transcript';
 
 describe('stream artifact hydration reconciliation', () => {
   beforeEach(() => {
     resetCliState();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it('drops evicted hydration before marking the retained set', () => {
@@ -38,38 +31,5 @@ describe('stream artifact hydration reconciliation', () => {
 
     expect(readStreamArtifacts(dropped)).toBeUndefined();
     expect(readStreamArtifacts(retained)).toBeDefined();
-  });
-
-  it('does not treat partial field authority as full-stream hydration', async () => {
-    const streamId = 'partial-authority@gpt#abc123def' as StreamTabId;
-    const snapshots = defaultSession().snapshots;
-    vi.spyOn(snapshots, 'preload').mockRejectedValueOnce(
-      new StreamSnapshotPreloadError(
-        new Error('historical sidecar unreadable'),
-        streamId,
-        {
-          outputFiles: false,
-          missingOutputs: false,
-          compileFailures: false,
-          usage: false,
-          todos: false,
-          plan: true,
-        },
-      ),
-    );
-
-    await expect(hydrateStreamArtifacts(snapshots, streamId)).resolves.toEqual({
-      kind: 'partial',
-      authoritativeFields: {
-        outputFiles: false,
-        missingOutputs: false,
-        compileFailures: false,
-        usage: false,
-        todos: false,
-        plan: true,
-      },
-      error: expect.any(StreamSnapshotPreloadError),
-    });
-    expect(readStreamArtifacts(streamId)).toBeUndefined();
   });
 });

--- a/src/test-kernel/cli/WorkPlanReader.vitest.ts
+++ b/src/test-kernel/cli/WorkPlanReader.vitest.ts
@@ -50,7 +50,7 @@ describe('WorkPlanReader display model', () => {
     );
   });
 
-  it('keeps plan-only and todo-only readers explicit', () => {
+  it('distinguishes absent work-plan fields from fields that were not loaded', () => {
     expect(formatWorkPlanReaderText({ objective: 'Plan only.' }, [])).toContain(
       '(no todos)',
     );
@@ -63,6 +63,15 @@ describe('WorkPlanReader display model', () => {
         },
       ]),
     ).toContain('(no objective)');
+    expect(
+      formatWorkPlanReaderText({ objective: 'Plan only.' }, [], {
+        plan: true,
+        todos: false,
+      }),
+    ).toContain('(todos unavailable)');
+    expect(
+      formatWorkPlanReaderText(null, [], { plan: false, todos: true }),
+    ).toContain('(objective unavailable)');
   });
 
   it('uses a concise title in narrow or unlabeled contexts', () => {
@@ -103,6 +112,7 @@ describe('WorkPlanReader display model', () => {
   it.each([
     { availableRows: 1, bodyRows: 0 },
     { availableRows: 2, bodyRows: 1 },
+    { availableRows: 3, bodyRows: 2 },
   ])(
     'uses a borderless title and $bodyRows body rows in a $availableRows-row viewport',
     ({ availableRows, bodyRows }) => {

--- a/src/test-kernel/cli/WorkPlanReader.vitest.ts
+++ b/src/test-kernel/cli/WorkPlanReader.vitest.ts
@@ -77,7 +77,12 @@ describe('WorkPlanReader display model', () => {
         contentWidth: 16,
         title: 'Work plan: proof',
       }),
-    ).toEqual({ bodyRows: 5, showFooter: true, showTitle: true });
+    ).toEqual({
+      bodyRows: 5,
+      showBorder: true,
+      showFooter: true,
+      showTitle: true,
+    });
   });
 
   it('drops chrome before exceeding a very short row budget', () => {
@@ -87,6 +92,32 @@ describe('WorkPlanReader display model', () => {
         contentWidth: 1,
         title: 'Work plan',
       }),
-    ).toEqual({ bodyRows: 2, showFooter: false, showTitle: false });
+    ).toEqual({
+      bodyRows: 2,
+      showBorder: true,
+      showFooter: false,
+      showTitle: false,
+    });
   });
+
+  it.each([
+    { availableRows: 1, bodyRows: 0 },
+    { availableRows: 2, bodyRows: 1 },
+  ])(
+    'uses a borderless title and $bodyRows body rows in a $availableRows-row viewport',
+    ({ availableRows, bodyRows }) => {
+      expect(
+        workPlanReaderLayout({
+          availableRows,
+          contentWidth: 1,
+          title: 'Work plan: a narrow stream',
+        }),
+      ).toEqual({
+        bodyRows,
+        showBorder: false,
+        showFooter: false,
+        showTitle: true,
+      });
+    },
+  );
 });

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -2601,6 +2601,9 @@ describe('StreamSnapshotStore', () => {
       plan: PLAN,
       todos: [TODO],
     });
+    const newerRefresh = store.preload([STREAM], {
+      reportArtifactAuthority: true,
+    });
     failRead.resolve();
     const error = await refresh.catch((cause) => cause);
     expect(error).toBeInstanceOf(StreamSnapshotPreloadError);
@@ -2616,6 +2619,7 @@ describe('StreamSnapshotStore', () => {
         plan: true,
       },
     });
+    await newerRefresh;
 
     readSpy.mockRestore();
     await store.flush();

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -2569,43 +2569,65 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('reports and retains authoritative work-plan state after preload fails', async () => {
+    const previous = await storeWithPersistedPlan();
+    previous.evictAll();
+    const readError = new Error('snapshot disk is unreadable');
+    const read = StorageFS.read.bind(StorageFS);
+    const readStarted = pDefer<void>();
+    const failRead = pDefer<void>();
+    let shouldFailRead = true;
+    const readSpy = vi
+      .spyOn(StorageFS, 'read')
+      .mockImplementation(async (...args) => {
+        if (shouldFailRead && args[0].startsWith(streamDataDir(STREAM))) {
+          shouldFailRead = false;
+          readStarted.resolve();
+          await failRead.promise;
+          throw readError;
+        }
+        return read(...args);
+      });
     const store = new StreamSnapshotStore();
-    await store.load([]);
-    const writeSpy = vi
-      .spyOn(StorageFS, 'writeAtomic')
-      .mockRejectedValue(new Error('snapshot disk is full'));
+    const output = outputFile('accepted-live.tex', 1);
 
-    snapshotFacts(store).setPlan(STREAM, PLAN);
-    await vi.waitFor(() => expect(writeSpy).toHaveBeenCalledOnce());
     const refresh = store.preload([STREAM], {
       reportArtifactAuthority: true,
     });
+    await readStarted.promise;
+    snapshotFacts(store).setPlan(STREAM, PLAN);
     snapshotFacts(store).setTodos(STREAM, [TODO]);
+    snapshotFacts(store).addOutputFiles(STREAM, { 1: [output] });
     expect(store.getWorkPlan(STREAM)).toMatchObject({
       plan: PLAN,
       todos: [TODO],
     });
+    failRead.resolve();
     const error = await refresh.catch((cause) => cause);
     expect(error).toBeInstanceOf(StreamSnapshotPreloadError);
     expect(error).toMatchObject({
-      message: expect.stringContaining('Sidecar writes remain dirty'),
+      message: expect.stringContaining('snapshot disk is unreadable'),
       streamId: STREAM,
       authoritativeFields: {
-        outputFiles: true,
-        missingOutputs: true,
-        compileFailures: true,
-        usage: true,
+        outputFiles: false,
+        missingOutputs: false,
+        compileFailures: false,
+        usage: false,
         todos: true,
         plan: true,
       },
     });
 
-    writeSpy.mockRestore();
+    readSpy.mockRestore();
     await store.flush();
 
     expect(await reloadWorkPlan()).toMatchObject({
       plan: PLAN,
       todos: [TODO],
+    });
+    expect(
+      (await readStreamFile(STREAM, 'outputFiles.json')) as object,
+    ).toEqual({
+      1: [output],
     });
   });
 

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -34,7 +34,11 @@ import {
 } from '@test/support/tempDirPlatform';
 import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 import { snapshotFacts } from '@test/support/storeTestDrivers';
-import { StreamSnapshotStore, streamDataDir } from '@transcript';
+import {
+  StreamSnapshotPreloadError,
+  StreamSnapshotStore,
+  streamDataDir,
+} from '@transcript';
 import type { StagedStreamSnapshotDeletion } from '@transcript/StagedDeletionCoordinator';
 import {
   stagedStreamDataDir,
@@ -2564,7 +2568,7 @@ describe('StreamSnapshotStore', () => {
     expect((await reloadWorkPlan()).plan).toEqual(revisedPlan);
   });
 
-  it('retains a mutation queued during a failed refresh', async () => {
+  it('reports and retains authoritative work-plan state after preload fails', async () => {
     const store = new StreamSnapshotStore();
     await store.load([]);
     const writeSpy = vi
@@ -2573,9 +2577,28 @@ describe('StreamSnapshotStore', () => {
 
     snapshotFacts(store).setPlan(STREAM, PLAN);
     await vi.waitFor(() => expect(writeSpy).toHaveBeenCalledOnce());
-    const refresh = store.load([STREAM]);
+    const refresh = store.preload([STREAM], {
+      reportArtifactAuthority: true,
+    });
     snapshotFacts(store).setTodos(STREAM, [TODO]);
-    await expect(refresh).rejects.toThrow('Sidecar writes remain dirty');
+    expect(store.getWorkPlan(STREAM)).toMatchObject({
+      plan: PLAN,
+      todos: [TODO],
+    });
+    const error = await refresh.catch((cause) => cause);
+    expect(error).toBeInstanceOf(StreamSnapshotPreloadError);
+    expect(error).toMatchObject({
+      message: expect.stringContaining('Sidecar writes remain dirty'),
+      streamId: STREAM,
+      authoritativeFields: {
+        outputFiles: true,
+        missingOutputs: true,
+        compileFailures: true,
+        usage: true,
+        todos: true,
+        plan: true,
+      },
+    });
 
     writeSpy.mockRestore();
     await store.flush();

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -348,10 +348,12 @@ function artifactAuthorityAfterPreloadFailure(
 ): StreamArtifactAuthority {
   if (baseline !== 'unknown') return ALL_STREAM_ARTIFACTS_AUTHORITATIVE;
   return {
-    outputFiles: overlays.outputFiles !== undefined,
-    missingOutputs: overlays.missingOutputs !== undefined,
-    compileFailures: overlays.compileFailures !== undefined,
-    usage: overlays.usage !== undefined,
+    // These four overlays are deltas over an unread disk baseline, so they do
+    // not establish the complete field value. Plan and todos are replacements.
+    outputFiles: false,
+    missingOutputs: false,
+    compileFailures: false,
+    usage: false,
     todos: overlays.workPlan?.todos !== undefined,
     plan: overlays.workPlan?.plan !== undefined,
   };
@@ -1891,12 +1893,7 @@ export class StreamSnapshotStore {
       });
       return;
     }
-    await pMap(
-      streamIds,
-      (streamId) =>
-        this.refreshSeed(streamId, options?.reportArtifactAuthority),
-      { concurrency: SEED_IO_CONCURRENCY },
-    );
+    await this.seedStreams(streamIds, options?.reportArtifactAuthority);
   }
 
   private async seedUsageOnly(streamId: StreamTabId): Promise<void> {
@@ -1926,10 +1923,15 @@ export class StreamSnapshotStore {
     current.usageProvenance = true;
   }
 
-  private async seedStreams(streamIds: readonly StreamTabId[]): Promise<void> {
-    await pMap(streamIds, (streamId) => this.refreshSeed(streamId), {
-      concurrency: SEED_IO_CONCURRENCY,
-    });
+  private async seedStreams(
+    streamIds: readonly StreamTabId[],
+    reportArtifactAuthority = false,
+  ): Promise<void> {
+    await pMap(
+      streamIds,
+      (streamId) => this.refreshSeed(streamId, reportArtifactAuthority),
+      { concurrency: SEED_IO_CONCURRENCY },
+    );
   }
 
   private evictStreamsExcept(keep: ReadonlySet<StreamTabId>): void {
@@ -1967,17 +1969,18 @@ export class StreamSnapshotStore {
           }
         },
         (error: unknown) => {
-          const authoritativeFields = reportArtifactAuthority
-            ? artifactAuthorityAfterPreloadFailure(
-                refreshBaseline,
-                record.overlays,
-              )
-            : undefined;
           const current = this.records.get(stream);
+          let authoritativeFields: StreamArtifactAuthority | undefined;
           if (
             current?.seedRefreshGeneration === refreshGeneration &&
             this.streamVersion(stream) === version
           ) {
+            if (reportArtifactAuthority) {
+              authoritativeFields = artifactAuthorityAfterPreloadFailure(
+                refreshBaseline,
+                current.overlays,
+              );
+            }
             current.diskState = refreshBaseline;
             current.seedRefreshBaseline = undefined;
             if (refreshBaseline !== 'unknown') {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -99,6 +99,38 @@ const MAX_DIRTY_WRITE_RETRIES = 3;
 
 class DirtySidecarWritesError extends Error {}
 
+/** Artifact fields whose in-memory values remain authoritative after preload fails. */
+export interface StreamArtifactAuthority {
+  readonly outputFiles: boolean;
+  readonly missingOutputs: boolean;
+  readonly compileFailures: boolean;
+  readonly usage: boolean;
+  readonly todos: boolean;
+  readonly plan: boolean;
+}
+
+const ALL_STREAM_ARTIFACTS_AUTHORITATIVE = Object.freeze({
+  outputFiles: true,
+  missingOutputs: true,
+  compileFailures: true,
+  usage: true,
+  todos: true,
+  plan: true,
+}) satisfies StreamArtifactAuthority;
+
+/** A failed preload together with the in-memory fields that remain usable. */
+export class StreamSnapshotPreloadError extends Error {
+  readonly name = 'StreamSnapshotPreloadError';
+
+  constructor(
+    cause: unknown,
+    readonly streamId: StreamTabId,
+    readonly authoritativeFields: StreamArtifactAuthority,
+  ) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+  }
+}
+
 /**
  * The run facts this store subscribes to, and the single source of truth for
  * the `attachSessionEvents` run-fact switch.
@@ -309,6 +341,21 @@ function mergeUsagePatch(
  * without a disk read. Never inferred from any global fact (#9956).
  */
 type DiskState = 'unknown' | 'verified-absent' | 'loaded';
+
+function artifactAuthorityAfterPreloadFailure(
+  baseline: DiskState,
+  overlays: Partial<OverlayPatches>,
+): StreamArtifactAuthority {
+  if (baseline !== 'unknown') return ALL_STREAM_ARTIFACTS_AUTHORITATIVE;
+  return {
+    outputFiles: overlays.outputFiles !== undefined,
+    missingOutputs: overlays.missingOutputs !== undefined,
+    compileFailures: overlays.compileFailures !== undefined,
+    usage: overlays.usage !== undefined,
+    todos: overlays.workPlan?.todos !== undefined,
+    plan: overlays.workPlan?.plan !== undefined,
+  };
+}
 
 /**
  * Every per-stream field this store tracks, keyed by stream id in ONE map
@@ -1826,10 +1873,17 @@ export class StreamSnapshotStore {
    * it for parked WAITING streams so the status-bar usage total is correct
    * immediately without making the full 6-file record resident for the whole
    * session (#9947, #10520).
+   *
+   * `reportArtifactAuthority` wraps a failed full preload with the fields whose
+   * prior seed or live overlay remains authoritative, so a reader may retain
+   * accepted in-memory state without treating unread disk defaults as facts.
    */
   async preload(
     streamIds: readonly StreamTabId[],
-    options?: { readonly usageOnly?: boolean },
+    options?: {
+      readonly usageOnly?: boolean;
+      readonly reportArtifactAuthority?: boolean;
+    },
   ): Promise<void> {
     if (options?.usageOnly) {
       await pMap(streamIds, (streamId) => this.seedUsageOnly(streamId), {
@@ -1837,7 +1891,12 @@ export class StreamSnapshotStore {
       });
       return;
     }
-    await this.seedStreams(streamIds);
+    await pMap(
+      streamIds,
+      (streamId) =>
+        this.refreshSeed(streamId, options?.reportArtifactAuthority),
+      { concurrency: SEED_IO_CONCURRENCY },
+    );
   }
 
   private async seedUsageOnly(streamId: StreamTabId): Promise<void> {
@@ -1879,7 +1938,10 @@ export class StreamSnapshotStore {
     }
   }
 
-  private refreshSeed(stream: StreamTabId): Promise<void> {
+  private refreshSeed(
+    stream: StreamTabId,
+    reportArtifactAuthority = false,
+  ): Promise<void> {
     const version = this.streamVersion(stream);
     const record = this.getOrCreateRecord(stream);
     const refreshBaseline = record.seedRefreshBaseline ?? record.diskState;
@@ -1905,6 +1967,12 @@ export class StreamSnapshotStore {
           }
         },
         (error: unknown) => {
+          const authoritativeFields = reportArtifactAuthority
+            ? artifactAuthorityAfterPreloadFailure(
+                refreshBaseline,
+                record.overlays,
+              )
+            : undefined;
           const current = this.records.get(stream);
           if (
             current?.seedRefreshGeneration === refreshGeneration &&
@@ -1916,6 +1984,13 @@ export class StreamSnapshotStore {
               this.persistEagerOverlays(stream, current);
             }
             if (current.seedChain === next) current.seedChain = undefined;
+          }
+          if (authoritativeFields) {
+            throw new StreamSnapshotPreloadError(
+              error,
+              stream,
+              authoritativeFields,
+            );
           }
           throw error;
         },

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1970,17 +1970,18 @@ export class StreamSnapshotStore {
         },
         (error: unknown) => {
           const current = this.records.get(stream);
-          let authoritativeFields: StreamArtifactAuthority | undefined;
+          const versionIsCurrent = this.streamVersion(stream) === version;
+          const authoritativeFields =
+            reportArtifactAuthority && current && versionIsCurrent
+              ? artifactAuthorityAfterPreloadFailure(
+                  refreshBaseline,
+                  current.overlays,
+                )
+              : undefined;
           if (
             current?.seedRefreshGeneration === refreshGeneration &&
-            this.streamVersion(stream) === version
+            versionIsCurrent
           ) {
-            if (reportArtifactAuthority) {
-              authoritativeFields = artifactAuthorityAfterPreloadFailure(
-                refreshBaseline,
-                current.overlays,
-              );
-            }
             current.diskState = refreshBaseline;
             current.seedRefreshBaseline = undefined;
             if (refreshBaseline !== 'unknown') {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1974,7 +1974,9 @@ export class StreamSnapshotStore {
           const authoritativeFields =
             reportArtifactAuthority && current && versionIsCurrent
               ? artifactAuthorityAfterPreloadFailure(
-                  refreshBaseline,
+                  refreshBaseline === 'unknown'
+                    ? current.diskState
+                    : refreshBaseline,
                   current.overlays,
                 )
               : undefined;

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -29,7 +29,11 @@ export {
   SPILL_ARTIFACT_DELETED_MESSAGE,
 } from './spillArtifacts';
 export { streamDataDir } from './streamDataPaths';
-export { StreamSnapshotStore } from './StreamSnapshotStore';
+export {
+  StreamSnapshotPreloadError,
+  StreamSnapshotStore,
+  type StreamArtifactAuthority,
+} from './StreamSnapshotStore';
 export { assembleTrace, type AssembleTraceResult } from './traceAssembler';
 export type { TraceDocument } from './traceDocumentSchema';
 export {


### PR DESCRIPTION
## Summary

Preserve accepted live work plans when disk snapshot preload fails, and keep the plan reader usable in one- and two-row terminals.

Preload failures now report which artifact fields remain authoritative. The `/plan` command uses that authority to distinguish an accepted live plan from unavailable disk state, without projecting unrelated artifact warnings.

## Issue acceptance gates

No linked issue.

- An accepted live plan or todo list remains available after a snapshot preload failure.
- The command reports that no plan exists only when both authoritative plan fields are empty.
- A genuine preload failure still produces an error when no plan field is authoritative.
- The reader renders a useful title or body in terminals with only one or two rows.

## Single source of truth

`StreamSnapshotStore` owns both artifact values and their authority. Hydration and command handling consume the same `StreamArtifactAuthority` mask instead of inferring authority independently.

## Duplication and abstraction budget

One authority mask represents the same fields on successful and failed preloads. The compact reader constructs its body once and only varies the frame at the terminal boundary. No pass-through layer was added.

## Net elements (R6)

n/a — this is a focused recovery and rendering fix, not a refactor PR.

## Consumer counts (R8)

n/a — no emit path or export was deleted or rerouted.

## Host impact

Extension: None.

Desktop: None.

CLI: Work-plan preload recovery and small-terminal rendering are corrected.

## Scheduled refactoring

None.

## Validation

- Focused Vitest suite: 148 tests passed across StreamSnapshotStore, SubscribeStreamArtifacts, SlashCommandDispatch, and WorkPlanReader.
- Root TypeScript check passed.
- Test-kernel TypeScript check passed.
- CLI application and scripts TypeScript checks passed.
- Changed-file ESLint check passed.
- Changed-file Prettier check passed.
- Guidance-reference check passed.
- CLI architecture check passed.
- Dead-code ratchet reported no new findings.
- `git diff --check` passed.
- Repository pre-push hook passed.
- The pre-commit formatter wrapper could not perform its interactive linked-`node_modules` maintenance in the temporary worktree; the equivalent direct Prettier check passed.