### PR TITLE
test(agent): remove redundant internal seam coverage

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1076,12 +1076,6 @@
       "name": "workbenchTab"
     },
     {
-      "file": "src/agent/implementations/agentCreator/agentCreatorFlow.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "ParsedCreatorYamlSchema"
-    },
-    {
       "file": "packages/extension/src/commands/extensionCommandHandlers.ts",
       "category": "production-dead",
       "kind": "exports",

--- a/src/agent/implementations/agentCreator/agentCreatorFlow.ts
+++ b/src/agent/implementations/agentCreator/agentCreatorFlow.ts
@@ -62,7 +62,7 @@ const PromptStringSchema = z.string().refine((value) => value.trim() !== '', {
 // settings) that this loader does not consume. The prompts block is strict so
 // a misspelled key (e.g. `retryPromt`) fails the load instead of being
 // stripped and silently replaced by the built-in fallback.
-export const ParsedCreatorYamlSchema = z.object({
+const ParsedCreatorYamlSchema = z.object({
   prompts: z.strictObject({
     systemPrompt: PromptStringSchema,
     userRequest: PromptStringSchema,

--- a/src/test-kernel/agent/core/ConfigSchemas.vitest.ts
+++ b/src/test-kernel/agent/core/ConfigSchemas.vitest.ts
@@ -3,7 +3,6 @@ import { strict as assert } from 'node:assert';
 
 // Third-party imports
 import { describe, it } from 'vitest';
-import { z } from 'zod';
 
 // Local imports
 import {
@@ -112,33 +111,5 @@ describe('AgentConfigSchema agentSource compatibility', () => {
 
     assert.strictEqual(result.success, false);
     assert.deepStrictEqual(result.error?.issues[0]?.path, ['agentSource']);
-  });
-
-  it('makes an older build reject an inline source rather than drop it', () => {
-    // Forward compatibility is a downgrade scenario: only a widened build can
-    // write `inline`, and an older build validates the same field with the
-    // enum as it stood before. `.nullish()` keeps the field optional, but a
-    // *present* unknown value is a parse error — so the older build fails at
-    // its read boundary rather than silently defaulting the source. Every
-    // persisted read is already written for that: `ExecutionKVStore.readConfig`
-    // goes through `readValidated`, which warns and returns null (the same
-    // "corrupt config" path history views already handle), and
-    // `executionListing`'s backfill logs and skips the entry.
-    const olderBuildSourceSchema = z
-      .enum(['custom', 'builtInWorkflow', 'builtInToolUse', 'remote'])
-      .nullish();
-
-    assert.strictEqual(
-      olderBuildSourceSchema.safeParse('inline').success,
-      false,
-    );
-    assert.strictEqual(
-      olderBuildSourceSchema.safeParse(undefined).success,
-      true,
-    );
-    assert.strictEqual(
-      olderBuildSourceSchema.safeParse('custom').success,
-      true,
-    );
   });
 });

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -150,28 +150,6 @@ describe('AgentLaunchContext', () => {
     ).toHaveLength(1);
   });
 
-  it('does not double-surface a delivered missing-agent banner via the generic toast', async () => {
-    // The delivery-confirmed path for webview-style hosts: the banner was
-    // rendered, so the launch catch must not emit a second generic error.
-    const recording = createRecordingHost({ emitDelivery: true });
-    const session = createTestSession({ interactions: recording.host });
-
-    try {
-      await launchWithMissingAgent(session);
-    } finally {
-      session.dispose();
-    }
-
-    expect(
-      recording.events.filter((event) => event.event === 'requestShowError'),
-    ).toEqual([]);
-    expect(
-      recording.events.filter(
-        (event) => event.event === 'showAgentConfigBanner',
-      ),
-    ).toHaveLength(1);
-  });
-
   it('renders a queued missing-agent banner once a live host replays it', async () => {
     // The retained replay owns the delivery decision: it renders the targeted
     // banner and emits no generic fallback.

--- a/src/test-kernel/agent/runtime/helperModelName.vitest.ts
+++ b/src/test-kernel/agent/runtime/helperModelName.vitest.ts
@@ -42,18 +42,6 @@ describe('resolveEffectiveHelperModel', () => {
 });
 
 describe('getHelperModelName', () => {
-  it('accepts a non-default configured model as-is when ENABLED_MODELS is unset', async () => {
-    await installPlatform({
-      globalState: {
-        [GlobalStateKey.HELPER_MODEL]: 'legacy-helper-model',
-        // ENABLED_MODELS intentionally left unset -- matches a user who has
-        // never touched the Enabled Models checkboxes.
-      },
-    });
-
-    expect(getHelperModelName()).toBe('legacy-helper-model');
-  });
-
   it('falls back to the built-in default when the configured model is not enabled', async () => {
     await installPlatform({
       globalState: {

--- a/src/test-kernel/commands/AgentCreatorTemplateSchema.vitest.ts
+++ b/src/test-kernel/commands/AgentCreatorTemplateSchema.vitest.ts
@@ -7,9 +7,9 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import * as yaml from 'yaml';
 
-import { ParsedCreatorYamlSchema } from '@agent/implementations/agentCreator/agentCreatorFlow';
+import { buildCreatorConfig } from '@agent/implementations/agentCreator/agentCreatorFlow';
 
-// Schema-boundary contract for the bundled agent-creator templates (#8187):
+// Public loader-boundary contract for the bundled agent-creator templates (#8187):
 // malformed prompt blocks must fail loudly at load instead of silently
 // stripping misspelled keys or handing empty prompts to the helper model.
 const TEMPLATES_DIR = resolve(
@@ -29,51 +29,75 @@ const VALID = {
   },
 };
 
-describe('bundled agent-creator template schema', () => {
-  it.each(['agentCreatorWorkflow.yaml', 'agentCreatorToolUse.yaml'])(
-    '%s parses with prompt content preserved verbatim',
-    (fileName) => {
-      const raw = yaml.parse(
-        readFileSync(resolve(TEMPLATES_DIR, fileName), 'utf8'),
-      );
-      const parsed = ParsedCreatorYamlSchema.parse(raw);
-      // No trimming or other rewriting of multiline block-scalar prompts.
-      expect(parsed.prompts).toEqual(raw.prompts);
-      expect(parsed.prompts.systemPrompt.endsWith('\n')).toBe(true);
-    },
-  );
+function buildWithWorkflowPrompts(prompts: Record<string, unknown>) {
+  return buildCreatorConfig({
+    workflowYaml: yaml.stringify({ ...VALID, prompts }),
+    toolUseYaml: yaml.stringify(VALID),
+    workflowSingle: 'workflow template bytes\n',
+    toolUseTpl: 'tool-use template bytes\n',
+  });
+}
 
-  it('accepts top-level metadata keys without prompts-level leniency', () => {
-    expect(ParsedCreatorYamlSchema.parse(VALID).prompts).toEqual(VALID.prompts);
+describe('bundled agent-creator template loading', () => {
+  it('preserves all bundled prompt and agent-template bytes', () => {
+    const files = {
+      workflowYaml: readFileSync(
+        resolve(TEMPLATES_DIR, 'agentCreatorWorkflow.yaml'),
+        'utf8',
+      ),
+      toolUseYaml: readFileSync(
+        resolve(TEMPLATES_DIR, 'agentCreatorToolUse.yaml'),
+        'utf8',
+      ),
+      workflowSingle: readFileSync(
+        resolve(TEMPLATES_DIR, 'agentTemplate-workflowSingle.yaml'),
+        'utf8',
+      ),
+      toolUseTpl: readFileSync(
+        resolve(TEMPLATES_DIR, 'agentTemplate-toolUse.yaml'),
+        'utf8',
+      ),
+    };
+    const config = buildCreatorConfig(files);
+
+    for (const [category, raw] of [
+      ['workflow', files.workflowYaml],
+      ['toolUse', files.toolUseYaml],
+    ] as const) {
+      const { prompts } = yaml.parse(raw);
+      // No trimming or other rewriting of multiline block-scalar prompts.
+      expect(config[category].systemPrompt).toBe(prompts.systemPrompt);
+      expect(config[category].userRequest).toBe(prompts.userRequest);
+      expect(config.retryPrompts[category]).toBe(prompts.retryPrompt);
+      expect(config[category].systemPrompt.endsWith('\n')).toBe(true);
+    }
+    expect(config.templates.workflowSingle).toBe(files.workflowSingle);
+    expect(config.templates.toolUse).toBe(files.toolUseTpl);
   });
 
   it.each(['systemPrompt', 'userRequest', 'retryPrompt'])(
     'rejects empty or whitespace-only %s',
     (field) => {
       for (const blank of ['', '  \n']) {
-        const result = ParsedCreatorYamlSchema.safeParse({
-          ...VALID,
-          prompts: { ...VALID.prompts, [field]: blank },
-        });
-        expect(result.success).toBe(false);
+        expect(() =>
+          buildWithWorkflowPrompts({
+            ...VALID.prompts,
+            [field]: blank,
+          }),
+        ).toThrow('prompt must not be empty');
       }
     },
   );
 
   it('rejects misspelled keys inside prompts instead of stripping them', () => {
     const { retryPrompt, ...rest } = VALID.prompts;
-    const result = ParsedCreatorYamlSchema.safeParse({
-      ...VALID,
-      prompts: { ...rest, retryPromt: retryPrompt },
-    });
-    expect(result.success).toBe(false);
-    expect(JSON.stringify(result.error?.issues)).toContain('retryPromt');
+    expect(() =>
+      buildWithWorkflowPrompts({ ...rest, retryPromt: retryPrompt }),
+    ).toThrow('retryPromt');
   });
 
   it('rejects a missing required prompt field', () => {
     const { userRequest: _omitted, ...rest } = VALID.prompts;
-    expect(
-      ParsedCreatorYamlSchema.safeParse({ ...VALID, prompts: rest }).success,
-    ).toBe(false);
+    expect(() => buildWithWorkflowPrompts(rest)).toThrow('userRequest');
   });
 });


### PR DESCRIPTION
## Summary

- delete three tests duplicated by stronger current-contract cases in the same suites
- test bundled creator templates through `buildCreatorConfig`, the public load boundary
- make the creator YAML schema private and remove its dead-export ratchet entry
- retain loud blank, missing, and misspelled prompt failures plus exact bundled prompt/template bytes

## Net elements (R6)

- files: 6 modified, 0 added, 0 deleted
- public exports: 1 removed, 0 added
- dead-code baseline entries: 1 removed
- redundant tests: 3 removed
- net diff: 56 insertions, 101 deletions, for 45 fewer lines

## Consumer counts (R8)

- `ParsedCreatorYamlSchema`: 0 production consumers outside its module and 1 direct test importer; production already enters through `buildCreatorConfig`
- removed older-build enum case: tested Zod enum behavior rather than a live product boundary
- removed live missing-agent banner case: duplicated the immediately adjacent exact event-list assertion
- removed unset helper-model case: duplicated the later runtime-versus-settings case with the same persisted state
- no prompt validation, launch error, helper-model, or template-loading behavior was removed

## Validation

- focused Vitest: 4 files, 33 tests passed
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- targeted ESLint and Prettier checks
- authoritative dead-code ratchet: no new findings
- `git diff --check`

The isolated CI static checks, build, and kernel shards are the final full gates.