### PR TITLE
feat(model): expose longer ChatGPT context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- **Use longer ChatGPT subscription context windows** — the TUI, extension,
+  and desktop app now let you raise the input token budget for supported GPT
+  models while keeping the standard limit by default.
 - **Choose skills per workspace** — the extension, desktop app, and CLI now let
   you enable or disable individual skills and skill source groups from one
   consolidated skills display. Skills are off by default until you enable the

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -64,6 +64,7 @@ import {
   approvalPolicy,
   bashApprovalEnabled,
   chatgptAuth,
+  chatgptCodexContextWindow,
   grokAuth,
   childRunConcurrencyBudget,
   claudeAgentEffort,
@@ -363,7 +364,9 @@ export class SettingsApp extends SettingsAppBase {
       case 'subscriptions':
         return html`
           <subscriptions-tab
+            .ackGeneration=${multiAgentSettingsRevision.get()}
             .chatgptAuth=${chatgptAuth.get()}
+            .chatgptCodexContextWindow=${chatgptCodexContextWindow.get()}
             .grokAuth=${grokAuth.get()}
             .usage=${subscriptionUsage.get()}
             .copilotModels=${copilotRouteInfos.get()}

--- a/packages/extension/src/settingsView/frontend/components/profile/SubscriptionSection.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/SubscriptionSection.ts
@@ -18,18 +18,24 @@ import { xaiAccountLabel } from '@auth/xai/xaiSessionTypes';
 import { commonViewStyles, designTokens } from '@shared/styles';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { postMessage } from '@shared/hostBridge';
-import type {
-  ChatGptAuthStatus,
-  GrokAuthStatus,
-  SubscriptionUsageSnapshot,
+import {
+  CHATGPT_CODEX_CONTEXT_WINDOW_SETTING,
+  type ChatGptAuthStatus,
+  type GrokAuthStatus,
+  type SubscriptionUsageSnapshot,
 } from '@shared/schemas';
 import { CHATGPT_AUTH, GROK_AUTH } from '@shared/copy/accountAuth';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import {
+  renderSettingsNumberRow,
   renderSettingsSectionHeading,
   renderSettingsToggleRow,
 } from '@shared/wa/settingsSection';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
+
+// Local imports - settings view components
+import './SubscriptionUsageRow';
+import { postStateSetting } from '../shared/stateSettingRows';
 
 // Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/button/button.js';
@@ -37,8 +43,6 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
 
 import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
-
-import './SubscriptionUsageRow';
 
 /** Sign-in status shared by every subscription provider. */
 export type SubscriptionAuthStatus = ChatGptAuthStatus | GrokAuthStatus;
@@ -65,6 +69,8 @@ export interface SubscriptionSectionProvider {
   };
   /** Human-readable account name for the signed-in row. */
   readonly accountLabel: (auth: SubscriptionAuthStatus | null) => string;
+  /** Optional advanced input-budget control for this subscription route. */
+  readonly contextWindowSetting?: typeof CHATGPT_CODEX_CONTEXT_WINDOW_SETTING;
 }
 
 @customElement('subscription-section')
@@ -80,7 +86,11 @@ export class SubscriptionSection extends LitElement {
   ];
 
   @property({ attribute: false }) provider!: SubscriptionSectionProvider;
+  /** Parent-owned acknowledgement generation for restoring rejected edits. */
+  @property({ attribute: false }) ackGeneration = 0;
   @property({ attribute: false }) auth: SubscriptionAuthStatus | null = null;
+  @property({ attribute: false }) contextWindow =
+    CHATGPT_CODEX_CONTEXT_WINDOW_SETTING.defaultValue;
   @property({ attribute: false }) usage: SubscriptionUsageSnapshot | null =
     null;
   @property({ attribute: false }) now = 0;
@@ -92,9 +102,12 @@ export class SubscriptionSection extends LitElement {
 
   override render(): TemplateResult {
     const provider = this.provider;
+    const contextWindowSetting = provider.contextWindowSetting;
     const signedIn = this.auth?.signedIn ?? false;
     const preferSubscription = this.auth?.preferSubscription ?? false;
     const account = provider.accountLabel(this.auth);
+    // A same-value settings rebroadcast must repaint a rejected number edit.
+    void this.ackGeneration;
     return html`
       <section id=${provider.sectionId}>
         ${renderSettingsSectionHeading({
@@ -116,6 +129,21 @@ export class SubscriptionSection extends LitElement {
             checked: preferSubscription,
             onChange: this.handlePreferSubscriptionChange,
           })}
+          ${
+            contextWindowSetting
+              ? renderSettingsNumberRow({
+                  label: 'Subscription input token budget',
+                  description: contextWindowSetting.description,
+                  value: this.contextWindow,
+                  min: contextWindowSetting.min,
+                  max: contextWindowSetting.max,
+                  step: 1_000,
+                  unit: 'tokens',
+                  onChange: (value) =>
+                    postStateSetting(contextWindowSetting.configKey, value),
+                })
+              : ''
+          }
           <div class="settings-row">
             <div class="settings-row-text">
               <span class="settings-row-label">
@@ -173,7 +201,8 @@ export const CHATGPT_SUBSCRIPTION_SECTION: SubscriptionSectionProvider =
     title: CHATGPT_AUTH.subscriptionLabel,
     description:
       'Use OpenAI models through your ChatGPT Plus, Pro, or Team subscription. No OpenAI API key is needed.',
-    note: 'Subscription routing uses a 272,000-token input budget by default. Advanced users can raise texra.chatgptCodex.contextWindow up to 872,000 for GPT-5.6 models; the displayed context also includes the output budget.',
+    note: 'Subscription routing uses a 272,000-token input budget by default. GPT-5.6 models support up to 872,000 input tokens; the displayed context also includes the output budget.',
+    contextWindowSetting: CHATGPT_CODEX_CONTEXT_WINDOW_SETTING,
     preferLabel: CHATGPT_AUTH.preferLabel,
     preferDescription: 'Use the subscription for eligible Codex models.',
     accountTitle: 'ChatGPT account',

--- a/packages/extension/src/settingsView/frontend/components/profile/SubscriptionSection.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/SubscriptionSection.ts
@@ -137,7 +137,6 @@ export class SubscriptionSection extends LitElement {
                   value: this.contextWindow,
                   min: contextWindowSetting.min,
                   max: contextWindowSetting.max,
-                  step: 1_000,
                   unit: 'tokens',
                   onChange: (value) =>
                     postStateSetting(contextWindowSetting.configKey, value),

--- a/packages/extension/src/settingsView/frontend/settingsState.ts
+++ b/packages/extension/src/settingsView/frontend/settingsState.ts
@@ -29,6 +29,7 @@ import {
   AGENT_SKILLS_CONFIG_KEY,
   BASH_APPROVAL_CONFIG_KEY,
   byCategory,
+  CHATGPT_CODEX_CONTEXT_WINDOW_SETTING,
   CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY,
   DEFAULT_GLOBAL_STREAMING,
   DEFAULT_LATEX_SETTINGS_STATUS,
@@ -207,6 +208,9 @@ export const activePresetId = trackedSignal<string | null>(() => null);
 // ---------------------------------------------------------------------------
 export const compactionThresholdPercent = settingSignal<number>(
   MODEL_COMPACTION_THRESHOLD_SETTING.configKey,
+);
+export const chatgptCodexContextWindow = settingSignal<number>(
+  CHATGPT_CODEX_CONTEXT_WINDOW_SETTING.configKey,
 );
 export const modelRetryMaxAttempts = settingSignal<number>(
   MODEL_RETRY_MAX_ATTEMPTS_SETTING.configKey,

--- a/packages/extension/src/settingsView/frontend/tabs/SubscriptionsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/SubscriptionsTab.ts
@@ -16,6 +16,7 @@ import { CODING_PLAN_SUBSCRIPTIONS } from '@shared/codingPlanSubscriptions';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { postMessage } from '@shared/hostBridge';
 import {
+  CHATGPT_CODEX_CONTEXT_WINDOW_SETTING,
   SETTINGS_TAB_PANEL_BY_NAME,
   type ChatGptAuthStatus,
   type CopilotRouteInfo,
@@ -69,7 +70,11 @@ export class SubscriptionsTab extends LitElement {
     `,
   ];
 
+  /** Parent-owned acknowledgement generation for restoring rejected edits. */
+  @property({ attribute: false }) ackGeneration = 0;
   @property({ attribute: false }) chatgptAuth: ChatGptAuthStatus | null = null;
+  @property({ attribute: false }) chatgptCodexContextWindow =
+    CHATGPT_CODEX_CONTEXT_WINDOW_SETTING.defaultValue;
   @property({ attribute: false }) grokAuth: GrokAuthStatus | null = null;
   @property({ attribute: false }) usage: SubscriptionUsageSnapshots | null =
     null;
@@ -128,8 +133,10 @@ export class SubscriptionsTab extends LitElement {
           </div>
         </div>
         <subscription-section
+          .ackGeneration=${this.ackGeneration}
           .provider=${CHATGPT_SUBSCRIPTION_SECTION}
           .auth=${this.chatgptAuth}
+          .contextWindow=${this.chatgptCodexContextWindow}
           .usage=${this.usage?.chatgpt ?? null}
           .now=${this.now}
         ></subscription-section>

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -70,7 +70,7 @@ export const CHATGPT_CODEX_CONTEXT_WINDOW_SETTING = Object.freeze({
   min: 1,
   max: 872_000,
   description:
-    "Input token budget for ChatGPT-subscription (Codex) routing, mirroring Codex CLI's model_context_window. The default 272,000 matches the Codex default; GPT-5.6 models accept up to 872,000. TeXRA adds the model's output budget when displaying the total context window. The OpenAI backend enforces the real per-account limit — values above what your subscription allows fail and trigger compaction recovery.",
+    "Input token budget for ChatGPT-subscription (Codex) routing, mirroring Codex CLI's model_context_window. The default 272,000 matches the Codex default; GPT-5.6 models accept up to 872,000. Automatic compaction may run earlier according to the separate compaction threshold. TeXRA adds the model's output budget when displaying the total context window. The OpenAI backend enforces the real per-account limit — values above what your subscription allows fail and trigger compaction recovery.",
 } as const);
 
 /**

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -579,7 +579,8 @@ const CORE_SETTING_ROWS: Record<
       through:
         'packages/cli/src/commands/agentsRun.ts -> packages/cli/src/runtime/runExecution.ts -> src/agent/runtime/ModelFactory.ts -> src/agent/modelHandlers/openai/modelHandlerCodex.ts -> src/model/providerCapabilities.ts',
     }),
-    surfaces: { cliConfig: true },
+    surfaces: { settingsView: 'multi-agent', cliConfig: true },
+    onWrite: { invalidatesModelOptions: true },
   },
   'xaiGrok.preferSubscription': {
     schema: z.boolean().prefault(false),

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -579,6 +579,8 @@ const CORE_SETTING_ROWS: Record<
       through:
         'packages/cli/src/commands/agentsRun.ts -> packages/cli/src/runtime/runExecution.ts -> src/agent/runtime/ModelFactory.ts -> src/agent/modelHandlers/openai/modelHandlerCodex.ts -> src/model/providerCapabilities.ts',
     }),
+    // This bucket controls snapshot/rebroadcast routing, not tab placement;
+    // reuse it for the Subscriptions control because no subscriptions bucket exists.
     surfaces: { settingsView: 'multi-agent', cliConfig: true },
     onWrite: { invalidatesModelOptions: true },
   },

--- a/src/test-kernel/settings/SubscriptionSection.vitest.ts
+++ b/src/test-kernel/settings/SubscriptionSection.vitest.ts
@@ -117,14 +117,14 @@ describe('subscription-section provider descriptors', () => {
     >('.setting-number-input');
 
     expect(input).toBeInstanceOf(HTMLElement);
-    input!.value = '872000';
+    input!.value = '272000';
     input!.dispatchEvent(
       new Event('change', { bubbles: true, composed: true }),
     );
 
     expect(mocks.postMessage).toHaveBeenCalledWith(
       SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING,
-      { key: 'texra.chatgptCodex.contextWindow', value: 872_000 },
+      { key: 'texra.chatgptCodex.contextWindow', value: 272_000 },
     );
   });
 });

--- a/src/test-kernel/settings/SubscriptionSection.vitest.ts
+++ b/src/test-kernel/settings/SubscriptionSection.vitest.ts
@@ -22,6 +22,7 @@ import {
 type SubscriptionSectionElement = HTMLElement & {
   provider: SubscriptionSectionProvider;
   auth: SubscriptionAuthStatus | null;
+  contextWindow: number;
   updateComplete: Promise<boolean>;
 };
 
@@ -106,6 +107,24 @@ describe('subscription-section provider descriptors', () => {
     expect(mocks.postMessage).toHaveBeenCalledWith(
       SETTINGS_VIEW_COMMANDS.SET_CHATGPT_PREFER_SUBSCRIPTION,
       { enabled: true },
+    );
+  });
+
+  it('offers the longer ChatGPT context budget and writes it as a setting', async () => {
+    const element = await mount(chatgptSection, null);
+    const input = element.shadowRoot?.querySelector<
+      HTMLElement & { value: string }
+    >('.setting-number-input');
+
+    expect(input).toBeInstanceOf(HTMLElement);
+    input!.value = '872000';
+    input!.dispatchEvent(
+      new Event('change', { bubbles: true, composed: true }),
+    );
+
+    expect(mocks.postMessage).toHaveBeenCalledWith(
+      SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING,
+      { key: 'texra.chatgptCodex.contextWindow', value: 872_000 },
     );
   });
 });


### PR DESCRIPTION
## Summary

- expose the existing ChatGPT subscription input-token budget in the extension and desktop Subscriptions settings
- keep the TUI `/config` row and settings-view control on the same catalog key
- refresh model options after budget changes so displayed context updates immediately
- clarify that automatic compaction can run before the input ceiling according to the separate threshold

The default remains 272,000 input tokens. Supported GPT-5.6 models can opt into as many as 872,000 input tokens. With the default 75% compaction threshold, the old 272,000 budget compacted at about 204,000 tokens; that was proactive compaction, not a second context cap.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test` (9,907 passed, 5 skipped)
- `npm run compile:fast`
- targeted settings, provider-capability, and catalog tests (44 passed)
- `git diff --check`