### PR TITLE
refactor(core): simplify export and inquiry data

### DIFF
--- a/src/agent/export/normalizeConversation.ts
+++ b/src/agent/export/normalizeConversation.ts
@@ -14,7 +14,6 @@
  */
 
 import { isAssistantMessage } from 'openai/lib/chatCompletionUtils';
-import { z } from 'zod';
 import { isFunctionToolCall } from '@agent/modelHandlers/openai/functionToolCalls';
 import {
   extractTextContentPart,
@@ -29,7 +28,7 @@ import {
 import {
   ANTHROPIC_SERVER_TOOL_BLOCK_TYPES,
   extractWebFetchResultFields,
-  WebSearchResultEntrySchema,
+  type WebSearchResult,
 } from '@agent/types/ServerTools';
 import { assertNever, isObject } from '@utils/core';
 import { isImageMimeType } from '@utils/files/mimeUtils';
@@ -42,103 +41,92 @@ import type {
 import type { ExportNode, UserPart } from './schemas';
 
 // ============================================================
-// Input schemas (implementation detail — not exported publicly)
+// Input types (implementation detail — not exported publicly)
 // ============================================================
 
 /**
  * One entry inside a `web_search_tool_result` block's `content` array: the
- * provider wire shape of the canonical {@link WebSearchResultEntrySchema},
+ * provider wire shape of the canonical {@link WebSearchResult},
  * read permissively (`title`/`url` optional on the wire) and tagged with the
  * block's `type` string.
  */
-const WebSearchResultItemSchema = WebSearchResultEntrySchema.pick({
-  title: true,
-  url: true,
-})
-  .partial()
-  .extend({ type: z.string() });
+type WebSearchResultItem = Partial<
+  Pick<WebSearchResult['results'][number], 'title' | 'url'>
+> & { type: string };
 
 /**
  * Discriminated union of API content blocks across the four provider shapes
  * this module normalizes (Anthropic, OpenAI Chat Completions, OpenAI
  * Response API, Google GenAI — the latter via {@link googlePartToBlocks},
  * which translates Google's field-based `Part` into these type-based
- * blocks). Each variant declares only the fields that provider actually
- * populates for that block kind, so the six consuming functions below can
- * switch/narrow on `type` instead of re-deriving validity with ad hoc
- * optional-field checks.
+ * blocks). Each variant declares only the fields this module reads for that
+ * block kind. Existing runtime guards narrow the raw values; this union gives
+ * the consumers below exhaustive `type`-based narrowing afterward.
  */
-const ContentBlockSchema = z.discriminatedUnion('type', [
+type ContentBlock =
   // Plain text. Anthropic and Google GenAI use 'text'; OpenAI Response API
   // splits it into 'input_text' (user) and 'output_text' (assistant).
-  z.object({ type: z.literal('text'), text: z.string().optional() }),
-  z.object({ type: z.literal('input_text'), text: z.string().optional() }),
-  z.object({ type: z.literal('output_text'), text: z.string().optional() }),
+  | { type: 'text'; text?: string }
+  | { type: 'input_text'; text?: string }
+  | { type: 'output_text'; text?: string }
 
   // Anthropic extended-thinking / Google GenAI thought blocks.
-  z.object({
-    type: z.literal(CONVERSATION_BLOCK_TYPES.thinking),
-    thinking: z.string().optional(),
-  }),
-  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.redactedThinking) }),
+  | {
+      type: typeof CONVERSATION_BLOCK_TYPES.thinking;
+      thinking?: string;
+    }
+  | { type: typeof CONVERSATION_BLOCK_TYPES.redactedThinking }
 
   // Tool call / tool result — shared by Anthropic, Google GenAI, and the
   // VS Code language-model bridge (see normalizeContentBlock).
-  z.object({
-    type: z.literal(CONVERSATION_BLOCK_TYPES.toolUse),
-    name: z.string().optional(),
-    input: z.unknown().optional(),
-  }),
-  z.object({
-    type: z.literal(CONVERSATION_BLOCK_TYPES.toolResult),
-    content: z.unknown().optional(),
-  }),
+  | {
+      type: typeof CONVERSATION_BLOCK_TYPES.toolUse;
+      name?: string;
+      input?: unknown;
+    }
+  | {
+      type: typeof CONVERSATION_BLOCK_TYPES.toolResult;
+      content?: unknown;
+    }
 
   // Attachment markers: Anthropic ('image'/'document'), OpenAI Response API
   // ('input_image'/'input_file'), OpenAI Chat Completions ('image_url'/
   // 'file'). None of these carry fields this module reads — only `type`
   // decides which attachment kind to render.
-  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.image) }),
-  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.inputImage) }),
-  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.imageUrl) }),
-  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.document) }),
-  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.inputFile) }),
-  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.file) }),
+  | { type: typeof CONVERSATION_BLOCK_TYPES.image }
+  | { type: typeof CONVERSATION_BLOCK_TYPES.inputImage }
+  | { type: typeof CONVERSATION_BLOCK_TYPES.imageUrl }
+  | { type: typeof CONVERSATION_BLOCK_TYPES.document }
+  | { type: typeof CONVERSATION_BLOCK_TYPES.inputFile }
+  | { type: typeof CONVERSATION_BLOCK_TYPES.file }
 
   // Anthropic server-side tool blocks (the provider executes these, not a
   // local tool handler).
