### PR TITLE
refactor(cli): drop the duplicated run-start signal and test pass-throughs; own the denial-path inquiry write

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -557,18 +557,6 @@
       "file": "packages/cli/src/chat/tui/state/subscribeStreamLog.ts",
       "category": "production-dead",
       "kind": "exports",
-      "name": "invalidateTranscriptFoldForTest"
-    },
-    {
-      "file": "packages/cli/src/chat/tui/state/subscribeStreamLog.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "streamRenderCacheSizesForTest"
-    },
-    {
-      "file": "packages/cli/src/chat/tui/state/subscribeStreamLog.ts",
-      "category": "production-dead",
-      "kind": "exports",
       "name": "transcriptFoldCountersForTest"
     },
     {

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -102,7 +102,6 @@ import {
 import {
   activeStreamId as activeStreamIdSignal,
   rootRunPending,
-  rootRunStartAvailable,
   rootRunStreamId,
   rootStreamId,
   resetCliState,
@@ -2438,7 +2437,6 @@ registerBuiltinSlashCommands({
     );
   },
 });
-rootRunStartAvailable.set(CAN_SELECT_AGENT);
 // Mirror the real publisher's run facts: an interruptible harness run is a
 // pending root-run claim on the harness stream, so the status bar derives
 // the Ctrl-C stop hint from these signals exactly as `texra chat` does.

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -271,7 +271,6 @@ const AGENT_PROPOSAL_INSTRUCTION =
     '6. Include a short independent enumeration so the orchestrator can compare results.',
   ].join('\n');
 const CAN_DELEGATE = process.env.HARNESS_CAN_DELEGATE === '1';
