### PR TITLE
fix(workflow): fail rejected final compile output

### DIFF
--- a/src/agent/implementations/flows/reflection/RoundPersistedFlow.ts
+++ b/src/agent/implementations/flows/reflection/RoundPersistedFlow.ts
@@ -51,6 +51,9 @@ export interface RoundAwareState {
 
   /** Set by nodes when execution fails. Skips round completion callbacks. */
   lastError?: RetryErrorInfo;
+
+  /** Output rejection carried into the next configured round, if one remains. */
+  compileFailureContext?: string;
 }
 
 // ============================================================================
@@ -206,7 +209,11 @@ export class RoundPersistedFlow<
   /** Derive the canonical RunOutcome from the current round state. */
   private resolveOutcome(shared: S): RunOutcome {
     return deriveRunOutcome({
-      failed: Boolean(shared.lastError),
+      failed: Boolean(
+        shared.lastError ||
+        (shared.compileFailureContext &&
+          shared.currentRound + 1 >= shared.totalRounds),
+      ),
       cancelled: this.callbacks.signal?.aborted || !shared.continueRounds,
     });
   }

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -894,7 +894,7 @@ const WORKFLOW_REJECT_RUNTIME_REACHABILITY = {
   command:
     'texra run <workflow-agent> --input paper.tex --instruction "revise the paper"',
   through:
-    'packages/cli/src/commands/workflow.ts -> src/agent/implementations/flows/reflection/runReflectionFlow.ts',
+    'packages/cli/src/commands/workflow.ts -> src/agent/implementations/flows/reflection/runReflectionFlow.ts -> src/agent/implementations/flows/reflection/nodes/OutputNode.ts',
 } satisfies CliRuntimeReachability;
 const OPENAI_WEBSOCKET_RUNTIME_REACHABILITY = {
   command:
@@ -1346,10 +1346,8 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       'Reject an agent edit when the automatic post-output compile fails, so broken LaTeX is not accepted.',
     category: 'workflow',
     slots: sameSlot('workspaceState'),
-    // Also read by OutputNode.ts (compileFailureContext gate); the row names
-    // the extra-round grant in runReflectionFlow.ts as its reader evidence.
     honoredBy: everyHost(
-      'src/agent/implementations/flows/reflection/runReflectionFlow.ts',
+      'src/agent/implementations/flows/reflection/nodes/OutputNode.ts',
       WORKFLOW_REJECT_RUNTIME_REACHABILITY,
     ),
     surfaces: { settingsView: 'latex', cliConfig: true },

--- a/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
+++ b/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
@@ -161,7 +161,7 @@ describe('RoundPersistedFlow compile-failure round limit', () => {
   });
 
   it('does not exceed the configured count when every round fails to compile', async () => {
-    const { shared, stages } = await runFlow({
+    const { shared, stages, outcome } = await runFlow({
       totalRounds: 3,
       failingRounds: [0, 1, 2],
     });
@@ -177,6 +177,7 @@ describe('RoundPersistedFlow compile-failure round limit', () => {
       { index: 1, total: 3 },
       { index: 2, total: 3 },
     ]);
+    expect(outcome).toBe(RUN_OUTCOME.FAILED);
   });
 
   it('fails without adding a repair round when final compile failure collides with cancellation', async () => {

--- a/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
+++ b/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
@@ -37,6 +37,10 @@ interface FakeShared extends RoundAwareState {
   contextSeenByRound: Record<number, string | undefined>;
   /** Round indices that should simulate a compile failure. */
   failingRounds: number[];
+  /** Round indices after which execution should be cancelled. */
+  cancellingRounds: number[];
+  /** Mirrors the reject-on-compile-failure setting read by OutputNode. */
+  rejectOnCompileFailure: boolean;
   /** Mirrors OutputNode's compile-failure context (set on failure, consumed next round). */
   compileFailureContext?: string;
 }
@@ -47,14 +51,24 @@ interface FakeShared extends RoundAwareState {
  * then sets fresh feedback when the current round fails compilation.
  */
 class FakeRoundNode extends BaseNode<FakeShared> {
+  constructor(private readonly abortController?: AbortController) {
+    super();
+  }
+
   override async post(shared: FakeShared): Promise<undefined> {
     shared.roundsRun.push(shared.currentRound);
     shared.contextSeenByRound[shared.currentRound] =
       shared.compileFailureContext;
     delete shared.compileFailureContext;
 
-    if (shared.failingRounds.includes(shared.currentRound)) {
+    if (
+      shared.rejectOnCompileFailure &&
+      shared.failingRounds.includes(shared.currentRound)
+    ) {
       shared.compileFailureContext = `compile failed on round ${shared.currentRound}`;
+    }
+    if (shared.cancellingRounds.includes(shared.currentRound)) {
+      this.abortController?.abort();
     }
     return undefined;
   }
@@ -67,7 +81,8 @@ class UnexpectedRoundNode extends BaseNode<FakeShared> {
 }
 
 function makeFlow(kv = createFakeKv()) {
-  const node = new FakeRoundNode();
+  const abortController = new AbortController();
+  const node = new FakeRoundNode(abortController);
   const logger = new TraceEmitter();
   /** `{ index, total }` each round stage opened with, in call order. */
   const stages: Array<{ index: number; total: number }> = [];
@@ -82,6 +97,7 @@ function makeFlow(kv = createFakeKv()) {
           ...stage,
         });
       },
+      signal: abortController.signal,
     },
   });
   return { flow, stages };
@@ -95,6 +111,8 @@ function initialShared(overrides: Partial<FakeShared>): FakeShared {
     roundsRun: [],
     contextSeenByRound: {},
     failingRounds: [],
+    cancellingRounds: [],
+    rejectOnCompileFailure: true,
     ...overrides,
   };
 }
@@ -102,10 +120,11 @@ function initialShared(overrides: Partial<FakeShared>): FakeShared {
 async function runFlow(overrides: Partial<FakeShared>): Promise<{
   shared: FakeShared;
   stages: Array<{ index: number; total: number }>;
+  outcome: RunOutcome;
 }> {
   const { flow, stages } = makeFlow();
-  await flow.run(initialShared(overrides));
-  return { shared: (await flow.getShared())!, stages };
+  const outcome = await flow.run(initialShared(overrides));
+  return { shared: (await flow.getShared())!, stages, outcome };
 }
 
 async function expectFlowDidNotResume(
@@ -122,10 +141,23 @@ async function expectFlowDidNotResume(
 
 describe('RoundPersistedFlow compile-failure round limit', () => {
   it('passes compile-failure feedback into a remaining configured round', async () => {
-    const { shared } = await runFlow({ failingRounds: [0] });
+    const { shared, outcome } = await runFlow({ failingRounds: [0] });
 
     expect(shared.roundsRun).toEqual([0, 1]);
     expect(shared.contextSeenByRound[1]).toBe('compile failed on round 0');
+    expect(outcome).toBe(RUN_OUTCOME.COMPLETED);
+  });
+
+  it('cancels when non-final compile feedback cannot reach the next round', async () => {
+    const { shared, outcome } = await runFlow({
+      totalRounds: 3,
+      failingRounds: [0],
+      cancellingRounds: [0],
+    });
+
+    expect(shared.roundsRun).toEqual([0]);
+    expect(shared.compileFailureContext).toBe('compile failed on round 0');
+    expect(outcome).toBe(RUN_OUTCOME.CANCELLED);
   });
 
   it('does not exceed the configured count when every round fails to compile', async () => {
@@ -147,11 +179,26 @@ describe('RoundPersistedFlow compile-failure round limit', () => {
     ]);
   });
 
-  it('does not add a repair round after the final configured round fails', async () => {
-    const { shared } = await runFlow({ failingRounds: [1] });
+  it('fails without adding a repair round when final compile failure collides with cancellation', async () => {
+    const { shared, outcome } = await runFlow({
+      failingRounds: [1],
+      cancellingRounds: [1],
+    });
 
     expect(shared.roundsRun).toEqual([0, 1]);
     expect(shared.compileFailureContext).toBe('compile failed on round 1');
+    expect(outcome).toBe(RUN_OUTCOME.FAILED);
+  });
+
+  it('retains completed behavior when compile-failure rejection is disabled', async () => {
+    const { shared, outcome } = await runFlow({
+      failingRounds: [1],
+      rejectOnCompileFailure: false,
+    });
+
+    expect(shared.roundsRun).toEqual([0, 1]);
+    expect(shared.compileFailureContext).toBeUndefined();
+    expect(outcome).toBe(RUN_OUTCOME.COMPLETED);
   });
 
   it('does not resume a persisted legacy repair round at the configured limit', async () => {
@@ -168,7 +215,7 @@ describe('RoundPersistedFlow compile-failure round limit', () => {
       cursor: { nextNodeId: 'start' },
     } satisfies FlowRecord);
 
-    await expect(flow.run(persisted)).resolves.toBe(RUN_OUTCOME.COMPLETED);
+    await expect(flow.run(persisted)).resolves.toBe(RUN_OUTCOME.FAILED);
 
     await expectFlowDidNotResume(flow, kv, stages);
   });

--- a/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
+++ b/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
@@ -108,6 +108,18 @@ async function runFlow(overrides: Partial<FakeShared>): Promise<{
   return { shared: (await flow.getShared())!, stages };
 }
 
+async function expectFlowDidNotResume(
+  flow: RoundPersistedFlow<FakeShared>,
+  kv: ReturnType<typeof createFakeKv>,
+  stages: unknown[],
+): Promise<void> {
+  expect((await flow.getShared())?.roundsRun).toEqual([]);
+  expect(stages).toEqual([]);
+  await expect(
+    kv.read<FlowRecord>(flowKey(kv.getExecutionId())),
+  ).resolves.toMatchObject({ cursor: { nextNodeId: 'start' } });
+}
+
 describe('RoundPersistedFlow compile-failure round limit', () => {
   it('passes compile-failure feedback into a remaining configured round', async () => {
     const { shared } = await runFlow({ failingRounds: [0] });
@@ -158,11 +170,7 @@ describe('RoundPersistedFlow compile-failure round limit', () => {
 
     await expect(flow.run(persisted)).resolves.toBe(RUN_OUTCOME.COMPLETED);
 
-    expect((await flow.getShared())?.roundsRun).toEqual([]);
-    expect(stages).toEqual([]);
-    await expect(
-      kv.read<FlowRecord>(flowKey(kv.getExecutionId())),
-    ).resolves.toMatchObject({ cursor: { nextNodeId: 'start' } });
+    await expectFlowDidNotResume(flow, kv, stages);
   });
 
   it('does not resume a persisted round excluded by a lowered round count', async () => {
@@ -179,11 +187,7 @@ describe('RoundPersistedFlow compile-failure round limit', () => {
 
     await expect(flow.run(synced)).resolves.toBe(RUN_OUTCOME.COMPLETED);
 
-    expect((await flow.getShared())?.roundsRun).toEqual([]);
-    expect(stages).toEqual([]);
-    await expect(
-      kv.read<FlowRecord>(flowKey(kv.getExecutionId())),
-    ).resolves.toMatchObject({ cursor: { nextNodeId: 'start' } });
+    await expectFlowDidNotResume(flow, kv, stages);
   });
 
   it('still resumes a valid persisted cursor within the configured limit', async () => {


### PR DESCRIPTION
## Summary

Fail a workflow when reject-on-compile-failure remains unresolved at the configured round cap, without adding another model round.

A compile failure before the cap still becomes feedback for the next configured round. If that next round succeeds, the workflow completes normally. If compile rejection is disabled, the existing completed behavior remains unchanged. The settings catalog now points to `OutputNode.ts`, the direct reader.

Fixes #11619.

## Issue acceptance gates

- Final configured round compile failure with rejection enabled resolves to `FAILED`.
- No repair round is added beyond the configured `rounds` count.
- Mid-run compile feedback still reaches the next configured round and can complete successfully.
- Non-final cancellation remains `CANCELLED`, even when compile feedback is pending.
- Final-round failure retains canonical precedence over simultaneous cancellation.
- Rejection-disabled workflows retain `COMPLETED` behavior.
- State-setting reader evidence names the actual runtime reader.

## Single source of truth

`RoundPersistedFlow.resolveOutcome()` owns final outcome derivation. An unconsumed compile-rejection context is fatal only once `currentRound + 1 >= totalRounds`.

## Duplication and abstraction budget

No new orchestration layer was added. A repeated no-resume test assertion was extracted into one local test helper following the requested Claude `/simplify` pass.

## Net elements (R6)

- Files: 3 modified
- Net LoC: +79 / -23
- Exported symbols: no new exports
- Classes/interfaces/enums: no new production constructs

## Consumer counts (R8)

n/a. No exported API or event path is removed or rerouted.

## Host impact

Extension: Rejected final-round broken LaTeX now produces a failed workflow.

Desktop: Same shared workflow outcome behavior.

CLI: Same shared workflow outcome behavior; settings reachability now traces through `OutputNode.ts`.

## Scheduled refactoring

None.

## Validation

- Focused workflow and state-settings tests: 58 passed
- Final compile-repair suite after formatting: 12 passed
- Workspace typecheck: passed
- Test-kernel typecheck: passed
- Changed-file lint: passed
- Prettier and `git diff --check`: passed
- Independent review: no remaining findings
