### PR TITLE
refactor(scripts): collapse installer icon stat probe

### DIFF
--- a/scripts/verify-desktop-installer-artifacts.mjs
+++ b/scripts/verify-desktop-installer-artifacts.mjs
@@ -1,3 +1,4 @@
+import { statSync } from 'node:fs';
 import { readdir, readFile, stat } from 'node:fs/promises';
 import { basename, join, relative } from 'node:path';
 import process from 'node:process';
@@ -149,21 +150,15 @@ function getPlatformKeys() {
 }
 
 async function verifyIcon(requirement) {
-  try {
-    const iconStat = await stat(requirement.iconPath);
-    if (iconStat.size === 0) {
-      failures.push(
-        `${requirement.label} installer icon is empty: ${relative(repoRoot, requirement.iconPath)}`,
-      );
-    }
-  } catch (error) {
-    if (error?.code === 'ENOENT') {
-      failures.push(
-        `Missing ${requirement.label} installer icon: ${relative(repoRoot, requirement.iconPath)}`,
-      );
-    } else {
-      throw error;
-    }
+  const iconStat = statSync(requirement.iconPath, { throwIfNoEntry: false });
+  if (iconStat == null) {
+    failures.push(
+      `Missing ${requirement.label} installer icon: ${relative(repoRoot, requirement.iconPath)}`,
+    );
+  } else if (iconStat.size === 0) {
+    failures.push(
+      `${requirement.label} installer icon is empty: ${relative(repoRoot, requirement.iconPath)}`,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the installer icon ENOENT stat guard with `statSync(..., { throwIfNoEntry: false })`
- retain missing and zero-byte icon diagnostics while surfacing other filesystem errors
- cover nonempty, missing, empty, and permission-denied icon fixtures

## Validation
- `npx vitest run src/test-kernel/scripts/DesktopInstallerArtifacts.vitest.ts`
- `npx eslint src/test-kernel/scripts/DesktopInstallerArtifacts.vitest.ts`
- `npx prettier --check scripts/verify-desktop-installer-artifacts.mjs src/test-kernel/scripts/DesktopInstallerArtifacts.vitest.ts`
- `npm run typecheck:test-kernel`
- `npm run check:dead-code-ratchet`
- `npx vitest run src/test-kernel/architecture/dependencyDirection.vitest.ts`

Closes #11444