### PR TITLE
fix(ui): clarify generated output actions

### DIFF
--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -662,8 +662,8 @@ export class InstructionPanel extends LitElement {
                     ${renderIconActionButton({
                       id: 'cleanButton',
                       icon: 'trash',
-                      label: 'Clean output',
-                      tooltip: 'Clean the output for this agent',
+                      label: 'Delete output files',
+                      tooltip: 'Delete generated output files for this agent',
                       action: 'clean',
                     })}
                   `
@@ -764,7 +764,12 @@ export class InstructionPanel extends LitElement {
             onClick: this.handleExecute,
           })}
         </div>
-        <div class="visually-hidden" aria-live="polite">
+        <div
+          class="visually-hidden"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
           ${session.statusAnnouncement}
         </div>
       </div>

--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -102,8 +102,8 @@ const COMMIT_MANAGE_ACTIONS: readonly DiffActionSpec[] = [
   {
     id: 'cleanLatexdiffvcButton',
     icon: 'trash',
-    label: 'Clean',
-    tooltip: 'Delete the latexdiff-vc output files',
+    label: 'Delete output',
+    tooltip: 'Delete generated latexdiff-vc output files',
     action: 'cleanLatexdiffvc',
   },
 ];


### PR DESCRIPTION
## Summary
- name generated-output deletion actions explicitly
- clarify latexdiff output cleanup behavior
- make instruction status announcements atomic and reliable

## Testing
- npm run lint
- npm run typecheck:workspace
- npm run compile:fast
- npm test