### PR TITLE
refactor(delegation): flatten in-band execution setup

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1760,18 +1760,6 @@
       "name": "runStreamedTurn"
     },
     {
-      "file": "src/tools/delegation/inBandSubagentExecution.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "SubagentReconciliationError"
-    },
-    {
-      "file": "src/tools/delegation/inBandSubagentExecution.ts",
-      "category": "production-dead",
-      "kind": "types",
-      "name": "InBandSubagentExecutionOptions"
-    },
-    {
       "file": "src/tools/delegation/subagentResults.ts",
       "category": "production-dead",
       "kind": "exports",

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -9,10 +9,7 @@ import {
   createWorkflowScriptAgentRunner,
   fingerprintWorkflowAgentDependencies,
 } from '@tools/delegation/workflowScriptAgentRunner';
-import {
-  SubagentDurabilityError,
-  SubagentReconciliationError,
-} from '@tools/delegation/inBandSubagentExecution';
+import { SubagentDurabilityError } from '@tools/delegation/inBandSubagentExecution';
 
 const mocks = vi.hoisted(() => ({
   executeStableSubagentInBand: vi.fn(),
@@ -40,16 +37,9 @@ vi.mock('@tools/delegation/inBandSubagentExecution', () => {
       this.name = 'SubagentDurabilityError';
     }
   }
-  class SubagentReconciliationError extends SubagentDurabilityError {
-    constructor(message: string) {
-      super(message);
-      this.name = 'SubagentReconciliationError';
-    }
-  }
   return {
     executeStableSubagentInBand: mocks.executeStableSubagentInBand,
     SubagentDurabilityError,
-    SubagentReconciliationError,
   };
 });
 
@@ -325,9 +315,7 @@ describe('createWorkflowScriptAgentRunner', () => {
     expect(mocks.preparedOptions[0]).toEqual(
       expect.objectContaining({
         agentName: 'correct',
-        parentExecutionId: runExecutionId,
         parentStreamId: runStreamId,
-        signal: call.signal,
         approvalPromptsUnavailable: true,
         runtimeUnavailableTools: ['user_question'],
         configPayload: expect.objectContaining({
@@ -783,18 +771,6 @@ describe('createWorkflowScriptAgentRunner', () => {
     await expect(runner(invocation())).rejects.toThrow(
       'Workflow subagent completed without producing any output files.',
     );
-  });
-
-  it('turns durable reconciliation failures into fatal workflow aborts', async () => {
-    mocks.executeStableSubagentInBand.mockRejectedValueOnce(
-      new SubagentReconciliationError('incomplete child state'),
-    );
-    const runner = defaultRunner();
-
-    await expect(runner(invocation())).rejects.toMatchObject({
-      name: 'WorkflowRunAbortError',
-      message: 'incomplete child state',
-    });
   });
 
   it('turns manifest-write failures into fatal workflow aborts', async () => {

--- a/src/test-kernel/tools/DelegationHeadless.vitest.ts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.ts
@@ -29,8 +29,6 @@ import { DelegateAgentTool } from '@tools/delegation/DelegationTools';
 import {
   executeStableSubagentInBand,
   SubagentDurabilityError,
-  SubagentReconciliationError,
-  type InBandSubagentExecutionOptions,
 } from '@tools/delegation/inBandSubagentExecution';
 import {
   provideAgentEngine,
@@ -187,6 +185,14 @@ async function delegateWithProposalDecision(decision: ProposalResult) {
 const STABLE_PARENT_EXECUTION_ID = 'abcdef123456' as ExecutionId;
 const IN_BAND_LOGICAL_EXECUTION_ID = 'aaaaaa111111' as ExecutionId;
 
+type PreparedInBandSubagentOptions = Awaited<
+  ReturnType<Parameters<typeof executeStableSubagentInBand>[0]['prepare']>
+>;
+type InBandSubagentExecutionOptions = PreparedInBandSubagentOptions & {
+  parentExecutionId: ExecutionId;
+  signal?: AbortSignal;
+};
+
 /** The in-band delegation options shared by nearly every case (fields vary). */
 function delegationOptions(
   overrides: Partial<InBandSubagentExecutionOptions> = {},
@@ -210,11 +216,12 @@ function runInBand(
   options: InBandSubagentExecutionOptions,
   executionId: ExecutionId = IN_BAND_LOGICAL_EXECUTION_ID,
 ) {
+  const { parentExecutionId, signal, ...prepared } = options;
   return executeStableSubagentInBand({
     executionId,
-    parentExecutionId: options.parentExecutionId,
-    signal: options.signal,
-    prepare: async () => options,
+    parentExecutionId,
+    signal,
+    prepare: async () => prepared,
   });
 }
 
@@ -791,7 +798,7 @@ describe('headless delegation', () => {
         parentExecutionId: STABLE_PARENT_EXECUTION_ID,
         prepare: vi.fn(),
       }),
-    ).rejects.toBeInstanceOf(SubagentReconciliationError);
+    ).rejects.toBeInstanceOf(SubagentDurabilityError);
     expect(mocks.registerExecution).not.toHaveBeenCalled();
     expect(mocks.executeAgent).not.toHaveBeenCalled();
   });
@@ -811,7 +818,7 @@ describe('headless delegation', () => {
 
     await expect(
       runInBand(delegationOptions(), logicalExecutionId),
-    ).rejects.toBeInstanceOf(SubagentReconciliationError);
+    ).rejects.toBeInstanceOf(SubagentDurabilityError);
     expect(mocks.registerExecution).not.toHaveBeenCalled();
     expect(mocks.executeAgent).not.toHaveBeenCalled();
   });
@@ -826,7 +833,7 @@ describe('headless delegation', () => {
 
     await expect(
       runInBand(delegationOptions(), logicalExecutionId),
-    ).rejects.toBeInstanceOf(SubagentReconciliationError);
+    ).rejects.toBeInstanceOf(SubagentDurabilityError);
     expect(mocks.registerExecution).not.toHaveBeenCalled();
     expect(mocks.executeAgent).not.toHaveBeenCalled();
   });
@@ -893,7 +900,7 @@ describe('headless delegation', () => {
       expect.objectContaining({ phase: 'launched' }),
     );
     await expect(runInBand(options, logicalExecutionId)).rejects.toBeInstanceOf(
-      SubagentReconciliationError,
+      SubagentDurabilityError,
     );
     expect(mocks.executeAgent).toHaveBeenCalledOnce();
   });
@@ -1016,7 +1023,7 @@ describe('headless delegation', () => {
 
     await expect(
       runInBand(delegationOptions(), logicalExecutionId),
-    ).rejects.toBeInstanceOf(SubagentReconciliationError);
+    ).rejects.toBeInstanceOf(SubagentDurabilityError);
     expect(mocks.executeAgent).toHaveBeenCalledOnce();
   });
 
@@ -1059,7 +1066,7 @@ describe('headless delegation', () => {
     abandonedLeasePresent = false;
     await expect(
       runInBand(delegationOptions(), logicalExecutionId),
-    ).rejects.toBeInstanceOf(SubagentReconciliationError);
+    ).rejects.toBeInstanceOf(SubagentDurabilityError);
     expect(mocks.executeAgent).toHaveBeenCalledOnce();
   });
 

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -13,18 +13,13 @@
  */
 
 // Local imports
-import {
-  getExecutionStore,
-  type ExecutionKVStore,
-  type ResultMeta,
-} from '@agent/storage';
+import { getExecutionStore, type ResultMeta } from '@agent/storage';
 import {
   ExecutionLeaseLostError,
   runWithInactiveExecutionLease,
 } from '@agent/storage/executionLease';
 import {
   AgentConfigSchema,
-  type AgentConfig,
   type AgentConfigPayload,
 } from '@agent/core/definition/AgentConfig';
 import type { AgentFinalResult } from '@agent/runtime/AgentFinalResult';
@@ -77,18 +72,15 @@ interface InBandSubagentExecutionBaseOptions extends ChildRunLaunchOptions {
   readonly notify?: (update: SubagentProgressUpdate) => void;
 }
 
-/** Options for the typed child API. Direct persisted parentage is required. */
-export interface InBandSubagentExecutionOptions extends InBandSubagentExecutionBaseOptions {
-  readonly parentExecutionId: ExecutionId;
-}
-
 interface StableInBandSubagentExecutionOptions {
   /** Cryptographic identity of the prompt/options call, stable across restart. */
   readonly executionId: ExecutionId;
   readonly parentExecutionId: ExecutionId;
   readonly signal?: AbortSignal;
   /** Resolve mutable launch prerequisites only when no result can be recovered. */
-  readonly prepare: () => Promise<InBandSubagentExecutionOptions>;
+  readonly prepare: () => Promise<
+    Omit<InBandSubagentExecutionBaseOptions, 'signal'>
+  >;
   /**
    * Fires once, just before a live attempt runs, with the execution id that
    * attempt actually uses — the logical id on attempt 0, an attempt-specific
@@ -138,7 +130,7 @@ export class SubagentDurabilityError extends Error {
   }
 }
 
-export class SubagentReconciliationError extends SubagentDurabilityError {
+class SubagentReconciliationError extends SubagentDurabilityError {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
     this.name = 'SubagentReconciliationError';
@@ -330,151 +322,6 @@ async function throwRetryableDurabilityError(
 }
 
 /**
- * Register the child execution and resolve its stream tab.
- *
- * The failure classification is the whole point of the wrapper: under the
- * typed-result contract a registration failure means no attempt ever launched,
- * which is a durability fault the stable-attempt ledger must see; best-effort
- * delivery surfaces the raw cause instead.
- */
-async function registerInBandChild(
-  options: InBandSubagentDeliveryOptions,
-  config: AgentConfig,
-  executionId: ExecutionId,
-  mode: PersistenceMode,
-): Promise<StreamTabId> {
-  try {
-    const { childStreamId } = await registerChildExecution({
-      executionId,
-      config,
-      agentName: options.agentName,
-      userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
-      parentExecutionId: options.parentExecutionId,
-    });
-    return childStreamId;
-  } catch (cause) {
-    if (mode === 'required-result') {
-      throw new SubagentDurabilityError(
-        `Failed to register subagent ${executionId}.`,
-        { cause },
-      );
-    }
-    throw cause;
-  }
-}
-
-/**
- * Post-drain, pre-lease-release durable commit: attest that the child's result
- * manifest is on disk, then flip the stable attempt marker to `committed`.
- *
- * Returns whether the commit happened. A non-stable call, an errored turn, or
- * a non-completed outcome is a deliberate no-op — only a durably completed
- * child earns the marker that later recovery treats as attestable.
- */
-async function commitStableCompletion(
-  store: ExecutionKVStore,
-  executionId: ExecutionId,
-  stableAttempt: StableSubagentAttempt | undefined,
-  settledTurn: SettledInBandTurn | undefined,
-): Promise<boolean> {
-  const settledResultMeta = settledTurn?.resultMeta;
-  if (
-    !stableAttempt ||
-    settledTurn?.isError === true ||
-    settledResultMeta?.producer !== 'subagent' ||
-    settledResultMeta.result.outcome !== RUN_OUTCOME.COMPLETED
-  ) {
-    return false;
-  }
-  let persisted: ResultMeta | null;
-  try {
-    persisted = await store.readResultMeta();
-  } catch (cause) {
-    throw new SubagentCommitError(
-      `Failed to verify durable completion for subagent ${executionId}.`,
-      { cause },
-    );
-  }
-  if (!persisted || persisted.producer !== 'subagent') {
-    throw new SubagentCommitError(
-      `Failed to persist result for subagent ${executionId}.`,
-    );
-  }
-  try {
-    await writeStableSubagentAttempt(store, {
-      ...stableAttempt,
-      phase: 'committed',
-    });
-  } catch (cause) {
-    throw new SubagentCommitError(
-      `Failed to commit durable completion for subagent ${executionId}.`,
-      { cause },
-    );
-  }
-  return true;
-}
-
-/**
- * Required-result mode only: confirm the manifest this caller is about to
- * report actually landed on disk. Returns normally when it did; every other
- * outcome throws.
- *
- * The ledger recovers restarts by inspecting the persisted manifest, so the
- * in-memory copy is not enough here. A FAILED child's attempt is marked
- * retryable (re-running a failed child is safe); a COMPLETED child whose
- * manifest did not persist keeps its 'launched' marker, so a later run refuses
- * to repeat side-effectful work rather than executing it twice.
- */
-async function verifyPersistedResultManifest(
-  store: ExecutionKVStore,
-  executionId: ExecutionId,
-  stableAttempt: StableSubagentAttempt | undefined,
-  childFailed: boolean,
-  childError: () => unknown,
-): Promise<void> {
-  let persisted: ResultMeta | null;
-  // A read failure is NOT the same fact as a missing manifest: keep it so
-  // the thrown error names the I/O cause instead of blaming persistence.
-  let readFailure: unknown;
-  try {
-    persisted = await store.readResultMeta();
-  } catch (cause) {
-    log.warn('Failed to read the persisted result manifest', {
-      data: { executionId, error: cause },
-    });
-    persisted = null;
-    readFailure = cause;
-  }
-  if (!persisted) {
-    if (childFailed) {
-      const error = childError();
-      await throwRetryableDurabilityError(
-        executionId,
-        stableAttempt,
-        new SubagentDurabilityError(
-          `Subagent ${executionId} failed (${toErrorMessage(error)}), and its failure result could not be persisted.`,
-          {
-            cause: new AggregateError(
-              readFailure === undefined ? [error] : [error, readFailure],
-              `Subagent ${executionId} execution and persistence both failed.`,
-            ),
-          },
-        ),
-      );
-    }
-    if (readFailure !== undefined) {
-      throw new SubagentDurabilityError(
-        `Failed to verify the persisted result for subagent ${executionId}.`,
-        { cause: readFailure },
-      );
-    }
-    throw new SubagentDurabilityError(
-      `Failed to persist result for subagent ${executionId}.`,
-    );
-  }
-}
-
-/**
  * Execute one child through the one shared driver and read its typed result
  * back from the durable record. The child runs under the same detached
  * child-run loop every native child uses (single-cycle strategy, persist-only
@@ -503,12 +350,24 @@ async function executeInBand(
   const workingDirectory = config.workingDirectory ?? undefined;
   const store = getExecutionStore(executionId);
 
-  const childStreamId = await registerInBandChild(
-    options,
-    config,
-    executionId,
-    mode,
-  );
+  let childStreamId: StreamTabId;
+  try {
+    ({ childStreamId } = await registerChildExecution({
+      executionId,
+      config,
+      agentName: options.agentName,
+      userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
+      parentExecutionId: options.parentExecutionId,
+    }));
+  } catch (cause) {
+    if (mode === 'required-result') {
+      throw new SubagentDurabilityError(
+        `Failed to register subagent ${executionId}.`,
+        { cause },
+      );
+    }
+    throw cause;
+  }
   let stableCompletionCommitted = false;
   const completed = await (async () => {
     let settledTurn: SettledInBandTurn | undefined;
@@ -526,13 +385,41 @@ async function executeInBand(
         settledTurn = settled;
       },
       afterArtifactsDrained: async () => {
-        const committed = await commitStableCompletion(
-          store,
-          executionId,
-          stableAttempt,
-          settledTurn,
-        );
-        if (committed) stableCompletionCommitted = true;
+        const settledResultMeta = settledTurn?.resultMeta;
+        if (
+          !stableAttempt ||
+          settledTurn?.isError === true ||
+          settledResultMeta?.producer !== 'subagent' ||
+          settledResultMeta.result.outcome !== RUN_OUTCOME.COMPLETED
+        ) {
+          return;
+        }
+        let persisted: ResultMeta | null;
+        try {
+          persisted = await store.readResultMeta();
+        } catch (cause) {
+          throw new SubagentCommitError(
+            `Failed to verify durable completion for subagent ${executionId}.`,
+            { cause },
+          );
+        }
+        if (!persisted || persisted.producer !== 'subagent') {
+          throw new SubagentCommitError(
+            `Failed to persist result for subagent ${executionId}.`,
+          );
+        }
+        try {
+          await writeStableSubagentAttempt(store, {
+            ...stableAttempt,
+            phase: 'committed',
+          });
+          stableCompletionCommitted = true;
+        } catch (cause) {
+          throw new SubagentCommitError(
+            `Failed to commit durable completion for subagent ${executionId}.`,
+            { cause },
+          );
+        }
       },
       buildLaunch: async () => {
         // Inside the loop's lease launch guard, like every attempt-scoped
@@ -619,13 +506,52 @@ async function executeInBand(
     }
 
     if (mode === 'required-result') {
-      await verifyPersistedResultManifest(
-        store,
-        executionId,
-        stableAttempt,
-        childFailed,
-        childError,
-      );
+      // The ledger recovers restarts by inspecting the persisted manifest, so
+      // the in-memory copy is not enough here: verify the write landed. A
+      // FAILED child's attempt is marked retryable (re-running a failed child
+      // is safe); a COMPLETED child whose manifest did not persist keeps its
+      // 'launched' marker, so a later run refuses to repeat side-effectful
+      // work rather than executing it twice.
+      let persisted: ResultMeta | null;
+      // A read failure is NOT the same fact as a missing manifest: keep it so
+      // the thrown error names the I/O cause instead of blaming persistence.
+      let readFailure: unknown;
+      try {
+        persisted = await store.readResultMeta();
+      } catch (cause) {
+        log.warn('Failed to read the persisted result manifest', {
+          data: { executionId, error: cause },
+        });
+        persisted = null;
+        readFailure = cause;
+      }
+      if (!persisted) {
+        if (childFailed) {
+          const error = childError();
+          await throwRetryableDurabilityError(
+            executionId,
+            stableAttempt,
+            new SubagentDurabilityError(
+              `Subagent ${executionId} failed (${toErrorMessage(error)}), and its failure result could not be persisted.`,
+              {
+                cause: new AggregateError(
+                  readFailure === undefined ? [error] : [error, readFailure],
+                  `Subagent ${executionId} execution and persistence both failed.`,
+                ),
+              },
+            ),
+          );
+        }
+        if (readFailure !== undefined) {
+          throw new SubagentDurabilityError(
+            `Failed to verify the persisted result for subagent ${executionId}.`,
+            { cause: readFailure },
+          );
+        }
+        throw new SubagentDurabilityError(
+          `Failed to persist result for subagent ${executionId}.`,
+        );
+      }
     }
 
     if (
@@ -776,15 +702,14 @@ export async function executeStableSubagentInBand(
     // so a host can target this in-flight attempt by the id the roster shows.
     options.onActiveExecutionId?.(executionId);
     const prepared = await options.prepare();
-    if (prepared.parentExecutionId !== options.parentExecutionId) {
-      throw new SubagentReconciliationError(
-        `Prepared subagent ${executionId} changed its parent execution.`,
-      );
-    }
     // The typed-result contract carries no delivery: a required-result child
     // renders none (`resultOnly`), and a recovered attempt has none to give.
     const completed = await executeInBand(
-      prepared,
+      {
+        ...prepared,
+        parentExecutionId: options.parentExecutionId,
+        signal: options.signal,
+      },
       'required-result',
       executionId,
       attempt,

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -325,10 +325,8 @@ export function createWorkflowScriptAgentRunner(
           return {
             configPayload,
             agentName,
-            parentExecutionId: run.executionId,
             parentStreamId: run.streamId,
             session: runScope.session,
-            signal: invocation.signal,
             approvalPromptsUnavailable: parent.approvalPromptsUnavailable,
             onApprovalPolicyDenial: parent.onApprovalPolicyDenial,
             runtimeUnavailableTools: parent.runtimeUnavailableTools,


### PR DESCRIPTION
## Summary

- make the stable execution wrapper own parent identity and cancellation instead of asking its one internal preparer to echo them
- inline three single-use durability helpers at their only decision points
- keep reconciliation failures private behind the public durability error contract and remove the unused exported option type
- remove duplicate tests that asserted the retired internal subclass seam

## Net elements (R6)

- files: 5 modified, 0 added, 0 deleted
- production declarations: 3 single-use helper functions removed, 1 exported interface removed, and 1 error subclass export removed
- public exports: 2 removed, 0 added
- dependencies and abstractions: 0 added
- net diff: 128 insertions, 234 deletions, for 106 fewer lines

## Consumer counts (R8)

- `registerInBandChild`, `commitStableCompletion`, and `verifyPersistedResultManifest`: each had exactly 1 production caller and no direct test consumer; their logic remains at that caller
- `InBandSubagentExecutionOptions`: 0 production consumers and 1 test-only consumer; the test now derives the preparation type from the public function
- `SubagentReconciliationError`: 0 external production consumers and test-only subclass assertions; production still classifies it through `SubagentDurabilityError`
- event and persistence paths: no emit, write, lease, retry, or manifest-verification path was removed

## Validation

- `corepack pnpm exec vitest run src/test-kernel/tools/DelegationHeadless.vitest.ts src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts src/test-kernel/tools/DelegationTools.vitest.ts --maxWorkers=1` (72 passed)
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- `corepack pnpm run lint`
- `corepack pnpm run compile:safe`
- `corepack pnpm test` (819 files passed, 1 skipped; 9,932 tests passed, 5 skipped)
- `node scripts/check-dead-code-ratchet.mjs` (321 of 321 baseline rows remain justified)
- `git diff --check`