### PR TITLE
Consolidate duplicated ✓/✗ glyphs and badge markup onto shared helpers

### DIFF
--- a/packages/cli/src/chat/tui/render/transcriptRowLines.ts
+++ b/packages/cli/src/chat/tui/render/transcriptRowLines.ts
@@ -6,7 +6,7 @@
 // over text a producer wrote. Nothing here truncates the model.
 
 import { safeTerminalText } from '@cli/runtime/terminalText';
-import { TOOL_OUTPUT_CORNER } from '@cli/tui/ui/glyphs';
+import { CROSS, TICK, TOOL_OUTPUT_CORNER } from '@cli/tui/ui/glyphs';
 import { redactSecrets } from '@logger/redaction';
 import {
   elideText,
@@ -63,7 +63,7 @@ function fileListLines(row: Extract<TranscriptRow, { kind: 'fileList' }>) {
   const mediaByPath = new Map(row.media.map((ref) => [ref.path, ref.media]));
   return row.files.map((file) => {
     const media = mediaByPath.get(file.path);
-    const marker = file.ok ? '✓' : '✗';
+    const marker = file.ok ? TICK : CROSS;
     const name = file.varName ? `${file.varName}: ` : '';
     const source = file.sourceDisplay ? ` (${file.sourceDisplay})` : '';
     const size = media
@@ -118,7 +118,7 @@ export function transcriptRowBodyLines(
       case 'latexdiff':
         return row.entries.map(
           (entry) =>
-            `${entry.status === 'success' ? '✓' : '✗'} ${entry.displayName}${
+            `${entry.status === 'success' ? TICK : CROSS} ${entry.displayName}${
               entry.message ? ` — ${entry.message}` : ''
             }`,
         );

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -56,6 +56,7 @@ import { getBasename } from '@utils/core';
 import { BaseApprovalPanel } from './BaseApprovalPanel';
 import { proposalRequestPanelStyles } from './ProposalRequestPanel.styles';
 import { APPROVE_ALL_DELEGATED_WORK_ACTION } from '../events';
+import { buildStatusBadge } from '../formatters/htmlBuilders';
 import { processMarkdownContent } from '../formatters/markdownRenderer';
 import { getComposedPathElement } from '../utils';
 
@@ -369,10 +370,7 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
       ${repeat(
         flags,
         (flag) => flag,
-        (flag) =>
-          html`<wa-badge variant="neutral" appearance="filled"
-            >${waIcon('image')} ${flag}</wa-badge
-          >`,
+        (flag) => buildStatusBadge('image', flag),
       )}
     </div>`;
   }


### PR DESCRIPTION
## Summary

Follow-up from a scheduled UI-standardization scan. Two spots hand-rolled markup that duplicated an existing shared helper in the same file/module:

- `packages/cli/src/chat/tui/render/transcriptRowLines.ts` re-declared the literal `'✓'`/`'✗'` glyphs at two call sites, even though `packages/cli/src/tui/ui/glyphs.ts` already exports `TICK`/`CROSS` for exactly this purpose ("Centralized here so every list/select/prompt uses the same marker instead of re-declaring the literal in each component").
- `packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts` hand-wrote a `<wa-badge>` template identical in shape to the existing `buildStatusBadge()` helper in `formatters/htmlBuilders.ts`, which is already used for the same badge pattern elsewhere (`toolSections.ts`).

Both are swapped to use the existing shared symbols instead.

## Issue acceptance gates

No tracked issue — output of a scheduled UI-consistency scan. Gate: replace the two duplicated markup sites with the pre-existing shared helper, with no behavior change.

## Single source of truth

`packages/cli/src/tui/ui/glyphs.ts` (`TICK`/`CROSS`) and `packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts` (`buildStatusBadge`) already owned these facts; this PR routes the two stray call sites through them instead of adding anything new.

## Duplication and abstraction budget

Removed two re-declarations (literal glyphs, hand-rolled badge template) that duplicated existing exports. No new abstraction added.

## Net elements (R6)

2 files changed, 0 added/removed. No exported symbols added or removed — both `TICK`/`CROSS` and `buildStatusBadge` already existed and were already exported. +5/-7 lines (net −2 LoC).

## Consumer counts (R8)

n/a — no export deleted or re-routed; two additional call sites were pointed at existing exports.

## Host impact

Extension: `ProposalRequestPanel.ts` badge rendering now goes through `buildStatusBadge` (visually identical output).

Desktop: none.

CLI: `transcriptRowLines.ts` ✓/✗ markers now use `TICK`/`CROSS` (visually identical output).

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean across workspace, test-kernel, agent, cli, trace-viewer, desktop.
- `npx eslint` on both changed files — clean.
- `npx vitest run src/test-kernel/progressView/ProposalRequestPanel.vitest.ts src/test-kernel/cli/ConversationTranscript.vitest.ts` — 86/86 passed.
- `npm run check:dead-code-ratchet` — no new findings.
- `npm test` (full `src/test-kernel` suite) — kicked off; will confirm/follow up if it surfaces anything.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyE7koqDjU13SMG8MFEpJ7)_