### PR TITLE
Bump llm-zoo to 1.32.0, default to Claude Fable 5.1

### DIFF
--- a/docs/.vitepress/components/CliModelsHero.vue
+++ b/docs/.vitepress/components/CliModelsHero.vue
@@ -13,7 +13,7 @@
 //
 // Built on <TermWindow>; .mockup-scoped and token-only. Static strings.
 const rows = [
-  { id: 'fable5', label: 'Claude Fable 5', status: 'api key set' },
+  { id: 'fable51', label: 'Claude Fable 5.1', status: 'api key set' },
   { id: 'opus5T', label: 'Opus 5 (Thinking)', status: 'api key set' },
   {
     id: 'sonnet5T',
@@ -48,11 +48,11 @@ const rows = [
       <!-- Beat 2: one model's details -->
       <div class="mk-term-prompt cmo-show">
         <span class="mk-term-sigil">$</span>
-        <span class="mk-term-cmd">texra models show fable5</span>
+        <span class="mk-term-cmd">texra models show fable51</span>
       </div>
       <div class="cmo-details">
-        <div><span class="cmo-k">id:</span> fable5</div>
-        <div><span class="cmo-k">label:</span> Claude Fable 5</div>
+        <div><span class="cmo-k">id:</span> fable51</div>
+        <div><span class="cmo-k">label:</span> Claude Fable 5.1</div>
         <div><span class="cmo-k">provider:</span> anthropic</div>
         <div><span class="cmo-k">status:</span> api key set</div>
       </div>

--- a/docs/.vitepress/components/ModelChoiceMatrix.vue
+++ b/docs/.vitepress/components/ModelChoiceMatrix.vue
@@ -18,7 +18,7 @@ const rows = [
     icon: 'chart-line',
     use: 'Complex tasks',
     note: 'Powerful flagship models',
-    models: ['fable5', 'opus5', 'gpt56', 'gemini31p'],
+    models: ['fable51', 'opus5', 'gpt56', 'gemini31p'],
   },
   {
     icon: 'code',
@@ -30,13 +30,13 @@ const rows = [
     icon: 'sparkle',
     use: 'Reasoning-heavy',
     note: 'Thinking models',
-    models: ['fable5', 'opus5T', 'sonnet5T', 'deepseekT', 'kimi3'],
+    models: ['fable51', 'opus5T', 'sonnet5T', 'deepseekT', 'kimi3'],
   },
   {
     icon: 'file-lines',
     use: 'Large documents',
     note: 'High-context models',
-    models: ['gemini31p', 'fable5', 'sonnet5', 'opus5'],
+    models: ['gemini31p', 'fable51', 'sonnet5', 'opus5'],
   },
 ];
 </script>

--- a/docs/.vitepress/components/ModelTierMatrixCard.vue
+++ b/docs/.vitepress/components/ModelTierMatrixCard.vue
@@ -23,13 +23,13 @@ const tiers = [
     icon: 'sparkle',
     kind: 'Complex',
     cue: 'Transformations, rewrites',
-    models: ['fable5', 'opus5T', 'gpt56', 'gemini31p'],
+    models: ['fable51', 'opus5T', 'gpt56', 'gemini31p'],
   },
   {
     icon: 'lightbulb',
     kind: 'Reasoning-heavy',
     cue: 'Deep, multi-step thinking',
-    models: ['fable5', 'sonnet5T', 'opus5T', 'deepseekT'],
+    models: ['fable51', 'sonnet5T', 'opus5T', 'deepseekT'],
   },
 ];
 </script>

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -23,7 +23,7 @@ TeXRA supports models from multiple providers, so you can pick the strongest rea
 
 | Model ID   | Use Case                                  | Cost | Speed  |
 | :--------- | :---------------------------------------- | :--- | :----- |
-| `fable5`   | Most capable, always-on adaptive thinking | $$$$ | Slow   |
+| `fable51`  | Most capable, always-on adaptive thinking | $$$$ | Slow   |
 | `opus5T`   | Top-tier reasoning, long-horizon work     | $$$$ | Slow   |
 | `opus5`    | Most capable for agentic coding           | $$$$ | Slow   |
 | `sonnet5T` | All-rounder with reasoning                | $$$  | Medium |
@@ -31,10 +31,10 @@ TeXRA supports models from multiple providers, so you can pick the strongest rea
 | `haiku45T` | Fast with reasoning                       | $$   | Fast   |
 | `haiku45`  | Fast responses                            | $$   | Fast   |
 
-Fable 5, Opus 5, and Sonnet 5 (and the older Opus 4.6 to 4.8 and Sonnet 4.6) include the full 1M context window at standard pricing, with no opt-in or
+Fable 5.1, Opus 5, and Sonnet 5 (and the older Opus 4.6 to 4.8 and Sonnet 4.6) include the full 1M context window at standard pricing, with no opt-in or
 beta header required. Haiku 4.5, Opus 4.5, and Sonnet 4.5 use a 200K context window.
 
-Claude Fable 5 (`fable5`) is Anthropic's most capable model. Thinking is always on (adaptive, with summarized reasoning), so there is no separate `T` variant. It supports the full reasoning-effort range up to Extra High and the top Max tier, and is eligible for context compaction in tool-use mode.
+Claude Fable 5.1 (`fable51`) is Anthropic's most capable model. Thinking is always on (adaptive, with summarized reasoning), so there is no separate `T` variant. It supports the full reasoning-effort range up to Extra High and the top Max tier, and is eligible for context compaction in tool-use mode.
 
 Claude Opus 5 uses adaptive thinking only (extended thinking with a manual `budget_tokens` is no longer accepted). TeXRA's reasoning-effort selector maps to Anthropic's effort levels automatically: pick `opus5T` with Extra High (or the top Max tier) effort for the strongest agentic coding and long-horizon tasks. Opus 5 also supports high-resolution images for better figure, chart, and screenshot understanding. TeXRA downscales images above `texra.maxImageDimension` (default 2000px) before sending, so raise that setting to send higher-resolution figures.
 

--- a/docs/guide/working-with-figures.md
+++ b/docs/guide/working-with-figures.md
@@ -162,7 +162,7 @@ Retrieves BibTeX records for every citation key found in the document.
 
 When you provide media files, they are handed to the model according to its capabilities:
 
-- **Vision models** (GPT-5.6, Claude Fable 5 / Opus 5 / Sonnet 5, Gemini 3.1 Pro, …): images are encoded and attached to the prompt.
+- **Vision models** (GPT-5.6, Claude Fable 5.1 / Opus 5 / Sonnet 5, Gemini 3.1 Pro, …): images are encoded and attached to the prompt.
 - **Audio models**: audio files are uploaded for transcription.
 - **Non-multimodal models**: only filenames are passed as context.
 

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "katex": "^0.18.4",
     "ky": "^2.1.0",
     "lit": "^3.3.3",
-    "llm-zoo": "^1.31.0",
+    "llm-zoo": "^1.32.0",
     "lru-cache": "^11.5.2",
     "markdown-it": "^15.0.1",
     "markdown-it-texmath": "^1.0.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -77,7 +77,7 @@
     "is-network-error": "^1.3.2",
     "is-wsl": "^3.1.1",
     "ky": "^2.1.0",
-    "llm-zoo": "^1.31.0",
+    "llm-zoo": "^1.32.0",
     "lru-cache": "^11.5.2",
     "mime-types": "^3.0.1",
     "nanoid": "^6.0.1",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1085,7 +1085,7 @@
     "identifiers-arxiv": "^0.1.1",
     "katex": "^0.18.4",
     "lit": "^3.3.3",
-    "llm-zoo": "^1.31.0",
+    "llm-zoo": "^1.32.0",
     "lru-cache": "^11.5.2",
     "markdown-it": "^15.0.1",
     "markdown-it-texmath": "^1.0.0",

--- a/packages/trace-viewer/package.json
+++ b/packages/trace-viewer/package.json
@@ -23,7 +23,7 @@
     "highlightjs-lean": "^1.2.0",
     "katex": "^0.18.4",
     "lit": "^3.3.3",
-    "llm-zoo": "^1.31.0",
+    "llm-zoo": "^1.32.0",
     "lru-cache": "^11.5.2",
     "markdown-it": "^15.0.1",
     "markdown-it-texmath": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,8 +154,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       llm-zoo:
-        specifier: ^1.31.0
-        version: 1.31.0(zod@4.4.3)
+        specifier: ^1.32.0
+        version: 1.32.0(zod@4.4.3)
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2
@@ -5083,6 +5083,15 @@ packages:
 
   llm-zoo@1.31.0:
     resolution: {integrity: sha512-dYAuFBgFN7bw1B12su1XyUFwSM13loI1Np1HKjS9YNVYiu8dV2lHia7C63MwZrZZkMVnDhIfjUspRcNB0vHfJA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  llm-zoo@1.32.0:
+    resolution: {integrity: sha512-vogZ+DWYtLFhRGtUpg762w/VukhhhwtlG7feeLfnv64x14jGtYV8vWk9PIeeawMDimbcZPK0xSGmbK20Us2YZg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
@@ -11066,6 +11075,10 @@ snapshots:
       lit-html: 3.3.2
 
   llm-zoo@1.31.0(zod@4.4.3):
+    optionalDependencies:
+      zod: 4.4.3
+
+  llm-zoo@1.32.0(zod@4.4.3):
     optionalDependencies:
       zod: 4.4.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -503,8 +503,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       llm-zoo:
-        specifier: ^1.31.0
-        version: 1.31.0(zod@4.4.3)
+        specifier: ^1.32.0
+        version: 1.32.0(zod@4.4.3)
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2
@@ -872,8 +872,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       llm-zoo:
-        specifier: ^1.31.0
-        version: 1.31.0(zod@4.4.3)
+        specifier: ^1.32.0
+        version: 1.32.0(zod@4.4.3)
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2
@@ -1074,8 +1074,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       llm-zoo:
-        specifier: ^1.31.0
-        version: 1.31.0(zod@4.4.3)
+        specifier: ^1.32.0
+        version: 1.32.0(zod@4.4.3)
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2
@@ -5080,15 +5080,6 @@ packages:
 
   lit@3.3.3:
     resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
-
-  llm-zoo@1.31.0:
-    resolution: {integrity: sha512-dYAuFBgFN7bw1B12su1XyUFwSM13loI1Np1HKjS9YNVYiu8dV2lHia7C63MwZrZZkMVnDhIfjUspRcNB0vHfJA==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      zod: ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   llm-zoo@1.32.0:
     resolution: {integrity: sha512-vogZ+DWYtLFhRGtUpg762w/VukhhhwtlG7feeLfnv64x14jGtYV8vWk9PIeeawMDimbcZPK0xSGmbK20Us2YZg==}
@@ -11073,10 +11064,6 @@ snapshots:
       '@lit/reactive-element': 2.1.2
       lit-element: 4.2.2
       lit-html: 3.3.2
-
-  llm-zoo@1.31.0(zod@4.4.3):
-    optionalDependencies:
-      zod: 4.4.3
 
   llm-zoo@1.32.0(zod@4.4.3):
     optionalDependencies:

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -38,7 +38,7 @@ export const PREFERRED_DEFAULT_MODELS: readonly string[] = [
   // Do not lead with Gemini — Sonnet is the quality default.
   'sonnet5T',
   'opus5T',
-  'fable5',
+  'fable51',
   'gpt56',
   'gpt56-',
   'gpt56--',


### PR DESCRIPTION
## Summary

Follow-up to #11743, which scoped this out because `llm-zoo` hadn't published the version with `fable51`/`mythos51` yet. It has now (`llm-zoo@1.32.0`, live on npm).

- Bumps the `llm-zoo` dependency from `^1.31.0` to `^1.32.0` in every workspace importer that declares it: the root `package.json`, plus `packages/agent`, `packages/extension`, and `packages/trace-viewer` (each declares its own copy; `packages/agent` in particular bundles with esbuild's `packages: 'external'`, so it resolves `llm-zoo` from its own dependency at runtime, not the workspace root's).
- Swaps `fable5` → `fable51` in `PREFERRED_DEFAULT_MODELS` (`src/model/modelOptionsBasic.ts`) — `fable5` is now `deprecated: true` in the registry, so `resolveDefaultModels` would drop it from `DEFAULT_MODELS` anyway; this replaces it with its drop-in successor instead of just losing the Fable entry from the default set.
- Updates `docs/guide/models.md`, `docs/guide/working-with-figures.md`, and the three VitePress mockup components (`ModelChoiceMatrix`, `CliModelsHero`, `ModelTierMatrixCard`) that hardcoded `fable5` in their sample data, so the rendered guides stop recommending the deprecated id.
- `MODEL_LIST_VERSION` recomputes automatically from `PREFERRED_DEFAULT_MODELS`'s content, so existing installs pick up the swap via the existing reconciliation mechanism — no manual version bump needed. **Note:** for a user who already has `fable5` enabled, this is additive, not a clean replace — `reconcileEnabledModels` only force-removes *retired* models, and `fable5` is deprecated, not retired, so they'll gain `fable51` as a new default while `fable5` stays in their list as a still-servable, non-default extra. That matches the deprecated-vs-retired design elsewhere in the codebase.

## Test plan

- [x] `npm run typecheck:workspace`
- [x] `npm run typecheck:test-kernel`
- [x] `npm run typecheck:cli`
- [x] `pnpm --filter @texra-ai/agent build`
- [x] `npx vitest run` on `ModelOptionsBasic`, `ModelListRefresh`, `AnthropicThinking` — 49 passed
- [x] `eslint` on the touched files
- [x] Confirmed `fable51`/`mythos51` resolve in the installed `llm-zoo@1.32.0` (`MODEL_CONFIGS`)
- [x] `git diff pnpm-lock.yaml` — all four importers resolve `1.32.0`, no unrelated transitive churn, the unused `1.31.0` package entry dropped cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EMgA7FGGLofRbPqrtFdTQ