### PR TITLE
refactor(agent): privatize internal flow types

### DIFF
--- a/src/agent/implementations/flows/reflection/output/compileCheck.ts
+++ b/src/agent/implementations/flows/reflection/output/compileCheck.ts
@@ -35,7 +35,7 @@ import {
 } from './compiledPdfArtifacts';
 import { getOutputFilesByRound, type OutputState } from './outputState';
 
-export interface CompileCheckContext {
+interface CompileCheckContext {
   fileService: TaskRunFileService;
   outputState: OutputState;
   logger: AgentTrace;
@@ -45,7 +45,7 @@ export interface CompileCheckContext {
 const COMPILE_LOG_EXCERPT_CHAR_LIMIT = 12000;
 const MIN_TIMEOUT_MS = LATEX_CONFIG_RANGES.workflowAutoCompileTimeoutMs.min;
 
-export interface CompileCheckResult {
+interface CompileCheckResult {
   artifacts: CompiledPdfArtifact[];
   /** Absent when no check ran at all, which is not the same as zero failures. */
   compileResult?: CompileResult;

--- a/src/agent/implementations/flows/reflection/output/compiledPdfArtifacts.ts
+++ b/src/agent/implementations/flows/reflection/output/compiledPdfArtifacts.ts
@@ -20,7 +20,7 @@ export interface CompiledPdfArtifact {
   latestPdf: RunStorageFileLocation;
 }
 
-export interface PublishCompiledPdfOptions {
+interface PublishCompiledPdfOptions {
   runDirectory: string;
   executionId: ExecutionId;
   round: number;

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -59,7 +59,7 @@ import {
 import { ToolUseSessionLifecycle } from './ToolUseSessionLifecycle';
 import type { ToolUseServices } from './ToolUseServices';
 
-export interface RunToolUseFlowInput extends BaseFlowContextInit {
+interface RunToolUseFlowInput extends BaseFlowContextInit {
   /** Abort this run's sticky signal. */
   interrupt: () => void;
   setting: AgentToolUseSetting;
@@ -100,7 +100,7 @@ export interface RunToolUseFlowInput extends BaseFlowContextInit {
   onFlowRecordDisposition?: (disposition: 'preserve' | 'delete') => void;
 }
 
-export interface RunToolUseFlowResult {
+interface RunToolUseFlowResult {
   outcome: RunOutcome | typeof STREAM_PHASE.WAITING;
   response?: string;
   /** Workspace-relative paths of files edited by tool calls during this session. */
@@ -140,7 +140,7 @@ export interface ToolUseFlowContext {
  * flow owns the pairing: every `attach` is followed by exactly one `detach`,
  * including when `attach` itself throws after wiring part of the host up.
  */
-export interface ToolUseFlowAttachment {
+interface ToolUseFlowAttachment {
   attach(context: ToolUseFlowContext): void;
   detach(context: ToolUseFlowContext): void;
 }

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -32,12 +32,7 @@ import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { ModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityKey';
 import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
 import { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
-import {
-  runToolUseFlow,
-  type RunToolUseFlowResult,
-  type RunToolUseFlowInput,
-  type ToolUseFlowAttachment,
-} from '@agent/implementations/flows/tooluse/runToolUseFlow';
+import { runToolUseFlow } from '@agent/implementations/flows/tooluse/runToolUseFlow';
 import {
   parseToolUseShared,
   type StateSlicesSnapshot,
@@ -91,6 +86,9 @@ const VALID_TOOL_USE_SHARED = {
   shouldSkipCycle: false,
   stateSlices: null,
 };
+
+type RunToolUseFlowInput = Parameters<typeof runToolUseFlow>[0];
+type ToolUseFlowAttachment = NonNullable<Parameters<typeof runToolUseFlow>[2]>;
 
 // Stored shared state left by a run whose handler identity was persisted.
 function activeHandlerShared(): Record<string, unknown> {
@@ -307,7 +305,7 @@ async function runPersistedFlow(
   streamId: StreamTabId,
   resume: ToolUseResumeData | undefined,
   options: PersistedFlowRunOptions = {},
-): Promise<RunToolUseFlowResult> {
+) {
   const { attachment } = options;
   const session = options.session ?? createTestSession();
   const config = options.config ?? resume?.agentConfig ?? CONFIG;

--- a/src/test-kernel/agent/output/compileCheckTestUtils.ts
+++ b/src/test-kernel/agent/output/compileCheckTestUtils.ts
@@ -2,7 +2,7 @@
 import * as path from 'node:path';
 
 // Local imports
-import type { CompileCheckContext } from '@agent/implementations/flows/reflection/output/compileCheck';
+import type { runCompileCheck } from '@agent/implementations/flows/reflection/output/compileCheck';
 import type { OutputState } from '@agent/implementations/flows/reflection/output/outputState';
 import type {
   ExecutionId,
@@ -51,7 +51,7 @@ export function outputFile(
 export function compileContext(
   executionId: ExecutionId,
   outputState: OutputState,
-): CompileCheckContext {
+): Parameters<typeof runCompileCheck>[0] {
   return {
     fileService: new TaskRunFileService(executionId),
     outputState,


### PR DESCRIPTION
## Summary

- make six implementation-only flow interfaces private to their owning modules
- derive the few test-only input shapes from the exported functions instead of maintaining test-facing type exports
- preserve every runtime value, call shape, return value, and attachment lifecycle

## Net elements (R6)

- files: 5 modified, 0 added, 0 deleted
- public exports: 6 removed, 0 added
- test-local aliases: 2 added from public function parameters
- runtime declarations, dependencies, schemas, and behavior: 0 changed
- net diff: 13 insertions, 15 deletions, for 2 fewer lines

## Consumer counts (R8)

- `CompileCheckContext`: 0 external production consumers and 1 test helper importer
- `CompileCheckResult`: 0 external consumers; its behavioral suite already derives the return type
- `PublishCompiledPdfOptions`: 0 external consumers
- `RunToolUseFlowInput`: 0 external production consumers and 1 test importer
- `RunToolUseFlowResult`: 0 external production consumers and 1 test return annotation
- `ToolUseFlowAttachment`: 0 external production consumers and 1 test importer
- no flow execution, compile check, PDF publication, resume, or attachment path was removed

## Validation

- focused Vitest: `SessionResumeRetrieval`, `CompileCheck`, and `CompiledPdfArtifacts` (3 files, 68 tests passed)
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- targeted ESLint and Prettier checks
- `corepack pnpm run check:dead-code-ratchet` (315 current findings and 315 baselined)
- `git diff --check`

The isolated CI static checks, build, and kernel shards are the final full gates.