-  z.object({
-    type: z.literal(ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.serverToolUse),
-    name: z.string().optional(),
-    input: z.unknown().optional(),
-  }),
-  z.object({
-    type: z.literal(ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webSearchToolResult),
-    content: z.array(WebSearchResultItemSchema).optional(),
-  }),
+  | {
+      type: typeof ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.serverToolUse;
+      name?: string;
+      input?: unknown;
+    }
+  | {
+      type: typeof ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webSearchToolResult;
+      content?: WebSearchResultItem[];
+    }
   // `extractWebFetchResultFields` reads its fields off the raw block itself
-  // (it accepts `unknown`), not off this schema's inferred type, so this
-  // variant only declares the discriminant. `looseObject` (not `object`)
-  // documents that undeclared fields are intentionally read elsewhere —
-  // and keeps that true if runtime `.parse()` is ever added to this schema
-  // (currently it isn't; see the module-level type-derivation-only note).
-  z.looseObject({
-    type: z.literal(ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webFetchToolResult),
-  }),
-]);
-type ContentBlock = z.infer<typeof ContentBlockSchema>;
+  // (it accepts `unknown`), so this variant only declares the discriminant.
+  | {
+      type: typeof ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webFetchToolResult;
+      [key: string]: unknown;
+    };
 
-const ConversationMessageSchema = z.looseObject({
-  role: z.string().optional(),
-  content: z
-    .union([z.string(), z.array(ContentBlockSchema), z.unknown()])
-    .optional(),
+interface ConversationMessage {
+  role?: string;
+  content?: unknown;
   // Google GenAI uses `parts` instead of `content`
-  parts: z.array(z.unknown()).optional(),
+  parts?: unknown[];
   // OpenAI Chat Completions: tool_calls on assistant messages
-  tool_calls: z.array(z.unknown()).optional(),
-});
-type ConversationMessage = z.infer<typeof ConversationMessageSchema>;
+  tool_calls?: unknown[];
+  [key: string]: unknown;
+}
 
 // ============================================================
 // Helpers

--- a/src/agent/export/schemas.ts
+++ b/src/agent/export/schemas.ts
@@ -1,5 +1,5 @@
 /**
- * Format-agnostic intermediate representation schemas for chat export.
+ * Format-agnostic intermediate representation types for chat export.
  *
  * These describe the `ExportNode` produced by normalization and consumed by
  * every format spec (markdown, LaTeX). The HTML export path uses
@@ -8,39 +8,35 @@
  * without pulling in `openai/*`, `@agent/modelHandlers/openai/*`, or
  * `@google/genai`.
  *
- * Zod schemas are the single source of truth; types are derived with `z.infer`.
- * The one cross-module dependency is the canonical web-search entry schema
- * from `@agent/types/ServerTools`, whose provider SDK imports are type-only,
- * so the neutrality note above still holds.
+ * These types describe an in-process representation rather than a validation
+ * boundary. The one cross-module dependency is the canonical web-search
+ * result type from `@agent/types/ServerTools`, whose provider SDK imports are
+ * type-only, so the neutrality note above still holds.
  */
 
