### PR TITLE
Support Claude Fable 5.1 in the Claude Code agent tool

### DIFF
--- a/docs/guide/agent-integrations.md
+++ b/docs/guide/agent-integrations.md
@@ -84,7 +84,7 @@ delivery. The new prompt joins that Codex session as the next turn.
 
 | Setting              | Options                                                                                            | Default             | What it controls                                                              |
 | -------------------- | -------------------------------------------------------------------------------------------------- | ------------------- | ----------------------------------------------------------------------------- |
-| **Model**            | `Sonnet 5`, `Fable 5`, `Opus 5`, `Haiku 4.5`                                                       | `Sonnet 5`          | Which Claude model the delegated agent runs on. Agents may override per call. |
+| **Model**            | `Sonnet 5`, `Fable 5.1`, `Opus 5`, `Haiku 4.5`                                                     | `Sonnet 5`          | Which Claude model the delegated agent runs on. Agents may override per call. |
 | **Permission mode**  | `Prompt for risky actions`, `Auto-accept edits`, `Bypass all (dangerous)`, `Plan only (read-only)` | `Auto-accept edits` | How much the Claude Code child process may do before stopping to ask.         |
 | **Reasoning effort** | `Low`, `Medium`, `High`, `Extra high`, `Maximum`                                                   | `High`              | How deeply Claude deliberates before acting.                                  |
 

