### PR TITLE
fix(hosts): preserve launch and walkthrough actions

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1245,11 +1245,14 @@ export class DesktopProgressBridge {
     );
     if (launch.status === 'cancelled') return;
     if (launch.status === 'error') {
-      await this.options.host.showErrorMessage(launch.message);
+      void this.options.host.showErrorMessage(launch.message);
       return;
     }
     if (launch.infoMessage) {
-      await this.options.host.showInfoMessage(launch.infoMessage);
+      void this.settleHostDialog(
+        this.options.host.showInfoMessage(launch.infoMessage),
+        'Failed to present the launch information dialog',
+      );
     }
     const { preparation } = launch;
     if (!preparation.valid) {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -513,7 +513,7 @@
           {
             "id": "texra.gettingStarted.setupAssistant",
             "title": "The setup assistant takes it from here",
-            "description": "One conversation covers the rest. The setup assistant checks your environment and installs any missing LaTeX tools, asks what you're working on and applies the matching team, then runs your first polish -- ending at a diff so you can see every change. It asks before every command and explains what it's about to do; you stay in control.\n\n[Run Setup Assistant](command:texra.runSetupAssistant)\n\nPrefer to do it yourself? The manual steps below walk the same loop.",
+            "description": "One conversation covers the rest. The setup assistant checks your environment and installs any missing LaTeX tools, asks what you're working on and applies the matching team, then runs your first polish -- ending at a diff so you can see every change. It asks before every command and explains what it's about to do; you stay in control.\n\n[Run Setup Assistant](command:texra.walkthroughWorkspaceAction?%5B%22texra.runSetupAssistant%22%5D)\n\nPrefer to do it yourself? The manual steps below walk the same loop.",
             "media": {
               "markdown": "resources/walkthroughs/getting-started.md"
             },
@@ -524,7 +524,7 @@
           {
             "id": "texra.gettingStarted.agentModel",
             "title": "Meet the orchestrator",
-            "description": "After setup, the **orchestrator** is the habit. You don't pick from 23 agents -- it reads your paper, figures out what needs work, and hands each task to the right agent. You just approve the proposals as they come in.\n\nPick **orchestrator** from the agent dropdown and choose a model -- bigger models give better results, smaller ones are faster and cheaper. The orchestrator itself comes from the hosted research-agent catalog, so sign in to TeXRA to use it; without sign-in, start with **assistant** instead.\n\nTeams give the orchestrator the right tools for your field. The setup assistant applies one for you, or pick one yourself:\n\n[Pick a team](command:texra.showMultiAgent)",
+            "description": "After setup, the **orchestrator** is the habit. You don't pick from 23 agents -- it reads your paper, figures out what needs work, and hands each task to the right agent. You just approve the proposals as they come in.\n\nPick **orchestrator** from the agent dropdown and choose a model -- bigger models give better results, smaller ones are faster and cheaper. The orchestrator itself comes from the hosted research-agent catalog, so sign in to TeXRA to use it; without sign-in, start with **assistant** instead.\n\nTeams give the orchestrator the right tools for your field. The setup assistant applies one for you, or pick one yourself:\n\n[Pick a team](command:texra.walkthroughWorkspaceAction?%5B%22texra.showMultiAgent%22%5D)",
             "media": {
               "image": "resources/walkthroughs/media/agent-model-selection.png",
               "altText": "Screenshot of the agent and model selection UI"
@@ -547,7 +547,7 @@
           {
             "id": "texra.gettingStarted.stageFiles",
             "title": "Manual path: pick your files",
-            "description": "Open the main view and tell TeXRA what to work on:\n\n- **Input** -- the manuscript you want edited\n- **Context** -- bib/style files, reference papers, or any read-only context (optional)\n- **Media** -- figures and images (optional)\n\nYou really only need an Input file to get going.\n\n[Open the TeXRA main view](command:texra.showMainView)",
+            "description": "Open the main view and tell TeXRA what to work on:\n\n- **Input** -- the manuscript you want edited\n- **Context** -- bib/style files, reference papers, or any read-only context (optional)\n- **Media** -- figures and images (optional)\n\nYou really only need an Input file to get going.\n\n[Open the TeXRA main view](command:texra.walkthroughWorkspaceAction?%5B%22texra.showMainView%22%5D)",
             "media": {
               "image": "resources/walkthroughs/media/file-selection.png",
               "altText": "Screenshot of the file selection interface"
@@ -559,7 +559,7 @@
           {
             "id": "texra.gettingStarted.autoExtract",
             "title": "Manual path: auto-extract figures (optional)",
-            "description": "Got figures or TikZ diagrams in your paper? Turn on auto-extraction and TeXRA will pull them out before running.\n\nFlip the **Auto-extract figures** and **Auto-extract TikZ** toggles in the main view. Or run TikZ extraction manually:\n\n[Extract TikZ figures](command:texra.extractTikzFigures)",
+            "description": "Got figures or TikZ diagrams in your paper? Turn on auto-extraction and TeXRA will pull them out before running.\n\nFlip the **Auto-extract figures** and **Auto-extract TikZ** toggles in the main view. Or run TikZ extraction manually:\n\n[Extract TikZ figures](command:texra.walkthroughWorkspaceAction?%5B%22texra.extractTikzFigures%22%5D)",
             "media": {
               "image": "resources/walkthroughs/media/auto-extract-options.png",
               "altText": "Screenshot showing auto-extraction options"
@@ -571,7 +571,7 @@
           {
             "id": "texra.gettingStarted.progress",
             "title": "Manual path: run the agent",
-            "description": "You're all set. Click Run agent and the orchestrator will start working through your paper.\n\n[Run agent](command:texra.execute)\n\nIt'll propose tasks as it goes -- you'll see each one pop up in the [Progress view](command:texra.showProgressView) where you can approve, tweak, or skip it.\n\nWant it to just run without asking? Turn on **auto-approve** in Settings > Multi-Agent.",
+            "description": "You're all set. Click Run agent and the orchestrator will start working through your paper.\n\n[Run agent](command:texra.walkthroughWorkspaceAction?%5B%22texra.execute%22%5D)\n\nIt'll propose tasks as it goes -- you'll see each one pop up in the [Progress view](command:texra.walkthroughWorkspaceAction?%5B%22texra.showProgressView%22%5D) where you can approve, tweak, or skip it.\n\nWant it to just run without asking? Turn on **auto-approve** in Settings > Multi-Agent.",
             "media": {
               "image": "resources/walkthroughs/media/texra-progressboard.png",
               "altText": "Screenshot of the Progress view"
@@ -592,7 +592,7 @@
           {
             "id": "texra.gettingStarted.housekeeping",
             "title": "Manual path: clean up when you're done",
-            "description": "Happy with the results? Use **Pack** $(archive) to save everything to a `History/` folder. Want to start over? Use **Clean** $(trash) to wipe the generated files.\n\nYou'll find both in the Progress toolbar or the command palette.\n\n[Clean all outputs](command:texra.cleanOutput) | [Clean build files](command:texra.cleanBuild)",
+            "description": "Happy with the results? Use **Pack** $(archive) to save everything to a `History/` folder. Want to start over? Use **Clean** $(trash) to wipe the generated files.\n\nYou'll find both in the Progress toolbar or the command palette.\n\n[Clean all outputs](command:texra.walkthroughWorkspaceAction?%5B%22texra.cleanOutput%22%5D) | [Clean build files](command:texra.walkthroughWorkspaceAction?%5B%22texra.cleanBuild%22%5D)",
             "media": {
               "image": "resources/walkthroughs/media/texra-progressboard.png",
               "altText": "Screenshot showing pack and clean buttons in the Progress toolbar"

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -196,12 +196,9 @@ async function refreshApiKeyStatus() {
 
 /**
  * Workspace-bound commands the getting-started walkthrough exposes as buttons.
- * The walkthrough opens right after install even when no folder is open — the
- * state where activation stops at the welcome view and never reaches
- * `registerCommands` — so without fallbacks every one of these buttons is a
- * dead click. The credential commands are registered for real in that state
- * (sign-in needs no folder); these need the workspace-backed platform, so each
- * fallback says why nothing can run yet and offers the two ways forward.
+ * Their links invoke one bridge command so a no-workspace click can explain
+ * the prerequisite without firing the real command's `onCommand` completion
+ * event.
  */
 const WALKTHROUGH_COMMANDS_NEEDING_WORKSPACE = [
   EXTENSION_COMMANDS.RUN_SETUP_ASSISTANT,
@@ -213,6 +210,9 @@ const WALKTHROUGH_COMMANDS_NEEDING_WORKSPACE = [
   'texra.cleanOutput',
   'texra.cleanBuild',
 ] as const satisfies readonly CommandId[];
+
+/** Internal command URI used by workspace-bound walkthrough links. */
+const WALKTHROUGH_WORKSPACE_ACTION_COMMAND = 'texra.walkthroughWorkspaceAction';
 
 async function explainWorkspaceRequired(extensionPath: string): Promise<void> {
   const openFolder = 'Open Folder';
@@ -227,6 +227,26 @@ async function explainWorkspaceRequired(extensionPath: string): Promise<void> {
   } else if (choice === createSample) {
     await createSampleProjectWithoutWorkspace(extensionPath);
   }
+}
+
+function registerWalkthroughWorkspaceAction(
+  context: vscode.ExtensionContext,
+  hasSingleWorkspace: boolean,
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      WALKTHROUGH_WORKSPACE_ACTION_COMMAND,
+      async (
+        command: (typeof WALKTHROUGH_COMMANDS_NEEDING_WORKSPACE)[number],
+      ) => {
+        if (hasSingleWorkspace) {
+          await vscode.commands.executeCommand(command);
+          return;
+        }
+        await explainWorkspaceRequired(context.extensionPath);
+      },
+    ),
+  );
 }
 
 /**
@@ -303,8 +323,9 @@ export async function activate(context: vscode.ExtensionContext) {
 async function activateExtension(context: vscode.ExtensionContext) {
   installUnhandledRejectionSurface(context.subscriptions);
   const workspaceFolders = vscode.workspace.workspaceFolders;
+  const hasSingleWorkspace = workspaceFolders?.length === 1;
 
-  if (!workspaceFolders || workspaceFolders.length !== 1) {
+  if (!hasSingleWorkspace) {
     registerWelcomeView(context);
     // Credential-only platform. Every sign-in path stores into SecretStorage
     // (`platform().secrets`) and the global `~/.texra` config — none of it
@@ -360,12 +381,8 @@ async function activateExtension(context: vscode.ExtensionContext) {
       vscode.commands.registerCommand(EXTENSION_COMMANDS.SET_API_KEY, () =>
         apiSetApiKey(async () => {}),
       ),
-      ...WALKTHROUGH_COMMANDS_NEEDING_WORKSPACE.map((command) =>
-        vscode.commands.registerCommand(command, () =>
-          explainWorkspaceRequired(context.extensionPath),
-        ),
-      ),
     );
+    registerWalkthroughWorkspaceAction(context, false);
     return;
   }
   const rawWorkspacePath = () =>
@@ -618,6 +635,7 @@ async function activateExtension(context: vscode.ExtensionContext) {
   // fully wrapped in try/catch.)
   setTimeout(() => void initializeLatexSupport(), 0);
   const mainViewProvider = registerCommands(context);
+  registerWalkthroughWorkspaceAction(context, true);
   // Wire the two sidebar surfaces to each other before anything can invoke a
   // placement command: `texra.showProgressView` is registered above and is
   // also the status bar item's command, and a progress view without its main

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -563,7 +563,7 @@
             },
             {
               "completionEvents": ["onCommand:texra.runSetupAssistant"],
-              "description": "One conversation covers the rest. The setup assistant checks your environment and installs any missing LaTeX tools, asks what you're working on and applies the matching team, then runs your first polish -- ending at a diff so you can see every change. It asks before every command and explains what it's about to do; you stay in control.\n\n[Run Setup Assistant](command:texra.runSetupAssistant)\n\nPrefer to do it yourself? The manual steps below walk the same loop.",
+              "description": "One conversation covers the rest. The setup assistant checks your environment and installs any missing LaTeX tools, asks what you're working on and applies the matching team, then runs your first polish -- ending at a diff so you can see every change. It asks before every command and explains what it's about to do; you stay in control.\n\n[Run Setup Assistant](command:texra.walkthroughWorkspaceAction?%5B%22texra.runSetupAssistant%22%5D)\n\nPrefer to do it yourself? The manual steps below walk the same loop.",
               "id": "texra.gettingStarted.setupAssistant",
               "media": {
                 "markdown": "resources/walkthroughs/getting-started.md"
@@ -572,7 +572,7 @@
             },
             {
               "completionEvents": ["onCommand:texra.showMultiAgent"],
-              "description": "After setup, the **orchestrator** is the habit. You don't pick from 23 agents -- it reads your paper, figures out what needs work, and hands each task to the right agent. You just approve the proposals as they come in.\n\nPick **orchestrator** from the agent dropdown and choose a model -- bigger models give better results, smaller ones are faster and cheaper. The orchestrator itself comes from the hosted research-agent catalog, so sign in to TeXRA to use it; without sign-in, start with **assistant** instead.\n\nTeams give the orchestrator the right tools for your field. The setup assistant applies one for you, or pick one yourself:\n\n[Pick a team](command:texra.showMultiAgent)",
+              "description": "After setup, the **orchestrator** is the habit. You don't pick from 23 agents -- it reads your paper, figures out what needs work, and hands each task to the right agent. You just approve the proposals as they come in.\n\nPick **orchestrator** from the agent dropdown and choose a model -- bigger models give better results, smaller ones are faster and cheaper. The orchestrator itself comes from the hosted research-agent catalog, so sign in to TeXRA to use it; without sign-in, start with **assistant** instead.\n\nTeams give the orchestrator the right tools for your field. The setup assistant applies one for you, or pick one yourself:\n\n[Pick a team](command:texra.walkthroughWorkspaceAction?%5B%22texra.showMultiAgent%22%5D)",
               "id": "texra.gettingStarted.agentModel",
               "media": {
                 "altText": "Screenshot of the agent and model selection UI",
@@ -591,7 +591,7 @@
             },
             {
               "completionEvents": ["onCommand:texra.showMainView"],
-              "description": "Open the main view and tell TeXRA what to work on:\n\n- **Input** -- the manuscript you want edited\n- **Context** -- bib/style files, reference papers, or any read-only context (optional)\n- **Media** -- figures and images (optional)\n\nYou really only need an Input file to get going.\n\n[Open the TeXRA main view](command:texra.showMainView)",
+              "description": "Open the main view and tell TeXRA what to work on:\n\n- **Input** -- the manuscript you want edited\n- **Context** -- bib/style files, reference papers, or any read-only context (optional)\n- **Media** -- figures and images (optional)\n\nYou really only need an Input file to get going.\n\n[Open the TeXRA main view](command:texra.walkthroughWorkspaceAction?%5B%22texra.showMainView%22%5D)",
               "id": "texra.gettingStarted.stageFiles",
               "media": {
                 "altText": "Screenshot of the file selection interface",
@@ -601,7 +601,7 @@
             },
             {
               "completionEvents": ["onCommand:texra.extractTikzFigures"],
-              "description": "Got figures or TikZ diagrams in your paper? Turn on auto-extraction and TeXRA will pull them out before running.\n\nFlip the **Auto-extract figures** and **Auto-extract TikZ** toggles in the main view. Or run TikZ extraction manually:\n\n[Extract TikZ figures](command:texra.extractTikzFigures)",
+              "description": "Got figures or TikZ diagrams in your paper? Turn on auto-extraction and TeXRA will pull them out before running.\n\nFlip the **Auto-extract figures** and **Auto-extract TikZ** toggles in the main view. Or run TikZ extraction manually:\n\n[Extract TikZ figures](command:texra.walkthroughWorkspaceAction?%5B%22texra.extractTikzFigures%22%5D)",
               "id": "texra.gettingStarted.autoExtract",
               "media": {
                 "altText": "Screenshot showing auto-extraction options",
@@ -611,7 +611,7 @@
             },
             {
               "completionEvents": ["onCommand:texra.execute"],
-              "description": "You're all set. Click Run agent and the orchestrator will start working through your paper.\n\n[Run agent](command:texra.execute)\n\nIt'll propose tasks as it goes -- you'll see each one pop up in the [Progress view](command:texra.showProgressView) where you can approve, tweak, or skip it.\n\nWant it to just run without asking? Turn on **auto-approve** in Settings > Multi-Agent.",
+              "description": "You're all set. Click Run agent and the orchestrator will start working through your paper.\n\n[Run agent](command:texra.walkthroughWorkspaceAction?%5B%22texra.execute%22%5D)\n\nIt'll propose tasks as it goes -- you'll see each one pop up in the [Progress view](command:texra.walkthroughWorkspaceAction?%5B%22texra.showProgressView%22%5D) where you can approve, tweak, or skip it.\n\nWant it to just run without asking? Turn on **auto-approve** in Settings > Multi-Agent.",
               "id": "texra.gettingStarted.progress",
               "media": {
                 "altText": "Screenshot of the Progress view",
@@ -635,7 +635,7 @@
                 "onCommand:texra.pack",
                 "onCommand:texra.clean"
               ],
-              "description": "Happy with the results? Use **Pack** $(archive) to save everything to a `History/` folder. Want to start over? Use **Clean** $(trash) to wipe the generated files.\n\nYou'll find both in the Progress toolbar or the command palette.\n\n[Clean all outputs](command:texra.cleanOutput) | [Clean build files](command:texra.cleanBuild)",
+              "description": "Happy with the results? Use **Pack** $(archive) to save everything to a `History/` folder. Want to start over? Use **Clean** $(trash) to wipe the generated files.\n\nYou'll find both in the Progress toolbar or the command palette.\n\n[Clean all outputs](command:texra.walkthroughWorkspaceAction?%5B%22texra.cleanOutput%22%5D) | [Clean build files](command:texra.walkthroughWorkspaceAction?%5B%22texra.cleanBuild%22%5D)",
               "id": "texra.gettingStarted.housekeeping",
               "media": {
                 "altText": "Screenshot showing pack and clean buttons in the Progress toolbar",


### PR DESCRIPTION
## Summary

- let desktop launches proceed without waiting for informational dialogs while still observing dialog failures
- route workspace-bound walkthrough links through a non-completing bridge command
- delegate that bridge to the real command only when a single workspace is open, preserving genuine completion events

## Validation

- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:desktop`
- `corepack pnpm run typecheck:test-kernel`
- `corepack pnpm exec eslint packages/desktop/src/main/desktopAgentExecution.ts packages/extension/src/extension.ts`
- `corepack pnpm exec prettier --check packages/desktop/src/main/desktopAgentExecution.ts packages/extension/src/extension.ts packages/extension/package.json`
- manifest invariant check: all eight workspace-bound links use the bridge and none invoke their real command ID directly

Closes #11510
Closes #11536