### PR TITLE
refactor(desktop): drop unreachable icon rows, orphan theme tokens, and the duplicate texra-* body classes

### DIFF
--- a/packages/desktop/src/renderer/desktopIconLibrary.ts
+++ b/packages/desktop/src/renderer/desktopIconLibrary.ts
@@ -13,6 +13,7 @@ import {
 } from '@awesome.me/webawesome/dist/components/icon/library.js';
 import iconNodes from 'lucide-static/icon-nodes.json';
 
+import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 
 /**
@@ -38,52 +39,31 @@ const LUCIDE_NAME_BY_TEXRA_NAME: Readonly<Record<string, string>> = {
   'backward-step': 'skip-back',
   'forward-step': 'skip-forward',
   'caret-down': 'chevron-down',
-  'up-right-and-down-left-from-center': 'maximize-2',
-  'down-left-and-up-right-to-center': 'minimize-2',
 
   // Files / storage
   'file-lines': 'file-text',
   'file-pdf': 'file-text',
-  'file-import': 'file-input',
   'file-export': 'file-output',
   'floppy-disk': 'save',
   'box-archive': 'archive',
   box: 'package',
   'magnifying-glass': 'search',
-  'magnifying-glass-plus': 'zoom-in',
   'cloud-arrow-down': 'cloud-download',
   'cloud-arrow-up': 'cloud-upload',
-  'arrow-up-from-bracket': 'upload',
-  'arrow-down-to-line': 'download',
 
   // Tools / concepts
   gear: 'settings',
-  gears: 'settings-2',
-  screwdriver: 'wrench',
   'screwdriver-wrench': 'wrench',
   'wand-magic-sparkles': 'wand-sparkles',
   flask: 'flask-conical',
   microphone: 'mic',
   'paper-plane': 'send',
-  'pen-to-square': 'square-pen',
-  'trash-can': 'trash-2',
   'clock-rotate-left': 'clock-arrow-left',
-  'right-left': 'arrow-left-right',
   'code-branch': 'git-branch',
-  'code-commit': 'git-commit-horizontal',
-  'code-pull-request': 'git-pull-request',
   'code-compare': 'git-compare',
-  'user-group': 'users',
   'check-double': 'check-check',
   'list-check': 'list-checks',
-  microchip: 'cpu',
-  'shield-halved': 'shield',
-  'triangle-exclamation-solid': 'triangle-alert',
   bolt: 'zap',
-  'money-bill': 'banknote',
-  'circle-half-stroke': 'contrast',
-  'sun-bright': 'sun',
-  'moon-stars': 'moon',
   thumbtack: 'pin',
   'thumbtack-slash': 'pin-off',
   spinner: 'loader-circle',
@@ -103,20 +83,14 @@ const LUCIDE_NAME_BY_TEXRA_NAME: Readonly<Record<string, string>> = {
   'magnifying-glass-chart': 'search-code',
   'note-sticky': 'sticky-note',
   'plus-minus': 'diff',
-  'circle-large-outline': 'circle',
   meteor: 'sparkles',
   cube: 'box',
   'diagram-project': 'workflow',
   'list-ul': 'list',
   comments: 'messages-square',
   comment: 'message-circle',
-  // Codicon-style symbol aliases used by the agent-team presets.
-  'symbol-structure': 'boxes',
   hashtag: 'hash',
-  'symbol-method': 'braces',
-  'symbol-namespace': 'box',
-  'symbol-keyword': 'key-round',
-};
+} satisfies Partial<Record<TeXRAIconName, string>>;
 
 /**
  * Lucide's icon geometry as data: `{ name: [[tag, attrs], ...] }`.

--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -51,13 +51,11 @@
   --desktop-color-background: light-dark(#ffffff, #212121);
   --desktop-color-foreground: light-dark(#0d0d0d, #ececec);
   --desktop-color-muted: light-dark(#5d5d5d, #b4b4b4);
-  --desktop-color-soft: light-dark(#8f8f8f, #8e8e8e);
 
   /* Surface ladder. Opaque neutral steps keep nested panels legible without
      translucent blue layers compounding into unrelated colors. */
   --desktop-color-sidebar: light-dark(#f9f9f9, #171717);
   --desktop-color-sidebar-header: light-dark(#f4f4f4, #2f2f2f);
-  --desktop-color-surface-3: light-dark(#ececec, #424242);
 
   /* Seams are intentionally quiet: enough contrast to explain containment,
      but never strong enough to make every region look like a card. */
@@ -82,12 +80,6 @@
   --desktop-color-accent-hover: light-dark(#2f2f2f, #ffffff);
   --desktop-color-accent-subtle: light-dark(#ececec, #3a3a3a);
   --desktop-color-focus: light-dark(#0d0d0d, #ffffff);
-  /* Kept as a background-image-compatible value for existing consumers, but
-     intentionally flat: the old blue-to-purple gradient dominated the shell. */
-  --desktop-gradient-brand: light-dark(
-    linear-gradient(#0d0d0d, #0d0d0d),
-    linear-gradient(#f4f4f4, #f4f4f4)
-  );
 
   --desktop-color-button-secondary: light-dark(#f4f4f4, #2f2f2f);
   --desktop-color-button-secondary-hover: light-dark(#e7e7e7, #424242);
@@ -104,10 +96,6 @@
     0 1px 2px rgb(0 0 0 / 6%),
     0 1px 2px rgb(0 0 0 / 24%)
   );
-  --desktop-shadow-md: light-dark(
-    0 4px 12px rgb(0 0 0 / 8%),
-    0 6px 18px rgb(0 0 0 / 28%)
-  );
   --desktop-shadow-lg: light-dark(
     0 18px 48px rgb(0 0 0 / 14%),
     0 24px 64px rgb(0 0 0 / 38%)
@@ -122,7 +110,6 @@
     rgb(255 207 92 / 13%)
   );
   --desktop-color-info: light-dark(#087ea4, #74c7ec);
-  --desktop-color-info-background: light-dark(#e7f5fa, rgb(116 199 236 / 14%));
   --desktop-color-success: light-dark(#0a7a54, #56e0a0);
   --desktop-color-success-background: light-dark(
     #e3f7ee,
@@ -132,7 +119,6 @@
   --desktop-color-orange: light-dark(#c2410c, #ff9d54);
   --desktop-color-yellow: light-dark(#a16207, #ffcf5c);
   --desktop-color-purple: light-dark(#7c3aed, #b183ff);
-  --desktop-color-cyan: light-dark(#0e8ba1, #5fd9e8);
   --desktop-color-terminal-selection: light-dark(
     #e7e7e7,
     rgb(255 255 255 / 18%)
@@ -358,7 +344,6 @@
   /* Seams. Only where a border is load-bearing; large regions separate by a
      background step. */
   --border-hairline: light-dark(rgb(0 0 0 / 10%), rgb(255 255 255 / 10%));
-  --border-hairline-soft: light-dark(rgb(0 0 0 / 5%), rgb(255 255 255 / 5%));
   --border-hairline-strong: light-dark(
     rgb(0 0 0 / 15%),
     rgb(255 255 255 / 20%)
@@ -371,9 +356,7 @@
   --control-padding-inline: 6px;
   --control-fill: light-dark(rgb(0 0 0 / 5%), rgb(255 255 255 / 5%));
   --control-fill-hover: light-dark(rgb(0 0 0 / 8%), rgb(255 255 255 / 9%));
-  --opacity-faint: 0.35;
   --opacity-disabled: 0.5;
-  --opacity-muted: 0.6;
   --row-height: 36px;
   --row-radius: var(--wa-border-radius-m);
   --row-padding: 6px 10px;
@@ -381,7 +364,6 @@
   --focus-ring-offset: 2px;
   --textarea-h-s: 2.75rem;
   --textarea-h-m: 6rem;
-  --textarea-h-l: 6.625rem;
 
   /* Two typographic regimes: 13px chrome (this hosts a code editor and a
      terminal, where 16px chrome would cost real content width) and 16px prose
@@ -411,14 +393,12 @@
   --font-weight-medium: 500;
   --font-weight-semibold: 600;
   --letter-spacing-tight: -0.005em;
-  --width-content-max: 1000px;
 
-  /* Motion. One easing, three durations; only background-color, opacity, and
+  /* Motion. One easing, two durations; only background-color, opacity, and
      box-shadow are ever transitioned. */
   --transition-ease: cubic-bezier(0.2, 0, 0, 1);
   --transition-fast: 120ms var(--transition-ease);
   --transition-normal: 180ms var(--transition-ease);
-  --transition-relaxed: 300ms ease;
 
   /* Buttons — niche tokens consumers still need. */
   --wa-color-button-hover: var(--desktop-color-accent-hover);
@@ -559,28 +539,24 @@
 /* The host's explicit theme choice pins `color-scheme`, which is what resolves
    every `light-dark()` pair above. Both themes are first-class: light is a
    paper-white skin with neutral shadows, dark is the deep blue-black canvas. */
-body.vscode-light,
-body.texra-light {
+body.vscode-light {
   color-scheme: light;
   --desktop-canvas-wash: var(--desktop-canvas-wash-light);
 }
 
-body.vscode-dark,
-body.texra-dark {
+body.vscode-dark {
   color-scheme: dark;
   --desktop-canvas-wash: var(--desktop-canvas-wash-dark);
 }
 
 body.vscode-high-contrast,
-body.vscode-high-contrast-light,
-body.texra-high-contrast {
+body.vscode-high-contrast-light {
   color-scheme: light dark;
   --desktop-color-background: Canvas;
   --desktop-color-foreground: CanvasText;
   --desktop-color-muted: GrayText;
   --desktop-color-sidebar: Canvas;
   --desktop-color-sidebar-header: Canvas;
-  --desktop-color-surface-3: Canvas;
   --desktop-color-border: CanvasText;
   --desktop-color-widget-border: CanvasText;
   --desktop-edge-highlight: none;
@@ -592,7 +568,6 @@ body.texra-high-contrast {
   --desktop-color-accent-hover: Highlight;
   --desktop-color-accent-subtle: Canvas;
   --desktop-color-focus: Highlight;
-  --desktop-gradient-brand: linear-gradient(Highlight, Highlight);
   --desktop-color-button-secondary: ButtonFace;
   --desktop-color-button-secondary-hover: ButtonFace;
   --desktop-color-toolbar-active: Highlight;
@@ -602,7 +577,6 @@ body.texra-high-contrast {
   --desktop-color-menu-border: CanvasText;
   --desktop-color-shadow: transparent;
   --desktop-shadow-sm: none;
-  --desktop-shadow-md: none;
   --desktop-shadow-lg: none;
   --desktop-canvas-wash: none;
   /* Error/warning FOREGROUNDS stay CanvasText: Mark is a background keyword
@@ -676,7 +650,6 @@ body.texra-high-contrast {
     --wa-transition-fast: 0ms;
     --transition-fast: 0ms;
     --transition-normal: 0ms;
-    --transition-relaxed: 0ms;
   }
 }
 

--- a/src/shared/wa/hostTheme.ts
+++ b/src/shared/wa/hostTheme.ts
@@ -14,8 +14,8 @@ import { setWaColorScheme, THEME_CLASSES, themeIsDark } from './waColorScheme';
 
 /**
  * Apply Electron-renderer-style host theme classes:
- *   - removes any prior `vscode-*` / `texra-*` body classes
- *   - adds `vscode-<kind>` AND `texra-<kind>`
+ *   - removes any prior `vscode-*` body classes
+ *   - adds `vscode-<kind>`
  *   - sets `body.dataset.vscodeThemeKind`
  *   - swaps the `wa-light`/`wa-dark` class on <html> via setWaColorScheme()
  *
@@ -27,7 +27,7 @@ export function applyHostBodyTheme(theme: Theme): void {
   const body = document.body;
   if (!body) return;
   body.classList.remove(...THEME_CLASSES);
-  body.classList.add(`vscode-${theme}`, `texra-${theme}`);
+  body.classList.add(`vscode-${theme}`);
   body.dataset.vscodeThemeKind = theme;
   setWaColorScheme(themeIsDark(theme));
 }

--- a/src/shared/wa/waColorScheme.ts
+++ b/src/shared/wa/waColorScheme.ts
@@ -15,26 +15,25 @@ import type { Theme } from '@shared/schemas';
  * mid-session (e.g. user toggles VS Code light/dark).
  *
  * This module is the single owner of the theme-kind vocabulary: the
- * kind→darkness mapping (`themeIsDark`) and the derived `vscode-*` / `texra-*`
+ * kind→darkness mapping (`themeIsDark`) and the derived `vscode-*`
  * body-class list (`THEME_CLASSES`) live here, and `hostTheme.ts` imports them
  * rather than re-encoding a parallel copy.
  */
 
-/** The host theme kinds we recognize. Single source for the `vscode-*` /
- *  `texra-*` class names and the kind→darkness mapping. */
+/** The host theme kinds we recognize. Single source for the `vscode-*`
+ *  class names and the kind→darkness mapping. */
 const THEME_KINDS = [
   'light',
   'dark',
   'high-contrast',
 ] as const satisfies readonly Theme[];
 
-/** Every `vscode-<kind>` / `texra-<kind>` body class, derived from THEME_KINDS.
+/** Every `vscode-<kind>` body class, derived from THEME_KINDS.
  *  `applyHostBodyTheme` strips these on re-apply and `isDarkTheme` below
  *  classifies body classes against this same list. */
-export const THEME_CLASSES: readonly string[] = THEME_KINDS.flatMap((kind) => [
-  `vscode-${kind}`,
-  `texra-${kind}`,
-]);
+export const THEME_CLASSES: readonly string[] = THEME_KINDS.map(
+  (kind) => `vscode-${kind}`,
+);
 
 /**
  * Convert a `Theme` kind to whether it should render as dark.
@@ -46,12 +45,12 @@ export function themeIsDark(theme: Theme): boolean {
 }
 
 const DARK_BODY_CLASSES: readonly string[] = THEME_KINDS.flatMap((kind) =>
-  themeIsDark(kind) ? [`vscode-${kind}`, `texra-${kind}`] : [],
+  themeIsDark(kind) ? [`vscode-${kind}`] : [],
 );
 
 const LIGHT_BODY_CLASSES: readonly string[] = [
   ...THEME_KINDS.flatMap((kind) =>
-    themeIsDark(kind) ? [] : [`vscode-${kind}`, `texra-${kind}`],
+    themeIsDark(kind) ? [] : [`vscode-${kind}`],
   ),
   // VS Code's special light high-contrast class, not derivable from
   // THEME_KINDS (it is a theme variant, not a kind).

--- a/src/test-kernel/desktop/DesktopThemeTokens.vitest.ts
+++ b/src/test-kernel/desktop/DesktopThemeTokens.vitest.ts
@@ -95,7 +95,7 @@ describe('desktop theme tokens', () => {
   it('keeps light and dark palettes in one semantic token layer', () => {
     const css = readThemeTokens();
     const darkBlock = css.match(
-      /body\.vscode-dark,\s*body\.texra-dark\s*{(?<body>[^}]*)}/,
+      /body\.vscode-dark\s*{(?<body>[^}]*)}/,
     )?.groups?.body;
 
     expect(css).toContain('light-dark(');

--- a/src/test-kernel/desktop/DesktopThemeTokens.vitest.ts
+++ b/src/test-kernel/desktop/DesktopThemeTokens.vitest.ts
@@ -94,9 +94,8 @@ describe('desktop theme tokens', () => {
 
   it('keeps light and dark palettes in one semantic token layer', () => {
     const css = readThemeTokens();
-    const darkBlock = css.match(
-      /body\.vscode-dark\s*{(?<body>[^}]*)}/,
-    )?.groups?.body;
+    const darkBlock = css.match(/body\.vscode-dark\s*{(?<body>[^}]*)}/)?.groups
+      ?.body;
 
     expect(css).toContain('light-dark(');
     expect(darkBlock).toContain('color-scheme: dark;');

--- a/src/test-kernel/desktop/HostTheme.vitest.ts
+++ b/src/test-kernel/desktop/HostTheme.vitest.ts
@@ -42,14 +42,12 @@ describe('applyHostBodyTheme', () => {
     restoreDom();
   });
 
-  it('replaces stale vscode-* / texra-* body classes', () => {
+  it('replaces stale vscode-* body classes', () => {
     const body = globalThis.document.body;
-    body.classList.add('vscode-light', 'texra-light', 'unrelated-class');
+    body.classList.add('vscode-light', 'unrelated-class');
     applyHostBodyTheme('dark');
     expect(body.classList.contains('vscode-dark')).toBe(true);
-    expect(body.classList.contains('texra-dark')).toBe(true);
     expect(body.classList.contains('vscode-light')).toBe(false);
-    expect(body.classList.contains('texra-light')).toBe(false);
     // Caller-set classes that aren't theme-related must not be touched.
     expect(body.classList.contains('unrelated-class')).toBe(true);
     expect(body.dataset.vscodeThemeKind).toBe('dark');


### PR DESCRIPTION
Three behavior-preserving removals in the desktop renderer, all of them residue left by earlier finished migrations.

## Summary

The desktop Lucide icon map still carried 26 Font Awesome spellings that are not members of `TEXRA_ICON_CANONICAL_NAMES`, so no typed render path could reach them. The desktop theme bridge still declared 12 custom properties that no `var()` reads anywhere, including inside the bridge file itself. And `applyHostBodyTheme` still wrote a `texra-<kind>` body class beside every `vscode-<kind>` class, a leftover from the `--vscode` / `--texra` double-bridge retirement that only ever finished on the CSS-variable side.

Nothing rendered changes. The icon resolver's `?? name` fallback and its missing-icon marker are untouched, the removed tokens had no readers, and every `body.texra-*` selector was a comma-sibling of a `body.vscode-*` selector applied to the same element by the same statement.

## What landed

- **Icon map.** Deleted the 26 non-canonical rows from `LUCIDE_NAME_BY_TEXRA_NAME` in `packages/desktop/src/renderer/desktopIconLibrary.ts`. The literal now carries `satisfies Partial<Record<TeXRAIconName, string>>` so a future canonical-name removal becomes a compile error instead of silent dead data. The declared index type stays `Readonly<Record<string, string>>`, because the resolver's `name` is a genuinely arbitrary runtime string and asserting otherwise would be false. Also dropped the stale codicon-alias comment: agent presets narrowed their icon field to a six-name allowlist, so `symbol-*` names can no longer arrive here.
- **Theme tokens.** Deleted 12 unread custom properties from `packages/desktop/src/renderer/themeTokens.css` plus their high-contrast and reduced-motion restatements: `--desktop-color-soft`, `--desktop-color-surface-3`, `--desktop-gradient-brand`, `--desktop-shadow-md`, `--desktop-color-info-background`, `--desktop-color-cyan`, `--border-hairline-soft`, `--opacity-faint`, `--opacity-muted`, `--textarea-h-l`, `--width-content-max`, `--transition-relaxed`. The gradient's "kept for existing consumers" comment goes with it, and the motion comment now says two durations rather than three.
- **Body classes.** `applyHostBodyTheme` adds only `vscode-<kind>`. `THEME_CLASSES`, `DARK_BODY_CLASSES`, and `LIGHT_BODY_CLASSES` in `src/shared/wa/waColorScheme.ts` collapse from a flatMap over two prefixes to a single derived list, keeping the non-derivable `vscode-high-contrast-light` member. The three `body.texra-*` selector lines are gone from the theme bridge.
- **Tests.** Trimmed the two `texra-*` assertions in `src/test-kernel/desktop/HostTheme.vitest.ts` and relaxed the dark-block regex in `src/test-kernel/desktop/DesktopThemeTokens.vitest.ts`. Both edits delete assertions on removed behavior rather than rewriting them to keep passing. No new tests.

## What was skipped

- **Dropping `vscode-*` instead of `texra-*`.** That is the more appealing direction for an Electron app, but it is blocked: `src/shared/BaseWebviewApp.ts` and `packages/extension/src/progressView/frontend/components/UserMessage.ts` classify darkness by `.vscode-dark` and `:host-context(.vscode-high-contrast)`, and those shared Lit components render inside the desktop renderer.
- **`LUCIDE_NAME_BY_TEXRA_NAME[name as TeXRAIconName]`.** The original proposal asked for this index assertion. It asserts a falsehood, since the resolver takes arbitrary runtime strings and a test exercises `'unexpected-runtime-icon'`. The `satisfies` clause gives the same drift guard without the lie.
- **The duplicate icon table in `docs/.vitepress/theme/webAwesomeIcons.js`.** It defines its own `circle-large-outline`, `symbol-keyword`, and `symbol-structure` entries and never imports the desktop module, so the VitePress site is unaffected. Consolidating the two tables is a separate piece of work.
- **Rewording the "Surface ladder" comment.** It stays accurate with `sidebar` and `sidebar-header` remaining, so it was left alone.

## Net elements (R6)

Files changed: 6 (`packages/desktop/src/renderer/desktopIconLibrary.ts`, `packages/desktop/src/renderer/themeTokens.css`, `src/shared/wa/hostTheme.ts`, `src/shared/wa/waColorScheme.ts`, `src/test-kernel/desktop/DesktopThemeTokens.vitest.ts`, `src/test-kernel/desktop/HostTheme.vitest.ts`).

`git diff --stat origin/main...simplify/L3-desktop`: 21 insertions, 77 deletions, net **-56 LoC**.

Export symbols: `^\+export` = 1, `^-export` = 1, net **0**. The pair is the same `export const THEME_CLASSES` declaration reflowed from `flatMap` to `map`.

Class / interface / enum declarations: **0 added, 0 removed** (`^[+-](export )?(abstract )?(class|interface|enum) ` matches nothing in the diff).

Removed elements, 48 total, none exported:

| Kind | Count |
| --- | --- |
| Icon-map rows | 26 |
| CSS custom-property declaration sites (12 base + 4 restatements) | 16 |
| `body.texra-*` selector lines (6 removed, 3 re-added) | 3 |
| Runtime body classes no longer written | 3 |

The lane brief estimated -61 LoC. The branch lands -56 because `hostTheme.ts` only shortens a line and both `*_BODY_CLASSES` lists stay multi-line after collapsing: the one-line form of `LIGHT_BODY_CLASSES` is 82 columns, so prettier keeps the break.

## Consumer counts (R8)

No exported symbol was deleted, so `config/ratchets/knip-baseline.json` needed no edit, and the diff touches no file under `config/ratchets/`.

**26 icon-map keys** (`up-right-and-down-left-from-center`, `down-left-and-up-right-to-center`, `file-import`, `magnifying-glass-plus`, `arrow-up-from-bracket`, `arrow-down-to-line`, `gears`, `screwdriver`, `pen-to-square`, `trash-can`, `right-left`, `code-commit`, `code-pull-request`, `user-group`, `microchip`, `shield-halved`, `triangle-exclamation-solid`, `money-bill`, `circle-half-stroke`, `sun-bright`, `moon-stars`, `circle-large-outline`, `symbol-structure`, `symbol-method`, `symbol-namespace`, `symbol-keyword`): **0 consumers.** `git grep` for each across the whole tree returns only known-false hits. `screwdriver` matches only inside the surviving canonical `screwdriver-wrench`. `docs/.vitepress/theme/webAwesomeIcons.js` is an independent table that never imports this module. `--wa-color-symbol-keyword` is a CSS custom-property name. `$(symbol-method)` at `packages/extension/package.json:372` and `src/shared/commands/catalog.ts:259` is a VS Code codicon string, and it cannot reach the desktop resolver: the desktop palette sources icons from `DESKTOP_COMMAND_ICONS` (`packages/desktop/src/shared/desktopCommandSurface.ts:127-146`, `satisfies Record<DesktopCommandId, TeXRAIconName>`, where `texra.showAgents` is `'robot'`), never from the catalog's `icon` field.

**The map itself**: 1 production consumer (`desktopIconLibrary.ts:167`, its own resolver) and 1 test consumer (`src/test-kernel/desktop/DesktopIconLibrary.vitest.ts:43-55`, which parses the table out of source text and asserts more than 50 rows). Re-running that test's exact regex against the branch yields 57 keys, all 57 members of `TEXRA_ICON_CANONICAL_NAMES`, no duplicates.

**12 custom properties**: **0 consumers each.** `git grep` for each name at the branch tip returns nothing repo-wide, including inside `themeTokens.css`. Positive controls (`--opacity-disabled`, `--desktop-shadow-lg`) return 9 files, so the search is not silently empty. No dynamic reader exists either: the only `getPropertyValue` call sites are `src/shared/wa/xtermTheme.ts:48` (reads `--wa-color-terminal-*`, `--wa-color-surface-default`, `--wa-color-text-normal`, `--wa-font-family-mono`) and two vitest helpers, and no code constructs CSS variable names by template.

**3 body classes** `texra-light` / `texra-dark` / `texra-high-contrast`: **0 remaining references.** Before this change there were 7, three CSS selector lines and four test lines, all handled here. `applyHostBodyTheme` has 1 production caller (`packages/desktop/src/renderer/main.ts:1393`) plus 1 test. `THEME_CLASSES` keeps its 1 consumer (`hostTheme.ts:29`) and stays exported. `DARK_BODY_CLASSES` and `LIGHT_BODY_CLASSES` are module-private with 1 reader each (`waColorScheme.ts:65`, `:68`); their classification result is unchanged because `texra-*` only ever appeared alongside the `vscode-*` class that still drives the decision.

## Notes for the reviewer

`packages/desktop` already imports `@shared/wa/iconNames` from two sibling modules (`desktopCommandPalette.ts:17`, `logsPane.ts:7`), so the new type-only import adds no distinct specifier and touches none of the host-import baselines. No `vscode` import enters a VS Code-free zone, no schema, persisted-data reader, `catch`, or `??` fallback is involved, and no re-export shim is left behind. Please run `npm run format` centrally: the three reflowed expressions were hand-checked against the 80-column limit but prettier was not executed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
