### PR TITLE
refactor(cli): collapse transcript render seams and delete unreachable TUI state

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -2,12 +2,6 @@
   "semantics": "Single baseline for the two Knip inputs owned by scripts/check-dead-code-ratchet.mjs: the normal run preserves ordinary findings, while findings emitted by the production run but absent from the normal run are categorized as production-dead. Each finding is identified by (file, category, kind, name), never by line number. Category is unused or production-dead; kind preserves Knip\u2019s files, exports, types, or duplicates issue kind so same-name findings of different kinds remain distinct. The ratchet fails when the combined result contains a finding not in this list. Removing resolved entries is always welcome; an intentional new finding must be added in sorted order by file, category, kind, then name. Run `npm run check:dead-code-ratchet` as the authoritative dead-code check.",
   "findings": [
     {
-      "file": "packages/cli/src/chat/tui/appLayout.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "allocateConversationBottomPanelRows"
-    },
-    {
       "file": "packages/cli/src/chat/tui/chatSubmitDriver.ts",
       "category": "production-dead",
       "kind": "exports",
@@ -404,12 +398,6 @@
       "name": "workflowRunStatusSummary"
     },
     {
-      "file": "packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "formatRenderError"
-    },
-    {
       "file": "packages/cli/src/chat/tui/panes/InfoPane.tsx",
       "category": "production-dead",
       "kind": "exports",
@@ -488,12 +476,6 @@
       "name": "StaticTranscriptState"
     },
     {
-      "file": "packages/cli/src/chat/tui/panes/statusBarDisplay.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "ctrlCActionForFocus"
-    },
-    {
       "file": "packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx",
       "category": "production-dead",
       "kind": "exports",
@@ -506,28 +488,10 @@
       "name": "CompactTodosPlanRow"
     },
     {
-      "file": "packages/cli/src/chat/tui/panes/toolRenderers.tsx",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "toolHeaderPreviewBudget"
-    },
-    {
       "file": "packages/cli/src/chat/tui/panes/ToolUseRow.tsx",
       "category": "production-dead",
       "kind": "exports",
       "name": "toolDisplaySpanTextProps"
-    },
-    {
-      "file": "packages/cli/src/chat/tui/panes/transcriptEntries.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "terminalVisibleTranscriptText"
-    },
-    {
-      "file": "packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "liveAssistantDisplayLines"
     },
     {
       "file": "packages/cli/src/chat/tui/panes/TranscriptReader.tsx",

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -38,7 +38,6 @@ import {
   selectedChildRowWorkflowControllable,
   shouldDeferEscapeInterruptForMetaChord,
   triggerAppCtrlC,
-  visibleApprovalRootStreamId,
   type EscapeInterruptState,
 } from './appInteractionPolicy';
 import { ApprovalModal } from './modals/ApprovalModal';
@@ -320,11 +319,14 @@ export function App(props: AppProps): React.JSX.Element {
         : undefined,
     [columns, workflowDashboardRoot],
   );
+  // Stream-less approvals fold onto the root of the visible surface: the
+  // scoped child-list root while one replaces the session list, else the
+  // session root.
   const pendingApprovalsForRows = useMemo(
     () =>
       groupPendingApprovalsByRow(
         pendingSummaries,
-        visibleApprovalRootStreamId(rootStreamId, childListTarget.streamId),
+        childListTarget.streamId ?? rootStreamId,
       ),
     [childListTarget.streamId, pendingSummaries, rootStreamId],
   );
@@ -585,7 +587,6 @@ export function App(props: AppProps): React.JSX.Element {
     return appEscapeInterruptActive({
       inputDisabled: state.inputDisabled,
       reverseSearchOpen: state.reverseSearchOpen,
-      runPending: true,
       slashPaletteOpen: state.slashPaletteOpen,
     });
   };
@@ -820,7 +821,6 @@ export function App(props: AppProps): React.JSX.Element {
               }
               childNavigationAvailable={childListAvailable}
               runningSessions={childRunningCount}
-              shortcutsActive={focusShortcutsActive}
               streamFocusAvailable={sessionViews.length > 0}
               transcriptAvailable={(activeSlice?.entries.length ?? 0) > 0}
             />

--- a/packages/cli/src/chat/tui/appInteractionPolicy.ts
+++ b/packages/cli/src/chat/tui/appInteractionPolicy.ts
@@ -42,17 +42,13 @@ export function appFocusShortcutsActive({
 export function appEscapeInterruptActive({
   inputDisabled,
   reverseSearchOpen,
-  runPending,
   slashPaletteOpen,
 }: {
   readonly inputDisabled: boolean;
   readonly reverseSearchOpen: boolean;
-  readonly runPending: boolean;
   readonly slashPaletteOpen: boolean;
 }): boolean {
-  return (
-    runPending && !inputDisabled && !slashPaletteOpen && !reverseSearchOpen
-  );
+  return !inputDisabled && !slashPaletteOpen && !reverseSearchOpen;
 }
 
 // Bare Esc must give a numbered stream-focus chord a chance to resolve while
@@ -77,8 +73,6 @@ export interface EscapeInterruptState {
   readonly onInterruptStream: (streamId: StreamTabId) => void;
 }
 
-type AppCtrlCAction = 'clear-draft' | 'delegate' | 'interrupt' | 'exit';
-
 export interface AppCtrlCState {
   readonly discardDraft: () => boolean;
   readonly canStopActiveRun: () => boolean;
@@ -100,23 +94,17 @@ export function appDraftDiscardActive({
 }
 
 /** Apply the root TUI's complete Ctrl+C policy from the latest composer state. */
-export function triggerAppCtrlC(state: AppCtrlCState): AppCtrlCAction {
-  if (state.discardDraft()) {
-    return 'clear-draft';
-  }
-
+export function triggerAppCtrlC(state: AppCtrlCState): void {
+  if (state.discardDraft()) return;
   if (state.onCtrlC) {
     state.onCtrlC();
-    return 'delegate';
+    return;
   }
-
   if (state.canStopActiveRun()) {
     state.onInterruptActive();
-    return 'interrupt';
+    return;
   }
-
   state.onExit();
-  return 'exit';
 }
 
 export function digitFromMetaShortcut(value: string): number | undefined {
@@ -257,14 +245,6 @@ export function groupPendingApprovalsByRow(
     (entry) => entry.key,
     (entry) => entry.summary.kind,
   );
-}
-
-/** Row key that owns stream-less approvals on the currently visible surface. */
-export function visibleApprovalRootStreamId(
-  sessionRootStreamId: StreamTabId | undefined,
-  childListRootStreamId: StreamTabId | undefined,
-): StreamTabId | undefined {
-  return childListRootStreamId ?? sessionRootStreamId;
 }
 
 // A workflow-script grandchild `agent()` call is the only interactively

--- a/packages/cli/src/chat/tui/appLayout.ts
+++ b/packages/cli/src/chat/tui/appLayout.ts
@@ -107,7 +107,7 @@ export function allocateMiddleRows({
   };
 }
 
-export function allocateConversationBottomPanelRows({
+function allocateConversationBottomPanelRows({
   maxRows,
   sessionCount,
   childListFocused,

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -35,10 +35,9 @@ import {
   TranscriptEntry,
 } from './TranscriptEntry';
 import { ToolUseRow } from './ToolUseRow';
-import { splitTranscriptEntries } from './transcriptEntries';
+import { pendingTranscriptEntries } from './transcriptEntries';
 import {
   estimateLiveTranscriptEntryRows,
-  estimateTranscriptEntryRows,
   selectTranscriptEntriesForViewport,
 } from './transcriptViewport';
 import {
@@ -100,6 +99,10 @@ function renderConversationPaneEntry({
       case 'log':
         return <LiveTranscriptEntry entry={entry} width={width} />;
       case 'user':
+      case 'compactionActivity':
+      case 'error':
+      case 'fileList':
+      case 'workflowTask':
         return (
           <TranscriptEntry
             colorEnabled={colorEnabled}
@@ -113,22 +116,6 @@ function renderConversationPaneEntry({
           <TranscriptEntry
             colorEnabled={colorEnabled}
             entry={entry}
-            width={width}
-          />
-        );
-      case 'compactionActivity':
-      case 'error':
-      case 'fileList':
-      case 'workflowTask':
-        return (
-          <BoundedTranscriptEntry
-            colorEnabled={colorEnabled}
-            entry={entry}
-            maxRows={estimateTranscriptEntryRows(
-              entry,
-              width,
-              subagentExecutionLabels,
-            )}
             width={width}
           />
         );
@@ -233,11 +220,11 @@ export function ConversationPane(
   const artifacts =
     activeStreamId && slice ? readStreamArtifacts(activeStreamId) : undefined;
   const entries = slice?.entries ?? [];
-  const displayEntries = splitTranscriptEntries(
+  const displayEntries = pendingTranscriptEntries(
     entries,
     slice?.finalizedFrontier ?? 0,
     slice?.status,
-  ).pending;
+  );
 
   const maxRows = props.maxRows ?? DEFAULT_TRANSCRIPT_ROWS;
   const metadataWidth =

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -4,7 +4,7 @@
 
 // Third-party imports
 import { Box } from 'ink';
-import { useLayoutEffect, useMemo, type ReactNode } from 'react';
+import { useLayoutEffect, type ReactNode } from 'react';
 
 // Local imports - shared constants and schemas
 import { clampModalWidth } from '@cli/tui/ui/theme';
@@ -132,12 +132,8 @@ export function ConversationRegion({
     rootStreamId: snapshot.rootStreamId,
     scopedTranscript,
   });
-  const executionLabelsKey = useMemo(
-    () => JSON.stringify([...snapshot.subagentExecutionLabels]),
-    [snapshot.subagentExecutionLabels],
-  );
   const staticTranscriptRepaint = useSignal(staticTranscriptRepaintEpoch);
-  const staticTranscriptKey = `${scrollbackTarget.ownerKey}:${executionLabelsKey}:${staticTranscriptRepaint}`;
+  const staticTranscriptKey = `${scrollbackTarget.ownerKey}:${staticTranscriptRepaint}`;
 
   const activeSlice = snapshot.activeStreamId
     ? snapshot.streams.get(snapshot.activeStreamId)

--- a/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
+++ b/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
@@ -34,7 +34,7 @@ interface EntryErrorBoundaryState {
   readonly error: unknown;
 }
 
-export function formatRenderError(error: unknown): string {
+function formatRenderError(error: unknown): string {
   let message: string;
   try {
     message = toErrorMessage(error);

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -741,7 +741,6 @@ function ensureStaticSessionHeader({
 }
 
 interface BuildStaticTranscriptItemsOptions {
-  readonly currentItems: readonly StaticTranscriptItem[];
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly childRosters?: ChildRosters;
   readonly executionLabels?: ExecutionLabels;
@@ -760,14 +759,14 @@ interface StaticTranscriptBuildResult {
   readonly trimmed: boolean;
 }
 
-/** Full rebuild path. This is the from-scratch oracle used on owner switch,
- *  hard reset, and fold rebuild; ordinary ticks use the incremental scan in
- *  {@link incrementalStaticTranscriptEntries}. */
+/** Full from-scratch build: the oracle used on owner switch, hard reset, and
+ *  fold rebuild; ordinary ticks use the incremental scan in
+ *  {@link incrementalStaticTranscriptEntries} via
+ *  {@link advanceStaticTranscriptState}. */
 export function buildStaticTranscriptItems(
   options: BuildStaticTranscriptItemsOptions,
 ): StaticTranscriptBuildResult {
   const {
-    currentItems,
     streams,
     childRosters = new Map(),
     executionLabels,
@@ -778,65 +777,35 @@ export function buildStaticTranscriptItems(
     width,
     ringBudgets = DEFAULT_STATIC_TRANSCRIPT_RING_BUDGETS,
   } = options;
-  const seen = new Set(currentItems.map((item) => item.id));
-  // Copied lazily: this runs on every stream-sync tick and most ticks append
-  // nothing.
-  let nextItems: StaticTranscriptItem[] | undefined;
+  // A focused child without a model yet holds neither header nor entries;
+  // `buildStaticTranscriptState` keeps its scan cursor at zero so they are
+  // still pending when the model arrives.
   if (
     shouldWaitForChildIdentity({
-      hasHeader: seen.has(SESSION_HEADER_ID),
+      hasHeader: false,
       parentStream,
       scrollbackStreamId,
     })
   ) {
-    const totals = staticTranscriptItemsTotals(
-      currentItems,
-      width,
-      executionLabels,
-    );
-    const trimmed = trimStaticTranscriptItems(currentItems, {
-      budgets: ringBudgets,
-      executionLabels,
-      totals,
-      width,
-    });
-    return {
-      items: trimmed.items,
-      rowCount: trimmed.totals.rows,
-      byteCount: trimmed.totals.bytes,
-      trimmed: trimmed.trimmed,
-    };
+    return { items: [], rowCount: 0, byteCount: 0, trimmed: false };
   }
 
-  if (!seen.has(SESSION_HEADER_ID)) {
-    // Same insert-if-it-fits logic `advanceStaticTranscriptState` uses on
-    // ordinary ticks. This path has no running rowCount/byteCount to diff
-    // against, so the totals are computed fresh with one full walk of
-    // `currentItems` — the whole history on a cold start, the newly appended
-    // tail once a previous render has already emitted rows.
-    const totals = staticTranscriptItemsTotals(
-      currentItems,
-      width,
-      executionLabels,
-    );
-    const header = ensureStaticSessionHeader({
-      byteCount: totals.bytes,
-      childRosters,
-      executionLabels,
-      items: currentItems,
-      maxRows,
-      meta,
-      parentStream,
-      rowCount: totals.rows,
-      scrollbackStreamId,
-      streams,
-      width,
-    });
-    if (header.inserted) {
-      nextItems = [...header.items];
-      seen.add(SESSION_HEADER_ID);
-    }
-  }
+  // Same insert-if-it-fits logic `advanceStaticTranscriptState` uses on
+  // ordinary ticks, applied to an empty transcript.
+  const header = ensureStaticSessionHeader({
+    byteCount: 0,
+    childRosters,
+    executionLabels,
+    items: [],
+    maxRows,
+    meta,
+    parentStream,
+    rowCount: 0,
+    scrollbackStreamId,
+    streams,
+    width,
+  });
+  const items: StaticTranscriptItem[] = [...header.items];
 
   // Only the selected scrollback owner feeds `<Static>` output. Root focus owns
   // root history; child focus owns that child's history. Other streams stay
@@ -844,25 +813,19 @@ export function buildStaticTranscriptItems(
   const slice = scrollbackStreamId
     ? streams.get(scrollbackStreamId)
     : undefined;
-  const entries = slice?.entries ?? [];
   const orderedStaticEntries = orderedStaticTranscriptEntries(
-    entries,
+    slice?.entries ?? [],
     slice?.finalizedFrontier ?? 0,
     slice?.status,
   );
-  const appendItem = (item: StaticTranscriptItem): void => {
-    nextItems ??= [...currentItems];
-    nextItems.push(item);
-    seen.add(item.id);
-  };
-
+  // Dedupe by the entry's own stable id, as the incremental path does.
+  const seen = new Set<string>();
   for (const entry of orderedStaticEntries) {
-    if (!seen.has(entry.id)) {
-      appendItem({ id: entry.id, kind: 'entry', entry });
-    }
+    if (seen.has(entry.id)) continue;
+    seen.add(entry.id);
+    items.push({ id: entry.id, kind: 'entry', entry });
   }
 
-  const items = nextItems ?? currentItems;
   const retained = retainedStaticTranscriptTail(items, {
     budgets: ringBudgets,
     executionLabels,
@@ -962,7 +925,6 @@ export function buildStaticTranscriptState({
   readonly eraseRequest?: number;
 }): StaticTranscriptState {
   const built = buildStaticTranscriptItems({
-    currentItems: [],
     streams,
     childRosters,
     executionLabels,
@@ -1114,9 +1076,14 @@ export function advanceStaticTranscriptState(
     return current;
   }
 
-  const layoutChanged =
-    width !== current.layoutWidth ||
-    !executionLabelsEqual(executionLabels, current.executionLabels);
+  // A label-content change (a child's human label arriving after its
+  // executions row printed) rewrites rows already in scrollback, so it repaints
+  // from a known origin; a bare width change is repainted by Ink's resize path.
+  const labelsChanged = !executionLabelsEqual(
+    executionLabels,
+    current.executionLabels,
+  );
+  const layoutChanged = width !== current.layoutWidth || labelsChanged;
   let nextItems = current.items;
   let nextRowCount = current.rowCount;
   let nextByteCount = current.byteCount;
@@ -1138,7 +1105,7 @@ export function advanceStaticTranscriptState(
     nextItems = trimmed.items;
     nextRowCount = trimmed.totals.rows;
     nextByteCount = trimmed.totals.bytes;
-    if (trimmed.trimmed) {
+    if (trimmed.trimmed || labelsChanged) {
       nextRepaintEpoch += 1;
     }
   }
@@ -1266,7 +1233,6 @@ export function StaticConversationTranscript({
 
   const buildFreshItems = (): readonly StaticTranscriptItem[] =>
     buildStaticTranscriptItems({
-      currentItems: [],
       streams,
       childRosters,
       executionLabels: subagentExecutionLabels,

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -893,6 +893,7 @@ function scanStaticTranscriptFromStart(
       scannedIndex: 0,
       lastScannedEntry: undefined,
       status: undefined,
+      lastAppendedKey: undefined,
     },
   ).cursor;
 }

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -62,7 +62,6 @@ interface StatusBarProps {
   readonly commandName?: string;
   readonly foregroundEscapeAction?: string;
   readonly foregroundInputActive?: boolean;
-  readonly shortcutsActive?: boolean;
   readonly streamFocusAvailable: boolean;
   readonly transcriptAvailable?: boolean;
 }
@@ -317,7 +316,6 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     foreground: {
       inputActive: props.foregroundInputActive,
       escapeAction: props.foregroundEscapeAction,
-      shortcutsActive: props.shortcutsActive,
     },
     childList: {
       focused: props.childListFocused,

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -151,12 +151,8 @@ export interface StatusBarDisplayInput {
 interface StatusBarForegroundInput {
   /** True while a modal, form, palette, or search surface owns input. */
   readonly inputActive?: boolean;
-  /** Label for the foreground surface's Escape action while `shortcutsActive`
-   *  is false. */
+  /** Label for the foreground surface's Escape action while `inputActive`. */
   readonly escapeAction?: string;
-  /** False while a foreground surface owns input and global chat shortcuts
-   *  are intentionally inactive. */
-  readonly shortcutsActive?: boolean;
 }
 
 interface StatusBarChildListInput {
@@ -775,7 +771,7 @@ function childListBindingsText(
   );
 }
 
-export function ctrlCActionForFocus({
+function ctrlCActionForFocus({
   activeStreamId,
   canStopActiveRun,
   parentStream,
@@ -936,13 +932,6 @@ function resolveStatusBarBindings(input: StatusBarDisplayInput): string {
   }
   if (input.childList.focused) {
     return childListBindingsText(input.childList, ctrlCAction, maxColumns);
-  }
-  if (input.foreground.shortcutsActive === false) {
-    return foregroundBindingsText(
-      ctrlCAction,
-      maxColumns,
-      input.foreground.escapeAction,
-    );
   }
   return statusBarBindingsText(input.shortcuts, ctrlCAction, maxColumns);
 }

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -65,7 +65,7 @@ const OUTPUT_LINE_MAX_CHARS = 2000;
  *  row instead of the historical fixed 80 columns, so wide terminals show the
  *  whole command and narrow ones truncate to fit a single row. Returns 0 (no
  *  preview) when the tool name plus chrome already eat the row. */
-export function toolHeaderPreviewBudget(
+function toolHeaderPreviewBudget(
   columns: number | undefined,
   displayName: string,
 ): number {

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -26,7 +26,7 @@ function isInvisibleTranscriptChar(char: string | undefined): boolean {
   return char !== undefined && INVISIBLE_TRANSCRIPT_CHARS.has(char);
 }
 
-export function terminalVisibleTranscriptText(text: string): string {
+function terminalVisibleTranscriptText(text: string): string {
   let out = '';
   for (const char of stripAnsi(text)) {
     if (!isInvisibleTranscriptChar(char)) out += char;

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -345,6 +345,9 @@ export interface StaticTranscriptScanCursor {
   readonly lastScannedEntry: TranscriptRow | undefined;
   /** Stream phase at scan time; a phase change forces a rescan of the tail. */
   readonly status: StreamPhase | undefined;
+  /** Order key of the last row this cursor's scans appended to scrollback.
+   *  A later suffix that sorts before it cannot be appended in place. */
+  readonly lastAppendedKey: readonly [number, number] | undefined;
 }
 
 interface StaticTranscriptScanResult {
@@ -359,6 +362,7 @@ function makeStaticTranscriptScanCursor(
   entriesRef: readonly TranscriptRow[] | undefined,
   scannedIndex: number,
   status: StreamPhase | undefined,
+  lastAppendedKey: readonly [number, number] | undefined,
 ): StaticTranscriptScanCursor {
   return {
     entriesRef,
@@ -368,6 +372,7 @@ function makeStaticTranscriptScanCursor(
         ? entriesRef[scannedIndex - 1]
         : undefined,
     status,
+    lastAppendedKey,
   };
 }
 
@@ -391,7 +396,7 @@ export function incrementalStaticTranscriptEntries(
   if (previous === undefined) {
     return {
       appended: [],
-      cursor: makeStaticTranscriptScanCursor(source, 0, status),
+      cursor: makeStaticTranscriptScanCursor(source, 0, status, undefined),
       rebuild: true,
     };
   }
@@ -413,7 +418,7 @@ export function incrementalStaticTranscriptEntries(
   if (!canContinue) {
     return {
       appended: [],
-      cursor: makeStaticTranscriptScanCursor(source, 0, status),
+      cursor: makeStaticTranscriptScanCursor(source, 0, status, undefined),
       rebuild: true,
     };
   }
@@ -460,7 +465,10 @@ export function incrementalStaticTranscriptEntries(
   }
   // Print the suffix in the same settlement order the rebuild oracle uses
   // (`orderedStaticTranscriptEntries`): a row that settled while an earlier
-  // tool was still running must not swap places across a repaint.
+  // tool was still running must not swap places across a repaint. Sorting
+  // covers a reorder inside one tick; a suffix whose first row belongs before
+  // rows an earlier tick already printed cannot be appended at all, so it
+  // falls back to the oracle rebuild (a known-origin repaint).
   const alreadyOrdered = appended.every(
     (candidate, i) =>
       i === 0 ||
@@ -474,9 +482,27 @@ export function incrementalStaticTranscriptEntries(
           left.index - right.index,
       );
 
+  const first = ordered[0];
+  if (
+    first !== undefined &&
+    previous.lastAppendedKey !== undefined &&
+    compareTranscriptOrderKeys(first.key, previous.lastAppendedKey) < 0
+  ) {
+    return {
+      appended: [],
+      cursor: makeStaticTranscriptScanCursor(source, 0, status, undefined),
+      rebuild: true,
+    };
+  }
+
   return {
     appended: ordered.map(({ entry }) => entry),
-    cursor: makeStaticTranscriptScanCursor(source, scannedIndex, status),
+    cursor: makeStaticTranscriptScanCursor(
+      source,
+      scannedIndex,
+      status,
+      ordered.at(-1)?.key ?? previous.lastAppendedKey,
+    ),
     rebuild: false,
   };
 }

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -272,24 +272,22 @@ export function orderedStaticTranscriptEntries(
   return ordered.map(({ entry }) => entry);
 }
 
-export function splitTranscriptEntries(
+/**
+ * Non-finalized entries in original stream order — the live pane's rows. The
+ * renderer must walk this list (rather than rendering tool rows and the live
+ * assistant as separate buckets) so that text emitted before a tool call
+ * appears above the tool row instead of below it. Tool entries defer
+ * finalization until the stream itself finalizes — promoting them earlier
+ * would let a fast tool jump ahead of still-streaming assistant text in
+ * `<Static>` scrollback, where insertion order is fixed. The complement (the
+ * settled prefix) is {@link orderedStaticTranscriptEntries}.
+ */
+export function pendingTranscriptEntries(
   entries: readonly TranscriptRow[],
   finalizedFrontier: number,
   status: StreamPhase | undefined,
-): {
-  readonly finalized: TranscriptRow[];
-  /** Non-finalized entries in original stream order. The renderer must
-   *  walk this list (rather than rendering tool rows and the live
-   *  assistant as separate buckets) so that text emitted before a tool
-   *  call appears above the tool row instead of below it. Tool entries
-   *  defer finalization until the stream itself finalizes — promoting
-   *  them earlier would let a fast tool jump ahead of still-streaming
-   *  assistant text in `<Static>` scrollback, where insertion order is
-   *  fixed. */
-  readonly pending: TranscriptRow[];
-} {
+): TranscriptRow[] {
   const showLiveAssistant = isActivePhase(status);
-  const finalized: TranscriptRow[] = [];
   const pending: TranscriptRow[] = [];
   let canPromoteToStatic = true;
   for (const [index, entry] of entries.entries()) {
@@ -310,7 +308,7 @@ export function splitTranscriptEntries(
       continue;
     }
     if (entryFinalized) {
-      (canPromoteToStatic ? finalized : pending).push(entry);
+      if (!canPromoteToStatic) pending.push(entry);
       continue;
     }
     if (
@@ -328,7 +326,7 @@ export function splitTranscriptEntries(
       pending.push(entry);
     }
   }
-  return { finalized, pending };
+  return pending;
 }
 
 const EMPTY_TRANSCRIPT_ENTRIES: readonly TranscriptRow[] = Object.freeze([]);
@@ -432,7 +430,11 @@ export function incrementalStaticTranscriptEntries(
     }
   }
 
-  const appended: TranscriptRow[] = [];
+  const appended: Array<{
+    entry: TranscriptRow;
+    index: number;
+    key: readonly [number, number];
+  }> = [];
   let scannedIndex = start;
   for (let index = 0; index < suffix.length; index += 1) {
     const entry = suffix[index]!;
@@ -450,11 +452,30 @@ export function incrementalStaticTranscriptEntries(
       !hasLaterRenderable[index];
     if (defersLiveUserPrompt) break;
     scannedIndex = start + index + 1;
-    appended.push(entry);
+    appended.push({
+      entry,
+      index: start + index,
+      key: transcriptOrderKey(entry, start + index),
+    });
   }
+  // Print the suffix in the same settlement order the rebuild oracle uses
+  // (`orderedStaticTranscriptEntries`): a row that settled while an earlier
+  // tool was still running must not swap places across a repaint.
+  const alreadyOrdered = appended.every(
+    (candidate, i) =>
+      i === 0 ||
+      compareTranscriptOrderKeys(appended[i - 1]!.key, candidate.key) <= 0,
+  );
+  const ordered = alreadyOrdered
+    ? appended
+    : appended.toSorted(
+        (left, right) =>
+          compareTranscriptOrderKeys(left.key, right.key) ||
+          left.index - right.index,
+      );
 
   return {
-    appended,
+    appended: ordered.map(({ entry }) => entry),
     cursor: makeStaticTranscriptScanCursor(source, scannedIndex, status),
     rebuild: false,
   };

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -244,7 +244,7 @@ function wrapDisplayLines(
   return lines.flatMap((line) => wrapDisplayLine(line, columns));
 }
 
-export function liveAssistantDisplayLines({
+function liveAssistantDisplayLines({
   rows,
   text,
   width,

--- a/packages/cli/src/chat/tui/panes/transcriptViewport.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptViewport.ts
@@ -16,15 +16,17 @@ const log = createLog('transcriptViewport');
  *  instead of once per stream-sync tick (the estimate path runs per frame). */
 const brokenEntryIdsReported = new Set<string>();
 
-function estimateEntryRows(
+// Live mode captures the pending-pane paint contract: assistant text uses its
+// capped raw tail, while rich tool rows keep one descriptor line per terminal
+// row instead of being reflowed like plain projections.
+export function estimateLiveTranscriptEntryRows(
   entry: TranscriptRow,
-  mode: 'live' | undefined,
-  width: number | undefined,
-  executionLabels: ExecutionLabels | undefined,
+  width?: number,
+  executionLabels?: ExecutionLabels,
 ): number {
   try {
     return transcriptEntryLayoutRows(
-      transcriptEntryLayout(entry, { executionLabels, mode, width }),
+      transcriptEntryLayout(entry, { executionLabels, mode: 'live', width }),
     );
   } catch (error) {
     if (!brokenEntryIdsReported.has(entry.id)) {
@@ -35,25 +37,6 @@ function estimateEntryRows(
     }
     return FAILED_ENTRY_ESTIMATE_ROWS;
   }
-}
-
-export function estimateTranscriptEntryRows(
-  entry: TranscriptRow,
-  width?: number,
-  executionLabels?: ExecutionLabels,
-): number {
-  return estimateEntryRows(entry, undefined, width, executionLabels);
-}
-
-// Live mode captures the pending-pane paint contract: assistant text uses its
-// capped raw tail, while rich tool rows keep one descriptor line per terminal
-// row instead of being reflowed like plain projections.
-export function estimateLiveTranscriptEntryRows(
-  entry: TranscriptRow,
-  width?: number,
-  executionLabels?: ExecutionLabels,
-): number {
-  return estimateEntryRows(entry, 'live', width, executionLabels);
 }
 
 interface TranscriptEntrySelection {

--- a/src/test-kernel/cli/AppInteractionPolicy.vitest.ts
+++ b/src/test-kernel/cli/AppInteractionPolicy.vitest.ts
@@ -13,7 +13,6 @@ import {
   foregroundSurfaceKind,
   shouldDeferEscapeInterruptForMetaChord,
   triggerAppCtrlC,
-  visibleApprovalRootStreamId,
   type AppCtrlCState,
   type ForegroundSurfaceKind,
 } from '@cli/chat/tui/appInteractionPolicy';
@@ -38,7 +37,6 @@ const focusEnabled = {
 const escapeInterruptEnabled = {
   inputDisabled: false,
   reverseSearchOpen: false,
-  runPending: true,
   slashPaletteOpen: false,
 } satisfies EscapeActiveState;
 const escChordHidden = {
@@ -108,52 +106,36 @@ function foregroundInput(
 }
 
 describe('app interaction policy', () => {
-  it('folds stream-less approvals onto the root of the visible surface', () => {
-    const sessionRoot = 'session-root' as StreamTabId;
-    const scopedListRoot = 'scoped-list-root' as StreamTabId;
-
-    expect(visibleApprovalRootStreamId(sessionRoot, undefined)).toBe(
-      sessionRoot,
-    );
-    expect(visibleApprovalRootStreamId(sessionRoot, scopedListRoot)).toBe(
-      scopedListRoot,
-    );
-  });
-
   it.each([
     {
       scenario:
         'clears a non-empty draft without interrupting an active response',
       active: true,
       draft: 'unfinished',
-      expected: 'clear-draft',
       events: ['clear'],
     },
     {
       scenario: 'clears a non-empty draft without exiting while idle',
       active: false,
       draft: 'unfinished',
-      expected: 'clear-draft',
       events: ['clear'],
     },
     {
       scenario: 'interrupts an active response when the draft is empty',
       active: true,
       draft: '',
-      expected: 'interrupt',
       events: ['interrupt'],
     },
     {
       scenario: 'exits an idle chat when the draft is empty',
       active: false,
       draft: '',
-      expected: 'exit',
       events: ['exit'],
     },
-  ])('$scenario', ({ active, draft, expected, events }) => {
+  ])('$scenario', ({ active, draft, events }) => {
     const fixture = ctrlCFixture({ active, draft });
 
-    expect(triggerAppCtrlC(fixture.state)).toBe(expected);
+    triggerAppCtrlC(fixture.state);
     if (draft.length > 0) {
       expect(fixture.readDraft()).toBe('');
     }
@@ -167,8 +149,8 @@ describe('app interaction policy', () => {
       delegate: true,
     });
 
-    expect(triggerAppCtrlC(fixture.state)).toBe('clear-draft');
-    expect(triggerAppCtrlC(fixture.state)).toBe('delegate');
+    triggerAppCtrlC(fixture.state);
+    triggerAppCtrlC(fixture.state);
     expect(fixture.events).toEqual(['clear', 'delegate']);
   });
 
@@ -249,7 +231,6 @@ describe('app interaction policy', () => {
   it('only lets Escape interrupt when no foreground input owns it', () => {
     const cases = [
       [escapeInterruptEnabled, true],
-      [{ ...escapeInterruptEnabled, runPending: false }, false],
       [{ ...escapeInterruptEnabled, inputDisabled: true }, false],
       [{ ...escapeInterruptEnabled, reverseSearchOpen: true }, false],
       [{ ...escapeInterruptEnabled, slashPaletteOpen: true }, false],

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -16,7 +16,6 @@ import {
   isInquiryContinuationText,
   isRenderableTranscriptEntry,
   orderedStaticTranscriptEntries,
-  splitTranscriptEntries,
   transcriptRowHeadline,
   trimAssistantTranscriptLead,
 } from '@cli/chat/tui/panes/transcriptEntries';
@@ -41,7 +40,6 @@ import {
 import { textDisplayWidth } from '@cli/runtime/terminalText';
 import {
   estimateLiveTranscriptEntryRows,
-  estimateTranscriptEntryRows,
   selectTranscriptEntriesForViewport,
 } from '@cli/chat/tui/panes/transcriptViewport';
 import {
@@ -81,6 +79,7 @@ import {
 import { buildChildRosters } from '@test/support/childRosters';
 import {
   compactionRowFixture,
+  splitTranscriptEntries,
   textRowFixture,
   toolRowFixture,
 } from '@test/support/transcriptRowFixtures';
@@ -285,26 +284,27 @@ describe('CLI conversation transcript', () => {
       'compaction:operation-1',
     ]);
     expect(
-      staticItemIds([completed], {
-        currentItems: staticItems([completed]),
-      }),
+      advancedItems(staticState([completed]), [completed]).map(
+        (item) => item.id,
+      ),
     ).toEqual(['session-header', 'compaction:operation-1']);
   });
 
   it('holds later rows out of Static until interrupted compaction is final', () => {
     const interrupted = compactionEntry('interrupted');
     const laterUser = entry('u1', 'user', 'Continue', true);
-    const liveItems = staticItems([interrupted, laterUser]);
+    const live = staticState([interrupted, laterUser]);
 
-    expect(liveItems.map((item) => item.id)).toEqual(['session-header']);
+    expect(live.items.map((item) => item.id)).toEqual(['session-header']);
     expect(
       splitTranscriptEntries([interrupted, laterUser], 0, STREAM_PHASE.RUNNING)
         .pending,
     ).toEqual([interrupted, laterUser]);
 
-    const finalItems = staticItems([compactionEntry('completed'), laterUser], {
-      currentItems: liveItems,
-    });
+    const finalItems = advancedItems(live, [
+      compactionEntry('completed'),
+      laterUser,
+    ]);
     expect(finalItems.map((item) => item.id)).toEqual([
       'session-header',
       'compaction:operation-1',
@@ -476,7 +476,7 @@ describe('CLI conversation transcript', () => {
       toolUse: malformedTool,
     };
 
-    expect(estimateTranscriptEntryRows(malformedEntry, 80)).toBe(1);
+    expect(estimateLiveTranscriptEntryRows(malformedEntry, 80)).toBe(1);
 
     const selected = selectTranscriptEntriesForViewport(
       [malformedEntry],
@@ -595,9 +595,6 @@ describe('CLI conversation transcript', () => {
     expect(userLayout.lines[1]?.startsWith('  ')).toBe(true);
     expect(userLayout.lines).toHaveLength(2);
     expect(transcriptEntryLayoutRows(userLayout)).toBe(4);
-    expect(estimateTranscriptEntryRows(user, 80)).toBe(
-      transcriptEntryLayoutRows(userLayout),
-    );
 
     const tool = toolEntry('t1', TOOL_USE_STATUS.COMPLETED, 'one\ntwo');
     const toolLayout = transcriptEntryLayout(tool, { width: 80 });
@@ -607,9 +604,7 @@ describe('CLI conversation transcript', () => {
       marginBottomRows: 1,
       marginTopRows: 0,
     });
-    expect(estimateTranscriptEntryRows(tool, 80)).toBe(
-      transcriptEntryLayoutRows(toolLayout),
-    );
+    expect(transcriptEntryLayoutRows(toolLayout)).toBe(4);
   });
 
   it('gives every workflow-call status its own steady marker', () => {
@@ -667,9 +662,9 @@ describe('CLI conversation transcript', () => {
     });
 
     expect(liveLayout.lines).toHaveLength(2);
-    expect(estimateTranscriptEntryRows(tool, 20)).toBeGreaterThan(
-      estimateLiveTranscriptEntryRows(tool, 20),
-    );
+    expect(
+      transcriptEntryLayoutRows(transcriptEntryLayout(tool, { width: 20 })),
+    ).toBeGreaterThan(estimateLiveTranscriptEntryRows(tool, 20));
     expect(selectTranscriptEntriesForViewport([tool], 20, 20).usedRows).toBe(
       transcriptEntryLayoutRows(liveLayout),
     );
@@ -689,7 +684,9 @@ describe('CLI conversation transcript', () => {
   it('budgets live user prompt bands with their margin rows', () => {
     const user = entry('u1', 'user', 'why do you write as a latex?', true);
 
-    expect(estimateTranscriptEntryRows(user, 80)).toBe(3);
+    expect(
+      transcriptEntryLayoutRows(transcriptEntryLayout(user, { width: 80 })),
+    ).toBe(3);
   });
 
   it('does not render empty assistant placeholders between user and tool rows', () => {
@@ -742,7 +739,6 @@ describe('CLI conversation transcript', () => {
 
     const items = buildStaticTranscriptItems({
       scrollbackStreamId: STREAM_ID,
-      currentItems: [],
       streams,
       meta: SESSION_META,
     }).items;
@@ -767,7 +763,6 @@ describe('CLI conversation transcript', () => {
 
     const items = buildStaticTranscriptItems({
       scrollbackStreamId: STREAM_ID,
-      currentItems: [],
       streams,
       meta: SESSION_META,
     }).items;
@@ -834,44 +829,53 @@ describe('CLI conversation transcript', () => {
       '[inquiry] ei_123 answered.\nQ: Can this be simplified?\nA: Yes.',
       true,
     );
-    expect(estimateTranscriptEntryRows(continuation, 80)).toBe(3);
+    expect(
+      transcriptEntryLayoutRows(
+        transcriptEntryLayout(continuation, { width: 80 }),
+      ),
+    ).toBe(3);
 
     // 77 chars exceeds the padded wrap width (80 - 4 = 76) by one, so the
     // row estimate must reflect the gutter + prefix geometry, not the
     // terminal width, and normal user prompts include the band margins.
     const long = entry('u2', 'user', 'x'.repeat(77), true);
-    expect(estimateTranscriptEntryRows(long, 80)).toBe(4);
+    expect(
+      transcriptEntryLayoutRows(transcriptEntryLayout(long, { width: 80 })),
+    ).toBe(4);
   });
 
   it('appends only finalized entries to terminal scrollback items', () => {
     const user = entry('u1', 'user', 'What is a tensor network?', true);
     const assistant = entry('a1', 'assistant', 'A decomposition.', false);
 
-    const first = staticItems([user, assistant]);
-    expect(first).toHaveLength(2);
-    expect(first[0]?.kind).toBe('header');
-    expect(first.slice(1).map((item) => item.id)).toEqual(['u1']);
+    const first = staticState([user, assistant]);
+    expect(first.items).toHaveLength(2);
+    expect(first.items[0]?.kind).toBe('header');
+    expect(first.items.slice(1).map((item) => item.id)).toEqual(['u1']);
 
-    const second = staticItems([user, settled(assistant)], {
-      currentItems: first,
-    });
+    const second = advancedItems(first, [user, settled(assistant)]);
     expect(second).toHaveLength(3);
     expect(second.slice(1).map((item) => item.id)).toEqual(['u1', 'a1']);
   });
 
   it('shows the session header exactly once', () => {
-    const first = buildStaticTranscriptItems({
+    const inputs = {
+      childRosters: new Map(),
+      ownerKey: 'root',
+      parentStream: new Map(),
       scrollbackStreamId: undefined,
-      currentItems: [],
       streams: new Map(),
+      width: 80,
+    };
+    const first = buildStaticTranscriptState({
+      ...inputs,
       meta: SESSION_META,
-    }).items;
-    expect(first).toHaveLength(1);
+      repaintEpoch: 0,
+    });
+    expect(first.items).toHaveLength(1);
 
-    const again = buildStaticTranscriptItems({
-      scrollbackStreamId: undefined,
-      currentItems: first,
-      streams: new Map(),
+    const again = advanceStaticTranscriptState(first, {
+      ...inputs,
       meta: { ...SESSION_META, model: 'sonnet' },
     }).items;
     expect(again).toHaveLength(1);
@@ -899,10 +903,12 @@ describe('CLI conversation transcript', () => {
   it('inserts a newly eligible header before existing compact transcript entries', () => {
     const user = entry('u1', 'user', 'What is a tensor network?', true);
     const assistant = entry('a1', 'assistant', 'A decomposition.', true);
-    const compact = staticItems([user, assistant], { maxRows: 0, width: 80 });
+    const compact = staticState([user, assistant], { maxRows: 0, width: 80 });
 
     expect(
-      staticItemIds([user, assistant], { currentItems: compact, width: 80 }),
+      advancedItems(compact, [user, assistant], { width: 80 }).map(
+        (item) => item.id,
+      ),
     ).toEqual(['session-header', 'u1', 'a1']);
   });
 
@@ -926,14 +932,13 @@ describe('CLI conversation transcript', () => {
     );
     expect(budgetRows).toBeGreaterThan(renderedRows);
 
-    const withoutHeader = staticItems([tool], { maxRows: 0, width: 80 });
-    expect(withoutHeader.map((item) => item.id)).toEqual(['t1']);
+    const withoutHeader = staticState([tool], { maxRows: 0, width: 80 });
+    expect(withoutHeader.items.map((item) => item.id)).toEqual(['t1']);
     expect(
-      staticItemIds([tool], {
-        currentItems: withoutHeader,
+      advancedItems(withoutHeader, [tool], {
         maxRows: renderedRows + 4,
         width: 80,
-      }),
+      }).map((item) => item.id),
     ).toEqual(['t1']);
   });
 
@@ -964,22 +969,20 @@ describe('CLI conversation transcript', () => {
   ])(
     'budgets $name before inserting a compact static header',
     ({ target, budgetWithoutHeader, budgetWithHeader }) => {
-      const compact = staticItems([target], { maxRows: 0, width: 80 });
+      const compact = staticState([target], { maxRows: 0, width: 80 });
 
-      expect(compact.map((item) => item.id)).toEqual([target.id]);
+      expect(compact.items.map((item) => item.id)).toEqual([target.id]);
       expect(
-        staticItemIds([target], {
-          currentItems: compact,
+        advancedItems(compact, [target], {
           maxRows: budgetWithoutHeader,
           width: 80,
-        }),
+        }).map((item) => item.id),
       ).toEqual([target.id]);
       expect(
-        staticItemIds([target], {
-          currentItems: compact,
+        advancedItems(compact, [target], {
           maxRows: budgetWithHeader,
           width: 80,
-        }),
+        }).map((item) => item.id),
       ).toEqual(['session-header', target.id]);
     },
   );
@@ -1005,7 +1008,6 @@ describe('CLI conversation transcript', () => {
       byteLowWater: 1024 * 1024,
     };
     const built = buildStaticTranscriptItems({
-      currentItems: [],
       streams: new Map([[STREAM_ID, sliceWithEntries(STREAM_ID, entries)]]),
       meta: SESSION_META,
       scrollbackStreamId: STREAM_ID,
@@ -1034,7 +1036,6 @@ describe('CLI conversation transcript', () => {
       byteLowWater: 64,
     };
     const built = buildStaticTranscriptItems({
-      currentItems: [],
       streams: new Map([[STREAM_ID, sliceWithEntries(STREAM_ID, entries)]]),
       meta: SESSION_META,
       scrollbackStreamId: STREAM_ID,
@@ -1057,7 +1058,6 @@ describe('CLI conversation transcript', () => {
       byteLowWater: 5,
     };
     const built = buildStaticTranscriptItems({
-      currentItems: [],
       streams: new Map([[STREAM_ID, sliceWithEntries(STREAM_ID, [oversized])]]),
       meta: SESSION_META,
       scrollbackStreamId: STREAM_ID,
@@ -1080,7 +1080,6 @@ describe('CLI conversation transcript', () => {
       byteLowWater: 1024 * 1024,
     };
     const built = buildStaticTranscriptItems({
-      currentItems: [],
       streams: new Map([
         [
           STREAM_ID,
@@ -1646,6 +1645,35 @@ describe('CLI conversation transcript', () => {
     expect(third.cursor.scannedIndex).toBe(2);
   });
 
+  it('appends an incremental suffix in the same settlement order a repaint uses', () => {
+    // Wire order is [t1, a1] but a1 settled first. The live path prints the
+    // suffix once; a repaint rebuilds from `orderedStaticTranscriptEntries`,
+    // so both must agree or rows swap places across the repaint.
+    const rows = [
+      { ...toolEntry('t1', TOOL_USE_STATUS.COMPLETED), settlementSeqNo: 20 },
+      { ...entry('a1', 'assistant', 'done', true), settlementSeqNo: 10 },
+    ];
+    const oracle = orderedStaticTranscriptEntries(
+      rows,
+      0,
+      STREAM_PHASE.RUNNING,
+    ).map((row) => row.id);
+    expect(oracle).toEqual(['a1', 't1']);
+
+    const live = incrementalStaticTranscriptEntries(
+      rows,
+      0,
+      STREAM_PHASE.RUNNING,
+      {
+        entriesRef: undefined,
+        scannedIndex: 0,
+        lastScannedEntry: undefined,
+        status: undefined,
+      },
+    );
+    expect(live.appended.map((row) => row.id)).toEqual(oracle);
+  });
+
   it('labels preset-launched sessions with team and root identity', () => {
     expect(
       sessionHeaderIdentityLine({
@@ -1798,7 +1826,6 @@ describe('CLI conversation transcript', () => {
       expect(
         buildStaticTranscriptItems({
           scrollbackStreamId: CHILD,
-          currentItems: [],
           streams,
           childRosters,
           meta: SESSION_META,
@@ -1827,7 +1854,6 @@ describe('CLI conversation transcript', () => {
       expect(
         buildStaticTranscriptItems({
           scrollbackStreamId: CHILD,
-          currentItems: [],
           streams: streamSlices,
           meta: SESSION_META,
           parentStream,
@@ -1841,7 +1867,6 @@ describe('CLI conversation transcript', () => {
       expect(
         buildStaticTranscriptItems({
           scrollbackStreamId: CHILD,
-          currentItems: [],
           streams: streamSlices,
           meta: SESSION_META,
           parentStream,
@@ -1853,7 +1878,6 @@ describe('CLI conversation transcript', () => {
   it('only feeds the root scrollback stream, not background subagents', () => {
     const items = buildStaticTranscriptItems({
       scrollbackStreamId: ROOT_STREAM,
-      currentItems: [],
       streams: rootChildStreams('do x', 'done'),
       meta: SESSION_META,
     }).items;
@@ -1869,7 +1893,6 @@ describe('CLI conversation transcript', () => {
     });
     const items = buildStaticTranscriptItems({
       scrollbackStreamId: scrollbackTarget.streamId,
-      currentItems: [],
       streams: rootChildStreams('root prompt', 'child detail'),
       meta: SESSION_META,
     }).items;
@@ -1889,7 +1912,6 @@ describe('CLI conversation transcript', () => {
     });
     const items = buildStaticTranscriptItems({
       scrollbackStreamId: scrollbackTarget.streamId,
-      currentItems: [],
       streams: rootChildStreams('root prompt', 'child detail'),
       meta: SESSION_META,
     }).items;
@@ -2187,18 +2209,54 @@ function rootChildStreams(
 function staticItems(
   entries: readonly TranscriptRow[],
   options: {
-    readonly currentItems?: readonly StaticTranscriptItem[];
     readonly maxRows?: number;
     readonly width?: number;
   } = {},
 ): readonly StaticTranscriptItem[] {
   return buildStaticTranscriptItems({
-    currentItems: options.currentItems ?? [],
     maxRows: options.maxRows,
     meta: SESSION_META,
     scrollbackStreamId: STREAM_ID,
     streams: new Map([[STREAM_ID, sliceWithEntries(STREAM_ID, entries)]]),
     width: options.width,
+  }).items;
+}
+
+type StaticState = ReturnType<typeof buildStaticTranscriptState>;
+
+/** The live transcript state after a cold build over `entries`. */
+function staticState(
+  entries: readonly TranscriptRow[],
+  options: { readonly maxRows?: number; readonly width?: number } = {},
+): StaticState {
+  return buildStaticTranscriptState({
+    childRosters: new Map(),
+    maxRows: options.maxRows,
+    meta: SESSION_META,
+    ownerKey: 'static-test',
+    parentStream: new Map(),
+    repaintEpoch: 0,
+    scrollbackStreamId: STREAM_ID,
+    streams: new Map([[STREAM_ID, sliceWithEntries(STREAM_ID, entries)]]),
+    width: options.width ?? 80,
+  });
+}
+
+/** Items after one ordinary stream-sync tick from `state` to `entries`. */
+function advancedItems(
+  state: StaticState,
+  entries: readonly TranscriptRow[],
+  options: { readonly maxRows?: number; readonly width?: number } = {},
+): readonly StaticTranscriptItem[] {
+  return advanceStaticTranscriptState(state, {
+    childRosters: new Map(),
+    maxRows: options.maxRows,
+    meta: SESSION_META,
+    ownerKey: state.ownerKey,
+    parentStream: new Map(),
+    scrollbackStreamId: STREAM_ID,
+    streams: new Map([[STREAM_ID, sliceWithEntries(STREAM_ID, entries)]]),
+    width: options.width ?? 80,
   }).items;
 }
 

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -5,20 +5,18 @@ import { describe, expect, it } from 'vitest';
 
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
-  LIVE_TAIL_ROWS,
   boundedTranscriptEntryLayout,
   fullTranscriptEntryLayout,
-  liveAssistantDisplayLines,
   transcriptEntryLayout,
   transcriptEntryLayoutRows,
 } from '@cli/chat/tui/panes/transcriptEntryLayout';
-import { formatRenderError } from '@cli/chat/tui/panes/EntryErrorBoundary';
+import { EntryErrorBoundary } from '@cli/chat/tui/panes/EntryErrorBoundary';
 import {
   incrementalStaticTranscriptEntries,
   isInquiryContinuationText,
+  isRenderableTranscriptEntry,
   orderedStaticTranscriptEntries,
   splitTranscriptEntries,
-  terminalVisibleTranscriptText,
   transcriptRowHeadline,
   trimAssistantTranscriptLead,
 } from '@cli/chat/tui/panes/transcriptEntries';
@@ -76,6 +74,10 @@ import {
 } from '@shared/schemas';
 import type { ToolRow, TranscriptRow } from '@shared/transcript';
 import { formatWorkflowPhaseHeading } from '@shared/copy/workflowCall';
+import {
+  loadInk,
+  renderOutputAtTerminalSize,
+} from '@test/support/inkTestHarness.ts';
 import { buildChildRosters } from '@test/support/childRosters';
 import {
   compactionRowFixture,
@@ -486,14 +488,28 @@ describe('CLI conversation transcript', () => {
     expect(selected.rowLimits.has('tool')).toBe(false);
   });
 
-  it('formats unprintable render errors without throwing', () => {
+  it('formats unprintable render errors without throwing', async () => {
     const unprintable = {
       toString() {
         throw new Error('cannot stringify');
       },
     };
+    const { ink, React } = await loadInk();
+    function Boom(): never {
+      throw unprintable;
+    }
 
-    expect(formatRenderError(unprintable)).toBe('');
+    const frame = await renderOutputAtTerminalSize(
+      ink,
+      React.createElement(
+        EntryErrorBoundary,
+        { label: 'entry' },
+        React.createElement(Boom),
+      ),
+      80,
+    );
+    expect(frame).toContain('failed to render entry');
+    expect(frame).not.toContain('failed to render entry:');
   });
 
   it('renders bounded finalized assistant tails through markdown', () => {
@@ -551,11 +567,8 @@ describe('CLI conversation transcript', () => {
     ].join('\n');
     const assistant = entry('a1', 'assistant', text, false);
     const width = 52;
-    const liveRows = liveAssistantDisplayLines({
-      rows: LIVE_TAIL_ROWS,
-      text,
-      width,
-    }).length;
+    const liveRows = transcriptEntryLayout(assistant, { mode: 'live', width })
+      .lines.length;
 
     const selected = selectTranscriptEntriesForViewport(
       [assistant],
@@ -791,7 +804,7 @@ describe('CLI conversation transcript', () => {
     const tool = toolEntry('t1', 'in_progress');
 
     const invisibleText = transcriptRowHeadline(invisibleAssistant);
-    expect(terminalVisibleTranscriptText(invisibleText)).toBe('');
+    expect(isRenderableTranscriptEntry(invisibleAssistant)).toBe(false);
     expect(trimAssistantTranscriptLead(invisibleText)).toBe('');
     expect(trimAssistantTranscriptLead('\u001B[2m\u200B\nvisible')).toBe(
       '\u001B[2mvisible',

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -1163,6 +1163,7 @@ describe('CLI conversation transcript', () => {
       scannedIndex: 0,
       lastScannedEntry: undefined,
       status: undefined,
+      lastAppendedKey: undefined,
     } as const;
 
     expect(
@@ -1615,6 +1616,7 @@ describe('CLI conversation transcript', () => {
       scannedIndex: 0,
       lastScannedEntry: undefined,
       status: undefined,
+      lastAppendedKey: undefined,
     } as const;
 
     const first = incrementalStaticTranscriptEntries(
@@ -1660,18 +1662,59 @@ describe('CLI conversation transcript', () => {
     ).map((row) => row.id);
     expect(oracle).toEqual(['a1', 't1']);
 
+    const emptyCursor = {
+      entriesRef: undefined,
+      scannedIndex: 0,
+      lastScannedEntry: undefined,
+      status: undefined,
+      lastAppendedKey: undefined,
+    } as const;
     const live = incrementalStaticTranscriptEntries(
       rows,
       0,
       STREAM_PHASE.RUNNING,
-      {
-        entriesRef: undefined,
-        scannedIndex: 0,
-        lastScannedEntry: undefined,
-        status: undefined,
-      },
+      emptyCursor,
     );
     expect(live.appended.map((row) => row.id)).toEqual(oracle);
+
+    // The same swap across a tick boundary: A settles late (key 20) and is
+    // printed while C still runs; then B (key 10) settles behind C. Sorting
+    // the new suffix alone would print [A, B, C] where the oracle says
+    // [B, A, C], so the scan must hand back to the oracle instead.
+    const a = {
+      ...toolEntry('a', TOOL_USE_STATUS.COMPLETED),
+      settlementSeqNo: 20,
+    };
+    const running = toolEntry('c', TOOL_USE_STATUS.IN_PROGRESS);
+    const c = {
+      ...running,
+      status: TOOL_USE_STATUS.COMPLETED,
+      settlementSeqNo: 30,
+    };
+    const b = {
+      ...entry('b', 'assistant', 'files', true),
+      settlementSeqNo: 10,
+    };
+    const tick1 = incrementalStaticTranscriptEntries(
+      [a, running],
+      0,
+      STREAM_PHASE.RUNNING,
+      emptyCursor,
+    );
+    expect(tick1.appended.map((row) => row.id)).toEqual(['a']);
+    const tick2 = incrementalStaticTranscriptEntries(
+      [a, c, b],
+      0,
+      STREAM_PHASE.RUNNING,
+      tick1.cursor,
+    );
+    expect(tick2.rebuild).toBe(true);
+    expect(tick2.appended).toEqual([]);
+    expect(
+      orderedStaticTranscriptEntries([a, c, b], 0, STREAM_PHASE.RUNNING).map(
+        (row) => row.id,
+      ),
+    ).toEqual(['b', 'a', 'c']);
   });
 
   it('labels preset-launched sessions with team and root identity', () => {

--- a/src/test-kernel/cli/StaticBandResize.vitest.ts
+++ b/src/test-kernel/cli/StaticBandResize.vitest.ts
@@ -251,7 +251,9 @@ describe('Static band resize', () => {
       current?: { repaint(options: TuiRepaintOptions): void };
     } = {};
     function App({ labels }: { labels: ReadonlyMap<string, string> }): unknown {
-      const renderKey = JSON.stringify([...labels]);
+      // The render key is label-agnostic, as in ConversationRegion: the
+      // transcript state owns the label-change repaint through its epoch.
+      const renderKey = 'execution-label-render';
       return createElement(StaticConversationTranscript, {
         onRenderKeyChange: () => {
           inkRef.current?.repaint({

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildStatusBarDisplay,
-  ctrlCActionForFocus,
   statusBarStreamTarget,
   subscriptionUsageProviderForStatus,
   type StatusBarDisplayInput,
@@ -382,7 +381,6 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         width: 140,
-        foreground: { shortcutsActive: false },
         childList: {
           focused: true,
           selectionKillable: true,
@@ -409,7 +407,6 @@ describe('CLI StatusBar display model', () => {
     const input = statusInput({
       width: 70,
       ctrlCAction: 'stop',
-      foreground: { shortcutsActive: false },
       childList: {
         focused: true,
         selectionKillable: true,
@@ -449,7 +446,6 @@ describe('CLI StatusBar display model', () => {
         foreground: {
           escapeAction: 'close',
           inputActive: true,
-          shortcutsActive: false,
         },
         childList: {
           focused: true,
@@ -866,7 +862,7 @@ describe('CLI StatusBar display model', () => {
         subagents: 3,
         ctrlCAction: 'stop',
         width: 34,
-        foreground: { shortcutsActive: false },
+        foreground: { inputActive: true },
         shortcuts: STREAM_NAV_SHORTCUTS,
       }),
     );
@@ -938,31 +934,9 @@ describe('CLI StatusBar display model', () => {
     ]);
   });
 
-  it('scopes Ctrl-C stop to the root when focus is on a child stream', () => {
-    const parentStream = new Map([['child', 'root']]);
-
-    expect(
-      ctrlCActionForFocus({
-        activeStreamId: 'root',
-        canStopActiveRun: true,
-        parentStream,
-      }),
-    ).toBe('stop');
-    expect(
-      ctrlCActionForFocus({
-        activeStreamId: 'child',
-        canStopActiveRun: true,
-        parentStream,
-      }),
-    ).toBe('stop root');
-    expect(
-      ctrlCActionForFocus({
-        activeStreamId: 'child',
-        canStopActiveRun: false,
-        parentStream,
-      }),
-    ).toBe('exit');
-
+  it('labels the root as active while a child stream has focus', () => {
+    // `statusBarStreamTarget` resolves the 'stop root' action itself (see its
+    // table below); this covers the footer it produces.
     const baseDisplayInput = statusInput({
       status: STREAM_PHASE.CANCELLED,
       ctrlCAction: 'stop root',
@@ -1303,7 +1277,7 @@ describe('CLI StatusBar display model', () => {
         subagents: 2,
         approvalDepth: 1,
         ctrlCAction: 'stop',
-        foreground: { shortcutsActive: false },
+        foreground: { inputActive: true },
         shortcuts: STREAM_NAV_SHORTCUTS,
       }),
     );
@@ -1320,7 +1294,7 @@ describe('CLI StatusBar display model', () => {
         status: STREAM_PHASE.RUNNING,
         approvalDepth: 1,
         approvalKind: 'question',
-        foreground: { escapeAction: 'skip', shortcutsActive: false },
+        foreground: { escapeAction: 'skip', inputActive: true },
       }),
     );
 
@@ -1334,7 +1308,7 @@ describe('CLI StatusBar display model', () => {
       statusInput({
         status: STREAM_PHASE.RUNNING,
         approvalDepth: 1,
-        foreground: { escapeAction: 'cancel', shortcutsActive: false },
+        foreground: { escapeAction: 'cancel', inputActive: true },
       }),
     );
 
@@ -1348,7 +1322,7 @@ describe('CLI StatusBar display model', () => {
         subagents: 3,
         ctrlCAction: 'stop',
         width: 40,
-        foreground: { shortcutsActive: false },
+        foreground: { inputActive: true },
         shortcuts: STREAM_NAV_SHORTCUTS,
       }),
     );
@@ -1363,7 +1337,7 @@ describe('CLI StatusBar display model', () => {
         subagents: 3,
         ctrlCAction: 'stop',
         width: 15,
-        foreground: { shortcutsActive: false },
+        foreground: { inputActive: true },
         shortcuts: STREAM_NAV_SHORTCUTS,
       }),
     );

--- a/src/test-kernel/cli/ToolRenderers.vitest.ts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.ts
@@ -3,11 +3,11 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports - CLI TUI rendering
 import {
-  toolHeaderPreviewBudget,
   toolUseDisplayLines,
   toolUseStyledLines,
 } from '@cli/chat/tui/panes/toolRenderers';
 import { toolDisplaySpanTextProps } from '@cli/chat/tui/panes/ToolUseRow';
+import { textDisplayWidth } from '@cli/runtime/terminalText';
 
 // Local imports - shared schemas
 import type { NormalizedToolUse } from '@shared/schemas';
@@ -414,15 +414,22 @@ describe('CLI tool display lines', () => {
   });
 
   it('sizes live header previews to the terminal width', () => {
+    const command = 'x'.repeat(300);
+    const header = (width: number | undefined, toolName = 'bash'): string =>
+      toolUseDisplayLines(toolUse(toolName, { command }), { width })[0] ?? '';
+
     // Wide terminals show more of the command than the historical 80 columns.
-    expect(toolHeaderPreviewBudget(200, 'bash')).toBe(191);
+    expect(textDisplayWidth(header(200))).toBeGreaterThan(150);
+    expect(textDisplayWidth(header(200))).toBeLessThanOrEqual(200);
     // Narrow terminals truncate to fit one row instead of wrapping.
-    expect(toolHeaderPreviewBudget(60, 'bash')).toBe(51);
+    expect(textDisplayWidth(header(60))).toBeLessThanOrEqual(60);
+    expect(textDisplayWidth(header(60))).toBeGreaterThan(40);
     // When the name + chrome already eat the row, drop the preview entirely
     // instead of overflowing into a second row.
-    expect(toolHeaderPreviewBudget(20, 'a-rather-long-tool-name')).toBe(0);
+    expect(header(20, 'a-rather-long-tool-name')).not.toContain('x');
     // Unknown width falls back to the historical fixed budget.
-    expect(toolHeaderPreviewBudget(undefined, 'bash')).toBe(80);
+    expect(textDisplayWidth(header(undefined))).toBeLessThanOrEqual(80 + 12);
+    expect(textDisplayWidth(header(undefined))).toBeGreaterThan(60);
   });
 });
 

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -28,7 +28,6 @@ import {
   transientNotice,
 } from '@cli/chat/tui/state/cliState';
 import {
-  allocateConversationBottomPanelRows,
   allocateConversationPanelRows,
   allocateMiddleRows,
   shouldShowTodosPlanPanel,
@@ -993,42 +992,45 @@ describe('CLI TUI row allocation', () => {
 
   it('hides the child list when its gap and content cannot both fit', () => {
     expect(
-      allocateConversationBottomPanelRows({
+      allocateConversationPanelRows({
         maxRows: 10,
         sessionCount: 2,
         childListFocused: false,
         todosPlanContentRows: 5,
-        transcriptRows: 1,
+        transcriptRows: 2,
       }),
     ).toEqual({
+      conversationRows: 2,
       bottomPanelRows: 0,
       sessionPanelRows: 0,
       todosPlanRows: 0,
     });
     expect(
-      allocateConversationBottomPanelRows({
+      allocateConversationPanelRows({
         maxRows: 10,
         sessionCount: 1,
         childListFocused: true,
         todosPlanContentRows: 0,
-        transcriptRows: 1,
+        transcriptRows: 2,
       }),
     ).toEqual({
+      conversationRows: 2,
       bottomPanelRows: 0,
       sessionPanelRows: 0,
       todosPlanRows: 0,
     });
 
     expect(
-      allocateConversationBottomPanelRows({
+      allocateConversationPanelRows({
         maxRows: 10,
         sessionCount: 3,
         childListFocused: true,
         minimumSessionPanelRows: 3,
         todosPlanContentRows: 0,
-        transcriptRows: 2,
+        transcriptRows: 3,
       }),
     ).toEqual({
+      conversationRows: 3,
       bottomPanelRows: 0,
       sessionPanelRows: 0,
       todosPlanRows: 0,
@@ -1037,28 +1039,30 @@ describe('CLI TUI row allocation', () => {
 
   it('keeps the child list collapsed until it receives focus', () => {
     expect(
-      allocateConversationBottomPanelRows({
+      allocateConversationPanelRows({
         maxRows: 10,
         sessionCount: 2,
         childListFocused: false,
         todosPlanContentRows: 0,
-        transcriptRows: 6,
+        transcriptRows: 7,
       }),
     ).toEqual({
+      conversationRows: 7,
       bottomPanelRows: 0,
       sessionPanelRows: 0,
       todosPlanRows: 0,
     });
 
     expect(
-      allocateConversationBottomPanelRows({
+      allocateConversationPanelRows({
         maxRows: 10,
         sessionCount: 2,
         childListFocused: true,
         todosPlanContentRows: 0,
-        transcriptRows: 6,
+        transcriptRows: 7,
       }),
     ).toEqual({
+      conversationRows: 4,
       bottomPanelRows: 3,
       sessionPanelRows: 3,
       todosPlanRows: 0,
@@ -1068,26 +1072,27 @@ describe('CLI TUI row allocation', () => {
   it('reserves a separator row above the todos panel', () => {
     // 2 todos + separator = 3 rows when the transcript allows it.
     expect(
-      allocateConversationBottomPanelRows({
+      allocateConversationPanelRows({
         maxRows: 10,
         sessionCount: 0,
         childListFocused: false,
         todosPlanContentRows: 2,
-        transcriptRows: 8,
+        transcriptRows: 9,
       }),
     ).toMatchObject({ bottomPanelRows: 3, todosPlanRows: 3 });
   });
 
   it('hands a lone todos row back instead of rendering a dead separator', () => {
     // The grant would be exactly one row — too small for separator + content.
-    const allocation = allocateConversationBottomPanelRows({
+    const allocation = allocateConversationPanelRows({
       maxRows: 10,
       sessionCount: 0,
       childListFocused: false,
       todosPlanContentRows: 4,
-      transcriptRows: 2,
+      transcriptRows: 3,
     });
     expect(allocation).toEqual({
+      conversationRows: 3,
       bottomPanelRows: 0,
       sessionPanelRows: 0,
       todosPlanRows: 0,
@@ -1096,14 +1101,15 @@ describe('CLI TUI row allocation', () => {
 
   it('does not allocate session rows without transcript space', () => {
     expect(
-      allocateConversationBottomPanelRows({
+      allocateConversationPanelRows({
         maxRows: 10,
         sessionCount: 2,
         childListFocused: false,
         todosPlanContentRows: 5,
-        transcriptRows: 0,
+        transcriptRows: 1,
       }),
     ).toEqual({
+      conversationRows: 1,
       bottomPanelRows: 0,
       sessionPanelRows: 0,
       todosPlanRows: 0,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -59,16 +59,15 @@ import {
   readStreamArtifacts,
   streamArtifactRevision,
 } from '@cli/chat/tui/state/subscribeStreamArtifacts';
-import {
-  estimateTranscriptEntryRows,
-  selectTranscriptEntriesForViewport,
-} from '@cli/chat/tui/panes/transcriptViewport';
+import { selectTranscriptEntriesForViewport } from '@cli/chat/tui/panes/transcriptViewport';
 import {
   isFinalizedTranscriptRow,
-  splitTranscriptEntries,
   transcriptRowHeadline,
 } from '@cli/chat/tui/panes/transcriptEntries';
-import { transcriptEntryLayout } from '@cli/chat/tui/panes/transcriptEntryLayout';
+import {
+  transcriptEntryLayout,
+  transcriptEntryLayoutRows,
+} from '@cli/chat/tui/panes/transcriptEntryLayout';
 import { renderAnsiMarkdown } from '@cli/chat/tui/render/ansiMarkdown';
 import {
   chatTuiCanInterruptActiveRun,
@@ -114,6 +113,7 @@ import { transcriptText, type TranscriptRow } from '@shared/transcript';
 import type { StreamTransitionCause } from '@shared/streams/streamStatus';
 import { clearAllStreamStatusesForTest } from '@test/support/streamStatusTestUtils';
 import {
+  splitTranscriptEntries,
   textRowFixture,
   toolRowFixture,
 } from '@test/support/transcriptRowFixtures';
@@ -3136,7 +3136,9 @@ describe('CLI transcript state', () => {
     const renderedRows = renderAnsiMarkdown(text, { width }).split('\n').length;
     const entry = textRowFixture('assistant-markdown', 'assistant', text, 0);
 
-    expect(estimateTranscriptEntryRows(entry, width)).toBe(renderedRows);
+    expect(
+      transcriptEntryLayoutRows(transcriptEntryLayout(entry, { width })),
+    ).toBe(renderedRows);
   });
 
   it('does not reserve spacer rows for compact one-line tool calls', () => {
@@ -3144,7 +3146,9 @@ describe('CLI transcript state', () => {
       path: '/executions/3a780a389327/report',
     });
 
-    expect(estimateTranscriptEntryRows(entry, 80)).toBe(1);
+    expect(
+      transcriptEntryLayoutRows(transcriptEntryLayout(entry, { width: 80 })),
+    ).toBe(1);
   });
 
   it('keeps pending transcript rows within their viewport budget', () => {

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
@@ -15,12 +15,12 @@ import '@test/support/defaultSessionTestSetup';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 
 import {
-  buildStaticTranscriptItems,
+  advanceStaticTranscriptState,
+  buildStaticTranscriptState,
   StaticConversationTranscript,
 } from '@cli/chat/tui/panes/StaticConversationTranscript';
 import {
   isFinalizedTranscriptRow,
-  splitTranscriptEntries,
   transcriptRowHeadline,
 } from '@cli/chat/tui/panes/transcriptEntries';
 import {
@@ -50,6 +50,7 @@ import { transcriptText, type TranscriptRow } from '@shared/transcript';
 import { STREAM_TRANSITION_CAUSE } from '@shared/streams/streamStatus';
 import { clearAllStreamStatusesForTest } from '@test/support/streamStatusTestUtils';
 import { loadInk } from '@test/support/inkTestHarness.ts';
+import { splitTranscriptEntries } from '@test/support/transcriptRowFixtures';
 import { createRunTrace } from '@transcript';
 import type { StreamSummaryMeta } from '@transcript/StreamLogStore';
 
@@ -116,33 +117,49 @@ async function renderStaticTranscript(): Promise<string> {
   );
 }
 
-type StaticItems = ReturnType<typeof buildStaticTranscriptItems>['items'];
+type StaticState = ReturnType<typeof buildStaticTranscriptState>;
 
+const STATIC_INPUTS = {
+  childRosters: new Map(),
+  meta: SESSION_META,
+  ownerKey: 'root',
+  parentStream: new Map(),
+  scrollbackStreamId: STREAM_ID,
+  width: 80,
+} as const;
+
+/** A cold build over the current slice, or one ordinary stream-sync tick
+ *  advancing `previous` to it. */
 function appendItems(
-  currentItems: StaticItems = [],
-  overrides: Partial<Parameters<typeof buildStaticTranscriptItems>[0]> = {},
-): StaticItems {
-  return buildStaticTranscriptItems({
-    currentItems,
-    meta: SESSION_META,
-    scrollbackStreamId: STREAM_ID,
-    streams: streams.get(),
-    ...overrides,
-  }).items;
+  previous?: StaticState,
+  overrides: Partial<Parameters<typeof buildStaticTranscriptState>[0]> = {},
+): StaticState {
+  return previous === undefined
+    ? buildStaticTranscriptState({
+        ...STATIC_INPUTS,
+        repaintEpoch: 0,
+        streams: streams.get(),
+        ...overrides,
+      })
+    : advanceStaticTranscriptState(previous, {
+        ...STATIC_INPUTS,
+        streams: streams.get(),
+        ...overrides,
+      });
 }
 
-function staticEntries(items: StaticItems): readonly TranscriptRow[] {
+function staticEntries({ items }: StaticState): readonly TranscriptRow[] {
   return items
     .filter((item) => item.kind === 'entry')
     .map((item) => item.entry);
 }
 
-function entryIds(items: StaticItems): string[] {
-  return staticEntries(items).map((entry) => entry.id);
+function entryIds(state: StaticState): string[] {
+  return staticEntries(state).map((entry) => entry.id);
 }
 
-function entryTexts(items: StaticItems): string[] {
-  return staticEntries(items).map(transcriptRowHeadline);
+function entryTexts(state: StaticState): string[] {
+  return staticEntries(state).map(transcriptRowHeadline);
 }
 
 function transcriptEntry(id: string): StreamLogEntry | undefined {
@@ -913,7 +930,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       ...prev,
       stage: { kind: 'phase', label: 'Draft sections' },
     }));
-    const staticItems = appendItems([], {
+    const staticItems = appendItems(undefined, {
       childRosters: new Map([
         [
           PARENT_STREAM_ID,
@@ -930,7 +947,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       parentStream: new Map([[STREAM_ID, PARENT_STREAM_ID]]),
       streams: streams.get(),
     });
-    expect(staticItems.at(0)).toMatchObject({
+    expect(staticItems.items.at(0)).toMatchObject({
       identityLine:
         'workflow script: draft-sections · Draft sections · parent: main · model: DeepSeek V4 Flash (Thinking)',
       kind: 'header',

--- a/src/test-kernel/support/transcriptRowFixtures.ts
+++ b/src/test-kernel/support/transcriptRowFixtures.ts
@@ -10,6 +10,10 @@
 // reducer.
 
 import {
+  orderedStaticTranscriptEntries,
+  pendingTranscriptEntries,
+} from '@cli/chat/tui/panes/transcriptEntries';
+import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_PHASE,
@@ -17,6 +21,7 @@ import {
   type FileListEntry,
   type NormalizedToolUse,
   type StreamLogEntry,
+  type StreamPhase,
   type TaskGroup,
 } from '@shared/schemas';
 import {
@@ -212,4 +217,25 @@ export function workflowPhaseGrouping(rows: readonly TranscriptRow[]): {
     return { ...row, groupId: openPhase.id };
   });
   return { taskGroups, entries };
+}
+
+/** The CLI's two panes' rows for one slice: the settled `<Static>` prefix and
+ *  the live rows. Production reads each half from its own pane; suites that
+ *  assert on the partition read both here. */
+export function splitTranscriptEntries(
+  entries: readonly TranscriptRow[],
+  finalizedFrontier: number,
+  status: StreamPhase | undefined,
+): {
+  readonly finalized: readonly TranscriptRow[];
+  readonly pending: readonly TranscriptRow[];
+} {
+  return {
+    finalized: orderedStaticTranscriptEntries(
+      entries,
+      finalizedFrontier,
+      status,
+    ),
+    pending: pendingTranscriptEntries(entries, finalizedFrontier, status),
+  };
 }


### PR DESCRIPTION
## Summary

Verified batch of CLI TUI pane/rendering simplifications; each item was adversarially verified on `origin/main` before landing. Two commits: stage 1 (unreachable state and dead exports) and stage 2 (transcript render seams, rebased onto #11545).

**Defect fixes**

- **Static suffix ordering (unmasked while removing `currentItems`).** `incrementalStaticTranscriptEntries` appended the settled suffix in array order while the rebuild oracle `orderedStaticTranscriptEntries` sorts by settlement order, so live scrollback could print `[tool, fileList]` and any repaint (resize, label change, ring trim) printed `[fileList, tool]`. The incremental path now sorts its appended suffix with the same `transcriptOrderKey`/`compareTranscriptOrderKeys` (skipping the sort when already ordered, as the oracle does). Sorting covers a reorder inside one tick; when the reorder spans a tick boundary (a row settles behind a still-running barrier after an earlier tick already printed a later-keyed row — review finding, third commit), the scan cursor now carries the last appended order key and a suffix that sorts before it hands back to the oracle rebuild (`rebuild: true`, the existing known-origin repaint path) instead of appending. Behavior: repaints now match live order. One regression test at the narrowest boundary (`incrementalStaticTranscriptEntries` vs the oracle) covers both the single-tick and the two-tick barrier case; each assertion fails with its half of the fix disabled.
- **Single owner for the execution-label repaint.** `ConversationRegion` folded `subagentExecutionLabels` into the `<Static>` key (remounting the whole band) *and* `advanceStaticTranscriptState` repainted on a label change. Now the state's advance path bumps `repaintEpoch` when labels changed (inside the existing `layoutChanged` block, alongside the ring-trim bump, so it never double-bumps), and the region key is `ownerKey:repaintEpoch` only.

**Simplifications**

- `buildStaticTranscriptItems` builds from scratch: both production callers passed `currentItems: []`, so the "append onto existing items" branches (lazy copy, header insert-if-fits over a running tail, wait-for-child-identity re-trim) were dead. Tests that exercised the append path now go through `buildStaticTranscriptState` + `advanceStaticTranscriptState` (the path production actually takes).
- `ConversationPane`: `compactionActivity`/`error`/`fileList`/`workflowTask` rows render through the same `<TranscriptEntry fillWidth>` arm as `user` rows instead of `<BoundedTranscriptEntry maxRows={estimateTranscriptEntryRows(...)}>` — verified 54/54 byte-identical frames. `estimateTranscriptEntryRows` and the shared inner `estimateEntryRows` collapse into `estimateLiveTranscriptEntryRows` (try/catch kept).
- `splitTranscriptEntries` → `pendingTranscriptEntries(...): TranscriptRow[]`; production only ever read `.pending` (the settled half is `orderedStaticTranscriptEntries`). The two-pane split lives once in `src/test-kernel/support/transcriptRowFixtures.ts` for the three suites that assert on both halves.
- StatusBar: delete `shortcutsActive` (provably `!childListFocused && !inputActive`; `resolveStatusBarBindings` already branches on `inputActive` first, so the `shortcutsActive === false` arm was unreachable). `focusShortcutsActive` in `App.tsx` stays — it still gates the focus-shortcut handler.
- #11499 residue in `appInteractionPolicy`: drop the always-`true` `runPending` input of `appEscapeInterruptActive`; `triggerAppCtrlC` returns `void` (delete `AppCtrlCAction`, no reader); inline `visibleApprovalRootStreamId` at its one `App.tsx` call site.
- `allocateConversationBottomPanelRows` becomes module-private (un-export only, not inlined); its 8 test sites go through `allocateConversationPanelRows`.
- Un-export five test-only symbols (`liveAssistantDisplayLines`, `terminalVisibleTranscriptText`, `ctrlCActionForFocus`, `formatRenderError`, `toolHeaderPreviewBudget`) and retarget their tests at the public surface. `toolDisplaySpanTextProps` and `slashSubmitText` deliberately untouched.

## Issue acceptance gates

n/a — simplification batch from the 2026-08-25/27 survey rounds; no issue.

## Single source of truth

- `advanceStaticTranscriptState` alone decides when `<Static>` repaints (width, ring trim, label change).
- `buildStaticTranscriptItems` is the from-scratch oracle; `advanceStaticTranscriptState` is the only incremental path, and both now agree on suffix order.
- `inputActive` alone selects the foreground status-bar bindings.
- `allocateConversationPanelRows` is the only entry into bottom-panel allocation.

## Duplication and abstraction budget

No new production abstractions. One shared test helper (`splitTranscriptEntries`) added to an existing support module in place of three identical local copies.

## Net elements (R6)

- Files: 22 changed, 0 added, 0 deleted.
- Exported symbols (`^[+-]export` over the diff): −11 / +4. Of the +4, two are signature-changed lines of surviving exports (`estimateLiveTranscriptEntryRows`, `triggerAppCtrlC`), one is the rename `splitTranscriptEntries` → `pendingTranscriptEntries`, and one is the test-support helper. Net production exports: **−8**.
- Class/interface/enum/type declarations: `type AppCtrlCAction` deleted (−1); in tests, `type StaticItems` → `type StaticState` (0 net).
- Net LoC (`git diff --stat` against the merge base `d2d5c202df`): **+461 / −419 = +42** overall; production `packages/cli/src` **+142 / −195 = −53**; `config/ratchets/knip-baseline.json` −36; tests + support +319 / −188 = +131 (state-carrying test helpers for the append path, the two-case regression test, one hoisted helper). The positive overall delta is test LoC for the two defect fixes; production shrinks.

## Consumer counts (R8)

Grepped on `origin/main` (`git grep -w`); production consumers outside the defining module, then test files:

- `splitTranscriptEntries`: 1 prod (`ConversationPane.tsx`, read `.pending` only) → renamed; 3 test files → shared support helper.
- `estimateTranscriptEntryRows`: 1 prod (`ConversationPane.tsx`, the deleted `BoundedTranscriptEntry` arm); 2 test files retargeted to `transcriptEntryLayoutRows(transcriptEntryLayout(...))`.
- `buildStaticTranscriptItems.currentItems`: 2 prod callers, both passing `[]`; 2 test files.
- `executionLabelsKey` (ConversationRegion `useMemo`): 0 outside the file.
- `shortcutsActive`: 1 prop writer (`App.tsx`) + 1 forwarder (`StatusBar.tsx`), both deleted; 1 test file.
- `visibleApprovalRootStreamId`: 1 (`App.tsx`, inlined); 1 test file.
- `AppCtrlCAction`: 0 (module-internal); 0 tests.
- `appEscapeInterruptActive.runPending`: 1 (`App.tsx`, literal `true`); 2 test rows.
- `allocateConversationBottomPanelRows`: 0 prod; 1 test file (8 sites retargeted).
- `liveAssistantDisplayLines`, `terminalVisibleTranscriptText`, `ctrlCActionForFocus`, `formatRenderError` (CLI copy — the extension's same-named formatter is unrelated), `toolHeaderPreviewBudget`: 0 prod, 1 test file each; all were `production-dead` baseline rows (removed).

No emit paths touched.

## Host impact

Extension: none.

Desktop: none.

CLI: repaints of `<Static>` scrollback now print rows in the same order the live path did (defect fix); label changes still repaint from a known origin. Everything else is behavior-preserving (54/54 frame-identical for the render-arm fold; status bar, Ctrl-C/Esc policy, and panel allocation unchanged).

## Scheduled refactoring

None.

## Validation

- `npm run format`; `git diff --check`
- `tsc --noEmit -p packages/cli/tsconfig.json`, `-p packages/cli/tsconfig.scripts.json`, `-p tsconfig.test-kernel.json`
- `vitest run src/test-kernel/cli` — 144 files green (2526 passed / 1 skipped)
- `npm run lint` (full) clean
- `eslint packages/cli/src src/test-kernel/cli src/test-kernel/support/transcriptRowFixtures.ts`
- `npm run check:dead-code-ratchet` — 373 vs 373 baselined (baseline shrunk by 6 rows, nothing added)

## Verified

- Regression test for the suffix order fails with the sort disabled (`['t1','a1']` vs `['a1','t1']`) and its two-tick barrier assertion fails with the cross-tick guard disabled (`rebuild` false); both pass with the fixes.
- `recomputes ring byte totals and trims when execution labels change` and the rest of `StaticBandResize` pass with the label bump inside the `layoutChanged` block (an unconditional bump double-counts and fails it).
- `shortcutsActive ≡ !childListFocused && !inputActive` at its single writer; `resolveStatusBarBindings` tests `childList.focused` then `foreground.inputActive` before the deleted arm.
- `triggerAppCtrlC`'s return value had no production reader.
- Rebased cleanly on #11545 (`d2d5c202df`); the only textual overlap was the `appendItems([] → undefined, …)` call in `WorkflowScriptStreamTranscript.vitest.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pZUVQRHJvb8tVCu8nU7TC
