### PR TITLE
refactor(settings): tabulate model.* provider toggles via a shared builder

### DIFF
--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -339,6 +339,33 @@ function surfacedSetting(entry: SurfacedSettingInput): SurfacedSettingEntry {
   return entry;
 }
 
+/**
+ * A Models-tab provider toggle: a globally-stored boolean that renders both as
+ * a profile row and as one per-provider control on the Models tab. These rows
+ * differ only in their default, copy, honoring reader, and Models-tab control,
+ * so the uniform `configTarget: 'global'` / `category: 'model'` /
+ * `settingsView: 'profile'` framing is written once here — the same tabulation
+ * the region toggles already use through `PROVIDER_ROUTING_SETTINGS`. Returns a
+ * `CORE_SETTING_ROWS` body (key and slot are added by the config-tree mapping).
+ */
+function modelProviderToggle(opts: {
+  readonly default: boolean;
+  readonly title: string;
+  readonly description: string;
+  readonly honoredBy: SettingHonoredBy;
+  readonly model: ModelsTabSurface;
+}): Omit<StateSettingEntry, 'key' | 'slots'> {
+  return {
+    schema: z.boolean().prefault(opts.default),
+    configTarget: 'global',
+    title: opts.title,
+    description: opts.description,
+    category: 'model',
+    honoredBy: opts.honoredBy,
+    surfaces: { settingsView: 'profile', models: [opts.model] },
+  };
+}
+
 // ============================================================================
 // Core (config-tree) rows
 // ============================================================================
@@ -401,141 +428,99 @@ const CORE_SETTING_ROWS: Record<
   // while Models-tab and runtime reads both keep merged-config semantics. A
   // workspace override therefore remains visible and honored; cleanup of values
   // stranded by the regression window is tracked separately in #11173.
