### PR TITLE
docs: correct four pure-win records

### DIFF
--- a/docs/proposals/2026-08-25-simplification-survey-49-candidates.md
+++ b/docs/proposals/2026-08-25-simplification-survey-49-candidates.md
@@ -37,15 +37,15 @@ Seven disjoint-lane PRs, batched by path ownership so they can be written in
 parallel and merged in any order. Small items are batched into their lane PR
 rather than shipped one at a time.
 
-| Lane           | Scope                                   | Items | PR     | Estimated net LoC | Measured net LoC |
-| -------------- | --------------------------------------- | ----- | ------ | ----------------- | ---------------- |
-| `L1-cli`       | CLI                                     | 7     | #11416 | -294              | -306             |
-| `L2-extension` | Extension host and views                | 6     | #11417 | -209              | -294             |
-| `L3-desktop`   | Desktop renderer                        | 3     | #11418 | -61               | -57              |
-| `L4-agent`     | Agent runtime, flows, storage, handlers | 10    | #11419 | -266              | -341             |
-| `L5-tools`     | Tools                                   | 7     | #11420 | -449              | -571             |
-| `L6-shared`    | Shared, controllers, platform, utils    | 13    | #11421 | -402              | -439             |
-| `L7-scripts`   | Scripts, config, resources              | 3     | #11422 | -1112             | -1181            |
+| Lane           | Scope                                   | Items | PR     | Estimated net LoC | Survey net elements | Measured net LoC |
+| -------------- | --------------------------------------- | ----- | ------ | ----------------- | ------------------- | ---------------- |
+| `L1-cli`       | CLI                                     | 7     | #11416 | -294              | -67                 | -306             |
+| `L2-extension` | Extension host and views                | 6     | #11417 | -209              | -31                 | -294             |
+| `L3-desktop`   | Desktop renderer                        | 3     | #11418 | -61               | -45                 | -57              |
+| `L4-agent`     | Agent runtime, flows, storage, handlers | 10    | #11419 | -266              | -32                 | -341             |
+| `L5-tools`     | Tools                                   | 7     | #11420 | -449              | -33                 | -571             |
+| `L6-shared`    | Shared, controllers, platform, utils    | 13    | #11421 | -402              | -43                 | -439             |
+| `L7-scripts`   | Scripts, config, resources              | 3     | #11422 | -1112             | -16                 | -1181            |
 
 All seven shipped. Measured total across the 223 changed files: +1236 / -4425,
 net **-3189 LoC**, against a survey estimate of -2793. Forty-seven of the 49
