### PR TITLE
fix: make four swallowed failures loud, including a Zod .catch on persisted data

### DIFF
--- a/packages/cli/src/chat/tui/history/inputHistory.ts
+++ b/packages/cli/src/chat/tui/history/inputHistory.ts
@@ -14,7 +14,10 @@ const HISTORY_PATH = `${HISTORY_DIR}/input-history.jsonl`;
 const MAX_LINES = 1000;
 const MAX_LINE_CHARS = 4000;
 
-const HistoryRecordSchema = z.object({ t: z.number().catch(0), v: z.string() });
+// No `.catch` on `t`: a record with a missing or corrupt timestamp fails
+// validation and is skipped by the reader below, per the malformed-line
+// policy — never rewritten into the file with a fabricated epoch-0 time.
+const HistoryRecordSchema = z.object({ t: z.number(), v: z.string() });
 type HistoryRecord = z.infer<typeof HistoryRecordSchema>;
 
 export interface InputHistory {

--- a/src/agent/implementations/flows/reflection/output/outputFileExtraction.ts
+++ b/src/agent/implementations/flows/reflection/output/outputFileExtraction.ts
@@ -12,12 +12,10 @@
 import { reportMissingOutputs } from '@agent/runtime/runFactEvents';
 import {
   fileLocationDisplayPath,
-  MESSAGE_TYPES,
   OUTPUT_DOCUMENTS_TAG,
   type FileLocation,
 } from '@shared/schemas';
 import { normalizeFilePath } from '@utils/core';
-import { toErrorMessage } from '@utils/errors/errorMessage';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 
 import { replaceInputCommands } from './fileMapping';
@@ -37,22 +35,8 @@ async function prepareRunWorkspaceIfNeeded(
 ): Promise<void> {
   if (!state.runPreparation) return;
 
-  try {
-    await state.runPreparation;
-  } catch (error) {
-    // Continue without the prepared workspace — extraction can still salvage
-    // the model's output — but warn loudly: without the `original/` snapshot,
-    // in-place workflows diff live-vs-live and report empty 0/0 stats.
-    deps.logger.warn(
-      `Failed to prepare run workspace; in-place diffs may be empty: ${toErrorMessage(error)}`,
-      {
-        data: error,
-        messageType: MESSAGE_TYPES.INTERNAL,
-      },
-    );
-  } finally {
-    state.runPreparation = null;
-  }
+  await state.runPreparation;
+  state.runPreparation = null;
 }
 
 /**

--- a/src/agent/implementations/flows/reflection/output/outputFileExtraction.ts
+++ b/src/agent/implementations/flows/reflection/output/outputFileExtraction.ts
@@ -17,6 +17,7 @@ import {
   type FileLocation,
 } from '@shared/schemas';
 import { normalizeFilePath } from '@utils/core';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 
 import { replaceInputCommands } from './fileMapping';
@@ -39,10 +40,16 @@ async function prepareRunWorkspaceIfNeeded(
   try {
     await state.runPreparation;
   } catch (error) {
-    deps.logger.debug('Failed to prepare run workspace', {
-      data: error,
-      messageType: MESSAGE_TYPES.INTERNAL,
-    });
+    // Continue without the prepared workspace — extraction can still salvage
+    // the model's output — but warn loudly: without the `original/` snapshot,
+    // in-place workflows diff live-vs-live and report empty 0/0 stats.
+    deps.logger.warn(
+      `Failed to prepare run workspace; in-place diffs may be empty: ${toErrorMessage(error)}`,
+      {
+        data: error,
+        messageType: MESSAGE_TYPES.INTERNAL,
+      },
+    );
   } finally {
     state.runPreparation = null;
   }

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -24,6 +24,7 @@ import {
   type RoundOutput,
   type RunOutcome,
   type FileLocation,
+  MESSAGE_TYPES,
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import {
@@ -31,6 +32,7 @@ import {
   workflowOutputPath,
 } from '@shared/constants/workflowOutput';
 import { TaskRunFileService } from '@utils/files/taskRunStorage';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 import { LatexDiffManager } from './output/LatexDiffManager';
 import { XmlOutputManager } from './output/XmlOutputManager';
@@ -201,15 +203,22 @@ export async function runReflectionFlow(
   };
 
   // Kick off run-workspace preparation (awaited lazily by extractFilesFromXml).
-  outputState.runPreparation = fileService.prepareRunWorkspace(baseFiles, {
-    linkFiles: collectRunSupportFiles(services.config),
-  });
-  // Observe rejections immediately: until extractFilesFromXml awaits the
-  // stored promise (minutes later, after the model call), a rejection would
-  // otherwise be an unhandled promise rejection — which force-quits the
-  // desktop app and crashes the CLI. The failure itself is still observed
-  // and surfaced at warn by prepareRunWorkspaceIfNeeded.
-  void outputState.runPreparation.catch(() => {});
+  // Handle failure here too: a response can fail or be cancelled before output
+  // extraction reaches the promise, and leaving it rejected would both hide the
+  // filesystem failure and trigger an unhandled rejection.
+  outputState.runPreparation = fileService
+    .prepareRunWorkspace(baseFiles, {
+      linkFiles: collectRunSupportFiles(services.config),
+    })
+    .catch((error) => {
+      logger.warn(
+        `Failed to prepare run workspace; in-place diffs may be empty: ${toErrorMessage(error)}`,
+        {
+          data: error,
+          messageType: MESSAGE_TYPES.INTERNAL,
+        },
+      );
+    });
 
   const kv = getExecutionStore(executionId);
 

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -204,6 +204,12 @@ export async function runReflectionFlow(
   outputState.runPreparation = fileService.prepareRunWorkspace(baseFiles, {
     linkFiles: collectRunSupportFiles(services.config),
   });
+  // Observe rejections immediately: until extractFilesFromXml awaits the
+  // stored promise (minutes later, after the model call), a rejection would
+  // otherwise be an unhandled promise rejection — which force-quits the
+  // desktop app and crashes the CLI. The failure itself is still observed
+  // and surfaced at warn by prepareRunWorkspaceIfNeeded.
+  void outputState.runPreparation.catch(() => {});
 
   const kv = getExecutionStore(executionId);
 

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -419,8 +419,9 @@ export class ModelHandlerOpenAI<
           finalResponse = { ...finalResponse, usage: totalUsage };
         } catch (err) {
           // totalUsage() may fail if stream ended abnormally — leave usage
-          // unset, but log so missing token accounting is traceable.
-          this.logger.debug('totalUsage() fallback failed; usage unavailable', {
+          // unset, but warn so the round's missing token accounting is
+          // traceable in production logs.
+          this.logger.warn('totalUsage() fallback failed; usage unavailable', {
             data: buildErrorLogData(err, { operation: 'totalUsage fallback' }),
           });
         }

--- a/src/shared/schemas/inquiry.ts
+++ b/src/shared/schemas/inquiry.ts
@@ -28,7 +28,11 @@ export type InquiryThreadId = z.infer<typeof InquiryThreadIdSchema>;
 // Status + summary
 // ============================================================================
 
-const InquiryThreadStatusSchema = z.enum(['open', 'answered', 'dropped']);
+export const InquiryThreadStatusSchema = z.enum([
+  'open',
+  'answered',
+  'dropped',
+]);
 export type InquiryThreadStatus = z.infer<typeof InquiryThreadStatusSchema>;
 
 const InquiryThreadSummarySchema = z.object({

--- a/src/shared/schemas/workflowScriptDelivery.ts
+++ b/src/shared/schemas/workflowScriptDelivery.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod';
 
+import { LineCountSchema } from './lineChanges';
+
 const WorkflowScriptDeliveryFileSchema = z.strictObject({
   path: z.string(),
-  added: z.int().nonnegative().nullable(),
-  removed: z.int().nonnegative().nullable(),
+  added: LineCountSchema.nullable(),
+  removed: LineCountSchema.nullable(),
 });
 
 /** Compact, host-neutral facts used to present a workflow-script delivery. */

--- a/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
+++ b/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
@@ -25,6 +25,7 @@ import { ReflectionFlowStateSchema } from '@agent/implementations/flows/reflecti
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { createRunScope } from '@agent/runtime/RunScope';
 import {
+  MESSAGE_TYPES,
   RUN_OUTCOME,
   type ExecutionId,
   type StreamTabId,
@@ -32,6 +33,7 @@ import {
 } from '@shared/schemas';
 import { createTestSession } from '@test/support/sessionTestUtils';
 import { setupPlatform } from '@test/support/setupPlatform';
+import { TaskRunFileService } from '@utils/files/taskRunStorage';
 import { testModelCell } from './modelCellTestUtils';
 import { reflectionFlowShared } from './progressTestUtils';
 
@@ -61,6 +63,7 @@ function createModelCell(): RunReflectionFlowInput['modelCell'] {
 async function runPersistedReflectionFlow(
   executionId: ExecutionId,
   streamId: StreamTabId,
+  logger: RunReflectionFlowInput['logger'] = noopTrace,
 ): Promise<Awaited<ReturnType<typeof runReflectionFlow>>> {
   const session = createTestSession();
   const runScope = createRunScope({
@@ -80,8 +83,8 @@ async function runPersistedReflectionFlow(
         runScope,
         setting: SETTING,
         prompt: PROMPT,
-        logger: noopTrace,
-        parentStage: noopTrace.openStage('Reflection flow recovery test'),
+        logger,
+        parentStage: logger.openStage('Reflection flow recovery test'),
         userVarChannels: {
           input: Object.freeze({ MODEL: CONFIG.model }),
           transient: {},
@@ -143,6 +146,33 @@ describe('runReflectionFlow persisted-state recovery', () => {
       cause: readFailure,
     });
     expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports workspace preparation failure even when validation prevents output extraction', async () => {
+    const { key, store } = recoveryCase('preparation-failure');
+    await store.write(key, flowRecord({ currentRound: 'zero' }));
+    const preparationFailure = new Error('workspace unavailable');
+    vi.spyOn(
+      TaskRunFileService.prototype,
+      'prepareRunWorkspace',
+    ).mockRejectedValueOnce(preparationFailure);
+    const logger = { ...noopTrace, warn: vi.fn() };
+
+    await expect(
+      runPersistedReflectionFlow(
+        'reflection-flow-preparation-failure' as ExecutionId,
+        'workflow@gpt54#reflection-flow-preparation-failure' as StreamTabId,
+        logger,
+      ),
+    ).rejects.toMatchObject({
+      name: PersistedFlowStateError.name,
+      reason: 'invalid-shared',
+    });
+
+    expect(logger.warn).toHaveBeenCalledExactlyOnceWith(
+      expect.stringContaining('workspace unavailable'),
+      { data: preparationFailure, messageType: MESSAGE_TYPES.INTERNAL },
+    );
   });
 
   it.each([

--- a/src/tools/approval/latexPreview.ts
+++ b/src/tools/approval/latexPreview.ts
@@ -8,9 +8,10 @@ import path from 'node:path';
 import { sync as globSync } from 'glob';
 import { z } from 'zod';
 
+import { isFileNotFoundError } from '@common/errors';
 import { TEMP_EXTENSIONS } from '@housekeeping/constants';
 import { LaTeXdiffService } from '@latex/latexdiff';
-import { debug } from '@logger/logUtils';
+import { debug, warn } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import {
   LATEXDIFF_TEMP_FILE_LOCATIONS,
@@ -121,7 +122,12 @@ async function withLatexOperation(
   }
 }
 
-/** Read file content with fallback to provided default */
+/** Read file content with fallback to provided default. The disk read exists
+ *  to pick up the user's saved hand edits to the approval temp file; a
+ *  missing file (entry settled/cleaned up racing the preview) is genuinely
+ *  benign, so only that case falls back silently. Any other failure still
+ *  falls back — the held in-memory content keeps the preview usable — but
+ *  warns, because the preview would silently drop the user's saved edits. */
 async function readFileWithFallback(
   uri: { fsPath: string },
   fallback: string,
@@ -129,7 +135,16 @@ async function readFileWithFallback(
   return platform()
     .fs.readFile(uri.fsPath)
     .then((bytes) => Buffer.from(bytes).toString('utf8'))
-    .catch(() => fallback);
+    .catch((error) => {
+      if (!isFileNotFoundError(error)) {
+        warn(
+          'latexPreview',
+          `Failed to read ${uri.fsPath}; previewing held content (saved hand edits may be missing): ${toErrorMessage(error)}`,
+          { data: error },
+        );
+      }
+      return fallback;
+    });
 }
 
 /**

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -11,6 +11,7 @@ import {
   InquiryDraftSchema,
   InquirySessionLinksSchema,
   InquiryThreadIdSchema,
+  InquiryThreadStatusSchema,
   StreamTabIdSchema,
   ToolError,
   type InquiryDraft,
@@ -91,7 +92,7 @@ const ManifestBaseShape = {
    * field existed, which are delivered by stream alone.
    */
   parentExecutionId: ExecutionIdSchema.nullable().default(null),
-  status: z.enum(['open', 'answered', 'dropped']),
+  status: InquiryThreadStatusSchema,
   createdAt: z.string().min(1),
   updatedAt: z.string().min(1),
   turns: z.array(ExternalInquiryTurnRecordSchema),


### PR DESCRIPTION
Lane `PB-defects` of [round 4B — production surfaces](https://github.com/texra-ai/coauthor/pull/11465).

The fourth pass over production code, on angles rounds 1-3 could not take: what their collapses left half-done in the **absorbing** owner, internal repetition inside the largest files, silent-degradation defects, and the Zod corpus.

## Findings

- **OpenAI streaming totalUsage() fallback failure logs at debug, silently under-counting run cost (accounting)** (amend, low) — target 0 LoC.
- **inputHistory persists corrupted timestamps as epoch-0 via Zod .catch(0) on a whole-file-rewritten JSONL** (amend, low) — target 0 LoC.
- **Two schema files re-declare vocabularies their documented shared owner already exports (inquiry status enum, line-count field)** (amend, low) — target 2 LoC.
- **Run-workspace preparation failure is swallowed at debug and its promise has no rejection owner (M1 + crash window)** (amend, medium) — target 6 LoC.
- **Approval preview readFileWithFallback swallows all read errors without the FNF predicate, silently previewing stale content** (amend, low) — target 7 LoC.

## On the line count

Some findings in round 4B **add** lines, and that is the intended outcome. CLAUDE.md treats a masking fallback as a defect: *"A fallback that masks a failure must be loud — log the cause at `warn` and surface it — or not exist."* Where a finding is an `amend`, the fix is to make the failure loud, never to delete it quietly.

## Validation

Run on this branch **in isolation**, so it does not depend on a sibling lane: `npm run typecheck` (all six projects), `npm run lint`, `npm run check:dead-code-ratchet`, `npm test` (full suite), `npm run format`.

<details><summary>Implementer risk notes</summary>

Net +39 LoC is expected: this is the loudness/defect lane; findings 4 and 5 correctly ADD lines per the brief. Central validator should re-check: (a) typecheck of new imports — toErrorMessage in outputFileExtraction.ts, isFileNotFoundError + warn in latexPreview.ts, LineCountSchema in workflowScriptDelivery.ts, and InquiryThreadStatusSchema resolving through the @shared/schemas barrel; (b) knip: new export InquiryThreadStatusSchema has its consumer in the same commit — no baseline rows touched; (c) prettier formatting of the new multi-line warn calls and wrapped enum (could not run prettier, worktree has no node_modules); (d) per verifier note, the two debug->warn upgrades on AgentTrace change progress-view/CLI severity rendering and add the entries to the persisted transcript — behavior-neutral for the run but visible; verify no snapshot/TUI test pins those levels; (e) OpenAI-compatible providers that never send usage will now warn once per round (each warn is a real under-count, per verifier). Note: brief file snapshotResolution.ts was evidence-only and is unedited. Global-gitignore history/ trap hit on packages/cli/.../history/inputHistory.ts; staged with git add -f (file is tracked).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)