### PR TITLE
ci(issue-tracker): raise the bar for post-merge follow-up issues

### DIFF
--- a/.github/prompts/issue-tracker-prompt.md
+++ b/.github/prompts/issue-tracker-prompt.md
@@ -44,67 +44,101 @@ B2: scan for follow-ups.
 2. Get the code diff with `git diff <base-sha>..<head-sha>`.
 3. Search the diff for new TODO, FIXME, HACK, XXX, and WORKAROUND markers.
 
-Identify actionable follow-ups. Prioritize human reviewer suggestions: comments
-from real people, not bots, carry the most weight. Bot accounts typically have
-`[bot]` in their username or are known services such as Dependabot, Renovate,
-Copilot, Cursor, and Codex.
+The expected outcome of B2 is **no issue**. Most merged pull requests produce
+zero follow-ups; roughly one in ten should produce one. The maintainer has
+found that this step over-files: it turns unaddressed review nits into
+permanent open issues whose fixes add branches, guards, compatibility paths,
+and abstractions for cases that almost never happen. Err toward silence.
 
-Look for:
+### What qualifies
 
-- Human reviewer feedback that was acknowledged but deferred.
-- Explicit deferred scope, such as "out of scope", "follow-up", "separate PR",
-  "later", or "Phase 2".
-- New TODO, FIXME, HACK, XXX, or WORKAROUND comments in the diff.
-- Unresolved review threads or open questions.
-- Roadmap implications for tracked work.
+File a follow-up only from one of these three sources. Anything else is not a
+follow-up, however well-argued it looks.
 
-Do not create issues for:
+1. **A human explicitly deferred it.** The PR author or a human reviewer, in
+   the PR body, a comment, or a review thread, said the work is wanted but
+   belongs in a separate PR: "out of scope", "follow-up", "separate PR",
+   "later", "Phase 2", or an equivalent. Humans are accounts without `[bot]`
+   in the username that are not Dependabot, Renovate, Copilot, Cursor, Codex,
+   `texra-ai`, or `claude`. A human paraphrasing or acknowledging a bot's
+   finding counts only if the human also said it should be done.
+2. **A human reviewer asked for a change that did not land.** The review
+   thread is unresolved, or was resolved without the requested change, and
+   the request is a concrete code change, not a question or a "worth a look".
+3. **A user-visible defect on the ordinary path.** A reviewer finding (human
+   or bot) or a new `TODO`/`FIXME`/`HACK`/`XXX`/`WORKAROUND` marker describes
+   a bug that a user of a shipped host hits in ordinary use, and you can
+   write down the triggering scenario in one sentence without the words
+   "legacy", "pre-existing data", "if a future change", "in theory", "race",
+   "another window", or "malformed". If the scenario needs any of those,
+   it is not ordinary use; skip it.
 
-- Work already completed in this pull request.
+A bot review finding that the author saw and merged past is presumed
+dismissed. The merge is the decision. Do not re-file it under source 3 unless
+the one-sentence scenario test above passes cleanly.
+
+### The complexity rule
+
+Before filing anything that passes the sources above, estimate the fix. Skip
+the finding when the fix would add code to handle a case that rarely or
+never occurs: a new branch, guard, fallback, flag, schema field, wrapper,
+helper, compatibility reader, or abstraction whose only justification is the
+rare case. A low-probability problem whose cure makes the mainline code more
+complex is not worth an issue; the maintainer would rather carry the
+theoretical gap than the permanent code. This rule applies even when the
+finding is technically correct.
+
+Concretely, never file:
+
+- Work already completed in this pull request, or in any PR merged since.
+- Handling for legacy or pre-migration persisted data shapes, records written
+  by older versions, or markers that older writers did not emit.
+- Cross-version, cross-window, or cross-host tolerance for states current
+  builds do not produce.
+- Races that require an interleaving nobody has observed.
+- Tolerance for malformed, unreadable, or hand-edited storage.
 - Pre-existing TODOs not introduced by this pull request.
-- Nitpick-level comments.
+- Nitpick-level comments and style preferences.
 - Speculative future work not discussed in the pull request.
-- Bot suggestions already addressed or dismissed.
+- Refactor suggestions: "unify X and Y", "relocate Z to its only consumer",
+  "collapse the projection layer", "investigate whether W is still needed".
+  These are proposals, not defects; if a human wants one, they will file it.
+- Editor, linter, or IDE configuration nits (a deprecated settings key, a
+  `$schema` URL that could be pinned, an inert option).
+- Wording, precision, or clarity fixes to docs, changelogs, code comments, or
+  JSDoc, including bot-flagged "this claim is imprecise" findings and stale
+  references to renamed symbols. File one only if the doc is normative and
+  the imprecision would visibly mislead an implementer building against it;
+  state which implementation decision would go wrong.
 - Test-coverage suggestions ("add tests for X", "increase coverage", missing
   test remarks from reviewers or bots). This repository deliberately keeps its
   test surface small because internal interfaces break often. See `AGENTS.md`
