### PR TITLE
dedupe: swap four hand-rolled clamp reimplementations for @utils/core clamp

### DIFF
--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -27,6 +27,7 @@ import {
   createMarkdownRenderer,
   type MarkdownItInstance,
 } from '@shared/markdown/createMarkdownRenderer';
+import { clamp } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { normalizeKnownHtmlForCliMarkdown } from './htmlMarkdownNormalize';
 
@@ -354,7 +355,7 @@ function configureAnsi(
 
   r.hr = (tokens, idx) =>
     `${quoteBlockStart(tokens, idx)}${style.dim(
-      '─'.repeat(Math.max(1, Math.min(40, width ?? 40))),
+      '─'.repeat(clamp(width ?? 40, 1, 40)),
     )}\n`;
 
   // Emit raw SGR codes so the styling stays open across the link body. The

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -24,6 +24,7 @@ import {
 } from '@shared/schemas';
 import { recordToolFileRead } from '@tools/fileInteractions';
 import { errorResult } from '@tools/core/result';
+import { clamp } from '@utils/core';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { getConfig } from '@utils/config/configUtils';
 import { applyPatchToText } from '@utils/text/diff';
@@ -177,11 +178,11 @@ export function firstChangedLine(
     // A deletion has no line of its own in the proposed text; reveal the
     // position it was removed from.
     if (marker === '-') {
-      return Math.min(Math.max(line - 1, 0), lastProposedLine);
+      return clamp(line - 1, 0, lastProposedLine);
     }
     line += 1;
   }
-  return Math.min(Math.max(hunk.newStart - 1, 0), lastProposedLine);
+  return clamp(hunk.newStart - 1, 0, lastProposedLine);
 }
 
 // ============================================================================

--- a/src/transcript/StreamLog.ts
+++ b/src/transcript/StreamLog.ts
@@ -7,7 +7,7 @@ import {
   type StreamLogTextDelta,
   type WorkflowCallProgress,
 } from '@shared/schemas';
-import { isObject } from '@utils/core';
+import { clamp, isObject } from '@utils/core';
 
 export type StreamLogAppendInput = Omit<
   StreamLogEntry,
@@ -549,7 +549,7 @@ export class StreamLog {
 
   getRange(fromSeq: number, toSeq: number = this.seqCounter): StreamLogEntry[] {
     const safeFrom = Math.max(0, fromSeq);
-    const safeTo = Math.min(this.seqCounter, Math.max(safeFrom, toSeq));
+    const safeTo = clamp(toSeq, safeFrom, this.seqCounter);
     if (safeFrom >= safeTo) return [];
     return this.entries.slice(safeFrom, safeTo);
   }


### PR DESCRIPTION
## Summary

Scheduled sweep for consolidation and native/existing-utility opportunities. The repo already ran three exhaustive simplification-survey rounds in the last 48 hours (`docs/proposals/2026-08-2{5,6}-simplification-survey-*.md`, ~115 verified findings shipped across dozens of PRs), and my own scan for classic hand-rolled-vs-native patterns (custom sleep/delay, debounce, throttle, deep-clone, UUID gen, manual promise chains, dedup loops) found nothing new — all came back empty or were legitimate, justified code.

The one genuine remaining bundle: four `Math.min(Math.max(...))` / `Math.max(..., Math.min(...))` clamp reimplementations, at five call sites in three files, where the repo's own `clamp(value, min, max)` helper (`src/utils/core/index.ts`, 30+ existing call sites across all four hosts) was already the established convention in sibling files in each of these very directories — these three files just didn't follow it.

- `src/tools/approval/toolEditApproval.ts:180,184` — verbatim-duplicated clamp within the same file.
- `src/transcript/StreamLog.ts:552` — `getRange`'s bound computation; verified behaviorally identical for every reachable branch (the reordering only differs when the lower bound exceeds the upper bound, and that case already short-circuits to an empty-range return either way).
- `packages/cli/src/chat/tui/render/ansiMarkdown.ts:357` — horizontal-rule width clamp; sibling files in the same directory tree already import `clamp` from `@utils/core`.

One additional candidate flagged by the survey (`BaseTextInput.tsx:295`, `textInputCappedRowCount`) was checked and rejected: `Math.min(Math.max(1, maxRows), X)` only lower-bounds `maxRows`, not the value being capped — it is not a three-argument clamp and swapping it would change behavior, so it was left alone.

No proposal or tech-debt issue was filed for this — the finding was small enough to ship directly as one bundle rather than write up.

## Issue acceptance gates

n/a — not tracked by an issue; a direct, small, verified finding from a scheduled consolidation sweep.

## Single source of truth

`clamp` in `src/utils/core/index.ts` is now the single implementation at all four call sites; no new module or coordinator introduced.

## Duplication and abstraction budget

Removed 4 duplicated nested-`Math.min(Math.max(...))` clamp reimplementations (5 call sites) in favor of the existing, already-adopted `clamp()` utility. No new abstraction added.

## Net elements (R6)

3 files changed, +7/-5 LoC (net +2, from the three added `import { clamp } from '@utils/core'` lines). No exported symbols, classes, interfaces, or enums added or removed.

## Consumer counts (R8)

n/a — no emit path or public export deleted or re-routed; this is an internal call-site swap to an existing utility whose own consumer count (30+) is unchanged.

## Host impact

Extension: none (files not in extension-only code).

Desktop: none.

CLI: `packages/cli/src/chat/tui/render/ansiMarkdown.ts` — horizontal-rule width clamp, behavior-preserving.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean across workspace, test-kernel, agent, cli, trace-viewer, desktop.
- `npm run lint` — clean (one import-order finding auto-fixed before commit).
- `npm run format` — clean.
- `npm run check:dead-code-ratchet` — no new findings.
- Targeted test suites for all three touched files (`StreamLog.vitest.ts`, `StreamLogDelta.vitest.ts`, `AnsiMarkdown.vitest.ts`, `ToolEditApprovalController.vitest.ts`, `DesktopToolEditApproval.vitest.ts`): 212/212 passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_0129CPrSv3j26FwodHcqyrsD)_