### PR TITLE
refactor(l3-model-transcript): implement verified simplification-survey findings (l3-model-transcript)

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1772,18 +1772,6 @@
       "name": "PROVIDER_KEY_REDACTION_RULES"
     },
     {
-      "file": "src/model/codex/codexPreference.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "CODEX_PREFER_SUBSCRIPTION_KEY"
-    },
-    {
-      "file": "src/model/codingPlanSubscriptions.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "activeCodingPlanForModel"
-    },
-    {
       "file": "src/model/modelOptionsBasic.ts",
       "category": "production-dead",
       "kind": "exports",

--- a/config/ratchets/store-public-surface-baseline.json
+++ b/config/ratchets/store-public-surface-baseline.json
@@ -28,7 +28,6 @@
     ],
     "StreamSnapshotStore": [
       "attachSessionEvents",
-      "deleteAll",
       "deleteStream",
       "evictAll",
       "flush",
@@ -41,14 +40,12 @@
       "getRunMetadata",
       "getRunUsage",
       "getWorkPlan",
-      "hasPersistedWorkPlan",
       "hasProvenance",
       "listPersistedStreams",
       "listStagedDeletions",
       "load",
       "preload",
       "read",
-      "readOutputFiles",
       "reconcileStagedDeletions",
       "stageDeleteStream"
     ]

--- a/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
@@ -148,7 +148,7 @@ export async function hydrateStreamArtifacts(
           (field) => error.authoritativeFields[field],
         ),
       );
