### PR TITLE
refactor(streams): remove obsolete rollback cause

### DIFF
--- a/src/shared/streams/streamStatus.ts
+++ b/src/shared/streams/streamStatus.ts
@@ -69,8 +69,6 @@ export const STREAM_TRANSITION_CAUSE = {
   RESUME: 'resume',
   USER_STOP: 'user-stop',
   RESTART_REPAIR: 'restart-repair',
-  /** Restores a snapshot of this machine's own phases after a failed storage-root replacement. */
-  ROLLBACK: 'rollback',
 } as const;
 
 export type StreamTransitionCause =
@@ -157,10 +155,5 @@ export function canTransitionStreamPhase(
       if (from === undefined) return isTerminalOutcomePhase(to);
       if (from === to) return true;
       return from === STREAM_PHASE.RUNNING && to === STREAM_PHASE.CANCELLED;
-    case STREAM_TRANSITION_CAUSE.ROLLBACK:
-      // A rollback restores phases this process observed before the failed
-      // replacement, in one step: no synthetic RUNNING fact, which the
-      // applier would treat as a run start.
-      return from === undefined;
   }
 }

--- a/src/test-kernel/shared/RunOutcomeAlgebra.vitest.ts
+++ b/src/test-kernel/shared/RunOutcomeAlgebra.vitest.ts
@@ -102,7 +102,6 @@ describe('stream phase transition table', () => {
         STREAM_PHASE.RUNNING,
         STREAM_PHASE.CANCELLED,
       ],
-      [STREAM_TRANSITION_CAUSE.ROLLBACK]: [],
     },
     [STREAM_PHASE.WAITING]: {
       ...NO_TRANSITIONS,
@@ -140,9 +139,6 @@ describe('stream phase transition table', () => {
         STREAM_PHASE.CANCELLED,
         STREAM_PHASE.FAILED,
       ],
-      // A storage-root rollback restores any phase this process observed in
-      // one step, so no synthetic RUNNING fact reaches the applier.
-      [STREAM_TRANSITION_CAUSE.ROLLBACK]: phases,
     };
 
     for (const cause of causes) {


### PR DESCRIPTION
## Summary\n- remove the unreachable  member and transition-table arm\n- remove its rows from the exhaustive run-outcome transition table\n\n## Evidence\n had no production producer. The only historical producer was the storage-root replacement rollback loop removed in #11452. Status events are ephemeral session facts, and the CLI's frozen  compatibility payload accepts the diagnostic cause as an unparsed optional string. No production parser or persisted reader requires ; a source scan finds no remaining literal  value in  or .\n\n## Validation\n- 
> texra-workspace@0.40.6 test
> vitest run --config vitest.config.mjs src/test-kernel/shared/RunOutcomeAlgebra.vitest.ts src/test-kernel/agent/runtime/StreamStatusService.vitest.ts


[1m[30m[46m RUN [49m[39m[22m [36mv4.1.11 [39m[90m/Users/siruilu/Local/AI-Projects/coauthor-purewin-11464[39m

 [32m✓[39m src/test-kernel/shared/RunOutcomeAlgebra.vitest.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/test-kernel/agent/runtime/StreamStatusService.vitest.ts [2m([22m[2m14 tests[22m[2m)[22m[32m 8[2mms[22m[39m

[2m Test Files [22m [1m[32m2 passed[39m[22m[90m (2)[39m
[2m      Tests [22m [1m[32m25 passed[39m[22m[90m (25)[39m
[2m   Start at [22m 11:51:37
[2m   Duration [22m 1.68s[2m (transform 799ms, setup 2.80s, import 172ms, tests 13ms, environment 0ms)[22m\n- 
> texra-workspace@0.40.6 typecheck:workspace
> tsc --noEmit --checkers 8\n- 
> texra-workspace@0.40.6 typecheck:test-kernel
> tsc --noEmit --checkers 8 -p tsconfig.test-kernel.json\n- \n- Checking formatting...
All matched files use Prettier code style!\n- 
> texra-workspace@0.40.6 check:dead-code-ratchet
> node scripts/check-dead-code-ratchet.mjs

knip dead-code findings: 8 normal, 390 production; 391 combined (unused=8, productionDead=383) vs 391 baselined
Dead-code ratchet OK: no new findings.\n\nCloses #11464