### PR TITLE
fix(model): centralize GLM route resolution

### DIFF
--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -1,5 +1,8 @@
 // Local imports
 import { computeModelOptionsData } from '@model/computeModelOptions';
+import { resolveGlmRoute } from '@model/glmRouting';
+import { shouldRouteModelThroughOpenRouter } from '@model/openRouterRouting';
+import { getRuntimeModelConfig } from '@model/runtimeModelRegistry';
 import {
   decideRunModel,
   type RunModelCandidate,
@@ -8,7 +11,7 @@ import {
 import type { ModelOptionData } from '@shared/schemas';
 import { isModelOptionAvailable } from '@shared/schemas';
 import { assertNever, unique } from '@utils/core';
-import { getGLMCodingPlan } from '@utils/config/providerConfig';
+import { getUseOpenRouter } from '@utils/config/providerConfig';
 
 // Local file imports
 import { resolveKnownCliModelId } from './cliConfig';
@@ -126,16 +129,20 @@ function formatModelAccessStatus(model: ModelOptionData): string {
 
 export function formatModelStatusForCli(model: CliModelAccess): string {
   if (model.model.provider === 'kimiCode') return 'api: Kimi Code subscription';
-  // GLM models route through the Coding Plan endpoint when the toggle is on.
-  // Gate on the resolved provider-key route (not just provider + toggle): the
-  // coding-plan path only applies to the direct GLM endpoint, never to an
-  // OpenRouter route, which stays reported as its own key status.
-  if (
-    model.model.provider === 'glm' &&
-    model.model.availability === 'provider-key' &&
-    getGLMCodingPlan()
-  ) {
-    return 'api: GLM Coding Plan';
+  if (model.model.provider === 'glm') {
+    const config = getRuntimeModelConfig(model.model.value);
+    if (config) {
+      const route = resolveGlmRoute({
+        baseUrl: config.baseUrl,
+        useOpenRouter: shouldRouteModelThroughOpenRouter(
+          config,
+          getUseOpenRouter(),
+        ),
+      });
+      if (route.route === 'official-coding-plan') {
+        return 'api: GLM Coding Plan';
+      }
+    }
   }
   return `api: ${model.status}`;
 }

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -129,7 +129,10 @@ function formatModelAccessStatus(model: ModelOptionData): string {
 
 export function formatModelStatusForCli(model: CliModelAccess): string {
   if (model.model.provider === 'kimiCode') return 'api: Kimi Code subscription';
-  if (model.model.provider === 'glm') {
+  if (
+    model.model.provider === 'glm' &&
+    model.model.availability === 'provider-key'
+  ) {
     const config = getRuntimeModelConfig(model.model.value);
     if (config) {
       const route = resolveGlmRoute({

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -539,7 +539,12 @@ export abstract class ModelHandler<
    */
   private buildProxyConfig(useOpenRouter: boolean): ProxyConfig {
     if (this.config.baseUrl) {
-      return { route: 'custom', url: this.config.baseUrl, logger: this.logger };
+      return {
+        route: 'custom',
+        provider: this.config.provider,
+        url: this.config.baseUrl,
+        logger: this.logger,
+      };
     }
     return {
       route: 'direct',

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -22,6 +22,7 @@ import {
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkError/errorPatterns';
 import { handleStreamingFailure } from '@common/errors/sdkError/streamFailure';
+import { OPENROUTER_BASE_URL } from '@model/glmRouting';
 import type {
   FileLocation,
   MediaAttachmentKind,
@@ -42,7 +43,6 @@ import {
   getDeclaredMaxReasoningEffort,
   normalizeSupportedReasoningEffort,
 } from '../support/reasoningEffort';
-import { OPENROUTER_BASE_URL } from '../support/ProxyConfigResolver';
 import {
   resolveMoonshotRequestParameters,
   type MoonshotRequestParameters,

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -22,7 +22,7 @@ import {
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkError/errorPatterns';
 import { handleStreamingFailure } from '@common/errors/sdkError/streamFailure';
-import { OPENROUTER_BASE_URL } from '@model/glmRouting';
+import { OPENROUTER_BASE_URL } from '@model/openRouterEndpoint';
 import type {
   FileLocation,
   MediaAttachmentKind,

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -1,10 +1,11 @@
 import { ModelProvider } from 'llm-zoo';
-import { OPENROUTER_BASE_URL, resolveGlmRoute } from '@model/glmRouting';
+import { resolveGlmRoute } from '@model/glmRouting';
+import { OPENROUTER_BASE_URL } from '@model/openRouterEndpoint';
+import { normalizeProviderEndpoint } from '@model/providerEndpoint';
 import {
   shouldRouteModelThroughOpenRouter,
   type ModelRoutingConfig,
 } from '@model/openRouterRouting';
-import { tryParseUrl } from '@utils/core';
 import {
   getProviderEndpoint,
   useChinaRegion,
@@ -12,16 +13,6 @@ import {
 } from '@utils/config/providerConfig';
 
 // Custom endpoints use the provider state written by the Models view.
-
-/** Normalize a URL-like string to `host/path` form (no protocol, no trailing slashes). */
-function normalizeUrl(input: string): string {
-  if (!input) return '';
-
-  const withProtocol = input.includes('://') ? input : `https://${input}`;
-  const parsed = tryParseUrl(withProtocol);
-  if (!parsed) return input.replace(/^https?:\/\//, '').replace(/\/+$/, '');
-  return `${parsed.host}${parsed.pathname}`.replace(/\/+$/, '');
-}
 
 /**
  * Provider default base URLs. Providers whose endpoint depends on the
@@ -122,7 +113,11 @@ export function resolveProxyEndpoint(config: ProxyConfig): {
     case 'custom': {
       config.logger?.debug(`Using custom base URL for model: ${config.url}`);
       if (config.provider === ModelProvider.GLM) {
-        return resolveGlmRoute({ baseUrl: config.url, useOpenRouter: false });
+        const route = resolveGlmRoute({
+          baseUrl: config.url,
+          useOpenRouter: false,
+        });
+        return { baseUrl: route.baseUrl };
       }
       return { baseUrl: config.url };
     }
@@ -152,7 +147,12 @@ function resolveDirectEndpoint(config: {
     if (route.route === 'provider-custom') {
       logger?.debug(`Using custom base URL for ${provider}: ${route.baseUrl}`);
     }
-    return route;
+    return {
+      baseUrl: route.baseUrl,
+      ...(route.route === 'official-coding-plan' && {
+        usageRoute: route.usageRoute,
+      }),
+    };
   }
 
   if (useOpenRouter) return { baseUrl: OPENROUTER_BASE_URL };
@@ -161,7 +161,7 @@ function resolveDirectEndpoint(config: {
   const customUrl = getProviderEndpoint(provider);
   if (customUrl) {
     logger?.debug(`Using custom base URL for ${provider}: ${customUrl}`);
-    return { baseUrl: `https://${normalizeUrl(customUrl)}` };
+    return { baseUrl: `https://${normalizeProviderEndpoint(customUrl)}` };
   }
 
   const baseUrl = BASE_URLS[provider];

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -1,4 +1,5 @@
 import { ModelProvider } from 'llm-zoo';
+import { OPENROUTER_BASE_URL, resolveGlmRoute } from '@model/glmRouting';
 import {
   shouldRouteModelThroughOpenRouter,
   type ModelRoutingConfig,
@@ -7,13 +8,10 @@ import { tryParseUrl } from '@utils/core';
 import {
   getProviderEndpoint,
   useChinaRegion,
-  getGLMCodingPlan,
   getUseOpenRouter,
 } from '@utils/config/providerConfig';
 
 // Custom endpoints use the provider state written by the Models view.
-
-export const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
 
 /** Normalize a URL-like string to `host/path` form (no protocol, no trailing slashes). */
 function normalizeUrl(input: string): string {
@@ -76,7 +74,12 @@ type ProxyLogger = { debug: (message: string) => void };
  * fact every call site already knows.
  */
 export type ProxyConfig =
-  | { route: 'custom'; url: string; logger?: ProxyLogger }
+  | {
+      route: 'custom';
+      provider: ModelProvider;
+      url: string;
+      logger?: ProxyLogger;
+    }
   | {
       route: 'direct';
       provider: ModelProvider;
@@ -116,9 +119,13 @@ export function resolveProxyEndpoint(config: ProxyConfig): {
 } {
   switch (config.route) {
     // Per-model custom base URL (e.g., temporary endpoints).
-    case 'custom':
+    case 'custom': {
       config.logger?.debug(`Using custom base URL for model: ${config.url}`);
+      if (config.provider === ModelProvider.GLM) {
+        return resolveGlmRoute({ baseUrl: config.url, useOpenRouter: false });
+      }
       return { baseUrl: config.url };
+    }
 
     case 'direct':
       return resolveDirectEndpoint(config);
@@ -140,6 +147,14 @@ function resolveDirectEndpoint(config: {
 } {
   const { provider, useOpenRouter, logger } = config;
 
+  if (provider === ModelProvider.GLM) {
+    const route = resolveGlmRoute({ useOpenRouter });
+    if (route.route === 'provider-custom') {
+      logger?.debug(`Using custom base URL for ${provider}: ${route.baseUrl}`);
+    }
+    return route;
+  }
+
   if (useOpenRouter) return { baseUrl: OPENROUTER_BASE_URL };
 
   // Per-provider custom endpoint from dashboard settings (global state)
@@ -147,16 +162,6 @@ function resolveDirectEndpoint(config: {
   if (customUrl) {
     logger?.debug(`Using custom base URL for ${provider}: ${customUrl}`);
     return { baseUrl: `https://${normalizeUrl(customUrl)}` };
-  }
-
-  if (provider === ModelProvider.GLM) {
-    const codingPlan = getGLMCodingPlan();
-    return {
-      baseUrl: `https://${useChinaRegion('glm') ? 'open.bigmodel.cn' : 'api.z.ai'}${codingPlan ? '/api/coding/paas/v4' : '/api/paas/v4'}`,
-      ...(codingPlan && {
-        usageRoute: 'glm-coding-plan-subscription' as const,
-      }),
-    };
   }
 
   const baseUrl = BASE_URLS[provider];

--- a/src/model/codingPlanSubscriptions.ts
+++ b/src/model/codingPlanSubscriptions.ts
@@ -1,6 +1,7 @@
 import { ModelProvider } from 'llm-zoo';
 
 import { hasUsableApiKey } from '@model/apiProviders';
+import { resolveGlmRoute } from '@model/glmRouting';
 import {
   isKimiCodeRoute,
   resolveKimiCodeRoutingFacts,
@@ -18,7 +19,6 @@ import { isKimiSubscriptionEligible } from '@shared/model/kimiCodeRetryGate';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import {
   getGLMCodingPlan,
-  getProviderEndpoint,
   getPreferKimiCode,
   getUseOpenRouter,
   setGLMCodingPlan,
@@ -35,16 +35,19 @@ export interface CodingPlanSubscriptionRuntime {
 
 async function isGlmCodingPlanActive(modelId: string): Promise<boolean> {
   const config = await resolveRuntimeModelConfig(modelId);
-  if (
-    config?.provider !== ModelProvider.GLM ||
-    !getGLMCodingPlan() ||
-    shouldRouteModelThroughOpenRouter(config, getUseOpenRouter()) ||
-    config.baseUrl != null ||
-    getProviderEndpoint('glm') !== ''
-  ) {
-    return false;
-  }
-  return hasUsableApiKey(platform().secrets, 'glm');
+  if (config?.provider !== ModelProvider.GLM) return false;
+
+  const route = resolveGlmRoute({
+    baseUrl: config.baseUrl,
+    useOpenRouter: shouldRouteModelThroughOpenRouter(
+      config,
+      getUseOpenRouter(),
+    ),
+  });
+  return (
+    route.route === 'official-coding-plan' &&
+    hasUsableApiKey(platform().secrets, 'glm')
+  );
 }
 
 /**

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -1,4 +1,5 @@
 import { LRUCache } from 'lru-cache';
+import { ModelProvider, type ModelConfig } from 'llm-zoo';
 
 import { isCodexSignedIn } from '@model/codex/codexSignedIn';
 import { isPreferCodexSubscription } from '@model/codex/codexPreference';
@@ -42,6 +43,7 @@ import {
 import {
   isOpenRouterRoutingUnsupported,
   resolveDirectModelApiKeyProvider,
+  resolveModelApiKeyProvider,
   resolveModelSource,
   shouldRouteModelThroughOpenRouter,
 } from './openRouterRouting';
@@ -56,8 +58,6 @@ import {
   staticModelConfigEntries,
 } from './runtimeModelRegistry';
 import type { ProviderCapabilityProfile } from './providerCapabilities';
-import type { ModelConfig } from 'llm-zoo';
-
 type PersonalModelAccessKind = 'provider-key' | 'openrouter-key';
 
 /**
@@ -242,7 +242,11 @@ async function getPersonalAccessKindForModel(
 
   // At the picker boundary, absent and unreadable provider keys both degrade to
   // unavailable while still allowing an OpenRouter route below.
-  return config.openrouterFullName && ctx.hasOpenRouter
+  const openRouterFallbackProvider = resolveModelApiKeyProvider(config, true);
+  return config.openrouterFullName &&
+    ctx.hasOpenRouter &&
+    (config.provider !== ModelProvider.GLM ||
+      openRouterFallbackProvider === 'openRouter')
     ? 'openrouter-key'
     : null;
 }

--- a/src/model/glmRouting.ts
+++ b/src/model/glmRouting.ts
@@ -1,0 +1,65 @@
+import { ModelProvider } from 'llm-zoo';
+
+import { tryParseUrl } from '@utils/core';
+import {
+  getGLMCodingPlan,
+  getProviderEndpoint,
+  useChinaRegion,
+} from '@utils/config/providerConfig';
+
+export const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+
+export type GlmRoute =
+  | { readonly route: 'model-custom'; readonly baseUrl: string }
+  | { readonly route: 'openrouter'; readonly baseUrl: string }
+  | { readonly route: 'provider-custom'; readonly baseUrl: string }
+  | {
+      readonly route: 'official-coding-plan';
+      readonly baseUrl: string;
+      readonly usageRoute: 'glm-coding-plan-subscription';
+    }
+  | { readonly route: 'official'; readonly baseUrl: string };
+
+interface GlmRoutingConfig {
+  readonly baseUrl?: string | null;
+  readonly useOpenRouter: boolean;
+}
+
+/** Normalize a provider endpoint to `host/path` form (no protocol or trailing slashes). */
+function normalizeProviderEndpoint(input: string): string {
+  const withProtocol = input.includes('://') ? input : `https://${input}`;
+  const parsed = tryParseUrl(withProtocol);
+  if (!parsed) return input.replace(/^https?:\/\//, '').replace(/\/+$/, '');
+  return `${parsed.host}${parsed.pathname}`.replace(/\/+$/, '');
+}
+
+/** Resolve the endpoint and usage classification for one GLM request. */
+export function resolveGlmRoute(config: GlmRoutingConfig): GlmRoute {
+  if (config.baseUrl) {
+    return { route: 'model-custom', baseUrl: config.baseUrl };
+  }
+  if (config.useOpenRouter) {
+    return { route: 'openrouter', baseUrl: OPENROUTER_BASE_URL };
+  }
+
+  const providerEndpoint = getProviderEndpoint(ModelProvider.GLM);
+  if (providerEndpoint) {
+    return {
+      route: 'provider-custom',
+      baseUrl: `https://${normalizeProviderEndpoint(providerEndpoint)}`,
+    };
+  }
+
+  const officialHost = useChinaRegion('glm') ? 'open.bigmodel.cn' : 'api.z.ai';
+  if (getGLMCodingPlan()) {
+    return {
+      route: 'official-coding-plan',
+      baseUrl: `https://${officialHost}/api/coding/paas/v4`,
+      usageRoute: 'glm-coding-plan-subscription',
+    };
+  }
+  return {
+    route: 'official',
+    baseUrl: `https://${officialHost}/api/paas/v4`,
+  };
+}

--- a/src/model/glmRouting.ts
+++ b/src/model/glmRouting.ts
@@ -8,7 +8,7 @@ import {
   useChinaRegion,
 } from '@utils/config/providerConfig';
 
-export type GlmRoute =
+type GlmRoute =
   | { readonly route: 'model-custom'; readonly baseUrl: string }
   | { readonly route: 'openrouter'; readonly baseUrl: string }
   | { readonly route: 'provider-custom'; readonly baseUrl: string }

--- a/src/model/glmRouting.ts
+++ b/src/model/glmRouting.ts
@@ -1,13 +1,12 @@
 import { ModelProvider } from 'llm-zoo';
 
-import { tryParseUrl } from '@utils/core';
+import { OPENROUTER_BASE_URL } from '@model/openRouterEndpoint';
+import { normalizeProviderEndpoint } from '@model/providerEndpoint';
 import {
   getGLMCodingPlan,
   getProviderEndpoint,
   useChinaRegion,
 } from '@utils/config/providerConfig';
-
-export const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
 
 export type GlmRoute =
   | { readonly route: 'model-custom'; readonly baseUrl: string }
@@ -23,14 +22,6 @@ export type GlmRoute =
 interface GlmRoutingConfig {
   readonly baseUrl?: string | null;
   readonly useOpenRouter: boolean;
-}
-
-/** Normalize a provider endpoint to `host/path` form (no protocol or trailing slashes). */
-function normalizeProviderEndpoint(input: string): string {
-  const withProtocol = input.includes('://') ? input : `https://${input}`;
-  const parsed = tryParseUrl(withProtocol);
-  if (!parsed) return input.replace(/^https?:\/\//, '').replace(/\/+$/, '');
-  return `${parsed.host}${parsed.pathname}`.replace(/\/+$/, '');
 }
 
 /** Resolve the endpoint and usage classification for one GLM request. */

--- a/src/model/openRouterEndpoint.ts
+++ b/src/model/openRouterEndpoint.ts
@@ -1,0 +1,1 @@
+export const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';

--- a/src/model/openRouterRouting.ts
+++ b/src/model/openRouterRouting.ts
@@ -1,11 +1,12 @@
+import { ModelProvider, type ModelConfig } from 'llm-zoo';
+
+import { resolveGlmRoute } from '@model/glmRouting';
 import {
   isKimiCodeExclusiveModel,
   type KimiSubscriptionModelFields,
 } from '@shared/model/kimiCodeRetryGate';
 
 import { isApiProvider, type ApiProvider } from './apiProviders';
-
-import type { ModelConfig } from 'llm-zoo';
 
 /**
  * A {@link ModelConfig} carrying TeXRA's own runtime-only routing override.
@@ -56,10 +57,11 @@ export function isOpenRouterRoutingUnsupported(
   config: ModelRoutingConfig,
   useOpenRouter: boolean,
 ): boolean {
-  return (
-    isOpenRouterAccessSelected(config, useOpenRouter) &&
-    config.capabilities?.reasoningMode !== undefined
-  );
+  const openRouterSelected =
+    config.provider === ModelProvider.GLM
+      ? shouldRouteModelThroughOpenRouter(config, useOpenRouter)
+      : isOpenRouterAccessSelected(config, useOpenRouter);
+  return openRouterSelected && config.capabilities?.reasoningMode !== undefined;
 }
 
 /** API-key owner for the route ModelFactory will use for this model. */
@@ -96,5 +98,12 @@ export function shouldRouteModelThroughOpenRouter(
   useOpenRouter: boolean,
 ): boolean {
   if (config.requiresResponsesAPI) return false;
-  return isOpenRouterAccessSelected(config, useOpenRouter);
+  const openRouterSelected = isOpenRouterAccessSelected(config, useOpenRouter);
+  if (config.provider !== ModelProvider.GLM) return openRouterSelected;
+  return (
+    resolveGlmRoute({
+      baseUrl: config.baseUrl,
+      useOpenRouter: openRouterSelected,
+    }).route === 'openrouter'
+  );
 }

--- a/src/model/providerEndpoint.ts
+++ b/src/model/providerEndpoint.ts
@@ -1,0 +1,11 @@
+import { tryParseUrl } from '@utils/core';
+
+/** Normalize a URL-like endpoint to `host/path` form without protocol or trailing slashes. */
+export function normalizeProviderEndpoint(input: string): string {
+  if (!input) return '';
+
+  const withProtocol = input.includes('://') ? input : `https://${input}`;
+  const parsed = tryParseUrl(withProtocol);
+  if (!parsed) return input.replace(/^https?:\/\//, '').replace(/\/+$/, '');
+  return `${parsed.host}${parsed.pathname}`.replace(/\/+$/, '');
+}

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -386,6 +386,39 @@ describe('GLM custom endpoint routing', () => {
       handler.dispose();
     }
   });
+
+  it('does not advertise OpenRouter for a model-custom route without a GLM key', async () => {
+    MODEL_CONFIGS.glm52.baseUrl = 'https://model.test/v4';
+    await installPlatform({
+      globalState: { 'texra.useOpenRouter': true },
+      secrets: {
+        [apiKeySecretName('openRouter')]: 'openrouter-key',
+      },
+    });
+    invalidateApiKeyCache();
+    invalidateModelOptionsCache();
+
+    const [customAccess] = await computeModelOptionsData(['glm52']);
+    const handler = await createModelHandler(MODEL_CONFIGS.glm52);
+    try {
+      expect(handler.constructor.name).toBe('ModelHandlerGLM');
+      expect(customAccess).toMatchObject({
+        availability: 'missing-key',
+        disabled: true,
+      });
+    } finally {
+      handler.dispose();
+    }
+
+    delete MODEL_CONFIGS.glm52.baseUrl;
+    invalidateModelOptionsCache();
+
+    const [openRouterAccess] = await computeModelOptionsData(['glm52']);
+    expect(openRouterAccess).toMatchObject({
+      availability: 'openrouter-key',
+      disabled: false,
+    });
+  });
 });
 
 describe('OpenAI model handler routing', () => {

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -10,6 +10,7 @@ import {
 } from 'llm-zoo';
 
 import type { ModelHandler } from '@agent/modelHandlers/ModelHandler';
+import type { ResolvedClientCredential } from '@agent/types/ModelHandlerContracts';
 import { ModelHandlerOpenRouterNative } from '@agent/modelHandlers/openrouter/modelHandlerOpenRouterNative';
 import { ModelHandlerOpenAI } from '@agent/modelHandlers/openai/modelHandlerOpenAI';
 import { ModelHandlerGoogleInteractions } from '@agent/modelHandlers/google/modelHandlerGoogleInteractions';
@@ -34,6 +35,11 @@ import {
 } from '@auth/codex';
 import { CODEX_SESSION_SECRET_KEY } from '@auth/codex/codexConstants';
 import type { CodexSession } from '@auth/codex/codexSessionTypes';
+import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
+import {
+  computeModelOptionsData,
+  invalidateModelOptionsCache,
+} from '@model/computeModelOptions';
 import { shouldRouteModelThroughOpenRouter } from '@model/openRouterRouting';
 import {
   invalidateRuntimeModelRegistry,
@@ -339,6 +345,46 @@ describe('Copilot route preference on a canonical base model', () => {
         );
       },
     );
+  });
+});
+
+describe('GLM custom endpoint routing', () => {
+  afterEach(() => {
+    delete MODEL_CONFIGS.glm52.baseUrl;
+    invalidateApiKeyCache();
+    invalidateModelOptionsCache();
+  });
+
+  it('keeps dispatch, availability, and credentials on the model custom route when OpenRouter is enabled', async () => {
+    MODEL_CONFIGS.glm52.baseUrl = 'https://model.test/v4';
+    await installPlatform({
+      globalState: { 'texra.useOpenRouter': true },
+      secrets: {
+        [apiKeySecretName('glm')]: 'glm-key',
+        [apiKeySecretName('openRouter')]: 'openrouter-key',
+      },
+    });
+    invalidateApiKeyCache();
+    invalidateModelOptionsCache();
+
+    const [access] = await computeModelOptionsData(['glm52']);
+    const handler = await createModelHandler(MODEL_CONFIGS.glm52);
+    try {
+      const credential = await (
+        handler as unknown as {
+          resolveClientCredential(): Promise<ResolvedClientCredential>;
+        }
+      ).resolveClientCredential();
+
+      expect(handler.constructor.name).toBe('ModelHandlerGLM');
+      expect(access?.availability).toBe('provider-key');
+      expect(credential).toMatchObject({
+        route: 'api-key',
+        baseUrl: 'https://model.test/v4',
+      });
+    } finally {
+      handler.dispose();
+    }
   });
 });
 

--- a/src/test-kernel/agent/modelHandlers/MoonshotBaseUrl.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/MoonshotBaseUrl.vitest.ts
@@ -33,6 +33,7 @@ describe('Moonshot base URL region resolution', () => {
     expect(
       resolveBaseUrl({
         route: 'custom',
+        provider: ModelProvider.MOONSHOT,
         url: 'https://api.kimi.com/coding/v1',
       }),
     ).toBe('https://api.kimi.com/coding/v1');

--- a/src/test-kernel/cli/ModelAccess.vitest.ts
+++ b/src/test-kernel/cli/ModelAccess.vitest.ts
@@ -17,6 +17,8 @@ import { computeModelOptionsData } from '@model/computeModelOptions';
 import type { ModelOptionData } from '@shared/schemas';
 
 const getGLMCodingPlanMock = vi.hoisted(() => vi.fn());
+const getProviderEndpointMock = vi.hoisted(() => vi.fn());
+const getUseOpenRouterMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@model/computeModelOptions', () => ({
   computeModelOptionsData: vi.fn(),
@@ -24,6 +26,9 @@ vi.mock('@model/computeModelOptions', () => ({
 
 vi.mock('@utils/config/providerConfig', () => ({
   getGLMCodingPlan: getGLMCodingPlanMock,
+  getProviderEndpoint: getProviderEndpointMock,
+  getUseOpenRouter: getUseOpenRouterMock,
+  useChinaRegion: vi.fn(() => true),
 }));
 
 vi.mock('llm-zoo', async (importOriginal) => {
@@ -36,6 +41,10 @@ vi.mock('llm-zoo', async (importOriginal) => {
       userFacingFixture: {
         fullName: 'user-facing-fixture',
         label: 'User Facing Fixture',
+      },
+      glmCustomFixture: {
+        ...actual.MODEL_CONFIGS.glm52,
+        baseUrl: 'https://model.test/v4',
       },
     },
   };
@@ -125,6 +134,9 @@ function expectModelOptionsRequested(models: string[]): void {
 describe('CLI model access resolution', () => {
   beforeEach(() => {
     computeModelOptionsDataMock.mockReset();
+    getGLMCodingPlanMock.mockReturnValue(false);
+    getProviderEndpointMock.mockReturnValue('');
+    getUseOpenRouterMock.mockReturnValue(false);
   });
 
   it('keeps the requested model when it is currently runnable', async () => {
@@ -270,6 +282,32 @@ describe('CLI model access resolution', () => {
       expected: 'api: GLM Coding Plan',
     },
     {
+      name: 'keeps the plain api status for a custom GLM provider endpoint',
+      entry: model('glm52', {
+        model: modelOption('glm52', {
+          availability: 'provider-key',
+          provider: 'glm',
+        }),
+        status: 'api key set',
+      }),
+      codingPlan: true,
+      providerEndpoint: 'proxy.test/api/paas/v4',
+      expected: 'api: api key set',
+    },
+    {
+      name: 'keeps the plain api status for a model custom GLM endpoint',
+      entry: model('glmCustomFixture', {
+        model: modelOption('glmCustomFixture', {
+          availability: 'provider-key',
+          provider: 'glm',
+        }),
+        status: 'api key set',
+      }),
+      codingPlan: true,
+      providerEndpoint: 'proxy.test/api/paas/v4',
+      expected: 'api: api key set',
+    },
+    {
       name: 'keeps the plain api status for GLM provider-key rows when the toggle is off',
       entry: model('glm52', {
         model: modelOption('glm52', {
@@ -291,13 +329,16 @@ describe('CLI model access resolution', () => {
         status: 'openrouter key',
       }),
       codingPlan: true,
+      useOpenRouter: true,
       expected: 'api: openrouter key',
     },
   ])(
     'formats model picker status: $name',
-    ({ entry, expected, codingPlan }) => {
+    ({ entry, expected, codingPlan, providerEndpoint, useOpenRouter }) => {
       if (codingPlan !== undefined)
         getGLMCodingPlanMock.mockReturnValue(codingPlan);
+      getProviderEndpointMock.mockReturnValue(providerEndpoint ?? '');
+      getUseOpenRouterMock.mockReturnValue(useOpenRouter ?? false);
       expect(formatModelStatusForCli(entry)).toBe(expected);
     },
   );

--- a/src/test-kernel/cli/ModelAccess.vitest.ts
+++ b/src/test-kernel/cli/ModelAccess.vitest.ts
@@ -305,6 +305,7 @@ describe('CLI model access resolution', () => {
       }),
       codingPlan: true,
       providerEndpoint: 'proxy.test/api/paas/v4',
+      useOpenRouter: true,
       expected: 'api: api key set',
     },
     {
@@ -318,6 +319,18 @@ describe('CLI model access resolution', () => {
       }),
       codingPlan: false,
       expected: 'api: api key set',
+    },
+    {
+      name: 'preserves an OpenRouter fallback row when the global toggle is off',
+      entry: model('glm52', {
+        model: modelOption('glm52', {
+          availability: 'openrouter-key',
+          provider: 'glm',
+        }),
+        status: 'openrouter key',
+      }),
+      codingPlan: true,
+      expected: 'api: openrouter key',
     },
     {
       name: 'never claims GLM Coding Plan for an OpenRouter-routed GLM row',

--- a/src/test-kernel/controllers/SetupLaunch.vitest.ts
+++ b/src/test-kernel/controllers/SetupLaunch.vitest.ts
@@ -22,6 +22,9 @@ const mocks = vi.hoisted(() => ({
       (secrets: unknown, provider: string) => Promise<string | undefined>
     >(),
   getUseOpenRouter: vi.fn<() => boolean>(),
+  getProviderEndpoint: vi.fn<() => string>(),
+  useChinaRegion: vi.fn<() => boolean>(),
+  getGLMCodingPlan: vi.fn<() => boolean>(),
 }));
 
 vi.mock('@model/providerCapabilities', async (importOriginal) => {
@@ -45,6 +48,9 @@ vi.mock('@platform/platform', () => ({
 
 vi.mock('@utils/config/providerConfig', () => ({
   getUseOpenRouter: mocks.getUseOpenRouter,
+  getProviderEndpoint: mocks.getProviderEndpoint,
+  useChinaRegion: mocks.useChinaRegion,
+  getGLMCodingPlan: mocks.getGLMCodingPlan,
 }));
 
 const {
@@ -58,6 +64,9 @@ beforeEach(() => {
   mocks.isXaiSubscriptionActive.mockReset().mockResolvedValue(false);
   mocks.lookupApiKey.mockReset().mockResolvedValue(undefined);
   mocks.getUseOpenRouter.mockReset().mockReturnValue(false);
+  mocks.getProviderEndpoint.mockReset().mockReturnValue('');
+  mocks.useChinaRegion.mockReset().mockReturnValue(true);
+  mocks.getGLMCodingPlan.mockReset().mockReturnValue(false);
 });
 
 function selectCredentialModel(

--- a/src/test-kernel/model/CodingPlanSubscriptionsRuntime.vitest.ts
+++ b/src/test-kernel/model/CodingPlanSubscriptionsRuntime.vitest.ts
@@ -32,6 +32,7 @@ describe('coding-plan subscription runtime', () => {
     delete MODEL_CONFIGS.glm52.baseUrl;
     await platform().globalState.update(GlobalStateKey.ENDPOINT_GLM, '');
     await platform().globalState.update(GlobalStateKey.GLM_CODING_PLAN, true);
+    await platform().globalState.update(GlobalStateKey.GLM_USE_CHINA, true);
     await platform().globalState.update(GlobalStateKey.USE_OPENROUTER, true);
   });
 
@@ -39,6 +40,63 @@ describe('coding-plan subscription runtime', () => {
     expect(Object.isFrozen(codingPlanSubscriptionRuntimes)).toBe(true);
     expect(codingPlanSubscriptionRuntimes.every(Object.isFrozen)).toBe(true);
   });
+
+  it.each([
+    {
+      name: 'China Coding Plan',
+      useChina: true,
+      codingPlan: true,
+      expected: {
+        route: 'official-coding-plan',
+        baseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4',
+        usageRoute: 'glm-coding-plan-subscription',
+      },
+    },
+    {
+      name: 'global Coding Plan',
+      useChina: false,
+      codingPlan: true,
+      expected: {
+        route: 'official-coding-plan',
+        baseUrl: 'https://api.z.ai/api/coding/paas/v4',
+        usageRoute: 'glm-coding-plan-subscription',
+      },
+    },
+    {
+      name: 'China regular API',
+      useChina: true,
+      codingPlan: false,
+      expected: {
+        route: 'official',
+        baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+      },
+    },
+    {
+      name: 'global regular API',
+      useChina: false,
+      codingPlan: false,
+      expected: {
+        route: 'official',
+        baseUrl: 'https://api.z.ai/api/paas/v4',
+      },
+    },
+  ])(
+    'resolves the exact $name route',
+    async ({ useChina, codingPlan, expected }) => {
+      await platform().globalState.update(GlobalStateKey.USE_OPENROUTER, false);
+      await platform().globalState.update(GlobalStateKey.ENDPOINT_GLM, '');
+      await platform().globalState.update(
+        GlobalStateKey.GLM_CODING_PLAN,
+        codingPlan,
+      );
+      await platform().globalState.update(
+        GlobalStateKey.GLM_USE_CHINA,
+        useChina,
+      );
+
+      expect(resolveGlmRoute({ useOpenRouter: false })).toEqual(expected);
+    },
+  );
 
   it.each([
     {
@@ -115,7 +173,11 @@ describe('coding-plan subscription runtime', () => {
             },
       );
 
-      expect(canonical).toMatchObject({ route, baseUrl });
+      expect(canonical).toEqual({
+        route,
+        baseUrl,
+        ...(usageRoute && { usageRoute }),
+      });
       expect(proxy).toMatchObject({ baseUrl });
       expect('usageRoute' in proxy ? proxy.usageRoute : undefined).toBe(
         usageRoute,

--- a/src/test-kernel/model/CodingPlanSubscriptionsRuntime.vitest.ts
+++ b/src/test-kernel/model/CodingPlanSubscriptionsRuntime.vitest.ts
@@ -1,10 +1,11 @@
 // Third-party imports
-import { ModelProvider } from 'llm-zoo';
+import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // Local imports
 import { resolveProxyEndpoint } from '@agent/modelHandlers/support/ProxyConfigResolver';
 import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
+import { resolveGlmRoute } from '@model/glmRouting';
 import {
   activeSubscriptionUsageRoute,
   codingPlanSubscriptionRuntimes,
@@ -28,7 +29,10 @@ describe('coding-plan subscription runtime', () => {
   });
 
   afterEach(async () => {
+    delete MODEL_CONFIGS.glm52.baseUrl;
     await platform().globalState.update(GlobalStateKey.ENDPOINT_GLM, '');
+    await platform().globalState.update(GlobalStateKey.GLM_CODING_PLAN, true);
+    await platform().globalState.update(GlobalStateKey.USE_OPENROUTER, true);
   });
 
   it('freezes every runtime catalog entry', () => {
@@ -36,58 +40,91 @@ describe('coding-plan subscription runtime', () => {
     expect(codingPlanSubscriptionRuntimes.every(Object.isFrozen)).toBe(true);
   });
 
-  it('classifies only the resolved official GLM coding endpoint as plan usage', async () => {
-    await platform().globalState.update(GlobalStateKey.USE_OPENROUTER, false);
-    await platform().globalState.update(GlobalStateKey.ENDPOINT_GLM, '');
+  it.each([
+    {
+      name: 'Coding Plan',
+      useOpenRouter: false,
+      providerEndpoint: '',
+      modelBaseUrl: undefined,
+      route: 'official-coding-plan',
+      baseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4',
+      usageRoute: 'glm-coding-plan-subscription',
+    },
+    {
+      name: 'provider custom endpoint',
+      useOpenRouter: false,
+      providerEndpoint: 'http://proxy.test/api/coding/paas/v4/',
+      modelBaseUrl: undefined,
+      route: 'provider-custom',
+      baseUrl: 'https://proxy.test/api/coding/paas/v4',
+      usageRoute: undefined,
+    },
+    {
+      name: 'model custom endpoint',
+      useOpenRouter: true,
+      providerEndpoint: 'provider.test/v4',
+      modelBaseUrl: 'https://model.test/v4',
+      route: 'model-custom',
+      baseUrl: 'https://model.test/v4',
+      usageRoute: undefined,
+    },
+    {
+      name: 'OpenRouter',
+      useOpenRouter: true,
+      providerEndpoint: 'provider.test/v4',
+      modelBaseUrl: undefined,
+      route: 'openrouter',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      usageRoute: undefined,
+    },
+  ])(
+    'keeps the canonical route, proxy endpoint, and subscription usage aligned for $name',
+    async ({
+      useOpenRouter,
+      providerEndpoint,
+      modelBaseUrl,
+      route,
+      baseUrl,
+      usageRoute,
+    }) => {
+      await platform().globalState.update(
+        GlobalStateKey.USE_OPENROUTER,
+        useOpenRouter,
+      );
+      await platform().globalState.update(
+        GlobalStateKey.ENDPOINT_GLM,
+        providerEndpoint,
+      );
+      if (modelBaseUrl) MODEL_CONFIGS.glm52.baseUrl = modelBaseUrl;
 
-    expect(
-      resolveProxyEndpoint({
-        route: 'direct',
-        provider: ModelProvider.GLM,
-        useOpenRouter: false,
-      }),
-    ).toMatchObject({ usageRoute: 'glm-coding-plan-subscription' });
+      const canonical = resolveGlmRoute({
+        baseUrl: modelBaseUrl,
+        useOpenRouter,
+      });
+      const proxy = resolveProxyEndpoint(
+        modelBaseUrl
+          ? {
+              route: 'custom',
+              provider: ModelProvider.GLM,
+              url: modelBaseUrl,
+            }
+          : {
+              route: 'direct',
+              provider: ModelProvider.GLM,
+              useOpenRouter,
+            },
+      );
 
-    await platform().globalState.update(
-      GlobalStateKey.ENDPOINT_GLM,
-      'proxy.test/api/coding/paas/v4',
-    );
-    expect(
-      resolveProxyEndpoint({
-        route: 'direct',
-        provider: ModelProvider.GLM,
-        useOpenRouter: false,
-      }),
-    ).toEqual({ baseUrl: 'https://proxy.test/api/coding/paas/v4' });
-
-    expect(
-      resolveProxyEndpoint({
-        route: 'direct',
-        provider: ModelProvider.GLM,
-        useOpenRouter: true,
-      }),
-    ).toEqual({ baseUrl: 'https://openrouter.ai/api/v1' });
-  });
-
-  it('reports the GLM plan for the resolved official endpoint', async () => {
-    await platform().globalState.update(GlobalStateKey.USE_OPENROUTER, false);
-
-    await expect(activeSubscriptionUsageRoute('glm52')).resolves.toBe(
-      'glm-coding-plan-subscription',
-    );
-  });
-
-  it('does not classify a custom coding-shaped GLM endpoint as plan usage', async () => {
-    await platform().globalState.update(GlobalStateKey.USE_OPENROUTER, false);
-    await platform().globalState.update(
-      GlobalStateKey.ENDPOINT_GLM,
-      'proxy.test/api/coding/paas/v4',
-    );
-
-    await expect(
-      activeSubscriptionUsageRoute('glm52'),
-    ).resolves.toBeUndefined();
-  });
+      expect(canonical).toMatchObject({ route, baseUrl });
+      expect(proxy).toMatchObject({ baseUrl });
+      expect('usageRoute' in proxy ? proxy.usageRoute : undefined).toBe(
+        usageRoute,
+      );
+      await expect(activeSubscriptionUsageRoute('glm52')).resolves.toBe(
+        usageRoute,
+      );
+    },
+  );
 
   it('restores Kimi preference without overwriting newer OpenRouter state', async () => {
     const kimi = codingPlanSubscriptionRuntimes.find(


### PR DESCRIPTION
## Summary

- add one synchronous canonical GLM route resolver with model-custom, OpenRouter, provider-custom, official Coding Plan, and official regular variants
- make proxy construction, subscription usage, CLI status, ModelFactory dispatch, credential ownership, and model availability share that route decision
- preserve GLM China/global endpoint selection, provider endpoint normalization, and generic non-GLM behavior
- keep model-level GLM custom URLs ahead of OpenRouter throughout dispatch and client credential resolution

Closes #11581.

## Issue acceptance gates

- `src/model/glmRouting.ts` owns the complete GLM precedence and returns a discriminated route with `baseUrl` and Coding Plan `usageRoute`
- `ProxyConfigResolver` delegates every GLM route to the canonical resolver and returns only its advertised proxy shape
- OpenRouter dispatch and API-key ownership consult the canonical GLM route, so model custom URLs cannot be overridden upstream
- `activeSubscriptionUsageRoute` retains its public API while GLM classification uses the canonical route
- synchronous CLI formatting reports `GLM Coding Plan` only for a resolved provider-key row on the official Coding Plan route
- focused tests cover model custom plus OpenRouter across ModelFactory, availability, credential selection, and endpoint resolution
- exact China/global Coding Plan and regular official URLs are asserted

## Single source of truth

`src/model/glmRouting.ts` owns GLM endpoint precedence, official region selection, and Coding Plan usage classification. Shared generic modules own the OpenRouter constant and provider endpoint normalization used by GLM and non-GLM consumers.

## Duplication and abstraction budget

Removed the separate GLM precedence cascades from `ProxyConfigResolver`, `codingPlanSubscriptions.ts`, and CLI status formatting. The new resolver owns one cross-layer invariant. Existing routing helpers consume it so ModelFactory, credential selection, and availability stay aligned without adding parallel GLM dispatch APIs.

## Net elements (R6)

- files: 3 added, 10 modified
- exported symbols: `resolveGlmRoute`, `OPENROUTER_BASE_URL`, and `normalizeProviderEndpoint` added; no exported symbols deleted
- classes/interfaces/enums: no exported class, interface, or enum changes
- net LoC: +300

## Consumer counts (R8)

n/a. No emit path or existing export was deleted.

## Host impact

Extension and desktop: GLM requests, credential selection, availability, and usage classification use the canonical route. No UI changes.

CLI: model status reports GLM Coding Plan only when the resolved runnable provider-key row uses that official endpoint. OpenRouter fallback rows retain their resolved status.

## Scheduled refactoring

None. Terminal emulator environment-boundary cleanup is tracked separately in #11698.

## Validation

- reproduced before the fix: `ModelAccess.vitest.ts` expected `api: api key set` but received `api: GLM Coding Plan` for a provider custom endpoint
- focused tests: 6 files, 127 tests passed
- architecture suite: 15 files, 101 tests passed
- `npm run typecheck:workspace`: passed
- `npm run typecheck:cli`: passed
- `npm run typecheck:test-kernel`: passed
- `npm run check:dead-code-ratchet`: passed, 315 findings matched 315 baselined
- changed-file ESLint: passed
- changed-file Prettier check: passed
- `npm run compile:fast`: passed (existing Vite native config-loader warnings only)
- `git diff --check`: passed