### PR TITLE
fix(cli): preserve warnings and incremental transcript cost

### DIFF
--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -506,6 +506,20 @@ function fitTransientNoticeStatusBarLeftSegments(
     fitNotice();
   }
 
+  const sacrificeBypassBadgesUntilFit = (): void => {
+    while (statusBarSegmentsWidth(fitted) > innerWidth) {
+      const badgeIndex = fitted.findLastIndex(isBypassBadge);
+      if (badgeIndex < 0) break;
+      fitted.splice(badgeIndex, 1);
+      fitNotice();
+    }
+  };
+
+  // Preserve the destructive-action warning before retaining auto-approval
+  // badges. Otherwise warning truncation can reduce it to empty text, making
+  // the row fit while hiding that queued input will be discarded.
+  if (discardWarning) sacrificeBypassBadgesUntilFit();
+
   // Extremely narrow terminals may not fit even the full discard warning.
   // Drop the lower-priority confirmation text and truncate the warning so the
   // status row never exceeds its layout budget.
@@ -525,12 +539,7 @@ function fitTransientNoticeStatusBarLeftSegments(
   // would soft-wrap the row, breaking the 2-row chrome budget. Sacrifice
   // badges from the tail — mirroring how liveness is sacrificed above — only
   // while the row still overflows.
-  while (statusBarSegmentsWidth(fitted) > innerWidth) {
-    const badgeIndex = fitted.findLastIndex(isBypassBadge);
-    if (badgeIndex < 0) break;
-    fitted.splice(badgeIndex, 1);
-    fitNotice();
-  }
+  sacrificeBypassBadgesUntilFit();
 
   return fitted;
 }

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -447,7 +447,7 @@ export function incrementalStaticTranscriptEntries(
       scannedIndex = start + index + 1;
       continue;
     }
-    if (userPromptAwaitsLiveContinuation(source, start + index, status)) {
+    if (userPromptAwaitsLiveContinuation(suffix, index, status)) {
       break;
     }
     scannedIndex = start + index + 1;

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -1637,6 +1637,43 @@ describe('CLI conversation transcript', () => {
     expect(third.cursor.scannedIndex).toBe(2);
   });
 
+  it('checks live-prompt continuation only in the incremental suffix', () => {
+    const prefix = Array.from({ length: 100 }, (_, index) =>
+      entry(`a${index}`, 'assistant', `settled ${index}`, true),
+    );
+    const user = entry('u-new', 'user', 'continue', true);
+    const assistant = entry('a-new', 'assistant', 'done', true);
+    const inspectedPrefixIndexes: number[] = [];
+    const source = new Proxy([...prefix, user, assistant], {
+      get(target, property, receiver) {
+        if (typeof property === 'string' && /^\d+$/.test(property)) {
+          const index = Number.parseInt(property, 10);
+          if (index < prefix.length) inspectedPrefixIndexes.push(index);
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const previous = {
+      entriesRef: prefix,
+      scannedIndex: prefix.length,
+      lastScannedEntry: prefix.at(-1),
+      status: STREAM_PHASE.RUNNING,
+      lastAppendedKey: [prefix.length, 0] as const,
+    };
+
+    const result = incrementalStaticTranscriptEntries(
+      source,
+      0,
+      STREAM_PHASE.RUNNING,
+      previous,
+    );
+
+    expect(result.rebuild).toBe(false);
+    expect(result.appended.map((item) => item.id)).toEqual(['u-new', 'a-new']);
+    expect(result.cursor.scannedIndex).toBe(source.length);
+    expect(inspectedPrefixIndexes).toEqual([prefix.length - 1]);
+  });
+
   it('appends an incremental suffix in the same settlement order a repaint uses', () => {
     // Wire order is [t1, a1] but a1 settled first. The live path prints the
     // suffix once; a repaint rebuilds from `orderedStaticTranscriptEntries`,

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -1571,6 +1571,7 @@ describe('CLI StatusBar display model', () => {
     {
       name: 'keeps queued-input discard warnings ahead of status details',
       width: 80,
+      bypass: NO_BYPASS,
       expected: [
         '◆',
         'run 45s',
@@ -1581,12 +1582,20 @@ describe('CLI StatusBar display model', () => {
     {
       name: 'bounds queued-input discard warnings in very narrow footers',
       width: 30,
+      bypass: NO_BYPASS,
       expected: ['◆', '1 queued follow-up will b…'],
     },
-  ])('$name', ({ width, expected }) => {
+    {
+      name: 'drops bypass badges before truncating queued-input discard warnings',
+      width: 30,
+      bypass: { bash: true, superYolo: true, toolEdit: true },
+      expected: ['◆', '1 queued follow-up will b…'],
+    },
+  ])('$name', ({ width, bypass, expected }) => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
+        bypass,
         runningFrame: '/',
         elapsedMs: 45_000,
         transientNotice: {


### PR DESCRIPTION
## Summary

- sacrifice auto-approval badges before truncating the armed-exit queued-input warning
- keep incremental live-prompt continuation checks inside the unscanned transcript suffix
- cover the narrow status bar and long-history cursor regressions in the existing suites

## Validation

- focused StatusBar and ConversationTranscript suites: 175 passed
- targeted ESLint: passed
- targeted Prettier check: passed
- CLI TypeScript checks: passed
- test-kernel TypeScript check: passed

Closes #11577
Closes #11578