### PR TITLE
refactor(agent): inline reflection support-file collection

### DIFF
--- a/src/agent/implementations/flows/reflection/output/outputState.ts
+++ b/src/agent/implementations/flows/reflection/output/outputState.ts
@@ -16,14 +16,12 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { AgentWorkflowSetting } from '@agent/core/definition/AgentDataclass';
 import type { RunScope } from '@agent/runtime/RunScope';
 import {
-  fileLocationDisplayPath,
   type CompileFailure,
   type FileLocation,
   type OutputFileInfo,
   type RoundIndexed,
   type RoundOutput,
 } from '@shared/schemas';
-import { pathToLocation } from '@utils/files/fileLocation';
 import { TaskRunFileService } from '@utils/files/taskRunStorage';
 
 export interface OutputState {
@@ -133,23 +131,4 @@ export function setCompileFailures(
   failures: CompileFailure[],
 ): void {
   ensureRoundData(state, round).compileFailures = failures;
-}
-
-export function collectRunSupportFiles(
-  agentConfig: AgentConfig,
-): FileLocation[] {
-  const allPaths = [
-    ...agentConfig.contextFiles,
-    ...agentConfig.mediaFiles,
-    ...agentConfig.inputFiles,
-  ];
-
-  const extras = new Map<string, FileLocation>();
-  for (const value of allPaths) {
-    if (!value) continue;
-    const location = pathToLocation(value);
-    extras.set(fileLocationDisplayPath(location), location);
-  }
-
-  return [...extras.values()];
 }

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -11,6 +11,7 @@ import { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { userRequestTemplateCount } from '@agent/index/agentYamlScanner';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { AgentWorkflowSetting } from '@agent/core/definition/AgentDataclass';
 import {
   PersistedFlowStateError,
@@ -24,6 +25,7 @@ import {
   type RoundOutput,
   type RunOutcome,
   type FileLocation,
+  fileLocationDisplayPath,
   MESSAGE_TYPES,
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
@@ -32,13 +34,13 @@ import {
   workflowOutputPath,
 } from '@shared/constants/workflowOutput';
 import { TaskRunFileService } from '@utils/files/taskRunStorage';
+import { pathToLocation } from '@utils/files/fileLocation';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 import { LatexDiffManager } from './output/LatexDiffManager';
 import { XmlOutputManager } from './output/XmlOutputManager';
 import {
   createOutputState,
-  collectRunSupportFiles,
   getOutputFilesByRound,
   roundsFromPersisted,
 } from './output/outputState';
@@ -109,6 +111,23 @@ export interface RunReflectionFlowResult {
    * with it.
    */
   error?: RetryErrorInfo;
+}
+
+function collectRunSupportFiles(agentConfig: AgentConfig): FileLocation[] {
+  const allPaths = [
+    ...agentConfig.contextFiles,
+    ...agentConfig.mediaFiles,
+    ...agentConfig.inputFiles,
+  ];
+
+  const extras = new Map<string, FileLocation>();
+  for (const value of allPaths) {
+    if (!value) continue;
+    const location = pathToLocation(value);
+    extras.set(fileLocationDisplayPath(location), location);
+  }
+
+  return [...extras.values()];
 }
 
 export async function runReflectionFlow(


### PR DESCRIPTION
## Summary
- move `collectRunSupportFiles` into `runReflectionFlow.ts` as a file-local helper
- remove the unused cross-file export from `outputState.ts`

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/output src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts src/test-kernel/agent/ReflectionOutputLocation.vitest.ts src/test-kernel/architecture`
- `npm run typecheck:workspace && npm run typecheck:test-kernel`
- `corepack pnpm exec eslint src/agent/implementations/flows/reflection/output/outputState.ts src/agent/implementations/flows/reflection/runReflectionFlow.ts`
- `corepack pnpm exec prettier --check src/agent/implementations/flows/reflection/output/outputState.ts src/agent/implementations/flows/reflection/runReflectionFlow.ts`
- `npm run check:dead-code-ratchet`

Closes #11426