### PR TITLE
refactor(cli): stream state reads the shared substrate — status, usage, run config, provenance

### DIFF
--- a/config/ratchets/store-public-surface-baseline.json
+++ b/config/ratchets/store-public-surface-baseline.json
@@ -42,6 +42,7 @@
       "getRunUsage",
       "getWorkPlan",
       "hasPersistedWorkPlan",
+      "hasProvenance",
       "listPersistedStreams",
       "listStagedDeletions",
       "load",

--- a/docs/proposals/2026-08-15-single-substrate-hosts-as-renderers.md
+++ b/docs/proposals/2026-08-15-single-substrate-hosts-as-renderers.md
@@ -51,6 +51,15 @@
 > (`sessionSignalsAdapter` 372 → 312 against ~90, `runProgressRenderer`
 > 573 → 535 against ~395, `cliState` 929 → 876 against ~490) — read the §3
 > table as a direction, not a budget.
+>
+> **Reconciled again (2026-08-28), after the CLI status / usage / run-config /
+> provenance PR.** The §4 promotion list is closed: `contextState` and
+> `runStartedAt` **landed** (each with one §8 fence row), `thinkingActive` is
+> **withdrawn** (fold output, no producer, one consumer), and root-run stream
+> identity and run input files + `plannedRounds` are **closed as
+> non-promotions** — the first is presentation state with an existing
+> execution-keyed query, the second was already on `StreamSnapshotStore`. The
+> per-row §3 and §4 lines below carry the detail.
 
 ## 0. The directive as a ruling, and what it does to prior rulings
 
@@ -232,7 +241,13 @@ Then, container by container:
   composition: 30 fields → 15, every mirror deleted, but the slice is still a
   standalone interface rather than the `StreamState & CliOnlyFields` shape this
   row named, and the file is 876 L against the ~490 target. The §0.1-item-8
-  supersession is executed.
+  supersession is executed. **Extended by the status/usage PR:** the lifecycle
+  triple (`status`, `substate`, `runStartedAt`) and the latest-usage gauge are
+  gone too — 15 fields → 11 — and with them `PatchableStreamSlice`,
+  `StreamSlicePatch`, `streamSliceWithStatus`, and `setStreamStatusInCliState`.
+  Renderers read `streamPhaseFor`, a slice-gated read of
+  `StreamStatusMachine.getStreamState`. What survives is transcript-fold
+  output plus terminal modality.
 - `sessionSignalsAdapter.ts` — **LANDED #10892/#10895/#10932** for the
   mechanism (the per-field patch forwarders and the dual status path are gone;
   `subscribeStreamStatus.ts` is deleted), **not** for the arithmetic: 372 →
@@ -240,17 +255,33 @@ Then, container by container:
 - `runProgressRenderer.ts` — **LANDED #10932**: a real headless
   `SessionRendererPort` implementation over the shared applier, `RenderState`'s
   six fields down to a three-field `RootRunConfigState`. Net −38, not −175.
+  **`RootRunConfigState` is now gone too:** the agent name, input label, and
+  planned rounds are read from
+  `snapshots.getRunMetadata(root, { quiet: true }).config` at paint, and the
+  root phase and its run window from the status machine. The renderer holds one
+  state field of its own (`rootPhaseText`, whose whole semantic is
+  last-write-wins ordering between a status label and a description) plus an
+  attach-time elapsed origin for the window before any run window exists.
 - `subscribeStreamArtifacts.ts` — **PARTIAL #10718/#10735/#10895.** The
   slice-copying is gone (renderers read the canonical projection), but the file
   survives at 222 L holding the async disk-preload edge and its invalidation.
   The "−135 to zero" line was wrong: there was a real asynchronous concern
-  underneath the copying.
+  underneath the copying. **The hydration set went next:**
+  `hydratedArtifactStreams`, `beginLoadedStreamsReconcile`, and
+  `markArtifactStreamHydrated` shadowed a fact the store already held
+  privately, so the store publishes it as `hasProvenance(stream)` (disk
+  provenance established, or a live write eagerly applied ahead of any seed)
+  and the CLI keeps only the revision bump. The `load`-eviction reconcile
+  disappears with it: `load` evicts synchronously, and an evicted record
+  reports no provenance by construction.
 - `streamViews.ts` — **LANDED #10932**; the CLI calls `buildStreamTabInfo`, so
   the ext/CLI name drift this row named is closed.
-- `statusBarDisplay.ts` context gauge — **OPEN.** Still
-  `MODEL_CONFIGS[model]?.contextWindow`; the correctness bug this row called
-  "a correctness fix wearing a refactor" is live, gated on the `contextState`
-  promotion (§4).
+- `statusBarDisplay.ts` context gauge — **LANDED.** `formatUsage` reads
+  `StreamExecutionState.contextState` (window, used input tokens, and the
+  handler's own `utilizationPercent`); the `MODEL_CONFIGS[model]?.contextWindow`
+  re-derivation and the correctness bug behind it are gone. Its pre-first-
+  `contextState` fallback now shows the store's cumulative input tokens rather
+  than the last call's.
 - `resumeHint.ts` targets — **LANDED #10754** via the `resumeEligible` roster
   field.
 
@@ -284,24 +315,44 @@ is noted).
 **Promotion status at `e00b9317f7` (2026-08-19)** — this is where the program's
 remaining work concentrates:
 
-- `contextState` — **OPEN.** Not on `StreamExecutionState`; the webview still
-  folds it out of the log rail and `statusBarDisplay.ts:221` still reads
-  `MODEL_CONFIGS[model]?.contextWindow`. The §7.4 revival note explains why it
-  is the hard one: it has no fact-rail writer today.
+- `contextState` — **LANDED.** It is a `StreamExecutionState` field, the
+  applier writes it, and the CLI status bar renders it instead of re-deriving a
+  window from `MODEL_CONFIGS`. One deliberate asymmetry, now a §8 fence row:
+  `LitSessionRenderer` ignores the `contextState` invalidation
+  (`LitSessionRenderer.ts:197-201`) because Lit's usage footer restores the
+  same snapshot from the transcript rail's own `contextState` entry, which —
+  unlike this session-scoped record — repopulates a stream reopened from disk.
+  Pushing it there too would mint a second writer for one footer.
 - removal tombstone / resurrection guard — **LANDED #10805**, as
   `SessionState._removedStreams` + `isStreamRemoved`, documented as the single
   owner of the rejection; the shared applier honors it for every host, which
   is the cross-host bug this row predicted.
-- `runStartedAt` — **OPEN.** Still CLI-only (`cliState.ts`).
-- `thinkingActive` — **OPEN.** Still derived CLI-side from the log rail.
+- `runStartedAt` — **LANDED.** `StreamPhaseState.runStartedAt` on the status
+  machine is the single stamper, it rides the wire
+  (`streamState.ts` `BackendOwnedFieldsSchema.runStartedAt`), and the board
+  renders elapsed from it. The CLI mirror is deleted by the status/usage PR;
+  every host now reads one clock.
+- `thinkingActive` — **WITHDRAWN**, for the same reason `compactingActive`
+  was: it is fold output, not a fact. Nothing on the fact rail produces it
+  (`subscribeStreamLog` derives it from the live-activity entry), and it has no
+  second consumer — one CLI status-bar segment reads it. Promoting it would
+  mint a producer and an owner for a value one renderer computes for itself.
 - `resumeEligible` — **LANDED #10754** on the roster row
   (`streamState.ts:34`), produced by `executionRegistry.ts`.
-- root-run stream identity — **OPEN.** Three copies survive (two in
-  `cliState.ts`, one in `runProgressRenderer.ts`); no execution-keyed query
-  exists.
-- run input files + `plannedRounds` — **OPEN.** Still headless-only, now in
-  `RootRunConfigState`, whose own comment concedes no shared record carries
-  them.
+- root-run stream identity — **CLOSED, not promoted.** The three "copies" are
+  not one fact restated: each host records _which stream its own root-run
+  claim went to_, and the CLI's claim exists before any stream does (the
+  pending-run window between submit and the first `run.start`). That is
+  presentation state by the §1 rule, and the live query the row asked for
+  already exists — `executions.getHandle(executionId).streamId`. Nothing to
+  promote.
+- run input files + `plannedRounds` — **CLOSED, not promoted.** The premise
+  was wrong: `StreamSnapshotStore` retains the whole `AgentConfig` on
+  `run.config` and serves it from `getRunMetadata`, so input files were already
+  shared and `plannedRounds` is `getAgent(config.agent, Workflow)?.rounds` — a
+  registry lookup, not a fact. `RootRunConfigState` was a duplicate of the
+  store, deleted by the status/usage PR; no GUI consumer asked for a
+  `SessionStreamConfigDetails` in the meantime, so none is added.
 - `cumulativeUsage` sum rule — **LANDED.** One owner,
   `StreamArtifactProjection.sumUsageStats`; the CLI reads it rather than
   eager-summing.
@@ -504,6 +555,21 @@ re-flagging them:
   (into `HostInteractions` result types, no registry merge); the rest is
   fenced unless the maintainer supersedes A16 by name — **this plan does not
   ask for that.**
+- **The Lit log-rail fold of `contextState`.** `LitSessionRenderer` drops the
+  `contextState` invalidation on purpose (`LitSessionRenderer.ts:197-201`):
+  Lit's usage footer restores that snapshot from the transcript rail's own
+  entry, which repopulates a stream reopened from disk while the session-scoped
+  record does not. One footer, one writer — pushing the shared record there as
+  well would create the second writer this plan exists to remove.
+- **Durable-rail vs ephemeral-rail facts are not one rail.** A fact a reopened
+  stream must still show (the workflow phase heading, `contextState`) is
+  recorded on the transcript rail and replayed from disk; a fact only a live
+  session needs (lifecycle phase, run window, roster) lives on the ephemeral
+  session record and dies with the process. Some values appear on both, and
+  that is not duplication to collapse: the rails answer different questions
+  ("what happened" vs "what is true now"), have different lifetimes, and a
+  single rail would either persist ephemera or lose history. Collapse the
+  _rules_ that read them, not the rails.
 - **`DesktopProgressBridge`** beyond its three 2-line sync wrappers — it is
   IPC + host callbacks, not a state layer.
 - **Platform ports, vocabulary aliases, `SessionHostInteractions` forwards**

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -70,6 +70,11 @@ import {
   isInFlightPhase,
   STREAM_TRANSITION_CAUSE,
 } from '@shared/streams/streamStatus';
+// The status machine stamps its own `Date.now()` run window and no production
+// fact lets a caller supply one, so a display fixture that needs a plausible
+// elapsed time reaches for the same seeding helper the kernel suites use.
+// Dev-harness only — this file is never part of the shipped CLI bundle.
+import { seedStreamStatusForTest } from '@test/support/streamStatusTestUtils';
 import { GoalStore } from '@tools/goal';
 import { prepareToolEditApprovalPrompt } from '@tools/approval/toolEditApproval';
 import { buildContinuationText } from '@tools/inquiry/inquiryContinuation';
@@ -105,15 +110,17 @@ import {
   setCliSessionModelOverride,
   patchStream,
   streams,
-  setStreamStatusInCliState,
+  streamPhaseFor,
 } from '../src/chat/tui/state/cliState';
 import {
   activeSubagentsFor,
   childRosters,
+  invalidateChildStreams,
   streamMetadataFor,
   parentStream,
   visibleSubagentRows,
 } from '../src/chat/tui/state/childExecutions';
+import { readStreamArtifacts } from '../src/chat/tui/state/subscribeStreamArtifacts';
 import { focusedChildFollowUpRoute } from '../src/chat/tui/state/focusedChildFollowUp';
 import { formatCliSessionStatus } from '../src/chat/tui/sessionStatus';
 import { notify } from '../src/chat/tui/notifications/terminalNotifier';
@@ -1166,10 +1173,7 @@ async function appendHarnessPlanDecision(
       ...slice,
       bypass: { ...slice.bypass, bash: true },
     }));
-    setStreamStatusInCliState({
-      streamId: STREAM_ID,
-      status: STREAM_PHASE.RUNNING,
-    });
+    seedHarnessStreamPhase(STREAM_ID, STREAM_PHASE.RUNNING);
     appendHarnessAssistantTranscript('PLAN-GOAL');
     return;
   }
@@ -1222,12 +1226,12 @@ patchStream(STREAM_ID, (slice) => ({
 }));
 const HARNESS_INITIAL_STREAM_STATUS = harnessInitialStreamStatus();
 if (HARNESS_INITIAL_STREAM_STATUS) {
-  setStreamStatusInCliState({
-    streamId: STREAM_ID,
-    status: HARNESS_INITIAL_STREAM_STATUS,
+  seedHarnessStreamPhase(
+    STREAM_ID,
+    HARNESS_INITIAL_STREAM_STATUS,
     // Backdated so the status bar shows a plausible elapsed time.
-    ...(HARNESS_RUN_ACTIVE ? { runStartedAt: Date.now() - 42_000 } : {}),
-  });
+    HARNESS_RUN_ACTIVE ? Date.now() - 42_000 : undefined,
+  );
 }
 
 if (SHOW_LIVE_TOOL_ONLY) {
@@ -1469,10 +1473,7 @@ function seedRunningProcessChild(): void {
     category: AgentCategory.ToolUse,
     description: 'sleep 30',
   }));
