### PR TITLE
refactor(progress): store canonical goal state

### DIFF
--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -17,7 +17,6 @@ import type {
 } from '@shared/schemas';
 import {
   DEFAULT_STREAM_METADATA_STATUS,
-  deriveGoalState,
   isPlainAgentIdentity,
   isToolUseState,
   isWorkflowState,
@@ -422,11 +421,7 @@ export class StreamHeader extends UnsupportedCommandsMixin(LitElement) {
       superYolo: Boolean(toolUse?.superYoloBypass),
       toolEdit: Boolean(toolUse?.toolEditBypass),
     };
-    const goal = deriveGoalState({
-      goalActive: toolUse?.goalActive,
-      goalStatus: toolUse?.goalStatus,
-      goalObjective: toolUse?.goalObjective,
-    });
+    const goal = toolUse?.goal ?? { active: false };
     const hasExecutionId = Boolean(this.stream.executionId);
     const identity = this.stream.identity;
     const isNativeAgentRun = isPlainAgentIdentity(identity);

--- a/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
@@ -12,13 +12,12 @@ import type {
   PermissionPayload,
   ProgressViewOutboundHandlerRegistry,
 } from '@shared/schemas';
-import { deriveGoalState } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { createBoundedIdSet } from '@utils/core/boundedIdSet';
 
 import { clearInquiryDraft } from './inquiryDraftState';
 import { permissions$ } from '../progressState';
-import { goalToStateFields, updateToolUseState } from '../stateUtils';
+import { updateToolUseState } from '../stateUtils';
 import { permissionId } from '../permissionState';
 
 // ============================================================
@@ -107,14 +106,15 @@ export const permissionHandlers = {
   },
 
   [PROGRESS_VIEW_COMMANDS.GOAL_ACTIVE_UPDATED]: (data) => {
-    const goal = deriveGoalState({
-      goalActive: data.active,
-      goalStatus: data.status,
-      goalObjective: data.objective,
-    });
     updateToolUseState(data.stream, (prev) =>
       create(prev, (draft) => {
-        Object.assign(draft, goalToStateFields(goal));
+        draft.goal = data.active
+          ? {
+              active: true,
+              status: data.status ?? 'active',
+              objective: data.objective ?? '',
+            }
+          : { active: false };
       }),
     );
   },

--- a/packages/extension/src/progressView/frontend/slices/syncSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/syncSlice.ts
@@ -6,11 +6,7 @@ import {
   type StreamContentRenderPayload,
 } from '@shared/schemas';
 // Local imports
-import {
-  goalToStateFields,
-  updateToolUseState,
-  updateWorkflowState,
-} from '../stateUtils';
+import { updateToolUseState, updateWorkflowState } from '../stateUtils';
 
 function activeStateFields(data: StreamContentRenderPayload) {
   if (!data.activeState) return {};
@@ -41,9 +37,6 @@ export const syncHandlers = {
       }));
     } else {
       const { workPlan, controls } = data;
-      // `controls.goal` already matches GoalStateSchema (the wire schema
-      // imports it directly from `@shared/schemas/goal`) — no need to
-      // round-trip it through deriveGoalState.
       const { goal, ...bypasses } = controls;
       updateToolUseState(data.stream, (prev) => ({
         ...prev,
@@ -53,7 +46,7 @@ export const syncHandlers = {
         plan: workPlan.plan,
         queuedFollowUps: workPlan.queuedFollowUps,
         ...bypasses,
-        ...goalToStateFields(goal),
+        goal,
       }));
     }
   },

--- a/packages/extension/src/progressView/frontend/stateUtils.ts
+++ b/packages/extension/src/progressView/frontend/stateUtils.ts
@@ -8,8 +8,6 @@ import {
   type TokenUsageStats,
   type ToolUseStreamState,
   type WorkflowStreamState,
-  type GoalState,
-  type GoalStatus,
 } from '@shared/schemas';
 
 // Local imports
