### PR TITLE
dedupe: reconcile the desktop/docs icon-alias tables

### DIFF
--- a/docs/.vitepress/theme/webAwesomeIcons.js
+++ b/docs/.vitepress/theme/webAwesomeIcons.js
@@ -1,9 +1,15 @@
 // Web Awesome icon registration for the VitePress site.
 //
-// Mirrors the codicon -> Font Awesome alias map used by the rest of the TeXRA
-// repo (see src/shared/wa/webAwesomeIcons.ts) so markdown that says
-//   <wa-icon library="texra" name="sparkle"></wa-icon>
-// resolves to the closest Font Awesome glyph.
+// Independent from packages/desktop/src/renderer/desktopIconLibrary.ts by
+// necessity, not by drift: that module resolves TeXRAIconName to Lucide
+// stroke glyphs for the Electron renderer, while this one resolves a wider
+// codicon-style alias vocabulary (kept for markdown ergonomics, e.g.
+// <wa-icon library="texra" name="sparkle"></wa-icon>) to Font Awesome glyphs
+// for the statically-built VitePress site, which cannot import from
+// packages/desktop or bundle Lucide's icon-nodes.json. Keep the two tables'
+// canonical-name overlap in sync by hand — see
+// docs/proposals/2026-08-25-simplification-survey-49-candidates.md and
+// issue #11424 for the last reconciliation pass.
 //
 // Imported from ./index.js for its side effects (calls registerIconLibrary
 // once per page load).
