### PR TITLE
test(progress-view): restore durable boundary coverage

### DIFF
--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -197,6 +197,90 @@ function expectDispatched(
   expect(dispatchProgressViewInbound(message, handlers)).toBe(true);
 }
 
+function expectMessageParses(message: unknown, valid: boolean): void {
+  expect(ProgressViewInboundMessageSchema.safeParse(message).success).toBe(
+    valid,
+  );
+}
+
+describe('createProgressViewCommandHandlers - workflow file actions', () => {
+  it('routes workflow file commands to their host actions', () => {
+    const actions = createActions();
+    const handlers = createProgressViewCommandHandlers(actions);
+
+    expectDispatched(
+      { command: PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE, stream: 'stream-a' },
+      handlers,
+    );
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL,
+        file: 'edited.tex',
+        base: 'paper.tex',
+      },
+      handlers,
+    );
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.COMPARE_PREVIOUS,
+        file: 'edited.tex',
+        base: 'paper.tex',
+        prev: 'previous.tex',
+      },
+      handlers,
+    );
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.ACCEPT_FILE,
+        file: 'edited.tex',
+        base: 'paper.tex',
+      },
+      handlers,
+    );
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.MERGE_FILE,
+        file: 'edited.tex',
+        base: 'paper.tex',
+      },
+      handlers,
+    );
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE,
+        file: 'edited.tex',
+        base: 'paper.tex',
+      },
+      handlers,
+    );
+
+    expect(actions.workflowFileActions.openTaskStorage).toHaveBeenCalledWith(
+      'stream-a',
+    );
+    expect(actions.workflowFileActions.compareOriginal).toHaveBeenCalledWith(
+      'edited.tex',
+      'paper.tex',
+    );
+    expect(actions.workflowFileActions.comparePrevious).toHaveBeenCalledWith(
+      'edited.tex',
+      'paper.tex',
+      'previous.tex',
+    );
+    expect(actions.workflowFileActions.acceptFile).toHaveBeenCalledWith(
+      'edited.tex',
+      'paper.tex',
+    );
+    expect(actions.workflowFileActions.mergeFile).toHaveBeenCalledWith(
+      'edited.tex',
+      'paper.tex',
+    );
+    expect(actions.workflowFileActions.latexdiffFile).toHaveBeenCalledWith(
+      'edited.tex',
+      'paper.tex',
+    );
+  });
+});
+
 describe('createProgressViewCommandHandlers - follow-up', () => {
   beforeEach(() => {
     savePastedImageBase64Mock.mockReset();
@@ -399,6 +483,16 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
       expect(showInfo).toHaveBeenCalledWith(notice);
     },
   );
+
+  it('rejects a bypass enable that does not name its kind', () => {
+    expectMessageParses(
+      {
+        command: PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS,
+        stream: 'stream:no-kind',
+      },
+      false,
+    );
+  });
 
   it('leaves an existing grant of its own kind untouched', async () => {
     // Set-on, never toggle: the header toggle or delegated inheritance can
@@ -631,6 +725,100 @@ describe('createProgressViewCommandHandlers - approvals', () => {
   });
 });
 
+describe('permission action schemas', () => {
+  const tool = {
+    command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+    requestId: 'edit-1',
+  };
+  const bash = {
+    command: PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION,
+    requestId: 'bash-1',
+  };
+  const proposal = {
+    command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+    requestId: 'proposal-1',
+  };
+  const plan = {
+    command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
+    requestId: 'plan-1',
+  };
+
+  it.each([
+    ['tool approve', { ...tool, action: 'approve' }, true],
+    ['tool reject', { ...tool, action: 'reject', feedback: 'No' }, true],
+    ['tool open diff', { ...tool, action: 'openDiff' }, true],
+    ['tool show latexdiff', { ...tool, action: 'showLatexdiff' }, true],
+    ['tool preview proposed', { ...tool, action: 'previewProposed' }, true],
+    [
+      'tool approve with feedback',
+      { ...tool, action: 'approve', feedback: 'x' },
+      false,
+    ],
+    [
+      'tool inspection with feedback',
+      { ...tool, action: 'openDiff', feedback: 'x' },
+      false,
+    ],
+    ['tool unknown field', { ...tool, action: 'approve', extra: true }, false],
+    ['bash approve', { ...bash, action: 'approve' }, true],
+    ['bash reject', { ...bash, action: 'reject', feedback: 'No' }, true],
+    ['bash tool action', { ...bash, action: 'openDiff' }, false],
+    [
+      'bash approve with feedback',
+      { ...bash, action: 'approve', feedback: 'x' },
+      false,
+    ],
+    ['bash unknown field', { ...bash, action: 'reject', extra: true }, false],
+    [
+      'proposal approve',
+      { ...proposal, action: 'approve', model: 'm', agent: 'a' },
+      true,
+    ],
+    [
+      'proposal reject',
+      { ...proposal, action: 'reject', feedback: 'No' },
+      true,
+    ],
+    ['proposal setup', { ...proposal, action: 'setup' }, true],
+    [
+      'proposal approve with feedback',
+      { ...proposal, action: 'approve', feedback: 'x' },
+      false,
+    ],
+    [
+      'proposal reject with model',
+      { ...proposal, action: 'reject', model: 'm' },
+      false,
+    ],
+    [
+      'proposal setup with agent',
+      { ...proposal, action: 'setup', agent: 'a' },
+      false,
+    ],
+    [
+      'proposal unknown field',
+      { ...proposal, action: 'setup', extra: true },
+      false,
+    ],
+    ['plan approve', { ...plan, action: 'approve' }, true],
+    ['plan approve and run', { ...plan, action: 'approve_and_goal' }, true],
+    ['plan reject', { ...plan, action: 'reject', feedback: 'No' }, true],
+    [
+      'plan approve with feedback',
+      { ...plan, action: 'approve', feedback: 'x' },
+      false,
+    ],
+    [
+      'plan run with feedback',
+      { ...plan, action: 'approve_and_goal', feedback: 'x' },
+      false,
+    ],
+    ['plan unknown field', { ...plan, action: 'reject', extra: true }, false],
+  ])('%s parses as %s', (_name, message, valid) => {
+    expectMessageParses(message, valid);
+  });
+});
+
 describe('external inquiry action schema', () => {
   const command = PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION;
   const threadId = 'ei_123456789abc';
@@ -638,6 +826,28 @@ describe('external inquiry action schema', () => {
   beforeEach(() => {
     externalInquiryMocks.continueExternalInquiryAction.mockReset();
     externalInquiryMocks.persistExternalInquiryAction.mockReset();
+  });
+
+  it.each([
+    [
+      'submit with an answer',
+      { command, action: 'submit', threadId, answer: 'Confirmed' },
+      true,
+    ],
+    ['drop', { command, action: 'drop', threadId }, true],
+    [
+      'draft with a null draft',
+      { command, action: 'draft', threadId, draft: null },
+      true,
+    ],
+    [
+      'submit without an answer',
+      { command, action: 'submit', threadId },
+      false,
+    ],
+    ['draft without a draft', { command, action: 'draft', threadId }, false],
+  ])('%s parses as %s', (_name, message, valid) => {
+    expectMessageParses(message, valid);
   });
 
   it.each([
@@ -683,6 +893,72 @@ describe('external inquiry action schema', () => {
       ).toHaveBeenCalledWith(transition, actions.externalInquiry);
     },
   );
+});
+
+describe('user question action schema', () => {
+  const command = PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION;
+  const requestId = 'question-1';
+
+  it.each([
+    {
+      name: 'submit with answers',
+      message: {
+        command,
+        requestId,
+        action: 'submit',
+        answers: { choice: 'A' },
+      },
+      valid: true,
+    },
+    {
+      name: 'reject with feedback',
+      message: { command, requestId, action: 'reject', feedback: 'Not now' },
+      valid: true,
+    },
+    {
+      name: 'skip without feedback',
+      message: { command, requestId, action: 'skip' },
+      valid: true,
+    },
+    {
+      name: 'submit without answers',
+      message: { command, requestId, action: 'submit' },
+      valid: false,
+    },
+    {
+      name: 'submit with rejection feedback',
+      message: {
+        command,
+        requestId,
+        action: 'submit',
+        answers: { choice: 'A' },
+        feedback: 'contradictory',
+      },
+      valid: false,
+    },
+    {
+      name: 'reject with answers',
+      message: {
+        command,
+        requestId,
+        action: 'reject',
+        answers: { choice: 'A' },
+      },
+      valid: false,
+    },
+    {
+      name: 'skip with answers',
+      message: {
+        command,
+        requestId,
+        action: 'skip',
+        answers: { choice: 'A' },
+      },
+      valid: false,
+    },
+  ])('$name is $valid', ({ message, valid }) => {
+    expectMessageParses(message, valid);
+  });
 });
 
 describe('createProgressViewSecondTierHandlers', () => {


### PR DESCRIPTION
## Summary

Follow-up to #11471. That merged test-budget PR inadvertently removed durable coverage at the webview-to-host boundary.

- Restores the runtime `ProgressViewInboundMessageSchema` assertions for approval, external-inquiry, user-question, and missing bypass-kind messages.
- Restores focused command-to-controller and argument-mapping coverage for workflow file actions.

No production code changes.

## Validation

- `npm exec -- vitest run --config vitest.config.mjs src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts src/test-kernel/webview/InstructionPanel.vitest.ts src/test-kernel/webview/MainViewActions.vitest.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run check:dead-code-ratchet`
- `npm test` (826 files passed, 1 skipped; 10,108 tests passed, 6 skipped)