### PR TITLE
refactor(webview): remove inert theme context

### DIFF
--- a/packages/desktop/src/renderer/TexraDiffView.ts
+++ b/packages/desktop/src/renderer/TexraDiffView.ts
@@ -1,10 +1,7 @@
 // Third-party imports
 import { LitElement, css, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { consume } from '@lit/context';
-
 // Local imports - shared modules
-import { themeContext } from '@shared/BaseWebviewApp';
 import { commonViewStyles, designTokens } from '@shared/styles';
 import { DESKTOP_THEME_KIND, type Theme } from '@shared/schemas';
 import {
@@ -84,7 +81,6 @@ export class TexraDiffView extends LitElement {
   @property() language = 'plaintext';
   @property({ type: Boolean, reflect: true }) fill = false;
 
-  @consume({ context: themeContext, subscribe: true })
   @property({ attribute: false })
   hostTheme: Theme = DESKTOP_THEME_KIND.DARK;
   @state() private loading = false;

--- a/src/shared/BaseWebviewApp.ts
+++ b/src/shared/BaseWebviewApp.ts
@@ -1,7 +1,5 @@
 // Third-party imports
 import { LitElement } from 'lit';
-import { createContext, provide } from '@lit/context';
-import { state } from 'lit/decorators.js';
 
 // Local imports - shared handlers
 import { COMMON_COMMANDS } from '@shared/ipc';
@@ -54,8 +52,6 @@ function handleCommonMessage(
   }
 }
 
-export const themeContext = createContext<Theme>('shared-theme');
-
 /**
  * Base class for Lit-powered webview apps.
  *
@@ -66,15 +62,11 @@ export const themeContext = createContext<Theme>('shared-theme');
  */
 
 export abstract class BaseWebviewApp<TMessage = unknown> extends LitElement {
-  @provide({ context: themeContext })
-  @state()
-  protected theme: Theme = 'dark';
-
   protected debugMode = false;
 
   private readonly messageListener = (event: MessageEvent) => {
     const handled = handleCommonMessage(event.data, {
-      setTheme: (theme) => this.onThemeChange(theme),
+      setTheme: () => {},
       setDebugMode: (enabled) => {
         this.debugMode = enabled;
       },
@@ -131,22 +123,6 @@ export abstract class BaseWebviewApp<TMessage = unknown> extends LitElement {
       `${appLabel} Message validation failed for command "${command}".`,
       error,
     );
-  }
-
-  /**
-   * Record the host theme kind.
-   *
-   * This method has no DOM job: `@shared/wa/waColorScheme`'s MutationObserver
-   * is the single owner of the `wa-light` / `wa-dark` class on `<html>`. It
-   * derives darkness from the body signals the host itself sets — VS Code's
-   * `vscode-*` classes and `data-vscode-theme-kind`, and on desktop the same
-   * attributes written by `applyHostBodyTheme()` — so no push is needed here.
-   * Writing `document.body.className = theme` from this method used to erase
-   * those host classes, which is why the `:host-context(.vscode-*)` rules
-   * stopped matching once a theme message arrived.
-   */
-  protected onThemeChange(theme: Theme): void {
-    this.theme = theme;
   }
 
   /**


### PR DESCRIPTION
## Summary
- remove the unobservable `themeContext` provider and the unused base theme state
- remove `TexraDiffView`'s inert Lit context consumer while retaining its live imperative `hostTheme` update path

## Evidence
`TexraDiffView` is created by `createReviewPane()` as a detached desktop workbench element. The desktop renderer mounts that review pane as a sibling of `main-app`, `settings-app`, and `stream-conversation`, so it can never descend from a `BaseWebviewApp` provider. Its live theme path remains `messageRoutes.applyTheme` to `reviewPane.setTheme(theme)` to `diffView.hostTheme`, which the component and Electron trajectory tests exercise.

## Validation
- desktop + webview kernel suites: 71 files, 682 tests
- desktop Electron trajectories: 9 tests
- workspace, test-kernel, and desktop typechecks
- desktop build and extension webview Electron smoke
- changed-file Prettier/ESLint, dead-code ratchet, package/path/browser-safety checks

Closes #11423