### PR TITLE
feat(runtime): one owner for child-run concurrency, sized to the machine by default

### DIFF
--- a/docs/proposals/2026-08-15-child-run-concurrency-budget.md
+++ b/docs/proposals/2026-08-15-child-run-concurrency-budget.md
@@ -19,7 +19,8 @@ capacity. Explicitly _not_ budgeted:
 - **Script governance.** The workflow engine's per-run semaphore
   (`concurrency`, default 4), its lifetime call cap, and `MAX_FANOUT` shape
   what a _script_ may request; they stay where they are. The budget gates
-  what the _process_ may run at once.
+  what the _process_ may run at once. _Amended 2026-08-29: the semaphore now
+  takes its value from the budget — see the amendment at the end._
 - **Generic tool calls.** `ToolUseDispatchNode`'s `PQueue({ concurrency: 4 })`
   gates parallel-safe tool calls (`read_file`, `grep`); routing the budget
   through it would throttle file reads while leaving child lifetimes ungated
@@ -89,7 +90,8 @@ caller. Two acquisition call sites, one budget, zero double-charging.
   `workflowScriptAgentRunner` to avoid the nested deadlock, and the engine
   semaphore already bounds grandchild fan-out per run. Recorded as the
   known soft spot: the budget under-counts scripted fan-out by up to
