### PR TITLE
chore: bump llm-zoo to 1.31.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "katex": "^0.18.4",
     "ky": "^2.0.2",
     "lit": "^3.3.3",
-    "llm-zoo": "^1.30.0",
+    "llm-zoo": "^1.31.0",
     "lru-cache": "^11.5.2",
     "markdown-it": "^15.0.0",
     "markdown-it-texmath": "^1.0.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -81,7 +81,7 @@
     "is-network-error": "^1.3.2",
     "is-wsl": "^3.1.1",
     "ky": "^2.0.2",
-    "llm-zoo": "^1.30.0",
+    "llm-zoo": "^1.31.0",
     "lru-cache": "^11.5.2",
     "mime-types": "^3.0.1",
     "nanoid": "^6.0.1",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1083,7 +1083,7 @@
     "identifiers-arxiv": "^0.1.1",
     "katex": "^0.18.4",
     "lit": "^3.3.3",
-    "llm-zoo": "^1.30.0",
+    "llm-zoo": "^1.31.0",
     "lru-cache": "^11.5.2",
     "markdown-it": "^15.0.0",
     "markdown-it-texmath": "^1.0.0",

--- a/packages/trace-viewer/package.json
+++ b/packages/trace-viewer/package.json
@@ -24,7 +24,7 @@
     "highlightjs-lean": "^1.2.0",
     "katex": "^0.18.4",
     "lit": "^3.3.3",
-    "llm-zoo": "^1.30.0",
+    "llm-zoo": "^1.31.0",
     "lru-cache": "^11.5.2",
     "markdown-it": "^15.0.0",
     "markdown-it-texmath": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,8 +157,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       llm-zoo:
-        specifier: ^1.30.0
-        version: 1.30.0(zod@4.4.3)
+        specifier: ^1.31.0
+        version: 1.31.0(zod@4.4.3)
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2
@@ -503,8 +503,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       llm-zoo:
-        specifier: ^1.30.0
-        version: 1.30.0(zod@4.4.3)
+        specifier: ^1.31.0
+        version: 1.31.0(zod@4.4.3)
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2
@@ -878,8 +878,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       llm-zoo:
-        specifier: ^1.30.0
-        version: 1.30.0(zod@4.4.3)
+        specifier: ^1.31.0
+        version: 1.31.0(zod@4.4.3)
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2
@@ -1083,8 +1083,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       llm-zoo:
-        specifier: ^1.30.0
-        version: 1.30.0(zod@4.4.3)
+        specifier: ^1.31.0
+        version: 1.31.0(zod@4.4.3)
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2
@@ -5045,8 +5045,8 @@ packages:
   lit@3.3.3:
     resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
 
-  llm-zoo@1.30.0:
-    resolution: {integrity: sha512-H7dkb6+qSPEbuH/B/Q5QH0HcI+ibSXpKeXY/cik7dpkuxwS4taJBZs6E0/mqNHSddfqRKlzbcy1mvOdwtqMBtQ==}
+  llm-zoo@1.31.0:
+    resolution: {integrity: sha512-dYAuFBgFN7bw1B12su1XyUFwSM13loI1Np1HKjS9YNVYiu8dV2lHia7C63MwZrZZkMVnDhIfjUspRcNB0vHfJA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
@@ -10924,7 +10924,7 @@ snapshots:
       lit-element: 4.2.2
       lit-html: 3.3.2
 
-  llm-zoo@1.30.0(zod@4.4.3):
+  llm-zoo@1.31.0(zod@4.4.3):
     optionalDependencies:
       zod: 4.4.3
 

--- a/src/agent/modelHandlers/anthropic/anthropicThinking.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicThinking.ts
@@ -102,7 +102,10 @@ export const requiresNoTemperatureWithThinking = (fullName: string): boolean =>
   );
 
 type AnthropicEffort = NonNullable<BetaOutputConfig['effort']>;
