### PR TITLE
fix(workflow): preserve unresolved compile rejection

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -6,7 +6,10 @@ import {
   persistChildRunResultMeta,
   type ResumabilityDecision,
 } from '@agent/storage';
-import type { AgentConfigPayload } from '@agent/runtime';
+import {
+  isTerminalPersistedCompileRejection,
+  type AgentConfigPayload,
+} from '@agent/runtime';
 import { RUN_OUTCOME, type ExecutionId, AgentCategory } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -198,7 +201,7 @@ export async function executeCliWorkflowConfig(
       typeof shared === 'object' && shared !== null
         ? (shared as Record<string, unknown>).lastError
         : undefined;
-    return lastError == null;
+    return lastError == null && !isTerminalPersistedCompileRejection(shared);
   };
   const writeResumeHint = (
     executionId: ExecutionId,

--- a/packages/cli/src/runtime/toolUseResumeData.ts
+++ b/packages/cli/src/runtime/toolUseResumeData.ts
@@ -1,11 +1,12 @@
-import { getExecutionStore } from '@agent/storage';
 import {
   classifyRun,
+  hasTerminalPersistedCompileRejection,
   retrieveSessionResumeData,
   type AgentConfig,
 } from '@agent/runtime';
+import { getExecutionStore } from '@agent/storage';
 import { createLog } from '@logger/logUtils';
-import type { ExecutionId } from '@shared/schemas';
+import { AgentCategory, type ExecutionId } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const logger = createLog('CliToolUseResumeData');
@@ -42,6 +43,12 @@ export async function readCliResumeDataForListing(
 ): Promise<CliSessionResumeData | null> {
   try {
     if ((await classifyRun(id)).kind !== 'resumable') return null;
+    if (
+      config.agentCategory === AgentCategory.Workflow &&
+      (await hasTerminalPersistedCompileRejection(id))
+    ) {
+      return null;
+    }
     return await readCliSessionResumeData(id, config);
   } catch (error) {
     logger.debug(

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -250,11 +250,9 @@ export async function resolveWorkflowOutput(
 ): Promise<CliWorkflowRunResult> {
   const runDirectory = options.runDirectory ?? getRunDir(result.executionId);
   const baseResult = { ...result, workingDirectory: context.cwd, runDirectory };
-  // Interrupted rounds remain inspectable in run storage, but are not final
-  // artifacts and must not replace the user's requested destination.
-  if (result.outcome === RUN_OUTCOME.CANCELLED && (outputFile || outputDir)) {
-    return baseResult;
-  }
+  // Only completed runs may publish to user-requested destinations. Partial or
+  // rejected artifacts remain inspectable in run storage through baseResult.
+  if (result.outcome !== RUN_OUTCOME.COMPLETED) return baseResult;
   // Commit before validation as well as copying: once output finalization owns
   // the verdict, its missing-output and filesystem failures must stay visible.
   if ((outputFile || outputDir) && options.tryCommitPublication?.() === false) {
@@ -326,6 +324,13 @@ export async function resolveWorkflowOutput(
 }
 
 export function formatWorkflowTextResult(result: CliWorkflowRunResult): string {
+  if (result.outcome === RUN_OUTCOME.FAILED) {
+    const diagnosticPath =
+      result.runDirectory ?? finalWorkflowOutput(result.outputs)?.absolutePath;
+    return diagnosticPath
+      ? `FAILED\nRun artifacts: ${diagnosticPath}`
+      : 'FAILED';
+  }
   if (
     result.outcome === RUN_OUTCOME.CANCELLED &&
     result.runDirectory &&

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -57,8 +57,11 @@ export const ReflectionFlowStateSchema = z.object({
   /** Provider-message format used by the persisted `context` messages. */
   modelHandlerCompatibilityKey: ModelHandlerCompatibilityKeySchema.nullish(),
 
-  /** Compile-failure context injected into the next configured round. */
+  /** One-shot compile-failure feedback injected into the next round prompt. */
   compileFailureContext: z.string().optional(),
+
+  /** Rejected compile result awaiting an explicit successful compile. */
+  unresolvedCompileRejection: z.boolean().optional(),
 });
 
 /** Shared state type for reflection flow nodes. */

--- a/src/agent/implementations/flows/reflection/ReflectionServices.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionServices.ts
@@ -10,6 +10,7 @@ import type { XmlOutputManager } from './output/XmlOutputManager';
 
 export interface ReflectionServices extends BaseFlowContextInit {
   readonly setting: AgentWorkflowSetting;
+  readonly getRejectOnCompileFailure: () => boolean;
   readonly outputState: OutputState;
   readonly xmlManager: XmlOutputManager;
   readonly diffManager: LatexDiffManager;

--- a/src/agent/implementations/flows/reflection/RoundPersistedFlow.ts
+++ b/src/agent/implementations/flows/reflection/RoundPersistedFlow.ts
@@ -22,6 +22,7 @@ import { BaseNode } from '@agent/node';
 import type { ExecutionKVStore } from '@agent/storage';
 import type { StageHandle } from '@agent/trace';
 import { PersistedFlow } from '@agent/node/persistedFlow';
+import { isTerminalPersistedCompileRejection } from '@agent/runtime/persistedCompileRejection';
 import {
   RUN_OUTCOME,
   type RetryErrorInfo,
@@ -52,8 +53,11 @@ export interface RoundAwareState {
   /** Set by nodes when execution fails. Skips round completion callbacks. */
   lastError?: RetryErrorInfo;
 
-  /** Output rejection carried into the next configured round, if one remains. */
+  /** One-shot output-rejection feedback for the next configured round. */
   compileFailureContext?: string;
+
+  /** Durable compile rejection awaiting an explicit successful compile. */
+  unresolvedCompileRejection?: boolean;
 }
 
 // ============================================================================
@@ -99,20 +103,23 @@ export class RoundPersistedFlow<
 > extends PersistedFlow<S, Svc> {
   private readonly callbacks: RoundCallbacks<S>;
   private readonly parentStage: StageHandle | null;
+  private readonly getRejectOnCompileFailure: () => boolean;
   private currentRoundStage: StageHandle | null = null;
 
   constructor(
     start: BaseNode,
     kv: ExecutionKVStore,
-    options?: {
+    options: {
       callbacks?: RoundCallbacks<S>;
       parentStage?: StageHandle | null;
       sharedSchema?: z.ZodType<S>;
+      getRejectOnCompileFailure: () => boolean;
     },
   ) {
-    super(start, kv, undefined, options?.sharedSchema);
-    this.callbacks = options?.callbacks ?? {};
-    this.parentStage = options?.parentStage ?? null;
+    super(start, kv, undefined, options.sharedSchema);
+    this.callbacks = options.callbacks ?? {};
+    this.parentStage = options.parentStage ?? null;
+    this.getRejectOnCompileFailure = options.getRejectOnCompileFailure;
   }
 
   /**
@@ -142,6 +149,10 @@ export class RoundPersistedFlow<
     let currentShared = (await this.getShared()) ?? shared;
 
     try {
+      // Disabling rejection is an explicit acceptance decision. Clear both the
+      // durable verdict and any unconsumed prompt feedback before the cap guard.
+      await this.normalizeCompileRejectionPolicy(currentShared);
+
       // A persisted cursor may point into a legacy extra repair round, or the
       // configured total may have been lowered since persistence. In either
       // case the hard round limit takes precedence over resuming that cursor.
@@ -162,7 +173,9 @@ export class RoundPersistedFlow<
         currentShared = await this.executeRoundSteps();
       }
 
-      // Determine final outcome
+      // Re-read policy at terminal resolution. A setting change during the
+      // final repair round is an explicit acceptance even without a compile.
+      await this.normalizeCompileRejectionPolicy(currentShared);
       outcome = this.resolveOutcome(currentShared);
     } finally {
       this.currentRoundStage?.end(outcome);
@@ -206,13 +219,24 @@ export class RoundPersistedFlow<
     return shared.currentRound + 1 < shared.totalRounds;
   }
 
+  /** Apply current compile-rejection policy and persist explicit acceptance. */
+  private async normalizeCompileRejectionPolicy(shared: S): Promise<void> {
+    if (
+      this.getRejectOnCompileFailure() ||
+      (!shared.unresolvedCompileRejection && !shared.compileFailureContext)
+    ) {
+      return;
+    }
+    delete shared.unresolvedCompileRejection;
+    delete shared.compileFailureContext;
+    await this.setShared(shared);
+  }
+
   /** Derive the canonical RunOutcome from the current round state. */
   private resolveOutcome(shared: S): RunOutcome {
     return deriveRunOutcome({
       failed: Boolean(
-        shared.lastError ||
-        (shared.compileFailureContext &&
-          shared.currentRound + 1 >= shared.totalRounds),
+        shared.lastError || isTerminalPersistedCompileRejection(shared),
       ),
       cancelled: this.callbacks.signal?.aborted || !shared.continueRounds,
     });

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -209,7 +209,8 @@ export class OutputNode extends BaseNode<
     prepRes: OutputPrepInput,
     execRes: OutputExecResult,
   ): Promise<string | undefined> {
-    const { logger, outputState, runScope } = this.services;
+    const { logger, outputState, runScope, getRejectOnCompileFailure } =
+      this.services;
     const { streamId } = runScope;
     const interactions = runScope.session.interactions;
     const { outputLocation, currentRound, endTurn } = prepRes;
@@ -277,24 +278,17 @@ export class OutputNode extends BaseNode<
 
     // Project the canonical live collection into PersistedFlow's cloned state.
     shared.roundOutputs = roundsToPersisted(outputState);
-    const compileFailureContext =
-      execRes.compileResult &&
-      readPlatformSetting<boolean>(
-        WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE,
-      )
+    if (execRes.compileResult) {
+      const compileFailureContext = getRejectOnCompileFailure()
         ? formatCompileFailureRoundContext(execRes.compileResult)
         : undefined;
-    if (compileFailureContext) {
-      shared.compileFailureContext = compileFailureContext;
-      if (!runScope.signal.aborted && currentRound + 1 >= shared.totalRounds) {
-        shared.lastError = {
-          message:
-            'Automatic LaTeX compilation failed after the final workflow round.',
-          userRetryable: false,
-        };
+      if (compileFailureContext) {
+        shared.compileFailureContext = compileFailureContext;
+        shared.unresolvedCompileRejection = true;
+      } else {
+        delete shared.compileFailureContext;
+        delete shared.unresolvedCompileRejection;
       }
-    } else {
-      delete shared.compileFailureContext;
     }
 
     return FlowTransition.DEFAULT;

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -6,6 +6,10 @@ import type {
   ToolPolicy,
 } from '@agent/core/flows/BaseFlowServices';
 import { activeModelHandlerCompatibilityKey } from '@agent/runtime/ModelFactory';
+import {
+  hasPersistedCompileRejection,
+  isLegacySyntheticFinalCompileError,
+} from '@agent/runtime/persistedCompileRejection';
 import { resolveAgentTools } from '@agent/runtime/agentToolResolution';
 import { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
@@ -32,6 +36,8 @@ import {
   WORKFLOW_RAW_OUTPUT_EXT,
   workflowOutputPath,
 } from '@shared/constants/workflowOutput';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import { readPlatformSetting } from '@utils/config/platformSettings';
 import { TaskRunFileService } from '@utils/files/taskRunStorage';
 import { pathToLocation } from '@utils/files/fileLocation';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -88,9 +94,9 @@ export interface RunReflectionFlowResult {
   outcome: RunOutcome;
   totalCostUsd?: number;
   /**
-   * The structured provider error behind a FAILED outcome. The run reports its
-   * failure here rather than by throwing, so the rounds it did produce travel
-   * with it.
+   * Structured provider/runtime error behind a FAILED outcome, when present.
+   * A rejected compile is an outcome-only domain failure whose diagnostics are
+   * carried by roundOutputs instead.
    */
   error?: RetryErrorInfo;
 }
@@ -126,6 +132,10 @@ export async function runReflectionFlow(
     runScope,
   } = input;
   const { streamId, executionId } = runScope;
+  const getRejectOnCompileFailure = () =>
+    readPlatformSetting<boolean>(
+      WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE,
+    );
   const resolvedSetting = await resolveWorkflowSettingTools(
     setting,
     input.toolPolicy,
@@ -178,6 +188,7 @@ export async function runReflectionFlow(
   const services: ReflectionServices = {
     ...input,
     setting: resolvedSetting,
+    getRejectOnCompileFailure,
     outputState,
     xmlManager,
     diffManager,
@@ -222,6 +233,25 @@ export async function runReflectionFlow(
     }
 
     shared = validated.data;
+    // Before the durable marker existed, prompt feedback was the only persisted
+    // evidence of rejection. Promote it once so an interrupted legacy repair
+    // does not silently complete after PrepareContext consumes the feedback.
+    const hasCompileRejection = hasPersistedCompileRejection(shared);
+    if (
+      hasCompileRejection &&
+      shared.unresolvedCompileRejection === undefined
+    ) {
+      shared.unresolvedCompileRejection = true;
+    }
+    // PR #11624 represented a final compile verdict as a provider-like error.
+    // Remove only that exact synthetic shape when compile-rejection evidence is
+    // present. Genuine provider and runtime errors remain durable.
+    if (
+      hasCompileRejection &&
+      isLegacySyntheticFinalCompileError(shared.lastError)
+    ) {
+      delete shared.lastError;
+    }
     // A keyless legacy record gets the active handler's key stamped here;
     // model-based inference for such records lives at SessionResumeRetrieval.
     shared = stampCompatibilityKey(shared, compatibilityKey);
@@ -272,6 +302,7 @@ export async function runReflectionFlow(
     {
       parentStage,
       sharedSchema: ReflectionFlowStateSchema,
+      getRejectOnCompileFailure,
       callbacks: {
         createRoundStage: (roundIndex, parent, shared) =>
           logger.openStage(`r${roundIndex}`, {

--- a/src/agent/runtime/AgentFinalResult.ts
+++ b/src/agent/runtime/AgentFinalResult.ts
@@ -44,10 +44,10 @@ export const WorkflowAgentFinalResultSchema = WorkflowFlowResultSchema.pick({
     diffsUnavailable: z.string().optional(),
     structured: JsonValueSchema.optional(),
     /**
-     * The structured error of a run that ended FAILED, carried on the typed
-     * result so chaining consumers read the failure from the artifact itself
-     * (the result-only observability contract). Absent on non-failed
-     * outcomes; journal entries only ever hold completed results.
+     * Structured provider/runtime error behind a FAILED outcome, when present.
+     * Outcome-only domain failures can end FAILED without this field and carry
+     * their diagnostics in category-specific result fields. Absent on every
+     * non-failed outcome; journal entries only ever hold completed results.
      */
     error: RetryErrorInfoSchema.optional(),
   })
@@ -64,12 +64,12 @@ const ToolUseAgentFinalResultSchema = ToolUseFlowResultSchema.pick({
     files: ToolUseFlowResultSchema.shape.files.unwrap().prefault(() => []),
     cost: CostSchema,
     structured: JsonValueSchema.optional(),
-    /** See the workflow member: failed runs carry their structured error. */
+    /** See the workflow member: provider/runtime failures carry this field. */
     error: RetryErrorInfoSchema.optional(),
   })
   .strict();
 
-/** Stable result returned by any completed agent run. */
+/** Stable result returned by any terminal agent run. */
 export const AgentFinalResultSchema = z.discriminatedUnion('category', [
   WorkflowAgentFinalResultSchema,
   ToolUseAgentFinalResultSchema,

--- a/src/agent/runtime/AgentFlowResult.ts
+++ b/src/agent/runtime/AgentFlowResult.ts
@@ -23,11 +23,11 @@ const AgentFlowMetaSchema = z.object({
    */
   totalCostUsd: z.number().nonnegative().optional(),
   /**
-   * The structured provider error of a run that ended FAILED. This is the one
-   * carrier for a failure that still has a result: a flow reports its failure
-   * on the result it returns rather than through an exception subclass, and
-   * `runFlowWithLifecycle` reads it to classify, log, and publish the terminal
-   * error facts. Absent on every non-failed outcome.
+   * Structured provider/runtime error behind a FAILED outcome, when one exists.
+   * `runFlowWithLifecycle` classifies and publishes this error. Domain verdicts
+   * such as rejected workflow output can also end FAILED without manufacturing
+   * provider error metadata; their diagnostics remain in category fields.
+   * Absent on every non-failed outcome.
    */
   error: RetryErrorInfoSchema.optional(),
 });

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -548,12 +548,11 @@ export async function runFlowWithLifecycle(
       ...arm,
     });
   /**
-   * The single owner of a failed run's exit, entered from both arms below: a
-   * flow that reported FAILED on its result (`carried`, whose structured error
-   * arrives recovered onto `err`) and an exception that escaped the runner
-   * without one. Classification, the run log, the terminal `result` event's
-   * error facts, subagent delivery, and the `AgentError` a root caller sees all
-   * happen here, so a carried failure is exactly as loud as a thrown one.
+   * The single owner of provider/runtime failure exits, entered from both arms
+   * below: a flow carrying structured error metadata and an exception that
+   * escaped the runner. Outcome-only domain failures bypass classification and
+   * finalize through the ordinary terminal-result path without a fabricated
+   * RetryErrorInfo.
    */
   const finalizeFailedRun = async (
     err: unknown,
@@ -732,10 +731,9 @@ export async function runFlowWithLifecycle(
       });
       return result;
     }
-    // A flow that failed reports it on the result it returns, together with the
-    // response, files, and cost it did produce. That is a failed run, not a
-    // successful one with an error field, so it exits through the same owner an
-    // escaped exception does.
+    // Provider/runtime failures carry structured error metadata and use the
+    // classified failure path. A domain failure may report FAILED without this
+    // field and is finalized below as an outcome-only terminal result.
     if (result.error) {
       return await finalizeFailedRun(toFlowFailureError(result.error), result);
     }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -308,10 +308,10 @@ export interface SubagentRunOptions {
   /** Session owning this run's coordination state. Defaults to the process session. */
   session?: SessionHandle;
   /**
-   * Fires when the subagent run itself fails, so a caller can report the
-   * failure up the delegation chain. Distinct from a host-level failure
-   * surface such as `ResumeQueuedToolUseOptions.onError` (log + toast for a
-   * failed resume-plumbing step) — this callback is about the run's outcome.
+   * Fires when a subagent fails with a provider/runtime error that the caller
+   * can report up the delegation chain. Outcome-only domain failures remain on
+   * the returned result and do not manufacture an error for this callback.
+   * Distinct from host-level resume-plumbing error surfaces.
    */
   onRunError?: (
     error: unknown,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -103,6 +103,12 @@ export type { FileContext } from './textEnhancement';
 // selectAutoOpenFinalOutput
 export { selectAutoOpenFinalOutput } from './selectAutoOpenFinalOutput';
 
+// persistedCompileRejection
+export {
+  hasTerminalPersistedCompileRejection,
+  isTerminalPersistedCompileRejection,
+} from './persistedCompileRejection';
+
 // modelHandlerCompatibilityKey
 export { ModelHandlerCompatibilityKeySchema } from './modelHandlerCompatibilityKey';
 

--- a/src/agent/runtime/persistedCompileRejection.ts
+++ b/src/agent/runtime/persistedCompileRejection.ts
@@ -1,0 +1,48 @@
+import { getExecutionStore } from '@agent/storage';
+import { readPersistedFlowRecord } from '@agent/node/persistedFlow';
+import type { ExecutionId } from '@shared/schemas';
+
+const LEGACY_FINAL_COMPILE_REJECTION_MESSAGE =
+  'Automatic LaTeX compilation failed after the final workflow round.';
+
+/** Whether persisted state records an unresolved compile rejection. */
+export function hasPersistedCompileRejection(shared: unknown): boolean {
+  if (typeof shared !== 'object' || shared === null) return false;
+  const state = shared as Record<string, unknown>;
+  if (state.unresolvedCompileRejection === true) return true;
+  return (
+    state.unresolvedCompileRejection === undefined &&
+    typeof state.compileFailureContext === 'string' &&
+    state.compileFailureContext.length > 0
+  );
+}
+
+/** Whether persisted compile rejection has reached the configured round cap. */
+export function isTerminalPersistedCompileRejection(shared: unknown): boolean {
+  if (!hasPersistedCompileRejection(shared)) return false;
+  const state = shared as Record<string, unknown>;
+  return (
+    typeof state.currentRound === 'number' &&
+    typeof state.totalRounds === 'number' &&
+    state.currentRound + 1 >= state.totalRounds
+  );
+}
+
+/** Read an execution's persisted workflow state and apply the terminal predicate. */
+export async function hasTerminalPersistedCompileRejection(
+  id: ExecutionId,
+): Promise<boolean> {
+  const flowRecord = await readPersistedFlowRecord(getExecutionStore(id), id);
+  return isTerminalPersistedCompileRejection(flowRecord?.shared);
+}
+
+/** Identify the exact provider-like error synthesized by legacy workflow code. */
+export function isLegacySyntheticFinalCompileError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const value = error as Record<string, unknown>;
+  return (
+    Object.keys(value).length === 2 &&
+    value.message === LEGACY_FINAL_COMPILE_REJECTION_MESSAGE &&
+    value.userRetryable === false
+  );
+}

--- a/src/agent/runtime/terminalResultToast.ts
+++ b/src/agent/runtime/terminalResultToast.ts
@@ -8,8 +8,9 @@
  * each host applies this pure mapper in its `session.onResult` consumer,
  * presenting the returned payload through its existing
  * `requestShowInstruction` / `requestShowError` path. Subagent results and
- * non-actionable outcomes (abort, success) return `null` (no toast),
- * preserving the lifecycle's `!isSubagent` gating.
+ * outcomes without provider/runtime error metadata return `null` (no toast).
+ * Outcome-only domain failures use their own diagnostics, such as workflow
+ * compile rows and retained artifacts, rather than a generic duplicate toast.
  *
  * `attachTerminalResultToast` wires that mapper to a session for hosts that
  * present through {@link SessionHostInteractions} (CLI, desktop, extension). The
@@ -45,7 +46,8 @@ const MISSING_API_KEY_MESSAGE =
 
 /**
  * Map a terminal `result` event to the toast a host should present, or `null`
- * when none applies (subagent runs, success, user aborts, unclassified errors).
+ * when none applies (subagent runs, outcome-only domain failures, success, or
+ * user aborts).
  */
 function terminalResultToast(event: ResultEvent): TerminalResultToast | null {
   if (event.isSubagent || !event.error) return null;

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -1367,7 +1367,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     category: 'workflow',
     slots: sameSlot('workspaceState'),
     honoredBy: everyHost(
-      'src/agent/implementations/flows/reflection/nodes/OutputNode.ts',
+      'src/agent/implementations/flows/reflection/runReflectionFlow.ts',
       WORKFLOW_REJECT_RUNTIME_REACHABILITY,
     ),
     surfaces: { settingsView: 'latex', cliConfig: true },

--- a/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
+++ b/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
@@ -31,8 +31,9 @@ import {
   type StreamTabId,
   AgentCategory,
 } from '@shared/schemas';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { createTestSession } from '@test/support/sessionTestUtils';
-import { setupPlatform } from '@test/support/setupPlatform';
+import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 import { TaskRunFileService } from '@utils/files/taskRunStorage';
 import { testModelCell } from './modelCellTestUtils';
 import { reflectionFlowShared } from './progressTestUtils';
@@ -64,6 +65,7 @@ async function runPersistedReflectionFlow(
   executionId: ExecutionId,
   streamId: StreamTabId,
   logger: RunReflectionFlowInput['logger'] = noopTrace,
+  options: { rounds?: number; aborted?: boolean } = {},
 ): Promise<Awaited<ReturnType<typeof runReflectionFlow>>> {
   const session = createTestSession();
   const runScope = createRunScope({
@@ -71,7 +73,10 @@ async function runPersistedReflectionFlow(
     executionId,
     agentName: CONFIG.agent,
     session,
-    signal: AbortSignal.abort(),
+    signal:
+      options.aborted === false
+        ? new AbortController().signal
+        : AbortSignal.abort(),
   });
   const modelCell = createModelCell();
   const context = createRunContext({ runScope, modelCell });
@@ -81,7 +86,10 @@ async function runPersistedReflectionFlow(
       runReflectionFlow({
         config: CONFIG,
         runScope,
-        setting: SETTING,
+        setting:
+          options.rounds === undefined
+            ? SETTING
+            : AgentWorkflowSettingSchema.parse({ rounds: options.rounds }),
         prompt: PROMPT,
         logger,
         parentStage: logger.openStage('Reflection flow recovery test'),
@@ -96,12 +104,16 @@ async function runPersistedReflectionFlow(
   }
 }
 
-function recoveryCase(name: string) {
+function recoveryCase(
+  name: string,
+  options: { rounds?: number; aborted?: boolean } = {},
+) {
   const executionId = `reflection-flow-${name}` as ExecutionId;
   const streamId = `workflow@gpt54#reflection-flow-${name}` as StreamTabId;
   return {
     key: flowKey(executionId),
-    run: () => runPersistedReflectionFlow(executionId, streamId),
+    run: () =>
+      runPersistedReflectionFlow(executionId, streamId, noopTrace, options),
     store: getExecutionStore(executionId),
   };
 }
@@ -244,6 +256,161 @@ describe('runReflectionFlow persisted-state recovery', () => {
     });
     expect(await store.read(key)).toEqual(flowRecord(legacyShared));
   });
+
+  const syntheticCompileError = {
+    message:
+      'Automatic LaTeX compilation failed after the final workflow round.',
+    userRetryable: false,
+  };
+
+  it('promotes context-only legacy rejection and fails at the same cap', async () => {
+    const { key, run, store } = recoveryCase('legacy-context-same-cap', {
+      aborted: false,
+    });
+    await store.write(
+      key,
+      flowRecord(
+        reflectionFlowShared({
+          totalRounds: 1,
+          compileFailureContext: 'legacy compile failure',
+        }),
+      ),
+    );
+
+    const result = await run();
+    expect(result.outcome).toBe(RUN_OUTCOME.FAILED);
+    expect(result.error).toBeUndefined();
+    const shared = ReflectionFlowStateSchema.parse(
+      (await store.read<FlowRecord>(key))?.shared,
+    );
+    expect(shared.unresolvedCompileRejection).toBe(true);
+    expect(shared.lastError).toBeUndefined();
+  });
+
+  it('removes the legacy synthetic error but still fails at the same cap', async () => {
+    const { key, run, store } = recoveryCase('legacy-error-same-cap', {
+      aborted: false,
+    });
+    await store.write(
+      key,
+      flowRecord(
+        reflectionFlowShared({
+          totalRounds: 1,
+          compileFailureContext: 'legacy compile failure',
+          lastError: syntheticCompileError,
+        }),
+      ),
+    );
+
+    const result = await run();
+    expect(result.outcome).toBe(RUN_OUTCOME.FAILED);
+    expect(result.error).toBeUndefined();
+    const shared = ReflectionFlowStateSchema.parse(
+      (await store.read<FlowRecord>(key))?.shared,
+    );
+    expect(shared.unresolvedCompileRejection).toBe(true);
+    expect(shared.lastError).toBeUndefined();
+  });
+
+  it('preserves a genuine runtime error even with legacy rejection evidence', async () => {
+    const { key, run, store } = recoveryCase('legacy-context-provider-error', {
+      aborted: false,
+    });
+    const providerError = {
+      message: 'Provider request failed',
+      userRetryable: true,
+      statusCode: 503,
+    };
+    await store.write(
+      key,
+      flowRecord(
+        reflectionFlowShared({
+          totalRounds: 1,
+          compileFailureContext: 'legacy compile failure',
+          lastError: providerError,
+        }),
+      ),
+    );
+
+    await expect(run()).resolves.toMatchObject({
+      outcome: RUN_OUTCOME.FAILED,
+      error: providerError,
+    });
+    const stored = await store.read<FlowRecord>(key);
+    expect(ReflectionFlowStateSchema.parse(stored?.shared).lastError).toEqual(
+      providerError,
+    );
+  });
+
+  it.each([
+    { name: 'context-only', lastError: undefined },
+    { name: 'synthetic-error', lastError: syntheticCompileError },
+  ])(
+    'normalizes $name legacy rejection when the cap is raised',
+    async ({ name, lastError }) => {
+      const { key, run, store } = recoveryCase(`legacy-${name}-raised-cap`, {
+        rounds: 2,
+      });
+      await store.write(
+        key,
+        flowRecord(
+          reflectionFlowShared({
+            totalRounds: 1,
+            compileFailureContext: 'legacy compile failure',
+            lastError,
+          }),
+        ),
+      );
+
+      const result = await run();
+      expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+      expect(result.error).toBeUndefined();
+      const shared = ReflectionFlowStateSchema.parse(
+        (await store.read<FlowRecord>(key))?.shared,
+      );
+      expect(shared.totalRounds).toBe(2);
+      expect(shared.unresolvedCompileRejection).toBe(true);
+      expect(shared.lastError).toBeUndefined();
+    },
+  );
+
+  it.each([
+    { name: 'context-only', lastError: undefined },
+    { name: 'synthetic-error', lastError: syntheticCompileError },
+  ])(
+    'clears $name legacy rejection when rejection is disabled',
+    async ({ name, lastError }) => {
+      await installPlatform({
+        workspacePath: '/workspace',
+        workspaceState: {
+          [WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE]: false,
+        },
+      });
+      const { key, run, store } = recoveryCase(`legacy-${name}-disabled`, {
+        aborted: false,
+      });
+      await store.write(
+        key,
+        flowRecord(
+          reflectionFlowShared({
+            totalRounds: 1,
+            compileFailureContext: 'legacy compile failure',
+            lastError,
+          }),
+        ),
+      );
+
+      const result = await run();
+      expect(result.outcome).toBe(RUN_OUTCOME.COMPLETED);
+      expect(result.error).toBeUndefined();
+      const shared = ReflectionFlowStateSchema.parse(
+        (await store.read<FlowRecord>(key))?.shared,
+      );
+      expect(shared.compileFailureContext).toBeUndefined();
+      expect(shared.unresolvedCompileRejection).toBeUndefined();
+      expect(shared.lastError).toBeUndefined();
+    },
+  );
 
   it('clears a persisted cancellation latch when resuming a workflow', async () => {
     const { key, run, store } = recoveryCase('cancelled-latch');

--- a/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
+++ b/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
@@ -37,12 +37,12 @@ interface FakeShared extends RoundAwareState {
   contextSeenByRound: Record<number, string | undefined>;
   /** Round indices that should simulate a compile failure. */
   failingRounds: number[];
+  /** Round indices with an explicit successful compile result. */
+  successfulRounds: number[];
   /** Round indices after which execution should be cancelled. */
   cancellingRounds: number[];
-  /** Mirrors the reject-on-compile-failure setting read by OutputNode. */
-  rejectOnCompileFailure: boolean;
-  /** Mirrors OutputNode's compile-failure context (set on failure, consumed next round). */
-  compileFailureContext?: string;
+  /** Durable rejection, separate from one-shot prompt feedback. */
+  unresolvedCompileRejection?: boolean;
 }
 
 /**
@@ -61,11 +61,11 @@ class FakeRoundNode extends BaseNode<FakeShared> {
       shared.compileFailureContext;
     delete shared.compileFailureContext;
 
-    if (
-      shared.rejectOnCompileFailure &&
-      shared.failingRounds.includes(shared.currentRound)
-    ) {
+    if (shared.failingRounds.includes(shared.currentRound)) {
       shared.compileFailureContext = `compile failed on round ${shared.currentRound}`;
+      shared.unresolvedCompileRejection = true;
+    } else if (shared.successfulRounds.includes(shared.currentRound)) {
+      delete shared.unresolvedCompileRejection;
     }
     if (shared.cancellingRounds.includes(shared.currentRound)) {
       this.abortController?.abort();
@@ -80,13 +80,45 @@ class UnexpectedRoundNode extends BaseNode<FakeShared> {
   }
 }
 
-function makeFlow(kv = createFakeKv()) {
+class ConsumeCompileFeedbackNode extends BaseNode<FakeShared> {
+  override async post(shared: FakeShared): Promise<undefined> {
+    delete shared.compileFailureContext;
+    return undefined;
+  }
+}
+
+class CrashingRoundNode extends BaseNode<FakeShared> {
+  override async post(): Promise<never> {
+    throw new Error('crashed after prompt preparation');
+  }
+}
+
+class DisableRejectionDuringFinalRepairNode extends BaseNode<FakeShared> {
+  constructor(private readonly policy: { enabled: boolean }) {
+    super();
+  }
+
+  override async post(shared: FakeShared): Promise<undefined> {
+    shared.roundsRun.push(shared.currentRound);
+    if (shared.currentRound === 0) {
+      shared.compileFailureContext = 'compile failed on round 0';
+      shared.unresolvedCompileRejection = true;
+    } else {
+      delete shared.compileFailureContext;
+      this.policy.enabled = false;
+    }
+    return undefined;
+  }
+}
+
+function makeFlow(kv = createFakeKv(), rejectOnCompileFailure = true) {
   const abortController = new AbortController();
   const node = new FakeRoundNode(abortController);
   const logger = new TraceEmitter();
   /** `{ index, total }` each round stage opened with, in call order. */
   const stages: Array<{ index: number; total: number }> = [];
   const flow = new RoundPersistedFlow<FakeShared>(node, kv, {
+    getRejectOnCompileFailure: () => rejectOnCompileFailure,
     callbacks: {
       createRoundStage: (roundIndex, parent, shared) => {
         const stage = { index: roundIndex, total: shared.totalRounds };
@@ -111,18 +143,21 @@ function initialShared(overrides: Partial<FakeShared>): FakeShared {
     roundsRun: [],
     contextSeenByRound: {},
     failingRounds: [],
+    successfulRounds: [0, 1, 2],
     cancellingRounds: [],
-    rejectOnCompileFailure: true,
     ...overrides,
   };
 }
 
-async function runFlow(overrides: Partial<FakeShared>): Promise<{
+async function runFlow(
+  overrides: Partial<FakeShared>,
+  rejectOnCompileFailure = true,
+): Promise<{
   shared: FakeShared;
   stages: Array<{ index: number; total: number }>;
   outcome: RunOutcome;
 }> {
-  const { flow, stages } = makeFlow();
+  const { flow, stages } = makeFlow(undefined, rejectOnCompileFailure);
   const outcome = await flow.run(initialShared(overrides));
   return { shared: (await flow.getShared())!, stages, outcome };
 }
@@ -140,12 +175,38 @@ async function expectFlowDidNotResume(
 }
 
 describe('RoundPersistedFlow compile-failure round limit', () => {
-  it('passes compile-failure feedback into a remaining configured round', async () => {
+  it('completes after an explicit compile success resolves a prior rejection', async () => {
     const { shared, outcome } = await runFlow({ failingRounds: [0] });
 
     expect(shared.roundsRun).toEqual([0, 1]);
     expect(shared.contextSeenByRound[1]).toBe('compile failed on round 0');
+    expect(shared.unresolvedCompileRejection).toBeUndefined();
     expect(outcome).toBe(RUN_OUTCOME.COMPLETED);
+  });
+
+  it('fails a single-round run with an unresolved compile rejection', async () => {
+    const { shared, outcome } = await runFlow({
+      totalRounds: 1,
+      failingRounds: [0],
+    });
+
+    expect(shared.roundsRun).toEqual([0]);
+    expect(shared.unresolvedCompileRejection).toBe(true);
+    expect(shared.lastError).toBeUndefined();
+    expect(outcome).toBe(RUN_OUTCOME.FAILED);
+  });
+
+  it('fails when the final round has no compile result after prior rejection', async () => {
+    const { shared, outcome } = await runFlow({
+      failingRounds: [0],
+      successfulRounds: [],
+    });
+
+    expect(shared.roundsRun).toEqual([0, 1]);
+    expect(shared.contextSeenByRound[1]).toBe('compile failed on round 0');
+    expect(shared.compileFailureContext).toBeUndefined();
+    expect(shared.unresolvedCompileRejection).toBe(true);
+    expect(outcome).toBe(RUN_OUTCOME.FAILED);
   });
 
   it('cancels when non-final compile feedback cannot reach the next round', async () => {
@@ -157,6 +218,7 @@ describe('RoundPersistedFlow compile-failure round limit', () => {
 
     expect(shared.roundsRun).toEqual([0]);
     expect(shared.compileFailureContext).toBe('compile failed on round 0');
+    expect(shared.unresolvedCompileRejection).toBe(true);
     expect(outcome).toBe(RUN_OUTCOME.CANCELLED);
   });
 
@@ -180,26 +242,84 @@ describe('RoundPersistedFlow compile-failure round limit', () => {
     expect(outcome).toBe(RUN_OUTCOME.FAILED);
   });
 
-  it('fails without adding a repair round when final compile failure collides with cancellation', async () => {
+  it('does not complete when cancellation lands after prompt feedback was consumed', async () => {
     const { shared, outcome } = await runFlow({
-      failingRounds: [1],
+      failingRounds: [0],
+      successfulRounds: [],
       cancellingRounds: [1],
     });
 
     expect(shared.roundsRun).toEqual([0, 1]);
-    expect(shared.compileFailureContext).toBe('compile failed on round 1');
+    expect(shared.contextSeenByRound[1]).toBe('compile failed on round 0');
+    expect(shared.compileFailureContext).toBeUndefined();
+    expect(shared.unresolvedCompileRejection).toBe(true);
     expect(outcome).toBe(RUN_OUTCOME.FAILED);
   });
 
-  it('retains completed behavior when compile-failure rejection is disabled', async () => {
-    const { shared, outcome } = await runFlow({
-      failingRounds: [1],
-      rejectOnCompileFailure: false,
+  it('persists unresolved rejection when execution crashes after prompt consumption', async () => {
+    const kv = createFakeKv();
+    const prepare = new ConsumeCompileFeedbackNode();
+    prepare.next(new CrashingRoundNode());
+    const flow = new RoundPersistedFlow<FakeShared>(prepare, kv, {
+      getRejectOnCompileFailure: () => true,
+    });
+    const shared = initialShared({
+      currentRound: 1,
+      totalRounds: 2,
+      compileFailureContext: 'compile failed on round 0',
+      unresolvedCompileRejection: true,
     });
 
-    expect(shared.roundsRun).toEqual([0, 1]);
-    expect(shared.compileFailureContext).toBeUndefined();
-    expect(outcome).toBe(RUN_OUTCOME.COMPLETED);
+    await expect(flow.run(shared)).rejects.toThrow(
+      'crashed after prompt preparation',
+    );
+
+    expect((await flow.getShared())?.compileFailureContext).toBeUndefined();
+    expect((await flow.getShared())?.unresolvedCompileRejection).toBe(true);
+  });
+
+  it('accepts a recorded rejection when policy is disabled during a final repair with no compile result', async () => {
+    const kv = createFakeKv();
+    const policy = { enabled: true };
+    const flow = new RoundPersistedFlow<FakeShared>(
+      new DisableRejectionDuringFinalRepairNode(policy),
+      kv,
+      { getRejectOnCompileFailure: () => policy.enabled },
+    );
+
+    await expect(flow.run(initialShared({}))).resolves.toBe(
+      RUN_OUTCOME.COMPLETED,
+    );
+
+    expect((await flow.getShared())?.roundsRun).toEqual([0, 1]);
+    expect((await flow.getShared())?.compileFailureContext).toBeUndefined();
+    expect(
+      (await flow.getShared())?.unresolvedCompileRejection,
+    ).toBeUndefined();
+  });
+
+  it('deactivates persisted rejection before the cap guard when rejection is disabled', async () => {
+    const kv = createFakeKv();
+    const { flow, stages } = makeFlow(kv, false);
+    const persisted = initialShared({
+      currentRound: 1,
+      totalRounds: 1,
+      compileFailureContext: 'compile failed on round 0',
+      unresolvedCompileRejection: true,
+    });
+    await kv.write(flowKey(kv.getExecutionId()), {
+      schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
+      shared: persisted,
+      cursor: { nextNodeId: 'start' },
+    } satisfies FlowRecord);
+
+    await expect(flow.run(persisted)).resolves.toBe(RUN_OUTCOME.COMPLETED);
+
+    expect((await flow.getShared())?.compileFailureContext).toBeUndefined();
+    expect(
+      (await flow.getShared())?.unresolvedCompileRejection,
+    ).toBeUndefined();
+    expect(stages).toEqual([]);
   });
 
   it('does not resume a persisted legacy repair round at the configured limit', async () => {
@@ -209,6 +329,7 @@ describe('RoundPersistedFlow compile-failure round limit', () => {
       currentRound: 2,
       totalRounds: 2,
       compileFailureContext: 'compile failed on round 1',
+      unresolvedCompileRejection: true,
     });
     await kv.write(flowKey(kv.getExecutionId()), {
       schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
@@ -221,10 +342,14 @@ describe('RoundPersistedFlow compile-failure round limit', () => {
     await expectFlowDidNotResume(flow, kv, stages);
   });
 
-  it('does not resume a persisted round excluded by a lowered round count', async () => {
+  it('fails unresolved rejection when a resumed round cap is lowered', async () => {
     const kv = createFakeKv();
     const { flow, stages } = makeFlow(kv);
-    const persisted = initialShared({ currentRound: 1, totalRounds: 3 });
+    const persisted = initialShared({
+      currentRound: 1,
+      totalRounds: 3,
+      unresolvedCompileRejection: true,
+    });
     await kv.write(flowKey(kv.getExecutionId()), {
       schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
       shared: persisted,
@@ -233,9 +358,37 @@ describe('RoundPersistedFlow compile-failure round limit', () => {
     const synced = { ...persisted, totalRounds: 1 };
     await flow.setShared(synced);
 
-    await expect(flow.run(synced)).resolves.toBe(RUN_OUTCOME.COMPLETED);
+    await expect(flow.run(synced)).resolves.toBe(RUN_OUTCOME.FAILED);
 
     await expectFlowDidNotResume(flow, kv, stages);
+  });
+
+  it('allows a raised cap to resolve persisted rejection with explicit success', async () => {
+    const kv = createFakeKv();
+    const { flow, stages } = makeFlow(kv);
+    const persisted = initialShared({
+      currentRound: 0,
+      totalRounds: 1,
+      compileFailureContext: 'compile failed on round 0',
+      unresolvedCompileRejection: true,
+    });
+    await kv.write(flowKey(kv.getExecutionId()), {
+      schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
+      shared: persisted,
+      cursor: { nextNodeId: null },
+    } satisfies FlowRecord);
+    const synced = { ...persisted, totalRounds: 2 };
+    await flow.setShared(synced);
+
+    await expect(flow.run(synced)).resolves.toBe(RUN_OUTCOME.COMPLETED);
+
+    expect(
+      (await flow.getShared())?.unresolvedCompileRejection,
+    ).toBeUndefined();
+    expect(stages).toEqual([
+      { index: 0, total: 2 },
+      { index: 1, total: 2 },
+    ]);
   });
 
   it('still resumes a valid persisted cursor within the configured limit', async () => {
@@ -244,6 +397,7 @@ describe('RoundPersistedFlow compile-failure round limit', () => {
     start.on('resume', new FakeRoundNode());
     const stages: number[] = [];
     const flow = new RoundPersistedFlow<FakeShared>(start, kv, {
+      getRejectOnCompileFailure: () => true,
       callbacks: {
         createRoundStage: (roundIndex) => {
           stages.push(roundIndex);
@@ -333,6 +487,7 @@ describe('RoundPersistedFlow round outcome persistence (#8137)', () => {
         new OutcomeRoundNode(control),
         kv,
         {
+          getRejectOnCompileFailure: () => true,
           callbacks: {
             createRoundStage: (roundIndex, parent, shared) =>
               logger.openStage(`r${roundIndex}`, {

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -96,12 +96,15 @@ function createOutputNode(
   logger: AgentTrace = noopTrace,
   outputState = createOutputState(),
   signal?: AbortSignal,
+  rejectOnCompileFailure = true,
+  getRejectOnCompileFailure = () => rejectOnCompileFailure,
 ): OutputNode {
   return new OutputNode().setServices({
     streamId,
     runScope: testRunScope(streamId, { interactions: host, signal }),
     logger,
     outputState,
+    getRejectOnCompileFailure,
   } as unknown as ReflectionServices);
 }
 
@@ -142,6 +145,7 @@ function runOutputPost(
 function compileContextCase(
   streamId: string,
   signal?: AbortSignal,
+  rejectOnCompileFailure = true,
 ): {
   outputNode: OutputNode;
   fixture: ReturnType<typeof createCompileFailureFixture>;
@@ -155,6 +159,7 @@ function compileContextCase(
       noopTrace,
       createOutputState(),
       signal,
+      rejectOnCompileFailure,
     ),
     fixture: createCompileFailureFixture(),
     shared: { roundOutputs: [] } as unknown as ReflectionFlowShared,
@@ -250,7 +255,11 @@ describe('output progress events', () => {
           rejectOnCompileFailure,
       },
     });
-    const { outputNode, fixture, shared } = compileContextCase(streamId);
+    const { outputNode, fixture, shared } = compileContextCase(
+      streamId,
+      undefined,
+      rejectOnCompileFailure,
+    );
 
     await runOutputPost(
       outputNode,
@@ -273,12 +282,54 @@ describe('output progress events', () => {
         'previous workflow round was rejected',
       );
       expect(shared.compileFailureContext).toContain('! Missing $ inserted.');
+      expect(shared.unresolvedCompileRejection).toBe(true);
     } else {
       expect(shared.compileFailureContext).toBeUndefined();
+      expect(shared.unresolvedCompileRejection).toBeUndefined();
     }
   });
 
-  it('clears stale compile failure context after a successful compile result', async () => {
+  it('does not retroactively reject a compile result handled while policy is disabled', async () => {
+    const policy = { enabled: false };
+    const { host } = createRecordingHost();
+    const outputNode = createOutputNode(
+      'stream:compile-context-live-policy',
+      host,
+      noopTrace,
+      createOutputState(),
+      undefined,
+      true,
+      () => policy.enabled,
+    );
+    const fixture = createCompileFailureFixture();
+    const shared = {
+      roundOutputs: [],
+      compileFailureContext: 'old context',
+      unresolvedCompileRejection: true,
+    } as unknown as ReflectionFlowShared;
+
+    await runOutputPost(
+      outputNode,
+      shared,
+      {
+        outputLocation: fixture.outputLocation,
+        currentRound: 1,
+        endTurn: false,
+      },
+      {
+        summary: fixture.summary,
+        compileResult: fixture.compileResult,
+        compiledArtifacts: [],
+        emitCompileFailures: false,
+      },
+    );
+    policy.enabled = true;
+
+    expect(shared.compileFailureContext).toBeUndefined();
+    expect(shared.unresolvedCompileRejection).toBeUndefined();
+  });
+
+  it('clears durable compile rejection after an explicit successful compile result', async () => {
     const { outputNode, fixture } = compileContextCase(
       'stream:compile-context-ok',
     );
@@ -286,6 +337,7 @@ describe('output progress events', () => {
     const shared = {
       roundOutputs: [],
       compileFailureContext: 'old context',
+      unresolvedCompileRejection: true,
     } as unknown as ReflectionFlowShared;
 
     await runOutputPost(
@@ -305,24 +357,19 @@ describe('output progress events', () => {
     );
 
     expect(shared.compileFailureContext).toBeUndefined();
+    expect(shared.unresolvedCompileRejection).toBeUndefined();
   });
 
   it.each([
     {
-      name: 'sets the final compile failure when the run is active',
+      name: 'records durable final compile rejection when the run is active',
       aborted: false,
-      expectedLastError: {
-        message:
-          'Automatic LaTeX compilation failed after the final workflow round.',
-        userRetryable: false,
-      },
     },
     {
-      name: 'does not overwrite cancellation with the final compile failure',
+      name: 'records durable final compile rejection when cancellation races',
       aborted: true,
-      expectedLastError: undefined,
     },
-  ])('$name', async ({ aborted, expectedLastError }) => {
+  ])('$name', async ({ aborted }) => {
     await installPlatform({
       workspaceState: {
         [WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE]: true,
@@ -357,10 +404,39 @@ describe('output progress events', () => {
       },
     );
 
-    expect(shared.lastError).toEqual(expectedLastError);
+    expect(shared.lastError).toBeUndefined();
+    expect(shared.unresolvedCompileRejection).toBe(true);
     expect(shared.compileFailureContext).toContain(
       'previous workflow round was rejected',
     );
+  });
+
+  it('preserves durable rejection when a later round has no compile result', async () => {
+    const { outputNode, fixture } = compileContextCase(
+      'stream:compile-context-missing',
+    );
+    const shared = {
+      roundOutputs: [],
+      unresolvedCompileRejection: true,
+    } as unknown as ReflectionFlowShared;
+
+    await runOutputPost(
+      outputNode,
+      shared,
+      {
+        outputLocation: fixture.outputLocation,
+        currentRound: 1,
+        endTurn: false,
+      },
+      {
+        summary: fixture.summary,
+        compileResult: undefined,
+        compiledArtifacts: [],
+        emitCompileFailures: false,
+      },
+    );
+
+    expect(shared.unresolvedCompileRejection).toBe(true);
   });
 
   it.each([

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -1056,6 +1056,50 @@ describe('runFlowWithLifecycle', () => {
     }
   });
 
+  it('finalizes an outcome-only failure without fabricating provider error facts', async () => {
+    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+      'outcome-only-failure',
+    );
+    const stageEnd = vi.spyOn(ctx.parentStage, 'end');
+    const emit = vi.spyOn(ctx.logger, 'emit');
+    const onError = vi.fn();
+
+    try {
+      const carriedResult = toolUseResult(
+        executionId,
+        streamId,
+        RUN_OUTCOME.FAILED,
+      );
+      const result = await runFlowWithLifecycle(
+        ctx,
+        async () => carriedResult,
+        { isSubagent: true, onError },
+      );
+
+      expect(result).toEqual(carriedResult);
+      expect(storageMocks.finalizeRun).toHaveBeenCalledWith({
+        executionId,
+        outcome: RUN_OUTCOME.FAILED,
+        flowRecord: 'preserve',
+      });
+      expect(stageEnd).toHaveBeenCalledWith(RUN_OUTCOME.FAILED);
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
+      const resultEvent = emit.mock.calls
+        .map(([event]) => event)
+        .find((event) => event.type === 'result');
+      expect(resultEvent).toMatchObject({
+        type: 'result',
+        outcome: RUN_OUTCOME.FAILED,
+      });
+      expect(resultEvent).not.toHaveProperty('error');
+      expect(onError).not.toHaveBeenCalled();
+    } finally {
+      emit.mockRestore();
+      defaultSession().executions.untrack(executionId);
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
   it('projects a thrown abort as cancelled on its own stage outcome', async () => {
     const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
       'outcome-thrown-abort',

--- a/src/test-kernel/agent/runtime/PersistedCompileRejection.vitest.ts
+++ b/src/test-kernel/agent/runtime/PersistedCompileRejection.vitest.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { clearStoreCache, getExecutionStore } from '@agent/storage';
+import { flowKey } from '@agent/node/persistedFlow';
+import { hasTerminalPersistedCompileRejection } from '@agent/runtime/persistedCompileRejection';
+import type { ExecutionId } from '@shared/schemas';
+import { setupPlatform } from '@test/support/setupPlatform';
+import { StorageFS } from '@utils/files/storageFS';
+
+setupPlatform({ workspacePath: '/workspace/persisted-compile-rejection' });
+
+const executionId = 'terminal-compile-rejection' as ExecutionId;
+
+async function writeFlowRecord(shared: Record<string, unknown>): Promise<void> {
+  await getExecutionStore(executionId).write(flowKey(executionId), {
+    shared,
+    cursor: { nextNodeId: 'start' },
+  });
+}
+
+afterEach(async () => {
+  clearStoreCache();
+  await StorageFS.delete('executions', { recursive: true }).catch(
+    () => undefined,
+  );
+});
+
+describe('persisted compile rejection lookup', () => {
+  it.each([
+    [
+      'the unresolved rejection marker',
+      {
+        currentRound: 1,
+        totalRounds: 2,
+        unresolvedCompileRejection: true,
+      },
+    ],
+    [
+      'legacy compile failure context',
+      {
+        currentRound: 1,
+        totalRounds: 2,
+        compileFailureContext: 'The generated document did not compile.',
+      },
+    ],
+  ])('recognizes terminal state from %s', async (_description, shared) => {
+    await writeFlowRecord(shared);
+
+    await expect(
+      hasTerminalPersistedCompileRejection(executionId),
+    ).resolves.toBe(true);
+  });
+});

--- a/src/test-kernel/agent/runtime/selectAutoOpenFinalOutput.vitest.ts
+++ b/src/test-kernel/agent/runtime/selectAutoOpenFinalOutput.vitest.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import type { WorkflowFlowResult } from '@agent/runtime/AgentFlowResult';
+import { selectAutoOpenFinalOutput } from '@agent/runtime/selectAutoOpenFinalOutput';
+import {
+  RUN_OUTCOME,
+  type ExecutionId,
+  type OutputFileSummary,
+  type StreamTabId,
+} from '@shared/schemas';
+import { setupPlatform } from '@test/support/setupPlatform';
+
+const OUTPUT = {
+  round: 0,
+  relativePath: 'result.pdf',
+  absolutePath: '/tmp/result.pdf',
+  location: 'runStorage',
+  originalPath: null,
+  added: null,
+  removed: null,
+} satisfies OutputFileSummary;
+
+function workflowResult(
+  outcome: WorkflowFlowResult['outcome'],
+): WorkflowFlowResult {
+  return {
+    category: 'workflow',
+    outcome,
+    executionId: 'auto-open-output' as ExecutionId,
+    streamId: 'workflow@gpt54#auto-open-output' as StreamTabId,
+    outputs: [OUTPUT],
+    compileFailures: [],
+  };
+}
+
+describe('selectAutoOpenFinalOutput', () => {
+  setupPlatform({
+    config: { 'texra.agentOutputs.autoOpenFinal': true },
+  });
+
+  it.each([RUN_OUTCOME.CANCELLED, RUN_OUTCOME.FAILED])(
+    'does not select partial output from a %s workflow',
+    (outcome) => {
+      expect(
+        selectAutoOpenFinalOutput(workflowResult(outcome)),
+      ).toBeUndefined();
+    },
+  );
+});

--- a/src/test-kernel/cli/CliRootArgs.vitest.ts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.ts
@@ -838,7 +838,7 @@ describe('CLI root argument routing', () => {
     });
   });
 
-  it('reports missing workflow outputs as a failed copy operation', async () => {
+  it('keeps a failed workflow with no output in run storage', async () => {
     await expect(
       resolveWorkflowOutput(
         'corrected.tex',
@@ -852,11 +852,13 @@ describe('CLI root argument routing', () => {
           compileFailures: [],
         },
         createRunCommandCliContext(),
-        {},
+        { runDirectory: '/tmp/runs/execution-without-output' },
       ),
-    ).rejects.toThrow(
-      'Workflow error without a generated output; corrected.tex was not written.',
-    );
+    ).resolves.toMatchObject({
+      outcome: RUN_OUTCOME.FAILED,
+      runDirectory: '/tmp/runs/execution-without-output',
+      outputs: [],
+    });
   });
 
   it('restores one requested workflow output path for resume', () => {

--- a/src/test-kernel/cli/ToolUseResumeData.vitest.ts
+++ b/src/test-kernel/cli/ToolUseResumeData.vitest.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { clearStoreCache, getExecutionStore } from '@agent/storage';
+import type { AgentConfig } from '@agent/runtime';
+import { flowKey } from '@agent/node/persistedFlow';
+import { readCliResumeDataForListing } from '@cli/runtime/toolUseResumeData';
+import type { ExecutionId } from '@shared/schemas';
+import { setupPlatform } from '@test/support/setupPlatform';
+import { StorageFS } from '@utils/files/storageFS';
+
+setupPlatform({ workspacePath: '/workspace/cli-resume-listing' });
+
+const config = {
+  agent: 'correct',
+  agentCategory: 'workflow',
+  model: 'deepseekT',
+} as AgentConfig;
+
+async function writeFlowRecord(
+  executionId: ExecutionId,
+  shared: Record<string, unknown>,
+): Promise<void> {
+  await getExecutionStore(executionId).write(flowKey(executionId), {
+    shared,
+    cursor: { nextNodeId: 'start' },
+  });
+}
+
+afterEach(async () => {
+  clearStoreCache();
+  await StorageFS.delete('executions', { recursive: true }).catch(
+    () => undefined,
+  );
+});
+
+describe('CLI listing resume data', () => {
+  it.each([
+    [
+      'the unresolved rejection marker',
+      {
+        currentRound: 1,
+        totalRounds: 2,
+        unresolvedCompileRejection: true,
+      },
+    ],
+    [
+      'legacy compile failure context',
+      {
+        currentRound: 1,
+        totalRounds: 2,
+        compileFailureContext: 'The generated document did not compile.',
+      },
+    ],
+  ])(
+    'does not advertise a failed workflow with terminal %s as resumable',
+    async (description, shared) => {
+      const executionId =
+        `workflow-terminal-${description.replaceAll(' ', '-')}` as ExecutionId;
+      await writeFlowRecord(executionId, shared);
+
+      await expect(
+        readCliResumeDataForListing(executionId, config),
+      ).resolves.toBeNull();
+    },
+  );
+});

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
@@ -765,6 +765,58 @@ describe('CLI workflow run command', () => {
     });
   });
 
+  it.each([
+    {
+      label: '--output',
+      init: { output: 'polished.tex' },
+      destination: (root: string) => path.join(root, 'polished.tex'),
+    },
+    {
+      label: '--output-dir',
+      init: { outputDir: 'out' },
+      destination: (root: string) => path.join(root, 'out', 'paper.tex'),
+    },
+  ])(
+    'keeps failed output in run storage and preserves the requested $label destination',
+    async ({ init, destination }) => {
+      await withTempDir('texra-workflow-', async (root) => {
+        const generated = await writeGeneratedOutput(root);
+        const outputSummary = runOutputSummary(
+          generated,
+          path.join(root, 'paper.tex'),
+        );
+        mockWorkflowExecution(
+          workflowExecution('exec-failed-output', {
+            outcome: RUN_OUTCOME.FAILED,
+            outputs: [outputSummary],
+          }),
+          true,
+        );
+        const target = destination(root);
+        await fs.mkdir(path.dirname(target), { recursive: true });
+        await fs.writeFile(target, 'keep-me');
+
+        const exitCode = await runWorkflow(
+          init,
+          createRunCommandCliContext({ cwd: root }),
+        );
+
+        expect(exitCode).toBe(CliExitCode.AgentError);
+        await expect(fs.readFile(target, 'utf8')).resolves.toBe('keep-me');
+        const emission = mocks.emitCliResult.mock.calls[0]?.[1];
+        expect(emission?.json).toMatchObject({
+          outcome: RUN_OUTCOME.FAILED,
+          outputs: [outputSummary],
+          runDirectory: '/tmp/runs/exec-failed-output',
+        });
+        expect(emission?.json).not.toHaveProperty('copiedOutput');
+        expect(emission?.json).not.toHaveProperty('copiedOutputs');
+        expect(emission?.text).toContain('FAILED');
+        expect(emission?.text).toContain('/tmp/runs/exec-failed-output');
+      });
+    },
+  );
+
   it('leaves a pre-existing --output destination untouched for a cancelled run', async () => {
     await withTempDir('texra-workflow-', async (root) => {
       const destination = path.join(root, 'polished.tex');
@@ -970,6 +1022,53 @@ describe('CLI workflow run command', () => {
         kind: 'checkpoint',
         flowRecord: {
           shared: { lastError: { message: 'provider failed' } },
+          cursor: { nextNodeId: 'start' },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects recovery advertising for terminal unresolved compile rejection', async () => {
+    await runWorkflow();
+    const canAdvertise =
+      mocks.executeCliConfig.mock.calls[0]?.[2]
+        .canAdvertiseInterruptedExecution;
+
+    expect(
+      canAdvertise?.({
+        kind: 'checkpoint',
+        flowRecord: {
+          shared: {
+            currentRound: 1,
+            totalRounds: 2,
+            unresolvedCompileRejection: true,
+          },
+          cursor: { nextNodeId: 'start' },
+        },
+      }),
+    ).toBe(false);
+    expect(
+      canAdvertise?.({
+        kind: 'checkpoint',
+        flowRecord: {
+          shared: {
+            currentRound: 0,
+            totalRounds: 2,
+            unresolvedCompileRejection: true,
+          },
+          cursor: { nextNodeId: 'start' },
+        },
+      }),
+    ).toBe(true);
+    expect(
+      canAdvertise?.({
+        kind: 'checkpoint',
+        flowRecord: {
+          shared: {
+            currentRound: 1,
+            totalRounds: 2,
+            compileFailureContext: 'legacy compile failure',
+          },
           cursor: { nextNodeId: 'start' },
         },
       }),


### PR DESCRIPTION
## Summary

- separate durable unresolved compile rejection from one-shot repair prompt feedback
- keep rejection through cancellation, crashes, and absent compile results until explicit compile success or policy disablement
- migrate legacy persisted rejection state and remove only the exact synthetic final-compile error
- publish and auto-open workflow artifacts only for `COMPLETED` outcomes
- label failed CLI output and suppress terminal rejection from resume advertising without deleting its checkpoint
- define compile rejection as an outcome-only domain failure rather than fabricated provider/runtime error metadata

## Tests

- 10 focused test files: 237 passed, 1 skipped
- workspace, test-kernel, and CLI typechecks passed
- changed-file ESLint and Prettier passed
- `git diff --check` passed
- independent scoped review found no remaining issues

Closes #11672