### PR TITLE
refactor(cli): move StreamArtifactProjection to its only consumer

### DIFF
--- a/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
@@ -30,7 +30,7 @@ import { hydrateStreamArtifacts } from '@cli/chat/tui/state/subscribeStreamArtif
 import { terminalCapabilities } from '@cli/chat/tui/state/terminalCapabilities';
 import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import { activeStreamParentOrSelfId } from '@cli/chat/tui/state/streamViews';
-import type { StreamArtifactReader } from '@controllers/session/StreamArtifactProjection';
+import type { StreamArtifactReader } from '@cli/chat/tui/state/streamArtifactProjection';
 import { activeSubscriptionUsageRoute } from '@model/codingPlanSubscriptions';
 import { formatTexraApprovalPolicy } from '@shared/approvalPolicy';
 import { MESSAGE_TYPES } from '@shared/schemas';

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -7,7 +7,7 @@ import {
   type CliLogoutTarget,
   parseChatLoginSlashArgs,
 } from '@cli/runtime/loginOptions';
-import type { StreamArtifactReader } from '@controllers/session/StreamArtifactProjection';
+import type { StreamArtifactReader } from '@cli/chat/tui/state/streamArtifactProjection';
 import type { ApiProvider } from '@model/apiProviders';
 import type { TexraApprovalPolicy } from '@shared/approvalPolicy';
 import { type ExecutionId } from '@shared/schemas';

