### PR TITLE
fix: default Google background responses off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Shared (all surfaces)
+
+#### Bug Fixes
+
+- **Google background responses are off by default** — Gemini workflow
+  generations stay on the live request unless you turn them on in the Google
+  provider settings. OpenAI's background setting is unchanged.
+
 ## [0.40.4] - 2026-08-23
 
 ### Shared (all surfaces)

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -501,7 +501,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       !this.backgroundUnsupported &&
       stateful &&
       this.isWorkflowMode() &&
-      getConfig<boolean>('texra.model.useBackgroundResponses', true)
+      getConfig<boolean>('texra.model.useGoogleBackgroundResponses', false)
     );
   }
 

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -102,6 +102,7 @@ export const DEFAULT_CORE_SETTINGS = {
   model: {
     useOpenAIResponsesAPI: true,
     useGoogleInteractionsServerState: true,
+    useGoogleBackgroundResponses: false,
     useBackgroundResponses: true,
     openaiParallelToolCalls: true,
     compactionThresholdPercent: MODEL_COMPACTION_THRESHOLD_SETTING.defaultValue,
@@ -252,6 +253,10 @@ export const CoreSettingsShape = {
       useGoogleInteractionsServerState: boolField(
         DEFAULT_CORE_SETTINGS.model.useGoogleInteractionsServerState,
         "Store Google Interactions conversation state on Google's servers via previous_interaction_id chaining, sending only the new turn each round. Google then retains the conversation for a limited period to enable chaining. Enabled by default. Disable to keep conversations off Google's servers — stateless mode resends the full transcript each round (store:false).",
+      ),
+      useGoogleBackgroundResponses: boolField(
+        DEFAULT_CORE_SETTINGS.model.useGoogleBackgroundResponses,
+        'Run long-running Google workflow generations as background Interactions (submit + poll) to avoid timeouts. Off by default. Requires server-side conversation state; models that do not support it fall back automatically.',
       ),
       useBackgroundResponses: boolField(
         DEFAULT_CORE_SETTINGS.model.useBackgroundResponses,
@@ -485,6 +490,7 @@ export const CORE_SETTING_PATHS = [
   'model.gpt5ReasoningSummary',
   'model.useOpenAIResponsesAPI',
   'model.useGoogleInteractionsServerState',
+  'model.useGoogleBackgroundResponses',
   'model.useBackgroundResponses',
   'model.openaiParallelToolCalls',
   'model.compactionThresholdPercent',

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -396,7 +396,7 @@ const CORE_SETTING_ROWS: Record<CoreSettingPath, CoreRowSpec> = {
   'goal.enabled': {
     honoredBy: everyHost('src/tools/goal/goalFeatureFlag.ts'),
   },
-  // The five Models-tab provider toggles below are `configTarget: 'global'`:
+  // The Models-tab provider toggles below are `configTarget: 'global'`:
   // they describe how you talk to a provider, not a property of one project,
   // and that is the scope they were written at before the catalog collapse
   // routed them through the shared write path. The target restores global
@@ -464,6 +464,25 @@ const CORE_SETTING_ROWS: Record<CoreSettingPath, CoreRowSpec> = {
       ],
     },
   },
+  'model.useGoogleBackgroundResponses': {
+    configTarget: 'global',
+    title: 'Google background responses',
+    category: 'model',
+    honoredBy: everyHost(
+      'src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts',
+    ),
+    surfaces: {
+      settingsView: 'profile',
+      models: [
+        {
+          provider: 'google',
+          label: 'Background responses',
+          description:
+            'Run long-running workflow generations as background Interactions (submit + poll) to avoid timeouts. Off by default. Requires server-side conversation state; models that do not support it fall back automatically.',
+        },
+      ],
+    },
+  },
   'model.useBackgroundResponses': {
     configTarget: 'global',
     title: 'Background responses',
@@ -479,12 +498,6 @@ const CORE_SETTING_ROWS: Record<CoreSettingPath, CoreRowSpec> = {
           label: 'Background responses',
           description:
             'Handle long-running generations (>10 min) via polling to prevent timeouts. Adds polling overhead.',
-        },
-        {
-          provider: 'google',
-          label: 'Background responses',
-          description:
-            'Run long-running workflow generations as background Interactions (submit + poll) to avoid timeouts. Requires server-side conversation state; models that do not support it fall back automatically.',
         },
       ],
     },

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
@@ -174,7 +174,7 @@ function mockConfig(
           typeof serverState === 'function' ? serverState() : serverState
         ) as T;
       }
-      if (key === 'texra.model.useBackgroundResponses') {
+      if (key === 'texra.model.useGoogleBackgroundResponses') {
         return (
           typeof background === 'function' ? background() : background
         ) as T;

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsLive.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsLive.vitest.ts
@@ -108,7 +108,8 @@ function mockConfig(background: boolean): void {
     <T>(k: string, d?: T): T => {
       if (k === 'texra.model.useGoogleInteractionsServerState')
         return true as T;
-      if (k === 'texra.model.useBackgroundResponses') return background as T;
+      if (k === 'texra.model.useGoogleBackgroundResponses')
+        return background as T;
       return orig(k, d);
     },
   );


### PR DESCRIPTION
## Summary

Google background responses now have their own setting and default to off. Gemini workflow generations stay on the live request unless you turn Background responses on in the Google provider settings.

OpenAI's background toggle is unchanged and no longer shares a control with Google.

## Issue acceptance gates

No tracking issue. Gate: a fresh install shows Google Background responses off, and an unset config does not send `background: true`.

## Single source of truth

`texra.model.useGoogleBackgroundResponses` in `coreSettings.ts` / `stateSettings.ts`. `ModelHandlerGoogleInteractions.useBackgroundMode` is the only runtime reader.

## Duplication and abstraction budget

No new abstraction. The Google Models-tab row no longer reuses OpenAI's `useBackgroundResponses` key.

## Net elements (R6)

n/a — bug fix, not a refactor/simplify/extract PR.

## Consumer counts (R8)

n/a — no emit path or existing export was deleted. Google stopped reading `texra.model.useBackgroundResponses`; OpenAI remains the sole reader of that key.

## Host impact

Extension: Google provider card shows Background responses off by default.

Desktop: same catalog-driven toggle.

CLI: same config key, default off.

## Scheduled refactoring

None.

## Validation

- `npx vitest run --config vitest.config.mjs src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts src/test-kernel/controllers/SettingsProfileController.vitest.ts src/test-kernel/shared/stateSettings.vitest.ts` (67 passed, 4 live tests skipped)
- ESLint on the changed TypeScript files
- `npx tsc --noEmit -p tsconfig.json`