### PR TITLE
refactor(cli): transcript plane reads the shared state — attempt scope, phase tree, membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### CLI
+
+#### Improvements
+
+- **The terminal shows the same run the progress view does** — a workflow
+  agent's transcript no longer hides its reasoning, replies, and prompts, a
+  relaunched workflow keeps its earlier attempt on screen as a closed group,
+  and phases are the phases the run actually opened rather than rows grouped by
+  a repeated label.
+- **Workflow dashboard rows read like the board's** — each phase shows
+  `done/total · N running · N failed` plus one marker per call, the panel
+  heading's tally is labelled as the whole run, a call's status word no longer
+  gets clipped by its metadata, and phase and task rows line up in one column.
+
 ## [0.40.5] - 2026-08-26
 
 ### Shared (all surfaces)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,20 @@ All notable changes to this project will be documented in this file.
 
 ### CLI
 
-#### Improvements
+#### Features
+
+- **Workflow dashboard rows read like the board's** — each phase shows
+  `done/total · N running · N failed` plus one marker per call, the panel
+  heading's tally is labelled as the whole run, a call's status word no longer
+  gets clipped by its metadata, and phase and task rows line up in one column.
+
+#### Bug Fixes
 
 - **The terminal shows the same run the progress view does** — a workflow
   agent's transcript no longer hides its reasoning, replies, and prompts, a
   relaunched workflow keeps its earlier attempt on screen as a closed group,
   and phases are the phases the run actually opened rather than rows grouped by
   a repeated label.
-- **Workflow dashboard rows read like the board's** — each phase shows
-  `done/total · N running · N failed` plus one marker per call, the panel
-  heading's tally is labelled as the whole run, a call's status word no longer
-  gets clipped by its metadata, and phase and task rows line up in one column.
 
 ## [0.40.5] - 2026-08-26
 

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -7,8 +7,10 @@ import { COLOR_WARNING } from '@cli/tui/ui/colors';
 import { AgentCategory } from '@shared/schemas';
 import type { TranscriptRow } from '@shared/transcript';
 import {
+  formatWorkflowPhaseHeading,
   workflowCallFailureTally,
   workflowPhaseCallProgress,
+  workflowPhaseHeadingOfGroup,
 } from '@shared/copy/workflowCall';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 
@@ -21,7 +23,6 @@ import {
   sessionStateRevision,
   streamMetadataFor,
 } from '../state/childExecutions';
