### PR TITLE
fix(memory): preserve canonical path errors

### DIFF
--- a/src/test-kernel/tools/MemoryTool.vitest.ts
+++ b/src/test-kernel/tools/MemoryTool.vitest.ts
@@ -116,6 +116,25 @@ describe('MemoryTool view with an omitted path', () => {
     });
   });
 
+  it.each([
+    [
+      '/outside.md',
+      'Invalid path "/outside.md". All memory paths must start with /memories',
+    ],
+    ['/memories/../outside.md', 'Invalid memory path: /memories/../outside.md'],
+  ])(
+    'preserves the path validator error for %s',
+    async (inputPath, message) => {
+      const result = await viewMemory(inputPath);
+
+      expect(result).toMatchObject({
+        status: 'error',
+        error: expect.stringContaining(message),
+        diagnostics: { name: 'ToolError' },
+      });
+    },
+  );
+
   it('preserves the model-facing directory listing bytes and depth limit', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-02T00:00:00.000Z'));

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -18,6 +18,7 @@ import {
   walkMemoryDirectory,
 } from '@tools/memory/memoryFileSystem';
 import { executed } from '@tools/core/result';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import { StorageFS } from '@utils/files/storageFS';
 import { isDirectory } from '@utils/files/fsEntryType';
 import {
@@ -237,10 +238,8 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
   private resolveMemoryPath(inputPath: string): string {
     try {
       return displayToStoragePath(inputPath);
-    } catch {
-      throw new ToolError(
-        `Invalid path "${inputPath}". All memory paths must start with /memories (e.g., /memories or /memories/notes.md).`,
-      );
+    } catch (error) {
+      throw new ToolError(toErrorMessage(error), { cause: error });
     }
   }
 


### PR DESCRIPTION
## What

- preserve the path validator’s canonical diagnostic at the memory-tool boundary
- keep failures classified as `ToolError`
- cover wrong-root and traversal inputs through the model-facing tool call

The proposed concurrency-limiter consolidation from #11742 is intentionally not implemented. The existing `pMapIterable` bound provides producer backpressure, while the shared `PQueue` caps filesystem work across recursive levels. Replacing both with custom scheduling would add complexity and risk rather than remove duplication.

Closes #11742

## Validation

- `pnpm exec vitest run src/test-kernel/tools/MemoryTool.vitest.ts src/test-kernel/cli/CliMemory.vitest.ts` (17 passed)
- `pnpm run typecheck:workspace`
- `pnpm run typecheck:test-kernel`
- `git diff --check`