### PR TITLE
fix(progress): show friendly model labels in extension proposals

### DIFF
--- a/packages/cli/src/chat/tui/modals/AgentProposal.tsx
+++ b/packages/cli/src/chat/tui/modals/AgentProposal.tsx
@@ -8,13 +8,13 @@ import {
 } from '@cli/tui/ui/theme';
 import { wrapAnsiToWidth } from '@cli/tui/ansiWrap';
 import { formatAgentProposalFileGroup } from '@cli/runtime/approval/approvalSummaries';
-import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import {
   AgentCategory,
   agentProposalCategoryLabel,
   getProposalFileGroups,
   type AgentProposalPermission,
 } from '@shared/schemas';
+import { getModelLabel } from '@shared/model/modelLabel';
 import { DELEGATION_APPROVAL_COPY } from '@shared/copy/delegationApproval';
 import {
   WORKFLOW_CALL_REVIEW_COPY,
@@ -124,7 +124,7 @@ function agentProposalMetadataLines({
           {
             text: WORKFLOW_SCRIPT_PROPOSAL_COPY.defaults(
               payload.agent,
-              getRuntimeModelLabel(payload.model),
+              getModelLabel(payload.model),
             ),
           },
         ],
@@ -160,7 +160,7 @@ function agentProposalMetadataLines({
     {
       segments: [
         { text: 'Model: ', bold: true },
-        { text: getRuntimeModelLabel(payload.model) },
+        { text: getModelLabel(payload.model) },
         { text: ' · ' },
         { text: 'Category: ', bold: true },
         { text: agentProposalCategoryLabel(payload.agentCategory) },

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -10,9 +10,9 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Box, Static, Text } from 'ink';
 
 import { COLOR_HINT } from '@cli/tui/ui/colors';
-import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import type { StreamPhase, StreamTabId } from '@shared/schemas';
 import type { TranscriptRow } from '@shared/transcript';
+import { getModelLabel } from '@shared/model/modelLabel';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { safeHomedir } from '@utils/system/platformPaths';
 
@@ -140,8 +140,7 @@ export function sessionHeaderIdentityLine(
     });
     // The shared tab projection owns the model label; the session's own model
     // is the fallback for a stream whose config has not resolved.
-    const model =
-      view.info?.modelLabel ?? getRuntimeModelLabel(meta.model || '—');
+    const model = view.info?.modelLabel ?? getModelLabel(meta.model || '—');
     const streamKind =
       view.info?.identity?.kind === 'multiAgentWorkflow'
         ? 'workflow script'
@@ -161,7 +160,7 @@ export function sessionHeaderIdentityLine(
       ? `${streamKind}: ${view.label} · ${phaseText} · parent: ${parentLabel} · model: ${model}`
       : `${streamKind}: ${view.label} · parent: ${parentLabel} · model: ${model}`;
   }
-  const model = getRuntimeModelLabel(meta.model || '—');
+  const model = getModelLabel(meta.model || '—');
   const agent = meta.agent || 'chat';
   if (meta.teamName) {
     return `team: ${meta.teamName} · root: ${agent} · model: ${model}`;

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -2,13 +2,13 @@ import {
   formatCliModelAccessRoute,
   type CliModelAccessRoute,
 } from '@cli/runtime/modelAccessRoute';
-import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import {
   formatTexraApprovalPolicy,
   type TexraApprovalPolicy,
 } from '@shared/approvalPolicy';
 import type { StreamPhase, StreamSubstate } from '@shared/schemas';
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
+import { getModelLabel } from '@shared/model/modelLabel';
 import { BACKGROUND_TASK } from '@shared/copy/nestedRuns';
 import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
 import { truncateSummary } from '@utils/text/stringUtils';
@@ -94,7 +94,7 @@ export function formatCliSessionStatus(input: CliSessionStatusInput): string {
   return [
     ...(input.teamName ? [`team: ${input.teamName}`] : []),
     `agent: ${input.agent}`,
-    `model: ${getRuntimeModelLabel(input.model)}`,
+    `model: ${getModelLabel(input.model)}`,
     `model access: ${formatCliModelAccessRoute(input.modelAccess)}`,
     `approval: ${formatTexraApprovalPolicy(input.approvalPolicy)}`,
     ...(bypassLabels.length > 0

--- a/packages/cli/src/runtime/approval/approvalSummaries.ts
+++ b/packages/cli/src/runtime/approval/approvalSummaries.ts
@@ -2,7 +2,6 @@ import type {
   HostBashApprovalRequest,
   HostUserQuestionRequest,
 } from '@agent/runtime';
-import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import {
   AgentCategory,
   agentProposalCategoryLabel,
@@ -10,6 +9,7 @@ import {
   type AgentProposalPermission,
   type RetryPermission,
 } from '@shared/schemas';
+import { getModelLabel } from '@shared/model/modelLabel';
 import {
   WORKFLOW_SCRIPT_PROPOSAL_COPY,
   workflowCallCardLine,
@@ -148,7 +148,7 @@ function agentProposalApprovalSummary(
         `Multi-agent workflow proposal requested: ${workflow.name} · ${workflowScriptPlanSummary(workflow)}`,
         WORKFLOW_SCRIPT_PROPOSAL_COPY.defaults(
           proposal.agent,
-          getRuntimeModelLabel(proposal.model),
+          getModelLabel(proposal.model),
         ),
         WORKFLOW_SCRIPT_PROPOSAL_COPY.costWarning,
         `Script: ${workflow.scriptPath}`,
@@ -157,7 +157,7 @@ function agentProposalApprovalSummary(
         `Agent proposal requested: ${proposal.agent} (${agentProposalCategoryLabel(
           proposal.agentCategory,
         )})`,
-        `Model: ${getRuntimeModelLabel(proposal.model)}`,
+        `Model: ${getModelLabel(proposal.model)}`,
         ...(proposal.workflowCall
           ? [
               `Workflow call: ${proposal.workflowCall.label}`,

--- a/packages/cli/src/runtime/enabledModels.ts
+++ b/packages/cli/src/runtime/enabledModels.ts
@@ -8,10 +8,8 @@
  */
 import { getEnabledModels, setModelEnabled } from '@model/computeModelOptions';
 import { isDeprecatedModel, isRetiredModel } from '@model/modelOptionsBasic';
-import {
-  getRuntimeModelConfig,
-  getRuntimeModelLabel,
-} from '@model/runtimeModelRegistry';
+import { getRuntimeModelConfig } from '@model/runtimeModelRegistry';
+import { getModelLabel } from '@shared/model/modelLabel';
 
 import { knownCliModelIds, resolveKnownCliModelId } from './cliConfig';
 
@@ -35,7 +33,7 @@ export function listCliEnabledModelCatalog(): readonly CliEnabledModelRow[] {
       const config = getRuntimeModelConfig(id);
       return {
         id,
-        label: getRuntimeModelLabel(id),
+        label: getModelLabel(id),
         provider: config?.provider ?? 'unknown',
         enabled: enabled.has(id),
         deprecated: isDeprecatedModel(id),

--- a/packages/cli/src/runtime/workflowPlainOutput.ts
+++ b/packages/cli/src/runtime/workflowPlainOutput.ts
@@ -1,6 +1,5 @@
 import type { AgentEvent } from '@agent/trace';
 import type { SessionEventHub } from '@agent/runtime';
-import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import {
   MESSAGE_TYPES,
   STREAM_PHASE,
@@ -9,6 +8,7 @@ import {
   type StreamTabId,
   type WorkflowCallProgress,
 } from '@shared/schemas';
+import { getModelLabel } from '@shared/model/modelLabel';
 import {
   formatWorkflowCallLine,
   formatWorkflowPhaseHeading,
@@ -87,7 +87,7 @@ function createWorkflowStreamProjection(
     // runtime label, as the transcript projection does.
     const line = formatWorkflowCallLine(
       'model' in call && call.model !== undefined
-        ? { ...call, model: getRuntimeModelLabel(call.model) }
+        ? { ...call, model: getModelLabel(call.model) }
         : call,
     );
     if (lastCallLines.get(logId) === line) return;

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -40,6 +40,7 @@ import {
   workflowScriptPlanSummary,
 } from '@shared/copy/workflowScriptProposal';
 import { markdownStyles } from '@shared/styles/markdownStyles';
+import { getModelLabel } from '@shared/model/modelLabel';
 import {
   readSelectValue,
   renderAgentOptions,
@@ -205,7 +206,7 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
                   </div>
                 `
               : html`<span class="workflow-proposal__model"
-                  >${data.model}</span
+                  >${getModelLabel(data.model)}</span
                 >`
           }
         </div>
@@ -257,7 +258,10 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
       <div class="workflow-proposal__cost-warning">
         ${waIcon('triangle-exclamation')}
         ${WORKFLOW_SCRIPT_PROPOSAL_COPY.costWarning}
-        ${WORKFLOW_SCRIPT_PROPOSAL_COPY.defaults(data.agent, data.model)}
+        ${WORKFLOW_SCRIPT_PROPOSAL_COPY.defaults(
+          data.agent,
+          getModelLabel(data.model),
+        )}
       </div>
       <wa-details
         class="workflow-proposal__workflow-details"

--- a/src/controllers/session/streamTabInfo.ts
+++ b/src/controllers/session/streamTabInfo.ts
@@ -1,13 +1,13 @@
 import { isRemoteAgent } from '@agent/index/agentRegistry';
 import { getStreamTabDisplayName } from '@agent/runtime/streamTab';
 import type { SessionStreamMetadata } from '@controllers/session/SessionState';
-import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import type { StreamTabInfo, WorktreeInfo } from '@shared/schemas';
 import {
   getCleanAgentName,
   projectStreamIdentityFields,
   runIdentityDisplayName,
 } from '@shared/schemas';
+import { getModelLabel } from '@shared/model/modelLabel';
 
 interface StreamTabInfoInputs {
   streamId: string;
@@ -82,7 +82,7 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
     name: streamId,
     label: identityName,
     model,
-    modelLabel: model ? getRuntimeModelLabel(model) : undefined,
+    modelLabel: model ? getModelLabel(model) : undefined,
     command,
     isRemote,
     worktree,

--- a/src/model/projectWorkflowCallEntry.ts
+++ b/src/model/projectWorkflowCallEntry.ts
@@ -1,17 +1,16 @@
-import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
   type StreamLogEntry,
 } from '@shared/schemas';
+import { getModelLabel } from '@shared/model/modelLabel';
 
 /**
  * Webview/browser-facing copy of one transcript entry. The stream-log store
  * keeps the canonical `WorkflowCallProgress.model` id; only the copy that
- * crosses the progress-view boundary projects it through the runtime model
- * registry (the CLI's headless workflow output does the same at its write
- * site), keeping `@model/runtimeModelRegistry` out of the browser frontend
- * import graph.
+ * crosses the progress-view boundary projects it through the browser-safe
+ * static label lookup (the CLI's headless workflow output does the same at its
+ * write site), keeping runtime model state out of the browser import graph.
  *
  * Shared by the live `WebviewBridge` LOG_DELTA path and the host-side trace
  * exporters so exported/archived traces show the same runtime label as the
@@ -28,7 +27,7 @@ export function projectWorkflowCallEntry(
   }
   const call = entry.data;
   if (!('model' in call) || call.model === undefined) return entry;
-  const model = getRuntimeModelLabel(call.model);
+  const model = getModelLabel(call.model);
   if (model === call.model) return entry;
   return { ...entry, data: { ...call, model } } as StreamLogEntry;
 }

--- a/src/model/runtimeModelRegistry.ts
+++ b/src/model/runtimeModelRegistry.ts
@@ -10,9 +10,6 @@ import type {
   LanguageModelReference,
 } from '@platform/languageModel';
 
-// Local exports - browser-safe model presentation
-export { getModelLabel as getRuntimeModelLabel } from '@shared/model/modelLabel';
-
 const MODEL_ACCESS_REQUEST_TIMEOUT_MS = 120_000;
 const MODEL_ACCESS_DISCOVERY_ATTEMPTS = 2;
 

--- a/src/model/runtimeModelRegistry.ts
+++ b/src/model/runtimeModelRegistry.ts
@@ -10,6 +10,9 @@ import type {
   LanguageModelReference,
 } from '@platform/languageModel';
 
+// Local exports - browser-safe model presentation
+export { getModelLabel as getRuntimeModelLabel } from '@shared/model/modelLabel';
+
 const MODEL_ACCESS_REQUEST_TIMEOUT_MS = 120_000;
 const MODEL_ACCESS_DISCOVERY_ATTEMPTS = 2;
 
@@ -193,11 +196,6 @@ export function invalidateRuntimeModelRegistry(): void {
 /** Resolve a static model config by its persisted id. */
 export function getRuntimeModelConfig(model: string): ModelConfig | undefined {
   return MODEL_CONFIGS[model];
-}
-
-/** Resolve a persisted model id to its user-facing registry label. */
-export function getRuntimeModelLabel(model: string): string {
-  return getRuntimeModelConfig(model)?.label ?? model;
 }
 
 /** All static model entries owned by TeXRA and llm-zoo. */

--- a/src/shared/model/modelLabel.ts
+++ b/src/shared/model/modelLabel.ts
@@ -1,0 +1,9 @@
+/** Browser-safe presentation helpers for persisted model identifiers. */
+
+// Third-party imports
+import { MODEL_CONFIGS } from 'llm-zoo';
+
+/** Resolve a persisted model id to its static user-facing catalogue label. */
+export function getModelLabel(model: string): string {
+  return MODEL_CONFIGS[model]?.label ?? model;
+}

--- a/src/test-kernel/progressView/ProposalRequestPanel.vitest.ts
+++ b/src/test-kernel/progressView/ProposalRequestPanel.vitest.ts
@@ -204,6 +204,7 @@ describe('proposal-request-panel file-name keyboard activation', () => {
         { id: 'merge', label: 'Merge findings', phase: 'Synthesize' },
       ],
     };
+    permission.data.model = 'gpt56';
 
     const element = await mountPanel(permission);
     const summary = element.shadowRoot?.querySelector(
@@ -217,8 +218,13 @@ describe('proposal-request-panel file-name keyboard activation', () => {
     expect(summary?.textContent).toContain('2 phases · 2 declared items');
     expect(summary?.textContent).not.toContain('tasks');
     expect(element.shadowRoot?.textContent).toContain('Multi-agent workflow');
+    expect(
+      element.shadowRoot
+        ?.querySelector('.workflow-proposal__model')
+        ?.textContent?.trim(),
+    ).toBe('GPT-5.6 Sol');
     expect(element.shadowRoot?.textContent).toContain(
-      'Defaults: writer (sonnet)',
+      'Defaults: writer (GPT-5.6 Sol)',
     );
     expect(element.shadowRoot?.textContent).toContain('high model cost');
     expect(details?.textContent).toContain('plan labels');


### PR DESCRIPTION
## Summary

- Show the static catalogue label, rather than the persisted model id, in the extension proposal model chip and workflow-default warning.
- Move the existing label lookup into a browser-safe shared model module; the webview does not import the stateful runtime registry or platform layer.
- Preserve the persisted id as the visible fallback when the catalogue does not recognize it.
- Remove the former runtime-registry label export and import the shared helper directly at every host and webview consumer.

## Issue acceptance gates

Closes #11549.

- [x] The extension proposal model chip renders a friendly catalogue label.
- [x] The workflow proposal's default-model warning uses the same friendly label.
- [x] Unknown model ids remain visible as their raw persisted value.
- [x] The browser bundle does not import the stateful runtime model registry.
- [x] No forwarding alias remains between consumers and the shared helper.

## Single source of truth

`src/shared/model/modelLabel.ts` is the sole owner of the static mapping from a persisted model id to its user-facing catalogue label. All eight production consumer files import `getModelLabel` directly; `getRuntimeModelLabel` has been removed.

## Duplication and abstraction budget

The label lookup moved unchanged out of `runtimeModelRegistry.ts` into the established browser-safe `src/shared/model/` boundary. One small module is added because the progress webview must not import the registry's mutable catalogue state or `platform()`. No model table, label string, host-specific adapter, barrel, or forwarding alias is duplicated.

## Net elements (R6)

- Files: +1 new, 10 modified (11 total).
- Exported symbols: net 0; `getRuntimeModelLabel` is removed and `getModelLabel` is added.
- Functions: net 0; the existing lookup moved to the shared boundary.
- Classes/interfaces/enums: net 0.
- Net LoC: +12 (44 added, 32 removed).

## Consumer counts (R8)

- `getModelLabel`: 8 direct production consumer files.
- `getRuntimeModelLabel`: 0 consumers and no remaining export.
- No event, schema, or dispatch path is deleted or rerouted.

## Host impact

Extension: Proposal cards now show friendly model labels in both the model chip and workflow-default warning.

Desktop: None.

CLI: No behavior change; existing label consumers now import the shared implementation directly.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --check` on all changed TypeScript files.
- `node --max-old-space-size=6144 ./node_modules/eslint/bin/eslint.js` on all changed TypeScript files.
- Eight targeted Vitest suites covering the proposal panel and migrated consumers: 161 passed.
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- `npm run typecheck:cli`
- `npm run compile:fast`
- `git diff --check`
- Pre-commit formatting/guidance hooks and the changed-file pre-push lint passed.

## Review findings addressed

Claude identified that the initial `getRuntimeModelLabel` re-export was a prohibited forwarding shim. Commit `03026dc744` removes it and migrates all seven former consumers to the shared helper directly.
