### PR TITLE
refactor: behavior-preserving simplification sweep over repo-root src/

### DIFF
--- a/src/agent/core/state/AgentState.ts
+++ b/src/agent/core/state/AgentState.ts
@@ -8,6 +8,7 @@ import {
   RunUsageAccumulatorJSONSchema,
   recordNormalizedUsage,
 } from '../usage/RunUsageAccumulator';
+
 export const ConversationRoundStateSnapshotSchema = z.object({
   roundIndex: z.int().nonnegative(),
   continuationCount: z.int().nonnegative().prefault(0),

--- a/src/agent/core/state/executionRequests.ts
+++ b/src/agent/core/state/executionRequests.ts
@@ -4,7 +4,6 @@ import {
   type AgentConfig,
   type AgentConfigInput,
 } from '../definition/AgentConfig';
-
 import type { z } from 'zod';
 
 export interface ExecutionRequest {

--- a/src/agent/followUp/ToolFileInteractionContext.ts
+++ b/src/agent/followUp/ToolFileInteractionContext.ts
@@ -53,7 +53,7 @@ export async function withToolFileInteractionContext<T>(
   run: () => Promise<T> | T,
 ): Promise<T> {
   const parentStack = contextStackScope.getStore() ?? [];
-  return contextStackScope.run([...parentStack, context], async () => run());
+  return contextStackScope.run([...parentStack, context], run);
 }
 
 export function getCurrentToolCallContext(): ToolCallContext | undefined {

--- a/src/agent/implementations/agentCreator/agentCreatorFlow.ts
+++ b/src/agent/implementations/agentCreator/agentCreatorFlow.ts
@@ -70,7 +70,10 @@ const ParsedCreatorYamlSchema = z.object({
   }),
 });
 
-function parseCreatorTemplate(fileName: string, raw: string) {
+function parseCreatorTemplate(
+  fileName: string,
+  raw: string,
+): z.infer<typeof ParsedCreatorYamlSchema> {
   const parsed = ParsedCreatorYamlSchema.safeParse(yaml.parse(raw));
   if (!parsed.success) {
     throw new Error(

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -99,21 +99,13 @@ export class OutputNode extends BaseNode<
       );
 
       if (hasRoundOutputs(outputState, currentRound)) {
-        const roundMapping = traceFileLineage(
-          outputState,
-          diffBaseFiles,
-          currentRound,
-        );
-        mapping = roundMapping;
+        mapping = traceFileLineage(outputState, diffBaseFiles, currentRound);
 
         // `handleLatexdiffOfOutput` already wraps its whole body in
         // `tryOperation`, so a second recover layer here would only ever see
         // its own push.
         compiledArtifacts.push(
-          ...(await diffManager.handleLatexdiffOfOutput(
-            currentRound,
-            roundMapping,
-          )),
+          ...(await diffManager.handleLatexdiffOfOutput(currentRound, mapping)),
         );
 
         await tryOperation(async () => {

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -74,13 +74,11 @@ export class ResponseCycleNode extends BaseNode<
   }
 
   override async exec(prepRes: CyclePrepInput): Promise<CycleOutcome> {
-    const { context } = prepRes;
-
     const [outputAlreadyComplete, initializedMessages] =
       await this.services.modelCell.handler.initializeOutputAndPrefill(
         this.services.config,
         this.services.setting,
-        context,
+        prepRes.context,
         prepRes.workspace,
         prepRes.outputLocation,
       );

--- a/src/agent/implementations/flows/reflection/output/XmlOutputManager.ts
+++ b/src/agent/implementations/flows/reflection/output/XmlOutputManager.ts
@@ -487,13 +487,14 @@ export class XmlOutputManager {
   ): string {
     const trimmed = content.trimEnd();
 
-    const cleaned =
-      trimmed.includes('\\begin{document}') ||
-      !trimmed.endsWith('\\end{document}')
-        ? trimmed
-        : trimmed.replace(/\\end{document}\s*$/, '').trimEnd();
-
-    if (cleaned !== trimmed) {
+    // Strip a trailing \end{document} only from a fragment; a complete
+    // document (one with \begin{document}) keeps its closing tag.
+    let cleaned = trimmed;
+    if (
+      !trimmed.includes('\\begin{document}') &&
+      trimmed.endsWith('\\end{document}')
+    ) {
+      cleaned = trimmed.replace(/\\end{document}\s*$/, '').trimEnd();
       this.logger.debug(`Removed trailing \\end{document} from ${fileName}`);
     }
 

--- a/src/agent/implementations/flows/reflection/output/fileMapping.ts
+++ b/src/agent/implementations/flows/reflection/output/fileMapping.ts
@@ -32,32 +32,31 @@ export function createFileMapping(
   const normalizeName = roundAware
     ? (name: string) => name.split('_r')[0]
     : (name: string) => name;
+  const baseNameOf = (filePath: string): string =>
+    normalizeName(path.parse(path.basename(filePath)).name);
+
+  // Source names do not depend on the target, so derive them once up front.
+  const sources = sourceFiles.map((sourceFile) => {
+    const sourcePath = fileLocationDisplayPath(sourceFile);
+    return { sourcePath, sourceName: baseNameOf(sourcePath) };
+  });
 
   for (const target of targetFiles) {
     const targetPath = fileLocationDisplayPath(target);
     const targetBaseName = path.basename(targetPath);
-    const targetName = normalizeName(path.parse(targetBaseName).name);
+    const targetName = baseNameOf(targetPath);
 
     let bestMatchSourcePath: string | null = null;
     let bestMatchScore = 0;
 
-    for (const sourceFile of sourceFiles) {
-      const sourcePath = fileLocationDisplayPath(sourceFile);
-      const sourceName = normalizeName(
-        path.parse(path.basename(sourcePath)).name,
-      );
+    for (const { sourcePath, sourceName } of sources) {
+      const matches =
+        matchStrategy === 'basename'
+          ? sourceName === targetName
+          : targetBaseName.includes(sourceName);
 
-      let matchScore = 0;
-      if (matchStrategy === 'basename') {
-        if (sourceName === targetName) {
-          matchScore = sourceName.length;
-        }
-      } else if (targetBaseName.includes(sourceName)) {
-        matchScore = sourceName.length;
-      }
-
-      if (matchScore > bestMatchScore) {
-        bestMatchScore = matchScore;
+      if (matches && sourceName.length > bestMatchScore) {
+        bestMatchScore = sourceName.length;
         bestMatchSourcePath = sourcePath;
       }
     }
@@ -70,6 +69,8 @@ export function createFileMapping(
   return fileMapping;
 }
 
+const TEX_EXTENSION_REGEX = /\.tex$/i;
+
 /**
  * Update \input commands in output files to reference new file paths.
  *
@@ -77,8 +78,6 @@ export function createFileMapping(
  * @param outputFiles Output file paths
  * @param logger Optional logger for debug messages
  */
-const TEX_EXTENSION_REGEX = /\.tex$/i;
-
 export async function replaceInputCommands(
   baseFiles: FileLocation[],
   outputFiles: FileLocation[],

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -58,7 +58,9 @@ export class ToolUsePrepareNode extends BaseNode<
         logger,
         promptOptions,
       );
-    const systemMessage = buildSystemText(systemPrompt, instructionSuffix);
+    const systemMessage = systemPrompt
+      ? `${systemPrompt}\n${instructionSuffix}`
+      : instructionSuffix;
 
     if (resumeShared) {
       // The persisted messages are used verbatim -- including `messages[0]`
@@ -161,18 +163,4 @@ export class ToolUsePrepareNode extends BaseNode<
 
     return FlowTransition.DEFAULT;
   }
-}
-
-/**
- * Combine the system prompt with the instruction suffix into the single text
- * block used for the system message. Falls back to the suffix alone when there
- * is no system prompt.
- */
-function buildSystemText(
-  systemPrompt: string,
-  instructionSuffix: string,
-): string {
-  return systemPrompt
-    ? `${systemPrompt}\n${instructionSuffix}`
-    : instructionSuffix;
 }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -381,7 +381,6 @@ export async function runToolUseFlow(
   let outcome: RunToolUseFlowResult['outcome'] = RUN_OUTCOME.CANCELLED;
   let files: string[] | undefined;
   let totalCostUsd: number | undefined;
-  let attachmentFollowUps: readonly FollowUpQueueBatchItem[] = [];
   let resumeStartupPreservation:
     'cancellation' | 'initial-read-failure' | undefined;
   let persistenceRecoveryPending = false;
@@ -434,7 +433,7 @@ export async function runToolUseFlow(
 
   try {
     liveAttachment.attach();
-    attachmentFollowUps = input.takePendingFollowUps?.() ?? [];
+    const attachmentFollowUps = input.takePendingFollowUps?.() ?? [];
     // A host can hand off a cancellation synchronously during setup. Observe
     // it before touching the persisted resume record.
     if (signal.aborted && input.resume) {

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -17,13 +17,9 @@ export {
   InvalidAgentTeamError,
 } from '../roster/AgentRosterController';
 
-export {
-  // Types
-  type AgentEntry,
-} from './agentEntry';
+export type { AgentEntry } from './agentEntry';
 
 export {
-  // Core functions
   loadAgents,
   registerInlineAgents,
   getAgent,

--- a/src/agent/index/remoteAgentMeta.ts
+++ b/src/agent/index/remoteAgentMeta.ts
@@ -48,16 +48,17 @@ export async function loadRemoteAgents(): Promise<AgentEntry[]> {
     const metaCache = getPersistedRemoteAgentMeta();
 
     return remotes.map((remote) => {
-      const isToolUse = remote.agentCategory === AgentCategory.ToolUse;
       const cached = metaCache[remote.name];
-      const dbTools = remote.tools?.length ? remote.tools : undefined;
       return {
         name: remote.name,
         source: 'remote' as const,
         path: '',
-        category: isToolUse ? AgentCategory.ToolUse : AgentCategory.Workflow,
+        category:
+          remote.agentCategory === AgentCategory.ToolUse
+            ? AgentCategory.ToolUse
+            : AgentCategory.Workflow,
         description: remote.description ?? undefined,
-        tools: dbTools ?? cached?.tools,
+        tools: remote.tools?.length ? remote.tools : cached?.tools,
         defaultOutputFiles: cached?.defaultOutputFiles,
       };
     });

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -630,13 +630,23 @@ export abstract class ModelHandler<
     if (this.lastAttemptUsageRoute !== undefined) {
       return this.lastAttemptUsageRoute;
     }
-    // OpenRouter billing rolls up under the direct API-key tag; the
-    // subscription route names are already valid usage tags, and a new
-    // credential route fails to compile here until it picks its own tag.
-    if (this.lastAttemptCredentialRoute === 'openrouter') {
-      return 'api-key';
+    const route = this.lastAttemptCredentialRoute;
+    switch (route) {
+      case 'chatgpt-subscription':
+        return 'chatgpt-subscription';
+      case 'xai-subscription':
+        return 'xai-subscription';
+      case 'api-key':
+      case 'openrouter':
+        return 'api-key';
+      case undefined:
+        return undefined;
+      default:
+        // A new route must pick its own usage tag here: untagged usage is
+        // dropped silently by the caller rather than reported.
+        route satisfies never;
+        return undefined;
     }
-    return this.lastAttemptCredentialRoute;
   }
 
   /**

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -630,23 +630,13 @@ export abstract class ModelHandler<
     if (this.lastAttemptUsageRoute !== undefined) {
       return this.lastAttemptUsageRoute;
     }
-    const route = this.lastAttemptCredentialRoute;
-    switch (route) {
-      case 'chatgpt-subscription':
-        return 'chatgpt-subscription';
-      case 'xai-subscription':
-        return 'xai-subscription';
-      case 'api-key':
-      case 'openrouter':
-        return 'api-key';
-      case undefined:
-        return undefined;
-      default:
-        // A new route must pick its own usage tag here: untagged usage is
-        // dropped silently by the caller rather than reported.
-        route satisfies never;
-        return undefined;
+    // OpenRouter billing rolls up under the direct API-key tag; the
+    // subscription route names are already valid usage tags, and a new
+    // credential route fails to compile here until it picks its own tag.
+    if (this.lastAttemptCredentialRoute === 'openrouter') {
+      return 'api-key';
     }
+    return this.lastAttemptCredentialRoute;
   }
 
   /**
@@ -915,7 +905,7 @@ export abstract class ModelHandler<
   ): MediaAttachmentKind[] {
     const kinds = this.insertedAttachmentKinds.get(context) ?? [];
     this.insertedAttachmentKinds.set(context, []);
-    return [...kinds];
+    return kinds;
   }
 
   /**

--- a/src/agent/modelHandlers/anthropic/anthropicServerTools.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicServerTools.ts
@@ -47,20 +47,19 @@ export function stripOrphanedServerToolUse<T>(blocks: readonly T[]): {
     }
   }
 
+  const resultIdsFor = (name: string): Set<string> | undefined => {
+    if (name === 'web_search') return searchResultIds;
+    if (name === 'web_fetch') return fetchResultIds;
+    return undefined;
+  };
+
   const orphanedIds: string[] = [];
   const kept = blocks.filter((block) => {
     if (!isAnthropicServerToolUse(block)) return true;
-    if (block.name === 'web_search') {
-      if (searchResultIds.has(block.id)) return true;
-      orphanedIds.push(block.id);
-      return false;
-    }
-    if (block.name === 'web_fetch') {
-      if (fetchResultIds.has(block.id)) return true;
-      orphanedIds.push(block.id);
-      return false;
-    }
-    return true;
+    const resultIds = resultIdsFor(block.name);
+    if (!resultIds || resultIds.has(block.id)) return true;
+    orphanedIds.push(block.id);
+    return false;
   });
 
   return { kept, orphanedIds };

--- a/src/agent/modelHandlers/anthropic/anthropicUsage.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicUsage.ts
@@ -18,7 +18,7 @@ const CACHE_CREATION_COST_MULTIPLIER_5M = 1.25;
 const CACHE_CREATION_COST_MULTIPLIER_1H = 2.0;
 
 /** Pricing inputs the handler supplies from its `config`/`capabilities`. */
-export interface AnthropicPricingConfig {
+interface AnthropicPricingConfig {
   inputPrice: number;
   outputPrice: number;
   supportsPromptCaching: boolean;

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -56,10 +56,7 @@ import type {
 import { countPdfPagesInBuffer } from '@utils/media/pdfPageCount';
 
 // Local file imports
-import {
-  normalizeAnthropicUsage,
-  type AnthropicPricingConfig,
-} from './anthropicUsage';
+import { normalizeAnthropicUsage } from './anthropicUsage';
 import {
   getAnthropicMaxPdfPages,
   estimateTokensFromText,
@@ -1365,19 +1362,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
   /** Normalizes Anthropic usage data into a unified format. */
   normalizeUsage(rawUsage: BetaUsage, responseTimeMs: number): NormalizedUsage {
-    return normalizeAnthropicUsage(
-      rawUsage,
-      responseTimeMs,
-      this.pricingConfig(),
-    );
-  }
-
-  /** Pricing/caching inputs for the extracted usage helpers. */
-  private pricingConfig(): AnthropicPricingConfig {
-    return {
+    return normalizeAnthropicUsage(rawUsage, responseTimeMs, {
       ...this.standardPricingConfig(),
       supportsPromptCaching: this.capabilities.supportsPromptCaching,
-    };
+    });
   }
 
   protected override createAssistantMessageForAccumulatedOutput(
@@ -1676,15 +1664,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     const uploadedAttachments: UploadedAnthropicAttachment[] =
       uploadResult?.uploaded ?? [];
-    const unsupportedAttachments: ToolFileAttachment[] = [];
+    const unsupportedAttachments: ToolFileAttachment[] = canUpload
+      ? [...(uploadResult?.unsupported ?? [])]
+      : [...attachments];
     const pageLimitExceeded: ToolFileAttachment[] =
       uploadResult?.pageLimitExceeded ?? [];
-
-    if (canUpload) {
-      unsupportedAttachments.push(...(uploadResult?.unsupported ?? []));
-    } else if (attachments.length > 0) {
-      unsupportedAttachments.push(...attachments);
-    }
 
     // Build tool result as plain text - JSON wastes tokens
     // Note: Anthropic handles attachments as separate content blocks, not in text

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -271,8 +271,7 @@ interface TransientBackgroundRetrievalState {
 function isStaleInteractionChainError(error: unknown): boolean {
   const status = detectStatusCode(error);
   const message = errorMessageOf(error);
-  const rawCode = (error as { code?: unknown })?.code;
-  const code = typeof rawCode === 'string' ? rawCode : '';
+  const code = pickStringField(error, 'code') ?? '';
 
   const mentionsPreviousInteractionId = /previous_interaction_id/i.test(
     message,

--- a/src/agent/modelHandlers/openai/OpenAIResponseWebSocketTransport.ts
+++ b/src/agent/modelHandlers/openai/OpenAIResponseWebSocketTransport.ts
@@ -184,7 +184,7 @@ export class OpenAIResponseWebSocketTransport {
       let settled = false;
       const cleanup = (): void => {
         ws.socket.off('open', onOpen);
-        ws.socket.off('error', onError);
+        ws.socket.off('error', failHandshake);
         ws.off('error', onTopLevelError);
         signal?.removeEventListener('abort', onAbort);
       };
@@ -210,9 +210,6 @@ export class OpenAIResponseWebSocketTransport {
         });
         reject(err);
       };
-      const onError = (err: Error): void => {
-        failHandshake(err);
-      };
       const onTopLevelError = (err: WebSocketError): void => {
         failHandshake(err.cause instanceof Error ? err.cause : err);
       };
@@ -225,7 +222,7 @@ export class OpenAIResponseWebSocketTransport {
       };
 
       ws.socket.once('open', onOpen);
-      ws.socket.once('error', onError);
+      ws.socket.once('error', failHandshake);
       ws.on('error', onTopLevelError);
       signal?.addEventListener('abort', onAbort, { once: true });
     });

--- a/src/agent/modelHandlers/openai/functionToolCalls.ts
+++ b/src/agent/modelHandlers/openai/functionToolCalls.ts
@@ -24,7 +24,7 @@ import type {
  * payloads (e.g. null array slots) without throwing.
  */
 export function isFunctionToolCall(
-  toolCall: ChatCompletionMessageToolCall | null | undefined | unknown,
+  toolCall: unknown,
 ): toolCall is ChatCompletionMessageFunctionToolCall {
   return (
     toolCall != null &&

--- a/src/agent/modelHandlers/openai/modelHandlerGLM.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerGLM.ts
@@ -77,11 +77,7 @@ export class ModelHandlerGLM extends ReasoningModelHandlerOpenAI {
 
     const effort = this.getEffectiveReasoningEffort();
     const normalized = effort
-      ? normalizeSupportedReasoningEffort(
-          effort,
-          supported,
-          this.capabilities.reasoningEffort,
-        )
+      ? this.normalizeReasoningEffort(effort)
       : this.capabilities.reasoningEffort;
     return normalized === ReasoningEffort.NONE
       ? { type: 'disabled' }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -573,9 +573,11 @@ export class ModelHandlerOpenAI<
     if (!convertContentToString && !this.mergeConsecutiveRoles) {
       return undefined;
     }
+    // Both flags default to false in normalizeOpenAIMessageContent, so
+    // passing them explicitly is the same as omitting the disabled ones.
     return {
-      ...(convertContentToString ? { convertContentToString: true } : {}),
-      ...(this.mergeConsecutiveRoles ? { mergeConsecutiveRoles: true } : {}),
+      convertContentToString,
+      mergeConsecutiveRoles: this.mergeConsecutiveRoles,
     };
   }
 

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -2551,10 +2551,6 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
     if (!Array.isArray(items)) return [];
 
     const calls = items.filter(isResponseFunctionToolCallItem);
-    if (calls.length === 0) {
-      return [];
-    }
-
     return calls.map((call) => ({
       provider: 'openai-response',
       callId: call.call_id,

--- a/src/agent/modelHandlers/openai/openAIMessageUtils.ts
+++ b/src/agent/modelHandlers/openai/openAIMessageUtils.ts
@@ -303,14 +303,13 @@ export async function initializeChatMessages<T extends MessageLike>(
 
   // Add final user request: into the user message just pushed, or as its own
   // 'system'-role message when the model requires intermediate dev messages.
-  const requestRole = capabilities.supportsIntermDevMsgs ? 'system' : 'user';
-  if (requestRole === 'user') {
-    userMessageContent.push({ type: 'text', text: userRequest });
-  } else {
+  if (capabilities.supportsIntermDevMsgs) {
     messages.push({
-      role: requestRole,
+      role: 'system',
       content: [{ type: 'text', text: userRequest }],
     } as T);
+  } else {
+    userMessageContent.push({ type: 'text', text: userRequest });
   }
 
   return messages;

--- a/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
@@ -121,7 +121,7 @@ async function replaceFileDataWithUpload(
         ? Buffer.from(dataUriToBuffer(fileData).buffer)
         : Buffer.from(fileData, 'base64');
     const uploadedFile = await client.files.create({
-      file: await toFile(buffer!, filename),
+      file: await toFile(buffer, filename),
       purpose: 'assistants',
     });
 
@@ -189,7 +189,7 @@ export async function uploadToolAttachments(
       const mimeType = attachment.mimeType ?? 'application/octet-stream';
 
       const uploadedFile = await client.files.create({
-        file: await toFile(buffer!, attachmentFilename(attachment), {
+        file: await toFile(buffer, attachmentFilename(attachment), {
           type: mimeType,
         }),
         purpose: 'assistants',

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -283,14 +283,12 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
         // starts fire (if ever) at the first reasoning/content delta.
         thinking = this.createThinkingStream();
         output = this.createOutputStream();
-        const thinkingStream = thinking;
-        const outputStream = output;
 
         for await (const chunk of stream) {
           const { contentDelta, reasoningDelta } =
             aggregator.consumeChunk(chunk);
-          if (reasoningDelta) thinkingStream.append(reasoningDelta);
-          if (contentDelta) outputStream.append(contentDelta);
+          if (reasoningDelta) thinking.append(reasoningDelta);
+          if (contentDelta) output.append(contentDelta);
         }
 
         const response = aggregator.buildResponse();

--- a/src/agent/modelHandlers/support/contextUtilization.ts
+++ b/src/agent/modelHandlers/support/contextUtilization.ts
@@ -1,13 +1,5 @@
 import { roundTo } from '@utils/core';
 
-/** Raw percentage of the context window consumed by `tokens`. */
-function computeUtilizationPercent(
-  tokens: number,
-  contextWindow: number,
-): number {
-  return (tokens / contextWindow) * 100;
-}
-
 /**
  * Rounded percentage of the context window consumed by `tokens`. Single
  * source for the rounded log/display value so every surface reports the same
@@ -18,5 +10,5 @@ export function roundedUtilizationPercent(
   contextWindow: number,
   decimals = 1,
 ): number {
-  return roundTo(computeUtilizationPercent(tokens, contextWindow), decimals);
+  return roundTo((tokens / contextWindow) * 100, decimals);
 }

--- a/src/agent/modelHandlers/support/mediaAttachmentPolicy.ts
+++ b/src/agent/modelHandlers/support/mediaAttachmentPolicy.ts
@@ -38,18 +38,11 @@ import { getSdkErrorMessage } from '@common/errors/sdkError/providerErrorFormat'
  * They stay distinct context labels (rather than collapsing to one) because
  * the label is what lands in the emitted trace message, and because a future
  * change to this policy (e.g. making `toolAttachment` failures stricter)
- * should be a one-line change to `shouldFailRound`/`CONTEXT_SEVERITY`, not a
- * re-audit of every call site.
+ * should be a one-line change to the fail-vs-warn check or `CONTEXT_SEVERITY`,
+ * not a re-audit of every call site.
  */
 export type MediaAttachmentContext =
   'initial' | 'followUp' | 'insert' | 'toolAttachment';
-
-/** The only place that decides fail-vs-warn for a media/attachment failure. */
-function shouldFailRound(
-  context: MediaAttachmentContext,
-): context is 'initial' {
-  return context === 'initial';
-}
 
 const CONTEXT_LABEL: Record<MediaAttachmentContext, string> = {
   initial: 'initial message',
@@ -97,7 +90,9 @@ export function reportMediaAttachmentFailure(
   err: unknown,
   detail?: string,
 ): void {
-  if (shouldFailRound(context)) {
+  // The only fail-vs-warn decision point: `initial` fails the round loudly;
+  // every other context logs and degrades to "continue without attachment".
+  if (context === 'initial') {
     throw err instanceof Error ? err : new Error(getSdkErrorMessage(err));
   }
   const suffix = detail ? ` (${detail})` : '';

--- a/src/agent/prompt/userVars.ts
+++ b/src/agent/prompt/userVars.ts
@@ -580,8 +580,9 @@ export function getToolFlags(
   agentSetting: AgentSetting,
   agentPrompt: AgentPrompt,
 ): ToolFlagVars {
-  const hasTool = (name: string) =>
-    agentSetting.tools.some((tool) => tool.name === name);
+  function hasTool(name: string): boolean {
+    return agentSetting.tools.some((tool) => tool.name === name);
+  }
 
   const flags: ToolFlagVars = {
     CODEX_GUIDANCE: hasTool('codex') ? TOOL_GUIDANCE.codex : '',

--- a/src/agent/runtime/AgentFlowResult.ts
+++ b/src/agent/runtime/AgentFlowResult.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
 
-import { AttachedMemoryMissSchema } from '@agent/types/AttachedMemory';
+import {
+  AttachedMemoryMissSchema,
+  type AttachedMemoryMiss,
+} from '@agent/types/AttachedMemory';
 import type { ExecutionId, RunOutcome, StreamTabId } from '@shared/schemas';
 import {
   CompileFailureSummarySchema,
@@ -108,7 +111,7 @@ export function buildTerminalFlowResult(
   outcome: RunOutcome,
   executionId: ExecutionId,
   streamId: StreamTabId,
-  memoryMisses?: z.infer<typeof AttachedMemoryMissSchema>[],
+  memoryMisses?: AttachedMemoryMiss[],
 ): AgentFlowResult {
   const meta = {
     executionId,

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -287,10 +287,10 @@ async function assembleAgentLaunchContext(
     fullConfig.agentSource,
   );
   input.signal?.throwIfAborted();
-  // `loadAgentSettingAndPrompts` already applies `ensureAgentCategoryForSource`
-  // before parsing, and `AgentSettingSchema` prefaults `agentCategory` (to
-  // Workflow when absent), so `setting.agentCategory` is always populated here —
-  // a second `ensureAgentCategoryForSource` pass would be a guaranteed no-op.
+  // `loadAgentSettingAndPrompts` already fills the built-in tool-use category
+  // default before parsing, and `AgentSettingSchema` prefaults `agentCategory`
+  // (to Workflow when absent), so `setting.agentCategory` is always populated
+  // here — a second defaulting pass would be a guaranteed no-op.
   const [setting, prompt] = await loadAgentSettingAndPrompts(resolution);
   input.signal?.throwIfAborted();
 

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -552,7 +552,7 @@ export class SessionHostInteractions implements HostInteractions {
   ): Promise<BashSettlement> {
     return this.enqueue<BashSettlement>(
       'bash',
-      request.streamId ?? undefined,
+      request.streamId,
       (interactions) => interactions.requestBashApproval?.(request),
       (cause) => cancellationResultFor('bash', cause),
     );

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -359,17 +359,11 @@ function withShortModelName(config: ModelConfig): ModelConfig {
 function withCompatibilityRoutingMode(
   config: ModelConfig,
   compatibilityKey: ModelHandlerCompatibilityKey,
-): ModelConfig {
+): ResolvedModelConfig {
   if (compatibilityKey === 'ModelHandlerOpenRouterNative') {
     return { ...config, openRouterOnly: true };
   }
-
-  const routed: ResolvedModelConfig = {
-    ...config,
-    openRouterOnly: false,
-    forceDirectProvider: true,
-  };
-  return routed;
+  return { ...config, openRouterOnly: false, forceDirectProvider: true };
 }
 
 /**

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -177,13 +177,10 @@ export class StreamStatusMachine {
     const fromReservation = entry?.kind === 'reserved';
     const previousState = fromReservation ? entry.rollbackTo : entry?.state;
     const from = previousState?.phase;
-    let tableFrom: StreamPhase | undefined;
-    if (!fromReservation) {
-      tableFrom = from;
-    } else if (to === STREAM_PHASE.RUNNING) {
-      tableFrom = undefined;
-    } else {
-      tableFrom = STREAM_PHASE.RUNNING;
+    let tableFrom = from;
+    if (fromReservation) {
+      tableFrom =
+        to === STREAM_PHASE.RUNNING ? undefined : STREAM_PHASE.RUNNING;
     }
     if (!canTransitionStreamPhase(tableFrom, to, cause)) return false;
 

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -15,7 +15,7 @@ import { mergeInheritedAgentObject } from '@agent/core/definition/agentDefinitio
 import { inlineAgentDefinition } from '@agent/index/inlineAgents';
 import { loadRemoteAgent } from '@agent/remote/RemoteAgentLoader';
 import { parseYamlWith, safeParseYaml } from '@common/parsing/safeParseYaml';
-import { agentKey, AgentCategory, type AgentSource } from '@shared/schemas';
+import { agentKey, AgentCategory } from '@shared/schemas';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 
 import { normalizeAgentSettingTools } from './agentSettingTools';
@@ -59,15 +59,6 @@ async function loadYaml(absolutePath: string): Promise<object> {
     );
   }
   return parsed.value as object;
-}
-
-function ensureAgentCategoryForSource<
-  T extends { agentCategory?: AgentCategory },
->(settings: T, source: AgentSource): T {
-  if (source === 'builtInToolUse' && !settings.agentCategory) {
-    return { ...settings, agentCategory: AgentCategory.ToolUse };
-  }
-  return settings;
 }
 
 export async function loadAgentSettingAndPrompts(
@@ -154,7 +145,9 @@ export async function loadAgentSettingAndPrompts(
     prompts = mergeInheritedAgentObject(parentPrompts, config.prompts);
   }
 
-  settings = ensureAgentCategoryForSource(settings, entry.source);
+  if (entry.source === 'builtInToolUse' && !settings.agentCategory) {
+    settings = { ...settings, agentCategory: AgentCategory.ToolUse };
+  }
 
   const normalizedSettings = normalizeAgentSettingTools(settings, CHANNEL);
 

--- a/src/agent/runtime/agentSettingTools.ts
+++ b/src/agent/runtime/agentSettingTools.ts
@@ -18,29 +18,24 @@ export function normalizeAgentSettingTools(
   channel: string,
 ): AgentSettingInput {
   if (!Array.isArray(settings.tools)) return settings;
+  const tools = settings.tools.map((tool) =>
+    typeof tool === 'string' ? { name: tool } : tool,
+  );
   // Latent silent-failure trap: the shared settings schema accepts `tools:`
   // for every category, but a workflow (reflection) run only *sends* the
   // definitions to the provider — a returned tool call is never dispatched.
   // Say so at load time instead of letting the agent author discover it from
   // a model that keeps asking for a tool that never answers.
-  if (
-    settings.agentCategory === AgentCategory.Workflow &&
-    settings.tools.length > 0
-  ) {
+  if (settings.agentCategory === AgentCategory.Workflow && tools.length > 0) {
     // The channel is caller-threaded (local and remote loaders report on their
     // own), so bind at call scope rather than freezing one at module load.
     createLog(channel).warn(
-      `Workflow-category agent declares tools: [${settings.tools
-        .map((tool) => (typeof tool === 'string' ? tool : tool.name))
+      `Workflow-category agent declares tools: [${tools
+        .map((tool) => tool.name)
         .join(
           ', ',
         )}]. Workflow runs never dispatch tool calls, so these are inert; remove tools: or make the agent toolUse.`,
     );
   }
-  return {
-    ...settings,
-    tools: settings.tools.map((tool) =>
-      typeof tool === 'string' ? { name: tool } : tool,
-    ),
-  };
+  return { ...settings, tools };
 }

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -517,18 +517,6 @@ function turnDeliveryId(turnRef: ChildTurnRef): string {
 type ChildLoopTerminationCause = 'interrupted' | 'turn_failed' | 'terminal';
 
 /**
- * Resolve the loop's termination cause without a nested ternary.
- */
-function resolveLoopTerminationCause(
-  interrupted: boolean,
-  turnFailed: boolean,
-): ChildLoopTerminationCause {
-  if (interrupted) return 'interrupted';
-  if (turnFailed) return 'turn_failed';
-  return 'terminal';
-}
-
-/**
  * Structured turn-lifecycle diagnostic (#9531): ties the execution, the turn's
  * logical identity, the follow-up queue owner/generation, and the interruption
  * cause into one event so a resumed/interrupted child's state is auditable.
@@ -1110,13 +1098,16 @@ export function startChildRunLoop<TTurn>(
       // acceptance record cannot land after the retry's newer turn state.
       await turnStateWrites.onIdle();
       detachLoopInterrupt?.();
+      let terminationCause: ChildLoopTerminationCause = 'terminal';
+      if (loop.isInterrupted()) {
+        terminationCause = 'interrupted';
+      } else if (sawTurnFailure) {
+        terminationCause = 'turn_failed';
+      }
       emitTurnDiagnostic(logger, 'loop.terminated', {
         executionId,
         queueOwner: queueLease,
-        interruptionCause: resolveLoopTerminationCause(
-          loop.isInterrupted(),
-          sawTurnFailure,
-        ),
+        interruptionCause: terminationCause,
       });
       if (queueLease) runSession.followUps.release(queueLease, 'terminal');
       releaseSessionOwnershipOnce();

--- a/src/agent/runtime/modelHandlerCompatibilityInference.ts
+++ b/src/agent/runtime/modelHandlerCompatibilityInference.ts
@@ -25,10 +25,9 @@ export function inferPersistedFlowModelHandlerCompatibilityKey(
   shared: unknown,
 ): ModelHandlerCompatibilityKey | undefined {
   if (!isObject(shared)) return undefined;
-  const record = shared;
 
   const parsedKey = ModelHandlerCompatibilityKeySchema.nullish().safeParse(
-    record.modelHandlerCompatibilityKey,
+    shared.modelHandlerCompatibilityKey,
   );
   if (parsedKey.success && parsedKey.data) return parsedKey.data;
 

--- a/src/agent/runtime/persistedCompileRejection.ts
+++ b/src/agent/runtime/persistedCompileRejection.ts
@@ -1,30 +1,29 @@
 import { getExecutionStore } from '@agent/storage';
 import { readPersistedFlowRecord } from '@agent/node/persistedFlow';
 import type { ExecutionId } from '@shared/schemas';
+import { isObject } from '@utils/core';
 
 const LEGACY_FINAL_COMPILE_REJECTION_MESSAGE =
   'Automatic LaTeX compilation failed after the final workflow round.';
 
 /** Whether persisted state records an unresolved compile rejection. */
 export function hasPersistedCompileRejection(shared: unknown): boolean {
-  if (typeof shared !== 'object' || shared === null) return false;
-  const state = shared as Record<string, unknown>;
-  if (state.unresolvedCompileRejection === true) return true;
+  if (!isObject(shared)) return false;
+  if (shared.unresolvedCompileRejection === true) return true;
   return (
-    state.unresolvedCompileRejection === undefined &&
-    typeof state.compileFailureContext === 'string' &&
-    state.compileFailureContext.length > 0
+    shared.unresolvedCompileRejection === undefined &&
+    typeof shared.compileFailureContext === 'string' &&
+    shared.compileFailureContext.length > 0
   );
 }
 
 /** Whether persisted compile rejection has reached the configured round cap. */
 export function isTerminalPersistedCompileRejection(shared: unknown): boolean {
-  if (!hasPersistedCompileRejection(shared)) return false;
-  const state = shared as Record<string, unknown>;
+  if (!isObject(shared) || !hasPersistedCompileRejection(shared)) return false;
   return (
-    typeof state.currentRound === 'number' &&
-    typeof state.totalRounds === 'number' &&
-    state.currentRound + 1 >= state.totalRounds
+    typeof shared.currentRound === 'number' &&
+    typeof shared.totalRounds === 'number' &&
+    shared.currentRound + 1 >= shared.totalRounds
   );
 }
 
@@ -38,11 +37,10 @@ export async function hasTerminalPersistedCompileRejection(
 
 /** Identify the exact provider-like error synthesized by legacy workflow code. */
 export function isLegacySyntheticFinalCompileError(error: unknown): boolean {
-  if (typeof error !== 'object' || error === null) return false;
-  const value = error as Record<string, unknown>;
+  if (!isObject(error)) return false;
   return (
-    Object.keys(value).length === 2 &&
-    value.message === LEGACY_FINAL_COMPILE_REJECTION_MESSAGE &&
-    value.userRetryable === false
+    Object.keys(error).length === 2 &&
+    error.message === LEGACY_FINAL_COMPILE_REJECTION_MESSAGE &&
+    error.userRetryable === false
   );
 }

--- a/src/agent/runtime/workflowControlRegistry.ts
+++ b/src/agent/runtime/workflowControlRegistry.ts
@@ -39,6 +39,6 @@ export class WorkflowControlRegistry {
    * id. No-op if no live run owns it.
    */
   control(grandchildId: ExecutionId, action: WorkflowControlAction): void {
-    for (const control of this.runs.values()) control(grandchildId, action);
+    for (const control of this.runs) control(grandchildId, action);
   }
 }

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -2,14 +2,6 @@
 import PQueue from 'p-queue';
 
 // Local imports
-import {
-  deleteExecution as deleteStoredExecution,
-  listExecutionStreamReferences,
-  type DeleteExecutionOptions,
-  type DeleteExecutionResult,
-  type ExecutionStreamReferenceListing,
-  readExecutionStreamIndex,
-} from '@agent/storage/executionListing';
 import { createLog } from '@logger/logUtils';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import type { StreamLogStore, StreamSnapshotStore } from '@transcript';
@@ -17,6 +9,14 @@ import { StreamDeletionSupersededError } from '@transcript/StreamLogStore';
 import { canUseStreamDataDir } from '@transcript/streamDataPaths';
 import { throwAggregated, unique } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import {
+  deleteExecution as deleteStoredExecution,
+  listExecutionStreamReferences,
+  type DeleteExecutionOptions,
+  type DeleteExecutionResult,
+  type ExecutionStreamReferenceListing,
+  readExecutionStreamIndex,
+} from './executionListing';
 
 const log = createLog('SessionStores');
 

--- a/src/agent/storage/childRunOutput.ts
+++ b/src/agent/storage/childRunOutput.ts
@@ -55,17 +55,20 @@ export async function resolveChildRunOutput(
     reference.executionId,
     reference.relativePath,
   );
-  if (entry.kind === 'file') return entry.location;
-  if (entry.kind === 'symlink') return undefined;
-  if (entry.kind === 'missing') {
-    throw new Error(
-      `Declared output ${reference.relativePath} is missing from execution ${reference.executionId}.`,
-    );
+  switch (entry.kind) {
+    case 'file':
+      return entry.location;
+    case 'symlink':
+      return undefined;
+    case 'missing':
+      throw new Error(
+        `Declared output ${reference.relativePath} is missing from execution ${reference.executionId}.`,
+      );
+    case 'invalid':
+      throw new Error(`Invalid declared workflow output: ${entry.reason}`);
+    default:
+      throw new Error(
+        `Declared output ${reference.relativePath} is not a regular file.`,
+      );
   }
-  if (entry.kind === 'invalid') {
-    throw new Error(`Invalid declared workflow output: ${entry.reason}`);
-  }
-  throw new Error(
-    `Declared output ${reference.relativePath} is not a regular file.`,
-  );
 }

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -651,8 +651,10 @@ export async function runWithExecutionLeaseWriteFence<T>(
   const key = ownershipKey(root, executionId);
   if (maintenanceExecutions.getStore()?.has(key)) return operation();
   const lease = ownedLeases.get(key);
-  if (lease?.releasing) throw new ExecutionLeaseLostError(executionId);
-  if (lease) return runWithValidatedOwnership(lease, operation);
+  if (lease) {
+    if (lease.releasing) throw new ExecutionLeaseLostError(executionId);
+    return runWithValidatedOwnership(lease, operation);
+  }
   // Unleased writers in this process take turns, so that two of them never
   // refuse each other over the maintenance claim the first one holds.
   // `runOnPerKeyQueue` also drops the idle queue when the operation throws,

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -268,6 +268,8 @@ export async function finalizeRun(
   input: FinalizeExecutionInput,
 ): Promise<FinalizeExecutionResult> {
   const { executionId, outcome, flowRecord, keepExistingOutcome } = input;
+  const deleteFlowRecord = (): Promise<void> =>
+    getExecutionStore(executionId).delete(flowKey(executionId));
   const failed = (
     error: unknown,
     outcomePersisted: boolean,
@@ -294,7 +296,7 @@ export async function finalizeRun(
     // checkpoint is deleted only on request, never to fail closed.
     if (flowRecord === 'delete') {
       try {
-        await getExecutionStore(executionId).delete(flowKey(executionId));
+        await deleteFlowRecord();
       } catch (deleteError) {
         return failed(
           new AggregateError(
@@ -310,7 +312,7 @@ export async function finalizeRun(
 
   if (flowRecord === 'delete') {
     try {
-      await getExecutionStore(executionId).delete(flowKey(executionId));
+      await deleteFlowRecord();
     } catch (error) {
       return failed(error, true);
     }

--- a/src/agent/types/ConversationBlockTypes.ts
+++ b/src/agent/types/ConversationBlockTypes.ts
@@ -17,7 +17,7 @@
  * {@link ANTHROPIC_SERVER_TOOL_BLOCK_TYPES} (`@agent/types/ServerTools`) and
  * are imported here for classification, not duplicated.
  */
-import { ANTHROPIC_SERVER_TOOL_BLOCK_TYPES } from '@agent/types/ServerTools';
+import { ANTHROPIC_SERVER_TOOL_BLOCK_TYPES } from './ServerTools';
 
 export const CONVERSATION_BLOCK_TYPES = Object.freeze({
   // Anthropic and Google GenAI extended-thinking / thought blocks.
@@ -83,7 +83,11 @@ export function classifyProviderMessageBlockType(
   // `Object.prototype`, so a provider block typed `'toString'` or
   // `'constructor'` would otherwise return a function into consumer switches
   // that `assertNever` on anything unrecognized.
-  return typeof type === 'string' && Object.hasOwn(CATEGORY_BY_BLOCK_TYPE, type)
-    ? CATEGORY_BY_BLOCK_TYPE[type as keyof typeof CATEGORY_BY_BLOCK_TYPE]
-    : undefined;
+  if (
+    typeof type !== 'string' ||
+    !Object.hasOwn(CATEGORY_BY_BLOCK_TYPE, type)
+  ) {
+    return undefined;
+  }
+  return CATEGORY_BY_BLOCK_TYPE[type as keyof typeof CATEGORY_BY_BLOCK_TYPE];
 }

--- a/src/agent/types/IModelHandler.ts
+++ b/src/agent/types/IModelHandler.ts
@@ -10,8 +10,8 @@ import type { ProviderMessage } from './ProviderMessage';
  * of its own, so it can never drift from the base class: adding, renaming, or
  * retyping a member there is automatically reflected here, and a base-class
  * signature change breaks exactly one place (the class) instead of two. Only
- * members consumers
- * actually call through this port are picked. Omitted members are reached
+ * members consumers actually call through this port are picked. Omitted
+ * members are reached
  * through the concrete class instead: this includes internal-only helpers
  * such as `supportsReasoningLevelOverride`, plus
  * `extractResponse`, which `helperModel` calls on its concrete handler.

--- a/src/agent/types/ProviderMessage.ts
+++ b/src/agent/types/ProviderMessage.ts
@@ -7,8 +7,6 @@ import type { ChatCompletionMessageParam } from 'openai/resources/chat/completio
 import type { ResponseInputItem } from 'openai/resources/responses/responses';
 import type { ChatMessages as OpenRouterMessage } from '@openrouter/sdk/models';
 
-// Local imports
-
 /**
  * Message formats supported by the provider SDKs and host language-model port.
  */

--- a/src/agent/types/ServerTools.ts
+++ b/src/agent/types/ServerTools.ts
@@ -153,11 +153,7 @@ export interface ServerToolExtractionResult {
 
 /** Shared shape check: a non-null object whose `type` matches the given tag. */
 function hasBlockType(value: unknown, type: string): boolean {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    (value as { type?: string }).type === type
-  );
+  return isObject(value) && value.type === type;
 }
 
 /** Type guard for Anthropic server tool use block. */
@@ -431,15 +427,14 @@ export function extractAnthropicWebFetchResults(
     const fetchUrl = urlMap.get(block.tool_use_id) ?? '';
 
     if (isWebFetchBlock(block.content)) {
-      // Successful fetch
-      const fields = extractWebFetchResultFields(block);
+      const fields = webFetchBlockFields(block.content);
       results.push({
-        url: fields?.url || fetchUrl,
-        title: fields?.title,
+        url: fields.url || fetchUrl,
+        title: fields.title,
         provider: 'anthropic',
         callId: block.tool_use_id,
         status: 'completed',
-        content: fields?.content,
+        content: fields.content,
       });
     } else {
       // Error result — block.content is narrowed to WebFetchToolResultErrorBlock

--- a/src/agent/workflowScript/workflowExecutionState.ts
+++ b/src/agent/workflowScript/workflowExecutionState.ts
@@ -371,8 +371,9 @@ export class WorkflowExecutionState {
     const call = this.#call(id);
     const attempt = call.attempts.at(-1);
     if (attempt && attempt.completedAt === undefined) {
-      attempt.completedAt = now();
-      call.timestamps.updatedAt = now();
+      const settledAt = now();
+      attempt.completedAt = settledAt;
+      call.timestamps.updatedAt = settledAt;
       this.#emit();
     }
     return true;
@@ -543,18 +544,7 @@ function totalAttemptCost(
     : undefined;
 }
 
-/** Whether a hydrated call's prior result can be replayed as-is. */
-type ReusableWorkflowExecutionCall = Extract<
-  WorkflowExecutionCall,
-  { readonly status: 'completed' | 'cached' }
->;
-
-function isReusableCall(
-  call: WorkflowExecutionCall,
-): call is ReusableWorkflowExecutionCall {
-  return isReusableStatus(call.status);
-}
-
+/** Whether a hydrated call's status means its prior result can be replayed as-is. */
 function isReusableStatus(status: WorkflowExecutionCall['status']): boolean {
   return (
     status === WORKFLOW_CALL_STATUS.COMPLETED ||
@@ -581,7 +571,7 @@ function recoverCall(
 ): WorkflowExecutionCall {
   if (!prior) return fresh;
   const attempts = closeOpenAttempts(prior.attempts, recoveryAt);
-  if (isReusableCall(prior) || journalProven) {
+  if (isReusableStatus(prior.status) || journalProven) {
     return {
       ...prior,
       id: fresh.id,
@@ -624,7 +614,7 @@ function hydrate(
   for (const prior of persisted.calls) {
     if (freshIds.has(prior.id)) continue;
     const attempts = closeOpenAttempts(prior.attempts, recoveryAt);
-    if (isReusableCall(prior)) {
+    if (isReusableStatus(prior.status)) {
       snapshot.calls.push({
         ...prior,
         stageId: undefined,

--- a/src/auth/authCallback.ts
+++ b/src/auth/authCallback.ts
@@ -8,33 +8,33 @@ export interface AuthCallbackUriParts {
   query?: string;
 }
 
+interface AuthCallbackCodeParseSuccess {
+  success: true;
+  code: string;
+}
+
 interface AuthCallbackParseError {
   success: false;
   error: string;
   isAuthError?: boolean;
 }
 
-function getAuthCallbackBasePath(path: string): string {
-  return path.split('?')[0];
-}
+export type AuthCallbackCodeParseResult =
+  AuthCallbackCodeParseSuccess | AuthCallbackParseError;
 
 export function isAuthCallbackPath(path: string): boolean {
   return AUTH_CALLBACK_PATHS.includes(
-    getAuthCallbackBasePath(path) as (typeof AUTH_CALLBACK_PATHS)[number],
+    path.split('?')[0] as (typeof AUTH_CALLBACK_PATHS)[number],
   );
-}
-
-function getQueryFromPath(path: string): string {
-  const queryStart = path.indexOf('?');
-  return queryStart === -1 ? '' : path.slice(queryStart + 1);
 }
 
 /** Extract the PKCE authorization code or auth error from a callback query. */
 export function parseAuthCallbackCode(
   uri: AuthCallbackUriParts,
 ): AuthCallbackCodeParseResult {
+  const queryStart = uri.path.indexOf('?');
   const queryParams = new URLSearchParams(
-    uri.query || getQueryFromPath(uri.path),
+    uri.query || (queryStart === -1 ? '' : uri.path.slice(queryStart + 1)),
   );
   const getParam = (name: string): string | null => queryParams.get(name);
 
@@ -52,11 +52,3 @@ export function parseAuthCallbackCode(
     ? { success: true, code }
     : { success: false, error: 'Missing authorization code in callback' };
 }
-
-interface AuthCallbackCodeParseSuccess {
-  success: true;
-  code: string;
-}
-
-export type AuthCallbackCodeParseResult =
-  AuthCallbackCodeParseSuccess | AuthCallbackParseError;

--- a/src/auth/codex/CodexSessionCoordinator.ts
+++ b/src/auth/codex/CodexSessionCoordinator.ts
@@ -92,14 +92,13 @@ const CODEX_POLICY: SubscriptionOAuthPolicy<CodexSession> = {
 
 export class CodexSessionCoordinator extends SubscriptionOAuthCoordinator<CodexSession> {
   constructor(init: CodexSessionCoordinatorInit) {
-    const client = init.client ?? {
-      exchangeAuthorizationCode: defaultExchange,
-      refreshTokens: defaultRefresh,
-    };
     super({
       storage: init.storage,
       policy: CODEX_POLICY,
-      client,
+      client: init.client ?? {
+        exchangeAuthorizationCode: defaultExchange,
+        refreshTokens: defaultRefresh,
+      },
       now: init.now,
       errorType: CodexAuthError,
     });

--- a/src/auth/oauth/SubscriptionOAuthCoordinator.ts
+++ b/src/auth/oauth/SubscriptionOAuthCoordinator.ts
@@ -126,7 +126,7 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
     this.storage = init.storage;
     this.policy = init.policy;
     this.client = init.client;
-    this.now = init.now ?? (() => Date.now());
+    this.now = init.now ?? Date.now;
     this.errorType = init.errorType;
   }
 

--- a/src/auth/oauth/deviceCodePoll.ts
+++ b/src/auth/oauth/deviceCodePoll.ts
@@ -36,9 +36,7 @@ export function deviceCodeAuthorized<T>(value: T): DeviceCodePollAuthorized<T> {
 export function deviceCodePending(
   intervalDeltaMs?: number,
 ): DeviceCodePollPending {
-  return intervalDeltaMs === undefined
-    ? { ok: false }
-    : { ok: false, intervalDeltaMs };
+  return { ok: false, intervalDeltaMs };
 }
 
 interface DeviceCodePollOptions<T> {
@@ -70,6 +68,13 @@ interface DeviceCodePollOptions<T> {
   readonly checkDeadlineBeforeSleep?: boolean;
 }
 
+function defaultSleepWithSignal(
+  ms: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  return defaultSleep(ms, undefined, { signal });
+}
+
 /**
  * Poll until {@link DeviceCodePollOptions.attempt} authorizes, the deadline
  * elapses, the signal aborts, or a hard error is thrown.
@@ -78,10 +83,7 @@ export async function pollUntilDeviceAuthorized<T>(
   options: DeviceCodePollOptions<T>,
 ): Promise<T> {
   const now = options.now ?? Date.now;
-  const sleep =
-    options.sleep ??
-    ((ms: number, signal?: AbortSignal) =>
-      defaultSleep(ms, undefined, { signal }));
+  const sleep = options.sleep ?? defaultSleepWithSignal;
   const checkBefore = options.checkDeadlineBeforeSleep ?? true;
   let intervalMs = options.intervalMs;
 

--- a/src/common/errors/sdkError/errorInspection.ts
+++ b/src/common/errors/sdkError/errorInspection.ts
@@ -46,13 +46,37 @@ export function firstBodyStringField(
 }
 
 /** First finite-number `key` field across the body candidates. */
-export function firstBodyNumberField(
+function firstBodyNumberField(
   rawErrorBody: unknown,
   key: string,
 ): number | undefined {
   return errorBodyCandidates(rawErrorBody)
     .map((candidate) => pickNumberField(candidate, key))
     .find((value) => value !== undefined);
+}
+
+/** Reset hint a message-matched subscription usage-limit body can report. */
+export interface UsageLimitMatch {
+  readonly resetsInSeconds?: number;
+}
+
+/** Match a subscription usage-limit phrase against the error's message — the
+ *  body `message` first, then the thrown error's own — returning the reset
+ *  hint when the phrase matches. Shared by the endpoint/route-guarded
+ *  subscription detectors (Kimi Code, SuperGrok), which differ only in their
+ *  guard and phrase. */
+export function matchUsageLimitMessage(
+  err: unknown,
+  rawErrorBody: unknown,
+  pattern: RegExp,
+): UsageLimitMatch | null {
+  const message =
+    firstBodyStringField(rawErrorBody, 'message') ??
+    pickStringField(err, 'message');
+  if (!message || !pattern.test(message)) return null;
+  return {
+    resetsInSeconds: firstBodyNumberField(rawErrorBody, 'resets_in_seconds'),
+  };
 }
 
 /** Get reason phrase, returning undefined for unknown codes (getReasonPhrase throws). */
@@ -160,15 +184,13 @@ export function detectProvider(err: unknown): string | undefined {
 }
 
 function detectProviderFromClassNames(
-  classNames: readonly (string | undefined)[],
+  classNames: readonly string[],
 ): string | undefined {
   // Match SDK class-name fragments, then normalize aliases to the canonical
   // API-provider names used by SecretManager / model handlers. This also covers
   // no-response connection errors whose provider only appears on a base SDK
   // class such as OpenAIError or AnthropicError.
-  const names = classNames
-    .filter((name): name is string => isString(name) && name.length > 0)
-    .map((name) => name.toLowerCase());
+  const names = classNames.map((name) => name.toLowerCase());
   const match = (['openai', 'anthropic', 'google', 'kimi'] as const).find(
     (provider) => names.some((name) => name.includes(provider)),
   );

--- a/src/common/errors/sdkError/kimiCodeSubscriptionDetection.ts
+++ b/src/common/errors/sdkError/kimiCodeSubscriptionDetection.ts
@@ -1,10 +1,6 @@
 import { KIMI_CODE_BASE_URL } from '@shared/constants/providers';
 
-import {
-  firstBodyNumberField,
-  firstBodyStringField,
-  pickStringField,
-} from './errorInspection';
+import { matchUsageLimitMessage } from './errorInspection';
 import { detectSdkRequestBaseURL } from './sdkRequestEndpoint';
 
 /**
@@ -52,13 +48,5 @@ export function parseKimiCodeSubscriptionLimit(
   rawErrorBody: unknown,
 ): KimiCodeSubscriptionLimit | null {
   if (!isKimiCodeEndpointError(err)) return null;
-
-  const message =
-    firstBodyStringField(rawErrorBody, 'message') ??
-    pickStringField(err, 'message');
-  if (!message || !USAGE_LIMIT_PATTERN.test(message)) return null;
-
-  return {
-    resetsInSeconds: firstBodyNumberField(rawErrorBody, 'resets_in_seconds'),
-  };
+  return matchUsageLimitMessage(err, rawErrorBody, USAGE_LIMIT_PATTERN);
 }

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -618,11 +618,6 @@ export function classifyModelRouteFailure(error: Error): ModelRouteVerdict {
   };
 }
 
-/** Whether a normalized provider error is a 401 (auth token rejected). */
-function isUnauthorizedProviderError(formatted: ProviderError): boolean {
-  return formatted.statusCode === StatusCodes.UNAUTHORIZED;
-}
-
 /** Whether repeating the same provider request can recover without user action. */
 export function isProviderErrorAutoRetryable(err: unknown): boolean {
   if (
@@ -637,7 +632,7 @@ export function isProviderErrorAutoRetryable(err: unknown): boolean {
   return (
     formatted.userRetryable &&
     getExhaustionReason(formatted) === undefined &&
-    !isUnauthorizedProviderError(formatted) &&
+    formatted.statusCode !== StatusCodes.UNAUTHORIZED &&
     formatted.statusCode !== StatusCodes.FORBIDDEN
   );
 }

--- a/src/common/errors/sdkError/streamFailure.ts
+++ b/src/common/errors/sdkError/streamFailure.ts
@@ -45,9 +45,7 @@ export function handleStreamingFailure(
 ): never {
   hooks.finalizeOnError?.();
   const partialTail = hooks.partialTail();
-  const decorated = hooks.decorateError
-    ? hooks.decorateError(err, partialTail)
-    : err;
+  const decorated = hooks.decorateError?.(err, partialTail) ?? err;
   attachPartialText(decorated, partialTail);
   throw decorated;
 }

--- a/src/common/errors/sdkError/xaiSubscriptionDetection.ts
+++ b/src/common/errors/sdkError/xaiSubscriptionDetection.ts
@@ -1,8 +1,4 @@
-import {
-  firstBodyNumberField,
-  firstBodyStringField,
-  pickStringField,
-} from './errorInspection';
+import { matchUsageLimitMessage } from './errorInspection';
 import { detectSdkCredentialRoute } from './sdkRequestEndpoint';
 
 /**
@@ -34,13 +30,5 @@ export function parseXaiSubscriptionLimit(
   rawErrorBody: unknown,
 ): XaiSubscriptionLimit | null {
   if (detectSdkCredentialRoute(err) !== 'xai-subscription') return null;
-
-  const message =
-    firstBodyStringField(rawErrorBody, 'message') ??
-    pickStringField(err, 'message');
-  if (!message || !USAGE_LIMIT_PATTERN.test(message)) return null;
-
-  return {
-    resetsInSeconds: firstBodyNumberField(rawErrorBody, 'resets_in_seconds'),
-  };
+  return matchUsageLimitMessage(err, rawErrorBody, USAGE_LIMIT_PATTERN);
 }

--- a/src/common/files/fileListingRules.ts
+++ b/src/common/files/fileListingRules.ts
@@ -61,7 +61,7 @@ export function loadFileListSettings(): FileListSettings {
 }
 
 function buildInputLikeConfig(
-  category: 'input' | 'edited',
+  category: 'input' | 'context' | 'edited',
   settings: FileListSettings,
 ): FileFilterConfig {
   return {
@@ -79,15 +79,8 @@ export function getFileListConfig(
 ): FileFilterConfig {
   switch (fileType) {
     case 'input':
-      return buildInputLikeConfig('input', settings);
     case 'context':
-      return {
-        include: getIncludedExtensions('context'),
-        excludeExtensions: settings.ignoredFileExtensions,
-        excludeDirs: settings.ignoredDirectories,
-        excludeKeywords: settings.ignoredKeywords,
-        excludeFiles: settings.ignoredInputFiles,
-      };
+      return buildInputLikeConfig(fileType, settings);
     case 'media':
       return {
         include: getIncludedExtensions('media'),

--- a/src/controllers/progressView/ProgressFollowUpController.ts
+++ b/src/controllers/progressView/ProgressFollowUpController.ts
@@ -65,13 +65,6 @@ interface CompileFixerInput {
   executionId?: string;
 }
 
-/** The compile-fixer planner is workflow-only; tool-use runs have no plan. */
-function asWorkflowConfig(
-  config: AgentConfig | undefined,
-): AgentConfig | undefined {
-  return config?.agentCategory === AgentCategory.Workflow ? config : undefined;
-}
-
 export class ProgressFollowUpController {
   constructor(private readonly deps: ProgressFollowUpControllerDeps) {}
 
@@ -99,7 +92,11 @@ export class ProgressFollowUpController {
   async planCompileFixer(
     input: CompileFixerInput,
   ): Promise<ProgressFollowUpPlan> {
-    const workflowConfig = asWorkflowConfig(input.runConfig);
+    // The compile-fixer planner is workflow-only; tool-use runs have no plan.
+    const workflowConfig =
+      input.runConfig?.agentCategory === AgentCategory.Workflow
+        ? input.runConfig
+        : undefined;
     if (!workflowConfig) {
       return {
         kind: 'warning',
@@ -154,15 +151,6 @@ export class ProgressFollowUpController {
     };
   }
 
-  private hasEnabledModel(
-    modelOptions: readonly ProgressFollowUpModelOption[],
-    model: string,
-  ): boolean {
-    return modelOptions.some(
-      (option) => option.value === model && !option.disabled,
-    );
-  }
-
   private selectWorkflowModel(
     workflowConfig: AgentConfig,
     modelOptions: readonly ProgressFollowUpModelOption[],
@@ -179,7 +167,10 @@ export class ProgressFollowUpController {
           reason: 'access-list-default',
         },
       ],
-      (model) => this.hasEnabledModel(modelOptions, model),
+      (model) =>
+        modelOptions.some(
+          (option) => option.value === model && !option.disabled,
+        ),
     );
     if (!decision || decision.unavailable) return null;
     return decision.model;

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -413,9 +413,9 @@ export class ProgressBackend {
 
   /** Inject a session fact (tests / rare host seeds). Prefer the hub in production. */
   applySessionFact(
-    ...args: Parameters<SessionFactApplier['handleSessionFact']>
+    fact: Parameters<SessionFactApplier['handleSessionFact']>[0],
   ): boolean {
-    return this.admitSessionFact(args[0]);
+    return this.admitSessionFact(fact);
   }
 
   /** Inject a run fact (tests / rare host seeds). Prefer the hub in production. */
@@ -639,7 +639,7 @@ export class ProgressBackend {
       activeAfterClear !== '' && remainingStreams.includes(activeAfterClear);
     const newerActivationPending =
       activationGenerationAtStart !== this.activationGeneration;
-    const newerIntentControlsSelection = this.newerIntentControlsSelection(
+    const newerIntentControls = this.newerIntentControlsSelection(
       activationGenerationAtStart,
       stream,
     );
@@ -647,8 +647,8 @@ export class ProgressBackend {
     // DELETE_STREAM. A concurrent explicit deselection is presentation intent
     // and must remain empty rather than being replaced by a fallback.
     const shouldActivateStream =
-      (selectionWasDeleted && !newerIntentControlsSelection) ||
-      (wasActive && hasVisibleActive && !newerIntentControlsSelection);
+      !newerIntentControls &&
+      (selectionWasDeleted || (wasActive && hasVisibleActive));
 
     this.postMessage({
       command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
@@ -677,11 +677,11 @@ export class ProgressBackend {
       () => this.prepareAllStreamDeletions(),
       () => this.deleteAllStreamsNow(),
     );
-    const newerIntentControlsSelection =
+    const newerIntentControls =
       this.newerIntentControlsSelection(activationGeneration);
     try {
       await this.lifecycle.rebuildRenderedStreams({
-        syncActiveStream: !outcome.allDeleted && !newerIntentControlsSelection,
+        syncActiveStream: !outcome.allDeleted && !newerIntentControls,
       });
     } catch (error) {
       log.warn('Failed to rebuild rendered streams after bulk deletion', {
@@ -763,12 +763,8 @@ export class ProgressBackend {
   load(): Promise<void> {
     return this.enqueueStorageOperation(async () => {
       await this.session.waitUntilReady();
-      await this.loadPresentationState();
+      await this.state.load(this.stateOwnership);
     });
-  }
-
-  private loadPresentationState(): Promise<void> {
-    return this.state.load(this.stateOwnership);
   }
 
   /**
@@ -790,23 +786,11 @@ export class ProgressBackend {
     prepare: () => Promise<P>,
     work: (prepared: P) => Promise<T>,
   ): Promise<T> {
-    let prepared!: P;
-    let publishPreparation!: (value: PromiseLike<void>) => void;
-    const preparation = new Promise<void>((resolve) => {
-      publishPreparation = resolve;
-    });
-    const operation = this.enqueueStorageOperation(async () => {
-      await preparation;
-      return work(prepared);
-    });
-    const pendingPreparation = Promise.resolve().then(async () => {
-      prepared = await prepare();
-    });
+    const preparation = Promise.resolve().then(prepare);
     // If an earlier queue entry is still running, attach a rejection handler
     // until this operation reaches the same promise.
     void preparation.catch(() => undefined);
-    publishPreparation(pendingPreparation);
-    return operation;
+    return this.enqueueStorageOperation(() => preparation.then(work));
   }
 
   /**

--- a/src/controllers/progressView/exportTranscript.ts
+++ b/src/controllers/progressView/exportTranscript.ts
@@ -18,8 +18,7 @@ import {
   type LatexExportResult,
 } from './ChatExportController';
 
-const TRANSCRIPT_EXPORT_FORMATS = ['html', 'md', 'tex'] as const;
-export type TranscriptExportFormat = (typeof TRANSCRIPT_EXPORT_FORMATS)[number];
+export type TranscriptExportFormat = 'html' | 'md' | 'tex';
 
 export type TranscriptExportOpenKind = 'text' | 'pdf' | 'external';
 

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -369,20 +369,18 @@ export class SessionState {
     const current = this._ephemeralState.get(stream)?.execution;
     if (!current) return;
 
-    const retainedSubagents = current.subagents.filter(
-      (child) => child.finishedAt !== undefined,
+    const liveSubagents = current.subagents.filter(
+      (child) => child.finishedAt === undefined,
     );
     const needsReset =
-      retainedSubagents.length > 0 ||
+      liveSubagents.length !== current.subagents.length ||
       current.conversationProgress.toolCallCount !== 0 ||
       current.stage !== undefined;
 
     if (needsReset) {
       this.getOrCreateEphemeral(stream).execution = {
         ...current,
-        subagents: current.subagents.filter(
-          (child) => child.finishedAt === undefined,
-        ),
+        subagents: liveSubagents,
         conversationProgress: { toolCallCount: 0 },
         stage: undefined,
       };

--- a/src/controllers/settingsView/SettingsViewHost.ts
+++ b/src/controllers/settingsView/SettingsViewHost.ts
@@ -37,6 +37,7 @@ interface SettingsViewHostOptions {
 
 interface SettingsViewHostMutationOptions {
   readonly afterPost?: () => Awaitable<void>;
+  readonly respond?: SettingsRespond;
 }
 
 export class SettingsViewHost {
@@ -112,7 +113,7 @@ export class SettingsViewHost {
 
   async setModelEnabled(
     input: SetModelEnabledInput,
-    options?: SettingsViewHostMutationOptions & { respond?: SettingsRespond },
+    options?: SettingsViewHostMutationOptions,
   ): Promise<void> {
     await this.modelSelectionController.setModelEnabled(input);
     await this.postModelSelectionMutation(options);
@@ -120,14 +121,14 @@ export class SettingsViewHost {
 
   async setReasoningLevel(
     input: SetReasoningLevelInput,
-    options?: SettingsViewHostMutationOptions & { respond?: SettingsRespond },
+    options?: SettingsViewHostMutationOptions,
   ): Promise<void> {
     await this.modelSelectionController.setReasoningLevel(input);
     await this.postModelSelectionMutation(options);
   }
 
   private async postModelSelectionMutation(
-    options?: SettingsViewHostMutationOptions & { respond?: SettingsRespond },
+    options?: SettingsViewHostMutationOptions,
   ): Promise<void> {
     await this.sendModelSelectionData(options?.respond);
     await options?.afterPost?.();

--- a/src/controllers/settingsView/ToolDashboardData.ts
+++ b/src/controllers/settingsView/ToolDashboardData.ts
@@ -67,7 +67,7 @@ export function planToolTerminalAction(input: {
  */
 const BUILTIN_TOOLS: (Omit<
   ToolDashboardItem,
-  'status' | 'tools' | 'installActions'
+  'status' | 'tools' | 'installActions' | 'requiresSetup'
 > & {
   toolNames: readonly RegisteredToolName[];
 })[] = [
@@ -78,7 +78,6 @@ const BUILTIN_TOOLS: (Omit<
     description:
       'Read, write, edit files and run shell commands. Includes glob/grep search.',
     toolNames: ['bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep'],
-    requiresSetup: false,
   },
   {
     id: 'latex-extract',
@@ -91,7 +90,6 @@ const BUILTIN_TOOLS: (Omit<
       'extract_tikz_figures',
       'extract_bib_entries',
     ],
-    requiresSetup: false,
   },
   {
     id: 'latex-diagnostics',
@@ -100,7 +98,6 @@ const BUILTIN_TOOLS: (Omit<
     description:
       'Report LaTeX compilation errors and warnings from the VS Code Problems panel.',
     toolNames: ['diagnostics'],
-    requiresSetup: false,
   },
   {
     id: 'arxiv',
@@ -109,7 +106,6 @@ const BUILTIN_TOOLS: (Omit<
     description:
       'Search arXiv papers, retrieve metadata, and download LaTeX source packages.',
     toolNames: ['arxiv_search', 'arxiv_metadata', 'download_arxiv_source'],
-    requiresSetup: false,
   },
   {
     id: 'crossref',
@@ -118,7 +114,6 @@ const BUILTIN_TOOLS: (Omit<
     description:
       'Search Crossref for academic publications by query or resolve DOIs to full metadata.',
     toolNames: ['crossref_search'],
-    requiresSetup: false,
   },
   {
     id: 'web',
@@ -127,7 +122,6 @@ const BUILTIN_TOOLS: (Omit<
     description:
       'Search the web and fetch or extract content from URLs. Uses native provider tools when available, and DuckDuckGo Instant Answers otherwise.',
     toolNames: ['web_search', 'web_fetch'],
-    requiresSetup: false,
   },
   {
     id: 'memory-workflow',
@@ -144,7 +138,6 @@ const BUILTIN_TOOLS: (Omit<
       'executions',
       'accept_run_files',
     ],
-    requiresSetup: false,
   },
 ];
 
@@ -175,6 +168,7 @@ export async function buildToolDashboardItems(
     tools: toolNames.map((name) => ({ name })),
     status: 'available' as const,
     installActions: [],
+    requiresSetup: false,
   }));
 
   const results = cachedResults ?? (await runExternalToolChecks());

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -78,7 +78,7 @@ export class LaTeXdiffService {
   private async readDiffInputs(
     inputLocation: FileLocation,
     editedLocation: FileLocation,
-  ): Promise<string[] | null> {
+  ): Promise<[string, string] | null> {
     try {
       return await Promise.all([
         AbsoluteFS.read(inputLocation.absolutePath),

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -197,19 +197,13 @@ export async function compileLatex2Pdf(
       log.debug(`Setting ${key} to: ${value}`);
     }
 
-    const latexmkArgs = [
-      '-pdf',
-      '-f',
-      '-interaction=nonstopmode',
-      `-output-directory=${outDir}`,
-      latexFile,
-    ];
-
     const pdflatexArgs = [
       '-interaction=nonstopmode',
       `-output-directory=${outDir}`,
       latexFile,
     ];
+
+    const latexmkArgs = ['-pdf', '-f', ...pdflatexArgs];
 
     function runPdflatex() {
       return runToolWithCheck('pdflatex', pdflatexArgs, {

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -1,5 +1,4 @@
 import { createLog } from '@logger/logUtils';
-import type { FileLocation } from '@shared/schemas';
 import { filterNotNull, filterNotNullish, ensureArray } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { pathToLocation } from '@utils/files/fileLocation';
@@ -19,11 +18,9 @@ const CHINESE_PACKAGES = [
   'ctexbook',
 ];
 
-async function hasChinesePackages(
-  fileLocation: FileLocation,
-): Promise<boolean> {
+async function hasChinesePackages(absolutePath: string): Promise<boolean> {
   try {
-    const content = await AbsoluteFS.read(fileLocation.absolutePath);
+    const content = await AbsoluteFS.read(absolutePath);
     return CHINESE_PACKAGES.some(
       (pkg) =>
         content.includes(`\\usepackage{${pkg}}`) ||
@@ -49,10 +46,9 @@ interface TexcountResult {
 
 /** Returns why the file cannot be counted, or null when it is countable. */
 async function rejectionReason(
-  fileLocation: FileLocation,
+  filePath: string,
   channel: string,
 ): Promise<string | null> {
-  const filePath = fileLocation.absolutePath;
   const log = createLog(channel);
   if (!(await AbsoluteFS.exists(filePath))) {
     const reason = `File ${filePath} does not exist.`;
@@ -119,8 +115,8 @@ async function getIndividualCounts(
 ): Promise<{ outputs: string[]; errors: string[] }> {
   const results = await Promise.all(
     paths.map(async (filePath) => {
-      const fileLocation = pathToLocation(filePath);
-      const reason = await rejectionReason(fileLocation, channel);
+      const absolutePath = pathToLocation(filePath).absolutePath;
+      const reason = await rejectionReason(absolutePath, channel);
       if (reason) {
         return { output: null, error: reason };
       }
@@ -129,7 +125,7 @@ async function getIndividualCounts(
       if (includeReferenced) {
         args.push('-inc');
       }
-      if (await hasChinesePackages(fileLocation)) {
+      if (await hasChinesePackages(absolutePath)) {
         args.push('-ch-only');
       }
       args.push(filePath);
@@ -140,9 +136,10 @@ async function getIndividualCounts(
         filePath,
         signal,
       );
-      return stdout
-        ? { output: `TeX Count Results for ${filePath}:\n${stdout}`, error }
-        : { output: null, error };
+      return {
+        output: stdout ? `TeX Count Results for ${filePath}:\n${stdout}` : null,
+        error,
+      };
     }),
   );
 
@@ -163,8 +160,8 @@ async function getSummedCount(
   let enableChineseMode = false;
 
   for (const filePath of paths) {
-    const fileLocation = pathToLocation(filePath);
-    const reason = await rejectionReason(fileLocation, channel);
+    const absolutePath = pathToLocation(filePath).absolutePath;
+    const reason = await rejectionReason(absolutePath, channel);
     if (reason) {
       errors.push(reason);
       continue;
@@ -172,7 +169,7 @@ async function getSummedCount(
 
     validPaths.push(filePath);
 
-    if (!enableChineseMode && (await hasChinesePackages(fileLocation))) {
+    if (!enableChineseMode && (await hasChinesePackages(absolutePath))) {
       enableChineseMode = true;
       log.debug(
         `Chinese packages detected in ${filePath}, enabling Chinese character counting`,

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -170,6 +170,17 @@ interface UnavailableReasonContext {
 }
 
 /**
+ * Unavailable reason for both Copilot kinds; see the comment at its use sites
+ * in {@link UNAVAILABLE_REASON_BUILDERS}.
+ */
+function copilotUnavailableReason({ model }: UnavailableReasonContext): string {
+  return (
+    copilotRouteUnavailableReason(model) ??
+    `Model "${model}" is currently unavailable through Copilot in VS Code.`
+  );
+}
+
+/**
  * Per-kind unavailable-reason prose, compiler-checked the same way
  * {@link AVAILABILITY_STATUS_FIELDS} is: omitting a kind here — including a
  * newly added `ModelAvailabilityKind` whose status is `available: false` —
@@ -196,12 +207,8 @@ const UNAVAILABLE_REASON_BUILDERS: Record<
   // sentence a run would fail with. The `??` arm is unreachable: these kinds
   // are only chosen inside the `prefersCopilotRoute` branch, which is the one
   // case that helper never answers `undefined` for.
-  'copilot-consent-required': ({ model }) =>
-    copilotRouteUnavailableReason(model) ??
-    `Model "${model}" is currently unavailable through Copilot in VS Code.`,
-  'copilot-unavailable': ({ model }) =>
-    copilotRouteUnavailableReason(model) ??
-    `Model "${model}" is currently unavailable through Copilot in VS Code.`,
+  'copilot-consent-required': copilotUnavailableReason,
+  'copilot-unavailable': copilotUnavailableReason,
   // Unreachable from `getModelUnavailableReason` today (it returns its own
   // "not recognized" message before a config resolves far enough to compute
   // availability at all), but the table must still cover it: `unknown-model`
@@ -593,21 +600,16 @@ export function invalidateModelOptionsCache(): void {
 export async function computeModelOptionsData(
   models?: readonly string[],
 ): Promise<ModelOptionData[]> {
-  const cacheKey = getModelOptionsCacheKey(models);
+  const cacheKey =
+    models == null
+      ? VISIBLE_MODELS_CACHE_KEY
+      : `${EXPLICIT_MODELS_CACHE_PREFIX}${JSON.stringify(models)}`;
   return coalesceAsync<string, ModelOptionData[]>(
     resolvedModelOptions,
     pendingModelOptions,
     cacheKey,
     () => computeModelOptionsDataUncached(models),
   );
-}
-
-function getModelOptionsCacheKey(
-  models: readonly string[] | undefined,
-): string {
-  return models == null
-    ? VISIBLE_MODELS_CACHE_KEY
-    : `${EXPLICIT_MODELS_CACHE_PREFIX}${JSON.stringify(models)}`;
 }
 
 async function computeModelOptionsDataUncached(

--- a/src/model/modelAvailabilityWarning.ts
+++ b/src/model/modelAvailabilityWarning.ts
@@ -4,35 +4,17 @@ export type ModelAvailabilityWarningSink = (
   error: unknown,
 ) => void;
 
-interface ModelAvailabilityWarningSlot {
-  setSink(next: ModelAvailabilityWarningSink): void;
-  warn(message: string, error: unknown): void;
-}
-
-/** Build a warning slot that stays silent until the host installs a sink. */
-function createModelAvailabilityWarningSlot(): ModelAvailabilityWarningSlot {
-  const NOOP: ModelAvailabilityWarningSink = () => {};
-  let sink = NOOP;
-  return {
-    setSink(next) {
-      sink = next;
-    },
-    warn(message, error) {
-      sink(message, error);
-    },
-  };
-}
-
-const availabilityWarnings = createModelAvailabilityWarningSlot();
+/** The host-installed sink; stays silent until the host installs one. */
+let warningSink: ModelAvailabilityWarningSink = () => {};
 
 /** Install the host's model-picker warning sink. */
 export function setModelAvailabilityWarningSink(
   next: ModelAvailabilityWarningSink,
 ): void {
-  availabilityWarnings.setSink(next);
+  warningSink = next;
 }
 
 /** Report a model-picker availability warning when the host has a sink. */
 export function warnModelAvailability(message: string, error: unknown): void {
-  availabilityWarnings.warn(message, error);
+  warningSink(message, error);
 }

--- a/src/model/modelListRefresh.ts
+++ b/src/model/modelListRefresh.ts
@@ -45,8 +45,6 @@ function reconcileEnabledModels(
   currentModels: readonly string[],
   addDefaults: boolean,
 ): EnabledModelReconciliation {
-  const strippedSet = new Set<string>();
-
   // Retired models are hard unavailable for everyone.
   // This sweep runs on every reconciliation, unconditionally --
   // deliberately *not* gated behind a version threshold.
@@ -60,11 +58,8 @@ function reconcileEnabledModels(
   // an existing user's enabled-models list. Running it unconditionally keeps
   // it correct across both versioning schemes, at negligible cost (the set of
   // currently-enabled models is small).
-  for (const model of currentModels) {
-    if (isRetiredModel(model)) strippedSet.add(model);
-  }
-
-  const kept = currentModels.filter((model) => !strippedSet.has(model));
+  const removed = currentModels.filter((model) => isRetiredModel(model));
+  const kept = currentModels.filter((model) => !isRetiredModel(model));
   // DEFAULT_MODELS is already resolved against the live registry --
   // resolveDefaultModels (modelOptionsBasic.ts) drops retired/deprecated
   // picks before this module ever sees them -- so the only remaining check
@@ -86,7 +81,7 @@ function reconcileEnabledModels(
   return {
     models: [...defaultOrdered, ...extras],
     added,
-    removed: [...strippedSet],
+    removed,
   };
 }
 

--- a/src/model/modelListRefresh.ts
+++ b/src/model/modelListRefresh.ts
@@ -58,7 +58,9 @@ function reconcileEnabledModels(
   // an existing user's enabled-models list. Running it unconditionally keeps
   // it correct across both versioning schemes, at negligible cost (the set of
   // currently-enabled models is small).
-  const removed = currentModels.filter((model) => isRetiredModel(model));
+  const removed = [
+    ...new Set(currentModels.filter((model) => isRetiredModel(model))),
+  ];
   const kept = currentModels.filter((model) => !isRetiredModel(model));
   // DEFAULT_MODELS is already resolved against the live registry --
   // resolveDefaultModels (modelOptionsBasic.ts) drops retired/deprecated

--- a/src/platform/defaults/nodeFilesystem.ts
+++ b/src/platform/defaults/nodeFilesystem.ts
@@ -16,25 +16,16 @@ export const nodeFilesystem: FileSystemProvider = {
     const lstats = await fs.promises.lstat(target);
     const type = await fileTypeFor(fs, lstats, target);
     // For symlinks, use stat (follows link) for size/timestamps to match
-    // vscode.workspace.fs.stat behavior. For non-symlinks, lstat === stat.
-    if (lstats.isSymbolicLink()) {
-      try {
-        const stats = await fs.promises.stat(target);
-        return {
-          type,
-          ctime: stats.ctimeMs,
-          mtime: stats.mtimeMs,
-          size: stats.size,
-        };
-      } catch {
-        // Dangling symlink — fall through to lstat metadata
-      }
-    }
+    // vscode.workspace.fs.stat behavior, falling back to lstat metadata for a
+    // dangling symlink. For non-symlinks, lstat === stat.
+    const stats = lstats.isSymbolicLink()
+      ? await fs.promises.stat(target).catch(() => lstats)
+      : lstats;
     return {
       type,
-      ctime: lstats.ctimeMs,
-      mtime: lstats.mtimeMs,
-      size: lstats.size,
+      ctime: stats.ctimeMs,
+      mtime: stats.mtimeMs,
+      size: stats.size,
     };
   },
 

--- a/src/replacement/advanced.ts
+++ b/src/replacement/advanced.ts
@@ -347,9 +347,10 @@ export function replaceMathUnicode(text: string): string {
   }
 
   // Handle inline math with $ ... $
-  return text.replaceAll(/\$(.*?)\$/g, (_, p1: string) => {
-    return `$${convertMathContent(p1)}$`;
-  });
+  return text.replaceAll(
+    /\$(.*?)\$/g,
+    (_, p1: string) => `$${convertMathContent(p1)}$`,
+  );
 }
 
 /**

--- a/src/replacement/rules.ts
+++ b/src/replacement/rules.ts
@@ -16,7 +16,7 @@ import {
   generateSectionSpacingFixes,
   generateXmlLatexConversions,
 } from '@replacement/helpers';
-import { NonRegexReplacementCategory } from '@replacement/types';
+import type { NonRegexReplacementCategory } from '@replacement/types';
 import type { NonRegexReplacementCategory as NonRegexReplacementCategoryName } from '@shared/constants/replacementCategories';
 
 export const CHARACTER_REPLACEMENTS: NonRegexReplacementCategory = {

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -1,12 +1,12 @@
 // Local imports
 import type { RegexReplacementCategory as RegexReplacementCategoryName } from '@shared/constants/replacementCategories';
 
-import { RegexReplacementCategory, ReplacementFunction } from './types';
 import {
   FENCED_LATEX_BLOCK_PATTERN_INLINE,
   FENCED_LATEX_BLOCK_PATTERN_MULTILINE,
 } from './constants';
 import { createPatterns } from './helpers';
+import type { RegexReplacementCategory, ReplacementFunction } from './types';
 
 const EQUATION_ENVIRONMENT_PATTERN =
   '(?:align\\*?|aligned\\*?|alignat\\*?|flalign\\*?|gather\\*?|multline\\*?|equation\\*?|eqnarray\\*?|split\\*?)';

--- a/src/shared/copy/executionHistory.ts
+++ b/src/shared/copy/executionHistory.ts
@@ -1,11 +1,5 @@
+import { filterNotNullish } from '@utils/core';
 import { formatResultCount } from '@utils/text/stringUtils';
-
-/** Joins non-empty parts (in order) with "and", dropping undefined slots. */
-function joinCountedParts(parts: ReadonlyArray<string | undefined>): string {
-  return parts
-    .filter((part): part is string => part !== undefined)
-    .join(' and ');
-}
 
 export function formatCliHistoryDeletionSummary(counts: {
   readonly deleted: number;
@@ -38,7 +32,7 @@ export function formatStreamDeletionRetention(
   activeCount: number,
   failedCount: number,
 ): string {
-  const reasons = joinCountedParts([
+  const reasons = [
     activeCount > 0
       ? formatResultCount(activeCount, 'active stream')
       : undefined,
@@ -49,6 +43,6 @@ export function formatStreamDeletionRetention(
           'streams that could not be deleted',
         )
       : undefined,
-  ]);
-  return `Kept ${reasons}.`;
+  ].filter(filterNotNullish);
+  return `Kept ${reasons.join(' and ')}.`;
 }

--- a/src/shared/schemas/agentCliSettings.ts
+++ b/src/shared/schemas/agentCliSettings.ts
@@ -11,12 +11,10 @@ function parseEnumSetting<T extends string>(
   values: readonly T[],
   fallback: T,
 ): (raw: unknown) => T {
-  const known = values as readonly string[];
-  return (raw: unknown): T => {
-    if (typeof raw !== 'string') return fallback;
-    if (known.includes(raw)) return raw as T;
-    return fallback;
-  };
+  return (raw: unknown): T =>
+    typeof raw === 'string' && (values as readonly string[]).includes(raw)
+      ? (raw as T)
+      : fallback;
 }
 
 /** Valid Codex sandbox modes. */

--- a/src/shared/schemas/commonViewMessages.ts
+++ b/src/shared/schemas/commonViewMessages.ts
@@ -41,11 +41,9 @@ export const WebviewReadyMessageSchema = z.object({
   view: z.enum(['main', 'progress', 'settings']).nullish(),
 });
 
-const SwitchViewTargetSchema = z.enum(['main', 'progress', 'dashboard']);
-
 export const SwitchViewMessageSchema = z.object({
   command: z.literal(COMMON_COMMANDS.SWITCH_VIEW),
-  view: SwitchViewTargetSchema,
+  view: z.enum(['main', 'progress', 'dashboard']),
   openInEditor: z.boolean().nullish(),
 });
 

--- a/src/shared/schemas/fileTypes.ts
+++ b/src/shared/schemas/fileTypes.ts
@@ -25,7 +25,6 @@ export const ExtendedDocumentFileTypeSchema = z.enum([
   'edited',
   'output',
 ]);
-type ExtendedDocumentFileType = z.infer<typeof ExtendedDocumentFileTypeSchema>;
 
 /**
  * Values accepted by the "get/set current editor file" round trip

--- a/src/shared/schemas/plan.ts
+++ b/src/shared/schemas/plan.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { StreamTabIdSchema } from './identifiers';
+import type { StreamTabId } from './identifiers';
 
 /**
  * A plan is a plain objective document: what to achieve, the intended
@@ -23,8 +23,12 @@ export const PlanSchema = z.strictObject({
 });
 export type Plan = z.infer<typeof PlanSchema>;
 
-const UpdatePlanPayloadSchema = z.strictObject({
-  streamId: StreamTabIdSchema,
-  plan: PlanSchema.nullable(),
-});
-export type UpdatePlanPayload = z.infer<typeof UpdatePlanPayloadSchema>;
+/**
+ * Payload for a plan update. Declared as a plain type, not a schema: nothing
+ * ever parses it — producers build the shape and consumers read it — so a Zod
+ * schema would own no boundary.
+ */
+export interface UpdatePlanPayload {
+  streamId: StreamTabId;
+  plan: Plan | null;
+}

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -64,6 +64,17 @@ function actionWithFeedback<Base extends z.ZodRawShape, Action extends string>(
   });
 }
 
+/**
+ * Base fields for an approval-action discriminated union: the command literal
+ * plus the request being answered.
+ */
+function approvalActionBase<T extends string>(command: T) {
+  return {
+    command: z.literal(command),
+    requestId: z.string().min(1),
+  };
+}
+
 const UseOwnApiKeyMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY),
   requestId: z.string(),
@@ -131,10 +142,9 @@ const CancelRetryRequestMessageSchema = StreamScopedBaseSchema.extend({
   requestId: z.string(),
 });
 
-const ToolEditActionMessageBase = {
-  command: z.literal(PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION),
-  requestId: z.string().min(1),
-};
+const ToolEditActionMessageBase = approvalActionBase(
+  PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+);
 const ToolEditApprovalActionMessageSchema = z.discriminatedUnion('action', [
   z.strictObject({
     ...ToolEditActionMessageBase,
@@ -143,10 +153,9 @@ const ToolEditApprovalActionMessageSchema = z.discriminatedUnion('action', [
   actionWithFeedback(ToolEditActionMessageBase, 'reject'),
 ]);
 
-const BashActionMessageBase = {
-  command: z.literal(PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION),
-  requestId: z.string().min(1),
-};
+const BashActionMessageBase = approvalActionBase(
+  PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION,
+);
 const BashApprovalActionMessageSchema = z.discriminatedUnion('action', [
   z.strictObject({
     ...BashActionMessageBase,
@@ -155,10 +164,9 @@ const BashApprovalActionMessageSchema = z.discriminatedUnion('action', [
   actionWithFeedback(BashActionMessageBase, 'reject'),
 ]);
 
-const ProposalActionMessageBase = {
-  command: z.literal(PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION),
-  requestId: z.string().min(1),
-};
+const ProposalActionMessageBase = approvalActionBase(
+  PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+);
 const AgentProposalActionMessageSchema = z.discriminatedUnion('action', [
   z.strictObject({
     ...ProposalActionMessageBase,
@@ -176,10 +184,9 @@ export type ProgressAgentProposalActionMessage = z.infer<
   typeof AgentProposalActionMessageSchema
 >;
 
-const PlanActionMessageBase = {
-  command: z.literal(PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION),
-  requestId: z.string().min(1),
-};
+const PlanActionMessageBase = approvalActionBase(
+  PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
+);
 const PlanApprovalActionMessageSchema = z.discriminatedUnion('action', [
   z.strictObject({
     ...PlanActionMessageBase,
@@ -203,10 +210,9 @@ const ExternalInquiryActionMessageSchema = z.discriminatedUnion('action', [
   }),
 ]);
 
-const UserQuestionActionMessageBase = {
-  command: z.literal(PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION),
-  requestId: z.string().min(1),
-};
+const UserQuestionActionMessageBase = approvalActionBase(
+  PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION,
+);
 
 const UserQuestionActionMessageSchema = z.discriminatedUnion('action', [
   z.strictObject({

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -960,18 +960,12 @@ const TOOL_PATH_PROTECTION_RUNTIME_REACHABILITY = {
 } satisfies CliRuntimeReachability;
 
 /**
- * Git identity rows keep the one documented slot divergence in the catalog:
- * the extension and desktop store them in worktree-shared WorkspaceState while
- * the CLI reads them from `.texra/config.json`, which is where an existing
- * user's values already live.
+ * The one documented slot divergence in the catalog, shared by the git
+ * identity and skill availability rows: the extension and desktop store them
+ * in worktree-shared WorkspaceState while the CLI reads them from
+ * `.texra/config.json`, which is where an existing user's values already live.
  */
-const GIT_AUTHOR_SLOTS: SettingSlots = {
-  vscode: 'workspaceState',
-  desktop: 'workspaceState',
-  cli: 'config',
-};
-
-const SKILL_AVAILABILITY_SLOTS: SettingSlots = {
+const WORKSPACE_STATE_CLI_CONFIG_SLOTS: SettingSlots = {
   vscode: 'workspaceState',
   desktop: 'workspaceState',
   cli: 'config',
@@ -992,6 +986,21 @@ const GIT_AUTHOR_HONORED_BY: SettingHonoredBy = {
     reachability: GIT_AUTHOR_RUNTIME_REACHABILITY,
   },
 };
+
+const CODEX_AGENT_HONORED_BY = everyHost(
+  CODEX_CONFIG_READER,
+  CODEX_AGENT_RUNTIME_REACHABILITY,
+);
+
+const CLAUDE_AGENT_HONORED_BY = everyHost(
+  CLAUDE_AGENT_CONFIG_READER,
+  CLAUDE_AGENT_RUNTIME_REACHABILITY,
+);
+
+const WORKFLOW_COMPILE_HONORED_BY = everyHost(
+  WORKFLOW_COMPILE_READER,
+  WORKFLOW_COMPILE_RUNTIME_REACHABILITY,
+);
 
 // Written by the extension/desktop Models tab and the CLI's `/config` panel
 // through the same catalog write path.
@@ -1122,7 +1131,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     description:
       'Attribute agent-authored git commits to the TeXRA identity so they are distinguishable from your own commits.',
     category: 'git',
-    slots: GIT_AUTHOR_SLOTS,
+    slots: WORKSPACE_STATE_CLI_CONFIG_SLOTS,
     honoredBy: GIT_AUTHOR_HONORED_BY,
     surfaces: { settingsView: 'git-author', cliConfig: true },
   }),
@@ -1136,7 +1145,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     description:
       'Author and committer name used for agent-authored commits when commit marking is enabled.',
     category: 'git',
-    slots: GIT_AUTHOR_SLOTS,
+    slots: WORKSPACE_STATE_CLI_CONFIG_SLOTS,
     honoredBy: GIT_AUTHOR_HONORED_BY,
     surfaces: { settingsView: 'git-author', cliConfig: true },
   }),
@@ -1147,7 +1156,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     description:
       'Author and committer email used for agent-authored commits when commit marking is enabled.',
     category: 'git',
-    slots: GIT_AUTHOR_SLOTS,
+    slots: WORKSPACE_STATE_CLI_CONFIG_SLOTS,
     honoredBy: GIT_AUTHOR_HONORED_BY,
     surfaces: { settingsView: 'git-author', cliConfig: true },
   }),
@@ -1158,7 +1167,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     description:
       'Allow spawned subagents to run in isolated git worktrees so parallel edits do not conflict.',
     category: 'git',
-    slots: GIT_AUTHOR_SLOTS,
+    slots: WORKSPACE_STATE_CLI_CONFIG_SLOTS,
     honoredBy: {
       ...GIT_AUTHOR_HONORED_BY,
       cli: {
@@ -1228,7 +1237,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     description: 'Filesystem access mode used when TeXRA launches Codex.',
     category: 'ai-agents',
     slots: sameSlot('workspaceState'),
-    honoredBy: everyHost(CODEX_CONFIG_READER, CODEX_AGENT_RUNTIME_REACHABILITY),
+    honoredBy: CODEX_AGENT_HONORED_BY,
     enumLabels: ['Read-only', 'Workspace write', 'Full access'],
     surfaces: { settingsView: 'approval', cliConfig: true },
   }),
@@ -1239,7 +1248,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     description: 'Reasoning effort hint passed to Codex runs.',
     category: 'ai-agents',
     slots: sameSlot('workspaceState'),
-    honoredBy: everyHost(CODEX_CONFIG_READER, CODEX_AGENT_RUNTIME_REACHABILITY),
+    honoredBy: CODEX_AGENT_HONORED_BY,
     enumLabels: ['Low', 'Medium', 'High', 'Extra high'],
     surfaces: { settingsView: 'approval', cliConfig: true },
   }),
@@ -1250,7 +1259,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     description: 'When Codex should ask for approval before risky actions.',
     category: 'ai-agents',
     slots: sameSlot('workspaceState'),
-    honoredBy: everyHost(CODEX_CONFIG_READER, CODEX_AGENT_RUNTIME_REACHABILITY),
+    honoredBy: CODEX_AGENT_HONORED_BY,
     enumLabels: [
       'Auto approve',
       'Ask when requested',
@@ -1267,10 +1276,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     description: 'Claude model selected for Claude Code agent sessions.',
     category: 'ai-agents',
     slots: sameSlot('workspaceState'),
-    honoredBy: everyHost(
-      CLAUDE_AGENT_CONFIG_READER,
-      CLAUDE_AGENT_RUNTIME_REACHABILITY,
-    ),
+    honoredBy: CLAUDE_AGENT_HONORED_BY,
     enumLabels: ['Sonnet 5', 'Fable 5', 'Opus 5', 'Haiku 4.5'],
     surfaces: { settingsView: 'approval', cliConfig: true },
   }),
@@ -1283,10 +1289,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     description: 'Permission policy used by Claude Code agent sessions.',
     category: 'ai-agents',
     slots: sameSlot('workspaceState'),
-    honoredBy: everyHost(
-      CLAUDE_AGENT_CONFIG_READER,
-      CLAUDE_AGENT_RUNTIME_REACHABILITY,
-    ),
+    honoredBy: CLAUDE_AGENT_HONORED_BY,
     enumLabels: [
       'Prompt for risky actions',
       'Auto-accept edits',
@@ -1302,10 +1305,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     description: 'Reasoning effort hint passed to Claude Code agent sessions.',
     category: 'ai-agents',
     slots: sameSlot('workspaceState'),
-    honoredBy: everyHost(
-      CLAUDE_AGENT_CONFIG_READER,
-      CLAUDE_AGENT_RUNTIME_REACHABILITY,
-    ),
+    honoredBy: CLAUDE_AGENT_HONORED_BY,
     enumLabels: ['Low', 'Medium', 'High', 'Extra high', 'Maximum'],
     surfaces: { settingsView: 'approval', cliConfig: true },
   }),
@@ -1319,10 +1319,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       'Compile the LaTeX project automatically after an agent writes its output.',
     category: 'workflow',
     slots: sameSlot('workspaceState'),
-    honoredBy: everyHost(
-      WORKFLOW_COMPILE_READER,
-      WORKFLOW_COMPILE_RUNTIME_REACHABILITY,
-    ),
+    honoredBy: WORKFLOW_COMPILE_HONORED_BY,
     surfaces: { settingsView: 'latex', cliConfig: true },
   }),
   surfacedSetting({
@@ -1336,10 +1333,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       'Maximum time (in milliseconds) to wait for an automatic post-output compile before giving up.',
     category: 'workflow',
     slots: sameSlot('workspaceState'),
-    honoredBy: everyHost(
-      WORKFLOW_COMPILE_READER,
-      WORKFLOW_COMPILE_RUNTIME_REACHABILITY,
-    ),
+    honoredBy: WORKFLOW_COMPILE_HONORED_BY,
     surfaces: { settingsView: 'latex', cliConfig: true },
   }),
   surfacedSetting({
@@ -1627,7 +1621,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     title: 'Skills',
     description: 'Enable or disable individual skills in this workspace.',
     category: 'tools',
-    slots: SKILL_AVAILABILITY_SLOTS,
+    slots: WORKSPACE_STATE_CLI_CONFIG_SLOTS,
     honoredBy: everyHost(
       'src/skills/runtimeSkills.ts',
       SKILL_AVAILABILITY_REACHABILITY,
@@ -1641,7 +1635,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     title: 'Skill sources',
     description: 'Enable or disable skill source groups in this workspace.',
     category: 'tools',
-    slots: SKILL_AVAILABILITY_SLOTS,
+    slots: WORKSPACE_STATE_CLI_CONFIG_SLOTS,
     honoredBy: everyHost(
       'src/skills/runtimeSkills.ts',
       SKILL_AVAILABILITY_REACHABILITY,

--- a/src/shared/schemas/toolConfig.ts
+++ b/src/shared/schemas/toolConfig.ts
@@ -12,26 +12,24 @@ export const DEFAULT_TOOL_CONFIG = {
 
 type ToolConfigField = keyof typeof DEFAULT_TOOL_CONFIG;
 
-const ToolConfigBooleanFieldsShape = Object.fromEntries(
-  Object.keys(DEFAULT_TOOL_CONFIG).map((key) => [key, z.boolean()]),
-) as Record<ToolConfigField, z.ZodBoolean>;
-
 export const ToolConfigInputFieldsSchema = z.object(
-  ToolConfigBooleanFieldsShape,
+  Object.fromEntries(
+    Object.keys(DEFAULT_TOOL_CONFIG).map((key) => [key, z.boolean()]),
+  ) as Record<ToolConfigField, z.ZodBoolean>,
 );
-
-const ToolConfigPrefaultFieldsShape = Object.fromEntries(
-  Object.entries(ToolConfigBooleanFieldsShape).map(([key, schema]) => [
-    key,
-    schema.prefault(DEFAULT_TOOL_CONFIG[key as ToolConfigField]),
-  ]),
-) as { [K in ToolConfigField]: z.ZodPrefault<z.ZodBoolean> };
 
 /**
  * Base tool config object schema (exposes .shape for composition).
  * Field-level prefaults handle partial inputs.
  */
-export const ToolConfigFieldsSchema = z.object(ToolConfigPrefaultFieldsShape);
+export const ToolConfigFieldsSchema = z.object(
+  Object.fromEntries(
+    Object.entries(DEFAULT_TOOL_CONFIG).map(([key, defaultValue]) => [
+      key,
+      z.boolean().prefault(defaultValue),
+    ]),
+  ) as { [K in ToolConfigField]: z.ZodPrefault<z.ZodBoolean> },
+);
 
 /**
  * Tool config schema with object-level prefault for standalone use.

--- a/src/shared/settingsView/handlers/stateSettingWrite.ts
+++ b/src/shared/settingsView/handlers/stateSettingWrite.ts
@@ -135,17 +135,17 @@ export async function applyStateSettingUpdate(
       ? resetSetting(write.entry, ports.stores, ports.host)
       : writeSetting(write.entry, write.value, ports.stores, ports.host));
     if (write.entry.key === TEXRA_APPROVAL_POLICY_CONFIG_KEY) {
-      ports.onApprovalPolicyChanged?.(
+      // A reset clears only the workspace layer, so a surviving global value
+      // is what the session must run (issue #9749).
+      const policy =
         write.kind === 'reset'
-          ? // A reset clears only the workspace layer, so a surviving global
-            // value is what the session must run (issue #9749).
-            (readSetting(
+          ? (readSetting(
               write.entry,
               ports.stores,
               ports.host,
             ) as TexraApprovalPolicy)
-          : (write.value as TexraApprovalPolicy),
-      );
+          : (write.value as TexraApprovalPolicy);
+      ports.onApprovalPolicyChanged?.(policy);
     }
     return { kind: 'applied', entry: write.entry };
   } catch (error) {

--- a/src/shared/streams/streamOrdering.ts
+++ b/src/shared/streams/streamOrdering.ts
@@ -39,7 +39,8 @@ export function compareBySeqNo<T>(
   return fallbackTimeOf(a) - fallbackTimeOf(b);
 }
 
-function usableSequence(seqNo: number | undefined): number | undefined {
+/** A `seqNo` only orders rows when it is a positive safe integer. */
+export function usableSequence(seqNo: number | undefined): number | undefined {
   return seqNo !== undefined && Number.isSafeInteger(seqNo) && seqNo > 0
     ? seqNo
     : undefined;

--- a/src/shared/streams/streamStatus.ts
+++ b/src/shared/streams/streamStatus.ts
@@ -1,19 +1,4 @@
-/**
- * Whether a workflow-script run has ended, as the shared workflow run model
- * reads it (`runSettled`): a known status that is neither running nor
- * waiting. An unknown status is not "ended" — a plan-only phase must not
- * vanish before the stream's first status has arrived. Both hosts call this,
- * so neither can drift.
- */
-export function workflowRunSettled(
-  phase: StreamLifecycleStatus | undefined,
-): boolean {
-  return phase !== undefined && !isInFlightPhase(phase);
-}
-/**
- * Stream status constants shared across agent runtime and UI layers.
- */
-// Local imports - shared schemas
+/** Stream status constants shared across agent runtime and UI layers. */
 import {
   EXECUTION_STATUS,
   RUN_OUTCOME,
@@ -116,6 +101,19 @@ export function isInFlightPhase(
   phase: StreamLifecycleStatus | undefined,
 ): boolean {
   return phase === STREAM_PHASE.RUNNING || phase === STREAM_PHASE.WAITING;
+}
+
+/**
+ * Whether a workflow-script run has ended, as the shared workflow run model
+ * reads it (`runSettled`): a known status that is neither running nor
+ * waiting. An unknown status is not "ended" — a plan-only phase must not
+ * vanish before the stream's first status has arrived. Both hosts call this,
+ * so neither can drift.
+ */
+export function workflowRunSettled(
+  phase: StreamLifecycleStatus | undefined,
+): boolean {
+  return phase !== undefined && !isInFlightPhase(phase);
 }
 
 export function canAcquireStreamReservation(

--- a/src/shared/streams/taskGroupProjection.ts
+++ b/src/shared/streams/taskGroupProjection.ts
@@ -74,6 +74,14 @@ export function upsertTaskGroupFromStreamLog(
   }
 
   const payload = entry.data;
+  const lifecycleFields = {
+    ...(entry.groupId ? { parentGroupId: entry.groupId } : {}),
+    ...taskGroupStageMetadata(payload.kind, payload.index),
+    ...(payload.attemptId !== undefined
+      ? { attemptId: payload.attemptId }
+      : {}),
+    ...(payload.total !== undefined ? { total: payload.total } : {}),
+  };
 
   if (entry.type === STREAM_LOG_ENTRY_TYPES.GROUP_START) {
     // GROUP_START only carries the native status vocabulary because the run
@@ -89,12 +97,7 @@ export function upsertTaskGroupFromStreamLog(
       name,
       startTime: entry.timestamp,
       status: startStatus,
-      ...(entry.groupId ? { parentGroupId: entry.groupId } : {}),
-      ...taskGroupStageMetadata(payload.kind, payload.index),
-      ...(payload.attemptId !== undefined
-        ? { attemptId: payload.attemptId }
-        : {}),
-      ...(payload.total !== undefined ? { total: payload.total } : {}),
+      ...lifecycleFields,
     };
 
     if (groupIndex === -1) {
@@ -117,12 +120,7 @@ export function upsertTaskGroupFromStreamLog(
       name,
       startTime: entry.timestamp,
       status,
-      ...(entry.groupId ? { parentGroupId: entry.groupId } : {}),
-      ...taskGroupStageMetadata(payload.kind, payload.index),
-      ...(payload.attemptId !== undefined
-        ? { attemptId: payload.attemptId }
-        : {}),
-      ...(payload.total !== undefined ? { total: payload.total } : {}),
+      ...lifecycleFields,
       ...(endTime !== undefined ? { endTime } : {}),
     });
   } else {

--- a/src/shared/streams/workflowRunModel.ts
+++ b/src/shared/streams/workflowRunModel.ts
@@ -25,6 +25,7 @@ import {
   type WorkflowPlanMarker,
 } from '@shared/schemas';
 import type { TranscriptRow, WorkflowTaskRow } from '@shared/transcript';
+import { compareBySeqNo, usableSequence } from '@shared/streams/streamOrdering';
 import {
   TOKENS_GENERATED,
   workflowPhaseHeadingOfGroup,
@@ -203,12 +204,15 @@ function workflowCardsInTranscriptOrder(
   const legacy: WorkflowTaskRow[] = [];
   for (const row of rows) {
     if (row.kind !== 'workflowTask') continue;
-    (usableSeqNo(row.seqNo) === undefined ? legacy : sequenced).push(row);
+    (usableSequence(row.seqNo) === undefined ? legacy : sequenced).push(row);
   }
-  sequenced.sort(
-    (left, right) =>
-      usableSeqNo(left.seqNo)! - usableSeqNo(right.seqNo)! ||
-      compareCardFallback(left, right),
+  sequenced.sort((left, right) =>
+    compareBySeqNo(
+      left,
+      right,
+      (row) => row.seqNo,
+      (row) => row.timestamp,
+    ),
   );
   legacy.sort(compareCardFallback);
   if (sequenced.length === 0) return legacy;
@@ -223,12 +227,6 @@ interface AttemptBoundary {
   readonly timestamp: number;
   readonly stableKey: string;
   readonly seqNo?: number;
-}
-
-function usableSeqNo(seqNo: number | undefined): number | undefined {
-  return seqNo !== undefined && Number.isSafeInteger(seqNo) && seqNo > 0
-    ? seqNo
-    : undefined;
 }
 
 function laterAttemptBoundaryByTime(
@@ -265,7 +263,7 @@ function latestWorkflowAttemptId(
   for (const row of cards) {
     const attemptId = row.call.attemptId;
     if (attemptId === undefined) continue;
-    const seqNo = usableSeqNo(row.seqNo);
+    const seqNo = usableSequence(row.seqNo);
     const boundary: AttemptBoundary = {
       attemptId,
       timestamp: row.timestamp,
@@ -563,17 +561,12 @@ export function formatWorkflowCallLiveParts(
 /** The counted groups a phase's quiet rows collapse into. */
 export type WorkflowRowGroup = 'queued' | 'declared';
 
-const WORKFLOW_ROW_GROUP_LABEL = {
-  queued: 'queued',
-  declared: 'declared',
-} as const satisfies Record<WorkflowRowGroup, string>;
-
 /** `12 queued` — the one spelling of a counted group's row. */
 export function formatWorkflowRowGroup(row: {
   readonly count: number;
   readonly group: WorkflowRowGroup;
 }): string {
-  return `${row.count} ${WORKFLOW_ROW_GROUP_LABEL[row.group]}`;
+  return `${row.count} ${row.group}`;
 }
 
 export type WorkflowPhaseRow =
@@ -596,8 +589,7 @@ export type WorkflowPhaseRow =
     };
 
 /** Rows that failed lead, rows worth watching follow. */
-const ATTENTION_STATUSES = ['failed', 'running'] as const;
-type AttentionStatus = (typeof ATTENTION_STATUSES)[number];
+type AttentionStatus = 'failed' | 'running';
 const ATTENTION_RANK: Record<AttentionStatus, number> = {
   failed: 0,
   running: 1,
@@ -606,7 +598,7 @@ const ATTENTION_RANK: Record<AttentionStatus, number> = {
 function isAttentionStatus(
   status: WorkflowCallProgress['status'],
 ): status is AttentionStatus {
-  return (ATTENTION_STATUSES as readonly string[]).includes(status);
+  return status === 'failed' || status === 'running';
 }
 
 const QUEUED_STATUSES: ReadonlySet<WorkflowCallProgress['status']> = new Set([

--- a/src/shared/transcript/projectTranscriptRow.ts
+++ b/src/shared/transcript/projectTranscriptRow.ts
@@ -44,6 +44,7 @@ import type {
   ErrorRow,
   ErrorRowDetail,
   LoadedMediaRef,
+  LogRow,
   StatItem,
   StreamingTextRow,
   TranscriptRow,
@@ -95,6 +96,13 @@ function rowBase(entry: StreamLogEntry): TranscriptRowBase {
 
 function entryText(entry: StreamLogEntry): TranscriptText {
   return transcriptText(entry.text ?? '');
+}
+
+/** A plain log row, or no row when the entry has no visible text. */
+function projectLogRow(entry: StreamLogEntry): LogRow | undefined {
+  const text = entryText(entry);
+  if (!text.oneLine.trim()) return undefined;
+  return { ...rowBase(entry), kind: 'log', text };
 }
 
 function isStreamingPayload(data: unknown): boolean {
@@ -335,17 +343,11 @@ export function projectTranscriptRow(
 
   if (entry.type !== STREAM_LOG_ENTRY_TYPES.LOG) {
     if (ctx.projectLifecycleToTaskGroups) return undefined;
-    const text = entryText(entry);
-    if (!text.oneLine.trim()) return undefined;
-    return { ...rowBase(entry), kind: 'log', text };
+    return projectLogRow(entry);
   }
 
   const messageType = entry.messageType;
-  if (messageType === undefined) {
-    const text = entryText(entry);
-    if (!text.oneLine.trim()) return undefined;
-    return { ...rowBase(entry), kind: 'log', text };
-  }
+  if (messageType === undefined) return projectLogRow(entry);
 
   switch (messageType) {
     case MESSAGE_TYPES.MODEL_RESPONSE:
@@ -559,11 +561,8 @@ export function projectTranscriptRow(
       };
     }
 
-    case MESSAGE_TYPES.DEFAULT: {
-      const text = entryText(entry);
-      if (!text.oneLine.trim()) return undefined;
-      return { ...rowBase(entry), kind: 'log', text };
-    }
+    case MESSAGE_TYPES.DEFAULT:
+      return projectLogRow(entry);
 
     // ── No row ──────────────────────────────────────────────────────────
     // A compaction lifecycle row is not a row of its own: the correlated

--- a/src/skills/loadSkills.ts
+++ b/src/skills/loadSkills.ts
@@ -13,8 +13,6 @@ import { type SkillLoadIssue, issue, loadSkillDirectory } from './skillLoader';
 import type { Dirent } from 'node:fs';
 import type { Skill } from './SkillSchema';
 
-// Local imports - shared schemas
-
 export { type SkillLoadIssue } from './skillLoader';
 
 interface DiscoveredSkill {
@@ -28,13 +26,11 @@ interface SkillRootScan {
   errors: SkillLoadIssue[];
 }
 
-/** Canonical scope vocabulary, derived from the shared wire-contract enum
+/** Scope vocabulary comes from the shared wire-contract enum
  *  (`@shared/schemas/activeSkills`) so the loader and the persisted snapshot
  *  can't drift. */
-type SkillSourceScope = ActiveSkillSourceScope;
-
 export interface SkillSource {
-  readonly scope: SkillSourceScope;
+  readonly scope: ActiveSkillSourceScope;
   readonly path: string;
   readonly label?: string;
   readonly required?: boolean;

--- a/src/skills/runtimeSkills.ts
+++ b/src/skills/runtimeSkills.ts
@@ -2,9 +2,9 @@ import {
   ACTIVE_SKILLS_SNAPSHOT_MAX_SKILLS,
   type ActiveSkillSourceScope,
   type RawAcceptedSkill,
+  type SettingHost,
   type SkillDisplayItem,
 } from '@shared/schemas';
-import type { SettingHost } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 import { readPlatformSetting } from '@utils/config/platformSettings';

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -31,7 +31,7 @@ import {
   requestToolEditApproval,
   writeApprovedContent,
 } from '@tools/approval/toolEditApproval';
-import { filterNotNull } from '@utils/core';
+import { filterNotNull, filterNotNullish } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { createWorkspaceLocation } from '@utils/files/fileLocation';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
@@ -288,7 +288,7 @@ Parameters map directly to subagent-result delivery attributes:
         firstUserRejectionPath,
         firstPolicyDenialPath,
         firstCancellationPath,
-      ].filter((path) => path !== undefined);
+      ].filter(filterNotNullish);
       const summaryPath =
         presentFirstPaths.length > 1
           ? 'multiple files'

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -136,13 +136,11 @@ async function queueAgentCliFollowUp(
   // A queued follow-up whose wake failed is still queued: it is delivered
   // when the agent is resumed, so the caller must not offer it again.
   const wakeFailed = result.status === 'queued' && result.wake === 'failed';
+  const followUpLine = wakeFailed
+    ? `Follow-up instruction queued for ${labels.queuedLabel} '${id}', but the agent could not be resumed. ${FOLLOW_UP_WAKE_FAILED_MESSAGE}`
+    : `Follow-up instruction queued for ${labels.queuedLabel} '${id}'. The agent will process it and deliver a new result automatically.`;
   return executed(
-    [
-      wakeFailed
-        ? `Follow-up instruction queued for ${labels.queuedLabel} '${id}', but the agent could not be resumed. ${FOLLOW_UP_WAKE_FAILED_MESSAGE}`
-        : `Follow-up instruction queued for ${labels.queuedLabel} '${id}'. The agent will process it and deliver a new result automatically.`,
-      `Execution ID: ${stored.executionId}`,
-    ].join('\n'),
+    [followUpLine, `Execution ID: ${stored.executionId}`].join('\n'),
     `Follow-up queued for ${labels.summaryLabel}: ${preview}`,
   );
 }

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -352,17 +352,16 @@ export function buildApprovalRejectedResult(
   rejection: ToolEditRejectionProvenance,
 ): ToolResult {
   const feedback = rejection.feedback?.trim();
-  const isPolicyDenial = rejection.reason !== undefined;
-  const isAutomaticCancellation = 'cause' in rejection;
   const reason = rejection.reason?.trim();
   const cause = rejection.cause?.trim();
-  let summary = `User rejected ${sourceTool} for ${path}.`;
-  if (isPolicyDenial) {
-    summary = `Tool edit denied: ${sourceTool} for ${path}.`;
-  }
   // Cancellation outranks policy denial in the summary.
-  if (isAutomaticCancellation) {
+  let summary: string;
+  if ('cause' in rejection) {
     summary = `Tool edit approval cancelled: ${sourceTool} for ${path}.`;
+  } else if (rejection.reason !== undefined) {
+    summary = `Tool edit denied: ${sourceTool} for ${path}.`;
+  } else {
+    summary = `User rejected ${sourceTool} for ${path}.`;
   }
   const details = [reason, cause].filter(isNonEmptyString);
   const error =

--- a/src/tools/arxiv/arxivShared.ts
+++ b/src/tools/arxiv/arxivShared.ts
@@ -13,7 +13,7 @@ type ArxivEntry = Awaited<ReturnType<typeof arxivClient.execute>>[number];
 // ============================================================================
 
 /** Base arXiv paper metadata shared between search and metadata tools. */
-export interface ArxivPaperBase {
+interface ArxivPaperBase {
   id: string | null;
   doi: string | null;
   title: string;

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -107,8 +107,7 @@ export async function buildFileAttachment({
   const { path, display } = resolved
     ? { path: resolved, display: toPosixPath(resolved.relative) }
     : resolveAndFormat(filePath);
-  const exists = await WorkspaceFS.exists(path.fsPath);
-  if (!exists) {
+  if (!(await WorkspaceFS.exists(path.fsPath))) {
     throw new ToolError(`Attachment not found: ${display}`);
   }
 

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -154,9 +154,6 @@ interface TurnResult {
   errorMessage?: string;
 }
 
-const INVALID_FORK_SESSION_MESSAGE =
-  'Claude Code fork did not create a distinct session';
-
 function claudeCostLines(turn: TurnResult): string[] | undefined {
   return typeof turn.totalCostUsd === 'number' && turn.totalCostUsd > 0
     ? [`<cost-usd>${turn.totalCostUsd.toFixed(4)}</cost-usd>`]
@@ -285,7 +282,10 @@ export async function runStreamedTurn(params: {
     (!sessionId || sessionId === params.resumeSessionId)
   ) {
     isError = true;
-    errorMessage = [errorMessage, INVALID_FORK_SESSION_MESSAGE]
+    errorMessage = [
+      errorMessage,
+      'Claude Code fork did not create a distinct session',
+    ]
       .filter(isNonEmptyString)
       .join('\n');
   }

--- a/src/tools/claudeAgentBackgroundTasks.ts
+++ b/src/tools/claudeAgentBackgroundTasks.ts
@@ -51,18 +51,15 @@ export class ClaudeBackgroundTaskTracker {
     }
 
     const log = buildBackgroundTaskLog(tasks);
-    if (!this.active) {
-      const ref = startToolUseCard(
+    const ref =
+      this.active?.ref ??
+      startToolUseCard(
         this.logger,
         CLAUDE_BACKGROUND_TASK_TOOL_NAME,
         log.input,
       );
-      endToolUseCard(this.logger, ref, log, 'in_progress');
-      this.active = { ref, log };
-      return;
-    }
-    endToolUseCard(this.logger, this.active.ref, log, 'in_progress');
-    this.active = { ...this.active, log };
+    endToolUseCard(this.logger, ref, log, 'in_progress');
+    this.active = { ref, log };
   }
 
   /** Close the card because every query starts with an empty background set. */

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -85,8 +85,8 @@ export abstract class BaseTool<T> implements ITool {
       return {
         status: 'error',
         error: message || 'Tool execution failed.',
-        ...(summary !== undefined ? { summary } : {}),
-        ...(diagnostics !== undefined ? { diagnostics } : {}),
+        ...(summary !== undefined && { summary }),
+        ...(diagnostics !== undefined && { diagnostics }),
       };
     }
   }

--- a/src/tools/delegation/DelegationTools.ts
+++ b/src/tools/delegation/DelegationTools.ts
@@ -61,8 +61,7 @@ import {
   type WorkflowAgentInput,
 } from './inputFields';
 
-const LOG_CHANNEL = 'delegation';
-const log = createLog(LOG_CHANNEL);
+const log = createLog('delegation');
 
 /**
  * Deliver a terminal error to the orchestrator when a resumed subagent's wake

--- a/src/tools/delegation/childStream.ts
+++ b/src/tools/delegation/childStream.ts
@@ -104,8 +104,7 @@ export function createChildStream(
     options.reservedWriter,
   );
   let traceDisposed = false;
-  let removeSpillFlusher = (): void => {};
-  removeSpillFlusher = session.useArtifactFlusher(async () => {
+  const removeSpillFlusher = session.useArtifactFlusher(async () => {
     await runTrace.flushSpills();
     if (traceDisposed) removeSpillFlusher();
   });

--- a/src/tools/delegation/delegationAvailability.ts
+++ b/src/tools/delegation/delegationAvailability.ts
@@ -304,7 +304,7 @@ export function annotateDelegationAvailability(
   const withAgents = replaceDelegationDescriptionBlock(
     withModels,
     AVAILABLE_AGENTS_BLOCK,
-    visibleDelegationAgentsBlock(category),
+    () => visibleDelegationAgentsBlock(category),
     { appendIfMissing: true },
   );
   return replaceDelegationDescriptionBlock(

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -55,8 +55,7 @@ import {
   type ChildRunLaunchOptions,
 } from './nativeSubagentStrategy';
 
-const LOG_CHANNEL = 'inBandSubagentExecution';
-const log = createLog(LOG_CHANNEL);
+const log = createLog('inBandSubagentExecution');
 
 interface InBandSubagentExecutionBaseOptions extends ChildRunLaunchOptions {
   readonly configPayload: AgentConfigPayload;

--- a/src/tools/delegation/nativeSubagentStrategy.ts
+++ b/src/tools/delegation/nativeSubagentStrategy.ts
@@ -452,6 +452,7 @@ export function createNativeSubagentStrategy(
         const result = turn
           ? toDeliveryResult(turn, params.executionId)
           : lastResult;
+        const wallTimeMs = Date.now() - params.startedAt;
         const failureOptions = {
           parentExecutionId: params.parentExecutionId,
           cause: lastErr ?? error,
@@ -461,7 +462,7 @@ export function createNativeSubagentStrategy(
             params.agentName,
             params.config.agentCategory,
             result,
-            Date.now() - params.startedAt,
+            wallTimeMs,
             failureOptions,
           );
         } catch (buildError) {
@@ -475,7 +476,7 @@ export function createNativeSubagentStrategy(
             params.agentName,
             params.config.agentCategory,
             undefined,
-            Date.now() - params.startedAt,
+            wallTimeMs,
             failureOptions,
           );
         }

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -44,8 +44,7 @@ import { createNativeSubagentStrategy } from './nativeSubagentStrategy';
 // Shared utilities
 // ============================================================================
 
-const LOG_CHANNEL = 'childRunLoop';
-const log = createLog(LOG_CHANNEL);
+const log = createLog('childRunLoop');
 
 /**
  * One compact trace line per child progress update, for the in-band arm where

--- a/src/tools/delegation/subagentResults.ts
+++ b/src/tools/delegation/subagentResults.ts
@@ -367,12 +367,10 @@ const LARGE_CHANGE_DIFF_LINES = 80;
  */
 const LARGE_CHANGE_RATIO = 0.4;
 
-const LOG_CHANNEL = 'subagentDiffs';
-const log = createLog(LOG_CHANNEL);
+const log = createLog('subagentDiffs');
 // The boundary warn in `buildSubagentResult` predates the A4 file merge and
 // stays on its historical channel so log ingestion keyed on it keeps seeing it.
-const DELIVERY_LOG_CHANNEL = 'subagentDelivery';
-const deliveryLog = createLog(DELIVERY_LOG_CHANNEL);
+const deliveryLog = createLog('subagentDelivery');
 
 /**
  * Truncate diff text to a maximum number of lines.

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -92,16 +92,12 @@ function workflowJournalEntryCost(entry: WorkflowJournalEntry): number {
   return result.data.cost;
 }
 
-type WorkflowAttemptIdentity = Pick<WorkflowAgentInvocation, 'index' | 'key'>;
-
 /**
  * Keys are unique per run (the engine faults duplicates), so the key alone
  * identifies an attempt; a replayed entry re-journaled at a new index still
  * matches the attempt that produced it.
  */
-function workflowAttemptIdentity(invocation: WorkflowAttemptIdentity): string {
-  return invocation.key;
-}
+type WorkflowAttemptIdentity = Pick<WorkflowAgentInvocation, 'index' | 'key'>;
 
 interface WorkflowAttemptCostTracker {
   /** Record one physical child attempt and return this tool invocation's live total. */
@@ -137,20 +133,18 @@ export function createWorkflowAttemptCostTracker(): WorkflowAttemptCostTracker {
   return {
     record: (invocation, costUsd) => {
       observedTotalUsd += costUsd;
-      const identity = workflowAttemptIdentity(invocation);
-      const attempts = attemptsByIdentity.get(identity) ?? [];
+      const attempts = attemptsByIdentity.get(invocation.key) ?? [];
       attempts.push(costUsd);
-      attemptsByIdentity.set(identity, attempts);
+      attemptsByIdentity.set(invocation.key, attempts);
       return observedTotalUsd;
     },
     total: (finalJournal) => {
       const journalIdentities = new Set<string>();
       let totalUsd = 0;
       for (const entry of finalJournal) {
-        const identity = workflowAttemptIdentity(entry);
-        journalIdentities.add(identity);
+        journalIdentities.add(entry.key);
         const journalCostUsd = workflowJournalEntryCost(entry);
-        const attempts = attemptsByIdentity.get(identity);
+        const attempts = attemptsByIdentity.get(entry.key);
         if (!attempts || attempts.length === 0) continue;
         for (const discardedCostUsd of attempts.slice(0, -1)) {
           totalUsd += discardedCostUsd;
@@ -227,7 +221,7 @@ export async function runPersistedWorkflowScriptWithProgress(
   /**
    * Open a phase stage once the run reaches it and answer the stage rows
    * emitted from there belong to. Callers that only need the phase opened
-   * ignore the return: `emitCall` resolves a card's group itself.
+   * ignore the return.
    */
   const openPhaseStage = (phase: string | undefined): string | undefined =>
     phase ? phaseFor(phase).handle.id : parentStageId;
@@ -250,10 +244,7 @@ export async function runPersistedWorkflowScriptWithProgress(
       // Stable trace identity for this call within its run stream.
       logId: `workflow-task-${projectionId}-${call.id}`,
       call: card,
-      stageId:
-        card.phase === undefined
-          ? parentStageId
-          : phaseFor(card.phase).handle.id,
+      stageId: openPhaseStage(card.phase),
     });
   };
   const markPhaseFailed = (title: string | undefined): void => {

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -251,6 +251,17 @@ export function createWorkflowScriptStrategy(
         [...attemptJournalByKey.values()].toSorted(
           (left, right) => left.index - right.index,
         );
+      // Settle only entries consumed by this invocation: the durable union may
+      // hold superseded or malformed untouched recovery history, and baseline
+      // history is irrelevant to this invocation's cost and delivered files.
+      const settleAttempt = (
+        snapshot: WorkflowExecutionSnapshot | undefined,
+      ): void => {
+        const journal = attemptJournal();
+        const costUsd = attemptCost.total(journal);
+        ports.recordCost(costUsd);
+        settleSummary({ journal, snapshot }, costUsd);
+      };
       const runAgent = params.createRunAgent({
         onCost: (invocation, totalCostUsd) => {
           ports.recordCost(attemptCost.record(invocation, totalCostUsd ?? 0));
@@ -304,13 +315,8 @@ export function createWorkflowScriptStrategy(
           },
         });
       } catch (runError) {
-        // Settle only entries consumed by this invocation. The durable union
-        // may contain superseded or malformed untouched recovery history.
         try {
-          const journal = attemptJournal();
-          const costUsd = attemptCost.total(journal);
-          ports.recordCost(costUsd);
-          settleSummary({ journal, snapshot: lastSnapshot }, costUsd);
+          settleAttempt(lastSnapshot);
         } catch (settlementError) {
           // The run error is what the caller must see, so settlement cannot
           // rethrow. Live candidates recorded through the loop remain billed;
@@ -328,12 +334,7 @@ export function createWorkflowScriptStrategy(
         unregisterControls?.();
       }
 
-      // The attempt-local journal supplies missing/lower completed-call
-      // fallback and delivered files. Durable baseline history is irrelevant.
-      const journal = attemptJournal();
-      const costUsd = attemptCost.total(journal);
-      ports.recordCost(costUsd);
-      settleSummary({ journal, snapshot: run.snapshot }, costUsd);
+      settleAttempt(run.snapshot);
       return run;
     },
 

--- a/src/tools/executions/workflowSummaryView.ts
+++ b/src/tools/executions/workflowSummaryView.ts
@@ -53,6 +53,20 @@ function workflowAttemptView(
   };
 }
 
+function compactWorkflowFiles(files: readonly string[]): {
+  sample: string[];
+  omitted?: number;
+} {
+  return {
+    sample: files
+      .slice(0, WORKFLOW_SUMMARY_MAX_FILES_PER_KIND)
+      .map((file) => compactWorkflowText(file)!),
+    ...(files.length > WORKFLOW_SUMMARY_MAX_FILES_PER_KIND && {
+      omitted: files.length - WORKFLOW_SUMMARY_MAX_FILES_PER_KIND,
+    }),
+  };
+}
+
 function workflowCallFailurePriority(status: string): number {
   // Within terminal calls, elevate failed/cancelled so the bounded projection
   // keeps the outcomes that matter for debugging (matches stage ranking).
@@ -78,30 +92,25 @@ export function workflowExecutionView(
         Number(right.stageId !== snapshot.currentStageId) ||
       right.timestamps.updatedAt.localeCompare(left.timestamps.updatedAt),
   );
+  const phasePriority = (
+    stage: WorkflowExecutionSnapshot['stages'][number],
+  ): number => {
+    if (stage.id === snapshot.currentStageId) return 0;
+    if (stage.lifecycle === 'failed' || stage.lifecycle === 'cancelled') {
+      return 1;
+    }
+    return 2;
+  };
   const phases = snapshot.stages
-    .toSorted((left, right) => {
-      const priority = (stage: (typeof snapshot.stages)[number]): number => {
-        if (stage.id === snapshot.currentStageId) return 0;
-        if (stage.lifecycle === 'failed' || stage.lifecycle === 'cancelled') {
-          return 1;
-        }
-        return 2;
-      };
-      return priority(left) - priority(right) || right.order - left.order;
-    })
+    .toSorted(
+      (left, right) =>
+        phasePriority(left) - phasePriority(right) || right.order - left.order,
+    )
     .slice(0, WORKFLOW_SUMMARY_MAX_ENTRIES)
     .map(workflowPhaseView);
   const calls = byPriority
     .slice(0, WORKFLOW_SUMMARY_MAX_ENTRIES)
     .map((call) => {
-      const compactFiles = (files: readonly string[]) => ({
-        sample: files
-          .slice(0, WORKFLOW_SUMMARY_MAX_FILES_PER_KIND)
-          .map((file) => compactWorkflowText(file)!),
-        ...(files.length > WORKFLOW_SUMMARY_MAX_FILES_PER_KIND && {
-          omitted: files.length - WORKFLOW_SUMMARY_MAX_FILES_PER_KIND,
-        }),
-      });
       return {
         id: compactWorkflowText(call.id),
         label: compactWorkflowText(call.label),
@@ -111,9 +120,9 @@ export function workflowExecutionView(
         agent: compactWorkflowText(call.agent),
         model: compactWorkflowText(call.model),
         files: {
-          input: compactFiles(call.files.input),
-          context: compactFiles(call.files.context),
-          media: compactFiles(call.files.media),
+          input: compactWorkflowFiles(call.files.input),
+          context: compactWorkflowFiles(call.files.context),
+          media: compactWorkflowFiles(call.files.media),
         },
         childExecutionId: compactWorkflowText(call.childExecutionId),
         childStreamId: compactWorkflowText(call.childStreamId),

--- a/src/tools/formatting.ts
+++ b/src/tools/formatting.ts
@@ -3,8 +3,6 @@ import { z } from 'zod';
 import type { ToolFileAttachment } from '@shared/schemas';
 import { clamp } from '@utils/core';
 
-// Local imports
-
 /** Canonical 1-based inclusive line range for tool view_range fields. */
 export const ViewRangeSchema = z
   .tuple([z.int().min(1), z.int().min(1)])

--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -196,9 +196,9 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     const detach = session.followUps.onRelease((streamId) => {
       const bound = this.perStream.get(streamId);
       if (!bound) return;
-      const owned = [...bound].filter(([, binding]) => {
-        return binding.owner === session;
-      });
+      const owned = [...bound].filter(
+        ([, binding]) => binding.owner === session,
+      );
       if (owned.length === 0) return;
       for (const [key] of owned) bound.delete(key);
       if (bound.size === 0) this.perStream.delete(streamId);

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -30,7 +30,6 @@ import {
 import { GlobalStorageFS } from '@utils/files/storageFS';
 import { isDirectory } from '@utils/files/fsEntryType';
 
-const THREADS_DIR = EXTERNAL_INQUIRY_THREADS_DIR;
 const QUESTION_PREVIEW_CHARS = 200;
 const logger = createLog('ExternalInquiryStorage');
 
@@ -118,7 +117,7 @@ const threadMutex = new KeyedMutex<string>();
 // ============================================================================
 
 function threadDir(threadId: InquiryThreadId): string {
-  return path.join(THREADS_DIR, threadId);
+  return path.join(EXTERNAL_INQUIRY_THREADS_DIR, threadId);
 }
 
 function threadManifestPath(threadId: InquiryThreadId): string {
@@ -478,12 +477,12 @@ function manifestToSummary(
 async function listAllManifests(): Promise<ExternalInquiryThreadManifest[]> {
   // A missing threads directory means no threads. Operational storage
   // failures must remain observable instead of masquerading as empty history.
-  const entries = await GlobalStorageFS.readDir(THREADS_DIR).catch(
-    (error: unknown): [string, number][] => {
-      if (isFileNotFoundError(error)) return [];
-      throw error;
-    },
-  );
+  const entries = await GlobalStorageFS.readDir(
+    EXTERNAL_INQUIRY_THREADS_DIR,
+  ).catch((error: unknown): [string, number][] => {
+    if (isFileNotFoundError(error)) return [];
+    throw error;
+  });
 
   const reads = entries.flatMap(([name, type]) => {
     if (!isDirectory(type)) return [];

--- a/src/tools/latex/figureExtractionShared.ts
+++ b/src/tools/latex/figureExtractionShared.ts
@@ -1,12 +1,17 @@
 import { z } from 'zod';
 
-import { ToolError, type ToolFileAttachment } from '@shared/schemas';
+import {
+  ToolError,
+  type ToolFileAttachment,
+  type ToolResult,
+} from '@shared/schemas';
 import { buildFileAttachment } from '@tools/attachments';
 import { formatToolOutput } from '@tools/formatting';
 import {
   resolveAndFormat,
   type WorkspacePathResolution,
 } from '@tools/pathResolution';
+import { executed } from '@tools/core/result';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 
 /** Shared `texPath` Zod field for LaTeX extraction tools, with a per-tool description. */
@@ -38,12 +43,8 @@ interface AttachmentLimitOptions {
 export function emptyExtractionResult(
   label: string,
   summary: string,
-): { status: 'executed'; summary: string; output: string } {
-  return {
-    status: 'executed',
-    summary,
-    output: formatToolOutput(label, null),
-  };
+): Extract<ToolResult, { status: 'executed' }> {
+  return executed(formatToolOutput(label, null), summary);
 }
 
 export async function resolveLatexFileOrThrow(

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -30,8 +30,10 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { runLakeCommand } from './lakeCommands';
 import { LeanSession } from './leanSession';
-import { setLeanLanguageServices } from '../leanLanguageServices';
-import type { LeanLanguageServices } from '../leanLanguageServices';
+import {
+  setLeanLanguageServices,
+  type LeanLanguageServices,
+} from '../leanLanguageServices';
 import type {
   LeanFileCommand,
   LeanProjectCommand,
@@ -741,8 +743,6 @@ export async function defaultResolveWorkspaceRoot(
       return dir;
     }
     if (dir === root) return null;
-    const parent = path.dirname(dir);
-    if (parent === dir) return null;
-    dir = parent;
+    dir = path.dirname(dir);
   }
 }

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -58,7 +58,6 @@ export interface LeanSessionOptions {
 }
 
 export class LeanSession {
-  private child?: ChildProcessWithoutNullStreams;
   private spawned?: ChildProcessWithoutNullStreams;
   private rpc?: JsonRpcConnection;
   private closeWait?: Promise<void>;
@@ -88,11 +87,9 @@ export class LeanSession {
   async dispose(): Promise<void> {
     if (this.disposed) return;
     this.disposed = true;
-    const child = this.child;
     const spawned = this.spawned;
     const rpc = this.rpc;
     const closeWait = this.closeWait;
-    this.child = undefined;
     this.spawned = undefined;
     this.rpc = undefined;
     this.readyPromise = undefined;
@@ -100,7 +97,7 @@ export class LeanSession {
     this.openFiles.clear();
     unregisterLeanServer(this.id);
     try {
-      if (rpc && child) {
+      if (rpc && spawned) {
         try {
           await pTimeout(rpc.request('shutdown'), {
             milliseconds: SHUTDOWN_TIMEOUT_MS,
@@ -204,7 +201,6 @@ export class LeanSession {
         cause: error,
       });
     }
-    this.child = child;
     this.spawned = child;
     this.closeWait = new Promise<void>((resolve) => {
       child.once('close', () => resolve());
@@ -217,7 +213,6 @@ export class LeanSession {
       finalized = true;
       this.options.onExit?.();
       updateLeanServer(this.id, { status, errorMessage: message });
-      this.child = undefined;
       this.rpc?.dispose(message ?? 'Lean server stopped');
       this.rpc = undefined;
       this.readyPromise = undefined;

--- a/src/tools/timeouts.ts
+++ b/src/tools/timeouts.ts
@@ -41,15 +41,9 @@ export function unwrapAbortError(error: unknown): unknown {
  */
 export function isTimeoutError(error: unknown): boolean {
   if (error instanceof TimeoutError) return true;
-  if (error instanceof Error && error.name === 'TimeoutError') return true;
-  if (
-    error instanceof Error &&
-    error.name === 'AbortError' &&
-    isTimeoutError(error.cause)
-  ) {
-    return true;
-  }
-  return false;
+  if (!(error instanceof Error)) return false;
+  if (error.name === 'TimeoutError') return true;
+  return error.name === 'AbortError' && isTimeoutError(error.cause);
 }
 
 /**

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -95,13 +95,14 @@ The tool returns a JSON object whose keys are the original question texts and wh
     }
 
     const answers = UserQuestionAnswersSchema.parse(result.answers);
-    if (Object.keys(answers).length === 0) {
+    const answerCount = Object.keys(answers).length;
+    if (answerCount === 0) {
       return executed('The user submitted no answers.');
     }
 
     return executed(
       JSON.stringify({ answers }, null, 2),
-      `Answered ${Object.keys(answers).length} user question(s).`,
+      `Answered ${answerCount} user question(s).`,
     );
   }
 }

--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -58,7 +58,6 @@ function buildTree(collections: BbtCollection[]): CollectionNode[] {
   const nodeMap = new Map<string, CollectionNode>();
   const roots: CollectionNode[] = [];
 
-  // Create all nodes
   for (const c of collections) {
     nodeMap.set(c.key, { key: c.key, name: c.name, children: [] });
   }
@@ -174,7 +173,6 @@ export class ZoteroCollectionsTool extends defineTool({
       );
     }
 
-    // Filter by library name if specified
     const normalizedLibrary = library?.toLowerCase();
     const targetLibraries = normalizedLibrary
       ? libraries.filter((lib) => lib.name.toLowerCase() === normalizedLibrary)

--- a/src/tools/zotero/ZoteroSearchTool.ts
+++ b/src/tools/zotero/ZoteroSearchTool.ts
@@ -185,7 +185,6 @@ export class ZoteroSearchTool extends defineTool({
         )
       : null;
 
-    // Format results
     const items = result.map((item) => {
       const base = formatSearchResult(item);
       if (!collectionMap) return base;

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -1272,7 +1272,6 @@ export class StreamLogStore {
 
   /** Shared post-mutation bookkeeping for append/update/appendText/group-end. */
   private commitChange(streamId: StreamTabId, logInstance: StreamLog): void {
-    this.assertWritableStore('commit transcript changes');
     this.refreshSummary(streamId, logInstance);
     if (this.mode.kind === 'persistent') this.markDirty(streamId);
     this.notify(streamId);

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -34,10 +34,10 @@ export async function assembleTrace(
     resolveStreamForExecution(executionId),
     executionStore.readRunRecord(),
   ]);
-  const snapshotStore = new StreamSnapshotStore();
   if (!config) return { status: 'config_missing' };
   if (!resolution) return { status: 'streamLogs_missing' };
   const { streamId, meta } = resolution;
+  const snapshotStore = new StreamSnapshotStore();
 
   // A call-scoped read-only store seeded with just this stream avoids
   // reloading a live host's session, scanning the whole streamLogs

--- a/src/utils/config/configUtils.ts
+++ b/src/utils/config/configUtils.ts
@@ -9,10 +9,6 @@ import type { ZodType } from 'zod';
 
 const log = createLog('configUtils');
 
-function configProvider() {
-  return platform().config;
-}
-
 /**
  * Gets a value from the host's native TeXRA configuration.
  *
@@ -29,7 +25,7 @@ function configProvider() {
  * @returns The configured, catalog-default, or caller-fallback value
  */
 export function getConfig<T>(path: string, defaultValue?: T): T {
-  const configured = configProvider().get<T | undefined>(path);
+  const configured = platform().config.get<T | undefined>(path);
   if (configured !== undefined) return configured;
   const catalogDefault = getCoreSettingDefault(path) as T | undefined;
   return catalogDefault === undefined ? (defaultValue as T) : catalogDefault;
@@ -76,7 +72,7 @@ export function getValidatedConfig<T>(
   if (result.success) return result.data;
   // Warn only when the user explicitly set the value (global, workspace, or
   // workspace folder); an unset setting failing the schema is normal.
-  if (configProvider().isExplicitlySet(path)) {
+  if (platform().config.isExplicitlySet(path)) {
     log.warn(
       `Ignoring invalid value for setting "${path}": ${toErrorMessage(result.error)}`,
     );

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -141,13 +141,8 @@ export function getWebSocketEnabled(): boolean {
 
 /**
  * Whether to route all API calls through OpenRouter. Catalog-modeled (see
- * `stateSettings.ts`); the legacy VS Code config fallback this used to carry
- * for pre-global-state-migration users was dead code — `StateStore.get(key,
- * defaultValue)` always resolves to `defaultValue` once the platform is
- * initialized, so the config fallback could only ever fire before
- * initialization, at which point `getConfig` also just returns its own
- * `defaultValue` (`false`). Removed rather than folded into
- * `readPlatformSetting()`.
+ * `stateSettings.ts`), so the default comes from the schema via the shared
+ * accessor.
  */
 export function getUseOpenRouter(): boolean {
   return readPlatformSetting<boolean>(GlobalStateKey.USE_OPENROUTER);

--- a/src/utils/files/baseFS.ts
+++ b/src/utils/files/baseFS.ts
@@ -10,10 +10,10 @@ import {
 } from '@common/errors';
 
 // Platform imports
-import { FileType, type FileStat } from '@platform/interfaces';
+import { type FileStat } from '@platform/interfaces';
 import { platform } from '@platform/platform';
 import { normalizeLineEndings } from '@utils/text/stringUtils';
-import { isFile } from './fsEntryType';
+import { isFile, isSymlink } from './fsEntryType';
 
 /** Convert content to Buffer for writing. */
 function toBuffer(content: string | Uint8Array): Uint8Array {
@@ -225,10 +225,7 @@ export abstract class BaseFS {
     target: string,
   ): Promise<boolean> {
     const stats = await this.statIfExists(target);
-    return (
-      stats !== undefined &&
-      (stats.type & FileType.SymbolicLink) === FileType.SymbolicLink
-    );
+    return stats !== undefined && isSymlink(stats.type);
   }
 
   // ===== Sync Methods =====

--- a/src/utils/files/relativeFS.ts
+++ b/src/utils/files/relativeFS.ts
@@ -10,8 +10,8 @@ import { createLog } from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local imports - filesystem
-import { isFile } from './fsEntryType';
 import { BaseFS } from './baseFS';
+import { isFile } from './fsEntryType';
 
 const log = createLog('relativeFS');
 

--- a/src/utils/files/runStorageFs.ts
+++ b/src/utils/files/runStorageFs.ts
@@ -98,7 +98,7 @@ export async function inspectRunStorageEntry(
   const root = resolveRunStoragePath(executionId);
   const entry = resolveRunStoragePath(executionId, normalizedPath);
   const ancestors = [root];
-  for (const [index] of pathSegments.slice(0, -1).entries()) {
+  for (let index = 0; index < pathSegments.length - 1; index++) {
     ancestors.push(
       resolveRunStoragePath(executionId, ...pathSegments.slice(0, index + 1)),
     );

--- a/src/utils/files/runStorageFs.ts
+++ b/src/utils/files/runStorageFs.ts
@@ -98,7 +98,7 @@ export async function inspectRunStorageEntry(
   const root = resolveRunStoragePath(executionId);
   const entry = resolveRunStoragePath(executionId, normalizedPath);
   const ancestors = [root];
-  for (let index = 0; index < pathSegments.length - 1; index++) {
+  for (const [index] of pathSegments.slice(0, -1).entries()) {
     ancestors.push(
       resolveRunStoragePath(executionId, ...pathSegments.slice(0, index + 1)),
     );

--- a/src/utils/files/varsUtils.ts
+++ b/src/utils/files/varsUtils.ts
@@ -20,7 +20,7 @@ export interface FileVarValue {
 export async function setVarFromFile(
   filePath: string,
   varName: string,
-  absolute: boolean = false,
+  absolute = false,
 ): Promise<FileVarValue | null> {
   try {
     const content = absolute

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -338,7 +338,7 @@ export async function executeCommand(
     if (Array.isArray(command)) {
       const [cmd, ...args] = command;
       if (!options.quiet) {
-        log.debug(`Running command: ${shellQuote([cmd, ...args])}`);
+        log.debug(`Running command: ${shellQuote(command)}`);
       }
       subprocess = execa(cmd, args, {
         ...execaOptions,
@@ -491,7 +491,7 @@ export function executeCommandSync(
     };
     const log = createLog(options.channel ?? CHANNEL);
     if (!options.quiet) {
-      log.debug(`Running command: ${shellQuote([cmd, ...args])}`);
+      log.debug(`Running command: ${shellQuote(command)}`);
     }
     const result = execaSync(cmd, args, execaOptions);
     const stdout = (result.stdout as string) ?? '';

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -51,6 +51,18 @@ function globDescending(pattern: string): string[] {
 }
 
 /**
+ * `~/bin` plus Claude Code's native-installer `~/.local/bin` — the one its docs
+ * recommend. A GUI-launched app does not inherit the shell profile that would
+ * normally put these on PATH.
+ */
+function pushHomeBinDirs(dirs: string[]): void {
+  const home = process.env.HOME;
+  if (home) {
+    dirs.push(path.join(home, 'bin'), path.join(home, '.local', 'bin'));
+  }
+}
+
+/**
  * Return common tool directories based on the current platform.
  * Results are cached for the session to improve performance.
  * Internal helper used by extendEnvPath and findToolInCommonPaths.
@@ -71,14 +83,7 @@ function getExtraDirs(): string[] {
     );
     // MiKTeX on macOS: app bundle and default symlink targets
     dirs.push('/Applications/MiKTeX Console.app/Contents/bin');
-    const macHome = process.env.HOME;
-    if (macHome) {
-      dirs.push(path.join(macHome, 'bin'));
-      // Claude Code's native installer — the one its docs recommend — installs
-      // here, and a GUI-launched app does not inherit the shell profile that
-      // would normally put it on PATH.
-      dirs.push(path.join(macHome, '.local', 'bin'));
-    }
+    pushHomeBinDirs(dirs);
   } else if (platform === 'win32') {
     dirs.push(
       'C:\\Program Files\\MiKTeX\\miktex\\bin\\x64',
@@ -181,15 +186,7 @@ function getExtraDirs(): string[] {
       '/snap/bin', // Ubuntu snap packages
       '/home/linuxbrew/.linuxbrew/bin',
     );
-    // MiKTeX on Linux: per-user symlink directory for private installs
-    const linuxHome = process.env.HOME;
-    if (linuxHome) {
-      dirs.push(path.join(linuxHome, 'bin'));
-      // Claude Code's native installer — the one its docs recommend — installs
-      // here, and a GUI-launched app does not inherit the shell profile that
-      // would normally put it on PATH.
-      dirs.push(path.join(linuxHome, '.local', 'bin'));
-    }
+    pushHomeBinDirs(dirs);
   }
 
   const texBinPatterns =


### PR DESCRIPTION
## What

Behavior-preserving simplification sweep over repo-root `src/` (176,814 LoC, everything except `src/test-kernel/`). The tree was mechanically cut into 46 disjoint ~3.6k-LoC partitions, each simplified by an independent code-simplifier agent on a shared checkout. `packages/*` is deliberately left for a later round.

Net: **128 files, +632 / -904**. Typical changes: collapsing single-caller wrappers into their caller, folding duplicated constant tables and helper copies into one shared implementation, inlining pass-throughs, dropping redundant narrowing, defensive copies, and dead locals. Most partitions were already clean and were left alone; churn concentrates where duplication was real.

## Net elements (R6)

- Files (diffstat vs merge-base, includes review follow-ups): **127 files, +627 / -887**; net **-260 LoC**. The 128th swept file was reverted byte-identical to main by review follow-ups, hence 127.
- Exported symbols (`^[+-]export` over the diff): **9 added / 9 removed, net 0**. Four pairs are the same symbol re-expressed in place (`TranscriptExportFormat`, `AuthCallbackCodeParseResult`, `workflowRunSettled`, `ToolConfigFieldsSchema`). Genuinely new exports all have same-PR consumers (`matchUsageLimitMessage` + `UsageLimitMatch`, `usableSequence`, `UpdatePlanPayload`, `AgentEntry` re-export). The three removed `export` keywords (`ArxivPaperBase`, `AnthropicPricingConfig`, `firstBodyNumberField`) are de-exports to module-private; the symbols still exist with zero external consumers (grep-verified on the head commit; knip ratchet green).
- Classes/interfaces/enums: no classes or enums added or removed. Interface churn is exactly the pairs above: `UsageLimitMatch` and `UpdatePlanPayload` added (the latter converting a `z.infer` alias to a plain interface; no consumer ever called `.parse()` on it), `ArxivPaperBase` and `AnthropicPricingConfig` de-exported.

## Consumer counts (R8)

n/a for emit paths: no `bus.emit`, `appSignals.emit`, trace event, or IPC key is deleted or re-routed anywhere in the diff (grep-verified). For the three de-exported symbols above: 0 external importers each (see R6).

## Guardrails held

- No edits outside an agent's partition; no git/format/typecheck inside agents.
- No schema-semantics, wire-format, CLI-flag, result-JSON, or persisted-shape changes. Zod `.prefault()`/`.default()`/`.catch()` and tool-input `.nullish()` untouched.
- No new exports without a same-PR consumer (ratchet-verified).

## Validation (central, post-sweep)

- `npm run typecheck` clean (one over-narrowed overload in `PollingSourceBase` caught and reverted)
- `npm run lint` clean
- `npm test`: 9996 passed (one pinned log-channel test caught an inline in `arxivProcessor.ts`; reverted)
- `check:dead-code-ratchet` OK, `compile:fast` OK

## Structural findings reported by the agents (not fixed here)

Each agent also reported structural/cross-cutting problems it was not allowed to fix: 31 cross-cutting, 50 local. These are untriaged leads for future tech-debt rounds, not claims.

<details><summary>Cross-cutting (31)</summary>

- Stream-keyed handle lookups are linear scans on hot paths (`src/agent/runtime/executionRegistry.ts`)
- Per-provider thinking/reasoning effort plumbing is per-class with overlapping shapes (`src/agent/modelHandlers/openai`)
- ModelHandler base class concentrates six concerns in ~2000 lines (`src/agent/modelHandlers/`)
- Per-provider usage modules duplicate token-total accumulation loops (`src/agent/modelHandlers`)
- Chat export barrel is incomplete: LaTeX path still deep-imported by the progress-view controller (`src/agent/export`)
- Provider-specific Kimi Code retry logic coupled into the flow-kernel ModelInvocationNode (`src/agent/core/flows + src/agent/runtime`)
- BackgroundRunLifecycle verdict DU is honored on only one of three retrieve paths (`src/agent/modelHandlers/support`)
- Lease v1/v2 compatibility shim has a dated retirement (2026-11-24) spanning two modules (`src/agent/storage + src/shared`)
- ResultEvent error-fact construction duplicated between run lifecycle and child-run loop (`src/agent/runtime/AgentRunLifecycle.ts + src/agent/runtime/childRunLoop.ts`)
- Round state has three parallel representations across reflection flow (`src/agent/implementations/flows/reflection`)
- Web-fetch dual representation (nested live block vs flat archived block) with readers in three subsystems (`src/agent/types + src/agent/storage + src/agent/export + src/agent/modelHandlers`)
- Dual request-settlement state machines for WebSocket vs HTTP Responses streaming (`src/agent/modelHandlers/openai`)
- Pass-through getProviderKeyUrl method on SettingsProfileController exists only to be re-injected into SettingsProfileKeyController (`src/controllers/settingsView`)
- Two parallel session coordinators duplicating refresh/supersede machinery (`src/auth`)
- Duplicate IPC keys for the 'restoreState' literal (`src/shared/ipc.ts`)
- Codex/xAI symmetric-pair duplication across the subscription-capability seam (`src/model/`)
- safeParseJson/safeParseYaml are fully parallel duplicated modules (`src/common/parsing`)
- Dated legacy-reader removals in schemas lack a tracked retirement mechanism (`src/shared/schemas`)
- Quota-fallback exhaustion vocabulary is triplicated across errors.ts, quotaFallbackRoutes.ts, and codingPlanSubscriptions.ts (`src/shared`)
- latexdiff service.ts CHANNEL alias is a pass-through re-export (`src/latex/latexdiff/service.ts`)
- Three parallel pack/clean orchestrations plus duplicated legacy filename-grammar readers (`src/housekeeping`)
- PhaseStage name collision between shared schema and workflow engine (`src/tools/delegation`)
- LatexConfigValues duplicates the catalog-derived latex snapshot (`src/shared/schemas`)
- selectStyles hardcodes 6px padding that --control-padding-inline token exists to centralize (`src/shared/styles`)
- Web Awesome UI helpers mixed into host-neutral src/shared/utils/ (`src/shared/utils vs src/shared/wa`)
- Two overlapping config-read paths: getConfig/getValidatedConfig vs readPlatformSetting catalog path (`src/utils/config/ vs src/shared/config/`)
- Run-storage code uses two parallel filesystem access layers for the same tree (`src/utils/files`)
- InquiryActionMessage drop variants re-narrowed at consumers with never-field unions (`src/shared/schemas + src/tools/inquiry`)
- Lean tool result construction is split between executed() and hand-built literals (`src/tools`)
- Tool detection is three layered systems (findToolInCommonPaths, BinaryResolver, checkToolInstalled execa probes) (`src/utils/system`)
- Fabricated AgentConfig built only to feed child-stream creation (`src/tools/delegation`)

</details>

<details><summary>Local (50)</summary>

- executionRegistry.ts carries four separable concerns in one 1100-line class (`src/agent/runtime`)
- SessionStores.ts is a 1000-line class mixing three deletion concerns (`src/agent/storage`)
- Fail-closed ownership-unreadable logic repeated at four sites in SessionStores.ts (`src/agent/storage/SessionStores.ts`)
- Duplicate AgentEntry derivation logic in YAML vs inline registration paths (`src/agent/index`)
- Tool-use flow persisted-state documentation spread across four files (`src/agent/implementations/flows/tooluse`)
- Compaction machinery in modelHandlerOpenAIResponse could follow the file's own collaborator pattern (`src/agent/modelHandlers/openai`)
- Thinking-parameter type `{ type: 'enabled' | 'disabled' }` duplicated across five handler declarations (`src/agent/modelHandlers/openai`)
- Dual flow-record readers: schema-validated vs raw cast (`src/agent/node/persistedFlow.ts`)
- Duplicated ky/auth/timeout plumbing across remote-agent clients (`src/agent/remote/`)
- resumeRun recovery-claim choreography is double-layered (`src/agent/runtime`)
- modelHandlerAnthropic.ts is ~1800 LOC despite the sibling-module split pattern (`src/agent/modelHandlers/anthropic`)
- Reflection output/ directory is over-fragmented around one shared state pair (`src/agent/implementations/flows/reflection/output`)
- extractFilenameHeaderDocuments is a 270-line closure state machine (`src/agent/implementations/flows/reflection/output/extraction`)
- Duplicated terminal-outcome precedence logic in childRunLoop (`src/agent/runtime/childRunLoop.ts`)
- XmlOutputManager extraction fallback tiers are an implicit precedence chain (`src/agent/implementations/flows/reflection/output/XmlOutputManager.ts`)
- Dead defensive nullish fallbacks against non-nullable SDK Choice type (`src/agent/modelHandlers/openai`)
- Duplicated deletion-settlement logic in SessionFactApplier fact vs command paths (`src/controllers/session`)
- Latexdiff \DIFdel/\DIFadd regex tables are near-duplicated with an unexplained asymmetry (`src/replacement`)
- slow_down signaled via error message string matching (`src/auth/xai`)
- Duplicated retained-deletion repair sequence in single- vs bulk-delete paths (`src/controllers/progressView/backend/ProgressBackend.ts`)
- LitSessionRenderer.invalidate() repeats sendIfActive+nonEmptyRounds per slice (`src/controllers/progressView/backend/LitSessionRenderer.ts`)
- Retry settlement state split across two owners (host interactions vs API-key retry controller) (`src/controllers/progressView`)
- createMarkdownProcessor.ts conflates caching, math shielding, and the beg_end probe (`src/shared/markdown`)
- Self-documented dead rules in maxRules manual pattern table (`src/replacement`)
- Duplicate 'ReplacementEngine' log channel across two modules (`src/replacement`)
- workspaceStorage path helpers kept alive only by tests (`src/platform/defaults`)
- Four near-identical subscription-limit result interfaces (`src/common/errors/sdkError`)
- Banner payload fields are defined twice: state.ts banner schemas vs outbound.ts SET_BANNER data (`src/shared/schemas/mainView`)
- Dual latexdiff output-discovery systems; legacy workspace scan is an expired-compatibility candidate (`src/latex/latexdiff`)
- Duplicated workspace-absolutize lambda in latexdiff discovery paths (`src/latex/latexdiff/diffOperations.ts + outputDiscovery.ts`)
- latexdiff service duplicates input-existence checks across runDiff wrappers (`src/latex/latexdiff`)
- Duplicated untyped-payload YAML serialization in toolUse.ts and transcriptText.ts (`src/shared`)
- toolRowModel.ts exceeds the repo's long-file modularity threshold (`src/shared/transcript`)
- Duplicate stream-id-or-empty union in prompts.ts and progressView/data.ts (`src/shared/schemas`)
- walkDir stacks two concurrency limiters that partially duplicate each other (`src/tools/memory`)
- MemoryTool.resolveMemoryPath catch-all masks the path-escape error and duplicates a user-facing string (`src/tools/memory`)
- Log channel names diverge from module names (`src/tools/delegation`)
- PR_POLL_INTERVAL_MS name under-scopes a shared constant (`src/tools/github`)
- 24h-detach rationale comment duplicated across three pollers (`src/tools/github`)
- Dual skill-description validation with divergent failure semantics (`src/skills`)
- Duplicated SDK dynamic-import error wrapper across agent CLI imports (`src/tools`)
- ExecutionsTool.ts god-tool at ~940 LOC despite executions/ helper directory (`src/tools`)
- Minor duplicated warn-then-derive blocks in ExecutionsTool and checkRunsClient (`src/tools`)
- StreamLogStore and StreamSnapshotStore remain far past the repo's own file-size bar (`src/transcript`)
- ZoteroSearchTool runtime invariant carried by schema refine, invisible to the compiler (`src/tools/zotero`)
- StreamSnapshotStore is 2146 lines mixing five concerns; the write-durability lane is extractable (`src/transcript/`)
- TranscriptSpillWriter is an export with no importer (`src/transcript/TexraTranscriptRecorder.ts`)
- createWorkspaceLocation/createRunStorageLocation/createExternalLocation are pure literal wrappers (`src/utils/files/fileLocation.ts`)
- xmlConversion scratchpad formatting runs three divergent conversion pipelines (pandoc, turndown, regex) for one job (`src/utils/text`)
- Dual owners of engine-status to card-status mapping (`src/tools/delegation`)

</details>

