### PR TITLE
test(desktop): make the timers/promises mock resolve with its value

### DIFF
--- a/src/test-kernel/desktop/DesktopDiffHost.vitest.ts
+++ b/src/test-kernel/desktop/DesktopDiffHost.vitest.ts
@@ -35,14 +35,14 @@ vi.mock('node:timers/promises', async (importOriginal) => {
   return {
     ...original,
     setTimeout: vi.fn(
-      (_delay: number, _value?: unknown, options?: { signal?: AbortSignal }) =>
-        new Promise<void>((resolve, reject) => {
+      (delay: number, value?: unknown, options?: { signal?: AbortSignal }) =>
+        new Promise<unknown>((resolve, reject) => {
           const signal = options?.signal;
           if (signal?.aborted) {
             reject(signal.reason ?? new Error('Aborted'));
             return;
           }
-          const timer = setTimeout(() => resolve(), _delay);
+          const timer = setTimeout(() => resolve(value), delay);
           signal?.addEventListener(
             'abort',
             () => {


### PR DESCRIPTION
## Summary

Kernel shard 1/2 has failed on every run of `main` since 2ee8544d8b (#11483) with `[vitest-pool]: Worker forks emitted error … Worker exited unexpectedly` while all tests report passing. The job log shows the actual cause: `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` in the fork running `src/test-kernel/desktop/DesktopDiffHost.vitest.ts`.

#11483 rewrote `drainFallbackSetups` in `packages/desktop/src/main/desktopDiffHost.ts` to recognise the dispose deadline by the **resolved value** of `sleep(DIFF_HOST_FALLBACK_SETUP_TIMEOUT_MS, 'deadline', { signal })`. The test file's `node:timers/promises` mock ignored the `value` argument and resolved `undefined`, so in `bounds the dispose wait for in-flight fallback setup`:

1. fake timers advance to the bound → the mocked sleep resolves `undefined`;
2. `winner !== 'deadline'`, so the loop continues with `inFlightFallbacks` still non-empty;
3. the already-settled `deadline` promise wins every subsequent `Promise.race` instantly;
4. `while (true)` spins in a microtask loop allocating promises until V8 runs out of heap (~4 GB in ~45 s).

Production is correct — the real `timers/promises.setTimeout` resolves with `value`. The mock's contract had diverged from the API it stands in for. This makes it resolve with `value`.

Reproduced locally: `NODE_OPTIONS=--max-old-space-size=1536 npx vitest run src/test-kernel/desktop/DesktopDiffHost.vitest.ts` crashes on `main` at the 16th test and passes 16/16 with this change.

## Verified

- `NODE_OPTIONS=--max-old-space-size=1536 npx vitest run src/test-kernel/desktop/DesktopDiffHost.vitest.ts` → 16/16 (crashed before).
- `tsc --noEmit -p tsconfig.test-kernel.json` clean.
- `prettier --check` clean.

Unblocks every PR currently red on kernel shard 1/2 (e.g. #11538).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pZUVQRHJvb8tVCu8nU7TC
