### PR TITLE
fix(latex): reject useless replacement escapes

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -652,6 +652,13 @@ export default tseslint.config(
     },
   },
 
+  {
+    files: ['src/replacement/**/*.{ts,tsx}'],
+    rules: {
+      'no-useless-escape': 'error',
+    },
+  },
+
   // Production core code must not reach back into host-owned layers; import
   // declarations are forbidden.
   {

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -408,10 +408,10 @@ export const EQUATION_STYLE_REPLACEMENTS: RegexReplacementCategory = {
       (cmd) => [[`\\\\${cmd}\\{\\s+([^}]*)\\s+\\}`, `\\${cmd}{$1}`]],
     ),
     // Remove spaces inside caption (only horizontal whitespace, preserving newlines for multi-line captions)
-    '\\\\caption\{((?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*)\}':
+    '\\\\caption{((?:[^{}]|{(?:[^{}]|{[^{}]*})*})*)}':
       createCaptionTrimmer('\\caption'),
     // Remove spaces inside caption*
-    '\\\\caption\\*\{((?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*)\}':
+    '\\\\caption\\*{((?:[^{}]|{(?:[^{}]|{[^{}]*})*})*)}':
       createCaptionTrimmer('\\caption*'),
   },
 };


### PR DESCRIPTION
## Summary

Remove the twelve behavior-irrelevant brace escapes that remained in the two caption replacement patterns, then enable ESLint's `no-useless-escape` rule for `src/replacement/`. This guards the replacement tables against the JavaScript escape defect class fixed in #11505 without changing either caption pattern at runtime.

## Issue acceptance gates

Closes #11512.

- Explicit linting found twelve violations, all in the two caption pattern keys.
- Those twelve escapes are removed.
- `no-useless-escape` is now an error for `src/replacement/**/*.{ts,tsx}` while remaining unchanged elsewhere.
- The existing caption normalization tests pass without modification.

## Single source of truth

`eslint.config.mjs` owns the scoped prevention rule. The replacement pattern definitions remain in `src/replacement/rulesRegex.ts`; no runtime policy or fact moved.

## Duplication and abstraction budget

No abstraction or duplicate path was added. One narrow ESLint override covers the complete replacement source directory.

## Net elements (R6)

- Files: 0 added, 0 deleted, 2 modified.
- Exported symbols: 0 added, 0 deleted.
- Classes/interfaces/enums: 0 added, 0 deleted.
- Runtime constructs: 0 added, 0 deleted.
- Net LoC: +7 (`eslint.config.mjs` override); the two production lines are spelling-only substitutions that delete twelve characters.

## Consumer counts (R8)

n/a — no export, event, subscriber, or dispatch path is deleted or rerouted.

## Host impact

Extension: No runtime change.

Desktop: No runtime change.

CLI: No runtime change.

## Scheduled refactoring

None.

## Validation

- Confirmed both pre-change and post-change JavaScript literals are equal and compile to equal `RegExp.source` values.
- `corepack pnpm exec eslint 'src/replacement/**/*.{ts,tsx}'`
- `npm test -- src/test-kernel/replacement/ReplacementRules.vitest.ts` — 70 passed.
- `npm run lint`
- `npm run typecheck:workspace`
- `corepack pnpm exec prettier --check eslint.config.mjs src/replacement/rulesRegex.ts`
- Pre-commit hooks and changed-file pre-push lint.
