### PR TITLE
fix(cli): clarify GLM Coding Plan key setup

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1358,6 +1358,23 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'provider-key-form',
+    rows: 24,
+    cols: 100,
+    env: { HARNESS_ENTRIES: '0' },
+    keys: ['/key', '\r'],
+    frame: 'viewport',
+    expect: [
+      'Add provider API key',
+      'Choose the service that issued the key.',
+      'GLM API/GLM Coding Plan',
+      'Kimi Code',
+      '↑/↓ navigate',
+      'Esc close',
+    ],
+    unexpect: ['GLM Coding Plan —', 'Platform not initialized', '/key - error'],
+  },
+  {
     name: 'api-form-chatgpt-hotkey',
     rows: 12,
     cols: 80,

--- a/packages/cli/src/chat/tui/commands/handlers/modelAccessCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/modelAccessCommands.ts
@@ -8,6 +8,7 @@ import {
 import { updateCliModelAccess } from '@cli/runtime/modelAccessSelection';
 
 import type { ApiProvider } from '@model/apiProviders';
+import { codingPlanForApiProvider } from '@shared/codingPlanSubscriptions';
 import { collapseWhitespace } from '@utils/text/stringUtils';
 import {
   abortableSlashCommand,
@@ -30,7 +31,11 @@ export async function applyCliProviderApiKey(
 ): Promise<string | undefined> {
   await saveProviderApiKey(provider, key);
   refreshSubscriptionPreferenceViews();
-  if (provider !== 'kimiCode') return undefined;
+  const codingPlan = codingPlanForApiProvider(provider);
+  if (!codingPlan) return undefined;
+  if (!codingPlan.exclusiveCredential) {
+    return `Tip: this key uses ${codingPlan.retryFallbackName} by default; enable '${codingPlan.preferenceLabel}' with \`/api ${codingPlan.cliProvider}\` or in \`/config\` to use ${codingPlan.displayName}.`;
+  }
   // The coding-only models route through the subscription automatically;
   // dual-backend K3 needs the opt-in switch, which is only discoverable if
   // we name it here.

--- a/packages/cli/src/chat/tui/forms/ProviderApiKeyForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ProviderApiKeyForm.tsx
@@ -6,6 +6,7 @@ import {
   type ApiKeyStatus,
   type ApiProvider,
 } from '@model/apiProviders';
+import { codingPlanForApiProvider } from '@shared/codingPlanSubscriptions';
 import { providerDisplayName } from '@shared/constants/providers';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -33,10 +34,18 @@ function providerApiKeyStatusLabel(
   return 'Status unavailable';
 }
 
+function providerApiKeyFormLabel(provider: ApiProvider): string {
+  const providerName = providerDisplayName(provider);
+  const codingPlan = codingPlanForApiProvider(provider);
+  return codingPlan && !codingPlan.exclusiveCredential
+    ? `${providerName} API/${codingPlan.displayName}`
+    : providerName;
+}
+
 export function buildProviderApiKeyItems(view: ProviderApiKeyStatusView) {
   return API_PROVIDERS.map((provider) => ({
     value: provider,
-    label: providerDisplayName(provider),
+    label: providerApiKeyFormLabel(provider),
     description: providerApiKeyStatusLabel(view.statuses?.[provider], view),
   }));
 }
@@ -94,7 +103,7 @@ export function ProviderApiKeyForm(
             ? buildProviderApiKeyItems(props.statusView)
             : API_PROVIDERS.map((provider) => ({
                 value: provider,
-                label: providerDisplayName(provider),
+                label: providerApiKeyFormLabel(provider),
               }))
         }
         description={

--- a/src/test-kernel/cli/ConfigForm.vitest.ts
+++ b/src/test-kernel/cli/ConfigForm.vitest.ts
@@ -355,6 +355,7 @@ describe('ConfigForm helpers', () => {
       statuses: {
         openai: 'set',
         anthropic: 'not-set',
+        glm: 'not-set',
         kimiCode: 'env',
       },
       loading: false,
@@ -371,6 +372,12 @@ describe('ConfigForm helpers', () => {
     expect(items.find((item) => item.value === 'kimiCode')).toMatchObject({
       label: 'Kimi Code',
       description: 'Env',
+    });
+    const glmRows = items.filter((item) => item.value === 'glm');
+    expect(glmRows).toHaveLength(1);
+    expect(glmRows[0]).toMatchObject({
+      label: 'GLM API/GLM Coding Plan',
+      description: 'Not set',
     });
   });
 

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -7,7 +7,10 @@ import { afterEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { handleTuiSlashCommand } from '@cli/chat/tui/commands/handleSlashCommand';
-import { applyCliModelAccessSelection } from '@cli/chat/tui/commands/handlers/modelAccessCommands';
+import {
+  applyCliModelAccessSelection,
+  applyCliProviderApiKey,
+} from '@cli/chat/tui/commands/handlers/modelAccessCommands';
 import {
   showCliMemoryList,
   showCliMemoryPreview,
@@ -48,6 +51,7 @@ import * as apiStatus from '@cli/runtime/apiStatus';
 import * as subscriptionLogin from '@cli/runtime/subscriptionLogin';
 import type { CliContext } from '@cli/runtime/cliContext';
 import * as modelAccessSelection from '@cli/runtime/modelAccessSelection';
+import * as providerApiKey from '@cli/runtime/providerApiKey';
 import * as supabaseAuth from '@cli/runtime/supabaseAuth';
 import { TuiSession } from '@cli/chat/tui/state/sessionRunState';
 import { SessionState } from '@controllers/session/SessionState';
@@ -804,6 +808,19 @@ describe('handleTuiSlashCommand', () => {
     expectAccessStatusText(apiStatusText);
     expect(apiStatusText).toBe(authStatusText);
     expect(overview).toHaveBeenCalledTimes(2);
+  });
+
+  it('explains the shared GLM key routes after saving it', async () => {
+    const save = vi
+      .spyOn(providerApiKey, 'saveProviderApiKey')
+      .mockResolvedValue(undefined);
+
+    const notice = await applyCliProviderApiKey('glm', 'glm-secret');
+
+    expect(save).toHaveBeenCalledWith('glm', 'glm-secret');
+    expect(notice).toBe(
+      "Tip: this key uses the regular GLM endpoint by default; enable 'Prefer GLM Coding Plan' with `/api glm-code` or in `/config` to use GLM Coding Plan.",
+    );
   });
 
   it('exposes cancellation while model access is signing in to ChatGPT', async () => {


### PR DESCRIPTION
## Summary
- label the existing shared GLM credential row as `GLM API/GLM Coding Plan` in the provider-key form
- explain after save that regular GLM is the default and that `/api glm-code` or `/config` enables Prefer GLM Coding Plan
- derive the menu copy and notice from the canonical coding-plan descriptor without adding a provider, credential, schema field, or auth path
- add focused helper, command, and TUI coverage, including an exact-one-GLM-row assertion

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ConfigForm.vitest.ts src/test-kernel/cli/SlashCommandDispatch.vitest.ts src/test-kernel/shared/CodingPlanSubscriptions.vitest.ts` (107 passed)
- `corepack pnpm --filter @texra-ai/cli validate:tui -- provider-key-form`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `corepack pnpm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli run check:architecture`
- `corepack pnpm run check:dead-code-ratchet`
- changed-file Prettier check
- `git diff --check origin/main...HEAD`

The raw dead-code scan reports the six findings already present in the repository baseline; the ratchet confirms no new findings. The full TUI harness also has unrelated existing scenario failures and exceeded ten minutes, while the new focused `provider-key-form` scenario passes.

Closes #11723
