### PR TITLE
fix: preserve retry labels in workflow backstop

### DIFF
--- a/src/test-kernel/agent/WorkflowScriptProgressProjectionFailure.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressProjectionFailure.vitest.ts
@@ -98,4 +98,72 @@ describe('workflow-script projection failure recovery', () => {
       }),
     );
   });
+
+  it("retains a retried call's attempt number when the backstop terminalizes it", async () => {
+    const construction = snapshot('waiting', 'planned');
+    const issued = snapshot('active', 'planned');
+    const running = snapshot('active', 'running');
+    for (const state of [construction, issued, running]) {
+      const call = state.calls[0];
+      if (call) {
+        call.attempts = [
+          {
+            number: 1,
+            startedAt: '2026-08-15T20:00:00.000Z',
+          },
+          {
+            number: 2,
+            startedAt: '2026-08-15T20:00:01.000Z',
+          },
+        ];
+      }
+    }
+    mocks.runPersistedWorkflowScript.mockImplementationOnce(
+      async (options: PersistedWorkflowScriptRunOptions) => {
+        options.onTransition?.(construction);
+        options.onTransition?.(issued);
+        options.onTransition?.(running);
+        await options.onSnapshot?.(running);
+        return { snapshot: running } as never;
+      },
+    );
+
+    const emit = vi.fn();
+    const trace = {
+      activeStageId: vi.fn(),
+      emit,
+      info: vi.fn(),
+      warn: vi.fn(),
+      openStage: vi.fn().mockReturnValue({
+        id: 'trace-review',
+        end: vi.fn(),
+      }),
+    } as unknown as AgentTrace;
+
+    await runPersistedWorkflowScriptWithProgress(trace, {
+      store: {} as never,
+      checkpointId: 'attempt-number-backstop',
+      script: 'return await agent("Retry review")',
+      runAgent: vi.fn(),
+    });
+
+    expect(emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'workflow.call',
+        call: expect.objectContaining({
+          status: 'running',
+          attemptNumber: 2,
+        }),
+      }),
+    );
+    expect(emit).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: 'workflow.call',
+        call: expect.objectContaining({
+          status: 'failed',
+          attemptNumber: 2,
+        }),
+      }),
+    );
+  });
 });

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -86,6 +86,7 @@ interface ProjectedWorkflowCall {
   readonly logId: string;
   readonly definition: Pick<WorkflowCallProgress, 'id' | 'label' | 'phase'>;
   status: WorkflowCallProgress['status'];
+  attemptNumber?: WorkflowCallProgress['attemptNumber'];
   childStreamId?: WorkflowCallProgress['childStreamId'];
   agent?: WorkflowCallProgress['agent'];
   model?: WorkflowCallProgress['model'];
@@ -280,6 +281,11 @@ export async function runPersistedWorkflowScriptWithProgress(
     }
     projected.agent = call.agent;
     projected.model = call.model;
+    if (call.attemptNumber === undefined) {
+      delete projected.attemptNumber;
+    } else {
+      projected.attemptNumber = call.attemptNumber;
+    }
     const phase = projected.definition.phase;
     // Cards are emitted only once the fold (or the settle sweep) has opened
     // their phase, so the group is the stage handle that already exists.
@@ -600,6 +606,9 @@ export async function runPersistedWorkflowScriptWithProgress(
       markPhaseFailed(projected.definition.phase);
       const call: WorkflowCallTerminalProgress = {
         ...projected.definition,
+        ...(projected.attemptNumber !== undefined && {
+          attemptNumber: projected.attemptNumber,
+        }),
         ...(projected.childStreamId !== undefined && {
           childStreamId: projected.childStreamId,
         }),


### PR DESCRIPTION
## Summary

Preserve a retried workflow call's optional `attemptNumber` when the progress projection's `finally` backstop replaces a still-live card with its synthetic failed card.

Issue #11521 was written against `settledWorkflowCall`, which was removed during the later projection simplification. On current main the same backstop is inline in `runPersistedWorkflowScriptWithProgress`; `emitCall` still discarded `attemptNumber` from its cached projection. This change carries that already-derived optional fact through the cache instead of recomputing it.

Closes #11521.

## Issue acceptance gates

- A live second-or-later attempt keeps the same `attempt N` identity when the `finally` backstop terminalizes it.
- Cards for which `cardFor` intentionally omits an attempt number continue to omit it; `emitCall` clears the cached optional fact when the emitted card does not carry one.
- The existing projection-failure suite contains one regression case covering the live-to-backstop transition.

## Single source of truth

`WorkflowExecutionCall.attempts` remains the canonical attempt history, and `cardFor` remains the sole derivation of the optional `WorkflowCallProgress.attemptNumber`. `ProjectedWorkflowCall` now retains the last emitted value solely so the backstop can carry the same card identity forward.

## Duplication and abstraction budget

No abstraction was added. The backstop reuses the optional fact already emitted and cached by the projection, avoiding a second attempt-count derivation.

## Net elements (R6)

- Files: 2 modified, 0 added, 0 deleted.
- Exported symbols: no change.
- Classes/interfaces/enums: no new construct; one optional field added to the existing private projection interface.
- Net LoC: +77 (+9 production, +68 regression test).

## Consumer counts (R8)

n/a — no export or emit path is deleted or rerouted. The existing `workflow.call` path preserves one additional existing field in its terminal backstop event.

## Host impact

Extension: Retried workflow cards no longer lose their `attempt N` label if the progress backstop terminalizes them.

Desktop: The shared workflow progress event retains the same attempt identity; no desktop-specific behavior changes.

CLI: The terminal backstop event now carries the same attempt identity as its live event; no CLI policy or command changes.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --check src/tools/delegation/workflowScriptRun.ts src/test-kernel/agent/WorkflowScriptProgressProjectionFailure.vitest.ts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/WorkflowScriptProgressProjectionFailure.vitest.ts` (2 tests passed)
- `npm run lint`
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- `npm run compile:fast`
