### PR TITLE
fix(progress-view): preserve polish result origin

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -866,24 +866,26 @@ export class DesktopProgressBridge {
         }
       },
       applyFollowUpPlan: (plan) => applyFollowUpPlan(plan, this.followUpPorts),
-      applyPolishResult: (result) =>
-        applyFollowUpPolishResult(result, this.followUpPorts),
-      onPolishError: async (stream, error) => {
-        const message = toErrorMessage(error);
-        this.postToRenderer({
-          command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
-          stream,
-          kind: 'polishError',
-          text: null,
-          error: message,
-        });
-        this.logger.error(`Error polishing follow-up: ${message}`, {
-          data: toLogData(error),
-        });
-        await this.options.host.showErrorMessage(
-          `Error polishing follow-up: ${message}`,
-        );
-      },
+      capturePolishReporter: () => ({
+        applyResult: (result) =>
+          applyFollowUpPolishResult(result, this.followUpPorts),
+        reportError: async (stream, error) => {
+          const message = toErrorMessage(error);
+          this.postToRenderer({
+            command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
+            stream,
+            kind: 'polishError',
+            text: null,
+            error: message,
+          });
+          this.logger.error(`Error polishing follow-up: ${message}`, {
+            data: toLogData(error),
+          });
+          await this.options.host.showErrorMessage(
+            `Error polishing follow-up: ${message}`,
+          );
+        },
+      }),
       postToRenderer: (message) => this.postToRenderer(message),
       restoreProposalConfig: async (proposal) => {
         await this.agentProposalController.restoreProposalConfig(proposal);

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -350,6 +350,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       // extension only wraps it in a VS Code progress notification and feeds
       // the shared handler's stage reports into it.
       [PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP]: async (data) => {
+        const reporter = secondTierActions.capturePolishReporter();
         await vscode.window.withProgress(
           {
             location: vscode.ProgressLocation.Notification,
@@ -361,6 +362,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
             try {
               await secondTierHandlers[PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP](
                 data,
+                reporter,
               );
             } finally {
               if (polishProgress === progress) polishProgress = undefined;
@@ -839,21 +841,32 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   }
 
   /**
-   * Capture a result route that never falls through to a replacement surface.
-   * A missing, disposed, or rejecting target makes the result undeliverable;
+   * Capture a result route that never falls through to a replacement surface
+   * or document. A missing, replaced, disposed, or rejecting target is undeliverable;
    * diagnose that at debug without turning completed work into a run failure.
    */
   private captureResultPost(
     resultName: string,
   ): (message: ProgressViewOutboundMessage) => void {
     const source = this.getActiveView()?.webview;
+    const isSourceDocumentCurrent = source
+      ? this.provider.captureWebviewDocument(source)
+      : () => false;
     return (message) => {
       if (!source) {
         this.log.debug(`${resultName} is undeliverable: target is unavailable`);
         return;
       }
       void Promise.resolve()
-        .then(() => source.postMessage(message))
+        .then(() => {
+          if (!isSourceDocumentCurrent()) {
+            this.log.debug(
+              `${resultName} is undeliverable: target document was replaced`,
+            );
+            return true;
+          }
+          return source.postMessage(message);
+        })
         .then(
           (delivered) => {
             if (!delivered) {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -45,6 +45,7 @@ import type {
   GettingStartedAction,
   ProgressViewInboundHandlerRegistry,
   ProgressViewInboundMessage,
+  ProgressViewOutboundMessage,
   StreamTabId,
 } from '@shared/schemas';
 import {
@@ -256,12 +257,18 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         await this.runViewCommand('texra.restoreState', [config]);
       },
       applyFollowUpPlan: (plan) => applyFollowUpPlan(plan, this.followUpPorts),
-      applyPolishResult: (result) =>
-        applyFollowUpPolishResult(result, this.followUpPorts),
+      capturePolishReporter: () => {
+        const post = this.captureResultPost('Follow-up polish result');
+        const ports = { ...this.followUpPorts, post };
+        return {
+          applyResult: (result) => applyFollowUpPolishResult(result, ports),
+          reportError: (stream, error) =>
+            this.reportPolishError(stream, error, post),
+        };
+      },
       onPolishProgress: (message) => {
         polishProgress?.report({ message });
       },
-      onPolishError: (stream, error) => this.reportPolishError(stream, error),
       postToRenderer: (message) => {
         this.postToActiveView(message);
       },
@@ -536,32 +543,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       },
       followUp: {
         captureAdmissionReporter: () => {
-          const source = this.getActiveView()?.webview;
+          const post = this.captureResultPost('Follow-up admission result');
           return (stream, accepted) => {
-            if (!source) return;
-            void Promise.resolve(
-              source.postMessage({
-                command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_RESULT,
-                stream,
-                accepted,
-              }),
-            ).then(
-              (delivered) => {
-                if (!delivered) {
-                  this.log.debug(
-                    'Follow-up result target did not accept the message',
-                  );
-                }
-              },
-              (error: unknown) => {
-                this.log.debug(
-                  'Follow-up result target is no longer attached',
-                  {
-                    data: error,
-                  },
-                );
-              },
-            );
+            post({
+              command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_RESULT,
+              stream,
+              accepted,
+            });
           };
         },
         reportImageSaveError: (_image, error) => {
@@ -850,10 +838,48 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     });
   }
 
+  /**
+   * Capture a result route that never falls through to a replacement surface.
+   * A missing, disposed, or rejecting target makes the result undeliverable;
+   * diagnose that at debug without turning completed work into a run failure.
+   */
+  private captureResultPost(
+    resultName: string,
+  ): (message: ProgressViewOutboundMessage) => void {
+    const source = this.getActiveView()?.webview;
+    return (message) => {
+      if (!source) {
+        this.log.debug(`${resultName} is undeliverable: target is unavailable`);
+        return;
+      }
+      void Promise.resolve()
+        .then(() => source.postMessage(message))
+        .then(
+          (delivered) => {
+            if (!delivered) {
+              this.log.debug(
+                `${resultName} is undeliverable: target did not accept the message`,
+              );
+            }
+          },
+          (error: unknown) => {
+            this.log.debug(
+              `${resultName} is undeliverable: target is no longer attached`,
+              { data: error },
+            );
+          },
+        );
+    };
+  }
+
   /** Post the polish failure to the renderer, surface it, and log it. */
-  private reportPolishError(stream: StreamTabId, error: unknown): void {
+  private reportPolishError(
+    stream: StreamTabId,
+    error: unknown,
+    post: (message: ProgressViewOutboundMessage) => void,
+  ): void {
     const errorMsg = toErrorMessage(error);
-    this.postToActiveView({
+    post({
       command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
       stream,
       kind: 'polishError',

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -84,6 +84,8 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     placement: 'sidebar',
     ready: false,
   };
+  /** Current progress document identity for each reusable VS Code webview. */
+  private readonly documentIdentities = new WeakMap<vscode.Webview, object>();
   private readonly logger: AgentTrace;
 
   private _mainViewProvider?: MainViewProvider;
@@ -207,6 +209,26 @@ export class ProgressViewProvider extends BaseWebviewProvider {
 
   public async refreshOnboardingFunnel(): Promise<void> {
     await this._mainViewProvider?.refreshOnboardingFunnel();
+  }
+
+  public override setupWebviewContent(
+    view: vscode.WebviewView | vscode.WebviewPanel,
+  ): vscode.Disposable {
+    this.documentIdentities.set(view.webview, {});
+    return super.setupWebviewContent(view);
+  }
+
+  /** Capture whether this exact progress document still occupies its webview. */
+  public captureWebviewDocument(webview: vscode.Webview): () => boolean {
+    const identity = this.documentIdentities.get(webview);
+    return () =>
+      identity !== undefined &&
+      this.documentIdentities.get(webview) === identity;
+  }
+
+  /** Invalidate a progress document before its webview is reused or disposed. */
+  public invalidateWebviewDocument(webview: vscode.Webview): void {
+    this.documentIdentities.delete(webview);
   }
 
   /** The sidebar stopped showing progress content; its handshake is void. */
@@ -402,6 +424,7 @@ export class ProgressViewProvider extends BaseWebviewProvider {
   private releaseEditorTarget(options: { disposePanel?: boolean } = {}): void {
     const target = this.target;
     if (target?.placement !== 'editor') return;
+    this.invalidateWebviewDocument(target.panel.webview);
     this.target = undefined;
     try {
       target.disposables.dispose();

--- a/packages/extension/src/webview/MainViewProvider.ts
+++ b/packages/extension/src/webview/MainViewProvider.ts
@@ -352,6 +352,8 @@ export class MainViewProvider
   }
 
   protected override cleanupView(): void {
+    const webview = this.getWebviewView()?.webview;
+    if (webview) this._progressViewProvider?.invalidateWebviewDocument(webview);
     this._messageDisposable?.dispose();
     this._messageDisposable = undefined;
     this.mainWebviewReady = false;
@@ -423,6 +425,7 @@ export class MainViewProvider
     // Guard provider availability before mutating any state.
     if (mode === SIDEBAR_VIEWS.PROGRESS && !this._progressViewProvider) return;
 
+    this._progressViewProvider?.invalidateWebviewDocument(webviewView.webview);
     setActiveSidebarView(mode);
     this._messageDisposable?.dispose();
     // Any HTML swap invalidates the previous document's ready handshake.

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -658,8 +658,10 @@ export function createProgressViewSecondTierHandlers(
     },
 
     // ── Follow-up polish ──
-    [CMD.POLISH_FOLLOW_UP]: async (data) => {
-      const reporter = deps.capturePolishReporter();
+    [CMD.POLISH_FOLLOW_UP]: async (
+      data,
+      reporter = deps.capturePolishReporter(),
+    ) => {
       await deps.preload?.(data.stream);
       const config = deps.getRunMetadata(data.stream).config;
       if (!config) {

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -468,6 +468,11 @@ export function createProgressViewCommandHandlers(
 
 // ── Second-tier handler deps ──────────────────────────────────────────────
 
+interface ProgressViewPolishReporter {
+  applyResult(result: ProgressFollowUpPolishResult): Promise<void>;
+  reportError(stream: StreamTabId, error: unknown): void | Promise<void>;
+}
+
 export interface ProgressViewSecondTierActions {
   /** Shared controllers (host-neutral; created once per host with injected deps). */
   readonly workflowActions: ProgressWorkflowActionsController;
@@ -497,21 +502,18 @@ export interface ProgressViewSecondTierActions {
   readonly restoreRunConfig: (config: AgentConfig) => Promise<void>;
   /** Resolve a follow-up plan (plan kinds map to host-specific execution). */
   readonly applyFollowUpPlan: (plan: ProgressFollowUpPlan) => Promise<void>;
-  /** Render a polish result (update renderer + show host messages). */
-  readonly applyPolishResult: (
-    result: ProgressFollowUpPolishResult,
-  ) => Promise<void>;
+  /**
+   * Capture the polish-result route before preload or model work yields. The
+   * extension has two progress surfaces, so resolving the active renderer when
+   * polishing finishes can overwrite a different composer's draft.
+   */
+  readonly capturePolishReporter: () => ProgressViewPolishReporter;
   /**
    * Report a polish stage to the user. Hosts with a progress surface (the
    * extension feeds a `vscode.window.withProgress` notification) implement it;
    * hosts without one leave it unset.
    */
   readonly onPolishProgress?: (message: string) => void;
-  /** Handle a polish controller exception (post error to renderer + log + host message). */
-  readonly onPolishError: (
-    stream: StreamTabId,
-    error: unknown,
-  ) => void | Promise<void>;
   /** Post a message to the renderer. */
   readonly postToRenderer: (message: ProgressViewOutboundMessage) => void;
   /** Restore an agent proposal config into the main view (delegates to agentProposalController). */
@@ -657,11 +659,12 @@ export function createProgressViewSecondTierHandlers(
 
     // ── Follow-up polish ──
     [CMD.POLISH_FOLLOW_UP]: async (data) => {
+      const reporter = deps.capturePolishReporter();
       await deps.preload?.(data.stream);
       const config = deps.getRunMetadata(data.stream).config;
       if (!config) {
         // Same port the polish failures use, rather than a silent return.
-        await deps.onPolishError(
+        await reporter.reportError(
           data.stream,
           new Error('This run has no saved configuration to polish against.'),
         );
@@ -675,9 +678,9 @@ export function createProgressViewSecondTierHandlers(
           runConfig: config,
         });
         deps.onPolishProgress?.('Applying changes...');
-        await deps.applyPolishResult(result);
+        await reporter.applyResult(result);
       } catch (error) {
-        await deps.onPolishError(data.stream, error);
+        await reporter.reportError(data.stream, error);
       }
     },
 

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -127,6 +127,10 @@ function createActions(
 function createSecondTierActions(
   overrides: Partial<ProgressViewSecondTierActions> = {},
 ): ProgressViewSecondTierActions {
+  const polishReporter = {
+    applyResult: vi.fn(),
+    reportError: vi.fn(),
+  };
   return {
     workflowActions: {
       diffStream: vi.fn(),
@@ -156,8 +160,7 @@ function createSecondTierActions(
     })),
     restoreRunConfig: vi.fn(),
     applyFollowUpPlan: vi.fn(),
-    applyPolishResult: vi.fn(),
-    onPolishError: vi.fn(),
+    capturePolishReporter: vi.fn(() => polishReporter),
     postToRenderer: vi.fn(),
     restoreProposalConfig: vi.fn(),
     retry: {
@@ -824,6 +827,7 @@ describe('createProgressViewSecondTierHandlers', () => {
     const actions = createSecondTierActions({
       getRunMetadata: vi.fn().mockReturnValue({}),
     });
+    const reporter = actions.capturePolishReporter();
     const handlers = createProgressViewSecondTierHandlers(actions);
 
     await assertSupported(handlers[PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP])({
@@ -833,18 +837,22 @@ describe('createProgressViewSecondTierHandlers', () => {
     });
 
     expect(actions.followUpPolish.polishFollowUp).not.toHaveBeenCalled();
-    expect(actions.applyPolishResult).not.toHaveBeenCalled();
+    expect(reporter.applyResult).not.toHaveBeenCalled();
   });
 
   it('awaits polish error reporting', async () => {
     const polishFailure = new Error('polish failed');
     const reportingFailure = new Error('reporting failed');
+    const reportError = vi.fn().mockRejectedValue(reportingFailure);
     const actions = createSecondTierActions({
       getRunMetadata: vi.fn().mockReturnValue({ config: {} }),
       followUpPolish: {
         polishFollowUp: vi.fn().mockRejectedValue(polishFailure),
       } as unknown as ProgressViewSecondTierActions['followUpPolish'],
-      onPolishError: vi.fn().mockRejectedValue(reportingFailure),
+      capturePolishReporter: vi.fn(() => ({
+        applyResult: vi.fn(),
+        reportError,
+      })),
     });
     const handlers = createProgressViewSecondTierHandlers(actions);
 
@@ -855,15 +863,15 @@ describe('createProgressViewSecondTierHandlers', () => {
         text: 'Improve this',
       }),
     ).rejects.toBe(reportingFailure);
-    expect(actions.onPolishError).toHaveBeenCalledWith(
-      'stream-1',
-      polishFailure,
-    );
+    expect(reportError).toHaveBeenCalledWith('stream-1', polishFailure);
   });
 
   it('reports polish stages around the controller call', async () => {
     const order: string[] = [];
     const polishResult = { kind: 'skipped' };
+    const applyResult = vi.fn(async () => {
+      order.push('apply');
+    });
     const actions = createSecondTierActions({
       getRunMetadata: vi.fn().mockReturnValue({ config: {} }),
       followUpPolish: {
@@ -872,9 +880,10 @@ describe('createProgressViewSecondTierHandlers', () => {
           return polishResult;
         }),
       } as unknown as ProgressViewSecondTierActions['followUpPolish'],
-      applyPolishResult: vi.fn(async () => {
-        order.push('apply');
-      }),
+      capturePolishReporter: vi.fn(() => ({
+        applyResult,
+        reportError: vi.fn(),
+      })),
       onPolishProgress: vi.fn((message: string) => {
         order.push(`progress:${message}`);
       }),
@@ -893,7 +902,7 @@ describe('createProgressViewSecondTierHandlers', () => {
       'progress:Applying changes...',
       'apply',
     ]);
-    expect(actions.applyPolishResult).toHaveBeenCalledWith(polishResult);
+    expect(applyResult).toHaveBeenCalledWith(polishResult);
   });
 
   it('polishes without a progress reporter when the host has none', async () => {
@@ -904,6 +913,7 @@ describe('createProgressViewSecondTierHandlers', () => {
         polishFollowUp: vi.fn().mockResolvedValue(polishResult),
       } as unknown as ProgressViewSecondTierActions['followUpPolish'],
     });
+    const reporter = actions.capturePolishReporter();
     const handlers = createProgressViewSecondTierHandlers(actions);
 
     await assertSupported(handlers[PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP])({
@@ -912,7 +922,7 @@ describe('createProgressViewSecondTierHandlers', () => {
       text: 'Improve this',
     });
 
-    expect(actions.applyPolishResult).toHaveBeenCalledWith(polishResult);
-    expect(actions.onPolishError).not.toHaveBeenCalled();
+    expect(reporter.applyResult).toHaveBeenCalledWith(polishResult);
+    expect(reporter.reportError).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/progressView/ProgressTargetOwnership.vitest.ts
+++ b/src/test-kernel/progressView/ProgressTargetOwnership.vitest.ts
@@ -105,6 +105,7 @@ function createProvider() {
   ) as ProgressViewProvider;
   const injected = provider as unknown as Record<string, unknown>;
   injected.target = { placement: 'sidebar', ready: false };
+  injected.documentIdentities = new WeakMap<vscode.Webview, object>();
   injected._mainViewProvider = mainViewProvider;
   injected.context = { extensionUri: { fsPath: '/ext' } };
   injected.contentProvider = { getHtmlContent: () => '<progress-view />' };

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
@@ -118,6 +118,7 @@ function createProgressViewProvider(): ProgressViewProviderFake {
     snapshots,
     pickValidActiveStream: vi.fn(() => ''),
   };
+  const documentIdentities = new WeakMap<vscode.Webview, object>();
   return {
     state,
     backend: {
@@ -132,6 +133,14 @@ function createProgressViewProvider(): ProgressViewProviderFake {
       clearStream: vi.fn(),
       clearAll: vi.fn(),
     },
+    captureWebviewDocument: vi.fn((webview: vscode.Webview) => {
+      const identity = documentIdentities.get(webview) ?? {};
+      documentIdentities.set(webview, identity);
+      return () => documentIdentities.get(webview) === identity;
+    }),
+    invalidateWebviewDocument: vi.fn((webview: vscode.Webview) => {
+      documentIdentities.delete(webview);
+    }),
     getPendingAgentProposal: vi.fn(),
     markWebviewReady: vi.fn(),
     popOutToEditor: vi.fn(),
@@ -256,7 +265,18 @@ describe('progress-view onboarding refresh wiring', () => {
     );
   });
 
-  it('returns follow-up polish to the originating surface', async () => {
+  it('returns follow-up polish only to its unchanged origin document', async () => {
+    const holdNextProgress = (): (() => void) => {
+      let start: () => void = () => undefined;
+      mocks.withProgress.mockImplementationOnce(
+        (_options, task) =>
+          new Promise((resolve) => {
+            start = () => resolve(task({ report: vi.fn() }));
+          }),
+      );
+      return () => start();
+    };
+    const startProgress = holdNextProgress();
     let finishPolish: (result: ProgressFollowUpPolishResult) => void = () =>
       undefined;
     const polishFollowUp = vi
@@ -284,13 +304,17 @@ describe('progress-view onboarding refresh wiring', () => {
       sidebar,
     );
     await vi.waitFor(() => {
-      expect(polishFollowUp).toHaveBeenCalledOnce();
+      expect(mocks.withProgress).toHaveBeenCalledOnce();
     });
 
     await handler.handleMessage(
       { command: PROGRESS_VIEW_COMMANDS.WEBVIEW_READY, view: 'progress' },
       panel,
     );
+    startProgress();
+    await vi.waitFor(() => {
+      expect(polishFollowUp).toHaveBeenCalledOnce();
+    });
     const update = {
       command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
       stream: 'originating-surface' as StreamTabId,
@@ -303,6 +327,47 @@ describe('progress-view onboarding refresh wiring', () => {
       expect(sidebar.webview.postMessage).toHaveBeenCalledWith(update);
     });
     expect(panel.webview.postMessage).not.toHaveBeenCalledWith(update);
+
+    const startReplacementProgress = holdNextProgress();
+    polishFollowUp.mockImplementationOnce(
+      () =>
+        new Promise<ProgressFollowUpPolishResult>((resolve) => {
+          finishPolish = resolve;
+        }),
+    );
+    const replacementPolishing = handler.handleMessage(
+      {
+        command: PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP,
+        stream: 'originating-surface',
+        text: 'try another revision',
+      },
+      sidebar,
+    );
+    await vi.waitFor(() => {
+      expect(mocks.withProgress).toHaveBeenCalledTimes(2);
+    });
+
+    provider.invalidateWebviewDocument(sidebar.webview);
+    await handler.handleMessage(
+      { command: PROGRESS_VIEW_COMMANDS.WEBVIEW_READY, view: 'progress' },
+      panel,
+    );
+    startReplacementProgress();
+    await vi.waitFor(() => {
+      expect(polishFollowUp).toHaveBeenCalledTimes(2);
+    });
+    const replacementUpdate = {
+      ...update,
+      text: 'A replacement-document revision',
+    };
+    finishPolish({ kind: 'updated', update: replacementUpdate });
+    await replacementPolishing;
+    await Promise.resolve();
+
+    expect(sidebar.webview.postMessage).toHaveBeenCalledTimes(1);
+    expect(panel.webview.postMessage).not.toHaveBeenCalledWith(
+      replacementUpdate,
+    );
   });
 
   it('acknowledges a replacement run when the runtime publishes its handle', async () => {

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
@@ -7,6 +7,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // Local imports
 import type { ProgressHostInteractions } from '@controllers/progressView/backend/progressHostInteractions';
 import type { ProgressFollowUpSubmitArgs } from '@controllers/progressView/progressFollowUpSubmit';
+import {
+  ProgressFollowUpPolishController,
+  type ProgressFollowUpPolishResult,
+} from '@controllers/progressView/ProgressFollowUpPolishController';
 import * as logger from '@logger/logUtils';
 import { ProgressViewMessageHandler } from '@progressView/ProgressViewMessageHandler';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
@@ -25,7 +29,19 @@ const mocks = vi.hoisted(() => ({
   safeExecuteCommand: vi.fn(),
   savePastedImageBase64: vi.fn(),
   submitProgressFollowUp: vi.fn(),
+  withProgress: vi.fn(
+    (_options: unknown, task: (progress: { report(): void }) => unknown) =>
+      task({ report: vi.fn() }),
+  ),
 }));
+
+vi.mock('vscode', async (importOriginal) => {
+  const vscode = await importOriginal<typeof import('vscode')>();
+  return {
+    ...vscode,
+    window: { ...vscode.window, withProgress: mocks.withProgress },
+  };
+});
 
 vi.mock('@frontend/system/commandUtils', () => ({
   safeExecuteCommand: mocks.safeExecuteCommand,
@@ -41,7 +57,7 @@ vi.mock('@utils/files/pastedImageUtils', () => ({
 
 function createWebviewView(): vscode.WebviewView {
   return {
-    webview: { postMessage: vi.fn() },
+    webview: { postMessage: vi.fn().mockResolvedValue(true) },
   } as unknown as vscode.WebviewView;
 }
 
@@ -238,6 +254,55 @@ describe('progress-view onboarding refresh wiring', () => {
         command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_RESULT,
       }),
     );
+  });
+
+  it('returns follow-up polish to the originating surface', async () => {
+    let finishPolish: (result: ProgressFollowUpPolishResult) => void = () =>
+      undefined;
+    const polishFollowUp = vi
+      .spyOn(ProgressFollowUpPolishController.prototype, 'polishFollowUp')
+      .mockImplementationOnce(
+        () =>
+          new Promise<ProgressFollowUpPolishResult>((resolve) => {
+            finishPolish = resolve;
+          }),
+      );
+    const provider = createProgressViewProvider();
+    vi.mocked(provider.state.snapshots.getRunMetadata).mockReturnValue({
+      config: createWorkflowConfig(),
+    });
+    const handler = createMessageHandler(provider);
+    const sidebar = createWebviewView();
+    const panel = createWebviewView();
+
+    const polishing = handler.handleMessage(
+      {
+        command: PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP,
+        stream: 'originating-surface',
+        text: 'make this clearer',
+      },
+      sidebar,
+    );
+    await vi.waitFor(() => {
+      expect(polishFollowUp).toHaveBeenCalledOnce();
+    });
+
+    await handler.handleMessage(
+      { command: PROGRESS_VIEW_COMMANDS.WEBVIEW_READY, view: 'progress' },
+      panel,
+    );
+    const update = {
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
+      stream: 'originating-surface' as StreamTabId,
+      kind: 'polished' as const,
+      text: 'A clearer follow-up',
+    };
+    finishPolish({ kind: 'updated', update });
+    await polishing;
+    await vi.waitFor(() => {
+      expect(sidebar.webview.postMessage).toHaveBeenCalledWith(update);
+    });
+    expect(panel.webview.postMessage).not.toHaveBeenCalledWith(update);
   });
 
   it('acknowledges a replacement run when the runtime publishes its handle', async () => {

--- a/src/test-kernel/webview/SidebarSurfaceOwnership.vitest.ts
+++ b/src/test-kernel/webview/SidebarSurfaceOwnership.vitest.ts
@@ -109,6 +109,7 @@ describe('sidebar surface ownership', () => {
   let progressViewProvider: {
     setupWebviewContent: ReturnType<typeof vi.fn>;
     resetSidebarReady: ReturnType<typeof vi.fn>;
+    invalidateWebviewDocument: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
@@ -125,6 +126,7 @@ describe('sidebar surface ownership', () => {
         return { dispose: vi.fn() };
       }),
       resetSidebarReady: vi.fn(),
+      invalidateWebviewDocument: vi.fn(),
     };
     provider.setProgressViewProvider(
       progressViewProvider as unknown as ProgressViewProvider,


### PR DESCRIPTION
## Summary

Follow-up polish can outlive the progress document that submitted it. Previously the extension applied `UPDATE_FOLLOW_UP_TEXT` through whichever sidebar or editor-panel webview most recently dispatched a message, so a late result could overwrite another composer.

This change captures a polish reporter synchronously in the extension dispatch override, before `withProgress`, preload, or model work can yield. The extension reporter holds both the submitting webview and its current document identity. A missing, replaced, disposed, rejecting, or non-accepting target is an undeliverable result: it is logged at debug and does not throw into the polish/run path. Desktop keeps its existing single-renderer behavior through the same reporter contract.

Closes #11369.

## Issue acceptance gates

- Captures the progress document that submitted `POLISH_FOLLOW_UP` before the first asynchronous operation, including VS Code's `withProgress` handoff.
- Delivers polish updates and polish-error updates only through that captured document.
- A disposed or replaced source document cannot fall through to the currently active composer, even when VS Code reuses the same webview object for new HTML.
- Defines undeliverable delivery as no captured target, a replaced document, `postMessage` returning false, or `postMessage` throwing/rejecting. Each case is debug-logged and swallowed.
- Adds one focused regression that delays the `withProgress` callback, dispatches from another surface, and proves no cross-surface or cross-document delivery.

## Single source of truth

`ProgressViewMessageHandler` owns extension capture timing and fixed-document delivery. `createProgressViewSecondTierHandlers` accepts that captured reporter while retaining a default capture for the desktop host. `ProgressViewProvider` owns progress-document identities across sidebar HTML swaps and editor-panel disposal.

## Duplication and abstraction budget

The reporter replaces the two mutable-active-view polish callbacks at the existing host boundary. The analogous admission-result route now reuses the same fixed-document delivery helper, so disposal handling and undeliverable logging have one implementation. A weak document-identity map is added to distinguish replacement HTML loaded into a reusable VS Code webview.

## Net elements (R6)

n/a: focused correctness fix, not a refactor-class PR.

## Consumer counts (R8)

n/a: no emit path or export was deleted. Both hosts implementing the existing second-tier action port were updated.

## Host impact

Extension: polish success and error updates return only to the originating sidebar/editor document. Undeliverable results are debug-logged without failing the run.

Desktop: behavior remains single-renderer; it adopts the captured reporter port contract.

CLI: no impact.

## Scheduled refactoring

None.

## Validation

- Focused and surrounding Vitest: 50 passed across dual-surface wiring, shared command handlers, target ownership, and sidebar ownership
- Full Vitest: 823 files passed, 1 skipped; 9,990 tests passed, 6 skipped
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- `npm run typecheck:desktop`
- `npm run compile:fast`
- `npm run lint`
- Prettier check on all changed files
- `npm run check:guidance-refs`
- `npm run check:dead-code-ratchet`
- `git diff --check`
