### PR TITLE
docs(settings): correct modelProviderToggle's PROVIDER_ROUTING_SETTINGS parallel

### DIFF
--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -344,13 +344,15 @@ function surfacedSetting(entry: SurfacedSettingInput): SurfacedSettingEntry {
 }
 
 /**
- * A Models-tab provider toggle: a globally-stored boolean that renders both as
+ * A Models-tab provider toggle: a globally-scoped boolean that renders both as
  * a profile row and as one per-provider control on the Models tab. These rows
  * differ only in their default, copy, honoring reader, and Models-tab control,
- * so the uniform `configTarget: 'global'` / `category: 'model'` /
- * `settingsView: 'profile'` framing is written once here — the same tabulation
- * the region toggles already use through `PROVIDER_ROUTING_SETTINGS`. Returns a
- * `CORE_SETTING_ROWS` body (key and slot are added by the config-tree mapping).
+ * so the uniform framing is written once here: the `category: 'model'` /
+ * `settingsView: 'profile'` / Models-tab surface the region toggles already
+ * share through `PROVIDER_ROUTING_SETTINGS`, plus the `configTarget: 'global'`
+ * these config-tree rows require (the region toggles instead live in
+ * `globalState` and set `cliConfig`). Returns a `CORE_SETTING_ROWS` body (key
+ * and slot are added by the config-tree mapping).
  */
 function modelProviderToggle(opts: {
   readonly default: boolean;


### PR DESCRIPTION
## Summary

The `modelProviderToggle()` helper itself already landed on `main` via #11569. This PR now carries **only** a doc-accuracy fix to that helper's JSDoc, addressing a reviewer nit: the comment claimed the region toggles built by `PROVIDER_ROUTING_SETTINGS` use "the same tabulation" including `configTarget: 'global'`. That is imprecise — those rows are `globalState`-backed (`slots: sameSlot('globalState')`), carry no `configTarget`, and set `cliConfig: true`. What they actually share with `modelProviderToggle` is `category: 'model'`, `settingsView: 'profile'`, and a Models-tab surface; `configTarget: 'global'` is specific to these config-tree rows.

The branch was restarted from the current `main` so this PR contains just the one comment reword, not a re-application of the already-merged extraction.

## Issue acceptance gates

N/a — doc-accuracy fix, no issue.

## Single source of truth

No change. The comment now accurately describes what `modelProviderToggle` and `PROVIDER_ROUTING_SETTINGS` share versus what is specific to config-tree rows.

## Duplication and abstraction budget

No code change. Comment-only.

## Net elements (R6)

- Files: 1 changed (`src/shared/schemas/stateSettings.ts`), diffstat `+7 / −5`, comment-only.
- Exported symbols: 0 added, 0 removed.
- No classes/interfaces/enums/functions added or removed.

## Consumer counts (R8)

n/a — comment-only; no emit path or export changed.

## Host impact

Extension: none. Desktop: none. CLI: none. (Comment-only — no behavior change.)

## Scheduled refactoring

None.

## Validation

- `npx eslint src/shared/schemas/stateSettings.ts` — clean.
- `npx prettier --check` — clean.
- Comment-only change; no type or runtime surface affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lfqn2jBReE7sqyTDDTVCSY