### PR TITLE
fix: bound long-lived memory retention

### DIFF
--- a/config/ratchets/store-public-surface-baseline.json
+++ b/config/ratchets/store-public-surface-baseline.json
@@ -29,7 +29,6 @@
     "StreamSnapshotStore": [
       "attachSessionEvents",
       "deleteStream",
-      "evictAll",
       "flush",
       "getCompileFailures",
       "getExecutionIdMap",

--- a/packages/cli/src/chat/tui/panes/transcriptViewport.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptViewport.ts
@@ -3,6 +3,7 @@
 import { createLog } from '@logger/logUtils';
 import type { TranscriptRow } from '@shared/transcript';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
+import { createBoundedIdSet } from '@utils/core/boundedIdSet';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
   transcriptEntryLayout,
@@ -11,10 +12,11 @@ import {
 import { isRenderableTranscriptEntry } from './transcriptEntries';
 
 const FAILED_ENTRY_ESTIMATE_ROWS = 1;
+const BROKEN_ENTRY_REPORT_CAP = 1000;
 const log = createLog('transcriptViewport');
 /** Entry ids already reported, so a persistently-throwing entry is logged once
  *  instead of once per stream-sync tick (the estimate path runs per frame). */
-const brokenEntryIdsReported = new Set<string>();
+const brokenEntryIdsReported = createBoundedIdSet(BROKEN_ENTRY_REPORT_CAP);
 
 // Live mode captures the pending-pane paint contract: assistant text uses its
 // capped raw tail, while rich tool rows keep one descriptor line per terminal

--- a/packages/desktop/src/renderer/fileRequests.ts
+++ b/packages/desktop/src/renderer/fileRequests.ts
@@ -4,8 +4,11 @@
 // same path — can't cross-resolve.
 
 import { postMessage } from '@shared/hostBridge';
+import { ensureError } from '@utils/errors/errorMessage';
 import { DESKTOP_WORKSPACE_COMMANDS } from '../shared/desktopWorkspaceMessages';
 import type { EditorFileEntry } from './editorTree';
+
+const FILE_REQUEST_TIMEOUT_MS = 60_000;
 
 type PendingFileRequest =
   | {
@@ -26,14 +29,47 @@ type PendingFileRequest =
       reject(error: Error): void;
     };
 
-const pendingFileRequests = new Map<string, PendingFileRequest>();
+interface PendingFileRequestEntry {
+  readonly request: PendingFileRequest;
+  readonly timeout: ReturnType<typeof setTimeout>;
+}
+
+const pendingFileRequests = new Map<string, PendingFileRequestEntry>();
+
+function registerFileRequest(
+  requestId: string,
+  request: PendingFileRequest,
+  send: () => void,
+): void {
+  const timeout = setTimeout(() => {
+    takePendingFileRequest(requestId)?.reject(
+      new Error('The desktop file request timed out.'),
+    );
+  }, FILE_REQUEST_TIMEOUT_MS);
+  pendingFileRequests.set(requestId, { request, timeout });
+  try {
+    send();
+  } catch (error) {
+    takePendingFileRequest(requestId)?.reject(ensureError(error));
+  }
+}
 
 export function takePendingFileRequest(
   requestId: string,
 ): PendingFileRequest | undefined {
   const pending = pendingFileRequests.get(requestId);
+  if (!pending) return undefined;
   pendingFileRequests.delete(requestId);
-  return pending;
+  clearTimeout(pending.timeout);
+  return pending.request;
+}
+
+/** Reject every request owned by the current renderer document. */
+export function disposePendingFileRequests(): void {
+  const error = new Error('The desktop renderer was disposed.');
+  for (const requestId of [...pendingFileRequests.keys()]) {
+    takePendingFileRequest(requestId)?.reject(error);
+  }
 }
 
 export function requestFiles(
@@ -41,7 +77,7 @@ export function requestFiles(
 ): Promise<readonly EditorFileEntry[]> {
   // A second list for a directory already in flight shares the promise rather
   // than posting a redundant LIST_FILES.
-  for (const request of pendingFileRequests.values()) {
+  for (const { request } of pendingFileRequests.values()) {
     if (request.kind === 'list' && request.directory === directory) {
       return request.promise;
     }
@@ -54,22 +90,30 @@ export function requestFiles(
     resolveList = resolve;
     rejectList = reject;
   });
-  pendingFileRequests.set(requestId, {
-    kind: 'list',
-    directory,
-    promise,
-    resolve: resolveList,
-    reject: rejectList,
-  });
-  postMessage(DESKTOP_WORKSPACE_COMMANDS.LIST_FILES, { requestId, directory });
+  registerFileRequest(
+    requestId,
+    {
+      kind: 'list',
+      directory,
+      promise,
+      resolve: resolveList,
+      reject: rejectList,
+    },
+    () =>
+      postMessage(DESKTOP_WORKSPACE_COMMANDS.LIST_FILES, {
+        requestId,
+        directory,
+      }),
+  );
   return promise;
 }
 
 export function requestFileRead(path: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const requestId = crypto.randomUUID();
-    pendingFileRequests.set(requestId, { kind: 'read', resolve, reject });
-    postMessage(DESKTOP_WORKSPACE_COMMANDS.READ_FILE, { requestId, path });
+    registerFileRequest(requestId, { kind: 'read', resolve, reject }, () =>
+      postMessage(DESKTOP_WORKSPACE_COMMANDS.READ_FILE, { requestId, path }),
+    );
   });
 }
 
@@ -79,15 +123,19 @@ export function requestFileWrite(
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const requestId = crypto.randomUUID();
-    pendingFileRequests.set(requestId, {
-      kind: 'write',
-      resolve: () => resolve(),
-      reject,
-    });
-    postMessage(DESKTOP_WORKSPACE_COMMANDS.WRITE_FILE, {
+    registerFileRequest(
       requestId,
-      path,
-      contents,
-    });
+      {
+        kind: 'write',
+        resolve: () => resolve(),
+        reject,
+      },
+      () =>
+        postMessage(DESKTOP_WORKSPACE_COMMANDS.WRITE_FILE, {
+          requestId,
+          path,
+          contents,
+        }),
+    );
   });
 }

