### PR TITLE
simplify(workflow): one declared-plan shape; the proposal panel folds through the run model

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -29,10 +29,10 @@ import type {
   AgentProposalPermission,
   PermissionPayload,
   WorkflowAgentProposalPermission,
-  WorkflowCallIdentity,
 } from '@shared/schemas';
 import { AgentCategory, getProposalFileGroups } from '@shared/schemas';
 import { postMessage } from '@shared/hostBridge';
+import { workflowRunModel } from '@shared/streams/workflowRunModel';
 import {
   WORKFLOW_SCRIPT_PROPOSAL_COPY,
   workflowScriptPlanSummary,
@@ -58,26 +58,6 @@ import { APPROVE_ALL_DELEGATED_WORK_ACTION } from '../events';
 import { buildStatusBadge } from '../formatters/htmlBuilders';
 import { processMarkdownContent } from '../formatters/markdownRenderer';
 import { getComposedPathElement } from '../utils';
-
-/**
- * Declared phases in order, each with its declared items. Empty phases still
- * appear, and unphased items come last. This grouping describes declarations,
- * not which calls run together or depend on one another.
- */
-function workflowScriptDeclaredItemsByPhase(plan: {
-  readonly phases: readonly { readonly title: string }[];
-  readonly tasks: readonly WorkflowCallIdentity[];
-}): {
-  readonly phase?: string;
-  readonly items: readonly WorkflowCallIdentity[];
-}[] {
-  const groups = plan.phases.map((phase) => ({
-    phase: phase.title,
-    items: plan.tasks.filter((task) => task.phase === phase.title),
-  }));
-  const unphased = plan.tasks.filter((task) => task.phase === undefined);
-  return [...groups, ...(unphased.length > 0 ? [{ items: unphased }] : [])];
-}
 
 function proposalRequestIdOf(
   p: PermissionPayload | null | undefined,
@@ -235,7 +215,17 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
     workflow: NonNullable<WorkflowAgentProposalPermission['workflowScript']>,
   ): TemplateResult {
     const fullName = `${workflow.name}: ${workflow.description}`;
-    const declaredGroups = workflowScriptDeclaredItemsByPhase(workflow);
+    // The plan's phases as the run model folds them for a run that has not
+    // started: every declared phase in order, its declared items under it,
+    // unphased items under the trailing `Unphased` phase — the same shape the
+    // popup and the board show once the run is live.
+    const { phases } = workflowRunModel({
+      taskGroups: [],
+      rows: [],
+      plan: workflow,
+      runSettled: false,
+      childProgress: new Map(),
+    });
 
     return html`
       <div class="workflow-proposal__workflow-summary">
@@ -261,17 +251,17 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
       >
         ${this.renderInstruction(workflow.description)}
         ${
-          declaredGroups.length > 0
+          phases.length > 0
             ? html`<ul class="workflow-proposal__task-list">
                 ${repeat(
-                  declaredGroups,
-                  (group) => group.phase ?? '',
-                  (group) =>
+                  phases,
+                  (phase) => phase.key,
+                  (phase) =>
                     html`<li>
-                      ${group.phase ?? 'No phase'}
+                      ${phase.heading.phaseLabel}
                       <ul>
                         ${repeat(
-                          group.items,
+                          phase.declaredTasks,
                           (task) => task.id,
                           (task) => html`<li>${task.label}</li>`,
                         )}

--- a/src/shared/copy/workflowScriptProposal.ts
+++ b/src/shared/copy/workflowScriptProposal.ts
@@ -1,9 +1,4 @@
-import type { WorkflowCallIdentity } from '@shared/schemas';
-
-interface WorkflowScriptPlan {
-  readonly phases: readonly { readonly title: string }[];
-  readonly tasks: readonly WorkflowCallIdentity[];
-}
+import type { WorkflowDeclaredPlan } from '@shared/schemas';
 
 /**
  * Copy for the multi-agent workflow proposal, shared by every host so the
@@ -25,7 +20,7 @@ export const WORKFLOW_SCRIPT_PROPOSAL_COPY = {
  * `2 phases · 3 declared items`, `2 phases · calls issued at runtime`, or the
  * bare tail when the script declares no phases. Never a fake `0 tasks`.
  */
-export function workflowScriptPlanSummary(plan: WorkflowScriptPlan): string {
+export function workflowScriptPlanSummary(plan: WorkflowDeclaredPlan): string {
   const items =
     plan.tasks.length > 0
       ? `${plan.tasks.length} declared ${plan.tasks.length === 1 ? 'item' : 'items'}`

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -15,7 +15,7 @@ import {
   BaseProposalFieldsSchema,
   WorkflowSpecificFieldsSchema,
 } from './proposalFields';
-import { WorkflowCallIdentitySchema } from './workflowCallProgress';
+import { WorkflowDeclaredPlanSchema } from './workflowCallProgress';
 
 /** Optional stream ID - allows empty string when stream context is unavailable */
 const OptionalStreamIdSchema = z.union([StreamTabIdSchema, z.literal('')]);
@@ -56,12 +56,10 @@ export const RetryPermissionSchema = z.strictObject({
 });
 export type RetryPermission = z.infer<typeof RetryPermissionSchema>;
 
-const WorkflowScriptProposalDetailsSchema = z.strictObject({
+const WorkflowScriptProposalDetailsSchema = WorkflowDeclaredPlanSchema.extend({
   name: z.string().min(1),
   description: z.string().min(1),
   scriptPath: z.string().min(1),
-  phases: z.array(z.strictObject({ title: z.string().min(1) })),
-  tasks: z.array(WorkflowCallIdentitySchema),
 });
 
 /** Workflow agent proposal - includes file fields for document processing */

--- a/src/shared/schemas/workflowCallProgress.ts
+++ b/src/shared/schemas/workflowCallProgress.ts
@@ -27,6 +27,17 @@ export const WorkflowCallIdentitySchema = z.strictObject({
 export type WorkflowCallIdentity = z.infer<typeof WorkflowCallIdentitySchema>;
 
 /**
+ * The declared shape of a workflow script — `meta.phases` in order and
+ * `meta.tasks` — as both the approval proposal and the plan marker carry it.
+ * A phase's position is its index in the array.
+ */
+export const WorkflowDeclaredPlanSchema = z.strictObject({
+  phases: z.array(z.strictObject({ title: z.string().min(1) })),
+  tasks: z.array(WorkflowCallIdentitySchema),
+});
+export type WorkflowDeclaredPlan = z.infer<typeof WorkflowDeclaredPlanSchema>;
+
+/**
  * The declared plan of one workflow-script attempt — every `meta.phases`
  * entry and every `meta.tasks` entry, in script order — recorded once on the
  * transcript when the attempt's execution state is constructed. Phases and
@@ -34,13 +45,9 @@ export type WorkflowCallIdentity = z.infer<typeof WorkflowCallIdentitySchema>;
  * what lets a host list the ones it has not reached yet without opening their
  * stage (a `stage.start` prints the phase divider into scrollback).
  */
-export const WorkflowPlanMarkerSchema = z.strictObject({
+export const WorkflowPlanMarkerSchema = WorkflowDeclaredPlanSchema.extend({
   kind: z.literal('workflowPlan'),
   attemptId: z.string().min(1),
-  phases: z.array(
-    z.strictObject({ title: z.string().min(1), index: z.int().nonnegative() }),
-  ),
-  tasks: z.array(WorkflowCallIdentitySchema),
 });
 export type WorkflowPlanMarker = z.infer<typeof WorkflowPlanMarkerSchema>;
 

--- a/src/shared/streams/workflowRunModel.ts
+++ b/src/shared/streams/workflowRunModel.ts
@@ -21,6 +21,7 @@ import {
   type TaskGroup,
   type WorkflowCallIdentity,
   type WorkflowCallProgress,
+  type WorkflowDeclaredPlan,
   type WorkflowPlanMarker,
 } from '@shared/schemas';
 import type { TranscriptRow, WorkflowTaskRow } from '@shared/transcript';
@@ -131,7 +132,7 @@ export interface WorkflowRunModelInput {
   /** The stream's rows; the model picks the `workflowTask` ones. */
   readonly rows: readonly TranscriptRow[];
   /** The newest attempt's declared plan, if the transcript recorded one. */
-  readonly plan: WorkflowPlanMarker | undefined;
+  readonly plan: WorkflowDeclaredPlan | undefined;
   /** True once the run has ended: plan-only phases it never reached are then
    *  nothing to show (the projection's settle sweep has housed every declared
    *  card under a stage, so an empty plan-only phase is its own
@@ -172,7 +173,7 @@ function tallyOf(
  */
 function unionWithDeclaredPlan(
   opened: readonly MutablePhase[],
-  plan: WorkflowPlanMarker,
+  plan: WorkflowDeclaredPlan,
   cards: readonly WorkflowTaskRow[],
   runSettled: boolean,
 ): readonly MutablePhase[] {
@@ -194,7 +195,7 @@ function unionWithDeclaredPlan(
   );
   const ordered: MutablePhase[] = [];
   const placed = new Set<MutablePhase>();
-  for (const declared of plan.phases) {
+  for (const [index, declared] of plan.phases.entries()) {
     const declaredTasks = declaredByPhase.get(declared.title) ?? [];
     let phase = byTitle.get(declared.title);
     if (!phase) {
@@ -203,7 +204,7 @@ function unionWithDeclaredPlan(
         key: `declared-${declared.title}`,
         heading: {
           phaseLabel: declared.title,
-          phaseIndex: declared.index,
+          phaseIndex: index,
           phaseTotal: plan.phases.length,
         },
         tasks: [],

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -129,10 +129,7 @@ return await agent('Inspect', { id: 'inspect' })`,
     expect(plans).toHaveLength(1);
     expect(plans[0]).toMatchObject({
       attemptId: expect.any(String),
-      phases: [
-        { title: 'Research', index: 0 },
-        { title: 'Write', index: 1 },
-      ],
+      phases: [{ title: 'Research' }, { title: 'Write' }],
       tasks: [
         { id: 'inspect', label: 'Inspect source', phase: 'Research' },
         { id: 'draft', label: 'Draft the section', phase: 'Write' },

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -762,10 +762,7 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
     const workflowPlan: WorkflowPlanMarker = {
       kind: 'workflowPlan',
       attemptId: 'attempt-1',
-      phases: [
-        { title: 'Map', index: 0 },
-        { title: 'Publish', index: 1 },
-      ],
+      phases: [{ title: 'Map' }, { title: 'Publish' }],
       tasks: [{ id: 'report', label: 'Write the report', phase: 'Publish' }],
     };
     const toggleStates = new ToggleStateStore();

--- a/src/test-kernel/shared/WorkflowRunModel.vitest.ts
+++ b/src/test-kernel/shared/WorkflowRunModel.vitest.ts
@@ -151,7 +151,7 @@ describe('workflow run model', () => {
         plan: {
           kind: 'workflowPlan',
           attemptId: 'attempt-1',
-          phases: [{ title: 'Derive', index: 0 }],
+          phases: [{ title: 'Derive' }],
           tasks: [{ id: 'later', label: 'Later on', phase: 'Derive' }],
         },
       },
@@ -217,11 +217,7 @@ describe('workflow run model', () => {
     const plan: WorkflowPlanMarker = {
       kind: 'workflowPlan',
       attemptId: 'attempt-1',
-      phases: [
-        { title: 'Map', index: 0 },
-        { title: 'Reduce', index: 1 },
-        { title: 'Publish', index: 2 },
-      ],
+      phases: [{ title: 'Map' }, { title: 'Reduce' }, { title: 'Publish' }],
       tasks: [
         { id: 'inspect', label: 'inspect', phase: 'Map' },
         { id: 'extract', label: 'Extract facts', phase: 'Map' },
@@ -343,7 +339,7 @@ describe('workflow run model', () => {
     const plan = {
       kind: 'workflowPlan',
       attemptId: 'a',
-      phases: [{ title: 'Map', index: 0 }],
+      phases: [{ title: 'Map' }],
       tasks: [],
     };
     expect(workflowMarkerOf(entry(plan))).toStrictEqual({ kind: 'plan', plan });

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -436,10 +436,7 @@ export async function runPersistedWorkflowScriptWithProgress(
           type: 'workflow.plan',
           attemptId: projectionId,
           stageId: parentStageId,
-          phases: snapshot.stages.map((stage) => ({
-            title: stage.title,
-            index: stage.order,
-          })),
+          phases: snapshot.stages.map((stage) => ({ title: stage.title })),
           // A resumed run's reusable results (completed or cached) are
           // history, not plan: they are never re-emitted as cards, so listing
           // them here would show finished work as declared.

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -548,7 +548,6 @@ export function attachTranscriptRecorder(
             attemptId: event.attemptId,
             phases: event.phases.map((phase) => ({
               title: redactSecrets(phase.title),
-              index: phase.index,
             })),
             tasks: event.tasks.map((task) => ({
               ...task,


### PR DESCRIPTION
## What

Bundle 3 (S6) of [the 2026-08-29 survey](docs/proposals/2026-08-29-simplification-survey-shared-workflow-model.md).

The approval proposal (`WorkflowScriptProposalDetailsSchema`) and the plan marker (`WorkflowPlanMarkerSchema`) carried the same `{ phases, tasks }` shape as two schemas, with a hand-written third (`WorkflowScriptPlan`) in the copy module. `WorkflowDeclaredPlanSchema` is now the one shape and both extend it. The marker's `index` was derivable — a phase's order is its array position at construction and for every appended stage (`workflowExecutionState.ts`), its one reader was the model — so it goes; the model reads `plan.phases.entries()`.

The proposal panel's own phase grouping (`workflowScriptDeclaredItemsByPhase`, relocated into the panel by #11608, closing #11605) was the same fold `unionWithDeclaredPlan` performs; the panel now calls `workflowRunModel` with an empty run (`taskGroups: []`, `rows: []`, `runSettled: false`) and paints its `phases[].heading.phaseLabel` / `declaredTasks` — the extension no longer regroups the plan at all, the divergence the owner ruling names. One copy change: the unphased tail reads **`Unphased`** (the model's label) instead of `No phase`.

**Persisted data:** plan markers written earlier today (#11590 landed this morning) carry `index` and now fail `strictObject` as `malformedPlan` — a warn and no plan, not a silent default. Intermediate-era data per the standing ruling; no tolerance arm.

## Net elements (R6)

`git diff --stat origin/main`: production 7 files, **+37 / −56**; tests 3 files, +8 / −12 (fixtures drop `index:`). Exported symbols +2 / −0 (`WorkflowDeclaredPlanSchema`, `WorkflowDeclaredPlan`); declarations −1 (`WorkflowScriptPlan`), −1 file-local function (`workflowScriptDeclaredItemsByPhase`), −1 schema field (`index`).

## Consumer counts (R8)

No emit path deleted. `workflowScriptDeclaredItemsByPhase` at `origin/main`: 1 caller (the panel). `WorkflowPlanMarker.phases[].index` readers: 1 (`unionWithDeclaredPlan`), writers: 2 (recorder, projection).

## Verified

- `npm run typecheck` — clean; `npm run lint` + prettier — clean on changed files
- vitest `src/test-kernel/{shared,cli,progressView,agent,transcript}` — 438 files, 6,548 tests passing
- `npm run check:dead-code-ratchet` — no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QESykrKh1yzvF2bB4pjDrS