### PR TITLE
simplify(cli): retire three CLI surfaces only a test or a hand-rolled latch used

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -830,12 +830,6 @@
       "name": "CLI_COMPLETION_SHELLS"
     },
     {
-      "file": "packages/cli/src/runtime/defaultAgents.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "BUILTIN_DEFAULT_CHAT_AGENT"
-    },
-    {
       "file": "packages/cli/src/runtime/doctor.ts",
       "category": "production-dead",
       "kind": "exports",
@@ -1296,12 +1290,6 @@
       "category": "production-dead",
       "kind": "exports",
       "name": "EXTENSION_INTERNAL_COMMAND_IDS"
-    },
-    {
-      "file": "packages/extension/src/commands/extensionCommandHandlers.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "EXTENSION_REGISTRY_CATALOG_COMMAND_IDS"
     },
     {
       "file": "packages/extension/src/frontend/auth/agentCatalogRefreshScope.ts",

--- a/packages/cli/src/runtime/defaultAgents.ts
+++ b/packages/cli/src/runtime/defaultAgents.ts
@@ -4,7 +4,7 @@ import {
   implicitDefaultToolUseAgents,
 } from '@shared/constants/agents';
 
-export const BUILTIN_DEFAULT_CHAT_AGENT = 'assistant';
+const BUILTIN_DEFAULT_CHAT_AGENT = 'assistant';
 
 // Priority for the implicit default: the built-in default first, then the shared
 // preferred order with the built-in removed so it isn't re-checked (it already

--- a/packages/cli/src/runtime/githubToken.ts
+++ b/packages/cli/src/runtime/githubToken.ts
@@ -17,9 +17,6 @@ export async function saveGitHubToken(token: string): Promise<void> {
     secretName: GITHUB_TOKEN_STORAGE_KEY,
     value: token,
     kind: 'github',
-    emptyMessage: 'GitHub token is empty.',
-    placeholderMessage:
-      'This looks like a placeholder rather than a GitHub token. Enter a personal access token from GitHub.',
   });
 }
 

--- a/packages/cli/src/runtime/logSinks.ts
+++ b/packages/cli/src/runtime/logSinks.ts
@@ -1,6 +1,9 @@
 // Node imports
 import { createInterface } from 'node:readline/promises';
 
