### PR TITLE
refactor(l6-tui-cmds-ratchets): implement verified simplification-survey findings (l6-tui-cmds-ratchets)

### DIFF
--- a/config/ratchets/architecture-edges-baseline.json
+++ b/config/ratchets/architecture-edges-baseline.json
@@ -58,7 +58,7 @@
     { "from": "platform", "to": "tools", "kind": "value" },
     { "from": "platform", "to": "utils", "kind": "value" },
     { "from": "replacement", "to": "logger", "kind": "value" },
-    { "from": "replacement", "to": "shared", "kind": "value" },
+    { "from": "replacement", "to": "shared", "kind": "type-only" },
     { "from": "replacement", "to": "utils", "kind": "value" },
     { "from": "shared", "to": "common", "kind": "value" },
     { "from": "shared", "to": "logger", "kind": "value" },

--- a/config/ratchets/host-agent-import-baseline.json
+++ b/config/ratchets/host-agent-import-baseline.json
@@ -3,7 +3,6 @@
   "hosts": {
     "cli": [
       "@agent/core/state/executionRequests",
-      "@agent/core/state/TaskState",
       "@agent/export",
       "@agent/followUp",
       "@agent/index",

--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1202,12 +1202,6 @@
       "name": "TraceDataSchema"
     },
     {
-      "file": "packages/trace-viewer/vite.standalone.config.ts",
-      "category": "unused",
-      "kind": "files",
-      "name": "packages/trace-viewer/vite.standalone.config.ts"
-    },
-    {
       "file": "src/agent/core/flows/ModelInvocationNode.ts",
       "category": "production-dead",
       "kind": "exports",
@@ -1944,12 +1938,6 @@
       "category": "production-dead",
       "kind": "exports",
       "name": "USAGE_LOG_FLUSH_OUTCOME"
-    },
-    {
-      "file": "src/test-kernel/support/setupFakePlatform.ts",
-      "category": "unused",
-      "kind": "files",
-      "name": "src/test-kernel/support/setupFakePlatform.ts"
     },
     {
       "file": "src/tools/agentCliShared.ts",

--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1427,30 +1427,6 @@
       "file": "src/auth/codex/index.ts",
       "category": "production-dead",
       "kind": "exports",
-      "name": "CODEX_CALLBACK_PATH"
-    },
-    {
-      "file": "src/auth/codex/index.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "CODEX_SESSION_SECRET_KEY"
-    },
-    {
-      "file": "src/auth/codex/index.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "CodexSessionCoordinator"
-    },
-    {
-      "file": "src/auth/codex/index.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "extractCodexClaims"
-    },
-    {
-      "file": "src/auth/codex/index.ts",
-      "category": "production-dead",
-      "kind": "exports",
       "name": "resetCodexCoordinator"
     },
     {
@@ -1463,25 +1439,7 @@
       "file": "src/auth/codex/index.ts",
       "category": "production-dead",
       "kind": "types",
-      "name": "CodexSession"
-    },
-    {
-      "file": "src/auth/codex/index.ts",
-      "category": "production-dead",
-      "kind": "types",
-      "name": "CodexSessionStatus"
-    },
-    {
-      "file": "src/auth/codex/index.ts",
-      "category": "production-dead",
-      "kind": "types",
       "name": "CodexSessionStorage"
-    },
-    {
-      "file": "src/auth/codex/index.ts",
-      "category": "production-dead",
-      "kind": "types",
-      "name": "CodexTokenResponse"
     },
     {
       "file": "src/auth/oauth/pkce.ts",
@@ -1522,18 +1480,6 @@
     {
       "file": "src/auth/xai/index.ts",
       "category": "production-dead",
-      "kind": "exports",
-      "name": "decodeXaiJwtClaims"
-    },
-    {
-      "file": "src/auth/xai/index.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "XaiSessionCoordinator"
-    },
-    {
-      "file": "src/auth/xai/index.ts",
-      "category": "production-dead",
       "kind": "types",
       "name": "XaiOAuthClient"
     },
@@ -1541,19 +1487,7 @@
       "file": "src/auth/xai/index.ts",
       "category": "production-dead",
       "kind": "types",
-      "name": "XaiSession"
-    },
-    {
-      "file": "src/auth/xai/index.ts",
-      "category": "production-dead",
-      "kind": "types",
       "name": "XaiSessionStorage"
-    },
-    {
-      "file": "src/auth/xai/index.ts",
-      "category": "production-dead",
-      "kind": "types",
-      "name": "XaiTokenResponse"
     },
     {
       "file": "src/auth/xai/XaiSessionCoordinator.ts",
@@ -2106,24 +2040,6 @@
       "category": "production-dead",
       "kind": "exports",
       "name": "STREAM_LOGS_DIR"
-    },
-    {
-      "file": "src/transcript/index.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "streamDataDir"
-    },
-    {
-      "file": "src/transcript/index.ts",
-      "category": "production-dead",
-      "kind": "types",
-      "name": "StreamLogAppendInput"
-    },
-    {
-      "file": "src/transcript/index.ts",
-      "category": "production-dead",
-      "kind": "types",
-      "name": "StreamLogDelta"
     },
     {
       "file": "src/transcript/spillArtifacts.ts",

--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -107,25 +107,7 @@
       "file": "packages/cli/src/chat/tui/forms/AgentRosterForm.tsx",
       "category": "production-dead",
       "kind": "exports",
-      "name": "agentRosterSelectWindow"
-    },
-    {
-      "file": "packages/cli/src/chat/tui/forms/AgentRosterForm.tsx",
-      "category": "production-dead",
-      "kind": "exports",
       "name": "buildChatDefaultAgentItems"
-    },
-    {
-      "file": "packages/cli/src/chat/tui/forms/AgentRosterForm.tsx",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "selectedAgentKeys"
-    },
-    {
-      "file": "packages/cli/src/chat/tui/forms/AgentRosterForm.tsx",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "setChatDefaultAgent"
     },
     {
       "file": "packages/cli/src/chat/tui/forms/CliConfigForm.tsx",
@@ -204,12 +186,6 @@
       "category": "production-dead",
       "kind": "exports",
       "name": "modelListDescription"
-    },
-    {
-      "file": "packages/cli/src/chat/tui/forms/ModelListForm.tsx",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "modelSelectWindow"
     },
     {
       "file": "packages/cli/src/chat/tui/forms/ProviderApiKeyForm.tsx",

--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -944,30 +944,6 @@
       "name": "CliNdjsonRecordSchema"
     },
     {
-      "file": "packages/cli/src/tui/noColorOutput.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "sgrStrippingWriteStream"
-    },
-    {
-      "file": "packages/cli/src/tui/noColorOutput.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "stripAnsiSgrChunk"
-    },
-    {
-      "file": "packages/cli/src/tui/selectWindow.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "COMPACT_FORM_MAX_ROWS"
-    },
-    {
-      "file": "packages/cli/src/tui/terminalCleanup.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "tuiInputModeRestoreSequence"
-    },
-    {
       "file": "packages/cli/src/tui/ui/Select.tsx",
       "category": "production-dead",
       "kind": "exports",

--- a/knip.json
+++ b/knip.json
@@ -4,7 +4,11 @@
   "ignoreBinaries": [".*"],
   "workspaces": {
     ".": {
-      "entry": ["src/test-kernel/**/*.vitest.ts", "scripts/**/*.mjs!"],
+      "entry": [
+        "src/test-kernel/**/*.vitest.ts",
+        "src/test-kernel/support/setupFakePlatform.ts",
+        "scripts/**/*.mjs!"
+      ],
       "project": ["src/**/*.ts!", "!src/**/*.js", "!src/test-kernel/**!"]
     },
     "packages/extension": {
@@ -34,6 +38,9 @@
       ],
       "project": ["src/**/*.{ts,tsx}!"],
       "ignore": ["src/renderer/vite-env.d.ts"]
+    },
+    "packages/trace-viewer": {
+      "entry": ["vite.standalone.config.ts"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "check:desktop-build-artifacts": "node scripts/verify-desktop-build-artifacts.mjs",
     "check:initial-build-artifacts": "corepack pnpm run check:vsix-contents && corepack pnpm run check:desktop-build-artifacts",
     "check:desktop-package": "node scripts/verify-desktop-package.mjs",
-    "check:dead-code": "knip --no-progress --include files,exports,types,duplicates",
+    "check:dead-code": "VITE_WEBVIEW=webview knip --no-progress --include files,exports,types,duplicates",
     "check:dead-code-ratchet": "node scripts/check-dead-code-ratchet.mjs",
     "check:guidance-refs": "node scripts/check-guidance-refs.mjs",
     "check:browser-safe-utils": "node scripts/check-browser-safe-utils.mjs",

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -2306,7 +2306,7 @@ function appendHarnessStatus(): void {
       modelAccess: resolveCliModelAccessRoute({
         usageRoute: readStreamArtifacts(streamId)?.cumulativeUsage?.usageRoute,
       }),
-      approval: formatTexraApprovalPolicy(harnessRuntimeSession.approvalPolicy),
+      approvalPolicy: harnessRuntimeSession.approvalPolicy,
       approvalBypasses: slice?.bypass,
       status: streamPhaseFor(streamId)?.phase,
       goal: GoalStore.getForStream(streamId),

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -123,7 +123,7 @@ function focusStreamAndPromoteApprovals(streamId: StreamTabId): void {
     childRosters: childRostersSignal.get(),
     parentStream: parentStreamSignal.get(),
     streams: streamsSignal.get(),
-  }).streamId;
+  });
   focusStream(streamId);
   promoteApprovalsForStream(streamId, {
     includeSessionWide: streamId === visibleListRootStreamId,
@@ -268,12 +268,12 @@ export function App(props: AppProps): React.JSX.Element {
         activeStreamId,
         childRosters,
         parentStream,
-        rootStreamId: childListTarget.streamId,
+        rootStreamId: childListTarget,
         streams,
       }),
     [
       activeStreamId,
-      childListTarget.streamId,
+      childListTarget,
       childRosters,
       parentStream,
       streams,
@@ -302,11 +302,13 @@ export function App(props: AppProps): React.JSX.Element {
     }
     return executionIds;
   }, [childRosters, sessionViews]);
+  const listRootSlice =
+    childListTarget !== undefined ? streams.get(childListTarget) : undefined;
   const workflowDashboardRoot =
-    childListTarget.slice !== undefined &&
-    streamMetadataFor(childListTarget.slice.streamId)?.identity?.kind ===
+    listRootSlice !== undefined &&
+    streamMetadataFor(listRootSlice.streamId)?.identity?.kind ===
       'multiAgentWorkflow'
-      ? childListTarget.slice
+      ? listRootSlice
       : undefined;
   // The only derivation: `SubagentList` renders this instance and
   // `ConversationRegion` budgets its rows from it, so rows cannot be grouped,
@@ -325,9 +327,9 @@ export function App(props: AppProps): React.JSX.Element {
     () =>
       groupPendingApprovalsByRow(
         pendingSummaries,
-        childListTarget.streamId ?? rootStreamId,
+        childListTarget ?? rootStreamId,
       ),
-    [childListTarget.streamId, pendingSummaries, rootStreamId],
+    [childListTarget, pendingSummaries, rootStreamId],
   );
   const childListValues = useMemo<readonly ChildListValue[]>(
     () =>
@@ -424,16 +426,16 @@ export function App(props: AppProps): React.JSX.Element {
     if (firstChildValue || workflowDashboardRootHasApproval) {
       if (
         workflowDashboardRootHasApproval &&
-        childListTarget.streamId !== undefined
+        childListTarget !== undefined
       ) {
         // The dashboard heading is not selectable, so focusing the list also
         // focuses its root and presents the approval advertised there.
-        focusStreamAndPromoteApprovals(childListTarget.streamId);
+        focusStreamAndPromoteApprovals(childListTarget);
       }
       dispatchChildListSelection({ kind: 'focus', value: firstChildValue });
     }
   }, [
-    childListTarget.streamId,
+    childListTarget,
     childListValues,
     workflowDashboardRootHasApproval,
   ]);
@@ -844,7 +846,7 @@ export function App(props: AppProps): React.JSX.Element {
           streams,
           subagentExecutionLabels,
           activeSubagentExecutionIds,
-          childListTarget,
+          listRootStreamId: childListTarget,
           pendingApprovals: pendingApprovalsForRows,
         }}
         onCancelChildList={cancelChildList}

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -271,13 +271,7 @@ export function App(props: AppProps): React.JSX.Element {
         rootStreamId: childListTarget,
         streams,
       }),
-    [
-      activeStreamId,
-      childListTarget,
-      childRosters,
-      parentStream,
-      streams,
-    ],
+    [activeStreamId, childListTarget, childRosters, parentStream, streams],
   );
   // Rows Tab navigates to that are still in flight — the count the status bar
   // advertises next to the Tab binding. `sessionViews` leads with the list