-const CAN_SELECT_AGENT = process.env.HARNESS_CAN_SELECT_AGENT === '1';
 const CAN_SELECT_MODEL = process.env.HARNESS_CAN_SELECT_MODEL === '1';
 const DISABLED_MODEL_SWITCHES = new Set(
   parseList(process.env.HARNESS_DISABLED_MODEL_SWITCHES),
@@ -2393,7 +2392,9 @@ function handleHarnessSlashCommand(line: string): boolean {
 }
 
 registerBuiltinSlashCommands({
-  canSelectAgent: () => CAN_SELECT_AGENT,
+  // Mirror `texra chat`: agent selection is open exactly while no root run
+  // is pending, the same fact the status bar's `/agent` hint derives from.
+  canSelectAgent: () => !rootRunPending.get(),
   canSelectModel: () => CAN_SELECT_MODEL,
   getModelSwitchDisabledReason: getHarnessModelSwitchDisabledReason,
   getApprovalPolicy: () => harnessRuntimeSession.approvalPolicy,

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -66,7 +66,6 @@ import {
 import {
   activeStreamId as activeStreamIdSignal,
   focusStream,
-  rootRunStartAvailable as rootRunStartAvailableSignal,
   rootStreamId as rootStreamIdSignal,
   activeForm as activeFormSignal,
   closeInfoPane,
@@ -177,7 +176,6 @@ export function App(props: AppProps): React.JSX.Element {
   const foregroundReader = useSignal(foregroundReaderSignal);
   const slashPaletteOpen = useSignal(slashPaletteOpenSignal);
   const reverseSearchOpen = useSignal(reverseSearchOpenSignal);
-  const rootRunStartAvailable = useSignal(rootRunStartAvailableSignal);
   // Render reads shared stream metadata through `streamMetadataFor`; the
   // revision signal re-renders on metadata changes the roster signal misses.
   useSignal(sessionStateRevision);
@@ -802,7 +800,6 @@ export function App(props: AppProps): React.JSX.Element {
               keyboardActive={!childListFocused}
             />
             <StatusBar
-              agentSelectionAvailable={rootRunStartAvailable}
               chatInputAvailable={!childInputHidden}
               commandName={props.commandName}
               foregroundEscapeAction={foregroundEscapeAction({

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -56,7 +56,6 @@ import {
 const CODEX_SUBSCRIPTION_REFRESH_MS = 10_000;
 const SUBSCRIPTION_QUOTA_REFRESH_MS = 30_000;
 interface StatusBarProps {
-  readonly agentSelectionAvailable?: boolean;
   /** True when the focused stream has a composer for slash commands and text. */
   readonly chatInputAvailable: boolean;
   readonly childListFocused?: boolean;
@@ -337,7 +336,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
         props.childListSelectionWorkflowControllable,
     },
     shortcuts: {
-      agentSelectionAvailable: props.agentSelectionAvailable,
+      agentSelectionAvailable: !rootRunPending,
       chatInputAvailable: props.chatInputAvailable,
       childNavigationAvailable: props.childNavigationAvailable,
       parentNavigationAvailable:

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -334,8 +334,6 @@ export function focusStream(
 
 /** The top-level stream the current session rooted at. */
 export const rootStreamId = signal<StreamTabId | undefined>(undefined);
-/** Whether starting a new root run is currently available. */
-export const rootRunStartAvailable = signal<boolean>(true);
 /** Whether the root session holds an unfinished run claim (run promise
  *  pending). Published only by `TuiSession`, so renders read the session
  *  run-state reactively instead of calling impure session closures that
@@ -718,7 +716,6 @@ export function resetCliState(
   activeStreamId.set(undefined);
   rootStreamId.set(undefined);
   streams.set(new Map());
-  rootRunStartAvailable.set(true);
   rootRunPending.set(false);
   rootRunStreamId.set(undefined);
   activeForm.set(undefined);

--- a/packages/cli/src/chat/tui/state/sessionRunState.ts
+++ b/packages/cli/src/chat/tui/state/sessionRunState.ts
@@ -7,11 +7,7 @@ import {
 } from '@shared/schemas';
 import { isActivePhase } from '@shared/streams/streamStatus';
 
-import {
-  rootRunPending,
-  rootRunStartAvailable,
-  rootRunStreamId,
-} from './cliState';
+import { rootRunPending, rootRunStreamId } from './cliState';
 
 /**
  * Root-run state of one chat TUI session.
@@ -114,7 +110,6 @@ export class TuiSession {
    */
   private publish(): void {
     const runPending = chatTuiRunPending(this);
-    rootRunStartAvailable.set(!runPending);
     rootRunPending.set(runPending);
     rootRunStreamId.set(this._streamId);
   }
@@ -144,7 +139,7 @@ export function chatTuiCanInterruptActiveRun(
  * and the StatusBar derives it from the `rootRunPending`/`rootRunStreamId`
  * signals so the Ctrl-C hint recomputes reactively during renders.
  */
-export interface ChatTuiRunStopFacts {
+interface ChatTuiRunStopFacts {
   readonly runPending: boolean;
   readonly streamId: StreamTabId | undefined;
   readonly status: StreamPhase | undefined;
@@ -193,7 +188,7 @@ export function chatTuiCanSelectModel(input: {
   );
 }
 
-export type ChatTuiSigintAction =
+type ChatTuiSigintAction =
   'clean-exit' | 'force-exit' | 'preserve-exit' | 'interrupt-and-arm-exit';
 
 export function chatTuiSigintAction(input: {

--- a/packages/cli/src/chat/tui/state/streamViews.ts
+++ b/packages/cli/src/chat/tui/state/streamViews.ts
@@ -31,7 +31,7 @@ export interface StreamView {
   readonly active: boolean;
 }
 
-export type ActiveStreamScope =
+type ActiveStreamScope =
   | { readonly kind: 'none' }
   | { readonly kind: 'root'; readonly streamId: StreamTabId }
   | {
@@ -40,12 +40,12 @@ export type ActiveStreamScope =
       readonly streamId: StreamTabId;
     };
 
-export interface ActiveStreamAncestor<T> {
+interface ActiveStreamAncestor<T> {
   readonly streamId: StreamTabId;
   readonly value: T;
 }
 
-export interface ActiveStreamTreeEntry {
+interface ActiveStreamTreeEntry {
   readonly id: StreamTabId;
   readonly shortcutIndex?: number;
 }

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -98,31 +98,6 @@ export function transcriptFoldCountersForTest(): {
   };
 }
 
-/** Test-only: drop a stream's fold state so the next sync rebuilds from
- *  scratch — the production resync path, used as the equivalence oracle. */
-export function invalidateTranscriptFoldForTest(streamId: StreamTabId): void {
-  const fold = streams.get().get(streamId)?.transcriptFold;
-  if (fold) resetTranscriptFoldState(fold);
-}
-
-/** Test-only: per-stream projection-state occupancy, for eviction-path regression coverage. */
-export function streamRenderCacheSizesForTest(): {
-  readonly taskGroups: number;
-  readonly compaction: number;
-  readonly render: number;
-} {
-  let taskGroups = 0;
-  let compaction = 0;
-  let render = 0;
-  for (const slice of streams.get().values()) {
-    const fold = slice.transcriptFold;
-    if (fold?.taskGroupProjection) taskGroups += 1;
-    if (fold?.compactionProjection) compaction += 1;
-    if (fold?.hydrated) render += 1;
-  }
-  return { taskGroups, compaction, render };
-}
-
 // ---------------------------------------------------------------------------
 // Subscription + sync entry points
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/runtime/approval/settleApprovals.ts
+++ b/packages/cli/src/runtime/approval/settleApprovals.ts
@@ -8,6 +8,7 @@
  */
 
 import { defaultSession } from '@agent/runtime';
+import { warn as logWarning } from '@logger/logUtils';
 import {
   decideHumanInputRequest,
   decideRetryApproval,
@@ -25,6 +26,7 @@ import {
   type RetryPermission,
 } from '@shared/schemas';
 import { handleExternalInquiryAction } from '@tools/inquiry/inquiryActions';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { type CliContext } from '../cliContext';
 
@@ -151,10 +153,18 @@ export function denyExternalInquiryIfNoHumanInput(
 ): boolean {
   const denial = settleHumanInputDenial(context, EXTERNAL_INQUIRY_YOLO_MESSAGE);
   if (denial == null) return false;
-  void handleExternalInquiryAction({
+  // Persisting the drop writes the inquiry thread; nothing else owns this
+  // promise, so its rejection is logged here instead of surfacing as an
+  // unhandled rejection.
+  handleExternalInquiryAction({
     action: 'drop',
     threadId,
     reason: denial.reason,
+  }).catch((error: unknown) => {
+    logWarning(
+      'cli.approval',
+      `External inquiry ${threadId} drop failed: ${toErrorMessage(error)}`,
+    );
   });
   return true;
 }

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -23,7 +23,7 @@ import {
   openInfoPane,
   patchStream,
   resetCliState,
-  rootRunStartAvailable,
+  rootRunPending,
   rootStreamId,
   streams,
 } from '@cli/chat/tui/state/cliState';
@@ -175,7 +175,7 @@ function seedParentEdge(
 
 function seedRootStream(): void {
   rootStreamId.set(ROOT);
-  rootRunStartAvailable.set(false);
+  rootRunPending.set(true);
   setRunning(ROOT);
   focusStream(ROOT);
 }
@@ -1186,7 +1186,7 @@ describe('App foreground Escape ownership', () => {
         streamId: streamId,
         status: STREAM_PHASE.CANCELLED,
       });
-      rootRunStartAvailable.set(true);
+      rootRunPending.set(false);
     });
     const { instance, stdin, stdout } = await renderApp({
       ...appProps(onInterruptStream),

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.ts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.ts
@@ -3,7 +3,7 @@ import '@test/support/defaultSessionTestSetup';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const handleExternalInquiryActionMock = vi.hoisted(() => vi.fn());
+const handleExternalInquiryActionMock = vi.hoisted(() => vi.fn(async () => {}));
 const formatRetryRequestMessageMock = vi.hoisted(() => vi.fn());
 let detachHostInteractions = (): void => {};
 

--- a/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
+++ b/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
@@ -31,11 +31,11 @@ import {
   unbindChildStreamState,
 } from '@cli/chat/tui/state/childExecutions';
 import {
-  invalidateTranscriptFoldForTest,
   subscribeStreamLog,
   syncStreamLog,
   transcriptFoldCountersForTest,
 } from '@cli/chat/tui/state/subscribeStreamLog';
+import { resetTranscriptFoldState } from '@cli/chat/tui/state/transcriptFold';
 import { SessionState } from '@controllers/session/SessionState';
 import {
   AgentCategory,
@@ -383,7 +383,10 @@ function syncBothAndCompare(
   const active = activeStreamId.get();
   syncStreamLog(defaultSession(), FOLD_STREAM, options);
   activeStreamId.set(active);
-  invalidateTranscriptFoldForTest(ORACLE_STREAM);
+  // Drop the oracle's fold state so its next sync rebuilds from scratch —
+  // the production resync path, used as the equivalence oracle.
+  const oracleFold = streams.get().get(ORACLE_STREAM)?.transcriptFold;
+  if (oracleFold) resetTranscriptFoldState(oracleFold);
   syncStreamLog(defaultSession(), ORACLE_STREAM, options);
   activeStreamId.set(active);
   const fold = projectedView(streams.get().get(FOLD_STREAM));

--- a/src/test-kernel/cli/SubscribeStreamLogDispose.vitest.ts
+++ b/src/test-kernel/cli/SubscribeStreamLogDispose.vitest.ts
@@ -11,7 +11,6 @@ import { defaultSession } from '@agent/runtime/SessionHandle';
 import { transcriptRowHeadline } from '@cli/chat/tui/panes/transcriptEntries';
 import {
   releaseInactiveStreamTranscript,
-  streamRenderCacheSizesForTest,
   subscribeStreamLog,
   syncStreamLog,
 } from '@cli/chat/tui/state/subscribeStreamLog';
@@ -62,6 +61,21 @@ function appendUserMessage(
     messageType: MESSAGE_TYPES.USER_MESSAGE,
     text,
   });
+}
+
+/** Per-stream projection-state occupancy, for the eviction-path check. */
+function streamRenderCacheSizes(): {
+  taskGroups: number;
+  compaction: number;
+  render: number;
+} {
+  const sizes = { taskGroups: 0, compaction: 0, render: 0 };
+  for (const { transcriptFold: fold } of streams.get().values()) {
+    if (fold?.taskGroupProjection) sizes.taskGroups += 1;
+    if (fold?.compactionProjection) sizes.compaction += 1;
+    if (fold?.hydrated) sizes.render += 1;
+  }
+  return sizes;
 }
 
 describe('subscribeStreamLog batching and dispose', () => {
@@ -241,7 +255,7 @@ describe('subscribeStreamLog batching and dispose', () => {
 
     // This sync is what seeds streamB's per-stream projection state.
     syncStreamLog(defaultSession(), streamB);
-    expect(streamRenderCacheSizesForTest()).toEqual({
+    expect(streamRenderCacheSizes()).toEqual({
       taskGroups: 1,
       compaction: 1,
       render: 1,
@@ -257,7 +271,7 @@ describe('subscribeStreamLog batching and dispose', () => {
     });
     releaseInactiveStreamTranscript(defaultSession().transcripts, streamB);
 
-    expect(streamRenderCacheSizesForTest()).toEqual({
+    expect(streamRenderCacheSizes()).toEqual({
       taskGroups: 0,
       compaction: 0,
       render: 0,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -16,7 +16,6 @@ import {
   infoPane,
   openInfoPane,
   rootRunPending,
-  rootRunStartAvailable,
   rootRunStreamId,
   rootStreamId,
   removeStream,
@@ -1293,7 +1292,6 @@ describe('CLI TUI row allocation', () => {
     expect(session.runCompleted).toBe(false);
     expect(session.stopRequested).toBe(false);
     expect(chatTuiCanStartRootRun(session)).toBe(false);
-    expect(rootRunStartAvailable.get()).toBe(false);
     expect(rootRunPending.get()).toBe(true);
     expect(rootRunStreamId.get()).toBeUndefined();
   });
@@ -1309,13 +1307,11 @@ describe('CLI TUI row allocation', () => {
 
     expect(rootRunStreamId.get()).toBe(root);
     expect(rootRunPending.get()).toBe(true);
-    expect(rootRunStartAvailable.get()).toBe(false);
 
     session.markRunCompleted();
 
     expect(rootRunStreamId.get()).toBe(root);
     expect(rootRunPending.get()).toBe(false);
-    expect(rootRunStartAvailable.get()).toBe(true);
   });
 
   it('restores root run availability when clearing session run state', () => {
@@ -1330,7 +1326,6 @@ describe('CLI TUI row allocation', () => {
     session.clearRunState();
 
     expect(chatTuiCanStartRootRun(session)).toBe(true);
-    expect(rootRunStartAvailable.get()).toBe(true);
     expect(rootRunPending.get()).toBe(false);
     expect(rootRunStreamId.get()).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

Batch B of the CLI simplification sweep (`docs/proposals/2026-08-28-simplification-survey-cli.md`, held until #11550 landed). Every premise was re-verified at `4d40f084e2` with `rg` before applying; one item was refuted at HEAD and skipped (below).

- **Delete `rootRunStartAvailable`** (`cliState.ts`, `sessionRunState.ts`, `App.tsx`, `StatusBar.tsx`). It was written only by `TuiSession.publish()` as `!runPending`, reset in lockstep with `rootRunPending`, and `chatTuiCanStartRootRun ≡ !chatTuiRunPending` — so it was `=== !rootRunPending` at every read. `StatusBar` already subscribes to `rootRunPending` for the Ctrl-C hint; it now derives `agentSelectionAvailable` from it and the prop is deleted. `statusBarDisplay.ts` keeps its pure-layout field. New consumer since the verifier's base: `packages/cli/scripts/tui-harness.tsx` seeded the signal from `HARNESS_CAN_SELECT_AGENT` (never set by any CI scenario); the harness now follows the run-pending signal exactly as `texra chat` does, and the 17 CI scenarios pass.
- **Delete the two `*ForTest` pass-throughs in `subscribeStreamLog.ts`** (`invalidateTranscriptFoldForTest`, `streamRenderCacheSizesForTest`) — both read only exported state (`streams` + `resetTranscriptFoldState`). The two suites reach the public seam directly; knip baseline −2 rows. `transcriptFoldCountersForTest` stays (module-private counters, not a pass-through).
- **Un-export five zero-consumer types**: `ChatTuiRunStopFacts`, `ChatTuiSigintAction` (`sessionRunState.ts`); `ActiveStreamScope`, `ActiveStreamAncestor`, `ActiveStreamTreeEntry` (`streamViews.ts`).
- **Defect fix — own the denial-path inquiry write.** `denyExternalInquiryIfNoHumanInput` (`settleApprovals.ts`) ran `void handleExternalInquiryAction(...)` with no rejection handler. The action persists the inquiry thread and the CLI has no `unhandledRejection` handler, so a failed write of a policy-denied external inquiry crashed the process. It now logs the cause at warn under `cli.approval` (the scope `approvalAdapter.ts`/`approvalPrompts.ts` already use), matching the owned `.catch` #11546 added in `subscribeApprovals.ts`. `ApprovalAdapter.vitest.ts` mocks the action as `vi.fn(async () => {})` so `.catch` has a promise to attach to. No new test.

**Skipped — C7(3) `streamViewForId` double `streamTabInfoFor`.** Refuted at HEAD: `streamLabelForId` has four other callers (`StatusBar.tsx:284`, `App.tsx:496,515`, the parent lookup), so the dedup would clone its root-label rule into `streamViewForId` for net +1 LoC. Not a simplification.

## Net elements (R6)

- Files: 14 changed, 0 added, 0 deleted (`git diff --stat origin/main`: **+44 / −73, net −29**; production + ratchet only: 9 files, +18 / −59, net −41).
- Exported symbols (`^[+-]export` over the diff): **+0 / −8** — `rootRunStartAvailable`, `invalidateTranscriptFoldForTest`, `streamRenderCacheSizesForTest`, `ChatTuiRunStopFacts`, `ChatTuiSigintAction`, `ActiveStreamScope`, `ActiveStreamAncestor`, `ActiveStreamTreeEntry`.
- class/interface/enum declarations: **+0 / −0** (three `interface`s lose `export`, none deleted or added).
- Props: `StatusBarProps.agentSelectionAvailable` deleted.
- Test LoC: +24 / −14 (a 13-line file-local `streamRenderCacheSizes()` replaces the deleted export's consumer; every other test hunk is a deletion or a 1:1 retarget).
- Positive-delta items: the defect fix adds +10 in `settleApprovals.ts` (owned `.catch` + two imports), stated as a defect fix, not a simplification.

## Consumer counts (R8)

No emit path or subscribe surface is deleted or re-routed. Grepped consumers per deleted public symbol (`rg` across `packages/ src/`, including `packages/cli/scripts/`):

| Symbol | Consumers at HEAD | Disposition |
| --- | --- | --- |
| `rootRunStartAvailable` | 4 (`sessionRunState.ts` write, `App.tsx` read, `tui-harness.tsx` write, 2 tests) | all retargeted to `rootRunPending` |
| `StatusBarProps.agentSelectionAvailable` | 1 (`App.tsx`) | derived inside `StatusBar` |
| `invalidateTranscriptFoldForTest` | 1 (`StreamLogDeltaFold.vitest.ts`) | inlined (2 lines) |
| `streamRenderCacheSizesForTest` | 1 (`SubscribeStreamLogDispose.vitest.ts`) | file-local helper |
| `ChatTuiRunStopFacts`, `ChatTuiSigintAction`, `ActiveStreamScope`, `ActiveStreamAncestor`, `ActiveStreamTreeEntry` | 0 outside the defining file | export dropped |

`handleExternalInquiryAction` call sites in the CLI: 3 (`approvalAdapter.ts:286` awaited; `subscribeApprovals.ts:885` owned by #11546; `settleApprovals.ts` owned here) — all now owned.

## Verified

In the worktree at `4d40f084e2`, `CI=true FORCE_COLOR=0`:

- `npm run format`; `git diff --check` clean.
- `tsc --noEmit -p packages/cli/tsconfig.json`, `-p packages/cli/tsconfig.scripts.json`, `-p tsconfig.test-kernel.json` — all clean.
- `vitest run src/test-kernel/cli` — 144 files, 2519 passed / 1 skipped, 36.6s, no timeouts.
- Full `npm run lint` — exit 0, no findings.
- `npm run check:dead-code-ratchet` — OK, 371 vs 371 baselined (baseline shrunk by the 2 deleted rows).
- `node packages/cli/scripts/validate-tui.mjs` on the CI scenario list from `.github/workflows/ci.yml` (`edit-approval … narrow-slash-palette-command-names`) — 17/17 passed.
- Opened and read: `cliState.ts`, `sessionRunState.ts` (`publish`, `chatTuiCanStartRootRun`), `App.tsx`, `StatusBar.tsx`, `statusBarDisplay.ts` (agent-hint cascade), `streamViews.ts` (`streamTabInfoFor`, `streamLabelForId`, `streamViewForId`), `subscribeStreamLog.ts`, `settleApprovals.ts`, `approvalAdapter.ts` (`openExternalInquiry`), `subscribeApprovals.ts` (#11546 `.catch`), `tui-harness.tsx` (knob wiring at 275/324/2397/2441), `validate-tui.mjs` (no scenario sets `HARNESS_CAN_SELECT_AGENT`), and the five test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pZUVQRHJvb8tVCu8nU7TC
