### PR TITLE
refactor(controllers): un-export 13 symbols with no cross-file consumer

### DIFF
--- a/src/controllers/mainView/MainViewDroppedFilesController.ts
+++ b/src/controllers/mainView/MainViewDroppedFilesController.ts
@@ -17,7 +17,7 @@ export type MainViewAllowedDropExtensions = Readonly<
   Record<MainViewAttachableDropCategory, readonly string[]>
 >;
 
-export interface MainViewDroppedFileAttachmentPlan {
+interface MainViewDroppedFileAttachmentPlan {
   readonly filesByCategory: Readonly<
     Record<MainViewAttachableDropCategory, readonly string[]>
   >;
@@ -25,7 +25,7 @@ export interface MainViewDroppedFileAttachmentPlan {
   readonly rejectedCount: number;
 }
 
-export interface MainViewDroppedFileAttachmentInput {
+interface MainViewDroppedFileAttachmentInput {
   readonly paths: readonly (string | null)[];
   readonly allowedExtensions: MainViewAllowedDropExtensions;
   readonly target?: MultipleDocumentFileType;

--- a/src/controllers/mainView/backend/MainViewExecutionLaunchController.ts
+++ b/src/controllers/mainView/backend/MainViewExecutionLaunchController.ts
@@ -31,7 +31,7 @@ export interface MainViewExecutionLaunchHost {
 }
 
 /** Host-neutral result of resolving the launch sequence. */
-export type MainViewExecutionLaunchResult =
+type MainViewExecutionLaunchResult =
   | {
       status: 'prepared';
       preparation: MainViewExecutionPreparationResult;

--- a/src/controllers/progressView/ChatExportController.ts
+++ b/src/controllers/progressView/ChatExportController.ts
@@ -25,8 +25,6 @@ import {
   type ChatExportInput,
 } from '@agent/export/chatExportFormatter';
 
-export type { ChatExportInput };
-
 import { compileLatex2Pdf } from '@latex/texTools';
 import { projectWorkflowCallEntries } from '@model/projectWorkflowCallEntry';
 import type { ExecutionId } from '@shared/schemas';

--- a/src/controllers/progressView/ChatExportController.ts
+++ b/src/controllers/progressView/ChatExportController.ts
@@ -22,8 +22,8 @@ import {
   formatChatAsMarkdown,
   formatChatAsLatex,
   generateExportFilename,
-  type ChatExportInput,
 } from '@agent/export/chatExportFormatter';
+import type { ChatExportInput } from '@agent/export/schemas';
 
 import { compileLatex2Pdf } from '@latex/texTools';
 import { projectWorkflowCallEntries } from '@model/projectWorkflowCallEntry';

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -17,7 +17,7 @@ import {
 } from '@shared/model/kimiCodeRetryGate';
 import { isNonEmptyString } from '@utils/core';
 
-export interface ProgressApiKeyRetryRequest {
+interface ProgressApiKeyRetryRequest {
   stream: StreamTabId;
   requestId: string;
   provider?: ApiProvider;
@@ -37,7 +37,7 @@ interface ProgressApiKeyPreparationResult {
   disabledQuotaRoutes: readonly ExhaustionReason[];
 }
 
-export interface ProgressApiKeyRetryResult extends ProgressApiKeyPreparationResult {
+interface ProgressApiKeyRetryResult extends ProgressApiKeyPreparationResult {
   retried: boolean;
 }
 

--- a/src/controllers/progressView/ProgressFollowUpController.ts
+++ b/src/controllers/progressView/ProgressFollowUpController.ts
@@ -29,7 +29,7 @@ interface ProgressFollowUpWorkspace {
   exists(relativePath: string): Promise<boolean>;
 }
 
-export interface ProgressFollowUpControllerDeps {
+interface ProgressFollowUpControllerDeps {
   loadModelOptions(): Promise<readonly ProgressFollowUpModelOption[]>;
   state: ProgressFollowUpState;
   workspace: ProgressFollowUpWorkspace;
@@ -56,7 +56,7 @@ export type ProgressFollowUpPlan =
   // producer would inherit it (gate the swap more narrowly if that isn't wanted).
   | { kind: 'execute'; request: ExecutionRequest };
 
-export interface CompileFixerInput {
+interface CompileFixerInput {
   streamId: StreamTabId;
   runConfig: AgentConfig | undefined;
   compileFailures: CompileFailure[];

--- a/src/controllers/progressView/ProgressFollowUpPolishController.ts
+++ b/src/controllers/progressView/ProgressFollowUpPolishController.ts
@@ -13,7 +13,7 @@ type UpdateFollowUpTextMessage = Extract<
   { command: typeof PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT }
 >;
 
-export interface ProgressFollowUpPolishInput {
+interface ProgressFollowUpPolishInput {
   readonly stream: StreamTabId;
   readonly text: string;
   /** The run's config, which the command handler resolves before dispatching:
@@ -32,7 +32,7 @@ type ProgressFollowUpPolishText = (
   fileContext?: FileContext,
 ) => Promise<ProgressFollowUpPolishTextResult>;
 
-export interface ProgressFollowUpPolishControllerDeps {
+interface ProgressFollowUpPolishControllerDeps {
   readonly polishText: ProgressFollowUpPolishText;
 }
 

--- a/src/controllers/progressView/ProgressWorkflowActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowActionsController.ts
@@ -36,7 +36,7 @@ interface ProgressWorkflowActionsState extends StreamOutputsSource {
   getKnownWorkspaceOutputPaths(stream: StreamTabId): Set<string>;
 }
 
-export interface ProgressWorkflowActionsControllerDeps {
+interface ProgressWorkflowActionsControllerDeps {
   state: ProgressWorkflowActionsState;
   runDiff(request: WorkflowDiffRequest): Promise<void>;
   runFileOperation(

--- a/src/controllers/progressView/backend/ExternalInquiryRequestHandler.ts
+++ b/src/controllers/progressView/backend/ExternalInquiryRequestHandler.ts
@@ -15,7 +15,7 @@ import { ApprovalRequestHandler } from './ApprovalRequestHandler';
 
 const MAX_INQUIRY_THREADS = 100;
 
-export interface ExternalInquiryRequestHandlerOptions {
+interface ExternalInquiryRequestHandlerOptions {
   show: (permission: ExternalInquiryPermission) => void;
   dismiss: (requestId: string) => void;
   syncThreads: (threads: InquiryThreadUpdatedEvent[]) => void;

--- a/src/controllers/progressView/exportTranscript.ts
+++ b/src/controllers/progressView/exportTranscript.ts
@@ -10,7 +10,7 @@
 import * as path from 'node:path';
 
 // Local imports
-import type { ChatExportInput } from '@agent/export';
+import type { ChatExportInput } from '@agent/export/schemas';
 import {
   ChatExportController,
   type ExportInputStatus,

--- a/src/controllers/progressView/exportTranscript.ts
+++ b/src/controllers/progressView/exportTranscript.ts
@@ -10,9 +10,9 @@
 import * as path from 'node:path';
 
 // Local imports
+import type { ChatExportInput } from '@agent/export';
 import {
   ChatExportController,
-  type ChatExportInput,
   type ExportInputStatus,
   type HtmlExportOutcome,
   type LatexExportResult,

--- a/src/controllers/progressView/progressStreamControls.ts
+++ b/src/controllers/progressView/progressStreamControls.ts
@@ -18,7 +18,7 @@ interface ProgressStreamBypassControls {
   superYoloBypass: boolean;
 }
 
-export type ProgressStreamControls = ProgressStreamBypassControls &
+type ProgressStreamControls = ProgressStreamBypassControls &
   (
     | { goalActive: false }
     | { goalActive: true; goalStatus: GoalStatus; goalObjective: string }


### PR DESCRIPTION
Closes #11386.

## Summary

Twelve types in `src/controllers/**` carried an `export` keyword with no cross-file traffic at all — not to production, not to `src/test-kernel/`. Each appears only in its own defining file, as a return type, a parameter type, or a constructor dependency bag.

They are invisible to the dead-code gate because a type reachable from an exported signature counts as used, so one level of nesting hides it.

**Correction (review-caught):** an earlier version of this body cited `docs/proposals/2026-08-19-dead-code-gate-blind-spots.md` §1 for that mechanism. That is the wrong section — §1 is "a test is a consumer", §2 is `packages/cli`, §3 is stray `.js` siblings. The mechanism here is a **fourth, unrecorded gap**, and the cleanest demonstration is inside one changed file: `MainViewAllowedDropExtensions`, referenced only from an interface member, *is* baselined as `production-dead/types`, whereas `MainViewDroppedFileAttachmentPlan`/`Input`, referenced directly in the exported `planMainViewDroppedFileAttachments` signature, never appear in the baseline at all. `knip.json` sets no `ignoreExportsUsedInFile`, so the documented default would have reported them. Recording that gap in the proposal is tracked separately. `npm run check:dead-code-ratchet` was green before this PR and is green after, with no baseline change — these were never in it.

Also drops `ChatExportController`'s `export type { ChatExportInput }`, a re-export of a type it does not own (`@agent/export/schemas`). Its one consumer, the sibling `exportTranscript.ts`, now imports it from `@agent/export` the way `packages/cli/src/runtime/history.ts:17` already does.

## Single source of truth

`ChatExportInput` now has one import specifier for controller-side consumers: `@agent/export/schemas`, the module that declares it (`z.infer<typeof ChatExportInputSchema>`). The `@agent/export` barrel re-exports it for hosts; the controllers no longer take a second door through `@agent/export/chatExportFormatter`.

## Duplication and abstraction budget

Removed: 13 `export` keywords and one re-export line. Added: one import line in `exportTranscript.ts`. No new indirection.

## Net elements (R6)

10 files changed, 14 insertions / 16 deletions (`git diff --stat origin/main`). Net **−13 exported elements**; no class, interface, or enum declaration was added or deleted — only their visibility narrowed. Net LoC **−2**.

(An earlier body said 13/14 and net −1. Review was right: the `ChatExportController.ts` hunk removes the re-export line *and* its trailing blank line. The count above also includes the follow-up commit aligning the `ChatExportInput` specifier.)

## Consumer counts (R8)

Every symbol below was verified with a whole-word grep across `src/`, `packages/*/src`, `packages/extension/resources/`, `prompts/`, and `supabase/functions/`. Cross-file production consumers before → after: **0 → 0** for all thirteen.

| symbol | file | in-file uses |
| --- | --- | --- |
| `MainViewDroppedFileAttachmentPlan` | `MainViewDroppedFilesController.ts` | 1 |
| `MainViewDroppedFileAttachmentInput` | `MainViewDroppedFilesController.ts` | 1 |
| `MainViewExecutionLaunchResult` | `backend/MainViewExecutionLaunchController.ts` | 1 |
| `ProgressApiKeyRetryRequest` | `ProgressApiKeyRetryController.ts` | 8 |
| `ProgressApiKeyRetryResult` | `ProgressApiKeyRetryController.ts` | 2 |
| `ProgressFollowUpControllerDeps` | `ProgressFollowUpController.ts` | 1 |
| `CompileFixerInput` | `ProgressFollowUpController.ts` | 1 |
| `ProgressFollowUpPolishInput` | `ProgressFollowUpPolishController.ts` | 1 |
| `ProgressFollowUpPolishControllerDeps` | `ProgressFollowUpPolishController.ts` | 1 |
| `ProgressWorkflowActionsControllerDeps` | `ProgressWorkflowActionsController.ts` | 1 |
| `ExternalInquiryRequestHandlerOptions` | `backend/ExternalInquiryRequestHandler.ts` | 1 |
| `ProgressStreamControls` | `progressStreamControls.ts` | 2 |
| `ChatExportInput` (re-export) | `ChatExportController.ts` | 1 consumer, repointed |

## Scope note — one survey claim refuted

The issue also listed `onboardingFunnel.ts:20`'s `export type { OnboardingFunnelState }` as a redundant re-export. **It is not**, and it is deliberately left alone: `packages/extension/src/webview/MainViewProvider.ts:23` and `packages/desktop/src/main/desktopOnboardingIpc.ts:3` both import that type *from the controller path*, not from `@shared/schemas`. Removing it would force churn across two host files to no benefit.

## Host impact

None. No host file changes; no wire schema, command, or setting touched.

## Validation

- `npm run typecheck` (all 6 sub-projects) — pass
- `npx eslint <changed files>` — clean
- `npm run check:dead-code-ratchet` — pass, 412 vs 412 baselined, zero net baseline change
- `npx vitest run src/test-kernel/controllers src/test-kernel/progressView` — 87 files, 863 tests, all pass
- `npx prettier --check <changed files>` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