+// Third-party imports
+import PQueue from 'p-queue';
+
 // Local imports
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 import type { LogLevel } from '@shared/schemas';
@@ -195,8 +198,7 @@ const processStdoutTarget: NdjsonWritable = {
 };
 
 export class NdjsonStdoutSink implements LogSink {
-  private readonly queue: CliNdjsonRecord[] = [];
-  private drainPromise: Promise<void> | undefined;
+  private readonly queue = new PQueue({ concurrency: 1 });
   private stdoutClosed = false;
 
   constructor(private readonly stdout: NdjsonWritable = processStdoutTarget) {}
@@ -207,56 +209,36 @@ export class NdjsonStdoutSink implements LogSink {
 
   writeRecord(record: CliNdjsonRecord): void {
     if (this.isClosed()) return;
-    this.queue.push(record);
-    void this.ensureDrain().catch(() => undefined);
+    void this.queue.add(() => this.writeLine(record)).catch(() => undefined);
   }
 
-  async flush(): Promise<void> {
-    while (this.drainPromise || this.queue.length > 0) {
-      await (this.drainPromise ?? this.ensureDrain());
-    }
+  flush(): Promise<void> {
+    return this.queue.onIdle();
   }
 
   async close(): Promise<void> {
     await this.flush();
   }
 
-  private ensureDrain(): Promise<void> {
-    if (!this.drainPromise) {
-      const promise = this.drain();
-      this.drainPromise = promise;
-      void promise.finally(() => {
-        if (this.drainPromise === promise) {
-          this.drainPromise = undefined;
-        }
-        if (!this.stdoutClosed && this.queue.length > 0) {
-          void this.ensureDrain().catch(() => undefined);
-        }
-      });
-    }
-    return this.drainPromise;
-  }
-
-  private async drain(): Promise<void> {
+  /**
+   * Writes one queued record, honouring backpressure. Never rejects: the
+   * queued promise is voided, so a throw here would surface as an unhandled
+   * rejection. A failed write or an unserializable record closes the sink.
+   */
+  private async writeLine(record: CliNdjsonRecord): Promise<void> {
     if (this.isClosed()) {
       this.closeQueue();
       return;
     }
-    while (!this.isClosed() && this.queue.length > 0) {
-      const record = this.queue.shift();
-      if (!record) continue;
-      const line = `${JSON.stringify(record)}\n`;
-      let canContinue: boolean;
-      try {
-        canContinue = this.stdout.write(line);
-      } catch {
-        this.closeQueue();
-        return;
-      }
-      if (!canContinue && !(await this.waitForStdoutDrain())) {
-        this.closeQueue();
-        return;
-      }
+    let canContinue: boolean;
+    try {
+      canContinue = this.stdout.write(`${JSON.stringify(record)}\n`);
+    } catch {
+      this.closeQueue();
+      return;
+    }
+    if (!canContinue && !(await this.waitForStdoutDrain())) {
+      this.closeQueue();
     }
   }
 
@@ -264,9 +246,10 @@ export class NdjsonStdoutSink implements LogSink {
     return this.stdoutClosed || !this.stdout.usable;
   }
 
+  /** Drops every record still queued: stdout is gone, nothing more can land. */
   private closeQueue(): void {
     this.stdoutClosed = true;
-    this.queue.length = 0;
+    this.queue.clear();
   }
 
   private waitForStdoutDrain(): Promise<boolean> {

--- a/packages/cli/src/runtime/providerApiKey.ts
+++ b/packages/cli/src/runtime/providerApiKey.ts
@@ -8,6 +8,7 @@ import {
   type ApiProvider,
 } from '@model/apiProviders';
 import { platform } from '@platform/platform';
+import { providerDisplayName } from '@shared/constants/providers';
 
 export function loadProviderApiKeyStatuses(): Promise<
   Record<ApiProvider, ApiKeyStatus>
@@ -25,8 +26,8 @@ export async function saveProviderApiKey(
   await storeCredential(platform().secrets, {
     secretName: apiKeySecretName(provider),
     value: key,
-    emptyMessage: 'API key is empty.',
-    placeholderMessage: `This looks like a placeholder rather than a ${provider} API key. Enter the key issued by the provider.`,
+    kind: 'provider',
+    label: providerDisplayName(provider),
   });
   invalidateApiKeyCache();
 }

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -325,14 +325,11 @@ export function createDesktopSettingsIpc(
       prompt: GITHUB_TOKEN_PROMPT,
     });
     if (token == null) return;
-    const stored = await storeCredential(platform().secrets, {
+    await storeCredential(platform().secrets, {
       secretName: GITHUB_TOKEN_STORAGE_KEY,
       value: token,
       kind: 'github',
-      placeholderMessage:
-        'This looks like a placeholder rather than a GitHub token. Enter a personal access token from GitHub.',
     });
-    if (!stored) return;
     await options.ui.showInfoMessage(GITHUB_TOKEN_SAVED_MESSAGE);
     await postGitHubTokenStatus();
     await refreshToolAvailability();

--- a/packages/extension/src/commands/extensionCommandHandlers.ts
+++ b/packages/extension/src/commands/extensionCommandHandlers.ts
@@ -137,19 +137,6 @@ export type ExtensionRegistryCommandId =
   ExtensionRegistryCatalogCommandId | InternalExtensionRegistryCommandId;
 
 /**
- * Runtime mirror of `ExtensionRegistryCatalogCommandId`, used by tests to
- * assert `EXTENSION_COMMAND_HANDLERS` registers every catalog entry tagged
- * `extensionRegistry: true` (and flag strays that no longer belong).
- */
-export const EXTENSION_REGISTRY_CATALOG_COMMAND_IDS: readonly ExtensionRegistryCatalogCommandId[] =
-  commandCatalog
-    .filter(
-      (entry): entry is ExtensionRegistryCatalogEntry =>
-        'extensionRegistry' in entry && entry.extensionRegistry === true,
-    )
-    .map((entry) => entry.id);
-
-/**
  * Capabilities the registry handlers need from the extension host. Mirrors
  * `DesktopCommandActions` in shape — both register parallel handler maps
  * over the same `CommandId` union with their host-specific actions.

--- a/packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts
@@ -58,14 +58,11 @@ export class GitHubSubscriptionHandlers {
       this.ctx,
       'Failed to save GitHub token',
       async () => {
-        const stored = await storeCredential(platform().secrets, {
+        await storeCredential(platform().secrets, {
           secretName: GITHUB_TOKEN_STORAGE_KEY,
           value: token,
           kind: 'github',
-          placeholderMessage:
-            'This looks like a placeholder rather than a GitHub token. Enter a personal access token from GitHub.',
         });
-        if (!stored) return;
         void vscode.window.showInformationMessage(GITHUB_TOKEN_SAVED_MESSAGE);
         await this.ctx.withActiveWebview((w) => this.sendGitHubTokenStatus(w));
       },

--- a/src/common/secrets/storeCredential.ts
+++ b/src/common/secrets/storeCredential.ts
@@ -8,25 +8,38 @@ interface CredentialStore {
 interface StoreCredentialOptions {
   readonly secretName: string;
   readonly value: string;
-  readonly kind?: 'provider' | 'github';
-  readonly emptyMessage?: string;
-  readonly placeholderMessage: string;
+  readonly kind: 'provider' | 'github';
+  /**
+   * Provider display name woven into the rejection messages. Caller-supplied
+   * because hosts resolve it through their own (region-aware) provider config;
+   * looking it up here would silently drop those variants.
+   */
+  readonly label?: string;
 }
 
-/** Validate, normalize, and persist a credential consistently across hosts. */
+/**
+ * Validate, normalize, and persist a credential consistently across hosts.
+ * The rejection copy lives here too, so the CLI, the desktop app, and the
+ * extension can't drift on what a rejected credential says. Rejections throw:
+ * every caller already funnels thrown errors into its own failure reporting.
+ */
 export async function storeCredential(
   store: CredentialStore,
   options: StoreCredentialOptions,
-): Promise<boolean> {
+): Promise<void> {
+  const subject =
+    options.kind === 'github'
+      ? 'GitHub token'
+      : `${options.label ?? 'provider'} API key`;
   const normalized = options.value.trim();
-  if (!normalized) {
-    if (options.emptyMessage) throw new Error(options.emptyMessage);
-    return false;
-  }
+  if (!normalized) throw new Error(`${subject} is empty.`);
   if (looksLikeCredentialPlaceholder(normalized, options.kind)) {
-    throw new Error(options.placeholderMessage);
+    throw new Error(
+      options.kind === 'github'
+        ? `This looks like a placeholder rather than a ${subject}. Enter a personal access token from GitHub.`
+        : `This looks like a placeholder rather than a ${subject}. Enter the key issued by the provider.`,
+    );
   }
 
   await store.set(options.secretName, normalized);
-  return true;
 }

--- a/src/controllers/settingsView/SettingsProfileKeyController.ts
+++ b/src/controllers/settingsView/SettingsProfileKeyController.ts
@@ -76,12 +76,12 @@ export class SettingsProfileKeyController {
     apiKey: string,
   ): Promise<boolean> {
     const displayName = this.deps.getProviderDisplayName(provider);
-    const stored = await storeCredential(platform().secrets, {
+    await storeCredential(platform().secrets, {
       secretName: secretNameFor(provider),
       value: apiKey,
-      placeholderMessage: `This looks like a placeholder rather than a ${displayName} API key. Enter the key issued by the provider.`,
+      kind: 'provider',
+      label: displayName,
     });
-    if (!stored) return false;
     void this.deps.prompt.info(`${displayName} API key has been set`);
     return true;
   }

--- a/src/test-kernel/cli/ChatDefaults.vitest.ts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.ts
@@ -14,7 +14,6 @@ import {
   CLI_BUILTIN_DEFAULT_MODEL,
   loadWorkspaceCliConfig,
 } from '@cli/runtime/cliConfig';
-import { BUILTIN_DEFAULT_CHAT_AGENT } from '@cli/runtime/defaultAgents';
 import * as logSinks from '@cli/runtime/logSinks';
 import type { ExecutionId } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas';
@@ -123,7 +122,6 @@ function expectChatDefaults(
 
 describe('CLI chat defaults', () => {
   it('uses assistant and DeepSeek as the built-in chat defaults', async () => {
-    expect(BUILTIN_DEFAULT_CHAT_AGENT).toBe('assistant');
     expect(CLI_BUILTIN_DEFAULT_MODEL).toBe('deepseekproT');
     expect(MODEL_CONFIGS[CLI_BUILTIN_DEFAULT_MODEL]).toBeDefined();
 

--- a/src/test-kernel/cli/DefaultAgents.vitest.ts
+++ b/src/test-kernel/cli/DefaultAgents.vitest.ts
@@ -1,19 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  BUILTIN_DEFAULT_CHAT_AGENT,
-  pickDefaultToolUseAgent,
-} from '@cli/runtime/defaultAgents';
+import { pickDefaultToolUseAgent } from '@cli/runtime/defaultAgents';
 import {
   implicitDefaultToolUseAgents,
   isImplicitDefaultEligible,
 } from '@shared/constants/agents';
 
 describe('CLI implicit default agent policy', () => {
-  it('uses assistant as the built-in default chat agent', () => {
-    expect(BUILTIN_DEFAULT_CHAT_AGENT).toBe('assistant');
-  });
-
   it('filters implicit default candidates without mutating explicit options', () => {
     const candidates = [
       { name: 'simplifier', source: 'built-in' },

--- a/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
+++ b/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
@@ -5,7 +5,6 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   EXTENSION_COMMAND_HANDLERS,
   EXTENSION_INTERNAL_COMMAND_IDS,
-  EXTENSION_REGISTRY_CATALOG_COMMAND_IDS,
   type ExtensionCommandActions,
   type ExtensionRegistryCommandId,
 } from '@commands/extensionCommandHandlers';
@@ -19,6 +18,13 @@ import { dispatchCommandFromRegistry } from '@shared/commands/registry';
 // the production handler map is exercised directly here. Only
 // `extensionCommandSurface.ts`, which wires the real actions against VS Code
 // APIs, needs the extension host.
+
+// Catalog ids tagged `extensionRegistry: true`, derived here rather than
+// mirrored in production: `EXTENSION_COMMAND_HANDLERS` already `satisfies`
+// `Record<ExtensionRegistryCommandId, ...>` at compile time.
+const catalogRegistryIds = (commandCatalog as readonly CommandCatalogEntry[])
+  .filter((entry) => entry.extensionRegistry === true)
+  .map((entry) => entry.id);
 
 function asyncNoop() {
   return vi.fn().mockResolvedValue(undefined);
@@ -86,7 +92,7 @@ describe('extension command registry — catalog-driven registration', () => {
   it('registers exactly the catalog ids tagged extensionRegistry, plus hidden aliases', () => {
     const registered = Object.keys(EXTENSION_COMMAND_HANDLERS).sort();
     const expected = [
-      ...EXTENSION_REGISTRY_CATALOG_COMMAND_IDS,
+      ...catalogRegistryIds,
       ...EXTENSION_INTERNAL_COMMAND_IDS,
     ].sort();
     expect(registered).toEqual(expected);
@@ -97,11 +103,7 @@ describe('extension command registry — catalog-driven registration', () => {
     // future catalog entry is tagged `extensionRegistry: true` without a
     // matching handler, the id set comparison must fail rather than
     // silently pass.
-    const taggedIds = new Set(
-      (commandCatalog as readonly CommandCatalogEntry[])
-        .filter((entry) => entry.extensionRegistry === true)
-        .map((entry) => entry.id),
-    );
+    const taggedIds = new Set(catalogRegistryIds);
     const registeredIds = new Set(Object.keys(EXTENSION_COMMAND_HANDLERS));
     for (const id of taggedIds) {
       expect(registeredIds.has(id)).toBe(true);

--- a/src/test-kernel/controllers/SettingsProfileKeyController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsProfileKeyController.vitest.ts
@@ -167,8 +167,8 @@ describe('SettingsProfileKeyController', () => {
     );
   });
 
-  it('does nothing when committing an empty provider key', async () => {
-    const { controller, secrets, refreshCount, hosts } =
+  it('reports an empty provider key instead of storing it', async () => {
+    const { controller, secrets, failures, refreshCount, hosts } =
       await createController();
 
     await controller.commitProviderKey('openai', '');
@@ -176,6 +176,7 @@ describe('SettingsProfileKeyController', () => {
     assert.equal(await secrets.get('apiKey.openai'), undefined);
     assert.equal(refreshCount(), 0);
     assert.equal(hosts.prompt.messages.length, 0);
+    assert.match(failures[0] ?? '', /empty/);
   });
 
   it('opens provider key URLs when configured', async () => {


### PR DESCRIPTION
Lane `M7-cli` of the [2026-08-26 cross-file simplification survey](https://github.com/texra-ai/coauthor/pull/11432) — CLI.

Every item below was proposed by a surveyor, then independently verified by an adversarial reviewer whose default was REFUTED. The verifier corrections are recorded in the survey doc and governed the implementation; where a correction cut or reshaped an item, that is noted.

## What this deletes

- _(skipped)_ **Retire two production surfaces that exist only to let a test restate a fact, plus a triplicated scanner self-check** — -42 LoC, -2 elements.
- _(skipped)_ **Serialize the CLI's NDJSON stdout sink with p-queue instead of the hand-rolled drain latch** — -22 LoC, -2 elements.
- _(skipped)_ **Let storeCredential own the placeholder/empty-credential messages instead of restating them at five call sites in three hosts** — -2 LoC, -2 elements.

## Deliberately not done

- **Item 1(c): delete two of the three expectRealCoverage(ALL_HOST_PRODUCTION_ROOTS) self-checks** — Verifier correction 9 documents that this exact triplication was already examined and deliberately preserved by d7582075cb (the shared body was hoisted into repoScan.ts, the three call sites knowingly kept), and correction 12 notes the trade converts a per-file vacuity self-check into an implicit cross-file dependency (a progressEventHandlerRetirement scanner regression would only surface from approvalPolicyAuthorityRatchet's failure). For -10 LoC of test code against a prior deliberate decision, the verifier's own recommendation was to ship (a)+(b) and drop (c). The three architecture vitest files are untouched.

## Net elements (R6)

| Metric | Delta |
| --- | --- |
| Files changed | 14 |
| `^[+-]export` symbols | +0 / -2 (net -2) |
| class/interface/enum/type declarations | +0 / -0 (net 0) |
| Net LoC (`git diff --stat origin/main`) | +70 / -113 (net -43) |

## Consumer counts (R8)

Grepped before each deletion across `src/`, `packages/*/src`, `packages/extension/resources/`, `prompts/`, `supabase/functions/`, `packages/extension/package.json` contributions, `packages/extension/src/commands.ts`, and the settings schemas. Per-symbol counts are recorded in the survey doc under each candidate's **Evidence** block; the deletions in this PR all had **zero** production consumers except where an item explicitly rewires a call site (noted in its evidence).

`config/ratchets/knip-baseline.json`: 2 row(s) removed. The baseline shrinks; it never grows.

## Validation

- `npm run typecheck` (all six projects) — clean
- `npm run lint` — clean
- `npm run check:dead-code-ratchet` — no new findings
- `npm test` — full suite green
- `npm run format` applied

Validated on this branch in isolation, not only in the integration merge, so this PR does not depend on a sibling lane.

## Risk notes

<details><summary>Implementer notes carried forward</summary>

Nothing was type-checked, linted, formatted, or run: this worktree has no node_modules, so every check below is central-validator work. Pushed with --no-verify (the pre-push hook fails on "Desktop renderer TS errors" for the same reason).

1. Item 2 (packages/cli/src/runtime/logSinks.ts) is the highest-risk change: it rewrites the module that produces the frozen `--output-format ndjson`/`json` stdout contract that texra-ai/texra-action parses. Please run `src/test-kernel/cli/LogSinks.vitest.ts` (unmodified — it is the #7793 regression suite) AND `pnpm --filter @texra-ai/cli validate:run` for byte parity. I verified by reading p-queue@9.3.3's dist that `add()` starts the task synchronously (`#tryToStartAnother` -> `job()` inside the Promise executor), which is what keeps the "preserves order across logger and public-record writes" test from hanging: the drain listener must be registered before the test's synchronous `emit('drain')`. If a future p-queue bump defers that, that test times out rather than fails loudly. Also note `queue.clear()` leaves dropped tasks' `add()` promises permanently unsettled (verifier correction 10); they are `void`ed with a `.catch`, so no unhandled rejection, but it is a real difference from `queue.length = 0`.

2. Item 3 is a deliberate user-visible behavior change, not a pure dedup: dropping the per-caller `emptyMessage` makes `storeCredential`'s boolean return dead, so an empty credential now throws on every host instead of silently returning false on the extension/desktop provider paths and the two GitHub-token paths. Blast radius per the verifier: desktop -> `createCommandHandler`'s `result.catch(reportAsyncError)`, extension -> `withHandlerErrorHandling`, controller -> `run()`'s catch -> `reportFailure`. No unhandled rejections, but three surfaces gain an error toast where they previously did nothing. `src/test-kernel/controllers/SettingsProfileKeyController.vitest.ts`'s "does nothing when committing an empty provider key" was renamed to "reports an empty provider key instead of storing it" with one added `assert.match(failures[0], /empty/)`; its other assertions were already compatible. `src/test-kernel/cli/SaveProviderApiKey.vitest.ts` was NOT touched — its `toThrow('empty')` / `toThrow('placeholder')` substrings all still match the new copy ("Anthropic API key is empty.", "This looks like a placeholder rather than a ...").

3. Item 3 also gives `packages/cli/src/runtime/providerApiKey.ts` a new import of `providerDisplayName` from `@shared/constants/providers` (precedent: `packages/cli/src/runtime/apiStatus.ts:10`). It fixes the CLI's raw-id wording ("a openRouter API key" -> "a OpenRouter API key", "kimiCode" -> "Kimi Code"). `storeCredential` never calls `providerDisplayName` itself — the label stays caller-supplied so `SettingsProfileKeyController`'s region-aware `getProviderDisplayName` is not silently dropped (verifier correction 8).

4. Item 3 is a strict subset of the still-open, maintainer-ruling-gated `SettingsCredentialActions` row in docs/proposals/2026-08-15-shared-contracts-and-retirement.md §2.5. Declared in the commit body; flagging it here so the integrator can drop the item if that ruling lands against it.

5. I did NOT take the verifier's optional suggestion (correction 6) to fold `@utils/text/credentialPlaceholder` into `storeCredential.ts` for another ~-4 LoC: it would require decrementing the browser-safe module count in both CLAUDE.md and AGENTS.md, which `scripts/check-browser-safe-utils.mjs` parses. That is cross-cutting churn outside this lane.

6. Formatting was not run. Two spots are the most likely prettier diffs: the hoisted `catalogRegistryIds` member chain in `src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts` (head line is 76 chars, so it should be stable) and `void this.queue.add(...).catch(...)` in logSinks.ts (75 chars). Per the verifier I deliberately did NOT demote the `commandCatalog` import in `extensionCommandHandlers.ts` to `import type` — it is still consumed by `typeof commandCatalog` at the `ExtensionRegistryCatalogEntry` declaration, and `consistent-type-imports` is not configured.

7. knip-baseline.json went 394 -> 392 findings; both removed rows (`packages/cli/src/runtime/defaultAgents.ts` / `BUILTIN_DEFAULT_CHAT_AGENT` and `packages/extension/src/commands/extensionCommandHandlers.ts` / `EXTENSION_REGISTRY_CATALOG_COMMAND_IDS`) were found and deleted exactly; the file still parses as JSON. No rows were added.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)