### PR TITLE
fix(cli): route terminal detection through env boundary

### DIFF
--- a/packages/cli/src/tui/terminalCleanup.ts
+++ b/packages/cli/src/tui/terminalCleanup.ts
@@ -50,13 +50,11 @@ export function supportsTerminalJobControl(
   return platform !== 'win32';
 }
 
-export function cleanupTerminalModes(
-  termProgram: string | undefined = cliEnvValue('TERM_PROGRAM'),
-): void {
+export function cleanupTerminalModes(): void {
   // TERM_PROGRAM is fixed for the process, so the writer owns the emulator
   // check rather than having it threaded through the exit controller.
   writeTerminalSequence(
-    termProgram === 'iTerm.app'
+    cliEnvValue('TERM_PROGRAM') === 'iTerm.app'
       ? `${RESET_TERMINAL_MODES}${CLEAR_ITERM_PROGRESS}`
       : RESET_TERMINAL_MODES,
   );

--- a/packages/cli/src/tui/terminalCleanup.ts
+++ b/packages/cli/src/tui/terminalCleanup.ts
@@ -2,6 +2,8 @@ import { writeSync } from 'node:fs';
 
 import { kittyFlags } from 'ink';
 
+import { cliEnvValue } from '../runtime/cliContext';
+
 // Undo exactly the input/display modes the TUI turns on: mouse tracking
 // (1000/1003/1006), the kitty keyboard stack (<u), bracketed paste (2004), and
 // cursor visibility (25h). The TUI deliberately never enters the alternate
@@ -48,11 +50,13 @@ export function supportsTerminalJobControl(
   return platform !== 'win32';
 }
 
-export function cleanupTerminalModes(): void {
+export function cleanupTerminalModes(
+  termProgram: string | undefined = cliEnvValue('TERM_PROGRAM'),
+): void {
   // TERM_PROGRAM is fixed for the process, so the writer owns the emulator
   // check rather than having it threaded through the exit controller.
   writeTerminalSequence(
-    process.env.TERM_PROGRAM === 'iTerm.app'
+    termProgram === 'iTerm.app'
       ? `${RESET_TERMINAL_MODES}${CLEAR_ITERM_PROGRESS}`
       : RESET_TERMINAL_MODES,
   );

--- a/src/test-kernel/cli/TerminalCleanup.vitest.ts
+++ b/src/test-kernel/cli/TerminalCleanup.vitest.ts
@@ -22,6 +22,7 @@ import {
   rootRunStreamId,
 } from '@cli/chat/tui/state/cliState';
 import {
+  cleanupTerminalModes,
   installTerminalRestoreOnExit,
   restoreTuiInputModes,
   supportsTerminalJobControl,
@@ -358,6 +359,26 @@ describe('installTerminalTitleUpdates', () => {
     await flushTitleUpdate();
     expectLastTitle('{T}·evil]0;pwned');
     capableUpdates.dispose();
+  });
+});
+
+describe('cleanupTerminalModes', () => {
+  it('clears iTerm progress after resetting terminal modes', () => {
+    cleanupTerminalModes('iTerm.app');
+
+    expect(writeSync).toHaveBeenLastCalledWith(
+      1,
+      '\x1b[?1000;1003;1006l\x1b[<u\x1b[?2004l\x1b[?25h\x1b]9;4;0\x07',
+    );
+  });
+
+  it('only resets terminal modes outside iTerm', () => {
+    cleanupTerminalModes('Apple_Terminal');
+
+    expect(writeSync).toHaveBeenLastCalledWith(
+      1,
+      '\x1b[?1000;1003;1006l\x1b[<u\x1b[?2004l\x1b[?25h',
+    );
   });
 });
 

--- a/src/test-kernel/cli/TerminalCleanup.vitest.ts
+++ b/src/test-kernel/cli/TerminalCleanup.vitest.ts
@@ -22,7 +22,6 @@ import {
   rootRunStreamId,
 } from '@cli/chat/tui/state/cliState';
 import {
-  cleanupTerminalModes,
   installTerminalRestoreOnExit,
   restoreTuiInputModes,
   supportsTerminalJobControl,
@@ -359,26 +358,6 @@ describe('installTerminalTitleUpdates', () => {
     await flushTitleUpdate();
     expectLastTitle('{T}·evil]0;pwned');
     capableUpdates.dispose();
-  });
-});
-
-describe('cleanupTerminalModes', () => {
-  it('clears iTerm progress after resetting terminal modes', () => {
-    cleanupTerminalModes('iTerm.app');
-
-    expect(writeSync).toHaveBeenLastCalledWith(
-      1,
-      '\x1b[?1000;1003;1006l\x1b[<u\x1b[?2004l\x1b[?25h\x1b]9;4;0\x07',
-    );
-  });
-
-  it('only resets terminal modes outside iTerm', () => {
-    cleanupTerminalModes('Apple_Terminal');
-
-    expect(writeSync).toHaveBeenLastCalledWith(
-      1,
-      '\x1b[?1000;1003;1006l\x1b[<u\x1b[?2004l\x1b[?25h',
-    );
   });
 });
 


### PR DESCRIPTION
## Summary

Route iTerm detection in terminal cleanup through the CLI environment boundary while preserving the existing synchronous best-effort reset behavior and public function signature.

This minimal architecture fix should merge before CLI-touching PRs #11696 and #11697 are rebased.

Closes #11698

## Issue acceptance gates

- `TERM_PROGRAM` is read through `cliEnvValue` instead of directly from `process.env`.
- Terminal cleanup remains synchronous and best-effort.
- Existing iTerm and non-iTerm output behavior is unchanged.
- The CLI architecture check now passes and guards the environment boundary.

## Single source of truth

`packages/cli/src/runtime/cliContext.ts` remains the owner of ambient CLI environment access through `cliEnvValue`.

## Duplication and abstraction budget

No new abstraction or test-only production seam was added. The existing environment boundary is reused directly inside `cleanupTerminalModes()`.

## Net elements (R6)

n/a. This is a bug fix, not a refactor-class PR.

## Consumer counts (R8)

n/a. No emit path or export was deleted or rerouted.

## Host impact

Extension: None.

Desktop: None.

CLI: Terminal emulator detection now respects the existing environment-access boundary. Reset output is unchanged.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm --filter @texra-ai/cli check:architecture`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/TerminalCleanup.vitest.ts`
- `npm run typecheck:workspace`
- `npm run typecheck:cli`
- `npm run typecheck:test-kernel`
- `corepack pnpm exec eslint packages/cli/src/tui/terminalCleanup.ts src/test-kernel/cli/TerminalCleanup.vitest.ts`
- `corepack pnpm exec prettier --check packages/cli/src/tui/terminalCleanup.ts src/test-kernel/cli/TerminalCleanup.vitest.ts`
- `git diff --check`
