### PR TITLE
fix(workflow): preserve legacy card identity

### DIFF
--- a/src/test-kernel/agent/WorkflowScriptProgressProjectionFailure.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressProjectionFailure.vitest.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { AgentTrace } from '@agent/trace';
 import type { PersistedWorkflowScriptRunOptions } from '@agent/workflowScript';
-import type { WorkflowExecutionSnapshot } from '@shared/schemas';
+import { PersistedWorkflowExecutionSnapshotSchema } from '@shared/schemas';
 import { runPersistedWorkflowScriptWithProgress } from '@tools/delegation/workflowScriptRun';
 
 const mocks = vi.hoisted(() => ({
@@ -14,75 +14,53 @@ vi.mock('@agent/workflowScript', async (importOriginal) => ({
   runPersistedWorkflowScript: mocks.runPersistedWorkflowScript,
 }));
 
-function snapshot(
-  lifecycle: 'waiting' | 'active',
-  status: 'planned' | 'running',
-): WorkflowExecutionSnapshot {
-  return {
-    stages: [
-      {
-        id: 'stage-review',
-        title: 'Review',
-        order: 0,
-        lifecycle,
-      },
-    ],
+function snapshot(status: 'planned' | 'running', markerFree = false) {
+  const timestamp = '2026-08-15T20:00:00.000Z';
+  const active = status === 'running';
+  return PersistedWorkflowExecutionSnapshotSchema.parse({
+    lifecycle: active ? 'active' : 'waiting',
+    stages: [],
     calls: [
       {
         id: 'retry-review',
         label: 'Retry review',
-        stageId: 'stage-review',
         status,
-        // The engine stamps the call issued when the script reaches it.
-        ...(lifecycle === 'active' && { issued: true }),
+        ...(active &&
+          (markerFree
+            ? { agent: 'historical-agent' }
+            : { issued: true, kind: 'document' })),
         attempts: [],
-        files: {},
-        timestamps: {
-          createdAt: '2026-08-15T20:00:00.000Z',
-          updatedAt: '2026-08-15T20:00:00.000Z',
-        },
+        files: { input: [], context: [], media: [] },
+        timestamps: { createdAt: timestamp, updatedAt: timestamp },
       },
     ],
-  } as unknown as WorkflowExecutionSnapshot;
+    timestamps: { createdAt: timestamp, updatedAt: timestamp },
+  });
 }
 
 describe('workflow-script projection failure recovery', () => {
   it('projects a marker-free issued call after a fold fails before projection', async () => {
-    const construction = snapshot('waiting', 'planned');
-    const issued = snapshot('active', 'planned');
-    const running = snapshot('active', 'running');
-    const call = running.calls[0]!;
-    delete call.issued;
-    Object.assign(call, {
-      kind: 'document',
-      agent: 'projection-agent',
-      model: 'projection-model',
-      files: { input: [], context: [], media: [] },
-    });
+    const construction = snapshot('planned');
+    const running = snapshot('running', true);
     mocks.runPersistedWorkflowScript.mockImplementationOnce(
       async (options: PersistedWorkflowScriptRunOptions) => {
         options.onTransition?.(construction);
-        options.onTransition?.(issued);
         options.onTransition?.(running);
         await options.onSnapshot?.(running);
         return { snapshot: running } as never;
       },
     );
 
-    const emit = vi.fn();
+    const emit = vi.fn().mockImplementationOnce(() => {
+      throw new Error('trace projection unavailable');
+    });
     const warn = vi.fn();
-    const openStage = vi
-      .fn()
-      .mockImplementationOnce(() => {
-        throw new Error('trace projection unavailable');
-      })
-      .mockReturnValue({ id: 'trace-review', end: vi.fn() });
     const trace = {
       activeStageId: vi.fn(),
       emit,
       info: vi.fn(),
       warn,
-      openStage,
+      openStage: vi.fn(),
     } as unknown as AgentTrace;
 
     await runPersistedWorkflowScriptWithProgress(trace, {
@@ -96,26 +74,23 @@ describe('workflow-script projection failure recovery', () => {
       expect.stringContaining('trace projection unavailable'),
       expect.anything(),
     );
-    expect(emit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'workflow.call',
-        call: expect.objectContaining({
-          id: 'retry-review',
-          status: 'running',
-          kind: 'document',
-          agent: 'projection-agent',
-          model: 'projection-model',
-          files: { input: [], context: [], media: [] },
-        }),
-      }),
-    );
+    const projected = emit.mock.calls
+      .map(([event]) => event)
+      .find((event) => event.call?.status === 'running');
+    expect(projected?.call).toStrictEqual({
+      id: 'retry-review',
+      label: 'Retry review',
+      status: 'running',
+      agent: 'historical-agent',
+      files: { input: [], context: [], media: [] },
+      attemptId: expect.any(String),
+    });
   });
 
   it("retains a retried call's attempt number when the backstop terminalizes it", async () => {
-    const construction = snapshot('waiting', 'planned');
-    const issued = snapshot('active', 'planned');
-    const running = snapshot('active', 'running');
-    for (const state of [construction, issued, running]) {
+    const construction = snapshot('planned');
+    const running = snapshot('running');
+    for (const state of [construction, running]) {
       const call = state.calls[0];
       if (call) {
         call.attempts = [
@@ -133,7 +108,6 @@ describe('workflow-script projection failure recovery', () => {
     mocks.runPersistedWorkflowScript.mockImplementationOnce(
       async (options: PersistedWorkflowScriptRunOptions) => {
         options.onTransition?.(construction);
-        options.onTransition?.(issued);
         options.onTransition?.(running);
         await options.onSnapshot?.(running);
         return { snapshot: running } as never;

--- a/src/test-kernel/agent/WorkflowScriptProgressProjectionFailure.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressProjectionFailure.vitest.ts
@@ -35,22 +35,30 @@ function snapshot(
         status,
         // The engine stamps the call issued when the script reaches it.
         ...(lifecycle === 'active' && { issued: true }),
-        attempts: [{}],
+        attempts: [],
         files: {},
         timestamps: {
           createdAt: '2026-08-15T20:00:00.000Z',
-          updatedAt: '2026-08-15T20:00:01.000Z',
+          updatedAt: '2026-08-15T20:00:00.000Z',
         },
       },
     ],
-  } as WorkflowExecutionSnapshot;
+  } as unknown as WorkflowExecutionSnapshot;
 }
 
 describe('workflow-script projection failure recovery', () => {
-  it('projects the issued call after a fold fails before projection', async () => {
+  it('projects a marker-free issued call after a fold fails before projection', async () => {
     const construction = snapshot('waiting', 'planned');
     const issued = snapshot('active', 'planned');
     const running = snapshot('active', 'running');
+    const call = running.calls[0]!;
+    delete call.issued;
+    Object.assign(call, {
+      kind: 'document',
+      agent: 'projection-agent',
+      model: 'projection-model',
+      files: { input: [], context: [], media: [] },
+    });
     mocks.runPersistedWorkflowScript.mockImplementationOnce(
       async (options: PersistedWorkflowScriptRunOptions) => {
         options.onTransition?.(construction);
@@ -94,6 +102,10 @@ describe('workflow-script projection failure recovery', () => {
         call: expect.objectContaining({
           id: 'retry-review',
           status: 'running',
+          kind: 'document',
+          agent: 'projection-agent',
+          model: 'projection-model',
+          files: { input: [], context: [], media: [] },
         }),
       }),
     );

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -302,6 +302,20 @@ export async function runPersistedWorkflowScriptWithProgress(
         status === 'failed' ||
         status === 'cancelled' ||
         (status === 'skipped' && !call.settledBySweep));
+    const hasInvocationFacts =
+      call.kind !== undefined ||
+      call.agent !== undefined ||
+      call.model !== undefined ||
+      call.childExecutionId !== undefined ||
+      call.childStreamId !== undefined ||
+      call.attempts.length > 0 ||
+      call.timestamps.startedAt !== undefined;
+    const includeFiles =
+      call.issued === true ||
+      (call.status !== WORKFLOW_CALL_STATUS.PLANNED &&
+        call.status !== WORKFLOW_CALL_STATUS.STAGE_BLOCKED &&
+        call.status !== WORKFLOW_CALL_STATUS.SKIPPED) ||
+      hasInvocationFacts;
     const identity = {
       id: call.id,
       label: call.label,
@@ -309,16 +323,12 @@ export async function runPersistedWorkflowScriptWithProgress(
       ...(call.childStreamId !== undefined
         ? { childStreamId: call.childStreamId }
         : {}),
-      // The invocation facts a card carries once the script has issued the
-      // call, read from the snapshot call — the one owner — so a declared stub
-      // never looks like a resolved call. Kind, unlike the newer issued marker,
-      // is also present on marker-free historical issued calls.
-      ...(call.kind !== undefined && {
-        kind: call.kind,
-        ...(call.agent !== undefined && { agent: call.agent }),
-        ...(call.model !== undefined && { model: call.model }),
-        files: call.files,
-      }),
+      // Project only invocation facts the snapshot owns. Historical issued
+      // calls may carry any subset and predate both explicit markers.
+      ...(call.kind !== undefined && { kind: call.kind }),
+      ...(call.agent !== undefined && { agent: call.agent }),
+      ...(call.model !== undefined && { model: call.model }),
+      ...(includeFiles && { files: call.files }),
       ...(attemptCounts && { attemptNumber: call.attempts.length }),
     };
     switch (call.status) {

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -81,14 +81,6 @@ interface PhaseStage {
   failed: boolean;
 }
 
-/** One call as the projection last emitted it — exactly the card the
- *  transcript holds under `logId`, so a later emission (the fold's diff,
- *  the finally sweep) starts from what the reader already sees. */
-interface ProjectedWorkflowCall {
-  readonly logId: string;
-  card: WorkflowCallProgress;
-}
-
 function workflowJournalEntryCost(entry: WorkflowJournalEntry): number {
   const result = AgentFinalResultSchema.safeParse(entry.result);
   if (!result.success) {
@@ -191,7 +183,7 @@ export async function runPersistedWorkflowScriptWithProgress(
   const projectionId = generateShortId();
   const projectedCalls = new Map<
     WorkflowCallProgress['id'],
-    ProjectedWorkflowCall
+    WorkflowCallProgress
   >();
   // The engine terminalizes and flushes its snapshot before returning or
   // rethrowing, so the last one published is its final account of every call —
@@ -252,17 +244,11 @@ export async function runPersistedWorkflowScriptWithProgress(
    */
   const emitCall = (call: WorkflowCallProgress): void => {
     const card: WorkflowCallProgress = { ...call, attemptId: projectionId };
-    let projected = projectedCalls.get(call.id);
-    if (projected) {
-      projected.card = card;
-    } else {
-      // Stable trace identity for this call within its run stream.
-      projected = { logId: `workflow-task-${projectionId}-${call.id}`, card };
-      projectedCalls.set(call.id, projected);
-    }
+    projectedCalls.set(call.id, card);
     trace.emit({
       type: 'workflow.call',
-      logId: projected.logId,
+      // Stable trace identity for this call within its run stream.
+      logId: `workflow-task-${projectionId}-${call.id}`,
       call: card,
       stageId:
         card.phase === undefined
@@ -325,9 +311,10 @@ export async function runPersistedWorkflowScriptWithProgress(
         : {}),
       // The invocation facts a card carries once the script has issued the
       // call, read from the snapshot call — the one owner — so a declared stub
-      // never looks like a resolved call.
-      ...(call.issued && {
-        ...(call.kind !== undefined && { kind: call.kind }),
+      // never looks like a resolved call. Kind, unlike the newer issued marker,
+      // is also present on marker-free historical issued calls.
+      ...(call.kind !== undefined && {
+        kind: call.kind,
         ...(call.agent !== undefined && { agent: call.agent }),
         ...(call.model !== undefined && { model: call.model }),
         files: call.files,
@@ -472,11 +459,11 @@ export async function runPersistedWorkflowScriptWithProgress(
         if (stage.lifecycle === 'active') currentPhase = stage.title;
       }
       for (const call of snapshot.calls) {
-        const projected = projectedCalls.get(call.id);
+        const last = projectedCalls.get(call.id);
         // A retry re-queues a running call; the card follows it to `queued`
         // because that wait is real when another call took the freed slot.
         const status = projectWorkflowCallStatus(call);
-        const baseline = projected ? undefined : hydratedBaseline.get(call.id);
+        const baseline = last ? undefined : hydratedBaseline.get(call.id);
         if (baseline !== undefined) {
           // A reset historical call is current only once `issueCall` stamps
           // it issued by this attempt (hydration clears the stamp), which
@@ -500,7 +487,6 @@ export async function runPersistedWorkflowScriptWithProgress(
         // stage loop above opens for them. A card whose group does not exist
         // yet is thereby unrepresentable.
         if (call.status === WORKFLOW_CALL_STATUS.STAGE_BLOCKED) continue;
-        const last = projected?.card;
         const streamChanged =
           call.childStreamId !== undefined &&
           last?.childStreamId !== call.childStreamId;
@@ -601,7 +587,7 @@ export async function runPersistedWorkflowScriptWithProgress(
       fold(lastSnapshot);
     }
     closed = true;
-    for (const { card } of projectedCalls.values()) {
+    for (const card of projectedCalls.values()) {
       if (isTerminalWorkflowCallProgress(card)) continue;
       // Open the declared phase the run never reached so the settled card
       // still lands under a header; the loop below then closes it. The card


### PR DESCRIPTION
## Summary

- project each persisted invocation fact independently for marker-free historical issued calls, including accepted records that carry `agent` and `files` without `kind`
- include files only when issuance is established by the current marker, an inherently issued status, or another persisted invocation fact; genuinely unissued planned and sweep-skipped stubs remain bare
- delete the redundant `ProjectedWorkflowCall` wrapper, store last-emitted cards directly, and derive the unchanged stable log ID from `projectionId` and call ID
- retain the last-emitted-card delivery ledger because the engine snapshot cannot replace projection-failure retries, hydrated-history suppression, host translation/redaction, dedup state, or the terminal backstop

Closes #11691.
Closes #11638.

## Issue acceptance gates

- The weakest accepted marker-free issued shape, `running` with `agent` but no `issued` or `kind`, schema-parses and projects exactly `agent` and `files` without invented identity values: complete.
- Present `kind`, `agent`, and `model` facts project independently: complete.
- Files project when `issued`, an inherently issued status, or another legacy invocation fact proves issuance; unissued planned and sweep-skipped plan stubs remain bare: complete.
- Current issued calls retain their identity fields and current declared stubs remain bare through the existing progress-bridge coverage: complete.
- Canonical workflow snapshot states are unchanged; compatibility remains confined to the existing persisted decoder and progress projection: complete.
- The redundant `{ logId, card }` wrapper is removed, while the last-emitted-card ledger, `projectionId`/`attemptId`, hydrated baseline, retry isolation, snapshot/phase state, dedup semantics, and finally backstop remain intact: complete.
- Full projection removal was investigated and rejected as unsafe. The execution snapshot owns workflow state, but it does not own delivery history or host-projected card state: complete.

## Single source of truth

`WorkflowExecutionSnapshot` remains the canonical workflow-state owner. `runPersistedWorkflowScriptWithProgress` retains only the delivery ledger needed to compare and settle the exact cards already emitted to the host. The ledger now maps call IDs directly to `WorkflowCallProgress`; the stable trace identity is derived as `workflow-task-${projectionId}-${call.id}`.

## Duplication and abstraction budget

Deleted the file-local `ProjectedWorkflowCall` interface and its mutable wrapper bookkeeping. No abstraction or export was added. The riskier duplicate status-mapping consolidation is deliberately not included.

## Net elements (R6)

- Files: 2 modified, 0 added, 0 deleted.
- LoC: +64 / -82, net -18.
- Exported symbols: no additions or deletions.
- Classes/interfaces/enums: one file-local interface deleted; none added.

## Consumer counts (R8)

n/a. The existing `workflow.call` emit path and event key are unchanged; no export, subscription, or emit route was added, removed, or redirected.

## Host impact

Extension: Resumed historical workflow cards retain every persisted issued-call identity fact and their file roles.

Desktop: Same shared progress projection behavior as the extension.

CLI: Same shared progress projection behavior; no CLI-specific path changed.

## Scheduled refactoring

None. Full projection removal is intentionally rejected because the last-emitted-card ledger is required for delivery-history semantics and failure recovery.

## Validation

- `npm exec vitest -- run src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts src/test-kernel/agent/WorkflowScriptProgressProjectionFailure.vitest.ts src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts` — 3 files, 64 tests passed.
- `npm exec eslint -- src/tools/delegation/workflowScriptRun.ts src/test-kernel/agent/WorkflowScriptProgressProjectionFailure.vitest.ts` — passed with no diagnostics.
- `npm exec prettier -- --check src/tools/delegation/workflowScriptRun.ts src/test-kernel/agent/WorkflowScriptProgressProjectionFailure.vitest.ts` — both files formatted.
- `npm run typecheck:workspace` — passed.
- `npm run typecheck:test-kernel` — passed.
- `npm exec vitest -- run src/test-kernel/architecture` — 15 files, 101 tests passed.
- `npm run check:dead-code-ratchet` — no new findings; 315 combined findings match the baseline.
- `npm run compile:fast` — passed. Vite emitted only its existing config-loader compatibility warning.
- `git diff --check` — passed.
