### PR TITLE
refactor(progress-view): localize workflow plan grouping

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -61,6 +61,11 @@ import { buildStatusBadge } from '../formatters/htmlBuilders';
 import { processMarkdownContent } from '../formatters/markdownRenderer';
 import { getComposedPathElement } from '../utils';
 
+/**
+ * Declared phases in order, each with its declared items. Empty phases still
+ * appear, and unphased items come last. This grouping describes declarations,
+ * not which calls run together or depend on one another.
+ */
 function workflowScriptDeclaredItemsByPhase(plan: {
   readonly phases: readonly { readonly title: string }[];
   readonly tasks: readonly WorkflowCallIdentity[];

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -29,6 +29,7 @@ import type {
   AgentProposalPermission,
   PermissionPayload,
   WorkflowAgentProposalPermission,
+  WorkflowCallIdentity,
   WorkflowCallReviewScope,
 } from '@shared/schemas';
 import { AgentCategory, getProposalFileGroups } from '@shared/schemas';
@@ -36,7 +37,6 @@ import { postMessage } from '@shared/hostBridge';
 import {
   WORKFLOW_SCRIPT_PROPOSAL_COPY,
   workflowCallCardLine,
-  workflowScriptDeclaredItemsByPhase,
   workflowScriptPlanSummary,
 } from '@shared/copy/workflowScriptProposal';
 import { markdownStyles } from '@shared/styles/markdownStyles';
@@ -60,6 +60,21 @@ import { APPROVE_ALL_DELEGATED_WORK_ACTION } from '../events';
 import { buildStatusBadge } from '../formatters/htmlBuilders';
 import { processMarkdownContent } from '../formatters/markdownRenderer';
 import { getComposedPathElement } from '../utils';
+
+function workflowScriptDeclaredItemsByPhase(plan: {
+  readonly phases: readonly { readonly title: string }[];
+  readonly tasks: readonly WorkflowCallIdentity[];
+}): {
+  readonly phase?: string;
+  readonly items: readonly WorkflowCallIdentity[];
+}[] {
+  const groups = plan.phases.map((phase) => ({
+    phase: phase.title,
+    items: plan.tasks.filter((task) => task.phase === phase.title),
+  }));
+  const unphased = plan.tasks.filter((task) => task.phase === undefined);
+  return [...groups, ...(unphased.length > 0 ? [{ items: unphased }] : [])];
+}
 
 function proposalRequestIdOf(
   p: PermissionPayload | null | undefined,

--- a/src/shared/copy/workflowScriptProposal.ts
+++ b/src/shared/copy/workflowScriptProposal.ts
@@ -74,22 +74,3 @@ export function workflowScriptPlanSummary(plan: WorkflowScriptPlan): string {
   if (plan.phases.length === 0) return items;
   return `${plan.phases.length} ${plan.phases.length === 1 ? 'phase' : 'phases'} · ${items}`;
 }
-
-/**
- * Declared phases in order, each with the declared items assigned to it —
- * a phase with none still appears, since a runtime-driven script declares
- * phases and no items. Items with no phase come last under no heading.
- * Grouping is by declaration only — it says nothing about which calls run
- * together or depend on one another.
- */
-export function workflowScriptDeclaredItemsByPhase(plan: WorkflowScriptPlan): {
-  readonly phase?: string;
-  readonly items: readonly WorkflowCallIdentity[];
-}[] {
-  const groups = plan.phases.map((phase) => ({
-    phase: phase.title,
-    items: plan.tasks.filter((task) => task.phase === phase.title),
-  }));
-  const unphased = plan.tasks.filter((task) => task.phase === undefined);
-  return [...groups, ...(unphased.length > 0 ? [{ items: unphased }] : [])];
-}


### PR DESCRIPTION
## Summary

Relocate workflow declared-item grouping into the extension proposal panel, its only production consumer. Shared proposal copy and summary behavior remain shared; rendering behavior is unchanged.

## Issue acceptance gates

Closes #11605.

- removed `workflowScriptDeclaredItemsByPhase` from nominally shared copy
- moved the unchanged grouping behavior to its only consumer
- did not make the separate product decision to add phase grouping to the CLI

## Single source of truth

`ProposalRequestPanel.ts` now owns extension-only grouping of workflow plan labels. `workflowScriptProposal.ts` remains the shared owner for copy and the cross-host plan summary.

## Duplication and abstraction budget

Removed one shared export and introduced no new abstraction or duplicate implementation.

## Net elements (R6)

- files: 0 added, 0 deleted, 2 modified
- exported symbols: 0 added, 1 deleted
- classes/interfaces/enums: no change
- net LoC: -15

## Consumer counts (R8)

Repo-wide grep found exactly 1 production consumer of `workflowScriptDeclaredItemsByPhase`, the extension's `ProposalRequestPanel.ts`. After relocation, grep finds one local definition and one local call.

## Host impact

Extension: Internal helper relocation only; rendered output is unchanged.

Desktop: Inherits the same extension progress-view rendering with no behavior change.

CLI: No change. Shared proposal summary and copy exports remain available.

## Scheduled refactoring

None.

## Validation

- `npx vitest run --config vitest.config.mjs src/test-kernel/progressView/ProposalRequestPanel.vitest.ts` (9 passed)
- `npx eslint packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts src/shared/copy/workflowScriptProposal.ts`
- `npx tsc --noEmit --checkers 8 -p tsconfig.test-kernel.json`