-import { currentWorkflowPhaseHeading } from '../state/workflowPhase';
 import {
   readStreamArtifacts,
   streamArtifactRevision,
@@ -164,6 +165,14 @@ interface WorkflowStatusSegment {
  * rather than on the `◆` divider because that divider prints once into
  * scrollback and can never be rewritten.
  *
+ * The phase and its calls both come from the run's own phase task groups — the
+ * band names the last phase the run opened and counts the calls whose
+ * `groupId` names it, which is the classification the progress view's group
+ * tree makes and the dashboard's phase rows reuse. Matching on the call's
+ * `phase` *label* instead would fuse two same-named phases into one tally.
+ * Naming the phase is also what keeps this number distinct from the
+ * dashboard heading's, which counts the whole run.
+ *
  * A whole-run failure tally is appended in a warning tone the moment any call
  * fails. The engine deliberately keeps the run going after a failed subagent
  * (it resolves to `null`), so the lifecycle stays `completed` — but the status
@@ -174,16 +183,25 @@ export function workflowRunStatusSummary(
   category: AgentCategory | undefined,
 ): readonly WorkflowStatusSegment[] | undefined {
   if (!slice || category !== AgentCategory.Workflow) return undefined;
-  const phase = currentWorkflowPhaseHeading(slice, category);
+  const phase = slice.taskGroups.findLast((group) => group.kind === 'phase');
   const currentCalls = slice.entries.flatMap((row) =>
     row.kind === 'workflowTask' ? [row.call] : [],
   );
   const { done, total } = workflowPhaseCallProgress(
-    phase ? currentCalls.filter((call) => call.phase === phase.phaseLabel) : [],
+    phase
+      ? slice.entries.flatMap((row) =>
+          row.kind === 'workflowTask' && row.groupId === phase.id
+            ? [row.call]
+            : [],
+        )
+      : [],
   );
   const segments: WorkflowStatusSegment[] = [];
   if (phase) {
-    segments.push({ text: phase.heading, tone: 'muted' });
+    segments.push({
+      text: formatWorkflowPhaseHeading(workflowPhaseHeadingOfGroup(phase)),
+      tone: 'muted',
+    });
   }
   if (total > 0) {
     segments.push({ text: `${done}/${total} done`, tone: 'muted' });

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -27,11 +27,12 @@ import {
   parentStream as parentStreamSignal,
   sessionStateRevision,
   streamMetadataFor,
+  streamStateFor,
   type ChildRosters,
 } from '../state/childExecutions';
 import { staticTranscriptEraseEpoch } from '../state/staticTranscriptRepaint';
 import { streamViewForId } from '../state/streamViews';
-import { ancestorWorkflowPhaseHeading } from '../state/workflowPhase';
+import { ancestorWorkflowPhaseLabel } from '../state/workflowPhase';
 import { useSignal } from '../state/useSignal';
 import { EntryErrorBoundary } from './EntryErrorBoundary';
 import {
@@ -144,13 +145,12 @@ export function sessionHeaderIdentityLine(
       view.info?.identity?.kind === 'multiAgentWorkflow'
         ? 'workflow script'
         : 'subagent';
-    const phase = ancestorWorkflowPhaseHeading({
+    const phaseText = ancestorWorkflowPhaseLabel({
       categoryOf: (id) => streamMetadataFor(id)?.agentCategory,
+      stageOf: (id) => streamStateFor(id)?.stage,
       parentStream,
       streamId: context.streamId,
-      streams: context.streams,
     });
-    const phaseText = phase?.heading;
     return phaseText
       ? `${streamKind}: ${view.label} · ${phaseText} · parent: ${view.parentLabel} · model: ${model}`
       : `${streamKind}: ${view.label} · parent: ${view.parentLabel} · model: ${model}`;

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -40,7 +40,7 @@ import {
   visibleSubagentRows,
 } from '../state/childExecutions';
 import { streamLabelForId } from '../state/streamViews';
-import { ancestorWorkflowPhaseHeading } from '../state/workflowPhase';
+import { ancestorWorkflowPhaseLabel } from '../state/workflowPhase';
 import { useSignal } from '../state/useSignal';
 import {
   buildStatusBarDisplay,
@@ -277,12 +277,12 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const focusedPhaseHeading =
     focusedStreamId === undefined
       ? undefined
-      : ancestorWorkflowPhaseHeading({
+      : ancestorWorkflowPhaseLabel({
           categoryOf: (id) => streamMetadataFor(id)?.agentCategory,
+          stageOf: (id) => streamStateFor(id)?.stage,
           parentStream,
           streamId: focusedStreamId,
-          streams,
-        })?.heading;
+        });
 
   const display = buildStatusBarDisplay({
     status: statusSlice?.status,

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -33,7 +33,6 @@ import {
   formatWorkflowPhaseHeading,
   workflowCallFailureTally,
   workflowPhaseCallProgress,
-  type WorkflowPhaseHeading,
 } from '@shared/copy/workflowCall';
 import { formatStageLabel } from '@shared/streams/streamStatusDisplay';
 import { filterNotNullish, formatCompactTokenCount } from '@utils/core';
@@ -77,7 +76,10 @@ import {
   CHILD_STATUS_MARKER,
   childRowMetadataText,
   childStatusColor,
+  dashboardMarkerCell,
   pendingApprovalRowDisplay,
+  workflowPhaseStatusStrip,
+  workflowPhaseTallyText,
 } from './SubagentListDisplay';
 import { useSignal } from '../state/useSignal';
 import type { PendingApprovalKind } from '../state/approvalQueue';
@@ -86,28 +88,65 @@ import type { StreamView } from '../state/streamViews';
 
 const SUBAGENT_SUMMARY_MAX_COLUMNS = 100;
 
-interface PhaseHeaderDetails extends WorkflowPhaseHeading {
-  readonly progress?: string;
-}
-
+/**
+ * One phase row of the dashboard, in both layouts: name, the phase's own
+ * `done/total · N running · N failed`, and one glyph per issued call — the
+ * same three things the progress view's phase header shows, folded from the
+ * same call cards. The tally reads as the phase because the phase names it;
+ * the panel heading's tally reads as the run for the same reason.
+ *
+ * The marker cell is shared with the task rows, so a phase and the tasks under
+ * it start their text in the same screen column whether or not the row is
+ * focused.
+ */
 function PhaseHeader({
-  details,
+  group,
   focused = false,
+  showStatusStrip,
 }: {
-  readonly details: PhaseHeaderDetails;
+  readonly group: WorkflowPhaseGroup;
   readonly focused?: boolean;
+  /** The strip is the phase row's own account of its calls, so it belongs to
+   *  the full-width list. The two-column layout paints one marker per call in
+   *  the task column beside it and gives the narrow phase column to the name. */
+  readonly showStatusStrip: boolean;
 }): React.JSX.Element {
-  const inlineProgress = details.progress ? ` · ${details.progress}` : '';
+  const calls = group.tasks.map((entry) => entry.call);
+  const strip = showStatusStrip ? workflowPhaseStatusStrip(calls) : undefined;
   return (
-    <Box flexDirection="row" flexGrow={1} minWidth={0}>
-      <Box minWidth={0} flexShrink={1}>
-        <Text aria-hidden dimColor>
-          {focused ? `${POINTER} ${STATUS_DIAMOND} ` : `    ${STATUS_DIAMOND} `}
+    <Box
+      flexDirection="row"
+      flexGrow={1}
+      height={1}
+      minWidth={0}
+      overflowY="hidden"
+    >
+      {/* One rigid gutter: Ink trims leading whitespace off a row it has to
+          wrap, so the pointer and marker only keep their columns while they
+          sit in a box that never shrinks. */}
+      <Box flexShrink={0}>
+        <Text aria-hidden color={focused ? COLOR_HINT : undefined}>
+          {focused ? POINTER : ' '}
         </Text>
-        <Text dimColor wrap="truncate-end">
-          {`${formatWorkflowPhaseHeading(details)}${inlineProgress}`}
+        <Text aria-hidden dimColor>
+          {dashboardMarkerCell(STATUS_DIAMOND)}
         </Text>
       </Box>
+      <Box minWidth={0} flexShrink={1}>
+        <Text dimColor wrap="truncate-end">
+          {formatWorkflowPhaseHeading(group.heading)}
+        </Text>
+      </Box>
+      <Box minWidth={0} flexShrink={2}>
+        <Text dimColor wrap="truncate-end">
+          {` · ${workflowPhaseTallyText(calls)}`}
+        </Text>
+      </Box>
+      {strip ? (
+        <Box minWidth={0} flexShrink={3}>
+          <Text dimColor wrap="truncate-end">{` ${strip}`}</Text>
+        </Box>
+      ) : null}
     </Box>
   );
 }
@@ -289,13 +328,24 @@ function WorkflowTaskRow({
   const approval = pendingApprovalRowDisplay(pendingKinds);
   return (
     <Box flexDirection="row" height={1} minWidth={0} overflowY="hidden">
-      <Text aria-hidden color={focused ? COLOR_HINT : undefined}>
-        {focused ? POINTER : ' '}
-      </Text>
-      <Text aria-hidden color={style.color}>{` ${style.marker} `}</Text>
+      <Box flexShrink={0}>
+        <Text aria-hidden color={focused ? COLOR_HINT : undefined}>
+          {focused ? POINTER : ' '}
+        </Text>
+        <Text aria-hidden color={style.color}>
+          {dashboardMarkerCell(style.marker)}
+        </Text>
+      </Box>
+      <Box minWidth={0} flexShrink={1}>
+        <Text wrap="truncate-end">{entry.call.label}</Text>
+      </Box>
+      {/* The status word outranks the metadata column: it is its own segment
+          at the label's shrink weight, so a wide row sheds metadata (weight 2)
+          long before it clips `· Running`, instead of the two sharing one
+          truncating box where the status was always the half that was cut. */}
       <Box minWidth={0} flexShrink={1}>
         <Text wrap="truncate-end">
-          {entry.call.label} · {WORKFLOW_TASK_STATUS_LABEL[entry.call.status]}
+          {` · ${WORKFLOW_TASK_STATUS_LABEL[entry.call.status]}`}
         </Text>
       </Box>
       {approval ? (
@@ -356,7 +406,7 @@ function WorkflowDashboard({
     }),
   );
   const phaseItems: SelectItem<ChildListValue>[] = groups.map((group) => ({
-    label: group.label,
+    label: group.heading.phaseLabel,
     value: group.value,
   }));
   const taskItems: SelectItem<ChildListValue>[] = (
@@ -367,7 +417,7 @@ function WorkflowDashboard({
   }));
   const narrowItems: SelectItem<ChildListValue>[] = groups.flatMap((group) => [
     {
-      label: group.label,
+      label: group.heading.phaseLabel,
       value: group.value,
       disabled: group.tasks.length > 0,
     },
@@ -417,19 +467,16 @@ function WorkflowDashboard({
   ) {
     return null;
   }
-  const headingPhase = activeGroup?.heading
-    ? formatWorkflowPhaseHeading(activeGroup.heading)
-    : undefined;
   // The heading leads with the run identity's display name — for a
   // multi-agent workflow root that is the workflow name, matching what the
-  // retired slice `agent` field carried from `run.config`.
+  // retired slice `agent` field carried from `run.config`. Its tally is the
+  // whole run's; each phase row carries its own, so the two numbers on screen
+  // are never the same number twice.
   const rootIdentity = streamMetadataFor(model.root.streamId)?.identity;
   const rootAgent = rootIdentity
     ? runIdentityDisplayName(rootIdentity)
     : undefined;
-  const heading = headingPhase
-    ? `${rootAgent ?? 'Workflow'} · ${headingPhase} · ${done}/${total} done`
-    : `${rootAgent ?? 'Workflow'} · ${done}/${total} done`;
+  const heading = `${rootAgent ?? 'Workflow'} · ${done}/${total} done`;
   const { failed } = workflowCallFailureTally(calls);
   const renderTask = (
     item: SelectItem<ChildListValue>,
@@ -455,15 +502,18 @@ function WorkflowDashboard({
       />
     );
   };
-  const groupDetails = (group: WorkflowPhaseGroup): PhaseHeaderDetails => {
-    const progress = workflowPhaseCallProgress(
-      group.tasks.map((entry) => entry.call),
-    );
-    return {
-      phaseLabel: group.label,
-      ...group.heading,
-      progress: `${progress.done}/${progress.total}`,
-    };
+  const renderPhase = (
+    item: SelectItem<ChildListValue>,
+    state: { readonly focused: boolean },
+  ): React.JSX.Element | null => {
+    const group = groupByValue.get(item.value);
+    return group ? (
+      <PhaseHeader
+        group={group}
+        focused={state.focused}
+        showStatusStrip={!wide}
+      />
+    ) : null;
   };
   const selectProps = {
     hotkeys: false,
@@ -512,7 +562,7 @@ function WorkflowDashboard({
       </Box>
       {wide ? (
         <Box flexDirection="row" height={contentRows} minWidth={0}>
-          <Box flexDirection="column" width="32%" paddingRight={1}>
+          <Box flexDirection="column" width="36%" paddingRight={1}>
             <Select
               {...selectProps}
               isActive={keyboardActive && selectedTask === undefined}
@@ -520,23 +570,10 @@ function WorkflowDashboard({
               items={phaseItems}
               onHighlightChange={(value) => onSelectionChange?.(value)}
               onSelect={enterPhase}
-              renderItem={(item, state) => {
-                const group = groupByValue.get(item.value);
-                if (!group) return null;
-                const details = groupDetails(group);
-                return (
-                  <Box minWidth={0}>
-                    <Text aria-hidden>{state.focused ? POINTER : ' '}</Text>
-                    <Text wrap="truncate-end">
-                      {' '}
-                      {formatWorkflowPhaseHeading(details)} · {details.progress}
-                    </Text>
-                  </Box>
-                );
-              }}
+              renderItem={renderPhase}
             />
           </Box>
-          <Box flexDirection="column" minWidth={0} width="68%">
+          <Box flexDirection="column" minWidth={0} width="64%">
             <Select
               {...selectProps}
               isActive={keyboardActive && selectedTask !== undefined}
@@ -556,17 +593,9 @@ function WorkflowDashboard({
           items={narrowItems}
           onHighlightChange={(value) => onSelectionChange?.(value)}
           onSelect={selectTask}
-          renderItem={(item, state) => {
-            const group = groupByValue.get(item.value);
-            return group ? (
-              <PhaseHeader
-                details={groupDetails(group)}
-                focused={state.focused}
-              />
-            ) : (
-              renderTask(item, state)
-            );
-          }}
+          renderItem={(item, state) =>
+            renderPhase(item, state) ?? renderTask(item, state)
+          }
         />
       )}
     </Box>

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -7,11 +7,17 @@ import {
   COLOR_WARNING,
 } from '@cli/tui/ui/colors';
 import { STATUS_DOT, TOKENS_GENERATED } from '@cli/tui/ui/glyphs';
-import { STREAM_PHASE } from '@shared/schemas';
-import { formatCompactTokenCount } from '@utils/core';
+import { fillRows } from '@cli/runtime/terminalText';
+import { STREAM_PHASE, type WorkflowCallProgress } from '@shared/schemas';
+import {
+  workflowCallFailureTally,
+  workflowPhaseCallProgress,
+} from '@shared/copy/workflowCall';
+import { filterNotNullish, formatCompactTokenCount } from '@utils/core';
 import { formatResultCount } from '@utils/text/stringUtils';
 
 // Local imports - TUI state and presentation
+import { WORKFLOW_TASK_STATUS_STYLE } from './transcriptEntryLayout';
 import type { PendingApprovalKind } from '../state/approvalQueue';
 
 /** Row-dot color for a child stream's phase.
@@ -105,4 +111,64 @@ export function pendingApprovalRowDisplay(
     label: PENDING_APPROVAL_ROW_LABELS[first],
     overflow: kinds.length > 1 ? `+${kinds.length - 1}` : undefined,
   };
+}
+
+/** Display columns the workflow dashboard reserves for a row's status marker,
+ *  counting the space that separates it from the focus pointer. */
+const DASHBOARD_MARKER_COLUMNS = 3;
+
+/**
+ * The marker cell every workflow-dashboard row shares. The cell is filled to a
+ * fixed column count by measured display width, so a marker the width helper
+ * counts as two columns takes its own cell instead of shoving the label right
+ * and leaving that row one column out of line with its neighbours.
+ *
+ * (A terminal whose East-Asian-Ambiguous table disagrees with the width helper
+ * — `□`, `●` and `·` are Ambiguous — still draws such a glyph double-wide; no
+ * padding computed on this side can see that, so glyph choice, not padding, is
+ * the lever there.)
+ */
+export function dashboardMarkerCell(marker: string): string {
+  return fillRows(` ${marker}`, DASHBOARD_MARKER_COLUMNS);
+}
+
+/**
+ * `done/total · N running · N failed` for one phase's calls — the same fold the
+ * progress view's phase headers render (`TaskGroupList.renderWorkflowCallTally`),
+ * so the terminal and the board can never disagree on what a phase has done.
+ */
+export function workflowPhaseTallyText(
+  calls: readonly WorkflowCallProgress[],
+): string {
+  const { done, total } = workflowPhaseCallProgress(calls);
+  const running = calls.filter((call) => call.status === 'running').length;
+  const { failed } = workflowCallFailureTally(calls);
+  return [
+    `${done}/${total}`,
+    running > 0 ? `${running} running` : undefined,
+    failed > 0 ? `${failed} failed` : undefined,
+  ]
+    .filter(filterNotNullish)
+    .join(' · ');
+}
+
+/** Calls a phase's status strip shows before it collapses into a `+N` count. */
+const PHASE_STATUS_STRIP_LIMIT = 24;
+
+/**
+ * One glyph per issued call, in issue order — the terminal's counterpart to the
+ * board's per-call status dots. The glyphs are the very markers the task rows
+ * paint (`WORKFLOW_TASK_STATUS_STYLE`), so the strip and the rows below it can
+ * never tell different stories.
+ */
+export function workflowPhaseStatusStrip(
+  calls: readonly WorkflowCallProgress[],
+): string | undefined {
+  if (calls.length === 0) return undefined;
+  const shown = calls
+    .slice(0, PHASE_STATUS_STRIP_LIMIT)
+    .map((call) => WORKFLOW_TASK_STATUS_STYLE[call.status].marker)
+    .join('');
+  const overflow = calls.length - PHASE_STATUS_STRIP_LIMIT;
+  return overflow > 0 ? `${shown}+${overflow}` : shown;
 }

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -105,15 +105,8 @@ export interface TranscriptFoldState {
   latestUserPos: number;
   /** Index of the last finalized model-response row with text, or -1. */
   latestResponsePos: number;
-  /** Projection-mode bits `items` was built under; a flip forces a rebuild. */
-  workflowOperationalOnly: boolean;
+  /** Projection-mode bit `items` was built under; a flip forces a rebuild. */
   projectLifecycleToTaskGroups: boolean;
-  /** Highest-seq live-activity entry (drives the thinking indicator). */
-  liveActivityEntry?: StreamLogEntry;
-  /** Latest durable workflow-attempt marker and its source order. */
-  workflowAttemptId?: string;
-  workflowAttemptBoundaryDeclared: boolean;
-  workflowAttemptSeqNo: number;
   /** Local rows reconciled into `items`, in slice order, by identity. */
   synthetics: readonly TranscriptRow[];
   /** Incremental task-group / compaction memos. Unlike the fold fields above

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -395,13 +395,11 @@ export function syncStreamLog(
     // thinking row, still streaming — rather than a second tracker over raw
     // log entries. A thinking block the producer opened but never wrote text
     // into projects no row, and so lights nothing up.
-    let thinkingActive = false;
-    for (let index = state.items.length - 1; index >= 0; index -= 1) {
-      const row = state.items[index]!.rendered;
-      if (row.kind !== 'thinking') continue;
-      thinkingActive = row.streaming;
-      break;
-    }
+    const lastThinkingRow = state.items.findLast(
+      (item) => item.rendered.kind === 'thinking',
+    )?.rendered;
+    const thinkingActive =
+      lastThinkingRow?.kind === 'thinking' && lastThinkingRow.streaming;
 
     // Transcript-derived live status only. The shared metadata `description`
     // is the runtime's own one-liner and is never written from here.

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -20,11 +20,7 @@
 // `./transcriptFold` remains only to cover rows persisted before that
 // landed; it is idempotent on already-redacted text.
 
-import {
-  AgentCategory,
-  MESSAGE_TYPES,
-  type StreamTabId,
-} from '@shared/schemas';
+import { AgentCategory, type StreamTabId } from '@shared/schemas';
 import type { TranscriptRow } from '@shared/transcript';
 import { subscribeToSignalChanges } from '@shared/signals';
 import {
@@ -52,7 +48,6 @@ import {
   compactWorkflowEntries,
   createTranscriptFoldState,
   isFullLogChildStream,
-  logEntryStreamIsRunning,
   newFoldChangeFlags,
   resetTranscriptFoldState,
   workflowOperationalLatestLine,
@@ -284,7 +279,10 @@ export function syncStreamLog(
   patchStream(streamId, (slice, lifecycle) => {
     const workflowStream = metadata?.agentCategory === AgentCategory.Workflow;
     const fullLogChild = isFullLogChildStream(metadata?.identity);
-    const workflowOperationalOnly = workflowStream && !fullLogChild;
+    // Which line a workflow-agent stream reports as its live status is CLI
+    // chrome, not transcript membership: the rows themselves are the same set
+    // every host renders.
+    const workflowStatusFeed = workflowStream && !fullLogChild;
     // Run/round/session headings go to the task-group surface wherever this
     // host paints one. The single exception is a full-log child that is not a
     // workflow run — a detached process or an external-CLI session, which has
@@ -296,7 +294,6 @@ export function syncStreamLog(
     const state = slice.transcriptFold ?? createTranscriptFoldState();
     const flags = newFoldChangeFlags();
     const modeCurrent =
-      state.workflowOperationalOnly === workflowOperationalOnly &&
       state.projectLifecycleToTaskGroups === lifecycleToTaskGroups;
     // Fold continuity: same log instance, and either the buffered burst picks
     // up exactly where the state left off and reaches the log's emission
@@ -376,7 +373,6 @@ export function syncStreamLog(
         if (index < promotedCount) promotedIds.add(row.id);
       }
       resetTranscriptFoldState(state);
-      state.workflowOperationalOnly = workflowOperationalOnly;
       state.projectLifecycleToTaskGroups = lifecycleToTaskGroups;
       state.logInstanceId = log.instanceId;
       state.emissionSeq = log.emissionHead;
@@ -395,11 +391,17 @@ export function syncStreamLog(
     const compactingActive = compaction.blocks.some(
       (block) => block.status === 'running',
     );
-    const live = state.liveActivityEntry;
-    const thinkingActive =
-      live !== undefined &&
-      live.messageType === MESSAGE_TYPES.THINKING &&
-      logEntryStreamIsRunning(live);
+    // The indicator reads the rows the transcript already holds — the newest
+    // thinking row, still streaming — rather than a second tracker over raw
+    // log entries. A thinking block the producer opened but never wrote text
+    // into projects no row, and so lights nothing up.
+    let thinkingActive = false;
+    for (let index = state.items.length - 1; index >= 0; index -= 1) {
+      const row = state.items[index]!.rendered;
+      if (row.kind !== 'thinking') continue;
+      thinkingActive = row.streaming;
+      break;
+    }
 
     // Transcript-derived live status only. The shared metadata `description`
     // is the runtime's own one-liner and is never written from here.
@@ -408,7 +410,7 @@ export function syncStreamLog(
       latestUserPos >= 0
         ? transcriptRowHeadline(state.items[latestUserPos].rendered)
         : undefined;
-    const latestLine = workflowOperationalOnly
+    const latestLine = workflowStatusFeed
       ? (workflowOperationalLatestLine(state.items) ?? slice.latestLine)
       : ((state.latestResponsePos > latestUserPos
           ? transcriptRowHeadline(state.items[state.latestResponsePos].rendered)

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -57,38 +57,9 @@ const WORKFLOW_DASHBOARD_KINDS = new Set<TranscriptRowKind>([
   'workflowTask',
 ]);
 
-// Row kinds a workflow-agent stream keeps when it projects an operational feed
-// instead of a model transcript. `compactionActivity` is here for the same
-// reason it is a dashboard kind: a run that compacted its context says so on
-// every surface.
-const WORKFLOW_OPERATIONAL_KINDS = new Set<TranscriptRowKind>([
-  'compactionActivity',
-  'error',
-  'fileList',
-  'phase',
-  'tool',
-  'workflowTask',
-]);
-
-/** Membership is one allowlist; this is the container filter a workflow-agent
- *  stream applies on top of it. Script log lines stay (they are the run's
- *  narration) unless they are debug chatter. */
-function isWorkflowOperationalRow(row: TranscriptRow): boolean {
-  if (row.kind === 'log') return row.level !== 'debug';
-  return WORKFLOW_OPERATIONAL_KINDS.has(row.kind);
-}
-
 // Compact inactive streams must not retain an unbounded operational transcript,
 // but the dashboard needs canonical phase/call identity while a child is open.
 const MAX_COMPACT_WORKFLOW_DASHBOARD_ENTRIES = 2_000;
-
-const LIVE_ACTIVITY_MESSAGE_TYPES = new Set<string>([
-  MESSAGE_TYPES.THINKING,
-  MESSAGE_TYPES.MODEL_RESPONSE,
-  MESSAGE_TYPES.TOOL_USE,
-  MESSAGE_TYPES.ERROR,
-  MESSAGE_TYPES.USER_MESSAGE,
-]);
 
 /**
  * Detached child runs that surface their full log output when focused: a
@@ -136,14 +107,6 @@ export function workflowOperationalLatestLine(
     }
   }
   return undefined;
-}
-
-export function logEntryStreamIsRunning(entry: StreamLogEntry): boolean {
-  const data = entry.data;
-  if (typeof data !== 'object' || data === null || !('status' in data)) {
-    return (entry.text ?? '').trim().length > 0;
-  }
-  return data.status === 'running';
 }
 
 /**
@@ -265,8 +228,13 @@ function projectCompactionIncrementally(
   );
   state.appliedHead = log.size;
   if (streamTerminal && !state.terminal) {
+    // One settle shape across hosts: the boundary is the projection's own
+    // applied head (the default) and the stream's last entry timestamp — the
+    // same two facts `logSlice` passes in the progress view.
     settleCompactionActivities(state.projection, {
-      throughSeqNo: log.size,
+      ...(log.lastTimestamp === undefined
+        ? {}
+        : { finishedAt: log.lastTimestamp }),
     });
   }
   state.terminal = streamTerminal;
@@ -307,9 +275,6 @@ export function createTranscriptFoldState(): TranscriptFoldState {
     finalizedFrontier: 0,
     latestUserPos: -1,
     latestResponsePos: -1,
-    workflowAttemptSeqNo: -1,
-    workflowAttemptBoundaryDeclared: false,
-    workflowOperationalOnly: false,
     projectLifecycleToTaskGroups: false,
     synthetics: [],
   };
@@ -324,10 +289,6 @@ export function resetTranscriptFoldState(state: TranscriptFoldState): void {
   state.finalizedFrontier = 0;
   state.latestUserPos = -1;
   state.latestResponsePos = -1;
-  state.workflowAttemptId = undefined;
-  state.workflowAttemptBoundaryDeclared = false;
-  state.workflowAttemptSeqNo = -1;
-  state.liveActivityEntry = undefined;
   state.synthetics = [];
   state.lastOutputFull = undefined;
   state.lastEntriesOutput = undefined;
@@ -569,96 +530,12 @@ function mergeChangedBySeqNo(
   return merged;
 }
 
-/**
- * The tracked live-activity row was mutated away from its tracked message
- * type: re-derive it from the full log (rare, producer-anomaly path; keeps
- * the ordinary fold allocation-free).
- */
-function retrackLiveActivityEntry(
-  state: TranscriptFoldState,
-  log: StreamLog,
-): void {
-  state.liveActivityEntry = log
-    .getRange(0)
-    .findLast((entry) =>
-      LIVE_ACTIVITY_MESSAGE_TYPES.has(entry.messageType ?? ''),
-    );
-}
-
-/** Once a boundary is declared only rows stamped with the current attempt
- *  are current: rows from an earlier attempt, rows without a stamp, and every
- *  row after a malformed boundary are superseded. Streams without a boundary
- *  (ordinary workflow agents) keep every row. */
-function isSupersededAttemptId(
-  state: TranscriptFoldState,
-  attemptId: string | undefined,
-): boolean {
-  if (!state.workflowAttemptBoundaryDeclared) return false;
-  return (
-    state.workflowAttemptId === undefined ||
-    attemptId !== state.workflowAttemptId
-  );
-}
-
-function isPriorWorkflowAttemptRow(
-  state: TranscriptFoldState,
-  row: TranscriptRow,
-): boolean {
-  if (!state.workflowAttemptBoundaryDeclared) return false;
-  if (row.kind === 'phase') return isSupersededAttemptId(state, row.attemptId);
-  if (row.kind === 'workflowTask') {
-    return isSupersededAttemptId(state, row.call.attemptId);
-  }
-  return (
-    row.messageType === MESSAGE_TYPES.DEFAULT &&
-    row.seqNo !== undefined &&
-    row.seqNo < state.workflowAttemptSeqNo
-  );
-}
-
-function evictPriorWorkflowAttemptItems(
-  state: TranscriptFoldState,
-  flags: FoldChangeFlags,
-): void {
-  if (!state.workflowAttemptBoundaryDeclared) return;
-  for (let index = state.items.length - 1; index >= 0; index -= 1) {
-    if (isPriorWorkflowAttemptRow(state, state.items[index]!.rendered)) {
-      removeFoldItemAt(state, index, flags);
-    }
-  }
-}
-
 /** Fold one changed (appended or dirtied) log entry into the items array. */
 function applyChangedLogEntry(
   state: TranscriptFoldState,
   entry: StreamLogEntry,
   ctx: FoldContext,
 ): void {
-  const messageType = entry.messageType ?? '';
-  const data = entry.data;
-  const isAttemptBoundary =
-    messageType === MESSAGE_TYPES.INTERNAL &&
-    typeof data === 'object' &&
-    data !== null &&
-    'kind' in data &&
-    data.kind === 'workflowAttempt' &&
-    entry.seqNo >= state.workflowAttemptSeqNo;
-  if (isAttemptBoundary) {
-    // A malformed declared boundary must supersede the preceding attempt.
-    // Retaining its identifier would project prior-run rows as current.
-    const attemptId = 'attemptId' in data ? data.attemptId : undefined;
-    state.workflowAttemptId =
-      typeof attemptId === 'string' && attemptId.length > 0
-        ? attemptId
-        : undefined;
-    state.workflowAttemptBoundaryDeclared = true;
-    state.workflowAttemptSeqNo = entry.seqNo;
-    // The dashboard already shows only the current attempt. The live
-    // transcript must match: a retry that appends a fresh attempt would
-    // otherwise leave the failed first-attempt task cards and their
-    // default-log leftovers in the streaming feed.
-    evictPriorWorkflowAttemptItems(state, ctx.flags);
-  }
   const trackedPos = state.indexById.get(entry.id);
   const existingPos =
     trackedPos !== undefined && state.items[trackedPos].rank === 1
@@ -680,17 +557,11 @@ function applyChangedLogEntry(
     ...(prev ? { previousRow: prev } : {}),
     projectLifecycleToTaskGroups: state.projectLifecycleToTaskGroups,
   });
-  if (row === undefined || isPriorWorkflowAttemptRow(state, row)) {
+  if (row === undefined) {
     drop();
     return;
   }
-  // Workflow-agent details are an operational feed, not a model transcript.
-  // Detached workflow-script runs intentionally keep their full child log,
-  // including Running/Finished and error rows.
-  const rendered =
-    state.workflowOperationalOnly && !isWorkflowOperationalRow(row)
-      ? null
-      : transcriptRowForPaint(row);
+  const rendered = transcriptRowForPaint(row);
   if (rendered === null) {
     drop();
     return;
@@ -718,11 +589,6 @@ function reconcileCompactionRows(
     if (pos !== undefined && state.items[pos].block === block) continue;
     const rendered = transcriptRowForPaint(row);
     if (rendered === null) continue;
-    // Same container filter the log and local paths apply, so a
-    // workflow-agent stream has one membership rule rather than three.
-    if (state.workflowOperationalOnly && !isWorkflowOperationalRow(row)) {
-      continue;
-    }
     if (pos !== undefined) {
       state.items[pos].block = block;
       replaceFoldRendered(state, pos, rendered, flags);
@@ -750,12 +616,7 @@ function reconcileSynthetics(
 ): void {
   const current: TranscriptRow[] = [];
   for (const row of sliceEntries) {
-    if (
-      row.origin === 'local' &&
-      (!state.workflowOperationalOnly || isWorkflowOperationalRow(row))
-    ) {
-      current.push(row);
-    }
+    if (row.origin === 'local') current.push(row);
   }
   const previous = state.synthetics;
   if (
@@ -835,21 +696,6 @@ export function applyStreamChanges(
   compaction: CompactionActivityProjection;
 } {
   const changed = mergeChangedBySeqNo(dirtied, appended);
-  let retrack = false;
-  for (const entry of changed) {
-    if (LIVE_ACTIVITY_MESSAGE_TYPES.has(entry.messageType ?? '')) {
-      if (
-        !state.liveActivityEntry ||
-        entry.seqNo >= state.liveActivityEntry.seqNo
-      ) {
-        state.liveActivityEntry = entry;
-      }
-    } else if (state.liveActivityEntry?.id === entry.id) {
-      retrack = true;
-    }
-  }
-  if (retrack) retrackLiveActivityEntry(state, ctx.log);
-
   const taskGroups = projectTaskGroupsIncrementally(state, changed);
   const compaction = projectCompactionIncrementally(
     state,

--- a/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
+++ b/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
@@ -10,7 +10,10 @@
 // Local imports - shared stream identity
 import type { StreamTabId } from '@shared/schemas';
 import type { TranscriptRowOf } from '@shared/transcript';
-import type { WorkflowPhaseHeading } from '@shared/copy/workflowCall';
+import {
+  workflowPhaseHeadingOfGroup,
+  type WorkflowPhaseHeading,
+} from '@shared/copy/workflowCall';
 
 // Local imports - TUI presentation constants
 import { WORKFLOW_DASHBOARD_WIDE_MIN_COLUMNS } from '../panes/SubagentListDisplay';
@@ -27,9 +30,8 @@ export type WorkflowTaskEntry = TranscriptRowOf<'workflowTask'>;
 
 export interface WorkflowPhaseGroup {
   readonly value: ChildListValue;
-  readonly label: string;
-  /** The phase's own heading facts, once a phase row has named it. */
-  readonly heading?: WorkflowPhaseHeading;
+  /** The phase's own heading facts, as its `TaskGroup` states them. */
+  readonly heading: WorkflowPhaseHeading;
   readonly tasks: readonly WorkflowTaskEntry[];
 }
 
@@ -44,7 +46,8 @@ type WorkflowChildTaskIndex = ReadonlyMap<
 export interface WorkflowDashboardModel {
   /** The workflow stream the dashboard is rooted on. */
   readonly root: StreamSlice;
-  /** Phase groups in first-appearance order; tasks stay in transcript order. */
+  /** Phase groups in the order the run opened them; tasks stay in transcript
+   *  order. */
   readonly groups: readonly WorkflowPhaseGroup[];
   /** Every task, in transcript-entry order. */
   readonly tasks: readonly WorkflowTaskEntry[];
@@ -68,62 +71,55 @@ export interface WorkflowDashboardModel {
 
 interface MutableWorkflowPhaseGroup {
   readonly value: ChildListValue;
-  readonly label: string;
-  heading?: WorkflowPhaseHeading;
+  readonly heading: WorkflowPhaseHeading;
   readonly tasks: WorkflowTaskEntry[];
 }
 
-/** Heading facts of one phase row, with counts omitted by the row (a
- *  GROUP_END row can omit them) retained from the previous heading. */
-function phaseHeading(
-  entry: TranscriptRowOf<'phase'>,
-  previous: WorkflowPhaseHeading | undefined,
-): WorkflowPhaseHeading {
-  const phaseIndex = entry.phaseIndex ?? previous?.phaseIndex;
-  const phaseTotal = entry.phaseTotal ?? previous?.phaseTotal;
-  return {
-    phaseLabel: entry.phaseLabel,
-    ...(phaseIndex !== undefined ? { phaseIndex } : {}),
-    ...(phaseTotal !== undefined ? { phaseTotal } : {}),
-  };
-}
-
-/** Derive the dashboard rows for one workflow root at one terminal width. */
+/** Derive the dashboard rows for one workflow root at one terminal width.
+ *
+ *  Phases are the run's own `phase` task groups, and a call joins the group
+ *  its `groupId` names — the same classification the progress view's group
+ *  tree makes (`messageIndex.rebuildTree`). Grouping by the call's `phase`
+ *  *label* instead would fuse two same-named phases and lose a phase the
+ *  script opened but never filled. */
 export function workflowDashboardModel(
   root: StreamSlice,
   columns: number,
 ): WorkflowDashboardModel {
   const groups: MutableWorkflowPhaseGroup[] = [];
-  const byPhase = new Map<string | undefined, MutableWorkflowPhaseGroup>();
-  const tasks: WorkflowTaskEntry[] = [];
-  // The transcript fold already holds exactly the current attempt's rows
-  // (`transcriptFold.ts`), one per logical call, so no re-selection here.
-  for (const entry of root.entries) {
-    if (entry.kind !== 'phase' && entry.kind !== 'workflowTask') continue;
-    const phase = entry.kind === 'phase' ? entry.phaseLabel : entry.call.phase;
-    let group = byPhase.get(phase);
-    if (!group) {
-      group = {
-        value: workflowPhaseListValue(entry.id),
-        label: phase ?? 'Unphased',
-        ...(entry.kind === 'phase'
-          ? { heading: phaseHeading(entry, undefined) }
-          : {}),
-        tasks: [],
-      };
-      byPhase.set(phase, group);
-      groups.push(group);
-    } else if (entry.kind === 'phase') {
-      // A rerun may retain the same phase label with revised index/total data.
-      // Keep the stable first-appearance row identity, but display the latest
-      // heading facts just as the status band does.
-      group.heading = phaseHeading(entry, group.heading);
-    }
-    if (entry.kind === 'workflowTask') {
-      group.tasks.push(entry);
-      tasks.push(entry);
-    }
+  const byGroupId = new Map<string, MutableWorkflowPhaseGroup>();
+  for (const group of root.taskGroups) {
+    if (group.kind !== 'phase') continue;
+    const phaseGroup: MutableWorkflowPhaseGroup = {
+      value: workflowPhaseListValue(group.id),
+      heading: workflowPhaseHeadingOfGroup(group),
+      tasks: [],
+    };
+    groups.push(phaseGroup);
+    byGroupId.set(group.id, phaseGroup);
   }
+  const tasks: WorkflowTaskEntry[] = [];
+  // A call the run issued outside any open phase has no group to sit under.
+  // The board leaves such a row ungrouped in the root timeline; the dashboard
+  // is a phase list, so it collects them into one trailing group rather than
+  // dropping rows the keyboard could otherwise never reach.
+  let ungrouped: MutableWorkflowPhaseGroup | undefined;
+  for (const entry of root.entries) {
+    if (entry.kind !== 'workflowTask') continue;
+    tasks.push(entry);
+    const group = entry.groupId ? byGroupId.get(entry.groupId) : undefined;
+    if (group) {
+      group.tasks.push(entry);
+      continue;
+    }
+    ungrouped ??= {
+      value: workflowPhaseListValue(entry.id),
+      heading: { phaseLabel: 'Unphased' },
+      tasks: [],
+    };
+    ungrouped.tasks.push(entry);
+  }
+  if (ungrouped) groups.push(ungrouped);
 
   const childTaskIndex = new Map<StreamTabId, WorkflowTaskEntry | null>();
   for (const entry of tasks) {

--- a/packages/cli/src/chat/tui/state/workflowPhase.ts
+++ b/packages/cli/src/chat/tui/state/workflowPhase.ts
@@ -1,41 +1,48 @@
 // Current workflow-script phase for orientation chrome (header, status bar).
 
-import { AgentCategory, type StreamTabId } from '@shared/schemas';
-import type { TranscriptRowOf } from '@shared/transcript';
-
-import type { StreamSlice } from './cliState';
+import {
+  AgentCategory,
+  type StreamStage,
+  type StreamTabId,
+} from '@shared/schemas';
+import { formatPhaseStageLabel } from '@shared/streams/streamStatusDisplay';
 
 /**
- * The open phase of one workflow-script stream, if it has emitted one.
- * `category` is the stream's shared-metadata agent category; callers read it
- * (`streamMetadataFor(id)?.agentCategory`) so this selector stays pure.
+ * The open phase of one workflow-script stream, named the way every host names
+ * it: from the shared `StreamExecutionState.stage` the session applier writes,
+ * not from a transcript row this host happens to hold. `stage` is ephemeral —
+ * a reloaded session has none until the run opens its next phase — which is
+ * exactly the gap the progress view's header already lives with.
+ *
+ * Callers pass the stream's shared facts (`streamStateFor(id)?.stage`,
+ * `streamMetadataFor(id)?.agentCategory`) so this selector stays pure.
  */
-export function currentWorkflowPhaseHeading(
-  slice: StreamSlice | undefined,
+function currentWorkflowPhaseLabel(
+  stage: StreamStage | undefined | null,
   category: AgentCategory | undefined,
-): TranscriptRowOf<'phase'> | undefined {
-  if (!slice || category !== AgentCategory.Workflow) return undefined;
-  return slice.entries.findLast(
-    (row): row is TranscriptRowOf<'phase'> => row.kind === 'phase',
-  );
+): string | undefined {
+  if (category !== AgentCategory.Workflow || stage?.kind !== 'phase') {
+    return undefined;
+  }
+  return formatPhaseStageLabel(stage);
 }
 
 /** Nearest workflow-script ancestor's current phase, walking parent links. */
-export function ancestorWorkflowPhaseHeading(init: {
+export function ancestorWorkflowPhaseLabel(init: {
   readonly categoryOf: (streamId: StreamTabId) => AgentCategory | undefined;
+  readonly stageOf: (streamId: StreamTabId) => StreamStage | undefined;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly streamId: StreamTabId;
-  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
-}): TranscriptRowOf<'phase'> | undefined {
+}): string | undefined {
   let id: StreamTabId | undefined = init.streamId;
   const seen = new Set<StreamTabId>();
   while (id && !seen.has(id)) {
     seen.add(id);
-    const phase = currentWorkflowPhaseHeading(
-      init.streams.get(id),
+    const label = currentWorkflowPhaseLabel(
+      init.stageOf(id),
       init.categoryOf(id),
     );
-    if (phase) return phase;
+    if (label) return label;
     id = init.parentStream.get(id);
   }
   return undefined;

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -23,6 +23,7 @@ import { designTokens } from '@shared/styles';
 import {
   formatWorkflowPhaseHeading,
   workflowPhaseCallProgress,
+  workflowPhaseHeadingOfGroup,
   workflowCallFailureTally,
 } from '@shared/copy/workflowCall';
 
@@ -493,11 +494,7 @@ export class TaskGroupList extends LitElement {
             index: group.index,
             total: group.total,
           })
-        : formatWorkflowPhaseHeading({
-            phaseLabel: group.name,
-            phaseIndex: group.index,
-            phaseTotal: group.total,
-          });
+        : formatWorkflowPhaseHeading(workflowPhaseHeadingOfGroup(group));
     return html`
       <span class="group-status-icon">
         ${waIcon(statusIcon, {

--- a/src/shared/copy/workflowCall.ts
+++ b/src/shared/copy/workflowCall.ts
@@ -1,6 +1,7 @@
 import {
   isTerminalWorkflowCallProgress,
   WORKFLOW_TASK_STATUS_LABEL,
+  type TaskGroup,
   type WorkflowCallKind,
   type WorkflowCallProgress,
 } from '@shared/schemas';
@@ -105,6 +106,22 @@ export interface WorkflowPhaseHeading {
   readonly phaseIndex?: number;
   /** Total phase count for the run, when the emitter provides it. */
   readonly phaseTotal?: number;
+}
+
+/**
+ * One phase task group's heading facts, under the names the heading copy uses.
+ * Both hosts hold a phase as a `TaskGroup` — the board's group tree and the
+ * terminal's dashboard — so the field mapping is stated once here rather than
+ * inlined at each call to `formatWorkflowPhaseHeading`.
+ */
+export function workflowPhaseHeadingOfGroup(
+  group: Pick<TaskGroup, 'name' | 'index' | 'total'>,
+): WorkflowPhaseHeading {
+  return {
+    phaseLabel: group.name,
+    ...(group.index !== undefined ? { phaseIndex: group.index } : {}),
+    ...(group.total !== undefined ? { phaseTotal: group.total } : {}),
+  };
 }
 
 /**

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -377,8 +377,10 @@ describe('App foreground Escape ownership', () => {
 
     try {
       stdin.write('\t');
+      // The panel heading tallies the run; the phase row tallies its phase.
+      await waitFor(() => stdout.output.includes('workflow · 0/2 done'));
       await waitFor(() =>
-        stdout.output.includes('workflow · Map (1/1) · 0/2 done'),
+        stdout.output.includes('Map (1/1) · 0/2 · 2 running'),
       );
       stdin.write('\r');
       await waitFor(() => stdout.output.includes('Inspect · Running'));

--- a/src/test-kernel/cli/ChildListInteraction.vitest.ts
+++ b/src/test-kernel/cli/ChildListInteraction.vitest.ts
@@ -27,6 +27,7 @@ import {
   type InkRenderHandles,
 } from '@test/support/inkTestHarness.ts';
 import { waitForCondition as waitFor } from '@test/support/asyncTestUtils';
+import { workflowPhaseGrouping } from '@test/support/transcriptRowFixtures';
 
 const root = 'root' as StreamTabId;
 const child = 'child' as StreamTabId;
@@ -83,9 +84,11 @@ function controlledList(
   return { Harness, current: () => selected };
 }
 
-function workflowRootSlice(entries: StreamSlice['entries']): StreamSlice {
+function workflowRootSlice(rows: StreamSlice['entries']): StreamSlice {
+  const { taskGroups, entries } = workflowPhaseGrouping(rows);
   return {
     ...emptySlice(root),
+    taskGroups,
     entries,
   };
 }

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -1726,6 +1726,13 @@ describe('CLI conversation transcript', () => {
         agentCategory: AgentCategory.Workflow,
         config: { model: 'kimi26T' },
       });
+      // The open phase is the shared stage fact every host names a phase from,
+      // not a transcript row this host happens to hold.
+      childState.getOrCreateStreamState(WORKFLOW, AgentCategory.Workflow);
+      childState.updateStreamState(WORKFLOW, (prev) => ({
+        ...prev,
+        stage: { kind: 'phase', label: 'Survey', index: 0, total: 1 },
+      }));
       childState.updateStreamMetadata(TASK, {
         config: { model: 'kimi26T' },
       });

--- a/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
+++ b/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
@@ -85,7 +85,7 @@ interface StreamConfig {
 
 const CONFIGS: readonly StreamConfig[] = [
   { name: 'tool-use transcript', category: AgentCategory.ToolUse },
-  { name: 'workflow operational feed', category: AgentCategory.Workflow },
+  { name: 'workflow agent transcript', category: AgentCategory.Workflow },
   {
     name: 'workflow full-log child',
     category: AgentCategory.Workflow,
@@ -503,71 +503,31 @@ describe('transcript fold vs from-scratch oracle', () => {
     });
   });
 
-  it('folds a hidden workflow-attempt marker into projection state', () => {
+  it("keeps a relaunched workflow's prior attempt as a closed group", () => {
+    // Parity with the progress view: a relaunch appends a fresh attempt's
+    // rows, and the board keeps the previous attempt's cards on screen (each
+    // relaunch carries fresh stage ids and fresh `workflow-task-*` log ids, so
+    // nothing is double-counted). The terminal shows the same rows. The
+    // attempt marker itself is an `internal` entry, which the shared projector
+    // gives no row on either host.
     withStreamSubscription(() => {
-      configureStreams(CONFIGS[1]);
-      appendTranscriptEntry(defaultSession().transcripts, FOLD_STREAM, {
-        id: 'workflow-attempt-current',
-        type: STREAM_LOG_ENTRY_TYPES.LOG,
-        level: LOG_LEVELS.INFO,
-        timestamp: 1,
-        messageType: MESSAGE_TYPES.INTERNAL,
-        text: '',
-        data: { kind: 'workflowAttempt', attemptId: 'current-attempt' },
-      });
+      const attemptMarker = (
+        id: string,
+        attemptId: string,
+        timestamp: number,
+      ) =>
+        appendTranscriptEntry(defaultSession().transcripts, FOLD_STREAM, {
+          id,
+          type: STREAM_LOG_ENTRY_TYPES.LOG,
+          level: LOG_LEVELS.INFO,
+          timestamp,
+          messageType: MESSAGE_TYPES.INTERNAL,
+          text: '',
+          data: { kind: 'workflowAttempt', attemptId },
+        });
 
-      syncStreamLog(defaultSession(), FOLD_STREAM);
-
-      const slice = streams.get().get(FOLD_STREAM);
-      expect(slice?.transcriptFold?.workflowAttemptId).toBe('current-attempt');
-      expect(slice?.transcriptFold?.workflowAttemptBoundaryDeclared).toBe(true);
-      expect(slice?.entries).toEqual([]);
-
-      appendTranscriptEntry(defaultSession().transcripts, FOLD_STREAM, {
-        id: 'unrelated-internal',
-        type: STREAM_LOG_ENTRY_TYPES.LOG,
-        level: LOG_LEVELS.INFO,
-        timestamp: 2,
-        messageType: MESSAGE_TYPES.INTERNAL,
-        text: '',
-        data: { kind: 'otherInternalRecord' },
-      });
-      syncStreamLog(defaultSession(), FOLD_STREAM);
-      expect(
-        streams.get().get(FOLD_STREAM)?.transcriptFold?.workflowAttemptId,
-      ).toBe('current-attempt');
-
-      appendTranscriptEntry(defaultSession().transcripts, FOLD_STREAM, {
-        id: 'workflow-attempt-malformed',
-        type: STREAM_LOG_ENTRY_TYPES.LOG,
-        level: LOG_LEVELS.INFO,
-        timestamp: 3,
-        messageType: MESSAGE_TYPES.INTERNAL,
-        text: '',
-        data: { kind: 'workflowAttempt', attemptId: '' },
-      });
-      syncStreamLog(defaultSession(), FOLD_STREAM);
-      const invalidSlice = streams.get().get(FOLD_STREAM);
-      expect(invalidSlice?.transcriptFold?.workflowAttemptId).toBeUndefined();
-      expect(
-        invalidSlice?.transcriptFold?.workflowAttemptBoundaryDeclared,
-      ).toBe(true);
-      expect(invalidSlice?.entries).toEqual([]);
-    });
-  });
-
-  it('evicts a failed prior attempt when a new workflow attempt starts', () => {
-    withStreamSubscription(() => {
       configureStreams(CONFIGS[2]);
-      appendTranscriptEntry(defaultSession().transcripts, FOLD_STREAM, {
-        id: 'workflow-attempt-old',
-        type: STREAM_LOG_ENTRY_TYPES.LOG,
-        level: LOG_LEVELS.INFO,
-        timestamp: 1,
-        messageType: MESSAGE_TYPES.INTERNAL,
-        text: '',
-        data: { kind: 'workflowAttempt', attemptId: 'attempt-old' },
-      });
+      attemptMarker('workflow-attempt-old', 'attempt-old', 1);
       appendTranscriptEntry(defaultSession().transcripts, FOLD_STREAM, {
         id: 'old-failed',
         type: STREAM_LOG_ENTRY_TYPES.LOG,
@@ -597,17 +557,9 @@ describe('transcript fold vs from-scratch oracle', () => {
           .get()
           .get(FOLD_STREAM)
           ?.entries.map((entry) => entry.id),
-      ).toEqual(expect.arrayContaining(['old-failed', 'survey-complete-old']));
+      ).toEqual(['old-failed', 'survey-complete-old']);
 
-      appendTranscriptEntry(defaultSession().transcripts, FOLD_STREAM, {
-        id: 'workflow-attempt-new',
-        type: STREAM_LOG_ENTRY_TYPES.LOG,
-        level: LOG_LEVELS.INFO,
-        timestamp: 4,
-        messageType: MESSAGE_TYPES.INTERNAL,
-        text: '',
-        data: { kind: 'workflowAttempt', attemptId: 'attempt-new' },
-      });
+      attemptMarker('workflow-attempt-new', 'attempt-new', 4);
       appendTranscriptEntry(defaultSession().transcripts, FOLD_STREAM, {
         id: 'new-running',
         type: STREAM_LOG_ENTRY_TYPES.LOG,
@@ -624,14 +576,12 @@ describe('transcript fold vs from-scratch oracle', () => {
       });
       syncStreamLog(defaultSession(), FOLD_STREAM);
 
-      const ids =
+      expect(
         streams
           .get()
           .get(FOLD_STREAM)
-          ?.entries.map((entry) => entry.id) ?? [];
-      expect(ids).not.toContain('old-failed');
-      expect(ids).not.toContain('survey-complete-old');
-      expect(ids).toContain('new-running');
+          ?.entries.map((entry) => entry.id),
+      ).toEqual(['old-failed', 'survey-complete-old', 'new-running']);
     });
   });
 

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -63,6 +63,7 @@ import { buildChildRosters } from '@test/support/childRosters';
 import {
   fileListRowFixture,
   toolRowFixture,
+  workflowPhaseGrouping,
 } from '@test/support/transcriptRowFixtures';
 import {
   loadInk,
@@ -78,14 +79,18 @@ function session(id: string, active = false): StreamView {
   };
 }
 
+/** A workflow root as its own run emits it — see `workflowPhaseGrouping`. */
 function workflowAgentSlice(
   id: string,
   overrides: Partial<StreamSlice>,
 ): StreamSlice {
+  const grouping = workflowPhaseGrouping(overrides.entries ?? []);
   return {
     ...emptySlice(id as StreamTabId),
     status: STREAM_PHASE.COMPLETED,
     ...overrides,
+    entries: grouping.entries,
+    ...(overrides.taskGroups ? {} : { taskGroups: grouping.taskGroups }),
   };
 }
 
@@ -1077,8 +1082,16 @@ describe('CLI child list display model', () => {
     const wideOutput = await renderAtColumns(100);
     const narrowOutput = await renderAtColumns(99);
 
-    expect(wideOutput).toContain('research-workflow · Map (1/2) · 2/4 done');
-    expect(wideOutput).toContain('Map (1/2) · 0/2');
+    // The panel heading tallies the run; each phase row tallies its own calls
+    // with the same `done/total · N running · N failed` fold the board's phase
+    // headers use, so the two numbers on screen are never the same number.
+    expect(wideOutput).toContain('research-workflow · 2/4 done');
+    expect(wideOutput).toContain('Map (1/2) · 0/2 · 1 running');
+    expect(wideOutput).toContain('Write (2/2) · 2/2');
+    // Focused and unfocused phase rows start their text in the same column,
+    // and so do the task rows under them.
+    expect(wideOutput).toContain('\n › ◆ Map (1/2)');
+    expect(wideOutput).toContain('\n   ◆ Write (2/2)');
     expect(wideOutput).toContain('Duplicate · Planned');
     expect(wideOutput).toContain('Duplicate · Running');
     expect(wideOutput).toContain('exact-live-model');
@@ -1100,6 +1113,8 @@ describe('CLI child list display model', () => {
     expect(narrowOutput).toContain('↓999');
     expect(narrowOutput).toContain('$0.125');
     expect(narrowOutput).toContain('Cached without child · Saved result');
+    // The full-width list adds one marker per call beside the phase tally.
+    expect(narrowOutput).toContain('Map (1/2) · 0/2 · 1 running □☐');
     for (const [output, columns] of [
       [wideOutput, 100],
       [narrowOutput, 99],
@@ -1111,7 +1126,7 @@ describe('CLI child list display model', () => {
     }
   });
 
-  it('collapses phase labels, synthesizes missing groups, and rejects ambiguous child facts', async () => {
+  it('keeps same-named phase stages apart and collects call-less phases, rejecting ambiguous child facts', async () => {
     const run = 'grouped-run' as StreamTabId;
     const shared = 'shared-child' as StreamTabId;
     const fallback = 'fallback-child' as StreamTabId;
@@ -1253,13 +1268,18 @@ describe('CLI child list display model', () => {
       { until: (frame) => frame.includes('Fallback · Finished') },
     );
 
-    expect(wideOutput.match(/Map \(1\/2\) · 0\/1/g)).toHaveLength(1);
-    expect(wideOutput).toContain('Synthesis · 0/1');
-    expect(wideOutput).toContain('Unphased · 3/7');
+    // Two stages that share the label `Map` are two phases, because the run
+    // opened two of them — the board's group tree says the same. A call whose
+    // declared phase never opened a stage (`Synthesis`) belongs to no group at
+    // all, and joins the trailing collection with the phase-less ones rather
+    // than conjuring a phase nothing entered.
+    expect(wideOutput.match(/Map \(1\/2\) · 0\/0/g)).toHaveLength(1);
+    expect(wideOutput.match(/Map · 0\/1/g)).toHaveLength(1);
+    expect(wideOutput).not.toContain('Synthesis');
+    expect(wideOutput).toContain('Unphased · 3/8 · 3 running');
     expect(wideOutput).toContain('Synthesize · Planned');
-    expect(narrowOutput.match(/Map \(1\/2\) · 0\/1/g)).toHaveLength(1);
-    expect(narrowOutput).toContain('Synthesis · 0/1');
-    expect(narrowOutput).toContain('Unphased · 3/7');
+    expect(narrowOutput.match(/Map \(1\/2\) · 0\/0/g)).toHaveLength(1);
+    expect(narrowOutput).toContain('Unphased · 3/8 · 3 running');
     expect(narrowOutput).toContain('Loose · Planned');
 
     const reusedLine = narrowOutput

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -2252,17 +2252,17 @@ describe('CLI transcript state', () => {
     expect(transcriptRowHeadline(entries[0]!)).toBe('');
   });
 
-  it('tracks hidden thinking activity without rendering thinking text', () => {
+  it('follows the thinking row for the reasoning indicator', () => {
     const logger = runTrace(root);
     const thinking = logger.openStream(MESSAGE_TYPES.THINKING);
 
-    // Opening the stream alone marks the phase — hidden reasoning (e.g.
-    // gpt-5 without summaries) may never produce a text delta.
+    // The indicator reads the transcript's own rows. An opened stream with no
+    // text delta yet (hidden reasoning — e.g. gpt-5 without summaries) has no
+    // row, so it lights nothing up until the first delta arrives.
     syncStreamLog(defaultSession(), root);
 
     let slice = streams.get().get(root);
-    expect(slice?.thinkingActive).toBe(true);
-    // An opened stream with no delta says nothing yet, so it has no row.
+    expect(slice?.thinkingActive).toBe(false);
     expect(slice?.entries).toEqual([]);
 
     thinking.append('private reasoning summary');
@@ -2291,7 +2291,7 @@ describe('CLI transcript state', () => {
     expect(entryTexts(root)).toEqual(['Thinking', 'Visible answer.']);
   });
 
-  it('projects workflow tools and errors while excluding thinking and raw model prose', () => {
+  it('projects the same rows on a workflow-agent stream as every other host', () => {
     markWorkflow(root);
     const logger = runTrace(root);
     const thinking = logger.openStream(MESSAGE_TYPES.THINKING);
@@ -2333,18 +2333,23 @@ describe('CLI transcript state', () => {
 
     syncStreamLog(defaultSession(), root);
 
+    // Membership is the shared projector's single allowlist: a workflow-agent
+    // stream withholds nothing the progress view would show. Which line the
+    // CLI's status chrome quotes is a separate, paint-time choice.
     const slice = streams.get().get(root);
     expect(slice?.entries.map(({ kind }) => kind)).toEqual([
+      'thinking',
+      'assistant',
       'tool',
       'error',
+      'user',
+      'assistant',
       'error',
     ]);
     expect(JSON.stringify(slice)).toContain('workflow provider failed');
     expect(JSON.stringify(slice)).toContain('synthetic workflow error');
-    expect(JSON.stringify(slice)).not.toContain('private workflow reasoning');
-    expect(JSON.stringify(slice)).not.toContain('raw workflow model response');
-    expect(JSON.stringify(slice)).not.toContain('synthetic workflow prompt');
-    expect(JSON.stringify(slice)).not.toContain('synthetic workflow response');
+    expect(JSON.stringify(slice)).toContain('private workflow reasoning');
+    expect(JSON.stringify(slice)).toContain('raw workflow model response');
     expect(slice?.latestLine).toBe('synthetic workflow error');
   });
 
@@ -2368,14 +2373,15 @@ describe('CLI transcript state', () => {
     expect(slice?.latestLine).not.toContain('\u001b');
     expect(slice?.latestLine).not.toContain('\u0007');
     expect(slice?.entries).toMatchObject([
+      { kind: 'user', messageType: MESSAGE_TYPES.USER_MESSAGE },
       { kind: 'log', messageType: MESSAGE_TYPES.DEFAULT },
+      { kind: 'assistant', messageType: MESSAGE_TYPES.MODEL_RESPONSE },
     ]);
     expect(entryTexts(child1)).toEqual([
+      'workflow prompt',
       'Preparing proof audit API_KEY=[redacted]',
-    ]);
-    expect(JSON.stringify(slice?.entries)).not.toContain(
       'raw workflow model response',
-    );
+    ]);
 
     logToolUse(logger, {
       toolName: 'bash',
@@ -2416,21 +2422,21 @@ describe('CLI transcript state', () => {
     slice = streams.get().get(child1);
     expect(slice?.latestLine).toBe('Proof audit failed');
     expect(slice?.entries.map(({ kind }) => kind)).toEqual([
+      'user',
       'log',
+      'assistant',
       'tool',
       'tool',
       'phase',
       'error',
     ]);
-    expect(JSON.stringify(slice)).not.toContain('workflow prompt');
     // The ordinary log line survives the later rows, and it still paints
     // safely: terminal control sequences are stripped by the headline the
     // painter reads, not stored pre-stripped on the row.
-    expect(entryTexts(child1)[0]).toBe(
+    expect(entryTexts(child1)[1]).toBe(
       'Preparing proof audit API_KEY=[redacted]',
     );
     expect(JSON.stringify(slice)).not.toContain(secret);
-    expect(JSON.stringify(slice)).not.toContain('raw workflow model response');
   });
 
   it('updates dormant workflow summaries while retaining only dashboard rows', () => {
@@ -2493,7 +2499,12 @@ describe('CLI transcript state', () => {
         },
       ],
     });
-    expect(JSON.stringify(slice)).not.toContain('raw dormant workflow prose');
+    // The compact selection an unfocused workflow keeps is a residency cap on
+    // what the dashboard paints, not a membership rule: the full transcript is
+    // still folded behind it and comes back when the stream is focused.
+    expect(JSON.stringify(slice?.entries)).not.toContain(
+      'raw dormant workflow prose',
+    );
   });
 
   it('bounds dormant workflow dashboard rows while preserving source order', () => {

--- a/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
+++ b/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
@@ -14,7 +14,11 @@ import {
   uniqueWorkflowChildStreamId,
   workflowDashboardModel,
 } from '@cli/chat/tui/state/workflowDashboardModel';
-import { type StreamTabId, type WorkflowCallProgress } from '@shared/schemas';
+import {
+  type StreamTabId,
+  type TaskGroup,
+  type WorkflowCallProgress,
+} from '@shared/schemas';
 import type { TranscriptRow, TranscriptRowOf } from '@shared/transcript';
 import { loadInk, renderInteractive } from '@test/support/inkTestHarness.ts';
 import {
@@ -34,20 +38,17 @@ interface TaskSpec {
   readonly childStreamId?: StreamTabId;
 }
 
-function phaseRow(
-  phaseLabel: string,
-  phaseIndex: number,
-  phaseTotal: number,
-): TranscriptRowOf<'phase'> {
+/** A phase as the run's own lifecycle rows record it — the container both
+ *  hosts group by. */
+function phaseGroup(name: string, index: number, total: number): TaskGroup {
   return {
+    id: `phase-${name}`,
+    name,
+    startTime: 0,
+    status: 'running',
     kind: 'phase',
-    id: `phase-${phaseLabel}`,
-    timestamp: 0,
-    level: 'info',
-    heading: phaseLabel,
-    phaseLabel,
-    phaseIndex,
-    phaseTotal,
+    index,
+    total,
   };
 }
 
@@ -66,6 +67,7 @@ function taskRow(task: TaskSpec): TranscriptRowOf<'workflowTask'> {
     id: `task-${task.id}`,
     timestamp: 0,
     level: 'info',
+    ...(task.phase === undefined ? {} : { groupId: `phase-${task.phase}` }),
     call,
     line: `Running: ${task.id}`,
     statusLabel: 'Running',
@@ -79,12 +81,10 @@ function workflowRoot(
 ): StreamSlice {
   return {
     ...emptySlice(ROOT),
-    entries: [
-      ...phases.map((phaseLabel, phaseIndex) =>
-        phaseRow(phaseLabel, phaseIndex, phases.length),
-      ),
-      ...tasks.map(taskRow),
-    ],
+    taskGroups: phases.map((name, index) =>
+      phaseGroup(name, index, phases.length),
+    ),
+    entries: tasks.map(taskRow),
   };
 }
 
@@ -185,10 +185,9 @@ describe('workflow dashboard model', () => {
   it('orders phase rows by first appearance and task rows by transcript order', () => {
     const model = workflowDashboardModel(TWO_PHASE_ROOT, WIDE_COLUMNS);
 
-    expect(model.groups.map((group) => group.label)).toStrictEqual([
-      'Map',
-      'Reduce',
-    ]);
+    expect(model.groups.map((group) => group.heading.phaseLabel)).toStrictEqual(
+      ['Map', 'Reduce'],
+    );
     expect(model.tasks.map((entry) => entry.call.label)).toStrictEqual([
       'inspect',
       'extract',
@@ -238,88 +237,48 @@ describe('workflow dashboard model', () => {
     ).toBeUndefined();
   });
 
-  it('uses the latest heading facts when a rerun retains a phase label', () => {
+  it('reads a phase heading from its task group, closed or open', () => {
+    // The shared task-group projection already carries index/total across a
+    // `GROUP_END` upsert, so the dashboard has no counts of its own to inherit.
     const root = workflowRoot(
       ['Verify'],
       [{ id: 'verification', phase: 'Verify' }],
     );
-    const currentHeading: TranscriptRowOf<'phase'> = {
-      kind: 'phase',
-      id: 'phase-verify-current',
-      timestamp: 0,
-      level: 'info',
-      heading: 'Verify',
-      phaseLabel: 'Verify',
-      phaseIndex: 2,
-      phaseTotal: 3,
-      attemptId: 'current',
+    const closed: TaskGroup = {
+      ...root.taskGroups[0]!,
+      status: 'completed',
+      endTime: 5,
     };
 
-    const model = workflowDashboardModel(
-      { ...root, entries: [...root.entries, currentHeading] },
-      WIDE_COLUMNS,
-    );
-
-    expect(model.groups[0]?.heading).toStrictEqual({
-      phaseLabel: 'Verify',
-      phaseIndex: 2,
-      phaseTotal: 3,
-    });
-  });
-
-  it('fills only the heading count omitted by the latest phase row', () => {
-    const root = workflowRoot(
-      ['Verify'],
-      [{ id: 'verification', phase: 'Verify' }],
-    );
-    const currentHeading: TranscriptRowOf<'phase'> = {
-      kind: 'phase',
-      id: 'phase-verify-partial',
-      timestamp: 0,
-      level: 'info',
-      heading: 'Verify',
-      phaseLabel: 'Verify',
-      phaseIndex: 2,
-    };
-
-    const model = workflowDashboardModel(
-      { ...root, entries: [...root.entries, currentHeading] },
-      WIDE_COLUMNS,
-    );
-
-    expect(model.groups[0]?.heading).toMatchObject({
-      phaseIndex: 2,
-      phaseTotal: 1,
-    });
+    expect(
+      workflowDashboardModel(root, WIDE_COLUMNS).groups[0]?.heading,
+    ).toStrictEqual({ phaseLabel: 'Verify', phaseIndex: 0, phaseTotal: 1 });
+    expect(
+      workflowDashboardModel({ ...root, taskGroups: [closed] }, WIDE_COLUMNS)
+        .groups[0]?.heading,
+    ).toStrictEqual({ phaseLabel: 'Verify', phaseIndex: 0, phaseTotal: 1 });
   });
 
   it('renders a current empty dynamic phase', async () => {
     const root = workflowRoot([], []);
-    const currentPhase: TranscriptRowOf<'phase'> = {
-      kind: 'phase',
+    // A phase the script opened dynamically carries no declared position.
+    const currentPhase: TaskGroup = {
       id: 'phase-current',
-      timestamp: 0,
-      level: 'info',
-      heading: 'Explore',
-      phaseLabel: 'Explore',
-      attemptId: 'current',
+      name: 'Explore',
+      startTime: 0,
+      status: 'running',
+      kind: 'phase',
     };
+    const withPhase = { ...root, taskGroups: [currentPhase] };
 
-    const model = workflowDashboardModel(
-      { ...root, entries: [currentPhase] },
-      WIDE_COLUMNS,
-    );
+    const model = workflowDashboardModel(withPhase, WIDE_COLUMNS);
 
     expect(model.groups).toHaveLength(1);
     expect(model.groups[0]).toMatchObject({
-      label: 'Explore',
       heading: { phaseLabel: 'Explore' },
       tasks: [],
     });
-    const narrowModel = workflowDashboardModel(
-      { ...root, entries: [currentPhase] },
-      NARROW_COLUMNS,
-    );
+    const narrowModel = workflowDashboardModel(withPhase, NARROW_COLUMNS);
     expect(narrowModel.listValues).toStrictEqual([
       narrowModel.groups[0]?.value,
     ]);
@@ -339,7 +298,8 @@ describe('workflow dashboard model', () => {
     );
     try {
       await waitFor(() => stdout.output.includes('Explore · 0/0'));
-      expect(stdout.output).toContain('Workflow · Explore · 0/0 done');
+      // The panel heading counts the run; the phase row counts the phase.
+      expect(stdout.output).toContain('Workflow · 0/0 done');
     } finally {
       instance.unmount();
     }

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
@@ -905,6 +905,14 @@ describe('CLI workflow-script child-stream transcript', () => {
       ).pending,
     ).toEqual([]);
 
+    // A run's open phase is the shared stage fact, which the applier writes
+    // from the same `stage.start` this test's `openStage` emitted; the header
+    // reads it there rather than scanning for a phase row of its own.
+    boundState.getOrCreateStreamState(STREAM_ID, AgentCategory.Workflow);
+    boundState.updateStreamState(STREAM_ID, (prev) => ({
+      ...prev,
+      stage: { kind: 'phase', label: 'Draft sections' },
+    }));
     const staticItems = appendItems([], {
       childRosters: new Map([
         [

--- a/src/test-kernel/support/transcriptRowFixtures.ts
+++ b/src/test-kernel/support/transcriptRowFixtures.ts
@@ -12,6 +12,7 @@
 import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
+  STREAM_PHASE,
   TOOL_USE_STATUS,
   type FileListEntry,
   type NormalizedToolUse,
@@ -169,4 +170,46 @@ export function projectTaskGroupsFromStreamLog(
     upsertTaskGroupFromStreamLog(taskGroups, taskGroupIndex, entry);
   }
   return taskGroups;
+}
+
+/**
+ * A workflow root's rows as its own run emits them: phase divider rows in
+ * emission order, each call carrying the phase it was issued in.
+ *
+ * The recorder records the open phase stage as a task group and stamps that
+ * stage's id onto the calls issued inside it, and both hosts group calls by
+ * that `groupId`. Deriving both here lets a fixture state a phase once. A call
+ * whose declared phase is not the open one carries no group, exactly as a
+ * stage-blocked call does.
+ */
+export function workflowPhaseGrouping(rows: readonly TranscriptRow[]): {
+  readonly taskGroups: TaskGroup[];
+  readonly entries: TranscriptRow[];
+} {
+  const taskGroups: TaskGroup[] = [];
+  let openPhase: TranscriptRowOf<'phase'> | undefined;
+  const entries = rows.map((row) => {
+    if (row.kind === 'phase') {
+      openPhase = row;
+      taskGroups.push({
+        id: row.id,
+        name: row.phaseLabel,
+        startTime: row.timestamp,
+        status: STREAM_PHASE.RUNNING,
+        kind: 'phase',
+        ...(row.phaseIndex !== undefined ? { index: row.phaseIndex } : {}),
+        ...(row.phaseTotal !== undefined ? { total: row.phaseTotal } : {}),
+      });
+      return row;
+    }
+    if (
+      row.kind !== 'workflowTask' ||
+      openPhase === undefined ||
+      row.call.phase !== openPhase.phaseLabel
+    ) {
+      return row;
+    }
+    return { ...row, groupId: openPhase.id };
+  });
+  return { taskGroups, entries };
 }


### PR DESCRIPTION
## Summary

The terminal's transcript/log plane held three private rules the progress view
does not have, so the same facts produced two different runs on screen. This PR
deletes all three and points the terminal at the shared state — same state,
different rendering.

1. **Prior-attempt eviction (deleted).** `transcriptFold` parsed a
   `workflow.attempt` `internal` marker and evicted every row of the preceding
   attempt from the fold. The board keeps a relaunched workflow's earlier
   attempt as a closed run group — each relaunch carries fresh stage ids and
   fresh `workflow-task-<projectionId>-<callId>` log ids, so nothing is
   double-counted — and `docs/proposals/2026-08-28-workflow-plan-vs-issued-calls.md`
   § Study rejects an extension-side attempt fold by name ("the double-counting
   it assumed does not exist"). The terminal now shows the same rows.
   The marker itself stays a durable diagnostic record: `projectTranscriptRow`
   returns `undefined` for `MESSAGE_TYPES.INTERNAL`, so **neither** host renders
   it and no host-local INTERNAL drop was needed (the extension's
   `logSlice.ts:136-142` early-return is the same decision, one layer up).

2. **Workflow-stream membership filter (deleted).** `WORKFLOW_OPERATIONAL_KINDS`
   / `isWorkflowOperationalRow` withheld `assistant`, `thinking`, and `user`
   rows on `AgentCategory.Workflow` streams at three sites (log fold, compaction
   reconcile, local-row reconcile), plus the `workflowOperationalOnly` mode bit
   that forced a fold rebuild on every flip. The shared projector's contract is
   explicit: membership is one allowlist, "row density … is a paint-time choice;
   it is never expressed by withholding a row". `compactWorkflowEntries` — the
   residency cap for an *unfocused* workflow — is a container, not a membership
   rule, and is kept. Which line the CLI's status chrome quotes stays CLI
   modality (`workflowStatusFeed`, a local, no longer a fold-state bit).

3. **Phase grouping (re-keyed onto the group tree).** The dashboard grouped by
   the call's `phase` *label* and `phaseHeading()` re-implemented the GROUP_END
   index/total inheritance that `upsertTaskGroupFromStreamLog` already performs.
   Phases are now `slice.taskGroups` filtered to `kind === 'phase'`, and a call
   joins the group its `groupId` names — the rule
   `messageIndex.rebuildTree` (packages/extension/.../messageIndex.ts:223-286)
   applies. Two same-named stages stay two phases; a stage the script opened but
   never filled keeps its row; a call with no open phase collects into one
   trailing group instead of conjuring a phase nothing entered. The live band and
   the status-bar/scrollback phase slot moved with it, the latter onto the shared
   `StreamExecutionState.stage` the applier writes (accepting the same
   reload gap the progress-view header already has — `stage` is ephemeral).

Also folded in: `thinkingActive` reads the newest thinking row's `streaming`
flag instead of a parallel live-activity tracker over raw log entries; the CLI's
compaction-settle call takes the same shape `logSlice` passes; and the dashboard
gained the board's phase fold.

**`rebuildTree` was measured for extraction and left host-local.** The board
needs a nested tree with orphan re-rooting, an ungrouped bucket, and a
chronological timeline (~65 L); the terminal needs an ordered flat phase list
with per-phase call buckets (~18 L in `workflowDashboardModel`). Sharing them
would have meant a superset shape plus two adapters — a net add, exactly the
extraction the refactor-LoC lesson warns about. What *is* shared is the rule
(group by `groupId`) and the copy: `workflowPhaseHeadingOfGroup` in
`@shared/copy/workflowCall`, which both hosts now use where each had the
`TaskGroup` → `WorkflowPhaseHeading` field mapping inlined.

## Issue acceptance gates

No issue. Directive work under
`docs/proposals/2026-08-15-single-substrate-hosts-as-renderers.md` §5 (Wave B —
"collapse the rules, keep the containers"; the B-2 membership ruling) and
`docs/proposals/2026-08-28-workflow-plan-vs-issued-calls.md` § Study (attempt
fold rejected; phase header = `done/total · N running · N failed` + one status
dot per call, both folds over rows the host already holds — no new owner of
counts).

## Single source of truth

- **Transcript-row membership** — `projectTranscriptRow` (`src/shared/transcript/`),
  the only allowlist. No host filters on top of it.
- **Phase identity and grouping** — the run's `phase` `TaskGroup`s plus each
  row's `groupId`, projected by `upsertTaskGroupFromStreamLog`. No host
  re-derives a phase from a label or re-inherits its counts.
- **Phase heading copy** — `workflowPhaseHeadingOfGroup` +
  `formatWorkflowPhaseHeading` (`src/shared/copy/workflowCall`).
- **Call tallies** — `workflowPhaseCallProgress` / `workflowCallFailureTally`,
  the same two folds `TaskGroupList.renderWorkflowCallTally` uses. The CLI's
  `workflowPhaseTallyText` composes them; it does not count anything itself.
- **Current stage** — `StreamExecutionState.stage` (written by
  `SessionFactApplier`), read via `streamStateFor(id)?.stage`.
- **Reasoning indicator** — the newest `thinking` row's `streaming` flag on the
  fold's own items.

## Duplication and abstraction budget

Removed: a second attempt-scope model, a second membership rule, a second
phase-count inheritance, a second live-activity tracker (`liveActivityEntry` +
`LIVE_ACTIVITY_MESSAGE_TYPES` + `retrackLiveActivityEntry`), a second
"is this payload streaming" predicate (`logEntryStreamIsRunning`, which
duplicated `isStreamingPayload`), and one of the two phase-row renderers in
`SubagentList` (the wide and narrow layouts had separate markup).

Added: `workflowPhaseHeadingOfGroup` (shared, 3 consumers: extension
`TaskGroupList`, CLI dashboard model, CLI status band) and three CLI display
helpers in `SubagentListDisplay` — `workflowPhaseTallyText` and
`workflowPhaseStatusStrip` (2 consumers each: the two dashboard layouts via
`PhaseHeader`) and `dashboardMarkerCell` (2 consumers: `PhaseHeader`,
`WorkflowTaskRow`). No new layer: each is a leaf formatter beside the component
that paints it, and none owns a count.

## Net elements (R6)

| | production | tests | total |
| --- | ---: | ---: | ---: |
| files changed | 12 | 9 | 22 (incl. CHANGELOG) |
| net LoC (`git diff --stat origin/main`) | +306 / −335 = **−29** | +211 / −193 | +517 / −528 = **−11** |

Exported symbols (`^[+-]export` over the full diff): **6 added, 3 removed**
(net +3).

- Removed: `logEntryStreamIsRunning`, `currentWorkflowPhaseHeading`,
  `ancestorWorkflowPhaseHeading`.
- Added: `workflowPhaseHeadingOfGroup` (shared),
  `dashboardMarkerCell` / `workflowPhaseTallyText` / `workflowPhaseStatusStrip`
  (CLI display), `ancestorWorkflowPhaseLabel` (replaces the removed
  `ancestorWorkflowPhaseHeading`, one param lighter), `workflowPhaseGrouping`
  (test-kernel fixture, 3 suites — the fixture rule of three).

Classes / interfaces / type declarations: **1 removed** (`PhaseHeaderDetails`),
0 added. Module-level constants: 2 removed (`WORKFLOW_OPERATIONAL_KINDS`,
`LIVE_ACTIVITY_MESSAGE_TYPES`), 2 added (`DASHBOARD_MARKER_COLUMNS`,
`PHASE_STATUS_STRIP_LIMIT`). Interface fields on `TranscriptFoldState`: **5
removed** (`workflowOperationalOnly`, `liveActivityEntry`, `workflowAttemptId`,
`workflowAttemptBoundaryDeclared`, `workflowAttemptSeqNo`), 0 added; on
`WorkflowPhaseGroup`, `label` removed and `heading` made required.
File-local functions: **6 removed** (`isWorkflowOperationalRow`,
`isSupersededAttemptId`, `isPriorWorkflowAttemptRow`,
`evictPriorWorkflowAttemptItems`, `retrackLiveActivityEntry`, `phaseHeading`),
1 added (`renderPhase`, which replaces two inline renderers).

`config/ratchets/knip-baseline.json` is unchanged: the ratchet reports
379 combined findings against 379 baselined, so nothing in it went dead here and
nothing new was added (`currentWorkflowPhaseLabel` is file-local by
construction, not baselined).

## Consumer counts (R8)

Grepped with `git grep -w <sym> origin/main -- src packages` (refs including the
definition; "consumers" excludes it).

| deleted symbol / field | refs @ origin/main | consuming files | after |
| --- | ---: | --- | --- |
| `isSupersededAttemptId` | 3 | `transcriptFold.ts` (file-local) | 0 |
| `isPriorWorkflowAttemptRow` | 3 | `transcriptFold.ts` (file-local) | 0 |
| `evictPriorWorkflowAttemptItems` | 2 | `transcriptFold.ts` (file-local) | 0 |
| `isWorkflowOperationalRow` | 4 | `transcriptFold.ts` (file-local, 3 call sites) | 0 |
| `WORKFLOW_OPERATIONAL_KINDS` | 2 | `transcriptFold.ts` (file-local) | 0 |
| `LIVE_ACTIVITY_MESSAGE_TYPES` | 3 | `transcriptFold.ts` (file-local) | 0 |
| `retrackLiveActivityEntry` | 2 | `transcriptFold.ts` (file-local) | 0 |
| `logEntryStreamIsRunning` (exported) | 3 | `transcriptFold.ts` (def), `subscribeStreamLog.ts` (1 consumer) | 0 |
| `currentWorkflowPhaseHeading` (exported) | 4 | `workflowPhase.ts` (def + 1), `ConversationPane.tsx` (2) | replaced by a file-local `currentWorkflowPhaseLabel` |
| `ancestorWorkflowPhaseHeading` (exported) | 5 | `workflowPhase.ts` (def), `StatusBar.tsx` (2), `StaticConversationTranscript.tsx` (2) | replaced 1:1 by `ancestorWorkflowPhaseLabel` at both sites |
| `phaseHeading` | 3 | `workflowDashboardModel.ts` (file-local) | 0 |
| `TranscriptFoldState.workflowAttemptId` | 8 | `cliState.ts` (decl), `transcriptFold.ts` (4), `StreamLogDeltaFold.vitest.ts` (3) | 0 |
| `TranscriptFoldState.workflowAttemptBoundaryDeclared` | 9 | `cliState.ts`, `transcriptFold.ts` (5), `StreamLogDeltaFold.vitest.ts` (3) | 0 |
| `TranscriptFoldState.workflowAttemptSeqNo` | 6 | `cliState.ts`, `transcriptFold.ts` (5) | 0 |
| `TranscriptFoldState.workflowOperationalOnly` | 9 | `cliState.ts`, `transcriptFold.ts` (4), `subscribeStreamLog.ts` (4) | 0 |
| `TranscriptFoldState.liveActivityEntry` | 8 | `cliState.ts`, `transcriptFold.ts` (6), `subscribeStreamLog.ts` (1) | 0 |
| `PhaseHeaderDetails` | 3 | `SubagentList.tsx` (file-local) | 0 |
| `WorkflowPhaseGroup.label` | — | `workflowDashboardModel.ts`, `SubagentList.tsx` (3), tests | now `heading.phaseLabel` |

No emit path, bus subscription, or IPC message was added, removed, or re-routed.

## What the CLI now shows identically to the board

- **Every row of a workflow-agent stream** — assistant prose, thinking,
  user prompts, tool rows, errors, file lists. One allowlist, no host filter.
- **A relaunched workflow's prior attempt**, retained as a closed group beside
  the new one, instead of vanishing when the fresh attempt marker lands.
- **Phases as the run opened them** — two stages named `Map` are two phases; a
  stage with no calls still shows; a call is in the phase whose stage issued it,
  not the phase whose label it repeats.
- **A phase's counts** — `done/total · N running · N failed`, the same
  `workflowPhaseCallProgress` + running filter + `workflowCallFailureTally` fold
  as `TaskGroupList.renderWorkflowCallTally`.
- **One status marker per issued call** beside the phase tally, the terminal's
  counterpart to the board's status-dot strip, capped at 24 with a `+N` tail
  (the board caps at 40). Rendered in the full-width list, where the phase row
  owns the terminal; in the two-column layout the task column beside it already
  paints one marker per call.
- **The phase heading text** — `formatWorkflowPhaseHeading` over the same
  `TaskGroup` name/index/total, via one shared field mapping.
- **The whole-run band above the phases** — the panel heading's `N/N done · N
  failed` is now labelled as the run (the phase name moved off it), matching
  `renderRunBand`; the live status band under the transcript names the phase it
  counts, so the two numbers on screen are never the same number twice.

## Host impact

Extension: one call site in `TaskGroupList.renderGroupHeader` now builds its
phase heading through the shared `workflowPhaseHeadingOfGroup` instead of an
inline field mapping. No rendered output changes.

Desktop: none (it renders the extension's progress view).

CLI: the behavior above. Two deliberate, stated behavior changes beyond parity:

- **A thinking block opened with no text delta no longer lights the "thinking"
  indicator.** The old tracker watched raw entries, so an opened-but-empty
  reasoning stream (e.g. gpt-5 without summaries) flipped the indicator with no
  row to show for it; the new derivation reads the rows, and a row that does not
  exist drives nothing. This is the same thing the progress view does with such
  an entry (nothing). The spinner still runs from the run's own status; only the
  "Thinking" wording is lost for that case.
- **The compaction settle boundary is now the projection's own applied head**
  (the shared default) rather than `log.size`, matching what `logSlice` passes,
  and the CLI now supplies `finishedAt` from `log.lastTimestamp` the way the
  progress view supplies it from `streamState.lastTimestamp`. The one-entry
  difference in `settledThroughSeqNo` only affected which late outcome could
  still replace a provisional interruption.

## Scheduled refactoring

None. The two §8 fence rows this touches near (`workflowPlainOutput`, the
log-fold container split) are untouched and stay fenced.

## Validation

- `npx prettier --write` on every changed file, then `npm run format` — clean.
- `CI=true npm run typecheck` — clean (workspace, test-kernel, agent, cli,
  trace-viewer, desktop).
- `npm run lint` — clean.
- `CI=true npm run check:dead-code-ratchet` — "no new findings"; 379 combined vs
  379 baselined, baseline unchanged.
- `FORCE_COLOR=0 npx vitest run src/test-kernel/cli src/test-kernel/shared
  src/test-kernel/transcript` — **191 files, 3119 passed, 1 skipped, 0 failed.**
- `src/test-kernel/progressView` (56 files / 536 tests) and
  `src/test-kernel/frontend` (16 / 79) — green, for the shared-copy and
  `TaskGroupList` edits.
- `src/test-kernel/desktop/DesktopAgentExecution.vitest.ts` fails 3 tests
  (timeouts / "default session has already been initialized") **identically on a
  clean `origin/main` worktree** — pre-existing flake, not from this change.

### Tests

No new test files. Existing suites were re-pointed at the new contract:
`StreamLogDeltaFold` replaces its two attempt-eviction tests with one retention
test; `TuiStateAndFocus` inverts the three membership assertions and the
thinking-indicator one; `WorkflowDashboardModel` drops the two
label-inheritance tests (that inheritance now lives in the shared task-group
projection) for one group-driven heading test; `SubagentListDisplay`,
`ChildListInteraction`, and `AppEscapeRouting` build their fixtures through a
new shared `workflowPhaseGrouping` helper in `src/test-kernel/support`
(fixture rule of three) instead of three local copies.
