### PR TITLE
simplify(cli): survey bundle 5 — five mechanical deletions on the popup path

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -352,12 +352,12 @@ export function App(props: AppProps): React.JSX.Element {
       const runStartedAt = streamPhaseFor(child.childStreamId)?.runStartedAt;
       const usage = readStreamArtifacts(child.childStreamId)?.cumulativeUsage;
       childProgress.set(child.childStreamId, {
-        ...(runStartedAt !== undefined ? { runStartedAt } : {}),
+        runStartedAt,
         toolCallCount:
           streamStateFor(child.childStreamId)?.conversationProgress
             .toolCallCount ?? 0,
-        ...(usage ? { outputTokens: usage.outputTokens } : {}),
-        ...(usage?.cost !== undefined ? { costUsd: usage.cost } : {}),
+        outputTokens: usage?.outputTokens,
+        costUsd: usage?.cost,
       });
     }
     return workflowRunModel({

--- a/packages/cli/src/chat/tui/appInteractionPolicy.ts
+++ b/packages/cli/src/chat/tui/appInteractionPolicy.ts
@@ -1,7 +1,7 @@
 /** Pure foreground-surface and keyboard interaction policy for the root TUI. */
 
 // Local imports - shared schemas and utilities
-import { type RunIdentity, type StreamTabId } from '@shared/schemas';
+import { type StreamTabId } from '@shared/schemas';
 import { assertNever, groupBy } from '@utils/core';
 
 // Local imports - TUI state
@@ -220,30 +220,5 @@ export function groupPendingApprovalsByRow(
     keyed,
     (entry) => entry.key,
     (entry) => entry.summary.kind,
-  );
-}
-
-// A workflow-script grandchild `agent()` call is the only interactively
-// skip/retry-able row: a NATIVE agent run (no external CLI tool — those
-// children are driven by their own tool and would no-op here) whose parent
-// stream IS the workflow-script run — one identity hop, which excludes the
-// run stream itself so its row never shows a control that would silently
-// no-op. Callers read both identities from the shared metadata
-// (`streamMetadataFor`), resolving the parent edge themselves, so this
-// selector stays pure.
-export function selectedChildRowWorkflowControllable({
-  parentIdentity,
-  selectedChildIdentity,
-  selectedChildKillable,
-}: {
-  readonly parentIdentity: RunIdentity | undefined;
-  readonly selectedChildIdentity: RunIdentity | undefined;
-  readonly selectedChildKillable: boolean;
-}): boolean {
-  return (
-    selectedChildKillable &&
-    selectedChildIdentity?.kind === 'agent' &&
-    selectedChildIdentity.tool === undefined &&
-    parentIdentity?.kind === 'multiAgentWorkflow'
   );
 }

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -146,7 +146,6 @@ export function sessionHeaderIdentityLine(
         ? 'workflow script'
         : 'subagent';
     const phaseText = ancestorWorkflowPhaseLabel({
-      categoryOf: (id) => streamMetadataFor(id)?.agentCategory,
       stageOf: (id) => streamStateFor(id)?.stage,
       parentStream,
       streamId: context.streamId,

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -288,7 +288,6 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     focusedStreamId === undefined
       ? undefined
       : ancestorWorkflowPhaseLabel({
-          categoryOf: (id) => streamMetadataFor(id)?.agentCategory,
           stageOf: (id) => streamStateFor(id)?.stage,
           parentStream,
           streamId: focusedStreamId,

--- a/packages/cli/src/chat/tui/panes/WorkflowPopup.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkflowPopup.tsx
@@ -60,7 +60,6 @@ import { filterNotNullish } from '@utils/core';
 import { formatCompactDuration, formatCostUsd } from '@utils/text/stringUtils';
 
 // Local imports - TUI state and policy
-import { selectedChildRowWorkflowControllable } from '../appInteractionPolicy';
 import { formFrameWidth } from '../forms/_shared/FormFrame';
 import { scrollableModalTextRowsBudget } from '../modals/ScrollableModalText';
 import {
@@ -245,8 +244,10 @@ interface WorkflowPopupProps {
   readonly view: WorkflowPopupView;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly activeSubagentExecutionIds: ReadonlyMap<StreamTabId, string>;
-  readonly pendingApprovals:
-    ReadonlyMap<string, readonly PendingApprovalKind[]> | undefined;
+  readonly pendingApprovals: ReadonlyMap<
+    string,
+    readonly PendingApprovalKind[]
+  >;
   readonly onClose: () => void;
   readonly onFocusStream: (streamId: StreamTabId) => void;
   readonly onKillExecution: (executionId: string) => void;
@@ -322,10 +323,9 @@ export function WorkflowPopup({
       : undefined;
   };
   const runStartedAt = streamPhaseFor(streamId)?.runStartedAt;
-  const nowMs = useLiveNowMsSince([
-    runStartedAt,
-    ...model.tasks.map((row) => model.liveOf.get(row.id)?.runStartedAt),
-  ]);
+  // A card is live only while its workflow is, and the run's own origin is
+  // set for every active phase, so it alone keys the clock.
+  const nowMs = useLiveNowMsSince([runStartedAt]);
 
   const identity = streamMetadataFor(streamId)?.identity;
   const name = identity ? runIdentityDisplayName(identity) : 'Workflow';
@@ -350,13 +350,19 @@ export function WorkflowPopup({
     selectedChildStreamId !== undefined
       ? activeSubagentExecutionIds.get(selectedChildStreamId)
       : undefined;
+  // A workflow-script grandchild `agent()` call is the only skip/retry-able
+  // row: a native agent run (an external CLI tool's child is driven by that
+  // tool and would no-op) whose parent is the workflow run — one identity
+  // hop, which excludes the run stream itself.
+  const selectedChildIdentity =
+    selectedChildStreamId !== undefined
+      ? streamMetadataFor(selectedChildStreamId)?.identity
+      : undefined;
   const controllable =
-    selectedChildStreamId !== undefined &&
-    selectedChildRowWorkflowControllable({
-      parentIdentity: identity,
-      selectedChildIdentity: streamMetadataFor(selectedChildStreamId)?.identity,
-      selectedChildKillable: selectedExecutionId !== undefined,
-    });
+    selectedExecutionId !== undefined &&
+    selectedChildIdentity?.kind === 'agent' &&
+    selectedChildIdentity.tool === undefined &&
+    identity?.kind === 'multiAgentWorkflow';
 
   const hints: KeyHint[] = [
     { key: '←/→', action: 'phase' },
@@ -500,7 +506,7 @@ export function WorkflowPopup({
             pendingKinds={
               childStreamId === undefined
                 ? undefined
-                : pendingApprovals?.get(childStreamId)
+                : pendingApprovals.get(childStreamId)
             }
           />
         );

--- a/packages/cli/src/chat/tui/state/workflowPhase.ts
+++ b/packages/cli/src/chat/tui/state/workflowPhase.ts
@@ -1,42 +1,22 @@
 // Current workflow-script phase for orientation chrome (header, status bar).
 
-import {
-  AgentCategory,
-  type StreamStage,
-  type StreamTabId,
-} from '@shared/schemas';
+import type { StreamStage, StreamTabId } from '@shared/schemas';
 import { formatPhaseStageLabel } from '@shared/streams/streamStatusDisplay';
 
 /**
- * The open phase of one workflow-script stream, named the way every host names
- * it: from the shared `StreamExecutionState.stage` the session applier writes,
- * not from a transcript row this host happens to hold. `stage` is ephemeral —
- * a reloaded session has none until the run opens its next phase — which is
- * exactly the gap the progress view's header already lives with.
- *
- * Callers pass the stream's shared facts (`streamStateFor(id)?.stage`,
- * `streamMetadataFor(id)?.agentCategory`) so this selector stays pure.
- */
-function currentWorkflowPhaseLabel(
-  stage: StreamStage | undefined | null,
-  category: AgentCategory | undefined,
-): string | undefined {
-  if (category !== AgentCategory.Workflow || stage?.kind !== 'phase') {
-    return undefined;
-  }
-  return formatPhaseStageLabel(stage);
-}
-
-/**
  * Nearest workflow-script ancestor's current phase, walking parent links
- * starting from the stream's parent. A stream's own stage is never its
- * location context: the header prints once into scrollback and would go
- * stale as the workflow advanced, and the status bar already has a stage
- * slot for the displayed stream's own phase — naming it here too printed
- * `Derive (1/2) › name … Derive (1/2)` on one row.
+ * starting from the stream's parent, named from the shared
+ * `StreamExecutionState.stage` the session applier writes — a `phase` stage
+ * is written by the workflow-script run alone, so its kind is the whole test.
+ * `stage` is ephemeral (a reloaded session has none until the run opens its
+ * next phase), the gap the progress view's header already lives with.
+ *
+ * A stream's own stage is never its location context: the header prints once
+ * into scrollback and would go stale as the workflow advanced, and the status
+ * bar already has a stage slot for the displayed stream's own phase — naming
+ * it here too printed `Derive (1/2) › name … Derive (1/2)` on one row.
  */
 export function ancestorWorkflowPhaseLabel(init: {
-  readonly categoryOf: (streamId: StreamTabId) => AgentCategory | undefined;
   readonly stageOf: (streamId: StreamTabId) => StreamStage | undefined;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly streamId: StreamTabId;
@@ -45,11 +25,8 @@ export function ancestorWorkflowPhaseLabel(init: {
   const seen = new Set<StreamTabId>();
   while (id && !seen.has(id)) {
     seen.add(id);
-    const label = currentWorkflowPhaseLabel(
-      init.stageOf(id),
-      init.categoryOf(id),
-    );
-    if (label) return label;
+    const stage = init.stageOf(id);
+    if (stage?.kind === 'phase') return formatPhaseStageLabel(stage);
     id = init.parentStream.get(id);
   }
   return undefined;

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -331,9 +331,7 @@ const activeChildProgress$ = new Signal.Computed(
       const childState = states.get(child.childStreamId);
       if (!childState) continue;
       progress.set(child.childStreamId, {
-        ...(childState.runStartedAt !== undefined
-          ? { runStartedAt: childState.runStartedAt }
-          : {}),
+        runStartedAt: childState.runStartedAt,
         toolCallCount: childState.conversationProgress.toolCallCount,
       });
     }

--- a/src/test-kernel/cli/WorkflowPopup.vitest.ts
+++ b/src/test-kernel/cli/WorkflowPopup.vitest.ts
@@ -76,7 +76,7 @@ async function renderPopup(
       onOpenTranscript: vi.fn(),
       onViewChange: vi.fn(),
       onWorkflowControl: vi.fn(),
-      pendingApprovals: undefined,
+      pendingApprovals: new Map(),
       streamId: ROOT,
       streams: new Map([[ROOT, slice]]),
       view: VIEW,


### PR DESCRIPTION
## What

Bundle 5 (S8–S12) of [the 2026-08-29 survey](docs/proposals/2026-08-29-simplification-survey-shared-workflow-model.md) — the CLI mechanical deletions on the popup path:

- **S8** `selectedChildRowWorkflowControllable` had one caller (the popup) and no tests since #11594 deleted the session-list home; inlined at that caller with its one load-bearing sentence (a native `agent()` grandchild, one identity hop, so the run stream itself never shows a control).
- **S9** `ancestorWorkflowPhaseLabel` tested `AgentCategory.Workflow` *and* `stage.kind === 'phase'`. A `phase` stage is written by the workflow-script run and nothing else, so the discriminant is the whole test — and the category guard could *hide* a correct label while the parent's category placeholder lagged. `currentWorkflowPhaseLabel` and the `categoryOf` parameter both callers paid for are gone.
- **S10** The two `ChildRunProgress` builders used conditional spreads for optional fields; no tsconfig sets `exactOptionalPropertyTypes` and every reader tests `!== undefined`, so plain literals.
- **S11** The popup's clock keys on the run's own `runStartedAt` alone: a card is live only while its workflow is, and the run's origin is set for every active phase (≤1 s staleness in the terminal→child-kill window).
- **S12** `pendingApprovals` required on the popup; its one production caller always passes a map.

No pixel or string changes.

## Net elements (R6)

`git diff --stat` against the base: production 7 files, **+38 / −84** (net −46); tests 1 file, +1 / −1. Exported symbols −1 (`selectedChildRowWorkflowControllable`); functions −1 (`currentWorkflowPhaseLabel`); −1 parameter (`categoryOf`) on a shared helper's call shape.

## Consumer counts (R8)

No emit path deleted. At the base (prod / test files): `selectedChildRowWorkflowControllable` 2 / 0 · `currentWorkflowPhaseLabel` 1 / 0 · `categoryOf` 3 / 0.

## Verified

- `npm run typecheck` — clean; eslint + prettier — clean on changed files
- vitest `src/test-kernel/{shared,cli,progressView}` — 236 files passing (one unrelated `TranscriptSessionPolicy` flake passed on re-run)
- `npm run check:dead-code-ratchet` — no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QESykrKh1yzvF2bB4pjDrS
