### PR TITLE
fix(progressView): apply better-ui polish pass - transitions, concentric radii, press feedback

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts
+++ b/packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts
@@ -16,7 +16,10 @@ import { DELEGATION_APPROVAL_COPY } from '@shared/copy/delegationApproval';
 import { WORKFLOW_CALL_REVIEW_COPY } from '@shared/copy/workflowScriptProposal';
 import { createEvent } from '@shared/utils/events';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
-import { renderSplitButtonMenuParts } from '@shared/wa/splitButton';
+import {
+  renderSplitButtonMenuParts,
+  splitButtonTriggerStyles,
+} from '@shared/wa/splitButton';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 /** Each menu item's dropdown-item value is the event it emits when selected. */
@@ -57,6 +60,7 @@ export class ApproveSplitButton extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
+    splitButtonTriggerStyles,
     css`
       /* Mirror the .action-button cap (requestPanelSharedStyles, #6658): hug
          content so Approve stays button-sized instead of filling the row. */
@@ -65,30 +69,6 @@ export class ApproveSplitButton extends LitElement {
         flex: 0 1 auto;
         min-width: auto;
         max-width: min(14rem, 100%);
-      }
-
-      .approve-split-trigger {
-        width: 1.5rem;
-        min-width: 1.5rem;
-      }
-
-      .approve-split-trigger::part(base) {
-        padding-inline: 0;
-      }
-
-      .approve-split-trigger wa-icon {
-        font-size: var(--font-size-sm);
-        transition: transform var(--transition-fast);
-      }
-
-      .approve-split-menu[open] .approve-split-trigger wa-icon {
-        transform: rotate(180deg);
-      }
-
-      @media (prefers-reduced-motion: reduce) {
-        .approve-split-trigger wa-icon {
-          transition: none;
-        }
       }
     `,
   ];
@@ -177,7 +157,7 @@ export class ApproveSplitButton extends LitElement {
     });
 
     return html`
-      <wa-button-group class="approve-split" label="Approve">
+      <wa-button-group class="approve-split split-group" label="Approve">
         ${approveButton} ${menu}
       </wa-button-group>
       ${tooltip}

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -144,7 +144,7 @@ export class BackgroundTasksPanel extends LitElement {
       }
 
       .task-name--clickable:hover {
-        text-decoration-color: var(--wa-color-text-normal);
+        text-decoration-color: currentColor;
       }
 
       /* Sits between the name and the description: a run's phase identifies

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -40,6 +40,7 @@ import {
 } from '@shared/styles';
 import { CopyButtonController } from '@shared/litControllers/CopyButtonController';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
+import { renderDotMeta } from '@shared/wa/metaStrip';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { createFlushableDebounce, tryParseUrl } from '@utils/core';
@@ -437,19 +438,20 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
           </div>
           <div class="external-inquiry-request__chat-links">
             Open:
-            <a
-              href="https://chatgpt.com/plans/pro/"
-              target="_blank"
-              rel="noopener noreferrer"
-              >ChatGPT Pro</a
-            >
-            &nbsp;·&nbsp;
-            <a
-              href="https://deepmind.google/models/gemini/deep-think/"
-              target="_blank"
-              rel="noopener noreferrer"
-              >Gemini Deep Think</a
-            >
+            ${renderDotMeta([
+              html`<a
+                href="https://chatgpt.com/plans/pro/"
+                target="_blank"
+                rel="noopener noreferrer"
+                >ChatGPT Pro</a
+              >`,
+              html`<a
+                href="https://deepmind.google/models/gemini/deep-think/"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Gemini Deep Think</a
+              >`,
+            ])}
           </div>
           <wa-textarea
             class="external-inquiry-request__session-links-input"

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -124,6 +124,7 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
             text: copilotQuotaExhausted ? 'Retry Copilot' : 'Retry',
             title: copilotQuotaExhausted ? 'Retry Copilot (r)' : 'Retry (r)',
             action: 'retry',
+            kind: 'primary',
             disabled,
             onClick: () => this.emitAction({ action: 'retry' }),
           })}

--- a/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
@@ -167,6 +167,7 @@ export const streamTabStyles = css`
     margin-inline: var(--wa-space-2xs) 0;
     color: var(--wa-color-text-quiet, var(--wa-color-text-normal));
     opacity: 0;
