### PR TITLE
docs: explain Google foreground deadline risk

### DIFF
--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -491,7 +491,7 @@ const CORE_SETTING_ROWS: Record<
     default: false,
     title: 'Google background responses',
     description:
-      'Run long-running Google workflow generations as background Interactions (submit + poll) to avoid timeouts. Off by default. Requires server-side conversation state; models that do not support it fall back automatically.',
+      'Run Google workflow generations as background Interactions (submit + poll). When this and Google provider streaming are off, direct Google workflows use one foreground request, so long generations can hit host, network, or Google API request deadlines before completion. Enable either setting to avoid relying on one long unary request. Off by default; requires server-side conversation state, and unsupported models fall back automatically.',
     honoredBy: everyHost(
       'src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts',
     ),
@@ -499,7 +499,7 @@ const CORE_SETTING_ROWS: Record<
       provider: 'google',
       label: 'Background responses',
       description:
-        'Run long-running workflow generations as background Interactions (submit + poll) to avoid timeouts. Off by default. Requires server-side conversation state; models that do not support it fall back automatically.',
+        'Run workflow generations as background Interactions (submit + poll). When this and provider streaming are off, direct Google workflows use one foreground request, so long generations can hit host, network, or Google API request deadlines before completion. Enable either setting to avoid relying on one long unary request. Off by default; requires server-side conversation state, and unsupported models fall back automatically.',
     },
   }),
   'model.useBackgroundResponses': modelProviderToggle({

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -491,7 +491,7 @@ const CORE_SETTING_ROWS: Record<
     default: false,
     title: 'Google background responses',
     description:
-      'Run Google workflow generations as background Interactions (submit + poll). When this and Google provider streaming are off, direct Google workflows use one foreground request, so long generations can hit host, network, or Google API request deadlines before completion. Enable either setting to avoid relying on one long unary request. Off by default; requires server-side conversation state, and unsupported models fall back automatically.',
+      'Run Google workflow generations as background Interactions (submit + poll). When this and Google provider streaming are off, direct Google workflows use one foreground request, so long generations can hit host, network, or Google API request deadlines before completion. Provider streaming avoids that unary request; background responses also do when server-side conversation state is enabled and the selected model supports them. Off by default; unsupported models fall back automatically.',
     honoredBy: everyHost(
       'src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts',
     ),
@@ -499,7 +499,7 @@ const CORE_SETTING_ROWS: Record<
       provider: 'google',
       label: 'Background responses',
       description:
-        'Run workflow generations as background Interactions (submit + poll). When this and provider streaming are off, direct Google workflows use one foreground request, so long generations can hit host, network, or Google API request deadlines before completion. Enable either setting to avoid relying on one long unary request. Off by default; requires server-side conversation state, and unsupported models fall back automatically.',
+        'Run workflow generations as background Interactions (submit + poll). When this and provider streaming are off, direct Google workflows use one foreground request, so long generations can hit host, network, or Google API request deadlines before completion. Provider streaming avoids that unary request; background responses also do when server-side conversation state is enabled and the selected model supports them. Off by default; unsupported models fall back automatically.',
     },
   }),
   'model.useBackgroundResponses': modelProviderToggle({

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -491,7 +491,7 @@ const CORE_SETTING_ROWS: Record<
     default: false,
     title: 'Google background responses',
     description:
-      'Run Google workflow generations as background Interactions (submit + poll). When this and Google provider streaming are off, direct Google workflows use one foreground request, so long generations can hit host, network, or Google API request deadlines before completion. Provider streaming avoids that unary request; background responses also do when server-side conversation state is enabled and the selected model supports them. Off by default; unsupported models fall back automatically.',
+      'Run Google workflow generations as background Interactions (submit + poll). When this and the Google streaming toggle are off, direct Google workflows use one foreground request, so long generations can hit host, network, or Google API request deadlines before completion. The Google streaming toggle avoids that unary request; background responses also do when server-side conversation state is enabled and the selected model supports them. Off by default; unsupported models fall back automatically.',
     honoredBy: everyHost(
       'src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts',
     ),
@@ -499,7 +499,7 @@ const CORE_SETTING_ROWS: Record<
       provider: 'google',
       label: 'Background responses',
       description:
-        'Run workflow generations as background Interactions (submit + poll). When this and provider streaming are off, direct Google workflows use one foreground request, so long generations can hit host, network, or Google API request deadlines before completion. Provider streaming avoids that unary request; background responses also do when server-side conversation state is enabled and the selected model supports them. Off by default; unsupported models fall back automatically.',
+        'Run workflow generations as background Interactions (submit + poll). When this and the Google streaming toggle are off, direct Google workflows use one foreground request, so long generations can hit host, network, or Google API request deadlines before completion. The Google streaming toggle avoids that unary request; background responses also do when server-side conversation state is enabled and the selected model supports them. Off by default; unsupported models fall back automatically.',
     },
   }),
   'model.useBackgroundResponses': modelProviderToggle({


### PR DESCRIPTION
## Summary

Choose issue #11378's smallest documentation remediation. The shared Google background responses setting now explains that direct Google workflow generations use one foreground request when both background responses and provider streaming are off, that long requests can encounter host, network, or Google API deadlines, and that provider streaming avoids the unary path while background responses do so when server-side state and model support allow them.

This does not change toggle semantics or override users' privacy or streaming preferences. Google background responses and provider streaming remain off when users disable them.

Closes #11378.

## Issue acceptance gates

- Documents the foreground unary-request behavior when both relevant toggles are off.
- Describes deadline risk without claiming an exact 10-minute cutoff.
- Identifies provider streaming as the unconditional mitigation and background responses as conditional on server-side state and model support.
- Preserves explicit background-response and streaming choices.

## Single source of truth

`src/shared/schemas/stateSettings.ts` remains the canonical catalog for the setting copy consumed by the shared settings view and provider Models controls across hosts.

## Duplication and abstraction budget

Updated the two existing UI-specific descriptions in the canonical catalog. Added no policy branch, helper, abstraction, or copied host-specific setting text.

## Net elements (R6)

One file changed, two lines replaced, no exports or constructs added.

## Consumer counts (R8)

n/a. No emit path or export was deleted or rerouted.

## Host impact

Extension: Updated copy in the shared profile setting and Google Models control.

Desktop: Receives the same updated catalog-driven copy as the extension.

CLI: No UI change; this setting is not listed in the CLI config panel.

## Scheduled refactoring

None in this PR. Residual risk: the current `@google/genai` transport reconstructs `Request` objects and drops the non-standard dispatcher, so the effective foreground cutoff remains dependent on the host and Google/API transport. A timeout transport redesign is deliberately out of scope for this smallest documentation remediation.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/shared/stateSettings.vitest.ts src/test-kernel/controllers/SettingsProfileController.vitest.ts src/test-kernel/settings/SharedSettingsViewBoundary.vitest.ts` (31 tests passed)
- `npm run typecheck`
- `npm run format:check`
- `npm run lint`
- `npm run compile:fast`
- `git diff --check`
