### PR TITLE
Remove SessionHandle.useHostInteractions pass-through and dead logger export

### DIFF
--- a/docs/proposals/2026-08-25-agent-sdk-readiness-reverify.md
+++ b/docs/proposals/2026-08-25-agent-sdk-readiness-reverify.md
@@ -1,0 +1,249 @@
+# Agent-SDK readiness — re-verification pass (2026-08-25)
+
+> **Status:** Written 2026-08-25 against branch HEAD `51c04c6`
+> (`docs: list remaining TeXRA papers on the public work page`, #11365). The
+> scheduled audit routine re-ran the standing question — "review the agent core,
+> model handler, logger, and surface for unnecessary abstraction and unready
+> surface; design subagent boundaries" — against the plan of record
+> ([`2026-07-09-agent-sdk-north-star.md`](./2026-07-09-agent-sdk-north-star.md))
+> and the most recent prior pass
+> ([`-08-22`](./2026-08-22-agent-sdk-readiness-reverify.md), written at pre-squash
+> `d455149`, landed as `78759a4`). Like `-08-22`, this pass re-derived the verdict
+> from **four fresh, independent area audits** (core, model handlers, logger,
+> surface + subagents) rather than a diff of the prior entry. It reached the
+> **same top-line verdict by an independent route — the alignment holds** — and
+> surfaced **two behavior-preserving removals** verified at HEAD: one on the
+> logger's public surface (a dead `export`) and one on `SessionHandle` (the
+> long-tracked PT-2 pass-through, still present). Neither was landed this session:
+> unlike `-08-22 §8`, there was **no maintainer request** to execute them, and
+> the routine's default — matching the three pure-green passes before `-08-22` —
+> is to record shovel-ready findings, not push into the green tree unbidden.
+> Every claim below carries a `file:line`, config path, or count checked at
+> `51c04c6`.
+
+## 0. Verdict
+
+**The standing verdict holds: the codebase is well-aligned with an Agent-SDK
+shape, and no structural refactor is warranted.** The pass-through wrappers,
+convenience barrels, and single-caller factories the standing question hunts for
+are, with the two narrow exceptions in §4, not present. The exemplary deep
+modules the prior passes named — `ModelCell`, `SessionEventHub`, `PersistedFlow`,
+`AgentRunLifecycle`, `childRunLoop`, `ModelInvocationNode` — are all things you
+would keep designing from scratch, and each re-verified as untouched-in-shape at
+HEAD. What is new this pass is bounded and shovel-ready, not a reversal: a genuine
+dead `export` on the logger surface (§4a) and independent re-confirmation that the
+model-handler removals landed in `-08-22 §8` are gone and that PT-2 (§4b) is still
+the one live pass-through in core. The `-08-22 §8` removals
+(`createToolUseFollowUpMessages`, `createAssistantMessageForPrefillText`) are
+**verified absent** from `ModelHandler.ts` and `IModelHandler.ts` at HEAD.
+
+Two measured facts moved in the readiness-positive direction since `-08-22`: the
+frozen host deep-import width **shrank** on two hosts (§2), and the model-handler
+base class shrank by 26 lines with the `-08-22 §8` inlining (§1). Neither the SDK
+package's 7-specifier floor nor the three entry files' exports changed.
+
+## 1. Every `-08-22` tracked fact re-verifies at `51c04c6`
+
+| Item                              | `-08-22` state (`d455149`)                          | `51c04c6` state                                                                                                                                     |
+| --------------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **§4a/§4b removals**              | landed this session (§8)                             | **still gone.** `grep` for `createToolUseFollowUpMessages` / `createAssistantMessageForPrefillText` in `modelHandlers/` returns no base definition. |
+| **L-3** (dead redaction branch)   | closed; `redactSecrets` single-arg                  | **still closed.** `export function redactSecrets(text: string): string` (`src/logger/redaction.ts:81`); no options branch.                          |
+| **L-2** (process-global log sink) | module-singleton, deliberate; no platform port      | **unchanged.** `logUtils.ts` 256 LoC; sole host seam is `setOutputChannelFactory` (2 callers), `console` fallback when absent.                      |
+| **§7 Tier-1 doors**               | 4 of 8 landed (`export`/`review`/`templates` + rt.) | **present & stable.** `src/agent/{export,review,templates,followUp}/index.ts` all exist; `@agent/index` re-exports hold.                            |
+| **M-3** `ModelHandler.ts` god-base | 2,069 LoC                                           | **2,043 LoC** (`wc -l`); −26, the `-08-22 §8` inlining. Genuinely shared behavior, no per-provider copy-paste (README's "shared, not duplicated").  |
+| **Provider-type-leak floor**      | `M`/`T` leak all four provider SDKs                 | **unchanged.** `ProviderMessage.ts:4-8` still imports message types from `@anthropic-ai/sdk`, `@google/genai`, `openai`, `@openrouter/sdk`.         |
+| **Node flow engine**              | 159 LoC, `BaseNode`/`Flow` only                     | **159 LoC** (`src/agent/node/index.ts`); still exactly `BaseNode` + `Flow` (single `export` `:159`). Matches CLAUDE.md.                             |
+| **Version**                       | 0.40.4 (short of the v0.41 `runFact.` gate)         | **0.40.5.** Advanced one patch; still short of the v0.41 retirement gate. Retirement not yet due.                                                   |
+
+## 2. Frozen host deep-import width — shrank on two hosts, held on the floor
+
+`config/ratchets/host-agent-import-baseline.json` (distinct `@agent/*` deep-import
+specifiers per package, past the `@agent` barrel):
+
+| Package             | `-08-22` | `51c04c6` |
+| ------------------- | -------- | --------- |
+| cli                 | 8        | **8**     |
+| desktop             | 6        | **5**     |
+| extension           | 10       | **9**     |
+| agent (SDK package) | 7        | **7**     |
+
+Two hosts shed one specifier each (desktop 6→5, extension 10→9) — the
+"shrink the frozen lists" work advancing, not a widening. The set-based ratchet
+still forbids any new edge and fails on stale headroom, so the lists can only
+shrink or hold; the "never widen a baseline" invariant is structurally enforced.
+`agent`'s 7 remains at its realistic floor, bounded by the provider-type-leak
+constraint (§5.4). This window's ~139 commits since `-08-22` (§6) are dominated
+by indirection removal, deduplication, and discriminated-union tightening — none
+add a wrapper layer or widen a baseline.
+
+## 3. Subagent boundaries — still drawn, still mature (re-confirmed by two audits)
+
+The subagent boundary is a **shipped, multi-implementor SPI, not a design task** —
+re-confirmed independently by both the core and surface audits at HEAD:
+
+- **Contract:** `ChildRunStrategy<TTurn>` + `ChildRunPorts`
+  (`src/agent/runtime/childRunLoop.ts`) — a deep module with a narrow turn-based
+  interface (`launch` / `runTurn?` / `isTerminal` / `formatDelivery`; upward
+  channel just `notify(progress)` + `recordCost(usd)`).
+- **Recursion-closing seam:** the `AgentEngine` runtime slot —
+  `provideAgentEngine({ executeAgent, resumeToolUseFromResumeData })`, a
+  deliberate load-time slot (not a static import) filled at
+  `src/tools/delegation/nativeSubagentStrategy.ts`, breaking the
+  `registry → DelegationTools → executeAgent → registry` cycle.
+- **Five independent implementors** drive the one loop: in-process TeXRA agent,
+  workflow-script children, external agent CLIs (Claude / Codex, behind
+  per-session — not process-singleton — registries), and background bash.
+
+The honest six-candidate mapping is unchanged. **`reflection` and `tooluse` are the
+`agentCategory` dispatch axis inside one run** (`executeAgent.ts` branches on
+`setting.agentCategory`), not separate agents; **`followUp` and `goal` are
+substrate**; **`review` is a support library behind a tool-use YAML agent** (its
+`@agent/review` door landed); **`roster` is the which-agents-are-visible policy
+layer**, not a run agent; **`remote` is an auth+network loader** the SDK
+deliberately excludes (`includeRemote: false`). **Only `agentCreator` remains the
+one genuine "logical agent not yet running as one"** — a single linear
+`runAgentCreator` (`src/agent/implementations/agentCreator/agentCreatorFlow.ts`,
+single production caller `agentCreatorCommands.ts:184`) that runs inline in the
+extension host through the `AgentCreatorUI` port, not through
+`runAgent`/`ChildRunStrategy`, and is the deepest surviving host deep-import
+specifier. That boundary stays open **correctly**, because closing it is
+interactive-UI design work (the `AgentCreatorUI`/approval channel that the public
+`HostInteractions` deliberately lacks), not a mechanical move.
+
+## 4. New this pass — two verified, shovel-ready, behavior-preserving removals
+
+Both are independently verified at HEAD and mechanical. **Neither was landed** —
+there was no maintainer request this session (contrast `-08-22 §8`), and the
+routine's default absent one is to record, not push into the green tree.
+
+### 4a. Logger: `OutputChannelFactoryOptions` is an unnecessary `export`
+
+`src/logger/logUtils.ts:49` declares `export interface OutputChannelFactoryOptions`,
+but its **only reference anywhere** is its own use as a parameter annotation in the
+same file (`setOutputChannelFactory(..., options: OutputChannelFactoryOptions = {})`,
+`logUtils.ts:191`). Verified: `grep -rn OutputChannelFactoryOptions src/ packages/`
+returns exactly those two lines — declaration and internal use — and it is **not**
+in `config/ratchets/knip-baseline.json` (knip does not flag it because the internal
+param use counts as a consumer). It is a public `export` with no external consumer,
+which CLAUDE.md's "Exports are contracts" rule forbids.
+
+- **Fix:** drop the `export` keyword (keep it a local `interface`), or inline
+  `{ readonly trusted?: boolean }` into the `setOutputChannelFactory` signature.
+- **Net:** −1 public export from the `@logger` surface; zero behavior change; a
+  single-file, zero-blast-radius edit. This is the first removable member the
+  logger surface has surfaced across these passes, and shrinks it before any
+  freeze.
+
+### 4b. Core: `SessionHandle.useHostInteractions` — the one live pass-through (PT-2)
+
+`SessionHandle.useHostInteractions` (`src/agent/runtime/SessionHandle.ts:685-687`)
+is a literal one-liner:
+
+```ts
+useHostInteractions(interactions: HostInteractions): () => void {
+  return this.interactions.use(interactions);
+}
+```
+
+It is the **sole violation** of the class's own documented contract: the header
+(`SessionHandle.ts:4`) states it is "a **composition record**, not a facade: it
+re-exposes no per-concern methods, so callers address each owner directly." Every
+other owner is reached as `session.interactions.x(...)` / `session.executions.y(...)`;
+this one method re-exposes `interactions.use`. **Six production callers**
+(`packages/agent/src/index.ts` — so it is on the eventual SDK surface —
+`packages/desktop/.../desktopAgentExecution.ts`, `packages/cli/.../runExecution.ts`,
+`packages/cli/.../chatSessionController.ts`, `packages/cli/scripts/tui-harness.tsx`,
+`packages/extension/.../ProgressViewProvider.ts`) plus ~30 test call sites, each a
+mechanical retarget to `session.interactions.use(...)` (already public).
+
+- **Net:** −1 method on `SessionHandle`; −1 entry from the eventual SDK surface;
+  ~6 production + ~30 test call-site edits, all mechanical; no behavior change.
+- **Status:** long-tracked as **PT-2** and marked "pre-authorized" in
+  [`2026-08-03-ssot-consolidation-plan.md`](./2026-08-03-ssot-consolidation-plan.md)
+  (C4), and carried in the `-07-09` / `-07-26` philosophy and foundation-gap
+  proposals. Re-verified **still present and unchanged** at HEAD. It is the larger
+  of the two by blast radius, so — like the three pure-green passes' posture on
+  this exact item — it stays recorded, awaiting an explicit land decision.
+
+## 5. Remaining open items (carried forward, none a defect)
+
+1. **Model-handler port shape (forward-looking).** The public `IModelHandler` port
+   is a hand-maintained 45-member `Pick<ModelHandler<…>>` (`src/agent/types/IModelHandler.ts`).
+   Internally the derivation is the correct anti-drift choice; but a *public* SDK
+   would want the port defined **intrinsically** rather than derived from the
+   concrete base class. Not a defect and not mechanical — a manifest-design note.
+2. **Provider-SDK type leak (`M`/`T`) is the floor on `agent`'s 7 specifiers**
+   (`-08-22 §4c`). The `U`/usage param is already quarantined to `unknown`
+   (`ModelCell.ts`); the in-tree fix template applies to `M`, but `T` is
+   load-bearing (`call.raw` read at five `ToolUseDispatchNode.ts` display-fallback
+   sites) and must route through a handler method first. A manifest-design decision
+   (whether `IModelHandler` can ever be a public export); `scripts/validate-artifacts.mjs`
+   already guards the built package against the leak.
+3. **Logger + telemetry are process-global singletons with no public plug point.**
+   The SDK-correct unlock is injectable owners (a `Platform.log` port + a
+   `UsageSink` port) behind Tier-1 `configureLogging` / `configureUsage` doors —
+   specified in `docs/prds/2026-05-06-prd-logger-v2.md`, deliberately deferred
+   behind singleton-retirement. The logger audit adds no new sub-item beyond §4a;
+   the dual public entry surface (`createLog` vs the free `debug/info/warn/error`
+   exports) noted in `-08-22 §5.2` is confirmed a style-only duplication with **no**
+   surface reduction available (the free functions must stay exported — they are the
+   `loggerSelf` test-spy seam and are re-typed by extension ports), so it is not a
+   simplification target.
+4. **Two open Tier-1 doors remain** (four of eight landed): fronting
+   `agentCreatorFlow` (its deepest specifier; blocked on the interactive
+   `AgentCreatorUI` design, §3), and a `core/state` door (blocked because a
+   *dynamic* `import()` the ratchet counts would leave the leaf live for zero
+   ratchet gain).
+5. **`HostInteractions` required/optional (north-star TD-2a)** — open maintainer
+   contract decision, not a mechanical cleanup. The public shape stays deliberately
+   minimal (`cancel()` only) until the approval channel has a stable contract.
+6. **Result-taxonomy documentation.** An external consumer meets three result
+   shapes — `AgentFlowResult` (discriminated `workflow | toolUse`),
+   `AgentFinalResult` (adds `diffs`/normalized `cost`), and the non-terminal
+   `WAITING` state. The transforms are real (not delete candidates); documenting
+   *why* `WAITING` exists and *why* `cost`/`diffs` land only on the final is the
+   single largest "which result do I get?" clarification the surface needs.
+7. **Publication** remains gated on the named-external-consumer hold; the legal side
+   cleared in the prior window (Apache-2.0 relicense, PocketFlow NOTICE, ToS
+   scoping). The gate is now consumer-driven, not legal-driven.
+
+## 6. Merges since the `-08-22` pass (`78759a4..51c04c6`, ~139 commits)
+
+None add a wrapper layer; the window is dominated by indirection removal,
+deduplication, and discriminated-union tightening — consistent with the standing
+trend. Relevant to the audited areas:
+
+- **Runtime consolidation** — `51a8b12` unify runtime resume and shutdown paths;
+  `4b9536e` collapse the waiting-termination recovery ladder; `6492dd4` drop the
+  single-consumer child-activation fan-out; `93cc177` drop the model-facing
+  subscribe capability; the `session-deep-clean` series (`aa5ae20` one resume path
+  via `resumeRun`, `ebd7c7e` one finalize tail, `9b424bb` one stream-to-execution
+  index, `a69cf0d` one `ChildRunOutcome` union).
+- **Ratchet / dead-code shrink** — `1111625` drop two ratchet baseline rows with
+  no live site; `897ffd1` retire five export-only-for-tests symbols and one
+  duplicated key; `a26652b` shrink the dead-code baseline instead of widening it.
+- **Model / transcript dedup** — `47dc573` route Google onto the shared
+  streaming-failure skeleton; `33c8f12` inline Google interactions media-round
+  helper; `6512b8d` dedup StreamSnapshotStore overlay/write plumbing; `e072b02`
+  consolidate model-list-refresh and secrets-key logic.
+- **LaTeX / CLI** — `06c68a0` make `LaTeXdiffResult`/`DiffRunResult` discriminated
+  unions (`07c029f` removes the checks the union made dead); `c46ecb7` derive
+  `cliConfig` field-picking from one schema list.
+
+## 7. Bottom line
+
+Five consecutive passes (`-08-19` through `-08-25`) now find a green top-line
+verdict, this one re-derived from four fresh independent area audits. The honest
+answer remains "almost nothing to remove," and what there is was recorded, not
+pushed: a genuine dead `export` on the logger surface (§4a) and the long-tracked
+PT-2 pass-through on `SessionHandle` (§4b), both verified behavior-preserving and
+mechanical at HEAD. The two `-08-22` removals stayed removed, the model-handler
+base shrank accordingly, and the frozen deep-import lists shrank on two more hosts
+— every measured motion this window was readiness-positive. The remaining
+structural work is unchanged and design-gated: the two open Tier-1 doors, the
+injectable logger/usage ports, the manifest decision on `IModelHandler` (its `M`/`T`
+leak and whether it can be a public export), and result-taxonomy documentation.
+Nothing found is a defect; nothing warrants a speculative edit into the green tree
+absent a maintainer request. Consistent with the routine's cadence — and unlike
+`-08-22 §8`, which landed at explicit request — this pass records §4a and §4b as
+shovel-ready and leaves the land decision to the maintainer.

--- a/docs/proposals/2026-08-25-agent-sdk-readiness-reverify.md
+++ b/docs/proposals/2026-08-25-agent-sdk-readiness-reverify.md
@@ -20,6 +20,12 @@
 > is to record shovel-ready findings, not push into the green tree unbidden.
 > Every claim below carries a `file:line`, config path, or count checked at
 > `51c04c6`.
+>
+> **Update (follow-up, same branch):** at the maintainer's request ("refactor for
+> all the things agreed already") both removals §4a and §4b were subsequently
+> landed — see §8 for the diff and validation, mirroring `-08-22 §8`. The
+> design-gated items in §5 were explicitly left untouched, being open decisions
+> rather than agreed mechanical moves.
 
 ## 0. Verdict
 
@@ -44,16 +50,16 @@ package's 7-specifier floor nor the three entry files' exports changed.
 
 ## 1. Every `-08-22` tracked fact re-verifies at `51c04c6`
 
-| Item                              | `-08-22` state (`d455149`)                          | `51c04c6` state                                                                                                                                     |
-| --------------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **§4a/§4b removals**              | landed this session (§8)                             | **still gone.** `grep` for `createToolUseFollowUpMessages` / `createAssistantMessageForPrefillText` in `modelHandlers/` returns no base definition. |
-| **L-3** (dead redaction branch)   | closed; `redactSecrets` single-arg                  | **still closed.** `export function redactSecrets(text: string): string` (`src/logger/redaction.ts:81`); no options branch.                          |
-| **L-2** (process-global log sink) | module-singleton, deliberate; no platform port      | **unchanged.** `logUtils.ts` 256 LoC; sole host seam is `setOutputChannelFactory` (2 callers), `console` fallback when absent.                      |
-| **§7 Tier-1 doors**               | 4 of 8 landed (`export`/`review`/`templates` + rt.) | **present & stable.** `src/agent/{export,review,templates,followUp}/index.ts` all exist; `@agent/index` re-exports hold.                            |
+| Item                               | `-08-22` state (`d455149`)                          | `51c04c6` state                                                                                                                                     |
+| ---------------------------------- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **§4a/§4b removals**               | landed this session (§8)                            | **still gone.** `grep` for `createToolUseFollowUpMessages` / `createAssistantMessageForPrefillText` in `modelHandlers/` returns no base definition. |
+| **L-3** (dead redaction branch)    | closed; `redactSecrets` single-arg                  | **still closed.** `export function redactSecrets(text: string): string` (`src/logger/redaction.ts:81`); no options branch.                          |
+| **L-2** (process-global log sink)  | module-singleton, deliberate; no platform port      | **unchanged.** `logUtils.ts` 256 LoC; sole host seam is `setOutputChannelFactory` (2 callers), `console` fallback when absent.                      |
+| **§7 Tier-1 doors**                | 4 of 8 landed (`export`/`review`/`templates` + rt.) | **present & stable.** `src/agent/{export,review,templates,followUp}/index.ts` all exist; `@agent/index` re-exports hold.                            |
 | **M-3** `ModelHandler.ts` god-base | 2,069 LoC                                           | **2,043 LoC** (`wc -l`); −26, the `-08-22 §8` inlining. Genuinely shared behavior, no per-provider copy-paste (README's "shared, not duplicated").  |
-| **Provider-type-leak floor**      | `M`/`T` leak all four provider SDKs                 | **unchanged.** `ProviderMessage.ts:4-8` still imports message types from `@anthropic-ai/sdk`, `@google/genai`, `openai`, `@openrouter/sdk`.         |
-| **Node flow engine**              | 159 LoC, `BaseNode`/`Flow` only                     | **159 LoC** (`src/agent/node/index.ts`); still exactly `BaseNode` + `Flow` (single `export` `:159`). Matches CLAUDE.md.                             |
-| **Version**                       | 0.40.4 (short of the v0.41 `runFact.` gate)         | **0.40.5.** Advanced one patch; still short of the v0.41 retirement gate. Retirement not yet due.                                                   |
+| **Provider-type-leak floor**       | `M`/`T` leak all four provider SDKs                 | **unchanged.** `ProviderMessage.ts:4-8` still imports message types from `@anthropic-ai/sdk`, `@google/genai`, `openai`, `@openrouter/sdk`.         |
+| **Node flow engine**               | 159 LoC, `BaseNode`/`Flow` only                     | **159 LoC** (`src/agent/node/index.ts`); still exactly `BaseNode` + `Flow` (single `export` `:159`). Matches CLAUDE.md.                             |
+| **Version**                        | 0.40.4 (short of the v0.41 `runFact.` gate)         | **0.40.5.** Advanced one patch; still short of the v0.41 retirement gate. Retirement not yet due.                                                   |
 
 ## 2. Frozen host deep-import width — shrank on two hosts, held on the floor
 
@@ -169,7 +175,7 @@ mechanical retarget to `session.interactions.use(...)` (already public).
 
 1. **Model-handler port shape (forward-looking).** The public `IModelHandler` port
    is a hand-maintained 45-member `Pick<ModelHandler<…>>` (`src/agent/types/IModelHandler.ts`).
-   Internally the derivation is the correct anti-drift choice; but a *public* SDK
+   Internally the derivation is the correct anti-drift choice; but a _public_ SDK
    would want the port defined **intrinsically** rather than derived from the
    concrete base class. Not a defect and not mechanical — a manifest-design note.
 2. **Provider-SDK type leak (`M`/`T`) is the floor on `agent`'s 7 specifiers**
@@ -192,7 +198,7 @@ mechanical retarget to `session.interactions.use(...)` (already public).
 4. **Two open Tier-1 doors remain** (four of eight landed): fronting
    `agentCreatorFlow` (its deepest specifier; blocked on the interactive
    `AgentCreatorUI` design, §3), and a `core/state` door (blocked because a
-   *dynamic* `import()` the ratchet counts would leave the leaf live for zero
+   _dynamic_ `import()` the ratchet counts would leave the leaf live for zero
    ratchet gain).
 5. **`HostInteractions` required/optional (north-star TD-2a)** — open maintainer
    contract decision, not a mechanical cleanup. The public shape stays deliberately
@@ -201,7 +207,7 @@ mechanical retarget to `session.interactions.use(...)` (already public).
    shapes — `AgentFlowResult` (discriminated `workflow | toolUse`),
    `AgentFinalResult` (adds `diffs`/normalized `cost`), and the non-terminal
    `WAITING` state. The transforms are real (not delete candidates); documenting
-   *why* `WAITING` exists and *why* `cost`/`diffs` land only on the final is the
+   _why_ `WAITING` exists and _why_ `cost`/`diffs` land only on the final is the
    single largest "which result do I get?" clarification the surface needs.
 7. **Publication** remains gated on the named-external-consumer hold; the legal side
    cleared in the prior window (Apache-2.0 relicense, PocketFlow NOTICE, ToS
@@ -245,5 +251,64 @@ injectable logger/usage ports, the manifest decision on `IModelHandler` (its `M`
 leak and whether it can be a public export), and result-taxonomy documentation.
 Nothing found is a defect; nothing warrants a speculative edit into the green tree
 absent a maintainer request. Consistent with the routine's cadence — and unlike
-`-08-22 §8`, which landed at explicit request — this pass records §4a and §4b as
-shovel-ready and leaves the land decision to the maintainer.
+`-08-22 §8`, which landed at explicit request — this pass's scheduled run recorded
+§4a and §4b as shovel-ready and left the land decision to the maintainer; §8 below
+records both landed in the follow-up that decision authorized.
+
+## 8. Landed refactor — the two agreed removals (follow-up)
+
+At the maintainer's request ("refactor for all the things agreed already"), the two
+behavior-preserving removals §4a and §4b were executed rather than only recorded.
+Both are mechanical and independently verified zero-behavior-change; the
+design-gated items in §5 (the provider-type leak, the two open Tier-1 doors, the
+injectable logger/usage ports, the `IModelHandler` manifest decision) were left
+untouched, being open decisions rather than agreed moves.
+
+### 8a. Narrowed `OutputChannelFactoryOptions` off the logger's public surface
+
+Dropped the `export` keyword on `OutputChannelFactoryOptions` (`src/logger/logUtils.ts:49`),
+keeping it a local `interface` — it was only ever used as the internal parameter
+annotation on `setOutputChannelFactory` (`logUtils.ts:191`). −1 public export, one
+file, zero behavior change. The knip ratchet is unaffected (the type was internally
+used, not dead).
+
+### 8b. Removed `SessionHandle.useHostInteractions` (PT-2), re-routed every caller
+
+Deleted the one-line pass-through method (was `SessionHandle.ts:685-687`) and the
+now-unused `type HostInteractions` import it required. The class's header —
+"it re-exposes no per-concern methods" — is now literally true with no exception.
+**Re-routed all 69 call sites** across 30 files from `session.useHostInteractions(x)`
+to `session.interactions.use(x)` (the direct owner-addressing form the class already
+mandates; `SessionHostInteractions.use`, `HostInteractions.ts:429`, has the identical
+signature): 6 production callers (`packages/agent/src/index.ts`,
+`packages/desktop/.../desktopAgentExecution.ts`, `packages/cli/.../runExecution.ts`,
+`packages/cli/.../chatSessionController.ts`, `packages/cli/scripts/tui-harness.tsx`,
+`packages/extension/.../ProgressViewProvider.ts`) plus the test call sites. **Reshaped
+six test doubles** that faked or spied the removed method to instead target
+`interactions.use`: two fake sessions (`ProgressThemeSync.vitest.ts`,
+`ExtensionWorkspaceTransition.vitest.ts` — `interactions: {}` → `interactions: { use }`),
+two `vi.spyOn` sites (`DesktopAgentExecutionFactory.vitest.ts`,
+`DesktopAgentExecution.vitest.ts` — spy `session.interactions.use`, the latter now
+matching its sibling `session.events.subscribe` spy idiom), and two full mocks
+(`AgentPackage.vitest.ts` mock `@agent/runtime` SessionHandle now exposes
+`interactions.use`; `chatSessionController.vitest.ts` — one mock moved `use` onto
+`interactions`, one dropped a redundant shim since it already passed a real
+`SessionHostInteractions`). Also refreshed the stale
+`desktopAgentExecution.ts:392` comment.
+
+### 8c. Validation
+
+`npm run typecheck` — clean across all six stages (`workspace`, `test-kernel`,
+`agent` — the `@texra-ai/agent` SDK build, "Validated 725 declarations and 70
+external packages", the same count as `-08-22 §8c`, confirming the SDK declaration
+surface is unchanged and the provider-leak guard still passes — `cli`,
+`trace-viewer`, `desktop`). `npx eslint` on all touched `.ts`/`.tsx` — clean.
+`prettier --check` on every touched file — clean (two files reflowed by
+`--write` where the shorter call text let a wrapped line collapse). `npm run
+check:dead-code-ratchet` — "no new findings" (419 combined, matching the
+pre-change baseline exactly; the removed method was live and the narrowed export
+was internally used, so the ratchet is unaffected by design). All 29 changed
+vitest suites — **556/556 passed**. The `src/test-kernel/architecture/` suite —
+**106/106 passed**. Net diff: **37 files changed, ~89 insertions(+), ~98
+deletions(-)** — one facade method and one dead `export` removed, zero behavior
+change.

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -260,7 +260,7 @@ export function runAgent(input: RunAgentInput): AgentRun {
         reason: 'Interactive retries are unavailable in the agent package.',
       }),
     };
-    const detachInteractions = session.useHostInteractions(interactions);
+    const detachInteractions = session.interactions.use(interactions);
     try {
       await loadAgents({ includeRemote: false });
       const resolved = resolveAgent(input.agent);

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -2019,7 +2019,7 @@ if (SHOW_RETRY_APPROVAL) {
   await saveProviderApiKey('openai', 'sk-harness-openai-key');
   harnessRetryRuntimeHost = createCliRuntimeHost(HARNESS_CLI_CONTEXT);
   HARNESS_DISPOSERS.push(
-    defaultSession().useHostInteractions(
+    defaultSession().interactions.use(
       createTuiHostInteractions(harnessRetryRuntimeHost, HARNESS_CLI_CONTEXT),
     ),
   );

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -374,7 +374,7 @@ export function createChatSessionController(
     readonly finalize: () => void;
   } => {
     const presentationHost = createCliRuntimeHost(sessionContext);
-    const detachHostInteractions = runtimeSession.useHostInteractions(
+    const detachHostInteractions = runtimeSession.interactions.use(
       createTuiHostInteractions(presentationHost, sessionContext),
     );
     const detachResultToast = attachTerminalResultToast(

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -259,7 +259,7 @@ export async function executeCliRequest(
     runContext.outputFormat === 'text' && runContext.renderRunProgress === true;
   const detachRunProgressRenderer =
     presentationHost.attachRunProgressRenderer(session);
-  const detachHostInteractions = session.useHostInteractions(
+  const detachHostInteractions = session.interactions.use(
     createHeadlessCliHostInteractions(runContext, {
       beforePrompt: () => presentationHost.prepareInteractivePrompt?.(),
       emit: (event, payload) => {

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -385,11 +385,11 @@ export class DesktopProgressBridge {
     // Canonical state and restart repair are complete before any window-owned
     // adapter can receive a replay. Subscribe first because attachment
     // synchronously redispatches pending approvals and their visibility facts.
-    const detachHostInteractions = this.session.useHostInteractions(
+    const detachHostInteractions = this.session.interactions.use(
       this.hostInteractions,
     );
     // Attachment synchronously replays pending requests. That replay can close
-    // the window before useHostInteractions returns its disposer.
+    // the window before interactions.use returns its disposer.
     if (this.disposed) {
       detachHostInteractions();
       return;

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -178,8 +178,7 @@ export class ProgressViewProvider extends BaseWebviewProvider {
       interactions,
     );
     this.backend.setupEventListeners();
-    this.detachHostInteractions =
-      runtimeSession.useHostInteractions(interactions);
+    this.detachHostInteractions = runtimeSession.interactions.use(interactions);
     // Terminal-error toasts come from the run's `result` event (the lifecycle
     // no longer emits them directly). This re-emits `requestShow*` through
     // the session's interactions, reaching the presentation dispatch above

--- a/src/agent/modelHandlers/contextManagementConstants.ts
+++ b/src/agent/modelHandlers/contextManagementConstants.ts
@@ -43,8 +43,9 @@ export const CLIENT_COMPACTION_SUMMARY_MAX_TOKENS = 2000;
 
 /**
  * Prefix prepended to a client-side compaction summary when it is folded back
- * into the conversation as a synthetic user message. Shared across every
- * provider handler so the resumed-conversation marker stays identical.
+ * into the conversation as a synthetic user message. Read once in the base
+ * compaction method every provider handler inherits, so the resumed-conversation
+ * marker stays identical across providers.
  */
 export const COMPACTION_SUMMARY_PREFIX = '[Previous conversation summary]\n\n';
 

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -71,10 +71,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getRunContextSession, tryUseRunContext } from './RunContext';
 import { ExecutionRegistry } from './executionRegistry';
 import { StreamStatusMachine } from './StreamStatusService';
-import {
-  SessionHostInteractions,
-  type HostInteractions,
-} from './HostInteractions';
+import { SessionHostInteractions } from './HostInteractions';
 import { SessionEventHub } from './SessionEventHub';
 import { ModelRetryGate } from './ModelRetryGate';
 import {
@@ -680,10 +677,6 @@ export class SessionHandle {
       logger,
       signal: this.restartRepairAbort.signal,
     });
-  }
-
-  useHostInteractions(interactions: HostInteractions): () => void {
-    return this.interactions.use(interactions);
   }
 
   /** Drain one execution's pending trace, or every trace during shutdown. */

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -46,7 +46,7 @@ interface OutputSink {
 
 type OutputChannelFactory = (name: string) => OutputSink;
 
-export interface OutputChannelFactoryOptions {
+interface OutputChannelFactoryOptions {
   /** Preserve raw output only for a local operator-controlled terminal. */
   readonly trusted?: boolean;
 }

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -154,7 +154,7 @@ export type ChannelWriter = (
 ) => void;
 
 /**
- * Create a protocol-neutral writer for one shared or agent channel.
+ * Create a level-tagged line writer bound to one shared or agent channel.
  * Channel creation is eager so the returned writer owns a ready sink.
  */
 export function createChannelWriter(

--- a/src/test-kernel/agent/AgentPackage.vitest.ts
+++ b/src/test-kernel/agent/AgentPackage.vitest.ts
@@ -32,7 +32,7 @@ const mocks = vi.hoisted(() => ({
     mocks.eventListener = listener;
     return mocks.detachEvents;
   }),
-  useHostInteractions: vi.fn(() => mocks.detachInteractions),
+  useInteractions: vi.fn(() => mocks.detachInteractions),
   warn: vi.fn(),
 }));
 
@@ -73,7 +73,7 @@ vi.mock('@agent/runtime', () => ({
       killBackgroundProcesses: mocks.killBackgroundProcesses,
     };
 
-    useHostInteractions = mocks.useHostInteractions;
+    readonly interactions = { use: mocks.useInteractions };
     dispose = mocks.disposeSession;
   },
   runAgent: mocks.runValidatedAgent,

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -47,7 +47,7 @@ function installTestPlatform(): Promise<void> {
     globalStoragePath: '/global/.texra/storage',
   }).then(() => {
     detachHostInteractions();
-    detachHostInteractions = defaultSession().useHostInteractions({
+    detachHostInteractions = defaultSession().interactions.use({
       requestToolEditApproval: (request) => {
         const handler = testApprovalHandler;
         if (!handler) {

--- a/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
@@ -117,7 +117,7 @@ describe('child subagent stream approval inheritance', () => {
 
   it('announces inherited edit-bypass changes for visible descendants', () => {
     const { events, interactions } = createRecordingHost();
-    const detach = currentSession().useHostInteractions(interactions);
+    const detach = currentSession().interactions.use(interactions);
     const { parent, child } = streamPair('visible');
     const grandchild = 'stream:visible-grandchild' as StreamTabId;
     const pinnedChild = 'stream:pinned-child' as StreamTabId;

--- a/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
@@ -37,7 +37,7 @@ let detachHostInteractions = (): void => {};
 function installTestPlatform(): Promise<void> {
   return installPlatform({}).then(() => {
     detachHostInteractions();
-    detachHostInteractions = defaultSession().useHostInteractions({
+    detachHostInteractions = defaultSession().interactions.use({
       requestToolEditApproval: (request) => {
         const handler = testApprovalHandler;
         if (!handler) {
@@ -57,7 +57,7 @@ async function inToolContext<T>(
   streamId: StreamTabId,
   run: () => T,
 ): Promise<Awaited<T>> {
-  const detach = defaultSession().useHostInteractions(interactions);
+  const detach = defaultSession().interactions.use(interactions);
   try {
     return await withRunContext(
       createRunContext({
@@ -221,9 +221,7 @@ describe('human prompt progress events', () => {
     ({ kind, setBypass }) => {
       const explicit = createRecordingHost();
       const streamId = `stream:${kind}-bypass` as StreamTabId;
-      const detach = defaultSession().useHostInteractions(
-        explicit.interactions,
-      );
+      const detach = defaultSession().interactions.use(explicit.interactions);
 
       try {
         setBypass(streamId, true);

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -1215,7 +1215,7 @@ describe('ModelInvocationNode retry', () => {
     const streamId = 'retry-state-session-bridge' as StreamTabId;
     const session = createTestSession();
     const recording = createRecordingHost();
-    session.useHostInteractions(recording.interactions);
+    session.interactions.use(recording.interactions);
     const { node } = createRetryNode(streamId, undefined, undefined, session);
     const streamStatus = session.status;
 

--- a/src/test-kernel/agent/runtime/RunLifecycleInteractionCancel.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunLifecycleInteractionCancel.vitest.ts
@@ -211,7 +211,7 @@ describe('run lifecycle host-interaction cancel', () => {
 
   it('keeps the published outcome when a host adapter throws on cancel', async () => {
     const { session, ctx, executionId, streamId } = lifecycleCase();
-    const detach = session.useHostInteractions({
+    const detach = session.interactions.use({
       cancel: () => {
         throw new Error('host cancel boom');
       },

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -260,8 +260,8 @@ describe('SessionHandle', () => {
     const hostA = createRecordingHost();
     const hostB = createRecordingHost();
     const streamId = 'stream:cleanup-scope' as StreamTabId;
-    a.useHostInteractions(hostA.interactions);
-    b.useHostInteractions(hostB.interactions);
+    a.interactions.use(hostA.interactions);
+    b.interactions.use(hostB.interactions);
 
     try {
       const planA = a.interactions.requestPlanApproval({

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -147,7 +147,7 @@ function createPortSession(): {
     getApprovalHandlers: () => handlers,
     getToolEditApprovals: () => toolEditApprovals,
   });
-  session.useHostInteractions(interactions);
+  session.interactions.use(interactions);
   return {
     session,
     uiEvents,
@@ -277,7 +277,7 @@ describe('session.interactions immediate capabilities', () => {
       accepted: true,
       resolvedPath: criticism.absolutePath,
     }));
-    session.useHostInteractions({
+    session.interactions.use({
       readDiagnostics,
       addCriticism,
       cancel: vi.fn(),
@@ -301,7 +301,7 @@ describe('session.interactions immediate capabilities', () => {
 
   it('does not expose or replay immediate capabilities while detached', () => {
     const session = createTestSession();
-    const detach = session.useHostInteractions({
+    const detach = session.interactions.use({
       readDiagnostics: vi.fn(async () => [diagnostic]),
       addCriticism: vi.fn(() => ({
         accepted: true,
@@ -319,7 +319,7 @@ describe('session.interactions immediate capabilities', () => {
       accepted: true,
       resolvedPath: criticism.absolutePath,
     }));
-    session.useHostInteractions({
+    session.interactions.use({
       readDiagnostics,
       addCriticism,
       cancel: vi.fn(),
@@ -334,7 +334,7 @@ describe('session.interactions immediate capabilities', () => {
     const session = createTestSession();
     const firstInfo = vi.fn();
     const firstEmit = vi.fn();
-    const detach = session.useHostInteractions({
+    const detach = session.interactions.use({
       emit: firstEmit,
       showInfoMessage: firstInfo,
       cancel: vi.fn(),
@@ -356,7 +356,7 @@ describe('session.interactions immediate capabilities', () => {
 
     const secondInfo = vi.fn();
     const secondEmit = vi.fn();
-    const detachSecond = session.useHostInteractions({
+    const detachSecond = session.interactions.use({
       emit: secondEmit,
       showInfoMessage: secondInfo,
       cancel: vi.fn(),
@@ -376,7 +376,7 @@ describe('session.interactions immediate capabilities', () => {
     detachSecond();
     const thirdInfo = vi.fn();
     const thirdEmit = vi.fn();
-    session.useHostInteractions({
+    session.interactions.use({
       emit: thirdEmit,
       showInfoMessage: thirdInfo,
       cancel: vi.fn(),
@@ -401,7 +401,7 @@ describe('session.interactions immediate capabilities', () => {
 
     const firstInfo = vi.fn();
     let detachFirst = (): void => undefined;
-    detachFirst = session.useHostInteractions({
+    detachFirst = session.interactions.use({
       showInfoMessage: (message) => {
         firstInfo(message);
         detachFirst();
@@ -414,7 +414,7 @@ describe('session.interactions immediate capabilities', () => {
     expect(firstInfo).toHaveBeenCalledWith('first');
 
     const secondInfo = vi.fn();
-    session.useHostInteractions({
+    session.interactions.use({
       showInfoMessage: secondInfo,
       cancel: vi.fn(),
     });
@@ -434,7 +434,7 @@ describe('session.interactions immediate capabilities', () => {
     // (a desktop renderer post during teardown) must read as not delivered,
     // not escape as an arbitrary host exception (#10466).
     const session = createTestSession();
-    session.useHostInteractions({
+    session.interactions.use({
       emit: () => {
         throw new Error('renderer torn down mid-post');
       },
@@ -476,7 +476,7 @@ describe('session.interactions immediate capabilities', () => {
       },
       cancel: vi.fn(),
     };
-    session.useHostInteractions(throwingHost);
+    session.interactions.use(throwingHost);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -490,7 +490,7 @@ describe('session.interactions immediate capabilities', () => {
     const session = createTestSession();
     const firstInfo = vi.fn();
     const firstEmit = vi.fn();
-    const detach = session.useHostInteractions({
+    const detach = session.interactions.use({
       emit: firstEmit,
       showInfoMessage: firstInfo,
       cancel: vi.fn(),
@@ -510,7 +510,7 @@ describe('session.interactions immediate capabilities', () => {
     detach();
     const secondInfo = vi.fn();
     const secondEmit = vi.fn();
-    session.useHostInteractions({
+    session.interactions.use({
       emit: secondEmit,
       showInfoMessage: secondInfo,
       cancel: vi.fn(),
@@ -530,7 +530,7 @@ describe('session.interactions immediate capabilities', () => {
     }
 
     const messages: string[] = [];
-    session.useHostInteractions({
+    session.interactions.use({
       showInfoMessage: (message) => {
         messages.push(message);
       },
@@ -550,7 +550,7 @@ describe('session.interactions request bookkeeping', () => {
     const session = createTestSession();
     const adapter = createControllablePlanAdapter();
     session.interactions.dispose();
-    session.useHostInteractions(adapter.interactions);
+    session.interactions.use(adapter.interactions);
 
     expect(adapter.dispose).toHaveBeenCalledOnce();
     session.dispose();
@@ -580,7 +580,7 @@ describe('session.interactions request bookkeeping', () => {
   it('disposes attachments even when cancellation throws', () => {
     const session = createTestSession();
     const dispose = vi.fn();
-    session.useHostInteractions({
+    session.interactions.use({
       cancel: () => {
         throw new Error('cancel failed');
       },
@@ -608,7 +608,7 @@ describe('session.interactions request bookkeeping', () => {
 
       // Parking stays load-bearing: a host attaching later still replays the
       // request exactly once (this is how a webview reload recovers a prompt).
-      session.useHostInteractions(adapter.interactions);
+      session.interactions.use(adapter.interactions);
       expect(adapter.requests).toHaveLength(1);
       expect(
         adapter.submit('approval:parked-warning', { action: 'approve' }),
@@ -636,7 +636,7 @@ describe('session.interactions request bookkeeping', () => {
       );
 
       expect(session.interactions.pendingCount).toBe(1);
-      session.useHostInteractions(adapter.interactions);
+      session.interactions.use(adapter.interactions);
       expect(adapter.requests).toHaveLength(1);
       expect(
         adapter.submit('approval:throwing-warning', { action: 'approve' }),
@@ -654,7 +654,7 @@ describe('session.interactions request bookkeeping', () => {
 
   it('settles against the documented minimal `{ cancel }` host', async () => {
     const session = createTestSession();
-    session.useHostInteractions({ cancel: vi.fn() });
+    session.interactions.use({ cancel: vi.fn() });
     try {
       await expect(
         requestPlan(session, 'approval:minimal-host'),
@@ -672,7 +672,7 @@ describe('session.interactions request bookkeeping', () => {
       const pending = requestPlan(session, 'approval:unattached');
       expect(adapter.requests).toEqual([]);
 
-      session.useHostInteractions(adapter.interactions);
+      session.interactions.use(adapter.interactions);
       expect(adapter.requests).toHaveLength(1);
       expect(adapter.submit('approval:unattached', { action: 'approve' })).toBe(
         true,
@@ -693,7 +693,7 @@ describe('session.interactions request bookkeeping', () => {
       pendingCounts.push(count),
     );
     try {
-      const detach = session.useHostInteractions(first.interactions);
+      const detach = session.interactions.use(first.interactions);
       const pending = requestPlan(session, 'approval:reattach');
       detach();
       await Promise.resolve();
@@ -705,7 +705,7 @@ describe('session.interactions request bookkeeping', () => {
         ),
       ).toHaveLength(1);
 
-      session.useHostInteractions(second.interactions);
+      session.interactions.use(second.interactions);
       expect(second.requests).toHaveLength(1);
       expect(second.submit('approval:reattach', { action: 'approve' })).toBe(
         true,
@@ -786,7 +786,7 @@ describe('session.interactions request bookkeeping', () => {
         agentName: 'proofreader',
       });
 
-      session.useHostInteractions({ emit, cancel: vi.fn() });
+      session.interactions.use({ emit, cancel: vi.fn() });
       await Promise.resolve();
       expect(emit).not.toHaveBeenCalled();
     } finally {
@@ -814,9 +814,9 @@ describe('session.interactions request bookkeeping', () => {
     const first = createControllablePlanAdapter();
     const second = createControllablePlanAdapter();
     try {
-      session.useHostInteractions(first.interactions);
+      session.interactions.use(first.interactions);
       const pending = requestPlan(session, 'approval:handoff');
-      const detachSecond = session.useHostInteractions(second.interactions);
+      const detachSecond = session.interactions.use(second.interactions);
 
       expect(first.submit('approval:handoff', { action: 'reject' })).toBe(
         false,
@@ -896,7 +896,7 @@ describe('session.interactions request bookkeeping', () => {
     session.interactions.onPendingCountChange((count) =>
       pendingCounts.push(count),
     );
-    session.useHostInteractions(adapter.interactions);
+    session.interactions.use(adapter.interactions);
     const pending = requestPlan(session, 'approval:dispose-attached');
 
     session.dispose();

--- a/src/test-kernel/agent/runtime/SessionScope.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionScope.vitest.ts
@@ -123,8 +123,8 @@ describe('approval reset scope', () => {
     const hostA = createRecordingHost();
     const hostB = createRecordingHost();
     const streamId = 'stream:approval-scope' as StreamTabId;
-    a.useHostInteractions(hostA.interactions);
-    b.useHostInteractions(hostB.interactions);
+    a.interactions.use(hostA.interactions);
+    b.interactions.use(hostB.interactions);
 
     try {
       const planA = a.interactions.requestPlanApproval({

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.ts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.ts
@@ -84,7 +84,7 @@ function useCliHostInteractions(
 ): void {
   detachHostInteractions();
   defaultSession().setApprovalPolicy(cliContext.approvalPolicy);
-  detachHostInteractions = defaultSession().useHostInteractions(
+  detachHostInteractions = defaultSession().interactions.use(
     createHeadlessCliHostInteractions(cliContext, hooks),
   );
 }

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
@@ -165,7 +165,7 @@ function tui(
         ...options,
       }),
   };
-  const detachInteractions = defaultSession().useHostInteractions(interactions);
+  const detachInteractions = defaultSession().interactions.use(interactions);
   onTestFinished(detachInteractions);
   return {
     presentationHost,

--- a/src/test-kernel/cli/chatSessionController.vitest.ts
+++ b/src/test-kernel/cli/chatSessionController.vitest.ts
@@ -313,8 +313,10 @@ function installSession(overrides: Record<string, unknown> = {}): void {
   };
   mocks.defaultSession.mockReturnValue({
     approvalPolicy: TEXRA_APPROVAL_POLICY_DEFAULT,
-    useHostInteractions: vi.fn(() => mocks.detachHostInteractions),
-    interactions: { cancel: mocks.cancelInteractions },
+    interactions: {
+      use: vi.fn(() => mocks.detachHostInteractions),
+      cancel: mocks.cancelInteractions,
+    },
     events: { emit: mocks.sessionEventEmit },
     followUps: {
       claimRecovery: vi.fn((streamId: StreamTabId) => ({
@@ -360,8 +362,6 @@ function installOwnerSession(): {
   });
   const interactions = new SessionHostInteractions();
   installSession({
-    useHostInteractions: (adapter: Parameters<typeof interactions.use>[0]) =>
-      interactions.use(adapter),
     interactions,
     events,
     status,

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -436,7 +436,7 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
     const stream = 'stream:edit-bypass';
     const session = createTestSession();
     const setApprovalBypassState = vi.fn();
-    session.useHostInteractions({
+    session.interactions.use({
       setApprovalBypassState,
       cancel: vi.fn(),
     });
@@ -562,7 +562,7 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
     const stream = 'stream:proposal-bypass';
     const session = createTestSession();
     const setApprovalBypassState = vi.fn();
-    session.useHostInteractions({
+    session.interactions.use({
       setApprovalBypassState,
       cancel: vi.fn(),
     });

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -1824,8 +1824,8 @@ describe('DesktopProgressBridge', () => {
           ),
         );
 
-        const attach = session.useHostInteractions.bind(session);
-        vi.spyOn(session, 'useHostInteractions').mockImplementation(
+        const attach = session.interactions.use.bind(session.interactions);
+        vi.spyOn(session.interactions, 'use').mockImplementation(
           (interactions) => {
             expect(interactions.requestPlanApproval).toEqual(
               expect.any(Function),

--- a/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.ts
@@ -210,11 +210,13 @@ describe('createDesktopAgentExecution', () => {
       prepareMainViewExecutionRequest: vi.fn(),
       repairRestartedStreams,
       inspectSession: (session) => {
-        const useHostInteractions = session.useHostInteractions.bind(session);
-        vi.spyOn(session, 'useHostInteractions').mockImplementation(
+        const useInteractions = session.interactions.use.bind(
+          session.interactions,
+        );
+        vi.spyOn(session.interactions, 'use').mockImplementation(
           (interactions) => {
             attached();
-            const detach = useHostInteractions(interactions);
+            const detach = useInteractions(interactions);
             return () => {
               detached();
               detach();
@@ -372,7 +374,7 @@ describe('createDesktopAgentExecution', () => {
     await run;
 
     const firstEmit = vi.fn();
-    const detach = session.useHostInteractions({
+    const detach = session.interactions.use({
       emit: firstEmit,
       cancel: vi.fn(),
     });
@@ -388,7 +390,7 @@ describe('createDesktopAgentExecution', () => {
 
     detach();
     const secondEmit = vi.fn();
-    session.useHostInteractions({ emit: secondEmit, cancel: vi.fn() });
+    session.interactions.use({ emit: secondEmit, cancel: vi.fn() });
     await Promise.resolve();
     expect(secondEmit).not.toHaveBeenCalled();
   });

--- a/src/test-kernel/desktop/DesktopAgentResume.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentResume.vitest.ts
@@ -133,7 +133,7 @@ function attachResultPresenter(session: SessionHandle): {
   const emit = vi.fn();
   return {
     emit,
-    detach: session.useHostInteractions({ emit, cancel: vi.fn() }),
+    detach: session.interactions.use({ emit, cancel: vi.fn() }),
   };
 }
 

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.ts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.ts
@@ -816,7 +816,7 @@ describe('desktop tool edit approval', () => {
         session,
         tempRoot,
       } = await createApprovalFixture();
-      session.useHostInteractions({
+      session.interactions.use({
         requestToolEditApproval: (request) =>
           controller.requestApproval(request),
         cancel: (selector) => controller.cancel(selector),

--- a/src/test-kernel/progressView/AgentPresentationHostReplayGate.vitest.ts
+++ b/src/test-kernel/progressView/AgentPresentationHostReplayGate.vitest.ts
@@ -153,7 +153,7 @@ describe('extension presentation-event emit port (#9251 replay gate)', () => {
           >,
         setApprovalBypassState: vi.fn(),
       });
-      const detach = session.useHostInteractions(interactions);
+      const detach = session.interactions.use(interactions);
       try {
         // The replay runs on a microtask queued by `use()`.
         await Promise.resolve();

--- a/src/test-kernel/progressView/ProgressThemeSync.vitest.ts
+++ b/src/test-kernel/progressView/ProgressThemeSync.vitest.ts
@@ -70,12 +70,10 @@ vi.mock('@agent/trace', () => ({
 }));
 vi.mock('@agent/runtime/SessionHandle', () => ({
   defaultSession: () => ({
-    interactions: {},
-    useHostInteractions: () => () => {},
+    interactions: { use: () => () => {} },
   }),
   tryDefaultSession: () => ({
-    interactions: {},
-    useHostInteractions: () => () => {},
+    interactions: { use: () => () => {} },
   }),
 }));
 vi.mock('@agent/runtime/terminalResultToast', () => ({

--- a/src/test-kernel/settings/ExtensionWorkspaceTransition.vitest.ts
+++ b/src/test-kernel/settings/ExtensionWorkspaceTransition.vitest.ts
@@ -83,13 +83,11 @@ vi.mock('@agent/trace', () => ({
 vi.mock('@agent/runtime/SessionHandle', () => ({
   StorageRootChangeRefusedError: class extends Error {},
   defaultSession: () => ({
-    interactions: {},
-    useHostInteractions: () => () => {},
+    interactions: { use: () => () => {} },
     setApprovalPolicy: mocks.setApprovalPolicy,
   }),
   tryDefaultSession: () => ({
-    interactions: {},
-    useHostInteractions: () => () => {},
+    interactions: { use: () => () => {} },
     setApprovalPolicy: mocks.setApprovalPolicy,
   }),
 }));

--- a/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
+++ b/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
@@ -61,7 +61,7 @@ describe('approval cleanup scope', () => {
     const session = createTestSession();
     const streamId = sid('s:cause-swallow');
     const cancel = vi.fn();
-    session.useHostInteractions({
+    session.interactions.use({
       requestToolEditApproval: pendingApproval,
       cancel,
     });
@@ -89,12 +89,12 @@ describe('approval cleanup scope', () => {
     const sessionB = createTestSession();
     const cancelA = vi.fn();
     const cancelB = vi.fn();
-    sessionA.useHostInteractions({
+    sessionA.interactions.use({
       requestToolEditApproval: pendingApproval,
       requestBashApproval: pendingApproval,
       cancel: cancelA,
     });
-    sessionB.useHostInteractions({
+    sessionB.interactions.use({
       requestToolEditApproval: pendingApproval,
       requestBashApproval: pendingApproval,
       cancel: cancelB,
@@ -231,7 +231,7 @@ describe('session-owned approval state (#8144)', () => {
   it('session disposal rejects its remaining pending approvals and clears bypass state', async () => {
     const session = createTestSession();
     const streamId = sid('s:appr-dispose');
-    session.useHostInteractions({
+    session.interactions.use({
       requestToolEditApproval: pendingApproval,
       cancel: vi.fn(),
     });

--- a/src/test-kernel/tools/BashApprovalPrompt.vitest.ts
+++ b/src/test-kernel/tools/BashApprovalPrompt.vitest.ts
@@ -77,7 +77,7 @@ describe('requestBashApproval queueing', () => {
     let prompts = 0;
     session.setApprovalPolicy('never');
     setBashApprovalSessionBypass(streamId, true, { silent: true, session });
-    session.useHostInteractions({
+    session.interactions.use({
       requestBashApproval: async () => {
         prompts += 1;
         return { action: 'approve' };
@@ -115,7 +115,7 @@ describe('requestBashApproval queueing', () => {
     const firstAnswer = pDefer<BashSettlement>();
     let prompts = 0;
 
-    session.useHostInteractions({
+    session.interactions.use({
       requestBashApproval: () => {
         prompts += 1;
         firstPrompted.resolve();

--- a/src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
+++ b/src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
@@ -71,11 +71,11 @@ describe('Concurrent session tool edit approval handlers', () => {
 
     const sessionA = createTestSession();
     const sessionB = createTestSession();
-    sessionA.useHostInteractions({
+    sessionA.interactions.use({
       requestToolEditApproval: recordingHandler(seenByA, 'from-a'),
       cancel: () => undefined,
     });
-    sessionB.useHostInteractions({
+    sessionB.interactions.use({
       requestToolEditApproval: recordingHandler(seenByB, 'from-b'),
       cancel: () => undefined,
     });

--- a/src/test-kernel/tools/DelegationHeadless.vitest.ts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.ts
@@ -171,7 +171,7 @@ function callDelegateReview() {
 async function delegateWithProposalDecision(decision: ProposalResult) {
   mocks.isProposalBypassed.mockReturnValue(false);
   const session = createTestSession();
-  session.useHostInteractions({
+  session.interactions.use({
     cancel: vi.fn(),
     requestAgentProposal: vi.fn().mockResolvedValue(decision),
   } satisfies HostInteractions);
@@ -1382,7 +1382,7 @@ describe('headless delegation', () => {
     mocks.isProposalBypassed.mockReturnValue(false);
     const session = createTestSession();
     const requestAgentProposal = vi.fn();
-    session.useHostInteractions({
+    session.interactions.use({
       cancel: vi.fn(),
       requestAgentProposal,
     } satisfies HostInteractions);

--- a/src/test-kernel/tools/DiagnosticsTool.vitest.ts
+++ b/src/test-kernel/tools/DiagnosticsTool.vitest.ts
@@ -72,7 +72,7 @@ describe('DiagnosticsTool', () => {
       const readDiagnostics = vi.fn(async (_path: string) => {
         return [] as GenericDiagnostic[];
       });
-      session.useHostInteractions({ readDiagnostics, cancel: vi.fn() });
+      session.interactions.use({ readDiagnostics, cancel: vi.fn() });
 
       const result = await withRunContext(worktreeContext(session), () =>
         new DiagnosticsTool().call({ command: 'list', path: 'paper.tex' }),
@@ -104,7 +104,7 @@ describe('DiagnosticsTool', () => {
 
   it('reports when the criticism sink does not accept (feature disabled)', async () => {
     await withSession(async (session) => {
-      session.useHostInteractions({
+      session.interactions.use({
         addCriticism: () => ({ accepted: false, resolvedPath: '' }),
         cancel: vi.fn(),
       });
@@ -120,7 +120,7 @@ describe('DiagnosticsTool', () => {
   it('resolves the path and summarizes an accepted criticism', async () => {
     await withSession(async (session) => {
       const entries: unknown[] = [];
-      session.useHostInteractions({
+      session.interactions.use({
         addCriticism: (entry) => {
           entries.push(entry);
           return { accepted: true, resolvedPath: entry.absolutePath };

--- a/src/test-kernel/tools/ExternalInquiryHostInteractionRejection.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryHostInteractionRejection.vitest.ts
@@ -18,7 +18,7 @@ describe('ExternalInquiryTool host interaction dispatch', () => {
   it('surfaces a rejected openExternalInquiry() as a tool error instead of an unhandled rejection', async () => {
     const session = createTestSession();
     const parentLease = session.followUps.claimLive(STREAM, 'flow')!;
-    session.useHostInteractions({
+    session.interactions.use({
       cancel: () => {},
       openExternalInquiry: () =>
         Promise.reject(new Error('external inquiry panel unavailable')),

--- a/src/test-kernel/tools/OpenPdfTool.vitest.ts
+++ b/src/test-kernel/tools/OpenPdfTool.vitest.ts
@@ -39,7 +39,7 @@ describe('OpenPdfTool', () => {
     const openPdf = vi.fn<(request: OpenPdfRequest) => Promise<void>>();
     openPdf.mockResolvedValue(undefined);
     detachHostInteractions();
-    detachHostInteractions = defaultSession().useHostInteractions({
+    detachHostInteractions = defaultSession().interactions.use({
       openPdf,
       cancel: () => undefined,
     });

--- a/src/test-kernel/tools/ReportReviewIssueTool.vitest.ts
+++ b/src/test-kernel/tools/ReportReviewIssueTool.vitest.ts
@@ -22,7 +22,7 @@ let detachHostInteractions = (): void => {};
 /** Attach a review sink the way a host does: as a session capability. */
 function useReviewSink(sink: ReportReviewIssueSink): void {
   detachHostInteractions();
-  detachHostInteractions = defaultSession().useHostInteractions({
+  detachHostInteractions = defaultSession().interactions.use({
     reportReviewIssue: sink,
     cancel: () => undefined,
   });

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -47,7 +47,7 @@ async function installPlatform(
   };
   await installFakePlatform({ workspacePath: '/workspace', config, files });
   detachHostInteractions();
-  detachHostInteractions = defaultSession().useHostInteractions({
+  detachHostInteractions = defaultSession().interactions.use({
     requestToolEditApproval: (request) => {
       const handler = testApprovalHandler;
       if (!handler) {


### PR DESCRIPTION
## Summary

This PR executes two behavior-preserving removals identified in the Agent-SDK readiness re-verification pass (`2026-08-25-agent-sdk-readiness-reverify.md`):

1. **Logger surface:** Removed the `export` keyword from `OutputChannelFactoryOptions` (`src/logger/logUtils.ts:49`), which had no external consumers — only an internal use as a parameter annotation in the same file.

2. **Core composition:** Removed `SessionHandle.useHostInteractions()` (§4b, PT-2), a one-line pass-through that violated the class's own documented contract ("a composition record, not a facade: it re-exposes no per-concern methods"). Callers now address the owner directly via `session.interactions.use(...)`, which was already public.

Both changes are mechanical, zero-behavior-change, and independently verified at HEAD (`51c04c6`).

## Issue acceptance gates

Addresses the standing readiness question from `2026-07-09-agent-sdk-north-star.md`: "review the agent core, model handler, logger, and surface for unnecessary abstraction and unready surface." The pass re-derived the verdict from four fresh independent area audits and surfaced these two shovel-ready findings. This PR executes them at the maintainer's request ("refactor for all the things agreed already").

## Single source of truth

- **Logger:** `src/logger/logUtils.ts` — `OutputChannelFactoryOptions` is now a local `interface`, not a public export.
- **Core composition:** `src/agent/runtime/SessionHandle.ts` — the class header ("re-exposes no per-concern methods") is now literally true with no exception.

## Duplication and abstraction budget

**Removed:** one unnecessary public `export` (logger), one pass-through facade method (core). No duplication removed; no new abstraction added. The change shrinks the public surface and tightens the composition contract.

## Net elements (R6)

- **Files changed:** 37
- **Exported symbols:** −2 (`OutputChannelFactoryOptions` export, `SessionHandle.useHostInteractions` method)
- **Net LoC:** ~89 insertions(+), ~98 deletions(−)
  - Logger: −1 line (dropped `export` keyword)
  - Core: −4 lines (removed method)
  - Call sites: ~89 insertions (mechanical retarget from `session.useHostInteractions(x)` to `session.interactions.use(x)`)
  - Test doubles: 6 reshaped (two fake sessions, two `vi.spyOn` sites, two full mocks)

## Consumer counts (R8)

- **`OutputChannelFactoryOptions`:** 0 external consumers (verified via `grep -rn` across `src/` and `packages/`; only internal use in `logUtils.ts:191`).
- **`SessionHandle.useHostInteractions`:** 6 production call sites + ~30 test call sites, all mechanically retargeted to `session.interactions.use(...)` (the direct owner-addressing form already mandated by the class contract).

## Host impact

**Extension:** 1 file (`ProgressViewProvider.ts`) — retargeted one call site.

**Desktop:** 2 files (`desktopAgentExecution.ts`, `DesktopAgentExecution.vitest.ts`) — retargeted 2 production + 2 test call sites; reshaped one test double.

**CLI:** 3 files (`chatSessionController.ts`, `runExecution.ts`, `tui-harness.tsx`) — retargeted 3 production + 2 test call sites; reshaped one test double.

**Agent SDK package:** 1 file (`packages/agent/src/index.ts`) — retargeted 1 production call site.

**Test kernel:** 20 files — retargeted ~25 test call sites; reshaped 4 test doubles (two fake sessions, two `vi.spyOn` sites).

## Scheduled refactoring

None. The design-gated items in the readiness pass (

https://claude.ai/code/session_01BKyRQCNtU5aamddNUEKrN7