### PR TITLE
refactor(cli): remove TUI identity and fixture residue

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -46,11 +46,8 @@ import {
 } from './appInteractionPolicy';
 import { ApprovalModal } from './modals/ApprovalModal';
 import { InfoPane } from './panes/InfoPane';
-import { WorkPlanReader, workPlanReaderTitle } from './panes/WorkPlanReader';
-import {
-  TranscriptReader,
-  transcriptReaderTitle,
-} from './panes/TranscriptReader';
+import { WorkPlanReader } from './panes/WorkPlanReader';
+import { TranscriptReader } from './panes/TranscriptReader';
 import { WorkflowPopup } from './panes/WorkflowPopup';
 import { InputBar, type InputBarHandle } from './panes/InputBar';
 import { ConversationRegion } from './panes/ConversationRegion';
@@ -110,7 +107,6 @@ import { focusedChildFollowUpRoute } from './state/focusedChildFollowUp';
 import {
   INITIAL_CHILD_LIST_SELECTION,
   reduceChildListSelection,
-  type ChildListValue,
 } from './state/childListSelection';
 import { streamLabelForId, streamTreeViews } from './state/streamViews';
 import { useSignal } from './state/useSignal';
@@ -426,15 +422,14 @@ export function App(props: AppProps): React.JSX.Element {
       ),
     [childListTarget, pendingSummaries, rootStreamId],
   );
