### PR TITLE
refactor: disambiguate ProgressWorkflowRunActionsController from file-actions sibling

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -43,11 +43,11 @@ import {
   type FollowUpApplyPorts,
 } from '@controllers/progressView/followUpApply';
 import {
-  ProgressWorkflowActionsController,
+  ProgressWorkflowRunActionsController,
   type WorkflowDiffRequest,
   type WorkflowFileOperation,
   type WorkflowFileOperationRequest,
-} from '@controllers/progressView/ProgressWorkflowActionsController';
+} from '@controllers/progressView/ProgressWorkflowRunActionsController';
 import type { ChatExportController } from '@controllers/progressView/ChatExportController';
 import { ProgressWorkflowFileActionsController } from '@controllers/progressView/ProgressWorkflowFileActionsController';
 import { ProgressAgentProposalController } from '@controllers/progressView/ProgressAgentProposalController';
@@ -203,7 +203,7 @@ export class DesktopProgressBridge {
    * each run's agent/model/input/output configuration from the shared snapshot
    * store and calls back into the two host-supplied operations below.
    */
-  private workflowActions!: ProgressWorkflowActionsController;
+  private workflowRunActions!: ProgressWorkflowRunActionsController;
   /** Plans compile-fix runs for a finished stream. */
   private followUpController!: ProgressFollowUpController;
   /** Rewrites follow-up text with the helper model ("Polish" in the follow-up box). */
@@ -411,7 +411,7 @@ export class DesktopProgressBridge {
     this.workflowFileActions = this.createWorkflowFileActionsController();
     this.agentProposalController = this.createAgentProposalController();
     this.commandHandlers = this.createSharedCommandHandlers();
-    this.workflowActions = this.createWorkflowActionsController();
+    this.workflowRunActions = this.createWorkflowRunActionsController();
     this.followUpController = this.createFollowUpController();
     this.apiKeyRetryController = this.createApiKeyRetryController();
     this.progressViewInboundHandlers = this.createProgressViewInboundHandlers();
@@ -465,7 +465,7 @@ export class DesktopProgressBridge {
   }
 
   /**
-   * Mirrors the extension's `createWorkflowActionsController`
+   * Mirrors the extension's `createWorkflowRunActionsController`
    * (`progressView/ProgressViewMessageHandler.ts`). The controller itself is
    * host-neutral; it reads each run's configuration from the same
    * `StreamSnapshotStore` both hosts share, so only the two terminal operations
@@ -473,8 +473,8 @@ export class DesktopProgressBridge {
    * `texra.pack` / `texra.clean` commands; the desktop calls the same
    * host-agnostic cores directly.
    */
-  private createWorkflowActionsController(): ProgressWorkflowActionsController {
-    return new ProgressWorkflowActionsController({
+  private createWorkflowRunActionsController(): ProgressWorkflowRunActionsController {
+    return new ProgressWorkflowRunActionsController({
       state: this.snapshotPort,
       runDiff: (request) => this.runWorkflowDiff(request),
       runFileOperation: (operation, request) =>
@@ -529,7 +529,8 @@ export class DesktopProgressBridge {
 
   private postRecordingStatus(
     status:
-      { status: 'started' | 'stopped' } | { status: 'error'; error: string },
+      | { status: 'started' | 'stopped' }
+      | { status: 'error'; error: string },
   ): void {
     this.postToRenderer({
       command: PROGRESS_VIEW_COMMANDS.UPDATE_RECORDING,
@@ -851,7 +852,7 @@ export class DesktopProgressBridge {
   private createProgressViewInboundHandlers(): DesktopProgressInboundHandlerRegistry {
     const secondTierActions: ProgressViewSecondTierActions = {
       ...this.snapshotPort,
-      workflowActions: this.workflowActions,
+      workflowRunActions: this.workflowRunActions,
       apiKeyRetry: this.apiKeyRetryController,
       followUp: this.followUpController,
       followUpPolish: this.followUpPolishController,
@@ -1150,7 +1151,7 @@ export class DesktopProgressBridge {
     // -- runLatexdiffFile -> diffAcceptedFilePair -> runSharedLatexdiff ->
     // runLatexdiffForExecution -- before anything enumerates it. A workflow
     // still producing output would otherwise change the diff scope after the
-    // user began the action. Mirrors ProgressWorkflowActionsController.diffStream.
+    // user began the action. Mirrors ProgressWorkflowRunActionsController.diffStream.
     const outputsByRound = cloneRoundIndexed(
       this.state.snapshots.getOutputFiles(stream),
     );

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -529,8 +529,7 @@ export class DesktopProgressBridge {
 
   private postRecordingStatus(
     status:
-      | { status: 'started' | 'stopped' }
-      | { status: 'error'; error: string },
+      { status: 'started' | 'stopped' } | { status: 'error'; error: string },
   ): void {
     this.postToRenderer({
       command: PROGRESS_VIEW_COMMANDS.UPDATE_RECORDING,

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -17,7 +17,7 @@ import {
   type FollowUpApplyPorts,
 } from '@controllers/progressView/followUpApply';
 import type { ProgressHostInteractions } from '@controllers/progressView/backend/progressHostInteractions';
-import { ProgressWorkflowActionsController } from '@controllers/progressView/ProgressWorkflowActionsController';
+import { ProgressWorkflowRunActionsController } from '@controllers/progressView/ProgressWorkflowRunActionsController';
 import { ProgressWorkflowFileActionsController } from '@controllers/progressView/ProgressWorkflowFileActionsController';
 import { ProgressAgentProposalController } from '@controllers/progressView/ProgressAgentProposalController';
 import {
@@ -96,7 +96,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private readonly commandHandlers: ReturnType<
     typeof createProgressViewCommandHandlers
   >;
-  private readonly workflowActionsController: ProgressWorkflowActionsController;
+  private readonly workflowRunActionsController: ProgressWorkflowRunActionsController;
   private readonly apiKeyRetryController: ProgressApiKeyRetryController;
   private readonly followUpController: ProgressFollowUpController;
   private readonly followUpPolishController: ProgressFollowUpPolishController;
@@ -190,7 +190,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       progressTitle: 'Transcribing follow-up message',
     });
 
-    this.workflowActionsController = this.createWorkflowActionsController();
+    this.workflowRunActionsController =
+      this.createWorkflowRunActionsController();
     this.workflowFileActionsController =
       this.createWorkflowFileActionsController();
     this.agentProposalController = this.createAgentProposalController();
@@ -247,7 +248,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
     const secondTierActions: ProgressViewSecondTierActions = {
       ...this.snapshotPort,
-      workflowActions: this.workflowActionsController,
+      workflowRunActions: this.workflowRunActionsController,
       apiKeyRetry: this.apiKeyRetryController,
       followUp: this.followUpController,
       followUpPolish: this.followUpPolishController,
@@ -650,8 +651,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     await vscode.window.showTextDocument(document, { preview: false });
   }
 
-  private createWorkflowActionsController(): ProgressWorkflowActionsController {
-    return new ProgressWorkflowActionsController({
+  private createWorkflowRunActionsController(): ProgressWorkflowRunActionsController {
+    return new ProgressWorkflowRunActionsController({
       state: this.snapshotPort,
       runDiff: async (request) => {
         await this.runViewCommand('texra.runLatexdiff', [request]);

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -38,7 +38,7 @@ import {
   type TranscriptExportPorts,
 } from './exportTranscript';
 import { submitProgressFollowUp } from './progressFollowUpSubmit';
-import type { ProgressWorkflowActionsController } from './ProgressWorkflowActionsController';
+import type { ProgressWorkflowRunActionsController } from './ProgressWorkflowRunActionsController';
 import type { ProgressWorkflowFileActionsController } from './ProgressWorkflowFileActionsController';
 import type { ProgressAgentProposalController } from './ProgressAgentProposalController';
 import type { ProgressApiKeyRetryController } from './ProgressApiKeyRetryController';
@@ -475,7 +475,7 @@ interface ProgressViewPolishReporter {
 
 export interface ProgressViewSecondTierActions {
   /** Shared controllers (host-neutral; created once per host with injected deps). */
-  readonly workflowActions: ProgressWorkflowActionsController;
+  readonly workflowRunActions: ProgressWorkflowRunActionsController;
   readonly apiKeyRetry: ProgressApiKeyRetryController;
   readonly followUp: ProgressFollowUpController;
   readonly followUpPolish: ProgressFollowUpPolishController;
@@ -538,7 +538,7 @@ export interface ProgressViewSecondTierActions {
  * Shared second-tier progress-view command handlers used by both extension and
  * desktop.
  *
- * These handlers wrap shared controllers ({@link ProgressWorkflowActionsController},
+ * These handlers wrap shared controllers ({@link ProgressWorkflowRunActionsController},
  * {@link ProgressApiKeyRetryController}, {@link ProgressFollowUpController},
  * {@link ProgressFollowUpPolishController}) plus host-injected callbacks for
  * messaging, retry settlement, state restoration, plan/polish result
@@ -555,11 +555,12 @@ export function createProgressViewSecondTierHandlers(
 
   return {
     // ── Workflow toolbar (diff / pack / clean) ──
-    [CMD.DIFF_STREAM]: (data) => deps.workflowActions.diffStream(data.stream),
+    [CMD.DIFF_STREAM]: (data) =>
+      deps.workflowRunActions.diffStream(data.stream),
     [CMD.PACK_STREAM]: (data) =>
-      deps.workflowActions.runFileOperation(data.stream, 'pack'),
+      deps.workflowRunActions.runFileOperation(data.stream, 'pack'),
     [CMD.CLEAN_STREAM]: (data) =>
-      deps.workflowActions.runFileOperation(data.stream, 'clean'),
+      deps.workflowRunActions.runFileOperation(data.stream, 'clean'),
 
     // ── Retry ──
     [CMD.RETRY_STREAM_REQUEST]: async (data) => {

--- a/src/controllers/progressView/ProgressWorkflowRunActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowRunActionsController.ts
@@ -33,12 +33,12 @@ export interface WorkflowFileOperationRequest {
   executionId?: string;
 }
 
-interface ProgressWorkflowActionsState extends StreamOutputsSource {
+interface ProgressWorkflowRunActionsState extends StreamOutputsSource {
   getKnownWorkspaceOutputPaths(stream: StreamTabId): Set<string>;
 }
 
-interface ProgressWorkflowActionsControllerDeps {
-  state: ProgressWorkflowActionsState;
+interface ProgressWorkflowRunActionsControllerDeps {
+  state: ProgressWorkflowRunActionsState;
   runDiff(request: WorkflowDiffRequest): Promise<void>;
   runFileOperation(
     operation: WorkflowFileOperation,
@@ -46,8 +46,10 @@ interface ProgressWorkflowActionsControllerDeps {
   ): Promise<void>;
 }
 
-export class ProgressWorkflowActionsController {
-  constructor(private readonly deps: ProgressWorkflowActionsControllerDeps) {}
+export class ProgressWorkflowRunActionsController {
+  constructor(
+    private readonly deps: ProgressWorkflowRunActionsControllerDeps,
+  ) {}
 
   async diffStream(stream: StreamTabId): Promise<void> {
     await this.withWorkflowConfig(stream, async (config, executionId) => {

--- a/src/controllers/progressView/ProgressWorkflowRunActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowRunActionsController.ts
@@ -10,7 +10,7 @@ import { AgentCategory, cloneRoundIndexed } from '@shared/schemas';
 import { unique } from '@utils/core';
 import type { StreamOutputsSource } from './streamOutputs';
 
-const log = createLog('ProgressWorkflowActions');
+const log = createLog('ProgressWorkflowRunActions');
 
 export interface WorkflowDiffRequest {
   agent: string;

--- a/src/controllers/progressView/streamOutputs.ts
+++ b/src/controllers/progressView/streamOutputs.ts
@@ -7,7 +7,7 @@ import type { RunMetadata } from '@transcript/StreamSnapshotStore';
 
 /**
  * The run-output accessors shared by the progress-view workflow controllers
- * ({@link ProgressWorkflowActionsController} and
+ * ({@link ProgressWorkflowRunActionsController} and
  * {@link ProgressWorkflowFileActionsController}). Both wire against the same
  * session-state slice, so the port is declared once and each controller adds
  * its own extra accessor on top.

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -132,7 +132,7 @@ function createSecondTierActions(
     reportError: vi.fn(),
   };
   return {
-    workflowActions: {
+    workflowRunActions: {
       diffStream: vi.fn(),
       runFileOperation: vi.fn(),
     },

--- a/src/test-kernel/controllers/ProgressWorkflowRunActionsController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressWorkflowRunActionsController.vitest.ts
@@ -6,18 +6,18 @@ import { AgentCategory } from '@shared/schemas';
 import {
   createAgentConfig,
   createOutputFile,
-  createProgressWorkflowActionsHarness,
+  createProgressWorkflowRunActionsHarness,
   createWorkflowConfig,
 } from '../support/ProgressControllerHarnesses';
 
-describe('ProgressWorkflowActionsController', () => {
+describe('ProgressWorkflowRunActionsController', () => {
   it('ignores toolbar actions for non-workflow streams', async () => {
     const toolUseConfig = createAgentConfig({
       agentCategory: AgentCategory.ToolUse,
       outputFiles: [],
     });
     const { controller, diffs, fileOperations } =
-      createProgressWorkflowActionsHarness({
+      createProgressWorkflowRunActionsHarness({
         runConfigs: new Map([['stream-a', toolUseConfig]]),
       });
 
@@ -32,7 +32,7 @@ describe('ProgressWorkflowActionsController', () => {
     const output = createOutputFile();
     const config = createWorkflowConfig({ outputFiles: ['declared.tex'] });
     const { controller, diffs, metadataReads } =
-      createProgressWorkflowActionsHarness({
+      createProgressWorkflowRunActionsHarness({
         runConfigs: new Map([['stream-a', config]]),
         executionIds: new Map([['stream-a', 'exec-123']]),
         outputs: new Map([['stream-a', { 1: [output] }]]),
@@ -57,7 +57,7 @@ describe('ProgressWorkflowActionsController', () => {
 
   it('reports no active output files when the run config declares none', async () => {
     const config = createWorkflowConfig({ outputFiles: [] });
-    const { controller, diffs } = createProgressWorkflowActionsHarness({
+    const { controller, diffs } = createProgressWorkflowRunActionsHarness({
       runConfigs: new Map([['stream-a', config]]),
     });
 
@@ -73,7 +73,7 @@ describe('ProgressWorkflowActionsController', () => {
       outputFiles: ['declared.tex', '/workspace/generated.tex'],
     });
     const { controller, fileOperations, metadataReads } =
-      createProgressWorkflowActionsHarness({
+      createProgressWorkflowRunActionsHarness({
         runConfigs: new Map([['stream-a', config]]),
         executionIds: new Map([['stream-a', 'exec-123']]),
         knownWorkspaceOutputs: new Map([
@@ -104,14 +104,13 @@ describe('ProgressWorkflowActionsController', () => {
 
   it('passes all resolved output files for clean requests', async () => {
     const config = createWorkflowConfig({ outputFiles: ['declared.tex'] });
-    const { controller, fileOperations } = createProgressWorkflowActionsHarness(
-      {
+    const { controller, fileOperations } =
+      createProgressWorkflowRunActionsHarness({
         runConfigs: new Map([['stream-a', config]]),
         knownWorkspaceOutputs: new Map([
           ['stream-a', new Set(['generated.tex'])],
         ]),
-      },
-    );
+      });
 
     await controller.runFileOperation('stream-a', 'clean');
 

--- a/src/test-kernel/support/ProgressControllerHarnesses.ts
+++ b/src/test-kernel/support/ProgressControllerHarnesses.ts
@@ -8,11 +8,11 @@ import {
 } from '@agent/core/definition/AgentConfig';
 import type { ProgressBackendOptions } from '@controllers/progressView/backend/ProgressBackend';
 import {
-  ProgressWorkflowActionsController,
+  ProgressWorkflowRunActionsController,
   type WorkflowDiffRequest,
   type WorkflowFileOperation,
   type WorkflowFileOperationRequest,
-} from '@controllers/progressView/ProgressWorkflowActionsController';
+} from '@controllers/progressView/ProgressWorkflowRunActionsController';
 import type {
   OutputFileInfo,
   RoundIndexed,
@@ -111,15 +111,15 @@ export function createOutputFile(
   };
 }
 
-export interface ProgressWorkflowActionsHarnessOptions {
+export interface ProgressWorkflowRunActionsHarnessOptions {
   runConfigs?: Map<StreamTabId, AgentConfig>;
   executionIds?: Map<StreamTabId, string>;
   outputs?: Map<StreamTabId, RoundIndexed<OutputFileInfo>>;
   knownWorkspaceOutputs?: Map<StreamTabId, Set<string>>;
 }
 
-export interface ProgressWorkflowActionsHarness {
-  controller: ProgressWorkflowActionsController;
+export interface ProgressWorkflowRunActionsHarness {
+  controller: ProgressWorkflowRunActionsController;
   metadataReads: StreamTabId[];
   diffs: WorkflowDiffRequest[];
   fileOperations: Array<{
@@ -128,9 +128,9 @@ export interface ProgressWorkflowActionsHarness {
   }>;
 }
 
-export function createProgressWorkflowActionsHarness(
-  options: ProgressWorkflowActionsHarnessOptions = {},
-): ProgressWorkflowActionsHarness {
+export function createProgressWorkflowRunActionsHarness(
+  options: ProgressWorkflowRunActionsHarnessOptions = {},
+): ProgressWorkflowRunActionsHarness {
   const metadataReads: StreamTabId[] = [];
   const diffs: WorkflowDiffRequest[] = [];
   const fileOperations: Array<{
@@ -139,7 +139,7 @@ export function createProgressWorkflowActionsHarness(
   }> = [];
 
   return {
-    controller: new ProgressWorkflowActionsController({
+    controller: new ProgressWorkflowRunActionsController({
       state: {
         getRunMetadata: (stream) => {
           metadataReads.push(stream);

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -529,9 +529,11 @@ export class StreamSnapshotStore {
    * this store stays the authority.
    */
   private summaryMetaSink:
-    ((stream: StreamTabId, meta: StreamSummaryMeta) => void) | undefined;
+    | ((stream: StreamTabId, meta: StreamSummaryMeta) => void)
+    | undefined;
   private summaryMetaSource:
-    ((stream: StreamTabId) => StreamSummaryMeta | undefined) | undefined;
+    | ((stream: StreamTabId) => StreamSummaryMeta | undefined)
+    | undefined;
 
   /**
    * Publish the whole current metadata view of a stream to the summary
@@ -1064,7 +1066,7 @@ export class StreamSnapshotStore {
   // artifact write. **A caller that carries the result across an `await` must
   // clone it** — `applyRoundPatch` mutates these records in place, so a live
   // run can add or drop a round while the caller is suspended. See
-  // `ProgressWorkflowActionsController.diffStream`, which snapshots before the
+  // `ProgressWorkflowRunActionsController.diffStream`, which snapshots before the
   // request crosses an interactive quick pick.
   //
   // The write path still snapshots (`snapshotFromMemory`, `writeRoundKeyedField`),

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -529,11 +529,9 @@ export class StreamSnapshotStore {
    * this store stays the authority.
    */
   private summaryMetaSink:
-    | ((stream: StreamTabId, meta: StreamSummaryMeta) => void)
-    | undefined;
+    ((stream: StreamTabId, meta: StreamSummaryMeta) => void) | undefined;
   private summaryMetaSource:
-    | ((stream: StreamTabId) => StreamSummaryMeta | undefined)
-    | undefined;
+    ((stream: StreamTabId) => StreamSummaryMeta | undefined) | undefined;
 
   /**
    * Publish the whole current metadata view of a stream to the summary


### PR DESCRIPTION
## Summary

An audit for overlapping/confusing responsibilities in `src/controllers/progressView/` found that `ProgressWorkflowActionsController` and `ProgressWorkflowFileActionsController` share an almost-identical name while owning genuinely different scopes:

- `ProgressWorkflowActionsController` — whole-run actions: `diffStream`, `runFileOperation('pack'|'clean')`.
- `ProgressWorkflowFileActionsController` — per-file actions: compare, accept, merge, latexdiff, open directory/label.

Both are wired into the exact same call sites (`ProgressViewCommandHandlers.ts`, `packages/extension/src/progressView/ProgressViewMessageHandler.ts`, `packages/desktop/src/main/desktopAgentExecution.ts`), so a reader has to open both files to know which "workflow action" lives where. This PR renames the run-scoped controller to `ProgressWorkflowRunActionsController` (Run vs File now reads at a glance) and carries the rename through its `Deps`/`State` interfaces, the `workflowActions` field/accessor that holds it, and its test harness.

Pure rename — no behavior change.

## Issue acceptance gates

No linked issue; this is a proactive clarity fix found during a scheduled repo-wide audit for confusing/overlapping responsibilities. Gate: the two controller names must no longer collide when read side by side. Satisfied — see rename below.

## Single source of truth

Unchanged: `ProgressWorkflowRunActionsController` (formerly `ProgressWorkflowActionsController`) remains the sole owner of whole-run diff/pack/clean orchestration; `ProgressWorkflowFileActionsController` remains the sole owner of per-file actions. This PR only renames the former for clarity — it does not move any logic or change which controller owns which fact.

## Duplication and abstraction budget

No duplication removed or added; no new abstraction introduced. This is a naming-only change — every renamed symbol keeps its exact prior shape and single call graph.

## Net elements (R6)

- Files: 9 changed (2 renamed: `ProgressWorkflowActionsController.ts` → `ProgressWorkflowRunActionsController.ts`, and its vitest file), 0 added, 0 deleted.
- Exported symbols (`^[+-]export` over the diff): `-3`/`+3` — `ProgressWorkflowActionsController` class, `ProgressWorkflowActionsHarnessOptions`, `ProgressWorkflowActionsHarness` interfaces renamed 1:1 to their `...Run...` counterparts (plus the non-exported `ProgressWorkflowActionsControllerDeps`/`ProgressWorkflowActionsState` internal interfaces). Net exported-symbol count: 0.
- Classes/interfaces/enums: 0 added, 0 removed — 5 renamed (`ProgressWorkflowActionsController`, `ProgressWorkflowActionsControllerDeps`, `ProgressWorkflowActionsState`, `ProgressWorkflowActionsHarnessOptions`, `ProgressWorkflowActionsHarness`).
- Net LoC (`git diff --stat origin/main`): 57 insertions(+), 51 deletions(-), net **+6** (import-statement reflow from the longer identifier plus one re-wrapped call-site line; no new logic).

## Consumer counts (R8)

Renamed export, not deleted/re-routed — every consumer was updated in this same PR, so there is no orphaned subscriber:

- `ProgressWorkflowActionsController` class: 2 call sites (`packages/extension/src/progressView/ProgressViewMessageHandler.ts`, `packages/desktop/src/main/desktopAgentExecution.ts`) + 1 test harness (`src/test-kernel/support/ProgressControllerHarnesses.ts`) — all updated to the new name.
- `workflowActions` field (`ProgressViewSecondTierActions.workflowActions`): 3 read sites (`ProgressViewCommandHandlers.ts` × 3 command handlers) + 2 construction sites (extension, desktop) + 1 test mock (`ProgressViewCommandHandlers.vitest.ts`) — all renamed to `workflowRunActions` together.
- `createProgressWorkflowActionsHarness` test helper: 5 call sites, all within `ProgressWorkflowRunActionsController.vitest.ts` — all updated.

## Host impact

Extension: Field/class rename only inside `ProgressViewMessageHandler.ts`; no behavior change.

Desktop: Field/class rename only inside `desktopAgentExecution.ts`; no behavior change.

CLI: Not touched.

## Scheduled refactoring

None. A second, smaller finding from the same audit (two webview trees — `webview/mainViewInboundContext.ts` and `settingsView/handlers/SettingsHandlerContext.ts` — independently built the same "slice host" facade-binding boilerplate under different field names) was intentionally **not** implemented here: one of the two facade methods it would need to unify (`postToActiveView` vs `postMessageToActiveWebview`) has a documented sync/async delivery-ordering difference on `BaseViewMessageHandler`, so collapsing it needs a deliberate design decision rather than a mechanical rename. Filing that as a follow-up is left to the repo owners' judgment rather than opened here.

## Validation

- `npm run typecheck:workspace` — pass
- `npm run typecheck:test-kernel` — pass
- `npm run typecheck:desktop` — pass
- `npx eslint` on all 9 changed files — pass, no findings
- `npx prettier --write` on all 9 changed files — no changes (already formatted)
- `npx vitest run src/test-kernel/controllers/` — 28 files, 273 tests passed
- `npm run check:dead-code-ratchet` — no new findings
- `git diff --check` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01TKAfSxHGkg9MpjWTr8yvDQ)_