### PR TITLE
fix(ui): improve file selection feedback

### DIFF
--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -416,7 +416,11 @@ export class FileSelectGroup extends LitElement {
             </span>
             <span class="file-select-label">${config.label}</span>
             <span class="file-select-count" role="status" aria-atomic="true">
-              ${formatResultCount(this.currentFiles.length, 'file')}
+              ${
+                this.currentFiles.length === 0
+                  ? nothing
+                  : formatResultCount(this.currentFiles.length, 'file')
+              }
             </span>
             ${
               config.toolConfig === 'tool'

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -19,7 +19,7 @@ import { renderIconActionButton } from '@shared/wa/actionButtons';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { getBasename, normalizeFilePath } from '@utils/core';
-import { capitalize } from '@utils/text/stringUtils';
+import { capitalize, formatResultCount } from '@utils/text/stringUtils';
 import { MainViewEvents } from '../events';
 import { FileDropController, postDroppedFiles } from '../fileDropHandler';
 import { SESSION_TYPES } from '../constants';
@@ -41,6 +41,10 @@ export class FileSelectGroup extends LitElement {
         display: block;
       }
 
+      .file-select {
+        position: relative;
+      }
+
       .file-select.drop-active {
         outline: 1px dashed var(--wa-color-brand-fill-loud);
         outline-offset: 2px;
@@ -49,6 +53,26 @@ export class FileSelectGroup extends LitElement {
           var(--wa-color-brand-fill-quiet) 22%,
           transparent
         );
+      }
+
+      .drop-cue {
+        position: absolute;
+        inset: var(--wa-space-3xs);
+        z-index: 2;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: var(--border-thin) dashed var(--wa-color-brand-fill-loud);
+        border-radius: var(--border-radius);
+        background: color-mix(
+          in srgb,
+          var(--wa-color-surface-default) 78%,
+          transparent
+        );
+        color: var(--wa-color-text-normal);
+        font-size: var(--font-size-sm);
+        font-weight: var(--font-weight-semibold);
+        pointer-events: none;
       }
     `,
   ];
@@ -263,7 +287,9 @@ export class FileSelectGroup extends LitElement {
 
   private renderFileList(): TemplateResult {
     if (this.currentFiles.length === 0) {
-      return html`<div class="file-list-placeholder">No files selected.</div>`;
+      return html`<div class="file-list-placeholder">
+        No files selected. Add or drop files here.
+      </div>`;
     }
 
     const movable = this.currentFiles.length > 1;
@@ -389,13 +415,9 @@ export class FileSelectGroup extends LitElement {
               ${waIcon(config.icon)}
             </span>
             <span class="file-select-label">${config.label}</span>
-            ${
-              this.currentFiles.length > 1
-                ? html`<span class="file-select-count">
-                    ${this.currentFiles.length} files
-                  </span>`
-                : nothing
-            }
+            <span class="file-select-count" role="status" aria-atomic="true">
+              ${formatResultCount(this.currentFiles.length, 'file')}
+            </span>
             ${
               config.toolConfig === 'tool'
                 ? this.renderToolConfigMenu()
@@ -438,6 +460,13 @@ export class FileSelectGroup extends LitElement {
             </div>
           </div>
         </div>
+        ${
+          this.fileDrop.isDragActive
+            ? html`<div class="drop-cue" aria-hidden="true">
+                Drop ${config.label.toLowerCase()} files here
+              </div>`
+            : nothing
+        }
       </div>
     `;
   }

--- a/packages/extension/src/webview/frontend/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/fileSelectStyles.ts
@@ -16,6 +16,7 @@ import { buttonStyles } from '@shared/styles/controlStyles';
 export const fileSelectLayoutStyles = css`
   .file-select {
     margin-bottom: var(--wa-space-xs);
+    container-type: inline-size;
   }
 
   .file-select-header {
@@ -93,6 +94,22 @@ export const fileSelectLayoutStyles = css`
   .file-select select,
   .file-select wa-select {
     width: 100%;
+  }
+
+  /* The action cluster has three fixed-size icon buttons. Stack it below the
+     label only once the component itself can no longer hold both groups; the
+     breakpoint follows this component in sidebars and desktop panes rather
+     than the viewport. */
+  @container (max-width: 18rem) {
+    .file-select-header {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .file-select-actions {
+      align-self: flex-end;
+      margin-inline-start: 0;
+    }
   }
 `;
 

--- a/packages/extension/src/webview/frontend/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/fileSelectStyles.ts
@@ -96,10 +96,10 @@ export const fileSelectLayoutStyles = css`
     width: 100%;
   }
 
-  /* The action cluster has three fixed-size icon buttons. Stack it below the
-     label only once the component itself can no longer hold both groups; the
-     breakpoint follows this component in sidebars and desktop panes rather
-     than the viewport. */
+  /* FileSelectGroup and LatexDiffsSection both render this shared header and
+     action structure. Stack their action clusters once each .file-select
+     container can no longer hold both groups, so sidebars and desktop panes
+     adapt independently of the viewport. */
   @container (max-width: 18rem) {
     .file-select-header {
       align-items: flex-start;


### PR DESCRIPTION
## Summary
- show explicit drag-and-drop guidance and selected-file counts
- keep the stable file-count status region silent at zero while preserving the visible empty-state guidance
- stack the shared FileSelectGroup and LatexDiffsSection header actions when their component containers become narrow

## Testing
- corepack pnpm exec prettier --check packages/extension/src/webview/frontend/components/FileSelectGroup.ts packages/extension/src/webview/frontend/fileSelectStyles.ts
- corepack pnpm exec eslint packages/extension/src/webview/frontend/components/FileSelectGroup.ts packages/extension/src/webview/frontend/fileSelectStyles.ts
- corepack pnpm run typecheck:workspace
- corepack pnpm exec vitest run src/test-kernel/webview/FileSelectGroupActions.vitest.ts src/test-kernel/webview/LatexDiffsSectionActions.vitest.ts