### PR TITLE
refactor(cli): delete dead runtime seams and fix approval-policy and help-flag handling

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -139,10 +139,7 @@ import {
   resolveCliModelAccessRoute,
 } from '../src/runtime/modelAccessRoute';
 import { updateCliModelAccess } from '../src/runtime/modelAccessSelection';
-import {
-  formatCliApiStatusActionHint,
-  formatCliAuthStatusLine,
-} from '../src/runtime/apiStatus';
+import { formatCliAuthStatusLine } from '../src/runtime/apiStatus';
 import {
   buildCliAgentItems,
   buildCliOrchestrationItems,
@@ -630,7 +627,6 @@ function harnessOrchestrationStatusLines(): readonly string[] {
   return [
     `api: ${formatCliModelAccessRouteInline('personal')}`,
     formatCliAuthStatusLine(profile),
-    formatCliApiStatusActionHint(profile),
   ];
 }
 

--- a/packages/cli/src/commands/_helpers/globalArgs.ts
+++ b/packages/cli/src/commands/_helpers/globalArgs.ts
@@ -58,8 +58,7 @@ type CliSkillSourceArgsDef = {
 };
 
 function formatCommaList(items: readonly string[]): string {
-  if (items.length <= 2) return items.join(' and ');
-  return `${items.slice(0, -1).join(', ')}, and ${items.at(-1)}`;
+  return new Intl.ListFormat('en', { type: 'conjunction' }).format(items);
 }
 
 export const GLOBAL_ARGS: CliGlobalArgsDef = {

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -1,32 +1,14 @@
 import { defineCommand } from 'citty';
 
-import { CliUsageError } from '../runtime/cliContext';
-
-import {
-  resolveDeepestSubCommand,
-  showUsage,
-  detectUnknownCliCommand,
-  formatUnknownCliCommand,
-} from './_helpers/dispatch';
+import { setExitCode } from './_helpers/exitCode';
 
 export const helpCommand = defineCommand({
   meta: { name: 'help', description: 'Show TeXRA CLI commands' },
   async run(ctx) {
-    const { rootCommand } = await import('./root');
-    if (ctx.rawArgs.length === 0) {
-      await showUsage(rootCommand);
-      return;
-    }
-
-    const unknownCommand = await detectUnknownCliCommand(
-      rootCommand,
-      ctx.rawArgs,
-    );
-    if (unknownCommand) {
-      throw new CliUsageError(formatUnknownCliCommand(unknownCommand));
-    }
-
-    const resolved = await resolveDeepestSubCommand(rootCommand, ctx.rawArgs);
-    await showUsage(resolved.command, resolved.parent, resolved);
+    // `texra help <path...>` is `texra <path...> --help`: re-enter the root
+    // dispatcher, which owns unknown-command detection and usage rendering.
+    const { runCli } = await import('./root');
+    const { exitCode } = await runCli([...ctx.rawArgs, '--help']);
+    setExitCode(exitCode);
   },
 });

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -4,6 +4,7 @@ import { defineCommand } from 'citty';
 
 import { formatChatAsMarkdown } from '@agent/export';
 import { projectWorkflowCallEntries } from '@model/projectWorkflowCallEntry';
+import { listExecutions } from '@agent/storage';
 import { type ExecutionId } from '@shared/schemas';
 import { formatCliHistoryDeletionSummary } from '@shared/copy/executionHistory';
 import { assembleTrace, injectStandaloneTrace } from '@transcript';
@@ -21,7 +22,6 @@ import {
   formatInvalidExportFormatText,
   listCliHistoryEntries,
   parseCliHistoryId,
-  preflightCliHistoryDeleteAll,
   readCliHistoryDetails,
   readCliHistoryExportInput,
   readCliHistoryStandaloneTemplate,
@@ -208,17 +208,16 @@ async function runHistoryDelete(
 
   // `--all` is destructive and unrecoverable. Refuse it unless the caller
   // also passes `--yes`, and quote the count so the stakes are explicit.
-  if (options.all) {
-    const preflight = await preflightCliHistoryDeleteAll({
-      all: true,
-      yes: options.yes,
-    });
-    if (!preflight.proceed) {
-      writeTextStderr(
-        `Refusing to delete ${formatResultCount(preflight.count, 'stored execution')}. Re-run with --yes to confirm.`,
-      );
-      return CliExitCode.Usage;
-    }
+  if (options.all && !options.yes) {
+    // Unlike list, a full wipe intentionally counts (and later clears) every
+    // stored execution, including `isUserVisibleExecution`-hidden
+    // process-bookkeeping entries and agent-spawned child runs — don't add the
+    // visibility filter here.
+    const count = (await listExecutions()).length;
+    writeTextStderr(
+      `Refusing to delete ${formatResultCount(count, 'stored execution')}. Re-run with --yes to confirm.`,
+    );
+    return CliExitCode.Usage;
   }
 
   let result: CliHistoryDeleteResult;

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -3,8 +3,8 @@ import * as path from 'node:path';
 import { defineCommand } from 'citty';
 
 import { formatChatAsMarkdown } from '@agent/export';
-import { projectWorkflowCallEntries } from '@model/projectWorkflowCallEntry';
 import { listExecutions } from '@agent/storage';
+import { projectWorkflowCallEntries } from '@model/projectWorkflowCallEntry';
 import { type ExecutionId } from '@shared/schemas';
 import { formatCliHistoryDeletionSummary } from '@shared/copy/executionHistory';
 import { assembleTrace, injectStandaloneTrace } from '@transcript';

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -15,7 +15,7 @@ import {
 } from '../runtime/modelAccess';
 import {
   buildInitConfig,
-  configFileExists,
+  pathExists,
   ensureTexraGitignored,
   writeInitConfig,
   type GitignoreOutcome,
@@ -168,7 +168,7 @@ async function runInit(
   await initCliPlatform({ ...context, quietLogs: true });
 
   const filePath = workspaceTexraConfigPath(context.cwd);
-  if (!opts.force && (await configFileExists(filePath))) {
+  if (!opts.force && (await pathExists(filePath))) {
     writeTextStderr(
       `Refusing to overwrite existing config at ${filePath}. Re-run with --force to replace it.`,
     );

--- a/packages/cli/src/commands/installGithubAction.ts
+++ b/packages/cli/src/commands/installGithubAction.ts
@@ -1,10 +1,11 @@
-import { mkdir, stat, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { ExecResult } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { CliExitCode } from '../runtime/exitCodes';
+import { pathExists } from '../runtime/initConfig';
 import { tryOpenBrowser } from '../runtime/browser';
 import { writeTextStderr, writeTextStdout } from '../runtime/logSinks';
 import {
@@ -98,15 +99,6 @@ interface InstallOptions {
   readonly base: string | undefined;
   readonly force: boolean;
   readonly openPr: boolean;
-}
-
-async function pathExists(target: string): Promise<boolean> {
-  try {
-    await stat(target);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 function compareUrl(slug: GitHubSlug, base: string, branch: string): string {

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -9,7 +9,6 @@ import type {
 } from '@shared/schemas';
 import { providerDisplayName } from '@shared/constants/providers';
 import { OWN_API_KEYS } from '@shared/copy/modelAccess';
-import { RESEARCHER_ACCESS_AUTH } from '@shared/copy/accountAuth';
 import { RESEARCHER_ACCESS } from '@shared/copy/onboarding';
 
 import {
@@ -108,47 +107,17 @@ export function formatPersonalApiKeysLine(
   return `${label}: ${providers}`;
 }
 
-const CLI_API_STATUS_ACTION_HINTS: Record<
-  'signedIn' | 'signedOut' | 'signedOutWithPersonalKey',
-  string
-> = {
-  signedIn: 'actions: choose Model access below; `texra logout` signs out',
-  signedOut: `actions: ${RESEARCHER_ACCESS_AUTH.actionHintLoginOrKey}`,
-  signedOutWithPersonalKey:
-    'actions: choose Model access below; provider keys are configured',
-};
-
-export function formatCliApiStatusActionHint(
-  profile: Pick<CliAuthProfile, 'authenticated'>,
-  options: { readonly hasPersonalKey?: boolean } = {},
-): string {
-  if (profile.authenticated) return CLI_API_STATUS_ACTION_HINTS.signedIn;
-  return options.hasPersonalKey === true
-    ? CLI_API_STATUS_ACTION_HINTS.signedOutWithPersonalKey
-    : CLI_API_STATUS_ACTION_HINTS.signedOut;
-}
-
 async function personalKeyProviders(): Promise<string[]> {
   return configuredApiKeyProviders(platform().secrets);
 }
 
-interface LoadCliApiStatusOptions {
-  readonly includeActionHint?: boolean;
-}
-
 /** Compact status lines used by the launcher. */
-export async function loadCliApiStatus(
-  options: LoadCliApiStatusOptions = {},
-): Promise<readonly string[]> {
+export async function loadCliApiStatus(): Promise<readonly string[]> {
   const [profile, configuredPersonalKeyProviders] = await Promise.all([
     getCliAuthProfile(),
     personalKeyProviders(),
   ]);
   const authLine = formatCliAuthStatusLine(profile);
-  const hasPersonalKey = configuredPersonalKeyProviders.length > 0;
-  const actionHint = options.includeActionHint
-    ? formatCliApiStatusActionHint(profile, { hasPersonalKey })
-    : undefined;
 
   const personalKeysLine = formatPersonalApiKeysLine(
     configuredPersonalKeyProviders,
@@ -159,7 +128,6 @@ export async function loadCliApiStatus(
     ...(personalKeysLine ? [personalKeysLine] : []),
     authLine,
     ...(profile.note ? [profile.note] : []),
-    ...(actionHint ? [actionHint] : []),
   ];
 }
 

--- a/packages/cli/src/runtime/approval/approvalPrompts.ts
+++ b/packages/cli/src/runtime/approval/approvalPrompts.ts
@@ -268,17 +268,13 @@ export async function askApproval(
       const parsed = parseApprovalAnswer(answer);
       let feedback = parsed.feedback;
       if (!parsed.accepted && parsed.shouldPromptForFeedback) {
-        try {
-          hooks.beforePrompt?.();
-          const feedbackAnswer = await askCliApprovalQuestion(context, {
-            kind: 'approval',
-            summary: '',
-            prompt: 'Rejection feedback (optional, Enter to skip): ',
-          });
-          feedback = feedbackAnswer.trim() || undefined;
-        } catch {
-          feedback = undefined;
-        }
+        hooks.beforePrompt?.();
+        const feedbackAnswer = await askCliApprovalQuestion(context, {
+          kind: 'approval',
+          summary: '',
+          prompt: 'Rejection feedback (optional, Enter to skip): ',
+        });
+        feedback = feedbackAnswer.trim() || undefined;
       }
 
       return {

--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -14,8 +14,6 @@ import {
 } from '@platform/defaults/nodeStorage';
 import { resolveGlobalStoragePath } from '@platform/defaults/workspaceStorage';
 import {
-  parseTexraApprovalPolicy,
-  TEXRA_APPROVAL_POLICY_CONFIG_KEY,
   TexraApprovalPolicySchema,
   type TexraApprovalPolicy,
 } from '@shared/approvalPolicy';
@@ -125,7 +123,15 @@ const TOP_LEVEL_FIELD_SCHEMAS: ReadonlyArray<
   ['agent', NonEmptyStringSchema],
   ['model', ModelSchema],
   ['outputFormat', OutputFormatSchema],
-  ['approvalPolicy', TexraApprovalPolicySchema],
+  // Same normalization the catalog row (`stateSettings.ts`) applies for the
+  // other hosts, so a hand-edited " Yolo" reads the same way in all three.
+  [
+    'approvalPolicy',
+    z.preprocess(
+      (raw) => (typeof raw === 'string' ? raw.trim().toLowerCase() : raw),
+      TexraApprovalPolicySchema,
+    ),
+  ],
 ];
 
 /** Same role as {@link TOP_LEVEL_FIELD_SCHEMAS}, for the `chat`/`run` command
@@ -392,20 +398,12 @@ export async function loadUserApprovalPolicy(
   if (result.status === 'missing') return { warnings: [] };
   if (result.status === 'warning') return { warnings: [result.warning] };
 
-  const stored = result.parsed[TEXRA_APPROVAL_POLICY_CONFIG_KEY];
-  if (stored === undefined) return { warnings: [] };
-  // Same normalization the catalog row applies for every other host, so a
-  // hand-edited " Yolo" reads the same way in all three.
-  const policy =
-    typeof stored === 'string' ? parseTexraApprovalPolicy(stored) : undefined;
-  if (!policy) {
-    return {
-      warnings: [
-        `Ignoring invalid ${filePath} key "${TEXRA_APPROVAL_POLICY_CONFIG_KEY}".`,
-      ],
-    };
-  }
-  return { value: policy, warnings: [] };
+  const { values, warnings } = parseCliConfigValues(result.parsed, filePath, {
+    reportUnknownKeys: false,
+    topLevelFields: new Set(['approvalPolicy']),
+    sections: new Set(),
+  });
+  return { value: values.approvalPolicy, warnings };
 }
 
 /**

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -403,32 +403,6 @@ export async function deleteCliHistory(options: {
   };
 }
 
-/**
- * `texra history delete --all` is destructive and unrecoverable. The command
- * handler must call this first: if `--all` is set without `--yes`, it should
- * refuse and quote the count back to the user; otherwise it can pass `count`
- * into the confirmation message before deletion.
- */
-interface CliHistoryDeleteAllPreflight {
-  readonly proceed: boolean;
-  readonly count: number;
-}
-
-export async function preflightCliHistoryDeleteAll(options: {
-  all?: boolean;
-  yes?: boolean;
-}): Promise<CliHistoryDeleteAllPreflight> {
-  if (!options.all) return { proceed: false, count: 0 };
-  // Unlike list, a full wipe intentionally counts (and later clears) every
-  // stored execution, including `isUserVisibleExecution`-hidden
-  // process-bookkeeping entries and agent-spawned child runs — don't add the
-  // visibility filter here.
-  // (`show`/`export` were never filtered either — both are explicit-id
-  // lookups, a different contract from browsing a list.)
-  const count = (await listExecutions()).length;
-  return { proceed: options.yes === true, count };
-}
-
 export function formatCliHistoryText(
   entries: readonly CliHistoryEntry[],
 ): string {

--- a/packages/cli/src/runtime/initConfig.ts
+++ b/packages/cli/src/runtime/initConfig.ts
@@ -10,7 +10,7 @@ import path from 'node:path';
 
 import writeFileAtomic from 'write-file-atomic';
 
-import { isFileNotFoundError } from '@common/errors';
+import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 import { TEXRA_STORAGE_DIR_NAME } from '@platform/defaults/nodeStorage';
 import type { TexraApprovalPolicy } from '@shared/approvalPolicy';
 
@@ -46,12 +46,15 @@ export function serializeInitConfig(config: InitConfigShape): string {
   return `${JSON.stringify(config, null, 2)}\n`;
 }
 
-export async function configFileExists(filePath: string): Promise<boolean> {
+/** `false` only for a genuinely absent path; any other failure (EACCES, EIO)
+ *  propagates instead of being reported as "absent". */
+export async function pathExists(filePath: string): Promise<boolean> {
   try {
     await access(filePath);
     return true;
-  } catch {
-    return false;
+  } catch (error: unknown) {
+    if (isFileNotFoundError(error) || isNotADirectoryError(error)) return false;
+    throw error;
   }
 }
 

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -229,8 +229,7 @@ function accountSummary(status: CliAccountStatus): string {
     return `TeXRA · ${status.texraAccountLabel ?? 'signed in'}`;
   }
   // Oxford list for 3+ accounts ("A, B, and C"), plain "A and B" for two.
-  if (signed.length === 2) return `${signed[0]} and ${signed[1]} signed in`;
-  return `${signed.slice(0, -1).join(', ')}, and ${signed.at(-1)} signed in`;
+  return `${new Intl.ListFormat('en', { type: 'conjunction' }).format(signed)} signed in`;
 }
 
 export function buildCliAccountItems(

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -78,11 +78,6 @@ interface CliExecuteOptions {
   readonly canAdvertiseInterruptedExecution?: (
     resumability: Extract<ResumabilityDecision, { kind: 'checkpoint' }>,
   ) => boolean;
-  /** Wrap the run (e.g. multi-agent preset visibility) without leaking the
-   *  runtime-host lifecycle into the caller. */
-  readonly wrap?: (
-    run: () => Promise<ExecuteAgentResult>,
-  ) => Promise<ExecuteAgentResult>;
 }
 
 type ExecuteAgentResultForCategory<C extends AgentCategory | undefined> =
@@ -224,8 +219,8 @@ export async function executeCliToolUseConfig(
 
 /**
  * Shared headless-execution skeleton for `run`, `agents run`, and
- * `multi-agent run`: stand up a runtime host, run the request (optionally
- * wrapped), always close the host, and resolve the terminal outcome.
+ * `multi-agent run`: stand up a runtime host, run the request, always close
+ * the host, and resolve the terminal outcome.
  * Centralizing this stops the three runners from drifting apart on host
  * lifecycle and outcome handling, which is how their behavior diverged before.
  *
@@ -524,7 +519,7 @@ export async function executeCliRequest(
     await presentationHost.close();
   };
   try {
-    const result = await (options.wrap ? options.wrap(invoke) : invoke());
+    const result = await invoke();
     runResult = { ok: true, result };
   } catch (err) {
     // Only a classified, already-handled AgentError resolves to a non-zero

--- a/packages/cli/src/runtime/runModel.ts
+++ b/packages/cli/src/runtime/runModel.ts
@@ -7,7 +7,6 @@ import {
   resolveKnownCliModelId,
 } from './cliConfig';
 import { CliUsageError, type CliContext } from './cliContext';
-import { initCliPlatform } from './initPlatform';
 import { writeTextStderr } from './logSinks';
 import { selectCliRunnableModel } from './modelAccess';
 import { shouldRenderRunProgress } from './runProgressRenderer';
@@ -49,7 +48,6 @@ export async function selectCliRunModel(
   modelOverride: string | undefined,
   role: 'chat' | 'run',
 ): Promise<string> {
-  await initCliPlatform({ ...context, quietLogs: true });
   try {
     const resolution = await selectCliRunnableModel(
       cliRunModelCandidates(context, modelOverride, role),

--- a/src/shared/copy/accountAuth.ts
+++ b/src/shared/copy/accountAuth.ts
@@ -90,8 +90,6 @@ export const RESEARCHER_ACCESS_AUTH = {
   logoutDescription: `Sign out of your ${RESEARCHER_ACCESS.label} account`,
   /** `/login` slash-command description. */
   slashLoginDescription: `Sign in to ${CHATGPT_AUTH.label} or ${RESEARCHER_ACCESS.label}`,
-  /** Longer launcher action hint when keys are also an option. */
-  actionHintLoginOrKey: `choose Model access below, add a provider key, or sign in with ${RESEARCHER_ACCESS.label}`,
   startingDevice: `Starting ${RESEARCHER_ACCESS.label} device-code sign-in.`,
   startingNoBrowser: (provider: string): string =>
     `Starting ${RESEARCHER_ACCESS.label} ${provider} sign-in.`,

--- a/src/test-kernel/cli/ApiStatus.vitest.ts
+++ b/src/test-kernel/cli/ApiStatus.vitest.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  formatCliApiStatusActionHint,
-  formatCliAuthStatusLine,
-} from '@cli/runtime/apiStatus';
+import { formatCliAuthStatusLine } from '@cli/runtime/apiStatus';
 
 describe('CLI API status text', () => {
   it.each<[Parameters<typeof formatCliAuthStatusLine>[0], string]>([
@@ -24,31 +21,5 @@ describe('CLI API status text', () => {
     [{ authenticated: false }, 'auth: signed out'],
   ])('formats auth status %j as "%s"', (status, expected) => {
     expect(formatCliAuthStatusLine(status)).toBe(expected);
-  });
-
-  it.each<
-    [
-      Parameters<typeof formatCliApiStatusActionHint>[0],
-      Parameters<typeof formatCliApiStatusActionHint>[1],
-      string,
-    ]
-  >([
-    [
-      { authenticated: true },
-      undefined,
-      'actions: choose Model access below; `texra logout` signs out',
-    ],
-    [
-      { authenticated: false },
-      undefined,
-      'actions: choose Model access below, add a provider key, or sign in with Researcher Access',
-    ],
-    [
-      { authenticated: false },
-      { hasPersonalKey: true },
-      'actions: choose Model access below; provider keys are configured',
-    ],
-  ])('formats the action hint (%#)', (auth, options, expected) => {
-    expect(formatCliApiStatusActionHint(auth, options)).toBe(expected);
   });
 });

--- a/src/test-kernel/cli/ApiStatusLoad.vitest.ts
+++ b/src/test-kernel/cli/ApiStatusLoad.vitest.ts
@@ -505,19 +505,6 @@ describe('loadCliApiStatus', () => {
     expect(mocks.getCliAuthProfile).toHaveBeenCalledOnce();
   });
 
-  it('does not ask signed-out personal-key users to add another key', async () => {
-    setPersonalKeys('deepseek');
-
-    await expect(
-      loadCliApiStatus({ includeActionHint: true }),
-    ).resolves.toEqual([
-      'api: your own API keys',
-      'your own API keys: DeepSeek',
-      'auth: signed out',
-      'actions: choose Model access below; provider keys are configured',
-    ]);
-  });
-
   it('lists providers configured by secret or env origin', async () => {
     const originsByProvider: Record<string, 'secret' | 'env' | 'none'> = {
       deepseek: 'secret',

--- a/src/test-kernel/cli/CliContext.vitest.ts
+++ b/src/test-kernel/cli/CliContext.vitest.ts
@@ -186,6 +186,21 @@ describe('CLI context config defaults', () => {
     ).resolves.toMatchObject({ approvalPolicy: 'yolo' });
   });
 
+  it('normalizes a hand-edited approval policy spelling in the workspace config', async () => {
+    const workspace = await workspaceWithConfig(
+      JSON.stringify({ 'texra.approvalPolicy': ' Yolo ' }),
+    );
+
+    const context = await cliContext({
+      ambient,
+      env: {},
+      globalArgs: { cwd: workspace },
+    });
+
+    expect(context.approvalPolicy).toBe('yolo');
+    expect(context.configWarnings).toEqual([]);
+  });
+
   it('reports unknown and invalid workspace config fields without failing', async () => {
     const workspace = await workspaceWithConfig(
       JSON.stringify({

--- a/src/test-kernel/cli/History.vitest.ts
+++ b/src/test-kernel/cli/History.vitest.ts
@@ -118,7 +118,6 @@ import {
   formatInvalidExportFormatText,
   listCliHistoryEntries,
   parseCliHistoryId,
-  preflightCliHistoryDeleteAll,
   readCliHistoryDetails,
   readCliHistoryExportInput,
   readCliHistoryStandaloneTemplate,
@@ -1191,36 +1190,6 @@ describe('CLI history runtime', () => {
   it('validates execution id shape before command handlers use storage', () => {
     expect(parseCliHistoryId('abc123')).toBe('abc123');
     expect(parseCliHistoryId('../abc123')).toBeUndefined();
-  });
-
-  it('preflight refuses --all without --yes and quotes the count', async () => {
-    mocks.listExecutions.mockResolvedValue([{}, {}, {}, {}, {}]);
-
-    await expect(
-      preflightCliHistoryDeleteAll({ all: true, yes: false }),
-    ).resolves.toEqual({ proceed: false, count: 5 });
-
-    // The runtime listing was the source of truth — assert we asked it.
-    expect(mocks.listExecutions).toHaveBeenCalled();
-    // Critically, deleteAllExecutions was NOT called by the preflight.
-    expect(mocks.deleteAllExecutions).not.toHaveBeenCalled();
-  });
-
-  it('preflight clears --all when --yes is set and reports the count', async () => {
-    mocks.listExecutions.mockResolvedValue([{}, {}]);
-
-    await expect(
-      preflightCliHistoryDeleteAll({ all: true, yes: true }),
-    ).resolves.toEqual({ proceed: true, count: 2 });
-  });
-
-  it('preflight short-circuits when --all is not set', async () => {
-    await expect(
-      preflightCliHistoryDeleteAll({ all: false, yes: false }),
-    ).resolves.toEqual({ proceed: false, count: 0 });
-
-    // No need to ask storage if we are not in the bulk path.
-    expect(mocks.listExecutions).not.toHaveBeenCalled();
   });
 
   it('surfaces the bulk-delete count in the structured result', async () => {

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -707,34 +707,6 @@ describe('executeCliRequest', () => {
     expect(mocks.close).toHaveBeenCalledOnce();
   });
 
-  it('keeps a completed run terminal status when wrap cleanup fails after invoke succeeded (#7863)', async () => {
-    const { executeCliRequest } = await loadRunExecution();
-    const request = baseRequest();
-    // runAgent resolves (default mock): the lifecycle has already persisted
-    // the run's true terminal status. A rejection from wrap's post-run
-    // cleanup must still propagate to the crash handler, but must NOT
-    // overwrite that status with ERROR.
-    const cleanupError = new Error('workspaceState.update failed');
-
-    await expect(
-      executeCliRequest(request, cliContext(), {
-        wrap: async (run) => {
-          await run();
-          throw cleanupError;
-        },
-      }),
-    ).rejects.toBe(cleanupError);
-
-    expect(mocks.finalizeRun).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        executionId: 'exec-1',
-        outcome: RUN_OUTCOME.FAILED,
-        flowRecord: 'preserve',
-      }),
-    );
-    expect(mocks.close).toHaveBeenCalledTimes(1);
-  });
-
   it('resolves a classified run failure to a non-zero exit code without rethrowing or finalizing again', async () => {
     const { executeCliRequest } = await loadRunExecution();
     const request = baseRequest();

--- a/src/test-kernel/cli/cliModelResolution.vitest.ts
+++ b/src/test-kernel/cli/cliModelResolution.vitest.ts
@@ -13,13 +13,8 @@ import { selectCliRunnableModel } from '@cli/runtime/modelAccess';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 
 const mocks = vi.hoisted(() => ({
-  initCliPlatform: vi.fn(),
   selectCliRunnableModel: vi.fn(),
   writeTextStderr: vi.fn(),
-}));
-
-vi.mock('@cli/runtime/initPlatform', () => ({
-  initCliPlatform: mocks.initCliPlatform,
 }));
 
 vi.mock('@cli/runtime/modelAccess', async (importOriginal) => {
@@ -52,7 +47,6 @@ const runConfig = (model: string): CliConfigValues => ({ run: { model } });
 describe('selectCliRunModel precedence', () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    mocks.initCliPlatform.mockResolvedValue(undefined);
     selectCliRunnableModelMock.mockImplementation(async (request) => ({
       model: Array.isArray(request)
         ? (request.find((candidate) => candidate.model)?.model ??
@@ -122,10 +116,6 @@ describe('selectCliRunModel precedence', () => {
       ]),
       {},
     );
-    expect(mocks.initCliPlatform).toHaveBeenCalledWith({
-      ...context,
-      quietLogs: true,
-    });
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
       'Using deepseekT instead.',
     );


### PR DESCRIPTION
## Summary

Nine verified CLI runtime/command simplifications, batched after an adversarial verifier applied and gated each one alone on `origin/main`. Seven are pure deletions of seams whose last producer was removed in an earlier PR; two are bug fixes that fell out of collapsing a duplicated code path.

**Deletions (behavior-preserving)**

- **apiStatus** — delete the action-hint machinery: `formatCliApiStatusActionHint`, `loadCliApiStatus({ includeActionHint })`, `LoadCliApiStatusOptions`, and `RESEARCHER_ACCESS_AUTH.actionHintLoginOrKey`. The only producer of `includeActionHint: true` was removed in 64615c890b; the remaining prod caller (`orchestrate.ts`) passes nothing. The `tui-harness.tsx` script consumer is updated.
- **history** — inline `preflightCliHistoryDeleteAll` into the `--all && !--yes` guard in `commands/history.ts`. The "count hidden entries too" comment moves with it. Refusal text and exit code are unchanged.
- **runExecution** — delete `CliExecuteOptions.wrap`; its last producer was removed in c9407853f8. Doc line updated; the #7863 wrap-cleanup test is deleted with the seam it pinned.
- **runModel** — drop the `initCliPlatform` call inside `selectCliRunModel`. All three callers initialize the platform before calling it — `multiAgent.ts` via `initCliPlatform` directly, `workflow.ts` and `agentsRun.ts` via `initLocalCliPlatform`, which itself calls `initCliPlatform({ ...context, quietLogs: true })`.
- **globalArgs / orchestration** — replace two hand-rolled Oxford-list joins with `Intl.ListFormat('en', { type: 'conjunction' })`. Verified byte-identical for 0–4 items.
- **initConfig** — rename `configFileExists` to `pathExists` and reuse it from `installGithubAction.ts` in place of its local `stat`-based copy. `resumeExecution.ts` is deliberately **not** migrated: its `fs.access` probe only suppresses a hint, and turning EACCES into a crash before resume starts is not acceptable there.

**Bug fixes**

- **approvalPrompts** — delete the inner `catch { feedback = undefined }` around the rejection-feedback prompt (introduced in eaeb43094a with no rationale). The outer catch already settles `rejectionCause: 'CLI approval prompt failed.'`; swallowing here only hid a failed prompt as "no feedback". Observable change: a feedback-prompt or `hooks.beforePrompt` failure now settles `{ accepted: false, rejectionCause: 'CLI approval prompt failed.' }` instead of `{ accepted: false, userMessage: undefined }` — consistent with the main-prompt failure path.
- **`texra.approvalPolicy` normalization** (`cliConfig.ts`). A hand-edited workspace `{"texra.approvalPolicy": " Yolo "}` warned `Ignoring invalid … key "texra.approvalPolicy"` and fell back to `ask`, while the extension and desktop catalog row read it as `yolo`. `loadUserApprovalPolicy` now goes through `parseCliConfigValues` like every other top-level field, with the `TOP_LEVEL_FIELD_SCHEMAS` entry wrapped in `z.preprocess(trim+lowercase, TexraApprovalPolicySchema)`. Warning text for genuinely invalid values is unchanged. One regression test added to the existing `CliContext.vitest.ts`.
- **`texra help --cwd X run`** (`help.ts`). The `help` command reimplemented dispatch (unknown-command detection, deepest-subcommand resolution, usage rendering) but skipped `reorderGlobalFlags`, so `texra help --cwd /nonexistent run` printed **root** usage instead of `run` usage. `help` now re-enters `runCli([...ctx.rawArgs, '--help'])` and forwards its exit code, so the root dispatcher's flag reordering, unknown-command handling, and usage rendering are the single owner. Confirmed against the pre-change bundle: old prints root usage, new prints `run` usage.

**Behavior change to state explicitly:** `pathExists` returns `false` only on ENOENT/ENOTDIR. For `texra init` and `texra install-github-action`, an EACCES/EIO on the probed path now throws instead of being silently reported as "absent" and proceeding to write. For `install-github-action` that reaches the command's `catchExitCode`; `init` has none, so it surfaces through the top-level handler as `TeXRA CLI failed: …`, the same path its write-EACCES already takes.

Not implemented from the verified set: R8c (refuted — it changed stderr line precedence) and R9 (`quietLogs`, ruled no-change).

## Issue acceptance gates

n/a — batch from a verified simplification sweep, not an issue.

## Single source of truth

- `runCli` (`commands/root.ts`) owns CLI dispatch, including for `texra help …`.
- `parseCliConfigValues` + `TOP_LEVEL_FIELD_SCHEMAS` (`runtime/cliConfig.ts`) own workspace-config field parsing, including `approvalPolicy`.
- `pathExists` (`runtime/initConfig.ts`) owns the "absent vs. failed" probe for `init` and `install-github-action`.

## Duplication and abstraction budget

Removed: a second dispatch implementation in `help.ts`, a second approval-policy parse path, a second `pathExists`, two hand-rolled list joiners, and four pass-through seams with zero producers (`wrap`, `includeActionHint`, `preflightCliHistoryDeleteAll`, the action-hint table). No new abstraction added.

## Net elements (R6)

- Files: 21 modified, 0 added, 0 deleted.
- Net LoC (`git diff --stat origin/main`): **21 files changed, 73 insertions(+), 272 deletions(-)** → **−199**; production only (`packages/cli/src`, `packages/cli/scripts`, `src/shared`): 15 files, +57 / −160 → **−103**.
- Exported symbols (`^[+-]export` over the diff): −3 deleted (`formatCliApiStatusActionHint`, `preflightCliHistoryDeleteAll`, `configFileExists`), +1 added (`pathExists`, a rename of `configFileExists`), 1 signature change (`loadCliApiStatus` loses its options parameter). Net **−2 exports**.
- Interfaces: −2 (`LoadCliApiStatusOptions`, `CliHistoryDeleteAllPreflight`); `CliExecuteOptions.wrap` field deleted. Classes/enums: 0.
- Tests: 1 added (approval-policy normalization regression, in the existing `CliContext.vitest.ts`), 6 cases deleted with the seams they pinned (3 preflight cases, 3 action-hint cases, 1 `includeActionHint` case, 1 `wrap` case, 1 `initCliPlatform` assertion).

## Consumer counts (R8)

No emit paths or bus keys touched. Grepped (`git grep` at `origin/main`, `packages/**`, `src/**`, `.ts/.tsx`) for every deleted or re-routed public symbol:

| Symbol | Prod consumers | Test/script consumers | Disposition |
|---|---|---|---|
| `formatCliApiStatusActionHint` | 0 outside its definition file | `tui-harness.tsx` (2), `ApiStatus.vitest.ts` (3) | harness updated, tests deleted |
| `loadCliApiStatus({ includeActionHint })` | 0 (the only prod caller passes nothing) | `ApiStatusLoad.vitest.ts` (1) | test deleted |
| `RESEARCHER_ACCESS_AUTH.actionHintLoginOrKey` | 1 (`apiStatus.ts`, deleted in same PR) | 0 | deleted |
| `preflightCliHistoryDeleteAll` | 1 (`commands/history.ts`, inlined) | `History.vitest.ts` (3) | inlined, tests deleted |
| `CliExecuteOptions.wrap` / `options.wrap` | 0 producers | `RunExecution.vitest.ts` (1) | deleted |
| `configFileExists` | 1 (`commands/init.ts`) | 0 | renamed to `pathExists`, caller updated |
| `initCliPlatform` inside `selectCliRunModel` | 3 callers of `selectCliRunModel`, all already init first (1 direct, 2 via `initLocalCliPlatform`) | `cliModelResolution.vitest.ts` mock + assertion | assertion and mock deleted |
| `help` command's private dispatch imports | 0 other consumers of that reimplementation | 0 | replaced by `runCli` re-entry |

Post-change grep for each deleted name across `packages`, `src`, `scripts`, `docs`: 0 hits.

## Host impact

Extension: none (only `src/shared/copy/accountAuth.ts` is shared, and the deleted key had no extension consumer).

Desktop: none.

CLI: `texra help --cwd X <cmd>` now prints `<cmd>` usage; `texra.approvalPolicy` in workspace config accepts case/whitespace variants; `init` / `install-github-action` surface EACCES/EIO on the probed path instead of treating it as absent. Headless `texra run` / `--print` / `--output-format json|ndjson` bytes are unchanged.

## Scheduled refactoring

None.

## Validation

In an isolated worktree with `CI=true FORCE_COLOR=0`, after applying all nine and rebasing onto `origin/main` @ 7fd7894d86 (only #11544 landed since the verifier's base, touching a desktop test file only):

- `npm run format` — clean; `git diff --check` — clean.
- `npx tsc --noEmit -p packages/cli/tsconfig.json` — pass.
- `npx tsc --noEmit -p packages/cli/tsconfig.scripts.json` — pass (covers `tui-harness.tsx`).
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — pass.
- `npx vitest run src/test-kernel/cli src/test-kernel/shared` — **181 files, 2858 passed, 1 skipped, 0 failed**, no timeouts.
- `eslint packages/cli/src packages/cli/scripts src/test-kernel/cli src/shared/copy` — clean.
- `npm run check:dead-code-ratchet` — OK, 379 vs 379 baselined (no widening; no rows to shrink since the deleted symbols were not baselined).
- Headless parity spot check on the rebuilt bundle (`build-bundle.mjs` + `copy-resources.mjs` + `copy-docs.mjs`): `texra help` ≡ `texra --help`; `texra help run` ≡ `texra run --help`; `texra help --cwd /nonexistent run` ≡ `texra run --help` (prints `run` usage, exit 0); `texra help nosuchcmd` → `Unknown command: texra nosuchcmd. Run \`texra --help\` for usage.` on stderr, exit 2. The pre-change bundle from the main checkout prints root usage for the `--cwd` case.

## Verified

- Each candidate was applied alone on `daa6efd601` by the verifier with typecheck + vitest before batching; the batched diff is the union of those diffs, plus one orphaned doc-comment removal in `accountAuth.ts` the R2 diff left behind.
- `Intl.ListFormat('en', { type: 'conjunction' })` output checked against the removed hand-rolled joiners for 0, 1, 2, 3, and 4 items.
- No `node_modules` symlinks staged (`git ls-files -s | awk '$1=="120000"'` is empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pZUVQRHJvb8tVCu8nU7TC


