### PR TITLE
fix(handlers): restore Grok temperature and five model-handler residues

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -130,12 +130,20 @@ interface ClientCompactionResult<M> {
   didCompact: boolean;
 }
 
-// Default continuation limits
-const DEFAULT_CONTINUE_LIMIT = 10;
+// Conversation stop limits. Fixed for every handler: nothing overrides them
+// per instance, so they are read straight from `checkStopConditions`.
+const CONTINUE_LIMIT = 10;
+const INPUT_TOKEN_LIMIT = 1500000;
+const OUTPUT_TOKEN_LIMIT_FACTOR = 2.5;
 
-// Default token limits
-const DEFAULT_INPUT_TOKEN_LIMIT = 1500000;
-const DEFAULT_OUTPUT_TOKEN_LIMIT_FACTOR = 2.5;
+/**
+ * A round's media content plus the entries behind it — what the transcript's
+ * attachment chips are derived from. Returned together so the two can't drift.
+ */
+export interface CreatedMedia<Media> {
+  readonly media: Media[];
+  readonly entries: readonly MediaEntry[];
+}
 
 interface AssistantTextAppendOptions {
   /**
@@ -215,9 +223,6 @@ export abstract class ModelHandler<
   private singleTurnInFlight = false;
   public config: ResolvedModelConfig;
   public capabilities: ModelCapabilities;
-  public continueLimit: number;
-  public inputTokenLimit: number;
-  public maxOutputTokensFactor: number;
   protected logger: AgentTrace;
   protected outputStreaming = false;
   protected backgroundModeSupported = false;
@@ -228,7 +233,6 @@ export abstract class ModelHandler<
     MediaAttachmentContext,
     MediaAttachmentKind[]
   >();
-  private createdMediaEntriesForAttachmentLog: MediaEntry[] = [];
   protected readonly normalizeResponseText: ResponseTextProcessing['normalizeResponseText'];
   protected readonly postProcessResponse: ResponseTextProcessing['postProcessResponse'];
 
@@ -281,9 +285,6 @@ export abstract class ModelHandler<
     this.normalizeResponseText = responseTextProcessing.normalizeResponseText;
     this.postProcessResponse = responseTextProcessing.postProcessResponse;
     this.capabilities = structuredClone(config.capabilities);
-    this.continueLimit = DEFAULT_CONTINUE_LIMIT;
-    this.inputTokenLimit = DEFAULT_INPUT_TOKEN_LIMIT;
-    this.maxOutputTokensFactor = DEFAULT_OUTPUT_TOKEN_LIMIT_FACTOR;
     // Initialize with default channel, will be overwritten by agent. Log-only
     // module singletons now use `createLog`; remaining `createChannelTrace`
     // sites are genuine `AgentTrace`-typed fallbacks plus log-only callers
@@ -887,22 +888,16 @@ export abstract class ModelHandler<
    * Create image/audio messages for the conversation.
    * This is a shared implementation that can be used by all providers.
    * Individual providers can override if needed.
-   * @returns Array of media content objects in provider-specific format
+   * @returns The provider-specific media content and the entries behind it
    */
   protected async createMediaMessage(
     mediaFiles: FileLocation[],
-  ): Promise<Media[]> {
+  ): Promise<CreatedMedia<Media>> {
     const { entries, results } =
       await this.mediaProcessor.loadEntries(mediaFiles);
     this.mediaProcessor.logResults(results);
-    this.setCreatedMediaEntriesForAttachmentLog(entries);
-    return this.createMediaContent(entries);
-  }
-
-  protected setCreatedMediaEntriesForAttachmentLog(
-    entries: readonly MediaEntry[],
-  ): void {
-    this.createdMediaEntriesForAttachmentLog = [...entries];
+    // Reports every loaded entry, including any `createMediaContent` drops.
+    return { media: this.createMediaContent(entries), entries };
   }
 
   public consumeInsertedAttachmentKinds(
@@ -928,15 +923,12 @@ export abstract class ModelHandler<
     context: MediaAttachmentContext,
   ): Promise<Media[]> {
     this.insertedAttachmentKinds.set(context, []);
-    this.setCreatedMediaEntriesForAttachmentLog([]);
     try {
-      const media = await this.createMediaMessage(mediaFiles);
+      const { media, entries } = await this.createMediaMessage(mediaFiles);
       if (media.length > 0) {
         this.insertedAttachmentKinds.set(
           context,
-          mediaAttachmentKindsFromEntries(
-            this.createdMediaEntriesForAttachmentLog,
-          ),
+          mediaAttachmentKindsFromEntries(entries),
         );
       }
       return media;
@@ -961,22 +953,23 @@ export abstract class ModelHandler<
     const totals = stateGlobal.usageAccumulator.totals;
     const maxOutputTokens =
       totals.firstInputTokens > 0
-        ? this.maxOutputTokensFactor * totals.firstInputTokens
+        ? OUTPUT_TOKEN_LIMIT_FACTOR * totals.firstInputTokens
         : Number.POSITIVE_INFINITY;
     const continuationLimitExceeded =
-      stateRound.continuationCount > this.continueLimit;
-    const inputTokenLimitExceeded =
-      totals.totalInputTokens > this.inputTokenLimit;
+      stateRound.continuationCount > CONTINUE_LIMIT;
+    const inputTokenLimitExceeded = totals.totalInputTokens > INPUT_TOKEN_LIMIT;
     const maxOutputTokensExceeded = totals.totalOutputTokens > maxOutputTokens;
 
     // Detect stop markers in model output
     const endTurn = END_TURN_REASONS.includes(stopReason ?? '');
     const encounterDocumentTag = newResponse.includes(OUTPUT_END_TAG);
 
+    // Warn-only by design: this multiplier has never fed `shouldStop`, it just
+    // flags a run whose output has run away relative to its first input.
     if (maxOutputTokensExceeded) {
       this.logger.warn('Output tokens exceed input token multiplier', {
         data: {
-          maxOutputTokensFactor: this.maxOutputTokensFactor,
+          maxOutputTokensFactor: OUTPUT_TOKEN_LIMIT_FACTOR,
           totalOutputTokens: totals.totalOutputTokens,
           firstInputTokens: totals.firstInputTokens,
         },

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -15,7 +15,10 @@ import { ReasoningEffort } from 'llm-zoo';
 // Local imports
 import { logProgressStatus } from '@agent/trace';
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
-import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
+import {
+  ModelHandler,
+  type CreatedMedia,
+} from '@agent/modelHandlers/ModelHandler';
 import { reportMediaAttachmentFailure } from '@agent/modelHandlers/support/mediaAttachmentPolicy';
 import { parseToolInputAsObject } from '@agent/core/flows/toolCallParsing';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
@@ -719,9 +722,9 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
 
   protected override async createMediaMessage(
     mediaFiles: FileLocation[],
-  ): Promise<Content[]> {
+  ): Promise<CreatedMedia<Content>> {
     if (!this.canAttachMedia(mediaFiles)) {
-      return [];
+      return { media: [], entries: [] };
     }
 
     const { entries, results } =
@@ -729,16 +732,20 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     this.mediaProcessor.logResults(results);
 
     if (entries.length === 0) {
-      return [];
+      return { media: [], entries: [] };
     }
 
     return this.uploadMediaEntries(entries);
   }
 
-  /** Media blocks for the entries (inline when small enough, uploaded otherwise). */
+  /**
+   * Media blocks for the entries (inline when small enough, uploaded
+   * otherwise). Unlike the base template this reports only the entries that
+   * were actually appended, since an upload can drop one.
+   */
   protected async uploadMediaEntries(
     entries: MediaEntry[],
-  ): Promise<Content[]> {
+  ): Promise<CreatedMedia<Content>> {
     const insertedEntries: MediaEntry[] = [];
     const media = await uploadGoogleMediaEntries<Content>(entries, {
       getClient: () => this.getClient(),
@@ -751,8 +758,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
         ),
       onInsertedEntry: (entry) => insertedEntries.push(entry),
     });
-    this.setCreatedMediaEntriesForAttachmentLog(insertedEntries);
-    return media;
+    return { media, entries: insertedEntries };
   }
 
   // ===========================================================================
@@ -1106,19 +1112,16 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
         stopReason = status;
     }
 
-    // If the model completed naturally without the end tag, append it (mirrors
-    // the chat handler's STOP behavior, keyed on the terminal completion).
-    if (
-      stopReason === GOOGLE_FINISH.STOP &&
-      endTag &&
-      responseText.length > 0 &&
-      !responseText.endsWith(endTag)
-    ) {
-      this.logger.debug(
-        `Model completed but didn't include end tag. Appending ${endTag}.`,
-      );
-      responseText += `\n${endTag}`;
-    }
+    // A terminal 'completed' is this route's "natural stop" predicate for the
+    // end tag configured as a stop sequence above (`stop_sequences: [endTag]`).
+    // The empty-text guard is Google-specific: 'completed' here cannot tell a
+    // stop-sequence match from a natural end of turn, so an empty completion
+    // must not be stamped as finished.
+    responseText = this.appendEndTagIfNeeded(
+      responseText,
+      endTag,
+      stopReason === GOOGLE_FINISH.STOP && responseText.length > 0,
+    );
 
     return { text: responseText, usage, stopReason };
   }

--- a/src/agent/modelHandlers/openai/ResponseStreamProcessor.ts
+++ b/src/agent/modelHandlers/openai/ResponseStreamProcessor.ts
@@ -104,11 +104,9 @@ export class ResponseStreamProcessor {
       this.outputItems.push(item);
       if (item.type === 'reasoning') {
         this.closeThinkingStream();
-      } else if (
-        item.type === 'web_search_call' &&
-        !this.emittedWebSearchIds.has(item.id) &&
-        hasOpenAIWebSearchData(item)
-      ) {
+      } else if (item.type === 'web_search_call') {
+        // Phase boundary, same as the `.in_progress` arm above.
+        // emitWebSearchOnce owns the dedup and missing-data checks.
         this.closeThinkingStream();
         this.emitWebSearchOnce(item);
       }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -322,11 +322,16 @@ export class ModelHandlerOpenAI<
         : { max_tokens: effectiveMaxTokens }),
     };
 
-    if (this.configuresEndTagStopSequence) {
-      if (endTag) {
-        baseParams.stop = [endTag];
-      }
+    // Only the o-series rejects `temperature`. Grok reasoning models take it
+    // (they reject `stop`, which is what configuresEndTagStopSequence is for),
+    // so the two decisions no longer ride on one flag — c70dd4cc96 widened the
+    // stop guard and dropped temperature for xAI as collateral.
+    if (!this.isOReasoningModel) {
       baseParams.temperature = temperature;
+    }
+
+    if (this.configuresEndTagStopSequence && endTag) {
+      baseParams.stop = [endTag];
     }
 
     const reasoningEffort = this.getReasoningEffortParameter();

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -601,16 +601,21 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
     if (response.usage?.input_tokens) {
       this.chainState.setCumulativeInputTokens(response.usage.input_tokens);
     } else {
-      // Not silent degradation: the chain anchor was already refused above
-      // (hasInputTokens gates safeToChain), this records that the context
-      // baseline could not be advanced for this turn.
+      // Reached when usage is absent OR input_tokens is 0 — deliberately a
+      // truthiness check, not the `hasInputTokens` typeof check above: a zero
+      // is a baseline that cannot be advanced, not a chain anchor to refuse.
+      // The previous cumulativeInputTokens is carried forward on purpose (see
+      // the invalidateChain rationale above), so a proxy that zeroes usage
+      // can't disable compaction — canCompactRoute() requires it to be > 0.
+      // Not silent degradation: the fact is recorded here with the raw value.
       this.logger.debug(
-        'Response usage missing input_tokens; context usage not tracked',
+        'Response usage missing or zero input_tokens; compaction baseline carried forward',
         {
           data: {
             responseId: response.id,
             responseStatus: response.status,
             hasUsage: !!response.usage,
+            inputTokens: response.usage?.input_tokens,
           },
         },
       );
@@ -1167,8 +1172,8 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
       ? 'system'
       : 'user';
 
-    if (requestRole === 'user' && messages.length > 0) {
-      this.appendInputText(messages.at(-1)!, userRequest);
+    if (requestRole === 'user') {
+      userContent.push(createInputText(userRequest));
     } else {
       const requestMessage: ResponseInputItem.Message = {
         type: 'message',
@@ -2848,26 +2853,6 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
     // undefined.
     const text = contentToText(message.content, '');
     return text.length > 0 ? text : undefined;
-  }
-
-  private appendInputText(message: ResponseInputItem, text: string): void {
-    if (!isMessageItem(message)) {
-      return;
-    }
-
-    const content = message.content;
-
-    if (Array.isArray(content)) {
-      content.push(createInputText(text));
-      return;
-    }
-
-    if (typeof content === 'string') {
-      message.content = [createInputText(content), createInputText(text)];
-      return;
-    }
-
-    message.content = [createInputText(text)];
   }
 
   private appendAssistantText(

--- a/src/agent/modelHandlers/openai/openAIMessageUtils.ts
+++ b/src/agent/modelHandlers/openai/openAIMessageUtils.ts
@@ -299,27 +299,14 @@ export async function initializeChatMessages<T extends MessageLike>(
     userMessageContent.push(...formattedMediaContent);
   }
 
-  // Append content to last user message, or create new user message
-  const lastMsg = messages.at(-1);
-  if (lastMsg?.role === 'user' && Array.isArray(lastMsg.content)) {
-    lastMsg.content.push(...userMessageContent);
-  } else {
-    messages.push({ role: 'user', content: userMessageContent } as T);
-  }
+  // Only the system prompt can precede this, so the user message is always new.
+  messages.push({ role: 'user', content: userMessageContent } as T);
 
-  // Add final user request
+  // Add final user request: into the user message just pushed, or as its own
+  // 'system'-role message when the model requires intermediate dev messages.
   const requestRole = capabilities.supportsIntermDevMsgs ? 'system' : 'user';
-  const lastMessage = messages.at(-1);
-
-  if (
-    requestRole === 'user' &&
-    lastMessage?.role === 'user' &&
-    Array.isArray(lastMessage.content)
-  ) {
-    lastMessage.content.push({
-      type: 'text',
-      text: userRequest,
-    });
+  if (requestRole === 'user') {
+    userMessageContent.push({ type: 'text', text: userRequest });
   } else {
     messages.push({
       role: requestRole,

--- a/src/agent/modelHandlers/support/BackgroundPoller.ts
+++ b/src/agent/modelHandlers/support/BackgroundPoller.ts
@@ -57,11 +57,12 @@ interface BackgroundPollOptions<TResponse> {
   /** Optional abort signal propagated to `delay` and `retrieve`. */
   readonly signal?: AbortSignal;
   /**
-   * Absolute wall-clock deadline for a polling lifetime that began before
-   * this invocation. When absent, this invocation receives the configured
-   * maximum duration.
+   * Absolute wall-clock deadline for the polling lifetime, which may have
+   * begun before this invocation (a resumed poll continues the original
+   * budget). Owned by the caller — {@link BackgroundRunLifecycle} keeps it
+   * alongside the pending run id.
    */
-  readonly deadlineAtMs?: number;
+  readonly deadlineAtMs: number;
   /**
    * Optional callback invoked on abort (best-effort). Handlers use this to
    * cancel the in-flight job server-side or clear local tracking state.
@@ -153,6 +154,7 @@ function safeExtraData<TResponse>(
  *   extractId: (r) => r.id,
  *   extractStatus: (r) => r.status ?? 'unknown',
  *   signal,
+ *   deadlineAtMs: Date.now() + 3 * 60 * 60 * 1000,
  *   providerLabel: 'OpenAI',
  * });
  * ```
@@ -189,19 +191,14 @@ export class BackgroundPoller<TResponse> {
 
     const { pollIntervalMs, maxDurationMs, isPending } = this.config;
     const logger = () => resolveLogger(this.config.logger);
-    const startTime =
-      deadlineAtMs === undefined ? Date.now() : deadlineAtMs - maxDurationMs;
+    const startTime = deadlineAtMs - maxDurationMs;
     let current = initialResponse;
     let pollCount = 0;
 
     const throwIfTimedOut = async (response: TResponse): Promise<void> => {
       const now = Date.now();
+      if (now < deadlineAtMs) return;
       const elapsedMs = now - startTime;
-      const timedOut =
-        deadlineAtMs === undefined
-          ? elapsedMs >= maxDurationMs
-          : now >= deadlineAtMs;
-      if (!timedOut) return;
 
       const stats = {
         responseId,
@@ -273,23 +270,21 @@ export class BackgroundPoller<TResponse> {
           throw err;
         }
 
-        if (deadlineAtMs !== undefined) signal?.throwIfAborted();
+        signal?.throwIfAborted();
         await throwIfTimedOut(current);
 
         let retrieved: TResponse;
         try {
           retrieved = await retrieve(responseId, signal);
         } catch (err) {
-          if (deadlineAtMs !== undefined && !isUserAbort(err)) {
+          if (!isUserAbort(err)) {
             signal?.throwIfAborted();
             await throwIfTimedOut(current);
           }
           throw err;
         }
-        if (deadlineAtMs !== undefined) {
-          signal?.throwIfAborted();
-          await throwIfTimedOut(retrieved);
-        }
+        signal?.throwIfAborted();
+        await throwIfTimedOut(retrieved);
         current = retrieved;
 
         const polledStatus = extractStatus(current);

--- a/src/test-kernel/agent/modelHandlers/BackgroundPoller.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/BackgroundPoller.vitest.ts
@@ -65,6 +65,7 @@ describe('BackgroundPoller', () => {
       retrieve: vi.fn(),
       extractId,
       extractStatus,
+      deadlineAtMs: Date.now() + 1000,
       providerLabel: 'OpenAI',
     });
 
@@ -85,6 +86,8 @@ describe('BackgroundPoller', () => {
         retrieve: vi.fn(),
         extractId,
         extractStatus,
+        // Already expired: mirrors the configured maxDurationMs of -1.
+        deadlineAtMs: Date.now() - 1,
         providerLabel: 'OpenAI',
         formatTimeoutError: ({ responseId, maxDurationMs }) =>
           `Cancel ${responseId} after ${maxDurationMs} ms with provider API.`,
@@ -207,7 +210,7 @@ describe('BackgroundPoller', () => {
     },
   );
 
-  it('times out the default poller exactly at its duration boundary', async () => {
+  it('times out exactly at the duration boundary', async () => {
     vi.useFakeTimers({ now: FROZEN_NOW });
     const retrieve = vi.fn(async () => ({
       id: 'resp-boundary',
@@ -220,6 +223,7 @@ describe('BackgroundPoller', () => {
       retrieve,
       extractId,
       extractStatus,
+      deadlineAtMs: Date.now(),
     });
     const rejection = expect(polling).rejects.toThrow(
       'exceeded maximum polling duration',
@@ -245,6 +249,7 @@ describe('BackgroundPoller', () => {
       extractId,
       extractStatus,
       signal: controller.signal,
+      deadlineAtMs: Date.now() + 10_000,
       providerLabel: 'Google Interactions',
       resourceLabel: 'interaction',
     });
@@ -277,6 +282,7 @@ describe('BackgroundPoller', () => {
       })),
       extractId,
       extractStatus,
+      deadlineAtMs: Date.now() + 1000,
       providerLabel: 'OpenAI',
       extraFinishData: (response) => ({ usage: response.usage }),
       onFinished: (_response, stats) => {

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 // Local imports
 import { noopTrace } from '@agent/trace';
 import { ModelHandlerGoogleInteractions } from '@agent/modelHandlers/google/modelHandlerGoogleInteractions';
+import type { CreatedMedia } from '@agent/modelHandlers/ModelHandler';
 import { GOOGLE_FINISH } from '@agent/types/StopReasonTypes';
 import type { MediaEntry } from '@agent/types/mediaTypes';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
@@ -64,14 +65,14 @@ class MediaProbeHandler extends ModelHandlerGoogleInteractions {
   }
 
   /** Invoke the media-upload pipeline directly. */
-  uploadEntries(entries: MediaEntry[]): Promise<Interactions.Content[]> {
-    return this.uploadMediaEntries(entries);
+  async uploadEntries(entries: MediaEntry[]): Promise<Interactions.Content[]> {
+    return (await this.uploadMediaEntries(entries)).media;
   }
 
   protected override async createMediaMessage(): Promise<
-    Interactions.Content[]
+    CreatedMedia<Interactions.Content>
   > {
-    return this.stubbedMedia;
+    return { media: this.stubbedMedia, entries: [] };
   }
 }
 

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -27,6 +27,7 @@ import {
 } from '@agent/core/definition/AgentDataclass';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/anthropic/modelHandlerAnthropic';
+import type { CreatedMedia } from '@agent/modelHandlers/ModelHandler';
 import type { AnthropicToolCall } from '@agent/types/ModelHandlerContracts';
 import { ANTHROPIC_STOP } from '@agent/types/StopReasonTypes';
 import {
@@ -496,8 +497,10 @@ class PdfStubAnthropicHandler extends ModelHandlerAnthropic {
     this.mediaContent = content;
   }
 
-  protected override async createMediaMessage(): Promise<any[]> {
-    return this.mediaContent;
+  protected override async createMediaMessage(): Promise<
+    CreatedMedia<ContentBlockParam>
+  > {
+    return { media: this.mediaContent, entries: [] };
   }
 }
 

--- a/src/test-kernel/agent/modelHandlers/OpenAICompatibleProviderParams.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAICompatibleProviderParams.vitest.ts
@@ -506,6 +506,18 @@ describe('OpenAI-compatible provider request params', () => {
     assert.equal(createCalls[0].reasoning_effort, 'max');
   });
 
+  it('preserves temperature for Grok reasoning models', async () => {
+    const handler = createXaiHandler({
+      name: 'grok45',
+      fullName: 'grok-4.5',
+      capabilities: { supportsReasoning: true },
+    });
+
+    const { createCalls } = await sendRequest(handler);
+
+    assert.equal(createCalls[0].temperature, 0);
+  });
+
   it('passes medium reasoning effort through for current Grok models', async () => {
     const handler = createXaiHandler({
       name: 'grok45',


### PR DESCRIPTION
Lane `L4-handlers` of the [round-5 deep read](https://github.com/texra-ai/coauthor/pull/11497).

Rounds 1-4 surveyed the codebase. Round 5 **read** it: all 295,148 lines of production TypeScript in 36 cohesive slices, every file opened. That is why 2 of this lane's 7 findings are **bugs**, not simplifications.

## Bugs fixed

- **finalizeResponse guards the same `input_tokens` field two different ways, and the else-branch comment is false in the case the first guard was written to protect** (amend)
- **Every live Grok model silently drops `temperature`: the setting rides on a flag documented to govern only the end-tag stop sequence** (defect)

## Simplifications

- **Batch: four guards that can never be false (or are already checked by the caller) in the OpenAI message builders and stream processor** (-19 LoC)
- **BackgroundPoller's optional `deadlineAtMs` mode is production-dead, and its two timeout branches compute the same value** (-10 LoC)
- **Google Interactions hand-rolls end-tag restoration with `endsWith` where the shared helper the other three handlers use checks `includes`** (-7 LoC)
- **Three public mutable stop-limit fields on ModelHandler that nothing outside the constructor ever writes or reads** (-6 LoC)
- **`createMediaMessage` returns its media through the return value but its entries through a private field on the base handler** (-5 LoC)

## Deliberately not done (5)

Round 5 shipped two findings that had to be withdrawn for reasoning past what the code says it is for. Every lane was told that skipping on those grounds is the most valuable thing it can do:

- **Finding 1(d) - drop the `?? this.getEffectiveMaxOutputTokens()` fallback at modelHandlerOpenAI.ts:634-635** — Skipped on the verifier's explicit instruction (correction 2), and independently confirmed: the `??` is load-bearing for the type system, not dead weight. `baseParams[maxTokensKey]` is `number | null | undefined` (the SDK types both `max_tokens` and `max_completion_tokens` as `number | null`), while `applyTokenCountLimit`'s `currentMaxTokens` is `number`. Dropping the `??` would force a non-null assertion - exactly t
- **Finding 2 - the 'optional extra step' of deleting the post-retrieve-failure re-check at BackgroundPoller.ts:283-286** — REFUSED per verifier correction 5, and I confirmed both halves. The block is the code path pinned by 'returns the timeout error when retrieval rejects at the deadline' (a regression pin from cb4a6e3f4f whose retrieve throws 'socket hang up' at the deadline and asserts `rejects.toBe(timeout)`); with the block gone the raw socket error propagates and the test fails. It also would make BackgroundPoller correct only when
- **Finding 2 - make `resourceLabel` / `providerLabel` required, and delete the `!responseId` early return at :185-188** — Both skipped per verifier corrections 2 and 4. Making the labels required is net-POSITIVE LoC (five poll() call sites omit providerLabel and eight of nine omit resourceLabel: ~13 test lines added to save 2 production lines). The `!responseId` guard is not as dead as claimed - pollToTerminal checks `pollId === undefined` only, so an empty-string id passes that check and is caught solely here; removing it also forces `
- **Finding 3 follow-up - hoist the `text.length > 0` guard into `appendEndTagIfNeeded` for all four handlers** — Skipped: the surveyor's recommendation would REGRESS Anthropic. Anthropic gates on `stopReason === ANTHROPIC_STOP.STOP_SEQUENCE`, the provider stating the configured stop sequence actually matched, so restoring the tag on empty text there is provably correct rather than forging (verifier correction 2). It also has its own empty-response bail before that point. Only OpenAI/OpenRouter share Google's ambiguity, and that
- **Verifier note 5 on finding 1 - the stale DEEPSEEK_OFFICIAL_API_MAX_TOKENS docstring at modelHandlerOpenAI.ts:106** — Explicitly out of scope: 'stale comment; do not fix it in this PR'. The docstring says 'see the buildChatBaseParams override below' but :308 is the base definition, not an override. Left for a separate change.

<details><summary>Deliberate code this lane found and left alone</summary>

Nothing in this lane turned out to be deliberate-and-defended in a way that killed a finding outright, but three edits were narrowed or dropped because the code explains its own shape, and two of the seven findings landed only in part for that reason.

1. **modelHandlerOpenAI.ts:634 `baseParams[maxTokensKey] ?? this.getEffectiveMaxOutputTokens()` (finding 1d) - SKIPPED.** The finding read this as pure dead weight because `buildChatBaseParams` sets that exact key on every path. It is dead at runtime, but the `??` is load-bearing for TYPES: the OpenAI SDK declares `max_tokens?: number | null` and `max_completion_tokens?: number | null`, so the indexed read is `number | null | undefined` while `applyTokenCountLimit`'s `currentMaxTokens` is `number`. Deleting it forces a non-null assertion to save one line. The tell that this was not an accident is that the same batch calls a non-null assertion 'the tell' of a bug three items earlier.

2. **modelHandlerAnthropic's end-tag restoration (finding 3 follow-up) - the recommended hoist was REFUSED.** The surveyor recommended hoisting a `text.length > 0` guard into the shared `appendEndTagIfNeeded` for all four handlers, calling the empty-completion case 'silent degradation'. Anthropic's caller gates on `ANTHROPIC_STOP.STOP_SEQUENCE` - the provider explicitly stating the configured stop sequence matched - which makes restoring the tag on empty text provably correct there, not forged. (Anthropic also carries the `usage.output_tokens === 3` empirical sentinel just above, the exact constant a previous round-5 finding was withdrawn over; I did not touch it.) The ambiguity is real only for `finish_reason: 'stop'` (OpenAI/OpenRouter) and Google's `'completed'`. So I landed the Google fold and kept Google's `length > 0` guard, now documented as route-specific rather than silently different.

3. **BackgroundPoller.ts:283-286 and :185-188 - both KEPT.** The post-failure abort/deadline re-check looks like a duplicate of what `handleRetrieveFailure` -> `assertCanPoll` already did, but it is the sole code path pinned by a named regression test from cb4a6e3f4f, and deleting it would make the shared collaborator correct only for a caller that pre-checks. The `!responseId` early return looks unreachable given `extractId: () => pollId`, but `pollToTerminal` only checks `pollId === undefined`, so an empty-string id is caught nowhere else.

4. **modelHandlerOpenAIResponse.ts:551-553 `typeof` guard (finding 6) - the guard was KEPT and only the comment fixed.** The comment 'Use a typeof check rather than truthiness so a legitimate 0 wouldn't be misclassified' explains the first guard, and the `:576-582` block explains why `cumulativeInputTokens` is carried forward rather than reset. The two guards genuinely disagree at `input_tokens === 0`, but the disagreement is in the direction the surrounding comments want; what was actually wrong was the else-branch's claim that the chain anchor had been refused. Fixing the comment kills t

</details>

## Validation

Run on this branch **in isolation**: `npm run typecheck` (six projects), `npm run lint`, `npm run check:dead-code-ratchet`, `npm test` (full suite), `npm run format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)