### PR TITLE
fix(cli): complete workflow popup follow-ups

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -203,15 +203,15 @@ const SCENARIOS = [
       HARNESS_WORKFLOW_RUNNING: '1',
     },
     // Tab to the session list, down to the workflow row, Enter opens the
-    // popup over main instead of focusing the workflow stream.
+    // popup over main. The direct child's queued approval must then surface
+    // over that foreground reader instead of waiting invisibly.
     bootExpect: 'Tab sessions',
     keys: ['\t', DOWN, '\r'],
     expect: [
-      'live-workflow-validation · 0/2 · 2 running',
-      '◆ Proofread (1/1) · 0/2 · 2 running',
-      'Proofread paper A · Running · bash',
-      'Proofread paper B · Running',
-      'Esc close',
+      'Run command?',
+      '$ npm run compile:safe',
+      'y approve',
+      'Keys go to the panel above',
     ],
     unexpect: ['Proofread paper B · Running · bash', 'Esc parent'],
   },

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -56,6 +56,7 @@ import { InputBar, type InputBarHandle } from './panes/InputBar';
 import { ConversationRegion } from './panes/ConversationRegion';
 import { StatusBar } from './panes/StatusBar';
 import {
+  approvalPayloadStreamId,
   currentApproval,
   pendingApprovalSummaries,
   promoteApprovalsForStream,
@@ -212,8 +213,20 @@ export function App(props: AppProps): React.JSX.Element {
     isWorkflowScriptStream(foregroundReader.streamId)
       ? foregroundReader.streamId
       : undefined;
+  const pendingApprovalStreamId = pending
+    ? approvalPayloadStreamId(pending.payload)
+    : undefined;
+  const foregroundApprovalStreamId =
+    foregroundWorkflowStreamId !== undefined &&
+    pendingApprovalStreamId !== undefined &&
+    (parentStream.get(pendingApprovalStreamId) === foregroundWorkflowStreamId ||
+      childRosters
+        .get(foregroundWorkflowStreamId)
+        ?.some((child) => child.childStreamId === pendingApprovalStreamId))
+      ? pendingApprovalStreamId
+      : foregroundWorkflowStreamId;
   const activeApprovalVisible = approvalVisibleForActiveStream({
-    activeStreamId: foregroundWorkflowStreamId ?? activeStreamId,
+    activeStreamId: foregroundApprovalStreamId ?? activeStreamId,
     pending,
   });
   // Walks the child-stream tree, so keep it at data-change frequency rather

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -66,6 +66,7 @@ import {
   createActiveDraftRegistry,
 } from './input/activeDraft';
 import {
+  directChildStreamIds,
   isWorkflowScriptStream,
   numericFocusTargetForActiveStream,
   presentStream,
@@ -131,7 +132,13 @@ function focusStreamAndPromoteApprovals(streamId: StreamTabId): void {
   // lives in `presentStream`); the popup's own stream owns the approvals
   // that surface.
   if (presentStream(streamId) === 'workflowPopup') {
-    promoteApprovalsForStream(streamId, { includeSessionWide: false });
+    promoteApprovalsForStream(streamId, {
+      includeStreamIds: directChildStreamIds({
+        parentStreamId: streamId,
+        childRosters: childRostersSignal.get(),
+        parentStream: parentStreamSignal.get(),
+      }),
+    });
     return;
   }
   const visibleListRootStreamId = resolveChildListTarget({
@@ -213,16 +220,20 @@ export function App(props: AppProps): React.JSX.Element {
     isWorkflowScriptStream(foregroundReader.streamId)
       ? foregroundReader.streamId
       : undefined;
+  const foregroundWorkflowChildStreamIds =
+    foregroundWorkflowStreamId === undefined
+      ? undefined
+      : directChildStreamIds({
+          parentStreamId: foregroundWorkflowStreamId,
+          childRosters,
+          parentStream,
+        });
   const pendingApprovalStreamId = pending
     ? approvalPayloadStreamId(pending.payload)
     : undefined;
   const foregroundApprovalStreamId =
-    foregroundWorkflowStreamId !== undefined &&
     pendingApprovalStreamId !== undefined &&
-    (parentStream.get(pendingApprovalStreamId) === foregroundWorkflowStreamId ||
-      childRosters
-        .get(foregroundWorkflowStreamId)
-        ?.some((child) => child.childStreamId === pendingApprovalStreamId))
+    foregroundWorkflowChildStreamIds?.has(pendingApprovalStreamId) === true
       ? pendingApprovalStreamId
       : foregroundWorkflowStreamId;
   const activeApprovalVisible = approvalVisibleForActiveStream({

--- a/packages/cli/src/chat/tui/panes/WorkflowPopup.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkflowPopup.tsx
@@ -457,17 +457,28 @@ export function WorkflowPopup({
       return;
     }
     if (input === 'f') {
-      const current =
-        selectedKey === undefined
-          ? -1
-          : rows.findIndex((row) => row.key === selectedKey);
-      const failed = rows
-        .map((row, index) => ({ row, index }))
+      const allRows = phases.flatMap((candidate, candidatePhaseIndex) =>
+        workflowPhaseRows(candidate, {
+          expanded: view.expanded,
+          filter: view.filter,
+        }).map((row) => ({ phaseIndex: candidatePhaseIndex, row })),
+      );
+      const current = allRows.findIndex(
+        (item) =>
+          item.phaseIndex === phaseIndex && item.row.key === selectedKey,
+      );
+      const failed = allRows
+        .map((item, index) => ({ ...item, index }))
         .filter(
           ({ row }) => row.kind === 'task' && row.row.call.status === 'failed',
         );
       const next = failed.find(({ index }) => index > current) ?? failed[0];
-      if (next) onViewChange({ selectedKey: next.row.key });
+      if (next) {
+        onViewChange({
+          phaseIndex: next.phaseIndex,
+          selectedKey: next.row.key,
+        });
+      }
       return;
     }
     if (

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -344,10 +344,15 @@ export function approvalPayloadStreamId(
  * focusing a session surfaces that session's approval immediately.
  * `includeSessionWide` also promotes stream-less (session-wide) items — pass
  * it when promoting the root stream, whose row those items fold onto.
+ * `includeStreamIds` lets a composite surface promote requests owned by the
+ * streams it presents, such as a workflow popup's direct children.
  */
 export function promoteApprovalsForStream(
   streamId: StreamTabId,
-  options: { readonly includeSessionWide?: boolean } = {},
+  options: {
+    readonly includeSessionWide?: boolean;
+    readonly includeStreamIds?: ReadonlySet<StreamTabId>;
+  } = {},
 ): void {
   const items = QUEUE.get();
   if (items.length < 2) return;
@@ -355,6 +360,8 @@ export function promoteApprovalsForStream(
     const itemStreamId = approvalPayloadStreamId(item.payload);
     return (
       itemStreamId === streamId ||
+      (itemStreamId !== undefined &&
+        options.includeStreamIds?.has(itemStreamId) === true) ||
       (options.includeSessionWide === true && itemStreamId === undefined)
     );
   };

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -45,6 +45,25 @@ function hasChildListItems(
   return visibleSubagentRows(parentStreamId, childRosters).length > 0;
 }
 
+/** Direct children known through either side of the roster-first edge race. */
+export function directChildStreamIds({
+  parentStreamId,
+  childRosters,
+  parentStream,
+}: {
+  readonly parentStreamId: StreamTabId;
+  readonly childRosters: ChildRosters;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+}): ReadonlySet<StreamTabId> {
+  const streamIds = new Set(
+    childRosters.get(parentStreamId)?.map((child) => child.childStreamId) ?? [],
+  );
+  for (const [streamId, parentId] of parentStream) {
+    if (parentId === parentStreamId) streamIds.add(streamId);
+  }
+  return streamIds;
+}
+
 /** Resolve the nearest stream whose child sessions populate the persistent
  * child list. */
 export function resolveChildListTarget({

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -82,7 +82,9 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 
 import { notify } from '../notifications/terminalNotifier';
-import { patchStream } from './cliState';
+import { foregroundReader, patchStream } from './cliState';
+import { directChildStreamIds, isWorkflowScriptStream } from './childControls';
+import { childRosters, parentStream } from './childExecutions';
 import {
   refreshSubscriptionPreferenceViews,
   setCliCodingPlanSubscription,
@@ -527,7 +529,17 @@ export function enqueueTuiApproval(
 /** Focus the asking stream and ring the terminal when a modal appears. */
 function announceApproval(payload: ApprovalPayload): void {
   const streamId = approvalPayloadStreamId(payload);
-  if (streamId) {
+  const reader = foregroundReader.get();
+  const workflowOwnsApproval =
+    streamId !== undefined &&
+    reader !== undefined &&
+    isWorkflowScriptStream(reader.streamId) &&
+    directChildStreamIds({
+      parentStreamId: reader.streamId,
+      childRosters: childRosters.get(),
+      parentStream: parentStream.get(),
+    }).has(streamId);
+  if (streamId && !workflowOwnsApproval) {
     defaultSession().events.emit({
       scope: 'session',
       event: {

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -28,11 +28,13 @@ import {
   isTranscriptSettlementPhase,
 } from '@shared/streams/streamStatus';
 import { StreamLogDeltaBuffer, type StreamLogStore } from '@transcript';
+import type { TranscriptPresentationLease } from '@transcript/StreamLogStore';
 import { createFlushableDebounce } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
   activeStreamId,
   focusStream,
+  foregroundReader,
   getCliStateGeneration,
   isCliStreamRetired,
   patchStream,
@@ -41,6 +43,7 @@ import {
   streamPhaseFor,
   streams,
 } from './cliState';
+import { isWorkflowScriptStream } from './childControls';
 import { isChildStreamRemoved, streamMetadataFor } from './childExecutions';
 import {
   advanceSettledPrefixIndex,
@@ -60,6 +63,18 @@ import {
 // can land before the first sync fires); one animation frame is enough
 // to batch chunks and keeps the transcript feeling live.
 const STREAM_SYNC_THROTTLE_MS = 16;
+
+/** A workflow popup and its Ctrl-T reader are two views of the same full
+ * transcript projection. Workflows never become the active viewport, so the
+ * foreground reader is their presentation-residency owner. */
+function foregroundWorkflowReaderStreamId(): StreamTabId | undefined {
+  const reader = foregroundReader.get();
+  if (!reader) return undefined;
+  if (reader.kind === 'workflow') return reader.streamId;
+  return reader.kind === 'transcript' && isWorkflowScriptStream(reader.streamId)
+    ? reader.streamId
+    : undefined;
+}
 
 interface StreamLogSession {
   readonly transcripts: StreamLogStore;
@@ -114,6 +129,9 @@ function trySyncStreamLog(
 export function subscribeStreamLog(session: StreamLogSession): () => void {
   const store = session.transcripts;
   let previousActiveStreamId = activeStreamId.get();
+  let workflowReaderStreamId: StreamTabId | undefined;
+  let workflowReaderLease: TranscriptPresentationLease | undefined;
+  let workflowReaderRevision = 0;
 
   // One trailing timer shared by every stream: during a multi-subagent burst
   // the root and each child emit within the same window, and per-stream
@@ -173,9 +191,59 @@ export function subscribeStreamLog(session: StreamLogSession): () => void {
       });
   });
 
+  const syncWorkflowReader = (): void => {
+    const nextStreamId = foregroundWorkflowReaderStreamId();
+    if (nextStreamId === workflowReaderStreamId) return;
+
+    const previousStreamId = workflowReaderStreamId;
+    workflowReaderStreamId = nextStreamId;
+    const revision = ++workflowReaderRevision;
+
+    if (previousStreamId !== undefined) {
+      // The signal already names the next surface, so this projects the old
+      // workflow back to its bounded background dashboard before releasing it.
+      trySyncStreamLog(session, previousStreamId);
+      workflowReaderLease?.close();
+      workflowReaderLease = undefined;
+      releaseInactiveStreamTranscript(store, previousStreamId);
+    }
+    if (nextStreamId === undefined) return;
+
+    void store
+      .ensureLoaded(nextStreamId, { retainForPresentation: true })
+      .then((lease) => {
+        if (
+          revision !== workflowReaderRevision ||
+          foregroundWorkflowReaderStreamId() !== nextStreamId
+        ) {
+          lease.close();
+          return;
+        }
+        workflowReaderLease = lease;
+        trySyncStreamLog(session, nextStreamId);
+      })
+      .catch((error: unknown) => {
+        if (foregroundWorkflowReaderStreamId() === nextStreamId) {
+          setTransientNotice(
+            `Could not load transcript: ${toErrorMessage(error)}`,
+            { ttlMs: Number.POSITIVE_INFINITY },
+          );
+        }
+      });
+  };
+  const disposeWorkflowReader = subscribeToSignalChanges(
+    [foregroundReader],
+    syncWorkflowReader,
+  );
+  syncWorkflowReader();
+
   return () => {
     dispose();
     disposeFocus();
+    disposeWorkflowReader();
+    workflowReaderRevision += 1;
+    workflowReaderLease?.close();
+    workflowReaderLease = undefined;
     // Cancel, not flush: the caller is tearing down (process exit or
     // unmount), so a final render of whatever was still pending isn't
     // needed and would race an already-torn-down UI.
@@ -234,7 +302,9 @@ export function syncStreamLog(
   }
   const currentActiveStreamId = activeStreamId.get();
   const projectFullTranscript =
-    currentActiveStreamId === undefined || currentActiveStreamId === streamId;
+    currentActiveStreamId === undefined ||
+    currentActiveStreamId === streamId ||
+    foregroundWorkflowReaderStreamId() === streamId;
 
   const metadata = streamMetadataFor(streamId);
   const streamSettled = isTranscriptSettlementPhase(
@@ -460,7 +530,8 @@ export function releaseInactiveStreamTranscript(
   const currentActiveStreamId = activeStreamId.get();
   if (
     currentActiveStreamId === undefined ||
-    currentActiveStreamId === streamId
+    currentActiveStreamId === streamId ||
+    foregroundWorkflowReaderStreamId() === streamId
   ) {
     return;
   }

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -508,10 +508,11 @@ export function syncStreamLog(
 
 /**
  * Release a background stream's transcript residency at a lifecycle
- * boundary. Two owners call this — the status subscriber when a stream
- * leaves its active phase, and the focus subscriber when focus moves off a
- * stream — never the render/sync path, so a terminal stream always
- * releases rather than only when a sync happens to run for it. A no-op for
+ * boundary. Three owners call this — the status subscriber when a stream
+ * leaves its active phase, the focus subscriber when focus moves off a
+ * stream, and the foreground workflow reader when it closes or changes —
+ * never the render/sync path, so a terminal stream always releases rather
+ * than only when a sync happens to run for it. A no-op for
  * the active stream, for a stream whose status is unknown or active, and
  * while no stream is focused (every stream then projects the full
  * transcript, exactly the states the old in-sync release also skipped).

--- a/src/test-kernel/architecture/transcriptResidencyLeaseSites.vitest.ts
+++ b/src/test-kernel/architecture/transcriptResidencyLeaseSites.vitest.ts
@@ -23,8 +23,9 @@ const HYDRATION_SITE_ALLOWLIST = new Set([
   'src/transcript/StreamLogStore.ts',
 ]);
 
-/** The progress coordinator is the sole production presentation lease owner. */
+/** Runtime sites allowed to retain transcripts for a visible reader. */
 const PRESENTATION_LEASE_SITE_ALLOWLIST = new Set([
+  'packages/cli/src/chat/tui/state/subscribeStreamLog.ts',
   'src/controllers/progressView/backend/ProgressBackend.ts',
   'src/transcript/StreamLogStore.ts',
 ]);

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -357,6 +357,22 @@ describe('App foreground Escape ownership', () => {
       await waitFor(() => currentApproval.get() === undefined);
       expect(foregroundReader.get()?.kind).toBe('workflow');
 
+      // A request from one of the workflow's own agent calls takes the same
+      // foreground modal; it must not wait invisibly behind the popup.
+      void enqueueApproval({
+        kind: 'planApproval',
+        data: {
+          requestId: 'plan-workflow-child',
+          streamId: CHILD,
+          plan: { objective: 'Verify the child result.' },
+          goalEnabled: false,
+        },
+      });
+      await waitFor(() => stdout.output.includes('Verify the child result.'));
+      clearApprovals();
+      await waitFor(() => currentApproval.get() === undefined);
+      expect(foregroundReader.get()?.kind).toBe('workflow');
+
       // Enter on the task focuses that agent; Esc returns to main with the
       // popup back where it was.
       stdin.write('\r');

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -17,10 +17,12 @@ import { POINTER } from '@cli/tui/ui/glyphs';
 import type { InputHistory } from '@cli/chat/tui/history/inputHistory';
 import {
   activeStreamId,
+  closeForegroundReader,
   focusStream,
   foregroundReader,
   infoPane,
   openInfoPane,
+  openWorkflowPopup,
   patchStream,
   resetCliState,
   rootRunPending,
@@ -34,6 +36,7 @@ import {
   invalidateChildStreams,
   unbindChildStreamState,
 } from '@cli/chat/tui/state/childExecutions';
+import { enqueueTuiApproval } from '@cli/chat/tui/state/subscribeApprovals';
 import { syncStreamLog } from '@cli/chat/tui/state/subscribeStreamLog';
 import { SessionState } from '@controllers/session/SessionState';
 import {
@@ -325,16 +328,44 @@ describe('App foreground Escape ownership', () => {
     ]);
     seedParentEdge(CHILD, WORKFLOW);
     markToolUseAgent(CHILD);
+    void enqueueApproval({
+      kind: 'planApproval',
+      data: {
+        requestId: 'plan-unrelated',
+        streamId: GRANDCHILD,
+        plan: { objective: 'Keep this unrelated request queued.' },
+        goalEnabled: false,
+      },
+    });
+    void enqueueApproval({
+      kind: 'planApproval',
+      data: {
+        requestId: 'plan-queued-workflow-child',
+        streamId: CHILD,
+        plan: { objective: 'Promote the queued workflow child.' },
+        goalEnabled: false,
+      },
+    });
     const { instance, stdin, stdout, onInterruptStream } =
       await renderWithInterrupt();
+    const emit = vi.spyOn(defaultSession().events, 'emit');
 
     try {
       stdin.write('\t');
       await waitFor(() => stdout.output.includes('workflow running'));
       stdin.write(ARROW_KEYS.Down);
       stdin.write('\r');
-      // The workflow row opens the popup over main; main stays the viewport.
+      // The workflow row opens the popup over main, promotes direct-child
+      // approvals, and keeps main as the underlying viewport.
       await waitFor(() => foregroundReader.get()?.kind === 'workflow');
+      await waitFor(() =>
+        stdout.output.includes('Promote the queued workflow child.'),
+      );
+      expect(stdout.output).not.toContain(
+        'Keep this unrelated request queued.',
+      );
+      clearApprovals();
+      await waitFor(() => currentApproval.get() === undefined);
       await waitFor(() => stdout.output.includes('Inspect · Running'));
       expect(activeStreamId.get()).toBe(ROOT);
       // View state the user set inside the popup survives the round trips
@@ -357,9 +388,9 @@ describe('App foreground Escape ownership', () => {
       await waitFor(() => currentApproval.get() === undefined);
       expect(foregroundReader.get()?.kind).toBe('workflow');
 
-      // A request from one of the workflow's own agent calls takes the same
-      // foreground modal; it must not wait invisibly behind the popup.
-      void enqueueApproval({
+      // A real announcement from one of the workflow's own agent calls takes
+      // the same foreground modal without moving the viewport underneath it.
+      void enqueueTuiApproval({
         kind: 'planApproval',
         data: {
           requestId: 'plan-workflow-child',
@@ -369,9 +400,14 @@ describe('App foreground Escape ownership', () => {
         },
       });
       await waitFor(() => stdout.output.includes('Verify the child result.'));
+      expect(activeStreamId.get()).toBe(ROOT);
+      expect(emit).not.toHaveBeenCalled();
       clearApprovals();
       await waitFor(() => currentApproval.get() === undefined);
       expect(foregroundReader.get()?.kind).toBe('workflow');
+      closeForegroundReader();
+      expect(activeStreamId.get()).toBe(ROOT);
+      openWorkflowPopup(WORKFLOW);
 
       // Enter on the task focuses that agent; Esc returns to main with the
       // popup back where it was.
@@ -386,6 +422,7 @@ describe('App foreground Escape ownership', () => {
       expect(workflowPopupView.get().expanded.has('queued')).toBe(true);
       expect(onInterruptStream).not.toHaveBeenCalled();
     } finally {
+      emit.mockRestore();
       instance.unmount();
     }
   });

--- a/src/test-kernel/cli/WorkflowPopup.vitest.ts
+++ b/src/test-kernel/cli/WorkflowPopup.vitest.ts
@@ -32,17 +32,18 @@ const VIEW: WorkflowPopupView = {
 function taskRow(
   id: string,
   status: WorkflowCallProgress['status'],
+  phase = 'Derive',
 ): WorkflowTaskRow {
   const call =
     status === 'failed'
-      ? { id, label: id, phase: 'Derive', status, error: 'boom' }
-      : ({ id, label: id, phase: 'Derive', status } as WorkflowCallProgress);
+      ? { id, label: id, phase, status, error: 'boom' }
+      : ({ id, label: id, phase, status } as WorkflowCallProgress);
   return {
     kind: 'workflowTask',
     id: `task-${id}`,
     timestamp: 0,
     level: 'info',
-    groupId: 'phase-Derive',
+    groupId: `phase-${phase}`,
     call,
     line: `${status}: ${id}`,
     statusLabel: status === 'failed' ? 'Failed' : 'Running',
@@ -64,7 +65,8 @@ async function renderPopup(
     childProgress: new Map(),
   });
   const { ink, React } = await loadInk();
-  return renderInteractive(
+  const onViewChange = vi.fn();
+  const rendered = renderInteractive(
     ink,
     React.createElement(WorkflowPopup, {
       activeSubagentExecutionIds: new Map(),
@@ -74,7 +76,7 @@ async function renderPopup(
       onFocusStream: vi.fn(),
       onKillExecution: vi.fn(),
       onOpenTranscript: vi.fn(),
-      onViewChange: vi.fn(),
+      onViewChange,
       onWorkflowControl: vi.fn(),
       pendingApprovals: new Map(),
       streamId: ROOT,
@@ -83,6 +85,7 @@ async function renderPopup(
     }),
     { columns: 100 },
   );
+  return { ...rendered, onViewChange };
 }
 
 describe('workflow popup', () => {
@@ -143,6 +146,44 @@ describe('workflow popup', () => {
       expect(firstRunning).toBeGreaterThan(failedLine);
       // 13 attention rows cannot all fit; the list says how many are below.
       expect(stdout.output).toMatch(/… \d+ more/);
+    } finally {
+      instance.unmount();
+    }
+  });
+
+  it('moves next-failed selection across phase tabs', async () => {
+    const { instance, stdin, onViewChange, stdout } = await renderPopup(
+      [
+        {
+          id: 'phase-Derive',
+          name: 'Derive',
+          startTime: 0,
+          status: 'completed',
+          kind: 'phase',
+          index: 0,
+          total: 2,
+        },
+        {
+          id: 'phase-Check',
+          name: 'Check',
+          startTime: 1,
+          status: 'running',
+          kind: 'phase',
+          index: 1,
+          total: 2,
+        },
+      ],
+      [taskRow('done', 'completed'), taskRow('bad', 'failed', 'Check')],
+      20,
+    );
+    try {
+      await waitFor(() => stdout.output.includes('done'));
+      stdin.write('f');
+      await waitFor(() => onViewChange.mock.calls.length > 0);
+      expect(onViewChange).toHaveBeenLastCalledWith({
+        phaseIndex: 1,
+        selectedKey: 'task:task-bad',
+      });
     } finally {
       instance.unmount();
     }

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
@@ -24,6 +24,10 @@ import {
   transcriptRowHeadline,
 } from '@cli/chat/tui/panes/transcriptEntries';
 import {
+  activeStreamId,
+  closeForegroundReader,
+  openTranscriptReader,
+  openWorkflowPopup,
   patchStream,
   resetCliState,
   streams,
@@ -33,7 +37,10 @@ import {
   invalidateChildStreams,
   unbindChildStreamState,
 } from '@cli/chat/tui/state/childExecutions';
-import { syncStreamLog } from '@cli/chat/tui/state/subscribeStreamLog';
+import {
+  subscribeStreamLog,
+  syncStreamLog,
+} from '@cli/chat/tui/state/subscribeStreamLog';
 import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import { SessionState } from '@controllers/session/SessionState';
 import {
@@ -48,6 +55,7 @@ import {
 import { transcriptText, type TranscriptRow } from '@shared/transcript';
 import { STREAM_TRANSITION_CAUSE } from '@shared/streams/streamStatus';
 import { setCliStreamPhase } from '@test/support/cliStreamStatus';
+import { waitForCondition as waitFor } from '@test/support/asyncTestUtils';
 import { clearAllStreamStatusesForTest } from '@test/support/streamStatusTestUtils';
 import { loadInk } from '@test/support/inkTestHarness.ts';
 import { splitTranscriptEntries } from '@test/support/transcriptRowFixtures';
@@ -216,6 +224,48 @@ afterEach(() => {
 });
 
 describe('CLI workflow-script child-stream transcript', () => {
+  it('loads a complete workflow projection for its popup and Ctrl-T log', async () => {
+    const runTrace = openRunTrace(STREAM_ID);
+    for (let index = 0; index < 2_001; index++) {
+      runTrace.trace.emit({
+        type: 'workflow.call',
+        logId: `task-${index}`,
+        call: {
+          id: `call-${index}`,
+          label: `Call ${index}`,
+          status: 'planned',
+        },
+      });
+    }
+    runTrace.trace.info('Full workflow log detail', {
+      messageType: MESSAGE_TYPES.DEFAULT,
+    });
+    patchStream(PARENT_STREAM_ID, (slice) => ({ ...slice }));
+    activeStreamId.set(PARENT_STREAM_ID);
+
+    syncStreamLog(defaultSession(), STREAM_ID);
+    expect(streamEntries()).toHaveLength(2_000);
+    expect(streamEntries().some((row) => row.id === 'task-0')).toBe(false);
+
+    const dispose = subscribeStreamLog(defaultSession());
+    try {
+      openWorkflowPopup(STREAM_ID);
+      await waitFor(() => streamEntries().length === 2_002);
+      expect(streamEntries().some((row) => row.id === 'task-0')).toBe(true);
+      expect(streamEntries().map(transcriptRowHeadline)).toContain(
+        'Full workflow log detail',
+      );
+
+      openTranscriptReader(STREAM_ID);
+      await waitFor(() => streamEntries().length === 2_002);
+
+      closeForegroundReader();
+      await waitFor(() => streamEntries().length === 2_000);
+    } finally {
+      dispose();
+    }
+  });
+
   it('keeps lifecycle headings for full-log SDK children', () => {
     const sdkStreamId = 'claude@agent-sdk#exec-1' as StreamTabId;
     // External-CLI agent sessions are full-log children too.

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
@@ -247,6 +247,24 @@ describe('CLI workflow-script child-stream transcript', () => {
     expect(streamEntries()).toHaveLength(2_000);
     expect(streamEntries().some((row) => row.id === 'task-0')).toBe(false);
 
+    // Exercise the roster-first interval: the parent already classifies this
+    // child as a workflow, but the child's own run metadata has not landed.
+    seedStreamMeta(STREAM_ID, { agentCategory: AgentCategory.Workflow });
+    boundState.getOrCreateStreamState(PARENT_STREAM_ID, AgentCategory.ToolUse);
+    boundState.updateStreamState(PARENT_STREAM_ID, (state) => ({
+      ...state,
+      subagents: [
+        {
+          executionId: 'workflow-exec-1',
+          agentName: 'draft-sections',
+          identity: WORKFLOW_IDENTITY,
+          childStreamId: STREAM_ID,
+          status: STREAM_PHASE.RUNNING,
+        },
+      ],
+    }));
+    invalidateChildStreams();
+
     const dispose = subscribeStreamLog(defaultSession());
     try {
       openWorkflowPopup(STREAM_ID);


### PR DESCRIPTION
## Summary

Complete the adjacent workflow-popup follow-ups with one CLI-owned presentation path:

- show approval modals requested by direct workflow child agents while the popup or its log is open
- hydrate and retain the full workflow projection for both the popup and Ctrl-T transcript, including rows beyond the compact 2,000-entry background cap
- make `f` advance to failed calls across phase tabs

## Issue acceptance gates

- Closes #11596: a direct workflow child's approval is visible over the workflow foreground reader.
- Closes #11597: opening the workflow popup hydrates a presentation-retained full projection that its Ctrl-T reader shares.
- Closes #11598: the visible popup model reads the complete foreground projection instead of the capped background slice.
- Closes #11599: next-failed traverses all phase rows, switches tabs, and wraps in workflow order.

## Single source of truth

`subscribeStreamLog` owns workflow foreground-reader hydration, transcript residency, and full-versus-compact projection. The existing roster-aware workflow classifier is shared by popup and transcript readers. `workflowRunModel` remains the sole popup grouping and tally model.

## Duplication and abstraction budget

No new exported abstraction or parallel state was added. The existing foreground-reader signal and transcript presentation lease now cover the workflow popup and its transcript as one surface.

## Net elements (R6)

- Files: 8 modified, 0 added, 0 deleted
- Exported symbols: 0 added, 0 removed
- Net LoC: +203

## Consumer counts (R8)

n/a — no export, event, or dispatch route was removed or rerouted.

## Host impact

Extension: None.

Desktop: None.

CLI: Workflow popup approval visibility, transcript completeness, large-run counts, and failed-call navigation are corrected.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck:cli`
- `npm run typecheck:test-kernel`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- workflow-running`
- `corepack pnpm exec eslint` on changed TypeScript files
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/AppEscapeRouting.vitest.ts src/test-kernel/cli/WorkflowPopup.vitest.ts src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts src/test-kernel/architecture/transcriptResidencyLeaseSites.vitest.ts` (56 tests)
- Prettier on all changed files
- `git diff --check origin/main...HEAD`