-import { z } from 'zod';
-
-import { WebSearchResultEntrySchema } from '@agent/types/ServerTools';
+import type { WebSearchResult } from '@agent/types/ServerTools';
 import type { MediaAttachmentKind } from '@shared/schemas';
 
 // ============================================================
 // Export configuration (caller-supplied)
 // ============================================================
 
-const ExportConfigSchema = z.object({
-  agent: z.string().optional(),
-  model: z.string().optional(),
-  instruction: z.string().optional(),
-  inputFiles: z.array(z.string()).optional(),
-  mediaFiles: z.array(z.string()).optional(),
-  contextFiles: z.array(z.string()).optional(),
-  outputFiles: z.array(z.string()).optional(),
-});
-export type ExportConfig = z.infer<typeof ExportConfigSchema>;
+export interface ExportConfig {
+  agent?: string;
+  model?: string;
+  instruction?: string;
+  inputFiles?: string[];
+  mediaFiles?: string[];
+  contextFiles?: string[];
+  outputFiles?: string[];
+}
 
-const ChatExportInputSchema = z.object({
-  timestamp: z.string(),
-  description: z.string().optional(),
-  config: ExportConfigSchema,
-  messages: z.array(z.unknown()),
-});
-export type ChatExportInput = z.infer<typeof ChatExportInputSchema>;
+export interface ChatExportInput {
+  timestamp: string;
+  description?: string;
+  config: ExportConfig;
+  messages: unknown[];
+}
 
 // ============================================================
 // Intermediate representation — format-agnostic
@@ -48,13 +44,13 @@ export type ChatExportInput = z.infer<typeof ChatExportInputSchema>;
 
 /**
  * One rendered search hit in the exported document: the title/url projection
- * of the canonical provider result entry ({@link WebSearchResultEntrySchema}
- * in `@agent/types/ServerTools`). Domain never reaches the export IR.
+ * of the canonical provider result entry ({@link WebSearchResult} in
+ * `@agent/types/ServerTools`). Domain never reaches the export IR.
  */
-const ExportWebSearchResultSchema = WebSearchResultEntrySchema.pick({
-  title: true,
-  url: true,
-});
+type ExportWebSearchResult = Pick<
+  WebSearchResult['results'][number],
+  'title' | 'url'
+>;
 
 /**
  * Attachment kinds a renderer must be able to label. Kept in step with the
@@ -62,55 +58,35 @@ const ExportWebSearchResultSchema = WebSearchResultEntrySchema.pick({
  * exported document describe the same attachment, so a kind added there must
  * also gain a label in every format spec.
  */
-const EXPORT_ATTACHMENT_TYPES = [
-  'image',
-  'document',
-] as const satisfies readonly MediaAttachmentKind[];
+export type ExportAttachmentType = MediaAttachmentKind;
 
-export type ExportAttachmentType = (typeof EXPORT_ATTACHMENT_TYPES)[number];
+export type UserPart =
+  | { type: 'text'; text: string }
+  | { type: 'attachment'; attachmentType: ExportAttachmentType };
 
