### PR TITLE
refactor(agent): remove test-only tool result limits

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1184,12 +1184,6 @@
       "name": "rewriteCodexRequestBody"
     },
     {
-      "file": "src/agent/modelHandlers/utils/toolAttachmentUtils.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "checkToolResultTextLimit"
-    },
-    {
       "file": "src/agent/node/persistedFlow.ts",
       "category": "production-dead",
       "kind": "exports",

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -146,14 +146,6 @@ export async function loadAttachmentBuffer(
 }
 
 /**
- * Fixed textual overhead of the message template below (labels, punctuation,
- * the elision marker, and the character-count numbers themselves) reserved
- * out of `maxLength` so head+tail content plus framing never balloons past
- * the caller's requested limit.
- */
-const TRUNCATION_FRAME_OVERHEAD_CHARS = 300;
-
-/**
  * Check if tool result text exceeds the maximum allowed length. Returns a
  * head+tail replacement (with an explicit elision marker) if exceeded,
  * otherwise returns null so the caller keeps the original text.
@@ -163,56 +155,26 @@ const TRUNCATION_FRAME_OVERHEAD_CHARS = 300;
  * entire result (the prior behavior) left repair agents with no error text
  * on exactly the runs that most needed it.
  *
- * The returned string is always bounded by `maxLength`: the default head/tail
- * budgets (`TOOL_RESULT_TRUNCATION_HEAD_CHARS`/`_TAIL_CHARS`) are scaled down
- * whenever a smaller custom `maxLength` can't fit them, and a defensive
- * hard-trim guarantees the invariant even for `maxLength` values too small to
- * fit the message template itself.
- *
  * @param text - The text to check
- * @param maxLength - Maximum allowed length (default: MAX_TOOL_RESULT_TEXT_LENGTH)
  * @returns Truncated head+tail replacement if limit exceeded, null otherwise
  */
-export function checkToolResultTextLimit(
-  text: string,
-  maxLength: number = MAX_TOOL_RESULT_TEXT_LENGTH,
-): string | null {
-  if (text.length <= maxLength) {
+function checkToolResultTextLimit(text: string): string | null {
+  if (text.length <= MAX_TOOL_RESULT_TEXT_LENGTH) {
     return null;
   }
 
-  // `text.length > maxLength` here, so `contentBudget < maxLength < text.length`
-  // — this keeps headLen/tailLen strictly below text.length below, which in
-  // turn keeps elidedChars > 0 (no more "0 characters elided" on near-boundary
-  // sizes where the head budget alone would otherwise cover the whole text).
-  const contentBudget = Math.max(
-    0,
-    maxLength - TRUNCATION_FRAME_OVERHEAD_CHARS,
-  );
-  const headBudget = Math.min(TOOL_RESULT_TRUNCATION_HEAD_CHARS, contentBudget);
-  const tailBudget = Math.min(
-    TOOL_RESULT_TRUNCATION_TAIL_CHARS,
-    contentBudget - headBudget,
-  );
-
-  const headLen = Math.min(headBudget, text.length);
-  const tailLen = Math.min(tailBudget, text.length - headLen);
-  const head = appendHead('', text, headLen);
-  const tail = tailLen > 0 ? appendTail('', text, tailLen) : '';
+  const head = appendHead('', text, TOOL_RESULT_TRUNCATION_HEAD_CHARS);
+  const tail = appendTail('', text, TOOL_RESULT_TRUNCATION_TAIL_CHARS);
   const elidedChars = text.length - head.length - tail.length;
 
   const message =
     `Tool result too large: ${text.length.toLocaleString()} characters ` +
-    `(limit: ${maxLength.toLocaleString()}). Showing the first ${head.length.toLocaleString()} ` +
+    `(limit: ${MAX_TOOL_RESULT_TEXT_LENGTH.toLocaleString()}). Showing the first ${head.length.toLocaleString()} ` +
     `and last ${tail.length.toLocaleString()} characters.\n\n` +
     `${head}\n\n[... ${elidedChars.toLocaleString()} characters elided ...]\n\n${tail}`;
 
-  // Defensive backstop: TRUNCATION_FRAME_OVERHEAD_CHARS is an estimate, not an
-  // exact accounting of the template above, so hard-trim as a last resort to
-  // guarantee the maxLength invariant for every input — including maxLength
-  // values too small to fit the template text at all.
-  return message.length > maxLength
-    ? appendHead('', message, maxLength)
+  return message.length > MAX_TOOL_RESULT_TEXT_LENGTH
+    ? appendHead('', message, MAX_TOOL_RESULT_TEXT_LENGTH)
     : message;
 }
 

--- a/src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports - utils
 import {
-  checkToolResultTextLimit,
   formatToolResultAsText,
   formatToolResultTextWithAttachments,
 } from '@agent/modelHandlers/utils/toolAttachmentUtils';
@@ -25,69 +24,6 @@ function oversizedText(): { head: string; tail: string; text: string } {
     text: head + 'x'.repeat(MAX_TOOL_RESULT_TEXT_LENGTH) + tail,
   };
 }
-
-describe('checkToolResultTextLimit', () => {
-  it('returns null for text within limit', () => {
-    const text = 'a'.repeat(1000);
-    expect(checkToolResultTextLimit(text)).toBeNull();
-  });
-
-  it('returns null for text exactly at limit', () => {
-    const text = 'a'.repeat(MAX_TOOL_RESULT_TEXT_LENGTH);
-    expect(checkToolResultTextLimit(text)).toBeNull();
-  });
-
-  it('keeps head and tail with an elision marker for text exceeding limit', () => {
-    const { head, tail, text } = oversizedText();
-
-    const result = checkToolResultTextLimit(text);
-    expect(result).not.toBeNull();
-    const truncated = result!;
-    expect(truncated).toContain('Tool result too large');
-    expect(truncated).toContain('characters elided');
-    // Head/tail content survives; the elided middle does not.
-    expect(truncated.startsWith('Tool result too large')).toBe(true);
-    expect(truncated).toContain(
-      head.slice(0, TOOL_RESULT_TRUNCATION_HEAD_CHARS),
-    );
-    expect(truncated).toContain(tail.slice(-TOOL_RESULT_TRUNCATION_TAIL_CHARS));
-    expect(truncated).not.toContain('x'.repeat(1000));
-  });
-
-  it('respects custom max length', () => {
-    const text = 'a'.repeat(150);
-    expect(checkToolResultTextLimit(text, 200)).toBeNull();
-    const error = checkToolResultTextLimit(text, 100);
-    expect(error).not.toBeNull();
-    const replacement = error!;
-    expect(replacement).toContain('Tool result too large');
-    // The whole point of maxLength is to bound context size — the replacement
-    // itself must never exceed the requested limit, even though the default
-    // head/tail budgets (4,000 / 50,000 chars) are far larger than 100.
-    expect(replacement.length).toBeLessThanOrEqual(100);
-  });
-
-  it('bounds the replacement by maxLength even when default head/tail budgets would overshoot it', () => {
-    const text = 'a'.repeat(10_000);
-    const maxLength = 500;
-    const error = checkToolResultTextLimit(text, maxLength);
-    expect(error).not.toBeNull();
-    expect(error!.length).toBeLessThanOrEqual(maxLength);
-  });
-
-  it('always elides a positive count when the head budget alone would cover the whole text', () => {
-    // text.length is only slightly over maxLength, and well under the
-    // hardcoded head budget (TOOL_RESULT_TRUNCATION_HEAD_CHARS = 4,000) — the
-    // near-boundary case where an unscaled head budget would swallow the
-    // entire text, leaving a nonsensical "0 characters elided" marker.
-    const text = 'a'.repeat(1500);
-    const maxLength = 1000;
-    const error = checkToolResultTextLimit(text, maxLength);
-    expect(error).not.toBeNull();
-    expect(error!.length).toBeLessThanOrEqual(maxLength);
-    expect(error!).not.toContain('[... 0 characters elided');
-  });
-});
 
 describe('formatToolResultAsText', () => {
   it.each([
@@ -150,6 +86,7 @@ describe('formatToolResultAsText', () => {
     expect(result).toContain('HEAD_MARKER_');
     expect(result).toContain('TAIL_MARKER_');
     expect(result).not.toContain('x'.repeat(1000));
+    expect(result.length).toBeLessThanOrEqual(MAX_TOOL_RESULT_TEXT_LENGTH);
   });
 
   it('returns normal result when within limit', () => {

--- a/src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts
@@ -7,11 +7,7 @@ import {
   formatToolResultTextWithAttachments,
 } from '@agent/modelHandlers/utils/toolAttachmentUtils';
 import { extractToolAttachments } from '@agent/core/tools/toolAttachmentExtraction';
-import {
-  MAX_TOOL_RESULT_TEXT_LENGTH,
-  TOOL_RESULT_TRUNCATION_HEAD_CHARS,
-  TOOL_RESULT_TRUNCATION_TAIL_CHARS,
-} from '@agent/modelHandlers/contextManagementConstants';
+import { MAX_TOOL_RESULT_TEXT_LENGTH } from '@agent/modelHandlers/contextManagementConstants';
 import type { ToolFileAttachment } from '@shared/schemas';
 
 /** Head and tail well over their truncation budgets, with an elidable middle. */


### PR DESCRIPTION
## Summary

- keep tool-result truncation on the one fixed production limit
- remove the test-only custom-limit parameter and its unreachable scaling branches
- make the single-use helper private and retain the public oversized-result regression

## Net elements (R6)

- files: 3 modified, 0 added, 0 deleted
- public exports: 1 removed, 0 added
- implementation surface: 1 unused parameter, its scaling branches, and 1 framing estimate removed
- tests: 6 helper-internal cases removed; the public boundary still checks head, tail, elision, and the hard limit
- net diff: 9 insertions, 120 deletions, for 111 fewer lines

## Consumer counts (R8)

- `checkToolResultTextLimit`: exactly 1 same-file production caller and 1 test-file importer with 7 direct calls
- custom `maxLength`: 0 production callers and 4 test-only calls
- live policy: every production call still uses `MAX_TOOL_RESULT_TEXT_LENGTH`, a 4,000-character head, and a 50,000-character tail
- no attachment loading, formatting, elision, or hard-cap path was removed

## Validation

- focused `toolAttachmentUtils.vitest.ts`: 22 tests passed
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- targeted ESLint and Prettier checks
- authoritative dead-code ratchet: 322 current findings and 322 baselined
- `git diff --check`

The isolated CI kernel shards and static checks are the whole-suite and full-lint gates.