### PR TITLE
docs(latex): add module README documenting src/latex/ responsibilities

### DIFF
--- a/scripts/check-guidance-refs.mjs
+++ b/scripts/check-guidance-refs.mjs
@@ -43,6 +43,7 @@ const GUIDANCE_FILES = [
   'src/agent/runtime/README.md',
   'src/agent/workflowScript/README.md',
   'src/replacement/README.md',
+  'src/latex/README.md',
 ];
 // Standing docs: architecture notes and the published guide. Dated proposals
 // and PRDs stay out — they are historical by design (see issue #9730).

--- a/src/latex/README.md
+++ b/src/latex/README.md
@@ -9,10 +9,12 @@ The files have distinct roles:
 
 - **Compilation** — `texTools.ts` builds the kpathsea search path and runs
   `compileLatex2Pdf`; `latexToolchain.ts` lists the core CLI tools TeXRA
-  depends on, kept in sync with `@shared/constants/latex`'s SSOT by a
-  type-level check; `latexLogging.ts` defines the one shared log channel
-  every tool-shell-out module (tex-fmt, latexindent, texcount, latexdiff, …)
-  logs under.
+  depends on, kept in sync with `@shared/constants/latexToolchain`'s SSOT by a
+  type-level check; `latexLogging.ts` defines the shared log channel that
+  `texcount.ts` and the `formatter/` backends log under. `latexdiff/`'s
+  service instead takes a caller-supplied channel (agent runs use their
+  stream id; desktop and the tool-approval preview use their own) — only the
+  extension's own latexdiff command group reuses this shared channel.
 - **Content extraction** — `extractFigure.ts` and `extractBibliography.ts`
   pull figure paths and bibliography entries out of LaTeX source;
   `extractFileDependencies.ts` resolves `\input`/`\include`/`\bibliography`

--- a/src/latex/README.md
+++ b/src/latex/README.md
@@ -1,0 +1,49 @@
+# LaTeX tooling
+
+Host-neutral LaTeX domain logic: compiling, parsing, diffing, and fetching
+documents. No file here imports `vscode`; host wiring (commands, UI prompts)
+stays in the extension/desktop/CLI layers and reaches this code through typed
+ports (see `overleafClone.ts`) rather than the other way around.
+
+The files have distinct roles:
+
+- **Compilation** — `texTools.ts` builds the kpathsea search path and runs
+  `compileLatex2Pdf`; `latexToolchain.ts` lists the core CLI tools TeXRA
+  depends on, kept in sync with `@shared/constants/latex`'s SSOT by a
+  type-level check; `latexLogging.ts` defines the one shared log channel
+  every tool-shell-out module (tex-fmt, latexindent, texcount, latexdiff, …)
+  logs under.
+- **Content extraction** — `extractFigure.ts` and `extractBibliography.ts`
+  pull figure paths and bibliography entries out of LaTeX source;
+  `extractFileDependencies.ts` resolves `\input`/`\include`/`\bibliography`
+  targets so `LatexMediaManager` can mirror them into run storage.
+  `latexParsingUtils.ts` holds the comment-stripping and bibliography-directive
+  matching those two extractors share — add new shared parsing there rather
+  than duplicating it in either extractor. `labelSearch.ts` scans files for a
+  `\label{}` definition. `criticismParser.ts` parses `\criticize{}` review
+  annotations (the counterpart that strips them lives in
+  `replacement/advanced.ts`, both built on the same shared brace-balanced
+  macro scanner).
+- **Output processing** — `texraResponseTextProcessing.ts` is the LaTeX-owned
+  policy for cleaning up and joining a model's continued LaTeX output; the
+  agent runtime only supplies the connector strategy. `texcount.ts` shells out
+  to `texcount` for word/character counts. `latexdiff.ts` runs `latexdiff`
+  between two revisions.
+- **Media and file management** — `LatexMediaManager.ts` owns per-workspace
+  media state and dependency mirroring; `TikzPictureManager.ts` extracts and
+  renders standalone TikZ pictures; `acceptedFileTarget.ts` resolves where an
+  accepted/edited file should land and commits the replacement;
+  `mergeFileUtils.ts` parses the `_rN_`-suffixed filenames TeXRA's merge
+  workflow generates.
+- **Remote sources** — `arxivIdentifier.ts` normalizes an arXiv ID out of a
+  URL or bare string; `arxivProcessor.ts` downloads and unpacks arXiv source
+  archives. `overleafProject.ts` is the pure, host-neutral parsing and
+  credential/URL derivation for an Overleaf git remote; `overleafClone.ts` is
+  the workflow built on top of it (precondition checks, clone execution,
+  auth-failure retry) — new Overleaf logic that doesn't need I/O belongs in
+  `overleafProject.ts`, not `overleafClone.ts`.
+
+New parsing helpers that more than one extractor needs belong in
+`latexParsingUtils.ts`; new host-facing workflows should take their side
+effects through a ports interface the way `overleafClone.ts` does, so the
+decision logic stays unit-testable and host-agnostic.

