### PR TITLE
fix(cli): ten bugs and nineteen dead surfaces found by reading the CLI line by line

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -881,12 +881,6 @@
       "file": "packages/cli/src/runtime/modelAccess.ts",
       "category": "production-dead",
       "kind": "exports",
-      "name": "formatCliNoRunnableModelsMessage"
-    },
-    {
-      "file": "packages/cli/src/runtime/modelAccess.ts",
-      "category": "production-dead",
-      "kind": "exports",
       "name": "formatModelStatusForCli"
     },
     {

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -2440,7 +2440,6 @@ function renderHarnessApp(): React.JSX.Element {
       onSubmit={handleHarnessSubmit}
       onKillExecution={markHarnessExecutionStopped}
       onWorkflowControl={() => undefined}
-      canInterruptActiveRun={() => canInterrupt}
       canInterruptStream={canInterruptHarnessStream}
       canStopActiveRun={() => canInterrupt}
       colorEnabled={HARNESS_COLOR_ENABLED}

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -38,7 +38,6 @@ import {
   selectedChildRowWorkflowControllable,
   shouldDeferEscapeInterruptForMetaChord,
   triggerAppCtrlC,
-  triggerEscapeInterrupt,
   visibleApprovalRootStreamId,
   type EscapeInterruptState,
 } from './appInteractionPolicy';
@@ -139,11 +138,10 @@ export interface AppProps {
     executionId: string,
     action: WorkflowControlAction,
   ) => void;
-  /** Whether Ctrl-C may stop the current root run. */
-  readonly canInterruptActiveRun: () => boolean;
   /** Whether bare Escape may stop the identified focused stream. */
   readonly canInterruptStream: (streamId: StreamTabId) => boolean;
-  readonly canStopActiveRun?: () => boolean;
+  /** Whether Ctrl-C may stop the current root run. */
+  readonly canStopActiveRun: () => boolean;
   readonly colorEnabled?: boolean;
   readonly commandName?: string;
   /** Apply the existing root-run interruption used by Ctrl-C. */
@@ -190,8 +188,6 @@ export function App(props: AppProps): React.JSX.Element {
   const { columns, rows } = useWindowSize();
   const { exit } = useApp();
   const activeDraftRegistry = useMemo(() => createActiveDraftRegistry(), []);
-  const canStopActiveRun =
-    props.canStopActiveRun ?? props.canInterruptActiveRun;
   const activeApprovalVisible = approvalVisibleForActiveStream({
     activeStreamId,
     pending,
@@ -616,7 +612,11 @@ export function App(props: AppProps): React.JSX.Element {
       }
       return true;
     }
-    return triggerEscapeInterrupt(escapeInterruptStateRef.current, streamId);
+    // `bareEscapeActive` already proved `canInterruptStream(streamId)` for a
+    // parentless stream: `parentStream` never stores an undefined value, so
+    // once `.get()` returned undefined the `has` disjunct is false too.
+    escapeInterruptStateRef.current.onInterruptStream(streamId);
+    return true;
   };
 
   const handlePendingBareEscape = (
@@ -718,7 +718,7 @@ export function App(props: AppProps): React.JSX.Element {
               childListFocused,
             }) &&
               (inputBarRef.current?.discardDraft() ?? false)),
-          canStopActiveRun,
+          canStopActiveRun: props.canStopActiveRun,
           onInterruptActive: props.onInterruptActive,
           onExit: exit,
           onCtrlC: props.onCtrlC,

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -106,6 +106,7 @@ import {
 import { streamLabelForId, streamTreeViews } from './state/streamViews';
 import { useSignal } from './state/useSignal';
 import type { InputHistory } from './history/inputHistory';
+import type { PastedImageEntry } from './input/draftAttachments';
 
 // Narrow subset of Ink's internal stdin emitter used to synthesize Enter.
 interface InputEventEmitterLike {
@@ -131,7 +132,11 @@ function focusStreamAndPromoteApprovals(streamId: StreamTabId): void {
 }
 
 export interface AppProps {
-  readonly onSubmit: (line: string, mediaFiles?: readonly string[]) => void;
+  readonly onSubmit: (
+    line: string,
+    mediaFiles?: readonly string[],
+    images?: readonly PastedImageEntry[],
+  ) => void;
   readonly onKillExecution: (executionId: string) => void;
   /** Skip or retry a focused, in-flight workflow-script grandchild `agent()` call. */
   readonly onWorkflowControl: (

--- a/packages/cli/src/chat/tui/appInteractionPolicy.ts
+++ b/packages/cli/src/chat/tui/appInteractionPolicy.ts
@@ -77,26 +77,6 @@ export interface EscapeInterruptState {
   readonly onInterruptStream: (streamId: StreamTabId) => void;
 }
 
-export function triggerEscapeInterrupt(
-  state: EscapeInterruptState,
-  streamId: StreamTabId | undefined,
-): boolean {
-  if (
-    streamId === undefined ||
-    !appEscapeInterruptActive({
-      inputDisabled: state.inputDisabled,
-      reverseSearchOpen: state.reverseSearchOpen,
-      runPending: state.canInterruptStream(streamId),
-      slashPaletteOpen: state.slashPaletteOpen,
-    })
-  ) {
-    return false;
-  }
-
-  state.onInterruptStream(streamId);
-  return true;
-}
-
 type AppCtrlCAction = 'clear-draft' | 'delegate' | 'interrupt' | 'exit';
 
 export interface AppCtrlCState {

--- a/packages/cli/src/chat/tui/chatSubmitDriver.ts
+++ b/packages/cli/src/chat/tui/chatSubmitDriver.ts
@@ -57,6 +57,7 @@ import {
 } from './state/transcript';
 import type { ChatSessionController } from '../chatSessionController';
 import type { SkillActivation } from './forms/SkillsListForm';
+import type { PastedImageEntry } from './input/draftAttachments';
 
 interface PreparedChatInstruction {
   readonly instruction: string;
@@ -132,6 +133,7 @@ interface ChatSubmitDriver {
   readonly handleSubmittedLine: (
     line: string,
     mediaFiles?: readonly string[],
+    images?: readonly PastedImageEntry[],
   ) => Promise<void>;
   /** Reserve a skill activation for the next submitted message. */
   readonly activateSkill: (selection: SkillActivation) => void;
@@ -223,6 +225,7 @@ export function createChatSubmitDriver(
   const submitChatMessage = async (
     line: string,
     mediaFiles?: readonly string[],
+    images?: readonly PastedImageEntry[],
   ): Promise<void> => {
     const focusedChildRoute = chatTuiFocusedChildFollowUpRoute();
     if (focusedChildRoute.kind === 'reject') {
@@ -303,7 +306,7 @@ export function createChatSubmitDriver(
         if (session.stopRequested) {
           // The user's own interrupt explains the outcome, so hand the draft
           // back without a notice rather than dropping a typed message.
-          requestDraftRestore(line);
+          requestDraftRestore(line, images);
           return;
         }
         if (!followUpTarget) {
@@ -311,7 +314,7 @@ export function createChatSubmitDriver(
           // stream id (a failed launch, config parse, or auth failure), so
           // there is nothing to queue against. Same treatment as a refused
           // send: the draft is the user's until admitted.
-          requestDraftRestore(line);
+          requestDraftRestore(line, images);
           setTransientNotice(
             'The conversation ended before the message could be sent. The message has been restored to the input.',
             { ttlMs: Infinity },
@@ -337,7 +340,7 @@ export function createChatSubmitDriver(
         } else {
           // The draft is the user's until admitted: hand it back before any
           // notice, so a refused send never costs a retype.
-          requestDraftRestore(line);
+          requestDraftRestore(line, images);
           setTransientNotice(
             `${describeFollowUpFailure(result.reason)} The message has been restored to the input.`,
             { ttlMs: Infinity },
@@ -363,11 +366,12 @@ export function createChatSubmitDriver(
   const handleSubmittedLine = async (
     line: string,
     mediaFiles?: readonly string[],
+    images?: readonly PastedImageEntry[],
   ): Promise<void> => {
     if (await handleTuiSlashCommand(line, getSlashCommandContext())) {
       return;
     }
-    await submitChatMessage(line, mediaFiles);
+    await submitChatMessage(line, mediaFiles, images);
   };
 
   const activateSkill = (selection: SkillActivation): void => {

--- a/packages/cli/src/chat/tui/chatSubmitDriver.ts
+++ b/packages/cli/src/chat/tui/chatSubmitDriver.ts
@@ -300,7 +300,24 @@ export function createChatSubmitDriver(
           await sleep(25);
           followUpTarget = session.streamId;
         }
-        if (!followUpTarget || session.stopRequested) return;
+        if (session.stopRequested) {
+          // The user's own interrupt explains the outcome, so hand the draft
+          // back without a notice rather than dropping a typed message.
+          requestDraftRestore(line);
+          return;
+        }
+        if (!followUpTarget) {
+          // The root run completed before `onStreamResolved` ever populated a
+          // stream id (a failed launch, config parse, or auth failure), so
+          // there is nothing to queue against. Same treatment as a refused
+          // send: the draft is the user's until admitted.
+          requestDraftRestore(line);
+          setTransientNotice(
+            'The conversation ended before the message could be sent. The message has been restored to the input.',
+            { ttlMs: Infinity },
+          );
+          return;
+        }
         const result = await submitFollowUp(followUpTarget, {
           text: prepared.instruction,
           mediaFiles,

--- a/packages/cli/src/chat/tui/commands/handlers/modelAccessCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/modelAccessCommands.ts
@@ -19,26 +19,22 @@ import {
 const MODEL_ACCESS_USAGE =
   'Usage: /api chatgpt | grok | kimi-code | glm-code | status';
 
-/** Save a provider key and refresh access-dependent TUI views. */
+/**
+ * Save a provider key and refresh access-dependent TUI views. Returns only the
+ * extra notice a provider needs, if any — the caller owns the
+ * "Saved the <provider> API key." confirmation line.
+ */
 export async function applyCliProviderApiKey(
   provider: ApiProvider,
   key: string,
 ): Promise<string | undefined> {
   await saveProviderApiKey(provider, key);
   refreshSubscriptionPreferenceViews();
-  const message = `Saved the ${provider} API key.`;
-  if (provider !== 'kimiCode') return message;
+  if (provider !== 'kimiCode') return undefined;
   // The coding-only models route through the subscription automatically;
   // dual-backend K3 needs the opt-in switch, which is only discoverable if
   // we name it here.
-  return collapseWhitespace(
-    [
-      message,
-      "Tip: the Kimi for Coding models use your subscription automatically; to use it for Kimi K3 too, enable 'Prefer Kimi Code' in /config.",
-    ]
-      .filter(Boolean)
-      .join(' · '),
-  );
+  return "Tip: the Kimi for Coding models use your subscription automatically; to use it for Kimi K3 too, enable 'Prefer Kimi Code' in /config.";
 }
 
 async function applyCliModelAccessSelectionWithSignal(

--- a/packages/cli/src/chat/tui/forms/ConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ConfigForm.tsx
@@ -156,7 +156,7 @@ export interface ConfigFormProps {
     value: unknown,
   ) => void | Promise<void>;
   /** Reset a setting to its default (delete the key). */
-  readonly resetValue?: (entry: SurfacedSettingEntry) => void | Promise<void>;
+  readonly resetValue: (entry: SurfacedSettingEntry) => void | Promise<void>;
   readonly formLinks?: readonly {
     readonly name: string;
     readonly label: string;
@@ -286,11 +286,7 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
   // a consumer that coalesces empty→default (e.g. the git-author reader) quietly
   // uses the default, leaving the panel and the effect out of sync.
   const resetEntry = (entry: SurfacedSettingEntry): void => {
-    if (!props.resetValue) {
-      commit(entry, '');
-      return;
-    }
-    runWrite(entry, settingDefault(entry), () => props.resetValue?.(entry));
+    runWrite(entry, settingDefault(entry), () => props.resetValue(entry));
   };
 
   useInput((input, key) => {

--- a/packages/cli/src/chat/tui/forms/LoginForm.tsx
+++ b/packages/cli/src/chat/tui/forms/LoginForm.tsx
@@ -4,13 +4,19 @@ import type { SelectItem } from '@cli/tui/ui/Select';
 import {
   CHATGPT_AUTH,
   DEVICE_CODE_DESCRIPTION,
+  GROK_AUTH,
   RESEARCHER_ACCESS_AUTH,
 } from '@shared/copy/accountAuth';
 import { RESEARCHER_ACCESS } from '@shared/copy/onboarding';
 import { ListForm } from './_shared/ListForm';
 
 export type LoginFormValue =
-  'texra' | 'chatgpt' | 'texra --device' | 'chatgpt --device';
+  | 'texra'
+  | 'chatgpt'
+  | 'grok'
+  | 'texra --device'
+  | 'chatgpt --device'
+  | 'grok --device';
 
 export interface LoginFormProps {
   readonly availableRows?: number;
@@ -25,6 +31,11 @@ export const LOGIN_FORM_ITEMS = [
     description: CHATGPT_AUTH.subscriptionDescription,
   },
   {
+    value: 'grok',
+    label: GROK_AUTH.subscriptionLabel,
+    description: GROK_AUTH.subscriptionDescription,
+  },
+  {
     value: 'texra',
     label: RESEARCHER_ACCESS.label,
     description: RESEARCHER_ACCESS_AUTH.loginDescription,
@@ -32,6 +43,11 @@ export const LOGIN_FORM_ITEMS = [
   {
     value: 'chatgpt --device',
     label: CHATGPT_AUTH.deviceCodeLabel,
+    description: DEVICE_CODE_DESCRIPTION,
+  },
+  {
+    value: 'grok --device',
+    label: GROK_AUTH.deviceCodeLabel,
     description: DEVICE_CODE_DESCRIPTION,
   },
   {

--- a/packages/cli/src/chat/tui/forms/LogoutForm.tsx
+++ b/packages/cli/src/chat/tui/forms/LogoutForm.tsx
@@ -3,7 +3,11 @@ import { Text } from 'ink';
 import type { CliLogoutTarget } from '@cli/runtime/loginOptions';
 
 import type { SelectItem } from '@cli/tui/ui/Select';
-import { CHATGPT_AUTH, RESEARCHER_ACCESS_AUTH } from '@shared/copy/accountAuth';
+import {
+  CHATGPT_AUTH,
+  GROK_AUTH,
+  RESEARCHER_ACCESS_AUTH,
+} from '@shared/copy/accountAuth';
 import { RESEARCHER_ACCESS } from '@shared/copy/onboarding';
 import { ListForm } from './_shared/ListForm';
 
@@ -20,6 +24,11 @@ const LOGOUT_FORM_ITEMS = [
     description: CHATGPT_AUTH.logoutDescription,
   },
   {
+    value: 'grok',
+    label: GROK_AUTH.label,
+    description: GROK_AUTH.logoutDescription,
+  },
+  {
     value: 'texra',
     label: RESEARCHER_ACCESS.label,
     description: RESEARCHER_ACCESS_AUTH.logoutDescription,
@@ -27,7 +36,7 @@ const LOGOUT_FORM_ITEMS = [
   {
     value: 'all',
     label: 'All accounts',
-    description: 'Sign out of both accounts',
+    description: 'Sign out of every signed-in account',
   },
 ] as const satisfies ReadonlyArray<SelectItem<CliLogoutTarget>>;
 

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -102,7 +102,9 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
     <FormFrame title="/model" showCloseHint={false}>
       <Text dimColor>{description}</Text>
       {items.length === 0 ? (
-        <Text>{formatCliNoRunnableModelsMessage(CHAT_API_MODE_MODEL_RECOVERY)}</Text>
+        <Text>
+          {formatCliNoRunnableModelsMessage(CHAT_API_MODE_MODEL_RECOVERY)}
+        </Text>
       ) : (
         <Box flexDirection="column">
           <Select

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -6,7 +6,7 @@
 import { Box, Text } from 'ink';
 
 import {
-  emptyModelListMessage,
+  formatCliNoRunnableModelsMessage,
   getCliModelAccessList,
   modelSelectItemsForCli,
   type CliModelAccess,
@@ -102,7 +102,7 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
     <FormFrame title="/model" showCloseHint={false}>
       <Text dimColor>{description}</Text>
       {items.length === 0 ? (
-        <Text>{emptyModelListMessage(CHAT_API_MODE_MODEL_RECOVERY)}</Text>
+        <Text>{formatCliNoRunnableModelsMessage(CHAT_API_MODE_MODEL_RECOVERY)}</Text>
       ) : (
         <Box flexDirection="column">
           <Select

--- a/packages/cli/src/chat/tui/input/draftAttachments.ts
+++ b/packages/cli/src/chat/tui/input/draftAttachments.ts
@@ -108,10 +108,6 @@ export class DraftAttachmentStore {
     return `[Image #${id}]`;
   }
 
-  isEmpty(): boolean {
-    return this.entries.size === 0;
-  }
-
   clear(): void {
     this.entries.clear();
     this.nextId = 1;
@@ -121,7 +117,8 @@ export class DraftAttachmentStore {
    * Expand text chips back to their stored content (reverse-offset splice so
    * earlier replacements don't shift later match indices, and any chip-like
    * text *inside* pasted content is never re-matched). Image chips are left in
-   * place — the image bytes ride along as media files (see {@link resolveMedia}).
+   * place — the image bytes ride along as media files (see
+   * {@link resolveImages}).
    */
   expandText(input: string): string {
     let out = input;
@@ -149,15 +146,10 @@ export class DraftAttachmentStore {
   }
 
   /**
-   * Absolute paths of image attachments whose `[Image #N]` chip still survives
-   * in the submitted draft. Orphaned chips (deleted from the text) are dropped,
-   * matching Claude Code's orphan gate.
+   * Image entries whose chip survives in `input`, in chip order. Orphaned
+   * chips (deleted from the text) are dropped, matching Claude Code's orphan
+   * gate.
    */
-  resolveMedia(input: string): string[] {
-    return this.resolveImages(input).map((entry) => entry.path);
-  }
-
-  /** Image entries whose chip survives in `input`, in chip order. */
   resolveImages(input: string): PastedImageEntry[] {
     const present = new Set(matchChips(input).map((m) => m.id));
     const images: PastedImageEntry[] = [];

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -82,7 +82,6 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
   const [feedbackMode, setFeedbackMode] = useState(false);
   const [feedbackValue, setFeedbackValue] = useState('');
   const [feedbackExitCount, setFeedbackExitCount] = useState(0);
-  const feedbackModeRef = useRef(false);
   const feedbackWasCompactRef = useRef(false);
   const { data, tui } = props.payload;
   const title = `Apply edit to ${data.path}?`;
@@ -140,11 +139,12 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
       if (active && feedbackDiffIsCompact(feedbackValue)) {
         feedbackWasCompactRef.current = true;
       }
-      if (feedbackModeRef.current && !active && feedbackWasCompactRef.current) {
+      // `feedbackWasCompactRef` is only ever latched while feedback mode is
+      // open and cleared on the way out, so it already implies the transition.
+      if (!active && feedbackWasCompactRef.current) {
         setFeedbackExitCount((count) => count + 1);
       }
       if (!active) feedbackWasCompactRef.current = false;
-      feedbackModeRef.current = active;
       setFeedbackMode(active);
     },
     [feedbackDiffIsCompact, feedbackValue],

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -214,16 +214,11 @@ export function boundedUserQuestionPromptLines({
 
   if (questionLines.length >= maxDisplayLines) {
     const visibleQuestionLines = questionLines.slice(0, maxDisplayLines);
-    const hiddenRows =
-      contextLines.length + questionLines.length - visibleQuestionLines.length;
-    if (hiddenRows <= 0) return visibleQuestionLines;
+    const hiddenRows = lines.length - maxDisplayLines;
     return [
       userQuestionInlineClipIndicator({
         hiddenRows,
-        line: visibleQuestionLines[0] ?? {
-          kind: 'overflow',
-          text: '',
-        },
+        line: visibleQuestionLines[0],
         width: wrapWidth,
       }),
       ...visibleQuestionLines.slice(1),
@@ -487,10 +482,6 @@ export function UserQuestion(props: UserQuestionProps): React.JSX.Element {
   }
 
   function submitAnswer(answer: string | string[] | undefined): void {
-    if (!question) {
-      onDecide(userQuestionDecision(answers));
-      return;
-    }
     const nextAnswers = updateUserQuestionAnswers(answers, question, answer);
     if (index + 1 >= questions.length) {
       onDecide(userQuestionDecision(nextAnswers));

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -44,6 +44,7 @@ import {
   reverseSearchOpen as reverseSearchOpenSignal,
   setTransientNotice,
   slashPaletteOpen,
+  takeDraftRestoreRequests,
 } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
 import type { CursorEdit } from '../input/textInputEditing';
@@ -54,7 +55,11 @@ const CSI_SEQUENCE_TAIL_RE = /^\[[0-?]*[ -/]*[@-~]$/u;
 interface InputBarProps {
   /** Forwarded to BaseTextInput; called only on real (non-paste) Enter.
    *  `mediaFiles` carries absolute paths of any pasted-image attachments. */
-  readonly onSubmit: (value: string, mediaFiles?: readonly string[]) => void;
+  readonly onSubmit: (
+    value: string,
+    mediaFiles?: readonly string[],
+    images?: readonly PastedImageEntry[],
+  ) => void;
   /** Disable the input while an approval modal is owning the screen. */
   readonly disabled?: boolean;
   /** Inline reason shown when the disabled input remains visible. */
@@ -195,29 +200,45 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
     [setValue],
   );
   // A refused follow-up hands its text back: the draft is the user's until
-  // the session admits it. Image chips are rebuilt from the entries captured
-  // at submit; anything typed since the send is kept and the restored text
-  // is appended below it.
-  const lastSubmittedImagesRef = useRef<readonly PastedImageEntry[]>([]);
-  const draftRestore = useSignal(draftRestoreRequest);
+  // the session admits it. Image chips are rebuilt from the entries carried by
+  // that restore request; anything typed since the send is kept and the
+  // restored text is appended below it.
+  const draftRestores = useSignal(draftRestoreRequest);
   useEffect(() => {
-    if (!draftRestore) return;
-    draftRestoreRequest.set(null);
-    // The submitted text still carries its `[Image #N]` tokens (only pasted
-    // text is expanded at submit); revive each one as a fresh chip, in order,
-    // so no placeholder is duplicated or left dangling.
+    if (draftRestores.length === 0) return;
+    const requests = takeDraftRestoreRequests();
     const store = attachmentsRef.current;
-    const images = [...lastSubmittedImagesRef.current];
-    const restored = draftRestore.text.replaceAll(
-      /\[Image #\d+\]/g,
-      (token) => {
-        const image = images.shift();
-        return image ? store.addPastedImage(image) : token;
-      },
-    );
-    const current = draftValueRef.current;
-    setValue(current.length > 0 ? `${current}\n${restored}` : restored);
-  }, [draftRestore, setValue]);
+    let next = draftValueRef.current;
+    for (const request of requests) {
+      // The submitted text still carries its `[Image #N]` tokens (only pasted
+      // text is expanded at submit). Match by the original chip id so an
+      // orphaned token cannot steal another attachment; duplicate references
+      // reuse the same newly-created chip.
+      const imagesById = new Map(
+        request.images.map((image) => [image.id, image] as const),
+      );
+      const restoredChips = new Map<number, string>();
+      const restored = request.text.replaceAll(
+        /\[Image #(\d+)\]/g,
+        (token, idText: string) => {
+          const id = Number(idText);
+          const existing = restoredChips.get(id);
+          if (existing) return existing;
+          const image = imagesById.get(id);
+          if (!image) return token;
+          const chip = store.addPastedImage({
+            path: image.path,
+            mediaType: image.mediaType,
+            displayName: image.displayName,
+          });
+          restoredChips.set(id, chip);
+          return chip;
+        },
+      );
+      next = next.length > 0 ? `${next}\n${restored}` : restored;
+    }
+    setValue(next);
+  }, [draftRestores, setValue]);
   const transformPaste = useCallback((text: string): string => {
     if (!shouldCollapsePaste(text)) return text;
     return attachmentsRef.current.addPastedText(text);
@@ -274,7 +295,6 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
       }
       const images = store.resolveImages(submitted);
       const mediaFiles = images.map((image) => image.path);
-      lastSubmittedImagesRef.current = images;
       const historyText = store.expandTextForHistory(submitted).trim();
       clearDraft();
       // Persisting history is best-effort — a disk failure (read-only fs,
@@ -289,7 +309,11 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
           `texra: failed to persist input history: ${String(err)}`,
         );
       });
-      onSubmit(trimmed, mediaFiles.length > 0 ? mediaFiles : undefined);
+      onSubmit(
+        trimmed,
+        mediaFiles.length > 0 ? mediaFiles : undefined,
+        images.length > 0 ? images : undefined,
+      );
     },
     [clearDraft, onSubmit],
   );

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -226,20 +226,16 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
         return;
       }
       const provider = subscriptionUsageProvider;
-      void subscriptionUsage
-        .getUsage(provider)
-        .then((snapshot) => {
-          if (desiredUsageProviderRef.current !== provider) return;
-          setSubscriptionQuotaRead({
-            provider,
-            snapshot,
-          });
-        })
-        .catch(() => {
-          if (desiredUsageProviderRef.current === provider) {
-            setSubscriptionQuotaRead(undefined);
-          }
+      // `getUsage` always resolves to a snapshot rather than rejecting (see its
+      // class doc), and an `unavailable` snapshot is the designed carrier of a
+      // transport failure — so there is no rejection arm to write here.
+      void subscriptionUsage.getUsage(provider).then((snapshot) => {
+        if (desiredUsageProviderRef.current !== provider) return;
+        setSubscriptionQuotaRead({
+          provider,
+          snapshot,
         });
+      });
     },
     SUBSCRIPTION_QUOTA_REFRESH_MS,
     subscriptionUsageProvider,

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -684,10 +684,8 @@ function statusBarBindingsText(
       statusBarBindingRow([childList, agent, ctrlC]),
     childNavigationAvailable &&
       statusBarBindingRow([childList, fullOutput, ctrlC]),
-    transcriptAvailable && statusBarBindingRow([childList, fullOutput, ctrlC]),
     parentNavigationAvailable && ctrlC,
     childNavigationAvailable && childList,
-    transcriptAvailable && statusBarBindingRow([fullOutput, ctrlC]),
   ].map((candidate) =>
     parentBack && candidate
       ? statusBarBindingRow([parentBack, candidate])

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -208,22 +208,6 @@ function userPromptAwaitsLiveContinuation(
   );
 }
 
-/** Whether an entry belongs in append-only terminal scrollback now. */
-function isStaticTranscriptEntryAt(
-  rows: readonly TranscriptRow[],
-  index: number,
-  finalizedFrontier: number,
-  status: StreamPhase | undefined,
-): boolean {
-  const row = rows[index];
-  return (
-    row !== undefined &&
-    isFinalizedTranscriptRow(row, index, finalizedFrontier) &&
-    isRenderableTranscriptEntry(row) &&
-    !userPromptAwaitsLiveContinuation(rows, index, status)
-  );
-}
-
 /** `(settlement order, local-after-source tiebreak)` sort key for one row. */
 function transcriptOrderKey(
   row: TranscriptRow,
@@ -264,10 +248,11 @@ export function orderedStaticTranscriptEntries(
     key: readonly [number, number];
   }> = [];
   for (const [index, entry] of entries.entries()) {
+    // Finalized, renderable, and not a user prompt still awaiting its live
+    // continuation: the three conditions for append-only scrollback.
     if (!isFinalizedTranscriptRow(entry, index, finalizedFrontier)) break;
-    if (!isStaticTranscriptEntryAt(entries, index, finalizedFrontier, status)) {
-      continue;
-    }
+    if (!isRenderableTranscriptEntry(entry)) continue;
+    if (userPromptAwaitsLiveContinuation(entries, index, status)) continue;
     candidates.push({ entry, index, key: transcriptOrderKey(entry, index) });
   }
 

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -500,7 +500,6 @@ export async function runChat(
       onSubmit={(line, mediaFiles) =>
         void submitDriver.handleSubmittedLine(line, mediaFiles)
       }
-      canInterruptActiveRun={canInterruptActiveRun}
       canInterruptStream={(streamId) =>
         (streamId === session.streamId && canInterruptActiveRun()) ||
         runtimeSession.status.isInFlight(streamId)

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -497,8 +497,8 @@ export async function runChat(
   const viewportController = createTuiViewportController(inkRef);
   const ink = render(
     <App
-      onSubmit={(line, mediaFiles) =>
-        void submitDriver.handleSubmittedLine(line, mediaFiles)
+      onSubmit={(line, mediaFiles, images) =>
+        void submitDriver.handleSubmittedLine(line, mediaFiles, images)
       }
       canInterruptStream={(streamId) =>
         (streamId === session.streamId && canInterruptActiveRun()) ||

--- a/packages/cli/src/chat/tui/sessionExitController.ts
+++ b/packages/cli/src/chat/tui/sessionExitController.ts
@@ -185,14 +185,17 @@ export function createSessionExitController(
   const persistBeforePlatformShutdown = async (): Promise<void> => {
     try {
       await ctx.flushArtifacts();
-    } catch {
+    } catch (error) {
       // Signal exit remains best-effort, but platform shutdown must still run.
+      // The resume hint is printed before this runs, so a silent failure hands
+      // the user a `texra resume` for a session whose tail was never written.
+      log.warn(
+        `Transcript flush failed during signal exit; the session tail may be missing: ${toErrorMessage(error)}`,
+      );
     }
-    try {
-      await runPlatformShutdown();
-    } catch {
-      // process.exit below remains the terminal owner when shutdown fails.
-    }
+    // `runCliPlatformShutdownSequence` catches its own failures and never
+    // rejects, so there is no rejection arm to write here.
+    await runPlatformShutdown();
   };
   const armExit = (): void => {
     exitConfirmationExpiresAt = Date.now() + EXIT_CONFIRMATION_TTL_MS;
@@ -248,7 +251,7 @@ export function createSessionExitController(
     }
     void teardown({ kind: 'signal', exitCode });
   };
-  const handleSigterm = (): void => handleTermSignal(143);
+  const handleSigterm = (): void => handleTermSignal(CliExitCode.Terminated);
   const handleSighup = (): void => handleTermSignal(129);
   // Suspend/resume (Ctrl-Z / `kill -TSTP` / `fg`). Raw mode keeps the tty
   // driver from ever turning ^Z into a signal, so App's unified useInput

--- a/packages/cli/src/chat/tui/sessionExitController.ts
+++ b/packages/cli/src/chat/tui/sessionExitController.ts
@@ -18,7 +18,7 @@ import {
   handOffCliShutdownSignalHandlers,
   runCliPlatformShutdownSequence,
 } from '@cli/runtime/initPlatform';
-import { writeTextStdout } from '@cli/runtime/logSinks';
+import { writeTextStderrAndWait, writeTextStdout } from '@cli/runtime/logSinks';
 import {
   cleanupTerminalModes,
   restoreTuiInputModes,
@@ -189,8 +189,8 @@ export function createSessionExitController(
       // Signal exit remains best-effort, but platform shutdown must still run.
       // The resume hint is printed before this runs, so a silent failure hands
       // the user a `texra resume` for a session whose tail was never written.
-      log.warn(
-        `Transcript flush failed during signal exit; the session tail may be missing: ${toErrorMessage(error)}`,
+      await writeTextStderrAndWait(
+        `[warn] [cli.lifecycle] Transcript flush failed during signal exit; the session tail may be missing: ${toErrorMessage(error)}`,
       );
     }
     // `runCliPlatformShutdownSequence` catches its own failures and never

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -26,6 +26,7 @@ import type {
 } from '@shared/streams/compactionActivityProjection';
 import type { StreamArtifactAuthority } from '@transcript';
 import { isChildStreamRemoved } from './childExecutions';
+import type { PastedImageEntry } from '../input/draftAttachments';
 
 // ---------------------------------------------------------------------------
 // types
@@ -636,17 +637,27 @@ export function closeForegroundReader(): void {
 export const slashPaletteOpen = signal<boolean>(false);
 export const reverseSearchOpen = signal<boolean>(false);
 
-/** A refused follow-up handing its submitted text back to the InputBar,
- *  image chips included. `seq` makes two identical restores distinguishable;
- *  the InputBar consumes and clears. */
-export const draftRestoreRequest = signal<{
+/** Refused follow-ups handing their submitted drafts back to the InputBar.
+ * Requests stay ordered until the InputBar atomically drains the whole batch. */
+interface DraftRestoreRequest {
   readonly text: string;
-  readonly seq: number;
-} | null>(null);
-let draftRestoreSeq = 0;
-export function requestDraftRestore(text: string): void {
-  draftRestoreSeq += 1;
-  draftRestoreRequest.set({ text, seq: draftRestoreSeq });
+  readonly images: readonly PastedImageEntry[];
+}
+export const draftRestoreRequest = signal<readonly DraftRestoreRequest[]>([]);
+export function requestDraftRestore(
+  text: string,
+  images: readonly PastedImageEntry[] = [],
+): void {
+  draftRestoreRequest.set([
+    ...draftRestoreRequest.get(),
+    { text, images: [...images] },
+  ]);
+}
+
+export function takeDraftRestoreRequests(): readonly DraftRestoreRequest[] {
+  const requests = draftRestoreRequest.get();
+  if (requests.length > 0) draftRestoreRequest.set([]);
+  return requests;
 }
 
 /** Windowed content rows of the chat input's current draft (≥ 1), reported
@@ -827,6 +838,7 @@ export function resetCliState(
   FOREGROUND_READER.set(undefined);
   slashPaletteOpen.set(false);
   reverseSearchOpen.set(false);
+  draftRestoreRequest.set([]);
   clearTransientNotice();
   for (const resetHook of RESET_HOOKS) resetHook();
 }

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -471,7 +471,6 @@ async function requestRetryInteraction(
       // the user must not be told a switch happened that did not.
       if (
         retryDecision.source === 'automatic' &&
-        decision.disableQuotaRoute !== undefined &&
         isCodingPlanQuotaRoute(decision.disableQuotaRoute)
       ) {
         notify('credentialSwitched');
@@ -683,11 +682,14 @@ async function applyRetryCredentialCommit(
   signal: AbortSignal,
   codingPlanRollback?: RetrySettingRollbackConfig,
 ): Promise<void> {
-  signal.throwIfAborted();
   const oauth = oauthCliPreference(decision.disableQuotaRoute);
   const previousOauthPreference = oauth?.isPrefer() ?? false;
   let subscriptionWriteStarted = false;
   try {
+    // Inside the try: a cancel landing on the coding-plan branch (where there
+    // is no oauth write and so nothing else can throw here) must still roll
+    // the already-disabled plan back rather than escape past the rollback.
+    signal.throwIfAborted();
     if (oauth) {
       subscriptionWriteStarted = true;
       const update = await runRetryTask(() => oauth.setPrefer(false), signal);

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -748,12 +748,11 @@ function reconcileSynthetics(
   sliceEntries: readonly TranscriptRow[],
   flags: FoldChangeFlags,
 ): void {
-  const wOO = state.workflowOperationalOnly;
   const current: TranscriptRow[] = [];
   for (const row of sliceEntries) {
     if (
       row.origin === 'local' &&
-      (!wOO || WORKFLOW_OPERATIONAL_KINDS.has(row.kind))
+      (!state.workflowOperationalOnly || isWorkflowOperationalRow(row))
     ) {
       current.push(row);
     }

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty';
 
-import { getCustomAgentScanIssues, loadAgents } from '@agent/index';
+import { getCustomAgentScanIssues } from '@agent/index';
 
 import {
   AGENT_NAME_DESCRIPTION,
@@ -29,9 +29,6 @@ export async function listAgents(
   options: CliAgentListOptions = {},
 ): Promise<number> {
   await initLocalCliPlatform(context);
-  if (options.includeHidden !== true) {
-    await loadAgents({ includeRemote: false });
-  }
   const result = await loadCliAgentList(options);
 
   if (!context.quietLogs) {

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -3,6 +3,7 @@ import { defineCommand } from 'citty';
 import {
   createWorkspaceAgentRosterController,
   InvalidAgentTeamError,
+  loadAgents,
 } from '@agent/index';
 import { agentKeyOf, CLI_STATE_SETTINGS } from '@shared/schemas';
 import { readSetting } from '@shared/config/settingsAccess';
@@ -95,7 +96,9 @@ async function configureAgentRoster(
   },
 ): Promise<number> {
   await initLocalCliPlatform(context);
-  await readCliAgentRoster();
+  // The controller below resolves agent keys, so the registry must be loaded
+  // first; the honest roster read happens once, later, where it is emitted.
+  await loadAgents({ includeRemote: false });
   const roster = createWorkspaceAgentRosterController();
   const customRequested =
     input.workflow !== undefined || input.toolUse !== undefined;

--- a/packages/cli/src/commands/installGithubAction.ts
+++ b/packages/cli/src/commands/installGithubAction.ts
@@ -183,7 +183,6 @@ async function runInstallGithubAction(
 
   const url = remoteUrl(root);
   const slug = url ? parseGitHubSlug(url) : null;
-  await openGitHubAppInstaller(slug);
   const base = opts.base ?? defaultBranch(root) ?? 'main';
   const branch = opts.branch ?? DEFAULT_BRANCH_NAME;
   const startBranch = currentBranch(root);
@@ -215,6 +214,11 @@ async function runInstallGithubAction(
     );
     return CliExitCode.AgentError;
   }
+
+  // Only once the command is committed to writing the workflow file: the two
+  // guards above still abort having done nothing, so they must not leave an
+  // installer tab open behind them.
+  await openGitHubAppInstaller(slug);
 
   // Report the failure, put the user back on the branch they started from, and
   // hand back the error exit code.

--- a/packages/cli/src/commands/installGithubAction.ts
+++ b/packages/cli/src/commands/installGithubAction.ts
@@ -195,17 +195,24 @@ async function runInstallGithubAction(
     return CliExitCode.Usage;
   }
 
+  const baseRef = branchExists ? base : resolveBaseRef(root, base);
+  if (!baseRef) {
+    writeTextStderr(
+      `Could not resolve base branch "${base}". Fetch it or pass --base <branch>.`,
+    );
+    return CliExitCode.Usage;
+  }
+
+  // Only once the command is committed to writing the workflow file: the
+  // guards above still abort having done nothing, so they must not leave an
+  // installer tab open behind them. Open it before checkout so interruption
+  // during the launch cannot strand the user on the target branch.
+  await openGitHubAppInstaller(slug);
+
   let checkout: ExecResult;
   if (branchExists) {
     checkout = git(root, 'checkout', branch);
   } else {
-    const baseRef = resolveBaseRef(root, base);
-    if (!baseRef) {
-      writeTextStderr(
-        `Could not resolve base branch "${base}". Fetch it or pass --base <branch>.`,
-      );
-      return CliExitCode.Usage;
-    }
     checkout = git(root, 'checkout', '-b', branch, baseRef);
   }
   if (!checkout.success) {
@@ -214,11 +221,6 @@ async function runInstallGithubAction(
     );
     return CliExitCode.AgentError;
   }
-
-  // Only once the command is committed to writing the workflow file: the two
-  // guards above still abort having done nothing, so they must not leave an
-  // installer tab open behind them.
-  await openGitHubAppInstaller(slug);
 
   // Report the failure, put the user back on the branch they started from, and
   // hand back the error exit code.

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -162,6 +162,11 @@ async function runOrchestration(context: CliContext): Promise<number> {
     return result.exitCode;
   }
 
+  // The TUI intercepts every navigation action (`browse-*`,
+  // `configure-model-access`) internally, so `runOrchestrationTui` only ever
+  // resolves with an action this switch handles. An unhandled kind falls out
+  // of the switch and re-runs the launcher, which is the same outcome the
+  // navigation kinds used to spell out.
   launcher: while (true) {
     const history = await listCliHistoryEntries();
     const presets = readCliMultiAgentPresets();
@@ -315,12 +320,6 @@ async function runOrchestration(context: CliContext): Promise<number> {
       }
       case 'resume':
         return runResumeExecution(context, action.id);
-      case 'browse-resumes':
-      case 'configure-model-access':
-      case 'browse-agents':
-      case 'browse-teams':
-      case 'browse-accounts':
-        continue launcher;
       case 'configure-settings': {
         const { runConfigTui } = await import('../config/runConfigTui');
         await runConfigTui({

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -142,6 +142,9 @@ interface OrchestrationLauncherLayoutInput {
 const ORCHESTRATION_SELECT_MARGIN_ROWS = 1;
 const ORCHESTRATION_KEY_HINT_ROWS = 2;
 const ORCHESTRATION_TARGET_VISIBLE_ITEMS = 4;
+// Shared by the launcher's branded header render and the row measurement that
+// budgets around it, so the two can never disagree about the header's width.
+const LAUNCHER_BRAND = '{ T } TeXRA';
 
 function orchestrationLinesRowCost(
   lines: readonly string[],
@@ -196,7 +199,7 @@ function orchestrationLauncherLayoutCandidates(
       });
     }
   }
-  candidates.push({ statusLines: [], footerHints: [] });
+  // No empty-detail candidate: the caller's post-loop fallback is that layout.
   return candidates;
 }
 
@@ -314,7 +317,7 @@ export function OrchestrationApp(
       break;
     case 'launcher':
       // The launcher renders its own branded header; measure the same rows.
-      title = `TeXRA v${props.version}`;
+      title = `${LAUNCHER_BRAND} v${props.version}`;
       subtitle = 'Start a session or configure model access.';
       itemCount = items.length;
       break;
@@ -479,7 +482,7 @@ export function OrchestrationApp(
         step.kind === 'launcher' ? (
           <Box gap={1}>
             <Text bold color={COLOR_HINT}>
-              {'{ T } TeXRA'}
+              {LAUNCHER_BRAND}
             </Text>
             <Text dimColor>v{props.version}</Text>
           </Box>

--- a/packages/cli/src/runtime/browser.ts
+++ b/packages/cli/src/runtime/browser.ts
@@ -7,10 +7,6 @@ export interface BrowserLaunchCommand {
   readonly args: string[];
 }
 
-interface BrowserLog {
-  debug(channel: string, message: string): void;
-}
-
 export function resolveBrowserLaunch(
   url: string,
   platform: NodeJS.Platform = process.platform,
@@ -56,13 +52,11 @@ async function launchBrowser(url: string): Promise<void> {
 
 export function openBrowser(
   url: string,
-  log: BrowserLog | undefined,
   manualBrowserHint: string,
 ): Promise<void> {
   return launchBrowser(url).catch((error: unknown) => {
     const message =
       extractErrorMessage(error) ?? 'unknown browser launch error';
-    log?.debug('cli-auth', message);
     throw new Error(
       `${message}. Run ${manualBrowserHint} to open the sign-in URL manually.`,
     );

--- a/packages/cli/src/runtime/completionBash.ts
+++ b/packages/cli/src/runtime/completionBash.ts
@@ -184,7 +184,6 @@ function commandCaseBlock(command: CompletionCommand): string {
 }
 
 export function bashCompletion(commands: readonly CompletionCommand[]): string {
-  const root = commands.find((command) => command.path.length === 0);
   const fixedValueCases = fixedFlagValueCases(commands);
   const dynamicValueCases = dynamicFlagValueCases(commands);
   const genericValueCases = genericFlagValueCases(commands);
@@ -254,7 +253,6 @@ _texra() {
   path="$(_texra_completion_path)"
   case "$path" in
     ${commands.map(commandCaseBlock).join('\n    ')}
-    *) subcommands='${root?.subcommands.join(' ') ?? ''}'; flags='' ;;
   esac
 
 ${positionalCompletionBlocks()}

--- a/packages/cli/src/runtime/enabledModels.ts
+++ b/packages/cli/src/runtime/enabledModels.ts
@@ -11,11 +11,7 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 import { getEnabledModels, setModelEnabled } from '@model/computeModelOptions';
 import { isDeprecatedModel, isRetiredModel } from '@model/modelOptionsBasic';
 
-import {
-  isCliSupportedModelId,
-  knownCliModelIds,
-  resolveKnownCliModelId,
-} from './cliConfig';
+import { knownCliModelIds, resolveKnownCliModelId } from './cliConfig';
 
 export interface CliEnabledModelRow {
   readonly id: string;
@@ -67,7 +63,7 @@ export async function setCliModelEnabled(
   readonly list: readonly string[];
 }> {
   const model = resolveKnownCliModelId(modelInput);
-  if (!model || !isCliSupportedModelId(model)) {
+  if (!model) {
     throw new Error(
       `Unknown model "${modelInput}". Use an id from \`texra models list --all\`.`,
     );

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -16,6 +16,7 @@ import {
 import { tryDefaultSession, type AgentConfig } from '@agent/runtime';
 import { loadChatExportInput, type ChatExportInput } from '@agent/export';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
+import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 import { createSessionStores } from '@controllers/session/createSessionStores';
 import {
   ExecutionIdSchema,
@@ -42,7 +43,9 @@ import {
   resolveAdjacentStreamCleanup,
 } from '@transcript/adjacentStreamCleanup';
 import { byStringProp } from '@utils/core';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
+import { CliUsageError } from './cliContext';
 import { readCliResumeDataForListing } from './toolUseResumeData';
 import {
   formatCliHistoryAgentLabel,
@@ -286,9 +289,12 @@ const TRACE_VIEWER_SHARED_DIR_NAME = 'traceViewerShared';
  * Read the trace-viewer's single-file default bundle — one self-contained
  * `index.html` with no external `assets/` (JS/CSS/fonts all inlined) so the
  * default export opens correctly via `file://` with no server. Returns `null`
- * (without throwing) when the CLI install doesn't have the bundled template
- * — e.g. a dev checkout where `packages/trace-viewer` hasn't been built —
- * so the caller can report a clear error instead of an ENOENT stack trace.
+ * (without throwing) only when the template is absent — e.g. a dev checkout
+ * where `packages/trace-viewer` hasn't been built — so the caller can report a
+ * clear error instead of an ENOENT stack trace. Any other read failure
+ * (EACCES, a transient I/O error) is a different problem and must not be
+ * reported as "rebuild the CLI", so it surfaces as a usage error naming the
+ * real cause.
  */
 export async function readCliHistoryStandaloneTemplate(
   resourcesPath: string,
@@ -298,7 +304,14 @@ export async function readCliHistoryStandaloneTemplate(
     TRACE_VIEWER_DIR_NAME,
     'index.html',
   );
-  return readFile(templatePath, 'utf8').catch(() => null);
+  try {
+    return await readFile(templatePath, 'utf8');
+  } catch (error) {
+    if (isFileNotFoundError(error) || isNotADirectoryError(error)) return null;
+    throw new CliUsageError(
+      `history export: cannot read ${templatePath}: ${toErrorMessage(error)}`,
+    );
+  }
 }
 
 /**
@@ -315,9 +328,11 @@ export async function readCliHistoryStandaloneTemplate(
  * nesting under it, so staging is safe to repeat across multiple exports
  * pointed at the same shared directory.
  *
- * Returns `'missing'` (without throwing) when the CLI install doesn't have
- * the bundled assets — e.g. a dev checkout where `copy:resources` hasn't run
- * — so the caller can warn instead of failing the export outright.
+ * Returns `'missing'` (without throwing) only when the bundled assets are
+ * absent — e.g. a dev checkout where `copy:resources` hasn't run — so the
+ * caller can warn instead of failing the export outright. Any other probe
+ * failure (EACCES, a transient I/O error) is a different problem and surfaces
+ * as a usage error naming the real cause rather than a "rebuild the CLI" hint.
  */
 export async function stageCliHistoryTraceViewerAssets(params: {
   readonly resourcesPath: string;
@@ -327,9 +342,18 @@ export async function stageCliHistoryTraceViewerAssets(params: {
     params.resourcesPath,
     TRACE_VIEWER_SHARED_DIR_NAME,
   );
-  const sourceExists = await stat(assetsSrc)
-    .then((info) => info.isDirectory())
-    .catch(() => false);
+  let sourceExists: boolean;
+  try {
+    sourceExists = (await stat(assetsSrc)).isDirectory();
+  } catch (error) {
+    if (!isFileNotFoundError(error) && !isNotADirectoryError(error)) {
+      throw new CliUsageError(
+        `history export: cannot read ${assetsSrc}: ${toErrorMessage(error)}`,
+      );
+    }
+    sourceExists = false;
+  }
+  // A plain file where the bundle should be is also "this install lacks it".
   if (!sourceExists) return 'missing';
 
   await cp(assetsSrc, params.destDir, { recursive: true });

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -74,6 +74,13 @@ function showPersistentConfigWarning(message: string): void {
   writeTextStderr(`[warn] [cli.config] ${message}`);
 }
 
+// A shutdown-handler failure is actionable degradation by the same rule, so it
+// bypasses quietLogs too — every CLI command passes quietLogs:true, and routing
+// this through logAt would make the cross-host parity below unreachable.
+function showLifecycleError(message: string): void {
+  writeTextStderr(`[error] [cli.lifecycle] ${message}`);
+}
+
 const cliPlatformLog: LogBackend = {
   debug: (channel, message) => logAt('debug', channel, message),
   info: (channel, message) => logAt('info', channel, message),
@@ -256,9 +263,7 @@ export async function initCliPlatform(
     // handler failure is an error everywhere, not a warning in one host.
     const lifecycle = createLifecycleHost({
       onError: (phase, error) => {
-        logAt(
-          'error',
-          'cli.lifecycle',
+        showLifecycleError(
           `Lifecycle ${phase} handler failed: ${toErrorMessage(error)}`,
         );
       },

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -30,7 +30,11 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { applyCliGitAuthorConfig } from './gitAuthor';
 import { getCliSecrets } from './cliSecrets';
 import { isTexraCliEntrypointPath, readCliEntrypointPath } from './cliContext';
-import { flushNdjsonStdout, writeTextStderr } from './logSinks';
+import {
+  flushNdjsonStdout,
+  flushTextStderr,
+  writeTextStderr,
+} from './logSinks';
 import { initializeCliSupabaseAuth, signInCliSupabase } from './supabaseAuth';
 import { createCliStateStores } from './cliStateStores';
 import { CliExitCode } from './exitCodes';
@@ -105,6 +109,11 @@ export async function runCliPlatformShutdownSequence(
     await lifecycle?.runShutdown();
   } catch {
     // Signal shutdown is best effort; output still gets one final flush.
+  }
+  try {
+    await flushTextStderr();
+  } catch {
+    // A closed stderr pipe must not prevent signal-based termination.
   }
   try {
     await flushNdjsonStdout();

--- a/packages/cli/src/runtime/logSinks.ts
+++ b/packages/cli/src/runtime/logSinks.ts
@@ -139,6 +139,11 @@ export function writeTextStderrAndWait(text: string): Promise<void> {
   return writeRawAndWait('stderr', `${text}\n`);
 }
 
+/** Wait until every stderr write queued before this call has completed. */
+export function flushTextStderr(): Promise<void> {
+  return writeRawAndWait('stderr', '');
+}
+
 /**
  * Write a caught error's human-readable message to stderr. Folds the
  * `writeTextStderr(toErrorMessage(error))` pair every command's catch block

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -81,7 +81,7 @@ export interface CliNoAvailableModelsRecoveryOptions {
   readonly configureKeyAction?: string;
 }
 
-const NO_RUNNABLE_MODEL_ACCESS_COPY = 'No models are available';
+export const NO_RUNNABLE_MODEL_ACCESS_COPY = 'No models are available';
 
 // Point shell users at the guided setup picker rather than leaving them to
 // figure out key storage on their own; TUI contexts override this with
@@ -159,16 +159,6 @@ export function modelSelectItemsForCli(
       disabled: disabledReason != null,
     };
   });
-}
-
-export function modelAccessLaunchBlockDescription(): string {
-  return NO_RUNNABLE_MODEL_ACCESS_COPY;
-}
-
-export function emptyModelListMessage(
-  options: CliNoAvailableModelsRecoveryOptions = {},
-): string {
-  return formatCliNoRunnableModelsMessage(options);
 }
 
 function toCliModelAccess(model: ModelOptionData): CliModelAccess {

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -25,8 +25,8 @@ import {
   type CliHistoryEntry,
 } from './history';
 import {
-  modelAccessLaunchBlockDescription,
   modelSelectItemsForCli,
+  NO_RUNNABLE_MODEL_ACCESS_COPY,
   type CliModelAccess,
   type CliModelPickerItem,
 } from './modelAccess';
@@ -131,7 +131,7 @@ export function orchestrationModelAccessView(
     return { items, modelItems };
   }
 
-  const description = modelAccessLaunchBlockDescription();
+  const description = NO_RUNNABLE_MODEL_ACCESS_COPY;
   return {
     modelItems,
     items: items.map((item) => {

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -26,11 +26,10 @@ import {
 } from './supabaseAuthDeviceCode';
 
 /**
- * Channel-logger contract used by the CLI auth coordinator and supporting
- * helpers. Shape-compatible with `* as logger from '@logger/logUtils'` so
- * callers can pass that module directly, but also allows a custom object
- * literal (e.g. the deferred forwarder below) without depending on the
- * platform layer.
+ * Channel-logger contract used by the CLI auth coordinator. Shape-compatible
+ * with `* as logger from '@logger/logUtils'` so callers can pass that module
+ * directly, but also allows a custom object literal (e.g. the deferred
+ * forwarder below) without depending on the platform layer.
  */
 export interface LogBackend {
   debug(channel: string, message: string): void;
@@ -58,7 +57,6 @@ interface CliLoginOptions {
   openBrowser?: boolean;
   selectAccount?: boolean;
   loginHint?: string;
-  log?: LogBackend;
   onAuthUrl?: (url: string) => void;
   manualBrowserHint?: string;
   signal?: AbortSignal;
@@ -131,7 +129,6 @@ export async function signInCliSupabase(
     if (options.openBrowser ?? true) {
       const browserLaunch = openBrowser(
         authUrl,
-        options.log,
         options.manualBrowserHint ?? 'texra login --no-browser',
       );
       // A completed callback supersedes the launcher result, while callback

--- a/packages/cli/src/tui/useLiveNowMs.ts
+++ b/packages/cli/src/tui/useLiveNowMs.ts
@@ -1,30 +1,16 @@
 import { useEffect, useState } from 'react';
 
+import { subscribeToPolling } from './usePollingInterval';
+
 // One shared interval for every live-elapsed display. StatusBar and the
 // subagent panel can tick at once; with per-component intervals each would
 // fire at its own phase, producing up to one render burst per component per
-// second. Subscribers of the shared ticker fire in the same callback, so
-// React batches them into one pass.
-type SharedTickSubscriber = () => void;
-const tickSubscribers = new Set<SharedTickSubscriber>();
-let tickTimer: ReturnType<typeof setInterval> | undefined;
-
+// second. The 1 Hz cadence of the shared poll registry is that ticker:
+// subscribers fire in the same callback, so React batches them into one pass.
 // Exported so non-React callers (e.g. the terminal-title updater) can join
 // the same 1 Hz registry instead of running a private setInterval.
-export function subscribeToSharedTick(
-  subscriber: SharedTickSubscriber,
-): () => void {
-  tickSubscribers.add(subscriber);
-  tickTimer ??= setInterval(() => {
-    for (const tick of tickSubscribers) tick();
-  }, 1000);
-  return () => {
-    tickSubscribers.delete(subscriber);
-    if (tickSubscribers.size === 0 && tickTimer !== undefined) {
-      clearInterval(tickTimer);
-      tickTimer = undefined;
-    }
-  };
+export function subscribeToSharedTick(subscriber: () => void): () => void {
+  return subscribeToPolling(1000, subscriber);
 }
 
 export function useLiveNowMs(shouldTick: boolean, resetKey?: unknown): number {

--- a/packages/cli/src/tui/usePollingInterval.ts
+++ b/packages/cli/src/tui/usePollingInterval.ts
@@ -11,7 +11,7 @@ type PollSubscriber = () => void;
 const pollSubscribers = new Map<number, Set<PollSubscriber>>();
 const pollTimers = new Map<number, ReturnType<typeof setInterval>>();
 
-function subscribeToPolling(
+export function subscribeToPolling(
   intervalMs: number,
   subscriber: PollSubscriber,
 ): () => void {
@@ -29,13 +29,17 @@ function subscribeToPolling(
     pollTimers.set(intervalMs, timer);
   }
   return () => {
-    subscribers.delete(subscriber);
-    if (subscribers.size === 0) {
-      const timer = pollTimers.get(intervalMs);
-      if (timer !== undefined) clearInterval(timer);
-      pollTimers.delete(intervalMs);
-      pollSubscribers.delete(intervalMs);
-    }
+    // Re-read the live entry rather than the Set captured at subscribe time:
+    // a stale disposer called twice must not clear a later generation's timer
+    // out from under its subscribers.
+    const live = pollSubscribers.get(intervalMs);
+    if (live === undefined) return;
+    live.delete(subscriber);
+    if (live.size > 0) return;
+    const timer = pollTimers.get(intervalMs);
+    if (timer !== undefined) clearInterval(timer);
+    pollTimers.delete(intervalMs);
+    pollSubscribers.delete(intervalMs);
   };
 }
 

--- a/src/shared/copy/accountAuth.ts
+++ b/src/shared/copy/accountAuth.ts
@@ -40,9 +40,12 @@ export const CHATGPT_AUTH = {
 export const GROK_AUTH = {
   label: 'Grok',
   subscriptionLabel: 'Grok subscription',
+  subscriptionDescription: 'xAI models via Grok/SuperGrok',
   signInLabel: 'Sign in with Grok',
   signOutLabel: 'Sign out of Grok',
   preferLabel: 'Prefer Grok subscription',
+  deviceCodeLabel: 'Grok device code',
+  logoutDescription: 'Sign out and disable subscription preference',
   startingDevice: 'Starting Grok device-code sign-in.',
   startingNoBrowser: 'Starting Grok sign-in.',
   startingBrowser: 'Opening browser for Grok sign-in...',

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -211,7 +211,7 @@ function appProps(
     onSubmit: vi.fn(),
     onKillExecution: vi.fn(),
     onWorkflowControl: vi.fn(),
-    canInterruptActiveRun: () => true,
+    canStopActiveRun: () => true,
     canInterruptStream: () => true,
     onInterruptActive: vi.fn(),
     onInterruptStream,

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -675,7 +675,7 @@ describe('App foreground Escape ownership', () => {
       stdin.write('\r');
       await waitFor(() => onSubmit.mock.calls.length === 1);
 
-      expect(onSubmit).toHaveBeenCalledWith('q', undefined);
+      expect(onSubmit).toHaveBeenCalledWith('q', undefined, undefined);
       expect(onInterruptStream).not.toHaveBeenCalled();
     } finally {
       instance.unmount();
@@ -887,7 +887,11 @@ describe('App foreground Escape ownership', () => {
       stdin.write('\r');
       await waitFor(() => onSubmit.mock.calls.length === 1);
 
-      expect(onSubmit).toHaveBeenCalledWith('preserved root draft', undefined);
+      expect(onSubmit).toHaveBeenCalledWith(
+        'preserved root draft',
+        undefined,
+        undefined,
+      );
       expect(onInterruptStream).not.toHaveBeenCalled();
     } finally {
       instance.unmount();
@@ -1024,7 +1028,11 @@ describe('App foreground Escape ownership', () => {
       try {
         stdin.write('child follow-up\r');
         await waitFor(() => onSubmit.mock.calls.length === 1);
-        expect(onSubmit).toHaveBeenCalledWith('child follow-up', undefined);
+        expect(onSubmit).toHaveBeenCalledWith(
+          'child follow-up',
+          undefined,
+          undefined,
+        );
       } finally {
         instance.unmount();
       }

--- a/src/test-kernel/cli/AppInteractionPolicy.vitest.ts
+++ b/src/test-kernel/cli/AppInteractionPolicy.vitest.ts
@@ -13,10 +13,8 @@ import {
   foregroundSurfaceKind,
   shouldDeferEscapeInterruptForMetaChord,
   triggerAppCtrlC,
-  triggerEscapeInterrupt,
   visibleApprovalRootStreamId,
   type AppCtrlCState,
-  type EscapeInterruptState,
   type ForegroundSurfaceKind,
 } from '@cli/chat/tui/appInteractionPolicy';
 import type { PendingApproval } from '@cli/chat/tui/state/approvalQueue';
@@ -293,45 +291,6 @@ describe('app interaction policy', () => {
     for (const [value, expected] of cases) {
       expect(digitFromMetaShortcut(value)).toBe(expected);
     }
-  });
-
-  it('runs Escape interrupt from the supplied current state', () => {
-    const interrupted: StreamTabId[] = [];
-    const target = 'focused-child' as StreamTabId;
-    const baseState = {
-      inputDisabled: false,
-      reverseSearchOpen: false,
-      slashPaletteOpen: false,
-      onInterruptStream: (streamId: StreamTabId) => interrupted.push(streamId),
-    } satisfies Omit<EscapeInterruptState, 'canInterruptStream'>;
-    const cases = [
-      [true, true, 1],
-      [false, false, 1],
-    ] satisfies readonly (readonly [boolean, boolean, number])[];
-
-    for (const [canInterrupt, expected, expectedInterrupts] of cases) {
-      expect(
-        triggerEscapeInterrupt(
-          {
-            ...baseState,
-            canInterruptStream: (streamId) =>
-              streamId === target && canInterrupt,
-          },
-          target,
-        ),
-      ).toBe(expected);
-      expect(interrupted).toHaveLength(expectedInterrupts);
-    }
-    expect(interrupted).toEqual([target]);
-    expect(
-      triggerEscapeInterrupt(
-        {
-          ...baseState,
-          canInterruptStream: () => true,
-        },
-        undefined,
-      ),
-    ).toBe(false);
   });
 
   it('lets approvals preempt only a busy form', () => {

--- a/src/test-kernel/cli/ChatSubmitDriver.vitest.ts
+++ b/src/test-kernel/cli/ChatSubmitDriver.vitest.ts
@@ -1,0 +1,107 @@
+import PQueue from 'p-queue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createChatSubmitDriver } from '@cli/chat/tui/chatSubmitDriver';
+import type { PastedImageEntry } from '@cli/chat/tui/input/draftAttachments';
+import { resetCliState } from '@cli/chat/tui/state/cliState';
+import { TuiSession } from '@cli/chat/tui/state/sessionRunState';
+import { createDeferred } from '@test/support/asyncTestUtils';
+
+const mocks = vi.hoisted(() => ({
+  handleTuiSlashCommand: vi.fn(),
+  requestDraftRestore: vi.fn(),
+  selectCliRunnableModel: vi.fn(),
+  setCliHelperModel: vi.fn(),
+}));
+
+vi.mock('@cli/chat/tui/commands/handleSlashCommand', () => ({
+  handleTuiSlashCommand: mocks.handleTuiSlashCommand,
+}));
+
+vi.mock('@cli/chat/tui/state/cliState', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@cli/chat/tui/state/cliState')>();
+  return { ...actual, requestDraftRestore: mocks.requestDraftRestore };
+});
+
+vi.mock('@cli/chat/tui/state/transcript', () => ({
+  appendLocalAssistantTranscript: vi.fn(),
+  appendLocalErrorTranscript: vi.fn(),
+  appendLocalUserTranscript: vi.fn(),
+}));
+
+vi.mock('@cli/runtime/initPlatform', () => ({
+  setCliHelperModel: mocks.setCliHelperModel,
+}));
+
+vi.mock('@cli/runtime/modelAccess', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@cli/runtime/modelAccess')>();
+  return { ...actual, selectCliRunnableModel: mocks.selectCliRunnableModel };
+});
+
+function image(path: string): PastedImageEntry {
+  return {
+    id: 1,
+    kind: 'image',
+    path,
+    mediaType: 'image/png',
+    displayName: path.split('/').at(-1) ?? path,
+  };
+}
+
+describe('chat submit driver draft restoration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCliState();
+    mocks.handleTuiSlashCommand.mockResolvedValue(false);
+    mocks.setCliHelperModel.mockResolvedValue(undefined);
+  });
+
+  it('restores each queued startup draft with its own image entries', async () => {
+    const modelSelection = createDeferred<{ readonly model: string }>();
+    mocks.selectCliRunnableModel.mockReturnValue(modelSelection.promise);
+    const session = new TuiSession();
+    const followUpQueue = new PQueue({ concurrency: 1 });
+    const driver = createChatSubmitDriver({
+      session,
+      chatController: {
+        admitInterruptedFollowUp: vi.fn(() => ({ kind: 'not_interrupted' })),
+        startRootRun: vi.fn(),
+      } as never,
+      followUpQueue,
+      runtimeSession: { events: { emit: vi.fn() } } as never,
+      initialAgent: 'assistant',
+      initialModel: 'test-model',
+      initialModelSource: 'builtin-default',
+      cwd: '/tmp/project',
+      getSlashCommandContext: vi.fn(() => ({}) as never),
+    });
+    const firstImage = image('/tmp/first.png');
+    const secondImage = image('/tmp/second.png');
+
+    const startup = driver.handleSubmittedLine('root startup');
+    await vi.waitFor(() =>
+      expect(mocks.selectCliRunnableModel).toHaveBeenCalledOnce(),
+    );
+    await driver.handleSubmittedLine(
+      '[Image #1] first follow-up',
+      [firstImage.path],
+      [firstImage],
+    );
+    await driver.handleSubmittedLine(
+      '[Image #1] second follow-up',
+      [secondImage.path],
+      [secondImage],
+    );
+
+    modelSelection.reject(new Error('startup failed'));
+    await startup;
+    await followUpQueue.onIdle();
+
+    expect(mocks.requestDraftRestore.mock.calls).toEqual([
+      ['[Image #1] first follow-up', [firstImage]],
+      ['[Image #1] second follow-up', [secondImage]],
+    ]);
+  });
+});

--- a/src/test-kernel/cli/DraftAttachments.vitest.ts
+++ b/src/test-kernel/cli/DraftAttachments.vitest.ts
@@ -70,9 +70,9 @@ describe('DraftAttachmentStore', () => {
     expect(store.expandTextForHistory(`look ${text} ${image} done`)).toBe(
       'look A\nB\nC\nD done',
     );
-    expect(store.resolveMedia(`look ${text} ${image} done`)).toEqual([
-      '/p/a.png',
-    ]);
+    expect(
+      store.resolveImages(`look ${text} ${image} done`).map((e) => e.path),
+    ).toEqual(['/p/a.png']);
   });
 
   it('does not strip chip-like text from pasted text history', () => {
@@ -86,14 +86,15 @@ describe('DraftAttachmentStore', () => {
   it('resolves only image chips still present in the draft (orphan gate)', () => {
     const kept = store.addPastedImage(img('a.png'));
     store.addPastedImage(img('b.png')); // orphaned — chip removed from draft
-    expect(store.resolveMedia(`keep ${kept}`)).toEqual(['/p/a.png']);
+    expect(store.resolveImages(`keep ${kept}`).map((e) => e.path)).toEqual([
+      '/p/a.png',
+    ]);
   });
 
   it('clears entries and resets the id counter', () => {
-    store.addPastedText('a\nb\nc\nd');
-    expect(store.isEmpty()).toBe(false);
+    const chip = store.addPastedText('a\nb\nc\nd');
     store.clear();
-    expect(store.isEmpty()).toBe(true);
+    expect(store.expandText(chip)).toBe(chip);
     expect(store.addPastedText('x\ny\nz\nw')).toBe('[Pasted text #1 +3 lines]');
   });
 });

--- a/src/test-kernel/cli/InitPlatformSignalHandlers.vitest.ts
+++ b/src/test-kernel/cli/InitPlatformSignalHandlers.vitest.ts
@@ -6,9 +6,9 @@ const mocks = vi.hoisted(() => ({
   flushNdjsonStdout: vi.fn<() => Promise<void>>(),
 }));
 
-vi.mock('@cli/runtime/logSinks', () => ({
+vi.mock('@cli/runtime/logSinks', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@cli/runtime/logSinks')>()),
   flushNdjsonStdout: mocks.flushNdjsonStdout,
-  writeTextStderr: vi.fn(),
 }));
 
 /** Captures the SIGINT/SIGTERM listeners the runtime installs via `process.once`. */
@@ -110,6 +110,57 @@ describe('CLI platform signal handlers', () => {
     removed.length = 0;
     handOffCliShutdownSignalHandlers();
     expect(removed).toEqual([]);
+  });
+
+  it('waits for persistent stderr writes before shutdown resolves', async () => {
+    vi.resetModules();
+    const order: string[] = [];
+    const stderrCallbacks: Array<(error?: Error | null) => void> = [];
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(((
+      ...args: unknown[]
+    ) => {
+      const callback = args.find(
+        (arg): arg is (error?: Error | null) => void =>
+          typeof arg === 'function',
+      );
+      if (callback) stderrCallbacks.push(callback);
+      return true;
+    }) as typeof process.stderr.write);
+    mocks.flushNdjsonStdout.mockImplementation(async () => {
+      order.push('ndjson');
+    });
+    const { runCliPlatformShutdownSequence } =
+      await import('@cli/runtime/initPlatform');
+    const { writeTextStderr } = await import('@cli/runtime/logSinks');
+    const runShutdown = vi.fn(async () => {
+      order.push('shutdown');
+      writeTextStderr('lifecycle diagnostic');
+    });
+
+    let resolved = false;
+    const shutdown = runCliPlatformShutdownSequence(
+      fakeLifecycle(runShutdown),
+    ).then(() => {
+      resolved = true;
+    });
+    await vi.waitFor(() => expect(stderrCallbacks).toHaveLength(2));
+
+    expect(stderrWrite.mock.calls.map(([text]) => text)).toEqual([
+      'lifecycle diagnostic\n',
+      '',
+    ]);
+    expect(order).toEqual(['shutdown']);
+    expect(resolved).toBe(false);
+
+    stderrCallbacks[0]?.();
+    await Promise.resolve();
+    expect(order).toEqual(['shutdown']);
+    expect(resolved).toBe(false);
+
+    stderrCallbacks[1]?.();
+    await shutdown;
+    expect(order).toEqual(['shutdown', 'ndjson']);
+    expect(resolved).toBe(true);
   });
 
   it('runCliPlatformShutdownSequence runs lifecycle shutdown then the NDJSON flush, best-effort', async () => {

--- a/src/test-kernel/cli/InputBar.vitest.ts
+++ b/src/test-kernel/cli/InputBar.vitest.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ImagePasteQueue } from '@cli/chat/tui/input/imagePasteQueue';
 import { BaseTextInput } from '@cli/chat/tui/input/BaseTextInput';
+import type { PastedImageEntry } from '@cli/chat/tui/input/draftAttachments';
 import {
   ActiveDraftScope,
   createActiveDraftRegistry,
@@ -25,6 +26,7 @@ import {
 } from '@cli/chat/tui/commands/slashRegistry';
 import {
   activeForm,
+  requestDraftRestore,
   resetCliState,
   streams,
 } from '@cli/chat/tui/state/cliState';
@@ -328,6 +330,111 @@ describe('InputBar draft discard', () => {
     expect(submitted).toEqual([]);
     expect(imagePasteQueue.hasPending).toBe(false);
     expect(imagePasteQueue.hasDeferredAction).toBe(false);
+  });
+
+  it('restores queued drafts with the image entries captured by each submission', async () => {
+    clipboardMock.attachClipboardImage
+      .mockResolvedValueOnce({
+        ok: true,
+        path: '/tmp/first.png',
+        mediaType: 'image/png',
+        displayName: 'first.png',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        path: '/tmp/second.png',
+        mediaType: 'image/png',
+        displayName: 'second.png',
+      });
+    const submitted: Array<{
+      readonly text: string;
+      readonly mediaFiles: readonly string[] | undefined;
+      readonly images: readonly PastedImageEntry[] | undefined;
+    }> = [];
+    const { ink, React } = await loadInk();
+    const { instance, stdin, stdout } = renderInteractive(
+      ink,
+      React.createElement(InputBar, {
+        onSubmit: (...args: unknown[]) => {
+          const [text, mediaFiles, images] = args as [
+            string,
+            readonly string[] | undefined,
+            readonly PastedImageEntry[] | undefined,
+          ];
+          submitted.push({ text, mediaFiles, images });
+        },
+      }),
+    );
+
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      stdin.write('\u0016');
+      await waitFor(() => stdout.output.includes('[Image #1]'));
+      stdin.write(' first');
+      stdin.write('\r');
+      await waitFor(() => submitted.length === 1);
+      await waitFor(
+        () => !latestRenderedFrame(stdout).includes('[Image #1] first'),
+      );
+      stdout.output = '';
+
+      stdin.write('\u0016');
+      await waitFor(
+        () => clipboardMock.attachClipboardImage.mock.calls.length === 2,
+      );
+      await waitFor(() => stdout.output.includes('[Image #1]'));
+      stdin.write(' second');
+      stdin.write('\r');
+      await waitFor(() => submitted.length === 2);
+
+      expect(submitted.slice(0, 2)).toMatchObject([
+        {
+          mediaFiles: ['/tmp/first.png'],
+          images: [{ path: '/tmp/first.png', displayName: 'first.png' }],
+        },
+        {
+          mediaFiles: ['/tmp/second.png'],
+          images: [{ path: '/tmp/second.png', displayName: 'second.png' }],
+        },
+      ]);
+      const [first, second] = submitted;
+      if (!first?.images || !second?.images) {
+        throw new Error('submitted image entries were not captured');
+      }
+
+      stdout.output = '';
+      requestDraftRestore(first.text, first.images);
+      requestDraftRestore(second.text, second.images);
+      await waitFor(
+        () =>
+          stdout.output.includes('first') && stdout.output.includes('second'),
+      );
+      stdin.write('\r');
+      await waitFor(() => submitted.length === 3);
+
+      expect(submitted[2]?.text).toMatch(/first\n.*second/);
+      expect(submitted[2]?.mediaFiles).toEqual([
+        '/tmp/first.png',
+        '/tmp/second.png',
+      ]);
+
+      stdout.output = '';
+      requestDraftRestore(
+        `[Image #999] unmatched [Image #${first.images[0]?.id}] valid [Image #${first.images[0]?.id}] duplicate`,
+        first.images,
+      );
+      await waitFor(() => stdout.output.includes('duplicate'));
+      stdin.write('\r');
+      await waitFor(() => submitted.length === 4);
+
+      expect(submitted[3]).toMatchObject({
+        text: '[Image #999] unmatched [Image #1] valid [Image #1] duplicate',
+        mediaFiles: ['/tmp/first.png'],
+      });
+    } finally {
+      instance.unmount();
+      resetCliState();
+    }
   });
 
   it('discards a pending image submit from an otherwise empty mounted input', async () => {

--- a/src/test-kernel/cli/InstallGithubAction.vitest.ts
+++ b/src/test-kernel/cli/InstallGithubAction.vitest.ts
@@ -106,6 +106,35 @@ describe('install-github-action command', () => {
     );
   });
 
+  it('does not switch branches before the GitHub App installer opens', async () => {
+    const repo = makeRepo();
+    git(
+      repo,
+      'remote',
+      'add',
+      'origin',
+      'https://github.com/example/project.git',
+    );
+    let rejectBrowser: ((error: Error) => void) | undefined;
+    browserMocks.tryOpenBrowser.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((_resolve, reject) => {
+          rejectBrowser = reject;
+        }),
+    );
+
+    const install = runInstall(repo);
+    await vi.waitFor(() =>
+      expect(browserMocks.tryOpenBrowser).toHaveBeenCalledOnce(),
+    );
+    expect(git(repo, 'branch', '--show-current')).toBe('main');
+
+    rejectBrowser?.(new Error('installer interrupted'));
+    await expect(install).resolves.toEqual({
+      exitCode: CliExitCode.AgentError,
+    });
+  });
+
   it('creates the install branch from the requested base', async () => {
     const repo = makeRepo();
     git(repo, 'checkout', '-b', 'feature');

--- a/src/test-kernel/cli/ModelAccess.vitest.ts
+++ b/src/test-kernel/cli/ModelAccess.vitest.ts
@@ -1,14 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
-  emptyModelListMessage,
   findCliModelAccessEntry,
   formatCliModelDetails,
   formatCliNoAvailableModelsRecovery,
   formatCliNoRunnableModelsMessage,
   formatModelStatusForCli,
   getCliModelAccessList,
-  modelAccessLaunchBlockDescription,
   modelSelectItemsForCli,
   runnableCliModelAccessEntries,
   loadCliModelAccessEntry,
@@ -405,8 +403,7 @@ describe('CLI model access resolution', () => {
     ).toEqual([]);
   });
 
-  it('formats no-runnable model reasons for launch and model picker views', () => {
-    expect(modelAccessLaunchBlockDescription()).toBe('No models are available');
+  it('formats no-runnable model reasons for the model picker view', () => {
     expect(formatCliNoRunnableModelsMessage(INTERACTIVE_RECOVERY)).toBe(
       'No models are available. Configure a provider API key.',
     );
@@ -430,12 +427,6 @@ describe('CLI model access resolution', () => {
       formatCliNoRunnableModelsMessage(runtimeNullishActions),
     ).toBe(
       'No models are available. Add a provider API key with `texra setup`.',
-    );
-  });
-
-  it('formats empty model picker messages with caller-owned recovery actions', () => {
-    expect(emptyModelListMessage(INTERACTIVE_RECOVERY)).toBe(
-      'No models are available. Configure a provider API key.',
     );
   });
 

--- a/src/test-kernel/cli/SessionExitController.vitest.ts
+++ b/src/test-kernel/cli/SessionExitController.vitest.ts
@@ -1,0 +1,126 @@
+import PQueue from 'p-queue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createSessionExitController } from '@cli/chat/tui/sessionExitController';
+import { TuiSession } from '@cli/chat/tui/state/sessionRunState';
+import { CliExitCode } from '@cli/runtime/exitCodes';
+import { DisposableStore } from '@platform/disposable';
+
+const mocks = vi.hoisted(() => ({
+  cleanupTerminalModes: vi.fn(),
+  handOffCliShutdownSignalHandlers: vi.fn(),
+  runCliPlatformShutdownSequence: vi.fn(),
+  writeTextStderrAndWait: vi.fn(),
+  writeTextStdout: vi.fn(),
+}));
+
+vi.mock('@cli/runtime/cliContext', () => ({
+  readCliCwd: () => '/tmp/project',
+}));
+
+vi.mock('@cli/runtime/initPlatform', () => ({
+  handOffCliShutdownSignalHandlers: mocks.handOffCliShutdownSignalHandlers,
+  runCliPlatformShutdownSequence: mocks.runCliPlatformShutdownSequence,
+}));
+
+vi.mock('@cli/runtime/logSinks', () => ({
+  writeTextStderrAndWait: mocks.writeTextStderrAndWait,
+  writeTextStdout: mocks.writeTextStdout,
+}));
+
+vi.mock('@cli/tui/terminalCleanup', () => ({
+  cleanupTerminalModes: mocks.cleanupTerminalModes,
+  restoreTuiInputModes: vi.fn(),
+  supportsTerminalJobControl: () => false,
+}));
+
+vi.mock('@logger/logUtils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@logger/logUtils')>();
+  return {
+    ...actual,
+    createLog: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('@platform/platform', () => ({
+  platform: () => ({ lifecycle: {} }),
+}));
+
+describe('chat TUI session exit controller', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.runCliPlatformShutdownSequence.mockResolvedValue(undefined);
+  });
+
+  it('prints an artifact flush failure during signal teardown despite quiet logging', async () => {
+    const session = new TuiSession();
+    session.executionId = 'exec-flush-warning';
+    session.runExitCode = CliExitCode.Success;
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => {
+      return undefined as never;
+    }) as typeof process.exit);
+    let finishStderrWrite: (() => void) | undefined;
+    const stderrWrite = new Promise<void>((resolve) => {
+      finishStderrWrite = resolve;
+    });
+    mocks.writeTextStderrAndWait.mockReturnValue(stderrWrite);
+    const controller = createSessionExitController({
+      ink: {
+        clear: vi.fn(),
+        repaint: vi.fn(),
+        rerender: vi.fn(),
+        unmount: vi.fn(),
+        waitUntilExit: vi.fn(),
+        waitUntilRenderFlush: vi.fn(),
+        cleanup: vi.fn(),
+      },
+      session,
+      commandName: 'texra',
+      cwd: '/tmp/project',
+      canResume: true,
+      clearItermProgress: false,
+      kittyKeyboardEnabled: false,
+      disposables: new DisposableStore(),
+      disposeTerminalRestoreOnExit: vi.fn(),
+      followUpQueue: new PQueue(),
+      getApprovalPolicy: () => 'ask',
+      flushArtifacts: vi.fn().mockRejectedValue(new Error('disk full')),
+      repaintAfterTerminalResume: vi.fn(),
+      suspendTerminalTitle: vi.fn(),
+      resumeTerminalTitle: vi.fn(),
+      canStopActiveRun: () => false,
+      isResumableIdle: () => true,
+      interruptActive: vi.fn(),
+    });
+
+    try {
+      controller.handleSigint();
+      await vi.waitFor(() =>
+        expect(mocks.writeTextStderrAndWait).toHaveBeenCalledOnce(),
+      );
+
+      expect(mocks.writeTextStdout).toHaveBeenCalledWith(
+        expect.stringContaining('texra resume exec-flush-warning'),
+      );
+      expect(mocks.writeTextStderrAndWait).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Transcript flush failed during signal exit; the session tail may be missing: disk full',
+        ),
+      );
+      expect(mocks.runCliPlatformShutdownSequence).not.toHaveBeenCalled();
+      expect(exit).not.toHaveBeenCalled();
+
+      finishStderrWrite?.();
+      await vi.waitFor(() =>
+        expect(exit).toHaveBeenCalledWith(CliExitCode.Success),
+      );
+    } finally {
+      exit.mockRestore();
+    }
+  });
+});

--- a/src/test-kernel/cli/SlashRegistry.vitest.ts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.ts
@@ -216,8 +216,10 @@ describe('slashRegistry', () => {
   it('keeps ChatGPT subscription first in the login picker', () => {
     expect(LOGIN_FORM_ITEMS.map((item) => item.value)).toEqual([
       'chatgpt',
+      'grok',
       'texra',
       'chatgpt --device',
+      'grok --device',
       'texra --device',
     ]);
   });

--- a/src/test-kernel/cli/__snapshots__/Completion.vitest.ts.snap
+++ b/src/test-kernel/cli/__snapshots__/Completion.vitest.ts.snap
@@ -143,7 +143,6 @@ _texra() {
     completion) subcommands=''; flags='--print -p --quiet -q --cwd --output-format --approval-policy --color --no-color --no-input' ;;
     version) subcommands=''; flags='--print -p --quiet -q --cwd --output-format --approval-policy --color --no-color --no-input' ;;
     help) subcommands=''; flags='' ;;
-    *) subcommands='orchestrate chat clone run resume setup init config install-github-action history memory agents skills tools multi-agent models login logout auth doctor completion version help'; flags='' ;;
   esac
 
   if [[ "$path" == 'run' && "$cur" != -* ]]; then


### PR DESCRIPTION
Lane `L1-cli` of the [round-5 deep read](https://github.com/texra-ai/coauthor/pull/11497).

Rounds 1-4 surveyed the codebase. Round 5 **read** it: all 295,148 lines of production TypeScript in 36 cohesive slices, every file opened. That is why 10 of this lane's 29 findings are **bugs**, not simplifications.

## Bugs fixed

- **`/key` prints its confirmation twice, the second copy with the raw provider id — `applyCliProviderApiKey`'s return value is a leftover from the deleted relay reconciliation** (defect)
- **The coding-plan rollback handed to applyRetryCredentialCommit is structurally unreachable, so a cancel at the commit step leaves the user's coding plan disabled** (defect)
- **The launcher header is measured as "TeXRA v<x>" but rendered as "{ T } TeXRA v<x>", so the layout under-reserves rows at narrow widths** (amend)
- **install-github-action opens the GitHub App installer in a browser before two guards that can still abort the command** (amend)
- **`texra config agents` calls readCliAgentRoster purely for its loadAgents side effect and throws away a whole roster snapshot plus a config-file read** (amend)
- **Signal-exit persistence swallows both transcript flush and usage-accounting shutdown failures with bare `catch {}`** (amend)
- **Lifecycle-handler failures are suppressed in every CLI command, against the intent stated in their own comment** (defect)
- **A queued follow-up is silently discarded when the root run ends before it resolves a stream id — the exact drop the loop's own PRD comment forbids** (amend)
- **Trace-viewer export reports 'not bundled in this CLI install, rebuild the CLI' for any read failure — the two probes catch every error instead of only file-not-found** (amend)
- **The `/login` and `/logout` pickers never offer Grok, while the same commands' usage text, `/api`, and `texra auth grok login` all do — and "All accounts" still says "both"** (amend)

## Simplifications

- **`triggerEscapeInterrupt` re-derives the exact four-condition guard its one caller has already proved, in the same synchronous frame** (-55 LoC)
- **CLI model surface: three exported names for one 'no models available' string, and a guard the resolver it calls already enforces** (-18 LoC)
- **orderedStaticTranscriptEntries re-asks the finalized question it just answered, through a single-caller helper** (-16 LoC)
- **Two shared-timer registries in packages/cli/src/tui: usePollingInterval is the general case of useLiveNowMs's, and only one of them unref's its timer** (-16 LoC)
- **DraftAttachmentStore.resolveMedia and isEmpty lost their production callers; a doc comment still points readers at the dead one** (-14 LoC)
- **CliLoginOptions.log has no producer anywhere, which makes openBrowser's `log` parameter and the BrowserLog interface dead by construction** (-9 LoC)
- **UserQuestion carries two guards that its own earlier returns already made unreachable** (-8 LoC)
- **BaseTextInput.discardDraft consults an image-paste queue that no input registering for Ctrl-C discard can ever have work in — InputBar owns that guard on the live path** (-7 LoC)
- **`AppProps.canInterruptActiveRun` exists only as a `??` fallback for `canStopActiveRun`, and it is a deliberately different predicate** (-5 LoC)
- **StatusBar's subscription-quota poll catches a rejection getUsage cannot produce, and the arm it runs is what the real failure path already renders** (-5 LoC)
- **runOrchestrationTui returns five action kinds it can never return, and the launcher loop carries five dead switch arms for them** (-5 LoC)
- **`ConfigFormProps.resetValue` is optional for a props type with exactly one producer, and its fallback writes `''` into settings that reject it** (-4 LoC)
- **listAgents pre-calls loadAgents under exactly the guard its callee re-applies one line later** (-3 LoC)
- **bashCompletion emits a `*)` fallback that bash can never reach, and it disagrees with the root case block emitted three lines above it** (-3 LoC)
- **EditApproval mirrors ConfirmCard's feedback-mode state in a ref whose value is always the negation of the argument it is compared against** (-2 LoC)
- **One of statusBarBindingsText's 15 fallback rows is provably unreachable, and two more differ from later rows only by an inert gate** (-2 LoC)
- **reconcileSynthetics applies the raw kind Set where the other two fold paths call isWorkflowOperationalRow, contradicting the comment that claims one membership rule** (-1 LoC)
- **requestRetryInteraction re-tests decision.disableQuotaRoute !== undefined inside the branch that already established it** (-1 LoC)
- **orchestrationLauncherLayout's last layout candidate and its post-loop fallback compute the identical result** (-1 LoC)

## Deliberately not done (4)

Round 5 shipped two findings that had to be withdrawn for reasoning past what the code says it is for. Every lane was told that skipping on those grounds is the most valuable thing it can do:

- **9. BaseTextInput.discardDraft consults an image-paste queue that can never have work** — SKIPPED on the deliberate-code rule. The guard is internally coherent for the component that owns it, and the proposal keeps two OTHER reads of the same permanently-false queue in the same file (BaseTextInput:539 and :652) while deleting only these — an asymmetry the verifier itself calls 'a judgment call, not something the evidence proves'. The deadness proof rests entirely on an App-level focus/disabled invariant t
- **17 (second half). Collapse statusBarBindingsText rows 2/3 against rows 7/8** — REFUTED by the verifier and skipped. Commit ce4193d4cdf ('fix(cli): prefer richer parent footer hints') added rows 2/3 fifteen minutes after rows 7/8 with 18 lines of new StatusBar.vitest assertions — the priority hoist is the recorded purpose of that commit, not copy-paste. All four candidates are selected somewhere in the input space, so nothing there is dead, and the collapse would have been net POSITIVE LoC once 
- **25 (rider). Add a Hangup: 129 row to CliExitCode** — Skipped as unnecessary scope: the verifier classes both exit-code riders as cosmetic and not what makes the finding survive. The Terminated:143 swap landed because the constant already exists; adding a new enum row for one call site is a fresh export surface for no behavior gain.
- **12 (type-narrowing half). Add CliOrchestrationResolvedAction via Exclude<>** — Skipped per the verifier: the alias plus doc is ~12-13 lines against 5 deleted, i.e. net +8 to +10, AND it breaks the onSelect={finish} prop assignment at runOrchestrationTui.tsx:420-427 under strictFunctionTypes, which the proposal did not budget for. Shipped the deletion-only variant, which the verifier established needs no type work at all (no switch-exhaustiveness lint rule, no noFallthroughCasesInSwitch, switch 

<details><summary>Deliberate code this lane found and left alone</summary>

Three cases where the code's own comment, commit provenance, or contract defeated or reshaped a finding, and I did NOT edit past them:

1. statusBarBindingsText rows 2/3 vs 7/8 (finding 17, half skipped). The finding claimed "nothing in the file's comments states that intent, and duplicated literal rows read as copy-paste rather than a deliberate reordering." That is false: ce4193d4cdf ("fix(cli): prefer richer parent footer hints", 2026-08-02 20:08) added rows 2/3 fifteen minutes after aa9ee4479e8 (19:53) added rows 7/8, and shipped 18 lines of new StatusBar.vitest assertions with it. The priority hoist is the recorded purpose of a commit, and all four candidates are genuinely selected somewhere in the 414,720-case flag space. I deleted only the two rows proven unreachable by exhaustive reasoning (candidates 11 and 14) and left the hoist alone.

2. initPlatform's quietLogs convention (finding 26). The file documents itself two lines above the code — "Malformed project config is actionable degradation, not routine progress noise, so this deliberately bypasses quietLogs" — with showPersistentConfigWarning as the precedent. That convention is what refuted the original sweeping "all platform-init logging is suppressed" claim. I did not touch any other logAt site; I only routed the lifecycle onError through the same documented stderr bypass, because THAT site carries its own comment ("Same severity and wording as the extension/desktop hosts") stating a parity the mechanism made unreachable. The fix follows the file's convention rather than overriding it.

3. SubscriptionUsageService's never-reject contract (finding 11). Rather than treating the .catch as a defensive guard worth keeping, I verified the class doc at SubscriptionUsageService.ts:100-101 ("always resolve to a snapshot instead of exposing provider transport failures to extension or CLI consumers") AND the test that pins it (SubscriptionUsageService.vitest.ts:579-609, sync-throw and rejected-promise cases both resolving to an unavailable snapshot). The deletion is safe because the contract is documented and tested, not because the code merely looks unreachable — and I left the sibling poll ~40 lines above untouched, since that one genuinely rejects and correctly latches a [warn] to stderr.

Also worth recording: I skipped finding 9 (BaseTextInput.discardDraft) precisely on this rule. Its proof of deadness comes entirely from App-level focus wiring, and the same proposal keeps two other permanently-false reads of the same queue in the same file. A guard whose removal is defensible only by an invariant no type, test, or comment enforces is not safe to delete for -6 lines.

</details>

## Validation

Run on this branch **in isolation**: `npm run typecheck` (six projects), `npm run lint`, `npm run check:dead-code-ratchet`, `npm test` (full suite), `npm run format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)