-  `engine.concurrency − 1` per workflow child.
+  `engine.concurrency − 1` per workflow child — which, since the 2026-08-29
+  amendment, is `budget − 1`.
 
 - **WAITING releases.** A detached tool-use child that suspends WAITING
   holds no model conversation; its slot releases at the turn boundary (the
@@ -110,22 +112,45 @@ execution, and a queued launch aborts cleanly if its parent is cancelled
 - No provider-key partitioning — ever (maintainer-rejected as
   overengineering; see the scope ruling above).
 - No cap on root runs or agent-CLI children.
-- No change to engine semaphore, lifetime call cap, or fan-out caps.
+- No change to the lifetime call cap or fan-out caps. _(The engine-semaphore
+  half of this ruling was amended 2026-08-29 — see below.)_
 
 ## Landed implementation
 
 Issue #10640 lands the previously-cut user-facing setting:
 
 - Canonical key: `texra.childRunConcurrencyBudget`.
-- Default: 16; allowed range 1–100 (integer), validated by
+- Default: `0` = auto — this machine's `os.availableParallelism()` clamped
+  to 1–100, resolved host-side in `childRunBudget.ts` (amended 2026-08-29;
+  was a fixed 16). Explicit values: 1–100 (integer). Validated by
   `ChildRunConcurrencyBudgetSchema`.
 - Persistence: workspace-scoped `.texra/config.json` (the settings-view catalog
   row omits `configTarget`, so the write path uses the workspace target).
-- Surface: the native VS Code/desktop settings view Multi-Agent tab only. The
-  CLI `/config` panel does not surface it, but the CLI still recognizes and
-  honors the key because the runtime reads it.
+- Surface: the native VS Code/desktop settings view Multi-Agent tab and, since
+  2026-08-29, the CLI `/config` panel (`cliConfig`).
 - Runtime: `childRunBudgetFor` re-reads the configured value on every call and
   live re-pins the session queue to it, so the queue always tracks the
-  configured value. Absent and invalid persisted values both resolve to 16.
+  configured value. Absent and invalid persisted values both resolve to auto.
 - Provider-key partitioning remains rejected (maintainer ruling) — this
   implementation is per-session count-based only.
+
+## Amendment (2026-08-29): one owner for the number
+
+- The workflow engine's per-run semaphore no longer carries its own product
+  value: `workflowScriptStrategy` passes `resolveChildRunConcurrencyBudget()`
+  as `concurrency`, so the setting governs scripted fan-out as well as
+  detached children. `DEFAULT_CONCURRENCY = 4` in `runWorkflowScript.ts` is
+  the library fallback for callers that pass nothing (tests, SDK), not a
+  product default. Before this, a workflow's `agent()` calls ran four at a
+  time whatever the setting said, and nothing passed the budget through.
+- The default became `0` = auto: `os.availableParallelism()` clamped to
+  1–100, resolved host-side in `childRunBudget.ts` (`src/shared` stays
+  `os`-free because the settings webview loads it). Model conversations are
+  network bound, so the core count is a floor for useful parallelism, not a
+  ceiling — the setting stays overridable up to 100. The number widget keeps
+  working unchanged: `0` is a value in range and the description names its
+  meaning, the same shape as `compactionThresholdPercent`'s `0 = disable`.
+- Known soft spot, restated: grandchildren still ride the workflow child's one
+  slot, so a workflow can now run up to `budget − 1` more conversations than
+  the budget counts. Charging grandchildren needs the reentrant lease noted
+  above and remains deferred.

--- a/src/agent/runtime/childRunBudget.ts
+++ b/src/agent/runtime/childRunBudget.ts
@@ -10,6 +10,8 @@
  * budget starts as soon as a slot frees, and a queued turn cancelled before
  * its slot never starts fresh model work.
  */
+import * as os from 'node:os';
+
 import PQueue from 'p-queue';
 
 import {
@@ -23,11 +25,28 @@ import type { SessionHandle } from './SessionHandle';
 
 const budgets = new WeakMap<SessionHandle, PQueue>();
 
-function readConfiguredChildRunBudget(): number {
-  return getValidatedConfig(
+/**
+ * The configured budget with the `auto` sentinel resolved to this machine's
+ * core count, clamped to the schema range. Model conversations are network
+ * bound, so the core count is a floor for useful parallelism rather than a
+ * ceiling — which is why the setting stays overridable up to `max`. This is
+ * the one host-side owner of the number: the session queue below and the
+ * workflow engine's per-run semaphore (`workflowScriptStrategy`) both read
+ * it here. Resolved host-side because `src/shared` is loaded by the settings
+ * webview and must stay free of `node:os`.
+ */
+export function resolveChildRunConcurrencyBudget(): number {
+  const configured = getValidatedConfig(
     CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY,
     ChildRunConcurrencyBudgetSchema,
     CHILD_RUN_CONCURRENCY_BUDGET_SETTING.defaultValue,
+  );
+  if (configured !== CHILD_RUN_CONCURRENCY_BUDGET_SETTING.auto) {
+    return configured;
+  }
+  return Math.min(
+    CHILD_RUN_CONCURRENCY_BUDGET_SETTING.max,
+    Math.max(1, os.availableParallelism()),
   );
 }
 
@@ -40,7 +59,7 @@ function readConfiguredChildRunBudget(): number {
  * queued work.
  */
 export function childRunBudgetFor(session: SessionHandle): PQueue {
-  const configured = readConfiguredChildRunBudget();
+  const configured = resolveChildRunConcurrencyBudget();
   const existing = budgets.get(session);
   if (existing) {
     existing.concurrency = configured;

--- a/src/agent/workflowScript/README.md
+++ b/src/agent/workflowScript/README.md
@@ -185,7 +185,7 @@ return await parallel(
   starts a new journal.
   Otherwise-identical calls must provide distinct `id` options; ambiguous
   duplicates fail before launch.
-- **Budgets**: one concurrency semaphore (default 4) across all `agent()`
+- **Budgets**: one concurrency semaphore (the host's child-run budget; library default 4) across all `agent()`
   calls, a live-call cap (default 200; journal replays are free), a fan-out cap per
   `parallel()` call, and a wall-clock timeout. The cap and
   timeout raise `WorkflowRunAbortError`, which `parallel()` does

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -60,6 +60,9 @@ function journalKey(
   return truncatedHexId(stableStringify(source), 16);
 }
 
+// Library fallback only: the TeXRA host passes the session's child-run budget
+// (`resolveChildRunConcurrencyBudget`) as `concurrency`, so this value
+// governs no product run.
 const DEFAULT_CONCURRENCY = 4;
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_MAX_AGENT_CALLS = 200;

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -401,7 +401,8 @@ export interface WorkflowScriptRunOptions {
   ) => Promise<WorkflowCallAdmission>;
   /** Parent cancellation signal; aborts guest execution and active agents. */
   signal?: AbortSignal;
-  /** Max concurrently running agent() calls. Default 4. */
+  /** Max concurrently running agent() calls. The host passes the session's
+   *  child-run budget; 4 is the library fallback. */
   concurrency?: number;
   /** Journal from a prior run; matching keys replay regardless of call position. */
   journal?: WorkflowJournalEntry[];

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -80,7 +80,7 @@ export const CHILD_RUN_CONCURRENCY_BUDGET_SETTING = Object.freeze({
   min: 0,
   max: 100,
   description:
-    "Maximum number of live native child model conversations one session may run at once; a workflow script runs this many agent() calls concurrently. 0 (the default) sizes it to this machine's CPU count. Detached subagents beyond the budget wait for a slot to free.",
+    "Maximum number of detached child runs one session may run at once; a workflow script also runs this many agent() calls concurrently (in-band, not counted against the session budget). 0 (the default) sizes it to this machine's CPU count. Detached subagents beyond the budget wait for a slot to free.",
 } as const);
 
 export const ModelRetryMaxAttemptsSchema = z

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -72,11 +72,15 @@ export const MODEL_COMPACTION_THRESHOLD_SETTING = Object.freeze({
  * about the range.
  */
 export const CHILD_RUN_CONCURRENCY_BUDGET_SETTING = Object.freeze({
-  defaultValue: 16,
-  min: 1,
+  /** `0` sizes the budget to this machine's core count at runtime — the
+   *  same "special value inside the range" shape as the compaction
+   *  threshold's `0 = disable`, so the number widget needs no second mode. */
+  auto: 0,
+  defaultValue: 0,
+  min: 0,
   max: 100,
   description:
-    'Maximum number of live native child model conversations one session may run at once. Detached subagents beyond this wait for a slot to free.',
+    "Maximum number of live native child model conversations one session may run at once; a workflow script runs this many agent() calls concurrently. 0 (the default) sizes it to this machine's CPU count. Detached subagents beyond the budget wait for a slot to free.",
 } as const);
 
 export const ModelRetryMaxAttemptsSchema = z

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -411,8 +411,13 @@ const CORE_SETTING_ROWS: Record<
     title: 'Child-run concurrency budget',
     description: CHILD_RUN_CONCURRENCY_BUDGET_SETTING.description,
     category: 'multi-agent',
-    honoredBy: everyHost('src/agent/runtime/childRunBudget.ts'),
-    surfaces: { settingsView: 'multi-agent' },
+    honoredBy: everyHost('src/agent/runtime/childRunBudget.ts', {
+      command:
+        'texra agents run <tool-use-agent> --instruction "dispatch two subagents"',
+      through:
+        'packages/cli/src/commands/agentsRun.ts -> packages/cli/src/runtime/runExecution.ts -> src/tools/delegation/detachedChildRun.ts -> src/agent/runtime/childRunLoop.ts -> src/agent/runtime/childRunBudget.ts',
+    }),
+    surfaces: { settingsView: 'multi-agent', cliConfig: true },
   },
   'goal.enabled': {
     schema: z.boolean().prefault(true),

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -1,4 +1,6 @@
 // Test composition imports
+import * as os from 'node:os';
+
 import '@test/support/defaultSessionTestSetup';
 
 // E2E fixtures for the promoted "one loop, N strategies" child-run driver.
@@ -65,6 +67,7 @@ import {
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
 import type { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
+import { resolveChildRunConcurrencyBudget } from '@agent/runtime/childRunBudget';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { platform } from '@platform/platform';
 import {
@@ -977,6 +980,29 @@ describe('childRunLoop E2E fixtures', () => {
     expect(mocks.finalizeRun).toHaveBeenCalledWith(
       expect.objectContaining({ outcome: RUN_OUTCOME.FAILED }),
     );
+  });
+
+  it('sizes the child-run budget to the machine when the setting is auto', () => {
+    const config = platform().config as FakeConfigProvider;
+    try {
+      config.set(
+        CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY,
+        CHILD_RUN_CONCURRENCY_BUDGET_SETTING.auto,
+      );
+      expect(resolveChildRunConcurrencyBudget()).toBe(
+        Math.min(
+          CHILD_RUN_CONCURRENCY_BUDGET_SETTING.max,
+          Math.max(1, os.availableParallelism()),
+        ),
+      );
+      config.set(CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY, 7);
+      expect(resolveChildRunConcurrencyBudget()).toBe(7);
+    } finally {
+      config.set(
+        CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY,
+        CHILD_RUN_CONCURRENCY_BUDGET_SETTING.defaultValue,
+      );
+    }
   });
 
   it('gates budgeted child turns through the session child-run budget', async () => {

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -36,6 +36,7 @@ import {
   CODEX_APPROVAL_POLICY_DEFAULT,
   CODEX_REASONING_EFFORT_DEFAULT,
   CODEX_SANDBOX_MODE_DEFAULT,
+  CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY,
   MODEL_COMPACTION_THRESHOLD_SETTING,
   MODEL_RETRY_MAX_ATTEMPTS_SETTING,
   ModelCompactionThresholdPercentSchema,
@@ -446,6 +447,9 @@ describe('state settings catalog', () => {
     //    orchestrator asks to kill one of its own child executions.
     //  - compaction threshold and retry attempts are read by the shared model
     //    handler and invocation node used by headless CLI runs.
+    //  - the child-run concurrency budget is read by childRunBudget (via the
+    //    child-run loop every detached subagent and workflow script launches
+    //    through) and passed to the workflow engine's semaphore.
     // auto-open-pdf (no CLI opener), latexdiff, and the formatter are
     // intentionally excluded. Changing the CLI roster must be a deliberate edit
     // here, not an accident of flipping `honoredBy.cli` or `surfaces.cliConfig`.
@@ -483,6 +487,7 @@ describe('state settings catalog', () => {
         AGENT_SKILLS_CONFIG_KEY,
         MODEL_COMPACTION_THRESHOLD_SETTING.configKey,
         MODEL_RETRY_MAX_ATTEMPTS_SETTING.configKey,
+        CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY,
         TEXRA_APPROVAL_POLICY_CONFIG_KEY,
       ].sort(),
     );

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -26,6 +26,7 @@ import type { ExecutionKVStore } from '@agent/storage';
 import type { ChildRunStrategy } from '@agent/runtime/childRunLoop';
 import type { WorkflowControlRegistry } from '@agent/runtime/workflowControlRegistry';
 import { AgentFinalResultSchema } from '@agent/runtime/AgentFinalResult';
+import { resolveChildRunConcurrencyBudget } from '@agent/runtime/childRunBudget';
 import { createLog } from '@logger/logUtils';
 import type {
   ExecutionId,
@@ -275,6 +276,9 @@ export function createWorkflowScriptStrategy(
             files: params.files,
           }),
           signal: abortController.signal,
+          // The session's child-run budget is the one owner of "how many at
+          // once": the engine's own default is a library fallback only.
+          concurrency: resolveChildRunConcurrencyBudget(),
           runAgent,
           ...(params.admitCall && { admitCall: params.admitCall }),
           fingerprintAgentDependencies: (options) =>


### PR DESCRIPTION
## What

Concurrency had two owners: the session setting `texra.childRunConcurrencyBudget` (default 16, `childRunBudget.ts`) gated detached children, while the workflow engine kept a private `DEFAULT_CONCURRENCY = 4` for its `agent()` semaphore (`runWorkflowScript.ts:63`) and nothing in `src/tools/delegation` passed the budget through. A workflow therefore ran four calls at a time whatever the setting said — and since its grandchildren run in-band (`budgeted: false`) and never acquire the budget, that semaphore was the *only* cap on scripted fan-out.

- **One owner of the number.** `workflowScriptStrategy` passes `resolveChildRunConcurrencyBudget()` as `concurrency`. The engine keeps `?? 4` as a library fallback for callers that pass nothing (83 test call sites, SDK); making it required would buy nothing.
- **Default `0` = auto.** `os.availableParallelism()` clamped to 1–100, resolved host-side in `childRunBudget.ts` (`src/shared` is loaded by the settings webview and must stay `os`-free). `0` is a value inside the range so `renderSettingsNumberRow` works unchanged — the `compactionThresholdPercent` `0 = disable` precedent — rather than a `'auto'` literal union the number widget cannot represent (`Number('auto')` → NaN → revert).
- **Editable from the CLI** `/config` panel (`surfaces.cliConfig`), with the runtime-reachability path the catalog guard demands (`agentsRun → runExecution → detachedChildRun → childRunLoop → childRunBudget`), and registered in the verified CLI-consumed list.
- **Ruling amended, not bypassed.** `docs/proposals/2026-08-15-child-run-concurrency-budget.md` said "no change to engine semaphore"; that half is amended in place with a dated section, and the known soft spot is restated at its new magnitude (`budget − 1` instead of `engine.concurrency − 1`). Charging grandchildren needs the reentrant lease the proposal already describes and stays deferred.

Why cores at all: the user wants fan-out to follow the machine (20 on a workstation). Model calls are network bound, so the core count is a floor for useful parallelism, not a ceiling — the setting stays overridable up to 100 and the description says what `0` means.

## Context

Slice 3 of the workflow-dashboard redesign (phase-tab popup): the popup is designed for 20 running / 40 queued agents per phase, which the old hard cap of 4 made unreachable. Follows #11588 and #11590; independent of both.

## Verified

- `npm run typecheck` — clean
- vitest: `src/test-kernel/cli`, `shared`, `agent/runtime`, `agent/Workflow*`, `tools/WorkflowScript*`, `architecture` — 145 + 48 + 15 files, all passing (2,514 + 724 + 101 tests)
- `npm run check:dead-code-ratchet` — no new findings
- eslint + prettier on changed files — clean
- One regression test at the boundary (`ChildRunLoop.vitest.ts`): `0` resolves to the clamped core count, an explicit value resolves to itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QESykrKh1yzvF2bB4pjDrS
