### PR TITLE
test(transcript): remove retired sidecar coverage

### DIFF
--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -831,12 +831,10 @@ describe('StreamSnapshotStore', () => {
     await installPlatform();
     await writeStreamFile(STREAM, 'meta.json', {
       schemaVersion: 0,
-      description: 'Unsupported stale session',
     });
 
     const store = new StreamSnapshotStore();
     await store.load([STREAM]);
-    expect(store.getRunMetadata(STREAM).description).toBeUndefined();
 
     snapshotFacts(store).setParentStream(STREAM, OTHER_STREAM);
     await store.flush();
@@ -844,12 +842,9 @@ describe('StreamSnapshotStore', () => {
     const raw = (await readStreamFile(STREAM, 'meta.json')) as {
       schemaVersion?: unknown;
       parentStreamId?: unknown;
-      description?: unknown;
     };
     expect(raw.schemaVersion).toBe(STREAM_TAB_META_SCHEMA_VERSION);
     expect(raw.parentStreamId).toBe(OTHER_STREAM);
-    // The rejected file's fields do not leak into the fresh current record.
-    expect(raw.description).toBeUndefined();
   });
 
   it('leaves the run config absent when an execution config is unreadable', async () => {
@@ -870,32 +865,6 @@ describe('StreamSnapshotStore', () => {
     expect(store.getRunMetadata(STREAM).config).toBeUndefined();
     expect(store.getRunMetadata(STREAM).identity).toBeUndefined();
     expect(store.getRunMetadata(STREAM).executionId).toBe(executionId);
-  });
-
-  it('strips a retired runDescriptor sidecar without reading its FK', async () => {
-    // Pre-FK sidecars carried a whole runDescriptor; that shape is retired.
-    // The unknown key is stripped: no FK is lifted out of it, and the rest
-    // of the meta (parentStreamId) survives untouched.
-    await writeMetaFile(STREAM, {
-      parentStreamId: OTHER_STREAM,
-      runDescriptor: {
-        schemaVersion: 1,
-        streamId: STREAM,
-        executionId: 'aa11bb22',
-        agent: 'legacy-search',
-        category: AgentCategory.ToolUse,
-        kind: 'agent',
-      },
-    });
-
-    const store = new StreamSnapshotStore();
-    await store.load([STREAM]);
-
-    expect(store.getRunMetadata(STREAM).executionId).toBeUndefined();
-    await expect(store.read(STREAM)).resolves.toMatchObject({
-      executionId: undefined,
-      parentStreamId: OTHER_STREAM,
-    });
   });
 
   it('drops only a malformed execution FK from meta, loudly', async () => {
@@ -2626,7 +2595,6 @@ describe('StreamSnapshotStore', () => {
     const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
     await writeStreamFile(STREAM, 'meta.json', {
       executionId: 'not-hex!!',
-      description: 'Prior session',
     });
     const snap = await new StreamSnapshotStore().read(STREAM);
     expect(snap.executionId).toBeUndefined();


### PR DESCRIPTION
## Summary

- delete the test for a retired pre-FK `runDescriptor` sidecar shape
- remove stale `description` payloads and assertions from current malformed-sidecar tests
- keep all current execution-FK, parent-stream, schema-version, warning, and persistence coverage

## Net elements (R6)

- files: 1 modified, 0 added, 0 deleted
- tests: 1 retired-format case removed
- production code, exports, dependencies, helpers, and fixtures: 0 added or changed
- net diff: 0 insertions, 32 deletions

## Consumer counts (R8)

- retired `runDescriptor` sidecar reader: 0 production paths; the unknown key is no longer a supported format
- stale `description` snippets: test-only payload fields inside three broader malformed/unsupported cases
- remaining `StreamSnapshotStore` suite: 88 focused tests passed after the deletion

## Validation

- `corepack pnpm exec vitest run src/test-kernel/transcript/StreamSnapshotStore.vitest.ts --maxWorkers=1` (88 passed)
- `corepack pnpm run typecheck:test-kernel`
- targeted ESLint and Prettier checks
- `corepack pnpm run lint`
- `git diff --check`

The isolated CI kernel shards are the whole-suite gate.