### PR TITLE
refactor: dedup SDK probe narrative and CLI inline-flag helper

### DIFF
--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -70,7 +70,7 @@ function knownGlobalFlagTokenCount(
   }
 
   const inline = arg.includes('=');
-  const baseFlag = inline ? inlineFlagBase(arg) : arg;
+  const baseFlag = inlineFlagBase(arg);
   if (GLOBAL_BOOL_FLAGS.has(baseFlag)) {
     return 1;
   }

--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -49,6 +49,12 @@ interface LeadingGlobalFlags {
   readonly stoppedOnUnknownFlag: boolean;
 }
 
+/** Strip a trailing `=value` from a flag token, leaving the bare flag. */
+function inlineFlagBase(token: string): string {
+  const equalsIndex = token.indexOf('=');
+  return equalsIndex === -1 ? token : token.slice(0, equalsIndex);
+}
+
 /**
  * How many tokens the known global flag at `index` consumes, or `undefined`
  * when the token is not a recognized global flag. Value flags consume two
@@ -64,7 +70,7 @@ function knownGlobalFlagTokenCount(
   }
 
   const inline = arg.includes('=');
-  const baseFlag = inline ? arg.slice(0, arg.indexOf('=')) : arg;
+  const baseFlag = inline ? inlineFlagBase(arg) : arg;
   if (GLOBAL_BOOL_FLAGS.has(baseFlag)) {
     return 1;
   }
@@ -495,11 +501,6 @@ async function commandFlagSpecs(
   }
 
   return specs;
-}
-
-function inlineFlagBase(token: string): string {
-  const equalsIndex = token.indexOf('=');
-  return equalsIndex === -1 ? token : token.slice(0, equalsIndex);
 }
 
 interface FlagValidation {

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -220,8 +220,7 @@ async function probeSdkBinaryAvailable(
 
 /** Resolved status of an SDK-backed CLI integration for the dashboard. */
 type SdkBinaryStatus =
