### PR TITLE
consolidate: reuse walkFiles and groupBy instead of hand-rolled duplicates

### DIFF
--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -141,7 +141,7 @@ export const topLevelStreams$ = new Signal.Computed(() =>
 export const childStreamsByParent$ = new Signal.Computed(() => {
   const childStreams = [...streamById$.get().values()].filter(
     (stream): stream is StreamTabInfo & { parentStreamId: StreamTabId } =>
-      stream.parentStreamId !== undefined,
+      Boolean(stream.parentStreamId),
   );
   if (childStreams.length === 0) return EMPTY_CHILD_MAP;
   return groupBy(childStreams, (stream) => stream.parentStreamId);

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -30,7 +30,7 @@ import {
 import { isTerminalOutcomePhase } from '@shared/streams/streamStatus';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
-import { toNewestFirstByTimestamp } from '@utils/core';
+import { groupBy, toNewestFirstByTimestamp } from '@utils/core';
 
 import { setsEqual, streamDisplayLabel } from './utils';
 import { clearFollowUpInputTransientStateStore } from './followUpInputState';
@@ -139,17 +139,12 @@ export const topLevelStreams$ = new Signal.Computed(() =>
  * every status or timestamp update.
  */
 export const childStreamsByParent$ = new Signal.Computed(() => {
-  const grouped = new Map<StreamTabId, StreamTabInfo[]>();
-  for (const stream of streamById$.get().values()) {
-    if (!stream.parentStreamId) continue;
-    const siblings = grouped.get(stream.parentStreamId);
-    if (siblings) {
-      siblings.push(stream);
-    } else {
-      grouped.set(stream.parentStreamId, [stream]);
-    }
-  }
-  return grouped.size > 0 ? grouped : EMPTY_CHILD_MAP;
+  const childStreams = [...streamById$.get().values()].filter(
+    (stream): stream is StreamTabInfo & { parentStreamId: StreamTabId } =>
+      stream.parentStreamId !== undefined,
+  );
+  if (childStreams.length === 0) return EMPTY_CHILD_MAP;
+  return groupBy(childStreams, (stream) => stream.parentStreamId);
 });
 
 /**

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -34,7 +34,7 @@ import {
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { isKnownUnsupported } from '@shared/utils/dispatcher';
-import { getBasename } from '@utils/core';
+import { getBasename, groupBy } from '@utils/core';
 
 // Local imports - shared schemas and events
 import { pluralize } from '@utils/text/stringUtils';
@@ -110,12 +110,7 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
 
   protected override willUpdate(changed: PropertyValues): void {
     if (changed.has('agents')) {
-      const groups = new Map<AgentSource, AgentSelectionItem[]>();
-      for (const agent of this.agents) {
-        const list = groups.get(agent.source) ?? [];
-        list.push(agent);
-        groups.set(agent.source, list);
-      }
+      const groups = groupBy(this.agents, (agent) => agent.source);
       this.groupedSources = groups;
       this.displayOrder = AgentSelectionPanel.SOURCE_ORDER.flatMap(
         (source) => groups.get(source) ?? [],

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -38,6 +38,7 @@ import {
 // Local imports - profile view styles and events
 import { readSelectValue } from '@shared/utils/selectTemplates';
 import { GlobalStateKey } from '@shared/state/stateKeys';
+import { groupBy } from '@utils/core';
 import { postStateSetting } from '../shared/stateSettingRows';
 import { modelSelectionListStyles } from './ModelSelectionList.styles';
 import { resolveProviderKeyRows } from './providerKeyRows';
@@ -77,12 +78,7 @@ export class ModelSelectionList extends LitElement {
   @state() private expandedDeprecated: Set<string> = new Set();
 
   private getProviderGroups(): ProviderGroup[] {
-    const byProvider = new Map<string, ModelSelectionItem[]>();
-    for (const model of this.models) {
-      const list = byProvider.get(model.provider) ?? [];
-      list.push(model);
-      byProvider.set(model.provider, list);
-    }
+    const byProvider = groupBy(this.models, (model) => model.provider);
 
     return MODEL_SOURCE_ORDER.filter((p) => byProvider.has(p)).map(
       (provider) => {

--- a/packages/extension/src/settingsView/frontend/tabs/ShortcutsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ShortcutsTab.ts
@@ -25,6 +25,7 @@ import { renderEmptyState } from '@shared/wa/emptyState';
 import { renderSettingsBanner } from '@shared/wa/settingsBanner';
 import { renderSettingsSectionHeading } from '@shared/wa/settingsSection';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
+import { groupBy } from '@utils/core';
 
 @customElement('shortcuts-tab')
 export class ShortcutsTab extends LitElement {
@@ -232,12 +233,7 @@ export class ShortcutsTab extends LitElement {
 
   override render(): TemplateResult {
     const entries = this.visibleEntries();
-    const groups = new Map<string, DesktopShortcutEntry[]>();
-    for (const entry of entries) {
-      const group = groups.get(entry.category) ?? [];
-      group.push(entry);
-      groups.set(entry.category, group);
-    }
+    const groups = groupBy(entries, (entry) => entry.category);
     return html`
       <div class="tab-content-container">
         ${renderSettingsBanner({

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -15,6 +15,7 @@ import {
   normalizeMetafilePath,
   resolveMetafileImportPath,
 } from './desktop-package-metafile-paths.mjs';
+import { walkFiles } from './walkFiles.mjs';
 
 const require = createRequire(import.meta.url);
 const { extractFile, listPackage, statFile } = require('@electron/asar');
@@ -102,18 +103,10 @@ async function readJson(path) {
   return JSON.parse(await readFile(path, 'utf8'));
 }
 
-async function collectFiles(dir) {
-  const entries = await readdir(dir, { withFileTypes: true });
-  const files = [];
-  for (const entry of entries) {
-    const entryPath = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...(await collectFiles(entryPath)));
-    } else if (entry.isFile()) {
-      files.push(entryPath);
-    }
-  }
-  return files.sort();
+function collectFiles(dir) {
+  return walkFiles(dir)
+    .map((entry) => entry.absolutePath)
+    .sort();
 }
 
 async function findPackagedApp() {
@@ -471,7 +464,7 @@ async function checkDesktopStartupBundles(app, failures) {
 async function checkDesktopSourceBoundaries(failures) {
   for (const dir of desktopSourceBoundaryDirs) {
     if (!(await exists(dir))) continue;
-    for (const filePath of await collectFiles(dir)) {
+    for (const filePath of collectFiles(dir)) {
       if (!/\.[cm]?tsx?$/.test(filePath)) continue;
       const source = await readFile(filePath, 'utf8');
       if (


### PR DESCRIPTION
## Summary

Scheduled sweep for consolidation opportunities (duplicate logic, hand-rolled code that a native/existing helper already covers). Four parallel domain surveys (webviews, agent runtime/model handlers, platform/hosts/utils, CLI/scripts) turned up two genuine, well-evidenced candidates; the other two domains came back clean since they've already been through recent simplification campaigns. This PR implements both:

1. `scripts/verify-desktop-package.mjs` hand-rolled a recursive async file walker (`collectFiles`) that's behaviorally identical to `scripts/walkFiles.mjs`, which is already the single owner of this traversal for 6 other scripts — including its own sibling `verify-desktop-build-artifacts.mjs`, which already does `walkFiles(dir).map(e => e.absolutePath).sort()`. Switched `verify-desktop-package.mjs` to the same one-liner.
2. Four sites across the settings/progress webviews (`AgentSelectionPanel.ts`, `ModelSelectionList.ts`, `ShortcutsTab.ts`, `progressState.ts`) hand-rolled the same 3-5 line "bucket into `Map<K, V[]>`" loop that `groupBy` in `@utils/core` already provides — a helper explicitly built as a stand-in for the not-yet-available `Map.groupBy` and already used elsewhere in both trees (`RequestPanels.ts`, `ToolsTab.ts`). Switched all four to call it.

No behavior change in either case; both are pure internal refactors.

## Issue acceptance gates

No tracking issue — this is scheduled-routine output. Both changes were vetted against the `find-simplification` skill's evidence bar (real duplication with consumer counts, not surface similarity) before implementing.

## Single source of truth

- File traversal for build/CI scripts: `scripts/walkFiles.mjs` (now also owns `verify-desktop-package.mjs`'s traversal).
- `Map`-bucketing/grouping in webview frontend code: `groupBy` in `src/utils/core/index.ts` (now also owns the 4 sites above).

## Duplication and abstraction budget

Removed 2 duplicate implementations of existing single-owner helpers; added zero new abstractions. No wrapper or pass-through layer introduced.

## Net elements (R6)

Diffstat vs. base (`git diff --stat`): 5 files changed, 19 insertions(+), 44 deletions(-) — net **-25 LoC**. Zero exported symbols added or removed (`git diff | grep -E '^[+-]export'` is empty — both `collectFiles` and the four grouping loops were already private/local). No new classes/interfaces/enums.

## Consumer counts (R8)

n/a — no emit path or public export was deleted or re-routed. All five changed call sites are private, single-caller functions/computed signals; the helpers they now call (`walkFiles`, `groupBy`) are pre-existing with their own established consumers, unaffected by this change.

## Host impact

Extension: `AgentSelectionPanel.ts`, `ModelSelectionList.ts`, `ShortcutsTab.ts` (settingsView) and `progressState.ts` (progressView) — internal refactor only, no UI or behavior change.

Desktop: `scripts/verify-desktop-package.mjs` is the desktop packaging-verification script run in CI; behavior is identical (same files collected, same sort order), only the implementation source changed.

CLI: No changes.

## Scheduled refactoring

None. The other two lower-confidence candidates surfaced by the survey (an "overflow marker text" duplication in `packages/cli/src/tui/ui/Select.tsx` / `SlashPalette.tsx`, and a rejected 2-caller approval-preamble dedup in `src/tools/approval/`) were judged net-neutral-or-worse on the abstraction-cost bar and intentionally not implemented — no follow-up filed since neither cleared the bar to be worth tracking.

## Validation

- `npm run typecheck:workspace` — clean
- `node --max-old-space-size=6144 ./node_modules/eslint/bin/eslint.js` scoped to the 4 touched extension files — clean (the pre-existing `no-undef` findings in `scripts/verify-desktop-package.mjs` for `URL`/`console` are unrelated to this change — verified identical on the unmodified file via `git stash`; `scripts/` is outside the repo's `npm run lint` glob)
- `npx prettier --check` on all 5 touched files — clean
- `npx vitest run` on the 8 test files covering the touched components (`StreamTabsExpandChevron`, `StreamTree`, `StreamTabsStatus`, `ShortcutsTab`, `AgentSelectionPanelToggle`, `ModelSelectionProviderKeys`, `SettingsStyleContracts`, `MultiAgentTab`) — 43/43 passed
- `npm run check:dead-code-ratchet` — no new findings
- `node --check scripts/verify-desktop-package.mjs` — syntax valid

Not run: full desktop package build (`verify-desktop-package.mjs` requires a built `dist-packaged` output to execute meaningfully; reasoned about behavioral equivalence against its sibling script's identical pattern instead).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARpVisAytsEtdn1BWCnjDt)_