### PR TITLE
fix(runtime): separate active and handle timestamps

### DIFF
--- a/docs/proposals/2026-08-15-cross-host-consolidation.md
+++ b/docs/proposals/2026-08-15-cross-host-consolidation.md
@@ -185,10 +185,12 @@ owner and one surface (CLI `/status` reads the log directly; the extension's
 reader-less fold and `StreamState.activeSkills` are deleted) — see the row.
 C13c **OPEN**. C17
 **OPEN** — the counts still are not on `ToolEditApprovalRequest` and
-`DiffView.statsFromHunks` still recomputes. C22 **PARTIAL #10892 — and now
-three representations, not two**: `startedAt` shipped and the CLI ticks from
-it, but the redundant `formatDuration` stamp survives on the wire and the
-webview still renders it. C18 **PARTIAL #10889** — the SYNC branch and
+`DiffView.statsFromHunks` still recomputes. C22 **RESOLVED #10892 / #11561**:
+rendered elapsed strings are gone, and live elapsed time now comes from the
+status plane's active-phase `runStartedAt` in
+both CLI and webview. The roster's `startedAt` remains a distinct
+handle-generation fact for retained rows and executions-tool output. C18
+**PARTIAL #10889** — the SYNC branch and
 `streamStates` go through the shared builders; the `StreamTabInfo` literal is
 still hand-built. Doc correction: `ProgressStreamProjectionBuilder.ts` no
 longer exists; the live owner is `src/shared/streams/streamContentSync.ts`.
@@ -275,11 +277,13 @@ longer exists; the live owner is `src/shared/streams/streamContentSync.ts`.
   have the CLI call the canonical counting helper; keep `buildHunks` only
   for the visual diff. Same disease as C22.
 - **C22. `elapsed`: wire-stamped vs locally recomputed.**
-  `executionRegistry.ts:323` stamps `formatDuration(...)`; the webview renders
-  it verbatim (`BackgroundTasksPanel.ts:478-480`); the CLI recomputes with a
-  _different_ formatter and live ticking (`childControls.ts:24-34`). → One
-  derivation + one formatter; if live ticking is wanted, ship `startedAt` on
-  the wire and derive in one shared helper. **Net:** ~−15 L.
+  **RESOLVED #10892 / #11561.** No rendered duration travels on the wire.
+  Live elapsed time derives from the child stream's status-plane
+  `runStartedAt`, which opens only for the current active phase, clears in
+  WAITING and terminal phases, and restamps on resume. The roster's
+  `startedAt` is deliberately retained as a different fact: handle-generation
+  creation, used with `finishedAt` for retained rows and by executions-tool
+  output.
 - **C18. `replayTrace` bootstrap re-implements two live builders.**
   `packages/trace-viewer/src/replayTrace.ts:228-254` hand-builds the
   `SyncStreamContentPayload` category branch that

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -38,9 +38,11 @@ import {
   runIdentityDisplayName,
   type ActiveChildInfo,
   type InquiryThreadUpdatedEvent,
+  type StreamTabId,
 } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { childElapsedMs } from '@shared/streams/childElapsed';
