### PR TITLE
fix(setup): continue after provider key read failures

### DIFF
--- a/src/model/setupCredentialAccess.ts
+++ b/src/model/setupCredentialAccess.ts
@@ -14,10 +14,16 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 /** True when any provider has a usable API key in secret storage or the environment. */
 async function hasAnyUsableProviderApiKey(
   secrets: PlatformSecrets,
+  onProbeFailure: (message: string) => void,
 ): Promise<boolean> {
   for (const provider of API_PROVIDERS) {
     // Keep the scan sequential so the first usable key ends the lookup.
-    if (isNonEmptyString(await lookupApiKey(secrets, provider))) return true;
+    const hasApiKey = await probeSetupCredential(
+      `${provider} API key`,
+      async () => isNonEmptyString(await lookupApiKey(secrets, provider)),
+      onProbeFailure,
+    );
+    if (hasApiKey) return true;
   }
   return false;
 }
@@ -56,9 +62,5 @@ export async function hasUsableSetupCredential(
     onProbeFailure,
   );
   if (hasGrokSubscription) return true;
-  return probeSetupCredential(
-    'Provider API key',
-    () => hasAnyUsableProviderApiKey(secrets),
-    onProbeFailure,
-  );
+  return hasAnyUsableProviderApiKey(secrets, onProbeFailure);
 }

--- a/src/test-kernel/model/SetupCredentialAccess.vitest.ts
+++ b/src/test-kernel/model/SetupCredentialAccess.vitest.ts
@@ -109,6 +109,7 @@ describe('setup credential access', () => {
           new Error('chatgpt offline'),
         ),
       message: 'chatgpt offline',
+      expectedResult: false,
       expectedEvents: ['subscription:grok', 'key:openai', 'key:anthropic'],
     },
     {
@@ -118,19 +119,31 @@ describe('setup credential access', () => {
           new Error('grok offline'),
         ),
       message: 'grok offline',
+      expectedResult: false,
       expectedEvents: ['subscription:chatgpt', 'key:openai', 'key:anthropic'],
     },
     {
-      kind: 'Provider API key',
-      fail: () =>
-        mocks.lookupApiKey.mockRejectedValueOnce(new Error('keychain locked')),
+      kind: 'openai API key',
+      fail: () => {
+        access.keys.anthropic = 'sk-ant-test';
+        mocks.lookupApiKey.mockImplementationOnce(async (_, provider) => {
+          events.push(`key:${provider}`);
+          throw new Error('keychain locked');
+        });
+      },
       message: 'keychain locked',
-      expectedEvents: ['subscription:chatgpt', 'subscription:grok'],
+      expectedResult: true,
+      expectedEvents: [
+        'subscription:chatgpt',
+        'subscription:grok',
+        'key:openai',
+        'key:anthropic',
+      ],
     },
   ])('reports a failed $kind probe and continues safely', async (testCase) => {
     testCase.fail();
 
-    await expect(hasCredential()).resolves.toBe(false);
+    await expect(hasCredential()).resolves.toBe(testCase.expectedResult);
     expect(mocks.reportProbeFailure).toHaveBeenCalledWith(
       `${testCase.kind} check failed; treating it as no credential: ${testCase.message}`,
     );


### PR DESCRIPTION
## Summary

- isolate API-key lookup failures to the provider being checked
- continue scanning later providers after a keychain or environment lookup error
- keep reporting each failed probe through the existing setup warning path
- add a regression proving a failed OpenAI lookup does not hide a valid Anthropic key

## Why

The previous outer probe wrapped the entire provider loop. If one provider lookup threw, setup treated the whole provider-key scan as failed and never checked later providers, so a usable credential could be reported as missing.

## Validation

Reconstructed on current `main` (`6e3dda7f05`) and validated at `1230c5fbfe`:

- focused setup/model/provider suites: 7 files, 65 tests passed
- `corepack pnpm run compile:safe`
- `corepack pnpm run lint`
- `corepack pnpm run format:check`
- `corepack pnpm --filter @texra-ai/cli run check:architecture`
- `corepack pnpm run check:dead-code-ratchet`
- `corepack pnpm test` (822 files passed, 1 skipped; 9,985 tests passed, 6 skipped)
- `git diff --check`