--- a/src/latex/README.md
+++ b/src/latex/README.md
@@ -27,8 +27,9 @@ The files have distinct roles:
 - **Output processing** — `texraResponseTextProcessing.ts` is the LaTeX-owned
   policy for cleaning up and joining a model's continued LaTeX output; the
   agent runtime only supplies the connector strategy. `texcount.ts` shells out
-  to `texcount` for word/character counts. `latexdiff.ts` runs `latexdiff`
-  between two revisions.
+  to `texcount` for word/character counts. `latexdiff.ts` is the thin
+  host-facing entry point for a diff; the actual `latexdiff` orchestration
+  lives in the `latexdiff/` subdirectory below.
 - **Media and file management** — `LatexMediaManager.ts` owns per-workspace
   media state and dependency mirroring; `TikzPictureManager.ts` extracts and
   renders standalone TikZ pictures; `acceptedFileTarget.ts` resolves where an
@@ -42,6 +43,24 @@ The files have distinct roles:
   the workflow built on top of it (precondition checks, clone execution,
   auth-failure retry) — new Overleaf logic that doesn't need I/O belongs in
   `overleafProject.ts`, not `overleafClone.ts`.
+
+## Subdirectories
+
+- **`formatter/`** — the local-formatter backends `latexindentpt.ts` (runs
+  `latexindent`) and `texfmt.ts` (runs `tex-fmt`) wrap, `texFormatter.ts`
+  resolves which one a workspace setting selects and runs it, and
+  `indentDirectory.ts` applies it across a whole directory.
+- **`latexdiff/`** — the real implementation behind `latexdiff.ts`.
+  `runLatexdiff.ts` is the host-neutral entry point every host (VS Code, CLI,
+  desktop) calls; it resolves which round outputs to diff via
+  `outputDiscovery.ts`/`executionDiscovery.ts` (the latter's narrow port lets
+  `latex` stay out of `@agent/storage`), builds the diff operations in
+  `diffOperations.ts`/`diffCommandExecutor.ts`, names output files with
+  `diffFileNameManager.ts`, and processes the raw diff in
+  `diffFileProcessor.ts` (math markup options come from `mathMarkup.ts`).
+  `service.ts` holds the shared `latexdiffService` singleton, `types.ts` the
+  types those pieces share, and `latexdiffCopy.ts` the user-facing outcome
+  strings both host commands print so they can't disagree on wording.
 
 New parsing helpers that more than one extractor needs belong in
 `latexParsingUtils.ts`; new host-facing workflows should take their side

--- a/src/latex/README.md
+++ b/src/latex/README.md
@@ -15,10 +15,14 @@ The files have distinct roles:
   service instead takes a caller-supplied channel (agent runs use their
   stream id; desktop and the tool-approval preview use their own) — only the
   extension's own latexdiff command group reuses this shared channel.
-- **Content extraction** — `extractFigure.ts` and `extractBibliography.ts`
-  pull figure paths and bibliography entries out of LaTeX source;
-  `extractFileDependencies.ts` resolves `\input`/`\include`/`\bibliography`
-  targets so `LatexMediaManager` can mirror them into run storage.
+- **Content extraction** — `extractFigure.ts` pulls figure paths out of LaTeX
+  source; `extractBibliography.ts` extracts bibliography-file references and
+  citation keys from the source (`extractBibliographyContext`) and separately
+  loads the actual entries from those referenced `.bib` files
+  (`loadBibliographyEntries`) — the two stages have different inputs, don't
+  conflate them. `extractFileDependencies.ts` resolves
+  `\input`/`\include`/`\bibliography` targets so `LatexMediaManager` can
+  mirror them into run storage.
   `latexParsingUtils.ts` holds the comment-stripping and bibliography-directive
   matching those two extractors share — add new shared parsing there rather
   than duplicating it in either extractor. `labelSearch.ts` scans files for a
