### PR TITLE
fix(settings): label skill controls

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -273,7 +273,7 @@ export class ToolCard extends LitElement {
     if (!hasGuide) return nothing;
 
     // When a primary install action exists (terminal command or extension
-    // marketplace), demote auxiliary buttons (Sign in, Open Install Page)
+    // marketplace), demote auxiliary buttons (Sign in, Open install page)
     // to secondary styling.
     const hasPrimaryInstallAction = Boolean(
       this.item.installCommand || this.item.installExtensionId,
@@ -305,7 +305,7 @@ export class ToolCard extends LitElement {
                     size="s"
                     @click=${() => this.runCommand('install')}
                   >
-                    ${waIcon('terminal', { slot: 'start' })} Install in Terminal
+                    ${waIcon('terminal', { slot: 'start' })} Install in terminal
                   </wa-button>
                   <wa-tooltip for="tool-install-btn-${this.item.id}"
                     >${this.item.installCommand}</wa-tooltip
@@ -341,7 +341,7 @@ export class ToolCard extends LitElement {
                     @click=${this.handleInstallExtension}
                   >
                     ${waIcon('cloud-arrow-down', { slot: 'start' })} Install
-                    Extension
+                    extension
                   </wa-button>
                 `
               : nothing
@@ -356,7 +356,7 @@ export class ToolCard extends LitElement {
                     @click=${this.handleInstallUrl}
                   >
                     ${waIcon('arrow-up-right-from-square', { slot: 'start' })}
-                    Open Install Page
+                    Open install page
                   </wa-button>
                 `
               : nothing

--- a/packages/extension/src/settingsView/frontend/tabs/SkillsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/SkillsTab.ts
@@ -103,10 +103,7 @@ export class SkillsTab extends LitElement {
 
   private renderSkill(item: SkillDisplayItem): TemplateResult {
     const sourceEnabled = !this.disabledSources.includes(item.scope);
-    const id = `skill-${item.scope}-${item.name
-      .toLowerCase()
-      .replaceAll(/[^a-z0-9]+/g, '-')
-      .replaceAll(/^-|-$/g, '')}`;
+    const id = `skill-${item.scope}-${item.name}`;
     return html`
       <div class="settings-row">
         <div class="settings-row-text">

--- a/packages/extension/src/settingsView/frontend/tabs/SkillsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/SkillsTab.ts
@@ -72,15 +72,18 @@ export class SkillsTab extends LitElement {
 
   private renderSourceToggle(scope: ActiveSkillSourceScope): TemplateResult {
     const checked = !this.disabledSources.includes(scope);
+    const id = `skill-source-${scope}`;
     return html`
       <div class="settings-row">
         <div class="settings-row-text">
-          <span class="settings-row-label">${SOURCE_LABELS[scope]}</span>
-          <span class="settings-row-help">${scope} skill sources</span>
+          <label class="settings-row-label" for=${id}
+            >Use ${SOURCE_LABELS[scope].toLowerCase()} skills</label
+          >
+          <span class="settings-row-help">Skills from ${scope} sources.</span>
         </div>
         <div class="settings-row-control">
           <wa-switch
-            aria-label=${`${SOURCE_LABELS[scope]} skill sources`}
+            id=${id}
             .checked=${checked}
             ?disabled=${!this.masterEnabled}
             @change=${(event: Event) =>
@@ -100,16 +103,20 @@ export class SkillsTab extends LitElement {
 
   private renderSkill(item: SkillDisplayItem): TemplateResult {
     const sourceEnabled = !this.disabledSources.includes(item.scope);
+    const id = `skill-${item.scope}-${item.name
+      .toLowerCase()
+      .replaceAll(/[^a-z0-9]+/g, '-')
+      .replaceAll(/^-|-$/g, '')}`;
     return html`
       <div class="settings-row">
         <div class="settings-row-text">
-          <span class="settings-row-label">${item.name}</span>
+          <label class="settings-row-label" for=${id}>Use ${item.name}</label>
           <span class="settings-row-help">${item.description}</span>
           <span class="settings-row-help"><code>${item.path}</code></span>
         </div>
         <div class="settings-row-control">
           <wa-switch
-            aria-label=${`Enable ${item.name}`}
+            id=${id}
             .checked=${item.enabled}
             ?disabled=${!this.masterEnabled || !sourceEnabled}
             @change=${(event: Event) =>
@@ -160,7 +167,7 @@ export class SkillsTab extends LitElement {
         }
         ${
           this.skills.length === 0
-            ? html`<div class="empty-state">No skills discovered</div>`
+            ? html`<div class="empty-state">No skills found</div>`
             : ActiveSkillSourceScopeSchema.options.flatMap((scope) => {
                 const items = groups.get(scope);
                 return items


### PR DESCRIPTION
## Summary
- associate skill and source switches with visible enabled-state labels
- clarify the skills empty state
- standardize tool installation action copy

## Testing
- npm run lint
- npm run typecheck:workspace
- npm run compile:fast
- npm test