### PR TITLE
refactor(cli): move StreamArtifactProjection to its only consumer

### DIFF
--- a/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
@@ -30,7 +30,7 @@ import { hydrateStreamArtifacts } from '@cli/chat/tui/state/subscribeStreamArtif
 import { terminalCapabilities } from '@cli/chat/tui/state/terminalCapabilities';
 import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import { activeStreamParentOrSelfId } from '@cli/chat/tui/state/streamViews';
-import type { StreamArtifactReader } from '@controllers/session/StreamArtifactProjection';
+import type { StreamArtifactReader } from '@cli/chat/tui/state/streamArtifactProjection';
 import { activeSubscriptionUsageRoute } from '@model/codingPlanSubscriptions';
 import { formatTexraApprovalPolicy } from '@shared/approvalPolicy';
 import { MESSAGE_TYPES } from '@shared/schemas';

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -7,7 +7,7 @@ import {
   type CliLogoutTarget,
   parseChatLoginSlashArgs,
 } from '@cli/runtime/loginOptions';
-import type { StreamArtifactReader } from '@controllers/session/StreamArtifactProjection';
+import type { StreamArtifactReader } from '@cli/chat/tui/state/streamArtifactProjection';
 import type { ApiProvider } from '@model/apiProviders';
 import type { TexraApprovalPolicy } from '@shared/approvalPolicy';
 import { type ExecutionId } from '@shared/schemas';