@@ -32,9 +36,12 @@ The files have distinct roles:
   to `texcount` for word/character counts. `latexdiff.ts` is the thin
   host-facing entry point for a diff; the actual `latexdiff` orchestration
   lives in the `latexdiff/` subdirectory below.
-- **Media and file management** — `LatexMediaManager.ts` owns per-workspace
-  media state and dependency mirroring; `TikzPictureManager.ts` extracts and
-  renders standalone TikZ pictures; `acceptedFileTarget.ts` resolves where an
+- **Media and file management** — `LatexMediaManager.ts` compiles PDFs and
+  mirrors figure dependencies into run storage, writing results into a
+  `MediaWorkspaceState` the caller owns (the manager itself holds only a
+  logger and an optional file service, no state);
+  `TikzPictureManager.ts` extracts and renders standalone TikZ pictures;
+  `acceptedFileTarget.ts` resolves where an
   accepted/edited file should land and commits the replacement;
   `mergeFileUtils.ts` parses the `_rN_`-suffixed filenames TeXRA's merge
   workflow generates.
@@ -43,8 +50,9 @@ The files have distinct roles:
   archives. `overleafProject.ts` is the pure, host-neutral parsing and
   credential/URL derivation for an Overleaf git remote; `overleafClone.ts` is
   the workflow built on top of it (precondition checks, clone execution,
-  auth-failure retry) — new Overleaf logic that doesn't need I/O belongs in
-  `overleafProject.ts`, not `overleafClone.ts`.
+  auth-failure handling — it clears the bad token and reports the failure,
+  it does not retry the clone itself) — new Overleaf logic that doesn't need
+  I/O belongs in `overleafProject.ts`, not `overleafClone.ts`.
 
 ## Subdirectories
 

--- a/src/latex/README.md
+++ b/src/latex/README.md
@@ -13,8 +13,8 @@ The files have distinct roles:
   type-level membership check — it catches a renamed/removed shared tool, not
   a new one added there that this list doesn't yet cover; `latexLogging.ts`
   defines the shared log channel that `texcount.ts` and the `formatter/`
-  backends log under. `latexdiff/`'s
-  service instead takes a caller-supplied channel (agent runs use their
+  backends log under. `latexdiff/`'s service instead takes a caller-supplied
+  channel (agent runs use their
   stream id; desktop and the tool-approval preview use their own) — only the
   extension's own latexdiff command group reuses this shared channel.
 - **Content extraction** — `extractFigure.ts` pulls figure paths out of LaTeX
@@ -23,8 +23,8 @@ The files have distinct roles:
   loads the actual entries from those referenced `.bib` files
   (`loadBibliographyEntries`) — the two stages have different inputs, don't
   conflate them. `extractFileDependencies.ts` resolves
-  `\input`/`\include`/`\bibliography` targets so `LatexMediaManager` can
-  mirror them into run storage.
+  `\input`/`\include`/`\bibliography`/`\addbibresource` targets so
+  `LatexMediaManager` can mirror them into run storage.
   `latexParsingUtils.ts` holds comment-stripping (shared by all three
   extractors above) and the bibliography-directive matching that
   `extractBibliography.ts` and `extractFileDependencies.ts` specifically share
@@ -75,9 +75,13 @@ The files have distinct roles:
   port lets `latex` stay out of `@agent/storage`), then builds and dispatches
   the diff operations via `diffOperations.ts`/`diffCommandExecutor.ts`, naming
   output files with `diffFileNameManager.ts` (math markup options come from
-  `mathMarkup.ts`). `service.ts` holds the shared `latexdiffService` singleton
-  (used only by the extension's own command group — see the Compilation
-  bullet above), `types.ts` the types those pieces share, and
+  `mathMarkup.ts`). `diffFileProcessor.ts` is the post-processor
+  `LaTeXdiffService` itself calls after generating a direct or VC diff, to
+  restore flattened bibliography directives and sanitize latexdiff's
+  `\DIFadd`/`\DIFdel` markup. `service.ts` holds the shared
+  `latexdiffService` singleton (used only by the extension's own command
+  group — see the Compilation bullet above), `types.ts` the types those
+  pieces share, and
   `latexdiffCopy.ts` the user-facing outcome strings both host commands print
   so they can't disagree on wording.
 

--- a/src/latex/README.md
+++ b/src/latex/README.md
@@ -25,9 +25,11 @@ The files have distinct roles:
   conflate them. `extractFileDependencies.ts` resolves
   `\input`/`\include`/`\bibliography` targets so `LatexMediaManager` can
   mirror them into run storage.
