### PR TITLE
feat(cli): compact the terminal tab title

### DIFF
--- a/packages/cli/src/chat/tui/terminalTitle.ts
+++ b/packages/cli/src/chat/tui/terminalTitle.ts
@@ -5,6 +5,7 @@ import { loadingFrameAt } from '@cli/tui/ui/LoadingIndicator';
 import { subscribeToSharedTick } from '@cli/tui/useLiveNowMs';
 import {
   formatSessionTitle,
+  TERMINAL_TAB_TITLE,
   type SessionTitleState,
 } from '@shared/sessionTitle';
 import { subscribeToSignalChanges } from '@shared/signals';
@@ -24,6 +25,12 @@ import { terminalCapabilities } from './state/terminalCapabilities';
 // eslint-disable-next-line no-control-regex -- stripping C0/C1 controls
 const TITLE_INVALID_CHARS = /[\x00-\x1f\x7f-\x9f]/g;
 
+// The TUI's ASCII spin cycle reads as stray punctuation once a frame stands
+// alone in a tab title (a `-` is indistinguishable from a separator), so the
+// title spins through braille dots instead. Quarter-turn steps, because the
+// shared clock ticks at 1 Hz and a ten-frame cycle would crawl.
+const TITLE_FRAMES = ['⠋', '⠹', '⠴', '⠦'] as const;
+
 /** Project-aware terminal title, optionally annotated with live TUI state. */
 export function terminalTitleText(
   cwd: string,
@@ -34,7 +41,10 @@ export function terminalTitleText(
     invalidCharPattern: TITLE_INVALID_CHARS,
     replacement: '',
   });
-  return formatSessionTitle(project, state, activityDetail);
+  return formatSessionTitle(project, state, {
+    detail: activityDetail,
+    style: TERMINAL_TAB_TITLE,
+  });
 }
 
 /** Write the title only when terminal capability discovery admitted OSC. */
