### PR TITLE
fix(cli): stop naming a workflow's own phase twice in its chrome

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -231,7 +231,7 @@ const SCENARIOS = [
     keys: ['\t'],
     expect: [
       "Workflow script 'live-workflow-validation'",
-      'Proofread (1/1) · 0/2 done',
+      'Proofread (1/1) · 0/2 · 2 running',
       'Running: Proofread paper A',
       'Running: Proofread paper B',
       'Proofread paper A · Running · bash',
@@ -255,7 +255,7 @@ const SCENARIOS = [
     keys: ['must not reach workflow', '\r'],
     expect: [
       "Workflow script 'live-workflow-validation'",
-      'Proofread (1/1) · 0/2 done',
+      'Proofread (1/1) · 0/2 · 2 running',
       'Esc back',
     ],
     unexpect: [

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -271,10 +271,12 @@ export function App(props: AppProps): React.JSX.Element {
   );
   // Rows Tab navigates to that are still in flight — the count the status bar
   // advertises next to the Tab binding. `sessionViews` leads with the list
-  // root, so require a parent: the root session is not a background session.
+  // root, which is never one of its own children: excluding it by identity
+  // (not by "has a parent") keeps a focused workflow stream, itself a child
+  // of main, from counting as its own active agent.
   const childRunningCount = sessionViews.filter(
     (view) =>
-      view.parentId !== undefined &&
+      view.id !== childListTarget &&
       view.slice !== undefined &&
       isActivePhase(streamPhaseFor(view.id)?.phase),
   ).length;

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -180,7 +180,7 @@ export function workflowRunStatusSummary(
   const callRows = slice.entries.flatMap((row) =>
     row.kind === 'workflowTask' ? [row] : [],
   );
-  const { done, total } = workflowCallTally(
+  const { done, total, running } = workflowCallTally(
     callRows.filter((row) => row.groupId === phase.id).map((row) => row.call),
   );
   const segments: WorkflowStatusSegment[] = [
@@ -189,8 +189,13 @@ export function workflowRunStatusSummary(
       tone: 'muted',
     },
   ];
+  // Same tally vocabulary as the dashboard heading and phase rows
+  // (`done/total · N running`): the band sits directly above them.
   if (total > 0) {
-    segments.push({ text: `${done}/${total} done`, tone: 'muted' });
+    segments.push({ text: `${done}/${total}`, tone: 'muted' });
+  }
+  if (running > 0) {
+    segments.push({ text: `${running} running`, tone: 'muted' });
   }
   const { failed } = workflowCallTally(callRows.map((row) => row.call));
   if (failed > 0) {

--- a/packages/cli/src/chat/tui/state/workflowPhase.ts
+++ b/packages/cli/src/chat/tui/state/workflowPhase.ts
@@ -27,14 +27,21 @@ function currentWorkflowPhaseLabel(
   return formatPhaseStageLabel(stage);
 }
 
-/** Nearest workflow-script ancestor's current phase, walking parent links. */
+/**
+ * Nearest workflow-script ancestor's current phase, walking parent links
+ * starting from the stream's parent. A stream's own stage is never its
+ * location context: the header prints once into scrollback and would go
+ * stale as the workflow advanced, and the status bar already has a stage
+ * slot for the displayed stream's own phase — naming it here too printed
+ * `Derive (1/2) › name … Derive (1/2)` on one row.
+ */
 export function ancestorWorkflowPhaseLabel(init: {
   readonly categoryOf: (streamId: StreamTabId) => AgentCategory | undefined;
   readonly stageOf: (streamId: StreamTabId) => StreamStage | undefined;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly streamId: StreamTabId;
 }): string | undefined {
-  let id: StreamTabId | undefined = init.streamId;
+  let id: StreamTabId | undefined = init.parentStream.get(init.streamId);
   const seen = new Set<StreamTabId>();
   while (id && !seen.has(id)) {
     seen.add(id);

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -355,12 +355,12 @@ describe('CLI child list display model', () => {
       workflowRunStatusSummary(slice, AgentCategory.Workflow)?.map(
         (segment) => segment.text,
       ),
-    ).toEqual(['Map (1/3)', '1/2 done']);
+    ).toEqual(['Map (1/3)', '1/2', '1 running']);
     expect(
       workflowRunStatusSummary(slice, AgentCategory.Workflow)?.map(
         (segment) => segment.tone,
       ),
-    ).toEqual(['muted', 'muted']);
+    ).toEqual(['muted', 'muted', 'muted']);
   });
 
   it('appends a warning failure tally when any call has failed', () => {
@@ -396,7 +396,7 @@ describe('CLI child list display model', () => {
       workflowRunStatusSummary(slice, AgentCategory.Workflow)?.map(
         (segment) => segment.text,
       ),
-    ).toEqual(['Map (1/1)', '2/2 done', '1 failed']);
+    ).toEqual(['Map (1/1)', '2/2', '1 failed']);
     expect(
       workflowRunStatusSummary(slice, AgentCategory.Workflow)?.map(
         (segment) => segment.tone,
@@ -437,7 +437,7 @@ describe('CLI child list display model', () => {
       workflowRunStatusSummary(slice, AgentCategory.Workflow)?.map(
         (segment) => segment.text,
       ),
-    ).toEqual(['Write (2/2)', '0/2 done', '1 failed']);
+    ).toEqual(['Write (2/2)', '0/2', '2 running', '1 failed']);
   });
 
   it('does not invent a phase fold for phase-less tasks', () => {
@@ -495,7 +495,7 @@ describe('CLI child list display model', () => {
       workflowRunStatusSummary(slice, AgentCategory.Workflow)?.map(
         (segment) => segment.text,
       ),
-    ).toEqual(['Map (1/2)', '0/1 done']);
+    ).toEqual(['Map (1/2)', '0/1', '1 running']);
   });
 
   it('prioritizes live workflow activity over metadata in a one-row viewport', async () => {

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
@@ -949,7 +949,7 @@ describe('CLI workflow-script child-stream transcript', () => {
     });
     expect(staticItems.items.at(0)).toMatchObject({
       identityLine:
-        'workflow script: draft-sections · Draft sections · parent: main · model: DeepSeek V4 Flash (Thinking)',
+        'workflow script: draft-sections · parent: main · model: DeepSeek V4 Flash (Thinking)',
       kind: 'header',
     });
 


### PR DESCRIPTION
## What

A focused workflow-script stream named its current phase five times on one screen (header, `◆` divider, band, and twice in the status bar) and reported `3 agents 4 active`. This PR fixes the copy that was wrong; the divider and band are legitimate and stay.

- **Status bar phase twice** — `ancestorWorkflowPhaseLabel` began its walk at the stream itself, so a workflow stream's location context was its own stage, which the stage slot then printed again. The walk now starts at the parent (`packages/cli/src/chat/tui/state/workflowPhase.ts`). The same change fixes the **session header**: it printed the workflow's *current* phase once into scrollback, where it went stale as the run advanced. Task (grandchild) streams keep their phase in both places — their phase does not change.
- **`N agents N+1 active`** — `childRunningCount` excluded the list root by "has a parent", which a focused workflow stream does, so it counted itself. Now excluded by identity (`App.tsx`).
- **Band vocabulary** — the live band said `0/3 done` directly above the dashboard heading that #11565 changed to `0/3 · 3 running`. The band now uses the same tally (`ConversationPane.tsx`).

Left alone on purpose: the `● Workflow script '…' Running` stage row. Every child stream opens a session stage (`childRunLoop.ts:868`, "Codex session" for native subagents) and the workflow's phase stages nest under it (`workflowScriptRun.ts:189`) — structural, not copy.

## Context

First slice of the workflow-dashboard redesign (phase-tab popup, option D on the design board). Independent of the popup; the `workflow.plan` preview fact and the concurrency single-owner fix follow in their own PRs.

## Verified

- `npm run typecheck` — clean
- `vitest run src/test-kernel/cli` — 143 files, 2458 passed; the two expectation changes are the intended behaviour (`SubagentListDisplay.vitest.ts` band text, `WorkflowScriptStreamTranscript.vitest.ts` workflow header without its own phase). The grandchild-header case in `ConversationTranscript.vitest.ts` (`subagent: … · Survey (1/1) · parent: survey`) passes unchanged.
- eslint + prettier on the changed files — clean
- No new exports, no new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QESykrKh1yzvF2bB4pjDrS