--- a/packages/desktop/src/renderer/fileRequests.ts
+++ b/packages/desktop/src/renderer/fileRequests.ts
@@ -31,7 +31,7 @@ type PendingFileRequest =
 
 interface PendingFileRequestEntry {
   readonly request: PendingFileRequest;
-  readonly timeout: ReturnType<typeof setTimeout>;
+  readonly timeout?: ReturnType<typeof setTimeout>;
 }
 
 const pendingFileRequests = new Map<string, PendingFileRequestEntry>();
@@ -41,11 +41,16 @@ function registerFileRequest(
   request: PendingFileRequest,
   send: () => void,
 ): void {
-  const timeout = setTimeout(() => {
-    takePendingFileRequest(requestId)?.reject(
-      new Error('The desktop file request timed out.'),
-    );
-  }, FILE_REQUEST_TIMEOUT_MS);
+  // The main process cannot cancel an in-flight write. Keep waiting for its
+  // response so a retry cannot race and later be overwritten by that write.
+  const timeout =
+    request.kind === 'write'
+      ? undefined
+      : setTimeout(() => {
+          takePendingFileRequest(requestId)?.reject(
+            new Error('The desktop file request timed out.'),
+          );
+        }, FILE_REQUEST_TIMEOUT_MS);
   pendingFileRequests.set(requestId, { request, timeout });
   try {
     send();

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -135,6 +135,7 @@ import { createReviewPane } from './reviewPane';
 import { createDesktopPromptOverlay } from './promptOverlay';
 import { createLogsPane } from './logsPane';
 import {
+  disposePendingFileRequests,
   requestFileRead,
   requestFileWrite,
   requestFiles,
@@ -1580,6 +1581,7 @@ window.addEventListener(
   () => {
     surfaceResizeObserver?.disconnect();
     shortcutBootstrap.dispose();
+    disposePendingFileRequests();
     editorPane.dispose();
     terminalPane.disposeAll();
   },

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -117,7 +117,7 @@ describe('SessionStores deletion coordination', () => {
       const snapshots = new StreamSnapshotStore();
       ownExecution(snapshots, stream, sidecarExecutionId);
       await snapshots.flush();
-      snapshots.evictAll();
+      const reloadedSnapshots = new StreamSnapshotStore();
       // The authored edge: registration stamps `meta.streamId` on the
       // execution row; the stream index resolves through it, never through
       // the summary mirror.
@@ -130,7 +130,7 @@ describe('SessionStores deletion coordination', () => {
       const deleteExecution = deletionSpy();
       const stores = new SessionStores({
         streamLogs: session.transcripts,
-        snapshots,
+        snapshots: reloadedSnapshots,
         deleteExecution,
       });
 

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -498,7 +498,6 @@ function withRunFacts(
   } finally {
     boundFactSession = undefined;
     detach();
-    snapshots.evictAll();
   }
 }
 
@@ -3376,7 +3375,6 @@ describe('sessionSignalsAdapter run facts', () => {
       expect(activeStreamId.get()).toBeUndefined();
     } finally {
       detach();
-      snapshots.evictAll();
     }
   });
 
@@ -3429,7 +3427,7 @@ describe('sessionSignalsAdapter run facts', () => {
     });
   });
 
-  it('invalidates a hydrated artifact memo on a live work-plan fact', () => {
+  it('invalidates a hydrated artifact memo on a live work-plan fact', async () => {
     const streamId = 'hydrated-artifact-memo' as StreamTabId;
     const previousTodos: TodoItem[] = [
       {
@@ -3475,7 +3473,7 @@ describe('sessionSignalsAdapter run facts', () => {
       expect(readStreamArtifacts(streamId)?.todos).toEqual(nextTodos);
     } finally {
       detach();
-      session.snapshots.evictAll();
+      await session.snapshots.load([]);
     }
   });
 

--- a/src/test-kernel/desktop/DesktopFileRequests.vitest.ts
+++ b/src/test-kernel/desktop/DesktopFileRequests.vitest.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { DESKTOP_WORKSPACE_COMMANDS } from '@desktop/shared/desktopWorkspaceMessages';
+
+const mocks = vi.hoisted(() => ({ postMessage: vi.fn() }));
+
+vi.mock('@shared/hostBridge', () => ({ postMessage: mocks.postMessage }));
+
+import {
+  disposePendingFileRequests,
+  requestFileRead,
+  requestFiles,
+} from '@desktop/renderer/fileRequests';
+
+describe('desktop file requests', () => {
+  afterEach(() => {
+    disposePendingFileRequests();
+    mocks.postMessage.mockReset();
+  });
+
+  it('rejects every pending request when its renderer is disposed', async () => {
+    const read = requestFileRead('main.tex');
+    const list = requestFiles('.');
+
+    disposePendingFileRequests();
+
+    await expect(read).rejects.toThrow('desktop renderer was disposed');
+    await expect(list).rejects.toThrow('desktop renderer was disposed');
+    expect(mocks.postMessage).toHaveBeenCalledWith(
+      DESKTOP_WORKSPACE_COMMANDS.READ_FILE,
+      expect.objectContaining({ path: 'main.tex' }),
+    );
+  });
+});

--- a/src/test-kernel/desktop/DesktopFileRequests.vitest.ts
+++ b/src/test-kernel/desktop/DesktopFileRequests.vitest.ts
@@ -9,7 +9,9 @@ vi.mock('@shared/hostBridge', () => ({ postMessage: mocks.postMessage }));
 import {
   disposePendingFileRequests,
   requestFileRead,
+  requestFileWrite,
   requestFiles,
+  takePendingFileRequest,
 } from '@desktop/renderer/fileRequests';
 
 describe('desktop file requests', () => {
@@ -30,5 +32,42 @@ describe('desktop file requests', () => {
       DESKTOP_WORKSPACE_COMMANDS.READ_FILE,
       expect.objectContaining({ path: 'main.tex' }),
     );
+  });
+
+  it('times out reads after 60 seconds and ignores a late response', async () => {
+    vi.useFakeTimers();
+    try {
+      const read = requestFileRead('main.tex');
+      const request = mocks.postMessage.mock.calls[0]?.[1] as
+        { requestId: string } | undefined;
+      if (!request) throw new Error('Expected a desktop file request');
+      const rejection = expect(read).rejects.toThrow(
+        'desktop file request timed out',
+      );
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      await rejection;
+      expect(takePendingFileRequest(request.requestId)).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps waiting for writes that may still complete in the main process', async () => {
+    vi.useFakeTimers();
+    try {
+      const write = requestFileWrite('main.tex', 'revised');
+      const settled = vi.fn();
+      void write.then(settled, settled);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(settled).not.toHaveBeenCalled();
+      disposePendingFileRequests();
+      await expect(write).rejects.toThrow('desktop renderer was disposed');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/test-kernel/transcript/StagedDeletionCoordinator.vitest.ts
+++ b/src/test-kernel/transcript/StagedDeletionCoordinator.vitest.ts
@@ -63,8 +63,8 @@ function createFakeHost(): FakeHost {
       calls.push('cancelPendingWrites');
       return [];
     },
-    bumpStreamVersion: () => {
-      calls.push('bumpStreamVersion');
+    invalidateStreamGeneration: () => {
+      calls.push('invalidateStreamGeneration');
     },
     seedChain: () => undefined,
     evict: () => {
@@ -109,7 +109,10 @@ describe('StagedDeletionCoordinator', () => {
 
     // Both must happen before the rename: a write queued against the
     // pre-staging directory would otherwise recreate it behind the move.
-    expect(calls).toStrictEqual(['cancelPendingWrites', 'bumpStreamVersion']);
+    expect(calls).toStrictEqual([
+      'cancelPendingWrites',
+      'invalidateStreamGeneration',
+    ]);
     expect(await StorageFS.exists(streamDataDir(STREAM))).toBe(false);
     expect(await StorageFS.exists(stagedStreamDataDir(STREAM))).toBe(true);
   });

--- a/src/test-kernel/transcript/StagedDeletionCoordinator.vitest.ts
+++ b/src/test-kernel/transcript/StagedDeletionCoordinator.vitest.ts
@@ -196,20 +196,6 @@ describe('StagedDeletionCoordinator', () => {
     });
   });
 
-  it('reset drops in-memory ownership while on-disk staging residue still blocks a new deletion', async () => {
-    const { coordinator } = setupCoordinator();
-    await writeLivePlan();
-    await coordinator.stage(STREAM);
-
-    coordinator.reset();
-
-    expect(coordinator.bufferWrite(STREAM, PLAN_KEY, {})).toBe(false);
-    // Disk, not memory, is authoritative for an unreconciled deletion.
-    await expect(coordinator.stage(STREAM)).rejects.toThrow(
-      /unreconciled snapshot deletion/,
-    );
-  });
-
   it('reconcile restores a crash-left staged directory', async () => {
     const { coordinator } = setupCoordinator();
     const stagedDir = stagedStreamDataDir(STREAM);

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -2313,8 +2313,7 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('reports and retains authoritative work-plan state after preload fails', async () => {
-    const previous = await storeWithPersistedPlan();
-    previous.evictAll();
+    await storeWithPersistedPlan();
     const readError = new Error('snapshot disk is unreadable');
     const read = StorageFS.read.bind(StorageFS);
     const readStarted = pDefer<void>();

--- a/src/transcript/ResidentStreamRegistry.ts
+++ b/src/transcript/ResidentStreamRegistry.ts
@@ -15,8 +15,7 @@
  * persist until an explicit `evict`) simply never calls {@link pruneIfEmpty},
  * and a store with no per-key generation guard (`StreamLogStore`, which
  * tracks a single store-wide revision instead) never calls
- * {@link generation}/{@link invalidateGeneration}/{@link evict}/
- * {@link evictAll}. The
+ * {@link generation}/{@link invalidateGeneration}/{@link evict}. The
  * two stores' own persistence-strategy code (per-(key,category) write
  * mutexes vs debounce+generation) is NOT part of this container and stays
  * on each store.
@@ -93,10 +92,5 @@ export class ResidentStreamRegistry<TId, TState> {
   evict(id: TId): void {
     this.invalidateGeneration(id);
     this.records.delete(id);
-  }
-
-  evictAll(): void {
-    this.generations.clear();
-    this.records.clear();
   }
 }

--- a/src/transcript/ResidentStreamRegistry.ts
+++ b/src/transcript/ResidentStreamRegistry.ts
@@ -13,9 +13,10 @@
  * Every capability here is opt-in per consumer: a store with no "prune once
  * every field is empty" concept (`StreamSnapshotStore`, whose records
  * persist until an explicit `evict`) simply never calls {@link pruneIfEmpty},
- * and a store with no per-key version counter (`StreamLogStore`, which
+ * and a store with no per-key generation guard (`StreamLogStore`, which
  * tracks a single store-wide revision instead) never calls
- * {@link version}/{@link bumpVersion}/{@link evict}/{@link evictAll}. The
+ * {@link generation}/{@link invalidateGeneration}/{@link evict}/
+ * {@link evictAll}. The
  * two stores' own persistence-strategy code (per-(key,category) write
  * mutexes vs debounce+generation) is NOT part of this container and stays
  * on each store.
@@ -23,12 +24,12 @@
 export class ResidentStreamRegistry<TId, TState> {
   private readonly records = new Map<TId, TState>();
   /**
-   * Per-key version counters. Deliberately never deleted — not even by
-   * {@link evict}/{@link evictAll} — so a version captured before a key's
-   * record is dropped still lets an in-flight async operation detect that it
-   * raced against a later change for the same key.
+   * Revocable per-key identities captured by asynchronous work. Eviction
+   * deletes the current token; a later use of the same key receives a fresh
+   * symbol, so stale continuations remain detectable without retaining every
+   * key ever observed.
    */
-  private readonly versions = new Map<TId, number>();
+  private readonly generations = new Map<TId, symbol>();
 
   constructor(private readonly createDefault: () => TState) {}
 
@@ -71,22 +72,31 @@ export class ResidentStreamRegistry<TId, TState> {
     if (record && isEmpty(record)) this.records.delete(id);
   }
 
-  version(id: TId): number {
-    return this.versions.get(id) ?? 0;
+  generation(id: TId): symbol {
+    let generation = this.generations.get(id);
+    if (generation === undefined) {
+      generation = Symbol();
+      this.generations.set(id, generation);
+    }
+    return generation;
   }
 
-  bumpVersion(id: TId): void {
-    this.versions.set(id, this.version(id) + 1);
+  isCurrentGeneration(id: TId, generation: symbol): boolean {
+    return this.generations.get(id) === generation;
   }
 
-  /** Bump a key's version, then drop its record — the two always happen together. */
+  invalidateGeneration(id: TId): void {
+    this.generations.delete(id);
+  }
+
+  /** Revoke a key's generation, then drop its record. */
   evict(id: TId): void {
-    this.bumpVersion(id);
+    this.invalidateGeneration(id);
     this.records.delete(id);
   }
 
   evictAll(): void {
-    for (const id of this.records.keys()) this.bumpVersion(id);
+    this.generations.clear();
     this.records.clear();
   }
 }

--- a/src/transcript/StagedDeletionCoordinator.ts
+++ b/src/transcript/StagedDeletionCoordinator.ts
@@ -186,14 +186,6 @@ export class StagedDeletionCoordinator {
     }
   }
 
-  /** Drop every deletion state, settling anyone awaiting a staged transaction. */
-  reset(): void {
-    for (const state of this.deletionStates.values()) {
-      if (state.kind === 'staging') state.resolveSettled();
-    }
-    this.deletionStates.clear();
-  }
-
   /**
    * Repair every stream left in a failed rollback, returning the failures so
    * the store's `flush()` can report them alongside its own.

--- a/src/transcript/StagedDeletionCoordinator.ts
+++ b/src/transcript/StagedDeletionCoordinator.ts
@@ -77,7 +77,7 @@ export interface StagedStreamSnapshotDeletion {
 /**
  * The narrow port back into the snapshot store. Every member is a capability
  * the staged-deletion machine cannot own itself: durable writes, the store's
- * per-(stream, category) write locks, its stream-version guard, its seeding
+ * per-(stream, category) write locks, its stream-generation guard, its seeding
  * chain, and its in-memory record.
  */
 export interface StagedDeletionHost {
@@ -90,7 +90,7 @@ export interface StagedDeletionHost {
    */
   cancelPendingWrites(stream: StreamTabId): Promise<void>[];
   /** Invalidate writes queued against the pre-staging directory. */
-  bumpStreamVersion(stream: StreamTabId): void;
+  invalidateStreamGeneration(stream: StreamTabId): void;
   /** The stream's in-flight seed/refresh chain, if one is running. */
   seedChain(stream: StreamTabId): Promise<void> | undefined;
   /** Drop the stream's in-memory record once a deletion commits. */
@@ -479,7 +479,7 @@ export class StagedDeletionCoordinator {
       if (writesCancelled) return;
       writesCancelled = true;
       const pending = this.host.cancelPendingWrites(stream);
-      this.host.bumpStreamVersion(stream);
+      this.host.invalidateStreamGeneration(stream);
       await Promise.all(pending);
     };
     const waitForSeedChain = async (ignoreFailure = false): Promise<void> => {
@@ -606,7 +606,7 @@ export class StagedDeletionCoordinator {
       const failures: unknown[] = [error];
       // An initial namespace inspection can fail before the normal seed wait.
       // Let any active refresh restore or replace authoritative memory before
-      // the version bump invalidates its continuation.
+      // revoking the generation invalidates its continuation.
       await waitForSeedChain(true);
       await cancelWrites();
       const failedRollback = this.markRollbackFailed(stream, state);

--- a/src/transcript/StagedDeletionCoordinator.ts
+++ b/src/transcript/StagedDeletionCoordinator.ts
@@ -20,7 +20,7 @@
  *   `flush()`.
  *
  * It reaches the snapshot store only through {@link StagedDeletionHost} — the
- * store keeps ownership of records, write mutexes, and stream versions, and
+ * store keeps ownership of records, write mutexes, and stream generations, and
  * this coordinator never inspects them.
  */
 

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -1472,6 +1472,7 @@ export class StreamLogStore {
     this.dirtyIds.delete(streamId);
     this.releaseRequests.delete(streamId);
     this.summaries.delete(streamId);
+    this.writeFailureWarned.delete(streamId);
   }
 
   private forgetAllStreamState(): void {
@@ -1482,6 +1483,7 @@ export class StreamLogStore {
     this.dirtyIds.clear();
     this.releaseRequests.clear();
     this.summaries.clear();
+    this.writeFailureWarned.clear();
   }
 
   private assertWritableStore(operation: string): void {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -484,7 +484,7 @@ export class StreamSnapshotStore {
    * The crash-safe staged-deletion + rollback-recovery machine. It owns which
    * namespace holds a staged stream's data and the sidecar writes buffered
    * behind that rename; this store keeps the records, write mutexes, and
-   * stream versions it reaches back for through {@link StagedDeletionHost}.
+   * stream generations it reaches back for through {@link StagedDeletionHost}.
    */
   private readonly deletions = new StagedDeletionCoordinator({
     queueWrite: (stream, key, value) => this.queueWrite(stream, key, value),

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -379,9 +379,10 @@ function workPlanProvenanceOf(
  * `records.delete(stream)` — every field disappears with it BY CONSTRUCTION,
  * so `evict()`/`evictAll()` cannot drift from the field list.
  *
- * Per-stream version counters (must survive eviction to keep guarding
- * in-flight seed races) live inside the shared {@link ResidentStreamRegistry}
- * container that backs `records`, not on the record itself. `writeMutexes`
+ * Revocable per-stream generation identities guard in-flight seed races and
+ * disappear on eviction rather than retaining historical stream ids. They
+ * live inside the shared {@link ResidentStreamRegistry} container that backs
+ * `records`, not on the record itself. `writeMutexes`
  * (keyed by the compound `${stream}::${key}`, not a bare stream id) stays as
  * its own map on the store — the same exclusion #7892 already carved out of
  * `perStreamStores()`.
@@ -488,7 +489,8 @@ export class StreamSnapshotStore {
   private readonly deletions = new StagedDeletionCoordinator({
     queueWrite: (stream, key, value) => this.queueWrite(stream, key, value),
     cancelPendingWrites: (stream) => this.cancelPendingWritesForStream(stream),
-    bumpStreamVersion: (stream) => this.records.bumpVersion(stream),
+    invalidateStreamGeneration: (stream) =>
+      this.records.invalidateGeneration(stream),
     seedChain: (stream) => this.records.get(stream)?.seedChain,
     evict: (stream) => this.evict(stream),
   } satisfies StagedDeletionHost);
@@ -615,8 +617,15 @@ export class StreamSnapshotStore {
     }
   }
 
-  private streamVersion(stream: StreamTabId): number {
-    return this.records.version(stream);
+  private streamGeneration(stream: StreamTabId): symbol {
+    return this.records.generation(stream);
+  }
+
+  private isCurrentGeneration(
+    stream: StreamTabId,
+    generation: symbol,
+  ): boolean {
+    return this.records.isCurrentGeneration(stream, generation);
   }
 
   /**
@@ -762,19 +771,19 @@ export class StreamSnapshotStore {
    */
   private queueAfterSeed(
     stream: StreamTabId,
-    version: number,
+    generation: symbol,
     apply: () => unknown,
   ): Promise<void> {
     const next: Promise<void> = this.seedQueueFor(stream)
       .add(async () => {
         if (!this.hasDiskProvenance(stream)) {
           try {
-            await this.readSeed(stream, version);
+            await this.readSeed(stream, generation);
           } catch (err: unknown) {
             if (!this.hasDiskProvenance(stream)) throw err;
           }
         }
-        if (this.streamVersion(stream) !== version) return;
+        if (!this.isCurrentGeneration(stream, generation)) return;
         const record = this.records.get(stream);
         if (!record || record.diskState === 'unknown') return;
         apply();
@@ -788,12 +797,15 @@ export class StreamSnapshotStore {
     return next;
   }
 
-  private async readSeed(stream: StreamTabId, version: number): Promise<void> {
-    if (this.streamVersion(stream) !== version) return;
+  private async readSeed(
+    stream: StreamTabId,
+    generation: symbol,
+  ): Promise<void> {
+    if (!this.isCurrentGeneration(stream, generation)) return;
     if (this.hasDiskProvenance(stream)) return;
     await this.retryDirtyWrites(stream);
-    if (this.streamVersion(stream) !== version) return;
-    await this.seedFromDisk(stream, version);
+    if (!this.isCurrentGeneration(stream, generation)) return;
+    await this.seedFromDisk(stream, generation);
   }
 
   /**
@@ -806,7 +818,7 @@ export class StreamSnapshotStore {
    */
   private async seedFromDisk(
     stream: StreamTabId,
-    version: number,
+    generation: symbol,
   ): Promise<void> {
     let exists: boolean;
     try {
@@ -821,11 +833,11 @@ export class StreamSnapshotStore {
       );
       exists = true;
     }
-    if (this.streamVersion(stream) !== version) return;
+    if (!this.isCurrentGeneration(stream, generation)) return;
     const data = exists
       ? await readStreamData(this.kv(stream))
       : emptyStreamData();
-    if (this.streamVersion(stream) !== version) return;
+    if (!this.isCurrentGeneration(stream, generation)) return;
     await this.applyStreamData(
       stream,
       data,
@@ -937,12 +949,12 @@ export class StreamSnapshotStore {
       return;
     }
 
-    const version = this.streamVersion(stream);
+    const generation = this.streamGeneration(stream);
     if (overlayPatch !== undefined) {
       const { overlays } = this.getOrCreateRecord(stream);
       overlays[overlayKey] = mergePatch(overlays[overlayKey], overlayPatch);
     }
-    this.queueAfterSeed(stream, version, () => undefined);
+    this.queueAfterSeed(stream, generation, () => undefined);
   }
 
   /**
@@ -1295,7 +1307,7 @@ export class StreamSnapshotStore {
       applyMeta();
       this.getOrCreateRecord(stream).metaOverlay = false;
     } else {
-      this.queueAfterSeed(stream, this.streamVersion(stream), applyMeta);
+      this.queueAfterSeed(stream, this.streamGeneration(stream), applyMeta);
     }
   }
 
@@ -1585,7 +1597,7 @@ export class StreamSnapshotStore {
     value: unknown,
   ): Promise<void> {
     const chainKey = `${stream}::${key}`;
-    const version = this.streamVersion(stream);
+    const generation = this.streamGeneration(stream);
     const mutex = this.writeMutexes.get(chainKey) ?? new Mutex();
     this.writeMutexes.set(chainKey, mutex);
     return mutex.runExclusive(() => {
@@ -1593,7 +1605,7 @@ export class StreamSnapshotStore {
       // write queued before that must NOT fire afterward, or a late `kv()`
       // would re-create the `streamData/{id}/` dir `deleteDir()` just removed.
       if (!this.writeMutexes.has(chainKey)) return;
-      if (this.streamVersion(stream) !== version) return;
+      if (!this.isCurrentGeneration(stream, generation)) return;
       return this.kv(stream).write(key, value);
     });
   }
@@ -1825,7 +1837,7 @@ export class StreamSnapshotStore {
     stream: StreamTabId,
     reportArtifactAuthority = false,
   ): Promise<void> {
-    const version = this.streamVersion(stream);
+    const generation = this.streamGeneration(stream);
     const record = this.getOrCreateRecord(stream);
     const refreshBaseline = record.seedRefreshBaseline ?? record.diskState;
     record.seedRefreshBaseline = refreshBaseline;
@@ -1833,24 +1845,27 @@ export class StreamSnapshotStore {
     record.diskState = 'unknown';
     const next: Promise<void> = this.seedQueueFor(stream)
       .add(async () => {
-        if (this.streamVersion(stream) !== version) return;
+        if (!this.isCurrentGeneration(stream, generation)) return;
         await this.retryDirtyWrites(stream);
-        if (this.streamVersion(stream) !== version) return;
-        await this.seedFromDisk(stream, version);
+        if (!this.isCurrentGeneration(stream, generation)) return;
+        await this.seedFromDisk(stream, generation);
       })
       .then(
         () => {
           const current = this.records.get(stream);
           if (
             current?.seedRefreshGeneration === refreshGeneration &&
-            this.streamVersion(stream) === version
+            this.isCurrentGeneration(stream, generation)
           ) {
             current.seedRefreshBaseline = undefined;
           }
         },
         (error: unknown) => {
           const current = this.records.get(stream);
-          const versionIsCurrent = this.streamVersion(stream) === version;
+          const generationIsCurrent = this.isCurrentGeneration(
+            stream,
+            generation,
+          );
           // Snapshot the surviving state BEFORE the restore below, whose
           // `persistEagerOverlays` drains the very overlays it reads.
           const resolvedRefreshBaseline =
@@ -1858,7 +1873,7 @@ export class StreamSnapshotStore {
               ? current?.diskState
               : refreshBaseline;
           const failureBaseline: DiskState | undefined =
-            reportArtifactAuthority && current && versionIsCurrent
+            reportArtifactAuthority && current && generationIsCurrent
               ? resolvedRefreshBaseline
               : undefined;
           const failureWorkPlanProvenance =
@@ -1867,7 +1882,7 @@ export class StreamSnapshotStore {
               : undefined;
           if (
             current?.seedRefreshGeneration === refreshGeneration &&
-            versionIsCurrent
+            generationIsCurrent
           ) {
             current.diskState = refreshBaseline;
             current.seedRefreshBaseline = undefined;
@@ -1947,7 +1962,7 @@ export class StreamSnapshotStore {
     data: StreamData,
     provenance: Exclude<DiskState, 'unknown'>,
   ): Promise<void> {
-    const version = this.streamVersion(stream);
+    const generation = this.streamGeneration(stream);
     const record = this.getOrCreateRecord(stream);
     const metaOverlay = record.metaOverlay ? record.meta : undefined;
     const usageOverlayToReplay = new Map(record.overlays.usage);
@@ -2015,7 +2030,7 @@ export class StreamSnapshotStore {
       } else {
         record.summaryMetaHydrationFallback = undefined;
       }
-      if (this.streamVersion(stream) !== version) return;
+      if (!this.isCurrentGeneration(stream, generation)) return;
       // Re-checked after the await: a `run.start` for another execution can
       // land during it, and this seed's pair belongs to the run it read.
       const liveExecutionId = record.runExecutionId;

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -377,7 +377,7 @@ function workPlanProvenanceOf(
  * bookkeeping, and the overlay patches. Because every field
  * for a stream lives on the same object, dropping a stream's memory is one
  * `records.delete(stream)` — every field disappears with it BY CONSTRUCTION,
- * so `evict()`/`evictAll()` cannot drift from the field list.
+ * so `evict()` cannot drift from the field list.
  *
  * Revocable per-stream generation identities guard in-flight seed races and
  * disappear on eviction rather than retaining historical stream ids. They
@@ -1128,15 +1128,6 @@ export class StreamSnapshotStore {
     for (const key of [...this.unseededReadWarned]) {
       if (key.startsWith(`${stream}::`)) this.unseededReadWarned.delete(key);
     }
-  }
-
-  evictAll(): void {
-    this.records.evictAll();
-    this.seedQueues.clear();
-    this.writeMutexes.clear();
-    this.dirtyWrites.clear();
-    this.unseededReadWarned.clear();
-    this.deletions.reset();
   }
 
   /**


### PR DESCRIPTION
## Summary

- replace permanently retained snapshot version counters with revocable generation tokens while preserving stale async-work rejection
- time out and dispose pending desktop file reads/listings, keep uncancellable writes authoritative, and make late responses no-ops
- clear write-failure diagnostics at stream lifecycle boundaries and bound CLI broken-entry diagnostics
- remove whole-store reset APIs that existed only for tests; tests now use fresh stores or the public reload boundary

## Issue acceptance gates

- Snapshot generation tokens are revoked on eviction and recreated with fresh identity, so stale continuations remain rejected without retaining historical stream IDs.
- Desktop reads/listings time out after 60 seconds; unload disposal rejects all pending requests; late responses are ignored. Writes remain pending because the main process cannot cancel them safely.
- `writeFailureWarned` is cleared on per-stream and whole-store cleanup, and broken transcript-entry diagnostics use a 1,000-ID LRU bound.
- Test-only `StreamSnapshotStore.evictAll`, registry-wide eviction, and staged-deletion reset surfaces are removed.
- Pending snapshot writes and desktop writes remain authoritative.

## Single source of truth

`ResidentStreamRegistry` owns revocable per-stream generation identity. `fileRequests.ts` owns renderer-document request registration, timeout, settlement, and disposal.

## Duplication and abstraction budget

The shared desktop request registration path replaces three duplicated map/send sequences and owns the timeout/disposal invariant. No pass-through layer was added. Test-only whole-store reset surfaces were deleted.

## Net elements (R6)

- Files: 1 added, 12 modified
- Exported symbols: +1 (`disposePendingFileRequests`), removed public method surface: `StreamSnapshotStore.evictAll`
- Classes/interfaces/enums: +1 internal interface (`PendingFileRequestEntry`); no new classes or enums
- LoC: +241 / -122, net +119

## Consumer counts (R8)

- `disposePendingFileRequests`: 1 production consumer (`packages/desktop/src/renderer/main.ts` unload lifecycle), plus its regression suite
- removed `StreamSnapshotStore.evictAll`: 0 production consumers; all test callers replaced
- removed staged-deletion reset and registry-wide eviction: 0 remaining consumers

## Host impact

Extension: Snapshot lifecycle and transcript write-diagnostic cleanup apply through shared storage; no extension-specific wiring changes.

Desktop: Pending reads/listings have a 60-second backstop, all request kinds reject on renderer unload, late responses do nothing, and uncancellable writes do not time out.

CLI: Broken transcript-entry diagnostic IDs are LRU-bounded at 1,000; tests no longer use whole-store reset hooks.

## Scheduled refactoring

None.

## Validation

- Focused transcript/desktop/CLI/storage tests: 393 passed
- Full Vitest suite: 823 files passed, 1 skipped; 9,987 tests passed, 6 skipped
- Architecture suites: 15 files / 101 tests passed
- `corepack pnpm run typecheck`
- `corepack pnpm run format:check`
- `corepack pnpm run lint`
- `corepack pnpm run compile:fast`
- `corepack pnpm run check:dead-code-ratchet`
- `corepack pnpm run check:guidance-refs`
- `corepack pnpm run check:browser-safe-utils`
- Raw `check:dead-code` still exits 1 on the same 6 baselined unused exports; the ratchet reports 295 combined findings versus 295 baselined and no new findings.