-  | { ok: false; message: string }
-  | { ok: true; binaryPath: string };
+  { ok: false; message: string } | { ok: true; binaryPath: string };
 
 /**
  * Human-readable probe shared by the SDK-backed CLI integrations (Codex,
@@ -252,7 +251,10 @@ async function probeSdkBinaryStatus(config: {
 
   const binaryPath = await config.findBinary();
   if (!binaryPath) {
-    return { ok: false, message: config.binaryNotFoundMessage + wslInstallHint() };
+    return {
+      ok: false,
+      message: config.binaryNotFoundMessage + wslInstallHint(),
+    };
   }
   return { ok: true, binaryPath };
 }

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -218,6 +218,45 @@ async function probeSdkBinaryAvailable(
   }
 }
 
+/** Resolved status of an SDK-backed CLI integration for the dashboard. */
+type SdkBinaryStatus =
+  | { ok: false; message: string }
+  | { ok: true; binaryPath: string };
+
+/**
+ * Human-readable probe shared by the SDK-backed CLI integrations (Codex,
+ * Claude Code): import the SDK (classifying a missing package specially),
+ * then resolve the native binary (appending {@link wslInstallHint} when it is
+ * absent). Callers own only the final "ready" line, so the import/binary
+ * narrative lives in one place instead of once per entry.
+ */
+async function probeSdkBinaryStatus(config: {
+  importSdk: () => Promise<unknown>;
+  findBinary: () => Promise<string | undefined>;
+  missingPackageMessage: string;
+  importFailedLabel: string;
+  binaryNotFoundMessage: string;
+  classifyImportError?: (msg: string) => string | undefined;
+}): Promise<SdkBinaryStatus> {
+  try {
+    await config.importSdk();
+  } catch (err: unknown) {
+    const msg = toErrorMessage(err);
+    if (isMissingPackageError(msg)) {
+      return { ok: false, message: config.missingPackageMessage };
+    }
+    const classified = config.classifyImportError?.(msg);
+    if (classified != null) return { ok: false, message: classified };
+    return { ok: false, message: `${config.importFailedLabel}: ${msg}` };
+  }
+
+  const binaryPath = await config.findBinary();
+  if (!binaryPath) {
+    return { ok: false, message: config.binaryNotFoundMessage + wslInstallHint() };
+  }
+  return { ok: true, binaryPath };
+}
+
 /**
  * Wire a prerequisites-style availability entry. `probe` runs once and its
  * result is cached by the availability layer, then handed back to every
@@ -571,31 +610,22 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     toggleable: true,
     check: () => probeSdkBinaryAvailable(importCodexClass, findCodexBinaryPath),
     detailCheck: async () => {
-      // Step 1: Can we import the SDK?
-      try {
-        await importCodexClass();
-      } catch (err: unknown) {
-        const msg = toErrorMessage(err);
-        if (isMissingPackageError(msg)) {
-          return '@openai/codex-sdk not found. Install with: npm install -g @openai/codex';
-        }
-        if (msg.includes('Unsupported platform')) {
-          return `Platform not supported: ${msg}`;
-        }
-        return `Codex SDK import failed: ${msg}`;
-      }
-
-      // Step 2: Can we find the native binary?
-      const codexPath = await findCodexBinaryPath();
-      if (!codexPath) {
-        return (
+      const status = await probeSdkBinaryStatus({
+        importSdk: importCodexClass,
+        findBinary: findCodexBinaryPath,
+        missingPackageMessage:
+          '@openai/codex-sdk not found. Install with: npm install -g @openai/codex',
+        importFailedLabel: 'Codex SDK import failed',
+        classifyImportError: (msg) =>
+          msg.includes('Unsupported platform')
+            ? `Platform not supported: ${msg}`
+            : undefined,
+        binaryNotFoundMessage:
           'Codex SDK loaded but native binary not found. ' +
-          'Install with: npm install -g @openai/codex' +
-          wslInstallHint()
-        );
-      }
-
-      return `Codex CLI ready. Binary: ${codexPath}`;
+          'Install with: npm install -g @openai/codex',
+      });
+      if (!status.ok) return status.message;
+      return `Codex CLI ready. Binary: ${status.binaryPath}`;
     },
   },
 
@@ -638,24 +668,18 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     check: () =>
       probeSdkBinaryAvailable(importClaudeAgentSdk, findClaudeBinaryPath),
     detailCheck: async () => {
-      try {
-        await importClaudeAgentSdk();
-      } catch (err: unknown) {
-        const msg = toErrorMessage(err);
-        if (isMissingPackageError(msg)) {
-          return '@anthropic-ai/claude-agent-sdk not found. Reinstall TeXRA or run: npm install @anthropic-ai/claude-agent-sdk';
-        }
-        return `Claude Code SDK import failed: ${msg}`;
-      }
-
-      const claudePath = await findClaudeBinaryPath();
-      if (!claudePath) {
-        return (
+      const status = await probeSdkBinaryStatus({
+        importSdk: importClaudeAgentSdk,
+        findBinary: findClaudeBinaryPath,
+        missingPackageMessage:
+          '@anthropic-ai/claude-agent-sdk not found. Reinstall TeXRA or run: npm install @anthropic-ai/claude-agent-sdk',
+        importFailedLabel: 'Claude Code SDK import failed',
+        binaryNotFoundMessage:
           'Claude Code SDK loaded but native `claude` binary not found. ' +
-          'Install via: npm install -g @anthropic-ai/claude-code' +
-          wslInstallHint()
-        );
-      }
+          'Install via: npm install -g @anthropic-ai/claude-code',
+      });
+      if (!status.ok) return status.message;
+      const claudePath = status.binaryPath;
 
       const anthropicApiKeyEnv = apiKeyEnvName('anthropic');
       const keyOrigin = await lookupApiKeyOrigin(


### PR DESCRIPTION
## Summary

A tech-debt audit fanned five subagents across the largest production areas (`src/agent`, `src/tools`, `src/shared`+`src/controllers`, `packages/cli`, `packages/extension`, ~220k LoC). The strongest and most consistent signal was that **the codebase is already well-factored** — the meaningful shared abstractions exist and the classic debt markers are largely absent. On close inspection most of the audit's headline "duplication" findings did **not** survive scrutiny: they were either already collapsed behind an existing helper, or an intentional, heavily-documented divergence in delicate code.

This PR lands the changes that *did* survive as genuine, behavior-preserving improvements, all fully verified. It is deliberately small — see "Findings examined but not changed" below for why the larger audit items were not force-fit into this PR.

**Change 1 — `src/tools/externalToolDefs.ts`:** the Codex and Claude Code dashboard entries each spelled out the same `import SDK → classify missing-package → resolve native binary → format ready-line` sequence in their `detailCheck` bodies, kept consistent only by hand. Extracted `probeSdkBinaryStatus` so that policy lives in one place, completing the pattern `probeSdkBinaryAvailable` already established for the boolean `check`. Each entry still owns only its final "ready" line (and Claude keeps its extra auth-detection tail).

**Change 2 — `packages/cli/src/commands/_helpers/dispatch.ts`:** `knownGlobalFlagTokenCount` inlined its own copy of the "strip `=value` from a flag token" logic that `inlineFlagBase` already expressed lower in the file. Hoisted `inlineFlagBase` above its first use and call it from both sites (unconditionally — it already returns the token unchanged when there is no `=`).

## Issue acceptance gates

No linked issue — this originates from a scheduled tech-debt audit. All changes are behavior-preserving refactors with no functional acceptance gate; the gate is "checks stay green" (see Validation).

## Single source of truth

- The SDK-backed CLI **probe narrative** (missing-package classification, WSL install-hint appending, import-then-binary ordering) is now owned by `probeSdkBinaryStatus` in `externalToolDefs.ts`, alongside the existing `probeSdkBinaryAvailable` that owns the boolean form.
- The **inline flag-base split** is now owned solely by `inlineFlagBase` in `dispatch.ts`.

## Duplication and abstraction budget

- Removed: the duplicated import→binary→ready sequence across the two `detailCheck` bodies; the second inline copy of the `=`-split in `knownGlobalFlagTokenCount`, plus the redundant ternary that re-tested the guard `inlineFlagBase` owns.
- New abstraction: `probeSdkBinaryStatus` — owns the shared probe policy for SDK-backed CLI integrations; not a pass-through (it encodes the missing-package/WSL/ordering decisions). Returns a discriminated `{ ok }` result so each caller keeps its own ready-line and (for Claude) auth tail. Two current callers, and the code anticipates additional providers.
- `inlineFlagBase` was moved, not newly introduced.

## Net elements (R6)

Honest accounting — this is a **single-source-of-truth consolidation, not a line reduction**:

- Files changed: 2 (`+74 / −47`, net **+27 LoC**).
- Exported symbols: **0** added/removed (`^[+-]export` over the diff is empty).
- New constructs: `probeSdkBinaryStatus` (file-local fn) + `SdkBinaryStatus` (file-local type) = **+2**; `inlineFlagBase` net 0 (relocated). Deleted constructs: 0.
- The `externalToolDefs` change is net line-positive because the parameterized config object is more verbose than the ~15 duplicated lines it replaces; the payoff is removing drift risk between the two providers' probe narratives and extending it to future providers, not LoC. The `dispatch` change is roughly line-neutral and removes two literal duplications.

## Consumer counts (R8)

n/a — no export or emit path is deleted or re-routed. Both new symbols are file-local; `probeSdkBinaryAvailable` and the `detailCheck`/`check` surfaces are unchanged. `inlineFlagBase` stays file-local within `dispatch.ts`.

## Host impact

Extension: `externalToolDefs.ts` feeds the external-tool dashboard availability display — `detailCheck` output strings are byte-for-byte unchanged, so no visible change.

Desktop: same as Extension (shares the host-agnostic `src/tools` surface).

CLI: `dispatch.ts` global-flag routing/usage behavior unchanged; covered by `CliRootArgs.vitest.ts` (all passing).

## Scheduled refactoring

The audit's larger findings were examined and deliberately **not** bundled here. Each would be its own focused, separately-verified PR if wanted:

- **Twin stateful server-response handlers** (`modelHandlerOpenAIResponse` 2,958 LoC + `modelHandlerGoogleInteractions` 2,268 LoC), kept in sync by "// Mirrors OpenAI…" comments — genuine debt, but **L / high blast radius** across two live providers (streaming + resume) that can't be verified without provider integration. Not safe to bundle.
- **`htmlMarkdownNormalize.ts` regex sieve** and the **reflection output-recovery heuristics** — correctness-sensitive; consolidation risks behavior regressions without runtime measurement of which heuristics fire.
- **`SessionFactApplier` removal settlement** and **`PRPollingSource.pollOne` seed/diff split** — examined closely and found to be *intentional, documented divergence*, not accidental duplication (fact-path vs command-path diverge on the `undefined`/`superseded` outcomes; the polling seed branch seeds terminal markers without emitting while the diff branch uses entirely different machinery). Collapsing them for ~10 LoC would risk delicate protocols against the maintainers' clear intent.
- **Extension notification ports** and **`LaTeXTab` config-row scaffold** — the meaningful shared helpers (`showInfo/showWarning/showError` fields, `renderConfigRow`, `renderSettingStatusIcon`, `renderResetButton`) already exist; the residual is trivial prelude or genuinely-divergent (`error` vs `error instanceof Error ? … : undefined`).

## Validation

- `npm run typecheck` — passes (full workspace + test-kernel + agent + cli + trace-viewer + desktop; TypeScript 6 via `corepack pnpm install`).
- `pnpm run format:check` (Prettier) — passes on both changed files.
- `npx eslint` on both changed files — clean.
- `npx vitest run src/test-kernel/tools/externalToolDefs.vitest.ts src/test-kernel/cli/CliRootArgs.vitest.ts` — passing (115, then 110 after the CLI follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)