### PR TITLE
simplify(cli): survey bundle 6 — the plan fold without its memo; no roster fallback for the parent

### DIFF
--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -90,15 +90,6 @@ export function numericFocusTargetForActiveStream(init: {
   }).find((entry) => entry.shortcutIndex === shortcutIndex)?.id;
 }
 
-/** The parent that lists a child on its roster, for the interval before the
- *  parent edge is recorded (roster-first event ordering). */
-function rosterParentOf(streamId: StreamTabId): StreamTabId | undefined {
-  for (const [parentId, rows] of childRosters.get()) {
-    if (rows.some((row) => row.childStreamId === streamId)) return parentId;
-  }
-  return undefined;
-}
-
 /** Whether a stream is a workflow-script run. */
 export function isWorkflowScriptStream(streamId: StreamTabId): boolean {
   return (
@@ -119,8 +110,10 @@ export function presentStream(
   streamId: StreamTabId,
 ): 'stream' | 'workflowPopup' {
   if (isWorkflowScriptStream(streamId)) {
-    const parentId =
-      parentStream.get().get(streamId) ?? rosterParentOf(streamId);
+    // The parent edge is here whenever the roster row is: the status applier
+    // creates the child's stream before the roster and the edge are emitted
+    // back to back, and the edge clears only with the parent, roster included.
+    const parentId = parentStream.get().get(streamId);
     if (parentId !== undefined) focusStream(parentId);
     openWorkflowPopup(streamId);
     return 'workflowPopup';

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -73,13 +73,6 @@ interface TaskGroupProjectionState {
   snapshot: readonly TaskGroup[];
 }
 
-/** Incremental declared-plan memo: the newest `workflowPlan` marker in
- *  transcript order, kept the same way as the task-group memo. */
-interface WorkflowPlanProjectionState {
-  readonly applied: Map<string, StreamLogEntry>;
-  snapshot: WorkflowPlanMarker | undefined;
-}
-
 /** Incremental compaction-activity projection state, cursored on the source
  *  log (`appliedHead`), so it too survives fold rebuilds. */
 interface CompactionProjectionState {
@@ -118,7 +111,8 @@ export interface TranscriptFoldState {
    *  residency is released, and die with the slice like everything here. */
   taskGroupProjection?: TaskGroupProjectionState;
   compactionProjection?: CompactionProjectionState;
-  workflowPlanProjection?: WorkflowPlanProjectionState;
+  /** The newest `workflowPlan` marker folded so far (last wins). */
+  workflowPlan?: WorkflowPlanMarker;
   /** Whether the last emitted `entries` was the full transcript or compact;
    *  undefined until the first emission. */
   lastOutputFull?: boolean;

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -474,6 +474,6 @@ export function releaseInactiveStreamTranscript(
     resetTranscriptFoldState(fold);
     fold.taskGroupProjection = undefined;
     fold.compactionProjection = undefined;
-    fold.workflowPlanProjection = undefined;
+    fold.workflowPlan = undefined;
   }
 }

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -211,36 +211,28 @@ function projectTaskGroupsIncrementally(
  * The newest `workflowPlan` marker in transcript order. A relaunch under the
  * same meta.name appends its own marker after the attempt it supersedes, so
  * the last one applied is the live attempt's plan — the same "newest attempt"
- * rule `workflowRunModel` applies to the cards.
+ * rule `workflowRunModel` applies to the cards. Markers are appended settled
+ * and never patched, and the fold is last-wins, so feeding it the appended
+ * tail or replaying any prefix lands on the same plan.
  */
 function projectWorkflowPlanIncrementally(
   fold: TranscriptFoldState,
   entries: readonly StreamLogEntry[],
 ): WorkflowPlanMarker | undefined {
-  let state = fold.workflowPlanProjection;
-  if (!state) {
-    state = { applied: new Map(), snapshot: undefined };
-    fold.workflowPlanProjection = state;
-  }
   for (const entry of entries) {
     const marker = workflowMarkerOf(entry);
     if (!marker) continue;
-    if (state.applied.get(entry.id) === entry) continue;
-    state.applied.set(entry.id, entry);
-    switch (marker.kind) {
-      case 'malformedPlan':
-        // An unreadable plan is an unknown plan, not the previous attempt's.
-        logger.warn(
-          `Ignoring malformed workflow plan marker ${entry.id}: ${marker.error}`,
-        );
-        state.snapshot = undefined;
-        break;
-      case 'plan':
-        state.snapshot = marker.plan;
-        break;
+    if (marker.kind === 'malformedPlan') {
+      // An unreadable plan is an unknown plan, not the previous attempt's.
+      logger.warn(
+        `Ignoring malformed workflow plan marker ${entry.id}: ${marker.error}`,
+      );
+      fold.workflowPlan = undefined;
+    } else {
+      fold.workflowPlan = marker.plan;
     }
   }
-  return state.snapshot;
+  return fold.workflowPlan;
 }
 
 function projectCompactionIncrementally(


### PR DESCRIPTION
## What

Bundle 6 (S13–S14) of [the 2026-08-29 survey](docs/proposals/2026-08-29-simplification-survey-shared-workflow-model.md) — two CLI state deletions:

- **S13** The plan fold kept a `Map<entryId, entry>` of applied entries to survive being re-fed. Markers are `appendSettled` and never patched, `dirtied` carries in-place mutations only, and the fold is last-marker-wins, so feeding it the appended tail or replaying any prefix lands on the same plan. `TranscriptFoldState.workflowPlanProjection` (a memo interface) becomes `workflowPlan?: WorkflowPlanMarker` — the shape the board already has in `logSlice`. One difference: a malformed marker re-warns on a rebuild (the loud side).
- **S14** `presentStream` fell back to scanning every roster for a workflow stream's parent "for the interval before the parent edge is recorded". That interval cannot occur: the status applier creates the child's stream before the roster row and the parent edge are emitted back to back, every `presentStream` caller needs a slice or is suppressed for child attachments, and the edge clears only with the parent, roster included. The fallback and `rosterParentOf` go; a two-line comment names the invariants. The identity scan in `streamIdentityFor` — the reviewer's actual ask on #11602 — stays.

## Net elements (R6)

`git diff --stat` against the base: production 4 files, **+19 / −40** (net −21); tests ±0. Declarations −1 (`WorkflowPlanProjectionState`); functions −1 (`rosterParentOf`); −1 `??`.

## Consumer counts (R8)

No emit path deleted. At the base (prod / test): `rosterParentOf` 1 / 0 · `WorkflowPlanProjectionState` 2 / 0 · `workflowPlanProjection` 3 / 0.

## Verified

- CLI typecheck clean; eslint + prettier clean on changed files
- vitest `src/test-kernel/cli` — 143 files, 2,435 tests passing
- `npm run check:dead-code-ratchet` — no new findings (run on the stacked branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QESykrKh1yzvF2bB4pjDrS
