### PR TITLE
fix(settings): adapt account usage layout

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/SubscriptionUsageRow.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/SubscriptionUsageRow.ts
@@ -90,6 +90,22 @@ export class SubscriptionUsageRow extends LitElement {
         color: var(--color-text-secondary);
         font-size: var(--wa-font-size-xs, 0.75rem);
       }
+
+      @container settings (max-width: 520px) {
+        .usage-window {
+          grid-template-columns: minmax(0, 1fr) auto;
+        }
+
+        .usage-window progress {
+          grid-column: 1 / -1;
+          grid-row: 2;
+        }
+
+        .usage-reset {
+          grid-column: 2;
+          grid-row: 1;
+        }
+      }
     `,
   ];
 
@@ -142,7 +158,7 @@ export class SubscriptionUsageRow extends LitElement {
                     value=${window.percentUsed}
                     aria-label="${snapshot.providerName} ${label} usage: ${percent} used"
                   ></progress>
-                  <span>${reset ?? ''}</span>
+                  <span class="usage-reset">${reset ?? ''}</span>
                 </div>
               `;
             })}

--- a/packages/extension/src/settingsView/frontend/components/profile/SubscriptionUsageRow.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/SubscriptionUsageRow.ts
@@ -96,6 +96,11 @@ export class SubscriptionUsageRow extends LitElement {
           grid-template-columns: minmax(0, 1fr) auto;
         }
 
+        .usage-summary {
+          grid-column: 1;
+          grid-row: 1;
+        }
+
         .usage-window progress {
           grid-column: 1 / -1;
           grid-row: 2;
@@ -152,7 +157,7 @@ export class SubscriptionUsageRow extends LitElement {
               );
               return html`
                 <div class="usage-window">
-                  <span>${label}: ${percent}</span>
+                  <span class="usage-summary">${label}: ${percent}</span>
                   <progress
                     max="100"
                     value=${window.percentUsed}

--- a/packages/extension/src/settingsView/frontend/tabs/AccountTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AccountTab.ts
@@ -37,6 +37,12 @@ export class AccountTab extends LitElement {
       .account-page {
         display: block;
       }
+
+      /* Stored account labels can be long email addresses. Keep them inside
+         the banner when the settings pane narrows or text is enlarged. */
+      .settings-banner-title {
+        overflow-wrap: anywhere;
+      }
     `,
   ];
 


### PR DESCRIPTION
## Summary
- keep long account labels contained at narrow widths
- move compact subscription meters to a readable two-row layout
- preserve the existing settings breakpoint and semantic tokens

## Testing
- npm run lint
- npm run typecheck:workspace
- npm run compile:fast
- npm test