@@ -29,24 +27,6 @@ export function updateRounds<T>(
   }
   if (!rounds) return current;
   return { ...current, ...rounds };
-}
-
-/**
- * Flatten a canonical `GoalState` (discriminated union) into the three
- * independently-optional fields `ToolUseStreamState` carries on the wire.
- * The inverse of `deriveGoalState`: status/objective only exist while a goal
- * is active, so inactive goals write `undefined` for both.
- */
-export function goalToStateFields(goal: GoalState): {
-  goalActive: boolean;
-  goalStatus: GoalStatus | undefined;
-  goalObjective: string | undefined;
-} {
-  return {
-    goalActive: goal.active,
-    goalStatus: goal.active ? goal.status : undefined,
-    goalObjective: goal.active ? goal.objective : undefined,
-  };
 }
 
 /**

--- a/src/controllers/progressView/progressStreamControls.ts
+++ b/src/controllers/progressView/progressStreamControls.ts
@@ -11,10 +11,9 @@ import { GoalStore } from '@tools/goal';
  * Per-stream control flags pushed to the progress view: approval bypass state
  * plus the goal chip state. A progress-view domain concept, owned here next to
  * the producer rather than inside the Lit renderer. `goal` is the same
- * canonical {@link GoalState} the wire projection (`ControlsSectionSchema`)
- * and `deriveGoalState` use, so the one production consumer
- * (`LitSessionRenderer`) can forward this return value as-is instead of
- * re-flattening and re-deriving it.
+ * canonical {@link GoalState} used by the wire projection
+ * (`ControlsSectionSchema`) and tool-use stream state, so the one production
+ * consumer (`LitSessionRenderer`) can forward this return value as-is.
  */
 interface ProgressStreamControls {
   bashBypass: boolean;

--- a/src/shared/schemas/goal.ts
+++ b/src/shared/schemas/goal.ts
@@ -42,27 +42,6 @@ export const GoalStateSchema = z.discriminatedUnion('active', [
 ]);
 export type GoalState = z.infer<typeof GoalStateSchema>;
 
-/**
- * Single source of truth for the "status/objective are only meaningful while
- * a goal is active" invariant. Wire messages and `ToolUseStreamState`
- * (`streamState.ts`) can't carry the canonical discriminated union directly
- * (three independently-optional fields on the wire), so every reader of that
- * flattened shape — frontend slices, UI components — must call this instead
- * of re-deriving the active/status/objective guard ad hoc at each site.
- */
-export function deriveGoalState(input: {
-  goalActive?: boolean;
-  goalStatus?: GoalStatus;
-  goalObjective?: string;
-}): GoalState {
-  if (!input.goalActive) return { active: false };
-  return {
-    active: true,
-    status: input.goalStatus ?? 'active',
-    objective: input.goalObjective ?? '',
-  };
-}
-
 export const GoalSchema = z.object({
   goalId: z.string().min(1),
   streamId: StreamTabIdSchema,

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { GoalStateSchema, GoalStatusSchema } from './goal';
+import { GoalStateSchema } from './goal';
 import { AgentCategory, AgentCategorySchema } from './agent';
 import { RunIdentitySchema } from './runIdentity';
 import { CompileFailureSchema, OutputFileInfoSchema } from './output';
@@ -198,57 +198,6 @@ const ToolUseStreamStateSchema = BaseStreamStateSchema.extend({
   ui: ToolUseUIStateSchema.prefault({}),
 });
 
-/**
- * Compatibility input for stream-state snapshots written before 2026-08-31.
- * Normalize the released flattened goal fields here, at the construction
- * boundary, so current state and every downstream consumer only see `goal`.
- * Remove after the three-month compatibility window ends on 2026-11-30.
- */
-const LegacyToolUseStreamStateSchema = z
-  .object({
-    goalActive: z.boolean().optional(),
-    goalStatus: GoalStatusSchema.optional(),
-    goalObjective: z.string().optional(),
-  })
-  .transform(({ goalActive, goalStatus, goalObjective }) => ({
-    goal: goalActive
-      ? {
-          active: true as const,
-          status: goalStatus ?? 'active',
-          objective: goalObjective ?? '',
-        }
-      : { active: false as const },
-  }));
-
-const ToolUseStreamStateInputSchema = z
-  .unknown()
-  .transform((input, ctx) => {
-    if (typeof input !== 'object' || input === null) return input;
-    const hasCanonicalGoal = Object.hasOwn(input, 'goal');
-    const hasLegacyGoal =
-      Object.hasOwn(input, 'goalActive') ||
-      Object.hasOwn(input, 'goalStatus') ||
-      Object.hasOwn(input, 'goalObjective');
-    if (hasCanonicalGoal && hasLegacyGoal) {
-      ctx.addIssue({
-        code: 'custom',
-        message: 'Stream state cannot mix canonical and legacy goal fields',
-      });
-      return z.NEVER;
-    }
-    if (!hasLegacyGoal) return input;
-
-    const legacy = LegacyToolUseStreamStateSchema.parse(input);
-    const {
-      goalActive: _active,
-      goalStatus: _status,
-      goalObjective: _objective,
-      ...current
-    } = input as Record<string, unknown>;
-    return { ...current, ...legacy };
-  })
-  .pipe(ToolUseStreamStateSchema);
-
 export type ToolUseStreamState = z.infer<typeof ToolUseStreamStateSchema>;
 
 // Workflow Stream State
@@ -313,7 +262,7 @@ export function createStreamState(
   partial?: Partial<StreamState>,
 ): StreamState {
   if (agentCategory === AgentCategory.ToolUse) {
-    return ToolUseStreamStateInputSchema.parse({
+    return ToolUseStreamStateSchema.parse({
       category: AgentCategory.ToolUse,
       ...partial,
     });

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { GoalStatusSchema } from './goal';
+import { GoalStateSchema, GoalStatusSchema } from './goal';
 import { AgentCategory, AgentCategorySchema } from './agent';
 import { RunIdentitySchema } from './runIdentity';
 import { CompileFailureSchema, OutputFileInfoSchema } from './output';
@@ -193,12 +193,61 @@ const ToolUseStreamStateSchema = BaseStreamStateSchema.extend({
   bashBypass: z.boolean().optional(),
   toolEditBypass: z.boolean().optional(),
   superYoloBypass: z.boolean().optional(),
-  goalActive: z.boolean().optional(),
-  goalStatus: GoalStatusSchema.optional(),
-  goalObjective: z.string().optional(),
+  goal: GoalStateSchema.prefault({ active: false }),
   // Frontend-owned (nested under ui)
   ui: ToolUseUIStateSchema.prefault({}),
 });
+
+/**
+ * Compatibility input for stream-state snapshots written before 2026-08-31.
+ * Normalize the released flattened goal fields here, at the construction
+ * boundary, so current state and every downstream consumer only see `goal`.
+ * Remove after the three-month compatibility window ends on 2026-11-30.
+ */
+const LegacyToolUseStreamStateSchema = z
+  .object({
+    goalActive: z.boolean().optional(),
+    goalStatus: GoalStatusSchema.optional(),
+    goalObjective: z.string().optional(),
+  })
+  .transform(({ goalActive, goalStatus, goalObjective }) => ({
+    goal: goalActive
+      ? {
+          active: true as const,
+          status: goalStatus ?? 'active',
+          objective: goalObjective ?? '',
+        }
+      : { active: false as const },
+  }));
+
+const ToolUseStreamStateInputSchema = z
+  .unknown()
+  .transform((input, ctx) => {
+    if (typeof input !== 'object' || input === null) return input;
+    const hasCanonicalGoal = Object.hasOwn(input, 'goal');
+    const hasLegacyGoal =
+      Object.hasOwn(input, 'goalActive') ||
+      Object.hasOwn(input, 'goalStatus') ||
+      Object.hasOwn(input, 'goalObjective');
+    if (hasCanonicalGoal && hasLegacyGoal) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Stream state cannot mix canonical and legacy goal fields',
+      });
+      return z.NEVER;
+    }
+    if (!hasLegacyGoal) return input;
+
+    const legacy = LegacyToolUseStreamStateSchema.parse(input);
+    const {
+      goalActive: _active,
+      goalStatus: _status,
+      goalObjective: _objective,
+      ...current
+    } = input as Record<string, unknown>;
+    return { ...current, ...legacy };
+  })
+  .pipe(ToolUseStreamStateSchema);
 
 export type ToolUseStreamState = z.infer<typeof ToolUseStreamStateSchema>;
 
@@ -264,7 +313,7 @@ export function createStreamState(
   partial?: Partial<StreamState>,
 ): StreamState {
   if (agentCategory === AgentCategory.ToolUse) {
-    return ToolUseStreamStateSchema.parse({
+    return ToolUseStreamStateInputSchema.parse({
       category: AgentCategory.ToolUse,
       ...partial,
     });

--- a/src/test-kernel/progressView/StreamHeader.vitest.ts
+++ b/src/test-kernel/progressView/StreamHeader.vitest.ts
@@ -197,9 +197,11 @@ describe('stream-header', () => {
     it('anchors the goal chip tooltip via wa-tooltip[for], not a native title', async () => {
       const element = await mount({
         state: baseState({
-          goalActive: true,
-          goalStatus: 'active',
-          goalObjective: 'ship the fix',
+          goal: {
+            active: true,
+            status: 'active',
+            objective: 'ship the fix',
+          },
         }),
       });
 

--- a/src/test-kernel/progressView/StreamMetaState.vitest.ts
+++ b/src/test-kernel/progressView/StreamMetaState.vitest.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { logHandlers } from '@progressView/frontend/slices/logSlice';
+import { permissionHandlers } from '@progressView/frontend/slices/permissionSlice';
 import { streamLifecycleHandlers } from '@progressView/frontend/slices/streamLifecycleSlice';
 import { syncHandlers } from '@progressView/frontend/slices/syncSlice';
 import {
@@ -189,6 +190,27 @@ function metadataPatchMessage(
 describe('stream meta frontend state', () => {
   beforeEach(() => {
     resetProgressState();
+  });
+
+  it('transitions one canonical goal through active, paused, and inactive states', () => {
+    const streamId = 'goal-stream' as StreamTabId;
+    const state = createInitialState();
+    registerStream(state, streamId, { agentCategory: AgentCategory.ToolUse });
+    state.streamStates.set(streamId, createStreamState(AgentCategory.ToolUse));
+    const getState = seedState(state);
+
+    for (const goal of [
+      { active: true, status: 'active' as const, objective: 'Ship it' },
+      { active: true, status: 'paused' as const, objective: 'Ship it' },
+      { active: false },
+    ]) {
+      dispatch(permissionHandlers, {
+        command: PROGRESS_VIEW_COMMANDS.GOAL_ACTIVE_UPDATED,
+        stream: streamId,
+        ...goal,
+      });
+      expect(getState().streamStates.get(streamId)).toMatchObject({ goal });
+    }
   });
 
   it('excludes child streams from the top-level stream list', () => {

--- a/src/test-kernel/schemas/SharedSchemas.vitest.ts
+++ b/src/test-kernel/schemas/SharedSchemas.vitest.ts
@@ -5,6 +5,8 @@
 import { describe, expect, it } from 'vitest';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import {
+  AgentCategory,
+  createStreamState,
   SETTINGS_TAB_GROUPS,
   SETTINGS_TAB_ORDER,
   SETTINGS_TAB_PANEL_NAMES,
@@ -212,5 +214,53 @@ describe('settings view tab definitions', () => {
 
     expect(labels.every((label) => label.trim().length > 0)).toBe(true);
     expect(new Set(labels).size).toBe(labels.length);
+  });
+});
+
+describe('tool-use stream goal state', () => {
+  it.each([
+    { active: false as const },
+    { active: true as const, status: 'active' as const, objective: 'Ship it' },
+    { active: true as const, status: 'paused' as const, objective: 'Ship it' },
+  ])('stores the canonical goal union: $active $status', (goal) => {
+    const state = createStreamState(AgentCategory.ToolUse, { goal });
+
+    expect(state).toMatchObject({ goal });
+    expect(state).not.toHaveProperty('goalActive');
+    expect(state).not.toHaveProperty('goalStatus');
+    expect(state).not.toHaveProperty('goalObjective');
+  });
+
+  it.each([
+    { goal: { active: false, objective: 'impossible' } },
+    {
+      goal: { active: true, status: 'active', objective: 'canonical' },
+      goalActive: true,
+      goalStatus: 'paused',
+      goalObjective: 'legacy',
+    },
+  ])('rejects invalid or mixed goal state %#', (partial) => {
+    expect(() =>
+      createStreamState(AgentCategory.ToolUse, partial as never),
+    ).toThrow();
+  });
+
+  it('normalizes historical flattened goal fields at the construction boundary', () => {
+    const state = createStreamState(AgentCategory.ToolUse, {
+      goalActive: true,
+      goalStatus: 'paused',
+      goalObjective: 'Resume after review',
+    } as never);
+
+    expect(state).toMatchObject({
+      goal: {
+        active: true,
+        status: 'paused',
+        objective: 'Resume after review',
+      },
+    });
+    expect(state).not.toHaveProperty('goalActive');
+    expect(state).not.toHaveProperty('goalStatus');
+    expect(state).not.toHaveProperty('goalObjective');
   });
 });

--- a/src/test-kernel/schemas/SharedSchemas.vitest.ts
+++ b/src/test-kernel/schemas/SharedSchemas.vitest.ts
@@ -5,9 +5,6 @@
 import { describe, expect, it } from 'vitest';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import {
-  AgentCategory,
-  createStreamState,
-  GoalStateSchema,
   SETTINGS_TAB_GROUPS,
   SETTINGS_TAB_ORDER,
   SETTINGS_TAB_PANEL_NAMES,
@@ -215,30 +212,5 @@ describe('settings view tab definitions', () => {
 
     expect(labels.every((label) => label.trim().length > 0)).toBe(true);
     expect(new Set(labels).size).toBe(labels.length);
-  });
-});
-
-describe('tool-use stream goal state', () => {
-  it.each([
-    { active: false as const },
-    { active: true as const, status: 'active' as const, objective: 'Ship it' },
-    { active: true as const, status: 'paused' as const, objective: 'Ship it' },
-  ])('stores the canonical goal union: $active $status', (goal) => {
-    const state = createStreamState(AgentCategory.ToolUse, { goal });
-
-    expect(state).toMatchObject({ goal });
-    expect(state).not.toHaveProperty('goalActive');
-    expect(state).not.toHaveProperty('goalStatus');
-    expect(state).not.toHaveProperty('goalObjective');
-  });
-
-  it('rejects fields from the other canonical union branch', () => {
-    expect(
-      GoalStateSchema.safeParse({
-        active: false,
-        status: 'paused',
-        objective: 'impossible',
-      }).success,
-    ).toBe(false);
   });
 });

--- a/src/test-kernel/schemas/SharedSchemas.vitest.ts
+++ b/src/test-kernel/schemas/SharedSchemas.vitest.ts
@@ -7,6 +7,7 @@ import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import {
   AgentCategory,
   createStreamState,
+  GoalStateSchema,
   SETTINGS_TAB_GROUPS,
   SETTINGS_TAB_ORDER,
   SETTINGS_TAB_PANEL_NAMES,
@@ -231,36 +232,13 @@ describe('tool-use stream goal state', () => {
     expect(state).not.toHaveProperty('goalObjective');
   });
 
-  it.each([
-    { goal: { active: false, objective: 'impossible' } },
-    {
-      goal: { active: true, status: 'active', objective: 'canonical' },
-      goalActive: true,
-      goalStatus: 'paused',
-      goalObjective: 'legacy',
-    },
-  ])('rejects invalid or mixed goal state %#', (partial) => {
-    expect(() =>
-      createStreamState(AgentCategory.ToolUse, partial as never),
-    ).toThrow();
-  });
-
-  it('normalizes historical flattened goal fields at the construction boundary', () => {
-    const state = createStreamState(AgentCategory.ToolUse, {
-      goalActive: true,
-      goalStatus: 'paused',
-      goalObjective: 'Resume after review',
-    } as never);
-
-    expect(state).toMatchObject({
-      goal: {
-        active: true,
+  it('rejects fields from the other canonical union branch', () => {
+    expect(
+      GoalStateSchema.safeParse({
+        active: false,
         status: 'paused',
-        objective: 'Resume after review',
-      },
-    });
-    expect(state).not.toHaveProperty('goalActive');
-    expect(state).not.toHaveProperty('goalStatus');
-    expect(state).not.toHaveProperty('goalObjective');
+        objective: 'impossible',
+      }).success,
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Store one canonical `GoalState` union on tool-use stream state instead of the independent `goalActive`, `goalStatus`, and `goalObjective` fields. Goal updates, full content sync, and rendering now pass that union directly.

This is a direct replacement of an internal, frontend-only representation. `ProgressState.streamStates` is not persisted, and hydration and trace replay already provide canonical `controls.goal`. The durable goal format is `GoalSchema` in `GoalStore`, which never used the flattened stream-state fields, so no migration or compatibility reader is needed.

Closes #11666.

## Issue acceptance gates

- Current stream state stores one canonical `goal: GoalState` value.
- Goal state is schema-valid as active, paused, or inactive, with fields from the wrong union branch rejected.
- Goal active, paused, inactive transitions, rendering, lifecycle, and progress synchronization have focused coverage.
- No historical stream-state migration is added because the replaced frontend representation has no persisted/loadable production boundary.

## Single source of truth

`GoalStateSchema` in `src/shared/schemas/goal.ts` owns the goal-state union. `ToolUseStreamStateSchema` imports it directly.

## Duplication and abstraction budget

Removed `deriveGoalState` and `goalToStateFields` plus all production call sites. Added no compatibility schema, migration, wrapper, or parallel representation.

## Net elements (R6)

- Files: 10 modified, no files added or deleted.
- Exported symbols: removed 2 (`deriveGoalState`, `goalToStateFields`), added 0.
- Classes/interfaces/enums: no additions or removals.
- LoC: +71 / -75, net -4, including focused canonical-state and reducer transition coverage.

## Consumer counts (R8)

- `deriveGoalState`: 2 production consumers removed (`permissionSlice`, `StreamHeader`).
- `goalToStateFields`: 2 production consumers removed (`permissionSlice`, `syncSlice`).
- No emit path changed. `GOAL_ACTIVE_UPDATED` keeps its existing wire contract.

## Host impact

Extension: Progress-view stream state, goal updates, sync, and rendering use canonical `GoalState`.

Desktop: Uses the shared progress frontend reducer and receives the same canonical state behavior.

CLI: No runtime behavior change.

## Scheduled refactoring

None.

## Validation

Passed after the review simplification:

- Focused reducer transition, stream synchronization, and rendering suites: 40 tests
- Full `npm run typecheck`
- Changed-file ESLint and Prettier checks

Also passed on the preceding commit, with the remaining production paths unchanged by this simplification:

- Architecture suites: 101 tests
- `npm run check:browser-safe-utils`
- `npm run check:dead-code-ratchet`
- `npm run compile:fast`

Repository-wide checks with existing unrelated findings:

- `npm test`: 9,943 passed, 6 skipped, 7 failed in CLI/desktop session-isolation suites unrelated to this diff (`ResumeCommand`, `RunChatSignalOwnership`, `DesktopAgentExecution`). Re-running those files also fails without touching goal-state code.
- `npm run check:dead-code`: reports the 6 unused exports already captured by the passing dead-code ratchet; this change adds no finding.
