### PR TITLE
feat(workflow): record the declared plan so the dashboard can show unopened phases

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -303,12 +303,23 @@ export function App(props: AppProps): React.JSX.Element {
   // The only derivation: `SubagentList` renders this instance and
   // `ConversationRegion` budgets its rows from it, so rows cannot be grouped,
   // ordered, or deduplicated twice and drift the keyboard off the screen.
+  // A plan-only phase a finished run never reached is nothing to list; only
+  // a known, no-longer-active phase counts as settled (an unknown phase is a
+  // stream still being created, not a finished run).
+  const workflowRootPhase =
+    workflowDashboardRoot === undefined
+      ? undefined
+      : streamPhaseFor(workflowDashboardRoot.streamId)?.phase;
+  const workflowRunSettled =
+    workflowRootPhase !== undefined && !isActivePhase(workflowRootPhase);
   const workflowDashboard = useMemo(
     () =>
       workflowDashboardRoot
-        ? workflowDashboardModel(workflowDashboardRoot, columns)
+        ? workflowDashboardModel(workflowDashboardRoot, columns, {
+            runSettled: workflowRunSettled,
+          })
         : undefined,
-    [columns, workflowDashboardRoot],
+    [columns, workflowDashboardRoot, workflowRunSettled],
   );
   // Stream-less approvals fold onto the root of the visible surface: the
   // scoped child-list root while one replaces the session list, else the

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -10,6 +10,7 @@ import { COLOR_HINT, COLOR_WARNING } from '@cli/tui/ui/colors';
 import {
   POINTER,
   STATUS_DIAMOND,
+  STATUS_DIAMOND_OUTLINE,
   TICK,
   TOKENS_GENERATED,
 } from '@cli/tui/ui/glyphs';
@@ -17,6 +18,7 @@ import { useLiveNowMsSince } from '@cli/tui/useLiveNowMs';
 import { truncateSummaryToWidth } from '@cli/runtime/terminalText';
 import {
   WORKFLOW_TASK_STATUS_LABEL,
+  type WorkflowCallIdentity,
   isTerminalWorkflowCallProgress,
   runIdentityDisplayName,
   type StreamTabId,
@@ -163,6 +165,16 @@ function PhaseHeader({
 }): React.JSX.Element {
   const calls = group.tasks.map((entry) => entry.call);
   const strip = showStatusStrip ? workflowPhaseStatusStrip(calls) : undefined;
+  const declared = group.declaredTasks.length;
+  // An opened phase tallies its calls and, while the plan still holds tasks
+  // it has not issued, how many; a phase known only from the plan has no
+  // calls to tally, so its declared count is the whole story.
+  const declaredText = declared > 0 ? `${declared} declared` : undefined;
+  const tally = group.opened
+    ? [workflowPhaseTallyText(calls), declaredText]
+        .filter(filterNotNullish)
+        .join(' · ')
+    : (declaredText ?? 'declared');
   return (
     <Box
       flexDirection="row"
@@ -179,7 +191,9 @@ function PhaseHeader({
           {focused ? POINTER : ' '}
         </Text>
         <Text aria-hidden dimColor>
-          {dashboardMarkerCell(STATUS_DIAMOND)}
+          {dashboardMarkerCell(
+            group.opened ? STATUS_DIAMOND : STATUS_DIAMOND_OUTLINE,
+          )}
         </Text>
       </Box>
       <Box minWidth={0} flexShrink={1}>
@@ -189,7 +203,7 @@ function PhaseHeader({
       </Box>
       <Box minWidth={0} flexShrink={2}>
         <Text dimColor wrap="truncate-end">
-          {` · ${workflowPhaseTallyText(calls)}`}
+          {` · ${tally}`}
         </Text>
       </Box>
       {strip ? (
@@ -386,6 +400,32 @@ function WorkflowTaskRow({
   );
 }
 
+/** A plan task the run has not issued yet: label and status, nothing to
+ *  focus, kill, or retry. */
+function DeclaredTaskRow({
+  task,
+}: {
+  readonly task: WorkflowCallIdentity;
+}): React.JSX.Element {
+  const style = WORKFLOW_TASK_STATUS_STYLE.declared;
+  return (
+    <Box flexDirection="row" height={1} minWidth={0} overflowY="hidden">
+      <Box flexShrink={0}>
+        <Text aria-hidden> </Text>
+        <Text aria-hidden color={style.color}>
+          {dashboardMarkerCell(style.marker)}
+        </Text>
+      </Box>
+      <RowSegment dimColor flexShrink={1}>
+        {task.label}
+      </RowSegment>
+      <RowSegment dimColor flexShrink={1}>
+        {` · ${WORKFLOW_TASK_STATUS_LABEL.declared}`}
+      </RowSegment>
+    </Box>
+  );
+}
+
 function WorkflowDashboard({
   columns,
   keyboardActive,
@@ -423,12 +463,26 @@ function WorkflowDashboard({
     label: group.heading.phaseLabel,
     value: group.value,
   }));
-  const taskItems: SelectItem<ChildListValue>[] = (
-    activeGroup?.tasks ?? []
-  ).map((entry) => ({
-    label: entry.call.label,
-    value: workflowTaskListValue(entry.id),
-  }));
+  // Declared rows sit under the phase's cards, disabled: they own no stream
+  // to focus and no call to control, and they leave the list the moment the
+  // run issues them (their card then takes the row).
+  const declaredTaskByValue = new Map<ChildListValue, WorkflowCallIdentity>(
+    (activeGroup?.declaredTasks ?? []).map((task) => [
+      workflowTaskListValue(`declared-${task.id}`),
+      task,
+    ]),
+  );
+  const taskItems: SelectItem<ChildListValue>[] = [
+    ...(activeGroup?.tasks ?? []).map((entry) => ({
+      label: entry.call.label,
+      value: workflowTaskListValue(entry.id),
+    })),
+    ...[...declaredTaskByValue].map(([value, task]) => ({
+      label: task.label,
+      value,
+      disabled: true,
+    })),
+  ];
   const narrowItems: SelectItem<ChildListValue>[] = groups.flatMap((group) => [
     {
       label: group.heading.phaseLabel,
@@ -496,7 +550,10 @@ function WorkflowDashboard({
     state: { readonly focused: boolean },
   ): React.JSX.Element | null => {
     const entry = taskByValue.get(item.value);
-    if (!entry) return null;
+    if (!entry) {
+      const declared = declaredTaskByValue.get(item.value);
+      return declared ? <DeclaredTaskRow task={declared} /> : null;
+    }
     const childStreamId = uniqueChildId(entry);
     return (
       <WorkflowTaskRow

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -463,25 +463,32 @@ function WorkflowDashboard({
     label: group.heading.phaseLabel,
     value: group.value,
   }));
-  // Declared rows sit under the phase's cards, disabled: they own no stream
+  // Declared rows sit under their phase's cards, disabled: they own no stream
   // to focus and no call to control, and they leave the list the moment the
   // run issues them (their card then takes the row).
+  const declaredTaskValue = (task: WorkflowCallIdentity): ChildListValue =>
+    workflowTaskListValue(`declared-${task.id}`);
   const declaredTaskByValue = new Map<ChildListValue, WorkflowCallIdentity>(
-    (activeGroup?.declaredTasks ?? []).map((task) => [
-      workflowTaskListValue(`declared-${task.id}`),
-      task,
-    ]),
+    groups.flatMap((group) =>
+      group.declaredTasks.map(
+        (task) => [declaredTaskValue(task), task] as const,
+      ),
+    ),
   );
+  const declaredItems = (
+    group: WorkflowPhaseGroup | undefined,
+  ): SelectItem<ChildListValue>[] =>
+    (group?.declaredTasks ?? []).map((task) => ({
+      label: task.label,
+      value: declaredTaskValue(task),
+      disabled: true,
+    }));
   const taskItems: SelectItem<ChildListValue>[] = [
     ...(activeGroup?.tasks ?? []).map((entry) => ({
       label: entry.call.label,
       value: workflowTaskListValue(entry.id),
     })),
-    ...[...declaredTaskByValue].map(([value, task]) => ({
-      label: task.label,
-      value,
-      disabled: true,
-    })),
+    ...declaredItems(activeGroup),
   ];
   const narrowItems: SelectItem<ChildListValue>[] = groups.flatMap((group) => [
     {
@@ -493,6 +500,7 @@ function WorkflowDashboard({
       label: entry.call.label,
       value: workflowTaskListValue(entry.id),
     })),
+    ...declaredItems(group),
   ]);
   const calls = tasks.map((entry) => entry.call);
   const { done, total, running, failed } = workflowCallTally(calls);

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -14,6 +14,7 @@ import type {
   StreamLogEntry,
   StreamTabId,
   TaskGroup,
+  WorkflowPlanMarker,
 } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas';
 import type { TranscriptRow } from '@shared/transcript';
@@ -71,6 +72,13 @@ interface TaskGroupProjectionState {
   snapshot: readonly TaskGroup[];
 }
 
+/** Incremental declared-plan memo: the newest `workflowPlan` marker in
+ *  transcript order, kept the same way as the task-group memo. */
+interface WorkflowPlanProjectionState {
+  readonly applied: Map<string, StreamLogEntry>;
+  snapshot: WorkflowPlanMarker | undefined;
+}
+
 /** Incremental compaction-activity projection state, cursored on the source
  *  log (`appliedHead`), so it too survives fold rebuilds. */
 interface CompactionProjectionState {
@@ -109,6 +117,7 @@ export interface TranscriptFoldState {
    *  residency is released, and die with the slice like everything here. */
   taskGroupProjection?: TaskGroupProjectionState;
   compactionProjection?: CompactionProjectionState;
+  workflowPlanProjection?: WorkflowPlanProjectionState;
   /** Whether the last emitted `entries` was the full transcript or compact;
    *  undefined until the first emission. */
   lastOutputFull?: boolean;
@@ -153,6 +162,10 @@ export interface StreamSlice {
   readonly streamId: StreamTabId;
   /** Run/round/phase lifecycle projected from the canonical StreamLog. */
   readonly taskGroups: readonly TaskGroup[];
+  /** The newest attempt's declared phases and tasks, from the transcript's
+   *  `workflowPlan` marker; undefined until a workflow-script run records
+   *  one. What the dashboard lists that the run has not reached yet. */
+  readonly workflowPlan: WorkflowPlanMarker | undefined;
   /** CLI-only live status: the newest meaningful transcript line for this
    *  stream, recomputed on every log sync. Fills the stream-list summary slot
    *  until the runtime supplies a `description`. */
@@ -193,6 +206,7 @@ export function emptySlice(streamId: StreamTabId): StreamSlice {
     streamId,
     latestLine: undefined,
     taskGroups: [],
+    workflowPlan: undefined,
     thinkingActive: false,
     compactingActive: false,
     entries: [],

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -350,7 +350,7 @@ export function syncStreamLog(
       });
     }
 
-    const { taskGroups, compaction } = projections;
+    const { taskGroups, workflowPlan, compaction } = projections;
     const compactingActive = compaction.blocks.some(
       (block) => block.status === 'running',
     );
@@ -413,7 +413,8 @@ export function syncStreamLog(
       slice.latestLine === latestLine &&
       slice.thinkingActive === thinkingActive &&
       slice.compactingActive === compactingActive &&
-      slice.taskGroups === taskGroups
+      slice.taskGroups === taskGroups &&
+      slice.workflowPlan === workflowPlan
     ) {
       return slice;
     }
@@ -426,6 +427,7 @@ export function syncStreamLog(
       thinkingActive,
       compactingActive,
       taskGroups,
+      workflowPlan,
     };
   });
 
@@ -472,5 +474,6 @@ export function releaseInactiveStreamTranscript(
     resetTranscriptFoldState(fold);
     fold.taskGroupProjection = undefined;
     fold.compactionProjection = undefined;
+    fold.workflowPlanProjection = undefined;
   }
 }

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -14,15 +14,18 @@
  */
 
 import { safeTerminalText } from '@cli/runtime/terminalText';
+import { createLog } from '@logger/logUtils';
 import { redactSecrets } from '@logger/redaction';
 import { projectWorkflowCallEntry } from '@model/projectWorkflowCallEntry';
 import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
+  WorkflowPlanMarkerSchema,
   isPlainAgentIdentity,
   type RunIdentity,
   type StreamLogEntry,
   type TaskGroup,
+  type WorkflowPlanMarker,
 } from '@shared/schemas';
 import {
   compactionActivityRow,
@@ -47,6 +50,8 @@ import {
   transcriptRowHeadline,
 } from '../panes/transcriptEntries';
 import type { TranscriptFoldItem, TranscriptFoldState } from './cliState';
+
+const log = createLog('transcriptFold');
 
 // Canonical dashboard rows retained when a workflow stream is compacted.
 // Compaction activity passes through like a local row: a run that compacted
@@ -199,6 +204,52 @@ function projectTaskGroupsIncrementally(
   // Fresh array only on change: the slice-unchanged check below compares the
   // snapshot by reference, replacing the former per-tick deep-equality walk.
   if (changed) state.snapshot = [...state.working];
+  return state.snapshot;
+}
+
+function isWorkflowPlanMarkerCandidate(data: unknown): boolean {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as { readonly kind?: unknown }).kind === 'workflowPlan'
+  );
+}
+
+/**
+ * The newest `workflowPlan` marker in transcript order. A relaunch under the
+ * same meta.name appends its own marker after the attempt it supersedes, so
+ * the last one applied is the live attempt's plan — the same "newest attempt"
+ * rule `workflowDashboardModel` applies to the cards.
+ */
+function projectWorkflowPlanIncrementally(
+  fold: TranscriptFoldState,
+  entries: readonly StreamLogEntry[],
+): WorkflowPlanMarker | undefined {
+  let state = fold.workflowPlanProjection;
+  if (!state) {
+    state = { applied: new Map(), snapshot: undefined };
+    fold.workflowPlanProjection = state;
+  }
+  for (const entry of entries) {
+    if (
+      entry.type !== STREAM_LOG_ENTRY_TYPES.LOG ||
+      entry.messageType !== MESSAGE_TYPES.INTERNAL ||
+      !isWorkflowPlanMarkerCandidate(entry.data)
+    ) {
+      continue;
+    }
+    if (state.applied.get(entry.id) === entry) continue;
+    state.applied.set(entry.id, entry);
+    const parsed = WorkflowPlanMarkerSchema.safeParse(entry.data);
+    if (!parsed.success) {
+      // A malformed marker hides the plan, never the run — but say so.
+      log.warn(
+        `Ignoring malformed workflow plan marker ${entry.id}: ${parsed.error.message}`,
+      );
+      continue;
+    }
+    state.snapshot = parsed.data;
+  }
   return state.snapshot;
 }
 
@@ -637,10 +688,12 @@ export function applyStreamChanges(
   ctx: FoldContext,
 ): {
   taskGroups: readonly TaskGroup[];
+  workflowPlan: WorkflowPlanMarker | undefined;
   compaction: CompactionActivityProjection;
 } {
   const changed = mergeChangedBySeqNo(dirtied, appended);
   const taskGroups = projectTaskGroupsIncrementally(state, changed);
+  const workflowPlan = projectWorkflowPlanIncrementally(state, changed);
   const compaction = projectCompactionIncrementally(
     state,
     ctx.log,
@@ -660,7 +713,7 @@ export function applyStreamChanges(
   // Promote only after the merged order is final: "is there a later entry"
   // and `<Static>` append order are both defined on the final stream order.
   advanceSettledPrefix(state, ctx.streamFinal);
-  return { taskGroups, compaction };
+  return { taskGroups, workflowPlan, compaction };
 }
 
 /** The bounded dashboard + local-row selection for an unfocused workflow

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -51,7 +51,7 @@ import {
 } from '../panes/transcriptEntries';
 import type { TranscriptFoldItem, TranscriptFoldState } from './cliState';
 
-const log = createLog('transcriptFold');
+const logger = createLog('transcriptFold');
 
 // Canonical dashboard rows retained when a workflow stream is compacted.
 // Compaction activity passes through like a local row: a run that compacted
@@ -242,10 +242,12 @@ function projectWorkflowPlanIncrementally(
     state.applied.set(entry.id, entry);
     const parsed = WorkflowPlanMarkerSchema.safeParse(entry.data);
     if (!parsed.success) {
-      // A malformed marker hides the plan, never the run — but say so.
-      log.warn(
+      // The newest marker is the live attempt's plan; when it is unreadable
+      // the plan is unknown, not the previous attempt's. Hide it and say so.
+      logger.warn(
         `Ignoring malformed workflow plan marker ${entry.id}: ${parsed.error.message}`,
       );
+      state.snapshot = undefined;
       continue;
     }
     state.snapshot = parsed.data;

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -207,12 +207,10 @@ function projectTaskGroupsIncrementally(
   return state.snapshot;
 }
 
-function isWorkflowPlanMarkerCandidate(data: unknown): boolean {
-  return (
-    typeof data === 'object' &&
-    data !== null &&
-    (data as { readonly kind?: unknown }).kind === 'workflowPlan'
-  );
+function internalMarkerKind(data: unknown): unknown {
+  return typeof data === 'object' && data !== null
+    ? (data as { readonly kind?: unknown }).kind
+    : undefined;
 }
 
 /**
@@ -233,13 +231,23 @@ function projectWorkflowPlanIncrementally(
   for (const entry of entries) {
     if (
       entry.type !== STREAM_LOG_ENTRY_TYPES.LOG ||
-      entry.messageType !== MESSAGE_TYPES.INTERNAL ||
-      !isWorkflowPlanMarkerCandidate(entry.data)
+      entry.messageType !== MESSAGE_TYPES.INTERNAL
     ) {
+      continue;
+    }
+    const markerKind = internalMarkerKind(entry.data);
+    if (markerKind !== 'workflowPlan' && markerKind !== 'workflowAttempt') {
       continue;
     }
     if (state.applied.get(entry.id) === entry) continue;
     state.applied.set(entry.id, entry);
+    if (markerKind === 'workflowAttempt') {
+      // A new attempt starts with no plan of its own until it records one;
+      // an attempt that fails before then must not inherit its
+      // predecessor's.
+      state.snapshot = undefined;
+      continue;
+    }
     const parsed = WorkflowPlanMarkerSchema.safeParse(entry.data);
     if (!parsed.success) {
       // The newest marker is the live attempt's plan; when it is unreadable

--- a/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
+++ b/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
@@ -8,7 +8,11 @@
 // re-sorts, or re-dedupes on its own.
 
 // Local imports - shared stream identity
-import type { StreamTabId } from '@shared/schemas';
+import type {
+  StreamTabId,
+  WorkflowCallIdentity,
+  WorkflowPlanMarker,
+} from '@shared/schemas';
 import type { TranscriptRowOf } from '@shared/transcript';
 import {
   latestWorkflowAttemptEntries,
@@ -31,9 +35,16 @@ export type WorkflowTaskEntry = TranscriptRowOf<'workflowTask'>;
 
 export interface WorkflowPhaseGroup {
   readonly value: ChildListValue;
-  /** The phase's own heading facts, as its `TaskGroup` states them. */
+  /** The phase's own heading facts, as its `TaskGroup` states them — or as
+   *  the declared plan states them for a phase the run has not opened. */
   readonly heading: WorkflowPhaseHeading;
   readonly tasks: readonly WorkflowTaskEntry[];
+  /** True once the run has opened this phase (it has a `TaskGroup`); false
+   *  for a phase known only from the declared plan. */
+  readonly opened: boolean;
+  /** Declared plan tasks in this phase the run has not issued as calls yet —
+   *  every plan task without a card. Empty for a dynamic script. */
+  readonly declaredTasks: readonly WorkflowCallIdentity[];
 }
 
 /** A task's child stream, or `null` when several tasks claim the same stream.
@@ -74,6 +85,55 @@ interface MutableWorkflowPhaseGroup {
   readonly value: ChildListValue;
   readonly heading: WorkflowPhaseHeading;
   readonly tasks: WorkflowTaskEntry[];
+  readonly opened: boolean;
+  declaredTasks: readonly WorkflowCallIdentity[];
+}
+
+/**
+ * Fill the run's opened phases in with its declared plan: a plan phase with no
+ * task group yet becomes a declared group in plan order, a plan task with no
+ * card lands under its phase as a declared task, and opened phases the plan
+ * never named (dynamic `phase()` calls) keep their run order after it. A card
+ * always wins over its plan entry, so nothing is listed twice.
+ */
+function unionWithDeclaredPlan(
+  opened: readonly MutableWorkflowPhaseGroup[],
+  plan: WorkflowPlanMarker,
+  cards: readonly WorkflowTaskEntry[],
+): readonly MutableWorkflowPhaseGroup[] {
+  const cardIds = new Set(cards.map((entry) => entry.call.id));
+  const declaredByPhase = new Map<string, WorkflowCallIdentity[]>();
+  for (const task of plan.tasks) {
+    if (task.phase === undefined || cardIds.has(task.id)) continue;
+    const list = declaredByPhase.get(task.phase) ?? [];
+    list.push(task);
+    declaredByPhase.set(task.phase, list);
+  }
+  const byTitle = new Map(
+    opened.map((group) => [group.heading.phaseLabel, group] as const),
+  );
+  const ordered: MutableWorkflowPhaseGroup[] = [];
+  const placed = new Set<MutableWorkflowPhaseGroup>();
+  for (const phase of plan.phases) {
+    const group: MutableWorkflowPhaseGroup = byTitle.get(phase.title) ?? {
+      value: workflowPhaseListValue(`declared-${phase.title}`),
+      heading: {
+        phaseLabel: phase.title,
+        phaseIndex: phase.index,
+        phaseTotal: plan.phases.length,
+      },
+      tasks: [],
+      opened: false,
+      declaredTasks: [],
+    };
+    group.declaredTasks = declaredByPhase.get(phase.title) ?? [];
+    ordered.push(group);
+    placed.add(group);
+  }
+  for (const group of opened) {
+    if (!placed.has(group)) ordered.push(group);
+  }
+  return ordered;
 }
 
 /** Derive the dashboard rows for one workflow root at one terminal width.
@@ -95,6 +155,8 @@ export function workflowDashboardModel(
       value: workflowPhaseListValue(group.id),
       heading: workflowPhaseHeadingOfGroup(group),
       tasks: [],
+      opened: true,
+      declaredTasks: [],
     };
     groups.push(phaseGroup);
     byGroupId.set(group.id, phaseGroup);
@@ -139,12 +201,19 @@ export function workflowDashboardModel(
       value: workflowPhaseListValue(entry.id),
       heading: { phaseLabel: 'Unphased' },
       tasks: [],
+      opened: true,
+      declaredTasks: [],
     };
     ungrouped.tasks.push(entry);
   }
-  const survivingGroups = groups.filter(
+  const openedGroups = groups.filter(
     (group) => group.tasks.length > 0 || !groupsWithStaleTasks.has(group),
   );
+  const survivingGroups = [
+    ...(root.workflowPlan
+      ? unionWithDeclaredPlan(openedGroups, root.workflowPlan, tasks)
+      : openedGroups),
+  ];
   if (ungrouped) survivingGroups.push(ungrouped);
 
   const childTaskIndex = new Map<StreamTabId, WorkflowTaskEntry | null>();
@@ -197,7 +266,9 @@ export function workflowDashboardPanelItemCount(
     return 1 + model.groups.length + model.tasks.length;
   }
   const { activeGroup } = workflowDashboardSelection(model, selectedValue);
-  return 1 + Math.max(model.groups.length, activeGroup?.tasks.length ?? 0);
+  const taskColumnRows =
+    (activeGroup?.tasks.length ?? 0) + (activeGroup?.declaredTasks.length ?? 0);
+  return 1 + Math.max(model.groups.length, taskColumnRows);
 }
 
 interface WorkflowDashboardSelection {

--- a/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
+++ b/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
@@ -104,8 +104,13 @@ function unionWithDeclaredPlan(
 ): readonly MutableWorkflowPhaseGroup[] {
   const cardIds = new Set(cards.map((entry) => entry.call.id));
   const declaredByPhase = new Map<string, WorkflowCallIdentity[]>();
+  const unphasedDeclared: WorkflowCallIdentity[] = [];
   for (const task of plan.tasks) {
-    if (task.phase === undefined || cardIds.has(task.id)) continue;
+    if (cardIds.has(task.id)) continue;
+    if (task.phase === undefined) {
+      unphasedDeclared.push(task);
+      continue;
+    }
     const list = declaredByPhase.get(task.phase) ?? [];
     list.push(task);
     declaredByPhase.set(task.phase, list);
@@ -142,6 +147,17 @@ function unionWithDeclaredPlan(
   }
   for (const group of opened) {
     if (!placed.has(group)) ordered.push(group);
+  }
+  // Plan tasks declared outside any phase sit under the same trailing
+  // "Unphased" heading their cards will use once issued.
+  if (unphasedDeclared.length > 0) {
+    ordered.push({
+      value: workflowPhaseListValue('declared-unphased'),
+      heading: { phaseLabel: 'Unphased' },
+      tasks: [],
+      opened: false,
+      declaredTasks: unphasedDeclared,
+    });
   }
   return ordered;
 }

--- a/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
+++ b/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
@@ -100,6 +100,7 @@ function unionWithDeclaredPlan(
   opened: readonly MutableWorkflowPhaseGroup[],
   plan: WorkflowPlanMarker,
   cards: readonly WorkflowTaskEntry[],
+  runSettled: boolean,
 ): readonly MutableWorkflowPhaseGroup[] {
   const cardIds = new Set(cards.map((entry) => entry.call.id));
   const declaredByPhase = new Map<string, WorkflowCallIdentity[]>();
@@ -115,18 +116,27 @@ function unionWithDeclaredPlan(
   const ordered: MutableWorkflowPhaseGroup[] = [];
   const placed = new Set<MutableWorkflowPhaseGroup>();
   for (const phase of plan.phases) {
-    const group: MutableWorkflowPhaseGroup = byTitle.get(phase.title) ?? {
-      value: workflowPhaseListValue(`declared-${phase.title}`),
-      heading: {
-        phaseLabel: phase.title,
-        phaseIndex: phase.index,
-        phaseTotal: plan.phases.length,
-      },
-      tasks: [],
-      opened: false,
-      declaredTasks: [],
-    };
-    group.declaredTasks = declaredByPhase.get(phase.title) ?? [];
+    const declaredTasks = declaredByPhase.get(phase.title) ?? [];
+    let group = byTitle.get(phase.title);
+    if (!group) {
+      // A settled run never opens a phase it did not reach, and its settle
+      // sweep has already housed every declared card under a stage — so an
+      // empty plan-only phase after settlement is the bridge's own
+      // skipped-empty-phase suppression, and stays gone.
+      if (runSettled && declaredTasks.length === 0) continue;
+      group = {
+        value: workflowPhaseListValue(`declared-${phase.title}`),
+        heading: {
+          phaseLabel: phase.title,
+          phaseIndex: phase.index,
+          phaseTotal: plan.phases.length,
+        },
+        tasks: [],
+        opened: false,
+        declaredTasks: [],
+      };
+    }
+    group.declaredTasks = declaredTasks;
     ordered.push(group);
     placed.add(group);
   }
@@ -146,6 +156,11 @@ function unionWithDeclaredPlan(
 export function workflowDashboardModel(
   root: StreamSlice,
   columns: number,
+  options: {
+    /** True once the workflow run has ended: plan-only phases it never
+     *  reached are then nothing to show. */
+    readonly runSettled?: boolean;
+  } = {},
 ): WorkflowDashboardModel {
   const groups: MutableWorkflowPhaseGroup[] = [];
   const byGroupId = new Map<string, MutableWorkflowPhaseGroup>();
@@ -211,7 +226,12 @@ export function workflowDashboardModel(
   );
   const survivingGroups = [
     ...(root.workflowPlan
-      ? unionWithDeclaredPlan(openedGroups, root.workflowPlan, tasks)
+      ? unionWithDeclaredPlan(
+          openedGroups,
+          root.workflowPlan,
+          tasks,
+          options.runSettled === true,
+        )
       : openedGroups),
   ];
   if (ungrouped) survivingGroups.push(ungrouped);
@@ -263,7 +283,13 @@ export function workflowDashboardPanelItemCount(
     return rootHasApproval ? 1 : 0;
   }
   if (!model.wide) {
-    return 1 + model.groups.length + model.tasks.length;
+    // Declared rows sit under their phase in the narrow list too.
+    return (
+      1 +
+      model.groups.length +
+      model.tasks.length +
+      model.groups.reduce((sum, group) => sum + group.declaredTasks.length, 0)
+    );
   }
   const { activeGroup } = workflowDashboardSelection(model, selectedValue);
   const taskColumnRows =

--- a/packages/cli/src/tui/ui/glyphs.ts
+++ b/packages/cli/src/tui/ui/glyphs.ts
@@ -19,6 +19,9 @@ export const STATUS_DOT = '●';
 
 /** Decorative brand marker at the head of the status bar (aria-hidden). */
 export const STATUS_DIAMOND = '◆';
+/** A phase the run has declared but not opened — the hollow twin of
+ *  STATUS_DIAMOND, so the two read apart without colour. */
+export const STATUS_DIAMOND_OUTLINE = '◇';
 
 /** Warning marker for inline failure notices (e.g. render-error fallback). */
 export const WARNING = '⚠';

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -32,6 +32,7 @@ import type {
   UpdateStreamUsagePayload,
   UpdateTodosPayload,
   WorkflowCallProgress,
+  WorkflowPlanMarker,
 } from '@shared/schemas';
 import type { StreamTransitionCause } from '@shared/streams/streamStatus';
 
@@ -150,6 +151,15 @@ interface WorkflowCallEvent extends StageStamp {
 interface WorkflowAttemptEvent extends StageStamp {
   readonly type: 'workflow.attempt';
   readonly attemptId: string;
+}
+
+/** The attempt's declared phases and tasks, emitted once before any of them
+ *  opens — see `WorkflowPlanMarker`. */
+interface WorkflowPlanEvent extends StageStamp {
+  readonly type: 'workflow.plan';
+  readonly attemptId: string;
+  readonly phases: WorkflowPlanMarker['phases'];
+  readonly tasks: WorkflowPlanMarker['tasks'];
 }
 
 /** Exact raw skill catalog accepted for this run's initial prompt. */
@@ -378,6 +388,7 @@ export type AgentEvent =
   | ToolStartEvent
   | ToolEndEvent
   | WorkflowAttemptEvent
+  | WorkflowPlanEvent
   | WorkflowCallEvent
   | ActiveSkillsEvent
   | UsageEvent

--- a/src/shared/schemas/workflowCallProgress.ts
+++ b/src/shared/schemas/workflowCallProgress.ts
@@ -44,7 +44,7 @@ export const WorkflowPlanMarkerSchema = z.strictObject({
   kind: z.literal('workflowPlan'),
   attemptId: z.string().min(1),
   phases: z.array(
-    z.strictObject({ title: z.string().min(1), index: z.int().min(0) }),
+    z.strictObject({ title: z.string().min(1), index: z.int().nonnegative() }),
   ),
   tasks: z.array(WorkflowCallIdentitySchema),
 });

--- a/src/shared/schemas/workflowCallProgress.ts
+++ b/src/shared/schemas/workflowCallProgress.ts
@@ -32,6 +32,24 @@ export type WorkflowAttemptMarker = {
   readonly attemptId: string;
 };
 
+/**
+ * The declared plan of one workflow-script attempt — every `meta.phases`
+ * entry and every `meta.tasks` entry, in script order — recorded once on the
+ * transcript when the attempt's execution state is constructed. Phases and
+ * calls the run has reached are projected as stages and cards; this marker is
+ * what lets a host list the ones it has not reached yet without opening their
+ * stage (a `stage.start` prints the phase divider into scrollback).
+ */
+export const WorkflowPlanMarkerSchema = z.strictObject({
+  kind: z.literal('workflowPlan'),
+  attemptId: z.string().min(1),
+  phases: z.array(
+    z.strictObject({ title: z.string().min(1), index: z.int().min(0) }),
+  ),
+  tasks: z.array(WorkflowCallIdentitySchema),
+});
+export type WorkflowPlanMarker = z.infer<typeof WorkflowPlanMarkerSchema>;
+
 const WorkflowCallTerminalMetadataSchema = z.strictObject({
   durationMs: z.number().nonnegative().optional(),
   totalCostUsd: z.number().nonnegative().optional(),

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -127,6 +127,50 @@ describe('workflow-script progress bridge', () => {
     ).toBe(false);
   });
 
+  it('records the declared plan once, before any phase opens', async () => {
+    const { trace, events } = recordingTrace();
+    await runScript(
+      trace,
+      'plan-marker',
+      `export const meta = {
+  name: 'plan-marker-test',
+  description: 'records the declared plan',
+  phases: [{ title: 'Research' }, { title: 'Write' }],
+  tasks: [
+    { id: 'inspect', label: 'Inspect source', phase: 'Research' },
+    { id: 'draft', label: 'Draft the section', phase: 'Write' },
+  ],
+}
+phase('Research')
+return await agent('Inspect', { id: 'inspect' })`,
+    );
+
+    const plans = events.filter((event) => event.type === 'workflow.plan');
+    expect(plans).toHaveLength(1);
+    expect(plans[0]).toMatchObject({
+      attemptId:
+        events[0]?.type === 'workflow.attempt' ? events[0].attemptId : '',
+      phases: [
+        { title: 'Research', index: 0 },
+        { title: 'Write', index: 1 },
+      ],
+      tasks: [
+        { id: 'inspect', label: 'Inspect source', phase: 'Research' },
+        { id: 'draft', label: 'Draft the section', phase: 'Write' },
+      ],
+    });
+    // The plan precedes the first phase stage and every card.
+    const planIndex = events.indexOf(plans[0]!);
+    const firstStage = events.findIndex(
+      (event) => event.type === 'stage.start',
+    );
+    const firstCard = events.findIndex(
+      (event) => event.type === 'workflow.call',
+    );
+    expect(planIndex).toBeLessThan(firstStage);
+    expect(planIndex).toBeLessThan(firstCard);
+  });
+
   it('keeps planned call cards in their phase stage across incremental updates', async () => {
     const { trace, events } = recordingTrace();
     const parent = trace.openStage('Parent');

--- a/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
+++ b/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
@@ -205,6 +205,49 @@ describe('workflow dashboard model', () => {
     ).toStrictEqual(model.tasks.map((entry) => `workflowTask:${entry.id}`));
   });
 
+  it('lists declared phases and tasks the run has not reached, never a card twice', () => {
+    const root: StreamSlice = {
+      ...workflowRoot(['Map'], [{ id: 'inspect', phase: 'Map' }]),
+      workflowPlan: {
+        kind: 'workflowPlan',
+        attemptId: 'attempt-1',
+        phases: [
+          { title: 'Map', index: 0 },
+          { title: 'Reduce', index: 1 },
+        ],
+        tasks: [
+          { id: 'inspect', label: 'inspect', phase: 'Map' },
+          { id: 'extract', label: 'Extract facts', phase: 'Map' },
+          { id: 'merge', label: 'Merge results', phase: 'Reduce' },
+        ],
+      },
+    };
+    const model = workflowDashboardModel(root, WIDE_COLUMNS);
+
+    expect(
+      model.groups.map((group) => [
+        group.heading.phaseLabel,
+        group.opened,
+        group.tasks.length,
+        group.declaredTasks.map((task) => task.id),
+      ]),
+    ).toEqual([
+      ['Map', true, 1, ['extract']],
+      ['Reduce', false, 0, ['merge']],
+    ]);
+    expect(model.groups[1]?.heading).toEqual({
+      phaseLabel: 'Reduce',
+      phaseIndex: 1,
+      phaseTotal: 2,
+    });
+    // The declared phase is a keyboard-reachable row; declared tasks are not.
+    expect(model.listValues).toEqual([
+      model.groups[0]?.value,
+      model.groups[1]?.value,
+      'workflowTask:task-inspect',
+    ]);
+  });
+
   it('gives an ambiguous child stream to no task at all', () => {
     const shared = 'shared-child' as StreamTabId;
     const root = workflowRoot(

--- a/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
+++ b/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
@@ -214,6 +214,7 @@ describe('workflow dashboard model', () => {
         phases: [
           { title: 'Map', index: 0 },
           { title: 'Reduce', index: 1 },
+          { title: 'Publish', index: 2 },
         ],
         tasks: [
           { id: 'inspect', label: 'inspect', phase: 'Map' },
@@ -223,27 +224,39 @@ describe('workflow dashboard model', () => {
       },
     };
     const model = workflowDashboardModel(root, WIDE_COLUMNS);
-
-    expect(
-      model.groups.map((group) => [
+    const summarize = (groups: typeof model.groups) =>
+      groups.map((group) => [
         group.heading.phaseLabel,
         group.opened,
         group.tasks.length,
         group.declaredTasks.map((task) => task.id),
-      ]),
-    ).toEqual([
+      ]);
+
+    expect(summarize(model.groups)).toEqual([
       ['Map', true, 1, ['extract']],
       ['Reduce', false, 0, ['merge']],
+      ['Publish', false, 0, []],
     ]);
     expect(model.groups[1]?.heading).toEqual({
       phaseLabel: 'Reduce',
       phaseIndex: 1,
-      phaseTotal: 2,
+      phaseTotal: 3,
     });
+    // Once the run has settled, a plan-only phase it never reached and that
+    // holds no declared task is gone; one still holding declared tasks stays.
+    expect(
+      summarize(
+        workflowDashboardModel(root, WIDE_COLUMNS, { runSettled: true }).groups,
+      ),
+    ).toEqual([
+      ['Map', true, 1, ['extract']],
+      ['Reduce', false, 0, ['merge']],
+    ]);
     // The declared phase is a keyboard-reachable row; declared tasks are not.
     expect(model.listValues).toEqual([
       model.groups[0]?.value,
       model.groups[1]?.value,
+      model.groups[2]?.value,
       'workflowTask:task-inspect',
     ]);
   });

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -443,14 +443,23 @@ export async function runPersistedWorkflowScriptWithProgress(
             title: stage.title,
             index: stage.order,
           })),
-          tasks: snapshot.calls.map((call) => {
-            const phase = stageTitleFor(snapshot, call);
-            return {
-              id: call.id,
-              label: call.label,
-              ...(phase !== undefined ? { phase } : {}),
-            };
-          }),
+          // A resumed run's reusable results (completed or cached) are
+          // history, not plan: they are never re-emitted as cards, so listing
+          // them here would show finished work as declared.
+          tasks: snapshot.calls
+            .filter(
+              (call) =>
+                call.status !== WORKFLOW_CALL_STATUS.COMPLETED &&
+                call.status !== WORKFLOW_CALL_STATUS.CACHED,
+            )
+            .map((call) => {
+              const phase = stageTitleFor(snapshot, call);
+              return {
+                id: call.id,
+                label: call.label,
+                ...(phase !== undefined ? { phase } : {}),
+              };
+            }),
         });
       }
       for (const stage of snapshot.stages) {

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -212,6 +212,7 @@ export async function runPersistedWorkflowScriptWithProgress(
     }
   >();
   let constructionEmissionSeen = false;
+  let planEmitted = false;
   let runOutcome: RunOutcome = RUN_OUTCOME.FAILED;
 
   const phaseFor = (
@@ -428,6 +429,30 @@ export async function runPersistedWorkflowScriptWithProgress(
     }
     try {
       declaredStageTotal ??= snapshot.stages.length;
+      if (!planEmitted) {
+        planEmitted = true;
+        // The plan is the snapshot's own stage and call lists, hydrated
+        // history included. Hosts union it with the stages and cards that
+        // follow, and a card always wins over its plan entry, so a resumed
+        // run's plan never doubles what its cards already say.
+        trace.emit({
+          type: 'workflow.plan',
+          attemptId: projectionId,
+          stageId: parentStageId,
+          phases: snapshot.stages.map((stage) => ({
+            title: stage.title,
+            index: stage.order,
+          })),
+          tasks: snapshot.calls.map((call) => {
+            const phase = stageTitleFor(snapshot, call);
+            return {
+              id: call.id,
+              label: call.label,
+              ...(phase !== undefined ? { phase } : {}),
+            };
+          }),
+        });
+      }
       for (const stage of snapshot.stages) {
         if (stage.lifecycle === 'waiting') continue;
         // A declared phase the run bypassed (`phase()` jumped past it, or the

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -563,11 +563,22 @@ export function attachTranscriptRecorder(
         }
 
         case 'workflow.plan': {
+          // Display strings pass through record-time redaction like every
+          // stage label and card the recorder persists; ids stay verbatim.
           const marker = {
             kind: 'workflowPlan',
             attemptId: event.attemptId,
-            phases: event.phases,
-            tasks: event.tasks,
+            phases: event.phases.map((phase) => ({
+              title: redactSecrets(phase.title),
+              index: phase.index,
+            })),
+            tasks: event.tasks.map((task) => ({
+              ...task,
+              label: redactSecrets(task.label),
+              ...(task.phase !== undefined && {
+                phase: redactSecrets(task.phase),
+              }),
+            })),
           } satisfies WorkflowPlanMarker;
           writer.appendSettled({
             id: `workflow-plan-${event.attemptId}`,

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -49,6 +49,7 @@ import {
   type MessageType,
   type ToolUseLog,
   type WorkflowAttemptMarker,
+  type WorkflowPlanMarker,
   type WorkflowCallProgress,
 } from '@shared/schemas';
 import { isTerminalOutcomePhase } from '@shared/streams/streamStatus';
@@ -550,6 +551,26 @@ export function attachTranscriptRecorder(
           } satisfies WorkflowAttemptMarker;
           writer.appendSettled({
             id: `workflow-attempt-${event.attemptId}`,
+            type: STREAM_LOG_ENTRY_TYPES.LOG,
+            level: 'info',
+            timestamp: Date.now(),
+            groupId: event.stageId,
+            messageType: MESSAGE_TYPES.INTERNAL,
+            data: marker,
+            verbose: false,
+          });
+          return;
+        }
+
+        case 'workflow.plan': {
+          const marker = {
+            kind: 'workflowPlan',
+            attemptId: event.attemptId,
+            phases: event.phases,
+            tasks: event.tasks,
+          } satisfies WorkflowPlanMarker;
+          writer.appendSettled({
+            id: `workflow-plan-${event.attemptId}`,
             type: STREAM_LOG_ENTRY_TYPES.LOG,
             level: 'info',
             timestamp: Date.now(),


### PR DESCRIPTION
## What

The CLI workflow dashboard could not show the next round: a script's `meta.phases` / `meta.tasks` reached hosts only through the approval proposal, and the progress projection opens a phase stage only when the run reaches it (`workflowScriptRun.ts` skips `waiting` stages on purpose).

This adds one run-scoped fact and unions it into the dashboard:

- **`workflow.plan` trace event** (`src/agent/trace/events.ts`), emitted once per attempt from the first execution snapshot in `runPersistedWorkflowScriptWithProgress` — every stage with its order, every call with its phase — before any stage or card. Not added to `RUN_FACT_EVENT_TYPES`: the fact rail, NDJSON output, and the progress view are untouched.
- **Transcript recorder** writes it as an `INTERNAL` `workflowPlan` marker (`WorkflowPlanMarkerSchema` beside `WorkflowAttemptMarker`), the same shape as the existing `workflowAttempt` marker. No new `messageType`; older trace viewers degrade it like any `INTERNAL` row.
- **CLI fold** (`transcriptFold.ts`) parses the marker into a new `StreamSlice.workflowPlan` (newest attempt wins, matching `latestWorkflowAttemptEntries`); a malformed marker is logged at `warn`, never swallowed.
- **`workflowDashboardModel`** unions the plan with task groups and cards: a plan phase with no group becomes a declared group in plan order; a plan task with no card becomes a `declaredTask` under its phase; a card always wins over its plan entry. `WorkflowPhaseGroup` gains `opened` and `declaredTasks`.
- **Rendering**: declared phases use a hollow `◇` (new `STATUS_DIAMOND_OUTLINE`) and tally `N declared`; opened phases append `· N declared` while the plan still holds unissued tasks; declared tasks are disabled rows in the wide task column (nothing to focus, kill, or retry).

Why not open waiting stages: the `◆` divider is projected from `stage.start` (`projectTranscriptRow.ts`), so it would print into scrollback before the phase began — on the extension too.

## Context

Slice 2 of the workflow-dashboard redesign (phase-tab popup); follows #11588. The popup itself is the next slice and consumes `declaredTasks` as-is.

## Verified

- `npm run typecheck` — clean
- vitest: `src/test-kernel/{cli,transcript,shared,progressView}`, `agent/Workflow*`, `tools/WorkflowScript*` — 256 files, 3,853 passed; `src/test-kernel/architecture` — 15 files, 101 passed
- `npm run check:dead-code-ratchet` — no new findings (every new export has a consumer)
- eslint + prettier on changed files — clean
- Two boundary tests: the bridge emits exactly one plan before the first stage and card (`WorkflowScriptProgressBridge.vitest.ts`); the model lists a declared phase and declared tasks without duplicating a card, and keeps declared tasks off the keyboard row list (`WorkflowDashboardModel.vitest.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QESykrKh1yzvF2bB4pjDrS