-  'model.gpt5ReasoningSummary': {
-    schema: z.boolean().prefault(false),
-    configTarget: 'global',
+  'model.gpt5ReasoningSummary': modelProviderToggle({
+    default: false,
     title: 'GPT-5 reasoning summary',
     description:
       "Show the model's reasoning steps alongside its output when using GPT-5 models. Requires an OpenAI account with access to reasoning features.",
-    category: 'model',
     honoredBy: everyHost(
       'src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts',
     ),
-    surfaces: {
-      settingsView: 'profile',
-      models: [
-        {
-          provider: 'openai',
-          label: 'GPT-5 reasoning summary',
-          description:
-            'Request reasoning summaries from GPT-5 models. Only available on OpenAI API Tier 3+.',
-          warning:
-            'New accounts with $20 credit are typically Tier 1 and will hit rate limits.',
-          warningUrl:
-            'https://platform.openai.com/settings/organization/billing/overview',
-          warningUrlLabel: 'Check your tier',
-        },
-      ],
+    model: {
+      provider: 'openai',
+      label: 'GPT-5 reasoning summary',
+      description:
+        'Request reasoning summaries from GPT-5 models. Only available on OpenAI API Tier 3+.',
+      warning:
+        'New accounts with $20 credit are typically Tier 1 and will hit rate limits.',
+      warningUrl:
+        'https://platform.openai.com/settings/organization/billing/overview',
+      warningUrlLabel: 'Check your tier',
     },
-  },
-  'model.useOpenAIResponsesAPI': {
-    schema: z.boolean().prefault(true),
-    configTarget: 'global',
+  }),
+  'model.useOpenAIResponsesAPI': modelProviderToggle({
+    default: true,
     title: 'Use the Responses API',
     description:
       "Use OpenAI's newer Responses API for additional features like built-in tool use. Disable to fall back to the classic Chat Completions API.",
-    category: 'model',
     honoredBy: everyHost('src/agent/runtime/ModelFactory.ts'),
-    surfaces: {
-      settingsView: 'profile',
-      models: [
-        {
-          provider: 'openai',
-          label: 'Use the Responses API',
-          description:
-            'Use the OpenAI Responses API instead of Chat Completions when available.',
-        },
-      ],
+    model: {
+      provider: 'openai',
+      label: 'Use the Responses API',
+      description:
+        'Use the OpenAI Responses API instead of Chat Completions when available.',
     },
-  },
-  'model.useGoogleInteractionsServerState': {
-    schema: z.boolean().prefault(true),
-    configTarget: 'global',
+  }),
+  'model.useGoogleInteractionsServerState': modelProviderToggle({
+    default: true,
     title: 'Server-side conversation state',
     description:
       "Store Google Interactions conversation state on Google's servers via previous_interaction_id chaining, sending only the new turn each round. Google then retains the conversation for a limited period to enable chaining. Enabled by default. Disable to keep conversations off Google's servers — stateless mode resends the full transcript each round (store:false).",
-    category: 'model',
     honoredBy: everyHost(
       'src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts',
     ),
-    surfaces: {
-      settingsView: 'profile',
-      models: [
-        {
-          provider: 'google',
-          label: 'Server-side conversation state',
-          description:
-            "Store Interactions conversation state on Google's servers (send only the new turn each round; Google retains the conversation for a limited period to enable chaining). Disable to keep conversations off Google's servers and resend the full transcript each round.",
-        },
-      ],
+    model: {
+      provider: 'google',
+      label: 'Server-side conversation state',
+      description:
+        "Store Interactions conversation state on Google's servers (send only the new turn each round; Google retains the conversation for a limited period to enable chaining). Disable to keep conversations off Google's servers and resend the full transcript each round.",
     },
-  },
-  'model.useGoogleBackgroundResponses': {
-    schema: z.boolean().prefault(false),
-    configTarget: 'global',
+  }),
+  'model.useGoogleBackgroundResponses': modelProviderToggle({
+    default: false,
     title: 'Google background responses',
     description:
       'Run long-running Google workflow generations as background Interactions (submit + poll) to avoid timeouts. Off by default. Requires server-side conversation state; models that do not support it fall back automatically.',
-    category: 'model',
     honoredBy: everyHost(
       'src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts',
     ),
-    surfaces: {
-      settingsView: 'profile',
-      models: [
-        {
-          provider: 'google',
-          label: 'Background responses',
-          description:
-            'Run long-running workflow generations as background Interactions (submit + poll) to avoid timeouts. Off by default. Requires server-side conversation state; models that do not support it fall back automatically.',
-        },
-      ],
+    model: {
+      provider: 'google',
+      label: 'Background responses',
+      description:
+        'Run long-running workflow generations as background Interactions (submit + poll) to avoid timeouts. Off by default. Requires server-side conversation state; models that do not support it fall back automatically.',
     },
-  },
-  'model.useBackgroundResponses': {
-    schema: z.boolean().prefault(true),
-    configTarget: 'global',
+  }),
+  'model.useBackgroundResponses': modelProviderToggle({
+    default: true,
     title: 'Background responses',
     description:
       'Keep long-running OpenAI requests alive in the background (polling) instead of timing out after 10 minutes. Applies automatically to GPT models running workflow agents; ignored otherwise. Disable to fall back to synchronous streaming requests.',
-    category: 'model',
     honoredBy: everyHost(
       'src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts',
     ),
-    surfaces: {
-      settingsView: 'profile',
-      models: [
-        {
-          provider: 'openai',
-          label: 'Background responses',
-          description:
-            'Handle long-running generations (>10 min) via polling to prevent timeouts. Adds polling overhead.',
-        },
-      ],
+    model: {
+      provider: 'openai',
+      label: 'Background responses',
+      description:
+        'Handle long-running generations (>10 min) via polling to prevent timeouts. Adds polling overhead.',
     },
-  },
-  'model.openaiParallelToolCalls': {
-    schema: z.boolean().prefault(true),
-    configTarget: 'global',
+  }),
+  'model.openaiParallelToolCalls': modelProviderToggle({
+    default: true,
     title: 'Parallel tool calls',
     description:
       'Let OpenAI models use multiple tools at the same time for faster results. Enabled by default; disable for models that require sequential tool execution.',
-    category: 'model',
     honoredBy: everyHost(
       'src/agent/modelHandlers/openai/modelHandlerOpenAI.ts',
     ),
-    surfaces: {
-      settingsView: 'profile',
-      models: [
-        {
-          provider: 'openai',
-          label: 'Parallel tool calls',
-          description:
-            'Allow the model to call multiple tools in parallel. On by default; disable for models that require sequential execution.',
-        },
-      ],
+    model: {
+      provider: 'openai',
+      label: 'Parallel tool calls',
+      description:
+        'Allow the model to call multiple tools in parallel. On by default; disable for models that require sequential execution.',
     },
-  },
+  }),
   // No `configTarget`: both runtime readers resolve the *merged* config value
   // through `getValidatedConfig`, so the row must not narrow itself to the
   // global scope — a workspace override the runtime honors would then be


### PR DESCRIPTION
## Summary

The six `model.*` boolean rows in `CORE_SETTING_ROWS` (`src/shared/schemas/stateSettings.ts`) are Models-tab provider toggles — a globally-stored boolean that renders both as a profile row and as one per-provider control on the Models tab. They differ only in their default, copy, honoring reader, and per-provider control, yet each row restated the same `configTarget: 'global'` / `category: 'model'` / `settingsView: 'profile'` framing and the `surfaces.models: [{ … }]` wrapper by hand.

This adds a local `modelProviderToggle(...)` builder that owns that uniform framing and routes the six rows (`gpt5ReasoningSummary`, `useOpenAIResponsesAPI`, `useGoogleInteractionsServerState`, `useGoogleBackgroundResponses`, `useBackgroundResponses`, `openaiParallelToolCalls`) through it. It is the same tabulation the region toggles already use through `PROVIDER_ROUTING_SETTINGS` in this file — an established in-file pattern, not a new abstraction.

The emitted catalog entries are equivalent field-for-field; object field order is irrelevant to every consumer, which reads by key. There is **no behavior change**: the settings catalog, its wire snapshots, and the Models-tab rendering are unchanged.

## Issue acceptance gates

No issue. Housekeeping refactor surfaced by a codebase debt scan; scoped to the one change that is output-equivalent and verifiable without the GUI.

## Single source of truth

`modelProviderToggle` in `stateSettings.ts` now owns the uniform framing shared by every Models-tab provider toggle (matching `PROVIDER_ROUTING_SETTINGS` for the region toggles). Per-row copy, default, provider control, and honoring reader remain declared at each call site.

## Duplication and abstraction budget

Removed the per-row restatement of `configTarget: 'global'`, `category: 'model'`, `surfaces.settingsView: 'profile'`, and the `models: [{ … }]` wrapper across six rows. The one abstraction added is a local, non-exported builder with six callers that owns the "a Models-tab provider toggle is a globally-stored boolean surfaced on profile + Models tab" invariant — no pass-through layer, and consistent with the existing `PROVIDER_ROUTING_SETTINGS` tabulation.

## Net elements (R6)

- Files: 1 changed (`src/shared/schemas/stateSettings.ts`), diffstat `+80 / −95` → **net −15 LoC**.
- Exported symbols: **0 added, 0 removed** (`^[+-]export` over the diff is empty; `modelProviderToggle` is file-local).
- Classes/interfaces/enums: none added or removed.
- Constructs: +1 local function (`modelProviderToggle`); six inline object literals collapsed to six builder calls.

## Consumer counts (R8)

No emit path or export changed. `modelProviderToggle` is a file-local function with 6 in-file callers; `CORE_SETTING_ROWS` keys, schemas, and surfaces are byte-equivalent, so every downstream consumer of the catalog is unaffected. n/a otherwise.

## Host impact

Extension: none — catalog output unchanged; settings view and Models tab render identically.

Desktop: none — same catalog.

CLI: none — same catalog (these rows are not `cliConfig` surfaces; unaffected).

## Scheduled refactoring

None. A broader debt scan flagged larger opportunities (LaTeXTab catalog migration, a base model-handler response pipeline, a shared transcript resident-loader, terminal-finalization consolidation), but each is behavior- or UI-sensitive and needs human review plus runtime/GUI verification, so they are intentionally out of scope here.

## Validation

- `npm run typecheck` — clean (exit 0), all packages.
- `npx eslint src/shared/schemas/stateSettings.ts` — clean.
- `npx prettier --check` — clean.
- `stateSettings.vitest.ts` — 29 passed (catalog invariants: key uniqueness, honoredBy reachability, schema validity, surfaces).
- `src/test-kernel/settings/` + `ConfigForm.vitest.ts` — 179 passed.
- Re-ran typecheck + catalog suite after rebasing onto latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lfqn2jBReE7sqyTDDTVCSY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lfqn2jBReE7sqyTDDTVCSY)_