### PR TITLE
refactor(workflow): journal identity is the content key, not the call index

### DIFF
--- a/docs/proposals/2026-07-05-workflow-script-engine.md
+++ b/docs/proposals/2026-07-05-workflow-script-engine.md
@@ -223,8 +223,9 @@ copy, no LLM involvement. Rounds that emitted nothing leave symlinks
 
 ### 6. Resume via call journal
 
-Every completed `agent()` call is journaled by its call index and a hash of
-the prompt plus execution-affecting options. Display labels and phases are
+Every completed `agent()` call is journaled by a hash of the prompt plus
+execution-affecting options (its position is recorded, not part of its
+identity — changed 2026-08-28). Display labels and phases are
 excluded, so revising a declarative task plan does not repeat completed model
 work. Re-running with a prior journal replays matching calls from cache and
 re-runs only edited or new calls; failed and cancelled calls are not journaled,

--- a/src/agent/workflowScript/README.md
+++ b/src/agent/workflowScript/README.md
@@ -132,8 +132,13 @@ return await parallel(
   stays readable, but readers predating the committed phase reject newer
   markers outright, downgrade or mixed-version recovery is unsupported, and
   unknown present values fail closed rather than being defaulted or coerced.
-  Checkpoints use the strict version-3 schema; malformed or
+  Checkpoints use the strict version-4 schema; malformed or
   older records fail instead of being translated into the current journal.
+  Deliberately NOT an append-only started/result journal (the shape Claude
+  Code's Workflow tool uses): such a log cannot distinguish "never
+  finished" from a `null` result, and beside the checkpoint, the commit
+  fence, and the child attempt ledger it would be a second owner of the
+  same fact. Ruled 2026-08-28 (docs/proposals/2026-08-28-workflow-plan-vs-issued-calls.md §Study).
 - **Cost ownership**: child costs remain in the persisted typed results. The
   future tool surface must aggregate the final journal at its tool-result
   boundary, rather than mutating parent totals during child launch; this keeps
@@ -163,13 +168,21 @@ return await parallel(
 - **Determinism**: `Date.now()`, `Math.random()`, and argless `new Date()`
   throw inside scripts, installed non-writable so scripts cannot restore
   them (`new Date(timestamp)` stays usable). Resume relies on replaying the
-  same call sequence: each `agent()` call is journaled by (call index,
-  prompt/execution-options hash), and a rerun with a prior journal replays
-  matching calls from cache, re-running only edited or new calls. File-backed
+  same calls: each `agent()` call is journaled by its prompt/execution-options
+  hash — its position is recorded, not part of its identity — and a rerun
+  with a prior journal replays matching calls from cache wherever they now
+  sit, re-running only edited or new calls (per call, never the
+  longest-unchanged-prefix rule Claude Code's Workflow tool applies, which
+  re-runs every call after the first change). File-backed
   calls also hash the current bytes of their input, context, and media files,
   so editing a referenced path invalidates both its cached result and stable
   child identity. Display labels and phases do not participate in identity.
-  Failed and cancelled calls are not journaled, so resume retries them.
+  Failed and cancelled calls are not journaled, so resume retries them; so
+  are a user's skip and a per-call admission denial — the journal records
+  outcomes of the script's calls, a human verdict belongs to the attempt
+  that asked for it, and a resume is a new attempt. The checkpoint identity
+  is `meta.name` plus the default agent: resuming under a different agent
+  starts a new journal.
   Otherwise-identical calls must provide distinct `id` options; ambiguous
   duplicates fail before launch.
 - **Budgets**: one concurrency semaphore (default 4) across all `agent()`

--- a/src/agent/workflowScript/persistence.ts
+++ b/src/agent/workflowScript/persistence.ts
@@ -21,7 +21,9 @@ import {
   type WorkflowScriptRunResult,
 } from './types';
 
-const WORKFLOW_SCRIPT_CHECKPOINT_SCHEMA_VERSION = 3;
+// v4: journal identity is the content key; v3 records could hold one key at
+// two indices after script drift and fail loudly rather than being translated.
+const WORKFLOW_SCRIPT_CHECKPOINT_SCHEMA_VERSION = 4;
 
 const PersistedJsonValueSchema = z.discriminatedUnion('kind', [
   z.strictObject({ kind: z.literal('undefined') }),
@@ -43,16 +45,16 @@ const WorkflowScriptCheckpointSchema = z
     journal: z.array(PersistedWorkflowJournalEntrySchema),
   })
   .superRefine(({ journal }, context) => {
-    const indices = new Set<number>();
+    const keys = new Set<string>();
     for (const entry of journal) {
-      if (indices.has(entry.index)) {
+      if (keys.has(entry.key)) {
         context.addIssue({
           code: 'custom',
-          message: `Duplicate workflow journal index ${entry.index}`,
+          message: `Duplicate workflow journal key ${entry.key}`,
           path: ['journal'],
         });
       }
-      indices.add(entry.index);
+      keys.add(entry.key);
     }
   });
 
@@ -220,9 +222,12 @@ async function runPersistedWorkflowScriptLocked(
   // A named checkpoint outlives one tool call, and callers legitimately
   // evolve the script between attempts (a model retrying after a timeout
   // rarely reproduces its source byte-for-byte). Adopt the requested script
-  // and args, keep the journal: an entry replays only on a matching call
-  // index and prompt/execution-options hash, so drifted calls re-execute
-  // while presentation-only edits and unchanged calls stay free.
+  // and args, keep the journal: an entry replays only on a matching
+  // prompt/execution-options hash, so drifted calls re-execute while
+  // presentation-only edits, unchanged calls, and calls that merely moved
+  // stay free. The union is monotone by key — a re-visited key overwrites
+  // its entry (and its position); entries this run never reached remain, so
+  // an args-driven branch taken again later still replays.
   const script = requestedScript ?? prior?.script;
   if (script === undefined) {
     throw new WorkflowScriptPersistenceError(
@@ -249,22 +254,22 @@ async function runPersistedWorkflowScriptLocked(
       ? WorkflowScriptFilesSchema.parse(requestedFiles ?? {})
       : prior.files;
 
-  const journalByIndex = new Map(
-    (prior?.journal ?? []).map((entry) => [entry.index, entry]),
+  const journalByKey = new Map(
+    (prior?.journal ?? []).map((entry) => [entry.key, entry]),
   );
   const persistCheckpoint = (): Promise<void> =>
     writeWorkflowScriptCheckpoint(store, checkpointId, {
       script,
       args,
       files,
-      journal: orderedJournal(journalByIndex.values()),
+      journal: orderedJournal(journalByKey.values()),
     });
 
   let acceptingEntries = true;
   const writeQueue = new PQueue({ concurrency: 1 });
   const persistEntry = async (entry: WorkflowJournalEntry): Promise<void> => {
     if (!acceptingEntries) return;
-    journalByIndex.set(entry.index, entry);
+    journalByKey.set(entry.key, entry);
     await writeQueue.add(persistCheckpoint);
   };
 
@@ -284,7 +289,7 @@ async function runPersistedWorkflowScriptLocked(
       onJournalEntry: persistEntry,
     });
     acceptingEntries = false;
-    for (const entry of result.journal) journalByIndex.set(entry.index, entry);
+    for (const entry of result.journal) journalByKey.set(entry.key, entry);
     await writeQueue.onIdle();
     await persistCheckpoint();
     return result;

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -37,9 +37,10 @@ import {
 /**
  * Stable execution identity for one agent() call. Current keys exclude
  * display-only labels and phases, so editing a declarative task plan does not
- * invalidate otherwise identical completed work. A prior entry at the same
- * call index with a matching key replays its cached result. sha256 (truncated)
- * makes a collision that replays the wrong result impractical.
+ * invalidate otherwise identical completed work. A prior entry with a
+ * matching key replays its cached result wherever the call now sits in the
+ * script. sha256 (truncated) makes a collision that replays the wrong result
+ * impractical.
  */
 function journalKey(
   prompt: string,
@@ -309,7 +310,7 @@ function raceWithAbort<T>(
  * agents. The script's control flow (loops, fan-out, joins, reduction) runs
  * as plain code with zero model round-trips between steps; every agent()
  * call is bounded by one shared p-queue concurrency limit and journaled for
- * resume (same call index + same prompt/execution options → cached result).
+ * resume (same prompt/execution options → cached result, at any position).
  *
  * On wall-clock timeout the sandbox preempts guest execution, fires the run's
  * AbortSignal (passed to every runAgent invocation), and refuses new calls.
@@ -331,8 +332,13 @@ export async function runWorkflowScript(
 
   const { meta, body } = parseWorkflowScript(options.script);
   const timeoutMs = options.timeoutMs ?? meta.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const priorEntries = new Map<number, WorkflowJournalEntry>(
-    (options.journal ?? []).map((entry) => [entry.index, entry]),
+  // Journal identity is the content key alone: keys are unique within a run
+  // (a duplicate is a contract fault below) and the durable child id is
+  // already index-free, so a call that moved because the script inserted,
+  // removed, or reordered a sibling still replays. `index` stays on every
+  // entry as an ordering fact for the resume journal and cost attribution.
+  const priorEntries = new Map<string, WorkflowJournalEntry>(
+    (options.journal ?? []).map((entry) => [entry.key, entry]),
   );
   const journal = new Map<number, WorkflowJournalEntry>();
   const queue = new PQueue({ concurrency });
@@ -667,8 +673,8 @@ export async function runWorkflowScript(
 
     // `key` still holds journalKey(prompt, callOptions, dependencyFingerprint)
     // here: refreshDependencyIdentity only runs at launch time, below.
-    const prior = priorEntries.get(index);
-    if (prior && prior.key === key) {
+    const prior = priorEntries.get(key);
+    if (prior) {
       const { payload, normalizedResult } = journalValue(
         prior.result,
         'Cached agent() result',

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -246,7 +246,7 @@ export type WorkflowAgentCallOptions = z.infer<
 >;
 
 export interface WorkflowAgentInvocation {
-  /** 0-based call sequence number; also the journal key position. */
+  /** 0-based call sequence number: ordering only, never identity. */
   index: number;
   /** Stable logical call identity within the workflow execution snapshot. */
   progressId: WorkflowScriptProgressId;
@@ -327,7 +327,12 @@ export type WorkflowAgentRunner = (
   invocation: WorkflowAgentInvocation,
 ) => Promise<unknown>;
 
-/** One completed agent() call, cached for resume. */
+/**
+ * One completed agent() call, cached for resume. Identity is `key` alone;
+ * `index` records where the call sat in the run that journaled it, for
+ * ordering and cost attribution, and is rewritten when a resumed run replays
+ * the entry at a new position.
+ */
 export interface WorkflowJournalEntry {
   index: number;
   /** Stable call hash including host-resolved dependency fingerprints. */

--- a/src/test-kernel/agent/WorkflowScriptCost.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptCost.vitest.ts
@@ -164,27 +164,6 @@ return await agent('retry cost')`,
     expect(tracker.total([cheapJournal])).toBeCloseTo(0.5);
   });
 
-  it('separates sequential duplicate keys when only the first call is live', () => {
-    const live = entry(0, workflowResult(0.4), 'duplicate');
-    const recovered = entry(1, workflowResult(0.7), 'duplicate');
-    const tracker = createWorkflowAttemptCostTracker();
-
-    tracker.record(live, 0.4);
-    expect(tracker.total([live, recovered])).toBe(0.4);
-  });
-
-  it('separates parallel duplicate keys when only one call retries', () => {
-    const retried = entry(0, workflowResult(0.5), 'duplicate');
-    const singleAttempt = entry(1, workflowResult(0.4), 'duplicate');
-    const tracker = createWorkflowAttemptCostTracker();
-
-    // Interleaved callback order models parallel calls. Only index 0 retries.
-    tracker.record(retried, 0.1);
-    tracker.record(singleAttempt, 0.4);
-    tracker.record(retried, 0);
-    expect(tracker.total([retried, singleAttempt])).toBeCloseTo(1);
-  });
-
   it('settles zero for empty-baseline stable recovery with no callback', () => {
     const recovered = entry(0, workflowResult(0.5), 'recovered');
     const tracker = createWorkflowAttemptCostTracker();

--- a/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
@@ -892,9 +892,9 @@ return 'guest success'`,
       runAgent: retryRunner,
     });
 
-    // 'first' is unchanged (same index + prompt hash) so it replays free;
-    // only the drifted second call executes live, and the evolved script
-    // becomes the stored one.
+    // 'first' is unchanged (same prompt hash) so it replays free; only the
+    // drifted second call executes live, and the evolved script becomes the
+    // stored one.
     expect(retryRunner).toHaveBeenCalledTimes(1);
     expect(evolved.result).toEqual(['v1:first', 'v2:changed']);
     await expect(
@@ -905,6 +905,41 @@ return 'guest success'`,
     ).resolves.toMatchObject({
       script: expect.stringContaining(`agent('changed')`),
     });
+  });
+
+  it('replays a call that moved because a sibling was inserted before it', async () => {
+    const store = getExecutionStore(executionId);
+    await runPersistedWorkflowScript({
+      store,
+      checkpointId: 'moved-call',
+      script,
+      runAgent: async ({ prompt }) => `v1:${prompt}`,
+    });
+
+    clearStoreCache();
+    const retryRunner = vi.fn(
+      async ({ prompt }: { prompt: string }) => `v2:${prompt}`,
+    );
+    const evolved = await runPersistedWorkflowScript({
+      store: getExecutionStore(executionId),
+      checkpointId: 'moved-call',
+      script: script.replace(
+        `const second = await agent('second')`,
+        `await agent('inserted')\nconst second = await agent('second')`,
+      ),
+      runAgent: retryRunner,
+    });
+
+    // Identity is the content key, not the position: 'second' now runs third
+    // and still replays; only the inserted call executes.
+    expect(retryRunner).toHaveBeenCalledTimes(1);
+    expect(evolved.result).toEqual(['v1:first', 'v1:second']);
+    expect(retryRunner.mock.calls[0]?.[0]?.prompt).toBe('inserted');
+    const checkpoint = await readWorkflowScriptCheckpoint(
+      getExecutionStore(executionId),
+      'moved-call',
+    );
+    expect(checkpoint?.journal.map((entry) => entry.index)).toEqual([0, 1, 2]);
   });
 
   it('round-trips an undefined agent result explicitly', async () => {

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -76,7 +76,9 @@ const WorkflowScriptToolInputSchema = z
     agent: z
       .string()
       .min(1)
-      .describe('Default workflow agent used when agent() omits agentName.'),
+      .describe(
+        'Default workflow agent used when agent() omits agentName. Part of the checkpoint identity with meta.name: resume with the same value; a different agent starts a new journal.',
+      ),
     args: z
       .unknown()
       .nullish()
@@ -245,7 +247,7 @@ return await agent('Merge the corrected drafts.', {
   inputFiles: correctedFiles,
 })
 
-Durability: the journal is keyed by meta.name within this session. If the run times out or is interrupted, call this tool again with the SAME meta.name: completed agent() calls replay for free (the script may be revised; only changed or unfinished calls execute). Use a new meta.name to start over. The default whole-run wall clock is 10 minutes; set meta.timeoutMs (1s to 60min) for longer runs.`,
+Durability: the journal is keyed by meta.name and the agent field within this session. If the run times out or is interrupted, call this tool again with the SAME meta.name and the same agent: completed agent() calls replay for free (the script may be revised or reordered; only changed or unfinished calls execute). A different agent starts a new journal. Use a new meta.name to start over. The default whole-run wall clock is 10 minutes; set meta.timeoutMs (1s to 60min) for longer runs.`,
   schema: WorkflowScriptToolInputSchema,
 }) {
   protected async execute(input: WorkflowScriptToolInput): Promise<ToolResult> {
@@ -480,7 +482,7 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
         return withScriptReference(
           executed(
             [
-              `A workflow script run for meta.name '${meta.name}' is already in progress (or finishing); its result arrives as a follow-up. Do not launch a competing run: wait for it, then resume with the same meta.name if it did not complete.`,
+              `A workflow script run for meta.name '${meta.name}' is already in progress (or finishing); its result arrives as a follow-up. Do not launch a competing run: wait for it, then resume with the same meta.name and agent if it did not complete.`,
               `Execution ID: ${runExecutionId}`,
               `To check progress or collect the result: executions tool with path=/executions/${runExecutionId} and action=wait (returns immediately if it already finished).`,
             ].join('\n'),
@@ -622,9 +624,10 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
           [
             `Workflow script '${meta.name}' launched. Its result and run log will be delivered automatically as a follow-up message when the run completes.`,
             `Execution ID: ${runExecutionId}`,
+            `Agent: ${defaultAgent.name} (part of the checkpoint identity with meta.name)`,
             `Stream tab: ${runChildStreamId}`,
             `The result arrives automatically. Continue other work meanwhile. To check progress: executions tool with path=/executions/${runExecutionId}; use action=wait only when you cannot proceed without it.`,
-            `To resume after a timeout or interruption: call this tool again with the same meta.name.`,
+            `To resume after a timeout or interruption: call this tool again with the same meta.name and agent.`,
           ].join('\n'),
           `Launched workflow script '${meta.name}' (async)`,
         ),

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -131,8 +131,13 @@ function workflowJournalEntryCost(entry: WorkflowJournalEntry): number {
 
 type WorkflowAttemptIdentity = Pick<WorkflowAgentInvocation, 'index' | 'key'>;
 
+/**
+ * Keys are unique per run (the engine faults duplicates), so the key alone
+ * identifies an attempt; a replayed entry re-journaled at a new index still
+ * matches the attempt that produced it.
+ */
 function workflowAttemptIdentity(invocation: WorkflowAttemptIdentity): string {
-  return `${invocation.index}:${invocation.key}`;
+  return invocation.key;
 }
 
 interface WorkflowAttemptCostTracker {

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -358,7 +358,7 @@ export function createWorkflowScriptStrategy(
           executionId: params.executionId,
         },
         {
-          message: `${errorCause}${runLog.format()}\n\n${formatWorkflowScriptReference(params.scriptPath)}\n\nCompleted agent() calls are journaled under meta.name '${params.name}'; rerunning that file resumes without repeating them.`,
+          message: `${errorCause}${runLog.format()}\n\n${formatWorkflowScriptReference(params.scriptPath)}\n\nCompleted agent() calls are journaled under meta.name '${params.name}' for this agent; rerunning that file with the same agent resumes without repeating them (failed, cancelled, and skipped calls run again).`,
           lines: [formatSummaryLine('failed', errorCause)],
         },
       );


### PR DESCRIPTION
> **Stacked on #11511 → #11498** (sibling of #11513, no file overlap). Base is `feat/workflow-call-admission`; retarget as the stack merges — do not merge into the base branch.

## Why

The resume half of the ultracode study (record: proposal doc §Study). A journal entry replayed only when the *same index* held the *same key*, so an inserted, removed, or reordered sibling turned every later identical call into a journal miss. The child attempt ledger — whose id is already derived from `{checkpointId, key, parentExecutionId}` with no index — rescued it, at the cost of a ledger round trip, a live-call cap charge, and a misleading `recovered` status. Keys are unique within a run (a duplicate `key` is a contract fault before launch), so the index contributed nothing but false misses. Two adversarial verifiers confirmed this at HEAD; their amendments are applied (no prune-on-success; `index` kept on entries because cost attribution and ordering read it).

## Change

- `runWorkflowScript`: prior entries keyed by `key`; replay on key match at any position. `index` stays on every entry as an ordering fact.
- `persistence`: schema **v3 → v4**, uniqueness on `key`; v3 records fail loudly (a v3 record can legitimately hold one key at two indices after drift — the README already promises no translation). The union stays monotone by key.
- Cost attempt identity keys on `key` alone; the two cost tests that pinned a same-key-at-two-indices state the engine forbids are removed.
- Tool copy says what the checkpoint identity really is: `meta.name` **and the `agent` field** (description, `agent` input `.describe()`, launch result with an `Agent:` fact line, lease-active message, strategy failure hint).
- README records the study rulings: keep per-call replay (not ultracode's longest-unchanged-prefix rule); do not adopt an append-only started/result journal; skips and admission denials stay per attempt.

## Tests

One regression test at the durable boundary: a call that moved because a sibling was inserted before it still replays; only the inserted call runs; journal indices are rewritten `[0, 1, 2]`.

## Verified

- `npm run typecheck` — clean · `npm run lint` — clean · `npm run check:dead-code-ratchet` — no new findings · prettier — clean
- vitest over agent/tools suites — 1 035 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pZUVQRHJvb8tVCu8nU7TC
