### PR TITLE
fix(cli): make GLM endpoint notice state-neutral

### DIFF
--- a/packages/cli/src/chat/tui/commands/handlers/modelAccessCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/modelAccessCommands.ts
@@ -34,7 +34,7 @@ export async function applyCliProviderApiKey(
   const codingPlan = codingPlanForApiProvider(provider);
   if (!codingPlan) return undefined;
   if (!codingPlan.exclusiveCredential) {
-    return `Tip: this key uses ${codingPlan.retryFallbackName} by default; enable '${codingPlan.preferenceLabel}' with \`/api ${codingPlan.cliProvider}\` or in \`/config\` to use ${codingPlan.displayName}.`;
+    return `Tip: ${codingPlan.retryFallbackName} is the default; enable '${codingPlan.preferenceLabel}' with \`/api ${codingPlan.cliProvider}\` or in \`/config\` to use ${codingPlan.displayName}.`;
   }
   // The coding-only models route through the subscription automatically;
   // dual-backend K3 needs the opt-in switch, which is only discoverable if

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -819,7 +819,7 @@ describe('handleTuiSlashCommand', () => {
 
     expect(save).toHaveBeenCalledWith('glm', 'glm-secret');
     expect(notice).toBe(
-      "Tip: this key uses the regular GLM endpoint by default; enable 'Prefer GLM Coding Plan' with `/api glm-code` or in `/config` to use GLM Coding Plan.",
+      "Tip: the regular GLM endpoint is the default; enable 'Prefer GLM Coding Plan' with `/api glm-code` or in `/config` to use GLM Coding Plan.",
     );
   });
 


### PR DESCRIPTION
## Summary
- follow up on the automated review finding from #11727
- describe the regular GLM endpoint as the default without claiming it is the active route
- keep the existing `/api glm-code` and `/config` setup guidance

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/SlashCommandDispatch.vitest.ts` (44 passed)
- changed-file Prettier check
- `corepack pnpm run typecheck:cli`
- `corepack pnpm run typecheck:test-kernel`
- `git diff --check`

Follow-up to #11727.
