### PR TITLE
refactor: behavior-preserving simplification sweep over packages/*/src

### DIFF
--- a/packages/cli/src/chat/tui/forms/GoalModeForm.tsx
+++ b/packages/cli/src/chat/tui/forms/GoalModeForm.tsx
@@ -11,19 +11,15 @@ export interface GoalModeFormProps {
   readonly onClose: () => void;
 }
 
-function toggleDescription(enabled: boolean): string {
-  return enabled
-    ? 'On · commands, file edits, and delegated work; other prompts still ask'
-    : 'Off · commands only; edits and other prompts still ask';
-}
-
 /** Goal-mode reference and its session-local approval-scope toggle. */
 export function GoalModeForm(props: GoalModeFormProps): React.JSX.Element {
   const items: ReadonlyArray<SelectItem<boolean>> = [
     {
       value: !props.autoApproveAll,
       label: 'Auto-approve all goal work',
-      description: toggleDescription(props.autoApproveAll),
+      description: props.autoApproveAll
+        ? 'On · commands, file edits, and delegated work; other prompts still ask'
+        : 'Off · commands only; edits and other prompts still ask',
     },
   ];
   return (

--- a/packages/cli/src/chat/tui/modals/AgentProposal.tsx
+++ b/packages/cli/src/chat/tui/modals/AgentProposal.tsx
@@ -41,10 +41,6 @@ function wrappedRows(text: string, width: number): number {
   return wrapAnsiToWidth(text, clampModalWidth(width)).split('\n').length;
 }
 
-function fileGroupText(label: string, files: readonly string[]): string {
-  return formatAgentProposalFileGroup(label, files, FILE_LIMIT);
-}
-
 interface MetadataSegment {
   readonly text: string;
   readonly bold?: boolean;
@@ -73,7 +69,11 @@ function fileGroupLine(group: {
   readonly label: string;
   readonly files: readonly string[];
 }): MetadataLine {
-  const text = fileGroupText(group.label, group.files);
+  const text = formatAgentProposalFileGroup(
+    group.label,
+    group.files,
+    FILE_LIMIT,
+  );
   const prefix = `${group.label}: `;
   return {
     segments: [

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -146,10 +146,12 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
       }
       // `feedbackWasCompactRef` is only ever latched while feedback mode is
       // open and cleared on the way out, so it already implies the transition.
-      if (!active && feedbackWasCompactRef.current) {
-        setFeedbackExitCount((count) => count + 1);
+      if (!active) {
+        if (feedbackWasCompactRef.current) {
+          setFeedbackExitCount((count) => count + 1);
+        }
+        feedbackWasCompactRef.current = false;
       }
-      if (!active) feedbackWasCompactRef.current = false;
       setFeedbackMode(active);
     },
     [feedbackDiffIsCompact, feedbackValue],

--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -70,10 +70,6 @@ function compactRowPriority(row: CompactTodosPlanRow): number {
   }
 }
 
-function representedSourceRows(row: CompactTodosPlanRow): number {
-  return row.kind === 'completedSummary' ? row.count : 1;
-}
-
 export function compactTodosPlanRows({
   maxRows,
   plan,
@@ -142,7 +138,11 @@ export function compactTodosPlanRows({
   return {
     hiddenCount: compactRows
       .filter((row) => !rows.includes(row))
-      .reduce((count, row) => count + representedSourceRows(row), 0),
+      .reduce(
+        (count, row) =>
+          count + (row.kind === 'completedSummary' ? row.count : 1),
+        0,
+      ),
     rows,
   };
 }

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -324,10 +324,7 @@ function buildStyledLines(
   const elide = options.elide !== false;
   const isBashKind = toolDisplayKind(toolUse.toolName) === 'bash';
 
-  const budget =
-    options.width === undefined
-      ? MAX_HEADER_PREVIEW
-      : toolHeaderPreviewBudget(options.width, model.headerLabel);
+  const budget = toolHeaderPreviewBudget(options.width, model.headerLabel);
   const preview =
     budget > 0 && headerPreview
       ? truncateSummaryToWidth(headerPreview, budget)

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -277,9 +277,7 @@ export function orderedStaticTranscriptEntries(
     candidates.push({ entry, index, key: transcriptOrderKey(entry, index) });
   }
 
-  const ordered = inSettlementOrder(candidates);
-
-  return ordered.map(({ entry }) => entry);
+  return inSettlementOrder(candidates).map(({ entry }) => entry);
 }
 
 /**

--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -44,22 +44,17 @@ const DEFAULT_DIFF_WIDTH = 74;
 type OverflowMarkerKind = 'hidden' | 'more' | 'previous';
 
 export function diffDisplayLines(hunks: readonly Hunk[]): DiffDisplayLine[] {
-  return hunks.flatMap((hunk) => {
-    const lines = hunk.lines.filter(
-      (line) => !line.startsWith(NO_NEWLINE_MARKER),
-    );
-    const hunkHeader = formatHunkHeader(hunk);
-    const rendered: DiffDisplayLine[] = [
-      { kind: 'header', text: hunkHeader },
-      ...lines.map((line): DiffDisplayLine => {
+  return hunks.flatMap((hunk) => [
+    { kind: 'header' as const, text: formatHunkHeader(hunk) },
+    ...hunk.lines
+      .filter((line) => !line.startsWith(NO_NEWLINE_MARKER))
+      .map((line): DiffDisplayLine => {
         const marker = line.at(0);
         if (marker === '+') return { kind: 'added', text: line };
         if (marker === '-') return { kind: 'removed', text: line };
         return { kind: 'context', text: line };
       }),
-    ];
-    return rendered;
-  });
+  ]);
 }
 
 export function wrappedDiffDisplayLines(
@@ -100,8 +95,10 @@ export function initialDiffScrollOffset(
     totalLines: lines.length,
   });
   const defaultOffset = clamp(changedIndex - 1, 0, maxOffset);
+  const fallbackOffset = (): number =>
+    changedIndex < initiallyVisibleContentRows ? 0 : defaultOffset;
   if (firstChange?.kind !== 'removed') {
-    return changedIndex < initiallyVisibleContentRows ? 0 : defaultOffset;
+    return fallbackOffset();
   }
 
   let removedEnd = changedIndex;
@@ -109,7 +106,7 @@ export function initialDiffScrollOffset(
   const addedIndex =
     lines.at(removedEnd + 1)?.kind === 'added' ? removedEnd + 1 : undefined;
   if (addedIndex === undefined) {
-    return changedIndex < initiallyVisibleContentRows ? 0 : defaultOffset;
+    return fallbackOffset();
   }
 
   if (addedIndex < initiallyVisibleContentRows) return 0;

--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -307,22 +307,18 @@ function configureAnsi(
       style.gray(tokens[idx]?.content.replace(/\n+$/, '') ?? ''),
     )}\n\n`;
 
-  r.bullet_list_open = () => {
+  const listOpen = (): string => {
     listDepth += 1;
     return '';
   };
-  r.bullet_list_close = () => {
+  const listClose = (): string => {
     listDepth = Math.max(0, listDepth - 1);
     return '';
   };
-  r.ordered_list_open = () => {
-    listDepth += 1;
-    return '';
-  };
-  r.ordered_list_close = () => {
-    listDepth = Math.max(0, listDepth - 1);
-    return '';
-  };
+  r.bullet_list_open = listOpen;
+  r.bullet_list_close = listClose;
+  r.ordered_list_open = listOpen;
+  r.ordered_list_close = listClose;
   // The first item in a list inherits the blockquote gutter from
   // `blockquote_open`; continuation items follow a `list_item_close → \n`
   // and need the gutter re-injected so the second bullet doesn't render

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -132,9 +132,7 @@ export interface PendingApprovalSummary {
   readonly kind: PendingApprovalKind;
 }
 
-const CURRENT: Signal.State<PendingApproval | undefined> = signal<
-  PendingApproval | undefined
->(undefined);
+const CURRENT = signal<PendingApproval | undefined>(undefined);
 
 export const currentApproval = CURRENT;
 

--- a/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
+++ b/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
@@ -225,10 +225,8 @@ export function attachSessionSignalsAdapter(
           presentStream(ownerStreamId);
         }
       }
-      // Roster phase-merge, tombstone gating, and eviction requests.
-      applier.handleSessionFact(fact);
-      return;
     }
+    // Roster phase-merge, tombstone gating, and eviction requests.
     applier.handleSessionFact(fact);
     if (fact.type === 'setActiveStream') {
       const streamId = fact.payload.streamId;

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -871,10 +871,9 @@ export function retainedWorkflowPopupProjection(input: {
   // A plan task that already issued outside the retained rows must not return
   // as Declared. Tasks that have not issued yet remain visible. After eviction,
   // use the bounded issued-id snapshot captured before the full fold was reset.
-  const issuedIds = fold?.hydrated
-    ? issuedWorkflowPlanTaskIds(fullRows, input.workflowPlan)
-    : (fold?.retainedWorkflowIssuedTaskIds ??
-      issuedWorkflowPlanTaskIds(fullRows, input.workflowPlan));
+  const issuedIds =
+    (fold?.hydrated ? undefined : fold?.retainedWorkflowIssuedTaskIds) ??
+    issuedWorkflowPlanTaskIds(fullRows, input.workflowPlan);
   const retainedIds = issuedWorkflowPlanTaskIds(
     compact.rows,
     input.workflowPlan,

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -371,12 +371,6 @@ const historyDeleteCommand = defineCliCommand({
   },
 });
 
-const HISTORY_SUBCOMMANDS = {
-  list: historyListCommand,
-  show: historyShowCommand,
-  delete: historyDeleteCommand,
-} as const;
-
 export const historyCommand = defineCommand({
   meta: { name: 'history', description: 'Inspect stored executions' },
   args: {
@@ -385,5 +379,9 @@ export const historyCommand = defineCommand({
   // Bare `texra history` is the obvious history listing command. Keep it as
   // an alias of `history list` so global flags continue to work at the parent.
   default: 'list',
-  subCommands: HISTORY_SUBCOMMANDS,
+  subCommands: {
+    list: historyListCommand,
+    show: historyShowCommand,
+    delete: historyDeleteCommand,
+  },
 });

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -21,7 +21,6 @@ import {
   formatCliMultiAgentPresetInspection,
   formatCliMultiAgentPresetList,
   readCliMultiAgentPresets,
-  type CliMultiAgentPresetRunPlan,
 } from '../runtime/multiAgentPresets';
 import {
   loadCliMultiAgentPresetPlanSet,
@@ -45,10 +44,7 @@ import {
 } from './_helpers/globalArgs';
 import { resolveFileBackedInstruction } from './_helpers/instructionFile';
 import { executeCliToolUseConfig } from '../runtime/runExecution';
-import {
-  toolUseResultText,
-  type CliToolUseRunResult,
-} from '../runtime/terminalStatus';
+import { toolUseResultText } from '../runtime/terminalStatus';
 import { withExpandedRunInputs } from '../runtime/workflowInputs';
 
 interface MultiAgentRunInit {
@@ -76,44 +72,6 @@ function formatAttachedFileList(
       return spec === '-' ? '- Standard input' : `- ${JSON.stringify(spec)}`;
     }),
   ].join('\n');
-}
-
-/** Preserve the user's launch input without copying model-only directives. */
-function formatMultiAgentDisplayInstruction(
-  instruction: string,
-  inputFiles: readonly string[],
-  contextFiles: readonly string[],
-): string {
-  if (instruction) return instruction;
-
-  return [
-    formatAttachedFileList('Attached input files:', inputFiles),
-    formatAttachedFileList('Attached read-only context files:', contextFiles),
-  ]
-    .filter(filterNotNullish)
-    .join('\n\n');
-}
-
-function writeMultiAgentRunResult(
-  context: CliContext,
-  plan: CliMultiAgentPresetRunPlan,
-  result: CliToolUseRunResult,
-): void {
-  const payload = {
-    preset: {
-      id: plan.preset.id,
-      name: plan.preset.name,
-      source: plan.preset.source,
-    },
-    rootAgent: plan.rootAgent?.name,
-    result,
-  };
-
-  emitCliResult(context, {
-    json: payload,
-    ndjson: { kind: 'multi-agent-result', ...payload },
-    text: toolUseResultText(result),
-  });
 }
 
 async function runMultiAgentList(context: CliContext): Promise<number> {
@@ -226,11 +184,19 @@ export async function runMultiAgentPreset(
         );
       }
 
-      const displayInstruction = formatMultiAgentDisplayInstruction(
-        instruction,
-        init.inputFiles,
-        init.contextFiles,
-      );
+      // Preserve the user's launch input without copying the model-only
+      // directive assembled into config.instruction below.
+      const displayInstruction =
+        instruction ||
+        [
+          formatAttachedFileList('Attached input files:', init.inputFiles),
+          formatAttachedFileList(
+            'Attached read-only context files:',
+            init.contextFiles,
+          ),
+        ]
+          .filter(filterNotNullish)
+          .join('\n\n');
       const config: AgentConfigPayload = {
         agent: rootAgent.name,
         model,
@@ -260,7 +226,20 @@ export async function runMultiAgentPreset(
       });
       if (!execution.ok) return execution.exitCode;
 
-      writeMultiAgentRunResult(runContext, plan, execution.result);
+      const payload = {
+        preset: {
+          id: plan.preset.id,
+          name: plan.preset.name,
+          source: plan.preset.source,
+        },
+        rootAgent: plan.rootAgent?.name,
+        result: execution.result,
+      };
+      emitCliResult(runContext, {
+        json: payload,
+        ndjson: { kind: 'multi-agent-result', ...payload },
+        text: toolUseResultText(execution.result),
+      });
 
       return execution.exitCode;
     },

--- a/packages/cli/src/commands/resumeExecution.ts
+++ b/packages/cli/src/commands/resumeExecution.ts
@@ -41,14 +41,12 @@ async function workflowRecoveryInputsAreDurable(
   const cwd = config.workingDirectory || fallbackCwd;
   const paths = [...(config.inputFiles ?? []), ...(config.contextFiles ?? [])];
   const checks = await Promise.all(
-    paths.map(async (inputPath) => {
-      try {
-        await fs.access(path.resolve(cwd, inputPath));
-        return true;
-      } catch {
-        return false;
-      }
-    }),
+    paths.map((inputPath) =>
+      fs.access(path.resolve(cwd, inputPath)).then(
+        () => true,
+        () => false,
+      ),
+    ),
   );
   return checks.every(Boolean);
 }

--- a/packages/cli/src/runtime/ansiEscapes.ts
+++ b/packages/cli/src/runtime/ansiEscapes.ts
@@ -47,12 +47,12 @@ export function ansiEscapeEnd(text: string, index: number): number {
     const belEnd = text.indexOf(ANSI_BEL, index + 2);
     const stEnd = text.indexOf(OSC_STRING_TERMINATOR, index + 2);
     const c1End = text.indexOf(ANSI_C1_STRING_TERMINATOR, index + 2);
-    const ends = [
-      belEnd === -1 ? undefined : belEnd + 1,
-      stEnd === -1 ? undefined : stEnd + OSC_STRING_TERMINATOR.length,
-      c1End === -1 ? undefined : c1End + 1,
-    ].filter((end): end is number => end !== undefined);
-    return Math.min(...ends, text.length);
+    return Math.min(
+      belEnd === -1 ? Infinity : belEnd + 1,
+      stEnd === -1 ? Infinity : stEnd + OSC_STRING_TERMINATOR.length,
+      c1End === -1 ? Infinity : c1End + 1,
+      text.length,
+    );
   }
 
   if (isAnsiIntermediateByte(next)) {

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -179,22 +179,6 @@ export async function loadCliDetailedAccountStatusLines(
     ),
   ]);
   const codingPlanUsage = new Map(codingPlanUsageEntries);
-  const routes = {
-    chatGpt: {
-      preferred: access.preferences.chatGpt === 'on',
-      account: formatAccountStatus(
-        access.chatGptSignedIn,
-        access.chatGptAccountLabel,
-      ),
-    },
-    grok: {
-      preferred: access.preferences.grok === 'on',
-      account: formatAccountStatus(
-        access.grokSignedIn,
-        access.grokAccountLabel,
-      ),
-    },
-  };
   const lines: string[] = [];
   const withUsage = (
     line: string,
@@ -207,19 +191,19 @@ export async function loadCliDetailedAccountStatusLines(
 
   const chatGptLine = formatModelPreferenceLine(
     'ChatGPT',
-    routes.chatGpt.preferred,
+    access.preferences.chatGpt === 'on',
     access.chatGptSignedIn,
     'sign in required',
-    routes.chatGpt.account,
+    formatAccountStatus(access.chatGptSignedIn, access.chatGptAccountLabel),
   );
   if (chatGptLine) lines.push(withUsage(chatGptLine, chatGptUsage));
 
   const grokLine = formatModelPreferenceLine(
     'Grok',
-    routes.grok.preferred,
+    access.preferences.grok === 'on',
     access.grokSignedIn,
     'sign in required',
-    routes.grok.account,
+    formatAccountStatus(access.grokSignedIn, access.grokAccountLabel),
   );
   if (grokLine) lines.push(grokLine);
 

--- a/packages/cli/src/runtime/cliNdjsonProgressEvents.ts
+++ b/packages/cli/src/runtime/cliNdjsonProgressEvents.ts
@@ -1,8 +1,4 @@
 import type { agentConfigToTaskState } from '@agent/runtime';
-
-// Derived rather than deep-imported from '@agent/core/state/TaskState', so the
-// cli host does not pin @agent's internal module layout for one payload type.
-type TaskState = ReturnType<typeof agentConfigToTaskState>;
 import type {
   AddOutputFilesPayload,
   ExecutionId,
@@ -25,6 +21,10 @@ import type {
   UpdateStreamUsagePayload,
   UpdateTodosPayload,
 } from '@shared/schemas';
+
+// Derived rather than deep-imported from '@agent/core/state/TaskState', so the
+// cli host does not pin @agent's internal module layout for one payload type.
+type TaskState = ReturnType<typeof agentConfigToTaskState>;
 
 /**
  * Frozen public `updateActiveSubagents` row — the pre-consolidation

--- a/packages/cli/src/runtime/initConfig.ts
+++ b/packages/cli/src/runtime/initConfig.ts
@@ -41,11 +41,6 @@ export function buildInitConfig(answers: InitAnswers): InitConfigShape {
   };
 }
 
-/** Stable, pretty JSON with a trailing newline (matches editor/formatter output). */
-function serializeInitConfig(config: InitConfigShape): string {
-  return `${JSON.stringify(config, null, 2)}\n`;
-}
-
 /** `false` only for a genuinely absent path; any other failure (EACCES, EIO)
  *  propagates instead of being reported as "absent". */
 export async function pathExists(filePath: string): Promise<boolean> {
@@ -76,7 +71,8 @@ export async function writeInitConfig(
   config: InitConfigShape,
 ): Promise<void> {
   await mkdir(path.dirname(filePath), { recursive: true });
-  await writeInitFileAtomic(filePath, serializeInitConfig(config));
+  // Stable, pretty JSON with a trailing newline (matches editor/formatter output).
+  await writeInitFileAtomic(filePath, `${JSON.stringify(config, null, 2)}\n`);
 }
 
 /**

--- a/packages/cli/src/runtime/logSinks.ts
+++ b/packages/cli/src/runtime/logSinks.ts
@@ -80,12 +80,17 @@ export function installCliPipeErrorHandlers(): void {
   }
 }
 
+function openStream(key: StreamKey): (typeof process)[StreamKey] | undefined {
+  if (closed[key]) return undefined;
+  const stream = process[key];
+  return stream.destroyed ? undefined : stream;
+}
+
 // CLI output is best effort: throwing from an async write callback would bypass
 // the command error boundary and can crash the process.
 function writeRaw(key: StreamKey, text: string): void {
-  if (closed[key]) return;
-  const stream = process[key];
-  if (stream.destroyed) return;
+  const stream = openStream(key);
+  if (!stream) return;
   try {
     stream.write(text, (error) => {
       if (error) closed[key] = true;
@@ -96,9 +101,8 @@ function writeRaw(key: StreamKey, text: string): void {
 }
 
 function writeRawAndWait(key: StreamKey, text: string): Promise<void> {
-  if (closed[key]) return Promise.resolve();
-  const stream = process[key];
-  if (stream.destroyed) return Promise.resolve();
+  const stream = openStream(key);
+  if (!stream) return Promise.resolve();
   return new Promise<void>((resolve) => {
     try {
       stream.write(text, (error) => {

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -183,7 +183,7 @@ export async function getCliModelAccessList(
   options: CliModelAccessListOptions = {},
 ): Promise<CliModelAccess[]> {
   const models = await computeModelOptionsData(options.models);
-  return models.map((model) => toCliModelAccess(model));
+  return models.map(toCliModelAccess);
 }
 
 export function findCliModelAccessEntry(
@@ -245,7 +245,7 @@ function formatCliModelRecovery(entry: CliModelAccess): string | undefined {
 
   switch (availability) {
     case 'missing-key':
-      return `${startSentence(DEFAULT_CONFIGURE_KEY_ACTION)}.`;
+      return formatCliNoAvailableModelsRecovery();
     case 'provider-key':
     case 'openrouter-key':
       return undefined;

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -250,13 +250,13 @@ function formatPresetAvailabilityForLauncher(
     formatPresetAgentCountForLauncher(
       'workflow',
       availability.agents.workflow,
-      {
-        countStyle,
-      },
-    ),
-    formatPresetAgentCountForLauncher('tool-use', availability.agents.toolUse, {
       countStyle,
-    }),
+    ),
+    formatPresetAgentCountForLauncher(
+      'tool-use',
+      availability.agents.toolUse,
+      countStyle,
+    ),
   ].filter(filterNotNullish);
 
   if (parts.length > 0) details.push(parts.join('; '));
@@ -272,11 +272,11 @@ function formatLauncherBlockReason(blockReason: string): string {
 function formatPresetAgentCountForLauncher(
   kind: 'workflow' | 'tool-use',
   availability: TeamAgentAvailability,
-  options: { readonly countStyle: 'total' | 'ratio' },
+  countStyle: 'total' | 'ratio',
 ): string | undefined {
   if (availability.total === 0) return undefined;
   const count =
-    options.countStyle === 'total'
+    countStyle === 'total'
       ? String(availability.total)
       : `${availability.available}/${availability.total}`;
   const label = pluralize(

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -255,7 +255,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
 
   applyStreamDescription(streamId: StreamTabId, description: string): void {
     if (this.rootStreamTerminal) return;
-    if (this.isRootStream(streamId)) {
+    if (this.rootStreamId === streamId) {
       this.rootPhaseText = description;
     } else if (
       !this.liveChildren().some((child) => child.childStreamId === streamId)
@@ -272,19 +272,11 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     return this.rootStreamId === streamId;
   }
 
-  private isRootStream(streamId: StreamTabId): boolean {
-    return this.rootStreamId === streamId;
-  }
-
   /** Live (not yet retired) children of the root run, from the shared roster. */
   private liveChildren(): readonly ActiveChildInfo[] {
     if (this.rootStreamTerminal || !this.rootStreamId) return [];
     const roster = this.state?.getStreamState(this.rootStreamId)?.subagents;
     return roster?.filter((child) => child.finishedAt === undefined) ?? [];
-  }
-
-  private childDescription(streamId: StreamTabId): string | undefined {
-    return this.state?.getStreamMetadata(streamId).description;
   }
 
   private render(force = false): void {
@@ -364,7 +356,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     const elapsed = formatElapsed(now - runStartedAt);
     const children = this.liveChildren();
     const describe = (child: ActiveChildInfo): string | undefined =>
-      this.childDescription(child.childStreamId);
+      this.state?.getStreamMetadata(child.childStreamId).description;
     const nameOnlySubagents = formatActiveChildren(children, describe, 0);
     if (nameOnlySubagents) {
       const descriptionColumns = this.descriptionColumnBudget(

--- a/packages/cli/src/runtime/workflowInputs.ts
+++ b/packages/cli/src/runtime/workflowInputs.ts
@@ -35,9 +35,7 @@ export function workflowInputGlobOptions(
 }
 
 function resolveAgainstCwd(candidate: string, cwd: string): string {
-  return path.isAbsolute(candidate)
-    ? path.resolve(candidate)
-    : path.resolve(cwd, candidate);
+  return path.resolve(cwd, candidate);
 }
 
 function normalizeCliInputPath(candidate: string, cwd: string): string {

--- a/packages/desktop/src/main/desktopAppLog.ts
+++ b/packages/desktop/src/main/desktopAppLog.ts
@@ -67,6 +67,10 @@ export function readDesktopLogSnapshot(options: {
     options.workspacePath == null
       ? undefined
       : normalizeFilePath(options.workspacePath);
+  const redactedPath = redactDesktopLogText(
+    normalizeFilePath(path),
+    workspacePath,
+  );
   try {
     const buffer = readFileSync(path);
     const truncated = buffer.length > maxBytes;
@@ -74,13 +78,13 @@ export function readDesktopLogSnapshot(options: {
       ? buffer.subarray(buffer.length - maxBytes)
       : buffer;
     return {
-      path: redactDesktopLogText(normalizeFilePath(path), workspacePath),
+      path: redactedPath,
       truncated,
       text: redactDesktopLogText(excerpt.toString('utf8'), workspacePath),
     };
   } catch (error) {
     return {
-      path: redactDesktopLogText(normalizeFilePath(path), workspacePath),
+      path: redactedPath,
       truncated: false,
       text: redactDesktopLogText(
         format('Desktop log is not available: %s', error),

--- a/packages/desktop/src/main/desktopCrashEventScrubber.ts
+++ b/packages/desktop/src/main/desktopCrashEventScrubber.ts
@@ -4,12 +4,16 @@ import type { ErrorEvent } from '@sentry/electron/main';
 
 const REDACTED_PATH = '<redacted-path>';
 
+function scrubString(value: string, scrubbers: readonly RegExp[]): string {
+  return scrubbers.reduce(
+    (current, scrubber) => current.replace(scrubber, REDACTED_PATH),
+    value,
+  );
+}
+
 function scrubValue(value: unknown, scrubbers: readonly RegExp[]): unknown {
   if (typeof value === 'string') {
-    return scrubbers.reduce(
-      (current, scrubber) => current.replace(scrubber, REDACTED_PATH),
-      value,
-    );
+    return scrubString(value, scrubbers);
   }
   if (Array.isArray(value)) {
     return value.map((item) => scrubValue(item, scrubbers));
@@ -17,10 +21,7 @@ function scrubValue(value: unknown, scrubbers: readonly RegExp[]): unknown {
   if (value && typeof value === 'object') {
     return Object.fromEntries(
       Object.entries(value).map(([key, entry]) => [
-        scrubbers.reduce(
-          (current, scrubber) => current.replace(scrubber, REDACTED_PATH),
-          key,
-        ),
+        scrubString(key, scrubbers),
         scrubValue(entry, scrubbers),
       ]),
     );

--- a/packages/desktop/src/main/desktopWindowLifecycle.ts
+++ b/packages/desktop/src/main/desktopWindowLifecycle.ts
@@ -27,17 +27,39 @@ interface BeforeQuitApp {
   quit(): void;
 }
 
-function installRendererNavigationCleanup(
-  webContents: EventSource,
-  workspaceIpc: DisposableRendererResources,
+export interface DesktopWindowLifecycleWiring {
+  webContents: EventSource;
+  workspaceIpc: DisposableRendererResources;
+  showDiscardDialog(): number;
+  isFatalShutdownRequested(): boolean;
+  clearPendingWorkspaceRelaunch(): void;
+  clearContinueQuitAfterWindowClose(): void;
+}
+
+export function bootstrapDesktopWindowLifecycle(
+  options: DesktopWindowLifecycleWiring,
 ): void {
+  options.webContents.on('will-prevent-unload', (event) => {
+    if (options.isFatalShutdownRequested()) {
+      options.clearPendingWorkspaceRelaunch();
+      event.preventDefault();
+      return;
+    }
+    if (options.showDiscardDialog() === 1) {
+      event.preventDefault();
+      return;
+    }
+    options.clearPendingWorkspaceRelaunch();
+    options.clearContinueQuitAfterWindowClose();
+  });
+
   let initialRendererNavigationComplete = false;
-  webContents.on('did-navigate', () => {
+  options.webContents.on('did-navigate', () => {
     if (!initialRendererNavigationComplete) {
       initialRendererNavigationComplete = true;
       return;
     }
-    workspaceIpc.disposeRendererResources();
+    options.workspaceIpc.disposeRendererResources();
   });
 }
 
@@ -66,42 +88,4 @@ export function installDesktopBeforeQuitWiring(options: {
       options.app.quit();
     });
   });
-}
-
-export interface DesktopWindowLifecycleWiring {
-  webContents: EventSource;
-  workspaceIpc: DisposableRendererResources;
-  showDiscardDialog(): number;
-  isFatalShutdownRequested(): boolean;
-  clearPendingWorkspaceRelaunch(): void;
-  clearContinueQuitAfterWindowClose(): void;
-}
-
-function installUnsavedChangesHandler(options: {
-  webContents: EventSource;
-  showDiscardDialog(): number;
-  isFatalShutdownRequested(): boolean;
-  clearPendingWorkspaceRelaunch(): void;
-  clearContinueQuitAfterWindowClose(): void;
-}): void {
-  options.webContents.on('will-prevent-unload', (event) => {
-    if (options.isFatalShutdownRequested()) {
-      options.clearPendingWorkspaceRelaunch();
-      event.preventDefault();
-      return;
-    }
-    if (options.showDiscardDialog() === 1) {
-      event.preventDefault();
-      return;
-    }
-    options.clearPendingWorkspaceRelaunch();
-    options.clearContinueQuitAfterWindowClose();
-  });
-}
-
-export function bootstrapDesktopWindowLifecycle(
-  options: DesktopWindowLifecycleWiring,
-): void {
-  installUnsavedChangesHandler(options);
-  installRendererNavigationCleanup(options.webContents, options.workspaceIpc);
 }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1011,7 +1011,6 @@ function createWindow(options: {
         // Idempotent: returns the in-flight/initialized registry so a kickoff
         // racing the startup `loadAgents()` cannot hit "Could not find agent:
         // setup" (mirrors `setupAssistantCommand.launchSetupAssistant`).
-        const { loadAgents } = await import('@agent/index');
         await loadAgents();
         const preparation = prepareMainViewExecutionRequest(message);
         if (!preparation.valid) {

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -202,8 +202,6 @@ export function createDesktopCommandPalette({
         event.preventDefault();
         executeActiveCommand();
         break;
-      default:
-        break;
     }
   };
 

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -1391,18 +1391,6 @@ const shortcutBootstrap = createDesktopShortcutBootstrap({
   },
 });
 
-/**
- * Install the keyboard shortcuts, the command palette and the accelerator-hint
- * subscription, exactly once. Driven from `completeBootstrap` rather than
- * module scope so a shell that recovers from a bootstrap failure gets them
- * too: the previous `const` was gated on `bootstrapFailed` and could never be
- * re-evaluated, leaving a recovered shell with no shortcuts and a permanently
- * inert command palette while the startup panel still advertised cmd/ctrl+K.
- */
-function ensureShortcutRegistry(): void {
-  shortcutBootstrap.ensure();
-}
-
 function openCommandPalette(): void {
   shortcutBootstrap.open();
 }
@@ -1556,7 +1544,9 @@ function wireConversation(): void {
 function completeBootstrap(): void {
   wireRailTabs();
   wireConversation();
-  ensureShortcutRegistry();
+  // Runs here rather than at module scope so a shell recovering from a
+  // bootstrap failure re-installs shortcuts too; every step is idempotent.
+  shortcutBootstrap.ensure();
   postMessage(DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE);
   postWebviewReady();
   if (hasWorkspace) void editorPane.refresh();

--- a/packages/desktop/src/shared/workspacePath.ts
+++ b/packages/desktop/src/shared/workspacePath.ts
@@ -30,7 +30,6 @@ export function withWorkspacePathArg(
   const nextArgs: string[] = [];
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
-    if (arg == null) continue;
     if (isDesktopProtocolUrl(arg)) continue;
     if (isWorkspacePathFlag(arg)) {
       const value = argv[index + 1];

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -119,9 +119,9 @@ interface OpenedLatexdiffResult {
 }
 
 /**
- * Open and build one generated diff, returning the path, the resolved
- * location, and whether the viewer may be scheduled for it. The path alone is
- * not enough: an external `compileLatex2Pdf` failure can produce a generated
+ * Open and build one generated diff, returning its resolved location and
+ * whether the viewer may be scheduled for it. A generated path alone is not
+ * enough: an external `compileLatex2Pdf` failure can produce a generated
  * file whose PDF is not viewer-ready.
  */
 async function openLatexdiffResult(

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -120,6 +120,13 @@ let apiKeyStatusBarItem: vscode.StatusBarItem | undefined;
 let lifecycleHost: LifecycleHost | undefined;
 let extensionShutdownPromise: Promise<void> | undefined;
 
+function createExtensionLifecycleHost(): LifecycleHost {
+  return createLifecycleHost({
+    onError: (phase, error) =>
+      log.error(`Lifecycle ${phase} handler failed`, { data: error }),
+  });
+}
+
 function shutdownExtension(): Promise<void> {
   if (extensionShutdownPromise) return extensionShutdownPromise;
 
@@ -332,10 +339,7 @@ async function activateExtension(context: vscode.ExtensionContext) {
     // needs a folder — so the walkthrough's credential buttons work before
     // one is open. Agents still require the workspace-backed platform below;
     // opening a folder reloads the window into that path (welcomeView.ts).
-    const lifecycle = createLifecycleHost({
-      onError: (phase, error) =>
-        log.error(`Lifecycle ${phase} handler failed`, { data: error }),
-    });
+    const lifecycle = createExtensionLifecycleHost();
     lifecycleHost = lifecycle;
     agentDirectories.initialize();
     const storage = createNodeStorageProvider();
@@ -411,12 +415,7 @@ async function activateExtension(context: vscode.ExtensionContext) {
         gitRepoRoot,
       )
     : context.workspaceState;
-  const lifecycle = createLifecycleHost({
-    onError: (phase, error) =>
-      log.error(`Lifecycle ${phase} handler failed`, {
-        data: error,
-      }),
-  });
+  const lifecycle = createExtensionLifecycleHost();
   lifecycleHost = lifecycle;
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => clearVscodeLeanServerEntries());
   const languageModel = createLanguageModelPort(context);

--- a/packages/extension/src/frontend/files/fileLister.ts
+++ b/packages/extension/src/frontend/files/fileLister.ts
@@ -17,7 +17,6 @@ const log = createLog('FileLister');
 
 export class FileLister {
   public static initialize(context: vscode.ExtensionContext): void {
-    getFileLister();
     context.subscriptions.push(
       vscode.workspace.onDidChangeWorkspaceFolders(() =>
         getFileLister().refresh(),

--- a/packages/extension/src/frontend/statusBar/statusBarSessionEvents.ts
+++ b/packages/extension/src/frontend/statusBar/statusBarSessionEvents.ts
@@ -20,18 +20,16 @@ export function subscribeStatusBarSessionEvents({
 }: StatusBarSessionEventOptions): () => void {
   const disposeStatus = session.events.subscribeStatus(onStatusChanged);
 
-  const disposeUsage = session.events.subscribe(
-    (sessionEvent) => {
-      if (sessionEvent.scope !== 'run') return;
-      if (sessionEvent.event.type !== 'usage') return;
+  const disposeUsage = session.events.subscribeRunFacts(
+    ({ event }) => {
       // The runtime publishes the in-flight status before usage for a round;
       // usage for a stream not in flight cannot change the projected total,
       // so stale async events skip the refresh.
-      if (session.status.isInFlight(sessionEvent.event.payload.streamId)) {
+      if (session.status.isInFlight(event.payload.streamId)) {
         onUsageChanged();
       }
     },
-    { scope: 'run', types: ['usage'] },
+    { types: ['usage'] },
   );
 
   return () => {

--- a/packages/extension/src/frontend/ui/dialogs.ts
+++ b/packages/extension/src/frontend/ui/dialogs.ts
@@ -100,7 +100,7 @@ export async function selectFolder(
     canSelectFolders: true,
     canSelectMany: false,
     openLabel: options.openLabel,
-    ...(options.title ? { title: options.title } : {}),
+    title: options.title,
   });
   return folders?.[0]?.fsPath ?? null;
 }

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -290,13 +290,8 @@ export class ProgressApp extends ProgressAppBase {
     }
     const view = event.detail.name === 'launcher' ? 'main' : 'progress';
     const tabs = event.currentTarget as MutableWaTabGroup;
-    if (view === 'main' && placement.get() === 'editor') {
-      this.focusLauncherSidebar(tabs);
-      return;
-    }
     if (view === 'main') {
-      postMessage(COMMON_COMMANDS.SWITCH_VIEW, { view });
-      this.resetProgressTab(tabs);
+      this.focusLauncherSidebar(tabs);
       return;
     }
     postMessage(COMMON_COMMANDS.SWITCH_VIEW, { view });

--- a/packages/extension/src/progressView/frontend/components/BaseStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseStreamContent.ts
@@ -31,8 +31,6 @@ import {
   type StreamContextValue,
 } from '../streamContexts';
 
-// Local imports - types
-
 // Side-effect imports - sibling components shared by both stream-content
 // containers (registered once, consumed by the render helpers below)
 import './RequestPanels';

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -91,14 +91,8 @@ function renderFileActionButton(opts: FileActionOptions): TemplateResult {
 
 const STORAGE_HINT_DISMISS_KEY = 'generatedFilesStorageHint.dismissed';
 
-/** Parsed path components for display */
-interface ParsedPath {
-  dir: string;
-  basename: string;
-}
-
 /** Parse a path into directory and basename components */
-function parsePath(path: string): ParsedPath {
+function parsePath(path: string): { dir: string; basename: string } {
   const normalized = normalizeFilePath(path);
   // With no slash, lastIndexOf is -1 and the dir slice already yields the
   // fallback: '' for dir.
@@ -242,7 +236,7 @@ export class FileList extends UnsupportedCommandsMixin(LitElement) {
     // A per-round disclosure only earns its chrome when there are multiple
     // rounds to tell apart; a single round renders its files directly.
     if (this.sortedRounds.length === 1) {
-      return html`${rows}`;
+      return rows;
     }
 
     return html`

--- a/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
@@ -62,12 +62,10 @@ export class PlanApprovalRequestPanel extends BaseApprovalPanel<'planApproval'> 
 
     return this.renderRequestShell({
       prefix: 'plan-approval-request',
-      // The objective div stays on one line so the pre-wrap body gets no
-      // template whitespace.
+      // Kept to one line so the pre-wrap body gets no template whitespace.
+      // prettier-ignore
       details: html`
-        <div class="plan-approval-request__objective" dir="auto">
-          ${plan.objective}
-        </div>
+        <div class="plan-approval-request__objective" dir="auto">${plan.objective}</div>
         ${
           goalEnabled
             ? html`<div class="plan-approval-request__goal-explanation">

--- a/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
@@ -62,8 +62,12 @@ export class PlanApprovalRequestPanel extends BaseApprovalPanel<'planApproval'> 
 
     return this.renderRequestShell({
       prefix: 'plan-approval-request',
+      // The objective div stays on one line so the pre-wrap body gets no
+      // template whitespace.
       details: html`
-        ${this.renderObjective(plan.objective)}
+        <div class="plan-approval-request__objective" dir="auto">
+          ${plan.objective}
+        </div>
         ${
           goalEnabled
             ? html`<div class="plan-approval-request__goal-explanation">
@@ -87,12 +91,6 @@ export class PlanApprovalRequestPanel extends BaseApprovalPanel<'planApproval'> 
           })
         : nothing,
     });
-  }
-
-  /** Kept to one line so the pre-wrap body gets no template whitespace. */
-  private renderObjective(text: string): TemplateResult {
-    // prettier-ignore
-    return html`<div class="plan-approval-request__objective" dir="auto">${text}</div>`;
   }
 }
 

--- a/packages/extension/src/progressView/frontend/components/PlanView.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanView.ts
@@ -54,14 +54,9 @@ export class PlanView extends CollapsiblePanel {
     return this.renderCollapsibleDetails({
       id: ELEMENT_IDS.PLAN_VIEW_CONTAINER,
       summary: 'Plan',
+      // Kept to one line so the pre-wrap document gets no template whitespace.
       // prettier-ignore
-      body: html`<div class="plan-body">${this.renderDocument(this.plan.objective)}</div>`,
+      body: html`<div class="plan-body"><div id=${ELEMENT_IDS.PLAN_VIEW} class="plan-document">${this.plan.objective}</div></div>`,
     });
-  }
-
-  /** Kept to one line so the pre-wrap body gets no template whitespace. */
-  private renderDocument(text: string): TemplateResult {
-    // prettier-ignore
-    return html`<div id=${ELEMENT_IDS.PLAN_VIEW} class="plan-document">${text}</div>`;
   }
 }

--- a/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { LitElement, css, html, unsafeCSS } from 'lit';
+import { LitElement, css, html, unsafeCSS, type TemplateResult } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
@@ -308,7 +308,7 @@ export class TerminalOutput extends LitElement {
     });
   }
 
-  override render() {
+  override render(): TemplateResult {
     return html`<div class="terminal-container"></div>`;
   }
 }

--- a/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -113,14 +113,14 @@ export class ToolUseStreamContent extends BaseStreamContent {
     state: ToolUseStreamState,
     streamInfo: StreamTabInfo,
   ): TemplateResult {
-    const visible = !composerVisible(state, streamInfo);
-    const message = visible
+    const showBanner = !composerVisible(state, streamInfo);
+    const message = showBanner
       ? streamStatusTooltip(state, RUN_ENDED_MESSAGE)
       : nothing;
 
     return html`<div
       class=${
-        visible
+        showBanner
           ? 'conversation-composer-banner'
           : 'conversation-composer-banner conversation-composer-banner--empty'
       }

--- a/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
+++ b/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
@@ -65,10 +65,6 @@ export class WorktreeChip extends LitElement {
 
   override render(): TemplateResult | typeof nothing {
     if (!this.info) return nothing;
-    return this.renderBranch();
-  }
-
-  private renderBranch(): TemplateResult | typeof nothing {
     const branch = this.info.branch ?? this.worktreeLabel();
     if (!branch) return nothing;
     const branchKind = this.info.branch ? 'Branch' : 'Worktree';

--- a/packages/extension/src/progressView/frontend/components/messageIndex.ts
+++ b/packages/extension/src/progressView/frontend/components/messageIndex.ts
@@ -26,18 +26,18 @@ function rowTime(row: TranscriptRow): number {
   return row.timestamp;
 }
 
-/** The wall-clock fallback order key for a task-group child. */
-function groupStartTime(group: TaskGroup): number {
-  return group.startTime;
-}
-
 /** Wire append sequence when both rows carry one, wall-clock otherwise. */
 function compareRows(a: TranscriptRow, b: TranscriptRow): number {
   return compareBySeqNo(a, b, (row) => row.seqNo, rowTime);
 }
 
 function compareGroups(a: TaskGroup, b: TaskGroup): number {
-  return compareBySeqNo(a, b, () => undefined, groupStartTime);
+  return compareBySeqNo(
+    a,
+    b,
+    () => undefined,
+    (group) => group.startTime,
+  );
 }
 
 function compareTimeline(a: TimelineEntry, b: TimelineEntry): number {

--- a/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -315,9 +315,7 @@ const LANGUAGE_LABELS: Record<string, string> = {
 
 /** Apply syntax highlighting to code if language is supported. Returns HTML string for unsafeHTML. */
 function highlightCode(text: string, language: string): string {
-  const isHighlightable = language && language !== 'plaintext';
-  if (!isHighlightable || !hljs.getLanguage(language)) {
-    // Return plain text - will be escaped by Lit
+  if (!language || language === 'plaintext' || !hljs.getLanguage(language)) {
     return text;
   }
   try {

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -124,15 +124,9 @@ const inquiries$ = select(appState, (s) => s.inquiries);
 // Derived computeds: only re-evaluate when selector inputs propagate.
 // ---------------------------------------------------------------------------
 
-// Not exported: every consumer now reads topLevelStreams$ (rail, palette,
-// sidebar count) so a child call/edit-approval stream is never mistaken for
-// a top-level task (#11511 family). Kept as topLevelStreams$'s own
-// intermediate step below.
-const streams$ = new Signal.Computed(() => [...streamById$.get().values()]);
-
 /** Top-level streams: the tab list, with child streams excluded. */
 export const topLevelStreams$ = new Signal.Computed(() =>
-  streams$.get().filter((stream) => !stream.parentStreamId),
+  [...streamById$.get().values()].filter((stream) => !stream.parentStreamId),
 );
 
 /**

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -315,8 +315,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       resetCustomAgentDir: () => this.agentHandlers.handleResetCustomAgentDir(),
       applyAgentModePreset: (message) =>
         this.agentHandlers.handleApplyAgentModePreset(message),
-      saveAgentModePreset: (message) =>
-        this.agentHandlers.handleSaveAgentModePreset(message),
+      saveAgentModePreset: () => this.agentHandlers.handleSaveAgentModePreset(),
       deleteAgentModePreset: (message) =>
         this.agentHandlers.handleDeleteAgentModePreset(message),
       getGitHubTokenStatus: () =>

--- a/packages/extension/src/settingsView/SettingsViewProvider.ts
+++ b/packages/extension/src/settingsView/SettingsViewProvider.ts
@@ -96,7 +96,7 @@ export class SettingsViewProvider extends BaseWebviewProvider {
       );
     }
 
-    if (tab != null && this._view) {
+    if (tab != null) {
       await this._view.webview.postMessage({
         command: SETTINGS_VIEW_COMMANDS.SET_TAB,
         tab,

--- a/packages/extension/src/settingsView/SettingsViewProvider.ts
+++ b/packages/extension/src/settingsView/SettingsViewProvider.ts
@@ -96,7 +96,9 @@ export class SettingsViewProvider extends BaseWebviewProvider {
       );
     }
 
-    if (tab != null) {
+    // this._view can be undefined here: the awaited sendAllData above yields,
+    // and disposing the dashboard panel during that await runs cleanupView.
+    if (tab != null && this._view) {
       await this._view.webview.postMessage({
         command: SETTINGS_VIEW_COMMANDS.SET_TAB,
         tab,

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -245,7 +245,7 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
         class="agent-list-pane"
         role="region"
         aria-label="Agents"
-        @keydown=${(e: KeyboardEvent) => this.handleListKeydown(e)}
+        @keydown=${this.handleListKeydown}
       >
         ${orderedSources.map((source) => {
           const agents = groups.get(source)!;

--- a/packages/extension/src/settingsView/frontend/components/profile/SubscriptionUsageRow.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/SubscriptionUsageRow.ts
@@ -17,18 +17,16 @@ type UnavailableReason = Extract<
   { state: 'unavailable' }
 >['reason'];
 
-const UNAVAILABLE_DETAILS: Record<UnavailableReason, string | undefined> = {
-  invalid_credentials: 'The provider rejected the configured credentials.',
-  malformed_response: 'The provider returned usage data TeXRA could not read.',
-  missing_credentials: undefined,
-  request_failed: undefined,
-};
-
 function unavailableDetail(reason: UnavailableReason): string {
-  return (
-    UNAVAILABLE_DETAILS[reason] ??
-    'The provider usage request failed. Try refreshing again shortly.'
-  );
+  switch (reason) {
+    case 'invalid_credentials':
+      return 'The provider rejected the configured credentials.';
+    case 'malformed_response':
+      return 'The provider returned usage data TeXRA could not read.';
+    case 'missing_credentials':
+    case 'request_failed':
+      return 'The provider usage request failed. Try refreshing again shortly.';
+  }
 }
 
 @customElement('subscription-usage-row')

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -174,19 +174,13 @@ export class GitTab extends UnsupportedCommandsMixin(LitElement) {
   @property({ attribute: false })
   prSubscriptions: readonly PRSubscriptionEntry[] = [];
 
-  private handleAuthorNameChange(event: Event): void {
-    const target = event.target as WaInput | null;
-    const name = target?.value?.trim();
-    if (name) {
-      postStateSetting(WorkspaceStateKey.GIT_AUTHOR_NAME, name);
-    }
-  }
-
-  private handleAuthorEmailChange(event: Event): void {
-    const target = event.target as WaInput | null;
-    const email = target?.value?.trim();
-    if (email) {
-      postStateSetting(WorkspaceStateKey.GIT_AUTHOR_EMAIL, email);
+  private handleIdentityInputChange(
+    event: Event,
+    key: WorkspaceStateKey,
+  ): void {
+    const value = (event.target as WaInput | null)?.value?.trim();
+    if (value) {
+      postStateSetting(key, value);
     }
   }
 
@@ -408,7 +402,11 @@ export class GitTab extends UnsupportedCommandsMixin(LitElement) {
                         spellcheck="false"
                         .value=${this.authorName}
                         placeholder=${DEFAULT_GIT_AUTHOR_NAME}
-                        @change=${this.handleAuthorNameChange}
+                        @change=${(event: Event) =>
+                          this.handleIdentityInputChange(
+                            event,
+                            WorkspaceStateKey.GIT_AUTHOR_NAME,
+                          )}
                       ></wa-input>
                     </div>
                     <div class="input-row">
@@ -425,7 +423,11 @@ export class GitTab extends UnsupportedCommandsMixin(LitElement) {
                         dir="ltr"
                         .value=${this.authorEmail}
                         placeholder=${DEFAULT_GIT_AUTHOR_EMAIL}
-                        @change=${this.handleAuthorEmailChange}
+                        @change=${(event: Event) =>
+                          this.handleIdentityInputChange(
+                            event,
+                            WorkspaceStateKey.GIT_AUTHOR_EMAIL,
+                          )}
                       ></wa-input>
                     </div>
                   </div>

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -820,14 +820,11 @@ export class LaTeXTab extends LitElement {
     try {
       parsed = JSON.parse(source);
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Invalid JSON.';
-      control.setCustomValidity(message);
+      const detail = error instanceof Error ? error.message : undefined;
+      control.setCustomValidity(detail ?? 'Invalid JSON.');
       this.replacementJsonErrors = {
         ...this.replacementJsonErrors,
-        [field]:
-          error instanceof Error
-            ? `Enter valid JSON. ${error.message}`
-            : 'Enter valid JSON.',
+        [field]: detail ? `Enter valid JSON. ${detail}` : 'Enter valid JSON.',
       };
       return;
     }

--- a/packages/extension/src/settingsView/frontend/tabs/MemoryTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MemoryTab.ts
@@ -43,41 +43,30 @@ export class MemoryTab extends LitElement {
   @property({ attribute: false }) items: MemoryViewItem[] = [];
   @property({ attribute: false }) enabled = false;
 
-  private handleRefresh = (): void => {
-    postMessage(SETTINGS_VIEW_COMMANDS.GET_MEMORY_DATA);
-  };
-
-  private handleOpenFolder = (): void => {
-    postMessage(SETTINGS_VIEW_COMMANDS.OPEN_MEMORY_FOLDER);
-  };
-
-  private renderActions(): TemplateResult {
-    return html`<div
-      class="memory-actions"
-      role="group"
-      aria-label="Saved memory actions"
-    >
-      ${renderLabeledActionButton({
-        icon: 'rotate-right',
-        text: 'Refresh memories',
-        kind: 'secondary',
-        appearance: 'outlined',
-        onClick: this.handleRefresh,
-      })}
-      ${renderLabeledActionButton({
-        icon: 'folder-open',
-        text: 'Open memory folder',
-        kind: 'secondary',
-        appearance: 'outlined',
-        onClick: this.handleOpenFolder,
-      })}
-    </div>`;
-  }
-
   override render(): TemplateResult {
     return html`
       <div class="memory-view-container tab-content-container">
-        ${this.renderActions()}
+        <div
+          class="memory-actions"
+          role="group"
+          aria-label="Saved memory actions"
+        >
+          ${renderLabeledActionButton({
+            icon: 'rotate-right',
+            text: 'Refresh memories',
+            kind: 'secondary',
+            appearance: 'outlined',
+            onClick: () => postMessage(SETTINGS_VIEW_COMMANDS.GET_MEMORY_DATA),
+          })}
+          ${renderLabeledActionButton({
+            icon: 'folder-open',
+            text: 'Open memory folder',
+            kind: 'secondary',
+            appearance: 'outlined',
+            onClick: () =>
+              postMessage(SETTINGS_VIEW_COMMANDS.OPEN_MEMORY_FOLDER),
+          })}
+        </div>
         ${renderStateSettingToggleRow({
           key: GlobalStateKey.MEMORY_ENABLED,
           checked: this.enabled,

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -166,10 +166,6 @@ export class ToolsTab extends LitElement {
   @property({ type: Boolean }) editApprovalEnabled = true;
   @property({ type: Boolean }) toolPathProtectionEnabled = true;
 
-  private handleRecheck(): void {
-    postMessage(SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS);
-  }
-
   private handleApprovalPolicyChange = (e: Event): void => {
     const policy = parseTexraApprovalPolicy(readSelectValue(e));
     if (policy) postStateSetting(TEXRA_APPROVAL_POLICY_CONFIG_KEY, policy);
@@ -292,7 +288,8 @@ export class ToolsTab extends LitElement {
             text: 'Re-check',
             kind: 'secondary',
             appearance: 'outlined',
-            onClick: () => this.handleRecheck(),
+            onClick: () =>
+              postMessage(SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS),
           })}
         </div>
         ${this.renderApprovalSettings()}

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -316,11 +316,10 @@ export class AgentHandlers {
             presentation: {
               chooseTeamAvailability: (prompt) =>
                 this.chooseTeamAvailability(prompt),
-              showInfoMessage: (message) => {
+              showInfoMessage: async (message) => {
                 void vscode.window.showInformationMessage(message);
-                return Promise.resolve();
               },
-              showErrorMessage: (message) => {
+              showErrorMessage: async (message) => {
                 void showLoggedMessage(this.ctx.channel, message).catch(
                   (err: unknown) => {
                     this.ctx.log.warn(
@@ -328,7 +327,6 @@ export class AgentHandlers {
                     );
                   },
                 );
-                return Promise.resolve();
               },
             },
             refreshAfterApply: (selectedToolUseAgent) =>
@@ -339,9 +337,7 @@ export class AgentHandlers {
     );
   }
 
-  async handleSaveAgentModePreset(
-    _data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.SAVE_AGENT_MODE_PRESET>,
-  ): Promise<void> {
+  async handleSaveAgentModePreset(): Promise<void> {
     await withHandlerErrorHandling(
       this.ctx,
       'Failed to save agent team',

--- a/packages/extension/src/settingsView/handlers/latexSettingsHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/latexSettingsHandlers.ts
@@ -180,7 +180,7 @@ export class LatexSettingsHandlers {
         await this.ctx.withActiveWebview((w) =>
           this.sendLatexSettingsStatus(w),
         );
-        const verb = data.reset ? 'reset' : 'applied';
+        const verb = reset ? 'reset' : 'applied';
         void vscode.window.showInformationMessage(
           data.field
             ? `LaTeX setting ${verb}`

--- a/packages/extension/src/settingsView/handlers/memoryHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/memoryHandlers.ts
@@ -16,7 +16,10 @@ import { SETTINGS_VIEW_CMD, type SettingsMessageFor } from '@shared/schemas';
 import { hasExtension } from '@utils/core/pathCore';
 import { StorageFS } from '@utils/files/storageFS';
 
-import type { SettingsHandlerContext } from './SettingsHandlerContext';
+import {
+  withHandlerErrorHandling,
+  type SettingsHandlerContext,
+} from './SettingsHandlerContext';
 
 /** Memory-settings handler delegate. */
 export class MemoryHandlers {
@@ -52,48 +55,44 @@ export class MemoryHandlers {
   async handleOpenMemoryFile(
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.OPEN_MEMORY_FILE>,
   ): Promise<void> {
-    try {
-      const resolvedPath = resolveMemoryStoragePath(data.storagePath);
-      const absolutePath = StorageFS.fullPath(resolvedPath);
-      const fileUri = vscode.Uri.file(absolutePath);
+    await withHandlerErrorHandling(
+      this.ctx,
+      'Failed to open memory file',
+      async () => {
+        const resolvedPath = resolveMemoryStoragePath(data.storagePath);
+        const absolutePath = StorageFS.fullPath(resolvedPath);
+        const fileUri = vscode.Uri.file(absolutePath);
 
-      // Open markdown files in preview mode (read-only rendered view)
-      if (hasExtension(absolutePath, '.md')) {
-        await safeExecuteCommand(
-          'markdown.showPreview',
-          [fileUri],
-          this.viewName,
-        );
-      } else {
-        const doc = await vscode.workspace.openTextDocument(fileUri);
-        await vscode.window.showTextDocument(doc, { preview: false });
-      }
-    } catch (error) {
-      await showLoggedErrorMessage(
-        this.ctx.channel,
-        'Failed to open memory file',
-        error,
-      );
-    }
+        // Open markdown files in preview mode (read-only rendered view)
+        if (hasExtension(absolutePath, '.md')) {
+          await safeExecuteCommand(
+            'markdown.showPreview',
+            [fileUri],
+            this.viewName,
+          );
+        } else {
+          const doc = await vscode.workspace.openTextDocument(fileUri);
+          await vscode.window.showTextDocument(doc, { preview: false });
+        }
+      },
+    );
   }
 
   async handleOpenMemoryFolder(): Promise<void> {
-    try {
-      const resolvedPath = resolveMemoryStoragePath();
-      await StorageFS.ensureDir(resolvedPath);
-      const absolutePath = StorageFS.fullPath(resolvedPath);
-      await safeExecuteCommand(
-        'revealFileInOS',
-        [vscode.Uri.file(absolutePath)],
-        this.viewName,
-      );
-    } catch (error) {
-      await showLoggedErrorMessage(
-        this.ctx.channel,
-        'Failed to open memory folder',
-        error,
-      );
-    }
+    await withHandlerErrorHandling(
+      this.ctx,
+      'Failed to open memory folder',
+      async () => {
+        const resolvedPath = resolveMemoryStoragePath();
+        await StorageFS.ensureDir(resolvedPath);
+        const absolutePath = StorageFS.fullPath(resolvedPath);
+        await safeExecuteCommand(
+          'revealFileInOS',
+          [vscode.Uri.file(absolutePath)],
+          this.viewName,
+        );
+      },
+    );
   }
 
   async handleDeleteMemory(
@@ -115,19 +114,15 @@ export class MemoryHandlers {
   }
 
   async setMemoryPinned(storagePath: string, pinned: boolean): Promise<void> {
-    try {
-      await this.settingsHost.setMemoryPinned(
-        storagePath,
-        pinned,
-        this.ctx.postMessageToActiveWebview,
-      );
-    } catch (error) {
-      const action = pinned ? 'pin' : 'unpin';
-      await showLoggedErrorMessage(
-        this.ctx.channel,
-        `Failed to ${action} memory`,
-        error,
-      );
-    }
+    await withHandlerErrorHandling(
+      this.ctx,
+      `Failed to ${pinned ? 'pin' : 'unpin'} memory`,
+      () =>
+        this.settingsHost.setMemoryPinned(
+          storagePath,
+          pinned,
+          this.ctx.postMessageToActiveWebview,
+        ),
+    );
   }
 }

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -146,10 +146,9 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   }
 
   private handleDebugModeRequest(): void {
-    const debugMode = isDebugModeEnabled();
     this.postToActiveView({
       command: MAIN_VIEW_COMMANDS.DEBUG_MODE_SET,
-      debugMode,
+      debugMode: isDebugModeEnabled(),
     });
   }
 

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -166,10 +166,6 @@ export class MainApp extends MainAppBase {
   // bodies, plus the two handlers bound at two template sites each. Everything
   // else binds inline at its template site.
 
-  private readonly onSignInFromBanner = (): void => {
-    postMessage(MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER);
-  };
-
   private readonly onOnboardingOpenGettingStarted = (): void => {
     postMessage(MAIN_VIEW_COMMANDS.ONBOARDING_OPEN_GETTING_STARTED);
   };
@@ -194,18 +190,6 @@ export class MainApp extends MainAppBase {
    * multi-agent settings section. */
   private readonly onOpenMultiAgentSettings = (): void => {
     postMessage(MAIN_VIEW_COMMANDS.OPEN_MULTI_AGENT_SETTINGS);
-  };
-
-  private readonly onLatexDiffsToggle = ({
-    detail,
-  }: CustomEvent<LatexDiffsToggleDetail>): void => {
-    latexdiffsVisible$.set(detail.visible);
-  };
-
-  private readonly onInstructionInput = ({
-    detail,
-  }: CustomEvent<InstructionChangeDetail>): void => {
-    setInstruction(detail.value);
   };
 
   override connectedCallback(): void {
@@ -438,7 +422,10 @@ export class MainApp extends MainAppBase {
           detail,
         }: CustomEvent<WorkingDirectoryChangeDetail>) =>
           changeWorkingDirectory(detail.value)}
-        @instruction-input=${this.onInstructionInput}
+        @instruction-input=${({
+          detail,
+        }: CustomEvent<InstructionChangeDetail>) =>
+          setInstruction(detail.value)}
         @panel-action=${({ detail }: CustomEvent<ActionDetail>) =>
           runPanelAction(detail.action)}
         @execute=${() => sendExecuteMessage()}
@@ -474,7 +461,7 @@ export class MainApp extends MainAppBase {
           postMessage(MAIN_VIEW_COMMANDS.OPEN_INSTALL_GUIDE, {
             tool: detail.tool,
           })}
-        @sign-in=${this.onSignInFromBanner}
+        @sign-in=${() => postMessage(MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER)}
         @dismiss-login=${this.onDismissLogin}
         @dismiss-getting-started=${this.onDismissGettingStarted}
         @getting-started-action=${({
@@ -610,7 +597,10 @@ export class MainApp extends MainAppBase {
           .commit=${commit$.get()}
           .commitOptions=${fo.commit}
           .isGitRepo=${isGitRepo$.get()}
-          @latexdiffs-toggle=${this.onLatexDiffsToggle}
+          @latexdiffs-toggle=${({
+            detail,
+          }: CustomEvent<LatexDiffsToggleDetail>) =>
+            latexdiffsVisible$.set(detail.visible)}
           @latexdiffs-action=${({
             detail,
           }: CustomEvent<LatexDiffsActionDetail>) =>

--- a/packages/extension/src/webview/frontend/components/DependencyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/DependencyBanner.ts
@@ -11,6 +11,17 @@ import { renderWarningBanner } from '@shared/wa/bannerFrame';
 import { StateVisibleBanner } from './StateVisibleBanner';
 import { MainViewEvents } from '../events';
 
+function getToolLabel(tool: string): string {
+  switch (tool) {
+    case 'gm':
+      return 'GraphicsMagick';
+    case 'magick':
+      return 'ImageMagick';
+    default:
+      return tool;
+  }
+}
+
 @customElement('dependency-banner')
 export class DependencyBanner extends StateVisibleBanner<DependencyBannerState> {
   static override styles = [
@@ -52,17 +63,6 @@ export class DependencyBanner extends StateVisibleBanner<DependencyBannerState> 
     this.dispatchEvent(MainViewEvents.openInstallGuide({ tool }));
   }
 
-  private getToolLabel(tool: string): string {
-    switch (tool) {
-      case 'gm':
-        return 'GraphicsMagick';
-      case 'magick':
-        return 'ImageMagick';
-      default:
-        return tool;
-    }
-  }
-
   override render(): TemplateResult {
     const missing = this.state.missingTools ?? [];
     const tools = missing.flatMap((tool) =>
@@ -84,7 +84,7 @@ export class DependencyBanner extends StateVisibleBanner<DependencyBannerState> 
                 tools,
                 (tool) => tool,
                 (tool) => {
-                  const label = this.getToolLabel(tool);
+                  const label = getToolLabel(tool);
 
                   return html`
                     <li class="dependency-item">

--- a/packages/extension/src/webview/managers/FileManager.ts
+++ b/packages/extension/src/webview/managers/FileManager.ts
@@ -145,11 +145,8 @@ export class FileManager {
         vscode.window.showInformationMessage('Choose a base file first.');
         return;
       }
-      const baseFileStem = path.basename(baseFile, path.extname(baseFile));
-      const currentFileStem = path.basename(
-        currentOpenFile,
-        path.extname(currentOpenFile),
-      );
+      const baseFileStem = getFileStem(baseFile);
+      const currentFileStem = getFileStem(currentOpenFile);
       if (
         !currentFileStem.startsWith(baseFileStem) ||
         currentFileStem === baseFileStem

--- a/packages/extension/src/webview/managers/executionHandlers.ts
+++ b/packages/extension/src/webview/managers/executionHandlers.ts
@@ -21,12 +21,10 @@ const log = createLog(CHANNEL);
 
 function observeNotification(
   notification: Thenable<unknown>,
-  kind: 'information' | 'error',
+  label: 'Information' | 'Error',
 ): void {
   void Promise.resolve(notification).catch((err: unknown) => {
-    log.warn(
-      `${kind[0].toUpperCase()}${kind.slice(1)} notification failed: ${toErrorMessage(err)}`,
-    );
+    log.warn(`${label} notification failed: ${toErrorMessage(err)}`);
   });
 }
 
@@ -85,14 +83,14 @@ export async function handleExecute(
   if (launch.status === 'error') {
     observeNotification(
       vscode.window.showErrorMessage(launch.message),
-      'error',
+      'Error',
     );
     return;
   }
   if (launch.infoMessage) {
     observeNotification(
       vscode.window.showInformationMessage(launch.infoMessage),
-      'information',
+      'Information',
     );
   }
   const { preparation } = launch;


### PR DESCRIPTION
## What

Round 2 of the behavior-preserving simplification sweep (round 1: #11725, repo-root `src/`). This round covers the host packages: `packages/cli`, `packages/desktop`, `packages/extension`, `packages/agent`, `packages/trace-viewer` (125,771 LoC), mechanically cut into 33 disjoint ~3.8k-LoC partitions, each simplified by an independent code-simplifier agent on a shared checkout.

Net: **62 files, +338 / -512**. Churn is deliberately lower than round 1: much of the CLI TUI and extension surface was already consolidated by earlier rounds, and several batches came back zero-churn. Typical changes: inlining single-caller wrappers, folding duplicated markdown-it renderer rules and helper copies, dropping redundant locals and narrowing. The frozen `packages/agent` SDK surface is untouched.

## Net elements (R6)

- Files (diffstat vs merge-base): **62 files, +338 / -512**; net **-174 LoC**.
- Exported symbols (`^[+-]export` over the diff): **2 added / 2 removed, net 0** — one pair (`DesktopWindowLifecycleWiring` + `bootstrapDesktopWindowLifecycle`) re-expressed in place in `packages/desktop/src/main/desktopWindowLifecycle.ts` (signature restructure); consumers unchanged (`main/index.ts` + `DesktopWindowLifecycle.vitest.ts`, grep-verified). No de-exports.
- Classes/interfaces/enums: no classes or enums added or removed. One module-private interface removed: `ParsedPath` in `packages/extension/src/progressView/frontend/components/FileList.ts`, inlined into the return type of its only function (`parsePath`); the unrelated `ParsedPath` type in `src/tools/github/githubSubscriptionTool.ts` is untouched.

## Consumer counts (R8)

n/a for emit paths: no `bus.emit`, `appSignals.emit`, trace event, or IPC key is deleted or re-routed anywhere in the diff (grep-verified). No de-exported symbols (see R6).

## Guardrails held

- No edits outside an agent's partition; no git/format/typecheck inside agents.
- No CLI flag, help text, exit code, result-JSON (texra-action contract), settings key, command registration, or package.json contributes changes.
- No new `vscode` imports; webview frontends kept sandbox-clean; `packages/agent` surface frozen (ratchet-verified, no new exports).

## Validation (central, post-sweep)

- `npm run typecheck` clean (four agent over-reaches caught and reverted: a union merge that broke discriminated-union narrowing in `loginOptions.ts`, a let-binding rewrite that broke closure-assignment narrowing in `subscribeApprovals.ts`, a removed load-bearing `return` in `desktopPreviewHost.ts`, a removed load-bearing `!` in desktop `main.ts`)
- `npm run lint` clean
- `npm test`: 9994 passed (two more caught by tests and reverted: an inlined React helper that broke referential stability in `CliConfigForm.tsx`, a removed test-seam method in `desktopAgentExecution.ts`)
- `check:dead-code-ratchet` OK, `compile:fast` OK
- Review follow-ups on this PR: restored the pre-wrap-safe one-line objective div in `PlanApprovalRequestPanel.ts` and the `_view` disposal guard in `SettingsViewProvider.ts` (both caught by advisory review, both fixed and re-reviewed clean)

## Structural findings reported by the agents (not fixed here)

Each agent also reported structural/cross-cutting problems it was not allowed to fix: 21 cross-cutting, 26 local. Untriaged leads for future tech-debt rounds, not claims.

<details><summary>Cross-cutting (21)</summary>

- Session child-teardown duplicated between npm package and host shutdown wiring (`packages/agent + src/tools`)
- Stale-async-result guards hand-rolled in three parallel subscription modules (`packages/cli/src/chat/tui/state`)
- snapshotPort superset-by-reference relies on a comment to stay safe (`packages/desktop/src/main vs packages/extension progressView backend`)
- Four ad-hoc bounded-scroll windowing implementations beside shared scrollBounds helpers (`packages/cli/src/chat/tui (modals + panes)`)
- Hand-rolled dialog.showMessageBox wrappers duplicated across desktop main files (`packages/desktop/src/main (dialog plumbing)`)
- cliState.ts is a 10-slice god-module (`packages/cli/src/chat/tui/state`)
- Two stream display-label resolvers across hosts (`packages/cli vs packages/extension progress view`)
- Five hand-rolled row-window/sizing implementations across CLI pickers (`packages/cli/src/chat/tui/commands + forms`)
- ENOENT/ENOTDIR 'absent file' probe pattern duplicated across CLI runtime files (`packages/cli/src/runtime (mirrors src/common/errors)`)
- CLI picker-item shape triplicated across model-access and account-access modules (`packages/cli/src/runtime + chat/tui/forms`)
- Request-id-correlated postMessage bridges reimplemented per surface (`packages/desktop/src/renderer + host frontends`)
- Stream status glyph/label mapping is defined in three separate places (`packages/extension/src/progressView/frontend/components + src/shared/streams`)
- Toolbar button enablement is duplicated between frontend tables and backend command gates (`packages/extension/src/progressView/frontend/components/StreamHeader.ts vs extension backend`)
- data-log-id/logId is written by ~8 progressView files but never read in production (`packages/extension/src/progressView/frontend`)
- Duplicated keyboard/click activation delegation across panels (`packages/extension/src/progressView/frontend/components`)
- Active-view dispatch surface declared and adapted three times per view (`packages/extension/src webview message handlers`)
- Module-global auth-refresh deferral scope requires a test-only reset export (`packages/extension/src/frontend/auth + webview providers`)
- Stream label/reveal accessors exist as thin per-host mirrors in three places (`progressView reveal/label across extension + desktop + CLI`)
- ackGeneration force-rerender pattern is duplicated across settings tabs (`packages/extension/src/settingsView/frontend`)
- Dual subagentExecutionLabels implementations across hosts (`packages/extension/src/progressView + packages/cli TUI`)
- Stale knip-baseline entry for TraceDataSchema masks a real test consumer (`config/ratchets + packages/trace-viewer`)

</details>

<details><summary>Local (26)</summary>

- Duplicated JSON-config read/validate sequences in CLI runtime (`packages/cli/src/runtime`)
- Two parallel sensitive-path-redaction regex builders in desktop main (`packages/desktop/src/main`)
- Duplicate scroll-bounds/overflow-marker machinery in DiffView vs scrollBounds (`packages/cli/src/chat/tui/render`)
- Overflow-marker wording lives in three vocabularies (`packages/cli/src/tui`)
- Test-only export alias in workflowOutput (`packages/cli/src/runtime/workflowOutput.ts`)
- Two near-identical rows-budget wrappers over confirmCardContentRowsBudget (`packages/cli/src/chat/tui/modals`)
- CLI workflow output plumbing threads state through closure-captured mutable lets (`packages/cli/src/commands + packages/cli/src/runtime`)
- createWindow in index.ts is a ~1000-line wiring monolith (`packages/desktop/src/main`)
- Duplicate column normalizers with divergent failure semantics (`packages/cli/src/runtime`)
- Team-launch readiness flow duplicated between headless `multi-agent run` and interactive `orchestrate` (`packages/cli/src/commands + packages/cli/src/runtime`)
- orchestrate.ts launcher switch is a 170-line multi-concern function (`packages/cli/src/commands/orchestrate.ts`)
- Retry credential-switch rollback machinery is over-built (`packages/cli/src/chat/tui/state/subscribeApprovals.ts`)
- Dual async-load lifecycles in CLI forms (`packages/cli/src/chat/tui/forms`)
- Provider login-item matrix hand-unrolled twice in AccountAccessForm (`packages/cli/src/chat/tui/forms/AccountAccessForm.tsx`)
- Duplicated status-view summary fold across token/API-key forms (`packages/cli/src/chat/tui/forms`)
- BaseTextInput.tsx is 713 LOC with a pure display-math half that could split out (`packages/cli/src/chat/tui/input/BaseTextInput.tsx`)
- Dual fitting algorithms for the status-bar left row (transient-notice path vs generic priority sweep) (`packages/cli/src/chat/tui/panes/statusBarDisplay.ts`)
- desktop renderer main.ts is a ~1590-line god-module (`packages/desktop/src/renderer`)
- Desktop renderer composition root main.ts is 1593 LOC (`packages/desktop/src/renderer`)
- workspacePath.ts value-validation asymmetry between parse and rewrite paths (`packages/desktop/src/shared`)
- Duplicated vscode.lm partial-namespace capability guard in the two lm/ modules (`packages/extension/src/frontend/lm`)
- ProgressViewMessageHandler is a 973-line wiring hub, over the repo's ~400-500 LOC modularity bar (`packages/extension/src/progressView`)
- Catalog-backed select-row pattern implemented twice in settings tabs (`packages/extension/src/settingsView/frontend`)
- Drop-cue overlay implemented twice in webview frontend (`packages/extension/src/webview/frontend`)
- Settings-view refresh fan-out is hand-enumerated at many sites, parallel to the existing declarative snapshot map (`packages/extension/src/settingsView`)
- bannerSlice RECHECK_DEPENDENCIES bypasses the outbound schema-assertion path (`packages/extension/src/webview`)

</details>