-  const childListValues = useMemo<readonly ChildListValue[]>(
+  const childListValues = useMemo<readonly StreamTabId[]>(
     () => sessionViews.map((session) => session.id),
     [sessionViews],
   );
   const childListAvailable = childListValues.length > 0;
-  const selectedChildStreamId = selectedChildValue;
   const selectedChildKillable =
-    selectedChildStreamId !== undefined &&
-    activeSubagentExecutionIds.has(selectedChildStreamId);
+    selectedChildValue !== undefined &&
+    activeSubagentExecutionIds.has(selectedChildValue);
   useEffect(() => {
     dispatchChildListSelection({
       kind: 'reconcile',
@@ -519,13 +514,11 @@ export function App(props: AppProps): React.JSX.Element {
         ) : null;
       case 'transcriptReader': {
         if (foregroundReader?.kind !== 'transcript') return null;
-        const title = transcriptReaderTitle(
-          streamLabelForId({
-            childRosters,
-            parentStream,
-            streamId: foregroundReader.streamId,
-          }),
-        );
+        const label = streamLabelForId({
+          childRosters,
+          parentStream,
+          streamId: foregroundReader.streamId,
+        });
         return (
           <TranscriptReader
             availableRows={availableRows}
@@ -540,7 +533,7 @@ export function App(props: AppProps): React.JSX.Element {
               }
             }}
             streamId={foregroundReader.streamId}
-            title={title}
+            title={`Transcript: ${label}`}
           />
         );
       }
@@ -574,13 +567,11 @@ export function App(props: AppProps): React.JSX.Element {
       }
       case 'workPlanReader': {
         if (foregroundReader?.kind !== 'workPlan') return null;
-        const title = workPlanReaderTitle(
-          streamLabelForId({
-            childRosters,
-            parentStream,
-            streamId: foregroundReader.streamId,
-          }),
-        );
+        const label = streamLabelForId({
+          childRosters,
+          parentStream,
+          streamId: foregroundReader.streamId,
+        });
         return (
           <WorkPlanReader
             availableRows={availableRows}
@@ -592,7 +583,7 @@ export function App(props: AppProps): React.JSX.Element {
             loading={foregroundReader.loading === true}
             onClose={closeForegroundReader}
             streamId={foregroundReader.streamId}
-            title={title}
+            title={`Work plan: ${label}`}
           />
         );
       }
@@ -876,7 +867,6 @@ export function App(props: AppProps): React.JSX.Element {
           childListFocused,
           sessionViews,
           selectedChildValue,
-          selectedChildStreamId,
           streams,
           subagentExecutionLabels,
           activeSubagentExecutionIds,

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -34,7 +34,6 @@ import {
   queuedFollowUpsFor,
   sessionStateRevision,
 } from '../state/childExecutions';
-import { type ChildListValue } from '../state/childListSelection';
 import { inputBarContentRows } from '../state/cliState';
 import {
   readStreamArtifacts,
@@ -58,9 +57,7 @@ interface ConversationRegionSnapshot {
   readonly reverseSearchOpen: boolean;
   readonly rootStreamId: StreamTabId | undefined;
   readonly slashPaletteOpen: boolean;
-  readonly selectedChildValue: ChildListValue | undefined;
-  /** Stream `selectedChildValue` points at, resolved once by `App`. */
-  readonly selectedChildStreamId: StreamTabId | undefined;
+  readonly selectedChildValue: StreamTabId | undefined;
   readonly childListFocused: boolean;
   readonly sessionViews: readonly StreamView[];
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
@@ -83,7 +80,7 @@ interface ConversationRegionProps {
   readonly rows: number;
   readonly snapshot: ConversationRegionSnapshot;
   readonly onCancelChildList: () => void;
-  readonly onChildSelectionChange: (value: ChildListValue) => void;
+  readonly onChildSelectionChange: (value: StreamTabId) => void;
   readonly onFocusSession: (streamId: StreamTabId) => void;
   readonly onKillExecution: (executionId: string) => void;
 }
@@ -265,7 +262,6 @@ export function ConversationRegion({
               onSelectionChange={onChildSelectionChange}
               pendingApprovals={snapshot.pendingApprovals}
               listRootStreamId={snapshot.listRootStreamId}
-              selectedChildStreamId={snapshot.selectedChildStreamId}
               selectedValue={snapshot.selectedChildValue}
               sessions={snapshot.sessionViews}
               activeSubagentExecutionIds={snapshot.activeSubagentExecutionIds}

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -38,7 +38,6 @@ import {
 } from './SubagentListDisplay';
 import { useSignal } from '../state/useSignal';
 import { streamPhaseFor } from '../state/cliState';
-import type { ChildListValue } from '../state/childListSelection';
 import type { PendingApprovalKind } from '../state/approvalQueue';
 import type { StreamView } from '../state/streamViews';
 
@@ -217,7 +216,7 @@ export interface SubagentListProps {
   readonly onCancel?: () => void;
   readonly onFocusStream?: (streamId: StreamTabId) => void;
   readonly onKillExecution?: (executionId: string) => void;
-  readonly onSelectionChange?: (value: ChildListValue) => void;
+  readonly onSelectionChange?: (value: StreamTabId) => void;
   /**
    * Pending approval kinds per stream id (see `pendingApprovalSummaries`; the
    * caller folds stream-less approvals onto the visible surface root via
@@ -232,11 +231,8 @@ export interface SubagentListProps {
     string,
     readonly PendingApprovalKind[]
   >;
-  readonly selectedValue?: ChildListValue;
+  readonly selectedValue?: StreamTabId;
   readonly sessions?: readonly StreamView[];
-  /** Stream `selectedValue` points at, resolved once by `App` — the same
-   *  stream the status bar advertises as killable. */
-  readonly selectedChildStreamId?: StreamTabId;
   /** Stream the list is rooted on — its row never shows a summary. */
   readonly listRootStreamId?: StreamTabId;
   readonly activeSubagentExecutionIds?: ReadonlyMap<StreamTabId, string>;
@@ -252,8 +248,8 @@ export function SubagentList(
     [sessions],
   );
   const { items, sessionsByValue } = useMemo(() => {
-    const nextItems: SelectItem<ChildListValue>[] = [];
-    const byValue = new Map<ChildListValue, StreamView>();
+    const nextItems: SelectItem<StreamTabId>[] = [];
+    const byValue = new Map<StreamTabId, StreamView>();
     // Row order has one owner, `streamTreeEntries`: do not re-sort here, it
     // would desynchronise the Alt+1..9 numbers it assigns from the rows on
     // screen.
@@ -271,7 +267,7 @@ export function SubagentList(
   useInput(
     (input, key) => {
       if (key.ctrl || key.meta) return;
-      const streamId = props.selectedChildStreamId;
+      const streamId = props.selectedValue;
       if (!streamId) return;
       if (input.toLowerCase() !== 'k') return;
       const executionId = props.activeSubagentExecutionIds?.get(streamId);
@@ -311,8 +307,7 @@ export function SubagentList(
         wrap={false}
         onHighlightChange={(value) => props.onSelectionChange?.(value)}
         onSelect={(value) => {
-          const streamId = value;
-          if (streamId) props.onFocusStream?.(streamId);
+          if (value) props.onFocusStream?.(value);
         }}
         renderItem={(item, state) => {
           const session = sessionsByValue.get(item.value);

--- a/packages/cli/src/chat/tui/panes/TranscriptReader.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptReader.tsx
@@ -135,10 +135,6 @@ function hydrateRowHeadline(
   }
 }
 
-export function transcriptReaderTitle(label: string | undefined): string {
-  return label ? `Transcript: ${label}` : 'Transcript';
-}
-
 export function TranscriptReader({
   availableRows,
   executionLabels,

--- a/packages/cli/src/chat/tui/panes/WorkPlanReader.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkPlanReader.tsx
@@ -88,10 +88,6 @@ export function workPlanReaderLayout({
   };
 }
 
-export function workPlanReaderTitle(label: string | undefined): string {
-  return label ? `Work plan: ${label}` : 'Work plan';
-}
-
 /** `available` marks the fields this reader may present as facts; a field it
  *  omits is presented, an unavailable one is masked. */
 export function formatWorkPlanReaderText(

--- a/packages/cli/src/chat/tui/state/childListSelection.ts
+++ b/packages/cli/src/chat/tui/state/childListSelection.ts
@@ -1,28 +1,25 @@
 // Local imports - shared stream identity
 import type { StreamTabId } from '@shared/schemas';
 
-/** A child-list row is a stream; the selection carries its id as is. */
-export type ChildListValue = StreamTabId;
-
 export interface ChildListSelectionState {
   readonly focused: boolean;
-  readonly selectedValue: ChildListValue | undefined;
+  readonly selectedValue: StreamTabId | undefined;
 }
 
 type ChildListSelectionAction =
   | { readonly kind: 'blur' }
-  | { readonly kind: 'focus'; readonly value?: ChildListValue }
+  | { readonly kind: 'focus'; readonly value?: StreamTabId }
   | { readonly kind: 'focusStream'; readonly streamId: StreamTabId }
-  | { readonly kind: 'highlight'; readonly value: ChildListValue }
+  | { readonly kind: 'highlight'; readonly value: StreamTabId }
   | {
       readonly kind: 'syncActiveStream';
       readonly streamId: StreamTabId;
-      readonly values: readonly ChildListValue[];
+      readonly values: readonly StreamTabId[];
     }
   | {
       readonly kind: 'reconcile';
       readonly activeStreamId: StreamTabId | undefined;
-      readonly values: readonly ChildListValue[];
+      readonly values: readonly StreamTabId[];
     };
 
 export const INITIAL_CHILD_LIST_SELECTION: ChildListSelectionState = {
@@ -31,16 +28,13 @@ export const INITIAL_CHILD_LIST_SELECTION: ChildListSelectionState = {
 };
 
 function resolveChildSelectionValue(
-  values: readonly ChildListValue[],
-  selectedValue: ChildListValue | undefined,
+  values: readonly StreamTabId[],
+  selectedValue: StreamTabId | undefined,
   activeStreamId: StreamTabId | undefined,
-): ChildListValue | undefined {
+): StreamTabId | undefined {
   if (selectedValue && values.includes(selectedValue)) return selectedValue;
-  if (activeStreamId) {
-    const activeValue = activeStreamId;
-    if (values.includes(activeValue)) return activeValue;
-    return undefined;
-  }
+  if (activeStreamId)
+    return values.includes(activeStreamId) ? activeStreamId : undefined;
   return values[0];
 }
 

--- a/src/test-kernel/cli/ChildListInteraction.vitest.ts
+++ b/src/test-kernel/cli/ChildListInteraction.vitest.ts
@@ -3,12 +3,9 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { describe, expect, it, vi } from 'vitest';
 
 import { SubagentList } from '@cli/chat/tui/panes/SubagentList';
-import type { ChildListValue } from '@cli/chat/tui/state/childListSelection';
-import { emptySlice, type StreamSlice } from '@cli/chat/tui/state/cliState';
 import type { StreamView } from '@cli/chat/tui/state/streamViews';
 import { POINTER } from '@cli/tui/ui/glyphs';
-import { type StreamTabId, type WorkflowCallProgress } from '@shared/schemas';
-import type { PhaseRow, WorkflowTaskRow } from '@shared/transcript';
+import { type StreamTabId } from '@shared/schemas';
 import {
   loadInk,
   renderInteractive,
@@ -17,7 +14,6 @@ import {
   type InkRenderHandles,
 } from '@test/support/inkTestHarness.ts';
 import { waitForCondition as waitFor } from '@test/support/asyncTestUtils';
-import { workflowPhaseGrouping } from '@test/support/transcriptRowFixtures';
 
 const root = 'root' as StreamTabId;
 const child = 'child' as StreamTabId;
@@ -42,76 +38,31 @@ function waitForInput(stdin: FakeStdin): Promise<void> {
  */
 function controlledList(
   React: any,
-  initial: ChildListValue,
+  initial: StreamTabId,
   props: Record<string, unknown>,
 ): {
   Harness: () => any;
-  current: () => ChildListValue;
+  current: () => StreamTabId;
 } {
   let selected = initial;
   function Harness() {
     const [value, setValue] = React.useState(selected) as [
-      ChildListValue,
-      (next: ChildListValue) => void,
+      StreamTabId,
+      (next: StreamTabId) => void,
     ];
     return React.createElement(SubagentList, {
       ...props,
-      onSelectionChange: (next: ChildListValue) => {
-        (
-          props.onSelectionChange as ((v: ChildListValue) => void) | undefined
-        )?.(next);
+      onSelectionChange: (next: StreamTabId) => {
+        (props.onSelectionChange as ((v: StreamTabId) => void) | undefined)?.(
+          next,
+        );
         selected = next;
         setValue(next);
       },
       selectedValue: value,
-      // `App` resolves the highlighted row to a stream once and hands the
-      // result down; a plain session row resolves to its own stream.
-      selectedChildStreamId:
-        value ?? (props.selectedChildStreamId as StreamTabId | undefined),
     });
   }
   return { Harness, current: () => selected };
-}
-
-function workflowRootSlice(rows: StreamSlice['entries']): StreamSlice {
-  const { taskGroups, entries } = workflowPhaseGrouping(rows);
-  return {
-    ...emptySlice(root),
-    taskGroups,
-    entries,
-  };
-}
-
-function phaseRow(
-  id: string,
-  phaseLabel: string,
-  phaseIndex: number,
-  phaseTotal: number,
-): PhaseRow {
-  return {
-    kind: 'phase',
-    id,
-    timestamp: 0,
-    level: 'info',
-    heading: phaseLabel,
-    phaseLabel,
-    phaseIndex,
-    phaseTotal,
-  };
-}
-
-function taskRow(id: string, call: WorkflowCallProgress): WorkflowTaskRow {
-  const statusLabel = call.status === 'running' ? 'Running' : 'Planned';
-  return {
-    kind: 'workflowTask',
-    id,
-    timestamp: 0,
-    level: 'info',
-    call,
-    line: `${statusLabel}: ${call.label}`,
-    statusLabel,
-    metadataParts: [],
-  };
 }
 
 describe('CLI child list interaction', () => {

--- a/src/test-kernel/cli/ChildListSelection.vitest.ts
+++ b/src/test-kernel/cli/ChildListSelection.vitest.ts
@@ -4,20 +4,16 @@ import {
   INITIAL_CHILD_LIST_SELECTION,
   reduceChildListSelection,
   type ChildListSelectionState,
-  type ChildListValue,
 } from '@cli/chat/tui/state/childListSelection';
 import type { StreamTabId } from '@shared/schemas';
 
 const main = 'main' as StreamTabId;
 const strategy = 'strategy' as StreamTabId;
 const analysis = 'analysis' as StreamTabId;
-const mainValue = main;
-const strategyValue = strategy;
-const analysisValue = analysis;
 
 function reconcileSelection(
   state: ChildListSelectionState,
-  values: readonly ChildListValue[],
+  values: readonly StreamTabId[],
   activeStreamId: StreamTabId | undefined,
 ): ChildListSelectionState {
   return reduceChildListSelection(state, {
@@ -31,67 +27,59 @@ describe('CLI child list selection', () => {
   it('preserves a selection across list focus and row reordering', () => {
     let state = reconcileSelection(
       INITIAL_CHILD_LIST_SELECTION,
-      [mainValue, strategyValue, analysisValue],
+      [main, strategy, analysis],
       main,
     );
     state = reduceChildListSelection(state, { kind: 'focus' });
     state = reduceChildListSelection(state, {
       kind: 'highlight',
-      value: analysisValue,
+      value: analysis,
     });
-    state = reconcileSelection(
-      state,
-      [strategyValue, analysisValue, mainValue],
-      main,
-    );
+    state = reconcileSelection(state, [strategy, analysis, main], main);
 
     expect(state).toEqual({
       focused: true,
-      selectedValue: analysisValue,
+      selectedValue: analysis,
     });
   });
 
   it('preserves selection while hidden and restores it when rows return', () => {
     const selected: ChildListSelectionState = {
       focused: true,
-      selectedValue: strategyValue,
+      selectedValue: strategy,
     };
     const hidden = reconcileSelection(selected, [], main);
-    const restored = reconcileSelection(
-      hidden,
-      [mainValue, strategyValue],
-      main,
-    );
+    const restored = reconcileSelection(hidden, [main, strategy], main);
 
     expect(hidden).toBe(selected);
-    expect(restored.selectedValue).toBe(strategyValue);
+    expect(restored.selectedValue).toBe(strategy);
   });
 
   it('selects the owner when lifecycle completion changes the active stream', () => {
     const state = reduceChildListSelection(
-      { focused: true, selectedValue: strategyValue },
+      { focused: true, selectedValue: strategy },
       {
         kind: 'syncActiveStream',
         streamId: main,
-        values: [mainValue, strategyValue],
+        values: [main, strategy],
       },
     );
 
     expect(state).toEqual({
       focused: true,
-      selectedValue: mainValue,
+      selectedValue: main,
     });
   });
 
   it('preserves identity when active-stream sync keeps the same row', () => {
     const hidden: ChildListSelectionState = {
       focused: true,
-      selectedValue: mainValue,
+      selectedValue: main,
     };
     const state = reduceChildListSelection(hidden, {
       kind: 'syncActiveStream',
       streamId: main,
-      values: [mainValue, strategyValue],
+      values: [main, strategy],
     });
 
     expect(state).toBe(hidden);
@@ -99,11 +87,11 @@ describe('CLI child list selection', () => {
 
   it('clears a stale row when the active stream is not in the projected list', () => {
     const state = reduceChildListSelection(
-      { focused: true, selectedValue: strategyValue },
+      { focused: true, selectedValue: strategy },
       {
         kind: 'syncActiveStream',
         streamId: main,
-        values: [analysisValue],
+        values: [analysis],
       },
     );
 
@@ -119,61 +107,57 @@ describe('CLI child list selection', () => {
         focused: true,
         selectedValue: 'gone' as StreamTabId,
       },
-      [analysisValue, mainValue],
+      [analysis, main],
       main,
     );
-    expect(state.selectedValue).toBe(mainValue);
+    expect(state.selectedValue).toBe(main);
 
-    state = reconcileSelection(
-      state,
-      [analysisValue, strategyValue],
-      undefined,
-    );
-    expect(state.selectedValue).toBe(analysisValue);
+    state = reconcileSelection(state, [analysis, strategy], undefined);
+    expect(state.selectedValue).toBe(analysis);
   });
 
   it('does not preselect a row while the active root is absent from the list', () => {
     let state = reconcileSelection(
       INITIAL_CHILD_LIST_SELECTION,
-      [analysisValue],
+      [analysis],
       main,
     );
     expect(state.selectedValue).toBeUndefined();
 
     state = reduceChildListSelection(state, {
       kind: 'focus',
-      value: analysisValue,
+      value: analysis,
     });
     expect(state).toEqual({
       focused: true,
-      selectedValue: analysisValue,
+      selectedValue: analysis,
     });
   });
 
   it('returns input after a stream is focused', () => {
     const state = reduceChildListSelection(
-      { focused: true, selectedValue: analysisValue },
+      { focused: true, selectedValue: analysis },
       { kind: 'focusStream', streamId: strategy },
     );
     expect(state).toEqual({
       focused: false,
-      selectedValue: strategyValue,
+      selectedValue: strategy,
     });
   });
 
   it('changes only the highlighted row without opening a detail block', () => {
     let state = reduceChildListSelection(
-      { focused: false, selectedValue: mainValue },
+      { focused: false, selectedValue: main },
       { kind: 'focus' },
     );
     state = reduceChildListSelection(state, {
       kind: 'highlight',
-      value: strategyValue,
+      value: strategy,
     });
 
     expect(state).toEqual({
       focused: true,
-      selectedValue: strategyValue,
+      selectedValue: strategy,
     });
   });
 });

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -38,15 +38,13 @@ import { SessionState } from '@controllers/session/SessionState';
 import {
   AgentCategory,
   STREAM_PHASE,
-  WORKFLOW_TASK_STATUS_LABEL,
   type ExecutionId,
   type StreamPhase,
   type StreamStage,
   type StreamTabId,
   type TokenUsageStats,
-  type WorkflowCallProgress,
 } from '@shared/schemas';
-import type { PhaseRow, WorkflowTaskRow } from '@shared/transcript';
+import type { PhaseRow } from '@shared/transcript';
 import { formatWorkflowPhaseHeading } from '@shared/copy/workflowCall';
 import { snapshotFacts } from '@test/support/storeTestDrivers';
 import {
@@ -171,27 +169,6 @@ function phaseEntry(
     heading: formatWorkflowPhaseHeading({ phaseLabel: label, ...overrides }),
     phaseLabel: label,
     ...overrides,
-  };
-}
-
-/** `settlementSeqNo` is the durable printable order the recorder assigns; a
- *  task row that has one is settled on arrival. */
-function workflowTaskEntry(
-  id: string,
-  line: string,
-  call: WorkflowCallProgress,
-  settlementSeqNo?: number,
-): WorkflowTaskRow {
-  return {
-    id,
-    kind: 'workflowTask',
-    timestamp: 0,
-    level: 'info',
-    ...(settlementSeqNo !== undefined ? { settlementSeqNo } : {}),
-    call,
-    line,
-    statusLabel: WORKFLOW_TASK_STATUS_LABEL[call.status],
-    metadataParts: [],
   };
 }
 

--- a/src/test-kernel/cli/WorkPlanReader.vitest.ts
+++ b/src/test-kernel/cli/WorkPlanReader.vitest.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import {
   formatWorkPlanReaderText,
   workPlanReaderLayout,
-  workPlanReaderTitle,
 } from '@cli/chat/tui/panes/WorkPlanReader';
 import { TODO_STATUS, type TodoItem } from '@shared/schemas';
 
@@ -72,11 +71,6 @@ describe('WorkPlanReader display model', () => {
     expect(
       formatWorkPlanReaderText(null, [], { plan: false, todos: true }),
     ).toContain('(objective unavailable)');
-  });
-
-  it('uses a concise title in narrow or unlabeled contexts', () => {
-    expect(workPlanReaderTitle(undefined)).toBe('Work plan');
-    expect(workPlanReaderTitle('proof')).toBe('Work plan: proof');
   });
 
   it('counts a wrapped narrow footer in the available row budget', () => {


### PR DESCRIPTION
## Summary

- use `StreamTabId` directly for child-list selection instead of an identity alias
- remove the mirrored selected-stream snapshot and component prop; the kill handler reads the same selected value directly
- inline two one-call reader-title helpers at their sole production owner
- delete four orphaned workflow-row test builders and stale test identity aliases

## Net elements (R6)

- files: 10 modified, 0 added, 0 deleted
- public exports: 1 identity type alias and 2 one-call functions removed
- component state surface: 1 snapshot field and 1 prop removed
- tests: 4 zero-call builders and 3 identity constants removed
- dependencies and abstractions: 0 added
- net diff: 72 insertions, 199 deletions, for 127 fewer lines

## Consumer counts (R8)

- `ChildListValue`: 3 production importers and 2 test importers; it was exactly `StreamTabId`
- `selectedChildStreamId`: mirrored through App, ConversationRegion, and SubagentList with 1 real use; that use now reads `selectedValue`
- `transcriptReaderTitle`: 1 production caller and 0 tests
- `workPlanReaderTitle`: 1 production caller and 1 two-assertion direct test
- `workflowRootSlice`, `phaseRow`, `taskRow`, and `workflowTaskEntry`: 0 callers after prior workflow-list test retirement
- selection, focus, kill, reader layout, workflow popup, and stream rendering paths remain unchanged

## Validation

- focused CLI/TUI Vitest: 4 files, 42 tests passed
- `corepack pnpm run typecheck:cli`
- `corepack pnpm run typecheck:test-kernel`
- targeted ESLint and Prettier checks
- `git diff --check`

The isolated CI static checks, build, and kernel shards are the final full gates.