### PR TITLE
fix(workflow): scope progress to latest attempt

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -383,6 +383,7 @@ export function App(props: AppProps): React.JSX.Element {
     return workflowRunModel({
       taskGroups: workflowPopupRoot.taskGroups,
       rows: workflowPopupRoot.entries,
+      workflowAttemptId: workflowPopupRoot.workflowAttemptId,
       plan: workflowPopupRoot.workflowPlan,
       runSettled: workflowPopupRunSettled,
       childProgress,

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -111,7 +111,10 @@ export interface TranscriptFoldState {
    *  residency is released, and die with the slice like everything here. */
   taskGroupProjection?: TaskGroupProjectionState;
   compactionProjection?: CompactionProjectionState;
-  /** The newest `workflowPlan` marker folded so far (last wins). */
+  /** Attempt boundary from the newest `workflowPlan` marker, even when its
+   *  declared-plan body is malformed. */
+  workflowAttemptId?: string;
+  /** The newest valid `workflowPlan` marker folded so far (last wins). */
   workflowPlan?: WorkflowPlanMarker;
   /** Whether the last emitted `entries` was the full transcript or compact;
    *  undefined until the first emission. */
@@ -157,9 +160,11 @@ export interface StreamSlice {
   readonly streamId: StreamTabId;
   /** Run/round/phase lifecycle projected from the canonical StreamLog. */
   readonly taskGroups: readonly TaskGroup[];
-  /** The newest attempt's declared phases and tasks, from the transcript's
-   *  `workflowPlan` marker; undefined until a workflow-script run records
-   *  one. What the dashboard lists that the run has not reached yet. */
+  /** Attempt boundary from the newest transcript marker, independently of
+   *  whether its declared-plan body was readable. */
+  readonly workflowAttemptId: string | undefined;
+  /** The newest attempt's declared phases and tasks, from a valid transcript
+   *  `workflowPlan` marker. What the dashboard lists but has not reached yet. */
   readonly workflowPlan: WorkflowPlanMarker | undefined;
   /** CLI-only live status: the newest meaningful transcript line for this
    *  stream, recomputed on every log sync. Fills the stream-list summary slot
@@ -201,6 +206,7 @@ export function emptySlice(streamId: StreamTabId): StreamSlice {
     streamId,
     latestLine: undefined,
     taskGroups: [],
+    workflowAttemptId: undefined,
     workflowPlan: undefined,
     thinkingActive: false,
     compactingActive: false,

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -420,7 +420,8 @@ export function syncStreamLog(
       });
     }
 
-    const { taskGroups, workflowPlan, compaction } = projections;
+    const { taskGroups, workflowAttemptId, workflowPlan, compaction } =
+      projections;
     const compactingActive = compaction.blocks.some(
       (block) => block.status === 'running',
     );
@@ -484,6 +485,7 @@ export function syncStreamLog(
       slice.thinkingActive === thinkingActive &&
       slice.compactingActive === compactingActive &&
       slice.taskGroups === taskGroups &&
+      slice.workflowAttemptId === workflowAttemptId &&
       slice.workflowPlan === workflowPlan
     ) {
       return slice;
@@ -497,6 +499,7 @@ export function syncStreamLog(
       thinkingActive,
       compactingActive,
       taskGroups,
+      workflowAttemptId,
       workflowPlan,
     };
   });
@@ -546,6 +549,7 @@ export function releaseInactiveStreamTranscript(
     resetTranscriptFoldState(fold);
     fold.taskGroupProjection = undefined;
     fold.compactionProjection = undefined;
+    fold.workflowAttemptId = undefined;
     fold.workflowPlan = undefined;
   }
 }

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -218,10 +218,14 @@ function projectTaskGroupsIncrementally(
 function projectWorkflowPlanIncrementally(
   fold: TranscriptFoldState,
   entries: readonly StreamLogEntry[],
-): WorkflowPlanMarker | undefined {
+): {
+  readonly workflowAttemptId: string | undefined;
+  readonly workflowPlan: WorkflowPlanMarker | undefined;
+} {
   for (const entry of entries) {
     const marker = workflowMarkerOf(entry);
     if (!marker) continue;
+    fold.workflowAttemptId = marker.attemptId;
     if (marker.kind === 'malformedPlan') {
       // An unreadable plan is an unknown plan, not the previous attempt's.
       logger.warn(
@@ -232,7 +236,10 @@ function projectWorkflowPlanIncrementally(
       fold.workflowPlan = marker.plan;
     }
   }
-  return fold.workflowPlan;
+  return {
+    workflowAttemptId: fold.workflowAttemptId,
+    workflowPlan: fold.workflowPlan,
+  };
 }
 
 function projectCompactionIncrementally(
@@ -670,12 +677,16 @@ export function applyStreamChanges(
   ctx: FoldContext,
 ): {
   taskGroups: readonly TaskGroup[];
+  workflowAttemptId: string | undefined;
   workflowPlan: WorkflowPlanMarker | undefined;
   compaction: CompactionActivityProjection;
 } {
   const changed = mergeChangedBySeqNo(dirtied, appended);
   const taskGroups = projectTaskGroupsIncrementally(state, changed);
-  const workflowPlan = projectWorkflowPlanIncrementally(state, changed);
+  const { workflowAttemptId, workflowPlan } = projectWorkflowPlanIncrementally(
+    state,
+    changed,
+  );
   const compaction = projectCompactionIncrementally(
     state,
     ctx.log,
@@ -695,7 +706,7 @@ export function applyStreamChanges(
   // Promote only after the merged order is final: "is there a later entry"
   // and `<Static>` append order are both defined on the final stream order.
   advanceSettledPrefix(state, ctx.streamFinal);
-  return { taskGroups, workflowPlan, compaction };
+  return { taskGroups, workflowAttemptId, workflowPlan, compaction };
 }
 
 /** The bounded dashboard + local-row selection for an unfocused workflow

--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -65,6 +65,7 @@ const LogListStateSchema = z.object({
 /** Cached per-stream data and DOM state */
 interface CachedStream {
   groups: TaskGroup[];
+  workflowAttemptId: string | undefined;
   workflowPlan: WorkflowPlanMarker | undefined;
   childProgress: ReadonlyMap<StreamTabId, ChildRunProgress>;
   entries: StreamLogEntry[];
@@ -133,6 +134,7 @@ export class LogList extends LitElement {
     if (streamId) {
       const entry = this.getOrCreateEntry(streamId);
       entry.groups = this.streamContext.taskGroups;
+      entry.workflowAttemptId = this.streamContext.workflowAttemptId;
       entry.workflowPlan = this.streamContext.workflowPlan;
       entry.childProgress = this.streamContext.childProgress;
       entry.entries = this.streamContext.entries;
@@ -170,6 +172,7 @@ export class LogList extends LitElement {
           ${ref(data.ref)}
           ?hidden=${id !== this.activeStreamId}
           .groups=${data.groups}
+          .workflowAttemptId=${data.workflowAttemptId}
           .workflowPlan=${data.workflowPlan}
           .childProgress=${data.childProgress}
           .entries=${data.entries}
@@ -241,6 +244,7 @@ export class LogList extends LitElement {
 
     const createdEntry: CachedStream = {
       groups: [],
+      workflowAttemptId: undefined,
       workflowPlan: undefined,
       childProgress: new Map(),
       entries: [],

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -695,15 +695,14 @@ export class TaskGroupList extends LitElement {
    */
   private renderGroupBody(node: GroupTree, isRoot: boolean): TemplateResult {
     const phase = this.phaseModels.get(node.group.id);
-    const workflowPhase =
-      phase ?? (isRoot ? this.model?.unphasedPhase : undefined);
     const rows =
       phase || (isRoot && this.model !== null)
         ? node.rows.filter((row) => row.kind !== 'workflowTask')
         : node.rows;
-    return html`${
-      workflowPhase ? this.renderPhaseRows(workflowPhase) : nothing
-    }${this.renderRowEntries(rows, `group:${node.group.id}`)}${repeat(
+    return html`${phase ? this.renderPhaseRows(phase) : nothing}${this.renderRowEntries(
+      rows,
+      `group:${node.group.id}`,
+    )}${repeat(
       node.children,
       (c) => c.group.id,
       (c) => this.renderGroupNode(c),
@@ -857,11 +856,20 @@ export class TaskGroupList extends LitElement {
       ${repeat(
         visibleTimeline,
         (item) => item.key,
-        (item) =>
-          'row' in item
-            ? this.renderLogEntry(item.row)
-            : this.renderGroupNode(item.tree, true),
+        (item) => {
+          if ('row' in item) {
+            return this.model !== null && item.row.kind === 'workflowTask'
+              ? nothing
+              : this.renderLogEntry(item.row);
+          }
+          return this.renderGroupNode(item.tree, true);
+        },
       )}
+      ${
+        this.model?.unphasedPhase
+          ? this.renderPhaseRows(this.model.unphasedPhase)
+          : nothing
+      }
       ${this.renderDeclaredPhases()}
     `;
   }

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -520,7 +520,7 @@ export class TaskGroupList extends LitElement {
   private renderRunBand(node: GroupTree): TemplateResult | typeof nothing {
     const model = this.model;
     if (this.isToolUse || !model || model.tally.total === 0) return nothing;
-    if (!node.children.some((child) => child.group.kind === 'phase')) {
+    if (!node.children.some((child) => this.phaseModels.has(child.group.id))) {
       return nothing;
     }
     return html`<div class="log-run-band">

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -177,8 +177,11 @@ export class TaskGroupList extends LitElement {
   @property({ attribute: false }) streamStatus: StreamLifecycleStatus | null =
     null;
 
-  /** The newest attempt's declared workflow plan; with the groups, rows, and
-   *  status it is the shared run model's whole input. */
+  /** Newest workflow-attempt boundary, even if its plan body was malformed. */
+  @property({ attribute: false }) workflowAttemptId: string | undefined =
+    undefined;
+
+  /** The newest attempt's valid declared workflow plan. */
   @property({ attribute: false }) workflowPlan: WorkflowPlanMarker | undefined =
     undefined;
 
@@ -287,6 +290,7 @@ export class TaskGroupList extends LitElement {
       groupsChanged ||
       rowsChanged ||
       changedProperties.has('rowGeneration') ||
+      changedProperties.has('workflowAttemptId') ||
       changedProperties.has('workflowPlan') ||
       changedProperties.has('childProgress') ||
       changedProperties.has('streamStatus')
@@ -351,11 +355,13 @@ export class TaskGroupList extends LitElement {
 
   private rebuildRunModel(): void {
     const model =
+      this.workflowAttemptId !== undefined ||
       this.workflowPlan !== undefined ||
       this.groups.some((group) => group.kind === 'phase')
         ? workflowRunModel({
             taskGroups: this.groups,
             rows: this.rows,
+            workflowAttemptId: this.workflowAttemptId,
             plan: this.workflowPlan,
             runSettled: workflowRunSettled(this.streamStatus ?? undefined),
             childProgress: this.childProgress,
@@ -684,9 +690,8 @@ export class TaskGroupList extends LitElement {
   /**
    * Rows of a group followed by its child groups. A phase's cards come from
    * the model (`renderPhaseRows`); its other rows — the script's own log
-   * lines — follow in transcript order. A phase the model does not hold (one
-   * whose every card belonged to a superseded attempt) keeps its rows as
-   * plain history.
+   * lines — follow in transcript order. Superseded phase groups do not reach
+   * this path: the shared model is the authority for which attempt is visible.
    */
   private renderGroupBody(node: GroupTree): TemplateResult {
     const phase = this.phaseModels.get(node.group.id);
@@ -708,6 +713,13 @@ export class TaskGroupList extends LitElement {
     isRoot = false,
   ): TemplateResult | typeof nothing {
     const { group } = node;
+    if (
+      group.kind === 'phase' &&
+      this.model !== null &&
+      !this.phaseModels.has(group.id)
+    ) {
+      return nothing;
+    }
     const detailsId = `${GROUP_DOM_IDS.DETAILS_PREFIX}${group.id}`;
     const contentId = `${GROUP_DOM_IDS.CONTENT_PREFIX}${group.id}`;
 

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -697,9 +697,10 @@ export class TaskGroupList extends LitElement {
     const phase = this.phaseModels.get(node.group.id);
     const workflowPhase =
       phase ?? (isRoot ? this.model?.unphasedPhase : undefined);
-    const rows = workflowPhase
-      ? node.rows.filter((row) => row.kind !== 'workflowTask')
-      : node.rows;
+    const rows =
+      phase || (isRoot && this.model !== null)
+        ? node.rows.filter((row) => row.kind !== 'workflowTask')
+        : node.rows;
     return html`${
       workflowPhase ? this.renderPhaseRows(workflowPhase) : nothing
     }${this.renderRowEntries(rows, `group:${node.group.id}`)}${repeat(

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -693,13 +693,15 @@ export class TaskGroupList extends LitElement {
    * lines — follow in transcript order. Superseded phase groups do not reach
    * this path: the shared model is the authority for which attempt is visible.
    */
-  private renderGroupBody(node: GroupTree): TemplateResult {
+  private renderGroupBody(node: GroupTree, isRoot: boolean): TemplateResult {
     const phase = this.phaseModels.get(node.group.id);
-    const rows = phase
+    const workflowPhase =
+      phase ?? (isRoot ? this.model?.unphasedPhase : undefined);
+    const rows = workflowPhase
       ? node.rows.filter((row) => row.kind !== 'workflowTask')
       : node.rows;
     return html`${
-      phase ? this.renderPhaseRows(phase) : nothing
+      workflowPhase ? this.renderPhaseRows(workflowPhase) : nothing
     }${this.renderRowEntries(rows, `group:${node.group.id}`)}${repeat(
       node.children,
       (c) => c.group.id,
@@ -732,7 +734,7 @@ export class TaskGroupList extends LitElement {
       return html`
         <div id=${detailsId} class="log-group log-run" data-run-id=${group.id}>
           <div id=${contentId} class="log-group-content">
-            ${this.renderRunBand(node)} ${this.renderGroupBody(node)}
+            ${this.renderRunBand(node)} ${this.renderGroupBody(node, true)}
           </div>
         </div>
       `;
@@ -761,7 +763,7 @@ export class TaskGroupList extends LitElement {
           ${this.renderGroupHeader(node)}
         </div>
         <div id=${contentId} class="log-group-content">
-          ${expanded ? this.renderGroupBody(node) : nothing}
+          ${expanded ? this.renderGroupBody(node, false) : nothing}
         </div>
       </wa-details>
     `;

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -489,6 +489,7 @@ export const logContext$ = new Signal.Computed((): StreamLogContextValue => {
     updatedRowBaseGeneration: streamLogs.updatedRowBaseGeneration,
     rowGeneration: streamLogs.generation,
     taskGroups: activeTaskGroups$.get(),
+    workflowAttemptId: streamLogs.workflowAttemptId,
     workflowPlan: streamLogs.workflowPlan,
     childProgress: activeChildProgress$.get(),
     isToolUse: activeIsToolUse$.get(),

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -135,6 +135,7 @@ function applyEntry(
   // previous attempt's.
   const marker = workflowMarkerOf(entry);
   if (marker) {
+    streamLogs.workflowAttemptId = marker.attemptId;
     if (marker.kind === 'malformedPlan') {
       console.warn(
         `[logSlice] Ignoring malformed workflow plan marker ${entry.id}: ${marker.error}`,
@@ -297,6 +298,7 @@ export const logHandlers = {
               rowIndex: streamLogs.rowIndex,
               taskGroupIndex: streamLogs.taskGroupIndex,
               compactionProjection: streamLogs.compactionProjection,
+              workflowAttemptId: streamLogs.workflowAttemptId,
               workflowPlan: streamLogs.workflowPlan,
               updatedRowIndices: [...updatedRowIndices],
               updatedRowBaseGeneration,

--- a/packages/extension/src/progressView/frontend/store.ts
+++ b/packages/extension/src/progressView/frontend/store.ts
@@ -46,11 +46,9 @@ export interface StreamLogs {
   taskGroupIndex: Map<string, number>;
   /** Correlated context-compaction lifecycle projected into stable rows. */
   compactionProjection: CompactionActivityProjection;
-  /**
-   * The newest attempt's declared workflow plan, folded from the
-   * `workflowPlan` markers (newest wins) the same way the CLI folds them;
-   * one input of the shared workflow run model the board paints.
-   */
+  /** Newest workflow-attempt boundary, even if its plan body was malformed. */
+  workflowAttemptId: string | undefined;
+  /** The newest valid declared workflow plan. */
   workflowPlan: WorkflowPlanMarker | undefined;
   /**
    * Existing row indices updated by the most recent backend delta.
@@ -71,6 +69,7 @@ function createEmptyStreamLogs(): StreamLogs {
     rowIndex: new Map(),
     taskGroupIndex: new Map(),
     compactionProjection: createCompactionActivityProjection(),
+    workflowAttemptId: undefined,
     workflowPlan: undefined,
     updatedRowIndices: [],
     updatedRowBaseGeneration: 0,

--- a/packages/extension/src/progressView/frontend/streamContexts.ts
+++ b/packages/extension/src/progressView/frontend/streamContexts.ts
@@ -70,7 +70,9 @@ export interface StreamLogContextValue {
   /** Current log generation. */
   rowGeneration: number;
   taskGroups: TaskGroup[];
-  /** The newest attempt's declared workflow plan, for the run model. */
+  /** Newest workflow-attempt boundary, even if its plan body was malformed. */
+  workflowAttemptId: string | undefined;
+  /** The newest valid declared workflow plan, for the run model. */
   workflowPlan: WorkflowPlanMarker | undefined;
   /** Live progress of the stream's children, by child stream. */
   childProgress: ReadonlyMap<StreamTabId, ChildRunProgress>;
@@ -91,6 +93,7 @@ export const EMPTY_LOG_CONTEXT: StreamLogContextValue = {
   updatedRowBaseGeneration: 0,
   rowGeneration: 0,
   taskGroups: [],
+  workflowAttemptId: undefined,
   workflowPlan: undefined,
   childProgress: new Map(),
   isToolUse: false,

--- a/src/shared/schemas/taskGroup.ts
+++ b/src/shared/schemas/taskGroup.ts
@@ -18,6 +18,8 @@ export const TaskGroupSchema = z.strictObject({
   status: TaskGroupStatusSchema,
   parentGroupId: z.string().optional(),
   kind: StageKindSchema.optional(),
+  /** Workflow-script projection attempt that opened this phase. */
+  attemptId: z.string().min(1).optional(),
   index: taskGroupIndexField.optional(),
   total: taskGroupTotalField.optional(),
 });
@@ -51,6 +53,7 @@ export type TaskGroup = z.infer<typeof TaskGroupSchema>;
 const groupLogPayloadFields = {
   status: z.union([TaskGroupStatusSchema, EndGroupStatusSchema]).optional(),
   kind: StageKindSchema.optional(),
+  attemptId: z.string().min(1).optional(),
   index: taskGroupIndexField.optional(),
   total: taskGroupTotalField.optional(),
   name: z.string().optional(),
@@ -68,6 +71,7 @@ export const TraceGroupLogPayloadSchema = z.looseObject({
   ...groupLogPayloadFields,
   status: groupLogPayloadFields.status.catch(undefined),
   kind: groupLogPayloadFields.kind.catch(undefined),
+  attemptId: groupLogPayloadFields.attemptId.catch(undefined),
   index: groupLogPayloadFields.index.catch(undefined),
   total: groupLogPayloadFields.total.catch(undefined),
   name: groupLogPayloadFields.name.catch(undefined),

--- a/src/shared/schemas/taskGroup.ts
+++ b/src/shared/schemas/taskGroup.ts
@@ -64,14 +64,16 @@ export const GroupLogPayloadSchema = z.looseObject(groupLogPayloadFields);
 
 /**
  * Permanent exported-trace recovery for group rows written by older versions.
- * Each display-only field recovers independently so one stale value does not
- * discard the whole trace entry.
+ * Display-only fields recover independently so one stale value does not
+ * discard the whole trace entry. Attempt ownership is lifecycle identity, not
+ * display data: an invalid present value rejects the entry rather than being
+ * mistaken for a compatible legacy omission.
  */
 export const TraceGroupLogPayloadSchema = z.looseObject({
   ...groupLogPayloadFields,
   status: groupLogPayloadFields.status.catch(undefined),
   kind: groupLogPayloadFields.kind.catch(undefined),
-  attemptId: groupLogPayloadFields.attemptId.catch(undefined),
+  attemptId: groupLogPayloadFields.attemptId,
   index: groupLogPayloadFields.index.catch(undefined),
   total: groupLogPayloadFields.total.catch(undefined),
   name: groupLogPayloadFields.name.catch(undefined),

--- a/src/shared/streams/taskGroupProjection.ts
+++ b/src/shared/streams/taskGroupProjection.ts
@@ -91,6 +91,9 @@ export function upsertTaskGroupFromStreamLog(
       status: startStatus,
       ...(entry.groupId ? { parentGroupId: entry.groupId } : {}),
       ...taskGroupStageMetadata(payload.kind, payload.index),
+      ...(payload.attemptId !== undefined
+        ? { attemptId: payload.attemptId }
+        : {}),
       ...(payload.total !== undefined ? { total: payload.total } : {}),
     };
 
@@ -116,6 +119,9 @@ export function upsertTaskGroupFromStreamLog(
       status,
       ...(entry.groupId ? { parentGroupId: entry.groupId } : {}),
       ...taskGroupStageMetadata(payload.kind, payload.index),
+      ...(payload.attemptId !== undefined
+        ? { attemptId: payload.attemptId }
+        : {}),
       ...(payload.total !== undefined ? { total: payload.total } : {}),
       ...(endTime !== undefined ? { endTime } : {}),
     });

--- a/src/shared/streams/workflowRunModel.ts
+++ b/src/shared/streams/workflowRunModel.ts
@@ -126,6 +126,8 @@ export interface WorkflowRunModel {
   readonly phases: readonly WorkflowPhaseModel[];
   /** Every card of the newest attempt, in transcript order. */
   readonly tasks: readonly WorkflowTaskRow[];
+  /** Current-attempt cards issued outside a phase, when any. */
+  readonly unphasedPhase: WorkflowPhaseModel | undefined;
   readonly tally: WorkflowTally;
   /** The child stream a card may open, by row id: its `childStreamId` when
    *  that card is the stream's only claimant. A stream two cards claim is
@@ -449,8 +451,10 @@ export function workflowRunModel(
   }
   // Phase ownership handles the call-less case that card references cannot:
   // an explicitly superseded empty phase is stale. Untagged empty phases are
-  // preserved for mixed-version traces unless the latest attempt opened the
-  // same title/index, which is the only evidence that the untagged copy is old.
+  // preserved for traces written before phase ownership shipped on 2026-08-31
+  // unless the latest attempt opened the same title/index, which is the only
+  // evidence that the untagged copy is old. Retire this compatibility branch
+  // after 2026-11-30, when those pre-ownership traces leave support.
   const latestOwnedPhaseIdentities = new Set(
     phases
       .filter((phase) => phase.attemptId === latestAttemptId)
@@ -490,13 +494,18 @@ export function workflowRunModel(
     (sum, phase) => sum + phase.declaredTasks.length,
     0,
   );
+  const phaseModels = ordered.map((phase) => ({
+    ...phase,
+    tally: tallyOf(phase.tasks, phase.declaredTasks.length),
+    cells: phase.tasks.map((row) => row.call.status),
+  }));
   return {
-    phases: ordered.map((phase) => ({
-      ...phase,
-      tally: tallyOf(phase.tasks, phase.declaredTasks.length),
-      cells: phase.tasks.map((row) => row.call.status),
-    })),
+    phases: phaseModels,
     tasks,
+    unphasedPhase:
+      unphased === undefined
+        ? undefined
+        : phaseModels[ordered.indexOf(unphased)],
     tally: tallyOf(tasks, declaredTotal),
     childStreamOf,
     liveOf,

--- a/src/shared/streams/workflowRunModel.ts
+++ b/src/shared/streams/workflowRunModel.ts
@@ -25,6 +25,7 @@ import {
   type WorkflowPlanMarker,
 } from '@shared/schemas';
 import type { TranscriptRow, WorkflowTaskRow } from '@shared/transcript';
+import { compareBySeqNo } from '@shared/streams/streamOrdering';
 import {
   TOKENS_GENERATED,
   workflowPhaseHeadingOfGroup,
@@ -158,23 +159,22 @@ function workflowCardsInTranscriptOrder(
   const cards = rows.filter(
     (row): row is WorkflowTaskRow => row.kind === 'workflowTask',
   );
-  return cards.every((row) => row.seqNo !== undefined)
-    ? cards.toSorted((left, right) => left.seqNo! - right.seqNo!)
-    : cards;
+  return cards.toSorted((left, right) =>
+    compareBySeqNo(
+      left,
+      right,
+      (row) => row.seqNo,
+      (row) => row.timestamp,
+    ),
+  );
 }
 
 /** One run-wide attempt identity, selected before any phase is tallied. */
 function latestWorkflowAttemptId(
   cards: readonly WorkflowTaskRow[],
-  taskGroups: readonly TaskGroup[],
   plan: WorkflowRunModelInput['plan'],
 ): string | undefined {
-  const hasAttemptOwnership =
-    cards.some((row) => row.call.attemptId !== undefined) ||
-    taskGroups.some((group) => group.attemptId !== undefined);
-  if (hasAttemptOwnership && plan && 'attemptId' in plan) {
-    return plan.attemptId;
-  }
+  if (plan && 'attemptId' in plan) return plan.attemptId;
   return cards.findLast((row) => row.call.attemptId !== undefined)?.call
     .attemptId;
 }
@@ -294,11 +294,7 @@ export function workflowRunModel(
   // The latest plan marker is definitive even before the attempt issues a
   // card. Traces predating plan markers fall back to the last tagged card in
   // true transcript order, including cards issued outside a phase.
-  const latestAttemptId = latestWorkflowAttemptId(
-    cards,
-    input.taskGroups,
-    input.plan,
-  );
+  const latestAttemptId = latestWorkflowAttemptId(cards, input.plan);
   const tasks: WorkflowTaskRow[] = [];
   // A card issued outside any open phase has no group to sit under; it joins
   // one trailing "Unphased" phase rather than vanishing.
@@ -324,12 +320,14 @@ export function workflowRunModel(
     unphased.tasks.push(row);
   }
   // Phase ownership handles the call-less case that card references cannot:
-  // an empty phase opened only by a superseded attempt is still stale. A
-  // current card keeps an untagged phase from a mixed-version transcript.
+  // an explicitly superseded empty phase is stale. Untagged empty phases are
+  // preserved for mixed-version traces: an old untagged call-less phase is
+  // indistinguishable from a current one without inventing host-local state.
   const opened = phases.filter(
     (phase) =>
       phase.tasks.length > 0 ||
       latestAttemptId === undefined ||
+      phase.attemptId === undefined ||
       phase.attemptId === latestAttemptId,
   );
   const ordered = [

--- a/src/shared/streams/workflowRunModel.ts
+++ b/src/shared/streams/workflowRunModel.ts
@@ -169,14 +169,88 @@ function workflowCardsInTranscriptOrder(
   );
 }
 
-/** One run-wide attempt identity, selected before any phase is tallied. */
+interface AttemptBoundary {
+  readonly attemptId: string;
+  readonly timestamp: number;
+  readonly stableKey: string;
+  readonly seqNo?: number;
+}
+
+function usableSeqNo(seqNo: number | undefined): number | undefined {
+  return seqNo !== undefined && Number.isSafeInteger(seqNo) && seqNo > 0
+    ? seqNo
+    : undefined;
+}
+
+function laterAttemptBoundaryByTime(
+  left: AttemptBoundary | undefined,
+  right: AttemptBoundary,
+): AttemptBoundary {
+  if (!left) return right;
+  if (right.timestamp !== left.timestamp) {
+    return right.timestamp > left.timestamp ? right : left;
+  }
+  return right.stableKey > left.stableKey ? right : left;
+}
+
+/**
+ * One run-wide attempt identity, selected before any phase is tallied.
+ * Sequenced cards first elect their newest wire fact without consulting wall
+ * clocks. Legacy cards and phase boundaries elect by time with a stable key;
+ * the two generation winners then use that same fallback chronology. There is
+ * no causal key that can order a legacy fact against a sequenced one, so clock
+ * skew across that boundary remains inherently ambiguous, but this staged fold
+ * is deterministic and cannot form the mixed-comparator cycles a sort can.
+ */
 function latestWorkflowAttemptId(
   cards: readonly WorkflowTaskRow[],
+  taskGroups: readonly TaskGroup[],
   plan: WorkflowRunModelInput['plan'],
 ): string | undefined {
   if (plan && 'attemptId' in plan) return plan.attemptId;
-  return cards.findLast((row) => row.call.attemptId !== undefined)?.call
-    .attemptId;
+
+  let sequenced: AttemptBoundary | undefined;
+  let fallback: AttemptBoundary | undefined;
+  for (const row of cards) {
+    const attemptId = row.call.attemptId;
+    if (attemptId === undefined) continue;
+    const seqNo = usableSeqNo(row.seqNo);
+    const boundary: AttemptBoundary = {
+      attemptId,
+      timestamp: row.timestamp,
+      stableKey: `card:${row.id}`,
+      ...(seqNo !== undefined ? { seqNo } : {}),
+    };
+    if (seqNo === undefined) {
+      fallback = laterAttemptBoundaryByTime(fallback, boundary);
+    } else {
+      const previousSeqNo = sequenced?.seqNo;
+      if (
+        previousSeqNo === undefined ||
+        seqNo > previousSeqNo ||
+        (seqNo === previousSeqNo &&
+          laterAttemptBoundaryByTime(sequenced, boundary) === boundary)
+      ) {
+        sequenced = boundary;
+      }
+    }
+  }
+  for (const group of taskGroups) {
+    if (group.kind !== 'phase' || group.attemptId === undefined) continue;
+    fallback = laterAttemptBoundaryByTime(fallback, {
+      attemptId: group.attemptId,
+      timestamp: group.startTime,
+      stableKey: `phase:${group.id}`,
+    });
+  }
+
+  if (!fallback) return sequenced?.attemptId;
+  if (!sequenced) return fallback.attemptId;
+  return laterAttemptBoundaryByTime(sequenced, fallback).attemptId;
+}
+
+function phaseLogicalIdentity(phase: MutablePhase): string {
+  return `${phase.heading.phaseLabel}\u0000${phase.heading.phaseIndex ?? 'unknown'}`;
 }
 
 function tallyOf(
@@ -292,9 +366,13 @@ export function workflowRunModel(
   // cards in with the one actually running.
   const cards = workflowCardsInTranscriptOrder(input.rows);
   // The latest plan marker is definitive even before the attempt issues a
-  // card. Traces predating plan markers fall back to the last tagged card in
-  // true transcript order, including cards issued outside a phase.
-  const latestAttemptId = latestWorkflowAttemptId(cards, input.plan);
+  // card. Without one, the fallback elects from sequenced cards plus timed
+  // legacy cards and phase openings, including calls issued outside a phase.
+  const latestAttemptId = latestWorkflowAttemptId(
+    cards,
+    input.taskGroups,
+    input.plan,
+  );
   const tasks: WorkflowTaskRow[] = [];
   // A card issued outside any open phase has no group to sit under; it joins
   // one trailing "Unphased" phase rather than vanishing.
@@ -321,14 +399,20 @@ export function workflowRunModel(
   }
   // Phase ownership handles the call-less case that card references cannot:
   // an explicitly superseded empty phase is stale. Untagged empty phases are
-  // preserved for mixed-version traces: an old untagged call-less phase is
-  // indistinguishable from a current one without inventing host-local state.
+  // preserved for mixed-version traces unless the latest attempt opened the
+  // same title/index, which is the only evidence that the untagged copy is old.
+  const latestOwnedPhaseIdentities = new Set(
+    phases
+      .filter((phase) => phase.attemptId === latestAttemptId)
+      .map(phaseLogicalIdentity),
+  );
   const opened = phases.filter(
     (phase) =>
       phase.tasks.length > 0 ||
       latestAttemptId === undefined ||
-      phase.attemptId === undefined ||
-      phase.attemptId === latestAttemptId,
+      phase.attemptId === latestAttemptId ||
+      (phase.attemptId === undefined &&
+        !latestOwnedPhaseIdentities.has(phaseLogicalIdentity(phase))),
   );
   const ordered = [
     ...(input.plan

--- a/src/shared/streams/workflowRunModel.ts
+++ b/src/shared/streams/workflowRunModel.ts
@@ -25,7 +25,6 @@ import {
   type WorkflowPlanMarker,
 } from '@shared/schemas';
 import type { TranscriptRow, WorkflowTaskRow } from '@shared/transcript';
-import { compareBySeqNo } from '@shared/streams/streamOrdering';
 import {
   TOKENS_GENERATED,
   workflowPhaseHeadingOfGroup,
@@ -45,8 +44,16 @@ import {
 
 /** What an `INTERNAL` transcript entry says about the workflow run. */
 export type WorkflowMarker =
-  | { readonly kind: 'plan'; readonly plan: WorkflowPlanMarker }
-  | { readonly kind: 'malformedPlan'; readonly error: string };
+  | {
+      readonly kind: 'plan';
+      readonly attemptId: string;
+      readonly plan: WorkflowPlanMarker;
+    }
+  | {
+      readonly kind: 'malformedPlan';
+      readonly attemptId?: string;
+      readonly error: string;
+    };
 
 function internalMarkerKind(data: unknown): unknown {
   return typeof data === 'object' && data !== null
@@ -72,9 +79,24 @@ export function workflowMarkerOf(
   }
   if (internalMarkerKind(entry.data) !== 'workflowPlan') return undefined;
   const parsed = WorkflowPlanMarkerSchema.safeParse(entry.data);
-  return parsed.success
-    ? { kind: 'plan', plan: parsed.data }
-    : { kind: 'malformedPlan', error: parsed.error.message };
+  if (parsed.success) {
+    return {
+      kind: 'plan',
+      attemptId: parsed.data.attemptId,
+      plan: parsed.data,
+    };
+  }
+  // Recover only the attempt boundary. The plan body remains unknown unless
+  // the full strict marker schema succeeds, so malformed phases/tasks never
+  // enter declared-plan rendering while a valid id still scopes stale rows.
+  const attemptId = WorkflowPlanMarkerSchema.shape.attemptId.safeParse(
+    (entry.data as { readonly attemptId?: unknown }).attemptId,
+  );
+  return {
+    kind: 'malformedPlan',
+    ...(attemptId.success ? { attemptId: attemptId.data } : {}),
+    error: parsed.error.message,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -132,7 +154,10 @@ export interface WorkflowRunModelInput {
   readonly taskGroups: readonly TaskGroup[];
   /** The stream's rows; the model picks the `workflowTask` ones. */
   readonly rows: readonly TranscriptRow[];
-  /** The newest attempt's declared plan, if the transcript recorded one. */
+  /** The newest attempt boundary recovered from its transcript marker, even
+   *  when that marker's declared-plan body is malformed. */
+  readonly workflowAttemptId?: string;
+  /** The newest attempt's declared plan, if the transcript recorded a valid one. */
   readonly plan: WorkflowDeclaredPlan | WorkflowPlanMarker | undefined;
   /** True once the run has ended: plan-only phases it never reached are then
    *  nothing to show (the projection's settle sweep has housed every declared
@@ -152,21 +177,43 @@ interface MutablePhase {
   declaredTasks: readonly WorkflowCallIdentity[];
 }
 
-/** Cards in wire order, even when a caller collected a group tree pre-order. */
+function compareCardFallback(
+  left: WorkflowTaskRow,
+  right: WorkflowTaskRow,
+): number {
+  return left.timestamp - right.timestamp;
+}
+
+/**
+ * Cards in deterministic transcript order, even when a caller collected a
+ * group tree pre-order. Sequence and legacy rows are each ordered by their
+ * own chronology, then kept as generation blocks ordered by their newest
+ * facts. No causal key exists between generations, so this cannot recover an
+ * interleaving across clock skew, but unlike a pairwise seq/time fallback it
+ * is transitive and independent of input tree order except for truly
+ * indistinguishable equal-time legacy facts, whose stable input order remains
+ * the compatibility tie-break.
+ */
 function workflowCardsInTranscriptOrder(
   rows: readonly TranscriptRow[],
 ): WorkflowTaskRow[] {
-  const cards = rows.filter(
-    (row): row is WorkflowTaskRow => row.kind === 'workflowTask',
+  const sequenced: WorkflowTaskRow[] = [];
+  const legacy: WorkflowTaskRow[] = [];
+  for (const row of rows) {
+    if (row.kind !== 'workflowTask') continue;
+    (usableSeqNo(row.seqNo) === undefined ? legacy : sequenced).push(row);
+  }
+  sequenced.sort(
+    (left, right) =>
+      usableSeqNo(left.seqNo)! - usableSeqNo(right.seqNo)! ||
+      compareCardFallback(left, right),
   );
-  return cards.toSorted((left, right) =>
-    compareBySeqNo(
-      left,
-      right,
-      (row) => row.seqNo,
-      (row) => row.timestamp,
-    ),
-  );
+  legacy.sort(compareCardFallback);
+  if (sequenced.length === 0) return legacy;
+  if (legacy.length === 0) return sequenced;
+  return compareCardFallback(sequenced.at(-1)!, legacy.at(-1)!) <= 0
+    ? [...sequenced, ...legacy]
+    : [...legacy, ...sequenced];
 }
 
 interface AttemptBoundary {
@@ -206,7 +253,9 @@ function latestWorkflowAttemptId(
   cards: readonly WorkflowTaskRow[],
   taskGroups: readonly TaskGroup[],
   plan: WorkflowRunModelInput['plan'],
+  markerAttemptId: string | undefined,
 ): string | undefined {
+  if (markerAttemptId !== undefined) return markerAttemptId;
   if (plan && 'attemptId' in plan) return plan.attemptId;
 
   let sequenced: AttemptBoundary | undefined;
@@ -372,6 +421,7 @@ export function workflowRunModel(
     cards,
     input.taskGroups,
     input.plan,
+    input.workflowAttemptId,
   );
   const tasks: WorkflowTaskRow[] = [];
   // A card issued outside any open phase has no group to sit under; it joins

--- a/src/shared/streams/workflowRunModel.ts
+++ b/src/shared/streams/workflowRunModel.ts
@@ -425,6 +425,18 @@ export function workflowRunModel(
     input.plan,
     input.workflowAttemptId,
   );
+  // Cards predate phase ownership. For an untagged legacy phase that did issue
+  // calls, those calls still prove which attempt owned the group; only a
+  // genuinely call-less untagged phase remains ambiguous.
+  const cardAttemptsByGroupId = new Map<string, Set<string>>();
+  for (const row of cards) {
+    const groupId = row.groupId;
+    const attemptId = row.call.attemptId;
+    if (groupId === undefined || attemptId === undefined) continue;
+    const attempts = cardAttemptsByGroupId.get(groupId) ?? new Set<string>();
+    attempts.add(attemptId);
+    cardAttemptsByGroupId.set(groupId, attempts);
+  }
   const tasks: WorkflowTaskRow[] = [];
   // A card issued outside any open phase has no group to sit under; it joins
   // one trailing "Unphased" phase rather than vanishing.
@@ -466,6 +478,7 @@ export function workflowRunModel(
       latestAttemptId === undefined ||
       phase.attemptId === latestAttemptId ||
       (phase.attemptId === undefined &&
+        (cardAttemptsByGroupId.get(phase.key)?.has(latestAttemptId) ?? true) &&
         !latestOwnedPhaseIdentities.has(phaseLogicalIdentity(phase))),
   );
   const ordered = [

--- a/src/shared/streams/workflowRunModel.ts
+++ b/src/shared/streams/workflowRunModel.ts
@@ -132,7 +132,7 @@ export interface WorkflowRunModelInput {
   /** The stream's rows; the model picks the `workflowTask` ones. */
   readonly rows: readonly TranscriptRow[];
   /** The newest attempt's declared plan, if the transcript recorded one. */
-  readonly plan: WorkflowDeclaredPlan | undefined;
+  readonly plan: WorkflowDeclaredPlan | WorkflowPlanMarker | undefined;
   /** True once the run has ended: plan-only phases it never reached are then
    *  nothing to show (the projection's settle sweep has housed every declared
    *  card under a stage, so an empty plan-only phase is its own
@@ -147,7 +147,36 @@ interface MutablePhase {
   readonly heading: WorkflowPhaseHeading;
   readonly tasks: WorkflowTaskRow[];
   readonly opened: boolean;
+  readonly attemptId?: string;
   declaredTasks: readonly WorkflowCallIdentity[];
+}
+
+/** Cards in wire order, even when a caller collected a group tree pre-order. */
+function workflowCardsInTranscriptOrder(
+  rows: readonly TranscriptRow[],
+): WorkflowTaskRow[] {
+  const cards = rows.filter(
+    (row): row is WorkflowTaskRow => row.kind === 'workflowTask',
+  );
+  return cards.every((row) => row.seqNo !== undefined)
+    ? cards.toSorted((left, right) => left.seqNo! - right.seqNo!)
+    : cards;
+}
+
+/** One run-wide attempt identity, selected before any phase is tallied. */
+function latestWorkflowAttemptId(
+  cards: readonly WorkflowTaskRow[],
+  taskGroups: readonly TaskGroup[],
+  plan: WorkflowRunModelInput['plan'],
+): string | undefined {
+  const hasAttemptOwnership =
+    cards.some((row) => row.call.attemptId !== undefined) ||
+    taskGroups.some((group) => group.attemptId !== undefined);
+  if (hasAttemptOwnership && plan && 'attemptId' in plan) {
+    return plan.attemptId;
+  }
+  return cards.findLast((row) => row.call.attemptId !== undefined)?.call
+    .attemptId;
 }
 
 function tallyOf(
@@ -251,6 +280,7 @@ export function workflowRunModel(
       heading: workflowPhaseHeadingOfGroup(group),
       tasks: [],
       opened: true,
+      ...(group.attemptId !== undefined ? { attemptId: group.attemptId } : {}),
       declaredTasks: [],
     };
     phases.push(phase);
@@ -260,29 +290,23 @@ export function workflowRunModel(
   // to the same transcript with fresh card ids; scope to the newest attempt
   // so a resume's live rows and totals never fold a superseded attempt's
   // cards in with the one actually running.
-  const cards = input.rows.filter(
-    (row): row is WorkflowTaskRow => row.kind === 'workflowTask',
+  const cards = workflowCardsInTranscriptOrder(input.rows);
+  // The latest plan marker is definitive even before the attempt issues a
+  // card. Traces predating plan markers fall back to the last tagged card in
+  // true transcript order, including cards issued outside a phase.
+  const latestAttemptId = latestWorkflowAttemptId(
+    cards,
+    input.taskGroups,
+    input.plan,
   );
-  // "Newest" is the last attempt id in transcript order — a resume's cards
-  // are appended after the attempt they supersede. Once one exists, cards
-  // from an older transcript without an attempt id are superseded too; keep
-  // every card only when the transcript has no attempt ids at all.
-  let latestAttemptId: string | undefined;
-  for (const row of cards)
-    latestAttemptId = row.call.attemptId ?? latestAttemptId;
   const tasks: WorkflowTaskRow[] = [];
   // A card issued outside any open phase has no group to sit under; it joins
   // one trailing "Unphased" phase rather than vanishing.
   let unphased: MutablePhase | undefined;
-  // A phase whose every card belonged to a superseded attempt is the resume's
-  // duplicate phase row (fresh stage ids per phase per attempt), not a
-  // genuinely empty phase — dropped below rather than shown empty.
-  const staleOnly = new Set<MutablePhase>();
   for (const row of cards) {
     const phase = row.groupId ? byGroupId.get(row.groupId) : undefined;
     const attemptId = row.call.attemptId;
     if (latestAttemptId !== undefined && attemptId !== latestAttemptId) {
-      if (phase) staleOnly.add(phase);
       continue;
     }
     tasks.push(row);
@@ -299,8 +323,14 @@ export function workflowRunModel(
     };
     unphased.tasks.push(row);
   }
+  // Phase ownership handles the call-less case that card references cannot:
+  // an empty phase opened only by a superseded attempt is still stale. A
+  // current card keeps an untagged phase from a mixed-version transcript.
   const opened = phases.filter(
-    (phase) => phase.tasks.length > 0 || !staleOnly.has(phase),
+    (phase) =>
+      phase.tasks.length > 0 ||
+      latestAttemptId === undefined ||
+      phase.attemptId === latestAttemptId,
   );
   const ordered = [
     ...(input.plan

--- a/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
+++ b/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
@@ -507,14 +507,17 @@ describe('transcript fold vs from-scratch oracle', () => {
   });
 
   it("keeps a relaunched workflow's prior attempt as a closed group", () => {
-    // Parity with the progress view: a relaunch appends a fresh attempt's
-    // rows, and the board keeps the previous attempt's cards on screen (each
-    // relaunch carries fresh stage ids and fresh `workflow-task-*` log ids, so
-    // nothing is double-counted). The terminal shows the same rows. The
-    // attempt marker itself is an `internal` entry, which the shared projector
-    // gives no row on either host.
+    // A relaunch appends a fresh attempt without deleting raw transcript
+    // history. The popup's shared model scopes those retained rows separately.
+    // The attempt marker itself is an `internal` entry, which the shared
+    // projector gives no row on either host.
     withStreamSubscription(() => {
-      const planMarker = (id: string, attemptId: string, timestamp: number) =>
+      const planMarker = (
+        id: string,
+        attemptId: string,
+        timestamp: number,
+        malformed = false,
+      ) =>
         appendTranscriptEntry(defaultSession().transcripts, FOLD_STREAM, {
           id,
           type: STREAM_LOG_ENTRY_TYPES.LOG,
@@ -522,7 +525,12 @@ describe('transcript fold vs from-scratch oracle', () => {
           timestamp,
           messageType: MESSAGE_TYPES.INTERNAL,
           text: '',
-          data: { kind: 'workflowPlan', attemptId, phases: [], tasks: [] },
+          data: {
+            kind: 'workflowPlan',
+            attemptId,
+            phases: malformed ? 'unreadable' : [],
+            tasks: [],
+          },
         });
 
       configureStreams(CONFIGS[2]);
@@ -558,7 +566,7 @@ describe('transcript fold vs from-scratch oracle', () => {
           ?.entries.map((entry) => entry.id),
       ).toEqual(['old-failed', 'survey-complete-old']);
 
-      planMarker('workflow-attempt-new', 'attempt-new', 4);
+      planMarker('workflow-attempt-new', 'attempt-new', 4, true);
       appendTranscriptEntry(defaultSession().transcripts, FOLD_STREAM, {
         id: 'new-running',
         type: STREAM_LOG_ENTRY_TYPES.LOG,
@@ -581,6 +589,10 @@ describe('transcript fold vs from-scratch oracle', () => {
           .get(FOLD_STREAM)
           ?.entries.map((entry) => entry.id),
       ).toEqual(['old-failed', 'survey-complete-old', 'new-running']);
+      expect(streams.get().get(FOLD_STREAM)?.workflowAttemptId).toBe(
+        'attempt-new',
+      );
+      expect(streams.get().get(FOLD_STREAM)?.workflowPlan).toBeUndefined();
     });
   });
 

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -49,6 +49,7 @@ type TaskGroupListInternals = HTMLElement & {
   isToolUse: boolean;
   terminal: boolean;
   toggleStates: ToggleStateStore | null;
+  workflowAttemptId: string | undefined;
   workflowPlan: WorkflowPlanMarker | undefined;
   childProgress: ReadonlyMap<StreamTabId, ChildRunProgress>;
   updateComplete: Promise<boolean>;
@@ -143,6 +144,7 @@ function renderList(
   rows: TranscriptRow[],
   options: {
     toggleStates?: ToggleStateStore;
+    workflowAttemptId?: string;
     workflowPlan?: WorkflowPlanMarker;
     childProgress?: ReadonlyMap<StreamTabId, ChildRunProgress>;
   } = {},
@@ -658,6 +660,54 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
       'reviewer@claude-opus-4#child-1',
       'reviewer@claude-opus-4#child-1',
     ]);
+  });
+
+  it('hides superseded phase headers and failed cards after a resume', async () => {
+    const run = runGroup('Run: workflow');
+    const oldMap = createGroup('old-map', STREAM_PHASE.FAILED, {
+      name: 'Map',
+      startTime: 2,
+      parentGroupId: 'run',
+      kind: 'phase',
+      attemptId: 'a1',
+      index: 0,
+      total: 1,
+    });
+    const currentMap = createGroup('current-map', STREAM_PHASE.RUNNING, {
+      name: 'Map',
+      startTime: 4,
+      parentGroupId: 'run',
+      kind: 'phase',
+      attemptId: 'a2',
+      index: 0,
+      total: 1,
+    });
+    const rows: TranscriptRow[] = [
+      workflowTaskRow(oldMap.id, 'stale-failure', 3, {
+        id: 'stale',
+        label: 'Stale failure',
+        phase: 'Map',
+        status: 'failed',
+        error: 'old attempt',
+        attemptId: 'a1',
+      }),
+      workflowTaskRow(currentMap.id, 'current-call', 5, {
+        id: 'current',
+        label: 'Current call',
+        phase: 'Map',
+        status: 'running',
+        attemptId: 'a2',
+      }),
+    ];
+
+    const list = await renderList([run, oldMap, currentMap], rows, {
+      workflowAttemptId: 'a2',
+    });
+
+    expect(groupHeader(list, oldMap.id)).toBeNull();
+    expect(groupHeader(list, currentMap.id)).not.toBeNull();
+    expect(list.shadowRoot?.textContent).not.toContain('Stale failure');
+    expect(list.shadowRoot?.textContent).toContain('Current call');
   });
 
   it('omits the (i/n) suffix when a phase group carries no counts', async () => {

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -705,6 +705,19 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
         error: 'old attempt',
         attemptId: 'a1',
       }),
+      workflowTaskRow(undefined, 'stale-standalone', 7, {
+        id: 'stale-standalone',
+        label: 'Stale standalone call',
+        status: 'failed',
+        error: 'old attempt',
+        attemptId: 'a1',
+      }),
+      workflowTaskRow(undefined, 'current-standalone', 8, {
+        id: 'current-standalone',
+        label: 'Current standalone call',
+        status: 'running',
+        attemptId: 'a2',
+      }),
     ];
 
     const list = await renderList([run, oldMap, currentMap], rows, {
@@ -715,7 +728,11 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
     expect(groupHeader(list, currentMap.id)).not.toBeNull();
     expect(list.shadowRoot?.textContent).not.toContain('Stale failure');
     expect(list.shadowRoot?.textContent).not.toContain('Stale unphased call');
+    expect(list.shadowRoot?.textContent).not.toContain('Stale standalone call');
     expect(list.shadowRoot?.textContent).toContain('Current call');
+    expect(
+      list.shadowRoot?.querySelectorAll('[data-log-id="current-standalone"]'),
+    ).toHaveLength(1);
   });
 
   it('omits the (i/n) suffix when a phase group carries no counts', async () => {

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -90,7 +90,7 @@ function runGroup(name: string, overrides: Partial<TaskGroup> = {}): TaskGroup {
 }
 
 function workflowTaskRow(
-  groupId: string,
+  groupId: string | undefined,
   id: string,
   timestamp: number,
   data: WorkflowCallProgress,
@@ -103,7 +103,7 @@ function workflowTaskRow(
     text: data.id,
     timestamp,
     level,
-    groupId,
+    ...(groupId === undefined ? {} : { groupId }),
     messageType: MESSAGE_TYPES.WORKFLOW_TASK,
     data,
   });
@@ -698,6 +698,19 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
         status: 'running',
         attemptId: 'a2',
       }),
+      workflowTaskRow(run.id, 'stale-unphased', 6, {
+        id: 'stale-unphased',
+        label: 'Stale unphased call',
+        status: 'failed',
+        error: 'old attempt',
+        attemptId: 'a1',
+      }),
+      workflowTaskRow(run.id, 'current-unphased', 7, {
+        id: 'current-unphased',
+        label: 'Current unphased call',
+        status: 'running',
+        attemptId: 'a2',
+      }),
     ];
 
     const list = await renderList([run, oldMap, currentMap], rows, {
@@ -707,7 +720,9 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
     expect(groupHeader(list, oldMap.id)).toBeNull();
     expect(groupHeader(list, currentMap.id)).not.toBeNull();
     expect(list.shadowRoot?.textContent).not.toContain('Stale failure');
+    expect(list.shadowRoot?.textContent).not.toContain('Stale unphased call');
     expect(list.shadowRoot?.textContent).toContain('Current call');
+    expect(list.shadowRoot?.textContent).toContain('Current unphased call');
   });
 
   it('omits the (i/n) suffix when a phase group carries no counts', async () => {

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -705,12 +705,6 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
         error: 'old attempt',
         attemptId: 'a1',
       }),
-      workflowTaskRow(run.id, 'current-unphased', 7, {
-        id: 'current-unphased',
-        label: 'Current unphased call',
-        status: 'running',
-        attemptId: 'a2',
-      }),
     ];
 
     const list = await renderList([run, oldMap, currentMap], rows, {
@@ -722,7 +716,6 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
     expect(list.shadowRoot?.textContent).not.toContain('Stale failure');
     expect(list.shadowRoot?.textContent).not.toContain('Stale unphased call');
     expect(list.shadowRoot?.textContent).toContain('Current call');
-    expect(list.shadowRoot?.textContent).toContain('Current unphased call');
   });
 
   it('omits the (i/n) suffix when a phase group carries no counts', async () => {

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -749,6 +749,7 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
           label: `Queued ${id}`,
           phase: 'Map',
           status: 'queued',
+          attemptId: 'attempt-1',
         }),
       ),
       workflowTaskRow('phase-map', 'live', 6, {
@@ -756,6 +757,7 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
         label: 'Running now',
         phase: 'Map',
         status: 'running',
+        attemptId: 'attempt-1',
         childStreamId: 'researcher@gpt#live',
       }),
     ];

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -663,11 +663,15 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
   });
 
   it('hides superseded phase headers and failed cards after a resume', async () => {
-    const run = runGroup('Run: workflow');
+    const oldRun = runGroup('Run: old workflow');
+    const currentRun = createGroup('current-run', STREAM_PHASE.RUNNING, {
+      name: 'Run: current workflow',
+      startTime: 4,
+    });
     const oldMap = createGroup('old-map', STREAM_PHASE.FAILED, {
       name: 'Map',
       startTime: 2,
-      parentGroupId: 'run',
+      parentGroupId: oldRun.id,
       kind: 'phase',
       attemptId: 'a1',
       index: 0,
@@ -676,7 +680,7 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
     const currentMap = createGroup('current-map', STREAM_PHASE.RUNNING, {
       name: 'Map',
       startTime: 4,
-      parentGroupId: 'run',
+      parentGroupId: currentRun.id,
       kind: 'phase',
       attemptId: 'a2',
       index: 0,
@@ -698,7 +702,7 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
         status: 'running',
         attemptId: 'a2',
       }),
-      workflowTaskRow(run.id, 'stale-unphased', 6, {
+      workflowTaskRow(oldRun.id, 'stale-unphased', 6, {
         id: 'stale-unphased',
         label: 'Stale unphased call',
         status: 'failed',
@@ -720,12 +724,17 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
       }),
     ];
 
-    const list = await renderList([run, oldMap, currentMap], rows, {
-      workflowAttemptId: 'a2',
-    });
+    const list = await renderList(
+      [oldRun, oldMap, currentRun, currentMap],
+      rows,
+      {
+        workflowAttemptId: 'a2',
+      },
+    );
 
     expect(groupHeader(list, oldMap.id)).toBeNull();
     expect(groupHeader(list, currentMap.id)).not.toBeNull();
+    expect(list.shadowRoot?.querySelectorAll('.log-run-band')).toHaveLength(1);
     expect(list.shadowRoot?.textContent).not.toContain('Stale failure');
     expect(list.shadowRoot?.textContent).not.toContain('Stale unphased call');
     expect(list.shadowRoot?.textContent).not.toContain('Stale standalone call');

--- a/src/test-kernel/shared/WorkflowRunModel.vitest.ts
+++ b/src/test-kernel/shared/WorkflowRunModel.vitest.ts
@@ -233,6 +233,64 @@ describe('workflow run model', () => {
     expect(model.phases.map((phase) => phase.key)).toStrictEqual([current.id]);
   });
 
+  it('deduplicates an untagged empty phase when the latest attempt owns its identity', () => {
+    const oldMap = {
+      ...phaseGroup('Map', 0, 1),
+      id: 'old-map',
+    };
+    const currentMap = {
+      ...phaseGroup('Map', 0, 1),
+      id: 'current-map',
+      attemptId: 'a2',
+    };
+
+    const model = workflowRunModel({
+      taskGroups: [oldMap, currentMap],
+      rows: [],
+      plan: { kind: 'workflowPlan', attemptId: 'a2', phases: [], tasks: [] },
+      runSettled: false,
+      childProgress: new Map(),
+    });
+
+    expect(model.phases.map((phase) => phase.key)).toStrictEqual([
+      currentMap.id,
+    ]);
+  });
+
+  it('uses a call-less tagged phase as the latest fallback boundary', () => {
+    const oldMap = {
+      ...phaseGroup('Map', 0, 2),
+      id: 'old-map',
+      startTime: 10,
+      attemptId: 'a1',
+    };
+    const currentReview = {
+      ...phaseGroup('Review', 1, 2),
+      id: 'current-review',
+      startTime: 30,
+      attemptId: 'a2',
+    };
+    const oldCard = {
+      ...taskRow({ id: 'old-card', phase: 'Map', attemptId: 'a1' }),
+      groupId: oldMap.id,
+      seqNo: 10,
+      timestamp: 20,
+    };
+
+    const model = workflowRunModel({
+      taskGroups: [oldMap, currentReview],
+      rows: [oldCard],
+      plan: undefined,
+      runSettled: false,
+      childProgress: new Map(),
+    });
+
+    expect(model.tasks).toStrictEqual([]);
+    expect(model.phases.map((phase) => phase.key)).toStrictEqual([
+      currentReview.id,
+    ]);
+  });
+
   it('orders mixed-generation cards by the shared transcript fallback', () => {
     const oldChild = {
       ...taskRow({ id: 'old-child', phase: 'Map', attemptId: 'a1' }),
@@ -256,6 +314,38 @@ describe('workflow run model', () => {
 
     expect(model.tasks.map((row) => row.call.id)).toStrictEqual([
       'resumed-root',
+    ]);
+  });
+
+  it('selects an attempt deterministically across clock-skewed row generations', () => {
+    const oldChild = {
+      ...taskRow({ id: 'old-child', phase: 'Map', attemptId: 'a1' }),
+      seqNo: 10,
+      timestamp: 300,
+    };
+    const currentChild = {
+      ...taskRow({ id: 'current-child', phase: 'Map', attemptId: 'a2' }),
+      seqNo: 20,
+      timestamp: 100,
+    };
+    const currentLegacyRoot = {
+      ...taskRow({ id: 'current-legacy-root', attemptId: 'a2' }),
+      timestamp: 200,
+    };
+
+    const model = workflowRunModel({
+      taskGroups: [],
+      // Root-first input plus 300 > 200 > 100 creates a cycle for pairwise
+      // seqNo/timestamp sorting. Attempt selection must not depend on that sort.
+      rows: [currentLegacyRoot, currentChild, oldChild],
+      plan: undefined,
+      runSettled: false,
+      childProgress: new Map(),
+    });
+
+    expect(model.tasks.map((row) => row.call.id).toSorted()).toStrictEqual([
+      'current-child',
+      'current-legacy-root',
     ]);
   });
 

--- a/src/test-kernel/shared/WorkflowRunModel.vitest.ts
+++ b/src/test-kernel/shared/WorkflowRunModel.vitest.ts
@@ -343,7 +343,7 @@ describe('workflow run model', () => {
       childProgress: new Map(),
     });
 
-    expect(model.tasks.map((row) => row.call.id).toSorted()).toStrictEqual([
+    expect(model.tasks.map((row) => row.call.id)).toStrictEqual([
       'current-child',
       'current-legacy-root',
     ]);
@@ -556,10 +556,16 @@ describe('workflow run model', () => {
       phases: [{ title: 'Map' }],
       tasks: [],
     };
-    expect(workflowMarkerOf(entry(plan))).toStrictEqual({ kind: 'plan', plan });
-    expect(workflowMarkerOf(entry({ kind: 'workflowPlan' }))?.kind).toBe(
-      'malformedPlan',
-    );
+    expect(workflowMarkerOf(entry(plan))).toStrictEqual({
+      kind: 'plan',
+      attemptId: 'a',
+      plan,
+    });
+    expect(
+      workflowMarkerOf(
+        entry({ kind: 'workflowPlan', attemptId: 'new', phases: 'broken' }),
+      ),
+    ).toMatchObject({ kind: 'malformedPlan', attemptId: 'new' });
     expect(workflowMarkerOf(entry({ kind: 'somethingElse' }))).toBeUndefined();
   });
 });

--- a/src/test-kernel/shared/WorkflowRunModel.vitest.ts
+++ b/src/test-kernel/shared/WorkflowRunModel.vitest.ts
@@ -123,17 +123,78 @@ describe('workflow run model', () => {
     });
   });
 
-  it('scopes cards and phases to the newest attempt', () => {
-    const model = modelOf(
-      ['Map'],
-      [
-        { id: 'legacy', phase: 'Map', status: 'failed' },
-        { id: 'old', phase: 'Map', status: 'failed', attemptId: 'a1' },
-        { id: 'new', phase: 'Map', attemptId: 'a2' },
-      ],
-    );
-    expect(model.tasks.map((row) => row.call.id)).toStrictEqual(['new']);
-    expect(model.phases[0]?.tally.failed).toBe(0);
+  it('scopes resumed calls and phase boundaries to the newest attempt', () => {
+    const oldMap = {
+      ...phaseGroup('Map', 0, 2),
+      id: 'old-map',
+      attemptId: 'a1',
+    };
+    const oldEmpty = {
+      ...phaseGroup('Review', 1, 2),
+      id: 'old-review',
+      attemptId: 'a1',
+    };
+    const newMap = {
+      ...phaseGroup('Map', 0, 2),
+      id: 'new-map',
+      attemptId: 'a2',
+    };
+    const newEmpty = {
+      ...phaseGroup('Review', 1, 2),
+      id: 'new-review',
+      attemptId: 'a2',
+    };
+    const old = {
+      ...taskRow({
+        id: 'old-failure',
+        phase: 'Map',
+        status: 'failed',
+        attemptId: 'a1',
+      }),
+      groupId: oldMap.id,
+      seqNo: 10,
+    };
+    const resumedPhase = {
+      ...taskRow({
+        id: 'resumed-phase',
+        phase: 'Map',
+        status: 'completed',
+        attemptId: 'a2',
+      }),
+      groupId: newMap.id,
+      seqNo: 30,
+    };
+    const resumedUngrouped = {
+      ...taskRow({ id: 'resumed-unphased', attemptId: 'a2' }),
+      seqNo: 40,
+    };
+
+    const model = workflowRunModel({
+      taskGroups: [oldMap, oldEmpty, newMap, newEmpty],
+      // A tree renderer can present root rows before child rows. seqNo remains
+      // the transcript authority regardless of that input arrangement.
+      rows: [resumedUngrouped, resumedPhase, old],
+      plan: { kind: 'workflowPlan', attemptId: 'a2', phases: [], tasks: [] },
+      runSettled: false,
+      childProgress: new Map(),
+    });
+
+    expect(model.tasks.map((row) => row.call.id)).toStrictEqual([
+      'resumed-phase',
+      'resumed-unphased',
+    ]);
+    expect(model.phases.map((phase) => phase.key)).toStrictEqual([
+      newMap.id,
+      newEmpty.id,
+      `unphased-${resumedUngrouped.id}`,
+    ]);
+    expect(model.tally).toStrictEqual({
+      done: 1,
+      total: 2,
+      running: 1,
+      failed: 0,
+      declared: 0,
+    });
   });
 
   it('leads a phase with what needs attention and collapses the rest into counted groups', () => {

--- a/src/test-kernel/shared/WorkflowRunModel.vitest.ts
+++ b/src/test-kernel/shared/WorkflowRunModel.vitest.ts
@@ -133,7 +133,6 @@ describe('workflow run model', () => {
     const oldMap = {
       ...phaseGroup('Map', 0, 2),
       id: 'old-map',
-      attemptId: 'a1',
     };
     const oldEmpty = {
       ...phaseGroup('Review', 1, 2),
@@ -143,7 +142,6 @@ describe('workflow run model', () => {
     const newMap = {
       ...phaseGroup('Map', 0, 2),
       id: 'new-map',
-      attemptId: 'a2',
     };
     const newEmpty = {
       ...phaseGroup('Review', 1, 2),

--- a/src/test-kernel/shared/WorkflowRunModel.vitest.ts
+++ b/src/test-kernel/shared/WorkflowRunModel.vitest.ts
@@ -85,7 +85,13 @@ function modelOf(
     taskGroups: phases.map((name, index) =>
       phaseGroup(name, index, phases.length),
     ),
-    rows: tasks.map(taskRow),
+    rows: tasks.map((task) =>
+      taskRow(
+        task.attemptId === undefined && options.plan
+          ? { ...task, attemptId: options.plan.attemptId }
+          : task,
+      ),
+    ),
     plan: options.plan,
     runSettled: options.runSettled ?? false,
     childProgress: options.childProgress ?? new Map(),
@@ -195,6 +201,62 @@ describe('workflow run model', () => {
       failed: 0,
       declared: 0,
     });
+  });
+
+  it('uses a new plan boundary before its calls or tagged phases arrive', () => {
+    const stale = {
+      ...phaseGroup('Old', 0, 2),
+      id: 'old-empty',
+      attemptId: 'a1',
+    };
+    const current = {
+      ...phaseGroup('Current', 1, 2),
+      id: 'current-empty',
+    };
+    const staleUntaggedCard = {
+      ...taskRow({ id: 'old-call', phase: 'Old', status: 'failed' }),
+      groupId: stale.id,
+    };
+
+    const model = workflowRunModel({
+      taskGroups: [stale, current],
+      rows: [staleUntaggedCard],
+      plan: { kind: 'workflowPlan', attemptId: 'a2', phases: [], tasks: [] },
+      runSettled: false,
+      childProgress: new Map(),
+    });
+
+    expect(model.tasks).toStrictEqual([]);
+    // Explicit old ownership is actionable. Missing ownership is not: mixed-
+    // version traces cannot distinguish an old call-less phase from this
+    // genuinely current one, so the compatible choice is to preserve it.
+    expect(model.phases.map((phase) => phase.key)).toStrictEqual([current.id]);
+  });
+
+  it('orders mixed-generation cards by the shared transcript fallback', () => {
+    const oldChild = {
+      ...taskRow({ id: 'old-child', phase: 'Map', attemptId: 'a1' }),
+      seqNo: 10,
+      timestamp: 10,
+    };
+    const resumedRoot = {
+      ...taskRow({ id: 'resumed-root', attemptId: 'a2' }),
+      timestamp: 20,
+    };
+
+    const model = workflowRunModel({
+      taskGroups: [],
+      // Tree pre-order places the newer root row before the older grouped
+      // child. Mixed-generation rows fall back to timestamps, not input order.
+      rows: [resumedRoot, oldChild],
+      plan: undefined,
+      runSettled: false,
+      childProgress: new Map(),
+    });
+
+    expect(model.tasks.map((row) => row.call.id)).toStrictEqual([
+      'resumed-root',
+    ]);
   });
 
   it('leads a phase with what needs attention and collapses the rest into counted groups', () => {

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -10,8 +10,10 @@ import {
   ToolUseLogSchema,
   type StreamLogEntry,
   type StreamTabId,
+  type TaskGroup,
 } from '@shared/schemas';
 import { STREAM_TRANSITION_CAUSE } from '@shared/streams/streamStatus';
+import { upsertTaskGroupFromStreamLog } from '@shared/streams/taskGroupProjection';
 import { setupPlatform } from '@test/support/setupPlatform';
 import {
   createTempDirPlatform,
@@ -124,6 +126,34 @@ describe('attachTranscriptRecorder stage kind (issue #7267)', () => {
 
     expect(runEntry?.type).toBe(STREAM_LOG_ENTRY_TYPES.GROUP_END);
     expect(dataOf(runEntry).kind).toBe('run');
+  });
+
+  it('persists and projects phase attempt ownership through stage end', () => {
+    const { trace, row } = attachRecorder();
+    trace.emit({
+      type: 'workflow.plan',
+      attemptId: 'attempt-2',
+      phases: [{ title: 'Review' }],
+      tasks: [],
+    });
+
+    const phase = trace.openStage('Review', {
+      kind: 'phase',
+      index: 0,
+      total: 1,
+    });
+    phase.end();
+
+    const entry = row(phase.id)!;
+    expect(entry).toMatchObject({
+      type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
+      data: { attemptId: 'attempt-2' },
+    });
+    const groups: TaskGroup[] = [];
+    expect(upsertTaskGroupFromStreamLog(groups, new Map(), entry)).toBe(true);
+    expect(groups).toMatchObject([
+      { id: phase.id, attemptId: 'attempt-2', status: STREAM_PHASE.COMPLETED },
+    ]);
   });
 
   it('preserves phase position metadata on the terminal row', () => {

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -166,7 +166,7 @@ interface StreamSinkState {
 type StageMetadata = Pick<
   Extract<AgentEvent, { type: 'stage.start' }>,
   'kind' | 'index' | 'total'
->;
+> & { readonly attemptId?: string };
 
 /**
  * Subscribe to a trace and route every event into the StreamLogStore for the
@@ -324,6 +324,7 @@ export function attachTranscriptRecorder(
   // rely on that distinction to tell a root run's terminal status apart from
   // a round's (see toStreamLifecycleStatus in packages/trace-viewer).
   const stageMetadata = new Map<string, StageMetadata>();
+  let workflowAttemptId: string | undefined;
   const workflowCallEntries = new Set<string>();
   const activeToolEntries = new Map<string, ToolUseLog>();
   let transcriptBoundaryClosed = false;
@@ -439,6 +440,9 @@ export function attachTranscriptRecorder(
         case 'stage.start': {
           const metadata = {
             ...(event.kind !== undefined ? { kind: event.kind } : {}),
+            ...(event.kind === 'phase' && workflowAttemptId !== undefined
+              ? { attemptId: workflowAttemptId }
+              : {}),
             ...(event.index !== undefined ? { index: event.index } : {}),
             ...(event.total !== undefined ? { total: event.total } : {}),
           } satisfies StageMetadata;
@@ -541,6 +545,7 @@ export function attachTranscriptRecorder(
         }
 
         case 'workflow.plan': {
+          workflowAttemptId = event.attemptId;
           // Display strings pass through record-time redaction like every
           // stage label and card the recorder persists; ids stay verbatim.
           const marker = {


### PR DESCRIPTION
## Summary

- stamp workflow phase task groups with the projection attempt that opened them
- select one latest attempt at the shared workflow-run-model root, using the newest plan when available and `seqNo`-ordered cards as the legacy fallback
- scope all phase and run tallies, status cells, ungrouped cards, and phase rows through that one identity
- drop call-less phase groups owned only by a superseded attempt while preserving traces with no attempt ownership

Current `main` has already replaced the issue-era CLI dashboard and `ConversationPane` tally folds with the shared `workflowRunModel` consumed by the CLI workflow popup and extension progress board. Fixing the shared model therefore applies the same attempt scope to both current host surfaces rather than recreating deleted host-local helpers.

Closes #11584
Closes #11585
Closes #11586

## Issue acceptance gates

- #11585: latest attempt is chosen once at the root. Tagged cards are put back into wire `seqNo` order, including ungrouped resumed calls, before the model scopes every phase and run tally. Superseded phase totals and failure cells disappear.
- #11584: phase groups carry optional `attemptId`, so a superseded call-less phase is filtered from the phase/tab list without relying on a stale task reference.
- #11586: the shared model's phase and whole-run tallies contain only the selected attempt, so a failed prior attempt does not remain in the current CLI/extension status presentation.
- Untagged historical traces retain the existing unscoped behavior.

## Single source of truth

`src/shared/streams/workflowRunModel.ts` owns latest-attempt selection and applies it once to the complete run before either host renders phases, tallies, or status cells. `TaskGroupSchema.attemptId` carries phase-boundary ownership from transcript projection into that model.

## Duplication and abstraction budget

No host-local wrappers or duplicate tally/filter paths were added. One file-local selector in the existing shared run model owns the root-level identity decision.

## Net elements (R6)

n/a: this is a bug fix, not a refactor-class PR.

## Consumer counts (R8)

n/a: no emit path or export was deleted or rerouted.

## Host impact

Extension: progress-board phase rows, phase headers, run tally, failure dots, and call-less phases use the corrected shared scope.

Desktop: shared schema accepts the optional phase ownership field; no desktop presentation behavior changes.

CLI: workflow popup phase tabs, task rows, phase tallies, run tally, failure count, and keyboard phase list use the corrected shared scope.

## Scheduled refactoring

None.

## Validation

Passed:

- `npm run compile:fast`
- `npm run typecheck` (workspace, test-kernel, agent, CLI, trace-viewer, desktop)
- `npm run lint`
- changed-file Prettier check, ESLint, and `git diff --check`
- `npm run check:dead-code-ratchet` (316 combined findings vs 316 baselined)
- focused Vitest run: 77/77 across `WorkflowRunModel`, `TaskGroupProjection`, `TaskGroupListIndex`, `WorkflowPopup`, `WorkflowRunDetails`, and `TexraTranscriptRecorder`
- broader focused run: 265/265 including CLI `TuiStateAndFocus`
- focused PTY validation: `node scripts/validate-tui.mjs --no-build workflow-running`

Repository-wide `npm test` completed 9,912 passing and 34 skipped tests, with 3 unrelated failures plus 2 suite setup timeouts: `SettingsNavigation` and `TaskGroupListIndex` JSDOM hook timeouts, and three `DesktopAgentExecution` timeout/session-isolation failures. The affected `TaskGroupListIndex` suite passes 17/17 in the focused run above.

Two existing main-branch ratchets are not green and are unrelated to this diff:

- CLI architecture check flags unchanged `packages/cli/src/tui/terminalCleanup.ts` for direct `process.env` access.
- the full PTY validator exceeded 10 minutes with multiple stale-copy expectations; the affected `workflow-running` scenario passed both before the timeout and in the focused run.
