### PR TITLE
fix(workflow): fail final compile rejection

### DIFF
--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -286,6 +286,13 @@ export class OutputNode extends BaseNode<
         : undefined;
     if (compileFailureContext) {
       shared.compileFailureContext = compileFailureContext;
+      if (currentRound + 1 >= shared.totalRounds) {
+        shared.lastError = {
+          message:
+            'Automatic LaTeX compilation failed after the final workflow round.',
+          userRetryable: false,
+        };
+      }
     } else {
       delete shared.compileFailureContext;
     }

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -286,7 +286,7 @@ export class OutputNode extends BaseNode<
         : undefined;
     if (compileFailureContext) {
       shared.compileFailureContext = compileFailureContext;
-      if (currentRound + 1 >= shared.totalRounds) {
+      if (!runScope.signal.aborted && currentRound + 1 >= shared.totalRounds) {
         shared.lastError = {
           message:
             'Automatic LaTeX compilation failed after the final workflow round.',

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -894,7 +894,7 @@ const WORKFLOW_REJECT_RUNTIME_REACHABILITY = {
   command:
     'texra run <workflow-agent> --input paper.tex --instruction "revise the paper"',
   through:
-    'packages/cli/src/commands/workflow.ts -> src/agent/implementations/flows/reflection/runReflectionFlow.ts',
+    'packages/cli/src/commands/workflow.ts -> src/agent/implementations/flows/reflection/runReflectionFlow.ts -> src/agent/implementations/flows/reflection/nodes/OutputNode.ts',
 } satisfies CliRuntimeReachability;
 const OPENAI_WEBSOCKET_RUNTIME_REACHABILITY = {
   command:
@@ -1346,10 +1346,8 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       'Reject an agent edit when the automatic post-output compile fails, so broken LaTeX is not accepted.',
     category: 'workflow',
     slots: sameSlot('workspaceState'),
-    // Also read by OutputNode.ts (compileFailureContext gate); the row names
-    // the extra-round grant in runReflectionFlow.ts as its reader evidence.
     honoredBy: everyHost(
-      'src/agent/implementations/flows/reflection/runReflectionFlow.ts',
+      'src/agent/implementations/flows/reflection/nodes/OutputNode.ts',
       WORKFLOW_REJECT_RUNTIME_REACHABILITY,
     ),
     surfaces: { settingsView: 'latex', cliConfig: true },

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 // Local imports
 import { noopTrace, TraceEmitter, type AgentTrace } from '@agent/trace';
 import { OutputNode } from '@agent/implementations/flows/reflection/nodes/OutputNode';
+import { RoundPersistedFlow } from '@agent/implementations/flows/reflection/RoundPersistedFlow';
 import type { ReflectionFlowShared } from '@agent/implementations/flows/reflection/ReflectionFlowState';
 import type { ReflectionServices } from '@agent/implementations/flows/reflection/ReflectionServices';
 import {
@@ -14,15 +15,17 @@ import { extractFilesFromXml } from '@agent/implementations/flows/reflection/out
 import type { OutputDependencies } from '@agent/implementations/flows/reflection/output/outputState';
 import type { XmlOutputManager } from '@agent/implementations/flows/reflection/output/XmlOutputManager';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
-import type {
-  AgentFileLocation,
-  CompileFailure,
-  CompileResult,
-  FileLocation,
-  OutputFileInfo,
-  StreamTabId,
+import {
+  RUN_OUTCOME,
+  type AgentFileLocation,
+  type CompileFailure,
+  type CompileResult,
+  type FileLocation,
+  type OutputFileInfo,
+  type StreamTabId,
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import { createFakeKv } from '@test/support/FakeExecutionKVStore';
 import { installPlatform } from '@test/support/setupPlatform';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import {
@@ -95,11 +98,10 @@ function createOutputNode(
   host: ReturnType<typeof createRecordingHost>['host'],
   logger: AgentTrace = noopTrace,
   outputState = createOutputState(),
-  signal?: AbortSignal,
 ): OutputNode {
   return new OutputNode().setServices({
     streamId,
-    runScope: testRunScope(streamId, { interactions: host, signal }),
+    runScope: testRunScope(streamId, { interactions: host }),
     logger,
     outputState,
   } as unknown as ReflectionServices);
@@ -139,26 +141,49 @@ function runOutputPost(
   );
 }
 
-function compileContextCase(
-  streamId: string,
-  signal?: AbortSignal,
-): {
+function compileContextCase(streamId: string): {
   outputNode: OutputNode;
   fixture: ReturnType<typeof createCompileFailureFixture>;
   shared: ReflectionFlowShared;
 } {
   const { host } = createRecordingHost();
   return {
-    outputNode: createOutputNode(
-      streamId,
-      host,
-      noopTrace,
-      createOutputState(),
-      signal,
-    ),
+    outputNode: createOutputNode(streamId, host),
     fixture: createCompileFailureFixture(),
     shared: { roundOutputs: [] } as unknown as ReflectionFlowShared,
   };
+}
+
+class FinalCompileOutputNode extends OutputNode {
+  constructor(
+    private readonly fixture: ReturnType<typeof createCompileFailureFixture>,
+    private readonly abortController?: AbortController,
+  ) {
+    super();
+  }
+
+  override async prep(
+    shared: ReflectionFlowShared,
+  ): ReturnType<OutputNode['prep']> {
+    return {
+      outputLocation: this.fixture.outputLocation,
+      currentRound: shared.currentRound,
+      endTurn: false,
+    };
+  }
+
+  override async exec(): ReturnType<OutputNode['exec']> {
+    const result = {
+      summary: this.fixture.summary,
+      compileResult: this.fixture.compileResult,
+      compiledArtifacts: [],
+      emitCompileFailures: false,
+    };
+    // Model an interrupt arriving after compile completes but before post()
+    // projects its result into the flow's terminal state.
+    this.abortController?.abort();
+    return result;
+  }
 }
 
 describe('output progress events', () => {
@@ -307,82 +332,74 @@ describe('output progress events', () => {
     expect(shared.compileFailureContext).toBeUndefined();
   });
 
-  it('fails the run when the final configured round fails compilation', async () => {
-    await installPlatform({
-      workspaceState: {
-        [WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE]: true,
+  it.each([
+    {
+      name: 'fails after a final-round compile failure',
+      abortAfterCompile: false,
+      expectedOutcome: RUN_OUTCOME.FAILED,
+      expectedLastError: {
+        message:
+          'Automatic LaTeX compilation failed after the final workflow round.',
+        userRetryable: false,
       },
-    });
-    const { outputNode, fixture } = compileContextCase(
-      'stream:final-compile-failure',
-    );
-    const shared = {
-      roundOutputs: [],
-      currentRound: 1,
-      totalRounds: 2,
-      continueRounds: true,
-    } as unknown as ReflectionFlowShared;
-
-    await runOutputPost(
-      outputNode,
-      shared,
-      {
-        outputLocation: fixture.outputLocation,
+    },
+    {
+      name: 'stays cancelled when aborted after final-round compile',
+      abortAfterCompile: true,
+      expectedOutcome: RUN_OUTCOME.CANCELLED,
+      expectedLastError: undefined,
+    },
+  ])(
+    '$name',
+    async ({ abortAfterCompile, expectedOutcome, expectedLastError }) => {
+      await installPlatform({
+        workspaceState: {
+          [WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE]: true,
+        },
+      });
+      const streamId = `stream:final-compile-failure-${expectedOutcome}`;
+      const controller = new AbortController();
+      const fixture = createCompileFailureFixture();
+      const node = new FinalCompileOutputNode(
+        fixture,
+        abortAfterCompile ? controller : undefined,
+      );
+      const { host } = createRecordingHost();
+      const runScope = testRunScope(streamId, {
+        interactions: host,
+        signal: controller.signal,
+      });
+      const services = {
+        streamId,
+        runScope,
+        logger: noopTrace,
+        outputState: createOutputState(),
+      } as unknown as ReflectionServices;
+      const flow = new RoundPersistedFlow<
+        ReflectionFlowShared,
+        ReflectionServices
+      >(node, createFakeKv(), {
+        callbacks: { signal: controller.signal },
+      }).setServices(services);
+      const shared = {
+        roundOutputs: [],
         currentRound: 1,
-        endTurn: false,
-      },
-      {
-        summary: fixture.summary,
-        compileResult: fixture.compileResult,
-        compiledArtifacts: [],
-        emitCompileFailures: false,
-      },
-    );
+        totalRounds: 2,
+        continueRounds: true,
+      } as unknown as ReflectionFlowShared;
 
-    expect(shared.lastError).toEqual({
-      message:
-        'Automatic LaTeX compilation failed after the final workflow round.',
-      userRetryable: false,
-    });
-  });
+      const outcome = await withTestRunContext(runScope, () =>
+        flow.run(shared),
+      );
+      const finalShared = await flow.getShared();
 
-  it('keeps a final-round compile failure cancelled after user abort', async () => {
-    await installPlatform({
-      workspaceState: {
-        [WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE]: true,
-      },
-    });
-    const controller = new AbortController();
-    const { outputNode, fixture } = compileContextCase(
-      'stream:aborted-final-compile-failure',
-      controller.signal,
-    );
-    const shared = {
-      roundOutputs: [],
-      currentRound: 1,
-      totalRounds: 2,
-      continueRounds: true,
-    } as unknown as ReflectionFlowShared;
-    controller.abort();
-
-    await runOutputPost(
-      outputNode,
-      shared,
-      {
-        outputLocation: fixture.outputLocation,
-        currentRound: 1,
-        endTurn: false,
-      },
-      {
-        summary: fixture.summary,
-        compileResult: fixture.compileResult,
-        compiledArtifacts: [],
-        emitCompileFailures: false,
-      },
-    );
-
-    expect(shared.lastError).toBeUndefined();
-  });
+      expect(outcome).toBe(expectedOutcome);
+      expect(finalShared?.lastError).toEqual(expectedLastError);
+      expect(finalShared?.compileFailureContext).toContain(
+        'previous workflow round was rejected',
+      );
+    },
+  );
 
   it.each([
     {

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -173,16 +173,23 @@ class FinalCompileOutputNode extends OutputNode {
   }
 
   override async exec(): ReturnType<OutputNode['exec']> {
-    const result = {
+    return {
       summary: this.fixture.summary,
       compileResult: this.fixture.compileResult,
       compiledArtifacts: [],
       emitCompileFailures: false,
     };
-    // Model an interrupt arriving after compile completes but before post()
+  }
+
+  override async post(
+    shared: ReflectionFlowShared,
+    prepRes: Parameters<OutputNode['post']>[1],
+    execRes: Parameters<OutputNode['post']>[2],
+  ): ReturnType<OutputNode['post']> {
+    // Model an interrupt arriving after compile completes but before OutputNode
     // projects its result into the flow's terminal state.
     this.abortController?.abort();
-    return result;
+    return super.post(shared, prepRes, execRes);
   }
 }
 

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -4,7 +4,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 // Local imports
 import { noopTrace, TraceEmitter, type AgentTrace } from '@agent/trace';
 import { OutputNode } from '@agent/implementations/flows/reflection/nodes/OutputNode';
-import { RoundPersistedFlow } from '@agent/implementations/flows/reflection/RoundPersistedFlow';
 import type { ReflectionFlowShared } from '@agent/implementations/flows/reflection/ReflectionFlowState';
 import type { ReflectionServices } from '@agent/implementations/flows/reflection/ReflectionServices';
 import {
@@ -15,17 +14,15 @@ import { extractFilesFromXml } from '@agent/implementations/flows/reflection/out
 import type { OutputDependencies } from '@agent/implementations/flows/reflection/output/outputState';
 import type { XmlOutputManager } from '@agent/implementations/flows/reflection/output/XmlOutputManager';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
-import {
-  RUN_OUTCOME,
-  type AgentFileLocation,
-  type CompileFailure,
-  type CompileResult,
-  type FileLocation,
-  type OutputFileInfo,
-  type StreamTabId,
+import type {
+  AgentFileLocation,
+  CompileFailure,
+  CompileResult,
+  FileLocation,
+  OutputFileInfo,
+  StreamTabId,
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import { createFakeKv } from '@test/support/FakeExecutionKVStore';
 import { installPlatform } from '@test/support/setupPlatform';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import {
@@ -98,10 +95,11 @@ function createOutputNode(
   host: ReturnType<typeof createRecordingHost>['host'],
   logger: AgentTrace = noopTrace,
   outputState = createOutputState(),
+  signal?: AbortSignal,
 ): OutputNode {
   return new OutputNode().setServices({
     streamId,
-    runScope: testRunScope(streamId, { interactions: host }),
+    runScope: testRunScope(streamId, { interactions: host, signal }),
     logger,
     outputState,
   } as unknown as ReflectionServices);
@@ -141,59 +139,26 @@ function runOutputPost(
   );
 }
 
-function compileContextCase(streamId: string): {
+function compileContextCase(
+  streamId: string,
+  signal?: AbortSignal,
+): {
   outputNode: OutputNode;
   fixture: ReturnType<typeof createCompileFailureFixture>;
   shared: ReflectionFlowShared;
 } {
   const { host } = createRecordingHost();
   return {
-    outputNode: createOutputNode(streamId, host),
+    outputNode: createOutputNode(
+      streamId,
+      host,
+      noopTrace,
+      createOutputState(),
+      signal,
+    ),
     fixture: createCompileFailureFixture(),
     shared: { roundOutputs: [] } as unknown as ReflectionFlowShared,
   };
-}
-
-type FinalCompileServices = ReflectionServices & {
-  abortAfterCompile?: () => void;
-};
-
-class FinalCompileOutputNode extends OutputNode {
-  constructor(
-    private readonly fixture: ReturnType<typeof createCompileFailureFixture>,
-  ) {
-    super();
-  }
-
-  override async prep(
-    shared: ReflectionFlowShared,
-  ): ReturnType<OutputNode['prep']> {
-    return {
-      outputLocation: this.fixture.outputLocation,
-      currentRound: shared.currentRound,
-      endTurn: false,
-    };
-  }
-
-  override async exec(): ReturnType<OutputNode['exec']> {
-    return {
-      summary: this.fixture.summary,
-      compileResult: this.fixture.compileResult,
-      compiledArtifacts: [],
-      emitCompileFailures: false,
-    };
-  }
-
-  override async post(
-    shared: ReflectionFlowShared,
-    prepRes: Parameters<OutputNode['post']>[1],
-    execRes: Parameters<OutputNode['post']>[2],
-  ): ReturnType<OutputNode['post']> {
-    // Model an interrupt arriving after compile completes but before OutputNode
-    // projects its result into the flow's terminal state.
-    (this.services as FinalCompileServices).abortAfterCompile?.();
-    return super.post(shared, prepRes, execRes);
-  }
 }
 
 describe('output progress events', () => {
@@ -344,9 +309,8 @@ describe('output progress events', () => {
 
   it.each([
     {
-      name: 'fails after a final-round compile failure',
-      abortAfterCompile: false,
-      expectedOutcome: RUN_OUTCOME.FAILED,
+      name: 'sets the final compile failure when the run is active',
+      aborted: false,
       expectedLastError: {
         message:
           'Automatic LaTeX compilation failed after the final workflow round.',
@@ -354,62 +318,50 @@ describe('output progress events', () => {
       },
     },
     {
-      name: 'stays cancelled when aborted after final-round compile',
-      abortAfterCompile: true,
-      expectedOutcome: RUN_OUTCOME.CANCELLED,
+      name: 'does not overwrite cancellation with the final compile failure',
+      aborted: true,
       expectedLastError: undefined,
     },
-  ])(
-    '$name',
-    async ({ abortAfterCompile, expectedOutcome, expectedLastError }) => {
-      await installPlatform({
-        workspaceState: {
-          [WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE]: true,
-        },
-      });
-      const streamId = `stream:final-compile-failure-${expectedOutcome}`;
-      const controller = new AbortController();
-      const fixture = createCompileFailureFixture();
-      const node = new FinalCompileOutputNode(fixture);
-      const { host } = createRecordingHost();
-      const runScope = testRunScope(streamId, {
-        interactions: host,
-        signal: controller.signal,
-      });
-      const services = {
-        streamId,
-        runScope,
-        logger: noopTrace,
-        outputState: createOutputState(),
-        abortAfterCompile: abortAfterCompile
-          ? () => controller.abort()
-          : undefined,
-      } as unknown as FinalCompileServices;
-      const flow = new RoundPersistedFlow<
-        ReflectionFlowShared,
-        ReflectionServices
-      >(node, createFakeKv(), {
-        callbacks: { signal: controller.signal },
-      }).setServices(services);
-      const shared = {
-        roundOutputs: [],
+  ])('$name', async ({ aborted, expectedLastError }) => {
+    await installPlatform({
+      workspaceState: {
+        [WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE]: true,
+      },
+    });
+    const controller = new AbortController();
+    const { outputNode, fixture } = compileContextCase(
+      `stream:final-compile-failure-${aborted ? 'aborted' : 'active'}`,
+      controller.signal,
+    );
+    const shared = {
+      roundOutputs: [],
+      currentRound: 1,
+      totalRounds: 2,
+      continueRounds: true,
+    } as unknown as ReflectionFlowShared;
+    if (aborted) controller.abort();
+
+    await runOutputPost(
+      outputNode,
+      shared,
+      {
+        outputLocation: fixture.outputLocation,
         currentRound: 1,
-        totalRounds: 2,
-        continueRounds: true,
-      } as unknown as ReflectionFlowShared;
+        endTurn: false,
+      },
+      {
+        summary: fixture.summary,
+        compileResult: fixture.compileResult,
+        compiledArtifacts: [],
+        emitCompileFailures: false,
+      },
+    );
 
-      const outcome = await withTestRunContext(runScope, () =>
-        flow.run(shared),
-      );
-      const finalShared = await flow.getShared();
-
-      expect(outcome).toBe(expectedOutcome);
-      expect(finalShared?.lastError).toEqual(expectedLastError);
-      expect(finalShared?.compileFailureContext).toContain(
-        'previous workflow round was rejected',
-      );
-    },
-  );
+    expect(shared.lastError).toEqual(expectedLastError);
+    expect(shared.compileFailureContext).toContain(
+      'previous workflow round was rejected',
+    );
+  });
 
   it.each([
     {

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -154,10 +154,13 @@ function compileContextCase(streamId: string): {
   };
 }
 
+type FinalCompileServices = ReflectionServices & {
+  abortAfterCompile?: () => void;
+};
+
 class FinalCompileOutputNode extends OutputNode {
   constructor(
     private readonly fixture: ReturnType<typeof createCompileFailureFixture>,
-    private readonly abortController?: AbortController,
   ) {
     super();
   }
@@ -188,7 +191,7 @@ class FinalCompileOutputNode extends OutputNode {
   ): ReturnType<OutputNode['post']> {
     // Model an interrupt arriving after compile completes but before OutputNode
     // projects its result into the flow's terminal state.
-    this.abortController?.abort();
+    (this.services as FinalCompileServices).abortAfterCompile?.();
     return super.post(shared, prepRes, execRes);
   }
 }
@@ -367,10 +370,7 @@ describe('output progress events', () => {
       const streamId = `stream:final-compile-failure-${expectedOutcome}`;
       const controller = new AbortController();
       const fixture = createCompileFailureFixture();
-      const node = new FinalCompileOutputNode(
-        fixture,
-        abortAfterCompile ? controller : undefined,
-      );
+      const node = new FinalCompileOutputNode(fixture);
       const { host } = createRecordingHost();
       const runScope = testRunScope(streamId, {
         interactions: host,
@@ -381,7 +381,10 @@ describe('output progress events', () => {
         runScope,
         logger: noopTrace,
         outputState: createOutputState(),
-      } as unknown as ReflectionServices;
+        abortAfterCompile: abortAfterCompile
+          ? () => controller.abort()
+          : undefined,
+      } as unknown as FinalCompileServices;
       const flow = new RoundPersistedFlow<
         ReflectionFlowShared,
         ReflectionServices

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -95,10 +95,11 @@ function createOutputNode(
   host: ReturnType<typeof createRecordingHost>['host'],
   logger: AgentTrace = noopTrace,
   outputState = createOutputState(),
+  signal?: AbortSignal,
 ): OutputNode {
   return new OutputNode().setServices({
     streamId,
-    runScope: testRunScope(streamId, { interactions: host }),
+    runScope: testRunScope(streamId, { interactions: host, signal }),
     logger,
     outputState,
   } as unknown as ReflectionServices);
@@ -138,14 +139,23 @@ function runOutputPost(
   );
 }
 
-function compileContextCase(streamId: string): {
+function compileContextCase(
+  streamId: string,
+  signal?: AbortSignal,
+): {
   outputNode: OutputNode;
   fixture: ReturnType<typeof createCompileFailureFixture>;
   shared: ReflectionFlowShared;
 } {
   const { host } = createRecordingHost();
   return {
-    outputNode: createOutputNode(streamId, host),
+    outputNode: createOutputNode(
+      streamId,
+      host,
+      noopTrace,
+      createOutputState(),
+      signal,
+    ),
     fixture: createCompileFailureFixture(),
     shared: { roundOutputs: [] } as unknown as ReflectionFlowShared,
   };
@@ -334,6 +344,44 @@ describe('output progress events', () => {
         'Automatic LaTeX compilation failed after the final workflow round.',
       userRetryable: false,
     });
+  });
+
+  it('keeps a final-round compile failure cancelled after user abort', async () => {
+    await installPlatform({
+      workspaceState: {
+        [WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE]: true,
+      },
+    });
+    const controller = new AbortController();
+    const { outputNode, fixture } = compileContextCase(
+      'stream:aborted-final-compile-failure',
+      controller.signal,
+    );
+    const shared = {
+      roundOutputs: [],
+      currentRound: 1,
+      totalRounds: 2,
+      continueRounds: true,
+    } as unknown as ReflectionFlowShared;
+    controller.abort();
+
+    await runOutputPost(
+      outputNode,
+      shared,
+      {
+        outputLocation: fixture.outputLocation,
+        currentRound: 1,
+        endTurn: false,
+      },
+      {
+        summary: fixture.summary,
+        compileResult: fixture.compileResult,
+        compiledArtifacts: [],
+        emitCompileFailures: false,
+      },
+    );
+
+    expect(shared.lastError).toBeUndefined();
   });
 
   it.each([

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -297,6 +297,45 @@ describe('output progress events', () => {
     expect(shared.compileFailureContext).toBeUndefined();
   });
 
+  it('fails the run when the final configured round fails compilation', async () => {
+    await installPlatform({
+      workspaceState: {
+        [WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE]: true,
+      },
+    });
+    const { outputNode, fixture } = compileContextCase(
+      'stream:final-compile-failure',
+    );
+    const shared = {
+      roundOutputs: [],
+      currentRound: 1,
+      totalRounds: 2,
+      continueRounds: true,
+    } as unknown as ReflectionFlowShared;
+
+    await runOutputPost(
+      outputNode,
+      shared,
+      {
+        outputLocation: fixture.outputLocation,
+        currentRound: 1,
+        endTurn: false,
+      },
+      {
+        summary: fixture.summary,
+        compileResult: fixture.compileResult,
+        compiledArtifacts: [],
+        emitCompileFailures: false,
+      },
+    );
+
+    expect(shared.lastError).toEqual({
+      message:
+        'Automatic LaTeX compilation failed after the final workflow round.',
+      userRetryable: false,
+    });
+  });
+
   it.each([
     {
       name: 'publishes missing-output processing events on the run trace',


### PR DESCRIPTION
## Summary

- end a reject-on-compile-failure workflow as failed when its final configured round does not compile
- keep the configured round limit hard; no repair round is added
- point the setting catalog at its actual runtime reader

## Validation

- `corepack pnpm exec vitest run src/test-kernel/agent/output/OutputProgressEvents.vitest.ts --maxWorkers=1` (8 passed)
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm exec eslint src/agent/implementations/flows/reflection/nodes/OutputNode.ts src/shared/schemas/stateSettings.ts src/test-kernel/agent/output/OutputProgressEvents.vitest.ts`
- Prettier check on the touched files

Closes #11619