-  setStreamStatusInCliState({
-    streamId: childStreamId,
-    status: STREAM_PHASE.RUNNING,
-  });
+  seedHarnessStreamPhase(childStreamId, STREAM_PHASE.RUNNING);
   emitChildRoster(STREAM_ID, [
     {
       executionId: 'aaaa0003f10e',
@@ -1585,6 +1586,27 @@ function emitSetActiveStream(
   });
 }
 
+/**
+ * Place a stream in a phase for a *display* fixture: write the session status
+ * machine — the single owner every renderer reads — the way a real transition
+ * does before it publishes, but without the fact. These fixtures own their
+ * synthetic transcript rows and their scenario's elapsed values, and a
+ * published status would make the adapter re-fold the stream from a log that
+ * has none of those rows and restamp the run window at `Date.now()`. Fixtures
+ * that exercise the fact pipeline itself use the real transitions below.
+ */
+function seedHarnessStreamPhase(
+  streamId: StreamTabId,
+  phase: StreamPhase,
+  runStartedAt?: number,
+): void {
+  seedStreamStatusForTest(defaultSession().status, streamId, {
+    phase,
+    ...(runStartedAt !== undefined ? { runStartedAt } : {}),
+  });
+  invalidateChildStreams();
+}
+
 // Real status-machine transitions on the default session — the session
 // adapter's status rail projects these into `cliState` (see
 // `runChildEventOrderFixture`), exactly as `chatSessionController.ts` wires
@@ -1607,10 +1629,10 @@ function transitionStreamTerminal(streamId: StreamTabId): void {
 
 // Late resume-transition attempt for an already-removed stream: unlike a
 // repeated terminal transition (a same-value no-op the status machine drops
-// before it ever reaches `cliState`), COMPLETED -> RUNNING via `resume` is a
-// transition the machine itself allows, so it reaches
-// `setStreamStatusInCliState` and actually exercises that function's
-// `isChildStreamRemoved` tombstone guard (see `completion-remove` below).
+// before it publishes anything), COMPLETED -> RUNNING via `resume` is a
+// transition the machine itself allows, so the fact reaches the CLI adapter
+// and actually exercises its `cliStreamAcceptsStatus` tombstone guard (see
+// `completion-remove` below).
 function attemptChildEventOrderLateResume(streamId: StreamTabId): void {
   defaultSession().status.transition(
     streamId,
@@ -1825,14 +1847,15 @@ if (SHOW_CHILDREN) {
   // survives.
   emitChildRoster(STREAM_ID, childStreams);
   emitChildRoster(STREAM_ID, activeSubagents);
-  setStreamStatusInCliState({
-    streamId: STREAM_ID,
-    status: STREAM_PHASE.RUNNING,
-    // The status machine stamps a run window once and holds it across every
-    // later active phase, so a scenario that already seeded an initial RUNNING
-    // keeps that backdated start rather than restarting the clock here.
-    runStartedAt: streams.get().get(STREAM_ID)?.runStartedAt ?? startedAt,
-  });
+  seedHarnessStreamPhase(
+    STREAM_ID,
+    STREAM_PHASE.RUNNING,
+    // The status machine holds one run window across every later active
+    // phase, so a scenario that already seeded an initial RUNNING keeps that
+    // backdated start rather than restarting the clock here.
+    defaultSession().status.getStreamState(STREAM_ID)?.runStartedAt ??
+      startedAt,
+  );
   for (const child of childStreams) {
     const streamId = child.childStreamId;
     const addNestedChildren =
@@ -1844,19 +1867,31 @@ if (SHOW_CHILDREN) {
     patchStream(streamId, (slice) => ({
       ...slice,
       entries: makeChildEntries(child.agentName, child.executionId),
-      // One child carries usage so scenarios pin the row metadata column's
-      // generated-token figure (`↓40k`).
-      usage:
-        child.agentName === 'reviewer'
-          ? { inputTokens: 52_000, outputTokens: 39_900, cost: 0.12 }
-          : slice.usage,
     }));
-    setStreamStatusInCliState({
-      streamId: streamId,
-      status: child.status,
-      runStartedAt:
+    // One child carries usage so scenarios pin the row metadata column's
+    // generated-token figure (`↓40k`). Usage lives on the snapshot store, so
+    // it arrives as the run fact the store accumulates.
+    if (child.agentName === 'reviewer') {
+      defaultSession().events.emit({
+        scope: 'run',
+        streamId,
+        event: {
+          type: 'usage',
+          payload: {
+            streamId,
+            storageKey: child.executionId as ExecutionId,
+            usage: { inputTokens: 52_000, outputTokens: 39_900, cost: 0.12 },
+          },
+        },
+      });
+    }
+    if (child.status !== undefined) {
+      seedHarnessStreamPhase(
+        streamId,
+        child.status,
         child.status === STREAM_PHASE.RUNNING ? child.startedAt : undefined,
-    });
+      );
+    }
   }
   if (SHOW_NESTED_CHILDREN) {
     emitSetActiveStream(
@@ -1875,11 +1910,11 @@ if (SHOW_CHILDREN) {
       ...slice,
       entries: makeChildEntries('localChecker', 'nested proof check'),
     }));
-    setStreamStatusInCliState({
-      streamId: 'harness-nested-local-checker-stream',
-      status: STREAM_PHASE.RUNNING,
-      runStartedAt: nestedStartedAt,
-    });
+    seedHarnessStreamPhase(
+      'harness-nested-local-checker-stream',
+      STREAM_PHASE.RUNNING,
+      nestedStartedAt,
+    );
   }
 }
 
@@ -2075,11 +2110,7 @@ function markHarnessInterrupted(): void {
   // the phase-merge of the real per-child transitions below.
   emitChildRoster(STREAM_ID, []);
   appendHarnessAssistantTranscript('Harness interrupt requested.', STREAM_ID);
-  setStreamStatusInCliState({
-    streamId: STREAM_ID,
-    status: STREAM_PHASE.CANCELLED,
-    runStartedAt: undefined,
-  });
+  seedHarnessStreamPhase(STREAM_ID, STREAM_PHASE.CANCELLED);
   for (const streamId of childStreamIds) {
     defaultSession().status.transition(
       streamId,
@@ -2090,7 +2121,7 @@ function markHarnessInterrupted(): void {
 }
 
 function canInterruptHarnessStream(streamId: StreamTabId): boolean {
-  return isInFlightPhase(streams.get().get(streamId)?.status);
+  return isInFlightPhase(streamPhaseFor(streamId)?.phase);
 }
 
 function markHarnessStreamInterrupted(streamId: StreamTabId): void {
@@ -2112,11 +2143,6 @@ function markHarnessStreamInterrupted(streamId: StreamTabId): void {
     `Harness focused interrupt requested for ${streamId}.`,
     streamId,
   );
-  setStreamStatusInCliState({
-    streamId: streamId,
-    status: STREAM_PHASE.CANCELLED,
-    runStartedAt: undefined,
-  });
   defaultSession().status.transition(
     streamId,
     STREAM_PHASE.CANCELLED,
@@ -2135,7 +2161,7 @@ function appendHarnessChildSubmitAck(
   text: string,
   streamId: StreamTabId,
 ): void {
-  const isLive = isActivePhase(streams.get().get(streamId)?.status);
+  const isLive = isActivePhase(streamPhaseFor(streamId)?.phase);
   appendHarnessTranscript('assistant', text, streamId, { finalized: !isLive });
 }
 
@@ -2251,7 +2277,7 @@ function handleHarnessSubmit(line: string): void {
     metadata: focusedActiveStreamId
       ? streamMetadataFor(focusedActiveStreamId)
       : undefined,
-    streams: streams.get(),
+    phaseOf: (streamId) => streamPhaseFor(streamId)?.phase,
   });
   if (focusedChildRoute.kind === 'reject') {
     appendHarnessAssistantTranscript(
@@ -2280,11 +2306,11 @@ function appendHarnessStatus(): void {
       model: meta.model,
       teamName: meta.teamName,
       modelAccess: resolveCliModelAccessRoute({
-        usageRoute: slice?.usage?.usageRoute,
+        usageRoute: readStreamArtifacts(streamId)?.cumulativeUsage?.usageRoute,
       }),
       approval: formatTexraApprovalPolicy(harnessRuntimeSession.approvalPolicy),
       approvalBypasses: slice?.bypass,
-      status: slice?.status,
+      status: streamPhaseFor(streamId)?.phase,
       goal: GoalStore.getForStream(streamId),
       // The harness never emits an ACTIVE_SKILLS snapshot.
       activeSkills: [],

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2774,7 +2774,7 @@ const SCENARIOS = [
       },
       {
         // A late resume-transition attempt is the one status fact that would
-        // otherwise reach `setStreamStatusInCliState` (a repeated terminal
+        // otherwise reach the CLI adapter's fold (a repeated terminal
         // transition is a same-value no-op the status machine drops before
         // it gets there) — it must still stay suppressed by the removal
         // tombstone.

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -58,6 +58,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { clearApprovals } from './tui/state/approvalQueue';
 import {
+  establishWorkPlanReaderAuthority,
   focusStream,
   rootStreamId,
   patchSessionMeta,
@@ -77,10 +78,7 @@ import {
   moveLocalTranscriptToStream,
 } from './tui/state/transcript';
 import { syncStreamLog } from './tui/state/subscribeStreamLog';
-import {
-  beginLoadedStreamsReconcile,
-  markArtifactStreamHydrated,
-} from './tui/state/subscribeStreamArtifacts';
+import { bumpStreamArtifactRevision } from './tui/state/subscribeStreamArtifacts';
 
 type InterruptedFollowUp = Pick<
   FollowUpQueueInput,
@@ -553,32 +551,26 @@ export function createChatSessionController(
 
       const sessionContext = beginRunContext(config, 'history');
 
-      const loadedStreamsReconcile = beginLoadedStreamsReconcile([streamId]);
-
       await runtimeSession.transcripts.ensureLoaded(streamId);
-      // `load` evicts synchronously before its async seed. Drop those markers
-      // before the await yields so `readStreamArtifacts` cannot project an
-      // evicted/unseeded record (and re-emit warnIfUnseeded) mid-seed. On
-      // rejection the retained root stays unmarked — it was never seeded. A
-      // previously hydrated retained root deliberately remains marked during
-      // reseeding: this keeps its canonical pre-resume projection visible at
-      // the cost of bounded warnIfUnseeded notices until the seed completes.
-      loadedStreamsReconcile.dropStale();
+      // `load` evicts every other record synchronously before its async seed,
+      // and the store reports no provenance for an evicted record, so nothing
+      // projects an evicted/unseeded stream (or re-emits warnIfUnseeded)
+      // mid-seed without any marker bookkeeping here. A previously seeded
+      // retained root deliberately keeps its provenance during reseeding:
+      // this keeps its canonical pre-resume projection visible at the cost of
+      // bounded warnIfUnseeded notices until the seed completes.
       await snapshotStore.load([streamId]);
-      // Mark the retained root before the log sync below can render a stale
-      // pre-resume projection.
-      loadedStreamsReconcile.reconcile();
+      // Promote an open `/plan` reader's failure-time mask for the retained
+      // root and drop the projection memo before the log sync below can
+      // render a stale pre-resume projection.
+      establishWorkPlanReaderAuthority(streamId, ['plan', 'todos']);
+      bumpStreamArtifactRevision();
       // A resumed stream may be one the user /clear-ed; the empty patch mints
       // the slice and drops the retired mark so `syncStreamLog` and
       // `focusStream` accept it again.
       patchStream(streamId, (slice) => ({ ...slice }));
       syncStreamLog(runtimeSession, streamId);
       focusStream(streamId);
-      // Re-reconcile now that focus has moved: a stale in-flight preload for the
-      // previous stream that re-added it during the awaited load above is cleared
-      // again, while any stream preloaded in the meantime is preserved. Later
-      // hydrations for the old stream also fail requestIsCurrent.
-      loadedStreamsReconcile.reconcile();
 
       const { presentationHost, approvalsUnavailable, ownExecution, finalize } =
         setupRunHost(sessionContext);
@@ -725,7 +717,7 @@ export function createChatSessionController(
         await snapshotStore.preload([streamId]);
         // Invalidate the memo immediately after the direct seed, before the
         // awaited metadata/patch/focus below can render a stale projection.
-        markArtifactStreamHydrated(streamId);
+        bumpStreamArtifactRevision();
         const runMetadata = snapshotStore.getRunMetadata(streamId);
         const executionId =
           runMetadata.executionId ??

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -78,6 +78,7 @@ import {
   reverseSearchOpen as reverseSearchOpenSignal,
   slashPaletteOpen as slashPaletteOpenSignal,
   streams as streamsSignal,
+  streamPhaseFor,
 } from './state/cliState';
 import { appendLocalAssistantTranscript } from './state/transcript';
 import {
@@ -220,7 +221,7 @@ export function App(props: AppProps): React.JSX.Element {
       activeStreamId,
       parentStream,
       metadata: activeStreamId ? streamMetadataFor(activeStreamId) : undefined,
-      streams,
+      phaseOf: (streamId) => streamPhaseFor(streamId)?.phase,
     }).kind === 'reject';
   const appInputDisabled = foregroundOpen || childListFocused;
   const inputDisabledMessage = childListFocused
@@ -287,7 +288,7 @@ export function App(props: AppProps): React.JSX.Element {
     (view) =>
       view.parentId !== undefined &&
       view.slice !== undefined &&
-      isActivePhase(view.slice.status),
+      isActivePhase(streamPhaseFor(view.id)?.phase),
   ).length;
   const activeSubagentExecutionIds = useMemo(() => {
     const executionIds = new Map<StreamTabId, string>();

--- a/packages/cli/src/chat/tui/chatSubmitDriver.ts
+++ b/packages/cli/src/chat/tui/chatSubmitDriver.ts
@@ -41,6 +41,7 @@ import {
   sessionMeta as sessionMetaSignal,
   setTransientNotice,
   streams as streamsSignal,
+  streamPhaseFor,
 } from './state/cliState';
 import {
   focusedChildFollowUpRoute,
@@ -112,7 +113,7 @@ export function chatTuiFocusedChildFollowUpRoute(): FocusedChildFollowUpRoute {
     activeStreamId,
     parentStream: parentStreamSignal.get(),
     metadata: activeStreamId ? streamMetadataFor(activeStreamId) : undefined,
-    streams: streamsSignal.get(),
+    phaseOf: (streamId) => streamPhaseFor(streamId)?.phase,
   });
 }
 

--- a/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
@@ -22,10 +22,14 @@ import {
   openInfoPane,
   sessionMeta,
   setTransientNotice,
+  streamPhaseFor,
   streams,
   workPlanReaderRequestIsCurrent,
 } from '@cli/chat/tui/state/cliState';
-import { hydrateStreamArtifacts } from '@cli/chat/tui/state/subscribeStreamArtifacts';
+import {
+  hydrateStreamArtifacts,
+  readStreamArtifacts,
+} from '@cli/chat/tui/state/subscribeStreamArtifacts';
 import { terminalCapabilities } from '@cli/chat/tui/state/terminalCapabilities';
 import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import { activeStreamParentOrSelfId } from '@cli/chat/tui/state/streamViews';
@@ -131,6 +135,7 @@ export async function showCliSessionStatus(
   const activeStreamId = activeStreamIdSignal.get();
   const streamSlices = streams.get();
   const slice = activeStreamId ? streamSlices.get(activeStreamId) : undefined;
+  const activePhase = slice ? streamPhaseFor(activeStreamId) : undefined;
   const rosters = childRosters.get();
   const directActiveChildren = activeStreamId
     ? activeSubagentsFor(activeStreamId, rosters)
@@ -159,13 +164,15 @@ export async function showCliSessionStatus(
       model,
       teamName: meta.teamName,
       modelAccess: resolveCliModelAccessRoute({
-        usageRoute: slice?.usage?.usageRoute,
+        usageRoute: activeStreamId
+          ? readStreamArtifacts(activeStreamId)?.cumulativeUsage?.usageRoute
+          : undefined,
         prospectiveRoute,
       }),
       approval: formatTexraApprovalPolicy(context.getApprovalPolicy()),
       approvalBypasses: slice?.bypass,
-      status: slice?.status,
-      substate: slice?.substate,
+      status: activePhase?.phase,
+      substate: activePhase?.substate,
       activeChildSessions,
       goal: activeStreamId ? GoalStore.getForStream(activeStreamId) : undefined,
       activeSkills: activeSkillNamesFor(activeStreamId),

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -16,6 +16,7 @@ import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 
 import {
   activeStreamId as activeStreamIdSignal,
+  streamPhaseFor,
   streams as streamsSignal,
   type StreamSlice,
 } from '../state/cliState';
@@ -223,7 +224,7 @@ export function ConversationPane(
   const displayEntries = pendingTranscriptEntries(
     entries,
     slice?.finalizedFrontier ?? 0,
-    slice?.status,
+    slice && streamPhaseFor(activeStreamId)?.phase,
   );
 
   const maxRows = props.maxRows ?? DEFAULT_TRANSCRIPT_ROWS;

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -18,6 +18,7 @@ import { safeHomedir } from '@utils/system/platformPaths';
 
 import {
   sessionMeta as sessionMetaSignal,
+  streamPhaseFor,
   streams as streamsSignal,
   type SessionMeta,
   type StreamSlice,
@@ -742,6 +743,11 @@ function ensureStaticSessionHeader({
 
 interface BuildStaticTranscriptItemsOptions {
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+  /** Lifecycle phase of `scrollbackStreamId`, read by the caller from the
+   *  session status machine (`streamPhaseFor`) — this projection stays pure.
+   *  Absent is a real value: a stream with no phase yet, which is also what a
+   *  fixture that does not care about settlement passes. */
+  readonly status?: StreamPhase;
   readonly childRosters?: ChildRosters;
   readonly executionLabels?: ExecutionLabels;
   readonly meta: SessionMeta;
@@ -768,6 +774,7 @@ export function buildStaticTranscriptItems(
 ): StaticTranscriptBuildResult {
   const {
     streams,
+    status,
     childRosters = new Map(),
     executionLabels,
     meta,
@@ -816,7 +823,7 @@ export function buildStaticTranscriptItems(
   const orderedStaticEntries = orderedStaticTranscriptEntries(
     slice?.entries ?? [],
     slice?.finalizedFrontier ?? 0,
-    slice?.status,
+    status,
   );
   // Dedupe by the entry's own stable id, as the incremental path does.
   const seen = new Set<string>();
@@ -909,6 +916,7 @@ export function buildStaticTranscriptState({
   repaintEpoch,
   ringBudgets = DEFAULT_STATIC_TRANSCRIPT_RING_BUDGETS,
   scrollbackStreamId,
+  status,
   streams,
   width,
 }: {
@@ -921,12 +929,14 @@ export function buildStaticTranscriptState({
   readonly repaintEpoch: number;
   readonly ringBudgets?: StaticTranscriptRingBudgets;
   readonly scrollbackStreamId: StreamTabId | undefined;
+  readonly status?: StreamPhase;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly width?: number;
   readonly eraseRequest?: number;
 }): StaticTranscriptState {
   const built = buildStaticTranscriptItems({
     streams,
+    status,
     childRosters,
     executionLabels,
     meta,
@@ -953,13 +963,13 @@ export function buildStaticTranscriptState({
     ? incrementalStaticTranscriptEntries(
         slice?.entries,
         slice?.finalizedFrontier ?? 0,
-        slice?.status,
+        status,
         undefined,
       ).cursor
     : scanStaticTranscriptFromStart(
         slice?.entries,
         slice?.finalizedFrontier ?? 0,
-        slice?.status,
+        status,
       );
   return {
     ownerKey,
@@ -986,6 +996,7 @@ export function advanceStaticTranscriptState(
     parentStream,
     ringBudgets = DEFAULT_STATIC_TRANSCRIPT_RING_BUDGETS,
     scrollbackStreamId,
+    status,
     streams,
     width,
   }: {
@@ -998,6 +1009,7 @@ export function advanceStaticTranscriptState(
     readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
     readonly ringBudgets?: StaticTranscriptRingBudgets;
     readonly scrollbackStreamId: StreamTabId | undefined;
+    readonly status?: StreamPhase;
     readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
     readonly width: number;
   },
@@ -1012,7 +1024,6 @@ export function advanceStaticTranscriptState(
   // scrollback slice is absent.
   const entries = slice?.entries;
   const finalizedFrontier = slice?.finalizedFrontier ?? 0;
-  const status = slice?.status;
 
   // Rebuilds below share every render input; only the repaint epoch differs
   // per call site.
@@ -1028,6 +1039,7 @@ export function advanceStaticTranscriptState(
       repaintEpoch,
       ringBudgets,
       scrollbackStreamId,
+      status,
       streams,
       width,
     });
@@ -1231,10 +1243,14 @@ export function StaticConversationTranscript({
   // bound SessionState; the revision drives the advance effect when metadata
   // (e.g. a focused child's model) lands without any other dependency moving.
   const sessionRevision = useSignal(sessionStateRevision);
+  // The one status read for this component: the session status machine owns
+  // the phase, gated on the scrollback owner having a slice at all.
+  const status = streamPhaseFor(scrollbackStreamId)?.phase;
 
   const buildFreshItems = (): readonly StaticTranscriptItem[] =>
     buildStaticTranscriptItems({
       streams,
+      status,
       childRosters,
       executionLabels: subagentExecutionLabels,
       meta: sessionMeta,
@@ -1255,6 +1271,7 @@ export function StaticConversationTranscript({
       parentStream,
       repaintEpoch: 0,
       scrollbackStreamId,
+      status,
       streams,
       width: normalizedWidth,
     }),
@@ -1273,6 +1290,7 @@ export function StaticConversationTranscript({
         ownerKey,
         parentStream,
         scrollbackStreamId,
+        status,
         streams,
         width: normalizedWidth,
       }),
@@ -1286,6 +1304,7 @@ export function StaticConversationTranscript({
     scrollbackStreamId,
     sessionMeta,
     sessionRevision,
+    status,
     streams,
     subagentExecutionLabels,
     normalizedWidth,

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -26,6 +26,7 @@ import {
   rootRunPending as rootRunPendingSignal,
   rootRunStreamId as rootRunStreamIdSignal,
   sessionMeta as sessionMetaSignal,
+  streamPhaseFor,
   streams as streamsSignal,
   NO_BYPASS,
 } from '../state/cliState';
@@ -39,6 +40,10 @@ import {
   streamStateFor,
   visibleSubagentRows,
 } from '../state/childExecutions';
+import {
+  readStreamArtifacts,
+  streamArtifactRevision,
+} from '../state/subscribeStreamArtifacts';
 import { streamLabelForId } from '../state/streamViews';
 import { ancestorWorkflowPhaseLabel } from '../state/workflowPhase';
 import { useSignal } from '../state/useSignal';
@@ -77,6 +82,9 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   // Subscribe to the shared SessionState: the model/stage/queued-follow-up
   // reads below go through its helpers rather than the streams map.
   useSignal(sessionStateRevision);
+  // The usage gauge projects `StreamArtifactProjection.cumulativeUsage`, which
+  // repaints on this revision rather than on the streams map.
+  useSignal(streamArtifactRevision);
   const transientNotice = useSignal(transientNoticeSignal);
   const approvals = useSignal(approvalQueueStatus);
   const caps = useSignal(terminalCapabilities);
@@ -92,17 +100,22 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     canStopActiveRun: chatTuiCanStopVisibleRun({
       runPending: rootRunPending,
       streamId: rootRunStreamId,
-      status: rootRunStreamId
-        ? streams.get(rootRunStreamId)?.status
-        : undefined,
+      status: streamPhaseFor(rootRunStreamId)?.phase,
     }),
     canStopPendingRunWithoutStream:
       rootRunPending && rootRunStreamId === undefined,
     parentStream,
+    phaseOf: (streamId) => streamPhaseFor(streamId)?.phase,
     streams,
   });
   const statusSlice = target.displaySlice;
   const displayStreamId = target.displayStreamId;
+  const displayPhase = streamPhaseFor(displayStreamId);
+  // Cumulative per-run usage for the displayed stream — the store's own sum,
+  // the same figure the subagent rows and the exit summary present.
+  const displayUsage = displayStreamId
+    ? readStreamArtifacts(displayStreamId)?.cumulativeUsage
+    : undefined;
   // Use root-session access facts only before any stream exists.
   const accessModel =
     (displayStreamId === undefined
@@ -130,9 +143,9 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const subscriptionProbeFailed =
     resolutionCurrent &&
     subscriptionResolution?.failed === true &&
-    statusSlice?.usage?.usageRoute === undefined;
+    displayUsage?.usageRoute === undefined;
   const modelAccess = resolveCliModelAccessRoute({
-    usageRoute: statusSlice?.usage?.usageRoute,
+    usageRoute: displayUsage?.usageRoute,
     prospectiveRoute,
   });
 
@@ -206,7 +219,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   );
 
   const subscriptionUsageProvider = subscriptionUsageProviderForStatus({
-    usageRoute: statusSlice?.usage?.usageRoute,
+    usageRoute: displayUsage?.usageRoute,
     prospectiveRoute,
   });
   const [subscriptionQuotaRead, setSubscriptionQuotaRead] = useState<{
@@ -247,8 +260,8 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const displayStreamState =
     displayStreamId === undefined ? undefined : streamStateFor(displayStreamId);
 
-  const runStartedAt = isActivePhase(statusSlice?.status)
-    ? statusSlice?.runStartedAt
+  const runStartedAt = isActivePhase(displayPhase?.phase)
+    ? displayPhase?.runStartedAt
     : undefined;
   const now = useLiveNowMsSince([runStartedAt]);
 
@@ -284,8 +297,8 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
         });
 
   const display = buildStatusBarDisplay({
-    status: statusSlice?.status,
-    substate: statusSlice?.substate,
+    status: displayPhase?.phase,
+    substate: displayPhase?.substate,
     elapsedMs: runStartedAt !== undefined ? now - runStartedAt : undefined,
     runningFrame: runStartedAt !== undefined ? loadingFrameAt(now) : undefined,
     transientNotice,
@@ -295,7 +308,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     compactingActive: statusSlice?.compactingActive ?? false,
     queuedFollowUpMessages:
       displayStreamId === undefined ? [] : queuedFollowUpsFor(displayStreamId),
-    usage: statusSlice?.usage,
+    usage: displayUsage,
     contextState: displayStreamState?.contextState,
     stage: displayStreamState?.stage,
     subagents: subagentCount,

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -54,8 +54,8 @@ import {
   streamStateFor,
 } from '../state/childExecutions';
 import {
+  readStreamArtifacts,
   streamArtifactRevision,
-  streamPreferredUsage,
 } from '../state/subscribeStreamArtifacts';
 import {
   childListStreamId,
@@ -82,8 +82,8 @@ import {
   workflowPhaseTallyText,
 } from './SubagentListDisplay';
 import { useSignal } from '../state/useSignal';
+import { streamPhaseFor, type StreamSlice } from '../state/cliState';
 import type { PendingApprovalKind } from '../state/approvalQueue';
-import type { StreamSlice } from '../state/cliState';
 import type { StreamView } from '../state/streamViews';
 
 const SUBAGENT_SUMMARY_MAX_COLUMNS = 100;
@@ -175,18 +175,15 @@ function SessionRow({
   useSignal(sessionStateRevision);
   const metadata = streamMetadataFor(session.id);
   const streamState = streamStateFor(session.id);
-  const status = session.slice?.status;
-  const substate = session.slice?.substate;
+  const phase = streamPhaseFor(session.id);
+  const status = phase?.phase;
   const statusLabel = formatCliStatusLabel(
     status,
-    substate,
+    phase?.substate,
     session.parentId !== undefined,
   );
   const elapsed = childElapsed(
-    {
-      status,
-      startedAt: session.slice?.runStartedAt,
-    },
+    { status, startedAt: phase?.runStartedAt },
     nowMs,
   );
   // Significance order — informational counts shed first, then the summary,
@@ -282,7 +279,6 @@ function SessionRow({
 
 function workflowTaskMetadata(
   call: WorkflowCallProgress,
-  child: StreamSlice | undefined,
   streamId: StreamTabId | undefined,
   nowMs: number,
 ): string | undefined {
@@ -291,11 +287,14 @@ function workflowTaskMetadata(
   // in-flight window the card itself cannot: elapsed, generated tokens, and
   // the running spend read off the child stream.
   const live = !isTerminalWorkflowCallProgress(call);
-  const usage = streamPreferredUsage(streamId, child);
+  const usage = streamId
+    ? readStreamArtifacts(streamId)?.cumulativeUsage
+    : undefined;
+  const runStartedAt = streamPhaseFor(streamId)?.runStartedAt;
   const parts = [
     ...formatWorkflowCallMetadataParts(call),
-    live && child?.runStartedAt !== undefined
-      ? formatCompactDuration(nowMs - child.runStartedAt)
+    live && runStartedAt !== undefined
+      ? formatCompactDuration(nowMs - runStartedAt)
       : undefined,
     usage && usage.outputTokens > 0
       ? `${TOKENS_GENERATED}${formatCompactTokenCount(usage.outputTokens)}`
@@ -308,14 +307,12 @@ function workflowTaskMetadata(
 }
 
 function WorkflowTaskRow({
-  child,
   entry,
   focused,
   nowMs,
   pendingKinds,
   streamId,
 }: {
-  readonly child: StreamSlice | undefined;
   readonly entry: WorkflowTaskEntry;
   readonly focused: boolean;
   readonly nowMs: number;
@@ -324,7 +321,7 @@ function WorkflowTaskRow({
 }): React.JSX.Element {
   useSignal(sessionStateRevision);
   const style = WORKFLOW_TASK_STATUS_STYLE[entry.call.status];
-  const metadata = workflowTaskMetadata(entry.call, child, streamId, nowMs);
+  const metadata = workflowTaskMetadata(entry.call, streamId, nowMs);
   const approval = pendingApprovalRowDisplay(pendingKinds);
   return (
     <Box flexDirection="row" height={1} minWidth={0} overflowY="hidden">
@@ -398,12 +395,7 @@ function WorkflowDashboard({
   const uniqueChildId = (entry: WorkflowTaskEntry): StreamTabId | undefined =>
     uniqueWorkflowChildStreamId(entry, model.childTaskIndex, streams);
   const nowMs = useLiveNowMsSince(
-    tasks.map((entry) => {
-      const childStreamId = uniqueChildId(entry);
-      return childStreamId === undefined
-        ? undefined
-        : streams.get(childStreamId)?.runStartedAt;
-    }),
+    tasks.map((entry) => streamPhaseFor(uniqueChildId(entry))?.runStartedAt),
   );
   const phaseItems: SelectItem<ChildListValue>[] = groups.map((group) => ({
     label: group.heading.phaseLabel,
@@ -487,9 +479,6 @@ function WorkflowDashboard({
     const childStreamId = uniqueChildId(entry);
     return (
       <WorkflowTaskRow
-        child={
-          childStreamId === undefined ? undefined : streams.get(childStreamId)
-        }
         entry={entry}
         focused={state.focused}
         nowMs={nowMs}
@@ -660,7 +649,7 @@ export function SubagentList(
   const sessions = props.sessions ?? [];
   useSignal(streamArtifactRevision);
   const startedAts = useMemo(
-    () => sessions.map((session) => session.slice?.runStartedAt),
+    () => sessions.map((session) => streamPhaseFor(session.id)?.runStartedAt),
     [sessions],
   );
   const { items, sessionsByValue } = useMemo(() => {
@@ -778,7 +767,7 @@ export function SubagentList(
             <SessionRow
               isListRoot={session.id === props.listRootStreamId}
               active={state.active}
-              cumulativeUsage={streamPreferredUsage(session.id, session.slice)}
+              cumulativeUsage={readStreamArtifacts(session.id)?.cumulativeUsage}
               focused={state.focused}
               hiddenRowSummary={hiddenRowSummary}
               metadataColumn={metadataColumn}

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -843,12 +843,15 @@ export function statusBarStreamTarget({
   canStopActiveRun,
   canStopPendingRunWithoutStream = false,
   parentStream,
+  phaseOf,
   streams,
 }: {
   readonly activeStreamId: StreamTabId | undefined;
   readonly canStopActiveRun: boolean;
   readonly canStopPendingRunWithoutStream?: boolean;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  /** Lifecycle phase for a stream, from the session status machine. */
+  readonly phaseOf: (streamId: StreamTabId) => StreamPhase | undefined;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }): StatusBarStreamTarget {
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
@@ -856,11 +859,12 @@ export function statusBarStreamTarget({
     activeStreamId,
     parentStream,
     values: streams,
-    canUseValue: (stream) => isActivePhase(stream.status),
+    canUseValue: (_stream, streamId) => isActivePhase(phaseOf(streamId)),
   });
   let hasPendingOrLiveStream = false;
-  for (const stream of streams.values()) {
-    if (stream.status === undefined || isActivePhase(stream.status)) {
+  for (const streamId of streams.keys()) {
+    const phase = phaseOf(streamId);
+    if (phase === undefined || isActivePhase(phase)) {
       hasPendingOrLiveStream = true;
       break;
     }

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -90,6 +90,7 @@ import {
   patchSessionMeta,
   sessionMeta as sessionMetaSignal,
   streams as streamsSignal,
+  streamPhaseFor,
 } from './state/cliState';
 import { subscribeStreamArtifacts } from './state/subscribeStreamArtifacts';
 import { notifyStaticTranscriptErased } from './state/staticTranscriptRepaint';
@@ -342,9 +343,7 @@ export async function runChat(
 
   const followUpQueue = new PQueue({ concurrency: 1 });
   const rootStreamStatus = (): StreamPhase | undefined =>
-    session.streamId
-      ? streamsSignal.get().get(session.streamId)?.status
-      : undefined;
+    streamPhaseFor(session.streamId)?.phase;
   const hasActiveToolUseFlow = (): boolean =>
     Boolean(
       session.streamId &&
@@ -418,9 +417,7 @@ export async function runChat(
 
   const resetSessionForClear = (): void => {
     const currentStreamId = session.streamId ?? activeStreamIdSignal.get();
-    const activeStatus = currentStreamId
-      ? streamsSignal.get().get(currentStreamId)?.status
-      : undefined;
+    const activeStatus = streamPhaseFor(currentStreamId)?.phase;
     const isRunPending = chatTuiRunPending(session);
 
     if (

--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -11,6 +11,7 @@
 // `CHILD_STREAMS` state machine — single-substrate plan, Wave A.)
 
 import { computed, signal, type Signal } from '@lit-labs/signals';
+import type { StreamPhaseState } from '@agent/runtime';
 import type {
   SessionState,
   SessionStreamMetadata,
@@ -78,6 +79,16 @@ export function streamStateFor(
   streamId: StreamTabId,
 ): StreamExecutionState | undefined {
   return BOUND.get()?.state.getStreamState(streamId);
+}
+
+/** Lifecycle state for a stream — phase, substate, and the run-window start
+ *  elapsed time is rendered from — straight off the session's status machine,
+ *  the single owner that stamps all three. Renderers go through
+ *  `streamPhaseFor` in `cliState`, which adds the no-slice-no-paint gate. */
+export function sessionStreamPhase(
+  streamId: StreamTabId,
+): StreamPhaseState | undefined {
+  return BOUND.get()?.state.streamStatus.getStreamState(streamId);
 }
 
 /** Queued follow-up messages for a stream, from the session-owned queue. */

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -3,6 +3,7 @@
  * focus, overlays, exit hints) lives here as signals.
  */
 import { computed, signal, type Signal } from '@lit-labs/signals';
+import type { StreamPhaseState } from '@agent/runtime';
 import type { RunModelDecisionReason } from '@model/runModelDecision';
 import {
   TEXRA_APPROVAL_POLICY_DEFAULT,
@@ -11,11 +12,8 @@ import {
 import type {
   AgentDelegationScope,
   StreamLogEntry,
-  StreamPhase,
-  StreamSubstate,
   StreamTabId,
   TaskGroup,
-  TokenUsageStats,
 } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas';
 import type { TranscriptRow } from '@shared/transcript';
@@ -24,7 +22,7 @@ import type {
   CompactionActivityProjection,
 } from '@shared/streams/compactionActivityProjection';
 import type { StreamArtifactAuthority } from '@transcript';
-import { isChildStreamRemoved } from './childExecutions';
+import { isChildStreamRemoved, sessionStreamPhase } from './childExecutions';
 import type { PastedImageEntry } from '../input/draftAttachments';
 
 // ---------------------------------------------------------------------------
@@ -147,9 +145,10 @@ export interface BypassState {
 
 /**
  * CLI-only per-stream view state. Everything the shared substrate owns —
- * identity/config/description metadata (`streamMetadataFor`), conversation
- * progress and stage (`streamStateFor`), workflow artifacts and cumulative
- * usage (`readStreamArtifacts`/`StreamArtifactProjection`), queued follow-ups
+ * identity/config/description metadata (`streamMetadataFor`), lifecycle phase,
+ * substate and run-window start (`streamPhaseFor`), conversation progress and
+ * stage (`streamStateFor`), workflow artifacts and cumulative usage
+ * (`readStreamArtifacts`/`StreamArtifactProjection`), queued follow-ups
  * (`queuedFollowUpsFor`) — is read from it at paint and has no field here.
  * What remains is transcript-rail projection output (the fold rail stays
  * separate from the fact rail by design) and terminal modality.
@@ -158,21 +157,10 @@ export interface StreamSlice {
   readonly streamId: StreamTabId;
   /** Run/round/phase lifecycle projected from the canonical StreamLog. */
   readonly taskGroups: readonly TaskGroup[];
-  readonly status: StreamPhase | undefined;
-  readonly substate?: StreamSubstate;
-  /** Run-window start mirrored verbatim from the `status` fact — the session
-   *  status machine stamps and clears it (`StreamPhaseState.runStartedAt`).
-   *  Drives the StatusBar's live elapsed-time segment so a long token-less
-   *  "thinking" turn still shows liveness. */
-  readonly runStartedAt: number | undefined;
   /** CLI-only live status: the newest meaningful transcript line for this
    *  stream, recomputed on every log sync. Fills the stream-list summary slot
    *  until the runtime supplies a `description`. */
   readonly latestLine: string | undefined;
-  /** Latest model usage snapshot, carried by the usage fact (no synchronous
-   *  shared read exists for the latest gauge). The StatusBar treats this as
-   *  current context occupancy, so it must not be accumulated across turns. */
-  readonly usage: TokenUsageStats | undefined;
   /** True while the latest hidden provider-side reasoning/thinking stream is
    *  the current live activity. The CLI never renders the content directly;
    *  this only drives a lightweight liveness indicator. */
@@ -207,14 +195,10 @@ export const NO_BYPASS: BypassState = {
 export function emptySlice(streamId: StreamTabId): StreamSlice {
   return {
     streamId,
-    status: undefined,
-    substate: undefined,
-    runStartedAt: undefined,
     latestLine: undefined,
     taskGroups: [],
     thinkingActive: false,
     compactingActive: false,
-    usage: undefined,
     entries: [],
     finalizedFrontier: 0,
     bypass: NO_BYPASS,
@@ -239,107 +223,44 @@ export function isCliStreamRetired(streamId: StreamTabId): boolean {
   return RETIRED_STREAMS.has(streamId);
 }
 
-/** A stream slice minus the lifecycle triple. `status`, its `substate`, and
- *  the `runStartedAt` the status machine stamps beside them belong to
- *  {@link setStreamStatusInCliState}, which is the only writer that enforces
- *  the removed/retired liveness rule. */
-type PatchableStreamSlice = Omit<
-  StreamSlice,
-  'status' | 'substate' | 'runStartedAt'
->;
-
-/** What a `patchStream` updater may return: the patchable fields, with the
- *  lifecycle triple closed off so re-writing `status` from a patch is a
- *  compile error rather than a second, unguarded status owner. */
-type StreamSlicePatch = PatchableStreamSlice & {
-  readonly status?: never;
-  readonly substate?: never;
-  readonly runStartedAt?: never;
-};
-
-/**
- * Patch one stream's view state. The updater receives the same slice twice:
- * once typed for patching (no lifecycle fields to spread back) and once whole,
- * for the patches that derive from the current status.
- */
+/** Patch one stream's view state. */
 export function patchStream(
   streamId: StreamTabId,
-  update: (
-    slice: PatchableStreamSlice,
-    lifecycle: Readonly<
-      Pick<StreamSlice, 'status' | 'substate' | 'runStartedAt'>
-    >,
-  ) => StreamSlicePatch,
+  update: (slice: StreamSlice) => StreamSlice,
 ): void {
   RETIRED_STREAMS.delete(streamId);
   const current = streams.get();
   const slice = current.get(streamId) ?? emptySlice(streamId);
-  const next = update(slice, slice);
+  const next = update(slice);
   if (next === slice) return;
   const out = new Map(current);
-  out.set(streamId, {
-    ...next,
-    status: slice.status,
-    substate: slice.substate,
-    runStartedAt: slice.runStartedAt,
-  });
+  out.set(streamId, next);
   streams.set(out);
 }
 
-function streamSliceWithStatus(
-  slice: StreamSlice,
-  status: StreamPhase,
-  substate: StreamSubstate | undefined,
-  runStartedAt: number | undefined,
-): StreamSlice {
-  if (
-    slice.status === status &&
-    slice.substate === substate &&
-    slice.runStartedAt === runStartedAt
-  ) {
-    return slice;
-  }
-  return { ...slice, status, substate, runStartedAt };
+/** Whether this stream identity is still live in the current state lifetime.
+ *  A stream tombstoned by `removeStream`, or retired by `resetCliState`, is
+ *  final: it accepts no further status, folds no log, and paints no phase. */
+export function cliStreamAcceptsStatus(streamId: StreamTabId): boolean {
+  return !isChildStreamRemoved(streamId) && !RETIRED_STREAMS.has(streamId);
 }
 
 /**
- * Apply a stream-status event once to the CLI state mirror.
+ * Lifecycle state for a stream at paint: phase, substate, and the run-window
+ * start elapsed time is rendered from, all read from the session's status
+ * machine — the single owner that stamps them and writes its entry before
+ * publishing the matching `status` fact.
  *
- * Runtime status still originates in the default session's status machine
- * (`defaultSession().status`), but TUI renderers should read only
- * StreamSlice data, so the slice is the single status owner at paint.
- * A status for a stream tombstoned by `removeStream`, or retired by
- * `resetCliState`, is ignored — both are final for that stream identity.
+ * Gated on this state lifetime holding a slice for the identity, which is how
+ * the removed/retired rule the deleted status mirror enforced still holds: the
+ * machine remembers the last phase of a stream `removeStream` dropped or
+ * `resetCliState` retired, and no slice means no paint.
  */
-export function setStreamStatusInCliState({
-  runStartedAt,
-  status,
-  substate,
-  streamId,
-}: {
-  /** Run-window start stamped by the session status machine and carried on the
-   *  `status` fact; absent for any non-active phase. */
-  readonly runStartedAt?: number;
-  readonly status: StreamPhase;
-  readonly substate?: StreamSubstate;
-  readonly streamId: StreamTabId;
-}): boolean {
-  if (isChildStreamRemoved(streamId) || RETIRED_STREAMS.has(streamId)) {
-    return false;
-  }
-  const current = streams.get();
-  const existingSlice = current.get(streamId);
-  const targetSlice = streamSliceWithStatus(
-    existingSlice ?? emptySlice(streamId),
-    status,
-    substate,
-    runStartedAt,
-  );
-  if (targetSlice === existingSlice) return true;
-  const out = new Map(current);
-  out.set(streamId, targetSlice);
-  streams.set(out);
-  return true;
+export function streamPhaseFor(
+  streamId: StreamTabId | undefined,
+): StreamPhaseState | undefined {
+  if (streamId === undefined || !streams.get().has(streamId)) return undefined;
+  return sessionStreamPhase(streamId);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/chat/tui/state/focusedChildFollowUp.ts
+++ b/packages/cli/src/chat/tui/state/focusedChildFollowUp.ts
@@ -3,12 +3,12 @@ import {
   AgentCategory,
   USER_FOLLOW_UP_SUPPORT,
   isPlainAgentIdentity,
+  type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
 import { isInFlightPhase } from '@shared/streams/streamStatus';
 
 import { activeStreamScope } from './streamViews';
-import type { StreamSlice } from './cliState';
 
 export type FocusedChildFollowUpRoute =
   | { readonly kind: 'none' }
@@ -16,13 +16,14 @@ export type FocusedChildFollowUpRoute =
   | { readonly kind: 'reject'; readonly streamId: StreamTabId };
 
 /** Select both the focused-child composer presentation and submission route.
- *  `metadata` is the active stream's shared metadata; callers read it
- *  (`streamMetadataFor(activeStreamId)`) so this selector stays pure. */
+ *  `metadata` is the active stream's shared metadata and `phaseOf` its
+ *  lifecycle phase; callers read both (`streamMetadataFor(activeStreamId)`,
+ *  `streamPhaseFor(streamId)`) so this selector stays pure. */
 export function focusedChildFollowUpRoute(init: {
   readonly activeStreamId: StreamTabId | undefined;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly metadata: Readonly<SessionStreamMetadata> | undefined;
-  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+  readonly phaseOf: (streamId: StreamTabId) => StreamPhase | undefined;
 }): FocusedChildFollowUpRoute {
   const scope = activeStreamScope({
     activeStreamId: init.activeStreamId,
@@ -32,7 +33,7 @@ export function focusedChildFollowUpRoute(init: {
     return { kind: 'none' };
   }
 
-  const status = init.streams.get(scope.streamId)?.status;
+  const status = init.phaseOf(scope.streamId);
   const metadata = init.metadata;
   // Terminal-backed agents consume follow-up queues at runtime, but the TUI
   // keeps their composer hidden until terminal-backed interaction has parity.

--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -22,7 +22,7 @@ import {
   visibleSubagentRows,
   type ChildRosters,
 } from './childExecutions';
-import { streamPreferredUsage } from './subscribeStreamArtifacts';
+import { readStreamArtifacts } from './subscribeStreamArtifacts';
 import type { StreamSlice } from './cliState';
 
 export interface ResumeTarget {
@@ -94,11 +94,9 @@ export function collectResumeUsage(
 ): TokenUsageStats | undefined {
   const usages: TokenUsageStats[] = [];
 
-  for (const [streamId, slice] of streams) {
-    const usage: TokenUsageStats | undefined = streamPreferredUsage(
-      streamId,
-      slice,
-    );
+  for (const streamId of streams.keys()) {
+    const usage: TokenUsageStats | undefined =
+      readStreamArtifacts(streamId)?.cumulativeUsage;
     if (!usage || !usageHasTokens(usage)) continue;
     usages.push(usage);
   }

--- a/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
+++ b/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
@@ -26,10 +26,10 @@ import {
 import { assertNever } from '@utils/core';
 import {
   activeStreamId,
+  cliStreamAcceptsStatus,
   focusStream,
   patchStream,
   removeStream,
-  setStreamStatusInCliState,
   streams,
 } from './cliState';
 import {
@@ -39,7 +39,7 @@ import {
   unbindChildStreamState,
 } from './childExecutions';
 import {
-  markArtifactStreamHydrated,
+  bumpStreamArtifactRevision,
   markWorkPlanArtifactHydrated,
 } from './subscribeStreamArtifacts';
 import {
@@ -84,13 +84,12 @@ class TuiSessionRenderer implements SessionRendererPort {
       case 'files':
       case 'compileFailures':
       case 'missingOutputs':
-        // Renderers read `StreamArtifactProjection` directly. The write itself
-        // is proof of established provenance for this session — a live fact
-        // must not wait on the focus-driven disk preload
-        // (`markArtifactStreamHydrated`'s other caller) that exists only to
-        // seed a stream cold, or a background (never-focused, or focus-raced)
-        // workflow's output files never surface.
-        return markArtifactStreamHydrated(streamId);
+        // Renderers read `StreamArtifactProjection` directly, and the store
+        // already accepted this write (eagerly, ahead of any seed), so it is
+        // the store that reports the record has provenance — a live fact
+        // never waits on the focus-driven disk preload that exists only to
+        // seed a stream cold. Only the repaint is owed here.
+        return bumpStreamArtifactRevision();
       case 'parentStreamId':
       case 'queuedFollowUps':
       case 'contextState':
@@ -111,12 +110,11 @@ class TuiSessionRenderer implements SessionRendererPort {
   }
 
   onStreamStatusChanged(): void {
-    // The slice already carries this transition: the CLI writes it from the
-    // `status` fact before handing the fact to the applier, and the fact
-    // carries the status machine's own `runStartedAt`, so there is nothing
-    // left for this callback to re-apply. Roster rows carry phase
-    // (`recordChildPhase`); re-derive snapshots so child rows repaint on
-    // phase flips.
+    // The status machine already holds this transition — it writes its entry
+    // before publishing the fact — and `streamPhaseFor` reads it at paint, so
+    // there is nothing to re-apply. Bump the shared revision so the phase,
+    // substate, run-window start, and the roster rows that carry phase
+    // (`recordChildPhase`) all repaint.
     invalidateChildStreams();
   }
 
@@ -152,22 +150,17 @@ class TuiSessionRenderer implements SessionRendererPort {
     invalidateChildStreams();
   }
 
-  onRunUsageChanged(
-    streamId: StreamTabId,
-    _storageKey: string,
-    latestUsage: Parameters<SessionRendererPort['onRunUsageChanged']>[2],
-  ): void {
-    // The latest-usage gauge is payload-only (no synchronous shared read);
-    // the cumulative sum is `StreamArtifactProjection.cumulativeUsage`. See
-    // `invalidate` for why the write marks the stream hydrated.
-    patchStream(streamId, (slice) => ({ ...slice, usage: latestUsage }));
-    markArtifactStreamHydrated(streamId);
+  onRunUsageChanged(): void {
+    // The store accumulated this delta before the callback; every usage
+    // reader projects `StreamArtifactProjection.cumulativeUsage` from it. See
+    // `invalidate` for why only the repaint is owed here.
+    bumpStreamArtifactRevision();
   }
 
   // Live todos/plan are readable from the snapshot store synchronously: a
   // live update is applied to `getWorkPlan` before the stream seeds
   // (StreamSnapshotStore eager-apply overlay), so renderers read the store.
-  // See `invalidate` for why the write marks the stream hydrated.
+  // The reader-authority promotion is the CLI's own `/plan` modality.
   onTodosChanged(streamId: StreamTabId, _todos: TodoItem[]): void {
     markWorkPlanArtifactHydrated(streamId, 'todos');
   }
@@ -207,19 +200,12 @@ export function attachSessionSignalsAdapter(
     if (fact.type === 'status') {
       // CLI status modality runs BEFORE the shared applier sees the fact:
       // the applier requests transcript eviction for non-active phases, and
-      // the final fold must land while the log is still resident. So the
-      // slice patch lands first (a reused stream still carrying `WAITING`
-      // from the previous turn would otherwise finalize the next run's
-      // first chunks early), THEN the log sync folds under the current
-      // status, THEN lifecycle releases residency for a stream that just
-      // left its active phase.
-      const recognized = setStreamStatusInCliState({
-        streamId: fact.streamId,
-        status: fact.phase,
-        substate: fact.substate,
-        runStartedAt: fact.runStartedAt,
-      });
-      if (recognized) {
+      // the final fold must land while the log is still resident. The status
+      // machine already holds this phase (it writes before publishing), so
+      // the fold below reads the new status through `streamPhaseFor`, THEN
+      // lifecycle releases residency for a stream that just left its active
+      // phase.
+      if (cliStreamAcceptsStatus(fact.streamId)) {
         syncStreamLog(
           session,
           fact.streamId,

--- a/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
@@ -5,7 +5,8 @@
 // replays any live deltas recorded meanwhile on top. Hydration copies none of
 // the round-artifact fields into `StreamSlice`, and no other mirror of them
 // exists: the live-fact adapter lands its writes on the shared store directly,
-// and renderers read the canonical projection (`projectStreamArtifacts`). This
+// renderers read the canonical projection (`projectStreamArtifacts`), and the
+// store answers whether a record has provenance yet (`hasProvenance`). This
 // module owns only the async preload edge plus the invalidation that makes
 // those reads repaint. Exit summaries and workflow-task metadata read
 // `readStreamArtifacts` the same way the renderers do.
@@ -13,7 +14,7 @@
 import { signal } from '@lit-labs/signals';
 
 import { tryDefaultSession } from '@agent/runtime';
-import { type StreamTabId, type TokenUsageStats } from '@shared/schemas';
+import { type StreamTabId } from '@shared/schemas';
 import { subscribeToSignalChanges } from '@shared/signals';
 import {
   StreamSnapshotPreloadError,
@@ -33,7 +34,6 @@ import {
   isCliStreamRetired,
   registerCliStateResetHook,
   setTransientNotice,
-  type StreamSlice,
 } from './cliState';
 import { isChildStreamRemoved } from './childExecutions';
 
@@ -41,15 +41,6 @@ import { isChildStreamRemoved } from './childExecutions';
  *  preload completes or when a live fact mutates the snapshot store. Renderers
  *  subscribe to this to repaint, and the projection memo keys on it. */
 export const streamArtifactRevision = signal<number>(0);
-
-/** Streams whose artifacts have established provenance this session: a
- *  completed preload, an authoritative `load` (resume reconciliation), or a
- *  live artifact write the adapter marked hydrated (see
- *  `readStreamArtifacts`). A stream absent here has no established disk
- *  provenance yet, so render-time reads return `undefined` — callers fall
- *  back to empty defaults — instead of hitting unseeded getters (and their
- *  `warnIfUnseeded` noise) mid-preload (#10730). */
-const hydratedArtifactStreams = new Set<StreamTabId>();
 
 /** Per-stream projection memo, invalidated on `streamArtifactRevision`. The
  *  four renderers share one projection per revision instead of re-summing usage
@@ -60,24 +51,17 @@ const hydratedArtifactStreams = new Set<StreamTabId>();
 const artifactProjectionMemo = new Map<StreamTabId, StreamArtifactProjection>();
 
 registerCliStateResetHook(() => {
-  hydratedArtifactStreams.clear();
   artifactProjectionMemo.clear();
   streamArtifactRevision.set(0);
 });
 
-/** Invalidate the projection memo and repaint artifact readers. */
-function bumpStreamArtifactRevision(): void {
+/** Invalidate the projection memo and repaint artifact readers. Called after
+ *  any write the store has already accepted — a live artifact fact, a
+ *  completed focus preload, or a resume `load` — since the store, not this
+ *  module, owns whether a record has provenance. */
+export function bumpStreamArtifactRevision(): void {
   artifactProjectionMemo.clear();
   streamArtifactRevision.set(streamArtifactRevision.get() + 1);
-}
-
-/** Mark a stream's durable artifacts hydrated and invalidate the projection
- *  memo. The focus-hydration owner calls this on success; direct store
- *  preload paths (resume) call it after their own seed so a focused stream
- *  loaded outside the focus subscription still repaints. */
-export function markArtifactStreamHydrated(streamId: StreamTabId): void {
-  hydratedArtifactStreams.add(streamId);
-  bumpStreamArtifactRevision();
 }
 
 /** Record a live plan/todo write as authority for an already-open partial
@@ -87,79 +71,28 @@ export function markWorkPlanArtifactHydrated(
   field: 'plan' | 'todos',
 ): void {
   establishWorkPlanReaderAuthority(streamId, [field]);
-  markArtifactStreamHydrated(streamId);
-}
-
-/** Prepare reconciliation for an authoritative full-set `load` of `retained`.
- *  `load` evicts every other record, so capture the markers it will evict up
- *  front (plus the active stream, whose first focus preload may still be in
- *  flight with no marker yet). Call `dropStale()` before awaiting `load` so the
- *  hydration gate stays honest across the async seed window (eviction is sync
- *  at the start of `load`); `reconcile()` after a successful `load` (and again
- *  after focus) re-drops those stale markers and marks the retained streams
- *  hydrated. A stale in-flight preload that re-adds an evicted stream is
- *  cleared either way, while a stream legitimately preloaded after the load is
- *  preserved (it was never in the captured stale set). */
-export function beginLoadedStreamsReconcile(retained: readonly StreamTabId[]): {
-  readonly dropStale: () => void;
-  readonly reconcile: () => void;
-} {
-  const retainedSet = new Set(retained);
-  const stale = new Set<StreamTabId>();
-  for (const streamId of hydratedArtifactStreams) {
-    if (!retainedSet.has(streamId)) stale.add(streamId);
-  }
-  const active = activeStreamId.get();
-  if (active !== undefined && !retainedSet.has(active)) stale.add(active);
-
-  const apply = (markRetained: boolean): void => {
-    for (const streamId of stale) hydratedArtifactStreams.delete(streamId);
-    if (markRetained) {
-      for (const streamId of retained) {
-        hydratedArtifactStreams.add(streamId);
-        establishWorkPlanReaderAuthority(streamId, ['plan', 'todos']);
-      }
-    }
-    bumpStreamArtifactRevision();
-  };
-  return {
-    dropStale: () => apply(false),
-    reconcile: () => apply(true),
-  };
+  bumpStreamArtifactRevision();
 }
 
 /** Read the canonical artifact projection for one stream from the live session.
  *  Returns `undefined` when no default session exists yet (harness/tests) or
- *  when the stream has no established provenance this session: no completed
- *  preload or resume `load`, and no live artifact write. `sessionSignalsAdapter` marks a stream
- *  hydrated on every live files, missing-outputs, compile-failures, usage,
- *  todos, or plan write, so a never-focused stream with live writes projects
- *  here too; callers default to empty values (`artifacts?.todos ?? []`) while
- *  the gate holds. */
+ *  when the store reports no provenance for the record: no completed preload
+ *  or resume `load`, and no live write eagerly applied ahead of a seed. The
+ *  store is the single owner of that fact (`hasProvenance`), so a
+ *  never-focused stream with live writes projects here too; callers default to
+ *  empty values (`artifacts?.todos ?? []`) while the gate holds — instead of
+ *  hitting unseeded getters (and their `warnIfUnseeded` noise) mid-preload
+ *  (#10730). */
 export function readStreamArtifacts(
   streamId: StreamTabId,
 ): StreamArtifactProjection | undefined {
   const session = tryDefaultSession();
-  if (!session || !hydratedArtifactStreams.has(streamId)) return undefined;
+  if (!session || !session.snapshots.hasProvenance(streamId)) return undefined;
   const cached = artifactProjectionMemo.get(streamId);
   if (cached !== undefined) return cached;
   const projection = projectStreamArtifacts(session.snapshots, streamId);
   artifactProjectionMemo.set(streamId, projection);
   return projection;
-}
-
-/** The usage a caller presents for one stream: the canonical store projection
- *  (durable + live) first, then the latest per-run usage gauge. Owned here so
- *  the exit summary and the workflow dashboard can't drift in precedence. */
-export function streamPreferredUsage(
-  streamId: StreamTabId | undefined,
-  slice: StreamSlice | undefined,
-): TokenUsageStats | undefined {
-  const projected =
-    streamId !== undefined
-      ? readStreamArtifacts(streamId)?.cumulativeUsage
-      : undefined;
-  return projected ?? slice?.usage;
 }
 
 function streamCanReceiveArtifacts(
@@ -216,7 +149,7 @@ export async function hydrateStreamArtifacts(
         ),
       );
       if (Object.values(error.authoritativeFields).every(Boolean)) {
-        markArtifactStreamHydrated(streamId);
+        bumpStreamArtifactRevision();
       }
       return {
         kind: 'partial',
@@ -230,7 +163,7 @@ export async function hydrateStreamArtifacts(
     return undefined;
   }
   establishWorkPlanReaderAuthority(streamId, ['plan', 'todos']);
-  markArtifactStreamHydrated(streamId);
+  bumpStreamArtifactRevision();
   return { kind: 'complete' };
 }
 

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -39,6 +39,7 @@ import {
   patchStream,
   registerCliStateResetHook,
   setTransientNotice,
+  streamPhaseFor,
   streams,
 } from './cliState';
 import { isChildStreamRemoved, streamMetadataFor } from './childExecutions';
@@ -276,7 +277,10 @@ export function syncStreamLog(
     currentActiveStreamId === undefined || currentActiveStreamId === streamId;
 
   const metadata = streamMetadataFor(streamId);
-  patchStream(streamId, (slice, lifecycle) => {
+  const streamSettled = isTranscriptSettlementPhase(
+    streamPhaseFor(streamId)?.phase,
+  );
+  patchStream(streamId, (slice) => {
     const workflowStream = metadata?.agentCategory === AgentCategory.Workflow;
     const fullLogChild = isFullLogChildStream(metadata?.identity);
     // Which line a workflow-agent stream reports as its live status is CLI
@@ -289,7 +293,6 @@ export function syncStreamLog(
     // no task-group renderer and whose verbatim log is the point of opening
     // it, so its headings stay transcript rows.
     const lifecycleToTaskGroups = workflowStream || !fullLogChild;
-    const streamSettled = isTranscriptSettlementPhase(lifecycle.status);
     const streamFinal = options.forceFinal === true || streamSettled;
     const state = slice.transcriptFold ?? createTranscriptFoldState();
     const flags = newFoldChangeFlags();
@@ -508,7 +511,9 @@ export function releaseInactiveStreamTranscript(
     return;
   }
   const slice = streams.get().get(streamId);
-  if (slice?.status === undefined || isActivePhase(slice.status)) return;
+  if (!slice) return;
+  const phase = streamPhaseFor(streamId)?.phase;
+  if (phase === undefined || isActivePhase(phase)) return;
   store.requestEviction(streamId);
   const fold = slice.transcriptFold;
   if (fold) {

--- a/packages/cli/src/chat/tui/terminalTitle.ts
+++ b/packages/cli/src/chat/tui/terminalTitle.ts
@@ -13,7 +13,12 @@ import { isActivePhase } from '@shared/streams/streamStatus';
 import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
 
 import { approvalQueueStatus } from './state/approvalQueue';
-import { rootRunPending, rootRunStreamId, streams } from './state/cliState';
+import {
+  rootRunPending,
+  rootRunStreamId,
+  streamPhaseFor,
+  streams,
+} from './state/cliState';
 import { chatTuiCanStopActiveRun } from './state/sessionRunState';
 import { terminalCapabilities } from './state/terminalCapabilities';
 
@@ -65,9 +70,11 @@ function currentTerminalTitleState(): SessionTitleState {
     chatTuiCanStopActiveRun({
       runPending: rootRunPending.get(),
       streamId: rootStreamId,
-      status: rootStreamId ? streamSlices.get(rootStreamId)?.status : undefined,
+      status: streamPhaseFor(rootStreamId)?.phase,
     }) ||
-    [...streamSlices.values()].some((stream) => isActivePhase(stream.status))
+    [...streamSlices.keys()].some((streamId) =>
+      isActivePhase(streamPhaseFor(streamId)?.phase),
+    )
   ) {
     return 'running';
   }

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -4,7 +4,11 @@ import path from 'node:path';
 // Local imports
 import { getAgent } from '@agent/index';
 import { RUN_FACT_EVENT_TYPES } from '@agent/trace';
-import type { AgentConfig, SessionHandle } from '@agent/runtime';
+import type {
+  AgentConfig,
+  SessionHandle,
+  StreamPhaseState,
+} from '@agent/runtime';
 import { SessionFactApplier } from '@controllers/session/SessionFactApplier';
 import type {
   PresentedStreamId,
@@ -98,23 +102,10 @@ export function createRunProgressRenderer(
   });
 }
 
-/**
- * Everything the live line needs that no shared record carries: the run's
- * `AgentConfig` never lands on `SessionState` (the summary mirror keeps only
- * model / working directory / command), so the agent name, the input-file
- * label and the workflow's declared round count are read from the fact and
- * held here. Round index, tool calls, child roster and child descriptions all
- * come from `SessionState` at paint time instead.
- */
-interface RootRunConfigState {
-  plannedRounds?: number;
-  agent?: string;
-  inputLabel?: string;
-}
-
 class DefaultRunProgressRenderer implements RunProgressRenderer {
-  private readonly config: RootRunConfigState = {};
-  private readonly startedAt: number;
+  /** Fallback elapsed origin for the window before the status machine opens a
+   *  run window (a live line painted off `run.config` alone). */
+  private readonly attachedAt: number;
   private readonly write: (text: string) => void;
   private readonly nowMs: () => number;
   private readonly minIntervalMs: number;
@@ -128,7 +119,6 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   private liveLine = false;
   private state: SessionState | undefined;
   private rootStreamId: StreamTabId | undefined;
-  private rootStreamStatus: StreamPhase | undefined;
   /**
    * Last-write-wins subject line for the root stream: a status transition
    * writes its label, a description fact replaces it with the run's own
@@ -137,11 +127,42 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
    * shared sources.
    */
   private rootPhaseText: string | undefined;
+  /**
+   * The phase `rootPhaseText` was last written for — the ordering companion of
+   * that field, not a second copy of the machine's state (terminal-ness and
+   * the run window are read from the machine). It exists because
+   * `StreamStatusMachine.transition` publishes on a substate-only change too:
+   * without it, a RUNNING/STARTING → RUNNING clear would look like a new
+   * transition and overwrite the run's own description.
+   */
+  private rootStreamPhase: StreamPhase | undefined;
   private heartbeatTimer: ReturnType<typeof setInterval> | undefined;
 
-  /** Derived from the one status field, never mirrored into a second flag. */
+  /** The root stream's lifecycle record, from the session status machine. */
+  private rootPhaseState(): StreamPhaseState | undefined {
+    return this.rootStreamId
+      ? this.state?.streamStatus.getStreamState(this.rootStreamId)
+      : undefined;
+  }
+
+  /** Read from the one status owner, never mirrored into a second flag. */
   private get rootStreamTerminal(): boolean {
-    return isTerminalOutcomePhase(this.rootStreamStatus);
+    return isTerminalOutcomePhase(this.rootPhaseState()?.phase);
+  }
+
+  /**
+   * The root run's `AgentConfig`, from the snapshot store's canonical run
+   * record. The store subscribes to the session hub in `SessionHandle`'s
+   * constructor — before any host attaches a renderer — so it has already
+   * accumulated the `run.config` this renderer is repainting for. `quiet`
+   * because a headless run paints from whatever has landed and must not
+   * emit an unseeded-read warning for a record it never preloads.
+   */
+  private rootRunConfig(): AgentConfig | undefined {
+    return this.rootStreamId
+      ? this.state?.snapshots.getRunMetadata(this.rootStreamId, { quiet: true })
+          .config
+      : undefined;
   }
 
   constructor(init: RunProgressRendererInit) {
@@ -153,7 +174,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     this.clearInterval = init.clearInterval ?? clearInterval;
     this.ansi = init.colorEnabled;
     this.getColumns = init.getColumns ?? (() => init.columns);
-    this.startedAt = this.nowMs();
+    this.attachedAt = this.nowMs();
   }
 
   attach(session: SessionHandle): () => void {
@@ -170,12 +191,14 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     );
     const detachRunFacts = session.events.subscribeRunFacts(
       (runFact) => {
-        // The run's `AgentConfig` is the one payload the shared state does not
-        // retain; take it before handing the fact to the applier.
-        if (runFact.event.type === 'run.config') {
-          this.applyRunConfig(runFact.event.streamId, runFact.event.config);
-        }
         applier.handleRunFact(runFact.streamId, runFact.event);
+        // The run config carries the live line's subject and its declared
+        // round count. The snapshot store subscribed to this hub in the
+        // session's constructor, so it has already accumulated the config by
+        // now: this claims the root slot and repaints, it copies nothing.
+        if (runFact.event.type === 'run.config') {
+          this.refreshFor(runFact.event.streamId, true);
+        }
       },
       { types: RUN_FACT_EVENT_TYPES },
     );
@@ -215,10 +238,17 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   }
 
   applyStatus(streamId: StreamTabId, status: StreamPhase | undefined): void {
-    if (status === undefined || !this.isRootStream(streamId)) return;
-    if (this.rootStreamStatus === status) return;
+    // The first stream to report a phase claims the root slot: a headless run
+    // renders one stream's line, and the status machine holds the phase this
+    // callback announces by the time it fires.
+    if (status === undefined || !this.claimRootStream(streamId)) return;
+    // Only a phase change takes the subject line back. A substate-only fact
+    // (STARTING/RESUMING cleared) is still a published `status`, and treating
+    // it as a transition would overwrite a description the run set for this
+    // same phase.
+    if (this.rootStreamPhase === status) return;
 
-    this.rootStreamStatus = status;
+    this.rootStreamPhase = status;
     this.rootPhaseText = formatStreamStatusLabel(status, { style: 'cli' });
     this.updateHeartbeat();
     this.render(true);
@@ -234,20 +264,6 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
       // A stream the live line does not name has nothing to repaint for.
       return;
     }
-    this.updateHeartbeat();
-    this.render(true);
-  }
-
-  private applyRunConfig(streamId: StreamTabId, config: AgentConfig): void {
-    if (!this.claimRootStream(streamId)) return;
-
-    this.config.agent = config.agent;
-    this.config.inputLabel = formatInputLabel(config.inputFiles);
-    this.config.plannedRounds =
-      config.agentCategory === AgentCategory.Workflow
-        ? getAgent(config.agent, AgentCategory.Workflow)?.rounds
-        : undefined;
-    this.rootPhaseText ??= 'running';
     this.updateHeartbeat();
     this.render(true);
   }
@@ -315,7 +331,12 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
       : undefined;
     const roundStage =
       execution?.stage?.kind === 'round' ? execution.stage : undefined;
-    const plannedRounds = roundStage?.total ?? this.config.plannedRounds;
+    const config = this.rootRunConfig();
+    const declaredRounds =
+      config?.agentCategory === AgentCategory.Workflow
+        ? getAgent(config.agent, AgentCategory.Workflow)?.rounds
+        : undefined;
+    const plannedRounds = roundStage?.total ?? declaredRounds;
 
     const parts: string[] = [];
     if (roundStage) {
@@ -327,7 +348,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
       );
     }
 
-    const subject = [this.config.agent, this.config.inputLabel]
+    const subject = [config?.agent, formatInputLabel(config?.inputFiles ?? [])]
       .filter(Boolean)
       .join(' ');
     const phase = this.rootPhaseText;
@@ -337,7 +358,11 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
       parts.push(`${plannedRounds} rounds`);
     }
 
-    const elapsed = formatElapsed(now - this.startedAt);
+    // Elapsed measures the run window the status machine opened — the same
+    // origin the TUI status bar and the progress board render from — falling
+    // back to attach time only before any run window exists.
+    const runStartedAt = this.rootPhaseState()?.runStartedAt ?? this.attachedAt;
+    const elapsed = formatElapsed(now - runStartedAt);
     const children = this.liveChildren();
     const describe = (child: ActiveChildInfo): string | undefined =>
       this.childDescription(child.childStreamId);

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -86,7 +86,19 @@ export class StreamStatusMachine {
   constructor(private readonly eventHub: SessionEventHub) {}
 
   get(stream: StreamTabId): StreamPhase | undefined {
-    return this.stateFor(stream)?.phase;
+    return this.getStreamState(stream)?.phase;
+  }
+
+  /**
+   * This stream's combined phase + substate + run-window start, including an
+   * in-flight reservation. The per-stream read every host renders from: the
+   * entry is written before the matching `status` fact is published, so a
+   * consumer reacting to that fact reads the phase the fact announced without
+   * mirroring it, and `getAllStreamStates()` stays for the whole-map cases.
+   */
+  getStreamState(stream: StreamTabId): StreamPhaseState | undefined {
+    const entry = this.streams.get(stream);
+    return entry ? effectiveState(entry) : undefined;
   }
 
   /** Opaque identity replaced whenever this stream's status entry changes. */
@@ -95,7 +107,7 @@ export class StreamStatusMachine {
   }
 
   getSubstate(stream: StreamTabId): StreamSubstate | undefined {
-    return this.stateFor(stream)?.substate;
+    return this.getStreamState(stream)?.substate;
   }
 
   tryAcquire(
@@ -318,11 +330,6 @@ export class StreamStatusMachine {
 
   isInFlight(stream: StreamTabId): boolean {
     return isInFlightPhase(this.get(stream));
-  }
-
-  private stateFor(stream: StreamTabId): StreamPhaseState | undefined {
-    const entry = this.streams.get(stream);
-    return entry ? effectiveState(entry) : undefined;
   }
 
   private publishStatus(

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -31,6 +31,11 @@ export {
 export { SessionEventHub } from './SessionEventHub';
 export type { SessionEvent, SessionFact } from './SessionEventHub';
 
+// StreamStatusMachine — the per-stream lifecycle record hosts render from
+// (`SessionState.streamStatus.getStreamState`). Type only: the machine itself
+// is reached through the session, never constructed by a host.
+export type { StreamPhaseState } from './StreamStatusService';
+
 // HostInteractions
 export {
   SessionHostInteractions,

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -25,7 +25,6 @@ import {
   resetCliState,
   rootRunStartAvailable,
   rootStreamId,
-  setStreamStatusInCliState,
   streams,
 } from '@cli/chat/tui/state/cliState';
 import {
@@ -44,6 +43,7 @@ import {
   type WorkflowCallProgress,
 } from '@shared/schemas';
 import type { TranscriptRowOf } from '@shared/transcript';
+import { setCliStreamPhase } from '@test/support/cliStreamStatus';
 import { textRowFixture } from '@test/support/transcriptRowFixtures';
 import {
   loadInk,
@@ -86,7 +86,7 @@ const CHORD_WINDOW_EXPIRED_MS = ESC_META_CHORD_INTERRUPT_DELAY_MS + 100;
 // layout assertions) exists only while it is set.
 function setRunning(...streamIds: StreamTabId[]): void {
   for (const streamId of streamIds) {
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId,
       status: STREAM_PHASE.RUNNING,
       runStartedAt: Date.now(),
@@ -196,7 +196,7 @@ function seedChildHierarchy(): void {
 
 function finishNestedHierarchyAndFocusRoot(): void {
   for (const streamId of [GRANDCHILD, CHILD]) {
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId,
       status: STREAM_PHASE.COMPLETED,
     });
@@ -659,7 +659,7 @@ describe('App foreground Escape ownership', () => {
     },
   ])('$name', async ({ childStatus }) => {
     seedChildHierarchy();
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: CHILD,
       status: childStatus,
     });
@@ -688,7 +688,7 @@ describe('App foreground Escape ownership', () => {
     'resolves deferred child back before %s',
     async (_name, arrowInput) => {
       seedChildHierarchy();
-      setStreamStatusInCliState({
+      setCliStreamPhase({
         streamId: CHILD,
         status: STREAM_PHASE.COMPLETED,
       });
@@ -1022,7 +1022,7 @@ describe('App foreground Escape ownership', () => {
     'keeps the composer enabled for a %s tool-use agent child',
     async (status) => {
       seedChildHierarchy();
-      setStreamStatusInCliState({ streamId: CHILD, status });
+      setCliStreamPhase({ streamId: CHILD, status });
       focusStream(CHILD);
       const onSubmit = vi.fn();
       const { instance, stdin } = await renderWithInterrupt({ onSubmit });
@@ -1182,7 +1182,7 @@ describe('App foreground Escape ownership', () => {
   it('returns keyboard ownership to prompt history after stopping the root', async () => {
     seedRootStream();
     const onInterruptStream = vi.fn((streamId: StreamTabId) => {
-      setStreamStatusInCliState({
+      setCliStreamPhase({
         streamId: streamId,
         status: STREAM_PHASE.CANCELLED,
       });

--- a/src/test-kernel/cli/ChildControls.vitest.ts
+++ b/src/test-kernel/cli/ChildControls.vitest.ts
@@ -13,7 +13,6 @@ import {
 import {
   STREAM_PHASE,
   type ActiveChildInfo,
-  type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
 import { buildChildRosters } from '@test/support/childRosters';
@@ -21,10 +20,6 @@ import { buildChildRosters } from '@test/support/childRosters';
 const root = 'root' as StreamTabId;
 const child = 'child' as StreamTabId;
 const leaf = 'leaf' as StreamTabId;
-
-function slice(overrides: Partial<StreamSlice> = {}): StreamSlice {
-  return { ...emptySlice(root), ...overrides };
-}
 
 /** A live agent roster row whose execution id follows its name. */
 function rosterChild(
@@ -42,14 +37,12 @@ function rosterChild(
   };
 }
 
+/** Slices for the given identities. These selectors read slice presence
+ *  only — lifecycle phase lives on the session status machine. */
 function streamMap(
-  ...entries: ReadonlyArray<readonly [StreamTabId, StreamPhase?]>
+  ...streamIds: readonly StreamTabId[]
 ): Map<StreamTabId, StreamSlice> {
-  return new Map(
-    entries.map(
-      ([streamId, status]) => [streamId, slice({ streamId, status })] as const,
-    ),
-  );
+  return new Map(streamIds.map((streamId) => [streamId, emptySlice(streamId)]));
 }
 
 describe('CLI child controls', () => {
@@ -72,7 +65,7 @@ describe('CLI child controls', () => {
         }),
       ],
     });
-    const streams = streamMap([root], [child, STREAM_PHASE.COMPLETED], [leaf]);
+    const streams = streamMap(root, child, leaf);
     const parentStream = new Map<StreamTabId, StreamTabId>([
       [child, root],
       [leaf, child],
@@ -102,11 +95,7 @@ describe('CLI child controls', () => {
         rows: [rosterChild('leaf', leaf)],
       }),
     ]);
-    const streams = streamMap(
-      [root],
-      [child, STREAM_PHASE.RUNNING],
-      [leaf, STREAM_PHASE.RUNNING],
-    );
+    const streams = streamMap(root, child, leaf);
     const parentStream = new Map<StreamTabId, StreamTabId>([
       [child, root],
       [leaf, child],
@@ -156,10 +145,7 @@ describe('CLI child controls', () => {
         rosterChild('e', e, { workflowPhase: 'Map' }),
       ],
     });
-    const streams = streamMap(
-      [root],
-      ...ids.map((id) => [id, STREAM_PHASE.RUNNING] as const),
-    );
+    const streams = streamMap(root, ...ids);
     const parentStream = new Map(
       ids.filter((id) => id !== b).map((id) => [id, root] as const),
     );
@@ -210,7 +196,7 @@ describe('CLI child controls', () => {
       parentStreamId: root,
       rows: [rosterChild('critic', child)],
     });
-    const streams = streamMap([root], [child, STREAM_PHASE.RUNNING]);
+    const streams = streamMap(root, child);
 
     expect(
       numericFocusTargetForActiveStream({

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -46,9 +46,9 @@ import {
   emptySlice,
   resetCliState,
   patchStream,
+  streamPhaseFor,
   streams,
   type StreamSlice,
-  setStreamStatusInCliState,
 } from '@cli/chat/tui/state/cliState';
 import {
   bindChildStreamState,
@@ -72,6 +72,7 @@ import {
 } from '@shared/schemas';
 import type { ToolRow, TranscriptRow } from '@shared/transcript';
 import { formatWorkflowPhaseHeading } from '@shared/copy/workflowCall';
+import { setCliStreamPhase } from '@test/support/cliStreamStatus';
 import {
   loadInk,
   renderOutputAtTerminalSize,
@@ -384,11 +385,8 @@ describe('CLI conversation transcript', () => {
   // syncStreamLog derives finalizeDeferred, otherwise the next run's
   // in-flight entries get finalized early and lose later chunks.
   it('clears a stale final status before the next run streams', () => {
-    // Twice: the first reset retires STREAM_ID from the previous test, and a
-    // retired identity cannot take a status.
     resetCliState();
-    resetCliState();
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: STREAM_ID,
       status: STREAM_PHASE.WAITING,
     });
@@ -401,7 +399,7 @@ describe('CLI conversation transcript', () => {
         'resume',
       );
 
-      expect(streams.get().get(STREAM_ID)?.status).toBe(STREAM_PHASE.RUNNING);
+      expect(streamPhaseFor(STREAM_ID)?.phase).toBe(STREAM_PHASE.RUNNING);
     } finally {
       dispose();
     }
@@ -725,12 +723,7 @@ describe('CLI conversation transcript', () => {
   it('keeps a live prompt out of static scrollback until a continuation exists', () => {
     const user = entry('u1', 'user', 'what is this repo about', true);
     const streams = new Map<StreamTabId, StreamSlice>([
-      [
-        STREAM_ID,
-        sliceWithEntries(STREAM_ID, [user], {
-          status: STREAM_PHASE.RUNNING,
-        }),
-      ],
+      [STREAM_ID, sliceWithEntries(STREAM_ID, [user])],
     ]);
 
     const split = splitTranscriptEntries([user], 0, STREAM_PHASE.RUNNING);
@@ -740,6 +733,7 @@ describe('CLI conversation transcript', () => {
     const items = buildStaticTranscriptItems({
       scrollbackStreamId: STREAM_ID,
       streams,
+      status: STREAM_PHASE.RUNNING,
       meta: SESSION_META,
     }).items;
     expect(items.map((item) => item.id)).toEqual(['session-header']);
@@ -749,12 +743,7 @@ describe('CLI conversation transcript', () => {
     const user = entry('u1', 'user', 'what is this repo about', true);
     const tool = toolEntry('t1', 'in_progress');
     const streams = new Map<StreamTabId, StreamSlice>([
-      [
-        STREAM_ID,
-        sliceWithEntries(STREAM_ID, [user, tool], {
-          status: STREAM_PHASE.RUNNING,
-        }),
-      ],
+      [STREAM_ID, sliceWithEntries(STREAM_ID, [user, tool])],
     ]);
 
     const split = splitTranscriptEntries([user, tool], 0, STREAM_PHASE.RUNNING);
@@ -764,6 +753,7 @@ describe('CLI conversation transcript', () => {
     const items = buildStaticTranscriptItems({
       scrollbackStreamId: STREAM_ID,
       streams,
+      status: STREAM_PHASE.RUNNING,
       meta: SESSION_META,
     }).items;
     expect(items.map((item) => item.id)).toEqual(['session-header', 'u1']);

--- a/src/test-kernel/cli/ResumeHint.vitest.ts
+++ b/src/test-kernel/cli/ResumeHint.vitest.ts
@@ -1,4 +1,8 @@
+import '@test/support/defaultSessionTestSetup';
+
 import { describe, expect, it } from 'vitest';
+
+import { defaultSession } from '@agent/runtime/SessionHandle';
 
 import {
   collectResumeUsage,
@@ -12,19 +16,31 @@ import {
 import { emptySlice, type StreamSlice } from '@cli/chat/tui/state/cliState';
 import {
   type ActiveChildInfo,
+  type ExecutionId,
   type StreamTabId,
   type TokenUsageStats,
 } from '@shared/schemas';
 import { buildChildRosters } from '@test/support/childRosters';
+import { snapshotFacts } from '@test/support/storeTestDrivers';
 
+/** A stream's view slice, with any `usage` accumulated on the snapshot store
+ *  instead — the resume summary sums the store's cumulative projection. */
 function makeSlice(
-  over: Partial<StreamSlice> & { streamId: string },
+  over: Partial<StreamSlice> & {
+    streamId: string;
+    readonly usage?: TokenUsageStats;
+  },
 ): StreamSlice {
-  return {
-    ...emptySlice(over.streamId as StreamTabId),
-    ...over,
-    streamId: over.streamId as StreamTabId,
-  };
+  const { usage, ...sliceOverrides } = over;
+  const streamId = over.streamId as StreamTabId;
+  if (usage) {
+    snapshotFacts(defaultSession().snapshots).addUsage(
+      streamId,
+      `${over.streamId}-usage` as ExecutionId,
+      usage,
+    );
+  }
+  return { ...emptySlice(streamId), ...sliceOverrides, streamId };
 }
 
 /** A finished roster row retained for display — the resume-target shape. */

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.ts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.ts
@@ -6,6 +6,7 @@ import type {
   RuntimePresentationEventPayloads,
 } from '@agent/runtime/runtimePresentationEvents';
 import type { SessionEvent } from '@agent/runtime/SessionEventHub';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { pickGlobalArgs } from '@cli/runtime/globalArgs';
 import {
   createRunProgressRenderer,
@@ -31,6 +32,7 @@ import {
 import { STREAM_TRANSITION_CAUSE } from '@shared/streams/streamStatus';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import { createTestSession } from '@test/support/sessionTestUtils';
+import { seedStreamStatusForTest } from '@test/support/streamStatusTestUtils';
 
 const mocks = vi.hoisted(() => ({
   getAgent: vi.fn(),
@@ -124,6 +126,7 @@ const RUNTIME_PRESENTATION_NDJSON_CASES = {
 type TestRunProgressRenderer = RunProgressRenderer & {
   emit(event: SessionEvent): void;
   detach(): void;
+  readonly session: SessionHandle;
 };
 
 function attached(renderer: RunProgressRenderer): TestRunProgressRenderer {
@@ -132,6 +135,7 @@ function attached(renderer: RunProgressRenderer): TestRunProgressRenderer {
   return Object.assign(renderer, {
     emit: (event: SessionEvent) => session.events.emit(event),
     detach,
+    session,
   });
 }
 
@@ -255,6 +259,13 @@ function handleStreamStatus(
   status: StreamPhase,
   previousStatus: StreamPhase = STREAM_PHASE.RUNNING,
 ): void {
+  // The status machine holds the phase before the fact is published, which is
+  // where the renderer reads it back from. No run window is stamped: elapsed
+  // then falls back to the renderer's injected clock, which is what these
+  // fixed-`now` cases assert on.
+  seedStreamStatusForTest(renderer.session.status, streamId as StreamTabId, {
+    phase: status,
+  });
   // Status reaches the renderer on the session-fact rail only.
   renderer.emit({
     scope: 'session',

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -37,7 +37,6 @@ import {
   patchStream,
   streams,
   transientNotice,
-  setStreamStatusInCliState,
 } from '@cli/chat/tui/state/cliState';
 import {
   bindChildStreamState,
@@ -67,7 +66,9 @@ import {
 } from '@shared/schemas';
 import type { TranscriptRow } from '@shared/transcript';
 import { RESEARCHER_ACCESS } from '@shared/copy/onboarding';
+import { setCliStreamPhase } from '@test/support/cliStreamStatus';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
+import { snapshotFacts } from '@test/support/storeTestDrivers';
 import * as memoryFileSystem from '@tools/memory/memoryFileSystem';
 import {
   StreamSnapshotPreloadError,
@@ -90,15 +91,19 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
+/** Bind a `SessionState` over the default session on first use: /status reads
+ *  child rosters, parent edges, and the stream's lifecycle phase through it. */
+function ensureBoundChildState(): SessionState {
+  childState ??= new SessionState(defaultSession());
+  bindChildStreamState(childState);
+  return childState;
+}
+
 function seedChildRoster(
   parentStreamId: StreamTabId,
   rows: readonly ActiveChildInfo[],
 ): void {
-  if (!childState) {
-    childState = new SessionState(defaultSession());
-    bindChildStreamState(childState);
-  }
-  const state = childState;
+  const state = ensureBoundChildState();
   state.streamLogs.ensureStream(parentStreamId);
   state.getOrCreateStreamState(parentStreamId, AgentCategory.ToolUse);
   state.updateStreamState(parentStreamId, (prev) => ({
@@ -944,7 +949,7 @@ describe('handleTuiSlashCommand', () => {
     session.streamId = streamId;
     session.executionId = 'exec-1' as ExecutionId;
     activeStreamId.set(streamId);
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId,
       status: STREAM_PHASE.WAITING,
     });
@@ -966,11 +971,11 @@ describe('handleTuiSlashCommand', () => {
     const rootStreamId = 'stream-root' as StreamTabId;
     const childStreamId = 'stream-child' as StreamTabId;
     activeStreamId.set(rootStreamId);
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: rootStreamId,
       status: STREAM_PHASE.WAITING,
     });
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: childStreamId,
       status: STREAM_PHASE.RUNNING,
     });
@@ -1005,20 +1010,20 @@ describe('handleTuiSlashCommand', () => {
     const waitingChildId = 'stream-child-waiting' as StreamTabId;
     activeStreamId.set(parentStreamId);
     for (const streamId of rootSiblingIds) {
-      setStreamStatusInCliState({
+      setCliStreamPhase({
         streamId,
         status: STREAM_PHASE.RUNNING,
       });
     }
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: parentStreamId,
       status: STREAM_PHASE.WAITING,
     });
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: runningChildId,
       status: STREAM_PHASE.RUNNING,
     });
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: waitingChildId,
       status: STREAM_PHASE.WAITING,
     });
@@ -1061,12 +1066,12 @@ describe('handleTuiSlashCommand', () => {
       'stream-child-2',
     ] as StreamTabId[];
     activeStreamId.set(rootStreamId);
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: rootStreamId,
       status: STREAM_PHASE.WAITING,
     });
     for (const [index, childStreamId] of childStreamIds.entries()) {
-      setStreamStatusInCliState({
+      setCliStreamPhase({
         streamId: childStreamId,
         status: index === 0 ? STREAM_PHASE.WAITING : STREAM_PHASE.COMPLETED,
       });
@@ -1098,7 +1103,7 @@ describe('handleTuiSlashCommand', () => {
     const siblingChildId = 'stream-sibling-child' as StreamTabId;
     activeStreamId.set(focusedChildId);
     for (const streamId of [focusedChildId, siblingChildId]) {
-      setStreamStatusInCliState({
+      setCliStreamPhase({
         streamId,
         status: STREAM_PHASE.RUNNING,
       });
@@ -1130,15 +1135,15 @@ describe('handleTuiSlashCommand', () => {
     const runningSiblingId = 'stream-running-sibling' as StreamTabId;
     const idleSiblingId = 'stream-idle-sibling' as StreamTabId;
     activeStreamId.set(focusedChildId);
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: focusedChildId,
       status: STREAM_PHASE.WAITING,
     });
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: runningSiblingId,
       status: STREAM_PHASE.RUNNING,
     });
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: idleSiblingId,
       status: STREAM_PHASE.WAITING,
     });
@@ -1178,7 +1183,7 @@ describe('handleTuiSlashCommand', () => {
     const grandchildId = 'stream-grandchild' as StreamTabId;
     activeStreamId.set(parentStreamId);
     for (const streamId of [parentStreamId, ...rootSiblingIds, grandchildId]) {
-      setStreamStatusInCliState({
+      setCliStreamPhase({
         streamId,
         status: STREAM_PHASE.RUNNING,
       });
@@ -1211,16 +1216,20 @@ describe('handleTuiSlashCommand', () => {
     const streamId = 'stream-access' as StreamTabId;
     activeStreamId.set(streamId);
     patchSessionMeta({ model: 'gpt55' });
-    patchStream(streamId, (slice) => ({
-      ...slice,
-      usage: {
+    ensureBoundChildState();
+    patchStream(streamId, (slice) => ({ ...slice }));
+    // The access route comes off the store's cumulative usage projection.
+    snapshotFacts(defaultSession().snapshots).addUsage(
+      streamId,
+      'stream-access-run' as ExecutionId,
+      {
         inputTokens: 1_000,
         outputTokens: 100,
         cost: 0,
         usageRoute: 'relay',
       },
-    }));
-    setStreamStatusInCliState({
+    );
+    setCliStreamPhase({
       streamId,
       status: STREAM_PHASE.WAITING,
     });
@@ -1257,7 +1266,7 @@ describe('handleTuiSlashCommand', () => {
     session.executionId = 'exec-ephemeral' as ExecutionId;
     activeStreamId.set(streamId);
     patchSessionMeta({ transcriptMode: 'ephemeral' });
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId,
       status: STREAM_PHASE.WAITING,
     });

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -13,7 +13,11 @@ import {
 } from '@cli/runtime/modelAccessRoute';
 import { KEY_HINT_SEPARATOR } from '@cli/tui/ui/KeyHints';
 import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
-import { STREAM_PHASE, STREAM_SUBSTATE } from '@shared/schemas';
+import {
+  STREAM_PHASE,
+  STREAM_SUBSTATE,
+  type StreamPhase,
+} from '@shared/schemas';
 
 // The bar renders the short access-route label.
 const INCLUDED_ACCESS_LABEL = shortCliModelAccessRoute('included');
@@ -1002,11 +1006,16 @@ describe('CLI StatusBar display model', () => {
   // `displaySlice` by identity so the live-ancestor fallback stays
   // distinguishable from a structurally equal slice.
   describe('statusBarStreamTarget', () => {
+    // Lifecycle phase is the session status machine's, not the slice's, so a
+    // fixture tags its intended phase here and the injected `phaseOf` answers
+    // from the same map the case already declares.
+    type PhasedSlice = StreamSlice & { readonly testPhase?: StreamPhase };
+
     function streamSlice(
       streamId: string,
-      status: StreamSlice['status'],
-    ): StreamSlice {
-      return { streamId, status } as StreamSlice;
+      testPhase: StreamPhase | undefined,
+    ): PhasedSlice {
+      return { streamId, testPhase } as PhasedSlice;
     }
 
     function streamMap(
@@ -1049,7 +1058,10 @@ describe('CLI StatusBar display model', () => {
 
     const cases: ReadonlyArray<{
       readonly name: string;
-      readonly input: Parameters<typeof statusBarStreamTarget>[0];
+      readonly input: Omit<
+        Parameters<typeof statusBarStreamTarget>[0],
+        'phaseOf'
+      >;
       readonly ctrlCAction: ReturnType<
         typeof statusBarStreamTarget
       >['ctrlCAction'];
@@ -1256,7 +1268,11 @@ describe('CLI StatusBar display model', () => {
     ];
 
     it.each(cases)('$name', ({ input, ...expected }) => {
-      const target = statusBarStreamTarget(input);
+      const target = statusBarStreamTarget({
+        ...input,
+        phaseOf: (streamId) =>
+          (input.streams.get(streamId) as PhasedSlice | undefined)?.testPhase,
+      });
 
       expect(target.ctrlCAction).toBe(expected.ctrlCAction);
       expect(target.displaySlice).toBe(expected.displaySlice);

--- a/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
+++ b/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
@@ -18,7 +18,6 @@ import {
   activeStreamId,
   patchStream,
   resetCliState,
-  setStreamStatusInCliState,
   streams,
   type StreamSlice,
 } from '@cli/chat/tui/state/cliState';
@@ -49,6 +48,7 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { transcriptText, type TranscriptRow } from '@shared/transcript';
+import { setCliStreamPhase } from '@test/support/cliStreamStatus';
 import {
   appendTranscriptEntry,
   appendTranscriptText,
@@ -445,7 +445,7 @@ describe('transcript fold vs from-scratch oracle', () => {
         configureStreams(config);
         activeStreamId.set(undefined);
         for (const streamId of MIRRORED) {
-          setStreamStatusInCliState({
+          setCliStreamPhase({
             streamId,
             status: STREAM_PHASE.RUNNING,
           });
@@ -460,14 +460,14 @@ describe('transcript fold vs from-scratch oracle', () => {
           const statusRoll = rng();
           if (statusRoll < 0.05) {
             for (const streamId of MIRRORED) {
-              setStreamStatusInCliState({
+              setCliStreamPhase({
                 streamId,
                 status: STREAM_PHASE.WAITING,
               });
             }
           } else if (statusRoll < 0.1) {
             for (const streamId of MIRRORED) {
-              setStreamStatusInCliState({
+              setCliStreamPhase({
                 streamId,
                 status: STREAM_PHASE.RUNNING,
               });
@@ -493,7 +493,7 @@ describe('transcript fold vs from-scratch oracle', () => {
       // dashboard selection. Status stays RUNNING so no release path fires.
       activeStreamId.set(OTHER_STREAM);
       for (const streamId of MIRRORED) {
-        setStreamStatusInCliState({ streamId, status: STREAM_PHASE.RUNNING });
+        setCliStreamPhase({ streamId, status: STREAM_PHASE.RUNNING });
       }
 
       for (let step = 0; step < 120; step += 1) {
@@ -596,7 +596,7 @@ describe('transcript fold vs from-scratch oracle', () => {
       configureStreams(CONFIGS[0]);
       activeStreamId.set(undefined);
       for (const streamId of MIRRORED) {
-        setStreamStatusInCliState({ streamId, status: STREAM_PHASE.RUNNING });
+        setCliStreamPhase({ streamId, status: STREAM_PHASE.RUNNING });
         appendTranscriptEntry(store, streamId, {
           id: 'u1',
           type: STREAM_LOG_ENTRY_TYPES.LOG,

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -53,12 +53,20 @@ import {
   AgentCategory,
   STREAM_PHASE,
   WORKFLOW_TASK_STATUS_LABEL,
+  type ExecutionId,
+  type StreamPhase,
   type StreamStage,
   type StreamTabId,
+  type TokenUsageStats,
   type WorkflowCallProgress,
 } from '@shared/schemas';
 import type { TranscriptRowOf } from '@shared/transcript';
 import { formatWorkflowPhaseHeading } from '@shared/copy/workflowCall';
+import { snapshotFacts } from '@test/support/storeTestDrivers';
+import {
+  clearAllStreamStatusesForTest,
+  seedStreamStatusForTest,
+} from '@test/support/streamStatusTestUtils';
 import { buildChildRosters } from '@test/support/childRosters';
 import {
   fileListRowFixture,
@@ -79,18 +87,43 @@ function session(id: string, active = false): StreamView {
   };
 }
 
-/** A workflow root as its own run emits it — see `workflowPhaseGrouping`. */
+/**
+ * A workflow root as its own run emits it — see `workflowPhaseGrouping`. The
+ * lifecycle phase (status machine) and cumulative usage (snapshot store) are
+ * seeded on the shared substrate beside the slice, which carries neither.
+ */
 function workflowAgentSlice(
   id: string,
-  overrides: Partial<StreamSlice>,
+  overrides: Partial<StreamSlice> & {
+    readonly status?: StreamPhase;
+    readonly runStartedAt?: number;
+    readonly usage?: TokenUsageStats;
+  },
 ): StreamSlice {
-  const grouping = workflowPhaseGrouping(overrides.entries ?? []);
+  const {
+    status = STREAM_PHASE.COMPLETED,
+    runStartedAt,
+    usage,
+    ...sliceOverrides
+  } = overrides;
+  const streamId = id as StreamTabId;
+  seedStreamStatusForTest(defaultSession().status, streamId, {
+    phase: status,
+    ...(runStartedAt !== undefined ? { runStartedAt } : {}),
+  });
+  if (usage) {
+    snapshotFacts(defaultSession().snapshots).addUsage(
+      streamId,
+      `${id}-usage` as ExecutionId,
+      usage,
+    );
+  }
+  const grouping = workflowPhaseGrouping(sliceOverrides.entries ?? []);
   return {
-    ...emptySlice(id as StreamTabId),
-    status: STREAM_PHASE.COMPLETED,
-    ...overrides,
+    ...emptySlice(streamId),
+    ...sliceOverrides,
     entries: grouping.entries,
-    ...(overrides.taskGroups ? {} : { taskGroups: grouping.taskGroups }),
+    ...(sliceOverrides.taskGroups ? {} : { taskGroups: grouping.taskGroups }),
   };
 }
 
@@ -105,6 +138,8 @@ beforeEach(() => {
 });
 afterEach(() => {
   unbindChildStreamState(sessionState);
+  streamsSignal.set(new Map());
+  clearAllStreamStatusesForTest(defaultSession().status);
 });
 
 function seedStream(
@@ -180,6 +215,17 @@ async function renderSubagentList(
   options: { readonly until?: (frame: string) => boolean } = {},
 ): Promise<string> {
   const { ink, React } = await loadInk();
+  // In production the list's `streams` prop is the signal itself, and the row
+  // renderers read lifecycle phase through `streamPhaseFor`, which paints only
+  // identities that signal holds. Publish the fixture's slices so a rendered
+  // row can reach its phase.
+  const published = new Map(props.streams ?? []);
+  for (const session of props.sessions ?? []) {
+    if (!published.has(session.id)) {
+      published.set(session.id, session.slice ?? emptySlice(session.id));
+    }
+  }
+  streamsSignal.set(published);
   return renderOutputAtTerminalSize(
     ink,
     React.createElement(SubagentList, props),
@@ -545,8 +591,7 @@ describe('CLI child list display model', () => {
   it('renders held media in the live pending pane behind an unfinished tool', async () => {
     const { ink, React } = await loadInk();
     const streamId = 'media-holder' as StreamTabId;
-    const slice: StreamSlice = {
-      ...emptySlice(streamId),
+    const slice: StreamSlice = workflowAgentSlice(streamId, {
       status: STREAM_PHASE.RUNNING,
       entries: [
         toolRowFixture('blocking-tool', {
@@ -563,7 +608,7 @@ describe('CLI child list display model', () => {
           },
         ]),
       ],
-    };
+    });
     activeStreamId.set(streamId);
     streamsSignal.set(new Map([[streamId, slice]]));
 
@@ -583,8 +628,7 @@ describe('CLI child list display model', () => {
   it('renders held workflow phases in the live pending pane behind an unfinished tool', async () => {
     const { ink, React } = await loadInk();
     const streamId = 'phase-holder' as StreamTabId;
-    const slice: StreamSlice = {
-      ...emptySlice(streamId),
+    const slice: StreamSlice = workflowAgentSlice(streamId, {
       status: STREAM_PHASE.RUNNING,
       entries: [
         toolRowFixture('blocking-tool', {
@@ -598,7 +642,7 @@ describe('CLI child list display model', () => {
           phaseTotal: 2,
         }),
       ],
-    };
+    });
     activeStreamId.set(streamId);
     streamsSignal.set(new Map([[streamId, slice]]));
 

--- a/src/test-kernel/cli/SubscribeStreamArtifacts.vitest.ts
+++ b/src/test-kernel/cli/SubscribeStreamArtifacts.vitest.ts
@@ -3,31 +3,33 @@ import '@test/support/defaultSessionTestSetup';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { resetCliState } from '@cli/chat/tui/state/cliState';
-import {
-  beginLoadedStreamsReconcile,
-  markArtifactStreamHydrated,
-  readStreamArtifacts,
-} from '@cli/chat/tui/state/subscribeStreamArtifacts';
-import type { StreamTabId } from '@shared/schemas';
+import { readStreamArtifacts } from '@cli/chat/tui/state/subscribeStreamArtifacts';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import { snapshotFacts } from '@test/support/storeTestDrivers';
 
-describe('stream artifact hydration reconciliation', () => {
+describe('stream artifact projection gating', () => {
   beforeEach(() => {
     resetCliState();
   });
 
-  it('drops evicted hydration before marking the retained set', () => {
+  it('projects exactly the streams the store still has provenance for', async () => {
+    const store = defaultSession().snapshots;
     const dropped = 'dropped@gpt#abc123def' as StreamTabId;
     const retained = 'retained@gpt#def456abc' as StreamTabId;
-    markArtifactStreamHydrated(dropped);
+    // A live write ahead of any seed establishes provenance on its own.
+    snapshotFacts(store).addUsage(dropped, 'dropped-run' as ExecutionId, {
+      inputTokens: 10,
+      outputTokens: 2,
+      cost: 0.1,
+    });
+    expect(readStreamArtifacts(dropped)).toBeDefined();
 
-    const reconciliation = beginLoadedStreamsReconcile([retained]);
-    reconciliation.dropStale();
-
-    expect(readStreamArtifacts(dropped)).toBeUndefined();
-    expect(readStreamArtifacts(retained)).toBeUndefined();
-
-    reconciliation.reconcile();
+    // `load` claims an authoritative stream set: it evicts every other record
+    // synchronously, so the gate turns off for `dropped` with no host-side
+    // hydration bookkeeping to reconcile.
+    await store.load([retained]);
 
     expect(readStreamArtifacts(dropped)).toBeUndefined();
     expect(readStreamArtifacts(retained)).toBeDefined();

--- a/src/test-kernel/cli/SubscribeStreamLogDispose.vitest.ts
+++ b/src/test-kernel/cli/SubscribeStreamLogDispose.vitest.ts
@@ -18,9 +18,14 @@ import {
 import {
   activeStreamId,
   resetCliState,
+  streamPhaseFor,
   streams,
-  setStreamStatusInCliState,
 } from '@cli/chat/tui/state/cliState';
+import {
+  bindChildStreamState,
+  unbindChildStreamState,
+} from '@cli/chat/tui/state/childExecutions';
+import { SessionState } from '@controllers/session/SessionState';
 import {
   LOG_LEVELS,
   MESSAGE_TYPES,
@@ -28,7 +33,9 @@ import {
   STREAM_PHASE,
   type StreamTabId,
 } from '@shared/schemas';
+import { setCliStreamPhase } from '@test/support/cliStreamStatus';
 import { appendTranscriptEntry } from '@test/support/storeTestDrivers';
+import { clearAllStreamStatusesForTest } from '@test/support/streamStatusTestUtils';
 import type { StreamLogStore } from '@transcript';
 
 const streamA = 'stream-a' as StreamTabId;
@@ -58,6 +65,10 @@ function appendUserMessage(
 }
 
 describe('subscribeStreamLog batching and dispose', () => {
+  // Transcript release reads the stream's phase off the session status
+  // machine, which reaches the CLI through the bound `SessionState`.
+  let sessionState: SessionState;
+
   beforeEach(async () => {
     // No separate default-store export to swap in anymore (#7694) —
     // `subscribeStreamLog(defaultSession())` reads the default session's own `transcripts`
@@ -67,10 +78,14 @@ describe('subscribeStreamLog batching and dispose', () => {
     // the second starts the lifetime with no retired identity.
     resetCliState();
     resetCliState();
+    clearAllStreamStatusesForTest(defaultSession().status);
+    sessionState = new SessionState(defaultSession());
+    bindChildStreamState(sessionState);
     vi.useFakeTimers();
   });
 
   afterEach(() => {
+    unbindChildStreamState(sessionState);
     vi.useRealTimers();
   });
 
@@ -125,7 +140,7 @@ describe('subscribeStreamLog batching and dispose', () => {
   it('releases a completed transcript whose focus load finishes late', async () => {
     const store = defaultSession().transcripts;
     appendUserMessage(store, streamA, 'a-1', 'loaded late');
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: streamA,
       status: STREAM_PHASE.COMPLETED,
     });
@@ -177,15 +192,15 @@ describe('subscribeStreamLog batching and dispose', () => {
     expect(streams.get().get(streamB)).toMatchObject({
       latestLine: 'starting',
       entries: [],
-      status: undefined,
     });
+    expect(streamPhaseFor(streamB)).toBeUndefined();
     expect(requestEviction).not.toHaveBeenCalledWith(streamB);
   });
 
   it('requests bounded residency for a hidden WAITING transcript', () => {
     const store = defaultSession().transcripts;
     appendUserMessage(store, streamB, 'b-1', 'waiting for retry');
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: streamB,
       status: STREAM_PHASE.WAITING,
     });
@@ -200,7 +215,7 @@ describe('subscribeStreamLog batching and dispose', () => {
   it('never releases the focused stream, nor anything while focus is unset', () => {
     const store = defaultSession().transcripts;
     appendUserMessage(store, streamA, 'a-1', 'done but focused');
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: streamA,
       status: STREAM_PHASE.COMPLETED,
     });
@@ -236,7 +251,7 @@ describe('subscribeStreamLog batching and dispose', () => {
     // eviction and must drop the projection state too, or it outlives the
     // store's own retention and keeps the whole transcript reachable
     // indefinitely.
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: streamB,
       status: STREAM_PHASE.COMPLETED,
     });

--- a/src/test-kernel/cli/TerminalCleanup.vitest.ts
+++ b/src/test-kernel/cli/TerminalCleanup.vitest.ts
@@ -1,6 +1,14 @@
+import '@test/support/defaultSessionTestSetup';
+
 import { writeSync } from 'node:fs';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { defaultSession } from '@agent/runtime/SessionHandle';
+import {
+  bindChildStreamState,
+  unbindChildStreamState,
+} from '@cli/chat/tui/state/childExecutions';
 
 import { terminalCapabilities } from '@cli/chat/tui/state/terminalCapabilities';
 import {
@@ -11,7 +19,6 @@ import {
   resetCliState,
   rootRunPending,
   rootRunStreamId,
-  setStreamStatusInCliState,
 } from '@cli/chat/tui/state/cliState';
 import {
   installTerminalRestoreOnExit,
@@ -22,7 +29,10 @@ import {
   installTerminalTitleUpdates,
   terminalTitleText,
 } from '@cli/chat/tui/terminalTitle';
+import { SessionState } from '@controllers/session/SessionState';
 import { STREAM_PHASE } from '@shared/schemas';
+import { clearAllStreamStatusesForTest } from '@test/support/streamStatusTestUtils';
+import { setCliStreamPhase } from '@test/support/cliStreamStatus';
 
 vi.mock('node:fs', async (importOriginal) => ({
   ...(await importOriginal()),
@@ -34,7 +44,18 @@ const NO_TERMINAL_CAPABILITIES = {
   oscColorReports: false,
 };
 
+// The title projects stream phases, which live on the session status machine
+// and reach the CLI through the bound `SessionState`.
+let sessionState: SessionState;
+
+beforeEach(() => {
+  sessionState = new SessionState(defaultSession());
+  bindChildStreamState(sessionState);
+});
+
 afterEach(() => {
+  unbindChildStreamState(sessionState);
+  clearAllStreamStatusesForTest(defaultSession().status);
   clearApprovals();
   resetCliState();
   vi.useRealTimers();
@@ -143,11 +164,11 @@ describe('installTerminalTitleUpdates', () => {
     const updates = installTerminalTitleUpdates('/work/coauthor');
     rootRunPending.set(true);
     rootRunStreamId.set('transition-root');
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: 'transition-root',
       status: STREAM_PHASE.WAITING,
     });
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: 'transition-child',
       status: STREAM_PHASE.RUNNING,
     });
@@ -162,7 +183,7 @@ describe('installTerminalTitleUpdates', () => {
     await flushTitleUpdate();
     expectLastTitle('⠋ {T}·coauthor');
 
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: 'transition-child',
       status: STREAM_PHASE.WAITING,
     });
@@ -176,7 +197,7 @@ describe('installTerminalTitleUpdates', () => {
     vi.setSystemTime(0);
     enableOscTitles();
     const updates = installTerminalTitleUpdates('/work/coauthor');
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: 'animated-root',
       status: STREAM_PHASE.RUNNING,
     });
@@ -207,7 +228,7 @@ describe('installTerminalTitleUpdates', () => {
 
     updates.resume();
     expectLastTitle('⠹ {T}·coauthor');
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: 'animated-root',
       status: STREAM_PHASE.WAITING,
     });
@@ -215,7 +236,7 @@ describe('installTerminalTitleUpdates', () => {
     expectLastTitle('{T}·coauthor');
     expectNoTitleWrites();
 
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: 'animated-root',
       status: STREAM_PHASE.RUNNING,
     });
@@ -231,12 +252,12 @@ describe('installTerminalTitleUpdates', () => {
     const off = vi.spyOn(process, 'off');
     const updates = installTerminalTitleUpdates('/work/coauthor');
     const exitListener = on.mock.calls.find(([event]) => event === 'exit')?.[1];
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: 'dedup-root',
       status: STREAM_PHASE.RUNNING,
     });
     await flushTitleUpdate();
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: 'dedup-child',
       status: STREAM_PHASE.RUNNING,
     });
@@ -256,7 +277,7 @@ describe('installTerminalTitleUpdates', () => {
     const exitListener = on.mock.calls.find(
       ([event]) => event === 'exit',
     )?.[1] as ((code: number) => void) | undefined;
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: 'exit-root',
       status: STREAM_PHASE.RUNNING,
     });
@@ -273,7 +294,7 @@ describe('installTerminalTitleUpdates', () => {
   it('shows the idle title while suspended and re-projects live state on resume', async () => {
     enableOscTitles();
     const updates = installTerminalTitleUpdates('/work/coauthor');
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: 'suspend-root',
       status: STREAM_PHASE.RUNNING,
     });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -23,7 +23,7 @@ import {
   resetCliState,
   patchStream,
   setTransientNotice,
-  setStreamStatusInCliState,
+  streamPhaseFor,
   streams,
   transientNotice,
 } from '@cli/chat/tui/state/cliState';
@@ -55,7 +55,7 @@ import { advanceSettledPrefixIndex } from '@cli/chat/tui/state/transcriptFold';
 import { transcriptViewportKey } from '@cli/chat/tui/state/transcriptViewportMode';
 import { attachSessionSignalsAdapter } from '@cli/chat/tui/state/sessionSignalsAdapter';
 import {
-  markArtifactStreamHydrated,
+  bumpStreamArtifactRevision,
   readStreamArtifacts,
   streamArtifactRevision,
 } from '@cli/chat/tui/state/subscribeStreamArtifacts';
@@ -111,6 +111,7 @@ import {
 } from '@shared/schemas';
 import { transcriptText, type TranscriptRow } from '@shared/transcript';
 import type { StreamTransitionCause } from '@shared/streams/streamStatus';
+import { setCliStreamPhase } from '@test/support/cliStreamStatus';
 import { clearAllStreamStatusesForTest } from '@test/support/streamStatusTestUtils';
 import {
   splitTranscriptEntries,
@@ -201,8 +202,17 @@ function runTrace(
 type TraceLogger = ReturnType<typeof runTrace>;
 
 /** Drive a stream to a phase through the production fact-application path. */
+/** The session whose status machine the CLI is currently bound to, while a
+ *  `withRunFacts` body runs against its own `SessionHandle`. */
+let boundFactSession: SessionHandle | undefined;
+
 function setStatus(streamId: StreamTabId, status: StreamPhase): void {
-  setStreamStatusInCliState({ streamId, status });
+  if (boundFactSession) {
+    setCliStreamPhase({ streamId, status, session: boundFactSession });
+    return;
+  }
+  ensureBoundSessionState();
+  setCliStreamPhase({ streamId, status });
 }
 
 /** Drive a status transition on `session`'s machine; the resulting status
@@ -433,15 +443,20 @@ function markToolUseAgent(hub: SessionEventHub, streamId: StreamTabId): void {
 // and write through its public API.
 let metadataState: SessionState | undefined;
 
+/** Bind a `SessionState` over the default session on first use, so the CLI's
+ *  shared reads (metadata, and the status machine `streamPhaseFor` consults)
+ *  resolve without an adapter attached. */
+function ensureBoundSessionState(): SessionState {
+  metadataState ??= new SessionState(defaultSession());
+  bindChildStreamState(metadataState);
+  return metadataState;
+}
+
 function seedStreamMetadata(
   streamId: StreamTabId,
   patch: Parameters<SessionState['updateStreamMetadata']>[1],
 ): void {
-  if (!metadataState) {
-    metadataState = new SessionState(defaultSession());
-    bindChildStreamState(metadataState);
-  }
-  metadataState.updateStreamMetadata(streamId, patch);
+  ensureBoundSessionState().updateStreamMetadata(streamId, patch);
   invalidateChildStreams();
 }
 
@@ -478,9 +493,11 @@ function withRunFacts(
     transcripts: StreamLogStore.ephemeral('TUI session signals test'),
   });
   const detach = attachSessionSignalsAdapter(session);
+  boundFactSession = session;
   try {
     body(hub, session);
   } finally {
+    boundFactSession = undefined;
     detach();
     snapshots.evictAll();
   }
@@ -670,7 +687,7 @@ describe('cliState stream, focus, and child-edge fields', () => {
       transitionStatus(session, child1, STREAM_PHASE.FAILED, 'restart-repair');
 
       expect(activeRows(root)).toEqual([]);
-      expect(streams.get().get(child1)?.status).toBe(STREAM_PHASE.FAILED);
+      expect(streamPhaseFor(child1)?.phase).toBe(STREAM_PHASE.FAILED);
       expect(visibleRows(root)).toMatchObject([
         {
           executionId: 'agent-1',
@@ -1653,7 +1670,7 @@ describe('CLI TUI row allocation', () => {
           agentCategory: fixture.category,
           creationTimestamp: 0,
         },
-        streams: streams.get(),
+        phaseOf: (streamId) => streamPhaseFor(streamId)?.phase,
       }),
     ).toEqual({ kind: fixture.expected, streamId: child1 });
   });
@@ -1688,7 +1705,7 @@ describe('CLI TUI row allocation', () => {
         activeStreamId: child1,
         parentStream: new Map([[child1, root]]),
         metadata: { creationTimestamp: 0, ...metadata },
-        streams: streams.get(),
+        phaseOf: (streamId) => streamPhaseFor(streamId)?.phase,
       }),
     ).toEqual({ kind: 'reject', streamId: child1 });
   });
@@ -1729,7 +1746,7 @@ describe('CLI TUI row allocation', () => {
       emitParentEdge(hub, child1, root);
 
       activeStreamId.set(child1);
-      expect(streams.get().get(child1)?.status).toBe(STREAM_PHASE.RUNNING);
+      expect(streamPhaseFor(child1)?.phase).toBe(STREAM_PHASE.RUNNING);
       expect(retainedRows(root)[0]?.status).toBe(STREAM_PHASE.RUNNING);
       expect(chatTuiFocusedChildFollowUpRoute()).toEqual({
         kind: 'accept',
@@ -1758,7 +1775,7 @@ describe('CLI TUI row allocation', () => {
       );
 
       activeStreamId.set(child1);
-      expect(streams.get().get(child1)?.status).toBe(STREAM_PHASE.CANCELLED);
+      expect(streamPhaseFor(child1)?.phase).toBe(STREAM_PHASE.CANCELLED);
       expect(retainedRows(root)[0]?.status).toBe(STREAM_PHASE.CANCELLED);
       expect(chatTuiFocusedChildFollowUpRoute()).toEqual({
         kind: 'reject',
@@ -2886,8 +2903,8 @@ describe('CLI transcript state', () => {
     expect(streams.get().get(child1)).toMatchObject({
       latestLine: 'The second lemma is valid.',
       entries: [],
-      status: STREAM_PHASE.WAITING,
     });
+    expect(streamPhaseFor(child1)?.phase).toBe(STREAM_PHASE.WAITING);
   });
 
   it('restores an exact dormant transcript when it is requested', () => {
@@ -3433,7 +3450,7 @@ describe('sessionSignalsAdapter run facts', () => {
           todos: previousTodos,
         },
       });
-      markArtifactStreamHydrated(streamId);
+      bumpStreamArtifactRevision();
       expect(readStreamArtifacts(streamId)?.todos).toEqual(previousTodos);
 
       // The event changes the canonical snapshot store and must clear the
@@ -3590,7 +3607,6 @@ describe('sessionSignalsAdapter run facts', () => {
 
       emitUsage(hub, root, storageKey, usage);
 
-      expect(streams.get().get(root)?.usage).toEqual(usage);
       // Cumulative usage is the snapshot store's per-run accumulator summed;
       // reasoningTokens is part of the one accumulated vocabulary.
       expect(
@@ -3837,7 +3853,6 @@ describe('sessionSignalsAdapter run facts', () => {
       emitUsage(hub, root, storageKey, firstUsage);
       emitUsage(hub, root, storageKey, secondUsage);
 
-      expect(streams.get().get(root)?.usage).toEqual(secondUsage);
       // Summed from the store's per-run map — the one accumulator, which
       // carries reasoningTokens — not a second running sum in the slice.
       expect(
@@ -3941,13 +3956,6 @@ describe('sessionSignalsAdapter run facts', () => {
         cacheCreationInputTokens: 7,
       });
 
-      expect(streams.get().get(root)?.usage).toEqual({
-        inputTokens: 40,
-        outputTokens: 10,
-        cost: 2,
-        cacheReadInputTokens: 5,
-        cacheCreationInputTokens: 7,
-      });
       expect(
         projectStreamArtifacts(session.snapshots, root).cumulativeUsage,
       ).toEqual({

--- a/src/test-kernel/cli/WorkflowRunDetails.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunDetails.vitest.ts
@@ -13,7 +13,6 @@ import {
   activeStreamId,
   patchStream,
   resetCliState,
-  setStreamStatusInCliState,
 } from '@cli/chat/tui/state/cliState';
 import { SessionState } from '@controllers/session/SessionState';
 import {
@@ -26,6 +25,7 @@ import {
   type StreamTabId,
   type TaskGroup,
 } from '@shared/schemas';
+import { setCliStreamPhase } from '@test/support/cliStreamStatus';
 import { loadInk } from '@test/support/inkTestHarness.ts';
 import {
   projectTaskGroupsFromStreamLog,
@@ -282,7 +282,7 @@ describe('selectWorkflowRunDetailLines', () => {
       // slice's `finalizedFrontier` still at 0.
       entries: [textRowFixture('live', 'log', 'live workflow log')],
     }));
-    setStreamStatusInCliState({
+    setCliStreamPhase({
       streamId: STREAM_ID,
       status: STREAM_PHASE.RUNNING,
     });

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
@@ -27,7 +27,6 @@ import {
   patchStream,
   resetCliState,
   streams,
-  setStreamStatusInCliState,
 } from '@cli/chat/tui/state/cliState';
 import {
   bindChildStreamState,
@@ -48,6 +47,7 @@ import {
 } from '@shared/schemas';
 import { transcriptText, type TranscriptRow } from '@shared/transcript';
 import { STREAM_TRANSITION_CAUSE } from '@shared/streams/streamStatus';
+import { setCliStreamPhase } from '@test/support/cliStreamStatus';
 import { clearAllStreamStatusesForTest } from '@test/support/streamStatusTestUtils';
 import { loadInk } from '@test/support/inkTestHarness.ts';
 import { splitTranscriptEntries } from '@test/support/transcriptRowFixtures';
@@ -174,7 +174,7 @@ function streamSlice() {
 }
 
 function setStatus(status: StreamPhase): void {
-  setStreamStatusInCliState({ streamId: STREAM_ID, status });
+  setCliStreamPhase({ streamId: STREAM_ID, status });
 }
 
 function streamEntries(): readonly TranscriptRow[] {

--- a/src/test-kernel/support/cliStreamStatus.ts
+++ b/src/test-kernel/support/cliStreamStatus.ts
@@ -1,0 +1,44 @@
+// Test-only lifecycle driver for the CLI TUI's stream view.
+//
+// The default session's `StreamStatusMachine` is the single owner of a
+// stream's phase, substate, and run window; CLI renderers read it through
+// `streamPhaseFor`, which refuses an identity this state lifetime has no
+// slice for. Suites that only need a stream to *be* in a phase drive both
+// here instead of restating that pairing at every call site — transition and
+// ordering coverage still belongs to the substrate suites and the
+// adapter-driven matrix in TuiStateAndFocus.vitest.ts.
+
+import {
+  defaultSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
+import { patchStream } from '@cli/chat/tui/state/cliState';
+import type { StreamPhase, StreamSubstate, StreamTabId } from '@shared/schemas';
+
+import { seedStreamStatusForTest } from './streamStatusTestUtils';
+
+/** Put one stream in a lifecycle phase and mint the view slice that makes it
+ *  paintable, the way an applied `status` fact does in production. */
+export function setCliStreamPhase(init: {
+  readonly streamId: StreamTabId;
+  readonly status: StreamPhase;
+  readonly substate?: StreamSubstate;
+  readonly runStartedAt?: number;
+  /** Session owning the machine the CLI reads. Defaults to the process
+   *  default session; a suite that attaches the signals adapter to a session
+   *  of its own must name that one. */
+  readonly session?: SessionHandle;
+}): void {
+  seedStreamStatusForTest(
+    (init.session ?? defaultSession()).status,
+    init.streamId,
+    {
+      phase: init.status,
+      ...(init.substate ? { substate: init.substate } : {}),
+      ...(init.runStartedAt !== undefined
+        ? { runStartedAt: init.runStartedAt }
+        : {}),
+    },
+  );
+  patchStream(init.streamId, (slice) => ({ ...slice }));
+}

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1443,6 +1443,25 @@ export class StreamSnapshotStore {
     });
   }
 
+  /**
+   * Whether this stream's accumulators answer from memory rather than from
+   * unread defaults: its disk provenance is established, or a live fact has
+   * already been eagerly applied ahead of any seed (the overlay this store
+   * replays after seeding). That is the disk-provenance condition
+   * {@link warnIfUnseeded} checks plus any live overlay, so it is the weaker
+   * of the two: an overlay-only record answers here but still emits
+   * unseeded-read warnings for the fields it holds no overlay for. Published
+   * so a caller can gate its reads on this bookkeeping instead of shadowing
+   * it with a hydration set of its own. A usage-only seed does not count: it
+   * leaves every round artifact unread.
+   */
+  hasProvenance(stream: StreamTabId): boolean {
+    const record = this.records.get(stream);
+    if (!record) return false;
+    if (record.diskState !== 'unknown') return true;
+    return Object.values(record.overlays).some((patch) => patch !== undefined);
+  }
+
   /** Streams with persisted sidecars under `streamData/`. */
   async listPersistedStreams(): Promise<StreamTabId[]> {
     return this.listStreamsUnder(STREAM_DATA_DIR);


### PR DESCRIPTION
"Same state, different rendering; no CLI-specific session state." Four places where the CLI kept a copy of a fact the shared substrate already owns now read the substrate. No new plane, bus, vocabulary, or subscribe surface; every item deletes the layer it replaces.

## What moved

**P1 — status triple → status machine.** `StreamSlice.status/substate/runStartedAt` mirrored `StreamStatusMachine`, which writes its entry *before* publishing the `status` fact (`StreamStatusService.ts` `transition`), and whose `StreamPhaseState.runStartedAt` is the single run-window stamper — it rides the wire (`BackendOwnedFieldsSchema.runStartedAt`) and the progress board already renders elapsed from it. The former private `stateFor` becomes the public per-stream read `getStreamState(stream)`, reached through `SessionState.streamStatus`; renderers call `streamPhaseFor`, a slice-gated read of it (`getAllStreamStates()` stays for the whole-map cases and allocates).

Deleted with it: `PatchableStreamSlice`, `StreamSlicePatch`, `patchStream`'s lifecycle re-spread, `streamSliceWithStatus`, `setStreamStatusInCliState`. The removed/retired refusal that writer enforced survives as `cliStreamAcceptsStatus`, checked by the adapter before it folds the log and releases residency. The adapter's sequencing is byte-for-byte unchanged: fold under the new status → release residency for a stream that just left its active phase → focus-return → applier.

**P2 — headless run config → snapshot store.** `RootRunConfigState`/`applyRunConfig` copied `run.config` into three fields. `StreamSnapshotStore` already retains the whole `AgentConfig` and serves it from `getRunMetadata(stream, { quiet: true })`; `plannedRounds` is `getAgent(config.agent, Workflow)?.rounds`, a registry lookup, not a fact. **Precondition verified:** the store calls `attachSessionEvents(events)` in `SessionHandle`'s constructor, and `SessionEventHub` dispatches subscribers in insertion order, so the store has accumulated the config before the headless renderer's own run-fact callback runs. `rootStreamStatus` → the machine; the run-config repaint stays (it is the live line's subject), it just copies nothing now.

**P3 — latest-usage gauge → cumulative projection.** `StreamSlice.usage` and the `onRunUsageChanged` patch are gone; readers project `StreamArtifactProjection.cumulativeUsage`. `streamPreferredUsage` was a two-source precedence rule with one source left, so it is inlined at its three call sites.

**P4 — store provenance query.** `hydratedArtifactStreams` / `beginLoadedStreamsReconcile` / `markArtifactStreamHydrated` shadowed a fact `StreamSnapshotStore` held privately (`hasDiskProvenance` + the eager-apply overlays). The store publishes it as `hasProvenance(stream)`. **Precondition verified:** `load` calls `evictStreamsExcept` synchronously before its async seed and `evict` drops the whole record, so an evicted stream reports no provenance by construction — that *is* `dropStale`/`reconcile`. The CLI keeps only the revision bump (`bumpStreamArtifactRevision`, promoted from private).

**Deliberately left:** P6, the `StreamSlice.bypass` mirror (−8). It is stream-scoped host permission state with a writer of its own; folding it needs the approval-plane ruling this PR does not ask for.

## Declared behavior changes

- **Headless elapsed origin.** The live line's elapsed now measures the status machine's run window (opening at RUNNING, the same origin the TUI status bar and the progress board use), falling back to renderer attach time only before any window exists. Previously it always ran from attach time.
- **Status-bar token fallback.** Before a stream's first `context.state`, the usage segment shows the store's cumulative input tokens rather than the last call's. After it, the gauge is unchanged (`contextState` owns window/used/utilization).
- **`/status` access route** reads the cumulative projection's `usageRoute` (`sumUsageStats` carries it when unmixed) instead of the last call's.

## Ratchet rider

`config/ratchets/store-public-surface-baseline.json`: `StreamSnapshotStore` **+1 unit** (`hasProvenance`), 22 → 23. Accounting: it converts one caller-visible contract *from* an 86-line host-side shadow of the store's private bookkeeping *into* one honest query on the owner — the surface grows by one method and the CLI loses a set, three functions, and the eviction-reconcile protocol built on top of them. `host-agent-import-baseline` does **not** move: `StreamPhaseState` is re-exported from the `@agent/runtime` barrel the CLI already imports, so no new deep-import specifier appears.

## Net elements (R6)

**Deleted — 18.** Slice fields `status`, `substate`, `runStartedAt`, `usage` (4). Types `PatchableStreamSlice`, `StreamSlicePatch`, `RootRunConfigState` (3). Functions `streamSliceWithStatus`, `setStreamStatusInCliState`, `applyRunConfig`, `beginLoadedStreamsReconcile`, `markArtifactStreamHydrated`, `streamPreferredUsage` (6). State `DefaultRunProgressRenderer.config`, `hydratedArtifactStreams` (2). Parameters/props `workflowTaskMetadata(child)`, `WorkflowTaskRow.child`, `focusedChildFollowUpRoute({ streams })` (3).

**Added — 12.** Functions `sessionStreamPhase`, `streamPhaseFor`, `cliStreamAcceptsStatus`, `StreamSnapshotStore.hasProvenance` (4). Private methods `rootPhaseState`, `rootRunConfig` (2). One type re-export, `StreamPhaseState` from `@agent/runtime` (1). Parameters `statusBarStreamTarget({ phaseOf })`, `focusedChildFollowUpRoute({ phaseOf })`, and the `status` option on the three static-transcript builders (5).

**Renames/visibility, counted as zero:** `stateFor` → public `getStreamState`; `startedAt` → `attachedAt`; `rootStreamStatus` → `rootStreamPhase` (kept, but narrowed: it is now only the ordering companion of `rootPhaseText`, since `StreamStatusMachine.transition` publishes on substate-only changes and a description must survive one — terminal-ness and the run window read the machine); `bumpStreamArtifactRevision` private → exported.

**Net: −6 elements.** LOC: production `23 files, +315 −385` (**−70**). `cliState.ts` 811 → 732, `subscribeStreamArtifacts.ts` 275 → 208, `sessionSignalsAdapter.ts` 276 → 262; `runProgressRenderer.ts` 518 → 533 (**+15**, and honestly: the copied state and its writer are gone, but the two reads that replace them carry the ordering and subscriber-order arguments in comments). Tests/harness `+394 −231`, all of it the mechanical status-driver migration plus one new 44-line test-support file. No new production file.

## Consumer counts (R8)

| symbol | before | after |
| --- | --- | --- |
| `StreamSlice.status` / `.substate` / `.runStartedAt` / `.usage` | 35 read sites in `packages/cli/src`, 6 in `packages/cli/scripts` | 0 — fields deleted |
| `streamPhaseFor` (new) | — | 21 call sites across 12 files |
| `readStreamArtifacts(…)?.cumulativeUsage` | 1 (inside `streamPreferredUsage`) | 5 direct call sites |
| `setStreamStatusInCliState` | 1 production caller (`sessionSignalsAdapter`), 9 harness/validator refs, 54 refs across 9 suites in `src/test-kernel` | 0 — deleted |
| `setCliStreamPhase` (test support, new) | — | 56 refs across the same 9 suites, replacing that writer one-for-one |
| `StreamStatusMachine.getStreamState` | 0 (private `stateFor`, 2 internal callers) | 2 external (`sessionStreamPhase`, `rootPhaseState`) + the same 2 internal |
| `StreamSnapshotStore.hasProvenance` | — | 1 (`readStreamArtifacts`) |
| `bumpStreamArtifactRevision` | 3 (private) | 8 production call sites |
| `markArtifactStreamHydrated` | 5 | 0 — folded into the bump |
| `beginLoadedStreamsReconcile` | 1 | 0 — the store's eviction is the reconcile |
| `streamPreferredUsage` | 3 | 0 — inlined |

## Tests

Zero net new tests. `SubscribeStreamArtifacts.vitest.ts`'s single case is rewritten one-for-one to the new boundary (it drove the deleted bookkeeping; it now drives a real `load` and asserts the store's provenance gate). Everything else is migration: 9 suites drive `setCliStreamPhase` — one test-support helper for the "seed the machine, mint the slice" pairing that appeared 56 times — and the fixtures that carried a `usage` literal on a slice now emit the `usage` run fact the store accumulates. Two suites that had no bound `SessionState` now bind one, because a phase read has to reach the machine.

## Record

`docs/proposals/2026-08-15-single-substrate-hosts-as-renderers.md` §3/§4 status lines and §8 are reconciled: `contextState` and `runStartedAt` **landed**; `thinkingActive` **withdrawn** (fold output, no fact-rail producer, one consumer — the `compactingActive` ruling applies verbatim); root-run stream identity **closed as presentation state** (the CLI's claim precedes stream existence, and `executions.getHandle(id).streamId` already answers the live query); run input files + `plannedRounds` **closed** (the store already carried them). Two new §8 fence rows: the Lit log-rail fold of `contextState` (`LitSessionRenderer.ts:197-201` drops the invalidation on purpose — Lit restores that snapshot from the transcript rail, which also repopulates a reopened stream, and two writers for one footer would be worse), and durable-rail vs ephemeral-rail facts.

**Rebased onto `d2d5c202df` (#11545, transcript plane), then onto `1b94d7f6a1` (#11548, transcript render seams).** Three textual conflicts across the two rebases, all one-for-one merges: `SubagentListDisplay.vitest.ts`'s `workflowAgentSlice` (keep #11545's `workflowPhaseGrouping` derivation *and* this PR's substrate seeding, in that order); `ConversationPane.tsx` (keep #11548's `pendingTranscriptEntries` call shape, apply this PR's `streamPhaseFor` status argument); one import block in `ConversationTranscript.vitest.ts`. Everything else merged cleanly.

**Harness fixtures drive the machine directly.** `packages/cli/scripts/tui-harness.tsx` used to write the slice mirror for display fixtures. It now calls `seedStreamStatusForTest` (the kernel suites' helper) through a local `seedHarnessStreamPhase`: it writes the machine the way a real transition does *before* it publishes, but emits no fact. Two reasons it cannot use a production transition: `StreamStatusMachine` stamps its own `Date.now()` run window and no fact lets a caller supply one, so a scenario like `single-run-liveness` could not show a backdated elapsed; and a published status makes the adapter re-fold the stream from a log that has none of the fixture's synthetic rows, which is what dropped the child description in `subagent-list-focus-full-frame`. Fixtures that exercise the fact pipeline itself (`runChildEventOrderFixture`, the interrupt paths) keep the real transitions.

## Verified

- `npx prettier --check` on every changed file — clean.
- `CI=true npm run typecheck` — 0 errors.
- `npm run lint` — clean.
- `CI=true npm run check:dead-code-ratchet` — `379 combined vs 379 baselined`, no new findings.
- `FORCE_COLOR=0 npx vitest run src/test-kernel/cli src/test-kernel/agent/runtime src/test-kernel/transcript src/test-kernel/controllers src/test-kernel/architecture` — `235 files passed, 3608 passed | 1 skipped`.
- Also ran `src/test-kernel/{desktop,extension,agent,tools}` (the status machine is cross-host): `348 passed | 1 skipped`, one unrelated vitest worker-exit flake.
- `validate:tui` over the 17 scenarios the `build artifacts (linux)` job runs: `validate-tui: all 17 scenario(s) passed`. The two full-suite scenarios that fail locally (`focused-stopped-subagent-tab-focus`, `focused-stopped-subagent-submit`) fail **identically on an untouched `origin/main` build** in a side worktree, and neither is in the CI set.

## Note for the child-elapsed fix

`SubagentList.tsx` rows read elapsed from `streamPhaseFor(streamId)?.runStartedAt` (`cliState.ts`), which is the machine's run window for a stream the CLI holds a slice for. For a roster row whose child stream has no slice yet, the shared read path is the roster row itself: `visibleSubagentRows(parentId, childRosters)` → `ActiveChildInfo.startedAt` (`streamState.ts`), written by the applier. Both are substrate reads; neither needs a new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pZUVQRHJvb8tVCu8nU7TC