@@ -256,7 +262,9 @@ const icons = {
 
 // Codicon-name aliases. Lets markdown keep using familiar codicon names
 // (e.g. <wa-icon name="warning">) while resolving to the closest Font Awesome
-// glyph in the registry above. Mirrors src/shared/wa/webAwesomeIcons.ts.
+// glyph in the registry above. Docs-site-only: there is no repo-wide
+// codicon-alias table left to mirror (src/shared/wa/webAwesomeIcons.ts
+// resolves TeXRAIconName directly, not codicon names).
 const CODICON_ALIASES = {
   account: 'circle-user',
   add: 'plus',
@@ -265,7 +273,6 @@ const CODICON_ALIASES = {
   beaker: 'flask',
   'check-all': 'check-double',
   checklist: 'list-check',
-  'circle-large-outline': 'circle',
   'circle-outline': 'circle',
   'circle-slash': 'circle-xmark',
   'clear-all': 'eraser',

--- a/packages/desktop/src/renderer/desktopIconLibrary.ts
+++ b/packages/desktop/src/renderer/desktopIconLibrary.ts
@@ -6,6 +6,14 @@
 //
 // Names are the existing `TeXRAIconName` values, so no call site changes: every
 // `waIcon('file-code')` in the shared components silently upgrades.
+//
+// Independent from docs/.vitepress/theme/webAwesomeIcons.js by necessity, not
+// by drift: that module resolves a wider codicon-style alias vocabulary to
+// Font Awesome glyphs for the statically-built VitePress site, which cannot
+// import this Electron-only module or its Lucide geometry. Keep the two
+// tables' canonical-name overlap in sync by hand — see
+// docs/proposals/2026-08-25-simplification-survey-49-candidates.md and issue
+// #11424 for the last reconciliation pass.
 
 import {
   registerIconLibrary,


### PR DESCRIPTION
## Summary

Scheduled consolidation sweep (find hand-rolled/duplicate logic worth
collapsing). Surveying the codebase found it already very heavily audited by
recent simplification rounds (`docs/proposals/2026-08-25` through
`2026-08-28`), so rather than re-file already-ruled-on candidates, I checked
the repo's open `tech-debt` issues for one matching this theme that was
still genuinely unresolved. #11446 (delete the duplicate
`DesktopHostInteractions.vitest.ts` suite) turned out to already be done by
#11468 — worth closing, not re-doing. #11424 ("Consolidate the duplicate
desktop/docs Lucide icon tables") was still live, so this PR resolves it.

`packages/desktop/src/renderer/desktopIconLibrary.ts` (TeXRAIconName ->
Lucide glyph, for the Electron renderer) and
`docs/.vitepress/theme/webAwesomeIcons.js` (codicon-style aliases -> Font
Awesome glyph, for the statically-built VitePress site) are independent by
necessity — different icon families, and the docs build cannot import
Electron-only code or bundle Lucide's `icon-nodes.json`. #11418 already
trimmed three non-canonical, zero-consumer entries
(`circle-large-outline`, `symbol-keyword`, `symbol-structure`) from the
desktop table. The docs table still carried all three; checking each
against actual markdown/Vue usage found `symbol-keyword` and
`symbol-structure` are live in several guide pages and components (e.g.
`docs/guide/latex-tools.md`, `docs/.vitepress/components/TikzDepsHero.vue`)
— they stay. Only `circle-large-outline` has zero consumers anywhere in
`docs/`, matching the desktop table's finding; it's deleted here.

Both files' header comments also claimed a "mirrors ... see
`src/shared/wa/webAwesomeIcons.ts`" relationship that no longer holds — that
file has no codicon-alias table today. Rewrote both comments to state why
two independent tables exist and where to look (this issue, and the
2026-08-25 survey doc) when reconciling them again, per the issue's
fallback option: a shared source of truth isn't practical across the
VitePress/Electron build boundary, so the tables are reconciled by content
and cross-referenced by comment instead of merged.

## Issue acceptance gates

Closes #11424.
- "reconcile the two tables' contents so they don't silently diverge" —
  done: the one truly-dead entry (`circle-large-outline`) is removed from
  the docs table; the two entries that looked dead by the same pattern but
  are actually live (`symbol-keyword`, `symbol-structure`) are kept, with
  evidence.
- "leave a comment on each explaining why a second table exists" — done on
  both files.

## Single source of truth

`src/shared/wa/iconNames.ts`'s `TEXRA_ICON_CANONICAL_NAMES` remains the
canonical name vocabulary; this PR does not change that. The two
per-renderer alias tables stay hand-maintained by design (documented now),
since a shared owner isn't reachable across the VitePress/Electron build
boundary.

## Duplication and abstraction budget

Removed one dead alias row. No new abstraction added — the fix is
reconciling content and adding explanatory comments, not merging the
tables (the issue's own text flags that merge as impractical given the
VitePress build's isolation from `packages/desktop`).

## Net elements (R6)

2 files changed, 0 exported symbols changed (`^[+-]export` count: 0), 0
classes/interfaces/enums, +21/-6 LoC (net +15, entirely comments; one data
row removed).

## Consumer counts (R8)

`circle-large-outline`: grepped across `docs/` (all file types) — 0
consumers besides its own definition. `symbol-keyword` / `symbol-structure`
(checked because they looked like the same pattern): grepped across `docs/`
— each has 2+ live consumers in guide pages and `.vue` components, so both
are kept.

## Host impact

Extension: none.

Desktop: comment-only change to `desktopIconLibrary.ts`; icon resolution
behavior unchanged (verified by `DesktopIconLibrary.vitest.ts`, 5/5
passing).

CLI: none.

## Scheduled refactoring

None. Also worth doing, tracked separately: closing #11446 as already
resolved by #11468 (the desktop `DesktopHostInteractions.vitest.ts` suite
it asks to port-and-delete was already ported into
`ExtensionHostInteractions.vitest.ts` and deleted in that PR).

## Validation

- `npx prettier --check` on both edited files: clean.
- `npx eslint` on both edited files: clean.
- `npx vitest run src/test-kernel/desktop/DesktopIconLibrary.vitest.ts`: 5/5
  passing.
- `npm run check:guidance-refs`: clean.
- `git diff --check`: clean.
- Full `npm run typecheck` / `npm test` not run (comment-only diff plus one
  dead literal-object-key deletion; no type or runtime surface changed).

---
_Generated by [Claude Code](https://claude.ai/code/session_019aKHw53nTGAudy6YZpmg7p)_