### PR TITLE
feat(skills): add workspace availability controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Features
+
+- **Choose skills per workspace** — the extension, desktop app, and CLI now let
+  you enable or disable individual skills and skill source groups from one
+  consolidated skills display.
+
 ## [0.40.6] - 2026-08-28
 
 ### Shared (all surfaces)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable changes to this project will be documented in this file.
 
 - **Choose skills per workspace** — the extension, desktop app, and CLI now let
   you enable or disable individual skills and skill source groups from one
-  consolidated skills display.
+  consolidated skills display. Skills are off by default until you enable the
+  master skills switch.
 
 ## [0.40.6] - 2026-08-28
 

--- a/docs/dev/skill-authoring.md
+++ b/docs/dev/skill-authoring.md
@@ -32,5 +32,5 @@ A user or agent opening a skill package in isolation should be able to answer:
 The Skills tab in the extension and desktop settings lets you disable an
 individual skill or an entire source group for the current workspace. The CLI
 offers the same project-scoped controls under `/config`; `/skills` continues to
-list only skills that are available for activation. The existing master switch
-can disable skill prompt injection without changing these selections.
+list only skills that are available for activation. Skills are off by default.
+The master switch controls prompt injection without changing these selections.

--- a/docs/dev/skill-authoring.md
+++ b/docs/dev/skill-authoring.md
@@ -26,3 +26,11 @@ A user or agent opening a skill package in isolation should be able to answer:
 - What workflow should I follow?
 - What quality bar am I aiming for?
 - Where do I look if I need the deeper checklist?
+
+## Workspace availability
+
+The Skills tab in the extension and desktop settings lets you disable an
+individual skill or an entire source group for the current workspace. The CLI
+offers the same project-scoped controls under `/config`; `/skills` continues to
+list only skills that are available for activation. The existing master switch
+can disable skill prompt injection without changing these selections.

--- a/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
@@ -37,6 +37,7 @@ import {
   type ProviderApiKeyStatusView,
 } from './ProviderApiKeyForm';
 import { ToolsListForm } from './ToolsListForm';
+import { SkillsSettingsForm } from './SkillsSettingsForm';
 
 export interface CliConfigFormProps {
   readonly availableRows?: number;
@@ -255,6 +256,13 @@ export function createCliConfigFormProps(
       ),
       tools: (onBack) => (
         <ToolsListForm availableRows={props.availableRows} onClose={onBack} />
+      ),
+      skills: (onBack) => (
+        <SkillsSettingsForm
+          availableRows={props.availableRows}
+          stores={stores}
+          onClose={onBack}
+        />
       ),
     },
     onClose: props.onClose,

--- a/packages/cli/src/chat/tui/forms/SkillsSettingsForm.tsx
+++ b/packages/cli/src/chat/tui/forms/SkillsSettingsForm.tsx
@@ -1,0 +1,133 @@
+import { Text } from 'ink';
+
+import {
+  ActiveSkillSourceScopeSchema,
+  stateSettingByKey,
+  type ActiveSkillSourceScope,
+  type SkillDisplayItem,
+} from '@shared/schemas';
+import type { SettingsStores } from '@shared/config/settingsAccess';
+import { readSetting } from '@shared/config/settingsAccess';
+import { applyStateSettingUpdate } from '@shared/settingsView/handlers/stateSettingWrite';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import { loadRuntimeSkillDisplay } from '@skills/runtimeSkills';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+
+import { setTransientNotice } from '../state/cliState';
+import { AsyncListForm } from './_shared/ListForm';
+
+type SkillToggle =
+  | { readonly kind: 'source'; readonly scope: ActiveSkillSourceScope }
+  | { readonly kind: 'skill'; readonly name: string };
+
+interface SkillsSettingsData {
+  readonly skills: SkillDisplayItem[];
+  readonly disabledNames: string[];
+  readonly disabledScopes: ActiveSkillSourceScope[];
+  readonly issueCount: number;
+}
+
+export interface SkillsSettingsFormProps {
+  readonly availableRows?: number;
+  readonly stores: SettingsStores;
+  readonly onClose: () => void;
+}
+
+function requireSetting(key: string) {
+  const entry = stateSettingByKey(key);
+  if (!entry) throw new Error(`Missing skill setting: ${key}`);
+  return entry;
+}
+
+async function loadSkillsSettings(
+  stores: SettingsStores,
+): Promise<SkillsSettingsData> {
+  const disabledNames = readSetting(
+    requireSetting(WorkspaceStateKey.DISABLED_SKILLS),
+    stores,
+    'cli',
+  ) as string[];
+  const disabledScopes = readSetting(
+    requireSetting(WorkspaceStateKey.DISABLED_SKILL_SOURCES),
+    stores,
+    'cli',
+  ) as ActiveSkillSourceScope[];
+  const result = await loadRuntimeSkillDisplay({
+    names: disabledNames,
+    scopes: disabledScopes,
+  });
+  return {
+    skills: result.skills,
+    disabledNames,
+    disabledScopes,
+    issueCount: result.issues.length,
+  };
+}
+
+function toggleDisabled<T>(
+  values: readonly T[],
+  value: T,
+  currentlyDisabled: boolean,
+): T[] {
+  return currentlyDisabled
+    ? values.filter((candidate) => candidate !== value)
+    : [...new Set([...values, value])];
+}
+
+export function SkillsSettingsForm(
+  props: SkillsSettingsFormProps,
+): React.JSX.Element {
+  return (
+    <AsyncListForm<SkillsSettingsData, SkillToggle>
+      title="/config · Skills"
+      loadingLabel="Loading skills..."
+      load={() => loadSkillsSettings(props.stores)}
+      items={(data) => [
+        ...ActiveSkillSourceScopeSchema.options.map((scope) => ({
+          value: { kind: 'source' as const, scope },
+          label: `Source: ${scope}`,
+          description: data.disabledScopes.includes(scope)
+            ? 'disabled'
+            : 'enabled',
+        })),
+        ...data.skills.map((skill) => ({
+          value: { kind: 'skill' as const, name: skill.name },
+          label: skill.name,
+          description: `${skill.label} · ${skill.enabled ? 'enabled' : 'disabled'} · ${skill.description}`,
+        })),
+      ]}
+      availableRows={props.availableRows}
+      description={<Text dimColor>Toggle skills for this project.</Text>}
+      detailFor={(data) =>
+        data.issueCount > 0 ? (
+          <Text dimColor>{data.issueCount} skill load issues</Text>
+        ) : undefined
+      }
+      detailRowsFor={(data) => (data.issueCount > 0 ? 1 : 0)}
+      action="toggle"
+      showTransientCloseHint={false}
+      onSelect={(toggle, { data, reload }) => {
+        const key =
+          toggle.kind === 'source'
+            ? WorkspaceStateKey.DISABLED_SKILL_SOURCES
+            : WorkspaceStateKey.DISABLED_SKILLS;
+        const current =
+          toggle.kind === 'source' ? data.disabledScopes : data.disabledNames;
+        const value = toggle.kind === 'source' ? toggle.scope : toggle.name;
+        const next = toggleDisabled(current, value, current.includes(value));
+        void applyStateSettingUpdate(key, next, {
+          host: 'cli',
+          stores: props.stores,
+        })
+          .then((result) => {
+            if (result.kind !== 'applied') {
+              throw new Error(`Could not update skills (${result.kind}).`);
+            }
+            reload();
+          })
+          .catch((error: unknown) => setTransientNotice(toErrorMessage(error)));
+      }}
+      onCancel={props.onClose}
+    />
+  );
+}

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from 'citty';
 
 import { CliExitCode } from '../runtime/exitCodes';
