### PR TITLE
fix(settings): source the active team from the roster

### DIFF
--- a/packages/desktop/src/main/desktopAgentSettingsController.ts
+++ b/packages/desktop/src/main/desktopAgentSettingsController.ts
@@ -231,6 +231,10 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
   }
 
   async refreshCatalogData(): Promise<void> {
+    // Presets ride along because every roster mutation can move the effective
+    // team: enabling one agent rewrites the selection as `custom`, which
+    // retires whatever team was applied.
+    this.postAgentModePresets();
     await Promise.all([
       this.postAgentSelectionData(),
       this.postMainAgentAndTeamOptionsData(),

--- a/packages/desktop/src/main/desktopAgentSettingsController.ts
+++ b/packages/desktop/src/main/desktopAgentSettingsController.ts
@@ -295,6 +295,7 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
         getCustomPresets: () => this.catalogController.getCustomPresets(),
         getOrchestratorAgentNames: () =>
           this.catalogController.getOrchestratorAgentNames(),
+        getActiveTeamId: () => this.roster.getActiveTeamId(),
       }),
     );
   }
@@ -457,6 +458,7 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
         showErrorMessage: this.notifications.showErrorMessage,
       },
       refreshAfterApply: async (selectedToolUseAgent) => {
+        this.postAgentModePresets();
         await Promise.all([
           this.postAgentSelectionData(),
           this.postMainAgentAndTeamOptionsData(selectedToolUseAgent),

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -361,6 +361,11 @@ export function createDesktopSettingsIpc(
     appSignals.on('githubSubscriptionsChanged', () =>
       runAsync(postGitHubSubscriptions()),
     ),
+    // `apply_team` writes the roster straight from the setup agent, so the
+    // open view is showing agents and a team it just replaced.
+    appSignals.on('agentRosterChanged', () =>
+      runAsync(options.agentSettingsController.refreshCatalogData()),
+    ),
     // Outside VS Code a rejected token left the pollers failing in silence.
     // The dialog is the whole fix: `resolveGitHubTokenSource` reports only
     // which store holds a token, and rejection leaves the secret in place, so

--- a/packages/extension/src/frontend/agents/register.ts
+++ b/packages/extension/src/frontend/agents/register.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { createWorkspaceAgentRosterController } from '@agent/index';
+import { appSignals } from '@eventBus/AppSignals';
 import { createLog } from '@logger/logUtils';
 import type { AgentSource } from '@shared/schemas';
 
@@ -37,6 +38,9 @@ export async function promptToAddAgentToConfig(
       name: agentName,
       enabled: true,
     });
+    // This rewrites the selection as `custom`, retiring any applied team, so
+    // an open settings view needs the same notice `apply_team` sends.
+    appSignals.emit('agentRosterChanged', undefined);
     await vscode.commands.executeCommand('texra.refreshAllOptions');
     vscode.window.showInformationMessage(`Agent "${agentName}" is now visible`);
   }

--- a/packages/extension/src/frontend/agents/register.ts
+++ b/packages/extension/src/frontend/agents/register.ts
@@ -38,10 +38,13 @@ export async function promptToAddAgentToConfig(
       name: agentName,
       enabled: true,
     });
-    // This rewrites the selection as `custom`, retiring any applied team, so
-    // an open settings view needs the same notice `apply_team` sends.
-    appSignals.emit('agentRosterChanged', undefined);
+    // Reload the catalog first: the agent-creator just wrote this YAML, so
+    // the registry still holds a cache without it and a listener that posted
+    // now would render a roster missing the agent it was told about.
     await vscode.commands.executeCommand('texra.refreshAllOptions');
+    // The write above rewrites the selection as `custom`, retiring any applied
+    // team, so an open settings view needs the same notice `apply_team` sends.
+    appSignals.emit('agentRosterChanged', undefined);
     vscode.window.showInformationMessage(`Agent "${agentName}" is now visible`);
   }
 }

--- a/packages/extension/src/frontend/agents/register.ts
+++ b/packages/extension/src/frontend/agents/register.ts
@@ -4,7 +4,7 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import { createWorkspaceAgentRosterController } from '@agent/index';
+import { createWorkspaceAgentRosterController, refresh } from '@agent/index';
 import { appSignals } from '@eventBus/AppSignals';
 import { createLog } from '@logger/logUtils';
 import type { AgentSource } from '@shared/schemas';
@@ -38,13 +38,18 @@ export async function promptToAddAgentToConfig(
       name: agentName,
       enabled: true,
     });
-    // Reload the catalog first: the agent-creator just wrote this YAML, so
-    // the registry still holds a cache without it and a listener that posted
-    // now would render a roster missing the agent it was told about.
-    await vscode.commands.executeCommand('texra.refreshAllOptions');
+    // Reload the catalog here rather than leaning on `refreshAllOptions`:
+    // that command returns early when the main webview is closed, so the
+    // reload it performs is conditional on an unrelated view being open. The
+    // agent-creator just wrote this YAML, so a listener posting against the
+    // stale cache would render a roster missing the agent it was told about.
+    await refresh();
     // The write above rewrites the selection as `custom`, retiring any applied
     // team, so an open settings view needs the same notice `apply_team` sends.
     appSignals.emit('agentRosterChanged', undefined);
