### PR TITLE
fix: adapt GLM reasoning flows to llm-zoo 1.31

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -139,7 +139,11 @@ export class ModelSelectionList extends LitElement {
         @change=${(e: Event) => this.handleReasoningLevelChange(model.name, e)}
       >
         <wa-option value=""> ${defaultLabel} </wa-option>
-        ${REASONING_LEVEL_OPTIONS.map(
+        ${REASONING_LEVEL_OPTIONS.filter(
+          (option) =>
+            !model.supportedReasoningLevels?.length ||
+            model.supportedReasoningLevels.includes(option.value),
+        ).map(
           (option) => html`
             <wa-option value=${option.value}> ${option.label} </wa-option>
           `,

--- a/src/agent/modelHandlers/openai/modelHandlerGLM.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerGLM.ts
@@ -1,6 +1,12 @@
+// Third-party imports
+import { ReasoningEffort } from 'llm-zoo';
+
 // Local imports - agent
 import type { StandardPricingConfig } from '@agent/modelHandlers/support/priceUtils';
-import { clampReasoningEffortToHighOrMax } from '@agent/modelHandlers/support/reasoningEffort';
+import {
+  clampReasoningEffortToHighOrMax,
+  normalizeSupportedReasoningEffort,
+} from '@agent/modelHandlers/support/reasoningEffort';
 
 // Local file imports
 import { ReasoningModelHandlerOpenAI } from './reasoningModelHandlerOpenAI';
@@ -39,23 +45,57 @@ export class ModelHandlerGLM extends ReasoningModelHandlerOpenAI {
     return false;
   }
 
-  /**
-   * GLM effort-capable models accept only high/max on the OpenAI-compatible
-   * surface; delegate to the shared high-or-max clamp (see
-   * `clampReasoningEffortToHighOrMax`).
-   */
-  protected override validateReasoningEffort(effort: string): string {
-    return clampReasoningEffortToHighOrMax(effort);
+  private normalizeReasoningEffort(effort: ReasoningEffort): ReasoningEffort {
+    const supported = this.capabilities.supportedReasoningEfforts;
+    return supported?.length
+      ? normalizeSupportedReasoningEffort(
+          effort,
+          supported,
+          this.capabilities.reasoningEffort,
+        )
+      : clampReasoningEffortToHighOrMax(effort);
+  }
+
+  protected override getReasoningEffortParameter(): string | undefined {
+    const effort = this.getEffectiveReasoningEffort();
+    if (!this.capabilities.supportsReasoning || !effort) return undefined;
+
+    const normalized = this.normalizeReasoningEffort(effort);
+    return normalized === ReasoningEffort.NONE ? undefined : normalized;
   }
 
   /**
    * GLM models require explicit `thinking` parameter to control reasoning.
-   * Thinking models (e.g. GLM-4.5) need it enabled; non-thinking variants
-   * get it explicitly disabled to prevent unexpected reasoning activation.
+   * Models whose vocabulary includes none can disable it; forced-thinking
+   * variants such as GLM-5.3 keep it enabled.
    */
   protected override getThinkingParameter(): { type: 'enabled' | 'disabled' } {
-    return this.capabilities.supportsReasoning
-      ? { type: 'enabled' }
-      : { type: 'disabled' };
+    if (!this.capabilities.supportsReasoning) return { type: 'disabled' };
+
+    const supported = this.capabilities.supportedReasoningEfforts;
+    if (!supported?.length) return { type: 'enabled' };
+
+    const effort = this.getEffectiveReasoningEffort();
+    const normalized = effort
+      ? normalizeSupportedReasoningEffort(
+          effort,
+          supported,
+          this.capabilities.reasoningEffort,
+        )
+      : this.capabilities.reasoningEffort;
+    return normalized === ReasoningEffort.NONE
+      ? { type: 'disabled' }
+      : { type: 'enabled' };
+  }
+
+  protected override getCompactionReasoningParameters() {
+    const supported = this.capabilities.supportedReasoningEfforts;
+    if (supported?.length && !supported.includes(ReasoningEffort.NONE)) {
+      return {
+        thinking: { type: 'enabled' as const },
+        reasoning_effort: this.normalizeReasoningEffort(ReasoningEffort.NONE),
+      };
+    }
+    return super.getCompactionReasoningParameters();
   }
 }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -249,6 +249,16 @@ export class ModelHandlerOpenAI<
     return undefined;
   }
 
+  /** Provider-specific reasoning controls for the auxiliary summary call. */
+  protected getCompactionReasoningParameters(): Pick<
+    ChatCompletionSummaryParams,
+    'thinking' | 'reasoning_effort'
+  > {
+    return this.getThinkingParameter() || this.capabilities.supportsReasoning
+      ? { thinking: { type: 'disabled' } }
+      : {};
+  }
+
   protected buildCompactionSummaryParams(
     conversationMessages: ChatCompletionMessageParam[],
     systemPrompt: string,
@@ -262,12 +272,8 @@ export class ModelHandlerOpenAI<
       max_tokens: CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
       temperature: 0,
       stream: false,
+      ...this.getCompactionReasoningParameters(),
     };
-    // Disable thinking for the summary call — reasoning models
-    // (DeepSeek, Kimi K2.5, GLM) don't need to think for summarization.
-    if (this.getThinkingParameter() || this.capabilities.supportsReasoning) {
-      summaryParams.thinking = { type: 'disabled' };
-    }
     return summaryParams;
   }
 
@@ -284,6 +290,19 @@ export class ModelHandlerOpenAI<
       this.config.provider === ModelProvider.XAI &&
       this.capabilities.supportsReasoning;
     return !this.isOReasoningModel && !isGrokReasoningModel;
+  }
+
+  /** Resolve the provider-facing reasoning effort, if this request should send one. */
+  protected getReasoningEffortParameter(): string | undefined {
+    const reasoningEffort = this.getEffectiveReasoningEffort();
+    if (!this.capabilities.supportsReasoning || !reasoningEffort)
+      return undefined;
+    return this.validateReasoningEffort(
+      toOpenAIReasoningEffort(
+        reasoningEffort,
+        getDeclaredMaxReasoningEffort(this.config.capabilities),
+      ),
+    );
   }
 
   protected buildChatBaseParams(
@@ -310,14 +329,10 @@ export class ModelHandlerOpenAI<
       baseParams.temperature = temperature;
     }
 
-    const reasoningEffort = this.getEffectiveReasoningEffort();
-    if (this.capabilities.supportsReasoning && reasoningEffort) {
-      baseParams.reasoning_effort = this.validateReasoningEffort(
-        toOpenAIReasoningEffort(
-          reasoningEffort,
-          getDeclaredMaxReasoningEffort(this.config.capabilities),
-        ),
-      ) as ChatCompletionRequestBase['reasoning_effort'];
+    const reasoningEffort = this.getReasoningEffortParameter();
+    if (reasoningEffort) {
+      baseParams.reasoning_effort =
+        reasoningEffort as ChatCompletionRequestBase['reasoning_effort'];
     }
 
     // Add thinking parameter if specified by subclass (Kimi K2.5, DeepSeek)

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -38,7 +38,10 @@ import {
   classifyMediaEntry,
   unknownMediaCategoryWarning,
 } from '../support/mediaClassification';
-import { getDeclaredMaxReasoningEffort } from '../support/reasoningEffort';
+import {
+  getDeclaredMaxReasoningEffort,
+  normalizeSupportedReasoningEffort,
+} from '../support/reasoningEffort';
 import { OPENROUTER_BASE_URL } from '../support/ProxyConfigResolver';
 import {
   resolveMoonshotRequestParameters,
@@ -72,8 +75,11 @@ import type {
   ChatUsage,
   ChatMessages,
   ChatToolCall,
+  ChatAssistantMessage,
   ChatContentItems,
   ChatRequest,
+  ChatRequestEffort,
+  ReasoningDetailUnion,
 } from '@openrouter/sdk/models';
 
 function isOpenRouterChatStream(
@@ -99,6 +105,8 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
   ChatResult,
   ChatContentItems
 > {
+  private reasoningDetails: ReasoningDetailUnion[] = [];
+
   /** Client-side compaction is implemented for tool-use sessions regardless of the routed-through provider. */
   override get supportsManualCompaction(): boolean {
     return this.isToolUseMode();
@@ -176,6 +184,28 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     );
   }
 
+  private normalizeReasoningEffort(effort: ReasoningEffort): ChatRequestEffort {
+    const supported = this.capabilities.supportedReasoningEfforts;
+    let normalized = effort;
+    if (supported?.length) {
+      normalized = normalizeSupportedReasoningEffort(
+        effort,
+        supported,
+        this.capabilities.reasoningEffort,
+      );
+    } else if (
+      effort === ReasoningEffort.NONE ||
+      effort === ReasoningEffort.MINIMAL
+    ) {
+      normalized = ReasoningEffort.LOW;
+    }
+    return toOpenRouterReasoningEffort(
+      this.validateReasoningEffort(normalized),
+      getDeclaredMaxReasoningEffort(this.config.capabilities) ===
+        ReasoningEffort.MAX,
+    );
+  }
+
   /** Creates an OpenRouter response after SDK-boundary error tagging is installed. */
   protected override async createResponseImpl(
     options: CreateResponseOptions<ChatMessages, OpenRouter>,
@@ -208,18 +238,14 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     // Reasoning configuration:
     // OpenRouter SDK serializes `reasoning.effort` but not `reasoning.enabled`.
     // Use getEffectiveReasoningEffort() for tier-based restrictions (e.g. GPT-5
-    // xhigh capped to high for Max-tier users on server-side keys).
+    // xhigh capped to high for Max-tier users on server-side keys), then clamp
+    // to the model's exact registry-declared vocabulary when one is available.
     if (this.capabilities.supportsReasoning) {
       const effective = this.capabilities.supportsReasoningEffort
-        ? (this.getEffectiveReasoningEffort() ?? 'low')
-        : 'low';
-      const effort = effective === 'none' ? 'low' : effective;
+        ? (this.getEffectiveReasoningEffort() ?? ReasoningEffort.LOW)
+        : ReasoningEffort.LOW;
       request.reasoning = {
-        effort: toOpenRouterReasoningEffort(
-          this.validateReasoningEffort(effort),
-          getDeclaredMaxReasoningEffort(this.config.capabilities) ===
-            ReasoningEffort.MAX,
-        ),
+        effort: this.normalizeReasoningEffort(effective),
       };
     }
 
@@ -374,7 +400,11 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
           // Minimize reasoning for summarization — use lowest valid effort
           ...(this.capabilities.supportsReasoningEffort &&
           !moonshotParameters?.disableThinkingInCompactionSummary
-            ? { reasoning: { effort: 'low' } }
+            ? {
+                reasoning: {
+                  effort: this.normalizeReasoningEffort(ReasoningEffort.NONE),
+                },
+              }
             : {}),
         };
         const summaryResponse = await auxiliaryRetry(
@@ -576,6 +606,8 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     const message = responseObject?.choices?.[0]?.message;
     if (!message) return null;
 
+    this.reasoningDetails = [...(message.reasoningDetails ?? [])];
+
     // Try reasoningDetails first (OpenRouter normalized format)
     const reasoningDetails = message.reasoningDetails;
     if (reasoningDetails) {
@@ -633,16 +665,20 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
       result: ToolResult;
       attachments: ToolFileAttachment[];
     }>,
-    _workspaceState?: AgentWorkspaceState,
+    workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<ChatMessages[]> {
     if (entries.length === 0) return [];
 
-    const callMsg: ChatMessages = {
+    const reasoningDetails = this.reasoningDetails;
+    this.reasoningDetails = [];
+    const callMsg: ChatAssistantMessage & { role: 'assistant' } = {
       role: 'assistant',
       toolCalls: entries.map(({ call }) => call.raw),
+      ...(reasoningDetails.length ? { reasoningDetails } : {}),
       ...(text ? { content: text } : {}),
     };
+    workspaceState?.resetReasoning();
 
     const resultMsgs: ChatMessages[] = entries.map(
       ({ call, result, attachments }) => ({

--- a/src/agent/modelHandlers/support/reasoningEffort.ts
+++ b/src/agent/modelHandlers/support/reasoningEffort.ts
@@ -13,6 +13,7 @@ import type { ReasoningEffort as OpenAIReasoningEffort } from 'openai/resources/
  */
 export const LEVEL_TO_EFFORT: Readonly<Record<string, ReasoningEffort>> = {
   none: ReasoningEffort.NONE,
+  minimal: ReasoningEffort.MINIMAL,
   low: ReasoningEffort.LOW,
   medium: ReasoningEffort.MEDIUM,
   high: ReasoningEffort.HIGH,
@@ -20,18 +21,60 @@ export const LEVEL_TO_EFFORT: Readonly<Record<string, ReasoningEffort>> = {
   max: ReasoningEffort.MAX,
 };
 
+const REASONING_EFFORT_ORDER: readonly ReasoningEffort[] = [
+  ReasoningEffort.NONE,
+  ReasoningEffort.MINIMAL,
+  ReasoningEffort.LOW,
+  ReasoningEffort.MEDIUM,
+  ReasoningEffort.HIGH,
+  ReasoningEffort.XHIGH,
+  ReasoningEffort.MAX,
+];
+
+/** Clamp an effort to the nearest tier in a model's exact declared vocabulary. */
+export function normalizeSupportedReasoningEffort(
+  effort: string,
+  supported: readonly ReasoningEffort[] | undefined,
+  fallback: ReasoningEffort,
+): ReasoningEffort {
+  if (!supported?.length) return fallback;
+  if (supported.includes(effort as ReasoningEffort)) {
+    return effort as ReasoningEffort;
+  }
+
+  const requestedIndex = REASONING_EFFORT_ORDER.indexOf(
+    effort as ReasoningEffort,
+  );
+  if (requestedIndex < 0) return fallback;
+
+  return supported.reduce((nearest, candidate) => {
+    const nearestIndex = REASONING_EFFORT_ORDER.indexOf(nearest);
+    const candidateIndex = REASONING_EFFORT_ORDER.indexOf(candidate);
+    const nearestDistance = Math.abs(nearestIndex - requestedIndex);
+    const candidateDistance = Math.abs(candidateIndex - requestedIndex);
+    return candidateDistance < nearestDistance ||
+      (candidateDistance === nearestDistance && candidateIndex > nearestIndex)
+      ? candidate
+      : nearest;
+  });
+}
+
 type NonNullOpenAIReasoningEffort = Exclude<OpenAIReasoningEffort, null>;
 
 /** Whether the model exposes a genuine user-selectable effort range. */
 function hasConfigurableReasoningEffort(
   capabilities: ModelCapabilities,
 ): boolean {
-  return (
-    capabilities.supportsReasoningEffort &&
-    !(
-      capabilities.reasoningEffort === ReasoningEffort.MAX &&
-      capabilities.maxReasoningEffort === undefined
-    )
+  if (!capabilities.supportsReasoningEffort) return false;
+
+  const exactEfforts = capabilities.supportedReasoningEfforts;
+  if (exactEfforts?.length) {
+    return new Set(exactEfforts).size > 1;
+  }
+
+  return !(
+    capabilities.reasoningEffort === ReasoningEffort.MAX &&
+    capabilities.maxReasoningEffort === undefined
   );
 }
 
@@ -91,15 +134,15 @@ export function toOpenAIReasoningEffort(
 
 /**
  * Clamp an internal reasoning-effort value for providers whose OpenAI-compatible
- * surface accepts only 'high' and 'max' (DeepSeek, GLM). Their compatibility
+ * surface accepts only 'high' and 'max' (DeepSeek). Their compatibility
  * layer maps the below-high tiers (none/low/medium) up to the 'high' floor and
  * the above-high tiers (xhigh, max) to 'max'; reproduce that explicitly so an
  * out-of-vocabulary value never leaks to the API.
  */
 export function clampReasoningEffortToHighOrMax(
   effort: string,
-): 'high' | 'max' {
+): ReasoningEffort.HIGH | ReasoningEffort.MAX {
   return effort === ReasoningEffort.XHIGH || effort === ReasoningEffort.MAX
-    ? 'max'
-    : 'high';
+    ? ReasoningEffort.MAX
+    : ReasoningEffort.HIGH;
 }

--- a/src/controllers/settingsView/SettingsModelSelectionController.ts
+++ b/src/controllers/settingsView/SettingsModelSelectionController.ts
@@ -239,6 +239,13 @@ export class SettingsModelSelectionController {
     if (!supportsReasoningLevel(config)) return;
 
     item.supportsReasoningLevel = true;
+    const supportedLevels = config.capabilities.supportedReasoningEfforts
+      ?.map((effort) => EFFORT_TO_LEVEL.get(effort))
+      .filter((level): level is ReasoningLevel => level !== undefined);
+    if (supportedLevels?.length) {
+      item.supportedReasoningLevels = supportedLevels;
+    }
+
     const defaultLevel = EFFORT_TO_LEVEL.get(
       config.capabilities.reasoningEffort,
     );
@@ -247,7 +254,10 @@ export class SettingsModelSelectionController {
     }
 
     const parsed = ReasoningLevelSchema.safeParse(override);
-    if (parsed.success) {
+    if (
+      parsed.success &&
+      (!supportedLevels?.length || supportedLevels.includes(parsed.data))
+    ) {
       item.reasoningLevel = parsed.data;
     }
   }

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -48,8 +48,9 @@ export const PREFERRED_DEFAULT_MODELS: readonly string[] = [
   'deepseekproT',
   'kimi26T',
   'kimi3',
-  // Current non-retired GLM flagship.
+  // Current non-retired GLM flagships.
   'glm53',
+  'glm53flash',
   // Current non-retired xAI flagship — API key or experimental Grok OAuth.
   'grok45',
 ];

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -276,6 +276,7 @@ export type UpdateAgentSelectionMessage = z.infer<
 /** Reasoning effort levels that a user can select (low → high tiers). */
 export const ReasoningLevelSchema = z.enum([
   'none',
+  'minimal',
   'low',
   'medium',
   'high',
@@ -285,6 +286,7 @@ export const ReasoningLevelSchema = z.enum([
 export type ReasoningLevel = z.infer<typeof ReasoningLevelSchema>;
 export const REASONING_LEVEL_LABELS: Record<ReasoningLevel, string> = {
   none: 'None',
+  minimal: 'Minimal',
   low: 'Low',
   medium: 'Medium',
   high: 'High',
@@ -313,6 +315,8 @@ const ModelSelectionItemSchema = z.object({
   defaultReasoningLevel: ReasoningLevelSchema.optional(),
   /** The user's chosen reasoning level override (undefined = use default). */
   reasoningLevel: ReasoningLevelSchema.optional(),
+  /** Exact registry-declared effort vocabulary for this model. */
+  supportedReasoningLevels: z.array(ReasoningLevelSchema).optional(),
   /** Whether this model qualifies as a "fast first response" pick (price-based). */
   isFast: z.boolean().optional(),
   // Resolved once by computeModelOptionsData and carried verbatim so the

--- a/src/test-kernel/agent/modelHandlers/OpenAICompatibleProviderParams.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAICompatibleProviderParams.vitest.ts
@@ -462,7 +462,7 @@ describe('OpenAI-compatible provider request params', () => {
     assert.equal(createCalls[0].thinking, undefined);
   });
 
-  it('maps GLM low reasoning effort to the provider minimum', async () => {
+  it('preserves GLM low reasoning effort when the registry accepts it', async () => {
     const handler = createGlmHandler({
       name: 'glm52',
       fullName: 'glm-5.2',
@@ -470,13 +470,22 @@ describe('OpenAI-compatible provider request params', () => {
         supportsReasoning: true,
         supportsReasoningEffort: true,
         reasoningEffort: ReasoningEffort.LOW,
+        supportedReasoningEfforts: [
+          ReasoningEffort.NONE,
+          ReasoningEffort.MINIMAL,
+          ReasoningEffort.LOW,
+          ReasoningEffort.MEDIUM,
+          ReasoningEffort.HIGH,
+          ReasoningEffort.XHIGH,
+          ReasoningEffort.MAX,
+        ],
       },
     });
 
     const { createCalls } = await sendRequest(handler);
 
     assert.deepEqual(createCalls[0].thinking, { type: 'enabled' });
-    assert.equal(createCalls[0].reasoning_effort, 'high');
+    assert.equal(createCalls[0].reasoning_effort, 'low');
   });
 
   it('maps GLM max reasoning effort to the provider maximum', async () => {

--- a/src/test-kernel/model/ModelOptionsBasic.vitest.ts
+++ b/src/test-kernel/model/ModelOptionsBasic.vitest.ts
@@ -150,7 +150,7 @@ describe('computeModelListVersion', () => {
   });
 
   it('preserves the established hash for the current preferred set', () => {
-    expect(MODEL_LIST_VERSION).toBe(3_975_990_547);
+    expect(MODEL_LIST_VERSION).toBe(1_872_513_843);
   });
 
   it('does not change when a non-preferred catalogue model retires', () => {

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -408,6 +408,7 @@ describe('state settings catalog', () => {
       ),
       [
         'none — None',
+        'minimal — Minimal',
         'low — Low',
         'medium — Medium',
         'high — High',

--- a/supabase/functions/log-usage/deno.lock
+++ b/supabase/functions/log-usage/deno.lock
@@ -7,7 +7,7 @@
     "npm:@supabase/postgrest-js@2.111.0": "2.111.0",
     "npm:@supabase/realtime-js@2.111.0": "2.111.0",
     "npm:@supabase/storage-js@2.111.0": "2.111.0",
-    "npm:llm-zoo@^1.30.0": "1.30.0_zod@4.4.3",
+    "npm:llm-zoo@^1.31.0": "1.31.0_zod@4.4.3",
     "npm:zod@^4.4.3": "4.4.3"
   },
   "jsr": {
@@ -61,8 +61,8 @@
     "iceberg-js@0.8.1": {
       "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
     },
-    "llm-zoo@1.30.0_zod@4.4.3": {
-      "integrity": "sha512-H7dkb6+qSPEbuH/B/Q5QH0HcI+ibSXpKeXY/cik7dpkuxwS4taJBZs6E0/mqNHSddfqRKlzbcy1mvOdwtqMBtQ==",
+    "llm-zoo@1.31.0_zod@4.4.3": {
+      "integrity": "sha512-dYAuFBgFN7bw1B12su1XyUFwSM13loI1Np1HKjS9YNVYiu8dV2lHia7C63MwZrZZkMVnDhIfjUspRcNB0vHfJA==",
       "dependencies": [
         "zod"
       ],
@@ -80,7 +80,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@supabase/supabase-js@2.111.0",
-      "npm:llm-zoo@^1.30.0",
+      "npm:llm-zoo@^1.31.0",
       "npm:zod@^4.4.3"
     ]
   }


### PR DESCRIPTION
## Summary

Follow-up to #11473 after the `llm-zoo` 1.31.0 bump exposed provider-specific reasoning behavior that TeXRA needed to consume.

- make native GLM request and compaction reasoning follow each model’s exact registry vocabulary
- keep forced thinking enabled for GLM-5.3 and GLM-5.3-Flash compaction
- add product-facing `minimal` reasoning and expose only each model’s supported effort levels in Settings
- normalize OpenRouter effort against exact model vocabularies while preserving `none` where supported
- preserve and replay OpenRouter `reasoningDetails` exactly once across tool follow-ups
- feature `glm53flash` alongside `glm53` in the preferred model list
- synchronize the active Supabase Deno lock with `llm-zoo` 1.31.0

## Compatibility details

- GLM-5.3/Flash accept `low`, `high`, and `max`; thinking cannot be disabled, including compaction summaries.
- GLM-5.2 accepts `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`; only `none` disables thinking, while `minimal` remains a valid enabled-thinking effort.
- Models without an exact registry vocabulary retain their existing provider behavior.

## Verification

- `pnpm run typecheck` — 721 declarations and 70 external packages validated
- focused GLM/settings/model-list suites — 3 files, 71 tests passed after the final rebase
- independent focused review — 5 files, 105 tests passed; no blocking findings
- ESLint on changed production files
- Prettier on changed supported files
- Deno lock JSON validation
- `git diff --check`

Deno itself is unavailable locally, so the Supabase Deno test was not executed. The lockfile uses the npm 1.31.0 integrity already resolved by pnpm.