-const UserPartSchema = z.discriminatedUnion('type', [
-  z.object({ type: z.literal('text'), text: z.string() }),
-  z.object({
-    type: z.literal('attachment'),
-    attachmentType: z.enum(EXPORT_ATTACHMENT_TYPES),
-  }),
-]);
-export type UserPart = z.infer<typeof UserPartSchema>;
-
-const ExportNodeSchema = z.discriminatedUnion('kind', [
-  z.object({ kind: z.literal('user-message'), parts: z.array(UserPartSchema) }),
-  z.object({ kind: z.literal('assistant-text'), text: z.string() }),
-  z.object({
-    kind: z.literal('tool-call'),
-    name: z.string(),
-    input: z.string(),
-  }),
-  z.object({ kind: z.literal('tool-result'), text: z.string() }),
-  z.object({ kind: z.literal('web-search'), query: z.string() }),
-  z.object({
-    kind: z.literal('web-search-results'),
-    results: z.array(ExportWebSearchResultSchema),
-  }),
-  z.object({
-    kind: z.literal('web-fetch'),
-    url: z.string().optional(),
-    title: z.string().optional(),
-    content: z.string().optional(),
-  }),
-]);
-export type ExportNode = z.infer<typeof ExportNodeSchema>;
+export type ExportNode =
+  | { kind: 'user-message'; parts: UserPart[] }
+  | { kind: 'assistant-text'; text: string }
+  | { kind: 'tool-call'; name: string; input: string }
+  | { kind: 'tool-result'; text: string }
+  | { kind: 'web-search'; query: string }
+  | { kind: 'web-search-results'; results: ExportWebSearchResult[] }
+  | {
+      kind: 'web-fetch';
+      url?: string;
+      title?: string;
+      content?: string;
+    };
 
 // ============================================================
 // Document metadata
 // ============================================================
 
-const DocumentMetaSchema = z.object({
-  date: z.string(),
-  agent: z.string().optional(),
-  model: z.string().optional(),
-  description: z.string().optional(),
-  instruction: z.string().optional(),
-  files: z.array(z.tuple([z.string(), z.string()])),
-});
-export type DocumentMeta = z.infer<typeof DocumentMetaSchema>;
+export interface DocumentMeta {
+  date: string;
+  agent?: string;
+  model?: string;
+  description?: string;
+  instruction?: string;
+  files: Array<[string, string]>;
+}

--- a/src/agent/types/ServerTools.ts
+++ b/src/agent/types/ServerTools.ts
@@ -39,7 +39,7 @@ const log = createLog('ServerTools');
  * Schema for a single web search result entry.
  * Normalized across all providers.
  */
