### PR TITLE
fix(follow-up): bound terminal tombstones

### DIFF
--- a/src/agent/followUp/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/followUp/ToolUseFollowUpQueueManager.ts
@@ -69,13 +69,16 @@ type FollowUpSubmission =
  * such as a child whose activation outlives its parent's teardown, cannot
  * recreate the queue and trigger a resume of a run that is gone; only an
  * explicit claim reopens the stream. Stream ids embed their execution id, so
- * the mark never collides with a later run, and a session accrues one per
- * ended stream.
+ * the mark never collides with a later run. Tombstones are bounded because
+ * evicting an old mark only lets a persisted-authority check recreate it.
  */
 export class ToolUseFollowUpQueue {
   static readonly DELIVERY_ID_CAP = 1000;
+  static readonly TERMINALIZED_CAP = 500;
   private readonly entries = new Map<StreamTabId, QueueEntry>();
-  private readonly terminalized = new Set<StreamTabId>();
+  private readonly terminalized = createBoundedIdSet<StreamTabId>(
+    ToolUseFollowUpQueue.TERMINALIZED_CAP,
+  );
   private readonly releaseObservers = new Set<
     (streamId: StreamTabId) => void
   >();

--- a/src/agent/followUp/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/followUp/ToolUseFollowUpQueueManager.ts
@@ -69,8 +69,9 @@ type FollowUpSubmission =
  * such as a child whose activation outlives its parent's teardown, cannot
  * recreate the queue and trigger a resume of a run that is gone; only an
  * explicit claim reopens the stream. Stream ids embed their execution id, so
- * the mark never collides with a later run. Tombstones are bounded because
- * evicting an old mark only lets a persisted-authority check recreate it.
+ * the mark never collides with a later run. Tombstones are bounded; after
+ * eviction, callers must revalidate persisted authority before recoverable
+ * admission.
  */
 export class ToolUseFollowUpQueue {
   static readonly DELIVERY_ID_CAP = 1000;

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -326,6 +326,32 @@ describe('ToolUseFollowUpQueue claim exclusivity', () => {
   });
 });
 
+describe('ToolUseFollowUpQueue terminal tombstones', () => {
+  it('evicts the least-recently-used tombstone at the historical cap', () => {
+    const followUps = new ToolUseFollowUpQueue();
+    const oldest = id('stream:terminalized-0');
+    followUps.terminalize(oldest);
+    for (
+      let index = 1;
+      index <= ToolUseFollowUpQueue.TERMINALIZED_CAP;
+      index += 1
+    ) {
+      followUps.terminalize(id(`stream:terminalized-${index}`));
+    }
+
+    expect(
+      followUps.submit(oldest, { text: 'after eviction' }, 'recoverable'),
+    ).toMatchObject({ kind: 'queued' });
+    expect(
+      followUps.submit(
+        id('stream:terminalized-1'),
+        { text: 'still terminalized' },
+        'recoverable',
+      ),
+    ).toEqual({ kind: 'refused' });
+  });
+});
+
 describe('presentFollowUpResult', () => {
   it('words only refusals, with a failed wake as information', () => {
     expect(presentFollowUpResult({ status: 'sent' })).toEqual({

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -327,7 +327,7 @@ describe('ToolUseFollowUpQueue claim exclusivity', () => {
 });
 
 describe('ToolUseFollowUpQueue terminal tombstones', () => {
-  it('evicts the least-recently-used tombstone at the historical cap', () => {
+  it('evicts the oldest tombstone at the historical cap', () => {
     const followUps = new ToolUseFollowUpQueue();
     const oldest = id('stream:terminalized-0');
     followUps.terminalize(oldest);


### PR DESCRIPTION
## Summary

- cap terminalized follow-up stream tombstones at the historical 500-entry bound
- reuse the existing `createBoundedIdSet` primitive instead of maintaining an unbounded `Set`
- add a regression proving the oldest tombstone is evicted while the remaining bound still refuses recoverable submission

## Issue acceptance gates

Closes #11325.

- Boundedness: `terminalized` now uses the existing bounded ID-set implementation with a 500-entry cap, and the regression exercises cap-plus-one tombstones.
- `claimLive` ordering: current `main` no longer has continuation generation fencing. Commit `bf635cda984aa4e1f5f09ee470f8addcbfa22be4` removed `generationId` from `claimLive` and all related generation-mismatch paths shortly after #11325 was filed. There is therefore no rejected generation-mismatched claim that can clear a tombstone on current code, and this PR does not reintroduce the deleted mechanism.

## Single source of truth

`src/utils/core/boundedIdSet.ts` remains the project primitive for capped in-memory ID guards. `ToolUseFollowUpQueue.TERMINALIZED_CAP` owns this queue's 500-entry policy.

## Duplication and abstraction budget

No new abstraction. The queue reuses `createBoundedIdSet`, which it already uses for admitted delivery IDs.

## Net elements (R6)

- Files: 0 added, 0 deleted, 2 modified
- Exported symbols: 0 added, 0 deleted
- Classes/interfaces/enums: 0 added, 0 deleted
- Net LoC: +30

## Consumer counts (R8)

n/a. No emit path or export is deleted or rerouted.

## Host impact

Extension: None beyond bounded session memory for terminalized follow-up streams.

Desktop: Same.

CLI: Same.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts` (14 passed)
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/followUp` (18 files, 161 passed)
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/architecture` (15 files, 101 passed)
- `corepack pnpm test` (822 files passed, 1 skipped; 9,990 tests passed, 6 skipped)
- `corepack pnpm run typecheck`
- `corepack pnpm run lint`
- `corepack pnpm run format:check`
- `corepack pnpm run check:dead-code-ratchet`
- `corepack pnpm run check:guidance-refs`
- `corepack pnpm run check:browser-safe-utils`
- `corepack pnpm run compile:fast`
- `git diff --check`