-      if (Object.values(error.authoritativeFields).every(Boolean)) {
+      if (error.authoritativeFields.complete) {
         bumpStreamArtifactRevision();
       }
       return {

--- a/packages/trace-viewer/src/replayTrace.ts
+++ b/packages/trace-viewer/src/replayTrace.ts
@@ -8,7 +8,6 @@ import type {
 import {
   AgentCategory,
   END_GROUP_STATUS,
-  executionStatusToRunOutcome,
   STREAM_PHASE,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_STATUS,
@@ -78,15 +77,15 @@ function findRootStageId(
 }
 
 /**
- * Maps the persisted-history `ExecutionStatus` onto the `StreamLifecycleStatus`
- * vocabulary `StreamMetadataSchema.status` renders. `executionStatusToRunOutcome`
- * is the sanctioned inverse of `runOutcomeToExecutionStatus` — its `RunOutcome`
- * result (`completed`/`cancelled`/`failed`) is structurally identical to
- * `StreamPhase`'s values, so it's already a valid `StreamLifecycleStatus`.
+ * The `StreamLifecycleStatus` that `StreamMetadataSchema.status` renders for
+ * this trace. The embedded `meta.outcome` is the one terminal fact the
+ * document carries; its `RunOutcome` values (`completed`/`cancelled`/`failed`)
+ * are structurally identical to `StreamPhase`'s, so it is already a valid
+ * `StreamLifecycleStatus`.
  *
- * `terminalStatus` is `null` for traces that predate outcome tracking (or
- * never reached a terminal state). For those legacy traces, derive status from
- * the persisted transcript's last terminal group row before falling back to the
+ * `meta.outcome` is absent for traces that predate outcome tracking (or that
+ * never reached a terminal state). For those, derive status from the
+ * persisted transcript's last terminal group row before falling back to the
  * older snapshot-status escape hatch (already normalized to `StreamPhase` at
  * trace parse — `StreamSnapshotSchema.status`'s legacy-inbound member maps the
  * retired 7-value vocabulary, with legacy `ready` parsing to `undefined`). Only
@@ -105,10 +104,7 @@ function findRootStageId(
  * works for freshly assembled documents and historical exported files alike.
  */
 function toStreamLifecycleStatus(trace: TraceDocument): StreamLifecycleStatus {
-  if (trace.terminalStatus !== null) {
-    const outcome = executionStatusToRunOutcome(trace.terminalStatus);
-    if (outcome) return outcome;
-  }
+  if (trace.meta?.outcome) return trace.meta.outcome;
   const rootStageId = findRootStageId(trace.entries);
   for (const entry of trace.entries.toReversed()) {
     if (entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_END) continue;

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -487,9 +487,10 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
    * impossible in stateless mode, so `stateful` is load-bearing (unlike OpenAI,
    * which always sends store:true). Workflow-only mirrors OpenAI's exclusion of
    * tool-use loops (which rely on per-step streaming). There is no Gemini
-   * analogue of isGptFamilyModelName, and not every Interactions-capable model
-   * supports background (gemini-2.5-flash 400s), so the per-model gate is the
-   * runtime `backgroundUnsupported` fallback rather than a model-name check.
+   * analogue of OpenAI's GPT-family name check, and not every
+   * Interactions-capable model supports background (gemini-2.5-flash 400s), so
+   * the per-model gate is the runtime `backgroundUnsupported` fallback rather
+   * than a model-name check.
    */
   private useBackgroundMode(stateful: boolean): boolean {
     return (

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -43,7 +43,7 @@ import {
   getSdkErrorMessage,
 } from '@common/errors/sdkError/providerErrorFormat';
 import { handleStreamingFailure } from '@common/errors/sdkError/streamFailure';
-import { isGpt5ModelName, isGptFamilyModelName } from '@model/modelNames';
+import { isGpt5ModelName } from '@model/modelNames';
 import type {
   OpenAIResponseProviderCapabilities,
   ProviderCapabilityProfile,
@@ -440,7 +440,9 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
    * on per-step streaming.
    */
   private isBackgroundModeEligible(): boolean {
-    return isGptFamilyModelName(this.config.name) && this.isWorkflowMode();
+    return (
+      this.config.name.toLowerCase().startsWith('gpt') && this.isWorkflowMode()
+    );
   }
 
   /** The `previous_response_id` chain anchor + conversation bookkeeping. See

--- a/src/controllers/progressView/backend/agentProposalTransport.ts
+++ b/src/controllers/progressView/backend/agentProposalTransport.ts
@@ -1,9 +1,10 @@
 import { computeAgentOptionsData } from '@agent/index';
 import { createLog } from '@logger/logUtils';
 import {
-  buildVisibleBasicModelOptionsData,
   computeModelOptionsData,
+  getEnabledModels,
 } from '@model/computeModelOptions';
+import { buildBasicModelOptionsData } from '@model/modelOptionsBasic';
 import {
   AgentCategory,
   agentName,
@@ -40,6 +41,12 @@ export function createAgentProposalTransport(options: {
   // appears if availability loading fails. Agent options have no static
   // equivalent, so the agent dropdown is omitted when the registry fetch
   // fails.
+  //
+  // `buildBasicModelOptionsData` is secret-free by design (no key reads), so
+  // it cannot resolve credential-dependent routing: a dual-backend model like
+  // `kimi3` shows its canonical provider home (Moonshot), and only the async
+  // `computeModelOptionsData` refines it to Kimi Code when "Prefer Kimi Code"
+  // plus a stored key actually reroute it.
   const sendResolvedOptions = async (
     proposal: AgentProposalPermission,
   ): Promise<void> => {
@@ -58,7 +65,7 @@ export function createAgentProposalTransport(options: {
         log.debug(
           `Model options fetch failed; falling back to the static visible-model list: ${toErrorMessage(error)}`,
         );
-        return buildVisibleBasicModelOptionsData();
+        return buildBasicModelOptionsData(getEnabledModels());
       }),
       loadAgentOptions().catch((error) => {
         log.debug(
@@ -90,7 +97,7 @@ export function createAgentProposalTransport(options: {
         kind: PERMISSION_KIND.PROPOSAL,
         data: proposal,
         ...(acceptsOverrides && {
-          modelOptionsData: buildVisibleBasicModelOptionsData(),
+          modelOptionsData: buildBasicModelOptionsData(getEnabledModels()),
         }),
       });
       if (acceptsOverrides) void sendResolvedOptions(proposal);

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -241,8 +241,9 @@ export async function discoverLatestExecutionOutputs(
       // Records without one go straight to the run-directory scan below.
       const streamId = await discovery.readStreamId(candidate.id);
       if (streamId !== undefined) {
-        const rounds = await snapshots.readOutputFiles(streamId);
-        if (rounds && Object.keys(rounds).length > 0) {
+        const { outputFilesByRound: rounds } =
+          await snapshots.read(streamId);
+        if (Object.keys(rounds).length > 0) {
           return { executionId: candidate.id, rounds };
         }
       }

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -241,8 +241,7 @@ export async function discoverLatestExecutionOutputs(
       // Records without one go straight to the run-directory scan below.
       const streamId = await discovery.readStreamId(candidate.id);
       if (streamId !== undefined) {
-        const { outputFilesByRound: rounds } =
-          await snapshots.read(streamId);
+        const { outputFilesByRound: rounds } = await snapshots.read(streamId);
         if (Object.keys(rounds).length > 0) {
           return { executionId: candidate.id, rounds };
         }

--- a/src/model/codex/codexPreference.ts
+++ b/src/model/codex/codexPreference.ts
@@ -8,8 +8,7 @@
 import { createSubscriptionPreference } from '../subscriptionPreference';
 
 /** Config key for the "prefer my ChatGPT subscription" switch (off by default). */
-export const CODEX_PREFER_SUBSCRIPTION_KEY =
-  'texra.chatgptCodex.preferSubscription';
+const CODEX_PREFER_SUBSCRIPTION_KEY = 'texra.chatgptCodex.preferSubscription';
 
 const preference = createSubscriptionPreference(CODEX_PREFER_SUBSCRIPTION_KEY);
 

--- a/src/model/codingPlanSubscriptions.ts
+++ b/src/model/codingPlanSubscriptions.ts
@@ -88,10 +88,10 @@ const RUNTIME_BY_ID = {
   CodingPlanSubscription['id'],
   Omit<CodingPlanSubscriptionRuntime, 'descriptor'> & {
     /**
-     * Whether this plan currently serves the model. Removed from the public
-     * {@link CodingPlanSubscriptionRuntime} interface (the spread into
-     * `codingPlanSubscriptionRuntimes` still carries it at runtime); the one
-     * intended reader is {@link activeCodingPlanForModel}, which
+     * Whether this plan currently serves the model. Module-private: excluded
+     * from the public {@link CodingPlanSubscriptionRuntime} interface and the
+     * exported catalog's element type; the one reader is
+     * {@link activeCodingPlanForModel}, which
      * {@link activeSubscriptionUsageRoute} owns as the single public answer to
      * "which subscription serves this model next".
      */
@@ -99,8 +99,8 @@ const RUNTIME_BY_ID = {
   }
 >;
 
-/** Runtime catalog consumed by retry policy and host route presentation. */
-export const codingPlanSubscriptionRuntimes = Object.freeze(
+/** Rich rows (with `isActiveForModel`) for the module-private reader. */
+const RUNTIMES = Object.freeze(
   CODING_PLAN_SUBSCRIPTIONS.map((descriptor) =>
     Object.freeze({
       descriptor,
@@ -109,12 +109,16 @@ export const codingPlanSubscriptionRuntimes = Object.freeze(
   ),
 );
 
+/** Runtime catalog consumed by retry policy and host route presentation. */
+export const codingPlanSubscriptionRuntimes: readonly CodingPlanSubscriptionRuntime[] =
+  RUNTIMES;
+
 /** Resolve the coding plan currently serving a model, if any. */
 async function activeCodingPlanForModel(
   modelId: string,
 ): Promise<CodingPlanSubscriptionRuntime | undefined> {
   const active = await Promise.all(
-    codingPlanSubscriptionRuntimes.map(async (runtime) => ({
+    RUNTIMES.map(async (runtime) => ({
       runtime,
       active: await runtime.isActiveForModel(modelId),
     })),

--- a/src/model/codingPlanSubscriptions.ts
+++ b/src/model/codingPlanSubscriptions.ts
@@ -88,8 +88,10 @@ const RUNTIME_BY_ID = {
   CodingPlanSubscription['id'],
   Omit<CodingPlanSubscriptionRuntime, 'descriptor'> & {
     /**
-     * Whether this plan currently serves the model. Module-private: the one
-     * reader is {@link activeCodingPlanForModel}, which
+     * Whether this plan currently serves the model. Removed from the public
+     * {@link CodingPlanSubscriptionRuntime} interface (the spread into
+     * `codingPlanSubscriptionRuntimes` still carries it at runtime); the one
+     * intended reader is {@link activeCodingPlanForModel}, which
      * {@link activeSubscriptionUsageRoute} owns as the single public answer to
      * "which subscription serves this model next".
      */

--- a/src/model/codingPlanSubscriptions.ts
+++ b/src/model/codingPlanSubscriptions.ts
@@ -31,7 +31,6 @@ export interface CodingPlanSubscriptionRuntime {
   readonly setEnabled: (enabled: boolean) => Promise<void>;
   /** Restore a captured preference without changing a newer competing route. */
   readonly restoreEnabled: (enabled: boolean) => Promise<void>;
-  readonly isActiveForModel: (modelId: string) => Promise<boolean>;
 }
 
 async function isGlmCodingPlanActive(modelId: string): Promise<boolean> {
@@ -87,7 +86,15 @@ const RUNTIME_BY_ID = {
   },
 } as const satisfies Record<
   CodingPlanSubscription['id'],
-  Omit<CodingPlanSubscriptionRuntime, 'descriptor'>
+  Omit<CodingPlanSubscriptionRuntime, 'descriptor'> & {
+    /**
+     * Whether this plan currently serves the model. Module-private: the one
+     * reader is {@link activeCodingPlanForModel}, which
+     * {@link activeSubscriptionUsageRoute} owns as the single public answer to
+     * "which subscription serves this model next".
+     */
+    readonly isActiveForModel: (modelId: string) => Promise<boolean>;
+  }
 >;
 
 /** Runtime catalog consumed by retry policy and host route presentation. */
@@ -101,7 +108,7 @@ export const codingPlanSubscriptionRuntimes = Object.freeze(
 );
 
 /** Resolve the coding plan currently serving a model, if any. */
-export async function activeCodingPlanForModel(
+async function activeCodingPlanForModel(
   modelId: string,
 ): Promise<CodingPlanSubscriptionRuntime | undefined> {
   const active = await Promise.all(

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -6,7 +6,6 @@ import { isPreferXaiSubscription } from '@model/xai/xaiPreference';
 import { isXaiSignedIn } from '@model/xai/xaiSignedIn';
 import type { StateStore } from '@platform/interfaces';
 import { platform } from '@platform/platform';
-import type { PlatformSecrets } from '@platform/secrets';
 import type { ModelAvailabilityKind, ModelOptionData } from '@shared/schemas';
 import { CHATGPT_AUTH, GROK_AUTH } from '@shared/copy/accountAuth';
 import {
@@ -24,20 +23,18 @@ import {
   getUseOpenRouter,
 } from '@utils/config/providerConfig';
 
-import {
-  apiKeyExistsUncached,
-  hasUsableApiKey,
-  type ApiProvider,
-} from './apiProviders';
+import { hasUsableApiKey, type ApiProvider } from './apiProviders';
 import {
   resolveCodexSubscriptionCapabilities,
   resolveXaiSubscriptionCapabilities,
 } from './providerCapabilities';
-import { kimiCodeEffectiveConfig } from './kimiCodeSubscriptionRouting';
+import {
+  kimiCodeEffectiveConfig,
+  type KimiCodeRoutingFacts,
+} from './kimiCodeSubscriptionRouting';
 import { resolveEffectiveHelperModel } from './helperModelSelection';
 import {
   buildBaseModelOption,
-  buildBasicModelOptionsData,
   DEFAULT_MODELS,
   isRetiredModel,
 } from './modelOptionsBasic';
@@ -47,7 +44,10 @@ import {
   resolveModelSource,
   shouldRouteModelThroughOpenRouter,
 } from './openRouterRouting';
-import { prefersCopilotRoute } from './copilotRouting';
+import {
+  copilotRouteUnavailableReason,
+  prefersCopilotRoute,
+} from './copilotRouting';
 import {
   discoveredCopilotRoutes,
   getRuntimeModelConfig,
@@ -58,12 +58,6 @@ import type { ProviderCapabilityProfile } from './providerCapabilities';
 import type { ModelConfig } from 'llm-zoo';
 
 type PersonalModelAccessKind = 'provider-key' | 'openrouter-key';
-
-export interface ModelOptionsAccess {
-  readonly visibleModels: readonly string[];
-  readonly secrets: PlatformSecrets;
-  readonly useOpenRouter: boolean;
-}
 
 /**
  * Module-private refinement of an unavailable {@link ModelAvailabilityKind},
@@ -196,9 +190,16 @@ const UNAVAILABLE_REASON_BUILDERS: Record<
     const providerName = providerDisplayName(modelSource);
     return `Model "${model}" requires your ${providerName} API key. Provide it to continue.`;
   },
+  // Both Copilot arms defer to the dispatch path's own wording
+  // ({@link copilotRouteUnavailableReason}), so the picker shows exactly the
+  // sentence a run would fail with. The `??` arm is unreachable: these kinds
+  // are only chosen inside the `prefersCopilotRoute` branch, which is the one
+  // case that helper never answers `undefined` for.
   'copilot-consent-required': ({ model }) =>
-    `Model "${model}" needs your approval before TeXRA can use it through Copilot in VS Code.`,
+    copilotRouteUnavailableReason(model) ??
+    `Model "${model}" is currently unavailable through Copilot in VS Code.`,
   'copilot-unavailable': ({ model }) =>
+    copilotRouteUnavailableReason(model) ??
     `Model "${model}" is currently unavailable through Copilot in VS Code.`,
   // Unreachable from `getModelUnavailableReason` today (it returns its own
   // "not recognized" message before a config resolves far enough to compute
@@ -257,33 +258,12 @@ interface ModelAvailabilityContext {
   codexSignedIn: boolean;
   /** Whether the user is signed in with Grok (only when prefer is on). */
   xaiSignedIn: boolean;
-  /** Whether the "Prefer Kimi Code" switch is on. */
-  preferKimiCode: boolean;
-  /** Whether a Kimi Code console API key is stored. */
-  kimiCodeKeySet: boolean;
-}
-
-/**
- * The config a Kimi-subscription-eligible model actually runs with, mirroring
- * ModelFactory's dispatch: when the shared route resolver picks the Kimi Code
- * endpoint for a dual-backend model (`kimi3`), swap in the synthesized runtime
- * config (coding base URL + `k3` wire id) so availability, the row's product
- * source, and the unavailable-reason all match what the handler builds.
- * Exclusive models already carry the pinned config, so this is only material
- * for dual-backend routes. Returns the original config otherwise.
- */
-function effectiveKimiCodeConfig(
-  config: ModelConfig,
-  ctx: ModelAvailabilityContext,
-): ModelConfig {
-  if (!isKimiSubscriptionEligible(config)) return config;
-  // The same route decision and post-route config synthesis ModelFactory
-  // applies, driven by the pre-resolved context facts.
-  return kimiCodeEffectiveConfig(config, {
-    useOpenRouter: ctx.useOpenRouter,
-    keySet: ctx.kimiCodeKeySet,
-    preferKimiCode: ctx.preferKimiCode,
-  });
+  /**
+   * The Kimi Code route facts in their canonical shape, so this module feeds
+   * the shared resolver ({@link kimiCodeEffectiveConfig}) the same assembly
+   * ModelFactory's dispatch uses instead of a hand-renamed copy.
+   */
+  kimiRouting: KimiCodeRoutingFacts;
 }
 
 /** Determine how a model can be used in the current access mode. */
@@ -370,14 +350,11 @@ async function resolveModelAvailability(
   return availabilityStatus('missing-key');
 }
 
-async function buildAvailabilityContext(
-  access: ModelOptionsAccess,
-  useApiKeyCache: boolean,
-): Promise<ModelAvailabilityContext> {
+async function buildAvailabilityContext(): Promise<ModelAvailabilityContext> {
+  const secrets = platform().secrets;
+  const useOpenRouter = getUseOpenRouter();
   const hasApiKey = (provider: ApiProvider) =>
-    useApiKeyCache
-      ? hasUsableApiKey(access.secrets, provider)
-      : apiKeyExistsUncached(access.secrets, provider);
+    hasUsableApiKey(secrets, provider);
   const [hasOpenRouter, codexSignedIn, xaiSignedIn, kimiCodeKeySet] =
     await Promise.all([
       hasApiKey('openRouter'),
@@ -389,11 +366,14 @@ async function buildAvailabilityContext(
   return {
     hasUsableApiKey: hasApiKey,
     hasOpenRouter,
-    useOpenRouter: access.useOpenRouter,
+    useOpenRouter,
     codexSignedIn,
     xaiSignedIn,
-    preferKimiCode: getPreferKimiCode(),
-    kimiCodeKeySet,
+    kimiRouting: {
+      useOpenRouter,
+      keySet: kimiCodeKeySet,
+      preferKimiCode: getPreferKimiCode(),
+    },
   };
 }
 
@@ -470,43 +450,16 @@ export async function setModelEnabled(input: {
   return next;
 }
 
-function buildDefaultModelOptionsAccess(): ModelOptionsAccess {
-  const host = platform();
-  return {
-    visibleModels: getEnabledModels(host.globalState),
-    secrets: host.secrets,
-    useOpenRouter: getUseOpenRouter(),
-  };
-}
-
-/**
- * Build synchronous fallback options from the current host-visible model list.
- *
- * Secret-free by design (no key reads), so it cannot resolve credential-
- * dependent routing: a dual-backend model like `kimi3` shows its canonical
- * provider home (Moonshot), and the async {@link computeModelOptionsData}
- * refines it to Kimi Code when "Prefer Kimi Code" plus a stored key actually
- * reroute it. Exclusive Kimi Code models still show `kimiCode` here because
- * that is a pure registry fact needing no secret.
- */
-export function buildVisibleBasicModelOptionsData(
-  visibleModels: readonly string[] = getEnabledModels(),
-): ModelOptionData[] {
-  return buildBasicModelOptionsData(visibleModels);
-}
-
 /** Returns a human-readable reason why a model is unavailable, or `null` if available. */
 export async function getModelUnavailableReason(
   model: string,
-  access?: ModelOptionsAccess,
 ): Promise<string | null> {
   await discoveredCopilotRoutes();
   const rawConfig = getRuntimeModelConfig(model);
   if (!rawConfig) return `Model "${model}" is not recognized.`;
 
-  const effectiveAccess = access ?? buildDefaultModelOptionsAccess();
-  const ctx = await buildAvailabilityContext(effectiveAccess, access == null);
-  const config = effectiveKimiCodeConfig(rawConfig, ctx);
+  const ctx = await buildAvailabilityContext();
+  const config = kimiCodeEffectiveConfig(rawConfig, ctx.kimiRouting);
   const availability = await resolveModelAvailability(model, config, ctx);
   if (availability.available) return null;
 
@@ -536,7 +489,7 @@ async function buildModelOptionData(
   }
   // Mirror ModelFactory: a dual-backend Kimi model routed to the coding
   // endpoint runs with the synthesized runtime config, so the row reflects it.
-  const config = effectiveKimiCodeConfig(rawConfig, ctx);
+  const config = kimiCodeEffectiveConfig(rawConfig, ctx.kimiRouting);
 
   const availability = await resolveModelAvailability(model, config, ctx);
   const copilotConfig =
@@ -606,29 +559,19 @@ export function invalidateModelOptionsCache(): void {
  * so alternate global-state views stay isolated while repeated settings/CLI
  * refreshes do not redo secret and server-side key checks.
  *
- * Passing `access` computes directly from that dependency snapshot and skips
- * the shared TTL cache. Use it when the caller owns access-state freshness,
- * such as tests or host adapters with explicitly supplied state.
+ * Callers that own access-state freshness invalidate the shared caches
+ * ({@link invalidateModelOptionsCache}, `invalidateApiKeyCache`) instead of
+ * passing their own dependency snapshot.
  */
 export async function computeModelOptionsData(
   models?: readonly string[],
-  access?: ModelOptionsAccess,
 ): Promise<ModelOptionData[]> {
-  if (access) {
-    return computeModelOptionsDataUncached(models, access, false);
-  }
-
   const cacheKey = getModelOptionsCacheKey(models);
   return coalesceAsync<string, ModelOptionData[]>(
     resolvedModelOptions,
     pendingModelOptions,
     cacheKey,
-    () =>
-      computeModelOptionsDataUncached(
-        models,
-        buildDefaultModelOptionsAccess(),
-        true,
-      ),
+    () => computeModelOptionsDataUncached(models),
   );
 }
 
@@ -642,17 +585,12 @@ function getModelOptionsCacheKey(
 
 async function computeModelOptionsDataUncached(
   modelsOverride: readonly string[] | undefined,
-  access: ModelOptionsAccess,
-  useApiKeyCache: boolean,
 ): Promise<ModelOptionData[]> {
   await discoveredCopilotRoutes();
-  const availabilityCtx = await buildAvailabilityContext(
-    access,
-    useApiKeyCache,
-  );
+  const availabilityCtx = await buildAvailabilityContext();
   const models =
     modelsOverride ??
-    visibleModelsForAccess(access.visibleModels, availabilityCtx);
+    visibleModelsForAccess(getEnabledModels(), availabilityCtx);
 
   return Promise.all(
     models.map((model) => buildModelOptionData(model, availabilityCtx)),

--- a/src/model/modelNames.ts
+++ b/src/model/modelNames.ts
@@ -8,8 +8,3 @@
 export function isGpt5ModelName(name: string): boolean {
   return name.startsWith('gpt5') || name.startsWith('gpt-5');
 }
-
-/** True for any GPT-family model name (`gpt4*`, `gpt5*`, `gpt-oss*`, …). */
-export function isGptFamilyModelName(name: string): boolean {
-  return name.toLowerCase().startsWith('gpt');
-}

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -40,8 +40,8 @@ export const EXECUTION_STATUS = {
   ERROR: 'error',
 } as const;
 
-export const ExecutionStatusSchema = z.enum(EXECUTION_STATUS);
-export type ExecutionStatus = z.infer<typeof ExecutionStatusSchema>;
+export type ExecutionStatus =
+  (typeof EXECUTION_STATUS)[keyof typeof EXECUTION_STATUS];
 
 /**
  * Canonical terminal outcome of an agent run — the single fact "how did this

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -159,21 +159,6 @@ export const STREAM_SUBSTATE = {
 export const StreamSubstateSchema = z.enum(STREAM_SUBSTATE);
 export type StreamSubstate = z.infer<typeof StreamSubstateSchema>;
 
-export function executionStatusToRunOutcome(
-  status: ExecutionStatus | undefined,
-): RunOutcome | undefined {
-  switch (status) {
-    case EXECUTION_STATUS.COMPLETED:
-      return RUN_OUTCOME.COMPLETED;
-    case EXECUTION_STATUS.INTERRUPTED:
-      return RUN_OUTCOME.CANCELLED;
-    case EXECUTION_STATUS.ERROR:
-      return RUN_OUTCOME.FAILED;
-    case undefined:
-      return undefined;
-  }
-}
-
 /**
  * Wire-level lifecycle status of a stream that has no phase in this process:
  * its execution lease is held by another TeXRA process, or its run state

--- a/src/shared/streams/streamStatus.ts
+++ b/src/shared/streams/streamStatus.ts
@@ -37,7 +37,7 @@ export function deriveRunOutcome(facts: {
 
 /**
  * Project the canonical outcome onto the frozen public execution-status
- * vocabulary (trace document `terminalStatus`, CLI NDJSON history status).
+ * vocabulary (persisted `ExecutionMeta`, CLI NDJSON history status).
  * The only production mapping — flows and hosts must not hand-roll their
  * own. An out-of-vocabulary value (stale fixture, unparsed legacy data)
  * fails with a named error instead of an undefined-property crash

--- a/src/shared/streams/streamStatus.ts
+++ b/src/shared/streams/streamStatus.ts
@@ -37,7 +37,7 @@ export function deriveRunOutcome(facts: {
 
 /**
  * Project the canonical outcome onto the frozen public execution-status
- * vocabulary (persisted `ExecutionMeta`, CLI NDJSON history status).
+ * vocabulary (CLI NDJSON history status, CLI display prose).
  * The only production mapping — flows and hosts must not hand-roll their
  * own. An out-of-vocabulary value (stale fixture, unparsed legacy data)
  * fails with a named error instead of an undefined-property crash

--- a/src/test-kernel/auth/CodexPreference.vitest.ts
+++ b/src/test-kernel/auth/CodexPreference.vitest.ts
@@ -3,13 +3,14 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports
 import {
-  CODEX_PREFER_SUBSCRIPTION_KEY,
   isPreferCodexSubscription,
   setPreferCodexSubscription,
 } from '@model/codex/codexPreference';
 import { platform } from '@platform/platform';
 import { installPlatform } from '@test/support/setupPlatform';
 import { FakeScopedConfigProvider } from '@test/support/FakePlatform';
+
+const CODEX_PREFER_SUBSCRIPTION_KEY = 'texra.chatgptCodex.preferSubscription';
 
 describe('Codex subscription preference', () => {
   it('writes workspace preference when workspace config already controls it', async () => {

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -501,14 +501,7 @@ describe('handleTuiSlashCommand', () => {
         plan: { objective: 'Use the accepted live plan.' },
         todos: [],
       },
-      authority: {
-        outputFiles: false,
-        missingOutputs: false,
-        compileFailures: false,
-        usage: false,
-        todos: false,
-        plan: true,
-      },
+      authority: { complete: false, todos: false, plan: true },
     },
     {
       label: 'todos',
@@ -522,14 +515,7 @@ describe('handleTuiSlashCommand', () => {
           },
         ],
       },
-      authority: {
-        outputFiles: false,
-        missingOutputs: false,
-        compileFailures: false,
-        usage: false,
-        todos: true,
-        plan: false,
-      },
+      authority: { complete: false, todos: true, plan: false },
     },
   ] satisfies readonly {
     label: string;

--- a/src/test-kernel/latex/OutputDiscovery.vitest.ts
+++ b/src/test-kernel/latex/OutputDiscovery.vitest.ts
@@ -20,7 +20,7 @@ import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 // r0/r1 outputs on disk (the same source the `--run-id` path scans).
 const mocks = vi.hoisted(() => ({
   findRunDir: vi.fn(),
-  readOutputFiles: vi.fn(),
+  read: vi.fn(),
 }));
 
 vi.mock('@utils/files/runStorageFs', async (importActual) => ({
@@ -31,7 +31,7 @@ vi.mock('@utils/files/runStorageFs', async (importActual) => ({
 vi.mock('@transcript', async (importActual) => {
   // A class (not an arrow) so `new StreamSnapshotStore()` is constructable.
   class FakeStreamSnapshotStore {
-    readOutputFiles = mocks.readOutputFiles;
+    read = mocks.read;
   }
   return {
     ...(await importActual<typeof import('@transcript')>()),
@@ -78,7 +78,7 @@ describe('discoverLatestExecutionOutputs', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     await installPlatform({}, { fs: nodeFilesystem });
-    mocks.readOutputFiles.mockResolvedValue(undefined);
+    mocks.read.mockResolvedValue({ outputFilesByRound: {} });
   });
 
   afterEach(async () => {
@@ -120,7 +120,7 @@ describe('discoverLatestExecutionOutputs', () => {
     // Registered under a stream the agent/model config would NOT derive.
     readStreamId.mockResolvedValue('polish@earlierModel#exec-registered');
     const rounds = { 0: [] };
-    mocks.readOutputFiles.mockResolvedValue(rounds);
+    mocks.read.mockResolvedValue({ outputFilesByRound: rounds });
 
     const result = await discoverLatestExecutionOutputs(
       discovery,
@@ -129,7 +129,7 @@ describe('discoverLatestExecutionOutputs', () => {
     );
 
     expect(readStreamId).toHaveBeenCalledWith('exec-registered');
-    expect(mocks.readOutputFiles).toHaveBeenCalledWith(
+    expect(mocks.read).toHaveBeenCalledWith(
       'polish@earlierModel#exec-registered',
     );
     expect(result).toEqual({ executionId: 'exec-registered', rounds });

--- a/src/test-kernel/model/CodingPlanSubscriptionsRuntime.vitest.ts
+++ b/src/test-kernel/model/CodingPlanSubscriptionsRuntime.vitest.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { resolveProxyEndpoint } from '@agent/modelHandlers/support/ProxyConfigResolver';
 import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
 import {
-  activeCodingPlanForModel,
+  activeSubscriptionUsageRoute,
   codingPlanSubscriptionRuntimes,
 } from '@model/codingPlanSubscriptions';
 import { platform } from '@platform/platform';
@@ -72,9 +72,9 @@ describe('coding-plan subscription runtime', () => {
   it('reports the GLM plan for the resolved official endpoint', async () => {
     await platform().globalState.update(GlobalStateKey.USE_OPENROUTER, false);
 
-    await expect(activeCodingPlanForModel('glm52')).resolves.toMatchObject({
-      descriptor: { id: 'glmCodingPlan' },
-    });
+    await expect(activeSubscriptionUsageRoute('glm52')).resolves.toBe(
+      'glm-coding-plan-subscription',
+    );
   });
 
   it('does not classify a custom coding-shaped GLM endpoint as plan usage', async () => {
@@ -84,7 +84,9 @@ describe('coding-plan subscription runtime', () => {
       'proxy.test/api/coding/paas/v4',
     );
 
-    await expect(activeCodingPlanForModel('glm52')).resolves.toBeUndefined();
+    await expect(
+      activeSubscriptionUsageRoute('glm52'),
+    ).resolves.toBeUndefined();
   });
 
   it('restores Kimi preference without overwriting newer OpenRouter state', async () => {

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -7,7 +7,6 @@ import {
   computeModelOptionsData,
   getModelUnavailableReason,
   invalidateModelOptionsCache,
-  type ModelOptionsAccess,
 } from '@model/computeModelOptions';
 import {
   resolveDirectModelApiKeyProvider,
@@ -21,19 +20,32 @@ import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
 import type { ModelOptionData } from '@shared/schemas';
 import { FAST_FIRST_RESPONSE_HINT } from '@shared/constants/providers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
-import { FakeSecrets } from '@test/support/FakePlatform';
 import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 
-function createModelOptionsAccess(
-  secrets: Record<string, string> = {
-    [apiKeySecretName('openai')]: 'sk-openai',
-  },
-): ModelOptionsAccess {
-  return {
-    visibleModels: ['gpt55'],
-    secrets: new FakeSecrets(secrets),
-    useOpenRouter: false,
-  };
+const OPENAI_KEY_SECRETS = { [apiKeySecretName('openai')]: 'sk-openai' };
+
+/**
+ * Reinstall the fake platform mid-test with the access state the case needs,
+ * then clear the two process-wide caches the picker reads through.
+ */
+async function installAccessPlatform(options: {
+  secrets?: Record<string, string>;
+  config?: Record<string, unknown>;
+  enabledModels?: string[];
+  useOpenRouter?: boolean;
+} = {}): Promise<void> {
+  await installPlatform({
+    config: options.config,
+    globalState: {
+      [GlobalStateKey.ENABLED_MODELS]: options.enabledModels ?? ['gpt55'],
+      ...(options.useOpenRouter === undefined
+        ? {}
+        : { [GlobalStateKey.USE_OPENROUTER]: options.useOpenRouter }),
+    },
+    secrets: options.secrets ?? OPENAI_KEY_SECRETS,
+  });
+  invalidateApiKeyCache();
+  invalidateModelOptionsCache();
 }
 
 function codexSessionSecrets(): Record<string, string> {
@@ -47,18 +59,9 @@ function codexSessionSecrets(): Record<string, string> {
   };
 }
 
-function initSubscriptionPlatform(
-  secrets: Record<string, string> = {},
-  enabledModels: string[] = ['gpt55'],
-): Promise<void> {
-  return installPlatform({
-    config: {
-      'texra.chatgptCodex.preferSubscription': true,
-    },
-    globalState: { [GlobalStateKey.ENABLED_MODELS]: enabledModels },
-    secrets,
-  });
-}
+const PREFER_CODEX_CONFIG = {
+  'texra.chatgptCodex.preferSubscription': true,
+};
 
 describe('model catalogue direct-route key ownership', () => {
   it('assigns every servable direct route to an API-key provider', () => {
@@ -77,10 +80,7 @@ describe('model catalogue direct-route key ownership', () => {
 describe('computeModelOptionsData availability', () => {
   setupPlatform({
     globalState: { [GlobalStateKey.ENABLED_MODELS]: ['gpt55'] },
-    secrets: {
-      [apiKeySecretName('openai')]: 'sk-openai',
-      [apiKeySecretName('deepseek')]: 'sk-deepseek',
-    },
+    secrets: OPENAI_KEY_SECRETS,
   });
 
   beforeEach(() => {
@@ -93,11 +93,11 @@ describe('computeModelOptionsData availability', () => {
   });
 
   it('uses a Kimi Code key for the plan-exclusive model', async () => {
-    const access = createModelOptionsAccess({
-      [apiKeySecretName('kimiCode')]: 'sk-kimi-code',
+    await installAccessPlatform({
+      secrets: { [apiKeySecretName('kimiCode')]: 'sk-kimi-code' },
     });
 
-    const [model] = await computeModelOptionsData(['kimiCoding'], access);
+    const [model] = await computeModelOptionsData(['kimiCoding']);
 
     expect(model).toMatchObject({
       provider: 'kimiCode',
@@ -107,12 +107,12 @@ describe('computeModelOptionsData availability', () => {
   });
 
   it('does not treat a Moonshot key as a Kimi Code credential', async () => {
-    const access = createModelOptionsAccess({
-      [apiKeySecretName('moonshot')]: 'sk-moonshot',
+    await installAccessPlatform({
+      secrets: { [apiKeySecretName('moonshot')]: 'sk-moonshot' },
     });
 
-    const [model] = await computeModelOptionsData(['kimiCoding'], access);
-    const reason = await getModelUnavailableReason('kimiCoding', access);
+    const [model] = await computeModelOptionsData(['kimiCoding']);
+    const reason = await getModelUnavailableReason('kimiCoding');
 
     expect(model).toMatchObject({
       provider: 'kimiCode',
@@ -125,17 +125,17 @@ describe('computeModelOptionsData availability', () => {
   });
 
   it('reports a model with no stored key as missing a key', async () => {
-    const access = createModelOptionsAccess({});
+    await installAccessPlatform({ secrets: {} });
 
-    const [model] = await computeModelOptionsData(['gpt55'], access);
+    const [model] = await computeModelOptionsData(['gpt55']);
 
     expect(model.availability).toBe('missing-key');
   });
 
   it('labels models the registry no longer describes instead of shipping a bare row', async () => {
-    const access = createModelOptionsAccess();
+    await installAccessPlatform();
 
-    const [model] = await computeModelOptionsData(['no-such-model'], access);
+    const [model] = await computeModelOptionsData(['no-such-model']);
 
     expect(model).toMatchObject({
       value: 'no-such-model',
@@ -148,19 +148,19 @@ describe('computeModelOptionsData availability', () => {
   });
 
   it('reports a stored personal key as provider-key access', async () => {
-    const access = createModelOptionsAccess();
+    await installAccessPlatform();
 
-    const [model] = await computeModelOptionsData(undefined, access);
+    const [model] = await computeModelOptionsData(undefined);
 
     expect(model.availability).toBe('provider-key');
     expect(model.disabled).toBe(false);
   });
 
   it('marks retired models unavailable', async () => {
-    const access = createModelOptionsAccess();
+    await installAccessPlatform();
 
-    const [model] = await computeModelOptionsData(['haiku3'], access);
-    const reason = await getModelUnavailableReason('haiku3', access);
+    const [model] = await computeModelOptionsData(['haiku3']);
+    const reason = await getModelUnavailableReason('haiku3');
 
     expect(model).toMatchObject({
       availability: 'retired',
@@ -174,10 +174,10 @@ describe('computeModelOptionsData availability', () => {
   });
 
   it('honors the catalogue retirement of the legacy Copilot model', async () => {
-    const access = createModelOptionsAccess();
+    await installAccessPlatform();
 
-    const [model] = await computeModelOptionsData(['copilot4o'], access);
-    const reason = await getModelUnavailableReason('copilot4o', access);
+    const [model] = await computeModelOptionsData(['copilot4o']);
+    const reason = await getModelUnavailableReason('copilot4o');
 
     expect(model).toMatchObject({
       availability: 'retired',
@@ -191,25 +191,21 @@ describe('computeModelOptionsData availability', () => {
   });
 
   it('does not disable API-key access when ChatGPT subscription is preferred but signed out', async () => {
-    await initSubscriptionPlatform();
-    const access = createModelOptionsAccess();
+    await installAccessPlatform({ config: PREFER_CODEX_CONFIG });
 
-    const [model] = await computeModelOptionsData(['gpt55'], access);
+    const [model] = await computeModelOptionsData(['gpt55']);
 
     expect(model.availability).toBe('provider-key');
     expect(model.disabled).toBe(false);
   });
 
   it('does not advertise GPT-5.6 Pro through ChatGPT subscription', async () => {
-    await installPlatform({
-      config: {
-        'texra.chatgptCodex.preferSubscription': true,
-      },
+    await installAccessPlatform({
+      config: PREFER_CODEX_CONFIG,
       secrets: codexSessionSecrets(),
     });
-    const access = createModelOptionsAccess({});
 
-    const [model] = await computeModelOptionsData(['gpt56pro'], access);
+    const [model] = await computeModelOptionsData(['gpt56pro']);
 
     expect(MODEL_CONFIGS.gpt56pro.codexSubscription).not.toBe(true);
     expect(model).toMatchObject({
@@ -220,13 +216,10 @@ describe('computeModelOptionsData availability', () => {
   });
 
   it('marks GPT-5.6 Pro unavailable through OpenRouter', async () => {
-    const access = {
-      ...createModelOptionsAccess(),
-      useOpenRouter: true,
-    };
+    await installAccessPlatform({ useOpenRouter: true });
 
-    const [model] = await computeModelOptionsData(['gpt56pro'], access);
-    const reason = await getModelUnavailableReason('gpt56pro', access);
+    const [model] = await computeModelOptionsData(['gpt56pro']);
+    const reason = await getModelUnavailableReason('gpt56pro');
 
     expect(model).toMatchObject({
       availability: 'provider-unavailable',
@@ -240,13 +233,10 @@ describe('computeModelOptionsData availability', () => {
   });
 
   it('asks for an OpenRouter key, not the provider key, on the OpenRouter route', async () => {
-    const access = {
-      ...createModelOptionsAccess({}),
-      useOpenRouter: true,
-    };
+    await installAccessPlatform({ secrets: {}, useOpenRouter: true });
 
-    const [model] = await computeModelOptionsData(['gpt55'], access);
-    const reason = await getModelUnavailableReason('gpt55', access);
+    const [model] = await computeModelOptionsData(['gpt55']);
+    const reason = await getModelUnavailableReason('gpt55');
 
     expect(model).toMatchObject({
       availability: 'missing-key',
@@ -257,10 +247,12 @@ describe('computeModelOptionsData availability', () => {
   });
 
   it('enables eligible OpenAI models from ChatGPT sign-in without an API key', async () => {
-    await initSubscriptionPlatform(codexSessionSecrets());
-    const access = createModelOptionsAccess({});
+    await installAccessPlatform({
+      config: PREFER_CODEX_CONFIG,
+      secrets: codexSessionSecrets(),
+    });
 
-    const [model] = await computeModelOptionsData(['gpt55'], access);
+    const [model] = await computeModelOptionsData(['gpt55']);
 
     expect(model.availability).toBe('subscription-access');
     expect(model.context).toBe(
@@ -276,13 +268,13 @@ describe('computeModelOptionsData availability', () => {
   });
 
   it('automatically lists every active model served by ChatGPT', async () => {
-    await initSubscriptionPlatform(codexSessionSecrets(), ['gemini31p']);
-    const access = {
-      ...createModelOptionsAccess({}),
-      visibleModels: ['gemini31p'],
-    };
+    await installAccessPlatform({
+      config: PREFER_CODEX_CONFIG,
+      secrets: codexSessionSecrets(),
+      enabledModels: ['gemini31p'],
+    });
 
-    const models = await computeModelOptionsData(undefined, access);
+    const models = await computeModelOptionsData(undefined);
     const expected = Object.entries(MODEL_CONFIGS)
       .filter(
         ([, config]) =>
@@ -307,23 +299,14 @@ describe('computeModelOptionsData availability', () => {
   });
 
   it('shows subscription access for a signed-in preferred subscription', async () => {
-    await initSubscriptionPlatform(codexSessionSecrets());
-    const access = createModelOptionsAccess();
+    await installAccessPlatform({
+      config: PREFER_CODEX_CONFIG,
+      secrets: { ...codexSessionSecrets(), ...OPENAI_KEY_SECRETS },
+    });
 
-    const [model] = await computeModelOptionsData(['gpt55'], access);
+    const [model] = await computeModelOptionsData(['gpt55']);
 
     expect(model.availability).toBe('subscription-access');
-  });
-
-  it('does not reuse cached provider keys for injected access', async () => {
-    await computeModelOptionsData(['deepseekproT']);
-
-    const access = createModelOptionsAccess({});
-
-    const [model] = await computeModelOptionsData(['deepseekproT'], access);
-
-    expect(model.availability).toBe('missing-key');
-    expect(model.disabled).toBe(true);
   });
 
   it('caches explicit model-list availability', async () => {
@@ -400,13 +383,10 @@ describe('computeModelOptionsData Kimi Code routing (dual-backend kimi3)', () =>
   });
 
   it('reports OpenRouter without changing the Kimi K3 registry identity', async () => {
-    const access = {
-      ...createModelOptionsAccess({
-        [apiKeySecretName('openRouter')]: 'sk-openrouter',
-      }),
-      useOpenRouter: true,
-    };
-    const [model] = await computeModelOptionsData(['kimi3'], access);
+    const model = await kimi3Option(
+      { [GlobalStateKey.USE_OPENROUTER]: true },
+      { [apiKeySecretName('openRouter')]: 'sk-openrouter' },
+    );
 
     expect(model).toMatchObject({
       provider: 'moonshot',

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -28,12 +28,14 @@ const OPENAI_KEY_SECRETS = { [apiKeySecretName('openai')]: 'sk-openai' };
  * Reinstall the fake platform mid-test with the access state the case needs,
  * then clear the two process-wide caches the picker reads through.
  */
-async function installAccessPlatform(options: {
-  secrets?: Record<string, string>;
-  config?: Record<string, unknown>;
-  enabledModels?: string[];
-  useOpenRouter?: boolean;
-} = {}): Promise<void> {
+async function installAccessPlatform(
+  options: {
+    secrets?: Record<string, string>;
+    config?: Record<string, unknown>;
+    enabledModels?: string[];
+    useOpenRouter?: boolean;
+  } = {},
+): Promise<void> {
   await installPlatform({
     config: options.config,
     globalState: {

--- a/src/test-kernel/model/ModelOptionsBasic.vitest.ts
+++ b/src/test-kernel/model/ModelOptionsBasic.vitest.ts
@@ -40,50 +40,6 @@ describe('default agent model', () => {
 });
 
 describe('default model list', () => {
-  it('includes Gemini 3.7 Flash as the active default Google Flash model', () => {
-    const config = MODEL_CONFIGS.gemini37f;
-
-    expect(DEFAULT_MODELS).toContain('gemini37f');
-    expect(config).toMatchObject({
-      fullName: 'gemini-3.7-flash',
-      label: 'Gemini 3.7 Flash',
-      provider: 'google',
-      openRouterOnly: false,
-    });
-    expect(config.deprecated ?? false).toBe(false);
-    expect(config.inputPrice).toBeLessThanOrEqual(3);
-  });
-
-  it('includes Fable 5 as a default model', () => {
-    const config = MODEL_CONFIGS.fable5;
-
-    expect(DEFAULT_MODELS).toContain('fable5');
-    expect(config).toMatchObject({
-      fullName: 'claude-fable-5',
-      label: 'Claude Fable 5',
-      provider: 'anthropic',
-      openRouterOnly: false,
-    });
-    expect(config.deprecated ?? false).toBe(false);
-    expect(config.inputPrice).toBe(10);
-    expect(config.outputPrice).toBe(50);
-    expect(config.contextWindow).toBe(1_000_000);
-    expect(config.maxOutputTokens).toBe(128_000);
-  });
-
-  it('includes Grok 4.5 as a default xAI model', () => {
-    const config = MODEL_CONFIGS.grok45;
-
-    expect(DEFAULT_MODELS).toContain('grok45');
-    expect(config).toMatchObject({
-      fullName: 'grok-4.5',
-      provider: 'xai',
-      openRouterOnly: false,
-    });
-    expect(config.retired ?? false).toBe(false);
-    expect(config.deprecated ?? false).toBe(false);
-  });
-
   it('only contains model ids known by llm-zoo', () => {
     expect(DEFAULT_MODELS.filter((model) => !MODEL_CONFIGS[model])).toEqual([]);
   });
@@ -147,10 +103,6 @@ describe('computeModelListVersion', () => {
     expect(MODEL_LIST_VERSION).toBe(
       computeModelListVersion(PREFERRED_DEFAULT_MODELS),
     );
-  });
-
-  it('preserves the established hash for the current preferred set', () => {
-    expect(MODEL_LIST_VERSION).toBe(1_872_513_843);
   });
 
   it('does not change when a non-preferred catalogue model retires', () => {

--- a/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
+++ b/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
@@ -3,14 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   computeModelOptionsData,
   invalidateModelOptionsCache,
-  type ModelOptionsAccess,
 } from '@model/computeModelOptions';
 import {
   copilotRouteUnavailableReason,
   preferredCopilotRouteModels,
   setCopilotRoutePreference,
 } from '@model/copilotRouting';
-import { apiKeySecretName } from '@model/apiProviders';
+import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
 import {
   copilotRouteForModel,
   discoveredCopilotRoutes,
@@ -27,7 +26,6 @@ import type {
 } from '@platform/languageModel';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { createDeferred } from '@test/support/asyncTestUtils';
-import { FakeSecrets } from '@test/support/FakePlatform';
 import { installPlatform } from '@test/support/setupPlatform';
 
 // The discovered-editor-model fixture must track an llm-zoo base model that
@@ -92,21 +90,11 @@ function failingDiscoveryPort(): LanguageModelPort {
 function resetModelCaches(): void {
   invalidateRuntimeModelRegistry();
   invalidateModelOptionsCache();
+  invalidateApiKeyCache();
 }
 
-function googleKeySecrets(): FakeSecrets {
-  return new FakeSecrets({ [apiKeySecretName('google')]: 'sk-google' });
-}
-
-function modelOptionsAccess(
-  overrides: Partial<ModelOptionsAccess> = {},
-): ModelOptionsAccess {
-  return {
-    visibleModels: [],
-    secrets: new FakeSecrets(),
-    useOpenRouter: false,
-    ...overrides,
-  };
+function googleKeySecrets(): Record<string, string> {
+  return { [apiKeySecretName('google')]: 'sk-google' };
 }
 
 describe('runtime model registry', () => {
@@ -472,14 +460,12 @@ describe('Copilot route in model pickers', () => {
         globalState: {
           [GlobalStateKey.COPILOT_ROUTE_MODELS]: ['gemini31p'],
         },
+        secrets: googleKeySecrets(),
       },
       { languageModel: port },
     );
 
-    const options = await computeModelOptionsData(
-      ['gemini31p'],
-      modelOptionsAccess({ secrets: googleKeySecrets() }),
-    );
+    const options = await computeModelOptionsData(['gemini31p']);
 
     expect(options).toHaveLength(1);
     expect(options[0]).toEqual(
@@ -498,12 +484,12 @@ describe('Copilot route in model pickers', () => {
 
   it('never appends route rows to the visible model list', async () => {
     const port = languageModelPort([GEMINI_PRO, GPT_56]);
-    await installPlatform({}, { languageModel: port });
-
-    const options = await computeModelOptionsData(
-      undefined,
-      modelOptionsAccess({ visibleModels: ['gpt55'] }),
+    await installPlatform(
+      { globalState: { [GlobalStateKey.ENABLED_MODELS]: ['gpt55'] } },
+      { languageModel: port },
     );
+
+    const options = await computeModelOptionsData(undefined);
 
     expect(options.map((option) => option.value)).toEqual(['gpt55']);
   });
@@ -516,15 +502,13 @@ describe('Copilot route in model pickers', () => {
       {
         globalState: {
           [GlobalStateKey.COPILOT_ROUTE_MODELS]: ['gemini31p'],
+          [GlobalStateKey.ENABLED_MODELS]: ['gemini31p'],
         },
       },
       { languageModel: port },
     );
 
-    const options = await computeModelOptionsData(
-      undefined,
-      modelOptionsAccess({ visibleModels: ['gemini31p'] }),
-    );
+    const options = await computeModelOptionsData(undefined);
 
     expect(options).toHaveLength(1);
     expect(options[0]).toEqual(
@@ -544,14 +528,12 @@ describe('Copilot route in model pickers', () => {
         globalState: {
           [GlobalStateKey.COPILOT_ROUTE_MODELS]: ['gemini31p'],
         },
+        secrets: googleKeySecrets(),
       },
       { languageModel: port },
     );
 
-    const options = await computeModelOptionsData(
-      ['gemini31p'],
-      modelOptionsAccess({ secrets: googleKeySecrets() }),
-    );
+    const options = await computeModelOptionsData(['gemini31p']);
 
     expect(options).toHaveLength(1);
     expect(options[0]).toEqual(
@@ -566,12 +548,12 @@ describe('Copilot route in model pickers', () => {
 
   it('leaves non-preferred models on their ordinary routes', async () => {
     const port = languageModelPort([GEMINI_PRO]);
-    await installPlatform({}, { languageModel: port });
-
-    const options = await computeModelOptionsData(
-      ['gemini31p'],
-      modelOptionsAccess({ secrets: googleKeySecrets() }),
+    await installPlatform(
+      { secrets: googleKeySecrets() },
+      { languageModel: port },
     );
+
+    const options = await computeModelOptionsData(['gemini31p']);
 
     expect(options[0]).toEqual(
       expect.objectContaining({

--- a/src/test-kernel/traceViewer/replayTrace.vitest.ts
+++ b/src/test-kernel/traceViewer/replayTrace.vitest.ts
@@ -94,9 +94,6 @@ function legacyTrace(
       streamId,
       status: snapshotStatus,
     }),
-    // The bug under test: `null` is what real traces recorded before outcome
-    // tracking (or that never reached a terminal state) persist here.
-    terminalStatus: null,
   };
 }
 
@@ -173,7 +170,7 @@ describe('replayTrace legacy-status fallback (issue #7188)', () => {
     const result = await assembleTrace(executionId);
     expect(result.status).toBe('ok');
     if (result.status !== 'ok') return;
-    expect(result.trace.terminalStatus).toBeNull();
+    expect(result.trace.meta?.outcome).toBeUndefined();
     expect(result.trace.snapshot.status).toBeUndefined();
 
     replayTrace(result.trace);
@@ -332,7 +329,7 @@ describe('replayTrace legacy-status fallback (issue #7188)', () => {
     },
   );
 
-  it('still reports READY when neither terminalStatus nor snapshot.status is set', () => {
+  it('still reports READY when neither meta.outcome nor snapshot.status is set', () => {
     const trace = legacyTrace(undefined);
 
     replayTrace(trace);

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -875,88 +875,6 @@ describe('StreamSnapshotStore', () => {
     expect(store.getRunMetadata(STREAM).executionId).toBe(executionId);
   });
 
-  it('usage-only preload supplies usage without warning and preserves live deltas', async () => {
-    await writeStreamFile(STREAM, 'usageStats.json', {
-      [RUN]: usage(1, 2, 0.1),
-    });
-
-    const store = new StreamSnapshotStore();
-    await store.preload([STREAM], { usageOnly: true });
-    const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
-
-    expect(store.getRunUsage(STREAM).get(RUN)).toMatchObject({
-      inputTokens: 1,
-      outputTokens: 2,
-      cost: 0.1,
-    });
-    expect(warnSpy).not.toHaveBeenCalled();
-
-    snapshotFacts(store).addUsage(STREAM, RUN_2, usage(3, 4, 0.2));
-    expect(store.getRunUsage(STREAM).get(RUN_2)).toMatchObject({
-      inputTokens: 3,
-      outputTokens: 4,
-      cost: 0.2,
-    });
-    expect(warnSpy).not.toHaveBeenCalled();
-
-    // Drain the seed chain started by the live usage event so teardown cannot
-    // race an in-flight sidecar write.
-    await store.flush();
-  });
-
-  it('usage-only preload replays an eager usage delta that lands during the read', async () => {
-    await writeStreamFile(STREAM, 'usageStats.json', {
-      [RUN]: usage(1, 2, 0.1),
-    });
-
-    let releaseRead!: () => void;
-    const readGate = new Promise<void>((resolve) => {
-      releaseRead = resolve;
-    });
-    const originalRead = StorageFS.read.bind(StorageFS);
-    const readUsageFile = vi
-      .spyOn(StorageFS, 'read')
-      .mockImplementation(async (filePath) => {
-        if (filePath.endsWith('usageStats.json')) {
-          await readGate;
-        }
-        return originalRead(filePath);
-      });
-
-    const store = new StreamSnapshotStore();
-    const preload = store.preload([STREAM], { usageOnly: true });
-    snapshotFacts(store).addUsage(STREAM, RUN_2, usage(3, 4, 0.2));
-    releaseRead();
-    await preload;
-
-    expect(readUsageFile).toHaveBeenCalled();
-    expect(store.getRunUsage(STREAM).get(RUN)).toMatchObject({
-      inputTokens: 1,
-      outputTokens: 2,
-      cost: 0.1,
-    });
-    expect(store.getRunUsage(STREAM).get(RUN_2)).toMatchObject({
-      inputTokens: 3,
-      outputTokens: 4,
-      cost: 0.2,
-    });
-
-    await store.flush();
-  });
-
-  it('usage-only preload rejects corrupt-present usageStats instead of zeroing', async () => {
-    await StorageFS.ensureDir(streamDataDir(STREAM));
-    await StorageFS.write(
-      path.join(streamDataDir(STREAM), 'usageStats.json'),
-      '{bad json',
-    );
-
-    const store = new StreamSnapshotStore();
-    await expect(
-      store.preload([STREAM], { usageOnly: true }),
-    ).rejects.toBeInstanceOf(SyntaxError);
-  });
-
   it('strips a retired runDescriptor sidecar without reading its FK', async () => {
     // Pre-FK sidecars carried a whole runDescriptor; that shape is retired.
     // The unknown key is stripped: no FK is lifted out of it, and the rest
@@ -2470,14 +2388,7 @@ describe('StreamSnapshotStore', () => {
     expect(error).toMatchObject({
       message: expect.stringContaining('snapshot disk is unreadable'),
       streamId: STREAM,
-      authoritativeFields: {
-        outputFiles: false,
-        missingOutputs: false,
-        compileFailures: false,
-        usage: false,
-        todos: true,
-        plan: true,
-      },
+      authoritativeFields: { complete: false, todos: true, plan: true },
     });
     await newerRefresh;
 

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -351,9 +351,7 @@ describe('completedRunArchive facade', () => {
       conversationResult.conversation,
     );
 
-    const todosResult = await readCompletedRunTodos(executionId);
-    expect(todosResult.source).toBe('streamData');
-    expect(todosResult.todos).toEqual([
+    expect(await readCompletedRunTodos(executionId)).toEqual([
       { content: 'Fix the bug', status: 'completed' },
     ]);
   });
@@ -526,14 +524,13 @@ describe('completedRunArchive facade', () => {
     );
   });
 
-  it('treats a present empty work plan as authoritative', async () => {
+  it('reads an empty task list from a present empty work plan', async () => {
     const executionId = '0aa2220aa222' as ExecutionId;
     const streamId = 'orchestrator@deepseekproT#0aa2220aa222' as StreamTabId;
     await seedStreams(executionId, [{ streamId, todos: [] }]);
     await stampStreamId(executionId, streamId);
-    const result = await readCompletedRunTodos(executionId);
 
-    expect(result).toEqual({ todos: [], source: 'streamData', streamId });
+    expect(await readCompletedRunTodos(executionId)).toEqual([]);
   });
 
   it('reports none, with no conversation evidence, when metadata has no stamped stream', async () => {
@@ -543,8 +540,7 @@ describe('completedRunArchive facade', () => {
     expect(conversationResult).toEqual({ conversation: null, source: 'none' });
     expect(hasCompletedRunConversationEvidence(conversationResult)).toBe(false);
 
-    const todosResult = await readCompletedRunTodos(executionId);
-    expect(todosResult).toEqual({ todos: [], source: 'none' });
+    expect(await readCompletedRunTodos(executionId)).toEqual([]);
 
     await getExecutionStore(executionId).writeMeta({
       timestamp: '2026-07-07T00:00:00.000Z',
@@ -596,8 +592,7 @@ describe('completedRunArchive facade', () => {
     // The stamped stream id alone is association evidence.
     expect(hasCompletedRunConversationEvidence(conversationResult)).toBe(true);
 
-    const todosResult = await readCompletedRunTodos(executionId);
-    expect(todosResult).toEqual({ todos: [], source: 'none' });
+    expect(await readCompletedRunTodos(executionId)).toEqual([]);
 
     expect(scan).not.toHaveBeenCalled();
   });

--- a/src/test-kernel/transcript/standaloneTraceHtml.vitest.ts
+++ b/src/test-kernel/transcript/standaloneTraceHtml.vitest.ts
@@ -28,7 +28,6 @@ function trace(overrides: Partial<TraceDocument> = {}): TraceDocument {
       streamId: STREAM_ID,
       status: 'ready',
     }),
-    terminalStatus: null,
     ...overrides,
   };
 }

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -215,5 +215,4 @@ describe('assembleTrace', () => {
     expect(trace.streamId).toBe(actualChildStreamId);
     expect(trace.entries).toHaveLength(1);
   });
-
 });

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -9,7 +9,6 @@ import {
 } from '@agent/core/definition/AgentConfig';
 import { getStreamTabId } from '@agent/runtime/streamTab';
 import {
-  EXECUTION_STATUS,
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
@@ -140,7 +139,7 @@ describe('assembleTrace', () => {
       id: 'entry-1',
       text: 'hello',
     });
-    expect(trace.terminalStatus).toBe(EXECUTION_STATUS.COMPLETED);
+    expect(trace.meta?.outcome).toBe('completed');
     expect(trace.snapshot.streamId).toBe(streamId);
   });
 
@@ -217,16 +216,4 @@ describe('assembleTrace', () => {
     expect(trace.entries).toHaveLength(1);
   });
 
-  it('returns a null terminalStatus when meta has no recorded outcome', async () => {
-    const executionId = 'exec-no-outcome' as ExecutionId;
-    const executionConfig = config();
-    const streamId = getStreamTabId(executionConfig.agent, { executionId });
-    await writeExecution(executionId, { streamId }, executionConfig);
-    await appendLogEntry(streamId, 'hello');
-
-    const trace = unwrapOkTrace(await assembleTrace(executionId));
-
-    expect(trace.meta).not.toBeNull();
-    expect(trace.terminalStatus).toBeNull();
-  });
 });

--- a/src/test-kernel/transcript/traceViewerSchema.vitest.ts
+++ b/src/test-kernel/transcript/traceViewerSchema.vitest.ts
@@ -51,7 +51,6 @@ function trace(
     meta: null,
     entries: [],
     snapshot: { streamId: 'stream-1' },
-    terminalStatus: null,
     ...overrides,
   };
 }
@@ -94,7 +93,7 @@ describe('trace-viewer TraceDataSchema', () => {
     if (!parsed.success) return;
     expect(parsed.data.executionId).toBe(executionId);
     expect(parsed.data.streamId).toBe(streamId);
-    expect(parsed.data.terminalStatus).toBe(EXECUTION_STATUS.COMPLETED);
+    expect(parsed.data.meta?.outcome).toBe('completed');
     expect(parsed.data.entries).toHaveLength(1);
 
     // parseTraceData must accept the same real document without throwing.
@@ -102,7 +101,7 @@ describe('trace-viewer TraceDataSchema', () => {
   });
 
   it('rejects a trace missing required top-level fields', () => {
-    // config, meta, entries, snapshot, terminalStatus all missing.
+    // config, meta, entries and snapshot all missing.
     expectTraceRejected({ executionId: 'abcdef', streamId: 'stream-1' });
   });
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -391,7 +391,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
 
     // Completed execution: full KV fetch
     const store = getExecutionStore(executionId);
-    const [meta, record, children, todosResult, report] = await Promise.all([
+    const [meta, record, children, todos, report] = await Promise.all([
       store.readMeta(),
       store.readRunRecord(),
       store.readChildren(),
@@ -434,7 +434,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       executionId,
       category,
       children,
-      todosResult.todos,
+      todos,
       report,
       { workflow: meta?.workflow },
     );
@@ -551,7 +551,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     const handle = session.executions.getHandle(executionId);
     const todos = handle
       ? getRunningTodos(session, handle)
-      : (await readCompletedRunTodos(executionId)).todos;
+      : await readCompletedRunTodos(executionId);
 
     if (todos.length === 0) {
       return executed(`No task list found for execution ${executionId}.`);

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -430,10 +430,8 @@ export class StreamLogStore {
    * racing it, so two batches can never persist the same stream out of order.
    */
   private readonly writeQueue = new PQueue({ concurrency: 1 });
-  private writeGeneration = 0;
   private readonly writeTombstones = new Set<StreamTabId>();
   private clearing = false;
-  private stateRevision = 0;
   private summaryCacheMaintenanceEnabled = true;
   /**
    * Streams whose durable write has already been reported as failing. The
@@ -479,15 +477,6 @@ export class StreamLogStore {
   /** Snapshot of streams with unsaved changes (list form of `dirtyIds`). */
   private dirtyStreamIds(): StreamTabId[] {
     return [...this.dirtyIds];
-  }
-
-  /** In-flight `ensureLoaded` promises across every resident stream. */
-  private pendingLoads(): Promise<void>[] {
-    const loads: Promise<void>[] = [];
-    for (const state of this.streams.values()) {
-      if (state.pendingLoad) loads.push(state.pendingLoad);
-    }
-    return loads;
   }
 
   /**
@@ -642,7 +631,6 @@ export class StreamLogStore {
     const summary = this.summaries.get(streamId);
     if (summary === undefined || isDeepStrictEqual(summary.meta, meta)) return;
     summary.meta = meta;
-    this.stateRevision += 1;
     // Share the transcript queue so flush() drains this write. Re-read at
     // execution time, and let a dirty transcript's own write carry the
     // metadata: persisting its newer log-derived summary fields before the
@@ -668,7 +656,6 @@ export class StreamLogStore {
       return;
     this.ensureStreamState(streamId).log = new StreamLog();
     this.summaries.set(streamId, {});
-    this.stateRevision += 1;
     if (this.mode.kind === 'persistent') {
       this.markDirty(streamId);
       this.scheduleSave();
@@ -900,7 +887,6 @@ export class StreamLogStore {
             diskEntries.preservedRawEntries,
           );
           this.ensureStreamState(streamId).log = merged;
-          this.stateRevision += 1;
           this.refreshSummary(streamId, merged);
           this.markDirty(streamId);
           this.scheduleSave();
@@ -914,7 +900,6 @@ export class StreamLogStore {
           );
           const state = this.ensureStreamState(streamId);
           state.log = logInstance;
-          this.stateRevision += 1;
           this.refreshSummary(streamId, logInstance);
           // An eviction request that arrived while the load was in flight gets
           // queued; honor it now (unless a reactivation cleared the intent).
@@ -1071,7 +1056,6 @@ export class StreamLogStore {
       // only after durable deletion succeeds so callers can retain and retry a
       // stream whose transcript cleanup failed.
       this.forgetStreamState(streamId);
-      this.stateRevision += 1;
     } catch (error) {
       // executeWrite() drains dirty ids while the tombstone suppresses writes.
       // Restore the retry marker if deletion fails and a resident log remains.
@@ -1090,10 +1074,8 @@ export class StreamLogStore {
     this.assertWritableStore('clear transcript streams');
     const count = this.summaries.size;
     this.clearing = true;
-    this.writeGeneration += 1;
     this.saveThrottle.cancel();
     this.forgetAllStreamState();
-    this.stateRevision += 1;
 
     try {
       await this.writeQueue.onIdle();
@@ -1229,8 +1211,8 @@ export class StreamLogStore {
     if (this.mode.kind === 'ephemeral') return;
 
     // Drain iteratively: executeWrite may re-queue streams that are still
-    // rehydrating (`pendingLoads`) or whose prior load failed. Wait for
-    // those to resolve and then re-run the save, so shutdown doesn't lose
+    // rehydrating (a resident `pendingLoad`) or whose prior load failed. Wait
+    // for those to resolve and then re-run the save, so shutdown doesn't lose
     // appends that landed on a resumed stream. Bound the loop by the set
     // of streams that could still make progress — if the only dirty
     // entries are persistently `loadFailed`, we can't persist them.
@@ -1240,7 +1222,11 @@ export class StreamLogStore {
     const MAX_WRITE_RETRIES = 3;
     let writeAttempts = 0;
     while (true) {
-      const loads = this.pendingLoads();
+      // In-flight `ensureLoaded` promises across every resident stream.
+      const loads: Promise<void>[] = [];
+      for (const state of this.streams.values()) {
+        if (state.pendingLoad) loads.push(state.pendingLoad);
+      }
       if (this.saveThrottle.pending) {
         this.saveThrottle.cancel();
         await this.executeWrite();
@@ -1288,7 +1274,6 @@ export class StreamLogStore {
   private commitChange(streamId: StreamTabId, logInstance: StreamLog): void {
     this.assertWritableStore('commit transcript changes');
     this.refreshSummary(streamId, logInstance);
-    this.stateRevision += 1;
     if (this.mode.kind === 'persistent') this.markDirty(streamId);
     this.notify(streamId);
   }
@@ -1352,7 +1337,6 @@ export class StreamLogStore {
     }
     this.writeTombstones.clear();
     this.clearing = false;
-    this.stateRevision += 1;
 
     log.info(`Loaded ${this.summaries.size} stream summaries (file-backed)`);
   }
@@ -1440,11 +1424,10 @@ export class StreamLogStore {
   private async writeStream(
     streamId: StreamTabId,
     logInstance: StreamLog,
-    expectedGeneration: number = this.writeGeneration,
   ): Promise<void> {
-    if (this.shouldSkipWrite(streamId, expectedGeneration)) return;
+    if (this.shouldSkipWrite(streamId)) return;
     await this.logsKv.write(streamId, logInstance.toPersistedEntries());
-    if (this.shouldSkipWrite(streamId, expectedGeneration)) {
+    if (this.shouldSkipWrite(streamId)) {
       await this.logsKv.delete(streamId);
       await this.deleteSummaryCache(streamId);
       return;
@@ -1458,19 +1441,22 @@ export class StreamLogStore {
       ...toSummary(logInstance),
       ...(meta !== undefined && { meta }),
     });
-    if (this.shouldSkipWrite(streamId, expectedGeneration)) {
+    if (this.shouldSkipWrite(streamId)) {
       await this.logsKv.delete(streamId);
       await this.deleteSummaryCache(streamId);
     }
   }
 
-  private shouldSkipWrite(
-    streamId: StreamTabId,
-    expectedGeneration: number,
-  ): boolean {
+  /**
+   * Whether an in-flight write batch must drop this stream. `clearing` is the
+   * single owner of "a clear is in progress": it is set synchronously before
+   * `clear()` awaits `writeQueue.onIdle()`, and the queue has concurrency 1,
+   * so every batch that could still be carrying pre-clear data runs while it
+   * is true.
+   */
+  private shouldSkipWrite(streamId: StreamTabId): boolean {
     return (
       this.clearing ||
-      expectedGeneration !== this.writeGeneration ||
       this.writeTombstones.has(streamId) ||
       !this.summaries.has(streamId)
     );
@@ -1605,7 +1591,6 @@ export class StreamLogStore {
     if (state.log) {
       this.refreshSummary(streamId, state.log);
       state.log = undefined;
-      this.stateRevision += 1;
     }
     this.pruneStreamState(streamId);
   }
@@ -1713,7 +1698,6 @@ export class StreamLogStore {
     if (toWrite.length === 0) return;
 
     log.debug(`Writing ${toWrite.length} dirty stream(s)`);
-    const writeGeneration = this.writeGeneration;
 
     // Write streams one at a time. Each KV write serializes the stream's full
     // transcript to JSON before the filesystem await; starting every dirty
@@ -1725,7 +1709,7 @@ export class StreamLogStore {
         const logInstance = this.streams.get(streamId)?.log;
         if (!logInstance) continue;
         try {
-          await this.writeStream(streamId, logInstance, writeGeneration);
+          await this.writeStream(streamId, logInstance);
           this.writeFailureWarned.delete(streamId);
         } catch (error) {
           // Failed writes re-mark their stream dirty so the next save retries.

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -83,7 +83,6 @@ import {
   emptyStreamData,
   readMeta,
   readStreamData,
-  readUsageData,
   type StreamData,
 } from './streamSnapshotRead';
 import type PQueue from 'p-queue';
@@ -102,24 +101,17 @@ const MAX_DIRTY_WRITE_RETRIES = 3;
 
 class DirtySidecarWritesError extends Error {}
 
-/** Artifact fields whose in-memory values remain authoritative after preload fails. */
+/** Artifact state whose in-memory values remain authoritative after preload fails. */
 export interface StreamArtifactAuthority {
-  readonly outputFiles: boolean;
-  readonly missingOutputs: boolean;
-  readonly compileFailures: boolean;
-  readonly usage: boolean;
+  /**
+   * The whole in-memory record is authoritative: a prior seed or an existence
+   * probe already established this stream's disk baseline, so every
+   * accumulator holds the complete field value and not just a delta.
+   */
+  readonly complete: boolean;
   readonly todos: boolean;
   readonly plan: boolean;
 }
-
-const ALL_STREAM_ARTIFACTS_AUTHORITATIVE = Object.freeze({
-  outputFiles: true,
-  missingOutputs: true,
-  compileFailures: true,
-  usage: true,
-  todos: true,
-  plan: true,
-}) satisfies StreamArtifactAuthority;
 
 /** A failed preload together with the in-memory fields that remain usable. */
 export class StreamSnapshotPreloadError extends Error {
@@ -361,16 +353,15 @@ function artifactAuthorityAfterPreloadFailure(
   baseline: DiskState,
   overlays: Partial<OverlayPatches>,
 ): StreamArtifactAuthority {
-  if (baseline !== 'unknown') return ALL_STREAM_ARTIFACTS_AUTHORITATIVE;
+  // Without an established baseline the output-file / missing-output /
+  // compile-failure / usage overlays are deltas over an unread disk state, so
+  // they establish nothing. Plan and todos are replacements, so a live overlay
+  // for either is authoritative on its own.
+  const complete = baseline !== 'unknown';
   return {
-    // These four overlays are deltas over an unread disk baseline, so they do
-    // not establish the complete field value. Plan and todos are replacements.
-    outputFiles: false,
-    missingOutputs: false,
-    compileFailures: false,
-    usage: false,
-    todos: overlays.workPlan?.todos !== undefined,
-    plan: overlays.workPlan?.plan !== undefined,
+    complete,
+    todos: complete || overlays.workPlan?.todos !== undefined,
+    plan: complete || overlays.workPlan?.plan !== undefined,
   };
 }
 
@@ -401,8 +392,6 @@ interface StreamRecord {
    * lossy read permanently deleting them on the next save (#7464).
    */
   usageUnparsed: Map<string, unknown>;
-  /** Usage was hydrated by a usage-only seed; `getRunUsage` needs no warning. */
-  usageProvenance: boolean;
   workPlan: WorkPlanSnapshot;
   meta: StreamTabMeta | undefined;
   /**
@@ -469,7 +458,6 @@ export class StreamSnapshotStore {
     compileFailures: {},
     usage: new Map(),
     usageUnparsed: new Map(),
-    usageProvenance: false,
     workPlan: EMPTY_WORK_PLAN,
     meta: undefined,
     runExecutionId: undefined,
@@ -509,7 +497,7 @@ export class StreamSnapshotStore {
    * mutations queued behind them — the same `PQueue({ concurrency: 1 })`-
    * per-key precedent as `streamApprovalQueue.ts`. Each queued unit of work
    * still publishes its promise onto `record.seedChain` for the readers that
-   * await it (`awaitSeeded`, `seedUsageOnly`, `flush`, staged deletion).
+   * await it (`awaitSeeded`, `flush`, staged deletion).
    */
   private readonly seedQueues = new Map<StreamTabId, PQueue>();
 
@@ -1082,11 +1070,8 @@ export class StreamSnapshotStore {
   }
 
   getRunUsage(stream: StreamTabId): ReadonlyMap<string, TokenUsageStats> {
-    const record = this.records.get(stream);
-    if (!record?.usageProvenance) {
-      this.warnIfUnseeded('getRunUsage', stream);
-    }
-    return record?.usage ?? EMPTY_RUN_USAGE;
+    this.warnIfUnseeded('getRunUsage', stream);
+    return this.records.get(stream)?.usage ?? EMPTY_RUN_USAGE;
   }
 
   /** Flattened set of known output-file paths for a stream. */
@@ -1209,23 +1194,6 @@ export class StreamSnapshotStore {
   async deleteStream(stream: StreamTabId): Promise<void> {
     const deletion = await this.stageDeleteStream(stream);
     await deletion.commit();
-  }
-
-  /** Delete the entire `streamData/` tree + all in-memory state. */
-  async deleteAll(): Promise<void> {
-    const pending = [...this.writeMutexes.values()].map((mutex) =>
-      mutex.waitForUnlock(),
-    );
-    this.evictAll();
-    await Promise.all(pending);
-    await Promise.all([
-      new KVStore(STREAM_DATA_DIR).deleteDir(),
-      StorageFS.delete(STREAM_DATA_DELETION_DIR, { recursive: true }).catch(
-        (error: unknown) => {
-          if (!isFileNotFoundError(error)) throw error;
-        },
-      ),
-    ]);
   }
 
   private setTodos(stream: StreamTabId, todos: TodoItem[]): void {
@@ -1470,14 +1438,6 @@ export class StreamSnapshotStore {
   /** Streams left in reversible staging by an interrupted deletion. */
   async listStagedDeletions(): Promise<StreamTabId[]> {
     return this.listStreamsUnder(STREAM_DATA_DELETION_DIR);
-  }
-
-  /**
-   * Whether a stream has a persisted `workPlan.json` sidecar — an existence
-   * check only (a single stat via `KVStore.exists`), not a read.
-   */
-  async hasPersistedWorkPlan(stream: StreamTabId): Promise<boolean> {
-    return this.kv(stream).exists(STREAM_DATA_KEYS.WORK_PLAN);
   }
 
   getParentStreamId(stream: StreamTabId): StreamTabId | undefined {
@@ -1741,8 +1701,8 @@ export class StreamSnapshotStore {
    * seeded (via {@link load} or a progress event) its in-memory accumulators
    * are the single source of truth — they already hold the disk state plus any
    * newer deltas — so we assemble from memory and skip a redundant disk re-read.
-   * The CLI resume path calls `load` then `read` back-to-back. Only an unseeded
-   * stream, such as a display-only read that was never resumed, hits disk.
+   * Only an unseeded stream — a display-only read from a call-scoped store that
+   * was never `load`ed or `preload`ed — hits disk.
    */
   async read(streamId: StreamTabId): Promise<StreamSnapshot> {
     if (await this.awaitSeeded(streamId)) {
@@ -1785,21 +1745,6 @@ export class StreamSnapshotStore {
   }
 
   /**
-   * A stream's output files (round → files). Served from the seeded in-memory
-   * accumulators when available — the single source of truth — so a caller that
-   * already `load()`ed the stream doesn't re-read all sidecars from disk; only
-   * an unseeded stream falls back to a disk read.
-   */
-  async readOutputFiles(
-    streamId: StreamTabId,
-  ): Promise<ReadonlyRoundIndexed<OutputFileInfo>> {
-    if (await this.awaitSeeded(streamId)) {
-      return this.getOutputFiles(streamId);
-    }
-    return (await readStreamData(this.kv(streamId))).outputFiles;
-  }
-
-  /**
    * Authoritatively hydrate the in-memory accumulators from the stream-log set.
    * Streams not present in `streamIds` are evicted; streams that are present are
    * refreshed from disk even if this store had seeded them before, so a reused
@@ -1818,11 +1763,6 @@ export class StreamSnapshotStore {
    * startup; later mutations for other streams must still seed from disk before
    * writing.
    *
-   * `usageOnly` hydrates only the per-stream usage sidecar. Restart repair uses
-   * it for parked WAITING streams so the status-bar usage total is correct
-   * immediately without making the full 6-file record resident for the whole
-   * session (#9947, #10520).
-   *
    * `reportArtifactAuthority` wraps a failed full preload with the fields whose
    * prior seed or live overlay remains authoritative, so a reader may retain
    * accepted in-memory state without treating unread disk defaults as facts.
@@ -1830,44 +1770,10 @@ export class StreamSnapshotStore {
   async preload(
     streamIds: readonly StreamTabId[],
     options?: {
-      readonly usageOnly?: boolean;
       readonly reportArtifactAuthority?: boolean;
     },
   ): Promise<void> {
-    if (options?.usageOnly) {
-      await pMap(streamIds, (streamId) => this.seedUsageOnly(streamId), {
-        concurrency: SEED_IO_CONCURRENCY,
-      });
-      return;
-    }
     await this.seedStreams(streamIds, options?.reportArtifactAuthority);
-  }
-
-  private async seedUsageOnly(streamId: StreamTabId): Promise<void> {
-    if (this.hasDiskProvenance(streamId)) return;
-    const version = this.streamVersion(streamId);
-    const record = this.getOrCreateRecord(streamId);
-    if (record.seedChain) {
-      await record.seedChain.catch(() => undefined);
-    }
-    if (this.streamVersion(streamId) !== version) return;
-    if (this.hasDiskProvenance(streamId)) return;
-    const usage = await readUsageData(this.kv(streamId));
-    if (this.streamVersion(streamId) !== version) return;
-    const current = this.records.get(streamId);
-    if (!current || current.diskState !== 'unknown') return;
-    current.usage = new Map(usage.usage);
-    current.usageUnparsed = new Map(usage.unparsedRuns);
-    // Replay any eager live usage delta that landed while the disk read was
-    // pending. The overlay stays in place so a later full seed replays it once
-    // on top of freshly-read disk usage; this seed performs no writes itself.
-    const usageOverlay = current.overlays.usage;
-    if (usageOverlay) {
-      for (const [storageKey, delta] of usageOverlay) {
-        this.applyUsageDeltaMemory(current, storageKey, delta);
-      }
-    }
-    current.usageProvenance = true;
   }
 
   private async seedStreams(

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -229,11 +229,20 @@ function utf8Prefix(text: string, byteBudget: number): string {
 /**
  * The longest suffix of `text` that encodes within `byteBudget` UTF-8 bytes,
  * found by walking the encoded bytes back past any `10xxxxxx` continuation
- * bytes to the nearest code-point boundary.
+ * bytes to the nearest code-point boundary. Only a bounded tail window is
+ * encoded: every UTF-16 code unit contributes at least one UTF-8 byte, so a
+ * `byteBudget + 1`-unit window always covers the kept bytes without an
+ * input-sized allocation on a huge single-line input, and the extra unit
+ * guarantees that a surrogate pair split by the window edge has its
+ * replacement bytes dropped before the kept region. Not exact for ill-formed
+ * input: a lone surrogate inside the kept suffix decodes to U+FFFD instead of
+ * surviving as a raw code unit (the persisted JSON bytes are identical either
+ * way, and the byte accounting matches — both encode to three bytes).
  */
 function utf8Suffix(text: string, byteBudget: number): string {
-  const bytes = UTF8_ENCODER.encode(text);
-  if (bytes.length <= byteBudget) return text;
+  const window = text.slice(Math.max(0, text.length - (byteBudget + 1)));
+  const bytes = UTF8_ENCODER.encode(window);
+  if (window.length === text.length && bytes.length <= byteBudget) return text;
   let start = Math.max(0, bytes.length - byteBudget);
   while (start < bytes.length && (bytes[start] & 0xc0) === 0x80) start += 1;
   return UTF8_DECODER.decode(bytes.subarray(start));

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -73,6 +73,7 @@ const TRANSCRIPT_TRUNCATION_MARKER =
 const LIVE_TOOL_TRUNCATION_MARKER =
   '\n\n… output truncated while the tool is running …\n\n';
 const UTF8_ENCODER = new TextEncoder();
+const UTF8_DECODER = new TextDecoder();
 
 const KNOWN_MESSAGE_TYPES = new Set<string>(Object.values(MESSAGE_TYPES));
 
@@ -214,48 +215,28 @@ function boundedTranscriptPreview(
   return `${head}${marker}${tail}`;
 }
 
+/**
+ * The longest prefix of `text` that encodes within `byteBudget` UTF-8 bytes.
+ * `encodeInto` reports how many source code units fit whole into the
+ * destination, which is exactly the code-point boundary we want.
+ */
 function utf8Prefix(text: string, byteBudget: number): string {
-  let bytes = 0;
-  let end = 0;
-  for (const character of text) {
-    const characterBytes = utf8CharacterBytes(character);
-    if (bytes + characterBytes > byteBudget) break;
-    bytes += characterBytes;
-    end += character.length;
-  }
-  return text.slice(0, end);
+  if (byteBudget <= 0) return '';
+  const { read } = UTF8_ENCODER.encodeInto(text, new Uint8Array(byteBudget));
+  return text.slice(0, read);
 }
 
+/**
+ * The longest suffix of `text` that encodes within `byteBudget` UTF-8 bytes,
+ * found by walking the encoded bytes back past any `10xxxxxx` continuation
+ * bytes to the nearest code-point boundary.
+ */
 function utf8Suffix(text: string, byteBudget: number): string {
-  let bytes = 0;
-  let start = text.length;
-  while (start > 0) {
-    let characterStart = start - 1;
-    const codeUnit = text.charCodeAt(characterStart);
-    if (
-      codeUnit >= 0xdc00 &&
-      codeUnit <= 0xdfff &&
-      characterStart > 0 &&
-      text.charCodeAt(characterStart - 1) >= 0xd800 &&
-      text.charCodeAt(characterStart - 1) <= 0xdbff
-    ) {
-      characterStart -= 1;
-    }
-    const character = text.slice(characterStart, start);
-    const characterBytes = utf8CharacterBytes(character);
-    if (bytes + characterBytes > byteBudget) break;
-    bytes += characterBytes;
-    start = characterStart;
-  }
-  return text.slice(start);
-}
-
-function utf8CharacterBytes(character: string): number {
-  const codePoint = character.codePointAt(0) ?? 0;
-  if (codePoint <= 0x7f) return 1;
-  if (codePoint <= 0x7ff) return 2;
-  if (codePoint <= 0xffff) return 3;
-  return 4;
+  const bytes = UTF8_ENCODER.encode(text);
+  if (bytes.length <= byteBudget) return text;
+  let start = Math.max(0, bytes.length - byteBudget);
+  while (start < bytes.length && (bytes[start] & 0xc0) === 0x80) start += 1;
+  return UTF8_DECODER.decode(bytes.subarray(start));
 }
 
 export function attachTranscriptRecorder(
@@ -356,7 +337,12 @@ export function attachTranscriptRecorder(
     if (!state.enabled) return;
 
     if (!state.created) {
-      const entry = {
+      // A state is only ever created by the `stream.start` arm, which flushes
+      // it synchronously with `ended: false`, so this row is always the
+      // still-running opener. An ended-before-created variant would be the one
+      // write path that persists `state.buffer` raw, bypassing
+      // `boundModelResponse`'s bounding and spill.
+      writer.append({
         id,
         type: STREAM_LOG_ENTRY_TYPES.LOG,
         level: 'info',
@@ -364,11 +350,9 @@ export function attachTranscriptRecorder(
         groupId: state.groupId,
         messageType: state.messageType,
         text: redactSecrets(state.buffer),
-        data: { status: state.ended ? 'completed' : 'running' },
+        data: { status: 'running' },
         verbose: isDebugModeEnabled(),
-      } satisfies StreamLogAppendInput;
-      if (state.ended) writer.appendSettled(entry);
-      else writer.append(entry);
+      } satisfies StreamLogAppendInput);
       state.created = true;
       return;
     }

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -33,59 +33,36 @@ import { StreamSnapshotStore } from './StreamSnapshotStore';
  *
  * The resolved branch carries the already-read `meta` so a caller that also
  * needs other metadata fields (the trace assembler) does not pay a second
- * `readMeta()`. The absence reason is typed so callers can distinguish "no
- * execution metadata at all" from "metadata that predates stamped streams".
+ * `readMeta()`. Absence is a plain `null`: no execution metadata at all and
+ * metadata predating stamped streams are the same answer to every caller.
  */
-export type ExecutionStreamResolution =
-  | {
-      readonly streamId: StreamTabId;
-      readonly meta: ExecutionMeta;
-    }
-  | { readonly reason: 'no-meta' | 'no-stream' };
-
 export async function resolveStreamForExecution(
   executionId: ExecutionId,
-): Promise<ExecutionStreamResolution> {
+): Promise<{
+  readonly streamId: StreamTabId;
+  readonly meta: ExecutionMeta;
+} | null> {
   const meta = await getExecutionStore(executionId).readMeta();
-  if (!meta) return { reason: 'no-meta' };
-  if (!meta.streamId) return { reason: 'no-stream' };
+  if (!meta?.streamId) return null;
   return { streamId: meta.streamId, meta };
-}
-
-type CompletedRunTodosSource = 'streamData' | 'none';
-
-export interface CompletedRunTodosReadResult {
-  readonly todos: TodoEntry[];
-  readonly source: CompletedRunTodosSource;
-  readonly streamId?: StreamTabId;
 }
 
 /**
  * Read the archived task list for a completed run from the durable stream
  * sidecar (`streamData/{stream}/workPlan.json`), keyed through
- * {@link resolveStreamForExecution}.
+ * {@link resolveStreamForExecution}. An unresolved execution, a missing
+ * sidecar and an empty one all read as `[]` — no consumer distinguished them.
  */
 export async function readCompletedRunTodos(
   executionId: ExecutionId,
-): Promise<CompletedRunTodosReadResult> {
-  const snapshotStore = new StreamSnapshotStore();
+): Promise<TodoEntry[]> {
   const resolution = await resolveStreamForExecution(executionId);
-
-  if (
-    !('reason' in resolution) &&
-    (await snapshotStore.hasPersistedWorkPlan(resolution.streamId))
-  ) {
-    const snapshot = await snapshotStore.read(resolution.streamId);
-    return {
-      todos: snapshot.todos.map((todo): TodoEntry => ({
-        content: todo.content,
-        status: todo.status,
-      })),
-      source: 'streamData',
-      streamId: resolution.streamId,
-    };
-  }
-  return { todos: [], source: 'none' };
+  if (!resolution) return [];
+  const snapshot = await new StreamSnapshotStore().read(resolution.streamId);
+  return snapshot.todos.map((todo): TodoEntry => ({
+    content: todo.content,
+    status: todo.status,
+  }));
 }
 
 // ============================================================================
@@ -339,7 +316,7 @@ export async function readCompletedRunConversation(
   executionId: ExecutionId,
 ): Promise<CompletedRunConversationReadResult> {
   const resolution = await resolveStreamForExecution(executionId);
-  if ('reason' in resolution) return { conversation: null, source: 'none' };
+  if (!resolution) return { conversation: null, source: 'none' };
   const { streamId } = resolution;
 
   // A call-scoped read-only store seeded with just this stream, so this

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -7,6 +7,7 @@
 import { getExecutionStore, type TodoEntry } from '@agent/storage';
 import { formatToolResultAsText } from '@agent/modelHandlers/utils/toolAttachmentUtils';
 import { stringifyConversationValue } from '@agent/storage/conversationFormat';
+import { KVStore } from '@common/storage/KVStore';
 import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
@@ -21,7 +22,8 @@ import {
 import { assertNever, isObject } from '@utils/core';
 
 import { StreamLogStore } from './StreamLogStore';
-import { StreamSnapshotStore } from './StreamSnapshotStore';
+import { streamDataDir } from './streamDataPaths';
+import { readWorkPlan } from './streamSnapshotRead';
 
 /**
  * The execution→stream foreign key: the `streamId` stamped on execution
@@ -58,8 +60,10 @@ export async function readCompletedRunTodos(
 ): Promise<TodoEntry[]> {
   const resolution = await resolveStreamForExecution(executionId);
   if (!resolution) return [];
-  const snapshot = await new StreamSnapshotStore().read(resolution.streamId);
-  return snapshot.todos.map((todo): TodoEntry => ({
+  const workPlan = await readWorkPlan(
+    new KVStore(streamDataDir(resolution.streamId)),
+  );
+  return workPlan.todos.map((todo): TodoEntry => ({
     content: todo.content,
     status: todo.status,
   }));

--- a/src/transcript/streamSnapshotRead.ts
+++ b/src/transcript/streamSnapshotRead.ts
@@ -192,6 +192,16 @@ function readPersistedWorkPlan(raw: unknown): WorkPlanSnapshot {
   });
 }
 
+/**
+ * Read only `workPlan.json` for a stream. Completed-run todo readers use this
+ * so a run that never created tasks reads one file instead of five, and an
+ * I/O error in an unrelated sidecar (e.g. `outputFiles.json`) cannot fail a
+ * todos lookup.
+ */
+export async function readWorkPlan(kv: KVStore): Promise<WorkPlanSnapshot> {
+  return readPersistedWorkPlan(await tryRead(kv, STREAM_DATA_KEYS.WORK_PLAN));
+}
+
 /** Read every per-stream sidecar file once. */
 export async function readStreamData(kv: KVStore): Promise<StreamData> {
   const meta = await readMeta(kv);

--- a/src/transcript/streamSnapshotRead.ts
+++ b/src/transcript/streamSnapshotRead.ts
@@ -23,7 +23,6 @@ import {
   WorkPlanSnapshotShape,
   type CompileFailure,
   type OutputFileInfo,
-  type ParsedUsageData,
   type RoundIndexed,
   type StreamSnapshot,
   type StreamTabId,
@@ -225,23 +224,6 @@ export async function readStreamData(kv: KVStore): Promise<StreamData> {
     usageUnparsed,
     workPlan,
   };
-}
-
-/**
- * Read only the per-stream usage sidecar for usage-only hydration paths.
- *
- * Unlike the tolerant full-stream read, this path must never turn a
- * corrupt-present `usageStats.json` into an authoritative zero map: genuine
- * I/O errors and JSON `SyntaxError` propagate, and a present non-object value
- * is rejected instead of being silently treated as empty.
- */
-export async function readUsageData(kv: KVStore): Promise<ParsedUsageData> {
-  const raw = await kv.read(STREAM_DATA_KEYS.USAGE_STATS);
-  if (raw === undefined) return parseUsageData(undefined);
-  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
-    throw new Error('Invalid persisted usageStats.json');
-  }
-  return parseUsageData(raw);
 }
 
 /**

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -11,7 +11,6 @@
  */
 import { getExecutionStore } from '@agent/storage';
 import type { ExecutionId } from '@shared/schemas';
-import { runOutcomeToExecutionStatus } from '@shared/streams/streamStatus';
 
 import { resolveStreamForExecution } from './completedRunArchive';
 import { StreamLogStore } from './StreamLogStore';
@@ -37,7 +36,7 @@ export async function assembleTrace(
   ]);
   const snapshotStore = new StreamSnapshotStore();
   if (!config) return { status: 'config_missing' };
-  if ('reason' in resolution) return { status: 'streamLogs_missing' };
+  if (!resolution) return { status: 'streamLogs_missing' };
   const { streamId, meta } = resolution;
 
   // A call-scoped read-only store seeded with just this stream avoids
@@ -50,20 +49,8 @@ export async function assembleTrace(
     snapshotStore.read(streamId),
   ]);
 
-  const terminalStatus = meta.outcome
-    ? runOutcomeToExecutionStatus(meta.outcome)
-    : null;
-
   return {
     status: 'ok',
-    trace: {
-      executionId,
-      streamId,
-      config,
-      meta,
-      entries,
-      snapshot,
-      terminalStatus,
-    },
+    trace: { executionId, streamId, config, meta, entries, snapshot },
   };
 }

--- a/src/transcript/traceDocumentSchema.ts
+++ b/src/transcript/traceDocumentSchema.ts
@@ -4,7 +4,6 @@ import { RunRecordSchema } from '@agent/core/definition/RunRecord';
 import {
   ExecutionIdSchema,
   ExecutionMetaSchema,
-  ExecutionStatusSchema,
   StreamLogEntrySchema,
   StreamSnapshotSchema,
   StreamTabIdSchema,
@@ -25,8 +24,6 @@ export const TraceDocumentSchema = z.object({
    */
   entries: z.array(StreamLogEntrySchema),
   snapshot: StreamSnapshotSchema,
-  /** `null` for executions that predate outcome tracking or never terminated. */
-  terminalStatus: ExecutionStatusSchema.nullable(),
 });
 
 export type TraceDocument = Readonly<z.infer<typeof TraceDocumentSchema>>;


### PR DESCRIPTION
Implements the verified simplification-survey findings for lane **l3-model-transcript** (src/model + src/transcript), rebased onto current main. Net **-476 lines** across 35 files; ratchet baselines only shrink, never widen.

## Implemented findings

- **#66** computeModelOptions' `access` parameter and the cached/uncached dual path exist only for tests
- **#70** effectiveKimiCodeConfig is a rename-only adapter that repeats an eligibility check its callee already performs
- **#71** buildVisibleBasicModelOptionsData is a single-caller wrapper whose only parameter is never passed
- **#72** Two src/model exports are baselined dead because only tests import them; narrowed and the knip baseline shrunk
- **#73** "Why can't Copilot serve this model" is worded twice, with the picker collapsing a state the dispatch path keeps distinct
- **#74** ModelOptionsBasic.vitest.ts pins llm-zoo registry data and a golden hash by hand — 3 edits in 15 days, all from unrelated catalogue PRs
- **#76** `isGptFamilyModelName` is a single-caller extraction of `.toLowerCase().startsWith('gpt')`
- **#79** StreamLogStore.stateRevision is a write-only counter left behind by the deleted reload() path
- **#80** StreamLogStore.writeGeneration now mirrors the `clearing` flag it is checked beside
- **#84** Two single-caller private helpers in StreamLogStore (partial: `pendingLoads()` inlined; `needsReload` kept — inlining it is net-zero)
- **#85** Delete the usage-only preload mode: its sole production caller was removed on 2026-08-23
- **#86** StreamSnapshotStore.deleteAll() has zero callers anywhere — deleted, store-public-surface ratchet shrunk
- **#87** StreamArtifactAuthority carries six booleans but four are a constant proxy for one fact (replaced by `.complete`)
- **#88** readOutputFiles' memory fast path is unreachable in production — every caller uses a call-scoped, never-seeded store
- **#89** Replace the hand-rolled UTF-8 byte-budget slicers in TexraTranscriptRecorder with TextEncoder.encodeInto / continuation-byte alignment
- **#90** Collapse the completed-run read envelopes (partial: steps 1-3 + 5; step 4 REFUTED — ExecutionsTool.ts prints `Source: ${source}` in showConversation output)
- **#91** Dead ended-branch in TexraTranscriptRecorder.flushStream's not-yet-created path
- **#92** TraceDocument.terminalStatus duplicates the embedded meta.outcome; the viewer immediately inverts the projection
- **#93** ExecutionStreamResolution's typed absence reason ('no-meta' | 'no-stream') has zero readers at all three call sites

### Deliberate behavior changes (each stated in its proposal, approved by its verifier)

- **#73**: the model picker's two Copilot unavailable-reason sentences now use the dispatch path's wording (`copilotRouteUnavailableReason`); a model with no discovered Copilot route gets the accurate "VS Code does not currently offer …" sentence. User-visible prose change; no test pinned the old strings.
- **#88**: a structurally corrupt sidecar set under `latexdiff` output discovery now degrades through assembleSnapshot's loud warn+empty fallback instead of returning partially parsed rounds; outputDiscovery treats an empty round map as not-found and falls through to the run-dir scan.
- **#92**: a hand-authored trace.json carrying `terminalStatus` but no `meta.outcome` now falls to the GROUP_END scan then snapshot.status. No TeXRA build has ever emitted such a file. **Maintainer note**: this supersedes the explicit keep-line in `docs/proposals/2026-08-03-run-classification-consolidation.md` ("the exporter keeps projecting via runOutcomeToExecutionStatus at that one boundary"); its stated rationale (old-trace compat, vocabulary confinement) is preserved by reading the embedded `meta.outcome` — the same doc's removal table deleted the planned `TraceDocument.identity` for the identical embedded-meta reason. An old dev-mode viewer bundle can no longer parse a NEW bare trace.json; exports inline their matching viewer, so this only affects the `main.ts` dev fetch affordance.
- **#74**: reverts the 2-week-old golden hash pin from #10036. Kept: the wiring assertion, the >21 migration-range invariant, the synthetic computeModelListVersion mechanism tests, and the model-agnostic DEFAULT_MODELS invariants.

## Net elements (R6)

- **Files touched**: 35 (`git diff --stat origin/main`: 301 insertions, 777 deletions, **net -476 LoC**)
- **Exported symbols**: -11 export declarations removed, +1 added (the re-derived `ExecutionStatus` type) → net **-10**
- **Class/interface/enum declarations**: **-2** (`ModelOptionsAccess`, `CompletedRunTodosReadResult`), +0
- **Ratchet baselines (shrink only)**: knip-baseline.json -2 entries; store-public-surface-baseline.json -3 rows

## Consumer counts (R8)

`rg` over the final tree (production + tests), post-deletion:

| Deleted export / surface | Remaining refs | Notes |
| --- | --- | --- |
| `ModelOptionsAccess` (interface) | 0 | |
| `buildVisibleBasicModelOptionsData` | 0 | |
| `isGptFamilyModelName` | 0 | |
| `CODEX_PREFER_SUBSCRIPTION_KEY` | 0 imports | un-exported, module-private; 2 vitest files use the literal key string |
| `activeCodingPlanForModel` | 0 imports | un-exported, module-private (3 in-module refs) |
| `CodingPlanSubscriptionRuntime.isActiveForModel` | 0 external | moved into module-private RUNTIME_BY_ID shape |
| `executionStatusToRunOutcome` | 0 | |
| `ExecutionStatusSchema` (follow-on) | 0 | last parse-site was the deleted `terminalStatus`; `ExecutionStatus` type re-derived from the const table |
| `readUsageData` | 0 | |
| `ExecutionStreamResolution` (type) | 0 | |
| `CompletedRunTodosReadResult` / `CompletedRunTodosSource` | 0 | |
| `StreamSnapshotStore.deleteAll` | 0 | `SessionStores.deleteAll` at SessionState.ts:667 is a different class |
| `StreamSnapshotStore.readOutputFiles` | 0 | |
| `StreamSnapshotStore.hasPersistedWorkPlan` | 0 | |
| `StreamArtifactAuthority.outputFiles/.missingOutputs/.compileFailures/.usage` | 0 | replaced by `.complete` |
| `TraceDocumentSchema.terminalStatus` | 0 in src/transcript + packages/trace-viewer | |

## Skipped

- **#81** — tier deferred, verifier DOWNGRADE: the proposal as written silently strips legacy three-flag summaries (z.object drops unknown keys, so the safeParse rebuild path never fires) and pre-upgrade orphans stay stuck "running" forever. Needs a parseSummaryShape legacy-key staleness guard, i.e. a persisted derived-cache migration, not a behavior-preserving collapse.
- **#188** — not behavior-preserving and net-positive: requires a NEW src/model GLM routing module, restructures ProxyConfigResolver.resolveDirectEndpoint's cascade, and changes the CLI status line; also collides with #72's narrowing shipped here. Needs its own design PR. (The underlying defect is real: with a custom GLM endpoint, packages/cli/src/runtime/modelAccess.ts reports "api: GLM Coding Plan" while ProxyConfigResolver routes elsewhere — worth its own issue.)
- **#204** — verifier already trimmed it to net ~0 LoC with zero elements deleted, and the surviving scope changes error behavior on persisted lifecycle data (loud write-site throw → later read-side warn + null). Fails the net-negative and behavior-preservation bars.

## Validation

`npm run typecheck`, `npm run lint`, `npm test` (822 files / 9993 tests passed), and `npm run check:dead-code-ratchet` all green on the rebased branch. Gate fixes on top of the lane head: prettier formatting (3 files) and the follow-on `ExecutionStatusSchema` removal the ratchet caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
