### PR TITLE
refactor(cli): drop the tool-status rules the shared probe already decides

### DIFF
--- a/packages/cli/src/runtime/tools.ts
+++ b/packages/cli/src/runtime/tools.ts
@@ -42,12 +42,6 @@ function getCliToolDefs(): ExternalToolDef[] {
   );
 }
 
-function detectedFromStatus(status: string): boolean | null {
-  if (status === 'available') return true;
-  if (status === 'not-found') return false;
-  return null;
-}
-
 function noteForTool(
   def: ExternalToolDef,
   detected: boolean | null,
@@ -64,11 +58,15 @@ export async function readCliToolStatuses(): Promise<CliToolStatusRecord[]> {
   const disabledIds = getDisabledToolIds();
 
   return getCliToolDefs().map((def) => {
+    // `runProbes` maps over the same EXTERNAL_TOOL_DEFS this filters, so the
+    // lookup always hits; the `??` arms are shape-level defaults, not reachable
+    // states. The probe already decides coming-soon (`status`) and the raw
+    // dependency outcome (`detected`), so neither is re-derived here.
     const check = checks.get(def.id);
     const comingSoon = def.comingSoon === true;
     const toggleable = def.toggleable === true;
-    const status = check?.status ?? (comingSoon ? 'coming-soon' : 'unknown');
-    const detected = check?.detected ?? detectedFromStatus(status);
+    const status = check?.status ?? 'unknown';
+    const detected = check?.detected ?? null;
     return {
       id: def.id,
       name: def.name,


### PR DESCRIPTION
Refs #11390. **Implements the verified half; rejects the issue's main proposal on cost — see below.**

## Summary

`readCliToolStatuses` re-derived two facts `runExternalToolChecks` already provides.

`runProbes` (`src/tools/toolAvailability.ts:136-181`) maps over the same `EXTERNAL_TOOL_DEFS` list that `getCliToolDefs` filters, so every surviving def has a result. It also never rejects: each probe body has its own `try/catch` that degrades to `'unknown'` (`:154-159`), `resolveOptionalStatus` catches (`:188`), and the outer wrapper is `try/finally` with no `catch` (`:120-131`). So `checks.get(def.id)` always hits, and the `??` arms were shape-level defaults rather than reachable states.

- **`status`** re-decided coming-soon. The probe already encodes it: `status: comingSoon ? 'coming-soon' : probedStatus` (`:172`).
- **`detected`** fell back to `detectedFromStatus`, which is unreachable *in effect*. `??` fires only when `check.detected` is `null`, and `detected` is null only when `probedStatus === 'unknown'` (`:173-174`). For `status` of `'unknown'` or `'coming-soon'`, `detectedFromStatus` returns `null` — the same value. It could never change the answer.

`detectedFromStatus` is deleted and the invariant is stated in a comment so the next reader doesn't restore the defence.

## Why the issue's main proposal is NOT implemented

#11390 proposed routing `readCliToolStatuses` through `buildToolDashboardItems('cli')`, since the `'cli'` arm of `ToolHost` has no caller. I verified that premise — it is true — and then costed the fold. It does not pay:

1. **The stated blocking precondition does not exist.** The issue said the shared builder "iterates probe results and drops defs with no result." It does iterate results, but `runProbes` produces exactly one result per def, so nothing is ever dropped. That removes the *reason* the fold looked like a bug fix.
2. **It would change extension and desktop behavior.** `buildToolDashboardItems` applies `isDefaultToolUnavailableOnHost` to built-ins only (`ToolDashboardData.ts:167-169`); the CLI applies it to externals too (`tools.ts:40`). Teaching the shared builder the CLI's rule silently changes what two other hosts render — a behavior change needing its own justification, not a refactor.
3. **It needs feature-decision fields.** `CliToolStatusRecord` carries `detected`, `note`, `comingSoon`, and a `toggleable`-aware `enabled: boolean | null`; `ToolDashboardItem` carries none of them. The issue itself puts adding them out of scope.
4. **It needs four host-conditional branches** in the shared builder (`hideFromCli` filtering, external host exclusion, suppress built-ins for CLI, the widened row) — and the CLI would still project `ToolDashboardItem` → `CliToolStatusRecord` afterwards.

Net effect: more elements and more coupling in a shared function, plus a cross-host behavior change, to delete ~40 lines of straightforward per-def mapping. That is the abstraction-cost trap §13 of the review checklist was written for (the Refactor-LoC lesson), and the "convergence adds LoC when the duplicated surface is smaller than the seam" case.

I have posted this evidence on #11390 and left it open for a maintainer ruling rather than closing it unilaterally. The unused `'cli'` arm of `ToolHost` is real and stays recorded there.

## Single source of truth

The external-tool probe (`runExternalToolChecks`) is now the sole decider of both `status` (coming-soon included) and `detected` for the CLI. The CLI reads them; it no longer re-decides either.

## Duplication and abstraction budget

Removed one function and one duplicated rule. Added a 4-line comment naming the invariant. No new abstraction.

## Net elements (R6)

1 file changed, 6 insertions / 8 deletions. Net LoC **−2** (−8 code, +4 comment). Elements: **−1 function** (`detectedFromStatus`, file-local), −1 duplicated coming-soon rule. No `^[+-]export` change.

## Consumer counts (R8)

- `detectedFromStatus`: production callers **1 → 0** (deleted).
- `readCliToolStatuses`: production callers unchanged (`packages/cli/src/runtime/tools.ts:92`, `ToolsListForm.tsx`, `texra tools list`).
- `buildToolDashboardItems`: production callers **2 → 2** (`desktop/main/index.ts:827`, `extension SettingsViewMessageHandler.ts:752`) — untouched by this PR.

## Host impact

CLI only. Output of `texra tools list` is unchanged: both deleted paths were provably value-preserving.

Extension and desktop: no change (deliberately — see above).

## Validation

- `npm run typecheck` (all 6 sub-projects) — pass
- `npx eslint <changed files>` — clean
- `npm run check:dead-code-ratchet` — pass, 412 vs 412 baselined
- `npx prettier --check <changed files>` — clean
- `npx vitest run src/test-kernel/cli src/test-kernel/tools` — 243 files, 3350 passed, 1 skipped.

  Reporting this honestly: the **first** run of that suite showed 1 failure, and two subsequent runs were clean at 243/243. I was not able to capture the failing test name before it passed again. The suite is dense with retry/stream simulation (`Retry requested (Model invocation): stream dropped before first token`), and this PR touches only two pure expression reads in `tools.ts`, neither reachable from a streaming path. I believe it was pre-existing local flake rather than this change, but I did not prove that, so it is flagged rather than dismissed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)