### PR TITLE
fix: enforce Google Interactions transport deadlines

### DIFF
--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -49,7 +49,7 @@ import {
   takeTail,
 } from '@common/errors/sdkError/errorPatterns';
 import { handleStreamingFailure } from '@common/errors/sdkError/streamFailure';
-import { composeLongRunningModelDispatcher } from '@platform/defaults/longRunningModelTransport';
+import { longRunningGoogleInteractionsFetch } from '@platform/defaults/longRunningModelTransport';
 import {
   type FileLocation,
   type MediaAttachmentKind,
@@ -376,6 +376,25 @@ type InteractionsRequestOptions = {
   fetchOptions: RequestInit;
 };
 
+type GoogleInteractionsSdkClient = {
+  _httpClient: { request(request: Request): Promise<Response> };
+};
+type GoogleInteractionsClientInternals = {
+  getClient(apiVersion?: string): GoogleInteractionsSdkClient;
+};
+
+/** Install the pinned SDK's request-local HTTP seam on every API-version client. */
+function installLongRunningInteractionsTransport(client: GoogleGenAI): void {
+  const interactions =
+    client.interactions as unknown as GoogleInteractionsClientInternals;
+  const getClient = interactions.getClient.bind(interactions);
+  interactions.getClient = (apiVersion?: string) => {
+    const sdk = getClient(apiVersion);
+    sdk._httpClient = { request: longRunningGoogleInteractionsFetch };
+    return sdk;
+  };
+}
+
 export class ModelHandlerGoogleInteractions extends ModelHandler<
   Step,
   Usage | null,
@@ -665,13 +684,15 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     // `{ attempts: 1 }` — switches apiCall into a pRetry wrapper that converts
     // non-ok responses into bare Errors with no status field, blinding the
     // route gate's 429/5xx classification for Google.
+    const googleClient = new GoogleGenAI({
+      apiKey: credential.apiKey,
+      httpOptions: {
+        baseUrl: credential.baseUrl ?? undefined,
+      },
+    });
+    installLongRunningInteractionsTransport(googleClient);
     const client = this.rememberClientCredentialRoute(
-      new GoogleGenAI({
-        apiKey: credential.apiKey,
-        httpOptions: {
-          baseUrl: credential.baseUrl ?? undefined,
-        },
-      }),
+      googleClient,
       credential.route,
       credential.apiKey,
     );
@@ -1780,22 +1801,16 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
    * client defaults to its own 4-retry backoff, which `httpOptions`-level
    * retry settings do not govern. Abort is wired via `fetchOptions.signal`
    * (GoogleGenAIRequestOptions has no top-level abortSignal field). The
-   * dispatcher threads the shared 30-minute stream-inactivity budget through
-   * the SDK's typed fetchOptions seam — `dispatcher` is undici's non-standard
-   * RequestInit extension honored by Node's fetch but absent from the DOM lib
-   * types this repo compiles against, hence the cast. Verified against
-   * @google/genai 2.12.0 (fetchOptions spreads into the Request init and
-   * survives the SDK's clone/rewrap); re-verify the seam on SDK bumps.
+   * request-local HTTP client observes native fetch response resolution and
+   * applies the shared header/body-inactivity policy without relying on
+   * non-standard RequestInit fields that the SDK drops while rebuilding.
    */
   private interactionsRequestOptions(
     signal?: AbortSignal,
   ): InteractionsRequestOptions {
     return {
       maxRetries: 0,
-      fetchOptions: {
-        ...(signal ? { signal } : {}),
-        dispatcher: composeLongRunningModelDispatcher(),
-      } as RequestInit,
+      fetchOptions: signal ? { signal } : {},
     };
   }
 

--- a/src/platform/defaults/longRunningModelTransport.ts
+++ b/src/platform/defaults/longRunningModelTransport.ts
@@ -12,6 +12,121 @@ const MODEL_STREAM_INACTIVITY_TIMEOUT_MS = 30 * 60 * 1000;
 const MODEL_RESPONSE_HEADERS_TIMEOUT_MS = 10 * 60 * 1000;
 type UploadCompatibleFetch = typeof fetch & { Response: typeof Response };
 
+function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
+  if (typeof timer === 'object' && 'unref' in timer) timer.unref();
+}
+
+/**
+ * Native fetch policy for the Google Interactions client's request-local HTTP
+ * seam. The SDK has already built the final Request by this point.
+ */
+export async function longRunningGoogleInteractionsFetch(
+  input: Request,
+): Promise<Response> {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let disposed = false;
+
+  const clearTimer = () => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    clearTimer();
+    input.signal.removeEventListener('abort', onCallerAbort);
+  };
+  const armTimer = (timeoutMs: number, message: string) => {
+    clearTimer();
+    if (controller.signal.aborted || disposed) return;
+    timer = setTimeout(() => {
+      timer = undefined;
+      controller.abort(new DOMException(message, 'TimeoutError'));
+    }, timeoutMs);
+    unrefTimer(timer);
+  };
+  const onCallerAbort = () => controller.abort(input.signal.reason);
+
+  if (input.signal.aborted) onCallerAbort();
+  else input.signal.addEventListener('abort', onCallerAbort, { once: true });
+  armTimer(
+    MODEL_RESPONSE_HEADERS_TIMEOUT_MS,
+    'Model response headers were not received within 10 minutes',
+  );
+
+  let response: Response;
+  try {
+    response = await globalThis.fetch(
+      new Request(input, { signal: controller.signal }),
+    );
+  } catch (error) {
+    dispose();
+    throw error;
+  }
+  clearTimer();
+
+  if (!response.body) {
+    dispose();
+    return response;
+  }
+
+  const reader = response.body.getReader();
+  const body = new ReadableStream<Uint8Array>({
+    async pull(streamController) {
+      armTimer(
+        MODEL_STREAM_INACTIVITY_TIMEOUT_MS,
+        'Model response body was inactive for 30 minutes',
+      );
+      let rejectForAbort: (() => void) | undefined;
+      const aborted = new Promise<never>((_resolve, reject) => {
+        rejectForAbort = () => reject(controller.signal.reason);
+        if (controller.signal.aborted) rejectForAbort();
+        else {
+          controller.signal.addEventListener('abort', rejectForAbort, {
+            once: true,
+          });
+        }
+      });
+      try {
+        const result = await Promise.race([reader.read(), aborted]);
+        if (result.done) {
+          dispose();
+          streamController.close();
+        } else {
+          streamController.enqueue(result.value);
+        }
+      } catch (error) {
+        dispose();
+        streamController.error(error);
+        void reader.cancel(error).catch(() => undefined);
+      } finally {
+        clearTimer();
+        if (rejectForAbort) {
+          controller.signal.removeEventListener('abort', rejectForAbort);
+        }
+      }
+    },
+    async cancel(reason) {
+      dispose();
+      await reader.cancel(reason);
+    },
+  });
+  const wrapped = new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+  Object.defineProperties(wrapped, {
+    redirected: { value: response.redirected },
+    type: { value: response.type },
+    url: { value: response.url },
+  });
+  return wrapped;
+}
+
 /**
  * Detect a WHATWG ReadableStream without `instanceof`. A stream constructed
  * in another realm (worker_threads, a second vendored `node:stream/web`)
@@ -138,7 +253,7 @@ const withLongStreamTimeouts =
 /** Composes the host's current dispatcher (proxy policy stays host-owned) with
  *  the long-stream timeouts. Composed per call so a runtime proxy change is
  *  honored by the next request. */
