### PR TITLE
fix(workflow): compact successful journals

### DIFF
--- a/src/agent/workflowScript/persistence.ts
+++ b/src/agent/workflowScript/persistence.ts
@@ -21,8 +21,8 @@ import {
   type WorkflowScriptRunResult,
 } from './types';
 
-// v4: journal identity is the content key; v3 records could hold one key at
-// two indices after script drift and fail loudly rather than being translated.
+// v4: journal identity is the content key. Index is only the last matched
+// invocation position, so stale v4 journals may legitimately repeat it.
 const WORKFLOW_SCRIPT_CHECKPOINT_SCHEMA_VERSION = 4;
 
 const PersistedJsonValueSchema = z.discriminatedUnion('kind', [
@@ -202,9 +202,10 @@ async function runPersistedWorkflowScriptLocked(
   // and args, keep the journal: an entry replays only on a matching
   // prompt/execution-options hash, so drifted calls re-execute while
   // presentation-only edits, unchanged calls, and calls that merely moved
-  // stay free. The union is monotone by key — a re-visited key overwrites
-  // its entry (and its position); entries this run never reached remain, so
-  // an args-driven branch taken again later still replays.
+  // stay free. Keep the key union while this invocation is running so a
+  // crash can resume prior branches and newly completed work together. A
+  // successful invocation replaces that recovery union with its own bounded
+  // journal below.
   const script = requestedScript ?? prior?.script;
   if (script === undefined) {
     throw new Error(
@@ -266,6 +267,9 @@ async function runPersistedWorkflowScriptLocked(
     // checkpoint store may belong to its orchestrator.
     onJournalEntry: persistEntry,
   });
+  // Success makes this invocation authoritative. Replace the recovery union
+  // atomically so superseded revisions cannot grow the durable cache forever.
+  journalByKey.clear();
   for (const entry of result.journal) journalByKey.set(entry.key, entry);
   await persistCheckpoint();
   return result;

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -298,6 +298,7 @@ export async function runWorkflowScript(
     fingerprintAgentDependencies,
     onEvent,
     onJournalEntry,
+    onJournalEntryConsumed,
     onControl,
   } = options;
   const concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
@@ -310,7 +311,7 @@ export async function runWorkflowScript(
   // (a duplicate is a contract fault below) and the durable child id is
   // already index-free, so a call that moved because the script inserted,
   // removed, or reordered a sibling still replays. `index` stays on every
-  // entry as an ordering fact for the resume journal and cost attribution.
+  // entry as the last position where this invocation matched it.
   const priorEntries = new Map<string, WorkflowJournalEntry>(
     (options.journal ?? []).map((entry) => [entry.key, entry]),
   );
@@ -674,10 +675,12 @@ export async function runWorkflowScript(
         prior.result,
         'Cached agent() result',
       );
-      journal.set(index, { index, key, result: normalizedResult });
+      const entry = { index, key, result: normalizedResult };
+      journal.set(index, entry);
       executionState.settleCall(progressId, {
         status: WORKFLOW_CALL_STATUS.CACHED,
       });
+      onJournalEntryConsumed?.(entry);
       return payload;
     }
     // The execution snapshot solely owns the queued fact (QUEUED status); no
@@ -836,20 +839,18 @@ export async function runWorkflowScript(
       let callSettled = false;
       try {
         const committed = await journalCommitFence.commit(async () => {
-          await persistJournalEntry({
-            index,
-            key,
-            result: normalizedResult,
-          });
+          const entry = { index, key, result: normalizedResult };
+          await persistJournalEntry(entry);
           // The durable journal write is the commit point: once the entry is
           // persisted, a resume replays this call from cache, so a later
-          // throw — including a transition observer throwing inside
-          // `settleCall`'s synchronous publish — must not rewrite the call
-          // to failed and leave the snapshot contradicting the journal.
+          // throw — including a synchronous observer throwing below — must
+          // not rewrite the call to failed and leave the snapshot
+          // contradicting the journal.
           callSettled = true;
           executionState.settleCall(progressId, {
             status: WORKFLOW_CALL_STATUS.COMPLETED,
           });
+          onJournalEntryConsumed?.(entry);
         });
         if (!committed) return undefined;
       } catch (error) {

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -388,8 +388,11 @@ export interface WorkflowScriptRunOptions {
   onJournalEntry?: (entry: WorkflowJournalEntry) => void | Promise<void>;
   /**
    * Synchronous observer for every validated result this invocation consumes,
-   * whether replayed or live. A live entry fires only after onJournalEntry has
-   * durably committed it and before the result becomes visible to the script.
+   * whether replayed or live. It fires after the call reaches its terminal
+   * cached/completed status and before the result becomes visible to the
+   * script; an onTransition throw during that status prevents both this
+   * callback and consumption. A live entry is already durably committed by
+   * onJournalEntry when this observer fires.
    */
   onJournalEntryConsumed?: (entry: WorkflowJournalEntry) => void;
   /**

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -308,9 +308,9 @@ export type WorkflowAgentRunner = (
 
 /**
  * One completed agent() call, cached for resume. Identity is `key` alone;
- * `index` records where the call sat in the run that journaled it, for
- * ordering and cost attribution, and is rewritten when a resumed run replays
- * the entry at a new position.
+ * `index` records the last invocation position that matched the entry. It is
+ * rewritten when a resumed run replays the entry at a new position and need
+ * not be unique in a stale recovery journal.
  */
 export interface WorkflowJournalEntry {
   index: number;
@@ -386,6 +386,12 @@ export interface WorkflowScriptRunOptions {
    * host restart cannot expose work whose journal entry was never persisted.
    */
   onJournalEntry?: (entry: WorkflowJournalEntry) => void | Promise<void>;
+  /**
+   * Synchronous observer for every validated result this invocation consumes,
+   * whether replayed or live. A live entry fires only after onJournalEntry has
+   * durably committed it and before the result becomes visible to the script.
+   */
+  onJournalEntryConsumed?: (entry: WorkflowJournalEntry) => void;
   /**
    * Durable-persistence hook: receives an isolated copy of the canonical
    * snapshot after a transition, with writes coalesced under backpressure —

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -681,6 +681,42 @@ return await parallel([
     expect(order).toEqual(['runner', 'checkpoint:1', 'completed:call-1']);
   });
 
+  it('observes validated cache hits and live results after durable commit', async () => {
+    const cached = await runScript(`return await agent('cached')`);
+    const order: string[] = [];
+    const run = await runWorkflowScript({
+      script: `${META}
+const cached = await agent('cached')
+log('after cache')
+const live = await agent('live')
+log('after live')
+return [cached, live]`,
+      journal: cached.journal,
+      runAgent: async ({ prompt }) => {
+        order.push(`runner:${prompt}`);
+        return `result:${prompt}`;
+      },
+      onJournalEntry: async (entry) => {
+        await delay(5);
+        order.push(`checkpoint:${entry.index}`);
+      },
+      onJournalEntryConsumed: (entry) => {
+        order.push(`consumed:${entry.index}`);
+      },
+      onEvent: (event) => order.push(event.message),
+    });
+
+    expect(run.result).toEqual(['result:cached', 'result:live']);
+    expect(order).toEqual([
+      'consumed:0',
+      'after cache',
+      'runner:live',
+      'checkpoint:1',
+      'consumed:1',
+      'after live',
+    ]);
+  });
+
   it('reports a synchronous snapshot-write failure instead of hanging', async () => {
     // A synchronous `onSnapshot` throw runs the coalescing writer's drain to
     // completion (`catch` and `finally` included) inside `publish`, so the

--- a/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
@@ -1038,14 +1038,105 @@ return 'guest success'`,
     // stored one.
     expect(retryRunner).toHaveBeenCalledTimes(1);
     expect(evolved.result).toEqual(['v1:first', 'v2:changed']);
-    await expect(
-      readWorkflowScriptCheckpoint(
-        getExecutionStore(executionId),
-        'stable-call',
-      ),
-    ).resolves.toMatchObject({
-      script: expect.stringContaining(`agent('changed')`),
+    const checkpoint = await readWorkflowScriptCheckpoint(
+      getExecutionStore(executionId),
+      'stable-call',
+    );
+    expect(checkpoint?.script).toContain(`agent('changed')`);
+    expect(checkpoint?.journal).toHaveLength(2);
+    expect(checkpoint?.journal.map((entry) => entry.index)).toEqual([0, 1]);
+    expect(checkpoint?.journal.map((entry) => entry.result)).toEqual([
+      'v1:first',
+      'v2:changed',
+    ]);
+  });
+
+  it('keeps a failed revision union for resume, then compacts on success', async () => {
+    const store = getExecutionStore(executionId);
+    await runPersistedWorkflowScript({
+      store,
+      checkpointId: 'revision-failure',
+      script,
+      runAgent: async ({ prompt }) => `v1:${prompt}`,
     });
+    const revised = script.replace(`agent('second')`, `agent('changed')`);
+    const failingRevision = revised.replace(
+      'return [first, second]',
+      `throw new Error('revision failed')`,
+    );
+
+    await expect(
+      runPersistedWorkflowScript({
+        store,
+        checkpointId: 'revision-failure',
+        script: failingRevision,
+        runAgent: async ({ prompt }) => `v2:${prompt}`,
+      }),
+    ).rejects.toThrow('revision failed');
+
+    const failed = await readWorkflowScriptCheckpoint(
+      store,
+      'revision-failure',
+    );
+    expect(failed?.journal.map((entry) => entry.result)).toEqual([
+      'v1:first',
+      'v1:second',
+      'v2:changed',
+    ]);
+    expect(failed?.journal.map((entry) => entry.index)).toEqual([0, 1, 1]);
+
+    const resumedRunner = vi.fn(() => Promise.reject(new Error('must replay')));
+    await runPersistedWorkflowScript({
+      store,
+      checkpointId: 'revision-failure',
+      script: revised,
+      runAgent: resumedRunner,
+    });
+    expect(resumedRunner).not.toHaveBeenCalled();
+    const completed = await readWorkflowScriptCheckpoint(
+      store,
+      'revision-failure',
+    );
+    expect(completed?.journal.map((entry) => entry.result)).toEqual([
+      'v1:first',
+      'v2:changed',
+    ]);
+    expect(completed?.journal.map((entry) => entry.index)).toEqual([0, 1]);
+  });
+
+  it('bounds prompt and dependency revisions to the successful invocation', async () => {
+    const store = getExecutionStore(executionId);
+    const promptScript = (revision: number) =>
+      `${script.replace(`agent('second')`, `agent('revision-${revision}')`)}`;
+    for (let revision = 0; revision < 4; revision += 1) {
+      await runPersistedWorkflowScript({
+        store,
+        checkpointId: 'prompt-revisions',
+        script: promptScript(revision),
+        runAgent: async ({ prompt }) => prompt,
+      });
+      await expect(
+        readWorkflowScriptCheckpoint(store, 'prompt-revisions'),
+      ).resolves.toMatchObject({ journal: [{ index: 0 }, { index: 1 }] });
+    }
+
+    const dependencyScript = `export const meta = {
+  name: 'dependency-revisions',
+  description: 'bounds dependency fingerprint revisions',
+}
+return await agent('edit', { inputFiles: ['paper.tex'] })`;
+    for (let revision = 0; revision < 4; revision += 1) {
+      await runPersistedWorkflowScript({
+        store,
+        checkpointId: 'dependency-revisions',
+        script: dependencyScript,
+        fingerprintAgentDependencies: async () => `revision-${revision}`,
+        runAgent: async () => revision,
+      });
+      await expect(
+        readWorkflowScriptCheckpoint(store, 'dependency-revisions'),
+      ).resolves.toMatchObject({ journal: [{ index: 0, result: revision }] });
+    }
   });
 
   it('replays a call that moved because a sibling was inserted before it', async () => {

--- a/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
@@ -178,6 +178,9 @@ describe('createWorkflowScriptStrategy', () => {
     expect(ports.recordCost).toHaveBeenCalledWith(0);
     const delivery = await strategy.formatDelivery(turn, 0);
     expect(delivery).toContain('Using saved result');
+    expect(delivery).toContain(
+      '"files":[{"path":"paper.tex","added":12,"removed":8}]',
+    );
   });
 
   it('passes JSON arguments through and formats a zero-call result', async () => {
@@ -304,6 +307,59 @@ throw new Error('script failed after replay')`;
     expect(errText).toContain('"phaseCount":0');
     expect(errText).toContain('"taskDone":1');
     expect(errText).toContain('"taskTotal":1');
+  });
+
+  it('settles failures from the touched journal without stale entries', async () => {
+    const name = 'attempt-local-settlement';
+    const baselineScript = `export const meta = {
+  name: '${name}',
+  description: 'seeds stale recovery entries',
+}
+await agent('stale file')
+return await agent('malformed stale')`;
+    const staleResult: AgentFinalResult = {
+      ...finalResult,
+      outputs: [{ ...finalResult.outputs[0], relativePath: 'stale.tex' }],
+    };
+    await runPersistedWorkflowScript({
+      store: getExecutionStore(executionId),
+      checkpointId: checkpointIdFor(name),
+      script: baselineScript,
+      runAgent: async ({ prompt }) =>
+        prompt === 'stale file' ? staleResult : { malformed: true },
+    });
+    clearStoreCache();
+
+    const currentResult: AgentFinalResult = {
+      ...finalResult,
+      cost: 0.25,
+      outputs: [{ ...finalResult.outputs[0], relativePath: 'current.tex' }],
+    };
+    const ports = fakePorts();
+    const strategy = createWorkflowScriptStrategy(
+      strategyParams({
+        name,
+        script: `export const meta = {
+  name: '${name}',
+  description: 'fails after current work',
+}
+await agent('current file')
+throw new Error('current revision failed')`,
+        createRunAgent: (hooks) => async (invocation) => {
+          hooks.onCost(invocation, currentResult.cost);
+          return currentResult;
+        },
+      }),
+    );
+
+    await expect(strategy.launch(ports, new AbortController())).rejects.toThrow(
+      'current revision failed',
+    );
+    expect(ports.recordCost.mock.calls).toEqual([[0.25], [0.25]]);
+    const errText = await strategy.formatError(null, new Error('boom'));
+    expect(errText).toContain('current.tex');
+    expect(errText).not.toContain('stale.tex');
+    expect(errText).toContain('"costUsd":0.25');
   });
 
   it('keeps the delivery summary at the last persisted snapshot when snapshot writes fail', async () => {

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -12,13 +12,11 @@
  */
 
 // Local imports
-import {
-  readWorkflowScriptCheckpoint,
-  type WorkflowScriptRunOptions,
-} from '@agent/workflowScript';
+import type { WorkflowScriptRunOptions } from '@agent/workflowScript';
 import type {
   WorkflowAgentInvocation,
   WorkflowAgentRunner,
+  WorkflowJournalEntry,
   WorkflowScriptRunResult,
 } from '@agent/workflowScript';
 import type { AgentTrace } from '@agent/trace';
@@ -248,6 +246,11 @@ export function createWorkflowScriptStrategy(
       // Physical-attempt callbacks are the current-invocation boundary: replay
       // and stable recovery emit none, while every model attempt emits one.
       const attemptCost = createWorkflowAttemptCostTracker();
+      const attemptJournalByKey = new Map<string, WorkflowJournalEntry>();
+      const attemptJournal = (): WorkflowJournalEntry[] =>
+        [...attemptJournalByKey.values()].toSorted(
+          (left, right) => left.index - right.index,
+        );
       const runAgent = params.createRunAgent({
         onCost: (invocation, totalCostUsd) => {
           ports.recordCost(attemptCost.record(invocation, totalCostUsd ?? 0));
@@ -281,6 +284,12 @@ export function createWorkflowScriptStrategy(
           fingerprintAgentDependencies: (options) =>
             fingerprintWorkflowAgentDependencies(params.executionId, options),
           onActivity: runLog.add,
+          // This invocation's consumed results are the only entries its cost
+          // and delivery summary may claim. The engine fires after durable
+          // commit for live results and after validation for cache hits.
+          onJournalEntryConsumed: (entry) => {
+            attemptJournalByKey.set(entry.key, entry);
+          },
           onSnapshot: async (snapshot) => {
             // Persist first: only a durably written snapshot may feed the
             // delivery summary, otherwise a failed write leaves the summary
@@ -295,26 +304,19 @@ export function createWorkflowScriptStrategy(
           },
         });
       } catch (runError) {
-        // Include newly journaled calls without re-billing the pre-run
-        // baseline. A malformed checkpoint never masks the run error; live
-        // candidates already recorded through the loop remain available.
+        // Settle only entries consumed by this invocation. The durable union
+        // may contain superseded or malformed untouched recovery history.
         try {
-          const checkpoint = await readWorkflowScriptCheckpoint(
-            params.store,
-            params.checkpointId,
-          );
-          const costUsd = attemptCost.total(checkpoint?.journal ?? []);
+          const journal = attemptJournal();
+          const costUsd = attemptCost.total(journal);
           ports.recordCost(costUsd);
-          settleSummary(
-            { journal: checkpoint?.journal ?? [], snapshot: lastSnapshot },
-            costUsd,
-          );
+          settleSummary({ journal, snapshot: lastSnapshot }, costUsd);
         } catch (settlementError) {
           // The run error is what the caller must see, so settlement cannot
-          // rethrow — but dropping it silently loses this invocation's spend
-          // from the parent's accounting. Say so.
+          // rethrow. Live candidates recorded through the loop remain billed;
+          // report when the final attempt-local reconciliation could not land.
           params.logger.warn(
-            `Workflow script '${params.name}' failed and its cost could not be settled from the checkpoint; this run's spend is unbilled: ${toErrorMessage(settlementError)}`,
+            `Workflow script '${params.name}' failed and its cost could not be settled from this attempt's journal: ${toErrorMessage(settlementError)}`,
             { data: settlementError },
           );
         }
@@ -326,11 +328,12 @@ export function createWorkflowScriptStrategy(
         unregisterControls?.();
       }
 
-      // The final journal supplies only this invocation's missing/lower
-      // completed-call fallback; baseline history contributes zero.
-      const costUsd = attemptCost.total(run.journal);
+      // The attempt-local journal supplies missing/lower completed-call
+      // fallback and delivered files. Durable baseline history is irrelevant.
+      const journal = attemptJournal();
+      const costUsd = attemptCost.total(journal);
       ports.recordCost(costUsd);
-      settleSummary(run, costUsd);
+      settleSummary({ journal, snapshot: run.snapshot }, costUsd);
       return run;
     },
 


### PR DESCRIPTION
## Summary

- keep the content key as the sole recovery identity while treating `index` only as the last matched invocation position
- preserve the stale-plus-current journal union during a running or failed invocation, then atomically replace it with the successful invocation's bounded journal
- expose a synchronous engine observer for validated cache hits and durably committed live results
- settle workflow strategy cost and file summaries exclusively from entries consumed by the current invocation

## Issue acceptance gates

Closes #11523.

- A,B to A,C success compacts to A,C with unique current indices
- prompt and dependency-fingerprint revisions remain bounded
- failures retain old and new entries for resume until a later success compacts them
- stale v4 duplicate indices remain readable, with no schema bump or index-uniqueness validation
- current-invocation observation covers cache hits and live results after durable commit
- failure cost and file summaries include touched current entries, exclude superseded stale entries, charge cache hits zero, and ignore malformed untouched stale entries
- existing moved-call recovery coverage from #11705 remains green

## Single source of truth

The engine's invocation-local result journal remains the source of truth for entries consumed by one run. Persistence owns the temporary crash-recovery union and replaces it only after engine success.

## Duplication and abstraction budget

No new layer or file. One callback extends the existing engine options, and the strategy consumes it directly.

## Net elements (R6)

n/a, bug fix rather than a refactor-class PR.

## Consumer counts (R8)

n/a, no existing emit path or export was removed or rerouted.

## Host impact

Extension: workflow retries keep bounded checkpoints and accurate delivery summaries.

Desktop: same shared workflow behavior.

CLI: same shared workflow behavior.

## Scheduled refactoring

None.

## Validation

Passed:

- focused engine, persistence, cost, and strategy suites: 180 tests
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- `npm run lint`
- `npm run format:check`
- architecture suites: 101 tests
- `npm run check:dead-code-ratchet`
- `npm run compile:fast`

Additional diagnostics:

- `npm run check:dead-code` reports the six already-baselined desktop unused exports; the dead-code ratchet confirms no new finding.
- full `npm test` completed 9,974 passing tests and reported four unrelated timing/state failures in SettingsNavigation, DesktopAgentExecution, and DirectLspAdapter. DirectLspAdapter and SettingsNavigation passed on focused rerun; three existing DesktopAgentExecution merge-notification assertions still fail locally. No changed file is in those suites or desktop code.