@@ -424,21 +418,14 @@ export function App(props: AppProps): React.JSX.Element {
   const focusChildList = useCallback(() => {
     const firstChildValue = childListValues.at(0);
     if (firstChildValue || workflowDashboardRootHasApproval) {
-      if (
-        workflowDashboardRootHasApproval &&
-        childListTarget !== undefined
-      ) {
+      if (workflowDashboardRootHasApproval && childListTarget !== undefined) {
         // The dashboard heading is not selectable, so focusing the list also
         // focuses its root and presents the approval advertised there.
         focusStreamAndPromoteApprovals(childListTarget);
       }
       dispatchChildListSelection({ kind: 'focus', value: firstChildValue });
     }
-  }, [
-    childListTarget,
-    childListValues,
-    workflowDashboardRootHasApproval,
-  ]);
+  }, [childListTarget, childListValues, workflowDashboardRootHasApproval]);
   const focusSession = useCallback(
     (streamId: StreamTabId) => {
       if (isWorkflowTaskListValue(selectedChildValue)) {

--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -11,7 +11,6 @@ import { POINTER } from '@cli/tui/ui/glyphs';
 import { clamp } from '@utils/core';
 import {
   matchSlashCommands,
-  slashPickIntent,
   type SlashCommand,
   type SlashPickIntent,
 } from './slashRegistry';
@@ -106,9 +105,7 @@ export function slashPaletteOwnsArrows(matchCount: number): boolean {
 export function slashPaletteEnterHintAction(
   command: SlashCommand | undefined,
 ): string {
-  if (!command) return 'run';
-  if (command.formComponent) return 'open';
-  return slashPickIntent(command, 'enter') === 'submit' ? 'run' : 'complete';
+  return command?.formComponent ? 'open' : 'run';
 }
 
 export function slashPaletteCommandLabelWidth(
@@ -155,12 +152,11 @@ export function SlashPalette(
       const returnPressed = isPlainReturnInput(input, key);
       if (returnPressed || key.tab || input === '\t') {
         const chosen = matches[highlight];
-        if (chosen) {
-          props.onPick(
-            chosen,
-            slashPickIntent(chosen, returnPressed ? 'enter' : 'tab'),
-          );
-        }
+        // Tab always just fills the input so the user can keep editing (e.g.
+        // add arguments); Enter runs the highlighted command immediately.
+        // Form-mounting commands never reach the intent — `acceptSlashCommand`
+        // opens the form first.
+        if (chosen) props.onPick(chosen, returnPressed ? 'submit' : 'complete');
       }
     },
     { isActive: matchCount > 0 },

--- a/packages/cli/src/chat/tui/commands/handlers/approvalCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/approvalCommand.ts
@@ -4,7 +4,6 @@ import {
   parseTexraApprovalPolicy,
 } from '@shared/approvalPolicy';
 
-import { openCliSlashCommandForm } from '../slashForms';
 import { type SlashCommandContext } from './slashContext';
 
 const APPROVAL_USAGE = 'Usage: /approval [ask | never | yolo]';
@@ -22,11 +21,6 @@ export function applyCliApprovalPolicySelection(
   usage: string = APPROVAL_USAGE,
 ): void {
   const normalized = input.trim().toLowerCase();
-  if (!normalized || normalized === 'status') {
-    openCliSlashCommandForm('approval', '');
-    return;
-  }
-
   const policy = parseTexraApprovalPolicy(normalized);
   if (!policy) {
     appendLocalAssistantTranscript(usage);

--- a/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
@@ -35,7 +35,6 @@ import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import { activeStreamParentOrSelfId } from '@cli/chat/tui/state/streamViews';
 import type { StreamArtifactReader } from '@cli/chat/tui/state/streamArtifactProjection';
 import { activeSubscriptionUsageRoute } from '@model/codingPlanSubscriptions';
-import { formatTexraApprovalPolicy } from '@shared/approvalPolicy';
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { isActivePhase } from '@shared/streams/streamStatus';
 import { GoalStore } from '@tools/goal';
@@ -169,7 +168,6 @@ export async function showCliSessionStatus(
           : undefined,
         prospectiveRoute,
       }),
-      approval: formatTexraApprovalPolicy(context.getApprovalPolicy()),
       approvalBypasses: slice?.bypass,
       status: activePhase?.phase,
       substate: activePhase?.substate,

--- a/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
@@ -182,8 +182,8 @@ export async function showCliSessionStatus(
         slice && meta.transcriptMode === 'persistent'
           ? context.session.executionId
           : undefined,
-      commandName: context.commandName,
-      cwd: context.cwd,
+      commandName: context.cliContext.commandName,
+      cwd: context.cliContext.cwd,
       processCwd: context.processCwd,
       approvalPolicy: context.getApprovalPolicy(),
       queuedFollowUpMessages:

--- a/packages/cli/src/chat/tui/commands/handlers/slashContext.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/slashContext.ts
@@ -10,8 +10,6 @@ import { type ExecutionId } from '@shared/schemas';
 export interface SlashCommandContext {
   readonly cliContext: CliContext;
   readonly session: TuiSession;
-  readonly commandName?: string;
-  readonly cwd: CliContext['cwd'];
   readonly processCwd?: CliContext['cwd'];
   readonly initialAgent: string;
   readonly initialModel: string;

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -32,9 +32,7 @@ import { ResumeListForm } from '../forms/ResumeListForm';
 import { SkillsListForm, type SkillActivation } from '../forms/SkillsListForm';
 import { ToolsListForm } from '../forms/ToolsListForm';
 import {
-  activeForm,
   formProgress,
-  getCliStateGeneration,
   patchSessionMeta,
   sessionMeta,
   setTransientNotice,
@@ -115,11 +113,12 @@ function formSelectionHandler<T>({
 }): (value: T) => void {
   return (value) => {
     if (completion === 'busy') {
-      const generation = getCliStateGeneration();
+      // The submission token is the single owner of "is this submission still
+      // live": resetCliState clears `formProgress`, so a stale token can never
+      // match the current progress.
       const token = Symbol('form submission');
       const actionController: { abort?: () => void } = {};
       const currentProgress = () => {
-        if (generation !== getCliStateGeneration()) return undefined;
         const current = formProgress.get();
         return current?.token === token ? current : undefined;
       };
@@ -138,9 +137,7 @@ function formSelectionHandler<T>({
         }
         formProgress.set(undefined);
         onDone(value);
-        if (!canAbort && generation === getCliStateGeneration()) {
-          setTransientNotice(abandonNotice);
-        }
+        if (!canAbort) setTransientNotice(abandonNotice);
       };
       const title = busyTitle?.(value) ?? 'Working';
       const archiveCopyable = (): void => {
@@ -296,22 +293,6 @@ export function registerBuiltinSlashCommands(options?: {
   const canSelectAgent = options?.canSelectAgent ?? (() => true);
   const canSelectModel = options?.canSelectModel ?? (() => true);
 
-  // Picking the root agent and the root model is a single up-front choice
-  // before the first message, so advance straight from the agent picker into
-  // the model picker instead of closing — the user chooses both in one flow.
-  function openModelSelectionForm(): void {
-    activeForm.set({
-      commandName: 'model',
-      render: (close, availableRows) => (
-        <ModelListFormAdapter
-          remainder=""
-          availableRows={availableRows}
-          onDone={() => close()}
-        />
-      ),
-    });
-  }
-
   function AgentListFormAdapter(props: SlashFormProps): React.JSX.Element {
     const current = sessionMeta.get().agent;
     const selectable = canSelectAgent();
@@ -322,12 +303,17 @@ export function registerBuiltinSlashCommands(options?: {
         selectable={selectable}
         onSelect={formSelectionHandler<string>({
           action: onAgentSelect,
-          // Chain into the model picker only while still choosing the root
+          // Picking the root agent and the root model is a single up-front
+          // choice before the first message, so chain straight into the model
+          // picker instead of closing — but only while still choosing the root
           // and model selection is available.
           onDone:
             selectable && canSelectModel()
-              ? () => openModelSelectionForm()
+              ? () => {
+                  openCliSlashCommandForm('model', '');
+                }
               : props.onDone,
+          onError: options?.onError,
           onPersist: props.onPersist,
           echoOnPersist: props.echoOnPersist,
         })}
@@ -365,6 +351,7 @@ export function registerBuiltinSlashCommands(options?: {
         onSelect={formSelectionHandler<TexraApprovalPolicy>({
           action: (value) => options?.onApprovalPolicySelect?.(value),
           onDone: props.onDone,
+          onError: options?.onError,
           completion: 'beforeAction',
           onPersist: props.onPersist,
           echoOnPersist: props.echoOnPersist,

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -242,20 +242,6 @@ export function suggestSlashCommand(
   return best?.command;
 }
 
-export function slashPickIntent(
-  command: SlashCommand,
-  acceptKey: 'enter' | 'tab',
-): SlashPickIntent {
-  // Tab always just fills the input so the user can keep editing (e.g. add
-  // arguments). Enter runs the highlighted command immediately — except for:
-  //  - commands that mount a structured form, which need the input cleared so
-  //    the form can take over (InputBar handles that branch before reading the
-  //    intent, so 'complete' here is just a safe default for them).
-  if (acceptKey !== 'enter') return 'complete';
-  if (command.formComponent) return 'complete';
-  return 'submit';
-}
-
 /**
  * Parse a `"/cmd remainder"` input into `{ name, remainder }`.
  * Returns `undefined` if `text` is not a slash command. Only command-shaped

--- a/packages/cli/src/chat/tui/forms/AgentRosterForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentRosterForm.tsx
@@ -16,10 +16,7 @@ import { COLOR_ERROR, COLOR_WARNING } from '@cli/tui/ui/colors';
 import { CROSS, TICK, WARNING } from '@cli/tui/ui/glyphs';
 import { KeyHints } from '@cli/tui/ui/KeyHints';
 import { Select, type SelectItem } from '@cli/tui/ui/Select';
-import {
-  computeSelectWindowSize,
-  type SelectWindowSize,
-} from '@cli/tui/selectWindow';
+import { computeSelectWindowSize } from '@cli/tui/selectWindow';
 import { platform } from '@platform/platform';
 import {
   AGENT_MODE_PRESETS,
@@ -82,7 +79,7 @@ export function buildChatDefaultAgentItems(
   ];
 }
 
-export function selectedAgentKeys(
+function selectedAgentKeys(
   selection: AgentRosterCategorySelection,
   agents: readonly AgentEntry[],
 ): readonly string[] {
@@ -94,22 +91,8 @@ function selectionSizeLabel(selection: AgentRosterCategorySelection): string {
   return selection === 'all' ? 'all' : String(selection.length);
 }
 
-export function agentRosterSelectWindow(args: {
-  readonly availableRows: number | undefined;
-  readonly itemCount: number;
-}): SelectWindowSize {
-  return computeSelectWindowSize({ ...args, chromeRows: 5 });
-}
-
-export async function setChatDefaultAgent(
-  workspacePath: string | undefined,
-  agent: string | undefined,
-): Promise<void> {
-  if (!workspacePath) {
-    throw new Error('Default chat-agent selection requires a workspace.');
-  }
-  await setWorkspaceCliChatAgent(workspacePath, agent);
-}
+// Border, title, footer spacer, and key hints are the chrome.
+const AGENT_ROSTER_SELECT_CHROME_ROWS = 5;
 
 async function loadRosterData(): Promise<AgentRosterData> {
   await loadAgents({ includeRemote: false });
@@ -154,9 +137,10 @@ export function AgentRosterForm(
     onSelect: (value: string) => void,
     onCancel: () => void,
   ) => {
-    const window = agentRosterSelectWindow({
+    const window = computeSelectWindowSize({
       availableRows: props.availableRows,
       itemCount: items.length,
+      chromeRows: AGENT_ROSTER_SELECT_CHROME_ROWS,
     });
     return (
       <FormFrame title="/config · Agents" showCloseHint={false}>
@@ -282,7 +266,12 @@ export function AgentRosterForm(
       ),
       (value) => {
         const cwd = platform().workspace.getWorkspacePath();
-        write(() => setChatDefaultAgent(cwd, value || undefined), 'overview');
+        write(async () => {
+          if (!cwd) {
+            throw new Error('Default chat-agent selection requires a workspace.');
+          }
+          await setWorkspaceCliChatAgent(cwd, value || undefined);
+        }, 'overview');
       },
       () => setMode('overview'),
     );

--- a/packages/cli/src/chat/tui/forms/AgentRosterForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentRosterForm.tsx
@@ -268,7 +268,9 @@ export function AgentRosterForm(
         const cwd = platform().workspace.getWorkspacePath();
         write(async () => {
           if (!cwd) {
-            throw new Error('Default chat-agent selection requires a workspace.');
+            throw new Error(
+              'Default chat-agent selection requires a workspace.',
+            );
           }
           await setWorkspaceCliChatAgent(cwd, value || undefined);
         }, 'overview');

--- a/packages/cli/src/chat/tui/forms/ApiKeyEntryForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ApiKeyEntryForm.tsx
@@ -27,7 +27,7 @@ export interface ApiKeyEntryFormProps {
   readonly onCancel: () => void;
 }
 
-export interface CredentialEntryFormProps {
+interface CredentialEntryFormProps {
   readonly title: string;
   readonly helper?: ReactNode;
   readonly placeholder: string;

--- a/packages/cli/src/chat/tui/forms/EnabledModelsForm.tsx
+++ b/packages/cli/src/chat/tui/forms/EnabledModelsForm.tsx
@@ -53,12 +53,11 @@ export function EnabledModelsForm(
       }
       action="toggle"
       showTransientCloseHint={false}
-      onSelect={(id, { data: models, setData: setModels }) => {
+      onSelect={(id, { data: models, reload }) => {
         const row = models.find((candidate) => candidate.id === id);
         if (!row) return;
         void setCliModelEnabled(id, !row.enabled)
-          .then(() => listCliEnabledModelCatalog())
-          .then(setModels)
+          .then(reload)
           .catch((error: unknown) => {
             // e.g. disabling the last remaining model — keep the catalog as-is.
             setTransientNotice(toErrorMessage(error));

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -16,7 +16,6 @@ import { Select } from '@cli/tui/ui/Select';
 import {
   computeSelectWindowSize,
   isCompactFormRows,
-  type SelectWindowSize,
 } from '@cli/tui/selectWindow';
 import {
   CompactPickerKeyHints,
@@ -35,13 +34,8 @@ export interface ModelListFormProps {
   readonly onClose: () => void;
 }
 
-export function modelSelectWindow(args: {
-  readonly availableRows: number | undefined;
-  readonly itemCount: number;
-}): SelectWindowSize {
-  // Border, title, description, footer spacer, and key hints are the chrome.
-  return computeSelectWindowSize({ ...args, chromeRows: 6 });
-}
+// Border, title, description, footer spacer, and key hints are the chrome.
+const MODEL_SELECT_CHROME_ROWS = 6;
 
 export function modelListDescription({
   itemCount,
@@ -70,9 +64,10 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
     onClose: props.onClose,
   });
   const items = picker.items;
-  const selectWindow = modelSelectWindow({
+  const selectWindow = computeSelectWindowSize({
     availableRows: props.availableRows,
     itemCount: items.length,
+    chromeRows: MODEL_SELECT_CHROME_ROWS,
   });
   const description = modelListDescription({
     itemCount: items.length,

--- a/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
@@ -68,12 +68,11 @@ export function ToolsListForm(props: ToolsListFormProps): React.JSX.Element {
       }
       action="toggle"
       showTransientCloseHint={false}
-      onSelect={(id, { data: tools, setData: setTools }) => {
+      onSelect={(id, { data: tools, reload }) => {
         const tool = tools.find((candidate) => candidate.id === id);
         if (!tool || tool.enabled == null) return;
         void setCliToolEnabled(id, !tool.enabled)
-          .then(() => readCliToolStatuses())
-          .then(setTools)
+          .then(reload)
           .catch((error: unknown) => {
             setTransientNotice(toErrorMessage(error));
           });

--- a/packages/cli/src/chat/tui/forms/_shared/ListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/_shared/ListForm.tsx
@@ -192,7 +192,6 @@ export function pendingListFormChoice<T>(args: {
 
 interface AsyncListFormControls<TData> {
   readonly data: TData;
-  readonly setData: (next: TData) => void;
   /** Re-run the loader, keeping the current data on screen until it returns. */
   readonly reload: () => void;
 }
@@ -235,7 +234,6 @@ export function useAsyncPickerForm<TData, TValue>(args: {
     error,
     pendingInput,
     clearPendingInput,
-    setData,
     reload,
   } = useAsyncListForm<TData>({
     load: args.load,
@@ -250,7 +248,7 @@ export function useAsyncPickerForm<TData, TValue>(args: {
       args.onClose();
       return;
     }
-    if (data !== undefined) args.onSelect?.(value, { data, setData, reload });
+    if (data !== undefined) args.onSelect?.(value, { data, reload });
   };
   usePendingListFormSelection({
     loading,
@@ -285,7 +283,6 @@ export interface AsyncListFormProps<TData, TValue> extends Omit<
   readonly items: (data: TData) => ReadonlyArray<SelectItem<TValue>>;
   readonly isEmpty?: (data: TData) => boolean;
   readonly showTransientCloseHint?: boolean;
-  readonly descriptionFor?: (data: TData) => ReactNode;
   readonly detailFor?: (data: TData) => ReactNode;
   readonly detailRowsFor?: (data: TData) => number;
   readonly compactDetailFor?: (data: TData) => ReactNode;
@@ -305,7 +302,6 @@ export function AsyncListForm<TData, TValue>(
     items: itemsFor,
     isEmpty,
     showTransientCloseHint,
-    descriptionFor,
     detailFor,
     detailRowsFor,
     compactDetailFor,
@@ -333,7 +329,6 @@ export function AsyncListForm<TData, TValue>(
     <ListForm
       {...listProps}
       items={picker.items}
-      description={descriptionFor?.(data) ?? listProps.description}
       detail={detailFor?.(data) ?? listProps.detail}
       detailRows={detailRowsFor?.(data) ?? listProps.detailRows}
       compactDetail={compactDetailFor?.(data) ?? listProps.compactDetail}

--- a/packages/cli/src/chat/tui/forms/_shared/ListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/_shared/ListForm.tsx
@@ -228,19 +228,13 @@ export function useAsyncPickerForm<TData, TValue>(args: {
   ) => void;
   readonly onClose: () => void;
 }): AsyncPickerForm<TData, TValue> {
-  const {
-    data,
-    loading,
-    error,
-    pendingInput,
-    clearPendingInput,
-    reload,
-  } = useAsyncListForm<TData>({
-    load: args.load,
-    onClose: args.onClose,
-    isEmpty: args.isEmpty,
-    closeEmptyOnEnter: args.closeEmptyOnEnter,
-  });
+  const { data, loading, error, pendingInput, clearPendingInput, reload } =
+    useAsyncListForm<TData>({
+      load: args.load,
+      onClose: args.onClose,
+      isEmpty: args.isEmpty,
+      closeEmptyOnEnter: args.closeEmptyOnEnter,
+    });
   const selectable = args.selectable !== false;
   const items = data === undefined ? [] : args.items(data);
   const select = (value: TValue): void => {

--- a/packages/cli/src/chat/tui/forms/_shared/useAsyncListForm.ts
+++ b/packages/cli/src/chat/tui/forms/_shared/useAsyncListForm.ts
@@ -25,11 +25,6 @@ export interface AsyncListFormState<T> {
   readonly pendingInput: string | undefined;
   readonly clearPendingInput: () => void;
   /**
-   * Replace the loaded data after mount. Used by forms whose loaded list is
-   * mutable in place (e.g. `/tools` re-reading statuses after a toggle).
-   */
-  readonly setData: (next: T) => void;
-  /**
    * Re-run the loader and replace the loaded data, keeping the current data
    * on screen until the next result arrives. Used by forms that must re-fetch
    * after a mutation (e.g. a roster write). Clears the error on success and
@@ -186,7 +181,6 @@ export function useAsyncListForm<T>(
     error,
     pendingInput,
     clearPendingInput,
-    setData,
     reload,
     reportError,
   };

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -20,10 +20,12 @@ import {
 import {
   DiffView,
   initialDiffScrollOffset,
-  maxDiffScrollOffset,
   wrappedDiffDisplayLines,
 } from '../render/DiffView';
-import { COMPACT_SCROLLABLE_CONTENT_ROWS } from '../render/scrollBounds';
+import {
+  COMPACT_SCROLLABLE_CONTENT_ROWS,
+  maxScrollableRowOffset,
+} from '../render/scrollBounds';
 import { useScrollableOffset } from '../state/useScrollableOffset';
 import type {
   ApprovalDecision,
@@ -103,7 +105,10 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
     () => wrappedDiffDisplayLines(hunks, diffWidth).length,
     [diffWidth, hunks],
   );
-  const maxScrollOffset = maxDiffScrollOffset(diffRows, maxDiffLines);
+  const maxScrollOffset = maxScrollableRowOffset({
+    maxDisplayLines: maxDiffLines,
+    totalLines: diffRows,
+  });
   const initialScrollOffset = useMemo(
     () => initialDiffScrollOffset(hunks, diffWidth, maxDiffLines),
     [diffWidth, hunks, maxDiffLines],

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -360,7 +360,8 @@ function ChoiceQuestion(props: QuestionVariantProps): React.JSX.Element {
         selectedValues={multi ? selectedValues : undefined}
         onToggle={
           multi
-            ? (label) => setSelected((s) => toggleUserQuestionSelection(s, label))
+            ? (label: string) =>
+                setSelected((s) => toggleUserQuestionSelection(s, label))
             : undefined
         }
         onSelect={multi ? () => props.onSubmit([...selected]) : props.onSubmit}

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -317,8 +317,14 @@ function QuestionShell(props: QuestionShellProps): React.JSX.Element {
   );
 }
 
-function MultiSelectQuestion(props: QuestionVariantProps): React.JSX.Element {
+/**
+ * One choice picker for both single- and multi-select questions: `Select`
+ * already models both through one props shape, so the only differences are
+ * the hint wording and whether the selected set is carried.
+ */
+function ChoiceQuestion(props: QuestionVariantProps): React.JSX.Element {
   const [selected, setSelected] = useState<readonly string[]>([]);
+  const multi = props.question.multiSelect === true;
   const options = props.question.options;
   const maxVisibleOptions = userQuestionChoiceRowsBudget({
     availableRows: props.availableRows,
@@ -336,26 +342,28 @@ function MultiSelectQuestion(props: QuestionVariantProps): React.JSX.Element {
       hints={[
         ...userQuestionChoiceHints({
           optionCount: options.length,
-          shortcutAction: 'toggle',
+          shortcutAction: multi ? 'toggle' : 'select now',
         }),
-        { key: 'Space', action: 'toggle' },
-        { key: 'Enter', action: 'submit' },
+        ...(multi ? [{ key: 'Space', action: 'toggle' }] : []),
+        { key: 'Enter', action: multi ? 'submit' : 'select' },
         { key: 'Esc', action: 'skip' },
       ]}
     >
       <Select
-        mode="multi"
+        mode={multi ? 'multi' : 'single'}
         items={options.map((option) => ({
           value: option.label,
           label: option.label,
           description: option.description ?? undefined,
         }))}
         maxVisibleItems={maxVisibleOptions}
-        selectedValues={selectedValues}
-        onToggle={(label) =>
-          setSelected((s) => toggleUserQuestionSelection(s, label))
+        selectedValues={multi ? selectedValues : undefined}
+        onToggle={
+          multi
+            ? (label) => setSelected((s) => toggleUserQuestionSelection(s, label))
+            : undefined
         }
-        onSelect={() => props.onSubmit([...selected])}
+        onSelect={multi ? () => props.onSubmit([...selected]) : props.onSubmit}
         onCancel={props.onCancel}
       />
     </QuestionShell>
@@ -432,41 +440,6 @@ function FreeTextQuestion(props: QuestionVariantProps): React.JSX.Element {
   );
 }
 
-function SingleSelectQuestion(props: QuestionVariantProps): React.JSX.Element {
-  const optionRows = userQuestionChoiceRowsBudget({
-    availableRows: props.availableRows,
-    optionCount: props.question.options.length,
-  });
-  return (
-    <QuestionShell
-      availableRows={props.availableRows}
-      controlRows={optionRows}
-      payload={props.payload}
-      question={props.question}
-      index={props.index}
-      hints={[
-        ...userQuestionChoiceHints({
-          optionCount: props.question.options.length,
-          shortcutAction: 'select now',
-        }),
-        { key: 'Enter', action: 'select' },
-        { key: 'Esc', action: 'skip' },
-      ]}
-    >
-      <Select
-        items={props.question.options.map((option) => ({
-          value: option.label,
-          label: option.label,
-          description: option.description ?? undefined,
-        }))}
-        maxVisibleItems={optionRows}
-        onSelect={props.onSubmit}
-        onCancel={props.onCancel}
-      />
-    </QuestionShell>
-  );
-}
-
 export function UserQuestion(props: UserQuestionProps): React.JSX.Element {
   const [index, setIndex] = useState(0);
   const [answers, setAnswers] = useState<UserQuestionAnswers>({});
@@ -502,7 +475,11 @@ export function UserQuestion(props: UserQuestionProps): React.JSX.Element {
     onCancel: cancel,
   };
 
-  if (question.multiSelect) return <MultiSelectQuestion {...variantProps} />;
-  if (question.allowFreeText) return <FreeTextQuestion {...variantProps} />;
-  return <SingleSelectQuestion {...variantProps} />;
+  if (question.allowFreeText && !question.multiSelect) {
+    return <FreeTextQuestion {...variantProps} />;
+  }
+  // Keyed by question index: the folded picker is now one element type across
+  // consecutive questions, so without a key React would reuse the instance and
+  // carry the previous question's toggled set into the next one.
+  return <ChoiceQuestion key={index} {...variantProps} />;
 }

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -21,10 +21,7 @@ import {
   staticScrollbackTarget,
   staticTranscriptRowBudget,
 } from '../appLayout';
-import {
-  isScopedTranscriptViewport,
-  transcriptViewportKey,
-} from '../state/transcriptViewportMode';
+import { activeTranscriptViewport } from '../state/transcriptViewportMode';
 import { ConversationPane } from './ConversationPane';
 import {
   QueuedFollowUpsPanel,
@@ -51,7 +48,6 @@ import {
 import { useSignal } from '../state/useSignal';
 import type { ForegroundSurfaceKind } from '../appInteractionPolicy';
 import type { PendingApprovalKind } from '../state/approvalQueue';
-import type { ChildListTarget } from '../state/childControls';
 import type { StreamSlice } from '../state/cliState';
 import type { StreamView } from '../state/streamViews';
 
@@ -80,7 +76,7 @@ interface ConversationRegionSnapshot {
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly subagentExecutionLabels: ExecutionLabels;
   readonly activeSubagentExecutionIds: ReadonlyMap<StreamTabId, string>;
-  readonly childListTarget: ChildListTarget;
+  readonly listRootStreamId: StreamTabId | undefined;
   readonly pendingApprovals: ReadonlyMap<
     string,
     readonly PendingApprovalKind[]
@@ -122,11 +118,10 @@ export function ConversationRegion({
   snapshot,
 }: ConversationRegionProps): React.JSX.Element {
   const foregroundOpen = snapshot.foregroundKind !== undefined;
-  const viewportKey = transcriptViewportKey({
+  const { key: viewportKey, scoped: scopedTranscript } = activeTranscriptViewport({
     activeStreamId: snapshot.activeStreamId,
     parentStream: snapshot.parentStream,
   });
-  const scopedTranscript = isScopedTranscriptViewport(viewportKey);
   const scrollbackTarget = staticScrollbackTarget({
     activeStreamId: snapshot.activeStreamId,
     rootStreamId: snapshot.rootStreamId,
@@ -292,7 +287,7 @@ export function ConversationRegion({
               onWorkflowControl={onWorkflowControl}
               onSelectionChange={onChildSelectionChange}
               pendingApprovals={snapshot.pendingApprovals}
-              listRootStreamId={snapshot.childListTarget.streamId}
+              listRootStreamId={snapshot.listRootStreamId}
               dashboard={snapshot.workflowDashboard}
               selectedChildStreamId={snapshot.selectedChildStreamId}
               selectedChildWorkflowControllable={

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -118,10 +118,11 @@ export function ConversationRegion({
   snapshot,
 }: ConversationRegionProps): React.JSX.Element {
   const foregroundOpen = snapshot.foregroundKind !== undefined;
-  const { key: viewportKey, scoped: scopedTranscript } = activeTranscriptViewport({
-    activeStreamId: snapshot.activeStreamId,
-    parentStream: snapshot.parentStream,
-  });
+  const { key: viewportKey, scoped: scopedTranscript } =
+    activeTranscriptViewport({
+      activeStreamId: snapshot.activeStreamId,
+      parentStream: snapshot.parentStream,
+    });
   const scrollbackTarget = staticScrollbackTarget({
     activeStreamId: snapshot.activeStreamId,
     rootStreamId: snapshot.rootStreamId,

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -34,7 +34,6 @@ import {
   parseSlashInput,
   prefixSlashCommands,
   shouldRedactSlashInput,
-  slashPickIntent,
   type SlashCommand,
   type SlashPickIntent,
 } from '../commands/slashRegistry';
@@ -370,12 +369,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         // Unmatched input falls through to the unknown-command suggestion.
         const chosen = prefixSlashCommands(slash.name)[0];
         if (chosen !== undefined) {
-          acceptSlashCommand(
-            chosen,
-            slashPickIntent(chosen, 'enter'),
-            slash.name,
-            slash.remainder,
-          );
+          acceptSlashCommand(chosen, 'submit', slash.name, slash.remainder);
           return;
         }
       }

--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -74,16 +74,6 @@ export function wrappedDiffDisplayLines(
   );
 }
 
-export function maxDiffScrollOffset(
-  totalLines: number,
-  maxDisplayLines: number,
-): number {
-  return maxScrollableRowOffset({
-    maxDisplayLines,
-    totalLines,
-  });
-}
-
 /**
  * Start a scrollable approval diff near its first changed visual row. Long
  * wrapped context lines can otherwise consume the whole initial viewport.
@@ -105,7 +95,10 @@ export function initialDiffScrollOffset(
 
   const initiallyVisibleContentRows = Math.max(1, maxDisplayLines - 1);
   const firstChange = lines.at(changedIndex);
-  const maxOffset = maxDiffScrollOffset(lines.length, maxDisplayLines);
+  const maxOffset = maxScrollableRowOffset({
+    maxDisplayLines,
+    totalLines: lines.length,
+  });
   const defaultOffset = clamp(changedIndex - 1, 0, maxOffset);
   if (firstChange?.kind !== 'removed') {
     return changedIndex < initiallyVisibleContentRows ? 0 : defaultOffset;
@@ -302,14 +295,16 @@ function DiffLine({
   readonly line: DiffDisplayLine;
   readonly width: number;
 }): React.JSX.Element {
-  const content = wrapAnsiToWidth(line.text, width);
+  // Every line reaching here already came through `wrappedDiffDisplayLines`
+  // (or the width-clipped overflow marker), and `clampModalWidth` is
+  // idempotent, so a second wrap could not split anything.
   const style = DIFF_LINE_STYLE[line.kind];
   if (style) {
     return (
       <Text color={style.color} backgroundColor={style.backgroundColor}>
-        {fillRows(content, width)}
+        {fillRows(line.text, width)}
       </Text>
     );
   }
-  return <Text dimColor>{content}</Text>;
+  return <Text dimColor>{line.text}</Text>;
 }

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -262,8 +262,6 @@ export async function runChat(
   const slashCommandContext = (): SlashCommandContext => ({
     cliContext: context,
     session,
-    commandName: context.commandName,
-    cwd: context.cwd,
     processCwd: process.cwd(),
     initialAgent: agent,
     initialModel: model,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -152,7 +152,6 @@ export async function runChat(
   // and `TERM=dumb` strips the cursor controls Ink depends on (Ink would
   // mount and emit garbled output instead of a usable session).
   const terminalFailure = interactiveTerminalFailure(context);
-  const clearItermProgress = process.env.TERM_PROGRAM === 'iTerm.app';
   if (terminalFailure) {
     // Headless precedence: in CI (headless + TERM=dumb often co-occur) the
     // actionable advice is "use `texra run`", not "fix your TERM".
@@ -326,9 +325,7 @@ export async function runChat(
   // Crash safety stays armed until graceful teardown has restored the terminal;
   // it outlives session subscriptions so a later teardown failure cannot leave
   // the user's shell in raw/kitty/mouse mode with a hidden cursor.
-  const disposeTerminalRestoreOnExit = installTerminalRestoreOnExit({
-    clearItermProgress,
-  });
+  const disposeTerminalRestoreOnExit = installTerminalRestoreOnExit();
   // Cosmetic, but "texra-local" (a local dev binary's own name) or a bare
   // shell prompt in every tab makes a multi-session workflow hard to
   // navigate. Keep the project name while surfacing live attention state.
@@ -554,8 +551,6 @@ export async function runChat(
     commandName: context.commandName,
     cwd: context.cwd,
     canResume: transcriptLifecycle.canResume,
-    clearItermProgress,
-    kittyKeyboardEnabled: terminalCaps.kittyKeyboard,
     disposables,
     disposeTerminalRestoreOnExit,
     followUpQueue,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -272,9 +272,8 @@ export async function runChat(
     resetSession: resetSessionForClear,
     resumeExecution: chatController.resume,
   });
-  const initialPresetId = initialResume
-    ? (initialResume.config.cli?.multiAgentPresetId ?? undefined)
-    : init.cliMultiAgentPresetId;
+  const initialPresetId =
+    initialResume?.config.cli?.multiAgentPresetId ?? init.cliMultiAgentPresetId;
   sessionMetaSignal.set({
     agent,
     category: AgentCategory.ToolUse,
@@ -284,13 +283,10 @@ export async function runChat(
     approvalPolicy: runtimeSession.approvalPolicy,
     canDelegate: chatAgentSupportsDelegation(agent),
     transcriptMode: transcriptLifecycle.canResume ? 'persistent' : 'ephemeral',
-    teamName: initialResume
-      ? readCliMultiAgentPresetName(initialPresetId)
-      : (init.teamName ?? readCliMultiAgentPresetName(initialPresetId)),
+    teamName: init.teamName ?? readCliMultiAgentPresetName(initialPresetId),
     cliMultiAgentPresetId: initialPresetId,
-    delegationAgentScope: initialResume
-      ? (initialResume.config.delegationAgentScope ?? undefined)
-      : init.delegationAgentScope,
+    delegationAgentScope:
+      initialResume?.config.delegationAgentScope ?? init.delegationAgentScope,
     version,
   });
   if (transcriptLifecycle.warning) {

--- a/packages/cli/src/chat/tui/sessionExitController.ts
+++ b/packages/cli/src/chat/tui/sessionExitController.ts
@@ -51,6 +51,7 @@ import {
   chatTuiSigintAction,
   type TuiSession,
 } from './state/sessionRunState';
+import { terminalCapabilities } from './state/terminalCapabilities';
 import type PQueue from 'p-queue';
 import type { Instance as InkInstance } from 'ink';
 
@@ -74,10 +75,6 @@ interface SessionExitControllerContext {
   readonly cwd: string;
   /** Whether this session persists a resumable transcript. */
   readonly canResume: boolean;
-  /** Clear iTerm2 progress on teardown (mirrors the render-time flag). */
-  readonly clearItermProgress: boolean;
-  /** Re-arm the Kitty keyboard protocol on SIGCONT when the terminal supports it. */
-  readonly kittyKeyboardEnabled: boolean;
   /** Session-scoped subscriptions torn down on graceful exit. */
   readonly disposables: DisposableStore;
   /** Removes the process-exit terminal backstop after terminal restoration. */
@@ -262,7 +259,7 @@ export function createSessionExitController(
   const handleSigtstp = (): void => {
     if (!terminalJobControlSupported) return;
     ctx.suspendTerminalTitle();
-    cleanupTerminalModes({ clearItermProgress: ctx.clearItermProgress });
+    cleanupTerminalModes();
     if (process.stdin.isTTY) process.stdin.setRawMode(false);
     process.kill(process.pid, 'SIGSTOP');
   };
@@ -273,7 +270,9 @@ export function createSessionExitController(
   // clear-and-reprint path as a width change is the only safe redraw.
   const handleSigcont = (): void => {
     if (process.stdin.isTTY) process.stdin.setRawMode(true);
-    restoreTuiInputModes({ kittyKeyboard: ctx.kittyKeyboardEnabled });
+    restoreTuiInputModes({
+      kittyKeyboard: terminalCapabilities.get().kittyKeyboard,
+    });
     ctx.resumeTerminalTitle();
     ctx.repaintAfterTerminalResume();
   };
@@ -312,7 +311,7 @@ export function createSessionExitController(
       // This synchronous prefix is load-bearing: force/signal exits must restore
       // the terminal before the first await so a stalled flush cannot strand raw
       // mode or emulator keyboard state.
-      cleanupTerminalModes({ clearItermProgress: ctx.clearItermProgress });
+      cleanupTerminalModes();
       printResumeHintOnExit(childRosters);
       return persistBeforePlatformShutdown().finally(() =>
         process.exit(cause.exitCode),
@@ -342,7 +341,7 @@ export function createSessionExitController(
       await session.runPromise;
     }
     await ctx.flushArtifacts();
-    cleanupTerminalModes({ clearItermProgress: ctx.clearItermProgress });
+    cleanupTerminalModes();
     ctx.disposeTerminalRestoreOnExit();
     // Print the resume hint after the terminal modes are restored, but before
     // resetCliState() clears the stream tree the hint is built from.

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -3,7 +3,10 @@ import {
   type CliModelAccessRoute,
 } from '@cli/runtime/modelAccessRoute';
 import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
-import type { TexraApprovalPolicy } from '@shared/approvalPolicy';
+import {
+  formatTexraApprovalPolicy,
+  type TexraApprovalPolicy,
+} from '@shared/approvalPolicy';
 import type { StreamPhase, StreamSubstate } from '@shared/schemas';
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
 import { BACKGROUND_TASK } from '@shared/copy/nestedRuns';
@@ -26,7 +29,6 @@ export interface CliSessionStatusInput {
   readonly model: string;
   readonly teamName?: string;
   readonly modelAccess: CliModelAccessRoute;
-  readonly approval: string;
   readonly approvalBypasses?: Partial<BypassState>;
   readonly status: StreamPhase | undefined;
   readonly substate?: StreamSubstate;
@@ -41,7 +43,7 @@ export interface CliSessionStatusInput {
   readonly commandName?: string;
   readonly cwd?: string;
   readonly processCwd?: string;
-  readonly approvalPolicy?: TexraApprovalPolicy;
+  readonly approvalPolicy: TexraApprovalPolicy;
 }
 
 export function formatCliStatusLabel(
@@ -94,7 +96,7 @@ export function formatCliSessionStatus(input: CliSessionStatusInput): string {
     `agent: ${input.agent}`,
     `model: ${getRuntimeModelLabel(input.model)}`,
     `model access: ${formatCliModelAccessRoute(input.modelAccess)}`,
-    `approval: ${input.approval}`,
+    `approval: ${formatTexraApprovalPolicy(input.approvalPolicy)}`,
     ...(bypassLabels.length > 0
       ? [`auto-approvals: ${bypassLabels.join(', ')}`]
       : []),

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -14,11 +14,6 @@ import { nearestActiveStreamAncestor, streamTreeEntries } from './streamViews';
 import { visibleSubagentRows, type ChildRosters } from './childExecutions';
 import type { StreamSlice } from './cliState';
 
-export interface ChildListTarget {
-  readonly slice: StreamSlice | undefined;
-  readonly streamId: StreamTabId | undefined;
-}
-
 /** Compact elapsed reading for one child row, shown only while it is running:
  *  a settled row's duration is reported by the task card that owns its
  *  outcome, so repeating a frozen figure in the live list is noise. */
@@ -53,8 +48,7 @@ export function resolveChildListTarget({
   readonly childRosters: ChildRosters;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
-}): ChildListTarget {
-  const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
+}): StreamTabId | undefined {
   if (activeStreamId && !hasChildListItems(activeStreamId, childRosters)) {
     const ancestor = nearestActiveStreamAncestor({
       activeStreamId,
@@ -63,18 +57,10 @@ export function resolveChildListTarget({
       canUseValue: (_slice, streamId) =>
         hasChildListItems(streamId, childRosters),
     });
-    if (ancestor) {
-      return {
-        streamId: ancestor.streamId,
-        slice: ancestor.value,
-      };
-    }
+    if (ancestor) return ancestor.streamId;
   }
 
-  return {
-    streamId: activeStreamId,
-    slice: activeSlice,
-  };
+  return activeStreamId;
 }
 
 export function numericFocusTargetForActiveStream(init: {
@@ -86,12 +72,11 @@ export function numericFocusTargetForActiveStream(init: {
 }): StreamTabId | undefined {
   if (!init.activeStreamId || init.zeroBasedIndex < 0) return undefined;
   const shortcutIndex = init.zeroBasedIndex + 1;
-  const target = resolveChildListTarget(init);
   return streamTreeEntries({
     activeStreamId: init.activeStreamId,
     childRosters: init.childRosters,
     parentStream: init.parentStream,
-    rootStreamId: target.streamId,
+    rootStreamId: resolveChildListTarget(init),
     streams: init.streams,
   }).find((entry) => entry.shortcutIndex === shortcutIndex)?.id;
 }

--- a/packages/cli/src/chat/tui/state/transcriptViewportMode.ts
+++ b/packages/cli/src/chat/tui/state/transcriptViewportMode.ts
@@ -2,8 +2,6 @@ import type { StreamTabId } from '@shared/schemas';
 
 import { activeStreamScope } from './streamViews';
 
-const ROOT_SCROLLBACK_VIEWPORT_KEY = 'root-scrollback';
-
 /**
  * The root stream owns ordinary terminal scrollback through Ink `<Static>`.
  * Focused child streams temporarily become that same scrollback owner so their
@@ -12,19 +10,15 @@ const ROOT_SCROLLBACK_VIEWPORT_KEY = 'root-scrollback';
  * a child page cannot appear under stale root scrollback, and returning to the
  * root can reprint the root static transcript as the active owner.
  */
-export function transcriptViewportKey({
+export function activeTranscriptViewport({
   activeStreamId,
   parentStream,
 }: {
   readonly activeStreamId: StreamTabId | undefined;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
-}): string {
+}): { readonly key: string; readonly scoped: boolean } {
   const scope = activeStreamScope({ activeStreamId, parentStream });
   return scope.kind === 'child'
-    ? `scoped:${scope.streamId}`
-    : ROOT_SCROLLBACK_VIEWPORT_KEY;
-}
-
-export function isScopedTranscriptViewport(viewportKey: string): boolean {
-  return viewportKey !== ROOT_SCROLLBACK_VIEWPORT_KEY;
+    ? { key: `scoped:${scope.streamId}`, scoped: true }
+    : { key: 'root-scrollback', scoped: false };
 }

--- a/packages/cli/src/chat/tui/terminalTitle.ts
+++ b/packages/cli/src/chat/tui/terminalTitle.ts
@@ -2,7 +2,7 @@ import { writeSync } from 'node:fs';
 import { basename } from 'node:path';
 
 import { loadingFrameAt } from '@cli/tui/ui/LoadingIndicator';
-import { subscribeToSharedTick } from '@cli/tui/useLiveNowMs';
+import { subscribeToPolling } from '@cli/tui/usePollingInterval';
 import {
   formatSessionTitle,
   TERMINAL_TAB_TITLE,
@@ -113,7 +113,7 @@ export function installTerminalTitleUpdates(
     if (stopSharedTick !== undefined) return;
     if (!terminalCapabilities.get().oscColorReports) return;
     updateTitle(runningTitle());
-    stopSharedTick = subscribeToSharedTick(() => {
+    stopSharedTick = subscribeToPolling(1000, () => {
       if (!terminalCapabilities.get().oscColorReports) {
         stopRunningAnimation();
         return;

--- a/packages/cli/src/runtime/cliNdjsonProgressEvents.ts
+++ b/packages/cli/src/runtime/cliNdjsonProgressEvents.ts
@@ -1,4 +1,8 @@
-import type { TaskState } from '@agent/core/state/TaskState';
+import type { agentConfigToTaskState } from '@agent/runtime';
+
+// Derived rather than deep-imported from '@agent/core/state/TaskState', so the
+// cli host does not pin @agent's internal module layout for one payload type.
+type TaskState = ReturnType<typeof agentConfigToTaskState>;
 import type {
   AddOutputFilesPayload,
   ExecutionId,

--- a/packages/cli/src/tui/noColorOutput.ts
+++ b/packages/cli/src/tui/noColorOutput.ts
@@ -60,9 +60,7 @@ function writeCallback(args: readonly unknown[]): (() => void) | undefined {
   return typeof callback === 'function' ? (callback as () => void) : undefined;
 }
 
-function sgrStrippingWriteStream<T extends NodeJS.WriteStream>(
-  stream: T,
-): T {
+function sgrStrippingWriteStream<T extends NodeJS.WriteStream>(stream: T): T {
   const state: SgrStripState = { pending: '' };
   const write = stream.write.bind(stream) as (
     chunk: string | Uint8Array,

--- a/packages/cli/src/tui/noColorOutput.ts
+++ b/packages/cli/src/tui/noColorOutput.ts
@@ -6,7 +6,7 @@ interface SgrStripState {
   pending: string;
 }
 
-export function stripAnsiSgrChunk(text: string, state: SgrStripState): string {
+function stripAnsiSgrChunk(text: string, state: SgrStripState): string {
   const input = `${state.pending}${text}`;
   state.pending = '';
 
@@ -60,7 +60,7 @@ function writeCallback(args: readonly unknown[]): (() => void) | undefined {
   return typeof callback === 'function' ? (callback as () => void) : undefined;
 }
 
-export function sgrStrippingWriteStream<T extends NodeJS.WriteStream>(
+function sgrStrippingWriteStream<T extends NodeJS.WriteStream>(
   stream: T,
 ): T {
   const state: SgrStripState = { pending: '' };

--- a/packages/cli/src/tui/selectWindow.ts
+++ b/packages/cli/src/tui/selectWindow.ts
@@ -10,7 +10,7 @@ export interface SelectWindowSize {
   readonly showOverflow: boolean;
 }
 
-export const COMPACT_FORM_MAX_ROWS = 9;
+const COMPACT_FORM_MAX_ROWS = 9;
 
 export function isCompactFormRows(availableRows: number | undefined): boolean {
   return isCompactRows(availableRows, COMPACT_FORM_MAX_ROWS);

--- a/packages/cli/src/tui/terminalCleanup.ts
+++ b/packages/cli/src/tui/terminalCleanup.ts
@@ -30,9 +30,6 @@ const REARM_INPUT_MODES = '\x1b[?2004h\x1b[?25l';
 // `<Static>` transcript lines persist in the primary-buffer scrollback.
 const CLEAR_SCREEN_AND_SCROLLBACK = '\x1b[2J\x1b[3J\x1b[H';
 const CLEAR_VISIBLE_SCREEN = '\x1b[2J\x1b[H';
-interface CleanupTerminalModesOptions {
-  readonly clearItermProgress?: boolean;
-}
 
 // The terminal may be gone (exit paths, a suspend, a closed window) and no
 // caller can surface a failed restore usefully, so every mode write is
@@ -51,11 +48,11 @@ export function supportsTerminalJobControl(
   return platform !== 'win32';
 }
 
-export function cleanupTerminalModes(
-  options: CleanupTerminalModesOptions = {},
-): void {
+export function cleanupTerminalModes(): void {
+  // TERM_PROGRAM is fixed for the process, so the writer owns the emulator
+  // check rather than having it threaded through the exit controller.
   writeTerminalSequence(
-    options.clearItermProgress
+    process.env.TERM_PROGRAM === 'iTerm.app'
       ? `${RESET_TERMINAL_MODES}${CLEAR_ITERM_PROGRESS}`
       : RESET_TERMINAL_MODES,
   );
@@ -70,27 +67,21 @@ export function cleanupTerminalModes(
  * `cleanupTerminalModes` is harmless — so install once while the TUI is
  * mounted and dispose with the other subscriptions.
  */
-export function installTerminalRestoreOnExit(
-  options: CleanupTerminalModesOptions = {},
-): () => void {
-  const onExit = (): void => cleanupTerminalModes(options);
+export function installTerminalRestoreOnExit(): () => void {
+  const onExit = (): void => cleanupTerminalModes();
   process.on('exit', onExit);
   return () => {
     process.off('exit', onExit);
   };
 }
 
-export function tuiInputModeRestoreSequence(options: {
-  readonly kittyKeyboard: boolean;
-}): string {
-  return `${options.kittyKeyboard ? KITTY_PUSH_DISAMBIGUATE : ''}${REARM_INPUT_MODES}`;
-}
-
 /** Re-enable the input modes the TUI relies on after a SIGCONT resume. */
 export function restoreTuiInputModes(options: {
   readonly kittyKeyboard: boolean;
 }): void {
-  writeTerminalSequence(tuiInputModeRestoreSequence(options));
+  writeTerminalSequence(
+    `${options.kittyKeyboard ? KITTY_PUSH_DISAMBIGUATE : ''}${REARM_INPUT_MODES}`,
+  );
 }
 
 export function clearTerminalScrollback(): void {

--- a/packages/cli/src/tui/useCancellableEffect.ts
+++ b/packages/cli/src/tui/useCancellableEffect.ts
@@ -12,21 +12,17 @@ type IsEffectCancelled = () => boolean;
  * Runs `effect` like a normal `useEffect`, but passes it an `isCancelled()`
  * check the effect can poll before applying async state updates after
  * unmount or a dependency change. `effect` may itself be async (its returned
- * promise is not awaited) and may optionally return its own cleanup
- * function, mirroring the real `useEffect` contract.
+ * promise is not awaited).
  */
 export function useCancellableEffect(
-  effect: (
-    isCancelled: IsEffectCancelled,
-  ) => void | Promise<void> | (() => void),
+  effect: (isCancelled: IsEffectCancelled) => void | Promise<void>,
   deps: React.DependencyList,
 ): void {
   useEffect(() => {
     let cancelled = false;
-    const cleanup = effect(() => cancelled);
+    effect(() => cancelled);
     return () => {
       cancelled = true;
-      if (typeof cleanup === 'function') cleanup();
     };
   }, deps);
 }

--- a/packages/cli/src/tui/useLiveNowMs.ts
+++ b/packages/cli/src/tui/useLiveNowMs.ts
@@ -2,24 +2,13 @@ import { useEffect, useState } from 'react';
 
 import { subscribeToPolling } from './usePollingInterval';
 
-// One shared interval for every live-elapsed display. StatusBar and the
-// subagent panel can tick at once; with per-component intervals each would
-// fire at its own phase, producing up to one render burst per component per
-// second. The 1 Hz cadence of the shared poll registry is that ticker:
-// subscribers fire in the same callback, so React batches them into one pass.
-// Exported so non-React callers (e.g. the terminal-title updater) can join
-// the same 1 Hz registry instead of running a private setInterval.
-export function subscribeToSharedTick(subscriber: () => void): () => void {
-  return subscribeToPolling(1000, subscriber);
-}
-
 export function useLiveNowMs(shouldTick: boolean, resetKey?: unknown): number {
   const [nowMs, setNowMs] = useState(() => Date.now());
 
   useEffect(() => {
     if (!shouldTick) return;
     setNowMs(Date.now());
-    return subscribeToSharedTick(() => setNowMs(Date.now()));
+    return subscribeToPolling(1000, () => setNowMs(Date.now()));
   }, [resetKey, shouldTick]);
 
   return nowMs;

--- a/packages/cli/src/tui/usePollingInterval.ts
+++ b/packages/cli/src/tui/usePollingInterval.ts
@@ -1,11 +1,14 @@
 import { useEffect, useRef } from 'react';
 
 /**
- * Shared poll registry, mirroring the `useLiveNowMs` ticker: one interval per
- * cadence, so N live surfaces never each own a timer. Subscribers at the same
- * cadence fire in one callback, so React batches their re-renders into one
- * pass. The timer is unref'd so a poll can never hold the process open on its
- * own, and is torn down once the last subscriber unsubscribes.
+ * Shared poll registry: one interval per cadence, so N live surfaces never
+ * each own a timer. Without it, per-component intervals would each fire at
+ * their own phase, producing up to one render burst per component per period.
+ * Subscribers at the same cadence fire in one callback, so React batches their
+ * re-renders into one pass. The timer is unref'd so a poll can never hold the
+ * process open on its own, and is torn down once the last subscriber
+ * unsubscribes. Non-React callers (e.g. the terminal-title updater) join the
+ * same registry instead of running a private setInterval.
  */
 type PollSubscriber = () => void;
 const pollSubscribers = new Map<number, Set<PollSubscriber>>();

--- a/scripts/check-dead-code-ratchet.mjs
+++ b/scripts/check-dead-code-ratchet.mjs
@@ -51,6 +51,12 @@ function runKnip({ production = false } = {}) {
     cwd: rootDir,
     encoding: 'utf8',
     maxBuffer: 32 * 1024 * 1024,
+    // Knip's vite plugin loads packages/extension/vite.config.ts for entry
+    // detection, and that config throws unless VITE_WEBVIEW names a webview.
+    // Without this the analyzer swallowed a permanent config-load ERROR on
+    // every green run, hiding any real config failure behind it. Build callers
+    // set the variable themselves, so the per-webview build guard is untouched.
+    env: { ...process.env, VITE_WEBVIEW: 'webview' },
   });
   if (result.error) {
     throw result.error;

--- a/src/auth/codex/index.ts
+++ b/src/auth/codex/index.ts
@@ -14,23 +14,16 @@ export {
   CODEX_BACKEND_BASE_URL,
   CODEX_BETA_HEADER,
   CODEX_BETA_VALUE,
-  CODEX_CALLBACK_PATH,
   CODEX_ORIGINATOR,
   CODEX_ORIGINATOR_HEADER,
-  CODEX_SESSION_SECRET_KEY,
 } from './codexConstants';
-export { extractCodexClaims } from './codexJwt';
 export {
   CodexAuthError,
   formatCodexAuthUnavailableMessage,
-  type CodexSession,
-  type CodexTokenResponse,
 } from './codexSessionTypes';
 export {
-  CodexSessionCoordinator,
   type CodexSessionStorage,
   type CodexOAuthClient,
-  type CodexSessionStatus,
 } from './CodexSessionCoordinator';
 export {
   codexCoordinator,

--- a/src/auth/xai/index.ts
+++ b/src/auth/xai/index.ts
@@ -9,16 +9,12 @@
  * preferences, owned by `@model/xai/xaiPreference` so the model layer can
  * read them without depending on this OAuth machinery.
  */
-export { decodeXaiJwtClaims } from './xaiJwt';
 export {
   XaiAuthError,
   formatXaiAuthUnavailableMessage,
   xaiAccountLabel,
-  type XaiSession,
-  type XaiTokenResponse,
 } from './xaiSessionTypes';
 export {
-  XaiSessionCoordinator,
   type XaiSessionStorage,
   type XaiOAuthClient,
 } from './XaiSessionCoordinator';

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -28,12 +28,12 @@ import {
 } from '@agent/runtime/ModelFactory';
 import {
   CODEX_BACKEND_BASE_URL,
-  CODEX_SESSION_SECRET_KEY,
   CodexAuthError,
   codexCoordinator,
   resetCodexCoordinator,
-  type CodexSession,
 } from '@auth/codex';
+import { CODEX_SESSION_SECRET_KEY } from '@auth/codex/codexConstants';
+import type { CodexSession } from '@auth/codex/codexSessionTypes';
 import { shouldRouteModelThroughOpenRouter } from '@model/openRouterRouting';
 import {
   invalidateRuntimeModelRegistry,

--- a/src/test-kernel/auth/CodexDeviceLogin.vitest.ts
+++ b/src/test-kernel/auth/CodexDeviceLogin.vitest.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { CodexAuthError, type CodexSessionCoordinator } from '@auth/codex';
+import { CodexAuthError } from '@auth/codex';
+import type { CodexSessionCoordinator } from '@auth/codex/CodexSessionCoordinator';
 
 const mocks = vi.hoisted(() => ({
   pollDeviceToken: vi.fn(),

--- a/src/test-kernel/auth/CodexJwt.vitest.ts
+++ b/src/test-kernel/auth/CodexJwt.vitest.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { extractCodexClaims } from '@auth/codex';
+import { extractCodexClaims } from '@auth/codex/codexJwt';
 
 /** Build a JWT with the given payload (signature is irrelevant — we only decode). */
 function makeJwt(payload: Record<string, unknown>): string {

--- a/src/test-kernel/auth/CodexLoopbackLogin.vitest.ts
+++ b/src/test-kernel/auth/CodexLoopbackLogin.vitest.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import {
-  CODEX_CALLBACK_PATH,
-  loginWithLoopback,
-  type CodexSession,
-  type CodexSessionCoordinator,
-} from '@auth/codex';
+import { loginWithLoopback } from '@auth/codex';
+import { CODEX_CALLBACK_PATH } from '@auth/codex/codexConstants';
+import type { CodexSessionCoordinator } from '@auth/codex/CodexSessionCoordinator';
+import type { CodexSession } from '@auth/codex/codexSessionTypes';
 import type { SubscriptionAuthorizeRequest } from '@auth/oauth/SubscriptionOAuthCoordinator';
 
 function testSession(): CodexSession {

--- a/src/test-kernel/auth/CodexSessionCoordinator.vitest.ts
+++ b/src/test-kernel/auth/CodexSessionCoordinator.vitest.ts
@@ -3,12 +3,14 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   CodexAuthError,
-  CodexSessionCoordinator,
   type CodexOAuthClient,
-  type CodexSession,
   type CodexSessionStorage,
-  type CodexTokenResponse,
 } from '@auth/codex';
+import { CodexSessionCoordinator } from '@auth/codex/CodexSessionCoordinator';
+import type {
+  CodexSession,
+  CodexTokenResponse,
+} from '@auth/codex/codexSessionTypes';
 import { codexAccountLabel } from '@auth/codex/codexSessionTypes';
 import { delay } from '@utils/core';
 

--- a/src/test-kernel/auth/XaiJwt.vitest.ts
+++ b/src/test-kernel/auth/XaiJwt.vitest.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { decodeXaiJwtClaims } from '@auth/xai';
+import { decodeXaiJwtClaims } from '@auth/xai/xaiJwt';
 
 function makeJwt(payload: object): string {
   const header = Buffer.from(

--- a/src/test-kernel/auth/XaiSessionCoordinator.vitest.ts
+++ b/src/test-kernel/auth/XaiSessionCoordinator.vitest.ts
@@ -2,12 +2,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   XaiAuthError,
-  XaiSessionCoordinator,
   type XaiOAuthClient,
-  type XaiSession,
   type XaiSessionStorage,
-  type XaiTokenResponse,
 } from '@auth/xai';
+import { XaiSessionCoordinator } from '@auth/xai/XaiSessionCoordinator';
+import type { XaiSession, XaiTokenResponse } from '@auth/xai/xaiSessionTypes';
 import * as logger from '@logger/logUtils';
 import { createDeferred } from '@test/support/asyncTestUtils';
 

--- a/src/test-kernel/cli/AgentRosterForm.vitest.ts
+++ b/src/test-kernel/cli/AgentRosterForm.vitest.ts
@@ -4,10 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { AgentEntry } from '@agent/index';
 import {
   AgentRosterForm,
-  agentRosterSelectWindow,
   buildChatDefaultAgentItems,
-  selectedAgentKeys,
-  setChatDefaultAgent,
 } from '@cli/chat/tui/forms/AgentRosterForm';
 import { formatCliAgentRoster } from '@cli/runtime/agentRoster';
 import {
@@ -74,21 +71,6 @@ describe('AgentRosterForm', () => {
         description: 'General assistant',
       },
     ]);
-  });
-
-  it('windows long roster lists to the available terminal rows', () => {
-    expect(
-      agentRosterSelectWindow({ availableRows: 10, itemCount: 20 }),
-    ).toEqual({ maxVisibleItems: 3, showOverflow: true });
-    expect(
-      agentRosterSelectWindow({ availableRows: undefined, itemCount: 20 }),
-    ).toEqual({ maxVisibleItems: undefined, showOverflow: false });
-  });
-
-  it('rejects default-chat selection when there is no workspace', async () => {
-    await expect(
-      setChatDefaultAgent(undefined, 'builtInToolUse:assistant'),
-    ).rejects.toThrow('Default chat-agent selection requires a workspace.');
   });
 
   it('reports open categories without materializing the current catalog', () => {

--- a/src/test-kernel/cli/ChildControls.vitest.ts
+++ b/src/test-kernel/cli/ChildControls.vitest.ts
@@ -78,10 +78,7 @@ describe('CLI child controls', () => {
         parentStream,
         streams,
       }),
-    ).toMatchObject({
-      streamId: root,
-      slice: streams.get(root),
-    });
+    ).toBe(root);
   });
 
   it('roots nested child-list rows at the resolved target stream', () => {
@@ -107,13 +104,13 @@ describe('CLI child controls', () => {
       streams,
     });
 
-    expect(target.streamId).toBe(child);
+    expect(target).toBe(child);
     expect(
       streamTreeViews({
         activeStreamId: child,
         childRosters: entries,
         parentStream,
-        rootStreamId: target.streamId,
+        rootStreamId: target,
         streams,
       }).map((view) => view.id),
     ).toEqual([child, leaf]);

--- a/src/test-kernel/cli/CliPersistenceFlush.vitest.ts
+++ b/src/test-kernel/cli/CliPersistenceFlush.vitest.ts
@@ -13,11 +13,8 @@ import {
   STREAM_LOG_ENTRY_TYPES,
 } from '@shared/schemas';
 import { appendTranscriptEntry } from '@test/support/storeTestDrivers';
-import {
-  StreamLogStore,
-  STREAM_LOGS_DIR,
-  type StreamLogAppendInput,
-} from '@transcript';
+import { StreamLogStore, STREAM_LOGS_DIR } from '@transcript';
+import type { StreamLogAppendInput } from '@transcript/StreamLog';
 import { StorageFS } from '@utils/files/storageFS';
 
 function notFound(): NodeJS.ErrnoException {

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -32,7 +32,7 @@ import {
 } from '@cli/chat/tui/panes/StaticConversationTranscript';
 import { staticScrollbackTarget } from '@cli/chat/tui/appLayout';
 import { staticTranscriptRepaintEpoch } from '@cli/chat/tui/state/staticTranscriptRepaint';
-import { transcriptViewportKey } from '@cli/chat/tui/state/transcriptViewportMode';
+import { activeTranscriptViewport } from '@cli/chat/tui/state/transcriptViewportMode';
 import {
   createTuiViewportController,
   type TuiRepaintOptions,
@@ -1981,17 +1981,12 @@ describe('CLI conversation transcript', () => {
     const parentStream = new Map<StreamTabId, StreamTabId>([
       [CHILD_STREAM, ROOT_STREAM],
     ]);
-    const rootViewportKey = transcriptViewportKey({
-      activeStreamId: ROOT_STREAM,
-      parentStream,
-    });
-    const childViewportKey = transcriptViewportKey({
-      activeStreamId: CHILD_STREAM,
-      parentStream,
-    });
-
-    expect(rootViewportKey).toBe('root-scrollback');
-    expect(childViewportKey).toBe(`scoped:${CHILD_STREAM}`);
+    expect(
+      activeTranscriptViewport({ activeStreamId: ROOT_STREAM, parentStream }),
+    ).toEqual({ key: 'root-scrollback', scoped: false });
+    expect(
+      activeTranscriptViewport({ activeStreamId: CHILD_STREAM, parentStream }),
+    ).toEqual({ key: `scoped:${CHILD_STREAM}`, scoped: true });
   });
 
   it('repaints static transcript invalidations from a clean origin', () => {

--- a/src/test-kernel/cli/DiffView.vitest.ts
+++ b/src/test-kernel/cli/DiffView.vitest.ts
@@ -58,9 +58,9 @@ describe('CLI diff display', () => {
   });
 
   it('clamps the bottom scroll offset so the last rows remain visible', () => {
-    expect(
-      maxScrollableRowOffset({ maxDisplayLines: 4, totalLines: 10 }),
-    ).toBe(7);
+    expect(maxScrollableRowOffset({ maxDisplayLines: 4, totalLines: 10 })).toBe(
+      7,
+    );
   });
 
   it.each([1, 2, 3])(

--- a/src/test-kernel/cli/DiffView.vitest.ts
+++ b/src/test-kernel/cli/DiffView.vitest.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
   initialDiffScrollOffset,
-  maxDiffScrollOffset,
   scrollBoundedDiffDisplayLines,
   wrappedDiffDisplayLines,
 } from '@cli/chat/tui/render/DiffView';
+import { maxScrollableRowOffset } from '@cli/chat/tui/render/scrollBounds';
 import { fillRows } from '@cli/runtime/terminalText';
 import { buildDiffHunks } from '@utils/text/unifiedDiff';
 
@@ -58,13 +58,17 @@ describe('CLI diff display', () => {
   });
 
   it('clamps the bottom scroll offset so the last rows remain visible', () => {
-    expect(maxDiffScrollOffset(10, 4)).toBe(7);
+    expect(
+      maxScrollableRowOffset({ maxDisplayLines: 4, totalLines: 10 }),
+    ).toBe(7);
   });
 
   it.each([1, 2, 3])(
     'keeps cramped diff windows static at a budget of %i rows',
     (budget) => {
-      expect(maxDiffScrollOffset(10, budget)).toBe(0);
+      expect(
+        maxScrollableRowOffset({ maxDisplayLines: budget, totalLines: 10 }),
+      ).toBe(0);
     },
   );
 

--- a/src/test-kernel/cli/ListForm.vitest.ts
+++ b/src/test-kernel/cli/ListForm.vitest.ts
@@ -47,6 +47,12 @@ describe('shared CLI list-form row budget', () => {
       }),
     ).toEqual({ maxVisibleItems: 1, showOverflow: false });
   });
+
+  it('leaves the list unwindowed when the terminal height is unknown', () => {
+    expect(
+      listFormSelectWindow({ availableRows: undefined, itemCount: 20 }),
+    ).toEqual({ maxVisibleItems: undefined, showOverflow: false });
+  });
 });
 
 describe('shared CLI list-form buffered selection', () => {

--- a/src/test-kernel/cli/ModelListForm.vitest.ts
+++ b/src/test-kernel/cli/ModelListForm.vitest.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  modelListDescription,
-  modelSelectWindow,
-} from '@cli/chat/tui/forms/ModelListForm';
+import { modelListDescription } from '@cli/chat/tui/forms/ModelListForm';
 import {
   shouldBufferAsyncListFormInput,
   shouldCloseAsyncListFormOnInput,
@@ -391,33 +388,4 @@ describe('CLI ModelListForm row budget', () => {
     expect(isCompactFormRows(9)).toBe(true);
     expect(isCompactFormRows(10)).toBe(false);
   });
-
-  it.each<{
-    availableRows: number;
-    expected: ReturnType<typeof modelSelectWindow>;
-  }>([
-    {
-      availableRows: 6,
-      expected: { maxVisibleItems: 1, showOverflow: false },
-    },
-    {
-      availableRows: 7,
-      expected: { maxVisibleItems: 1, showOverflow: false },
-    },
-    {
-      availableRows: 8,
-      expected: { maxVisibleItems: 2, showOverflow: false },
-    },
-    {
-      availableRows: 12,
-      expected: { maxVisibleItems: 4, showOverflow: true },
-    },
-  ])(
-    'sizes the window for $availableRows available rows',
-    ({ availableRows, expected }) => {
-      expect(modelSelectWindow({ availableRows, itemCount: 8 })).toEqual(
-        expected,
-      );
-    },
-  );
 });

--- a/src/test-kernel/cli/ModelListForm.vitest.ts
+++ b/src/test-kernel/cli/ModelListForm.vitest.ts
@@ -5,10 +5,7 @@ import {
   shouldBufferAsyncListFormInput,
   shouldCloseAsyncListFormOnInput,
 } from '@cli/chat/tui/forms/_shared/useAsyncListForm';
-import {
-  COMPACT_FORM_MAX_ROWS,
-  isCompactFormRows,
-} from '@cli/tui/selectWindow';
+import { isCompactFormRows } from '@cli/tui/selectWindow';
 import {
   nextSelectHighlightIndex,
   selectInitialHighlightIndex,
@@ -384,7 +381,6 @@ describe('CLI Select disabled-row focus', () => {
 
 describe('CLI ModelListForm row budget', () => {
   it('uses compact slash forms before bordered content clips titles', () => {
-    expect(COMPACT_FORM_MAX_ROWS).toBe(9);
     expect(isCompactFormRows(9)).toBe(true);
     expect(isCompactFormRows(10)).toBe(false);
   });

--- a/src/test-kernel/cli/SessionExitController.vitest.ts
+++ b/src/test-kernel/cli/SessionExitController.vitest.ts
@@ -83,8 +83,6 @@ describe('chat TUI session exit controller', () => {
       commandName: 'texra',
       cwd: '/tmp/project',
       canResume: true,
-      clearItermProgress: false,
-      kittyKeyboardEnabled: false,
       disposables: new DisposableStore(),
       disposeTerminalRestoreOnExit: vi.fn(),
       followUpQueue: new PQueue(),

--- a/src/test-kernel/cli/SessionStatus.vitest.ts
+++ b/src/test-kernel/cli/SessionStatus.vitest.ts
@@ -231,7 +231,7 @@ describe('CLI session status formatter', () => {
         agent: 'research',
         model: 'deepseekT',
         modelAccess: 'included',
-          status: STREAM_PHASE.WAITING,
+        status: STREAM_PHASE.WAITING,
       }),
     ).toContain('status: idle');
   });

--- a/src/test-kernel/cli/SessionStatus.vitest.ts
+++ b/src/test-kernel/cli/SessionStatus.vitest.ts
@@ -12,7 +12,7 @@ function sessionStatus(overrides: Partial<CliSessionStatusInput> = {}): string {
     agent: 'chat',
     model: 'harness-model',
     modelAccess: 'personal',
-    approval: 'ask',
+    approvalPolicy: 'ask',
     status: STREAM_PHASE.RUNNING,
     activeSkills: [],
     queuedFollowUpMessages: [],
@@ -34,7 +34,7 @@ describe('CLI session status formatter', () => {
         'agent: chat',
         'model: harness-model',
         'model access: Your own API keys',
-        'approval: ask',
+        'approval: Control Bash and edit prompts independently.',
         'status: running',
         'queued follow-ups: 2',
         '1. First queued follow-up is to re-run the narrow layout proof check.',
@@ -106,7 +106,6 @@ describe('CLI session status formatter', () => {
     {
       name: 'includes the active non-default approval policy',
       overrides: {
-        approval: 'deny privileged actions',
         approvalPolicy: 'never' as const,
         status: 'waiting' as const,
         commandName: 'texra-local',
@@ -117,7 +116,6 @@ describe('CLI session status formatter', () => {
     {
       name: 'includes cwd and approval policy when both apply',
       overrides: {
-        approval: 'deny privileged actions',
         approvalPolicy: 'never' as const,
         status: 'waiting' as const,
         commandName: 'texra-local',
@@ -162,7 +160,6 @@ describe('CLI session status formatter', () => {
 
   it('reports active session approval bypasses', () => {
     const status = sessionStatus({
-      approval: 'ask before privileged actions',
       approvalBypasses: { superYolo: true, bash: true, toolEdit: true },
       status: STREAM_PHASE.WAITING,
     });
@@ -176,7 +173,6 @@ describe('CLI session status formatter', () => {
   it('surfaces an active goal in status details', () => {
     const status = sessionStatus({
       modelAccess: 'included',
-      approval: 'ask before privileged actions',
       status: STREAM_PHASE.CANCELLED,
       goal: {
         status: 'active',
@@ -201,7 +197,10 @@ describe('CLI session status formatter', () => {
 
     expect(status).toContain('model: GPT-5.6 Terra');
     expect(status).toContain(
-      ['model access: ChatGPT subscription', 'approval: ask'].join('\n'),
+      [
+        'model access: ChatGPT subscription',
+        'approval: Control Bash and edit prompts independently.',
+      ].join('\n'),
     );
   });
 
@@ -232,8 +231,7 @@ describe('CLI session status formatter', () => {
         agent: 'research',
         model: 'deepseekT',
         modelAccess: 'included',
-        approval: 'ask before privileged actions',
-        status: STREAM_PHASE.WAITING,
+          status: STREAM_PHASE.WAITING,
       }),
     ).toContain('status: idle');
   });

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -158,7 +158,6 @@ function createContext(
   return {
     cliContext: createCliContext(),
     session,
-    cwd: '/tmp/workspace',
     processCwd: '/tmp/launcher',
     initialAgent: 'chat',
     initialModel: 'deepseekT',

--- a/src/test-kernel/cli/SlashRegistry.vitest.ts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.ts
@@ -12,7 +12,6 @@ import {
   parseSlashInput,
   prefixSlashCommands,
   registerSlashCommand,
-  slashPickIntent,
   suggestSlashCommand,
   unregisterSlashCommand,
   type SlashCommand,
@@ -771,14 +770,6 @@ describe('slashRegistry', () => {
     expect(findSlashCommand('age')).toBeUndefined();
   });
 
-  it('submits no-form commands on Enter and completes on Tab', () => {
-    const help = { name: 'help', description: 'show help', aliases: ['h'] };
-    registerSlashCommand(help);
-
-    expect(slashPickIntent(help, 'enter')).toBe('submit');
-    expect(slashPickIntent(help, 'tab')).toBe('complete');
-  });
-
   it('suggests the closest command for a typo within the shared threshold', () => {
     registerBuiltinSlashCommands();
 
@@ -801,17 +792,6 @@ describe('slashRegistry', () => {
     registerBuiltinSlashCommands();
 
     expect(suggestSlashCommand('frobnicate')).toBeUndefined();
-  });
-
-  it('does not directly submit structured-form commands from the palette', () => {
-    const agent = {
-      name: 'agent',
-      description: 'pick an agent',
-      formComponent: () => null,
-    };
-    registerSlashCommand(agent);
-
-    expect(slashPickIntent(agent, 'enter')).toBe('complete');
   });
 });
 

--- a/src/test-kernel/cli/TerminalCleanup.vitest.ts
+++ b/src/test-kernel/cli/TerminalCleanup.vitest.ts
@@ -22,8 +22,8 @@ import {
 } from '@cli/chat/tui/state/cliState';
 import {
   installTerminalRestoreOnExit,
+  restoreTuiInputModes,
   supportsTerminalJobControl,
-  tuiInputModeRestoreSequence,
 } from '@cli/tui/terminalCleanup';
 import {
   installTerminalTitleUpdates,
@@ -331,15 +331,18 @@ describe('installTerminalTitleUpdates', () => {
   });
 });
 
-describe('tuiInputModeRestoreSequence', () => {
+describe('restoreTuiInputModes', () => {
   it('re-arms bracketed paste and cursor hide after a SIGCONT resume', () => {
-    expect(tuiInputModeRestoreSequence({ kittyKeyboard: false })).toBe(
-      '\x1b[?2004h\x1b[?25l',
-    );
+    restoreTuiInputModes({ kittyKeyboard: false });
+
+    expect(writeSync).toHaveBeenLastCalledWith(1, '\x1b[?2004h\x1b[?25l');
   });
 
   it("re-pushes Ink's kitty disambiguate flag on kitty terminals", () => {
-    expect(tuiInputModeRestoreSequence({ kittyKeyboard: true })).toBe(
+    restoreTuiInputModes({ kittyKeyboard: true });
+
+    expect(writeSync).toHaveBeenLastCalledWith(
+      1,
       '\x1b[>1u\x1b[?2004h\x1b[?25l',
     );
   });

--- a/src/test-kernel/cli/TuiNoColorOutput.vitest.ts
+++ b/src/test-kernel/cli/TuiNoColorOutput.vitest.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  sgrStrippingWriteStream,
-  stripAnsiSgrChunk,
-} from '@cli/tui/noColorOutput';
+import { tuiOutputStreamForColor } from '@cli/tui/noColorOutput';
 
 describe('TUI no-color output', () => {
   function fakeWriteStream(): { stream: NodeJS.WriteStream; writes: string[] } {
@@ -22,17 +19,19 @@ describe('TUI no-color output', () => {
   }
 
   it('strips SGR styling while preserving terminal control escapes', () => {
-    const input = '\x1b[2mDim\x1b[22m\x1b[36m cyan\x1b[39m\x1b[2K\x1b[1;1H';
+    const { stream, writes } = fakeWriteStream();
 
-    expect(stripAnsiSgrChunk(input, { pending: '' })).toBe(
-      'Dim cyan\x1b[2K\x1b[1;1H',
+    tuiOutputStreamForColor(stream, false).write(
+      '\x1b[2mDim\x1b[22m\x1b[36m cyan\x1b[39m\x1b[2K\x1b[1;1H',
     );
+
+    expect(writes).toEqual(['Dim cyan\x1b[2K\x1b[1;1H']);
   });
 
   it('strips SGR styling from byte chunks passed to write streams', () => {
     const { stream, writes } = fakeWriteStream();
 
-    sgrStrippingWriteStream(stream).write(
+    tuiOutputStreamForColor(stream, false).write(
       Buffer.from('\x1b[31mred\x1b[39m\x1b[2K'),
     );
 
@@ -41,7 +40,7 @@ describe('TUI no-color output', () => {
 
   it('keeps partial SGR sequences from leaking across writes', () => {
     const { stream, writes } = fakeWriteStream();
-    const stripped = sgrStrippingWriteStream(stream);
+    const stripped = tuiOutputStreamForColor(stream, false);
 
     stripped.write('\x1b[');
     stripped.write('31mred\x1b[3');
@@ -52,7 +51,7 @@ describe('TUI no-color output', () => {
 
   it('preserves split non-SGR terminal control sequences', () => {
     const { stream, writes } = fakeWriteStream();
-    const stripped = sgrStrippingWriteStream(stream);
+    const stripped = tuiOutputStreamForColor(stream, false);
 
     stripped.write('\x1b[');
     stripped.write('2Kclear');

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -51,7 +51,7 @@ import {
 } from '@cli/chat/tui/state/childExecutions';
 import { syncStreamLog } from '@cli/chat/tui/state/subscribeStreamLog';
 import { advanceSettledPrefixIndex } from '@cli/chat/tui/state/transcriptFold';
-import { transcriptViewportKey } from '@cli/chat/tui/state/transcriptViewportMode';
+import { activeTranscriptViewport } from '@cli/chat/tui/state/transcriptViewportMode';
 import { attachSessionSignalsAdapter } from '@cli/chat/tui/state/sessionSignalsAdapter';
 import {
   bumpStreamArtifactRevision,
@@ -779,17 +779,17 @@ describe('cliState stream, focus, and child-edge fields', () => {
       expect(parentStream.get().get(child1)).toBe(root);
       expect(orderedSessionDescendants(root)[0]).toBe(child1);
       expect(
-        transcriptViewportKey({
+        activeTranscriptViewport({
           activeStreamId: child1,
           parentStream: parentStream.get(),
         }),
-      ).toBe(`scoped:${child1}`);
+      ).toEqual({ key: `scoped:${child1}`, scoped: true });
       expect(
-        transcriptViewportKey({
+        activeTranscriptViewport({
           activeStreamId: root,
           parentStream: parentStream.get(),
         }),
-      ).toBe('root-scrollback');
+      ).toEqual({ key: 'root-scrollback', scoped: false });
     });
   });
 });

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
-import { CODEX_SESSION_SECRET_KEY, resetCodexCoordinator } from '@auth/codex';
+import { resetCodexCoordinator } from '@auth/codex';
+import { CODEX_SESSION_SECRET_KEY } from '@auth/codex/codexConstants';
 import { installTexraAccountProbes } from '@controllers/modelAccess/installTexraAccountProbes';
 import {
   computeModelOptionsData,

--- a/src/test-kernel/model/ProviderCapabilities.vitest.ts
+++ b/src/test-kernel/model/ProviderCapabilities.vitest.ts
@@ -7,11 +7,9 @@ import {
   type ModelConfig,
 } from 'llm-zoo';
 
-import {
-  CODEX_SESSION_SECRET_KEY,
-  resetCodexCoordinator,
-  type CodexSession,
-} from '@auth/codex';
+import { resetCodexCoordinator } from '@auth/codex';
+import { CODEX_SESSION_SECRET_KEY } from '@auth/codex/codexConstants';
+import type { CodexSession } from '@auth/codex/codexSessionTypes';
 import { installTexraAccountProbes } from '@controllers/modelAccess/installTexraAccountProbes';
 import {
   CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,

--- a/src/test-kernel/progressView/ProgressBackendCleanup.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendCleanup.vitest.ts
@@ -39,7 +39,8 @@ import {
   snapshotFacts,
 } from '@test/support/storeTestDrivers';
 import { GoalStore } from '@tools/goal';
-import { streamDataDir, StreamSnapshotStore } from '@transcript';
+import { StreamSnapshotStore } from '@transcript';
+import { streamDataDir } from '@transcript/streamDataPaths';
 import {
   stagedStreamDataDir,
   STREAM_DATA_DIR,

--- a/src/test-kernel/progressView/WebviewBridge.vitest.ts
+++ b/src/test-kernel/progressView/WebviewBridge.vitest.ts
@@ -26,7 +26,8 @@ import {
   updateTranscriptEntry,
   withTranscriptWriter,
 } from '@test/support/storeTestDrivers';
-import { StreamLogStore, type StreamLogAppendInput } from '@transcript';
+import { StreamLogStore } from '@transcript';
+import type { StreamLogAppendInput } from '@transcript/StreamLog';
 
 const ACTIVE = 'active' as StreamTabId;
 const INACTIVE = 'inactive' as StreamTabId;

--- a/src/test-kernel/support/storeTestDrivers.ts
+++ b/src/test-kernel/support/storeTestDrivers.ts
@@ -13,7 +13,8 @@ import type {
   StreamTabId,
   TodoItem,
 } from '@shared/schemas';
-import type { StreamSnapshotStore, StreamLogAppendInput } from '@transcript';
+import type { StreamSnapshotStore } from '@transcript';
+import type { StreamLogAppendInput } from '@transcript/StreamLog';
 import type {
   StreamLogStore,
   TranscriptWriter,

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -25,7 +25,8 @@ import { createTestSession } from '@test/support/sessionTestUtils';
 import { snapshotFacts } from '@test/support/storeTestDrivers';
 import { withTempDir } from '@test/support/tempDirPlatform';
 import { ExecutionsTool } from '@tools/ExecutionsTool';
-import { StreamSnapshotStore, streamDataDir } from '@transcript';
+import { StreamSnapshotStore } from '@transcript';
+import { streamDataDir } from '@transcript/streamDataPaths';
 import { StorageFS } from '@utils/files/storageFS';
 
 const tempDirs = useTempDirs();

--- a/src/test-kernel/transcript/StreamLogDelta.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogDelta.vitest.ts
@@ -14,7 +14,8 @@ import {
   type StreamLogEntry,
   type StreamTabId,
 } from '@shared/schemas';
-import { StreamLogDeltaBuffer, type StreamLogDelta } from '@transcript';
+import { StreamLogDeltaBuffer } from '@transcript';
+import type { StreamLogDelta } from '@transcript/StreamLog';
 import { StreamLogStore } from '@transcript/StreamLogStore';
 
 import {

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -24,8 +24,8 @@ import {
   StreamLogStore,
   STREAM_LOGS_DIR,
   STREAM_LOG_SUMMARIES_DIR,
-  type StreamLogAppendInput,
 } from '@transcript';
+import type { StreamLogAppendInput } from '@transcript/StreamLog';
 import { clearPersistedSummaryParentStream } from '@transcript/StreamLogStore';
 import { delay } from '@utils/core';
 import { StorageFS } from '@utils/files/storageFS';

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -37,8 +37,8 @@ import { snapshotFacts } from '@test/support/storeTestDrivers';
 import {
   StreamSnapshotPreloadError,
   StreamSnapshotStore,
-  streamDataDir,
 } from '@transcript';
+import { streamDataDir } from '@transcript/streamDataPaths';
 import type { StagedStreamSnapshotDeletion } from '@transcript/StagedDeletionCoordinator';
 import {
   stagedStreamDataDir,

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -34,10 +34,7 @@ import {
 } from '@test/support/tempDirPlatform';
 import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 import { snapshotFacts } from '@test/support/storeTestDrivers';
-import {
-  StreamSnapshotPreloadError,
-  StreamSnapshotStore,
-} from '@transcript';
+import { StreamSnapshotPreloadError, StreamSnapshotStore } from '@transcript';
 import { streamDataDir } from '@transcript/streamDataPaths';
 import type { StagedStreamSnapshotDeletion } from '@transcript/StagedDeletionCoordinator';
 import {

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -15,12 +15,7 @@ export {
   STREAM_LOGS_DIR,
   STREAM_LOG_SUMMARIES_DIR,
 } from './StreamLogStore';
-export {
-  StreamLog,
-  StreamLogDeltaBuffer,
-  type StreamLogAppendInput,
-  type StreamLogDelta,
-} from './StreamLog';
+export { StreamLog, StreamLogDeltaBuffer } from './StreamLog';
 export { createRunTrace, type RunTrace } from './runTrace';
 export {
   findTranscriptSpillFile,
@@ -28,7 +23,6 @@ export {
   spillArtifactOpenFailedMessage,
   SPILL_ARTIFACT_DELETED_MESSAGE,
 } from './spillArtifacts';
-export { streamDataDir } from './streamDataPaths';
 export {
   StreamSnapshotPreloadError,
   StreamSnapshotStore,


### PR DESCRIPTION
Implements the verified simplification-survey findings for lane l6-tui-cmds-ratchets: CLI TUI commands/forms cleanup, dead-export deletion across three barrels, and ratchet-baseline shrinks. 9 lane commits plus a formatting commit; all central validation checks pass (typecheck, lint, full Vitest suite 822 files / 9995 tests, dead-code ratchet 347 vs 347 baselined with no new findings).

## Implemented findings

- 100 — `openModelSelectionForm` hand-rolls a second, partial copy of the registry's form-open path
- 101 — `slashPickIntent`'s form-command branch is value-dead; the helper collapses to a keystroke test
- 102 — `formSelectionHandler` guards one liveness fact with two owners: a state-generation counter and a submission token
- 103 — `/agent` and `/approval` form selections swallow their errors silently while the other five adapters route them
- 104 — `/approval`'s handler re-implements the `formRemainders` rule the registration already declares
- 105 — `SlashCommandContext` re-carries two fields it already holds via `cliContext`
- 106 — Baselined test-only exports in the form/palette files (verifier-downgraded survivor: inline `setChatDefaultAgent`, delete its guard-only test; `selectedAgentKeys` additionally un-exported)
- 108 — Inline the trivial one-line `*SelectWindow` wrappers and delete their cloned arithmetic tests
- 109 — `AsyncListFormControls` exposes both `setData` and `reload`; the only two `setData` callers hand-roll exactly what `reload` does
- 110 — ListForm/ApiKeyEntryForm props sweep: dead `descriptionFor` option and a never-imported exported interface
- 115 — UserQuestion's MultiSelectQuestion and SingleSelectQuestion are one component behind a `multiSelect` flag
- 127 — DiffView micro-batch: a single-caller argument adapter and a provably idempotent re-wrap
- 128 — Exit controller threads two process-constant terminal facts that already have owners
- 129 — CliSessionStatusInput carries both a formatted approval string and the policy it was formatted from
- 131 — runChatTui resume-vs-init ternaries whose two branches can never both be live
- 134 — ChildListTarget.slice is a denormalized copy of streams.get(target.streamId)
- 137 — `isScopedTranscriptViewport` decodes back out of the string key that was encoded from the scope one line earlier (replaced by new `activeTranscriptViewport`, consumer in the same commit)
- 180 — Five more CLI test-only exports made module-private (4 of 5: `workflowInputGlobOptions` kept — its test pins win32-vs-linux glob semantics unreachable from a single platform)
- 182 — subscribeToSharedTick is a pure alias for subscribeToPolling(1000, …) with one external caller
- 183 — useCancellableEffect's optional-cleanup return arm has no production caller
- 184 — Two knip-baseline "unused files" entries are config false positives — fix knip.json, shrink baseline by 2
- 185 — knip errors on every dead-code run: packages/extension/vite.config.ts throws when VITE_WEBVIEW is unset
- 194 — Drop cli's `@agent/core/state/TaskState` deep-import row via a derived type
- 195 — Delete dead barrel re-export lines in codex/xai/transcript barrels; knip baseline shrinks accordingly
- 196 — Tighten architecture-edges row replacement->shared from value to type-only

Declared behavior changes (each is the point of its finding, not a side effect):

- 103: `/agent` and `/approval` form-selection failures now reach the transcript error sink instead of being swallowed.
- 104: `/yolo status` now prints `Usage: /yolo [ask | never | yolo]` instead of opening the /approval picker; `/approval` and `/approval status` unchanged.
- 109: a failed post-toggle re-read in /tools and /models lands in the form's shared error frame instead of a private transient notice.
- 115: the folded ChoiceQuestion is keyed by question index, which also stops a multi-select question from inheriting the previous one's toggles (a pre-existing leak).

## Net elements (R6)

- Files touched: 72 (`git diff --stat origin/main`: 283 insertions, 676 deletions, **net -393 LoC**)
- Exported symbols: **-29 / +1** — 15 exports deleted or made module-private in packages/cli, 14 dead barrel re-export names removed from `src/auth/codex/index.ts`, `src/auth/xai/index.ts`, and `src/transcript/index.ts`; one new export `activeTranscriptViewport` (packages/cli/src/chat/tui/state/transcriptViewportMode.ts) replaces the two deleted exports there and has a same-commit consumer
- Class/interface/enum declarations: **-2** (`ChildListTarget` and `CleanupTerminalModesOptions` interfaces deleted; `CredentialEntryFormProps` kept but un-exported)
- knip baseline: 371 -> 347 rows (24 removed, 0 added); host-agent-import-baseline loses one hosts.cli row; architecture-edges row replacement->shared tightened value -> type-only. No baseline widened.

## Consumer counts (R8)

Remaining cross-file consumers after deletion, grepped over `src/` + `packages/` (defining file excluded):

| Deleted export | Consumers left |
| --- | --- |
| slashPickIntent | 0 |
| transcriptViewportKey | 0 |
| isScopedTranscriptViewport | 0 |
| ChildListTarget | 0 |
| modelSelectWindow | 0 |
| agentRosterSelectWindow | 0 |
| setChatDefaultAgent | 0 |
| selectedAgentKeys (un-exported) | 0 outside defining file |
| CredentialEntryFormProps (un-exported) | 0 outside defining file |
| maxDiffScrollOffset | 0 |
| tuiInputModeRestoreSequence | 0 |
| stripAnsiSgrChunk (un-exported) | 0 outside defining file |
| sgrStrippingWriteStream (un-exported) | 0 outside defining file |
| COMPACT_FORM_MAX_ROWS (un-exported) | 0 outside defining file |
| subscribeToSharedTick | 0 |
| 14 barrel re-export names (codex ×7, xai ×4, transcript ×3) | 0 barrel imports remain; all uses go through the leaf modules |

Barrel names checked individually (CODEX_CALLBACK_PATH, CODEX_SESSION_SECRET_KEY, extractCodexClaims, CodexSessionCoordinator, CodexSession, CodexTokenResponse, CodexSessionStatus, decodeXaiJwtClaims, XaiSessionCoordinator, XaiSession, XaiTokenResponse, streamDataDir, StreamLogAppendInput, StreamLogDelta): 0 files import any of them from the barrel; every remaining reference is a leaf-module import or same-file use.

## Skipped

- 107 — declared UI/UX behavior changes (new footer prefix, shortened action label, compact /config layout) plus a validate-tui expectation rewrite; not behavior-preserving, needs its own reviewed PR
- 111 — verifier gated it on an unresolved maintainer decision to delete the whole CLI ExternalInquiry surface (~-1050 LoC); landing first would be moot churn
- 112 — approval-modal render rewrite cannot be proven pixel-equivalent without the render suite; medium risk on a security-relevant card
- 197 — maintainer-ruling-gated per the 2026-08-21/2026-08-25 docs
- 198 — record-only finding, explicitly "No PR"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
