### PR TITLE
refactor(runtime): finish the storage-transition cleanup the round-3 collapses left behind

### DIFF
--- a/config/ratchets/store-public-surface-baseline.json
+++ b/config/ratchets/store-public-surface-baseline.json
@@ -24,7 +24,6 @@
       "openReadOnlyForStream",
       "readEntries",
       "recordSummaryMeta",
-      "reload",
       "requestEviction"
     ],
     "StreamSnapshotStore": [

--- a/docs/proposals/2026-08-16-define-out-of-existence.md
+++ b/docs/proposals/2026-08-16-define-out-of-existence.md
@@ -297,7 +297,9 @@ lease exclusivity is proven airtight), startup double abort-check,
 error-classification arm (external producer shapes). **Refuted-as-deletable
 and stays:** `ModelCell` retirement guards (reachable via `/model` racing
 a child-result wake into a WAITING parent), `storageGeneration` (it IS the
-per-pass cancellation token; supersede lands mid-await),
+per-pass cancellation token; supersede lands mid-await — ruling retired
+2026-08-26: #11452 deleted the only supersede writer, so the field was
+removed and the teardown abort signal is the remaining cancellation token),
 the CLI interrupted-follow-up shadow buffer (the dying flow still owns the
 durable queue's lease — some holding pen must exist), the onboarding
 funnel's edge-trigger (protects a user choice from level-triggered

--- a/docs/proposals/2026-08-16-overdefensive-top10.md
+++ b/docs/proposals/2026-08-16-overdefensive-top10.md
@@ -462,7 +462,8 @@ grow, don't remove), and the OpenAI-compat `.nullish()` /
 `?? undefined` normalizations (98); and **(iii) the fenced
 irreducibility registers** — lease/crash-repair machinery, the
 `inBandSubagentExecution.ts:529` manifest read-back, auth credential
-cells, ModelCell, storageGeneration, the interrupted-follow-up buffer
+cells, ModelCell, storageGeneration (since removed: #11452 deleted its
+only supersede writer), the interrupted-follow-up buffer
 (`ToolUseFollowUpQueueManager.ts:83,364`), onboarding funnel,
 round-update reset, `workflowExecutionState` sealed-guard silent
 returns (documented late-async-publication tolerance — watch, don't

--- a/packages/cli/src/runtime/cliStateStores.ts
+++ b/packages/cli/src/runtime/cliStateStores.ts
@@ -13,7 +13,7 @@ interface CliStateStores {
 
 interface CliStateStoresInit {
   readonly storageRoot?: string;
-  readonly workspacePath: string | (() => string | undefined);
+  readonly workspacePath: string | undefined;
 }
 
 /** Open the CLI's global `state.json` under the given storage provider. This

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -239,7 +239,7 @@ export async function initCliPlatform(
   if (!tryPlatform()) {
     const stateStores = await createCliStateStores({
       storageRoot: context.storageRoot,
-      workspacePath: () => cliWorkspaceCwd,
+      workspacePath: context.cwd,
     });
     // The project `.texra/config.json` backs the workspace target and
     // user-level config (`~/.texra/global-storage/config.json`, the same file

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -268,7 +268,7 @@ async function activateExtension(context: vscode.ExtensionContext) {
   // Shared `~/.texra` storage root (one history across CLI/desktop/extension,
   // #8622).
   const storage = createNodeStorageProvider({
-    workspacePath: () => workspace.getWorkspacePath(),
+    workspacePath: workspace.getWorkspacePath(),
   });
   const config = await createExtensionTexraConfig(
     storage,
@@ -726,9 +726,9 @@ async function activateExtension(context: vscode.ExtensionContext) {
   // Paint the policy line immediately; otherwise the tooltip shows the
   // generic "Show TeXRA Tasks" text until the first status/usage event.
   updateStatusBarTooltip();
-  // Workspace transitions and approval-policy setting updates emit on this
-  // signal; the subscription here is what makes the refresh reachable, so a
-  // missed subscribe is a missing behavior rather than a silent no-op.
+  // Approval-policy setting updates emit on this signal; the subscription
+  // here is what makes the refresh reachable, so a missed subscribe is a
+  // missing behavior rather than a silent no-op.
   const disposeApprovalPolicyTooltipRefresh = appSignals.on(
     'approvalPolicyChanged',
     updateStatusBarTooltip,

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -177,8 +177,8 @@ function admitFollowUp(
 /**
  * The execution a stream currently belongs to. Prefer the resident snapshot
  * record for a live session: `run.start` updates it synchronously. A stream
- * whose run metadata is not resident (after a host restart, or evicted by a
- * storage-root change) resolves through the authored `meta.streamId` index.
+ * whose run metadata is not resident (after a host restart, or evicted from
+ * the snapshot store) resolves through the authored `meta.streamId` index.
  */
 export async function lookupStreamExecutionId(
   streamId: StreamTabId,

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -30,7 +30,6 @@
  */
 
 import pDefer, { type DeferredPromise } from 'p-defer';
-import PQueue from 'p-queue';
 
 import type { AgentEvent, AgentTrace, ResultEvent } from '@agent/trace';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
@@ -154,9 +153,7 @@ export class SessionHandle {
    */
   readonly workflowControls: WorkflowControlRegistry;
   private restartRepairPromise: Promise<unknown> | undefined;
-  private readonly restartRepairQueue = new PQueue({ concurrency: 1 });
   private readonly restartRepairAbort = new AbortController();
-  private storageGeneration = 0;
   /** LIFO owner for the session's constructor-registered teardown. */
   private readonly teardown = new DisposableStore();
   constructor(init: SessionHandleInit) {
@@ -267,43 +264,32 @@ export class SessionHandle {
     return this.ensureRestartRepair().then(() => undefined);
   }
 
-  private enqueueRestartRepair<T>(work: () => Promise<T>): Promise<T> {
-    // `add` widens to `T | void` for abort/timeout options; neither is used.
-    return this.restartRepairQueue.add(work) as Promise<T>;
-  }
-
   /**
-   * Start the restart-repair pass for the current storage generation, or reuse
-   * the in-flight one. Shared by the constructor and {@link waitUntilReady}.
+   * Start the single restart-repair pass, or reuse the in-flight one. Shared
+   * by the constructor and {@link waitUntilReady}; the memoized promise is
+   * the single-flight guard.
    */
   private ensureRestartRepair(): Promise<unknown> {
     if (!this.restartRepairPromise) {
-      this.restartRepairPromise = this.enqueueRestartRepair(() =>
-        this.repairStoresAfterRestart(this.storageGeneration),
-      );
+      this.restartRepairPromise = this.repairStoresAfterRestart();
     }
     return this.restartRepairPromise;
   }
 
   /**
-   * Whether a repair pass started for `generation` may no longer mutate: a
-   * later storage generation owns the stores, or session teardown aborted
-   * repair. Both reads are pure, so every checkpoint below re-reads them.
+   * Whether the repair pass may no longer mutate: session teardown aborted
+   * repair. The read is pure, so every checkpoint below re-reads it.
    */
-  private isRepairSuperseded(generation: number): boolean {
-    return (
-      generation !== this.storageGeneration ||
-      this.restartRepairAbort.signal.aborted
-    );
+  private isRepairSuperseded(): boolean {
+    return this.restartRepairAbort.signal.aborted;
   }
 
-  private async repairStoresAfterRestart(generation: number): Promise<boolean> {
+  private async repairStoresAfterRestart(): Promise<boolean> {
     try {
-      if (this.restartRepairAbort.signal.aborted) return false;
-      if (generation !== this.storageGeneration) return false;
+      if (this.isRepairSuperseded()) return false;
       await this.snapshots.preload([...this.computeStartupSeedSet()]);
-      if (this.isRepairSuperseded(generation)) return false;
-      await this.runRestartRepair(generation);
+      if (this.isRepairSuperseded()) return false;
+      await this.runRestartRepair();
       return true;
     } catch (error) {
       logger.warn('Failed to repair session stores after restart', {
@@ -346,8 +332,8 @@ export class SessionHandle {
    * in-memory phases are facts about this registry, and startup never
    * remembers one for a run it does not own.
    */
-  private async runRestartRepair(generation: number): Promise<void> {
-    if (this.isRepairSuperseded(generation)) return;
+  private async runRestartRepair(): Promise<void> {
+    if (this.isRepairSuperseded()) return;
     const unfinished = new Set(this.transcripts.getUnfinishedStreamIds());
     const candidateSet = new Set(this.computeStartupSeedSet());
     // The scan reads the authoritative `meta.streamId` edge, so it also
@@ -384,7 +370,7 @@ export class SessionHandle {
         { data: error },
       );
     }
-    if (this.isRepairSuperseded(generation)) return;
+    if (this.isRepairSuperseded()) return;
     const candidates = [...candidateSet].filter(
       (streamId) =>
         this.transcripts.has(streamId) &&
@@ -444,7 +430,7 @@ export class SessionHandle {
         );
       }
     }
-    if (this.isRepairSuperseded(generation)) return;
+    if (this.isRepairSuperseded()) return;
     for (const [streamId, cause] of unreadableStreams) {
       if (
         this.status.getGeneration(streamId) ===

--- a/src/agent/runtime/streamApprovalQueue.ts
+++ b/src/agent/runtime/streamApprovalQueue.ts
@@ -42,8 +42,17 @@ export interface StreamApprovalBypass {
     enabled: boolean,
     options?: { silent?: boolean },
   ): void;
-  clearForStream(streamId: StreamTabId): void;
   clearAll(): void;
+}
+
+/**
+ * Internal bypass surface: adds per-stream value teardown, which only the
+ * ancestry owner (`forgetStreamAncestry`) may call — clearing a stream's
+ * explicit values before its children are promoted would silently revoke
+ * their inherited bypasses.
+ */
+interface StreamApprovalBypassState extends StreamApprovalBypass {
+  clearForStream(streamId: StreamTabId): void;
 }
 
 function createStreamApprovalBypass(
@@ -51,7 +60,7 @@ function createStreamApprovalBypass(
   interactions: Pick<SessionHostInteractions, 'setApprovalBypassState'>,
   resolveParent: (streamId: StreamTabId) => StreamTabId | undefined,
   resolveDescendants: (streamId: StreamTabId) => readonly StreamTabId[],
-): StreamApprovalBypass {
+): StreamApprovalBypassState {
   const byStream = new Map<StreamTabId, boolean>();
 
   function resolve(streamId: StreamTabId): boolean {
@@ -136,23 +145,10 @@ interface StreamApprovalController {
   ): Promise<T>;
 }
 
-interface StreamApprovalControllerOptions {
-  kind: ApprovalBypassKind;
-  interactions: Pick<SessionHostInteractions, 'setApprovalBypassState'>;
-  resolveParent: (streamId: StreamTabId) => StreamTabId | undefined;
-  resolveDescendants: (streamId: StreamTabId) => readonly StreamTabId[];
-}
-
 function createStreamApprovalController(
-  options: StreamApprovalControllerOptions,
+  bypass: StreamApprovalBypass,
 ): StreamApprovalController {
   const queues = new Map<StreamTabId | undefined, PQueue>();
-  const bypass = createStreamApprovalBypass(
-    options.kind,
-    options.interactions,
-    options.resolveParent,
-    options.resolveDescendants,
-  );
 
   return {
     bypass,
@@ -231,9 +227,10 @@ export interface SessionApprovals {
    */
   detachStreamFromParent(streamId: StreamTabId): void;
   /**
-   * Drop `streamId` from the ancestry graph. Direct children are first
-   * promoted through {@link detachStreamFromParent}, preserving their
-   * effective values before the torn-down parent's own values are cleared.
+   * Drop `streamId` from the ancestry graph and clear its explicit bypass
+   * values for every kind. Direct children are first promoted through
+   * {@link detachStreamFromParent}, preserving their effective values before
+   * the torn-down parent's own values are cleared.
    */
   forgetStreamAncestry(streamId: StreamTabId): void;
   /**
@@ -273,27 +270,29 @@ export function createSessionApprovals(
     return descendants;
   };
 
-  const toolEdit = createStreamApprovalController({
-    kind: 'toolEdit',
+  const toolEditBypass = createStreamApprovalBypass(
+    'toolEdit',
     interactions,
     resolveParent,
     resolveDescendants,
-  });
-  const bash = createStreamApprovalController({
-    kind: 'bash',
+  );
+  const bashBypass = createStreamApprovalBypass(
+    'bash',
     interactions,
     resolveParent,
     resolveDescendants,
-  });
+  );
+  const toolEdit = createStreamApprovalController(toolEditBypass);
+  const bash = createStreamApprovalController(bashBypass);
   const proposal = createStreamApprovalBypass(
     'superYolo',
     interactions,
     resolveParent,
     resolveDescendants,
   );
-  const bypasses: readonly StreamApprovalBypass[] = [
-    toolEdit.bypass,
-    bash.bypass,
+  const bypasses: readonly StreamApprovalBypassState[] = [
+    toolEditBypass,
+    bashBypass,
     proposal,
   ];
 
@@ -335,6 +334,10 @@ export function createSessionApprovals(
         .map(([child]) => child);
       for (const child of directChildren) detachStreamFromParent(child);
       parentOf.delete(streamId);
+      // Only after the children were promoted: clearing the parent's
+      // explicit values first would resolve an inherited bypass to `false`
+      // and silently revoke it.
+      for (const bypass of bypasses) bypass.clearForStream(streamId);
     },
     clearAll() {
       for (const bypass of bypasses) bypass.clearAll();

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -773,8 +773,8 @@ export class ProgressBackend {
   }
 
   /**
-   * Serialize operations whose filesystem work must observe one workspace
-   * root from beginning to end.
+   * Serialize storage operations against each other, so a deletion never
+   * interleaves with a concurrent load or another deletion.
    */
   private enqueueStorageOperation<T>(work: () => Promise<T>): Promise<T> {
     // `add` widens to `T | void` for abort/timeout options; neither is used,

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -572,7 +572,7 @@ export class SessionFactApplier {
    * Complete a command-owned removal once its host delete resolves. A retained
    * (`active`/`failed`) outcome retires the barrier and replays buffered facts;
    * a committed outcome discards the buffer; anything the command path reports
-   * as `undefined` (reserved id, no durable data, storage-root change) retires
+   * as `undefined` (reserved id, or the data directory cannot be used) retires
    * the barrier because nothing was deleted.
    */
   completeCommandRemoval(

--- a/src/platform/defaults/nodeStorage.ts
+++ b/src/platform/defaults/nodeStorage.ts
@@ -31,7 +31,7 @@ export function workspaceTexraConfigPath(workspaceRoot: string): string {
 
 interface NodeStorageProviderOptions {
   readonly storageRoot?: string;
-  readonly workspacePath?: string | (() => string | undefined);
+  readonly workspacePath?: string;
 }
 
 export function createNodeStorageProvider({

--- a/src/platform/defaults/workspaceStorage.ts
+++ b/src/platform/defaults/workspaceStorage.ts
@@ -25,8 +25,6 @@ const STORAGE_LAYOUT = {
 export const MEMORY_STORAGE_DIR = WORKSPACE_STORAGE_LAYOUT.memory;
 export const RUNS_STORAGE_DIR = WORKSPACE_STORAGE_LAYOUT.runs;
 
-type WorkspacePathSource = string | undefined | (() => string | undefined);
-
 function legacyWorkspaceStorageId(workspacePath: string | undefined): string {
   const source = workspacePath?.trim() || 'no-workspace';
   return truncatedHexId(source, 16);
@@ -169,10 +167,9 @@ export class WorkspaceStorageProvider implements StorageProvider {
 
   constructor(
     private readonly storageRoot: string,
-    workspacePath: WorkspacePathSource,
+    workspacePath: string | undefined,
   ) {
-    this.activeWorkspacePath =
-      typeof workspacePath === 'function' ? workspacePath() : workspacePath;
+    this.activeWorkspacePath = workspacePath;
   }
 
   private storagePathFor(workspacePath: string | undefined): string {

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -134,7 +134,6 @@ type TestableBridge = {
       close(): void;
     };
     requestEviction(streamId: StreamTabId): void;
-    reload(): Promise<void>;
     ensureLoaded(streamId: StreamTabId): Promise<void>;
     getUnfinishedStreamIds(): StreamTabId[];
     get(streamId: StreamTabId):
@@ -2759,7 +2758,6 @@ describe('DesktopProgressBridge', () => {
 
     await bridgeSession(bridge).flushArtifacts();
     bridge.streamLogs.requestEviction(streamId);
-    await bridge.streamLogs.reload();
     await bridge.streamLogs.ensureLoaded(streamId);
 
     expect(

--- a/src/test-kernel/platform/WorkspaceStorage.vitest.ts
+++ b/src/test-kernel/platform/WorkspaceStorage.vitest.ts
@@ -97,22 +97,6 @@ describe('workspace storage defaults', () => {
     },
   );
 
-  it('pins the workspace storage root at construction', async () => {
-    const root = await makeStorageRoot();
-    let workspacePath: string | undefined = '/workspace/a';
-    const provider = new WorkspaceStorageProvider(root, () => workspacePath);
-    const storagePath = provider.getStoragePath();
-
-    workspacePath = '/workspace/b';
-
-    expect(provider.getStoragePath()).toBe(storagePath);
-    expect(provider.getGlobalStoragePath()).toBe(join(root, 'global-storage'));
-    await expect(pathExists(storagePath)).resolves.toBe(true);
-    await expect(readWorkspaceMarker(storagePath)).resolves.toMatchObject({
-      path: '/workspace/a',
-    });
-  });
-
   it('migrates legacy hash-only workspace storage when possible', async () => {
     const root = await makeStorageRoot();
     const workspacePath = '/workspace/Legacy Project';

--- a/src/test-kernel/progressView/ProgressBackendPresentation.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendPresentation.vitest.ts
@@ -13,15 +13,15 @@ import {
 } from './progressBackendHarness';
 
 describe('ProgressBackend', () => {
-  it('loads a presentation without reloading its live transcript', async () => {
+  it('loads a presentation by waiting for the live transcript', async () => {
     const session = await createLiveStoreSession();
     const waitUntilReady = vi.spyOn(session, 'waitUntilReady');
-    const reload = vi.spyOn(session.transcripts, 'reload');
     const { backend } = createIsolatedRecordingBackend(session);
 
     await backend.load();
 
+    // The companion `reload` assertion retired with StreamLogStore.reload:
+    // a re-read is no longer expressible, so it cannot be asserted against.
     expect(waitUntilReady).toHaveBeenCalledOnce();
-    expect(reload).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -47,7 +47,6 @@ interface MockStorageOptions {
   onLogRead?: (key: string) => Promise<void> | void;
   onLogDelete?: (key: string) => Promise<void> | void;
   onLogWrite?: (key: string) => Promise<void> | void;
-  onSummaryWrite?: (key: string) => Promise<void> | void;
   pauseLogWriteKey?: string;
 }
 
@@ -219,7 +218,6 @@ function mockStorage({
   onLogRead,
   onLogDelete,
   onLogWrite,
-  onSummaryWrite,
   pauseLogWriteKey,
 }: MockStorageOptions): {
   deletes: string[];
@@ -309,9 +307,6 @@ function mockStorage({
     }
     if (areaOf(target) === 'log') {
       await onLogWrite?.(streamKeyFromFile(target));
-    }
-    if (areaOf(target) === 'summary') {
-      await onSummaryWrite?.(streamKeyFromFile(target));
     }
 
     const text =
@@ -874,81 +869,6 @@ describe('StreamLogStore load', () => {
       'StreamLogStore',
       expect.stringContaining('Failed to clear transcript summary cache'),
     );
-  });
-
-  it('preserves live state when a transactional reload fails', async () => {
-    const logs: Record<string, unknown> = {
-      alpha: [logEntry('alpha', 1, 100)],
-    };
-    mockStorage({
-      logs,
-      summaries: {
-        alpha: summary(100, 100, { hasRunningGroup: false }),
-      },
-    });
-    const store = await StreamLogStore.open();
-    await store.ensureLoaded('alpha');
-    const liveAlpha = store.get('alpha');
-    logs.beta = { corrupted: true };
-
-    await expect(store.reload()).rejects.toThrow(
-      'persisted log is not an array',
-    );
-
-    expect(store.keys()).toEqual(['alpha']);
-    expect(store.get('alpha')).toBe(liveAlpha);
-    expect(
-      store
-        .get('alpha')
-        ?.getRange(0)
-        .map((entry) => entry.id),
-    ).toEqual(['alpha-1']);
-    expect(store.getTimestampRange('alpha').first).toBe(100);
-    expect(store.has('beta')).toBe(false);
-  });
-
-  it('discards pending writes when restoring a previously flushed root', async () => {
-    const storage = mockStorage({
-      logs: {
-        alpha: [logEntry('alpha', 1, 100)],
-      },
-      summaries: {
-        alpha: summary(100, 100, { hasRunningGroup: false }),
-      },
-    });
-    const store = await StreamLogStore.open();
-    appendTranscriptEntry(
-      store,
-      'new-root-dirty',
-      logEntry('new-root-dirty', 1, 200),
-    );
-
-    await store.reload({ discardPendingWrites: true });
-
-    expect(store.keys()).toEqual(['alpha']);
-    expect(
-      [...storage.writes.keys()].some((target) =>
-        target.includes(encodeURIComponent('new-root-dirty')),
-      ),
-    ).toBe(false);
-  });
-
-  it('prepares transcript directories again after a storage-root reload', async () => {
-    const storage = mockStorage({ logs: {}, summaries: {} });
-    const store = await StreamLogStore.open();
-    appendTranscriptEntry(store, 'old-root', logEntry('old-root', 1, 100));
-    await store.flush();
-    const oldRootPreparations = storage.ensuredDirs.filter(
-      (dir) => dir === STREAM_LOGS_DIR,
-    ).length;
-
-    await store.reload();
-    appendTranscriptEntry(store, 'new-root', logEntry('new-root', 1, 200));
-    await store.flush();
-
-    expect(
-      storage.ensuredDirs.filter((dir) => dir === STREAM_LOGS_DIR),
-    ).toHaveLength(oldRootPreparations + 1);
   });
 
   it('uses stream summaries without reading full log files at startup', async () => {
@@ -1833,35 +1753,6 @@ describe('StreamLogStore save throttle', () => {
     expect(writtenLog(storage.writes, 'alpha')[0]?.text).toBe('first second');
   });
 
-  it('drains an in-flight write batch before a discarding reload', async () => {
-    const storage = mockStorage({
-      logs: {},
-      summaries: {},
-      pauseLogWriteKey: 'alpha',
-    });
-    const store = await StreamLogStore.open();
-    vi.useFakeTimers();
-
-    const writer = store.acquireWriter('alpha', 'execution-alpha');
-    writer.append(namedEntry('m1', 1, 'first'));
-    await vi.advanceTimersByTimeAsync(300);
-    await storage.waitForPausedWrite();
-
-    // A rollback reload must not resolve while a write batch is still
-    // running against the pre-rollback adapters.
-    let reloaded = false;
-    const reload = store.reload({ discardPendingWrites: true }).then(() => {
-      reloaded = true;
-    });
-    await vi.advanceTimersByTimeAsync(0);
-    expect(reloaded).toBe(false);
-
-    storage.releasePausedWrite();
-    await reload;
-    expect(reloaded).toBe(true);
-    writer.close();
-  });
-
   it('releases a writer that starts after terminal eviction once its flush is durable', async () => {
     mockStorage({
       logs: { alpha: [logEntry('alpha', 1, 100)] },
@@ -1992,96 +1883,6 @@ describe('StreamLogStore summary metadata mirror', () => {
       lastTimestamp: 300,
       meta: META,
     });
-  });
-
-  it('drains a queued metadata write before a discard-pending reload', async () => {
-    const summaryWriteStarted = createDeferred();
-    const releaseSummaryWrite = createDeferred();
-    mockStorage({
-      logs: { alpha: [logEntry('alpha', 1, 200)] },
-      summaries: { alpha: summary(200, 200) },
-      onSummaryWrite: async (streamId) => {
-        if (streamId !== 'alpha') return;
-        summaryWriteStarted.resolve();
-        await releaseSummaryWrite.promise;
-      },
-    });
-    const store = await StreamLogStore.open();
-
-    store.recordSummaryMeta('alpha', META);
-    await summaryWriteStarted.promise;
-
-    let reloaded = false;
-    const reload = store.reload({ discardPendingWrites: true }).then(() => {
-      reloaded = true;
-    });
-    await delay(0);
-    expect(reloaded).toBe(false);
-
-    releaseSummaryWrite.resolve();
-    await reload;
-    expect(reloaded).toBe(true);
-  });
-
-  it('drops metadata awaiting a stream that is absent after reload', async () => {
-    mockStorage({ logs: {}, summaries: {} });
-    const store = await StreamLogStore.open();
-    store.recordSummaryMeta('old-root-stream', META);
-
-    await store.reload({ discardPendingWrites: true });
-
-    expect(store.getSummaryMeta('old-root-stream')).toBeUndefined();
-  });
-
-  it('preserves metadata recorded while reload reads are in flight', async () => {
-    const reloadReadStarted = createDeferred();
-    const releaseReloadRead = createDeferred();
-    let reads = 0;
-    mockStorage({
-      logs: { alpha: [logEntry('alpha', 1, 200)] },
-      summaries: {},
-      onLogRead: async () => {
-        reads += 1;
-        if (reads === 2) {
-          reloadReadStarted.resolve();
-          await releaseReloadRead.promise;
-        }
-      },
-    });
-    const store = await StreamLogStore.open();
-
-    const reload = store.reload({ discardPendingWrites: true });
-    await reloadReadStarted.promise;
-    store.recordSummaryMeta('new-run', META);
-    releaseReloadRead.resolve();
-
-    await expect(reload).rejects.toThrow('state changed during reload');
-    expect(store.getSummaryMeta('new-run')).toEqual(META);
-  });
-
-  it('preserves metadata recorded while reload flushes pending writes', async () => {
-    const summaryWriteStarted = createDeferred();
-    const releaseSummaryWrite = createDeferred();
-    mockStorage({
-      logs: { alpha: [logEntry('alpha', 1, 200)] },
-      summaries: { alpha: summary(200, 200) },
-      onSummaryWrite: async (streamId) => {
-        if (streamId !== 'alpha') return;
-        summaryWriteStarted.resolve();
-        await releaseSummaryWrite.promise;
-      },
-    });
-    const store = await StreamLogStore.open();
-    await store.ensureLoaded('alpha');
-    appendTranscriptEntry(store, 'alpha', logEntry('alpha', 2, 300));
-
-    const reload = store.reload();
-    await summaryWriteStarted.promise;
-    store.recordSummaryMeta('new-run', META);
-    releaseSummaryWrite.resolve();
-
-    await expect(reload).rejects.toThrow('state changed during reload');
-    expect(store.getSummaryMeta('new-run')).toEqual(META);
   });
 
   it('discards a stale-shaped summary cache loudly and rebuilds from the log', async () => {

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -65,21 +65,18 @@ export function configureDelegatedChildApprovals(
 
 /**
  * Clean up all approval state for a deleted stream in the owning session.
- * Cancels pending host interactions and clears stream-scoped bypass state.
+ * Cancels pending host interactions; `forgetStreamAncestry` clears the
+ * stream's ancestry edges and its explicit bypass values.
  */
 function cleanupApprovalsForStream(
   streamId: StreamTabId,
   session: SessionHandle = defaultSession(),
 ): void {
-  const { toolEdit, bash, proposal } = session.approvals;
   session.interactions.cancel({
     streamId,
     cause: 'Stream resources released.',
   });
   session.approvals.forgetStreamAncestry(streamId);
-  toolEdit.bypass.clearForStream(streamId);
-  bash.bypass.clearForStream(streamId);
-  proposal.clearForStream(streamId);
 }
 
 /**

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -399,7 +399,7 @@ export class StreamLogStore {
   /**
    * Handles over the two fixed transcript directories. A handle holds only
    * the storage-root-relative directory, and every operation re-resolves the
-   * root, so one handle per directory survives a storage-root reload.
+   * root.
    */
   private readonly logsKv = new KVStore(STREAM_LOGS_DIR, { compactJson: true });
   private readonly summariesKv = new KVStore(STREAM_LOG_SUMMARIES_DIR, {
@@ -408,7 +408,7 @@ export class StreamLogStore {
 
   /**
    * Lightweight summary per stream (first/last timestamp). Populated at open
-   * or reload and refreshed on append/update. Survives eviction so sidebar
+   * and refreshed on append/update. Survives eviction so sidebar
    * metadata stays available for streams whose heavy entries have been evicted.
    */
   private readonly summaries = new Map<StreamTabId, StreamLogSummary>();
@@ -434,7 +434,6 @@ export class StreamLogStore {
   private readonly writeTombstones = new Set<StreamTabId>();
   private clearing = false;
   private stateRevision = 0;
-  private pendingReload: Promise<void> | undefined;
   private summaryCacheMaintenanceEnabled = true;
 
   private constructor(mode: StreamLogStoreMode) {
@@ -638,11 +637,11 @@ export class StreamLogStore {
     if (summary === undefined || isDeepStrictEqual(summary.meta, meta)) return;
     summary.meta = meta;
     this.stateRevision += 1;
-    // Share the transcript queue so flush/reload drains this write before a
-    // storage-root change. Re-read at execution time, and let a dirty
-    // transcript's own write carry the metadata: persisting its newer
-    // log-derived summary fields before the authoritative log would make a
-    // crash-time cache look more durable than it is.
+    // Share the transcript queue so flush() drains this write. Re-read at
+    // execution time, and let a dirty transcript's own write carry the
+    // metadata: persisting its newer log-derived summary fields before the
+    // authoritative log would make a crash-time cache look more durable
+    // than it is.
     void this.writeQueue.add(async () => {
       if (this.dirtyIds.has(streamId)) return;
       const current = this.summaries.get(streamId);
@@ -1206,32 +1205,6 @@ export class StreamLogStore {
   }
 
   /**
-   * Transactionally reload persistent summaries. A failed read leaves the
-   * previously valid in-memory state untouched and rejects to the host.
-   * `discardPendingWrites` is reserved for workspace-root rollback after the
-   * old root was already flushed; it prevents failed new-root repair state
-   * from being written after the provider returns to the old root.
-   */
-  async reload(
-    options: { readonly discardPendingWrites?: boolean } = {},
-  ): Promise<void> {
-    if (this.mode.kind === 'ephemeral') {
-      throw new Error(
-        `Cannot reload an ephemeral transcript store (${this.mode.reason}).`,
-      );
-    }
-    if (this.pendingReload) return this.pendingReload;
-
-    const work = this.executeReload(options.discardPendingWrites ?? false);
-    this.pendingReload = work;
-    try {
-      await work;
-    } finally {
-      if (this.pendingReload === work) this.pendingReload = undefined;
-    }
-  }
-
-  /**
    * Throttled internal persistence trigger; every mutator schedules it.
    * Fire-and-forget by design: only `flush()` is awaitable, and it drains,
    * retries, and throws.
@@ -1331,41 +1304,6 @@ export class StreamLogStore {
     } else {
       this.summaries.set(streamId, toSummary(logInstance));
     }
-  }
-
-  private async executeReload(discardPendingWrites: boolean): Promise<void> {
-    // Sample before the first await: run facts may arrive while pending writes
-    // drain or the replacement adapters prepare, and the reload must not fold
-    // those new-root facts into the state it is about to replace.
-    const revision = this.stateRevision;
-    if (discardPendingWrites) {
-      this.saveThrottle.cancel();
-      // Invalidate and drain any in-flight batch before the adapters
-      // repoint: a write started before a storage-root rollback must not
-      // keep landing streams against the restored root. The generation
-      // bump makes the batch's remaining per-stream writes skip; the
-      // drain keeps a mid-write stream from straddling the repoint.
-      this.writeGeneration += 1;
-      await this.writeQueue.onIdle();
-    } else if (this.mode.kind === 'persistent') {
-      await this.flush();
-    }
-    if (!discardPendingWrites && this.dirtyIds.size > 0) {
-      throw new Error(
-        'Cannot reload transcripts while persistent writes remain unresolved.',
-      );
-    }
-
-    this.summaryCacheMaintenanceEnabled = true;
-    if (this.mode.kind === 'persistent') await this.prepareSummaryCache();
-
-    const summaries = await this.readPersistentSummaries();
-    if (revision !== this.stateRevision || this.pendingLoads().length > 0) {
-      throw new Error(
-        'Transcript state changed during reload; preserving the live state.',
-      );
-    }
-    this.replaceSummaries(summaries);
   }
 
   private async readPersistentSummaries(): Promise<


### PR DESCRIPTION
## Summary

Retires storage-transition and restart-repair residue whose production callers were deleted by earlier round-3 changes. The runtime now has one restart-repair pass, workspace storage captures its construction-time path directly, stream approvals clear their bypass state at their ancestry owner, and `StreamLogStore.reload` is no longer exposed without a production lifecycle that can use it.

## Issue acceptance gates

- `StreamLogStore.reload` and its reload-only support state have no production consumer and are removed with their test-only reload scenarios.
- Restart repair remains single-flight and is cancellable on session teardown.
- Workspace storage still captures the construction-time workspace path for CLI and extension hosts.
- Stream deletion still promotes child bypasses before clearing the deleted stream's explicit bypasses.

## Single source of truth

`SessionHandle.restartRepairPromise` is the sole owner of restart-repair single-flight state. `WorkspaceStorageProvider.activeWorkspacePath` owns the construction-time workspace path. `SessionApprovals.forgetStreamAncestry` owns both ancestry teardown and per-stream bypass cleanup.

## Duplication and abstraction budget

Removed the reload-only transaction path and the restart-repair queue/generation pair. Moved the one cleanup sequence from `cleanupApprovalsForStream` into its sole ancestry owner; `StreamApprovalBypassState` narrows the per-stream clear operation to that owner rather than adding a public surface.

## Net elements (R6)

19 modified files, 78 additions and 372 deletions: **-294 LoC**. No files were added or deleted. Exported-symbol diff: 0 added, 0 deleted. Declarations: 1 internal interface added (`StreamApprovalBypassState`) and 1 internal interface deleted (`StreamApprovalControllerOptions`), net 0. Removed public surface: `StreamLogStore.reload` (and its ratchet-baseline entry); the internal `executeReload`, `WorkspacePathSource`, restart-repair queue/generation, and public `StreamApprovalBypass.clearForStream` exposure are also retired or narrowed.

## Consumer counts (R8)

`StreamLogStore.reload` and `executeReload`: 0 production consumers (`rg` across `src/` and `packages/`, excluding tests; unrelated reload names only). `storageGeneration`, `enqueueRestartRepair`, and `WorkspacePathSource`: 0 remaining consumers after deletion. `clearForStream`: 1 internal consumer, `SessionApprovals.forgetStreamAncestry`; it retains the same three bypass clears after child promotion. `createNodeStorageProvider` / `WorkspaceStorageProvider` have 5 production construction sites, all passing a plain path or no path; the two changed call sites capture the same synchronous path value at construction. No event emitter or subscriber is deleted or rerouted.

## Host impact

Extension: captures the current workspace path at activation; no workspace-transition path remains.

Desktop: no behavioral surface change; transcript presentation waits for the resident session store.

CLI: captures `context.cwd` when CLI state stores are constructed.

## Scheduled refactoring

None. The deliberately deferred `ToolDefinition.parameters` investigation remains explicitly out of this PR's file scope.

Lane `PA-postmerge` of [round 4B — production surfaces](https://github.com/texra-ai/coauthor/pull/11465).

The fourth pass over production code, on angles rounds 1-3 could not take: what their collapses left half-done in the **absorbing** owner, internal repetition inside the largest files, silent-degradation defects, and the Zod corpus.

## Findings

- **StreamLogStore.reload/executeReload lost their only production callers in #11452 — now a test-only surface** (delete, medium) — target -255 LoC.
- **ToolDefinition.parameters lost its last producer in #11454; the two converter fallback arms are dead** (delete, medium) — target -20 LoC.
- **SessionHandle restart repair still threads a storage generation that can never change** (amend, low) — target -18 LoC.
- **WorkspacePathSource keeps the lazy-callable arm the storage transition needed, and both remaining lambdas close over constants** (delete, low) — target -12 LoC.
- **Stream approval teardown is split across two owners: forgetStreamAncestry documents a clearing step that lives in its only caller** (consolidate, low) — target -5 LoC.
- **Four comments still describe the deleted workspace-storage transition as live behavior** (amend, low) — target -2 LoC.

## Deliberately not done

- **Finding 2: ToolDefinition.parameters + the two converter fallback arms** — Test blast radius is far larger than verified and partly unresolvable as proposed. The verifier's correction 3 says 'roughly 7-8 sites across 3 suites', but ToolConversion.vitest.ts lines ~808-1110 contain ~13 additional tests that feed raw JSON Schema through def.parameters into convertGoogleToolSchema/toGoogleTools to pin Google-converter semantics (opaque-annotation preservation, oneOf/allOf/not + contains/if/then/else/dependentSchemas/prefixItems keyword rejection, array-valued type rejection, exclusive-bound intersection, const/enum intersection/contradiction, $ref rejection). These shapes are NOT producible from Zod schemas, so the proposal's instruction to rewrite 'to zodSchema form' is unsatisfiable for them; deleting the arm makes every one fail (null return / no throw), and deleting the tests would silently drop a whole coverage suite for toGoogleOpenApiSchemaNode branches whose post-change reachability (via Zod-emitted allOf/anyOf/$defs) I cannot adjudicate without running the converter. Two further unexamined fixture suites also feed parameters-only defs: ModelHandlerDeepSeek.vitest.ts:380-395 and AnthropicCacheBeta.vitest.ts:86-94. I applied the change fully, discovered this while sweeping for remaining constructors, and reverted it cleanly rather than improvise. Recommend re-verifying with an explicit disposition for the Google exotic-schema suite (rewrite against an exported unit surface vs. delete-with-rationale) before re-queueing.

## On the line count

Some findings in round 4B **add** lines, and that is the intended outcome. CLAUDE.md treats a masking fallback as a defect: *"A fallback that masks a failure must be loud — log the cause at `warn` and surface it — or not exist."* Where a finding is an `amend`, the fix is to make the failure loud, never to delete it quietly.

## Validation

Focused regression suites passed locally: `StreamLogStoreLoad`, `WorkspaceStorage`, `DesktopAgentExecution`, `ProgressBackendPresentation`, `SessionRestartRepair`, `RestartRepair`, and `ApprovalCleanupScope` (7 files, 184 tests). `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run check:dead-code-ratchet`, `npm run check:guidance-refs`, and `npm run check:browser-safe-utils` also passed. The full local Vitest run had two failures outside this diff: the pre-existing desktop merge-error assertion (also reproducible in isolation) and one non-reproducible legacy-workflow timeout; required CI kernel shards passed.

<details><summary>Implementer risk notes</summary>

Central validator must: (1) typecheck — highest-risk spots are the streamApprovalQueue restructure (StreamApprovalBypassState internal interface, controller factory signature change) and the desktop bridge type after removing reload() from DesktopAgentExecution.vitest.ts:137; (2) run StreamLogStoreLoad.vitest.ts, DesktopAgentExecution.vitest.ts, SessionRestartRepair.vitest.ts, RestartRepair.vitest.ts, WorkspaceStorage.vitest.ts, and any approval/bypass suites; (3) run the store-public-surface ratchet check (baseline lowered by one row — that check must agree reload is gone); (4) confirm no suite constructs SessionHandle non-deferred and depends on repair NOT starting synchronously before its mocks (correction 5's timing nuance; deferred-mode tests are unaffected). The SDK surface is unaffected: `packages/agent/src/index.ts:252` constructs only `StreamLogStore.ephemeral`, on which `reload` threw. This PR deliberately scopes to `StreamLogStore.reload`, not the three sibling orphans #11452 grouped with it (`StreamSnapshotStore.evictAll`, `StreamStatusMachine.clearAll`, `getAllStreamStates`).

</details>

