### PR TITLE
fix(dev): pin Effect editor guidance and config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,5 @@
   "typescript.tsc.autoDetect": "off",
   // Use the workspace TypeScript (6.0.3) so the editor matches the build; the
   // bundled VS Code TS server is older and rejects `ignoreDeprecations: "6.0"`.
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -689,7 +689,8 @@ These rules were earned from a 2026-07 whole-repo simplification campaign, not d
 
 ## Effect Best Practices
 
-**IMPORTANT:** Always consult effect-solutions before writing Effect code.
+When the optional local `effect-solutions` tool is installed, consult it before
+writing non-trivial Effect code:
 
 1. Run `effect-solutions list` to see available guides
 2. Run `effect-solutions show <topic>...` for relevant patterns (supports multiple topics)
@@ -697,13 +698,15 @@ These rules were earned from a 2026-07 whole-repo simplification campaign, not d
 
 Topics: quick-start, project-setup, tsconfig, basics, services-and-layers, data-modeling, error-handling, config, testing, cli.
 
-Never guess at Effect patterns - check the guide first.
+If the tool is unavailable, consult the pinned package sources and types in
+`node_modules` instead of guessing at Effect patterns.
 
 ### Local Effect Source
 
-The Effect v4 repository is cloned to `~/.local/share/effect-solutions/effect`
-for reference. Use it to explore APIs, find usage examples, and understand
-implementation details when the documentation isn't enough. This repo pins
-`effect` 4.0.0-rc.x (v4) — match `effect-smol` (v4) sources, not Effect v3 docs.
+`effect-solutions` may clone the Effect repository to
+`~/.local/share/effect-solutions/effect` for reference. This optional checkout
+is not provisioned by the repository. When present, it should track
+`Effect-TS/effect` `main` (v4); Effect v3 lives on that repository's `v3`
+branch. Match the installed `effect` version when APIs differ.
 
 <!-- effect-solutions:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,23 +237,6 @@ Load these when the work lands in their territory:
 
 <!-- effect-solutions:start -->
 
-## Effect Best Practices
-
-**IMPORTANT:** Always consult effect-solutions before writing Effect code.
-
-1. Run `effect-solutions list` to see available guides
-2. Run `effect-solutions show <topic>...` for relevant patterns (supports multiple topics)
-3. Search `~/.local/share/effect-solutions/effect` for real implementations
-
-Topics: quick-start, project-setup, tsconfig, basics, services-and-layers, data-modeling, error-handling, config, testing, cli.
-
-Never guess at Effect patterns - check the guide first.
-
-### Local Effect Source
-
-The Effect v4 repository is cloned to `~/.local/share/effect-solutions/effect`
-for reference. Use it to explore APIs, find usage examples, and understand
-implementation details when the documentation isn't enough. This repo pins
-`effect` 4.0.0-rc.x (v4) — match `effect-smol` (v4) sources, not Effect v3 docs.
+Follow the **Effect Best Practices** guidance in `AGENTS.md`.
 
 <!-- effect-solutions:end -->

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Effect-TS/language-service/refs/heads/main/schema.json",
+  "$schema": "./node_modules/@effect/language-service/schema.json",
   "compilerOptions": {
     "plugins": [
       {


### PR DESCRIPTION
## Summary

- keep Effect guidance in AGENTS.md as one source and make the unprovisioned local helper explicitly optional
- point v4 source guidance at Effect-TS/effect main instead of the archived effect-smol repository
- remove the redundant deprecated workspace-TypeScript prompt setting
- use the schema shipped by the pinned Effect language-service package

## Validation

- Prettier check on all four touched files
- workspace `tsc --noEmit --checkers 8`
- confirmed `@effect/language-service` ships the referenced `schema.json`

Closes #11610
Closes #11611