### PR TITLE
Unify config parsing and validation into single walk

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -806,6 +806,12 @@
       "name": "BrowserLaunchCommand"
     },
     {
+      "file": "packages/cli/src/runtime/chatDefaults.ts",
+      "category": "production-dead",
+      "kind": "exports",
+      "name": "__resetUserConfigWarningDedupeForTests"
+    },
+    {
       "file": "packages/cli/src/runtime/cliContext.ts",
       "category": "production-dead",
       "kind": "exports",

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -78,10 +78,21 @@ const USER_CONFIG_LABEL = `user config (${TEXRA_CONFIG_FILE_NAME})`;
 /** `orchestrate`'s `launcher: while (true)` loop re-resolves chat defaults
  *  on every return to the launcher, so an in-scope invalid field (a typo'd
  *  texra.agent/texra.model/texra.chat.*) would otherwise reprint its warning
- *  once per loop pass for as long as the session stays open. Deduped by
- *  message text at module scope — live for the process, not just one call —
- *  since a config file left broken mid-session should warn once, not spam. */
-const printedUserConfigWarnings = new Set<string>();
+ *  once per loop pass for as long as the session stays open. Deduped against
+ *  only the *previous* call's warnings (not every warning ever seen this
+ *  process): the message text carries just the field name, not the invalid
+ *  value, so a field a user fixes and later breaks again the same way would
+ *  otherwise never warn again if this stayed a monotonically-growing set. */
+let previousUserConfigWarnings = new Set<string>();
+
+/** Test-only: this module-level dedup state otherwise leaks across `it()`
+ *  blocks in the same file (Vitest doesn't reset module state between tests
+ *  by default), which would make one test's warnings spuriously suppress
+ *  another's. Call from a `beforeEach` in any suite that asserts on
+ *  `loadUserDefaults`/`resolveChatDefaults` warnings. */
+export function __resetUserConfigWarningDedupeForTests(): void {
+  previousUserConfigWarnings = new Set();
+}
 
 async function loadUserDefaults(quiet: boolean): Promise<PartialDefaults> {
   // A missing user config means no user defaults (parseCliConfigValues maps
@@ -96,10 +107,11 @@ async function loadUserDefaults(quiet: boolean): Promise<PartialDefaults> {
   // other config warning is gated by contextFromArgs on context.quietLogs
   // before this function ever runs, so these warnings honor the same flag
   // instead of always printing.
+  const thisCallsWarnings = new Set<string>();
   const warn = (message: string): void => {
+    thisCallsWarnings.add(message);
     if (quiet) return;
-    if (printedUserConfigWarnings.has(message)) return;
-    printedUserConfigWarnings.add(message);
+    if (previousUserConfigWarnings.has(message)) return;
     writeTextStderr(`WARN ${message}`);
   };
   let raw: unknown;
@@ -122,11 +134,12 @@ async function loadUserDefaults(quiet: boolean): Promise<PartialDefaults> {
     // approvalPolicy (already warned about by loadUserApprovalPolicy) and
     // outputFormat/run.* (unused here). Scoping alone doesn't stop an
     // in-scope invalid field from reprinting every launcher-loop pass —
-    // that's what `printedUserConfigWarnings` is for, above.
+    // that's what `previousUserConfigWarnings` is for, above.
     topLevelFields: new Set(['agent', 'model']),
     sections: new Set(['chat']),
   });
   for (const warning of warnings) warn(warning);
+  previousUserConfigWarnings = thisCallsWarnings;
   return defaultsFromConfigValues(values);
 }
 

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -70,6 +70,19 @@ function defaultsFromConfigValues(values: CliConfigValues): PartialDefaults {
   };
 }
 
