### PR TITLE
fix(extension): do not block team launch on notification

### DIFF
--- a/packages/extension/src/webview/managers/executionHandlers.ts
+++ b/packages/extension/src/webview/managers/executionHandlers.ts
@@ -13,10 +13,22 @@ import type {
   MainViewExecuteMessage,
   MainViewInboundMessage,
 } from '@shared/schemas';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import { pathToLocation } from '@utils/files/fileLocation';
 
 const CHANNEL = 'ExecutionHandlers';
 const log = createLog(CHANNEL);
+
+function observeNotification(
+  notification: Thenable<unknown>,
+  kind: 'information' | 'error',
+): void {
+  void Promise.resolve(notification).catch((err: unknown) => {
+    log.warn(
+      `${kind[0].toUpperCase()}${kind.slice(1)} notification failed: ${toErrorMessage(err)}`,
+    );
+  });
+}
 
 type MessageFor<C extends MainViewInboundMessage['command']> = Extract<
   MainViewInboundMessage,
@@ -71,11 +83,17 @@ export async function handleExecute(
   });
   if (launch.status === 'cancelled') return;
   if (launch.status === 'error') {
-    await vscode.window.showErrorMessage(launch.message);
+    observeNotification(
+      vscode.window.showErrorMessage(launch.message),
+      'error',
+    );
     return;
   }
   if (launch.infoMessage) {
-    await vscode.window.showInformationMessage(launch.infoMessage);
+    observeNotification(
+      vscode.window.showInformationMessage(launch.infoMessage),
+      'information',
+    );
   }
   const { preparation } = launch;
   if (!preparation.valid) {

--- a/src/test-kernel/webview/ExecutionHandlers.vitest.ts
+++ b/src/test-kernel/webview/ExecutionHandlers.vitest.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   prepareMainViewExecutionLaunch: vi.fn(),
   showErrorMessage: vi.fn(),
   showInformationMessage: vi.fn(),
+  warn: vi.fn(),
   pathToLocation: vi.fn((absolutePath: string) => ({
     kind: 'external' as const,
     absolutePath,
@@ -65,7 +66,7 @@ vi.mock('@logger/logUtils', () => ({
   createLog: () => ({
     debug: vi.fn(),
     info: vi.fn(),
-    warn: vi.fn(),
+    warn: mocks.warn,
     error: vi.fn(),
   }),
   info: vi.fn(),
@@ -96,8 +97,13 @@ describe('MainView execution handlers', () => {
     expect(mocks.executeCommand).not.toHaveBeenCalled();
   });
 
-  it('presents launch information before executing the prepared request', async () => {
+  it('executes the prepared request before launch information settles', async () => {
     const request = { agentName: 'team-root' };
+    let settleInfo!: () => void;
+    const infoPromise = new Promise<void>((resolve) => {
+      settleInfo = resolve;
+    });
+    mocks.showInformationMessage.mockReturnValue(infoPromise);
     mocks.prepareMainViewExecutionLaunch.mockResolvedValue({
       status: 'prepared',
       preparation: { valid: true, request },
@@ -113,6 +119,26 @@ describe('MainView execution handlers', () => {
       'texra.execute',
       request,
     );
+
+    settleInfo();
+    await infoPromise;
+  });
+
+  it('logs rejected launch information without creating an unhandled rejection', async () => {
+    const rejection = new Error('toast dismissed unexpectedly');
+    mocks.showInformationMessage.mockReturnValue(Promise.reject(rejection));
+    mocks.prepareMainViewExecutionLaunch.mockResolvedValue({
+      status: 'prepared',
+      preparation: { valid: true, request: { agentName: 'team-root' } },
+      infoMessage: 'Continuing without writer',
+    });
+
+    await handleExecute({});
+    await vi.waitFor(() => {
+      expect(mocks.warn).toHaveBeenCalledExactlyOnceWith(
+        'Information notification failed: toast dismissed unexpectedly',
+      );
+    });
   });
 
   it.each([

--- a/src/test-kernel/webview/ExecutionHandlers.vitest.ts
+++ b/src/test-kernel/webview/ExecutionHandlers.vitest.ts
@@ -97,11 +97,13 @@ describe('MainView execution handlers', () => {
     expect(mocks.executeCommand).not.toHaveBeenCalled();
   });
 
-  it('executes the prepared request before launch information settles', async () => {
+  it('dispatches before launch information settles and logs its rejection', async () => {
     const request = { agentName: 'team-root' };
-    let settleInfo!: () => void;
-    const infoPromise = new Promise<void>((resolve) => {
+    let settleInfo!: (value: void | PromiseLike<void>) => void;
+    let rejectInfo!: (reason?: unknown) => void;
+    const infoPromise = new Promise<void>((resolve, reject) => {
       settleInfo = resolve;
+      rejectInfo = reject;
     });
     mocks.showInformationMessage.mockReturnValue(infoPromise);
     mocks.prepareMainViewExecutionLaunch.mockResolvedValue({
@@ -120,25 +122,13 @@ describe('MainView execution handlers', () => {
       request,
     );
 
-    settleInfo();
-    await infoPromise;
-  });
-
-  it('logs rejected launch information without creating an unhandled rejection', async () => {
-    const rejection = new Error('toast dismissed unexpectedly');
-    mocks.showInformationMessage.mockReturnValue(Promise.reject(rejection));
-    mocks.prepareMainViewExecutionLaunch.mockResolvedValue({
-      status: 'prepared',
-      preparation: { valid: true, request: { agentName: 'team-root' } },
-      infoMessage: 'Continuing without writer',
-    });
-
-    await handleExecute({});
+    rejectInfo(new Error('toast dismissed unexpectedly'));
     await vi.waitFor(() => {
       expect(mocks.warn).toHaveBeenCalledExactlyOnceWith(
         'Information notification failed: toast dismissed unexpectedly',
       );
     });
+    settleInfo();
   });
 
   it.each([


### PR DESCRIPTION
## Summary
- dispatch `texra.execute` without waiting for partial-team information toast dismissal
- observe and log rejected launch notifications
- apply the same non-blocking observation to immediate launch errors

Closes #11372

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/webview/ExecutionHandlers.vitest.ts`
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- changed-file ESLint and Prettier
- `npm run check:dead-code-ratchet`