### PR TITLE
feat(workflow): join each child run's live progress to its card in both hosts

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -94,8 +94,8 @@ import {
   childRosters as childRostersSignal,
   parentStream as parentStreamSignal,
   sessionStateRevision,
-  sessionStreamExecution,
   streamMetadataFor,
+  streamStateFor,
   subagentExecutionLabels as subagentExecutionLabelsSignal,
   visibleSubagentRows,
 } from './state/childExecutions';
@@ -352,7 +352,7 @@ export function App(props: AppProps): React.JSX.Element {
       childProgress.set(child.childStreamId, {
         ...(runStartedAt !== undefined ? { runStartedAt } : {}),
         toolCallCount:
-          sessionStreamExecution(child.childStreamId)?.conversationProgress
+          streamStateFor(child.childStreamId)?.conversationProgress
             .toolCallCount ?? 0,
         ...(usage ? { outputTokens: usage.outputTokens } : {}),
         ...(usage?.cost !== undefined ? { costUsd: usage.cost } : {}),

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -27,7 +27,10 @@ import {
 import { SESSION_LIST } from '@shared/copy/nestedRuns';
 
 // Local imports - TUI surfaces and state
-import { workflowRunModel } from '@shared/streams/workflowRunModel';
+import {
+  workflowRunModel,
+  type ChildRunProgress,
+} from '@shared/streams/workflowRunModel';
 import {
   appDraftDiscardActive,
   approvalVisibleForActiveStream,
@@ -91,9 +94,15 @@ import {
   childRosters as childRostersSignal,
   parentStream as parentStreamSignal,
   sessionStateRevision,
+  sessionStreamExecution,
   streamMetadataFor,
   subagentExecutionLabels as subagentExecutionLabelsSignal,
+  visibleSubagentRows,
 } from './state/childExecutions';
+import {
+  readStreamArtifacts,
+  streamArtifactRevision,
+} from './state/subscribeStreamArtifacts';
 import { focusedChildFollowUpRoute } from './state/focusedChildFollowUp';
 import {
   INITIAL_CHILD_LIST_SELECTION,
@@ -180,7 +189,8 @@ export function App(props: AppProps): React.JSX.Element {
   const reverseSearchOpen = useSignal(reverseSearchOpenSignal);
   // Render reads shared stream metadata through `streamMetadataFor`; the
   // revision signal re-renders on metadata changes the roster signal misses.
-  useSignal(sessionStateRevision);
+  const sessionRevision = useSignal(sessionStateRevision);
+  const artifactRevision = useSignal(streamArtifactRevision);
   const formBusy = formProgress?.status === 'running';
   const pendingSummaries = useSignal(pendingApprovalSummaries);
   const [childListSelection, dispatchChildListSelection] = useReducer(
@@ -325,18 +335,46 @@ export function App(props: AppProps): React.JSX.Element {
       ? undefined
       : streamPhaseFor(workflowPopupStreamId)?.phase;
   const workflowPopupRunSettled = workflowRunSettled(workflowRootPhase);
-  const workflowPopupModel = useMemo(
-    () =>
-      workflowPopupRoot
-        ? workflowRunModel({
-            taskGroups: workflowPopupRoot.taskGroups,
-            rows: workflowPopupRoot.entries,
-            plan: workflowPopupRoot.workflowPlan,
-            runSettled: workflowPopupRunSettled,
-          })
-        : undefined,
-    [workflowPopupRoot, workflowPopupRunSettled],
-  );
+  // Each child's live progress is read once here off the session's own
+  // record of that child (status machine, execution state, usage) and joined
+  // to its card by the model; the popup paints the join and reads no stream.
+  const workflowPopupModel = useMemo(() => {
+    if (!workflowPopupRoot || workflowPopupStreamId === undefined) {
+      return undefined;
+    }
+    const childProgress = new Map<StreamTabId, ChildRunProgress>();
+    for (const child of visibleSubagentRows(
+      workflowPopupStreamId,
+      childRosters,
+    )) {
+      const runStartedAt = streamPhaseFor(child.childStreamId)?.runStartedAt;
+      const usage = readStreamArtifacts(child.childStreamId)?.cumulativeUsage;
+      childProgress.set(child.childStreamId, {
+        ...(runStartedAt !== undefined ? { runStartedAt } : {}),
+        toolCallCount:
+          sessionStreamExecution(child.childStreamId)?.conversationProgress
+            .toolCallCount ?? 0,
+        ...(usage ? { outputTokens: usage.outputTokens } : {}),
+        ...(usage?.cost !== undefined ? { costUsd: usage.cost } : {}),
+      });
+    }
+    return workflowRunModel({
+      taskGroups: workflowPopupRoot.taskGroups,
+      rows: workflowPopupRoot.entries,
+      plan: workflowPopupRoot.workflowPlan,
+      runSettled: workflowPopupRunSettled,
+      childProgress,
+    });
+    // The two revisions are the signals that a child's progress or usage
+    // moved; they carry no value of their own.
+  }, [
+    workflowPopupRoot,
+    workflowPopupRunSettled,
+    workflowPopupStreamId,
+    childRosters,
+    sessionRevision,
+    artifactRevision,
+  ]);
   const workflowPopup = useSignal(workflowPopupViewSignal);
   // The popup controls its own grandchildren: their execution ids live on the
   // workflow's roster, not on the parent conversation's.

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -6,8 +6,9 @@ import {
   COLOR_SUCCESS,
   COLOR_WARNING,
 } from '@cli/tui/ui/colors';
-import { STATUS_DOT, TOKENS_GENERATED } from '@cli/tui/ui/glyphs';
+import { STATUS_DOT } from '@cli/tui/ui/glyphs';
 import { STREAM_PHASE } from '@shared/schemas';
+import { TOKENS_GENERATED } from '@shared/copy/workflowCall';
 import { formatCompactTokenCount } from '@utils/core';
 import { formatResultCount } from '@utils/text/stringUtils';
 

--- a/packages/cli/src/chat/tui/panes/WorkflowPopup.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkflowPopup.tsx
@@ -23,7 +23,7 @@ import {
 } from '@cli/tui/ui/KeyHints';
 import { Select, type SelectItem } from '@cli/tui/ui/Select';
 import { COLOR_HINT } from '@cli/tui/ui/colors';
-import { POINTER, TOKENS_GENERATED } from '@cli/tui/ui/glyphs';
+import { POINTER } from '@cli/tui/ui/glyphs';
 import { CONFIRM_CARD_HORIZONTAL_DECORATION } from '@cli/tui/ui/theme';
 import { useLiveNowMsSince } from '@cli/tui/useLiveNowMs';
 import { fillRows, textDisplayWidth } from '@cli/runtime/terminalText';
@@ -48,8 +48,10 @@ import {
   formatWorkflowTally,
 } from '@shared/copy/workflowCall';
 import {
+  formatWorkflowCallLiveParts,
   formatWorkflowRowGroup,
   workflowPhaseRows,
+  type ChildRunProgress,
   type WorkflowPhaseModel,
   type WorkflowPhaseRow,
   type WorkflowRowGroup,
@@ -138,50 +140,27 @@ function statusStrip(
   return `${cells.slice(0, shownCount).map(glyph).join('')}+${cells.length - shownCount}`;
 }
 
-function liveTaskMetadata(
-  row: WorkflowTaskRowModel,
-  streamId: StreamTabId | undefined,
-  nowMs: number,
-): string | undefined {
-  // The row's own parts name the call (kind · agent · model · attempt · files)
-  // and, once it settles, what it cost; the live segments below cover the
-  // in-flight window the card itself cannot: elapsed, generated tokens, and
-  // the running spend read off the child stream.
-  const live = !isTerminalWorkflowCallProgress(row.call);
-  const usage = streamId
-    ? readStreamArtifacts(streamId)?.cumulativeUsage
-    : undefined;
-  const runStartedAt = streamPhaseFor(streamId)?.runStartedAt;
-  const parts = [
-    ...row.metadataParts,
-    live && runStartedAt !== undefined
-      ? formatCompactDuration(nowMs - runStartedAt)
-      : undefined,
-    usage && usage.outputTokens > 0
-      ? `${TOKENS_GENERATED}${formatCompactTokenCount(usage.outputTokens)}`
-      : undefined,
-    live && usage?.cost !== undefined && usage.cost > 0
-      ? formatCostUsd(usage.cost)
-      : undefined,
-  ].filter(filterNotNullish);
-  return parts.length > 0 ? parts.join(' · ') : undefined;
-}
-
 function TaskRow({
   focused,
+  live,
   nowMs,
   pendingKinds,
   row,
-  streamId,
 }: {
   readonly focused: boolean;
+  readonly live: ChildRunProgress | undefined;
   readonly nowMs: number;
   readonly pendingKinds: readonly PendingApprovalKind[] | undefined;
   readonly row: WorkflowTaskRowModel;
-  readonly streamId: StreamTabId | undefined;
 }): React.JSX.Element {
   const style = WORKFLOW_TASK_STATUS_STYLE[row.call.status];
-  const metadata = liveTaskMetadata(row, streamId, nowMs);
+  // The row's own parts name the call and, once settled, what it cost; the
+  // model's live join adds the in-flight window the card cannot carry.
+  const parts = [
+    ...row.metadataParts,
+    ...formatWorkflowCallLiveParts(row.call, live, nowMs),
+  ];
+  const metadata = parts.length > 0 ? parts.join(' · ') : undefined;
   const approval = pendingApprovalRowDisplay(pendingKinds);
   return (
     <Box flexDirection="row" height={1} minWidth={0} overflowY="hidden">
@@ -348,9 +327,7 @@ export function WorkflowPopup({
   const runStartedAt = streamPhaseFor(streamId)?.runStartedAt;
   const nowMs = useLiveNowMsSince([
     runStartedAt,
-    ...model.tasks.map(
-      (row) => streamPhaseFor(childStreamOf(row))?.runStartedAt,
-    ),
+    ...model.tasks.map((row) => model.liveOf.get(row.id)?.runStartedAt),
   ]);
 
   const identity = streamMetadataFor(streamId)?.identity;
@@ -520,9 +497,9 @@ export function WorkflowPopup({
         return (
           <TaskRow
             focused={state.focused}
+            live={model.liveOf.get(row.row.id)}
             nowMs={nowMs}
             row={row.row}
-            streamId={childStreamId}
             pendingKinds={
               childStreamId === undefined
                 ? undefined

--- a/packages/cli/src/chat/tui/panes/WorkflowPopup.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkflowPopup.tsx
@@ -32,7 +32,6 @@ import { wrapAnsiToWidth } from '@cli/tui/ansiWrap';
 // Local imports - shared schemas, model, and copy
 import {
   WORKFLOW_TASK_STATUS_LABEL,
-  isTerminalWorkflowCallProgress,
   runIdentityDisplayName,
   type StreamTabId,
   type WorkflowCallIdentity,
@@ -57,7 +56,7 @@ import {
   type WorkflowRowGroup,
   type WorkflowRunModel,
 } from '@shared/streams/workflowRunModel';
-import { filterNotNullish, formatCompactTokenCount } from '@utils/core';
+import { filterNotNullish } from '@utils/core';
 import { formatCompactDuration, formatCostUsd } from '@utils/text/stringUtils';
 
 // Local imports - TUI state and policy

--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -91,14 +91,6 @@ export function sessionStreamPhase(
   return BOUND.get()?.state.streamStatus.getStreamState(streamId);
 }
 
-/** A stream's execution state (tool-call progress, stage), off the session's
- *  own record of it. */
-export function sessionStreamExecution(
-  streamId: StreamTabId,
-): StreamExecutionState | undefined {
-  return BOUND.get()?.state.getStreamState(streamId);
-}
-
 /** Queued follow-up messages for a stream, from the session-owned queue. */
 export function queuedFollowUpsFor(streamId: StreamTabId): readonly string[] {
   return BOUND.get()?.state.followUps.getAll(streamId) ?? [];

--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -91,6 +91,14 @@ export function sessionStreamPhase(
   return BOUND.get()?.state.streamStatus.getStreamState(streamId);
 }
 
+/** A stream's execution state (tool-call progress, stage), off the session's
+ *  own record of it. */
+export function sessionStreamExecution(
+  streamId: StreamTabId,
+): StreamExecutionState | undefined {
+  return BOUND.get()?.state.getStreamState(streamId);
+}
+
 /** Queued follow-up messages for a stream, from the session-owned queue. */
 export function queuedFollowUpsFor(streamId: StreamTabId): readonly string[] {
   return BOUND.get()?.state.followUps.getAll(streamId) ?? [];

--- a/packages/cli/src/tui/ui/glyphs.ts
+++ b/packages/cli/src/tui/ui/glyphs.ts
@@ -45,7 +45,6 @@ export const ERROR_ENTRY_PREFIX = '! ';
 export const TOOL_OUTPUT_CORNER = '⎿';
 
 /** Generated-tokens marker in child-row metadata (`↓40k`). */
-export const TOKENS_GENERATED = '↓';
 
 /** 1 Hz solid/hollow blink pair for "your input is needed" prompts (approval
  *  modals) — deliberately distinct from STATUS_DOT (never animated) so the

--- a/packages/cli/src/tui/ui/glyphs.ts
+++ b/packages/cli/src/tui/ui/glyphs.ts
@@ -44,8 +44,6 @@ export const ERROR_ENTRY_PREFIX = '! ';
 /** Corner glyph that opens each tool-output block. */
 export const TOOL_OUTPUT_CORNER = '⎿';
 
-/** Generated-tokens marker in child-row metadata (`↓40k`). */
-
 /** 1 Hz solid/hollow blink pair for "your input is needed" prompts (approval
  *  modals) — deliberately distinct from STATUS_DOT (never animated) so the
  *  two never read as the same signal. Pair with `ui/LoadingIndicator`'s

--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -32,12 +32,14 @@ import '@shared/wa/spinner';
 import type {
   StreamLifecycleStatus,
   StreamLogEntry,
+  StreamTabId,
   TaskGroup,
   WorkflowPlanMarker,
 } from '@shared/schemas';
 import type { TranscriptRow } from '@shared/transcript';
 import { designTokens } from '@shared/styles';
 import { postMessage } from '@shared/hostBridge';
+import type { ChildRunProgress } from '@shared/streams/workflowRunModel';
 import { PersistedState } from '@shared/state/PersistedState';
 import { ToggleStateStore } from '@shared/state/ToggleStateStore';
 import { logListStateKey, webviewStorage } from '../webviewStorage';
@@ -64,6 +66,7 @@ const LogListStateSchema = z.object({
 interface CachedStream {
   groups: TaskGroup[];
   workflowPlan: WorkflowPlanMarker | undefined;
+  childProgress: ReadonlyMap<StreamTabId, ChildRunProgress>;
   entries: StreamLogEntry[];
   rows: TranscriptRow[];
   updatedRowIndices: readonly number[];
@@ -131,6 +134,7 @@ export class LogList extends LitElement {
       const entry = this.getOrCreateEntry(streamId);
       entry.groups = this.streamContext.taskGroups;
       entry.workflowPlan = this.streamContext.workflowPlan;
+      entry.childProgress = this.streamContext.childProgress;
       entry.entries = this.streamContext.entries;
       entry.rows = this.streamContext.rows;
       entry.updatedRowIndices = this.streamContext.updatedRowIndices;
@@ -167,6 +171,7 @@ export class LogList extends LitElement {
           ?hidden=${id !== this.activeStreamId}
           .groups=${data.groups}
           .workflowPlan=${data.workflowPlan}
+          .childProgress=${data.childProgress}
           .entries=${data.entries}
           .rows=${data.rows}
           .updatedRowIndices=${data.updatedRowIndices}
@@ -237,6 +242,7 @@ export class LogList extends LitElement {
     const createdEntry: CachedStream = {
       groups: [],
       workflowPlan: undefined,
+      childProgress: new Map(),
       entries: [],
       rows: [],
       updatedRowIndices: [],

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -15,6 +15,7 @@ import {
   type GettingStartedAction,
   type StreamLifecycleStatus,
   type StreamLogEntry,
+  type StreamTabId,
   type TaskGroup,
   type WorkflowCallProgress,
   type WorkflowPlanMarker,
@@ -30,9 +31,11 @@ import {
   workflowPhaseHeadingOfGroup,
 } from '@shared/copy/workflowCall';
 import {
+  formatWorkflowCallLiveParts,
   formatWorkflowRowGroup,
   workflowPhaseRows,
   workflowRunModel,
+  type ChildRunProgress,
   type WorkflowPhaseModel,
   type WorkflowRowGroup,
   type WorkflowRunModel,
@@ -70,7 +73,10 @@ import { playCompletionSound } from '../audioNotification';
 
 // Local imports - formatters
 import { formatLogEntry } from '../formatters';
-import { formatWorkflowDeclaredTaskTemplate } from '../formatters/logFormatters/workflowCallFormatter';
+import {
+  formatWorkflowCallTemplate,
+  formatWorkflowDeclaredTaskTemplate,
+} from '../formatters/logFormatters/workflowCallFormatter';
 import { getTimeFormatter } from '../formatters/timestampUtils';
 
 // Local imports - sibling helpers
@@ -176,6 +182,13 @@ export class TaskGroupList extends LitElement {
   @property({ attribute: false }) workflowPlan: WorkflowPlanMarker | undefined =
     undefined;
 
+  /** Live progress of this stream's children, by child stream — the model
+   *  joins it to the cards that opened them. */
+  @property({ attribute: false }) childProgress: ReadonlyMap<
+    StreamTabId,
+    ChildRunProgress
+  > = new Map();
+
   /** Toggle state store for persistence */
   @property({ attribute: false }) toggleStates: ToggleStateStore | null = null;
 
@@ -275,6 +288,7 @@ export class TaskGroupList extends LitElement {
       rowsChanged ||
       changedProperties.has('rowGeneration') ||
       changedProperties.has('workflowPlan') ||
+      changedProperties.has('childProgress') ||
       changedProperties.has('streamStatus')
     ) {
       this.rebuildRunModel();
@@ -344,6 +358,7 @@ export class TaskGroupList extends LitElement {
             rows: this.rows,
             plan: this.workflowPlan,
             runSettled: workflowRunSettled(this.streamStatus ?? undefined),
+            childProgress: this.childProgress,
           })
         : null;
     this.model = model;
@@ -548,8 +563,17 @@ export class TaskGroupList extends LitElement {
       (row) => row.key,
       (row) => {
         switch (row.kind) {
-          case 'task':
-            return this.renderLogEntry(row.row);
+          case 'task': {
+            // The card plus the model's live join for it; the board has no
+            // clock, so elapsed is left to the popup.
+            const live = this.model?.liveOf.get(row.row.id);
+            return guard([row.row, live], () =>
+              formatWorkflowCallTemplate(
+                row.row,
+                formatWorkflowCallLiveParts(row.row.call, live),
+              ),
+            );
+          }
           case 'declared':
             return formatWorkflowDeclaredTaskTemplate(row.task);
           case 'group':

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowCallFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowCallFormatter.ts
@@ -69,9 +69,11 @@ export function formatWorkflowDeclaredTaskTemplate(
   `;
 }
 
-/** Render one workflow call as a status card updated in place by log id. */
+/** Render one workflow call as a status card updated in place by log id;
+ *  `liveParts` are the in-flight segments the run model joins to it. */
 export function formatWorkflowCallTemplate(
   row: WorkflowTaskRow,
+  liveParts: readonly string[] = [],
 ): TemplateResult {
   const { call, detail } = row;
   const hasChildStream = call.childStreamId !== undefined;
@@ -102,7 +104,7 @@ export function formatWorkflowCallTemplate(
       <span class="workflow-task-icon">${statusIcon(call)}</span>
       <span class="workflow-task-body">
         <span class="workflow-task-title">${call.label}</span>
-        ${callMetadata(row.metadataParts)}
+        ${callMetadata([...row.metadataParts, ...liveParts])}
         ${
           detail
             ? html`<span

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -28,6 +28,7 @@ import {
   type TaskGroup,
 } from '@shared/schemas';
 import { isTerminalOutcomePhase } from '@shared/streams/streamStatus';
+import type { ChildRunProgress } from '@shared/streams/workflowRunModel';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { groupBy, toNewestFirstByTimestamp } from '@utils/core';
@@ -315,6 +316,43 @@ const activeStreamState$ = new Signal.Computed(() => {
   return info.agentCategory ? createStreamState(info.agentCategory) : null;
 });
 
+/**
+ * Live progress of the active stream's children, by child stream, for the
+ * workflow run model: the elapsed origin and tool-call count each child's own
+ * state carries. Compared by value so a tick on an unrelated stream — or a
+ * child update that changed neither — leaves the log alone.
+ */
+const activeChildProgress$ = new Signal.Computed(
+  (): ReadonlyMap<StreamTabId, ChildRunProgress> => {
+    const state = activeStreamState$.get();
+    const states = streamStates$.get();
+    const progress = new Map<StreamTabId, ChildRunProgress>();
+    for (const child of state?.subagents ?? []) {
+      const childState = states.get(child.childStreamId);
+      if (!childState) continue;
+      progress.set(child.childStreamId, {
+        ...(childState.runStartedAt !== undefined
+          ? { runStartedAt: childState.runStartedAt }
+          : {}),
+        toolCallCount: childState.conversationProgress.toolCallCount,
+      });
+    }
+    return progress;
+  },
+  {
+    equals: (a, b) =>
+      a.size === b.size &&
+      [...a].every(([id, live]) => {
+        const other = b.get(id);
+        return (
+          other !== undefined &&
+          other.runStartedAt === live.runStartedAt &&
+          other.toolCallCount === live.toolCallCount
+        );
+      }),
+  },
+);
+
 /** Only changes when the ACTIVE stream's logs change, not any stream. */
 const activeStreamLogs$ = new Signal.Computed(() => {
   const info = activeStreamInfo$.get();
@@ -454,6 +492,7 @@ export const logContext$ = new Signal.Computed((): StreamLogContextValue => {
     rowGeneration: streamLogs.generation,
     taskGroups: activeTaskGroups$.get(),
     workflowPlan: streamLogs.workflowPlan,
+    childProgress: activeChildProgress$.get(),
     isToolUse: activeIsToolUse$.get(),
     hasStreams,
     streamName: activeStreamInfo.name,

--- a/packages/extension/src/progressView/frontend/streamContexts.ts
+++ b/packages/extension/src/progressView/frontend/streamContexts.ts
@@ -21,6 +21,7 @@ import type {
   WorkflowPlanMarker,
 } from '@shared/schemas';
 import type { TranscriptRow } from '@shared/transcript';
+import type { ChildRunProgress } from '@shared/streams/workflowRunModel';
 
 /** Context value for stream state, providing all data needed by stream content components. */
 export interface StreamContextValue {
@@ -71,6 +72,8 @@ export interface StreamLogContextValue {
   taskGroups: TaskGroup[];
   /** The newest attempt's declared workflow plan, for the run model. */
   workflowPlan: WorkflowPlanMarker | undefined;
+  /** Live progress of the stream's children, by child stream. */
+  childProgress: ReadonlyMap<StreamTabId, ChildRunProgress>;
   isToolUse: boolean;
   hasStreams: boolean;
   /** Stream name for switch detection in LogList */
@@ -89,6 +92,7 @@ export const EMPTY_LOG_CONTEXT: StreamLogContextValue = {
   rowGeneration: 0,
   taskGroups: [],
   workflowPlan: undefined,
+  childProgress: new Map(),
   isToolUse: false,
   hasStreams: false,
   streamName: null,

--- a/src/shared/copy/workflowCall.ts
+++ b/src/shared/copy/workflowCall.ts
@@ -226,6 +226,10 @@ export const WORKFLOW_CALL_STATUS_GLYPH = {
   failed: '✗',
 } as const satisfies Record<WorkflowCallProgress['status'], string>;
 
+/** Generated-token marker, prefixed to a compact token count (`↓1.2k`)
+ *  wherever a host shows what a run has produced so far. */
+export const TOKENS_GENERATED = '↓';
+
 /** A phase the run has opened, and its hollow twin for one it has only
  *  declared. */
 export const WORKFLOW_PHASE_GLYPH = { opened: '◆', declared: '◇' } as const;

--- a/src/shared/streams/workflowRunModel.ts
+++ b/src/shared/streams/workflowRunModel.ts
@@ -15,6 +15,7 @@ import {
   STREAM_LOG_ENTRY_TYPES,
   WORKFLOW_TASK_STATUS_LABEL,
   WorkflowPlanMarkerSchema,
+  isTerminalWorkflowCallProgress,
   type StreamLogEntry,
   type StreamTabId,
   type TaskGroup,
@@ -24,11 +25,18 @@ import {
 } from '@shared/schemas';
 import type { TranscriptRow, WorkflowTaskRow } from '@shared/transcript';
 import {
+  TOKENS_GENERATED,
   latestWorkflowAttemptEntries,
   workflowCallTally,
   workflowPhaseHeadingOfGroup,
   type WorkflowPhaseHeading,
 } from '@shared/copy/workflowCall';
+import { filterNotNullish, formatCompactTokenCount } from '@utils/core';
+import {
+  formatCompactDuration,
+  formatCostUsd,
+  pluralize,
+} from '@utils/text/stringUtils';
 
 // ---------------------------------------------------------------------------
 // Markers on the transcript
@@ -111,6 +119,23 @@ export interface WorkflowRunModel {
    *  that card is the stream's only claimant. A stream two cards claim is
    *  nobody's — opening it would jump somewhere the user did not point at. */
   readonly childStreamOf: ReadonlyMap<string, StreamTabId>;
+  /** A card's child run progress, by row id, where the card has a child
+   *  stream of its own (`childStreamOf`) and the host holds that stream. */
+  readonly liveOf: ReadonlyMap<string, ChildRunProgress>;
+}
+
+/**
+ * What a child run reports about itself while it runs, read off the child's
+ * own stream by whichever host holds it — the one owner of these facts — and
+ * joined to the card that opened the child by the model (`liveOf`). Elapsed
+ * origin and tool calls come from stream state on every host; tokens and
+ * spend only where a host projects usage per stream.
+ */
+export interface ChildRunProgress {
+  readonly runStartedAt?: number;
+  readonly toolCallCount: number;
+  readonly outputTokens?: number;
+  readonly costUsd?: number;
 }
 
 export interface WorkflowRunModelInput {
@@ -124,6 +149,8 @@ export interface WorkflowRunModelInput {
    *  card under a stage, so an empty plan-only phase is its own
    *  skipped-empty-phase suppression). */
   readonly runSettled: boolean;
+  /** Live progress by child stream, for the cards that opened those streams. */
+  readonly childProgress: ReadonlyMap<StreamTabId, ChildRunProgress>;
 }
 
 interface MutablePhase {
@@ -290,8 +317,12 @@ export function workflowRunModel(
     claimants.set(childStreamId, claimants.has(childStreamId) ? null : row);
   }
   const childStreamOf = new Map<string, StreamTabId>();
+  const liveOf = new Map<string, ChildRunProgress>();
   for (const [childStreamId, row] of claimants) {
-    if (row) childStreamOf.set(row.id, childStreamId);
+    if (!row) continue;
+    childStreamOf.set(row.id, childStreamId);
+    const progress = input.childProgress.get(childStreamId);
+    if (progress) liveOf.set(row.id, progress);
   }
 
   const declaredTotal = ordered.reduce(
@@ -307,7 +338,39 @@ export function workflowRunModel(
     tasks,
     tally: tallyOf(tasks, declaredTotal),
     childStreamOf,
+    liveOf,
   };
+}
+
+/**
+ * The in-flight segments a card cannot carry itself — elapsed, generated
+ * tokens, running spend, tool calls — from the child run's own progress.
+ * Elapsed and spend show only while the call is live (a settled card carries
+ * its own duration and cost); tokens and tool calls stay, since nothing else
+ * records them. Elapsed needs a clock: a host without one passes no `nowMs`
+ * and shows the rest.
+ */
+export function formatWorkflowCallLiveParts(
+  call: WorkflowCallProgress,
+  live: ChildRunProgress | undefined,
+  nowMs?: number,
+): string[] {
+  if (!live) return [];
+  const settled = isTerminalWorkflowCallProgress(call);
+  return [
+    !settled && live.runStartedAt !== undefined && nowMs !== undefined
+      ? formatCompactDuration(nowMs - live.runStartedAt)
+      : undefined,
+    live.outputTokens !== undefined && live.outputTokens > 0
+      ? `${TOKENS_GENERATED}${formatCompactTokenCount(live.outputTokens)}`
+      : undefined,
+    !settled && live.costUsd !== undefined && live.costUsd > 0
+      ? formatCostUsd(live.costUsd)
+      : undefined,
+    live.toolCallCount > 0
+      ? `${live.toolCallCount} ${pluralize(live.toolCallCount, 'tool')}`
+      : undefined,
+  ].filter(filterNotNullish);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/test-kernel/cli/WorkflowPopup.vitest.ts
+++ b/src/test-kernel/cli/WorkflowPopup.vitest.ts
@@ -61,6 +61,7 @@ async function renderPopup(
     rows,
     plan: undefined,
     runSettled: false,
+    childProgress: new Map(),
   });
   const { ink, React } = await loadInk();
   return renderInteractive(

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -28,6 +28,7 @@ import {
   type WorkflowTaskRow,
 } from '@shared/transcript';
 import { ToggleStateStore } from '@shared/state/ToggleStateStore';
+import type { ChildRunProgress } from '@shared/streams/workflowRunModel';
 
 // Local file imports
 import {
@@ -49,6 +50,7 @@ type TaskGroupListInternals = HTMLElement & {
   terminal: boolean;
   toggleStates: ToggleStateStore | null;
   workflowPlan: WorkflowPlanMarker | undefined;
+  childProgress: ReadonlyMap<StreamTabId, ChildRunProgress>;
   updateComplete: Promise<boolean>;
   readonly index: TranscriptIndex;
   willUpdate: (changedProperties: Map<string, unknown>) => void;
@@ -142,6 +144,7 @@ function renderList(
   options: {
     toggleStates?: ToggleStateStore;
     workflowPlan?: WorkflowPlanMarker;
+    childProgress?: ReadonlyMap<StreamTabId, ChildRunProgress>;
   } = {},
 ): Promise<TaskGroupListInternals> {
   return mountComponent<TaskGroupListInternals>('task-group-list', {
@@ -757,6 +760,7 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
         label: 'Running now',
         phase: 'Map',
         status: 'running',
+        childStreamId: 'researcher@gpt#live',
       }),
     ];
     const workflowPlan: WorkflowPlanMarker = {
@@ -772,11 +776,19 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
     const list = await renderList([run, phase], rows, {
       toggleStates,
       workflowPlan,
+      childProgress: new Map([
+        ['researcher@gpt#live' as StreamTabId, { toolCallCount: 3 }],
+      ]),
     });
 
-    // The running card leads; the queued cards are one counted row until
-    // the reader opens it in place.
+    // The running card leads, carrying its child's live progress; the
+    // queued cards are one counted row until the reader opens it in place.
     const content = groupContent(list, 'phase-map');
+    expect(
+      content
+        ?.querySelector('[data-log-id="live"] .workflow-task-meta')
+        ?.textContent?.trim(),
+    ).toBe('3 tools');
     const cardsBefore = [
       ...(content?.querySelectorAll('.workflow-task') ?? []),
     ].map((card) => card.getAttribute('data-log-id'));

--- a/src/test-kernel/shared/WorkflowRunModel.vitest.ts
+++ b/src/test-kernel/shared/WorkflowRunModel.vitest.ts
@@ -16,9 +16,11 @@ import {
 } from '@shared/schemas';
 import type { WorkflowTaskRow } from '@shared/transcript';
 import {
+  formatWorkflowCallLiveParts,
   workflowMarkerOf,
   workflowPhaseRows,
   workflowRunModel,
+  type ChildRunProgress,
   type WorkflowRunModel,
 } from '@shared/streams/workflowRunModel';
 
@@ -73,7 +75,11 @@ function taskRow(task: TaskSpec): WorkflowTaskRow {
 function modelOf(
   phases: readonly string[],
   tasks: readonly TaskSpec[],
-  options: { plan?: WorkflowPlanMarker; runSettled?: boolean } = {},
+  options: {
+    plan?: WorkflowPlanMarker;
+    runSettled?: boolean;
+    childProgress?: ReadonlyMap<StreamTabId, ChildRunProgress>;
+  } = {},
 ): WorkflowRunModel {
   return workflowRunModel({
     taskGroups: phases.map((name, index) =>
@@ -82,6 +88,7 @@ function modelOf(
     rows: tasks.map(taskRow),
     plan: options.plan,
     runSettled: options.runSettled ?? false,
+    childProgress: options.childProgress ?? new Map(),
   });
 }
 
@@ -254,17 +261,46 @@ describe('workflow run model', () => {
 
   it('gives an ambiguous child stream to no card at all', () => {
     const shared = 'shared-child' as StreamTabId;
+    const own = 'own-child' as StreamTabId;
+    const live: ChildRunProgress = {
+      runStartedAt: 1_000,
+      toolCallCount: 7,
+      outputTokens: 12_000,
+      costUsd: 0.03,
+    };
     const model = modelOf(
       [],
       [
         { id: 'first', childStreamId: shared },
         { id: 'second', childStreamId: shared },
-        { id: 'third', childStreamId: 'own-child' as StreamTabId },
+        { id: 'third', childStreamId: own },
       ],
+      {
+        childProgress: new Map([
+          [shared, live],
+          [own, live],
+        ]),
+      },
     );
     expect(
       model.tasks.map((row) => model.childStreamOf.get(row.id)),
     ).toStrictEqual([undefined, undefined, 'own-child']);
+    // The live join follows the same claimant rule, and its copy is one
+    // string per fact — elapsed only with a clock, tokens and tools always.
+    expect(model.tasks.map((row) => model.liveOf.get(row.id))).toStrictEqual([
+      undefined,
+      undefined,
+      live,
+    ]);
+    const third = model.tasks[2]!;
+    expect(formatWorkflowCallLiveParts(third.call, live, 13_000)).toStrictEqual(
+      ['12s', '↓12k', '$0.030', '7 tools'],
+    );
+    expect(formatWorkflowCallLiveParts(third.call, live)).toStrictEqual([
+      '↓12k',
+      '$0.030',
+      '7 tools',
+    ]);
     // Cards outside any phase share one trailing heading.
     expect(model.phases.map((phase) => phase.heading.phaseLabel)).toStrictEqual(
       ['Unphased'],
@@ -289,6 +325,7 @@ describe('workflow run model', () => {
         rows: [taskRow({ id: 'v', phase: 'Verify' })],
         plan: undefined,
         runSettled: true,
+        childProgress: new Map(),
       }).phases[0]?.heading,
     ).toStrictEqual({ phaseLabel: 'Verify', phaseIndex: 0, phaseTotal: 1 });
   });


### PR DESCRIPTION
## What

A card for a running tool-use agent said nothing about what the agent was doing — twenty `Structured · researcher · gpt56 · Running` rows with no way to tell them apart. The facts already exist exactly once: each child's own stream state (elapsed origin, `conversationProgress.toolCallCount`) and, where a host projects usage per stream, tokens and spend. This PR **joins** them to the card instead of copying them:

- **`workflowRunModel`** takes `childProgress: ReadonlyMap<StreamTabId, ChildRunProgress>` beside `taskGroups / rows / plan / runSettled` and exposes `liveOf: ReadonlyMap<rowId, ChildRunProgress>` — the join runs through the existing `childStreamOf`, so a stream two cards claim is nobody's here too.
- **`formatWorkflowCallLiveParts(call, live, nowMs?)`** is the one spelling of the in-flight segments: `12s · ↓12k · $0.030 · 7 tools`. Elapsed needs a clock (`nowMs`); elapsed and spend show only while the call is live (a settled card carries its own duration and cost); tokens and tool calls stay, since nothing else records them.
- **CLI:** `App` reads each child's progress once off the session's own records (`streamPhaseFor`, `streamStateFor`, `readStreamArtifacts`) and hands the map to the model; the popup paints `model.liveOf` and its **private `liveTaskMetadata` read is deleted** — the popup no longer touches a stream.
- **Board:** a value-compared leaf selector `activeChildProgress$` (elapsed origin + tool count for the active stream's roster children) rides `logContext$ → LogList → TaskGroupList`; the card template takes the live parts. The board has no clock, so it shows tokens/spend/tools without elapsed — and today's board holds no per-stream usage, so in practice `· 5 tools`.
- `TOKENS_GENERATED` (`↓`) moves from the CLI glyph table to shared copy; both hosts read it there.

Not in scope, as noted in the design: a *current tool name* is not a fact anywhere yet (only a count) and would need a new emitted field on `conversation.progress`.

### Captured from the real bundle

Wide phase, live cards: `Structured · researcher · gpt56 · 2 tools` (awaiting approval), `Structured · lean-search · gpt56 · 5 tools`, `Document · polish · gemini37f · figures.tex · 1 context · 8 tools`, … — page: https://claude.ai/code/artifact/ee281655-b576-4504-8511-94a0886998da

## Net elements (R6)

`git diff --stat origin/main`:

- Production (`src/shared`, `packages/cli/src`, `packages/extension/src`): 12 files, **+224 / −59** (net +165)
- Tests: 3 files, +54 / −4
- Files: ±0
- Exported symbols: +2 (`ChildRunProgress`, `formatWorkflowCallLiveParts`) / −0; `TOKENS_GENERATED` re-homed (CLI glyphs → shared copy)
- Declarations: +1 (`ChildRunProgress`)

Net-positive, stated reason: a feature (live child progress on both hosts) built on one shared join; the only pre-existing host path for it — the popup's `liveTaskMetadata` — is deleted rather than kept beside it.

## Consumer counts (R8)

No emit path is deleted or re-routed. `liveTaskMetadata` (deleted): 2 sites in 1 file / 0 tests. `TOKENS_GENERATED` (moved): 5 sites in 3 files, all updated.

## Verified

- `npm run typecheck` — clean
- `npm run lint` (repo-wide) + prettier — clean
- vitest `src/test-kernel/{progressView,cli,shared}` — 236 files, 3,312 tests passing
- `npm run check:dead-code-ratchet` — no new findings
- `validate-tui workflow-running`, `subagent-list-focus-full-frame` — pass
- Real-bundle capture: the running and awaiting cards in a 40-card phase carry their child's tool count; no schema or console errors
- Tests: one assertion block added to the shared model suite (the join follows the claimant rule; the copy with and without a clock) and one to the board's phase test (`3 tools` on the live card)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QESykrKh1yzvF2bB4pjDrS
