### PR TITLE
feat(progress-view): the board paints the shared workflow run model

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -20,7 +20,10 @@ import {
   rewriteKittyEnterInput,
 } from '@cli/tui/inputKeys';
 import { type StreamTabId, type WorkflowControlAction } from '@shared/schemas';
-import { isActivePhase } from '@shared/streams/streamStatus';
+import {
+  isActivePhase,
+  workflowRunSettled,
+} from '@shared/streams/streamStatus';
 import { SESSION_LIST } from '@shared/copy/nestedRuns';
 
 // Local imports - TUI surfaces and state
@@ -321,8 +324,7 @@ export function App(props: AppProps): React.JSX.Element {
     workflowPopupStreamId === undefined
       ? undefined
       : streamPhaseFor(workflowPopupStreamId)?.phase;
-  const workflowRunSettled =
-    workflowRootPhase !== undefined && !isActivePhase(workflowRootPhase);
+  const workflowPopupRunSettled = workflowRunSettled(workflowRootPhase);
   const workflowPopupModel = useMemo(
     () =>
       workflowPopupRoot
@@ -330,10 +332,10 @@ export function App(props: AppProps): React.JSX.Element {
             taskGroups: workflowPopupRoot.taskGroups,
             rows: workflowPopupRoot.entries,
             plan: workflowPopupRoot.workflowPlan,
-            runSettled: workflowRunSettled,
+            runSettled: workflowPopupRunSettled,
           })
         : undefined,
-    [workflowPopupRoot, workflowRunSettled],
+    [workflowPopupRoot, workflowPopupRunSettled],
   );
   const workflowPopup = useSignal(workflowPopupViewSignal);
   // The popup controls its own grandchildren: their execution ids live on the

