### PR TITLE
fix(follow-up): refuse terminal parent child-stream delivery

### DIFF
--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -784,20 +784,24 @@ export function startChildRunLoop<TTurn>(
     childStreamId,
     strategy.ownsBackgroundProcess === true,
   );
-  // The parent counts this child as active from here until the final delivery
-  // below has landed, whatever turn handles come and go in between: a child
-  // result can therefore never reach a parent whose queue already went terminal.
+  // Native children have no persistent child-stream handle between turns, so
+  // retain their parent lineage until final delivery. Child-stream loops own
+  // their lifecycle through that stream instead; reserving parent delivery for
+  // them would make a terminal parent look recoverable after it can no longer
+  // accept either user input or the child's result.
   let activationDetached = false;
-  const releaseChildActivation = runSession.executions.reserveChildActivation({
-    executionId,
-    parentStreamId,
-    childStreamId,
-    interrupt: () => loop.interrupt(),
-    detach: () => {
-      activationDetached = true;
-    },
-    isDetached: () => activationDetached,
-  });
+  const releaseChildActivation = childStream
+    ? () => undefined
+    : runSession.executions.reserveChildActivation({
+        executionId,
+        parentStreamId,
+        childStreamId,
+        interrupt: () => loop.interrupt(),
+        detach: () => {
+          activationDetached = true;
+        },
+        isDetached: () => activationDetached,
+      });
   let sessionOwnershipReleased = false;
   const releaseSessionOwnershipOnce = (): void => {
     if (sessionOwnershipReleased) return;

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -282,11 +282,10 @@ export interface ChildRunStrategy<TTurn> {
   ): ResultMeta | undefined | Promise<ResultMeta | undefined>;
 
   /**
-   * Where a turn's delivery should be sent. Defaults to the run's static
-   * `parentStreamId` when omitted. Native strategies track the live run
-   * handle's `deliveryTargetStreamId`, which goes `undefined` once the child
-   * is detached from its orchestrator (see `AgentExecutionHandle.detach`), so
-   * a detached child's results stop routing to the old parent.
+   * Where a turn's delivery should be sent. Native strategies track their
+   * per-turn handle directly. Child-stream loops omit this and the driver reads
+   * their persistent handle's live `deliveryTargetStreamId`, which goes
+   * `undefined` once the child is detached from its orchestrator.
    */
   resolveDeliveryTarget?(): StreamTabId | undefined;
 
@@ -582,19 +581,18 @@ async function persistTurnStateBestEffort(
 }
 
 /**
- * Where this turn's output goes. A strategy without `resolveDeliveryTarget`
- * (agent-CLI) always delivers to the run's static parent. A strategy that HAS
- * one (native) may return `undefined` — meaning the child was detached from its
- * orchestrator (see `AgentExecutionHandle.detach`) — which must skip delivery
- * entirely, not silently fall back to the old parent.
+ * Where this turn's output goes. Native strategies resolve their per-turn
+ * handle; child-stream loops receive their persistent handle's live target.
+ * Either may return `undefined` after detachment, which must skip delivery
+ * entirely rather than silently falling back to the old parent.
  */
 function resolveDeliveryTarget<TTurn>(
   strategy: ChildRunStrategy<TTurn>,
-  parentStreamId: StreamTabId,
+  childStreamTarget: StreamTabId | undefined,
 ): StreamTabId | undefined {
   return strategy.resolveDeliveryTarget
     ? strategy.resolveDeliveryTarget()
-    : parentStreamId;
+    : childStreamTarget;
 }
 
 /**
@@ -622,7 +620,6 @@ interface PendingChildDelivery {
 async function deliverTurn<TTurn>(params: {
   strategy: ChildRunStrategy<TTurn>;
   executionId: ExecutionId;
-  parentStreamId: StreamTabId;
   logger: AgentTrace;
   turn: TTurn | null;
   turnRef: ChildTurnRef;
@@ -630,6 +627,7 @@ async function deliverTurn<TTurn>(params: {
   wallTimeMs: number;
   isError: boolean;
   prepareParentDelivery?: () => boolean;
+  defaultDeliveryTarget: StreamTabId | undefined;
   /** Serializes turn-state writes against the acceptance write (#9531). */
   turnStateWrites: PQueue;
   onTurnSettled?: ChildRunLoopParams<TTurn>['onTurnSettled'];
@@ -637,7 +635,6 @@ async function deliverTurn<TTurn>(params: {
   const {
     strategy,
     executionId,
-    parentStreamId,
     logger,
     turn,
     turnRef,
@@ -645,6 +642,7 @@ async function deliverTurn<TTurn>(params: {
     wallTimeMs,
     isError,
     prepareParentDelivery,
+    defaultDeliveryTarget,
   } = params;
   const delivered = turn != null && !isError;
   const msg = await (delivered
@@ -698,7 +696,7 @@ async function deliverTurn<TTurn>(params: {
 
   if (strategy.deliveryMode === 'persistOnly') return undefined;
 
-  const targetStreamId = resolveDeliveryTarget(strategy, parentStreamId);
+  const targetStreamId = resolveDeliveryTarget(strategy, defaultDeliveryTarget);
   if (!targetStreamId) {
     logger.warn(
       'Turn result not delivered: child was detached from its orchestrator. The result remains in the execution report.',
@@ -880,7 +878,12 @@ export function startChildRunLoop<TTurn>(
         return;
       }
       if (strategy.deliveryMode === 'persistOnly' || activationDetached) return;
-      const targetStreamId = resolveDeliveryTarget(strategy, parentStreamId);
+      const targetStreamId = resolveDeliveryTarget(
+        strategy,
+        childStream
+          ? runSession.executions.getHandle(executionId)?.deliveryTargetStreamId
+          : parentStreamId,
+      );
       if (!targetStreamId) return;
       const msg = formatSubagentProgress(executionId, agentName, update);
       void deliverChildRunFollowUp({
@@ -1004,7 +1007,10 @@ export function startChildRunLoop<TTurn>(
         const delivery = await deliverTurn({
           strategy,
           executionId,
-          parentStreamId,
+          defaultDeliveryTarget: childStream
+            ? runSession.executions.getHandle(executionId)
+                ?.deliveryTargetStreamId
+            : parentStreamId,
           logger,
           turn,
           turnRef,

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -588,11 +588,11 @@ async function persistTurnStateBestEffort(
  */
 function resolveDeliveryTarget<TTurn>(
   strategy: ChildRunStrategy<TTurn>,
-  childStreamTarget: StreamTabId | undefined,
+  resolveChildStreamTarget: () => StreamTabId | undefined,
 ): StreamTabId | undefined {
   return strategy.resolveDeliveryTarget
     ? strategy.resolveDeliveryTarget()
-    : childStreamTarget;
+    : resolveChildStreamTarget();
 }
 
 /**
@@ -605,7 +605,7 @@ function resolveDeliveryTarget<TTurn>(
  * another turn (no finalize pending) may wake immediately.
  */
 interface PendingChildDelivery {
-  readonly targetStreamId: StreamTabId;
+  readonly resolveTargetStreamId: () => StreamTabId | undefined;
   readonly followUp: FollowUpQueueInput;
 }
 
@@ -627,7 +627,7 @@ async function deliverTurn<TTurn>(params: {
   wallTimeMs: number;
   isError: boolean;
   prepareParentDelivery?: () => boolean;
-  defaultDeliveryTarget: StreamTabId | undefined;
+  resolveDefaultDeliveryTarget: () => StreamTabId | undefined;
   /** Serializes turn-state writes against the acceptance write (#9531). */
   turnStateWrites: PQueue;
   onTurnSettled?: ChildRunLoopParams<TTurn>['onTurnSettled'];
@@ -642,7 +642,7 @@ async function deliverTurn<TTurn>(params: {
     wallTimeMs,
     isError,
     prepareParentDelivery,
-    defaultDeliveryTarget,
+    resolveDefaultDeliveryTarget,
   } = params;
   const delivered = turn != null && !isError;
   const msg = await (delivered
@@ -696,8 +696,9 @@ async function deliverTurn<TTurn>(params: {
 
   if (strategy.deliveryMode === 'persistOnly') return undefined;
 
-  const targetStreamId = resolveDeliveryTarget(strategy, defaultDeliveryTarget);
-  if (!targetStreamId) {
+  const resolveTargetStreamId = (): StreamTabId | undefined =>
+    resolveDeliveryTarget(strategy, resolveDefaultDeliveryTarget);
+  if (!resolveTargetStreamId()) {
     logger.warn(
       'Turn result not delivered: child was detached from its orchestrator. The result remains in the execution report.',
       { data: { executionId } },
@@ -706,7 +707,7 @@ async function deliverTurn<TTurn>(params: {
   }
   if (prepareParentDelivery?.() === false) return undefined;
   return {
-    targetStreamId,
+    resolveTargetStreamId,
     followUp: {
       text: msg,
       origin: 'subagent_result',
@@ -726,8 +727,16 @@ async function submitPendingDelivery(
   logger: AgentTrace,
 ): Promise<void> {
   if (!pending) return;
+  const targetStreamId = pending.resolveTargetStreamId();
+  if (!targetStreamId) {
+    logger.warn(
+      'Turn result not delivered: child was detached from its orchestrator. The result remains in the execution report.',
+      { data: { executionId } },
+    );
+    return;
+  }
   const delivery = await deliverChildRunFollowUp({
-    targetStreamId: pending.targetStreamId,
+    targetStreamId,
     followUp: pending.followUp,
     session,
   });
@@ -737,7 +746,7 @@ async function submitPendingDelivery(
       {
         data: {
           executionId,
-          parentStreamId: pending.targetStreamId,
+          parentStreamId: targetStreamId,
           reason: delivery.reason,
         },
       },
@@ -745,7 +754,7 @@ async function submitPendingDelivery(
   } else if (delivery.wake === 'failed') {
     logger.warn(
       'Turn result queued for the parent, but the parent could not be resumed; an explicit Resume delivers it.',
-      { data: { executionId, parentStreamId: pending.targetStreamId } },
+      { data: { executionId, parentStreamId: targetStreamId } },
     );
   }
 }
@@ -869,6 +878,12 @@ export function startChildRunLoop<TTurn>(
   }
 
   const attemptId = randomUUID();
+  // Keep the child-stream handle itself, not a target snapshot. Finalization
+  // untracks the handle before terminal delivery, while detachment still
+  // mutates this object's live delivery target.
+  const childStreamHandle = childStream
+    ? runSession.executions.getHandle(executionId)
+    : undefined;
 
   let bestCostUsd: number | undefined;
   const ports: ChildRunPorts = {
@@ -878,10 +893,9 @@ export function startChildRunLoop<TTurn>(
         return;
       }
       if (strategy.deliveryMode === 'persistOnly' || activationDetached) return;
-      const targetStreamId = resolveDeliveryTarget(
-        strategy,
+      const targetStreamId = resolveDeliveryTarget(strategy, () =>
         childStream
-          ? runSession.executions.getHandle(executionId)?.deliveryTargetStreamId
+          ? childStreamHandle?.deliveryTargetStreamId
           : parentStreamId,
       );
       if (!targetStreamId) return;
@@ -1007,10 +1021,10 @@ export function startChildRunLoop<TTurn>(
         const delivery = await deliverTurn({
           strategy,
           executionId,
-          defaultDeliveryTarget: childStream
-            ? runSession.executions.getHandle(executionId)
-                ?.deliveryTargetStreamId
-            : parentStreamId,
+          resolveDefaultDeliveryTarget: () =>
+            childStream
+              ? childStreamHandle?.deliveryTargetStreamId
+              : parentStreamId,
           logger,
           turn,
           turnRef,

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -58,12 +58,12 @@ interface ExecutionStopOptions {
 }
 
 /**
- * A child loop's lineage for the loop's whole life: from the synchronous start
- * of the loop, across every turn handle it tracks and untracks, until its
- * final result has been delivered to the parent. The parent counts it as an
- * active child throughout, so the parent's continuation stays recoverable
- * until the last delivery has landed and a child result can never arrive
- * after the parent's queue went terminal.
+ * A native child loop's lineage for the loop's whole life: from the
+ * synchronous start of the loop, across every turn handle it tracks and
+ * untracks, until its final result has been delivered to the parent. The
+ * parent counts it as an active child throughout, so the parent's continuation
+ * stays recoverable until the last delivery has landed. Child-stream loops use
+ * their persistent execution handle for lineage instead.
  */
 export interface ChildExecutionActivation {
   readonly executionId: ExecutionId;
@@ -529,13 +529,18 @@ export class ExecutionRegistry {
    */
   getToolUseFollowUpTarget(streamId: StreamTabId): ToolUseFollowUpTarget {
     const status = this.streamStatus.get(streamId);
-    const hasActiveChildren = this.hasActiveChildren(streamId);
 
     if (status !== undefined && !isInFlightPhase(status)) {
-      if (hasActiveChildren) return { kind: 'queue' };
+      // Only a native child's explicit delivery reservation can retain a
+      // terminal parent's continuation. A child-stream handle is lifecycle
+      // ownership, not authority to revive a parent that already finished.
+      for (const activation of this.activeChildActivations(streamId)) {
+        return { kind: 'queue' };
+      }
       return { kind: 'no_session', streamStatus: status };
     }
 
+    const hasActiveChildren = this.hasActiveChildren(streamId);
     const context = this.getToolUseFlowContext(streamId);
     if (context) return { kind: 'active', context };
 
@@ -772,8 +777,8 @@ export class ExecutionRegistry {
   }
 
   /**
-   * Retain a child loop's lineage until the returned disposer runs, which the
-   * loop does only after its final delivery to the parent.
+   * Retain a native child loop's lineage until the returned disposer runs,
+   * which the loop does only after its final delivery to the parent.
    */
   reserveChildActivation(activation: ChildExecutionActivation): () => void {
     this.assertActive();

--- a/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
@@ -235,31 +235,4 @@ describe('tool-use follow-up progress events', () => {
       defaultSession().followUps.terminalize(resumingStreamId);
     }
   });
-
-  it('refuses a terminal parent even while its child handle remains active', async () => {
-    const parentStreamId = 'stream:terminal-parent' as StreamTabId;
-    const childStreamId = 'stream:terminal-parent-child' as StreamTabId;
-    const executionId = 'exec-terminal-parent-child';
-    const handle = testExecutionHandle({
-      executionId,
-      parentStreamId,
-      childStreamId,
-      agent: 'critic',
-    });
-
-    seedStreamStatusForTest(defaultSession().status, parentStreamId, {
-      phase: STREAM_PHASE.COMPLETED,
-    });
-    defaultSession().executions.track(handle);
-
-    try {
-      const result = await submitFollowUp(parentStreamId, 'continue child');
-
-      expect(result).toMatchObject({ status: 'failed' });
-      expect(defaultSession().followUps.getAll(parentStreamId)).toEqual([]);
-    } finally {
-      defaultSession().executions.untrack(executionId);
-      defaultSession().followUps.terminalize(parentStreamId);
-    }
-  });
 });

--- a/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
@@ -236,7 +236,7 @@ describe('tool-use follow-up progress events', () => {
     }
   });
 
-  it('keeps terminal parents with active children on the children-running queue path', async () => {
+  it('refuses a terminal parent even while its child handle remains active', async () => {
     const parentStreamId = 'stream:terminal-parent' as StreamTabId;
     const childStreamId = 'stream:terminal-parent-child' as StreamTabId;
     const executionId = 'exec-terminal-parent-child';
@@ -255,10 +255,8 @@ describe('tool-use follow-up progress events', () => {
     try {
       const result = await submitFollowUp(parentStreamId, 'continue child');
 
-      expect(result).toEqual({ status: 'queued', wake: 'failed' });
-      expect(defaultSession().followUps.getAll(parentStreamId)).toEqual([
-        'continue child',
-      ]);
+      expect(result).toMatchObject({ status: 'failed' });
+      expect(defaultSession().followUps.getAll(parentStreamId)).toEqual([]);
     } finally {
       defaultSession().executions.untrack(executionId);
       defaultSession().followUps.terminalize(parentStreamId);

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -53,8 +53,9 @@ vi.mock('@agent/followUp/childRunDelivery', () => ({
   deliverChildRunFollowUp: mocks.deliverChildRunFollowUp,
 }));
 
-import type { WorkflowJournalEntry } from '@agent/workflowScript';
 import { getExecutionStore } from '@agent/storage';
+import type { WorkflowJournalEntry } from '@agent/workflowScript';
+import { submitFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import {
   startChildRunLoop,
   type ChildRunLoopParams,
@@ -81,6 +82,7 @@ import {
 } from '@shared/schemas';
 import { FakeConfigProvider } from '@test/support/FakePlatform';
 import { testExecutionHandle } from '@test/support/executionHandleFixtures';
+import { seedStreamStatusForTest } from '@test/support/streamStatusTestUtils';
 import { AgentCliSessionRegistry } from '@tools/agentCliSessionRegistry';
 import {
   claudeAgentSessionsFor,
@@ -495,6 +497,64 @@ describe('childRunLoop E2E fixtures', () => {
     } finally {
       writeBarrier.resolve();
       writeTurnState.mockRestore();
+    }
+  });
+
+  it('refuses follow-ups for a completed parent while a child-stream loop is still running', async () => {
+    const { childStreamId, executionId } = loopIds(
+      'completed-parent-child-stream',
+    );
+    const { strategy, resolveTurn } = createFakeStrategy();
+    const sourceStream = createChildStream(executionId, PARENT_STREAM_ID, {
+      streamPrefix: 'codex',
+      run: { kind: 'agent', agent: 'fake-cli', tool: 'codex' },
+      description: 'Keep a background child running',
+      config: childStreamConfig,
+    });
+    session.executions.untrack(executionId);
+    const childStream: NonNullable<
+      ChildRunLoopParams<FakeTurn>['childStream']
+    > = {
+      logger: sourceStream.logger,
+      waitForInput: vi.fn(),
+      beginTurn: vi.fn(),
+      failTurn: vi.fn(),
+      finalize: vi.fn(async () => {}),
+    };
+    const loop = startLoop({ childStreamId, executionId }, strategy, {
+      childStream,
+    });
+    seedStreamStatusForTest(session.status, PARENT_STREAM_ID, {
+      phase: STREAM_PHASE.COMPLETED,
+    });
+    const tryResumeStream = vi.fn(async () => false);
+    const userAdmission = vi.fn();
+
+    try {
+      await expect(
+        submitFollowUp(PARENT_STREAM_ID, 'restore me', {
+          session,
+          resumePort: { tryResumeStream },
+          onAdmitted: userAdmission,
+        }),
+      ).resolves.toMatchObject({ status: 'failed' });
+      expect(userAdmission).toHaveBeenCalledWith(false);
+      await expect(
+        submitFollowUp(
+          PARENT_STREAM_ID,
+          { text: 'late child result', origin: 'subagent_result' },
+          {
+            session,
+            resumePort: { tryResumeStream },
+            mode: 'child_delivery',
+          },
+        ),
+      ).resolves.toMatchObject({ status: 'failed' });
+      expect(tryResumeStream).not.toHaveBeenCalled();
+      expect(session.followUps.getAll(PARENT_STREAM_ID)).toEqual([]);
+    } finally {
+      await resolveTurn(1, { kind: 'terminal', value: 'done' });
+      await loop.completion;
     }
   });
 

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -501,26 +501,16 @@ describe('childRunLoop E2E fixtures', () => {
   });
 
   it('refuses follow-ups for a completed parent while a child-stream loop is still running', async () => {
-    const { childStreamId, executionId } = loopIds(
-      'completed-parent-child-stream',
-    );
+    const { executionId } = loopIds('completed-parent-child-stream');
     const { strategy, resolveTurn } = createFakeStrategy();
-    const sourceStream = createChildStream(executionId, PARENT_STREAM_ID, {
+    const childStream = createChildStream(executionId, PARENT_STREAM_ID, {
       streamPrefix: 'codex',
       run: { kind: 'agent', agent: 'fake-cli', tool: 'codex' },
       description: 'Keep a background child running',
       config: childStreamConfig,
     });
-    session.executions.untrack(executionId);
-    const childStream: NonNullable<
-      ChildRunLoopParams<FakeTurn>['childStream']
-    > = {
-      logger: sourceStream.logger,
-      waitForInput: vi.fn(),
-      beginTurn: vi.fn(),
-      failTurn: vi.fn(),
-      finalize: vi.fn(async () => {}),
-    };
+    const { childStreamId } = childStream;
+    trackedExecutionIds.add(executionId);
     const loop = startLoop({ childStreamId, executionId }, strategy, {
       childStream,
     });
@@ -556,6 +546,49 @@ describe('childRunLoop E2E fixtures', () => {
       await resolveTurn(1, { kind: 'terminal', value: 'done' });
       await loop.completion;
     }
+  });
+
+  it('does not deliver child-stream progress or results after detachment', async () => {
+    const { executionId } = loopIds('detached-child-stream');
+    const turn = pDefer<FakeTurn>();
+    const launchStarted = pDefer<void>();
+    let notifyProgress: ChildRunPorts['notify'] = () => {};
+    const strategy = createTerminalStrategy(
+      'Detached child stream',
+      (ports) => {
+        notifyProgress = ports.notify;
+        launchStarted.resolve();
+        return turn.promise;
+      },
+    );
+    const childStream = createChildStream(executionId, PARENT_STREAM_ID, {
+      streamPrefix: 'codex',
+      run: { kind: 'agent', agent: 'fake-cli', tool: 'codex' },
+      description: 'Detach a background child',
+      config: childStreamConfig,
+    });
+    const { childStreamId } = childStream;
+    trackedExecutionIds.add(executionId);
+    const loop = startLoop({ childStreamId, executionId }, strategy, {
+      childStream,
+    });
+    await launchStarted.promise;
+
+    notifyProgress({ kind: 'started' });
+    expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetStreamId: PARENT_STREAM_ID,
+        mode: 'live_notification',
+      }),
+    );
+    mocks.deliverChildRunFollowUp.mockClear();
+
+    session.executions.detachActiveChildren(PARENT_STREAM_ID);
+    notifyProgress({ kind: 'started' });
+    turn.resolve({ kind: 'terminal', value: 'done' });
+    await loop.completion;
+
+    expect(mocks.deliverChildRunFollowUp).not.toHaveBeenCalled();
   });
 
   it('persists without parent delivery in persist-only mode', async () => {

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -527,7 +527,7 @@ describe('childRunLoop E2E fixtures', () => {
     });
     const { childStreamId } = childStream;
     trackedExecutionIds.add(executionId);
-    const loop = startLoop({ childStreamId, executionId }, strategy, {
+    const completion = startLoop({ childStreamId, executionId }, strategy, {
       childStream,
     });
     const tryResumeStream = vi.fn(async () => false);
@@ -602,7 +602,7 @@ describe('childRunLoop E2E fixtures', () => {
       session.executions.detachActiveChildren(PARENT_STREAM_ID);
       notifyProgress({ kind: 'started' });
       formattedDelivery.resolve('delivered:done');
-      await loop.completion;
+      await completion;
 
       expect(mocks.deliverChildRunFollowUp).not.toHaveBeenCalled();
     } finally {
@@ -610,7 +610,7 @@ describe('childRunLoop E2E fixtures', () => {
       session.executions.detachActiveChildren(PARENT_STREAM_ID);
       turn.resolve({ kind: 'terminal', value: 'done' });
       formattedDelivery.resolve('delivered:done');
-      await loop.completion;
+      await completion;
     }
   });
 

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -500,9 +500,25 @@ describe('childRunLoop E2E fixtures', () => {
     }
   });
 
-  it('refuses follow-ups for a completed parent while a child-stream loop is still running', async () => {
-    const { executionId } = loopIds('completed-parent-child-stream');
-    const { strategy, resolveTurn } = createFakeStrategy();
+  it('keeps follow-up ownership distinct across child-stream and native child lifecycles', async () => {
+    const { executionId } = loopIds('follow-up-ownership');
+    const turn = pDefer<FakeTurn>();
+    const launchStarted = pDefer<void>();
+    const formatStarted = pDefer<void>();
+    const formattedDelivery = pDefer<string>();
+    let notifyProgress: ChildRunPorts['notify'] = () => {};
+    const strategy = createTerminalStrategy(
+      'Follow-up ownership',
+      (ports) => {
+        notifyProgress = ports.notify;
+        launchStarted.resolve();
+        return turn.promise;
+      },
+      () => {
+        formatStarted.resolve();
+        return formattedDelivery.promise;
+      },
+    );
     const childStream = createChildStream(executionId, PARENT_STREAM_ID, {
       streamPrefix: 'codex',
       run: { kind: 'agent', agent: 'fake-cli', tool: 'codex' },
@@ -514,17 +530,29 @@ describe('childRunLoop E2E fixtures', () => {
     const loop = startLoop({ childStreamId, executionId }, strategy, {
       childStream,
     });
-    seedStreamStatusForTest(session.status, PARENT_STREAM_ID, {
-      phase: STREAM_PHASE.COMPLETED,
-    });
     const tryResumeStream = vi.fn(async () => false);
-    const userAdmission = vi.fn();
+    const resumePort = { tryResumeStream };
+    await launchStarted.promise;
 
     try {
+      seedStreamStatusForTest(session.status, PARENT_STREAM_ID, {
+        phase: STREAM_PHASE.RUNNING,
+      });
+      await expect(
+        submitFollowUp(PARENT_STREAM_ID, 'active parent', {
+          session,
+          resumePort,
+        }),
+      ).resolves.toEqual({ status: 'queued', wake: 'failed' });
+
+      seedStreamStatusForTest(session.status, PARENT_STREAM_ID, {
+        phase: STREAM_PHASE.COMPLETED,
+      });
+      const userAdmission = vi.fn();
       await expect(
         submitFollowUp(PARENT_STREAM_ID, 'restore me', {
           session,
-          resumePort: { tryResumeStream },
+          resumePort,
           onAdmitted: userAdmission,
         }),
       ).resolves.toMatchObject({ status: 'failed' });
@@ -533,62 +561,57 @@ describe('childRunLoop E2E fixtures', () => {
         submitFollowUp(
           PARENT_STREAM_ID,
           { text: 'late child result', origin: 'subagent_result' },
-          {
-            session,
-            resumePort: { tryResumeStream },
-            mode: 'child_delivery',
-          },
+          { session, resumePort, mode: 'child_delivery' },
         ),
       ).resolves.toMatchObject({ status: 'failed' });
-      expect(tryResumeStream).not.toHaveBeenCalled();
-      expect(session.followUps.getAll(PARENT_STREAM_ID)).toEqual([]);
+      expect(session.followUps.getAll(PARENT_STREAM_ID)).toEqual([
+        'active parent',
+      ]);
+
+      const releaseNativeChild = session.executions.reserveChildActivation({
+        executionId: 'exec-follow-up-native-child-test' as ExecutionId,
+        parentStreamId: PARENT_STREAM_ID,
+        childStreamId: 'stream-follow-up-native-child-test' as StreamTabId,
+        interrupt: vi.fn(),
+        detach: vi.fn(),
+        isDetached: () => false,
+      });
+      try {
+        await expect(
+          submitFollowUp(PARENT_STREAM_ID, 'native child result', {
+            session,
+            resumePort,
+            mode: 'child_delivery',
+          }),
+        ).resolves.toEqual({ status: 'queued', wake: 'failed' });
+      } finally {
+        releaseNativeChild();
+      }
+
+      notifyProgress({ kind: 'started' });
+      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targetStreamId: PARENT_STREAM_ID,
+          mode: 'live_notification',
+        }),
+      );
+      mocks.deliverChildRunFollowUp.mockClear();
+
+      turn.resolve({ kind: 'terminal', value: 'done' });
+      await formatStarted.promise;
+      session.executions.detachActiveChildren(PARENT_STREAM_ID);
+      notifyProgress({ kind: 'started' });
+      formattedDelivery.resolve('delivered:done');
+      await loop.completion;
+
+      expect(mocks.deliverChildRunFollowUp).not.toHaveBeenCalled();
     } finally {
-      await resolveTurn(1, { kind: 'terminal', value: 'done' });
+      session.followUps.terminalize(PARENT_STREAM_ID);
+      session.executions.detachActiveChildren(PARENT_STREAM_ID);
+      turn.resolve({ kind: 'terminal', value: 'done' });
+      formattedDelivery.resolve('delivered:done');
       await loop.completion;
     }
-  });
-
-  it('does not deliver child-stream progress or results after detachment', async () => {
-    const { executionId } = loopIds('detached-child-stream');
-    const turn = pDefer<FakeTurn>();
-    const launchStarted = pDefer<void>();
-    let notifyProgress: ChildRunPorts['notify'] = () => {};
-    const strategy = createTerminalStrategy(
-      'Detached child stream',
-      (ports) => {
-        notifyProgress = ports.notify;
-        launchStarted.resolve();
-        return turn.promise;
-      },
-    );
-    const childStream = createChildStream(executionId, PARENT_STREAM_ID, {
-      streamPrefix: 'codex',
-      run: { kind: 'agent', agent: 'fake-cli', tool: 'codex' },
-      description: 'Detach a background child',
-      config: childStreamConfig,
-    });
-    const { childStreamId } = childStream;
-    trackedExecutionIds.add(executionId);
-    const loop = startLoop({ childStreamId, executionId }, strategy, {
-      childStream,
-    });
-    await launchStarted.promise;
-
-    notifyProgress({ kind: 'started' });
-    expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledWith(
-      expect.objectContaining({
-        targetStreamId: PARENT_STREAM_ID,
-        mode: 'live_notification',
-      }),
-    );
-    mocks.deliverChildRunFollowUp.mockClear();
-
-    session.executions.detachActiveChildren(PARENT_STREAM_ID);
-    notifyProgress({ kind: 'started' });
-    turn.resolve({ kind: 'terminal', value: 'done' });
-    await loop.completion;
-
-    expect(mocks.deliverChildRunFollowUp).not.toHaveBeenCalled();
   });
 
   it('persists without parent delivery in persist-only mode', async () => {

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -1607,8 +1607,30 @@ describe('executionRegistry', () => {
         ),
       );
       expect(registry.getToolUseFollowUpTarget(parentStreamId)).toEqual({
+        kind: 'no_session',
+        streamStatus: STREAM_PHASE.CANCELLED,
+      });
+      seedStreamStatusForTest(streamStatus, parentStreamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
+      expect(registry.getToolUseFollowUpTarget(parentStreamId)).toEqual({
         kind: 'queue',
       });
+      seedStreamStatusForTest(streamStatus, parentStreamId, {
+        phase: STREAM_PHASE.CANCELLED,
+      });
+      const releaseNativeChild = registry.reserveChildActivation({
+        executionId: 'exec-follow-up-native-child-test' as ExecutionId,
+        parentStreamId,
+        childStreamId: 'stream-follow-up-native-child-test' as StreamTabId,
+        interrupt: vi.fn(),
+        detach: vi.fn(),
+        isDetached: () => false,
+      });
+      expect(registry.getToolUseFollowUpTarget(parentStreamId)).toEqual({
+        kind: 'queue',
+      });
+      releaseNativeChild();
     } finally {
       registry.dispose();
     }

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -1551,8 +1551,6 @@ describe('executionRegistry', () => {
     const resumingStreamId = 'stream-follow-up-resuming-test' as StreamTabId;
     const waitingStreamId = 'stream-follow-up-waiting-test' as StreamTabId;
     const stoppedStreamId = 'stream-follow-up-stopped-test' as StreamTabId;
-    const parentStreamId = 'stream-follow-up-parent-test' as StreamTabId;
-    const childStreamId = 'stream-follow-up-child-test' as StreamTabId;
     const context = createLiveToolUseFlowContext();
 
     try {
@@ -1595,42 +1593,6 @@ describe('executionRegistry', () => {
         kind: 'no_session',
         streamStatus: STREAM_PHASE.CANCELLED,
       });
-
-      seedStreamStatusForTest(streamStatus, parentStreamId, {
-        phase: STREAM_PHASE.CANCELLED,
-      });
-      registry.track(
-        createHandle(
-          'exec-follow-up-child-test',
-          parentStreamId,
-          childStreamId,
-        ),
-      );
-      expect(registry.getToolUseFollowUpTarget(parentStreamId)).toEqual({
-        kind: 'no_session',
-        streamStatus: STREAM_PHASE.CANCELLED,
-      });
-      seedStreamStatusForTest(streamStatus, parentStreamId, {
-        phase: STREAM_PHASE.RUNNING,
-      });
-      expect(registry.getToolUseFollowUpTarget(parentStreamId)).toEqual({
-        kind: 'queue',
-      });
-      seedStreamStatusForTest(streamStatus, parentStreamId, {
-        phase: STREAM_PHASE.CANCELLED,
-      });
-      const releaseNativeChild = registry.reserveChildActivation({
-        executionId: 'exec-follow-up-native-child-test' as ExecutionId,
-        parentStreamId,
-        childStreamId: 'stream-follow-up-native-child-test' as StreamTabId,
-        interrupt: vi.fn(),
-        detach: vi.fn(),
-        isDetached: () => false,
-      });
-      expect(registry.getToolUseFollowUpTarget(parentStreamId)).toEqual({
-        kind: 'queue',
-      });
-      releaseNativeChild();
     } finally {
       registry.dispose();
     }


### PR DESCRIPTION
## Summary

- restore the pre-#11318 activation boundary so only native, child-stream-less loops reserve parent lineage through final delivery
- let completed parents with background or child-stream loops take the existing refusal path instead of admitting input that cannot be woken
- resolve child-stream delivery from the persistent live handle immediately before submission, so detachment during asynchronous formatting cannot deliver to a stale parent
- consolidate active-parent, terminal child-stream, native-child, final-delivery, progress, and detachment-race coverage into one lifecycle regression

Closes #11324.

## Validation

- `corepack pnpm vitest run src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts` (73 passed)
- `corepack pnpm test` (9,982 passed, 6 skipped; 5 unrelated load-sensitive failures), followed by isolated rerun of all failures (96 passed)
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm format:check`
- `corepack pnpm vitest run src/test-kernel/architecture` (101 passed)
- `corepack pnpm check:dead-code-ratchet` (304 combined findings vs. 304 baselined)
- `corepack pnpm check:dead-code` (reports the 6 existing unused exports tracked by the ratchet)
- `corepack pnpm build:fast`
- `corepack pnpm desktop:build`
