### PR TITLE
fix(workflow): exclude untagged superseded cards

### DIFF
--- a/src/shared/streams/workflowRunModel.ts
+++ b/src/shared/streams/workflowRunModel.ts
@@ -263,9 +263,9 @@ export function workflowRunModel(
     (row): row is WorkflowTaskRow => row.kind === 'workflowTask',
   );
   // "Newest" is the last attempt id in transcript order — a resume's cards
-  // are appended after the attempt they supersede. A card with no attempt id
-  // (an older transcript) is never dropped; only a defined id that disagrees
-  // with the newest one is.
+  // are appended after the attempt they supersede. Once one exists, cards
+  // from an older transcript without an attempt id are superseded too; keep
+  // every card only when the transcript has no attempt ids at all.
   let latestAttemptId: string | undefined;
   for (const row of cards)
     latestAttemptId = row.call.attemptId ?? latestAttemptId;
@@ -280,7 +280,7 @@ export function workflowRunModel(
   for (const row of cards) {
     const phase = row.groupId ? byGroupId.get(row.groupId) : undefined;
     const attemptId = row.call.attemptId;
-    if (attemptId !== undefined && attemptId !== latestAttemptId) {
+    if (latestAttemptId !== undefined && attemptId !== latestAttemptId) {
       if (phase) staleOnly.add(phase);
       continue;
     }

--- a/src/test-kernel/shared/WorkflowRunModel.vitest.ts
+++ b/src/test-kernel/shared/WorkflowRunModel.vitest.ts
@@ -127,6 +127,7 @@ describe('workflow run model', () => {
     const model = modelOf(
       ['Map'],
       [
+        { id: 'legacy', phase: 'Map', status: 'failed' },
         { id: 'old', phase: 'Map', status: 'failed', attemptId: 'a1' },
         { id: 'new', phase: 'Map', attemptId: 'a2' },
       ],


### PR DESCRIPTION
## Summary

- exclude legacy untagged workflow cards once a newer tagged attempt is present
- preserve all cards for transcripts that contain no attempt IDs
- extend the shared-model regression case across tagged and untagged superseded cards

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/shared/WorkflowRunModel.vitest.ts`
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm exec eslint src/shared/streams/workflowRunModel.ts src/test-kernel/shared/WorkflowRunModel.vitest.ts`
- `corepack pnpm exec prettier --check src/shared/streams/workflowRunModel.ts src/test-kernel/shared/WorkflowRunModel.vitest.ts`

Closes #11583