### PR TITLE
perf(cli): avoid redundant access status reads

### DIFF
--- a/packages/cli/src/chat/tui/forms/AccountAccessForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AccountAccessForm.tsx
@@ -121,7 +121,7 @@ function buildAccountAccessFormItems(
       description: DEVICE_CODE_DESCRIPTION,
     });
   }
-  if (status.texraSignedIn !== true) {
+  if (!status.texraSignedIn) {
     accountItems.push({
       value: { kind: 'login', target: 'texra' },
       label: RESEARCHER_ACCESS_AUTH.signInLabel,
@@ -136,7 +136,7 @@ function buildAccountAccessFormItems(
   const signedInCount = [
     status.chatGptSignedIn,
     status.grokSignedIn,
-    status.texraSignedIn === true,
+    status.texraSignedIn,
   ].filter(Boolean).length;
   if (signedInCount >= 2) {
     accountItems.push({

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -59,6 +59,7 @@ import { loadCliApiStatus } from '../runtime/apiStatus';
 import { notifyCliUpdate } from '../runtime/updateChecker';
 import { resolveChatDefaults } from '../runtime/chatDefaults';
 import {
+  mergeCliTexraAccountStatus,
   readCliModelAccessStatus,
   updateCliModelAccess,
 } from '../runtime/modelAccessSelection';
@@ -183,11 +184,10 @@ async function runOrchestration(context: CliContext): Promise<number> {
     // One shape for one fact: the launcher's "Account & access" row and its
     // step are built from the same record, so they cannot disagree about who
     // is signed in.
-    const launcherModelAccess = {
-      ...modelAccess,
-      texraSignedIn: authProfile.authenticated,
-      texraAccountLabel: authProfile.accountLabel,
-    };
+    const launcherModelAccess = mergeCliTexraAccountStatus(
+      modelAccess,
+      authProfile,
+    );
     const items = buildCliOrchestrationItems({
       presetPlans: presetPlanSet.plans,
       history,
@@ -200,7 +200,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
     // launches with the default model instead of blocking the launcher.
     const [models, statusLines] = await Promise.all([
       getCliModelAccessList().catch((): readonly CliModelAccess[] => []),
-      loadCliApiStatus(),
+      loadCliApiStatus(authProfile),
     ]);
     const allowDefaultModelLaunch = await canLaunchWithDefaultModel(
       context,

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -18,9 +18,13 @@ import {
   formatCliModelAccessRoute,
   formatCliModelAccessRouteInline,
   cliCodingPlanStatus,
+  type CliAccountStatus,
   type CliModelAccessStatus,
 } from './modelAccessRoute';
-import { readCliModelAccessStatus } from './modelAccessSelection';
+import {
+  mergeCliTexraAccountStatus,
+  readCliModelAccessStatus,
+} from './modelAccessSelection';
 import { getCliAuthProfile, type CliAuthProfile } from './supabaseAuth';
 
 interface SubscriptionUsageReader {
@@ -56,7 +60,7 @@ function formatAccountStatusLine(
 }
 
 export interface CliModelAccessOverview {
-  readonly access: CliModelAccessStatus;
+  readonly access: CliAccountStatus;
   readonly lines: readonly string[];
   /** Stale-metadata warning from the auth profile, when any. */
   readonly note?: string;
@@ -84,11 +88,7 @@ export async function loadCliModelAccessOverview(): Promise<CliModelAccessOvervi
   ];
   if (profile.note) lines.push(profile.note);
   return {
-    access: {
-      ...access,
-      texraSignedIn: profile.authenticated,
-      texraAccountLabel: profile.accountLabel,
-    },
+    access: mergeCliTexraAccountStatus(access, profile),
     lines,
     note: profile.note,
   };
@@ -111,11 +111,10 @@ async function personalKeyProviders(): Promise<string[]> {
 }
 
 /** Compact status lines used by the launcher. */
-export async function loadCliApiStatus(): Promise<readonly string[]> {
-  const [profile, configuredPersonalKeyProviders] = await Promise.all([
-    getCliAuthProfile(),
-    personalKeyProviders(),
-  ]);
+export async function loadCliApiStatus(
+  profile: Pick<CliAuthProfile, 'authenticated' | 'accountLabel' | 'note'>,
+): Promise<readonly string[]> {
+  const configuredPersonalKeyProviders = await personalKeyProviders();
   const authLine = formatCliAuthStatusLine(profile);
 
   const personalKeysLine = formatPersonalApiKeysLine(

--- a/packages/cli/src/runtime/modelAccessRoute.ts
+++ b/packages/cli/src/runtime/modelAccessRoute.ts
@@ -55,9 +55,11 @@ export interface CliModelAccessStatus {
   >;
   readonly texraSignedIn?: boolean;
   readonly texraAccountLabel?: string;
-  /** Display names of providers with configured API keys (e.g. `['DeepSeek']`). */
-  readonly personalKeyProviders?: readonly string[];
 }
+
+export type CliAccountStatus = CliModelAccessStatus & {
+  readonly texraSignedIn: boolean;
+};
 
 interface CliModelAccessItem {
   readonly value: CliModelAccessSelection;

--- a/packages/cli/src/runtime/modelAccessSelection.ts
+++ b/packages/cli/src/runtime/modelAccessSelection.ts
@@ -2,17 +2,13 @@ import {
   subscriptionProvider,
   type SubscriptionProviderId,
 } from '@controllers/modelAccess/subscriptionProviders';
-import {
-  configuredApiKeyProviders,
-  hasUsableApiKey,
-} from '@model/apiProviders';
+import { hasUsableApiKey } from '@model/apiProviders';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import {
   codingPlanSubscriptionRuntimes,
   type CodingPlanSubscriptionRuntime,
 } from '@model/codingPlanSubscriptions';
 import { platform } from '@platform/platform';
-import { providerDisplayName } from '@shared/constants/providers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
 import {
@@ -22,10 +18,12 @@ import {
 } from './subscriptionLogin';
 import {
   formatCliModelAccessRouteInline,
+  type CliAccountStatus,
   type CliModelAccessSelection,
   type CliModelAccessStatus,
 } from './modelAccessRoute';
 import type { CliContext } from './cliContext';
+import type { CliAuthProfile } from './supabaseAuth';
 
 interface CliModelAccessSelectionResult {
   readonly message: string;
@@ -33,27 +31,25 @@ interface CliModelAccessSelectionResult {
 
 export async function readCliModelAccessStatus(): Promise<CliModelAccessStatus> {
   const secrets = platform().secrets;
-  const [chatGpt, grok, configuredProviders, codingPlanEntries] =
-    await Promise.all([
-      subscriptionProvider('chatgpt').getStatus(),
-      subscriptionProvider('grok').getStatus(),
-      configuredApiKeyProviders(secrets),
-      Promise.all(
-        codingPlanSubscriptionRuntimes.map(
-          async (runtime) =>
-            [
-              runtime.descriptor.id,
-              {
-                preferred: runtime.getEnabled(),
-                keySet: await hasUsableApiKey(
-                  secrets,
-                  runtime.descriptor.apiProvider,
-                ),
-              },
-            ] as const,
-        ),
+  const [chatGpt, grok, codingPlanEntries] = await Promise.all([
+    subscriptionProvider('chatgpt').getStatus(),
+    subscriptionProvider('grok').getStatus(),
+    Promise.all(
+      codingPlanSubscriptionRuntimes.map(
+        async (runtime) =>
+          [
+            runtime.descriptor.id,
+            {
+              preferred: runtime.getEnabled(),
+              keySet: await hasUsableApiKey(
+                secrets,
+                runtime.descriptor.apiProvider,
+              ),
+            },
+          ] as const,
       ),
-    ]);
+    ),
+  ]);
   const codingPlans = Object.fromEntries(
     codingPlanEntries,
   ) as CliModelAccessStatus['codingPlans'];
@@ -63,9 +59,6 @@ export async function readCliModelAccessStatus(): Promise<CliModelAccessStatus> 
       : 'off',
     grok: subscriptionProvider('grok').isPreferSubscription() ? 'on' : 'off',
   } as const;
-  const personalKeyProviders = configuredProviders.map((provider) =>
-    providerDisplayName(provider),
-  );
   return {
     preferences,
     chatGptSignedIn: chatGpt.signedIn,
@@ -73,7 +66,17 @@ export async function readCliModelAccessStatus(): Promise<CliModelAccessStatus> 
     grokSignedIn: grok.signedIn,
     grokAccountLabel: grok.email,
     codingPlans,
-    personalKeyProviders,
+  };
+}
+
+export function mergeCliTexraAccountStatus(
+  access: CliModelAccessStatus,
+  profile: Pick<CliAuthProfile, 'authenticated' | 'accountLabel'>,
+): CliAccountStatus {
+  return {
+    ...access,
+    texraSignedIn: profile.authenticated,
+    texraAccountLabel: profile.accountLabel,
   };
 }
 

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -33,6 +33,7 @@ import {
   buildCliAccountAccessRows,
   buildCliModelAccessItems,
   formatCliAccountAccessSummary,
+  type CliAccountStatus,
   type CliModelAccessSelection,
   type CliModelAccessStatus,
 } from './modelAccessRoute';
@@ -95,16 +96,6 @@ export interface BuildCliOrchestrationItemsInput {
 
 type CliAccountProvider = 'chatgpt' | 'grok' | 'texra';
 type CliAccountOperation = 'sign-in' | 'sign-out';
-
-/**
- * The launcher's account view is the model-access status with the TeXRA
- * session merged in — `readCliModelAccessStatus` never sets `texraSignedIn`,
- * so requiring it here keeps the compile-time proof that the auth profile was
- * merged before the account rows are built.
- */
-export type CliAccountStatus = CliModelAccessStatus & {
-  readonly texraSignedIn: boolean;
-};
 
 export function isCliOrchestrationModelPickAction(
   action: CliOrchestrationAction,

--- a/src/test-kernel/cli/ApiStatusLoad.vitest.ts
+++ b/src/test-kernel/cli/ApiStatusLoad.vitest.ts
@@ -23,6 +23,14 @@ vi.mock('@cli/runtime/supabaseAuth', () => ({
 
 vi.mock('@cli/runtime/modelAccessSelection', () => ({
   readCliModelAccessStatus: mocks.readCliModelAccessStatus,
+  mergeCliTexraAccountStatus: (
+    access: Record<string, unknown>,
+    profile: { authenticated: boolean; accountLabel?: string },
+  ) => ({
+    ...access,
+    texraSignedIn: profile.authenticated,
+    texraAccountLabel: profile.accountLabel,
+  }),
 }));
 
 vi.mock('@model/apiProviders', () => ({
@@ -77,6 +85,16 @@ function codingPlans(
 
 function accountStatusLines(): Promise<string[]> {
   return loadCliDetailedAccountStatusLines();
+}
+
+function launcherStatus(
+  profile: {
+    authenticated: boolean;
+    accountLabel?: string;
+    note?: string;
+  } = { authenticated: false },
+): Promise<readonly string[]> {
+  return loadCliApiStatus(profile);
 }
 
 function renderPreferenceRoute(
@@ -152,21 +170,19 @@ describe('loadCliApiStatus', () => {
   ])(
     'preserves signed-out launcher details $name',
     async ({ profile, lines }) => {
-      mocks.getCliAuthProfile.mockResolvedValue(profile);
-
-      await expect(loadCliApiStatus()).resolves.toEqual(lines);
+      await expect(launcherStatus(profile)).resolves.toEqual(lines);
     },
   );
 
   it('groups personal keys with their route', async () => {
-    mocks.getCliAuthProfile.mockResolvedValue({
+    const profile = {
       authenticated: true,
       accountLabel: 'researcher@example.com',
       note: 'Account metadata may be stale.',
-    });
+    };
     setPersonalKeys('deepseek');
 
-    await expect(loadCliApiStatus()).resolves.toEqual([
+    await expect(launcherStatus(profile)).resolves.toEqual([
       'api: your own API keys',
       'your own API keys: DeepSeek',
       'auth: signed in as researcher@example.com',
@@ -179,12 +195,12 @@ describe('loadCliApiStatus', () => {
       new Error('preference store offline'),
     );
 
-    await expect(loadCliApiStatus()).resolves.toEqual([
+    await expect(launcherStatus()).resolves.toEqual([
       'api: your own API keys',
       'auth: signed out',
     ]);
     expect(mocks.readCliModelAccessStatus).not.toHaveBeenCalled();
-    expect(mocks.getCliAuthProfile).toHaveBeenCalledOnce();
+    expect(mocks.getCliAuthProfile).not.toHaveBeenCalled();
     expect(mocks.lookupApiKeyOrigin).toHaveBeenCalledTimes(3);
   });
 
@@ -516,7 +532,7 @@ describe('loadCliApiStatus', () => {
         Promise.resolve(originsByProvider[provider] ?? 'none'),
     );
 
-    await expect(loadCliApiStatus()).resolves.toEqual([
+    await expect(launcherStatus()).resolves.toEqual([
       'api: your own API keys',
       'your own API keys: DeepSeek, Kimi Code',
       'auth: signed out',

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.ts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.ts
@@ -143,7 +143,6 @@ function expectedAccessStatus(
     chatGptAccountLabel: undefined,
     grokSignedIn: false,
     grokAccountLabel: undefined,
-    personalKeyProviders: [],
     ...overrides,
     codingPlans: {
       glmCodingPlan: {
@@ -315,19 +314,6 @@ describe('CLI model access routes', () => {
     mocks.hasUsableApiKey.mockResolvedValue(false);
     await expect(readCliModelAccessStatus()).resolves.toMatchObject({
       codingPlans: { kimiCode: { preferred: true, keySet: false } },
-    });
-  });
-
-  it('reports configured provider keys as display names', async () => {
-    mocks.lookupApiKeyOrigin.mockImplementation(async (_secrets, provider) => {
-      if (provider === 'deepseek') return 'secret';
-      if (provider === 'moonshot') return 'env';
-      if (provider === 'kimiCode') return 'secret';
-      return 'none';
-    });
-
-    await expect(readCliModelAccessStatus()).resolves.toMatchObject({
-      personalKeyProviders: ['DeepSeek', 'Moonshot', 'Kimi Code'],
     });
   });
 

--- a/src/test-kernel/cli/Orchestration.vitest.ts
+++ b/src/test-kernel/cli/Orchestration.vitest.ts
@@ -14,11 +14,11 @@ import {
   buildCliTeamItems,
   orchestrationModelAccessView,
   type BuildCliOrchestrationItemsInput,
-  type CliAccountStatus,
   type CliOrchestrationItem,
 } from '@cli/runtime/orchestration';
 import {
   buildCliModelAccessItems,
+  type CliAccountStatus,
   type CliModelAccessStatus,
 } from '@cli/runtime/modelAccessRoute';
 

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -134,6 +134,7 @@ function mockModelAccessOverview(): void {
       },
       chatGptSignedIn: false,
       grokSignedIn: false,
+      texraSignedIn: false,
     },
     lines: ['model access: Your own API keys'],
   });


### PR DESCRIPTION
## Summary

- stop scanning API-key storage for a write-only model-access status field
- reuse the launcher auth profile instead of reading it again for compact status
- centralize the TeXRA account merge and make the merged status required at account surfaces

## Validation

- `vitest run src/test-kernel/cli/ModelAccessSelection.vitest.ts src/test-kernel/cli/ApiStatusLoad.vitest.ts --maxWorkers=1` (59 passed)
- workspace `tsc --noEmit --checkers 8`
- ESLint and Prettier on all touched files

Closes #11589