--- a/src/shared/schemas/agentCliSettings.ts
+++ b/src/shared/schemas/agentCliSettings.ts
@@ -84,6 +84,10 @@ const parseClaudeAgentModelEnum = parseEnumSetting(
  * default -- `readSetting` runs this before `schema.safeParse`, so an
  * unmapped legacy id would already look "valid" by the time the loud
  * invalid-value warning path could fire.
+ *
+ * Introduced 2026-09-01. Per AGENTS.md's compatibility-retirement policy,
+ * this branch (and its regression test) may be removed three months after
+ * Fable 5.1 shipped, i.e. on or after 2026-12-01.
  */
 export function parseClaudeAgentModel(raw: unknown): ClaudeAgentModel {
   if (raw === 'claude-fable-5') return 'claude-fable-5-1';

--- a/src/shared/schemas/agentCliSettings.ts
+++ b/src/shared/schemas/agentCliSettings.ts
@@ -64,7 +64,7 @@ export const parseCodexApprovalPolicy = parseEnumSetting(
 /** Claude Code CLI model options surfaced in the picker. */
 export const ClaudeAgentModelSchema = z.enum([
   'claude-sonnet-5',
-  'claude-fable-5',
+  'claude-fable-5-1',
   'claude-opus-5',
   'claude-haiku-4-5-20251001',
 ]);

--- a/src/shared/schemas/agentCliSettings.ts
+++ b/src/shared/schemas/agentCliSettings.ts
@@ -72,10 +72,23 @@ export type ClaudeAgentModel = z.infer<typeof ClaudeAgentModelSchema>;
 
 export const CLAUDE_AGENT_DEFAULT_MODEL: ClaudeAgentModel = 'claude-sonnet-5';
 
-export const parseClaudeAgentModel = parseEnumSetting(
+const parseClaudeAgentModelEnum = parseEnumSetting(
   ClaudeAgentModelSchema.options,
   CLAUDE_AGENT_DEFAULT_MODEL,
 );
+
+/**
+ * Claude Fable 5 was retired in favor of Fable 5.1 (identical specs/pricing,
+ * cheaper cache reads). Map a previously-persisted `claude-fable-5` forward
+ * instead of letting the enum parser silently discard it back to the
+ * default -- `readSetting` runs this before `schema.safeParse`, so an
+ * unmapped legacy id would already look "valid" by the time the loud
+ * invalid-value warning path could fire.
+ */
+export function parseClaudeAgentModel(raw: unknown): ClaudeAgentModel {
+  if (raw === 'claude-fable-5') return 'claude-fable-5-1';
+  return parseClaudeAgentModelEnum(raw);
+}
 
 /** Claude Code CLI permission modes exposed in settings. */
 export const ClaudeAgentPermissionModeSchema = z.enum([

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -1277,7 +1277,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     category: 'ai-agents',
     slots: sameSlot('workspaceState'),
     honoredBy: CLAUDE_AGENT_HONORED_BY,
-    enumLabels: ['Sonnet 5', 'Fable 5', 'Opus 5', 'Haiku 4.5'],
+    enumLabels: ['Sonnet 5', 'Fable 5.1', 'Opus 5', 'Haiku 4.5'],
     surfaces: { settingsView: 'approval', cliConfig: true },
   }),
   surfacedSetting({

--- a/src/test-kernel/schemas/SharedSchemas.vitest.ts
+++ b/src/test-kernel/schemas/SharedSchemas.vitest.ts
@@ -40,6 +40,10 @@ describe('parseClaudeAgentModel', () => {
   it('defaults invalid persisted selections to Sonnet', () => {
     expect(parseClaudeAgentModel('claude-opus-3')).toBe('claude-sonnet-5');
   });
+
+  it('maps a persisted claude-fable-5 selection forward to its 5.1 successor', () => {
+    expect(parseClaudeAgentModel('claude-fable-5')).toBe('claude-fable-5-1');
+  });
 });
 
 describe('MainView housekeeping messages', () => {

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -383,7 +383,7 @@ describe('state settings catalog', () => {
     ]);
     assert.deepEqual(labelsFor(WorkspaceStateKey.CLAUDE_AGENT_MODEL), [
       'claude-sonnet-5 — Sonnet 5',
-      'claude-fable-5 — Fable 5',
+      'claude-fable-5-1 — Fable 5.1',
       'claude-opus-5 — Opus 5',
       'claude-haiku-4-5-20251001 — Haiku 4.5',
     ]);

--- a/src/test-kernel/tools/ClaudeAgentSchema.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentSchema.vitest.ts
@@ -11,7 +11,7 @@ describe('ClaudeAgentTool schema', () => {
     const modelDescription = parameters?.properties?.model?.description ?? '';
 
     expect(modelDescription).toContain('claude-sonnet-5');
-    expect(modelDescription).toContain('claude-fable-5');
+    expect(modelDescription).toContain('claude-fable-5-1');
     expect(modelDescription).toContain('claude-opus-5');
     expect(modelDescription).not.toContain('claude-opus-4-8');
   });

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -115,7 +115,7 @@ const ClaudeAgentInputSchema = z
       .string()
       .nullish()
       .describe(
-        "Claude model to use (e.g. 'claude-sonnet-5', 'claude-fable-5', 'claude-opus-5'). Defaults to user-configured model.",
+        "Claude model to use (e.g. 'claude-sonnet-5', 'claude-fable-5-1', 'claude-opus-5'). Defaults to user-configured model.",
       ),
     effort: ClaudeAgentEffortSchema.nullish().describe(
       'Reasoning depth hint passed to the SDK (defaults to user-configured effort, typically high).',


### PR DESCRIPTION
## Summary

- Swaps the "Claude Code" agent tool's selectable/default model from `claude-fable-5` to `claude-fable-5-1` in `ClaudeAgentModelSchema` (`agentCliSettings.ts`), the matching settings label (`stateSettings.ts`), the tool's input-schema example (`claudeAgent.ts`), and the settings doc table (`docs/guide/agent-integrations.md`).
- `anthropicThinking.ts` / `claudeAgentShared.ts` already match Fable/Mythos models by family prefix (`claude-fable-`, `claude-mythos-`), so the adaptive-thinking and compaction-eligibility logic needs no change — verified by the existing `AnthropicThinking.vitest.ts` suite, which already exercises a synthetic future model (`claude-fable-6`).
- Updated the two tests pinned to the old model id/label (`ClaudeAgentSchema.vitest.ts`, `stateSettings.vitest.ts`).

**Out of scope:** the main model picker (`PREFERRED_DEFAULT_MODELS` in `src/model/modelOptionsBasic.ts`) is backed by the `llm-zoo` npm package, which now has `fable51`/`mythos51` on [texra-ai/llm-zoo#56](https://github.com/texra-ai/llm-zoo/pull/56) but hasn't been published yet. Swapping `fable5` → `fable51` there has to wait until that version is actually released — doing it now would leave `MODEL_CONFIGS['fable51']` resolving to `undefined` against the currently-installed 1.31.0, which `ModelOptionsBasic.vitest.ts` explicitly guards against.

## Test plan

- [x] `npm run typecheck:workspace`
- [x] `npm run typecheck:test-kernel`
- [x] `npx vitest run` on the touched suites (`ClaudeAgentSchema`, `stateSettings`, `AnthropicThinking`, `ModelOptionsBasic`, `ModelListRefresh`) — 81 passed
- [x] `eslint` on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EMgA7FGGLofRbPqrtFdTQ