### PR TITLE
feat(cli): refine session status and goal controls

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -78,6 +78,7 @@ import {
   closeForegroundReader,
   foregroundReader as foregroundReaderSignal,
   formProgress as formProgressSignal,
+  goalAutoApproveAll as goalAutoApproveAllSignal,
   infoPane as infoPaneSignal,
   openTranscriptReader,
   openWorkflowPopup,
@@ -183,6 +184,7 @@ export function App(props: AppProps): React.JSX.Element {
   const subagentExecutionLabels = useSignal(subagentExecutionLabelsSignal);
   const activeForm = useSignal(activeFormSignal);
   const formProgress = useSignal(formProgressSignal);
+  const goalAutoApproveAll = useSignal(goalAutoApproveAllSignal);
   const infoPane = useSignal(infoPaneSignal);
   const foregroundReader = useSignal(foregroundReaderSignal);
   const slashPaletteOpen = useSignal(slashPaletteOpenSignal);
@@ -485,7 +487,11 @@ export function App(props: AppProps): React.JSX.Element {
         ) : null;
       case 'approval':
         return activeApprovalVisible && pending ? (
-          <ApprovalModal pending={pending} availableRows={availableRows} />
+          <ApprovalModal
+            availableRows={availableRows}
+            goalAutoApproveAll={goalAutoApproveAll}
+            pending={pending}
+          />
         ) : null;
       case 'transcriptReader': {
         if (foregroundReader?.kind !== 'transcript') return null;

--- a/packages/cli/src/chat/tui/commands/helpText.ts
+++ b/packages/cli/src/chat/tui/commands/helpText.ts
@@ -18,7 +18,7 @@ export const GOAL_MODE_HELP = [
   'Ask the agent to create a plan, then choose `r run as goal` in the plan approval panel. ' +
     'The active goal keeps the agent working across turns until it verifies completion, pauses, or you stop it.',
   '',
-  'Use `/status` to inspect the active session. Goal mode auto-approves bash only; edits and other approvals still ask.',
+  'Use `/goal` to choose whether goal mode auto-approves commands only or all goal work (commands, file edits, and delegated work). Other prompts still ask. Use `/status` to inspect the active session.',
 ].join('\n');
 
 // Help sections in display order; `undefined` collects uncategorized

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -28,6 +28,7 @@ import { ApprovalPolicyForm } from '../forms/ApprovalPolicyForm';
 import { CliConfigForm } from '../forms/CliConfigForm';
 import { MemoryListForm } from '../forms/MemoryListForm';
 import { EnabledModelsForm } from '../forms/EnabledModelsForm';
+import { GoalModeForm } from '../forms/GoalModeForm';
 import { ModelListForm } from '../forms/ModelListForm';
 import { ProviderApiKeyForm } from '../forms/ProviderApiKeyForm';
 import { ResumeListForm } from '../forms/ResumeListForm';
@@ -35,6 +36,7 @@ import { SkillsListForm, type SkillActivation } from '../forms/SkillsListForm';
 import { ToolsListForm } from '../forms/ToolsListForm';
 import {
   formProgress,
+  goalAutoApproveAll,
   patchSessionMeta,
   sessionMeta,
   setTransientNotice,
@@ -393,6 +395,20 @@ export function registerBuiltinSlashCommands(options?: {
     );
   }
 
+  function GoalModeFormAdapter(props: SlashFormProps): React.JSX.Element {
+    return (
+      <GoalModeForm
+        autoApproveAll={goalAutoApproveAll.get()}
+        availableRows={props.availableRows}
+        onToggle={(enabled) => {
+          goalAutoApproveAll.set(enabled);
+          props.onDone(enabled);
+        }}
+        onClose={() => props.onDone(undefined)}
+      />
+    );
+  }
+
   function ProviderApiKeyFormAdapter(props: SlashFormProps): React.JSX.Element {
     return (
       <ProviderApiKeyForm
@@ -620,11 +636,12 @@ export function registerBuiltinSlashCommands(options?: {
   });
   registerSlashCommand({
     name: 'goal',
-    description: 'Explain autonomous goal mode',
+    description: 'Configure autonomous goal mode',
     aliases: ['goals'],
     category: 'session',
     echo: 'never',
     handler: showCliGoalModeHelp,
+    formComponent: GoalModeFormAdapter,
   });
   registerSlashCommand({
     name: 'resume',

--- a/packages/cli/src/chat/tui/forms/GoalModeForm.tsx
+++ b/packages/cli/src/chat/tui/forms/GoalModeForm.tsx
@@ -1,0 +1,47 @@
+import { Text } from 'ink';
+
+import type { SelectItem } from '@cli/tui/ui/Select';
+
+import { ListForm } from './_shared/ListForm';
+
+export interface GoalModeFormProps {
+  readonly autoApproveAll: boolean;
+  readonly availableRows?: number;
+  readonly onToggle: (enabled: boolean) => void;
+  readonly onClose: () => void;
+}
+
+function toggleDescription(enabled: boolean): string {
+  return enabled
+    ? 'On · commands, file edits, and delegated work; other prompts still ask'
+    : 'Off · commands only; edits and other prompts still ask';
+}
+
+/** Goal-mode reference and its session-local approval-scope toggle. */
+export function GoalModeForm(props: GoalModeFormProps): React.JSX.Element {
+  const items: ReadonlyArray<SelectItem<boolean>> = [
+    {
+      value: !props.autoApproveAll,
+      label: 'Auto-approve all goal work',
+      description: toggleDescription(props.autoApproveAll),
+    },
+  ];
+  return (
+    <ListForm
+      title="/goal"
+      compactTitle="/goal · Configure autonomous goal mode."
+      availableRows={props.availableRows}
+      items={items}
+      compactVisibleItems={1}
+      description={
+        <Text dimColor>
+          Run an approved plan until it finishes, pauses, or you stop it.
+        </Text>
+      }
+      selectMarginTop={1}
+      action="toggle"
+      onSelect={props.onToggle}
+      onCancel={props.onClose}
+    />
+  );
+}

--- a/packages/cli/src/chat/tui/modals/ApprovalModal.tsx
+++ b/packages/cli/src/chat/tui/modals/ApprovalModal.tsx
@@ -16,6 +16,7 @@ import type { PendingApproval } from '../state/approvalQueue';
 
 export interface ApprovalModalProps {
   readonly availableRows?: number;
+  readonly goalAutoApproveAll: boolean;
   readonly pending: PendingApproval | undefined;
 }
 
@@ -45,6 +46,7 @@ export function ApprovalModal(
     case 'planApproval':
       return (
         <PlanApproval
+          autoApproveAll={props.goalAutoApproveAll}
           availableRows={availableRows}
           payload={payload.data}
           onDecide={decide}

--- a/packages/cli/src/chat/tui/modals/PlanApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/PlanApproval.tsx
@@ -21,6 +21,7 @@ import { confirmCardCompactChromeRows } from './ConfirmCardState';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
 export interface PlanApprovalProps {
+  readonly autoApproveAll: boolean;
   readonly availableRows?: number;
   readonly payload: PlanApprovalPermission;
   readonly onDecide: (decision: ApprovalDecision) => void;
@@ -49,10 +50,18 @@ export function isCompactPlanApprovalRows(
   );
 }
 
-export function planApprovalGoalNoticeLine(width: number): string {
+export function planApprovalGoalNoticeLine(
+  width: number,
+  autoApproveAll = false,
+): string {
   const lineWidth = Math.max(1, width);
   return fillRows(
-    truncateToWidth(PLAN_GOAL_COPY.cliNotice, lineWidth),
+    truncateToWidth(
+      autoApproveAll
+        ? PLAN_GOAL_COPY.cliAutoApproveAllNotice
+        : PLAN_GOAL_COPY.cliNotice,
+      lineWidth,
+    ),
     lineWidth,
   );
 }
@@ -93,7 +102,7 @@ export function PlanApproval(props: PlanApprovalProps): React.JSX.Element {
   const { columns } = useWindowSize();
   const [feedbackMode, setFeedbackMode] = useState(false);
   const [feedbackValue, setFeedbackValue] = useState('');
-  const { availableRows, onDecide, payload } = props;
+  const { autoApproveAll, availableRows, onDecide, payload } = props;
   const { goalEnabled, plan } = payload;
   const compact = isCompactPlanApprovalRows(availableRows, goalEnabled);
   const contentWidth = clampModalWidth(
@@ -147,6 +156,7 @@ export function PlanApproval(props: PlanApprovalProps): React.JSX.Element {
                 label: PLAN_APPROVAL_GOAL_ACTION.action,
                 decision: {
                   accepted: true,
+                  ...(autoApproveAll ? { goalAutoApproveAll: true } : {}),
                   planAction: 'approve_and_goal',
                 },
               },
@@ -159,7 +169,7 @@ export function PlanApproval(props: PlanApprovalProps): React.JSX.Element {
       onDecide={onDecide}
     >
       {compact && goalNoticeVisible && (
-        <Text>{planApprovalGoalNoticeLine(contentWidth)}</Text>
+        <Text>{planApprovalGoalNoticeLine(contentWidth, autoApproveAll)}</Text>
       )}
       <ScrollableModalText
         hiddenNoun={PLAN_APPROVAL_HIDDEN_NOUN}
@@ -175,7 +185,9 @@ export function PlanApproval(props: PlanApprovalProps): React.JSX.Element {
       {!compact && goalNoticeVisible && (
         <Box flexDirection="column">
           <Text> </Text>
-          <Text>{planApprovalGoalNoticeLine(contentWidth)}</Text>
+          <Text>
+            {planApprovalGoalNoticeLine(contentWidth, autoApproveAll)}
+          </Text>
         </Box>
       )}
     </ConfirmCard>

--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -45,6 +45,7 @@ function TodoRow({ todo }: { readonly todo: TodoItem }): React.JSX.Element {
 
 export type CompactTodosPlanRow =
   | { kind: 'todo'; sourceIndex: number; todo: TodoItem }
+  | { kind: 'completedSummary'; sourceIndex: number; count: number }
   | { kind: 'planSummary'; sourceIndex: number; summary: string };
 
 // Sort priority by (row kind, status). The map is total, so a new status
@@ -55,12 +56,22 @@ const COMPACT_TODO_ROW_PRIORITY: Record<TodoStatus, number> = {
   [TODO_STATUS.PENDING]: 1,
   [TODO_STATUS.COMPLETED]: 4,
 };
+const COMPLETED_SUMMARY_PRIORITY = 2;
 const PLAN_SUMMARY_PRIORITY = 5;
 
 function compactRowPriority(row: CompactTodosPlanRow): number {
-  return row.kind === 'todo'
-    ? COMPACT_TODO_ROW_PRIORITY[row.todo.status]
-    : PLAN_SUMMARY_PRIORITY;
+  switch (row.kind) {
+    case 'todo':
+      return COMPACT_TODO_ROW_PRIORITY[row.todo.status];
+    case 'completedSummary':
+      return COMPLETED_SUMMARY_PRIORITY;
+    case 'planSummary':
+      return PLAN_SUMMARY_PRIORITY;
+  }
+}
+
+function representedSourceRows(row: CompactTodosPlanRow): number {
+  return row.kind === 'completedSummary' ? row.count : 1;
 }
 
 export function compactTodosPlanRows({
@@ -96,10 +107,30 @@ export function compactTodosPlanRows({
     return { hiddenCount: allRows.length, rows: [] };
   }
 
+  // Once the full checklist no longer fits, completed history becomes one
+  // quiet count. Keep the current and remaining work as individual rows.
+  const completedRows = allRows.filter(
+    (row) => row.kind === 'todo' && row.todo.status === TODO_STATUS.COMPLETED,
+  );
+  const compactRows = allRows.filter(
+    (row) => row.kind !== 'todo' || row.todo.status !== TODO_STATUS.COMPLETED,
+  );
+  if (completedRows.length > 0) {
+    compactRows.push({
+      kind: 'completedSummary',
+      sourceIndex: completedRows.at(-1)?.sourceIndex ?? 0,
+      count: completedRows.length,
+    });
+    compactRows.sort((left, right) => left.sourceIndex - right.sourceIndex);
+  }
+  if (compactRows.length <= rowBudget) {
+    return { hiddenCount: 0, rows: compactRows };
+  }
+
   // At one row, show the highest-signal item instead of spending the only row
   // on the hidden-count marker.
   const visibleCount = rowBudget === 1 ? 1 : rowBudget - 1;
-  const rows = [...allRows]
+  const rows = [...compactRows]
     .sort(
       (left, right) =>
         compactRowPriority(left) - compactRowPriority(right) ||
@@ -109,7 +140,9 @@ export function compactTodosPlanRows({
     .sort((left, right) => left.sourceIndex - right.sourceIndex);
 
   return {
-    hiddenCount: allRows.length - rows.length,
+    hiddenCount: compactRows
+      .filter((row) => !rows.includes(row))
+      .reduce((count, row) => count + representedSourceRows(row), 0),
     rows,
   };
 }
@@ -130,6 +163,14 @@ function CompactRow({ row }: { row: CompactTodosPlanRow }): React.JSX.Element {
   switch (row.kind) {
     case 'todo':
       return <TodoRow todo={row.todo} />;
+    case 'completedSummary':
+      return (
+        <Box height={1} minWidth={0} overflowY="hidden">
+          <Text color={COLOR_SUCCESS} dimColor wrap="truncate-end">
+            {TODO_DONE} {row.count} completed
+          </Text>
+        </Box>
+      );
     case 'planSummary':
       return (
         <Box height={1} minWidth={0} overflowY="hidden">

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -90,6 +90,8 @@ export interface ApprovalDecision extends Readonly<SharedApprovalDecision> {
   readonly disableQuotaRoute?: QuotaFallbackRouteId;
   /** Plan-only approval action when plain approve/reject is not specific enough. */
   readonly planAction?: Extract<PlanApprovalAction, 'approve_and_goal'>;
+  /** Run-as-goal only: extend automatic commands to edits and delegated work. */
+  readonly goalAutoApproveAll?: true;
 }
 
 export interface PendingApproval {

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -381,6 +381,9 @@ export const activeForm: Signal.State<ActiveSlashForm | undefined> = signal<
   ActiveSlashForm | undefined
 >(undefined);
 
+/** Session-local approval scope captured by the next Run as Goal action. */
+export const goalAutoApproveAll = signal(false);
+
 interface InfoPaneContent {
   readonly title: string;
   readonly lines: readonly string[];
@@ -781,6 +784,7 @@ export function resetCliState(
   rootRunPending.set(false);
   rootRunStreamId.set(undefined);
   activeForm.set(undefined);
+  goalAutoApproveAll.set(false);
   INFO_PANE_QUEUE.set([]);
   FOREGROUND_READER.set(undefined);
   WORKFLOW_POPUP_VIEW.set({

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -315,7 +315,10 @@ async function requestPlanInteraction(
   // `approve_and_goal` is a TUI-only plan action; every other outcome is the
   // shared approve/reject settlement.
   if (decision.accepted && decision.planAction) {
-    return { action: decision.planAction };
+    return {
+      action: decision.planAction,
+      ...(decision.goalAutoApproveAll ? { autoApproveAll: true } : {}),
+    };
   }
   return toApprovalSettlement(decision);
 }

--- a/packages/cli/src/chat/tui/terminalTitle.ts
+++ b/packages/cli/src/chat/tui/terminalTitle.ts
@@ -13,6 +13,7 @@ import { isActivePhase } from '@shared/streams/streamStatus';
 import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
 
 import { approvalQueueStatus } from './state/approvalQueue';
+import { sessionStateRevision } from './state/childExecutions';
 import {
   rootRunPending,
   rootRunStreamId,
@@ -136,7 +137,13 @@ export function installTerminalTitleUpdates(
     updateTitle(terminalTitleText(cwd));
   };
   const unsubscribe = subscribeToSignalChanges(
-    [approvalQueueStatus, rootRunPending, rootRunStreamId, streams],
+    [
+      approvalQueueStatus,
+      rootRunPending,
+      rootRunStreamId,
+      sessionStateRevision,
+      streams,
+    ],
     synchronize,
   );
   synchronize();

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -56,7 +56,7 @@ export const chatCommand = withUsageSections(
       rows: [
         ['/help', 'show slash commands inside chat'],
         ['/status', 'show session state'],
-        ['/goal', 'explain autonomous goal mode and approved-plan startup'],
+        ['/goal', 'configure autonomous goal mode and auto-approval scope'],
         ['/login, /logout', 'sign in or out of ChatGPT or Researcher Access'],
         [
           'Ctrl-T',

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -9,7 +9,7 @@ import {
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import { USER_VAR_INSTRUCTION } from '@agent/prompt/userVars';
 import { STREAM_PHASE } from '@shared/schemas';
-import { GoalStore, setGoalSessionBashAutoApproval } from '@tools/goal';
+import { GoalStore, setGoalSessionAutoApproval } from '@tools/goal';
 
 import type { ToolUseServices } from '../ToolUseServices';
 import type { ToolUseRunShared, WaitExecResult } from './types';
@@ -210,7 +210,7 @@ export class ToolUseWaitNode extends BaseNode<
     // Route the bypass mutation through the session this flow already owns
     // (`runScope.session`) rather than `currentSession()`, so the goal-pause
     // path stays drivable without an ambient RunContext/ALS frame.
-    await setGoalSessionBashAutoApproval(streamId, false, {
+    await setGoalSessionAutoApproval(streamId, false, {
       session: this.services.runScope.session,
     });
     emitRunFact(this.services.logger, 'goalPaused', { streamId });

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -133,7 +133,11 @@ type NoRejectionProvenance = {
 
 export type PlanApprovalResult =
   | ({ action: 'approve' } & NoRejectionProvenance)
-  | ({ action: 'approve_and_goal' } & NoRejectionProvenance)
+  | ({
+      action: 'approve_and_goal';
+      /** Auto-approve commands, edits, and delegated work for this goal. */
+      autoApproveAll?: true;
+    } & NoRejectionProvenance)
   | ({ action: 'reject' } & RejectionProvenance);
 
 export type ProposalResult =

--- a/src/shared/copy/delegationApproval.ts
+++ b/src/shared/copy/delegationApproval.ts
@@ -16,14 +16,16 @@ export const DELEGATION_APPROVAL_COPY = Object.freeze({
 } as const);
 
 /**
- * Host-specific user copy for the plan "Run as Goal" grant. Both hosts state
- * the same rule, owned by `goalAutoApproval.ts`: a goal run auto-approves Bash
- * and nothing else. `progressViewExplanation` is the clause that follows the
- * bolded action name in the panel, so it opens mid-sentence.
+ * Host-specific user copy for the plan "Run as Goal" grant. Commands-only is
+ * the shared default; the CLI may explicitly broaden one goal to commands,
+ * edits, and delegated work. `progressViewExplanation` is the clause that
+ * follows the bolded action name in the panel, so it opens mid-sentence.
  */
 export const PLAN_GOAL_COPY = Object.freeze({
   action: 'Run as Goal',
   progressViewExplanation:
     'keeps the agent working across turns until it completes the plan, needs your input, or you stop it. Only Bash commands are auto-approved; edits and other actions still ask.',
   cliNotice: 'Runs until done; only Bash is automatic.',
+  cliAutoApproveAllNotice:
+    'Runs until done; commands, edits, and agent work are automatic.',
 } as const);

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -420,9 +420,9 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
-      // No AsyncLocalStorage frame: `pauseActiveGoal` routes the bash bypass
-      // mutation through `services.runScope.session` (the owner session), never
-      // through `currentSession()`/`defaultSession()`.
+      // No AsyncLocalStorage frame: `pauseActiveGoal` clears every possible
+      // goal bypass through `services.runScope.session` (the owner session),
+      // never through `currentSession()`/`defaultSession()`.
       const exec = await node.exec(waitPrep(true));
 
       const goal = GoalStore.getForStream(streamId);
@@ -439,9 +439,14 @@ describe('ToolUseWaitNode', () => {
         kind: 'bash',
         bypassActive: false,
       });
-      expect(setApprovalBypassState).not.toHaveBeenCalledWith({
+      expect(setApprovalBypassState).toHaveBeenCalledWith({
         streamId,
         kind: 'toolEdit',
+        bypassActive: false,
+      });
+      expect(setApprovalBypassState).toHaveBeenCalledWith({
+        streamId,
+        kind: 'superYolo',
         bypassActive: false,
       });
     } finally {

--- a/src/test-kernel/cli/CliRootArgs.vitest.ts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.ts
@@ -1321,7 +1321,7 @@ describe('runCli usage output stream routing', () => {
     expect(stdout).toContain('/status');
     expect(stdout).toContain('/goal');
     expect(stdout).toContain(
-      'explain autonomous goal mode and approved-plan startup',
+      'configure autonomous goal mode and auto-approval scope',
     );
     expect(stdout).toContain('/login, /logout');
     expect(stdout).toContain('ChatGPT or Researcher Access');

--- a/src/test-kernel/cli/PlanApproval.vitest.ts
+++ b/src/test-kernel/cli/PlanApproval.vitest.ts
@@ -98,6 +98,12 @@ describe('CLI plan approval layout', () => {
     expect(PLAN_GOAL_COPY.cliNotice.length).toBeLessThanOrEqual(40);
   });
 
+  it('explains the broader goal approval scope without claiming every prompt', () => {
+    expect(PLAN_GOAL_COPY.cliAutoApproveAllNotice).toContain('commands');
+    expect(PLAN_GOAL_COPY.cliAutoApproveAllNotice).toContain('edits');
+    expect(PLAN_GOAL_COPY.cliAutoApproveAllNotice).toContain('agent work');
+  });
+
   it('keeps the goal explanation to one display row on narrow cards', () => {
     const notice = planApprovalGoalNoticeLine(40);
 

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -302,10 +302,7 @@ describe('handleTuiSlashCommand', () => {
 
     closeInfoPane();
     await handleTuiSlashCommand('/goal', context);
-    expect(infoPane.get()).toMatchObject({ title: '/goal' });
-    expect(infoPane.get()?.lines.join('\n')).toContain(
-      'Goal mode starts from an approved plan',
-    );
+    expect(activeForm.get()).toMatchObject({ commandName: 'goal' });
     expect(localEntries()).toEqual([]);
   });
 

--- a/src/test-kernel/cli/SlashHelpText.vitest.ts
+++ b/src/test-kernel/cli/SlashHelpText.vitest.ts
@@ -35,7 +35,7 @@ describe('formatSlashCommandHelp', () => {
     // collapse in the help surface's markdown renderer, list items do not.
     expect(help).toContain('- `/clear` — Start a fresh chat session');
     expect(help).toContain(
-      '- `/goal` (`/goals`) — Explain autonomous goal mode',
+      '- `/goal` (`/goals`) — Configure autonomous goal mode',
     );
     expect(help).toContain('- `/plan` — Read the focused session work plan');
     expect(help).toContain('- `/exit` (`/quit`) — Exit the CLI session');

--- a/src/test-kernel/cli/TerminalCleanup.vitest.ts
+++ b/src/test-kernel/cli/TerminalCleanup.vitest.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
   bindChildStreamState,
+  invalidateChildStreams,
   unbindChildStreamState,
 } from '@cli/chat/tui/state/childExecutions';
 
@@ -31,7 +32,10 @@ import {
 } from '@cli/chat/tui/terminalTitle';
 import { SessionState } from '@controllers/session/SessionState';
 import { STREAM_PHASE } from '@shared/schemas';
-import { clearAllStreamStatusesForTest } from '@test/support/streamStatusTestUtils';
+import {
+  clearAllStreamStatusesForTest,
+  seedStreamStatusForTest,
+} from '@test/support/streamStatusTestUtils';
 import { setCliStreamPhase } from '@test/support/cliStreamStatus';
 
 vi.mock('node:fs', async (importOriginal) => ({
@@ -244,6 +248,32 @@ describe('installTerminalTitleUpdates', () => {
     expectLastTitle('⠴ {T}·coauthor');
     updates.dispose();
     expectNoTitleWrites();
+  });
+
+  it('returns to idle when only the canonical stream phase changes', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    enableOscTitles();
+    const updates = installTerminalTitleUpdates('/work/coauthor');
+    setCliStreamPhase({
+      streamId: 'status-only-root',
+      status: STREAM_PHASE.RUNNING,
+    });
+    await flushTitleUpdate();
+    expectLastTitle('⠋ {T}·coauthor');
+
+    // Status is no longer mirrored into `streams`: production publishes this
+    // repaint revision after the machine changes, without rewriting the CLI
+    // slice. The title must subscribe to that same revision as the status bar.
+    seedStreamStatusForTest(defaultSession().status, 'status-only-root', {
+      phase: STREAM_PHASE.WAITING,
+    });
+    invalidateChildStreams();
+    await flushTitleUpdate();
+
+    expectLastTitle('{T}·coauthor');
+    expectNoTitleWrites();
+    updates.dispose();
   });
 
   it('deduplicates unchanged title projections and resets an active title on teardown', async () => {

--- a/src/test-kernel/cli/TodosPlanPanel.vitest.ts
+++ b/src/test-kernel/cli/TodosPlanPanel.vitest.ts
@@ -10,6 +10,8 @@ function rowKey(row: CompactTodosPlanRow): string {
   switch (row.kind) {
     case 'todo':
       return `todo:${row.todo.content}`;
+    case 'completedSummary':
+      return `completed:${row.count}`;
     case 'planSummary':
       return 'plan:summary';
   }
@@ -97,10 +99,42 @@ describe('CLI TodosPlanPanel display model', () => {
       todos: [todos[0]],
     });
 
+    expectRows(display, ['completed:1'], 1);
+  });
+
+  it('collapses completed history and keeps the actionable tail visible', () => {
+    const completed = Array.from({ length: 7 }, (_, index): TodoItem => ({
+      content: `Completed optimization ${index + 1}`,
+      activeForm: `Completing optimization ${index + 1}`,
+      status: TODO_STATUS.COMPLETED,
+    }));
+    const display = compactTodosPlanRows({
+      maxRows: 8,
+      plan,
+      todos: [
+        ...completed,
+        {
+          content: 'Finish active CPSV16 pull request validation',
+          activeForm: 'Finishing active CPSV16 pull request validation',
+          status: TODO_STATUS.IN_PROGRESS,
+        },
+        {
+          content: 'Publish the validated result',
+          activeForm: 'Publishing the validated result',
+          status: TODO_STATUS.PENDING,
+        },
+      ],
+    });
+
     expectRows(
       display,
-      ['todo:Split theorem into algebraic and analytic checks'],
-      1,
+      [
+        'completed:7',
+        'todo:Finish active CPSV16 pull request validation',
+        'todo:Publish the validated result',
+        'plan:summary',
+      ],
+      0,
     );
   });
 });

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
@@ -126,7 +126,7 @@ import {
 } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { createTuiCliContext } from '@test/cli/fixtures/cliContext';
-import { setGoalSessionBashAutoApproval } from '@tools/goal';
+import { setGoalSessionAutoApproval } from '@tools/goal';
 import {
   isApprovalBypassedForStream,
   isBashApprovalBypassedForStream,
@@ -487,9 +487,9 @@ describe('TUI retry approvals', () => {
     });
   });
 
-  it('updates TUI bash bypass state when goal auto-approval is enabled and cleared', async () => {
+  it('updates TUI command bypass state when goal auto-approval is enabled and cleared', async () => {
     const { presentationHost } = tui();
-    await setGoalSessionBashAutoApproval('goal-bypass-stream', true);
+    await setGoalSessionAutoApproval('goal-bypass-stream', 'commands');
     expect(streams.get().get('goal-bypass-stream')?.bypass.bash).toBe(true);
     expect(presentationHost.emitApprovalBypassState).toHaveBeenCalledWith({
       streamId: 'goal-bypass-stream',
@@ -497,12 +497,29 @@ describe('TUI retry approvals', () => {
       bypassActive: true,
     });
 
-    await setGoalSessionBashAutoApproval('goal-bypass-stream', false);
+    await setGoalSessionAutoApproval('goal-bypass-stream', false);
     expect(streams.get().get('goal-bypass-stream')?.bypass.bash).toBe(false);
     expect(presentationHost.emitApprovalBypassState).toHaveBeenCalledWith({
       streamId: 'goal-bypass-stream',
       kind: 'bash',
       bypassActive: false,
+    });
+  });
+
+  it('scopes goal auto-approval to all agent work and clears it together', async () => {
+    tui();
+    await setGoalSessionAutoApproval('goal-all-bypass-stream', 'allAgentWork');
+    expect(streams.get().get('goal-all-bypass-stream')?.bypass).toEqual({
+      bash: true,
+      superYolo: true,
+      toolEdit: true,
+    });
+
+    await setGoalSessionAutoApproval('goal-all-bypass-stream', false);
+    expect(streams.get().get('goal-all-bypass-stream')?.bypass).toEqual({
+      bash: false,
+      superYolo: false,
+      toolEdit: false,
     });
   });
 

--- a/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.ts
+++ b/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.ts
@@ -127,10 +127,12 @@ describe('createTuiHostInteractions', () => {
     await waitForApproval('planApproval', { streamId: 'stream-a' });
     currentApproval.get()?.decide({
       accepted: true,
+      goalAutoApproveAll: true,
       planAction: 'approve_and_goal',
     });
     await expect(goalResult).resolves.toEqual({
       action: 'approve_and_goal',
+      autoApproveAll: true,
     });
 
     const rejected = interactions.requestPlanApproval?.({

--- a/src/test-kernel/shared/DelegationApprovalCopy.vitest.ts
+++ b/src/test-kernel/shared/DelegationApprovalCopy.vitest.ts
@@ -27,13 +27,15 @@ describe('delegated-work approval copy', () => {
 });
 
 describe('plan goal copy', () => {
-  it('freezes the Bash-only auto-approval wording both hosts state', () => {
+  it('freezes the default and broader auto-approval wording', () => {
     expect(Object.isFrozen(PLAN_GOAL_COPY)).toBe(true);
     expect(PLAN_GOAL_COPY).toEqual({
       action: 'Run as Goal',
       progressViewExplanation:
         'keeps the agent working across turns until it completes the plan, needs your input, or you stop it. Only Bash commands are auto-approved; edits and other actions still ask.',
       cliNotice: 'Runs until done; only Bash is automatic.',
+      cliAutoApproveAllNotice:
+        'Runs until done; commands, edits, and agent work are automatic.',
     });
   });
 });

--- a/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
+++ b/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
@@ -228,6 +228,67 @@ describe('PlanTool — update (plan approval)', () => {
       expect(goal!.objective).toBe(plan.objective);
       expect(isBashApprovalBypassedForStream(streamId, session)).toBe(true);
       expect(isApprovalBypassedForStream(streamId, session)).toBe(false);
+      expect(
+        events.filter((entry) => entry.event === 'setApprovalBypassState'),
+      ).toEqual([
+        {
+          event: 'setApprovalBypassState',
+          payload: { streamId, kind: 'toolEdit', bypassActive: false },
+        },
+        {
+          event: 'setApprovalBypassState',
+          payload: { streamId, kind: 'superYolo', bypassActive: false },
+        },
+        {
+          event: 'setApprovalBypassState',
+          payload: { streamId, kind: 'bash', bypassActive: true },
+        },
+      ]);
+    } finally {
+      await GoalStore.forget(streamId);
+      releaseStreamResources(streamId, session);
+    }
+  });
+
+  it('approve_and_goal applies the explicitly broadened approval scope', async () => {
+    const streamId = 'stream:plan-goal-all' as StreamTabId;
+    await installPlatform(true);
+
+    const { decisions, resultPromise, events, session } = startPlanUpdate(
+      streamId,
+      plan.objective,
+    );
+    try {
+      const approval = findPlanApproval(events);
+      expect(
+        submitPlanDecision(decisions, approval, {
+          action: 'approve_and_goal',
+          autoApproveAll: true,
+        }),
+      ).toBe(true);
+
+      await expect(resultPromise).resolves.toMatchObject({
+        status: 'executed',
+      });
+      expect(isBashApprovalBypassedForStream(streamId, session)).toBe(true);
+      expect(isApprovalBypassedForStream(streamId, session)).toBe(true);
+      expect(session.approvals.proposal.isBypassed(streamId)).toBe(true);
+      expect(
+        events.filter((entry) => entry.event === 'setApprovalBypassState'),
+      ).toEqual([
+        {
+          event: 'setApprovalBypassState',
+          payload: { streamId, kind: 'superYolo', bypassActive: true },
+        },
+        {
+          event: 'setApprovalBypassState',
+          payload: { streamId, kind: 'toolEdit', bypassActive: true },
+        },
+        {
+          event: 'setApprovalBypassState',
+          payload: { streamId, kind: 'bash', bypassActive: true },
+        },
+      ]);
     } finally {
       await GoalStore.forget(streamId);
       releaseStreamResources(streamId, session);

--- a/src/tools/goal/goalAutoApproval.ts
+++ b/src/tools/goal/goalAutoApproval.ts
@@ -1,33 +1,33 @@
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas';
 
+export type GoalAutoApprovalScope = 'commands' | 'allAgentWork';
+
 /**
- * Engage or clear the per-stream bash approval bypass for an autonomous goal.
- *
- * "Run as Goal" is the user's explicit consent to unattended
- * command execution; without the bypass, the first verification/build command
- * silently parks the loop, which reads as the goal "stopping early". File edits
- * keep their normal diff approval prompt because an approved plan is not an
- * edit approval. Engaged when a goal starts or is retargeted, cleared whenever
- * it pauses or ends so manual follow-up turns prompt normally again.
- *
- * Subagents inherit the parent stream's bypass through the existing
- * delegation wiring (`configureDelegatedChildApprovals`), so no
- * child-stream handling is needed here — each bypass kind resolves its own
- * value through that ancestry, so a goal parent with bash bypassed but edits
- * gated propagates exactly that split.
- *
- * The approval modules are imported lazily: this file sits in the host-neutral
- * agent-loop import graph (via ToolUseWaitNode), and pulling the approval
- * modules at module scope drags their filesystem/logger imports into every
- * consumer — breaking partial logger mocks in CLI tests.
+ * Apply one goal's selected approval scope, or clear every goal grant.
+ * Commands-only remains the default: an approved plan is not consent to edit
+ * files or launch delegated work unless the user explicitly enables the
+ * broader scope. Descendants inherit each bypass through session ancestry.
  */
-export async function setGoalSessionBashAutoApproval(
+export async function setGoalSessionAutoApproval(
   streamId: StreamTabId,
-  enabled: boolean,
+  scope: GoalAutoApprovalScope | false,
   options?: { session?: SessionHandle },
 ): Promise<void> {
-  const { setBashApprovalSessionBypass } =
-    await import('@tools/approval/bashApproval');
-  setBashApprovalSessionBypass(streamId, enabled, options);
+  // Keep this lazy: a static SessionHandle import pulls host runtime into the
+  // host-neutral goal graph and breaks tests that install partial logger mocks.
+  const session =
+    options?.session ??
+    (await import('@agent/runtime/SessionHandle')).currentSession();
+  if (scope === 'allAgentWork') {
+    session.approvals.setDelegatedWorkBypasses(streamId, true);
+  } else if (scope === 'commands') {
+    // Retargeting from all-agent-work must revoke the broad grants without
+    // publishing a transient command revocation immediately before re-enable.
+    session.approvals.toolEdit.bypass.setBypass(streamId, false);
+    session.approvals.proposal.setBypass(streamId, false);
+    session.approvals.bash.bypass.setBypass(streamId, true);
+  } else {
+    session.approvals.setDelegatedWorkBypasses(streamId, false);
+  }
 }

--- a/src/tools/goal/index.ts
+++ b/src/tools/goal/index.ts
@@ -9,4 +9,7 @@
  */
 export { isGoalEnabled } from './goalFeatureFlag';
 export { GoalStore, subscribeGoalStateChanges } from './goalStore';
-export { setGoalSessionBashAutoApproval } from './goalAutoApproval';
+export {
+  setGoalSessionAutoApproval,
+  type GoalAutoApprovalScope,
+} from './goalAutoApproval';

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -43,7 +43,8 @@ import { requireStreamId } from '@tools/contextHelpers';
 import {
   GoalStore,
   isGoalEnabled,
-  setGoalSessionBashAutoApproval,
+  setGoalSessionAutoApproval,
+  type GoalAutoApprovalScope,
 } from '@tools/goal';
 import { requireNonEmptyString } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
@@ -180,7 +181,7 @@ pause/complete only affect autonomous goals; with no goal running they return gu
       );
     }
     const updated = (await GoalStore.setStatus(streamId, 'paused')) ?? goal;
-    await this.setBashAutoApproval(streamId, false);
+    await this.setGoalAutoApproval(streamId, false);
     return executed(
       `Goal paused: ${reason}\n\n${formatGoalView(updated)}`,
       'Goal paused.',
@@ -188,19 +189,19 @@ pause/complete only affect autonomous goals; with no goal running they return gu
   }
 
   /**
-   * Engage/clear the goal's bash auto-approval bypass when the run context can
-   * reach the host. Best-effort: without a runtime host (e.g.
+   * Engage or clear the goal's selected auto-approval scope when the run
+   * context can reach the host. Best-effort: without a runtime host (e.g.
    * tests or headless edge paths) approvals simply keep prompting.
    */
-  private async setBashAutoApproval(
+  private async setGoalAutoApproval(
     streamId: string,
-    enabled: boolean,
+    scope: GoalAutoApprovalScope | false,
   ): Promise<void> {
     const interactions = getRunContextInteractions(
       getCurrentToolContexts()?.runContext,
     );
     if (interactions) {
-      await setGoalSessionBashAutoApproval(streamId, enabled);
+      await setGoalSessionAutoApproval(streamId, scope);
     }
   }
 
@@ -220,7 +221,7 @@ pause/complete only affect autonomous goals; with no goal running they return gu
     // archived one. The autonomous loop stops because no `active` record
     // remains for the next wait-node continuation check.
     await GoalStore.forget(streamId);
-    await this.setBashAutoApproval(streamId, false);
+    await this.setGoalAutoApproval(streamId, false);
     return executed(
       `Goal ${goal.goalId} marked complete.\n\n` +
         `Reason: ${reason}\n\n` +
@@ -261,7 +262,11 @@ pause/complete only affect autonomous goals; with no goal running they return gu
 
     if (result.action === 'approve_and_goal') {
       logger.info('Plan approved by user with goal mode');
-      return this.startGoalForPlan(plan, streamId);
+      return this.startGoalForPlan(
+        plan,
+        streamId,
+        result.autoApproveAll ? 'allAgentWork' : 'commands',
+      );
     }
 
     // Rejected — clear the plan from UI
@@ -326,6 +331,7 @@ pause/complete only affect autonomous goals; with no goal running they return gu
   private async startGoalForPlan(
     plan: Plan,
     streamId: string,
+    autoApprovalScope: GoalAutoApprovalScope,
   ): Promise<ToolResult> {
     if (!isGoalEnabled()) {
       logger.warn(
@@ -355,7 +361,7 @@ pause/complete only affect autonomous goals; with no goal running they return gu
           retargeted.status === 'paused'
             ? ((await GoalStore.setStatus(streamId, 'active')) ?? retargeted)
             : retargeted;
-        await this.setBashAutoApproval(streamId, true);
+        await this.setGoalAutoApproval(streamId, autoApprovalScope);
         return executed(
           `The user approved a new plan while goal ${active.goalId} ` +
             `was already in flight. The goal has been retargeted to the ` +
@@ -391,7 +397,7 @@ pause/complete only affect autonomous goals; with no goal running they return gu
 
     try {
       const goal = await GoalStore.start(streamId, objective);
-      await this.setBashAutoApproval(streamId, true);
+      await this.setGoalAutoApproval(streamId, autoApprovalScope);
       return executed(
         `The user approved this plan and started an autonomous goal ` +
           `(${goal.goalId}) toward its stopping condition.\n\n` +


### PR DESCRIPTION
## Summary

- keep the terminal tab spinner synchronized with canonical idle transitions
- collapse completed todo history so current and pending work remain visible
- add a session-scoped `/goal` toggle for commands-only versus all-agent-work auto-approval

## Testing

- `npm run format`
- `npm run compile:fast`
- `npm run lint`
- `npm run typecheck`
- `npm test` (9,907 passed, 5 skipped)