### PR TITLE
refactor(agent): namespace CLI-only fields on AgentConfig under `cli`

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -213,20 +213,19 @@ export function createChatSessionController(
   const beginRunContext = (
     config: Pick<
       AgentConfig,
-      'agent' | 'model' | 'cliMultiAgentPresetId' | 'delegationAgentScope'
+      'agent' | 'model' | 'cli' | 'delegationAgentScope'
     >,
     modelSource?: 'history',
   ): CliContext => {
     const sessionContext = getSessionContext(config.model);
+    const cliMultiAgentPresetId = config.cli?.multiAgentPresetId ?? undefined;
     patchSessionMeta({
       agent: config.agent,
       model: config.model,
       ...(modelSource ? { modelSource } : {}),
       canDelegate: chatAgentSupportsDelegation(config.agent),
-      teamName: readCliMultiAgentPresetName(
-        config.cliMultiAgentPresetId ?? undefined,
-      ),
-      cliMultiAgentPresetId: config.cliMultiAgentPresetId ?? undefined,
+      teamName: readCliMultiAgentPresetName(cliMultiAgentPresetId),
+      cliMultiAgentPresetId,
       delegationAgentScope: config.delegationAgentScope ?? undefined,
     });
     return sessionContext;

--- a/packages/cli/src/chat/tui/chatSubmitDriver.ts
+++ b/packages/cli/src/chat/tui/chatSubmitDriver.ts
@@ -199,7 +199,7 @@ export function createChatSubmitDriver(
           workingDirectory: cwd,
           ...(mediaFiles?.length ? { mediaFiles: [...mediaFiles] } : {}),
           ...(meta.cliMultiAgentPresetId
-            ? { cliMultiAgentPresetId: meta.cliMultiAgentPresetId }
+            ? { cli: { multiAgentPresetId: meta.cliMultiAgentPresetId } }
             : {}),
           ...(meta.delegationAgentScope
             ? { delegationAgentScope: meta.delegationAgentScope }

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -275,7 +275,7 @@ export async function runChat(
     resumeExecution: chatController.resume,
   });
   const initialPresetId = initialResume
-    ? (initialResume.config.cliMultiAgentPresetId ?? undefined)
+    ? (initialResume.config.cli?.multiAgentPresetId ?? undefined)
     : init.cliMultiAgentPresetId;
   sessionMetaSignal.set({
     agent,

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -250,7 +250,7 @@ export async function runMultiAgentPreset(
         displayInstruction,
         workingDirectory: runContext.cwd,
         agentCategory: AgentCategory.ToolUse,
-        cliMultiAgentPresetId: plan.preset.id,
+        cli: { multiAgentPresetId: plan.preset.id },
         delegationAgentScope: byCategory((category) => [
           ...plan.agentKeys[category],
         ]),

--- a/packages/cli/src/commands/resumeExecution.ts
+++ b/packages/cli/src/commands/resumeExecution.ts
@@ -173,7 +173,7 @@ export async function runResumeExecution(
             output,
             outputDir,
             expectedOutputFiles:
-              workflowConfig.cliExpectedOutputFiles ?? undefined,
+              workflowConfig.cli?.expectedOutputFiles ?? undefined,
             recoveryInputIsDurable: await workflowRecoveryInputsAreDurable(
               workflowConfig,
               context.cwd,

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -120,22 +120,33 @@ export async function runWorkflowAgent(
       const expectedOutputFiles = init.outputDir
         ? expectedOutputFilesForOutputDir(agent, inputFiles)
         : undefined;
+      // Persist CLI destinations absolutely so resumption has one path
+      // representation and never reconstructs output locations.
+      const cliOutputFile = absoluteOutputDestination(
+        init.output,
+        runContext.cwd,
+      );
+      const cliOutputDirectory = absoluteOutputDestination(
+        init.outputDir,
+        runContext.cwd,
+      );
       const config: AgentConfigPayload = {
         agent: init.agent,
         model,
         inputFiles,
         contextFiles,
         outputFiles: [],
-        // Persist CLI destinations absolutely so resumption has one path
-        // representation and never reconstructs output locations.
-        cliOutputFile: absoluteOutputDestination(init.output, runContext.cwd),
-        cliOutputDirectory: absoluteOutputDestination(
-          init.outputDir,
-          runContext.cwd,
-        ),
-        cliExpectedOutputFiles: expectedOutputFiles
-          ? [...expectedOutputFiles]
-          : undefined,
+        ...(cliOutputFile !== undefined || cliOutputDirectory !== undefined
+          ? {
+              cli: {
+                outputFile: cliOutputFile,
+                outputDirectory: cliOutputDirectory,
+                expectedOutputFiles: expectedOutputFiles
+                  ? [...expectedOutputFiles]
+                  : undefined,
+              },
+            }
+          : {}),
         instruction,
         workingDirectory: runContext.cwd,
         agentCategory: AgentCategory.Workflow,

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -154,7 +154,7 @@ async function loadHistoryDefaults(): Promise<PartialDefaults> {
         entry.record.agentCategory === AgentCategory.ToolUse &&
         // A multi-agent team run's root is an orchestrator agent, not a
         // sensible default for a plain single-agent chat session.
-        !entry.record.cliMultiAgentPresetId,
+        !entry.record.cli?.multiAgentPresetId,
     ),
     (item) => item.timestamp,
   );

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -511,7 +511,7 @@ export function formatCliHistoryDetailsText(
   const { config, meta } = details;
   const model = details.currentModel ?? config?.model;
   const teamPreset = teamPresetId(config);
-  const cliOutputFile = config?.cliOutputFile?.trim();
+  const cliOutputFile = config?.cli?.outputFile?.trim();
   const lines = [
     `Execution: ${details.id}`,
     `Status: ${HISTORY_RUN_STATUS_LABEL[details.status]}`,
@@ -585,5 +585,5 @@ async function toCliHistoryEntry(
 }
 
 function teamPresetId(config: AgentConfig | null): string | undefined {
-  return config?.cliMultiAgentPresetId?.trim() || undefined;
+  return config?.cli?.multiAgentPresetId?.trim() || undefined;
 }

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -354,7 +354,7 @@ export function resumeWorkflowOutputFile(
 ): string | undefined {
   if (config.agentCategory !== AgentCategory.Workflow) return undefined;
 
-  const cliOutputFile = config.cliOutputFile;
+  const cliOutputFile = config.cli?.outputFile;
   if (isNonEmptyString(cliOutputFile)) {
     if (!path.isAbsolute(cliOutputFile)) {
       throw new CliUsageError(
@@ -381,7 +381,7 @@ export function resumeWorkflowOutputDirectory(
 ): string | undefined {
   if (config.agentCategory !== AgentCategory.Workflow) return undefined;
 
-  const outputDirectory = config.cliOutputDirectory;
+  const outputDirectory = config.cli?.outputDirectory;
   if (!isNonEmptyString(outputDirectory)) return undefined;
   if (!path.isAbsolute(outputDirectory)) {
     throw new CliUsageError(

--- a/src/agent/core/definition/AgentConfig.ts
+++ b/src/agent/core/definition/AgentConfig.ts
@@ -12,6 +12,28 @@ import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
 /** Agent assumed when a config omits `agent`, and sorted first in the workflow dropdown. */
 export const DEFAULT_WORKFLOW_AGENT = 'correct';
 
+/**
+ * CLI-only fields, grouped so the CLI-specific footprint of {@link AgentConfig}
+ * is self-evident at the schema level. Absent for extension/desktop-launched
+ * runs.
+ */
+const CliOutputFieldsSchema = z.object({
+  /** Workspace copy target for `texra run --output`, preserved for resume. */
+  outputFile: z.string().nullish(),
+  /** Workspace copy directory for `texra run --output-dir`. */
+  outputDirectory: z.string().nullish(),
+  /** Relative artifacts expected under {@link CliOutputFieldsSchema.outputDirectory}. */
+  expectedOutputFiles: z.array(z.string()).nullish(),
+  /**
+   * Team preset id this execution was launched from (`texra multi-agent run
+   * <preset>` in the CLI; the main-view launcher also sets it for team runs so
+   * resume retains team identity). Used so a team run — whose root is an
+   * orchestrator agent — is not inferred as the default agent for a plain
+   * `texra chat` session. Preserved across resume.
+   */
+  multiAgentPresetId: z.string().nullish(),
+});
+
 /** Fields shared by both category-specific config variants. */
 const AgentConfigSharedFieldsSchema = NullableFileFieldsSchema.extend({
   agent: z.string().prefault(DEFAULT_WORKFLOW_AGENT),
@@ -35,20 +57,8 @@ const AgentConfigSharedFieldsSchema = NullableFileFieldsSchema.extend({
   memories: z.array(z.string()).prefault([]),
   /** Working directory override for subagent tool calls (e.g. a git worktree). */
   workingDirectory: z.string().nullish(),
-  /** CLI-only workspace copy target for `texra run --output`, preserved for resume. */
-  cliOutputFile: z.string().nullish(),
-  /** CLI-only workspace copy directory for `texra run --output-dir`. */
-  cliOutputDirectory: z.string().nullish(),
-  /** Relative artifacts expected under {@link cliOutputDirectory}. */
-  cliExpectedOutputFiles: z.array(z.string()).nullish(),
-  /**
-   * Team preset id this execution was launched from (`texra multi-agent run
-   * <preset>` in the CLI; the main-view launcher also sets it for team runs so
-   * resume retains team identity). Used so a team run — whose root is an
-   * orchestrator agent — is not inferred as the default agent for a plain
-   * `texra chat` session. Preserved across resume.
-   */
-  cliMultiAgentPresetId: z.string().nullish(),
+  /** CLI-only fields, absent for extension/desktop-launched runs. */
+  cli: CliOutputFieldsSchema.nullish(),
   /** Execution-scoped delegation roster used by team runs and their children. */
   delegationAgentScope: AgentDelegationScopeSchema.nullish(),
 });
@@ -73,20 +83,56 @@ const AgentConfigFieldsSchema = z.discriminatedUnion('agentCategory', [
   ToolUseAgentConfigFieldsSchema,
 ]);
 
+const LEGACY_CLI_FIELD_NAMES = [
+  'cliOutputFile',
+  'cliOutputDirectory',
+  'cliExpectedOutputFiles',
+  'cliMultiAgentPresetId',
+] as const;
+
+/**
+ * Move the pre-nesting flat `cli*` fields into the `cli` sub-object once, at
+ * the schema entrance, so downstream code only ever sees the nested shape.
+ * A no-op once a `cli` object is already present, or when none of the legacy
+ * fields are.
+ */
+function migrateLegacyCliFields(
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  if ('cli' in input && input.cli !== undefined) return input;
+  if (!LEGACY_CLI_FIELD_NAMES.some((name) => name in input)) return input;
+
+  const {
+    cliOutputFile,
+    cliOutputDirectory,
+    cliExpectedOutputFiles,
+    cliMultiAgentPresetId,
+    ...rest
+  } = input as Record<string, unknown>;
+  return {
+    ...rest,
+    cli: {
+      outputFile: cliOutputFile,
+      outputDirectory: cliOutputDirectory,
+      expectedOutputFiles: cliExpectedOutputFiles,
+      multiAgentPresetId: cliMultiAgentPresetId,
+    },
+  };
+}
+
 /**
  * Materialize the absent-category default before the discriminated union
- * selects a variant.
+ * selects a variant, and migrate legacy flat CLI fields into `cli`.
  */
 function normalizeAgentConfigInput(input: unknown): unknown {
-  if (
-    typeof input !== 'object' ||
-    input === null ||
-    Array.isArray(input) ||
-    ('agentCategory' in input && input.agentCategory !== undefined)
-  ) {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
     return input;
   }
-  return { ...input, agentCategory: AgentCategory.Workflow };
+  const migrated = migrateLegacyCliFields(input as Record<string, unknown>);
+  if ('agentCategory' in migrated && migrated.agentCategory !== undefined) {
+    return migrated;
+  }
+  return { ...migrated, agentCategory: AgentCategory.Workflow };
 }
 
 function validateOutputFileCount(

--- a/src/agent/core/definition/AgentConfig.ts
+++ b/src/agent/core/definition/AgentConfig.ts
@@ -104,7 +104,7 @@ const LEGACY_CLI_FIELD_NAMES = [
 function migrateLegacyCliFields(
   input: Record<string, unknown>,
 ): Record<string, unknown> {
-  if ('cli' in input && input.cli !== undefined) return input;
+  if ('cli' in input && input.cli != null) return input;
   if (!LEGACY_CLI_FIELD_NAMES.some((name) => name in input)) return input;
 
   const {

--- a/src/agent/core/definition/AgentConfig.ts
+++ b/src/agent/core/definition/AgentConfig.ts
@@ -95,6 +95,11 @@ const LEGACY_CLI_FIELD_NAMES = [
  * the schema entrance, so downstream code only ever sees the nested shape.
  * A no-op once a `cli` object is already present, or when none of the legacy
  * fields are.
+ *
+ * Introduced 2026-08-28. Retire three months after this ships (see AGENTS.md
+ * "Compatibility and format retirement"): once no execution on disk still
+ * predates it, delete this function, `LEGACY_CLI_FIELD_NAMES`, and the
+ * migration branch in {@link normalizeAgentConfigInput}.
  */
 function migrateLegacyCliFields(
   input: Record<string, unknown>,

--- a/src/common/teams/TeamPlan.ts
+++ b/src/common/teams/TeamPlan.ts
@@ -207,14 +207,14 @@ function teamExecutionFields<T extends TeamCatalogAgent>(
 ): {
   agent: string;
   delegationAgentScope: AgentDelegationScope;
-  cliMultiAgentPresetId: string;
+  cli: { multiAgentPresetId: string };
 } {
   return {
     agent: agentKeyOf(plan.rootAgent),
     delegationAgentScope: byCategory((category) => [
       ...plan.agentKeys[category],
     ]),
-    cliMultiAgentPresetId: plan.preset.id,
+    cli: { multiAgentPresetId: plan.preset.id },
   };
 }
 

--- a/src/controllers/mainView/MainViewExecutionController.ts
+++ b/src/controllers/mainView/MainViewExecutionController.ts
@@ -42,7 +42,7 @@ export function prepareMainViewTeamExecutionRequest(
   fields: {
     agent: string;
     delegationAgentScope: AgentDelegationScope;
-    cliMultiAgentPresetId: string;
+    cli: { multiAgentPresetId: string };
   },
 ): MainViewExecutionPreparationResult {
   if (!message.model) {
@@ -68,7 +68,7 @@ function buildMainViewExecutionRequest(
   agentCategory: AgentCategory,
   teamFields?: {
     readonly delegationAgentScope: AgentDelegationScope;
-    readonly cliMultiAgentPresetId: string;
+    readonly cli: { readonly multiAgentPresetId: string };
   },
 ): MainViewExecutionPreparationResult {
   const isToolUse = agentCategory === AgentCategory.ToolUse;
@@ -94,8 +94,18 @@ function buildMainViewExecutionRequest(
   }
 
   // The webview's session preset id is always nullish; only teamFields is
-  // authoritative, so strip it rather than relying on spread order.
-  const { cliMultiAgentPresetId: _, ...sessionFields } = message.session ?? {};
+  // authoritative, so strip it rather than relying on spread order. The
+  // session's `cli.outputFile` (if ever set) still passes through for both
+  // team and non-team requests.
+  const { cli: sessionCli, ...sessionFields } = message.session ?? {};
+  const cli = {
+    ...(sessionCli?.outputFile != null
+      ? { outputFile: sessionCli.outputFile }
+      : {}),
+    ...(teamFields
+      ? { multiAgentPresetId: teamFields.cli.multiAgentPresetId }
+      : {}),
+  };
   const validation = validateExecutionRequest({
     config: {
       agent,
@@ -106,7 +116,10 @@ function buildMainViewExecutionRequest(
       ...sessionFields,
       ...files,
       agentCategory,
-      ...teamFields,
+      ...(teamFields
+        ? { delegationAgentScope: teamFields.delegationAgentScope }
+        : {}),
+      ...(Object.keys(cli).length > 0 ? { cli } : {}),
       // Workflow output paths are implicit in the input list. Agent settings
       // may still declare generated filenames later during prompt rendering.
       outputFiles: [],

--- a/src/shared/schemas/mainView/executeMessage.ts
+++ b/src/shared/schemas/mainView/executeMessage.ts
@@ -28,8 +28,12 @@ export const MainViewExecuteMessageSchema = z.object({
   session: z
     .object({
       workingDirectory: z.string().nullish(),
-      cliOutputFile: z.string().nullish(),
-      cliMultiAgentPresetId: z.string().nullish(),
+      cli: z
+        .object({
+          outputFile: z.string().nullish(),
+          multiAgentPresetId: z.string().nullish(),
+        })
+        .nullish(),
       // Team runs send team identity only; hosts resolve the roster at the
       // execution boundary where catalog/auth state is authoritative.
       launchTarget: LaunchTargetSchema.nullish(),

--- a/src/test-kernel/cli/ChatDefaults.vitest.ts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.ts
@@ -224,7 +224,7 @@ describe('CLI chat defaults', () => {
     // `texra chat` defaults — fall back to the built-ins instead.
     mockedListExecutions.mockResolvedValueOnce([
       historyEntry('leanOrchestrator', {
-        cliMultiAgentPresetId: 'lean-project',
+        cli: { multiAgentPresetId: 'lean-project' },
       }),
     ]);
 
@@ -267,7 +267,7 @@ describe('CLI chat defaults', () => {
       historyEntry(
         'orchestrator',
         {
-          cliMultiAgentPresetId: 'physicist',
+          cli: { multiAgentPresetId: 'physicist' },
         },
         '2026-05-21T08:02:00.000Z',
       ),

--- a/src/test-kernel/cli/CliRootArgs.vitest.ts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.ts
@@ -66,7 +66,6 @@ function storedConfig(
     inputFiles: ['paper.tex'],
     contextFiles: [],
     outputFiles: [],
-    cliOutputFile: undefined,
     instruction: undefined,
     workingDirectory: '/tmp/project',
     agentCategory: AgentCategory.Workflow,
@@ -883,7 +882,7 @@ describe('CLI root argument routing', () => {
     expect(
       resumeWorkflowOutputFile(
         storedConfig({
-          cliOutputFile: '/tmp/elsewhere/paper.polished.tex',
+          cli: { outputFile: '/tmp/elsewhere/paper.polished.tex' },
           outputFiles: ['paper.polished.tex'],
         }),
       ),
@@ -894,7 +893,7 @@ describe('CLI root argument routing', () => {
     expect(() =>
       resumeWorkflowOutputFile(
         storedConfig({
-          cliOutputFile: 'out/paper.polished.tex',
+          cli: { outputFile: 'out/paper.polished.tex' },
           outputFiles: ['paper.polished.tex'],
         }),
       ),
@@ -910,7 +909,7 @@ describe('CLI root argument routing', () => {
       resumeWorkflowOutputFile(
         storedConfig({
           workingDirectory,
-          cliOutputFile: outputFile,
+          cli: { outputFile },
         }),
       ),
     ).toBe(outputFile);
@@ -949,7 +948,7 @@ describe('CLI root argument routing', () => {
   it('rejects a non-absolute stored CLI output directory', () => {
     expect(() =>
       resumeWorkflowOutputDirectory(
-        storedConfig({ cliOutputDirectory: 'out/polished' }),
+        storedConfig({ cli: { outputDirectory: 'out/polished' } }),
       ),
     ).toThrow('Stored workflow output directory is not absolute: out/polished');
   });

--- a/src/test-kernel/cli/History.vitest.ts
+++ b/src/test-kernel/cli/History.vitest.ts
@@ -396,7 +396,7 @@ describe('CLI history runtime', () => {
   it('labels multi-agent team runs by preset in history lists', async () => {
     const teamConfig = toolUseAgentConfig({
       agent: 'engineer',
-      cliMultiAgentPresetId: ' software-engineer ',
+      cli: { multiAgentPresetId: ' software-engineer ' },
     });
     mocks.listExecutions.mockResolvedValue([
       runListEntry('team1', {
@@ -589,7 +589,7 @@ describe('CLI history runtime', () => {
         agent: 'engineer',
         model: 'sonnet46T',
         agentCategory: 'toolUse',
-        cliMultiAgentPresetId: ' software-engineer ',
+        cli: { multiAgentPresetId: ' software-engineer ' },
       }),
     );
 
@@ -605,7 +605,7 @@ describe('CLI history runtime', () => {
     mocks.readConfig.mockResolvedValue(
       AgentConfigSchema.parse({
         ...config,
-        cliOutputFile: ' /tmp/texra-output/polished.tex ',
+        cli: { outputFile: ' /tmp/texra-output/polished.tex ' },
       }),
     );
 

--- a/src/test-kernel/cli/ResumeCommand.vitest.ts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.ts
@@ -225,8 +225,10 @@ describe('runResumeExecution', () => {
     const workflowConfig = AgentConfigSchema.parse({
       ...WORKFLOW_CONFIG,
       workingDirectory,
-      cliOutputDirectory: outputDirectory,
-      cliExpectedOutputFiles: ['paper.tex', 'appendix.tex'],
+      cli: {
+        outputDirectory,
+        expectedOutputFiles: ['paper.tex', 'appendix.tex'],
+      },
     });
     await stubWorkflowResume(workflowConfig);
 
@@ -248,7 +250,7 @@ describe('runResumeExecution', () => {
     const workflowConfig = AgentConfigSchema.parse({
       ...WORKFLOW_CONFIG,
       workingDirectory,
-      cliOutputDirectory: outputDirectory,
+      cli: { outputDirectory },
     });
     await stubWorkflowResume(workflowConfig);
 
@@ -268,7 +270,7 @@ describe('runResumeExecution', () => {
     const workflowConfig = AgentConfigSchema.parse({
       ...WORKFLOW_CONFIG,
       workingDirectory,
-      cliOutputDirectory: path.join(workingDirectory, 'out'),
+      cli: { outputDirectory: path.join(workingDirectory, 'out') },
     });
     await stubWorkflowResume(workflowConfig);
     mocks.assertOutputDirAvailable.mockRejectedValue(

--- a/src/test-kernel/cli/RunChatSignalOwnership.vitest.ts
+++ b/src/test-kernel/cli/RunChatSignalOwnership.vitest.ts
@@ -465,7 +465,7 @@ describe('runChat signal ownership wiring', () => {
       agent: 'orchestrator',
       model: 'gpt-test',
       agentCategory: 'toolUse',
-      cliMultiAgentPresetId: 'physicist',
+      cli: { multiAgentPresetId: 'physicist' },
       delegationAgentScope,
     });
     const { runChat } = await import('@cli/chat/tui/runChatTui');
@@ -502,7 +502,7 @@ describe('runChat signal ownership wiring', () => {
         agentCategory: 'toolUse',
         workingDirectory: '/tmp/texra-chat',
         mediaFiles: ['/tmp/diagram.png'],
-        cliMultiAgentPresetId: 'physicist',
+        cli: { multiAgentPresetId: 'physicist' },
         delegationAgentScope,
       });
     } finally {

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
@@ -491,9 +491,11 @@ describe('CLI workflow run command', () => {
       expect(config).toMatchObject({
         inputFiles: ['paper.tex'],
         outputFiles: [],
-        cliOutputFile: path.join(root, 'polished.tex'),
-        cliOutputDirectory: undefined,
-        cliExpectedOutputFiles: undefined,
+        cli: {
+          outputFile: path.join(root, 'polished.tex'),
+          outputDirectory: undefined,
+          expectedOutputFiles: undefined,
+        },
       });
       await expect(
         fs.readFile(path.join(root, 'polished.tex'), 'utf8'),
@@ -554,9 +556,11 @@ describe('CLI workflow run command', () => {
 
       expect(exitCode).toBe(0);
       expect(mocks.executeCliConfig.mock.calls[0]?.[0]).toMatchObject({
-        cliOutputFile: undefined,
-        cliOutputDirectory: path.join(workspace, 'out'),
-        cliExpectedOutputFiles: ['paper.tex'],
+        cli: {
+          outputFile: undefined,
+          outputDirectory: path.join(workspace, 'out'),
+          expectedOutputFiles: ['paper.tex'],
+        },
       });
       await expect(
         fs.readFile(path.join(workspace, 'out', 'paper.tex'), 'utf8'),

--- a/src/test-kernel/cli/chatSessionController.vitest.ts
+++ b/src/test-kernel/cli/chatSessionController.vitest.ts
@@ -1143,7 +1143,7 @@ describe('createChatSessionController', () => {
 
   it('retains the configuration of a manually resumed conversation', async () => {
     const config = makeResumeConfig({
-      cliMultiAgentPresetId: 'physicist',
+      cli: { multiAgentPresetId: 'physicist' },
       delegationAgentScope: {
         workflow: ['builtInWorkflow:physicsReviewer'],
         toolUse: ['builtInToolUse:orchestrator'],

--- a/src/test-kernel/common/teams/TeamPlan.vitest.ts
+++ b/src/test-kernel/common/teams/TeamPlan.vitest.ts
@@ -481,7 +481,7 @@ describe('resolveTeamLaunch', () => {
           workflow: ['builtInWorkflow:writer'],
           toolUse: ['builtInToolUse:lead', 'builtInToolUse:member'],
         },
-        cliMultiAgentPresetId: 'custom-team',
+        cli: { multiAgentPresetId: 'custom-team' },
       },
       partial: false,
       missingNames: [],

--- a/src/test-kernel/controllers/MainViewExecutionController.vitest.ts
+++ b/src/test-kernel/controllers/MainViewExecutionController.vitest.ts
@@ -70,7 +70,7 @@ describe('MainViewExecutionController', () => {
       {
         agent: 'stale-renderer-agent',
         model: 'gpt-5.4',
-        session: { cliMultiAgentPresetId: 'stale-preset' },
+        session: { cli: { multiAgentPresetId: 'stale-preset' } },
       },
       {
         agent: 'builtInToolUse:lead',
@@ -78,7 +78,7 @@ describe('MainViewExecutionController', () => {
           workflow: ['builtInWorkflow:writer'],
           toolUse: ['builtInToolUse:lead', 'builtInToolUse:member'],
         },
-        cliMultiAgentPresetId: 'custom-team',
+        cli: { multiAgentPresetId: 'custom-team' },
       },
     );
 
@@ -92,7 +92,7 @@ describe('MainViewExecutionController', () => {
         workflow: ['builtInWorkflow:writer'],
         toolUse: ['builtInToolUse:lead', 'builtInToolUse:member'],
       },
-      cliMultiAgentPresetId: 'custom-team',
+      cli: { multiAgentPresetId: 'custom-team' },
     });
   });
 
@@ -103,7 +103,7 @@ describe('MainViewExecutionController', () => {
         workflow: ['builtInWorkflow:writer'],
         toolUse: ['builtInToolUse:lead'],
       },
-      cliMultiAgentPresetId: 'custom-team',
+      cli: { multiAgentPresetId: 'custom-team' },
     };
 
     expect(

--- a/src/test-kernel/controllers/MainViewExecutionLaunchController.vitest.ts
+++ b/src/test-kernel/controllers/MainViewExecutionLaunchController.vitest.ts
@@ -122,7 +122,7 @@ describe('main-view execution launch controller', () => {
         workflowAgentKeys: ['workflow:critic'],
         toolUseAgentKeys: ['toolUse:team-root'],
       },
-      cliMultiAgentPresetId: 'physicist',
+      cli: { multiAgentPresetId: 'physicist' },
     };
     const preparation = { valid: false as const, message: 'invalid model' };
     mocks.resolveTeamLaunch.mockResolvedValue({

--- a/src/test-kernel/progressView/ChatExportController.vitest.ts
+++ b/src/test-kernel/progressView/ChatExportController.vitest.ts
@@ -73,8 +73,7 @@ function config(overrides: Partial<AgentConfig> = {}): AgentConfig {
     toolConfig: DEFAULT_TOOL_CONFIG,
     memories: [],
     workingDirectory: '/workspace',
-    cliOutputFile: null,
-    cliMultiAgentPresetId: null,
+    cli: { outputFile: null, multiAgentPresetId: null },
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

A scheduled data-structure-complexity audit flagged that `AgentConfig` (`src/agent/core/definition/AgentConfig.ts`) — a host-agnostic core schema used identically by the extension, desktop app, and CLI to persist/resume every agent execution's `config.json` — mixed 4 CLI-only fields (`cliOutputFile`, `cliOutputDirectory`, `cliExpectedOutputFiles`, `cliMultiAgentPresetId`) flat among 15+ other shared fields. Only `packages/cli/` ever reads them; no extension or desktop code does. This PR groups the 4 fields under a single nested `cli` object so the CLI-specific footprint is self-evident at the schema level, without forking `AgentConfig` into a host-specific schema (which the persistence/resume layer can't support — the format is host-agnostic by design).

## Issue acceptance gates

No tracked issue — this came out of a scheduled complexity-audit routine. Acceptance gate: the 4 CLI-only fields are namespaced under `cli`, existing persisted `config.json` files (flat shape) still parse and resume correctly, and no production call site was missed.

## Single source of truth

`normalizeAgentConfigInput` in `AgentConfig.ts` remains the single entry point that normalizes input before the discriminated union parses — extended with a `migrateLegacyCliFields` step so legacy flat `cli*` fields are folded into `cli` once, at the boundary. Downstream code never branches on old-vs-new shape.

## Duplication and abstraction budget

No new abstraction beyond the one grouping object (`CliOutputFieldsSchema`) the schema itself needed. Two schemas that duplicated a subset of these fields independently (`MainViewExecuteMessageSchema.session` in `src/shared/schemas/mainView/executeMessage.ts`, and `TeamPlan.ts`'s `teamExecutionFields`) were updated to the same nested shape for consistency, since they feed into the same `AgentConfig`-shaped object at the execution boundary.

## Net elements (R6)

24 files changed, 163 insertions(+), 86 deletions(-). No exported symbols added or removed (`git diff | grep -E '^[+-]export'` is empty) — this is a pure field-regrouping refactor, not new surface area.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed. All 4 fields' call sites (~14 production files, found via `grep -rln 'cliOutputFile\|cliOutputDirectory\|cliExpectedOutputFiles\|cliMultiAgentPresetId'`) were updated in this PR to read/construct the new nested shape; none were left half-migrated.

## Host impact

Extension: `MainViewExecutionController.ts` and `executeMessage.ts` (main-view IPC schema) updated — team launches now send/receive `cli.multiAgentPresetId` instead of a flat field.

Desktop: no code change (it never read these fields); `AgentConfig` is shared, so desktop-launched runs simply carry an absent `cli` field as before.

CLI: all read/write sites across `packages/cli/` (workflow, resumeExecution, multiAgent, history, workflowOutput, chatDefaults, chat/tui/*) updated to the nested shape. CLI-internal-only types that never touch the shared `AgentConfig` schema (`SessionMeta.cliMultiAgentPresetId`, `RunChatInit.cliMultiAgentPresetId`) were deliberately left as-is — out of scope, not part of the persisted schema.

## Scheduled refactoring

None. A separate audit finding (grouping the ~26-field `ExecuteAgentOptions`/`SubagentRunOptions` bag in `src/agent/runtime/executeAgent.ts` by concern) was deliberately left out of this PR — its blast radius spans every `executeAgent`/subagent call site across all three hosts for a more subjective benefit, and wasn't scoped here.

## Validation

- `npm run typecheck` — clean across workspace, test-kernel, agent, cli, trace-viewer, desktop (re-verified independently after the implementing agent's run).
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — no new findings (379 baselined, 379 found).
- `npx prettier --check` on touched files — clean.
- Targeted vitest run across all files referencing these fields plus the storage/persistence suites — 351 passed / 1 skipped.
- Full repo suite: `npx vitest run` — 823 test files passed / 1 skipped, 10010 tests passed / 6 skipped.
- `src/test-kernel/agent/storage/ExecutionListing.vitest.ts` was deliberately left with its flat legacy `config.json` fixture — it's the regression test for the back-compat migration path (raw pre-PR bytes bypassing the type system).


---
_Generated by [Claude Code](https://claude.ai/code/session_01CxxFP9BhZjm2XboyVh13Kj)_