### PR TITLE
fix(ui): improve extension interface quality

### DIFF
--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -240,12 +240,13 @@ export class ProgressApp extends ProgressAppBase {
 
   private renderEmptyState(): TemplateResult {
     return html`
-      <section class="progress-empty-state">
+      <div class="progress-empty-state">
         <div class="progress-empty-panel">
           ${renderEmptyState({
             icon: 'robot',
             kicker: 'Sessions',
             title: 'No runs yet',
+            headingTag: 'h1',
             body: 'Start an agent from the New tab or Commands. Runs, streamed logs, approvals, and follow-up controls will appear here.',
             actions: [
               {
@@ -265,7 +266,7 @@ export class ProgressApp extends ProgressAppBase {
             ],
           })}
         </div>
-      </section>
+      </div>
     `;
   }
 

--- a/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
@@ -71,7 +71,7 @@ export const streamTabStyles = css`
     border: none;
     background: none;
     color: var(--wa-color-text-normal);
-    text-align: left;
+    text-align: start;
     font-family: var(--font-family);
     min-width: 0;
     overflow-x: hidden;
@@ -313,7 +313,12 @@ export const streamTabStyles = css`
 
   .tab-expand wa-icon {
     font-size: var(--font-size-xs);
-    transition: transform var(--transition-fast);
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .tab-expand wa-icon {
+      transition: transform var(--transition-fast);
+    }
   }
 
   .tab-expand[aria-expanded='true'] wa-icon {

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -240,7 +240,7 @@ class StreamTab extends LitElement {
         >
           <button
             id="stream-tab-select-button"
-            class="tab"
+            class="tab focus-ring-inset"
             data-stream=${stream.name}
             data-action="select"
             aria-label=${compactSelectLabel}

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -24,6 +24,7 @@ import {
   type StreamTabInfo,
 } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
+import { focusRingStyles } from '@shared/styles/controlStyles';
 import { isTerminalOutcomePhase } from '@shared/streams/streamStatus';
 import {
   progressHeaderStatus,
@@ -127,7 +128,7 @@ function buildTooltip(
  */
 @customElement('stream-tab')
 class StreamTab extends LitElement {
-  static override styles = [designTokens, streamTabStyles];
+  static override styles = [designTokens, focusRingStyles, streamTabStyles];
 
   @property({ attribute: false }) info!: StreamTabInfo;
   @property({ attribute: false }) status: StreamLifecycleStatus =

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -51,7 +51,7 @@ export class MemoryItem extends LitElement {
         font-size: var(--font-size);
         font-weight: var(--font-weight-medium);
         color: var(--wa-color-text-link);
-        word-break: break-all;
+        overflow-wrap: anywhere;
       }
 
       .memory-contents {
@@ -60,7 +60,7 @@ export class MemoryItem extends LitElement {
 
       .memory-preview {
         font-size: var(--font-size-sm);
-        line-height: var(--line-height-tight, 1.3);
+        line-height: var(--line-height-relaxed, 1.5);
         padding: var(--wa-space-3xs) var(--wa-space-2xs);
         border-radius: var(--border-radius);
         margin: 0;
@@ -253,7 +253,7 @@ export class MemoryItem extends LitElement {
     if (item.preview === undefined) {
       return item.previewError === true
         ? html`<em class="text-secondary">Unable to load contents.</em>`
-        : html`<em class="text-secondary">Loading contents...</em>`;
+        : html`<em class="text-secondary">Loading contents…</em>`;
     }
     if (!item.preview.trim()) {
       return html`<em class="text-secondary">This note is empty.</em>`;

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryList.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryList.ts
@@ -86,7 +86,7 @@ export class MemoryList extends LitElement {
     if (!this.items.length) {
       return renderEmptyState({
         icon: 'database',
-        title: 'No saved memories yet.',
+        title: 'No saved memories yet',
         body: 'Memories are created automatically when the assistant learns something worth remembering across conversations.',
         headingTag: 'h3',
         className: 'empty-state',

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.styles.ts
@@ -146,10 +146,12 @@ export const agentSelectionPanelStyles: CSSResult = css`
   }
 
   .agent-detail-name {
+    margin: 0;
     font-size: var(--font-size-lg);
     font-weight: var(--font-weight-semibold);
     font-family: var(--wa-font-family-mono);
     color: var(--wa-color-text-normal);
+    line-height: var(--line-height-tight);
   }
 
   .agent-detail-description {
@@ -202,6 +204,7 @@ export const agentSelectionPanelStyles: CSSResult = css`
     justify-content: space-between;
     padding: var(--wa-space-2xs) var(--wa-space-xs);
     font-size: var(--font-size-xs);
+    font-variant-numeric: tabular-nums;
     color: var(--color-text-secondary);
     background: var(--wa-color-surface-default);
   }

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -406,7 +406,7 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
     return html`
       <div class="agent-detail-pane">
         <div class="agent-detail-header">
-          <h2 class="agent-detail-name">${agent.name}</h2>
+          <h3 class="agent-detail-name">${agent.name}</h3>
           <wa-tag variant="neutral" size="s" title="${displayName} agent"
             >${badge ? html`${waIcon(badge.icon)} ` : nothing}${displayName}</wa-tag
           >

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -264,7 +264,10 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
                         @click=${() => this.handleSetAllEnabled(source, true)}
                         title="Show all ${sourceName} agents"
                       >
-                        All
+                        Show all
+                        <span class="visually-hidden"
+                          >${sourceName} agents</span
+                        >
                       </wa-button>`
                     : nothing
                 }
@@ -277,7 +280,10 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
                         @click=${() => this.handleSetAllEnabled(source, false)}
                         title="Hide all ${sourceName} agents"
                       >
-                        None
+                        Hide all
+                        <span class="visually-hidden"
+                          >${sourceName} agents</span
+                        >
                       </wa-button>`
                     : nothing
                 }
@@ -400,7 +406,7 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
     return html`
       <div class="agent-detail-pane">
         <div class="agent-detail-header">
-          <span class="agent-detail-name">${agent.name}</span>
+          <h3 class="agent-detail-name">${agent.name}</h3>
           <wa-tag variant="neutral" size="s" title="${displayName} agent"
             >${badge ? html`${waIcon(badge.icon)} ` : nothing}${displayName}</wa-tag
           >
@@ -422,7 +428,7 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
         }
 
         <div class="agent-detail-meta">
-          <span class="agent-detail-meta-label">Available</span>
+          <span class="agent-detail-meta-label">Shown in agent selector</span>
           <span class="agent-detail-meta-value">
             ${agent.enabled ? 'Yes' : 'No'}
           </span>

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -406,7 +406,7 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
     return html`
       <div class="agent-detail-pane">
         <div class="agent-detail-header">
-          <h3 class="agent-detail-name">${agent.name}</h3>
+          <h2 class="agent-detail-name">${agent.name}</h2>
           <wa-tag variant="neutral" size="s" title="${displayName} agent"
             >${badge ? html`${waIcon(badge.icon)} ` : nothing}${displayName}</wa-tag
           >

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.styles.ts
@@ -22,7 +22,7 @@ export const modelSelectionListStyles: CSSResult = css`
     margin-bottom: var(--wa-space-s);
   }
 
-  .helper-model-row label {
+  .helper-model-label {
     font-weight: var(--font-weight-medium);
     color: var(--wa-color-text-normal);
     white-space: nowrap;
@@ -194,7 +194,7 @@ export const modelSelectionListStyles: CSSResult = css`
       flex-direction: column;
     }
 
-    .helper-model-row label {
+    .helper-model-label {
       white-space: normal;
     }
 

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.styles.ts
@@ -188,6 +188,20 @@ export const modelSelectionListStyles: CSSResult = css`
   }
 
   @container settings (max-width: 520px) {
+    .helper-model-row,
+    .short-names-toggle {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .helper-model-row label {
+      white-space: normal;
+    }
+
+    .helper-model-select {
+      max-width: none;
+    }
+
     .model-row {
       flex-wrap: wrap;
     }

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -134,11 +134,13 @@ export class ModelSelectionList extends LitElement {
       <wa-select
         class="reasoning-level-select"
         .value=${currentValue}
-        aria-label=${`Reasoning level for ${model.label}`}
         title="Reasoning level"
         ?disabled=${model.disabled}
         @change=${(e: Event) => this.handleReasoningLevelChange(model.name, e)}
       >
+        <span slot="label" class="visually-hidden"
+          >Reasoning level for ${model.label}</span
+        >
         <wa-option value=""> ${defaultLabel} </wa-option>
         ${REASONING_LEVEL_OPTIONS.filter(
           (option) =>
@@ -342,14 +344,21 @@ export class ModelSelectionList extends LitElement {
 
     return html`
       <div class="helper-model-row">
-        <label for="helper-model-select">Model for quick fixes</label>
+        <span class="helper-model-label" aria-hidden="true"
+          >Model for quick fixes</span
+        >
         <wa-select
           id="helper-model-select"
           class="helper-model-select form-control-fill"
-          aria-describedby="helper-model-help"
           .value=${this.helperModel}
           @change=${this.handleHelperModelChange}
         >
+          <span slot="label" class="visually-hidden"
+            >Model for quick fixes</span
+          >
+          <span slot="hint" class="visually-hidden"
+            >Used for quick background tasks, such as intelligent merge.</span
+          >
           ${helperOptions.map(
             (m) => html`
               <wa-option value=${m.name}>
@@ -358,7 +367,7 @@ export class ModelSelectionList extends LitElement {
             `,
           )}
         </wa-select>
-        <span id="helper-model-help" class="helper-model-help">
+        <span class="helper-model-help" aria-hidden="true">
           Used for quick background tasks, such as intelligent merge.
         </span>
       </div>
@@ -379,7 +388,6 @@ export class ModelSelectionList extends LitElement {
         ${this.renderHelperModelDropdown()}
         <div class="short-names-toggle">
           <wa-switch
-            aria-describedby="short-names-description"
             ?checked=${this.preferShortModelNames}
             @change=${(e: Event) => {
               const enabled = (e.target as WaSwitch).checked;
@@ -390,8 +398,12 @@ export class ModelSelectionList extends LitElement {
             }}
           >
             Use short model names
+            <span slot="hint" class="visually-hidden"
+              >Use unpinned names, such as gpt-5.5 instead of
+              gpt-5.5-2026-04-15.</span
+            >
           </wa-switch>
-          <span id="short-names-description" class="short-names-description">
+          <span class="short-names-description" aria-hidden="true">
             Use unpinned names, such as gpt-5.5 instead of gpt-5.5-2026-04-15.
           </span>
         </div>

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -134,6 +134,7 @@ export class ModelSelectionList extends LitElement {
       <wa-select
         class="reasoning-level-select"
         .value=${currentValue}
+        aria-label=${`Reasoning level for ${model.label}`}
         title="Reasoning level"
         ?disabled=${model.disabled}
         @change=${(e: Event) => this.handleReasoningLevelChange(model.name, e)}
@@ -345,6 +346,7 @@ export class ModelSelectionList extends LitElement {
         <wa-select
           id="helper-model-select"
           class="helper-model-select form-control-fill"
+          aria-describedby="helper-model-help"
           .value=${this.helperModel}
           @change=${this.handleHelperModelChange}
         >
@@ -356,8 +358,8 @@ export class ModelSelectionList extends LitElement {
             `,
           )}
         </wa-select>
-        <span class="helper-model-help">
-          Used for quick background jobs (e.g. intelligent merge).
+        <span id="helper-model-help" class="helper-model-help">
+          Used for quick background tasks, such as intelligent merge.
         </span>
       </div>
     `;
@@ -371,12 +373,13 @@ export class ModelSelectionList extends LitElement {
         ${renderSettingsSectionHeading({
           title: 'Model selection',
           description:
-            'Choose the models exposed to agents, plus the cheaper model used for quick background tasks.',
+            'Choose which models agents can use and the model used for quick background tasks.',
           icon: 'server',
         })}
         ${this.renderHelperModelDropdown()}
         <div class="short-names-toggle">
           <wa-switch
+            aria-describedby="short-names-description"
             ?checked=${this.preferShortModelNames}
             @change=${(e: Event) => {
               const enabled = (e.target as WaSwitch).checked;
@@ -388,8 +391,8 @@ export class ModelSelectionList extends LitElement {
           >
             Use short model names
           </wa-switch>
-          <span class="short-names-description">
-            Send unpinned names (e.g. gpt-5.5 instead of gpt-5.5-2026-04-15)
+          <span id="short-names-description" class="short-names-description">
+            Use unpinned names, such as gpt-5.5 instead of gpt-5.5-2026-04-15.
           </span>
         </div>
         <div class="settings-disclosure-list">

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -115,7 +115,6 @@ export class ProviderKeyList extends LitElement {
     const streamingToggle = html`
       <div class="provider-setting">
         <wa-switch
-          aria-label=${`Streaming for ${entry.displayName}`}
           ?checked=${entry.streaming}
           @change=${(e: Event) => {
             const checked = (e.target as WaSwitch).checked;
@@ -124,6 +123,7 @@ export class ProviderKeyList extends LitElement {
           }}
         >
           Streaming
+          <span class="visually-hidden">for ${entry.displayName}</span>
         </wa-switch>
       </div>
     `;

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -115,6 +115,7 @@ export class ProviderKeyList extends LitElement {
     const streamingToggle = html`
       <div class="provider-setting">
         <wa-switch
+          aria-label=${`Streaming for ${entry.displayName}`}
           ?checked=${entry.streaming}
           @change=${(e: Event) => {
             const checked = (e.target as WaSwitch).checked;
@@ -226,7 +227,7 @@ export class ProviderKeyList extends LitElement {
     const rows = resolveProviderKeyRows(this.providerKeyStatuses);
 
     const description =
-      "Except for Codex models through the ChatGPT subscription section above, chat subscriptions do not include API access. Use a key from the provider's developer console.";
+      "Chat subscriptions do not include API access. Codex models connected through ChatGPT are the exception. Add keys from each provider's developer console.";
 
     return html`
       <div class="provider-keys-section">

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
@@ -156,11 +156,20 @@ export class ProviderKeyModal extends LitElement {
               type="password"
               autocomplete="off"
               spellcheck="false"
+              aria-invalid=${String(Boolean(this.error))}
+              aria-describedby="provider-key-error"
               .value=${this.value}
               @input=${this.handleInput}
             ></wa-input>
           </label>
-          <p class="provider-key-error" aria-live="polite">${this.error}</p>
+          <p
+            id="provider-key-error"
+            class="provider-key-error"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            ${this.error}
+          </p>
         </form>
         <div slot="footer" class="provider-key-actions">
           <wa-button

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
@@ -50,10 +50,12 @@ export class ProviderKeyModal extends LitElement {
       }
 
       .provider-key-error {
+        display: block;
         min-height: 1.4em;
         margin: var(--wa-space-2xs) 0 0;
         color: var(--wa-color-danger-on-quiet, var(--color-error));
         font-size: var(--font-size-sm);
+        font-weight: var(--font-weight-normal, 400);
       }
 
       .provider-key-actions {
@@ -88,6 +90,11 @@ export class ProviderKeyModal extends LitElement {
     }
   }
 
+  private setError(message: string, input = this.keyInput): void {
+    this.error = message;
+    input?.setCustomValidity(message);
+  }
+
   private close(): void {
     this.dialogOpen = false;
   }
@@ -102,14 +109,15 @@ export class ProviderKeyModal extends LitElement {
       return;
     }
     this.clearSecretValue();
-    this.error = '';
+    this.setError('');
     this.dispatchEvent(createEvent('provider-key-cancel'));
   }
 
   private handleInput(event: Event): void {
-    this.value = (event.target as WaInput).value ?? '';
+    const input = event.target as WaInput;
+    this.value = input.value ?? '';
     if (this.error) {
-      this.error = '';
+      this.setError('', input);
     }
   }
 
@@ -117,13 +125,13 @@ export class ProviderKeyModal extends LitElement {
     event.preventDefault();
     const apiKey = this.value.trim();
     if (!apiKey) {
-      this.error = 'Enter an API key before saving.';
+      this.setError('Enter an API key before saving.');
       this.keyInput?.focus();
       return;
     }
 
     this.clearSecretValue();
-    this.error = '';
+    this.setError('');
     this.suppressCancel = true;
     this.dispatchEvent(
       createEvent('provider-key-submit', {
@@ -149,27 +157,25 @@ export class ProviderKeyModal extends LitElement {
             The key is stored by TeXRA on this device and is not shown again
             after saving.
           </p>
-          <label class="provider-key-label">
-            ${displayName} API key
+          <div class="provider-key-label">
             <wa-input
               class="provider-key-input"
               type="password"
               autocomplete="off"
               spellcheck="false"
-              aria-invalid=${String(Boolean(this.error))}
-              aria-describedby="provider-key-error"
               .value=${this.value}
               @input=${this.handleInput}
-            ></wa-input>
-          </label>
-          <p
-            id="provider-key-error"
-            class="provider-key-error"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            ${this.error}
-          </p>
+            >
+              <span slot="label">${displayName} API key</span>
+              <span
+                slot="hint"
+                class="provider-key-error"
+                aria-live="polite"
+                aria-atomic="true"
+                >${this.error}</span
+              >
+            </wa-input>
+          </div>
         </form>
         <div slot="footer" class="provider-key-actions">
           <wa-button

--- a/packages/extension/src/settingsView/frontend/components/profile/SubscriptionUsageRow.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/SubscriptionUsageRow.ts
@@ -90,6 +90,22 @@ export class SubscriptionUsageRow extends LitElement {
         color: var(--color-text-secondary);
         font-size: var(--wa-font-size-xs, 0.75rem);
       }
+
+      @container settings (max-width: 520px) {
+        .usage-window {
+          grid-template-columns: minmax(0, 1fr) auto;
+        }
+
+        .usage-window progress {
+          grid-column: 1 / -1;
+          grid-row: 2;
+        }
+
+        .usage-reset {
+          grid-column: 2;
+          grid-row: 1;
+        }
+      }
     `,
   ];
 
@@ -142,7 +158,7 @@ export class SubscriptionUsageRow extends LitElement {
                     value=${window.percentUsed}
                     aria-label="${snapshot.providerName} ${label} usage: ${percent} used"
                   ></progress>
-                  <span>${reset ?? ''}</span>
+                  <span class="usage-reset">${reset ?? ''}</span>
                 </div>
               `;
             })}

--- a/packages/extension/src/settingsView/frontend/components/profile/SubscriptionUsageRow.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/SubscriptionUsageRow.ts
@@ -96,6 +96,11 @@ export class SubscriptionUsageRow extends LitElement {
           grid-template-columns: minmax(0, 1fr) auto;
         }
 
+        .usage-summary {
+          grid-column: 1;
+          grid-row: 1;
+        }
+
         .usage-window progress {
           grid-column: 1 / -1;
           grid-row: 2;
@@ -152,7 +157,7 @@ export class SubscriptionUsageRow extends LitElement {
               );
               return html`
                 <div class="usage-window">
-                  <span>${label}: ${percent}</span>
+                  <span class="usage-summary">${label}: ${percent}</span>
                   <progress
                     max="100"
                     value=${window.percentUsed}

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -273,7 +273,7 @@ export class ToolCard extends LitElement {
     if (!hasGuide) return nothing;
 
     // When a primary install action exists (terminal command or extension
-    // marketplace), demote auxiliary buttons (Sign in, Open Install Page)
+    // marketplace), demote auxiliary buttons (Sign in, Open install page)
     // to secondary styling.
     const hasPrimaryInstallAction = Boolean(
       this.item.installCommand || this.item.installExtensionId,
@@ -305,7 +305,7 @@ export class ToolCard extends LitElement {
                     size="s"
                     @click=${() => this.runCommand('install')}
                   >
-                    ${waIcon('terminal', { slot: 'start' })} Install in Terminal
+                    ${waIcon('terminal', { slot: 'start' })} Install in terminal
                   </wa-button>
                   <wa-tooltip for="tool-install-btn-${this.item.id}"
                     >${this.item.installCommand}</wa-tooltip
@@ -341,7 +341,7 @@ export class ToolCard extends LitElement {
                     @click=${this.handleInstallExtension}
                   >
                     ${waIcon('cloud-arrow-down', { slot: 'start' })} Install
-                    Extension
+                    extension
                   </wa-button>
                 `
               : nothing
@@ -356,7 +356,7 @@ export class ToolCard extends LitElement {
                     @click=${this.handleInstallUrl}
                   >
                     ${waIcon('arrow-up-right-from-square', { slot: 'start' })}
-                    Open Install Page
+                    Open install page
                   </wa-button>
                 `
               : nothing

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -72,6 +72,7 @@ export class AIAgentsTab extends LitElement {
         align-items: center;
         gap: var(--wa-space-2xs);
         white-space: nowrap;
+        font-variant-numeric: tabular-nums;
       }
 
       .ai-agents-status-stat wa-icon {
@@ -230,8 +231,8 @@ export class AIAgentsTab extends LitElement {
           counts['not-found'] > 0
             ? html`
                 <span class="ai-agents-status-stat ai-agents-status-missing">
-                  ${waIcon('triangle-exclamation')} ${counts['not-found']} need
-                  setup
+                  ${waIcon('triangle-exclamation')} ${counts['not-found']}
+                  ${counts['not-found'] === 1 ? 'needs' : 'need'} setup
                 </span>
               `
             : nothing

--- a/packages/extension/src/settingsView/frontend/tabs/AccountTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AccountTab.ts
@@ -37,6 +37,12 @@ export class AccountTab extends LitElement {
       .account-page {
         display: block;
       }
+
+      /* Stored account labels can be long email addresses. Keep them inside
+         the banner when the settings pane narrows or text is enlarged. */
+      .settings-banner-title {
+        overflow-wrap: anywhere;
+      }
     `,
   ];
 

--- a/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -181,7 +181,7 @@ export class AgentsTab extends UnsupportedCommandsMixin(LitElement) {
       ? html`
           ${renderLabeledActionButton({
             icon: 'file-circle-plus',
-            text: 'From template',
+            text: 'Create from template',
             kind: 'secondary',
             appearance: 'outlined',
             onClick: () => this.handleCreateAgent(category, true),
@@ -257,6 +257,7 @@ export class AgentsTab extends UnsupportedCommandsMixin(LitElement) {
               })}
               ${renderLabeledActionButton({
                 text: 'Change',
+                label: 'Change custom agents folder',
                 kind: 'secondary',
                 appearance: 'outlined',
                 onClick: () => this.handleChangeCustomDir(),
@@ -267,6 +268,7 @@ export class AgentsTab extends UnsupportedCommandsMixin(LitElement) {
                   : renderLabeledActionButton({
                       icon: 'arrow-rotate-left',
                       text: 'Reset',
+                      label: 'Reset custom agents folder',
                       kind: 'secondary',
                       appearance: 'outlined',
                       onClick: () => this.handleResetCustomDir(),

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -411,7 +411,6 @@ export class GitTab extends UnsupportedCommandsMixin(LitElement) {
                       <wa-input
                         id="git-author-email"
                         class="form-control-fill"
-                        type="email"
                         name="git-author-email"
                         autocomplete="email"
                         spellcheck="false"

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -256,7 +256,7 @@ export class GitTab extends UnsupportedCommandsMixin(LitElement) {
                         this.githubTokenStatus === 'secret'
                           ? renderLabeledActionButton({
                               icon: 'trash',
-                              text: 'Remove',
+                              text: 'Remove token',
                               kind: 'danger',
                               onClick: this.handleRemoveGitHubToken,
                             })
@@ -275,7 +275,7 @@ export class GitTab extends UnsupportedCommandsMixin(LitElement) {
                     <strong>How to get a token:</strong>
                     <ol>
                       <li>
-                        Click <em>Create on GitHub…</em> to open the
+                        Select <em>Create on GitHub…</em> to open the
                         token-creation page in your browser.
                       </li>
                       <li>
@@ -284,7 +284,7 @@ export class GitTab extends UnsupportedCommandsMixin(LitElement) {
                         usage; no write scopes needed.
                       </li>
                       <li>
-                        Pick an expiration (90 days is common) and click
+                        Pick an expiration (90 days is common) and select
                         <em>Generate token</em>.
                       </li>
                       <li>
@@ -363,7 +363,7 @@ export class GitTab extends UnsupportedCommandsMixin(LitElement) {
                           </div>
                           ${renderLabeledActionButton({
                             icon: 'circle-stop',
-                            text: 'Stop',
+                            text: 'Stop monitoring',
                             kind: 'secondary',
                             appearance: 'outlined',
                             onClick: () =>
@@ -399,6 +399,8 @@ export class GitTab extends UnsupportedCommandsMixin(LitElement) {
                       <wa-input
                         id="git-author-name"
                         class="form-control-fill"
+                        name="git-author-name"
+                        autocomplete="name"
                         .value=${this.authorName}
                         placeholder=${DEFAULT_GIT_AUTHOR_NAME}
                         @change=${this.handleAuthorNameChange}
@@ -409,6 +411,10 @@ export class GitTab extends UnsupportedCommandsMixin(LitElement) {
                       <wa-input
                         id="git-author-email"
                         class="form-control-fill"
+                        type="email"
+                        name="git-author-email"
+                        autocomplete="email"
+                        spellcheck="false"
                         .value=${this.authorEmail}
                         placeholder=${DEFAULT_GIT_AUTHOR_EMAIL}
                         @change=${this.handleAuthorEmailChange}

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.styles.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.styles.ts
@@ -121,6 +121,22 @@ export const latexTabStyles: CSSResult = css`
     min-width: 180px;
   }
 
+  /* These Web Awesome slots name and describe the inner native controls.
+     The same copy already renders in the row's visible text column. */
+  .setting-control-metadata::part(form-control-label),
+  .setting-control-metadata::part(label),
+  .setting-control-metadata::part(hint) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+
   .replacement-groups-row,
   .replacement-map-row {
     align-items: flex-start;

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -694,38 +694,36 @@ export class LaTeXTab extends LitElement {
     const isCustom = Object.keys(value).length > 0;
     const error = this.replacementJsonErrors[opts.field];
     const controlId = `latex-setting-${opts.field}`;
-    const descriptionId = `${controlId}-description`;
-    const errorId = `${controlId}-error`;
     return html`
       <div class="settings-row replacement-map-row">
         <div class="settings-row-text">
           <label class="settings-row-label" for=${controlId}
             >${opts.label}</label
           >
-          <span id=${descriptionId} class="settings-row-help"
-            >${opts.description}</span
-          >
+          <span class="settings-row-help">${opts.description}</span>
           <wa-textarea
             id=${controlId}
+            class="setting-control-metadata"
             rows="4"
             resize="auto"
             spellcheck="false"
-            aria-invalid=${error ? 'true' : 'false'}
-            aria-describedby=${
-              error ? `${descriptionId} ${errorId}` : descriptionId
-            }
             .value=${JSON.stringify(value, null, 2)}
             @change=${(event: Event) =>
               this.handleCustomReplacementChange(
                 opts.field,
-                (event.target as WaTextarea).value ?? '',
+                event.target as WaTextarea,
               )}
-          ></wa-textarea>
+          >
+            <span slot="label" class="visually-hidden">${opts.label}</span>
+            <span slot="hint" class="visually-hidden"
+              >${
+                error ? `${opts.description} ${error}` : opts.description
+              }</span
+            >
+          </wa-textarea>
           ${
             error
-              ? html`<span id=${errorId} class="replacement-json-error"
-                  >${error}</span
-                >`
+              ? html`<span class="replacement-json-error">${error}</span>`
               : nothing
           }
         </div>
@@ -739,15 +737,18 @@ export class LaTeXTab extends LitElement {
 
   private handleCustomReplacementChange(
     field: 'customReplacements' | 'customReplacementsRegex',
-    source: string,
+    control: WaTextarea,
   ): void {
+    const source = control.value ?? '';
     let parsed: unknown;
     try {
       parsed = JSON.parse(source);
     } catch (error) {
+      const message = error instanceof Error ? error.message : 'Invalid JSON.';
+      control.setCustomValidity(message);
       this.replacementJsonErrors = {
         ...this.replacementJsonErrors,
-        [field]: error instanceof Error ? error.message : 'Invalid JSON.',
+        [field]: message,
       };
       return;
     }
@@ -760,12 +761,15 @@ export class LaTeXTab extends LitElement {
     }
     const result = entry.schema.safeParse(parsed);
     if (!result.success) {
+      const message = 'Enter a JSON object with string values.';
+      control.setCustomValidity(message);
       this.replacementJsonErrors = {
         ...this.replacementJsonErrors,
-        [field]: 'Enter a JSON object with string values.',
+        [field]: message,
       };
       return;
     }
+    control.setCustomValidity('');
     this.replacementJsonErrors = {
       ...this.replacementJsonErrors,
       [field]: undefined,
@@ -884,16 +888,13 @@ export class LaTeXTab extends LitElement {
     control: TemplateResult;
     reset: TemplateResult | typeof nothing;
   }): TemplateResult {
-    const descriptionId = `${opts.controlId}-description`;
     return html`
       <div class="settings-row">
         <div class="settings-row-text">
           <label class="settings-row-label" for=${opts.controlId}
             >${opts.label}</label
           >
-          <span id=${descriptionId} class="settings-row-help"
-            >${opts.description}</span
-          >
+          <span class="settings-row-help">${opts.description}</span>
         </div>
         <div class="settings-row-control">
           ${opts.statusIcon ?? nothing} ${opts.control} ${opts.reset}
@@ -927,13 +928,16 @@ export class LaTeXTab extends LitElement {
       control: html`
         <wa-switch
           id=${controlId}
-          aria-describedby=${`${controlId}-description`}
+          class="setting-control-metadata"
           ?checked=${effective}
           @change=${(e: Event) => {
             const checked = (e.target as WaSwitch).checked;
             this.dispatchSetConfigValue(opts.field, checked);
           }}
-        ></wa-switch>
+        >
+          <span class="visually-hidden">${opts.label}</span>
+          <span slot="hint" class="visually-hidden">${opts.description}</span>
+        </wa-switch>
       `,
       reset: isCustom
         ? this.renderResetButton(opts.field, opts.defaultValue ? 'On' : 'Off')
@@ -993,7 +997,7 @@ export class LaTeXTab extends LitElement {
       control: html`
         <wa-input
           id=${controlId}
-          aria-describedby=${`${controlId}-description`}
+          class="setting-number-input setting-control-metadata"
           type="number"
           min=${opts.min}
           max=${opts.max ?? nothing}
@@ -1011,8 +1015,10 @@ export class LaTeXTab extends LitElement {
             const clamped = clampOptional(integer, opts.min, opts.max);
             this.dispatchSetConfigValue(opts.field, clamped);
           }}
-          class="setting-number-input"
-        ></wa-input>
+        >
+          <span slot="label" class="visually-hidden">${opts.label}</span>
+          <span slot="hint" class="visually-hidden">${opts.description}</span>
+        </wa-input>
       `,
       reset: isCustom
         ? this.renderResetButton(opts.field, String(opts.defaultValue))
@@ -1059,14 +1065,15 @@ export class LaTeXTab extends LitElement {
       control: html`
         <wa-select
           id=${controlId}
-          aria-describedby=${`${controlId}-description`}
+          class="setting-enum-select setting-control-metadata"
           .value=${String(effective)}
           @change=${(e: Event) => {
             const v = (e.target as WaSelect).value as LatexConfigValueFor<F>;
             this.dispatchSetConfigValue(opts.field, v);
           }}
-          class="setting-enum-select"
         >
+          <span slot="label" class="visually-hidden">${opts.label}</span>
+          <span slot="hint" class="visually-hidden">${opts.description}</span>
           ${options.map(
             (o) =>
               html`<wa-option value=${String(o.value)}>${o.label}</wa-option>`,

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -630,15 +630,24 @@ export class LaTeXTab extends LitElement {
   }): TemplateResult {
     const effective = opts.currentValue ?? opts.defaultValue;
     const enabled = new Set(effective);
+    const labelId = `latex-setting-${opts.field}-label`;
+    const descriptionId = `latex-setting-${opts.field}-description`;
     const isCustom =
       effective.length !== opts.defaultValue.length ||
       effective.some((value) => !opts.defaultValue.includes(value));
     return html`
       <div class="settings-row replacement-groups-row">
         <div class="settings-row-text">
-          <span class="settings-row-label">${opts.label}</span>
-          <span class="settings-row-help">${opts.description}</span>
-          <div class="replacement-category-grid">
+          <span id=${labelId} class="settings-row-label">${opts.label}</span>
+          <span id=${descriptionId} class="settings-row-help"
+            >${opts.description}</span
+          >
+          <div
+            class="replacement-category-grid"
+            role="group"
+            aria-labelledby=${labelId}
+            aria-describedby=${descriptionId}
+          >
             ${opts.categories.map(
               (category) => html`
                 <wa-checkbox
@@ -685,18 +694,26 @@ export class LaTeXTab extends LitElement {
     const isCustom = Object.keys(value).length > 0;
     const error = this.replacementJsonErrors[opts.field];
     const controlId = `latex-setting-${opts.field}`;
+    const descriptionId = `${controlId}-description`;
+    const errorId = `${controlId}-error`;
     return html`
       <div class="settings-row replacement-map-row">
         <div class="settings-row-text">
           <label class="settings-row-label" for=${controlId}
             >${opts.label}</label
           >
-          <span class="settings-row-help">${opts.description}</span>
+          <span id=${descriptionId} class="settings-row-help"
+            >${opts.description}</span
+          >
           <wa-textarea
             id=${controlId}
             rows="4"
             resize="auto"
             spellcheck="false"
+            aria-invalid=${error ? 'true' : 'false'}
+            aria-describedby=${
+              error ? `${descriptionId} ${errorId}` : descriptionId
+            }
             .value=${JSON.stringify(value, null, 2)}
             @change=${(event: Event) =>
               this.handleCustomReplacementChange(
@@ -706,7 +723,9 @@ export class LaTeXTab extends LitElement {
           ></wa-textarea>
           ${
             error
-              ? html`<span class="replacement-json-error">${error}</span>`
+              ? html`<span id=${errorId} class="replacement-json-error"
+                  >${error}</span
+                >`
               : nothing
           }
         </div>
@@ -865,13 +884,16 @@ export class LaTeXTab extends LitElement {
     control: TemplateResult;
     reset: TemplateResult | typeof nothing;
   }): TemplateResult {
+    const descriptionId = `${opts.controlId}-description`;
     return html`
       <div class="settings-row">
         <div class="settings-row-text">
           <label class="settings-row-label" for=${opts.controlId}
             >${opts.label}</label
           >
-          <span class="settings-row-help">${opts.description}</span>
+          <span id=${descriptionId} class="settings-row-help"
+            >${opts.description}</span
+          >
         </div>
         <div class="settings-row-control">
           ${opts.statusIcon ?? nothing} ${opts.control} ${opts.reset}
@@ -905,6 +927,7 @@ export class LaTeXTab extends LitElement {
       control: html`
         <wa-switch
           id=${controlId}
+          aria-describedby=${`${controlId}-description`}
           ?checked=${effective}
           @change=${(e: Event) => {
             const checked = (e.target as WaSwitch).checked;
@@ -970,6 +993,7 @@ export class LaTeXTab extends LitElement {
       control: html`
         <wa-input
           id=${controlId}
+          aria-describedby=${`${controlId}-description`}
           type="number"
           min=${opts.min}
           max=${opts.max ?? nothing}
@@ -1035,6 +1059,7 @@ export class LaTeXTab extends LitElement {
       control: html`
         <wa-select
           id=${controlId}
+          aria-describedby=${`${controlId}-description`}
           .value=${String(effective)}
           @change=${(e: Event) => {
             const v = (e.target as WaSelect).value as LatexConfigValueFor<F>;

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -9,7 +9,13 @@ import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
 import '@awesome.me/webawesome/dist/components/copy-button/copy-button.js';
 import '@awesome.me/webawesome/dist/components/details/details.js';
-import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  nothing,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports - shared webview
@@ -237,6 +243,21 @@ export class LaTeXTab extends LitElement {
   private replacementJsonErrors: Partial<
     Record<'customReplacements' | 'customReplacementsRegex', string>
   > = {};
+
+  protected override willUpdate(changed: PropertyValues<this>): void {
+    super.willUpdate(changed);
+    if (changed.has('configValues')) {
+      this.replacementJsonErrors = {};
+    }
+  }
+
+  protected override updated(changed: PropertyValues<this>): void {
+    super.updated(changed);
+    if (!changed.has('configValues')) return;
+
+    this.syncCustomReplacementControl('customReplacements');
+    this.syncCustomReplacementControl('customReplacementsRegex');
+  }
 
   private handleApply(field?: SettingInfo['key'], reset = false): void {
     postMessage(SETTINGS_VIEW_COMMANDS.APPLY_LATEX_SETTINGS, { field, reset });
@@ -732,13 +753,44 @@ export class LaTeXTab extends LitElement {
           ${
             isCustom
               ? this.renderResetButton(opts.field, '{}', () =>
-                  this.resetCustomReplacement(opts.field, controlId),
+                  this.clearCustomReplacementError(opts.field, '{}'),
                 )
               : nothing
           }
         </div>
       </div>
     `;
+  }
+
+  private syncCustomReplacementControl(
+    field: 'customReplacements' | 'customReplacementsRegex',
+  ): void {
+    const control = this.shadowRoot?.querySelector<WaTextarea>(
+      `#latex-setting-${field}`,
+    );
+    if (!control) return;
+
+    control.value = JSON.stringify(this.configValues[field] ?? {}, null, 2);
+    control.setCustomValidity('');
+  }
+
+  private clearCustomReplacementError(
+    field: 'customReplacements' | 'customReplacementsRegex',
+    source?: string,
+  ): void {
+    const control = this.shadowRoot?.querySelector<WaTextarea>(
+      `#latex-setting-${field}`,
+    );
+    if (control) {
+      if (source !== undefined) control.value = source;
+      control.setCustomValidity('');
+    }
+    if (this.replacementJsonErrors[field] === undefined) return;
+
+    this.replacementJsonErrors = {
+      ...this.replacementJsonErrors,
+      [field]: undefined,
+    };
   }
 
   private handleCustomReplacementChange(
@@ -784,20 +836,6 @@ export class LaTeXTab extends LitElement {
       field,
       result.data as LatexConfigValueFor<typeof field>,
     );
-  }
-
-  private resetCustomReplacement(
-    field: 'customReplacements' | 'customReplacementsRegex',
-    controlId: string,
-  ): void {
-    this.renderRoot
-      .querySelector<WaTextarea>(`#${controlId}`)
-      ?.setCustomValidity('');
-    this.replacementJsonErrors = {
-      ...this.replacementJsonErrors,
-      [field]: undefined,
-    };
-    this.dispatchSetConfigValue(field, undefined);
   }
 
   private dispatchSetConfigValue<F extends LatexConfigField>(
@@ -985,7 +1023,7 @@ export class LaTeXTab extends LitElement {
   private renderResetButton(
     field: LatexConfigField,
     defaultDisplay: string,
-    onReset = (): void => this.dispatchSetConfigValue(field, undefined),
+    beforeReset?: () => void,
   ): TemplateResult {
     return renderLabeledActionButton({
       icon: 'arrow-rotate-left',
@@ -994,7 +1032,10 @@ export class LaTeXTab extends LitElement {
       appearance: 'outlined',
       label: 'Reset to default',
       title: `Reset to default (${defaultDisplay})`,
-      onClick: onReset,
+      onClick: () => {
+        beforeReset?.();
+        this.dispatchSetConfigValue(field, undefined);
+      },
     });
   }
 

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -729,7 +729,13 @@ export class LaTeXTab extends LitElement {
         </div>
         <div class="settings-row-control">
           ${this.renderSettingStatusIcon(isCustom)}
-          ${isCustom ? this.renderResetButton(opts.field, '{}') : nothing}
+          ${
+            isCustom
+              ? this.renderResetButton(opts.field, '{}', () =>
+                  this.resetCustomReplacement(opts.field, controlId),
+                )
+              : nothing
+          }
         </div>
       </div>
     `;
@@ -778,6 +784,20 @@ export class LaTeXTab extends LitElement {
       field,
       result.data as LatexConfigValueFor<typeof field>,
     );
+  }
+
+  private resetCustomReplacement(
+    field: 'customReplacements' | 'customReplacementsRegex',
+    controlId: string,
+  ): void {
+    this.renderRoot
+      .querySelector<WaTextarea>(`#${controlId}`)
+      ?.setCustomValidity('');
+    this.replacementJsonErrors = {
+      ...this.replacementJsonErrors,
+      [field]: undefined,
+    };
+    this.dispatchSetConfigValue(field, undefined);
   }
 
   private dispatchSetConfigValue<F extends LatexConfigField>(
@@ -965,6 +985,7 @@ export class LaTeXTab extends LitElement {
   private renderResetButton(
     field: LatexConfigField,
     defaultDisplay: string,
+    onReset = (): void => this.dispatchSetConfigValue(field, undefined),
   ): TemplateResult {
     return renderLabeledActionButton({
       icon: 'arrow-rotate-left',
@@ -973,7 +994,7 @@ export class LaTeXTab extends LitElement {
       appearance: 'outlined',
       label: 'Reset to default',
       title: `Reset to default (${defaultDisplay})`,
-      onClick: () => this.dispatchSetConfigValue(field, undefined),
+      onClick: onReset,
     });
   }
 

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -247,6 +247,7 @@ export class MultiAgentTab extends LitElement {
         class=${classMap({ 'preset-card': true, active: isActive })}
         role="button"
         tabindex="0"
+        aria-current=${isActive ? 'true' : nothing}
         @click=${() => this.handlePresetClick(preset)}
         @keydown=${(e: KeyboardEvent) => this.handlePresetKey(e, preset)}
         title="Apply ${preset.name} team"
@@ -304,7 +305,7 @@ export class MultiAgentTab extends LitElement {
           deletable
             ? renderIconActionButton({
                 icon: 'trash',
-                label: 'Delete team',
+                label: `Delete ${preset.name} team`,
                 className: 'preset-delete-btn',
                 onClick: (e) => this.handleDeletePreset(e, preset),
               })

--- a/packages/extension/src/settingsView/frontend/tabs/ShortcutsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ShortcutsTab.ts
@@ -107,6 +107,8 @@ export class ShortcutsTab extends LitElement {
   private handleSearch(event: Event): void {
     const input = event.target as HTMLInputElement | null;
     this.query = input?.value ?? '';
+    this.feedback = '';
+    this.feedbackIsError = false;
   }
 
   private startRecording(id: string): void {
@@ -234,6 +236,12 @@ export class ShortcutsTab extends LitElement {
   override render(): TemplateResult {
     const entries = this.visibleEntries();
     const groups = groupBy(entries, (entry) => entry.category);
+    const query = this.query.trim();
+    const feedback =
+      this.feedback ||
+      (query
+        ? `${entries.length} matching ${entries.length === 1 ? 'shortcut' : 'shortcuts'}.`
+        : '');
     return html`
       <div class="tab-content-container">
         ${renderSettingsBanner({
@@ -262,13 +270,13 @@ export class ShortcutsTab extends LitElement {
           role="status"
           data-error=${String(this.feedbackIsError)}
         >
-          ${this.feedback || nothing}
+          ${feedback || nothing}
         </p>
         ${
           entries.length === 0
             ? renderEmptyState({
                 icon: 'magnifying-glass',
-                title: 'No matching commands.',
+                title: 'No matching commands',
                 body: 'Try a different search term.',
                 headingTag: 'h3',
                 className: 'empty-state',

--- a/packages/extension/src/settingsView/frontend/tabs/SkillsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/SkillsTab.ts
@@ -103,10 +103,7 @@ export class SkillsTab extends LitElement {
 
   private renderSkill(item: SkillDisplayItem): TemplateResult {
     const sourceEnabled = !this.disabledSources.includes(item.scope);
-    const id = `skill-${item.scope}-${item.name
-      .toLowerCase()
-      .replaceAll(/[^a-z0-9]+/g, '-')
-      .replaceAll(/^-|-$/g, '')}`;
+    const id = `skill-${item.scope}-${item.name}`;
     return html`
       <div class="settings-row">
         <div class="settings-row-text">

--- a/packages/extension/src/settingsView/frontend/tabs/SkillsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/SkillsTab.ts
@@ -72,15 +72,18 @@ export class SkillsTab extends LitElement {
 
   private renderSourceToggle(scope: ActiveSkillSourceScope): TemplateResult {
     const checked = !this.disabledSources.includes(scope);
+    const id = `skill-source-${scope}`;
     return html`
       <div class="settings-row">
         <div class="settings-row-text">
-          <span class="settings-row-label">${SOURCE_LABELS[scope]}</span>
-          <span class="settings-row-help">${scope} skill sources</span>
+          <label class="settings-row-label" for=${id}
+            >Use ${SOURCE_LABELS[scope].toLowerCase()} skills</label
+          >
+          <span class="settings-row-help">Skills from ${scope} sources.</span>
         </div>
         <div class="settings-row-control">
           <wa-switch
-            aria-label=${`${SOURCE_LABELS[scope]} skill sources`}
+            id=${id}
             .checked=${checked}
             ?disabled=${!this.masterEnabled}
             @change=${(event: Event) =>
@@ -100,16 +103,20 @@ export class SkillsTab extends LitElement {
 
   private renderSkill(item: SkillDisplayItem): TemplateResult {
     const sourceEnabled = !this.disabledSources.includes(item.scope);
+    const id = `skill-${item.scope}-${item.name
+      .toLowerCase()
+      .replaceAll(/[^a-z0-9]+/g, '-')
+      .replaceAll(/^-|-$/g, '')}`;
     return html`
       <div class="settings-row">
         <div class="settings-row-text">
-          <span class="settings-row-label">${item.name}</span>
+          <label class="settings-row-label" for=${id}>Use ${item.name}</label>
           <span class="settings-row-help">${item.description}</span>
           <span class="settings-row-help"><code>${item.path}</code></span>
         </div>
         <div class="settings-row-control">
           <wa-switch
-            aria-label=${`Enable ${item.name}`}
+            id=${id}
             .checked=${item.enabled}
             ?disabled=${!this.masterEnabled || !sourceEnabled}
             @change=${(event: Event) =>
@@ -160,7 +167,7 @@ export class SkillsTab extends LitElement {
         }
         ${
           this.skills.length === 0
-            ? html`<div class="empty-state">No skills discovered</div>`
+            ? html`<div class="empty-state">No skills found</div>`
             : ActiveSkillSourceScopeSchema.options.flatMap((scope) => {
                 const items = groups.get(scope);
                 return items

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -405,6 +405,7 @@ export class MainApp extends MainAppBase {
     const setupCard =
       onboardingState === 'setup'
         ? html`<onboarding-setup-card
+            .headingLevel=${desktopHost ? 2 : 1}
             @onboarding-run-setup=${() =>
               postMessage(MAIN_VIEW_COMMANDS.ONBOARDING_RUN_SETUP)}
             @onboarding-open-getting-started=${

--- a/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
@@ -57,7 +57,7 @@ export class ApiKeyBanner extends StateVisibleBanner<ApiKeyBannerState> {
           </wa-button>
         </div>
         <span class="hint">
-          Chat subscriptions don't include API access - except Codex models
+          Chat subscriptions don't include API access — except Codex models
           through ChatGPT. For other models, use a provider developer key.
         </span>
       `,

--- a/packages/extension/src/webview/frontend/components/DependencyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/DependencyBanner.ts
@@ -85,6 +85,7 @@ export class DependencyBanner extends StateVisibleBanner<DependencyBannerState> 
                       class="dependency-install-button"
                       appearance="plain"
                       size="s"
+                      aria-label=${`Install ${this.getToolLabel(tool)}`}
                       @click=${() => this.handleInstall(tool)}
                     >
                       ${waIcon('cloud-arrow-down', { slot: 'start' })} Install

--- a/packages/extension/src/webview/frontend/components/DependencyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/DependencyBanner.ts
@@ -80,15 +80,17 @@ export class DependencyBanner extends StateVisibleBanner<DependencyBannerState> 
                 (tool) => tool,
                 (tool) => html`
                   <div class="dependency-item">
-                    <span>${this.getToolLabel(tool)}</span>
+                    <span aria-hidden="true">${this.getToolLabel(tool)}</span>
                     <wa-button
                       class="dependency-install-button"
                       appearance="plain"
                       size="s"
-                      aria-label=${`Install ${this.getToolLabel(tool)}`}
                       @click=${() => this.handleInstall(tool)}
                     >
                       ${waIcon('cloud-arrow-down', { slot: 'start' })} Install
+                      <span class="visually-hidden"
+                        >${this.getToolLabel(tool)}</span
+                      >
                     </wa-button>
                   </div>
                 `,

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -416,7 +416,11 @@ export class FileSelectGroup extends LitElement {
             </span>
             <span class="file-select-label">${config.label}</span>
             <span class="file-select-count" role="status" aria-atomic="true">
-              ${formatResultCount(this.currentFiles.length, 'file')}
+              ${
+                this.currentFiles.length === 0
+                  ? nothing
+                  : formatResultCount(this.currentFiles.length, 'file')
+              }
             </span>
             ${
               config.toolConfig === 'tool'

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -19,7 +19,7 @@ import { renderIconActionButton } from '@shared/wa/actionButtons';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { getBasename, normalizeFilePath } from '@utils/core';
-import { capitalize } from '@utils/text/stringUtils';
+import { capitalize, formatResultCount } from '@utils/text/stringUtils';
 import { MainViewEvents } from '../events';
 import { FileDropController, postDroppedFiles } from '../fileDropHandler';
 import { SESSION_TYPES } from '../constants';
@@ -41,6 +41,10 @@ export class FileSelectGroup extends LitElement {
         display: block;
       }
 
+      .file-select {
+        position: relative;
+      }
+
       .file-select.drop-active {
         outline: 1px dashed var(--wa-color-brand-fill-loud);
         outline-offset: 2px;
@@ -49,6 +53,26 @@ export class FileSelectGroup extends LitElement {
           var(--wa-color-brand-fill-quiet) 22%,
           transparent
         );
+      }
+
+      .drop-cue {
+        position: absolute;
+        inset: var(--wa-space-3xs);
+        z-index: 2;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: var(--border-thin) dashed var(--wa-color-brand-fill-loud);
+        border-radius: var(--border-radius);
+        background: color-mix(
+          in srgb,
+          var(--wa-color-surface-default) 78%,
+          transparent
+        );
+        color: var(--wa-color-text-normal);
+        font-size: var(--font-size-sm);
+        font-weight: var(--font-weight-semibold);
+        pointer-events: none;
       }
     `,
   ];
@@ -263,7 +287,9 @@ export class FileSelectGroup extends LitElement {
 
   private renderFileList(): TemplateResult {
     if (this.currentFiles.length === 0) {
-      return html`<div class="file-list-placeholder">No files selected.</div>`;
+      return html`<div class="file-list-placeholder">
+        No files selected. Add or drop files here.
+      </div>`;
     }
 
     const movable = this.currentFiles.length > 1;
@@ -389,13 +415,9 @@ export class FileSelectGroup extends LitElement {
               ${waIcon(config.icon)}
             </span>
             <span class="file-select-label">${config.label}</span>
-            ${
-              this.currentFiles.length > 1
-                ? html`<span class="file-select-count">
-                    ${this.currentFiles.length} files
-                  </span>`
-                : nothing
-            }
+            <span class="file-select-count" role="status" aria-atomic="true">
+              ${formatResultCount(this.currentFiles.length, 'file')}
+            </span>
             ${
               config.toolConfig === 'tool'
                 ? this.renderToolConfigMenu()
@@ -438,6 +460,13 @@ export class FileSelectGroup extends LitElement {
             </div>
           </div>
         </div>
+        ${
+          this.fileDrop.isDragActive
+            ? html`<div class="drop-cue" aria-hidden="true">
+                Drop ${config.label.toLowerCase()} files here
+              </div>`
+            : nothing
+        }
       </div>
     `;
   }

--- a/packages/extension/src/webview/frontend/components/OnboardingSetupCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingSetupCard.ts
@@ -2,7 +2,7 @@ import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import { LitElement, css, html, type TemplateResult } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { GETTING_STARTED_ACTION_PRESENTATION } from '@shared/schemas';
@@ -55,6 +55,8 @@ export class OnboardingSetupCard extends LitElement {
     `,
   ];
 
+  @property({ attribute: false }) headingLevel: 1 | 2 = 1;
+
   private handleRunSetup(): void {
     this.dispatchEvent(MainViewEvents.onboardingRunSetup());
   }
@@ -71,7 +73,11 @@ export class OnboardingSetupCard extends LitElement {
     return html`
       <wa-callout id="onboardingSetupCard" variant="brand">
         ${waIcon('rocket', { slot: 'icon' })}
-        <h2 class="title">Credential ready</h2>
+        ${
+          this.headingLevel === 1
+            ? html`<h1 class="title">Credential ready</h1>`
+            : html`<h2 class="title">Credential ready</h2>`
+        }
         <p class="copy">${ONBOARDING_SETUP_HANDOFF}</p>
         <div class="actions">
           <wa-button

--- a/packages/extension/src/webview/frontend/components/OnboardingSetupCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingSetupCard.ts
@@ -36,9 +36,9 @@ export class OnboardingSetupCard extends LitElement {
 
       .title {
         display: block;
+        margin: 0 0 var(--wa-space-2xs);
         font-weight: var(--font-weight-semibold, 600);
         font-size: 1.05em;
-        margin-bottom: var(--wa-space-2xs);
       }
 
       .copy {
@@ -71,7 +71,7 @@ export class OnboardingSetupCard extends LitElement {
     return html`
       <wa-callout id="onboardingSetupCard" variant="brand">
         ${waIcon('rocket', { slot: 'icon' })}
-        <span class="title">Credential ready</span>
+        <h2 class="title">Credential ready</h2>
         <p class="copy">${ONBOARDING_SETUP_HANDOFF}</p>
         <div class="actions">
           <wa-button

--- a/packages/extension/src/webview/frontend/components/OnboardingSetupCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingSetupCard.ts
@@ -71,7 +71,7 @@ export class OnboardingSetupCard extends LitElement {
     return html`
       <wa-callout id="onboardingSetupCard" variant="brand">
         ${waIcon('rocket', { slot: 'icon' })}
-        <h1 class="title">Credential ready</h1>
+        <h2 class="title">Credential ready</h2>
         <p class="copy">${ONBOARDING_SETUP_HANDOFF}</p>
         <div class="actions">
           <wa-button

--- a/packages/extension/src/webview/frontend/components/OnboardingSetupCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingSetupCard.ts
@@ -71,7 +71,7 @@ export class OnboardingSetupCard extends LitElement {
     return html`
       <wa-callout id="onboardingSetupCard" variant="brand">
         ${waIcon('rocket', { slot: 'icon' })}
-        <h2 class="title">Credential ready</h2>
+        <h1 class="title">Credential ready</h1>
         <p class="copy">${ONBOARDING_SETUP_HANDOFF}</p>
         <div class="actions">
           <wa-button

--- a/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
@@ -294,16 +294,15 @@ export class OnboardingWelcomeCard extends LitElement {
                 variant="brand"
                 appearance="filled"
                 size="m"
-                aria-describedby="onboardingChatGptDescription"
                 @click=${this.handleChatGpt}
               >
                 ${waIcon('comments', { slot: 'start' })}
                 ${ONBOARDING_CHOICE_CHATGPT.label}
+                <span class="visually-hidden"
+                  >. ${ONBOARDING_CHOICE_CHATGPT.description}</span
+                >
               </wa-button>
-              <span
-                id="onboardingChatGptDescription"
-                class="choice-description"
-              >
+              <span class="choice-description" aria-hidden="true">
                 ${ONBOARDING_CHOICE_CHATGPT.description}
               </span>
             </div>
@@ -313,13 +312,15 @@ export class OnboardingWelcomeCard extends LitElement {
                 class="btn-secondary"
                 appearance="outlined"
                 size="m"
-                aria-describedby="onboardingApiKeyDescription"
                 @click=${this.handleApiKey}
               >
                 ${waIcon('key', { slot: 'start' })}
                 ${ONBOARDING_CHOICE_API_KEY.label}
+                <span class="visually-hidden"
+                  >. ${ONBOARDING_CHOICE_API_KEY.description}</span
+                >
               </wa-button>
-              <span id="onboardingApiKeyDescription" class="choice-description">
+              <span class="choice-description" aria-hidden="true">
                 ${ONBOARDING_CHOICE_API_KEY.description}
               </span>
             </div>

--- a/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
@@ -244,7 +244,7 @@ export class OnboardingWelcomeCard extends LitElement {
               ${waIcon('wand-magic-sparkles')}
             </span>
             <div class="welcome-heading">
-              <span class="card-title">${ONBOARDING_CARD_TITLE}</span>
+              <h1 class="card-title">${ONBOARDING_CARD_TITLE}</h1>
               <p class="card-copy">
                 Start with one credential. TeXRA then checks this project, picks
                 the right agent team, and starts your first useful edit.
@@ -294,12 +294,16 @@ export class OnboardingWelcomeCard extends LitElement {
                 variant="brand"
                 appearance="filled"
                 size="m"
+                aria-describedby="onboardingChatGptDescription"
                 @click=${this.handleChatGpt}
               >
                 ${waIcon('comments', { slot: 'start' })}
                 ${ONBOARDING_CHOICE_CHATGPT.label}
               </wa-button>
-              <span class="choice-description">
+              <span
+                id="onboardingChatGptDescription"
+                class="choice-description"
+              >
                 ${ONBOARDING_CHOICE_CHATGPT.description}
               </span>
             </div>
@@ -309,12 +313,13 @@ export class OnboardingWelcomeCard extends LitElement {
                 class="btn-secondary"
                 appearance="outlined"
                 size="m"
+                aria-describedby="onboardingApiKeyDescription"
                 @click=${this.handleApiKey}
               >
                 ${waIcon('key', { slot: 'start' })}
                 ${ONBOARDING_CHOICE_API_KEY.label}
               </wa-button>
-              <span class="choice-description">
+              <span id="onboardingApiKeyDescription" class="choice-description">
                 ${ONBOARDING_CHOICE_API_KEY.description}
               </span>
             </div>

--- a/packages/extension/src/webview/frontend/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/fileSelectStyles.ts
@@ -16,6 +16,7 @@ import { buttonStyles } from '@shared/styles/controlStyles';
 export const fileSelectLayoutStyles = css`
   .file-select {
     margin-bottom: var(--wa-space-xs);
+    container-type: inline-size;
   }
 
   .file-select-header {
@@ -93,6 +94,22 @@ export const fileSelectLayoutStyles = css`
   .file-select select,
   .file-select wa-select {
     width: 100%;
+  }
+
+  /* The action cluster has three fixed-size icon buttons. Stack it below the
+     label only once the component itself can no longer hold both groups; the
+     breakpoint follows this component in sidebars and desktop panes rather
+     than the viewport. */
+  @container (max-width: 18rem) {
+    .file-select-header {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .file-select-actions {
+      align-self: flex-end;
+      margin-inline-start: 0;
+    }
   }
 `;
 

--- a/packages/extension/src/webview/frontend/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/fileSelectStyles.ts
@@ -96,10 +96,10 @@ export const fileSelectLayoutStyles = css`
     width: 100%;
   }
 
-  /* The action cluster has three fixed-size icon buttons. Stack it below the
-     label only once the component itself can no longer hold both groups; the
-     breakpoint follows this component in sidebars and desktop panes rather
-     than the viewport. */
+  /* FileSelectGroup and LatexDiffsSection both render this shared header and
+     action structure. Stack their action clusters once each .file-select
+     container can no longer hold both groups, so sidebars and desktop panes
+     adapt independently of the viewport. */
   @container (max-width: 18rem) {
     .file-select-header {
       align-items: flex-start;

--- a/src/test-kernel/settings/LaTeXTab.vitest.ts
+++ b/src/test-kernel/settings/LaTeXTab.vitest.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  postMessage: vi.fn(),
+}));
+
+vi.mock('@shared/hostBridge', () => ({
+  postMessage: mocks.postMessage,
+}));
+
+import type { LatexConfigValues } from '@shared/schemas';
+import {
+  mountComponent,
+  useLitComponentTestDom,
+} from './litComponentTestUtils';
+
+type LaTeXTabElement = HTMLElement & {
+  loaded: boolean;
+  configValues: LatexConfigValues;
+  updateComplete: Promise<boolean>;
+};
+
+type WaTextareaElement = HTMLElement & {
+  value: string;
+  setCustomValidity: (message: string) => void;
+};
+
+async function mountLaTeXTab(
+  configValues: LatexConfigValues,
+): Promise<LaTeXTabElement> {
+  return mountComponent<LaTeXTabElement>('latex-tab', {
+    loaded: true,
+    configValues,
+  });
+}
+
+function customReplacementsInput(tab: LaTeXTabElement): WaTextareaElement {
+  return tab.shadowRoot!.querySelector<WaTextareaElement>(
+    '#latex-setting-customReplacements',
+  )!;
+}
+
+async function enterInvalidJson(
+  tab: LaTeXTabElement,
+): Promise<ReturnType<typeof vi.spyOn>> {
+  const input = customReplacementsInput(tab);
+  const setCustomValidity = vi.spyOn(input, 'setCustomValidity');
+  input.value = '{';
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+  await tab.updateComplete;
+  expect(
+    tab.shadowRoot!.querySelector('.replacement-json-error'),
+  ).not.toBeNull();
+  expect(setCustomValidity).toHaveBeenCalledWith(
+    expect.stringMatching(/JSON/i),
+  );
+  return setCustomValidity;
+}
+
+describe('LaTeXTab custom replacement validation', () => {
+  useLitComponentTestDom(() => import('@settingsView/frontend/tabs/LaTeXTab'));
+
+  it('clears stale JSON validity immediately when reset is selected', async () => {
+    const tab = await mountLaTeXTab({
+      customReplacements: { before: 'after' },
+    });
+    const setCustomValidity = await enterInvalidJson(tab);
+    const input = customReplacementsInput(tab);
+    const reset = input
+      .closest('.settings-row')!
+      .querySelector<HTMLElement>('.settings-row-control wa-button')!;
+
+    reset.click();
+    await tab.updateComplete;
+
+    expect(input.value).toBe('{}');
+    expect(setCustomValidity).toHaveBeenLastCalledWith('');
+    expect(tab.shadowRoot!.querySelector('.replacement-json-error')).toBeNull();
+  });
+
+  it('replaces an invalid draft and validity when external config changes', async () => {
+    const tab = await mountLaTeXTab({});
+    const setCustomValidity = await enterInvalidJson(tab);
+    const input = customReplacementsInput(tab);
+
+    tab.configValues = { customReplacements: {} };
+    await tab.updateComplete;
+
+    expect(input.value).toBe('{}');
+    expect(setCustomValidity).toHaveBeenLastCalledWith('');
+    expect(tab.shadowRoot!.querySelector('.replacement-json-error')).toBeNull();
+  });
+});

--- a/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
+++ b/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
@@ -83,6 +83,45 @@ describe('ModelSelectionList provider key status', () => {
     );
   });
 
+  it('slots labels and hints into the focused Web Awesome controls', async () => {
+    const list = await renderModelSelectionList({
+      models: [{ ...deepseekModel, supportsReasoningLevel: true }],
+      helperModel: 'deepseek',
+    });
+
+    const helperSelect = list.shadowRoot!.querySelector(
+      '.helper-model-select',
+    )!;
+    expect(helperSelect.querySelector('[slot="label"]')?.textContent).toContain(
+      'Model for quick fixes',
+    );
+    expect(helperSelect.querySelector('[slot="hint"]')?.textContent).toContain(
+      'quick background tasks',
+    );
+    expect(helperSelect.hasAttribute('aria-describedby')).toBe(false);
+
+    const shortNamesSwitch = list.shadowRoot!.querySelector(
+      '.short-names-toggle wa-switch',
+    )!;
+    expect(shortNamesSwitch.textContent).toContain('Use short model names');
+    expect(
+      shortNamesSwitch.querySelector('[slot="hint"]')?.textContent,
+    ).toContain('Use unpinned names');
+    expect(shortNamesSwitch.hasAttribute('aria-describedby')).toBe(false);
+
+    list
+      .shadowRoot!.querySelector<HTMLElement>('.provider-group-toggle')
+      ?.click();
+    await list.updateComplete;
+    const reasoningSelect = list.shadowRoot!.querySelector(
+      '.reasoning-level-select',
+    )!;
+    expect(
+      reasoningSelect.querySelector('[slot="label"]')?.textContent,
+    ).toContain('Reasoning level for DeepSeek V4 Flash');
+    expect(reasoningSelect.hasAttribute('aria-label')).toBe(false);
+  });
+
   it('keeps the pinned helper visible when it is not enabled', async () => {
     const list = await renderModelSelectionList({
       models: [

--- a/src/test-kernel/settings/ProviderKeyModal.vitest.ts
+++ b/src/test-kernel/settings/ProviderKeyModal.vitest.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { delay } from '@utils/core';
 import {
@@ -101,6 +101,31 @@ describe('ProviderKeyModal', () => {
 
     expect(counts).toEqual({ cancelled: 1, submitted: 0 });
     expect(input.value).toBe('');
+  });
+
+  it('sets and clears the input custom validity with the visible error', async () => {
+    const modal = await mountModal();
+    const input = modal.shadowRoot!.querySelector('wa-input') as HTMLElement & {
+      setCustomValidity: (message: string) => void;
+    };
+    const setCustomValidity = vi.spyOn(input, 'setCustomValidity');
+
+    submitForm(modal);
+    await modal.updateComplete;
+
+    expect(setCustomValidity).toHaveBeenCalledWith(
+      'Enter an API key before saving.',
+    );
+    expect(input.querySelector('[slot="hint"]')?.textContent?.trim()).toBe(
+      'Enter an API key before saving.',
+    );
+    expect(input.hasAttribute('aria-invalid')).toBe(false);
+
+    setKey(modal, 'sk-corrected');
+    await modal.updateComplete;
+
+    expect(setCustomValidity).toHaveBeenLastCalledWith('');
+    expect(input.querySelector('[slot="hint"]')?.textContent?.trim()).toBe('');
   });
 
   it('opens the wa-dialog when mounted and closes it after submit', async () => {

--- a/src/test-kernel/settings/litComponentTestUtils.ts
+++ b/src/test-kernel/settings/litComponentTestUtils.ts
@@ -257,6 +257,7 @@ function installElementInternalsPolyfill(window: TestDomWindow): void {
  */
 export function useLitComponentTestDom(
   importComponents?: () => Promise<unknown>,
+  hookTimeout?: number,
 ): void {
   let dom: JSDOM;
   const previousGlobals = new Map<
@@ -336,7 +337,7 @@ export function useLitComponentTestDom(
     installAnimationPolyfill(dom.window);
     installXtermBrowserPolyfill(dom.window);
     await importComponents?.();
-  });
+  }, hookTimeout);
 
   beforeEach(() => {
     document.body.replaceChildren();

--- a/src/test-kernel/webview/MainAppDesktopGating.vitest.ts
+++ b/src/test-kernel/webview/MainAppDesktopGating.vitest.ts
@@ -59,7 +59,10 @@ function hasSection(element: MainApp, tag: string): boolean {
  * skeleton with no launcher body, so every gated section would read as absent
  * and the assertions would pass for the wrong reason.
  */
-async function mountMainApp(options: { desktop: boolean }): Promise<MainApp> {
+async function mountMainApp(options: {
+  desktop: boolean;
+  onboarding?: 'done' | 'setup';
+}): Promise<MainApp> {
   const element = document.createElement('main-app') as unknown as MainApp;
   if (options.desktop) {
     (element as unknown as HTMLElement).setAttribute(
@@ -69,13 +72,13 @@ async function mountMainApp(options: { desktop: boolean }): Promise<MainApp> {
   }
   document.body.append(element as unknown as HTMLElement);
   await element.updateComplete;
-  mainViewState.onboardingFunnelState$.set('done');
+  mainViewState.onboardingFunnelState$.set(options.onboarding ?? 'done');
   await element.updateComplete;
   return element;
 }
 
 describe('MainApp desktop host gating', () => {
-  useLitComponentTestDom(() => import('@webview/frontend/MainApp'));
+  useLitComponentTestDom(() => import('@webview/frontend/MainApp'), 30_000);
 
   beforeAll(async () => {
     mainViewState = await import('@webview/frontend/mainViewState');
@@ -91,6 +94,27 @@ describe('MainApp desktop host gating', () => {
 
       expect(hasSection(element, 'latexdiffs-section')).toBe(visible);
       expect(hasSection(element, '.view-header')).toBe(visible);
+    },
+  );
+
+  it.each([
+    { host: 'extension', desktop: false, heading: 'h1' },
+    { host: 'desktop', desktop: true, heading: 'h2' },
+  ])(
+    'uses the setup-card heading below the $host host heading: $heading',
+    async ({ desktop, heading }) => {
+      const element = await mountMainApp({ desktop, onboarding: 'setup' });
+      const card = element.shadowRoot!.querySelector(
+        'onboarding-setup-card',
+      ) as HTMLElement & { updateComplete: Promise<boolean> };
+      await card.updateComplete;
+
+      expect(card.shadowRoot!.querySelector(heading)?.textContent).toContain(
+        'Credential ready',
+      );
+      expect(
+        card.shadowRoot!.querySelector(heading === 'h1' ? 'h2' : 'h1'),
+      ).toBeNull();
     },
   );
 });


### PR DESCRIPTION
## Summary

- improve file-selection feedback and onboarding semantics in the main webview
- make settings account usage, model and agent controls, skills, and forms clearer and more responsive
- strengthen progress-view empty states, keyboard focus, reduced-motion behavior, and RTL compatibility
- keep the design restrained: no theme migration, decorative redesign, or unnecessary abstraction

This consolidates the remaining unmerged interface-quality work from #11645, #11646, and #11649–#11655. The earlier shared typography, output-action, and settings-navigation changes were already merged separately in #11644, #11647, and #11648 before consolidation.

## Validation

- `npm run lint`
- `npm run typecheck:workspace`
- `npm run compile:fast`
- `npm test`
- focused follow-up lint, typecheck, and Vitest checks for review fixes
- `git diff --check`

No new tests were added; existing suites cover these presentation changes.