### PR TITLE
fix(desktop): surface pending approvals, actionable dialogs, honest task counts

### DIFF
--- a/packages/cli/src/runtime/cliPresentationHost.ts
+++ b/packages/cli/src/runtime/cliPresentationHost.ts
@@ -93,9 +93,7 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
         // actions as fields instead, and `StderrTextSink` drops `fields`, so
         // one call serves both.
         runProgress?.preserve();
-        const hint = ndjson
-          ? ''
-          : formatInstructionActionHint(payload.actions, 'cli');
+        const hint = ndjson ? '' : formatInstructionActionHint(payload.actions);
         ensureLogger().info(`${payload.message}${hint}`, {
           key: payload.key,
           actions: payload.actions,

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -89,7 +89,6 @@ import {
   formatActiveStreamRetention,
   formatStreamDeletionRetention,
 } from '@shared/copy/executionHistory';
-import { formatInstructionActionHint } from '@shared/copy/instructionActionHint';
 import {
   ALL_STREAMS_DELETED_CAUSE,
   RETRY_REQUEST_CLEARED_CAUSE,
@@ -252,20 +251,19 @@ export class DesktopProgressBridge {
           this.options.host.showErrorMessage(message),
           'Failed to present the error dialog',
         ),
-      requestShowInstruction: (instruction) => {
+      requestShowInstruction: (instruction) =>
         // An instruction is actionable guidance, not a failure, so it uses
-        // the info dialog. The desktop dialog carries no buttons, so the
-        // action tokens the extension renders as buttons become trailing
-        // hint text and `showSuppress` has no affordance to attach to.
-        const hint = formatInstructionActionHint(
-          instruction.actions,
-          'desktop',
-        );
-        return this.settleHostDialog(
-          this.options.host.showInfoMessage(`${instruction.message}${hint}`),
+        // the info-style dialog. `showInstructionDialog` renders each action
+        // token as a real button; `showSuppress` still has no affordance to
+        // attach to (a native dialog has no persistent "never remind again"
+        // control).
+        this.settleHostDialog(
+          this.options.host.showInstructionDialog(
+            instruction.message,
+            instruction.actions,
+          ),
           'Failed to present the instruction dialog',
-        );
-      },
+        ),
       showAgentConfigBanner: ({ agentName }) =>
         this.postToRenderer({
           command: MAIN_VIEW_COMMANDS.SET_BANNER,

--- a/packages/desktop/src/main/desktopAgentExecutionHost.ts
+++ b/packages/desktop/src/main/desktopAgentExecutionHost.ts
@@ -1,6 +1,7 @@
 import type { MainViewExecutionLaunchHost } from '@controllers/mainView/backend/MainViewExecutionLaunchController';
 import type { TranscriptExportFormat } from '@controllers/progressView/exportTranscript';
 import type { DiffViewHost } from '@hosts/uiHosts';
+import type { InstructionAction } from '@shared/schemas';
 import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 
 /** Required desktop capabilities used throughout an agent execution. */
@@ -8,6 +9,16 @@ export interface DesktopAgentExecutionHost extends MainViewExecutionLaunchHost {
   showErrorMessage(message: string): Promise<void> | void;
   showWarningMessage(message: string): Promise<void> | void;
   showInfoMessage(message: string): Promise<void> | void;
+  /**
+   * Presents an instruction (e.g. a missing API key) as an actionable
+   * dialog: each token in `actions` becomes a button — dispatched to the
+   * matching main-process action (open Settings, open a doc) — plus a
+   * defaulted "Dismiss", instead of degrading to inert trailing hint text.
+   */
+  showInstructionDialog(
+    message: string,
+    actions: readonly InstructionAction[] | undefined,
+  ): Promise<void>;
   pickTranscriptExportFormat(): Promise<TranscriptExportFormat | undefined>;
   openPath(filePath: string, line?: number): Promise<void>;
   openBuildDisplay: BuildDisplayFn;

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -45,7 +45,13 @@ import {
   type TexraApprovalPolicy,
 } from '@shared/approvalPolicy';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
-import { AgentCategory, agentKeyOf, type AgentSource } from '@shared/schemas';
+import {
+  AgentCategory,
+  agentKeyOf,
+  INSTRUCTION_ACTION,
+  type AgentSource,
+  type InstructionAction,
+} from '@shared/schemas';
 import { normalizePlatform } from '@shared/constants/latexToolchain';
 import { registerRuntimeShutdownHandlers } from '@tools/agentCliSessionStores';
 import { killActiveRecording } from '@tools/media/audio';
@@ -127,7 +133,10 @@ import { installDesktopMainViewIpc } from './mainViewIpc.js';
 import { initializeDesktopCrashReporting } from './desktopCrashReporting.js';
 import { initializeElectronPlatform } from './platform/index.js';
 import { showDesktopWarningDialog } from './platform/warningDialog.js';
-import { DESKTOP_DOCS_URL } from '../shared/desktopCommandSurface.js';
+import {
+  DESKTOP_DOCS_URL,
+  postDesktopSettingsView,
+} from '../shared/desktopCommandSurface.js';
 import {
   DESKTOP_WORKSPACE_PATH_STATE_KEY,
   serializeWorkspacePresenceArg,
@@ -443,6 +452,58 @@ function createWindow(options: {
     // external viewer (`shell.openPath`) so previews never silently disappear.
     postToRenderer: postToRendererIfAlive,
   });
+  // Button labels for the instruction dialog below. Desktop has one settings
+  // home (Settings tab), so SET_API_KEY opens it directly rather than the
+  // extension's separate "enter a key" quick pick.
+  const INSTRUCTION_ACTION_BUTTON_LABELS: Record<InstructionAction, string> = {
+    [INSTRUCTION_ACTION.SET_API_KEY]: 'Set API Key',
+    [INSTRUCTION_ACTION.OPEN_CONFIGURATION_GUIDE]: 'Configuration Guide',
+    [INSTRUCTION_ACTION.OPEN_MODELS_DOC]: 'Model Documentation',
+  };
+  const dispatchInstructionAction = (action: InstructionAction): void => {
+    switch (action) {
+      case INSTRUCTION_ACTION.SET_API_KEY:
+        postDesktopSettingsView(postToRendererIfAlive, 'models');
+        return;
+      case INSTRUCTION_ACTION.OPEN_CONFIGURATION_GUIDE:
+        previewHost
+          .openExternal('https://texra.ai/guide/configuration.html')
+          .catch(reportBackgroundError);
+        return;
+      case INSTRUCTION_ACTION.OPEN_MODELS_DOC:
+        previewHost
+          .openExternal('https://texra.ai/guide/models.html')
+          .catch(reportBackgroundError);
+        return;
+    }
+  };
+  /**
+   * Instructions (e.g. a missing API key) are actionable guidance, not
+   * failures, so this stays an 'info' dialog — but each action token now
+   * renders as a real button instead of degrading to trailing hint text with
+   * nothing to click. `showSuppress` still has no affordance to attach to: a
+   * native dialog has no persistent "never remind again" control.
+   */
+  const showInstructionDialog = async (
+    message: string,
+    actions: readonly InstructionAction[] | undefined,
+  ): Promise<void> => {
+    const tokens = actions ?? [];
+    const buttons = [
+      ...tokens.map((token) => INSTRUCTION_ACTION_BUTTON_LABELS[token]),
+      'Dismiss',
+    ];
+    const dismissId = buttons.length - 1;
+    const { response } = await dialog.showMessageBox(window, {
+      type: 'info',
+      message,
+      buttons,
+      defaultId: dismissId,
+      cancelId: dismissId,
+    });
+    const action = tokens[response];
+    if (action) dispatchInstructionAction(action);
+  };
   let teamSignInPending = false;
   const refreshDesktopAuthSurfaces = async () => {
     const authenticated = await SupabaseClient.isAuthenticated();
@@ -559,6 +620,7 @@ function createWindow(options: {
     showWarningMessage,
     showErrorMessage: (message) =>
       showErrorMessage(message).catch(reportBackgroundError),
+    showInstructionDialog,
     pickTranscriptExportFormat: async () => {
       const { TRANSCRIPT_EXPORT_FORMAT_CHOICES } =
         await import('@controllers/progressView/exportTranscript');

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -407,7 +407,7 @@ function toStreamPaletteEntry(stream: StreamTabInfo): CommandPaletteEntry {
       streamDisplayLabel(stream) ||
       'Stream',
     icon: 'terminal',
-    category: 'Streams',
+    category: 'Tasks',
   };
 }
 

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -47,7 +47,6 @@ import {
   pendingApprovalIds$,
   streamById$,
   streamStates$,
-  streams$,
   topLevelStreams$,
 } from '@progressView/frontend/progressState';
 import { streamDisplayLabel } from '@progressView/frontend/utils';
@@ -829,9 +828,20 @@ function taskConversationTemplate(): TemplateResult {
   const activeId = activeStreamId$.get();
   const showConversation = activeId != null && hasAnyStreams$.get();
   const startupPanelVisible = startupTeamPanel.isVisible();
-  const sidebarToggleLabel = shellState.sidebarCollapsed
+  // The sidebar is the only home for the rail's per-stream pending-approval
+  // badge (StreamTabs.ts). Collapsing it removes that cue entirely, so a
+  // call held at the approval gate — often on a workflow's child stream, not
+  // the one on screen — can stall with zero visible affordance (#11511).
+  // Surface the same signal on the toggle that reopens the rail.
+  const hasPendingApproval = pendingApprovalIds$.get().size > 0;
+  const sidebarCollapsedWithPendingApproval =
+    shellState.sidebarCollapsed && hasPendingApproval;
+  let sidebarToggleLabel = shellState.sidebarCollapsed
     ? 'Show sidebar'
     : 'Hide sidebar';
+  if (sidebarCollapsedWithPendingApproval) {
+    sidebarToggleLabel = 'Show sidebar - approval pending';
+  }
   const workspacePath = window.texraDesktop?.workspacePath;
   // Names the button even when the ≤560px container query collapses it to the
   // icon: the shadow button then has no visible text, so only `title` reaches
@@ -840,19 +850,29 @@ function taskConversationTemplate(): TemplateResult {
   return html`
     <main class="task-conversation" aria-label="Task conversation">
       <header class="task-header">
-        <wa-button
-          type="button"
-          class="task-header-button icon-button is-size-l"
-          appearance="plain"
-          size="s"
-          aria-label=${sidebarToggleLabel}
-          title=${sidebarToggleLabel}
-          @click=${() => updateShell(toggleSidebar(shellState))}
-        >
-          ${waIcon(
-            shellState.sidebarCollapsed ? 'chevron-right' : 'chevron-left',
-          )}
-        </wa-button>
+        <span class="task-header-button-slot">
+          <wa-button
+            type="button"
+            class="task-header-button icon-button is-size-l"
+            appearance="plain"
+            size="s"
+            aria-label=${sidebarToggleLabel}
+            title=${sidebarToggleLabel}
+            @click=${() => updateShell(toggleSidebar(shellState))}
+          >
+            ${waIcon(
+              shellState.sidebarCollapsed ? 'chevron-right' : 'chevron-left',
+            )}
+          </wa-button>
+          ${
+            sidebarCollapsedWithPendingApproval
+              ? html`<span
+                  class="task-header-pending-approval-badge"
+                  aria-hidden="true"
+                ></span>`
+              : nothing
+          }
+        </span>
         <span class="task-header-title">${currentTaskTitle()}</span>
         <span class="task-header-spacer"></span>
         ${
@@ -1087,7 +1107,7 @@ function shellTemplate(): TemplateResult {
             initials: workspaceInitials(workspacePath),
             projectSectionPosition: shellState.projectSectionPosition,
             sessions: railTabs,
-            streamCount: streams$.get().length,
+            streamCount: topLevelStreams$.get().length,
             workspaceName: workspaceName(workspacePath),
             commandsLabel: commandLabel(DESKTOP_COMMAND_PALETTE_ID),
             workspacePath,
@@ -1131,8 +1151,44 @@ function observeSurfaceResizes(): void {
   }
 }
 
+/**
+ * Streams whose off-screen pending approval has already reopened the
+ * sidebar once. A user who re-collapses it mid-run must not be fought on
+ * every unrelated signal change — only a newly appearing off-screen
+ * approval (one not in this set) reopens it again.
+ */
+let sidebarRevealedForApprovalIds = new Set<string>();
+
+/**
+ * Auto-reveals a collapsed sidebar when a pending approval lands on a
+ * stream other than the one on screen. That is the dead-end case: the
+ * request card lives on the pending stream's own view (one home for the
+ * decision), so a collapsed, non-viewed rail leaves nothing to click
+ * (#11511 — per-call workflow review cards land on a child stream, not the
+ * one the user is watching). Mutates `shellState` directly rather than going
+ * through `updateShell` so this can run from inside `rerenderShell` without
+ * recursing into another render pass.
+ */
+function revealSidebarForOffScreenApproval(): void {
+  const offScreen = [...pendingApprovalIds$.get()].filter(
+    (id) => id !== displayedActiveStreamId$.get(),
+  );
+  if (offScreen.length === 0) {
+    sidebarRevealedForApprovalIds = new Set();
+    return;
+  }
+  const isNewApproval = offScreen.some(
+    (id) => !sidebarRevealedForApprovalIds.has(id),
+  );
+  sidebarRevealedForApprovalIds = new Set(offScreen);
+  if (isNewApproval && shellState.sidebarCollapsed) {
+    shellState = toggleSidebar(shellState);
+  }
+}
+
 function rerenderShell(): void {
   if (bootstrapFailed) return;
+  revealSidebarForOffScreenApproval();
   render(shellTemplate(), appRoot);
   logsController.setActive(
     activeWorkbenchTab(shellState, 'right')?.kind === 'logs' ||
@@ -1325,7 +1381,7 @@ const shortcutBootstrap = createDesktopShortcutBootstrap({
     createDesktopCommandPalette({
       document,
       actions: desktopRendererCommandActions,
-      getStreams: () => streams$.get(),
+      getStreams: () => topLevelStreams$.get(),
       getShortcuts: () => registry.entries(),
     }),
   appendPalette: (element) => document.body.append(element),

--- a/packages/desktop/src/renderer/taskShell.css
+++ b/packages/desktop/src/renderer/taskShell.css
@@ -499,6 +499,28 @@ body[data-desktop-platform='darwin'] .task-sidebar-brand {
   -webkit-app-region: no-drag;
 }
 
+.task-header-button-slot {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+/* Same warning hue the rail's per-stream pending-approval indicator uses
+   (StreamTab.styles.ts `.has-pending-approval`) — the only cue left when a
+   call held at the approval gate is on a stream the collapsed sidebar
+   currently hides. */
+.task-header-pending-approval-badge {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-warning);
+  border: 1.5px solid var(--wa-color-surface-default);
+  pointer-events: none;
+}
+
 .task-header-title {
   min-width: 0;
   overflow: hidden;

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -123,9 +123,11 @@ const inquiries$ = select(appState, (s) => s.inquiries);
 // Derived computeds: only re-evaluate when selector inputs propagate.
 // ---------------------------------------------------------------------------
 
-export const streams$ = new Signal.Computed(() => [
-  ...streamById$.get().values(),
-]);
+// Not exported: every consumer now reads topLevelStreams$ (rail, palette,
+// sidebar count) so a child call/edit-approval stream is never mistaken for
+// a top-level task (#11511 family). Kept as topLevelStreams$'s own
+// intermediate step below.
+const streams$ = new Signal.Computed(() => [...streamById$.get().values()]);
 
 /** Top-level streams: the tab list, with child streams excluded. */
 export const topLevelStreams$ = new Signal.Computed(() =>

--- a/src/shared/copy/instructionActionHint.ts
+++ b/src/shared/copy/instructionActionHint.ts
@@ -2,35 +2,20 @@
  * Trailing hint text for the {@link InstructionAction} tokens the agent core
  * attaches to an instruction.
  *
- * A host that can render each token as a button (the VS Code extension, via
- * `INSTRUCTION_ACTION_VIEW`) keeps its own command table, because the token →
- * `texra.*` command mapping is what the core must stay free of. The hosts with
- * no button to click — the CLI's stderr line and the desktop's button-less
- * dialog — render the same tokens as one parenthesized phrase appended to the
- * message, and that phrasing is the same on both except for where the user
- * goes to set a key. One rule, two styles, like
- * `formatStreamStatusLabel`.
+ * A host that can render each token as a button (the VS Code extension's
+ * `INSTRUCTION_ACTION_VIEW`, or desktop's `showInstructionDialog`) keeps its
+ * own command table, because the token → command mapping is what the core
+ * must stay free of. The CLI has no button to click — its stderr line renders
+ * the same tokens as one parenthesized phrase appended to the message.
  */
 
 import { INSTRUCTION_ACTION, type InstructionAction } from '@shared/schemas';
 
-// The two styles share every phrase except SET_API_KEY, so `desktop` is
-// derived from `cli` rather than hand-synced.
-const cliInstructionActionHints = {
+const CLI_INSTRUCTION_ACTION_HINTS = {
   [INSTRUCTION_ACTION.SET_API_KEY]: 'set your API key (texra setup)',
   [INSTRUCTION_ACTION.OPEN_CONFIGURATION_GUIDE]: 'see the configuration guide',
   [INSTRUCTION_ACTION.OPEN_MODELS_DOC]: 'see the model documentation',
 } as const satisfies Record<InstructionAction, string>;
-
-const INSTRUCTION_ACTION_HINTS = {
-  cli: cliInstructionActionHints,
-  desktop: {
-    ...cliInstructionActionHints,
-    [INSTRUCTION_ACTION.SET_API_KEY]: 'set your API key in Settings',
-  },
-} as const;
-
-type InstructionActionHintStyle = keyof typeof INSTRUCTION_ACTION_HINTS;
 
 /**
  * The ` (hint, hint)` suffix for an instruction's action tokens, or `''` when
@@ -40,10 +25,7 @@ type InstructionActionHintStyle = keyof typeof INSTRUCTION_ACTION_HINTS;
  */
 export function formatInstructionActionHint(
   actions: readonly InstructionAction[] | undefined,
-  style: InstructionActionHintStyle,
 ): string {
   if (!actions?.length) return '';
-  const hints: Partial<Record<InstructionAction, string>> =
-    INSTRUCTION_ACTION_HINTS[style];
-  return ` (${actions.map((action) => hints[action] ?? action).join(', ')})`;
+  return ` (${actions.map((action) => CLI_INSTRUCTION_ACTION_HINTS[action] ?? action).join(', ')})`;
 }

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -37,6 +37,7 @@ import {
 } from '@shared/schemas';
 import type {
   ExecutionId,
+  InstructionAction,
   OutputFileInfo,
   StreamPhase,
   StreamTabId,
@@ -293,6 +294,10 @@ type CreateBridgeOptions = {
   repairRestartedStreams?: RepairRestartedStreamsMock;
   showErrorMessage?: (message: string) => Promise<void> | void;
   showInfoMessage?: (message: string) => Promise<void> | void;
+  showInstructionDialog?: (
+    message: string,
+    actions: readonly InstructionAction[] | undefined,
+  ) => Promise<void>;
   onRunCompleted?: () => void;
   openPath?: (filePath: string, line?: number) => Promise<void>;
   /** Seeds the fake filesystem (e.g. a transcript spill artifact). */
@@ -548,6 +553,9 @@ async function createBridge(
         : {}),
       ...(options.showInfoMessage
         ? { showInfoMessage: options.showInfoMessage }
+        : {}),
+      ...(options.showInstructionDialog
+        ? { showInstructionDialog: options.showInstructionDialog }
         : {}),
       ...(options.onRunCompleted
         ? { onRunCompleted: options.onRunCompleted }
@@ -1099,9 +1107,11 @@ describe('DesktopProgressBridge', () => {
     const messages: unknown[] = [];
     const showErrorMessage = vi.fn();
     const showInfoMessage = vi.fn();
+    const showInstructionDialog = vi.fn();
     const bridge = await createBridge(messages, {
       showErrorMessage,
       showInfoMessage,
+      showInstructionDialog,
     });
     messages.length = 0;
 
@@ -1137,30 +1147,32 @@ describe('DesktopProgressBridge', () => {
     expect(showErrorMessage).toHaveBeenCalledWith('Root run failed');
     expect(showErrorMessage).toHaveBeenCalledTimes(1);
     // Instructions are actionable guidance, not failures: they use the info
-    // dialog, with action tokens rendered as trailing hint text.
-    expect(showInfoMessage).toHaveBeenCalledWith(
-      'API key not found. Set your API key in Settings and run again. ' +
-        '(set your API key in Settings, see the configuration guide)',
+    // dialog, with action tokens rendered as real buttons (not trailing hint
+    // text — desktop's dialog has no click target for hint text).
+    expect(showInfoMessage).not.toHaveBeenCalled();
+    expect(showInstructionDialog).toHaveBeenCalledWith(
+      'API key not found. Set your API key in Settings and run again.',
+      ['set-api-key', 'open-configuration-guide'],
     );
   });
 
   it('observes the instruction dialog promise before reporting delivery', async () => {
-    // The concrete showInfoMessage awaits dialog.showMessageBox, which can
-    // reject while its window is being torn down. Delivery must be reported
-    // from that promise's settlement — not synchronously — so a rejected
-    // dialog reads as non-delivery instead of an unhandled rejection plus a
-    // falsely "presented" launch error (#10399).
+    // The concrete showInstructionDialog awaits dialog.showMessageBox, which
+    // can reject while its window is being torn down. Delivery must be
+    // reported from that promise's settlement — not synchronously — so a
+    // rejected dialog reads as non-delivery instead of an unhandled
+    // rejection plus a falsely "presented" launch error (#10399).
     const messages: unknown[] = [];
     let resolveDialog: (() => void) | undefined;
     let rejectDialog: ((error: unknown) => void) | undefined;
-    const showInfoMessage = vi.fn(
+    const showInstructionDialog = vi.fn(
       () =>
         new Promise<void>((resolve, reject) => {
           resolveDialog = resolve;
           rejectDialog = reject;
         }),
     );
-    const bridge = await createBridge(messages, { showInfoMessage });
+    const bridge = await createBridge(messages, { showInstructionDialog });
 
     const instruction = {
       key: 'modelNotRecognized',
@@ -1171,7 +1183,7 @@ describe('DesktopProgressBridge', () => {
       'requestShowInstruction',
       instruction,
     );
-    expect(showInfoMessage).toHaveBeenCalledOnce();
+    expect(showInstructionDialog).toHaveBeenCalledOnce();
 
     // Nothing is reported until the dialog settles.
     const settled: unknown[] = [];

--- a/src/test-kernel/desktop/desktopAgentExecutionTestHarness.ts
+++ b/src/test-kernel/desktop/desktopAgentExecutionTestHarness.ts
@@ -50,6 +50,7 @@ export function createStubDesktopAgentExecutionHost(
     showErrorMessage: async () => undefined,
     showWarningMessage: async () => undefined,
     showInfoMessage: async () => undefined,
+    showInstructionDialog: async () => undefined,
     pickTranscriptExportFormat: async () => undefined,
     onRunCompleted: () => undefined,
     ...overrides,


### PR DESCRIPTION
## Summary

Four verified desktop-only dispatch-friction fixes from batch F.

| Item | File | Change | Why |
|---|---|---|---|
| 1 | `packages/desktop/src/renderer/main.ts`, `taskShell.css` | Renderer-only fix: when the sidebar is collapsed and `pendingApprovalIds$` is non-empty, the sidebar-toggle chevron shows a small warning-colored badge (same hue as the rail's per-stream pending-approval indicator). Additionally, a pending approval on a stream other than the one on screen auto-reopens a collapsed sidebar once per newly-appearing off-screen approval id, so a user's later manual re-collapse isn't fought. No new IPC route — built entirely from signals the shell watcher already subscribes to (`pendingApprovalIds$`, `displayedActiveStreamId$`). | Per-call workflow review cards land on a workflow's child stream, not the one being viewed, and `requestEnsureProgressView` is a no-op on desktop (the conversation canvas is "always on screen"). With the sidebar collapsed, a call held at the approval gate had zero visible affordance. |
| 2 | `packages/desktop/src/main/desktopAgentExecutionHost.ts`, `desktopAgentExecution.ts`, `index.ts`, `src/shared/copy/instructionActionHint.ts`, `packages/cli/src/runtime/cliPresentationHost.ts` | Added `showInstructionDialog(message, actions)` to `DesktopAgentExecutionHost`. The main-process implementation passes a real `buttons` array to `dialog.showMessageBox` (one button per `InstructionAction` token, plus a defaulted "Dismiss") and dispatches the chosen button to `postDesktopSettingsView(..., 'models')` for `SET_API_KEY` or `previewHost.openExternal(...)` for the two doc actions. Deleted the now-unused `formatInstructionActionHint('desktop', ...)` hint-text path (the function's `style` parameter is gone; only the CLI's phrase-based style remains). | An instruction dialog (missing API key, etc.) previously degraded its action tokens to trailing hint text with nothing to click, unlike the VS Code extension's actionable toast buttons. |
| 3 | `packages/desktop/src/renderer/main.ts` | `streamCount` for the sidebar's "Tasks" badge now reads `topLevelStreams$.get().length` instead of `streams$.get().length`. | The badge counted every workflow-call child stream even though the list beneath it only ever renders top-level streams, so the badge read e.g. "8" over a visible 2-row list mid-dispatch. |
| 4 | `packages/desktop/src/renderer/desktopCommandPalette.ts`, `main.ts` | The command palette's stream switcher now feeds `topLevelStreams$.get()` (was `streams$.get()`), and its category label is `'Tasks'` (was `'Streams'`, matching a word used nowhere else in the desktop UI). | A multi-call dispatch flooded the palette with one "Switch to …" row per child call stream, under a category name that doesn't match the sidebar's "Tasks" section; children stay reachable by expanding the parent in the rail. |

`streams$` in `packages/extension/src/progressView/frontend/progressState.ts` is no longer exported (only used internally now, by `topLevelStreams$`) — every consumer reads `topLevelStreams$` instead, closing a dead-code-ratchet finding the change would otherwise have introduced.

## Verified

- `npm run typecheck` — clean (workspace, test-kernel, agent, cli, trace-viewer, desktop).
- `npm run lint` — clean (one `no-nested-ternary` finding fixed during the pass).
- `npm run check:dead-code-ratchet` — clean, no new findings (net -1 vs baseline after un-exporting `streams$`).
- Targeted `vitest run` (not full suite): `DesktopAgentExecution`, `DesktopAgentExecutionFactory`, `DesktopCommandPalette`, `DesktopShortcutRegistry`, `DesktopTaskShell`, `DesktopToolEditApproval`, CLI's `RunExecution`, `RunProgressRenderer`, `TranscriptSessionPolicy`, `TuiApprovalRetry`, `TuiHostInteractionsCancelForStream`, `chatSessionController`, and the `progressView` suites touching `progressState.ts` — all pass (310 + 81 tests). Updated two existing `DesktopAgentExecution.vitest.ts` tests whose assertions targeted the old `showInfoMessage`-with-hint-text path for `requestShowInstruction`; no new test files added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmNFntsYS6WUa1buU1SD1k