--- a/packages/cli/src/chat/tui/state/streamArtifactProjection.ts
+++ b/packages/cli/src/chat/tui/state/streamArtifactProjection.ts
@@ -11,10 +11,11 @@ import {
 import type { StreamSnapshotStore } from '@transcript';
 
 /**
- * The store surface a host needs to preload and read the accumulated
- * round-artifact/usage projection. The CLI and the shared progress-view
- * controllers project the same fields, so the reader shape lives here rather
- * than on any one host.
+ * The store surface needed to preload and read the accumulated
+ * round-artifact/usage projection. The TUI is the only consumer: the
+ * progress-view renderer reads `StreamSnapshotStore` directly instead
+ * (`LitSessionRenderer.getOutputFiles`/`getRunUsage`), so this projection is
+ * CLI presentation, not shared state.
  */
 export type StreamArtifactReader = Pick<
   StreamSnapshotStore,

--- a/packages/cli/src/chat/tui/state/streamArtifactProjection.ts
+++ b/packages/cli/src/chat/tui/state/streamArtifactProjection.ts
@@ -12,10 +12,11 @@ import type { StreamSnapshotStore } from '@transcript';
 
 /**
  * The store surface needed to preload and read the accumulated
- * round-artifact/usage projection. The TUI is the only consumer: the
- * progress-view renderer reads `StreamSnapshotStore` directly instead
- * (`LitSessionRenderer.getOutputFiles`/`getRunUsage`), so this projection is
- * CLI presentation, not shared state.
+ * round-artifact/usage projection. No host-neutral module imports this
+ * projection: the progress-view renderer reads the store directly
+ * (`state.snapshots.getOutputFiles`/`getRunUsage`), and the progress-view
+ * controllers reach those same accessors through their own narrower
+ * `StreamOutputsSource` port. So this is CLI presentation, not shared state.
  */
 export type StreamArtifactReader = Pick<
   StreamSnapshotStore,

--- a/packages/cli/src/chat/tui/state/streamArtifactProjection.ts
+++ b/packages/cli/src/chat/tui/state/streamArtifactProjection.ts
@@ -15,7 +15,7 @@ import type { StreamSnapshotStore } from '@transcript';
  * round-artifact/usage projection. No host-neutral module imports this
  * projection: the progress-view renderer reads the store directly
  * (`state.snapshots.getOutputFiles`/`getRunUsage`), and the progress-view
- * controllers reach those same accessors through their own narrower
+ * controllers reach `getOutputFiles`/`preload` through their own narrower
  * `StreamOutputsSource` port. So this is CLI presentation, not shared state.
  */
 export type StreamArtifactReader = Pick<

--- a/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
@@ -13,11 +13,6 @@
 import { signal } from '@lit-labs/signals';
 
 import { tryDefaultSession } from '@agent/runtime';
-import {
-  projectStreamArtifacts,
-  type StreamArtifactProjection,
-  type StreamArtifactReader,
-} from '@controllers/session/StreamArtifactProjection';
 import { type StreamTabId, type TokenUsageStats } from '@shared/schemas';
 import { subscribeToSignalChanges } from '@shared/signals';
 import {
@@ -25,6 +20,11 @@ import {
   type StreamArtifactAuthority,
 } from '@transcript';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import {
+  projectStreamArtifacts,
+  type StreamArtifactProjection,
+  type StreamArtifactReader,
+} from './streamArtifactProjection';
 
 import {
   activeStreamId,

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -51,8 +51,8 @@ import type { CliContext } from '@cli/runtime/cliContext';
 import * as modelAccessSelection from '@cli/runtime/modelAccessSelection';
 import * as supabaseAuth from '@cli/runtime/supabaseAuth';
 import { TuiSession } from '@cli/chat/tui/state/sessionRunState';
+import type { StreamArtifactReader } from '@cli/chat/tui/state/streamArtifactProjection';
 import { SessionState } from '@controllers/session/SessionState';
-import type { StreamArtifactReader } from '@controllers/session/StreamArtifactProjection';
 import * as codexPreference from '@model/codex/codexPreference';
 import type { TexraApprovalPolicy } from '@shared/approvalPolicy';
 import {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -92,7 +92,7 @@ import {
   moveLocalTranscriptToStream,
   resolveLocalTranscriptStreamId,
 } from '@cli/chat/tui/state/transcript';
-import { projectStreamArtifacts } from '@controllers/session/StreamArtifactProjection';
+import { projectStreamArtifacts } from '@cli/chat/tui/state/streamArtifactProjection';
 import { SessionState } from '@controllers/session/SessionState';
 import { stripOrchestratorFollowup } from '@shared/subagentFollowup';
 import {


### PR DESCRIPTION
Closes #11388.

## Summary

`src/controllers/session/StreamArtifactProjection.ts` justified its place in the host-agnostic layer with a docstring claiming:

> The CLI **and the shared progress-view controllers** project the same fields, so the reader shape lives here rather than on any one host.

That is false at HEAD. Every consumer is the CLI:

- `packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts:144` — the only call site of `projectStreamArtifacts`
- `packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts:33`
- `packages/cli/src/chat/tui/commands/registerBuiltins.tsx:10`
- tests: `src/test-kernel/cli/SlashCommandDispatch.vitest.ts`, `src/test-kernel/cli/TuiStateAndFocus.vitest.ts` — both under `test-kernel/cli/`

`LitSessionRenderer` reads `StreamSnapshotStore` directly (`:247`, `:351`, `:359-366`) and never imports this module, so there is no "shared progress-view" consumer for it to be neutral between.

Moved to `packages/cli/src/chat/tui/state/streamArtifactProjection.ts`, beside `subscribeStreamArtifacts`, and the docstring rewritten to state what is actually true. `src/controllers/` is host-neutral orchestration, not a home for one host's presentation projection.

## Single source of truth

Unchanged — `projectStreamArtifacts` remains the one canonical per-stream artifact/usage projection for the TUI, and still delegates the summing rule to `sumUsageStats` (`@shared/schemas`). Only its location moves.

## Duplication and abstraction budget

No new module, type, or wrapper. One file relocated, five import specifiers repointed, one false docstring corrected.

## Net elements (R6)

6 files changed, 15 insertions / 13 deletions against `origin/main` (an earlier body said 14/13; rename detection counts the docstring hunk differently, and two follow-up commits tightened it after review). Net LoC **+1** (the corrected docstring runs one line longer). Elements: **−3 exports out of `src/controllers/session/`** (`StreamArtifactReader`, `StreamArtifactProjection`, `projectStreamArtifacts`), same three added under `packages/cli`. No class/interface/enum created or deleted.

This one is honest about direction: it is a **layering fix, not a LoC win**. The gain is that the host-agnostic layer no longer carries a single-host projection behind a docstring that misdescribed it.

## Consumer counts (R8)

- `projectStreamArtifacts`: production call sites **1 → 1** (`subscribeStreamArtifacts.ts:144`), all CLI before and after.
- `StreamArtifactReader`: production consumers **3 → 3**, all under `packages/cli/src/chat/tui/`.
- `StreamArtifactProjection`: production consumers **1 → 1**.
- Extension/desktop consumers: **0 → 0**.

## Ratchets

Per the B3 obligation (`2026-08-15-single-substrate-hosts-as-renderers.md:30-32`), both edge ratchets were run rather than assumed:

- `npx vitest run src/test-kernel/architecture` — 17 files, 106 tests, all pass. No `architecture-edges-baseline.json` or `host-agent-import-baseline.json` change is required: the moved file imports `@shared/schemas` and `@transcript`, neither of which is an `@agent/*` deep import, and the CLI already reaches both.
- `npm run check:dead-code-ratchet` — 412 vs 412 baselined, unchanged.

## Host impact

CLI: three import specifiers repointed; one now relative (`./streamArtifactProjection`) since it sits in the same directory.

Extension and desktop: none — neither imported the module.

## Validation

- `npm run typecheck` (all 6 sub-projects) — pass
- `npx eslint <changed files>` — clean (import-order auto-fixed after the move)
- `npx vitest run src/test-kernel/cli src/test-kernel/architecture` — 161 files, 2656 passed, 1 skipped
- `npm run check:dead-code-ratchet` — pass, zero net baseline change
- `npx prettier --check <changed files>` — clean

## Deferred

The issue also listed `StreamInfoSource` (`src/controllers/session/streamInfoUtils.ts:7`) as an export used only inside its own file. It is left alone here: it has three references in `src/test-kernel/progressView/streamInfoUtils.vitest.ts`, which puts it in the "a test is a consumer" species that `2026-08-19-dead-code-gate-blind-spots.md` §1 says needs per-symbol judgement rather than a blanket un-export. Unrelated to this move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
