### PR TITLE
refactor(cli): collapse duplicated transcript/status rules; fix bypass-badge compaction

### DIFF
--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -172,39 +172,33 @@ export function workflowRunStatusSummary(
 ): readonly WorkflowStatusSegment[] | undefined {
   if (!slice || category !== AgentCategory.Workflow) return undefined;
   const phase = slice.taskGroups.findLast((group) => group.kind === 'phase');
-  const currentCalls = slice.entries.flatMap((row) =>
-    row.kind === 'workflowTask' ? [row.call] : [],
+  // Surface failures only once the band has a phase/progress anchor, so a
+  // stray phase-less failed call does not invent a band on its own (a
+  // phase-less run can never produce total>0, so the band would already
+  // always be undefined here). The tally is whole-run, so a failure persists
+  // after the run advances past its phase (unlike the current-phase
+  // done/total).
+  if (!phase) return undefined;
+  const callRows = slice.entries.flatMap((row) =>
+    row.kind === 'workflowTask' ? [row] : [],
   );
   const { done, total } = workflowPhaseCallProgress(
-    phase
-      ? slice.entries.flatMap((row) =>
-          row.kind === 'workflowTask' && row.groupId === phase.id
-            ? [row.call]
-            : [],
-        )
-      : [],
+    callRows.filter((row) => row.groupId === phase.id).map((row) => row.call),
   );
-  const segments: WorkflowStatusSegment[] = [];
-  if (phase) {
-    segments.push({
+  const segments: WorkflowStatusSegment[] = [
+    {
       text: formatWorkflowPhaseHeading(workflowPhaseHeadingOfGroup(phase)),
       tone: 'muted',
-    });
-  }
+    },
+  ];
   if (total > 0) {
     segments.push({ text: `${done}/${total} done`, tone: 'muted' });
   }
-  // Surface failures only once the band has a phase/progress anchor, so a
-  // stray phase-less failed call does not invent a band on its own. The tally
-  // is whole-run, so a failure persists after the run advances past its phase
-  // (unlike the current-phase done/total).
-  if (segments.length > 0) {
-    const { failed } = workflowCallFailureTally(currentCalls);
-    if (failed > 0) {
-      segments.push({ text: `${failed} failed`, tone: 'warning' });
-    }
+  const { failed } = workflowCallFailureTally(callRows.map((row) => row.call));
+  if (failed > 0) {
+    segments.push({ text: `${failed} failed`, tone: 'warning' });
   }
-  return segments.length > 0 ? segments : undefined;
+  return segments;
 }
 
 export function ConversationPane(
@@ -292,12 +286,14 @@ export function ConversationPane(
         <Box height={1} width={metadataWidth} overflowY="hidden">
           <Text wrap="truncate-end">
             {workflowMetadata.map((segment, index) => (
-              <Text
-                key={index}
-                dimColor={segment.tone === 'muted'}
-                color={segment.tone === 'warning' ? COLOR_WARNING : undefined}
-              >
-                {index > 0 ? ` · ${segment.text}` : segment.text}
+              <Text key={index}>
+                {index > 0 ? <Text dimColor>{' · '}</Text> : null}
+                <Text
+                  dimColor={segment.tone === 'muted'}
+                  color={segment.tone === 'warning' ? COLOR_WARNING : undefined}
+                >
+                  {segment.text}
+                </Text>
               </Text>
             ))}
           </Text>

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -245,26 +245,17 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
   }, []);
   const onImagePaste = useCallback(
     async (attempt: ImagePasteAttempt): Promise<string | null> => {
-      try {
-        const result = await attachClipboardImage();
-        if (!attempt.isCurrent()) return null;
-        if (!result.ok) {
-          setTransientNotice(result.reason);
-          return null;
-        }
-        return attachmentsRef.current.addPastedImage({
-          path: result.path,
-          mediaType: result.mediaType,
-          displayName: result.displayName,
-        });
-      } catch (error) {
-        if (attempt.isCurrent()) {
-          setTransientNotice(`Image paste failed: ${toErrorMessage(error)}`, {
-            ttlMs: Number.POSITIVE_INFINITY,
-          });
-        }
+      const result = await attachClipboardImage();
+      if (!attempt.isCurrent()) return null;
+      if (!result.ok) {
+        setTransientNotice(result.reason);
         return null;
       }
+      return attachmentsRef.current.addPastedImage({
+        path: result.path,
+        mediaType: result.mediaType,
+        displayName: result.displayName,
+      });
     },
     [],
   );

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -296,32 +296,15 @@ function staticTranscriptItemBaseMetrics(
 
 function staticTranscriptItemMetricsForPrevious(
   base: StaticTranscriptItemMetrics,
-  previousBase: StaticTranscriptItemMetrics | undefined,
+  previousMarginBottomRows = 0,
 ): StaticTranscriptItemMetrics {
-  const marginTopRows =
-    previousBase === undefined
-      ? base.declaredTopRows
-      : Math.max(0, base.declaredTopRows - previousBase.marginBottomRows);
+  const marginTopRows = Math.max(
+    0,
+    base.declaredTopRows - previousMarginBottomRows,
+  );
   return {
     ...base,
     rows: base.contentRows + marginTopRows + base.marginBottomRows,
-  };
-}
-
-function staticTranscriptPreviousBase(
-  previousItem: StaticTranscriptItem | undefined,
-): StaticTranscriptItemMetrics | undefined {
-  const previousEntry =
-    previousItem === undefined ? undefined : entryAbove(previousItem);
-  if (previousEntry === undefined) return undefined;
-  // Only the previous entry's bottom margin participates in collapse; laying
-  // out the whole previous item here would duplicate its layout cost.
-  return {
-    rows: 0,
-    bytes: 0,
-    contentRows: 0,
-    declaredTopRows: 0,
-    marginBottomRows: transcriptEntryMarginBottomRows(previousEntry),
   };
 }
 
@@ -333,9 +316,12 @@ function staticTranscriptItemMetrics(
 ): StaticTranscriptItemMetrics {
   const base = staticTranscriptItemBaseMetrics(item, width, executionLabels);
   if (item.kind === 'header') return base;
+  const previousEntry = entryAbove(previousItem);
   return staticTranscriptItemMetricsForPrevious(
     base,
-    staticTranscriptPreviousBase(previousItem),
+    previousEntry === undefined
+      ? 0
+      : transcriptEntryMarginBottomRows(previousEntry),
   );
 }
 
@@ -499,10 +485,7 @@ function retainedStaticTranscriptTail(
   if (firstBase === undefined) {
     return { items, totals: { rows: 0, bytes: 0 }, trimmed: false };
   }
-  const firstMetrics = staticTranscriptItemMetricsForPrevious(
-    firstBase,
-    headerBase,
-  );
+  const firstMetrics = staticTranscriptItemMetricsForPrevious(firstBase);
   let totals = {
     rows: (headerBase?.rows ?? 0) + firstMetrics.rows,
     bytes: (headerBase?.bytes ?? 0) + firstMetrics.bytes,
@@ -517,17 +500,12 @@ function retainedStaticTranscriptTail(
     const oldFirst = items[start];
     if (oldFirst === undefined) break;
     const oldFirstBase = firstBase;
-    const oldFirstBefore = staticTranscriptItemMetricsForPrevious(
-      oldFirstBase,
-      headerBase,
-    );
-    const candidateMetrics = staticTranscriptItemMetricsForPrevious(
-      candidateBase,
-      headerBase,
-    );
+    const oldFirstBefore = staticTranscriptItemMetricsForPrevious(oldFirstBase);
+    const candidateMetrics =
+      staticTranscriptItemMetricsForPrevious(candidateBase);
     const oldFirstAfter = staticTranscriptItemMetricsForPrevious(
       oldFirstBase,
-      candidateBase,
+      candidateBase.marginBottomRows,
     );
     totals = {
       rows:
@@ -615,16 +593,13 @@ function staticTranscriptItemsEquivalent(
 }
 
 function shouldWaitForChildIdentity({
-  hasHeader,
   parentStream,
   scrollbackStreamId,
 }: {
-  readonly hasHeader: boolean;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly scrollbackStreamId: StreamTabId | undefined;
 }): boolean {
   return (
-    !hasHeader &&
     scrollbackStreamId !== undefined &&
     parentStream.has(scrollbackStreamId) &&
     !streamMetadataFor(scrollbackStreamId)?.config?.model
@@ -661,12 +636,11 @@ function ensureStaticSessionHeader({
   readonly byteCount: number;
   readonly inserted: boolean;
 } {
-  if (items.some((item) => item.id === SESSION_HEADER_ID)) {
+  if (items[0]?.id === SESSION_HEADER_ID) {
     return { items, rowCount, byteCount, inserted: false };
   }
   if (
     shouldWaitForChildIdentity({
-      hasHeader: false,
       parentStream,
       scrollbackStreamId,
     })
@@ -692,7 +666,7 @@ function ensureStaticSessionHeader({
     width,
     executionLabels,
   );
-  const firstItem = items.find((item) => item.kind !== 'header');
+  const firstItem = items[0];
   let nextRowCount: number;
   let nextByteCount: number;
   if (firstItem === undefined) {
@@ -726,13 +700,7 @@ function ensureStaticSessionHeader({
     return { items, rowCount, byteCount, inserted: false };
   }
 
-  const firstEntryIndex = items.findIndex((item) => item.kind !== 'header');
-  const nextItems = [...items];
-  nextItems.splice(
-    firstEntryIndex < 0 ? nextItems.length : firstEntryIndex,
-    0,
-    header,
-  );
+  const nextItems = [header, ...items];
   return {
     items: nextItems,
     rowCount: nextRowCount,
@@ -789,7 +757,6 @@ export function buildStaticTranscriptItems(
   // still pending when the model arrives.
   if (
     shouldWaitForChildIdentity({
-      hasHeader: false,
       parentStream,
       scrollbackStreamId,
     })
@@ -955,7 +922,6 @@ export function buildStaticTranscriptState({
   // pending when the model arrives; scanning them now would mark them
   // consumed and drop them later.
   const waitingForChildIdentity = shouldWaitForChildIdentity({
-    hasHeader: false,
     parentStream,
     scrollbackStreamId,
   });
@@ -1080,8 +1046,8 @@ export function advanceStaticTranscriptState(
   }
 
   if (
+    !current.items.some((item) => item.id === SESSION_HEADER_ID) &&
     shouldWaitForChildIdentity({
-      hasHeader: current.items.some((item) => item.id === SESSION_HEADER_ID),
       parentStream,
       scrollbackStreamId,
     })

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -322,9 +322,10 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     width: columns,
     ctrlCAction: target.ctrlCAction,
     isChildStream: target.isChildStream,
-    location: focusedPhaseHeading
-      ? `${focusedPhaseHeading} › ${focusedLabel}`
-      : focusedLabel,
+    location:
+      focusedLabel === undefined
+        ? undefined
+        : { context: focusedPhaseHeading, label: focusedLabel },
     foreground: {
       inputActive: props.foregroundInputActive,
       escapeAction: props.foregroundEscapeAction,

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -76,7 +76,7 @@ function PlainEntryRows({
   // Workflow-call rows carry the same status color as their layout marker, so
   // the six statuses stay distinguishable at a glance.
   let rowColor: string | undefined;
-  if (entry.kind === 'error') {
+  if (entry.kind === 'error' && colorEnabled !== false) {
     rowColor = COLOR_ERROR;
   } else if (entry.kind === 'compactionActivity' && colorEnabled !== false) {
     rowColor = COMPACTION_ACTIVITY_STATUS_STYLE[entry.block.status].color;

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -136,7 +136,7 @@ export interface StatusBarDisplayInput {
   readonly isChildStream?: boolean;
   /** Nested-session location (`Survey (1/1) › Agent runtime`). Omitted on
    *  the root session, where the header already names the conversation. */
-  readonly location?: string;
+  readonly location?: { readonly context?: string; readonly label: string };
   /** Which surface currently owns input and global chat shortcuts: a
    *  foreground surface (approval, detail, form, slash palette, reverse
    *  search) or the persistent child list. Neither active means the normal
@@ -276,13 +276,15 @@ function formatUsage(
 // One status-bar slot carries whichever stage this stream has (mirrors the
 // SubagentList row's `stageLabel`).
 function locationSegment(
-  location: string | undefined,
+  location: { readonly context?: string; readonly label: string } | undefined,
 ): StatusBarSegment | undefined {
   if (!location) return undefined;
-  const separator = location.indexOf(' › ');
+  const text = location.context
+    ? `${location.context} › ${location.label}`
+    : location.label;
   return {
-    text: location,
-    compactText: separator >= 0 ? location.slice(0, separator) : location,
+    text,
+    compactText: location.context ?? location.label,
     color: 'dim',
     compactPriority: STATUS_BAR_COMPACT_PRIORITY.location,
   };
@@ -443,6 +445,12 @@ function fitTransientNoticeStatusBarLeftSegments(
     livenessIndex === undefined ? undefined : fitted[livenessIndex];
   const discardWarning =
     discardWarningIndex === undefined ? undefined : fitted[discardWarningIndex];
+  // Bypass badges announce active auto-approval and must not be silently
+  // dropped by the trailing-removal sweep below (see
+  // STATUS_BAR_COMPACT_PRIORITY.bypassBadge) — they are exempt here the same
+  // way discardWarning is, and only give way to the final fallback sweep.
+  const isBypassBadge = (segment: StatusBarSegment): boolean =>
+    segment.compactPriority === STATUS_BAR_COMPACT_PRIORITY.bypassBadge;
 
   // Compact liveness before removing content. In particular, the queued-input
   // discard warning is safety-critical and must not be displaced by the wider
@@ -453,10 +461,14 @@ function fitTransientNoticeStatusBarLeftSegments(
     fitted[index] = liveness;
   }
 
-  // Remove trailing segments after the notice (excluding the discard warning).
+  // Remove trailing segments after the notice (excluding the discard warning
+  // and bypass badges).
   while (statusBarSegmentsWidth(fitted) > innerWidth) {
     const removableIndex = fitted.findLastIndex(
-      (segment, index) => index > noticeIndex && segment !== discardWarning,
+      (segment, index) =>
+        index > noticeIndex &&
+        segment !== discardWarning &&
+        !isBypassBadge(segment),
     );
     if (removableIndex < 0) break;
     fitted.splice(removableIndex, 1);
@@ -510,6 +522,17 @@ function fitTransientNoticeStatusBarLeftSegments(
       discardWarning,
       innerWidth,
     );
+  }
+
+  // Last resort: a bypass badge wider than innerWidth is unfittable above and
+  // would soft-wrap the row, breaking the 2-row chrome budget. Sacrifice
+  // badges from the tail — mirroring how liveness is sacrificed above — only
+  // while the row still overflows.
+  while (statusBarSegmentsWidth(fitted) > innerWidth) {
+    const badgeIndex = fitted.findLastIndex(isBypassBadge);
+    if (badgeIndex < 0) break;
+    fitted.splice(badgeIndex, 1);
+    fitNotice();
   }
 
   return fitted;
@@ -771,21 +794,6 @@ function childListBindingsText(
   );
 }
 
-function ctrlCActionForFocus({
-  activeStreamId,
-  canStopActiveRun,
-  parentStream,
-}: {
-  readonly activeStreamId: StreamTabId | undefined;
-  readonly canStopActiveRun: boolean;
-  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
-}): CtrlCAction {
-  if (!canStopActiveRun) return 'exit';
-  return activeStreamScope({ activeStreamId, parentStream }).kind === 'child'
-    ? 'stop root'
-    : 'stop';
-}
-
 function rootActiveSegment(
   input: StatusBarDisplayInput,
 ): StatusBarSegment | undefined {
@@ -873,12 +881,17 @@ export function statusBarStreamTarget({
     canStopActiveRun &&
     (canStopPendingRunWithoutStream || hasPendingOrLiveStream);
   const displayStreamId = activeSlice ? activeStreamId : liveAncestor?.streamId;
+  let ctrlCAction: CtrlCAction;
+  if (!canStopVisibleRun) {
+    ctrlCAction = 'exit';
+  } else {
+    ctrlCAction =
+      activeStreamScope({ activeStreamId, parentStream }).kind === 'child'
+        ? 'stop root'
+        : 'stop';
+  }
   return {
-    ctrlCAction: ctrlCActionForFocus({
-      activeStreamId,
-      canStopActiveRun: canStopVisibleRun,
-      parentStream,
-    }),
+    ctrlCAction,
     displaySlice: activeSlice ?? liveAncestor?.value,
     displayStreamId,
     isChildStream:
@@ -940,11 +953,22 @@ function resolveStatusBarBindings(input: StatusBarDisplayInput): string {
   return statusBarBindingsText(input.shortcuts, ctrlCAction, maxColumns);
 }
 
-function buildStatusSegments(input: StatusBarDisplayInput): {
-  segments: StatusBarSegment[];
-  transientLivenessIndex?: number;
-} {
-  const segments: StatusBarSegment[] = [];
+export function buildStatusBarDisplay(
+  input: StatusBarDisplayInput,
+): StatusBarDisplay {
+  const left: StatusBarSegment[] = [
+    { text: STATUS_DIAMOND, color: COLOR_HINT, decorative: true },
+  ];
+  if (input.transcriptMode === 'ephemeral') {
+    left.push({
+      text: 'EPHEMERAL TRANSCRIPT',
+      compactText: 'EPHEMERAL',
+      badge: true,
+      badgeColor: COLOR_WARNING,
+      compactPriority: STATUS_BAR_COMPACT_PRIORITY.ephemeralBadge,
+    });
+  }
+
   const statusLabel = formatCliStatusLabel(
     input.status,
     input.substate,
@@ -964,8 +988,8 @@ function buildStatusSegments(input: StatusBarDisplayInput): {
         input.elapsedMs === undefined
           ? ''
           : ` ${formatCompactDuration(input.elapsedMs)}`;
-      transientLivenessIndex = segments.length;
-      segments.push({
+      transientLivenessIndex = left.length;
+      left.push({
         text: `${spinPrefix}${statusLabel}${elapsed}`,
         compactText:
           input.elapsedMs === undefined
@@ -975,12 +999,12 @@ function buildStatusSegments(input: StatusBarDisplayInput): {
       });
     }
   } else {
-    segments.push({
+    left.push({
       text: `${spinPrefix}${statusLabel}`,
       color: 'dim',
     });
     if (isActivePhase(input.status) && input.elapsedMs !== undefined) {
-      segments.push({
+      left.push({
         text: formatCompactDuration(input.elapsedMs),
         color: 'dim',
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.elapsed,
@@ -991,44 +1015,18 @@ function buildStatusSegments(input: StatusBarDisplayInput): {
   // painting them yellow trains the eye to ignore the color that also
   // announces auto-approval bypasses and quota exhaustion.
   if (input.compactingActive === true && isActivePhase(input.status)) {
-    segments.push({
+    left.push({
       text: 'compacting...',
       color: 'dim',
       compactPriority: STATUS_BAR_COMPACT_PRIORITY.compacting,
     });
   } else if (input.thinkingActive === true && isActivePhase(input.status)) {
-    segments.push({
+    left.push({
       text: 'thinking...',
       color: 'dim',
       compactPriority: STATUS_BAR_COMPACT_PRIORITY.thinking,
     });
   }
-  return { segments, transientLivenessIndex };
-}
-
-export function buildStatusBarDisplay(
-  input: StatusBarDisplayInput,
-): StatusBarDisplay {
-  const left: StatusBarSegment[] = [
-    { text: STATUS_DIAMOND, color: COLOR_HINT, decorative: true },
-  ];
-  if (input.transcriptMode === 'ephemeral') {
-    left.push({
-      text: 'EPHEMERAL TRANSCRIPT',
-      compactText: 'EPHEMERAL',
-      badge: true,
-      badgeColor: COLOR_WARNING,
-      compactPriority: STATUS_BAR_COMPACT_PRIORITY.ephemeralBadge,
-    });
-  }
-
-  const { segments: statusSegs, transientLivenessIndex: statusLivenessIndex } =
-    buildStatusSegments(input);
-  const transientLivenessIndex =
-    statusLivenessIndex === undefined
-      ? undefined
-      : left.length + statusLivenessIndex;
-  left.push(...statusSegs);
 
   let transientNoticeIndex: number | undefined;
   let discardWarningIndex: number | undefined;

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -225,6 +225,27 @@ function compareTranscriptOrderKeys(
 }
 
 /**
+ * Candidates already in settlement order, else stably sorted into it. Used
+ * identically by the append-only scan and its rebuild oracle so the two
+ * paths can never disagree on scrollback order.
+ */
+function inSettlementOrder<
+  T extends {
+    readonly index: number;
+    readonly key: readonly [number, number];
+  },
+>(items: readonly T[]): readonly T[] {
+  return items.every(
+    (c, i) =>
+      i === 0 || compareTranscriptOrderKeys(items[i - 1]!.key, c.key) <= 0,
+  )
+    ? items
+    : items.toSorted(
+        (l, r) => compareTranscriptOrderKeys(l.key, r.key) || l.index - r.index,
+      );
+}
+
+/**
  * Printable rows in their append-only scrollback order.
  *
  * Source-backed rows use the durable order in which they became immutable.
@@ -256,18 +277,7 @@ export function orderedStaticTranscriptEntries(
     candidates.push({ entry, index, key: transcriptOrderKey(entry, index) });
   }
 
-  const alreadyOrdered = candidates.every(
-    (candidate, i) =>
-      i === 0 ||
-      compareTranscriptOrderKeys(candidates[i - 1]!.key, candidate.key) <= 0,
-  );
-  const ordered = alreadyOrdered
-    ? candidates
-    : candidates.toSorted(
-        (left, right) =>
-          compareTranscriptOrderKeys(left.key, right.key) ||
-          left.index - right.index,
-      );
+  const ordered = inSettlementOrder(candidates);
 
   return ordered.map(({ entry }) => entry);
 }
@@ -381,10 +391,6 @@ function makeStaticTranscriptScanCursor(
  * {@link orderedStaticTranscriptEntries} (the full rebuild path), this walks
  * only the suffix after `previous.scannedIndex`, so ordinary stream-sync ticks
  * cost O(delta) instead of O(history).
- *
- * The suffix is exact: `hasLaterRenderable` is computed backward over just
- * the suffix, which is all that is needed to resolve the live-user-prompt
- * deferral rule (`userPromptAwaitsLiveContinuation`).
  */
 export function incrementalStaticTranscriptEntries(
   entries: readonly TranscriptRow[] | undefined,
@@ -425,15 +431,6 @@ export function incrementalStaticTranscriptEntries(
 
   const start = previous.scannedIndex;
   const suffix = source.slice(start);
-  const hasLaterRenderable = new Array<boolean>(suffix.length);
-  let laterRenderable = false;
-  for (let index = suffix.length - 1; index >= 0; index -= 1) {
-    hasLaterRenderable[index] = laterRenderable;
-    const entry = suffix[index]!;
-    if (isRenderableTranscriptEntry(entry)) {
-      laterRenderable = true;
-    }
-  }
 
   const appended: Array<{
     entry: TranscriptRow;
@@ -450,12 +447,9 @@ export function incrementalStaticTranscriptEntries(
       scannedIndex = start + index + 1;
       continue;
     }
-    const defersLiveUserPrompt =
-      isActivePhase(status) &&
-      entry.kind === 'user' &&
-      !isInquiryContinuationText(transcriptRowHeadline(entry)) &&
-      !hasLaterRenderable[index];
-    if (defersLiveUserPrompt) break;
+    if (userPromptAwaitsLiveContinuation(source, start + index, status)) {
+      break;
+    }
     scannedIndex = start + index + 1;
     appended.push({
       entry,
@@ -469,18 +463,7 @@ export function incrementalStaticTranscriptEntries(
   // covers a reorder inside one tick; a suffix whose first row belongs before
   // rows an earlier tick already printed cannot be appended at all, so it
   // falls back to the oracle rebuild (a known-origin repaint).
-  const alreadyOrdered = appended.every(
-    (candidate, i) =>
-      i === 0 ||
-      compareTranscriptOrderKeys(appended[i - 1]!.key, candidate.key) <= 0,
-  );
-  const ordered = alreadyOrdered
-    ? appended
-    : appended.toSorted(
-        (left, right) =>
-          compareTranscriptOrderKeys(left.key, right.key) ||
-          left.index - right.index,
-      );
+  const ordered = inSettlementOrder(appended);
 
   const first = ordered[0];
   if (

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -261,7 +261,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         isChildStream: true,
-        location: 'Survey (1/1) › Agent runtime',
+        location: { context: 'Survey (1/1)', label: 'Agent runtime' },
         width: 80,
       }),
     );


### PR DESCRIPTION
## Summary

Batch C: 15 adversarially-verified consolidation cuts (2 duplicate pairs implemented once each) across the CLI TUI's transcript and status-bar panes. Behavior-preserving except two named defect fixes.

| # | File | Change | Why |
|---|------|--------|-----|
| 1 + 4 | `transcriptEntries.ts` | One module-private `inSettlementOrder` helper replaces the byte-identical 12-line settlement-order block that was hand-duplicated in `orderedStaticTranscriptEntries` and `incrementalStaticTranscriptEntries` | Two spellings of one ordering rule invite exactly the class of drift the fallback-to-oracle machinery exists to prevent; one definition makes the append-path/rebuild-oracle order invariant structural |
| 2 + 3 | `transcriptEntries.ts` | `incrementalStaticTranscriptEntries` now calls `userPromptAwaitsLiveContinuation` directly instead of re-deriving the same four-clause rule inline; deletes the 9-line `hasLaterRenderable` backward-pass precompute and the now-stale doc paragraph | Two encodings of the rule that decides whether a user prompt may enter append-only scrollback risk silent disagreement between the incremental path and the rebuild oracle |
| 5 | `TranscriptEntry.tsx` | Error rows now gate `rowColor = COLOR_ERROR` on `colorEnabled !== false`, matching the `compactionActivity`/`workflowTask`/`inverse` siblings (**behavior fix**) | The error branch predated the color-gating vocabulary and was never revisited; `NO_COLOR` terminals keep the `! ` prefix cue regardless, so nothing is lost |
| 6 | `statusBarDisplay.ts` | Bypass badges are exempt from the transient-notice trailing-removal sweep (`isBypassBadge` check), with a required bounded fallback sweep after the discard-warning pass so an unfittable badge can't soft-wrap the row (**behavior fix**) | The notice path previously dropped the auto-approval badge *first* on overflow, contradicting the file's own priority-ladder comment and the non-notice path, which drops it *last*; sticky (`ttlMs: Infinity`) notices could hide active bypass indefinitely |
| 7 | `statusBarDisplay.ts` + `StatusBar.tsx` | `location` becomes a structured `{ context?, label }` object composed once in `locationSegment` instead of a `' › '`-joined string that `statusBarDisplay.ts` re-parses by `indexOf` | Removes a stringly two-file contract; a label containing `' › '` would previously mis-compact |
| 8 | `statusBarDisplay.ts` | Inlined the single-caller `ctrlCActionForFocus` wrapper into `statusBarStreamTarget` | Banned single-caller extraction, left behind after #11548 un-exported its last independent consumer |
| 9 | `statusBarDisplay.ts` | Inlined `buildStatusSegments` into `buildStatusBarDisplay`, pushing directly onto `left` and recording `transientLivenessIndex` at the actual push (matching the sibling notice/discard-warning indices) | The extraction's only effect was an index in a private coordinate system the caller had to re-base |
| 10 | `ConversationPane.tsx` | `workflowRunStatusSummary` now early-returns when there's no phase anchor and walks `slice.entries` once instead of twice | Removes a redundant `flatMap` pass and the dead-computation path on phase-less runs, where the band always rendered nothing |
| 11 | `ConversationPane.tsx` | The workflow status band's `' · '` separator now renders as its own neutral dim fragment instead of inheriting the tone of the segment it precedes | Separators are chrome, not content; a warning-toned dot enlarged the alarm area beyond the fact being alarmed about |
| 12 | `StaticConversationTranscript.tsx` | Deleted `staticTranscriptPreviousBase` (a fabricated full-metrics object built to carry one number); `staticTranscriptItemMetricsForPrevious` now takes `previousMarginBottomRows` directly | The fake-metrics adapter was pure ceremony around "subtract the previous entry's bottom margin"; passing `headerBase` as "previous" was a provable no-op since header margin is always 0 |
| 13 | `StaticConversationTranscript.tsx` | `ensureStaticSessionHeader` now uses the index-0 header invariant (`items[0]?.id === SESSION_HEADER_ID`, `items[0]`, `[header, ...items]`) instead of `some()`/`find()`/`findIndex+splice` scans | The rest of the file (`trimStaticTranscriptItems`, `retainedStaticTranscriptTail`) already assumes a header, when present, is always item 0 |
| 14 | `StaticConversationTranscript.tsx` | Dropped the `hasHeader` parameter from `shouldWaitForChildIdentity`, which was a compile-time constant (`false`) at 3 of its 4 call sites | A parameter that's constant at most call sites forces every reader to re-derive that it only matters once; the remaining caller folds its own `.some()` check inline, kept verbatim |
| 15 | `InputBar.tsx` | Removed the local `try/catch` around `onImagePaste`'s body, which duplicated the `onImagePasteError` prop's notice text and guard | `BaseTextInput` is the designed single owner of paste-rejection handling; the local catch was a shadow copy that could only drift |

## Verified

- `npm run typecheck` — clean across workspace, test-kernel, agent, cli, trace-viewer, desktop.
- `npm run lint` — clean (fixed one `no-nested-ternary` from the Item 8 inline by using an `if`/`else` instead).
- `npm run check:dead-code-ratchet` — no new findings (371 baselined, matches).
- Targeted tests (grepped `src/test-kernel/cli` for suites importing the touched modules, not the full suite): `ConversationTranscript`, `InputBar`, `SlashCommandDispatch`, `SlashRegistry`, `StatusBar`, `StreamLogDeltaFold`, `SubagentListDisplay`, `SubscribeStreamLogDispose`, `TuiStateAndFocus`, `WorkflowRunDetails`, `WorkflowScriptStreamTranscript`, `StaticBandResize`, `CliPersistenceFlush`, `History`, `ToolRenderers` — **616/616 passed**. One existing fixture (`StatusBar.vitest.ts`) updated to the new structured `location` shape (Item 7's only non-production caller).
- No headless/`--print`/`texra run` code paths touch these files (they're TUI-only Ink panes and display-model builders); headless output is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmNFntsYS6WUa1buU1SD1k