### PR TITLE
simplify(workflow): drop the attempt marker — the plan and every card already carry the attempt

### DIFF
--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -228,10 +228,6 @@ function projectWorkflowPlanIncrementally(
     if (state.applied.get(entry.id) === entry) continue;
     state.applied.set(entry.id, entry);
     switch (marker.kind) {
-      case 'attempt':
-        // A new attempt starts with no plan of its own until it records one.
-        state.snapshot = undefined;
-        break;
       case 'malformedPlan':
         // An unreadable plan is an unknown plan, not the previous attempt's.
         logger.warn(

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -129,10 +129,10 @@ function applyEntry(
     streamLogs,
     applyCompactionActivityEntries(streamLogs.compactionProjection, [entry]),
   );
-  // The workflow attempt and plan markers are the one internal record this
-  // host reads: they are an input of the shared workflow run model the board
-  // paints. A new attempt starts with no plan of its own until it records one,
-  // and an unreadable plan is an unknown plan, not the previous attempt's.
+  // The workflow plan marker is the one internal record this host reads: it
+  // is an input of the shared workflow run model the board paints. The newest
+  // marker is the live plan; an unreadable one is an unknown plan, not the
+  // previous attempt's.
   const marker = workflowMarkerOf(entry);
   if (marker) {
     if (marker.kind === 'malformedPlan') {

--- a/packages/extension/src/progressView/frontend/store.ts
+++ b/packages/extension/src/progressView/frontend/store.ts
@@ -48,8 +48,8 @@ export interface StreamLogs {
   compactionProjection: CompactionActivityProjection;
   /**
    * The newest attempt's declared workflow plan, folded from the
-   * `workflowAttempt` / `workflowPlan` markers the same way the CLI folds
-   * them; one input of the shared workflow run model the board paints.
+   * `workflowPlan` markers (newest wins) the same way the CLI folds them;
+   * one input of the shared workflow run model the board paints.
    */
   workflowPlan: WorkflowPlanMarker | undefined;
   /**

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -146,12 +146,6 @@ interface WorkflowCallEvent extends StageStamp {
   readonly call: WorkflowCallProgress;
 }
 
-/** A physical workflow-script projection began, before any optional work. */
-interface WorkflowAttemptEvent extends StageStamp {
-  readonly type: 'workflow.attempt';
-  readonly attemptId: string;
-}
-
 /** The attempt's declared phases and tasks, emitted once before any of them
  *  opens — see `WorkflowPlanMarker`. */
 interface WorkflowPlanEvent extends StageStamp {
@@ -386,7 +380,6 @@ export type AgentEvent =
   | StageEndEvent
   | ToolStartEvent
   | ToolEndEvent
-  | WorkflowAttemptEvent
   | WorkflowPlanEvent
   | WorkflowCallEvent
   | ActiveSkillsEvent

--- a/src/shared/schemas/workflowCallProgress.ts
+++ b/src/shared/schemas/workflowCallProgress.ts
@@ -26,12 +26,6 @@ export const WorkflowCallIdentitySchema = z.strictObject({
 });
 export type WorkflowCallIdentity = z.infer<typeof WorkflowCallIdentitySchema>;
 
-/** Durable boundary emitted by the controlled workflow transcript writer. */
-export type WorkflowAttemptMarker = {
-  readonly kind: 'workflowAttempt';
-  readonly attemptId: string;
-};
-
 /**
  * The declared plan of one workflow-script attempt — every `meta.phases`
  * entry and every `meta.tasks` entry, in script order — recorded once on the

--- a/src/shared/streams/workflowRunModel.ts
+++ b/src/shared/streams/workflowRunModel.ts
@@ -43,7 +43,6 @@ import {
 
 /** What an `INTERNAL` transcript entry says about the workflow run. */
 export type WorkflowMarker =
-  | { readonly kind: 'attempt' }
   | { readonly kind: 'plan'; readonly plan: WorkflowPlanMarker }
   | { readonly kind: 'malformedPlan'; readonly error: string };
 
@@ -55,8 +54,9 @@ function internalMarkerKind(data: unknown): unknown {
 
 /**
  * Read the workflow marker one transcript entry carries, if any. Every host
- * folds these the same way: a new attempt starts with no plan until it records
- * one (an attempt that fails before then must not inherit its predecessor's),
+ * folds these the same way: the newest plan marker is the live plan (a
+ * relaunch under the same `meta.name` appends its own after the one it
+ * supersedes, and every attempt that reaches the engine records exactly one),
  * and a malformed plan is an unknown plan, not the previous attempt's.
  */
 export function workflowMarkerOf(
@@ -68,9 +68,7 @@ export function workflowMarkerOf(
   ) {
     return undefined;
   }
-  const kind = internalMarkerKind(entry.data);
-  if (kind === 'workflowAttempt') return { kind: 'attempt' };
-  if (kind !== 'workflowPlan') return undefined;
+  if (internalMarkerKind(entry.data) !== 'workflowPlan') return undefined;
   const parsed = WorkflowPlanMarkerSchema.safeParse(entry.data);
   return parsed.success
     ? { kind: 'plan', plan: parsed.data }

--- a/src/shared/transcript/projectTranscriptRow.ts
+++ b/src/shared/transcript/projectTranscriptRow.ts
@@ -572,7 +572,7 @@ export function projectTranscriptRow(
     // block a stream projects from several of them is, via
     // `compactionActivityRow`. `activeSkills` is a per-run snapshot read on
     // demand from the log (the CLI's `/status`), not a transcript row, and
-    // `internal` is a durable marker (the workflow-attempt boundary) that
+    // `internal` is a durable marker (the workflow plan) that
     // nothing renders. Context utilization is a status surface on both hosts —
     // the CLI reads it off `StreamExecutionState.contextState` and the webview
     // off the raw entry in `logSlice` — so it has no transcript row either.

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -107,25 +107,6 @@ function latestWorkflowCallEvents(
 beforeEach(() => clearStoreCache());
 
 describe('workflow-script progress bridge', () => {
-  it('announces an attempt before script parsing can fail', async () => {
-    const { trace, events } = recordingTrace();
-
-    await expect(
-      runScript(trace, 'invalid-script', 'not valid js'),
-    ).rejects.toThrow();
-
-    expect(events[0]).toMatchObject({
-      type: 'workflow.attempt',
-      attemptId: expect.any(String),
-    });
-    expect(
-      events.some(
-        (event) =>
-          event.type === 'workflow.call' || event.type === 'stage.start',
-      ),
-    ).toBe(false);
-  });
-
   it('records the declared plan once, before any phase opens', async () => {
     const { trace, events } = recordingTrace();
     await runScript(
@@ -147,8 +128,7 @@ return await agent('Inspect', { id: 'inspect' })`,
     const plans = events.filter((event) => event.type === 'workflow.plan');
     expect(plans).toHaveLength(1);
     expect(plans[0]).toMatchObject({
-      attemptId:
-        events[0]?.type === 'workflow.attempt' ? events[0].attemptId : '',
+      attemptId: expect.any(String),
       phases: [
         { title: 'Research', index: 0 },
         { title: 'Write', index: 1 },

--- a/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
+++ b/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
@@ -514,11 +514,7 @@ describe('transcript fold vs from-scratch oracle', () => {
     // attempt marker itself is an `internal` entry, which the shared projector
     // gives no row on either host.
     withStreamSubscription(() => {
-      const attemptMarker = (
-        id: string,
-        attemptId: string,
-        timestamp: number,
-      ) =>
+      const planMarker = (id: string, attemptId: string, timestamp: number) =>
         appendTranscriptEntry(defaultSession().transcripts, FOLD_STREAM, {
           id,
           type: STREAM_LOG_ENTRY_TYPES.LOG,
@@ -526,11 +522,11 @@ describe('transcript fold vs from-scratch oracle', () => {
           timestamp,
           messageType: MESSAGE_TYPES.INTERNAL,
           text: '',
-          data: { kind: 'workflowAttempt', attemptId },
+          data: { kind: 'workflowPlan', attemptId, phases: [], tasks: [] },
         });
 
       configureStreams(CONFIGS[2]);
-      attemptMarker('workflow-attempt-old', 'attempt-old', 1);
+      planMarker('workflow-attempt-old', 'attempt-old', 1);
       appendTranscriptEntry(defaultSession().transcripts, FOLD_STREAM, {
         id: 'old-failed',
         type: STREAM_LOG_ENTRY_TYPES.LOG,
@@ -562,7 +558,7 @@ describe('transcript fold vs from-scratch oracle', () => {
           ?.entries.map((entry) => entry.id),
       ).toEqual(['old-failed', 'survey-complete-old']);
 
-      attemptMarker('workflow-attempt-new', 'attempt-new', 4);
+      planMarker('workflow-attempt-new', 'attempt-new', 4);
       appendTranscriptEntry(defaultSession().transcripts, FOLD_STREAM, {
         id: 'new-running',
         type: STREAM_LOG_ENTRY_TYPES.LOG,

--- a/src/test-kernel/shared/TranscriptRowProjection.vitest.ts
+++ b/src/test-kernel/shared/TranscriptRowProjection.vitest.ts
@@ -143,7 +143,7 @@ describe('projectTranscriptRow', () => {
         ...base,
         messageType: MESSAGE_TYPES.INTERNAL,
         text: '',
-        data: { kind: 'workflowAttempt', attemptId: 'x' },
+        data: { kind: 'workflowPlan', attemptId: 'x', phases: [], tasks: [] },
       }),
     ).toBeUndefined();
   });

--- a/src/test-kernel/shared/WorkflowRunModel.vitest.ts
+++ b/src/test-kernel/shared/WorkflowRunModel.vitest.ts
@@ -340,9 +340,6 @@ describe('workflow run model', () => {
         data,
         verbose: false,
       }) as StreamLogEntry;
-    expect(
-      workflowMarkerOf(entry({ kind: 'workflowAttempt', attemptId: 'a' })),
-    ).toStrictEqual({ kind: 'attempt' });
     const plan = {
       kind: 'workflowPlan',
       attemptId: 'a',

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -51,24 +51,6 @@ function dataOf(entry: StreamLogEntry | undefined): Record<string, unknown> {
 }
 
 describe('attachTranscriptRecorder StreamPhase-native group rows (issue #7993)', () => {
-  it('persists a workflow attempt before it has tasks or phases', () => {
-    const { trace, rows } = attachRecorder();
-
-    trace.emit({ type: 'workflow.attempt', attemptId: 'attempt-empty' });
-
-    expect(rows()).toContainEqual(
-      expect.objectContaining({
-        id: 'workflow-attempt-attempt-empty',
-        type: STREAM_LOG_ENTRY_TYPES.LOG,
-        messageType: MESSAGE_TYPES.INTERNAL,
-        data: {
-          kind: 'workflowAttempt',
-          attemptId: 'attempt-empty',
-        },
-      }),
-    );
-  });
-
   it("writes GROUP_START's data.status as StreamPhase.RUNNING", () => {
     const { trace, row } = attachRecorder();
 

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -593,11 +593,6 @@ export async function runPersistedWorkflowScriptWithProgress(
     }
   };
 
-  // The physical attempt exists even when parsing or initial persistence fails
-  // before the engine can emit a plan, phase, or call. Publish its boundary
-  // first so live projections never infer the current run from optional work.
-  trace.emit({ type: 'workflow.attempt', attemptId: projectionId });
-
   try {
     const result = await runPersistedWorkflowScript({
       ...runOptions,

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -48,7 +48,6 @@ import {
   type LogLevel,
   type MessageType,
   type ToolUseLog,
-  type WorkflowAttemptMarker,
   type WorkflowPlanMarker,
   type WorkflowCallProgress,
 } from '@shared/schemas';
@@ -538,24 +537,6 @@ export function attachTranscriptRecorder(
             writer.settle(event.logId, patch);
             activeToolEntries.delete(event.logId);
           }
-          return;
-        }
-
-        case 'workflow.attempt': {
-          const marker = {
-            kind: 'workflowAttempt',
-            attemptId: event.attemptId,
-          } satisfies WorkflowAttemptMarker;
-          writer.appendSettled({
-            id: `workflow-attempt-${event.attemptId}`,
-            type: STREAM_LOG_ENTRY_TYPES.LOG,
-            level: 'info',
-            timestamp: Date.now(),
-            groupId: event.stageId,
-            messageType: MESSAGE_TYPES.INTERNAL,
-            data: marker,
-            verbose: false,
-          });
           return;
         }
 


### PR DESCRIPTION
## What

Bundle 2 (S5) of [the 2026-08-29 survey](docs/proposals/2026-08-29-simplification-survey-shared-workflow-model.md), found independently by two scouts and verified.

`workflow.attempt` and its `workflowAttempt` INTERNAL transcript entry had exactly one reader — `workflowMarkerOf`'s `attempt` arm — which both hosts reduced to "no plan until a plan marker arrives". The attempt is already on the wire twice (`attemptId` on the plan marker and on every card), the model scopes cards by the cards' own ids and never by the marker, and every attempt that reaches the engine records exactly one plan marker on its first fold (constructor `#emit()` → first fold, unconditional, empty phases/tasks for a dynamic script). So "newest plan marker wins" is the whole rule.

Deleted: `WorkflowAttemptEvent` and its union arm, the recorder case, `WorkflowAttemptMarker`, the emit in the projection, the `attempt` arm of `WorkflowMarker`, the CLI fold's reset branch, and the board's comment that described it. Old persisted markers still parse: INTERNAL data is `z.unknown()` and an unknown kind reads as no marker.

**The one behaviour change:** a relaunch that dies before engine construction used to show the predecessor's cards with *no* plan (a half reset — cards were never cleared by the marker); it now shows the predecessor's plan beside its cards, consistently, and the run stream carries the failure.

## Net elements (R6)

`git diff --stat origin/main`: production 8 files, **+11 / −52**; tests 5 files, +4 / −48 (two pins retired — "persists a workflow attempt", "announces an attempt before script parsing can fail"; two fixtures now use a plan marker as their "INTERNAL entry with no row"; one plan expectation uses `expect.any(String)`). Exported symbols −1 (`WorkflowAttemptMarker`); declarations −1 (`WorkflowAttemptEvent`); −1 `AgentEvent` arm, −1 `WorkflowMarker` arm, −1 transcript INTERNAL kind.

## Consumer counts (R8)

Emit path deleted: `workflow.attempt` — subscribers at `origin/main`: 1 (the recorder). INTERNAL `workflowAttempt` entry readers: 1 (`workflowMarkerOf`). `WorkflowAttemptMarker` prod / test files: 2 / 0.

## Verified

- `npm run typecheck` — clean; `npm run lint` + prettier — clean on changed files
- vitest `src/test-kernel/{shared,cli,progressView,agent,transcript}` — 438 files, 6,548 tests passing
- `npm run check:dead-code-ratchet` — no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QESykrKh1yzvF2bB4pjDrS