+    transition: opacity var(--transition-fast);
     position: relative;
     z-index: 10;
   }
@@ -312,6 +313,7 @@ export const streamTabStyles = css`
 
   .tab-expand wa-icon {
     font-size: var(--font-size-xs);
+    transition: transform var(--transition-fast);
   }
 
   .tab-expand[aria-expanded='true'] wa-icon {

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.styles.ts
@@ -50,28 +50,4 @@ export const toolEditRequestPanelStyles: CSSResult = css`
     min-width: 0;
     max-width: none;
   }
-
-  .diff-dropdown-trigger {
-    width: 1.5rem;
-    min-width: 1.5rem;
-  }
-
-  .diff-dropdown-trigger::part(base) {
-    padding-inline: 0;
-  }
-
-  .diff-dropdown-trigger wa-icon {
-    font-size: var(--font-size-sm);
-    transition: transform var(--transition-fast);
-  }
-
-  .diff-dropdown-menu[open] .diff-dropdown-trigger wa-icon {
-    transform: rotate(180deg);
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .diff-dropdown-trigger wa-icon {
-      transition: none;
-    }
-  }
 `;

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -23,7 +23,10 @@ import {
   renderLabeledActionButtonParts,
 } from '@shared/wa/actionButtons';
 import { renderDotMeta, type MetaPart } from '@shared/wa/metaStrip';
-import { renderSplitButtonMenuParts } from '@shared/wa/splitButton';
+import {
+  renderSplitButtonMenuParts,
+  splitButtonTriggerStyles,
+} from '@shared/wa/splitButton';
 import { pluralize } from '@utils/text/stringUtils';
 
 // Local imports - base class
@@ -38,6 +41,7 @@ export class ToolEditRequestPanel extends BaseBypassApprovalPanel<'toolEdit'> {
     designTokens,
     commonViewStyles,
     requestPanelSharedStyles,
+    splitButtonTriggerStyles,
     toolEditRequestPanelStyles,
   ];
 
@@ -107,7 +111,7 @@ export class ToolEditRequestPanel extends BaseBypassApprovalPanel<'toolEdit'> {
     });
 
     return html`
-      <wa-button-group class="diff-dropdown" label="Diff actions">
+      <wa-button-group class="diff-dropdown split-group" label="Diff actions">
         ${diffButton.button} ${diffMenu.menu}
       </wa-button-group>
       ${diffButton.tooltip} ${diffMenu.tooltip}

--- a/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
+++ b/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
@@ -25,7 +25,7 @@ export class WorktreeChip extends LitElement {
         align-items: center;
         gap: var(--wa-space-3xs);
         font-size: var(--font-size-xs);
-        line-height: 1.4;
+        line-height: var(--line-height-normal);
         min-width: 0;
         max-width: 100%;
       }

--- a/packages/extension/src/progressView/frontend/styles/groupStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/groupStyles.ts
@@ -88,6 +88,7 @@ export const groupStyles = css`
     height: 7px;
     border-radius: 2px;
     background: var(--wa-color-surface-border);
+    box-sizing: border-box;
   }
 
   .group-dot--awaitingApproval {

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -158,8 +158,6 @@ export const logEntryStyles = css`
   .workflow-task-status {
     align-self: center;
     padding: calc(var(--wa-space-3xs) / 2) var(--wa-space-2xs);
-    border-radius: 999px;
-    background: transparent;
     color: var(--color-text-secondary);
     font-size: var(--font-size-sm);
     white-space: nowrap;

--- a/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
@@ -103,7 +103,7 @@ export const toolUseStyles = css`
 
   .tool-output-terminal {
     display: block;
-    border-radius: var(--wa-border-radius-m, var(--border-radius-small));
+    border-radius: var(--border-radius-small);
     overflow: hidden;
     background: var(--wa-color-surface-default);
     border: var(--border-thin) solid var(--color-border);

--- a/packages/extension/src/progressView/frontend/styles/toolbarToggleStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/toolbarToggleStyles.ts
@@ -7,16 +7,21 @@ export const toolbarToggleStyles = css`
     flex-shrink: 0;
   }
 
