### PR TITLE
Reduce data-structure duplication from complexity audit

### DIFF
--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -10,7 +10,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import type {
   ConversationProgress,
-  GoalStatus,
+  GoalState,
   StreamStage,
   StreamState,
   StreamTabInfo,
@@ -422,9 +422,11 @@ export class StreamHeader extends UnsupportedCommandsMixin(LitElement) {
       superYolo: Boolean(toolUse?.superYoloBypass),
       toolEdit: Boolean(toolUse?.toolEditBypass),
     };
-    const goalActive = Boolean(toolUse?.goalActive);
-    const goalStatus = toolUse?.goalStatus;
-    const goalObjective = toolUse?.goalObjective ?? '';
+    const goal = deriveGoalState({
+      goalActive: toolUse?.goalActive,
+      goalStatus: toolUse?.goalStatus,
+      goalObjective: toolUse?.goalObjective,
+    });
     const hasExecutionId = Boolean(this.stream.executionId);
     const identity = this.stream.identity;
     const isNativeAgentRun = isPlainAgentIdentity(identity);
@@ -546,7 +548,7 @@ export class StreamHeader extends UnsupportedCommandsMixin(LitElement) {
             ${streamStatusTooltip(state, statusLabel)}
           </wa-tooltip>
           ${this.renderRunElapsed(state?.runStartedAt)}
-          ${this.renderGoalChip(goalActive, goalStatus, goalObjective)}
+          ${this.renderGoalChip(goal)}
           ${this.renderProgressBadge(progress, stage)}
         </div>
         <div class="header-actions">
@@ -591,20 +593,7 @@ export class StreamHeader extends UnsupportedCommandsMixin(LitElement) {
     return { disabled, hidden };
   }
 
-  private renderGoalChip(
-    goalActive: boolean,
-    goalStatus: GoalStatus | undefined,
-    goalObjective: string,
-  ): TemplateResult | typeof nothing {
-    // `goalActive`/`goalStatus`/`goalObjective` are three independently-set
-    // state fields (mirroring the wire/storage shape) — derive the canonical
-    // "status/objective only meaningful when active" union once here rather
-    // than guarding ad hoc.
-    const goal = deriveGoalState({
-      goalActive,
-      goalStatus,
-      goalObjective: goalObjective || undefined,
-    });
+  private renderGoalChip(goal: GoalState): TemplateResult | typeof nothing {
     if (!goal.active) return nothing;
     const isPaused = goal.status === 'paused';
     const label = isPaused ? 'Goal paused' : 'Goal';

--- a/packages/extension/src/progressView/frontend/slices/syncSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/syncSlice.ts
@@ -44,7 +44,7 @@ export const syncHandlers = {
       // `controls.goal` already matches GoalStateSchema (the wire schema
       // imports it directly from `@shared/schemas/goal`) — no need to
       // round-trip it through deriveGoalState.
-      const goal = controls.goal;
+      const { goal, ...bypasses } = controls;
       updateToolUseState(data.stream, (prev) => ({
         ...prev,
         ...activeStateFields(data),
@@ -52,9 +52,7 @@ export const syncHandlers = {
         todos: workPlan.todos,
         plan: workPlan.plan,
         queuedFollowUps: workPlan.queuedFollowUps,
-        bashBypass: controls.bashBypass,
-        toolEditBypass: controls.toolEditBypass,
-        superYoloBypass: controls.superYoloBypass,
+        ...bypasses,
         ...goalToStateFields(goal),
       }));
     }

--- a/src/agent/implementations/flows/tooluse/toolUseRound/ToolUseProcessNode.ts
+++ b/src/agent/implementations/flows/tooluse/toolUseRound/ToolUseProcessNode.ts
@@ -4,11 +4,13 @@ import { logWebFetch, logWebSearch } from '@agent/trace';
 import { recordCycleMetrics } from '@agent/core/state/AgentState';
 import { extractModelResponse } from '@agent/core/flows/CommonCycleTypes';
 import { appendFollowUpAsUserMessage } from '@agent/followUp/followUpMessages';
+import { isFunctionCallOutputItem } from '@agent/modelHandlers/openai/responsesShapeGuards';
 import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import type { ServerToolContentBlock } from '@agent/types/ServerTools';
 import type { ProviderStopReason } from '@agent/types/StopReasonTypes';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
+import { classifyProviderMessageBlockType } from '@agent/types/ConversationBlockTypes';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
 import { MESSAGE_TYPES } from '@shared/schemas';
@@ -28,7 +30,11 @@ function hasToolResultContent(value: unknown): boolean {
     value.some((item) => {
       if (!isObject(item)) return false;
       return (
-        item.type === 'tool_result' ||
+        // Anthropic/Google Content `type: 'tool_result'` blocks share the
+        // canonical classifier with the export/storage formatters; VS Code
+        // LM's `kind` discriminant and Google's legacy `functionResponse`
+        // shape have no SSOT classifier to delegate to yet.
+        classifyProviderMessageBlockType(item.type) === 'tool-result' ||
         item.kind === 'toolResult' ||
         isObject(item.functionResponse)
       );
@@ -41,7 +47,7 @@ function isToolResultMessage(message: ProviderMessage | undefined): boolean {
   const record: Record<string, unknown> = message;
 
   return (
-    record['type'] === 'function_call_output' ||
+    isFunctionCallOutputItem(record) ||
     record['type'] === 'function_result' ||
     record['role'] === 'tool' ||
     (record['role'] === 'user' &&

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -430,9 +430,14 @@ function toOpenAISchemaObject(def: ToolDefinition): Record<string, unknown> {
   return toObjectParametersSchema(convertToolSchema(def), 'OpenAI');
 }
 
+// The base `Tool` (custom function tool) member of `ToolUnion` carries no
+// `type` field at all, so `ToolUnion['type']` doesn't type-check directly —
+// `Extract` narrows to the native-tool members first.
+type AnthropicNativeToolType = Extract<ToolUnion, { type: string }>['type'];
+
 // Map local tool names to Anthropic remote tool types.
 // The custom `memory` tool (with pin/unpin) is sent as a regular function tool.
-const ANTHROPIC_TOOL_TYPE_MAP: Record<string, string> = {
+const ANTHROPIC_TOOL_TYPE_MAP: Record<string, AnthropicNativeToolType> = {
   bash: 'bash_20250124',
   web_search: 'web_search_20260209',
   web_fetch: 'web_fetch_20260209',

--- a/src/controllers/progressView/backend/LitSessionRenderer.ts
+++ b/src/controllers/progressView/backend/LitSessionRenderer.ts
@@ -357,19 +357,7 @@ export class LitSessionRenderer implements SessionRendererPort {
         };
       },
       get controls() {
-        const controls = getStreamControls(stream);
-        return {
-          bashBypass: controls.bashBypass,
-          toolEditBypass: controls.toolEditBypass,
-          superYoloBypass: controls.superYoloBypass,
-          goal: controls.goalActive
-            ? {
-                active: true as const,
-                status: controls.goalStatus,
-                objective: controls.goalObjective,
-              }
-            : { active: false as const },
-        };
+        return getStreamControls(stream);
       },
     });
   }

--- a/src/controllers/progressView/progressStreamControls.ts
+++ b/src/controllers/progressView/progressStreamControls.ts
@@ -1,5 +1,5 @@
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
-import type { GoalStatus, StreamTabId } from '@shared/schemas';
+import type { GoalState, StreamTabId } from '@shared/schemas';
 import {
   isApprovalBypassedForStream,
   isBashApprovalBypassedForStream,
@@ -10,19 +10,18 @@ import { GoalStore } from '@tools/goal';
 /**
  * Per-stream control flags pushed to the progress view: approval bypass state
  * plus the goal chip state. A progress-view domain concept, owned here next to
- * the producer rather than inside the Lit renderer.
+ * the producer rather than inside the Lit renderer. `goal` is the same
+ * canonical {@link GoalState} the wire projection (`ControlsSectionSchema`)
+ * and `deriveGoalState` use, so the one production consumer
+ * (`LitSessionRenderer`) can forward this return value as-is instead of
+ * re-flattening and re-deriving it.
  */
-interface ProgressStreamBypassControls {
+interface ProgressStreamControls {
   bashBypass: boolean;
   toolEditBypass: boolean;
   superYoloBypass: boolean;
+  goal: GoalState;
 }
-
-type ProgressStreamControls = ProgressStreamBypassControls &
-  (
-    | { goalActive: false }
-    | { goalActive: true; goalStatus: GoalStatus; goalObjective: string }
-  );
 
 export type GetProgressStreamControls = (
   stream: StreamTabId,
@@ -33,18 +32,12 @@ export function getProgressStreamControls(
   session?: SessionHandle,
 ): ProgressStreamControls {
   const goal = GoalStore.getForStream(streamId);
-  const bypasses = {
+  return {
     bashBypass: isBashApprovalBypassedForStream(streamId, session),
     toolEditBypass: isApprovalBypassedForStream(streamId, session),
     superYoloBypass: proposalApprovals(session).isBypassed(streamId),
-  };
-  if (!goal) {
-    return { ...bypasses, goalActive: false };
-  }
-  return {
-    ...bypasses,
-    goalActive: true,
-    goalStatus: goal.status,
-    goalObjective: goal.objective,
+    goal: goal
+      ? { active: true, status: goal.status, objective: goal.objective }
+      : { active: false },
   };
 }

--- a/src/shared/schemas/codex.ts
+++ b/src/shared/schemas/codex.ts
@@ -33,9 +33,9 @@ export type CodexFileChangeToolInput = z.infer<
 >;
 
 export const CodexMcpToolOutputSchema = z.object({
-  status: z.string().optional(),
-  structuredContent: z.unknown().optional(),
-  contentBlocks: z.array(z.record(z.string(), z.unknown())).optional(),
+  status: z.string().nullish(),
+  structuredContent: z.unknown().nullish(),
+  contentBlocks: z.array(z.record(z.string(), z.unknown())).nullish(),
 });
 
 export type CodexMcpToolOutput = z.infer<typeof CodexMcpToolOutputSchema>;

--- a/src/test-kernel/progressView/StreamContentSync.vitest.ts
+++ b/src/test-kernel/progressView/StreamContentSync.vitest.ts
@@ -92,7 +92,7 @@ async function createSyncHarness(
     bashBypass: false,
     toolEditBypass: false,
     superYoloBypass: false,
-    goalActive: false,
+    goal: { active: false },
   }),
 ): Promise<SyncHarness> {
   const state = new SessionState();
@@ -281,9 +281,11 @@ describe('progress view stream-content projection', () => {
           bashBypass: true,
           toolEditBypass: true,
           superYoloBypass: true,
-          goalActive: true,
-          goalStatus: 'active',
-          goalObjective: 'Keep making progress.',
+          goal: {
+            active: true,
+            status: 'active',
+            objective: 'Keep making progress.',
+          },
         };
       },
     );

--- a/src/test-kernel/progressView/progressBackendHarness.ts
+++ b/src/test-kernel/progressView/progressBackendHarness.ts
@@ -68,7 +68,7 @@ export const stubStreamControls: GetProgressStreamControls = () => ({
   bashBypass: false,
   toolEditBypass: false,
   superYoloBypass: false,
-  goalActive: false,
+  goal: { active: false },
 });
 
 export function toolUseConfig(agent: string, model: string): AgentConfig {


### PR DESCRIPTION
## Summary

A scheduled data-structure complexity review flagged several places where a fact was re-derived or re-flattened instead of reusing an existing single source of truth. This PR fixes the findings that had a real, low-risk fix; it documents (rather than forces) the ones where the "simplification" would have been net-negative.

Fixed:
- **`ToolUseProcessNode`'s tool-result detection** duck-typed six shape checks inline instead of using the existing canonical guards (`isFunctionCallOutputItem`, `classifyProviderMessageBlockType`). Now delegates to them for the two checks that were genuine duplicates; the VS Code LM `kind` and legacy Google `functionResponse` checks have no existing SSOT to delegate to and are left as-is.
- **`StreamHeader`** flattened `deriveGoalState`'s result into three primitives, then re-derived the union *inside* `renderGoalChip` from those primitives. Now calls `deriveGoalState` once in `render()` and threads the resulting `GoalState` through.
- **`toAnthropicTools`'s native-tool-type map** was `Record<string, string>`, so a typo'd tool-type literal wouldn't be caught until runtime. Retyped against `Extract<ToolUnion, {type: string}>['type']` (the SDK's own tool-type literals) so an invalid value fails at compile time. `ToolUnion['type']` doesn't work directly because the base `Tool` member carries no `type` field at all.
- **`getProgressStreamControls`** returned a flattened `{goalActive, goalStatus?, goalObjective?}` shape; its one production consumer (`LitSessionRenderer`) immediately re-normalized that back into the canonical `GoalState` union. It now returns `goal: GoalState` directly, collapsing `LitSessionRenderer`'s `controls` getter to a plain passthrough. `syncSlice` now spreads the bypass triad via rest-destructure instead of listing all three fields, so a future bypass kind added to the wire schema reaches the frontend state without a matching edit here.
- **`codex.ts`**'s `CodexMcpToolOutputSchema` mixed `.optional()` and `.nullish()` within one file that otherwise standardizes on `.nullish()` for external Codex tool-log data. Normalized to `.nullish()` (a strict widen — every consumer already used `typeof`/`Array.isArray`/`in` checks that treat `null` the same as `undefined`).

Declined (investigated, no change — documented so the same finding isn't re-raised):
- Routing `ToolUseCycleNode`/`ToolUseWaitNode`/`runToolUseFlow` through the existing `PreparedShared` type more consistently: most of the flagged `stateSlices` null checks reflect a genuine pre-init window (flow init, the persistence projection callback, early-cancellation exit), not duplicated defensive machinery — forcing non-null there would be incorrect, not simpler.
- `ToolDashboardItem`'s 16-field schema as a discriminated union on `requiresSetup`: its one consumer (`ToolCard.ts`) already reads each optional field independently across ~15 render-helper methods with its own truthy check; a discriminated union would need to re-narrow `requiresSetup` at every one of those methods for no behavior change.
- Collapsing `openAIMessageUtils.ts`'s content-union narrowing into shared `toContentParts`/`fromContentParts` helpers: only 4 of the 6 cited functions actually narrow an existing union, and each has a genuinely different output-shape contract (string-stays-string vs. always-promote-to-array vs. always-collapse-to-string) — unifying them risks a wire-format regression for no real reduction in branching.

## Issue acceptance gates

No linked issue — this is a proactive fix from a scheduled codebase audit, not tracked against a filed issue.

## Single source of truth

- `GoalState` (`@shared/schemas/goal`) is now the one shape carried end-to-end from `getProgressStreamControls` through the wire projection to `StreamHeader`, instead of being flattened and re-derived at two of those three hops.
- `isFunctionCallOutputItem` / `classifyProviderMessageBlockType` are now also the source of truth for the two provider-message shape checks in `ToolUseProcessNode` that duplicated them.
- `Extract<ToolUnion, {type: string}>['type']` makes the Anthropic SDK's own tool-type union the source of truth for `ANTHROPIC_TOOL_TYPE_MAP`'s valid values, instead of a bare `string`.

## Duplication and abstraction budget

Removed duplication at five sites (see Summary); no new types, files, or abstractions were added — one interface (`ProgressStreamBypassControls`) was deleted and folded into the existing `ProgressStreamControls` interface it was married to. No pass-through layers introduced.

## Net elements (R6)

9 files changed, 47 insertions(+), 66 deletions(-) (net -19 LoC). No exported symbols added or removed (`git diff` shows zero `^[+-]export` lines across the changed files — the one interface removed, `ProgressStreamBypassControls`, was never exported). No new classes/interfaces/enums; one interface deleted and merged into an existing one.

## Consumer counts (R8)

`getProgressStreamControls`'s return shape has exactly one production consumer (`LitSessionRenderer.ts`, grepped) plus two test call sites (`progressBackendHarness.ts`, `StreamContentSync.vitest.ts`), both updated in this PR. No emit path or export was deleted or re-routed.

## Host impact

Extension: `StreamHeader.ts`, `syncSlice.ts` (progress-view webview) behavior unchanged, same rendered output — verified by existing `StreamHeader.vitest.ts` / `StreamContentSync.vitest.ts`.

Desktop: no desktop-specific code touched; typechecks clean (`typecheck:desktop`).

CLI: no CLI-specific code touched; typechecks clean (`typecheck:cli`).

## Scheduled refactoring

None — the three declined findings above are documented in this PR body rather than filed as follow-ups, since re-investigating them concluded no change is warranted.

## Validation

- `npm run typecheck` — full workspace (workspace, test-kernel, agent, cli, trace-viewer, desktop) — clean.
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — no new findings.
- `npx prettier --check` on every changed file — clean.
- Targeted `vitest` runs covering every touched module (progress-view sync/header, tool conversion, tool-use process node, tool-use flow/dispatch/wait/follow-up, codex tool-log formatting): 977 tests passed, 0 failed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pph4A65BVFbrzPfkmTiTvw)_