+/** Labels `loadUserDefaults`' warnings distinctly from the workspace file's
+ *  (both are literally named `config.json`, just in different directories),
+ *  matching the wording the read-failure branch already used. */
+const USER_CONFIG_LABEL = `user config (${TEXRA_CONFIG_FILE_NAME})`;
+
+/** `orchestrate`'s `launcher: while (true)` loop re-resolves chat defaults
+ *  on every return to the launcher, so an in-scope invalid field (a typo'd
+ *  texra.agent/texra.model/texra.chat.*) would otherwise reprint its warning
+ *  once per loop pass for as long as the session stays open. Deduped by
+ *  message text at module scope — live for the process, not just one call —
+ *  since a config file left broken mid-session should warn once, not spam. */
+const printedUserConfigWarnings = new Set<string>();
+
 async function loadUserDefaults(quiet: boolean): Promise<PartialDefaults> {
   // A missing user config means no user defaults (parseCliConfigValues maps
   // the undefined fallback to {}). A read failure — corrupt JSON, a
@@ -84,39 +97,35 @@ async function loadUserDefaults(quiet: boolean): Promise<PartialDefaults> {
   // before this function ever runs, so these warnings honor the same flag
   // instead of always printing.
   const warn = (message: string): void => {
-    if (!quiet) writeTextStderr(`WARN ${message}`);
+    if (quiet) return;
+    if (printedUserConfigWarnings.has(message)) return;
+    printedUserConfigWarnings.add(message);
+    writeTextStderr(`WARN ${message}`);
   };
   let raw: unknown;
   try {
     raw = await GlobalStorageFS.readJson(TEXRA_CONFIG_FILE_NAME);
   } catch (error: unknown) {
     if (!isFileNotFoundError(error)) {
-      warn(
-        `Could not read user config (${TEXRA_CONFIG_FILE_NAME}): ${toErrorMessage(error)}`,
-      );
+      warn(`Could not read ${USER_CONFIG_LABEL}: ${toErrorMessage(error)}`);
     }
     raw = undefined;
   }
   if (raw !== undefined && !isObject(raw)) {
-    warn(`Ignoring ${TEXRA_CONFIG_FILE_NAME}; expected a JSON object.`);
+    warn(`Ignoring ${USER_CONFIG_LABEL}; expected a JSON object.`);
     raw = undefined;
   }
-  const { values, warnings } = parseCliConfigValues(
-    raw,
-    TEXRA_CONFIG_FILE_NAME,
-    {
-      reportUnknownKeys: false,
-      // defaultsFromConfigValues only reads agent/model (top-level and
-      // chat.*) — scoping to just those fields avoids re-validating
-      // approvalPolicy (already warned about by loadUserApprovalPolicy) and
-      // outputFormat/run.* (unused here), and matters more than it would for
-      // a one-shot read: orchestrate's launcher loop calls resolveChatDefaults
-      // on every iteration, so an unrelated invalid field would otherwise
-      // re-print its warning every time through the loop.
-      topLevelFields: new Set(['agent', 'model']),
-      sections: new Set(['chat']),
-    },
-  );
+  const { values, warnings } = parseCliConfigValues(raw, USER_CONFIG_LABEL, {
+    reportUnknownKeys: false,
+    // defaultsFromConfigValues only reads agent/model (top-level and
+    // chat.*) — scoping to just those fields avoids re-validating
+    // approvalPolicy (already warned about by loadUserApprovalPolicy) and
+    // outputFormat/run.* (unused here). Scoping alone doesn't stop an
+    // in-scope invalid field from reprinting every launcher-loop pass —
+    // that's what `printedUserConfigWarnings` is for, above.
+    topLevelFields: new Set(['agent', 'model']),
+    sections: new Set(['chat']),
+  });
   for (const warning of warnings) warn(warning);
   return defaultsFromConfigValues(values);
 }

--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -294,18 +294,13 @@ function pickConfigValues(
 export function parseCliConfigValues(
   value: unknown,
   filePath: string,
-  {
-    reportUnknownKeys = true,
-    sections,
-    topLevelFields,
-  }: Partial<PickConfigOptions> = {},
+  options: Partial<PickConfigOptions> = {},
 ): { readonly values: CliConfigValues; readonly warnings: readonly string[] } {
   const warnings: string[] = [];
   const values = isObject(value)
     ? pickConfigValues(value, warnings, filePath, {
-        reportUnknownKeys,
-        sections,
-        topLevelFields,
+        ...options,
+        reportUnknownKeys: options.reportUnknownKeys ?? true,
       })
     : {};
   return { values, warnings };

--- a/src/test-kernel/cli/ChatDefaults.vitest.ts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.ts
@@ -6,7 +6,10 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 
 import { listExecutions } from '@agent/storage';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
-import { resolveChatDefaults } from '@cli/runtime/chatDefaults';
+import {
+  __resetUserConfigWarningDedupeForTests,
+  resolveChatDefaults,
+} from '@cli/runtime/chatDefaults';
 import {
   CLI_BUILTIN_DEFAULT_MODEL,
   loadWorkspaceCliConfig,
@@ -96,6 +99,7 @@ beforeEach(() => {
   mockedReadJson.mockReset();
   // A missing user config (the common case) mirrors a real ENOENT rejection.
   mockedReadJson.mockRejectedValue(enoentError());
+  __resetUserConfigWarningDedupeForTests();
 });
 
 const tempDirs = useTempDirs();
@@ -585,6 +589,42 @@ describe('CLI chat defaults', () => {
     );
 
     expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('reprints a warning once an intervening valid read clears the dedup state', async () => {
+    // The warning text carries only the field name, not the invalid value,
+    // so a field a user fixes and later breaks again the same way must
+    // still warn — deduping must not be "seen this message ever," only
+    // "seen this message on the immediately preceding read."
+    const invalidModel = {
+      'texra.agent': 'assistant',
+      'texra.model': 'not-a-real-model-xyz',
+    };
+    const validModel = { 'texra.agent': 'assistant', 'texra.model': 'gpt55' };
+    const warnSpy = vi
+      .spyOn(logSinks, 'writeTextStderr')
+      .mockImplementation(() => {});
+
+    mockedReadJson.mockResolvedValueOnce(invalidModel);
+    await resolveChatDefaults({ cwd: NO_WORKSPACE });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    // Same invalid config again: deduped against the previous read.
+    mockedReadJson.mockResolvedValueOnce(invalidModel);
+    await resolveChatDefaults({ cwd: NO_WORKSPACE });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    // Fixed: no warning, and the dedup state no longer carries the old one.
+    mockedReadJson.mockResolvedValueOnce(validModel);
+    await resolveChatDefaults({ cwd: NO_WORKSPACE });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    // Broken again: warns again, since the previous read had no warnings.
+    mockedReadJson.mockResolvedValueOnce(invalidModel);
+    await resolveChatDefaults({ cwd: NO_WORKSPACE });
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+
     warnSpy.mockRestore();
   });
 });

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -130,10 +130,13 @@ function parseSummaryShape(value: unknown): StreamLogSummary | undefined {
   if (value === undefined) return undefined;
   const result = StreamLogSummarySchema.safeParse(value);
   if (!result.success) {
-    // Derived tier (#9434): discard the stale-shaped cache loudly instead of
-    // migrating it in place.
+    // Derived tier (#9434): ignore the stale-shaped cache loudly instead of
+    // migrating it in place. Worded for both callers — the loader then
+    // rebuilds from the authoritative stream log, while the standalone
+    // parent-edge patch below just skips its write — neither "discards"
+    // anything from storage on this path.
     log.warn(
-      `Discarding a stale-shaped summary cache entry: ${result.error.issues
+      `Ignoring a stale-shaped summary cache entry: ${result.error.issues
         .map((issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
         .join('; ')}`,
     );

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -117,12 +117,14 @@ type StreamLogSummary = z.infer<typeof StreamLogSummarySchema>;
 
 /**
  * The one schema-validated read path for the persisted `StreamLogSummary`
- * shape — every reader of the summary cache (the in-class loader and the
- * standalone `clearPersistedSummaryParentStream` patch below) goes through
- * this instead of trusting a raw `KVStore.read()` cast. Does not apply the
- * loader's registration-evidence gate (see {@link parsePersistedSummary}):
- * a metadata-only summary persisted before a stream's first append (see
- * `recordSummaryMeta`) has no timestamps but is still a valid, live entry.
+ * shape — every reader of the summary cache (the in-class loader's
+ * `readSummary` and the standalone `clearPersistedSummaryParentStream` patch
+ * below) goes through this instead of trusting a raw `KVStore.read()` cast.
+ * Does not apply the loader's own registration-evidence gate (see
+ * `readSummary`): a metadata-only summary persisted before a stream's first
+ * append (see `recordSummaryMeta`) has no timestamps but is still a valid,
+ * live entry, so only the loader — which has a log-rebuild fallback for a
+ * timestamp-less entry — additionally filters on that.
  */
 function parseSummaryShape(value: unknown): StreamLogSummary | undefined {
   // A missing cache file (KVStore's quiet-missing `undefined`) is an
@@ -143,24 +145,6 @@ function parseSummaryShape(value: unknown): StreamLogSummary | undefined {
     return undefined;
   }
   return result.data;
-}
-
-/**
- * {@link parseSummaryShape}, plus the loader's registration-evidence gate:
- * empty transcripts have no timestamps, so a timestamp-less summary cache
- * entry isn't evidence the stream is registered — the loader falls back to
- * rebuilding from the authoritative stream log for that case.
- */
-function parsePersistedSummary(value: unknown): StreamLogSummary | undefined {
-  const summary = parseSummaryShape(value);
-  if (!summary) return undefined;
-  if (
-    summary.firstTimestamp === undefined &&
-    summary.lastTimestamp === undefined
-  ) {
-    return undefined;
-  }
-  return summary;
 }
 
 interface StreamLoadResult {
@@ -1470,8 +1454,17 @@ export class StreamLogStore {
   ): Promise<StreamLogSummary | undefined> {
     try {
       const persisted = await this.summaryKv().read<unknown>(streamId);
-      const summary = parsePersistedSummary(persisted);
+      const summary = parseSummaryShape(persisted);
       if (!summary) return undefined;
+      // Empty transcripts have no timestamps, so a timestamp-less summary
+      // cache entry isn't evidence the stream is registered — rebuild from
+      // the authoritative stream log for that case instead of trusting it.
+      if (
+        summary.firstTimestamp === undefined &&
+        summary.lastTimestamp === undefined
+      ) {
+        return undefined;
+      }
 
       const [summaryMtime, logMtime] = await Promise.all([
         this.summaryKv().modifiedAt(streamId),


### PR DESCRIPTION
## Summary

Three validation-gap fixes found by a scheduled codebase audit, plus the review fixes that landed while addressing them (this PR's `claude/dazzling-cori-jxyd15` branch was previously merged as #11376; this PR reopened from the same branch after a squash-merge left the branch's own commits without the squashed merge commit as an ancestor — the diff below is real, not a rebase artifact, and includes one additional commit beyond #11376 fixing a wording nit this PR's own review caught).

1. **`ProviderMessageSchema`** (`src/agent/types/ProviderMessage.ts`) used a `z.custom()` predicate that accepted *any* non-empty, non-array object. Its own docstring says it exists to fail loudly on corrupted persisted conversation state during session resume — but the predicate let corrupted/legacy-shaped messages through, where they'd crash confusingly deep inside a model handler instead. Every member of the `ProviderMessage` union carries a top-level `role` or `type` string, except legacy Gemini `Content` which instead carries a `parts` array — verified against each SDK's `.d.ts`. The predicate now requires one of those three.

2. **`clearPersistedSummaryParentStream`** (`src/transcript/StreamLogStore.ts`) read the summary cache via a bare `KVStore.read()` type-cast (no runtime validation) and wrote it straight back — a read-modify-write that could durably re-persist a corrupted or stale-shaped cache entry. `parseSummaryShape`/`parsePersistedSummary` (previously one private method used only by the loader) are split so both the class loader and the standalone patch function share the schema-validated read path, without the patch function incorrectly inheriting the loader's registration-evidence gate (a real regression caught in review — see commits after the initial fix).

3. **`cliConfig.ts`**'s value-picking and warning-collection independently walked the same field-schema lists, callable without each other. That gap was already live: `chatDefaults.ts`'s `loadUserDefaults` called the value-picker alone, so an invalid field in the *user* config was silently dropped with no warning — while the same field in the *workspace* config already produced one. Merged into a single pass; `parseCliConfigValues` now returns `{ values, warnings }`. Follow-up review passes (from claude[bot], Codex, and texra-ai's automated reviewers on the original PR) caught three further real bugs this merge introduced, all fixed here too: unknown-key warnings leaking into the CLI-exclusive `chat`/`run` sections' suppression, `--quiet` being bypassed for the new warning path, and an invalid unrelated field (`approvalPolicy`/`outputFormat`) re-warning on every pass through `orchestrate`'s `launcher: while (true)` loop.

## Issue acceptance gates

No tracked issue; filed directly from a scheduled codebase audit. Gate: each of the three findings above has its validation gap closed, the four regressions later reviews caught are fixed, and all are covered by tests (see Validation).

## Single source of truth

- `parseSummaryShape`/`parsePersistedSummary` (module-level in `StreamLogStore.ts`) are the one schema-validated read path for the persisted `StreamLogSummary` shape, split so the patch function doesn't inherit the loader-only registration-evidence gate.
- `parseCliConfigValues` (in `cliConfig.ts`) is the one pass producing both `CliConfigValues` and its validation warnings, with `reportUnknownKeys`/`topLevelFields`/`sections` options letting each caller scope what it actually consumes instead of a second independent walk per caller.

## Duplication and abstraction budget

Removed: `StreamLogStore`'s private `parsePersistedSummary` method (folded into the module-level split above); `cliConfig.ts`'s `collectValidationWarnings`, `warnInvalidField`, `parseOptional`, `pickRecord` (folded into `pickFields`/`pickCommandSection`). Added: the `PickConfigOptions` interface (not exported — internal to `cliConfig.ts`) documenting the three scoping knobs, and `pickCommandSection` replacing `pickCommandConfig`. No new abstractions beyond what the merge itself required; both new/renamed helpers have their call sites confirmed exhaustive by grep.

## Net elements (R6)

Actual diff (`git diff --stat origin/main...HEAD`): **8 files changed, +391/-127** (net +264). This is *not* the doc-only/refactor-only diff the size suggests — it bundles two independent correctness fixes (`ProviderMessage.ts`, and the `StreamLogStore.ts` shape/gate split) and 153 lines of new regression tests (`ChatDefaults.vitest.ts` +127, `StreamLogStoreLoad.vitest.ts` +26) alongside the `cliConfig.ts` consolidation itself, which is why the total doesn't read as a pure reduction despite removing four named helpers. One export's signature changed (`parseCliConfigValues`, now returning `{ values, warnings }` instead of bare `CliConfigValues`) — no net change in exported symbol *count*, and the new `PickConfigOptions` type is intentionally *not* exported.

## Consumer counts (R8)

`parseCliConfigValues`'s signature changed; both of its two call sites were updated (`loadWorkspaceCliConfig` in `cliConfig.ts`, `loadUserDefaults` in `chatDefaults.ts`). `resolveChatDefaults`'s new `quiet` option required updating both of its call sites (`orchestrate.ts`, `runChatTui.tsx`) — grepped and confirmed exhaustive. No emit paths touched.

## Host impact

Extension: none (these modules are host-agnostic / CLI-only).

Desktop: none.

CLI: `texra chat`/`texra orchestrate`'s default-agent/default-model resolution now surfaces a `WARN` for an invalid or unknown-in-a-CLI-owned-section field in the user-level config file, matching (and properly scoping/gating) the warning already given for the workspace-level config file. `--quiet` now suppresses these warnings like every other config warning. No behavior change for valid config.

## Scheduled refactoring

None — a couple of "worth a look" notes from review (the exact duplicate `approvalPolicy` warning between this path and `loadUserApprovalPolicy`, and the `ProviderMessage` predicate's narrower-than-the-type-union edge for an SDK shape nothing in this codebase constructs) were judged justified complexity/acceptable risk and left as documented notes rather than follow-up issues.

## Validation

- `npm run typecheck` (full workspace: extension, desktop, CLI, agent SDK, trace-viewer) — passes
- `npx eslint` on all changed files — clean
- `npx prettier --check` on all changed files — clean
- `npx vitest run` on the directly relevant suites (`StreamLogStoreLoad`, `CliContext`, `ChatDefaults`, `ConfigForm`, `InitConfig`, `ConfigCommand`, `CliRootArgs`, `RunChatSignalOwnership`) — all passing, including 8 new regression tests each independently verified to fail against the pre-fix code
- `npm run check:dead-code-ratchet` — no new findings vs baseline