### PR TITLE
Refactor PR polling and subagent execution for clarity

### DIFF
--- a/config/ratchets/store-public-surface-baseline.json
+++ b/config/ratchets/store-public-surface-baseline.json
@@ -47,7 +47,8 @@
       "preload",
       "read",
       "reconcileStagedDeletions",
-      "stageDeleteStream"
+      "stageDeleteStream",
+      "workPlanProvenance"
     ]
   },
   "aggregateContracts": {

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -55,7 +55,6 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { clearApprovals } from './tui/state/approvalQueue';
 import {
-  establishWorkPlanReaderAuthority,
   focusStream,
   rootStreamId,
   patchSessionMeta,
@@ -567,10 +566,10 @@ export function createChatSessionController(
       // this keeps its canonical pre-resume projection visible at the cost of
       // bounded warnIfUnseeded notices until the seed completes.
       await snapshotStore.load([streamId]);
-      // Promote an open `/plan` reader's failure-time mask for the retained
-      // root and drop the projection memo before the log sync below can
-      // render a stale pre-resume projection.
-      establishWorkPlanReaderAuthority(streamId, ['plan', 'todos']);
+      // Drop the projection memo before the log sync below can render a stale
+      // pre-resume projection. The load also re-establishes this stream's
+      // work-plan provenance in the store, which is what an open `/plan`
+      // reader re-reads to clear its failure-time mask.
       bumpStreamArtifactRevision();
       // A resumed stream may be one the user /clear-ed; the empty patch mints
       // the slice and drops the retired mark so `syncStreamLog` and

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -560,10 +560,10 @@ export function App(props: AppProps): React.JSX.Element {
         return (
           <WorkPlanReader
             availableRows={availableRows}
-            authority={
+            provenanceAtOpen={
               foregroundReader.loading === true
                 ? undefined
-                : foregroundReader.authority
+                : foregroundReader.provenanceAtOpen
             }
             loading={foregroundReader.loading === true}
             onClose={closeForegroundReader}

--- a/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
@@ -81,18 +81,19 @@ export async function showCliWorkPlan(
     return;
   }
   const workPlan = snapshots.getWorkPlan(streamId);
-  const authority = {
-    plan: outcome.kind === 'complete' || outcome.authoritativeFields.plan,
-    todos: outcome.kind === 'complete' || outcome.authoritativeFields.todos,
-  };
-  const { plan: planIsAuthoritative, todos: todosAreAuthoritative } = authority;
+  const provenance =
+    outcome.kind === 'complete'
+      ? { plan: true, todos: true }
+      : outcome.workPlanProvenance;
+  const { plan: planIsAuthoritative, todos: todosAreAuthoritative } =
+    provenance;
   if (
     (planIsAuthoritative && workPlan.plan !== null) ||
     (todosAreAuthoritative && workPlan.todos.length > 0)
   ) {
     finishWorkPlanReaderRequest(
       request,
-      outcome.kind === 'partial' ? authority : undefined,
+      outcome.kind === 'partial' ? provenance : undefined,
     );
     return;
   }

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -1,12 +1,15 @@
 import { isEscapeInput, type ReturnKeyInput } from '@cli/tui/inputKeys';
 import {
   KEY_HINT_SEPARATOR,
-  keyHintText,
+  keyHintsText,
   type KeyHint,
 } from '@cli/tui/ui/KeyHints';
 import { loadingFrameAt } from '@cli/tui/ui/LoadingIndicator';
 import { APPROVAL_PULSE_FRAMES } from '@cli/tui/ui/glyphs';
-import { textDisplayWidth } from '@cli/runtime/terminalText';
+import {
+  firstFittingCandidate,
+  textDisplayWidth,
+} from '@cli/runtime/terminalText';
 import { DELEGATION_APPROVAL_COPY } from '@shared/copy/delegationApproval';
 
 type ConfirmCardKeyAction =
@@ -102,19 +105,6 @@ export function confirmCardFeedbackHints(): KeyHint[] {
   ];
 }
 
-// Reuses the canonical `keyHintText` projection (see its doc comment) so this
-// measures exactly what KeyHints renders, instead of re-deriving the format.
-function hintColumns(hints: readonly KeyHint[]): number {
-  return textDisplayWidth(hints.map(keyHintText).join(KEY_HINT_SEPARATOR));
-}
-
-function hintsFit(
-  hints: readonly KeyHint[],
-  maxColumns: number | undefined,
-): boolean {
-  return maxColumns === undefined || hintColumns(hints) <= maxColumns;
-}
-
 const COMPACT_HINT_ACTIONS: Readonly<Record<string, string>> = {
   'reject & note': 'reject',
   'approve commands for session': 'all commands',
@@ -131,25 +121,22 @@ export function confirmCardKeyHintsForWidth(
   options: ConfirmCardHintWidthOptions,
 ): KeyHint[] {
   const fullHints = confirmCardKeyHints(options);
-  if (hintsFit(fullHints, options.maxColumns)) return fullHints;
-
   const compactHints = fullHints.map((hint) => ({
     ...hint,
     action: COMPACT_HINT_ACTIONS[hint.action] ?? hint.action,
   }));
-  if (hintsFit(compactHints, options.maxColumns)) return compactHints;
-
-  const withoutExtraActions = compactHints.filter(
-    (hint) => isCoreApprovalHint(hint) || hint.key === 'a',
-  );
-  if (hintsFit(withoutExtraActions, options.maxColumns)) {
-    return withoutExtraActions;
-  }
-
-  const coreHints = compactHints.filter(isCoreApprovalHint);
-  if (hintsFit(coreHints, options.maxColumns)) return coreHints;
-
-  return fullHints.slice(-1);
+  const candidates: readonly KeyHint[][] = [
+    fullHints,
+    compactHints,
+    compactHints.filter((hint) => isCoreApprovalHint(hint) || hint.key === 'a'),
+    compactHints.filter(isCoreApprovalHint),
+  ];
+  return firstFittingCandidate({
+    candidates,
+    fallback: fullHints.slice(-1),
+    maxColumns: options.maxColumns,
+    measure: (hints) => textDisplayWidth(keyHintsText(hints)),
+  });
 }
 
 export function confirmCardCompactHintLayout({

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -9,12 +9,7 @@ import {
   scrollStatusText,
 } from '@cli/tui/overflowText';
 import { BorderedPanel } from '@cli/tui/ui/BorderedPanel';
-import {
-  KEY_HINT_SEPARATOR,
-  KeyHints,
-  keyHintText,
-  type KeyHint,
-} from '@cli/tui/ui/KeyHints';
+import { KeyHints, keyHintsText, type KeyHint } from '@cli/tui/ui/KeyHints';
 import { COLOR_ERROR, COLOR_SUCCESS } from '@cli/tui/ui/colors';
 import { POINTER } from '@cli/tui/ui/glyphs';
 import {
@@ -57,16 +52,6 @@ const COPY_STATUS_LABELS: Readonly<
 const DEFAULT_EXTERNAL_INQUIRY_QUESTION_ROWS = 16;
 const EXTERNAL_INQUIRY_FIXED_ROWS = 6;
 
-// Measured through the canonical `keyHintText` projection so the fit check
-// sees exactly what `KeyHints` renders. Strictly narrower than the budget:
-// the footer sits inside the card decoration and must not touch its edge.
-function keyHintsFit(hints: readonly KeyHint[], maxColumns: number): boolean {
-  return (
-    textDisplayWidth(hints.map(keyHintText).join(KEY_HINT_SEPARATOR)) <
-    maxColumns
-  );
-}
-
 export function externalInquiryKeyHintsForWidth({
   maxColumns,
   questionScrollable,
@@ -105,10 +90,12 @@ export function externalInquiryKeyHintsForWidth({
     compactTailHints,
     compactTailHints.filter((h) => h.key !== 'Ctrl-R'),
   ];
+  // Strictly narrower than the budget: the footer sits inside the card
+  // decoration and must not touch its edge.
   return (
-    candidates.find((hints) => keyHintsFit(hints, maxColumns)) ?? [
-      { key: 'Esc', action: 'skip' },
-    ]
+    candidates.find(
+      (hints) => textDisplayWidth(keyHintsText(hints)) < maxColumns,
+    ) ?? [{ key: 'Esc', action: 'skip' }]
   );
 }
 

--- a/packages/cli/src/chat/tui/panes/WorkPlanReader.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkPlanReader.tsx
@@ -8,8 +8,7 @@ import { isEscapeInput } from '@cli/tui/inputKeys';
 import { BorderedPanel } from '@cli/tui/ui/BorderedPanel';
 import {
   KeyHints,
-  KEY_HINT_SEPARATOR,
-  keyHintText,
+  keyHintsText,
   READER_SCROLL_HINTS,
   type KeyHint,
 } from '@cli/tui/ui/KeyHints';
@@ -22,7 +21,7 @@ import {
   type TodoItem,
   type TodoStatus,
 } from '@shared/schemas';
-import type { StreamArtifactAuthority } from '@transcript';
+import type { WorkPlanProvenance } from '@transcript';
 
 import { formFrameWidth } from '../forms/_shared/FormFrame';
 import { ScrollableModalText } from '../modals/ScrollableModalText';
@@ -73,10 +72,7 @@ export function workPlanReaderLayout({
       showTitle: true,
     };
   }
-  const footerRows = wrappedRows(
-    hints.map(keyHintText).join(KEY_HINT_SEPARATOR),
-    width,
-  );
+  const footerRows = wrappedRows(keyHintsText(hints), width);
   const showFooter = rows >= BORDER_ROWS + 1 + FOOTER_MARGIN_ROWS + footerRows;
   const titleRows = wrappedRows(title, width);
   const footerFixedRows = showFooter ? FOOTER_MARGIN_ROWS + footerRows : 0;
@@ -96,17 +92,19 @@ export function workPlanReaderTitle(label: string | undefined): string {
   return label ? `Work plan: ${label}` : 'Work plan';
 }
 
+/** `available` marks the fields this reader may present as facts; a field it
+ *  omits is presented, an unavailable one is masked. */
 export function formatWorkPlanReaderText(
   plan: Plan | null,
   todos: readonly TodoItem[],
-  authority?: Pick<StreamArtifactAuthority, 'plan' | 'todos'>,
+  available?: WorkPlanProvenance,
 ): string {
   const objective =
-    authority?.plan === false
+    available?.plan === false
       ? '(objective unavailable)'
       : (plan?.objective ?? '(no objective)');
   let todoLines: string[];
-  if (authority?.todos === false) {
+  if (available?.todos === false) {
     todoLines = ['(todos unavailable)'];
   } else if (todos.length === 0) {
     todoLines = ['(no todos)'];
@@ -121,14 +119,17 @@ export function formatWorkPlanReaderText(
 
 export function WorkPlanReader({
   availableRows,
-  authority,
+  provenanceAtOpen,
   loading = false,
   onClose,
   streamId,
   title,
 }: {
   readonly availableRows: number;
-  readonly authority?: Pick<StreamArtifactAuthority, 'plan' | 'todos'>;
+  /** Present only when this reader opened from a partially failed load: the
+   *  fields vouched for at that instant. Fields it excludes stay masked until
+   *  the store establishes them — no promotion is pushed in from outside. */
+  readonly provenanceAtOpen?: WorkPlanProvenance;
   readonly loading?: boolean;
   readonly onClose: () => void;
   readonly streamId: StreamTabId;
@@ -136,9 +137,17 @@ export function WorkPlanReader({
 }): React.JSX.Element {
   const { columns } = useWindowSize();
   useSignal(streamArtifactRevision);
-  const workPlan = loading
-    ? undefined
-    : tryDefaultSession()?.snapshots.getWorkPlan(streamId);
+  const snapshots = loading ? undefined : tryDefaultSession()?.snapshots;
+  const workPlan = snapshots?.getWorkPlan(streamId);
+  // A field this reader's own load could not vouch for stays masked only while
+  // the store still cannot vouch for it. Every event that establishes one — a
+  // live todos/plan write, a completed preload, a resume load — bumps
+  // `streamArtifactRevision`, so this re-read repaints with it.
+  const established = snapshots?.workPlanProvenance(streamId);
+  const available: WorkPlanProvenance | undefined = provenanceAtOpen && {
+    plan: provenanceAtOpen.plan || established?.plan === true,
+    todos: provenanceAtOpen.todos || established?.todos === true,
+  };
   const frameWidth = formFrameWidth(columns);
   const width = Math.max(1, frameWidth - CONFIRM_CARD_HORIZONTAL_DECORATION);
   const hints = loading ? WORK_PLAN_LOADING_HINTS : READER_SCROLL_HINTS;
@@ -153,7 +162,7 @@ export function WorkPlanReader({
     : formatWorkPlanReaderText(
         workPlan?.plan ?? null,
         workPlan?.todos ?? [],
-        authority,
+        available,
       );
 
   useInput((input, key) => {

--- a/packages/cli/src/chat/tui/panes/WorkflowPopup.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkflowPopup.tsx
@@ -15,12 +15,7 @@ import { useMemo } from 'react';
 // Local imports - TUI primitives
 import { isEscapeInput } from '@cli/tui/inputKeys';
 import { BorderedPanel } from '@cli/tui/ui/BorderedPanel';
-import {
-  KEY_HINT_SEPARATOR,
-  KeyHints,
-  keyHintText,
-  type KeyHint,
-} from '@cli/tui/ui/KeyHints';
+import { KeyHints, keyHintsText, type KeyHint } from '@cli/tui/ui/KeyHints';
 import { Select, type SelectItem } from '@cli/tui/ui/Select';
 import { COLOR_HINT } from '@cli/tui/ui/colors';
 import { POINTER } from '@cli/tui/ui/glyphs';
@@ -386,10 +381,7 @@ export function WorkflowPopup({
   // they measure at this width.
   const hintRows = Math.max(
     1,
-    wrapAnsiToWidth(
-      hints.map(keyHintText).join(KEY_HINT_SEPARATOR),
-      Math.max(1, width),
-    ).split('\n').length,
+    wrapAnsiToWidth(keyHintsText(hints), Math.max(1, width)).split('\n').length,
   );
   const filterShown = view.filterEditing || view.filter.length > 0;
   const listRows = Math.max(

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -756,14 +756,6 @@ function childListBindingsText(
         escBinding,
         ctrlCBinding,
       ]),
-      statusBarBindingRow([
-        selectBinding,
-        enterBinding,
-        killBinding,
-        tabBinding,
-        escBinding,
-        ctrlCBinding,
-      ]),
       selectionKillable &&
         statusBarBindingRow([
           selectBinding,

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -7,6 +7,7 @@ import {
   metaChordLabel,
 } from '@cli/runtime/shortcutLabels';
 import {
+  firstFittingCandidate,
   textDisplayWidth,
   truncateSummaryToWidth,
 } from '@cli/runtime/terminalText';
@@ -599,24 +600,8 @@ function statusBarBindingRow(
     .join(KEY_HINT_SEPARATOR);
 }
 
-// Every bindings row below is a widest-first cascade: candidates are built
-// eagerly, and the first one that fits the row wins. Inapplicable candidates
-// are left in place as `false`/`undefined` so each list still reads top to
-// bottom as "this layout, else this one".
-function firstRowThatFits(
-  candidates: readonly (string | false | undefined)[],
-  maxColumns: number | undefined,
-  fallback: string,
-): string {
-  return (
-    candidates.find(
-      (candidate): candidate is string =>
-        typeof candidate === 'string' &&
-        (maxColumns === undefined || textDisplayWidth(candidate) <= maxColumns),
-    ) ?? fallback
-  );
-}
-
+// Every bindings row below is a widest-first `firstFittingCandidate` cascade.
+//
 // No module-level memo: the bindings cascade below eagerly builds ~13
 // candidate rows and stringWidth-measures them until one fits, and its inputs
 // are a handful of flags that change far less often than the StatusBar
@@ -709,7 +694,12 @@ function statusBarBindingsText(
   );
   if (parentBack) candidates.push(parentBack);
 
-  return firstRowThatFits(candidates, maxColumns, ctrlC);
+  return firstFittingCandidate({
+    candidates,
+    fallback: ctrlC,
+    maxColumns,
+    measure: textDisplayWidth,
+  });
 }
 
 function foregroundBindingsText(
@@ -719,8 +709,8 @@ function foregroundBindingsText(
 ): string {
   const ctrlCBinding = keyHintText({ key: 'Ctrl-C', action: ctrlCAction });
   const escBinding = keyHintText({ key: 'Esc', action: escapeAction });
-  return firstRowThatFits(
-    [
+  return firstFittingCandidate({
+    candidates: [
       statusBarBindingRow([
         FOREGROUND_OWNERSHIP.keysGoAbove,
         escBinding,
@@ -728,9 +718,10 @@ function foregroundBindingsText(
       ]),
       statusBarBindingRow([escBinding, ctrlCBinding]),
     ],
+    fallback: ctrlCBinding,
     maxColumns,
-    ctrlCBinding,
-  );
+    measure: textDisplayWidth,
+  });
 }
 
 function childListBindingsText(
@@ -746,8 +737,8 @@ function childListBindingsText(
   const selectBinding = keyHintText({ key: '↑/↓', action: 'select' });
   const tabBinding = keyHintText({ key: 'Tab', action: 'input' });
   const escBinding = keyHintText({ key: 'Esc', action: 'input' });
-  return firstRowThatFits(
-    [
+  return firstFittingCandidate({
+    candidates: [
       statusBarBindingRow([
         selectBinding,
         enterBinding,
@@ -767,9 +758,10 @@ function childListBindingsText(
       statusBarBindingRow([enterBinding, escBinding, ctrlCBinding]),
       ctrlCBinding,
     ],
+    fallback: ctrlCBinding,
     maxColumns,
-    ctrlCBinding,
-  );
+    measure: textDisplayWidth,
+  });
 }
 
 function rootActiveSegment(

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -23,7 +23,7 @@ import type {
   CompactionActivityProjection,
 } from '@shared/streams/compactionActivityProjection';
 import type { WorkflowRowGroup } from '@shared/streams/workflowRunModel';
-import type { StreamArtifactAuthority } from '@transcript';
+import type { WorkPlanProvenance } from '@transcript';
 import { isChildStreamRemoved, sessionStreamPhase } from './childExecutions';
 import type { PastedImageEntry } from '../input/draftAttachments';
 
@@ -415,7 +415,14 @@ type ForegroundReaderTarget =
       readonly kind: 'workPlan';
       readonly streamId: StreamTabId;
       readonly loading?: false;
-      readonly authority?: Pick<StreamArtifactAuthority, 'plan' | 'todos'>;
+      /**
+       * Set only when this reader opened from a partially failed load: the
+       * work-plan fields the store could vouch for at that instant. The reader
+       * masks the rest until `snapshots.workPlanProvenance` establishes them,
+       * so nothing promotes this snapshot — it records one load's outcome and
+       * the store answers for everything after it.
+       */
+      readonly provenanceAtOpen?: WorkPlanProvenance;
     }
   | {
       readonly kind: 'workPlan';
@@ -513,47 +520,15 @@ export function workPlanReaderRequestIsCurrent(
 /** Resolve the loading reader without allowing an older request to replace it. */
 export function finishWorkPlanReaderRequest(
   request: WorkPlanReaderRequest,
-  authority?: Pick<StreamArtifactAuthority, 'plan' | 'todos'>,
+  provenanceAtOpen?: WorkPlanProvenance,
 ): boolean {
   if (!workPlanReaderRequestIsCurrent(request)) return false;
   FOREGROUND_READER.set({
     kind: 'workPlan',
     streamId: request.streamId,
-    ...(authority ? { authority } : {}),
+    ...(provenanceAtOpen ? { provenanceAtOpen } : {}),
   });
   return true;
-}
-
-/** Promote fields whose provenance was established after a partial `/plan`
- * load. Live writes and later successful preloads must replace the reader's
- * failure-time mask rather than leaving a now-current field unavailable. */
-export function establishWorkPlanReaderAuthority(
-  streamId: StreamTabId,
-  fields: readonly (keyof Pick<StreamArtifactAuthority, 'plan' | 'todos'>)[],
-): void {
-  const target = FOREGROUND_READER.get();
-  if (
-    target?.kind !== 'workPlan' ||
-    target.loading === true ||
-    target.streamId !== streamId ||
-    target.authority === undefined
-  ) {
-    return;
-  }
-  const authority = { ...target.authority };
-  let changed = false;
-  for (const field of fields) {
-    if (!authority[field]) {
-      authority[field] = true;
-      changed = true;
-    }
-  }
-  if (!changed) return;
-  FOREGROUND_READER.set(
-    authority.plan && authority.todos
-      ? { kind: 'workPlan', streamId }
-      : { ...target, authority },
-  );
 }
 
 export function cancelPendingWorkPlanReaderRequest(): void {

--- a/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
+++ b/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
@@ -38,10 +38,7 @@ import {
   unbindChildStreamState,
 } from './childExecutions';
 import { presentStream } from './childControls';
-import {
-  bumpStreamArtifactRevision,
-  markWorkPlanArtifactHydrated,
-} from './subscribeStreamArtifacts';
+import { bumpStreamArtifactRevision } from './subscribeStreamArtifacts';
 import {
   releaseInactiveStreamTranscript,
   syncStreamLog,
@@ -159,14 +156,15 @@ class TuiSessionRenderer implements SessionRendererPort {
 
   // Live todos/plan are readable from the snapshot store synchronously: a
   // live update is applied to `getWorkPlan` before the stream seeds
-  // (StreamSnapshotStore eager-apply overlay), so renderers read the store.
-  // The reader-authority promotion is the CLI's own `/plan` modality.
-  onTodosChanged(streamId: StreamTabId, _todos: TodoItem[]): void {
-    markWorkPlanArtifactHydrated(streamId, 'todos');
+  // (StreamSnapshotStore eager-apply overlay), so renderers read the store —
+  // including `workPlanProvenance`, which the same overlay establishes. Only
+  // the repaint is owed here.
+  onTodosChanged(_streamId: StreamTabId, _todos: TodoItem[]): void {
+    bumpStreamArtifactRevision();
   }
 
-  onPlanChanged(streamId: StreamTabId, _plan: Plan | null): void {
-    markWorkPlanArtifactHydrated(streamId, 'plan');
+  onPlanChanged(_streamId: StreamTabId, _plan: Plan | null): void {
+    bumpStreamArtifactRevision();
   }
 
   onInquiryThreadUpdated(_thread: InquiryThreadUpdatedEvent): void {}

--- a/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
@@ -18,7 +18,7 @@ import { type StreamTabId } from '@shared/schemas';
 import { subscribeToSignalChanges } from '@shared/signals';
 import {
   StreamSnapshotPreloadError,
-  type StreamArtifactAuthority,
+  type WorkPlanProvenance,
 } from '@transcript';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -29,7 +29,6 @@ import {
 } from './streamArtifactProjection';
 import {
   activeStreamId,
-  establishWorkPlanReaderAuthority,
   getCliStateGeneration,
   isCliStreamRetired,
   registerCliStateResetHook,
@@ -62,16 +61,6 @@ registerCliStateResetHook(() => {
 export function bumpStreamArtifactRevision(): void {
   artifactProjectionMemo.clear();
   streamArtifactRevision.set(streamArtifactRevision.get() + 1);
-}
-
-/** Record a live plan/todo write as authority for an already-open partial
- * reader, then invalidate the canonical projection like any artifact write. */
-export function markWorkPlanArtifactHydrated(
-  streamId: StreamTabId,
-  field: 'plan' | 'todos',
-): void {
-  establishWorkPlanReaderAuthority(streamId, [field]);
-  bumpStreamArtifactRevision();
 }
 
 /** Read the canonical artifact projection for one stream from the live session.
@@ -113,7 +102,7 @@ type StreamArtifactHydrationOutcome =
   | { readonly kind: 'complete' }
   | {
       readonly kind: 'partial';
-      readonly authoritativeFields: StreamArtifactAuthority;
+      readonly workPlanProvenance: WorkPlanProvenance;
       readonly error: unknown;
     }
   | { readonly kind: 'failed'; readonly error: unknown };
@@ -122,7 +111,9 @@ type StreamArtifactHydrationOutcome =
  * Preload one stream from the canonical artifact accumulator and invalidate
  * the artifact projection. Callers own request currentness and error
  * presentation. `undefined` means the request was superseded; a partial
- * outcome is usable only for fields selected by `authoritativeFields`.
+ * outcome's work plan is usable only for the fields `workPlanProvenance`
+ * vouches for at that instant — the store keeps answering that question live
+ * (`snapshots.workPlanProvenance`) as later writes and seeds establish more.
  */
 export async function hydrateStreamArtifacts(
   store: StreamArtifactReader,
@@ -142,18 +133,12 @@ export async function hydrateStreamArtifacts(
       error instanceof StreamSnapshotPreloadError &&
       error.streamId === streamId
     ) {
-      establishWorkPlanReaderAuthority(
-        streamId,
-        (['plan', 'todos'] as const).filter(
-          (field) => error.authoritativeFields[field],
-        ),
-      );
-      if (error.authoritativeFields.complete) {
+      if (error.baselineEstablished) {
         bumpStreamArtifactRevision();
       }
       return {
         kind: 'partial',
-        authoritativeFields: error.authoritativeFields,
+        workPlanProvenance: error.workPlanProvenance,
         error,
       };
     }
@@ -162,7 +147,6 @@ export async function hydrateStreamArtifacts(
   if (!streamCanReceiveArtifacts(streamId, generation, requestIsCurrent)) {
     return undefined;
   }
-  establishWorkPlanReaderAuthority(streamId, ['plan', 'todos']);
   bumpStreamArtifactRevision();
   return { kind: 'complete' };
 }

--- a/packages/cli/src/runtime/terminalText.ts
+++ b/packages/cli/src/runtime/terminalText.ts
@@ -47,6 +47,33 @@ export function truncateSummaryToWidth(
   return truncateToWidth(collapseWhitespace(text), maxColumns);
 }
 
+/**
+ * Widest-first layout cascade: the first candidate whose measured width fits
+ * `maxColumns` wins, `fallback` when none does. `false`/`undefined` entries are
+ * inapplicable layouts left in place, so a candidate list still reads top to
+ * bottom as "this layout, else this one". An undefined `maxColumns` — an
+ * unknown terminal width, as in tests and headless runs — fits everything.
+ */
+export function firstFittingCandidate<T>({
+  candidates,
+  fallback,
+  maxColumns,
+  measure,
+}: {
+  readonly candidates: readonly (T | false | undefined)[];
+  readonly fallback: T;
+  readonly maxColumns: number | undefined;
+  readonly measure: (candidate: T) => number;
+}): T {
+  for (const candidate of candidates) {
+    if (candidate === false || candidate === undefined) continue;
+    if (maxColumns === undefined || measure(candidate) <= maxColumns) {
+      return candidate;
+    }
+  }
+  return fallback;
+}
+
 /** Pad each visual row to `width` display columns. */
 export function fillRows(text: string, width: number): string {
   return text

--- a/packages/cli/src/tui/ui/KeyHints.tsx
+++ b/packages/cli/src/tui/ui/KeyHints.tsx
@@ -33,6 +33,13 @@ export function keyHintText(hint: KeyHint): string {
   return `${hint.key} ${hint.action}`;
 }
 
+/** Plain-text projection of a whole hint strip, joined exactly as the
+ *  component below renders it. Width math and row-budget math measure this
+ *  rather than re-deriving the separator. */
+export function keyHintsText(hints: readonly KeyHint[]): string {
+  return hints.map(keyHintText).join(KEY_HINT_SEPARATOR);
+}
+
 const DEFAULT_TAIL: readonly KeyHint[] = [
   { key: 'Enter', action: 'confirm' },
   { key: 'Esc', action: 'cancel' },

--- a/src/platform/defaults/lifecycleHost.ts
+++ b/src/platform/defaults/lifecycleHost.ts
@@ -1,10 +1,12 @@
-import { logError } from '@shared/log';
+import { createLog } from '@logger/logUtils';
 import { onAbort } from '@utils/core';
 import {
   SHUTDOWN_PHASE,
   type LifecycleHost,
   type ShutdownPhase,
 } from '../interfaces';
+
+const log = createLog('LifecycleHost');
 
 type Callback = (signal: AbortSignal) => void | Promise<void>;
 
@@ -41,7 +43,7 @@ export function createLifecycleHost(
   const onError =
     options.onError ??
     ((phase, error) => {
-      logError(`[lifecycle] ${phase} handler failed:`, error);
+      log.error(`[lifecycle] ${phase} handler failed`, { data: error });
     });
 
   // Abort-then-advance: wait for settlement, or for the deadline signal plus

--- a/src/platform/defaults/lifecycleHost.ts
+++ b/src/platform/defaults/lifecycleHost.ts
@@ -1,3 +1,4 @@
+import { logError } from '@shared/log';
 import { onAbort } from '@utils/core';
 import {
   SHUTDOWN_PHASE,
@@ -40,7 +41,7 @@ export function createLifecycleHost(
   const onError =
     options.onError ??
     ((phase, error) => {
-      console.error(`[lifecycle] ${phase} handler failed:`, error);
+      logError(`[lifecycle] ${phase} handler failed:`, error);
     });
 
   // Abort-then-advance: wait for settlement, or for the deadline signal plus

--- a/src/shared/BaseWebviewApp.ts
+++ b/src/shared/BaseWebviewApp.ts
@@ -3,6 +3,7 @@ import { LitElement } from 'lit';
 
 // Local imports - shared handlers
 import { COMMON_COMMANDS } from '@shared/ipc';
+import { logWarn } from '@shared/log';
 import { postMessage } from '@shared/hostBridge';
 import {
   CommonViewMessageSchema,
@@ -102,7 +103,7 @@ export abstract class BaseWebviewApp<TMessage = unknown> extends LitElement {
     if (!this.debugMode) {
       return;
     }
-    console.warn(context, error);
+    logWarn(context, error);
   }
 
   /**

--- a/src/shared/highlighting/highlightCode.ts
+++ b/src/shared/highlighting/highlightCode.ts
@@ -5,6 +5,8 @@
  * Falls back to empty string for unknown languages (markdown-it escapes).
  */
 
+import { logWarn } from '@shared/log';
+
 import { hljs } from './hljs';
 
 export function highlightCode(code: string, lang: string): string {
@@ -23,7 +25,10 @@ export function highlightCode(code: string, lang: string): string {
       // Fall through to plain text, but surface genuine highlight failures so
       // a throwing renderer is not indistinguishable from an unknown-language
       // case.
-      console.warn(`highlight.js failed for language "${lang}":`, error);
+      logWarn(
+        `[highlightCode] highlight.js failed for language "${lang}":`,
+        error,
+      );
     }
   }
   // Return empty string — markdown-it will escape and wrap in its own <pre><code>

--- a/src/shared/log.ts
+++ b/src/shared/log.ts
@@ -1,0 +1,31 @@
+/**
+ * Browser-safe diagnostic sink for browser-reachable, VS Code-free code.
+ *
+ * `@logger/logUtils` is the repo's real logging subsystem, but it is
+ * Node-oriented — it pulls in `safe-stable-stringify`, secret redaction, and
+ * `@utils/config/configUtils` — so a module that ships inside a webview bundle
+ * (`@shared/schemas/*`, `@shared/state/*`, `@shared/wa/*`, `BaseWebviewApp`)
+ * cannot call it. Those modules used to reach for bare `console.warn` /
+ * `console.error` one site at a time, leaving diagnostics from the browser
+ * side with no owner at all.
+ *
+ * This module is that owner: the single place browser-reachable code writes a
+ * diagnostic, and the single place a host-supplied sink, level gate, or
+ * redaction pass would be added if one is ever needed. It deliberately has no
+ * imports and no injection seam — it is a sink, not a framework.
+ *
+ * Convention: prefix the message with a bracketed scope (`[roundIndexed] …`,
+ * `[PersistedState] …`) so a warning in a shared module names its origin. Pass
+ * an `Error` or a structured detail object as a trailing argument rather than
+ * interpolating it, exactly as with `console.warn`.
+ */
+
+/** Report a recoverable problem: a salvaged parse, a fallback, a degraded read. */
+export function logWarn(message: string, ...details: unknown[]): void {
+  console.warn(message, ...details);
+}
+
+/** Report a failure that a caller could not recover from. */
+export function logError(message: string, ...details: unknown[]): void {
+  console.error(message, ...details);
+}

--- a/src/shared/log.ts
+++ b/src/shared/log.ts
@@ -24,8 +24,3 @@
 export function logWarn(message: string, ...details: unknown[]): void {
   console.warn(message, ...details);
 }
-
-/** Report a failure that a caller could not recover from. */
-export function logError(message: string, ...details: unknown[]): void {
-  console.error(message, ...details);
-}

--- a/src/shared/schemas/agentPresets.ts
+++ b/src/shared/schemas/agentPresets.ts
@@ -9,6 +9,7 @@
 
 import { z } from 'zod';
 
+import { logWarn } from '@shared/log';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 
 import { AgentCategorySchema } from './agent';
@@ -39,7 +40,7 @@ const AgentModePresetIconSchema = z.string().transform((rawIcon) => {
     return normalized as AgentModePresetIconName;
   }
 
-  console.warn(
+  logWarn(
     `[agentPresets] Unknown agent team icon "${normalized}"; falling back to ` +
       `"${FALLBACK_AGENT_MODE_PRESET_ICON}" instead of dropping the team.`,
   );
@@ -62,7 +63,7 @@ export type AgentModePreset = z.infer<typeof AgentModePresetSchema>;
 export function parseAgentModePresets(raw: unknown): AgentModePreset[] {
   const parsedRecords = z.array(z.unknown()).prefault([]).safeParse(raw);
   if (!parsedRecords.success) {
-    console.warn(
+    logWarn(
       `[agentPresets] Custom agent teams are not an array; ignoring them for ` +
         `this read: ${parsedRecords.error.message}`,
     );
@@ -73,7 +74,7 @@ export function parseAgentModePresets(raw: unknown): AgentModePreset[] {
     const result = AgentModePresetSchema.safeParse(rawPreset);
     if (result.success) return [result.data];
 
-    console.warn(
+    logWarn(
       `[agentPresets] Ignoring malformed custom agent team at index ${index}: ` +
         result.error.message,
     );

--- a/src/shared/schemas/roundIndexed.ts
+++ b/src/shared/schemas/roundIndexed.ts
@@ -16,6 +16,8 @@
 
 import { z } from 'zod';
 
+import { logWarn } from '@shared/log';
+
 import { formatZodIssuesMessage } from './toolResult';
 
 /**
@@ -151,7 +153,7 @@ function warnDroppedItem(
   kind: string,
   error: { issues: readonly { path: PropertyKey[]; message: string }[] },
 ): void {
-  console.warn(
+  logWarn(
     `[roundIndexed] Dropping malformed ${kind} entry: ${formatZodIssuesMessage(error.issues)}`,
   );
 }
@@ -181,9 +183,7 @@ export function parsePersistedRoundIndexed<T>(
       const round = RoundKeySchema.safeParse(key);
       if (!round.success) continue;
       if (!Array.isArray(value)) {
-        console.warn(
-          `[roundIndexed] Dropping non-array round "${key}" in ${kind}.`,
-        );
+        logWarn(`[roundIndexed] Dropping non-array round "${key}" in ${kind}.`);
         continue;
       }
       const items = value.flatMap((item) => {
@@ -199,7 +199,7 @@ export function parsePersistedRoundIndexed<T>(
 
   const result = z.record(z.string(), z.unknown()).safeParse(raw);
   if (!result.success) {
-    console.warn(
+    logWarn(
       `[roundIndexed] Ignoring malformed ${kind} (not a round-keyed record); treating as empty.`,
     );
     return {};

--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -13,6 +13,8 @@
 
 import { z } from 'zod';
 
+import { logWarn } from '@shared/log';
+
 import { ExecutionIdSchema } from './identifiers';
 import { formatZodIssuesMessage } from './toolResult';
 import {
@@ -118,7 +120,7 @@ export function parseUsageData(raw: unknown): ParsedUsageData {
     } else {
       rawKind = typeof raw;
     }
-    console.warn(
+    logWarn(
       `[streamData] usageStats.json is not a per-run object (got ${rawKind}); ` +
         'ignoring for this read instead of silently zeroing usage.',
     );
@@ -128,7 +130,7 @@ export function parseUsageData(raw: unknown): ParsedUsageData {
   for (const [runId, value] of Object.entries(raw as Record<string, unknown>)) {
     const parsed = TokenUsageStatsParsingBaseSchema.safeParse(value);
     if (!parsed.success) {
-      console.warn(
+      logWarn(
         `[streamData] Preserving unparseable usage entry for run "${runId}" ` +
           `unchanged (not dropped): ${formatZodIssuesMessage(parsed.error.issues)}`,
       );

--- a/src/shared/state/PersistedState.ts
+++ b/src/shared/state/PersistedState.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import type { StateStore } from '@platform/interfaces';
+import { logWarn } from '@shared/log';
 
 /**
  * Create a {@link StateStore} over webview host state. All keys share a single
@@ -98,7 +99,7 @@ export class PersistedState<T extends Record<string, unknown>> {
     // PersistedState key must never block webview activation or extension
     // startup. Also persist the reset so the bad value is replaced and the next
     // load doesn't keep hitting this path.
-    console.warn(
+    logWarn(
       `[PersistedState] Invalid stored data for ${this.key}, resetting.`,
       {
         storedType: describeStored(stored),
@@ -119,7 +120,7 @@ export class PersistedState<T extends Record<string, unknown>> {
   private persist(value: T): void {
     void Promise.resolve(this.storage.update(this.key, value)).catch(
       (error: unknown) => {
-        console.warn(
+        logWarn(
           `[PersistedState] Failed to persist ${this.key}; the in-memory value is now ahead of storage.`,
           error,
         );
@@ -137,7 +138,7 @@ export class PersistedState<T extends Record<string, unknown>> {
     if (defaultResult.success) {
       return defaultResult.data;
     }
-    console.warn(
+    logWarn(
       `[PersistedState] No schema defaults for ${this.key}; using empty object.`,
       { issues: summarizeIssues(defaultResult.error) },
     );

--- a/src/shared/wa/spinner.ts
+++ b/src/shared/wa/spinner.ts
@@ -8,6 +8,8 @@ import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
 import { nothing } from 'lit';
 import { Directive, directive, type ElementPart } from 'lit/directive.js';
 
+import { logWarn } from '@shared/log';
+
 const REDUCED_MOTION_STYLE_ATTR = 'data-texra-reduced-motion';
 const REDUCED_MOTION_CSS = `@media (prefers-reduced-motion: reduce) {
   svg,
@@ -41,8 +43,8 @@ function scheduleAdopt(host: Element): void {
     void pending.then(
       () => adoptReducedMotion(host),
       (error: unknown) => {
-        console.warn(
-          'Failed to adopt reduced-motion style for wa-spinner',
+        logWarn(
+          '[spinner] Failed to adopt reduced-motion style for wa-spinner',
           error,
         );
       },

--- a/src/shared/wa/xtermTheme.ts
+++ b/src/shared/wa/xtermTheme.ts
@@ -11,6 +11,8 @@
  * broken mapping.
  */
 
+import { logWarn } from '@shared/log';
+
 const XTERM_THEME_FALLBACKS = {
   background: '#1e1e1e',
   foreground: '#cccccc',
@@ -60,7 +62,7 @@ export function resolveXtermTheme(target: Element): ResolvedXtermTheme {
     .filter(([value]) => !value)
     .map(([, name]) => name);
   if (unresolved.length > 0) {
-    console.warn(
+    logWarn(
       `[xtermTheme] ${unresolved.join(', ')} did not resolve; falling back to the surface palette or built-in defaults.`,
     );
   }

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -43,7 +43,6 @@ import {
   invalidateChildStreams,
   unbindChildStreamState,
 } from '@cli/chat/tui/state/childExecutions';
-import { markWorkPlanArtifactHydrated } from '@cli/chat/tui/state/subscribeStreamArtifacts';
 import type { StreamArtifactReader } from '@cli/chat/tui/state/streamArtifactProjection';
 import * as apiStatus from '@cli/runtime/apiStatus';
 import * as subscriptionLogin from '@cli/runtime/subscriptionLogin';
@@ -72,7 +71,7 @@ import { snapshotFacts } from '@test/support/storeTestDrivers';
 import * as memoryFileSystem from '@tools/memory/memoryFileSystem';
 import {
   StreamSnapshotPreloadError,
-  type StreamArtifactAuthority,
+  type WorkPlanProvenance,
 } from '@transcript';
 
 // Child rosters and parent edges live on the adapter-bound `SessionState`;
@@ -498,7 +497,7 @@ describe('handleTuiSlashCommand', () => {
         plan: { objective: 'Use the accepted live plan.' },
         todos: [],
       },
-      authority: { complete: false, todos: false, plan: true },
+      provenance: { todos: false, plan: true },
     },
     {
       label: 'todos',
@@ -512,7 +511,7 @@ describe('handleTuiSlashCommand', () => {
           },
         ],
       },
-      authority: { complete: false, todos: true, plan: false },
+      provenance: { todos: true, plan: false },
     },
   ] satisfies readonly {
     label: string;
@@ -520,10 +519,10 @@ describe('handleTuiSlashCommand', () => {
       readonly plan: Plan | null;
       readonly todos: readonly TodoItem[];
     };
-    authority: StreamArtifactAuthority;
+    provenance: WorkPlanProvenance;
   }[])(
     'opens accepted in-memory $label state when historical preload fails',
-    async ({ workPlan, authority }) => {
+    async ({ workPlan, provenance }) => {
       const { promise: preload, reject: rejectPreload } = deferred<void>();
       const streamId = 'live-plan-after-load-error' as StreamTabId;
       registerBuiltinSlashCommands({
@@ -540,20 +539,21 @@ describe('handleTuiSlashCommand', () => {
         new StreamSnapshotPreloadError(
           new Error('historical sidecar unreadable'),
           streamId,
-          authority,
+          false,
+          provenance,
         ),
       );
       await dispatched;
 
+      // The reader records only what this load could vouch for; the fields it
+      // could not are re-asked of the store on every repaint, so nothing
+      // promotes this snapshot afterwards.
       expect(foregroundReader.get()).toEqual({
         kind: 'workPlan',
         streamId,
-        authority: { plan: authority.plan, todos: authority.todos },
+        provenanceAtOpen: provenance,
       });
       expect(transientNotice.get()).toBeUndefined();
-
-      markWorkPlanArtifactHydrated(streamId, authority.plan ? 'todos' : 'plan');
-      expect(foregroundReader.get()).toEqual({ kind: 'workPlan', streamId });
     },
   );
 

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -2385,9 +2385,19 @@ describe('StreamSnapshotStore', () => {
     expect(error).toMatchObject({
       message: expect.stringContaining('snapshot disk is unreadable'),
       streamId: STREAM,
-      authoritativeFields: { complete: false, todos: true, plan: true },
+      baselineEstablished: false,
+      workPlanProvenance: { todos: true, plan: true },
+    });
+    // The same question asked live keeps answering as the record changes.
+    expect(store.workPlanProvenance(STREAM)).toEqual({
+      todos: true,
+      plan: true,
     });
     await newerRefresh;
+    expect(store.workPlanProvenance(STREAM)).toEqual({
+      todos: true,
+      plan: true,
+    });
 
     readSpy.mockRestore();
     await store.flush();

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -163,28 +163,6 @@ function claudeCostLines(turn: TurnResult): string[] | undefined {
     : undefined;
 }
 
-function formatClaudeDelivery(
-  executionId: string,
-  prompt: string,
-  wallTimeMs: number,
-  turn: TurnResult,
-): string {
-  return formatChildRunDelivery(
-    {
-      tag: DELIVERY_TAG.claudeAgentResult,
-      executionId,
-      prompt,
-      attributes: [{ name: 'session-id', value: turn.sessionId || null }],
-    },
-    {
-      wallTime: formatWallTimeSeconds(wallTimeMs),
-      response: turn.finalResponse,
-      usage: toDeliveryUsage(turn.usage),
-      lines: claudeCostLines(turn),
-    },
-  );
-}
-
 // ============================================================================
 // Stream tab helpers
 // ============================================================================
@@ -479,7 +457,20 @@ function startClaudeAgentLoop(params: {
       if (turn.errorMessage) log.error(turn.errorMessage);
     },
     formatDelivery: (turn, wallTimeMs, lastPrompt) =>
-      formatClaudeDelivery(executionId, lastPrompt, wallTimeMs, turn),
+      formatChildRunDelivery(
+        {
+          tag: DELIVERY_TAG.claudeAgentResult,
+          executionId,
+          prompt: lastPrompt,
+          attributes: [{ name: 'session-id', value: turn.sessionId || null }],
+        },
+        {
+          wallTime: formatWallTimeSeconds(wallTimeMs),
+          response: turn.finalResponse,
+          usage: toDeliveryUsage(turn.usage),
+          lines: claudeCostLines(turn),
+        },
+      ),
     formatError: (turn, err, lastPrompt) =>
       formatChildRunError(
         { tag: DELIVERY_TAG.claudeAgentError, executionId, prompt: lastPrompt },

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -128,33 +128,6 @@ const CodexInputSchema = z.strictObject({
 export type CodexInput = z.infer<typeof CodexInputSchema>;
 
 // ============================================================================
-// Result formatting
-// ============================================================================
-
-/** Format a Codex result for delivery as XML on the parent's follow-up queue. */
-function formatCodexDelivery(
-  executionId: string,
-  prompt: string,
-  wallTimeMs: number,
-  turn: RunResult,
-  threadId?: string | null,
-): string {
-  return formatChildRunDelivery(
-    {
-      tag: DELIVERY_TAG.codexResult,
-      executionId,
-      prompt,
-      attributes: [{ name: 'thread-id', value: threadId || null }],
-    },
-    {
-      wallTime: formatWallTimeSeconds(wallTimeMs),
-      response: turn.finalResponse,
-      usage: toDeliveryUsage(turn.usage),
-    },
-  );
-}
-
-// ============================================================================
 // Stream tab helpers
 // ============================================================================
 
@@ -425,7 +398,19 @@ function startCodexLoop(params: {
     buildUsageStats: (turn) =>
       turn.usage ? buildCodexUsageStats(turn.usage) : undefined,
     formatDelivery: (turn, wallTimeMs, lastPrompt) =>
-      formatCodexDelivery(executionId, lastPrompt, wallTimeMs, turn, thread.id),
+      formatChildRunDelivery(
+        {
+          tag: DELIVERY_TAG.codexResult,
+          executionId,
+          prompt: lastPrompt,
+          attributes: [{ name: 'thread-id', value: thread.id || null }],
+        },
+        {
+          wallTime: formatWallTimeSeconds(wallTimeMs),
+          response: turn.finalResponse,
+          usage: toDeliveryUsage(turn.usage),
+        },
+      ),
     formatError: (_turn, err, lastPrompt) =>
       formatChildRunError(
         { tag: DELIVERY_TAG.codexError, executionId, prompt: lastPrompt },

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -13,13 +13,18 @@
  */
 
 // Local imports
-import { getExecutionStore, type ResultMeta } from '@agent/storage';
+import {
+  getExecutionStore,
+  type ExecutionKVStore,
+  type ResultMeta,
+} from '@agent/storage';
 import {
   ExecutionLeaseLostError,
   runWithInactiveExecutionLease,
 } from '@agent/storage/executionLease';
 import {
   AgentConfigSchema,
+  type AgentConfig,
   type AgentConfigPayload,
 } from '@agent/core/definition/AgentConfig';
 import type { AgentFinalResult } from '@agent/runtime/AgentFinalResult';
@@ -325,6 +330,151 @@ async function throwRetryableDurabilityError(
 }
 
 /**
+ * Register the child execution and resolve its stream tab.
+ *
+ * The failure classification is the whole point of the wrapper: under the
+ * typed-result contract a registration failure means no attempt ever launched,
+ * which is a durability fault the stable-attempt ledger must see; best-effort
+ * delivery surfaces the raw cause instead.
+ */
+async function registerInBandChild(
+  options: InBandSubagentDeliveryOptions,
+  config: AgentConfig,
+  executionId: ExecutionId,
+  mode: PersistenceMode,
+): Promise<StreamTabId> {
+  try {
+    const { childStreamId } = await registerChildExecution({
+      executionId,
+      config,
+      agentName: options.agentName,
+      userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
+      parentExecutionId: options.parentExecutionId,
+    });
+    return childStreamId;
+  } catch (cause) {
+    if (mode === 'required-result') {
+      throw new SubagentDurabilityError(
+        `Failed to register subagent ${executionId}.`,
+        { cause },
+      );
+    }
+    throw cause;
+  }
+}
+
+/**
+ * Post-drain, pre-lease-release durable commit: attest that the child's result
+ * manifest is on disk, then flip the stable attempt marker to `committed`.
+ *
+ * Returns whether the commit happened. A non-stable call, an errored turn, or
+ * a non-completed outcome is a deliberate no-op — only a durably completed
+ * child earns the marker that later recovery treats as attestable.
+ */
+async function commitStableCompletion(
+  store: ExecutionKVStore,
+  executionId: ExecutionId,
+  stableAttempt: StableSubagentAttempt | undefined,
+  settledTurn: SettledInBandTurn | undefined,
+): Promise<boolean> {
+  const settledResultMeta = settledTurn?.resultMeta;
+  if (
+    !stableAttempt ||
+    settledTurn?.isError === true ||
+    settledResultMeta?.producer !== 'subagent' ||
+    settledResultMeta.result.outcome !== RUN_OUTCOME.COMPLETED
+  ) {
+    return false;
+  }
+  let persisted: ResultMeta | null;
+  try {
+    persisted = await store.readResultMeta();
+  } catch (cause) {
+    throw new SubagentCommitError(
+      `Failed to verify durable completion for subagent ${executionId}.`,
+      { cause },
+    );
+  }
+  if (!persisted || persisted.producer !== 'subagent') {
+    throw new SubagentCommitError(
+      `Failed to persist result for subagent ${executionId}.`,
+    );
+  }
+  try {
+    await writeStableSubagentAttempt(store, {
+      ...stableAttempt,
+      phase: 'committed',
+    });
+  } catch (cause) {
+    throw new SubagentCommitError(
+      `Failed to commit durable completion for subagent ${executionId}.`,
+      { cause },
+    );
+  }
+  return true;
+}
+
+/**
+ * Required-result mode only: confirm the manifest this caller is about to
+ * report actually landed on disk. Returns normally when it did; every other
+ * outcome throws.
+ *
+ * The ledger recovers restarts by inspecting the persisted manifest, so the
+ * in-memory copy is not enough here. A FAILED child's attempt is marked
+ * retryable (re-running a failed child is safe); a COMPLETED child whose
+ * manifest did not persist keeps its 'launched' marker, so a later run refuses
+ * to repeat side-effectful work rather than executing it twice.
+ */
+async function verifyPersistedResultManifest(
+  store: ExecutionKVStore,
+  executionId: ExecutionId,
+  stableAttempt: StableSubagentAttempt | undefined,
+  childFailed: boolean,
+  childError: () => unknown,
+): Promise<void> {
+  let persisted: ResultMeta | null;
+  // A read failure is NOT the same fact as a missing manifest: keep it so
+  // the thrown error names the I/O cause instead of blaming persistence.
+  let readFailure: unknown;
+  try {
+    persisted = await store.readResultMeta();
+  } catch (cause) {
+    log.warn('Failed to read the persisted result manifest', {
+      data: { executionId, error: cause },
+    });
+    persisted = null;
+    readFailure = cause;
+  }
+  if (!persisted) {
+    if (childFailed) {
+      const error = childError();
+      await throwRetryableDurabilityError(
+        executionId,
+        stableAttempt,
+        new SubagentDurabilityError(
+          `Subagent ${executionId} failed (${toErrorMessage(error)}), and its failure result could not be persisted.`,
+          {
+            cause: new AggregateError(
+              readFailure === undefined ? [error] : [error, readFailure],
+              `Subagent ${executionId} execution and persistence both failed.`,
+            ),
+          },
+        ),
+      );
+    }
+    if (readFailure !== undefined) {
+      throw new SubagentDurabilityError(
+        `Failed to verify the persisted result for subagent ${executionId}.`,
+        { cause: readFailure },
+      );
+    }
+    throw new SubagentDurabilityError(
+      `Failed to persist result for subagent ${executionId}.`,
+    );
+  }
+}
+
+/**
  * Execute one child through the one shared driver and read its typed result
  * back from the durable record. The child runs under the same detached
  * child-run loop every native child uses (single-cycle strategy, persist-only
@@ -353,24 +503,12 @@ async function executeInBand(
   const workingDirectory = config.workingDirectory ?? undefined;
   const store = getExecutionStore(executionId);
 
-  let childStreamId: StreamTabId;
-  try {
-    ({ childStreamId } = await registerChildExecution({
-      executionId,
-      config,
-      agentName: options.agentName,
-      userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
-      parentExecutionId: options.parentExecutionId,
-    }));
-  } catch (cause) {
-    if (mode === 'required-result') {
-      throw new SubagentDurabilityError(
-        `Failed to register subagent ${executionId}.`,
-        { cause },
-      );
-    }
-    throw cause;
-  }
+  const childStreamId = await registerInBandChild(
+    options,
+    config,
+    executionId,
+    mode,
+  );
   let stableCompletionCommitted = false;
   const completed = await (async () => {
     let settledTurn: SettledInBandTurn | undefined;
@@ -388,41 +526,13 @@ async function executeInBand(
         settledTurn = settled;
       },
       afterArtifactsDrained: async () => {
-        const settledResultMeta = settledTurn?.resultMeta;
-        if (
-          !stableAttempt ||
-          settledTurn?.isError === true ||
-          settledResultMeta?.producer !== 'subagent' ||
-          settledResultMeta.result.outcome !== RUN_OUTCOME.COMPLETED
-        ) {
-          return;
-        }
-        let persisted: ResultMeta | null;
-        try {
-          persisted = await store.readResultMeta();
-        } catch (cause) {
-          throw new SubagentCommitError(
-            `Failed to verify durable completion for subagent ${executionId}.`,
-            { cause },
-          );
-        }
-        if (!persisted || persisted.producer !== 'subagent') {
-          throw new SubagentCommitError(
-            `Failed to persist result for subagent ${executionId}.`,
-          );
-        }
-        try {
-          await writeStableSubagentAttempt(store, {
-            ...stableAttempt,
-            phase: 'committed',
-          });
-          stableCompletionCommitted = true;
-        } catch (cause) {
-          throw new SubagentCommitError(
-            `Failed to commit durable completion for subagent ${executionId}.`,
-            { cause },
-          );
-        }
+        const committed = await commitStableCompletion(
+          store,
+          executionId,
+          stableAttempt,
+          settledTurn,
+        );
+        if (committed) stableCompletionCommitted = true;
       },
       buildLaunch: async () => {
         // Inside the loop's lease launch guard, like every attempt-scoped
@@ -509,52 +619,13 @@ async function executeInBand(
     }
 
     if (mode === 'required-result') {
-      // The ledger recovers restarts by inspecting the persisted manifest, so
-      // the in-memory copy is not enough here: verify the write landed. A
-      // FAILED child's attempt is marked retryable (re-running a failed child
-      // is safe); a COMPLETED child whose manifest did not persist keeps its
-      // 'launched' marker, so a later run refuses to repeat side-effectful
-      // work rather than executing it twice.
-      let persisted: ResultMeta | null;
-      // A read failure is NOT the same fact as a missing manifest: keep it so
-      // the thrown error names the I/O cause instead of blaming persistence.
-      let readFailure: unknown;
-      try {
-        persisted = await store.readResultMeta();
-      } catch (cause) {
-        log.warn('Failed to read the persisted result manifest', {
-          data: { executionId, error: cause },
-        });
-        persisted = null;
-        readFailure = cause;
-      }
-      if (!persisted) {
-        if (childFailed) {
-          const error = childError();
-          await throwRetryableDurabilityError(
-            executionId,
-            stableAttempt,
-            new SubagentDurabilityError(
-              `Subagent ${executionId} failed (${toErrorMessage(error)}), and its failure result could not be persisted.`,
-              {
-                cause: new AggregateError(
-                  readFailure === undefined ? [error] : [error, readFailure],
-                  `Subagent ${executionId} execution and persistence both failed.`,
-                ),
-              },
-            ),
-          );
-        }
-        if (readFailure !== undefined) {
-          throw new SubagentDurabilityError(
-            `Failed to verify the persisted result for subagent ${executionId}.`,
-            { cause: readFailure },
-          );
-        }
-        throw new SubagentDurabilityError(
-          `Failed to persist result for subagent ${executionId}.`,
-        );
-      }
+      await verifyPersistedResultManifest(
+        store,
+        executionId,
+        stableAttempt,
+        childFailed,
+        childError,
+      );
     }
 
     if (

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -36,6 +36,7 @@ import {
 import { prRef, withSince } from './githubPaths';
 import {
   ghGet,
+  type ConditionalResponse,
   GitHubAuthError,
   GitHubPermanentError,
   GitHubRateLimitError,
@@ -196,6 +197,26 @@ export interface PRCurrentShaState {
   pendingAnnotationRuns: GhCheckRun[];
 }
 
+/**
+ * One tick's conditional GETs for everything except the PR detail itself,
+ * issued in parallel by `fetchTickResources`.
+ *
+ * `stagedCheckRunsCache` is deliberately carried alongside `checksRes` rather
+ * than committed by the fetch: the caller writes it to
+ * `currentShaState.checkRunsCache` only after consuming `checksRes`. See
+ * `fetchAllCheckRuns` and `commitStagedCheckRunsCache` for why.
+ */
+interface PRTickResources {
+  commentsRes: ConditionalResponse<GhIssueComment[]>;
+  reviewCommentsRes: ConditionalResponse<GhReviewComment[]>;
+  reviewsRes: ConditionalResponse<GhReview[]>;
+  checksRes: ConditionalResponse<{
+    total_count: number;
+    check_runs: GhCheckRun[];
+  }>;
+  stagedCheckRunsCache: CheckRunsCache | undefined;
+}
+
 export class PRPollingSource extends PollingSourceBase<
   string,
   PRSubscriptionState
@@ -285,95 +306,14 @@ export class PRPollingSource extends PollingSourceBase<
     const prPath = `/repos/${pr.owner}/${pr.repo}/pulls/${pr.pullNumber}`;
     const issuePath = `/repos/${pr.owner}/${pr.repo}/issues/${pr.pullNumber}`;
 
-    const prRes = await ghGet<GhPullRequest>(prPath, state.etags.pr);
-    if (prRes.status === 200) {
-      // Validate the state-driving PR payload. A parse failure must NOT throw:
-      // pollOne runs inside pollEntry's try/catch, and a throw here would bump
-      // consecutiveFailures every tick without advancing lastSuccessAt, so a
-      // persistently-odd-but-200 payload would detach this live subscription
-      // after the 24 h failure window. Log + return instead: returning lets
-      // pollEntry reset lastSuccessAt/consecutiveFailures, so the detach gate
-      // never trips. We skip BEFORE writing state.etags.pr, so the PR-detail
-      // ETag is not advanced on a bad body — the next tick re-fetches the same
-      // resource and re-validates (no strand).
-      const parsed = this.validateOrSkip(
-        prRes,
-        GhPullRequestSchema,
-        `Skipping PR poll for ${key}: malformed pull-request payload`,
-      );
-      if (!parsed) return;
-      const prData = parsed.data;
-      state.etags.pr = prRes.etag;
-      const newHead = prData.head.sha;
-      const newState = prData.state;
-      const newMerged = prData.merged;
-      const newMergeable = prData.mergeable_state;
-
-      // Detect close/merge on initialized subscriptions.
-      if (
-        state.initialized &&
-        state.state === 'open' &&
-        newState === 'closed'
-      ) {
-        this.emit(state, formatPRClosed(state.slug, pr.pullNumber, newMerged));
-        this.detach(key);
-        return;
-      }
-      state.state = newState;
-      state.merged = newMerged;
-      // New push invalidates prior CI terminal state — the next completion
-      // on the new SHA should re-emit CI progress events. Also drop the
-      // per-page check-runs cache: it's keyed only by page number, and the
-      // ETags from the previous SHA can never match the new SHA's responses.
-      // Letting it linger would cost one wasted If-None-Match per page on
-      // the first post-push tick before the cache naturally refreshes. Old
-      // SHA's deferred annotations are no longer the user's focus; the new
-      // SHA's runs will re-enqueue from the next 200 tick. Replacing the
-      // whole per-SHA object (rather than clearing fields one by one) means
-      // a future per-SHA field can't be left stale across a push.
-      if (state.currentShaState?.sha !== newHead) {
-        state.currentShaState = {
-          sha: newHead,
-          ciStarted: false,
-          ciComplete: false,
-          ciPassed: false,
-          checkRunsCache: undefined,
-          pendingAnnotationRuns: [],
-        };
-      }
-
-      // Mergeable-state transitions: only definite-to-definite reads count,
-      // so the seeding tick (and any tick where GitHub returns `'unknown'`)
-      // is silent. See `isDefiniteMergeableState` for the rationale.
-      if (isDefiniteMergeableState(newMergeable)) {
-        const prev = state.mergeableState;
-        state.mergeableState = newMergeable;
-        if (isDefiniteMergeableState(prev) && prev !== newMergeable) {
-          if (newMergeable === 'dirty') {
-            this.emit(
-              state,
-              formatMergeConflictDetected(state.slug, pr.pullNumber, prev),
-            );
-          } else if (prev === 'dirty') {
-            this.emit(
-              state,
-              formatMergeConflictResolved(
-                state.slug,
-                pr.pullNumber,
-                newMergeable,
-              ),
-            );
-          }
-        }
-      }
-    }
+    if (!(await this.refreshPrMetadata(key, state, prPath))) return;
 
     // Bail cleanly if the PR is already closed. On the first (initialization)
     // tick this prevents a zombie subscription: without this branch the
     // subscription would stay in the map forever, burning an API call every
     // 30s and a slot in the concurrent-subscription cap, because the
-    // open→closed auto-unsubscribe transition above never fires for a PR
-    // that was closed before we started watching.
+    // open→closed auto-unsubscribe transition in `refreshPrMetadata` never
+    // fires for a PR that was closed before we started watching.
     if (state.state === 'closed') {
       // Defense-in-depth: auto-unsubscribe whenever we land here while
       // still tracked, not only on `!initialized`. The open→closed
@@ -391,42 +331,18 @@ export class PRPollingSource extends PollingSourceBase<
       return;
     }
 
-    const issueCommentsUrl = withSince(
-      `${issuePath}/comments?per_page=100`,
-      state.issueComments.sinceCursor,
-    );
-    const reviewCommentsUrl = withSince(
-      `${prPath}/comments?per_page=100`,
-      state.reviewComments.sinceCursor,
-    );
-    const [commentsRes, reviewCommentsRes, reviewsRes, checksOutcome] =
-      await Promise.all([
-        ghGet<GhIssueComment[]>(issueCommentsUrl, state.etags.issueComments),
-        ghGet<GhReviewComment[]>(reviewCommentsUrl, state.etags.reviewComments),
-        ghGet<GhReview[]>(
-          `${prPath}/reviews?per_page=100`,
-          state.etags.reviews,
-        ),
-        state.currentShaState?.sha
-          ? fetchAllCheckRunsClient(
-              pr.owner,
-              pr.repo,
-              state.currentShaState.sha,
-              state.currentShaState.checkRunsCache,
-              this.logger,
-            )
-          : Promise.resolve({
-              response: { status: 304 as const },
-              stagedCache: undefined,
-            }),
-      ]);
-    // Destructure separately so we can commit `stagedCache` only at the end
-    // of the success path (after the diff branch). If a sibling rejection
-    // had thrown above, the cache would not have been advanced — preventing
-    // a stale cache + 304 next tick from silently swallowing check-run
-    // transitions.
-    const checksRes = checksOutcome.response;
-    const stagedCheckRunsCache = checksOutcome.stagedCache;
+    // `stagedCheckRunsCache` stays uncommitted here on purpose: it is written
+    // to `currentShaState.checkRunsCache` only at the end of the success path
+    // (after the diff branch), so a sibling rejection in the parallel fetch
+    // can never advance the cache while the diff never ran — a stale cache +
+    // 304 next tick would silently swallow check-run transitions.
+    const {
+      commentsRes,
+      reviewCommentsRes,
+      reviewsRes,
+      checksRes,
+      stagedCheckRunsCache,
+    } = await this.fetchTickResources(state, prPath, issuePath);
 
     // Issue/review comment lists: seed on the first tick (nothing emitted),
     // diff + emit on later ticks. consumeCommentList branches on
@@ -457,58 +373,7 @@ export class PRPollingSource extends PollingSourceBase<
 
     // First tick only seeds cursors so we never replay history.
     if (!state.initialized) {
-      if (reviewsRes.status === 200) {
-        state.etags.reviews = reviewsRes.etag;
-        // Skip PENDING: these are the authenticated user's own drafts
-        // (only visible via their own token). A review keeps the same ID
-        // when it transitions PENDING → APPROVED/CHANGES_REQUESTED/COMMENTED,
-        // so if we seed the pending id here the actual submission will be
-        // silently deduped later.
-        state.reviews.seed(reviewsRes.data.filter(isSubmittedReview));
-      }
-      if (checksRes.status === 200) {
-        // ETag/page caching is owned by `fetchAllCheckRuns` via
-        // `state.currentShaState.checkRunsCache`; nothing to record on
-        // `state.etags` here.
-        const runs = checksRes.data.check_runs;
-        for (const r of runs) {
-          if (isCheckFailure(r)) {
-            state.lastFailedCheckKeys.add(checkKey(r));
-          }
-          // Seed annotation keys so pre-subscription annotations don't
-          // replay; the timestamp in the key lets re-runs re-emit.
-          if (
-            r.status === 'completed' &&
-            (r.output?.annotations_count ?? 0) > 0
-          ) {
-            state.lastAnnotationKeys.add(checkKey(r));
-          }
-        }
-        if (state.currentShaState?.sha && runs.length > 0) {
-          state.currentShaState.ciStarted = true;
-        }
-        // Seed so pre-existing terminal CI doesn't fire on the next tick —
-        // we only surface transitions that happen after subscribe. See
-        // `ciTerminalStatus` for the gating rationale (empty/partial run sets,
-        // page-shift safety).
-        const { complete, passed } = ciTerminalStatus(
-          state.currentShaState?.sha,
-          runs,
-          checksRes.data.total_count,
-        );
-        if (complete && state.currentShaState) {
-          state.currentShaState.ciComplete = true;
-          if (passed) {
-            state.currentShaState.ciPassed = true;
-          }
-        }
-      }
-      // Commit the deferred check-runs cache only after successfully
-      // consuming the response. See `fetchAllCheckRuns` for why we defer.
-      if (stagedCheckRunsCache !== undefined && state.currentShaState) {
-        state.currentShaState.checkRunsCache = stagedCheckRunsCache;
-      }
-      state.initialized = true;
+      this.seedFirstTick(state, reviewsRes, checksRes, stagedCheckRunsCache);
       return;
     }
 
@@ -530,87 +395,317 @@ export class PRPollingSource extends PollingSourceBase<
       // ETag/page caching is owned by `fetchAllCheckRuns` via
       // `state.currentShaState.checkRunsCache`; nothing to record on
       // `state.etags` here.
-      const runs = checksRes.data.check_runs;
-
-      const currentShaState = state.currentShaState;
-      const headSha = currentShaState?.sha;
-      if (
-        currentShaState &&
-        headSha &&
-        runs.length > 0 &&
-        !currentShaState.ciStarted
-      ) {
-        currentShaState.ciStarted = true;
-        this.emit(
-          state,
-          formatCIStarted(
-            state.slug,
-            pr.pullNumber,
-            headSha,
-            runs,
-            checksRes.data.total_count,
-          ),
-        );
-      }
-
-      const { newFailures, currentFailureKeys } = computeNewCheckFailures(
-        runs,
-        state.lastFailedCheckKeys,
-      );
-      state.lastFailedCheckKeys = currentFailureKeys;
-      if (newFailures.length >= COALESCE_THRESHOLD) {
-        this.emit(
-          state,
-          formatCheckFailureSummary(state.slug, pr.pullNumber, newFailures),
-        );
-      } else {
-        for (const r of newFailures) {
-          this.emit(state, formatCheckFailure(state.slug, pr.pullNumber, r));
-        }
-      }
-
-      // Emit two one-shot events per head SHA: "CI complete" on first
-      // terminal state (any conclusion), then "CI passed" the first time
-      // all checks pass (which may happen via a later rerun). Each is
-      // deduped against its own marker so a rerun turning red→green still
-      // emits "CI passed" even after "CI complete" already fired.
-      //
-      // See `ciTerminalStatus` for the gating rationale (empty/partial run
-      // sets, page-shift safety).
-      const { complete, passed } = ciTerminalStatus(
-        headSha,
-        runs,
+      this.consumeCheckRuns(
+        state,
+        checksRes.data.check_runs,
         checksRes.data.total_count,
       );
-      if (complete && currentShaState && headSha) {
-        if (!currentShaState.ciComplete) {
-          currentShaState.ciComplete = true;
-          this.emit(
-            state,
-            formatCIComplete(state.slug, pr.pullNumber, headSha, runs),
-          );
-        }
-        if (!currentShaState.ciPassed && passed) {
-          currentShaState.ciPassed = true;
-          this.emit(
-            state,
-            formatCIPassed(state.slug, pr.pullNumber, headSha, runs),
-          );
-        }
-      }
-
-      // Annotations are emitted independently of failures: they also surface
-      // on passing checks (lint suggestions, custom workflow advisories).
-      // Enqueue here, drain below — the drain runs on every tick (including
-      // 304) so excess candidates aren't stranded once check-runs settle.
-      this.enqueueAnnotationCandidates(state, runs);
     }
 
     // Commit the deferred check-runs cache only after successfully consuming
-    // the response (including the diff branch above). See `fetchAllCheckRuns`
-    // for why we defer: this prevents a sibling rejection in the `Promise.all`
-    // from advancing the cache while the diff never ran, which would cause
-    // the next tick to get 304 and silently skip the missed transitions.
+    // the response (including the diff branch above).
+    this.commitStagedCheckRunsCache(state, stagedCheckRunsCache);
+  }
+
+  /**
+   * Conditional GET of the PR detail, applying every subscription-state
+   * transition it drives: close/merge auto-unsubscribe, the per-head-SHA state
+   * reset, and mergeable-state transitions.
+   *
+   * Returns `false` when the rest of the tick must be skipped — either a
+   * malformed payload or the open→closed transition that already detached the
+   * subscription. A 304 (or any non-200) leaves state untouched and continues.
+   */
+  private async refreshPrMetadata(
+    key: string,
+    state: PRSubscriptionState,
+    prPath: string,
+  ): Promise<boolean> {
+    const { pr } = state;
+    const prRes = await ghGet<GhPullRequest>(prPath, state.etags.pr);
+    if (prRes.status !== 200) return true;
+
+    // Validate the state-driving PR payload. A parse failure must NOT throw:
+    // pollOne runs inside pollEntry's try/catch, and a throw here would bump
+    // consecutiveFailures every tick without advancing lastSuccessAt, so a
+    // persistently-odd-but-200 payload would detach this live subscription
+    // after the 24 h failure window. Log + skip the tick instead: returning
+    // normally lets pollEntry reset lastSuccessAt/consecutiveFailures, so the
+    // detach gate never trips. We skip BEFORE writing state.etags.pr, so the
+    // PR-detail ETag is not advanced on a bad body — the next tick re-fetches
+    // the same resource and re-validates (no strand).
+    const parsed = this.validateOrSkip(
+      prRes,
+      GhPullRequestSchema,
+      `Skipping PR poll for ${key}: malformed pull-request payload`,
+    );
+    if (!parsed) return false;
+    const prData = parsed.data;
+    state.etags.pr = prRes.etag;
+    const newHead = prData.head.sha;
+    const newState = prData.state;
+    const newMerged = prData.merged;
+    const newMergeable = prData.mergeable_state;
+
+    // Detect close/merge on initialized subscriptions.
+    if (state.initialized && state.state === 'open' && newState === 'closed') {
+      this.emit(state, formatPRClosed(state.slug, pr.pullNumber, newMerged));
+      this.detach(key);
+      return false;
+    }
+    state.state = newState;
+    state.merged = newMerged;
+    // New push invalidates prior CI terminal state — the next completion
+    // on the new SHA should re-emit CI progress events. Also drop the
+    // per-page check-runs cache: it's keyed only by page number, and the
+    // ETags from the previous SHA can never match the new SHA's responses.
+    // Letting it linger would cost one wasted If-None-Match per page on
+    // the first post-push tick before the cache naturally refreshes. Old
+    // SHA's deferred annotations are no longer the user's focus; the new
+    // SHA's runs will re-enqueue from the next 200 tick. Replacing the
+    // whole per-SHA object (rather than clearing fields one by one) means
+    // a future per-SHA field can't be left stale across a push.
+    if (state.currentShaState?.sha !== newHead) {
+      state.currentShaState = {
+        sha: newHead,
+        ciStarted: false,
+        ciComplete: false,
+        ciPassed: false,
+        checkRunsCache: undefined,
+        pendingAnnotationRuns: [],
+      };
+    }
+
+    // Mergeable-state transitions: only definite-to-definite reads count,
+    // so the seeding tick (and any tick where GitHub returns `'unknown'`)
+    // is silent. See `isDefiniteMergeableState` for the rationale.
+    if (isDefiniteMergeableState(newMergeable)) {
+      const prev = state.mergeableState;
+      state.mergeableState = newMergeable;
+      if (isDefiniteMergeableState(prev) && prev !== newMergeable) {
+        if (newMergeable === 'dirty') {
+          this.emit(
+            state,
+            formatMergeConflictDetected(state.slug, pr.pullNumber, prev),
+          );
+        } else if (prev === 'dirty') {
+          this.emit(
+            state,
+            formatMergeConflictResolved(
+              state.slug,
+              pr.pullNumber,
+              newMergeable,
+            ),
+          );
+        }
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Issue every non-PR-detail conditional GET for one tick in parallel. The
+   * check-runs leg is skipped (synthesized as a 304) until a head SHA is
+   * known, and its cache replacement is returned staged rather than committed
+   * — see {@link PRTickResources}.
+   */
+  private async fetchTickResources(
+    state: PRSubscriptionState,
+    prPath: string,
+    issuePath: string,
+  ): Promise<PRTickResources> {
+    const { pr } = state;
+    const issueCommentsUrl = withSince(
+      `${issuePath}/comments?per_page=100`,
+      state.issueComments.sinceCursor,
+    );
+    const reviewCommentsUrl = withSince(
+      `${prPath}/comments?per_page=100`,
+      state.reviewComments.sinceCursor,
+    );
+    const [commentsRes, reviewCommentsRes, reviewsRes, checksOutcome] =
+      await Promise.all([
+        ghGet<GhIssueComment[]>(issueCommentsUrl, state.etags.issueComments),
+        ghGet<GhReviewComment[]>(reviewCommentsUrl, state.etags.reviewComments),
+        ghGet<GhReview[]>(
+          `${prPath}/reviews?per_page=100`,
+          state.etags.reviews,
+        ),
+        state.currentShaState?.sha
+          ? fetchAllCheckRunsClient(
+              pr.owner,
+              pr.repo,
+              state.currentShaState.sha,
+              state.currentShaState.checkRunsCache,
+              this.logger,
+            )
+          : Promise.resolve({
+              response: { status: 304 as const },
+              stagedCache: undefined,
+            }),
+      ]);
+    return {
+      commentsRes,
+      reviewCommentsRes,
+      reviewsRes,
+      checksRes: checksOutcome.response,
+      stagedCheckRunsCache: checksOutcome.stagedCache,
+    };
+  }
+
+  /**
+   * First tick for a subscription: seed the review and check-run cursors so
+   * pre-subscription history is never replayed, then mark the subscription
+   * initialized. Emits nothing. Comment lists are seeded by the shared
+   * `consumeCommentList` calls that run before this, on every tick.
+   */
+  private seedFirstTick(
+    state: PRSubscriptionState,
+    reviewsRes: PRTickResources['reviewsRes'],
+    checksRes: PRTickResources['checksRes'],
+    stagedCheckRunsCache: CheckRunsCache | undefined,
+  ): void {
+    if (reviewsRes.status === 200) {
+      state.etags.reviews = reviewsRes.etag;
+      // Skip PENDING: these are the authenticated user's own drafts
+      // (only visible via their own token). A review keeps the same ID
+      // when it transitions PENDING → APPROVED/CHANGES_REQUESTED/COMMENTED,
+      // so if we seed the pending id here the actual submission will be
+      // silently deduped later.
+      state.reviews.seed(reviewsRes.data.filter(isSubmittedReview));
+    }
+    if (checksRes.status === 200) {
+      // ETag/page caching is owned by `fetchAllCheckRuns` via
+      // `state.currentShaState.checkRunsCache`; nothing to record on
+      // `state.etags` here.
+      const runs = checksRes.data.check_runs;
+      for (const r of runs) {
+        if (isCheckFailure(r)) {
+          state.lastFailedCheckKeys.add(checkKey(r));
+        }
+        // Seed annotation keys so pre-subscription annotations don't
+        // replay; the timestamp in the key lets re-runs re-emit.
+        if (
+          r.status === 'completed' &&
+          (r.output?.annotations_count ?? 0) > 0
+        ) {
+          state.lastAnnotationKeys.add(checkKey(r));
+        }
+      }
+      if (state.currentShaState?.sha && runs.length > 0) {
+        state.currentShaState.ciStarted = true;
+      }
+      // Seed so pre-existing terminal CI doesn't fire on the next tick —
+      // we only surface transitions that happen after subscribe. See
+      // `ciTerminalStatus` for the gating rationale (empty/partial run sets,
+      // page-shift safety).
+      const { complete, passed } = ciTerminalStatus(
+        state.currentShaState?.sha,
+        runs,
+        checksRes.data.total_count,
+      );
+      if (complete && state.currentShaState) {
+        state.currentShaState.ciComplete = true;
+        if (passed) {
+          state.currentShaState.ciPassed = true;
+        }
+      }
+    }
+    // Commit the deferred check-runs cache only after successfully consuming
+    // the response.
+    this.commitStagedCheckRunsCache(state, stagedCheckRunsCache);
+    state.initialized = true;
+  }
+
+  /**
+   * Diff one tick's check runs against the per-SHA markers and emit the
+   * resulting events: the one-shot "CI triggered", new failures (coalesced
+   * past {@link COALESCE_THRESHOLD}), the one-shot "CI complete"/"CI passed",
+   * and the annotation candidates queued for the post-tick drain.
+   */
+  private consumeCheckRuns(
+    state: PRSubscriptionState,
+    runs: GhCheckRun[],
+    totalCount: number,
+  ): void {
+    const { pr } = state;
+    const currentShaState = state.currentShaState;
+    const headSha = currentShaState?.sha;
+    if (
+      currentShaState &&
+      headSha &&
+      runs.length > 0 &&
+      !currentShaState.ciStarted
+    ) {
+      currentShaState.ciStarted = true;
+      this.emit(
+        state,
+        formatCIStarted(state.slug, pr.pullNumber, headSha, runs, totalCount),
+      );
+    }
+
+    const { newFailures, currentFailureKeys } = computeNewCheckFailures(
+      runs,
+      state.lastFailedCheckKeys,
+    );
+    state.lastFailedCheckKeys = currentFailureKeys;
+    if (newFailures.length >= COALESCE_THRESHOLD) {
+      this.emit(
+        state,
+        formatCheckFailureSummary(state.slug, pr.pullNumber, newFailures),
+      );
+    } else {
+      for (const r of newFailures) {
+        this.emit(state, formatCheckFailure(state.slug, pr.pullNumber, r));
+      }
+    }
+
+    // Emit two one-shot events per head SHA: "CI complete" on first
+    // terminal state (any conclusion), then "CI passed" the first time
+    // all checks pass (which may happen via a later rerun). Each is
+    // deduped against its own marker so a rerun turning red→green still
+    // emits "CI passed" even after "CI complete" already fired.
+    //
+    // See `ciTerminalStatus` for the gating rationale (empty/partial run
+    // sets, page-shift safety).
+    const { complete, passed } = ciTerminalStatus(headSha, runs, totalCount);
+    if (complete && currentShaState && headSha) {
+      if (!currentShaState.ciComplete) {
+        currentShaState.ciComplete = true;
+        this.emit(
+          state,
+          formatCIComplete(state.slug, pr.pullNumber, headSha, runs),
+        );
+      }
+      if (!currentShaState.ciPassed && passed) {
+        currentShaState.ciPassed = true;
+        this.emit(
+          state,
+          formatCIPassed(state.slug, pr.pullNumber, headSha, runs),
+        );
+      }
+    }
+
+    // Annotations are emitted independently of failures: they also surface
+    // on passing checks (lint suggestions, custom workflow advisories).
+    // Enqueue here, drain in `afterTick` — the drain runs on every tick
+    // (including 304) so excess candidates aren't stranded once check-runs
+    // settle.
+    this.enqueueAnnotationCandidates(state, runs);
+  }
+
+  /**
+   * Commit the check-runs page cache staged by `fetchAllCheckRuns`. The single
+   * owner of that write, called from both tick shapes (seeding and diffing) at
+   * the same point: only after the response has been fully consumed. See
+   * `fetchAllCheckRuns` for why the commit is deferred — advancing the cache
+   * while the consume step never ran would make the next tick 304 and silently
+   * skip the missed transitions.
+   */
+  private commitStagedCheckRunsCache(
+    state: PRSubscriptionState,
+    stagedCheckRunsCache: CheckRunsCache | undefined,
+  ): void {
     if (stagedCheckRunsCache !== undefined && state.currentShaState) {
       state.currentShaState.checkRunsCache = stagedCheckRunsCache;
     }

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1854,7 +1854,9 @@ export class StreamSnapshotStore {
           // Snapshot the surviving state BEFORE the restore below, whose
           // `persistEagerOverlays` drains the very overlays it reads.
           const resolvedRefreshBaseline =
-            refreshBaseline === 'unknown' ? current?.diskState : refreshBaseline;
+            refreshBaseline === 'unknown'
+              ? current?.diskState
+              : refreshBaseline;
           const failureBaseline: DiskState | undefined =
             reportArtifactAuthority && current && versionIsCurrent
               ? resolvedRefreshBaseline

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -101,26 +101,33 @@ const MAX_DIRTY_WRITE_RETRIES = 3;
 
 class DirtySidecarWritesError extends Error {}
 
-/** Artifact state whose in-memory values remain authoritative after preload fails. */
-export interface StreamArtifactAuthority {
-  /**
-   * The whole in-memory record is authoritative: a prior seed or an existence
-   * probe already established this stream's disk baseline, so every
-   * accumulator holds the complete field value and not just a delta.
-   */
-  readonly complete: boolean;
-  readonly todos: boolean;
+/**
+ * Per-field provenance of one stream's work plan: whether the in-memory value
+ * for that field has an established origin — a seeded disk baseline, or a live
+ * replacement applied ahead of one — rather than an unread default. Todos and
+ * plan are whole-value replacements, so a live overlay for either establishes
+ * that field on its own; every other accumulator is a delta over a base only a
+ * baseline can supply. Read live via {@link StreamSnapshotStore.workPlanProvenance}.
+ */
+export interface WorkPlanProvenance {
   readonly plan: boolean;
+  readonly todos: boolean;
 }
 
-/** A failed preload together with the in-memory fields that remain usable. */
+/** A failed preload together with the in-memory state that remains usable. */
 export class StreamSnapshotPreloadError extends Error {
   override readonly name = 'StreamSnapshotPreloadError';
 
   constructor(
     cause: unknown,
     readonly streamId: StreamTabId,
-    readonly authoritativeFields: StreamArtifactAuthority,
+    /**
+     * The whole in-memory record is authoritative: a prior seed or an
+     * existence probe already established this stream's disk baseline, so
+     * every accumulator holds the complete field value and not just a delta.
+     */
+    readonly baselineEstablished: boolean,
+    readonly workPlanProvenance: WorkPlanProvenance,
   ) {
     super(cause instanceof Error ? cause.message : String(cause), { cause });
   }
@@ -349,17 +356,16 @@ function mergeUsagePatch(
  */
 type DiskState = 'unknown' | 'verified-absent' | 'loaded';
 
-function artifactAuthorityAfterPreloadFailure(
+function workPlanProvenanceOf(
   baseline: DiskState,
   overlays: Partial<OverlayPatches>,
-): StreamArtifactAuthority {
+): WorkPlanProvenance {
   // Without an established baseline the output-file / missing-output /
   // compile-failure / usage overlays are deltas over an unread disk state, so
   // they establish nothing. Plan and todos are replacements, so a live overlay
   // for either is authoritative on its own.
   const complete = baseline !== 'unknown';
   return {
-    complete,
     todos: complete || overlays.workPlan?.todos !== undefined,
     plan: complete || overlays.workPlan?.plan !== undefined,
   };
@@ -1430,6 +1436,28 @@ export class StreamSnapshotStore {
     return Object.values(record.overlays).some((patch) => patch !== undefined);
   }
 
+  /**
+   * Which work-plan fields this record can vouch for right now — the same
+   * question {@link StreamSnapshotPreloadError.workPlanProvenance} answers at
+   * one failure instant, asked live. A reader that could not vouch for a field
+   * when its load failed re-reads this instead of tracking promotions of its
+   * own: a later live todos/plan write or a completed seed establishes the
+   * field here, and this store is the only owner of that fact.
+   *
+   * An in-flight refresh does not retract it. `refreshSeed` parks the record at
+   * 'unknown' so mutations queue behind the new read, but the accumulators it
+   * is about to refresh still hold their established values, so the captured
+   * `seedRefreshBaseline` — not the parked state — answers for readers.
+   */
+  workPlanProvenance(stream: StreamTabId): WorkPlanProvenance {
+    const record = this.records.get(stream);
+    if (!record) return { plan: false, todos: false };
+    return workPlanProvenanceOf(
+      record.seedRefreshBaseline ?? record.diskState,
+      record.overlays,
+    );
+  }
+
   /** Streams with persisted sidecars under `streamData/`. */
   async listPersistedStreams(): Promise<StreamTabId[]> {
     return this.listStreamsUnder(STREAM_DATA_DIR);
@@ -1823,14 +1851,17 @@ export class StreamSnapshotStore {
         (error: unknown) => {
           const current = this.records.get(stream);
           const versionIsCurrent = this.streamVersion(stream) === version;
-          const authoritativeFields =
+          // Snapshot the surviving state BEFORE the restore below, whose
+          // `persistEagerOverlays` drains the very overlays it reads.
+          const resolvedRefreshBaseline =
+            refreshBaseline === 'unknown' ? current?.diskState : refreshBaseline;
+          const failureBaseline: DiskState | undefined =
             reportArtifactAuthority && current && versionIsCurrent
-              ? artifactAuthorityAfterPreloadFailure(
-                  refreshBaseline === 'unknown'
-                    ? current.diskState
-                    : refreshBaseline,
-                  current.overlays,
-                )
+              ? resolvedRefreshBaseline
+              : undefined;
+          const failureWorkPlanProvenance =
+            failureBaseline !== undefined && current
+              ? workPlanProvenanceOf(failureBaseline, current.overlays)
               : undefined;
           if (
             current?.seedRefreshGeneration === refreshGeneration &&
@@ -1843,11 +1874,12 @@ export class StreamSnapshotStore {
             }
             if (current.seedChain === next) current.seedChain = undefined;
           }
-          if (authoritativeFields) {
+          if (failureBaseline !== undefined && failureWorkPlanProvenance) {
             throw new StreamSnapshotPreloadError(
               error,
               stream,
-              authoritativeFields,
+              failureBaseline !== 'unknown',
+              failureWorkPlanProvenance,
             );
           }
           throw error;

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -26,7 +26,7 @@ export {
 export {
   StreamSnapshotPreloadError,
   StreamSnapshotStore,
-  type StreamArtifactAuthority,
+  type WorkPlanProvenance,
 } from './StreamSnapshotStore';
 export { assembleTrace, type AssembleTraceResult } from './traceAssembler';
 export type { TraceDocument } from './traceDocumentSchema';


### PR DESCRIPTION
## Summary

This PR extracts complex polling and execution logic into focused helper methods to improve code clarity and maintainability. The changes consolidate related operations into single-responsibility functions without altering behavior.

**PRPollingSource.ts:** Extracted PR metadata refresh, tick resource fetching, first-tick seeding, and check-run consumption into dedicated methods. Introduced `PRTickResources` interface to document the parallel fetch contract.

**inBandSubagentExecution.ts:** Extracted child registration, stable completion commit, and result manifest verification into helper functions with clear error classification.

**StreamSnapshotStore.ts:** Renamed `StreamArtifactAuthority` to `WorkPlanProvenance` for semantic clarity (the interface describes field provenance, not authority over all artifacts). Updated `StreamSnapshotPreloadError` to use the new name and clarify the `baselineEstablished` boolean.

**terminalText.ts:** Extracted `firstFittingCandidate` utility for widest-first layout cascades, replacing inline implementations in status bar and modal code.

**KeyHints.tsx:** Added `keyHintsText` helper to project hint strips consistently.

**Shared logging:** Added `@shared/log` module for browser-safe diagnostic output from webview-reachable code.

## Issue acceptance gates

N/A — this is a refactoring/clarity improvement with no issue.

## Single source of truth

- `PRTickResources` documents the contract for parallel resource fetching in one tick
- `WorkPlanProvenance` (renamed from `StreamArtifactAuthority`) owns the semantics of per-field provenance
- `firstFittingCandidate` owns the widest-first layout cascade pattern
- `@shared/log` owns diagnostic output for browser-reachable code

## Duplication and abstraction budget

**Removed duplication:**
- Consolidated PR polling logic (metadata refresh, resource fetching, seeding, check-run consumption) from inline code into four focused methods
- Consolidated subagent execution logic (registration, completion commit, manifest verification) into three focused functions
- Extracted `firstFittingCandidate` to replace three separate inline cascade implementations
- Extracted `keyHintsText` to replace inline hint-strip formatting

**Abstraction invariants:**
- `PRTickResources` clarifies why `stagedCheckRunsCache` is staged rather than committed immediately
- `firstFittingCandidate` owns the widest-first cascade pattern with pluggable measurement
- `@shared/log` owns the single diagnostic sink for browser-reachable code (no Node built-ins, no secret redaction)

## Net elements (R6)

**Files:**
- Modified: 20 files
- Added: 1 file (`src/shared/log.ts`)

**Exported symbols:**
- Added: `firstFittingCandidate`, `keyHintsText`, `logWarn`, `logError`, `WorkPlanProvenance` (renamed from `StreamArtifactAuthority`)
- Removed: `StreamArtifactAuthority` (renamed)

**Classes/interfaces:**
- Added: `PRTickResources` interface
- Renamed: `StreamArtifactAuthority` → `WorkPlanProvenance`
- Modified: `StreamSnapshotPreloadError` (field renames for clarity)

**Net LoC:** ~+200 (extraction adds method signatures and docstrings; inline code removed)

## Consumer counts (R8)

**`StreamArtifactAuthority` → `WorkPlanProvenance`:** 8 files updated (rename only, no behavior change)
- `cliState.ts`, `WorkPlanReader.tsx`, `subscribeStreamArtifacts.ts`, `sessionCommands.ts`, `SlashCommandDispatch.vitest.ts`, `StreamSnapshotStore.vitest.ts`, `index.ts` (transcript), `chatSessionController.ts`

**`firstFittingCandidate`:** 3 new call sites (statusBarDisplay.ts, ConfirmCardState.ts, ExternalInquiry.tsx)

**`keyHintsText`:** 3 new call sites (statusBarDisplay.ts, WorkPlanReader.tsx

https://claude.ai/code/session_01NUBziiy7hX89367XqPdYWW