### PR TITLE
consolidate: fold duplicated logic into shared helpers, fix drifted usage predicates

### DIFF
--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -11,6 +11,7 @@ import { quote } from 'shell-quote';
 import type { CliOutputFormat } from '@cli/schemas/cliSettings';
 import type { TexraApprovalPolicy } from '@shared/approvalPolicy';
 import {
+  isEmptyUsage,
   sumUsageStats,
   type StreamTabId,
   type TokenUsageStats,
@@ -78,17 +79,6 @@ export function formatResumeCommand(
   return `${commandName || DEFAULT_RESUME_COMMAND_NAME} resume ${executionId}${cwdArg}${policyFlag}${outputFormatFlag}${printFlag}${interopFlag}${sourceFlags}`;
 }
 
-function usageHasTokens(usage: TokenUsageStats): boolean {
-  return (
-    usage.inputTokens > 0 ||
-    usage.outputTokens > 0 ||
-    (usage.cacheReadInputTokens ?? 0) > 0 ||
-    (usage.cacheMissInputTokens ?? 0) > 0 ||
-    (usage.cacheCreationInputTokens ?? 0) > 0 ||
-    (usage.reasoningTokens ?? 0) > 0
-  );
-}
-
 export function collectResumeUsage(
   streams: ReadonlyMap<StreamTabId, StreamSlice>,
 ): TokenUsageStats | undefined {
@@ -96,18 +86,18 @@ export function collectResumeUsage(
 
   for (const streamId of streams.keys()) {
     const usage = readStreamArtifacts(streamId)?.cumulativeUsage;
-    if (!usage || !usageHasTokens(usage)) continue;
+    if (!usage || isEmptyUsage(usage)) continue;
     usages.push(usage);
   }
 
   const total = sumUsageStats(usages);
-  return usageHasTokens(total) ? total : undefined;
+  return isEmptyUsage(total) ? undefined : total;
 }
 
 export function formatResumeUsage(
   usage: TokenUsageStats | undefined,
 ): string | undefined {
-  if (!usage || !usageHasTokens(usage)) return undefined;
+  if (!usage || isEmptyUsage(usage)) return undefined;
   const total = usage.inputTokens + usage.outputTokens;
   const cached = usage.cacheReadInputTokens ?? 0;
   const reasoning = usage.reasoningTokens ?? 0;

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -8,7 +8,7 @@ import '@awesome.me/webawesome/dist/components/split-panel/split-panel.js';
 // Local imports - shared webview
 import { COMMON_COMMANDS, PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import '@shared/wa/spinner';
-import { BaseWebviewApp } from '@shared/BaseWebviewApp';
+import { signalWatcherWebviewAppBase } from '@shared/BaseWebviewApp';
 import { postMessage } from '@shared/hostBridge';
 
 // Local imports - shared schemas
@@ -17,7 +17,7 @@ import type {
   StreamLifecycleStatus,
   StreamTabId,
 } from '@shared/schemas';
-import { SignalWatcher, subscribeToSignalChanges } from '@shared/signals';
+import { subscribeToSignalChanges } from '@shared/signals';
 import {
   designTokens,
   viewTabStyles,
@@ -67,13 +67,8 @@ import './components/StreamConversation';
 
 registerTeXRAWebAwesomeIcons();
 
-// Cast: BaseWebviewApp is abstract, but SignalWatcher expects a concrete constructor.
-// Safe because ProgressApp implements all abstract members below.
-const ProgressAppBase = SignalWatcher(
-  BaseWebviewApp as unknown as new (
-    ...args: any[]
-  ) => BaseWebviewApp<ProgressViewOutboundMessage>,
-);
+const ProgressAppBase =
+  signalWatcherWebviewAppBase<ProgressViewOutboundMessage>();
 
 @customElement('progress-app')
 export class ProgressApp extends ProgressAppBase {

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -10,10 +10,11 @@ import '@awesome.me/webawesome/dist/components/progress-bar/progress-bar.js';
 import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports - shared schemas, styles, and constants
-import type {
-  ContextStateData,
-  TokenUsageStats,
-  UsageRoute,
+import {
+  isEmptyUsage,
+  type ContextStateData,
+  type TokenUsageStats,
+  type UsageRoute,
 } from '@shared/schemas';
 import { designTokens } from '@shared/styles';
 import { usageCostLabel, usageRouteBadge } from '@shared/copy/modelAccess';
@@ -177,17 +178,7 @@ export class UsagePanel extends LitElement {
 
   /** Whether the usage stats have any non-zero values worth displaying. */
   private get hasUsage(): boolean {
-    const u = this.usage;
-    if (!u) return false;
-    return (
-      u.inputTokens > 0 ||
-      u.outputTokens > 0 ||
-      u.cost > 0 ||
-      (u.cacheReadInputTokens ?? 0) > 0 ||
-      (u.cacheMissInputTokens ?? 0) > 0 ||
-      (u.cacheCreationInputTokens ?? 0) > 0 ||
-      (u.reasoningTokens ?? 0) > 0
-    );
+    return this.usage != null && !isEmptyUsage(this.usage);
   }
 
   /** `ContextStateDataSchema` requires both gauge fields, so presence is all

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -7,11 +7,8 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared webview
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import { BaseWebviewApp } from '@shared/BaseWebviewApp';
+import { signalWatcherWebviewAppBase } from '@shared/BaseWebviewApp';
 import { postMessage } from '@shared/hostBridge';
-
-// Local imports - shared signals
-import { SignalWatcher } from '@shared/signals';
 
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
@@ -125,11 +122,7 @@ registerTeXRAWebAwesomeIcons();
 
 const MAX_TIMEOUT_MS = 2_147_483_647;
 
-// Cast: BaseWebviewApp is abstract, but SignalWatcher expects a concrete constructor.
-// Safe because SettingsApp implements all abstract members below.
-const SettingsAppBase = SignalWatcher(
-  BaseWebviewApp as unknown as new (...args: any[]) => BaseWebviewApp,
-);
+const SettingsAppBase = signalWatcherWebviewAppBase();
 
 @customElement('settings-app')
 export class SettingsApp extends SettingsAppBase {

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -6,8 +6,7 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/divider/divider.js';
 import '@awesome.me/webawesome/dist/components/skeleton/skeleton.js';
 import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@shared/ipc';
-import { SignalWatcher } from '@shared/signals';
-import { BaseWebviewApp } from '@shared/BaseWebviewApp';
+import { signalWatcherWebviewAppBase } from '@shared/BaseWebviewApp';
 import { postMessage } from '@shared/hostBridge';
 import {
   designTokens,
@@ -125,11 +124,7 @@ import { mainViewStyles } from './styles';
 
 registerTeXRAWebAwesomeIcons();
 
-// Cast: BaseWebviewApp is abstract, but SignalWatcher expects a concrete constructor.
-// Safe because MainApp implements all abstract members below.
-const MainAppBase = SignalWatcher(
-  BaseWebviewApp as unknown as new (...args: any[]) => BaseWebviewApp,
-);
+const MainAppBase = signalWatcherWebviewAppBase();
 
 @customElement('main-app')
 export class MainApp extends MainAppBase {

--- a/scripts/extension-package-utils.mjs
+++ b/scripts/extension-package-utils.mjs
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import process from 'node:process';
 
 import { walkFiles } from './walkFiles.mjs';
 
@@ -15,6 +16,14 @@ export const requiredMonacoWorkers = [
 
 export function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+/** Print accumulated failures under `label` and exit(1); no-op when empty. */
+export function reportCheckFailures(label, failures) {
+  if (failures.length === 0) return;
+  console.error(`${label} failed:`);
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
 }
 
 /** Return recursive file paths with stable VSIX-compatible separators. */

--- a/scripts/verify-desktop-build-artifacts.mjs
+++ b/scripts/verify-desktop-build-artifacts.mjs
@@ -1,10 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 import {
   readJson,
+  reportCheckFailures,
   requiredMonacoWorkers,
   vscodeRuntimeImportPattern,
 } from './extension-package-utils.mjs';
@@ -75,11 +75,7 @@ if (
   );
 }
 
-if (failures.length > 0) {
-  console.error('Desktop build artifact check failed:');
-  for (const failure of failures) console.error(`- ${failure}`);
-  process.exit(1);
-}
+reportCheckFailures('Desktop build artifact check', failures);
 
 const artifactList = [
   ...requiredFiles,

--- a/scripts/verify-desktop-installer-artifacts.mjs
+++ b/scripts/verify-desktop-installer-artifacts.mjs
@@ -3,6 +3,8 @@ import { basename, join, relative } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
+import { reportCheckFailures } from './extension-package-utils.mjs';
+
 const repoRoot = fileURLToPath(new URL('..', import.meta.url));
 const desktopPackageRoot =
   process.env.TEXRA_DESKTOP_INSTALLER_ROOT ??
@@ -259,11 +261,7 @@ for (const platform of getPlatformKeys()) {
   verifiedPlatforms.push(await verifyPlatformArtifacts(platform));
 }
 
-if (failures.length > 0) {
-  console.error('Desktop installer artifact check failed:');
-  for (const failure of failures) console.error(`- ${failure}`);
-  process.exit(1);
-}
+reportCheckFailures('Desktop installer artifact check', failures);
 
 for (const { requirement, matchedArtifacts } of verifiedPlatforms) {
   console.log(`${requirement.label} desktop installer artifact check passed:`);

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -6,6 +6,7 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 import {
+  reportCheckFailures,
   requiredMonacoWorkers,
   vscodeRuntimeImportPattern,
 } from './extension-package-utils.mjs';
@@ -638,11 +639,7 @@ if (!app) {
   }
 }
 
-if (failures.length > 0) {
-  console.error('Desktop package check failed:');
-  for (const failure of failures) console.error(`- ${failure}`);
-  process.exit(1);
-}
+reportCheckFailures('Desktop package check', failures);
 
 const summary = [
   `Desktop package check passed for ${app.label}`,

--- a/scripts/verify-extension-package-invariants.mjs
+++ b/scripts/verify-extension-package-invariants.mjs
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 import {
@@ -8,6 +7,7 @@ import {
   EXCLUDED_TRACE_VIEWER_DIR,
   extensionManifestSnapshot,
   readJson,
+  reportCheckFailures,
   withoutCatalogDerivedContributes,
 } from './extension-package-utils.mjs';
 import { walkFiles } from './walkFiles.mjs';
@@ -286,10 +286,6 @@ verifyAssets(snapshot, failures);
 verifyBundledSkills(failures);
 verifyVscodeIgnore(snapshot, failures);
 
-if (failures.length > 0) {
-  console.error('Extension package invariant check failed:');
-  for (const failure of failures) console.error(`- ${failure}`);
-  process.exit(1);
-}
+reportCheckFailures('Extension package invariant check', failures);
 
 console.log('Extension package invariants are in sync');

--- a/scripts/verify-vsix-contents.mjs
+++ b/scripts/verify-vsix-contents.mjs
@@ -11,6 +11,7 @@ import {
   EXCLUDED_TRACE_VIEWER_DIR,
   extensionManifestSnapshot,
   readJson,
+  reportCheckFailures,
   requiredMonacoWorkers,
   withoutCatalogDerivedContributes,
 } from './extension-package-utils.mjs';
@@ -270,11 +271,7 @@ verifyDistEntrypoints(entries, failures);
 verifyNoMonacoWorkers(entries, failures);
 verifyPackagedDocs(vsixPath, entries, failures);
 
-if (failures.length > 0) {
-  console.error('VSIX content check failed:');
-  for (const failure of failures) console.error(`- ${failure}`);
-  process.exit(1);
-}
+reportCheckFailures('VSIX content check', failures);
 
 console.log(
   `VSIX content check passed for ${path.relative(rootDir, vsixPath)}`,

--- a/src/shared/BaseWebviewApp.ts
+++ b/src/shared/BaseWebviewApp.ts
@@ -9,6 +9,7 @@ import {
   type StateRestoreMessage,
   type Theme,
 } from '@shared/schemas';
+import { SignalWatcher } from '@shared/signals';
 import { installToolbarTooltips } from '@shared/litControllers/TooltipController';
 
 import type { ZodError } from 'zod';
@@ -61,7 +62,7 @@ function handleCommonMessage(
  * instead of `unknown`.
  */
 
-export abstract class BaseWebviewApp<TMessage = unknown> extends LitElement {
+abstract class BaseWebviewApp<TMessage = unknown> extends LitElement {
   protected debugMode = false;
 
   private readonly messageListener = (event: MessageEvent) => {
@@ -155,4 +156,18 @@ export abstract class BaseWebviewApp<TMessage = unknown> extends LitElement {
    * The backend sends TMessage objects via postMessage (structured clone).
    */
   protected abstract handleMessage(message: TMessage): void;
+}
+
+/**
+ * `SignalWatcher(BaseWebviewApp<TMessage>)`, cast once here instead of at
+ * each of the three view-root components: `BaseWebviewApp` is abstract, but
+ * `SignalWatcher` expects a concrete constructor. Safe because every app
+ * subclass implements the abstract members before `@customElement` runs.
+ */
+export function signalWatcherWebviewAppBase<TMessage = unknown>() {
+  return SignalWatcher(
+    BaseWebviewApp as unknown as new (
+      ...args: any[]
+    ) => BaseWebviewApp<TMessage>,
+  );
 }


### PR DESCRIPTION
## Summary

Scheduled consolidation sweep: scanned the codebase for duplicate/near-duplicate logic and hand-rolled code that a shared helper or the canonical implementation already covers. Four parallel surveys (agent runtime/tools, platform/hosts, webviews, storage/scripts) turned up three strong, evidence-backed candidates; the agent-runtime/tools survey came back empty (that area has already been through prior simplification sweeps). This PR implements the three surviving candidates:

1. **Webview mixin cast, triplicated → one factory.** `MainApp.ts`, `ProgressApp.ts`, and `SettingsApp.ts` each independently did the identical `SignalWatcher(BaseWebviewApp as unknown as new (...) => BaseWebviewApp<...>)` cast, with an identical justifying comment. Moved to one `signalWatcherWebviewAppBase()` factory in `src/shared/BaseWebviewApp.ts`; each app now does `const XAppBase = signalWatcherWebviewAppBase<...>();`.
2. **Packaging script failure-report block, copy-pasted 5x.** `verify-vsix-contents.mjs`, `verify-desktop-build-artifacts.mjs`, `verify-extension-package-invariants.mjs`, `verify-desktop-installer-artifacts.mjs`, and `verify-desktop-package.mjs` each had the exact same 4-line "print failures and exit(1)" block, differing only in the label string. Extracted to `reportCheckFailures(label, failures)` in the existing shared `scripts/extension-package-utils.mjs`.
3. **Drifted duplicate "usage is empty" predicates.** The canonical `isEmptyUsage` (`src/shared/schemas/usage.ts`) checks 7 usage fields. The CLI's `usageHasTokens` (`resumeHint.ts`) independently checked only 6 (**omitting `cost`** — still true on latest `main` as of this rebase, a real drift bug: a cost-only run's resume hint disagrees with the webview's usage footer). The webview's `hasUsage` getter (`UsagePanel.ts`) had also drifted at the point this sweep started, but an unrelated commit that landed on `main` while this PR was in flight independently brought it back to checking all 7 fields — so that half is now a pure dedup rather than a bug fix, and the CLI half remains the one real behavioral fix. Both local predicates are deleted in favor of the shared `isEmptyUsage`.

*(Edit: this PR was rebased onto the current `main` tip after the branch was found to be built on a stale/incomplete fetch of `main` — see Validation. The rebase surfaced the upstream `UsagePanel.ts` fix described above and an unrelated upstream refactor of `resumeHint.ts`'s stream-usage lookup (`streamPreferredUsage` → `readStreamArtifacts`), both merged in cleanly.)*

## Issue acceptance gates

No tracking issue — this is a scheduled proactive consolidation pass, not a response to a filed issue.

## Single source of truth

- `signalWatcherWebviewAppBase()` in `src/shared/BaseWebviewApp.ts` now owns the one unsafe mixin cast for all three webview app roots.
- `reportCheckFailures()` in `scripts/extension-package-utils.mjs` now owns the packaging-script failure-report format for all 5 verification scripts.
- `isEmptyUsage()` in `src/shared/schemas/usage.ts` now owns "is this usage worth showing/reporting" for both hosts that previously reimplemented it (CLI, extension webview).

## Duplication and abstraction budget

Removed: one 4-line unsafe-cast block duplicated 3x, one 4-line failure-report block duplicated 5x, and two reimplementations (one still-drifted, one no-longer-drifted) of a 7-field predicate. Added: one factory function and one utility function, each with ≥3 real call sites (the bar this repo sets for a shared helper) — no new abstraction layer, no pass-through wrapper. `BaseWebviewApp` itself is no longer exported since nothing outside its file references it directly anymore (only the new factory does, in the same file).

## Net elements (R6)

- Files changed: 12 (diffstat: `+54 -82`, net **-28 LoC**)
- Exported symbols: `+2` (`reportCheckFailures`, `signalWatcherWebviewAppBase`), `-1` (`BaseWebviewApp` un-exported — still defined, just module-private now); net `+1` export, `-2` local duplicate functions (`usageHasTokens` in `resumeHint.ts`, the `hasUsage` getter body in `UsagePanel.ts`) deleted in favor of an existing shared symbol
- No new classes/interfaces/enums

## Consumer counts (R8)

- `BaseWebviewApp` (un-exported): 0 remaining external importers (verified via repo-wide grep — only 3 in-repo mentions left are prose comments, not imports); its only reference now is the same-file `signalWatcherWebviewAppBase`.
- `signalWatcherWebviewAppBase`: 3 callers (`MainApp.ts`, `ProgressApp.ts`, `SettingsApp.ts`).
- `reportCheckFailures`: 5 callers (the 5 packaging-verification scripts).
- `isEmptyUsage`: consumer count grew from 2 files (`usage.ts`, `streamData.ts`) to 4 (adds `resumeHint.ts` ×3 call sites, `UsagePanel.ts` ×1 call site), replacing the 2 deleted local predicates.

## Host impact

Extension: `MainApp.ts`, `SettingsApp.ts`, `ProgressApp.ts` construction sites simplified; `UsagePanel.ts`'s usage-footer visibility is unchanged in behavior (an upstream commit already fixed its field count before this rebase) and now shares its implementation with the canonical predicate instead of duplicating it.

Desktop: no source changes; the 5 packaging-verification scripts also validate desktop build/installer artifacts, exercised by `typecheck:desktop` and the desktop-targeted vitest suites, both green.

CLI: `resumeHint.ts`'s resume-usage-hint visibility now matches the webview's usage-footer visibility exactly on the `cost`-only case, which it previously disagreed on (real, still-current bug fix).

## Scheduled refactoring

None — the fourth survey area (agent runtime/tools under `src/agent/`, `src/tools/`) was audited in the same pass and found already fully consolidated (prior simplification sweeps had already collapsed per-provider duplication onto shared helpers with `p-retry`/`p-queue`/`structuredClone` already in use everywhere applicable); no follow-up filed there.

## Validation

- The branch was originally built on a stale `main` ref from an incomplete shallow-clone fetch (~50 commits behind true `main`, including a new `effect` dependency). Re-fetched with `--unshallow`, confirmed the stale ref was a genuine ancestor of true `main` (not a diverged history), rebased onto the correct tip, resolved two real conflicts (`resumeHint.ts`, `UsagePanel.ts`, both described above), reinstalled dependencies, and re-ran full validation below against the corrected base.
- `npm run typecheck` (all sub-targets: workspace, test-kernel, agent, cli, trace-viewer, desktop) — clean
- `npm run lint` — clean (one `import/order` finding auto-fixed via `eslint --fix`)
- `npm test` — full suite: 1 pre-existing failure unrelated to this diff (`DesktopAgentExecution.vitest.ts > DesktopProgressBridge > presents a merge failure that occurs before lifecycle startup`), reproduced identically against unmodified `origin/main` in an isolated worktree with no changes from this PR applied — confirmed not caused by this PR. All other tests green: 9993 passed / 6 skipped (plus the 1 known-unrelated failure), 821 passed / 1 skipped test files.
- `npm run check:dead-code-ratchet` — OK, no new findings (un-exporting `BaseWebviewApp` avoided introducing one)
- `npx prettier --check` on all touched files — clean