### PR TITLE
fix(workflow): recover moved call progress by journal position

### DIFF
--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -314,6 +314,15 @@ export async function runWorkflowScript(
   const priorEntries = new Map<string, WorkflowJournalEntry>(
     (options.journal ?? []).map((entry) => [entry.key, entry]),
   );
+  // The monotone journal can retain multiple content keys last seen at one
+  // index. Such an index cannot prove which implicit snapshot call owns the
+  // matching history, even though each journal result remains replayable.
+  const priorKeysByIndex = new Map<number, Set<string>>();
+  for (const entry of options.journal ?? []) {
+    const keys = priorKeysByIndex.get(entry.index) ?? new Set<string>();
+    keys.add(entry.key);
+    priorKeysByIndex.set(entry.index, keys);
+  }
   const journal = new Map<number, WorkflowJournalEntry>();
   const queue = new PQueue({ concurrency });
   const runAbort = new AbortController();
@@ -528,6 +537,19 @@ export async function runWorkflowScript(
       : undefined;
     let key = journalKey(prompt, callOptions, dependencyFingerprint);
     const progressId = plannedTask?.id ?? callOptions.id ?? `call-${index}`;
+    const prior = priorEntries.get(key);
+    let recoverySource:
+      | { readonly id: string; readonly journalProven: boolean }
+      | { readonly implicitIndex: number; readonly journalProven: true }
+      | undefined;
+    if (plannedTask !== undefined || callOptions.id !== undefined) {
+      recoverySource = { id: progressId, journalProven: prior !== undefined };
+    } else if (
+      prior !== undefined &&
+      priorKeysByIndex.get(prior.index)?.size === 1
+    ) {
+      recoverySource = { implicitIndex: prior.index, journalProven: true };
+    }
     if (
       callOptions.phase !== undefined &&
       executionState.currentPhaseIndex === -1
@@ -539,24 +561,27 @@ export async function runWorkflowScript(
       }
     }
     try {
-      executionState.issueCall({
-        id: progressId,
-        label,
-        phase: callOptions.phase,
-        kind:
-          callOptions.schema === undefined
-            ? WORKFLOW_CALL_KIND.DOCUMENT
-            : WORKFLOW_CALL_KIND.STRUCTURED,
-        agent: callOptions.agentName,
-        model: callOptions.model,
-        files: {
-          input: (callOptions.inputFiles ?? []).map((file) => basename(file)),
-          context: (callOptions.contextFiles ?? []).map((file) =>
-            basename(file),
-          ),
-          media: (callOptions.mediaFiles ?? []).map((file) => basename(file)),
+      executionState.issueCall(
+        {
+          id: progressId,
+          label,
+          phase: callOptions.phase,
+          kind:
+            callOptions.schema === undefined
+              ? WORKFLOW_CALL_KIND.DOCUMENT
+              : WORKFLOW_CALL_KIND.STRUCTURED,
+          agent: callOptions.agentName,
+          model: callOptions.model,
+          files: {
+            input: (callOptions.inputFiles ?? []).map((file) => basename(file)),
+            context: (callOptions.contextFiles ?? []).map((file) =>
+              basename(file),
+            ),
+            media: (callOptions.mediaFiles ?? []).map((file) => basename(file)),
+          },
         },
-      });
+        recoverySource,
+      );
     } catch (error) {
       throw contractFault(error);
     }
@@ -644,7 +669,6 @@ export async function runWorkflowScript(
 
     // `key` still holds journalKey(prompt, callOptions, dependencyFingerprint)
     // here: refreshDependencyIdentity only runs at launch time, below.
-    const prior = priorEntries.get(key);
     if (prior) {
       const { payload, normalizedResult } = journalValue(
         prior.result,

--- a/src/agent/workflowScript/workflowExecutionState.ts
+++ b/src/agent/workflowScript/workflowExecutionState.ts
@@ -22,9 +22,15 @@ interface WorkflowCallDefinition {
   readonly files: WorkflowExecutionCall['files'];
 }
 
+type WorkflowCallRecoverySource = (
+  { readonly id: string } | { readonly implicitIndex: number }
+) & { readonly journalProven: boolean };
+
 /** Owns canonical workflow stage/call transitions and interrupted-run hydration. */
 export class WorkflowExecutionState {
   readonly #snapshot: WorkflowExecutionSnapshot;
+  readonly #persistedCalls: readonly WorkflowExecutionCall[];
+  readonly #recoveryAt: string;
   readonly #publish: (snapshot: WorkflowExecutionSnapshot) => void;
   readonly #hasDeclaredStages: boolean;
   readonly #issuedCallIds = new Set<string>();
@@ -44,6 +50,10 @@ export class WorkflowExecutionState {
     this.#publish = options.publish;
     this.#hasDeclaredStages = options.phases.length > 0;
     const createdAt = now();
+    this.#recoveryAt = createdAt;
+    this.#persistedCalls = structuredClone(
+      options.initialSnapshot?.calls ?? [],
+    );
     const fresh: WorkflowExecutionSnapshot = {
       lifecycle: WORKFLOW_EXECUTION_LIFECYCLE.WAITING,
       stages: options.phases.map((phase, index) => ({
@@ -150,7 +160,10 @@ export class WorkflowExecutionState {
     this.#emit();
   }
 
-  issueCall(definition: WorkflowCallDefinition): void {
+  issueCall(
+    definition: WorkflowCallDefinition,
+    recoverySource?: WorkflowCallRecoverySource,
+  ): void {
     if (this.#sealed) throw new Error('Workflow execution state is sealed.');
     if (this.#issuedCallIds.has(definition.id)) {
       throw new Error(
@@ -158,9 +171,6 @@ export class WorkflowExecutionState {
       );
     }
     this.#issuedCallIds.add(definition.id);
-    let call = this.#snapshot.calls.find(
-      (candidate) => candidate.id === definition.id,
-    );
     const stageIndex =
       definition.phase === undefined
         ? -1
@@ -183,7 +193,7 @@ export class WorkflowExecutionState {
     const timestamp = now();
     // Only assign agent when the call definition supplies one. Engine issue
     // often omits agentName; a later report fills the host-resolved name.
-    // Re-issuing on resume must not wipe a hydrated agent with undefined —
+    // Re-issuing on resume must not wipe a recovered agent with undefined —
     // the journal-cache path only patches status/timestamps and would leave
     // /executions without the resolved agent after a cached replay.
     const canonical = {
@@ -195,30 +205,44 @@ export class WorkflowExecutionState {
       ...(definition.agent !== undefined && { agent: definition.agent }),
       ...(definition.model !== undefined && { model: definition.model }),
     };
-    if (!call) {
-      call = {
-        id: definition.id,
-        ...canonical,
-        attempts: [],
-        status: WORKFLOW_CALL_STATUS.PLANNED,
-        timestamps: { createdAt: timestamp, updatedAt: timestamp },
-      };
-      this.#snapshot.calls.push(call);
-    } else {
-      // A hydrated completed/cached result belongs to the prior attempt until
-      // the script re-issues the call; from here it is this attempt's call —
-      // replayed from the journal as cached, or re-run in a fresh execution
-      // window — so every attempt projects it the same way.
-      Object.assign(
-        call,
-        canonical,
-        isReusableStatus(call.status) && {
-          status: WORKFLOW_CALL_STATUS.PLANNED,
-          timestamps: { createdAt: call.timestamps.createdAt },
-        },
+    const fresh: WorkflowExecutionCall = {
+      id: definition.id,
+      ...canonical,
+      attempts: [],
+      status: WORKFLOW_CALL_STATUS.PLANNED,
+      timestamps: { createdAt: timestamp, updatedAt: timestamp },
+    };
+    let prior: WorkflowExecutionCall | undefined;
+    if (recoverySource !== undefined) {
+      const recoveryId =
+        'id' in recoverySource
+          ? recoverySource.id
+          : `call-${recoverySource.implicitIndex}`;
+      prior = this.#persistedCalls.find(
+        (candidate) => candidate.id === recoveryId,
       );
-      call.timestamps.updatedAt = timestamp;
     }
+    const call = recoverCall(
+      fresh,
+      prior,
+      this.#recoveryAt,
+      recoverySource?.journalProven ?? false,
+    );
+    Object.assign(
+      call,
+      canonical,
+      (isReusableStatus(call.status) || recoverySource?.journalProven) && {
+        status: WORKFLOW_CALL_STATUS.PLANNED,
+        timestamps: { createdAt: call.timestamps.createdAt },
+      },
+    );
+    call.timestamps.updatedAt = timestamp;
+
+    const existingIndex = this.#snapshot.calls.findIndex(
+      (candidate) => candidate.id === definition.id,
+    );
+    if (existingIndex < 0) this.#snapshot.calls.push(call);
+    else this.#snapshot.calls[existingIndex] = call;
     this.#emit();
   }
 
@@ -549,6 +573,41 @@ function closeOpenAttempts(
   );
 }
 
+function recoverCall(
+  fresh: WorkflowExecutionCall,
+  prior: WorkflowExecutionCall | undefined,
+  recoveryAt: string,
+  journalProven = false,
+): WorkflowExecutionCall {
+  if (!prior) return fresh;
+  const attempts = closeOpenAttempts(prior.attempts, recoveryAt);
+  if (isReusableCall(prior) || journalProven) {
+    return {
+      ...prior,
+      id: fresh.id,
+      label: fresh.label,
+      stageId: fresh.stageId,
+      attempts,
+      costUsd: totalAttemptCost(attempts),
+    };
+  }
+  if (
+    fresh.status !== WORKFLOW_CALL_STATUS.PLANNED &&
+    fresh.status !== WORKFLOW_CALL_STATUS.STAGE_BLOCKED
+  ) {
+    throw new Error(`Fresh workflow call ${fresh.id} is not a plan stub.`);
+  }
+  return {
+    ...fresh,
+    attempts,
+    costUsd: totalAttemptCost(attempts),
+    timestamps: {
+      createdAt: prior.timestamps.createdAt,
+      updatedAt: recoveryAt,
+    },
+  };
+}
+
 function hydrate(
   fresh: WorkflowExecutionSnapshot,
   persisted: WorkflowExecutionSnapshot | undefined,
@@ -559,35 +618,9 @@ function hydrate(
   snapshot.timestamps.createdAt = persisted.timestamps.createdAt;
   const freshIds = new Set(snapshot.calls.map((call) => call.id));
   const priorById = new Map(persisted.calls.map((call) => [call.id, call]));
-  snapshot.calls = snapshot.calls.map((call) => {
-    const prior = priorById.get(call.id);
-    if (!prior) return call;
-    const attempts = closeOpenAttempts(prior.attempts, recoveryAt);
-    if (isReusableCall(prior)) {
-      return {
-        ...prior,
-        label: call.label,
-        stageId: call.stageId,
-        attempts,
-        costUsd: totalAttemptCost(attempts),
-      };
-    }
-    if (
-      call.status !== WORKFLOW_CALL_STATUS.PLANNED &&
-      call.status !== WORKFLOW_CALL_STATUS.STAGE_BLOCKED
-    ) {
-      throw new Error(`Fresh workflow call ${call.id} is not a plan stub.`);
-    }
-    return {
-      ...call,
-      attempts,
-      costUsd: totalAttemptCost(attempts),
-      timestamps: {
-        createdAt: prior.timestamps.createdAt,
-        updatedAt: recoveryAt,
-      },
-    };
-  });
+  snapshot.calls = snapshot.calls.map((call) =>
+    recoverCall(call, priorById.get(call.id), recoveryAt),
+  );
   for (const prior of persisted.calls) {
     if (freshIds.has(prior.id)) continue;
     const attempts = closeOpenAttempts(prior.attempts, recoveryAt);

--- a/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
@@ -1083,6 +1083,334 @@ return 'guest success'`,
     expect(checkpoint?.journal.map((entry) => entry.index)).toEqual([0, 1, 2]);
   });
 
+  it('recovers moved implicit calls from their journaled positions', async () => {
+    const originalScript = `export const meta = {
+  name: 'moved-implicit-history',
+  description: 'keeps moved call history with its content identity',
+}
+const a = await agent('A')
+const b = await agent('B')
+const c = await agent('C')
+return [a, b, c]`;
+    const priorFacts = {
+      A: {
+        agent: 'agent-a',
+        model: 'model-a',
+        childExecutionId: 'aaaaaaaaaaaa' as ExecutionId,
+        childStreamId: 'agent-a#aaaaaaaaaaaa',
+        costUsd: 10,
+      },
+      B: {
+        agent: 'agent-b',
+        model: 'model-b',
+        childExecutionId: 'bbbbbbbbbbbb' as ExecutionId,
+        childStreamId: 'agent-b#bbbbbbbbbbbb',
+        costUsd: 20,
+      },
+      C: {
+        agent: 'agent-c',
+        model: 'model-c',
+        childExecutionId: 'cccccccccccc' as ExecutionId,
+        childStreamId: 'agent-c#cccccccccccc',
+        costUsd: 30,
+      },
+    } as const;
+    const completed = await runWorkflowScript({
+      script: originalScript,
+      runAgent: async (invocation) => {
+        const prompt = invocation.prompt as keyof typeof priorFacts;
+        invocation.report?.(priorFacts[prompt]);
+        return `result:${prompt}`;
+      },
+    });
+
+    const liveRunner = vi.fn(async (invocation) => {
+      expect(invocation.prompt).toBe('N');
+      invocation.report?.({
+        agent: 'agent-n',
+        model: 'model-n',
+        childExecutionId: 'nnnnnnnnnnnn' as ExecutionId,
+        childStreamId: 'agent-n#nnnnnnnnnnnn',
+        costUsd: 1,
+      });
+      return 'result:N';
+    });
+    const moved = await runWorkflowScript({
+      script: originalScript.replace(
+        `const b = await agent('B')`,
+        `await agent('N')\nconst b = await agent('B')`,
+      ),
+      initialSnapshot: completed.snapshot,
+      journal: completed.journal,
+      runAgent: liveRunner,
+    });
+
+    expect(liveRunner).toHaveBeenCalledOnce();
+    expect(moved.result).toEqual(['result:A', 'result:B', 'result:C']);
+    expect(moved.snapshot.calls).toMatchObject([
+      {
+        id: 'call-0',
+        status: 'cached',
+        agent: 'agent-a',
+        model: 'model-a',
+        childExecutionId: 'aaaaaaaaaaaa',
+        childStreamId: 'agent-a#aaaaaaaaaaaa',
+        costUsd: 10,
+        attempts: [
+          {
+            number: 1,
+            id: 'aaaaaaaaaaaa',
+            childStreamId: 'agent-a#aaaaaaaaaaaa',
+            model: 'model-a',
+            costUsd: 10,
+          },
+        ],
+      },
+      {
+        id: 'call-1',
+        status: 'completed',
+        agent: 'agent-n',
+        model: 'model-n',
+        childExecutionId: 'nnnnnnnnnnnn',
+        childStreamId: 'agent-n#nnnnnnnnnnnn',
+        costUsd: 1,
+        attempts: [
+          {
+            number: 1,
+            id: 'nnnnnnnnnnnn',
+            childStreamId: 'agent-n#nnnnnnnnnnnn',
+            model: 'model-n',
+            costUsd: 1,
+          },
+        ],
+      },
+      {
+        id: 'call-2',
+        status: 'cached',
+        agent: 'agent-b',
+        model: 'model-b',
+        childExecutionId: 'bbbbbbbbbbbb',
+        childStreamId: 'agent-b#bbbbbbbbbbbb',
+        costUsd: 20,
+        attempts: [
+          {
+            number: 1,
+            id: 'bbbbbbbbbbbb',
+            childStreamId: 'agent-b#bbbbbbbbbbbb',
+            model: 'model-b',
+            costUsd: 20,
+          },
+        ],
+      },
+      {
+        id: 'call-3',
+        status: 'cached',
+        agent: 'agent-c',
+        model: 'model-c',
+        childExecutionId: 'cccccccccccc',
+        childStreamId: 'agent-c#cccccccccccc',
+        costUsd: 30,
+        attempts: [
+          {
+            number: 1,
+            id: 'cccccccccccc',
+            childStreamId: 'agent-c#cccccccccccc',
+            model: 'model-c',
+            costUsd: 30,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('declines positional recovery when stale journal keys share an index', async () => {
+    const firstScript = `export const meta = {
+  name: 'duplicate-journal-index',
+  description: 'does not guess among stale keys at one position',
+}
+const a = await agent('A')
+const b = await agent('B')
+return [a, b]`;
+    const first = await runWorkflowScript({
+      script: firstScript,
+      runAgent: async (invocation) => {
+        invocation.report?.({
+          agent: `agent-${invocation.prompt.toLowerCase()}`,
+          costUsd: invocation.prompt === 'A' ? 10 : 20,
+        });
+        return `result:${invocation.prompt}`;
+      },
+    });
+    const second = await runWorkflowScript({
+      script: firstScript.replaceAll('B', 'C').replaceAll('b', 'c'),
+      initialSnapshot: first.snapshot,
+      journal: first.journal,
+      runAgent: async (invocation) => {
+        invocation.report?.({ agent: 'agent-c', costUsd: 30 });
+        return `result:${invocation.prompt}`;
+      },
+    });
+    const staleJournal = [
+      ...new Map(
+        [...first.journal, ...second.journal].map((entry) => [
+          entry.key,
+          entry,
+        ]),
+      ).values(),
+    ];
+    expect(staleJournal.filter((entry) => entry.index === 1)).toHaveLength(2);
+
+    second.snapshot.calls.reverse();
+    const restored = await runWorkflowScript({
+      script: firstScript,
+      initialSnapshot: second.snapshot,
+      journal: staleJournal,
+      runAgent: vi.fn(() => Promise.reject(new Error('must replay'))),
+    });
+
+    expect(restored.result).toEqual(['result:A', 'result:B']);
+    expect(
+      restored.snapshot.calls.find((call) => call.id === 'call-0'),
+    ).toMatchObject({
+      status: 'cached',
+      agent: 'agent-a',
+      costUsd: 10,
+    });
+    const restoredB = restored.snapshot.calls.find(
+      (call) => call.id === 'call-1',
+    );
+    expect(restoredB).toMatchObject({ status: 'cached', attempts: [] });
+    expect(restoredB?.agent).toBeUndefined();
+    expect(restoredB?.costUsd).toBeUndefined();
+  });
+
+  it.each(['queued', 'running'] as const)(
+    'preserves journal-proven metadata from a lagging %s snapshot',
+    async (status) => {
+      const laggingScript = `export const meta = {
+  name: 'lagging-journal-snapshot',
+  description: 'journal proof outranks lagging snapshot status',
+}
+return await agent('proven result')`;
+      const completed = await runWorkflowScript({
+        script: laggingScript,
+        runAgent: async (invocation) => {
+          invocation.report?.({
+            agent: 'proven-agent',
+            model: 'proven-model',
+            childExecutionId: 'pppppppppppp' as ExecutionId,
+            childStreamId: 'proven#pppppppppppp',
+            costUsd: 7,
+          });
+          return 'cached result';
+        },
+      });
+      const lagging = structuredClone(completed.snapshot);
+      lagging.lifecycle = 'active';
+      lagging.timestamps.completedAt = undefined;
+      lagging.calls[0]!.status = status;
+      lagging.calls[0]!.timestamps.completedAt = undefined;
+      lagging.calls[0]!.attempts[0]!.completedAt = undefined;
+
+      const snapshots: WorkflowExecutionSnapshot[] = [];
+      const replayed = await runWorkflowScript({
+        script: laggingScript,
+        initialSnapshot: lagging,
+        journal: completed.journal,
+        runAgent: vi.fn(() => Promise.reject(new Error('must replay'))),
+        onSnapshot: (snapshot) => {
+          snapshots.push(snapshot);
+        },
+      });
+      const call = replayed.snapshot.calls[0]!;
+
+      expect(call).toMatchObject({
+        id: 'call-0',
+        status: 'cached',
+        agent: 'proven-agent',
+        model: 'proven-model',
+        childExecutionId: 'pppppppppppp',
+        childStreamId: 'proven#pppppppppppp',
+        costUsd: 7,
+        attempts: [
+          {
+            number: 1,
+            id: 'pppppppppppp',
+            childStreamId: 'proven#pppppppppppp',
+            model: 'proven-model',
+            costUsd: 7,
+            completedAt: expect.any(String),
+          },
+        ],
+      });
+      expect(
+        snapshots.some((snapshot) => snapshot.calls[0]?.status === 'completed'),
+      ).toBe(false);
+    },
+  );
+
+  it.each(['failed', 'cancelled', 'skipped'] as const)(
+    'starts an implicit %s call clean without journal recovery proof',
+    async (status) => {
+      const implicitScript = `export const meta = {
+  name: 'implicit-legacy-reset',
+  description: 'resets unproven implicit history',
+}
+return await agent('same position')`;
+      const prior = await runWorkflowScript({
+        script: implicitScript,
+        runAgent: async (invocation) => {
+          invocation.report?.({
+            agent: 'stale-agent',
+            model: 'stale-model',
+            childExecutionId: 'ssssssssssss' as ExecutionId,
+            childStreamId: 'stale#ssssssssssss',
+            costUsd: 9,
+          });
+          return 'stale result';
+        },
+      });
+      prior.snapshot.calls[0]!.status = status;
+
+      const resumed = await runWorkflowScript({
+        script: implicitScript,
+        initialSnapshot: prior.snapshot,
+        journal: [],
+        runAgent: async (invocation) => {
+          invocation.report?.({
+            agent: 'fresh-agent',
+            model: 'fresh-model',
+            childExecutionId: 'ffffffffffff' as ExecutionId,
+            childStreamId: 'fresh#ffffffffffff',
+            costUsd: 1,
+          });
+          return 'fresh result';
+        },
+      });
+
+      expect(resumed.snapshot.calls).toMatchObject([
+        {
+          id: 'call-0',
+          status: 'completed',
+          agent: 'fresh-agent',
+          model: 'fresh-model',
+          childExecutionId: 'ffffffffffff',
+          childStreamId: 'fresh#ffffffffffff',
+          costUsd: 1,
+          attempts: [
+            {
+              number: 1,
+              id: 'ffffffffffff',
+              childStreamId: 'fresh#ffffffffffff',
+              model: 'fresh-model',
+              costUsd: 1,
+            },
+          ],
+        },
+      ]);
+    },
+  );
+
   it('round-trips an undefined agent result explicitly', async () => {
     const store = getExecutionStore(executionId);
     const undefinedScript = `export const meta = {


### PR DESCRIPTION
## Summary

- select implicit call snapshot recovery from the prior index recorded by the matching content-keyed journal entry
- keep explicit `options.id` and `meta.tasks` recovery keyed by their stable IDs
- keep an immutable copy of persisted calls so an inserted call cannot overwrite the history needed by a later moved call
- decline positional history recovery when retained journal keys make a prior index ambiguous, while still replaying the matching journal result
- preserve metadata and close attempts when journal proof outranks a lagging queued/running snapshot
- reset implicit calls with no journal proof, including failed, cancelled, and skipped legacy calls

Closes #11524

## Issue acceptance gates

- An inserted call starts without the displaced call's attempts, cost, agent/model, child execution, or stream links.
- Moved cached calls keep their own prior histories and links.
- Explicit stable-ID recovery remains compatible.
- The persisted snapshot wire and hash-derived IDs are unchanged.

## Single source of truth

The content-keyed workflow journal remains the canonical recovery provenance. `runWorkflowScript` translates a journal hit's recorded index into the persisted-call recovery source for implicit calls. `WorkflowExecutionState` owns hydration from that selected source.

## Duplication and abstraction budget

The existing call hydration logic is shared by constructor hydration and issue-time selected recovery. No persisted fields, exported APIs, or pass-through layers were added.

## Net elements (R6)

n/a. This is a bug fix, not a refactor-class PR.

## Consumer counts (R8)

n/a. No emit path or export was deleted or rerouted.

## Host impact

Extension: Correct workflow progress costs, attempts, resolved agent/model, and child links after script insertion or reorder.

Desktop: Same correction through the shared workflow execution snapshot.

CLI: Same correction through the shared workflow execution snapshot.

## Scheduled refactoring

None.

## Validation

- Five focused workflow suites: 202 passed
- Workflow persistence suite: 44 passed, including moved history, duplicate-index, lagging-snapshot, and conservative legacy reset regressions
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- changed-file ESLint and Prettier checks
- architecture suites: 101 passed
- `npm run check:dead-code-ratchet`
- `npm run compile:fast`
