### PR TITLE
fix(cli): preserve compact workflow fallback

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -89,7 +89,10 @@ import {
   streamPhaseFor,
 } from './state/cliState';
 import { appendLocalAssistantTranscript } from './state/transcript';
-import { retainedWorkflowPopupProjection } from './state/transcriptFold';
+import {
+  retainedWorkflowPopupProjection,
+  retainedWorkflowRunModel,
+} from './state/transcriptFold';
 import {
   activeSubagentsFor,
   childRosters as childRostersSignal,
@@ -382,14 +385,17 @@ export function App(props: AppProps): React.JSX.Element {
       });
     }
     const retained = retainedWorkflowPopupProjection(workflowPopupRoot);
-    return workflowRunModel({
-      taskGroups: retained.taskGroups,
-      rows: retained.rows,
-      workflowAttemptId: workflowPopupRoot.workflowAttemptId,
-      plan: retained.plan,
-      runSettled: workflowPopupRunSettled,
-      childProgress,
-    });
+    return retainedWorkflowRunModel(
+      workflowRunModel({
+        taskGroups: retained.taskGroups,
+        rows: retained.rows,
+        workflowAttemptId: workflowPopupRoot.workflowAttemptId,
+        plan: retained.plan,
+        runSettled: workflowPopupRunSettled,
+        childProgress,
+      }),
+      retained,
+    );
     // The two revisions are the signals that a child's progress or usage
     // moved; they carry no value of their own.
   }, [

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -116,6 +116,10 @@ export interface TranscriptFoldState {
   workflowAttemptId?: string;
   /** The newest valid `workflowPlan` marker folded so far (last wins). */
   workflowPlan?: WorkflowPlanMarker;
+  /** Current-plan task ids known to have issued before transcript eviction.
+   *  Bounded by the already-retained plan, this keeps compact popup fallback
+   *  from reviving cutoff tasks as declared while the full log reloads. */
+  retainedWorkflowIssuedTaskIds?: ReadonlySet<string>;
   /** Whether the last emitted `entries` was the full transcript or compact;
    *  undefined until the first emission. */
   lastOutputFull?: boolean;

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -51,6 +51,7 @@ import {
   compactWorkflowEntries,
   createTranscriptFoldState,
   isFullLogChildStream,
+  issuedWorkflowPlanTaskIds,
   latestConversationLine,
   newFoldChangeFlags,
   resetTranscriptFoldState,
@@ -546,7 +547,14 @@ export function releaseInactiveStreamTranscript(
   store.requestEviction(streamId);
   const fold = slice.transcriptFold;
   if (fold) {
+    const retainedWorkflowIssuedTaskIds = fold.hydrated
+      ? issuedWorkflowPlanTaskIds(
+          fold.items.map((item) => item.rendered),
+          slice.workflowPlan,
+        )
+      : fold.retainedWorkflowIssuedTaskIds;
     resetTranscriptFoldState(fold);
+    fold.retainedWorkflowIssuedTaskIds = retainedWorkflowIssuedTaskIds;
     fold.taskGroupProjection = undefined;
     fold.compactionProjection = undefined;
     fold.workflowAttemptId = undefined;

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -41,7 +41,10 @@ import {
   type CompactionActivityProjection,
 } from '@shared/streams/compactionActivityProjection';
 import { upsertTaskGroupFromStreamLog } from '@shared/streams/taskGroupProjection';
-import { workflowMarkerOf } from '@shared/streams/workflowRunModel';
+import {
+  workflowMarkerOf,
+  type WorkflowRunModel,
+} from '@shared/streams/workflowRunModel';
 import type { StreamLog } from '@transcript';
 import { truncateSummary } from '@utils/text/stringUtils';
 import {
@@ -773,6 +776,33 @@ export function compactWorkflowEntries(
   };
 }
 
+/** Current-plan task ids that have appeared as cards. Intersecting with the
+ *  plan bounds the eviction snapshot by state the slice already retains. */
+export function issuedWorkflowPlanTaskIds(
+  rows: readonly TranscriptRow[],
+  plan: WorkflowPlanMarker | undefined,
+): ReadonlySet<string> {
+  if (!plan) return new Set();
+  const planTaskIds = new Set(plan.tasks.map((task) => task.id));
+  return new Set(
+    rows.flatMap((row) =>
+      row.kind === 'workflowTask' &&
+      row.call.attemptId === plan.attemptId &&
+      planTaskIds.has(row.call.id)
+        ? [row.call.id]
+        : [],
+    ),
+  );
+}
+
+export interface RetainedWorkflowPopupProjection {
+  readonly rows: readonly TranscriptRow[];
+  readonly taskGroups: readonly TaskGroup[];
+  readonly plan: WorkflowPlanMarker | undefined;
+  readonly retainedPhaseIds: ReadonlySet<string>;
+  readonly firstPlanIndex: number;
+}
+
 /** The popup's dashboard projection, kept bounded even while its presentation
  *  lease makes the slice expose the complete transcript to Ctrl-T. */
 export function retainedWorkflowPopupProjection(input: {
@@ -780,11 +810,7 @@ export function retainedWorkflowPopupProjection(input: {
   readonly taskGroups: readonly TaskGroup[];
   readonly workflowPlan: WorkflowPlanMarker | undefined;
   readonly transcriptFold?: TranscriptFoldState;
-}): {
-  readonly rows: readonly TranscriptRow[];
-  readonly taskGroups: readonly TaskGroup[];
-  readonly plan: WorkflowPlanMarker | undefined;
-} {
+}): RetainedWorkflowPopupProjection {
   const fold = input.transcriptFold;
   const fullRows = fold?.hydrated
     ? fold.items.map((item) => item.rendered)
@@ -809,13 +835,19 @@ export function retainedWorkflowPopupProjection(input: {
     !input.workflowPlan ||
     (!compact.dashboardTruncated && !phaseGroupWasDropped)
   ) {
-    return { rows: compact.rows, taskGroups, plan: input.workflowPlan };
+    return {
+      rows: compact.rows,
+      taskGroups,
+      plan: input.workflowPlan,
+      retainedPhaseIds,
+      firstPlanIndex: 0,
+    };
   }
 
   const attemptId = input.workflowPlan.attemptId;
-  // An opened plan phase's index pins the cutoff in declared-plan order. Keep
-  // that phase and every still-unopened phase after it, but do not let an
-  // earlier dropped phase come back through the plan union.
+  // An opened plan phase's index pins the cutoff in declared-plan order. The
+  // model keeps the complete phase array so later plan-only headings retain
+  // their original index/total; retainedWorkflowRunModel removes earlier ones.
   const allIndexedPhases = input.taskGroups.filter(
     (
       group,
@@ -836,32 +868,50 @@ export function retainedWorkflowPopupProjection(input: {
   } else if (openedIndexes.length > 0) {
     firstPlanIndex = Math.max(...openedIndexes) + 1;
   }
-  const phases = input.workflowPlan.phases.slice(firstPlanIndex);
-  const phaseTitles = new Set(phases.map((phase) => phase.title));
   // A plan task that already issued outside the retained rows must not return
-  // as Declared. Tasks that have not issued yet remain visible.
-  const issuedIds = new Set(
-    fullRows.flatMap((row) =>
-      row.kind === 'workflowTask' && row.call.attemptId === attemptId
-        ? [row.call.id]
-        : [],
-    ),
-  );
-  const retainedIds = new Set(
-    compact.rows.flatMap((row) =>
-      row.kind === 'workflowTask' && row.call.attemptId === attemptId
-        ? [row.call.id]
-        : [],
-    ),
+  // as Declared. Tasks that have not issued yet remain visible. After eviction,
+  // use the bounded issued-id snapshot captured before the full fold was reset.
+  const issuedIds = fold?.hydrated
+    ? issuedWorkflowPlanTaskIds(fullRows, input.workflowPlan)
+    : (fold?.retainedWorkflowIssuedTaskIds ??
+      issuedWorkflowPlanTaskIds(fullRows, input.workflowPlan));
+  const retainedIds = issuedWorkflowPlanTaskIds(
+    compact.rows,
+    input.workflowPlan,
   );
   const tasks = input.workflowPlan.tasks.filter(
-    (task) =>
-      (!issuedIds.has(task.id) || retainedIds.has(task.id)) &&
-      (task.phase === undefined || phaseTitles.has(task.phase)),
+    (task) => !issuedIds.has(task.id) || retainedIds.has(task.id),
   );
   return {
     rows: compact.rows,
     taskGroups,
-    plan: { ...input.workflowPlan, phases, tasks },
+    plan: { ...input.workflowPlan, tasks },
+    retainedPhaseIds,
+    firstPlanIndex,
+  };
+}
+
+/** Remove model phases outside the CLI compaction projection. The shared model
+ *  still sees the original plan, preserving declared phase numbering. */
+export function retainedWorkflowRunModel(
+  model: WorkflowRunModel,
+  projection: RetainedWorkflowPopupProjection,
+): WorkflowRunModel {
+  const phases = model.phases.filter(
+    (phase) =>
+      projection.retainedPhaseIds.has(phase.key) ||
+      phase === model.unphasedPhase ||
+      (!phase.opened &&
+        (phase.heading.phaseIndex === undefined ||
+          phase.heading.phaseIndex >= projection.firstPlanIndex)),
+  );
+  const declared = phases.reduce(
+    (total, phase) => total + phase.declaredTasks.length,
+    0,
+  );
+  return {
+    ...model,
+    phases,
+    tally: { ...model.tally, declared },
   };
 }

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
@@ -38,11 +38,15 @@ import {
   unbindChildStreamState,
 } from '@cli/chat/tui/state/childExecutions';
 import {
+  releaseInactiveStreamTranscript,
   subscribeStreamLog,
   syncStreamLog,
 } from '@cli/chat/tui/state/subscribeStreamLog';
 import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
-import { retainedWorkflowPopupProjection } from '@cli/chat/tui/state/transcriptFold';
+import {
+  retainedWorkflowPopupProjection,
+  retainedWorkflowRunModel,
+} from '@cli/chat/tui/state/transcriptFold';
 import { SessionState } from '@controllers/session/SessionState';
 import {
   AgentCategory,
@@ -235,6 +239,11 @@ describe('CLI workflow-script child-stream transcript', () => {
       tasks: [
         { id: 'stale-call', label: 'Stale call', phase: 'Stale' },
         {
+          id: 'retained-call-0',
+          label: 'Retained call 0',
+          phase: 'Repeated',
+        },
+        {
           id: 'retained-call-1998',
           label: 'Retained call 1998',
           phase: 'Repeated',
@@ -271,7 +280,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       index: 1,
       total: 3,
     });
-    for (let index = 0; index < 1_999; index++) {
+    for (let index = 0; index < 2_000; index++) {
       runTrace.trace.emit({
         type: 'workflow.call',
         logId: `retained-task-${index}`,
@@ -303,6 +312,37 @@ describe('CLI workflow-script child-stream transcript', () => {
       false,
     );
 
+    setStatus(STREAM_PHASE.COMPLETED);
+    releaseInactiveStreamTranscript(defaultSession().transcripts, STREAM_ID);
+    expect(streamSlice()?.transcriptFold?.hydrated).toBe(false);
+    const evictedSlice = streamSlice()!;
+    const evictedRetained = retainedWorkflowPopupProjection(evictedSlice);
+    const evictedModel = retainedWorkflowRunModel(
+      workflowRunModel({
+        taskGroups: evictedRetained.taskGroups,
+        rows: evictedRetained.rows,
+        workflowAttemptId: evictedSlice.workflowAttemptId,
+        plan: evictedRetained.plan,
+        runSettled: true,
+        childProgress: new Map(),
+      }),
+      evictedRetained,
+    );
+    expect(evictedModel.phases.map((phase) => phase.key)).toEqual([
+      'empty-phase',
+      'declared-Future',
+      'referenced-phase',
+    ]);
+    expect(
+      evictedModel.phases.flatMap((phase) =>
+        phase.declaredTasks.map((task) => task.id),
+      ),
+    ).toEqual(['future-call']);
+    expect(
+      evictedModel.phases.find((phase) => phase.key === 'declared-Future')
+        ?.heading,
+    ).toMatchObject({ phaseIndex: 2, phaseTotal: 3 });
+
     // Exercise the roster-first interval: the parent already classifies this
     // child as a workflow, but the child's own run metadata has not landed.
     seedStreamMeta(STREAM_ID, { agentCategory: AgentCategory.Workflow });
@@ -324,7 +364,7 @@ describe('CLI workflow-script child-stream transcript', () => {
     const dispose = subscribeStreamLog(defaultSession());
     try {
       openWorkflowPopup(STREAM_ID);
-      await waitFor(() => streamEntries().length === 2_005);
+      await waitFor(() => streamEntries().length === 2_006);
       expect(streamEntries().some((row) => row.id === 'stale-phase')).toBe(
         true,
       );
@@ -339,16 +379,20 @@ describe('CLI workflow-script child-stream transcript', () => {
         'empty-phase',
       ]);
       const retained = retainedWorkflowPopupProjection(slice);
-      const model = workflowRunModel({
-        taskGroups: retained.taskGroups,
-        rows: retained.rows,
-        workflowAttemptId: slice.workflowAttemptId,
-        plan: retained.plan,
-        runSettled: false,
-        childProgress: new Map(),
-      });
+      const model = retainedWorkflowRunModel(
+        workflowRunModel({
+          taskGroups: retained.taskGroups,
+          rows: retained.rows,
+          workflowAttemptId: slice.workflowAttemptId,
+          plan: retained.plan,
+          runSettled: true,
+          childProgress: new Map(),
+        }),
+        retained,
+      );
       expect(retained.rows).toHaveLength(2_000);
       expect(retained.plan?.phases.map((phase) => phase.title)).toEqual([
+        'Stale',
         'Repeated',
         'Future',
       ]);
@@ -366,6 +410,9 @@ describe('CLI workflow-script child-stream transcript', () => {
         'Future',
         'Repeated',
       ]);
+      expect(
+        model.phases.find((phase) => phase.key === 'declared-Future')?.heading,
+      ).toMatchObject({ phaseIndex: 2, phaseTotal: 3 });
       expect(model.phases.map((phase) => phase.tasks.length)).toEqual([
         0, 0, 1_999,
       ]);
@@ -376,7 +423,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       seedWorkflowStreamMeta();
       openTranscriptReader(STREAM_ID);
       syncStreamLog(defaultSession(), STREAM_ID);
-      await waitFor(() => streamEntries().length === 2_005);
+      await waitFor(() => streamEntries().length === 2_006);
       expect(streamEntries().map(transcriptRowHeadline)).toContain(
         'Old workflow detail',
       );


### PR DESCRIPTION
Follow-up to #11702 for the two final Codex findings that arrived immediately before that PR was merged externally.

- Preserve current-plan issued-task knowledge across transcript eviction so compact popup fallback does not revive cutoff tasks as `Declared`.
- Keep the original declared phase array through `workflowRunModel`, then apply the CLI retention projection to the model so future phases retain their original index and total.
- Extend the popup/full-transcript lifecycle regression with the eviction window and original phase numbering.

Issue context: #11552.
Review findings: https://github.com/LionSR/TeXRA/pull/11702#discussion_r3892114289 and https://github.com/LionSR/TeXRA/pull/11702#discussion_r3892114291.