@@ -91,7 +101,7 @@ export function installTerminalTitleUpdates(
   // rotation `LoadingIndicator` and the status bar use, so the tab title
   // joins the shared clock instead of running its own interval.
   const runningTitle = (): string =>
-    terminalTitleText(cwd, 'running', loadingFrameAt(Date.now()));
+    terminalTitleText(cwd, 'running', loadingFrameAt(Date.now(), TITLE_FRAMES));
   const startRunningAnimation = (): void => {
     if (stopSharedTick !== undefined) return;
     if (!terminalCapabilities.get().oscColorReports) return;

--- a/packages/desktop/src/main/desktopWindowTitle.ts
+++ b/packages/desktop/src/main/desktopWindowTitle.ts
@@ -4,6 +4,7 @@ import type { SessionHandle } from '@agent/runtime';
 import { STREAM_PHASE } from '@shared/schemas';
 import {
   formatSessionTitle,
+  NATIVE_WINDOW_TITLE,
   type SessionTitleState,
 } from '@shared/sessionTitle';
 
@@ -37,7 +38,9 @@ export function getDesktopWindowTitle(
   workspacePath: string | undefined,
 ): string {
   const workspaceName = workspacePath ? basename(workspacePath) : undefined;
-  return formatSessionTitle(workspaceName, getDesktopSessionActivity(session));
+  return formatSessionTitle(workspaceName, getDesktopSessionActivity(session), {
+    style: NATIVE_WINDOW_TITLE,
+  });
 }
 
 /**

--- a/src/shared/sessionTitle.ts
+++ b/src/shared/sessionTitle.ts
@@ -1,32 +1,54 @@
 export type SessionTitleState = 'idle' | 'running' | 'approval';
 
-const ACTIVITY_LABEL: Record<SessionTitleState, string | undefined> = {
-  idle: undefined,
-  running: 'Running',
-  approval: 'Approval needed',
+/**
+ * Host-specific vocabulary and density for one title surface. A terminal tab
+ * is a few characters wide and competes with sibling tabs, so it gets the
+ * brand mark and glyph markers; a native window title has room for words.
+ */
+export interface SessionTitleStyle {
+  /** Product name as rendered: compact mark or spelled-out name. */
+  readonly brand: string;
+  /** Placed between the brand and the project name. */
+  readonly separator: string;
+  /** State marker, or `undefined` to leave that state unmarked. */
+  readonly marker: Record<SessionTitleState, string | undefined>;
+}
+
+export const TERMINAL_TAB_TITLE: SessionTitleStyle = {
+  brand: '{T}',
+  separator: '·',
+  marker: { idle: undefined, running: '⠋', approval: '⚠' },
 };
 
+export const NATIVE_WINDOW_TITLE: SessionTitleStyle = {
+  brand: 'TeXRA',
+  separator: ' · ',
+  marker: { idle: undefined, running: 'Running', approval: 'Approval needed' },
+};
+
+export interface SessionTitleOptions {
+  /** Live activity, e.g. a spinner frame; REPLACES the running marker. */
+  readonly detail?: string;
+  readonly style: SessionTitleStyle;
+}
+
 /**
- * Format the product title shared by native windows and terminal tabs.
- * Optional `activityDetail` (e.g. a live spinner frame) REPLACES the state
- * label for the running state — an animated frame already says "running",
- * so `TeXRA — ⠋ — proj` instead of `TeXRA — Running ⠋ — proj`; the label
- * stays when there is no live detail to carry it.
+ * Format the product title shared by native windows and terminal tabs:
+ * `⠋ {T}·proj`. The state marker leads so it survives tab truncation, and a
+ * live `detail` frame stands in for the running marker — an animated frame
+ * already says "running", so no redundant word beside it.
  */
 export function formatSessionTitle(
   project: string | undefined,
   state: SessionTitleState,
-  activityDetail?: string,
+  options: SessionTitleOptions,
 ): string {
-  const label = ACTIVITY_LABEL[state];
-  let activity = label;
-  if (state === 'running' && activityDetail) {
-    // A live spinner frame already says "running"; no redundant word.
-    activity = activityDetail;
-  } else if (label != null && activityDetail) {
-    activity = `${label} ${activityDetail}`;
-  }
-  return ['TeXRA', activity, project]
-    .filter((segment): segment is string => Boolean(segment))
-    .join(' — ');
+  const { detail, style } = options;
+  // A live frame stands in for the running marker; other states keep theirs.
+  const marker =
+    state === 'running'
+      ? (detail ?? style.marker.running)
+      : style.marker[state];
+  const head = marker ? `${marker} ${style.brand}` : style.brand;
+  return project ? `${head}${style.separator}${project}` : head;
 }

--- a/src/shared/sessionTitle.ts
+++ b/src/shared/sessionTitle.ts
@@ -14,17 +14,23 @@ export interface SessionTitleStyle {
   readonly marker: Record<SessionTitleState, string | undefined>;
 }
 
-export const TERMINAL_TAB_TITLE: SessionTitleStyle = {
+// Deep-frozen: both styles cross a module boundary, and `readonly` alone is
+// compile-time only — a mutated `marker` here would retitle both hosts.
+export const TERMINAL_TAB_TITLE: SessionTitleStyle = Object.freeze({
   brand: '{T}',
   separator: '·',
-  marker: { idle: undefined, running: '⠋', approval: '⚠' },
-};
+  marker: Object.freeze({ idle: undefined, running: '⠋', approval: '⚠' }),
+});
 
-export const NATIVE_WINDOW_TITLE: SessionTitleStyle = {
+export const NATIVE_WINDOW_TITLE: SessionTitleStyle = Object.freeze({
   brand: 'TeXRA',
   separator: ' · ',
-  marker: { idle: undefined, running: 'Running', approval: 'Approval needed' },
-};
+  marker: Object.freeze({
+    idle: undefined,
+    running: 'Running',
+    approval: 'Approval needed',
+  }),
+});
 
 export interface SessionTitleOptions {
   /** Live activity, e.g. a spinner frame; REPLACES the running marker. */

--- a/src/test-kernel/cli/TerminalCleanup.vitest.ts
+++ b/src/test-kernel/cli/TerminalCleanup.vitest.ts
@@ -65,27 +65,27 @@ function queueTitleApproval(streamId: string): void {
 describe('terminalTitleText', () => {
   it('names the tab after the project folder', () => {
     expect(terminalTitleText('/Users/ray/projects/coauthor')).toBe(
-      'TeXRA — coauthor',
+      '{T}·coauthor',
     );
   });
 
   it('falls back to the bare brand name at the filesystem root', () => {
-    expect(terminalTitleText('/')).toBe('TeXRA');
+    expect(terminalTitleText('/')).toBe('{T}');
   });
 
-  it('adds running and approval labels before the project name', () => {
+  it('leads with running and approval labels ahead of the brand name', () => {
     expect(terminalTitleText('/Users/ray/projects/coauthor', 'running')).toBe(
-      'TeXRA — Running — coauthor',
+      '⠋ {T}·coauthor',
     );
     expect(terminalTitleText('/Users/ray/projects/coauthor', 'approval')).toBe(
-      'TeXRA — Approval needed — coauthor',
+      '⚠ {T}·coauthor',
     );
-    expect(terminalTitleText('/', 'running')).toBe('TeXRA — Running');
+    expect(terminalTitleText('/', 'running')).toBe('⠋ {T}');
   });
 
   it('strips control characters out of a hostile folder name', () => {
     expect(terminalTitleText('/tmp/evil\x07\x1b]0;pwned\x07')).toBe(
-      'TeXRA — evil]0;pwned',
+      '{T}·evil]0;pwned',
     );
   });
 });
@@ -119,7 +119,7 @@ describe('installTerminalTitleUpdates', () => {
 
     await flushTitleUpdate();
 
-    expectLastTitle('TeXRA — | — coauthor');
+    expectLastTitle('⠋ {T}·coauthor');
     updates.dispose();
   });
 
@@ -132,7 +132,7 @@ describe('installTerminalTitleUpdates', () => {
 
     const updates = installTerminalTitleUpdates('/work/coauthor');
 
-    expectLastTitle('TeXRA — | — coauthor');
+    expectLastTitle('⠋ {T}·coauthor');
     updates.dispose();
   });
 
@@ -152,22 +152,22 @@ describe('installTerminalTitleUpdates', () => {
       status: STREAM_PHASE.RUNNING,
     });
     await flushTitleUpdate();
-    expectLastTitle('TeXRA — | — coauthor');
+    expectLastTitle('⠋ {T}·coauthor');
 
     queueTitleApproval('title-transition');
     await flushTitleUpdate();
-    expectLastTitle('TeXRA — Approval needed — coauthor');
+    expectLastTitle('⚠ {T}·coauthor');
 
     clearApprovals();
     await flushTitleUpdate();
-    expectLastTitle('TeXRA — | — coauthor');
+    expectLastTitle('⠋ {T}·coauthor');
 
     setStreamStatusInCliState({
       streamId: 'transition-child',
       status: STREAM_PHASE.WAITING,
     });
     await flushTitleUpdate();
-    expectLastTitle('TeXRA — coauthor');
+    expectLastTitle('{T}·coauthor');
     updates.dispose();
   });
 
@@ -182,36 +182,37 @@ describe('installTerminalTitleUpdates', () => {
     });
     await flushTitleUpdate();
 
-    // Frame comes from `loadingFrameAt(Date.now())` on the shared 1 Hz tick
-    // (see LOADING_FRAMES in LoadingIndicator.tsx), not a private timer, so
+    // Frame comes from `loadingFrameAt(Date.now(), TITLE_FRAMES)` on the
+    // shared 1 Hz tick (braille dots, not the TUI's ASCII spin cycle: a bare
+    // `-` reads as punctuation in a tab), not a private timer, so
     // each check advances a full second and the frame is whatever wall time
     // projects to — not reset to index 0 on each animation restart.
-    expectLastTitle('TeXRA — | — coauthor');
+    expectLastTitle('⠋ {T}·coauthor');
     vi.advanceTimersByTime(1000);
-    expectLastTitle('TeXRA — / — coauthor');
+    expectLastTitle('⠹ {T}·coauthor');
     vi.advanceTimersByTime(1000);
-    expectLastTitle('TeXRA — - — coauthor');
+    expectLastTitle('⠴ {T}·coauthor');
 
     queueTitleApproval('animated-root');
     await flushTitleUpdate();
-    expectLastTitle('TeXRA — Approval needed — coauthor');
+    expectLastTitle('⚠ {T}·coauthor');
     expectNoTitleWrites();
 
     clearApprovals();
     await flushTitleUpdate();
-    expectLastTitle('TeXRA — \\ — coauthor');
+    expectLastTitle('⠦ {T}·coauthor');
     updates.suspend();
-    expectLastTitle('TeXRA — coauthor');
+    expectLastTitle('{T}·coauthor');
     expectNoTitleWrites();
 
     updates.resume();
-    expectLastTitle('TeXRA — / — coauthor');
+    expectLastTitle('⠹ {T}·coauthor');
     setStreamStatusInCliState({
       streamId: 'animated-root',
       status: STREAM_PHASE.WAITING,
     });
     await flushTitleUpdate();
-    expectLastTitle('TeXRA — coauthor');
+    expectLastTitle('{T}·coauthor');
     expectNoTitleWrites();
 
     setStreamStatusInCliState({
@@ -219,7 +220,7 @@ describe('installTerminalTitleUpdates', () => {
       status: STREAM_PHASE.RUNNING,
     });
     await flushTitleUpdate();
-    expectLastTitle('TeXRA — - — coauthor');
+    expectLastTitle('⠴ {T}·coauthor');
     updates.dispose();
     expectNoTitleWrites();
   });
@@ -244,7 +245,7 @@ describe('installTerminalTitleUpdates', () => {
     expect(writeSync).toHaveBeenCalledTimes(2);
     updates.dispose();
     expect(writeSync).toHaveBeenCalledTimes(3);
-    expectLastTitle('TeXRA — coauthor');
+    expectLastTitle('{T}·coauthor');
     expect(off).toHaveBeenCalledWith('exit', exitListener);
   });
 
@@ -263,7 +264,7 @@ describe('installTerminalTitleUpdates', () => {
 
     exitListener?.(0);
 
-    expectLastTitle('TeXRA — coauthor');
+    expectLastTitle('{T}·coauthor');
     expect(writeSync).toHaveBeenCalledTimes(3);
     updates.dispose();
     expect(writeSync).toHaveBeenCalledTimes(3);
@@ -279,13 +280,13 @@ describe('installTerminalTitleUpdates', () => {
     await flushTitleUpdate();
 
     updates.suspend();
-    expectLastTitle('TeXRA — coauthor');
+    expectLastTitle('{T}·coauthor');
     queueTitleApproval('title-suspend');
     await flushTitleUpdate();
     expect(writeSync).toHaveBeenCalledTimes(3);
 
     updates.resume();
-    expectLastTitle('TeXRA — Approval needed — coauthor');
+    expectLastTitle('⚠ {T}·coauthor');
     updates.dispose();
   });
 
@@ -304,7 +305,7 @@ describe('installTerminalTitleUpdates', () => {
     );
     rootRunPending.set(false);
     await flushTitleUpdate();
-    expectLastTitle('TeXRA — evil]0;pwned');
+    expectLastTitle('{T}·evil]0;pwned');
     capableUpdates.dispose();
   });
 });

--- a/src/test-kernel/desktop/DesktopWindowTitle.vitest.ts
+++ b/src/test-kernel/desktop/DesktopWindowTitle.vitest.ts
@@ -9,7 +9,7 @@ import {
   installDesktopWindowTitle,
 } from '@desktop/main/desktopWindowTitle';
 import { STREAM_PHASE, type StreamTabId } from '@shared/schemas';
-import { formatSessionTitle } from '@shared/sessionTitle';
+import { formatSessionTitle, NATIVE_WINDOW_TITLE } from '@shared/sessionTitle';
 import { seedStreamStatusForTest } from '@test/support/streamStatusTestUtils';
 import { testExecutionHandle } from '@test/support/executionHandleFixtures';
 import { createTestSession } from '@test/support/sessionTestUtils';
@@ -70,14 +70,17 @@ function installTitle(
 
 describe('desktop process-session window title', () => {
   it('formats exact copy for absent and hostile workspace names', () => {
-    expect(formatSessionTitle(undefined, 'idle')).toBe('TeXRA');
-    expect(formatSessionTitle(undefined, 'running')).toBe('TeXRA — Running');
-    expect(formatSessionTitle(undefined, 'approval')).toBe(
-      'TeXRA — Approval needed',
+    const style = { style: NATIVE_WINDOW_TITLE };
+    expect(formatSessionTitle(undefined, 'idle', style)).toBe('TeXRA');
+    expect(formatSessionTitle(undefined, 'running', style)).toBe(
+      'Running TeXRA',
     );
-    expect(formatSessionTitle('draft — Running <script>.tex', 'approval')).toBe(
-      'TeXRA — Approval needed — draft — Running <script>.tex',
+    expect(formatSessionTitle(undefined, 'approval', style)).toBe(
+      'Approval needed TeXRA',
     );
+    expect(
+      formatSessionTitle('draft — Running <script>.tex', 'approval', style),
+    ).toBe('Approval needed TeXRA · draft — Running <script>.tex');
   });
 
   it('requires a registered agent with canonical RUNNING status', () => {
@@ -166,7 +169,7 @@ describe('desktop process-session window title', () => {
 
   it('prevents renderer replacement, deduplicates writes, and disposes', () => {
     const session = createTestSession();
-    const view = createWindow('TeXRA — geometry');
+    const view = createWindow('TeXRA · geometry');
     const dispose = installTitle(view.window, session);
     try {
       expect(view.setTitle).not.toHaveBeenCalled();
@@ -198,7 +201,7 @@ describe('desktop process-session window title', () => {
 
   it('does not write the native title after window destruction', () => {
     const session = createTestSession();
-    const view = createWindow('TeXRA — geometry');
+    const view = createWindow('TeXRA · geometry');
     const dispose = installTitle(view.window, session);
     try {
       view.destroy();
@@ -227,10 +230,10 @@ describe('desktop process-session window title', () => {
       });
 
       expect(getDesktopWindowTitle(firstSession, '/work/geometry')).toBe(
-        'TeXRA — Approval needed — geometry',
+        'Approval needed TeXRA · geometry',
       );
       expect(getDesktopWindowTitle(secondSession, '/work/algebra')).toBe(
-        'TeXRA — algebra',
+        'TeXRA · algebra',
       );
 
       const reopened = createWindow(


### PR DESCRIPTION
## What

The terminal tab title spent most of its width on the product name and two spaced em dashes:

```
TeXRA — - — TNLean
```

The `-` in the middle was not a separator — it was the spinner. `loadingFrameAt` cycles `| / - \` at 1 Hz, so a quarter of the time the running title showed a bare hyphen indistinguishable from the punctuation around it.

Now:

| state | before | after |
| --- | --- | --- |
| running | `TeXRA — - — TNLean` | `⠋ {T}·TNLean` |
| approval | `TeXRA — Approval needed — TNLean` | `⚠ {T}·TNLean` |
| idle | `TeXRA — TNLean` | `{T}·TNLean` |

The state marker leads so it survives end-truncation in a narrow tab, the brand becomes the `{T}` mark, and the separator drops to a tight middle dot. `Approval needed` was 15 characters that pushed the project name out of view exactly when you are scanning tabs to find the one asking for something; `⚠` says the same in one column.

The title keeps its animation, but through braille dots rather than the TUI's ASCII frames — in a tab title with no adjacent label, `-` and `\` read as debris. Quarter-turn steps, since the shared clock ticks at 1 Hz and a ten-frame cycle would crawl.

## Style, not a second formatter

`formatSessionTitle` is shared with the Electron window title, where the mark alone would be cryptic and there is room for words. It now takes a `SessionTitleStyle` — brand, separator, per-state markers — with `TERMINAL_TAB_TITLE` and `NATIVE_WINDOW_TITLE` as the two instances. Desktop windows read `Approval needed TeXRA · geometry`. One formatter, one shape, host-specific vocabulary.

## Verified

- `npm run typecheck` clean
- `npm run lint` clean
- `npx vitest run src/test-kernel/cli/TerminalCleanup.vitest.ts src/test-kernel/desktop/DesktopWindowTitle.vitest.ts` — 26 passed (expectations updated in place, no new test files)
- `npm run check:dead-code-ratchet` — no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)