### PR TITLE
simplify(workflow): survey bundle 1 — four deletions in the shared model's orbit

### DIFF
--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -16,7 +16,7 @@ import { ToolUseRow } from './ToolUseRow';
 import {
   COMPACTION_ACTIVITY_STATUS_STYLE,
   LIVE_TAIL_ROWS,
-  WORKFLOW_TASK_STATUS_STYLE,
+  WORKFLOW_TASK_STATUS_COLOR,
   boundedTranscriptEntryLayout,
   transcriptEntryLayout,
   type TranscriptEntryLayout,
@@ -81,7 +81,7 @@ function PlainEntryRows({
   } else if (entry.kind === 'compactionActivity' && colorEnabled !== false) {
     rowColor = COMPACTION_ACTIVITY_STATUS_STYLE[entry.block.status].color;
   } else if (entry.kind === 'workflowTask' && colorEnabled !== false) {
-    rowColor = WORKFLOW_TASK_STATUS_STYLE[entry.call.status].color;
+    rowColor = WORKFLOW_TASK_STATUS_COLOR[entry.call.status];
   }
 
   return (

--- a/packages/cli/src/chat/tui/panes/WorkflowPopup.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkflowPopup.tsx
@@ -81,7 +81,7 @@ import { useSignal } from '../state/useSignal';
 // Local imports - sibling panes
 import { ApprovalSegments, RowSegment } from './SubagentList';
 import { pendingApprovalRowDisplay } from './SubagentListDisplay';
-import { WORKFLOW_TASK_STATUS_STYLE } from './transcriptEntryLayout';
+import { WORKFLOW_TASK_STATUS_COLOR } from './transcriptEntryLayout';
 import type { PendingApprovalKind } from '../state/approvalQueue';
 
 /** Rows of chrome inside the panel beyond what the shared budget already
@@ -152,7 +152,6 @@ function TaskRow({
   readonly pendingKinds: readonly PendingApprovalKind[] | undefined;
   readonly row: WorkflowTaskRowModel;
 }): React.JSX.Element {
-  const style = WORKFLOW_TASK_STATUS_STYLE[row.call.status];
   // The row's own parts name the call and, once settled, what it cost; the
   // model's live join adds the in-flight window the card cannot carry.
   const parts = [
@@ -167,8 +166,8 @@ function TaskRow({
         <Text aria-hidden color={focused ? COLOR_HINT : undefined}>
           {focused ? POINTER : ' '}
         </Text>
-        <Text aria-hidden color={style.color}>
-          {markerCell(style.marker)}
+        <Text aria-hidden color={WORKFLOW_TASK_STATUS_COLOR[row.call.status]}>
+          {markerCell(WORKFLOW_CALL_STATUS_GLYPH[row.call.status])}
         </Text>
       </Box>
       <RowSegment flexShrink={1}>{row.call.label}</RowSegment>
@@ -191,13 +190,12 @@ function DeclaredTaskRow({
 }: {
   readonly task: WorkflowCallIdentity;
 }): React.JSX.Element {
-  const style = WORKFLOW_TASK_STATUS_STYLE.declared;
   return (
     <Box flexDirection="row" height={1} minWidth={0} overflowY="hidden">
       <Box flexShrink={0}>
         <Text aria-hidden> </Text>
-        <Text aria-hidden color={style.color}>
-          {markerCell(style.marker)}
+        <Text aria-hidden color={WORKFLOW_TASK_STATUS_COLOR.declared}>
+          {markerCell(WORKFLOW_CALL_STATUS_GLYPH.declared)}
         </Text>
       </Box>
       <RowSegment dimColor flexShrink={1}>

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -134,7 +134,7 @@ const ROW_GEOMETRY = {
   },
   workflowTask: {
     // Two spaces nest the task under the `◆` phase divider that heads it. The
-    // first-line marker is per-status (WORKFLOW_TASK_STATUS_STYLE), so
+    // first-line marker is per-status (WORKFLOW_CALL_STATUS_GLYPH), so
     // `firstPrefix` carries the indent alone and continuation lines add the
     // marker's own width on top of it.
     firstPrefix: '  ',
@@ -158,31 +158,19 @@ export const COMPACTION_ACTIVITY_STATUS_STYLE = {
   { readonly marker: string; readonly color: string | undefined }
 >;
 
-/** Colour per call status; the marker is the shared per-status glyph, so the
- *  strip, the popup rows, and the transcript rows can never disagree. */
-export const WORKFLOW_TASK_STATUS_STYLE = {
-  declared: {
-    marker: WORKFLOW_CALL_STATUS_GLYPH.declared,
-    color: COLOR_BORDER,
-  },
-  planned: { marker: WORKFLOW_CALL_STATUS_GLYPH.planned, color: undefined },
-  queued: { marker: WORKFLOW_CALL_STATUS_GLYPH.queued, color: undefined },
-  running: { marker: WORKFLOW_CALL_STATUS_GLYPH.running, color: COLOR_HINT },
-  completed: {
-    marker: WORKFLOW_CALL_STATUS_GLYPH.completed,
-    color: COLOR_SUCCESS,
-  },
-  cached: { marker: WORKFLOW_CALL_STATUS_GLYPH.cached, color: COLOR_SUCCESS },
-  skipped: { marker: WORKFLOW_CALL_STATUS_GLYPH.skipped, color: COLOR_BORDER },
-  cancelled: {
-    marker: WORKFLOW_CALL_STATUS_GLYPH.cancelled,
-    color: COLOR_BORDER,
-  },
-  failed: { marker: WORKFLOW_CALL_STATUS_GLYPH.failed, color: COLOR_ERROR },
-} as const satisfies Record<
-  WorkflowCallProgress['status'],
-  { readonly marker: string; readonly color: string | undefined }
->;
+/** Colour per call status; the glyph beside it is the shared
+ *  `WORKFLOW_CALL_STATUS_GLYPH`, read directly wherever a row is painted. */
+export const WORKFLOW_TASK_STATUS_COLOR = {
+  declared: COLOR_BORDER,
+  planned: undefined,
+  queued: undefined,
+  running: COLOR_HINT,
+  completed: COLOR_SUCCESS,
+  cached: COLOR_SUCCESS,
+  skipped: COLOR_BORDER,
+  cancelled: COLOR_BORDER,
+  failed: COLOR_ERROR,
+} as const satisfies Record<WorkflowCallProgress['status'], string | undefined>;
 
 export interface TranscriptEntryLayout {
   readonly columns: number;
@@ -366,7 +354,7 @@ function entryLines(
         ...wrapWithPrefix(
           headline,
           columns,
-          `${ROW_GEOMETRY.workflowTask.firstPrefix}${WORKFLOW_TASK_STATUS_STYLE[row.call.status].marker} `,
+          `${ROW_GEOMETRY.workflowTask.firstPrefix}${WORKFLOW_CALL_STATUS_GLYPH[row.call.status]} `,
           ROW_GEOMETRY.workflowTask.continuationPrefix,
         ),
         ...body,

--- a/src/agent/trace/AgentTrace.ts
+++ b/src/agent/trace/AgentTrace.ts
@@ -36,8 +36,6 @@ export interface StageOptions {
   readonly index?: number;
   /** Planned total count, when known, currently used for workflow rounds. */
   readonly total?: number;
-  /** Physical workflow attempt that owns this stage, when applicable. */
-  readonly attemptId?: string;
   /**
    * Skip stage creation but propagate parent context to nested calls.
    * `handle.id` is undefined; `handle.within(fn)` runs `fn` in the parent

--- a/src/agent/trace/TraceEmitter.ts
+++ b/src/agent/trace/TraceEmitter.ts
@@ -229,7 +229,6 @@ export class TraceEmitter implements AgentTrace {
       kind: options.kind,
       index: options.index,
       total: options.total,
-      attemptId: options.attemptId,
     });
     return new StageHandleImpl(this, id);
   }

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -85,7 +85,6 @@ export interface StageStartEvent extends StageStamp {
   readonly kind?: 'run' | 'round' | 'phase' | 'session';
   readonly index?: number;
   readonly total?: number;
-  readonly attemptId?: string;
 }
 
 /** Immutable run identity emitted once when a stream enters RUNNING. */

--- a/src/shared/copy/workflowCall.ts
+++ b/src/shared/copy/workflowCall.ts
@@ -1,5 +1,4 @@
 import {
-  isTerminalWorkflowCallProgress,
   WORKFLOW_TASK_STATUS_LABEL,
   type TaskGroup,
   type WorkflowCallKind,

--- a/src/shared/copy/workflowCall.ts
+++ b/src/shared/copy/workflowCall.ts
@@ -69,63 +69,6 @@ export function formatWorkflowCallMetadataParts(
   ].filter(filterNotNullish);
 }
 
-/**
- * Completion fold for a caller-selected list of calls — `done/total · N
- * running · N failed` — shared by every host so the terminal and the
- * progress view can never disagree on what a phase, or a whole run, has
- * done. The caller selects the calls (each host already holds them in its
- * own container, and matching them here would duplicate that ownership), so
- * the same helper serves both a phase-scoped fold and a whole-run fold from
- * two different call lists.
- *
- * Cancelled calls remain distinct from failures and do not contribute to
- * `failed`. Snapshot consumers (`/executions`) derive their own per-status
- * tallies with `deriveWorkflowCounts` and do not need this helper.
- */
-export function workflowCallTally(calls: readonly WorkflowCallProgress[]): {
-  readonly done: number;
-  readonly total: number;
-  readonly running: number;
-  readonly failed: number;
-} {
-  return {
-    done: calls.filter((call) => isTerminalWorkflowCallProgress(call)).length,
-    total: calls.length,
-    running: calls.filter((call) => call.status === 'running').length,
-    failed: calls.filter((call) => call.status === 'failed').length,
-  };
-}
-
-/**
- * Scope a caller-selected list of workflow-task rows to the newest resume
- * attempt, shared by every host's live tally and row selection. A relaunch
- * under the same `meta.name` appends a second projection attempt to the same
- * deterministic transcript with fresh card ids, so without this, dashboards
- * and boards fold every attempt together — doubling totals and keeping stale
- * failures the resume is actively re-running.
- *
- * "Newest" is the last attempt id observed while scanning `entries` in the
- * caller's own (transcript) order, since a resume's cards are appended after
- * the attempt they supersede. Entries with no attempt id (older, pre-attempt
- * transcripts) are never filtered out — only a defined id that disagrees
- * with the newest one drops a row.
- */
-export function latestWorkflowAttemptEntries<T>(
-  entries: readonly T[],
-  attemptIdOf: (entry: T) => string | undefined,
-): readonly T[] {
-  let latestAttemptId: string | undefined;
-  for (const entry of entries) {
-    const attemptId = attemptIdOf(entry);
-    if (attemptId !== undefined) latestAttemptId = attemptId;
-  }
-  if (latestAttemptId === undefined) return entries;
-  return entries.filter((entry) => {
-    const attemptId = attemptIdOf(entry);
-    return attemptId === undefined || attemptId === latestAttemptId;
-  });
-}
-
 /** One workflow phase as its emitter names and orders it. */
 export interface WorkflowPhaseHeading {
   readonly phaseLabel: string;
@@ -233,16 +176,23 @@ export const TOKENS_GENERATED = '↓';
  *  declared. */
 export const WORKFLOW_PHASE_GLYPH = { opened: '◆', declared: '◇' } as const;
 
-interface WorkflowTallyCounts {
+/**
+ * A run's or a phase's tally as the run model folds it: `done` counts every
+ * settled call (cancelled and skipped included — they are distinct from
+ * `failed`), `declared` how many plan tasks are still unissued. Snapshot
+ * consumers (`/executions`) derive their own per-status counts with
+ * `deriveWorkflowCounts` over the engine's vocabulary.
+ */
+export interface WorkflowTally {
   readonly done: number;
   readonly total: number;
   readonly running: number;
   readonly failed: number;
-  readonly declared?: number;
+  readonly declared: number;
 }
 
 /** `done/total · N running · N failed` — the one spelling of a tally. */
-export function formatWorkflowTally(tally: WorkflowTallyCounts): string {
+export function formatWorkflowTally(tally: WorkflowTally): string {
   return [
     `${tally.done}/${tally.total}`,
     tally.running > 0 ? `${tally.running} running` : undefined,
@@ -257,9 +207,9 @@ export function formatWorkflowTally(tally: WorkflowTallyCounts): string {
  *  plan has no calls to count, so its declared count is the whole story. */
 export function formatWorkflowPhaseTally(phase: {
   readonly opened: boolean;
-  readonly tally: WorkflowTallyCounts;
+  readonly tally: WorkflowTally;
 }): string {
-  const declared = phase.tally.declared ?? 0;
+  const { declared } = phase.tally;
   const declaredText = declared > 0 ? `${declared} declared` : undefined;
   if (!phase.opened) return declaredText ?? 'declared';
   return [formatWorkflowTally(phase.tally), declaredText]

--- a/src/shared/schemas/taskGroup.ts
+++ b/src/shared/schemas/taskGroup.ts
@@ -46,16 +46,13 @@ export type TaskGroup = z.infer<typeof TaskGroupSchema>;
  * projection maps a legacy value UP to the native value it corresponds to;
  * a value in neither vocabulary is rejected at the canonical persistence
  * boundary. Exported traces recover stale display fields independently in
- * `TraceGroupLogPayloadSchema`. `attemptId` is different: it owns physical-run
- * identity, so genuine absence remains valid for older rows while a malformed
- * present value rejects the payload instead of becoming a legacy omission.
+ * `TraceGroupLogPayloadSchema`.
  */
 const groupLogPayloadFields = {
   status: z.union([TaskGroupStatusSchema, EndGroupStatusSchema]).optional(),
   kind: StageKindSchema.optional(),
   index: taskGroupIndexField.optional(),
   total: taskGroupTotalField.optional(),
-  attemptId: z.string().min(1).optional(),
   name: z.string().optional(),
   endTime: taskGroupEndTimeField.optional(),
 };

--- a/src/shared/schemas/taskGroup.ts
+++ b/src/shared/schemas/taskGroup.ts
@@ -62,8 +62,7 @@ export const GroupLogPayloadSchema = z.looseObject(groupLogPayloadFields);
 /**
  * Permanent exported-trace recovery for group rows written by older versions.
  * Each display-only field recovers independently so one stale value does not
- * discard the whole trace entry. Attempt identity remains strict because
- * erasing malformed ownership would attach work to the wrong physical run.
+ * discard the whole trace entry.
  */
 export const TraceGroupLogPayloadSchema = z.looseObject({
   ...groupLogPayloadFields,

--- a/src/shared/streams/workflowRunModel.ts
+++ b/src/shared/streams/workflowRunModel.ts
@@ -26,10 +26,9 @@ import {
 import type { TranscriptRow, WorkflowTaskRow } from '@shared/transcript';
 import {
   TOKENS_GENERATED,
-  latestWorkflowAttemptEntries,
-  workflowCallTally,
   workflowPhaseHeadingOfGroup,
   type WorkflowPhaseHeading,
+  type WorkflowTally,
 } from '@shared/copy/workflowCall';
 import { filterNotNullish, formatCompactTokenCount } from '@utils/core';
 import {
@@ -81,15 +80,6 @@ export function workflowMarkerOf(
 // ---------------------------------------------------------------------------
 // The run model
 // ---------------------------------------------------------------------------
-
-/** `done/total`, the live counts, and how many plan tasks are still unissued. */
-interface WorkflowTally {
-  readonly done: number;
-  readonly total: number;
-  readonly running: number;
-  readonly failed: number;
-  readonly declared: number;
-}
 
 export interface WorkflowPhaseModel {
   /** Stable identity: the task group id, or `declared-<title>` for a phase
@@ -165,7 +155,14 @@ function tallyOf(
   tasks: readonly WorkflowTaskRow[],
   declared: number,
 ): WorkflowTally {
-  return { ...workflowCallTally(tasks.map((row) => row.call)), declared };
+  return {
+    done: tasks.filter((row) => isTerminalWorkflowCallProgress(row.call))
+      .length,
+    total: tasks.length,
+    running: tasks.filter((row) => row.call.status === 'running').length,
+    failed: tasks.filter((row) => row.call.status === 'failed').length,
+    declared,
+  };
 }
 
 /**
@@ -267,11 +264,13 @@ export function workflowRunModel(
   const cards = input.rows.filter(
     (row): row is WorkflowTaskRow => row.kind === 'workflowTask',
   );
-  const liveIds = new Set(
-    latestWorkflowAttemptEntries(cards, (row) => row.call.attemptId).map(
-      (row) => row.id,
-    ),
-  );
+  // "Newest" is the last attempt id in transcript order — a resume's cards
+  // are appended after the attempt they supersede. A card with no attempt id
+  // (an older transcript) is never dropped; only a defined id that disagrees
+  // with the newest one is.
+  let latestAttemptId: string | undefined;
+  for (const row of cards)
+    latestAttemptId = row.call.attemptId ?? latestAttemptId;
   const tasks: WorkflowTaskRow[] = [];
   // A card issued outside any open phase has no group to sit under; it joins
   // one trailing "Unphased" phase rather than vanishing.
@@ -282,7 +281,8 @@ export function workflowRunModel(
   const staleOnly = new Set<MutablePhase>();
   for (const row of cards) {
     const phase = row.groupId ? byGroupId.get(row.groupId) : undefined;
-    if (!liveIds.has(row.id)) {
+    const attemptId = row.call.attemptId;
+    if (attemptId !== undefined && attemptId !== latestAttemptId) {
       if (phase) staleOnly.add(phase);
       continue;
     }

--- a/src/shared/transcript/projectTranscriptRow.ts
+++ b/src/shared/transcript/projectTranscriptRow.ts
@@ -288,19 +288,18 @@ const WEB_FETCH_ERROR_LABEL: Readonly<Record<string, string>> = {
  */
 function phaseGroupData(
   entry: StreamLogEntry,
-): { index?: number; total?: number; attemptId?: string } | undefined {
+): { index?: number; total?: number } | undefined {
   if (
     entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_START &&
     entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_END
   ) {
     return undefined;
   }
-  const { kind, index, total, attemptId } = entry.data;
+  const { kind, index, total } = entry.data;
   if (kind !== 'phase') return undefined;
   return {
     ...(index !== undefined ? { index } : {}),
     ...(total !== undefined ? { total } : {}),
-    ...(attemptId !== undefined ? { attemptId } : {}),
   };
 }
 
@@ -333,7 +332,6 @@ export function projectTranscriptRow(
       phaseLabel,
       ...(phaseIndex !== undefined ? { phaseIndex } : {}),
       ...(phaseTotal !== undefined ? { phaseTotal } : {}),
-      ...(phase.attemptId !== undefined ? { attemptId: phase.attemptId } : {}),
     };
   }
 

--- a/src/shared/transcript/transcriptRow.ts
+++ b/src/shared/transcript/transcriptRow.ts
@@ -242,7 +242,6 @@ export interface PhaseRow extends TranscriptRowBase {
   readonly phaseLabel: string;
   readonly phaseIndex?: number;
   readonly phaseTotal?: number;
-  readonly attemptId?: string;
 }
 
 /** A plain log line: a `default` row, a row with no message type, or a

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -13,7 +13,6 @@ import {
   type StreamTabId,
   type WorkflowCallProgress,
 } from '@shared/schemas';
-import { workflowCallTally } from '@shared/copy/workflowCall';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { runPersistedWorkflowScriptWithProgress } from '@tools/delegation/workflowScriptRun';
 
@@ -231,7 +230,6 @@ return await agent('Inspect', { id: 'inspect' })`,
         kind: 'phase',
         index: 0,
         total: 2,
-        attemptId: planned?.call.attemptId,
       }),
     );
     expect(events.some((event) => event.type === 'child.activity')).toBe(false);
@@ -428,12 +426,8 @@ return await agent('Run loose', { id: 'loose' })`,
     const researchId = stageId(events, 'Research');
     const latest = latestWorkflowCallEvents(events);
     expect(
-      workflowCallTally(
-        latest.flatMap((event) =>
-          event.call.phase === 'Research' ? [event.call] : [],
-        ),
-      ),
-    ).toMatchObject({ done: 0, total: 0 });
+      latest.filter((event) => event.call.phase === 'Research'),
+    ).toHaveLength(0);
     expect(latest.filter((event) => event.stageId === researchId)).toHaveLength(
       0,
     );

--- a/src/test-kernel/shared/WorkflowCallCopy.vitest.ts
+++ b/src/test-kernel/shared/WorkflowCallCopy.vitest.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import {
   formatWorkflowCallMetadataParts,
   formatWorkflowCallLine,
-  workflowCallTally,
 } from '@shared/copy/workflowCall';
 
 describe('workflow call copy', () => {
@@ -55,58 +54,6 @@ describe('workflow call copy', () => {
     ).toBe(
       'Skipped: Audit later — The workflow ended before this call was reached.',
     );
-  });
-
-  it('counts an empty phase as no work rather than complete', () => {
-    expect(workflowCallTally([])).toEqual({
-      done: 0,
-      total: 0,
-      running: 0,
-      failed: 0,
-    });
-  });
-
-  it('tallys no failures for a clean or empty run', () => {
-    expect(workflowCallTally([])).toMatchObject({ failed: 0 });
-    expect(
-      workflowCallTally([
-        { id: 'a', label: 'A', status: 'completed', durationMs: 1 },
-        { id: 'b', label: 'B', status: 'running' },
-      ]),
-    ).toMatchObject({ failed: 0, running: 1 });
-  });
-
-  it('tallys only failed calls across a mixed run', () => {
-    expect(
-      workflowCallTally([
-        { id: 'a', label: 'A', status: 'completed', durationMs: 1 },
-        { id: 'b', label: 'B', status: 'failed', error: 'boom' },
-        { id: 'c', label: 'C', status: 'skipped', reason: 'not-reached' },
-        { id: 'd', label: 'D', status: 'failed', error: 'also boom' },
-      ]),
-    ).toMatchObject({ failed: 2 });
-  });
-
-  it('counts every terminal status as done, not just completions', () => {
-    expect(
-      workflowCallTally([
-        { id: 'a', label: 'A', status: 'completed', durationMs: 1 },
-        { id: 'b', label: 'B', status: 'cached' },
-        { id: 'c', label: 'C', status: 'skipped', reason: 'not-reached' },
-        { id: 'd', label: 'D', status: 'cancelled' },
-        { id: 'e', label: 'E', status: 'failed', error: 'nope' },
-      ]),
-    ).toMatchObject({ done: 5, total: 5 });
-  });
-
-  it('leaves planned and running calls outstanding', () => {
-    expect(
-      workflowCallTally([
-        { id: 'a', label: 'A', status: 'completed', durationMs: 1 },
-        { id: 'b', label: 'B', status: 'running' },
-        { id: 'c', label: 'C', status: 'planned' },
-      ]),
-    ).toMatchObject({ done: 1, total: 3, running: 1 });
   });
 
   it('leaves a user skip without an explanatory clause', () => {

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -80,20 +80,6 @@ describe('attachTranscriptRecorder StreamPhase-native group rows (issue #7993)',
     expect(dataOf(startEntry).status).toBe(STREAM_PHASE.RUNNING);
   });
 
-  it('retains workflow attempt identity when a phase settles', () => {
-    const { trace, row } = attachRecorder();
-
-    const stage = trace.openStage('Verify', {
-      kind: 'phase',
-      attemptId: 'attempt-current',
-    });
-    expect(dataOf(row(stage.id)).attemptId).toBe('attempt-current');
-
-    stage.end();
-
-    expect(dataOf(row(stage.id)).attemptId).toBe('attempt-current');
-  });
-
   it('defaults GROUP_END to the literal RunOutcome.COMPLETED, not a folded EndGroupStatus', () => {
     const { trace, row } = attachRecorder();
 

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -226,7 +226,6 @@ export async function runPersistedWorkflowScriptWithProgress(
         parentId: parentStageId,
         index,
         total,
-        attemptId: projectionId,
       }),
       failed: false,
     };

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -166,7 +166,7 @@ export function createWorkflowScriptStrategy(
    *
    * `taskDone` counts the tasks that produced a result (completed or cached),
    * which is deliberately narrower than the phase header's `done/total`
-   * (workflowCallTally), where every settled call counts, failures and
+   * (the run model's tally), where every settled call counts, failures and
    * skips included. The two answer different questions, so the delivery line
    * labels its count "succeeded".
    *

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -166,7 +166,7 @@ interface StreamSinkState {
 
 type StageMetadata = Pick<
   Extract<AgentEvent, { type: 'stage.start' }>,
-  'kind' | 'index' | 'total' | 'attemptId'
+  'kind' | 'index' | 'total'
 >;
 
 /**
@@ -442,9 +442,6 @@ export function attachTranscriptRecorder(
             ...(event.kind !== undefined ? { kind: event.kind } : {}),
             ...(event.index !== undefined ? { index: event.index } : {}),
             ...(event.total !== undefined ? { total: event.total } : {}),
-            ...(event.attemptId !== undefined
-              ? { attemptId: event.attemptId }
-              : {}),
           } satisfies StageMetadata;
           stageMetadata.set(event.id, metadata);
           // A new model-turn boundary starts fresh: whatever MODEL_RESPONSE


### PR DESCRIPTION
## What

Bundle 1 of [the 2026-08-29 survey](docs/proposals/2026-08-29-simplification-survey-shared-workflow-model.md) — the pure deletions:

- **S1** `attemptId` on phase stages: write-only since #11602 deleted the CLI folds that read it (verified: zero readers across every host and `src/shared`). Removed from `StageStartEvent`, `StageOptions`, the recorder's stage metadata, `groupLogPayloadFields`, `phaseGroupData`, and `PhaseRow`. Persisted payloads are `looseObject`, so old entries keep parsing.
- **S2** One tally: `workflowCallTally` (one caller) inlined into the model's `tallyOf`; `WorkflowTally` declared once in the copy module with `declared` required, replacing the model's copy and the copy module's `WorkflowTallyCounts`; the `?? 0` that served no caller is gone. The strategy comment that named the helper is reworded.
- **S3** `latestWorkflowAttemptEntries<T>` (one caller since #11604) inlined: one loop finds the newest attempt id, the card loop tests it, and the `liveIds` set is gone. The doc sentence that matters (a card with no attempt id is never dropped) moved with it.
- **S4** The CLI's `WORKFLOW_TASK_STATUS_STYLE` re-spelled every shared glyph as `marker`; it is now `WORKFLOW_TASK_STATUS_COLOR`, and the popup rows, the transcript row prefix, and the row colour read `WORKFLOW_CALL_STATUS_GLYPH` / the colour table directly.

No pixel or string changes.

## Net elements (R6)

`git diff --stat origin/main`:
- Production: 14 files, **+57 / −135** (net −78)
- Tests: 3 files, +2 / −75 (five direct `workflowCallTally` pins and one stage-`attemptId` recorder pin retired; one bridge assertion loses its stage `attemptId` field; one bridge tally check counts directly)
- Exported symbols: −2 (`workflowCallTally`, `latestWorkflowAttemptEntries`); +1 / −1 (`WorkflowTally` exported from the copy module, `WORKFLOW_TASK_STATUS_STYLE` → `WORKFLOW_TASK_STATUS_COLOR`)
- Declarations: −2 (`WorkflowTallyCounts`, the model's private `WorkflowTally`); −1 event field, −1 option field, −1 schema field, −1 row field

## Consumer counts (R8)

No emit path deleted or re-routed. At `origin/main` (prod files / test files): `workflowCallTally` 3 / 2 · `latestWorkflowAttemptEntries` 2 / 0 · `WorkflowTallyCounts` 1 / 0 · `WORKFLOW_TASK_STATUS_STYLE` 3 / 0 · stage `attemptId`: 6 writer sites / 0 readers (survey S1).

## Verified

- `npm run typecheck` — clean
- `npm run lint` (repo-wide) + prettier — clean
- vitest `src/test-kernel/{shared,cli,progressView,agent,transcript}` — 438 files, 6,550 tests passing
- `npm run check:dead-code-ratchet` — no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QESykrKh1yzvF2bB4pjDrS