### PR TITLE
fix(progress-view): return follow-up admission to sender

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -750,7 +750,7 @@ export class DesktopProgressBridge {
       },
       followUp: {
         session: this.session,
-        acknowledge: (stream, accepted) => {
+        captureAdmissionReporter: () => (stream, accepted) => {
           this.postToRenderer({
             command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_RESULT,
             stream,

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -99,6 +99,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private readonly apiKeyRetryController: ProgressApiKeyRetryController;
   private readonly followUpController: ProgressFollowUpController;
   private readonly followUpPolishController: ProgressFollowUpPolishController;
+  private dispatchSource: vscode.WebviewView | vscode.WebviewPanel | undefined;
   private chatExportController: ChatExportController | undefined;
 
   /**
@@ -370,6 +371,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     );
   }
 
+  protected override onDispatch(
+    webviewView: vscode.WebviewView | vscode.WebviewPanel,
+  ): void {
+    this.dispatchSource = webviewView;
+  }
+
   /**
    * Commands this registry declares `unsupported(...)`, for the derived
    * frontend capability view (see `ProgressBackendOptions.getUnsupportedCommands`).
@@ -529,12 +536,25 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         stopStream: (stream) => this.provider.backend.stopStream(stream),
       },
       followUp: {
-        acknowledge: (stream, accepted) =>
-          this.postToActiveView({
-            command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_RESULT,
-            stream,
-            accepted,
-          }),
+        captureAdmissionReporter: () => {
+          const source = this.dispatchSource?.webview;
+          return (stream, accepted) => {
+            if (!source) return;
+            void Promise.resolve(
+              source.postMessage({
+                command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_RESULT,
+                stream,
+                accepted,
+              }),
+            ).catch((error: unknown) => {
+              this.logger.debug(
+                this.channel,
+                'Follow-up result target is no longer attached',
+                { data: error },
+              );
+            });
+          };
+        },
         reportImageSaveError: (_image, error) => {
           // Best-effort: a failed image save must not block the text, but log
           // it so a missing attachment is diagnosable.

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -539,13 +539,23 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
                 stream,
                 accepted,
               }),
-            ).catch((error: unknown) => {
-              this.logger.debug(
-                this.channel,
-                'Follow-up result target is no longer attached',
-                { data: error },
-              );
-            });
+            ).then(
+              (delivered) => {
+                if (!delivered) {
+                  this.logger.debug(
+                    this.channel,
+                    'Follow-up result target did not accept the message',
+                  );
+                }
+              },
+              (error: unknown) => {
+                this.logger.debug(
+                  this.channel,
+                  'Follow-up result target is no longer attached',
+                  { data: error },
+                );
+              },
+            );
           };
         },
         reportImageSaveError: (_image, error) => {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -99,7 +99,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private readonly apiKeyRetryController: ProgressApiKeyRetryController;
   private readonly followUpController: ProgressFollowUpController;
   private readonly followUpPolishController: ProgressFollowUpPolishController;
-  private dispatchSource: vscode.WebviewView | vscode.WebviewPanel | undefined;
   private chatExportController: ChatExportController | undefined;
 
   /**
@@ -371,12 +370,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     );
   }
 
-  protected override onDispatch(
-    webviewView: vscode.WebviewView | vscode.WebviewPanel,
-  ): void {
-    this.dispatchSource = webviewView;
-  }
-
   /**
    * Commands this registry declares `unsupported(...)`, for the derived
    * frontend capability view (see `ProgressBackendOptions.getUnsupportedCommands`).
@@ -537,7 +530,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       },
       followUp: {
         captureAdmissionReporter: () => {
-          const source = this.dispatchSource?.webview;
+          const source = this.getActiveView()?.webview;
           return (stream, accepted) => {
             if (!source) return;
             void Promise.resolve(

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -190,8 +190,12 @@ interface ProgressViewFollowUpCommandActions {
    * extension omits it so the module default applies.
    */
   session?: SessionHandle;
-  /** Admission ack back to the composer that sent the draft. */
-  acknowledge(stream: StreamTabId, accepted: boolean): void;
+  /**
+   * Capture the admission-result route before image persistence yields. The
+   * extension has two progress surfaces, so resolving through whichever view
+   * is active later can clear a different composer's draft.
+   */
+  captureAdmissionReporter(): (stream: StreamTabId, accepted: boolean) => void;
   reportImageSaveError(image: ProgressViewFollowUpImage, error: unknown): void;
 }
 
@@ -335,6 +339,7 @@ export function createProgressViewCommandHandlers(
       workflowFileActions.openLabel(data.label),
 
     [PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP]: async (data) => {
+      const acknowledge = followUp.captureAdmissionReporter();
       const mediaFiles = await saveFollowUpImages(
         data.images ?? [],
         followUp.reportImageSaveError,
@@ -347,7 +352,7 @@ export function createProgressViewCommandHandlers(
           text: data.text,
           ...(mediaFiles.length > 0 ? { mediaFiles } : {}),
         },
-        acknowledge: (accepted) => followUp.acknowledge(data.stream, accepted),
+        acknowledge: (accepted) => acknowledge(data.stream, accepted),
         showInfo,
       });
     },

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -106,7 +106,7 @@ function createActions(
       handleAction: vi.fn(),
     } as unknown as ProgressAgentProposalController,
     followUp: {
-      acknowledge: vi.fn(),
+      captureAdmissionReporter: vi.fn(() => vi.fn()),
       reportImageSaveError: vi.fn(),
     },
     bypass: { showInfo: vi.fn() },

--- a/src/test-kernel/controllers/ProgressViewRunCommands.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewRunCommands.vitest.ts
@@ -97,7 +97,7 @@ function createHostHarness(
       stopStream: vi.fn(),
     },
     followUp: {
-      acknowledge: vi.fn(),
+      captureAdmissionReporter: vi.fn(() => vi.fn()),
       reportImageSaveError: vi.fn(),
     },
     bypass: {

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import type { ProgressHostInteractions } from '@controllers/progressView/backend/progressHostInteractions';
+import type { ProgressFollowUpSubmitArgs } from '@controllers/progressView/progressFollowUpSubmit';
 import * as logger from '@logger/logUtils';
 import { ProgressViewMessageHandler } from '@progressView/ProgressViewMessageHandler';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
@@ -22,10 +23,15 @@ import type * as vscode from 'vscode';
 
 const mocks = vi.hoisted(() => ({
   safeExecuteCommand: vi.fn(),
+  submitProgressFollowUp: vi.fn(),
 }));
 
 vi.mock('@frontend/system/commandUtils', () => ({
   safeExecuteCommand: mocks.safeExecuteCommand,
+}));
+
+vi.mock('@controllers/progressView/progressFollowUpSubmit', () => ({
+  submitProgressFollowUp: mocks.submitProgressFollowUp,
 }));
 
 function createWebviewView(): vscode.WebviewView {
@@ -132,6 +138,7 @@ describe('progress-view onboarding refresh wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.safeExecuteCommand.mockResolvedValue(undefined);
+    mocks.submitProgressFollowUp.mockResolvedValue(true);
   });
 
   it('refreshes the onboarding funnel after progress setup actions', async () => {
@@ -160,6 +167,53 @@ describe('progress-view onboarding refresh wiring', () => {
         provider.refreshOnboardingFunnel.mock.invocationCallOrder[0]!,
       );
     });
+  });
+
+  it('returns follow-up admission to the originating surface', async () => {
+    let finishSubmission: () => void = () => undefined;
+    mocks.submitProgressFollowUp.mockImplementation(
+      (args: ProgressFollowUpSubmitArgs) =>
+        new Promise<boolean>((resolve) => {
+          finishSubmission = () => {
+            args.acknowledge(true);
+            resolve(true);
+          };
+        }),
+    );
+    const provider = createProgressViewProvider();
+    const handler = createMessageHandler(provider);
+    const sidebar = createWebviewView();
+    const panel = createWebviewView();
+
+    const sending = handler.handleMessage(
+      {
+        command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
+        stream: 'originating-surface',
+        text: 'continue',
+      },
+      sidebar,
+    );
+    await vi.waitFor(() => {
+      expect(mocks.submitProgressFollowUp).toHaveBeenCalledOnce();
+    });
+
+    await handler.handleMessage(
+      { command: PROGRESS_VIEW_COMMANDS.WEBVIEW_READY, view: 'progress' },
+      panel,
+    );
+    finishSubmission();
+    await sending;
+
+    expect(sidebar.webview.postMessage).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_RESULT,
+      stream: 'originating-surface',
+      accepted: true,
+    });
+    expect(panel.webview.postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_RESULT,
+      }),
+    );
   });
 
   it('acknowledges a replacement run when the runtime publishes its handle', async () => {

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
@@ -23,6 +23,7 @@ import type * as vscode from 'vscode';
 
 const mocks = vi.hoisted(() => ({
   safeExecuteCommand: vi.fn(),
+  savePastedImageBase64: vi.fn(),
   submitProgressFollowUp: vi.fn(),
 }));
 
@@ -32,6 +33,10 @@ vi.mock('@frontend/system/commandUtils', () => ({
 
 vi.mock('@controllers/progressView/progressFollowUpSubmit', () => ({
   submitProgressFollowUp: mocks.submitProgressFollowUp,
+}));
+
+vi.mock('@utils/files/pastedImageUtils', () => ({
+  savePastedImageBase64: mocks.savePastedImageBase64,
 }));
 
 function createWebviewView(): vscode.WebviewView {
@@ -138,6 +143,7 @@ describe('progress-view onboarding refresh wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.safeExecuteCommand.mockResolvedValue(undefined);
+    mocks.savePastedImageBase64.mockResolvedValue('/tmp/pasted.png');
     mocks.submitProgressFollowUp.mockResolvedValue(true);
   });
 
@@ -170,6 +176,13 @@ describe('progress-view onboarding refresh wiring', () => {
   });
 
   it('returns follow-up admission to the originating surface', async () => {
+    let finishImageSave: () => void = () => undefined;
+    mocks.savePastedImageBase64.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          finishImageSave = () => resolve('/tmp/pasted.png');
+        }),
+    );
     let finishSubmission: () => void = () => undefined;
     mocks.submitProgressFollowUp.mockImplementation(
       (args: ProgressFollowUpSubmitArgs) =>
@@ -190,17 +203,28 @@ describe('progress-view onboarding refresh wiring', () => {
         command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
         stream: 'originating-surface',
         text: 'continue',
+        images: [
+          {
+            base64: 'aGVsbG8=',
+            mediaType: 'image/png',
+            fileName: 'pasted_origin.png',
+          },
+        ],
       },
       sidebar,
     );
     await vi.waitFor(() => {
-      expect(mocks.submitProgressFollowUp).toHaveBeenCalledOnce();
+      expect(mocks.savePastedImageBase64).toHaveBeenCalledOnce();
     });
 
     await handler.handleMessage(
       { command: PROGRESS_VIEW_COMMANDS.WEBVIEW_READY, view: 'progress' },
       panel,
     );
+    finishImageSave();
+    await vi.waitFor(() => {
+      expect(mocks.submitProgressFollowUp).toHaveBeenCalledOnce();
+    });
     finishSubmission();
     await sending;
 


### PR DESCRIPTION
## Summary

The extension can display the progress view in both the sidebar and an editor panel. Follow-up admission is asynchronous because pasted images are persisted before submission. Previously, the result was posted to whichever surface was active when admission finished, so switching surfaces during submission could clear a different composer or lose the result when the sending document was replaced.

This change captures the sending surface before the first asynchronous operation and returns the admission result through that fixed route. Desktop retains its existing single-renderer route.

## Issue acceptance gates

No linked issue. The focused regression holds image persistence pending, dispatches from the panel, and proves that a sidebar submission still reports its result only to the sidebar.

## Single source of truth

ProgressViewCommandHandlers owns the ordering invariant: it captures the host admission reporter before image persistence yields. Each host remains the single owner of its result-delivery route.

## Duplication and abstraction budget

The existing shared command handler remains the only follow-up submission path. The host port now captures a reporter from the base handler active-view state instead of resolving mutable state after an asynchronous operation; no parallel view state, new module, or pass-through layer was added.

## Net elements (R6)

n/a: this is a focused correctness fix rather than a refactor PR.

## Consumer counts (R8)

n/a: no emit path or export is deleted. Both host implementations of the existing follow-up action port were updated.

## Host impact

Extension: admission results return to the webview that submitted the follow-up; failed or false delivery is logged at debug.

Desktop: behavior is unchanged; the single renderer is captured through the same port contract.

CLI: no impact.

## Scheduled refactoring

#11369 records the analogous, longer-lived follow-up polish result route. It is intentionally outside this admission fix.

## Validation

- 163 focused tests across the shared handlers, extension dual-surface wiring, and desktop bridge
- Root, test-kernel, and desktop TypeScript checks
- ESLint on all changed files
- Prettier check on all changed files
- Guidance-reference check
- Dead-code ratchet
- Repository pre-push hook
- git diff --check