### PR TITLE
refactor(schemas): delete the legacy workflow-snapshot reader

### DIFF
--- a/docs/proposals/2026-08-28-simplification-survey-multi-agent-dispatch.md
+++ b/docs/proposals/2026-08-28-simplification-survey-multi-agent-dispatch.md
@@ -45,8 +45,11 @@ design, the QuickJS bridge shape, per-call replay.
 - **The multi-agent proposal card's row budget was one row short** (the
   workflow branch of `agentProposalMetadataRows` omitted the outer margin
   row), overflowing by one row in feedback mode.
-- **A persisted `status: 'starting'` snapshot would fail resume loudly** once
-  the status is removed; the existing preprocess strip maps it to `running`.
+- **A persisted `status: 'starting'` snapshot fails resume loudly** once
+  the status is removed. The compatibility preprocess that briefly mapped it
+  (and stripped `stageTitle`/`blockedReason`/`queuedAt`) was deleted the same
+  day — intermediate-era data is disposable, not age-gated; an interrupted
+  run's `meta.json` from an older build is rejected loudly on resume.
 - Three silent catches in the delegation layer made loud (§15 M2/M4).
 
 ## Landed simplifications (measured)

--- a/src/shared/schemas/workflowExecutionSnapshot.ts
+++ b/src/shared/schemas/workflowExecutionSnapshot.ts
@@ -84,7 +84,7 @@ export const WorkflowCallFilesSchema = z.strictObject({
   media: z.array(z.string()),
 });
 
-const WorkflowExecutionCallShape = z.strictObject({
+const WorkflowExecutionCallSchema = z.strictObject({
   id: z.string().min(1),
   label: z.string(),
   stageId: z.string().min(1).optional(),
@@ -117,41 +117,6 @@ const WorkflowExecutionCallShape = z.strictObject({
   costUsd: z.number().nonnegative().optional(),
   timestamps: WorkflowExecutionTimestampsSchema,
 });
-/**
- * Shapes an older build persisted, normalized here ahead of the strict shape
- * so a `meta.json` snapshot of an interrupted run `hydrate()` must still
- * recover keeps parsing instead of failing strictObject's unrecognized-key
- * check. Dropped keys: `stageTitle` (a denormalized duplicate of the
- * referenced stage's title — resolve it with `stageTitleFor`; removed
- * 2026-08-18), `blockedReason` (derivable from `status`, the stage, and
- * `settledBySweep`) and `timestamps.queuedAt` (never read) — both removed
- * 2026-08-28. Dropped value: the transient `starting` call status, folded
- * into `running` (removed 2026-08-28; last written by 0.40.5).
- *
- * Compatibility reader, not a contract: delete this preprocess (and pass the
- * strict shape directly) once every release that wrote these shapes is
- * three months old — on or after 2026-11-28 — per AGENTS.md "Compatibility
- * and format retirement". A snapshot from an interrupted run that old is
- * disposable; the strict shape then fails it loudly.
- */
-const WorkflowExecutionCallSchema = z.preprocess((value) => {
-  if (!value || typeof value !== 'object') return value;
-  const {
-    stageTitle: _stageTitle,
-    blockedReason: _blockedReason,
-    timestamps,
-    ...rest
-  } = value as Record<string, unknown>;
-  if (rest.status === 'starting') rest.status = WORKFLOW_CALL_STATUS.RUNNING;
-  if (!timestamps || typeof timestamps !== 'object') {
-    return { ...rest, timestamps };
-  }
-  const { queuedAt: _queuedAt, ...keptTimestamps } = timestamps as Record<
-    string,
-    unknown
-  >;
-  return { ...rest, timestamps: keptTimestamps };
-}, WorkflowExecutionCallShape);
 export type WorkflowExecutionCall = z.infer<typeof WorkflowExecutionCallSchema>;
 
 type WorkflowExecutionCounts = Record<WorkflowExecutionCallStatus, number> & {

--- a/src/test-kernel/agent/WorkflowExecutionObservability.vitest.ts
+++ b/src/test-kernel/agent/WorkflowExecutionObservability.vitest.ts
@@ -134,18 +134,15 @@ return await agent('work', { id: 'work-call' })`,
       candidate.calls[0]!.attempts[0]!.id = '' as ExecutionId;
     });
 
-    // A meta.json persisted before stageTitle was removed still carries the
-    // key on disk; the read path must tolerate it rather than fail closed.
+    // A meta.json persisted by an older build with a retired key fails
+    // loudly: there is no compatibility reader, by policy.
     const legacy = structuredClone(result.snapshot) as unknown as {
       calls: Array<Record<string, unknown>>;
     };
     legacy.calls[0]!.stageTitle = 'Work';
-    const legacyParsed = WorkflowExecutionSnapshotSchema.safeParse(legacy);
-    expect(legacyParsed.success).toBe(true);
-    expect(
-      (legacyParsed.data?.calls[0] as { stageTitle?: unknown } | undefined)
-        ?.stageTitle,
-    ).toBeUndefined();
+    expect(WorkflowExecutionSnapshotSchema.safeParse(legacy).success).toBe(
+      false,
+    );
 
     const active = structuredClone(
       snapshots.find(


### PR DESCRIPTION
## What

Deletes the `z.preprocess` compatibility reader on `WorkflowExecutionCallSchema` that stripped `stageTitle` (removed 2026-08-18), `blockedReason` and `timestamps.queuedAt` (removed 2026-08-28), and mapped a persisted `status: 'starting'` to `running`. The strict call shape is now the schema; a `meta.json` snapshot of an interrupted run written by an older build fails `hydrate()`/`/executions` loudly rather than being translated.

Why now rather than 2026-11-28: these shapes are intermediate-era data from an opt-in prototype feature; the repo's ruling (#9590) is to delete such readers early and loudly, not to age-gate them.

## Net elements (R6)

- `git diff --stat origin/main`: 3 files, +11 / −46 (net −35); production 1 file, −29.
- Exported symbols: 0 added, 0 deleted (`WorkflowExecutionCallShape` was file-local and is renamed to the schema). Declarations: 0. Files: 0.

## Consumer counts (R8)

No emit path or public symbol deleted. The reader had one consumer (`WorkflowExecutionSnapshotSchema.calls`), which now takes the strict shape directly. `rg "stageTitle\b|blockedReason|queuedAt" src packages/*/src` → only `stageTitleFor` and the one test, which now asserts the loud rejection.

## Verified

- `npm run typecheck` — clean · `npm run lint` — clean · `npm run check:dead-code-ratchet` — no new findings · prettier — clean
- vitest over agent/tools/transcript/shared suites — 60 files / 896 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pZUVQRHJvb8tVCu8nU7TC