-  "Testing discipline". The post-merge filing bar here is intentionally
-  stricter than that policy's review-time bar: a missing test is the _default_,
-  expected state of a merged PR, not a gap. File a test follow-up only when
-  **both**: (a) the gap is a reproduced, user-visible defect (not a refactor,
-  comment, or doc fix) that shipped without a regression test, and (b) the PR
-  body or a reviewer explicitly weighed adding that test and chose not to for
-  a stated reason. "The fix works but nobody happened to write a test" is not
-  sufficient by itself. That describes most merged PRs in this repo by design
-  and is not follow-up-worthy on its own.
-- Wording, precision, or clarity fixes to internal docs (proposals, PRDs,
-  ADRs, planning docs) that change no code and no user-facing behavior —
-  including bot-flagged "this claim is imprecise" or "this section is
-  ambiguous" findings. File one only if the doc is normative and the
-  imprecision would visibly mislead an implementer building against it (state
-  which implementation decision would go wrong); otherwise skip.
-- Stale in-code comments or JSDoc that reference a renamed or deleted symbol
-  but do not misdescribe current runtime behavior in a way that could cause a
-  future bug. Leave these for an incidental cleanup rather than creating a
-  standing issue.
-- A finding whose only proposed action is itself "file more issues" or
-  "survey X and open tickets" — meta-tracking work that adds process overhead
-  without doing anything. Either do the survey now and file the results
-  directly, or skip it.
-- A finding that only asks someone to manually look at or visually confirm
-  something ("verify X still renders correctly", "confirm Y looks right")
-  with no concrete code change attached. These have no actionable owner and
-  rot forever unaddressed; if a real regression shows up later, it will be
-  reported on its own.
+  "Testing discipline". A missing test is the _default_, expected state of a
+  merged PR, not a gap. File a test follow-up only when **both**: (a) the gap
+  is a reproduced, user-visible defect that shipped without a regression
+  test, and (b) the PR body or a human reviewer explicitly weighed adding that
+  test and chose not to for a stated reason.
+- "Once X is published/released/merged, bump Y" reminders. Dependency bumps
+  and version swaps happen on their own schedule and are usually done within
+  a day; an issue for them is noise.
+- A finding whose only proposed action is itself "file more issues",
+  "survey X", or "record a ruling", or that only asks someone to manually
+  look at or visually confirm something with no concrete code change
+  attached.
+- Roadmap or tracking implications. Update existing tracking checklists in
+  B1; do not create new work from them.
+
+### Final test and cap
 
 Apply a one-line test before filing anything: if you described this finding
 to the maintainer in a single sentence, would they say "yes, file that" or
 "meh, don't bother"? If you cannot confidently predict "yes", skip it. A repo
 where every unaddressed nitpick becomes a permanent open issue is worse than
-one that occasionally lets a nitpick go unfiled — err toward silence.
+one that occasionally lets a nitpick go unfiled.
 
-When several related findings from the same review each pass the filing bar,
-prefer folding them into one coherent issue over filing one issue per finding.
+File at most **one** issue per merged pull request unless two findings come
+from different sources above and touch unrelated code. When several related
+findings pass the bar, fold them into one coherent issue.
 
 For each genuine follow-up, create an issue with:
 

--- a/.github/prompts/issue-tracker-prompt.md
+++ b/.github/prompts/issue-tracker-prompt.md
@@ -88,6 +88,35 @@ complex is not worth an issue; the maintainer would rather carry the
 theoretical gap than the permanent code. This rule applies even when the
 finding is technically correct.
 
+### Doomed areas and local minima
+
+A fix can be common, correct, and still wrong to file, because it patches a
+design the repository is already leaving. Two checks before filing:
+
+1. **Is the area doomed?** Look for signals that the code the finding touches
+   is slated for removal, replacement, or retirement: a `docs/proposals/` or
+   `docs/architecture/` document that names the area as being deleted or
+   superseded; an open `tracking` issue scheduling its removal; comments
+   such as "delete after", "compatibility window", "retire", "legacy", or a
+   dated tolerance; an `attic/` move; or a PR body that calls the area a
+   transitional shape. When the area is doomed, do not file a fix for it.
+   The fix dies with the area, and until then it only makes the removal
+   harder. If the finding is a real user-visible defect, mention it as a
+   comment on the tracking issue that schedules the removal instead.
+2. **Is the proposed fix a local minimum?** Ask what the right long-term
+   shape is. If the durable answer is structural (delete the seam, keep one
+   authority, drop the compatibility path, collapse two copies into one) and
+   the finding proposes a local patch instead (another guard, a second code
+   path, a special case, a wait-for-release, a parallel wiring for one more
+   host), do not file the local patch. Filing it entrenches the design and
+   invites the next patch. When the structural change is already tracked,
+   do nothing; when it is not, skip unless a human asked for it, and never
+   turn a bot's local patch into a structural proposal on your own.
+
+The pattern to avoid is the sequence "tolerate the old shape, then guard the
+guard, then wire the guard into a third host". Each step is locally
+reasonable and the sum is a codebase that cannot delete anything.
+
 Concretely, never file:
 
 - Work already completed in this pull request, or in any PR merged since.


### PR DESCRIPTION
The tracker's B2 scan has been filing low-value follow-ups: bot review
findings the author already merged past, legacy-data edge cases, editor
config nits, changelog wording, and refactor proposals. Their fixes add
guards, compatibility paths, and abstractions for cases that almost never
occur, and several were closed the same day by a PR that had already
done the work.

Replace the open-ended trigger list with three narrow sources (human
deferred it, human reviewer asked and it did not land, user-visible
defect on the ordinary path), add an explicit complexity rule that
skips findings whose fix only exists to serve a rare case, treat a bot
finding the author merged past as dismissed, and cap output at one
issue per merged PR.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P51ksnMGYGHRoEhamjTCL8