### PR TITLE
Fix dead walkthrough buttons when no workspace folder is open

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -83,6 +83,7 @@ import {
   TEXRA_APPROVAL_POLICY_OPTIONS,
   type TexraApprovalPolicy,
 } from '@shared/approvalPolicy';
+import type { CommandId } from '@shared/commands/catalog';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { backfillFirstRunDone } from '@shared/state/onboardingState';
 import { UsageLogService } from '@telemetry/UsageLogService';
@@ -190,6 +191,42 @@ async function refreshApiKeyStatus() {
   }
 }
 
+/**
+ * Commands the getting-started walkthrough exposes as buttons. The walkthrough
+ * opens right after install even when no folder is open — the state where
+ * activation stops at the welcome view and never reaches `registerCommands` —
+ * so without fallbacks every one of these buttons is a dead click. Each
+ * fallback says why nothing can run yet and offers the two ways forward.
+ */
+const WALKTHROUGH_COMMANDS_NEEDING_WORKSPACE = [
+  AUTH_COMMANDS.SIGN_IN,
+  'texra.auth.chatgpt.signIn',
+  EXTENSION_COMMANDS.SET_API_KEY,
+  EXTENSION_COMMANDS.RUN_SETUP_ASSISTANT,
+  'texra.showMultiAgent',
+  'texra.showMainView',
+  'texra.extractTikzFigures',
+  'texra.execute',
+  'texra.showProgressView',
+  'texra.cleanOutput',
+  'texra.cleanBuild',
+] as const satisfies readonly CommandId[];
+
+async function explainWorkspaceRequired(extensionPath: string): Promise<void> {
+  const openFolder = 'Open Folder';
+  const createSample = 'Create Sample Project';
+  const choice = await vscode.window.showInformationMessage(
+    'TeXRA activates once a single folder is open. Open your LaTeX project folder or create the sample project, then sign in and run agents from there.',
+    openFolder,
+    createSample,
+  );
+  if (choice === openFolder) {
+    await vscode.commands.executeCommand('workbench.action.files.openFolder');
+  } else if (choice === createSample) {
+    await createSampleProjectWithoutWorkspace(extensionPath);
+  }
+}
+
 export async function activate(context: vscode.ExtensionContext) {
   try {
     await activateExtension(context);
@@ -226,6 +263,11 @@ async function activateExtension(context: vscode.ExtensionContext) {
       vscode.commands.registerCommand(
         EXTENSION_COMMANDS.OPEN_GETTING_STARTED,
         () => openGettingStarted(context.extension.id),
+      ),
+      ...WALKTHROUGH_COMMANDS_NEEDING_WORKSPACE.map((command) =>
+        vscode.commands.registerCommand(command, () =>
+          explainWorkspaceRequired(context.extensionPath),
+        ),
       ),
     );
     return;

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -20,6 +20,8 @@ import { AUTH_COMMANDS, AUTH_PROVIDER_ID } from '@auth/constants';
 import { setRuntimeExtensionId } from '@auth/config';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { EXTENSION_COMMANDS } from '@commands/extensionCommandIds';
+import { setApiKey as apiSetApiKey } from '@commands/api/apiKeyCommands';
+import { signIn as authSignIn } from '@commands/auth/authCommands';
 import { hasAnyUsableSetupCredential } from '@commands/setup/setupAssistantCommand';
 import { openGettingStarted } from '@commands/system/walkthroughCommands';
 import { createSampleProjectWithoutWorkspace } from '@commands/system/sampleProjectCommands';
@@ -42,6 +44,7 @@ import { disposeDiffRefresh } from '@frontend/ui/diffView';
 import { registerFileDecorations } from '@frontend/ui/fileDecorations';
 import { registerWelcomeView } from '@frontend/ui/welcomeView';
 import { SupabaseAuthProvider } from '@frontend/auth/SupabaseAuthProvider';
+import { signInWithSubscription } from '@frontend/auth/subscriptionSignIn';
 import { SupabaseUriHandler } from '@frontend/auth/UriHandler';
 import { createLanguageModelPort } from '@frontend/lm/createLanguageModelPort';
 import { registerLanguageModelTools } from '@frontend/lm/registerLanguageModelTools';
@@ -192,16 +195,15 @@ async function refreshApiKeyStatus() {
 }
 
 /**
- * Commands the getting-started walkthrough exposes as buttons. The walkthrough
- * opens right after install even when no folder is open — the state where
- * activation stops at the welcome view and never reaches `registerCommands` —
- * so without fallbacks every one of these buttons is a dead click. Each
+ * Workspace-bound commands the getting-started walkthrough exposes as buttons.
+ * The walkthrough opens right after install even when no folder is open — the
+ * state where activation stops at the welcome view and never reaches
+ * `registerCommands` — so without fallbacks every one of these buttons is a
+ * dead click. The credential commands are registered for real in that state
+ * (sign-in needs no folder); these need the workspace-backed platform, so each
  * fallback says why nothing can run yet and offers the two ways forward.
  */
 const WALKTHROUGH_COMMANDS_NEEDING_WORKSPACE = [
-  AUTH_COMMANDS.SIGN_IN,
-  'texra.auth.chatgpt.signIn',
-  EXTENSION_COMMANDS.SET_API_KEY,
   EXTENSION_COMMANDS.RUN_SETUP_ASSISTANT,
   'texra.showMultiAgent',
   'texra.showMainView',
@@ -216,7 +218,7 @@ async function explainWorkspaceRequired(extensionPath: string): Promise<void> {
   const openFolder = 'Open Folder';
   const createSample = 'Create Sample Project';
   const choice = await vscode.window.showInformationMessage(
-    'TeXRA activates once a single folder is open. Open your LaTeX project folder or create the sample project, then sign in and run agents from there.',
+    'TeXRA agents run inside a single-folder workspace. Open your LaTeX project folder or create the sample project first.',
     openFolder,
     createSample,
   );
@@ -224,6 +226,60 @@ async function explainWorkspaceRequired(extensionPath: string): Promise<void> {
     await vscode.commands.executeCommand('workbench.action.files.openFolder');
   } else if (choice === createSample) {
     await createSampleProjectWithoutWorkspace(extensionPath);
+  }
+}
+
+/**
+ * Register the TeXRA account (Supabase) authentication provider and its OAuth
+ * URI handler. Both activation paths run this: signing in stores the session
+ * in SecretStorage, which needs no workspace, so the welcome (no-folder) path
+ * offers the same sign-in the full path does.
+ */
+function registerSupabaseAuth(context: vscode.ExtensionContext): void {
+  try {
+    setRuntimeExtensionId(context.extension.id);
+    const authProvider = new SupabaseAuthProvider({
+      showError: (msg) => void vscode.window.showErrorMessage(msg),
+      showInfo: (msg) => void vscode.window.showInformationMessage(msg),
+      showSignInPrompt: async (reason) => {
+        const message =
+          reason === 'expired'
+            ? 'Your TeXRA session has expired. Please sign in again to access AI models and remote agents.'
+            : 'Your TeXRA session is no longer valid. Please sign in again to access AI models and remote agents.';
+        const action = await vscode.window.showWarningMessage(
+          message,
+          'Sign In',
+        );
+        if (action === 'Sign In') {
+          await vscode.commands
+            .executeCommand('texra.auth.signIn')
+            .then(undefined, (err: unknown) =>
+              authLog.error(
+                `Failed to trigger sign-in: ${toErrorMessage(err)}`,
+              ),
+            );
+        }
+      },
+    });
+    context.subscriptions.push(
+      vscode.authentication.registerAuthenticationProvider(
+        AUTH_PROVIDER_ID,
+        'TeXRA Account',
+        authProvider,
+        { supportsMultipleAccounts: false },
+      ),
+    );
+
+    const uriHandler = new SupabaseUriHandler();
+    context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));
+    authProvider.setUriHandler(uriHandler);
+
+    log.info('Supabase authentication provider registered');
+  } catch (error) {
+    SupabaseClient.setInitError(ensureError(error));
+    log.error(
+      `Failed to initialize Supabase authentication: ${toErrorMessage(error)}`,
+    );
   }
 }
 
@@ -250,6 +306,35 @@ async function activateExtension(context: vscode.ExtensionContext) {
 
   if (!workspaceFolders || workspaceFolders.length !== 1) {
     registerWelcomeView(context);
+    // Credential-only platform. Every sign-in path stores into SecretStorage
+    // (`platform().secrets`) and the global `~/.texra` config — none of it
+    // needs a folder — so the walkthrough's credential buttons work before
+    // one is open. Agents still require the workspace-backed platform below;
+    // opening a folder reloads the window into that path (welcomeView.ts).
+    const lifecycle = createLifecycleHost({
+      onError: (phase, error) =>
+        log.error(`Lifecycle ${phase} handler failed`, { data: error }),
+    });
+    lifecycleHost = lifecycle;
+    agentDirectories.initialize();
+    const storage = createNodeStorageProvider();
+    const config = await createExtensionTexraConfig(storage, undefined);
+    initPlatform(
+      createNodePlatform({
+        config,
+        globalState: context.globalState,
+        workspaceState: context.workspaceState,
+        getWorkspacePath: () => undefined,
+        storage,
+        secrets: new VscodeSecrets(context),
+        lifecycle,
+        agentDirectories,
+        agentResume: {
+          tryResumeStream: tryResumeFromResumeData,
+        },
+      }),
+    );
+    registerSupabaseAuth(context);
     // The full command surface (including the workspace-backed
     // `texra.createSampleProject`) is only registered on the single-folder
     // path below, so the welcome view registers its own standalone variant:
@@ -263,6 +348,17 @@ async function activateExtension(context: vscode.ExtensionContext) {
       vscode.commands.registerCommand(
         EXTENSION_COMMANDS.OPEN_GETTING_STARTED,
         () => openGettingStarted(context.extension.id),
+      ),
+      vscode.commands.registerCommand(AUTH_COMMANDS.SIGN_IN, () =>
+        authSignIn(),
+      ),
+      vscode.commands.registerCommand('texra.auth.chatgpt.signIn', () =>
+        signInWithSubscription('welcomeView', 'chatgpt'),
+      ),
+      // No settings view exists before a folder is open, so there is no
+      // credential surface to refresh after the key write.
+      vscode.commands.registerCommand(EXTENSION_COMMANDS.SET_API_KEY, () =>
+        apiSetApiKey(async () => {}),
       ),
       ...WALKTHROUGH_COMMANDS_NEEDING_WORKSPACE.map((command) =>
         vscode.commands.registerCommand(command, () =>
@@ -491,51 +587,7 @@ async function activateExtension(context: vscode.ExtensionContext) {
     })(),
   ]);
 
-  try {
-    setRuntimeExtensionId(context.extension.id);
-    const authProvider = new SupabaseAuthProvider({
-      showError: (msg) => void vscode.window.showErrorMessage(msg),
-      showInfo: (msg) => void vscode.window.showInformationMessage(msg),
-      showSignInPrompt: async (reason) => {
-        const message =
-          reason === 'expired'
-            ? 'Your TeXRA session has expired. Please sign in again to access AI models and remote agents.'
-            : 'Your TeXRA session is no longer valid. Please sign in again to access AI models and remote agents.';
-        const action = await vscode.window.showWarningMessage(
-          message,
-          'Sign In',
-        );
-        if (action === 'Sign In') {
-          await vscode.commands
-            .executeCommand('texra.auth.signIn')
-            .then(undefined, (err: unknown) =>
-              authLog.error(
-                `Failed to trigger sign-in: ${toErrorMessage(err)}`,
-              ),
-            );
-        }
-      },
-    });
-    context.subscriptions.push(
-      vscode.authentication.registerAuthenticationProvider(
-        AUTH_PROVIDER_ID,
-        'TeXRA Account',
-        authProvider,
-        { supportsMultipleAccounts: false },
-      ),
-    );
-
-    const uriHandler = new SupabaseUriHandler();
-    context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));
-    authProvider.setUriHandler(uriHandler);
-
-    log.info('Supabase authentication provider registered');
-  } catch (error) {
-    SupabaseClient.setInitError(ensureError(error));
-    log.error(
-      `Failed to initialize Supabase authentication: ${toErrorMessage(error)}`,
-    );
-  }
+  registerSupabaseAuth(context);
 
   // Usage logging is a runtime service, not an authentication-provider
   // capability. Initialize it even when Supabase sign-in is not configured,

--- a/packages/extension/src/frontend/ui/welcomeView.ts
+++ b/packages/extension/src/frontend/ui/welcomeView.ts
@@ -1,9 +1,13 @@
 import * as vscode from 'vscode';
 
+import { AUTH_COMMANDS } from '@auth/constants';
 import { EXTENSION_COMMANDS } from '@commands/extensionCommandIds';
+import { CHATGPT_AUTH } from '@shared/copy/accountAuth';
 import {
+  ONBOARDING_CHOICE_API_KEY,
   ONBOARDING_CHOICE_CHATGPT,
   ONBOARDING_NARRATIVE,
+  RESEARCHER_ACCESS,
 } from '@shared/copy/onboarding';
 
 /**
@@ -28,6 +32,9 @@ function renderWelcomeHtml(): string {
   const cloneRepo = 'command:git.clone';
   const createSample = `command:${EXTENSION_COMMANDS.CREATE_SAMPLE_PROJECT}`;
   const openWalkthrough = `command:${EXTENSION_COMMANDS.OPEN_GETTING_STARTED}`;
+  const signInChatGpt = 'command:texra.auth.chatgpt.signIn';
+  const setApiKey = `command:${EXTENSION_COMMANDS.SET_API_KEY}`;
+  const signInTexra = `command:${AUTH_COMMANDS.SIGN_IN}`;
   const docs = 'https://texra.ai';
 
   return /* html */ `
@@ -61,7 +68,15 @@ function renderWelcomeHtml(): string {
       display: grid;
       grid-template-columns: minmax(0, 1fr);
       gap: 8px;
-      margin: 16px 0;
+      margin: 8px 0 16px;
+    }
+    .section-label {
+      margin: 14px 0 4px;
+      font-weight: 600;
+      text-transform: uppercase;
+      font-size: 0.85em;
+      letter-spacing: 0.04em;
+      color: color-mix(in srgb, var(--vscode-foreground) 80%, transparent);
     }
     a {
       color: var(--vscode-textLink-foreground);
@@ -110,10 +125,21 @@ function renderWelcomeHtml(): string {
   </p>
   <p>${ONBOARDING_NARRATIVE}</p>
   <ol>
+    <li>Connect a credential: ${ONBOARDING_CHOICE_CHATGPT.label} or a provider API key. You can do that right here.</li>
     <li>Open a single-folder workspace containing your LaTeX project, or start with the sample project.</li>
-    <li>The main view will show the credential picker: ${ONBOARDING_CHOICE_CHATGPT.label} or a provider API key.</li>
     <li>Run setup once to check LaTeX, apply the right team, and launch the first review.</li>
   </ol>
+  <p class="section-label">Connect</p>
+  <div class="actions">
+    <a class="button secondary" href="${signInChatGpt}">${CHATGPT_AUTH.signInLabel}</a>
+    <a class="button secondary" href="${setApiKey}">Set API key &mdash; ${ONBOARDING_CHOICE_API_KEY.description}</a>
+  </div>
+  <p class="muted">
+    Signing in to TeXRA (${RESEARCHER_ACCESS.label}) separately unlocks the
+    hosted research-agent catalog, including the orchestrator.
+    <a href="${signInTexra}">Sign In</a>
+  </p>
+  <p class="section-label">Open your project</p>
   <div class="actions">
     <a class="button" href="${openFolder}">Open Folder</a>
     <a class="button secondary" href="${createSample}">Try the Sample Project</a>


### PR DESCRIPTION
Activation without a single folder open stops at the welcome view and
never reaches registerCommands, so the getting-started walkthrough's
buttons (Sign in with ChatGPT, Set API key, Sign In, and the later
steps) dispatched commands that were never registered — clicking them
did nothing. The walkthrough opens right after install, before most
users have opened a folder, so this was the first-run experience.

Register a fallback for each walkthrough-linked command on the
no-workspace path that explains the single-folder requirement and
offers Open Folder / Create Sample Project; opening a folder reloads
the window into the full activation path as before.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018ChJPNVYo5dX42GngNt6Yv