### PR TITLE
docs(runtime): clarify run-start vs active-phase-start ownership

### DIFF
--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -114,18 +114,12 @@ export type LiveToolUseFlowContext = {
  */
 export class AgentExecutionHandle {
   /**
-   * Epoch ms when this generation's handle was created. Retained, not
-   * cleared, while this handle sits parked at WAITING — but a resume
-   * constructs a fresh `AgentExecutionHandle` that `ExecutionRegistry.track`
-   * installs in its place ("a resumed generation taking over from its
-   * predecessor", `executionRegistry.ts`), so this value does not survive a
-   * resume; it is the current generation's start, not the run's original
-   * creation time. It feeds `executionRegistry.getStatus`'s elapsed, the
-   * roster's `ActiveChildInfo.startedAt`, and the `executions` tool's
-   * `Started:` line. Distinct from `StreamPhaseState.runStartedAt`
-   * (`StreamStatusService.ts`): that field clears the instant the phase
-   * leaves active, while this one lingers through a WAITING interval — but
-   * neither survives an actual resume.
+   * Epoch ms when this handle generation was created. The value remains on a
+   * handle while it is parked at WAITING. Resume constructs and tracks a
+   * replacement handle, whose `startedAt` is stamped anew. This feeds
+   * `executionRegistry.getStatus`'s elapsed, the roster's
+   * `ActiveChildInfo.startedAt`, and the `executions` tool's `Started:` line.
+   * Durable execution creation time is `ExecutionMeta.timestamp`.
    */
   readonly startedAt = Date.now();
   private _parentStreamId: StreamTabId;

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -114,13 +114,18 @@ export type LiveToolUseFlowContext = {
  */
 export class AgentExecutionHandle {
   /**
-   * Epoch ms when this handle was created — the run's creation time, stable
-   * for the handle's whole lifetime including any WAITING interval. The one
-   * owner of that fact: it feeds `executionRegistry.getStatus`'s elapsed,
-   * the roster's `ActiveChildInfo.startedAt`, and the `executions` tool's
+   * Epoch ms when this generation's handle was created. Retained, not
+   * cleared, while this handle sits parked at WAITING — but a resume
+   * constructs a fresh `AgentExecutionHandle` that `ExecutionRegistry.track`
+   * installs in its place ("a resumed generation taking over from its
+   * predecessor", `executionRegistry.ts`), so this value does not survive a
+   * resume; it is the current generation's start, not the run's original
+   * creation time. It feeds `executionRegistry.getStatus`'s elapsed, the
+   * roster's `ActiveChildInfo.startedAt`, and the `executions` tool's
    * `Started:` line. Distinct from `StreamPhaseState.runStartedAt`
-   * (`StreamStatusService.ts`), which tracks only the current active-phase
-   * window and resets on every WAITING→RUNNING transition.
+   * (`StreamStatusService.ts`): that field clears the instant the phase
+   * leaves active, while this one lingers through a WAITING interval — but
+   * neither survives an actual resume.
    */
   readonly startedAt = Date.now();
   private _parentStreamId: StreamTabId;

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -113,6 +113,15 @@ export type LiveToolUseFlowContext = {
  * a subagent whose parent is an orchestrator.
  */
 export class AgentExecutionHandle {
+  /**
+   * Epoch ms when this handle was created — the run's creation time, stable
+   * for the handle's whole lifetime including any WAITING interval. The one
+   * owner of that fact: it feeds `executionRegistry.getStatus`'s elapsed,
+   * the roster's `ActiveChildInfo.startedAt`, and the `executions` tool's
+   * `Started:` line. Distinct from `StreamPhaseState.runStartedAt`
+   * (`StreamStatusService.ts`), which tracks only the current active-phase
+   * window and resets on every WAITING→RUNNING transition.
+   */
   readonly startedAt = Date.now();
   private _parentStreamId: StreamTabId;
   private interruptHandler?: ExecutionInterruptHandler;

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -31,18 +31,13 @@ export interface StreamPhaseState {
   readonly phase: StreamPhase;
   readonly substate?: StreamSubstate;
   /**
-   * Epoch ms when the stream entered its CURRENT active phase, held across
-   * substate changes and cleared the moment the phase stops being active —
-   * it resets on every WAITING→RUNNING transition. The one owner of
-   * "when did the active window now in progress start"; hosts render
-   * elapsed-while-active time from it instead of each stamping a clock read
-   * of their own. `AgentExecutionHandle.startedAt` (`ExecutionHandle.ts`)
-   * tracks a related but distinct fact — the current handle generation's
-   * start, feeding the roster's `Started:` display — and differs only in
-   * when it resets: it lingers through a WAITING interval where this field
-   * clears immediately, but like this field it is replaced by a fresh
-   * timestamp once a resume installs a new handle generation. Neither field
-   * is the run's original creation time.
+   * Epoch ms when the stream entered its current active phase. Held across
+   * substate changes, cleared when the phase stops being active, and stamped
+   * again on a later WAITING→RUNNING transition. Hosts render
+   * elapsed-while-active time from this value. This is not durable execution
+   * creation time; that is `ExecutionMeta.timestamp`.
+   * `AgentExecutionHandle.startedAt` separately timestamps a handle generation
+   * and may remain present on a parked handle after this field has cleared.
    */
   readonly runStartedAt?: number;
 }

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -31,10 +31,15 @@ export interface StreamPhaseState {
   readonly phase: StreamPhase;
   readonly substate?: StreamSubstate;
   /**
-   * Epoch ms when the stream entered its current active phase, held across
-   * substate changes and cleared the moment the phase stops being active.
-   * The one owner of "when did this run start" — hosts render elapsed time
-   * from it instead of each stamping a clock read of their own.
+   * Epoch ms when the stream entered its CURRENT active phase, held across
+   * substate changes and cleared the moment the phase stops being active —
+   * it resets on every WAITING→RUNNING transition. The one owner of
+   * "when did the active window now in progress start"; hosts render
+   * elapsed-while-active time from it instead of each stamping a clock read
+   * of their own. Not the run's creation time: that fact, stable across
+   * WAITING and never cleared, is owned separately by
+   * `AgentExecutionHandle.startedAt` (`ExecutionHandle.ts`), which feeds the
+   * roster's `Started:` display and survives phases this field does not.
    */
   readonly runStartedAt?: number;
 }

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -36,10 +36,13 @@ export interface StreamPhaseState {
    * it resets on every WAITING→RUNNING transition. The one owner of
    * "when did the active window now in progress start"; hosts render
    * elapsed-while-active time from it instead of each stamping a clock read
-   * of their own. Not the run's creation time: that fact, stable across
-   * WAITING and never cleared, is owned separately by
-   * `AgentExecutionHandle.startedAt` (`ExecutionHandle.ts`), which feeds the
-   * roster's `Started:` display and survives phases this field does not.
+   * of their own. `AgentExecutionHandle.startedAt` (`ExecutionHandle.ts`)
+   * tracks a related but distinct fact — the current handle generation's
+   * start, feeding the roster's `Started:` display — and differs only in
+   * when it resets: it lingers through a WAITING interval where this field
+   * clears immediately, but like this field it is replaced by a fresh
+   * timestamp once a resume installs a new handle generation. Neither field
+   * is the run's original creation time.
    */
   readonly runStartedAt?: number;
 }


### PR DESCRIPTION
## Summary

This comments-only PR clarifies the timestamps used by runtime status views:

- `StreamPhaseState.runStartedAt` is the start of the current active phase. It is cleared when the stream leaves an active phase and stamped again on a later WAITING→RUNNING transition.
- `AgentExecutionHandle.startedAt` is the creation time of one handle generation. It remains available while that handle is parked at WAITING, but resume constructs and tracks a replacement handle with a newly stamped value.
- `ExecutionMeta.timestamp` is the durable execution creation timestamp written by `registerExecution` and retained across resume.

The lifecycle confirms the distinction: `runFlowWithLifecycle` constructs a new `AgentExecutionHandle` for each generation, and `ExecutionRegistry.track` replaces the prior handle for the same execution ID. Resume clears terminal outcome state without rewriting `ExecutionMeta.timestamp`.

## Issue acceptance gates

Partially addresses #11561 by removing the misleading claim that `runStartedAt` owns “when did this run start” and documenting the actual scope of both runtime timestamps. It does not change timestamp behavior or resolve the larger field-ownership refactor described by that issue.

## Single source of truth

Unchanged. `StreamPhaseState.runStartedAt` owns current active-phase start, `AgentExecutionHandle.startedAt` owns handle-generation start for registry and roster views, and `ExecutionMeta.timestamp` owns durable execution creation time.

## Duplication and abstraction budget

No code, schema, export, or wire-field changes. The comments now describe the existing lifecycle accurately.

## Net elements (R6)

n/a. No exported symbols, classes, or schema fields were added or removed.

## Consumer counts (R8)

n/a. No emit path, export, or wire field was rerouted or deleted.

## Host impact

Extension: none (comments only).
Desktop: none (comments only).
CLI: none (comments only).

## Scheduled refactoring

#11561 remains open for any structural consolidation. This PR only corrects the documentation.

## Validation

- `pnpm dlx prettier@3.9.6 --check src/agent/runtime/ExecutionHandle.ts src/agent/runtime/StreamStatusService.ts` — clean.
- `git diff --check` — clean.
- Tests and runtime static checks were not run because no executable code or types changed.

---

This PR was produced by an unattended scheduled run tasked with finding and fixing one significant overlapping-responsibility issue in the codebase.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5XFgqhnWhdqrWMyLKb3RM)_