### PR TITLE
fix: route streaming Interactions through long-running transport

### DIFF
--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -376,8 +376,12 @@ type InteractionsRequestOptions = {
   fetchOptions: RequestInit;
 };
 
+type GoogleInteractionsHttpClient = {
+  request(request: Request): Promise<Response>;
+};
 type GoogleInteractionsSdkClient = {
-  _httpClient: { request(request: Request): Promise<Response> };
+  _httpClient: GoogleInteractionsHttpClient;
+  _options: { http_client: GoogleInteractionsHttpClient };
 };
 type GoogleInteractionsClientInternals = {
   getClient(apiVersion?: string): GoogleInteractionsSdkClient;
@@ -390,7 +394,10 @@ function installLongRunningInteractionsTransport(client: GoogleGenAI): void {
   const getClient = interactions.getClient.bind(interactions);
   interactions.getClient = (apiVersion?: string) => {
     const sdk = getClient(apiVersion);
-    sdk._httpClient = { request: longRunningGoogleInteractionsFetch };
+    const httpClient = { request: longRunningGoogleInteractionsFetch };
+    sdk._httpClient = httpClient;
+    // Streaming lazily constructs sdk.interactions from this option object.
+    sdk._options.http_client = httpClient;
     return sdk;
   };
 }

--- a/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
@@ -87,14 +87,29 @@ async function createGoogleTransportClient(): Promise<GoogleGenAI> {
   return handler.getClient();
 }
 
-function pendingBodyResponse(
-  sourceCancel: (reason?: unknown) => void,
-): Response {
-  return new Response(
+function stubGoogleBody(
+  path: string,
+  options: { body?: string; signal?: AbortSignal } = {},
+) {
+  const input = new Request(
+    `https://generativelanguage.googleapis.com/${path}`,
+    options.signal ? { signal: options.signal } : undefined,
+  );
+  const addListener = vi.spyOn(input.signal, 'addEventListener');
+  const removeListener = vi.spyOn(input.signal, 'removeEventListener');
+  const sourceCancel = vi.fn();
+  const response = new Response(
     new ReadableStream<Uint8Array>({
+      start(controller) {
+        if (options.body === undefined) return;
+        controller.enqueue(new TextEncoder().encode(options.body));
+        controller.close();
+      },
       cancel: sourceCancel,
     }),
   );
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+  return { input, addListener, removeListener, sourceCancel };
 }
 
 describe('long-running model transport', () => {
@@ -270,54 +285,48 @@ describe('long-running model transport', () => {
     await userCancellationRejection;
   });
 
-  it.each(['normal success', 'fetch failure'] as const)(
-    'cleans up its timer and caller abort listener after %s',
-    async (outcome) => {
-      vi.useFakeTimers();
-      const caller = new AbortController();
-      const input = new Request(
-        'https://generativelanguage.googleapis.com/test',
-        {
-          signal: caller.signal,
-        },
-      );
-      const addListener = vi.spyOn(input.signal, 'addEventListener');
-      const removeListener = vi.spyOn(input.signal, 'removeEventListener');
-      const failure = new Error('fetch failed');
-      vi.stubGlobal(
-        'fetch',
-        vi.fn(() => {
-          if (outcome === 'normal success') {
-            return Promise.resolve(new Response('{"ok":true}'));
-          }
-          return Promise.reject(failure);
-        }),
-      );
+  it('cleans up after normal source stream consumption', async () => {
+    vi.useFakeTimers();
+    const caller = new AbortController();
+    const { input, addListener, removeListener, sourceCancel } = stubGoogleBody(
+      'success',
+      { body: '{"ok":true}', signal: caller.signal },
+    );
 
-      const result = longRunningGoogleInteractionsFetch(input);
-      if (outcome === 'normal success') {
-        await expect((await result).json()).resolves.toEqual({ ok: true });
-      } else {
-        await expect(result).rejects.toBe(failure);
-      }
+    const response = await longRunningGoogleInteractionsFetch(input);
+    await expect(response.json()).resolves.toEqual({ ok: true });
 
-      expect(addListener).toHaveBeenCalledOnce();
-      expect(removeListener).toHaveBeenCalledOnce();
-      expect(vi.getTimerCount()).toBe(0);
-    },
-  );
+    expect(addListener).toHaveBeenCalledOnce();
+    expect(removeListener).toHaveBeenCalledOnce();
+    expect(sourceCancel).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('cleans up its timer and caller abort listener after fetch failure', async () => {
+    vi.useFakeTimers();
+    const caller = new AbortController();
+    const input = new Request(
+      'https://generativelanguage.googleapis.com/fetch-failure',
+      { signal: caller.signal },
+    );
+    const addListener = vi.spyOn(input.signal, 'addEventListener');
+    const removeListener = vi.spyOn(input.signal, 'removeEventListener');
+    const failure = new Error('fetch failed');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(failure));
+
+    await expect(longRunningGoogleInteractionsFetch(input)).rejects.toBe(
+      failure,
+    );
+
+    expect(addListener).toHaveBeenCalledOnce();
+    expect(removeListener).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
 
   it('cancels the source reader and cleans up after a body timeout', async () => {
     vi.useFakeTimers();
-    const input = new Request(
-      'https://generativelanguage.googleapis.com/body-timeout',
-    );
-    const removeListener = vi.spyOn(input.signal, 'removeEventListener');
-    const sourceCancel = vi.fn();
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue(pendingBodyResponse(sourceCancel)),
-    );
+    const { input, removeListener, sourceCancel } =
+      stubGoogleBody('body-timeout');
 
     const response = await longRunningGoogleInteractionsFetch(input);
     const body = response.text();
@@ -335,15 +344,11 @@ describe('long-running model transport', () => {
   it('cancels the source reader and cleans up when the caller aborts during the body', async () => {
     vi.useFakeTimers();
     const caller = new AbortController();
-    const input = new Request(
-      'https://generativelanguage.googleapis.com/abort-body',
-      { signal: caller.signal },
-    );
-    const removeListener = vi.spyOn(input.signal, 'removeEventListener');
-    const sourceCancel = vi.fn();
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue(pendingBodyResponse(sourceCancel)),
+    const { input, removeListener, sourceCancel } = stubGoogleBody(
+      'abort-body',
+      {
+        signal: caller.signal,
+      },
     );
 
     const response = await longRunningGoogleInteractionsFetch(input);
@@ -362,15 +367,8 @@ describe('long-running model transport', () => {
 
   it('cancels the source reader and cleans up when the consumer cancels the stream', async () => {
     vi.useFakeTimers();
-    const input = new Request(
-      'https://generativelanguage.googleapis.com/cancel-stream',
-    );
-    const removeListener = vi.spyOn(input.signal, 'removeEventListener');
-    const sourceCancel = vi.fn();
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue(pendingBodyResponse(sourceCancel)),
-    );
+    const { input, removeListener, sourceCancel } =
+      stubGoogleBody('cancel-stream');
 
     const response = await longRunningGoogleInteractionsFetch(input);
     const reason = new Error('consumer stopped');
@@ -381,7 +379,7 @@ describe('long-running model transport', () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
-  it('installs the long-running HTTP seam for every Google Interactions route and API version', async () => {
+  it('routes every Google Interactions request through the long-running HTTP seam', async () => {
     vi.useFakeTimers();
     const client = await createGoogleTransportClient();
     const interactions = client.interactions as unknown as {
@@ -392,11 +390,12 @@ describe('long-running model transport', () => {
     const installedGetClient = interactions.getClient.bind(interactions);
     const routeClients: Array<{
       apiVersion: string | undefined;
-      request: unknown;
+      request: ReturnType<typeof vi.fn>;
     }> = [];
     interactions.getClient = (apiVersion?: string) => {
       const sdk = installedGetClient(apiVersion);
-      routeClients.push({ apiVersion, request: sdk._httpClient.request });
+      const request = vi.spyOn(sdk._httpClient, 'request');
+      routeClients.push({ apiVersion, request });
       return sdk;
     };
 
@@ -412,28 +411,35 @@ describe('long-running model transport', () => {
             { headers: { 'content-type': 'text/event-stream' } },
           );
         }
+        const responses = [
+          { id: 'created', status: 'completed' },
+          { id: 'retrieved', status: 'completed' },
+          { id: 'cancelled', status: 'cancelled' },
+        ];
         return new Response(
-          JSON.stringify({
-            id: requests.length === 2 ? 'retrieved' : 'cancelled',
-            status: requests.length === 2 ? 'completed' : 'cancelled',
-            outputs: [],
-          }),
+          JSON.stringify({ ...responses[requests.length - 2], outputs: [] }),
           { headers: { 'content-type': 'application/json' } },
         );
       }),
     );
 
     const stream = await client.interactions.create(
-      {
-        model: 'gemini-test',
-        input: [],
-        stream: true,
-        api_version: 'v1alpha',
-      },
+      { model: 'gemini-test', input: [], stream: true },
       { maxRetries: 0 },
     );
     const events = [];
     for await (const event of stream) events.push(event);
+    await expect(
+      client.interactions.create(
+        {
+          model: 'gemini-test',
+          input: [],
+          stream: false,
+          api_version: 'v1alpha',
+        },
+        { maxRetries: 0 },
+      ),
+    ).resolves.toMatchObject({ id: 'created', status: 'completed' });
     await expect(
       client.interactions.get('retrieved', {}, { maxRetries: 0 }),
     ).resolves.toMatchObject({ id: 'retrieved', status: 'completed' });
@@ -444,12 +450,17 @@ describe('long-running model transport', () => {
     expect(events).toEqual([
       expect.objectContaining({ event_type: 'interaction.completed' }),
     ]);
-    expect(routeClients).toEqual([
-      { apiVersion: 'v1alpha', request: longRunningGoogleInteractionsFetch },
-      { apiVersion: undefined, request: longRunningGoogleInteractionsFetch },
-      { apiVersion: undefined, request: longRunningGoogleInteractionsFetch },
+    expect(routeClients.map(({ apiVersion }) => apiVersion)).toEqual([
+      undefined,
+      'v1alpha',
+      undefined,
+      undefined,
     ]);
+    expect(
+      routeClients.map(({ request }) => request.mock.calls.length),
+    ).toEqual([1, 1, 1, 1]);
     expect(requests.map((request) => new URL(request.url).pathname)).toEqual([
+      '/v1beta/interactions',
       '/v1alpha/interactions',
       '/v1beta/interactions/retrieved',
       '/v1beta/interactions/cancelled/cancel',

--- a/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
@@ -394,6 +394,7 @@ describe('long-running model transport', () => {
     }> = [];
     interactions.getClient = (apiVersion?: string) => {
       const sdk = installedGetClient(apiVersion);
+      expect(sdk._httpClient.request).toBe(longRunningGoogleInteractionsFetch);
       const request = vi.spyOn(sdk._httpClient, 'request');
       routeClients.push({ apiVersion, request });
       return sdk;

--- a/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
@@ -21,8 +21,12 @@ vi.mock('undici', async (importOriginal) => {
 // Local imports
 import { ModelHandlerGoogleInteractions } from '@agent/modelHandlers/google/modelHandlerGoogleInteractions';
 import type { ResolvedClientCredential } from '@agent/types/ModelHandlerContracts';
-import { longRunningModelFetch } from '@platform/defaults/longRunningModelTransport';
+import {
+  longRunningGoogleInteractionsFetch,
+  longRunningModelFetch,
+} from '@platform/defaults/longRunningModelTransport';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
+import type { GoogleGenAI } from '@google/genai';
 
 interface ComposedDispatcherStub {
   readonly baseDispatch: Dispatcher['dispatch'];
@@ -56,6 +60,40 @@ function stubOkResponse(): void {
   stubComposedDispatcher();
   transportMocks.undiciFetch.mockResolvedValueOnce(
     new Response(null, { status: 204 }),
+  );
+}
+
+class GoogleTransportProbe extends ModelHandlerGoogleInteractions {
+  protected override async resolveClientCredential(): Promise<ResolvedClientCredential> {
+    return {
+      apiKey: 'test-key',
+      baseUrl: null,
+      route: 'api-key',
+    };
+  }
+}
+
+async function createGoogleTransportClient(): Promise<GoogleGenAI> {
+  const handler = new GoogleTransportProbe(
+    buildTestModelConfig({
+      name: 'google-transport-probe',
+      label: 'Google transport probe',
+      fullName: 'gemini-test',
+      shortName: 'gemini-test',
+      provider: ModelProvider.GOOGLE,
+      contextWindow: 4096,
+    }),
+  );
+  return handler.getClient();
+}
+
+function pendingBodyResponse(
+  sourceCancel: (reason?: unknown) => void,
+): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      cancel: sourceCancel,
+    }),
   );
 }
 
@@ -104,26 +142,7 @@ describe('long-running model transport', () => {
 
   it('enforces header and body-inactivity deadlines at the pinned Google SDK fetch boundary', async () => {
     vi.useFakeTimers();
-    class GoogleTransportProbe extends ModelHandlerGoogleInteractions {
-      protected override async resolveClientCredential(): Promise<ResolvedClientCredential> {
-        return {
-          apiKey: 'test-key',
-          baseUrl: null,
-          route: 'api-key',
-        };
-      }
-    }
-    const handler = new GoogleTransportProbe(
-      buildTestModelConfig({
-        name: 'google-transport-probe',
-        label: 'Google transport probe',
-        fullName: 'gemini-test',
-        shortName: 'gemini-test',
-        provider: ModelProvider.GOOGLE,
-        contextWindow: 4096,
-      }),
-    );
-    const client = await handler.getClient();
+    const client = await createGoogleTransportClient();
     const requests: Request[] = [];
     let resolveLongHeaders: ((response: Response) => void) | undefined;
     let longBody: ReadableStreamDefaultController<Uint8Array> | undefined;
@@ -249,6 +268,193 @@ describe('long-running model transport', () => {
     expect(finalRequest.signal.aborted).toBe(true);
     expect(finalRequest.signal.reason).toBe(reason);
     await userCancellationRejection;
+  });
+
+  it.each(['normal success', 'fetch failure'] as const)(
+    'cleans up its timer and caller abort listener after %s',
+    async (outcome) => {
+      vi.useFakeTimers();
+      const caller = new AbortController();
+      const input = new Request(
+        'https://generativelanguage.googleapis.com/test',
+        {
+          signal: caller.signal,
+        },
+      );
+      const addListener = vi.spyOn(input.signal, 'addEventListener');
+      const removeListener = vi.spyOn(input.signal, 'removeEventListener');
+      const failure = new Error('fetch failed');
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(() => {
+          if (outcome === 'normal success') {
+            return Promise.resolve(new Response('{"ok":true}'));
+          }
+          return Promise.reject(failure);
+        }),
+      );
+
+      const result = longRunningGoogleInteractionsFetch(input);
+      if (outcome === 'normal success') {
+        await expect((await result).json()).resolves.toEqual({ ok: true });
+      } else {
+        await expect(result).rejects.toBe(failure);
+      }
+
+      expect(addListener).toHaveBeenCalledOnce();
+      expect(removeListener).toHaveBeenCalledOnce();
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it('cancels the source reader and cleans up after a body timeout', async () => {
+    vi.useFakeTimers();
+    const input = new Request(
+      'https://generativelanguage.googleapis.com/body-timeout',
+    );
+    const removeListener = vi.spyOn(input.signal, 'removeEventListener');
+    const sourceCancel = vi.fn();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(pendingBodyResponse(sourceCancel)),
+    );
+
+    const response = await longRunningGoogleInteractionsFetch(input);
+    const body = response.text();
+    const rejection = expect(body).rejects.toMatchObject({
+      name: 'TimeoutError',
+    });
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+    await rejection;
+    await vi.waitFor(() => expect(sourceCancel).toHaveBeenCalledOnce());
+
+    expect(removeListener).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('cancels the source reader and cleans up when the caller aborts during the body', async () => {
+    vi.useFakeTimers();
+    const caller = new AbortController();
+    const input = new Request(
+      'https://generativelanguage.googleapis.com/abort-body',
+      { signal: caller.signal },
+    );
+    const removeListener = vi.spyOn(input.signal, 'removeEventListener');
+    const sourceCancel = vi.fn();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(pendingBodyResponse(sourceCancel)),
+    );
+
+    const response = await longRunningGoogleInteractionsFetch(input);
+    const body = response.text();
+    const rejection = expect(body).rejects.toMatchObject({
+      name: 'AbortError',
+    });
+    const reason = new DOMException('caller cancelled', 'AbortError');
+    caller.abort(reason);
+    await rejection;
+    await vi.waitFor(() => expect(sourceCancel).toHaveBeenCalledWith(reason));
+
+    expect(removeListener).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('cancels the source reader and cleans up when the consumer cancels the stream', async () => {
+    vi.useFakeTimers();
+    const input = new Request(
+      'https://generativelanguage.googleapis.com/cancel-stream',
+    );
+    const removeListener = vi.spyOn(input.signal, 'removeEventListener');
+    const sourceCancel = vi.fn();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(pendingBodyResponse(sourceCancel)),
+    );
+
+    const response = await longRunningGoogleInteractionsFetch(input);
+    const reason = new Error('consumer stopped');
+    await response.body?.cancel(reason);
+
+    expect(sourceCancel).toHaveBeenCalledWith(reason);
+    expect(removeListener).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('installs the long-running HTTP seam for every Google Interactions route and API version', async () => {
+    vi.useFakeTimers();
+    const client = await createGoogleTransportClient();
+    const interactions = client.interactions as unknown as {
+      getClient(apiVersion?: string): {
+        _httpClient: { request(request: Request): Promise<Response> };
+      };
+    };
+    const installedGetClient = interactions.getClient.bind(interactions);
+    const routeClients: Array<{
+      apiVersion: string | undefined;
+      request: unknown;
+    }> = [];
+    interactions.getClient = (apiVersion?: string) => {
+      const sdk = installedGetClient(apiVersion);
+      routeClients.push({ apiVersion, request: sdk._httpClient.request });
+      return sdk;
+    };
+
+    const requests: Request[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const request = input as Request;
+        requests.push(request);
+        if (requests.length === 1) {
+          return new Response(
+            'data: {"event_type":"interaction.completed","interaction":{"id":"streamed","status":"completed","outputs":[]}}\n\n',
+            { headers: { 'content-type': 'text/event-stream' } },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            id: requests.length === 2 ? 'retrieved' : 'cancelled',
+            status: requests.length === 2 ? 'completed' : 'cancelled',
+            outputs: [],
+          }),
+          { headers: { 'content-type': 'application/json' } },
+        );
+      }),
+    );
+
+    const stream = await client.interactions.create(
+      {
+        model: 'gemini-test',
+        input: [],
+        stream: true,
+        api_version: 'v1alpha',
+      },
+      { maxRetries: 0 },
+    );
+    const events = [];
+    for await (const event of stream) events.push(event);
+    await expect(
+      client.interactions.get('retrieved', {}, { maxRetries: 0 }),
+    ).resolves.toMatchObject({ id: 'retrieved', status: 'completed' });
+    await expect(
+      client.interactions.cancel('cancelled', {}, { maxRetries: 0 }),
+    ).resolves.toMatchObject({ id: 'cancelled', status: 'cancelled' });
+
+    expect(events).toEqual([
+      expect.objectContaining({ event_type: 'interaction.completed' }),
+    ]);
+    expect(routeClients).toEqual([
+      { apiVersion: 'v1alpha', request: longRunningGoogleInteractionsFetch },
+      { apiVersion: undefined, request: longRunningGoogleInteractionsFetch },
+      { apiVersion: undefined, request: longRunningGoogleInteractionsFetch },
+    ]);
+    expect(requests.map((request) => new URL(request.url).pathname)).toEqual([
+      '/v1alpha/interactions',
+      '/v1beta/interactions/retrieved',
+      '/v1beta/interactions/cancelled/cancel',
+    ]);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it('translates OpenAI multipart uploads for package Undici', async () => {


### PR DESCRIPTION
## Summary

Fixes the Google Interactions streaming transport bypass found while hardening the real `@google/genai` 2.19.0 boundary.

The SDK's streaming path lazily constructs its nested `interactions` facade from `sdk._options.http_client`, while unary, get, and cancel routes use `sdk._httpClient`. `installLongRunningInteractionsTransport` now installs one request-local HTTP client on both private seams. This keeps the fix local to each generated client and does not replace global fetch or the process dispatcher.

The real-SDK regression now executes and spies on four routes independently:

- default-version streaming create
- alternate-version (`v1alpha`) unary create
- default-version get
- default-version cancel

It consumes the streaming SSE iterator, verifies each route invokes its own installed request seam exactly once, checks API-version routing and URL paths, and leaves no timers behind. The transport cleanup coverage also verifies normal body consumption, fetch failure, body inactivity timeout, caller abort, and consumer cancellation, including listener disposal and source-reader cancellation where required.

Closes #11719.

## Behavior and scope

- Client-local transport installation only.
- No global fetch replacement.
- No process dispatcher mutation.
- Unary, streaming, background, compaction, alternate API-version, get, and cancel behavior remains on the existing code paths.
- Production change is limited to installing the same HTTP client on the two seams used by pinned SDK 2.19.0.
- Regression coverage remains in the existing `LongRunningModelFetch.vitest.ts` suite.

## Validation

- Pre-fix reproduction: focused route regression received request-spy counts `[0, 1, 1, 1]` instead of `[1, 1, 1, 1]`.
- Focused Vitest: 1 file, 22 tests passed.
- `npm run compile:fast`: passed.
- `npm run typecheck`: passed, including workspace, test-kernel, agent, CLI, trace-viewer, and desktop checks.
- `npm run lint`: passed.
- Changed-file Prettier check: passed.
- `git diff --check`: passed.
- Architecture suite: 15 files, 101 tests passed.
- Dead-code ratchet: passed at 295 combined findings versus 295 baselined.
- Full Vitest run: 816 files and 9,974 tests passed; 7 files had 12 unrelated timeout/load failures under full-suite contention. Re-running those 7 files together passed all 124 tests.

## Validation caveats

- Repository-wide `npm run format:check` reports four generated trace-viewer artifacts; both changed files pass Prettier directly.
- Raw `npm run check:dead-code` reports the six existing unused desktop exports represented by the baseline; `npm run check:dead-code-ratchet` passes with no new findings.