-  `latexParsingUtils.ts` holds the comment-stripping and bibliography-directive
-  matching those two extractors share — add new shared parsing there rather
-  than duplicating it in either extractor. `labelSearch.ts` scans files for a
+  `latexParsingUtils.ts` holds comment-stripping (shared by all three
+  extractors above) and the bibliography-directive matching that
+  `extractBibliography.ts` and `extractFileDependencies.ts` specifically share
+  — add new shared parsing there rather than duplicating it in an extractor.
+  `labelSearch.ts` scans files for a
   `\label{}` definition. `criticismParser.ts` parses `\criticize{}` review
   annotations (the counterpart that strips them lives in
   `replacement/advanced.ts`, both built on the same shared brace-balanced

--- a/src/latex/README.md
+++ b/src/latex/README.md
@@ -9,9 +9,11 @@ The files have distinct roles:
 
 - **Compilation** — `texTools.ts` builds the kpathsea search path and runs
   `compileLatex2Pdf`; `latexToolchain.ts` lists the core CLI tools TeXRA
-  depends on, kept in sync with `@shared/constants/latexToolchain`'s SSOT by a
-  type-level check; `latexLogging.ts` defines the shared log channel that
-  `texcount.ts` and the `formatter/` backends log under. `latexdiff/`'s
+  depends on, checked against `@shared/constants/latexToolchain`'s SSOT by a
+  type-level membership check — it catches a renamed/removed shared tool, not
+  a new one added there that this list doesn't yet cover; `latexLogging.ts`
+  defines the shared log channel that `texcount.ts` and the `formatter/`
+  backends log under. `latexdiff/`'s
   service instead takes a caller-supplied channel (agent runs use their
   stream id; desktop and the tool-approval preview use their own) — only the
   extension's own latexdiff command group reuses this shared channel.
@@ -33,9 +35,11 @@ The files have distinct roles:
 - **Output processing** — `texraResponseTextProcessing.ts` is the LaTeX-owned
   policy for cleaning up and joining a model's continued LaTeX output; the
   agent runtime only supplies the connector strategy. `texcount.ts` shells out
-  to `texcount` for word/character counts. `latexdiff.ts` is the thin
-  host-facing entry point for a diff; the actual `latexdiff` orchestration
-  lives in the `latexdiff/` subdirectory below.
+  to `texcount` for word/character counts. `latexdiff.ts` defines
+  `LaTeXdiffService`, which executes a single diff (invokes the command,
+  writes and post-processes the output) in its direct/VC/per-round/
+  between-round forms; the `latexdiff/` subdirectory below adds full-run
+  discovery and operation planning around it, not the execution itself.
 - **Media and file management** — `LatexMediaManager.ts` compiles PDFs and
   mirrors figure dependencies into run storage, writing results into a
   `MediaWorkspaceState` the caller owns (the manager itself holds only a
@@ -60,17 +64,20 @@ The files have distinct roles:
   `latexindent`) and `texfmt.ts` (runs `tex-fmt`) wrap, `texFormatter.ts`
   resolves which one a workspace setting selects and runs it, and
   `indentDirectory.ts` applies it across a whole directory.
-- **`latexdiff/`** — the real implementation behind `latexdiff.ts`.
-  `runLatexdiff.ts` is the host-neutral entry point every host (VS Code, CLI,
-  desktop) calls; it resolves which round outputs to diff via
-  `outputDiscovery.ts`/`executionDiscovery.ts` (the latter's narrow port lets
-  `latex` stay out of `@agent/storage`), builds the diff operations in
-  `diffOperations.ts`/`diffCommandExecutor.ts`, names output files with
-  `diffFileNameManager.ts`, and processes the raw diff in
-  `diffFileProcessor.ts` (math markup options come from `mathMarkup.ts`).
-  `service.ts` holds the shared `latexdiffService` singleton, `types.ts` the
-  types those pieces share, and `latexdiffCopy.ts` the user-facing outcome
-  strings both host commands print so they can't disagree on wording.
+- **`latexdiff/`** — full-run discovery and operation planning around
+  `LaTeXdiffService`. `runLatexdiff.ts` is the host-neutral entry point the
+  VS Code command and the desktop stream-toolbar action call (the CLI's
+  latexdiff workflow instead goes through the agent's own `LatexDiffManager`,
+  which uses `LaTeXdiffService` directly); it resolves which round outputs to
+  diff via `outputDiscovery.ts`/`executionDiscovery.ts` (the latter's narrow
+  port lets `latex` stay out of `@agent/storage`), then builds and dispatches
+  the diff operations via `diffOperations.ts`/`diffCommandExecutor.ts`, naming
+  output files with `diffFileNameManager.ts` (math markup options come from
+  `mathMarkup.ts`). `service.ts` holds the shared `latexdiffService` singleton
+  (used only by the extension's own command group — see the Compilation
+  bullet above), `types.ts` the types those pieces share, and
+  `latexdiffCopy.ts` the user-facing outcome strings both host commands print
+  so they can't disagree on wording.
 
 New parsing helpers that more than one extractor needs belong in
 `latexParsingUtils.ts`; new host-facing workflows should take their side


### PR DESCRIPTION
## Summary

Scheduled audit for confusing/overlapping responsibilities across the repo. Two independent passes (one by me, one by a dedicated survey subagent) covered `src/latex/`, `src/model/`, `src/replacement/`, `src/agent/modelHandlers/`, `packages/desktop/`, the webview frontends, `src/eventBus/`, the `src/shared/`/`src/controllers/` boundary, and `config/ratchets/`. The recent near-daily simplification campaign (`docs/proposals/2026-08-*`) has left this codebase in genuinely good shape: every suspicious-looking pair we checked (e.g. `src/replacement/rules.ts` vs `maxRules.ts`, the codex/xai preference pairs in `src/model/`, the inbound/outbound `webview/slices/` split, the per-provider model handlers' retry ownership) turned out to be deliberately separated, with explicit rationale comments, and no duplicated logic.

The one real gap found: `src/latex/` has 20 files spanning compilation, extraction, diffing, media management, and remote-source fetching, but — unlike `src/replacement/` and `src/agent/modelHandlers/`, which each ship a README explaining their split — it has no map between them. A newcomer has to open all 20 files to confirm each one's job is in fact distinct (it is). This PR adds that README, grouped by responsibility, with pointers to where new shared parsing (`latexParsingUtils.ts`) or host-facing workflow logic (`overleafClone.ts`'s ports pattern) belongs so future additions don't drift into the wrong file.

Also registers the new README with `scripts/check-guidance-refs.mjs` (the CI gate that keeps guidance-file path citations honest) alongside the other module READMEs it already tracks.

Two smaller, lower-priority items surfaced but are **not** addressed here (invasive renames for a cosmetic gain aren't a good fit for an automated docs pass): `packages/desktop/src/renderer/taskShell.ts` (Lit templates) vs `packages/desktop/src/shared/desktopTaskShell.ts` (reducer) are a fuzzy-search collision risk one substring apart; and `packages/extension/src/webview/slices/` vs `.../webview/frontend/slices/` share basenames without a directory-level inbound/outbound marker. Neither is a logic bug — just worth a maintainer's judgment call on whether a rename is worth the blast radius.

## Issue acceptance gates

No linked issue — this is a scheduled tech-debt scan. Acceptance gate: document `src/latex/`'s file responsibilities so ownership is no longer implicit; keep `check-guidance-refs.mjs` honest about the new file.

## Single source of truth

No new coordinator or schema — this is a documentation-only change. `src/latex/README.md` is now the single map of file responsibilities for that directory, mirroring `src/replacement/README.md` and `src/agent/modelHandlers/README.md`.

## Duplication and abstraction budget

No code duplication removed or added (none was found in this directory). No new abstraction — a README, not a code layer.

## Net elements (R6)

Not a refactor/simplify/consolidate/dedupe PR — n/a. Diffstat: 2 files changed, 50 insertions(+), 0 deletions(-); 0 exported symbols changed.

## Consumer counts (R8)

n/a — no emit path, export, or code symbol was deleted or re-routed.

## Host impact

Extension: none.

Desktop: none.

CLI: none.

## Scheduled refactoring

None. The two rename candidates noted in the Summary are left for a maintainer to decide are worth their blast radius; no follow-up issue filed since they're informational, not a chartered scope.

## Validation

- `node scripts/check-guidance-refs.mjs` — passes, confirms all path citations in the new README (and every other guidance file) resolve.
- No code changed; `npm run lint`/`npm run typecheck` not applicable (dependencies aren't installed in this sandbox and the change is markdown-only with no code touched).

---
_Generated by [Claude Code](https://claude.ai/code/session_012avNHGp4G1mh8CwWsdRShN)_