### PR TITLE
refactor(extension): flatten options refresh command

### DIFF
--- a/packages/extension/src/commands/system/mainViewCommands.ts
+++ b/packages/extension/src/commands/system/mainViewCommands.ts
@@ -10,57 +10,12 @@ import { getMainWebview } from '@frontend/system/commandUtils';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { computeModelOptionsData } from '@model/computeModelOptions';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
-import type { ModelOptionData } from '@shared/schemas';
 
 const CHANNEL = 'mainViewCommands';
 
-type AgentOptionsData = Awaited<ReturnType<typeof computeAgentOptionsData>>;
 interface RefreshAllOptionsArgs {
   readonly selectedToolUseAgent?: string;
   readonly agentCatalogAlreadyFresh?: boolean;
-}
-
-function postModelOptions(
-  webview: vscode.WebviewView,
-  optionsData: ModelOptionData[],
-): void {
-  webview.webview.postMessage({
-    command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
-    optionsData,
-  });
-}
-
-function postAgentOptions(
-  webview: vscode.WebviewView,
-  optionsData: AgentOptionsData,
-  selectedToolUseAgent?: string,
-): void {
-  webview.webview.postMessage({
-    command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
-    optionsData,
-    ...(selectedToolUseAgent && { selectedToolUseAgent }),
-  });
-}
-
-async function postTeamOptions(webview: vscode.WebviewView): Promise<void> {
-  webview.webview.postMessage({
-    command: MAIN_VIEW_COMMANDS.SET_TEAM_OPTIONS,
-    optionsData: await loadMainViewTeamOptions(),
-  });
-}
-
-async function runRefresh(
-  label: string,
-  apply: (webview: vscode.WebviewView) => Promise<void>,
-): Promise<void> {
-  const webview = await getMainWebview(CHANNEL);
-  if (!webview) return;
-
-  try {
-    await apply(webview);
-  } catch (error) {
-    await showLoggedErrorMessage(CHANNEL, `Failed to refresh ${label}`, error);
-  }
 }
 
 /**
@@ -75,21 +30,39 @@ export function registerMainViewCommands(
   registerCommandEntries(context, [
     {
       id: 'texra.refreshAllOptions',
-      handler: (args?: RefreshAllOptionsArgs) =>
-        runRefresh('options', async (webview) => {
+      handler: async (args?: RefreshAllOptionsArgs) => {
+        const webview = await getMainWebview(CHANNEL);
+        if (!webview) return;
+
+        try {
           if (!args?.agentCatalogAlreadyFresh) await refresh();
           const [modelOptions, agentOptionsData] = await Promise.all([
             computeModelOptionsData(),
             computeAgentOptionsData(),
           ]);
-          postModelOptions(webview, modelOptions);
-          postAgentOptions(
-            webview,
-            agentOptionsData,
-            args?.selectedToolUseAgent,
+          webview.webview.postMessage({
+            command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+            optionsData: modelOptions,
+          });
+          webview.webview.postMessage({
+            command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+            optionsData: agentOptionsData,
+            ...(args?.selectedToolUseAgent && {
+              selectedToolUseAgent: args.selectedToolUseAgent,
+            }),
+          });
+          webview.webview.postMessage({
+            command: MAIN_VIEW_COMMANDS.SET_TEAM_OPTIONS,
+            optionsData: await loadMainViewTeamOptions(),
+          });
+        } catch (error) {
+          await showLoggedErrorMessage(
+            CHANNEL,
+            'Failed to refresh options',
+            error,
           );
-          await postTeamOptions(webview);
-        }),
+        }
+      },
     },
   ]);
 }


### PR DESCRIPTION
## Summary

- inline the stranded refresh-command abstraction tail into the sole surviving command
- remove one generic callback wrapper, three one-call posting helpers, and their local payload alias
- preserve refresh acquisition, selected-agent handling, model-agent-team post order, and the existing error boundary

## Net elements (R6)

- files: 1 modified, 0 added, 0 deleted
- production declarations: 4 functions and 1 type alias removed
- public exports, dependencies, command IDs, and message types: 0 changed
- net diff: 27 insertions, 54 deletions, for 27 fewer lines

## Consumer counts (R8)

- `runRefresh`, `postModelOptions`, `postAgentOptions`, `postTeamOptions`, and `AgentOptionsData`: exactly 1 same-file production consumer each and 0 test consumers
- `texra.refreshAllOptions`: unchanged, with 10 production invocation sites plus its registration
- no command registration, webview receiver, refresh skip, selected-agent, outbound post, or error-surfacing path was removed

## Validation

- focused command-layer Vitest: 4 files, 72 tests passed
- workspace `tsc --noEmit --checkers 8`
- targeted ESLint and Prettier checks
- `git diff --check`

The isolated CI static checks, build, and kernel shards are the final full gates.