### PR TITLE
refactor(agent): remove redundant runtime wrappers

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1265,12 +1265,6 @@
       "file": "src/agent/workflowScript/persistence.ts",
       "category": "production-dead",
       "kind": "exports",
-      "name": "WorkflowScriptPersistenceError"
-    },
-    {
-      "file": "src/agent/workflowScript/persistence.ts",
-      "category": "production-dead",
-      "kind": "exports",
       "name": "writeWorkflowScriptCheckpoint"
     },
     {

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -140,11 +140,6 @@ export async function readPersistedFlowRecord(
   return parsed.data;
 }
 
-function stampFlowRecordSchemaVersion<T extends FlowRecord>(flow: T): T {
-  flow.schemaVersion = FLOW_RECORD_SCHEMA_VERSION;
-  return flow;
-}
-
 /**
  * Stamps the active handler's compatibility key onto a keyless legacy shared
  * record so {@link PersistedFlow.ensureRecord} never sees a stale legacy
@@ -510,10 +505,8 @@ export class PersistedFlow<
   private async persistRecord(flow: FlowRecord, shared: S): Promise<void> {
     this.cachedRecord = null;
     flow.shared = this.serializeShared(shared);
-    await this.kv.write(
-      flowKey(this.runId),
-      stampFlowRecordSchemaVersion(flow),
-    );
+    flow.schemaVersion = FLOW_RECORD_SCHEMA_VERSION;
+    await this.kv.write(flowKey(this.runId), flow);
     this.cachedRecord = flow;
     this.cachedSharedTrusted = true;
     await this.fireProjection(shared);

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -360,14 +360,3 @@ export type AgentRunHandle = Pick<
   | 'deliveryTargetStreamId'
   | 'interrupt'
 >;
-
-/**
- * True when the handle is a child of parentStreamId (not the parent itself).
- */
-export function isChildExecution(
-  handle: AgentExecutionHandle,
-  parentStreamId: StreamTabId,
-): boolean {
-  if (handle.parentStreamId !== parentStreamId) return false;
-  return handle.isChildExecution;
-}

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -36,7 +36,6 @@ import {
 import { formatDuration, onAbort } from '@utils/core';
 import { createListenerSet, type ListenerSet } from '@utils/core/listenerSet';
 import {
-  isChildExecution,
   type AgentExecutionHandle,
   type ExecutionStatusInfo,
   type LiveToolUseFlowContext,
@@ -655,7 +654,7 @@ export class ExecutionRegistry {
       activation.interrupt();
     }
     for (const handle of this.handles.values()) {
-      if (isChildExecution(handle, parentStreamId)) {
+      if (handle.isOwnedBy(parentStreamId)) {
         this.terminate(handle, visited, options);
       }
     }
@@ -675,7 +674,7 @@ export class ExecutionRegistry {
       detachedChildStreamIds.push(activation.childStreamId);
     }
     for (const handle of this.handles.values()) {
-      if (!isChildExecution(handle, parentStreamId)) continue;
+      if (!handle.isOwnedBy(parentStreamId)) continue;
       this.approvals.detachStreamFromParent(handle.childStreamId);
       handle.detach();
       detachedChildStreamIds.push(handle.childStreamId);
@@ -818,7 +817,7 @@ export class ExecutionRegistry {
   getActiveChildren(parentStreamId: StreamTabId): ActiveChildInfo[] {
     const result: ActiveChildInfo[] = [];
     for (const handle of this.handles.values()) {
-      if (!isChildExecution(handle, parentStreamId)) continue;
+      if (!handle.isOwnedBy(parentStreamId)) continue;
       const { status } = this.getStatus(handle);
       result.push({
         executionId: handle.executionId,
@@ -843,7 +842,7 @@ export class ExecutionRegistry {
       return true;
     }
     for (const handle of this.handles.values()) {
-      if (isChildExecution(handle, parentStreamId)) return true;
+      if (handle.isOwnedBy(parentStreamId)) return true;
     }
     return false;
   }

--- a/src/agent/workflowScript/parseScript.ts
+++ b/src/agent/workflowScript/parseScript.ts
@@ -8,13 +8,6 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { WorkflowScriptMetaSchema, type WorkflowScriptMeta } from './types';
 
-export class WorkflowScriptParseError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'WorkflowScriptParseError';
-  }
-}
-
 export interface ParsedWorkflowScript {
   meta: WorkflowScriptMeta;
   /** Script source with the meta `export` keyword stripped, sandbox-ready. */
@@ -36,9 +29,7 @@ function parseProgram(source: string): Program {
       allowReturnOutsideFunction: true,
     });
   } catch (error) {
-    throw new WorkflowScriptParseError(
-      `Invalid workflow script syntax: ${toErrorMessage(error)}`,
-    );
+    throw new Error(`Invalid workflow script syntax: ${toErrorMessage(error)}`);
   }
 }
 
@@ -113,14 +104,14 @@ export function parseWorkflowScript(source: string): ParsedWorkflowScript {
   const program = parseProgram(source);
 
   if (rejectsModuleLoading(program)) {
-    throw new WorkflowScriptParseError(
+    throw new Error(
       'Workflow scripts cannot import modules; use only the injected primitives (agent, parallel, log, phase, args, files).',
     );
   }
 
   const metaDeclaration = exportedMetaDeclaration(program);
   if (!metaDeclaration) {
-    throw new WorkflowScriptParseError(
+    throw new Error(
       'Workflow script must begin with `export const meta = { name, description, ... }` (only whitespace/comments may precede it).',
     );
   }
@@ -143,15 +134,13 @@ export function parseWorkflowScript(source: string): ParsedWorkflowScript {
       { timeout: 250 },
     );
   } catch (error) {
-    throw new WorkflowScriptParseError(
+    throw new Error(
       `meta must be a pure object literal: ${toErrorMessage(error)}`,
     );
   }
   const parsed = WorkflowScriptMetaSchema.safeParse(rawMeta);
   if (!parsed.success) {
-    throw new WorkflowScriptParseError(
-      `Invalid workflow meta: ${z.prettifyError(parsed.error)}`,
-    );
+    throw new Error(`Invalid workflow meta: ${z.prettifyError(parsed.error)}`);
   }
 
   const body =

--- a/src/agent/workflowScript/persistence.ts
+++ b/src/agent/workflowScript/persistence.ts
@@ -71,13 +71,6 @@ export interface WorkflowScriptCheckpoint {
   readonly journal: WorkflowJournalEntry[];
 }
 
-export class WorkflowScriptPersistenceError extends Error {
-  constructor(message: string, options?: ErrorOptions) {
-    super(message, options);
-    this.name = 'WorkflowScriptPersistenceError';
-  }
-}
-
 export interface PersistedWorkflowScriptRunOptions extends Omit<
   WorkflowScriptRunOptions,
   'script' | 'journal' | 'onJournalEntry'
@@ -141,10 +134,9 @@ export async function readWorkflowScriptCheckpoint(
 
   const parsed = WorkflowScriptCheckpointSchema.safeParse(raw);
   if (!parsed.success) {
-    throw new WorkflowScriptPersistenceError(
-      `Workflow checkpoint ${checkpointId} is malformed.`,
-      { cause: parsed.error },
-    );
+    throw new Error(`Workflow checkpoint ${checkpointId} is malformed.`, {
+      cause: parsed.error,
+    });
   }
   const checkpoint = parsed.data;
   return {
@@ -171,7 +163,7 @@ export async function writeWorkflowScriptCheckpoint(
       journal: orderedJournal(checkpoint.journal).map(encodeJournalEntry),
     });
   } catch (error) {
-    throw new WorkflowScriptPersistenceError(
+    throw new Error(
       `Workflow checkpoint ${checkpointId} cannot be persisted.`,
       { cause: error },
     );
@@ -215,7 +207,7 @@ async function runPersistedWorkflowScriptLocked(
   // an args-driven branch taken again later still replays.
   const script = requestedScript ?? prior?.script;
   if (script === undefined) {
-    throw new WorkflowScriptPersistenceError(
+    throw new Error(
       `Workflow checkpoint ${checkpointId} does not exist; a script is required for the first run.`,
     );
   }
@@ -225,7 +217,7 @@ async function runPersistedWorkflowScriptLocked(
   try {
     encodedRequestedArgs = encodeJsonValue(requestedArgs);
   } catch (error) {
-    throw new WorkflowScriptPersistenceError(
+    throw new Error(
       `Workflow checkpoint ${checkpointId} arguments cannot be persisted.`,
       { cause: error },
     );

--- a/src/agent/workflowScript/sandbox.ts
+++ b/src/agent/workflowScript/sandbox.ts
@@ -20,9 +20,6 @@ import { z } from 'zod';
 import { onAbort } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-// Local imports - workflow scripts
-import { WorkflowScriptParseError } from './parseScript';
-
 export interface SandboxHostBridge {
   /** Async primitives. Arguments and results cross as JSON text only. */
   asyncFns: Record<string, (args: unknown[]) => Promise<string | undefined>>;
@@ -388,7 +385,7 @@ export async function runScriptInSandbox(
           options.filename,
         );
       } catch (error) {
-        throw new WorkflowScriptParseError(
+        throw new Error(
           `Workflow script syntax error: ${toErrorMessage(error)}`,
         );
       }

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -7,7 +7,6 @@ import {
   type WorkflowScriptControl,
   type WorkflowScriptRunResult,
 } from '@agent/workflowScript';
-import { WorkflowScriptParseError } from '@agent/workflowScript/parseScript';
 import { runWorkflowScript } from '@agent/workflowScript/runWorkflowScript';
 import { WORKFLOW_SKIPPED_RESULT } from '@agent/workflowScript/types';
 import { runScriptInSandbox } from '@agent/workflowScript/sandbox';
@@ -138,7 +137,7 @@ return null`),
 
   it('rejects scripts without a leading meta export', () => {
     expect(() => parseWorkflowScript(`return 1`)).toThrow(
-      WorkflowScriptParseError,
+      /Workflow script must begin with `export const meta/,
     );
   });
 

--- a/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
@@ -11,10 +11,7 @@ import {
   type ExecutionKVStore,
 } from '@agent/storage';
 import { workflowScriptCheckpointKvKey } from '@agent/workflowScript/checkpointKey';
-import {
-  WorkflowScriptPersistenceError,
-  writeWorkflowScriptCheckpoint,
-} from '@agent/workflowScript/persistence';
+import { writeWorkflowScriptCheckpoint } from '@agent/workflowScript/persistence';
 import { runWorkflowScript } from '@agent/workflowScript/runWorkflowScript';
 import {
   WorkflowExecutionSnapshotSchema,
@@ -851,7 +848,7 @@ return 'guest success'`,
     await store.write(workflowScriptCheckpointKvKey('corrupt'), null);
     await expect(
       readWorkflowScriptCheckpoint(store, 'corrupt'),
-    ).rejects.toBeInstanceOf(WorkflowScriptPersistenceError);
+    ).rejects.toThrow('Workflow checkpoint corrupt is malformed.');
     await expect(
       writeWorkflowScriptCheckpoint(store, 'invalid-write', {
         script,
@@ -865,7 +862,7 @@ return 'guest success'`,
           },
         ],
       }),
-    ).rejects.toBeInstanceOf(WorkflowScriptPersistenceError);
+    ).rejects.toThrow('Workflow checkpoint invalid-write cannot be persisted.');
   });
 
   it('accepts script drift: unchanged calls replay, changed calls re-run', async () => {
@@ -1118,7 +1115,9 @@ return [first, args.topic]`;
         args: { invalid: () => undefined },
         runAgent: runner,
       }),
-    ).rejects.toBeInstanceOf(WorkflowScriptPersistenceError);
+    ).rejects.toThrow(
+      'Workflow checkpoint invalid-args arguments cannot be persisted.',
+    );
     expect(runner).not.toHaveBeenCalled();
     await expect(
       readWorkflowScriptCheckpoint(store, 'invalid-args'),


### PR DESCRIPTION
## Summary

- use the execution handle ownership predicate directly at its four registry call sites
- stamp the persisted flow schema version at the one write boundary
- replace two unobserved marker-only workflow error classes with standard errors while preserving messages and causes
- update tests to assert durable behavior instead of internal subclasses

## Net elements (R6)

- files: 9 modified, 0 added, 0 deleted
- production declarations: 2 functions and 2 marker-only classes removed
- public exports: 3 removed, 0 added
- dead-code baseline entries: 1 removed
- net diff: 25 insertions, 74 deletions, for 49 fewer lines

## Consumer counts (R8)

- `isChildExecution`: 4 production callers and 0 direct test consumers; all now use the equivalent existing `handle.isOwnedBy` authority
- `stampFlowRecordSchemaVersion`: exactly 1 production caller and 0 test consumers
- `WorkflowScriptParseError`: 0 production consumers as a class and 1 test importer; all throw messages remain
- `WorkflowScriptPersistenceError`: 0 production consumers as a class and 1 test importer; all persisted-write and parse causes remain
- no execution termination, detach, workflow parse, checkpoint read, checkpoint write, or projection path was removed

## Validation

- focused Vitest: 4 files, 179 tests passed
- authoritative dead-code ratchet: no new findings
- full workspace `typecheck`
- targeted ESLint for all modified files
- `git diff --check`

The isolated CI static checks, build, and kernel shards are the final full gates.