### PR TITLE
refactor(session): fold missing output invalidation

### DIFF
--- a/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
+++ b/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
@@ -83,6 +83,7 @@ class TuiSessionRenderer implements SessionRendererPort {
     switch (slice) {
       case 'files':
       case 'compileFailures':
+      case 'missingOutputs':
         // Renderers read `StreamArtifactProjection` directly. The write itself
         // is proof of established provenance for this session — a live fact
         // must not wait on the focus-driven disk preload
@@ -154,13 +155,6 @@ class TuiSessionRenderer implements SessionRendererPort {
     // rows plus the finished children it retains for display (phase-merged,
     // 200-capped). The CLI reads it there; only the snapshots re-derive.
     invalidateChildStreams();
-  }
-
-  onMissingOutputsChanged(streamId: StreamTabId): void {
-    // Renderers read `StreamArtifactProjection` directly; a disk-restored
-    // clear invalidates the memo like any other change. See `invalidate` for
-    // why the write marks the stream hydrated rather than only bumping.
-    markArtifactStreamHydrated(streamId);
   }
 
   onRunUsageChanged(

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -439,8 +439,6 @@ class HeadlessPort implements SessionRendererPort {
     this.renderer.refreshFor(streamId, true);
   }
 
-  onMissingOutputsChanged(_streamId: StreamTabId): void {}
-
   onRunUsageChanged(
     _streamId: StreamTabId,
     _storageKey: string,

--- a/src/controllers/progressView/backend/LitSessionRenderer.ts
+++ b/src/controllers/progressView/backend/LitSessionRenderer.ts
@@ -166,6 +166,16 @@ export class LitSessionRenderer implements SessionRendererPort {
             reset: true,
           }),
         );
+      case 'missingOutputs':
+        return this.sendIfActive(streamId, () => {
+          this.sendMessage({
+            command: PROGRESS_VIEW_COMMANDS.UPDATE_MISSING_OUTPUTS,
+            stream: streamId,
+            rounds: nonEmptyRounds(
+              this.state.snapshots.getMissingOutputs(streamId),
+            ),
+          });
+        });
       case 'queuedFollowUps':
         return this.sendIfActive(streamId, () =>
           this.sendMessage({
@@ -212,18 +222,6 @@ export class LitSessionRenderer implements SessionRendererPort {
 
   onBadgesChanged(streamId: StreamTabId): void {
     this.updateStreamMetadata(streamId);
-  }
-
-  onMissingOutputsChanged(streamId: StreamTabId): void {
-    this.sendIfActive(streamId, () => {
-      this.sendMessage({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_MISSING_OUTPUTS,
-        stream: streamId,
-        rounds: nonEmptyRounds(
-          this.state.snapshots.getMissingOutputs(streamId),
-        ),
-      });
-    });
   }
 
   onRunUsageChanged(

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -196,7 +196,7 @@ export class SessionFactApplier {
     addOutputFiles: (_streamId, event) =>
       this.renderer.invalidate(event.streamId, 'files'),
     updateMissingOutputs: (_streamId, event) =>
-      this.renderer.onMissingOutputsChanged(event.streamId),
+      this.renderer.invalidate(event.streamId, 'missingOutputs'),
     updateCompileFailures: (_streamId, event) =>
       this.renderer.invalidate(event.streamId, 'compileFailures'),
     goalPaused: (_streamId, event) =>

--- a/src/controllers/session/SessionRendererPort.ts
+++ b/src/controllers/session/SessionRendererPort.ts
@@ -28,6 +28,7 @@ export type PresentedStreamId = StreamTabId | '';
 export type SessionRenderSlice =
   | 'files'
   | 'compileFailures'
+  | 'missingOutputs'
   | 'queuedFollowUps'
   | 'parentStreamId'
   | 'contextState'
@@ -86,8 +87,6 @@ export interface SessionRendererPort {
   /** The stream's child-activity roster changed; hosts re-read
    *  `SessionState.getStreamState(streamId).subagents`. */
   onBadgesChanged(streamId: StreamTabId): void;
-
-  onMissingOutputsChanged(streamId: StreamTabId): void;
 
   onRunUsageChanged(
     streamId: StreamTabId,

--- a/src/controllers/session/SessionRendererPort.ts
+++ b/src/controllers/session/SessionRendererPort.ts
@@ -18,7 +18,7 @@ export type PresentedStreamId = StreamTabId | '';
 /**
  * A projection slice whose new value the host re-reads from the shared state
  * rather than receiving on the wire. Each key names the field the host reads
- * (`outputs.files`, `outputs.compileFailures`, `workPlan.queuedFollowUps`,
+ * (`outputs.files`, `outputs.missingOutputs`, `outputs.compileFailures`, `workPlan.queuedFollowUps`,
  * `SessionStreamMetadata.parentStreamId`,
  * `StreamExecutionState.contextState`) or the fact it reacts to
  * (`goalPaused`); nothing here is new vocabulary. Slices whose notification


### PR DESCRIPTION
## Summary
- fold `onMissingOutputsChanged` into `invalidate(streamId, 'missingOutputs')`
- remove the redundant renderer-port method and implementations
- preserve active-stream delivery, snapshot timing, and CLI artifact hydration

Closes #11447

## Validation
- focused progress renderer/fact-applier tests
- architecture boundary test
- workspace, test-kernel, and CLI typechecks
- changed-file ESLint and Prettier
- dead-code ratchet