+    await vscode.commands.executeCommand('texra.refreshAllOptions', {
+      agentCatalogAlreadyFresh: true,
+    });
     vscode.window.showInformationMessage(`Agent "${agentName}" is now visible`);
   }
 }

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -220,9 +220,13 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       },
       {
         // `apply_team` writes the roster straight from the setup agent, so
-        // the open view is showing agents and a team it just replaced.
+        // the open view is showing agents and a team it just replaced. The
+        // catalog is already fresh: a team change moves no agent files, and
+        // the agent-creator reloads before it emits. Without that flag this
+        // listener would rescan the YAML and re-fetch the remote catalog on
+        // every roster write.
         dispose: appSignals.on('agentRosterChanged', () => {
-          void this.refreshAfterAgentMutation();
+          void this.refreshAfterAgentMutation(undefined, true);
         }),
       },
       {

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -219,6 +219,13 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         }),
       },
       {
+        // `apply_team` writes the roster straight from the setup agent, so
+        // the open view is showing agents and a team it just replaced.
+        dispose: appSignals.on('agentRosterChanged', () => {
+          void this.refreshAfterAgentMutation();
+        }),
+      },
+      {
         dispose: appSignals.on('languageModelsChanged', () => {
           void this.withActiveWebview((webview) =>
             this.sendModelSelectionData(webview),

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -719,7 +719,12 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     ]);
   }
 
-  /** Refresh settings-view agent list and main-view dropdown after agent mutations. */
+  /**
+   * Refresh settings-view agent list and main-view dropdown after agent
+   * mutations. The team presets ride along because every roster mutation can
+   * move the effective team: enabling one agent rewrites the selection as
+   * `custom`, which retires whatever team was applied.
+   */
   private async refreshAfterAgentMutation(
     selectedToolUseAgent?: string,
     agentCatalogAlreadyFresh = false,
@@ -728,6 +733,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       this.withActiveWebview((w) =>
         this.agentHandlers.sendAgentSelectionData(w),
       ),
+      this.withActiveWebview((w) => this.agentHandlers.sendAgentModePresets(w)),
       safeExecuteCommand(
         'texra.refreshAllOptions',
         selectedToolUseAgent || agentCatalogAlreadyFresh

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -55,6 +55,7 @@ import './components/profile/ProviderKeyModal';
 // Local imports - module-scope settings state + composed message handlers
 import { settingsViewHandlers } from './messageDispatcher';
 import {
+  activePresetId,
   agentSubTab,
   agentSkillsEnabled,
   allowOrchestratorKill,
@@ -405,6 +406,7 @@ export class SettingsApp extends SettingsAppBase {
         const ackGeneration = multiAgentSettingsRevision.get();
         return html`
           <multi-agent-tab
+            .activePresetId=${activePresetId.get()}
             .customPresets=${customPresets.get()}
             .orchestratorAgents=${orchestratorAgents.get()}
             .allowOrchestratorKill=${allowOrchestratorKill.get()}

--- a/packages/extension/src/settingsView/frontend/settingsState.ts
+++ b/packages/extension/src/settingsView/frontend/settingsState.ts
@@ -196,6 +196,8 @@ export const agentSubTab = trackedSignal<AgentCategory | undefined>(
 // ---------------------------------------------------------------------------
 export const customPresets = trackedSignal<AgentModePreset[]>(() => []);
 export const orchestratorAgents = trackedSignal<string[]>(() => []);
+/** Team the workspace roster resolves to; null when the roster runs no team. */
+export const activePresetId = trackedSignal<string | null>(() => null);
 
 // ---------------------------------------------------------------------------
 // Multi-agent coordination state

--- a/packages/extension/src/settingsView/frontend/slices/miscSettingsSlice.ts
+++ b/packages/extension/src/settingsView/frontend/slices/miscSettingsSlice.ts
@@ -9,6 +9,7 @@ import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { SettingsViewOutboundHandlerRegistry } from '@shared/schemas';
 
 import {
+  activePresetId,
   applySettingsSnapshot,
   customPresets,
   goalItems,
@@ -40,6 +41,7 @@ export const agentTeamsHandlers = {
   [SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS]: (data) => {
     customPresets.set(data.customPresets);
     orchestratorAgents.set(data.orchestratorAgents);
+    activePresetId.set(data.activePresetId);
   },
 } satisfies Partial<SettingsViewOutboundHandlerRegistry>;
 

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -2,7 +2,7 @@
 
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
 // Local imports - shared styles
@@ -197,10 +197,14 @@ export class MultiAgentTab extends LitElement {
   @property({ attribute: false }) customPresets: AgentModePreset[] = [];
   /** Agent names that carry delegation tools, computed backend-side from the registry. */
   @property({ attribute: false }) orchestratorAgents: string[] = [];
-  @state() private activePresetId: string | null = null;
+  /**
+   * The applied team, from the backend roster. Deliberately not local state:
+   * an apply can be cancelled or blocked by unavailable members, and an
+   * optimistic flip would badge a team the roster never adopted.
+   */
+  @property({ attribute: false }) activePresetId: string | null = null;
 
   private handlePresetClick(preset: AgentModePreset): void {
-    this.activePresetId = preset.id;
     postMessage(SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET, {
       presetId: preset.id,
     });

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -290,6 +290,7 @@ export class AgentHandlers {
         getCustomPresets: () => this.catalogController.getCustomPresets(),
         getOrchestratorAgentNames: () =>
           this.catalogController.getOrchestratorAgentNames(),
+        getActiveTeamId: () => this.roster.getActiveTeamId(),
       }),
     );
   }
@@ -331,8 +332,12 @@ export class AgentHandlers {
                 return Promise.resolve();
               },
             },
-            refreshAfterApply: (selectedToolUseAgent) =>
-              this.refreshAfterAgentMutation(selectedToolUseAgent, true),
+            refreshAfterApply: async (selectedToolUseAgent) => {
+              await Promise.all([
+                this.refreshAfterAgentMutation(selectedToolUseAgent, true),
+                this.ctx.withActiveWebview((w) => this.sendAgentModePresets(w)),
+              ]);
+            },
           }),
         );
       },

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -332,12 +332,8 @@ export class AgentHandlers {
                 return Promise.resolve();
               },
             },
-            refreshAfterApply: async (selectedToolUseAgent) => {
-              await Promise.all([
-                this.refreshAfterAgentMutation(selectedToolUseAgent, true),
-                this.ctx.withActiveWebview((w) => this.sendAgentModePresets(w)),
-              ]);
-            },
+            refreshAfterApply: (selectedToolUseAgent) =>
+              this.refreshAfterAgentMutation(selectedToolUseAgent, true),
           }),
         );
       },
@@ -362,10 +358,7 @@ export class AgentHandlers {
 
         await this.catalogController.saveCurrentPreset(name);
 
-        await Promise.all([
-          this.ctx.withActiveWebview((w) => this.sendAgentModePresets(w)),
-          this.refreshAfterAgentMutation(undefined, true),
-        ]);
+        await this.refreshAfterAgentMutation(undefined, true);
 
         void vscode.window.showInformationMessage(
           `Saved team "${name.trim()}"`,
@@ -392,10 +385,7 @@ export class AgentHandlers {
 
         await this.catalogController.deleteCustomPreset(data.presetId);
 
-        await Promise.all([
-          this.ctx.withActiveWebview((w) => this.sendAgentModePresets(w)),
-          this.refreshAfterAgentMutation(undefined, true),
-        ]);
+        await this.refreshAfterAgentMutation(undefined, true);
       },
     );
   }

--- a/src/agent/roster/AgentRosterController.ts
+++ b/src/agent/roster/AgentRosterController.ts
@@ -41,7 +41,13 @@ export interface AgentRosterControllerDeps<
   readonly globalState: StateStore;
   readonly getAgents: (category: AgentCategory) => Entry[];
   readonly getPresets?: () => readonly AgentModePreset[];
-  /** Resolve one stored identifier without collapsing exact source identity. */
+  /**
+   * Resolve one stored identifier without collapsing exact source identity.
+   * The controller applies no fallback around this, so an implementation owns
+   * the whole contract: match a bare name against the category's agents, match
+   * a source-qualified key exactly, and return nothing for an entry outside
+   * `category`. `getRosterAgent` is the production implementation.
+   */
   readonly resolveAgent: (
     category: AgentCategory,
     identifier: string,

--- a/src/agent/roster/AgentRosterController.ts
+++ b/src/agent/roster/AgentRosterController.ts
@@ -25,6 +25,7 @@ import {
 } from '@shared/state/onboardingState';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { KeyedMutex, unique } from '@utils/core';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 export interface AgentRosterEntry {
   readonly name: string;
@@ -42,7 +43,7 @@ export interface AgentRosterControllerDeps<
   readonly getAgents: (category: AgentCategory) => Entry[];
   readonly getPresets?: () => readonly AgentModePreset[];
   /** Resolve one stored identifier without collapsing exact source identity. */
-  readonly resolveAgent?: (
+  readonly resolveAgent: (
     category: AgentCategory,
     identifier: string,
   ) => Entry | undefined;
@@ -82,8 +83,11 @@ function allPresets(
  * Read the canonical workspace selection. A value that does not parse is
  * tried against the legacy pair-shaped format (`{workflowAgentKeys,
  * toolUseAgentKeys}`, with or without a stray `kind` field) via the existing
- * AgentDelegationScopeLegacySchema. On a match the stored value is
- * immediately repaired so the warning is a one-time event per workspace.
+ * AgentDelegationScopeLegacySchema. On a match the stored value is repaired in
+ * place so the legacy shape is normalized once per workspace. That repair is
+ * the one write this module issues outside an awaited mutation, so it goes
+ * through the same write mutex: an unserialized update here can interleave
+ * with a mutation already in flight and leave the roster half-written.
  */
 function readAgentRosterSelection(
   workspaceState: StateStore,
@@ -96,10 +100,18 @@ function readAgentRosterSelection(
   if (parsed.success) return parsed.data;
   const repaired = repairLegacySelection(raw);
   if (repaired) {
-    void workspaceState.update(
-      WorkspaceStateKey.AGENT_ROSTER_SELECTION,
-      repaired,
-    );
+    void serializeWorkspaceWrite(workspaceState, async () => {
+      await workspaceState.update(
+        WorkspaceStateKey.AGENT_ROSTER_SELECTION,
+        repaired,
+      );
+    }).catch((error: unknown) => {
+      console.warn(
+        `[agentRoster] Could not normalize the legacy roster selection; it ` +
+          `still reads correctly and the repair retries on the next read: ` +
+          toErrorMessage(error),
+      );
+    });
     return repaired;
   }
   console.warn(
@@ -178,6 +190,12 @@ export class AgentRosterController<
     return this.resolveEffectiveSelection(selection);
   }
 
+  /** The team this workspace effectively runs, or null when it runs no team. */
+  getActiveTeamId(): string | null {
+    const effective = this.getEffectiveSelection();
+    return effective.kind === 'team' ? effective.teamId : null;
+  }
+
   getVisibleAgents(category: AgentCategory): Entry[] {
     const effective = this.getEffectiveSelection();
     const identifiers = selectedIdentifiers(
@@ -188,7 +206,7 @@ export class AgentRosterController<
     if (identifiers === undefined) return this.deps.getAgents(category);
 
     const resolved = identifiers
-      .map((identifier) => this.resolveEntry(category, identifier))
+      .map((identifier) => this.deps.resolveAgent(category, identifier))
       .filter((entry): entry is Entry => entry !== undefined);
     return [
       ...new Map(resolved.map((entry) => [agentKeyOf(entry), entry])).values(),
@@ -212,7 +230,7 @@ export class AgentRosterController<
       );
       if (identifiers === undefined) return [];
       return identifiers
-        .filter((identifier) => !this.resolveEntry(category, identifier))
+        .filter((identifier) => !this.deps.resolveAgent(category, identifier))
         .map(agentName);
     });
     return {
@@ -239,23 +257,10 @@ export class AgentRosterController<
     return unique(
       identifiers.map((identifier) => {
         if (selection.kind === 'custom') return identifier;
-        const entry = this.resolveEntry(category, identifier);
+        const entry = this.deps.resolveAgent(category, identifier);
         return entry ? agentKeyOf(entry) : identifier;
       }),
     );
-  }
-
-  private resolveEntry(
-    category: AgentCategory,
-    identifier: string,
-  ): Entry | undefined {
-    const resolved = this.deps.resolveAgent?.(category, identifier);
-    if (resolved) {
-      return resolved.category === category ? resolved : undefined;
-    }
-    return this.deps
-      .getAgents(category)
-      .find((entry) => agentMatchesIdentifier(entry, identifier));
   }
 
   /** Team identity a selection resolves to, following inherit to the default. */
@@ -315,7 +320,7 @@ export class AgentRosterController<
     );
   }
 
-  async setSelection(selection: AgentRosterSelection): Promise<void> {
+  private async setSelection(selection: AgentRosterSelection): Promise<void> {
     await serializeWorkspaceWrite(this.deps.workspaceState, () =>
       this.writeSelection(selection),
     );
@@ -425,9 +430,6 @@ export class AgentRosterController<
       );
     }
     await setDefaultTeamId(this.deps.globalState, teamId);
-    if (this.getSelection().kind === 'inherit') {
-      await this.setSelection(INHERITED_AGENT_ROSTER);
-    }
   }
 
   async clearDefaultTeam(): Promise<void> {
@@ -435,8 +437,5 @@ export class AgentRosterController<
       GlobalStateKey.ONBOARDING_DEFAULT_TEAM_ID,
       undefined,
     );
-    if (this.getSelection().kind === 'inherit') {
-      await this.setSelection(INHERITED_AGENT_ROSTER);
-    }
   }
 }

--- a/src/agent/roster/AgentRosterController.ts
+++ b/src/agent/roster/AgentRosterController.ts
@@ -83,7 +83,8 @@ function allPresets(
  * tried against the legacy pair-shaped format (`{workflowAgentKeys,
  * toolUseAgentKeys}`, with or without a stray `kind` field) via the existing
  * AgentDelegationScopeLegacySchema. The reader is deliberately pure. It used to
- * repair the stored value in place, but every mutation below reads the
+ * repair the stored value in place, but the read-modify-write mutations
+ * (`setEnabledAgentKeys`, `setAgentEnabled`, `removeTeamPreset`) read the
  * selection while already holding the write mutex, so a repair issued from
  * here either races that mutation or, if serialized behind it, overwrites the
  * selection the mutation just committed. The mutations own every durable

--- a/src/agent/roster/AgentRosterController.ts
+++ b/src/agent/roster/AgentRosterController.ts
@@ -25,7 +25,6 @@ import {
 } from '@shared/state/onboardingState';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { KeyedMutex, unique } from '@utils/core';
-import { toErrorMessage } from '@utils/errors/errorMessage';
 
 export interface AgentRosterEntry {
   readonly name: string;
@@ -83,11 +82,12 @@ function allPresets(
  * Read the canonical workspace selection. A value that does not parse is
  * tried against the legacy pair-shaped format (`{workflowAgentKeys,
  * toolUseAgentKeys}`, with or without a stray `kind` field) via the existing
- * AgentDelegationScopeLegacySchema. On a match the stored value is repaired in
- * place so the legacy shape is normalized once per workspace. That repair is
- * the one write this module issues outside an awaited mutation, so it goes
- * through the same write mutex: an unserialized update here can interleave
- * with a mutation already in flight and leave the roster half-written.
+ * AgentDelegationScopeLegacySchema. The reader is deliberately pure. It used to
+ * repair the stored value in place, but every mutation below reads the
+ * selection while already holding the write mutex, so a repair issued from
+ * here either races that mutation or, if serialized behind it, overwrites the
+ * selection the mutation just committed. The mutations own every durable
+ * write; a legacy value normalizes the next time one of them runs.
  */
 function readAgentRosterSelection(
   workspaceState: StateStore,
@@ -98,22 +98,8 @@ function readAgentRosterSelection(
   if (raw === undefined) return INHERITED_AGENT_ROSTER;
   const parsed = AgentRosterSelectionSchema.safeParse(raw);
   if (parsed.success) return parsed.data;
-  const repaired = repairLegacySelection(raw);
-  if (repaired) {
-    void serializeWorkspaceWrite(workspaceState, async () => {
-      await workspaceState.update(
-        WorkspaceStateKey.AGENT_ROSTER_SELECTION,
-        repaired,
-      );
-    }).catch((error: unknown) => {
-      console.warn(
-        `[agentRoster] Could not normalize the legacy roster selection; it ` +
-          `still reads correctly and the repair retries on the next read: ` +
-          toErrorMessage(error),
-      );
-    });
-    return repaired;
-  }
+  const legacy = parseLegacySelection(raw);
+  if (legacy) return legacy;
   console.warn(
     `[agentRoster] Ignoring malformed roster selection; falling back to ` +
       `the inherited roster: ${parsed.error.message}`,
@@ -121,13 +107,13 @@ function readAgentRosterSelection(
   return INHERITED_AGENT_ROSTER;
 }
 
-function repairLegacySelection(raw: unknown): AgentRosterSelection | undefined {
+function parseLegacySelection(raw: unknown): AgentRosterSelection | undefined {
   // The legacy pair-shaped value may carry a stray `kind` field: an
   // intermediate version wrote `{kind: 'custom', workflowAgentKeys,
   // toolUseAgentKeys}` under AGENT_ROSTER_SELECTION, which neither the
   // canonical schema (missing `agentKeys`) nor the strict legacy schema
   // (rejects `kind`) accepts. Drop the discriminant before parsing so both
-  // the pure and hybrid legacy shapes repair to the same canonical value.
+  // the pure and hybrid legacy shapes normalize to the same canonical value.
   let candidate: unknown = raw;
   if (raw !== null && typeof raw === 'object' && 'kind' in raw) {
     const { kind: _ignored, ...rest } = raw as Record<string, unknown>;

--- a/src/common/teams/TeamRoster.ts
+++ b/src/common/teams/TeamRoster.ts
@@ -21,9 +21,10 @@ export interface TeamRosterResolution {
   readonly keys: ByCategory<string[]>;
   /**
    * Roster member names that did not resolve to a catalog entry at resolve
-   * time, per category. These persist alongside `keys` as name-matched slots,
-   * so an agent activates the moment it appears in the catalog (sign-in,
-   * install) — never silently dropped.
+   * time, per category. Nothing persists these: the roster stores the team
+   * reference and re-resolves `preset.agents` on read, so a member activates
+   * the moment it appears in the catalog (sign-in, install) without a stored
+   * slot. They exist to feed `unresolvedNames` for the availability preflight.
    */
   readonly nameSlots: ByCategory<string[]>;
   /** Unresolved member names across all categories, in canonical order. */

--- a/src/common/teams/TeamRoster.ts
+++ b/src/common/teams/TeamRoster.ts
@@ -9,12 +9,8 @@ import {
   type ByCategory,
 } from '@shared/schemas';
 
-interface TeamRosterState {
+interface TeamRosterAgentCatalog {
   getAgents(category: AgentCategory): { name: string; source: AgentSource }[];
-  setEnabledAgentKeys(
-    category: AgentCategory,
-    enabledKeys: string[],
-  ): Promise<void>;
 }
 
 export interface TeamRosterResolution {
@@ -45,15 +41,18 @@ export type TeamRosterPresetResolution =
 
 export interface TeamRosterCatalog {
   resolvePreset(presetId: string): TeamRosterPresetResolution;
-  commitPresetResolution(
-    preset: AgentModePreset,
-    resolution: TeamRosterResolution,
-  ): Promise<void>;
+  /**
+   * Persist the symbolic preset. The resolution {@link resolvePreset} computed
+   * is preflight evidence only: the roster stores the team reference and
+   * re-resolves it against the catalog on read, so no committer freezes the
+   * per-agent-key snapshot.
+   */
+  commitPreset(preset: AgentModePreset): Promise<void>;
 }
 
 /** Resolve a team against the current catalog without writing roster state. */
 export function resolveTeamRoster(
-  state: Pick<TeamRosterState, 'getAgents'>,
+  state: TeamRosterAgentCatalog,
   preset: AgentModePreset,
 ): TeamRosterResolution {
   const resolved = byCategory((category) =>
@@ -66,21 +65,6 @@ export function resolveTeamRoster(
       (category) => resolved[category].nameSlots,
     ),
   };
-}
-
-/** Commit a previously resolved roster. */
-export async function commitTeamRoster(
-  state: Pick<TeamRosterState, 'setEnabledAgentKeys'>,
-  resolution: TeamRosterResolution,
-): Promise<void> {
-  for (const category of AGENT_CATEGORIES) {
-    // Resolved keys and unresolved name slots persist side by side so a
-    // name-matched member activates the moment it appears in the catalog.
-    await state.setEnabledAgentKeys(category, [
-      ...resolution.keys[category],
-      ...resolution.nameSlots[category],
-    ]);
-  }
 }
 
 /**
@@ -96,7 +80,7 @@ export function teamHostedNamesForPreflight(
 }
 
 function resolveAgentKeys(
-  state: Pick<TeamRosterState, 'getAgents'>,
+  state: TeamRosterAgentCatalog,
   category: AgentCategory,
   names: string[],
 ): { keys: string[]; nameSlots: string[] } {

--- a/src/common/teams/TeamRosterApplication.ts
+++ b/src/common/teams/TeamRosterApplication.ts
@@ -94,10 +94,7 @@ export async function applyTeamRosterWithPreflight(
     };
   }
 
-  await deps.catalog.commitPresetResolution(
-    preflight.value.preset,
-    preflight.value.resolution,
-  );
+  await deps.catalog.commitPreset(preflight.value.preset);
   return {
     status: 'applied',
     preset: preflight.value.preset,

--- a/src/controllers/settingsView/SettingsAgentCatalogController.ts
+++ b/src/controllers/settingsView/SettingsAgentCatalogController.ts
@@ -6,11 +6,9 @@ import {
   type TeamPreset,
 } from '@common/teams/TeamPlan';
 import {
-  commitTeamRoster,
   resolveTeamRoster,
   type TeamRosterCatalog,
   type TeamRosterPresetResolution,
-  type TeamRosterResolution,
 } from '@common/teams/TeamRoster';
 import {
   AGENT_CATEGORIES,
@@ -45,7 +43,7 @@ export interface SettingsAgentCatalogState {
     category: AgentCategory,
     enabledKeys: string[],
   ): Promise<void>;
-  setTeamRoster?(preset: AgentModePreset): Promise<void>;
+  setTeamRoster(preset: AgentModePreset): Promise<void>;
   getAgents(category: AgentCategory): SettingsAgentCatalogEntry[];
   getVisibleAgents(category: AgentCategory): SettingsAgentCatalogEntry[];
   getCustomPresetsRaw(): unknown;
@@ -149,15 +147,8 @@ export class SettingsAgentCatalogController implements TeamRosterCatalog {
     };
   }
 
-  async commitPresetResolution(
-    preset: AgentModePreset,
-    resolution: TeamRosterResolution,
-  ): Promise<void> {
-    if (this.deps.state.setTeamRoster) {
-      await this.deps.state.setTeamRoster(preset);
-      return;
-    }
-    await commitTeamRoster(this.deps.state, resolution);
+  async commitPreset(preset: AgentModePreset): Promise<void> {
+    await this.deps.state.setTeamRoster(preset);
   }
 
   async saveCurrentPreset(name: string): Promise<AgentModePreset> {

--- a/src/eventBus/AppSignals.ts
+++ b/src/eventBus/AppSignals.ts
@@ -49,6 +49,21 @@ export interface AppSignalPayloads {
   toolAvailabilityChanged: undefined;
 
   /**
+   * The workspace agent roster changed outside a settings round-trip. Keyless
+   * on purpose: every listener re-reads the roster, so which team or agent
+   * moved carries no information.
+   *
+   * Emitted by `apply_team`, which the setup agent runs mid-conversation and
+   * which writes the roster and the user default directly. Settings-originated
+   * changes repaint through their own handler and do not emit.
+   *
+   * Consumed by: extension and desktop settings views, both re-reading the
+   * agent list and team presets. Not the CLI: it reads the roster per command
+   * and has no persistent panel that could go stale.
+   */
+  agentRosterChanged: undefined;
+
+  /**
    * The editor's language-model catalogue or access permissions changed.
    *
    * Extension-only by construction: the sole emitter is VS Code's

--- a/src/eventBus/AppSignals.ts
+++ b/src/eventBus/AppSignals.ts
@@ -53,9 +53,11 @@ export interface AppSignalPayloads {
    * on purpose: every listener re-reads the roster, so which team or agent
    * moved carries no information.
    *
-   * Emitted by `apply_team`, which the setup agent runs mid-conversation and
-   * which writes the roster and the user default directly. Settings-originated
-   * changes repaint through their own handler and do not emit.
+   * Emitted by the in-process roster writers that bypass the settings
+   * round-trip: `apply_team`, which the setup agent runs mid-conversation,
+   * and the agent-creator prompt that adds a new agent to the dropdown.
+   * Settings-originated changes repaint through their own handler and do not
+   * emit.
    *
    * Consumed by: extension and desktop settings views, both re-reading the
    * agent list and team presets. Not the CLI: it reads the roster per command

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -396,7 +396,7 @@ const UpdateAgentModePresetsMessageSchema = z.object({
    * no team. Owned by the roster so a preset card reports the applied team
    * rather than the last one the user clicked.
    */
-  activePresetId: z.string().nullable(),
+  activePresetId: z.string().nullable().prefault(null),
 });
 export type UpdateAgentModePresetsMessage = z.infer<
   typeof UpdateAgentModePresetsMessageSchema

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -391,6 +391,12 @@ const UpdateAgentModePresetsMessageSchema = z.object({
    * instead of guessing from the agent's name.
    */
   orchestratorAgents: z.array(z.string()).prefault([]),
+  /**
+   * The team the workspace roster currently resolves to, or null when it runs
+   * no team. Owned by the roster so a preset card reports the applied team
+   * rather than the last one the user clicked.
+   */
+  activePresetId: z.string().nullable(),
 });
 export type UpdateAgentModePresetsMessage = z.infer<
   typeof UpdateAgentModePresetsMessageSchema

--- a/src/shared/settingsView/handlers/agentSelectionHandlers.ts
+++ b/src/shared/settingsView/handlers/agentSelectionHandlers.ts
@@ -53,6 +53,7 @@ export async function buildCustomAgentDirMessage(
 export interface AgentModePresetsPorts {
   getCustomPresets(): AgentModePreset[];
   getOrchestratorAgentNames(): string[];
+  getActiveTeamId(): string | null;
 }
 
 export function buildAgentModePresetsMessage(
@@ -62,5 +63,6 @@ export function buildAgentModePresetsMessage(
     command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
     customPresets: ports.getCustomPresets(),
     orchestratorAgents: ports.getOrchestratorAgentNames(),
+    activePresetId: ports.getActiveTeamId(),
   };
 }

--- a/src/test-kernel/controllers/AgentRosterController.vitest.ts
+++ b/src/test-kernel/controllers/AgentRosterController.vitest.ts
@@ -111,12 +111,14 @@ describe('AgentRosterController', () => {
     });
   });
 
-  it('repairs the hybrid pair-shaped roster that carries a stray kind field in place', async () => {
+  it('normalizes the hybrid pair-shaped roster on read without writing', async () => {
     // An intermediate version wrote `{kind: 'custom', workflowAgentKeys,
     // toolUseAgentKeys}` under AGENT_ROSTER_SELECTION. Neither the canonical
     // schema (missing `agentKeys`) nor the strict legacy schema (rejects
     // `kind`) accepts it, so it must be normalized to the canonical custom
-    // selection without warning.
+    // selection without warning. The read must not persist that
+    // normalization: the mutations read the selection while holding the write
+    // mutex, so a write from here would overwrite what they just committed.
     const warn = stubWarn();
     const hybrid = {
       kind: 'custom',
@@ -136,19 +138,15 @@ describe('AgentRosterController', () => {
       },
     });
     expect(warn).not.toHaveBeenCalled();
-    // The repair runs behind the same write mutex the mutations use, so it
-    // lands a tick after the read rather than during it.
-    await vi.waitFor(() => {
-      expect(
-        workspaceState.get(WorkspaceStateKey.AGENT_ROSTER_SELECTION),
-      ).toEqual({
-        kind: 'custom',
-        agentKeys: {
-          workflow: ['builtInWorkflow:write'],
-          toolUse: ['builtInToolUse:lead'],
-        },
-      });
-    });
+    expect(workspaceState.get(WorkspaceStateKey.AGENT_ROSTER_SELECTION)).toBe(
+      hybrid,
+    );
+
+    // The next mutation is what normalizes the stored value.
+    await roster.setTeam('test-team');
+    expect(
+      workspaceState.get(WorkspaceStateKey.AGENT_ROSTER_SELECTION),
+    ).toEqual({ kind: 'team', teamId: 'test-team' });
   });
 
   it('uses the user default only for inherited workspaces', () => {

--- a/src/test-kernel/controllers/AgentRosterController.vitest.ts
+++ b/src/test-kernel/controllers/AgentRosterController.vitest.ts
@@ -6,7 +6,11 @@ import {
   type AgentRosterEntry,
 } from '@agent/roster/AgentRosterController';
 import type { StateStore } from '@platform/interfaces';
-import type { AgentCategory, AgentModePreset } from '@shared/schemas';
+import {
+  agentMatchesIdentifier,
+  type AgentCategory,
+  type AgentModePreset,
+} from '@shared/schemas';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { FakeStateStore } from '@test/support/FakePlatform';
 
@@ -36,11 +40,17 @@ function controller(
   workspaceState: StateStore,
   overrides: Partial<AgentRosterControllerDeps> = {},
 ): AgentRosterController {
+  const getAgents =
+    overrides.getAgents ?? ((category: AgentCategory) => agents[category]);
   return new AgentRosterController({
     workspaceState,
     globalState: new FakeStateStore(),
-    getAgents: (category) => agents[category],
+    getAgents,
     getPresets: () => [preset],
+    resolveAgent: (category, identifier) =>
+      getAgents(category).find((entry) =>
+        agentMatchesIdentifier(entry, identifier),
+      ),
     ...overrides,
   });
 }
@@ -101,7 +111,7 @@ describe('AgentRosterController', () => {
     });
   });
 
-  it('repairs the hybrid pair-shaped roster that carries a stray kind field in place', () => {
+  it('repairs the hybrid pair-shaped roster that carries a stray kind field in place', async () => {
     // An intermediate version wrote `{kind: 'custom', workflowAgentKeys,
     // toolUseAgentKeys}` under AGENT_ROSTER_SELECTION. Neither the canonical
     // schema (missing `agentKeys`) nor the strict legacy schema (rejects
@@ -126,14 +136,18 @@ describe('AgentRosterController', () => {
       },
     });
     expect(warn).not.toHaveBeenCalled();
-    expect(
-      workspaceState.get(WorkspaceStateKey.AGENT_ROSTER_SELECTION),
-    ).toEqual({
-      kind: 'custom',
-      agentKeys: {
-        workflow: ['builtInWorkflow:write'],
-        toolUse: ['builtInToolUse:lead'],
-      },
+    // The repair runs behind the same write mutex the mutations use, so it
+    // lands a tick after the read rather than during it.
+    await vi.waitFor(() => {
+      expect(
+        workspaceState.get(WorkspaceStateKey.AGENT_ROSTER_SELECTION),
+      ).toEqual({
+        kind: 'custom',
+        agentKeys: {
+          workflow: ['builtInWorkflow:write'],
+          toolUse: ['builtInToolUse:lead'],
+        },
+      });
     });
   });
 

--- a/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
@@ -69,9 +69,11 @@ function createController(options?: {
 }): {
   controller: SettingsAgentCatalogController;
   enabled: Partial<Record<AgentCategory, string[] | undefined>>;
+  committedTeams: string[];
   customPresets: unknown[];
 } {
   const enabled = { ...(options?.enabled ?? {}) };
+  const committedTeams: string[] = [];
   let customPresetsRaw: unknown = options?.customPresets ?? [];
   return {
     controller: new SettingsAgentCatalogController({
@@ -80,6 +82,9 @@ function createController(options?: {
         getEnabledAgentKeys: (category) => enabled[category],
         setEnabledAgentKeys: async (category, enabledKeys) => {
           enabled[category] = enabledKeys;
+        },
+        setTeamRoster: async (preset) => {
+          committedTeams.push(preset.id);
         },
         getAgents: (category) =>
           options?.agents?.[category] ?? AGENTS[category],
@@ -97,6 +102,7 @@ function createController(options?: {
       },
     }),
     enabled,
+    committedTeams,
     get customPresets() {
       return Array.isArray(customPresetsRaw) ? customPresetsRaw : [];
     },
@@ -159,7 +165,7 @@ describe('SettingsAgentCatalogController', () => {
     });
   });
 
-  it('applies custom presets by resolving names to canonical source keys', async () => {
+  it('resolves preset members to canonical keys and commits the team symbolically', async () => {
     const persistedPreset = {
       id: 'custom-team',
       name: 'Custom Team',
@@ -170,7 +176,7 @@ describe('SettingsAgentCatalogController', () => {
         toolUse: ['review', 'missing'],
       },
     };
-    const { controller, enabled } = createController({
+    const { controller, enabled, committedTeams } = createController({
       customPresets: [persistedPreset],
     });
 
@@ -182,15 +188,21 @@ describe('SettingsAgentCatalogController', () => {
       icon: 'bookmark',
     });
     expect(resolved.resolution.unresolvedNames).toStrictEqual(['missing']);
-    await controller.commitPresetResolution(
-      resolved.preset,
-      resolved.resolution,
-    );
+    assert.deepEqual(resolved.resolution.keys.workflow, ['remote:writer']);
+    // Unresolved names are kept as bare slots so the agent joins the roster
+    // the moment it appears (sign-in, install), never silently dropped.
+    assert.deepEqual(resolved.resolution.keys.toolUse, [
+      'builtInToolUse:review',
+    ]);
+    assert.deepEqual(resolved.resolution.nameSlots.toolUse, ['missing']);
 
-    assert.deepEqual(enabled.workflow, ['remote:writer']);
-    // Unresolved names are kept bare so the agent joins the roster the
-    // moment it appears (sign-in, install) — never silently dropped.
-    assert.deepEqual(enabled.toolUse, ['builtInToolUse:review', 'missing']);
+    await controller.commitPreset(resolved.preset);
+
+    // The commit stores the team reference, not a frozen key snapshot: the
+    // roster re-resolves it against the catalog on every read.
+    assert.deepEqual(committedTeams, ['custom-team']);
+    assert.deepEqual(enabled.workflow, undefined);
+    assert.deepEqual(enabled.toolUse, undefined);
   });
 
   it('reports unknown presets without writing enabled agent state', () => {

--- a/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
@@ -189,8 +189,10 @@ describe('SettingsAgentCatalogController', () => {
     });
     expect(resolved.resolution.unresolvedNames).toStrictEqual(['missing']);
     assert.deepEqual(resolved.resolution.keys.workflow, ['remote:writer']);
-    // Unresolved names are kept as bare slots so the agent joins the roster
-    // the moment it appears (sign-in, install), never silently dropped.
+    // Unresolved names stay in the resolution's nameSlots to feed the
+    // availability preflight. Nothing persists them: the stored team
+    // reference re-resolves against the catalog on read, so a member joins
+    // the moment it appears (sign-in, install).
     assert.deepEqual(resolved.resolution.keys.toolUse, [
       'builtInToolUse:review',
     ]);

--- a/src/test-kernel/settings/ExtensionTeamAuthRefreshScope.vitest.ts
+++ b/src/test-kernel/settings/ExtensionTeamAuthRefreshScope.vitest.ts
@@ -13,7 +13,7 @@ describe('extension team auth catalog refresh scope', () => {
   it('defers auth listeners and fetches the remote catalog exactly once', async () => {
     let refreshed = false;
     let remoteFetches = 0;
-    const commitPresetResolution = vi.fn(async () => {});
+    const commitPreset = vi.fn(async () => {});
     const preset = {
       id: 'remote-team',
       name: 'Remote team',
@@ -56,7 +56,7 @@ describe('extension team auth catalog refresh scope', () => {
                   unresolvedNames: ['orchestrator'],
                 },
           }),
-          commitPresetResolution,
+          commitPreset,
         },
         loadLocalCatalog: async () => {},
         canAccessRemoteCatalog: async () => false,
@@ -78,6 +78,6 @@ describe('extension team auth catalog refresh scope', () => {
 
     expect(result.status).toBe('applied');
     expect(remoteFetches).toBe(1);
-    expect(commitPresetResolution).toHaveBeenCalledOnce();
+    expect(commitPreset).toHaveBeenCalledOnce();
   });
 });

--- a/src/test-kernel/settings/MultiAgentTab.vitest.ts
+++ b/src/test-kernel/settings/MultiAgentTab.vitest.ts
@@ -102,4 +102,29 @@ describe('multi-agent-tab preset card keyboard activation', () => {
 
     expect(appliedPresetIds()).toHaveLength(0);
   });
+
+  /**
+   * The card previously flipped a local `@state()` on click, so a team the
+   * roster never adopted (cancelled sign-in, unavailable members) still read
+   * as active, and a freshly opened Settings badged nothing at all.
+   */
+  it('badges the team the roster reports, not the one last clicked', async () => {
+    const active = AGENT_MODE_PRESETS[1]!;
+    const element = await mount({ activePresetId: active.id });
+
+    const activeCards = element.shadowRoot?.querySelectorAll(
+      '.preset-card.active',
+    );
+    expect(activeCards?.length).toBe(1);
+    expect(activeCards?.[0]?.textContent).toContain(active.name);
+
+    const otherCard = element.shadowRoot?.querySelector('.preset-card');
+    (otherCard as HTMLElement).click();
+    await element.updateComplete;
+
+    expect(appliedPresetIds()).toEqual([AGENT_MODE_PRESETS[0]!.id]);
+    expect(
+      element.shadowRoot?.querySelector('.preset-card.active')?.textContent,
+    ).toContain(active.name);
+  });
 });

--- a/src/test-kernel/settings/TeamRosterApplication.vitest.ts
+++ b/src/test-kernel/settings/TeamRosterApplication.vitest.ts
@@ -52,7 +52,7 @@ function makeDeps(
   return {
     catalog: {
       resolvePreset: () => ({ ok: true, preset, resolution: unresolved }),
-      commitPresetResolution: vi.fn(),
+      commitPreset: vi.fn(),
       ...catalog,
     },
     loadLocalCatalog: async () => {},
@@ -68,7 +68,7 @@ describe('team roster application', () => {
   it('signs in, forces one refresh, and commits exactly once', async () => {
     const calls: string[] = [];
     let refreshed = false;
-    const commitPresetResolution = vi.fn(async () => {
+    const commitPreset = vi.fn(async () => {
       calls.push('commit');
     });
 
@@ -81,7 +81,7 @@ describe('team roster application', () => {
             preset,
             resolution: refreshed ? resolved : unresolved,
           }),
-          commitPresetResolution,
+          commitPreset,
         },
         loadLocalCatalog: async () => {
           calls.push('local-load');
@@ -113,19 +113,19 @@ describe('team roster application', () => {
       'forced-refresh',
       'commit',
     ]);
-    expect(commitPresetResolution).toHaveBeenCalledOnce();
-    expect(commitPresetResolution).toHaveBeenCalledWith(preset, resolved);
+    expect(commitPreset).toHaveBeenCalledOnce();
+    expect(commitPreset).toHaveBeenCalledWith(preset);
   });
 
   it('cancels before refresh or roster writes', async () => {
-    const commitPresetResolution = vi.fn();
+    const commitPreset = vi.fn();
     const forceRefreshRemoteCatalog = vi.fn();
     const signIn = vi.fn();
 
     const result = await applyTeamRosterWithPreflight(
       'research',
       makeDeps({
-        catalog: { commitPresetResolution },
+        catalog: { commitPreset },
         signIn,
         forceRefreshRemoteCatalog,
       }),
@@ -134,7 +134,7 @@ describe('team roster application', () => {
     expect(result).toEqual({ status: 'cancelled', preset });
     expect(signIn).not.toHaveBeenCalled();
     expect(forceRefreshRemoteCatalog).not.toHaveBeenCalled();
-    expect(commitPresetResolution).not.toHaveBeenCalled();
+    expect(commitPreset).not.toHaveBeenCalled();
   });
 
   it('preflights an arbitrary unresolved member in a legacy custom team', async () => {
@@ -151,7 +151,7 @@ describe('team roster application', () => {
     const choose = vi.fn(
       async (_names: readonly string[]) => 'cancel' as const,
     );
-    const commitPresetResolution = vi.fn();
+    const commitPreset = vi.fn();
 
     const result = await applyTeamRosterWithPreflight(
       'legacy',
@@ -172,7 +172,7 @@ describe('team roster application', () => {
               unresolvedNames: ['remoteSpecialist'],
             },
           }),
-          commitPresetResolution,
+          commitPreset,
         },
         choose: async (_preset, names) => choose(names),
       }),
@@ -180,7 +180,7 @@ describe('team roster application', () => {
 
     expect(result.status).toBe('cancelled');
     expect(choose).toHaveBeenCalledWith(['remoteSpecialist']);
-    expect(commitPresetResolution).not.toHaveBeenCalled();
+    expect(commitPreset).not.toHaveBeenCalled();
   });
 
   it('preflights recognized and arbitrary unresolved members in a mixed legacy team', async () => {
@@ -233,7 +233,7 @@ describe('team roster application', () => {
     await applySettingsTeamRoster('research', {
       catalog: {
         resolvePreset: () => ({ ok: true, preset, resolution: resolved }),
-        commitPresetResolution: async () => {
+        commitPreset: async () => {
           calls.push('apply');
         },
         getPresetToolUseRoot,
@@ -272,7 +272,7 @@ describe('team roster application', () => {
     await applySettingsTeamRoster('research', {
       catalog: {
         resolvePreset: () => ({ ok: true, preset, resolution: unresolved }),
-        commitPresetResolution: vi.fn(),
+        commitPreset: vi.fn(),
         getPresetToolUseRoot: vi.fn(),
       },
       loadLocalCatalog: async () => {},
@@ -313,12 +313,12 @@ describe('team roster application', () => {
   it('proceeds on a provided "continue" choice without prompting or signing in', async () => {
     const choose = vi.fn();
     const signIn = vi.fn();
-    const commitPresetResolution = vi.fn();
+    const commitPreset = vi.fn();
 
     const result = await applyTeamRosterWithPreflight(
       'research',
       makeDeps({
-        catalog: { commitPresetResolution },
+        catalog: { commitPreset },
         providedChoice: 'continue',
         choose,
         signIn,
@@ -332,6 +332,6 @@ describe('team roster application', () => {
     });
     expect(choose).not.toHaveBeenCalled();
     expect(signIn).not.toHaveBeenCalled();
-    expect(commitPresetResolution).toHaveBeenCalledWith(preset, unresolved);
+    expect(commitPreset).toHaveBeenCalledWith(preset);
   });
 });

--- a/src/test-kernel/settings/settingsNotificationHandlers.vitest.ts
+++ b/src/test-kernel/settings/settingsNotificationHandlers.vitest.ts
@@ -85,16 +85,18 @@ describe('settingsView notification message builders', () => {
     });
   });
 
-  it('buildAgentModePresetsMessage wraps presets and orchestrator names', () => {
+  it('buildAgentModePresetsMessage wraps presets, orchestrators and the active team', () => {
     const message = buildAgentModePresetsMessage({
       getCustomPresets: () => [],
       getOrchestratorAgentNames: () => ['orchestrator-agent'],
+      getActiveTeamId: () => 'research',
     });
 
     expect(message).toEqual({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
       customPresets: [],
       orchestratorAgents: ['orchestrator-agent'],
+      activePresetId: 'research',
     });
   });
 

--- a/src/tools/delegation/proposalFlow.ts
+++ b/src/tools/delegation/proposalFlow.ts
@@ -83,18 +83,22 @@ export function requireWorkflowOrToolUseAgent(
   name: string,
   scope?: AgentDelegationScope,
 ): { agent: AgentEntry; category: AgentCategory } {
-  let firstError: unknown;
-  for (const category of [
-    AgentCategory.Workflow,
-    AgentCategory.ToolUse,
-  ] as const) {
-    try {
-      return { agent: requireVisibleAgent(category, name, scope), category };
-    } catch (error) {
-      firstError ??= error;
-    }
+  const searched = [AgentCategory.Workflow, AgentCategory.ToolUse] as const;
+  for (const category of searched) {
+    const agent = getDelegationAgent(category, name, scope);
+    if (agent) return { agent, category };
   }
-  throw firstError;
+  // Both rosters were searched, so both belong in the message: rethrowing the
+  // workflow-only error would advertise half the candidates the caller had.
+  const available = searched
+    .map((category) => {
+      const names = getDelegationAgents(category, scope).map((a) => a.name);
+      return `${category}: ${names.join(', ') || 'none'}`;
+    })
+    .join('; ');
+  throw new Error(
+    `Unknown workflow or toolUse agent '${name}'. Available: ${available}`,
+  );
 }
 
 /** Build a concise summary of proposal parameters for rejection echo. */

--- a/src/tools/setup/ApplyTeamTool.ts
+++ b/src/tools/setup/ApplyTeamTool.ts
@@ -102,10 +102,7 @@ ${describeTeams()}`,
           resolution: resolveTeamRoster(state, preset),
         };
       },
-      // `resolution` is unused: roster.setTeam persists a live {kind:'team'}
-      // reference and re-resolves against the catalog on read, rather than
-      // committing the frozen per-agent-key snapshot the preflight computed.
-      commitPresetResolution: async (preset) => {
+      commitPreset: async (preset) => {
         await roster.setTeam(preset.id);
         await roster.setDefaultTeam(preset.id);
       },

--- a/src/tools/setup/ApplyTeamTool.ts
+++ b/src/tools/setup/ApplyTeamTool.ts
@@ -27,6 +27,7 @@ import {
   type TeamRosterCatalog,
 } from '@common/teams/TeamRoster';
 import { applyTeamRosterWithPreflight } from '@common/teams/TeamRosterApplication';
+import { appSignals } from '@eventBus/AppSignals';
 import type { ToolResult } from '@shared/schemas';
 import {
   AGENT_MODE_PRESETS,
@@ -105,6 +106,9 @@ ${describeTeams()}`,
       commitPreset: async (preset) => {
         await roster.setTeam(preset.id);
         await roster.setDefaultTeam(preset.id);
+        // The setup agent runs this mid-conversation, so an open settings
+        // view is showing a roster this call just replaced.
+        appSignals.emit('agentRosterChanged', undefined);
       },
     };
 

--- a/src/tools/setup/ApplyTeamTool.ts
+++ b/src/tools/setup/ApplyTeamTool.ts
@@ -158,12 +158,13 @@ ${describeTeams()}`,
       unresolvedNames,
     );
 
-    // `keys` holds only the agent keys that resolved in the registry; names
-    // that didn't resolve right now stay in the roster as name slots (from
-    // `unresolvedNames`), where visibility matches by name and they activate
-    // the moment they appear. Account-served leads are absent until sign-in —
-    // say so instead of letting it read as a silent failure; check registry
-    // resolution, never auth.
+    // `keys` holds only the agent keys that resolved in the registry. Names
+    // that didn't resolve are not dropped: the roster stores the team
+    // reference and re-resolves `preset.agents` on every read, so a member
+    // activates the moment it appears. `unresolvedNames` is preflight
+    // evidence, not stored state. Account-served leads are absent until
+    // sign-in — say so instead of letting it read as a silent failure; check
+    // registry resolution, never auth.
     const activeWorkflow = keys.workflow;
     const activeToolUse = keys.toolUse;
     const pendingRemoteLeads = unresolvedNames.filter((name) =>


### PR DESCRIPTION
Extracts the parts of the preserved maintenance stack in #11373 that still apply to current `main`. Everything else on that branch is superseded, diverged, or in the ARIA lane; see the closing note there.

## The bug

`MultiAgentTab` tracked the applied team in a local `@state()` it flipped on click. `applyTeamRosterWithPreflight` can end in `unknown`, `cancelled`, `choice-required`, or `unavailable` without committing anything, so:

- clicking a team with unavailable members and cancelling the sign-in prompt left the card badged `✓ Active` over a roster that never changed;
- opening Settings fresh badged nothing at all, because the local state starts `null` regardless of which team the workspace runs.

The roster already knows the answer. `AgentRosterController.getActiveTeamId()` reports the effective team, `updateAgentModePresets` carries it as `activePresetId`, and the tab takes it as a `@property`. Both hosts post the presets from their shared post-mutation refresh (`refreshAfterAgentMutation` in the extension, `refreshCatalogData` on the desktop), so the badge tracks every roster mutation, not just apply: enabling a single agent rewrites the selection as `custom` and retires the applied team, which the first revision of this PR missed.

## Cleanups from the same reading

**Collapse the team-commit dual path.** Every production `TeamRosterCatalog` either supplies `setTeamRoster` (the sole `SettingsAgentCatalogController` construction, in `SettingsAgentControllerFactory`) or ignores the resolution outright (`ApplyTeamTool`, which said so in a comment). That made `commitTeamRoster` and `TeamRosterState.setEnabledAgentKeys` unreachable. `commitPresetResolution(preset, resolution)` becomes `commitPreset(preset)`; the preflight resolution stays what it always was, evidence for the availability prompt.

**Require `resolveAgent` on the roster controller.** Both call sites pass `getRosterAgent`, and its bare-name path is already `findAgentByIdentifier(getAgentsByCategory(category), ...)`, exactly the fallback `resolveEntry` repeated. The qualified path agrees too: `getAgent(key, category)` plus the same category check `resolveEntry` performed.

**Make the legacy-selection read pure.** `readAgentRosterSelection` fired `void workspaceState.update(...)` from a synchronous read. The read-modify-write mutations (`setEnabledAgentKeys`, `setAgentEnabled`, `removeTeamPreset`) read the selection while holding the write mutex, so a repair issued from the reader either races the mutation or, if serialized behind it, overwrites the selection that mutation just committed and loses a legacy workspace's first roster edit. There is no ordering that makes a read-issued write safe here, so the write is gone: the mutations own every durable write and a legacy value normalizes the next time one runs.

**Drop two no-op writes.** `setDefaultTeam`/`clearDefaultTeam` rewrote `INHERITED_AGENT_ROSTER` when the selection already read as inherit. Nothing subscribes to that key, `writeSelection` emits nothing, and `WorktreeStateStore` is straight key routing with no parent cascade, so `undefined` and `{kind:'inherit'}` read back identically. `setSelection` is now private, having had no caller outside its own class.

**Name both catalogs in the delegation error.** `requireWorkflowOrToolUseAgent` searched Workflow then ToolUse but rethrew the workflow-only failure, so an unknown name advertised half the candidates the caller could have used.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run check:dead-code-ratchet` all clean; CI green.
- One new test, in the existing `MultiAgentTab.vitest.ts`: the badge follows the roster's value and a click does not move it. The roster test that pinned in-place repair now pins the pure read plus the follow-on normalization.

## Known non-change

A workspace running the starter team shows no badge, because `STARTER_AGENT_MODE_PRESET` is deliberately excluded from `AGENT_MODE_PRESETS` and renders no card. That is the existing "starter is not a discipline and must not appear as a team card" design, left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
