### PR TITLE
refactor(agent): flatten runtime result carriers

### DIFF
--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -5,6 +5,7 @@ import {
   MESSAGE_TYPES,
   type AgentFileLocation,
   type CompileResult,
+  type RunStorageFileLocation,
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { readPlatformSetting } from '@utils/config/platformSettings';
@@ -23,7 +24,6 @@ import { checkExpectedOutputs } from '../output/outputValidation';
 import { summarizeRound, type RoundSummary } from '../output/roundSummary';
 import { formatCompileFailureRoundContext } from '../output/compileFailureRoundContext';
 import { tryOperation } from '../output/outputOperations';
-import type { CompiledPdfArtifact } from '../output/compiledPdfArtifacts';
 import type { RoundFileMapping } from '../output/types';
 
 import type { ReflectionFlowShared } from '../ReflectionFlowState';
@@ -38,7 +38,7 @@ interface OutputPrepInput {
 interface OutputExecResult {
   summary: RoundSummary;
   compileResult?: CompileResult;
-  compiledArtifacts: CompiledPdfArtifact[];
+  compiledArtifacts: RunStorageFileLocation[];
   emitCompileFailures: boolean;
 }
 
@@ -74,7 +74,7 @@ export class OutputNode extends BaseNode<
 
     let mapping: RoundFileMapping | undefined;
     let compileRoundResult: CompileResult | undefined;
-    const compiledArtifacts: CompiledPdfArtifact[] = [];
+    const compiledArtifacts: RunStorageFileLocation[] = [];
     let emitCompileFailures = false;
 
     // Only process if turn ended (model completed response)
@@ -249,7 +249,7 @@ export class OutputNode extends BaseNode<
       } else {
         for (const artifact of execRes.compiledArtifacts) {
           interactions.emit('requestOpenFile', {
-            location: artifact.latestPdf,
+            location: artifact,
             preserveFocus: true,
           });
         }

--- a/src/agent/implementations/flows/reflection/output/LatexDiffManager.ts
+++ b/src/agent/implementations/flows/reflection/output/LatexDiffManager.ts
@@ -12,6 +12,7 @@ import {
   MESSAGE_TYPES,
   type OutputFileInfo,
   type RoundIndexed,
+  type RunStorageFileLocation,
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
@@ -21,10 +22,7 @@ import { checkToolInstalled } from '@utils/system/toolUtils';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-import {
-  publishCompiledPdfArtifact,
-  type CompiledPdfArtifact,
-} from './compiledPdfArtifacts';
+import { publishCompiledPdfArtifact } from './compiledPdfArtifacts';
 import {
   getWorkflowAutoCompileTimeoutMs,
   resolveWorkspaceSourceDir,
@@ -40,7 +38,7 @@ interface DiffOutputDirectory {
 
 type SingleDiffOutcome = {
   diffResult: DiffResult;
-  artifact: CompiledPdfArtifact | null;
+  artifact: RunStorageFileLocation | null;
 };
 
 export class LatexDiffManager {
@@ -111,8 +109,8 @@ export class LatexDiffManager {
   async handleLatexdiffOfOutput(
     currRound: number,
     mapping: RoundFileMapping,
-  ): Promise<CompiledPdfArtifact[]> {
-    const execute = async (): Promise<CompiledPdfArtifact[]> => {
+  ): Promise<RunStorageFileLocation[]> {
+    const execute = async (): Promise<RunStorageFileLocation[]> => {
       if (!(await checkToolInstalled('latexdiff'))) {
         this.logger.warn(
           'Skipping latexdiff operations - latexdiff not installed',
@@ -148,7 +146,7 @@ export class LatexDiffManager {
       });
 
       const aggregated: DiffResult[] = [];
-      const artifacts: CompiledPdfArtifact[] = [];
+      const artifacts: RunStorageFileLocation[] = [];
       const collect = (outcome: SingleDiffOutcome | null): void => {
         if (!outcome) return;
         aggregated.push(outcome.diffResult);
@@ -371,7 +369,7 @@ export class LatexDiffManager {
     pdfStemSuffix: string,
   ): Promise<{
     diffLocation: FileLocation;
-    artifact: CompiledPdfArtifact | null;
+    artifact: RunStorageFileLocation | null;
   } | null> {
     if (!result.success) {
       return null;

--- a/src/agent/implementations/flows/reflection/output/compileCheck.ts
+++ b/src/agent/implementations/flows/reflection/output/compileCheck.ts
@@ -11,6 +11,7 @@ import {
   type ExecutionId,
   type FileLocation,
   type OutputFileInfo,
+  type RunStorageFileLocation,
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { LATEX_CONFIG_RANGES } from '@shared/constants/latexConfig';
@@ -29,10 +30,7 @@ import { readPlatformSetting } from '@utils/config/platformSettings';
 import { getRunDir } from '@utils/files/runStorageFs';
 import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
 
-import {
-  publishCompiledPdfArtifact,
-  type CompiledPdfArtifact,
-} from './compiledPdfArtifacts';
+import { publishCompiledPdfArtifact } from './compiledPdfArtifacts';
 import { getOutputFilesByRound, type OutputState } from './outputState';
 
 interface CompileCheckContext {
@@ -46,7 +44,7 @@ const COMPILE_LOG_EXCERPT_CHAR_LIMIT = 12000;
 const MIN_TIMEOUT_MS = LATEX_CONFIG_RANGES.workflowAutoCompileTimeoutMs.min;
 
 interface CompileCheckResult {
-  artifacts: CompiledPdfArtifact[];
+  artifacts: RunStorageFileLocation[];
   /** Absent when no check ran at all, which is not the same as zero failures. */
   compileResult?: CompileResult;
 }
@@ -145,7 +143,7 @@ export async function runCompileCheck(
   const compileRoot = path.join(runDirectory, 'compile');
   const failures: CompileFailure[] = [];
   const failureLogExcerpts: string[] = [];
-  const artifacts: CompiledPdfArtifact[] = [];
+  const artifacts: RunStorageFileLocation[] = [];
 
   for (const outputFile of texOutputs) {
     const displayName = getCompileDisplayName(outputFile);
@@ -254,7 +252,7 @@ async function compileOne(
 ): Promise<{
   failure: CompileFailure | null;
   failureLogExcerpt: string;
-  artifact: CompiledPdfArtifact | null;
+  artifact: RunStorageFileLocation | null;
 }> {
   // Full relative path keeps two outputs sharing a basename distinct
   // (ch1/main.tex vs ch2/main.tex). Strip the leading r<N>/ segment because
@@ -453,7 +451,7 @@ async function tryPublishArtifact({
   outputFile,
   compiledPdfPath,
   executionId,
-}: TryPublishArtifactArgs): Promise<CompiledPdfArtifact | null> {
+}: TryPublishArtifactArgs): Promise<RunStorageFileLocation | null> {
   try {
     const artifact = await publishCompiledPdfArtifact({
       runDirectory: opts.runDirectory,
@@ -465,7 +463,7 @@ async function tryPublishArtifact({
     });
     if (artifact) {
       ctx.logger.debug(`Compile check: ${displayName} PDF persisted`, {
-        data: artifact.latestPdf.relativePath,
+        data: artifact.relativePath,
       });
     }
     return artifact;

--- a/src/agent/implementations/flows/reflection/output/compiledPdfArtifacts.ts
+++ b/src/agent/implementations/flows/reflection/output/compiledPdfArtifacts.ts
@@ -15,11 +15,6 @@ import { createRunStorageLocation } from '@utils/files/fileLocation';
 import { isFile } from '@utils/files/fsEntryType';
 import { hasExtension } from '@utils/core/pathCore';
 
-export interface CompiledPdfArtifact {
-  pdf: RunStorageFileLocation;
-  latestPdf: RunStorageFileLocation;
-}
-
 interface PublishCompiledPdfOptions {
   runDirectory: string;
   executionId: ExecutionId;
@@ -77,7 +72,7 @@ async function copyArtifactFile(
 
 export async function publishCompiledPdfArtifact(
   options: PublishCompiledPdfOptions,
-): Promise<CompiledPdfArtifact | null> {
+): Promise<RunStorageFileLocation | null> {
   let stats;
   try {
     stats = await platform().fs.stat(options.compiledPdfPath);
@@ -107,16 +102,9 @@ export async function publishCompiledPdfArtifact(
   await copyArtifactFile(options.compiledPdfPath, roundAbsolutePath);
   await copyArtifactFile(roundAbsolutePath, latestAbsolutePath);
 
-  return {
-    pdf: createRunStorageLocation(
-      roundAbsolutePath,
-      roundRelativePath,
-      options.executionId,
-    ),
-    latestPdf: createRunStorageLocation(
-      latestAbsolutePath,
-      latestRelativePath,
-      options.executionId,
-    ),
-  };
+  return createRunStorageLocation(
+    latestAbsolutePath,
+    latestRelativePath,
+    options.executionId,
+  );
 }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -49,6 +49,18 @@ export class ToolUsePrepareNode extends BaseNode<
 
     if (resumeShared) {
       logger.debug('Resuming tool-use session from saved state.');
+    }
+
+    const { systemPrompt, userPrefix, userRequest, instructionSuffix } =
+      await buildInitialToolUsePrompts(
+        this.services.prompt,
+        promptVars,
+        logger,
+        promptOptions,
+      );
+    const systemMessage = buildSystemText(systemPrompt, instructionSuffix);
+
+    if (resumeShared) {
       // The persisted messages are used verbatim -- including `messages[0]`
       // for providers that embed the system prompt into `messages` (OpenAI,
       // OpenRouter). Rewriting that text on every resume to reflect current
@@ -58,21 +70,11 @@ export class ToolUsePrepareNode extends BaseNode<
       // system-prompt edit made between suspend and resume therefore does
       // not propagate into an already-suspended run.
       //
-      // `systemPrompt` below is still rebuilt fresh: for providers that pass
+      // The system prompt is still rebuilt fresh for providers that pass
       // `system` per-call instead of storing it in `messages` (Anthropic,
       // Google), it isn't part of the cached prefix at all -- the round flow
       // resupplies it on every model call regardless of resume, so rebuilding
       // it here is orthogonal to the caching concern above.
-      const rebuiltPrompts = await buildInitialToolUsePrompts(
-        this.services.prompt,
-        promptVars,
-        logger,
-        promptOptions,
-      );
-      const systemMessage = buildSystemText(
-        rebuiltPrompts.systemPrompt,
-        rebuiltPrompts.instructionSuffix,
-      );
       const workspaceState = AgentWorkspaceState.fromSnapshot(
         resumeShared.stateSlices.workspaceSnapshot,
       );
@@ -88,16 +90,6 @@ export class ToolUsePrepareNode extends BaseNode<
 
     const runState = AgentRunStateSnapshotSchema.parse({});
     const workspaceState = AgentWorkspaceState.create();
-
-    const { systemPrompt, userPrefix, userRequest, instructionSuffix } =
-      await buildInitialToolUsePrompts(
-        this.services.prompt,
-        promptVars,
-        logger,
-        promptOptions,
-      );
-
-    const systemMessage = buildSystemText(systemPrompt, instructionSuffix);
     // Attach any media files (CLI `--media`, an image pasted on the first
     // message) to the initial user message via the shared media slot. No-ops
     // when empty or the model lacks vision.

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -69,6 +69,8 @@ import type {
 const logger = createLog('AgentLaunchContext');
 
 export interface AgentLaunchContext extends AgentCore {
+  /** Description from the exact registry entry selected for this launch. */
+  resolvedAgentDescription?: string;
   usageMonitor: UsageMonitor;
   parentStage: StageHandle;
   attachedMemoryMisses: AttachedMemoryMiss[];
@@ -507,6 +509,7 @@ async function assembleAgentLaunchContext(
   );
   return {
     config,
+    resolvedAgentDescription: resolution.entry.description,
     setting,
     prompt,
     modelCell,

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -361,11 +361,6 @@ export interface ChildRunLoopParams<TTurn> {
   readonly afterArtifactsDrained?: () => void | Promise<void>;
 }
 
-export interface ChildRunLoopHandle {
-  /** Settles after terminal delivery, finalization, and artifact release. */
-  readonly completion: Promise<void>;
-}
-
 /**
  * Interrupt handler attached to the child's execution handle for the child's
  * whole lifetime, so the stop button always finds a live target — including
@@ -766,7 +761,7 @@ async function submitPendingDelivery(
  */
 export function startChildRunLoop<TTurn>(
   params: ChildRunLoopParams<TTurn>,
-): ChildRunLoopHandle {
+): Promise<void> {
   const {
     childStream,
     childStreamId,
@@ -1236,12 +1231,10 @@ export function startChildRunLoop<TTurn>(
   } catch (error) {
     throw unwindSetup(error);
   }
-  return {
-    completion: completion.catch((error: unknown) => {
-      // Refused before `run` began (the registry disposed, or a storage-root
-      // change holds the lifecycle): `run`'s own unwinding never ran.
-      if (runStarted) throw error;
-      throw unwindSetup(error);
-    }),
-  };
+  return completion.catch((error: unknown) => {
+    // Refused before `run` began (the registry disposed, or a storage-root
+    // change holds the lifecycle): `run`'s own unwinding never ran.
+    if (runStarted) throw error;
+    throw unwindSetup(error);
+  });
 }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -436,6 +436,7 @@ export async function executeAgent(
         runExecutionId,
         runStreamId,
         config,
+        ctx.resolvedAgentDescription,
         runSession,
         ctx.runScope.signal,
       );

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -7,7 +7,6 @@
  * future agents can quickly understand each session.
  */
 
-import { resolveAgentForLaunch } from '@agent/index';
 import { writeSessionDescription } from '@agent/storage/executionLifecycle';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
@@ -102,6 +101,7 @@ export async function generateSessionDescription(
   executionId: ExecutionId,
   streamId: StreamTabId,
   config: AgentConfig,
+  agentDescription: string | undefined,
   session: SessionHandle,
   signal?: AbortSignal,
 ): Promise<void> {
@@ -119,17 +119,7 @@ export async function generateSessionDescription(
 
     const userPrompt = buildUserPrompt(
       config.agent,
-      // The launch resolver, not a lookup of our own: `getAgentPath` is a thin
-      // wrapper over this same call, so the purpose we describe always belongs
-      // to the entry that actually ran. Any other resolver can diverge — by
-      // category, by pinned source, or by picking a higher-priority same-name
-      // agent the visible roster did not select — and label a run with a
-      // different agent's purpose.
-      resolveAgentForLaunch(
-        config.agentCategory,
-        config.agent,
-        config.agentSource,
-      )?.entry.description,
+      agentDescription,
       instruction,
     );
     const text = await runHelperModelCompletion(helperResult.kit, {

--- a/src/test-kernel/agent/output/CompiledPdfArtifacts.vitest.ts
+++ b/src/test-kernel/agent/output/CompiledPdfArtifacts.vitest.ts
@@ -155,8 +155,7 @@ describe('compiled PDF artifacts', () => {
       compiledPdfPath,
     });
 
-    expect(artifact?.pdf.relativePath).toBe('output/r2/paper.pdf');
-    expect(artifact?.latestPdf.relativePath).toBe('output/latest/paper.pdf');
+    expect(artifact?.relativePath).toBe('output/latest/paper.pdf');
     await expect(readOutput(runDirectory, 'r2', 'paper.pdf')).resolves.toBe(
       'pdf bytes',
     );
@@ -185,10 +184,7 @@ describe('compiled PDF artifacts', () => {
       pdfStemSuffix: '-diff',
     });
 
-    expect(artifact?.pdf.relativePath).toBe('output/r4/sections/main-diff.pdf');
-    expect(artifact?.latestPdf.relativePath).toBe(
-      'output/latest/sections/main-diff.pdf',
-    );
+    expect(artifact?.relativePath).toBe('output/latest/sections/main-diff.pdf');
   });
 
   it('strips a Windows-style round prefix without duplicating it', async () => {
@@ -210,10 +206,7 @@ describe('compiled PDF artifacts', () => {
       pdfStemSuffix: '-diff',
     });
 
-    expect(artifact?.pdf.relativePath).toBe('output/r4/sections/main-diff.pdf');
-    expect(artifact?.latestPdf.relativePath).toBe(
-      'output/latest/sections/main-diff.pdf',
-    );
+    expect(artifact?.relativePath).toBe('output/latest/sections/main-diff.pdf');
   });
 
   it('keeps distinct diff kinds for the same revised source', async () => {
@@ -248,9 +241,9 @@ describe('compiled PDF artifacts', () => {
       pdfStemSuffix: '-round-diff',
     });
 
-    expect(baseDiff?.pdf.relativePath).toBe('output/r5/sections/main-diff.pdf');
-    expect(roundDiff?.pdf.relativePath).toBe(
-      'output/r5/sections/main-round-diff.pdf',
+    expect(baseDiff?.relativePath).toBe('output/latest/sections/main-diff.pdf');
+    expect(roundDiff?.relativePath).toBe(
+      'output/latest/sections/main-round-diff.pdf',
     );
     await expect(
       readOutput(runDirectory, 'r5', 'sections', 'main-diff.pdf'),
@@ -293,10 +286,8 @@ describe('compiled PDF artifacts', () => {
       compiledPdfPath: secondPdfPath,
     });
 
-    expect(first?.pdf.relativePath).toBe('output/r3/ch1/main.pdf');
-    expect(second?.pdf.relativePath).toBe('output/r3/ch2/main.pdf');
-    expect(first?.latestPdf.relativePath).toBe('output/latest/ch1/main.pdf');
-    expect(second?.latestPdf.relativePath).toBe('output/latest/ch2/main.pdf');
+    expect(first?.relativePath).toBe('output/latest/ch1/main.pdf');
+    expect(second?.relativePath).toBe('output/latest/ch2/main.pdf');
     await expect(
       readOutput(runDirectory, 'r3', 'ch1', 'main.pdf'),
     ).resolves.toBe('chapter 1');

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -57,7 +57,6 @@ import type { WorkflowJournalEntry } from '@agent/workflowScript';
 import { getExecutionStore } from '@agent/storage';
 import {
   startChildRunLoop,
-  type ChildRunLoopHandle,
   type ChildRunLoopParams,
   type ChildRunPorts,
   type ChildRunStrategy,
@@ -235,7 +234,7 @@ function startLoop(
   ids: { childStreamId: StreamTabId; executionId: ExecutionId },
   strategy: ChildRunStrategy<FakeTurn>,
   extras: Partial<ChildRunLoopParams<FakeTurn>> = {},
-): ChildRunLoopHandle {
+): Promise<void> {
   return startChildRunLoop({
     ...ids,
     parentStreamId: PARENT_STREAM_ID,
@@ -473,7 +472,7 @@ describe('childRunLoop E2E fixtures', () => {
       });
 
     try {
-      const handle = startLoop({ childStreamId, executionId }, strategy);
+      const completion = startLoop({ childStreamId, executionId }, strategy);
       await writeStarted.promise;
       // Interrupt the loop through its parent lineage: no turn handle is
       // tracked in this fixture, so the stop reaches the loop via its
@@ -487,7 +486,7 @@ describe('childRunLoop E2E fixtures', () => {
       expect(mocks.releaseExecutionLeaseAfterArtifacts).not.toHaveBeenCalled();
 
       writeBarrier.resolve();
-      await handle.completion;
+      await completion;
       expect(writeTurnState).toHaveBeenCalledOnce();
       expect(mocks.releaseExecutionLeaseAfterArtifacts).toHaveBeenCalledWith(
         session,
@@ -503,13 +502,13 @@ describe('childRunLoop E2E fixtures', () => {
     const { childStreamId, executionId } = loopIds('persist-only');
     const { strategy, resolveTurn } = createFakeStrategy();
 
-    const handle = startLoop(
+    const completion = startLoop(
       { childStreamId, executionId },
       { ...strategy, deliveryMode: 'persistOnly' },
       { parentStreamId: 'headless-parent' as StreamTabId },
     );
     await resolveTurn(1, { kind: 'terminal', value: 'saved' });
-    await handle.completion;
+    await completion;
 
     expect(mocks.persistChildRunReport).toHaveBeenCalledWith(
       executionId,
@@ -536,11 +535,11 @@ describe('childRunLoop E2E fixtures', () => {
     });
 
     try {
-      await startLoop(ids, createTerminalStrategy('First attempt')).completion;
+      await startLoop(ids, createTerminalStrategy('First attempt'));
       expect(session.followUps.hasLiveOwner(ids.childStreamId)).toBe(false);
 
       await expect(
-        startLoop(ids, createTerminalStrategy('Retry attempt')).completion,
+        startLoop(ids, createTerminalStrategy('Retry attempt')),
       ).resolves.toBeUndefined();
       expect(admissions).toEqual(['delivered_live', 'delivered_live']);
       const delivered = session.followUps.queue(parentLease).drainItems();
@@ -1142,11 +1141,9 @@ describe('childRunLoop E2E fixtures', () => {
       () => 'delivered',
     );
 
-    const { completion } = startLoop(
-      loopIds('workflow-attempt-cost'),
-      strategy,
-      { recordCost },
-    );
+    const completion = startLoop(loopIds('workflow-attempt-cost'), strategy, {
+      recordCost,
+    });
 
     await expect(completion).resolves.toBeUndefined();
     expect(recordCost).toHaveBeenCalledOnce();
@@ -1177,7 +1174,7 @@ describe('childRunLoop E2E fixtures', () => {
       );
       const recordCost = vi.fn(observe);
 
-      const { completion } = startLoop(
+      const completion = startLoop(
         loopIds(`${failure}-cost-observer`),
         strategy,
         { recordCost },

--- a/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
@@ -14,12 +14,7 @@ import { createTestSession } from '@test/support/sessionTestUtils';
 
 const mocks = vi.hoisted(() => ({
   createHelperModelKit: vi.fn(),
-  resolveAgentForLaunch: vi.fn(),
   writeSessionDescription: vi.fn(),
-}));
-
-vi.mock('@agent/index', () => ({
-  resolveAgentForLaunch: mocks.resolveAgentForLaunch,
 }));
 
 vi.mock('@agent/runtime/helperModel', async (importActual) => ({
@@ -36,7 +31,7 @@ function runDescription(
   streamId: string,
   session: ReturnType<typeof createTestSession>,
   category: AgentCategory = AgentCategory.ToolUse,
-  agentSource?: string,
+  agentDescription?: string,
 ): Promise<void> {
   return generateSessionDescription(
     executionId as ExecutionId,
@@ -46,8 +41,8 @@ function runDescription(
       model: 'gemini35f',
       instruction: 'Fix grammar.',
       agentCategory: category,
-      ...(agentSource ? { agentSource } : {}),
     }),
+    agentDescription,
     session,
   );
 }
@@ -61,12 +56,13 @@ function helperAnswering(text: string) {
   };
 }
 
-/** Point the launch resolver and helper-model kit at one resolved answer. */
-function mockToolUseAnswer(description: string, text: string): void {
-  mocks.resolveAgentForLaunch.mockReturnValue({ entry: { description } });
+/** Point the helper-model kit at one resolved answer. */
+function mockToolUseAnswer(text: string): ReturnType<typeof helperAnswering> {
+  const handler = helperAnswering(text);
   mocks.createHelperModelKit.mockResolvedValue({
-    kit: { client: {}, handler: helperAnswering(text) },
+    kit: { client: {}, handler },
   });
+  return handler;
 }
 
 describe('session description helpers', () => {
@@ -94,29 +90,25 @@ describe('session description helpers', () => {
     ).toBe('Summarize the paper.');
   });
 
-  it('generates descriptions for workflow runs, looked up in their own roster', async () => {
+  it('uses the exact workflow-agent description carried by launch context', async () => {
     const session = createTestSession();
     const events: SessionEvent[] = [];
     const detach = session.events.subscribe((event) => events.push(event), {
       scope: 'session',
     });
-    mockToolUseAnswer('Corrects a draft', 'Correcting derivation signs');
+    const handler = mockToolUseAnswer('Correcting derivation signs');
 
     await runDescription(
       'exec-workflow',
       'stream-workflow',
       session,
       AgentCategory.Workflow,
+      'Corrects a draft',
     );
     detach();
 
-    // Resolved through the launch resolver under the run's own category: a
-    // tool-use lookup would miss a workflow agent entirely, leaving the helper
-    // prompt without the agent's purpose.
-    expect(mocks.resolveAgentForLaunch).toHaveBeenCalledWith(
-      AgentCategory.Workflow,
-      'correct',
-      undefined,
+    expect(handler.initializeMessages.mock.calls[0]?.[1]).toContain(
+      '<agent-purpose>Corrects a draft</agent-purpose>',
     );
     expect(mocks.writeSessionDescription).toHaveBeenCalledWith(
       'exec-workflow',
@@ -136,34 +128,10 @@ describe('session description helpers', () => {
     ]);
   });
 
-  it('passes the pinned agent source to the launch resolver', async () => {
-    const session = createTestSession();
-    mockToolUseAnswer('The custom roster copy', 'Correcting derivation signs');
-
-    await runDescription(
-      'exec-pinned',
-      'stream-pinned',
-      session,
-      AgentCategory.Workflow,
-      'custom',
-    );
-
-    // Without the source, two rosters holding `correct` resolve by priority
-    // and the label can describe the agent that did not run.
-    expect(mocks.resolveAgentForLaunch).toHaveBeenCalledWith(
-      AgentCategory.Workflow,
-      'correct',
-      'custom',
-    );
-  });
-
   it('logs helper-model failures without rejecting the fire-and-forget call', async () => {
     const session = createTestSession();
     const helperError = new Error('helper unavailable');
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
-    mocks.resolveAgentForLaunch.mockReturnValue({
-      entry: { description: 'General chat assistant' },
-    });
     mocks.createHelperModelKit.mockRejectedValueOnce(helperError);
 
     await expect(
@@ -179,9 +147,6 @@ describe('session description helpers', () => {
 
   it('does not reject when the diagnostic sink also fails', async () => {
     const session = createTestSession();
-    mocks.resolveAgentForLaunch.mockReturnValue({
-      entry: { description: 'General chat assistant' },
-    });
     mocks.createHelperModelKit.mockRejectedValueOnce(
       new Error('helper unavailable'),
     );
@@ -200,7 +165,7 @@ describe('session description helpers', () => {
     const detach = session.events.subscribe((event) => events.push(event), {
       scope: 'session',
     });
-    mockToolUseAnswer('General chat assistant', 'Fixing proof typos');
+    mockToolUseAnswer('Fixing proof typos');
 
     await runDescription('exec-tool', 'stream-tool', session);
     detach();

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -117,8 +117,8 @@ const parentStreamId = 'stream:parent' as StreamTabId;
 const childStreamId = 'stream:claude-child' as StreamTabId;
 const executionId = 'parent-exec' as ExecutionId;
 
-function completedChildRunLoop(): { completion: Promise<void> } {
-  return { completion: Promise.resolve() };
+function completedChildRunLoop(): Promise<void> {
+  return Promise.resolve();
 }
 
 function stubExecutions(): any {
@@ -277,9 +277,7 @@ describe('claude_agent tool launch and resume fallback', () => {
       .mockImplementation(() => {});
     const lateFailure = new Error('late Claude finalization failed');
     mocks.createChildStream.mockReturnValue(childStream);
-    mocks.startChildRunLoop.mockReturnValue({
-      completion: Promise.reject(lateFailure),
-    });
+    mocks.startChildRunLoop.mockReturnValue(Promise.reject(lateFailure));
 
     await expect(
       new ClaudeAgentTool().call({ prompt: 'launch Claude' }),

--- a/src/test-kernel/tools/CodexResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/CodexResumeFallback.vitest.ts
@@ -111,8 +111,8 @@ const parentStreamId = 'stream:parent' as StreamTabId;
 const childStreamId = 'stream:codex-child' as StreamTabId;
 const executionId = 'parent-exec' as ExecutionId;
 
-function completedChildRunLoop(): { completion: Promise<void> } {
-  return { completion: Promise.resolve() };
+function completedChildRunLoop(): Promise<void> {
+  return Promise.resolve();
 }
 
 function toolContext(runContext: Record<string, unknown> = {}): unknown {
@@ -170,9 +170,7 @@ describe('codex tool - atomic resume fallback', () => {
       .mockImplementation(() => {});
     const lateFailure = new Error('late Codex finalization failed');
     mocks.createChildStream.mockReturnValue(childStream);
-    mocks.startChildRunLoop.mockReturnValue({
-      completion: Promise.reject(lateFailure),
-    });
+    mocks.startChildRunLoop.mockReturnValue(Promise.reject(lateFailure));
     mocks.importCodexClass.mockResolvedValue(
       class MockCodex {
         startThread(): {

--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -285,7 +285,7 @@ describe('NativeSubagentStrategy', () => {
       }),
     );
 
-    const { completion } = startChildRunLoop({
+    const completion = startChildRunLoop({
       childStreamId: CHILD_STREAM_ID,
       parentStreamId: params.parentStreamId,
       executionId: params.executionId,
@@ -316,7 +316,7 @@ describe('NativeSubagentStrategy', () => {
       });
     });
 
-    const { completion } = startChildRunLoop({
+    const completion = startChildRunLoop({
       childStreamId: CHILD_STREAM_ID,
       parentStreamId: params.parentStreamId,
       executionId: params.executionId,

--- a/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
+++ b/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
@@ -104,9 +104,7 @@ describe('executeSubagent childStreamId derivation', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.startChildRunLoop.mockReturnValue({
-      completion: Promise.resolve(),
-    });
+    mocks.startChildRunLoop.mockReturnValue(Promise.resolve());
     mocks.registerExecution.mockResolvedValue(undefined);
     mocks.tryUseRunContext.mockReturnValue({
       executionId: 'parent-exec',
@@ -184,9 +182,7 @@ describe('executeSubagent childStreamId derivation', () => {
 
   it('logs a detached run-loop rejection through the childRunLoop channel log', async () => {
     const lateFailure = new Error('late subagent finalization failed');
-    mocks.startChildRunLoop.mockReturnValue({
-      completion: Promise.reject(lateFailure),
-    });
+    mocks.startChildRunLoop.mockReturnValue(Promise.reject(lateFailure));
 
     await expect(runDefaultSubagent()).resolves.toMatchObject({
       status: 'executed',

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -239,9 +239,7 @@ beforeEach(async () => {
     result: { action: 'approve' },
     autoApproved: false,
   });
-  mocks.startChildRunLoop.mockReturnValue({
-    completion: Promise.resolve(),
-  });
+  mocks.startChildRunLoop.mockReturnValue(Promise.resolve());
   mocks.requireWorkflowOrToolUseAgent.mockImplementation((name) => {
     if (name === 'missing-agent') {
       throw new Error(
@@ -395,9 +393,7 @@ return null`;
 
   it('owns a detached run completion rejection without delivering a second error', async () => {
     const lateFailure = new Error('late finalization failed');
-    mocks.startChildRunLoop.mockReturnValueOnce({
-      completion: Promise.reject(lateFailure),
-    });
+    mocks.startChildRunLoop.mockReturnValueOnce(Promise.reject(lateFailure));
 
     const result = await callTool();
 

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -548,7 +548,7 @@ export function startAgentCliLoop<TTurn>(
     },
   };
 
-  const { completion } = startChildRunLoop({
+  const completion = startChildRunLoop({
     childStream,
     childStreamId,
     parentStreamId,

--- a/src/tools/delegation/detachedChildRun.ts
+++ b/src/tools/delegation/detachedChildRun.ts
@@ -133,14 +133,14 @@ export async function startDetachedChildRunLoop<TTurn>(
         budgeted,
         ...loopParams
       } = input;
-      ({ completion } = startChildRunLoop({
+      completion = startChildRunLoop({
         ...loopParams,
         ...(childStream !== undefined && { childStream }),
         strategy: launch.strategy,
         // Every detached native/workflow child takes one shared-budget slot per
         // turn; an awaited in-band child rides its idle parent's slot instead.
         budgeted: budgeted ?? true,
-      }));
+      });
     } catch (error) {
       if (childStream) {
         try {


### PR DESCRIPTION
## Summary

- carry the exact resolved agent description through launch context instead of resolving the agent twice
- return the child-run completion promise directly while preserving synchronous setup failures and terminal rejection handling
- return only the latest compiled-PDF location while retaining both round-specific and latest-file writes
- give fresh and resumed tool-use preparation one prompt-construction site while preserving resumed-message identity

## Issue acceptance gates

No linked issue. Acceptance gates for this behavior-preserving refactor:

- [x] session-description generation receives the description from the exact registry entry selected for launch
- [x] `startChildRunLoop` returns its completion promise directly without becoming `async`, so setup throws remain synchronous and terminal failures still reject
- [x] compiled-PDF publication writes both `output/r<N>/...` and `output/latest/...` while returning only the latest location
- [x] fresh and resumed tool-use paths share one `buildInitialToolUsePrompts` call site; persisted resumed messages remain verbatim
- [x] current-main workflow compile rejection behavior from #11673 remains intact

## Single source of truth

`AgentLaunchContext.resolvedAgentDescription` now carries `resolution.entry.description` from the exact launch resolution into `generateSessionDescription`. Session-description generation no longer performs a second registry lookup that could select a different same-name or pinned-source entry.

`publishCompiledPdfArtifact` now exposes only the latest `RunStorageFileLocation`, which was the only returned location consumed. It still owns both required file writes.

## Duplication and abstraction budget

Removed two one-field/dead-field carriers and one duplicate prompt-construction branch. No replacement abstraction or pass-through layer was added. `startChildRunLoop` remains a synchronous function returning the existing catch-wrapped completion promise.

## Net elements (R6)

- files: 19 modified, 0 added, 0 deleted
- exported symbols: 0 added, 2 deleted (`ChildRunLoopHandle`, `CompiledPdfArtifact`)
- classes/interfaces/enums: 0 added, 2 interfaces deleted
- LoC: +97 / -193, net -96

## Consumer counts (R8)

n/a. No emit path is deleted or rerouted. The two deleted exports were internal result carriers whose production and test consumers were all migrated in this change.

## Host impact

Extension: No behavior change. Compiled PDFs still open from `output/latest`, and both latest and round-specific files are written.

Desktop: No behavior change. Runtime launch and child completion semantics are preserved.

CLI: No behavior change. The CLI still owns detached child-loop rejections through the same completion promise.

## Scheduled refactoring

None.

## Validation

- focused Vitest suites: 13 files, 160 tests passed
- full typecheck: workspace, test kernel, agent declarations, CLI, trace viewer, desktop
- full ESLint and Prettier checks
- dead-code ratchet: 299 findings against 299 baselined
- extension package, contributes, tsconfig-path, guidance-reference, browser-safe-utils, and CLI React Compiler checks
- production extension build and VSIX packaging
- `git diff --check`
- full Vitest run: 820 files and 9,974 tests passed; one unrelated suite hook timed out and one unrelated desktop test failed. The desktop failure reproduces on `origin/main` (all three matching merge-presentation tests fail there); focused tests for this PR remain green.
