### PR TITLE
refactor(session): fold badges invalidation into invalidate(streamId, slice)

### DIFF
--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -44,7 +44,7 @@ export function unbindChildStreamState(state: SessionState): void {
 /**
  * Re-derive the child-stream snapshots from the bound `SessionState`. Called
  * by the adapter after any change that can move rosters, parent edges, or
- * tombstones: `onBadgesChanged`, `invalidate(…, 'parentStreamId')`,
+ * tombstones: `invalidate(…, 'subagents')`, `invalidate(…, 'parentStreamId')`,
  * `onStreamMetadataChanged` (a new RUNNING drops the previous run's retained
  * rows and surfaces only here), and the adapter's `deleteStream` removal hook
  * (removal fires no renderer-port callback by design).

--- a/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
+++ b/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
@@ -94,10 +94,12 @@ class TuiSessionRenderer implements SessionRendererPort {
       case 'parentStreamId':
       case 'queuedFollowUps':
       case 'contextState':
+      case 'subagents':
         // The applier already landed the edge / the session-owned queue /
-        // the model handler's context snapshot on `SessionState`; the CLI's
-        // topology snapshot, `queuedFollowUpsFor`, and the status bar's
-        // `streamStateFor` read re-derive from there at paint.
+        // the model handler's context snapshot / the child-activity roster
+        // on `SessionState`; the CLI's topology snapshot, `queuedFollowUpsFor`,
+        // and the status bar's `streamStateFor` read re-derive from there at
+        // paint.
         return invalidateChildStreams();
       case 'goalPaused':
         return appendLocalAssistantTranscript(
@@ -147,13 +149,6 @@ class TuiSessionRenderer implements SessionRendererPort {
   onStageChanged(_streamId: StreamTabId, _stage: StreamStage): void {
     // `StreamExecutionState.stage` is written by the applier before this
     // callback; renderers re-read it.
-    invalidateChildStreams();
-  }
-
-  onBadgesChanged(_streamId: StreamTabId): void {
-    // The shared applier already landed this roster on `SessionState` — live
-    // rows plus the finished children it retains for display (phase-merged,
-    // 200-capped). The CLI reads it there; only the snapshots re-derive.
     invalidateChildStreams();
   }
 

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -400,7 +400,9 @@ class HeadlessPort implements SessionRendererPort {
 
   dispose(): void {}
 
-  invalidate(_streamId: StreamTabId, _slice: SessionRenderSlice): void {}
+  invalidate(streamId: StreamTabId, slice: SessionRenderSlice): void {
+    if (slice === 'subagents') this.renderer.refreshFor(streamId, true);
+  }
 
   onStreamMetadataChanged(
     streamId: StreamTabId,
@@ -433,10 +435,6 @@ class HeadlessPort implements SessionRendererPort {
 
   onStageChanged(streamId: StreamTabId, _stage: StreamStage): void {
     this.renderer.refreshFor(streamId);
-  }
-
-  onBadgesChanged(streamId: StreamTabId): void {
-    this.renderer.refreshFor(streamId, true);
   }
 
   onRunUsageChanged(

--- a/src/controllers/progressView/backend/LitSessionRenderer.ts
+++ b/src/controllers/progressView/backend/LitSessionRenderer.ts
@@ -204,6 +204,8 @@ export class LitSessionRenderer implements SessionRendererPort {
         // Lit surfaces pause via the goal chip (`goalStateChanged`); no
         // transcript notice, unlike the TUI.
         return;
+      case 'subagents':
+        return this.updateStreamMetadata(streamId);
     }
     assertNever(slice, 'Unhandled session render slice');
   }
@@ -224,10 +226,6 @@ export class LitSessionRenderer implements SessionRendererPort {
       return;
     }
     this.sendIfActive(streamId, () => this.updateStreamMetadata(streamId));
-  }
-
-  onBadgesChanged(streamId: StreamTabId): void {
-    this.updateStreamMetadata(streamId);
   }
 
   onRunUsageChanged(

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -792,7 +792,7 @@ export class SessionFactApplier {
       return { ...prev, subagents: [...live, ...retained] };
     });
 
-    this.renderer.onBadgesChanged(parentStreamId);
+    this.renderer.invalidate(parentStreamId, 'subagents');
   }
 
   private notifyRosterParents(parents: readonly StreamTabId[]): void {
@@ -808,7 +808,7 @@ export class SessionFactApplier {
           withEventErrorHandling(
             'SessionFacts',
             `failed to notify roster changes for ${parent}`,
-            () => this.renderer.onBadgesChanged(parent),
+            () => this.renderer.invalidate(parent, 'subagents'),
           );
         }
       },

--- a/src/controllers/session/SessionRendererPort.ts
+++ b/src/controllers/session/SessionRendererPort.ts
@@ -20,10 +20,10 @@ export type PresentedStreamId = StreamTabId | '';
  * rather than receiving on the wire. Each key names the field the host reads
  * (`outputs.files`, `outputs.missingOutputs`, `outputs.compileFailures`, `workPlan.queuedFollowUps`,
  * `SessionStreamMetadata.parentStreamId`,
- * `StreamExecutionState.contextState`) or the fact it reacts to
- * (`goalPaused`); nothing here is new vocabulary. Slices whose notification
- * carries real delta semantics — `onStageChanged`'s phase-vs-round split —
- * keep their own method.
+ * `StreamExecutionState.contextState`, `SessionState.getStreamState(streamId).subagents`)
+ * or the fact it reacts to (`goalPaused`); nothing here is new vocabulary.
+ * Slices whose notification carries real delta semantics —
+ * `onStageChanged`'s phase-vs-round split — keep their own method.
  */
 export type SessionRenderSlice =
   | 'files'
@@ -32,7 +32,8 @@ export type SessionRenderSlice =
   | 'queuedFollowUps'
   | 'parentStreamId'
   | 'contextState'
-  | 'goalPaused';
+  | 'goalPaused'
+  | 'subagents';
 
 /**
  * Host-renderer notifications from {@link SessionFactApplier}.
@@ -83,10 +84,6 @@ export interface SessionRendererPort {
    * other hosts project the slot verbatim.
    */
   onStageChanged(streamId: StreamTabId, stage: StreamStage): void;
-
-  /** The stream's child-activity roster changed; hosts re-read
-   *  `SessionState.getStreamState(streamId).subagents`. */
-  onBadgesChanged(streamId: StreamTabId): void;
 
   onRunUsageChanged(
     streamId: StreamTabId,

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -261,7 +261,7 @@ describe('ProgressBackend', () => {
       backend.state.streamLogs.ensureStream(streamId);
       backend.state.getOrCreateStreamState(streamId, AgentCategory.ToolUse);
       setChildRoster(backend, parent, [before, child, after]);
-      const badgesChanged = vi.spyOn(backend.renderer, 'onBadgesChanged');
+      const invalidate = vi.spyOn(backend.renderer, 'invalidate');
 
       emitRemoveStream(target, streamId);
 
@@ -272,7 +272,7 @@ describe('ProgressBackend', () => {
         before,
         after,
       ]);
-      expect(badgesChanged).toHaveBeenLastCalledWith(parent);
+      expect(invalidate).toHaveBeenCalledWith(parent, 'subagents');
     } finally {
       await backend.state.clearAll();
     }
@@ -378,7 +378,7 @@ describe('ProgressBackend', () => {
     vi.spyOn(session.executions, 'getAgentHandleByStream').mockReturnValue(
       {} as never,
     );
-    const badgesChanged = vi.spyOn(backend.renderer, 'onBadgesChanged');
+    const invalidate = vi.spyOn(backend.renderer, 'invalidate');
 
     expect(
       backend.applySessionFact({
@@ -387,7 +387,7 @@ describe('ProgressBackend', () => {
       }),
     ).toBe(true);
     expect(backend.state.getStreamState(parent)?.subagents).toEqual([]);
-    expect(badgesChanged).toHaveBeenCalledWith(parent);
+    expect(invalidate).toHaveBeenCalledWith(parent, 'subagents');
   });
 
   it('keeps superseded settlements from revealing rows across parent and child reclaims', () => {
@@ -1301,11 +1301,17 @@ describe('ProgressBackend', () => {
     // The notification no longer carries the roster, so capture what a host
     // would re-read at scrub time to keep the scrub→restore sequence observable.
     let rosterDuringScrub: ActiveChildInfo[] | undefined;
-    const badgesChanged = vi
-      .spyOn(backend.renderer, 'onBadgesChanged')
-      .mockImplementationOnce(() => {
-        rosterDuringScrub = backend.state.getStreamState(parent)?.subagents;
-        throw new Error('renderer unavailable during roster scrub');
+    let subagentsScrubThrown = false;
+    const realInvalidate = backend.renderer.invalidate.bind(backend.renderer);
+    const invalidate = vi
+      .spyOn(backend.renderer, 'invalidate')
+      .mockImplementation((invalidatedStreamId, slice) => {
+        if (slice === 'subagents' && !subagentsScrubThrown) {
+          subagentsScrubThrown = true;
+          rosterDuringScrub = backend.state.getStreamState(parent)?.subagents;
+          throw new Error('renderer unavailable during roster scrub');
+        }
+        return realInvalidate(invalidatedStreamId, slice);
       });
     const clearStream = vi
       .spyOn(backend.state, 'clearStream')
@@ -1324,7 +1330,7 @@ describe('ProgressBackend', () => {
     expect(backend.state.isStreamRemoved(stream)).toBe(false);
     expect(backend.state.getStreamState(parent)?.subagents).toEqual(roster);
     expect(rosterDuringScrub).toEqual([before, after]);
-    expect(badgesChanged).toHaveBeenCalledWith(parent);
+    expect(invalidate).toHaveBeenCalledWith(parent, 'subagents');
     expect(lifecycle.notifyDeletionRetained).toHaveBeenCalledWith(0, 1);
   });
 


### PR DESCRIPTION
## Summary

Repo-wide audit for overlapping/duplicated responsibilities turned up one clear case: `SessionRendererPort` carries two notification idioms for the same kind of fact — a generic `invalidate(streamId, slice)` dispatcher for payload-free slices, and a set of dedicated `on<Thing>Changed` methods. `onBadgesChanged(streamId)` was payload-free exactly like the seven existing `invalidate` slices, and all three host implementations (`LitSessionRenderer`, the CLI's `TuiSessionRenderer`, and the headless `HeadlessPort`) already re-read shared state the same way an `invalidate` arm does — the TUI's body was byte-identical to an arm already sitting a few lines away in its own switch; Lit's body was byte-identical to its separate `onStreamDescriptionChanged` method. This PR finishes the same fold #11493 already applied to the sibling `onMissingOutputsChanged` slice.

## Issue acceptance gates

No filed issue. Scoped from a codebase-wide review for confusing/overlapping responsibilities; this is the one candidate that survived adversarial verification as a genuine net simplification with low risk (three known implementors, exhaustive `assertNever` switches on two of the three, one shared test file).

## Single source of truth

`SessionRendererPort.invalidate(streamId, slice)` is now the sole notification path for every payload-free projection slice, including the child-activity roster (`'subagents'`). No new coordinator; an existing one absorbs a member that never needed its own name.

## Duplication and abstraction budget

Removed: one interface method (`onBadgesChanged`) plus three near-duplicate per-host implementations that each re-read `SessionState`/`StreamSnapshotStore` the same way an existing `invalidate` arm (or sibling method) already did. No new abstraction added — the fix is folding a redundant idiom into the one that already exists for this exact shape of notification.

## Net elements (R6)

- 7 files changed, 35 insertions(+), 41 deletions(-) (`git diff --stat`)
- Removed: 1 interface method (`SessionRendererPort.onBadgesChanged`) + 3 host implementations (`LitSessionRenderer`, `TuiSessionRenderer`, `HeadlessPort`)
- Added: 1 union member (`'subagents'` on `SessionRenderSlice`) + a `case 'subagents':` arm in Lit and TUI's existing `invalidate` switches, and one `if (slice === 'subagents')` branch in `HeadlessPort.invalidate` (which was already an `if`-based no-op, not a switch)
- Net: −4 named methods, +0 named methods (only switch-case/if branches inside already-existing dispatchers)

## Consumer counts (R8)

`onBadgesChanged` had exactly 2 production call sites, both in `SessionFactApplier.ts` (repointed to `invalidate(id, 'subagents')`), and exactly 3 test call sites in `ProgressBackendStreamLifecycle.vitest.ts` (`grep -rn onBadgesChanged` returns none after this change). No other production or test file referenced it.

## Host impact

Extension: `LitSessionRenderer.invalidate` gains a `'subagents'` arm calling the existing `updateStreamMetadata(streamId)` (unchanged behavior; self-guards on `isAvailable()` as before).

Desktop: shares the extension's `LitSessionRenderer` — same change, no desktop-specific code touched.

CLI: `TuiSessionRenderer.invalidate` folds `'subagents'` into its existing `invalidateChildStreams()` group; the headless `HeadlessPort.invalidate` (previously an unconditional no-op) gains one conditional arm calling `refreshFor(streamId, true)` for the `'subagents'` slice only, matching its prior `onBadgesChanged` body.

## Scheduled refactoring

None — this closes out the badges half of the payload-free-methods fold that #11493 started for `onMissingOutputsChanged`.

## Validation

- `npm run typecheck` — clean across workspace, test-kernel, agent, cli, trace-viewer, desktop
- `npx vitest run src/test-kernel/progressView src/test-kernel/controllers/session` — 56 files / 536 tests passed
- `npx vitest run src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts` — 44/44 passed, including the three updated spy sites (one converted to a slice-filtered `mockImplementation` with its own once-guard, since a bare `mockImplementationOnce` on the shared `invalidate` spy would otherwise fire on whichever slice happens to be dispatched first)
- `npx eslint` on all seven changed files — clean
- `npm run check:dead-code-ratchet` — no new findings (379 baselined, 379 found)
- Two automated reviews (`claude-review-anthropic`, `texra-ai review`) both passed with no code issues raised

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dast77AuGvswGZY4krRXF7)_