### PR TITLE
refactor: simplify data structures flagged by the complexity audit

### DIFF
--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -298,18 +298,35 @@ export async function executeCliRequest(
   let ownedExecutionId: ExecutionId | undefined;
   const launchAbortController = new AbortController();
   let shutdownRequested = false;
-  let shutdownInterrupted = false;
-  let workflowOutputPublicationCommitted = false;
-  let shutdownArtifactFailure: unknown;
-  let shutdownFinalizationFailureReported = false;
+  // Workflow-output publication and shutdown-driven interruption race on the
+  // same synchronous tick (see tryCommitWorkflowOutputPublication and the
+  // onShutdown handler below): at most one may own the terminal verdict for
+  // this launch. Modeling that as one variable makes "both committed and
+  // interrupted" unrepresentable instead of relying on two booleans staying
+  // in sync by hand. The artifact-failure and report-dedupe bookkeeping are
+  // only ever meaningful once interrupted, so they live on that variant too.
+  type LaunchVerdict =
+    | { readonly kind: 'undecided' }
+    | { readonly kind: 'published' }
+    | {
+        readonly kind: 'interrupted';
+        artifactFailure: unknown;
+        finalizationFailureReported: boolean;
+      };
+  let launchVerdict: LaunchVerdict = { kind: 'undecided' };
   const reportFinalizationFailure = (error: unknown): void => {
     session.interactions.emit('requestShowError', {
       message: toErrorMessage(error),
     });
   };
   const reportShutdownFinalizationFailure = (error: Error): void => {
-    if (shutdownFinalizationFailureReported) return;
-    shutdownFinalizationFailureReported = true;
+    if (
+      launchVerdict.kind !== 'interrupted' ||
+      launchVerdict.finalizationFailureReported
+    ) {
+      return;
+    }
+    launchVerdict.finalizationFailureReported = true;
     reportFinalizationFailure(error);
   };
   let settleLeaseAcquired: (
@@ -330,12 +347,12 @@ export async function executeCliRequest(
   // Both callbacks enter on this event loop, and neither yields between the
   // check and assignment. Exactly one can therefore own the terminal verdict.
   const tryCommitWorkflowOutputPublication = (): boolean => {
-    if (shutdownInterrupted) return false;
-    workflowOutputPublicationCommitted = true;
+    if (launchVerdict.kind === 'interrupted') return false;
+    launchVerdict = { kind: 'published' };
     return true;
   };
   const finalizeShutdownStatus = (): Promise<boolean> => {
-    if (!shutdownInterrupted) return Promise.resolve(false);
+    if (launchVerdict.kind !== 'interrupted') return Promise.resolve(false);
     shutdownStatusFinalized ??= (async () => {
       const executionId = await leaseAcquired;
       if (!executionId) return false;
@@ -368,8 +385,11 @@ export async function executeCliRequest(
         // below, which rethrows it into runAgent's artifact aggregate. This
         // memoized operation itself resolves false so the outer shutdown await
         // cannot rethrow the same error over the primary run failure.
-        if (!(error instanceof ExecutionLeaseLostError)) {
-          shutdownArtifactFailure = error;
+        if (
+          !(error instanceof ExecutionLeaseLostError) &&
+          launchVerdict.kind === 'interrupted'
+        ) {
+          launchVerdict.artifactFailure = error;
         }
         return false;
       }
@@ -381,21 +401,27 @@ export async function executeCliRequest(
     async (shutdownDeadline) => {
       shutdownRequested = true;
       launchAbortController.abort();
-      // Paired with tryCommitWorkflowOutputPublication: keep this flag read
-      // and the shutdownInterrupted assignment below in one synchronous turn.
+      // Paired with tryCommitWorkflowOutputPublication: keep this read of
+      // launchVerdict and the assignment below in one synchronous turn.
       // Headless shutdown deliberately cascades into active children: a
       // detached child cannot outlive the exiting CLI process, so the
       // detach-on-stop toggle is not consulted on this path.
       const interruptionAccepted =
-        !workflowOutputPublicationCommitted && launchExecutionId
+        launchVerdict.kind !== 'published' && launchExecutionId
           ? session.executions.kill(launchExecutionId, {
               detachActiveChildren: false,
             })
           : false;
-      shutdownInterrupted = interruptionAccepted || shutdownInterrupted;
+      if (interruptionAccepted && launchVerdict.kind === 'undecided') {
+        launchVerdict = {
+          kind: 'interrupted',
+          artifactFailure: undefined,
+          finalizationFailureReported: false,
+        };
+      }
       let resumableCheckpoint:
         Extract<ResumabilityDecision, { kind: 'checkpoint' }> | undefined;
-      if (shutdownInterrupted && ownedExecutionId) {
+      if (launchVerdict.kind === 'interrupted' && ownedExecutionId) {
         try {
           const resumability = await deriveResumability(ownedExecutionId);
           if (resumability.kind === 'checkpoint') {
@@ -453,9 +479,12 @@ export async function executeCliRequest(
         launchSignal: launchAbortController.signal,
         beforeLeaseRelease: async () => {
           const handled = await finalizeShutdownStatus();
-          if (shutdownArtifactFailure !== undefined) {
-            const error = shutdownArtifactFailure;
-            shutdownArtifactFailure = undefined;
+          if (
+            launchVerdict.kind === 'interrupted' &&
+            launchVerdict.artifactFailure !== undefined
+          ) {
+            const error = launchVerdict.artifactFailure;
+            launchVerdict.artifactFailure = undefined;
             throw error;
           }
           return handled;

--- a/packages/desktop/src/main/desktopFileSelection.ts
+++ b/packages/desktop/src/main/desktopFileSelection.ts
@@ -5,7 +5,7 @@ import {
   getFileListConfig,
   loadFileListSettings,
   matchesEditedFile,
-  type FileListConfig,
+  type FileFilterConfig,
   type ListableFileType,
 } from '@common/files/fileListingRules';
 import { listWorkspaceFiles } from '@common/files/workspaceFileListing';
@@ -76,7 +76,7 @@ type DesktopMultiFileType = keyof typeof MULTI_SET_COMMAND_BY_FILE_TYPE;
 
 async function listFiles(
   root: string,
-  rawConfig: FileListConfig,
+  rawConfig: FileFilterConfig,
 ): Promise<string[]> {
   return listWorkspaceFiles({
     root,
@@ -216,7 +216,7 @@ export function createDesktopFileSelection(
           // Electron's dialog filter extensions must not include the leading
           // dot (unlike getFileListConfig's `.tex`-style entries); the VS
           // Code picker gets this right via getFilterExtensions.
-          extensions: (listConfig?.extensions ?? ['*']).map((ext) =>
+          extensions: (listConfig?.include ?? ['*']).map((ext) =>
             ext.replace(/^\./, ''),
           ),
         },

--- a/packages/desktop/src/main/desktopWorkspaceIpc.ts
+++ b/packages/desktop/src/main/desktopWorkspaceIpc.ts
@@ -228,17 +228,17 @@ export function createDesktopWorkspaceIpc(
       // the input picker's `.ts`/`.js`/`.json` exclusions. Only known binary
       // media and office formats are hidden from this text editor.
       const filters = prepareFileFilters({
-        extensions: [],
-        ignoredExtensions: [
+        include: [],
+        excludeExtensions: [
           ...new Set([
             ...getIncludedExtensions('media'),
             ...OFFICE_EXTENSIONS,
             '.vsix',
           ]),
         ],
-        ignoredDirs: settings.ignoredDirectories,
-        ignoredKeywords: [],
-        ignoredFiles: [],
+        excludeDirs: settings.ignoredDirectories,
+        excludeKeywords: [],
+        excludeFiles: [],
       });
       const absoluteDirectory = normalizedDirectory
         ? await resolveWorkspacePath(normalizedDirectory)

--- a/packages/extension/src/commands/agent/executeCommand.ts
+++ b/packages/extension/src/commands/agent/executeCommand.ts
@@ -11,18 +11,24 @@ import {
 } from '@agent/runtime';
 import { openFinalOutputIfAvailable } from '@frontend/agents/finalOutputOpener';
 import { createLog } from '@logger/logUtils';
-import type { ExecutionId } from '@shared/schemas';
+import { ExecutionIdSchema } from '@shared/schemas';
 
 const log = createLog('ExecuteCommand');
 
-interface WrappedExecuteInput {
-  config: unknown;
-  executionId?: ExecutionId;
-  preferHelperModel?: boolean;
-  modelHandlerCompatibilityKey?: unknown;
-  copilotRouteOverride?: unknown;
-  onRun?: () => void;
-}
+/**
+ * The "wrapped" launch shape — `{ config, executionId?, ... }` — as opposed to
+ * a bare `AgentConfig` passed directly (see `runExecuteCommand`'s doc
+ * comment). `config` is validated separately against `AgentConfigSchema`, so
+ * it stays `z.unknown()` here. `onRun` is a live callback, not serializable
+ * data, so it is read directly off the input rather than run through Zod.
+ */
+const WrappedExecuteInputSchema = z.object({
+  config: z.unknown(),
+  executionId: ExecutionIdSchema.optional(),
+  preferHelperModel: z.boolean().optional(),
+  modelHandlerCompatibilityKey: ModelHandlerCompatibilityKeySchema.nullish(),
+  copilotRouteOverride: z.literal('direct').optional(),
+});
 
 /**
  * Execute an agent with the given configuration.
@@ -35,19 +41,14 @@ interface WrappedExecuteInput {
  */
 export async function runExecuteCommand(input: unknown): Promise<void> {
   try {
-    const wrapped =
-      input !== null && typeof input === 'object' && 'config' in input
-        ? (input as WrappedExecuteInput)
-        : null;
+    const isWrapped =
+      input !== null && typeof input === 'object' && 'config' in input;
+    const wrapped = isWrapped ? WrappedExecuteInputSchema.parse(input) : null;
     const config = AgentConfigSchema.parse(wrapped ? wrapped.config : input);
-    const modelHandlerCompatibilityKey =
-      ModelHandlerCompatibilityKeySchema.nullish().parse(
-        wrapped?.modelHandlerCompatibilityKey,
-      );
-    const copilotRouteOverride = z
-      .literal('direct')
-      .optional()
-      .parse(wrapped?.copilotRouteOverride);
+    // Not data, so it bypasses the Zod schema above — see that schema's doc.
+    const onRun = isWrapped
+      ? (input as { onRun?: () => void }).onRun
+      : undefined;
 
     const request = wrapped?.executionId
       ? ({ kind: 'resume', config, executionId: wrapped.executionId } as const)
@@ -58,9 +59,9 @@ export async function runExecuteCommand(input: unknown): Promise<void> {
       // progress-view compile fixer); a direct main-view launch omits it and
       // keeps the user's selected model.
       preferHelperModel: wrapped?.preferHelperModel === true,
-      modelHandlerCompatibilityKey,
-      copilotRouteOverride,
-      onRun: wrapped?.onRun,
+      modelHandlerCompatibilityKey: wrapped?.modelHandlerCompatibilityKey,
+      copilotRouteOverride: wrapped?.copilotRouteOverride,
+      onRun,
     });
   } catch (error) {
     if (error instanceof ZodError) {

--- a/packages/extension/src/frontend/files/fileLister.ts
+++ b/packages/extension/src/frontend/files/fileLister.ts
@@ -5,7 +5,7 @@ import {
   getFileListConfig,
   loadFileListSettings,
   matchesEditedFile,
-  type FileListConfig,
+  type FileFilterConfig,
   type ListableFileType,
 } from '@common/files/fileListingRules';
 import { createLog } from '@logger/logUtils';
@@ -46,7 +46,7 @@ export class FileLister {
     return files.filter((file) => matchesEditedFile(file, baseFileName));
   }
 
-  private async listFiles(config: FileListConfig): Promise<string[]> {
+  private async listFiles(config: FileFilterConfig): Promise<string[]> {
     if (!this.workspacePath) {
       log.warn('No workspace folder found');
       return [];

--- a/packages/extension/src/frontend/files/listing.ts
+++ b/packages/extension/src/frontend/files/listing.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import {
   passesFileFilters,
   prepareFileFilters,
-  type FileListConfig,
+  type FileFilterConfig,
 } from '@common/files/fileListingRules';
 import { normalizeFilePath } from '@utils/core';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
@@ -56,7 +56,7 @@ function getRelativePathPreservingSymlinks(
 
 export async function getFilesRecursively(
   root: string,
-  config: FileListConfig,
+  config: FileFilterConfig,
 ): Promise<string[]> {
   const filters = prepareFileFilters(config);
 

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -607,7 +607,7 @@ export class MainApp extends MainAppBase {
           .editedFile=${sf.editedFile}
           .editedFileOptions=${fo.editedFile ?? []}
           .commit=${commit$.get()}
-          .commitOptions=${fo.commit ?? []}
+          .commitOptions=${fo.commit}
           .isGitRepo=${isGitRepo$.get()}
           @latexdiffs-toggle=${this.onLatexDiffsToggle}
           @latexdiffs-action=${({

--- a/packages/extension/src/webview/frontend/slices/documentSlice.ts
+++ b/packages/extension/src/webview/frontend/slices/documentSlice.ts
@@ -59,7 +59,7 @@ function isDocumentFileType(value: string): value is DocumentFileType {
 /** Check if a commit hash exists in the options array. */
 function hasCommitValue(value: string): boolean {
   if (!value) return false;
-  return (fileOptions$.get().commit ?? []).some((commit) => {
+  return fileOptions$.get().commit.some((commit) => {
     const [hash] = commit.split(': ');
     return hash === value;
   });
@@ -162,7 +162,7 @@ export const documentHandlers = {
 
     if (!commitHash) return;
     const fo = fileOptions$.get();
-    const options = fo.commit ?? [];
+    const options = fo.commit;
     if (!options.some((option) => option.startsWith(commitHash))) {
       fileOptions$.set({
         ...fo,

--- a/src/agent/core/tools/toolAttachmentExtraction.ts
+++ b/src/agent/core/tools/toolAttachmentExtraction.ts
@@ -7,12 +7,24 @@ import {
   ValidationErrorDiagnosticsSchema,
 } from '@shared/schemas';
 
-const ERROR_PAYLOAD_STRIPPED_KEYS = new Set([
-  'output',
-  'summary',
-  'edits',
-  'files',
-]);
+/**
+ * Sanitize the shared `diagnostics` field. Sanitized results only carry the
+ * validation-error diagnostics shape (see `ToolResultSharedFields.diagnostics`
+ * for why the source field is `z.unknown()`); any other tool's diagnostics
+ * payload — or a validation-error payload whose `formatted` doesn't actually
+ * match `FormattedZodIssueSchema` — is dropped rather than passed through
+ * untyped.
+ */
+function sanitizeDiagnostics(
+  diagnostics: unknown,
+): { type: 'validation_error'; formatted: unknown } | undefined {
+  if (diagnostics === undefined) return undefined;
+  const validationError =
+    ValidationErrorDiagnosticsSchema.safeParse(diagnostics);
+  if (!validationError.success) return undefined;
+  const { type, formatted } = validationError.data;
+  return { type, formatted };
+}
 
 /**
  * Result from extracting attachments from a tool result.
@@ -39,50 +51,60 @@ export function extractToolAttachments(
   result: ToolResult,
 ): ExtractedToolAttachments {
   const parsed = ToolResultSchema.parse(result);
-  const status = parsed.status;
-  const attachments: ToolFileAttachment[] =
-    status === 'executed' ? (parsed.files ?? []) : [];
-  const sanitizedResult: Record<string, unknown> = { status };
+  const diagnostics = sanitizeDiagnostics(parsed.diagnostics);
 
-  for (const [key, value] of Object.entries(parsed)) {
-    if (value === undefined) continue;
-    if (key === 'base64Data' || key === 'bytes') {
-      continue;
-    }
-    if (status === 'executed' && key === 'error') {
-      continue;
-    }
-    if (status === 'error' && ERROR_PAYLOAD_STRIPPED_KEYS.has(key)) {
-      continue;
-    }
-    if (key === 'diagnostics') {
-      // Sanitized results only carry the validation-error diagnostics shape
-      // (see ToolResultSharedFields.diagnostics); any other tool's
-      // diagnostics payload — or a validation-error payload whose `formatted`
-      // doesn't actually match FormattedZodIssueSchema — is dropped here
-      // rather than passed through untyped.
-      const validationError = ValidationErrorDiagnosticsSchema.safeParse(value);
-      if (validationError.success) {
-        const { type, formatted } = validationError.data;
-        sanitizedResult[key] = { type, formatted };
-      }
-      continue;
-    }
-    sanitizedResult[key] = value;
+  if (parsed.status === 'error') {
+    // Error variant: no binary-bearing fields exist on this branch of the
+    // schema (output/edits/files are all `z.undefined()` here), so there is
+    // nothing to strip beyond binary payloads that can't occur. `summary` is
+    // real on this variant — "Brief summary for human-facing logs" — and must
+    // survive sanitization; it feeds ToolUseDispatchNode's progress log.
+    const sanitizedResult: ToolResult = {
+      status: 'error',
+      error: parsed.error,
+      ...(parsed.summary !== undefined ? { summary: parsed.summary } : {}),
+      ...(parsed.userInstruction !== undefined
+        ? { userInstruction: parsed.userInstruction }
+        : {}),
+      ...(parsed.userPatch !== undefined
+        ? { userPatch: parsed.userPatch }
+        : {}),
+      ...(parsed.attachmentSummary !== undefined
+        ? { attachmentSummary: parsed.attachmentSummary }
+        : {}),
+      ...(diagnostics !== undefined ? { diagnostics } : {}),
+    };
+    return { attachments: [], sanitizedResult };
   }
 
-  if (status === 'executed' && attachments.length > 0) {
-    sanitizedResult.files = attachments.map((file): FileReference => ({
-      path: file.path,
-      mimeType: file.mimeType,
-      ...(file.description ? { description: file.description } : {}),
-    }));
-  } else {
-    delete sanitizedResult.files;
-  }
+  // Executed variant: strip binary data (base64Data/bytes) from files, keep
+  // everything else the schema declares.
+  const attachments: ToolFileAttachment[] = parsed.files ?? [];
+  const sanitizedFiles: FileReference[] | undefined =
+    attachments.length > 0
+      ? attachments.map((file): FileReference => ({
+          path: file.path,
+          mimeType: file.mimeType,
+          ...(file.description ? { description: file.description } : {}),
+        }))
+      : undefined;
 
-  return {
-    attachments,
-    sanitizedResult: sanitizedResult as ToolResult,
+  const sanitizedResult: ToolResult = {
+    status: 'executed',
+    ...(parsed.output !== undefined ? { output: parsed.output } : {}),
+    ...(parsed.summary !== undefined ? { summary: parsed.summary } : {}),
+    ...(parsed.endTurn !== undefined ? { endTurn: parsed.endTurn } : {}),
+    ...(parsed.edits !== undefined ? { edits: parsed.edits } : {}),
+    ...(sanitizedFiles !== undefined ? { files: sanitizedFiles } : {}),
+    ...(parsed.userInstruction !== undefined
+      ? { userInstruction: parsed.userInstruction }
+      : {}),
+    ...(parsed.userPatch !== undefined ? { userPatch: parsed.userPatch } : {}),
+    ...(parsed.attachmentSummary !== undefined
+      ? { attachmentSummary: parsed.attachmentSummary }
+      : {}),
+    ...(diagnostics !== undefined ? { diagnostics } : {}),
   };
+
+  return { attachments, sanitizedResult };
 }

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -1,4 +1,4 @@
-import { Mutex } from 'async-mutex';
+import PQueue from 'p-queue';
 
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
@@ -68,7 +68,12 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
   private lastStoredSession: SupabaseSession | null = null;
   private lastStoredSessionVersion = 0;
   private lastRefreshFailure: SessionRefreshFailure | null = null;
-  private readonly sessionMutex = new Mutex();
+  // Single-flight serialized writes, same mechanism as
+  // SubscriptionOAuthCoordinator's `sessionMutations`: concurrency:1 makes
+  // `.onIdle()` alone a sufficient "no mutation in flight, and none can start
+  // without bumping sessionMutationVersion first" barrier for
+  // `loadStableSessionSnapshot`'s version-recheck loop below.
+  private readonly sessionMutations = new PQueue({ concurrency: 1 });
   private readonly log: Required<SupabaseSessionLog>;
 
   constructor(private readonly options: SupabaseSessionCoordinatorOptions) {
@@ -103,15 +108,14 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
    * delete the replacement.
    */
   async clearSessionIfCurrent(expected: SupabaseSession): Promise<boolean> {
-    let cleared = false;
-    await this.sessionMutex.runExclusive(async () => {
+    return this.sessionMutations.add(async () => {
       const current = await this.loadSession();
       if (
         !current ||
         current.accessToken !== expected.accessToken ||
         current.refreshToken !== expected.refreshToken
       ) {
-        return;
+        return false;
       }
 
       this.sessionMutationVersion += 1;
@@ -119,10 +123,8 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
       await this.options.storage.delete();
       this.lastStoredSession = null;
       this.lastStoredSessionVersion = mutationVersion;
-      cleared = true;
+      return true;
     });
-
-    return cleared;
   }
 
   /**
@@ -317,12 +319,9 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
   private async loadStableSessionSnapshot(): Promise<StableSessionSnapshot> {
     for (;;) {
       const versionBeforeLoad = this.sessionMutationVersion;
-      await this.sessionMutex.waitForUnlock();
+      await this.sessionMutations.onIdle();
       const session = await this.loadSession();
-      if (
-        versionBeforeLoad === this.sessionMutationVersion &&
-        !this.sessionMutex.isLocked()
-      ) {
+      if (versionBeforeLoad === this.sessionMutationVersion) {
         return { session, version: versionBeforeLoad };
       }
     }
@@ -332,7 +331,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     session: SupabaseSession | null,
     operation: () => Promise<void>,
   ): Promise<void> {
-    await this.sessionMutex.runExclusive(async () => {
+    await this.sessionMutations.add(async () => {
       this.sessionMutationVersion += 1;
       const mutationVersion = this.sessionMutationVersion;
       await operation();
@@ -347,7 +346,8 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
   ): Promise<SupabaseSession | null> {
     if (
       this.sessionMutationVersion !== expectedVersion ||
-      this.sessionMutex.isLocked()
+      this.sessionMutations.size > 0 ||
+      this.sessionMutations.pending > 0
     ) {
       return this.loadStableSession();
     }

--- a/src/common/files/fileListingRules.ts
+++ b/src/common/files/fileListingRules.ts
@@ -14,20 +14,26 @@ export interface FileListSettings {
   ignoredMediaDirs: string[];
 }
 
-export interface FileListConfig {
-  extensions: string[];
-  ignoredExtensions: string[];
-  ignoredDirs: string[];
-  ignoredKeywords: string[];
-  ignoredFiles: string[];
+/**
+ * One include/exclude file-filter shape, shared verbatim from category
+ * selection through to normalization — `prepareFileFilters` fills these same
+ * fields in place rather than renaming them, so `PreparedFileFilters` only
+ * adds `sanitizedDirs` on top.
+ */
+export interface FileFilterConfig {
+  include: string[];
+  excludeExtensions: string[];
+  excludeDirs: string[];
+  excludeKeywords: string[];
+  excludeFiles: string[];
 }
 
-export interface PreparedFileFilters {
-  includeExt: string[];
-  excludeExt: string[];
-  excludeKeywords: string[];
-  excludeDirs: string[];
-  excludeFiles: string[];
+export interface PreparedFileFilters extends FileFilterConfig {
+  /**
+   * `excludeDirs` before case-folding. Matching (`containsExcludedDirectory`)
+   * lowercases both sides, but the VS Code glob exclude pattern built in
+   * `listing.ts` runs against on-disk paths and needs the original case.
+   */
   sanitizedDirs: string[];
 }
 
@@ -56,41 +62,41 @@ export function loadFileListSettings(): FileListSettings {
 function buildInputLikeConfig(
   category: 'input' | 'edited',
   settings: FileListSettings,
-): FileListConfig {
+): FileFilterConfig {
   return {
-    extensions: getIncludedExtensions(category),
-    ignoredExtensions: settings.ignoredFileExtensions,
-    ignoredDirs: [
+    include: getIncludedExtensions(category),
+    excludeExtensions: settings.ignoredFileExtensions,
+    excludeDirs: [
       ...settings.ignoredDirectories,
       ...settings.ignoredInputDirectories,
     ],
-    ignoredKeywords: settings.ignoredKeywords,
-    ignoredFiles: settings.ignoredInputFiles,
+    excludeKeywords: settings.ignoredKeywords,
+    excludeFiles: settings.ignoredInputFiles,
   };
 }
 
 export function getFileListConfig(
   fileType: ListableFileType,
   settings: FileListSettings,
-): FileListConfig | null {
+): FileFilterConfig | null {
   switch (fileType) {
     case 'input':
       return buildInputLikeConfig('input', settings);
     case 'context':
       return {
-        extensions: getIncludedExtensions('context'),
-        ignoredExtensions: settings.ignoredFileExtensions,
-        ignoredDirs: settings.ignoredDirectories,
-        ignoredKeywords: settings.ignoredKeywords,
-        ignoredFiles: settings.ignoredInputFiles,
+        include: getIncludedExtensions('context'),
+        excludeExtensions: settings.ignoredFileExtensions,
+        excludeDirs: settings.ignoredDirectories,
+        excludeKeywords: settings.ignoredKeywords,
+        excludeFiles: settings.ignoredInputFiles,
       };
     case 'media':
       return {
-        extensions: getIncludedExtensions('media'),
-        ignoredExtensions: [],
-        ignoredDirs: settings.ignoredMediaDirs,
-        ignoredKeywords: settings.ignoredKeywords,
-        ignoredFiles: [],
+        include: getIncludedExtensions('media'),
+        excludeExtensions: [],
+        excludeDirs: settings.ignoredMediaDirs,
+        excludeKeywords: settings.ignoredKeywords,
+        excludeFiles: [],
       };
     case 'edited':
       return null;
@@ -99,7 +105,7 @@ export function getFileListConfig(
 
 export function getEditedFileListConfig(
   settings: FileListSettings,
-): FileListConfig {
+): FileFilterConfig {
   return buildInputLikeConfig('edited', settings);
 }
 
@@ -110,15 +116,15 @@ function sanitizeDirectories(directories: readonly string[]): string[] {
 }
 
 export function prepareFileFilters(
-  config: FileListConfig,
+  config: FileFilterConfig,
 ): PreparedFileFilters {
-  const sanitizedDirs = sanitizeDirectories(config.ignoredDirs);
+  const sanitizedDirs = sanitizeDirectories(config.excludeDirs);
   return {
-    includeExt: normalizeList(config.extensions),
-    excludeExt: normalizeList(config.ignoredExtensions),
-    excludeKeywords: normalizeList(config.ignoredKeywords),
+    include: normalizeList(config.include),
+    excludeExtensions: normalizeList(config.excludeExtensions),
+    excludeKeywords: normalizeList(config.excludeKeywords),
     excludeDirs: sanitizedDirs.map((dir) => dir.toLowerCase()),
-    excludeFiles: normalizeList(config.ignoredFiles),
+    excludeFiles: normalizeList(config.excludeFiles),
     sanitizedDirs,
   };
 }
@@ -156,12 +162,13 @@ export function passesFileFilters(
   const fileNameLower = getBasename(lowerPath);
   if (filters.excludeFiles.includes(fileNameLower)) return false;
   if (
-    filters.includeExt.length > 0 &&
-    !filters.includeExt.some((ext) => lowerPath.endsWith(ext))
+    filters.include.length > 0 &&
+    !filters.include.some((ext) => lowerPath.endsWith(ext))
   ) {
     return false;
   }
-  if (filters.excludeExt.some((ext) => lowerPath.endsWith(ext))) return false;
+  if (filters.excludeExtensions.some((ext) => lowerPath.endsWith(ext)))
+    return false;
   if (filters.excludeKeywords.some((kw) => fileNameLower.includes(kw))) {
     return false;
   }

--- a/src/common/files/workspaceFileListing.ts
+++ b/src/common/files/workspaceFileListing.ts
@@ -7,12 +7,12 @@ import {
   passesFileFilters,
   prepareFileFilters,
   shouldVisitDirectory,
-  type FileListConfig,
+  type FileFilterConfig,
 } from './fileListingRules';
 
 export interface WorkspaceFileListingOptions {
   root: string;
-  config: FileListConfig;
+  config: FileFilterConfig;
   readDirectory(path: string): Promise<[string, number][]>;
 }
 

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -880,7 +880,7 @@ export class SessionFactApplier {
 
     const isNewStream = !this.state.streamLogs.has(streamId);
     this.state.streamLogs.ensureStream(streamId);
-    // Persisted streams may be in stream logs but missing from _streamStates.
+    // Persisted streams may be in stream logs but missing from _ephemeralState.
     // The first RUNNING transition already created/reset the state above.
     const category = runningCategory ?? this.getStreamCategory(streamId);
     if (!isNewRunningTransition && category !== undefined) {

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -56,11 +56,6 @@ export interface SessionStreamMetadata extends StreamIdentityFields {
 type StoredStreamMetadata = Omit<SessionStreamMetadata, 'creationTimestamp'>;
 const EMPTY_STORED_STREAM_METADATA: StoredStreamMetadata = Object.freeze({});
 
-/** Ephemeral session state per stream (not persisted). */
-interface StreamSessionState {
-  metadata: StoredStreamMetadata;
-}
-
 interface CachedStreamMetadata {
   readonly stored: StoredStreamMetadata;
   readonly summary: ReturnType<StreamLogStore['getSummaryMeta']>;
@@ -91,6 +86,25 @@ export interface StreamExecutionState {
 }
 
 /**
+ * Ephemeral session-only state for one stream: live metadata patches plus
+ * backend-owned execution counters. The two are always created and cleared
+ * together (`claimStreamIdentity`, `clearEphemeralStreamState`), so they
+ * share one map entry rather than two separately-keyed maps; `execution` is
+ * still optional because a stream can accrue metadata (e.g. a description
+ * set before RUNNING) before `getOrCreateStreamState` ever mints it.
+ *
+ * `_streamMetadataCache` (a derived read cache invalidated by comparing
+ * `metadata`/summary/timestamp identity), `_streamIncarnations` (identity
+ * generation, which must outlive an ephemeral clear), and `_removedStreams`
+ * (tombstones, which must outlive the very ephemeral state they retire) each
+ * have a genuinely different lifetime and stay as separate maps.
+ */
+interface EphemeralStreamState {
+  metadata: StoredStreamMetadata;
+  execution?: StreamExecutionState;
+}
+
+/**
  * Host-neutral session state.
  *
  * Coordinates two persistence stores — `streamLogs` (transcript) and
@@ -109,8 +123,10 @@ export class SessionState {
   readonly stores: SessionStores;
 
   // -- Ephemeral state (session-only, not persisted) --------------------------
-  private readonly _streamStates = new Map<StreamTabId, StreamExecutionState>();
-  private readonly _sessionState = new Map<StreamTabId, StreamSessionState>();
+  private readonly _ephemeralState = new Map<
+    StreamTabId,
+    EphemeralStreamState
+  >();
   private readonly _streamMetadataCache = new Map<
     StreamTabId,
     CachedStreamMetadata
@@ -183,11 +199,11 @@ export class SessionState {
 
   // -- Ephemeral session state ------------------------------------------------
 
-  private getOrCreateSession(stream: StreamTabId): StreamSessionState {
-    let state = this._sessionState.get(stream);
+  private getOrCreateEphemeral(stream: StreamTabId): EphemeralStreamState {
+    let state = this._ephemeralState.get(stream);
     if (!state) {
       state = { metadata: {} };
-      this._sessionState.set(stream, state);
+      this._ephemeralState.set(stream, state);
     }
     return state;
   }
@@ -229,7 +245,7 @@ export class SessionState {
     stream: StreamTabId,
     metadata: StoredStreamMetadata,
   ): void {
-    this.getOrCreateSession(stream).metadata = metadata;
+    this.getOrCreateEphemeral(stream).metadata = metadata;
     this._streamMetadataCache.delete(stream);
   }
 
@@ -245,7 +261,7 @@ export class SessionState {
     stream: StreamTabId,
     patch: Partial<StoredStreamMetadata>,
   ): void {
-    const { metadata } = this.getOrCreateSession(stream);
+    const { metadata } = this.getOrCreateEphemeral(stream);
     this.setStoredStreamMetadata(stream, { ...metadata, ...patch });
   }
 
@@ -263,8 +279,8 @@ export class SessionState {
    */
   getStreamMetadata(stream: StreamTabId): Readonly<SessionStreamMetadata> {
     const removed = this.isStreamRemoved(stream);
-    const session = removed ? undefined : this.getOrCreateSession(stream);
-    const stored = session?.metadata ?? EMPTY_STORED_STREAM_METADATA;
+    const ephemeral = removed ? undefined : this.getOrCreateEphemeral(stream);
+    const stored = ephemeral?.metadata ?? EMPTY_STORED_STREAM_METADATA;
     const summary = this.streamLogs.getSummaryMeta(stream);
     const firstTimestamp = this.streamLogs.getTimestampRange(stream).first;
     const cached = this._streamMetadataCache.get(stream);
@@ -313,14 +329,15 @@ export class SessionState {
     stream: StreamTabId,
     agentCategory: (typeof AgentCategory)[keyof typeof AgentCategory],
   ): StreamExecutionState {
-    const existing = this._streamStates.get(stream);
+    const ephemeral = this.getOrCreateEphemeral(stream);
+    const existing = ephemeral.execution;
     if (!existing) {
       const state: StreamExecutionState = {
         category: agentCategory,
         conversationProgress: { toolCallCount: 0 },
         subagents: [],
       };
-      this._streamStates.set(stream, state);
+      ephemeral.execution = state;
       return state;
     }
     // Roster facts may provision a ToolUse placeholder before RUNNING supplies
@@ -330,7 +347,7 @@ export class SessionState {
         ...existing,
         category: agentCategory,
       };
-      this._streamStates.set(stream, state);
+      ephemeral.execution = state;
       return state;
     }
     return existing;
@@ -340,16 +357,16 @@ export class SessionState {
     stream: StreamTabId,
     updater: (prev: StreamExecutionState) => StreamExecutionState,
   ): void {
-    const current = this._streamStates.get(stream);
+    const current = this._ephemeralState.get(stream)?.execution;
     if (current) {
-      this._streamStates.set(stream, updater(current));
+      this.getOrCreateEphemeral(stream).execution = updater(current);
     }
   }
 
   /** Reset per-run ephemeral child state when a new run starts on the same
    *  stream — retained finished children belong to the previous run. */
   resetPerRunChildState(stream: StreamTabId): void {
-    const current = this._streamStates.get(stream);
+    const current = this._ephemeralState.get(stream)?.execution;
     if (!current) return;
 
     const retainedSubagents = current.subagents.filter(
@@ -361,14 +378,14 @@ export class SessionState {
       current.stage !== undefined;
 
     if (needsReset) {
-      this._streamStates.set(stream, {
+      this.getOrCreateEphemeral(stream).execution = {
         ...current,
         subagents: current.subagents.filter(
           (child) => child.finishedAt === undefined,
         ),
         conversationProgress: { toolCallCount: 0 },
         stage: undefined,
-      });
+      };
     }
   }
 
@@ -378,7 +395,7 @@ export class SessionState {
    * children from every host until that deletion settles.
    */
   getStreamState(stream: StreamTabId): StreamExecutionState | undefined {
-    const state = this._streamStates.get(stream);
+    const state = this._ephemeralState.get(stream)?.execution;
     if (!state) return undefined;
     const subagents = state.subagents.filter(
       (child) => !this.isStreamRemoved(child.childStreamId),
@@ -403,20 +420,22 @@ export class SessionState {
     phase: StreamPhase,
   ): StreamTabId[] {
     const changedParents: StreamTabId[] = [];
-    for (const [parent, state] of this._streamStates) {
+    for (const [parent, ephemeral] of this._ephemeralState) {
+      const state = ephemeral.execution;
+      if (!state) continue;
       const tracksChild = state.subagents.some(
         (child) =>
           child.childStreamId === childStreamId && child.status !== phase,
       );
       if (!tracksChild) continue;
-      this._streamStates.set(parent, {
+      ephemeral.execution = {
         ...state,
         subagents: state.subagents.map((child) =>
           child.childStreamId === childStreamId
             ? { ...child, status: phase }
             : child,
         ),
-      });
+      };
       changedParents.push(parent);
     }
     return changedParents;
@@ -482,8 +501,7 @@ export class SessionState {
     // execution state the previous incarnation left behind (a provisional
     // removal may not have committed yet). The status machine is left alone —
     // the fresh run has already tracked its own phase there.
-    this._sessionState.delete(stream);
-    this._streamStates.delete(stream);
+    this._ephemeralState.delete(stream);
     this._streamMetadataCache.delete(stream);
     return { incarnation, changedRosterParents };
   }
@@ -543,8 +561,12 @@ export class SessionState {
 
   private rosterParentsContaining(stream: StreamTabId): StreamTabId[] {
     const parents: StreamTabId[] = [];
-    for (const [parent, state] of this._streamStates) {
-      if (state.subagents.some((child) => child.childStreamId === stream)) {
+    for (const [parent, ephemeral] of this._ephemeralState) {
+      if (
+        ephemeral.execution?.subagents.some(
+          (child) => child.childStreamId === stream,
+        )
+      ) {
         parents.push(parent);
       }
     }
@@ -553,12 +575,14 @@ export class SessionState {
 
   private scrubStreamFromRosters(stream: StreamTabId): StreamTabId[] {
     const changedParents: StreamTabId[] = [];
-    for (const [parent, state] of this._streamStates) {
+    for (const [parent, ephemeral] of this._ephemeralState) {
+      const state = ephemeral.execution;
+      if (!state) continue;
       const subagents = state.subagents.filter(
         (child) => child.childStreamId !== stream,
       );
       if (subagents.length === state.subagents.length) continue;
-      this._streamStates.set(parent, { ...state, subagents });
+      ephemeral.execution = { ...state, subagents };
       changedParents.push(parent);
     }
     return changedParents;
@@ -569,8 +593,7 @@ export class SessionState {
    *  `_removedStreams` and, for `clearAll`, scrubbing rosters. */
   private clearEphemeralStreamState(stream: StreamTabId): void {
     this.streamStatus.clearStream(stream);
-    this._sessionState.delete(stream);
-    this._streamStates.delete(stream);
+    this._ephemeralState.delete(stream);
     this._streamMetadataCache.delete(stream);
   }
 
@@ -632,8 +655,7 @@ export class SessionState {
     // pre-delete enumeration would reintroduce the TOCTOU this barrier exists
     // to close.
     const preExistingEphemeral = new Set<StreamTabId>([
-      ...this._streamStates.keys(),
-      ...this._sessionState.keys(),
+      ...this._ephemeralState.keys(),
       ...Array.from(this.streamStatus.entries(), ([stream]) => stream),
     ]);
     const identitiesAtStart = new Set<StreamTabId>([

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -228,7 +228,7 @@ export type SingleFiles = z.infer<typeof SingleFilesSchema>;
 const FileOptionsSchema = z.object({
   baseFile: z.array(z.string()),
   editedFile: z.array(z.string()),
-  commit: z.array(z.string()).optional(),
+  commit: z.array(z.string()),
 });
 export type FileOptions = z.infer<typeof FileOptionsSchema>;
 

--- a/src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts
@@ -251,18 +251,22 @@ describe('extractToolAttachments', () => {
     expect(sanitizedResult.output).toBe('done');
   });
 
-  it('keeps error summaries out of model payloads', () => {
+  it('keeps error summaries for human-facing logs', () => {
     const { sanitizedResult } = extractToolAttachments({
       status: 'error',
       error: 'The operation failed before producing output.',
-      summary: 'The operation failed before producing output.',
+      summary: 'Operation failed.',
     });
 
     expect(sanitizedResult.status).toBe('error');
     expect(sanitizedResult.error).toBe(
       'The operation failed before producing output.',
     );
-    expect(Object.hasOwn(sanitizedResult, 'summary')).toBe(false);
+    // `summary` is "Brief summary for human-facing logs" on the error
+    // variant (see ErrorToolResultSchema) — it must survive sanitization so
+    // ToolUseDispatchNode's progress log can surface it, even though
+    // formatToolResultAsText never sends it to the model on this variant.
+    expect(sanitizedResult.summary).toBe('Operation failed.');
   });
 
   it('drops editedFiles from executed payloads', () => {

--- a/src/test-kernel/common/FileListingRules.vitest.ts
+++ b/src/test-kernel/common/FileListingRules.vitest.ts
@@ -16,19 +16,19 @@ describe('shared file-listing rules', () => {
     const config = getFileListConfig('input', settings);
 
     expect(config).toMatchObject({
-      extensions: ['.txt', '.tex', '.md'],
-      ignoredFiles: ['command.tex', 'commands.tex', 'preamble.tex', 'yaml'],
+      include: ['.txt', '.tex', '.md'],
+      excludeFiles: ['command.tex', 'commands.tex', 'preamble.tex', 'yaml'],
     });
-    expect(config?.ignoredDirs).toContain('node_modules');
+    expect(config?.excludeDirs).toContain('node_modules');
   });
 
   it('normalizes filters once and applies file and directory rules', () => {
     const filters = prepareFileFilters({
-      extensions: ['.TEX'],
-      ignoredExtensions: ['.PDF'],
-      ignoredDirs: ['node_modules', 'drafts/generated'],
-      ignoredKeywords: ['scratch', 'template'],
-      ignoredFiles: ['command.tex'],
+      include: ['.TEX'],
+      excludeExtensions: ['.PDF'],
+      excludeDirs: ['node_modules', 'drafts/generated'],
+      excludeKeywords: ['scratch', 'template'],
+      excludeFiles: ['command.tex'],
     });
 
     const directoryCases: ReadonlyArray<readonly [string, boolean]> = [


### PR DESCRIPTION
## Summary

Follow-up to the scheduled data-structure-complexity audit (0 High / 6 Medium / 3 Low findings). This PR lands fixes for 7 of the 9 findings; the remaining 2 turned out, on closer inspection, to conflict with real tested behavior and were left as-is rather than shipped incorrectly (see below).

- **`SessionState.ts`**: merged `_streamStates` and `_sessionState` — the two per-stream maps that always share the same create/clear lifecycle (`claimStreamIdentity`, `clearEphemeralStreamState`) — into one `_ephemeralState` map. `_streamMetadataCache` (a derived read cache), `_streamIncarnations` (identity generation, must outlive an ephemeral clear), and `_removedStreams` (tombstones, must outlive the very state they retire) each have a genuinely different lifetime and stay separate — merging those would have broken real invariants.
- **`runExecution.ts`** (CLI headless shutdown): replaced four of the shutdown/finalization booleans (`shutdownInterrupted`, `workflowOutputPublicationCommitted`, `shutdownArtifactFailure`, `shutdownFinalizationFailureReported`) with one `LaunchVerdict` discriminated union, so "at most one of published/interrupted" is enforced by the type instead of a prose comment. The remaining flags (`shutdownRequested`, `ownedExecutionId`, `shutdownLaunchAborted`, `presentationAttached`, `primaryRunFailure`, `finalizationCompleted`, `runResult`) are orthogonal to the verdict state machine and stay as separate variables.
- **`FileOptions.commit`**: made required like its siblings (`baseFile`/`editedFile`); removed the three duplicated `?? []` guards that compensated for the mismatch.
- **`fileListingRules.ts`**: collapsed `FileListConfig`/`PreparedFileFilters` into one `FileFilterConfig` shape shared verbatim from category selection through normalization, instead of three renamed vocabularies for the same five fields.
- **Auth session refresh**: `SupabaseSessionCoordinator` now uses the same `PQueue(concurrency:1)` single-flight primitive as `SubscriptionOAuthCoordinator`, replacing its own `async-mutex` + manual polling loop. Credential-comparison logic specific to Supabase (`isCurrentStoredSession`, `clearSessionIfCurrent`) was left untouched — it encodes real behavior the generic coordinator doesn't need.
- **`toolAttachmentExtraction.ts`**: `extractToolAttachments` now branches on the `ToolResult` variant and builds each output shape from that variant's own known fields, instead of iterating a generic `Record` against a hand-maintained strip-list. This also fixes the strip-list having drifted to drop `summary` from error results — the field that variant's schema documents as existing specifically for human-facing logs.
- **`executeCommand.ts`**: the wrapped launch input is now validated through one Zod schema at the boundary instead of six ad hoc optional-chained reads.

**Not landed** (audit claim didn't survive contact with the actual code/tests, reverted after investigation):
- A `StatusBarForegroundInput` discriminated union coupling `escapeAction` to `inputActive: true` — the real invariant is more permissive (`escapeAction` is also read on a second, `shortcutsActive === false` branch in `resolveStatusBarBindings`, confirmed by the original doc comment and by existing tests exercising exactly that combination).
- Tightening `extractTouchedFiles`'s optional chaining — an existing test (`tolerates legacy partial state slices`) exercises `stateSlices` values that don't conform to the schema's guarantees, so the extra chaining is load-bearing, not defensive habit.

## Issue acceptance gates

No linked issue — this is a direct follow-up to a scheduled audit report. All 7 landed findings' suggested alternatives from the audit are implemented as described above.

## Single source of truth

- `SessionState`'s `_ephemeralState` map is now the sole owner of per-stream live metadata + execution counters.
- `runExecution.ts`'s `launchVerdict` is the sole owner of the launch's publish/interrupt verdict.
- `fileListingRules.ts`'s `FileFilterConfig` is the sole shape for include/exclude file filters from settings load through to filter matching.
- `SubscriptionOAuthCoordinator`'s generation+`PQueue` pattern is now the shared single-flight-refresh mechanism for both OAuth coordinators.

## Duplication and abstraction budget

Removed: two parallel per-stream maps, three renamed vocabularies for one filter shape, two independent mutex mechanisms for the same single-flight-refresh problem, three duplicated `?? []` guards, six ad hoc optional-chained reads. No new abstractions were introduced beyond the discriminated unions/merged types described above, each of which replaces an existing implicit invariant with one the type system checks.

## Net elements (R6)

16 files changed, +294/-209 (diffstat). Exported-symbol delta (`^[+-]export` over the diff): one rename, `FileListConfig` → `FileFilterConfig` (net 0 new exports). No new classes/interfaces beyond type consolidations that replace removed ones (`EphemeralStreamState` replaces `StreamSessionState`; `LaunchVerdict` replaces four flag declarations; `FileFilterConfig` replaces `FileListConfig`).

## Consumer counts (R8)

`FileListConfig` → `FileFilterConfig` rename: all consumers updated in this PR (`desktopFileSelection.ts`, `desktopWorkspaceIpc.ts`, `fileLister.ts`, `listing.ts`, `workspaceFileListing.ts`, plus the test file); grepped repo-wide post-change, zero remaining references to the old name.

## Host impact

Extension: `executeCommand.ts` (Zod boundary), `documentSlice.ts`/`MainApp.ts` (`FileOptions.commit`), `fileLister.ts`/`listing.ts` (filter type rename).

Desktop: `desktopFileSelection.ts`/`desktopWorkspaceIpc.ts` (filter type rename).

CLI: `runExecution.ts` (shutdown state machine).

## Scheduled refactoring

None — the 2 findings left unfixed were determined not to be real bugs, not deferred work.

## Validation

- `npm run typecheck` (all 6 sub-checks: workspace, test-kernel, agent, cli, trace-viewer, desktop) — clean.
- `npm test` — 10,036 passed, 6 skipped, 0 failed.
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — no new findings (391 baselined, 391 found).
- `npx prettier --check` on all changed files — clean.

**Update:** addressed independent third-party review feedback — fixed a stale doc comment in `SessionFactApplier.ts` left over from the `SessionState.ts` merge (the review's other two notes were non-blocking/no-change-needed).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBqL5hjkhCsdQ6gBwWJuLf)_