### PR TITLE
refactor(progress): flatten provider wiring wrappers

### DIFF
--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -22,11 +22,7 @@ import { VscodePromptHost } from '@frontend/hosts/VscodePromptHost';
 import { createAgentPresentationHost } from '@frontend/events/agentEventListeners';
 import { DisposableStore } from '@platform/disposable';
 import { platform } from '@platform/platform';
-import type {
-  AgentProposalPermission,
-  ProgressViewOutboundMessage,
-  StreamTabId,
-} from '@shared/schemas';
+import type { AgentProposalPermission, StreamTabId } from '@shared/schemas';
 import {
   formatActiveStreamRetention,
   formatStreamDeletionRetention,
@@ -101,7 +97,13 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     this.backend = new ProgressBackend({
       session: runtimeSession,
       storage: platform().workspaceState,
-      sendMessage: (message) => this.sendToActiveProgressWebview(message),
+      sendMessage: async (message) => {
+        const webview = this.getActiveWebview();
+        if (!webview) return false;
+        // Delivery failures belong to WebviewBridge's retry path or the
+        // backend's best-effort refresh path, so let postMessage reject.
+        return webview.postMessage(message);
+      },
       hasTarget: () => this.getActiveWebview() !== undefined,
       getStreamControls: getProgressStreamControls,
       getUnsupportedCommands: () =>
@@ -109,7 +111,8 @@ export class ProgressViewProvider extends BaseWebviewProvider {
       reportTranscriptLoadError: (error, stream) =>
         this.reportTranscriptLoadError(error, stream),
       approvals: {
-        canSend: () => this.canSendToWebview(),
+        canSend: () =>
+          this.target?.ready === true && this.renderer.isAvailable(),
         logger: this.logger,
       },
       lifecycle: {
@@ -246,14 +249,11 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     // A handshake from a surface that no longer holds the target describes
     // content that has since been swapped away; it has nothing to sync.
     if (!target) return;
-    if ((target.placement === 'editor') !== this.isPanelView(view)) return;
+    const isEditorView = 'viewColumn' in view;
+    if ((target.placement === 'editor') !== isEditorView) return;
 
     target.ready = true;
     this.syncFullView();
-    await this.replayPendingPrompts();
-  }
-
-  private async replayPendingPrompts(): Promise<void> {
     if (!this.renderer.isAvailable()) return;
 
     await replayApprovalRequestHandlers(this.backend.approvalHandlers);
@@ -264,10 +264,6 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     requestId: string,
   ): AgentProposalPermission | undefined {
     return this.backend.approvalHandlers.proposal.get(requestId);
-  }
-
-  private canSendToWebview(): boolean {
-    return this.target?.ready === true && this.renderer.isAvailable();
   }
 
   public isViewVisible(): boolean {
@@ -422,22 +418,5 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     // Otherwise progress messages would be routed to the launcher webview.
     if (getActiveSidebarView() !== SIDEBAR_VIEWS.PROGRESS) return undefined;
     return this._mainViewProvider?.getWebviewView()?.webview;
-  }
-
-  private async sendToActiveProgressWebview(
-    message: ProgressViewOutboundMessage,
-  ): Promise<boolean> {
-    const webview = this.getActiveWebview();
-    if (!webview) return false;
-    // Delivery failures are reported by the two callers that own them
-    // (`WebviewBridge.deliver` logs and retries the frame; `ProgressBackend`
-    // drops best-effort view refreshes), so this must not swallow them here.
-    return webview.postMessage(message);
-  }
-
-  private isPanelView(
-    view: vscode.WebviewView | vscode.WebviewPanel,
-  ): view is vscode.WebviewPanel {
-    return 'viewColumn' in view;
   }
 }


### PR DESCRIPTION
## Summary

- inline four one-caller provider helpers at the callbacks and ready-handshake steps they own
- preserve active-webview delivery, rejection propagation, target readiness, panel discrimination, and approval replay order
- remove the unused outbound-message type import without adding a replacement abstraction

## Net elements (R6)

- files: 1 modified, 0 added, 0 deleted
- production declarations: 4 private methods removed
- imports: 1 unused type import removed
- public exports, dependencies, message types, and event paths: 0 changed
- net diff: 12 insertions, 33 deletions, for 21 fewer lines

## Consumer counts (R8)

- `sendToActiveProgressWebview`: exactly 1 production caller and 0 direct test consumers
- `canSendToWebview`: exactly 1 production caller and 0 direct test consumers
- `isPanelView`: exactly 1 production caller and 0 direct test consumers
- `replayPendingPrompts`: exactly 1 production caller and 0 direct test consumers
- no backend message, ownership, retry, ready-handshake, or approval-request path was removed

## Validation

- focused Vitest: `ProgressTargetOwnership`, `ProgressViewOnboardingRefresh`, `ProgressBackendPresentation`, and `WebviewBridge` (4 files, 36 tests passed)
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- `corepack pnpm run lint`
- targeted ESLint and Prettier checks
- `git diff --check`

The isolated CI static checks, build, and kernel shards are the final full gates.