### PR TITLE
refactor: dedup adapter boilerplate across CLI, extension, and subscriptions

### DIFF
--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -457,40 +457,6 @@ export function registerBuiltinSlashCommands(options?: {
     );
   }
 
-  function MemoryListFormAdapter(props: SlashFormProps): React.JSX.Element {
-    return (
-      <MemoryListForm
-        availableRows={props.availableRows}
-        onSelect={formSelectionHandler<string>({
-          action: (value) => options?.onMemorySelect?.(value),
-          onDone: props.onDone,
-          onError: options?.onError,
-          completion: 'beforeAction',
-          onPersist: props.onPersist,
-          echoOnPersist: props.echoOnPersist,
-        })}
-        onClose={() => props.onDone(undefined)}
-      />
-    );
-  }
-
-  function ResumeListFormAdapter(props: SlashFormProps): React.JSX.Element {
-    return (
-      <ResumeListForm
-        availableRows={props.availableRows}
-        onSelect={formSelectionHandler<ExecutionId>({
-          action: (id) => options?.onResumeSelect?.(id),
-          onDone: props.onDone,
-          onError: options?.onError,
-          completion: 'beforeAction',
-          onPersist: props.onPersist,
-          echoOnPersist: props.echoOnPersist,
-        })}
-        onClose={() => props.onDone(undefined)}
-      />
-    );
-  }
-
   function ToolsListFormAdapter(props: SlashFormProps): React.JSX.Element {
     return (
       <ToolsListForm
@@ -500,12 +466,22 @@ export function registerBuiltinSlashCommands(options?: {
     );
   }
 
-  function SkillsListFormAdapter(props: SlashFormProps): React.JSX.Element {
-    return (
-      <SkillsListForm
+  // The plain list pickers differ only by their form and their selection
+  // action; the completion mode, error routing, and persistence plumbing are
+  // one shape, owned here rather than copied per command.
+  function makeSelectFormAdapter<T>(
+    Form: React.ComponentType<{
+      readonly availableRows?: number;
+      readonly onSelect: (value: T) => void;
+      readonly onClose: () => void;
+    }>,
+    action: (value: T) => FormActionResult,
+  ): React.ComponentType<SlashFormProps> {
+    return (props) => (
+      <Form
         availableRows={props.availableRows}
-        onSelect={formSelectionHandler<SkillActivation>({
-          action: (value) => options?.onSkillSelect?.(value),
+        onSelect={formSelectionHandler<T>({
+          action,
           onDone: props.onDone,
           onError: options?.onError,
           completion: 'beforeAction',
@@ -516,6 +492,19 @@ export function registerBuiltinSlashCommands(options?: {
       />
     );
   }
+
+  const MemoryListFormAdapter = makeSelectFormAdapter(
+    MemoryListForm,
+    (value: string) => options?.onMemorySelect?.(value),
+  );
+  const ResumeListFormAdapter = makeSelectFormAdapter(
+    ResumeListForm,
+    (id: ExecutionId) => options?.onResumeSelect?.(id),
+  );
+  const SkillsListFormAdapter = makeSelectFormAdapter(
+    SkillsListForm,
+    (value: SkillActivation) => options?.onSkillSelect?.(value),
+  );
 
   registerSlashCommand({
     name: 'help',

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -88,6 +88,61 @@ import type { StreamView } from '../state/streamViews';
 
 const SUBAGENT_SUMMARY_MAX_COLUMNS = 100;
 
+/** Emphasis a row segment inherits from its host row: the dashboard heading
+ *  renders bold and warning-colored, plain rows do neither. */
+interface SegmentStyle {
+  readonly bold?: boolean;
+  readonly color?: string;
+}
+
+/** One inline segment of a single-line row: a cell that may shrink to nothing
+ *  and truncates rather than wrapping. `flexShrink` carries the significance
+ *  order — higher numbers yield first as the row narrows. */
+function RowSegment({
+  bold,
+  children,
+  color,
+  dimColor,
+  flexShrink,
+}: SegmentStyle & {
+  readonly children: React.ReactNode;
+  readonly dimColor?: boolean;
+  readonly flexShrink: number;
+}): React.JSX.Element {
+  return (
+    <Box minWidth={0} flexShrink={flexShrink}>
+      <Text bold={bold} color={color} dimColor={dimColor} wrap="truncate-end">
+        {children}
+      </Text>
+    </Box>
+  );
+}
+
+/** The ` · <kind>` pending-approval suffix shared by session rows, workflow
+ *  task rows, and the dashboard heading. The kind is actionable so it never
+ *  shrinks; the overflow count is informational and yields early. */
+function ApprovalSegments({
+  approval,
+  bold,
+  color,
+}: SegmentStyle & {
+  readonly approval: ReturnType<typeof pendingApprovalRowDisplay>;
+}): React.JSX.Element | null {
+  if (!approval) return null;
+  return (
+    <>
+      <Box flexShrink={0}>
+        <Text bold={bold} color={color}>{` · ${approval.label}`}</Text>
+      </Box>
+      {approval.overflow ? (
+        <RowSegment bold={bold} color={color} flexShrink={3}>
+          {` ${approval.overflow}`}
+        </RowSegment>
+      ) : null}
+    </>
+  );
+}
+
 /**
  * One phase row of the dashboard, in both layouts: name, the phase's own
  * `done/total · N running · N failed`, and one glyph per issued call — the
@@ -234,36 +289,23 @@ function SessionRow({
       <Text aria-hidden color={childStatusColor(status)}>
         {CHILD_STATUS_MARKER}
       </Text>
-      <Box minWidth={0} flexShrink={1}>
-        <Text bold={active} wrap="truncate-end">
-          {session.label}
-          {statusLabel ? ` ${statusLabel}` : ''}
-          {stageLabel ? ` · ${stageLabel}` : ''}
-          {modelLabel ? ` · ${modelLabel}` : ''}
-          {!metadataColumn && elapsed ? ` · ${elapsed}` : ''}
-        </Text>
-      </Box>
+      <RowSegment bold={active} flexShrink={1}>
+        {session.label}
+        {statusLabel ? ` ${statusLabel}` : ''}
+        {stageLabel ? ` · ${stageLabel}` : ''}
+        {modelLabel ? ` · ${modelLabel}` : ''}
+        {!metadataColumn && elapsed ? ` · ${elapsed}` : ''}
+      </RowSegment>
       {summary ? (
-        <Box minWidth={0} flexShrink={2}>
-          <Text dimColor wrap="truncate-end">
-            {` · ${truncateSummaryToWidth(summary, SUBAGENT_SUMMARY_MAX_COLUMNS)}`}
-          </Text>
-        </Box>
+        <RowSegment dimColor flexShrink={2}>
+          {` · ${truncateSummaryToWidth(summary, SUBAGENT_SUMMARY_MAX_COLUMNS)}`}
+        </RowSegment>
       ) : null}
-      {approval ? (
-        <Box flexShrink={0}>
-          <Text>{` · ${approval.label}`}</Text>
-        </Box>
-      ) : null}
-      {approval?.overflow ? (
-        <Box minWidth={0} flexShrink={3}>
-          <Text wrap="truncate-end">{` ${approval.overflow}`}</Text>
-        </Box>
-      ) : null}
+      <ApprovalSegments approval={approval} />
       {focused && hiddenRowSummary ? (
-        <Box minWidth={0} flexShrink={4}>
-          <Text dimColor wrap="truncate-end">{` · ${hiddenRowSummary}`}</Text>
-        </Box>
+        <RowSegment dimColor flexShrink={4}>
+          {` · ${hiddenRowSummary}`}
+        </RowSegment>
       ) : null}
       {metadataText ? (
         <>
@@ -333,32 +375,17 @@ function WorkflowTaskRow({
           {dashboardMarkerCell(style.marker)}
         </Text>
       </Box>
-      <Box minWidth={0} flexShrink={1}>
-        <Text wrap="truncate-end">{entry.call.label}</Text>
-      </Box>
+      <RowSegment flexShrink={1}>{entry.call.label}</RowSegment>
       {/* The status word outranks the metadata column: it is its own segment
           at the label's shrink weight, so a wide row sheds metadata (weight 2)
           long before it clips `· Running`, instead of the two sharing one
           truncating box where the status was always the half that was cut. */}
-      <Box minWidth={0} flexShrink={1}>
-        <Text wrap="truncate-end">
-          {` · ${WORKFLOW_TASK_STATUS_LABEL[entry.call.status]}`}
-        </Text>
-      </Box>
-      {approval ? (
-        <Box flexShrink={0}>
-          <Text>{` · ${approval.label}`}</Text>
-        </Box>
-      ) : null}
-      {approval?.overflow ? (
-        <Box minWidth={0} flexShrink={3}>
-          <Text wrap="truncate-end">{` ${approval.overflow}`}</Text>
-        </Box>
-      ) : null}
+      <RowSegment flexShrink={1}>
+        {` · ${WORKFLOW_TASK_STATUS_LABEL[entry.call.status]}`}
+      </RowSegment>
+      <ApprovalSegments approval={approval} />
       {metadata ? (
-        <Box minWidth={0} flexShrink={2}>
-          <Text dimColor wrap="truncate-end">{`  ${metadata}`}</Text>
-        </Box>
+        <RowSegment dimColor flexShrink={2}>{`  ${metadata}`}</RowSegment>
       ) : null}
     </Box>
   );
@@ -520,34 +547,21 @@ function WorkflowDashboard({
       width={columns}
     >
       <Box flexDirection="row" height={1} minWidth={0} overflowY="hidden">
-        <Box minWidth={0} flexShrink={1}>
-          <Text bold wrap="truncate-end">
-            {heading}
-          </Text>
-        </Box>
+        <RowSegment bold flexShrink={1}>
+          {heading}
+        </RowSegment>
         {failed > 0 ? (
           // A pending approval needs action, so this tally yields before the
           // fixed approval suffix when the two cannot both fit.
-          <Box minWidth={0} flexShrink={2}>
-            <Text bold color={COLOR_WARNING} wrap="truncate-end">
-              {` · ${failed} failed`}
-            </Text>
-          </Box>
+          <RowSegment bold color={COLOR_WARNING} flexShrink={2}>
+            {` · ${failed} failed`}
+          </RowSegment>
         ) : null}
-        {sessionApproval ? (
-          <Box flexShrink={0}>
-            <Text bold color={COLOR_WARNING}>
-              {` · ${sessionApproval.label}`}
-            </Text>
-          </Box>
-        ) : null}
-        {sessionApproval?.overflow ? (
-          <Box minWidth={0} flexShrink={3}>
-            <Text bold color={COLOR_WARNING} wrap="truncate-end">
-              {` ${sessionApproval.overflow}`}
-            </Text>
-          </Box>
-        ) : null}
+        <ApprovalSegments
+          approval={sessionApproval}
+          bold
+          color={COLOR_WARNING}
+        />
       </Box>
       {wide ? (
         <Box flexDirection="row" height={contentRows} minWidth={0}>

--- a/packages/extension/src/common/webview/BaseViewMessageHandler.ts
+++ b/packages/extension/src/common/webview/BaseViewMessageHandler.ts
@@ -91,6 +91,20 @@ export abstract class BaseViewMessageHandler<
   }
 
   /**
+   * Post a message to the active view's webview, awaiting delivery. A `null`
+   * or `undefined` message posts nothing, so callers can forward an optional
+   * response payload without a guard of their own. Unlike
+   * {@link postToActiveView}, this resolves only after the post settles —
+   * mutation paths that run a follow-up step depend on that ordering.
+   */
+  protected async postMessageToActiveWebview(message: unknown): Promise<void> {
+    if (message == null) return;
+    await this.withActiveWebview(async (webview) => {
+      await webview.postMessage(message);
+    });
+  }
+
+  /**
    * Schema-driven dispatch shared by views that route through a typed
    * {@link DispatcherFn}. Tracks the active view, runs the dispatcher, logs
    * Zod validation failures at debug (expected, frequent) and handler

--- a/packages/extension/src/common/webview/BaseWebviewProvider.ts
+++ b/packages/extension/src/common/webview/BaseWebviewProvider.ts
@@ -4,15 +4,20 @@ import * as vscode from 'vscode';
 // Local imports
 import { DisposableStore } from '@platform/disposable';
 
+import type { BundledViewContentProvider } from './BaseViewContentProvider';
+
 /**
  * Base class for webview providers.
- * Holds the active view, its message handler, and disposable management;
- * each provider wires up its own view (sidebar or panel).
+ * Holds the active view, its content provider, its message handler, and
+ * disposable management; each provider wires up its own view (sidebar or
+ * panel).
  */
 export abstract class BaseWebviewProvider {
   protected _view?: vscode.WebviewView | vscode.WebviewPanel;
   protected readonly _disposables = new DisposableStore();
   protected _viewDisposables = new DisposableStore();
+
+  protected abstract contentProvider: BundledViewContentProvider;
 
   protected abstract messageHandler: {
     handleMessage(
@@ -23,6 +28,25 @@ export abstract class BaseWebviewProvider {
   };
 
   constructor(protected readonly context: vscode.ExtensionContext) {}
+
+  /**
+   * Render this provider's HTML into `view` and route the view's inbound
+   * messages to this provider's handler. The returned disposable removes that
+   * listener; callers keep it wherever the listener's lifetime belongs (a view
+   * disposable store, or the single slot a swappable surface reassigns).
+   *
+   * Public because the sidebar is one VS Code view slot two providers share:
+   * MainViewProvider hands the slot to the progress view by calling this on
+   * ProgressViewProvider.
+   */
+  public setupWebviewContent(
+    view: vscode.WebviewView | vscode.WebviewPanel,
+  ): vscode.Disposable {
+    view.webview.html = this.contentProvider.getHtmlContent(view.webview);
+    return view.webview.onDidReceiveMessage((message) =>
+      this.messageHandler.handleMessage(message, view),
+    );
+  }
 
   protected cleanupView(): void {
     const disposables = this._viewDisposables;

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -206,18 +206,6 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     await this._mainViewProvider?.refreshOnboardingFunnel();
   }
 
-  public getContentProvider(): BundledViewContentProvider {
-    return this.contentProvider;
-  }
-
-  /** Routes a sidebar message to the progress view message handler. */
-  public handleSidebarMessage(
-    message: unknown,
-    view: vscode.WebviewView,
-  ): void {
-    void this.messageHandler.handleMessage(message, view);
-  }
-
   /** The sidebar stopped showing progress content; its handshake is void. */
   public resetSidebarReady(): void {
     if (this.target?.placement === 'sidebar') this.target.ready = false;
@@ -225,15 +213,6 @@ export class ProgressViewProvider extends BaseWebviewProvider {
 
   public static getInstance(): ProgressViewProvider | undefined {
     return this._instance;
-  }
-
-  private setupWebviewContent(
-    view: vscode.WebviewView | vscode.WebviewPanel,
-  ): vscode.Disposable {
-    view.webview.html = this.contentProvider.getHtmlContent(view.webview);
-    return view.webview.onDidReceiveMessage((message) =>
-      this.messageHandler.handleMessage(message, view),
-    );
   }
 
   public syncFullView(): void {

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -128,6 +128,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       log: this.log,
       extensionContext: context,
       withActiveWebview: (fn) => this.withActiveWebview(fn),
+      postMessageToActiveWebview: (message) =>
+        this.postMessageToActiveWebview(message),
     };
 
     // Must build inside the constructor: the platform is initialized by
@@ -768,13 +770,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
   private async openExternalUrl(url: string): Promise<void> {
     await vscode.env.openExternal(vscode.Uri.parse(url));
-  }
-
-  private async postMessageToActiveWebview(message: unknown): Promise<void> {
-    if (message == null) return;
-    await this.withActiveWebview(async (webview) => {
-      await webview.postMessage(message);
-    });
   }
 
   private async setModelEnabled(

--- a/packages/extension/src/settingsView/SettingsViewProvider.ts
+++ b/packages/extension/src/settingsView/SettingsViewProvider.ts
@@ -90,12 +90,7 @@ export class SettingsViewProvider extends BaseWebviewProvider {
 
       this.cleanupView();
       this._view = panel;
-      panel.webview.html = this.contentProvider.getHtmlContent(panel.webview);
-      this._viewDisposables.add(
-        panel.webview.onDidReceiveMessage((message) =>
-          this.messageHandler.handleMessage(message, panel),
-        ),
-      );
+      this._viewDisposables.add(this.setupWebviewContent(panel));
       this._viewDisposables.add(
         panel.onDidDispose(this.cleanupView.bind(this)),
       );

--- a/packages/extension/src/settingsView/handlers/SettingsHandlerContext.ts
+++ b/packages/extension/src/settingsView/handlers/SettingsHandlerContext.ts
@@ -18,6 +18,8 @@ export interface SettingsHandlerContext {
   withActiveWebview: (
     fn: (w: vscode.Webview) => Promise<void>,
   ) => Promise<void>;
+  /** Post a message to the active webview; a nullish message posts nothing. */
+  postMessageToActiveWebview: (message: unknown) => Promise<void>;
 }
 
 /**

--- a/packages/extension/src/settingsView/handlers/memoryHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/memoryHandlers.ts
@@ -100,8 +100,9 @@ export class MemoryHandlers {
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.DELETE_MEMORY>,
   ): Promise<void> {
     try {
-      await this.settingsHost.deleteMemory(data, (message) =>
-        this.postMessageToActiveWebview(message),
+      await this.settingsHost.deleteMemory(
+        data,
+        this.ctx.postMessageToActiveWebview,
       );
     } catch (error) {
       await showLoggedErrorMessage(
@@ -115,8 +116,10 @@ export class MemoryHandlers {
 
   async setMemoryPinned(storagePath: string, pinned: boolean): Promise<void> {
     try {
-      await this.settingsHost.setMemoryPinned(storagePath, pinned, (message) =>
-        this.postMessageToActiveWebview(message),
+      await this.settingsHost.setMemoryPinned(
+        storagePath,
+        pinned,
+        this.ctx.postMessageToActiveWebview,
       );
     } catch (error) {
       const action = pinned ? 'pin' : 'unpin';
@@ -126,12 +129,5 @@ export class MemoryHandlers {
         error,
       );
     }
-  }
-
-  private async postMessageToActiveWebview(message: unknown): Promise<void> {
-    if (message == null) return;
-    await this.ctx.withActiveWebview(async (webview) => {
-      await webview.postMessage(message);
-    });
   }
 }

--- a/packages/extension/src/webview/MainViewProvider.ts
+++ b/packages/extension/src/webview/MainViewProvider.ts
@@ -342,13 +342,7 @@ export class MainViewProvider
     this._view = webviewView;
 
     this.mainWebviewReady = false;
-    webviewView.webview.html = this.contentProvider.getHtmlContent(
-      webviewView.webview,
-    );
-
-    this._messageDisposable = webviewView.webview.onDidReceiveMessage(
-      (message) => this.messageHandler.handleMessage(message, webviewView),
-    );
+    this._messageDisposable = this.setupWebviewContent(webviewView);
 
     this._viewDisposables.add(
       webviewView.onDidDispose(this.cleanupView.bind(this)),
@@ -439,21 +433,11 @@ export class MainViewProvider
       // finished across an await (polished instruction text, a transcription)
       // would be posted into the progress document that replaced it.
       this.messageHandler.clearActiveView();
-      const pvp = this._progressViewProvider!;
-      webviewView.webview.html = pvp
-        .getContentProvider()
-        .getHtmlContent(webviewView.webview);
-      this._messageDisposable = webviewView.webview.onDidReceiveMessage(
-        (message) => pvp.handleSidebarMessage(message, webviewView),
-      );
+      this._messageDisposable =
+        this._progressViewProvider!.setupWebviewContent(webviewView);
     } else {
       this._progressViewProvider?.resetSidebarReady();
-      webviewView.webview.html = this.contentProvider.getHtmlContent(
-        webviewView.webview,
-      );
-      this._messageDisposable = webviewView.webview.onDidReceiveMessage(
-        (message) => this.messageHandler.handleMessage(message, webviewView),
-      );
+      this._messageDisposable = this.setupWebviewContent(webviewView);
     }
   }
 

--- a/src/controllers/modelAccess/subscriptionUsage/codexUsageAdapter.ts
+++ b/src/controllers/modelAccess/subscriptionUsage/codexUsageAdapter.ts
@@ -2,7 +2,7 @@ import type { SubscriptionUsageWindow } from '@shared/schemas';
 
 import {
   asObject,
-  assertSubscriptionUsageResponse,
+  fetchSubscriptionUsage,
   numberField,
   stringField,
   timestampField,
@@ -134,11 +134,11 @@ export async function fetchChatGptUsage(
   if (credential.accountId) {
     headers['ChatGPT-Account-Id'] = credential.accountId;
   }
-  const response = await http(CHATGPT_USAGE_URL, {
-    method: 'GET',
-    headers,
-    signal,
-  });
-  assertSubscriptionUsageResponse(response);
-  return parseChatGptUsage(await response.json());
+  return parseChatGptUsage(
+    await fetchSubscriptionUsage(http, {
+      url: CHATGPT_USAGE_URL,
+      headers,
+      signal,
+    }),
+  );
 }

--- a/src/controllers/modelAccess/subscriptionUsage/glmCodingPlanUsageAdapter.ts
+++ b/src/controllers/modelAccess/subscriptionUsage/glmCodingPlanUsageAdapter.ts
@@ -2,7 +2,7 @@ import type { SubscriptionUsageWindow } from '@shared/schemas';
 
 import {
   asObject,
-  assertSubscriptionUsageResponse,
+  fetchSubscriptionUsage,
   numberField,
   stringField,
   timestampField,
@@ -165,16 +165,16 @@ export async function fetchGlmCodingPlanUsage(
   signal: AbortSignal,
   usageUrl = GLM_CODING_PLAN_USAGE_URL,
 ): Promise<ParsedSubscriptionUsage> {
-  const response = await http(usageUrl, {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json',
-      'Accept-Language': 'en-US,en',
-      Authorization: apiKey,
-      'Content-Type': 'application/json',
-    },
-    signal,
-  });
-  assertSubscriptionUsageResponse(response);
-  return parseGlmCodingPlanUsage(await response.json());
+  return parseGlmCodingPlanUsage(
+    await fetchSubscriptionUsage(http, {
+      url: usageUrl,
+      headers: {
+        Accept: 'application/json',
+        'Accept-Language': 'en-US,en',
+        Authorization: apiKey,
+        'Content-Type': 'application/json',
+      },
+      signal,
+    }),
+  );
 }

--- a/src/controllers/modelAccess/subscriptionUsage/kimiCodeUsageAdapter.ts
+++ b/src/controllers/modelAccess/subscriptionUsage/kimiCodeUsageAdapter.ts
@@ -2,7 +2,7 @@ import type { SubscriptionUsageWindow } from '@shared/schemas';
 
 import {
   asObject,
-  assertSubscriptionUsageResponse,
+  fetchSubscriptionUsage,
   numberField,
   ratioWindow,
   stringField,
@@ -84,14 +84,14 @@ export async function fetchKimiCodeUsage(
   apiKey: string,
   signal: AbortSignal,
 ): Promise<ParsedSubscriptionUsage> {
-  const response = await http(KIMI_CODE_USAGE_URL, {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json',
-      Authorization: `Bearer ${apiKey}`,
-    },
-    signal,
-  });
-  assertSubscriptionUsageResponse(response);
-  return parseKimiCodeUsage(await response.json());
+  return parseKimiCodeUsage(
+    await fetchSubscriptionUsage(http, {
+      url: KIMI_CODE_USAGE_URL,
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      signal,
+    }),
+  );
 }

--- a/src/controllers/modelAccess/subscriptionUsage/subscriptionUsageParsing.ts
+++ b/src/controllers/modelAccess/subscriptionUsage/subscriptionUsageParsing.ts
@@ -19,8 +19,31 @@ export class SubscriptionUsageHttpError extends Error {
   }
 }
 
-export function assertSubscriptionUsageResponse(response: Response): void {
+function assertSubscriptionUsageResponse(response: Response): void {
   if (!response.ok) throw new SubscriptionUsageHttpError(response.status);
+}
+
+/**
+ * The one subscription-usage request every provider adapter makes. Only the
+ * URL and headers differ per provider, so the GET, the abort wiring, and the
+ * non-OK status assertion live here; the decoded body goes back to the
+ * adapter's own `parseX`.
+ */
+export async function fetchSubscriptionUsage(
+  http: SubscriptionUsageHttp,
+  request: {
+    readonly url: string;
+    readonly headers: Record<string, string>;
+    readonly signal: AbortSignal;
+  },
+): Promise<unknown> {
+  const response = await http(request.url, {
+    method: 'GET',
+    headers: request.headers,
+    signal: request.signal,
+  });
+  assertSubscriptionUsageResponse(response);
+  return response.json();
 }
 
 export function asObject(value: unknown): JsonObject | undefined {

--- a/src/test-kernel/settings/AgentHandlersDelete.vitest.ts
+++ b/src/test-kernel/settings/AgentHandlersDelete.vitest.ts
@@ -113,6 +113,7 @@ function createHandlers(): AgentHandlers {
         warn: mocks.logWarn,
       },
       withActiveWebview: vi.fn(),
+      postMessageToActiveWebview: vi.fn(),
     },
     mocks.refreshAfterAgentMutation,
   );

--- a/src/test-kernel/settings/ExtensionAgentHandlers.vitest.ts
+++ b/src/test-kernel/settings/ExtensionAgentHandlers.vitest.ts
@@ -108,6 +108,7 @@ async function createHandlerFixture(options: HandlerFixtureOptions = {}) {
       },
       extensionContext: {} as never,
       withActiveWebview: async () => {},
+      postMessageToActiveWebview: async () => {},
     },
     refreshAfterAgentMutation,
   );

--- a/src/test-kernel/webview/SidebarSurfaceOwnership.vitest.ts
+++ b/src/test-kernel/webview/SidebarSurfaceOwnership.vitest.ts
@@ -107,8 +107,7 @@ describe('sidebar surface ownership', () => {
   let provider: InstanceType<typeof MainViewProvider>;
   let view: ReturnType<typeof createWebviewView>;
   let progressViewProvider: {
-    getContentProvider: () => { getHtmlContent: () => string };
-    handleSidebarMessage: ReturnType<typeof vi.fn>;
+    setupWebviewContent: ReturnType<typeof vi.fn>;
     resetSidebarReady: ReturnType<typeof vi.fn>;
   };
 
@@ -121,8 +120,10 @@ describe('sidebar surface ownership', () => {
       globalState: { get: () => undefined, update: async () => {} },
     } as unknown as vscode.ExtensionContext);
     progressViewProvider = {
-      getContentProvider: () => ({ getHtmlContent: () => PROGRESS_HTML }),
-      handleSidebarMessage: vi.fn(),
+      setupWebviewContent: vi.fn((target: vscode.WebviewView) => {
+        (target.webview as { html: string }).html = PROGRESS_HTML;
+        return { dispose: vi.fn() };
+      }),
       resetSidebarReady: vi.fn(),
     };
     provider.setProgressViewProvider(


### PR DESCRIPTION
## Summary

Follow-up to a tech-debt audit that scanned the codebase for messy/ad-hoc concentrations. This PR implements the "adapters" cluster of findings — the 3 highest-payback, lowest-risk items plus one bonus catch, all behavior-preserving:

- **CLI slash-command forms** (`registerBuiltins.tsx`): 3 of 13 `*FormAdapter` wrappers (Memory/Resume/Skills list) turned out to be byte-identical in shape — collapsed into one generic `makeSelectFormAdapter` factory. The other 10 were inspected and correctly left alone; each diverges structurally (different completion modes, extra props, no `onSelect`, etc).
- **CLI dashboard rows** (`SubagentList.tsx`): extracted `RowSegment`/`ApprovalSegments` helpers, collapsing 7 hand-built truncating-segment blocks and 3 copies of the approval label/overflow pair. Full unification of the two row components (subagent row vs. workflow-dashboard row) was investigated and declined — they diverge in 6 load-bearing ways (layout, active-state styling, summary fields) that would require flag-parameter forking for no element reduction.
- **Extension webview plumbing**: hoisted `postMessageToActiveWebview` (duplicated identically in `SettingsViewMessageHandler` and `memoryHandlers`) onto `BaseViewMessageHandler`, and hoisted the webview content/message-listener setup onto `BaseWebviewProvider` as `setupWebviewContent`. The audit found 3 inline copies of this snippet; the actual sweep found a 4th (`SettingsViewProvider`) and folded it in too.
- **Subscription usage adapters**: the Codex/Kimi/GLM usage adapters each hand-rolled the same `http(url, {method:'GET', headers, signal})` → `assertSubscriptionUsageResponse` → `parseX(json)` skeleton. Replaced with one shared `fetchSubscriptionUsage` helper; each adapter now only supplies its own URL/headers and keeps its own parser.

## Issue acceptance gates

No tracked issue — this was requested directly as a follow-up to an ad-hoc tech-debt scan. Acceptance gate: the 5 candidate refactor areas from that scan are each either implemented or investigated-and-declined with a stated reason (see below).

## Single source of truth

- `BaseViewMessageHandler.postMessageToActiveWebview` — now the one place that posts to the active webview with the await + nullish-guard semantics `setModelEnabled`'s ordering depends on.
- `BaseWebviewProvider.setupWebviewContent` — now the one place that wires `webview.html` + the `onDidReceiveMessage` listener and returns the disposable for the caller to own.
- `subscriptionUsageParsing.fetchSubscriptionUsage` — now the one place that performs the GET + response-assertion for subscription usage; provider adapters only supply URL/headers/parser.
- `makeSelectFormAdapter` — now the one place owning the `beforeAction`/`onError`/persistence plumbing for the plain-picker slash-form adapters.

## Duplication and abstraction budget

Removed: 3 identical `*FormAdapter` bodies → 1 factory + 3 call sites; 4 identical webview-setup inlines → 1 base-class method; 2 identical `postMessageToActiveWebview` bodies → 1 base-class method; 3 identical HTTP-fetch skeletons → 1 helper; 3 identical approval-segment renders + 7 truncating-segment blocks → 2 shared row-primitive components.

Explicitly **not** abstracted, with reasons (see commit message for full detail): the three model handlers' `dispatch*Execution` skeletons (catch-clause contracts genuinely differ per provider — recover-and-return vs. annotate-and-rethrow vs. retry-or-decorate); a new `ResourceStack` helper (`DisposableStore` already exists and is already used at 3 of 4 candidate sites, and the 4th has a non-LIFO unwind order that would change observable error shape if forced onto it); the codex/xai preference/signedIn/authStatus/capability pairs (preference and signedIn already share factories; authStatus and capabilities have genuinely divergent wire schemas/bodies).

## Net elements (R6)

Diffstat: 17 files changed, 232 insertions(+), 212 deletions(-).
Exported symbols (`git diff main...HEAD -- packages/cli/src packages/extension/src src/controllers | grep -E '^[+-]export'`): net 0 (`-assertSubscriptionUsageResponse` became module-private, `+fetchSubscriptionUsage` added).
Net LoC by cluster: CLI FormAdapter −11 (region), CLI dashboard rows +16 (element-negative: 2 shared primitives replace ~10 duplicated blocks), extension webview plumbing −8, subscription adapters +23 (deliberately LOC-positive/element-negative per the repo's own accounting bar — 3 request-skeleton copies collapse to 1, one export leaves the module surface).

## Consumer counts (R8)

- `assertSubscriptionUsageResponse` lost its `export`: grepped repo-wide, its only 3 callers were the 3 skeletons that collapsed into `fetchSubscriptionUsage`; now module-private with 1 caller.
- `ProgressViewProvider.getContentProvider` / `handleSidebarMessage` deleted (now inherited via `setupWebviewContent`): grepped repo-wide for both names, no remaining references outside the deleted definitions and the one test fake, which was updated.
- No other emit path, subscribe surface, or exported symbol was re-routed.

## Host impact

Extension: webview base-class changes affect all 3 webviews (main, progressView, settingsView) — verified via typecheck + 890 tests across `webview/`, `settings/`, `progressView/`, `architecture/` suites.

Desktop: no changes.

CLI: `registerBuiltins.tsx` and `SubagentList.tsx` — verified via typecheck + targeted suites (`SlashRegistry`, `SlashCommandDispatch`, `SlashHelpText`, dashboard/transcript rendering) plus a throwaway 120-scenario byte-identical ANSI-frame diff harness for the row-renderer change (deleted before commit).

## Scheduled refactoring

None — the declined items above were investigated and found not to be worth doing (see "Duplication and abstraction budget"), not deferred.

## Validation

- `npm run typecheck` — clean, all 6 project stages.
- `npm run lint` — clean, no output.
- `npx prettier --check` on all changed files — clean.
- `npm run check:dead-code-ratchet` — no new findings (379 vs. 379 baselined).
- `npx vitest run` across `cli/`, `webview/`, `settings/`, `progressView/`, `controllers/modelAccess/`, `model/`, `auth/`, `architecture/` — 290 files, 3715 tests passed, 1 skipped (pre-existing, unrelated).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BuCmLZdAaygjMGQgkAQ9F

---
_Generated by [Claude Code](https://claude.ai/code/session_013BuCmLZdAaygjMGQgkAQ9F)_