### PR TITLE
fix(cli): hide the todos/plan panel while the child list has focus

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -8,12 +8,6 @@
       "name": "allocateConversationBottomPanelRows"
     },
     {
-      "file": "packages/cli/src/chat/tui/appLayout.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "allocateSidePanelRows"
-    },
-    {
       "file": "packages/cli/src/chat/tui/chatSubmitDriver.ts",
       "category": "production-dead",
       "kind": "exports",

--- a/packages/cli/src/chat/tui/appLayout.ts
+++ b/packages/cli/src/chat/tui/appLayout.ts
@@ -107,44 +107,6 @@ export function allocateMiddleRows({
   };
 }
 
-export function allocateSidePanelRows({
-  subagentContentRows,
-  todosPlanContentRows,
-  rows,
-}: {
-  readonly subagentContentRows: number;
-  readonly todosPlanContentRows: number;
-  readonly rows: number;
-}): {
-  readonly subagentRows: number;
-  readonly todosPlanRows: number;
-} {
-  const available = Math.max(0, rows);
-  const subagentNeed = Math.max(0, subagentContentRows);
-  const todosNeed = Math.max(0, todosPlanContentRows);
-  if (available === 0 || subagentNeed + todosNeed === 0) {
-    return { subagentRows: 0, todosPlanRows: 0 };
-  }
-  // Everything fits: each panel gets exactly what its content needs.
-  if (subagentNeed + todosNeed <= available) {
-    return { subagentRows: subagentNeed, todosPlanRows: todosNeed };
-  }
-  // Over budget: a panel with no content gets nothing, a lone panel takes all.
-  if (subagentNeed === 0) return { subagentRows: 0, todosPlanRows: available };
-  if (todosNeed === 0) return { subagentRows: available, todosPlanRows: 0 };
-  // Both present and over budget: keep at least one row each, split the rest
-  // proportionally to need. At a single row the todo/plan panel wins.
-  if (available === 1) return { subagentRows: 0, todosPlanRows: 1 };
-  const subagentRows = Math.min(
-    available - 1,
-    Math.max(
-      1,
-      Math.round((subagentNeed / (subagentNeed + todosNeed)) * available),
-    ),
-  );
-  return { subagentRows, todosPlanRows: available - subagentRows };
-}
-
 export function allocateConversationBottomPanelRows({
   maxRows,
   sessionCount,
@@ -164,81 +126,29 @@ export function allocateConversationBottomPanelRows({
   readonly sessionPanelRows: number;
   readonly todosPlanRows: number;
 } {
-  // Child sessions already have a compact count and navigation affordance in
-  // the status bar. Keep their rows collapsed until the user focuses the
-  // list; a large workflow must not take transcript space merely because it
-  // is running in the background.
-  const childListRowCount = childListFocused ? sessionCount : 0;
-  // The expanded child list owns one blank separator row above its Select.
-  const sessionPanelContentRows =
-    childListRowCount > 0 ? childListRowCount + 1 : 0;
-  // The todos/plan panel likewise owns a separator row above its checklist.
-  const todosPanelContentRows =
-    todosPlanContentRows > 0 ? todosPlanContentRows + 1 : 0;
-  const minimumSessionRows =
-    childListRowCount > 0 ? minimumSessionPanelRows : 0;
   const availableTranscriptRows = Math.max(0, transcriptRows);
-  let panelTranscriptLimit: number;
+  const none = { bottomPanelRows: 0, sessionPanelRows: 0, todosPlanRows: 0 };
+  // Exactly one bottom panel exists at a time. Child sessions already have a
+  // compact count and navigation affordance in the status bar, so their list
+  // stays collapsed until the user focuses it — a large workflow must not take
+  // transcript space merely because it is running in the background — and the
+  // todos/plan panel hides while the list has focus
+  // (`shouldShowTodosPlanPanel`). Each panel owns one separator row above its
+  // content, and a lone row cannot hold separator plus content.
   if (childListFocused) {
-    panelTranscriptLimit = availableTranscriptRows;
-  } else if (availableTranscriptRows === 0) {
-    panelTranscriptLimit = 0;
-  } else {
-    const unfocusedLimit = Math.floor(availableTranscriptRows / 2);
-    panelTranscriptLimit =
-      availableTranscriptRows >= minimumSessionRows
-        ? Math.max(minimumSessionRows, unfocusedLimit)
-        : unfocusedLimit;
+    if (sessionCount === 0) return none;
+    const rows = Math.min(maxRows, sessionCount + 1, availableTranscriptRows);
+    if (rows < minimumSessionPanelRows) return none;
+    return { bottomPanelRows: rows, sessionPanelRows: rows, todosPlanRows: 0 };
   }
-  if (
-    sessionPanelContentRows > 0 &&
-    todosPanelContentRows === 0 &&
-    panelTranscriptLimit < minimumSessionRows
-  ) {
-    return {
-      bottomPanelRows: 0,
-      sessionPanelRows: 0,
-      todosPlanRows: 0,
-    };
-  }
-  const bottomPanelRows = Math.min(
+  if (todosPlanContentRows === 0) return none;
+  const rows = Math.min(
     maxRows,
-    sessionPanelContentRows + todosPanelContentRows,
-    panelTranscriptLimit,
+    todosPlanContentRows + 1,
+    Math.floor(availableTranscriptRows / 2),
   );
-  const allocated = allocateSidePanelRows({
-    subagentContentRows: sessionPanelContentRows,
-    todosPlanContentRows: todosPanelContentRows,
-    rows: bottomPanelRows,
-  });
-  const sessionPanelRows =
-    allocated.subagentRows > 0 &&
-    bottomPanelRows >= minimumSessionRows &&
-    (childListRowCount > 0 || childListFocused) &&
-    sessionPanelContentRows > 0
-      ? Math.max(minimumSessionRows, allocated.subagentRows)
-      : 0;
-  let finalBottomPanelRows = bottomPanelRows;
-  let finalSessionPanelRows = sessionPanelRows;
-  let todosPlanRows = bottomPanelRows - sessionPanelRows;
-  // A lone row cannot hold the separator plus content; hand it back instead
-  // of rendering a dead blank line under the child list. When the child list
-  // has rows above its own minimum, transfer one first so both panels remain
-  // useful under a proportional split.
-  if (todosPanelContentRows > 0 && todosPlanRows === 1) {
-    if (sessionPanelRows > minimumSessionRows) {
-      finalSessionPanelRows -= 1;
-      todosPlanRows = 2;
-    } else {
-      finalBottomPanelRows -= 1;
-      todosPlanRows = 0;
-    }
-  }
-  return {
-    bottomPanelRows: finalBottomPanelRows,
-    sessionPanelRows: finalSessionPanelRows,
-    todosPlanRows,
-  };
+  if (rows < 2) return none;
+  return { bottomPanelRows: rows, sessionPanelRows: 0, todosPlanRows: rows };
 }
 
 export function allocateConversationPanelRows({
@@ -329,15 +239,18 @@ export function staticScrollbackTarget({
 }
 
 export function shouldShowTodosPlanPanel({
+  childListFocused,
   foregroundOpen,
   hasPlan,
   todos,
 }: {
+  /** The focused child list is the only bottom panel; todos yield to it. */
+  readonly childListFocused: boolean;
   readonly foregroundOpen: boolean;
   readonly hasPlan: boolean;
   readonly todos: readonly TodoItem[];
 }): boolean {
-  if (foregroundOpen) return false;
+  if (foregroundOpen || childListFocused) return false;
   if (hasPlan) return true;
   return todos.some((todo) => todo.status !== TODO_STATUS.COMPLETED);
 }

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -175,6 +175,7 @@ export function ConversationRegion({
         rows,
       });
   const hasTodosPlanPanel = shouldShowTodosPlanPanel({
+    childListFocused: snapshot.childListFocused,
     foregroundOpen,
     hasPlan: activePlan != null,
     todos: activeTodos,
@@ -191,10 +192,9 @@ export function ConversationRegion({
     slashPaletteOpen: snapshot.slashPaletteOpen,
     staticTranscriptRows: staticTranscriptRows ?? 0,
   });
-  // The subagent/todos panels live at the bottom of the same vertical column.
-  // Reserve only as many rows as the panels actually need. Child sessions stay
-  // behind the status-bar navigation affordance until the list has focus, so a
-  // background workflow cannot expand over the conversation by default.
+  // One bottom panel at a time in the same vertical column: the child list
+  // while it has focus, otherwise the todos/plan panel. Reserve only as many
+  // rows as that panel actually needs.
   const todosPlanContentRows =
     hasTodosPlanPanel && activeSlice
       ? todosPlanPanelRowCount(activeTodos, activePlan)

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -31,7 +31,6 @@ import {
   allocateConversationBottomPanelRows,
   allocateConversationPanelRows,
   allocateMiddleRows,
-  allocateSidePanelRows,
   shouldShowTodosPlanPanel,
   staticTranscriptRowBudget,
 } from '@cli/chat/tui/appLayout';
@@ -938,54 +937,6 @@ describe('CLI TUI row allocation', () => {
     expect(layout.foregroundRows).toBe(foregroundRows);
   });
 
-  it('sizes side panels to their content within the budget', () => {
-    // Everything fits: each panel takes exactly its content (no dead rows).
-    expect(
-      allocateSidePanelRows({
-        subagentContentRows: 3,
-        todosPlanContentRows: 4,
-        rows: 13,
-      }),
-    ).toEqual({ subagentRows: 3, todosPlanRows: 4 });
-
-    // A lone panel takes only what it needs; the rest is the conversation's.
-    expect(
-      allocateSidePanelRows({
-        subagentContentRows: 0,
-        todosPlanContentRows: 4,
-        rows: 13,
-      }),
-    ).toEqual({ subagentRows: 0, todosPlanRows: 4 });
-
-    // Over budget, a lone panel is capped at the available rows.
-    expect(
-      allocateSidePanelRows({
-        subagentContentRows: 0,
-        todosPlanContentRows: 20,
-        rows: 13,
-      }),
-    ).toEqual({ subagentRows: 0, todosPlanRows: 13 });
-
-    // Over budget with both present: keep at least one row each, split the
-    // remainder proportionally to need.
-    expect(
-      allocateSidePanelRows({
-        subagentContentRows: 10,
-        todosPlanContentRows: 10,
-        rows: 13,
-      }),
-    ).toEqual({ subagentRows: 7, todosPlanRows: 6 });
-
-    // A single row with both present goes to the todos/plan panel.
-    expect(
-      allocateSidePanelRows({
-        subagentContentRows: 5,
-        todosPlanContentRows: 5,
-        rows: 1,
-      }),
-    ).toEqual({ subagentRows: 0, todosPlanRows: 1 });
-  });
-
   it.each([
     {
       transcriptRows: 1,
@@ -1014,13 +965,15 @@ describe('CLI TUI row allocation', () => {
         todosPlanRows: 0,
       },
     },
+    // The focused list takes its full content (4 sessions + separator) and
+    // never shares the panel with todos, which hide while it has focus.
     {
       transcriptRows: 8,
       expected: {
-        bottomPanelRows: 7,
-        conversationRows: 1,
-        sessionPanelRows: 4,
-        todosPlanRows: 3,
+        bottomPanelRows: 5,
+        conversationRows: 3,
+        sessionPanelRows: 5,
+        todosPlanRows: 0,
       },
     },
   ])(
@@ -1125,24 +1078,6 @@ describe('CLI TUI row allocation', () => {
     ).toMatchObject({ bottomPanelRows: 3, todosPlanRows: 3 });
   });
 
-  it('borrows a focused child-list row so an active todo stays visible', () => {
-    // Many children plus one todo under the 10-row cap: the proportional
-    // split grants todos a single row, too small for separator plus content,
-    // so one row shifts from the ample child list instead.
-    const allocation = allocateConversationBottomPanelRows({
-      maxRows: 10,
-      sessionCount: 11,
-      childListFocused: true,
-      todosPlanContentRows: 1,
-      transcriptRows: 30,
-    });
-    expect(allocation.todosPlanRows).toBe(2);
-    expect(allocation.sessionPanelRows).toBeGreaterThanOrEqual(2);
-    expect(allocation.bottomPanelRows).toBe(
-      allocation.sessionPanelRows + allocation.todosPlanRows,
-    );
-  });
-
   it('hands a lone todos row back instead of rendering a dead separator', () => {
     // The grant would be exactly one row — too small for separator + content.
     const allocation = allocateConversationBottomPanelRows({
@@ -1156,22 +1091,6 @@ describe('CLI TUI row allocation', () => {
       bottomPanelRows: 0,
       sessionPanelRows: 0,
       todosPlanRows: 0,
-    });
-  });
-
-  it('preserves todo content when the focused child list can yield one row', () => {
-    expect(
-      allocateConversationBottomPanelRows({
-        maxRows: 10,
-        sessionCount: 11,
-        childListFocused: true,
-        todosPlanContentRows: 1,
-        transcriptRows: 20,
-      }),
-    ).toEqual({
-      bottomPanelRows: 10,
-      sessionPanelRows: 8,
-      todosPlanRows: 2,
     });
   });
 
@@ -1239,12 +1158,31 @@ describe('CLI TUI row allocation', () => {
       ],
       expected: true,
     },
+    {
+      name: 'the child list focused',
+      childListFocused: true,
+      foregroundOpen: false,
+      hasPlan: true,
+      todos: [openTodo],
+      expected: false,
+    },
   ])(
     'keeps unfinished todo and plan chrome across stream phases: $name',
-    ({ foregroundOpen, hasPlan, todos, expected }) => {
-      expect(shouldShowTodosPlanPanel({ foregroundOpen, hasPlan, todos })).toBe(
-        expected,
-      );
+    ({
+      childListFocused = false,
+      foregroundOpen,
+      hasPlan,
+      todos,
+      expected,
+    }) => {
+      expect(
+        shouldShowTodosPlanPanel({
+          childListFocused,
+          foregroundOpen,
+          hasPlan,
+          todos,
+        }),
+      ).toBe(expected);
     },
   );
 


### PR DESCRIPTION
## Problem

Tabbing into the subagent/session list showed the todo/plan checklist under it, splitting the bottom panel proportionally between the two, so most of the list was hidden behind `… 7 todo/plan items hidden`. The list is what the user tabbed to; the todos belong to the conversation view.

## Change

Exactly one bottom panel at a time: the child list while it has focus (it already stays collapsed behind the status-bar count otherwise), the todos/plan panel when it does not.

- `shouldShowTodosPlanPanel` takes `childListFocused` and returns false while the list has focus; `ConversationRegion` passes it.
- `allocateConversationBottomPanelRows` follows the rule directly — focused: the list takes its content up to the transcript budget; unfocused: the todos panel takes at most half — which makes the proportional side-panel split (`allocateSidePanelRows`) and the lone-row transfer branch unreachable, so they are deleted with their tests (net −149 lines).

## Verified

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run check:dead-code-ratchet` — no new findings
- `vitest run src/test-kernel/cli` — 2534 passed; `TranscriptSessionPolicy` times out (10 s budget) on this box right now on the untouched `main` checkout too (load avg 36–80 while a 15-agent run is active) — environmental, unrelated to layout
- prettier — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pZUVQRHJvb8tVCu8nU7TC