+import type { ChildRunProgress } from '@shared/streams/workflowRunModel';
 import {
   formatPhaseStageLabel,
   formatStreamStatusLabel,
@@ -55,6 +57,8 @@ import '@progressView/frontend/components/ToolTimer';
 
 // Local imports - contexts
 import {
+  childProgressContext,
+  EMPTY_CHILD_PROGRESS,
   EMPTY_INQUIRY_THREADS,
   EMPTY_PHASE_STAGE_MAP,
   EMPTY_STREAM_BY_ID,
@@ -243,6 +247,11 @@ export class BackgroundTasksPanel extends LitElement {
   @consume({ context: inquiryThreadsContext, subscribe: true })
   @state()
   private inquiries: InquiryThreadUpdatedEvent[] = EMPTY_INQUIRY_THREADS;
+
+  @consume({ context: childProgressContext, subscribe: true })
+  @state()
+  private childProgress: ReadonlyMap<StreamTabId, ChildRunProgress> =
+    EMPTY_CHILD_PROGRESS;
 
   /** Current phase per stream — a workflow-script run's row is otherwise
    *  indistinguishable at minute 2 and minute 38 of the same run. */
@@ -483,7 +492,10 @@ export class BackgroundTasksPanel extends LitElement {
                 >`
             : nothing
         }
-        ${renderChildElapsed(child)}
+        ${renderChildElapsed(
+          child,
+          this.childProgress.get(childStreamId)?.runStartedAt,
+        )}
         <wa-badge
           class="task-status"
           variant=${badge.variant}
@@ -505,22 +517,24 @@ export class BackgroundTasksPanel extends LitElement {
 }
 
 /**
- * Elapsed reading for one roster row, derived from the row's own timestamps —
- * the roster carries no rendered duration. A live row hands its start stamp to
- * the shared `<tool-timer>`, which owns the tick; paused rows show no elapsed
- * reading, matching the CLI. A retained row's window is closed by `finishedAt`,
- * so its reading is fixed and needs no clock read.
+ * Elapsed reading for one roster row. A live row uses the child's current
+ * active-phase start from the status plane and hands it to `<tool-timer>`,
+ * which owns the tick. A retained row uses the roster's handle-generation
+ * window, closed by `finishedAt`, so its reading is fixed.
  */
 function renderChildElapsed(
   child: ActiveChildInfo,
+  runStartedAt: number | undefined,
 ): TemplateResult | typeof nothing {
-  if (child.startedAt === undefined) return nothing;
   if (child.finishedAt === undefined) {
-    if (child.status !== STREAM_PHASE.RUNNING) return nothing;
+    if (child.status !== STREAM_PHASE.RUNNING || runStartedAt === undefined) {
+      return nothing;
+    }
     return html`<span class="task-elapsed"
-      >(<tool-timer .startTime=${child.startedAt}></tool-timer>)</span
+      >(<tool-timer .startTime=${runStartedAt}></tool-timer>)</span
     >`;
   }
+  if (child.startedAt === undefined) return nothing;
   const elapsedMs = childElapsedMs(child, child.finishedAt);
   return elapsedMs === undefined
     ? nothing

--- a/packages/extension/src/progressView/frontend/components/StreamConversation.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamConversation.ts
@@ -9,8 +9,10 @@ import { customElement, property, state } from 'lit/decorators.js';
 import type {
   InquiryThreadUpdatedEvent,
   PermissionPayload,
+  StreamTabId,
 } from '@shared/schemas';
 import { SignalWatcher } from '@shared/signals';
+import type { ChildRunProgress } from '@shared/streams/workflowRunModel';
 
 // Local imports - progress view
 import {
@@ -23,6 +25,8 @@ import {
 } from '../progressState';
 import {
   archivedContext,
+  childProgressContext,
+  EMPTY_CHILD_PROGRESS,
   EMPTY_INQUIRY_THREADS,
   EMPTY_LOG_CONTEXT,
   EMPTY_PHASE_STAGE_MAP,
@@ -90,6 +94,13 @@ export class StreamConversation extends SignalWatcher(LitElement) {
   @state()
   private streamLogContextValue: StreamLogContextValue = EMPTY_LOG_CONTEXT;
 
+  @provide({ context: childProgressContext })
+  @state()
+  private childProgressContextValue: ReadonlyMap<
+    StreamTabId,
+    ChildRunProgress
+  > = EMPTY_CHILD_PROGRESS;
+
   @provide({ context: permissionsContext })
   @state()
   private permissionsContextValue: PermissionPayload[] = [];
@@ -126,6 +137,7 @@ export class StreamConversation extends SignalWatcher(LitElement) {
   protected override willUpdate(): void {
     this.streamContextValue = streamContext$.get();
     this.streamLogContextValue = logContext$.get();
+    this.childProgressContextValue = this.streamLogContextValue.childProgress;
     this.permissionsContextValue = permissions$.get();
     this.streamByIdContextValue = streamById$.get();
     this.inquiryThreadsContextValue = activeInquiries$.get();

--- a/packages/extension/src/progressView/frontend/streamContexts.ts
+++ b/packages/extension/src/progressView/frontend/streamContexts.ts
@@ -107,6 +107,14 @@ export const streamLogContext = createContext<StreamLogContextValue>(
   'progress-stream-log',
 );
 
+/** Live active-phase progress for each child of the active stream. */
+export const EMPTY_CHILD_PROGRESS: ReadonlyMap<StreamTabId, ChildRunProgress> =
+  new Map();
+
+export const childProgressContext = createContext<
+  ReadonlyMap<StreamTabId, ChildRunProgress>
+>('progress-child-run-progress');
+
 export const permissionsContext = createContext<PermissionPayload[]>(
   'progress-permissions',
 );

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -116,9 +116,9 @@ export class AgentExecutionHandle {
   /**
    * Epoch ms when this handle generation was created. The value remains on a
    * handle while it is parked at WAITING. Resume constructs and tracks a
-   * replacement handle, whose `startedAt` is stamped anew. This feeds
-   * `executionRegistry.getStatus`'s elapsed, the roster's
-   * `ActiveChildInfo.startedAt`, and the `executions` tool's `Started:` line.
+   * replacement handle, whose `startedAt` is stamped anew. This feeds the
+   * roster's `ActiveChildInfo.startedAt` and the `executions` tool's `Started:`
+   * line.
    * Durable execution creation time is `ExecutionMeta.timestamp`.
    */
   readonly startedAt = Date.now();

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -462,16 +462,17 @@ export class ExecutionRegistry {
   getStatus(
     handle: AgentExecutionHandle,
   ): ExecutionStatusInfo & { status: StreamPhase } {
-    const status =
-      this.streamStatus.get(handle.childStreamId) ?? STREAM_PHASE.RUNNING;
+    const phaseState = this.streamStatus.getStreamState(handle.childStreamId);
+    const status = phaseState?.phase ?? STREAM_PHASE.RUNNING;
+    const runStartedAt = phaseState?.runStartedAt;
 
-    if (!isActivePhase(status)) {
+    if (!isActivePhase(status) || runStartedAt === undefined) {
       return { status, elapsed: null };
     }
 
     return {
       status,
-      elapsed: formatDuration(Date.now() - handle.startedAt),
+      elapsed: formatDuration(Date.now() - runStartedAt),
     };
   }
 

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -725,8 +725,9 @@ export class SessionFactApplier {
   /**
    * Replace a parent stream's live child roster, retaining every non-process
    * child that just left it instead of folding it into a counter — a finished
-   * subagent keeps its executionId, agentName, status, startedAt, elapsed and
-   * toolName so hosts can list it. Process children (background bash) are
+   * subagent keeps its executionId, identity, status, and handle-generation
+   * startedAt so hosts can list it and close that window with `finishedAt`.
+   * Process children (background bash) are
    * ephemeral and are never retained. A retained row is only ever created from
    * an entry that was already in OUR roster and is absent from `next`, so a
    * first roster can never mark anything finished.

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -38,7 +38,11 @@ export const ActiveChildInfoSchema = z.object({
    * `StreamStatus` vocabulary and there is nothing to normalize here.
    */
   status: StreamPhaseSchema.optional(),
-  /** Epoch milliseconds when the child execution began. */
+  /**
+   * Epoch milliseconds when the current child handle generation was created.
+   * Kept on the wire for live and retained roster rows; live active-phase
+   * elapsed time comes from the child stream's `runStartedAt` instead.
+   */
   startedAt: z.int().positive().optional(),
   /**
    * Epoch milliseconds when the child left its parent's active roster.

--- a/src/shared/streams/childElapsed.ts
+++ b/src/shared/streams/childElapsed.ts
@@ -1,21 +1,19 @@
-// Host-neutral "how long has this child run" derivation over a roster row.
+// Host-neutral elapsed derivation over a selected child time window.
 //
-// The roster carries timestamps, never a rendered duration: `startedAt` opens
-// the window and `finishedAt` closes it, so every surface answers elapsed time
-// from the same two numbers and differs only in how it formats and how often
-// it re-reads the clock. That is the whole point of this module — a formatted
-// string on the wire would make the emitter's clock read and format the
-// authority for readers that tick at their own rate.
+// Callers select the window before invoking this helper: live rows project the
+// status plane's active-phase `runStartedAt` into the start slot, while retained
+// rows use the roster's handle-generation `startedAt` and `finishedAt`. The
+// helper keeps only the arithmetic shared; each surface owns its formatting and
+// tick rate instead of receiving a rendered duration on the wire.
 //
 // NO host imports here: a pure function over plain values.
 
 import type { ActiveChildInfo } from '@shared/schemas';
 
 /**
- * Elapsed run duration in ms for one roster row, or `undefined` when the row
- * carries no start stamp (legacy rows and hand-built fixtures). A retained
- * (finished) row measures to its `finishedAt` retention stamp so its reading
- * stops moving; a live row measures to `nowMs`.
+ * Elapsed duration in ms for the caller-selected child window, or `undefined`
+ * when it carries no start stamp. A closed window measures to `finishedAt` so
+ * its reading stops moving; an open window measures to `nowMs`.
  */
 export function childElapsedMs(
   child: Pick<ActiveChildInfo, 'startedAt' | 'finishedAt'>,

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -1242,6 +1242,43 @@ describe('executionRegistry', () => {
     }
   });
 
+  it('reports active elapsed from runStartedAt without a handle fallback', () => {
+    vi.useFakeTimers({ now: 1_000 });
+    const { streamStatus, registry } = createRegistry();
+    const parentStreamId = 'parent-active-elapsed-test' as StreamTabId;
+    const childStreamId = 'child-active-elapsed-test' as StreamTabId;
+    const handle = createHandle(
+      'exec-active-elapsed-test',
+      parentStreamId,
+      childStreamId,
+    );
+
+    try {
+      registry.track(handle);
+      vi.setSystemTime(10_000);
+      seedStreamStatusForTest(streamStatus, childStreamId, {
+        phase: STREAM_PHASE.RUNNING,
+        runStartedAt: 6_000,
+      });
+
+      expect(registry.getStatus(handle)).toEqual({
+        status: STREAM_PHASE.RUNNING,
+        elapsed: '4s',
+      });
+      expect(registry.getActiveChildren(parentStreamId)[0]?.startedAt).toBe(
+        1_000,
+      );
+
+      seedStreamStatusForTest(streamStatus, childStreamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
+      expect(registry.getStatus(handle).elapsed).toBeNull();
+    } finally {
+      vi.useRealTimers();
+      registry.dispose();
+    }
+  });
+
   it('publishes initial status when tracking an agent execution', () => {
     const { streamStatus, registry } = createRegistry();
     const parentStreamId = 'parent-track-agent-status-test' as StreamTabId;

--- a/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
+++ b/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { StatusEvent } from '@agent/trace';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
@@ -113,6 +113,36 @@ describe('StreamStatusMachine', () => {
     );
     expect(machine.get(streamId)).toBe(STREAM_PHASE.WAITING);
     expect(machine.tryAcquire(streamId)).toBe(false);
+  });
+
+  it('closes the active window in WAITING and restamps after the resume gap', () => {
+    vi.useFakeTimers({ now: 1_000 });
+    const { machine, streamId } = setupMachine(
+      'stream-status-active-window-resume',
+    );
+
+    try {
+      expect(
+        machine.transition(streamId, STREAM_PHASE.RUNNING, 'lifecycle'),
+      ).toBe(true);
+      expect(machine.getStreamState(streamId)?.runStartedAt).toBe(1_000);
+
+      vi.setSystemTime(5_000);
+      expect(machine.transition(streamId, STREAM_PHASE.WAITING, 'wait')).toBe(
+        true,
+      );
+      expect(machine.getStreamState(streamId)).toEqual({
+        phase: STREAM_PHASE.WAITING,
+      });
+
+      vi.setSystemTime(15_000);
+      expect(machine.transition(streamId, STREAM_PHASE.RUNNING, 'resume')).toBe(
+        true,
+      );
+      expect(machine.getStreamState(streamId)?.runStartedAt).toBe(15_000);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it.each([

--- a/src/test-kernel/progressView/BackgroundTasksPanel.vitest.ts
+++ b/src/test-kernel/progressView/BackgroundTasksPanel.vitest.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 // Local imports
 import type { BackgroundTasksPanel } from '@progressView/frontend/components/BackgroundTasksPanel';
 import type {
+  childProgressContext as ChildProgressContext,
   inquiryThreadsContext as InquiryThreadsContext,
   phaseStagesContext as PhaseStagesContext,
 } from '@progressView/frontend/streamContexts';
@@ -23,6 +24,7 @@ interface StyledBackgroundTasksPanelConstructor extends CustomElementConstructor
 // and the context definitions can only be imported after the test DOM globals
 // are installed (that is what useLitComponentTestDom's hook does).
 let ContextProviderCtor: typeof ContextProvider;
+let childProgressContext: typeof ChildProgressContext;
 let inquiryThreadsContext: typeof InquiryThreadsContext;
 let phaseStagesContext: typeof PhaseStagesContext;
 
@@ -69,7 +71,7 @@ async function mountPanel(
 describe('background-tasks-panel', () => {
   useLitComponentTestDom(async () => {
     ({ ContextProvider: ContextProviderCtor } = await import('@lit/context'));
-    ({ inquiryThreadsContext, phaseStagesContext } =
+    ({ childProgressContext, inquiryThreadsContext, phaseStagesContext } =
       await import('@progressView/frontend/streamContexts'));
     await import('@progressView/frontend/components/BackgroundTasksPanel');
   });
@@ -101,7 +103,7 @@ describe('background-tasks-panel', () => {
     expect(rule?.style.borderRadius).toBe('0px');
   });
 
-  it('lists a retained finished subagent as a named row, not a count', async () => {
+  it('uses the roster generation window for a retained finished row', async () => {
     const element = await mountPanel([
       subagentRow({ executionId: 'exec-1', startedAt: 1_000 }),
       subagentRow({
@@ -134,6 +136,36 @@ describe('background-tasks-panel', () => {
     expect(shadow.textContent).not.toMatch(/All \d+ subagents completed/);
 
     element.remove();
+  });
+
+  it('uses child runStartedAt for a live row timer', async () => {
+    const element = createPanel();
+    element.subagents = [
+      subagentRow({
+        executionId: 'exec-live-timer',
+        childStreamId: 'child-live-timer',
+        startedAt: 1_000,
+      }),
+    ];
+    const container = document.createElement('div');
+    document.body.append(container);
+    new ContextProviderCtor(container, {
+      context: childProgressContext,
+      initialValue: new Map([
+        [
+          'child-live-timer' as StreamTabId,
+          { runStartedAt: 5_000, toolCallCount: 0 },
+        ],
+      ]),
+    }).hostConnected();
+    container.append(element);
+    await element.updateComplete;
+
+    const timer = element.shadowRoot?.querySelector('tool-timer') as
+      (HTMLElement & { startTime: number }) | null;
+    expect(timer?.startTime).toBe(5_000);
+
+    container.remove();
   });
 
   it('labels a running workflow-script row with its current phase', async () => {


### PR DESCRIPTION
## Summary

Separate the two timestamp facts that issue #11561 identified instead of treating them as interchangeable:

- `StreamPhaseState.runStartedAt` is the current active-phase window. It clears in WAITING and terminal phases and restamps on resume.
- `AgentExecutionHandle.startedAt` is handle-generation creation. It remains on parked and retained roster rows and continues to feed the executions tool's `Started:` line.
- `ExecutionMeta.timestamp` remains durable execution creation.

`ExecutionRegistry.getStatus()` now derives active elapsed time only from `runStartedAt`. The extension background-task panel also uses each child's existing progress-plane `runStartedAt` for live timers, while retained rows keep using roster `startedAt` through `finishedAt`.

## Issue acceptance gates

Closes #11561

- Active elapsed has no fallback to `handle.startedAt`.
- WAITING has no active-phase timestamp or elapsed display.
- Resume gaps are excluded because the active timestamp is restamped.
- Live extension rows use child progress `runStartedAt`.
- Retained extension rows preserve the handle-generation window.
- `ActiveChildInfo.startedAt` remains wire-compatible.
- The stale roster comment and C22 ruling are updated.

## Single source of truth

`StreamStatusMachine` owns `StreamPhaseState.runStartedAt` and the active-phase window. `AgentExecutionHandle` independently owns handle-generation creation. `ExecutionMeta.timestamp` independently owns durable execution creation.

## Duplication and abstraction budget

The new `childProgressContext` exposes the already-computed active child progress map to sibling progress-view components without making the background-task panel subscribe to the full streaming log context. It owns no new timestamp and adds no parallel derivation.

## Net elements (R6)

- Files: 12 modified, 0 added, 0 deleted.
- Exported symbols: 2 added (`EMPTY_CHILD_PROGRESS`, `childProgressContext`), 0 deleted.
- Classes/interfaces/enums: no additions or deletions.
- Net LoC: +141.

Most additions are five focused regression cases/assertions plus context wiring and ownership documentation.

## Consumer counts (R8)

- `ExecutionRegistry.getStatus`: one active-elapsed derivation rerouted from `handle.startedAt` to status-plane `runStartedAt`.
- `BackgroundTasksPanel` live timer: one consumer rerouted from roster `startedAt` to child progress `runStartedAt`.
- `ActiveChildInfo.startedAt`: retained by both production producers/consumers. No wire field was removed or renamed.

## Host impact

Extension: Live background-task timers now exclude WAITING gaps. Retained rows still show their fixed handle-generation duration.

Desktop: Shared `ExecutionRegistry.getStatus()` uses active-phase elapsed semantics. No wire change.

CLI: No behavior change. Existing CLI elapsed consumers already use status-plane `runStartedAt`; focused CLI suites confirm the contract.

## Scheduled refactoring

None.

## Validation

- `npx vitest run --config vitest.config.mjs` with ExecutionRegistry, StreamStatusService, BackgroundTasksPanel, ChildControls, SubagentListDisplay, and ExecutionsToolOutput: 6 files, 105 tests passed.
- `npx vitest run --config vitest.config.mjs src/test-kernel/architecture`: 15 files, 101 tests passed.
- `npm run typecheck:workspace`: passed.
- `npm run typecheck:test-kernel`: passed.
- Changed-file ESLint: passed.
- Changed-file Prettier check: passed.
- `npm run check:dead-code-ratchet`: passed.
- `npm run check:browser-safe-utils`: passed.
- `npm run compile:fast`: passed.