--- a/packages/cli/src/chat/tui/panes/WorkflowPopup.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkflowPopup.tsx
@@ -48,6 +48,7 @@ import {
   formatWorkflowTally,
 } from '@shared/copy/workflowCall';
 import {
+  formatWorkflowRowGroup,
   workflowPhaseRows,
   type WorkflowPhaseModel,
   type WorkflowPhaseRow,
@@ -81,12 +82,6 @@ import { ApprovalSegments, RowSegment } from './SubagentList';
 import { pendingApprovalRowDisplay } from './SubagentListDisplay';
 import { WORKFLOW_TASK_STATUS_STYLE } from './transcriptEntryLayout';
 import type { PendingApprovalKind } from '../state/approvalQueue';
-
-const GROUP_LABEL = {
-  queued: 'queued',
-  done: 'done',
-  declared: 'declared',
-} as const satisfies Record<WorkflowRowGroup, string>;
 
 /** Rows of chrome inside the panel beyond what the shared budget already
  *  counts: the tab strip and the per-call status strip. The filter line adds
@@ -260,7 +255,7 @@ function GroupRow({
         </Text>
       </Box>
       <RowSegment dimColor={!focused} flexShrink={1}>
-        {`${count} ${GROUP_LABEL[group]}`}
+        {formatWorkflowRowGroup({ count, group })}
       </RowSegment>
     </Box>
   );

--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -33,6 +33,7 @@ import type {
   StreamLifecycleStatus,
   StreamLogEntry,
   TaskGroup,
+  WorkflowPlanMarker,
 } from '@shared/schemas';
 import type { TranscriptRow } from '@shared/transcript';
 import { designTokens } from '@shared/styles';
@@ -62,6 +63,7 @@ const LogListStateSchema = z.object({
 /** Cached per-stream data and DOM state */
 interface CachedStream {
   groups: TaskGroup[];
+  workflowPlan: WorkflowPlanMarker | undefined;
   entries: StreamLogEntry[];
   rows: TranscriptRow[];
   updatedRowIndices: readonly number[];
@@ -128,6 +130,7 @@ export class LogList extends LitElement {
     if (streamId) {
       const entry = this.getOrCreateEntry(streamId);
       entry.groups = this.streamContext.taskGroups;
+      entry.workflowPlan = this.streamContext.workflowPlan;
       entry.entries = this.streamContext.entries;
       entry.rows = this.streamContext.rows;
       entry.updatedRowIndices = this.streamContext.updatedRowIndices;
@@ -163,6 +166,7 @@ export class LogList extends LitElement {
           ${ref(data.ref)}
           ?hidden=${id !== this.activeStreamId}
           .groups=${data.groups}
+          .workflowPlan=${data.workflowPlan}
           .entries=${data.entries}
           .rows=${data.rows}
           .updatedRowIndices=${data.updatedRowIndices}
@@ -232,6 +236,7 @@ export class LogList extends LitElement {
 
     const createdEntry: CachedStream = {
       groups: [],
+      workflowPlan: undefined,
       entries: [],
       rows: [],
       updatedRowIndices: [],

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -43,7 +43,10 @@ import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
-import { isInFlightPhase } from '@shared/streams/streamStatus';
+import {
+  isInFlightPhase,
+  workflowRunSettled,
+} from '@shared/streams/streamStatus';
 import {
   formatRoundStageLabel,
   formatStreamStatusLabel,
@@ -340,7 +343,7 @@ export class TaskGroupList extends LitElement {
             taskGroups: this.groups,
             rows: this.rows,
             plan: this.workflowPlan,
-            runSettled: !isInFlightPhase(this.streamStatus ?? undefined),
+            runSettled: workflowRunSettled(this.streamStatus ?? undefined),
           })
         : null;
     this.model = model;

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -17,15 +17,26 @@ import {
   type StreamLogEntry,
   type TaskGroup,
   type WorkflowCallProgress,
+  type WorkflowPlanMarker,
 } from '@shared/schemas';
 import type { TranscriptRow } from '@shared/transcript';
 import { designTokens } from '@shared/styles';
 import {
+  WORKFLOW_CALL_STATUS_GLYPH,
+  WORKFLOW_PHASE_GLYPH,
   formatWorkflowPhaseHeading,
-  latestWorkflowAttemptEntries,
-  workflowCallTally,
+  formatWorkflowPhaseTally,
+  formatWorkflowTally,
   workflowPhaseHeadingOfGroup,
 } from '@shared/copy/workflowCall';
+import {
+  formatWorkflowRowGroup,
+  workflowPhaseRows,
+  workflowRunModel,
+  type WorkflowPhaseModel,
+  type WorkflowRowGroup,
+  type WorkflowRunModel,
+} from '@shared/streams/workflowRunModel';
 
 // Side-effect imports - register Web Awesome components
 import '@awesome.me/webawesome/dist/components/button/button.js';
@@ -56,6 +67,7 @@ import { playCompletionSound } from '../audioNotification';
 
 // Local imports - formatters
 import { formatLogEntry } from '../formatters';
+import { formatWorkflowDeclaredTaskTemplate } from '../formatters/logFormatters/workflowCallFormatter';
 import { getTimeFormatter } from '../formatters/timestampUtils';
 
 // Local imports - sibling helpers
@@ -91,50 +103,29 @@ function getStatusIcon(status: string): TeXRAIconName {
   }
 }
 
-const GROUP_DOT_LIMIT = 40;
+const WORKFLOW_ROW_GROUPS = ['queued', 'done', 'declared'] as const;
 
-function collectWorkflowCalls(node: GroupTree): WorkflowCallProgress[] {
-  return [
-    ...node.rows.flatMap((row) =>
-      row.kind === 'workflowTask' ? [row.call] : [],
-    ),
-    ...node.children.flatMap((child) => collectWorkflowCalls(child)),
-  ];
+/** Toggle-store key of one phase's counted group of quiet cards. */
+function rowGroupToggleKey(phaseKey: string, group: WorkflowRowGroup): string {
+  return `${phaseKey}#${group}`;
 }
 
 /**
- * `collectWorkflowCalls`, scoped to the newest resume attempt. A relaunch
- * under the same `meta.name` appends a second projection attempt to the same
- * transcript with fresh card ids; without this, a subtree's live tally folds
- * every attempt together — doubling totals and keeping stale failures the
- * resume is actively re-running. Older attempts' cards remain readable as
- * history in the rows themselves — only the live count and dots are scoped.
+ * One glyph per card in issue order — the same cells, from the same model,
+ * the CLI popup's strip paints — so a phase reads at a glance and reads
+ * without colour.
  */
-function collectLatestAttemptWorkflowCalls(
-  node: GroupTree,
-): readonly WorkflowCallProgress[] {
-  return latestWorkflowAttemptEntries(
-    collectWorkflowCalls(node),
-    (call) => call.attemptId,
-  );
-}
-
-/** `done/total`, then `· N running` while live and `· N failed` in warning tone. */
-function renderWorkflowCallTally(
-  calls: readonly WorkflowCallProgress[],
+function renderStatusStrip(
+  cells: readonly WorkflowCallProgress['status'][],
 ): TemplateResult {
-  const { done, total, running, failed } = workflowCallTally(calls);
-  return html`<span class="group-progress">${done}/${total}</span>${
-      running > 0
-        ? html`<span class="group-progress">· ${running} running</span>`
-        : nothing
-    }${
-      failed > 0
-        ? html`<span class="group-progress group-progress--failed"
-            >· ${failed} failed</span
-          >`
-        : nothing
-    }`;
+  return html`<span class="group-strip" aria-hidden="true"
+    >${cells.map(
+      (status) =>
+        html`<span class="group-cell group-cell--${status}"
+          >${WORKFLOW_CALL_STATUS_GLYPH[status]}</span
+        >`,
+    )}</span
+  >`;
 }
 
 @customElement('task-group-list')
@@ -177,6 +168,11 @@ export class TaskGroupList extends LitElement {
   @property({ attribute: false }) streamStatus: StreamLifecycleStatus | null =
     null;
 
+  /** The newest attempt's declared workflow plan; with the groups, rows, and
+   *  status it is the shared run model's whole input. */
+  @property({ attribute: false }) workflowPlan: WorkflowPlanMarker | undefined =
+    undefined;
+
   /** Toggle state store for persistence */
   @property({ attribute: false }) toggleStates: ToggleStateStore | null = null;
 
@@ -190,6 +186,17 @@ export class TaskGroupList extends LitElement {
   private previousStatuses = new Map<string, string>();
 
   private readonly index = new TranscriptIndex();
+
+  /**
+   * The shared workflow run model — the fold the CLI popup paints, over the
+   * same task groups, rows, plan, and settled state — rebuilt in willUpdate
+   * whenever one of those inputs changes. Null for a stream with no phases
+   * and no plan.
+   */
+  private model: WorkflowRunModel | null = null;
+
+  /** The model's opened phases by task-group id, for the group tree. */
+  private phaseModels = new Map<string, WorkflowPhaseModel>();
 
   /** Number of recent top-level timeline entries currently rendered. */
   @state() private timelineItemWindow = DEFAULT_TIMELINE_ITEM_WINDOW;
@@ -260,6 +267,15 @@ export class TaskGroupList extends LitElement {
     if (groupsChanged) {
       this.checkForCompletedRuns();
     }
+    if (
+      groupsChanged ||
+      rowsChanged ||
+      changedProperties.has('rowGeneration') ||
+      changedProperties.has('workflowPlan') ||
+      changedProperties.has('streamStatus')
+    ) {
+      this.rebuildRunModel();
+    }
 
     const renderWindowsStale = this.index.apply({
       terminal: this.terminal,
@@ -314,6 +330,25 @@ export class TaskGroupList extends LitElement {
       nextStatuses.set(group.id, group.status);
     }
     this.previousStatuses = nextStatuses;
+  }
+
+  private rebuildRunModel(): void {
+    const model =
+      this.workflowPlan !== undefined ||
+      this.groups.some((group) => group.kind === 'phase')
+        ? workflowRunModel({
+            taskGroups: this.groups,
+            rows: this.rows,
+            plan: this.workflowPlan,
+            runSettled: !isInFlightPhase(this.streamStatus ?? undefined),
+          })
+        : null;
+    this.model = model;
+    this.phaseModels = new Map(
+      (model?.phases ?? [])
+        .filter((phase) => phase.opened)
+        .map((phase) => [phase.key, phase]),
+    );
   }
 
   private resetRenderWindows(): void {
@@ -444,52 +479,138 @@ export class TaskGroupList extends LitElement {
   }
 
   /**
-   * `done/total · N running · N failed` plus one status dot per call for a
-   * phase header, folded from the workflow-call cards the group already holds
-   * via the same shared `workflowCallTally` the CLI's phase and run tallies
-   * use, so no second owner of counts. Nothing renders for a group with no
-   * call cards, so round and run headers are unaffected.
+   * A phase header's tally and status strip, read off the model: the one
+   * spelling of `done/total · N running · N failed · N declared`, then one
+   * glyph per card. A phase with nothing to count shows neither.
    */
-  private renderGroupProgress(
-    node: GroupTree,
+  private renderPhaseProgress(
+    phase: WorkflowPhaseModel,
   ): TemplateResult | typeof nothing {
-    if (node.group.kind !== 'phase') return nothing;
-    // The header counts the whole subtree, exactly as renderRunBand does.
-    const calls = collectLatestAttemptWorkflowCalls(node);
-    if (calls.length === 0) return nothing;
-    return html`${renderWorkflowCallTally(calls)}
-      <span class="group-dots" aria-hidden="true"
-        >${calls
-          .slice(0, GROUP_DOT_LIMIT)
-          .map(
-            (call) =>
-              html`<span class="group-dot group-dot--${call.status}"></span>`,
-          )}${
-          calls.length > GROUP_DOT_LIMIT
-            ? html`<span class="group-dots-more"
-                >+${calls.length - GROUP_DOT_LIMIT}</span
-              >`
-            : nothing
-        }</span
-      >`;
+    if (phase.tally.total === 0 && phase.tally.declared === 0) return nothing;
+    return html`<span class="group-progress"
+        >${formatWorkflowPhaseTally(phase)}</span
+      >${phase.cells.length > 0 ? renderStatusStrip(phase.cells) : nothing}`;
   }
 
-  /**
-   * Whole-run tally above a multi-agent workflow's phases: the same fold as
-   * the phase headers, one level up, over rows the root already holds.
-   */
+  /** Whole-run tally above a multi-agent workflow's phases. */
   private renderRunBand(node: GroupTree): TemplateResult | typeof nothing {
-    if (this.isToolUse) return nothing;
+    const model = this.model;
+    if (this.isToolUse || !model || model.tally.total === 0) return nothing;
     if (!node.children.some((child) => child.group.kind === 'phase')) {
       return nothing;
     }
-    return html`${guard([node, this.rowGeneration], () => {
-      const calls = collectLatestAttemptWorkflowCalls(node);
-      if (calls.length === 0) return nothing;
-      return html`<div class="log-run-band">
-        ${renderWorkflowCallTally(calls)}
-      </div>`;
-    })}`;
+    return html`<div class="log-run-band">
+      ${formatWorkflowTally(model.tally)}
+    </div>`;
+  }
+
+  /** Quiet groups stay closed until the reader opens one. `true` in the
+   *  store means collapsed, as for task groups, so only an explicit `false`
+   *  opens a group. */
+  private expandedRowGroups(phaseKey: string): ReadonlySet<WorkflowRowGroup> {
+    const expanded = new Set<WorkflowRowGroup>();
+    for (const group of WORKFLOW_ROW_GROUPS) {
+      if (
+        this.toggleStates?.get(rowGroupToggleKey(phaseKey, group)) === false
+      ) {
+        expanded.add(group);
+      }
+    }
+    return expanded;
+  }
+
+  private handleRowGroupToggle(event: Event): void {
+    event.preventDefault();
+    event.stopPropagation();
+    const target = event.currentTarget as HTMLElement;
+    const key = target.dataset.toggleKey;
+    if (!key || !this.toggleStates) return;
+    // Open → collapse (true), closed → open (false).
+    this.toggleStates.set(key, target.getAttribute('aria-expanded') === 'true');
+    this.requestUpdate();
+  }
+
+  /**
+   * One phase's cards in the model's order — the CLI popup's order: cards
+   * needing attention first, the rest as counted groups that open in place,
+   * and the plan's tasks the run has not issued yet.
+   */
+  private renderPhaseRows(phase: WorkflowPhaseModel): TemplateResult {
+    const rows = workflowPhaseRows(phase, {
+      expanded: this.expandedRowGroups(phase.key),
+      filter: '',
+    });
+    return html`${repeat(
+      rows,
+      (row) => row.key,
+      (row) => {
+        switch (row.kind) {
+          case 'task':
+            return this.renderLogEntry(row.row);
+          case 'declared':
+            return formatWorkflowDeclaredTaskTemplate(row.task);
+          case 'group':
+            return html`<button
+              type="button"
+              class="workflow-row-group"
+              aria-expanded=${row.expanded ? 'true' : 'false'}
+              data-toggle-key=${rowGroupToggleKey(phase.key, row.group)}
+              @click=${this.handleRowGroupToggle}
+            >
+              ${waIcon(row.expanded ? 'chevron-down' : 'chevron-right')}
+              ${formatWorkflowRowGroup(row)}
+            </button>`;
+        }
+      },
+    )}`;
+  }
+
+  /**
+   * Phases the plan declares that the run has not opened, after everything it
+   * has: the hollow twin of an opened phase's header, holding the plan's tasks
+   * for that phase. The model drops them once the run settles.
+   */
+  private renderDeclaredPhases(): TemplateResult | typeof nothing {
+    const declared = this.model?.phases.filter((phase) => !phase.opened) ?? [];
+    if (declared.length === 0) return nothing;
+    return html`${repeat(
+      declared,
+      (phase) => phase.key,
+      (phase) => {
+        const expanded = this.isExpanded(phase.key);
+        return html`
+          <wa-details
+            id=${`${GROUP_DOM_IDS.DETAILS_PREFIX}${phase.key}`}
+            class="log-group"
+            ?open=${expanded}
+            @wa-show=${this.handleGroupToggle}
+            @wa-hide=${this.handleGroupToggle}
+          >
+            <div
+              slot="summary"
+              id="${GROUP_DOM_IDS.HEADER_PREFIX}${phase.key}"
+              class="log-group-header is-declared"
+            >
+              <span class="group-status-icon" aria-hidden="true"
+                >${WORKFLOW_PHASE_GLYPH.declared}</span
+              >
+              <span class="group-title"
+                >${formatWorkflowPhaseHeading(phase.heading)}</span
+              >
+              <span class="group-progress"
+                >${formatWorkflowPhaseTally(phase)}</span
+              >
+            </div>
+            <div
+              id=${`${GROUP_DOM_IDS.CONTENT_PREFIX}${phase.key}`}
+              class="log-group-content"
+            >
+              ${expanded ? this.renderPhaseRows(phase) : nothing}
+            </div>
+          </wa-details>
+        `;
+      },
+    )}`;
   }
 
   /** Render child group header inline (only called for non-root groups) */
@@ -503,6 +624,7 @@ export class TaskGroupList extends LitElement {
       : '';
 
     const statusIcon = getStatusIcon(group.status);
+    const phase = this.phaseModels.get(group.id);
     const title =
       group.kind === 'round' && group.index !== undefined
         ? formatRoundStageLabel({
@@ -517,7 +639,7 @@ export class TaskGroupList extends LitElement {
         })}
       </span>
       <span class="group-title">${title}</span>
-      ${this.renderGroupProgress(node)}
+      ${phase ? this.renderPhaseProgress(phase) : nothing}
       <span class="group-time">
         <span class="group-start-time">
           ${waIcon('clock')} ${formattedStartTime}
@@ -531,12 +653,21 @@ export class TaskGroupList extends LitElement {
     `;
   }
 
-  /** Rows of a group followed by its child groups. */
+  /**
+   * Rows of a group followed by its child groups. A phase's cards come from
+   * the model (`renderPhaseRows`); its other rows — the script's own log
+   * lines — follow in transcript order. A phase the model does not hold (one
+   * whose every card belonged to a superseded attempt) keeps its rows as
+   * plain history.
+   */
   private renderGroupBody(node: GroupTree): TemplateResult {
-    return html`${this.renderRowEntries(
-      node.rows,
-      `group:${node.group.id}`,
-    )}${repeat(
+    const phase = this.phaseModels.get(node.group.id);
+    const rows = phase
+      ? node.rows.filter((row) => row.kind !== 'workflowTask')
+      : node.rows;
+    return html`${
+      phase ? this.renderPhaseRows(phase) : nothing
+    }${this.renderRowEntries(rows, `group:${node.group.id}`)}${repeat(
       node.children,
       (c) => c.group.id,
       (c) => this.renderGroupNode(c),
@@ -688,6 +819,7 @@ export class TaskGroupList extends LitElement {
             ? this.renderLogEntry(item.row)
             : this.renderGroupNode(item.tree, true),
       )}
+      ${this.renderDeclaredPhases()}
     `;
   }
 }

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowCallFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowCallFormatter.ts
@@ -5,7 +5,11 @@ import { html, nothing, type TemplateResult } from 'lit';
 import { ProgressEvents } from '@progressView/frontend/events';
 
 // Local imports - shared contracts
-import type { WorkflowCallProgress } from '@shared/schemas';
+import {
+  WORKFLOW_TASK_STATUS_LABEL,
+  type WorkflowCallIdentity,
+  type WorkflowCallProgress,
+} from '@shared/schemas';
 import type { WorkflowTaskRow } from '@shared/transcript';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { terminalStatusIcon } from '@shared/wa/statusIcons';
@@ -43,6 +47,26 @@ function callMetadata(
   return parts.length > 0
     ? html`<span class="workflow-task-meta">${parts.join(' · ')}</span>`
     : nothing;
+}
+
+/** A plan task the run has not issued yet: the card's quiet, dashed twin. */
+export function formatWorkflowDeclaredTaskTemplate(
+  task: WorkflowCallIdentity,
+): TemplateResult {
+  return html`
+    <div
+      class="workflow-task workflow-task--declared"
+      data-declared-id=${task.id}
+    >
+      <span class="workflow-task-icon">${waIcon('circle')}</span>
+      <span class="workflow-task-body">
+        <span class="workflow-task-title">${task.label}</span>
+      </span>
+      <span class="workflow-task-status"
+        >${WORKFLOW_TASK_STATUS_LABEL.declared}</span
+      >
+    </div>
+  `;
 }
 
 /** Render one workflow call as a status card updated in place by log id. */

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -453,6 +453,7 @@ export const logContext$ = new Signal.Computed((): StreamLogContextValue => {
     updatedRowBaseGeneration: streamLogs.updatedRowBaseGeneration,
     rowGeneration: streamLogs.generation,
     taskGroups: activeTaskGroups$.get(),
+    workflowPlan: streamLogs.workflowPlan,
     isToolUse: activeIsToolUse$.get(),
     hasStreams,
     streamName: activeStreamInfo.name,

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -19,6 +19,7 @@ import {
 } from '@shared/streams/compactionActivityProjection';
 import { isTranscriptSettlementPhase } from '@shared/streams/streamStatus';
 import { upsertTaskGroupFromStreamLog } from '@shared/streams/taskGroupProjection';
+import { workflowMarkerOf } from '@shared/streams/workflowRunModel';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 
 import { appState, subagentExecutionLabels } from '../progressState';
@@ -128,7 +129,21 @@ function applyEntry(
     streamLogs,
     applyCompactionActivityEntries(streamLogs.compactionProjection, [entry]),
   );
-  // Internal records remain diagnostic-only. Raw compaction lifecycle records
+  // The workflow attempt and plan markers are the one internal record this
+  // host reads: they are an input of the shared workflow run model the board
+  // paints. A new attempt starts with no plan of its own until it records one,
+  // and an unreadable plan is an unknown plan, not the previous attempt's.
+  const marker = workflowMarkerOf(entry);
+  if (marker) {
+    if (marker.kind === 'malformedPlan') {
+      console.warn(
+        `[logSlice] Ignoring malformed workflow plan marker ${entry.id}: ${marker.error}`,
+      );
+    }
+    streamLogs.workflowPlan = marker.kind === 'plan' ? marker.plan : undefined;
+    return { ...compactionResult, logChanged: true, stateChanged: false };
+  }
+  // Other internal records remain diagnostic-only. Raw compaction lifecycle records
   // are replaced by the correlated stable row projected above. An active-skills
   // snapshot projects no row either (`projectTranscriptRow`); this host has no
   // surface for it, so it is not retained here — the durable transcript is
@@ -282,6 +297,7 @@ export const logHandlers = {
               rowIndex: streamLogs.rowIndex,
               taskGroupIndex: streamLogs.taskGroupIndex,
               compactionProjection: streamLogs.compactionProjection,
+              workflowPlan: streamLogs.workflowPlan,
               updatedRowIndices: [...updatedRowIndices],
               updatedRowBaseGeneration,
               generation: streamLogs.generation + 1,

--- a/packages/extension/src/progressView/frontend/store.ts
+++ b/packages/extension/src/progressView/frontend/store.ts
@@ -10,6 +10,7 @@ import {
   type StreamTabId,
   type InquiryThreadUpdatedEvent,
   type InquiryThreadId,
+  type WorkflowPlanMarker,
 } from '@shared/schemas';
 import type { TranscriptRow } from '@shared/transcript';
 import {
@@ -46,6 +47,12 @@ export interface StreamLogs {
   /** Correlated context-compaction lifecycle projected into stable rows. */
   compactionProjection: CompactionActivityProjection;
   /**
+   * The newest attempt's declared workflow plan, folded from the
+   * `workflowAttempt` / `workflowPlan` markers the same way the CLI folds
+   * them; one input of the shared workflow run model the board paints.
+   */
+  workflowPlan: WorkflowPlanMarker | undefined;
+  /**
    * Existing row indices updated by the most recent backend delta.
    * Pure append batches leave this empty so renderers can skip whole-log scans.
    */
@@ -64,6 +71,7 @@ function createEmptyStreamLogs(): StreamLogs {
     rowIndex: new Map(),
     taskGroupIndex: new Map(),
     compactionProjection: createCompactionActivityProjection(),
+    workflowPlan: undefined,
     updatedRowIndices: [],
     updatedRowBaseGeneration: 0,
     generation: 0,

--- a/packages/extension/src/progressView/frontend/streamContexts.ts
+++ b/packages/extension/src/progressView/frontend/streamContexts.ts
@@ -18,6 +18,7 @@ import type {
   StreamTabId,
   StreamTabInfo,
   TaskGroup,
+  WorkflowPlanMarker,
 } from '@shared/schemas';
 import type { TranscriptRow } from '@shared/transcript';
 
@@ -68,6 +69,8 @@ export interface StreamLogContextValue {
   /** Current log generation. */
   rowGeneration: number;
   taskGroups: TaskGroup[];
+  /** The newest attempt's declared workflow plan, for the run model. */
+  workflowPlan: WorkflowPlanMarker | undefined;
   isToolUse: boolean;
   hasStreams: boolean;
   /** Stream name for switch detection in LogList */
@@ -85,6 +88,7 @@ export const EMPTY_LOG_CONTEXT: StreamLogContextValue = {
   updatedRowBaseGeneration: 0,
   rowGeneration: 0,
   taskGroups: [],
+  workflowPlan: undefined,
   isToolUse: false,
   hasStreams: false,
   streamName: null,

--- a/packages/extension/src/progressView/frontend/styles/groupStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/groupStyles.ts
@@ -11,6 +11,7 @@ export const groupStyles = css`
     border-radius: var(--wa-border-radius-m, var(--border-radius-small));
     cursor: pointer;
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     background-color: color-mix(
       in srgb,
@@ -35,6 +36,13 @@ export const groupStyles = css`
        matching the shared status dot and the CLI row marker. */
     &.is-cancelled {
       border-inline-start-color: var(--border-control);
+    }
+
+    /* A phase the plan declares and the run has not opened: hollow glyph,
+       dashed rail, quiet. */
+    &.is-declared {
+      border-inline-start-style: dashed;
+      color: var(--color-text-muted);
     }
   }
 
@@ -62,8 +70,7 @@ export const groupStyles = css`
     flex-grow: 1;
   }
 
-  /* Completed/declared task count for a phase header, right-aligned beside
-     the timestamps. */
+  /* A phase header's tally, right-aligned beside the timestamps. */
   .group-progress {
     font-size: var(--font-size-sm);
     font-variant-numeric: tabular-nums;
@@ -71,52 +78,67 @@ export const groupStyles = css`
     margin-inline-start: var(--wa-space-2xs);
   }
 
-  .group-progress--failed {
+  /* One glyph per card, inline after the tally; a strip too wide for the
+     header wraps its cells rather than squeezing the title. Failed reads
+     red, running blue, done green; the shapes carry the same distinctions
+     without colour. */
+  .group-strip {
+    flex: 0 1 auto;
+    min-width: 0;
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 1px 2px;
+    margin-inline-start: var(--wa-space-xs);
+    font-size: var(--font-size-sm);
+    line-height: 1.1;
+    color: var(--color-text-muted);
+  }
+
+  .group-cell--awaitingApproval {
+    color: var(--color-warning);
+  }
+
+  .group-cell--running {
+    color: var(--wa-color-focus);
+  }
+
+  .group-cell--completed,
+  .group-cell--cached {
+    color: var(--color-success);
+  }
+
+  .group-cell--failed {
     color: var(--color-error);
   }
 
-  /* One dot per call: what a phase holds, at a glance. */
-  .group-dots {
+  .group-cell--skipped,
+  .group-cell--cancelled {
+    opacity: var(--opacity-subtle);
+  }
+
+  /* A counted group of quiet cards; a click unfolds it in place. */
+  .workflow-row-group {
     display: inline-flex;
     align-items: center;
-    gap: 3px;
-    margin-inline-start: var(--wa-space-xs);
-  }
-
-  .group-dot {
-    width: 7px;
-    height: 7px;
-    border-radius: 2px;
-    background: var(--wa-color-surface-border);
-    box-sizing: border-box;
-  }
-
-  .group-dot--awaitingApproval {
-    background: var(--wa-color-warning-border-loud);
-  }
-
-  .group-dot--running {
-    background: var(--wa-color-focus);
-  }
-
-  .group-dot--completed,
-  .group-dot--cached {
-    background: var(--color-success);
-  }
-
-  .group-dot--failed {
-    background: var(--color-error);
-  }
-
-  .group-dot--skipped,
-  .group-dot--cancelled {
+    gap: var(--wa-space-2xs);
+    margin: var(--wa-space-2xs) 0;
+    padding: calc(var(--wa-space-3xs) / 2) var(--wa-space-2xs);
+    border: none;
+    border-radius: var(--wa-border-radius-m, var(--border-radius));
     background: transparent;
-    border: 1px solid var(--wa-color-surface-border);
+    color: var(--color-text-secondary);
+    font: inherit;
+    font-size: var(--font-size-sm);
+    cursor: pointer;
   }
 
-  .group-dots-more {
-    font-size: var(--font-size-xs);
-    color: var(--color-text-muted);
+  .workflow-row-group:hover {
+    background: var(--wa-color-neutral-fill-quiet);
+  }
+
+  .workflow-row-group:focus-visible {
+    outline: 2px solid var(--wa-color-focus);
+    outline-offset: 1px;
   }
 
   .log-run-band {

--- a/src/shared/streams/streamStatus.ts
+++ b/src/shared/streams/streamStatus.ts
@@ -1,4 +1,16 @@
 /**
+ * Whether a workflow-script run has ended, as the shared workflow run model
+ * reads it (`runSettled`): a known status that is neither running nor
+ * waiting. An unknown status is not "ended" — a plan-only phase must not
+ * vanish before the stream's first status has arrived. Both hosts call this,
+ * so neither can drift.
+ */
+export function workflowRunSettled(
+  phase: StreamLifecycleStatus | undefined,
+): boolean {
+  return phase !== undefined && !isInFlightPhase(phase);
+}
+/**
  * Stream status constants shared across agent runtime and UI layers.
  */
 // Local imports - shared schemas

--- a/src/shared/streams/workflowRunModel.ts
+++ b/src/shared/streams/workflowRunModel.ts
@@ -317,6 +317,20 @@ export function workflowRunModel(
 /** The counted groups a phase's quiet rows collapse into. */
 export type WorkflowRowGroup = 'queued' | 'done' | 'declared';
 
+const WORKFLOW_ROW_GROUP_LABEL = {
+  queued: 'queued',
+  done: 'done',
+  declared: 'declared',
+} as const satisfies Record<WorkflowRowGroup, string>;
+
+/** `12 queued` — the one spelling of a counted group's row. */
+export function formatWorkflowRowGroup(row: {
+  readonly count: number;
+  readonly group: WorkflowRowGroup;
+}): string {
+  return `${row.count} ${WORKFLOW_ROW_GROUP_LABEL[row.group]}`;
+}
+
 export type WorkflowPhaseRow =
   | {
       readonly kind: 'task';

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -18,6 +18,7 @@ import {
   type StreamTabId,
   type TaskGroup,
   type WorkflowCallProgress,
+  type WorkflowPlanMarker,
 } from '@shared/schemas';
 import {
   projectTranscriptRow,
@@ -26,6 +27,7 @@ import {
   type TranscriptRow,
   type WorkflowTaskRow,
 } from '@shared/transcript';
+import { ToggleStateStore } from '@shared/state/ToggleStateStore';
 
 // Local file imports
 import {
@@ -45,6 +47,8 @@ type TaskGroupListInternals = HTMLElement & {
   hasStreams: boolean;
   isToolUse: boolean;
   terminal: boolean;
+  toggleStates: ToggleStateStore | null;
+  workflowPlan: WorkflowPlanMarker | undefined;
   updateComplete: Promise<boolean>;
   readonly index: TranscriptIndex;
   willUpdate: (changedProperties: Map<string, unknown>) => void;
@@ -135,11 +139,16 @@ function createList(rows: TranscriptRow[]): TaskGroupListInternals {
 function renderList(
   groups: TaskGroup[],
   rows: TranscriptRow[],
+  options: {
+    toggleStates?: ToggleStateStore;
+    workflowPlan?: WorkflowPlanMarker;
+  } = {},
 ): Promise<TaskGroupListInternals> {
   return mountComponent<TaskGroupListInternals>('task-group-list', {
     hasStreams: true,
     groups,
     rows,
+    ...options,
   });
 }
 
@@ -585,7 +594,11 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
       }),
     ];
 
-    const list = await renderList([run, phase], rows);
+    // The finished cards sit in the phase's "done" group; open it so the
+    // cards below are in the DOM (`false` = expanded, as for task groups).
+    const toggleStates = new ToggleStateStore();
+    toggleStates.set('phase-review#done', false);
+    const list = await renderList([run, phase], rows, { toggleStates });
 
     // Header shows the phase label plus the one-based position, matching the
     // CLI's `(index+1/total)` diamond header.
@@ -594,11 +607,14 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
       'Review (2/3)',
     );
 
-    // The header also folds its own cards into a completion count. All four
-    // are terminal here (completed / failed / skipped x2).
+    // The header's tally and strip are the shared model's: all four cards
+    // are terminal (completed / failed / skipped x2), one failed.
     expect(header?.querySelector('.group-progress')?.textContent?.trim()).toBe(
-      '4/4',
+      '4/4 · 1 failed',
     );
+    expect(
+      header?.querySelector('.group-strip')?.textContent?.replaceAll(/\s/g, ''),
+    ).toBe('☑✗⊘⊘');
 
     // Each task is one structured card with its status and terminal metadata.
     const content = groupContent(list, 'phase-review');
@@ -694,7 +710,7 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
 
     const header = groupHeader(list, 'phase-map');
     expect(header?.querySelector('.group-progress')?.textContent?.trim()).toBe(
-      '1/2',
+      '1/2 · 1 running',
     );
     expect(header?.querySelector('wa-spinner')).toBeNull();
     expect(header?.querySelector('wa-icon')?.getAttribute('name')).toBe(
@@ -715,5 +731,84 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
         ?.querySelector('[data-log-id="task-b"] .workflow-task-status')
         ?.textContent?.trim(),
     ).toBe('Running');
+  });
+
+  it('leads with attention, folds the rest into counted groups, and lists declared phases', async () => {
+    const run = runGroup('Run: workflow');
+    const phase = createGroup('phase-map', STREAM_PHASE.RUNNING, {
+      name: 'Map',
+      startTime: 2,
+      parentGroupId: 'run',
+      kind: 'phase',
+      index: 0,
+      total: 2,
+    });
+    const rows: TranscriptRow[] = [
+      ...['q1', 'q2', 'q3'].map((id, index) =>
+        workflowTaskRow('phase-map', id, 3 + index, {
+          id,
+          label: `Queued ${id}`,
+          phase: 'Map',
+          status: 'queued',
+        }),
+      ),
+      workflowTaskRow('phase-map', 'live', 6, {
+        id: 'live',
+        label: 'Running now',
+        phase: 'Map',
+        status: 'running',
+      }),
+    ];
+    const workflowPlan: WorkflowPlanMarker = {
+      kind: 'workflowPlan',
+      attemptId: 'attempt-1',
+      phases: [
+        { title: 'Map', index: 0 },
+        { title: 'Publish', index: 1 },
+      ],
+      tasks: [{ id: 'report', label: 'Write the report', phase: 'Publish' }],
+    };
+    const toggleStates = new ToggleStateStore();
+    const list = await renderList([run, phase], rows, {
+      toggleStates,
+      workflowPlan,
+    });
+
+    // The running card leads; the queued cards are one counted row until
+    // the reader opens it in place.
+    const content = groupContent(list, 'phase-map');
+    const cardsBefore = [
+      ...(content?.querySelectorAll('.workflow-task') ?? []),
+    ].map((card) => card.getAttribute('data-log-id'));
+    expect(cardsBefore).toEqual(['live']);
+    const group = content?.querySelector<HTMLButtonElement>(
+      '.workflow-row-group',
+    );
+    expect(group?.textContent?.trim()).toBe('3 queued');
+    expect(group?.getAttribute('aria-expanded')).toBe('false');
+    group?.click();
+    await list.updateComplete;
+    const cardsAfter = [
+      ...(groupContent(list, 'phase-map')?.querySelectorAll('.workflow-task') ??
+        []),
+    ].map((card) => card.getAttribute('data-log-id'));
+    expect(cardsAfter).toEqual(['live', 'q1', 'q2', 'q3']);
+    expect(toggleStates.get('phase-map#queued')).toBe(false);
+
+    // A phase the plan declares and the run has not opened follows with its
+    // hollow glyph and the plan's tasks for it.
+    const declaredHeader = groupHeader(list, 'declared-Publish');
+    expect(declaredHeader?.classList.contains('is-declared')).toBe(true);
+    expect(
+      declaredHeader?.querySelector('.group-title')?.textContent?.trim(),
+    ).toBe('Publish (2/2)');
+    expect(
+      declaredHeader?.querySelector('.group-progress')?.textContent?.trim(),
+    ).toBe('1 declared');
+    expect(
+      groupContent(list, 'declared-Publish')
+        ?.querySelector('.workflow-row-group')
+        ?.textContent?.trim(),
+    ).toBe('1 declared');
   });
 });


### PR DESCRIPTION
## What

Second half of the owner ruling in `docs/proposals/2026-08-29-simplification-survey-workflow-display-hosts.md` (first half: #11602, merged): the TUI and the board share **one** workflow-display model and differ only in how they paint it — no projector or adapter layer on either side.

`TaskGroupList` now folds its task groups, rows, plan, and settled state through `workflowRunModel` — the same call the CLI popup makes — and paints what the popup paints:

- **Phase header** — the tally in the one shared spelling (`14/39 · 6 running · 1 failed · 4 declared`) and the **glyph strip**, one cell per card in issue order from the model's `cells` and `WORKFLOW_CALL_STATUS_GLYPH` (`☑☑☑✗□☐☐□□…`). The strip sits inline after the tally and wraps under the title when a phase is wide; the shapes read without colour, and colour adds failed / running / done / awaiting.
- **Phase body** — `workflowPhaseRows`: cards needing attention first (awaiting approval, failed, running), the rest folded into counted `▸ 18 queued` / `▸ 13 done` / `▸ 4 declared` groups that open in place (a `<button aria-expanded>` per group; open state lives in the existing per-stream `ToggleStateStore`, `false` = open, same convention as the phase groups). The script's own log lines follow the cards in transcript order.
- **Declared phases** — the plan's phases the run has not reached yet render after everything it has, as the hollow `◇ Publish (3/3) · 2 declared` twin of an opened header, holding the plan's tasks as quiet dashed cards. The model drops them once the run settles.
- **Run band** — `formatWorkflowTally(model.tally)`.

The plan reaches the board because `logSlice.applyEntry` reads the `workflowAttempt` / `workflowPlan` markers through the shared `workflowMarkerOf` instead of dropping every `INTERNAL` entry, and `StreamLogs` carries the newest attempt's plan (`workflowPlan`) through `logContext$` → `LogList` → `TaskGroupList` beside the rows and task groups it already carried.

Behavior change worth knowing: the board scopes a phase's cards to the newest attempt exactly as the popup does, so a superseded attempt's cards no longer show as history inside a live phase (a phase whose every card is stale keeps its rows as plain history — the model does not hold it).

Known, unchanged: a card issued outside any phase (the model's trailing `Unphased` phase) has no task-group node on the board, so it still renders as a plain transcript row in the run body rather than through the model's attention order — the pre-PR behaviour, and a follow-up if a script ever relies on unphased calls. Cards bypass the 400-row `groupRowWindows` cap (they carry `content-visibility: auto`); the attention set is bounded by concurrency, the quiet sets by their counted groups.

Both hosts now read `runSettled` off one predicate, `workflowRunSettled(status)` in `@shared/streams/streamStatus` (a known status that is neither running nor waiting); an unknown status is not "ended", so a plan-only phase cannot be dropped before the stream's first status arrives.

### Captured from the real bundle (Electron smoke runner, seeded with a captured run + a synthesized plan marker and a 40-card phase)

Mid-run: `2/6 · 2 running`; `✓ Investigate (1/3) 2/2 ☑☑`; `● Revise (2/3) 0/4 · 2 running □□☐☐` → two running cards, `▸ 1 queued ▸ 1 done`; `◇ Publish (3/3) 2 declared`.
Wide phase (40 cards): `14/39 · 6 running · 1 failed · 4 declared`, strip `☑×12 ✗ □ ☐×6 □×18 ⊘`, then the awaiting-approval card, the failed card, six running, `▾ 18 queued` opened in place.

## Dead code cleaned in the same pass

- `collectWorkflowCalls`, `collectLatestAttemptWorkflowCalls`, `renderWorkflowCallTally`, `renderGroupProgress`, `GROUP_DOT_LIMIT`, and the `.group-dot*` / `.group-progress--failed` styles — the board's private fold of the cards.
- The popup's private `GROUP_LABEL` table — `formatWorkflowRowGroup` on the model is the one spelling of `12 queued`.

## Net elements (R6)

`git diff --stat` against `origin/main`:

- Production (`src/shared`, `packages/cli/src`, `packages/extension/src`): 10 files, **+344 / −125** (net +219)
- Tests: 1 file, +100 / −5
- Files: ±0
- Exported symbols: +3 (`formatWorkflowRowGroup` — two consumers; `formatWorkflowDeclaredTaskTemplate` — one; `workflowRunSettled` — two) / −0
- Declarations: ±0

Net-positive, stated reason: this is the feature half of the ruling — the strip, the counted groups, the declared phases and tasks, and the plan plumbing did not exist on the board — layered on the deletion of the board's own fold. Nothing is duplicated: every fold the board paints from lives in `src/shared/streams/workflowRunModel.ts`.

## Consumer counts (R8)

No emit path is deleted or re-routed. Deleted symbols, grepped at `origin/main` (prod / test): `collectWorkflowCalls` 4 sites / 0, `collectLatestAttemptWorkflowCalls` 3 / 0, `renderWorkflowCallTally` 3 / 0, `renderGroupProgress` 2 / 0, `GROUP_DOT_LIMIT` 4 / 0, `.group-dot` 13 CSS sites / 0, `GROUP_LABEL` 2 / 0. `logSlice` still drops every other `INTERNAL` record; only the two workflow markers are read.

## Verified

- `npm run typecheck` — clean
- `npm run lint` (repo-wide) + prettier — clean
- vitest `src/test-kernel/{progressView,cli,shared,architecture}` — 251 files, 3,413 tests passing
- `npm run check:dead-code-ratchet` — no new findings
- Real-bundle capture (`npm run vite:webviews` + `scripts/smoke-webviews-electron-runner.cjs`) of a mid-run, a settled run, and a 40-card phase with every status; the counted group opened by a real click, the queued cards then in the DOM; no schema or console errors.
- Tests kept minimal: the two existing phase assertions updated (shared tally spelling; done cards sit in a group), one new case for attention order, the group toggle, and a declared phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QESykrKh1yzvF2bB4pjDrS
