### PR TITLE
feat(progress-view): preserve follow-up drafts and delivery state

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -19,6 +19,7 @@ import { polishTextWithAI } from '@agent/runtime/textEnhancement';
 import {
   presentFollowUpResult,
   submitFollowUp,
+  type SubmitFollowUpResult,
 } from '@agent/followUp/ToolUseFollowUp';
 import {
   dispatchPresentationEvent,
@@ -94,6 +95,7 @@ import {
 } from '@shared/copy/executionHistory';
 import { SESSION_DISPOSED_CAUSE } from '@shared/copy/interactionCancellation';
 import type { MainViewExecuteMessage } from '@shared/schemas/mainView/executeMessage';
+import type { RejectedFollowUpSubmissionResult } from '@shared/schemas/progressView';
 import type { FileOpResult } from '@shared/schemas/opResults';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { cleanupUnscopedApprovals } from '@tools/approval';
@@ -807,7 +809,9 @@ export class DesktopProgressBridge {
             });
           },
         },
-        sendFollowUp: (stream, text) => this.sendFollowUp(stream, text),
+        sendFollowUp: async (stream, text) => {
+          await this.sendFollowUp(stream, text);
+        },
       },
       agentProposal: {
         getPendingProposal: (proposalId) =>
@@ -851,13 +855,22 @@ export class DesktopProgressBridge {
           stopStream: (stream) => this.backend.stopStream(stream),
         },
         followUp: {
-          sendFollowUp: ({ stream, text, mediaFiles }) =>
-            this.sendFollowUp(stream, text, mediaFiles),
-          reportImageSaveError: (image, error) => {
-            this.logger.warn(
-              `Failed to save pasted follow-up image ${image.fileName}`,
-              { data: toLogData(error) },
-            );
+          getCurrentTargetMetadata: (stream) => ({
+            userFollowUpSupport:
+              this.state.getStreamMetadata(stream).userFollowUpSupport,
+            status: this.session.status.get(stream),
+          }),
+          sendFollowUp: ({ stream, text, deliveryId, mediaFiles }) =>
+            this.sendFollowUp(stream, text, mediaFiles, deliveryId),
+          captureSubmissionResultReporter: () => (result) => {
+            this.postToRenderer(result);
+          },
+          reportImageSaveError: (_image, error) => {
+            this.logger.warn('Failed to save pasted follow-up image', {
+              data: {
+                category: error instanceof Error ? 'error' : 'non-error',
+              },
+            });
           },
         },
         bypass: {
@@ -1108,9 +1121,18 @@ export class DesktopProgressBridge {
     this.syncStreamContent(this.updateStreamMetadata());
   }
 
+  reportRejectedFollowUpSubmission(
+    result: RejectedFollowUpSubmissionResult,
+  ): void {
+    this.postToRenderer(result);
+  }
+
   /** Send canonical state and replay pending prompts after attachment. */
   async completeWebviewReady(): Promise<void> {
     this.syncFullView();
+    this.postToRenderer({
+      command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TRANSPORT_RESTORED,
+    });
     await replayApprovalRequestHandlers(this.backend.approvalHandlers);
   }
 
@@ -1234,54 +1256,44 @@ export class DesktopProgressBridge {
     };
   }
 
-  private sendFollowUp(
+  private async sendFollowUp(
     streamId: StreamTabId,
     text: string,
     mediaFiles?: readonly string[],
-  ): Promise<void> {
+    deliveryId?: string,
+  ): Promise<SubmitFollowUpResult> {
     // Resolve the follow-up target against the process session: the run's
     // handle is tracked in `this.session`, but this IPC path runs outside the
-    // run ALS, so the module default (currentSession ⇒ defaultSession) would
-    // look in the wrong registry and report `no_session` for a live run.
-    // Admission and the recovery claim happen synchronously inside
-    // submitFollowUp. Presentation remains detached because recovery may run a
-    // complete agent turn; closing a desktop window must not await that turn.
-    void submitFollowUp(
-      streamId,
-      { text, mediaFiles },
-      { session: this.session },
-    )
-      .then(async (result) => {
-        if (result.status === 'sent' || result.status === 'queued') {
-          this.session.events.emit({
-            scope: 'session',
-            event: {
-              type: 'updateQueuedFollowUps',
-              payload: { streamId },
-            },
-          });
-          const presentation = presentFollowUpResult(result);
-          if (presentation.severity !== 'none') {
-            await this.session.interactions.showInfoMessage(
-              presentation.message,
-              {
-                replayWhenAttached: true,
-              },
-            );
-          }
-          return;
-        }
-
-        await this.options.host.showInfoMessage(
-          'No active session. Start a new agent task to continue.',
-        );
-      })
-      .catch((error: unknown) => {
-        this.logger.warn(`Failed to submit follow-up for stream ${streamId}`, {
-          data: toLogData(error),
+    // run ALS, so the module default would inspect the wrong registry.
+    try {
+      const result = await submitFollowUp(
+        streamId,
+        { text, mediaFiles, deliveryId },
+        { session: this.session },
+      );
+      if (result.status === 'sent' || result.status === 'queued') {
+        this.session.events.emit({
+          scope: 'session',
+          event: {
+            type: 'updateQueuedFollowUps',
+            payload: { streamId },
+          },
         });
+        const presentation = presentFollowUpResult(result);
+        if (presentation.severity !== 'none') {
+          await this.session.interactions.showInfoMessage(
+            presentation.message,
+            { replayWhenAttached: true },
+          );
+        }
+      }
+      return result;
+    } catch (error: unknown) {
+      this.logger.warn(`Failed to submit follow-up for stream ${streamId}`, {
+        data: toLogData(error),
       });
-    return Promise.resolve();
+      throw error;
+    }
   }
 
   openFileCompile(filePath: string): Promise<void> {

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -2,7 +2,9 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   dispatchProgressViewInbound,
   ProgressViewInboundMessageSchema,
+  rejectedInvalidFollowUpSubmission,
   type ProgressViewInboundHandlerRegistry,
+  type RejectedFollowUpSubmissionResult,
   type ProgressViewInboundMessage,
 } from '@shared/schemas/progressView';
 import { UnsupportedCommandError } from '@shared/utils/dispatcher';
@@ -31,6 +33,9 @@ export type DesktopProgressInboundHandlerRegistry = Omit<
 interface DesktopProgressIpcBridge {
   readonly progressViewInboundHandlers: DesktopProgressInboundHandlerRegistry;
   completeWebviewReady(): Promise<void>;
+  reportRejectedFollowUpSubmission(
+    result: RejectedFollowUpSubmissionResult,
+  ): void;
 }
 
 interface DesktopProgressSource {
@@ -105,6 +110,13 @@ export function createDesktopProgressIpc(
 
   return {
     handleMessage(message: DesktopCommandMessage): boolean {
+      const rejectedFollowUp = rejectedInvalidFollowUpSubmission(message);
+      if (rejectedFollowUp) {
+        withProgress((progress) =>
+          progress.reportRejectedFollowUpSubmission(rejectedFollowUp),
+        );
+        return true;
+      }
       const result = ProgressViewInboundMessageSchema.safeParse(message);
       if (!result.success) return false;
 

--- a/packages/desktop/src/main/desktopWebviewStateStore.ts
+++ b/packages/desktop/src/main/desktopWebviewStateStore.ts
@@ -1,0 +1,106 @@
+import { mkdirSync, readFileSync, renameSync, rmSync, statSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { dirname, join } from 'node:path';
+
+import writeFileAtomic from 'write-file-atomic';
+
+import { MAX_FOLLOW_UP_PAYLOAD_BYTES } from '@shared/schemas/progressView';
+
+const MAX_DESKTOP_WEBVIEW_STATE_BYTES = MAX_FOLLOW_UP_PAYLOAD_BYTES;
+const INVALID_STATE_SUFFIX = '.invalid';
+const PERSISTENCE_ERROR = 'Desktop webview state could not be persisted.';
+
+type WebviewState = Record<string, unknown>;
+
+function isRecord(value: unknown): value is WebviewState {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function quarantine(filePath: string): void {
+  try {
+    renameSync(filePath, `${filePath}${INVALID_STATE_SUFFIX}`);
+  } catch {
+    try {
+      rmSync(filePath, { force: true });
+    } catch {
+      // Read-only invalid state is treated as absent without logging it.
+    }
+  }
+}
+
+/**
+ * Main-process authority for one logical desktop window's renderer state.
+ * Reads reject oversized bytes before JSON.parse. Atomic writes preserve the
+ * previous file if serialization or replacement fails.
+ */
+export class DesktopWebviewStateStore {
+  constructor(private readonly filePath: string) {}
+
+  getState(): WebviewState | undefined {
+    let size: number;
+    try {
+      size = statSync(this.filePath).size;
+    } catch {
+      return undefined;
+    }
+    if (size > MAX_DESKTOP_WEBVIEW_STATE_BYTES) {
+      quarantine(this.filePath);
+      return undefined;
+    }
+    let serialized: string;
+    try {
+      serialized = readFileSync(this.filePath, 'utf8');
+    } catch {
+      return undefined;
+    }
+    if (
+      Buffer.byteLength(serialized, 'utf8') > MAX_DESKTOP_WEBVIEW_STATE_BYTES
+    ) {
+      quarantine(this.filePath);
+      return undefined;
+    }
+    try {
+      const parsed: unknown = JSON.parse(serialized);
+      if (isRecord(parsed)) return parsed;
+    } catch {
+      // Invalid state is quarantined below without exposing its payload.
+    }
+    quarantine(this.filePath);
+    return undefined;
+  }
+
+  setState(state: unknown): void {
+    if (!isRecord(state)) throw new Error(PERSISTENCE_ERROR);
+    let serialized: string;
+    try {
+      serialized = JSON.stringify(state);
+    } catch {
+      throw new Error(PERSISTENCE_ERROR);
+    }
+    if (
+      Buffer.byteLength(serialized, 'utf8') > MAX_DESKTOP_WEBVIEW_STATE_BYTES
+    ) {
+      throw new Error(PERSISTENCE_ERROR);
+    }
+    try {
+      mkdirSync(dirname(this.filePath), { recursive: true, mode: 0o700 });
+      writeFileAtomic.sync(this.filePath, serialized, {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
+    } catch {
+      throw new Error(PERSISTENCE_ERROR);
+    }
+  }
+}
+
+/** Keep renderer state under userData and separate it by logical workspace window. */
+export function desktopWebviewStatePath(
+  userDataPath: string,
+  workspacePath: string | undefined,
+): string {
+  const scope = createHash('sha256')
+    .update(workspacePath ?? 'no-workspace')
+    .digest('hex');
+  return join(userDataPath, 'window-state', `${scope}.json`);
+}

--- a/packages/desktop/src/main/hostBridge.ts
+++ b/packages/desktop/src/main/hostBridge.ts
@@ -7,10 +7,18 @@ import { assertKnownOutboundMessage } from '@shared/utils/dispatcher';
 import {
   ELECTRON_WEBVIEW_MESSAGE_CHANNEL,
   ELECTRON_WEBVIEW_PUSH_CHANNEL,
+  ELECTRON_WEBVIEW_STATE_GET_CHANNEL,
+  ELECTRON_WEBVIEW_STATE_SET_CHANNEL,
 } from '../shared/hostBridgeChannels.js';
+
+interface DesktopWebviewStateStore {
+  getState(): Record<string, unknown> | undefined;
+  setState(state: unknown): void;
+}
 
 export interface DesktopHostBridgeOptions {
   onRendererMessage?: (message: unknown, window: BrowserWindow) => void;
+  webviewState?: DesktopWebviewStateStore;
 }
 
 export interface DesktopHostBridge {
@@ -27,12 +35,33 @@ export function installDesktopHostBridge(
     if (event.sender !== window.webContents) return;
     options.onRendererMessage?.(message, window);
   };
+  const getState = (event: IpcMainEvent) => {
+    if (event.sender !== window.webContents) return;
+    event.returnValue = { ok: true, state: options.webviewState?.getState() };
+  };
+  const setState = (event: IpcMainEvent, state: unknown) => {
+    if (event.sender !== window.webContents) return;
+    if (!options.webviewState) {
+      event.returnValue = { ok: false };
+      return;
+    }
+    try {
+      options.webviewState.setState(state);
+      event.returnValue = { ok: true };
+    } catch {
+      event.returnValue = { ok: false };
+    }
+  };
   ipcMain.on(ELECTRON_WEBVIEW_MESSAGE_CHANNEL, listener);
+  ipcMain.on(ELECTRON_WEBVIEW_STATE_GET_CHANNEL, getState);
+  ipcMain.on(ELECTRON_WEBVIEW_STATE_SET_CHANNEL, setState);
 
   const dispose = () => {
     if (disposed) return;
     disposed = true;
     ipcMain.off(ELECTRON_WEBVIEW_MESSAGE_CHANNEL, listener);
+    ipcMain.off(ELECTRON_WEBVIEW_STATE_GET_CHANNEL, getState);
+    ipcMain.off(ELECTRON_WEBVIEW_STATE_SET_CHANNEL, setState);
   };
   window.once('closed', dispose);
   return {
@@ -43,7 +72,7 @@ export function installDesktopHostBridge(
       // desktop-only overlay/settings commands (`desktop:showPdf`,
       // git-author settings, history, ...) onto this one renderer-push
       // channel; only the first two domains have an outbound Zod schema
-      // today — a command belonging to neither passes through unchecked.
+      // today. A command belonging to neither passes through unchecked.
       assertKnownOutboundMessage(
         [MainViewMessageSchema, ProgressViewOutboundMessageSchema],
         message,

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -81,6 +81,10 @@ import {
 } from './desktopOnboardingIpc.js';
 import { DesktopPromptController } from './desktopPromptController.js';
 import { createDesktopProgressIpc } from './desktopProgressIpc.js';
+import {
+  DesktopWebviewStateStore,
+  desktopWebviewStatePath,
+} from './desktopWebviewStateStore.js';
 import { DefaultDesktopAgentSettingsController } from './desktopAgentSettingsController.js';
 import { DefaultDesktopCredentialSettingsController } from './desktopCredentialSettingsController.js';
 import { DesktopHistoryHandlers } from './desktopHistoryHandlers.js';
@@ -233,6 +237,9 @@ function createWindow(options: {
   const initialWindowTitle = getDesktopWindowTitle(
     options.processSession,
     options.workspacePath,
+  );
+  const webviewState = new DesktopWebviewStateStore(
+    desktopWebviewStatePath(app.getPath('userData'), options.workspacePath),
   );
   const window = new BrowserWindow({
     // The task canvas remains useful with a project sidebar and an optional
@@ -1056,6 +1063,7 @@ function createWindow(options: {
       authenticated: await SupabaseClient.isAuthenticated(),
     }),
     onAsyncError: reportAsyncError,
+    webviewState,
   });
   ipcRef.current = mainViewIpc;
   Menu.setApplicationMenu(

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -23,6 +23,7 @@ import type { DesktopProgressIpc } from './desktopProgressIpc.js';
 import type { DesktopPromptIpc } from './desktopPromptController.js';
 import type { DesktopSettingsIpc } from './desktopSettingsIpc.js';
 import type { DesktopFileSelection } from './desktopFileSelection.js';
+import type { DesktopWebviewStateStore } from './desktopWebviewStateStore.js';
 
 export interface DesktopMainViewIpcOptions {
   debugMode?: boolean;
@@ -48,6 +49,7 @@ export interface DesktopMainViewIpcOptions {
   loadStartupOptions?: () => Promise<MainViewStartupOptions>;
   handleExecuteMessage(message: MainViewExecuteMessage): Promise<void>;
   onAsyncError?: (error: unknown) => void;
+  webviewState?: DesktopWebviewStateStore;
 }
 
 export interface DesktopMainViewIpc {
@@ -70,6 +72,7 @@ export function installDesktopMainViewIpc(
 
   const bridge = installDesktopHostBridge(window, {
     onRendererMessage: handleRendererMessage,
+    webviewState: options.webviewState,
   });
   const viewState = createDesktopViewStateIpc(bridge, {
     debugMode: options.debugMode,

--- a/packages/desktop/src/preload/hostBridge.ts
+++ b/packages/desktop/src/preload/hostBridge.ts
@@ -6,10 +6,13 @@ import {
 import {
   ELECTRON_WEBVIEW_MESSAGE_CHANNEL,
   ELECTRON_WEBVIEW_PUSH_CHANNEL,
+  ELECTRON_WEBVIEW_STATE_GET_CHANNEL,
+  ELECTRON_WEBVIEW_STATE_SET_CHANNEL,
 } from '../shared/hostBridgeChannels.js';
 
 export interface ElectronHostBridgeInstallOptions {
   exposeInMainWorld(name: string, api: HostBridgeApi): void;
+  getStateFromMain(channel: typeof ELECTRON_WEBVIEW_STATE_GET_CHANNEL): unknown;
   onHostMessage(
     channel: typeof ELECTRON_WEBVIEW_PUSH_CHANNEL,
     listener: (message: unknown) => void,
@@ -19,18 +22,45 @@ export interface ElectronHostBridgeInstallOptions {
     channel: typeof ELECTRON_WEBVIEW_MESSAGE_CHANNEL,
     message: unknown,
   ): void;
+  setStateInMain(
+    channel: typeof ELECTRON_WEBVIEW_STATE_SET_CHANNEL,
+    state: unknown,
+  ): unknown;
+}
+
+const PERSISTENCE_ERROR = 'Desktop webview state could not be persisted.';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readStateResult(result: unknown): unknown {
+  if (!isRecord(result) || result.ok !== true) return undefined;
+  return result.state;
+}
+
+function stateWriteSucceeded(result: unknown): boolean {
+  return isRecord(result) && result.ok === true;
 }
 
 export function installElectronHostBridge(
   options: ElectronHostBridgeInstallOptions,
 ): HostBridgeApi {
-  let state: unknown;
   const bridge: HostBridgeApi = {
     postMessage: (message) =>
       options.sendToMain(ELECTRON_WEBVIEW_MESSAGE_CHANNEL, message),
-    getState: () => state,
+    getState: () =>
+      readStateResult(
+        options.getStateFromMain(ELECTRON_WEBVIEW_STATE_GET_CHANNEL),
+      ),
     setState: (nextState) => {
-      state = nextState;
+      if (
+        !stateWriteSucceeded(
+          options.setStateInMain(ELECTRON_WEBVIEW_STATE_SET_CHANNEL, nextState),
+        )
+      ) {
+        throw new Error(PERSISTENCE_ERROR);
+      }
     },
   };
   options.exposeInMainWorld(HOST_BRIDGE_API_KEY, bridge);

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -19,6 +19,7 @@ const rendererWindow = globalThis as typeof globalThis & {
 
 installElectronHostBridge({
   exposeInMainWorld: (name, api) => contextBridge.exposeInMainWorld(name, api),
+  getStateFromMain: (channel) => ipcRenderer.sendSync(channel),
   onHostMessage: (channel, listener) => {
     const handler = (_event: IpcRendererEvent, message: unknown) =>
       listener(message);
@@ -35,6 +36,7 @@ installElectronHostBridge({
       resolvePostMessageTargetOrigin(rendererWindow.location?.origin),
     ),
   sendToMain: (channel, message) => ipcRenderer.send(channel, message),
+  setStateInMain: (channel, state) => ipcRenderer.sendSync(channel, state),
 });
 
 contextBridge.exposeInMainWorld('texraDesktop', {

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -38,6 +38,7 @@ import {
   runCompileFixer,
   sendFollowupCommand,
 } from '@progressView/frontend/eventHandlers';
+import { prepareFollowUpDraftRestore } from '@progressView/frontend/followUpDraftPersistence';
 import { dispatchMessage } from '@progressView/frontend/messageDispatcher';
 import {
   activeStreamId$,
@@ -1688,6 +1689,7 @@ window.addEventListener(
 );
 
 function postWebviewReady(): void {
+  prepareFollowUpDraftRestore();
   // The desktop main process expects `WEBVIEW_READY` from both the 'main' and
   // 'progress' views to drive startup messages and a full progress sync; this
   // single renderer plays both roles.

--- a/packages/desktop/src/shared/hostBridgeChannels.ts
+++ b/packages/desktop/src/shared/hostBridgeChannels.ts
@@ -1,2 +1,4 @@
 export const ELECTRON_WEBVIEW_MESSAGE_CHANNEL = 'texra:webview-message';
 export const ELECTRON_WEBVIEW_PUSH_CHANNEL = 'texra:webview-push';
+export const ELECTRON_WEBVIEW_STATE_GET_CHANNEL = 'texra:webview-state-get';
+export const ELECTRON_WEBVIEW_STATE_SET_CHANNEL = 'texra:webview-state-set';

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -2,6 +2,10 @@ import * as vscode from 'vscode';
 
 import { getAgent } from '@agent/index';
 import {
+  presentFollowUpResult,
+  submitFollowUp,
+} from '@agent/followUp/ToolUseFollowUp';
+import {
   validateExecutionRequest,
   type ExecutionRequest,
 } from '@agent/core/state/executionRequests';
@@ -42,6 +46,7 @@ import { COMMON_COMMANDS, PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { unsupportedCommands } from '@shared/utils/dispatcher';
 import {
   dispatchProgressViewInbound,
+  rejectedInvalidFollowUpSubmission,
   type ProgressViewInboundHandlerRegistry,
   type ProgressViewInboundMessage,
 } from '@shared/schemas/progressView';
@@ -261,6 +266,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         const view = this.getActiveView();
         if (view) {
           await this.provider.markWebviewReady(view);
+          await view.webview.postMessage({
+            command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TRANSPORT_RESTORED,
+          });
         }
       },
       [PROGRESS_VIEW_COMMANDS.THEME_SET]: forwardToActiveView,
@@ -338,6 +346,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     message: unknown,
     webviewView: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
+    const rejectedFollowUp = rejectedInvalidFollowUpSubmission(message);
+    if (rejectedFollowUp) {
+      await webviewView.webview.postMessage(rejectedFollowUp);
+      return;
+    }
     await this.dispatchInbound(
       message,
       webviewView,
@@ -513,21 +526,58 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           stopStream: (stream) => this.provider.backend.stopStream(stream),
         },
         followUp: {
-          sendFollowUp: async ({ stream, text, mediaFiles }) => {
-            await this.runViewCommand('texra.sendFollowUp', [
-              {
-                stream,
-                text,
-                ...(mediaFiles && mediaFiles.length > 0 ? { mediaFiles } : {}),
-              },
-            ]);
+          getCurrentTargetMetadata: (stream) => ({
+            userFollowUpSupport:
+              this.provider.state.getStreamMetadata(stream).userFollowUpSupport,
+            status: defaultSession().status.get(stream),
+          }),
+          sendFollowUp: async ({ stream, text, deliveryId, mediaFiles }) => {
+            const result = await submitFollowUp(stream, {
+              text,
+              deliveryId,
+              ...(mediaFiles && mediaFiles.length > 0 ? { mediaFiles } : {}),
+            });
+            if (result.status === 'sent' || result.status === 'queued') {
+              defaultSession().events.emit({
+                scope: 'session',
+                event: {
+                  type: 'updateQueuedFollowUps',
+                  payload: { streamId: stream },
+                },
+              });
+              const presentation = presentFollowUpResult(result);
+              if (presentation.severity === 'info') {
+                await vscode.window.showInformationMessage(
+                  presentation.message,
+                );
+              }
+            }
+            return result;
+          },
+          captureSubmissionResultReporter: () => {
+            const source = this.getActiveView()?.webview;
+            return (result) => {
+              if (!source) return;
+              void Promise.resolve(source.postMessage(result)).catch(
+                (error: unknown) => {
+                  this.logger.debug(
+                    this.channel,
+                    'Follow-up result target is no longer attached',
+                    { data: error },
+                  );
+                },
+              );
+            };
           },
           reportImageSaveError: (_image, error) => {
-            // Best-effort: a failed image save must not block the text, but log
-            // it so a missing attachment is diagnosable.
             this.logger.warn(
               this.channel,
-              `Failed to save pasted follow-up image: ${toErrorMessage(error)}`,
+              'Failed to save a pasted follow-up image',
+              {
+                data: {
+                  category: error instanceof Error ? 'error' : 'non-error',
+                },
+              },
             );
           },
         },

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -26,6 +26,7 @@ import '@shared/wa/tabs';
 import type { MutableWaTabGroup, WaTabShowEvent } from '@shared/wa/tabs';
 
 // Local imports - progress view frontend
+import { prepareFollowUpDraftRestore } from './followUpDraftPersistence';
 import { progressAppStyles } from './progressAppStyles';
 import {
   activeStreamId$,
@@ -118,6 +119,7 @@ export class ProgressApp extends ProgressAppBase {
   constructor() {
     super();
     resetProgressState();
+    prepareFollowUpDraftRestore();
   }
 
   override connectedCallback(): void {

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -14,6 +14,7 @@ import { consume } from '@lit/context';
 // Local imports
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { designTokens, commonViewStyles } from '@shared/styles';
+import type { ToolUseStreamState } from '@shared/schemas';
 import { RecordingButtonController } from '@shared/litControllers/RecordingButtonController';
 import { getTextareaValue, insertTextAtCursor } from '@shared/utils/textarea';
 import {
@@ -22,6 +23,7 @@ import {
   readFileAsBase64,
   type ExtractedClipboardImage,
 } from '@shared/utils/clipboardImages';
+import type { UserFollowUpAvailability } from '@shared/streams/followUpCapability';
 import { isKnownUnsupported } from '@shared/utils/dispatcher';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { filterNotNullish } from '@utils/core';
@@ -167,6 +169,15 @@ export class FollowUpInput extends LitElement {
         line-height: var(--line-height-relaxed);
       }
 
+      .follow-up-error {
+        min-height: 1.4em;
+        margin: 0;
+        padding-inline: var(--wa-space-s);
+        color: var(--wa-color-danger-on-quiet);
+        font-size: var(--font-size-small);
+        line-height: 1.4;
+      }
+
       .follow-up-actions {
         display: flex;
         flex-direction: row;
@@ -241,6 +252,14 @@ export class FollowUpInput extends LitElement {
   @property({ attribute: false }) polishRevision = 0;
   @property({ attribute: false }) transcribedText: string | null = null;
   @property({ attribute: false }) recording = false;
+  @property({ attribute: false })
+  submission: ToolUseStreamState['ui']['followUpSubmission'] = null;
+  @property({ attribute: false })
+  availability: UserFollowUpAvailability = {
+    available: false,
+    reason: 'pending',
+    message: 'Wait for this run to start, then try again.',
+  };
   /**
    * Progress-view commands the active host's registry declares
    * `unsupported(...)` (see StreamHeader's `unsupportedCommands` for the
@@ -433,6 +452,12 @@ export class FollowUpInput extends LitElement {
     `;
   }
 
+  private get submissionMessage(): string {
+    if (this.submission?.status === 'sending') return 'Sending...';
+    if (this.submission?.status === 'failed') return this.submission.error;
+    return this.availability.available ? '' : this.availability.message;
+  }
+
   private renderComposerBody(): TemplateResult {
     return html`
       <div id=${ELEMENT_IDS.FOLLOW_UP_CONTAINER} class="follow-up-container">
@@ -452,10 +477,16 @@ export class FollowUpInput extends LitElement {
             rows="2"
             resize="vertical"
             .value=${live(this.value)}
+            ?disabled=${this.submission?.status === 'sending'}
+            aria-busy=${this.submission?.status === 'sending' ? 'true' : 'false'}
             @input=${this.handleInput}
             @keydown=${this.handleKeydown}
             @paste=${this.handlePaste}
           ></wa-textarea>
+
+          <p class="follow-up-error" role="status" aria-live="polite">
+            ${this.submissionMessage}
+          </p>
 
           <div class="follow-up-actions">
             ${
@@ -470,6 +501,7 @@ export class FollowUpInput extends LitElement {
                     label: 'Polish follow-up',
                     tooltip: 'Polish follow-up with AI',
                     busy: this.polishing,
+                    disabled: this.submission?.status === 'sending',
                     onClick: this.emitPolish,
                   })
             }
@@ -487,6 +519,9 @@ export class FollowUpInput extends LitElement {
                     className: this.recordingController.state.recording
                       ? this.recordingController.state.recordingClass
                       : '',
+                    disabled:
+                      this.submission?.status === 'sending' &&
+                      !this.recordingController.state.recording,
                     onClick: this.recordingController.handleClick,
                   })
             }
@@ -497,6 +532,10 @@ export class FollowUpInput extends LitElement {
               tooltip: 'Send follow-up message',
               className: 'composer-primary-action',
               appearance: 'filled',
+              busy: this.submission?.status === 'sending',
+              disabled:
+                this.submission?.status === 'sending' ||
+                !this.availability.available,
               size: 'l',
               onClick: this.emitSend,
             })}
@@ -565,7 +604,6 @@ export class FollowUpInput extends LitElement {
         images: transientState.pendingImages,
       }),
     );
-    transientState.pendingImages = [];
     transientState.sendAfterImagePastes = false;
   }
 

--- a/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -5,6 +5,8 @@ import { html, nothing, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 // Local imports - progress view
+import { userFollowUpAvailability } from '@shared/streams/followUpCapability';
+
 import { ProgressEvents } from '../events';
 import { getFollowUpInputTransientState } from '../followUpInputState';
 import { BaseStreamContent } from './BaseStreamContent';
@@ -98,6 +100,11 @@ export class ToolUseStreamContent extends BaseStreamContent {
             .polishRevision=${currentState.ui.polishRevision}
             .transcribedText=${currentState.ui.transcribedText}
             .recording=${currentState.ui.recording}
+            .submission=${currentState.ui.followUpSubmission}
+            .availability=${userFollowUpAvailability({
+              userFollowUpSupport: currentState.userFollowUpSupport,
+              status: currentState.status,
+            })}
             .unsupportedCommands=${this.streamContext.unsupportedCommands}
             @focus-complete=${this.handleFocusComplete}
           ></follow-up-input>

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -7,7 +7,9 @@ import {
   type GettingStartedActionDetail,
   type ProgressViewInboundMessage,
   type StreamTabId,
+  type ToolUseStreamState,
 } from '@shared/schemas';
+import { userFollowUpAvailability } from '@shared/streams/followUpCapability';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
 // Local imports - progress view
@@ -17,7 +19,15 @@ import {
   firstStreamId,
   isToolUseState,
 } from './store';
-import { deleteFollowUpInputTransientState } from './followUpInputState';
+import {
+  deleteFollowUpInputTransientState,
+  followUpAttachmentFingerprintsMatch,
+  followUpAttachmentSnapshot,
+} from './followUpInputState';
+import {
+  deletePersistedFollowUpDraft,
+  persistFollowUpDraft,
+} from './followUpDraftPersistence';
 import { addResolvedProposalId, removePrompt } from './slices/permissionSlice';
 import { updateToolUseState } from './stateUtils';
 import { clearInquiryDraft } from './components/ExternalInquiryPanel';
@@ -52,6 +62,7 @@ export function handleStreamDelete(
 ): void {
   const streamId = event.detail.streamId;
   deleteFollowUpInputTransientState(streamId);
+  deletePersistedFollowUpDraft(streamId);
 
   // Optimistic removal: apply delete locally before notifying backend
   appState.set(
@@ -106,6 +117,12 @@ export function handleFollowUpChange(
     create(prev, (draft) => {
       if (mode === 'replace') {
         draft.ui.followUpText = value;
+        if (
+          draft.ui.followUpSubmission?.status === 'failed' &&
+          draft.ui.followUpSubmission.text !== value.trim()
+        ) {
+          draft.ui.followUpSubmission = null;
+        }
         return;
       }
       if (!value) return;
@@ -115,44 +132,92 @@ export function handleFollowUpChange(
       draft.ui.followUpText = `${current}${separator}${value}`;
     }),
   );
+  persistFollowUpDraft(streamId);
 }
 
 /** Resolve one tool-use stream's trimmed follow-up text, or null if unavailable. */
-function getFollowUpText(
-  streamId: StreamTabId,
-): { streamId: StreamTabId; text: string } | null {
-  const state = appState.get();
-  const streamState = state.streamStates.get(streamId);
+function getFollowUpText(streamId: StreamTabId): {
+  streamState: ToolUseStreamState;
+  text: string;
+} | null {
+  const streamState = appState.get().streamStates.get(streamId);
   if (!streamState || !isToolUseState(streamState)) return null;
 
-  const text = streamState.ui.followUpText?.trim() ?? '';
-  if (!text) return null;
-
-  return { streamId, text };
+  const text = streamState.ui.followUpText.trim();
+  return text ? { streamState, text } : null;
 }
 
 export function handleFollowUpSend(
   event: CustomEvent<FollowUpSendDetail>,
 ): void {
-  const result = getFollowUpText(event.detail.streamId);
+  const { streamId } = event.detail;
+  const result = getFollowUpText(streamId);
   if (!result) return;
+
+  if (result.streamState.ui.followUpSubmission?.status === 'sending') return;
 
   // Orphan gate: only attach images whose [fileName] token survives in the
   // submitted text (the user may have deleted a pasted chip before sending).
-  const attached = event.detail.images.filter((img) =>
-    result.text.includes(`[${img.fileName}]`),
-  );
+  const { images: attached, fingerprints: attachmentFingerprints } =
+    followUpAttachmentSnapshot(result.text, event.detail.images);
+  const previousSubmission = result.streamState.ui.followUpSubmission;
+  const reuseDelivery =
+    previousSubmission?.status === 'failed' &&
+    previousSubmission.text === result.text &&
+    followUpAttachmentFingerprintsMatch(
+      previousSubmission.attachmentFingerprints,
+      attachmentFingerprints,
+    );
+  const deliveryId = reuseDelivery
+    ? previousSubmission.deliveryId
+    : globalThis.crypto.randomUUID();
+  const availability = userFollowUpAvailability(result.streamState);
+  if (!availability.available) {
+    updateToolUseState(streamId, (prev) =>
+      create(prev, (draft) => {
+        draft.ui.followUpSubmission = {
+          status: 'failed',
+          deliveryId,
+          text: result.text,
+          attachmentFingerprints,
+          error: availability.message,
+        };
+      }),
+    );
+    persistFollowUpDraft(streamId);
+    return;
+  }
 
-  postMessage(PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP, {
-    stream: result.streamId,
-    text: result.text,
-    ...(attached.length > 0 ? { images: attached } : {}),
-  });
-  updateToolUseState(result.streamId, (prev) =>
+  updateToolUseState(streamId, (prev) =>
     create(prev, (draft) => {
-      draft.ui.followUpText = '';
+      draft.ui.followUpSubmission = {
+        status: 'sending',
+        deliveryId,
+        text: result.text,
+        attachmentFingerprints,
+      };
     }),
   );
+  const persistence = persistFollowUpDraft(streamId);
+  if (!persistence.persisted) {
+    updateToolUseState(streamId, (prev) =>
+      create(prev, (draft) => {
+        draft.ui.followUpSubmission = {
+          ...draft.ui.followUpSubmission!,
+          status: 'failed',
+          error: persistence.error,
+        };
+      }),
+    );
+    persistFollowUpDraft(streamId);
+    return;
+  }
+  postMessage(PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP, {
+    stream: streamId,
+    text: result.text,
+    deliveryId,
+    ...(attached.length > 0 ? { images: attached } : {}),
+  });
 }
 
 export function handleFollowUpPolish(): void {
@@ -161,7 +226,7 @@ export function handleFollowUpPolish(): void {
   if (!result) return;
 
   postMessage(PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP, {
-    stream: result.streamId,
+    stream: streamId,
     text: result.text,
   });
 }

--- a/packages/extension/src/progressView/frontend/followUpDraftPersistence.ts
+++ b/packages/extension/src/progressView/frontend/followUpDraftPersistence.ts
@@ -1,0 +1,358 @@
+import { create } from 'mutative';
+import { z } from 'zod';
+
+import {
+  FollowUpAttachmentFingerprintSchema,
+  FollowUpImageSchema,
+  FollowUpSubmissionStateSchema,
+  MAX_FOLLOW_UP_ERROR_LENGTH,
+  MAX_FOLLOW_UP_FILE_NAME_LENGTH,
+  MAX_FOLLOW_UP_FINGERPRINT_LENGTH,
+  MAX_FOLLOW_UP_ID_LENGTH,
+  MAX_FOLLOW_UP_IMAGE_BASE64_BYTES,
+  MAX_FOLLOW_UP_IMAGES,
+  MAX_FOLLOW_UP_MEDIA_TYPE_LENGTH,
+  MAX_FOLLOW_UP_PAYLOAD_BYTES,
+  MAX_FOLLOW_UP_PERSISTED_STREAMS,
+  MAX_FOLLOW_UP_TEXT_LENGTH,
+  serializedFollowUpPayloadBytes,
+  type StreamTabId,
+  type ToolUseStreamState,
+} from '@shared/schemas';
+
+import {
+  fingerprintFollowUpImage,
+  getFollowUpInputTransientState,
+} from './followUpInputState';
+import { appState } from './progressState';
+import { isToolUseState, type ProgressState } from './store';
+import { webviewStorage } from './webviewStorage';
+
+const PERSISTED_FOLLOW_UP_DRAFTS_KEY = 'followUpDrafts:v1';
+
+const PersistedAttachmentSchema = FollowUpImageSchema.and(
+  z.object({ fingerprint: FollowUpAttachmentFingerprintSchema }),
+);
+
+const PersistedDraftSchema = z.object({
+  text: z.string().max(MAX_FOLLOW_UP_TEXT_LENGTH),
+  submission: FollowUpSubmissionStateSchema.nullable(),
+  attachments: z.array(PersistedAttachmentSchema).max(MAX_FOLLOW_UP_IMAGES),
+  updatedAt: z.number().finite(),
+});
+
+const PersistedDraftEnvelopeSchema = z.object({
+  version: z.literal(1),
+  drafts: z.record(
+    z.string().min(1).max(MAX_FOLLOW_UP_ID_LENGTH),
+    PersistedDraftSchema,
+  ),
+});
+
+type PersistedDraft = z.infer<typeof PersistedDraftSchema>;
+type FollowUpSubmission = ToolUseStreamState['ui']['followUpSubmission'];
+
+/** Make an unconfirmed delivery retryable without changing its identity. */
+export function recoverInterruptedFollowUpSubmission(
+  submission: FollowUpSubmission,
+): FollowUpSubmission {
+  return submission?.status === 'sending'
+    ? {
+        ...submission,
+        status: 'failed',
+        error: 'Delivery status was not confirmed. Try again.',
+      }
+    : submission;
+}
+
+export type PersistFollowUpDraftResult =
+  | { readonly persisted: true }
+  | { readonly persisted: false; readonly error: string };
+
+let drafts = new Map<StreamTabId, PersistedDraft>();
+let pendingRestore = new Set<StreamTabId>();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function boundedString(value: unknown, maxLength: number): value is string {
+  return typeof value === 'string' && value.length <= maxLength;
+}
+
+/** Cheap shape and size checks that run before Zod regexes or fingerprints. */
+function isBoundedPersistedEnvelope(value: unknown): boolean {
+  if (!isRecord(value) || value.version !== 1 || !isRecord(value.drafts)) {
+    return false;
+  }
+  const entries = Object.entries(value.drafts);
+  if (entries.length > MAX_FOLLOW_UP_PERSISTED_STREAMS) return false;
+  for (const [streamId, draftValue] of entries) {
+    if (!boundedString(streamId, MAX_FOLLOW_UP_ID_LENGTH)) return false;
+    if (!isRecord(draftValue)) return false;
+    if (!boundedString(draftValue.text, MAX_FOLLOW_UP_TEXT_LENGTH))
+      return false;
+    if (!Array.isArray(draftValue.attachments)) return false;
+    if (draftValue.attachments.length > MAX_FOLLOW_UP_IMAGES) return false;
+    for (const attachment of draftValue.attachments) {
+      if (!isRecord(attachment)) return false;
+      if (
+        !boundedString(attachment.base64, MAX_FOLLOW_UP_IMAGE_BASE64_BYTES) ||
+        !boundedString(attachment.fileName, MAX_FOLLOW_UP_FILE_NAME_LENGTH) ||
+        !boundedString(attachment.mediaType, MAX_FOLLOW_UP_MEDIA_TYPE_LENGTH) ||
+        !boundedString(attachment.fingerprint, MAX_FOLLOW_UP_FINGERPRINT_LENGTH)
+      ) {
+        return false;
+      }
+    }
+    const submission = draftValue.submission;
+    if (submission !== null) {
+      if (!isRecord(submission)) return false;
+      if (
+        !boundedString(submission.deliveryId, MAX_FOLLOW_UP_ID_LENGTH) ||
+        !boundedString(submission.text, MAX_FOLLOW_UP_TEXT_LENGTH) ||
+        !Array.isArray(submission.attachmentFingerprints) ||
+        submission.attachmentFingerprints.length > MAX_FOLLOW_UP_IMAGES ||
+        submission.attachmentFingerprints.some(
+          (fingerprint) =>
+            !boundedString(fingerprint, MAX_FOLLOW_UP_FINGERPRINT_LENGTH),
+        ) ||
+        (submission.status !== 'sending' && submission.status !== 'failed') ||
+        (submission.status === 'failed' &&
+          (!boundedString(submission.error, MAX_FOLLOW_UP_ERROR_LENGTH) ||
+            submission.error.length === 0))
+      ) {
+        return false;
+      }
+    }
+    if (typeof draftValue.updatedAt !== 'number') return false;
+  }
+  return serializedFollowUpPayloadBytes(value) <= MAX_FOLLOW_UP_PAYLOAD_BYTES;
+}
+
+/** Commit a complete candidate without changing the last-known-good map on failure. */
+function writeDrafts(
+  candidateDrafts: Map<StreamTabId, PersistedDraft>,
+): PersistFollowUpDraftResult {
+  if (candidateDrafts.size > MAX_FOLLOW_UP_PERSISTED_STREAMS) {
+    return {
+      persisted: false,
+      error: 'Follow-up storage is full. Clear an older draft, then try again.',
+    };
+  }
+  const envelope = {
+    version: 1 as const,
+    drafts: Object.fromEntries(candidateDrafts),
+  };
+  if (serializedFollowUpPayloadBytes(envelope) > MAX_FOLLOW_UP_PAYLOAD_BYTES) {
+    return {
+      persisted: false,
+      error:
+        'The follow-up is too large to preserve safely. Remove an image or shorten the message, then try again.',
+    };
+  }
+  try {
+    webviewStorage.set(PERSISTED_FOLLOW_UP_DRAFTS_KEY, envelope);
+  } catch {
+    return {
+      persisted: false,
+      error:
+        'The follow-up could not be saved in this window. Free storage or reload TeXRA, then try again.',
+    };
+  }
+  drafts = candidateDrafts;
+  return { persisted: true };
+}
+
+/**
+ * Load the one webview-scoped follow-up persistence authority before the ready
+ * handshake. Attachment bytes stay in VS Code webview state or the desktop
+ * app's user-data state only. They never enter workspace storage or logs.
+ */
+export function prepareFollowUpDraftRestore(): void {
+  const stored = webviewStorage.get(PERSISTED_FOLLOW_UP_DRAFTS_KEY);
+  const parsed = isBoundedPersistedEnvelope(stored)
+    ? PersistedDraftEnvelopeSchema.safeParse(stored)
+    : undefined;
+  if (parsed?.success) {
+    drafts = new Map(
+      Object.entries(parsed.data.drafts).map(([streamId, draft]) => [
+        streamId as StreamTabId,
+        draft,
+      ]),
+    );
+  } else {
+    drafts = new Map();
+    if (stored !== undefined) {
+      try {
+        webviewStorage.delete(PERSISTED_FOLLOW_UP_DRAFTS_KEY);
+      } catch {
+        // A disabled host store must not block a clean in-memory restore.
+      }
+    }
+  }
+  pendingRestore = new Set(drafts.keys());
+}
+
+/** Apply each prepared draft once its stream has complete tool-use metadata. */
+export function applyPreparedFollowUpDrafts(
+  state: ProgressState,
+): ProgressState {
+  if (pendingRestore.size === 0) return state;
+  const restorable = new Map<StreamTabId, PersistedDraft>();
+  const invalid = new Set<StreamTabId>();
+  for (const streamId of pendingRestore) {
+    const streamState = state.streamStates.get(streamId);
+    if (!streamState || !isToolUseState(streamState)) continue;
+    const draft = drafts.get(streamId);
+    if (!draft) {
+      pendingRestore.delete(streamId);
+      continue;
+    }
+    const attachments = draft.attachments.map(
+      ({ fingerprint: _fingerprint, ...attachment }) => attachment,
+    );
+    if (
+      attachments.some(
+        (attachment, index) =>
+          fingerprintFollowUpImage(attachment) !==
+          draft.attachments[index]?.fingerprint,
+      )
+    ) {
+      invalid.add(streamId);
+      continue;
+    }
+    getFollowUpInputTransientState(streamId).pendingImages = attachments;
+    restorable.set(streamId, draft);
+  }
+  const restored = create(state, (next) => {
+    for (const [streamId, draft] of restorable) {
+      const streamState = next.streamStates.get(streamId);
+      if (!streamState || !('ui' in streamState)) continue;
+      streamState.ui.followUpText = draft.text;
+      streamState.ui.followUpSubmission = draft.submission;
+    }
+  });
+  for (const streamId of restorable.keys()) pendingRestore.delete(streamId);
+  if (invalid.size > 0) {
+    const candidateDrafts = new Map(drafts);
+    for (const streamId of invalid) {
+      candidateDrafts.delete(streamId);
+      pendingRestore.delete(streamId);
+    }
+    writeDrafts(candidateDrafts);
+  }
+  return restored;
+}
+
+/** Persist one complete stream snapshot without evicting any other draft. */
+export function persistFollowUpDraft(
+  streamId: StreamTabId,
+): PersistFollowUpDraftResult {
+  if (streamId.length > MAX_FOLLOW_UP_ID_LENGTH) {
+    return { persisted: false, error: 'This run identifier is invalid.' };
+  }
+  const streamState = appState.get().streamStates.get(streamId);
+  const candidateDrafts = new Map(drafts);
+  if (!streamState || !isToolUseState(streamState)) {
+    candidateDrafts.delete(streamId);
+    pendingRestore.delete(streamId);
+    return writeDrafts(candidateDrafts);
+  }
+  if (streamState.ui.followUpText.length > MAX_FOLLOW_UP_TEXT_LENGTH) {
+    return {
+      persisted: false,
+      error: 'The message is too long. Shorten it and try again.',
+    };
+  }
+  const attachments = getFollowUpInputTransientState(streamId).pendingImages;
+  if (attachments.length > MAX_FOLLOW_UP_IMAGES) {
+    return {
+      persisted: false,
+      error: `Attach no more than ${MAX_FOLLOW_UP_IMAGES} images, then try again.`,
+    };
+  }
+  if (
+    attachments.some(
+      (attachment) =>
+        attachment.base64.length > MAX_FOLLOW_UP_IMAGE_BASE64_BYTES,
+    )
+  ) {
+    return {
+      persisted: false,
+      error:
+        'Each image must be 3 MiB or smaller. Remove the large image, then try again.',
+    };
+  }
+  const preflightEnvelope = {
+    version: 1,
+    drafts: {
+      ...Object.fromEntries(candidateDrafts),
+      [streamId]: {
+        text: streamState.ui.followUpText,
+        submission: streamState.ui.followUpSubmission,
+        attachments: attachments.map((attachment) => ({
+          ...attachment,
+          fingerprint: '',
+        })),
+        updatedAt: Date.now(),
+      },
+    },
+  };
+  if (
+    serializedFollowUpPayloadBytes(preflightEnvelope) >
+    MAX_FOLLOW_UP_PAYLOAD_BYTES
+  ) {
+    return {
+      persisted: false,
+      error:
+        'The follow-up is too large to preserve safely. Remove an image or shorten the message, then try again.',
+    };
+  }
+  const parsedAttachments = z.array(FollowUpImageSchema).safeParse(attachments);
+  if (!parsedAttachments.success) {
+    return {
+      persisted: false,
+      error:
+        'One or more images are invalid. Remove and paste them again, then try again.',
+    };
+  }
+  const draft: PersistedDraft = {
+    text: streamState.ui.followUpText,
+    submission: streamState.ui.followUpSubmission,
+    attachments: parsedAttachments.data.map((attachment) => ({
+      ...attachment,
+      fingerprint: fingerprintFollowUpImage(attachment),
+    })),
+    updatedAt: Date.now(),
+  };
+  if (
+    !draft.text &&
+    draft.submission === null &&
+    draft.attachments.length === 0
+  ) {
+    candidateDrafts.delete(streamId);
+    pendingRestore.delete(streamId);
+    return writeDrafts(candidateDrafts);
+  }
+  candidateDrafts.set(streamId, draft);
+  pendingRestore.delete(streamId);
+  return writeDrafts(candidateDrafts);
+}
+
+export function deletePersistedFollowUpDraft(streamId: StreamTabId): void {
+  const candidateDrafts = new Map(drafts);
+  candidateDrafts.delete(streamId);
+  pendingRestore.delete(streamId);
+  writeDrafts(candidateDrafts);
+}
+
+export function clearPersistedFollowUpDrafts(): void {
+  try {
+    webviewStorage.delete(PERSISTED_FOLLOW_UP_DRAFTS_KEY);
+    drafts.clear();
+    pendingRestore.clear();
+  } catch {
+    // Keep the last-known-good in-memory snapshots so a later write can retry.
+  }
+}

--- a/packages/extension/src/progressView/frontend/followUpInputState.ts
+++ b/packages/extension/src/progressView/frontend/followUpInputState.ts
@@ -3,12 +3,12 @@ import type { StreamTabId } from '@shared/schemas';
 import type { ExtractedClipboardImage } from '@shared/utils/clipboardImages';
 
 /**
- * Non-persisted follow-up image state for one stream.
+ * Live follow-up image state for one stream.
  *
  * Follow-up text remains in `ToolUseStreamState.ui.followUpText`, the
  * canonical stream state used by both the extension and desktop renderers.
- * Image bytes and promises cannot live in that Zod-backed state, so this
- * module gives them the same stream-keyed ownership without serializing them.
+ * Image promises cannot live in that Zod-backed state, so this module owns the
+ * live objects while followUpDraftPersistence snapshots their settled bytes.
  */
 export interface FollowUpInputTransientState {
   pendingImages: ExtractedClipboardImage[];
@@ -18,6 +18,66 @@ export interface FollowUpInputTransientState {
 }
 
 const stateByStream = new Map<StreamTabId, FollowUpInputTransientState>();
+
+/** Deterministic immutable-content fingerprint that survives document reload. */
+export function fingerprintFollowUpImage(
+  image: ExtractedClipboardImage,
+): string {
+  const value = `${image.fileName}\0${image.mediaType}\0${image.base64}`;
+  let firstHash = 2166136261;
+  let secondHash = 3339675911;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    firstHash = Math.imul(firstHash ^ code, 16777619);
+    secondHash = Math.imul(secondHash ^ code, 16777619);
+  }
+  const formatHash = (hash: number): string =>
+    (hash >>> 0).toString(16).padStart(8, '0');
+  return [
+    image.base64.length,
+    formatHash(firstHash),
+    formatHash(secondHash),
+  ].join(':');
+}
+
+/** Capture the images whose tokens remain in the submitted text. */
+export function followUpAttachmentSnapshot(
+  text: string,
+  images: readonly ExtractedClipboardImage[],
+): {
+  images: ExtractedClipboardImage[];
+  fingerprints: string[];
+} {
+  const attached = images.filter((image) =>
+    text.includes(`[${image.fileName}]`),
+  );
+  return {
+    images: attached,
+    fingerprints: attached.map(fingerprintFollowUpImage),
+  };
+}
+
+/** Compare ordered attachment snapshots that contribute to delivery identity. */
+export function followUpAttachmentFingerprintsMatch(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((fingerprint, index) => fingerprint === right[index])
+  );
+}
+
+/** Remove only images captured by an accepted delivery snapshot. */
+export function removeAcceptedFollowUpImages(
+  state: FollowUpInputTransientState,
+  acceptedFingerprints: readonly string[],
+): void {
+  const accepted = new Set(acceptedFingerprints);
+  state.pendingImages = state.pendingImages.filter(
+    (image) => !accepted.has(fingerprintFollowUpImage(image)),
+  );
+}
 
 /** Return the stable transient-state object owned by `streamId`. */
 export function getFollowUpInputTransientState(

--- a/packages/extension/src/progressView/frontend/slices/followUpSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/followUpSlice.ts
@@ -8,6 +8,16 @@ import { create } from 'mutative';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import type { ProgressViewOutboundHandlerRegistry } from '@shared/schemas';
 
+import {
+  persistFollowUpDraft,
+  recoverInterruptedFollowUpSubmission,
+} from '../followUpDraftPersistence';
+import {
+  followUpAttachmentFingerprintsMatch,
+  followUpAttachmentSnapshot,
+  getFollowUpInputTransientState,
+  removeAcceptedFollowUpImages,
+} from '../followUpInputState';
 import { appState } from '../progressState';
 import { updateToolUseState } from '../stateUtils';
 
@@ -48,6 +58,73 @@ export const followUpHandlers = {
         }
       }),
     );
+    persistFollowUpDraft(streamId);
+  },
+
+  [PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TRANSPORT_RESTORED]: () => {
+    const interrupted = [...appState.get().streamStates.entries()]
+      .filter(
+        ([, streamState]) =>
+          'ui' in streamState &&
+          streamState.ui.followUpSubmission?.status === 'sending',
+      )
+      .map(([streamId]) => streamId);
+    appState.set(
+      create(appState.get(), (draft) => {
+        for (const streamId of interrupted) {
+          const streamState = draft.streamStates.get(streamId);
+          if (!streamState || !('ui' in streamState)) continue;
+          const submission = streamState.ui.followUpSubmission;
+          if (submission?.status !== 'sending') continue;
+          streamState.ui.followUpSubmission =
+            recoverInterruptedFollowUpSubmission(submission);
+        }
+      }),
+    );
+    for (const streamId of interrupted) persistFollowUpDraft(streamId);
+  },
+
+  [PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT]: (data) => {
+    const streamState = appState.get().streamStates.get(data.stream);
+    if (!streamState || !('ui' in streamState)) return;
+    const submission = streamState.ui.followUpSubmission;
+    if (!submission || submission.deliveryId !== data.deliveryId) return;
+    const transientState = getFollowUpInputTransientState(data.stream);
+    const currentText = streamState.ui.followUpText.trim();
+    const currentAttachmentFingerprints = followUpAttachmentSnapshot(
+      currentText,
+      transientState.pendingImages,
+    ).fingerprints;
+    const draftStillMatches =
+      currentText === submission.text &&
+      followUpAttachmentFingerprintsMatch(
+        currentAttachmentFingerprints,
+        submission.attachmentFingerprints,
+      );
+
+    updateToolUseState(data.stream, (prev) =>
+      create(prev, (draft) => {
+        if (data.accepted) {
+          if (draftStillMatches) {
+            draft.ui.followUpText = '';
+          }
+          draft.ui.followUpSubmission = null;
+          return;
+        }
+        draft.ui.followUpSubmission = {
+          ...submission,
+          status: 'failed',
+          error: data.error,
+        };
+      }),
+    );
+    if (data.accepted) {
+      removeAcceptedFollowUpImages(
+        transientState,
+        submission.attachmentFingerprints,
+      );
+    }
+    persistFollowUpDraft(data.stream);
   },
 
   [PROGRESS_VIEW_COMMANDS.UPDATE_RECORDING]: (data) => {

--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -36,6 +36,11 @@ import {
   clearProposalInputStore,
 } from '../formatters/contentStore';
 import {
+  applyPreparedFollowUpDrafts,
+  clearPersistedFollowUpDrafts,
+  deletePersistedFollowUpDraft,
+} from '../followUpDraftPersistence';
+import {
   clearFollowUpInputTransientStateStore,
   deleteFollowUpInputTransientState,
 } from '../followUpInputState';
@@ -91,6 +96,7 @@ function updateStreamInfo(
     if (!newStreamById.has(key)) {
       pendingDescriptions.delete(key);
       deleteFollowUpInputTransientState(key);
+      deletePersistedFollowUpDraft(key);
     }
   }
 
@@ -147,10 +153,8 @@ export const streamLifecycleHandlers = {
     if (data.unsupportedCommands) {
       unsupportedProgressCommands$.set(new Set(data.unsupportedCommands));
     }
-    const updated = updateStreamInfo(
-      appState.get(),
-      data.streams,
-      data.streamStates,
+    const updated = applyPreparedFollowUpDrafts(
+      updateStreamInfo(appState.get(), data.streams, data.streamStates),
     );
     // Honor explicit empty-string as "no selection" — backend sends this
     // when the current filter excludes every stream. Since the backend now
@@ -190,6 +194,7 @@ export const streamLifecycleHandlers = {
     clearCopyContentStore();
     clearProposalInputStore();
     deleteFollowUpInputTransientState(streamId);
+    deletePersistedFollowUpDraft(streamId);
     webviewStorage.delete(logListStateKey(streamId));
 
     // Remove permissions for the deleted stream to prevent orphaned entries
@@ -213,6 +218,7 @@ export const streamLifecycleHandlers = {
     clearCopyContentStore();
     clearProposalInputStore();
     clearFollowUpInputTransientStateStore();
+    clearPersistedFollowUpDrafts();
     pendingDescriptions.clear();
 
     // Clear all permissions — no streams means no valid permissions

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -1,6 +1,9 @@
 // Local imports
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { notifyFollowUpSent } from '@agent/followUp/ToolUseFollowUp';
+import {
+  notifyFollowUpSent,
+  type SubmitFollowUpResult,
+} from '@agent/followUp/ToolUseFollowUp';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { isApiProvider } from '@model/apiProviders';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
@@ -9,12 +12,18 @@ import type {
   AgentProposal,
   ModelOptionData,
 } from '@shared/schemas';
-import type { RunIdentity, StreamTabId } from '@shared/schemas';
+import type {
+  RunIdentity,
+  StreamPhase,
+  StreamTabId,
+  UserFollowUpSupport,
+} from '@shared/schemas';
 import type {
   ProgressViewInboundHandlerRegistry,
   ProgressViewInboundMessage,
   ProgressViewOutboundMessage,
 } from '@shared/schemas/progressView';
+import { userFollowUpAvailability } from '@shared/streams/followUpCapability';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import {
   isApprovalBypassedForStream,
@@ -78,8 +87,19 @@ type ProgressViewFollowUpImage = NonNullable<
 interface ProgressViewFollowUpSubmission {
   stream: StreamTabId;
   text: string;
+  deliveryId: string;
   mediaFiles?: readonly string[];
 }
+
+interface ProgressViewFollowUpTargetMetadata {
+  readonly userFollowUpSupport?: UserFollowUpSupport;
+  readonly status?: StreamPhase;
+}
+
+type FollowUpSubmissionResultMessage = Extract<
+  ProgressViewOutboundMessage,
+  { command: typeof PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT }
+>;
 
 export interface ProgressViewLifecycleCommandActions {
   setActiveStream(stream: StreamTabId): Promise<void> | void;
@@ -110,9 +130,15 @@ export interface ProgressViewFileCommandActions {
 }
 
 export interface ProgressViewFollowUpCommandActions {
+  getCurrentTargetMetadata(
+    stream: StreamTabId,
+  ): ProgressViewFollowUpTargetMetadata;
   sendFollowUp(
     submission: ProgressViewFollowUpSubmission,
-  ): Promise<void> | void;
+  ): Promise<SubmitFollowUpResult>;
+  captureSubmissionResultReporter(): (
+    result: FollowUpSubmissionResultMessage,
+  ) => void;
   reportImageSaveError(image: ProgressViewFollowUpImage, error: unknown): void;
 }
 
@@ -243,15 +269,63 @@ export function createProgressViewCommandHandlers(
     [PROGRESS_VIEW_COMMANDS.OPEN_LABEL]: (data) => file.openLabel(data.label),
 
     [PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP]: async (data) => {
-      const mediaFiles = await saveFollowUpImages(
-        data.images ?? [],
-        followUp.reportImageSaveError,
+      const reportToOrigin = followUp.captureSubmissionResultReporter();
+      const report = (
+        result:
+          | { readonly accepted: true }
+          | { readonly accepted: false; readonly error: string },
+      ): void => {
+        reportToOrigin({
+          command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT,
+          stream: data.stream,
+          deliveryId: data.deliveryId,
+          ...result,
+        });
+      };
+
+      const availability = userFollowUpAvailability(
+        followUp.getCurrentTargetMetadata(data.stream),
       );
-      await followUp.sendFollowUp({
-        stream: data.stream,
-        text: data.text,
-        ...(mediaFiles.length > 0 ? { mediaFiles } : {}),
-      });
+      if (!availability.available) {
+        report({ accepted: false, error: availability.message });
+        return;
+      }
+
+      try {
+        const mediaFiles = await saveFollowUpImages(
+          data.images ?? [],
+          followUp.reportImageSaveError,
+        );
+        const result = await followUp.sendFollowUp({
+          stream: data.stream,
+          text: data.text,
+          deliveryId: data.deliveryId,
+          ...(mediaFiles.length > 0 ? { mediaFiles } : {}),
+        });
+        if (
+          result.status === 'sent' ||
+          result.status === 'queued' ||
+          result.status === 'duplicate'
+        ) {
+          report({ accepted: true });
+          return;
+        }
+        report({
+          accepted: false,
+          error:
+            result.status === 'no_session'
+              ? 'This run is no longer active. Refresh the run and try again.'
+              : 'Unable to deliver this message. Refresh the run and try again.',
+        });
+      } catch (error) {
+        report({
+          accepted: false,
+          error:
+            error instanceof FollowUpImageSaveError
+              ? 'An image could not be saved. Remove and paste the images again, then try again.'
+              : 'Unable to send. Check your connection and try again.',
+        });
+      }
     },
 
     // The shield is the explicit both-kinds preset: one click sets file edits
@@ -568,6 +642,8 @@ export function createProgressViewSecondTierHandlers(
   } satisfies Partial<ProgressViewInboundHandlerRegistry>;
 }
 
+class FollowUpImageSaveError extends Error {}
+
 async function saveFollowUpImages(
   images: readonly ProgressViewFollowUpImage[],
   reportImageSaveError: ProgressViewFollowUpCommandActions['reportImageSaveError'],
@@ -580,6 +656,7 @@ async function saveFollowUpImages(
       );
     } catch (error) {
       reportImageSaveError(image, error);
+      throw new FollowUpImageSaveError();
     }
   }
   return mediaFiles;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -178,6 +178,8 @@ export const PROGRESS_VIEW_COMMANDS = {
   PACK_STREAM: 'packStream',
   RESTORE_STATE: 'restoreState',
   SEND_FOLLOW_UP: 'sendFollowUp',
+  FOLLOW_UP_SUBMISSION_RESULT: 'followUpSubmissionResult',
+  FOLLOW_UP_TRANSPORT_RESTORED: 'followUpTransportRestored',
   POLISH_FOLLOW_UP: 'polishFollowUp',
   UPDATE_FOLLOW_UP_TEXT: 'updateFollowUpText',
   SETUP_FOLLOWUP: 'setupFollowup',

--- a/src/shared/schemas/progressView/followUpPolicy.ts
+++ b/src/shared/schemas/progressView/followUpPolicy.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+
+import { getSupportedImageExtension } from '@shared/utils/clipboardImages';
+
+export const MAX_FOLLOW_UP_IMAGES = 8;
+export const MAX_FOLLOW_UP_IMAGE_BASE64_BYTES = 3 * 1024 * 1024;
+export const MAX_FOLLOW_UP_PERSISTED_STREAMS = 20;
+export const MAX_FOLLOW_UP_PAYLOAD_BYTES = 4 * 1024 * 1024;
+export const MAX_FOLLOW_UP_TEXT_LENGTH = 256 * 1024;
+export const MAX_FOLLOW_UP_ID_LENGTH = 256;
+export const MAX_FOLLOW_UP_ERROR_LENGTH = 1024;
+export const MAX_FOLLOW_UP_FILE_NAME_LENGTH = 255;
+export const MAX_FOLLOW_UP_MEDIA_TYPE_LENGTH = 64;
+export const MAX_FOLLOW_UP_FINGERPRINT_LENGTH = 128;
+
+const CanonicalBase64Schema = z
+  .string()
+  .min(1)
+  .max(MAX_FOLLOW_UP_IMAGE_BASE64_BYTES)
+  .regex(
+    /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/,
+    'Expected canonical base64.',
+  );
+
+const FollowUpImageFileNameSchema = z
+  .string()
+  .min(1)
+  .max(MAX_FOLLOW_UP_FILE_NAME_LENGTH)
+  .regex(/^pasted_[^/\\\0]+\.[A-Za-z0-9]+$/, 'Invalid pasted image filename.');
+
+/** Canonical renderer image shape accepted at persistence and IPC boundaries. */
+export const FollowUpImageSchema = z
+  .object({
+    base64: CanonicalBase64Schema,
+    mediaType: z
+      .string()
+      .min(1)
+      .max(MAX_FOLLOW_UP_MEDIA_TYPE_LENGTH)
+      .refine(
+        (value) => getSupportedImageExtension(value) !== undefined,
+        'Unsupported image media type.',
+      ),
+    fileName: FollowUpImageFileNameSchema,
+  })
+  .refine(
+    (image) => {
+      const extension = image.fileName.slice(
+        image.fileName.lastIndexOf('.') + 1,
+      );
+      return (
+        getSupportedImageExtension(image.mediaType) === extension.toLowerCase()
+      );
+    },
+    { message: 'Image media type and filename do not match.' },
+  );
+
+/** Measure the serialized payload at persistence and IPC trust boundaries. */
+export function serializedFollowUpPayloadBytes(value: unknown): number {
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined
+      ? Number.POSITIVE_INFINITY
+      : new TextEncoder().encode(serialized).byteLength;
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -28,6 +28,16 @@ import { AgentProposalSchema, UserQuestionAnswersSchema } from '../prompts';
 import { StreamScopedBaseSchema } from './data';
 import { GettingStartedActionSchema } from '../mainView/state';
 import { ExhaustionReasonSchema } from '../errors';
+import {
+  FollowUpImageSchema,
+  MAX_FOLLOW_UP_ID_LENGTH,
+  MAX_FOLLOW_UP_IMAGE_BASE64_BYTES,
+  MAX_FOLLOW_UP_IMAGES,
+  MAX_FOLLOW_UP_PAYLOAD_BYTES,
+  MAX_FOLLOW_UP_TEXT_LENGTH,
+  serializedFollowUpPayloadBytes,
+} from './followUpPolicy';
+import type { ProgressViewOutboundMessage } from './outbound';
 
 const TrimmedStringSchema = z
   .string()
@@ -111,18 +121,101 @@ const EnableApprovalBypassMessageSchema = StreamScopedBaseSchema.extend({
 
 const SendFollowUpMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP),
-  text: TrimmedStringSchema,
+  stream: z.string().min(1).max(MAX_FOLLOW_UP_ID_LENGTH),
+  text: TrimmedStringSchema.pipe(z.string().max(MAX_FOLLOW_UP_TEXT_LENGTH)),
+  deliveryId: z.string().min(1).max(MAX_FOLLOW_UP_ID_LENGTH),
   /** Pasted images (base64) to attach to this follow-up turn. */
-  images: z
-    .array(
-      z.object({
-        base64: z.string(),
-        mediaType: z.string(),
-        fileName: z.string(),
-      }),
-    )
-    .optional(),
+  images: z.array(FollowUpImageSchema).max(MAX_FOLLOW_UP_IMAGES).optional(),
+}).refine(
+  (message) =>
+    serializedFollowUpPayloadBytes(message) <= MAX_FOLLOW_UP_PAYLOAD_BYTES,
+  { message: 'Follow-up payload exceeds the 4 MiB limit.' },
+);
+
+const FollowUpSubmissionIdentitySchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP),
+  stream: z.string().min(1).max(MAX_FOLLOW_UP_ID_LENGTH),
+  deliveryId: z.string().min(1).max(MAX_FOLLOW_UP_ID_LENGTH),
 });
+
+export type RejectedFollowUpSubmissionResult = Extract<
+  ProgressViewOutboundMessage,
+  {
+    command: typeof PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT;
+    accepted: false;
+  }
+>;
+
+function rejectedFollowUp(
+  identity: z.infer<typeof FollowUpSubmissionIdentitySchema>,
+  error: string,
+): RejectedFollowUpSubmissionResult {
+  return {
+    command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT,
+    stream: identity.stream,
+    deliveryId: identity.deliveryId,
+    accepted: false,
+    error,
+  };
+}
+
+/** Build a safe retryable rejection for an invalid renderer submission. */
+export function rejectedInvalidFollowUpSubmission(
+  message: unknown,
+): RejectedFollowUpSubmissionResult | undefined {
+  const identity = FollowUpSubmissionIdentitySchema.safeParse(message);
+  if (
+    !identity.success ||
+    SendFollowUpMessageSchema.safeParse(message).success
+  ) {
+    return undefined;
+  }
+  const candidate = message as Record<string, unknown>;
+  if (typeof candidate.text === 'string' && !candidate.text.trim()) {
+    return rejectedFollowUp(identity.data, 'Enter a message before sending.');
+  }
+  if (typeof candidate.text !== 'string') {
+    return rejectedFollowUp(
+      identity.data,
+      'The message details are invalid. Refresh the run and try again.',
+    );
+  }
+  if (candidate.text.length > MAX_FOLLOW_UP_TEXT_LENGTH) {
+    return rejectedFollowUp(
+      identity.data,
+      'The message is too long. Shorten it and try again.',
+    );
+  }
+  if (Array.isArray(candidate.images)) {
+    const exceedsAttachmentLimits =
+      candidate.images.length > MAX_FOLLOW_UP_IMAGES ||
+      candidate.images.some(
+        (image) =>
+          typeof image === 'object' &&
+          image !== null &&
+          typeof (image as Record<string, unknown>).base64 === 'string' &&
+          ((image as Record<string, unknown>).base64 as string).length >
+            MAX_FOLLOW_UP_IMAGE_BASE64_BYTES,
+      ) ||
+      serializedFollowUpPayloadBytes(message) > MAX_FOLLOW_UP_PAYLOAD_BYTES;
+    if (exceedsAttachmentLimits) {
+      return rejectedFollowUp(
+        identity.data,
+        'Attachment limits are 8 images, 3 MiB per image, and 4 MiB total. Remove an image and try again.',
+      );
+    }
+    if (!z.array(FollowUpImageSchema).safeParse(candidate.images).success) {
+      return rejectedFollowUp(
+        identity.data,
+        'One or more images are invalid. Remove and paste them again, then try again.',
+      );
+    }
+  }
+  return rejectedFollowUp(
+    identity.data,
+    'The message details are invalid. Refresh the run and try again.',
+  );
+}
 
 const PolishFollowUpMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP),

--- a/src/shared/schemas/progressView/index.ts
+++ b/src/shared/schemas/progressView/index.ts
@@ -12,5 +12,6 @@
  *                  union + dispatcher
  */
 export * from './data';
+export * from './followUpPolicy';
 export * from './outbound';
 export * from './inbound';

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -26,6 +26,10 @@ import { CompileFailureSchema, OutputFileInfoSchema } from '../output';
 import { roundIndexedRecord } from '../roundIndexed';
 import { InquiryThreadUpdatedEventSchema } from '../inquiry';
 import {
+  MAX_FOLLOW_UP_ERROR_LENGTH,
+  MAX_FOLLOW_UP_ID_LENGTH,
+} from './followUpPolicy';
+import {
   AgentProposalPermissionSchema,
   BashPermissionSchema,
   ExternalInquiryPermissionSchema,
@@ -261,6 +265,24 @@ const UpdateFollowUpTextMessageSchema = z.discriminatedUnion('kind', [
   }),
 ]);
 
+const FollowUpSubmissionResultMessageSchema = z.discriminatedUnion('accepted', [
+  StreamScopedBaseSchema.extend({
+    command: z.literal(PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT),
+    deliveryId: z.string().min(1).max(MAX_FOLLOW_UP_ID_LENGTH),
+    accepted: z.literal(true),
+  }),
+  StreamScopedBaseSchema.extend({
+    command: z.literal(PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT),
+    deliveryId: z.string().min(1).max(MAX_FOLLOW_UP_ID_LENGTH),
+    accepted: z.literal(false),
+    error: z.string().min(1).max(MAX_FOLLOW_UP_ERROR_LENGTH),
+  }),
+]);
+
+const FollowUpTransportRestoredMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TRANSPORT_RESTORED),
+});
+
 const RecordingStatusSchema = z.enum(['started', 'stopped', 'error']);
 
 const UpdateRecordingMessageSchema = z.object({
@@ -408,6 +430,8 @@ export const ProgressViewOutboundMessageSchema = z.discriminatedUnion(
     UpdateBypassMessageSchema,
     GoalActiveUpdatedMessageSchema,
     UpdateFollowUpTextMessageSchema,
+    FollowUpSubmissionResultMessageSchema,
+    FollowUpTransportRestoredMessageSchema,
     UpdateRecordingMessageSchema,
     SyncInquiryThreadsMessageSchema,
     UpdateInquiryThreadMessageSchema,

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -17,6 +17,13 @@ import { PlanSchema } from './plan';
 import { TodoItemSchema } from './todo';
 import { ContextStateDataSchema } from './contextManagement';
 import { RunUsageMapSchema } from './usage';
+import {
+  MAX_FOLLOW_UP_ERROR_LENGTH,
+  MAX_FOLLOW_UP_FINGERPRINT_LENGTH,
+  MAX_FOLLOW_UP_ID_LENGTH,
+  MAX_FOLLOW_UP_IMAGES,
+  MAX_FOLLOW_UP_TEXT_LENGTH,
+} from './progressView/followUpPolicy';
 
 // Active Child Info — one flat row shape. Every child owns a stream tab
 // (`childStreamId` always present) and carries its parsed `identity`
@@ -162,8 +169,29 @@ const BaseStreamStateSchema = BackendOwnedFieldsSchema.extend({
 
 // Tool-Use UI State (frontend-only, preserved during backend updates)
 
+export const FollowUpAttachmentFingerprintSchema = z
+  .string()
+  .min(1)
+  .max(MAX_FOLLOW_UP_FINGERPRINT_LENGTH);
+
+const FollowUpSubmissionBaseSchema = z.object({
+  deliveryId: z.string().min(1).max(MAX_FOLLOW_UP_ID_LENGTH),
+  text: z.string().max(MAX_FOLLOW_UP_TEXT_LENGTH),
+  attachmentFingerprints: z
+    .array(FollowUpAttachmentFingerprintSchema)
+    .max(MAX_FOLLOW_UP_IMAGES),
+});
+export const FollowUpSubmissionStateSchema = z.discriminatedUnion('status', [
+  FollowUpSubmissionBaseSchema.extend({ status: z.literal('sending') }),
+  FollowUpSubmissionBaseSchema.extend({
+    status: z.literal('failed'),
+    error: z.string().min(1).max(MAX_FOLLOW_UP_ERROR_LENGTH),
+  }),
+]);
+
 const ToolUseUIStateSchema = z.object({
-  followUpText: z.string().prefault(''),
+  followUpText: z.string().max(MAX_FOLLOW_UP_TEXT_LENGTH).prefault(''),
+  followUpSubmission: FollowUpSubmissionStateSchema.nullable().prefault(null),
   polishedText: z.string().nullable().prefault(null),
   polishRevision: z.int().prefault(0),
   transcribedText: z.string().nullable().prefault(null),

--- a/src/shared/streams/followUpCapability.ts
+++ b/src/shared/streams/followUpCapability.ts
@@ -1,12 +1,58 @@
 import {
   AgentCategory,
+  STREAM_STATUS,
   USER_FOLLOW_UP_SUPPORT,
   type RunIdentity,
+  type StreamLifecycleStatus,
   type StreamPhase,
   type UserFollowUpSupport,
 } from '@shared/schemas';
 
-import { isInFlightPhase } from './streamStatus';
+import { isInFlightPhase, isTerminalOutcomePhase } from './streamStatus';
+
+export type UserFollowUpAvailability =
+  | { readonly available: true }
+  | {
+      readonly available: false;
+      readonly reason: 'unsupported' | 'pending' | 'terminal';
+      readonly message: string;
+    };
+
+/**
+ * Canonical host admission policy for user-authored follow-ups. Runtime support
+ * comes from launch metadata; the current lifecycle phase prevents stale views
+ * from reviving a run that has already ended.
+ */
+export function userFollowUpAvailability(stream: {
+  readonly userFollowUpSupport?: UserFollowUpSupport | undefined;
+  readonly status?: StreamLifecycleStatus | undefined;
+}): UserFollowUpAvailability {
+  if (
+    stream.userFollowUpSupport === undefined ||
+    stream.userFollowUpSupport === USER_FOLLOW_UP_SUPPORT.UNSUPPORTED
+  ) {
+    return {
+      available: false,
+      reason: 'unsupported',
+      message: 'This run does not accept follow-up messages.',
+    };
+  }
+  const status =
+    stream.status === STREAM_STATUS.READY ? undefined : stream.status;
+  if (isInFlightPhase(status)) return { available: true };
+  if (isTerminalOutcomePhase(status)) {
+    return {
+      available: false,
+      reason: 'terminal',
+      message: 'This run has ended. Start a new agent task to continue.',
+    };
+  }
+  return {
+    available: false,
+    reason: 'pending',
+    message: 'Wait for this run to start, then try again.',
+  };
+}
 
 /**
  * Whether the child composer policy allows user follow-ups for this stream.

--- a/src/shared/utils/clipboardImages.ts
+++ b/src/shared/utils/clipboardImages.ts
@@ -26,8 +26,16 @@ const IMAGE_MIME_TYPES: Record<string, string> = {
   'image/x-psd': 'psd',
 };
 
+export function getSupportedImageExtension(
+  mimeType: string,
+): string | undefined {
+  return IMAGE_MIME_TYPES[mimeType];
+}
+
 export function getExtensionFromMimeType(mimeType: string): string {
-  return IMAGE_MIME_TYPES[mimeType] || mimeType.split('/')[1] || 'png';
+  return (
+    getSupportedImageExtension(mimeType) || mimeType.split('/')[1] || 'png'
+  );
 }
 
 export interface ExtractedClipboardImage {

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -12,6 +12,7 @@ import {
   type ProgressViewSecondTierActions,
 } from '@controllers/progressView/ProgressViewCommandHandlers';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import { STREAM_PHASE, USER_FOLLOW_UP_SUPPORT } from '@shared/schemas';
 import {
   ProgressViewInboundMessageSchema,
   dispatchProgressViewInbound,
@@ -92,7 +93,12 @@ function createActions(
       openLabel: vi.fn(),
     },
     followUp: {
-      sendFollowUp: vi.fn(),
+      getCurrentTargetMetadata: vi.fn(() => ({
+        userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
+        status: STREAM_PHASE.RUNNING,
+      })),
+      sendFollowUp: vi.fn().mockResolvedValue({ status: 'sent' }),
+      captureSubmissionResultReporter: vi.fn(() => vi.fn()),
       reportImageSaveError: vi.fn(),
     },
     bypass: { showInfo: vi.fn() },
@@ -109,6 +115,11 @@ function createActions(
     },
     ...overrides,
   };
+}
+
+function capturedSubmissionReporter(actions: ProgressViewCommandActions) {
+  return vi.mocked(actions.followUp.captureSubmissionResultReporter).mock
+    .results[0]?.value;
 }
 
 function createSecondTierActions(
@@ -338,6 +349,7 @@ describe('createProgressViewCommandHandlers - follow-up', () => {
         command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
         stream: 'stream-a',
         text: 'continue',
+        deliveryId: 'delivery-1',
       }),
     );
 
@@ -346,10 +358,56 @@ describe('createProgressViewCommandHandlers - follow-up', () => {
     expect(actions.followUp.sendFollowUp).toHaveBeenCalledWith({
       stream: 'stream-a',
       text: 'continue',
+      deliveryId: 'delivery-1',
+    });
+    expect(capturedSubmissionReporter(actions)).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT,
+      stream: 'stream-a',
+      deliveryId: 'delivery-1',
+      accepted: true,
     });
   });
 
-  it('persists follow-up images and keeps sending text after an image save fails', async () => {
+  it('captures the result transport before asynchronous image persistence', async () => {
+    let finishSave: (path: string) => void = () => {};
+    savePastedImageBase64Mock.mockReturnValue(
+      new Promise((resolve) => {
+        finishSave = resolve;
+      }),
+    );
+    const actions = createActions();
+    const handlers = createProgressViewCommandHandlers(actions);
+
+    const handling = assertSupported(
+      handlers[PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP],
+    )(
+      parseSendFollowUpMessage({
+        command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
+        stream: 'stream-a',
+        text: 'look [pasted_1.png]',
+        deliveryId: 'delivery-captured',
+        images: [
+          {
+            base64: 'aW1hZ2U=',
+            mediaType: 'image/png',
+            fileName: 'pasted_1.png',
+          },
+        ],
+      }),
+    );
+
+    expect(
+      actions.followUp.captureSubmissionResultReporter,
+    ).toHaveBeenCalledOnce();
+    expect(actions.followUp.sendFollowUp).not.toHaveBeenCalled();
+    finishSave('/tmp/pasted.png');
+    await handling;
+    expect(capturedSubmissionReporter(actions)).toHaveBeenCalledWith(
+      expect.objectContaining({ accepted: true }),
+    );
+  });
+
+  it('rejects the whole multi-image submission when one image save fails', async () => {
     const failedImageError = new Error('bad image');
     savePastedImageBase64Mock
       .mockResolvedValueOnce('/tmp/pasted/a.png')
@@ -358,7 +416,7 @@ describe('createProgressViewCommandHandlers - follow-up', () => {
     const actions = createActions();
     const handlers = createProgressViewCommandHandlers(actions);
     const failedImage = {
-      base64: 'broken',
+      base64: 'YnJva2Vu',
       mediaType: 'image/png',
       fileName: 'pasted_2.png',
     };
@@ -368,9 +426,10 @@ describe('createProgressViewCommandHandlers - follow-up', () => {
         command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
         stream: 'stream-a',
         text: 'look at these',
+        deliveryId: 'delivery-2',
         images: [
           {
-            base64: 'ok',
+            base64: 'b2s=',
             mediaType: 'image/png',
             fileName: 'pasted_1.png',
           },
@@ -381,22 +440,97 @@ describe('createProgressViewCommandHandlers - follow-up', () => {
 
     expect(savePastedImageBase64Mock).toHaveBeenNthCalledWith(
       1,
-      'ok',
+      'b2s=',
       'pasted_1.png',
     );
     expect(savePastedImageBase64Mock).toHaveBeenNthCalledWith(
       2,
-      'broken',
+      'YnJva2Vu',
       'pasted_2.png',
     );
     expect(actions.followUp.reportImageSaveError).toHaveBeenCalledWith(
       failedImage,
       failedImageError,
     );
-    expect(actions.followUp.sendFollowUp).toHaveBeenCalledWith({
+    expect(actions.followUp.sendFollowUp).not.toHaveBeenCalled();
+    expect(capturedSubmissionReporter(actions)).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT,
       stream: 'stream-a',
-      text: 'look at these',
-      mediaFiles: ['/tmp/pasted/a.png'],
+      deliveryId: 'delivery-2',
+      accepted: false,
+      error:
+        'An image could not be saved. Remove and paste the images again, then try again.',
+    });
+  });
+
+  it.each([
+    [
+      'unsupported',
+      {
+        userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
+        status: STREAM_PHASE.RUNNING,
+      },
+      'This run does not accept follow-up messages.',
+    ],
+    [
+      'terminal',
+      {
+        userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
+        status: STREAM_PHASE.COMPLETED,
+      },
+      'This run has ended. Start a new agent task to continue.',
+    ],
+  ])(
+    'rejects %s current metadata before delivery',
+    async (_name, metadata, error) => {
+      const actions = createActions();
+      vi.mocked(actions.followUp.getCurrentTargetMetadata).mockReturnValue(
+        metadata,
+      );
+      const handlers = createProgressViewCommandHandlers(actions);
+
+      await assertSupported(handlers[PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP])(
+        parseSendFollowUpMessage({
+          command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
+          stream: 'stream-a',
+          text: 'continue',
+          deliveryId: 'delivery-rejected',
+        }),
+      );
+
+      expect(actions.followUp.sendFollowUp).not.toHaveBeenCalled();
+      expect(capturedSubmissionReporter(actions)).toHaveBeenCalledWith({
+        command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT,
+        stream: 'stream-a',
+        deliveryId: 'delivery-rejected',
+        accepted: false,
+        error,
+      });
+    },
+  );
+
+  it('reports failed delivery without accepting the draft', async () => {
+    const actions = createActions();
+    vi.mocked(actions.followUp.sendFollowUp).mockRejectedValueOnce(
+      new Error('offline'),
+    );
+    const handlers = createProgressViewCommandHandlers(actions);
+
+    await assertSupported(handlers[PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP])(
+      parseSendFollowUpMessage({
+        command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
+        stream: 'stream-a',
+        text: 'continue',
+        deliveryId: 'delivery-failed',
+      }),
+    );
+
+    expect(capturedSubmissionReporter(actions)).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT,
+      stream: 'stream-a',
+      deliveryId: 'delivery-failed',
+      accepted: false,
+      error: 'Unable to send. Check your connection and try again.',
     });
   });
 });

--- a/src/test-kernel/controllers/ProgressViewHost.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewHost.vitest.ts
@@ -17,7 +17,11 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { ProgressViewHost } from '@controllers/progressView/ProgressViewHost';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import type { RunIdentity } from '@shared/schemas';
+import {
+  STREAM_PHASE,
+  USER_FOLLOW_UP_SUPPORT,
+  type RunIdentity,
+} from '@shared/schemas';
 
 // Local file imports
 import {
@@ -96,7 +100,12 @@ function createHostHarness(
         stopStream: vi.fn(),
       },
       followUp: {
-        sendFollowUp: vi.fn(),
+        getCurrentTargetMetadata: () => ({
+          userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
+          status: STREAM_PHASE.RUNNING,
+        }),
+        sendFollowUp: vi.fn(async () => ({ status: 'sent' as const })),
+        captureSubmissionResultReporter: vi.fn(() => vi.fn()),
         reportImageSaveError: vi.fn(),
       },
       bypass: {

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -110,7 +110,7 @@ type TestableBridge = Bridge & {
     streamId: StreamTabId,
     text: string,
     mediaFiles?: readonly string[],
-  ): Promise<void>;
+  ): Promise<unknown>;
   setActiveStream(streamId: StreamTabId): void;
   revealStream(streamId: StreamTabId): Promise<'revealed' | 'missing'>;
   progressViewInboundHandlers: ProgressViewInboundHandlerRegistry;
@@ -600,7 +600,7 @@ async function waitForShownPermission(
 }
 
 describe('desktop follow-up submission', () => {
-  it('does not hold the IPC request open for the resumed turn', async () => {
+  it('returns the delivery admission result before the resumed turn completes', async () => {
     const streamId = 'desktop-detached-follow-up' as StreamTabId;
     let finishResumeLookup!: (value: null) => void;
     const resumeLookup = new Promise<null>((resolve) => {
@@ -615,9 +615,11 @@ describe('desktop follow-up submission', () => {
       },
     });
 
-    await expect(bridge.sendFollowUp(streamId, 'continue')).resolves.toBe(
-      undefined,
-    );
+    await expect(bridge.sendFollowUp(streamId, 'continue')).resolves.toEqual({
+      status: 'queued',
+      reason: 'waiting',
+      continuation: 'resume_failed',
+    });
     expect(bridgeFollowUps(bridge).getAll(streamId)).toEqual(['continue']);
 
     finishResumeLookup(null);
@@ -1492,6 +1494,22 @@ describe('DesktopProgressBridge', () => {
         progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS)
           .length,
       ).toBeGreaterThan(0);
+      expect(messages).toContainEqual({
+        command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TRANSPORT_RESTORED,
+      });
+      expect(
+        messages.findIndex(
+          (message) =>
+            (message as { command?: string }).command ===
+            PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TRANSPORT_RESTORED,
+        ),
+      ).toBeGreaterThan(
+        messages.findIndex(
+          (message) =>
+            (message as { command?: string }).command ===
+            PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+        ),
+      );
     });
   });
 

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.ts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.ts
@@ -44,6 +44,7 @@ function createProgress(
   return {
     completeWebviewReady: vi.fn(async () => undefined),
     progressViewInboundHandlers: fillRegistry(progressViewInboundHandlers),
+    reportRejectedFollowUpSubmission: vi.fn(),
   };
 }
 
@@ -213,6 +214,7 @@ describe('desktop Progress IPC', () => {
     const progress = {
       completeWebviewReady: vi.fn(() => Promise.reject(error)),
       progressViewInboundHandlers: fillRegistry(),
+      reportRejectedFollowUpSubmission: vi.fn(),
     };
     const ipc = createDesktopProgressIpc({
       source: readySource(progress),
@@ -229,6 +231,129 @@ describe('desktop Progress IPC', () => {
     await Promise.resolve();
     expect(onAsyncError).toHaveBeenCalledWith(error);
   });
+
+  it.each([
+    [
+      'nine images',
+      Array.from({ length: 9 }, (_, index) => ({
+        fileName: `pasted-${index}.png`,
+        mediaType: 'image/png',
+        base64: 'A',
+      })),
+    ],
+    [
+      'an image over 3 MiB',
+      [
+        {
+          fileName: 'pasted.png',
+          mediaType: 'image/png',
+          base64: 'A'.repeat(3 * 1024 * 1024 + 1),
+        },
+      ],
+    ],
+    [
+      'an aggregate payload over 4 MiB',
+      [
+        {
+          fileName: 'pasted-a.png',
+          mediaType: 'image/png',
+          base64: 'A'.repeat(2 * 1024 * 1024 + 1),
+        },
+        {
+          fileName: 'pasted-b.png',
+          mediaType: 'image/png',
+          base64: 'B'.repeat(2 * 1024 * 1024 + 1),
+        },
+      ],
+    ],
+  ])(
+    'returns the normal rejected-submission result for %s',
+    async (_name, images) => {
+      const progress = createProgress();
+      const ipc = createDesktopProgressIpc({ source: readySource(progress) });
+
+      expect(
+        ipc.handleMessage({
+          command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
+          stream: 'run-1',
+          text: 'continue',
+          deliveryId: 'delivery-1',
+          images,
+        }),
+      ).toBe(true);
+      expect(progress.reportRejectedFollowUpSubmission).toHaveBeenCalledWith({
+        command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT,
+        stream: 'run-1',
+        deliveryId: 'delivery-1',
+        accepted: false,
+        error:
+          'Attachment limits are 8 images, 3 MiB per image, and 4 MiB total. Remove an image and try again.',
+      });
+    },
+  );
+
+  it.each([
+    ['whitespace text', { text: '   ' }, 'Enter a message before sending.'],
+    [
+      'malformed text',
+      { text: 42 },
+      'The message details are invalid. Refresh the run and try again.',
+    ],
+    [
+      'non-canonical base64',
+      {
+        text: 'continue',
+        images: [
+          {
+            fileName: 'pasted_1.png',
+            mediaType: 'image/png',
+            base64: 'not base64',
+          },
+        ],
+      },
+      'One or more images are invalid. Remove and paste them again, then try again.',
+    ],
+    [
+      'mismatched image metadata',
+      {
+        text: 'continue',
+        images: [
+          {
+            fileName: 'pasted_1.jpg',
+            mediaType: 'image/png',
+            base64: 'AAAA',
+          },
+        ],
+      },
+      'One or more images are invalid. Remove and paste them again, then try again.',
+    ],
+  ])(
+    'reports %s accurately without dispatching it',
+    async (_name, fields, error) => {
+      const sendFollowUp = vi.fn();
+      const progress = createProgress({
+        [PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP]: sendFollowUp,
+      });
+      const ipc = createDesktopProgressIpc({ source: readySource(progress) });
+
+      expect(
+        ipc.handleMessage({
+          command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
+          stream: 'run-1',
+          deliveryId: 'delivery-1',
+          ...fields,
+        }),
+      ).toBe(true);
+      expect(sendFollowUp).not.toHaveBeenCalled();
+      expect(progress.reportRejectedFollowUpSubmission).toHaveBeenCalledWith({
+        command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT,
+        stream: 'run-1',
+        deliveryId: 'delivery-1',
+        accepted: false,
+        error,
+      });
+    },
+  );
 
   it('ignores invalid Progress IPC payloads', async () => {
     const ipc = createDesktopProgressIpc({

--- a/src/test-kernel/desktop/DesktopWebviewStateStore.vitest.ts
+++ b/src/test-kernel/desktop/DesktopWebviewStateStore.vitest.ts
@@ -1,0 +1,86 @@
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DesktopWebviewStateStore,
+  desktopWebviewStatePath,
+} from '@desktop/main/desktopWebviewStateStore';
+
+const tempDirs: string[] = [];
+
+async function tempFile(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'texra-webview-state-'));
+  tempDirs.push(root);
+  return join(root, 'state.json');
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe('desktop webview state store', () => {
+  it('restores through a new main-process store instance', async () => {
+    const file = await tempFile();
+    const firstProcess = new DesktopWebviewStateStore(file);
+    firstProcess.setState({ followUpDrafts: { text: 'continue' } });
+
+    const recreatedProcess = new DesktopWebviewStateStore(file);
+
+    expect(recreatedProcess.getState()).toEqual({
+      followUpDrafts: { text: 'continue' },
+    });
+  });
+
+  it('keeps logical workspace windows in separate user-data files', () => {
+    expect(desktopWebviewStatePath('/user-data', '/workspace/a')).not.toBe(
+      desktopWebviewStatePath('/user-data', '/workspace/b'),
+    );
+    expect(desktopWebviewStatePath('/user-data', '/workspace/a')).toBe(
+      desktopWebviewStatePath('/user-data', '/workspace/a'),
+    );
+  });
+
+  it('keeps the previous atomic snapshot when a replacement is oversized', async () => {
+    const file = await tempFile();
+    const store = new DesktopWebviewStateStore(file);
+    store.setState({ draft: 'known-good' });
+
+    expect(() =>
+      store.setState({ draft: 'A'.repeat(4 * 1024 * 1024 + 1) }),
+    ).toThrow('Desktop webview state could not be persisted.');
+
+    expect(new DesktopWebviewStateStore(file).getState()).toEqual({
+      draft: 'known-good',
+    });
+  });
+
+  it('quarantines oversized serialized state before JSON.parse', async () => {
+    const file = await tempFile();
+    await writeFile(file, `{"draft":"${'A'.repeat(4 * 1024 * 1024)}"}`);
+    const parse = vi.spyOn(JSON, 'parse');
+
+    expect(new DesktopWebviewStateStore(file).getState()).toBeUndefined();
+
+    expect(parse).not.toHaveBeenCalled();
+    parse.mockRestore();
+    expect(existsSync(file)).toBe(false);
+    expect(existsSync(`${file}.invalid`)).toBe(true);
+  });
+
+  it('quarantines malformed state without exposing its payload', async () => {
+    const file = await tempFile();
+    await writeFile(file, '{');
+
+    expect(new DesktopWebviewStateStore(file).getState()).toBeUndefined();
+    expect(existsSync(file)).toBe(false);
+    expect(existsSync(`${file}.invalid`)).toBe(true);
+  });
+});

--- a/src/test-kernel/desktop/ElectronHostBridge.vitest.ts
+++ b/src/test-kernel/desktop/ElectronHostBridge.vitest.ts
@@ -5,6 +5,8 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   ELECTRON_WEBVIEW_MESSAGE_CHANNEL,
   ELECTRON_WEBVIEW_PUSH_CHANNEL,
+  ELECTRON_WEBVIEW_STATE_GET_CHANNEL,
+  ELECTRON_WEBVIEW_STATE_SET_CHANNEL,
 } from '@desktop/shared/hostBridgeChannels';
 import { HOST_BRIDGE_API_KEY } from '@shared/hostBridgeTypes';
 import { createModuleMocks } from '@test/support/moduleMocks';
@@ -14,27 +16,44 @@ import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.ts';
 
 const mocks = createModuleMocks();
 
+type IpcListener = (
+  event: { sender: unknown; returnValue?: unknown },
+  message?: unknown,
+) => void;
+
 interface HostBridgeModule {
   installElectronHostBridge(options: {
     exposeInMainWorld(name: string, api: unknown): void;
+    getStateFromMain(channel: string): unknown;
     onHostMessage(channel: string, listener: (message: unknown) => void): void;
     postToRenderer(message: unknown): void;
     sendToMain(channel: string, message: unknown): void;
-  }): unknown;
+    setStateInMain(channel: string, state: unknown): unknown;
+  }): {
+    postMessage(message: unknown): void;
+    getState(): unknown;
+    setState(state: unknown): void;
+  };
+}
+
+interface FakeMainWindow {
+  isDestroyed(): boolean;
+  once(event: 'closed', listener: () => void): void;
+  webContents: {
+    isDestroyed(): boolean;
+    send(channel: string, message: unknown): void;
+  };
 }
 
 interface MainHostBridgeModule {
   installDesktopHostBridge(
-    window: {
-      isDestroyed(): boolean;
-      once(event: 'closed', listener: () => void): void;
-      webContents: {
-        isDestroyed(): boolean;
-        send(channel: string, message: unknown): void;
-      };
-    },
+    window: FakeMainWindow,
     options?: {
       onRendererMessage?(message: unknown, window: unknown): void;
+      webviewState?: {
+        getState(): Record<string, unknown> | undefined;
+        setState(state: unknown): void;
+      };
     },
   ): {
     postToRenderer(message: unknown): void;
@@ -49,29 +68,14 @@ async function loadHostBridgeModule(): Promise<HostBridgeModule> {
 }
 
 async function loadMainHostBridgeModule(ipcMain: {
-  on(
-    channel: string,
-    listener: (event: { sender: unknown }, message: unknown) => void,
-  ): void;
-  off(
-    channel: string,
-    listener: (event: { sender: unknown }, message: unknown) => void,
-  ): void;
+  on(channel: string, listener: IpcListener): void;
+  off(channel: string, listener: IpcListener): void;
 }): Promise<MainHostBridgeModule> {
   vi.resetModules();
   mocks.doMock('electron', () => ({ ipcMain }));
   return import(
     moduleFileUrl(desktopSourcePath('main', 'hostBridge.ts'))
   ) as Promise<MainHostBridgeModule>;
-}
-
-interface FakeMainWindow {
-  isDestroyed(): boolean;
-  once(event: 'closed', listener: () => void): void;
-  webContents: {
-    isDestroyed(): boolean;
-    send(channel: string, message: unknown): void;
-  };
 }
 
 function fakeMainWindow(sends: Array<{ channel: string; message: unknown }>) {
@@ -92,22 +96,31 @@ function fakeMainWindow(sends: Array<{ channel: string; message: unknown }>) {
   return { closedListeners, webContents, window };
 }
 
+function createPreloadOptions() {
+  let state: unknown;
+  return {
+    exposeInMainWorld: vi.fn(),
+    getStateFromMain: vi.fn(() => ({ ok: true, state })),
+    onHostMessage: vi.fn(),
+    postToRenderer: vi.fn(),
+    sendToMain: vi.fn(),
+    setStateInMain: vi.fn((_channel: string, nextState: unknown) => {
+      state = nextState;
+      return { ok: true };
+    }),
+  };
+}
+
 describe('desktop Electron host bridge', () => {
   it('exposes only the shared synchronous host bridge surface', async () => {
     const { installElectronHostBridge } = await loadHostBridgeModule();
-    const sends: Array<{ channel: string; message: unknown }> = [];
     const exposed: Record<string, unknown> = {};
-
-    installElectronHostBridge({
-      exposeInMainWorld: (name, api) => {
-        exposed[name] = api;
-      },
-      onHostMessage: () => undefined,
-      postToRenderer: () => undefined,
-      sendToMain: (channel, message) => {
-        sends.push({ channel, message });
-      },
+    const options = createPreloadOptions();
+    options.exposeInMainWorld.mockImplementation((name, api) => {
+      exposed[name] = api;
     });
+
+    installElectronHostBridge(options);
     const bridge = exposed[HOST_BRIDGE_API_KEY] as {
       postMessage(message: unknown): void;
       getState(): unknown;
@@ -120,16 +133,51 @@ describe('desktop Electron host bridge', () => {
       'setState',
     ]);
     expect(bridge.getState()).toBeUndefined();
-
     const state = { route: 'main' };
     bridge.setState(state);
     expect(bridge.getState()).toBe(state);
+    expect(options.setStateInMain).toHaveBeenCalledWith(
+      ELECTRON_WEBVIEW_STATE_SET_CHANNEL,
+      state,
+    );
 
     const message = { command: 'webview.ready' };
     bridge.postMessage(message);
-    expect(sends).toEqual([
-      { channel: ELECTRON_WEBVIEW_MESSAGE_CHANNEL, message },
-    ]);
+    expect(options.sendToMain).toHaveBeenCalledWith(
+      ELECTRON_WEBVIEW_MESSAGE_CHANNEL,
+      message,
+    );
+  });
+
+  it('reads every state snapshot from the main-process authority', async () => {
+    const { installElectronHostBridge } = await loadHostBridgeModule();
+    const options = createPreloadOptions();
+    options.getStateFromMain
+      .mockReturnValueOnce({ ok: true, state: { draft: 'first' } })
+      .mockReturnValueOnce({ ok: true, state: { draft: 'recreated' } });
+    const bridge = installElectronHostBridge(options);
+
+    expect(bridge.getState()).toEqual({ draft: 'first' });
+    expect(bridge.getState()).toEqual({ draft: 'recreated' });
+    expect(options.getStateFromMain).toHaveBeenCalledWith(
+      ELECTRON_WEBVIEW_STATE_GET_CHANNEL,
+    );
+  });
+
+  it('reports a rejected replacement without keeping a preload copy', async () => {
+    const { installElectronHostBridge } = await loadHostBridgeModule();
+    const options = createPreloadOptions();
+    options.getStateFromMain.mockReturnValue({
+      ok: true,
+      state: { draft: 'known-good' },
+    });
+    options.setStateInMain.mockReturnValue({ ok: false });
+    const bridge = installElectronHostBridge(options);
+
+    expect(() => bridge.setState({ draft: 'new' })).toThrow(
+      'Desktop webview state could not be persisted.',
+    );
+    expect(bridge.getState()).toEqual({ draft: 'known-good' });
   });
 
   it('installs the bridge on the shared key and forwards host pushes', async () => {
@@ -137,77 +185,88 @@ describe('desktop Electron host bridge', () => {
     const exposed: Record<string, unknown> = {};
     const pushes: unknown[] = [];
     let pushListener: ((message: unknown) => void) | undefined;
-
-    const installed = installElectronHostBridge({
-      exposeInMainWorld: (name, api) => {
-        exposed[name] = api;
-      },
-      onHostMessage: (channel, listener) => {
-        expect(channel).toBe(ELECTRON_WEBVIEW_PUSH_CHANNEL);
-        pushListener = listener;
-      },
-      postToRenderer: (message) => {
-        pushes.push(message);
-      },
-      sendToMain: () => undefined,
+    const options = createPreloadOptions();
+    options.exposeInMainWorld.mockImplementation((name, api) => {
+      exposed[name] = api;
+    });
+    options.onHostMessage.mockImplementation((_channel, listener) => {
+      pushListener = listener;
+    });
+    options.postToRenderer.mockImplementation((message) => {
+      pushes.push(message);
     });
 
+    const installed = installElectronHostBridge(options);
     expect(exposed[HOST_BRIDGE_API_KEY]).toBe(installed);
-    expect(pushListener).toBeDefined();
-
+    expect(options.onHostMessage).toHaveBeenCalledWith(
+      ELECTRON_WEBVIEW_PUSH_CHANNEL,
+      expect.any(Function),
+    );
     const message = { command: 'setTheme', theme: 'vscode-dark' };
     pushListener?.(message);
     expect(pushes).toEqual([message]);
   });
 
-  it('routes main-process bridge messages over fixed Electron channels', async () => {
-    let rendererListener:
-      ((event: { sender: unknown }, message: unknown) => void) | undefined;
+  it('routes messages and synchronous state through fixed Electron channels', async () => {
+    const listeners = new Map<string, IpcListener>();
     const ipcMain = {
-      on: vi.fn((channel, listener) => {
-        expect(channel).toBe(ELECTRON_WEBVIEW_MESSAGE_CHANNEL);
-        rendererListener = listener;
+      on: vi.fn((channel: string, listener: IpcListener) => {
+        listeners.set(channel, listener);
       }),
-      off: vi.fn(),
+      off: vi.fn((channel: string) => {
+        listeners.delete(channel);
+      }),
     };
     const { installDesktopHostBridge } =
       await loadMainHostBridgeModule(ipcMain);
     const sends: Array<{ channel: string; message: unknown }> = [];
     const { closedListeners, webContents, window } = fakeMainWindow(sends);
     const rendererMessages: unknown[] = [];
+    let state: Record<string, unknown> | undefined = { draft: 'stored' };
     const bridge = installDesktopHostBridge(window, {
       onRendererMessage: (message) => rendererMessages.push(message),
+      webviewState: {
+        getState: () => state,
+        setState: (nextState) => {
+          state = nextState as Record<string, unknown>;
+        },
+      },
     });
 
-    expect(rendererListener).toBeDefined();
-    rendererListener?.({ sender: {} }, { ignored: true });
-    rendererListener?.({ sender: webContents }, { command: 'ready' });
+    listeners.get(ELECTRON_WEBVIEW_MESSAGE_CHANNEL)?.(
+      { sender: {} },
+      { ignored: true },
+    );
+    listeners.get(ELECTRON_WEBVIEW_MESSAGE_CHANNEL)?.(
+      { sender: webContents },
+      { command: 'ready' },
+    );
     expect(rendererMessages).toEqual([{ command: 'ready' }]);
 
-    // `theme` must be a real `ProgressSetThemeMessageSchema` value
-    // ('dark' | 'light') — `postToRenderer` now runs every message through
-    // `assertKnownOutboundMessage` (dev/test only), so an arbitrary
-    // placeholder like the renderer-side test's `'vscode-dark'` would throw
-    // here instead of exercising the channel-routing behavior under test.
+    const getEvent = { sender: webContents, returnValue: undefined as unknown };
+    listeners.get(ELECTRON_WEBVIEW_STATE_GET_CHANNEL)?.(getEvent);
+    expect(getEvent.returnValue).toEqual({
+      ok: true,
+      state: { draft: 'stored' },
+    });
+    const setEvent = { sender: webContents, returnValue: undefined as unknown };
+    listeners.get(ELECTRON_WEBVIEW_STATE_SET_CHANNEL)?.(setEvent, {
+      draft: 'next',
+    });
+    expect(setEvent.returnValue).toEqual({ ok: true });
+    expect(state).toEqual({ draft: 'next' });
+
     const hostMessage = { command: 'setTheme', theme: 'dark' };
     bridge.postToRenderer(hostMessage);
     expect(sends).toEqual([
       { channel: ELECTRON_WEBVIEW_PUSH_CHANNEL, message: hostMessage },
     ]);
-
     bridge.dispose();
-    expect(ipcMain.off).toHaveBeenCalledWith(
-      ELECTRON_WEBVIEW_MESSAGE_CHANNEL,
-      rendererListener,
-    );
+    expect(ipcMain.off).toHaveBeenCalledTimes(3);
     closedListeners[0]?.();
-    expect(ipcMain.off).toHaveBeenCalledTimes(1);
+    expect(ipcMain.off).toHaveBeenCalledTimes(3);
   });
 
-  // #8123: `postToRenderer` now routes every message through the existing
-  // MainView / ProgressView outbound Zod schemas (dev/test only) before
-  // handing it to `webContents.send`, instead of forwarding whatever shape
-  // the caller happened to build.
   describe('outbound schema validation (#8123)', () => {
     async function createBridge() {
       const ipcMain = { on: vi.fn(), off: vi.fn() };
@@ -215,18 +274,11 @@ describe('desktop Electron host bridge', () => {
         await loadMainHostBridgeModule(ipcMain);
       const sends: Array<{ channel: string; message: unknown }> = [];
       const { window } = fakeMainWindow(sends);
-      return {
-        bridge: installDesktopHostBridge(window),
-        sends,
-      };
+      return { bridge: installDesktopHostBridge(window), sends };
     }
 
-    it('throws on a ProgressView-domain message with a bad field (schema/producer drift)', async () => {
+    it('throws on a ProgressView-domain message with a bad field', async () => {
       const { bridge } = await createBridge();
-      // Same fixture shape as the channel-routing test above, but with the
-      // invalid theme value restored — proves the assertion actually fires
-      // for a real MainView/ProgressView schema mismatch, not just that the
-      // production code compiles.
       expect(() =>
         bridge.postToRenderer({ command: 'setTheme', theme: 'vscode-dark' }),
       ).toThrow(/Outbound message failed schema validation/);
@@ -245,12 +297,8 @@ describe('desktop Electron host bridge', () => {
       ]);
     });
 
-    it('passes a desktop-only command unrecognized by either outbound schema through unchecked', async () => {
+    it('passes desktop-only commands through unchecked', async () => {
       const { bridge, sends } = await createBridge();
-      // `desktop:showPdf` (and settings/history/onboarding commands) aren't
-      // modeled by MainViewMessageSchema or ProgressViewOutboundMessageSchema
-      // — out of scope for this change, so no schema claims the command and
-      // it must not throw.
       const message = { command: 'desktop:showPdf', title: 't' };
       expect(() => bridge.postToRenderer(message)).not.toThrow();
       expect(sends).toEqual([

--- a/src/test-kernel/progressView/FollowUpDraftPersistence.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpDraftPersistence.vitest.ts
@@ -1,0 +1,417 @@
+// Third-party imports
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const host = vi.hoisted(() => ({
+  state: undefined as unknown,
+  postMessage: vi.fn(),
+  setState: vi.fn((state: unknown) => {
+    host.state = state;
+  }),
+}));
+
+vi.mock('@shared/hostBridge', () => ({
+  hostBridge: {
+    getState: () => host.state,
+    setState: host.setState,
+    postMessage: host.postMessage,
+  },
+  postMessage: (command: string, payload: Record<string, unknown> = {}) => {
+    host.postMessage({ command, ...payload });
+  },
+}));
+
+vi.mock('@progressView/frontend/components/ExternalInquiryPanel', () => ({
+  clearInquiryDraft: vi.fn(),
+}));
+
+async function loadFreshFrontend() {
+  vi.resetModules();
+  const persistence =
+    await import('@progressView/frontend/followUpDraftPersistence');
+  const progressState = await import('@progressView/frontend/progressState');
+  const lifecycle =
+    await import('@progressView/frontend/slices/streamLifecycleSlice');
+  const followUps = await import('@progressView/frontend/slices/followUpSlice');
+  const events = await import('@progressView/frontend/eventHandlers');
+  const transient = await import('@progressView/frontend/followUpInputState');
+  const store = await import('@progressView/frontend/store');
+  return {
+    ...persistence,
+    ...progressState,
+    lifecycle: lifecycle.streamLifecycleHandlers,
+    followUps: followUps.followUpHandlers,
+    events,
+    transient,
+    store,
+  };
+}
+
+async function syncStreams(
+  frontend: Awaited<ReturnType<typeof loadFreshFrontend>>,
+  streamIds: string[] = ['stream-a'],
+) {
+  const { AgentCategory, STREAM_PHASE, USER_FOLLOW_UP_SUPPORT } =
+    await import('@shared/schemas');
+  const { PROGRESS_VIEW_COMMANDS } = await import('@shared/ipc');
+  frontend.lifecycle[PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS]({
+    command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+    streams: streamIds.map((name, index) => ({
+      name,
+      label: name,
+      agentCategory: AgentCategory.ToolUse,
+      userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
+      creationTimestamp: index + 1,
+    })),
+    activeStream: streamIds[0] ?? '',
+    streamStates: Object.fromEntries(
+      streamIds.map((streamId) => [
+        streamId,
+        {
+          category: AgentCategory.ToolUse,
+          status: STREAM_PHASE.RUNNING,
+          userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
+          conversationProgress: { toolCallCount: 0 },
+          subagents: [],
+        },
+      ]),
+    ),
+  });
+}
+
+function toolUseState(
+  frontend: Awaited<ReturnType<typeof loadFreshFrontend>>,
+  streamId = 'stream-a',
+) {
+  const state = frontend.appState.get().streamStates.get(streamId);
+  if (!state || !frontend.store.isToolUseState(state)) {
+    throw new Error('Expected tool-use stream state');
+  }
+  return state;
+}
+
+function image(base64: string, fileName = 'pasted_a.png') {
+  return {
+    fileName,
+    mediaType: 'image/png',
+    base64,
+  };
+}
+
+function persistedEnvelope() {
+  return (host.state as Record<string, unknown>)['followUpDrafts:v1'] as {
+    version: 1;
+    drafts: Record<string, unknown>;
+  };
+}
+
+function storedDraft(text: string) {
+  return {
+    text,
+    submission: null,
+    attachments: [],
+    updatedAt: 1,
+  };
+}
+
+describe('persisted follow-up draft recovery', () => {
+  beforeEach(() => {
+    host.state = undefined;
+    host.postMessage.mockReset();
+    host.setState.mockClear();
+  });
+
+  it('restores sending until the host explicitly reports restored transport', async () => {
+    const { PROGRESS_VIEW_COMMANDS } = await import('@shared/ipc');
+    const first = await loadFreshFrontend();
+    first.prepareFollowUpDraftRestore();
+    await syncStreams(first);
+    const originalImage = image('AAAA');
+    first.transient.getFollowUpInputTransientState('stream-a').pendingImages = [
+      originalImage,
+    ];
+    first.events.handleFollowUpChange({
+      detail: { streamId: 'stream-a', value: 'draft [pasted_a.png]' },
+    } as CustomEvent);
+    first.events.handleFollowUpSend({
+      detail: { streamId: 'stream-a', images: [originalImage] },
+    } as CustomEvent);
+    const originalDeliveryId =
+      toolUseState(first).ui.followUpSubmission?.deliveryId;
+    expect(originalDeliveryId).toBeTypeOf('string');
+
+    const reloaded = await loadFreshFrontend();
+    reloaded.prepareFollowUpDraftRestore();
+    await syncStreams(reloaded);
+    expect(toolUseState(reloaded).ui.followUpSubmission).toEqual(
+      expect.objectContaining({
+        status: 'sending',
+        deliveryId: originalDeliveryId,
+      }),
+    );
+
+    reloaded.followUps[PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TRANSPORT_RESTORED]();
+    const restoredImages =
+      reloaded.transient.getFollowUpInputTransientState(
+        'stream-a',
+      ).pendingImages;
+    expect(toolUseState(reloaded).ui.followUpSubmission).toEqual(
+      expect.objectContaining({
+        status: 'failed',
+        deliveryId: originalDeliveryId,
+        error: 'Delivery status was not confirmed. Try again.',
+      }),
+    );
+    expect(restoredImages).toEqual([originalImage]);
+
+    reloaded.events.handleFollowUpSend({
+      detail: { streamId: 'stream-a', images: restoredImages },
+    } as CustomEvent);
+    expect(host.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
+        deliveryId: originalDeliveryId,
+        images: [originalImage],
+      }),
+    );
+  });
+
+  it('keeps restore pending across incomplete stream metadata updates', async () => {
+    const { USER_FOLLOW_UP_SUPPORT } = await import('@shared/schemas');
+    const { PROGRESS_VIEW_COMMANDS } = await import('@shared/ipc');
+    host.state = {
+      'followUpDrafts:v1': {
+        version: 1,
+        drafts: { 'stream-a': storedDraft('restored draft') },
+      },
+    };
+    const frontend = await loadFreshFrontend();
+    frontend.prepareFollowUpDraftRestore();
+
+    frontend.lifecycle[PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS]({
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+      streams: [
+        {
+          name: 'stream-a',
+          label: 'stream-a',
+          userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
+          creationTimestamp: 1,
+        },
+      ],
+      activeStream: 'stream-a',
+      streamStates: {},
+    });
+    expect(frontend.appState.get().streamStates.has('stream-a')).toBe(false);
+
+    await syncStreams(frontend);
+
+    expect(toolUseState(frontend).ui.followUpText).toBe('restored draft');
+  });
+
+  it.each([
+    [
+      'record count',
+      () =>
+        Object.fromEntries(
+          Array.from({ length: 21 }, (_, index) => [
+            `stream-${index}`,
+            storedDraft('draft'),
+          ]),
+        ),
+    ],
+    [
+      'text length',
+      () => ({
+        'stream-a': storedDraft('A'.repeat(256 * 1024 + 1)),
+      }),
+    ],
+    ['stream id length', () => ({ ['s'.repeat(257)]: storedDraft('draft') })],
+    [
+      'submission id length',
+      () => ({
+        'stream-a': {
+          ...storedDraft('draft'),
+          submission: {
+            status: 'sending',
+            deliveryId: 'd'.repeat(257),
+            text: 'draft',
+            attachmentFingerprints: [],
+          },
+        },
+      }),
+    ],
+    [
+      'submission error length',
+      () => ({
+        'stream-a': {
+          ...storedDraft('draft'),
+          submission: {
+            status: 'failed',
+            deliveryId: 'delivery',
+            text: 'draft',
+            attachmentFingerprints: [],
+            error: 'E'.repeat(1025),
+          },
+        },
+      }),
+    ],
+    [
+      'attachment count',
+      () => ({
+        'stream-a': {
+          ...storedDraft('draft'),
+          attachments: Array.from({ length: 9 }, (_, index) => ({
+            ...image('AAAA', `pasted_${index}.png`),
+            fingerprint: 'fingerprint',
+          })),
+        },
+      }),
+    ],
+    [
+      'per-image base64 length',
+      () => ({
+        'stream-a': {
+          ...storedDraft('draft'),
+          attachments: [
+            {
+              ...image('A'.repeat(3 * 1024 * 1024 + 1)),
+              fingerprint: 'fingerprint',
+            },
+          ],
+        },
+      }),
+    ],
+    [
+      'attachment fingerprint length',
+      () => ({
+        'stream-a': {
+          ...storedDraft('draft'),
+          attachments: [
+            {
+              ...image('AAAA'),
+              fingerprint: 'f'.repeat(129),
+            },
+          ],
+        },
+      }),
+    ],
+    [
+      'attachment metadata',
+      () => ({
+        'stream-a': {
+          ...storedDraft('draft'),
+          attachments: [
+            {
+              ...image('AAAA', 'pasted_a.jpg'),
+              fingerprint: 'fingerprint',
+            },
+          ],
+        },
+      }),
+    ],
+    [
+      'aggregate size',
+      () => ({
+        'stream-a': {
+          ...storedDraft('draft'),
+          attachments: [
+            {
+              ...image('A'.repeat(2 * 1024 * 1024 + 4), 'pasted_a.png'),
+              fingerprint: 'first',
+            },
+            {
+              ...image('B'.repeat(2 * 1024 * 1024 + 4), 'pasted_b.png'),
+              fingerprint: 'second',
+            },
+          ],
+        },
+      }),
+    ],
+  ])(
+    'clears restored state that violates the %s limit',
+    async (_name, buildDrafts) => {
+      host.state = {
+        'followUpDrafts:v1': { version: 1, drafts: buildDrafts() },
+      };
+      const frontend = await loadFreshFrontend();
+
+      frontend.prepareFollowUpDraftRestore();
+
+      expect(
+        (host.state as Record<string, unknown>)['followUpDrafts:v1'],
+      ).toBeUndefined();
+    },
+  );
+
+  it('rejects a twenty-first stream without evicting the existing drafts', async () => {
+    const existingIds = Array.from(
+      { length: 20 },
+      (_, index) => `stream-${index + 1}`,
+    );
+    host.state = {
+      'followUpDrafts:v1': {
+        version: 1,
+        drafts: Object.fromEntries(
+          existingIds.map((streamId) => [streamId, storedDraft(streamId)]),
+        ),
+      },
+    };
+    const frontend = await loadFreshFrontend();
+    frontend.prepareFollowUpDraftRestore();
+    await syncStreams(frontend, [...existingIds, 'stream-21']);
+    frontend.events.handleFollowUpChange({
+      detail: { streamId: 'stream-21', value: 'new draft' },
+    } as CustomEvent);
+
+    const result = frontend.persistFollowUpDraft('stream-21');
+
+    expect(result).toEqual({
+      persisted: false,
+      error: 'Follow-up storage is full. Clear an older draft, then try again.',
+    });
+    expect(Object.keys(persistedEnvelope().drafts)).toEqual(existingIds);
+  });
+
+  it.each([
+    {
+      name: 'nine attachments',
+      images: Array.from({ length: 9 }, (_, index) =>
+        image('A', `pasted-${index}.png`),
+      ),
+      error: 'Attach no more than 8 images, then try again.',
+    },
+    {
+      name: 'an attachment over 3 MiB',
+      images: [image('A'.repeat(3 * 1024 * 1024 + 1))],
+      error:
+        'Each image must be 3 MiB or smaller. Remove the large image, then try again.',
+    },
+    {
+      name: 'aggregate 4 MiB pressure',
+      images: [
+        image('A'.repeat(2 * 1024 * 1024 + 1), 'pasted_a.png'),
+        image('B'.repeat(2 * 1024 * 1024 + 1), 'pasted_b.png'),
+      ],
+      error:
+        'The follow-up is too large to preserve safely. Remove an image or shorten the message, then try again.',
+    },
+  ])(
+    'keeps the last-known-good snapshot for $name',
+    async ({ images, error }) => {
+      const frontend = await loadFreshFrontend();
+      frontend.prepareFollowUpDraftRestore();
+      await syncStreams(frontend);
+      frontend.events.handleFollowUpChange({
+        detail: { streamId: 'stream-a', value: 'known good' },
+      } as CustomEvent);
+      const before = JSON.stringify(persistedEnvelope());
+      frontend.transient.getFollowUpInputTransientState(
+        'stream-a',
+      ).pendingImages = images;
+
+      const result = frontend.persistFollowUpDraft('stream-a');
+
+      expect(result).toEqual({ persisted: false, error });
+      expect(JSON.stringify(persistedEnvelope())).toBe(before);
+    },
+  );
+});

--- a/src/test-kernel/progressView/FollowUpEventHandlers.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpEventHandlers.vitest.ts
@@ -4,9 +4,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   postMessage: vi.fn(),
+  setState: vi.fn(),
 }));
 
 vi.mock('@shared/hostBridge', () => ({
+  hostBridge: {
+    getState: () => undefined,
+    setState: mocks.setState,
+  },
   postMessage: mocks.postMessage,
 }));
 
@@ -24,6 +29,12 @@ import {
   resetProgressState,
 } from '@progressView/frontend/progressState';
 import {
+  fingerprintFollowUpImage,
+  getFollowUpInputTransientState,
+} from '@progressView/frontend/followUpInputState';
+import { followUpHandlers } from '@progressView/frontend/slices/followUpSlice';
+import { streamLifecycleHandlers } from '@progressView/frontend/slices/streamLifecycleSlice';
+import {
   createInitialState,
   isToolUseState,
   type ProgressState,
@@ -33,6 +44,8 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   AgentCategory,
   createStreamState,
+  STREAM_PHASE,
+  USER_FOLLOW_UP_SUPPORT,
   type StreamTabId,
 } from '@shared/schemas';
 
@@ -40,15 +53,13 @@ function createToolUseState(text: string): StreamState {
   const state = createStreamState(AgentCategory.ToolUse);
   if (!isToolUseState(state)) throw new Error('Expected tool-use state');
   return create(state, (draft) => {
+    draft.status = STREAM_PHASE.RUNNING;
+    draft.userFollowUpSupport = USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE;
     draft.ui.followUpText = text;
   });
 }
 
-/**
- * Seed the shared appState singleton with two tool-use streams and return a
- * live reader over it. Streams are registered in `streamById` too, so the
- * real `setStreamStateForId` mutator accepts updates for them.
- */
+/** Seed two supported streams while stream B owns visible focus. */
 function seedState(): () => ProgressState {
   const state = createInitialState();
   state.activeStreamId = 'stream-b';
@@ -61,6 +72,7 @@ function seedState(): () => ProgressState {
       name: streamId as StreamTabId,
       label: streamId,
       agentCategory: AgentCategory.ToolUse,
+      userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
       creationTimestamp: 1,
     });
   }
@@ -68,12 +80,21 @@ function seedState(): () => ProgressState {
   return () => appState.get();
 }
 
-function followUpText(state: ProgressState, streamId: string): string {
+function toolUseState(state: ProgressState, streamId: string) {
   const stream = state.streamStates.get(streamId);
   if (!stream || !isToolUseState(stream)) {
     throw new Error(`Expected tool-use state for ${streamId}`);
   }
-  return stream.ui.followUpText;
+  return stream;
+}
+
+function send(
+  streamId = 'stream-a',
+  images: Array<{ fileName: string; base64: string; mediaType: string }> = [],
+): void {
+  handleFollowUpSend({
+    detail: { streamId, images },
+  } as CustomEvent);
 }
 
 describe('stream-scoped follow-up event handlers', () => {
@@ -88,45 +109,369 @@ describe('stream-scoped follow-up event handlers', () => {
     handleFollowUpChange({
       detail: {
         streamId: 'stream-a',
-        value: '[pasted-a.png]',
+        value: '[pasted_a.png]',
         mode: 'append',
       },
     } as CustomEvent);
 
-    expect(followUpText(getState(), 'stream-a')).toBe('draft [pasted-a.png]');
-    expect(followUpText(getState(), 'stream-b')).toBe('other');
+    expect(toolUseState(getState(), 'stream-a').ui.followUpText).toBe(
+      'draft [pasted_a.png]',
+    );
+    expect(toolUseState(getState(), 'stream-b').ui.followUpText).toBe('other');
   });
 
-  it('sends stream A images while stream B is active', () => {
+  it('routes the source stream while another stream has focus and waits for acceptance', () => {
     const getState = seedState();
     handleFollowUpChange({
       detail: {
         streamId: 'stream-a',
-        value: 'draft [pasted-a.png]',
+        value: 'draft [pasted_a.png]',
       },
     } as CustomEvent);
     const pastedImage = {
-      fileName: 'pasted-a.png',
+      fileName: 'pasted_a.png',
       base64: 'AAAA',
       mediaType: 'image/png',
     };
 
     handleFollowUpSend({
-      detail: {
-        streamId: 'stream-a',
-        images: [pastedImage],
-      },
+      detail: { streamId: 'stream-a', images: [pastedImage] },
     } as CustomEvent);
 
     expect(mocks.postMessage).toHaveBeenCalledWith(
       PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
       {
         stream: 'stream-a',
-        text: 'draft [pasted-a.png]',
+        text: 'draft [pasted_a.png]',
+        deliveryId: expect.any(String),
         images: [pastedImage],
       },
     );
-    expect(followUpText(getState(), 'stream-a')).toBe('');
-    expect(followUpText(getState(), 'stream-b')).toBe('other');
+    expect(toolUseState(getState(), 'stream-a').ui.followUpText).toBe(
+      'draft [pasted_a.png]',
+    );
+    expect(toolUseState(getState(), 'stream-b').ui.followUpText).toBe('other');
   });
+
+  it('prevents duplicate sends while delivery is in flight', () => {
+    seedState();
+
+    send();
+    send();
+
+    expect(mocks.postMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('makes a storage failure retryable instead of posting or staying sending', () => {
+    const getState = seedState();
+    mocks.setState.mockImplementationOnce(() => {
+      throw new Error('quota');
+    });
+
+    send();
+
+    expect(mocks.postMessage).not.toHaveBeenCalled();
+    expect(toolUseState(getState(), 'stream-a').ui.followUpSubmission).toEqual(
+      expect.objectContaining({
+        status: 'failed',
+        error:
+          'The follow-up could not be saved in this window. Free storage or reload TeXRA, then try again.',
+      }),
+    );
+  });
+
+  it('preserves a failed draft and retries with the same delivery id', () => {
+    const getState = seedState();
+    send();
+    const deliveryId = toolUseState(getState(), 'stream-a').ui
+      .followUpSubmission?.deliveryId;
+    if (!deliveryId) throw new Error('Expected pending delivery');
+
+    followUpHandlers[PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT]({
+      command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT,
+      stream: 'stream-a',
+      deliveryId,
+      accepted: false,
+      error: 'Unable to send. Check your connection and try again.',
+    });
+
+    expect(toolUseState(getState(), 'stream-a').ui.followUpText).toBe('draft');
+    expect(toolUseState(getState(), 'stream-a').ui.followUpSubmission).toEqual({
+      status: 'failed',
+      deliveryId,
+      text: 'draft',
+      attachmentFingerprints: [],
+      error: 'Unable to send. Check your connection and try again.',
+    });
+
+    send();
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
+      expect.objectContaining({ deliveryId }),
+    );
+  });
+
+  it('retains text and images after an image-save rejection', () => {
+    const getState = seedState();
+    const image = {
+      fileName: 'pasted_a.png',
+      base64: 'AAAA',
+      mediaType: 'image/png',
+    };
+    const transientState = getFollowUpInputTransientState('stream-a');
+    transientState.pendingImages = [image];
+    handleFollowUpChange({
+      detail: { streamId: 'stream-a', value: 'draft [pasted_a.png]' },
+    } as CustomEvent);
+    send('stream-a', [image]);
+    const deliveryId = toolUseState(getState(), 'stream-a').ui
+      .followUpSubmission?.deliveryId;
+    if (!deliveryId) throw new Error('Expected pending delivery');
+
+    followUpHandlers[PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT]({
+      command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT,
+      stream: 'stream-a',
+      deliveryId,
+      accepted: false,
+      error:
+        'An image could not be saved. Remove and paste the images again, then try again.',
+    });
+
+    expect(toolUseState(getState(), 'stream-a').ui.followUpText).toBe(
+      'draft [pasted_a.png]',
+    );
+    expect(transientState.pendingImages).toEqual([image]);
+  });
+
+  it('uses a new delivery id when failed-retry attachments change', () => {
+    const getState = seedState();
+    const firstImage = {
+      fileName: 'pasted_a.png',
+      base64: 'AAAA',
+      mediaType: 'image/png',
+    };
+    handleFollowUpChange({
+      detail: { streamId: 'stream-a', value: 'draft [pasted_a.png]' },
+    } as CustomEvent);
+    send('stream-a', [firstImage]);
+    const firstSubmission = toolUseState(getState(), 'stream-a').ui
+      .followUpSubmission;
+    if (!firstSubmission) throw new Error('Expected pending delivery');
+    followUpHandlers[PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT]({
+      command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT,
+      stream: 'stream-a',
+      deliveryId: firstSubmission.deliveryId,
+      accepted: false,
+      error: 'Try again.',
+    });
+
+    const changedImage = { ...firstImage, base64: 'BBBB' };
+    send('stream-a', [changedImage]);
+
+    const retry = toolUseState(getState(), 'stream-a').ui.followUpSubmission;
+    expect(retry?.deliveryId).not.toBe(firstSubmission.deliveryId);
+    expect(retry?.attachmentFingerprints).toEqual([
+      fingerprintFollowUpImage(changedImage),
+    ]);
+  });
+
+  it('clears only the accepted attachment snapshot after async draft changes', () => {
+    const getState = seedState();
+    const sentImage = {
+      fileName: 'pasted_a.png',
+      base64: 'AAAA',
+      mediaType: 'image/png',
+    };
+    const newImage = {
+      fileName: 'pasted_b.png',
+      base64: 'BBBB',
+      mediaType: 'image/png',
+    };
+    const transientState = getFollowUpInputTransientState('stream-a');
+    transientState.pendingImages = [sentImage];
+    handleFollowUpChange({
+      detail: { streamId: 'stream-a', value: 'draft [pasted_a.png]' },
+    } as CustomEvent);
+    send('stream-a', transientState.pendingImages);
+    const submission = toolUseState(getState(), 'stream-a').ui
+      .followUpSubmission;
+    if (!submission) throw new Error('Expected pending delivery');
+
+    transientState.pendingImages = [sentImage, newImage];
+    handleFollowUpChange({
+      detail: {
+        streamId: 'stream-a',
+        value: 'new draft [pasted_b.png]',
+      },
+    } as CustomEvent);
+    followUpHandlers[PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT]({
+      command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT,
+      stream: 'stream-a',
+      deliveryId: submission.deliveryId,
+      accepted: true,
+    });
+
+    expect(toolUseState(getState(), 'stream-a').ui.followUpText).toBe(
+      'new draft [pasted_b.png]',
+    );
+    expect(transientState.pendingImages).toEqual([newImage]);
+  });
+
+  it('preserves matching text when its attachment changed during delivery', () => {
+    const getState = seedState();
+    const sentImage = {
+      fileName: 'pasted_a.png',
+      base64: 'AAAA',
+      mediaType: 'image/png',
+    };
+    const changedImage = { ...sentImage, base64: 'BBBB' };
+    const transientState = getFollowUpInputTransientState('stream-a');
+    transientState.pendingImages = [sentImage];
+    handleFollowUpChange({
+      detail: { streamId: 'stream-a', value: 'draft [pasted_a.png]' },
+    } as CustomEvent);
+    send('stream-a', transientState.pendingImages);
+    const deliveryId = toolUseState(getState(), 'stream-a').ui
+      .followUpSubmission?.deliveryId;
+    if (!deliveryId) throw new Error('Expected pending delivery');
+
+    transientState.pendingImages = [changedImage];
+    followUpHandlers[PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT]({
+      command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT,
+      stream: 'stream-a',
+      deliveryId,
+      accepted: true,
+    });
+
+    expect(toolUseState(getState(), 'stream-a').ui.followUpText).toBe(
+      'draft [pasted_a.png]',
+    );
+    expect(transientState.pendingImages).toEqual([changedImage]);
+  });
+
+  it('clears only the accepted stream draft and ignores stale replay', () => {
+    const getState = seedState();
+    send();
+    const deliveryId = toolUseState(getState(), 'stream-a').ui
+      .followUpSubmission?.deliveryId;
+    if (!deliveryId) throw new Error('Expected pending delivery');
+
+    followUpHandlers[PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT]({
+      command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT,
+      stream: 'stream-a',
+      deliveryId: 'stale-delivery',
+      accepted: true,
+    });
+    expect(toolUseState(getState(), 'stream-a').ui.followUpText).toBe('draft');
+
+    followUpHandlers[PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT]({
+      command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT,
+      stream: 'stream-a',
+      deliveryId,
+      accepted: true,
+    });
+    expect(toolUseState(getState(), 'stream-a').ui.followUpText).toBe('');
+    expect(toolUseState(getState(), 'stream-b').ui.followUpText).toBe('other');
+  });
+
+  it('keeps delivery in flight across ordinary structural state refreshes', () => {
+    const getState = seedState();
+    send();
+    const streamInfo = getState().streamById.get('stream-a');
+    const otherStreamInfo = getState().streamById.get('stream-b');
+    if (!streamInfo || !otherStreamInfo)
+      throw new Error('Expected stream info');
+
+    streamLifecycleHandlers[PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS]({
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+      streams: [streamInfo, otherStreamInfo],
+      activeStream: 'stream-a',
+      streamStates: {
+        'stream-a': {
+          category: AgentCategory.ToolUse,
+          status: STREAM_PHASE.WAITING,
+          userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
+          conversationProgress: { toolCallCount: 1 },
+          subagents: [],
+        },
+      },
+    });
+
+    expect(toolUseState(getState(), 'stream-a').ui.followUpText).toBe('draft');
+    expect(toolUseState(getState(), 'stream-a').ui.followUpSubmission).toEqual(
+      expect.objectContaining({ status: 'sending' }),
+    );
+    send();
+    expect(mocks.postMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('makes an unresolved delivery retryable on explicit transport restore', () => {
+    const getState = seedState();
+    const image = {
+      fileName: 'pasted_a.png',
+      base64: 'AAAA',
+      mediaType: 'image/png',
+    };
+    handleFollowUpChange({
+      detail: { streamId: 'stream-a', value: 'draft [pasted_a.png]' },
+    } as CustomEvent);
+    send('stream-a', [image]);
+    const deliveryId = toolUseState(getState(), 'stream-a').ui
+      .followUpSubmission?.deliveryId;
+
+    followUpHandlers[PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TRANSPORT_RESTORED]();
+
+    expect(toolUseState(getState(), 'stream-a').ui.followUpSubmission).toEqual(
+      expect.objectContaining({
+        status: 'failed',
+        deliveryId,
+        error: 'Delivery status was not confirmed. Try again.',
+      }),
+    );
+    send('stream-a', [image]);
+    expect(mocks.postMessage).toHaveBeenCalledTimes(2);
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
+      expect.objectContaining({ deliveryId, images: [image] }),
+    );
+  });
+
+  it.each([
+    [
+      'unsupported',
+      USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
+      STREAM_PHASE.RUNNING,
+      'This run does not accept follow-up messages.',
+    ],
+    [
+      'terminal',
+      USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
+      STREAM_PHASE.COMPLETED,
+      'This run has ended. Start a new agent task to continue.',
+    ],
+  ])(
+    'rejects %s current metadata and preserves the draft',
+    (_name, support, status, error) => {
+      const getState = seedState();
+      appState.set(
+        create(appState.get(), (draft) => {
+          const state = draft.streamStates.get('stream-a');
+          if (state) {
+            state.userFollowUpSupport = support;
+            state.status = status;
+          }
+        }),
+      );
+
+      send();
+
+      expect(mocks.postMessage).not.toHaveBeenCalled();
+      expect(toolUseState(getState(), 'stream-a').ui.followUpText).toBe(
+        'draft',
+      );
+      expect(
+        toolUseState(getState(), 'stream-a').ui.followUpSubmission,
+      ).toEqual(expect.objectContaining({ status: 'failed', error }));
+    },
+  );
 });

--- a/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
@@ -52,6 +52,10 @@ type FollowUpInputInternals = HTMLElement & {
   value: string;
   streamId: string;
   transientState: FollowUpInputTransientState | null;
+  submission: unknown;
+  availability: unknown;
+  unsupportedCommands: ReadonlySet<string> | null;
+  recording: boolean;
   followUpEventSink: (event: CustomEvent) => void;
   updateComplete: Promise<boolean>;
   handlePaste: (event: ClipboardEvent) => void;
@@ -144,6 +148,42 @@ describe('follow-up-input layout', () => {
     expect(textarea?.resize).toBe('vertical');
     expect(textarea?.input.rows).toBe(2);
   });
+
+  it('announces sending and disables draft-mutating controls', async () => {
+    const element = createFollowUpInput('stream-sending');
+    element.availability = { available: true };
+    element.unsupportedCommands = new Set();
+    element.submission = {
+      status: 'sending',
+      deliveryId: 'delivery-a',
+      text: 'draft',
+      attachmentFingerprints: [],
+    };
+    await element.updateComplete;
+
+    const root = element.shadowRoot;
+    expect(root?.querySelector('[role="status"]')?.textContent?.trim()).toBe(
+      'Sending...',
+    );
+    expect(root?.querySelector('wa-textarea')?.hasAttribute('disabled')).toBe(
+      true,
+    );
+    expect(
+      root?.querySelector('#polishFollowUpBtn')?.hasAttribute('disabled'),
+    ).toBe(true);
+    expect(
+      root?.querySelector('#sendFollowUpBtn')?.classList.contains('is-busy'),
+    ).toBe(true);
+    expect(
+      root?.querySelector('#recordFollowUpBtn')?.hasAttribute('disabled'),
+    ).toBe(true);
+
+    element.recording = true;
+    await element.updateComplete;
+    expect(
+      root?.querySelector('#recordFollowUpBtn')?.hasAttribute('disabled'),
+    ).toBe(false);
+  });
 });
 
 describe('follow-up-input pasted-image state across stream switches', () => {
@@ -158,8 +198,8 @@ describe('follow-up-input pasted-image state across stream switches', () => {
     await element.updateComplete;
 
     const streamB = getFollowUpInputTransientState('stream-b');
-    const imageA = seedPendingImage('stream-a', 'pasted-a.png');
-    const imageB = image('pasted-b.png');
+    const imageA = seedPendingImage('stream-a', 'pasted_a.png');
+    const imageB = image('pasted_b.png');
 
     bindStream(element, 'stream-b');
     streamB.pendingImages = [imageB];
@@ -177,7 +217,7 @@ describe('follow-up-input pasted-image state across stream switches', () => {
     await element.updateComplete;
 
     const streamA = getFollowUpInputTransientState('stream-a');
-    const imageA = seedPendingImage('stream-a', 'pasted-a.png');
+    const imageA = seedPendingImage('stream-a', 'pasted_a.png');
     const pendingPaste = new Promise<void>(() => {});
     streamA.pendingImagePastes.add(pendingPaste);
 
@@ -200,7 +240,7 @@ describe('follow-up-input pasted-image state across stream switches', () => {
     const element = createFollowUpInput('stream-a');
     await element.updateComplete;
 
-    const imageA = seedPendingImage('stream-a', 'pasted-a.png');
+    const imageA = seedPendingImage('stream-a', 'pasted_a.png');
 
     element.value = 'follow-up text';
     await element.updateComplete;
@@ -266,6 +306,15 @@ describe('follow-up-input pasted-image state across stream switches', () => {
         },
       ],
     });
-    expect(streamA.pendingImages).toEqual([]);
+    // The delivery result handler clears attachments only after the host
+    // accepts this send. A rejected or interrupted delivery must retain them
+    // for the retry together with the text draft.
+    expect(streamA.pendingImages).toEqual([
+      {
+        fileName: 'pasted-test.png',
+        base64: 'encoded-image',
+        mediaType: 'image/png',
+      },
+    ]);
   });
 });

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
@@ -3,14 +3,22 @@ import '@test/support/defaultSessionTestSetup';
 
 // Third-party imports
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
 
 // Local imports
+import type { SubmitFollowUpResult } from '@agent/followUp/ToolUseFollowUp';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { ProgressHostInteractions } from '@controllers/progressView/backend/progressHostInteractions';
 import * as logger from '@logger/logUtils';
 import { ProgressViewMessageHandler } from '@progressView/ProgressViewMessageHandler';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
-import type { StreamTabId } from '@shared/schemas';
+import {
+  STREAM_PHASE,
+  USER_FOLLOW_UP_SUPPORT,
+  type StreamTabId,
+} from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import { seedStreamStatusForTest } from '@test/support/streamStatusTestUtils';
 
 // Local file imports
 import { FakePromptHost } from '../support/FakeHosts';
@@ -19,11 +27,16 @@ import {
   createWorkflowConfig,
 } from '../support/ProgressControllerHarnesses';
 
-import type * as vscode from 'vscode';
-
 const mocks = vi.hoisted(() => ({
   safeExecuteCommand: vi.fn(),
+  submitFollowUp: vi.fn(),
 }));
+
+vi.mock('@agent/followUp/ToolUseFollowUp', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@agent/followUp/ToolUseFollowUp')>();
+  return { ...actual, submitFollowUp: mocks.submitFollowUp };
+});
 
 vi.mock('@frontend/system/commandUtils', () => ({
   safeExecuteCommand: mocks.safeExecuteCommand,
@@ -90,6 +103,9 @@ function createProgressViewProvider(): ProgressViewProviderFake {
     streamLogs: new Map<StreamTabId, unknown>(),
     snapshots,
     pickValidActiveStream: vi.fn(() => ''),
+    getStreamMetadata: vi.fn(() => ({
+      userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
+    })),
     waitForOwnedExecutionRelease: vi.fn(async () => undefined),
   };
   return {
@@ -131,8 +147,13 @@ function createProviderShell(
 
 describe('progress-view onboarding refresh wiring', () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
     mocks.safeExecuteCommand.mockResolvedValue(undefined);
+    mocks.submitFollowUp.mockResolvedValue({ status: 'sent' });
+    vi.spyOn(vscode.window, 'showInformationMessage').mockResolvedValue(
+      undefined,
+    );
   });
 
   it('refreshes the onboarding funnel after progress setup actions', async () => {
@@ -163,6 +184,153 @@ describe('progress-view onboarding refresh wiring', () => {
       expect(refreshCallOrder).toBeDefined();
       expect(setupCallOrder!).toBeLessThan(refreshCallOrder!);
     });
+  });
+
+  it('syncs restored drafts before reporting restored follow-up transport', async () => {
+    const provider = createProgressViewProvider();
+    const view = createWebviewView();
+    vi.mocked(provider.markWebviewReady).mockImplementation(async () => {
+      await view.webview.postMessage({
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+      });
+    });
+    const handler = createMessageHandler(provider);
+
+    await handler.handleMessage(
+      { command: PROGRESS_VIEW_COMMANDS.WEBVIEW_READY, view: 'progress' },
+      view,
+    );
+
+    expect(view.webview.postMessage).toHaveBeenNthCalledWith(1, {
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+    });
+    expect(view.webview.postMessage).toHaveBeenNthCalledWith(2, {
+      command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TRANSPORT_RESTORED,
+    });
+  });
+
+  it('rejects an oversized renderer follow-up through the normal result channel', async () => {
+    const source = createWebviewView();
+    const handler = createMessageHandler(createProgressViewProvider());
+
+    await handler.handleMessage(
+      {
+        command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
+        stream: 'oversized-renderer',
+        text: 'continue',
+        deliveryId: 'oversized-delivery',
+        images: Array.from({ length: 9 }, (_, index) => ({
+          fileName: `pasted-${index}.png`,
+          mediaType: 'image/png',
+          base64: 'A',
+        })),
+      },
+      source,
+    );
+
+    expect(source.webview.postMessage).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT,
+      stream: 'oversized-renderer',
+      deliveryId: 'oversized-delivery',
+      accepted: false,
+      error:
+        'Attachment limits are 8 images, 3 MiB per image, and 4 MiB total. Remove an image and try again.',
+    });
+    expect(mocks.submitFollowUp).not.toHaveBeenCalled();
+  });
+
+  it('returns a pending follow-up result to its originating surface', async () => {
+    const streamId = 'originating-surface' as StreamTabId;
+    seedStreamStatusForTest(defaultSession().status, streamId, {
+      phase: STREAM_PHASE.RUNNING,
+    });
+    let finishSubmission: (result: SubmitFollowUpResult) => void = () => {};
+    mocks.submitFollowUp.mockReturnValue(
+      new Promise((resolve) => {
+        finishSubmission = resolve;
+      }),
+    );
+    const emit = vi.spyOn(defaultSession().events, 'emit');
+    const provider = createProgressViewProvider();
+    const handler = createMessageHandler(provider);
+    const sidebar = createWebviewView();
+    const panel = createWebviewView();
+
+    await handler.handleMessage(
+      {
+        command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
+        stream: streamId,
+        text: 'continue',
+        deliveryId: 'delivery-origin',
+      },
+      sidebar,
+    );
+    await handler.handleMessage(
+      { command: PROGRESS_VIEW_COMMANDS.WEBVIEW_READY, view: 'progress' },
+      panel,
+    );
+    finishSubmission({
+      status: 'queued',
+      reason: 'waiting',
+      continuation: 'resume_failed',
+    });
+
+    await vi.waitFor(() => {
+      expect(sidebar.webview.postMessage).toHaveBeenCalledWith({
+        command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT,
+        stream: streamId,
+        deliveryId: 'delivery-origin',
+        accepted: true,
+      });
+    });
+    expect(panel.webview.postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_SUBMISSION_RESULT,
+      }),
+    );
+    expect(emit).toHaveBeenCalledWith({
+      scope: 'session',
+      event: {
+        type: 'updateQueuedFollowUps',
+        payload: { streamId },
+      },
+    });
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      'Message queued. Auto-resume failed; start a new agent task to continue.',
+    );
+  });
+
+  it('accepts a duplicate follow-up without repeating runtime effects', async () => {
+    const streamId = 'duplicate-delivery' as StreamTabId;
+    seedStreamStatusForTest(defaultSession().status, streamId, {
+      phase: STREAM_PHASE.RUNNING,
+    });
+    mocks.submitFollowUp.mockResolvedValue({ status: 'duplicate' });
+    const emit = vi.spyOn(defaultSession().events, 'emit');
+    const handler = createMessageHandler(createProgressViewProvider());
+    const source = createWebviewView();
+
+    await handler.handleMessage(
+      {
+        command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
+        stream: streamId,
+        text: 'continue',
+        deliveryId: 'delivery-duplicate',
+      },
+      source,
+    );
+
+    await vi.waitFor(() => {
+      expect(source.webview.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ accepted: true }),
+      );
+    });
+    expect(emit).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({ type: 'updateQueuedFollowUps' }),
+      }),
+    );
+    expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
   });
 
   it('acknowledges a replacement run when the runtime publishes its handle', async () => {

--- a/src/test-kernel/shared/StreamFollowUpCapability.vitest.ts
+++ b/src/test-kernel/shared/StreamFollowUpCapability.vitest.ts
@@ -8,7 +8,10 @@ import {
   type StreamPhase,
   type UserFollowUpSupport,
 } from '@shared/schemas';
-import { streamAllowsChildFollowUpComposer } from '@shared/streams/followUpCapability';
+import {
+  streamAllowsChildFollowUpComposer,
+  userFollowUpAvailability,
+} from '@shared/streams/followUpCapability';
 
 describe('streamAllowsChildFollowUpComposer', () => {
   const inFlightPhases = [STREAM_PHASE.RUNNING, STREAM_PHASE.WAITING] as const;
@@ -140,4 +143,37 @@ describe('streamAllowsChildFollowUpComposer', () => {
       ).toBe(false);
     },
   );
+});
+
+describe('userFollowUpAvailability', () => {
+  it.each([
+    USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
+    USER_FOLLOW_UP_SUPPORT.TERMINAL_BACKED,
+  ])('admits %s host delivery in running and waiting phases', (support) => {
+    for (const status of [STREAM_PHASE.RUNNING, STREAM_PHASE.WAITING]) {
+      expect(
+        userFollowUpAvailability({
+          userFollowUpSupport: support,
+          status,
+        }),
+      ).toEqual({ available: true });
+    }
+  });
+
+  it.each([
+    STREAM_PHASE.COMPLETED,
+    STREAM_PHASE.CANCELLED,
+    STREAM_PHASE.FAILED,
+  ])('rejects terminal phase %s', (status) => {
+    expect(
+      userFollowUpAvailability({
+        userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
+        status,
+      }),
+    ).toEqual({
+      available: false,
+      reason: 'terminal',
+      message: 'This run has ended. Start a new agent task to continue.',
+    });
+  });
 });


### PR DESCRIPTION
## Preservation status

This is a preservation draft, not a merge-ready change. It publishes a previously uncommitted worktree exactly enough to prevent loss while the design is separated and rebased. Review should treat the branch as an architectural source, not as a candidate for direct merge.

GitHub reports that this historical #9911 line has no common history with current main. The draft therefore targets a dedicated preservation anchor at the exact pre-change commit. It cannot and must not be merged into a product branch. Current main has since gained #11303, #11318, and #11367; those implementations must remain authoritative during extraction.

## Summary

The preserved implementation attempts an end-to-end reliable follow-up submission protocol across extension and desktop surfaces:

- stable delivery identities and explicit sending or failed submission state;
- bounded validation for text, image, identifier, error, and total IPC payload sizes;
- per-stream text and pasted-image draft persistence in webview storage;
- recovery of an unconfirmed send as a retryable failed submission after reload;
- field-level admission results returned to the originating progress surface;
- an atomic, workspace-scoped desktop renderer-state store under user data;
- lifecycle-aware host admission checks for unsupported, pending, and terminal streams.

## Architectural inventory

1. Boundary policy: src/shared/schemas/progressView/followUpPolicy.ts owns limits and the accepted image shape. Inbound, outbound, and stream-state schemas derive their follow-up contracts from it.
2. Submission protocol: ProgressViewCommandHandlers assigns the delivery identity, validates current target availability, persists attachments, and emits an explicit accepted or rejected result.
3. Frontend state: followUpDraftPersistence.ts owns bounded per-stream text, attachment, and submission snapshots. Image fingerprints detect corrupt restored bytes, and an interrupted sending state is recovered as failed rather than assumed delivered.
4. Desktop persistence: desktopWebviewStateStore.ts owns atomic JSON replacement, size checks, invalid-state quarantine, user-data placement, and workspace hashing. The preload and main-process bridge expose only get and set operations.
5. Host policy: followUpCapability.ts combines launch-declared support with the current stream phase so stale views cannot revive terminal runs.
6. Tests: the preserved tests cover schema limits, persistence recovery, desktop storage, IPC, host routing, lifecycle policy, and frontend send or retry behavior.

## Dependency and extraction order

1. Merge #11367 and retain its base active-view capture; adapt the richer submission-result vocabulary on top of that result rather than restoring parallel view state.
2. Rebase onto current main and reconcile the preserved protocol with #11303 and #11318. The current submitProgressFollowUp path and execution-owned serial lane remain the single admission authorities.
3. Extract the boundary policy and delivery-result schemas as one focused change.
4. Extract webview draft persistence and recovery without desktop disk storage.
5. Add the desktop state store and IPC bridge only after the webview contract is stable.
6. Integrate lifecycle admission wording and UI retry behavior.
7. Reduce the preserved test surface to the current one-regression-per-fix budget, then run the full current-main verification matrix.

## Explicit exclusions

- The 16-file LionSR/TeXRA to texra-ai/texra-issues link migration was removed before this branch was committed. PR #11362 was closed because the number-preserving destinations returned 404 or referred to unrelated records.
- The exact #11367 captureAdmissionReporter patch is not duplicated here. This draft preserves a richer captureSubmissionResultReporter protocol that must be adapted after #11367, not substituted for it wholesale.
- No claim is made that this broad design satisfies a currently accepted issue or should merge as one PR.

## Issue acceptance gates

No linked issue. This draft exists solely to preserve unique local work. Product acceptance gates must be written for each extracted child change before any part is proposed for merge.

## Single source of truth

The intended ownership is split by concern: followUpPolicy for boundary limits, ProgressViewCommandHandlers for submission sequencing, followUpDraftPersistence for renderer draft state, DesktopWebviewStateStore for desktop disk state, and the existing runtime admission path on current main for execution ownership.

## Duplication and abstraction budget

The preserved tree predates current-main refactors and is expected to contain superseded paths. Extraction must remove overlap with #11303, #11318, and #11367 rather than layering another coordinator over them.

## Net elements (R6)

- 39 files changed
- 5 files added
- 2,907 lines added, 257 removed; net +2,650
- New principal constructs: FollowUpImageSchema and size policy, follow-up submission state and result messages, webview draft persistence, DesktopWebviewStateStore, and lifecycle admission availability.

## Consumer counts (R8)

n/a: this preservation draft does not delete or reroute a current-main emit path. Consumer counting is required again for each rebased extraction.

## Host impact

Extension: preserves text, pasted images, and submission state per stream and routes explicit results to the captured progress surface.

Desktop: adds disk-backed renderer state and the same submission-result protocol.

CLI: no intended product change in this preserved tree.

## Scheduled refactoring

The dependency and extraction order above is mandatory before merge consideration. This draft must not be converted to ready-for-review as one change.

## Known validation state

Passed on the historical preservation base after a frozen dependency install:

- 258 focused tests in 11 affected test files
- root TypeScript
- test-kernel TypeScript
- desktop TypeScript
- ESLint on every changed TypeScript file
- Prettier on all 39 changed files
- guidance-reference check
- dead-code ratchet
- git diff --check
- repository pre-push hook

Not run or not established:

- rebase or type-check against current main
- full repository test suite
- build artifacts or webview smoke tests
- current-main architecture and privacy review

These omissions are intentional evidence that the draft is not merge-ready.