### PR TITLE
fix(settings): improve navigation responsiveness

### DIFF
--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -288,7 +288,11 @@ export class SettingsApp extends SettingsAppBase {
 
     return html`
       <nav class="settings-navigation" aria-label="Settings">
-        <div class="settings-category-nav" aria-label="Settings categories">
+        <div
+          class="settings-category-nav"
+          role="group"
+          aria-label="Settings categories"
+        >
           ${SETTINGS_NAV_GROUPS.map((group) => {
             const entries = this.entriesForGroup(group, goalSupported);
             if (entries.length === 0) return nothing;
@@ -316,6 +320,7 @@ export class SettingsApp extends SettingsAppBase {
              actual behavior — same pattern as the category nav above. -->
         <div
           class="settings-page-nav"
+          role="group"
           aria-label=${`${activeGroup.label} pages`}
         >
           ${activeEntries.map((entry) => {

--- a/packages/extension/src/settingsView/frontend/components/shared/Pagination.ts
+++ b/packages/extension/src/settingsView/frontend/components/shared/Pagination.ts
@@ -53,12 +53,13 @@ export class Pagination extends LitElement {
 
       .pagination-bar {
         display: flex;
+        flex-wrap: wrap;
         align-items: center;
         justify-content: space-between;
+        gap: var(--wa-space-2xs);
         padding: var(--wa-space-2xs) 0;
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
-        user-select: none;
       }
 
       .pagination-status {
@@ -70,6 +71,7 @@ export class Pagination extends LitElement {
         display: flex;
         align-items: center;
         gap: var(--wa-space-2xs);
+        margin-inline-start: auto;
       }
 
       .pagination-controls wa-button::part(base) {
@@ -135,7 +137,7 @@ export class Pagination extends LitElement {
     const atLast = page >= totalPages - 1;
 
     return html`
-      <div class="pagination-bar">
+      <div class="pagination-bar" role="group" aria-label="Pagination">
         <span class="pagination-status" role="status" aria-atomic="true">
           ${this.rangeStart}–${this.rangeEnd} of ${this.totalItems}
         </span>


### PR DESCRIPTION
## Summary
- expose settings navigation strips as labeled groups
- allow pagination controls to wrap cleanly in narrow panes
- preserve selectable status text and logical alignment

## Testing
- npm run lint
- npm run typecheck:workspace
- npm run compile:fast
- npm test