### PR TITLE
fix(workflow): list finished calls as ticked rows instead of folding them

### DIFF
--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -550,8 +550,9 @@ export class TaskGroupList extends LitElement {
 
   /**
    * One phase's cards in the model's order — the CLI popup's order: cards
-   * needing attention first, the rest as counted groups that open in place,
-   * and the plan's tasks the run has not issued yet.
+   * needing attention first, finished cards as ticked rows, the unstarted
+   * ones as counted groups that open in place, and the plan's tasks the run
+   * has not issued yet.
    */
   private renderPhaseRows(phase: WorkflowPhaseModel): TemplateResult {
     const rows = workflowPhaseRows(phase, {

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -112,7 +112,7 @@ function getStatusIcon(status: string): TeXRAIconName {
   }
 }
 
-const WORKFLOW_ROW_GROUPS = ['queued', 'done', 'declared'] as const;
+const WORKFLOW_ROW_GROUPS = ['queued', 'declared'] as const;
 
 /** Toggle-store key of one phase's counted group of quiet cards. */
 function rowGroupToggleKey(phaseKey: string, group: WorkflowRowGroup): string {

--- a/src/shared/streams/workflowRunModel.ts
+++ b/src/shared/streams/workflowRunModel.ts
@@ -378,11 +378,10 @@ export function formatWorkflowCallLiveParts(
 // ---------------------------------------------------------------------------
 
 /** The counted groups a phase's quiet rows collapse into. */
-export type WorkflowRowGroup = 'queued' | 'done' | 'declared';
+export type WorkflowRowGroup = 'queued' | 'declared';
 
 const WORKFLOW_ROW_GROUP_LABEL = {
   queued: 'queued',
-  done: 'done',
   declared: 'declared',
 } as const satisfies Record<WorkflowRowGroup, string>;
 
@@ -451,9 +450,10 @@ function matchesFilter(
 /**
  * One phase's rows. With a filter every matching card is one flat row;
  * without one, cards needing attention (awaiting approval, failed, running —
- * in that order, transcript order within) lead, and the rest collapse into
- * `queued` / `done` / `declared` groups that open in place. Screen rows scale
- * with states, not with agents.
+ * in that order, transcript order within) lead, finished cards follow as
+ * rows of their own (a ticked box is the record of what ran), and the cards
+ * that have not started collapse into `queued` / `declared` groups that open
+ * in place.
  */
 export function workflowPhaseRows(
   phase: WorkflowPhaseModel,
@@ -521,8 +521,8 @@ export function workflowPhaseRows(
   };
   return [
     ...attentionRows,
+    ...done.map(taskRowOf),
     ...groupRows('queued', queued.map(taskRowOf)),
-    ...groupRows('done', done.map(taskRowOf)),
     ...groupRows('declared', phase.declaredTasks.map(declaredRowOf)),
   ];
 }

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -339,7 +339,7 @@ describe('App foreground Escape ownership', () => {
       expect(activeStreamId.get()).toBe(ROOT);
       // View state the user set inside the popup survives the round trips
       // below; only opening a different workflow would start fresh.
-      updateWorkflowPopupView({ expanded: new Set(['done']) });
+      updateWorkflowPopupView({ expanded: new Set(['queued']) });
 
       // An approval bound to the workflow stream surfaces over the popup,
       // and the popup comes back once it is answered.
@@ -367,7 +367,7 @@ describe('App foreground Escape ownership', () => {
         timeoutMs: 1_000,
       });
       await waitFor(() => foregroundReader.get()?.kind === 'workflow');
-      expect(workflowPopupView.get().expanded.has('done')).toBe(true);
+      expect(workflowPopupView.get().expanded.has('queued')).toBe(true);
       expect(onInterruptStream).not.toHaveBeenCalled();
     } finally {
       instance.unmount();

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -597,11 +597,7 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
       }),
     ];
 
-    // The finished cards sit in the phase's "done" group; open it so the
-    // cards below are in the DOM (`false` = expanded, as for task groups).
-    const toggleStates = new ToggleStateStore();
-    toggleStates.set('phase-review#done', false);
-    const list = await renderList([run, phase], rows, { toggleStates });
+    const list = await renderList([run, phase], rows);
 
     // Header shows the phase label plus the one-based position, matching the
     // CLI's `(index+1/total)` diamond header.

--- a/src/test-kernel/shared/WorkflowRunModel.vitest.ts
+++ b/src/test-kernel/shared/WorkflowRunModel.vitest.ts
@@ -166,7 +166,7 @@ describe('workflow run model', () => {
       );
 
     // Awaiting approval, then failed, then running — transcript order within
-    // each — and one row per quiet group.
+    // each — then the finished cards as rows, and one row per unstarted group.
     expect(
       summarize(workflowPhaseRows(phase, { expanded: new Set(), filter: '' })),
     ).toStrictEqual([
@@ -174,8 +174,9 @@ describe('workflow run model', () => {
       'task:task-bad',
       'task:task-r1',
       'task:task-r2',
+      'task:task-ok1',
+      'task:task-ok2',
       '▸ 2 queued',
-      '▸ 2 done',
       '▸ 1 declared',
     ]);
     // An opened group lists its members under its header, in place.
@@ -188,10 +189,11 @@ describe('workflow run model', () => {
       'task:task-bad',
       'task:task-r1',
       'task:task-r2',
+      'task:task-ok1',
+      'task:task-ok2',
       '▾ 2 queued',
       'task:task-q1',
       'task:task-q2',
-      '▸ 2 done',
       '▸ 1 declared',
     ]);
     // A filter is one flat list of matches, groups and all.


### PR DESCRIPTION
## What

Owner feedback on a live run: finished calls folded into `▸ 7 done` should stay listed — tick the box, do not hide the row.

`workflowPhaseRows` (the shared model, so the popup and the board change together) now orders a phase as: attention rows (awaiting approval, failed, running), then every finished call as its own row in transcript order (`☑`/`✓`/`⊘`/`✗`), then the counted `▸ N queued` / `▸ N declared` groups for what has not started. `WorkflowRowGroup` loses its `done` member; the board's toggle-key list follows.

## Net elements (R6)

`git diff --stat origin/main`: production 2 files, +7 / −7; tests 3 files, +8 / −10. Exports ±0; `WorkflowRowGroup` narrowed by one member.

## Consumer counts (R8)

No emit path deleted. `'done'` group consumers at `origin/main` (prod / test): the model's own fold, the board's `WORKFLOW_ROW_GROUPS` list, three test expectations — all updated here.

## Verified

- CLI + extension typecheck clean; eslint + prettier clean on changed files
- vitest `src/test-kernel/{shared,cli,progressView}` — 236 files, 3,312 tests passing
- `validate-tui workflow-running` — pass (real TUI, ttyd frames)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QESykrKh1yzvF2bB4pjDrS