### PR TITLE
fix(surface): gate the Grok sign-in command and reconcile the agent roster entry

### DIFF
--- a/docs/guide/built-in-agents.md
+++ b/docs/guide/built-in-agents.md
@@ -421,7 +421,9 @@ Reviews a diff or file for correctness, clarity, security, and convention fit, a
 
 Reviews the working tree's diff against the main branch, verifies each suspicion with repository tools and language-server diagnostics, and reports confirmed findings to the Agent Review (Find Issues) panel in Source Control. It is read-only, does not edit, and has no `bash` tool by design.
 
-**Best for:** Reviewing uncommitted changes before you commit
+Launch it with the **Find Issues** button in Source Control (or the `Find Issues (Agent Review)` command) rather than from the agent dropdown: findings are only accepted into the panel while a review started there is collecting them.
+
+**Best for:** Reviewing uncommitted changes before you commit, driven from Source Control
 
 ### `testEngineer`
 

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -846,6 +846,10 @@
           "when": "texra.activated"
         },
         {
+          "command": "texra.auth.grok.signIn",
+          "when": "texra.activated"
+        },
+        {
           "command": "texra.auth.signOut",
           "when": "texra.activated"
         },

--- a/packages/extension/src/frontend/review/AgentReviewService.ts
+++ b/packages/extension/src/frontend/review/AgentReviewService.ts
@@ -396,7 +396,7 @@ class AgentReviewServiceImpl {
       return {
         accepted: false,
         reason:
-          'No agent review session is collecting issues. Findings can only be reported from a review started via "Run Agent Review".',
+          'No agent review session is collecting issues. Findings can only be reported from a review started via "Find Issues (Agent Review)".',
       };
     }
     if (this.issues.length >= MAX_ISSUES_PER_REVIEW) {

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -334,6 +334,10 @@
             "when": "texra.activated"
           },
           {
+            "command": "texra.auth.grok.signIn",
+            "when": "texra.activated"
+          },
+          {
             "command": "texra.auth.signOut",
             "when": "texra.activated"
           },

--- a/src/test-kernel/commands/CommandCatalog.vitest.ts
+++ b/src/test-kernel/commands/CommandCatalog.vitest.ts
@@ -13,10 +13,18 @@ import {
   type CommandCatalogEntry,
 } from '@shared/commands/catalog';
 
+interface CommandPaletteItem {
+  command: string;
+  when?: string;
+}
+
 interface PackageJson {
   contributes: {
     commands: unknown[];
     keybindings?: unknown[];
+    menus?: {
+      commandPalette?: CommandPaletteItem[];
+    };
   };
 }
 
@@ -41,6 +49,18 @@ describe('commandCatalog', () => {
     assert.deepEqual(
       packageJson.contributes.keybindings ?? [],
       commandKeybindings,
+    );
+  });
+
+  it('gates the Grok subscription sign-in command in the command palette', () => {
+    assert.deepEqual(
+      packageJson.contributes.menus?.commandPalette?.find(
+        (entry) => entry.command === 'texra.auth.grok.signIn',
+      ),
+      {
+        command: 'texra.auth.grok.signIn',
+        when: 'texra.activated',
+      },
     );
   });
 

--- a/src/test-kernel/progressView/ProgressBackendPresentation.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendPresentation.vitest.ts
@@ -13,15 +13,15 @@ import {
 } from './progressBackendHarness';
 
 describe('ProgressBackend', () => {
-  it('loads a presentation without reloading its live transcript', async () => {
+  it('loads a presentation by waiting for the live transcript', async () => {
     const session = await createLiveStoreSession();
     const waitUntilReady = vi.spyOn(session, 'waitUntilReady');
-    const reload = vi.spyOn(session.transcripts, 'reload');
     const { backend } = createIsolatedRecordingBackend(session);
 
     await backend.load();
 
+    // The companion `reload` assertion retired with StreamLogStore.reload:
+    // a re-read is no longer expressible, so it cannot be asserted against.
     expect(waitUntilReady).toHaveBeenCalledOnce();
-    expect(reload).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Lane `PD-surface` of [round 4B — production surfaces](https://github.com/texra-ai/coauthor/pull/11465).

The fourth pass over production code, on angles rounds 1-3 could not take: what their collapses left half-done in the **absorbing** owner, internal repetition inside the largest files, silent-degradation defects, and the Zod corpus.

## Findings

- **Add the missing commandPalette gate for texra.auth.grok.signIn — the one hand-maintained palette row #9709 never wrote** (amend, low) — target 8 LoC.
- **PRODUCT DECISION: changeReviewer is offered in the agent dropdown on every host, but its only reporting channel works solely inside a review started by texra.agentReview.run** (consolidate, medium) — target 10 LoC.

## Deliberately not done

- **Finding 2 option (a): default-hide changeReviewer from the visible roster via schema marker honored by getVisibleAgents** — Mechanism spans core files outside this lane's list (src/agent/core/definition/AgentDataclass.ts schema field, src/agent/roster/AgentRosterController.ts filter, scanner); the finding itself states it needs maintainer product sign-off; and the verifier-flagged trap (marker leaking into name resolution breaks the Find Issues button and 'texra run --agent changeReviewer') is unverifiable here without typecheck/tests. Deferred rather than improvised.

## On the line count

Some findings in round 4B **add** lines, and that is the intended outcome. CLAUDE.md treats a masking fallback as a defect: *"A fallback that masks a failure must be loud — log the cause at `warn` and surface it — or not exist."* Where a finding is an `amend`, the fix is to make the failure loud, never to delete it quietly.

## Validation

Run on this branch **in isolation**, so it does not depend on a sibling lane: `npm run typecheck` (all six projects), `npm run lint`, `npm run check:dead-code-ratchet`, `npm test` (full suite), `npm run format`.

<details><summary>Implementer risk notes</summary>

Central validator should re-run check:extension-package-invariants (passed locally via plain node) and prettier over the two hand-edited JSON files (style matched by hand). packages/extension/package.json is shared with lane PC-misc — my edit is only the 4-line commandPalette row after texra.auth.chatgpt.signIn; merge conflicts there are mechanical. The deferred roster-hiding half of finding 2 still needs a maintainer product decision; until then changeReviewer remains pickable in dropdowns where its findings are rejected.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)