### PR TITLE
refactor(shared): retire test-only schema exports

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1598,30 +1598,6 @@
       "name": "ActiveSkillSummarySchema"
     },
     {
-      "file": "src/shared/schemas/diffResult.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "DiffResultDisplaySchema"
-    },
-    {
-      "file": "src/shared/schemas/mainView/executeMessage.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "MainViewExecuteMessageSchema"
-    },
-    {
-      "file": "src/shared/schemas/output.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "CompileFailureSummaryFromFailureSchema"
-    },
-    {
-      "file": "src/shared/schemas/output.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "OutputFileSummaryFromInfoSchema"
-    },
-    {
       "file": "src/shared/schemas/progressView/outbound.ts",
       "category": "production-dead",
       "kind": "exports",

--- a/src/shared/schemas/diffResult.ts
+++ b/src/shared/schemas/diffResult.ts
@@ -67,8 +67,7 @@ function diffResultToDisplay(entry: DiffResult): DiffResultDisplay {
  * Transform canonical latexdiff entries into flattened display entries for the
  * progress view. Use {@link DiffResultDisplay} for the output shape.
  */
-export const DiffResultDisplaySchema =
-  DiffResultSchema.transform(diffResultToDisplay);
+const DiffResultDisplaySchema = DiffResultSchema.transform(diffResultToDisplay);
 
 function getAbsolutePath(location: FileLocation | null): string {
   return location?.absolutePath ?? '';

--- a/src/shared/schemas/mainView/executeMessage.ts
+++ b/src/shared/schemas/mainView/executeMessage.ts
@@ -17,7 +17,7 @@ export const MainViewExecuteFilesSchema = z.object({
  * command discriminant separately; keeping the payload schema command-free
  * matches the browser-side builder and the execution controller.
  */
-export const MainViewExecuteMessageSchema = z.object({
+const MainViewExecuteMessageSchema = z.object({
   agent: z.string().optional(),
   model: z.string().optional(),
   instruction: z.string().optional(),

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -278,7 +278,7 @@ export const RoundOutputSchema = z.strictObject({
 });
 export type RoundOutput = z.infer<typeof RoundOutputSchema>;
 
-export const OutputFileSummaryFromInfoSchema = OutputFileInfoSchema.transform(
+const OutputFileSummaryFromInfoSchema = OutputFileInfoSchema.transform(
   (output) => ({
     round: output.round,
     relativePath: fileLocationDisplayPath(output.location),
@@ -290,14 +290,15 @@ export const OutputFileSummaryFromInfoSchema = OutputFileInfoSchema.transform(
   }),
 ).pipe(OutputFileSummarySchema);
 
-export const CompileFailureSummaryFromFailureSchema =
-  CompileFailureSchema.transform((failure) => ({
+const CompileFailureSummaryFromFailureSchema = CompileFailureSchema.transform(
+  (failure) => ({
     round: failure.round,
     displayName: failure.displayName,
     outputPath: fileLocationDisplayPath(failure.output),
     logPath: failure.logRelativePath,
     logAbsolutePath: failure.log.absolutePath,
-  })).pipe(CompileFailureSummarySchema);
+  }),
+).pipe(CompileFailureSummarySchema);
 
 export function roundOutputsToOutputSummaries(
   roundOutputs: RoundOutput[],

--- a/src/test-kernel/schemas/DiffResultTransforms.vitest.ts
+++ b/src/test-kernel/schemas/DiffResultTransforms.vitest.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  DiffResultDisplaySchema,
-  parseDiffResultEntries,
-} from '@shared/schemas';
+import { parseDiffResultEntries } from '@shared/schemas';
 
 const canonicalDiffResult = {
   status: 'success',
@@ -56,12 +53,6 @@ const canonicalDisplay = {
 };
 
 describe('DiffResult transforms', () => {
-  it('derives display data from the canonical schema', () => {
-    expect(DiffResultDisplaySchema.parse(canonicalDiffResult)).toEqual(
-      canonicalDisplay,
-    );
-  });
-
   it('parses canonical entries through the public parser', () => {
     expect(parseDiffResultEntries([canonicalDiffResult])).toEqual([
       canonicalDisplay,

--- a/src/test-kernel/schemas/OutputSummaryTransforms.vitest.ts
+++ b/src/test-kernel/schemas/OutputSummaryTransforms.vitest.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  CompileFailureSummaryFromFailureSchema,
-  OutputFileSummaryFromInfoSchema,
   roundOutputsToCompileFailureSummaries,
   roundOutputsToOutputSummaries,
   type CompileFailure,
@@ -65,18 +63,23 @@ function roundOutput(overrides: Partial<RoundOutput> = {}): RoundOutput {
 
 describe('output summary transforms', () => {
   it('projects rich output metadata to the flattened summary shape', () => {
-    const summary = OutputFileSummaryFromInfoSchema.parse(
-      outputFile({
-        lineage: {
-          original: workspace('src/main.tex', '/workspace/src/main.tex'),
-          diffBase: workspace(
-            'snapshots/main.tex',
-            '/run/r1/original/main.tex',
-          ),
-        },
-        diff: { added: 7, removed: 3 },
+    const [summary] = roundOutputsToOutputSummaries([
+      roundOutput({
+        round: 1,
+        outputs: [
+          outputFile({
+            lineage: {
+              original: workspace('src/main.tex', '/workspace/src/main.tex'),
+              diffBase: workspace(
+                'snapshots/main.tex',
+                '/run/r1/original/main.tex',
+              ),
+            },
+            diff: { added: 7, removed: 3 },
+          }),
+        ],
       }),
-    );
+    ]);
 
     expect(summary).toEqual({
       round: 1,
@@ -90,11 +93,11 @@ describe('output summary transforms', () => {
   });
 
   it('falls back to the absolute path for external output locations', () => {
-    const summary = OutputFileSummaryFromInfoSchema.parse(
-      outputFile({
-        location: external('/tmp/main.pdf'),
+    const [summary] = roundOutputsToOutputSummaries([
+      roundOutput({
+        outputs: [outputFile({ location: external('/tmp/main.pdf') })],
       }),
-    );
+    ]);
 
     expect(summary.relativePath).toBe('/tmp/main.pdf');
     expect(summary.absolutePath).toBe('/tmp/main.pdf');
@@ -114,16 +117,17 @@ describe('output summary transforms', () => {
   });
 
   it('projects compile failures to flattened paths', () => {
-    const workspaceSummary = CompileFailureSummaryFromFailureSchema.parse(
-      compileFailure({
-        output: workspace('build/main.pdf', '/workspace/build/main.pdf'),
-      }),
-    );
-    const externalSummary = CompileFailureSummaryFromFailureSchema.parse(
-      compileFailure({
-        output: external('/tmp/main.pdf'),
-      }),
-    );
+    const [workspaceSummary, externalSummary] =
+      roundOutputsToCompileFailureSummaries([
+        roundOutput({
+          compileFailures: [
+            compileFailure({
+              output: workspace('build/main.pdf', '/workspace/build/main.pdf'),
+            }),
+            compileFailure({ output: external('/tmp/main.pdf') }),
+          ],
+        }),
+      ]);
 
     expect(workspaceSummary.outputPath).toBe('build/main.pdf');
     expect(workspaceSummary.logPath).toBe('logs/main.log');

--- a/src/test-kernel/shared/MainViewExecuteMessage.vitest.ts
+++ b/src/test-kernel/shared/MainViewExecuteMessage.vitest.ts
@@ -4,7 +4,6 @@ import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import {
   AgentCategory,
   MainViewExecuteInboundMessageSchema,
-  MainViewExecuteMessageSchema,
 } from '@shared/schemas';
 import {
   buildMainViewExecuteMessage,
@@ -122,7 +121,6 @@ describe('MainView execute message builder', () => {
       }),
     );
 
-    expect(MainViewExecuteMessageSchema.parse(message)).toEqual(message);
     expect(
       MainViewExecuteInboundMessageSchema.parse({
         command: MAIN_VIEW_COMMANDS.EXECUTE,


### PR DESCRIPTION
## Summary

- make four leaf transform schemas private to their owning public parser or aggregate transform
- route the remaining tests through the same public boundaries production uses
- remove duplicate child-schema assertions and four dead-export ratchet entries

## Net elements (R6)

- files: 7 modified, 0 added, 0 deleted
- public exports: 4 removed, 0 added
- dead-code baseline entries: 4 removed
- dependencies and abstractions: 0 added
- net diff: 39 insertions, 70 deletions, for 31 fewer lines

## Consumer counts (R8)

- `DiffResultDisplaySchema`: 0 external production consumers, 1 internal owner, and 1 duplicate direct test call
- `MainViewExecuteMessageSchema`: 0 external production consumers, 1 parent-schema owner, and 1 duplicate direct test assertion
- `OutputFileSummaryFromInfoSchema`: 0 external production consumers, 1 aggregate owner, and 2 direct test calls
- `CompileFailureSummaryFromFailureSchema`: 0 external production consumers, 1 aggregate owner, and 2 direct test calls
- the exported domain types and public parser/aggregate functions remain unchanged

## Validation

- focused Vitest: 3 files, 13 tests passed
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- targeted ESLint for all modified TypeScript files
- authoritative dead-code ratchet: 319 current findings and 319 baselined
- Prettier check
- `git diff --check`

The isolated CI kernel shards and static checks are the whole-suite and full-lint gates.