-type AnthropicReasoningEffort = Exclude<ReasoningEffort, ReasoningEffort.NONE>;
+type AnthropicReasoningEffort = Exclude<
+  ReasoningEffort,
+  ReasoningEffort.NONE | ReasoningEffort.MINIMAL
+>;
 
 const ANTHROPIC_EFFORT_ORDER: readonly AnthropicReasoningEffort[] = [
   ReasoningEffort.LOW,
@@ -122,7 +125,8 @@ export function normalizeAnthropicEffort(
   reasoningEffort: ReasoningEffort | null,
 ): AnthropicEffort {
   const requested =
-    reasoningEffort === ReasoningEffort.NONE
+    reasoningEffort === ReasoningEffort.NONE ||
+    reasoningEffort === ReasoningEffort.MINIMAL
       ? ReasoningEffort.LOW
       : (reasoningEffort ?? ReasoningEffort.HIGH);
 

--- a/src/agent/modelHandlers/support/reasoningEffort.ts
+++ b/src/agent/modelHandlers/support/reasoningEffort.ts
@@ -76,6 +76,8 @@ export function toOpenAIReasoningEffort(
     case ReasoningEffort.NONE:
     case ReasoningEffort.LOW:
       return 'low';
+    case ReasoningEffort.MINIMAL:
+      return 'minimal';
     case ReasoningEffort.MEDIUM:
       return 'medium';
     case ReasoningEffort.HIGH:

--- a/supabase/functions/log-usage/deno.json
+++ b/supabase/functions/log-usage/deno.json
@@ -1,7 +1,7 @@
 {
   "imports": {
     "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.111.0",
-    "llm-zoo": "npm:llm-zoo@^1.30.0",
+    "llm-zoo": "npm:llm-zoo@^1.31.0",
     "zod": "npm:zod@^4.4.3"
   }
 }

--- a/supabase/functions/log-usage/equivalentCost_test.ts
+++ b/supabase/functions/log-usage/equivalentCost_test.ts
@@ -2,7 +2,7 @@ import { equal } from 'node:assert/strict';
 
 import { equivalentListCost } from './equivalentCost.ts';
 
-// gpt-5.6-sol list price in llm-zoo@1.30.0: $4/M input, $20/M output,
+// gpt-5.6-sol list price in llm-zoo@1.31.0: $4/M input, $20/M output,
 // cache discount 0.1. The fast-tier registry entry for the same model id
 // ($8/$40) must not be selected.
 Deno.test('prices a known model at standard-tier list price', () => {


### PR DESCRIPTION
## Summary

- bump all TeXRA and active Supabase `llm-zoo` dependencies from 1.30.0 to 1.31.0
- add compatibility for the additive `ReasoningEffort.MINIMAL` value
- make native GLM request and compaction reasoning follow each model’s exact registry vocabulary
- keep forced thinking enabled for GLM-5.3 and GLM-5.3-Flash compaction
- expose only each model’s supported effort levels in Settings, including `minimal`
- normalize OpenRouter effort against exact model vocabularies and preserve `none` where supported
- preserve and replay OpenRouter `reasoningDetails` exactly once across tool follow-ups
- feature `glm53flash` alongside `glm53` in the preferred model list
- synchronize the Supabase Deno lockfile

This picks up GLM-5.3-Flash and corrected GLM capability metadata from texra-ai/llm-zoo#55.

## Compatibility details

- Anthropic does not accept `minimal`, so TeXRA floors it to `low` there.
- OpenAI accepts `minimal`, so TeXRA preserves it.
- GLM-5.3/Flash accept `low`, `high`, and `max`; thinking cannot be disabled.
- GLM-5.2 accepts `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`; `none`/`minimal` disable thinking without sending an incompatible effort parameter.

## Verification

- `pnpm run typecheck` — 723 declarations and 70 external packages validated
- focused GLM/OpenRouter/settings/model-list suites — 8 files, 134 tests passed
- ESLint on changed production files
- Prettier on changed supported files
- Deno lock JSON validation
- `git diff --check`

Deno itself is unavailable locally, so the Supabase Deno test was not executed. The lockfile was synchronized to the npm 1.31.0 package integrity already resolved by pnpm.