+import { initCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
 import {
   formatCliSkillIssue,
@@ -25,6 +26,7 @@ async function listSkills(
     readonly additionalPaths: readonly string[];
   },
 ): Promise<number> {
+  await initCliPlatform({ ...context, quietLogs: true });
   const result = await readCliSkills(context, options);
   const exitCode = result.errors.some(
     (issue) =>

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -389,6 +389,7 @@ export async function initCliPlatform(
   });
 
   initializeNodeRuntimeSkills({
+    host: 'cli',
     cwd: context.cwd,
     resourcesPath: context.resourcesPath,
     skillSourceOptions: context.skillSourceOptions,

--- a/packages/cli/src/runtime/skills.ts
+++ b/packages/cli/src/runtime/skills.ts
@@ -10,7 +10,10 @@ import {
   defaultSkillSources,
   type SkillSourceOptions,
 } from '@skills/skillSources';
-import { listRuntimeSkillSources } from '@skills/runtimeSkills';
+import {
+  filterDiscoveredSkills,
+  loadEnabledRuntimeSkills,
+} from '@skills/runtimeSkills';
 
 // Local imports - CLI runtime
 import type { CliContext } from './cliContext';
@@ -39,11 +42,13 @@ export async function readCliSkills(
   context: Pick<CliContext, 'cwd' | 'resourcesPath'>,
   options: SkillSourceOptions = {},
 ): Promise<DiscoverSkillSourcesResult> {
-  return discoverSkillSources(defaultSkillSources(context, options));
+  return filterDiscoveredSkills(
+    await discoverSkillSources(defaultSkillSources(context, options)),
+  );
 }
 
 export async function readCliRuntimeSkills(): Promise<DiscoverSkillSourcesResult> {
-  return discoverSkillSources(listRuntimeSkillSources());
+  return loadEnabledRuntimeSkills();
 }
 
 export function formatCliSkillIssue(issue: SkillLoadIssue): string {

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -29,6 +29,7 @@ import { unsupported, unsupportedCommands } from '@shared/utils/dispatcher';
 import { buildSettingsSnapshotMessage } from '@shared/settingsView/handlers/settingsSnapshot';
 import type { SettingsStores } from '@shared/config/settingsAccess';
 import type { SettingsStatePorts } from '@shared/settingsView/types';
+import { loadRuntimeSkillDisplay } from '@skills/runtimeSkills';
 import { GoalStore, subscribeGoalStateChanges } from '@tools/goal';
 import { refreshToolAvailability } from '@tools/toolAvailability';
 import {
@@ -158,6 +159,14 @@ export function createDesktopSettingsIpc(
     );
   }
 
+  async function postSkillsList(): Promise<void> {
+    const result = await loadRuntimeSkillDisplay();
+    options.postToRenderer({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_SKILLS_LIST,
+      ...result,
+    });
+  }
+
   async function openMemoryFile(input: { storagePath: string }): Promise<void> {
     const resolvedPath = resolveMemoryStoragePath(input.storagePath);
     await options.ui.openPath(StorageFS.fullPath(resolvedPath));
@@ -193,11 +202,12 @@ export function createDesktopSettingsIpc(
     const modelSelectionDataPosted = settingsHost.sendModelSelectionData();
     postSettingsSnapshot('multi-agent');
     postSettingsSnapshot('approval');
-    postSettingsSnapshot('agent-skills');
+    postSettingsSnapshot('skills');
     postSettingsSnapshot('telemetry');
     postSettingsSnapshot('memory');
     await Promise.all([
       goalListPosted,
+      postSkillsList(),
       settingsHost.sendMemoryData(),
       modelSelectionDataPosted,
       postGitHubTokenStatus(),
@@ -228,7 +238,6 @@ export function createDesktopSettingsIpc(
   }
 
   const stateSettingSnapshotPosters: SettingsSnapshotPosters = {
-    'agent-skills': () => postSettingsSnapshot('agent-skills'),
     approval: () => postSettingsSnapshot('approval'),
     'git-author': () => {
       // Git identity is also process env, so the write must reach `git` before
@@ -241,6 +250,10 @@ export function createDesktopSettingsIpc(
     models: () => settingsHost.sendModelSelectionData(),
     'multi-agent': () => postSettingsSnapshot('multi-agent'),
     profile: () => options.credentialSettingsController.postProfileData(),
+    skills: async () => {
+      postSettingsSnapshot('skills');
+      await postSkillsList();
+    },
     telemetry: () => postSettingsSnapshot('telemetry'),
   };
 

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -146,6 +146,7 @@ export async function initializeElectronPlatform(
   // desktop cannot wire one prompt and forget another the way it once did.
   initializeBundledPrompts(resourcesPath);
   initializeNodeRuntimeSkills({
+    host: 'desktop',
     cwd: workspacePath ?? app.getPath('home'),
     resourcesPath,
   });

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -498,6 +498,7 @@ async function activateExtension(context: vscode.ExtensionContext) {
   // (`initNodeAgentRuntime`, which registers the direct Lean adapter, stays
   // out: VS Code drives Lean through its own integration.)
   initializeNodeRuntimeSkills({
+    host: 'vscode',
     cwd: workspaceRoot,
     resourcesPath: path.join(context.extensionPath, 'resources'),
   });

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -84,6 +84,7 @@ import {
 import { unsupportedCommands } from '@shared/utils/dispatcher';
 import { buildSettingsSnapshotMessage } from '@shared/settingsView/handlers/settingsSnapshot';
 import type { SettingsStores } from '@shared/config/settingsAccess';
+import { loadRuntimeSkillDisplay } from '@skills/runtimeSkills';
 import {
   getLastCheckResults,
   refreshToolAvailability,
@@ -458,7 +459,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       this.grokHandlers.sendAuthStatus(webview),
       this.githubHandlers.sendPRSubscriptions(webview),
       this.sendSettingsSnapshot(webview, 'approval'),
-      this.sendSettingsSnapshot(webview, 'agent-skills'),
+      this.sendSettingsSnapshot(webview, 'skills'),
+      this.sendSkillsList(webview),
       this.sendSettingsSnapshot(webview, 'telemetry'),
       this.latexHandlers.sendLatexSettingsStatus(webview),
       this.sendSettingsSnapshot(webview, 'latex'),
@@ -532,6 +534,14 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     );
   }
 
+  private async sendSkillsList(webview: vscode.Webview): Promise<void> {
+    const result = await loadRuntimeSkillDisplay();
+    await webview.postMessage({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_SKILLS_LIST,
+      ...result,
+    });
+  }
+
   /**
    * Generic write path for catalog-backed settings-view rows.
    */
@@ -584,7 +594,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     snapshot: SettingsViewSnapshot,
   ): Promise<void> {
     await dispatchStateSettingSnapshot(snapshot, {
-      'agent-skills': () => this.rebroadcastSnapshot('agent-skills'),
       approval: () => this.rebroadcastSnapshot('approval'),
       'git-author': () => {
         // Git identity is also process env, so the write must reach `git`
@@ -598,6 +607,10 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         this.withActiveWebview((w) => this.sendModelSelectionData(w)),
       'multi-agent': () => this.rebroadcastSnapshot('multi-agent'),
       profile: () => this.withActiveWebview((w) => this.sendProfileData(w)),
+      skills: async () => {
+        await this.rebroadcastSnapshot('skills');
+        await this.withActiveWebview((w) => this.sendSkillsList(w));
+      },
       telemetry: () => this.rebroadcastSnapshot('telemetry'),
     });
   }

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -46,6 +46,7 @@ import './tabs/ModelsTab';
 import './tabs/AgentsTab';
 import './tabs/MultiAgentTab';
 import './tabs/ToolsTab';
+import './tabs/SkillsTab';
 import './tabs/AIAgentsTab';
 import './tabs/GitTab';
 import './tabs/LaTeXTab';
@@ -78,6 +79,8 @@ import {
   customAgentScanIssues,
   customPresets,
   detachSubagentsOnStop,
+  disabledSkills,
+  disabledSkillSources,
   multiAgentSettingsRevision,
   editApprovalEnabled,
   gitAuthorEmail,
@@ -105,6 +108,8 @@ import {
   resetSettingsState,
   selectedPanel,
   sessionProblem,
+  skillLoadIssues,
+  skillsList,
   subscriptionUsage,
   telemetryEnabled,
   toolDashboardItems,
@@ -420,8 +425,17 @@ export class SettingsApp extends SettingsAppBase {
             .bashApprovalEnabled=${bashApprovalEnabled.get()}
             .editApprovalEnabled=${editApprovalEnabled.get()}
             .toolPathProtectionEnabled=${toolPathProtectionEnabled.get()}
-            .agentSkillsEnabled=${agentSkillsEnabled.get()}
           ></tools-tab>
+        `;
+      case 'skills':
+        return html`
+          <skills-tab
+            .masterEnabled=${agentSkillsEnabled.get()}
+            .disabledSkills=${disabledSkills.get()}
+            .disabledSources=${disabledSkillSources.get()}
+            .skills=${skillsList.get()}
+            .issues=${skillLoadIssues.get()}
+          ></skills-tab>
         `;
       case 'ai-agents':
         return html`

--- a/packages/extension/src/settingsView/frontend/messageDispatcher.ts
+++ b/packages/extension/src/settingsView/frontend/messageDispatcher.ts
@@ -9,8 +9,8 @@
  * Handlers are organized into domain-specific slices under ./slices/, one per
  * section of `SettingsApp`'s state (see `settingsState.ts`) — except
  * miscSettingsSlice.ts, which bundles the single-command/single-toggle
- * handlers that don't own a state section of their own (agent skills,
- * telemetry, goals, agent teams, tool dashboard, multi-agent coordination).
+ * handlers that don't own a state section of their own (telemetry, goals,
+ * agent teams, tool dashboard, multi-agent coordination).
  * modelSelectionSlice.ts and approvalSettingsSlice.ts are also single-command
  * but stay standalone: each owns a named, independently-surfaced state
  * section (model selection, approval/safety) rather than a one-off toggle.
@@ -27,7 +27,6 @@ import { gitHandlers } from './slices/gitSlice';
 import { latexHandlers } from './slices/latexSlice';
 import { memoryHandlers } from './slices/memorySlice';
 import {
-  agentSkillsSettingsHandlers,
   agentTeamsHandlers,
   goalHandlers,
   multiAgentHandlers,
@@ -36,6 +35,7 @@ import {
 } from './slices/miscSettingsSlice';
 import { modelSelectionHandlers } from './slices/modelSelectionSlice';
 import { profileHandlers } from './slices/profileSlice';
+import { skillsHandlers } from './slices/skillsSlice';
 import { subscriptionUsageHandlers } from './slices/subscriptionUsageSlice';
 import { tabHandlers } from './slices/tabSlice';
 
@@ -46,7 +46,7 @@ export const settingsViewHandlers: SettingsViewOutboundHandlerRegistry = {
   ...profileHandlers,
   ...modelSelectionHandlers,
   ...agentSelectionHandlers,
-  ...agentSkillsSettingsHandlers,
+  ...skillsHandlers,
   ...telemetrySettingsHandlers,
   ...agentTeamsHandlers,
   ...multiAgentHandlers,

--- a/packages/extension/src/settingsView/frontend/settingsNav.ts
+++ b/packages/extension/src/settingsView/frontend/settingsNav.ts
@@ -67,6 +67,11 @@ const SETTINGS_TAB_METADATA: Record<
     description:
       'Review tool availability, permissions, and desktop diagnostics.',
   },
+  SKILLS: {
+    icon: 'wand-magic-sparkles',
+    label: 'Skills',
+    description: 'Choose which reusable instructions agents can load.',
+  },
   AI_AGENTS: {
     icon: 'link',
     label: 'Integrations',

--- a/packages/extension/src/settingsView/frontend/settingsState.ts
+++ b/packages/extension/src/settingsView/frontend/settingsState.ts
@@ -58,6 +58,8 @@ import {
   type ModelSelectionItem,
   type ProviderKeyStatus,
   type PRSubscriptionEntry,
+  type SkillDisplayIssue,
+  type SkillDisplayItem,
   type SubscriptionUsageSnapshots,
   type ToolDashboardItem,
 } from '@shared/schemas';
@@ -245,6 +247,14 @@ export const toolPathProtectionEnabled = settingSignal<boolean>(
 export const agentSkillsEnabled = settingSignal<boolean>(
   AGENT_SKILLS_CONFIG_KEY,
 );
+export const disabledSkills = settingSignal<string[]>(
+  WorkspaceStateKey.DISABLED_SKILLS,
+);
+export const disabledSkillSources = settingSignal<string[]>(
+  WorkspaceStateKey.DISABLED_SKILL_SOURCES,
+);
+export const skillsList = trackedSignal<SkillDisplayItem[]>(() => []);
+export const skillLoadIssues = trackedSignal<SkillDisplayIssue[]>(() => []);
 export const telemetryEnabled = settingSignal<boolean>(TELEMETRY_ENABLED_KEY);
 export const codexSandboxMode = settingSignal<CodexSandboxMode>(
   WorkspaceStateKey.CODEX_SANDBOX_MODE,

--- a/packages/extension/src/settingsView/frontend/slices/miscSettingsSlice.ts
+++ b/packages/extension/src/settingsView/frontend/slices/miscSettingsSlice.ts
@@ -1,6 +1,6 @@
 /**
  * Single-command, single-toggle handlers with no state section of their own:
- * agent skills, telemetry, goals, agent teams, tool dashboard, multi-agent
+ * telemetry, goals, agent teams, tool dashboard, and multi-agent
  * coordination. Bundled here rather than split one-file-per-command; see
  * ../messageDispatcher.ts for why modelSelectionSlice.ts and
  * approvalSettingsSlice.ts (also single-command) stay separate.
@@ -18,12 +18,6 @@ import {
   toolDashboardItems,
   toolDashboardLoaded,
 } from '../settingsState';
-
-export const agentSkillsSettingsHandlers = {
-  [SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SKILLS_SETTINGS]: (data) => {
-    applySettingsSnapshot(data.values);
-  },
-} satisfies Partial<SettingsViewOutboundHandlerRegistry>;
 
 export const telemetrySettingsHandlers = {
   [SETTINGS_VIEW_COMMANDS.UPDATE_TELEMETRY_SETTINGS]: (data) => {

--- a/packages/extension/src/settingsView/frontend/slices/skillsSlice.ts
+++ b/packages/extension/src/settingsView/frontend/slices/skillsSlice.ts
@@ -1,0 +1,18 @@
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import type { SettingsViewOutboundHandlerRegistry } from '@shared/schemas';
+
+import {
+  applySettingsSnapshot,
+  skillLoadIssues,
+  skillsList,
+} from '../settingsState';
+
+export const skillsHandlers = {
+  [SETTINGS_VIEW_COMMANDS.UPDATE_SKILLS_SETTINGS]: (data) => {
+    applySettingsSnapshot(data.values);
+  },
+  [SETTINGS_VIEW_COMMANDS.UPDATE_SKILLS_LIST]: (data) => {
+    skillsList.set(data.skills);
+    skillLoadIssues.set(data.issues);
+  },
+} satisfies Partial<SettingsViewOutboundHandlerRegistry>;

--- a/packages/extension/src/settingsView/frontend/tabs/SkillsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/SkillsTab.ts
@@ -1,0 +1,195 @@
+import '@awesome.me/webawesome/dist/components/switch/switch.js';
+
+import { LitElement, css, html, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+
+import {
+  AGENT_SKILLS_CONFIG_KEY,
+  ActiveSkillSourceScopeSchema,
+  type ActiveSkillSourceScope,
+  type SkillDisplayIssue,
+  type SkillDisplayItem,
+} from '@shared/schemas';
+import { commonViewStyles, designTokens } from '@shared/styles';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import { renderSettingsSectionHeading } from '@shared/wa/settingsSection';
+import { groupBy } from '@utils/core';
+
+import {
+  postStateSetting,
+  renderStateSettingToggleRow,
+} from '../components/shared/stateSettingRows';
+
+import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
+
+const SOURCE_LABELS: Record<ActiveSkillSourceScope, string> = {
+  bundled: 'Bundled',
+  project: 'Project',
+  user: 'User',
+  custom: 'Custom',
+  interop: 'Imported',
+};
+
+@customElement('skills-tab')
+export class SkillsTab extends LitElement {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    css`
+      :host {
+        display: block;
+      }
+      code {
+        overflow-wrap: anywhere;
+      }
+      .skill-issues {
+        color: var(--wa-color-danger-text);
+      }
+      .empty-state {
+        padding-block: var(--wa-space-l);
+        text-align: center;
+      }
+    `,
+  ];
+
+  @property({ type: Boolean }) masterEnabled = true;
+  @property({ attribute: false }) disabledSkills: string[] = [];
+  @property({ attribute: false }) disabledSources: ActiveSkillSourceScope[] =
+    [];
+  @property({ attribute: false }) skills: SkillDisplayItem[] = [];
+  @property({ attribute: false }) issues: SkillDisplayIssue[] = [];
+
+  private toggleValue<T>(
+    values: readonly T[],
+    value: T,
+    enabled: boolean,
+  ): T[] {
+    return enabled
+      ? values.filter((candidate) => candidate !== value)
+      : [...new Set([...values, value])];
+  }
+
+  private renderSourceToggle(scope: ActiveSkillSourceScope): TemplateResult {
+    const checked = !this.disabledSources.includes(scope);
+    return html`
+      <div class="settings-row">
+        <div class="settings-row-text">
+          <span class="settings-row-label">${SOURCE_LABELS[scope]}</span>
+          <span class="settings-row-help">${scope} skill sources</span>
+        </div>
+        <div class="settings-row-control">
+          <wa-switch
+            aria-label=${`${SOURCE_LABELS[scope]} skill sources`}
+            .checked=${checked}
+            ?disabled=${!this.masterEnabled}
+            @change=${(event: Event) =>
+              postStateSetting(
+                WorkspaceStateKey.DISABLED_SKILL_SOURCES,
+                this.toggleValue(
+                  this.disabledSources,
+                  scope,
+                  Boolean((event.target as WaSwitch).checked),
+                ),
+              )}
+          ></wa-switch>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderSkill(item: SkillDisplayItem): TemplateResult {
+    const sourceEnabled = !this.disabledSources.includes(item.scope);
+    return html`
+      <div class="settings-row">
+        <div class="settings-row-text">
+          <span class="settings-row-label">${item.name}</span>
+          <span class="settings-row-help">${item.description}</span>
+          <span class="settings-row-help"><code>${item.path}</code></span>
+        </div>
+        <div class="settings-row-control">
+          <wa-switch
+            aria-label=${`Enable ${item.name}`}
+            .checked=${item.enabled}
+            ?disabled=${!this.masterEnabled || !sourceEnabled}
+            @change=${(event: Event) =>
+              postStateSetting(
+                WorkspaceStateKey.DISABLED_SKILLS,
+                this.toggleValue(
+                  this.disabledSkills,
+                  item.name,
+                  Boolean((event.target as WaSwitch).checked),
+                ),
+              )}
+          ></wa-switch>
+        </div>
+      </div>
+    `;
+  }
+
+  override render(): TemplateResult {
+    const groups = groupBy(this.skills, (skill) => skill.scope);
+    return html`
+      <div class="tab-content-container">
+        <div class="settings-section">
+          ${renderStateSettingToggleRow({
+            key: AGENT_SKILLS_CONFIG_KEY,
+            checked: this.masterEnabled,
+          })}
+        </div>
+        <div class="category-section">
+          ${renderSettingsSectionHeading({
+            icon: 'folder-tree',
+            title: 'Sources',
+            description: 'Choose which workspace skill sources are available.',
+          })}
+          <div class="settings-section">
+            ${ActiveSkillSourceScopeSchema.options.map((scope) =>
+              this.renderSourceToggle(scope),
+            )}
+          </div>
+        </div>
+        ${
+          this.issues.length === 0
+            ? nothing
+            : html`<div class="skill-issues" role="status">
+                ${this.issues.length} skill load
+                issue${this.issues.length === 1 ? '' : 's'}:
+                ${this.issues.map((issue) => issue.message).join('; ')}
+              </div>`
+        }
+        ${
+          this.skills.length === 0
+            ? html`<div class="empty-state">No skills discovered</div>`
+            : ActiveSkillSourceScopeSchema.options.flatMap((scope) => {
+                const items = groups.get(scope);
+                return items
+                  ? [
+                      html`<div class="category-section">
+                        ${renderSettingsSectionHeading({
+                          icon: 'wand-magic-sparkles',
+                          title: `${SOURCE_LABELS[scope]} (${items.length})`,
+                          description: `Skills discovered from ${scope} sources.`,
+                        })}
+                        <div class="settings-section">
+                          ${repeat(
+                            items,
+                            (item) => item.path,
+                            (item) => this.renderSkill(item),
+                          )}
+                        </div>
+                      </div>`,
+                    ]
+                  : [];
+              })
+        }
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'skills-tab': SkillsTab;
+  }
+}

--- a/packages/extension/src/settingsView/frontend/tabs/SkillsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/SkillsTab.ts
@@ -53,7 +53,7 @@ export class SkillsTab extends LitElement {
     `,
   ];
 
-  @property({ type: Boolean }) masterEnabled = true;
+  @property({ type: Boolean }) masterEnabled = false;
   @property({ attribute: false }) disabledSkills: string[] = [];
   @property({ attribute: false }) disabledSources: ActiveSkillSourceScope[] =
     [];

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -18,7 +18,6 @@ import {
 import {
   type ToolCategory,
   type ToolDashboardItem,
-  AGENT_SKILLS_CONFIG_KEY,
   BASH_APPROVAL_CONFIG_KEY,
   TOOL_EDIT_APPROVAL_CONFIG_KEY,
 } from '@shared/schemas';
@@ -166,7 +165,6 @@ export class ToolsTab extends LitElement {
   @property({ type: Boolean }) bashApprovalEnabled = true;
   @property({ type: Boolean }) editApprovalEnabled = true;
   @property({ type: Boolean }) toolPathProtectionEnabled = true;
-  @property({ type: Boolean }) agentSkillsEnabled = true;
 
   private handleRecheck(): void {
     postMessage(SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS);
@@ -211,24 +209,6 @@ export class ToolsTab extends LitElement {
           ${renderStateSettingToggleRow({
             key: BASH_APPROVAL_CONFIG_KEY,
             checked: this.bashApprovalEnabled,
-          })}
-        </div>
-      </div>
-    `;
-  }
-
-  private renderAgentSkillsSettings(): TemplateResult {
-    return html`
-      <div class="category-section">
-        ${renderSettingsSectionHeading({
-          icon: 'robot',
-          title: 'Agent skills',
-          description: 'Extend tool-use agents with reusable skill packages.',
-        })}
-        <div class="settings-section">
-          ${renderStateSettingToggleRow({
-            key: AGENT_SKILLS_CONFIG_KEY,
-            checked: this.agentSkillsEnabled,
           })}
         </div>
       </div>
@@ -315,7 +295,7 @@ export class ToolsTab extends LitElement {
             onClick: () => this.handleRecheck(),
           })}
         </div>
-        ${this.renderAgentSkillsSettings()} ${this.renderApprovalSettings()}
+        ${this.renderApprovalSettings()}
         ${CATEGORY_ORDER.flatMap((cat) => {
           const catItems = groups.get(cat);
           return catItems ? [this.renderCategory(cat, catItems)] : [];

--- a/src/platform/defaults/nodeHost.ts
+++ b/src/platform/defaults/nodeHost.ts
@@ -17,6 +17,7 @@
 
 // Local imports
 import { bootstrapPlatformAgentDirectories } from '@agent/index/platformAgentDirectories';
+import type { SettingHost } from '@shared/schemas';
 import { setRuntimeSkillSources } from '@skills/runtimeSkills';
 import {
   defaultSkillSources,
@@ -92,6 +93,7 @@ export interface NodeAgentDirectoryBootstrapOptions {
 }
 
 export interface NodeRuntimeSkillOptions {
+  readonly host: SettingHost;
   readonly cwd: string;
   readonly resourcesPath: string;
   readonly skillSourceOptions?: SkillSourceOptions;
@@ -154,6 +156,7 @@ export function initializeNodeRuntimeSkills(
       },
       options.skillSourceOptions,
     ),
+    options.host,
   );
 }
 

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -317,7 +317,8 @@ export const SETTINGS_VIEW_COMMANDS = {
   // Stable outbound name for the broader execution-permissions-and-safety
   // snapshot (bash approval, coding-agent controls, and tool path protection).
   UPDATE_APPROVAL_SETTINGS: 'updateApprovalSettings',
-  UPDATE_AGENT_SKILLS_SETTINGS: 'updateAgentSkillsSettings',
+  UPDATE_SKILLS_SETTINGS: 'updateSkillsSettings',
+  UPDATE_SKILLS_LIST: 'updateSkillsList',
   UPDATE_TELEMETRY_SETTINGS: 'updateTelemetrySettings',
   UPDATE_TOOL_DASHBOARD: 'updateToolDashboard',
   UPDATE_GIT_AUTHOR_SETTINGS: 'updateGitAuthorSettings',

--- a/src/shared/schemas/activeSkills.ts
+++ b/src/shared/schemas/activeSkills.ts
@@ -12,7 +12,7 @@ export const ACTIVE_SKILLS_SNAPSHOT_MAX_SKILLS = 200;
 /** Canonical skill-source scope vocabulary, shared with the skills loader
  *  (`src/skills/loadSkills.ts`) so the loader and the persisted snapshot wire
  *  contract can't drift — a scope added here is representable everywhere. */
-const ActiveSkillSourceScopeSchema = z.enum([
+export const ActiveSkillSourceScopeSchema = z.enum([
   'bundled',
   'user',
   'project',

--- a/src/shared/schemas/agentSkills.ts
+++ b/src/shared/schemas/agentSkills.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const AGENT_SKILLS_CONFIG_KEY = 'texra.skills.enabled';
-export const AGENT_SKILLS_ENABLED_DEFAULT = true;
+export const AGENT_SKILLS_ENABLED_DEFAULT = false;
 
 /** Whether tool-use agents receive the available TeXRA and imported skills. */
 export const AgentSkillsEnabledSchema = z

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -21,6 +21,7 @@ export * from './toolDefinition';
 export * from './agentSkills';
 export * from './activeSkills';
 export * from './skillName';
+export * from './skillDisplay';
 export * from './codex';
 export * from './coreSettings';
 export * from './opResults';

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -27,6 +27,10 @@ import {
   settingsViewSnapshotEntries,
   type SettingsViewSnapshot,
 } from './stateSettings';
+import {
+  SkillDisplayIssueSchema,
+  SkillDisplayItemSchema,
+} from './skillDisplay';
 import { GoalSchema } from './goal';
 
 import {
@@ -102,6 +106,7 @@ export const SETTINGS_TAB_ORDER = [
   'AGENTS',
   'MULTI_AGENT',
   'TOOLS',
+  'SKILLS',
   'AI_AGENTS',
   'GIT',
   'LATEX',
@@ -164,7 +169,7 @@ export const SETTINGS_TAB_GROUPS = [
   { label: 'Account', tabs: ['ACCOUNT', 'SUBSCRIPTIONS'] },
   { label: 'Models', tabs: ['MODELS'] },
   { label: 'Agents', tabs: ['AGENTS', 'MULTI_AGENT'] },
-  { label: 'Capabilities', tabs: ['TOOLS', 'AI_AGENTS', 'LATEX'] },
+  { label: 'Capabilities', tabs: ['TOOLS', 'SKILLS', 'AI_AGENTS', 'LATEX'] },
   { label: 'Workspace', tabs: ['GIT', 'SHORTCUTS'] },
   { label: 'Data & Activity', tabs: ['MEMORY', 'GOAL'] },
 ] as const satisfies readonly {
@@ -195,7 +200,7 @@ const SetTabMessageSchema = z.object({
 export const SETTINGS_SNAPSHOT_COMMANDS = {
   approval: SETTINGS_VIEW_COMMANDS.UPDATE_APPROVAL_SETTINGS,
   'git-author': SETTINGS_VIEW_COMMANDS.UPDATE_GIT_AUTHOR_SETTINGS,
-  'agent-skills': SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SKILLS_SETTINGS,
+  skills: SETTINGS_VIEW_COMMANDS.UPDATE_SKILLS_SETTINGS,
   telemetry: SETTINGS_VIEW_COMMANDS.UPDATE_TELEMETRY_SETTINGS,
   'multi-agent': SETTINGS_VIEW_COMMANDS.UPDATE_SUPER_YOLO_ENABLED,
   latex: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES,
@@ -482,8 +487,12 @@ const UpdateToolDashboardMessageSchema = z.object({
 const UpdateApprovalAndSafetySettingsMessageSchema =
   snapshotMessage('approval');
 
-/** Outbound: backend → frontend agent skill-catalog setting. */
-const UpdateAgentSkillsSettingsMessageSchema = snapshotMessage('agent-skills');
+/** Outbound: discovered skill inventory for the consolidated Skills tab. */
+const UpdateSkillsListMessageSchema = z.object({
+  command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_SKILLS_LIST),
+  skills: z.array(SkillDisplayItemSchema),
+  issues: z.array(SkillDisplayIssueSchema),
+});
 
 /** Outbound: backend → frontend telemetry preference. */
 const UpdateTelemetrySettingsMessageSchema = snapshotMessage('telemetry');
@@ -672,7 +681,8 @@ const SettingsViewOutboundMessageSchema = z.discriminatedUnion('command', [
   UpdateReliabilityAndOrchestrationMessageSchema,
   UpdateAgentModePresetsMessageSchema,
   UpdateApprovalAndSafetySettingsMessageSchema,
-  UpdateAgentSkillsSettingsMessageSchema,
+  snapshotMessage('skills'),
+  UpdateSkillsListMessageSchema,
   UpdateTelemetrySettingsMessageSchema,
   UpdateToolDashboardMessageSchema,
   UpdateGitAuthorSettingsMessageSchema,

--- a/src/shared/schemas/skillDisplay.ts
+++ b/src/shared/schemas/skillDisplay.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+import { ActiveSkillSourceScopeSchema } from './activeSkills';
+import { SkillNameSchema } from './skillName';
+
+/** One discovered skill projected for host settings displays. */
+export const SkillDisplayItemSchema = z.strictObject({
+  name: SkillNameSchema,
+  description: z.string(),
+  scope: ActiveSkillSourceScopeSchema,
+  label: z.string(),
+  path: z.string(),
+  enabled: z.boolean(),
+});
+
+export type SkillDisplayItem = z.infer<typeof SkillDisplayItemSchema>;
+
+/** Discovery problem safe to carry to settings UIs. */
+export const SkillDisplayIssueSchema = z.strictObject({
+  message: z.string(),
+  path: z.string().optional(),
+});
+
+export type SkillDisplayIssue = z.infer<typeof SkillDisplayIssueSchema>;

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -56,6 +56,8 @@ import {
   AgentSkillsEnabledSchema,
 } from '@shared/schemas/agentSkills';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
+import { ActiveSkillSourceScopeSchema } from './activeSkills';
+import { SkillNameSchema } from './skillName';
 
 // ============================================================================
 // Git defaults
@@ -131,7 +133,6 @@ type SettingSlots = {
 };
 
 export type SettingsViewSnapshot =
-  | 'agent-skills'
   | 'approval'
   | 'git-author'
   | 'latex'
@@ -139,6 +140,7 @@ export type SettingsViewSnapshot =
   | 'models'
   | 'multi-agent'
   | 'profile'
+  | 'skills'
   | 'telemetry';
 
 interface CliRuntimeReachability {
@@ -751,7 +753,7 @@ const CORE_SETTING_ROWS: Record<
       through:
         'packages/cli/src/commands/agentsRun.ts -> packages/cli/src/runtime/runExecution.ts -> src/agent/runtime/runAgent.ts -> src/agent/runtime/executeAgent.ts -> src/agent/runtime/AgentLaunchContext.ts -> src/agent/prompt/userVars.ts',
     }),
-    surfaces: { settingsView: 'agent-skills', cliConfig: true },
+    surfaces: { settingsView: 'skills', cliConfig: true },
   },
   'toolUse.requireEditApproval': {
     schema: z.boolean().prefault(true),
@@ -963,6 +965,19 @@ const GIT_AUTHOR_SLOTS: SettingSlots = {
   desktop: 'workspaceState',
   cli: 'config',
 };
+
+const SKILL_AVAILABILITY_SLOTS: SettingSlots = {
+  vscode: 'workspaceState',
+  desktop: 'workspaceState',
+  cli: 'config',
+};
+
+const SKILL_AVAILABILITY_REACHABILITY = {
+  command:
+    'texra agents run <tool-use-agent> --instruction "answer a short question"',
+  through:
+    'packages/cli/src/commands/agentsRun.ts -> src/agent/prompt/userVars.ts -> src/skills/runtimeSkills.ts',
+} satisfies CliRuntimeReachability;
 
 const GIT_AUTHOR_HONORED_BY: SettingHonoredBy = {
   vscode: { reader: 'packages/extension/src/frontend/git/gitAuthorSetup.ts' },
@@ -1602,6 +1617,34 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     ),
     openForm: 'tools',
     surfaces: { cliConfig: true },
+  }),
+  surfacedSetting({
+    key: WorkspaceStateKey.DISABLED_SKILLS,
+    schema: z.array(SkillNameSchema).prefault([]),
+    title: 'Skills',
+    description: 'Enable or disable individual skills in this workspace.',
+    category: 'tools',
+    slots: SKILL_AVAILABILITY_SLOTS,
+    honoredBy: everyHost(
+      'src/skills/runtimeSkills.ts',
+      SKILL_AVAILABILITY_REACHABILITY,
+    ),
+    openForm: 'skills',
+    surfaces: { settingsView: 'skills', cliConfig: true },
+  }),
+  surfacedSetting({
+    key: WorkspaceStateKey.DISABLED_SKILL_SOURCES,
+    schema: z.array(ActiveSkillSourceScopeSchema).prefault([]),
+    title: 'Skill sources',
+    description: 'Enable or disable skill source groups in this workspace.',
+    category: 'tools',
+    slots: SKILL_AVAILABILITY_SLOTS,
+    honoredBy: everyHost(
+      'src/skills/runtimeSkills.ts',
+      SKILL_AVAILABILITY_REACHABILITY,
+    ),
+    openForm: 'skills',
+    surfaces: { settingsView: 'skills', cliConfig: true },
   }),
   surfacedSetting({
     key: WorkspaceStateKey.TOOL_PATH_PROTECTION_ENABLED,

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -743,9 +743,9 @@ const CORE_SETTING_ROWS: Record<
   },
   'skills.enabled': {
     schema: AgentSkillsEnabledSchema.prefault(AGENT_SKILLS_ENABLED_DEFAULT),
-    title: 'Make skills available to tool-use agents',
+    title: 'Enable skills for tool-use agents',
     description:
-      'Discover TeXRA and imported skills and expose them to tool-use agent prompts.',
+      'Expose enabled TeXRA and imported skills to tool-use agent prompts. Skills are off by default.',
     category: 'tools',
     honoredBy: everyHost('src/agent/prompt/userVars.ts', {
       command:
@@ -976,7 +976,7 @@ const SKILL_AVAILABILITY_REACHABILITY = {
   command:
     'texra agents run <tool-use-agent> --instruction "answer a short question"',
   through:
-    'packages/cli/src/commands/agentsRun.ts -> src/agent/prompt/userVars.ts -> src/skills/runtimeSkills.ts',
+    'packages/cli/src/commands/agentsRun.ts -> packages/cli/src/runtime/runExecution.ts -> src/agent/runtime/runAgent.ts -> src/agent/runtime/executeAgent.ts -> src/agent/runtime/AgentLaunchContext.ts -> src/agent/prompt/userVars.ts -> src/skills/runtimeSkills.ts',
 } satisfies CliRuntimeReachability;
 
 const GIT_AUTHOR_HONORED_BY: SettingHonoredBy = {

--- a/src/shared/settingsView/handlers/settingsSnapshot.ts
+++ b/src/shared/settingsView/handlers/settingsSnapshot.ts
@@ -2,7 +2,7 @@
  * The one builder for every catalog-derived settings-view snapshot.
  *
  * A snapshot is exactly "the catalog rows tagged for it", so this reads that
- * list rather than naming fields: the approval/safety, git-author, agent-skills,
+ * list rather than naming fields: the approval/safety, git-author, skills,
  * telemetry, multi-agent, and LaTeX snapshots all come from here. Per-row defaults,
  * validation, storage slot, and legacy normalization already live on the
  * catalog row and are applied by `readSetting`, so a snapshot builder has

--- a/src/shared/state/stateKeys.ts
+++ b/src/shared/state/stateKeys.ts
@@ -21,6 +21,10 @@ export enum WorkspaceStateKey {
   AGENT_ROSTER_SELECTION = 'texra.agentRosterSelection',
   CUSTOM_AGENT_PRESETS = 'texra.customAgentPresets',
 
+  // Skill availability
+  DISABLED_SKILLS = 'texra.skills.disabled',
+  DISABLED_SKILL_SOURCES = 'texra.skills.disabledSources',
+
   // Codex settings
   CODEX_SANDBOX_MODE = 'texra.codexSandboxMode',
   CODEX_REASONING_EFFORT = 'texra.codexReasoningEffort',

--- a/src/skills/runtimeSkills.ts
+++ b/src/skills/runtimeSkills.ts
@@ -1,17 +1,24 @@
 import {
   ACTIVE_SKILLS_SNAPSHOT_MAX_SKILLS,
+  type ActiveSkillSourceScope,
   type RawAcceptedSkill,
+  type SkillDisplayItem,
 } from '@shared/schemas';
+import type { SettingHost } from '@shared/schemas';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
+import { readPlatformSetting } from '@utils/config/platformSettings';
 
 import {
   discoverSkillSources,
+  type DiscoverSkillSourcesResult,
   type SkillLoadIssue,
   type SkillSource,
   type SourcedSkill,
 } from './loadSkills';
 
 let runtimeSkillSources: readonly SkillSource[] = [];
+let runtimeSkillHost: SettingHost = 'vscode';
 
 export interface RuntimeSkillCatalogResult {
   catalog: string;
@@ -19,12 +26,87 @@ export interface RuntimeSkillCatalogResult {
   issues: SkillLoadIssue[];
 }
 
-export function setRuntimeSkillSources(sources: readonly SkillSource[]): void {
-  runtimeSkillSources = [...sources];
+interface DisabledSkills {
+  readonly names: readonly string[];
+  readonly scopes: readonly ActiveSkillSourceScope[];
 }
 
-export function listRuntimeSkillSources(): readonly SkillSource[] {
-  return runtimeSkillSources;
+export function setRuntimeSkillSources(
+  sources: readonly SkillSource[],
+  host: SettingHost = 'vscode',
+): void {
+  runtimeSkillSources = [...sources];
+  runtimeSkillHost = host;
+}
+
+/** Discover the complete runtime source registry for settings displays. */
+function discoverRuntimeSkills() {
+  return discoverSkillSources(runtimeSkillSources);
+}
+
+function isSkillDisabled(
+  name: string,
+  scope: ActiveSkillSourceScope,
+  disabled: DisabledSkills,
+): boolean {
+  return disabled.names.includes(name) || disabled.scopes.includes(scope);
+}
+
+function readDisabledSkills(): DisabledSkills {
+  return {
+    names: readPlatformSetting<string[]>(
+      WorkspaceStateKey.DISABLED_SKILLS,
+      runtimeSkillHost,
+    ),
+    scopes: readPlatformSetting<ActiveSkillSourceScope[]>(
+      WorkspaceStateKey.DISABLED_SKILL_SOURCES,
+      runtimeSkillHost,
+    ),
+  };
+}
+
+function skillDisplayItems(
+  skills: readonly SourcedSkill[],
+  disabled: DisabledSkills,
+): SkillDisplayItem[] {
+  return skills.map(({ skill, source }) => ({
+    name: skill.name,
+    description: skill.description,
+    scope: source.scope,
+    label: source.label ?? source.scope,
+    path: skill.path,
+    enabled: !isSkillDisabled(skill.name, source.scope, disabled),
+  }));
+}
+
+/** Discover the complete inventory for host settings displays. */
+export async function loadRuntimeSkillDisplay(
+  disabled: DisabledSkills = readDisabledSkills(),
+) {
+  const result = await discoverRuntimeSkills();
+  return {
+    skills: skillDisplayItems(result.skills, disabled),
+    issues: result.errors.map(({ message, path }) => ({ message, path })),
+  };
+}
+
+export function filterDiscoveredSkills(
+  result: DiscoverSkillSourcesResult,
+  disabled: DisabledSkills = readDisabledSkills(),
+): DiscoverSkillSourcesResult {
+  return {
+    skills: result.skills.filter(
+      ({ skill, source }) =>
+        !isSkillDisabled(skill.name, source.scope, disabled),
+    ),
+    errors: result.errors,
+  };
+}
+
+/** Discover only skills that may be injected or explicitly activated. */
+export async function loadEnabledRuntimeSkills() {
+  const result = await discoverRuntimeSkills();
+  return filterDiscoveredSkills(result);
 }
 
 function sourceLabel(source: SkillSource): string {
@@ -60,10 +142,11 @@ export function formatRuntimeSkillActivation({
 }
 
 export async function loadRuntimeSkillCatalog(): Promise<RuntimeSkillCatalogResult> {
-  const sources = listRuntimeSkillSources();
-  if (sources.length === 0) return { catalog: '', skills: [], issues: [] };
+  if (runtimeSkillSources.length === 0) {
+    return { catalog: '', skills: [], issues: [] };
+  }
 
-  const result = await discoverSkillSources(sources);
+  const result = await loadEnabledRuntimeSkills();
   // Discovery already orders by source precedence and then skill directory.
   // Bound that accepted set once here, before either prompt or event projection.
   const accepted = result.skills.slice(0, ACTIVE_SKILLS_SNAPSHOT_MAX_SKILLS);

--- a/src/skills/runtimeSkills.ts
+++ b/src/skills/runtimeSkills.ts
@@ -99,6 +99,8 @@ export function filterDiscoveredSkills(
       ({ skill, source }) =>
         !isSkillDisabled(skill.name, source.scope, disabled),
     ),
+    // Keep discovery issues visible even for disabled sources so users can
+    // repair a source before enabling it again.
     errors: result.errors,
   };
 }

--- a/src/test-kernel/agent/prompt/userVars.vitest.ts
+++ b/src/test-kernel/agent/prompt/userVars.vitest.ts
@@ -112,6 +112,29 @@ describe('buildUserVars runtime skill diagnostics', () => {
     await fakeConfig.update('texra.skills.enabled', undefined);
   });
 
+  it('keeps skills off until the master switch is enabled', async () => {
+    await fakeConfig.update('texra.skills.enabled', undefined);
+    const warn = vi.fn();
+    const emit = vi.fn();
+
+    const vars = await buildUserVars(
+      baseConfig,
+      { ...baseSetting, agentCategory: AgentCategory.ToolUse },
+      basePrompt,
+      '/agents/generic',
+      { isOpenai: false, isAnthropic: false, isGoogle: false },
+      spiedTrace({ warn, emit }),
+      { workspacePath: '/workspace' },
+    );
+
+    expect(vars.AVAILABLE_SKILLS).toBe('');
+    expect(warn).not.toHaveBeenCalled();
+    expect(emit).toHaveBeenCalledExactlyOnceWith({
+      type: 'skills.snapshot',
+      skills: [],
+    });
+  });
+
   it('emits catalog load issues and the exact accepted snapshot through the agent trace', async () => {
     const warn = vi.fn();
     const emit = vi.fn();

--- a/src/test-kernel/cli/CliInitPlatform.vitest.ts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.ts
@@ -510,6 +510,7 @@ describe('CLI platform init', () => {
     );
 
     expect(mocks.initializeNodeRuntimeSkills).toHaveBeenCalledWith({
+      host: 'cli',
       cwd: '/tmp/project',
       resourcesPath: '/tmp/resources',
       skillSourceOptions: {

--- a/src/test-kernel/cli/CliSkills.vitest.ts
+++ b/src/test-kernel/cli/CliSkills.vitest.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   formatCliSkillList,
@@ -12,9 +12,18 @@ import {
 } from '@cli/runtime/skills';
 import { defaultSkillSources } from '@skills/skillSources';
 import { setRuntimeSkillSources } from '@skills/runtimeSkills';
+import { spyOnStreamWrite } from '@test/cli/fixtures/streamWriteSpy';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 const tempRoots = useTempDirs();
+const commandMocks = vi.hoisted(() => ({ initCliPlatform: vi.fn() }));
+
+vi.mock('@cli/runtime/initPlatform', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@cli/runtime/initPlatform')>()),
+  initCliPlatform: commandMocks.initCliPlatform,
+}));
+
+const { runCli } = await import('@cli/commands/root');
 
 async function writeSkill(
   root: string,
@@ -31,9 +40,33 @@ async function writeSkill(
 
 afterEach(() => {
   setRuntimeSkillSources([]);
+  commandMocks.initCliPlatform.mockReset();
 });
 
 describe('CLI skills runtime', () => {
+  it('initializes platform settings before listing skills', async () => {
+    commandMocks.initCliPlatform.mockResolvedValue(undefined);
+    const stdoutSpy = spyOnStreamWrite(process.stdout, () => undefined);
+
+    try {
+      const result = await runCli([
+        'skills',
+        'list',
+        '--print',
+        '--no-color',
+        '--output-format',
+        'json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(commandMocks.initCliPlatform).toHaveBeenCalledWith(
+        expect.objectContaining({ quietLogs: true }),
+      );
+    } finally {
+      stdoutSpy.mockRestore();
+    }
+  });
+
   it('resolves default, interop, and custom skill sources in precedence order', () => {
     const cwd = path.resolve(path.sep, 'tmp', 'project');
     const resourcesPath = path.resolve(

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.ts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.ts
@@ -802,7 +802,7 @@ describe('desktop settings IPC', () => {
     expect(postLatexConfigValues).toHaveBeenCalledOnce();
   });
 
-  it('writes the agent-skills toggle and returns the shared setting message', async () => {
+  it('writes the agent-skills toggle and returns the skills settings', async () => {
     const config = new FakeScopedConfigProvider();
 
     const { settings, posted } = createCapturedSettingsFixture({
@@ -822,10 +822,14 @@ describe('desktop settings IPC', () => {
     expect(config.get(AGENT_SKILLS_CONFIG_KEY)).toBe(false);
     expect(config.lastTargetFor(AGENT_SKILLS_CONFIG_KEY)).toBe('workspace');
     expect(
-      findPosted(posted, SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SKILLS_SETTINGS),
+      findPosted(posted, SETTINGS_VIEW_COMMANDS.UPDATE_SKILLS_SETTINGS),
     ).toEqual({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SKILLS_SETTINGS,
-      values: { [AGENT_SKILLS_CONFIG_KEY]: false },
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_SKILLS_SETTINGS,
+      values: {
+        [AGENT_SKILLS_CONFIG_KEY]: false,
+        [WorkspaceStateKey.DISABLED_SKILLS]: [],
+        [WorkspaceStateKey.DISABLED_SKILL_SOURCES]: [],
+      },
     });
   });
 

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { dirname, join, resolve, sep } from 'node:path';
+import { dirname, join } from 'node:path';
 import { setImmediate as nextTurn } from 'node:timers/promises';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -20,6 +20,7 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { FakeConfigProvider, FakeSecrets } from '@test/support/FakePlatform';
+import { writeSkill } from '@test/support/skillFixtures';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
 
 import { loadSourceModule } from './loadSourceModule.ts';
@@ -335,13 +336,33 @@ describe('desktop agent directory bootstrap', () => {
 
   it('registers runtime skills through the shared Node host defaults', async () => {
     const { resourcesPath } = await createHarness();
+    const projectPath = join(dirname(resourcesPath), 'project');
+    await Promise.all([
+      writeSkill(join(resourcesPath, 'skills'), 'bundled-skill', {
+        name: 'bundled-skill',
+        description: 'Bundled skill.',
+      }),
+      writeSkill(join(projectPath, '.texra', 'skills'), 'project-skill', {
+        name: 'project-skill',
+        description: 'Project skill.',
+      }),
+      writeSkill(join(projectPath, '.codex', 'skills'), 'interop-skill', {
+        name: 'interop-skill',
+        description: 'Interop skill.',
+      }),
+      writeSkill(join(projectPath, 'vendor', 'skills'), 'custom-skill', {
+        name: 'custom-skill',
+        description: 'Custom skill.',
+      }),
+    ]);
     const { initializeNodeRuntimeSkills } = await loadSourceModule(
       '@platform/defaults/nodeHost',
     );
-    const { listRuntimeSkillSources } = await import('@skills/runtimeSkills');
+    const { loadRuntimeSkillDisplay } = await import('@skills/runtimeSkills');
 
     initializeNodeRuntimeSkills({
-      cwd: resolve(sep, 'tmp', 'project'),
+      host: 'desktop',
+      cwd: projectPath,
       resourcesPath,
       skillSourceOptions: {
         includeInterop: true,
@@ -349,25 +370,24 @@ describe('desktop agent directory bootstrap', () => {
       },
     });
 
-    const sources = listRuntimeSkillSources();
-    expect(sources).toEqual(
+    const { skills } = await loadRuntimeSkillDisplay();
+    expect(skills).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
+          name: 'custom-skill',
           scope: 'custom',
-          path: resolve(sep, 'tmp', 'project', 'vendor', 'skills'),
-          required: true,
         }),
         expect.objectContaining({
+          name: 'project-skill',
           scope: 'project',
-          path: resolve(sep, 'tmp', 'project', '.texra', 'skills'),
         }),
         expect.objectContaining({
+          name: 'interop-skill',
           scope: 'interop',
-          path: resolve(sep, 'tmp', 'project', '.codex', 'skills'),
         }),
         expect.objectContaining({
+          name: 'bundled-skill',
           scope: 'bundled',
-          path: join(resourcesPath, 'skills'),
         }),
       ]),
     );

--- a/src/test-kernel/schemas/SharedSchemas.vitest.ts
+++ b/src/test-kernel/schemas/SharedSchemas.vitest.ts
@@ -186,6 +186,7 @@ describe('settings view tab definitions', () => {
       'agents',
       'multi-agent',
       'tools',
+      'skills',
       'ai-agents',
       'git',
       'latex',

--- a/src/test-kernel/settings/AgentSkillsWorkspaceGuard.vitest.ts
+++ b/src/test-kernel/settings/AgentSkillsWorkspaceGuard.vitest.ts
@@ -65,9 +65,7 @@ describe('agent skills workspace guard', () => {
       'SettingsViewMessageHandler',
       'Open a workspace folder before changing the “Make skills available to tool-use agents” setting.',
     );
-    expect(handler.postStateSettingSnapshot).toHaveBeenCalledWith(
-      'agent-skills',
-    );
+    expect(handler.postStateSettingSnapshot).toHaveBeenCalledWith('skills');
   });
 
   it('writes user-wide telemetry in an empty VS Code window', async () => {

--- a/src/test-kernel/settings/AgentSkillsWorkspaceGuard.vitest.ts
+++ b/src/test-kernel/settings/AgentSkillsWorkspaceGuard.vitest.ts
@@ -63,7 +63,7 @@ describe('agent skills workspace guard', () => {
     expect(mocks.writeSetting).not.toHaveBeenCalled();
     expect(mocks.showLoggedInfoMessage).toHaveBeenCalledWith(
       'SettingsViewMessageHandler',
-      'Open a workspace folder before changing the “Make skills available to tool-use agents” setting.',
+      'Open a workspace folder before changing the “Enable skills for tool-use agents” setting.',
     );
     expect(handler.postStateSettingSnapshot).toHaveBeenCalledWith('skills');
   });

--- a/src/test-kernel/settings/ToolsTab.vitest.ts
+++ b/src/test-kernel/settings/ToolsTab.vitest.ts
@@ -10,7 +10,6 @@ vi.mock('@shared/hostBridge', () => ({
 
 import type { ToolsTab } from '@settingsView/frontend/tabs/ToolsTab';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import { AGENT_SKILLS_CONFIG_KEY } from '@shared/schemas';
 import type { ToolDashboardItem } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 
@@ -102,15 +101,6 @@ describe('tools-tab availability summary', () => {
       tool('second', 'available'),
     ]);
     expect(element.shadowRoot?.textContent).toContain('2/2 available');
-  });
-
-  it('renders and updates the shared agent-skills switch', async () => {
-    await expectTogglableSwitch({
-      id: 'settings-toggle-make-skills-available-to-tool-use-agents',
-      label: 'Make skills available to tool-use agents',
-      initialChecked: true,
-      stateKey: AGENT_SKILLS_CONFIG_KEY,
-    });
   });
 
   it('renders and updates working-directory path protection', async () => {

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -154,6 +154,8 @@ const EXPECTED_DEFAULTS: Record<string, unknown> = {
   [GlobalStateKey.GLM_USE_CHINA]: true,
   [GlobalStateKey.GLM_CODING_PLAN]: false,
   [GlobalStateKey.DISABLED_TOOLS]: [],
+  [WorkspaceStateKey.DISABLED_SKILLS]: [],
+  [WorkspaceStateKey.DISABLED_SKILL_SOURCES]: [],
 };
 
 /** Every canonical `texra.*` key in the state-backed catalog. */
@@ -440,6 +442,8 @@ describe('state settings catalog', () => {
     //    dual-backend Kimi models in CLI runs.
     //  - agent skills is read by buildUserVars (userVars) when assembling
     //    tool-use agent prompts, skipping skill discovery when disabled.
+    //  - skill and source exclusions are read by runtimeSkills before prompt
+    //    injection and explicit `/skills` activation.
     //  - texra.approvalPolicy is read by cliConfig / cliContext and seeded onto
     //    SessionHandle before bash/edit approval boundaries decide.
     //  - detach-subagents-on-stop is read by detachSubagentsOnStop() when the
@@ -485,6 +489,8 @@ describe('state settings catalog', () => {
         GlobalStateKey.GLM_USE_CHINA,
         GlobalStateKey.GLM_CODING_PLAN,
         GlobalStateKey.DISABLED_TOOLS,
+        WorkspaceStateKey.DISABLED_SKILLS,
+        WorkspaceStateKey.DISABLED_SKILL_SOURCES,
         AGENT_SKILLS_CONFIG_KEY,
         CHATGPT_CODEX_CONTEXT_WINDOW_SETTING.configKey,
         MODEL_COMPACTION_THRESHOLD_SETTING.configKey,

--- a/src/test-kernel/skills/RuntimeSkills.vitest.ts
+++ b/src/test-kernel/skills/RuntimeSkills.vitest.ts
@@ -6,10 +6,12 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { TraceEmitter } from '@agent/trace';
 import { buildInitialToolUsePrompts } from '@agent/prompt/PromptBuilder';
+import { platform } from '@platform/platform';
 import {
   ACTIVE_SKILLS_SNAPSHOT_MAX_SKILLS,
   MESSAGE_TYPES,
 } from '@shared/schemas';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import {
   formatRuntimeSkillActivation,
   loadRuntimeSkillCatalog,
@@ -35,6 +37,14 @@ setupPlatform({ workspacePath: '/workspace' });
 
 afterEach(async () => {
   setRuntimeSkillSources([]);
+  await platform().workspaceState.update(
+    WorkspaceStateKey.DISABLED_SKILLS,
+    undefined,
+  );
+  await platform().workspaceState.update(
+    WorkspaceStateKey.DISABLED_SKILL_SOURCES,
+    undefined,
+  );
 });
 
 describe('runtime skills', () => {
@@ -118,6 +128,44 @@ describe('runtime skills', () => {
       },
     ]);
   });
+
+  it.each([
+    {
+      label: 'name',
+      key: WorkspaceStateKey.DISABLED_SKILLS,
+      value: ['project-skill'],
+      expected: ['user-skill'],
+    },
+    {
+      label: 'source',
+      key: WorkspaceStateKey.DISABLED_SKILL_SOURCES,
+      value: ['user'],
+      expected: ['project-skill'],
+    },
+  ])(
+    'filters runtime skills disabled by $label',
+    async ({ key, value, expected }) => {
+      const projectRoot = await createTempRoot();
+      const userRoot = await createTempRoot();
+      await writeSkill(projectRoot, 'project-skill', {
+        name: 'project-skill',
+        description: 'Project skill.',
+      });
+      await writeSkill(userRoot, 'user-skill', {
+        name: 'user-skill',
+        description: 'User skill.',
+      });
+      setRuntimeSkillSources([
+        { scope: 'project', path: projectRoot },
+        { scope: 'user', path: userRoot },
+      ]);
+      await platform().workspaceState.update(key, value);
+
+      const result = await loadRuntimeSkillCatalog();
+
+      expect(result.skills.map((skill) => skill.name)).toStrictEqual(expected);
+    },
+  );
 
   it('keeps ANSI-only and controls-only skills in the raw accepted projection', async () => {
     const root = await createTempRoot();

--- a/src/utils/config/platformSettings.ts
+++ b/src/utils/config/platformSettings.ts
@@ -1,5 +1,5 @@
 import { platform } from '@platform/platform';
-import { settingByKey } from '@shared/schemas';
+import { settingByKey, type SettingHost } from '@shared/schemas';
 import { readSetting, writeSetting } from '@shared/config/settingsAccess';
 
 function requireEntry(key: string) {
@@ -21,14 +21,18 @@ function requireEntry(key: string) {
  * (`workspaceState` / `globalState` / `config`) is the one the catalog entry
  * declares, so the right backing store is picked without the caller naming it.
  *
- * Reads resolve to the `'vscode'` slot, which every row shares with `desktop`;
- * the CLI-divergent git-author keys are read through the CLI's own
- * `readGitAuthorSettingsFromState`.
+ * Reads default to the `'vscode'` slot, which most rows share with `desktop`.
+ * A host-neutral runtime whose row deliberately diverges by host may pass the
+ * active host explicitly; host-specific convenience readers remain preferable
+ * when they also own normalization or side effects.
  */
-export function readPlatformSetting<T>(key: string): T {
+export function readPlatformSetting<T>(
+  key: string,
+  host: SettingHost = 'vscode',
+): T {
   // `Platform` structurally supplies the `config`/`workspaceState`/`globalState`
   // slots `readSetting` reads from, so it passes as `SettingsStores` directly.
-  return readSetting(requireEntry(key), platform()) as T;
+  return readSetting(requireEntry(key), platform(), host) as T;
 }
 
 /**


### PR DESCRIPTION
## Summary

- add a dedicated Skills settings tab for the extension and desktop with master, per-source, and per-skill controls
- persist disabled skill names and source scopes per workspace/project and filter the shared runtime catalog used by prompts, CLI status, and activation
- add the matching CLI `/config` form while keeping `/skills` as the activation picker
- document workspace skill availability and add a user-facing changelog entry

## Validation

- `npm run format`
- `npm run compile:safe`
- `npm run lint`
- `npm run check:dead-code-ratchet`
- affected Vitest suites: 126/126 passed
- full serial Vitest run: 9,909 passed; one unrelated 1-second desktop merge-lifecycle timing test failed under concurrent machine load and passed immediately when rerun alone