-export function composeLongRunningModelDispatcher(): Dispatcher {
+function composeLongRunningModelDispatcher(): Dispatcher {
   return getGlobalDispatcher().compose(withLongStreamTimeouts);
 }
 

--- a/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ModelProvider } from 'llm-zoo';
 import OpenAI from 'openai';
 import { FormData as UndiciFormData, type Dispatcher } from 'undici';
 
@@ -18,7 +19,10 @@ vi.mock('undici', async (importOriginal) => {
 });
 
 // Local imports
+import { ModelHandlerGoogleInteractions } from '@agent/modelHandlers/google/modelHandlerGoogleInteractions';
+import type { ResolvedClientCredential } from '@agent/types/ModelHandlerContracts';
 import { longRunningModelFetch } from '@platform/defaults/longRunningModelTransport';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 interface ComposedDispatcherStub {
   readonly baseDispatch: Dispatcher['dispatch'];
@@ -58,6 +62,8 @@ function stubOkResponse(): void {
 describe('long-running model transport', () => {
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it('applies long timeouts through the host dispatcher for a native Request', async () => {
@@ -94,6 +100,155 @@ describe('long-running model transport', () => {
       }),
       expect.anything(),
     );
+  });
+
+  it('enforces header and body-inactivity deadlines at the pinned Google SDK fetch boundary', async () => {
+    vi.useFakeTimers();
+    class GoogleTransportProbe extends ModelHandlerGoogleInteractions {
+      protected override async resolveClientCredential(): Promise<ResolvedClientCredential> {
+        return {
+          apiKey: 'test-key',
+          baseUrl: null,
+          route: 'api-key',
+        };
+      }
+    }
+    const handler = new GoogleTransportProbe(
+      buildTestModelConfig({
+        name: 'google-transport-probe',
+        label: 'Google transport probe',
+        fullName: 'gemini-test',
+        shortName: 'gemini-test',
+        provider: ModelProvider.GOOGLE,
+        contextWindow: 4096,
+      }),
+    );
+    const client = await handler.getClient();
+    const requests: Request[] = [];
+    let resolveLongHeaders: ((response: Response) => void) | undefined;
+    let longBody: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      requests.push(request);
+      if (requests.length === 1) {
+        return new Promise<Response>((_resolve, reject) => {
+          request.signal.addEventListener(
+            'abort',
+            () => reject(request.signal.reason),
+            { once: true },
+          );
+        });
+      }
+      if (requests.length === 2) {
+        return new Promise<Response>((resolve) => {
+          resolveLongHeaders = resolve;
+        });
+      }
+      if (requests.length === 3) {
+        return Promise.resolve(
+          new Response(new ReadableStream<Uint8Array>(), {
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      return new Promise<Response>((_resolve, reject) => {
+        request.signal.addEventListener(
+          'abort',
+          () => reject(request.signal.reason),
+          { once: true },
+        );
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const params = {
+      model: 'gemini-test',
+      input: [
+        {
+          type: 'user_input' as const,
+          content: [{ type: 'text' as const, text: 'hello' }],
+        },
+      ],
+      stream: false as const,
+    };
+    const options = { maxRetries: 0 };
+
+    const missingHeaders = client.interactions.create(params, options);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    const headerRejection = expect(missingHeaders).rejects.toThrow();
+    expect(requests[0]).toBeInstanceOf(Request);
+    expect(fetchMock.mock.calls[0]).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+    expect(requests[0].signal.reason).toMatchObject({ name: 'TimeoutError' });
+    await headerRejection;
+
+    const longUnary = client.interactions.create(params, options);
+    let longUnarySettled = false;
+    void longUnary.then(
+      () => {
+        longUnarySettled = true;
+      },
+      () => {
+        longUnarySettled = true;
+      },
+    );
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    await vi.advanceTimersByTimeAsync(9 * 60 * 1000);
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        longBody = controller;
+      },
+    });
+    resolveLongHeaders?.(
+      new Response(body, {
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    await Promise.resolve();
+
+    await vi.advanceTimersByTimeAsync(20 * 60 * 1000);
+    longBody?.enqueue(new TextEncoder().encode('{"id":'));
+    await vi.advanceTimersByTimeAsync(20 * 60 * 1000);
+    longBody?.enqueue(new TextEncoder().encode('"int_long",'));
+    expect(longUnarySettled).toBe(false);
+    expect(requests[1].signal.aborted).toBe(false);
+
+    longBody?.enqueue(
+      new TextEncoder().encode('"status":"completed","outputs":[]}'),
+    );
+    longBody?.close();
+    await expect(longUnary).resolves.toMatchObject({
+      id: 'int_long',
+      status: 'completed',
+    });
+
+    const inactiveBody = client.interactions.create(params, options);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+    const inactivityRejection = expect(inactiveBody).rejects.toThrow();
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+    expect(requests[2].signal.reason).toMatchObject({ name: 'TimeoutError' });
+    await inactivityRejection;
+
+    const callerAbort = new AbortController();
+    const dispatcherMarker = {};
+    const userCancelled = client.interactions.create(params, {
+      maxRetries: 0,
+      fetchOptions: {
+        signal: callerAbort.signal,
+        dispatcher: dispatcherMarker,
+      } as RequestInit,
+    });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
+    const finalRequest = requests[3] as Request & { dispatcher?: unknown };
+    expect(finalRequest).toBeInstanceOf(Request);
+    expect(fetchMock.mock.calls[3]).toHaveLength(1);
+    expect(finalRequest.dispatcher).toBeUndefined();
+
+    const userCancellationRejection = expect(userCancelled).rejects.toThrow();
+    const reason = new DOMException('cancelled by user', 'AbortError');
+    callerAbort.abort(reason);
+    expect(finalRequest.signal.aborted).toBe(true);
+    expect(finalRequest.signal.reason).toBe(reason);
+    await userCancellationRejection;
   });
 
   it('translates OpenAI multipart uploads for package Undici', async () => {


### PR DESCRIPTION
## Summary

- stop relying on `fetchOptions.dispatcher` for Google Interactions, because `@google/genai` 2.18.0 rebuilds a native `Request` and calls `fetch(request)`, dropping that non-standard field
- install a request-local HTTP client on the pinned SDK's generated Interactions subclient, after the SDK has built its final `Request`
- enforce the shared 10-minute deadline until native fetch resolves with response headers, then enforce a resettable 30-minute inactivity deadline around response-body reads
- apply the policy to foreground unary and streaming calls, background submit/get/cancel, and compaction while preserving caller abort reasons and the existing server-side cancellation flow

Closes #11713.

## Issue acceptance gates

- [x] No Google Interactions request relies on `fetchOptions.dispatcher`.
- [x] Timeout durations remain defined only in `src/platform/defaults/longRunningModelTransport.ts`.
- [x] The 10-minute timer is cleared when native fetch resolves, not when the outer SDK promise finishes parsing the body.
- [x] Every response-body read gets the shared 30-minute inactivity budget; activity resets it and there is no total generation wall-clock timer.
- [x] The final SDK `Request` signal composes with user/RunScope/host aborts and forwards their reason.
- [x] Timers and abort listeners are removed on fetch failure, body completion, stream cancellation, timeout, or caller abort.
- [x] No process-global dispatcher or global fetch replacement is installed. Unrelated HTTP retains its existing transport.
- [x] The request-local seam covers foreground unary, streaming, background submit/poll/cancel, and compaction.
- [x] The regression invokes the real pinned SDK with mocked global fetch. It verifies the final native `Request`, dropped `dispatcher`, propagated caller abort, header timeout, resettable body inactivity timeout, and a unary body active for more than 10 minutes.

No live-key test was run, so Google background cancellation state transitions retain their existing smoke-test caveat.

## Single source of truth

`src/platform/defaults/longRunningModelTransport.ts` owns both timeout durations and both request phases. The Google-specific adapter consumes those values rather than defining provider-local policy.

## Duplication and abstraction budget

One transport function implements the native fetch header/body boundary. One narrow installer applies it to every API-version client produced by the pinned Interactions runtime. No provider-wide transport facade or duplicate constants were added.

## Net elements (R6)

3 files changed, +303/-18 lines. Added one transport helper export and two file-local structural types. No files, classes, or enums added.

## Consumer counts (R8)

The new transport export has one production consumer, the Google Interactions client installer. The installer applies it to every generated Interactions client, so all `create`, `get`, and `cancel` call sites share the policy without per-call wrappers.

## Host impact

Extension, desktop, and CLI share the same direct Google Interactions handler and receive the same request-local behavior. OpenAI, OpenRouter, uploads, and unrelated native fetch calls are unchanged.

## Validation

- Direct reproduction against `@google/genai` 2.18.0: final fetch input was a native `Request`; `fetch` received no init; `dispatcher` was absent; the cloned signal reacted to source abort.
- Focused Google + transport suites: 7 files passed, 1 live suite skipped; 100 tests passed, 4 live tests skipped.
- `corepack pnpm run typecheck`: all six typecheck lanes passed.
- `corepack pnpm run lint`: passed.
- `corepack pnpm run format:check`: passed.
- `corepack pnpm run compile:fast`: passed.
- `corepack pnpm run check:dead-code-ratchet`: passed, 295 findings matched 295 baselined.
- `corepack pnpm test`: 822 files passed, 1 skipped; 9,990 tests passed, 6 skipped. One unrelated desktop timing test failed in the full parallel run and passed immediately in isolation: `DesktopAgentExecution.vitest.ts > presents a merge failure that occurs before lifecycle startup`.