--- a/packages/cli/src/chat/tui/state/streamArtifactProjection.ts
+++ b/packages/cli/src/chat/tui/state/streamArtifactProjection.ts
@@ -11,10 +11,12 @@ import {
 import type { StreamSnapshotStore } from '@transcript';
 
 /**
- * The store surface a host needs to preload and read the accumulated
- * round-artifact/usage projection. The CLI and the shared progress-view
- * controllers project the same fields, so the reader shape lives here rather
- * than on any one host.
+ * The store surface needed to preload and read the accumulated
+ * round-artifact/usage projection. No host-neutral module imports this: the
+ * progress-view renderer reads the store directly
+ * (`state.snapshots.getOutputFiles`/`getRunUsage`), and the progress-view
+ * controllers reach `getOutputFiles`/`preload` through their own narrower
+ * `StreamOutputsSource` port. So this is CLI presentation, not shared state.
  */
 export type StreamArtifactReader = Pick<
   StreamSnapshotStore,
@@ -40,6 +42,12 @@ export interface StreamArtifactProjection {
  * Read the artifact/usage fields the TUI renderers present. The store has
  * already ordered the disk seed against live facts, so this is a pure
  * projection — no host-side merge.
+ *
+ * Five of the six fields are now straight reads of the store's live readonly
+ * views (#11402), so they cost nothing. `cumulativeUsage` is the one that does
+ * real work — a map spread plus `sumUsageStats` — which is why callers go
+ * through `readStreamArtifacts`'s per-revision memo rather than calling this on
+ * every repaint.
  */
 export function projectStreamArtifacts(
   store: StreamArtifactReader,

--- a/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
@@ -13,11 +13,6 @@
 import { signal } from '@lit-labs/signals';
 
 import { tryDefaultSession } from '@agent/runtime';
-import {
-  projectStreamArtifacts,
-  type StreamArtifactProjection,
-  type StreamArtifactReader,
-} from '@controllers/session/StreamArtifactProjection';
 import { type StreamTabId, type TokenUsageStats } from '@shared/schemas';
 import { subscribeToSignalChanges } from '@shared/signals';
 import {
@@ -25,6 +20,11 @@ import {
   type StreamArtifactAuthority,
 } from '@transcript';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import {
+  projectStreamArtifacts,
+  type StreamArtifactProjection,
+  type StreamArtifactReader,
+} from './streamArtifactProjection';
 
 import {
   activeStreamId,

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -51,8 +51,8 @@ import type { CliContext } from '@cli/runtime/cliContext';
 import * as modelAccessSelection from '@cli/runtime/modelAccessSelection';
 import * as supabaseAuth from '@cli/runtime/supabaseAuth';
 import { TuiSession } from '@cli/chat/tui/state/sessionRunState';
+import type { StreamArtifactReader } from '@cli/chat/tui/state/streamArtifactProjection';
 import { SessionState } from '@controllers/session/SessionState';
-import type { StreamArtifactReader } from '@controllers/session/StreamArtifactProjection';
 import * as codexPreference from '@model/codex/codexPreference';
 import type { TexraApprovalPolicy } from '@shared/approvalPolicy';
 import {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -92,7 +92,7 @@ import {
   moveLocalTranscriptToStream,
   resolveLocalTranscriptStreamId,
 } from '@cli/chat/tui/state/transcript';
-import { projectStreamArtifacts } from '@controllers/session/StreamArtifactProjection';
+import { projectStreamArtifacts } from '@cli/chat/tui/state/streamArtifactProjection';
 import { SessionState } from '@controllers/session/SessionState';
 import { stripOrchestratorFollowup } from '@shared/subagentFollowup';
 import {


### PR DESCRIPTION
Closes #11388. Redoes #11396, which I closed on a premise that turned out to be false.

## The premise that was wrong

I closed #11396 arguing that #11400/#11402 would collapse this projection outright, making the move churn. **#11402 has landed and it does not collapse it.**

Five of the six fields did become free — they are now straight reads of live readonly views. But `cumulativeUsage` still does real work: `[...store.getRunUsage(id).values()]` plus `sumUsageStats` (a loop over every run's usage, `usage.ts:76-100`). And `readStreamArtifacts` is called **inside render bodies** — `ConversationPane.tsx:225` and `ConversationRegion.tsx:146` — which Ink re-runs on every repaint, i.e. per streaming token, while `streamArtifactRevision` only bumps on artifact writes.

So the per-revision memo still earns its keep, and `StreamArtifactProjection` is its value shape. My claim in #11400 that "the memo loses its reason to exist" was wrong.

## What that leaves — the original finding, still true and now unaddressed

Because I closed #11396, its docstring fix never landed. At merged `main` the module still says:

> The CLI **and the shared progress-view controllers** project the same fields, so the reader shape lives here rather than on any one host.

Every consumer is the CLI:

- `packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts` (the only `projectStreamArtifacts` call site)
- `packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts:33`
- `packages/cli/src/chat/tui/commands/registerBuiltins.tsx:10`
- tests: `src/test-kernel/cli/SlashCommandDispatch.vitest.ts`, `TuiStateAndFocus.vitest.ts` — both under `test-kernel/cli/`

`LitSessionRenderer` reads `StreamSnapshotStore` directly and never imports this module, so the "shared progress-view controllers" half of the claim has no referent.

## What this PR does

Moves the module beside `subscribeStreamArtifacts`, its only call site, and rewrites the docstring to what is true — scoped to **imports**, because the progress-view controllers genuinely do reach two of the same accessors (`getOutputFiles`, `preload`) through their own narrower `StreamOutputsSource` port. Overclaiming there is how the previous docstring rotted.

Also adds a note on `projectStreamArtifacts` recording *why* the memo still exists after #11402, so the next reader does not repeat my mistake and delete it.

## Single source of truth

Unchanged. `sumUsageStats` (`@shared/schemas`) remains the one summing rule; only the projection's location moves.

## Duplication and abstraction budget

No new module, type, or wrapper. One file relocated, five import specifiers repointed, one false docstring corrected, one rationale recorded.

## Net elements (R6)

6 files changed, 21 insertions / 13 deletions. Net LoC **+8**, all doc comment. Elements: **−3 exports out of `src/controllers/session/`** (`StreamArtifactReader`, `StreamArtifactProjection`, `projectStreamArtifacts`), the same three added under `packages/cli`. No class/interface/enum created or deleted.

Honest about direction: this is a **layering and accuracy fix, not a LoC win**. The gain is that the host-agnostic layer stops carrying a single-host projection behind a docstring that misdescribes it.

## Consumer counts (R8)

- `projectStreamArtifacts`: production call sites **1 → 1**, CLI before and after.
- `StreamArtifactReader`: production consumers **3 → 3**, all under `packages/cli/src/chat/tui/`.
- Extension/desktop consumers: **0 → 0**.

## Ratchets

- `npx vitest run src/test-kernel/architecture` — pass. No `architecture-edges-baseline.json` or `host-agent-import-baseline.json` change needed: the moved file imports `@shared/schemas` and `@transcript`, neither an `@agent/*` deep import, and the CLI already reaches both.
- `npm run check:dead-code-ratchet` — 411 vs 411, unchanged.

## Host impact

CLI: three import specifiers repointed, one now relative since it sits in the same directory. Extension and desktop: none.

## Validation

- `npm run typecheck` (all 6 sub-projects) — pass
- `npx eslint <changed files>` — clean
- `npx vitest run src/test-kernel/cli src/test-kernel/architecture src/test-kernel/controllers` — 189 files, 2967 passed, 1 skipped
- `npm run check:dead-code-ratchet` — pass
- `npx prettier --check <changed files>` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)