### PR TITLE
fix(ui): improve interaction accessibility

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts
+++ b/packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts
@@ -25,6 +25,14 @@ import { waIcon } from '@shared/wa/webAwesomeIcons';
 const MENU_EVENTS = ['approve-session', 'approve-all-delegated-work'] as const;
 type MenuEvent = (typeof MENU_EVENTS)[number];
 
+/** Keep the visible "Approve" text in the accessible name while adding the
+ * request-specific context supplied by the parent panel. */
+function accessibleApproveLabel(title: string): string {
+  const context = title.trim();
+  if (!context || /^approve\b/i.test(context)) return context || 'Approve';
+  return `Approve: ${context}`;
+}
+
 /**
  * Approve control for approval prompts, used declaratively:
  *
@@ -87,9 +95,11 @@ export class ApproveSplitButton extends LitElement {
   override render(): TemplateResult {
     const hasMenu =
       !this.disabled && (this.canBypass || this.canApproveAllDelegatedWork);
+    const approveLabel = accessibleApproveLabel(this.approveTitle);
     const approveButton = renderLabeledActionButton({
       icon: 'check',
       text: 'Approve',
+      label: approveLabel,
       title: this.approveTitle,
       action: 'approve',
       kind: hasMenu ? undefined : 'primary',

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -127,8 +127,8 @@ export class BackgroundTasksPanel extends LitElement {
       }
 
       .task-name {
-        flex: 0 1 auto;
-        max-width: min(14rem, 40%);
+        display: block;
+        min-width: 0;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -136,6 +136,15 @@ export class BackgroundTasksPanel extends LitElement {
       }
 
       .task-name--clickable {
+        appearance: none;
+        flex: 0 1 auto;
+        min-width: 0;
+        max-width: min(14rem, 40%);
+        padding: 0;
+        border: 0;
+        background: transparent;
+        font: inherit;
+        text-align: start;
         cursor: pointer;
         color: var(--color-text-link);
         text-decoration: underline;
@@ -145,6 +154,10 @@ export class BackgroundTasksPanel extends LitElement {
 
       .task-name--clickable:hover {
         text-decoration-color: currentColor;
+      }
+
+      .task-name--clickable .task-name {
+        color: inherit;
       }
 
       /* Sits between the name and the description: a run's phase identifies
@@ -174,6 +187,7 @@ export class BackgroundTasksPanel extends LitElement {
       .task-elapsed {
         flex-shrink: 0;
         font-size: var(--font-size-xs);
+        font-variant-numeric: tabular-nums;
         color: var(--color-text-secondary);
       }
 
@@ -181,6 +195,7 @@ export class BackgroundTasksPanel extends LitElement {
         flex: 0 0 auto;
         font-family: var(--wa-font-family-code);
         font-size: var(--font-size-xs);
+        font-variant-numeric: tabular-nums;
         color: var(--color-text-secondary);
       }
 
@@ -338,7 +353,7 @@ export class BackgroundTasksPanel extends LitElement {
     const preview = thread.lastQuestionPreview || '(empty question)';
     const idPrefix = `background-inquiry-${index}`;
     return html`
-      <div class="task-header">
+      <div class="task-header" role="listitem">
         ${waIcon('circle-question', { className: 'task-icon task-icon--inquiry' })}
         <span class="inquiry-id">${thread.threadId}</span>
         <span id="${idPrefix}-description" class="task-description"
@@ -413,7 +428,9 @@ export class BackgroundTasksPanel extends LitElement {
     if (items.length === 0) return nothing;
 
     const content = html`
-      <div class="section-content">${repeat(items, key, renderItem)}</div>
+      <div class="section-content" role="list">
+        ${repeat(items, key, renderItem)}
+      </div>
     `;
     if (!withHeader) return content;
 
@@ -448,25 +465,22 @@ export class BackgroundTasksPanel extends LitElement {
     const displayName = runIdentityDisplayName(child.identity);
 
     return html`
-      <div class="task-header">
+      <div class="task-header" role="listitem">
         ${waIcon(icon, {
           className: `task-icon ${child.identity.kind === 'process' ? 'task-icon--process' : 'task-icon--subagent'}`,
         })}
-        <span
+        <button
           id="${idPrefix}-name"
-          class="task-name task-name--clickable"
-          role="link"
-          tabindex="0"
+          class="task-name--clickable"
+          type="button"
+          aria-label="Open ${displayName} stream"
           @click=${() => this.navigateToStream(childStreamId)}
-          @keydown=${(e: KeyboardEvent) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              this.navigateToStream(childStreamId);
-            }
-          }}
-          >${displayName}</span
         >
-        <wa-tooltip for="${idPrefix}-name">Go to ${displayName}</wa-tooltip>
+          <span class="task-name">${displayName}</span>
+        </button>
+        <wa-tooltip for="${idPrefix}-name"
+          >Open ${displayName} stream</wa-tooltip
+        >
         ${
           phaseLabel
             ? html`<span id="${idPrefix}-phase" class="task-phase"

--- a/packages/extension/src/progressView/frontend/components/BaseApprovalPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseApprovalPanel.ts
@@ -116,12 +116,19 @@ export abstract class BaseApprovalPanel<
    * surface via the overridable members above; none re-template this markup.
    */
   protected renderApproveButton(approveTitle: string): TemplateResult {
+    // Rejection feedback is a distinct decision mode. Keep the one-off
+    // Approve action available so the user can change course, but hide the
+    // conflicting run-scoped grants just as handleKeyboardShortcut blocks
+    // their `a` accelerator while feedback is open.
+    const canUseRunScopedApproval = !this.showFeedback;
     return html`
       <approve-split-button
         .approveTitle=${approveTitle}
-        .canBypass=${this.canBypass}
+        .canBypass=${canUseRunScopedApproval && this.canBypass}
         .bypassAction=${this.bypassAction}
-        .canApproveAllDelegatedWork=${this.canApproveAllDelegatedWork}
+        .canApproveAllDelegatedWork=${
+          canUseRunScopedApproval && this.canApproveAllDelegatedWork
+        }
         .disabled=${this.archived}
         @approve=${() => this.emitAction(this.approvalDecision)}
         @approve-session=${() => this.approveSessionHandler()}

--- a/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
@@ -25,7 +25,10 @@ export const REDIRECT_FEEDBACK_PROMPT = 'What should the agent do instead?';
 export abstract class BaseFeedbackPanel<
   K extends FeedbackPermissionKind = FeedbackPermissionKind,
 > extends BaseRequestPanel<K> {
-  @query('[data-feedback-input]') private feedbackInput?: HTMLElement;
+  @query('[data-feedback-input]')
+  private feedbackInput?: HTMLElementTagNameMap['wa-textarea'];
+  @query('wa-button[data-action="reject"]')
+  private rejectButton?: HTMLElement;
   @state() protected showFeedback = false;
 
   // ===========================================================================
@@ -42,7 +45,7 @@ export abstract class BaseFeedbackPanel<
         return true;
       case 'escape':
         if (this.showFeedback) {
-          this.showFeedback = false;
+          this.hideFeedback();
           return true;
         }
         return false;
@@ -77,6 +80,22 @@ export abstract class BaseFeedbackPanel<
     });
   }
 
+  private handleFeedbackKeydown(event: KeyboardEvent): void {
+    if (event.key !== 'Escape') return;
+
+    // RequestPanels deliberately ignores shortcuts while a text field owns
+    // focus. Handle Escape at the field so the advertised dismissal still
+    // works, then return focus to the action that opened it.
+    event.preventDefault();
+    event.stopPropagation();
+    this.hideFeedback();
+  }
+
+  private hideFeedback(): void {
+    this.showFeedback = false;
+    void this.updateComplete.then(() => this.rejectButton?.focus());
+  }
+
   protected renderRejectButton(rejectTitle: string): TemplateResult {
     // Both states keep the reject icon and name the consequence. Switching to
     // a checkmark labelled "Submit" made the confirm step of a rejection wear
@@ -94,23 +113,26 @@ export abstract class BaseFeedbackPanel<
   protected renderFeedbackSection(
     containerClass: string,
     inputClass: string,
-    placeholder = 'What should the agent change?',
+    prompt = 'What should the agent change?',
   ): TemplateResult | typeof nothing {
     if (!this.showFeedback) return nothing;
 
-    // A visible label, not a placeholder doing the label's job: the
-    // placeholder disappears on the first keystroke, taking the only
-    // description of the field with it.
+    // Use Web Awesome's supported label/hint API so both strings reach the
+    // internal textarea's accessibility tree as well as remaining visible.
     return html`
       <div class=${containerClass}>
-        <label for="feedback-input">${placeholder}</label>
         <wa-textarea
-          id="feedback-input"
           class=${inputClass}
-          placeholder="Optional — this is sent back to the agent"
+          name="rejection-feedback"
+          label=${prompt}
+          hint="Optional. This note is sent to the agent."
           rows="2"
           resize="vertical"
+          autocomplete="off"
+          spellcheck="true"
+          ?disabled=${this.archived}
           data-feedback-input
+          @keydown=${this.handleFeedbackKeydown}
         ></wa-textarea>
       </div>
     `;
@@ -121,9 +143,7 @@ export abstract class BaseFeedbackPanel<
   // ===========================================================================
 
   private getFeedbackValue(): string | undefined {
-    const trimmed = (
-      (this.feedbackInput as HTMLElement & { value?: string })?.value ?? ''
-    ).trim();
+    const trimmed = (this.feedbackInput?.value ?? '').trim();
     return trimmed || undefined;
   }
 }

--- a/packages/extension/src/progressView/frontend/components/BashRequestPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/BashRequestPanel.styles.ts
@@ -6,6 +6,14 @@ export const bashRequestPanelStyles: CSSResult = css`
   .bash-approval-request__command {
     font-family: var(--wa-font-family-mono);
     font-size: var(--font-size-sm);
+    font-variant-ligatures: none;
+    line-height: var(--line-height-normal);
+    text-align: start;
+  }
+
+  .bash-approval-request__command .tool-command-input {
+    direction: ltr;
+    text-align: left;
   }
 
   /* The directory a command will run in is the security-relevant field of
@@ -22,12 +30,7 @@ export const bashRequestPanelStyles: CSSResult = css`
     overflow-wrap: anywhere;
   }
 
-  .bash-approval-request__cwd span {
+  .bash-approval-request__cwd bdi {
     color: var(--wa-color-text-normal);
-  }
-
-  .bash-approval-request__command .code-block pre {
-    white-space: pre-wrap;
-    word-break: break-word;
   }
 `;

--- a/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
@@ -47,16 +47,21 @@ export class BashRequestPanel extends BaseBypassApprovalPanel<'bash'> {
         ${
           data.cwd
             ? html`<div class="bash-approval-request__cwd">
-                Directory: <span>${data.cwd}</span>
+                Runs in: <bdi dir="ltr">${data.cwd}</bdi>
               </div>`
             : nothing
         }
         <div class="bash-approval-request__command">
-          ${buildCodeBlock(data.command ?? '', { language: 'bash' })}
+          ${buildCodeBlock(data.command, {
+            language: 'bash',
+            className: 'tool-command-input',
+            showLanguage: true,
+            showCopy: true,
+          })}
         </div>
       `,
-      approveTitle: 'Allow this command to execute (y)',
-      rejectTitle: 'Reject this command (n)',
+      approveTitle: 'Run this command (y)',
+      rejectTitle: 'Do not run this command (n)',
     });
   }
 }

--- a/packages/extension/src/progressView/frontend/components/ContextManagement.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/ContextManagement.styles.ts
@@ -12,14 +12,16 @@ export const contextManagementStyles: CSSResult = css`
     margin: 0;
   }
 
-  /* Extend .details-summary from commonViewStyles with accent color */
-  .details-summary,
-  .details-summary .icon,
-  .context-title {
+  /* Keep the event color on the decorative status cue. Chart tokens are not
+     guaranteed to meet text contrast across every host theme. */
+  .details-summary .icon {
     color: var(--accent-color, var(--wa-color-text-normal));
   }
 
   .context-title {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    color: var(--wa-color-text-normal);
     font-weight: var(--font-weight-medium);
   }
 
@@ -32,6 +34,7 @@ export const contextManagementStyles: CSSResult = css`
   .stat-item {
     display: inline-flex;
     align-items: center;
+    min-width: 0;
     gap: var(--wa-space-3xs);
     font-size: var(--font-size-sm);
   }
@@ -40,8 +43,13 @@ export const contextManagementStyles: CSSResult = css`
     color: var(--color-text-muted);
   }
 
+  .stat-value {
+    overflow-wrap: anywhere;
+    font-variant-numeric: tabular-nums;
+  }
+
   .summary-block {
-    margin-top: var(--wa-space-2xs);
+    margin-block-start: var(--wa-space-2xs);
     display: block;
     width: 100%;
   }
@@ -59,7 +67,7 @@ export const contextManagementStyles: CSSResult = css`
     margin: 0;
     padding: var(--wa-space-2xs);
     white-space: pre-wrap;
-    word-break: break-word;
+    overflow-wrap: anywhere;
     border: var(--border-thin) solid var(--wa-color-surface-border);
     border-radius: var(--border-radius-small);
     background: var(--wa-color-surface-raised);

--- a/packages/extension/src/progressView/frontend/components/ContextManagement.ts
+++ b/packages/extension/src/progressView/frontend/components/ContextManagement.ts
@@ -79,7 +79,9 @@ export class ContextManagement extends LitElement {
             (item) => item.label,
             (item, index) => html`
               <span id="context-stat-${index}" class="stat-item">
-                ${waIcon(item.icon)} ${item.value}
+                ${waIcon(item.icon)}
+                <span class="visually-hidden">${item.label}: </span>
+                <bdi class="stat-value">${item.value}</bdi>
               </span>
               <wa-tooltip for="context-stat-${index}">${item.label}</wa-tooltip>
             `,
@@ -91,7 +93,7 @@ export class ContextManagement extends LitElement {
                     <div class="summary-title">
                       ${waIcon('note-sticky')} Compaction summary
                     </div>
-                    <pre class="summary-text">${this.summary}</pre>
+                    <pre class="summary-text" dir="auto">${this.summary}</pre>
                   </div>
                 `
               : nothing

--- a/packages/extension/src/progressView/frontend/components/ConversationContent.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/ConversationContent.styles.ts
@@ -49,6 +49,7 @@ export const conversationContentStyles: CSSResult = css`
     padding-top: var(--wa-space-xs);
     overflow-x: hidden;
     overflow-y: auto;
+    overscroll-behavior-block: contain;
     scrollbar-width: thin;
     position: relative;
     z-index: 2;
@@ -62,6 +63,7 @@ export const conversationContentStyles: CSSResult = css`
     padding-top: var(--wa-space-xs);
     overflow-x: hidden;
     overflow-y: auto;
+    overscroll-behavior-block: contain;
     scrollbar-width: thin;
   }
 

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.styles.ts
@@ -120,6 +120,9 @@ export const externalInquiryPanelStyles: CSSResult = css`
     display: flex;
     flex-direction: column;
     gap: ${sp.tiny};
+    margin: 0;
+    padding: 0;
+    list-style: none;
   }
 
   .external-inquiry-request__search-hint {
@@ -148,6 +151,8 @@ export const externalInquiryPanelStyles: CSSResult = css`
     padding: ${sp.small};
     background: var(--wa-color-surface-lowered);
     border-radius: var(--border-radius-small);
+    margin: 0;
+    list-style: none;
   }
 
   .external-inquiry-request__file-item {
@@ -189,6 +194,11 @@ export const externalInquiryPanelStyles: CSSResult = css`
   .external-inquiry-request__chat-links a {
     color: var(--wa-color-text-link);
     text-decoration: none;
+  }
+
+  .external-inquiry-request__chat-links {
+    line-height: var(--line-height-normal);
+    overflow-wrap: anywhere;
   }
 
   .external-inquiry-request__chat-links a:hover {

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -76,6 +76,11 @@ interface PendingDraftSave extends InquiryPermissionIds {
   draft: InquiryDraft | null;
 }
 
+interface ValidatableTextarea extends HTMLElement {
+  setCustomValidity(message: string): void;
+  reportValidity(): boolean;
+}
+
 function safeHttpUrl(link: string): string | undefined {
   const url = tryParseUrl(link);
   return url && (url.protocol === 'http:' || url.protocol === 'https:')
@@ -315,22 +320,23 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
               `
             : nothing
         }
-        <div class="external-inquiry-request__transcript-label">Q</div>
+        <div class="external-inquiry-request__transcript-label">Question</div>
         <div class="external-inquiry-request__transcript-text">
           ${turn.question}
         </div>
-        <div class="external-inquiry-request__transcript-label">A</div>
+        <div class="external-inquiry-request__transcript-label">Answer</div>
         <div class="external-inquiry-request__transcript-text">
           ${turn.answer}
         </div>
         ${
           turn.sessionLinks?.length
             ? html`
-                <div class="external-inquiry-request__transcript-links">
-                  ${turn.sessionLinks.map((link) =>
-                    this.renderKnownSessionLink(link),
+                <ul class="external-inquiry-request__transcript-links">
+                  ${turn.sessionLinks.map(
+                    (link) =>
+                      html`<li>${this.renderKnownSessionLink(link)}</li>`,
                   )}
-                </div>
+                </ul>
               `
             : nothing
         }
@@ -340,7 +346,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
 
   private renderQuestion(question: string): TemplateResult {
     const { copied } = this.copyController.state;
-    const text = copied ? 'Copied!' : 'Copy question';
+    const text = copied ? 'Question copied' : 'Copy question';
 
     return html`
       <div class="external-inquiry-request__question">
@@ -349,8 +355,9 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
           ${renderLabeledActionButton({
             icon: copied ? 'check' : 'copy',
             text,
-            title:
-              'Copy question to clipboard for pasting into an external AI model',
+            title: copied
+              ? 'Question copied to clipboard'
+              : 'Copy question to clipboard for pasting into an external AI model',
             onClick: () => this.copyController.copy(question),
           })}
         </div>
@@ -373,16 +380,16 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
         <div class="external-inquiry-request__attach-label">
           ${waIcon('cloud-arrow-up')} Files to upload to the external model:
         </div>
-        <div class="external-inquiry-request__file-list">
+        <ul class="external-inquiry-request__file-list">
           ${files.map(
             (file) => html`
-              <div class="external-inquiry-request__file-item">
+              <li class="external-inquiry-request__file-item">
                 ${waIcon('file')}
                 <span>${file}</span>
-              </div>
+              </li>
             `,
           )}
-        </div>
+        </ul>
       </div>
     `;
   }
@@ -390,23 +397,27 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
   private renderAnswerArea(): TemplateResult {
     return html`
       <div class="external-inquiry-request__answer-area">
-        <div class="external-inquiry-request__answer-label">
-          Paste the answer from the external model:
-        </div>
         <wa-textarea
           class="external-inquiry-request__answer-input"
-          aria-label="Answer from the external model"
+          name="external-inquiry-answer"
           placeholder="Paste the answer here…"
           rows="4"
           resize="vertical"
+          required
+          autocomplete="off"
+          spellcheck="true"
           .value=${live(this.answerText)}
           @input=${this.handleAnswerInput}
           @keydown=${this.handleKeyDown}
-        ></wa-textarea>
-        <div class="external-inquiry-request__answer-hint">
-          If the external model returns files, save them into the workspace and
-          tell the agent the paths.
-        </div>
+        >
+          <span slot="label" class="external-inquiry-request__answer-label">
+            Paste the answer from the external model
+          </span>
+          <span slot="hint" class="external-inquiry-request__answer-hint">
+            If the external model returns files, save them into the workspace
+            and tell the agent the paths.
+          </span>
+        </wa-textarea>
       </div>
     `;
   }
@@ -421,21 +432,19 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
                   <div class="external-inquiry-request__session-links-label">
                     Known external session links:
                   </div>
-                  <div class="external-inquiry-request__session-links-list">
+                  <ul class="external-inquiry-request__session-links-list">
                     ${repeat(
                       sessionLinks,
                       (link) => link,
-                      (link) => this.renderKnownSessionLink(link),
+                      (link) =>
+                        html`<li>${this.renderKnownSessionLink(link)}</li>`,
                     )}
-                  </div>
+                  </ul>
                 </div>
               `
             : nothing
         }
         <div class="external-inquiry-request__session-links-input-group">
-          <div class="external-inquiry-request__session-links-label">
-            Save external session link for follow-ups:
-          </div>
           <div class="external-inquiry-request__chat-links">
             Open:
             ${renderDotMeta([
@@ -455,16 +464,30 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
           </div>
           <wa-textarea
             class="external-inquiry-request__session-links-input"
-            aria-label="External session links, one per line"
+            name="external-inquiry-session-links"
             placeholder="Paste one external session link per line…"
             rows="2"
             resize="vertical"
+            autocomplete="off"
+            autocapitalize="none"
+            spellcheck="false"
+            inputmode="url"
             .value=${live(this.sessionLinksText)}
             @input=${this.handleSessionLinksInput}
-          ></wa-textarea>
-          <div class="external-inquiry-request__session-links-hint">
-            Add the chat URL you used after pasting the answer.
-          </div>
+          >
+            <span
+              slot="label"
+              class="external-inquiry-request__session-links-label"
+            >
+              Save external session links for follow-ups
+            </span>
+            <span
+              slot="hint"
+              class="external-inquiry-request__session-links-hint"
+            >
+              Add the chat URLs you used, one per line.
+            </span>
+          </wa-textarea>
         </div>
       </div>
     `;
@@ -498,7 +521,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
           title: 'Submit the answer from the external model',
           action: INQUIRY_SUBMIT_ACTION,
           kind: 'primary',
-          disabled: !this.hasAnswer,
+          disabled: this.archived,
           onClick: this.handleSubmit,
         })}
         ${this.renderRejectButton('Reject this external inquiry (n)')}
@@ -511,12 +534,14 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
   private handleAnswerInput(e: Event): void {
     this.answerText =
       (e.target as HTMLElement & { value?: string }).value ?? '';
+    (e.currentTarget as ValidatableTextarea).setCustomValidity('');
     this.scheduleDraftSave();
   }
 
   private handleSessionLinksInput(e: Event): void {
     this.sessionLinksText =
       (e.target as HTMLElement & { value?: string }).value ?? '';
+    (e.currentTarget as ValidatableTextarea).setCustomValidity('');
     this.scheduleDraftSave();
   }
 
@@ -529,9 +554,38 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
 
   private handleSubmit(): void {
     if (this.archived) return;
-    if (!this.hasAnswer) return;
-    const answer = this.answerText.trim();
+    const answerInput = this.renderRoot.querySelector<ValidatableTextarea>(
+      '.external-inquiry-request__answer-input',
+    );
+    answerInput?.setCustomValidity(
+      this.hasAnswer
+        ? ''
+        : 'Paste the external model’s answer before submitting.',
+    );
+    if (!this.hasAnswer) {
+      answerInput?.reportValidity();
+      return;
+    }
+
     const sessionLinks = this.normalizedSessionLinks;
+    const sessionLinksInput =
+      this.renderRoot.querySelector<ValidatableTextarea>(
+        '.external-inquiry-request__session-links-input',
+      );
+    const hasInvalidSessionLink = sessionLinks.some(
+      (link) => safeHttpUrl(link) === undefined,
+    );
+    sessionLinksInput?.setCustomValidity(
+      hasInvalidSessionLink
+        ? 'Enter complete http:// or https:// URLs, one per line.'
+        : '',
+    );
+    if (hasInvalidSessionLink) {
+      sessionLinksInput?.reportValidity();
+      return;
+    }
+
+    const answer = this.answerText.trim();
 
     clearInquiryDraft(this.permission.data.requestId);
 

--- a/packages/extension/src/progressView/frontend/components/FileList.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.styles.ts
@@ -47,6 +47,12 @@ export const fileListStyles: CSSResult = css`
     margin-bottom: 0;
   }
 
+  .file-round-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
   .file-name {
     overflow: hidden;
     text-overflow: ellipsis;
@@ -70,9 +76,10 @@ export const fileListStyles: CSSResult = css`
     flex-shrink: 0;
     font-size: var(--font-size-sm);
     color: var(--color-text-secondary);
+    font-variant-numeric: tabular-nums;
   }
 