-  .bypass-toggle-button.is-active {
-    border-radius: var(--border-radius);
-    /* AUTO-EDIT / AUTO-BASH match the CLI warning badges. */
+  /* AUTO-EDIT / AUTO-BASH match the CLI warning badges. Targets ::part(base)
+     rather than the host: the pressed state's action-icon-button skin
+     (controlStyles.ts) also paints ::part(base), and this rule must win that
+     tie by winning the cascade at equal specificity — toolbarToggleStyles is
+     adopted after commonViewStyles in StreamHeader.ts — for one fill at one
+     radius instead of two mismatched stacked fills. */
+  .bypass-toggle-button.is-active::part(base) {
     --_toggle-color: var(--color-warning);
     color: var(--_toggle-color);
+    border-color: color-mix(in srgb, var(--_toggle-color) 40%, transparent);
     background-color: color-mix(in srgb, var(--_toggle-color) 15%, transparent);
   }
 
   /* AUTO-TASK is the complete grant — CLI uses the error badge. */
-  .bypass-toggle-button--task.is-active {
+  .bypass-toggle-button--task.is-active::part(base) {
     --_toggle-color: var(--color-error);
   }
 `;

--- a/src/shared/styles/controlStyles.ts
+++ b/src/shared/styles/controlStyles.ts
@@ -247,6 +247,25 @@ export const buttonStyles: CSSResult = css`
     transform: translateY(0) scale(0.97);
   }
 
+  /* Native WA split-action groups (the approve caret menu, the diff-actions
+     dropdown) render nativeChrome segments that carry none of the
+     INTERACTIVE_CONTROLS aliases above, so the fused group needs its own
+     lift/press feedback — applied to the wa-button-group host so the whole
+     control moves as one unit instead of the segments moving independently. */
+  wa-button-group.split-group {
+    transition:
+      filter var(--transition-normal),
+      transform var(--transition-normal);
+  }
+
+  wa-button-group.split-group:hover {
+    transform: translateY(-1px);
+  }
+
+  wa-button-group.split-group:active {
+    transform: translateY(0) scale(0.97);
+  }
+
   .icon-button wa-icon,
   .action-icon-button wa-icon {
     font-size: var(--font-size-icon-sm);
@@ -370,6 +389,10 @@ export const buttonStyles: CSSResult = css`
 
   @media (prefers-reduced-motion: reduce) {
     :is(${INTERACTIVE_CONTROLS}):not([disabled]):is(:hover, :active) {
+      transform: none;
+    }
+
+    wa-button-group.split-group:is(:hover, :active) {
       transform: none;
     }
   }

--- a/src/shared/styles/requestPanelSharedStyles.ts
+++ b/src/shared/styles/requestPanelSharedStyles.ts
@@ -216,7 +216,7 @@ export const requestPanelSharedStyles: CSSResult = css`
     display: block;
     outline: var(--border-medium) solid var(--wa-color-focus);
     outline-offset: calc(-1 * ${sp.tiny});
-    border-radius: var(--border-radius-medium);
+    border-radius: var(--border-radius);
   }
 
   :is(${LISTS}) {

--- a/src/shared/wa/splitButton.ts
+++ b/src/shared/wa/splitButton.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { html, type TemplateResult } from 'lit';
+import { css, html, type CSSResult, type TemplateResult } from 'lit';
 
 // Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/button/button.js';
@@ -43,6 +43,39 @@ function selectedItemValue(event: WaSelectEvent): string {
 }
 
 /**
+ * Shared styling for the caret trigger `renderSplitButtonMenuParts` emits —
+ * the two call sites (ApproveSplitButton, ToolEditRequestPanel) rendered a
+ * verbatim copy of these rules under their own class prefix; keyed on the
+ * fixed `.split-trigger`/`.split-menu` classes the template below also
+ * emits, so one definition covers both.
+ */
+export const splitButtonTriggerStyles: CSSResult = css`
+  .split-trigger {
+    width: 1.5rem;
+    min-width: 1.5rem;
+  }
+
+  .split-trigger::part(base) {
+    padding-inline: 0;
+  }
+
+  .split-trigger wa-icon {
+    font-size: var(--font-size-sm);
+    transition: transform var(--transition-fast);
+  }
+
+  .split-menu[open] .split-trigger wa-icon {
+    transform: rotate(180deg);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .split-trigger wa-icon {
+      transition: none;
+    }
+  }
+`;
+
+/**
  * Returns the dropdown and tooltip separately for a native
  * `<wa-button-group>` caller, which must keep the tooltip outside the group so
  * the dropdown remains its trailing segment.
@@ -60,7 +93,7 @@ export function renderSplitButtonMenuParts({
   return {
     menu: html`
       <wa-dropdown
-        class="${classPrefix}-menu"
+        class="${classPrefix}-menu split-menu"
         placement="bottom-end"
         @wa-select=${(event: WaSelectEvent) =>
           onSelect(selectedItemValue(event))}
@@ -68,7 +101,7 @@ export function renderSplitButtonMenuParts({
         <wa-button
           id=${triggerId}
           slot="trigger"
-          class="${classPrefix}-trigger"
+          class="${classPrefix}-trigger split-trigger"
           appearance=${triggerAppearance}
           variant=${triggerVariant}
           size="s"

--- a/src/test-kernel/progressView/ToolEditRequestPanel.vitest.ts
+++ b/src/test-kernel/progressView/ToolEditRequestPanel.vitest.ts
@@ -179,22 +179,22 @@ describe('tool-edit-request-panel', () => {
   });
 
   it('keeps native caret state motion-safe and removes legacy split styles', () => {
+    const splitButtonSource = readFileSync(
+      'src/shared/wa/splitButton.ts',
+      'utf8',
+    );
     const toolEditStyles = readFileSync(
       'packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.styles.ts',
       'utf8',
     );
-    const approveButton = readFileSync(
-      'packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts',
-      'utf8',
+
+    expect(splitButtonSource).toContain('.split-menu[open]');
+    expect(splitButtonSource).toContain(
+      '@media (prefers-reduced-motion: reduce)',
     );
 
-    expect(toolEditStyles).toContain('.diff-dropdown-menu[open]');
-    expect(approveButton).toContain('.approve-split-menu[open]');
-    expect(toolEditStyles).toContain('@media (prefers-reduced-motion: reduce)');
-    expect(approveButton).toContain('@media (prefers-reduced-motion: reduce)');
-
     for (const source of [
-      readFileSync('src/shared/wa/splitButton.ts', 'utf8'),
+      splitButtonSource,
       readFileSync('src/shared/styles/controlStyles.ts', 'utf8'),
       toolEditStyles,
     ]) {


### PR DESCRIPTION
## Summary

Batch A of pre-verified UI fixes for the progressView webview (better-ui polish pass). Each item below was found by a review agent and independently verified against the working tree before implementation; line numbers and evidence are in the source batch file.

| # | File | Change | Why |
|---|------|--------|-----|
| 1 | `packages/extension/src/progressView/frontend/styles/groupStyles.ts` | Add `box-sizing: border-box` to `.group-dot` | Outlined skipped/cancelled dots rendered 9x9 vs. 7x7 filled dots, jittering the phase-header dot row |
| 2 | `packages/extension/src/progressView/frontend/components/StreamTab.styles.ts` | Add `transition: transform var(--transition-fast)` to `.tab-expand wa-icon` | Expand chevron snapped instead of easing, unlike every other disclosure chevron in the app |
| 3 | `packages/extension/src/progressView/frontend/components/StreamTab.styles.ts` | Add `transition: opacity var(--transition-fast)` to `.tab-delete` | Hover-revealed delete button popped in/out instantly instead of fading like the app's other hover-reveal pattern |
| 4 | `packages/extension/src/progressView/frontend/styles/toolUseStyles.ts` | `.tool-output-terminal` border-radius: `--wa-border-radius-m` -> `--border-radius-small` | Inner terminal block reused the outer card's radius despite being inset by padding (concentric-radius rule) |
| 5 | `packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts` | `.task-name--clickable:hover` decoration color -> `currentColor` | Hover underline was a neutral gray under link-blue text, producing a two-tone link |
| 6 | `packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts` | Superseded by item 7's shared fix (see Verified section) | n/a |
| 7 | `src/shared/styles/controlStyles.ts`, `ApproveSplitButton.ts`, `ToolEditRequestPanel.ts` | Add shared `wa-button-group.split-group` lift/press rule to `controlStyles.ts`; tag both split-button call sites with the `split-group` class | Native-chrome split buttons (Approve caret menu, diff-actions dropdown) carried no hover-lift/press-scale feedback, unlike every other button in the app |
| 8 | `src/shared/wa/splitButton.ts`, `ApproveSplitButton.ts`, `ToolEditRequestPanel.styles.ts`, `ToolEditRequestPanel.ts` | Extract the duplicated caret-trigger/menu CSS (verbatim in both components) into one exported `splitButtonTriggerStyles` in the shared helper; emit fixed `.split-trigger`/`.split-menu` classes alongside the prefixed ones | Two verbatim 23-line copies of the same rules could only drift; two consumers clear the single-caller-extraction bar |
| 9 | `packages/extension/src/progressView/frontend/styles/toolbarToggleStyles.ts` | Move the warning/error tint from the host to `::part(base)`, drop the host border-radius | Active toggle showed two stacked fills at mismatched radii (host warning tint vs. part-level pressed-state brand fill) |
| 10 | `packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts` | Add `kind: 'primary'` to the Retry button | Every sibling request panel gives its affirmative/accelerated action the primary skin; Retry was the only all-ghost row |
| 11 | `packages/extension/src/progressView/frontend/styles/logEntryStyles.ts` | Delete inert `border-radius: 999px` / `background: transparent` on `.workflow-task-status` | Leftover declarations from a filled-badge design that no longer exists; nothing sets a visible background |
| 12 | `packages/extension/src/progressView/frontend/components/WorktreeChip.ts` | `line-height: 1.4` -> `var(--line-height-normal)` | Hardcoded value duplicates an existing design token; every sibling reads line-height through the token |
| 13 | `packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts` | Replace hand-typed `&nbsp;·&nbsp;` with the shared `renderDotMeta` helper | Every other meta strip in the app joins parts with the shared dot-separator helper instead of hand-typed entities |
| 14 | `src/shared/styles/requestPanelSharedStyles.ts` | Armed-panel focus ring border-radius: `--border-radius-medium` -> `--border-radius` | The inset keyboard-target ring was rounder than the card it sits inside, violating the concentric-radius rule |

## Verified

- **Item 6 merged into item 7:** Item 6's proposed fix (local `.approve-split` transform rules inside `ApproveSplitButton.ts`) and item 7's proposed fix (a shared `controlStyles.ts` rule covering both `ApproveSplitButton` and `ToolEditRequestPanel`) address the same underlying gap on the same class of control. Item 7's own verified text explicitly requires "no local CSS in ... ApproveSplitButton's component styles," which supersedes item 6's local-CSS approach. Implemented item 7's shared-rule fix only; it covers item 6's case.
- `npm run typecheck` - passes (workspace, test-kernel, agent, cli, trace-viewer, desktop).
- `npm run lint` - passes, no findings.
- `npm run check:dead-code-ratchet` - passes, no new findings (the new `splitButtonTriggerStyles` export has two consumers).
- Targeted `npx vitest run` on the 10 suites importing touched files (`ApproveSplitButton`, `BackgroundTasksPanel`, `ExternalInquiryPanelTextarea`, `ProposalRequestPanel`, `RetryRequestPanel`, `TaskGroupListIndex`, `ToolEditRequestPanel`, `WorktreeChip`, `SettingsStyleContracts`, `BadgeStyleContracts`) - 78/78 tests pass. `ToolEditRequestPanel.vitest.ts`'s source-pin test was updated to assert the moved caret/reduced-motion rules live in `src/shared/wa/splitButton.ts` instead of the two now-deleted local copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmNFntsYS6WUa1buU1SD1k