@@ -1529,7 +1529,7 @@ Scope is bounded (one file deleted, three small edits in one component, one comm
 #### Fold the internal-only Kimi Code route resolver, wire-id helper, and config synthesizer into their two live entry points
 
 - **Area**: `latex-replacement-model` · **Kind**: speculative-generality · **Risk**: low
-- **Net**: -40 LoC, -4 elements
+- **Net**: -40 LoC, -3 elements
 
 **Evidence**
 
@@ -1537,7 +1537,7 @@ src/model/kimiCodeSubscriptionRouting.ts exports 7 symbols; only 3 have producti
 
 **Proposal**
 
-Move the four-branch body of `resolveKimiCodeRoute` into `isKimiCodeRoute(config, facts): boolean` and delete `resolveKimiCodeRoute`; inline `kimiCodeWireModelId`'s one-entry `KIMI_CODE_WIRE_MODEL_IDS` lookup into `kimiCodeRuntimeConfig`, and inline `kimiCodeRuntimeConfig` into `kimiCodeEffectiveConfig` (:170-178) since it is the only caller; drop the `export` on `KimiCodeRoutingFacts`. Module keeps exactly three exported functions. Reroute the three vitest describes through `isKimiCodeRoute(config, {useOpenRouter, keySet, preferKimiCode})` and `kimiCodeEffectiveConfig(config, facts)` — the four positional args map 1:1 onto the facts literal, so every existing case survives. Regenerate the knip baseline: 3 rows leave, none is added.
+Move the four-branch body of `resolveKimiCodeRoute` into `isKimiCodeRoute(config, facts): boolean` and delete `resolveKimiCodeRoute`; inline `kimiCodeWireModelId`'s one-entry `KIMI_CODE_WIRE_MODEL_IDS` lookup into `kimiCodeRuntimeConfig`, and inline `kimiCodeRuntimeConfig` into `kimiCodeEffectiveConfig` (:170-178) since it is the only caller. Module keeps `KimiCodeRoutingFacts` and three exported functions. Reroute the three vitest describes through `isKimiCodeRoute(config, {useOpenRouter, keySet, preferKimiCode})` and `kimiCodeEffectiveConfig(config, facts)` — the four positional args map 1:1 onto the facts literal, so every existing case survives. Regenerate the knip baseline: 3 rows leave, none is added.
 
 **What we give up**
 
@@ -1933,7 +1933,7 @@ Residual risk is that the kept core manipulates the git index and working tree (
 #### log-usage: delete the two wire fields no client has ever sent (subscriptionSource, isMultipleOutput)
 
 - **Area**: `resources-prompts-supabase` · **Kind**: dead-export · **Risk**: medium
-- **Net**: -8 LoC, -2 elements
+- **Net**: -8 LoC, -3 elements
 
 **Evidence**
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -579,9 +579,10 @@ export async function runToolUseFlow(
       // Rewind before throwing. The outcome was COMPLETED, so the rewind above
       // was skipped and the cursor still points past the terminal step; the
       // `catch` below then preserves the record. Preserving an un-rewound
-      // cursor produces a file no reader accepts -- `ResumableFlowRecordSchema`
-      // rejects `nextNodeId !== null`, so it is unresumable and only
-      // `history delete` can clear it (#11314). Rewinding makes the preserved
+      // cursor produces a checkpoint `deriveResumability` reports as unreadable,
+      // which `classifyRun` maps to unclassified: `ResumableFlowRecordSchema`
+      // rejects `nextNodeId === null`, so only `history delete` can clear it
+      // (#11314). Rewinding makes the preserved
       // record mean what preservation is for: a resume gets another model turn
       // to call `submit_output`.
       await activePersistedFlow?.prepareForFollowUp(shared);

--- a/src/agent/prompt/userVars.ts
+++ b/src/agent/prompt/userVars.ts
@@ -433,10 +433,8 @@ async function getFileVars(
 /**
  * A required-file variable `X` generates the `X_FILE`/`X_CONTENT` pair, which
  * `buildUserVars` spreads after the fixed variables — so a name like `MEDIA`
- * or `INPUT` would silently override a fixed variable, and the persisted
- * channel schema's per-key validator would then reject checkpoints the
- * application itself produced, making the session impossible to resume. Fail
- * loudly when the variables are built instead.
+ * or `INPUT` would silently override a fixed variable. Fail loudly when the
+ * variables are built instead.
  */
 function assertNoFixedVarCollision(varName: string): void {
   for (const generatedKey of [`${varName}_FILE`, `${varName}_CONTENT`]) {

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -214,10 +214,11 @@ export async function clearTerminalExecutionState(
  * the caveat below — and every such site should say why in a comment.
  *
  * Caveat, learned from #11314: preserving is not free. A record whose cursor
- * was never rewound (`cursor.nextNodeId !== null`) fails
- * `ResumableFlowRecordSchema`'s refinement, so every reader classifies it
- * `invalid-flow` and only `history delete` can remove it. Keeping such a
- * record is strictly worse than deleting it. So a caller that ends COMPLETED
+ * was never rewound (`cursor.nextNodeId === null`) fails
+ * `ResumableFlowRecordSchema`'s refinement. `deriveResumability` reports it
+ * as `unreadable`, which `classifyRun` maps to `unclassified`; only `history
+ * delete` can remove it. Keeping such a record is strictly worse than deleting
+ * it. So a caller that ends COMPLETED
  * *without* consuming its cursor must still report `'delete'`; this policy
  * covers the ordinary case where the outcome and the cursor agree.
  */

--- a/src/test-kernel/agent/prompt/userVars.vitest.ts
+++ b/src/test-kernel/agent/prompt/userVars.vitest.ts
@@ -389,10 +389,8 @@ describe('requiredFilesInternal custom variables', () => {
   });
 
   // A required file named after a file category generates the fixed X_FILE /
-  // X_CONTENT variables and would silently override them, producing
-  // checkpoints the persisted channel schema's per-key validators reject and
-  // making the session impossible to resume. The guard fails loudly at
-  // variable-build time instead.
+  // X_CONTENT variables and would silently override them. The guard fails
+  // loudly at variable-build time instead.
   it.each(['INPUT', 'CONTEXT', 'EDITED', 'MEDIA'])(
     'rejects a required file named %s whose generated variables collide with the fixed vocabulary',
     async (varName) => {


### PR DESCRIPTION
## Summary

- verify that #11409’s seam-audit corrections were already present on this branch’s `main` base via #11411 (`afef057ae3`): the re-export evidence and `MainViewStartupControllerDeps` accounting are correct
- correct Kimi Code and log-usage element counts, proposal wording, and lane accounting while preserving the -267 aggregate
- correct the checkpoint cursor polarity and the unreadable-to-unclassified terminology
- remove the obsolete persisted-schema resumability rationale from the fixed-variable collision comments

## Validation

- `npx prettier --check docs/proposals/2026-08-25-simplification-survey-49-candidates.md src/agent/storage/executionLifecycle.ts src/agent/implementations/flows/tooluse/runToolUseFlow.ts src/agent/prompt/userVars.ts src/test-kernel/agent/prompt/userVars.vitest.ts`
- `npm run check:guidance-refs`
- `git diff --check`
- verified the survey lane-element sum remains `-267`

Typechecks were not run because this changes comments and documentation only.

Closes #11409
Closes #11427
Closes #11429
Closes #11443