-  .file-stats span:first-child {
+  .file-stats > .added {
     margin-inline-start: 0;
   }
 

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -211,8 +211,8 @@ export class FileList extends UnsupportedCommandsMixin(LitElement) {
         ${renderIconActionButton({
           id: 'storage-hint-dismiss-button',
           icon: 'xmark',
-          label: 'Dismiss storage explanation',
-          tooltip: 'Dismiss storage explanation',
+          label: 'Dismiss generated files explanation',
+          tooltip: 'Dismiss generated files explanation',
           className: 'storage-hint__dismiss',
           onClick: this.handleDismissStorageHint,
         })}
@@ -229,11 +229,15 @@ export class FileList extends UnsupportedCommandsMixin(LitElement) {
     round: number,
     files: readonly OutputFileInfo[],
   ): TemplateResult {
-    const rows = repeat(
-      files,
-      (file, index) => `${round}-${file.location?.absolutePath ?? index}`,
-      (file, index) => this.renderFileItem(file, round, index),
-    );
+    const rows = html`
+      <ul class="file-round-list">
+        ${repeat(
+          files,
+          (file, index) => `${round}-${file.location?.absolutePath ?? index}`,
+          (file, index) => this.renderFileItem(file, round, index),
+        )}
+      </ul>
+    `;
 
     // A per-round disclosure only earns its chrome when there are multiple
     // rounds to tell apart; a single round renders its files directly.
@@ -286,17 +290,19 @@ export class FileList extends UnsupportedCommandsMixin(LitElement) {
       filePath,
       effectiveBase,
       compareBase,
+      tooltipPath,
       idPrefix,
     );
     const previousAction = this.renderPreviousAction(
       filePath,
       effectiveBase,
       diffBase,
+      tooltipPath,
       idPrefix,
     );
 
     return html`
-      <div class="file-item">
+      <li class="file-item">
         ${
           failure
             ? html`${waIcon('triangle-exclamation', { id: `${idPrefix}-compile-warning`, className: 'compile-warning', label: 'Compile check failed' })}
@@ -325,7 +331,7 @@ export class FileList extends UnsupportedCommandsMixin(LitElement) {
             failure
               ? renderFileActionButton({
                   icon: 'terminal',
-                  label: 'Open compile log',
+                  label: `Open compile log for ${tooltipPath}`,
                   title: `Open compile log (${failure.logRelativePath})`,
                   className: '',
                   command: PROGRESS_VIEW_COMMANDS.OPEN_FILE,
@@ -336,7 +342,7 @@ export class FileList extends UnsupportedCommandsMixin(LitElement) {
           }
           ${baseActions} ${previousAction}
         </div>
-      </div>
+      </li>
     `;
   }
 
@@ -388,8 +394,13 @@ export class FileList extends UnsupportedCommandsMixin(LitElement) {
 
     return html`
       <span class="file-stats">
-        <span class="added">+${counts.added}</span>
-        <span class="removed">-${counts.removed}</span>
+        <span class="visually-hidden"
+          >${counts.added} ${counts.added === 1 ? 'line' : 'lines'} added,
+          ${counts.removed} ${counts.removed === 1 ? 'line' : 'lines'}
+          removed</span
+        >
+        <span class="added" aria-hidden="true">+${counts.added}</span>
+        <span class="removed" aria-hidden="true">-${counts.removed}</span>
       </span>
     `;
   }
@@ -398,6 +409,7 @@ export class FileList extends UnsupportedCommandsMixin(LitElement) {
     filePath: string,
     basePath: string,
     compareBase: string,
+    displayPath: string,
     idPrefix: string,
   ): TemplateResult | typeof nothing {
     if (!basePath) return nothing;
@@ -405,7 +417,7 @@ export class FileList extends UnsupportedCommandsMixin(LitElement) {
     return html`
       ${renderFileActionButton({
         icon: 'code-compare',
-        label: 'Compare with base',
+        label: `Compare ${displayPath} with base`,
         title: 'Compare with base in a side-by-side diff',
         className: 'compare-btn',
         command: PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL,
@@ -415,7 +427,7 @@ export class FileList extends UnsupportedCommandsMixin(LitElement) {
       })}
       ${renderFileActionButton({
         icon: 'plus-minus',
-        label: 'Run latexdiff',
+        label: `Run latexdiff for ${displayPath}`,
         title: 'Run latexdiff against the base file',
         className: 'latexdiff-btn',
         command: PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE,
@@ -425,7 +437,7 @@ export class FileList extends UnsupportedCommandsMixin(LitElement) {
       })}
       ${renderFileActionButton({
         icon: 'check',
-        label: 'Accept edits',
+        label: `Accept edits for ${displayPath}`,
         title: 'Accept edits into the workspace file',
         className: 'accept-btn',
         command: PROGRESS_VIEW_COMMANDS.ACCEPT_FILE,
@@ -435,7 +447,7 @@ export class FileList extends UnsupportedCommandsMixin(LitElement) {
       })}
       ${renderFileActionButton({
         icon: 'code-merge',
-        label: 'Merge edits',
+        label: `Merge edits for ${displayPath}`,
         title: 'Merge edits into the workspace file',
         className: 'merge-btn',
         command: PROGRESS_VIEW_COMMANDS.MERGE_FILE,
@@ -450,13 +462,14 @@ export class FileList extends UnsupportedCommandsMixin(LitElement) {
     filePath: string,
     basePath: string,
     previousPath: string | undefined,
+    displayPath: string,
     idPrefix: string,
   ): TemplateResult | typeof nothing {
     if (!previousPath || previousPath === basePath) return nothing;
 
     return renderFileActionButton({
       icon: 'plus',
-      label: 'Compare with previous round',
+      label: `Compare ${displayPath} with previous round`,
       title: 'Compare with previous round in a side-by-side diff',
       className: 'prev-btn',
       command: PROGRESS_VIEW_COMMANDS.COMPARE_PREVIOUS,

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.styles.ts
@@ -123,6 +123,10 @@ export const followUpInputStyles: CSSResult = css`
     border-radius: var(--wa-border-radius-circle);
   }
 
+  .follow-up-actions > .action-icon-busy:has(.composer-primary-action) {
+    margin-inline-start: auto;
+  }
+
   .follow-up-actions .recording::part(base) {
     color: var(--wa-color-danger-on-quiet);
     background: var(--wa-color-danger-fill-quiet);

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -105,6 +105,7 @@ export class FollowUpInput extends UnsupportedCommandsMixin(LitElement) {
   @property({ attribute: false }) recording = false;
 
   @state() private polishing = false;
+  @state() private statusAnnouncement = '';
 
   @query(`#${ELEMENT_IDS.FOLLOW_UP_INPUT}`)
   declare private textAreaEl: HTMLElement | null;
@@ -250,6 +251,11 @@ export class FollowUpInput extends UnsupportedCommandsMixin(LitElement) {
         'replace',
         eventSink,
       );
+      this.announceStatus(
+        added.length === 1
+          ? 'Image attached to the follow-up message.'
+          : `${added.length} images attached to the follow-up message.`,
+      );
       return;
     }
 
@@ -278,7 +284,7 @@ export class FollowUpInput extends UnsupportedCommandsMixin(LitElement) {
       return html` <section aria-label="Follow-up message">${body}</section> `;
     }
     return html`
-      <wa-details class="panel-collapsible" summary="Followup">
+      <wa-details class="panel-collapsible" summary="Follow-up">
         ${body}
       </wa-details>
     `;
@@ -298,16 +304,24 @@ export class FollowUpInput extends UnsupportedCommandsMixin(LitElement) {
         <div class="composer-surface">
           <wa-textarea
             id=${ELEMENT_IDS.FOLLOW_UP_INPUT}
-            aria-label="Follow-up message"
+            name="follow-up-message"
             placeholder="Message TeXRA…"
             rows="2"
             resize="vertical"
+            autocomplete="off"
+            spellcheck="true"
             ?disabled=${this.sending}
             .value=${live(this.value)}
             @input=${this.handleInput}
             @keydown=${this.handleKeydown}
             @paste=${this.handlePaste}
-          ></wa-textarea>
+          >
+            <span slot="label" class="visually-hidden">Follow-up message</span>
+            <span slot="hint" class="visually-hidden">
+              Press Enter to send or Shift+Enter for a new line. Paste images to
+              attach them.
+            </span>
+          </wa-textarea>
 
           <div class="follow-up-actions">
             ${
@@ -355,6 +369,9 @@ export class FollowUpInput extends UnsupportedCommandsMixin(LitElement) {
             })}
           </div>
         </div>
+        <div class="visually-hidden" role="status">
+          ${this.statusAnnouncement}
+        </div>
       </div>
     `;
   }
@@ -400,6 +417,15 @@ export class FollowUpInput extends UnsupportedCommandsMixin(LitElement) {
     const streamId = this.streamId;
     const transientState = this.transientState;
     if (!streamId || !transientState || this.sending) return;
+    if (
+      !this.value.trim() &&
+      transientState.pendingImages.length === 0 &&
+      transientState.pendingImagePastes.size === 0
+    ) {
+      this.announceStatus('Enter a follow-up message before sending.');
+      void this.focusInput();
+      return;
+    }
     this.emitSendForStream(streamId, transientState);
   }
 
@@ -410,6 +436,7 @@ export class FollowUpInput extends UnsupportedCommandsMixin(LitElement) {
   ): void {
     if (transientState.pendingImagePastes.size > 0) {
       transientState.sendAfterImagePastes = true;
+      this.announceStatus('Attaching images before sending.');
       return;
     }
     // Image chips stay in the draft until FOLLOW_UP_RESULT accepts the send.
@@ -419,6 +446,7 @@ export class FollowUpInput extends UnsupportedCommandsMixin(LitElement) {
         images: transientState.pendingImages,
       }),
     );
+    this.announceStatus('Sending follow-up message.');
     transientState.sendAfterImagePastes = false;
   }
 
@@ -437,9 +465,22 @@ export class FollowUpInput extends UnsupportedCommandsMixin(LitElement) {
   }
 
   private emitPolish(): void {
-    if (!this.value.trim()) return;
+    if (!this.value.trim()) {
+      this.announceStatus('Enter a follow-up message before polishing.');
+      void this.focusInput();
+      return;
+    }
     this.polishing = true;
+    this.announceStatus('Polishing follow-up message.');
     this.dispatchEvent(ProgressEvents.followupPolish());
+  }
+
+  /** Update the stable polite region, including when the same message repeats. */
+  private announceStatus(message: string): void {
+    this.statusAnnouncement = '';
+    void this.updateComplete.then(() => {
+      if (this.isConnected) this.statusAnnouncement = message;
+    });
   }
 
   private updateValue(

--- a/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
+++ b/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
@@ -33,6 +33,12 @@ const LATEXDIFF_STATUS_ICONS: Record<DiffStatus, TeXRAIconName> = {
   error: 'circle-exclamation',
 };
 
+/** Screen-reader labels for the otherwise icon-only result status. */
+const LATEXDIFF_STATUS_LABELS: Record<DiffStatus, string> = {
+  success: 'Comparison succeeded',
+  error: 'Comparison failed',
+};
+
 @customElement('latexdiff-results')
 export class LatexdiffResults extends LitElement {
   static override styles = [
@@ -51,7 +57,8 @@ export class LatexdiffResults extends LitElement {
       .latexdiff-content {
         list-style: none;
         margin: 0;
-        padding: var(--wa-space-3xs) 0 var(--wa-space-2xs) var(--wa-space-s);
+        padding-block: var(--wa-space-3xs) var(--wa-space-2xs);
+        padding-inline: var(--wa-space-s) 0;
         display: flex;
         flex-direction: column;
         gap: var(--wa-space-3xs);
@@ -63,8 +70,17 @@ export class LatexdiffResults extends LitElement {
       }
 
       .file-link {
+        appearance: none;
+        padding: 0;
+        border: 0;
+        background: none;
         color: var(--color-text-link);
         cursor: pointer;
+        font: inherit;
+        text-align: inherit;
+        text-decoration: underline;
+        text-decoration-thickness: from-font;
+        text-underline-position: from-font;
         overflow-wrap: anywhere;
       }
 
@@ -91,24 +107,23 @@ export class LatexdiffResults extends LitElement {
     this.dispatchEvent(ProgressEvents.fileClick({ file: filePath }));
   }
 
-  private renderFileLink(filePath: string, label: string): TemplateResult {
+  private renderFileLink(
+    filePath: string,
+    label: string,
+    accessibleLabel: string,
+  ): TemplateResult {
     if (!filePath) {
       return html`<span>${label}</span>`;
     }
-    return html`<span
+    return html`<button
+      type="button"
       class="file-link"
       data-file=${filePath}
-      role="button"
-      tabindex="0"
+      aria-label=${accessibleLabel}
       @click=${() => this.handleFileClick(filePath)}
-      @keydown=${(e: KeyboardEvent) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          this.handleFileClick(filePath);
-        }
-      }}
-      >${label}</span
-    >`;
+    >
+      ${label}
+    </button>`;
   }
 
   private renderEntry(entry: DiffResultDisplay, index: number): TemplateResult {
@@ -125,6 +140,7 @@ export class LatexdiffResults extends LitElement {
     } = entry;
 
     const icon = LATEXDIFF_STATUS_ICONS[status];
+    const statusLabel = LATEXDIFF_STATUS_LABELS[status];
     const baseLabel =
       baseRound === null
         ? displayName
@@ -134,10 +150,15 @@ export class LatexdiffResults extends LitElement {
     const entryId = `latexdiff-entry-${index}`;
     return html`
       <li id=${entryId} class="detail-item" data-run-id=${ifDefined(runId)}>
-        ${waIcon(icon)} ${this.renderFileLink(baseFile, baseLabel)}
+        ${waIcon(icon, { label: statusLabel })}
+        ${this.renderFileLink(baseFile, baseLabel, `Open base file: ${baseLabel}`)}
         ${waIcon('arrow-right', { className: 'arrow' })}
-        ${this.renderFileLink(revisedFile, revisedLabel)}
-        (${this.renderFileLink(diffFile, 'diff')})
+        ${this.renderFileLink(
+          revisedFile,
+          revisedLabel,
+          `Open revised file ${revisedLabel} for ${displayName}`,
+        )}
+        (${this.renderFileLink(diffFile, 'diff', `Open ${displayName} diff`)})
         ${message ? html`<wa-tooltip for=${entryId}>${message}</wa-tooltip>` : nothing}
       </li>
     `;

--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -13,7 +13,7 @@
 
 // Third-party imports
 import { LRUCache } from 'lru-cache';
-import { LitElement, html, type TemplateResult } from 'lit';
+import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { consume } from '@lit/context';
 import { customElement, state } from 'lit/decorators.js';
 import { createRef, ref, type Ref } from 'lit/directives/ref.js';
@@ -150,6 +150,9 @@ export class LogList extends LitElement {
   override render(): TemplateResult {
     if (this.streamCache.size === 0 || !this.streamContext.hasStreams) {
       return html`<task-group-list
+        role=${this.streamContext.terminalMode ? nothing : 'log'}
+        aria-label=${this.streamContext.terminalMode ? nothing : 'Run activity'}
+        aria-relevant=${this.streamContext.terminalMode ? nothing : 'additions'}
         .hasStreams=${this.streamContext.hasStreams}
         .streamStatus=${this.streamContext.streamStatus}
         .isToolUse=${this.streamContext.isToolUse}
@@ -168,6 +171,9 @@ export class LogList extends LitElement {
       ([id, data]) => html`
         <task-group-list
           ${ref(data.ref)}
+          role=${data.terminalMode ? nothing : 'log'}
+          aria-label=${data.terminalMode ? nothing : `Activity for ${id}`}
+          aria-relevant=${data.terminalMode ? nothing : 'additions'}
           ?hidden=${id !== this.activeStreamId}
           .groups=${data.groups}
           .workflowPlan=${data.workflowPlan}

--- a/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
@@ -27,8 +27,9 @@ const planApprovalRequestPanelStyles: CSSResult = css`
   .plan-approval-request__objective {
     margin: ${sp.small} 0;
     color: var(--wa-color-text-normal);
+    line-height: var(--line-height-normal);
     white-space: pre-wrap;
-    word-break: break-word;
+    overflow-wrap: anywhere;
   }
 
   .plan-approval-request__goal-explanation {
@@ -49,7 +50,9 @@ export class PlanApprovalRequestPanel extends BaseApprovalPanel<'planApproval'> 
   protected readonly approvalDecision = { action: 'approve' } as const;
 
   protected override handleExtraKey(key: string): boolean {
-    if (key !== 'r' || !this.permission.data.goalEnabled) return false;
+    if (key !== 'r' || this.archived || !this.permission.data.goalEnabled) {
+      return false;
+    }
     this.emitAction({ action: 'approve_and_goal' });
     return true;
   }
@@ -79,6 +82,7 @@ export class PlanApprovalRequestPanel extends BaseApprovalPanel<'planApproval'> 
             title:
               'Approve this plan and keep working across turns until it completes or needs your input (r)',
             action: 'approve_and_goal',
+            disabled: this.archived,
             onClick: () => this.emitAction({ action: 'approve_and_goal' }),
           })
         : nothing,
@@ -87,7 +91,8 @@ export class PlanApprovalRequestPanel extends BaseApprovalPanel<'planApproval'> 
 
   /** Kept to one line so the pre-wrap body gets no template whitespace. */
   private renderObjective(text: string): TemplateResult {
-    return html`<div class="plan-approval-request__objective">${text}</div>`;
+    // prettier-ignore
+    return html`<div class="plan-approval-request__objective" dir="auto">${text}</div>`;
   }
 }
 

--- a/packages/extension/src/progressView/frontend/components/PlanView.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanView.ts
@@ -34,7 +34,8 @@ export class PlanView extends CollapsiblePanel {
 
       .plan-document {
         white-space: pre-wrap;
-        word-break: break-word;
+        overflow-wrap: anywhere;
+        unicode-bidi: plaintext;
         font-size: var(--font-size);
         line-height: var(--line-height-relaxed);
         color: var(--color-text-secondary);

--- a/packages/extension/src/progressView/frontend/components/ProcessStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/ProcessStreamContent.ts
@@ -54,8 +54,13 @@ export class ProcessStreamContent extends LitElement {
         word-break: break-word;
       }
 
-      .command-strip > span {
+      .command-strip > * {
         min-width: 0;
+      }
+
+      .command-strip:focus-visible {
+        outline: var(--focus-ring-width) solid var(--wa-color-focus);
+        outline-offset: calc(-1 * var(--focus-ring-offset));
       }
 
       .prompt {
@@ -96,9 +101,14 @@ export class ProcessStreamContent extends LitElement {
           command
             ? html`
                 <div class="conversation-column process-command">
-                  <div class="command-strip">
-                    <span class="prompt">$</span>
-                    <span class="command">${command}</span>
+                  <div
+                    class="command-strip"
+                    role="region"
+                    aria-label="Command"
+                    tabindex="0"
+                  >
+                    <span class="prompt" aria-hidden="true">$</span>
+                    <code class="command" dir="ltr">${command}</code>
                   </div>
                 </div>
               `

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.styles.ts
@@ -26,7 +26,7 @@ export const proposalRequestPanelStyles: CSSResult = css`
 
   .workflow-proposal__model::before {
     content: '\u2022';
-    margin-right: ${sp.small};
+    margin-inline-end: ${sp.small};
   }
 
   .workflow-proposal__agent-select,
@@ -42,9 +42,9 @@ export const proposalRequestPanelStyles: CSSResult = css`
     flex-shrink: 0;
   }
 
-  /* Model dropdown floats to the right edge of the header row. */
+  /* Model dropdown floats to the trailing edge of the header row. */
   .workflow-proposal__model-select {
-    margin-left: auto;
+    margin-inline-start: auto;
   }
 
   .proposal-model-dropdown {
@@ -110,7 +110,7 @@ export const proposalRequestPanelStyles: CSSResult = css`
   .workflow-proposal__instruction {
     font-size: var(--font-size-sm);
     color: var(--wa-color-text-normal);
-    word-break: break-word;
+    overflow-wrap: anywhere;
     max-height: 12em;
     overflow-y: auto;
     line-height: var(--line-height-normal);
@@ -126,14 +126,14 @@ export const proposalRequestPanelStyles: CSSResult = css`
     display: flex;
     gap: ${sp.small};
     flex-wrap: wrap;
-    margin-top: ${sp.small};
+    margin-block-start: ${sp.small};
   }
 
   .workflow-proposal__files {
     display: flex;
     flex-direction: column;
     gap: ${sp.small};
-    margin-top: ${sp.small};
+    margin-block-start: ${sp.small};
   }
 
   .workflow-proposal__files > div {
@@ -174,7 +174,7 @@ export const proposalRequestPanelStyles: CSSResult = css`
   }
 
   .workflow-proposal__file-name--wrap {
-    word-break: break-word;
+    overflow-wrap: anywhere;
   }
 
   .workflow-proposal__input-files .workflow-proposal__file-label {

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -158,6 +158,9 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
                       .value=${currentAgent}
                       @change=${this.handleAgentSelectChange}
                     >
+                      <span slot="label" class="visually-hidden"
+                        >Agent for this proposal</span
+                      >
                       ${renderAgentOptions(agentOptions)}
                     </wa-select>
                   </div>
@@ -176,6 +179,9 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
                       .value=${currentModel}
                       @change=${this.handleSelectChange}
                     >
+                      <span slot="label" class="visually-hidden"
+                        >Model for this proposal</span
+                      >
                       ${renderModelOptions(modelOptions)}
                     </wa-select>
                   </div>
@@ -193,8 +199,8 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
               ${this.renderProposalFiles(data)}`
         }
       `,
-      approveTitle: 'Approve (y)',
-      rejectTitle: 'Reject (n)',
+      approveTitle: 'Approve this proposal (y)',
+      rejectTitle: 'Reject this proposal (n)',
       trailingActions: renderLabeledActionButton({
         id: 'proposal-setup-button',
         icon: 'reply',
@@ -378,6 +384,7 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
                 data-file=${ifDefined(clickable ? file : undefined)}
                 role=${ifDefined(clickable ? 'button' : undefined)}
                 tabindex=${ifDefined(clickable ? '0' : undefined)}
+                aria-label=${ifDefined(clickable ? `Open ${file}` : undefined)}
                 >${getBasename(file)}</span
               ><wa-tooltip for="${idPrefix}-file-${i}">${file}</wa-tooltip>`,
         )}

--- a/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
+++ b/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
@@ -53,6 +53,9 @@ export class QueuedFollowUps extends LitElement {
         display: flex;
         flex-direction: column;
         gap: var(--wa-space-3xs);
+        margin: 0;
+        padding: 0;
+        list-style: none;
       }
 
       .queued-follow-up-item {
@@ -81,6 +84,7 @@ export class QueuedFollowUps extends LitElement {
         min-width: 0;
         overflow-wrap: anywhere;
         white-space: pre-wrap;
+        text-align: start;
         color: var(--wa-color-text-normal);
       }
     `,
@@ -95,9 +99,13 @@ export class QueuedFollowUps extends LitElement {
     if (message.length <= MAX_MESSAGE_LENGTH) {
       return { display: message, full: undefined };
     }
+    const display = truncateWithEllipsis(message, MAX_MESSAGE_LENGTH);
     return {
-      display: truncateWithEllipsis(message, MAX_MESSAGE_LENGTH),
-      full: message,
+      display,
+      // The cheap length guard above counts UTF-16 code units, while the
+      // shared truncator counts graphemes. Do not add a redundant tooltip or
+      // tab stop when emoji or combining marks made the guard conservative.
+      full: display === message ? undefined : message,
     };
   }
 
@@ -107,16 +115,19 @@ export class QueuedFollowUps extends LitElement {
     // clears shadow content but the host stays in the parent's layout, so a
     // mounted-but-empty host would still consume the parent's flex gap.
     if (this.messages.length === 0) return nothing;
+    const messageCount = this.messages.length;
+    const summary = `${messageCount === 1 ? 'Queued message' : 'Queued messages'} (${messageCount})`;
     return html`
       <wa-details
         id=${ELEMENT_IDS.QUEUED_FOLLOW_UPS_COLLAPSIBLE}
         class="queued-collapsible"
-        summary="Queued messages"
+        summary=${summary}
         open
       >
-        <div
+        <ol
           id=${ELEMENT_IDS.QUEUED_FOLLOW_UPS_LIST}
           class="queued-follow-ups-list"
+          aria-label="Queued messages"
         >
           ${repeat(
             this.messages,
@@ -125,15 +136,25 @@ export class QueuedFollowUps extends LitElement {
               const { display, full } = this.truncateMessage(message);
               const itemId = `queued-follow-up-${index}`;
               return html`
-                <div id=${itemId} class="queued-follow-up-item">
+                <li
+                  id=${itemId}
+                  class="queued-follow-up-item"
+                  tabindex=${full ? '0' : nothing}
+                >
                   ${waIcon('comment', { className: 'queued-follow-up-icon' })}
-                  <span class="queued-follow-up-text">${display}</span>
-                </div>
-                ${full ? html`<wa-tooltip for=${itemId}>${full}</wa-tooltip>` : nothing}
+                  <bdi class="queued-follow-up-text">${display}</bdi>
+                </li>
+                ${
+                  full
+                    ? html`<wa-tooltip for=${itemId} dir="auto"
+                        >${full}</wa-tooltip
+                      >`
+                    : nothing
+                }
               `;
             },
           )}
-        </div>
+        </ol>
       </wa-details>
     `;
   }

--- a/packages/extension/src/progressView/frontend/components/RequestPanels.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanels.ts
@@ -166,6 +166,18 @@ export class RequestPanels extends LitElement {
         color: var(--color-text-secondary);
         font-size: var(--font-size-sm);
       }
+
+      /* Keep the inquiry title and its compact pager reachable when the dock
+         narrows or localized labels grow. */
+      .external-inquiry-requests__header {
+        flex-wrap: wrap;
+      }
+
+      /* Previous/next are logical directions, so mirror their directional
+         glyphs with the surrounding writing direction. */
+      :dir(rtl) .external-inquiry-requests__nav wa-icon {
+        transform: scaleX(-1);
+      }
     `,
   ];
 
@@ -295,7 +307,7 @@ export class RequestPanels extends LitElement {
     return html`
       <div class="${config.cssClass}__header">
         ${waIcon(config.icon)}
-        <h2>${config.title}</h2>
+        <h2 id="${config.cssClass}-heading">${config.title}</h2>
         ${extra}
       </div>
     `;
@@ -309,7 +321,10 @@ export class RequestPanels extends LitElement {
 
     const armedKey = this.armedPermissionKey();
     return html`
-      <section class=${config.cssClass}>
+      <section
+        class=${config.cssClass}
+        aria-labelledby="${config.cssClass}-heading"
+      >
         ${this.renderSectionHeader(config)}
         <div class="${config.cssClass}__list">
           ${repeat(
@@ -382,24 +397,37 @@ export class RequestPanels extends LitElement {
     const current = perms[index];
     const currentKey = getPermissionKey(current);
     const nav = html`
-      <div class="external-inquiry-requests__nav">
+      <div
+        class="external-inquiry-requests__nav"
+        role="group"
+        aria-label="External inquiry navigation"
+      >
         <wa-button
           id="ei-prev-btn"
           appearance="plain"
           size="s"
+          type="button"
+          aria-label="Previous inquiry"
           ?disabled=${index === 0}
           @click=${this.showPreviousInquiry}
         >
           ${waIcon('chevron-left')}
         </wa-button>
         <wa-tooltip for="ei-prev-btn">Previous inquiry</wa-tooltip>
-        <span class="external-inquiry-requests__counter">
-          ${index + 1} / ${perms.length}
+        <span
+          class="external-inquiry-requests__counter"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          ${index + 1} of ${perms.length}
         </span>
         <wa-button
           id="ei-next-btn"
           appearance="plain"
           size="s"
+          type="button"
+          aria-label="Next inquiry"
           ?disabled=${index === perms.length - 1}
           @click=${this.showNextInquiry}
         >
@@ -410,7 +438,10 @@ export class RequestPanels extends LitElement {
     `;
 
     return html`
-      <section class=${config.cssClass}>
+      <section
+        class=${config.cssClass}
+        aria-labelledby="${config.cssClass}-heading"
+      >
         ${this.renderSectionHeader(config, nav)}
         <div class="${config.cssClass}__list">
           ${keyed(
@@ -481,8 +512,9 @@ export class RequestPanels extends LitElement {
    * opt-out would cross into settingsView/shared lanes; remapping is
    * already impossible for hardwired keys). Without the gate, one stray
    * keystroke anywhere in the view could approve or reject a run.
-   * Non-character keys (Escape, arrows) are outside 2.1.4's scope and stay
-   * global.
+   * Arrow navigation is also focus-scoped so it cannot intercept navigation
+   * in another control elsewhere in the progress view. Escape stays global
+   * because it dismisses the active request rather than selecting content.
    */
   private handleGlobalKeydown = (event: KeyboardEvent): void => {
     if (isTextInput(document.activeElement)) return;
@@ -490,22 +522,31 @@ export class RequestPanels extends LitElement {
     if (this.permissions.length === 0) return;
 
     const key = event.key.toLowerCase();
+    const eventPath = event.composedPath();
+    const focusWithinPanels = eventPath.includes(this);
+    const focusWithinInquiry = eventPath.some(
+      (target) =>
+        target instanceof Element &&
+        target.classList.contains('external-inquiry-requests'),
+    );
 
-    // Arrow keys navigate the external inquiry carousel
-    if (this.externalInquiryCarouselActive) {
-      if (key === 'arrowleft') {
+    // Arrow keys navigate the visible carousel in its visual direction, but
+    // only while focus is within these request panels.
+    if (this.externalInquiryCarouselActive && focusWithinInquiry) {
+      const rtl = getComputedStyle(this).direction === 'rtl';
+      if (key === (rtl ? 'arrowright' : 'arrowleft')) {
         this.showPreviousInquiry();
         event.preventDefault();
         return;
       }
-      if (key === 'arrowright') {
+      if (key === (rtl ? 'arrowleft' : 'arrowright')) {
         this.showNextInquiry();
         event.preventDefault();
         return;
       }
     }
 
-    if (key.length === 1 && !event.composedPath().includes(this)) return;
+    if (key.length === 1 && !focusWithinPanels) return;
 
     const armed = this.armedPermission;
     const panel = armed ? this.findPanelFor(armed) : null;

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.styles.ts
@@ -6,10 +6,13 @@ import { sp } from '@shared/styles';
 
 export const retryRequestPanelStyles: CSSResult = css`
   .retry-request__operation {
+    margin: 0;
     font-family: var(--wa-font-family-mono);
     font-size: var(--font-size-sm);
     color: var(--wa-color-text-normal);
     font-weight: var(--font-weight-medium);
+    line-height: var(--line-height-normal);
+    overflow-wrap: anywhere;
   }
 
   /* No local clip. A max-height of 4em with overflow hidden cut the message
@@ -26,7 +29,9 @@ export const retryRequestPanelStyles: CSSResult = css`
   .retry-request__error {
     font-size: var(--font-size-sm);
     color: var(--color-error);
-    word-break: break-word;
+    line-height: var(--line-height-normal);
+    overflow-wrap: anywhere;
+    text-wrap: pretty;
   }
 
   .retry-request__error-details {

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -78,9 +78,9 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
     return html`
       <div class="retry-request">
         <div class="retry-request__details">
-          <div class="retry-request__operation">
+          <h3 class="retry-request__operation">
             ${data.operation ? `Failed: ${data.operation}` : 'Request failed'}
-          </div>
+          </h3>
           <div class="retry-request__meta">${renderDotMeta(metaParts)}</div>
           ${when(
             data.errorMessage,

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -220,13 +220,22 @@ export class StreamHeader extends UnsupportedCommandsMixin(LitElement) {
       #activeStreamName {
         flex: 1;
         min-width: 0;
+        margin: 0;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
         color: var(--wa-color-text-normal);
         font-size: var(--font-size);
         font-weight: var(--font-weight-semibold);
+        line-height: 1.2;
         letter-spacing: -0.012em;
+      }
+
+      .status-label {
+        flex: 0 0 auto;
+        color: var(--color-text-secondary);
+        font-size: var(--font-size-sm);
+        white-space: nowrap;
       }
 
       .header-actions {
@@ -236,6 +245,9 @@ export class StreamHeader extends UnsupportedCommandsMixin(LitElement) {
         min-width: 0;
         max-width: 100%;
         margin-inline-start: auto;
+        overflow-x: auto;
+        overscroll-behavior-inline: contain;
+        scrollbar-width: thin;
       }
 
       .header-actions wa-button-group {
@@ -342,7 +354,19 @@ export class StreamHeader extends UnsupportedCommandsMixin(LitElement) {
         font-size: var(--font-size-xs);
       }
 
+      wa-tag.progress-badge {
+        font-variant-numeric: tabular-nums;
+      }
+
+      :dir(rtl) .parent-link wa-icon {
+        transform: scaleX(-1);
+      }
+
       @container (max-width: 520px) {
+        .status-label {
+          display: none;
+        }
+
         .log-header {
           padding-inline: var(--wa-space-xs);
           flex-wrap: wrap;
@@ -522,12 +546,12 @@ export class StreamHeader extends UnsupportedCommandsMixin(LitElement) {
       <div class="log-header">
         <div class="header-left">
           ${this.renderParentLink()}
-          <span
+          <h1
             id=${ELEMENT_IDS.ACTIVE_STREAM_NAME}
             data-stream=${this.stream.name}
           >
             ${streamDisplayLabel(this.stream)}
-          </span>
+          </h1>
           ${
             this.stream.label
               ? html`<wa-tooltip for=${ELEMENT_IDS.ACTIVE_STREAM_NAME}
@@ -547,6 +571,7 @@ export class StreamHeader extends UnsupportedCommandsMixin(LitElement) {
           <wa-tooltip for=${ELEMENT_IDS.STATUS_INDICATOR}>
             ${streamStatusTooltip(state, statusLabel)}
           </wa-tooltip>
+          <span class="status-label" aria-hidden="true">${statusLabel}</span>
           ${this.renderRunElapsed(state?.runStartedAt)}
           ${this.renderGoalChip(goal)}
           ${this.renderProgressBadge(progress, stage)}
@@ -669,6 +694,7 @@ export class StreamHeader extends UnsupportedCommandsMixin(LitElement) {
         class="parent-link"
         role="button"
         tabindex="0"
+        aria-label=${`Go to parent session: ${displayName}`}
         @click=${this.navigateToParent}
         @keydown=${this.handleParentLinkKey}
       >

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -1,7 +1,7 @@
 /** Declarative task group list — renders groups, headers, and log entries inline. */
 
 // Third-party imports
-import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import { LitElement, css, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { guard } from 'lit/directives/guard.js';
@@ -92,6 +92,30 @@ const TIMELINE_ITEM_WINDOW_STEP = 120;
 const DEFAULT_GROUP_ROW_WINDOW = 400;
 const GROUP_ROW_WINDOW_STEP = 400;
 
+const taskGroupListStyles = css`
+  /* Phase labels may come from workflow plans, so let long or untranslated
+     values wrap instead of forcing the status and timestamp off-screen. */
+  .group-title {
+    min-inline-size: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .group-time {
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* This compact disclosure is the only native button in the task-group
+     surface. Keep its target at the WCAG minimum without increasing the
+     visual density of every workflow row. */
+  .workflow-row-group {
+    min-block-size: 24px;
+  }
+
+  :host(:dir(rtl)) .workflow-row-group wa-icon {
+    transform: scaleX(-1);
+  }
+`;
+
 /**
  * Maps a group's `StreamPhase`/`RunOutcome` status to a steady wa-icon name.
  * Each terminal phase gets its own icon; an unrecognized status renders as
@@ -139,7 +163,7 @@ function renderStatusStrip(
 
 @customElement('task-group-list')
 export class TaskGroupList extends LitElement {
-  static override styles = [designTokens, ...logStyles];
+  static override styles = [designTokens, ...logStyles, taskGroupListStyles];
 
   /** All task groups to render */
   @property({ attribute: false }) groups: TaskGroup[] = [];
@@ -622,8 +646,8 @@ export class TaskGroupList extends LitElement {
               <span class="group-status-icon" aria-hidden="true"
                 >${WORKFLOW_PHASE_GLYPH.declared}</span
               >
-              <span class="group-title"
-                >${formatWorkflowPhaseHeading(phase.heading)}</span
+              <bdi class="group-title"
+                >${formatWorkflowPhaseHeading(phase.heading)}</bdi
               >
               <span class="group-progress"
                 >${formatWorkflowPhaseTally(phase)}</span
@@ -666,15 +690,22 @@ export class TaskGroupList extends LitElement {
           label: formatStreamStatusLabel(group.status),
         })}
       </span>
-      <span class="group-title">${title}</span>
+      <bdi class="group-title">${title}</bdi>
       ${phase ? this.renderPhaseProgress(phase) : nothing}
       <span class="group-time">
         <span class="group-start-time">
-          ${waIcon('clock')} ${formattedStartTime}
+          ${waIcon('clock')}
+          <span class="visually-hidden">Started at </span>
+          <time datetime=${new Date(group.startTime).toISOString()}
+            >${formattedStartTime}</time
+          >
         </span>
         ${
           durationText
-            ? html`<span class="group-duration">${durationText}</span>`
+            ? html`<span class="group-duration"
+                ><span class="visually-hidden">Duration </span
+                >${durationText}</span
+              >`
             : nothing
         }
       </span>

--- a/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
@@ -82,6 +82,14 @@ export class TerminalOutput extends LitElement {
         overflow: hidden;
       }
 
+      /* xterm removes its own outline. Restore the shared focus treatment on
+         the visible terminal surface when its hidden textarea receives
+         keyboard focus. Keep it inset so the container does not clip it. */
+      .xterm:has(.xterm-helper-textarea:focus-visible) {
+        outline: var(--focus-ring-width) solid var(--wa-color-focus);
+        outline-offset: calc(-1 * var(--focus-ring-offset));
+      }
+
       :host([fill]),
       :host([fill]) .terminal-container {
         height: 100%;
@@ -124,18 +132,28 @@ export class TerminalOutput extends LitElement {
 
   override firstUpdated(): void {
     const { theme, fontFamily } = resolveXtermTheme(this);
+    const editorFontSize = Number.parseFloat(
+      getComputedStyle(this).getPropertyValue('--wa-editor-font-size'),
+    );
     this.terminal = new Terminal({
       disableStdin: true,
       convertEol: true,
       scrollback: MIN_SCROLLBACK,
       fontFamily,
-      fontSize: 12,
+      fontSize: Number.isFinite(editorFontSize) ? editorFontSize : 12,
+      // Without this, xterm paints the buffer only to a canvas. Its supported
+      // accessibility tree exposes the read-only output as text instead.
+      screenReaderMode: true,
       theme,
     });
 
     this.fitAddon = new FitAddon();
     this.terminal.loadAddon(this.fitAddon);
     this.terminal.open(this.terminalContainer);
+    this.terminal.textarea?.setAttribute('aria-label', 'Terminal output');
+    this.terminal.element
+      ?.querySelector<HTMLElement>('.live-region')
+      ?.setAttribute('aria-live', 'off');
 
     this.attachResizeHooks();
     this.refitIfVisible();

--- a/packages/extension/src/progressView/frontend/components/TodoList.ts
+++ b/packages/extension/src/progressView/frontend/components/TodoList.ts
@@ -18,6 +18,12 @@ import { ELEMENT_IDS } from '../constants';
 // Local imports - base class
 import { CollapsiblePanel } from './CollapsiblePanel';
 
+const TODO_STATUS_LABELS: Readonly<Record<TodoItem['status'], string>> = {
+  [TODO_STATUS.PENDING]: 'Pending',
+  [TODO_STATUS.IN_PROGRESS]: 'In progress',
+  [TODO_STATUS.COMPLETED]: 'Completed',
+};
+
 @customElement('todo-list')
 export class TodoList extends CollapsiblePanel {
   static override styles = [
@@ -32,6 +38,9 @@ export class TodoList extends CollapsiblePanel {
         display: flex;
         flex-direction: column;
         gap: var(--wa-space-3xs);
+        margin: 0;
+        padding: 0;
+        list-style: none;
       }
 
       .todo-item {
@@ -52,15 +61,16 @@ export class TodoList extends CollapsiblePanel {
 
       .todo-item__content {
         flex: 1;
-        word-break: break-word;
+        min-width: 0;
+        overflow-wrap: anywhere;
       }
 
       .todo-item--pending {
-        opacity: var(--opacity-subtle);
+        color: var(--color-text-secondary);
       }
 
       .todo-item--pending .todo-item__icon {
-        color: var(--color-text-secondary);
+        color: var(--color-text-muted);
       }
 
       .todo-item--in-progress {
@@ -68,11 +78,11 @@ export class TodoList extends CollapsiblePanel {
       }
 
       .todo-item--in-progress .todo-item__icon {
-        color: var(--wa-color-progress-bg);
+        color: var(--color-pending);
       }
 
       .todo-item--completed {
-        opacity: var(--opacity-disabled);
+        color: var(--color-text-secondary);
       }
 
       .todo-item--completed .todo-item__icon {
@@ -96,20 +106,31 @@ export class TodoList extends CollapsiblePanel {
       (t) => t.status === TODO_STATUS.COMPLETED,
     ).length;
     const total = this.todos.length;
+    const activeTodo = this.todos.find(
+      (todo) => todo.status === TODO_STATUS.IN_PROGRESS,
+    );
+    const progressText = `${completed} of ${total} ${total === 1 ? 'task' : 'tasks'} complete`;
 
-    return this.renderCollapsibleDetails({
-      id: ELEMENT_IDS.TODO_LIST_CONTAINER,
-      summary: `Todos (${completed}/${total})`,
-      body: html`
-        <div id=${ELEMENT_IDS.TODO_LIST} class="todo-list">
-          ${repeat(
-            this.todos,
-            (_todo, index) => index,
-            (todo) => this.renderTodo(todo),
-          )}
-        </div>
-      `,
-    });
+    return html`
+      <div class="visually-hidden" role="status">
+        ${progressText}.${
+          activeTodo ? ` In progress: ${activeTodo.activeForm}.` : nothing
+        }
+      </div>
+      ${this.renderCollapsibleDetails({
+        id: ELEMENT_IDS.TODO_LIST_CONTAINER,
+        summary: `Tasks (${completed} of ${total} complete)`,
+        body: html`
+          <ol id=${ELEMENT_IDS.TODO_LIST} class="todo-list" aria-label="Tasks">
+            ${repeat(
+              this.todos,
+              (_todo, index) => index,
+              (todo) => this.renderTodo(todo),
+            )}
+          </ol>
+        `,
+      })}
+    `;
   }
 
   private renderTodo(todo: TodoItem): TemplateResult {
@@ -119,13 +140,14 @@ export class TodoList extends CollapsiblePanel {
     const content = isInProgress ? todo.activeForm : todo.content;
 
     return html`
-      <div
+      <li
         class=${classMap({
           'todo-item': true,
           'todo-item--pending': status === TODO_STATUS.PENDING,
           'todo-item--in-progress': status === TODO_STATUS.IN_PROGRESS,
           'todo-item--completed': status === TODO_STATUS.COMPLETED,
         })}
+        aria-current=${isInProgress ? 'step' : nothing}
       >
         ${
           isInProgress
@@ -135,8 +157,9 @@ export class TodoList extends CollapsiblePanel {
               ></wa-spinner>`
             : waIcon(icon, { className: 'todo-item__icon' })
         }
-        <span class="todo-item__content">${content}</span>
-      </div>
+        <span class="visually-hidden">${TODO_STATUS_LABELS[status]}: </span>
+        <bdi class="todo-item__content">${content}</bdi>
+      </li>
     `;
   }
 }

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.styles.ts
@@ -8,14 +8,25 @@ export const toolEditRequestPanelStyles: CSSResult = css`
   .approval-request__path {
     font-family: var(--wa-font-family-mono);
     font-size: var(--font-size-sm);
-    color: var(--color-text-link);
-    word-break: break-word;
+    font-variant-ligatures: none;
+    line-height: var(--line-height-normal);
+    color: var(--wa-color-text-normal);
+    overflow-wrap: anywhere;
+    text-align: start;
+  }
+
+  .approval-request__source-tool {
+    font-family: var(--wa-font-family-mono);
+    font-variant-ligatures: none;
+    color: var(--wa-color-text-normal);
+    overflow-wrap: anywhere;
   }
 
   .approval-request__diff {
     display: inline-flex;
     align-items: baseline;
     gap: ${sp.small};
+    font-variant-numeric: tabular-nums;
   }
 
   .approval-request__diff-added,

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -58,19 +58,26 @@ export class ToolEditRequestPanel extends BaseBypassApprovalPanel<'toolEdit'> {
   override render(): TemplateResult {
     const data = this.permission.data;
     const metaParts: MetaPart[] = [];
-    if (data.sourceTool) metaParts.push(`Requested by ${data.sourceTool}`);
+    if (data.sourceTool) {
+      metaParts.push(html`
+        Requested by
+        <bdi class="approval-request__source-tool" dir="ltr"
+          >${data.sourceTool}</bdi
+        >
+      `);
+    }
     metaParts.push(this.renderDiffMeta());
 
     return this.renderRequestShell({
       prefix: 'approval-request',
       details: html`
-        <div class="approval-request__path">
+        <div class="approval-request__path" dir="ltr">
           ${data.relativePath || data.path}
         </div>
         <div class="approval-request__meta">${renderDotMeta(metaParts)}</div>
       `,
-      approveTitle: 'Approve (y)',
-      rejectTitle: 'Reject (n)',
+      approveTitle: 'Approve this edit (y)',
+      rejectTitle: 'Reject this edit (n)',
       leadingActions: this.renderDiffActions(),
     });
   }
@@ -104,8 +111,12 @@ export class ToolEditRequestPanel extends BaseBypassApprovalPanel<'toolEdit'> {
       triggerAriaLabel: 'More diff actions',
       tooltip: 'More diff actions',
       items: html`
-        <wa-dropdown-item value="previewProposed">Preview</wa-dropdown-item>
-        <wa-dropdown-item value="showLatexdiff">LaTeXdiff</wa-dropdown-item>
+        <wa-dropdown-item value="previewProposed"
+          >Preview proposed PDF</wa-dropdown-item
+        >
+        <wa-dropdown-item value="showLatexdiff"
+          >Show LaTeXdiff</wa-dropdown-item
+        >
       `,
       onSelect: this.handleMenuSelect,
     });

--- a/packages/extension/src/progressView/frontend/components/ToolTimer.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolTimer.ts
@@ -1,7 +1,14 @@
 /** Live elapsed-time timer for in-progress tool calls. */
 
 // Third-party imports
-import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  css,
+  nothing,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports
@@ -48,8 +55,15 @@ export class ToolTimer extends LitElement {
     }
   }
 
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has('startTime')) this._update();
+  }
+
   private _update(): void {
-    if (!this.startTime) return;
+    if (this.startTime <= 0) {
+      this._elapsed = '';
+      return;
+    }
     // Lit's default `hasChanged` is `!==`, so an unchanged string schedules
     // no update on its own.
     this._elapsed = formatDuration(Date.now() - this.startTime);
@@ -60,9 +74,16 @@ export class ToolTimer extends LitElement {
     if (this.timeoutMs > 0) {
       const limit = formatDuration(this.timeoutMs);
       // prettier-ignore
-      return html`<span class="timer">${this._elapsed}<span class="timer-limit"> / ${limit}</span></span>`;
+      return html`<span class="timer" role="timer" aria-live="off" aria-label=${`Elapsed time: ${this._elapsed} of ${limit}`} dir="ltr">${this._elapsed}<span class="timer-limit"> / ${limit}</span></span>`;
     }
-    return html`<span class="timer">${this._elapsed}</span>`;
+    return html`<span
+      class="timer"
+      role="timer"
+      aria-live="off"
+      aria-label=${`Elapsed time: ${this._elapsed}`}
+      dir="ltr"
+      >${this._elapsed}</span
+    >`;
   }
 }
 

--- a/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -1,7 +1,7 @@
 /** Container component for tool-use agent streams. */
 
 // Third-party imports
-import { html, nothing, type TemplateResult } from 'lit';
+import { css, html, nothing, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 // Local imports - shared schemas
@@ -32,7 +32,14 @@ import './FollowUpInput';
 
 @customElement('tool-use-stream-content')
 export class ToolUseStreamContent extends BaseStreamContent {
-  static override styles = conversationContentStyles;
+  static override styles = [
+    conversationContentStyles,
+    css`
+      .conversation-composer-banner--empty {
+        padding: 0;
+      }
+    `,
+  ];
 
   private get currentState(): ToolUseStreamState | null {
     const { streamState } = this.streamContext;
@@ -105,10 +112,22 @@ export class ToolUseStreamContent extends BaseStreamContent {
   private renderComposerBanner(
     state: ToolUseStreamState,
     streamInfo: StreamTabInfo,
-  ): TemplateResult | typeof nothing {
-    if (composerVisible(state, streamInfo)) return nothing;
-    return html`<div class="conversation-composer-banner">
-      ${streamStatusTooltip(state, RUN_ENDED_MESSAGE)}
+  ): TemplateResult {
+    const visible = !composerVisible(state, streamInfo);
+    const message = visible
+      ? streamStatusTooltip(state, RUN_ENDED_MESSAGE)
+      : nothing;
+
+    return html`<div
+      class=${
+        visible
+          ? 'conversation-composer-banner'
+          : 'conversation-composer-banner conversation-composer-banner--empty'
+      }
+      role="status"
+      aria-atomic="true"
+    >
+      ${message}
     </div>`;
   }
 

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -17,6 +17,7 @@ import type {
 } from '@shared/schemas';
 import { designTokens } from '@shared/styles';
 import { usageCostLabel, usageRouteBadge } from '@shared/copy/modelAccess';
+import { focusRingStyles } from '@shared/styles/controlStyles';
 
 // Local imports - shared icons and utils
 import type { TeXRAIconName } from '@shared/wa/iconNames';
@@ -33,13 +34,14 @@ type TokenStat = {
   id: string;
   value: number;
   tooltip: string;
-  /** Cache counters are hidden when the run never touched the cache. */
+  /** Optional counters stay hidden until the run reports them. */
   onlyWhenPositive?: boolean;
 };
 
 function renderTokenStat(stat: TokenStat): TemplateResult {
+  const tooltip = `${stat.tooltip}: ${stat.value.toLocaleString('en-US')}`;
   // prettier-ignore
-  return html`${waIcon(stat.icon, { id: stat.id })}${formatCompactTokenCount(stat.value)}<wa-tooltip for=${stat.id}>${stat.tooltip}</wa-tooltip>`;
+  return html`<span id=${stat.id} class="token-stat">${waIcon(stat.icon)}${formatCompactTokenCount(stat.value)}</span><wa-tooltip for=${stat.id}>${tooltip}</wa-tooltip>`;
 }
 
 /** Solid fill color based on context utilization. */
@@ -74,6 +76,7 @@ function usageRouteDecision(
 export class UsagePanel extends LitElement {
   static override styles = [
     designTokens,
+    focusRingStyles,
     css`
       :host {
         display: block;
@@ -110,6 +113,17 @@ export class UsagePanel extends LitElement {
         font-size: var(--font-size-icon-sm);
       }
 
+      /* Each compact counter needs a keyboard-reachable explanation. Keeping
+         the icon and value together also prevents either half wrapping away
+         from the other at narrow widths. */
+      .token-stat {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--wa-space-3xs);
+        border-radius: var(--border-radius-small);
+        white-space: nowrap;
+      }
+
       .run-summary__route {
         font-weight: var(--wa-font-weight-semibold);
         white-space: nowrap;
@@ -125,6 +139,7 @@ export class UsagePanel extends LitElement {
         display: inline-flex;
         align-items: center;
         gap: var(--wa-space-2xs);
+        border-radius: var(--border-radius-small);
       }
 
       .context-gauge__track {
@@ -169,7 +184,9 @@ export class UsagePanel extends LitElement {
       u.outputTokens > 0 ||
       u.cost > 0 ||
       (u.cacheReadInputTokens ?? 0) > 0 ||
-      (u.cacheCreationInputTokens ?? 0) > 0
+      (u.cacheMissInputTokens ?? 0) > 0 ||
+      (u.cacheCreationInputTokens ?? 0) > 0 ||
+      (u.reasoningTokens ?? 0) > 0
     );
   }
 
@@ -191,9 +208,10 @@ export class UsagePanel extends LitElement {
         </span>
         <span
           id=${ELEMENT_IDS.RUN_SUMMARY}
-          class="run-summary"
+          class="run-summary focus-ring-inset"
           role=${this.usage ? 'group' : nothing}
           aria-label=${this.buildUsageLabel()}
+          tabindex=${this.usage ? '0' : nothing}
         >
           ${this.renderUsage()}
         </span>
@@ -208,6 +226,7 @@ export class UsagePanel extends LitElement {
     const cacheRead = this.usage.cacheReadInputTokens ?? 0;
     const cacheMiss = this.usage.cacheMissInputTokens ?? 0;
     const cacheWrite = this.usage.cacheCreationInputTokens ?? 0;
+    const reasoning = this.usage.reasoningTokens ?? 0;
 
     const stats: TokenStat[] = [
       {
@@ -234,7 +253,7 @@ export class UsagePanel extends LitElement {
         icon: 'database',
         id: 'usage-cache-write-icon',
         value: cacheWrite,
-        tooltip: 'Cache creation tokens (1.25x cost)',
+        tooltip: 'Cache creation tokens (1.25× cost)',
         onlyWhenPositive: true,
       },
       {
@@ -242,6 +261,13 @@ export class UsagePanel extends LitElement {
         id: 'usage-output-icon',
         value: outputTokens,
         tooltip: 'Output tokens',
+      },
+      {
+        icon: 'comments',
+        id: 'usage-reasoning-icon',
+        value: reasoning,
+        tooltip: 'Reasoning tokens',
+        onlyWhenPositive: true,
       },
     ];
 
@@ -286,10 +312,12 @@ export class UsagePanel extends LitElement {
     // used` — the rule `formatSubscriptionUsagePercent` sets and the CLI
     // status bar already applies to this same number.
     const clamped = clamp(utilizationPercent, 0, 100);
-    const percentLabel = `${Math.max(1, Math.round(utilizationPercent))}% context used`;
+    const roundedPercent =
+      utilizationPercent > 0 ? Math.max(1, Math.round(utilizationPercent)) : 0;
+    const percentLabel = `${roundedPercent}% context used`;
 
     return html`
-      <span id="usage-context-gauge" class="context-gauge">
+      <span id="usage-context-gauge" class="context-gauge" tabindex="0">
         ${waIcon('window-maximize')}
         <span class="context-gauge__track">
           <wa-progress-bar
@@ -304,7 +332,10 @@ export class UsagePanel extends LitElement {
           ${formatCompactTokenCount(contextWindow)}
         </span>
       </span>
-      <wa-tooltip for="usage-context-gauge">${percentLabel}</wa-tooltip>
+      <wa-tooltip for="usage-context-gauge"
+        >${percentLabel} (${formatCompactTokenCount(inputTokens)} of
+        ${formatCompactTokenCount(contextWindow)} tokens)</wa-tooltip
+      >
     `;
   }
 
@@ -315,6 +346,21 @@ export class UsagePanel extends LitElement {
     // still states it as "$0.000".
     const costLabel =
       usageCostLabel(cost, this.usage.usageRoute) ?? formatCostUsd(cost);
-    return `Total usage: ${formatCompactTokenCount(inputTokens)} input tokens, ${formatCompactTokenCount(outputTokens)} output tokens, ${costLabel}`;
+    const parts = [`${formatCompactTokenCount(inputTokens)} input tokens`];
+    const optionalParts: ReadonlyArray<readonly [number, string]> = [
+      [this.usage.cacheReadInputTokens ?? 0, 'cache read tokens'],
+      [this.usage.cacheMissInputTokens ?? 0, 'cache miss tokens'],
+      [this.usage.cacheCreationInputTokens ?? 0, 'cache creation tokens'],
+    ];
+    for (const [value, label] of optionalParts) {
+      if (value > 0) parts.push(`${formatCompactTokenCount(value)} ${label}`);
+    }
+    parts.push(`${formatCompactTokenCount(outputTokens)} output tokens`);
+    const reasoning = this.usage.reasoningTokens ?? 0;
+    if (reasoning > 0) {
+      parts.push(`${formatCompactTokenCount(reasoning)} reasoning tokens`);
+    }
+    parts.push(costLabel);
+    return `Total usage: ${parts.join(', ')}`;
   }
 }

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -127,7 +127,8 @@ export class UserMessage extends LitElement {
       .user-message-content {
         color: var(--wa-color-text-normal);
         white-space: pre-wrap;
-        word-wrap: break-word;
+        overflow-wrap: anywhere;
+        unicode-bidi: plaintext;
         line-height: 1.55;
         font-size: var(--font-size);
       }
@@ -251,9 +252,9 @@ export class UserMessage extends LitElement {
   }
 
   override render(): TemplateResult {
-    const { timeDisplay, tooltipTimestamp } = formatDisplayTimestamp(
-      new Date(this.timestamp),
-    );
+    const messageDate = new Date(this.timestamp);
+    const { timeDisplay, tooltipTimestamp } =
+      formatDisplayTimestamp(messageDate);
     const copyState = this.copyController.state;
     const rawMessageCopyState = this.rawMessageCopyController.state;
     // processMarkdownContent uses MarkdownIt with html:false and escapes
@@ -269,7 +270,8 @@ export class UserMessage extends LitElement {
 
     return html`
       <div class="user-message-container">
-        <div
+        <article
+          aria-label="User message"
           class=${classMap({
             'user-message': true,
             'user-message--structured-delivery': isStructuredDelivery,
@@ -278,8 +280,11 @@ export class UserMessage extends LitElement {
           <div class="user-message-header">
             <span class="user-message-header-left">
               ${waIcon('comment', { className: 'user-message-icon' })}
-              <span id="user-message-timestamp" class="user-message-timestamp"
-                >${timeDisplay}</span
+              <time
+                id="user-message-timestamp"
+                class="user-message-timestamp"
+                datetime=${messageDate.toISOString()}
+                >${timeDisplay}</time
               >
               <wa-tooltip for="user-message-timestamp"
                 >${tooltipTimestamp}</wa-tooltip
@@ -312,6 +317,8 @@ export class UserMessage extends LitElement {
               ? html`<div
                   class="user-message-content markdown-content"
                   data-log-id=${this.logId}
+                  tabindex="0"
+                  aria-label="User message details"
                 >
                   ${unsafeHTML(structuredMarkdownHtml)}
                 </div>`
@@ -321,7 +328,7 @@ export class UserMessage extends LitElement {
                   .textContent=${displayText}
                 ></div>`
           }
-        </div>
+        </article>
       </div>
     `;
   }

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.styles.ts
@@ -24,16 +24,20 @@ export const userQuestionPanelStyles: CSSResult = css`
   }
 
   .user-question-request__heading {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: ${sp.small};
     max-inline-size: 100%;
     padding: 0;
     color: var(--wa-color-text-normal);
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-normal);
     overflow-wrap: anywhere;
+  }
+
+  .user-question-request__heading-content {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: ${sp.small};
+    max-inline-size: 100%;
   }
 
   .user-question-request__header {
@@ -59,9 +63,9 @@ export const userQuestionPanelStyles: CSSResult = css`
     gap: ${sp.small};
   }
 
-  /* Web Awesome requires its label API to name the internal radio group. The
-     fieldset legend is the visible label, so keep the duplicate text available
-     only to assistive technology. */
+  /* Web Awesome requires its label API to name the internal radio group. Keep
+     the short action cue available to assistive technology without repeating
+     the question already supplied by the outer fieldset legend. */
   wa-radio-group::part(form-control-label) {
     position: absolute;
     width: 1px;

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.styles.ts
@@ -15,6 +15,8 @@ export const userQuestionPanelStyles: CSSResult = css`
     display: flex;
     flex-direction: column;
     gap: ${sp.small};
+    min-inline-size: 0;
+    margin: 0;
     padding: ${sp.medium};
     border: var(--border-thin) solid var(--wa-color-surface-border);
     border-radius: var(--border-radius);
@@ -23,11 +25,15 @@ export const userQuestionPanelStyles: CSSResult = css`
 
   .user-question-request__heading {
     display: flex;
+    flex-wrap: wrap;
     align-items: baseline;
     gap: ${sp.small};
+    max-inline-size: 100%;
+    padding: 0;
     color: var(--wa-color-text-normal);
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-normal);
+    overflow-wrap: anywhere;
   }
 
   .user-question-request__header {
@@ -53,6 +59,21 @@ export const userQuestionPanelStyles: CSSResult = css`
     gap: ${sp.small};
   }
 
+  /* Web Awesome requires its label API to name the internal radio group. The
+     fieldset legend is the visible label, so keep the duplicate text available
+     only to assistive technology. */
+  wa-radio-group::part(form-control-label) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+
   .user-question-request__option {
     font-size: var(--font-size-sm);
     line-height: var(--line-height-normal);
@@ -63,10 +84,24 @@ export const userQuestionPanelStyles: CSSResult = css`
     display: flex;
     flex-direction: column;
     gap: ${sp.tiny};
+    min-inline-size: 0;
+    overflow-wrap: anywhere;
   }
 
   .user-question-request__option small {
     color: var(--wa-color-text-quiet);
     font-size: var(--font-size-xs);
+  }
+
+  .user-question-request__free-text {
+    min-inline-size: 0;
+  }
+
+  .user-question-request__answer-requirement {
+    min-height: calc(var(--font-size-xs) * var(--line-height-normal));
+    margin: 0;
+    color: var(--wa-color-text-quiet);
+    font-size: var(--font-size-xs);
+    line-height: var(--line-height-normal);
   }
 `;

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
@@ -70,17 +70,20 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
         <div class="user-question-request__actions">
           ${renderLabeledActionButton({
             icon: 'check',
-            text: 'Submit',
+            text: 'Submit answers',
             title: canSubmit
               ? 'Submit answers (y)'
               : 'Select or type at least one answer before submitting',
             action: 'submit',
             kind: 'primary',
-            disabled: !canSubmit,
+            disabled: this.archived,
             onClick: () => this.submitAnswers(),
           })}
           ${this.renderRejectButton('Reject this question (n)')}
         </div>
+        <p class="user-question-request__answer-requirement" role="status">
+          ${canSubmit ? '' : 'Answer at least one question to continue.'}
+        </p>
         ${this.renderFeedbackSection(
           'user-question-request__feedback',
           'user-question-request__feedback-input',
@@ -93,11 +96,7 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
   override handleKeyboardShortcut(key: string): boolean {
     if (key !== 'y') return super.handleKeyboardShortcut(key);
     if (this.showFeedback) return false;
-    // Swallow 'y' when nothing is answerable, mirroring the disabled submit
-    // button, so the shortcut doesn't fall through to other handlers.
-    if (this.hasAnyAnswer(this.permission.data)) {
-      this.submitAnswers();
-    }
+    this.submitAnswers();
     return true;
   }
 
@@ -105,8 +104,8 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
     const current = this.selections[question.question] ?? [];
 
     return html`
-      <section class="user-question-request__question">
-        <div class="user-question-request__heading">
+      <fieldset class="user-question-request__question">
+        <legend class="user-question-request__heading">
           ${
             question.header
               ? html`<span class="user-question-request__header">
@@ -115,7 +114,7 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
               : nothing
           }
           <span>${question.question}</span>
-        </div>
+        </legend>
         <div class="user-question-request__options">
           ${
             question.multiSelect
@@ -127,8 +126,12 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
                 )
               : html`
                   <wa-radio-group
-                    aria-label=${question.question}
-                    .value=${current[0] ?? ''}
+                    label=${question.question}
+                    .value=${
+                      this.freeText[question.question]?.trim()
+                        ? ''
+                        : (current[0] ?? '')
+                    }
                     @change=${(event: Event) =>
                       this.updateSingleSelection(question, event)}
                   >
@@ -145,16 +148,22 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
           question.allowFreeText
             ? html`<wa-textarea
                 class="user-question-request__free-text"
-                aria-label=${`Another answer for: ${question.question}`}
-                placeholder="Type another answer"
+                label="Another answer"
+                hint=${
+                  question.multiSelect
+                    ? 'Adds to the selected options.'
+                    : 'Replaces the selected option.'
+                }
                 rows="2"
+                resize="vertical"
+                autocomplete="off"
+                spellcheck
                 .value=${this.freeText[question.question] ?? ''}
-                @input=${(event: Event) =>
-                  this.updateFreeText(question.question, event)}
+                @input=${(event: Event) => this.updateFreeText(question, event)}
               ></wa-textarea>`
             : nothing
         }
-      </section>
+      </fieldset>
     `;
   }
 
@@ -222,24 +231,33 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
       ...this.selections,
       [question.question]: value ? [value] : [],
     };
+    if (value && this.freeText[question.question]) {
+      this.freeText = { ...this.freeText, [question.question]: '' };
+    }
   }
 
-  private updateFreeText(question: string, event: Event): void {
+  private updateFreeText(question: UserQuestionPrompt, event: Event): void {
     const value =
       (event.currentTarget as HTMLElement & { value?: string }).value ?? '';
-    this.freeText = { ...this.freeText, [question]: value };
+    this.freeText = { ...this.freeText, [question.question]: value };
   }
 
   private submitAnswers(): void {
     if (this.archived) return;
     const data = this.permission.data;
+    if (!this.hasAnyAnswer(data)) {
+      this.renderRoot
+        .querySelector<HTMLElement>('wa-radio-group, wa-checkbox, wa-textarea')
+        ?.focus();
+      return;
+    }
     const answers: UserQuestionAnswers = {};
 
     for (const question of data.questions) {
       const custom = this.freeText[question.question]?.trim();
       const selected = this.selections[question.question] ?? [];
       if (question.multiSelect) {
-        // The box is labelled "Type another answer", so on a multi-select
+        // The box is labelled "Another answer", so on a multi-select
         // question it adds to the checked options instead of replacing them.
         const merged = custom ? [...selected, custom] : selected;
         const answer = [...new Set(merged)];

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
@@ -106,14 +106,16 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
     return html`
       <fieldset class="user-question-request__question">
         <legend class="user-question-request__heading">
-          ${
-            question.header
-              ? html`<span class="user-question-request__header">
-                  ${question.header}
-                </span>`
-              : nothing
-          }
-          <span>${question.question}</span>
+          <span class="user-question-request__heading-content">
+            ${
+              question.header
+                ? html`<span class="user-question-request__header">
+                    ${question.header}
+                  </span>`
+                : nothing
+            }
+            <span>${question.question}</span>
+          </span>
         </legend>
         <div class="user-question-request__options">
           ${
@@ -126,7 +128,7 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
                 )
               : html`
                   <wa-radio-group
-                    label=${question.question}
+                    label="Choose one answer"
                     .value=${
                       this.freeText[question.question]?.trim()
                         ? ''

--- a/packages/extension/src/progressView/frontend/components/WorkflowStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowStreamContent.ts
@@ -53,13 +53,13 @@ export class WorkflowStreamContent extends BaseStreamContent {
         ${this.renderLog()}
 
         <div class="conversation-column conversation-epilogue">
-          ${this.renderUsagePanel(state.runUsage, state.contextState)}
-
           <file-list
             .filesByRound=${state.files}
             .failuresByRound=${state.compileFailures}
             .unsupportedCommands=${this.streamContext.unsupportedCommands}
           ></file-list>
+
+          ${this.renderUsagePanel(state.runUsage, state.contextState)}
         </div>
       </div>
     `;

--- a/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
+++ b/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
@@ -49,8 +49,14 @@ export class WorktreeChip extends LitElement {
         width: 6px;
         height: 6px;
         border-radius: 50%;
-        background-color: var(--color-chart-orange);
+        background-color: var(--color-warning);
         flex-shrink: 0;
+      }
+
+      @media (forced-colors: active) {
+        .dirty-dot {
+          background-color: CanvasText;
+        }
       }
     `,
   ];
@@ -66,24 +72,24 @@ export class WorktreeChip extends LitElement {
     const branch = this.info.branch ?? this.worktreeLabel();
     if (!branch) return nothing;
     const branchKind = this.info.branch ? 'Branch' : 'Worktree';
-    const tooltip = this.info.dirty
-      ? `${branchKind} ${branch} (uncommitted changes)`
-      : `${branchKind} ${branch}`;
     return html`<span id="worktree-branch" class="branch">
         ${waIcon('code-branch')}
-        <span class="branch-name">${branch}</span>
+        <bdi class="branch-name" dir="auto">${branch}</bdi>
         ${
           this.info.dirty
             ? html`<span
-                  class="dirty-dot"
-                  role="img"
-                  aria-label="uncommitted changes"
-                ></span>
-                <span class="visually-hidden">uncommitted changes</span>`
+                class="dirty-dot"
+                role="img"
+                aria-label="uncommitted changes"
+              ></span>`
             : nothing
         }
       </span>
-      <wa-tooltip for="worktree-branch">${tooltip}</wa-tooltip>`;
+      <wa-tooltip for="worktree-branch"
+        >${branchKind}: <bdi dir="auto">${branch}</bdi>${
+          this.info.dirty ? ' — uncommitted changes' : nothing
+        }</wa-tooltip
+      >`;
   }
 
   private worktreeLabel(): string | undefined {

--- a/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -238,14 +238,14 @@ export function buildDetailsSummary(
   const iconTemplate = renderIconOrSpinner(iconName, 'icon');
   // prettier-ignore
   const timestampTemplate = timestamp
-    ? html` <span class="timestamp" title=${timestamp.tooltip}>${timestamp.display}</span>`
+    ? html` <span class="timestamp" title=${timestamp.tooltip}><bdi dir="ltr">${timestamp.display}</bdi></span>`
     : nothing;
   const copyTemplate = copyButton
     ? buildCopyButton(copyButton.title, copyButton)
     : nothing;
   const extraTemplate = extraContent ?? nothing;
   // prettier-ignore
-  return html`<div slot="summary" class="details-summary">${iconTemplate} <span class=${labelClass}>${label}</span>${extraTemplate}${timestampTemplate}${copyTemplate}</div>`;
+  return html`<div slot="summary" class="details-summary">${iconTemplate} <span class=${labelClass} dir="auto">${label}</span>${extraTemplate}${timestampTemplate}${copyTemplate}</div>`;
 }
 
 /**
@@ -258,8 +258,10 @@ export function buildFileLinkSpan(
   content: unknown,
   options: { startLine?: number } = {},
 ): TemplateResult {
+  const lineSuffix = options.startLine ? `:${options.startLine}` : '';
+  const accessibleName = `Open ${filePath}${lineSuffix}`;
   // prettier-ignore
-  return html`<span class="file-link clickable-link" data-file=${filePath} data-file-line=${ifDefined(options.startLine)} role="button" tabindex="0">${content}</span>`;
+  return html`<span class="file-link clickable-link" data-file=${filePath} data-file-line=${ifDefined(options.startLine)} role="button" tabindex="0" aria-label=${accessibleName} dir="auto">${content}</span>`;
 }
 
 /** Build the `<li>` rows for a file-list banner. The summary line above them
@@ -283,7 +285,7 @@ export function buildFileListRender(
     // worth labelling sets `sourceDisplay`, so no host needs a fallback to
     // spell it out.
     // prettier-ignore
-    return html`<li class="detail-item" title=${filePath}>${waIcon(iconName)} ${buildFileLinkSpan(filePath, fileName)}${file.varName ? html` <span class="file-var">[${file.varName}]</span>` : ''}${file.sourceDisplay ? html` <span class="file-source">(${file.sourceDisplay})</span>` : ''}${loaded ? html` <span class="file-media">[${loaded.kind}, ${formatBytes(loaded.sizeBytes)}]</span>` : ''}</li>`;
+    return html`<li class="detail-item" title=${filePath}>${waIcon(iconName)} ${buildFileLinkSpan(filePath, html`<bdi dir="auto">${fileName}</bdi>`)}${file.varName ? html` <span class="file-var">[<bdi dir="auto">${file.varName}</bdi>]</span>` : ''}${file.sourceDisplay ? html` <span class="file-source">(<bdi dir="auto">${file.sourceDisplay}</bdi>)</span>` : ''}${loaded ? html` <span class="file-media">[${loaded.kind}, <bdi dir="ltr">${formatBytes(loaded.sizeBytes)}</bdi>]</span>` : ''}</li>`;
   })}`;
 }
 
@@ -357,9 +359,9 @@ export function buildCodeBlock(
   // prettier-ignore
   const languageBadge = showLanguage ? html`<span class="code-block-language">${LANGUAGE_LABELS[language] ?? (language || 'Text')}</span>` : nothing;
   // prettier-ignore
-  const copyButton = showCopy ? html`<wa-button class="code-block-copy" appearance="plain" variant="neutral" size="s" type="button" title="Copy to clipboard" aria-label="Copy to clipboard" @click=${(event: Event) => copyFromClick(event, text, 'copied')}>${waIcon('copy')}</wa-button>` : nothing;
+  const copyButton = showCopy ? html`<wa-button class="code-block-copy" appearance="plain" variant="neutral" size="s" type="button" title="Copy code" aria-label="Copy code" @click=${(event: Event) => copyFromClick(event, text, 'copied')}>${waIcon('copy')}</wa-button>` : nothing;
   // prettier-ignore
-  const codeTemplate = html`<pre class=${classMap(preClasses)}><code>${isHighlighted ? unsafeHTML(highlighted) : text}</code></pre>`;
+  const codeTemplate = html`<pre class=${classMap(preClasses)} dir="ltr"><code>${isHighlighted ? unsafeHTML(highlighted) : text}</code></pre>`;
   // prettier-ignore
   const headerTemplate = showHeader ? html`<div class="code-block-header">${languageBadge}${copyButton}</div>` : nothing;
   // prettier-ignore
@@ -386,9 +388,13 @@ export function buildFileLinkWithLines(
         : `:${startLine}`;
   }
 
-  return buildFileLinkSpan(filePath, html`${waIcon('file')} ${displayText}`, {
-    startLine,
-  });
+  return buildFileLinkSpan(
+    filePath,
+    html`${waIcon('file')} <bdi dir="auto">${displayText}</bdi>`,
+    {
+      startLine,
+    },
+  );
 }
 
 // ============================================================================
@@ -402,7 +408,7 @@ export function buildMemoryPathDisplay(
   if (!memoryPath) return nothing;
   const fileName = getBasename(memoryPath) || memoryPath;
   // prettier-ignore
-  return html`<span class="memory-path">${waIcon('database')} ${fileName} <span class="file-source">(${memoryPath})</span></span>`;
+  return html`<span class="memory-path">${waIcon('database')} <bdi dir="auto">${fileName}</bdi> <span class="file-source">(<bdi dir="auto">${memoryPath}</bdi>)</span></span>`;
 }
 
 // ============================================================================
@@ -415,7 +421,7 @@ export function buildExecutionsPathDisplay(
 ): TemplateResult | typeof nothing {
   if (!execPath) return nothing;
   // prettier-ignore
-  return html`<span class="memory-path">${waIcon('clock-rotate-left')} ${execPath}</span>`;
+  return html`<span class="memory-path">${waIcon('clock-rotate-left')} <bdi dir="auto">${execPath}</bdi></span>`;
 }
 
 // ============================================================================
@@ -447,15 +453,15 @@ function generateInlineDiff(oldText: string, newText: string): TemplateResult {
         `painting it as a whole replacement.`,
     );
     // prettier-ignore
-    return html`<span class="diff-inline-del">${oldText}</span><span class="diff-inline-add">${newText}</span>`;
+    return html`<del class="diff-inline-del" dir="auto">${oldText}</del><ins class="diff-inline-add" dir="auto">${newText}</ins>`;
   }
 
   return html`${parts.map((part) => {
     if (part.removed) {
-      return html`<span class="diff-inline-del">${part.value}</span>`;
+      return html`<del class="diff-inline-del" dir="auto">${part.value}</del>`;
     }
     if (part.added) {
-      return html`<span class="diff-inline-add">${part.value}</span>`;
+      return html`<ins class="diff-inline-add" dir="auto">${part.value}</ins>`;
     }
     return part.value;
   })}`;
@@ -468,5 +474,5 @@ export function buildEditDiffSection(
 ): TemplateResult {
   const diffContent = generateInlineDiff(oldString, newString);
   // prettier-ignore
-  return html`<div class="edit-diff-container"><pre class="diff-inline-view">${diffContent}</pre></div>`;
+  return html`<div class="edit-diff-container"><pre class="diff-inline-view" dir="auto">${diffContent}</pre></div>`;
 }

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/bannerFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/bannerFormatters.ts
@@ -105,7 +105,7 @@ export function formatBannerContentTemplate(
     : html`<div class="banner-content markdown-content log-entry-content ${contentClass}">${unsafeHTML(processMarkdownContent(trimmedContent))}</div>`;
 
   // prettier-ignore
-  return html`<wa-details appearance="plain" icon-placement="start" class="banner-details" ?open=${shouldOpen} data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)}>${buildDetailsSummary({
+  return html`<wa-details appearance="plain" icon-placement="start" class="banner-details" ?open=${shouldOpen} aria-busy=${isRunning ? 'true' : 'false'} data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)}>${buildDetailsSummary({
     iconName: config.iconName,
     label: config.labelText,
     timestamp: config.showTimestamp && verbose

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
@@ -72,7 +72,7 @@ export function formatFileListTemplate(row: FileListRow): FormatResult {
 function renderXmlLink(xmlFile: string): TemplateResult {
   const xmlFileName = getBasename(xmlFile);
   // prettier-ignore
-  return html`<div class="xml-link-container">${waIcon('file-code')} <span>Open XML to check tag consistency:</span> ${buildFileLinkSpan(xmlFile, xmlFileName)} <span class="document-tag">(Expected &lt;${OUTPUT_DOCUMENTS_TAG}&gt; block)</span></div>`;
+  return html`<div class="xml-link-container">${waIcon('file-code')} <span>Open XML to check tag consistency:</span> ${buildFileLinkSpan(xmlFile, html`<bdi dir="auto">${xmlFileName}</bdi>`)} <span class="document-tag">(Expected <code dir="ltr">&lt;${OUTPUT_DOCUMENTS_TAG}&gt;</code> block)</span></div>`;
 }
 
 /** Format missing outputs entry as TemplateResult. */
@@ -90,7 +90,7 @@ export function formatMissingOutputsTemplate(
   const listItems = missing.map((f) => {
     const filePath = String(f);
     const basename = getBasename(filePath);
-    return html`<li class="detail-item" title=${filePath}>${waIcon('triangle-exclamation')} ${buildFileLinkSpan(filePath, basename)}</li>`;
+    return html`<li class="detail-item" title=${filePath}>${waIcon('triangle-exclamation')} ${buildFileLinkSpan(filePath, html`<bdi dir="auto">${basename}</bdi>`)}</li>`;
   });
   return buildFileListDetails({
     logId: id,

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
@@ -18,7 +18,6 @@ import '@progressView/frontend/components/UserMessage';
 
 // Third-party imports - Lit template utilities
 import { html, type TemplateResult } from 'lit';
-import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { when } from 'lit/directives/when.js';
 
@@ -92,9 +91,17 @@ export function formatErrorTemplate(row: ErrorRow): FormatResult {
   const hasDetails = row.details.length > 0;
   const rawContent = detailText || summaryText;
 
-  // Build modular template parts to avoid overly long single-line templates
+  // Do not expose a disclosure control when the row has nothing to reveal.
+  // The level icon supplies a non-color error cue for the static row.
+  if (!hasDetails) {
+    const levelIcon = buildLevelIcon('error');
+    // prettier-ignore
+    return html`<div class="log-line" data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)}><span class="timestamp" title=${tooltipTimestamp}>${levelIcon} [${timeDisplay}]</span> <span class="message-error">${summaryText}</span></div>`;
+  }
+
+  // Build modular template parts to avoid overly long single-line templates.
   // prettier-ignore
-  const detailTemplate = when(hasDetails, () => html`<pre class="error-details">${detailText}</pre>`);
+  const detailTemplate = html`<pre class="error-details">${detailText}</pre>`;
   // prettier-ignore
   const contentTemplate = html`<div class="banner-content log-entry-content banner-content--error">${detailTemplate}</div>`;
   // prettier-ignore
@@ -103,20 +110,12 @@ export function formatErrorTemplate(row: ErrorRow): FormatResult {
   // built here because its title carries the formatted timestamp.
   // prettier-ignore
   const copyButton = buildCopyButton('Copy error details', {
-    hidden: !hasDetails,
     content: rawContent,
   });
-  // Toggle chevron now comes from <wa-details>'s built-in disclosure icon
-  // (::part(icon)); banner-details--no-toggle hides that part when there's
-  // nothing to expand, replacing the old inline visibility:hidden style.
   // prettier-ignore
   const summaryTemplate = html`<div slot="summary" class="details-summary">${waIcon('circle-exclamation', { className: 'icon' })}${labelSpan}${copyButton}</div>`;
   // prettier-ignore
-  return html`<wa-details appearance="plain" icon-placement="start" class=${classMap({
-    'banner-details': true,
-    'banner-details--error': true,
-    'banner-details--no-toggle': !hasDetails,
-  })} data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)}>${summaryTemplate}${contentTemplate}</wa-details>`;
+  return html`<wa-details appearance="plain" icon-placement="start" class="banner-details banner-details--error" data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)}>${summaryTemplate}${contentTemplate}</wa-details>`;
 }
 
 /**

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -102,7 +102,7 @@ export function formatToolUseTemplate(row: ToolRow): FormatResult {
   // a successful command's `exit 0` says nothing the status icon does not.
   if (model.isError && model.exitCode !== undefined) {
     // prettier-ignore
-    sections.push(html`<div class="tool-use-section tool-exit-code">exit ${model.exitCode}</div>`);
+    sections.push(html`<div class="tool-use-section tool-exit-code" dir="ltr">exit ${model.exitCode}</div>`);
   }
 
   if (model.errorPreview) {
@@ -162,7 +162,7 @@ export function formatToolUseTemplate(row: ToolRow): FormatResult {
   // itself, so nothing has to survive a round trip through a DOM attribute.
   // prettier-ignore
   const setupButton = proposal
-    ? html`<button type="button" class="proposal-restore-link proposal-banner-setup" title="Setup this proposal configuration" @click=${(event: Event) => { event.preventDefault(); postMessage(PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG, { proposal }); }} @keydown=${stopSummaryToggleKeydown}>${waIcon('reply')} Setup</button>`
+    ? html`<button type="button" class="proposal-restore-link proposal-banner-setup" @click=${(event: Event) => { event.preventDefault(); postMessage(PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG, { proposal }); }} @keydown=${stopSummaryToggleKeydown}>${waIcon('reply')} Restore setup</button>`
     : nothing;
   // prettier-ignore
   const extraContent = html`${timerTemplate ?? nothing}${row.spillPath ? buildSpillArtifactButton(row.spillPath) : nothing}${setupButton}`;

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
@@ -6,7 +6,7 @@
  * with `// prettier-ignore` to prevent whitespace issues.
  */
 
-import { html, type TemplateResult } from 'lit';
+import { html, nothing, type TemplateResult } from 'lit';
 import { classMap, type ClassInfo } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { TOOL_OUTPUT_LANGUAGES } from '@progressView/frontend/formatters/constants';
@@ -100,8 +100,14 @@ export function buildToolUseDetails(opts: {
     'tool-use-error': opts.isError,
     ...opts.extraClasses,
   };
+  // The failure icon is decorative and hidden from assistive technology.
+  // Keep the collapsed summary's state available without adding visual noise.
+  const statusText = opts.isError
+    ? html`<span class="visually-hidden"> — Failed</span>`
+    : nothing;
+  const extraContent = html`${statusText}${opts.extraContent ?? nothing}`;
   // prettier-ignore
-  return html`<wa-details appearance="plain" icon-placement="start" class=${classMap(classes)} ?open=${opts.defaultOpen ?? false}>${buildDetailsSummary({ iconName: opts.iconName, label: opts.label, labelClass: 'tool-use-title', extraContent: opts.extraContent })}<div class="banner-content log-entry-content" data-log-id=${ifDefined(opts.row.id)} data-group-id=${ifDefined(opts.row.groupId)}>${opts.content}</div></wa-details>`;
+  return html`<wa-details appearance="plain" icon-placement="start" class=${classMap(classes)} ?open=${opts.defaultOpen ?? false}>${buildDetailsSummary({ iconName: opts.iconName, label: opts.label, labelClass: 'tool-use-title', extraContent })}<div class="banner-content log-entry-content" data-log-id=${ifDefined(opts.row.id)} data-group-id=${ifDefined(opts.row.groupId)}>${opts.content}</div></wa-details>`;
 }
 
 type ToolSectionOptions = {

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -13,7 +13,6 @@
  */
 
 import { html, nothing, type TemplateResult } from 'lit';
-import { ifDefined } from 'lit/directives/if-defined.js';
 
 import {
   buildToolUseSection,
@@ -98,7 +97,7 @@ function renderFileGroupsSection(
   section: ToolFileGroupsSection,
 ): TemplateResult {
   // prettier-ignore
-  const fileItems = html`${section.groups.flatMap((group) => group.files.map((file) => html`<li class="detail-item">${waIcon('file')} <span class="${group.clickable ? 'file-link clickable-link' : 'file-label'}" data-file=${ifDefined(group.clickable ? file : undefined)} role=${ifDefined(group.clickable ? 'button' : undefined)} tabindex=${ifDefined(group.clickable ? '0' : undefined)}>${file}</span> <span class="file-source">(${group.label})</span></li>`))}`;
+  const fileItems = html`${section.groups.flatMap((group) => group.files.map((file) => html`<li class="detail-item">${waIcon('file')} ${group.clickable ? buildFileLinkSpan(file, html`<bdi dir="auto">${file}</bdi>`) : html`<span class="file-label"><bdi dir="auto">${file}</bdi></span>`} <span class="file-source">(<bdi dir="auto">${group.label}</bdi>)</span></li>`))}`;
   // prettier-ignore
   return buildToolUseSection(section.label, html`<ul class="detail-list">${fileItems}</ul>`);
 }
@@ -107,10 +106,10 @@ function renderFileListSection(section: ToolFileListSection): TemplateResult {
   // prettier-ignore
   const fileItems = html`${section.files.map((file) => {
     const diffStats = file.lineChanges
-      ? html` <span class="file-stats"><span class="added">+${file.lineChanges.added}</span><span class="removed">-${file.lineChanges.removed}</span></span>`
+      ? html` <span class="file-stats"><span class="visually-hidden">${file.lineChanges.added} ${file.lineChanges.added === 1 ? 'line' : 'lines'} added, ${file.lineChanges.removed} ${file.lineChanges.removed === 1 ? 'line' : 'lines'} removed</span><span class="added" aria-hidden="true">+${file.lineChanges.added}</span><span class="removed" aria-hidden="true">-${file.lineChanges.removed}</span></span>`
       : nothing;
     // prettier-ignore
-    return html`<li class="detail-item">${waIcon('file')} ${buildFileLinkSpan(file.path, file.path)}${file.from ? html` <span class="file-source">(from ${file.from})</span>` : nothing}${file.note ? html` <span class="file-source">(${file.note})</span>` : nothing}${diffStats}</li>`;
+    return html`<li class="detail-item">${waIcon('file')} ${buildFileLinkSpan(file.path, html`<bdi dir="auto">${file.path}</bdi>`)}${file.from ? html` <span class="file-source">(from <bdi dir="auto">${file.from}</bdi>)</span>` : nothing}${file.note ? html` <span class="file-source">(<bdi dir="auto">${file.note}</bdi>)</span>` : nothing}${diffStats}</li>`;
   })}`;
   // prettier-ignore
   return buildToolUseSection(section.label, html`<ul class="detail-list">${fileItems}</ul>`);
@@ -118,7 +117,7 @@ function renderFileListSection(section: ToolFileListSection): TemplateResult {
 
 function renderChecklistSection(section: ToolChecklistSection): TemplateResult {
   // prettier-ignore
-  const items = html`${section.items.map((item) => html`<li class="detail-item">${waIcon(item.done ? 'circle-check' : 'circle')} <span>${item.text}</span></li>`)}`;
+  const items = html`${section.items.map((item) => html`<li class="detail-item">${waIcon(item.done ? 'circle-check' : 'circle')} <span class="visually-hidden">${item.done ? 'Completed' : 'Pending'}: </span><bdi dir="auto">${item.text}</bdi></li>`)}`;
   // prettier-ignore
   return buildToolUseSection(section.label, html`<ul class="detail-list">${items}</ul>`);
 }
@@ -154,9 +153,9 @@ function renderToolSection(
       });
     case 'identifier': {
       // prettier-ignore
-      const note = section.note ? html` <span class="file-source">(${section.note})</span>` : nothing;
+      const note = section.note ? html` <span class="file-source">(<bdi dir="auto">${section.note}</bdi>)</span>` : nothing;
       // prettier-ignore
-      return buildToolUseSection(section.label, html`<code class="execution-id">${section.value}</code>${note}`);
+      return buildToolUseSection(section.label, html`<code class="execution-id" dir="ltr">${section.value}</code>${note}`);
     }
     case 'file':
       return renderFileSection(section);

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts
@@ -6,6 +6,7 @@
  */
 
 import { html, type TemplateResult } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 import {
   buildToolUseSection,
@@ -27,6 +28,29 @@ const STATUS_ICONS: Record<string, TeXRAIconName | typeof SPINNER_ICON_NAME> = {
 /** Line count past which fetched page text becomes a fixed-height scroll box. */
 const CONTENT_SCROLL_LINES = 20;
 
+/** Render a sanitized destination with protocol-appropriate navigation. */
+function buildWebLink(
+  url: string,
+  label: TemplateResult,
+  accessibleLabel: string,
+): TemplateResult {
+  const opensNewTab = /^https?:/i.test(url);
+  // prettier-ignore
+  return html`<a href=${url} class="web-search-link" target=${ifDefined(opensNewTab ? '_blank' : undefined)} rel=${ifDefined(opensNewTab ? 'noopener noreferrer' : undefined)} aria-label=${ifDefined(opensNewTab ? `${accessibleLabel} (opens in a new tab)` : undefined)}>${label}</a>`;
+}
+
+function webSearchFallback(status: string): string {
+  if (status === 'in_progress') return 'Search in progress';
+  if (status === 'failed') return 'Unable to complete search';
+  return 'Search completed';
+}
+
+function webFetchFallback(status: string | undefined, failed: boolean): string {
+  if (status === 'in_progress') return 'Fetching page';
+  if (failed) return 'Unable to fetch page';
+  return 'Fetch completed';
+}
+
 /** Format web search results as TemplateResult. */
 export function formatWebSearchTemplate(row: WebSearchRow): FormatResult {
   const searchResults = row.results;
@@ -43,11 +67,14 @@ export function formatWebSearchTemplate(row: WebSearchRow): FormatResult {
     // real href (an empty/missing href is not itself dangerous, but a
     // result with no safe URL should read as inert text, not a dead link).
     // prettier-ignore
-    const resultItems = searchResults.map(
-      (r) => html`<li class="detail-item">${waIcon('link')} ${r.url ? html`<a href=${r.url} class="web-search-link" target="_blank" rel="noopener noreferrer">${r.title ?? r.domain ?? r.url}</a>` : html`<span class="web-search-link">${r.title ?? r.domain ?? ''}</span>`}${r.domain ? html` <span class="file-source">(${r.domain})</span>` : ''}</li>`,
-    );
+    const resultItems = searchResults.map((r) => {
+      const label = r.title ?? r.domain ?? r.url ?? 'Untitled result';
+      const showDomain = r.domain && r.domain !== label;
+      // prettier-ignore
+      return html`<li class="detail-item">${waIcon('link')} ${r.url ? buildWebLink(r.url, html`<bdi dir="auto">${label}</bdi>`, label) : html`<span><bdi dir="auto">${label}</bdi></span>`}${showDomain ? html` <span class="file-source">(<bdi dir="auto">${r.domain}</bdi>)</span>` : ''}</li>`;
+    });
     // prettier-ignore
-    const resultsTemplate = html`<span class="file-list-summary">Results (${resultCount})</span><ul class="detail-list">${resultItems}</ul>`;
+    const resultsTemplate = html`<span class="file-list-summary">${resultCount} ${resultCount === 1 ? 'result' : 'results'}</span><ul class="detail-list">${resultItems}</ul>`;
     sections.push(buildToolUseSection('Sources:', resultsTemplate));
   } else if (statusKey === 'completed') {
     sections.push(
@@ -61,7 +88,7 @@ export function formatWebSearchTemplate(row: WebSearchRow): FormatResult {
   const contentTemplate =
     sections.length > 0
       ? html`${sections}`
-      : html`<pre>Web search executed</pre>`;
+      : html`<pre>${webSearchFallback(statusKey)}</pre>`;
 
   return buildToolUseDetails({
     row,
@@ -82,7 +109,7 @@ export function formatWebFetchTemplate(row: WebFetchRow): FormatResult {
 
   if (url) {
     // prettier-ignore
-    sections.push(buildToolUseSection('URL:', html`<a href=${url} class="web-search-link" target="_blank" rel="noopener noreferrer">${url}</a>`));
+    sections.push(buildToolUseSection('URL:', buildWebLink(url, html`<bdi dir="ltr">${url}</bdi>`, url)));
   }
 
   if (title) {
@@ -112,7 +139,7 @@ export function formatWebFetchTemplate(row: WebFetchRow): FormatResult {
   const contentTemplate =
     sections.length > 0
       ? html`${sections}`
-      : html`<pre>Web fetch executed</pre>`;
+      : html`<pre>${webFetchFallback(row.status, failed)}</pre>`;
 
   return buildToolUseDetails({
     row,

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowCallFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowCallFormatter.ts
@@ -43,7 +43,12 @@ function callMetadata(
   parts: readonly string[],
 ): TemplateResult | typeof nothing {
   return parts.length > 0
-    ? html`<span class="workflow-task-meta">${parts.join(' · ')}</span>`
+    ? html`<span class="workflow-task-meta"
+        >${parts.map(
+          (part, index) =>
+            html`${index === 0 ? nothing : ' · '}<bdi dir="auto">${part}</bdi>`,
+        )}</span
+      >`
     : nothing;
 }
 
@@ -58,7 +63,7 @@ export function formatWorkflowDeclaredTaskTemplate(
     >
       <span class="workflow-task-icon">${waIcon('circle')}</span>
       <span class="workflow-task-body">
-        <span class="workflow-task-title">${task.label}</span>
+        <bdi class="workflow-task-title" dir="auto">${task.label}</bdi>
       </span>
       <span class="workflow-task-status"
         >${WORKFLOW_TASK_STATUS_LABEL.declared}</span
@@ -96,18 +101,21 @@ export function formatWorkflowCallTemplate(
       data-group-id=${row.groupId ?? ''}
       role=${hasChildStream ? 'button' : nothing}
       tabindex=${hasChildStream ? '0' : nothing}
+      aria-label=${
+        hasChildStream ? `${call.label}, ${row.statusLabel}. Open run` : nothing
+      }
       @click=${hasChildStream ? openChildStream : nothing}
       @keydown=${hasChildStream ? handleKeydown : nothing}
     >
       <span class="workflow-task-icon">${statusIcon(call)}</span>
       <span class="workflow-task-body">
-        <span class="workflow-task-title">${call.label}</span>
+        <bdi class="workflow-task-title" dir="auto">${call.label}</bdi>
         ${callMetadata([...row.metadataParts, ...liveParts])}
         ${
           detail
             ? html`<span
                 class=${`workflow-task-detail workflow-task-detail--${detail.kind}`}
-                >${detail.text}</span
+                ><bdi dir="auto">${detail.text}</bdi></span
               >`
             : nothing
         }

--- a/packages/extension/src/progressView/frontend/formatters/progressBadgeFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/progressBadgeFormatter.ts
@@ -13,12 +13,20 @@ export function renderProgressBadgeContent(
 ): TemplateResult | typeof nothing {
   const stageLabel = formatStageLabel(stage);
   const tools = progress?.toolCallCount ?? 0;
-  const parts = [
-    stageLabel ?? '',
-    tools > 0 ? formatResultCount(tools, 'tool call') : '',
-  ].filter(Boolean);
-  if (parts.length === 0) return nothing;
-  return html`${parts.join(', ')}`;
+  if (!stageLabel && tools <= 0) return nothing;
+
+  const accessibleLabel = getProgressBadgeTitle(progress, stage);
+  return html`<span aria-hidden="true"
+      >${stageLabel ? html`<bdi dir="auto">${stageLabel}</bdi>` : nothing}${
+        stageLabel && tools > 0 ? ', ' : nothing
+      }${tools > 0 ? formatResultCount(tools, 'tool call') : nothing}</span
+    >${
+      accessibleLabel
+        ? html`<span class="visually-hidden"
+            ><bdi dir="auto">${accessibleLabel}</bdi></span
+          >`
+        : nothing
+    }`;
 }
 
 export function getProgressBadgeTitle(

--- a/packages/extension/src/progressView/frontend/formatters/timestampUtils.ts
+++ b/packages/extension/src/progressView/frontend/formatters/timestampUtils.ts
@@ -10,14 +10,12 @@ const DATETIME_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
   hour: '2-digit',
   minute: '2-digit',
   second: '2-digit',
-  hour12: false,
 };
 
 const TIME_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
   hour: '2-digit',
   minute: '2-digit',
   second: '2-digit',
-  hour12: false,
 };
 
 // Shared formatters (lazily initialized for browser environments)

--- a/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
@@ -58,12 +58,6 @@ export const toolUseStyles = css`
     word-break: break-word;
   }
 
-  /* Hide <wa-details>'s built-in disclosure icon when there's nothing to
-     expand (mirrors the old native-details toggle-icon visibility:hidden). */
-  wa-details.banner-details--no-toggle::part(icon) {
-    visibility: hidden;
-  }
-
   .tool-use-user-feedback > .details-summary :is(.tool-use-title, wa-icon) {
     color: var(--color-text-link);
   }

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -27,7 +27,6 @@ import { getLightweightMd } from '@shared/highlighting/lightweightMd';
 import { renderIconActionButtonParts } from '@shared/wa/actionButtons';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { metaStripStyles, renderDotMeta } from '@shared/wa/metaStrip';
-import { getBasename } from '@utils/core';
 import {
   formatBytes,
   formatResultCount,
@@ -51,7 +50,7 @@ export class MemoryItem extends LitElement {
         font-size: var(--font-size);
         font-weight: var(--font-weight-medium);
         color: var(--wa-color-text-link);
-        word-break: break-all;
+        overflow-wrap: anywhere;
       }
 
       .memory-contents {
@@ -60,7 +59,7 @@ export class MemoryItem extends LitElement {
 
       .memory-preview {
         font-size: var(--font-size-sm);
-        line-height: var(--line-height-tight, 1.3);
+        line-height: var(--line-height-relaxed);
         padding: var(--wa-space-3xs) var(--wa-space-2xs);
         border-radius: var(--border-radius);
         margin: 0;
@@ -201,7 +200,7 @@ export class MemoryItem extends LitElement {
    */
   private renderActionGroup(): TemplateResult {
     const pinned = this.item?.pinned === true;
-    const memoryName = getBasename(this.item?.displayPath);
+    const memoryPath = this.item?.displayPath;
     const actions = [
       {
         id: 'memory-pin-button',
@@ -230,7 +229,7 @@ export class MemoryItem extends LitElement {
       // down a list tell a screen-reader user nothing about which one they hit.
       ...renderIconActionButtonParts({
         ...action,
-        label: memoryName ? `${action.label}: ${memoryName}` : action.label,
+        label: memoryPath ? `${action.label}: ${memoryPath}` : action.label,
       }),
     }));
     return html`
@@ -277,7 +276,7 @@ export class MemoryItem extends LitElement {
         })}
       >
         <div class="list-item-header">
-          <div class="memory-path">${this.item.displayPath}</div>
+          <div class="memory-path" dir="auto">${this.item.displayPath}</div>
           ${this.renderActionGroup()}
         </div>
         <div class="text-secondary meta-strip">

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryList.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryList.ts
@@ -15,9 +15,6 @@ import type { MemoryViewItem } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { renderEmptyState } from '@shared/wa/emptyState';
 
-// Side-effect imports - register WA icon component
-import '@awesome.me/webawesome/dist/components/icon/icon.js';
-
 // Local imports - memory view components (side-effect: register)
 import './MemoryItem';
 
@@ -52,6 +49,9 @@ export class MemoryList extends LitElement {
         display: flex;
         flex-direction: column;
         gap: var(--wa-space-xs);
+        margin: 0;
+        padding: 0;
+        list-style: none;
       }
     `,
   ];
@@ -97,13 +97,13 @@ export class MemoryList extends LitElement {
 
     return html`
       ${this.renderPagination()}
-      <div class="memory-list">
+      <ul class="memory-list" aria-label="Saved memories">
         ${repeat(
           paged,
           (item) => item.storagePath,
-          (item) => html`<memory-item .item=${item}></memory-item>`,
+          (item) => html` <li><memory-item .item=${item}></memory-item></li> `,
         )}
-      </div>
+      </ul>
       ${this.renderPagination()}
     `;
   }

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.styles.ts
@@ -62,32 +62,10 @@ export const agentSelectionPanelStyles: CSSResult = css`
     align-items: center;
     gap: var(--wa-space-2xs);
     padding: var(--wa-space-2xs) var(--wa-space-xs);
-    cursor: pointer;
+    min-height: var(--wa-height-option, 32px);
     font-size: var(--font-size-sm);
     color: var(--wa-color-text-normal);
     border-inline-start: var(--border-medium) solid transparent;
-  }
-
-  /*
-   * Source-tinted left rail — uses existing WA semantic colours so each
-   * group gets a quiet identity cue without introducing a new palette.
-   * Inline = warning, custom = success, remote = neutral; built-in rows fall
-   * through to the brand rail below, which shows only while selected. The
-   * hairline shows on hover/selected so the resting state stays calm.
-   */
-  .agent-list-item[data-source='inline']:hover,
-  .agent-list-item[data-source='inline'].selected {
-    border-inline-start-color: var(--wa-color-warning-fill-loud);
-  }
-
-  .agent-list-item[data-source='custom']:hover,
-  .agent-list-item[data-source='custom'].selected {
-    border-inline-start-color: var(--wa-color-success-fill-loud);
-  }
-
-  .agent-list-item[data-source='remote']:hover,
-  .agent-list-item[data-source='remote'].selected {
-    border-inline-start-color: var(--border-control);
   }
 
   .agent-list-item:hover {
@@ -111,6 +89,23 @@ export const agentSelectionPanelStyles: CSSResult = css`
 
   .agent-list-item-toggle {
     flex-shrink: 0;
+  }
+
+  .agent-list-item-select {
+    display: flex;
+    align-items: center;
+    gap: var(--wa-space-2xs);
+    flex: 1;
+    min-width: 0;
+    min-height: var(--height-control-compact);
+    padding: 0;
+    border: 0;
+    border-radius: var(--border-radius-small);
+    color: inherit;
+    background: transparent;
+    font: inherit;
+    text-align: start;
+    cursor: pointer;
   }
 
   .agent-list-item-name {
@@ -146,6 +141,7 @@ export const agentSelectionPanelStyles: CSSResult = css`
   }
 
   .agent-detail-name {
+    margin: 0;
     font-size: var(--font-size-lg);
     font-weight: var(--font-weight-semibold);
     font-family: var(--wa-font-family-mono);
@@ -174,6 +170,7 @@ export const agentSelectionPanelStyles: CSSResult = css`
 
   .agent-detail-meta-value {
     color: var(--wa-color-text-normal);
+    margin: 0;
   }
 
   .agent-detail-tools {

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -122,6 +122,12 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
   }
 
   private handleListKeydown(event: KeyboardEvent): void {
+    if (
+      !(event.target as HTMLElement | null)?.closest('.agent-list-item-select')
+    ) {
+      return;
+    }
+
     const items = this.displayOrder;
     if (items.length === 0) return;
 
@@ -152,7 +158,7 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
       this.selectAgent(items[nextIndex]);
       requestAnimationFrame(() => {
         const el = this.shadowRoot?.querySelector(
-          '.agent-list-item.selected',
+          '.agent-list-item-select[aria-current="true"]',
         ) as HTMLElement | null;
         el?.focus();
       });
@@ -170,33 +176,15 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
   private renderListItem(agent: AgentSelectionItem): TemplateResult {
     const key = agentKey(agent);
     const isSelected = this.selectedKey === key;
-    const { tone, badge } = sourceMeta(agent.source);
+    const { badge } = sourceMeta(agent.source);
 
     return html`
       <div
         class=${classMap({
           'agent-list-item': true,
-          'focus-ring-inset': true,
           selected: isSelected,
         })}
-        data-source=${tone}
-        role="option"
-        aria-selected=${isSelected}
-        tabindex=${isSelected ? '0' : '-1'}
-        @click=${() => this.selectAgent(agent)}
-        @keydown=${(e: KeyboardEvent) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            // Ignore Enter/Space that bubbled out of the nested wa-switch —
-            // it owns its own activation and must not also select the row
-            // (same guard as the preset cards in MultiAgentTab).
-            if ((e.target as HTMLElement | null)?.closest('wa-switch')) {
-              return;
-            }
-            e.preventDefault();
-            this.selectAgent(agent);
-          }
-        }}
-        title=${agent.description ?? agent.name}
+        role="listitem"
       >
         <wa-switch
           class="agent-list-item-toggle"
@@ -220,16 +208,28 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
             >Show ${agent.name} in agent selector</span
           >
         </wa-switch>
-        <span class="agent-list-item-name">${agent.name}</span>
-        <span class="agent-list-item-badges">
-          ${
-            badge
-              ? html`<span title="${badge.label} agent"
-                  >${waIcon(badge.icon, { label: `${badge.label} agent` })}</span
-                >`
-              : nothing
-          }
-        </span>
+        <button
+          class="agent-list-item-select focus-ring-inset"
+          type="button"
+          aria-current=${isSelected ? 'true' : nothing}
+          aria-controls="${this.category}-agent-detail"
+          tabindex=${isSelected ? '0' : '-1'}
+          @click=${() => this.selectAgent(agent)}
+          title=${agent.description ?? agent.name}
+        >
+          <bdi class="agent-list-item-name" dir="auto">${agent.name}</bdi>
+          <span class="agent-list-item-badges">
+            ${
+              badge
+                ? html`<span title="${badge.label} agent"
+                    >${waIcon(badge.icon, {
+                      label: `${badge.label} agent`,
+                    })}</span
+                  >`
+                : nothing
+            }
+          </span>
+        </button>
       </div>
     `;
   }
@@ -243,16 +243,17 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
     return html`
       <div
         class="agent-list-pane"
-        role="listbox"
-        aria-label="Agent list"
+        role="region"
+        aria-label="Agents"
         @keydown=${(e: KeyboardEvent) => this.handleListKeydown(e)}
       >
         ${orderedSources.map((source) => {
           const agents = groups.get(source)!;
           const enabledInGroup = agents.filter((a) => a.enabled).length;
           const sourceName = sourceMeta(source).displayName;
+          const headingId = `${this.category}-${source}-agents-heading`;
           return html`
-            <div class="agent-list-section-header">
+            <div class="agent-list-section-header" id=${headingId}>
               <span>${sourceName}</span>
               <span class="agent-list-section-actions">
                 ${
@@ -264,7 +265,7 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
                         @click=${() => this.handleSetAllEnabled(source, true)}
                         title="Show all ${sourceName} agents"
                       >
-                        All
+                        Show all
                       </wa-button>`
                     : nothing
                 }
@@ -277,13 +278,15 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
                         @click=${() => this.handleSetAllEnabled(source, false)}
                         title="Hide all ${sourceName} agents"
                       >
-                        None
+                        Hide all
                       </wa-button>`
                     : nothing
                 }
               </span>
             </div>
-            ${agents.map((a) => this.renderListItem(a))}
+            <div role="list" aria-labelledby=${headingId}>
+              ${agents.map((a) => this.renderListItem(a))}
+            </div>
           `;
         })}
       </div>
@@ -398,9 +401,15 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
     const { displayName, badge } = sourceMeta(agent.source);
 
     return html`
-      <div class="agent-detail-pane">
+      <section
+        class="agent-detail-pane"
+        id="${this.category}-agent-detail"
+        aria-labelledby="${this.category}-agent-detail-name"
+      >
         <div class="agent-detail-header">
-          <span class="agent-detail-name">${agent.name}</span>
+          <h3 class="agent-detail-name" id="${this.category}-agent-detail-name">
+            <bdi dir="auto">${agent.name}</bdi>
+          </h3>
           <wa-tag variant="neutral" size="s" title="${displayName} agent"
             >${badge ? html`${waIcon(badge.icon)} ` : nothing}${displayName}</wa-tag
           >
@@ -408,7 +417,7 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
 
         ${
           agent.description
-            ? html`<div class="agent-detail-description">
+            ? html`<div class="agent-detail-description" dir="auto">
                 ${agent.description}
               </div>`
             : nothing
@@ -416,22 +425,22 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
         ${
           agent.filePath
             ? html`<div class="agent-detail-path" title=${agent.filePath}>
-                ${getBasename(agent.filePath)}
+                <bdi dir="auto">${getBasename(agent.filePath)}</bdi>
               </div>`
             : nothing
         }
 
-        <div class="agent-detail-meta">
-          <span class="agent-detail-meta-label">Available</span>
-          <span class="agent-detail-meta-value">
+        <dl class="agent-detail-meta">
+          <dt class="agent-detail-meta-label">Shown in selector</dt>
+          <dd class="agent-detail-meta-value">
             ${agent.enabled ? 'Yes' : 'No'}
-          </span>
+          </dd>
 
           ${
             agent.tools?.length
               ? html`
-                  <span class="agent-detail-meta-label">Tools</span>
-                  <div class="agent-detail-meta-value">
+                  <dt class="agent-detail-meta-label">Tools</dt>
+                  <dd class="agent-detail-meta-value">
                     <div class="agent-detail-tools">
                       ${agent.tools.map(
                         (t) =>
@@ -439,20 +448,20 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
                             class="agent-tool-badge"
                             variant="neutral"
                             size="s"
-                            >${t}</wa-tag
+                            ><bdi dir="auto">${t}</bdi></wa-tag
                           >`,
                       )}
                     </div>
-                  </div>
+                  </dd>
                 `
               : nothing
           }
-        </div>
+        </dl>
 
         <div class="agent-detail-actions">
           ${this.renderDetailActions(agent)}
         </div>
-      </div>
+      </section>
     `;
   }
 
@@ -470,9 +479,9 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
       <div class="agent-split-panel">
         ${this.renderList()} ${this.renderDetail(agent)}
       </div>
-      <div class="agent-count">
-        ${enabledCount}/${this.agents.length}
-        ${pluralize(this.agents.length, 'agent')} in dropdown
+      <div class="agent-count" aria-live="polite" aria-atomic="true">
+        ${enabledCount} of ${this.agents.length}
+        ${pluralize(this.agents.length, 'agent')} shown in selector
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.styles.ts
@@ -18,6 +18,7 @@ export const modelSelectionListStyles: CSSResult = css`
   .helper-model-row {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: var(--wa-space-xs);
     margin-bottom: var(--wa-space-s);
   }
@@ -83,6 +84,12 @@ export const modelSelectionListStyles: CSSResult = css`
     gap: var(--wa-space-xs);
   }
 
+  .model-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
   .model-row wa-switch {
     flex: 1;
     min-width: 0;
@@ -107,7 +114,6 @@ export const modelSelectionListStyles: CSSResult = css`
   }
 
   .model-name {
-    font-family: var(--wa-font-family-mono);
     white-space: nowrap;
     min-width: 0;
     overflow: hidden;
@@ -115,6 +121,7 @@ export const modelSelectionListStyles: CSSResult = css`
   }
 
   .model-shortname {
+    font-family: var(--wa-font-family-mono);
     color: var(--color-text-secondary);
     font-size: var(--font-size-xs);
   }
@@ -126,6 +133,7 @@ export const modelSelectionListStyles: CSSResult = css`
     font-size: var(--font-size-xs);
     white-space: nowrap;
     margin-inline-start: auto;
+    font-variant-numeric: tabular-nums;
   }
 
   .model-route {

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -134,7 +134,7 @@ export class ModelSelectionList extends LitElement {
       <wa-select
         class="reasoning-level-select"
         .value=${currentValue}
-        title="Reasoning level"
+        aria-label=${`Reasoning level for ${model.label}`}
         ?disabled=${model.disabled}
         @change=${(e: Event) => this.handleReasoningLevelChange(model.name, e)}
       >
@@ -206,11 +206,13 @@ export class ModelSelectionList extends LitElement {
             });
           }}
         >
-          <span class="model-name">${model.label}</span>
-          <span class="model-shortname">(${model.name})</span>
+          <bdi class="model-name" dir="auto">${model.label}</bdi>
+          <bdi class="model-shortname" dir="auto">(${model.name})</bdi>
           ${
             model.routeLabel
-              ? html`<span class="model-route">· ${model.routeLabel}</span>`
+              ? html`<span class="model-route"
+                  >· <bdi dir="auto">${model.routeLabel}</bdi></span
+                >`
               : nothing
           }
           ${this.renderAvailabilityIcon(model, isLastEnabledActiveModel)}
@@ -270,7 +272,7 @@ export class ModelSelectionList extends LitElement {
             })}
             <span class="provider-group-name">${group.displayName}</span>
             <span class="provider-group-count">
-              ${enabledCount}/${totalCount} enabled
+              ${enabledCount} of ${totalCount} enabled
             </span>
           </wa-button>
           <div class="provider-group-actions settings-disclosure-actions">
@@ -281,7 +283,11 @@ export class ModelSelectionList extends LitElement {
           isExpanded
             ? html`
                 <div class="provider-group-content settings-disclosure-content">
-                  ${group.current.map((m) => this.renderModelRow(m))}
+                  <ul class="model-list">
+                    ${group.current.map(
+                      (model) => html`<li>${this.renderModelRow(model)}</li>`,
+                    )}
+                  </ul>
                   ${
                     group.deprecated.length > 0
                       ? this.renderDeprecatedToggle(group)
@@ -311,13 +317,16 @@ export class ModelSelectionList extends LitElement {
             ? 'provider-group-chevron expanded'
             : 'provider-group-chevron',
         })}
-        ${group.deprecated.length} deprecated
+        ${group.deprecated.length}
+        ${group.deprecated.length === 1 ? 'deprecated model' : 'deprecated models'}
       </wa-button>
       ${
         isOpen
-          ? html`<div class="deprecated-models">
-              ${group.deprecated.map((m) => this.renderModelRow(m))}
-            </div>`
+          ? html`<ul class="model-list deprecated-models">
+              ${group.deprecated.map(
+                (model) => html`<li>${this.renderModelRow(model)}</li>`,
+              )}
+            </ul>`
           : nothing
       }
     `;
@@ -389,7 +398,7 @@ export class ModelSelectionList extends LitElement {
             Use short model names
           </wa-switch>
           <span class="short-names-description">
-            Send unpinned names (e.g. gpt-5.5 instead of gpt-5.5-2026-04-15)
+            Send aliases such as gpt-5.5 instead of dated model versions.
           </span>
         </div>
         <div class="settings-disclosure-list">

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -69,13 +69,13 @@ export class ProviderKeyList extends LitElement {
   }
 
   private renderActions(entry: ProviderKeyStatus): TemplateResult {
-    const { provider } = entry;
+    const { displayName, provider } = entry;
     const removeButton =
       entry.status === 'set'
         ? renderIconActionButton({
             id: `provider-key-remove-${provider}`,
             icon: 'trash',
-            label: `Remove ${provider} key`,
+            label: `Remove ${displayName} API key`,
             tooltip: 'Remove key',
             onClick: () =>
               postMessage(SETTINGS_VIEW_COMMANDS.REMOVE_PROVIDER_KEY, {
@@ -89,7 +89,7 @@ export class ProviderKeyList extends LitElement {
         ${renderIconActionButton({
           id: `provider-key-set-${provider}`,
           icon: 'key',
-          label: `Set ${provider} API key`,
+          label: `Set ${displayName} API key`,
           tooltip: 'Set API key',
           // Bubbles to SettingsApp, which owns the desktop-vs-VS Code
           // provider-key entry flow (modal on desktop, host prompt otherwise).
@@ -99,7 +99,7 @@ export class ProviderKeyList extends LitElement {
         ${renderIconActionButton({
           id: `provider-key-get-${provider}`,
           icon: 'arrow-up-right-from-square',
-          label: `Get ${provider} API key`,
+          label: `Open ${displayName} API key page`,
           tooltip: 'Get API key from provider',
           onClick: () =>
             postMessage(SETTINGS_VIEW_COMMANDS.OPEN_PROVIDER_KEY_URL, {
@@ -134,6 +134,12 @@ export class ProviderKeyList extends LitElement {
             <wa-input
               id=${`endpoint-${entry.provider}`}
               class="endpoint-input form-control-fill"
+              name=${`endpoint-${entry.provider}`}
+              type="url"
+              inputmode="url"
+              autocomplete="url"
+              spellcheck="false"
+              dir="ltr"
               .value=${entry.customEndpoint}
               placeholder="Leave blank for default"
               @change=${(e: Event) => {
@@ -195,20 +201,23 @@ export class ProviderKeyList extends LitElement {
     const isExpanded = this.expandedProvider === entry.provider;
 
     return html`
-      <section class="settings-disclosure">
+      <section class="settings-disclosure" role="listitem">
         <div class="settings-disclosure-summary">
           <wa-button
             class="settings-disclosure-toggle"
             appearance="plain"
             size="s"
             aria-expanded=${String(isExpanded)}
+            aria-label=${`${entry.displayName} settings`}
             title="${isExpanded ? 'Collapse settings' : 'Expand settings'}"
             @click=${() => this.toggleExpanded(entry.provider)}
           >
             ${waIcon('chevron-right', {
               className: 'settings-disclosure-chevron',
             })}
-            <span class="provider-name">${entry.displayName}</span>
+            <span class="provider-name"
+              ><bdi dir="auto">${entry.displayName}</bdi></span
+            >
           </wa-button>
           <span class="settings-disclosure-status">
             ${renderKeyStatusIcon(entry.status)}
@@ -244,7 +253,11 @@ export class ProviderKeyList extends LitElement {
             postStateSetting(GlobalStateKey.STREAMING_GLOBAL, checked);
           },
         })}
-        <div class="settings-disclosure-list">
+        <div
+          class="settings-disclosure-list"
+          role="list"
+          aria-label="Provider API keys"
+        >
           ${rows.map((entry) => this.renderRow(entry))}
         </div>
       </div>

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
@@ -37,13 +37,6 @@ export class ProviderKeyModal extends LitElement {
         line-height: var(--line-height-normal);
       }
 
-      .provider-key-label {
-        display: flex;
-        flex-direction: column;
-        gap: var(--wa-space-2xs);
-        font-weight: var(--font-weight-medium);
-      }
-
       wa-input.provider-key-input {
         display: block;
         width: 100%;
@@ -149,18 +142,20 @@ export class ProviderKeyModal extends LitElement {
             The key is stored by TeXRA on this device and is not shown again
             after saving.
           </p>
-          <label class="provider-key-label">
-            ${displayName} API key
-            <wa-input
-              class="provider-key-input"
-              type="password"
-              autocomplete="off"
-              spellcheck="false"
-              .value=${this.value}
-              @input=${this.handleInput}
-            ></wa-input>
-          </label>
-          <p class="provider-key-error" aria-live="polite">${this.error}</p>
+          <wa-input
+            class="provider-key-input"
+            type="password"
+            label=${`${displayName} API key`}
+            autocomplete="off"
+            autocapitalize="off"
+            spellcheck="false"
+            .value=${this.value}
+            @input=${this.handleInput}
+          >
+            <p slot="hint" class="provider-key-error" aria-live="polite">
+              ${this.error}
+            </p>
+          </wa-input>
         </form>
         <div slot="footer" class="provider-key-actions">
           <wa-button

--- a/packages/extension/src/settingsView/frontend/components/profile/SubscriptionSection.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/SubscriptionSection.ts
@@ -102,6 +102,7 @@ export class SubscriptionSection extends LitElement {
 
   override render(): TemplateResult {
     const provider = this.provider;
+    const headingId = `${provider.sectionId}-heading`;
     const contextWindowSetting = provider.contextWindowSetting;
     const signedIn = this.auth?.signedIn ?? false;
     const preferSubscription = this.auth?.preferSubscription ?? false;
@@ -109,8 +110,9 @@ export class SubscriptionSection extends LitElement {
     // A same-value settings rebroadcast must repaint a rejected number edit.
     void this.ackGeneration;
     return html`
-      <section id=${provider.sectionId}>
+      <section id=${provider.sectionId} aria-labelledby=${headingId}>
         ${renderSettingsSectionHeading({
+          id: headingId,
           title: provider.title,
           description: provider.description,
           icon: 'circle-user',
@@ -145,10 +147,11 @@ export class SubscriptionSection extends LitElement {
           }
           <div class="settings-row">
             <div class="settings-row-text">
-              <span class="settings-row-label">
+              <span class="settings-row-label" aria-live="polite">
                 ${
                   signedIn
-                    ? html`${waIcon('circle-check')} Signed in as ${account}`
+                    ? html`${waIcon('circle-check')} Signed in as
+                        <bdi dir="auto">${account}</bdi>`
                     : provider.accountTitle
                 }
               </span>
@@ -165,6 +168,7 @@ export class SubscriptionSection extends LitElement {
                 signedIn
                   ? renderLabeledActionButton({
                       text: 'Sign out',
+                      label: `Sign out of ${provider.title}`,
                       kind: 'secondary',
                       appearance: 'outlined',
                       onClick: () => postMessage(provider.commands.signOut),

--- a/packages/extension/src/settingsView/frontend/components/profile/SubscriptionSection.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/SubscriptionSection.ts
@@ -150,8 +150,8 @@ export class SubscriptionSection extends LitElement {
               <span class="settings-row-label" aria-live="polite">
                 ${
                   signedIn
-                    ? html`${waIcon('circle-check')} Signed in as
-                        <bdi dir="auto">${account}</bdi>`
+                    ? html`${waIcon('circle-check')}
+                        <bdi dir="auto">${`Signed in as ${account}`}</bdi>`
                     : provider.accountTitle
                 }
               </span>

--- a/packages/extension/src/settingsView/frontend/components/profile/SubscriptionUsageRow.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/SubscriptionUsageRow.ts
@@ -124,7 +124,9 @@ export class SubscriptionUsageRow extends LitElement {
       <div class="settings-row subscription-usage-row">
         <div class="settings-row-text">
           <div class="usage-card">
-            <span class="usage-plan">${snapshot.planName} usage</span>
+            <span class="usage-plan"
+              ><bdi dir="auto">${snapshot.planName}</bdi> usage</span
+            >
             ${snapshot.windows.map((window) => {
               const label = subscriptionUsageWindowLabel(window);
               const percent = formatSubscriptionUsagePercent(
@@ -136,13 +138,16 @@ export class SubscriptionUsageRow extends LitElement {
               );
               return html`
                 <div class="usage-window">
-                  <span>${label}: ${percent}</span>
+                  <span
+                    ><bdi dir="auto">${label}</bdi>:
+                    <bdi dir="auto">${percent}</bdi></span
+                  >
                   <progress
                     max="100"
                     value=${window.percentUsed}
-                    aria-label="${snapshot.providerName} ${label} usage: ${percent} used"
+                    aria-label="${snapshot.providerName} ${label} usage"
                   ></progress>
-                  <span>${reset ?? ''}</span>
+                  <span><bdi dir="auto">${reset ?? ''}</bdi></span>
                 </div>
               `;
             })}

--- a/packages/extension/src/settingsView/frontend/components/shared/Pagination.ts
+++ b/packages/extension/src/settingsView/frontend/components/shared/Pagination.ts
@@ -63,8 +63,7 @@ export class Pagination extends LitElement {
       }
 
       .pagination-status {
-        font-family: var(--wa-font-family-mono, monospace), monospace;
-        letter-spacing: 0.02em;
+        font-variant-numeric: tabular-nums;
       }
 
       .pagination-controls {
@@ -139,7 +138,7 @@ export class Pagination extends LitElement {
     return html`
       <div class="pagination-bar" role="group" aria-label="Pagination">
         <span class="pagination-status" role="status" aria-atomic="true">
-          ${this.rangeStart}–${this.rangeEnd} of ${this.totalItems}
+          ${this.rangeStart}–${this.rangeEnd} of ${this.totalItems} items
         </span>
         <div class="pagination-controls">
           ${this.renderNavButton('backward-step', 'First page', 0, atFirst)}
@@ -149,7 +148,9 @@ export class Pagination extends LitElement {
             page - 1,
             atFirst,
           )}
-          <span class="pagination-status"> ${page + 1}/${totalPages} </span>
+          <span class="pagination-status"
+            >Page ${page + 1} of ${totalPages}</span
+          >
           ${this.renderNavButton('chevron-right', 'Next page', page + 1, atLast)}
           ${this.renderNavButton(
             'forward-step',

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -66,7 +66,8 @@ export class ToolCard extends LitElement {
         font-weight: var(--font-weight-medium);
         font-size: var(--font-size);
         color: var(--wa-color-text-normal);
-        white-space: nowrap;
+        margin: 0;
+        overflow-wrap: anywhere;
       }
 
       wa-tag.tool-badge {
@@ -90,20 +91,29 @@ export class ToolCard extends LitElement {
       .tool-description {
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
+        margin-top: 0;
         margin-bottom: var(--wa-space-2xs);
         line-height: var(--line-height-normal);
+        overflow-wrap: anywhere;
       }
 
       .tool-ids {
         display: flex;
         flex-wrap: wrap;
         gap: var(--wa-space-2xs);
-        margin-bottom: var(--wa-space-2xs);
+        padding: 0;
+        margin: 0 0 var(--wa-space-2xs);
+        list-style: none;
+      }
+
+      .tool-id {
+        min-width: 0;
       }
 
       wa-badge.tool-id-tag::part(base) {
         font-family: var(--wa-font-family-mono, monospace), monospace;
         font-size: var(--font-size-xs);
+        overflow-wrap: anywhere;
       }
 
       .tool-guide {
@@ -135,10 +145,10 @@ export class ToolCard extends LitElement {
         padding: var(--border-thin) var(--wa-space-2xs);
         font-size: var(--font-size-xs);
         border-radius: var(--border-radius);
-        white-space: nowrap;
         font-weight: var(--font-weight-medium);
         color: var(--color-info);
         background: color-mix(in srgb, var(--color-info) 12%, transparent);
+        overflow-wrap: anywhere;
       }
 
       .tool-toggle {
@@ -165,7 +175,7 @@ export class ToolCard extends LitElement {
         margin-top: var(--wa-space-2xs);
         font-size: var(--font-size-xs);
         color: var(--color-text-secondary);
-        font-style: italic;
+        overflow-wrap: anywhere;
       }
     `,
   ];
@@ -284,7 +294,7 @@ export class ToolCard extends LitElement {
     return html`
       <wa-details
         class="collapsible-quiet tool-guide-details"
-        summary="Setup guide"
+        summary=${`Set up ${this.item.name}`}
         ?open=${this.guideExpanded}
         @wa-show=${this.handleGuideShow}
         @wa-hide=${this.handleGuideHide}
@@ -394,14 +404,14 @@ export class ToolCard extends LitElement {
     if (!this.item.authNote) return nothing;
     return html`
       <span class="tool-auth-note">
-        ${waIcon('key')} ${this.item.authNote}
+        ${waIcon('key')} <bdi dir="auto">${this.item.authNote}</bdi>
       </span>
     `;
   }
 
   override render(): TemplateResult {
     return html`
-      <div class="tool-card">
+      <article class="tool-card">
         <div class="tool-header">
           <div class="tool-title-group">
             ${
@@ -409,7 +419,9 @@ export class ToolCard extends LitElement {
                 ? this.renderAvailableStatusIcon()
                 : nothing
             }
-            <span class="tool-name">${this.item.name}</span>
+            <h3 class="tool-name">
+              <bdi dir="auto">${this.item.name}</bdi>
+            </h3>
             ${
               this.item.status === 'available'
                 ? nothing
@@ -419,10 +431,10 @@ export class ToolCard extends LitElement {
           </div>
           ${this.renderToggle()}
         </div>
-        <div class="tool-description">${this.item.description}</div>
+        <p class="tool-description" dir="auto">${this.item.description}</p>
         ${
           this.item.statusDetail
-            ? html`<div class="tool-config-note">
+            ? html`<div class="tool-config-note" dir="auto">
                 ${this.item.statusDetail}
               </div>`
             : nothing
@@ -430,27 +442,34 @@ export class ToolCard extends LitElement {
         ${
           this.item.tools.length > 0
             ? html`
-                <div class="tool-ids">
+                <ul class="tool-ids" aria-label="Included tools">
                   ${this.item.tools.map((tool, index) => {
                     const badgeId = `tool-id-badge-${this.item.id}-${index}`;
-                    return html`<wa-badge
+                    return html`<li class="tool-id">
+                      <wa-badge
                         id=${badgeId}
                         class="tool-id-tag"
                         variant="neutral"
                         appearance="filled"
-                        >${tool.name}</wa-badge
+                        aria-label=${
+                          tool.description
+                            ? `${tool.name}: ${tool.description}`
+                            : tool.name
+                        }
+                        ><bdi dir="auto">${tool.name}</bdi></wa-badge
                       >
                       <wa-tooltip for=${badgeId}
                         >${tool.description ?? tool.name}</wa-tooltip
-                      >`;
+                      >
+                    </li>`;
                   })}
-                </div>
+                </ul>
               `
             : nothing
         }
         <slot name="details"></slot>
         ${this.renderGuide()}
-      </div>
+      </article>
     `;
   }
 }

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -4,7 +4,6 @@
  * plus the Codex-specific inline settings that used to live inside ToolsTab.
  */
 
-import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
@@ -63,8 +62,10 @@ export class AIAgentsTab extends LitElement {
         align-items: center;
         flex-wrap: wrap;
         gap: var(--wa-space-s);
-        margin-bottom: var(--wa-space-xs);
+        padding: 0;
+        margin: 0 0 var(--wa-space-xs);
         font-size: var(--font-size-sm);
+        list-style: none;
       }
 
       .ai-agents-status-stat {
@@ -72,6 +73,7 @@ export class AIAgentsTab extends LitElement {
         align-items: center;
         gap: var(--wa-space-2xs);
         white-space: nowrap;
+        font-variant-numeric: tabular-nums;
       }
 
       .ai-agents-status-stat wa-icon {
@@ -131,6 +133,7 @@ export class AIAgentsTab extends LitElement {
       throw new Error(`No settings-view catalog row for setting "${key}"`);
     }
     const options = catalogEnumChoices(key);
+    const controlId = `ai-agent-${key.replaceAll('.', '-')}`;
     const onChange = (e: Event): void => {
       const selected = readSelectValue(e);
       if (selected) {
@@ -140,13 +143,13 @@ export class AIAgentsTab extends LitElement {
     return html`
       <div class="settings-row">
         <div class="settings-row-text">
-          <span class="settings-row-label">${label}</span>
+          <label class="settings-row-label" for=${controlId}>${label}</label>
           <span class="settings-row-help">${entry.description}</span>
         </div>
         <div class="settings-row-control">
           <wa-select
             class="setting-select"
-            aria-label=${label}
+            id=${controlId}
             .value=${value}
             @change=${onChange}
           >
@@ -222,30 +225,30 @@ export class AIAgentsTab extends LitElement {
     const pending = counts.unknown + counts['coming-soon'];
 
     return html`
-      <div class="ai-agents-status">
-        <span class="ai-agents-status-stat ai-agents-status-available">
-          ${waIcon('check')} ${counts.available} available
-        </span>
+      <ul class="ai-agents-status" aria-label="Integration status">
+        <li class="ai-agents-status-stat ai-agents-status-available">
+          ${waIcon('check')} Available: ${counts.available}
+        </li>
         ${
           counts['not-found'] > 0
             ? html`
-                <span class="ai-agents-status-stat ai-agents-status-missing">
-                  ${waIcon('triangle-exclamation')} ${counts['not-found']} need
-                  setup
-                </span>
+                <li class="ai-agents-status-stat ai-agents-status-missing">
+                  ${waIcon('triangle-exclamation')} Need setup:
+                  ${counts['not-found']}
+                </li>
               `
             : nothing
         }
         ${
           pending > 0
             ? html`
-                <span class="ai-agents-status-stat ai-agents-status-neutral">
-                  ${waIcon('clock')} ${pending} pending
-                </span>
+                <li class="ai-agents-status-stat ai-agents-status-neutral">
+                  ${waIcon('clock')} Pending: ${pending}
+                </li>
               `
             : nothing
         }
-      </div>
+      </ul>
     `;
   }
 

--- a/packages/extension/src/settingsView/frontend/tabs/AccountTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AccountTab.ts
@@ -37,6 +37,11 @@ export class AccountTab extends LitElement {
       .account-page {
         display: block;
       }
+
+      .settings-banner-title {
+        overflow-wrap: anywhere;
+        unicode-bidi: plaintext;
+      }
     `,
   ];
 
@@ -136,7 +141,7 @@ export class AccountTab extends LitElement {
           ${renderSettingsSectionHeading({
             title: 'Credentials',
             description:
-              'Provider API keys remain in Providers & Models, alongside the models that use them.',
+              'Manage provider API keys alongside the models that use them.',
             icon: 'key',
           })}
           <div class="settings-section">
@@ -163,7 +168,8 @@ export class AccountTab extends LitElement {
         <section>
           ${renderSettingsSectionHeading({
             title: 'Privacy',
-            description: 'Choose what TeXRA records about your model usage.',
+            description:
+              'Choose whether TeXRA sends telemetry for model usage billed to your API keys.',
             icon: 'shield',
           })}
           <div class="settings-section">

--- a/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -159,7 +159,10 @@ export class AgentsTab extends UnsupportedCommandsMixin(LitElement) {
         <ul class="custom-agent-issues">
           ${issues.map(
             (issue) =>
-              html`<li><code>${issue.path}</code> — ${issue.message}</li>`,
+              html`<li>
+                <bdi dir="auto"><code>${issue.path}</code></bdi> —
+                <bdi dir="auto">${issue.message}</bdi>
+              </li>`,
           )}
         </ul>
       `,
@@ -181,14 +184,14 @@ export class AgentsTab extends UnsupportedCommandsMixin(LitElement) {
       ? html`
           ${renderLabeledActionButton({
             icon: 'file-circle-plus',
-            text: 'From template',
+            text: 'Create from template',
             kind: 'secondary',
             appearance: 'outlined',
             onClick: () => this.handleCreateAgent(category, true),
           })}
           ${renderLabeledActionButton({
             icon: 'plus',
-            text: 'New agent',
+            text: 'Create agent',
             kind: 'primary',
             appearance: 'filled',
             onClick: () => this.handleCreateAgent(category),
@@ -196,12 +199,17 @@ export class AgentsTab extends UnsupportedCommandsMixin(LitElement) {
         `
       : nothing;
     return html`
-      <section id="${category}-agents-section" class="agent-category">
+      <section
+        id="${category}-agents-section"
+        class="agent-category"
+        aria-labelledby="${category}-agents-heading"
+      >
         ${renderSettingsSectionHeading({
           title: `${title} (${agents.length})`,
           description,
           icon,
           actions,
+          id: `${category}-agents-heading`,
         })}
         <agent-selection-panel
           .agents=${agents}
@@ -246,7 +254,7 @@ export class AgentsTab extends UnsupportedCommandsMixin(LitElement) {
                 class="settings-row-help agents-dir-path"
                 title=${this.customAgentDir}
               >
-                ${this.customAgentDir}
+                <bdi dir="auto">${this.customAgentDir}</bdi>
               </span>
             </div>
             <div class="settings-row-control action-button-group">
@@ -256,7 +264,7 @@ export class AgentsTab extends UnsupportedCommandsMixin(LitElement) {
                 onClick: () => this.handleOpenFolder(),
               })}
               ${renderLabeledActionButton({
-                text: 'Change',
+                text: 'Change folder',
                 kind: 'secondary',
                 appearance: 'outlined',
                 onClick: () => this.handleChangeCustomDir(),
@@ -266,7 +274,7 @@ export class AgentsTab extends UnsupportedCommandsMixin(LitElement) {
                   ? nothing
                   : renderLabeledActionButton({
                       icon: 'arrow-rotate-left',
-                      text: 'Reset',
+                      text: 'Use default folder',
                       kind: 'secondary',
                       appearance: 'outlined',
                       onClick: () => this.handleResetCustomDir(),
@@ -293,7 +301,7 @@ export class AgentsTab extends UnsupportedCommandsMixin(LitElement) {
         ${renderSettingsSectionHeading({
           title: 'Reliability',
           description:
-            'Tweak how long model sessions handle retries and context limits.',
+            'Configure how model sessions handle retries and context limits.',
           icon: 'rotate-right',
         })}
         <div class="settings-section">

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -256,7 +256,7 @@ export class GitTab extends UnsupportedCommandsMixin(LitElement) {
                         this.githubTokenStatus === 'secret'
                           ? renderLabeledActionButton({
                               icon: 'trash',
-                              text: 'Remove',
+                              text: 'Remove token',
                               kind: 'danger',
                               onClick: this.handleRemoveGitHubToken,
                             })
@@ -275,7 +275,7 @@ export class GitTab extends UnsupportedCommandsMixin(LitElement) {
                     <strong>How to get a token:</strong>
                     <ol>
                       <li>
-                        Click <em>Create on GitHub…</em> to open the
+                        Select <em>Create on GitHub…</em> to open the
                         token-creation page in your browser.
                       </li>
                       <li>
@@ -284,7 +284,7 @@ export class GitTab extends UnsupportedCommandsMixin(LitElement) {
                         usage; no write scopes needed.
                       </li>
                       <li>
-                        Pick an expiration (90 days is common) and click
+                        Pick an expiration (90 days is common) and select
                         <em>Generate token</em>.
                       </li>
                       <li>
@@ -324,8 +324,8 @@ export class GitTab extends UnsupportedCommandsMixin(LitElement) {
                       (subscription) => html`
                         <li>
                           <div class="subscription-meta">
-                            <code class="subscription-key"
-                              >${subscription.key}</code
+                            <code class="subscription-key" dir="ltr"
+                              ><bdi>${subscription.key}</bdi></code
                             >
                             ${
                               subscription.owners.length > 0
@@ -336,11 +336,14 @@ export class GitTab extends UnsupportedCommandsMixin(LitElement) {
                                           <div class="subscription-owner-row">
                                             <span
                                               class="subscription-owner-label"
-                                              >${owner.label}</span
+                                              ><bdi dir="auto"
+                                                >${owner.label}</bdi
+                                              ></span
                                             >
                                             ${renderLabeledActionButton({
                                               icon: 'comments',
                                               text: 'Jump to agent',
+                                              label: `Jump to ${owner.label}`,
                                               kind: 'secondary',
                                               appearance: 'outlined',
                                               onClick: () =>
@@ -364,6 +367,7 @@ export class GitTab extends UnsupportedCommandsMixin(LitElement) {
                           ${renderLabeledActionButton({
                             icon: 'circle-stop',
                             text: 'Stop',
+                            label: `Stop monitoring ${subscription.key}`,
                             kind: 'secondary',
                             appearance: 'outlined',
                             onClick: () =>
@@ -399,6 +403,9 @@ export class GitTab extends UnsupportedCommandsMixin(LitElement) {
                       <wa-input
                         id="git-author-name"
                         class="form-control-fill"
+                        name="git-author-name"
+                        autocomplete="off"
+                        spellcheck="false"
                         .value=${this.authorName}
                         placeholder=${DEFAULT_GIT_AUTHOR_NAME}
                         @change=${this.handleAuthorNameChange}
@@ -409,6 +416,13 @@ export class GitTab extends UnsupportedCommandsMixin(LitElement) {
                       <wa-input
                         id="git-author-email"
                         class="form-control-fill"
+                        name="git-author-email"
+                        type="email"
+                        inputmode="email"
+                        autocomplete="off"
+                        autocapitalize="off"
+                        spellcheck="false"
+                        dir="ltr"
                         .value=${this.authorEmail}
                         placeholder=${DEFAULT_GIT_AUTHOR_EMAIL}
                         @change=${this.handleAuthorEmailChange}

--- a/packages/extension/src/settingsView/frontend/tabs/GoalTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GoalTab.ts
@@ -33,6 +33,9 @@ export class GoalTab extends LitElement {
         display: flex;
         flex-direction: column;
         gap: var(--wa-space-xs);
+        margin: 0;
+        padding: 0;
+        list-style: none;
       }
 
       .goal-actions {
@@ -44,12 +47,17 @@ export class GoalTab extends LitElement {
       .goal-row {
         display: grid;
         grid-template-columns: auto 1fr auto;
+        width: 100%;
+        min-width: 0;
         gap: var(--wa-space-s);
         align-items: center;
         padding: var(--wa-space-s);
         border: 1px solid var(--wa-color-neutral-border-quiet);
         border-radius: var(--wa-border-radius-m);
         background: var(--wa-color-surface-default);
+        color: inherit;
+        font: inherit;
+        text-align: start;
       }
 
       .goal-row.is-clickable {
@@ -96,13 +104,6 @@ export class GoalTab extends LitElement {
     postMessage(SETTINGS_VIEW_COMMANDS.REVEAL_GOAL_STREAM, { streamId });
   }
 
-  private handleRowKey(event: KeyboardEvent, streamId: string): void {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      this.handleReveal(streamId);
-    }
-  }
-
   private renderActions(): TemplateResult {
     return html`<div class="goal-actions">
       ${renderLabeledActionButton({
@@ -117,19 +118,18 @@ export class GoalTab extends LitElement {
 
   private renderRow(item: Goal): TemplateResult {
     const metaParts: MetaPart[] = [
-      html`<span class="stream-id">${item.streamId}</span>`,
+      html`<code class="stream-id" dir="ltr">${item.streamId}</code>`,
       html`<span title="Wall-clock duration since this Goal started"
         >duration ${formatGoalTime(goalElapsedMs(item))}</span
       >`,
     ];
     return html`
-      <div
+      <button
+        type="button"
         class="goal-row is-clickable"
         @click=${() => this.handleReveal(item.streamId)}
-        @keydown=${(e: KeyboardEvent) => this.handleRowKey(e, item.streamId)}
-        role="button"
-        tabindex="0"
       >
+        <span class="visually-hidden">Open goal:</span>
         <wa-badge
           class="status-chip"
           variant=${item.status === 'active' ? 'success' : 'warning'}
@@ -137,13 +137,15 @@ export class GoalTab extends LitElement {
           >${capitalize(item.status)}</wa-badge
         >
         <div>
-          <div class="objective" title=${item.objective}>${item.objective}</div>
+          <div class="objective" title=${item.objective}>
+            <bdi>${item.objective}</bdi>
+          </div>
           <div class="text-secondary meta-strip">
             ${renderDotMeta(metaParts)}
           </div>
         </div>
         ${waIcon('chevron-right')}
-      </div>
+      </button>
     `;
   }
 
@@ -161,13 +163,13 @@ export class GoalTab extends LitElement {
                 className: 'empty-state',
               })
             : html`
-                <div class="goal-list">
+                <ul class="goal-list" aria-label="Goals">
                   ${repeat(
                     this.items,
                     (it) => it.goalId,
-                    (it) => this.renderRow(it),
+                    (it) => html`<li>${this.renderRow(it)}</li>`,
                   )}
-                </div>
+                </ul>
               `
         }
       </div>

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.styles.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.styles.ts
@@ -81,6 +81,7 @@ export const latexTabStyles: CSSResult = css`
     font-family: var(--wa-font-family-mono, monospace), monospace;
     font-size: var(--font-size-sm);
     color: var(--color-text-secondary);
+    overflow-wrap: anywhere;
   }
 
   .dependency-install-actions {
@@ -98,9 +99,9 @@ export const latexTabStyles: CSSResult = css`
     font-family: var(--wa-font-family-mono, monospace), monospace;
     font-size: var(--font-size-sm);
     color: var(--wa-color-text-normal);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    direction: ltr;
+    overflow-wrap: anywhere;
+    unicode-bidi: isolate;
   }
 
   /* The shared settings banner owns the callout; this view only lets the
@@ -144,6 +145,10 @@ export const latexTabStyles: CSSResult = css`
     margin-top: var(--wa-space-2xs);
     color: var(--color-status-error);
     font-size: var(--font-size-sm);
+  }
+
+  .replacement-json-error:empty {
+    display: none;
   }
 
   .setting-config-key {

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -326,7 +326,10 @@ export class LaTeXTab extends LitElement {
               ${installed ? dep.installedDesc : dep.missingDesc}
             </div>
             ${detectedPaths.map(
-              (p) => html`<div class="dependency-path">${p}</div>`,
+              (p) =>
+                html`<div class="dependency-path">
+                  <bdi dir="auto">${p}</bdi>
+                </div>`,
             )}
           </div>
           ${actionSlot}
@@ -335,7 +338,10 @@ export class LaTeXTab extends LitElement {
           !installed && installCmd
             ? html`
                 <div class="dependency-install-actions">
-                  <wa-copy-button value=${installCmd.command}></wa-copy-button>
+                  <wa-copy-button
+                    value=${installCmd.command}
+                    copy-label="Copy install command"
+                  ></wa-copy-button>
                   <wa-button
                     appearance="outlined"
                     variant="neutral"
@@ -410,8 +416,11 @@ export class LaTeXTab extends LitElement {
       title,
       description,
       actions: html`
-        <code class="install-command-text">${installCommand}</code>
-        <wa-copy-button value=${installCommand}></wa-copy-button>
+        <code class="install-command-text" dir="ltr">${installCommand}</code>
+        <wa-copy-button
+          value=${installCommand}
+          copy-label="Copy install command"
+        ></wa-copy-button>
         ${renderLabeledActionButton({
           icon: 'terminal',
           text: 'Run in Terminal',
@@ -685,6 +694,7 @@ export class LaTeXTab extends LitElement {
     const isCustom = Object.keys(value).length > 0;
     const error = this.replacementJsonErrors[opts.field];
     const controlId = `latex-setting-${opts.field}`;
+    const errorId = `${controlId}-error`;
     return html`
       <div class="settings-row replacement-map-row">
         <div class="settings-row-text">
@@ -697,6 +707,8 @@ export class LaTeXTab extends LitElement {
             rows="4"
             resize="auto"
             spellcheck="false"
+            aria-describedby=${errorId}
+            aria-invalid=${error ? 'true' : 'false'}
             .value=${JSON.stringify(value, null, 2)}
             @change=${(event: Event) =>
               this.handleCustomReplacementChange(
@@ -704,11 +716,9 @@ export class LaTeXTab extends LitElement {
                 (event.target as WaTextarea).value ?? '',
               )}
           ></wa-textarea>
-          ${
-            error
-              ? html`<span class="replacement-json-error">${error}</span>`
-              : nothing
-          }
+          <span id=${errorId} class="replacement-json-error" aria-live="polite"
+            >${error ?? nothing}</span
+          >
         </div>
         <div class="settings-row-control">
           ${this.renderSettingStatusIcon(isCustom)}
@@ -728,7 +738,10 @@ export class LaTeXTab extends LitElement {
     } catch (error) {
       this.replacementJsonErrors = {
         ...this.replacementJsonErrors,
-        [field]: error instanceof Error ? error.message : 'Invalid JSON.',
+        [field]:
+          error instanceof Error
+            ? `Enter valid JSON. ${error.message}`
+            : 'Enter valid JSON.',
       };
       return;
     }

--- a/packages/extension/src/settingsView/frontend/tabs/MemoryTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MemoryTab.ts
@@ -33,6 +33,7 @@ export class MemoryTab extends LitElement {
 
       .memory-actions {
         display: flex;
+        flex-wrap: wrap;
         justify-content: flex-end;
         gap: var(--wa-space-2xs);
       }
@@ -51,20 +52,23 @@ export class MemoryTab extends LitElement {
   };
 
   private renderActions(): TemplateResult {
-    return html`<div class="memory-actions">
+    return html`<div
+      class="memory-actions"
+      role="group"
+      aria-label="Saved memory actions"
+    >
       ${renderLabeledActionButton({
         icon: 'rotate-right',
-        text: 'Refresh',
+        text: 'Refresh memories',
         kind: 'secondary',
         appearance: 'outlined',
         onClick: this.handleRefresh,
       })}
       ${renderLabeledActionButton({
         icon: 'folder-open',
-        text: 'Open folder',
+        text: 'Open memory folder',
         kind: 'secondary',
         appearance: 'outlined',
-        title: 'Open memory folder in file explorer',
         onClick: this.handleOpenFolder,
       })}
     </div>`;

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -57,16 +57,27 @@ export class MultiAgentTab extends LitElement {
         gap: var(--wa-space-xs);
       }
 
-      .preset-card {
+      .preset-card-shell {
         position: relative;
+      }
+
+      .preset-card {
         display: flex;
         flex-direction: column;
         gap: var(--wa-space-3xs);
+        width: 100%;
+        height: 100%;
         padding: var(--wa-space-2xs) var(--wa-space-xs);
+        font: inherit;
+        text-align: start;
         background-color: var(--wa-color-neutral-fill-quiet);
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--border-radius);
         cursor: pointer;
+      }
+
+      .preset-card.deletable .preset-card-header {
+        padding-inline-end: var(--wa-space-xl);
       }
 
       .preset-card:hover {
@@ -151,11 +162,6 @@ export class MultiAgentTab extends LitElement {
         position: absolute;
         inset-block-start: var(--wa-space-2xs);
         inset-inline-end: var(--wa-space-2xs);
-        opacity: 0;
-        /* Destructive and invisible: a tap on the card corner must not delete a
-           team. Keyboard focus is unaffected, and focusing reveals the button
-           through :focus-within below. */
-        pointer-events: none;
         z-index: 10;
       }
 
@@ -173,12 +179,6 @@ export class MultiAgentTab extends LitElement {
         outline: var(--focus-ring-width) solid var(--wa-color-focus);
         outline-offset: var(--focus-ring-offset);
         border-radius: var(--border-radius-small);
-      }
-
-      .preset-card:hover .preset-delete-btn,
-      .preset-card:focus-within .preset-delete-btn {
-        opacity: var(--opacity-full);
-        pointer-events: auto;
       }
     `,
   ];
@@ -206,19 +206,6 @@ export class MultiAgentTab extends LitElement {
     });
   }
 
-  private handlePresetKey(event: KeyboardEvent, preset: AgentModePreset): void {
-    if (event.key === 'Enter' || event.key === ' ') {
-      // Ignore Enter/Space that bubbled up from the nested delete button —
-      // that control owns its own click/keydown activation and must not
-      // also apply the preset it's being deleted from.
-      if ((event.target as HTMLElement | null)?.closest('.preset-delete-btn')) {
-        return;
-      }
-      event.preventDefault();
-      this.handlePresetClick(preset);
-    }
-  }
-
   private handleDeletePreset(event: Event, preset: AgentModePreset): void {
     event.stopPropagation();
     postMessage(SETTINGS_VIEW_COMMANDS.DELETE_AGENT_MODE_PRESET, {
@@ -243,68 +230,82 @@ export class MultiAgentTab extends LitElement {
     );
     const isActive = this.activePresetId === preset.id;
     return html`
-      <div
-        class=${classMap({ 'preset-card': true, active: isActive })}
-        role="button"
-        tabindex="0"
-        @click=${() => this.handlePresetClick(preset)}
-        @keydown=${(e: KeyboardEvent) => this.handlePresetKey(e, preset)}
-        title="Apply ${preset.name} team"
-      >
-        <div class="preset-card-header">
-          ${waIcon(preset.icon, { className: 'preset-card-icon' })}
-          <span class="preset-card-name">${preset.name}</span>
+      <div class="preset-card-shell" role="listitem">
+        <button
+          class=${classMap({
+            'preset-card': true,
+            active: isActive,
+            deletable,
+          })}
+          type="button"
+          aria-pressed=${isActive}
+          @click=${() => this.handlePresetClick(preset)}
+          title=${`Apply ${preset.name} team`}
+        >
+          <div class="preset-card-header">
+            ${waIcon(preset.icon, { className: 'preset-card-icon' })}
+            <span class="preset-card-name"
+              ><bdi dir="auto">${preset.name}</bdi></span
+            >
+            ${
+              isActive
+                ? html`<wa-tag
+                    class="preset-active-badge"
+                    variant="brand"
+                    size="s"
+                  >
+                    ${waIcon('check')} Active
+                  </wa-tag>`
+                : nothing
+            }
+          </div>
+          <p class="preset-card-description">
+            <bdi dir="auto">${preset.description}</bdi>
+          </p>
           ${
-            isActive
-              ? html`<wa-tag
-                  class="preset-active-badge"
-                  variant="brand"
-                  size="s"
-                >
-                  ${waIcon('check')} Active
-                </wa-tag>`
+            orchestratorAgents.length > 0
+              ? html`<div class="preset-card-orchestrators">
+                  ${orchestratorAgents.map(
+                    (name) => html`
+                      <wa-tag
+                        class="preset-agent-badge preset-agent-badge--orchestrator"
+                        variant="brand"
+                        size="s"
+                        title="${name} is the orchestrator for this team"
+                      >
+                        <span
+                          class="preset-orchestrator-icon"
+                          aria-hidden="true"
+                          >${waIcon('bullseye')}</span
+                        >
+                        <!-- The bullseye is aria-hidden and the tag's title is
+                             hover-only, so carry the orchestrator identity as
+                             (visually hidden) text. -->
+                        <span class="visually-hidden">Orchestrator:</span>
+                        <bdi dir="auto">${name}</bdi>
+                      </wa-tag>
+                    `,
+                  )}
+                </div>`
               : nothing
           }
-        </div>
-        <p class="preset-card-description">${preset.description}</p>
-        ${
-          orchestratorAgents.length > 0
-            ? html`<div class="preset-card-orchestrators">
-                ${orchestratorAgents.map(
-                  (name) => html`
-                    <wa-tag
-                      class="preset-agent-badge preset-agent-badge--orchestrator"
-                      variant="brand"
-                      size="s"
-                      title="${name} is the orchestrator for this team"
-                    >
-                      <span class="preset-orchestrator-icon" aria-hidden="true"
-                        >${waIcon('bullseye')}</span
-                      >
-                      <!-- The bullseye is aria-hidden and the tag's title is
-                           hover-only, so carry the orchestrator identity as
-                           (visually hidden) text. -->
-                      <span class="visually-hidden">Orchestrator:</span>
-                      ${name}
-                    </wa-tag>
-                  `,
-                )}
-              </div>`
-            : nothing
-        }
-        <div class="preset-card-agents">
-          ${teammateAgents.map(
-            (name) =>
-              html`<wa-tag class="preset-agent-badge" variant="neutral" size="s"
-                >${name}</wa-tag
-              >`,
-          )}
-        </div>
+          <div class="preset-card-agents">
+            ${teammateAgents.map(
+              (name) =>
+                html`<wa-tag
+                  class="preset-agent-badge"
+                  variant="neutral"
+                  size="s"
+                  ><bdi dir="auto">${name}</bdi></wa-tag
+                >`,
+            )}
+          </div>
+        </button>
         ${
           deletable
             ? renderIconActionButton({
                 icon: 'trash',
-                label: 'Delete team',
+                label: `Delete ${preset.name} team`,
                 className: 'preset-delete-btn',
                 onClick: (e) => this.handleDeletePreset(e, preset),
               })
@@ -326,7 +327,7 @@ export class MultiAgentTab extends LitElement {
           icon: 'users',
         })}
 
-        <div class="preset-grid">
+        <div class="preset-grid" role="list">
           ${AGENT_MODE_PRESETS.map((p) => this.renderPresetCard(p, false))}
           ${this.customPresets.map((p) => this.renderPresetCard(p, true))}
         </div>

--- a/packages/extension/src/settingsView/frontend/tabs/ShortcutsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ShortcutsTab.ts
@@ -125,7 +125,7 @@ export class ShortcutsTab extends LitElement {
     event.stopPropagation();
     if (event.key === 'Escape') {
       this.recordingId = undefined;
-      this.feedback = '';
+      this.feedback = 'Shortcut recording canceled.';
       return;
     }
     if (event.key === 'Backspace' || event.key === 'Delete') {
@@ -189,13 +189,16 @@ export class ShortcutsTab extends LitElement {
       detectBrowserPlatform(),
     );
     const label = recording ? 'Press shortcut…' : (current ?? 'Not assigned');
+    const recorderLabel = recording
+      ? `Recording shortcut for ${entry.label}. Press the new shortcut.`
+      : `Change shortcut for ${entry.label}. Current shortcut: ${label}.`;
     return html`
       <div class="settings-row">
         <div class="settings-row-text">
           <span class="settings-row-label">${entry.label}</span>
           <span class="settings-row-help">
             ${entry.category}
-            <span class="shortcuts-command">${entry.id}</span>
+            <bdi class="shortcuts-command" dir="ltr">${entry.id}</bdi>
           </span>
         </div>
         <div class="settings-row-control shortcuts-control">
@@ -203,12 +206,14 @@ export class ShortcutsTab extends LitElement {
             class="shortcut-recorder btn-secondary"
             appearance="outlined"
             size="s"
+            aria-label=${recorderLabel}
             data-recording=${String(recording)}
             @click=${() => this.startRecording(entry.id)}
             @keydown=${(event: KeyboardEvent) =>
               this.captureShortcut(event, entry)}
           >
-            ${waIcon('code', { slot: 'start' })} ${label}
+            ${waIcon('code', { slot: 'start' })}
+            ${recording ? label : html`<bdi dir="ltr">${label}</bdi>`}
           </wa-button>
           ${renderLabeledActionButton({
             icon: 'arrow-rotate-left',
@@ -251,10 +256,10 @@ export class ShortcutsTab extends LitElement {
           }),
         })}
         <wa-input
+          id="shortcuts-search"
           class="shortcuts-search"
           type="search"
-          placeholder="Filter shortcuts"
-          aria-label="Filter shortcuts"
+          label="Filter shortcuts"
           @input=${this.handleSearch}
         ></wa-input>
         <p

--- a/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
+++ b/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
@@ -34,7 +34,9 @@ export class AgentConfigBanner extends StateVisibleBanner<AgentConfigBannerState
         <span>
           ${
             this.state.agentName
-              ? `Agent file for “${this.state.agentName}” is missing.`
+              ? html`Agent file for “<bdi dir="auto"
+                    >${this.state.agentName}</bdi
+                  >” is missing.`
               : 'Agent configuration is missing.'
           }
         </span>
@@ -54,7 +56,11 @@ export class AgentConfigBanner extends StateVisibleBanner<AgentConfigBannerState
             @click=${() => this.handleAction('dir')}
           >
             ${waIcon('folder', { slot: 'start' })}
-            ${this.state.customDirSet ? 'Open directory' : 'Set directory'}
+            ${
+              this.state.customDirSet
+                ? 'Open agent directory'
+                : 'Set agent directory'
+            }
           </wa-button>
           <wa-button
             id="agentConfigDocButton"
@@ -62,7 +68,7 @@ export class AgentConfigBanner extends StateVisibleBanner<AgentConfigBannerState
             size="s"
             @click=${() => this.handleAction('docs')}
           >
-            ${waIcon('book', { slot: 'start' })} Open docs
+            ${waIcon('book', { slot: 'start' })} Read agent docs
           </wa-button>
         </div>
       `,

--- a/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
@@ -25,6 +25,7 @@ export class ApiKeyBanner extends StateVisibleBanner<ApiKeyBannerState> {
 
   override render(): TemplateResult {
     const provider = this.state.provider ?? '';
+    const providerLabel = capitalize(provider);
 
     return renderWarningBanner({
       id: 'apiKeyBanner',
@@ -33,7 +34,8 @@ export class ApiKeyBanner extends StateVisibleBanner<ApiKeyBannerState> {
         <span>
           ${
             provider
-              ? html`<strong>${capitalize(provider)}</strong> API key missing.`
+              ? html`<strong><bdi dir="auto">${providerLabel}</bdi></strong> API
+                  key is missing.`
               : 'TeXRA requires an API key to run.'
           }
         </span>
@@ -44,7 +46,12 @@ export class ApiKeyBanner extends StateVisibleBanner<ApiKeyBannerState> {
             size="s"
             @click=${() => this.handleAction('set')}
           >
-            ${waIcon('key', { slot: 'start' })} Set API key
+            ${waIcon('key', { slot: 'start' })}
+            ${
+              provider
+                ? html`Set <bdi dir="auto">${providerLabel}</bdi> API key`
+                : 'Set API key'
+            }
           </wa-button>
           <wa-button
             id="apiKeyGuideButton"
@@ -53,7 +60,11 @@ export class ApiKeyBanner extends StateVisibleBanner<ApiKeyBannerState> {
             @click=${() => this.handleAction('guide')}
           >
             ${waIcon('book', { slot: 'start' })}
-            ${provider ? 'Get a key' : 'Open key guide'}
+            ${
+              provider
+                ? html`Get <bdi dir="auto">${providerLabel}</bdi> API key`
+                : 'Open key guide'
+            }
           </wa-button>
         </div>
         <span class="hint">

--- a/packages/extension/src/webview/frontend/components/DependencyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/DependencyBanner.ts
@@ -29,6 +29,9 @@ export class DependencyBanner extends StateVisibleBanner<DependencyBannerState> 
         display: flex;
         flex-direction: column;
         gap: var(--wa-space-3xs);
+        margin: 0;
+        padding: 0;
+        list-style: none;
       }
     `,
   ];
@@ -65,35 +68,50 @@ export class DependencyBanner extends StateVisibleBanner<DependencyBannerState> 
     const tools = missing.flatMap((tool) =>
       tool === 'gm/magick' ? ['gm', 'magick'] : [tool],
     );
+    const imageToolMissing = missing.includes('gm/magick');
 
     return renderWarningBanner({
       id: 'dependencyBanner',
       role: 'status',
       body: html`
-        <div class="missing-tools">
-          ${when(
-            tools.length === 0,
-            () => html`Missing dependencies: none`,
-            () =>
-              repeat(
+        ${when(
+          tools.length === 0,
+          () => html`<span>No dependencies are missing.</span>`,
+          () => html`
+            <span>Missing dependencies:</span>
+            <ul class="missing-tools">
+              ${repeat(
                 tools,
                 (tool) => tool,
-                (tool) => html`
-                  <div class="dependency-item">
-                    <span>${this.getToolLabel(tool)}</span>
-                    <wa-button
-                      class="dependency-install-button"
-                      appearance="plain"
-                      size="s"
-                      @click=${() => this.handleInstall(tool)}
-                    >
-                      ${waIcon('cloud-arrow-down', { slot: 'start' })} Install
-                    </wa-button>
-                  </div>
-                `,
-              ),
-          )}
-        </div>
+                (tool) => {
+                  const label = this.getToolLabel(tool);
+
+                  return html`
+                    <li class="dependency-item">
+                      <span
+                        ><bdi dir="auto">${label}</bdi>${
+                          imageToolMissing &&
+                          (tool === 'gm' || tool === 'magick')
+                            ? ' (choose one)'
+                            : ''
+                        }</span
+                      >
+                      <wa-button
+                        class="dependency-install-button"
+                        appearance="plain"
+                        size="s"
+                        aria-label=${`Open ${label} install guide`}
+                        @click=${() => this.handleInstall(tool)}
+                      >
+                        ${waIcon('book', { slot: 'start' })} Install guide
+                      </wa-button>
+                    </li>
+                  `;
+                },
+              )}
+            </ul>
+          `,
+        )}
         <div class="actions">
           <wa-button
             id="dependencyRecheckButton"
@@ -101,13 +119,12 @@ export class DependencyBanner extends StateVisibleBanner<DependencyBannerState> 
             size="s"
             @click=${this.handleRecheck}
           >
-            ${waIcon('rotate-right', { slot: 'start' })} Re-check
+            ${waIcon('rotate-right', { slot: 'start' })} Check again
           </wa-button>
           <wa-button
             id="dependencyDismissButton"
             appearance="plain"
             size="s"
-            title="Dismiss (can be re-enabled in settings)"
             @click=${this.handleDismiss}
           >
             ${waIcon('xmark', { slot: 'start' })} Dismiss

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -267,7 +267,11 @@ export class FileSelectGroup extends LitElement {
     }
 
     const movable = this.currentFiles.length > 1;
-    return html`<div role="list" @click=${this.handleFileListClick}>
+    return html`<div
+      role="list"
+      aria-label=${`${this.config.label} files`}
+      @click=${this.handleFileListClick}
+    >
       ${repeat(
         this.currentFiles,
         (file) => file,
@@ -287,11 +291,12 @@ export class FileSelectGroup extends LitElement {
               title=${file}
             >
               <span class="file-name">
-                <span class="file-name-main">${display.name}</span>
+                <bdi class="file-name-main" dir="auto">${display.name}</bdi>
                 ${
                   display.folder
                     ? html`<span class="file-folder">
-                        ${waIcon('folder')} ${display.folder}
+                        ${waIcon('folder')}
+                        <bdi dir="auto">${display.folder}</bdi>
                       </span>`
                     : nothing
                 }
@@ -306,7 +311,7 @@ export class FileSelectGroup extends LitElement {
                         variant="neutral"
                         size="s"
                         type="button"
-                        aria-label=${`Move ${display.name} up`}
+                        aria-label=${`Move ${file} up`}
                         data-move-index=${index}
                         data-move-direction="-1"
                         ?disabled=${index === 0}
@@ -323,7 +328,7 @@ export class FileSelectGroup extends LitElement {
                         variant="neutral"
                         size="s"
                         type="button"
-                        aria-label=${`Move ${display.name} down`}
+                        aria-label=${`Move ${file} down`}
                         data-move-index=${index}
                         data-move-direction="1"
                         ?disabled=${index === this.currentFiles.length - 1}
@@ -343,7 +348,7 @@ export class FileSelectGroup extends LitElement {
                 variant="neutral"
                 size="s"
                 type="button"
-                aria-label=${`Remove ${display.name}`}
+                aria-label=${`Remove ${file}`}
                 data-remove-file=${file}
               >
                 ${waIcon('trash')}
@@ -371,6 +376,7 @@ export class FileSelectGroup extends LitElement {
   override render(): TemplateResult {
     const { config } = this;
     const typeLabel = capitalize(config.type);
+    const labelId = `${this.listId}Label`;
 
     return html`
       <div
@@ -378,6 +384,8 @@ export class FileSelectGroup extends LitElement {
           'file-select': true,
           'drop-active': this.fileDrop.isDragActive,
         })}
+        role="group"
+        aria-labelledby=${labelId}
         @dragenter=${this.fileDrop.handleDragEnter}
         @dragover=${this.fileDrop.handleDragOver}
         @dragleave=${this.fileDrop.handleDragLeave}
@@ -388,7 +396,7 @@ export class FileSelectGroup extends LitElement {
             <span class="file-select-icon" aria-hidden="true">
               ${waIcon(config.icon)}
             </span>
-            <span class="file-select-label">${config.label}</span>
+            <span id=${labelId} class="file-select-label">${config.label}</span>
             ${
               this.currentFiles.length > 1
                 ? html`<span class="file-select-count">
@@ -420,6 +428,7 @@ export class FileSelectGroup extends LitElement {
               icon: 'trash',
               label: config.emptyListLabel,
               tooltip: config.emptyListLabel,
+              disabled: this.currentFiles.length === 0,
               onClick: this.handleEmptyFiles,
             })}
             ${renderIconActionButton({

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -37,19 +37,12 @@ export class GettingStartedBanner extends LitElement {
       }
 
       .getting-started-title {
-        display: flex;
-        align-items: center;
-        flex-wrap: wrap;
-        gap: var(--wa-space-3xs);
+        margin: 0;
         line-height: var(--line-height-normal);
       }
 
       .getting-started-title strong {
         font-weight: var(--font-weight-semibold, 600);
-      }
-
-      .getting-started-title span {
-        color: var(--wa-color-text-quiet);
       }
 
       .getting-started-copy {
@@ -109,15 +102,18 @@ export class GettingStartedBanner extends LitElement {
       body: html`
         <div class="getting-started-row">
           <div class="getting-started-body">
-            <div class="getting-started-title">
+            <p class="getting-started-title">
               <strong>No LaTeX files yet</strong>
-              <span>Start from a sample or import an existing paper.</span>
-            </div>
-            <p class="getting-started-copy">
-              Then run setup to connect TeXRA, check LaTeX, and choose a starter
-              agent team.
             </p>
-            <div class="getting-started-actions actions">
+            <p class="getting-started-copy">
+              Create or import a project, then run setup to check LaTeX and
+              choose an agent team.
+            </p>
+            <div
+              class="getting-started-actions actions"
+              role="group"
+              aria-label="Getting started actions"
+            >
               ${this.renderAction('runSetup', 'filled', 'brand')}
               ${this.renderAction('createSampleProject', 'outlined')}
               ${this.renderAction('cloneOverleaf', 'outlined')}
@@ -130,7 +126,7 @@ export class GettingStartedBanner extends LitElement {
             appearance="plain"
             size="s"
             title="Dismiss for this session"
-            aria-label="Dismiss getting started row"
+            aria-label="Dismiss getting started for this session"
             @click=${this.handleDismiss}
           >
             ${waIcon('xmark')}

--- a/src/test-kernel/progressView/BackgroundTasksPanel.vitest.ts
+++ b/src/test-kernel/progressView/BackgroundTasksPanel.vitest.ts
@@ -120,7 +120,11 @@ describe('background-tasks-panel', () => {
     expect(names).toEqual(['reviewer', 'polisher']);
     for (const name of shadow.querySelectorAll<HTMLElement>('.task-name')) {
       expect(name.hasAttribute('title')).toBe(false);
-      expect(shadow.querySelector(`wa-tooltip[for="${name.id}"]`)).toBeTruthy();
+      const button = name.closest<HTMLButtonElement>('button');
+      expect(button).not.toBeNull();
+      expect(
+        shadow.querySelector(`wa-tooltip[for="${button?.id}"]`),
+      ).toBeTruthy();
     }
 
     const rows = [...shadow.querySelectorAll('.task-header')];

--- a/src/test-kernel/progressView/ExternalInquiryPanelTextarea.vitest.ts
+++ b/src/test-kernel/progressView/ExternalInquiryPanelTextarea.vitest.ts
@@ -119,7 +119,7 @@ describe('external-inquiry-panel answer/session-link inputs', () => {
       'wa-button[data-action="submit"]',
     ) as HTMLElement & { disabled?: boolean };
 
-    expect(submitButton.disabled).toBe(true);
+    expect(submitButton.disabled).toBe(false);
 
     setTextareaValue(answerInput, '  the answer  ');
     await element.updateComplete;

--- a/src/test-kernel/progressView/StreamHeader.vitest.ts
+++ b/src/test-kernel/progressView/StreamHeader.vitest.ts
@@ -233,7 +233,7 @@ describe('stream-header', () => {
     function badgeText(element: StreamHeader): string | undefined {
       return element.shadowRoot
         ?.querySelector(`#${ELEMENT_IDS.PROGRESS_BADGE}`)
-        ?.querySelector(':scope > span[aria-hidden="true"]')
+        ?.querySelector('span[aria-hidden="true"]')
         ?.textContent?.trim();
     }
 

--- a/src/test-kernel/progressView/StreamHeader.vitest.ts
+++ b/src/test-kernel/progressView/StreamHeader.vitest.ts
@@ -233,12 +233,19 @@ describe('stream-header', () => {
     function badgeText(element: StreamHeader): string | undefined {
       return element.shadowRoot
         ?.querySelector(`#${ELEMENT_IDS.PROGRESS_BADGE}`)
+        ?.querySelector(':scope > span[aria-hidden="true"]')
         ?.textContent?.trim();
     }
 
     function badgeTooltip(element: StreamHeader): string | undefined {
       return element.shadowRoot
         ?.querySelector(`wa-tooltip[for="${ELEMENT_IDS.PROGRESS_BADGE}"]`)
+        ?.textContent?.trim();
+    }
+
+    function badgeAccessibleText(element: StreamHeader): string | undefined {
+      return element.shadowRoot
+        ?.querySelector(`#${ELEMENT_IDS.PROGRESS_BADGE} .visually-hidden`)
         ?.textContent?.trim();
     }
 
@@ -281,6 +288,7 @@ describe('stream-header', () => {
       const element = await mount(props);
 
       expect(badgeText(element)).toBe(text);
+      expect(badgeAccessibleText(element)).toBe(tooltip);
       expect(badgeTooltip(element)).toBe(tooltip);
     });
   });

--- a/src/test-kernel/progressView/UserQuestionPanel.vitest.ts
+++ b/src/test-kernel/progressView/UserQuestionPanel.vitest.ts
@@ -81,7 +81,7 @@ describe('user-question-panel', () => {
     const element = await mountPanel();
     const actions = collectActions(element);
 
-    expect(submitButton(element).disabled).toBe(true);
+    expect(submitButton(element).disabled).toBe(false);
     expect(element.handleKeyboardShortcut('y')).toBe(true);
     expect(actions).toEqual([]);
   });

--- a/src/test-kernel/progressView/UserQuestionPanel.vitest.ts
+++ b/src/test-kernel/progressView/UserQuestionPanel.vitest.ts
@@ -172,6 +172,7 @@ describe('user-question-panel', () => {
     const radioGroup = element.shadowRoot?.querySelector(
       'wa-radio-group',
     ) as HTMLElement & { value?: string };
+    expect(radioGroup.getAttribute('label')).toBe('Choose one answer');
     radioGroup.value = 'No';
     dispatchChange(radioGroup);
     await element.updateComplete;

--- a/src/test-kernel/settings/AgentSelectionPanelToggle.vitest.ts
+++ b/src/test-kernel/settings/AgentSelectionPanelToggle.vitest.ts
@@ -77,6 +77,19 @@ describe('AgentSelectionPanel', () => {
     expect(toggle.checked).toBe(true);
   });
 
+  it('keeps selection and availability as separate accessible controls', async () => {
+    const panel = await renderAgentSelectionPanel();
+    const root = panel.shadowRoot!;
+    const row = root.querySelector('.agent-list-item');
+    const selectButton = root.querySelector('.agent-list-item-select');
+
+    expect(root.querySelector('[role="listbox"]')).toBeNull();
+    expect(row?.getAttribute('role')).toBe('listitem');
+    expect(selectButton?.tagName.toLowerCase()).toBe('button');
+    expect(selectButton?.getAttribute('aria-current')).toBe('true');
+    expect(selectButton?.contains(queryToggle(panel))).toBe(false);
+  });
+
   it('posts setAgentEnabled (not a click on the row) when the toggle is clicked', async () => {
     const panel = await renderAgentSelectionPanel();
 

--- a/src/test-kernel/settings/MultiAgentTab.vitest.ts
+++ b/src/test-kernel/settings/MultiAgentTab.vitest.ts
@@ -66,7 +66,7 @@ describe('multi-agent-tab preset card keyboard activation', () => {
     const cards = element.shadowRoot?.querySelectorAll('.preset-card') ?? [];
     expect(cards.length).toBe(AGENT_MODE_PRESETS.length);
     for (const card of cards) {
-      expect(card).toBeInstanceOf(HTMLButtonElement);
+      expect(card.tagName).toBe('BUTTON');
       expect(card.getAttribute('type')).toBe('button');
     }
   });
@@ -75,8 +75,8 @@ describe('multi-agent-tab preset card keyboard activation', () => {
     const element = await mount();
 
     const firstCard = element.shadowRoot?.querySelector('.preset-card');
-    expect(firstCard).toBeInstanceOf(HTMLButtonElement);
-    (firstCard as HTMLButtonElement).click();
+    expect(firstCard?.tagName).toBe('BUTTON');
+    (firstCard as HTMLElement).click();
 
     expect(appliedPresetIds()).toEqual([AGENT_MODE_PRESETS[0]!.id]);
   });

--- a/src/test-kernel/settings/MultiAgentTab.vitest.ts
+++ b/src/test-kernel/settings/MultiAgentTab.vitest.ts
@@ -17,7 +17,6 @@ import type { AgentModePreset } from '@shared/schemas';
 
 // Local file imports
 import {
-  dispatchKey,
   mountComponent,
   useLitComponentTestDom,
 } from './litComponentTestUtils';
@@ -39,10 +38,9 @@ const CUSTOM_PRESET: AgentModePreset = {
 
 /**
  * Regression coverage for the a11y-clickables audit: the team-preset card
- * was a plain `<div @click>` with no role/tabindex/keydown, so keyboard
- * users could never select a team even though `.preset-card:focus-visible`
- * already shipped an outline. Mirrors GoalTab.ts's `.goal-row` and
- * AgentSelectionPanel.ts's `.agent-list-item` keyboard-activation pattern.
+ * was a plain `<div @click>`, so keyboard users could never select a team.
+ * Keep the apply action on a native button so browser keyboard behavior does
+ * not depend on a hand-rolled key handler.
  */
 describe('multi-agent-tab preset card keyboard activation', () => {
   useLitComponentTestDom(
@@ -63,44 +61,40 @@ describe('multi-agent-tab preset card keyboard activation', () => {
       .map(([, payload]) => (payload as { presetId: string }).presetId);
   }
 
-  it('exposes role=button and tabindex=0 on every preset card', async () => {
+  it('renders every preset apply action as a native button', async () => {
     const element = await mount();
     const cards = element.shadowRoot?.querySelectorAll('.preset-card') ?? [];
     expect(cards.length).toBe(AGENT_MODE_PRESETS.length);
     for (const card of cards) {
-      expect(card.getAttribute('role')).toBe('button');
-      expect(card.getAttribute('tabindex')).toBe('0');
+      expect(card).toBeInstanceOf(HTMLButtonElement);
+      expect(card.getAttribute('type')).toBe('button');
     }
   });
 
-  it('applies the preset on Enter and Space, not on other keys', async () => {
+  it('applies the preset from its native button', async () => {
     const element = await mount();
 
     const firstCard = element.shadowRoot?.querySelector('.preset-card');
-    expect(firstCard).toBeInstanceOf(HTMLElement);
+    expect(firstCard).toBeInstanceOf(HTMLButtonElement);
+    (firstCard as HTMLButtonElement).click();
 
-    dispatchKey(firstCard!, 'a');
-    expect(appliedPresetIds()).toHaveLength(0);
-
-    dispatchKey(firstCard!, 'Enter');
-    dispatchKey(firstCard!, ' ');
-
-    expect(appliedPresetIds()).toEqual([
-      AGENT_MODE_PRESETS[0]!.id,
-      AGENT_MODE_PRESETS[0]!.id,
-    ]);
+    expect(appliedPresetIds()).toEqual([AGENT_MODE_PRESETS[0]!.id]);
   });
 
-  it('does not apply the preset when Enter/Space bubbles from the delete button', async () => {
+  it('keeps the delete action separate from the preset button', async () => {
     const element = await mount({ customPresets: [CUSTOM_PRESET] });
 
     const deleteButton =
       element.shadowRoot?.querySelector('.preset-delete-btn');
     expect(deleteButton).toBeInstanceOf(HTMLElement);
 
-    dispatchKey(deleteButton!, 'Enter');
+    (deleteButton as HTMLElement).click();
 
     expect(appliedPresetIds()).toHaveLength(0);
+    expect(mocks.postMessage).toHaveBeenCalledWith(
+      SETTINGS_VIEW_COMMANDS.DELETE_AGENT_MODE_PRESET,
+      { presetId: CUSTOM_PRESET.id },
+    );
   });
 
   /**
@@ -117,6 +111,7 @@ describe('multi-agent-tab preset card keyboard activation', () => {
     );
     expect(activeCards?.length).toBe(1);
     expect(activeCards?.[0]?.textContent).toContain(active.name);
+    expect(activeCards?.[0]?.getAttribute('aria-pressed')).toBe('true');
 
     const otherCard = element.shadowRoot?.querySelector('.preset-card');
     (otherCard as HTMLElement).click();

--- a/src/test-kernel/settings/SubscriptionUsageRendering.vitest.ts
+++ b/src/test-kernel/settings/SubscriptionUsageRendering.vitest.ts
@@ -125,8 +125,8 @@ describe('subscription usage rendering', () => {
     expect(styleText).toContain('min-width: 0');
     const text = kimiRow!.shadowRoot?.textContent ?? '';
     expect(text).toContain('Kimi Code plan usage');
-    expect(text.split('5-hour: 25%')).toHaveLength(2);
-    expect(text.split('7-day: 100%')).toHaveLength(2);
+    expect(text).toMatch(/5-hour\s*:\s*25%/);
+    expect(text).toMatch(/7-day\s*:\s*100%/);
     const meters = kimiRow!.shadowRoot?.querySelectorAll('progress');
     expect(meters).toHaveLength(2);
     expect(meters?.[0]?.getAttribute('aria-label')).toBe(

--- a/src/test-kernel/settings/SubscriptionUsageRendering.vitest.ts
+++ b/src/test-kernel/settings/SubscriptionUsageRendering.vitest.ts
@@ -130,7 +130,7 @@ describe('subscription usage rendering', () => {
     const meters = kimiRow!.shadowRoot?.querySelectorAll('progress');
     expect(meters).toHaveLength(2);
     expect(meters?.[0]?.getAttribute('aria-label')).toBe(
-      'Kimi Code 5-hour usage: 25% used',
+      'Kimi Code 5-hour usage',
     );
     expect(text).toContain('resets in 1d 21h');
     expect(tab.shadowRoot?.textContent).not.toContain('Grok usage unavailable');


### PR DESCRIPTION
## Summary

- improve progress-view requests, approvals, task status, logs, formatters, terminal output, and file actions with native semantics, accurate labels, bidi-safe content, and restrained responsive behavior
- simplify settings controls, lists, forms, agent/team selection, provider keys, model choices, usage meters, goals, shortcuts, and LaTeX validation
- clarify main-webview setup banners and file selection while preserving the existing component library, tokens, density, and motion language
- consolidate 75 independently reviewed interface areas into one substantial PR, including evidence-backed no-ops where added design or abstraction was not justified

## Restraint

- remove decorative source-color rails and redundant tooltips/copy instead of adding visual treatments
- no palette migration, new animation, decorative card system, speculative empty states, or new UI abstraction
- preserve current tokens and established component patterns
- integration review removed over-announcement, excess tab stops, an unused feedback attribute, and an unjustified global animation override

## Validation

- Prettier and targeted ESLint across changed surfaces
- branch-wide ESLint across the PR diff
- npm run typecheck:workspace on the final merged head
- 14 focused UI suites covering progress, settings, and webview behavior; 103 tests covered, with merge-conflict assertion failures corrected and the affected suites rerun green
- git diff --check against origin/main

Existing suites were extended only for consequential semantic contracts; no new test file was added by this campaign.