### PR TITLE
refactor(auth): retire the token-pair accessor no caller used

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -667,10 +667,6 @@ if (HARNESS_AUTHENTICATED === '1' || HARNESS_AUTHENTICATED === '0') {
   SupabaseClient.setAuthProvider({
     whenReady: async () => {},
     ensureFreshToken: async () => accessToken,
-    getSessionTokens: async () =>
-      accessToken
-        ? { accessToken, refreshToken: 'harness-refresh-token' }
-        : null,
     getStoredSessionState: async () =>
       accessToken === null ? 'none' : 'authenticated',
     getStoredAccountLabel: async () => null,

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -9,11 +9,7 @@ import { createLog } from '@logger/logUtils';
 import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
 import { SUPABASE_GOTRUE_STORAGE_KEY } from './config';
 import type { SessionSecretStore } from './oauth/sessionAccess';
-import type {
-  AuthTokenProvider,
-  SessionTokens,
-  StoredSessionState,
-} from './TokenProvider';
+import type { AuthTokenProvider, StoredSessionState } from './TokenProvider';
 
 const log = createLog('SupabaseClient');
 
@@ -242,23 +238,6 @@ export class SupabaseClient {
       return await this.authProvider.ensureFreshToken(forceRefresh);
     } catch (error) {
       log.error(`Error getting access token: ${toErrorMessage(error)}`);
-      return null;
-    }
-  }
-
-  /**
-   * Get access and refresh tokens from secure storage.
-   * Ensures tokens are fresh before returning.
-   */
-  static async getSessionTokens(): Promise<SessionTokens | null> {
-    if (!this.authProvider) {
-      return null;
-    }
-
-    try {
-      return await this.authProvider.getSessionTokens();
-    } catch (error) {
-      log.error(`Error getting session tokens: ${toErrorMessage(error)}`);
       return null;
     }
   }

--- a/src/auth/TokenProvider.ts
+++ b/src/auth/TokenProvider.ts
@@ -22,7 +22,6 @@ export function classifyAuthFailureStatus(
 export interface AuthTokenProvider {
   whenReady(): Promise<void>;
   ensureFreshToken(forceRefresh?: boolean): Promise<string | null>;
-  getSessionTokens(): Promise<SessionTokens | null>;
   /** Classify the stored session while guarding against replacement races. */
   getStoredSessionState(): Promise<StoredSessionState>;
   /**

--- a/src/test-kernel/auth/SupabaseClient.vitest.ts
+++ b/src/test-kernel/auth/SupabaseClient.vitest.ts
@@ -24,7 +24,6 @@ function createTokenProvider(
   return {
     whenReady: async () => {},
     ensureFreshToken: async () => 'access-token',
-    getSessionTokens: async () => null,
     getStoredSessionState: async () => 'none',
     getStoredAccountLabel: async () => null,
     getLastRefreshFailure: () => null,
@@ -32,42 +31,10 @@ function createTokenProvider(
   };
 }
 
-/** Provider holding a refreshable session pair for `accessToken`. */
-function sessionTokenProvider(accessToken: string): AuthTokenProvider {
-  return createTokenProvider({
-    ensureFreshToken: async () => accessToken,
-    getSessionTokens: async () => ({
-      accessToken,
-      refreshToken: 'refresh-token',
-    }),
-  });
-}
-
 describe('SupabaseClient', () => {
   afterEach(() => {
     SupabaseClient.resetForTests();
     vi.restoreAllMocks();
-  });
-
-  it('reads session tokens through the registered token provider', async () => {
-    SupabaseClient.setAuthProvider(sessionTokenProvider('access-token'));
-
-    assert.deepEqual(await SupabaseClient.getSessionTokens(), {
-      accessToken: 'access-token',
-      refreshToken: 'refresh-token',
-    });
-  });
-
-  it('returns null when the token provider throws while reading session tokens', async () => {
-    const provider = createTokenProvider({
-      getSessionTokens: async () => {
-        throw new Error('storage unavailable');
-      },
-    });
-
-    SupabaseClient.setAuthProvider(provider);
-
-    assert.equal(await SupabaseClient.getSessionTokens(), null);
   });
 
   it('waits for token provider readiness', async () => {

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.ts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.ts
@@ -38,14 +38,6 @@ function createCoordinator() {
     ensureFreshToken: vi.fn(
       async () => storedSession.current?.accessToken ?? null,
     ),
-    getSessionTokens: vi.fn(async () =>
-      storedSession.current
-        ? {
-            accessToken: storedSession.current.accessToken,
-            refreshToken: storedSession.current.refreshToken,
-          }
-        : null,
-    ),
   };
 }
 
@@ -195,10 +187,6 @@ function routeMatchingCallback(
 
 function installAuthenticatedSupabaseProvider() {
   const ensureFreshToken = vi.fn(async () => 'fresh-access-token');
-  const getSessionTokens = vi.fn(async () => ({
-    accessToken: 'fresh-access-token',
-    refreshToken: 'refresh-token',
-  }));
   const getStoredSessionState = vi.fn(async () => 'authenticated' as const);
   SupabaseClient.initialize(
     'https://example.supabase.co',
@@ -208,7 +196,6 @@ function installAuthenticatedSupabaseProvider() {
   SupabaseClient.setAuthProvider({
     whenReady: vi.fn(async () => {}),
     ensureFreshToken,
-    getSessionTokens,
     getStoredSessionState,
     getStoredAccountLabel: vi.fn(async () => null),
     getLastRefreshFailure: vi.fn(() => null),
@@ -217,7 +204,7 @@ function installAuthenticatedSupabaseProvider() {
     id: 'user-1',
     email: 'user@example.com',
   } as never);
-  return { ensureFreshToken, getSessionTokens, getStoredSessionState };
+  return { ensureFreshToken, getStoredSessionState };
 }
 
 describe('desktop Supabase auth', () => {
@@ -867,7 +854,7 @@ describe('desktop Supabase auth', () => {
   });
 
   it('refreshes desktop session state for profile data without a token fetch', async () => {
-    const { ensureFreshToken, getSessionTokens, getStoredSessionState } =
+    const { ensureFreshToken, getStoredSessionState } =
       installAuthenticatedSupabaseProvider();
 
     const controller = new SettingsProfileController({
@@ -879,7 +866,6 @@ describe('desktop Supabase auth', () => {
     const message = await controller.buildProfileMessage();
 
     expect(getStoredSessionState).toHaveBeenCalledOnce();
-    expect(getSessionTokens).not.toHaveBeenCalled();
     expect(ensureFreshToken).not.toHaveBeenCalled();
     expect(message).toMatchObject({
       authenticated: true,


### PR DESCRIPTION
Closes #11389.

## Summary

`SupabaseClient.getSessionTokens` had **zero production consumers**. A whole-word grep over `src/`, `packages/*/src`, `packages/extension/resources/`, `prompts/`, and `supabase/functions/` found only its own declaration plus three references in `src/test-kernel/auth/SupabaseClient.vitest.ts`. Nothing outside the auth module ever read a refresh token; `getAccessToken` (4 production call sites) covers every real use.

This removes the static and the `AuthTokenProvider` interface member behind it.

The direction is **security-positive**: it retires the static, provider-agnostic path by which any caller could obtain the raw refresh token.

**Precision (review-caught):** this is not the *last* read path, and an earlier version of this body overstated it. `createHostAuthCoordinator` returns the concrete `SupabaseSessionCoordinator` (`SupabaseAuthCoordinator.ts:30,54`), and every host holds that object (`SupabaseAuthProvider.ts:91`, `desktopSupabaseAuth.ts:404`, `packages/cli/src/runtime/supabaseAuth.ts:95`); its public `getSessionTokens` (`SupabaseSession.ts:180-187`) still returns the pair to any holder. What goes here is the ambient static — a real reduction in exposure, not an elimination of it.

## Scope — narrower than the issue proposed, deliberately

The issue suggested making `SupabaseSessionCoordinator.getSessionTokens` private or inlining it. **It stays public**, because the issue's consumer count was incomplete: `src/test-kernel/auth/SupabaseSessionLifecycle.vitest.ts` uses it at `:322`, `:459`, `:472`, `:490`, and `:581`, including a refresh-race test (`:490`) that pins read-count behavior across a concurrent delete. Deleting it would delete that coverage, and the internal caller (`getStoredSessionState:148`) still needs it.

So the cut is: the unused public surface goes, the tested concrete method stays. `SupabaseSessionCoordinator` is the only production implementor of `AuthTokenProvider`, so dropping the member from the interface costs nothing.

## Single source of truth

`AuthTokenProvider` now declares only the token surface hosts actually consume. "Read this session's token pair" has one home, the concrete coordinator, and one internal caller.

## Duplication and abstraction budget

Removed only: one static, one interface member, and the stubs that existed solely to satisfy the member. No new abstraction.

## Net elements (R6)

5 files changed, 3 insertions / 76 deletions (`git diff --stat origin/main`). Net LoC **−73**. Elements: **−1 public static, −1 interface member, −1 type import**; no `^[+-]export` change and no class/interface/enum added or removed.

## Consumer counts (R8)

- `SupabaseClient.getSessionTokens`: production callers **0 → 0** (deleted); test callers 2 → 0.
- `AuthTokenProvider.getSessionTokens`: production call sites through the interface **1 → 0** (only the deleted static); implementors required to supply it 4 → 0 (`SupabaseSessionCoordinator` plus 3 fakes).
- `SupabaseSessionCoordinator.getSessionTokens`: production callers **1 → 1** (`getStoredSessionState:148`), test callers 5 → 5. Unchanged.
- `SessionTokens` type: still declared and used by the concrete method; only the `SupabaseClient` import of it goes.

## Test changes

Two tests in `SupabaseClient.vitest.ts` existed only to exercise the deleted static ("reads session tokens through the registered token provider", "returns null when the token provider throws"). They are deleted with the behavior per AGENTS.md testing discipline, along with the now-unused `sessionTokenProvider` helper.

Three fakes shed the stub they carried only to satisfy the interface: `SupabaseClient.vitest.ts:27`, `DesktopSupabaseAuth.vitest.ts:41`/`:198`, and `packages/cli/scripts/tui-harness.tsx:670`.

The desktop test "refreshes desktop session state for profile data without a token fetch" keeps the invariant it exists for — `expect(ensureFreshToken).not.toHaveBeenCalled()` still asserts no token fetch. No test was added.

## Host impact

None functionally. Extension, desktop, and CLI all reach auth through `createHostAuthCoordinator` and never called the removed static. `packages/cli/scripts/tui-harness.tsx` drops one stub from its fake provider.

## Validation

- `npm run typecheck` (all 6 sub-projects) — pass
- `npx eslint <changed files>` — clean
- `npx vitest run src/test-kernel/auth src/test-kernel/desktop src/test-kernel/controllers` — 104 files, 1035 tests, all pass
- `npm run check:dead-code-ratchet` — pass, 412 vs 412 baselined, zero net baseline change
- `npx prettier --write <changed files>` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
