### PR TITLE
docs: correct workflow journal identity comments

### DIFF
--- a/docs/proposals/2026-08-28-workflow-plan-vs-issued-calls.md
+++ b/docs/proposals/2026-08-28-workflow-plan-vs-issued-calls.md
@@ -180,7 +180,7 @@ verification:
 
 - Ultracode replays the longest unchanged _prefix_; one dead agent at p85 forced
   16 re-runs in one record, an inserted call re-ran the 5 after it. TeXRA
-  replays per call (same index, same key) and its key already covers prompt,
+  replays per call (same key, regardless of index) and its key covers prompt,
   id, agentName, model, schema, file paths and file bytes — broader than
   anything the ultracode evidence can show. Keep per-call replay; do NOT
   adopt the prefix rule or the append-only started/result protocol (it cannot

--- a/src/agent/workflowScript/checkpointKey.ts
+++ b/src/agent/workflowScript/checkpointKey.ts
@@ -7,8 +7,8 @@ const WORKFLOW_SCRIPT_CHECKPOINT_KEY_PREFIX = 'workflow-script-';
  * parent execution owns one durable journal. A retry after a timeout or
  * interruption resumes that journal even when the model rewrites the script
  * (models rarely reproduce source byte-for-byte); safety lives in the journal
- * itself, whose entries replay only on a matching call index and prompt/
- * options hash — a changed call re-executes, an unchanged one is free.
+ * itself, whose entries replay only on a matching prompt/options hash key —
+ * a changed call re-executes, while an unchanged call is free to move.
  * A script that must re-execute everything from scratch needs a new
  * meta.name.
  */

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -704,7 +704,7 @@ export async function runWorkflowScript(
     // Attempt loop: retry() re-enters with a fresh AbortController and a fresh
     // runAgent call for this same index/key; skip() and normal settlement exit.
     // Every physical model attempt is charged against liveCallCounter; the
-    // logical call key and eventual journal entry remain index-scoped.
+    // logical call key stays stable while its current index records order.
     for (;;) {
       const callController = new AbortController();
       const call: InFlightAgentCall = { index, controller: callController };

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -403,7 +403,7 @@ export interface WorkflowScriptRunOptions {
   signal?: AbortSignal;
   /** Max concurrently running agent() calls. Default 4. */
   concurrency?: number;
-  /** Journal from a prior run; per-index key matches return cached results. */
+  /** Journal from a prior run; matching keys replay regardless of call position. */
   journal?: WorkflowJournalEntry[];
   /** Recovery snapshot from the prior attempt, re-published after reconciliation. */
   initialSnapshot?: WorkflowExecutionSnapshot;

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -125,7 +125,7 @@ interface WorkflowAttemptCostTracker {
 
 /**
  * Track one tool invocation's physical attempts in callback order per journal
- * index+key identity. The production child runner emits exactly one callback for every
+ * key. The production child runner emits exactly one callback for every
  * physical attempt, including `undefined` cost (normalized to zero), and emits
  * none for replay or stable recovery. For a completed key, all callbacks but
  * the last are discarded retries; only the last can correspond to the journal


### PR DESCRIPTION
## Summary

Correct stale comments and survey text that still described workflow-journal replay as index-based. Journal entries are matched by key regardless of call position; the index records ordering only.

## Issue acceptance gates

Closes #11525.

- Updates the three stale comments identified by the issue.
- Corrects the stale statement in the existing Study section.
- Corrects one additional nearby `index-scoped` comment found during verification.
- Confirms no old per-index identity wording remains in the affected workflow-journal documentation.

## Single source of truth

The workflow journal key remains the replay identity. The journal index remains an ordering fact and is not part of matching.

## Duplication and abstraction budget

No abstraction or production behavior changes. The change removes contradictory descriptions of the same identity invariant.

## Net elements (R6)

- Files: 5 modified.
- Exported symbols: 0 added, 0 removed.
- Classes/interfaces/enums: 0 added, 0 removed.
- Net LoC: 0 (6 additions, 6 deletions).

## Consumer counts (R8)

n/a — no export, event, or dispatch path changes.

## Host impact

Extension: None.

Desktop: None.

CLI: None.

## Scheduled refactoring

None.

## Validation

- Prettier check on all changed files.
- `npm run lint`.
- `npm run typecheck:workspace`.
- Commit hooks: Prettier, docs-boundary check, and guidance-reference check.
- Pre-push changed-file lint.
- No runtime tests were added or run because only comments and internal documentation changed.