-export const WebSearchResultEntrySchema = z.object({
+const WebSearchResultEntrySchema = z.object({
   /** URL of the search result */
   url: z.string(),
   /** Title of the page */

--- a/src/shared/schemas/progressView/data.ts
+++ b/src/shared/schemas/progressView/data.ts
@@ -123,10 +123,11 @@ const SafeUrlSchema = z.string().transform(sanitizeLiveLinkUrl);
 
 /**
  * Render-boundary projection of the canonical provider web-search entry
- * (`WebSearchResultEntrySchema` in `@agent/types/ServerTools` — not imported
- * here because the shared layer must not depend on the agent layer). Keeps
- * only the rendered fields, all optional because persisted archives may be
- * partial, and applies the SafeUrl sanitization transform to `url` at this
+ * (`WebSearchResult['results'][number]` in `@agent/types/ServerTools`). The
+ * schema is not imported here because the shared layer must not depend on the
+ * agent layer. It keeps only the rendered fields, all optional because
+ * persisted archives may be partial, and applies the SafeUrl sanitization
+ * transform to `url` at this
  * boundary (#7230). Named for its payload so it no longer collides with the
  * agent layer's same-name schemas (#10279).
  */

--- a/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
@@ -52,7 +52,7 @@ describe('handleExternalInquiryAction', () => {
 
   it('persists and continues submit actions', async () => {
     const manifest = { status: 'answered' };
-    storageMocks.recordAnswerForOpenTurn.mockResolvedValue({ manifest });
+    storageMocks.recordAnswerForOpenTurn.mockResolvedValue(manifest);
 
     await handleExternalInquiryAction({
       action: 'submit',

--- a/src/test-kernel/tools/InquiryStorage.vitest.ts
+++ b/src/test-kernel/tools/InquiryStorage.vitest.ts
@@ -126,10 +126,10 @@ describe('InquiryStorage', () => {
       suggestSearch: false,
     });
 
-    expect(opened.manifest.status).toBe('open');
-    expect(opened.manifest.parentStreamId).toBe(STREAM_A);
-    expect(opened.manifest.turns).toHaveLength(1);
-    expect(opened.turn.suggestSearch).toBe(false);
+    expect(opened.status).toBe('open');
+    expect(opened.parentStreamId).toBe(STREAM_A);
+    expect(opened.turns).toHaveLength(1);
+    expect(opened.turns.at(-1)?.suggestSearch).toBe(false);
 
     const open = await listThreadsByStatus({ status: 'open', scope: 'all' });
     expect(open).toHaveLength(1);
@@ -140,8 +140,10 @@ describe('InquiryStorage', () => {
       answer: 'C = (n(n-2))^{-1} * ω_n^{2/n}',
     });
     expect(answered).not.toBeNull();
-    expect(answered!.manifest.status).toBe('answered');
-    expect(answered!.turn.answer).toBe('C = (n(n-2))^{-1} * ω_n^{2/n}');
+    expect(answered!.status).toBe('answered');
+    expect(answered!.turns.at(-1)).toMatchObject({
+      answer: 'C = (n(n-2))^{-1} * ω_n^{2/n}',
+    });
 
     const stillOpen = await listThreadsByStatus({
       status: 'open',
@@ -194,9 +196,9 @@ describe('InquiryStorage', () => {
       question: 'Q2 (follow-up)',
     });
 
-    expect(followUp.manifest.status).toBe('open');
-    expect(followUp.manifest.turns).toHaveLength(2);
-    expect(followUp.turn.question).toBe('Q2 (follow-up)');
+    expect(followUp.status).toBe('open');
+    expect(followUp.turns).toHaveLength(2);
+    expect(followUp.turns.at(-1)?.question).toBe('Q2 (follow-up)');
   });
 
   it('keeps first-turn draft context valid for hydrated new inquiries', async () => {
@@ -282,7 +284,7 @@ describe('InquiryStorage', () => {
       parentExecutionId: null,
       question: 'Q2 from B',
     });
-    expect(fromB.manifest.parentStreamId).toBe(STREAM_B);
+    expect(fromB.parentStreamId).toBe(STREAM_B);
 
     const openOnA = await listThreadsByStatus({
       status: 'open',

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -281,7 +281,7 @@ export class ExternalInquiryTool extends defineTool({
       data: input.question.slice(0, 100),
     });
 
-    const persisted = await recordOpenQuestion({
+    const manifest = await recordOpenQuestion({
       threadId: input.thread_id ?? undefined,
       parentStreamId: streamId,
       parentExecutionId: executionId ?? null,
@@ -293,7 +293,6 @@ export class ExternalInquiryTool extends defineTool({
     // Use the manifest recordOpenQuestion just wrote under the thread lock —
     // a re-read would only reintroduce the write/read race the continuation
     // injectors already avoid via writer snapshots.
-    const manifest = persisted.manifest;
 
     // Register the asking stream without switching the active view: hosts
     // own presentation focus (the extension/desktop progress views badge the
@@ -310,9 +309,9 @@ export class ExternalInquiryTool extends defineTool({
       },
     });
     const permission: ExternalInquiryPermission = {
-      requestId: persisted.threadId, // legacy field — panel addresses by threadId now
+      requestId: manifest.threadId, // legacy field — panel addresses by threadId now
       question: input.question,
-      threadId: persisted.threadId,
+      threadId: manifest.threadId,
       context: questionContext,
       suggestSearch,
       attachFiles,
@@ -330,7 +329,7 @@ export class ExternalInquiryTool extends defineTool({
     await interaction;
 
     // Background Tasks panel: announce the open thread.
-    const summary = await getThreadSummary(persisted.threadId);
+    const summary = await getThreadSummary(manifest.threadId);
     if (summary) {
       ownerSession.events.emit({
         scope: 'session',
@@ -344,13 +343,13 @@ export class ExternalInquiryTool extends defineTool({
     const message =
       'Question dispatched to the user. The tool returned without waiting. ' +
       'You will be woken with a continuation message when an answer arrives. ' +
-      `Do NOT re-dispatch on thread_id=${persisted.threadId}. ` +
+      `Do NOT re-dispatch on thread_id=${manifest.threadId}. ` +
       'If your next step depends on this answer, end your turn now; ' +
       'otherwise proceed with independent work.';
 
     return executed(
-      `status: dispatched\nthread_id: ${persisted.threadId}\n\n${message}`,
-      `Inquiry dispatched (${persisted.threadId})`,
+      `status: dispatched\nthread_id: ${manifest.threadId}\n\n${message}`,
+      `Inquiry dispatched (${manifest.threadId})`,
     );
   }
 

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -107,18 +107,6 @@ export type ExternalInquiryThreadManifest = z.infer<
   typeof ExternalInquiryThreadManifestSchema
 >;
 
-interface PersistedOpenTurn {
-  threadId: InquiryThreadId;
-  manifest: ExternalInquiryThreadManifest;
-  turn: OpenInquiryTurn;
-}
-
-interface PersistedAnsweredTurn {
-  threadId: InquiryThreadId;
-  manifest: ExternalInquiryThreadManifest;
-  turn: AnsweredInquiryTurn;
-}
-
 // ============================================================================
 // Per-thread write lock
 // ============================================================================
@@ -213,11 +201,6 @@ function normalizeSessionLinks(links?: string[] | null): string[] | undefined {
 // Open / answer / drop helpers
 // ============================================================================
 
-interface OpenTurnUpdate<T> {
-  manifest: ExternalInquiryThreadManifest;
-  result: T;
-}
-
 /**
  * Read a thread manifest under its lock, require the last turn to be open,
  * and replace it via `update`. Returns null without calling `update` if the
@@ -225,14 +208,17 @@ interface OpenTurnUpdate<T> {
  * the shared guard behind `recordAnswerForOpenTurn` and
  * `persistOpenTurnDraft`.
  */
-async function withOpenTurnUpdate<T>(
+async function withOpenTurnUpdate(
   threadId: InquiryThreadId,
   update: (
     existing: ExternalInquiryThreadManifest,
     lastTurn: OpenInquiryTurn,
     timestamp: string,
-  ) => Promise<OpenTurnUpdate<T> | null> | OpenTurnUpdate<T> | null,
-): Promise<{ manifest: ExternalInquiryThreadManifest; result: T } | null> {
+  ) =>
+    | Promise<ExternalInquiryThreadManifest | null>
+    | ExternalInquiryThreadManifest
+    | null,
+): Promise<ExternalInquiryThreadManifest | null> {
   return threadMutex.runExclusive(threadId, async () => {
     const existing = await readThreadManifest(threadId);
     if (!existing || existing.status !== 'open' || existing.turns.length === 0)
@@ -243,11 +229,11 @@ async function withOpenTurnUpdate<T>(
     if (lastTurn.kind !== 'open') return null;
 
     const timestamp = new Date().toISOString();
-    const outcome = await update(existing, lastTurn, timestamp);
-    if (!outcome) return null;
+    const nextManifest = await update(existing, lastTurn, timestamp);
+    if (!nextManifest) return null;
 
-    await writeThreadManifest(outcome.manifest);
-    return { manifest: outcome.manifest, result: outcome.result };
+    await writeThreadManifest(nextManifest);
+    return nextManifest;
   });
 }
 
@@ -271,7 +257,7 @@ export async function recordOpenQuestion(params: {
   context?: string;
   suggestSearch?: boolean;
   attachFiles?: string[];
-}): Promise<PersistedOpenTurn> {
+}): Promise<ExternalInquiryThreadManifest> {
   const threadId = params.threadId ?? (`ei_${hexId12()}` as InquiryThreadId);
 
   return threadMutex.runExclusive(threadId, async () => {
@@ -332,7 +318,7 @@ export async function recordOpenQuestion(params: {
 
     await writeThreadManifest(nextManifest);
 
-    return { threadId, manifest: nextManifest, turn };
+    return nextManifest;
   });
 }
 
@@ -347,8 +333,8 @@ export async function recordAnswerForOpenTurn(params: {
   threadId: InquiryThreadId;
   answer: string;
   sessionLinks?: string[] | null;
-}): Promise<PersistedAnsweredTurn | null> {
-  const outcome = await withOpenTurnUpdate(
+}): Promise<ExternalInquiryThreadManifest | null> {
+  return withOpenTurnUpdate(
     params.threadId,
     (existing, lastTurn, timestamp) => {
       const sessionLinks = normalizeSessionLinks(params.sessionLinks);
@@ -370,17 +356,9 @@ export async function recordAnswerForOpenTurn(params: {
         turns: [...existing.turns.slice(0, -1), answeredTurn],
       };
 
-      return { manifest: nextManifest, result: answeredTurn };
+      return nextManifest;
     },
   );
-
-  if (!outcome) return null;
-
-  return {
-    threadId: params.threadId,
-    manifest: outcome.manifest,
-    turn: outcome.result,
-  };
 }
 
 /**
@@ -389,9 +367,8 @@ export async function recordAnswerForOpenTurn(params: {
  * overwrite an `answered` status (which would emit a contradictory
  * dropped continuation and corrupt the audit trail).
  *
- * Returns the just-written manifest on success so callers can pass
- * it to the continuation injector without a re-read (symmetric with
- * `recordAnswerForOpenTurn`'s `PersistedAnsweredTurn.manifest`).
+ * Returns the just-written manifest on success so callers can pass it to the
+ * continuation injector without a re-read, matching `recordAnswerForOpenTurn`.
  * Returns `null` when the drop was a no-op (already answered/dropped
  * or not found).
  */
@@ -438,7 +415,7 @@ export async function persistOpenTurnDraft(params: {
       turns: [...existing.turns.slice(0, -1), nextTurn],
     };
 
-    return { manifest: nextManifest, result: undefined };
+    return nextManifest;
   });
 }
 

--- a/src/tools/inquiry/inquiryActions.ts
+++ b/src/tools/inquiry/inquiryActions.ts
@@ -75,12 +75,12 @@ export async function persistExternalInquiryAction(
   payload: ExternalInquiryAction,
 ): Promise<ExternalInquiryTransition> {
   if (payload.action === 'submit') {
-    const persisted = await recordAnswerForOpenTurn({
+    const manifest = await recordAnswerForOpenTurn({
       threadId: payload.threadId,
       answer: payload.answer,
       sessionLinks: payload.sessionLinks ?? undefined,
     });
-    if (!persisted) {
+    if (!manifest) {
       logger.warn(
         `Inquiry submit ignored: thread ${payload.threadId} has no open turn.`,
       );
@@ -89,7 +89,7 @@ export async function persistExternalInquiryAction(
     return {
       kind: 'answered',
       threadId: payload.threadId,
-      manifest: persisted.manifest,
+      manifest,
     };
   }
 

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -230,8 +230,8 @@ function webFetchEntryToMessages(
           type: 'web_fetch_tool_result',
           url: data.url,
           ...(data.title !== undefined && { title: data.title }),
-          // `page_content` is the field name normalizeConversationForExport's
-          // ContentBlockSchema already recognizes for this block type (#7508).
+          // `page_content` is the archived field name the export normalizer's
+          // web-fetch handling recognizes for this block type (#7508).
           ...(data.content !== undefined && {
             page_content: data.content,
           }),


### PR DESCRIPTION
## Summary

- replace nine chat-export Zod schemas that were never parsed with equivalent TypeScript types while retaining every provider, archive, URL-sanitization, and persistence validation boundary
- preserve canonical export field ownership through `WebSearchResult` and `MediaAttachmentKind`
- return inquiry manifests directly while retaining per-thread mutex ownership, stale-action arbitration, `threadId` identity, and just-written snapshot semantics
- privatize only the otherwise-unused `WebSearchResultEntrySchema` export and point the shared-layer projection comment to the canonical public type

## Issue acceptance gates

No linked issue. Acceptance gates for this refactor:

- chat-export type-only schemas are removed without removing runtime parsing at provider, archive, render, or persistence boundaries
- canonical exported fields remain sourced from existing public types rather than being re-declared
- inquiry writers return the exact manifest written under the keyed mutex, and callers do not re-read storage
- submit/drop races still resolve through open-turn/status guards, so stale actions cannot overwrite a terminal state or dispatch a contradictory continuation
- generated and supplied `threadId` values remain the manifest's canonical `threadId`
- the stale shared-layer comment names the public canonical source, not the private schema

All gates are satisfied.

## Single source of truth

- `WebSearchResult['results'][number]` in `src/agent/types/ServerTools.ts` owns canonical provider web-search entry fields.
- `MediaAttachmentKind` in `src/shared/schemas/progressView/data.ts` owns export attachment vocabulary.
- `ExternalInquiryThreadManifest` and the per-thread writer mutex in `src/tools/inquiry/externalInquiryStorage.ts` own inquiry persistence state and write snapshots.
- Runtime validation remains at the actual boundaries: provider result schemas in `ServerTools.ts`, archive/input parsing, progress-view URL sanitization, and inquiry manifest parsing.

## Duplication and abstraction budget

Removed nine type-derivation-only Zod schemas, three inquiry result-wrapper interfaces, one generic update wrapper, and their pass-through object construction. No new pass-through layer was added. The replacement types reuse canonical field owners, while inquiry APIs return the durable manifest they already write.

## Net elements (R6)

- Files: 0 added, 0 deleted, 10 modified.
- Exported symbols: net -1. Six existing exported type names remain under equivalent TypeScript declarations; the unused runtime export `WebSearchResultEntrySchema` becomes private.
- Classes: 0 added, 0 deleted.
- Interfaces: 4 added and 3 deleted, net +1. Three additions replace existing exported type aliases; `ConversationMessage` replaces a private inferred type.
- Enums: 0 added, 0 deleted.
- LoC: +156 / -213, net -57.

## Consumer counts (R8)

- `WebSearchResultEntrySchema`: 2 production imports before this change (`normalizeConversation.ts` and `schemas.ts`), both rerouted to the public `WebSearchResult` type; 0 external imports remain. Its private schema still has 2 internal references in `ServerTools.ts`: the canonical entry type inference and the nested `WebSearchResultSchema` validation boundary; `mapAnthropicWebSearchEntries` continues to produce that canonical entry type.
- Inquiry return wrappers: `recordOpenQuestion` has 1 production caller and `recordAnswerForOpenTurn` has 1 production caller; both now consume the direct manifest. No event emit path is deleted or rerouted.

## Host impact

Extension: No user-visible change. Chat export and inquiry panel behavior are preserved.

Desktop: No user-visible change. Shared export/inquiry runtime behavior and persistence semantics are preserved.

CLI: No user-visible change. Inquiry remains unavailable in CLI, and CLI source plus script typechecks and host-import architecture checks pass.

## Scheduled refactoring

None. The refactor is complete and does not leave a compatibility shim or follow-up abstraction.

## Validation

- focused export/parity/archive suites: 7 files, 97 tests passed
- focused inquiry suites: 9 files, 68 tests passed
- full Vitest suite: 822 files passed, 1 skipped; 9,985 tests passed, 6 skipped
- full `typecheck`: workspace, test-kernel, agent declaration build, CLI source and scripts, trace viewer, desktop
- full ESLint
- full Prettier check
- CLI host-import architecture check
- architecture kernel suites: 15 files, 101 tests passed
- dead-code ratchet: 295 findings against 295 baselined, no new findings
- guidance-reference check
- browser-safe-utils drift check: 65 total, 6 reachable
- `git diff --check`

No changelog entry is included because the refactor preserves user-visible behavior.
