### PR TITLE
docs(auth): correct two callback-path comments that describe a path nothing emits

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1,5 +1,5 @@
 {
-  "semantics": "Single baseline for the two Knip inputs owned by scripts/check-dead-code-ratchet.mjs: the normal run preserves ordinary findings, while findings emitted by the production run but absent from the normal run are categorized as production-dead. Each finding is identified by (file, category, kind, name), never by line number. Category is unused or production-dead; kind preserves Knip’s files, exports, types, or duplicates issue kind so same-name findings of different kinds remain distinct. The ratchet fails when the combined result contains a finding not in this list. Removing resolved entries is always welcome; an intentional new finding must be added in sorted order by file, category, kind, then name. Run `npm run check:dead-code-ratchet` as the authoritative dead-code check.",
+  "semantics": "Single baseline for the two Knip inputs owned by scripts/check-dead-code-ratchet.mjs: the normal run preserves ordinary findings, while findings emitted by the production run but absent from the normal run are categorized as production-dead. Each finding is identified by (file, category, kind, name), never by line number. Category is unused or production-dead; kind preserves Knip\u2019s files, exports, types, or duplicates issue kind so same-name findings of different kinds remain distinct. The ratchet fails when the combined result contains a finding not in this list. Removing resolved entries is always welcome; an intentional new finding must be added in sorted order by file, category, kind, then name. Run `npm run check:dead-code-ratchet` as the authoritative dead-code check.",
   "findings": [
     {
       "file": "packages/cli/src/chat/tui/appLayout.ts",
@@ -1626,12 +1626,6 @@
       "category": "production-dead",
       "kind": "exports",
       "name": "writeWorkflowScriptCheckpoint"
-    },
-    {
-      "file": "src/auth/authCallback.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "getAuthCallbackBasePath"
     },
     {
       "file": "src/auth/codex/codexAuthAccess.ts",

--- a/packages/extension/src/frontend/auth/UriHandler.ts
+++ b/packages/extension/src/frontend/auth/UriHandler.ts
@@ -13,13 +13,16 @@ export class SupabaseUriHandler implements vscode.UriHandler {
    * Handle incoming URIs from OAuth callbacks.
    * This is called when the user is redirected back from the OAuth provider.
    *
-   * Accepts both paths:
-   * - /auth-callback: Used by desktop VS Code (vscode://, cursor://)
-   * - /extension-auth-callback: Used by VS Code web/Codespaces (https://*.github.dev/)
+   * Accepts both paths in `AUTH_CALLBACK_PATHS`. Only `/auth-callback` is
+   * produced today: the resolver builds every redirect from
+   * `getAuthCallbackUri`, which hardcodes that path, and `asExternalUri` only
+   * appends VS Code's `?state=` routing token. `/extension-auth-callback` is
+   * retained tolerance for a web/Codespaces shape this repo no longer emits;
+   * narrowing it needs a Codespaces sign-in check, not a grep.
    */
   handleUri(uri: vscode.Uri): vscode.ProviderResult<void> {
-    // Check if this is an auth callback (both desktop and web/Codespaces paths)
-    // In Codespaces, the state param may be URL-encoded into the path (e.g., /extension-auth-callback?state=xxx)
+    // The routed-back URI carries VS Code's ?state= token on the path, so the
+    // check is on the base path only.
     if (isAuthCallbackPath(uri.path)) {
       // Fire event so the auth provider can handle it
       this._onDidReceiveCallback.fire(uri);

--- a/src/auth/authCallback.ts
+++ b/src/auth/authCallback.ts
@@ -14,7 +14,7 @@ interface AuthCallbackParseError {
   isAuthError?: boolean;
 }
 
-export function getAuthCallbackBasePath(path: string): string {
+function getAuthCallbackBasePath(path: string): string {
   return path.split('?')[0];
 }
 

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -175,7 +175,8 @@ export function setExternalAuthCallbackResolver(
  * Uses the host-provided adapter to handle different environments:
  * - Desktop VS Code: returns vscode://texra-ai.texra/auth-callback
  * - Cursor: returns cursor://texra-ai.texra/auth-callback
- * - Codespaces: returns https://*.github.dev/extension-auth-callback
+ * - Codespaces: returns the workbench URL asExternalUri() routes back, with
+ *   VS Code's ?state= token appended to the same /auth-callback path
  * - Remote SSH: handles port forwarding automatically
  *
  * In Codespaces, VS Code generates a state parameter that MUST be preserved

--- a/src/test-kernel/auth/authCallback.vitest.ts
+++ b/src/test-kernel/auth/authCallback.vitest.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  getAuthCallbackBasePath,
-  isAuthCallbackPath,
-  parseAuthCallbackCode,
-} from '@auth/authCallback';
+import { isAuthCallbackPath, parseAuthCallbackCode } from '@auth/authCallback';
 
 describe('authCallback', () => {
   it('recognizes desktop and web callback paths', () => {
@@ -14,9 +10,6 @@ describe('authCallback', () => {
       isAuthCallbackPath('/extension-auth-callback?state=vscode-state'),
     ).toBe(true);
     expect(isAuthCallbackPath('/not-auth')).toBe(false);
-    expect(getAuthCallbackBasePath('/extension-auth-callback?state=abc')).toBe(
-      '/extension-auth-callback',
-    );
   });
 
   it('extracts the PKCE code from the query string', () => {


### PR DESCRIPTION
## Summary

Two comments claimed Codespaces returns `https://*.github.dev/extension-auth-callback`:

- `src/auth/config.ts:178`
- `packages/extension/src/frontend/auth/UriHandler.ts:18`

Neither is true, and neither has been since the resolver was rewritten to derive from `getAuthCallbackUri`. The chain is:

1. `packages/extension/src/extension.ts:455-459` builds every redirect from `getAuthCallbackUri(vscode.env.uriScheme)`
2. `src/auth/config.ts:140-142` hardcodes `/auth-callback`
3. `asExternalUri` only appends VS Code's `?state=` routing token

So nothing in the repo can emit `/extension-auth-callback`.

## What this deliberately does NOT do

`AUTH_CALLBACK_PATHS` still accepts `/extension-auth-callback`, and `isAuthCallbackPath` still matches it.

Narrowing an accepted auth-callback surface depends on VS Code web routing never delivering that path to `handleUri` — which a grep cannot establish, because the routing happens inside VS Code, not this repo. That needs a real Codespaces sign-in check. Getting it wrong breaks sign-in for exactly the users who cannot easily work around it.

The comment now records that state honestly ("retained tolerance for a shape this repo no longer emits; narrowing it needs a Codespaces sign-in check, not a grep") instead of asserting a shape the code cannot produce. A future sweep reading it will know both the fact and the gate.

## Also

`getAuthCallbackBasePath` is un-exported — no consumer outside its own file. It was already carried in `config/ratchets/knip-baseline.json` as `production-dead/exports`, so **the baseline shrinks by one entry in this PR**, as the ratchet requires.

Its one direct assertion is dropped rather than rewritten: the same query-stripping is already exercised through the public predicate two lines above (`isAuthCallbackPath('/extension-auth-callback?state=vscode-state')`).

## Single source of truth

`getAuthCallbackUri` remains the only producer of a callback path; the comments now describe it rather than a parallel story.

## Net elements (R6)

5 files changed, 13 insertions / 22 deletions. Net LoC **−9**. Elements: **−1 exported function** (now file-local), **−1 knip baseline entry**. No class/interface/enum change.

## Consumer counts (R8)

- `getAuthCallbackBasePath`: production consumers outside its file **0 → 0**; exported **yes → no**; test consumers 1 → 0.
- `isAuthCallbackPath`: 2 production consumers (`UriHandler.ts:23`, `desktopProtocolCallbacks.ts:78`) — unchanged.
- `AUTH_CALLBACK_PATHS`: unchanged, still 2 entries.

## Host impact

None. No runtime behavior changes: the only code change is a visibility narrowing on a function with no external caller.

## Validation

- `npm run typecheck` (all 6 sub-projects) — pass
- `npx eslint <changed files>` — clean
- `npm run check:dead-code-ratchet` — pass, **411 vs 411** (down from 412; the shrink is in this PR)
- `npx vitest run src/test-kernel/auth` — 18 files, 143 tests, all pass
- `npx prettier --check <changed files>` — clean

## Two candidates from the same survey, rejected on closer reading

Recording these so the next sweep does not re-raise them:

- **`src/auth/fetchWithTimeout.ts` → `AbortSignal.timeout`.** Not a clean builtin swap. The module adds a custom timeout *message* and aborts-then-throws; `AbortSignal.timeout` rejects with a `TimeoutError` DOMException, so replacing it needs a catch-and-map layer. Net saving is roughly a wash, it moves tested pure logic inline into a security-adjacent path, and it costs two focused tests that pin real abort semantics (`SupabaseSessionLifecycle.vitest.ts:608`, `:628` — upstream-signal combination and upstream-error preservation).
- **`checkDeadlineBeforeSleep` in `deviceCodePoll.ts`.** A genuine one-caller knob, but its documented purpose is preserving Supabase CLI device-auth timing. Deleting it makes that flow time out up to one server-supplied interval earlier. That is a behavior change in an auth flow for ~10 lines, and a product call rather than a cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)