### PR TITLE
fix: make Windows kernel paths portable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Extension (VS Code)
+
+#### Bug Fixes
+
+- **Archive custom-agent output on Windows** — packing generated files into the
+  History folder now works for custom agents.
+
 ## [0.40.7] - 2026-08-31
 
 ### Shared (all surfaces)

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -78,12 +78,13 @@ export async function runPackSingle(
 
   log.debug(buildFileListLog(movedFiles, copiedFiles));
 
+  const cleanAgent = getCleanAgentName(agent);
   const resolvedOutputFolder =
     outputFolder ||
     path.join(
       inputDir,
       HISTORY_DIR,
-      `${generateTimestamp()}_${baseName}_${agent}_${model}`,
+      `${generateTimestamp()}_${baseName}_${cleanAgent}_${model}`,
     );
   log.debug(`Output folder: ${resolvedOutputFolder}`);
 
@@ -125,10 +126,11 @@ export async function runPackMultiple(
 
   const baseName = path.parse(inputFile).name;
   const outputDir = path.dirname(inputFile);
+  const cleanAgent = getCleanAgentName(agent);
   const commonOutputFolder = path.join(
     outputDir,
     HISTORY_DIR,
-    `${generateTimestamp()}_${baseName}_multiple_${agent}_${model}`,
+    `${generateTimestamp()}_${baseName}_multiple_${cleanAgent}_${model}`,
   );
   log.debug(`Common output folder: ${commonOutputFolder}`);
 

--- a/src/test-kernel/agent/prompt/userVars.vitest.ts
+++ b/src/test-kernel/agent/prompt/userVars.vitest.ts
@@ -1,3 +1,5 @@
+import * as path from 'node:path';
+
 import {
   afterEach,
   beforeEach,
@@ -401,13 +403,15 @@ describe('buildUserVars with missing configured files', () => {
 });
 
 describe('requiredFilesInternal custom variables', () => {
+  const briefPath = path.resolve('/agents/generic', 'brief.txt');
+
   beforeEach(async () => {
     const { initPlatform } = await import('@platform/platform');
 
     initPlatform(
       createFakePlatform({
         workspacePath: '/workspace',
-        files: { '/agents/generic/brief.txt': 'briefing notes' },
+        files: { [briefPath]: 'briefing notes' },
       }),
     );
   });
@@ -444,7 +448,7 @@ describe('requiredFilesInternal custom variables', () => {
       { BRIEF: 'brief.txt' },
     );
 
-    expect(vars['BRIEF_FILE']).toBe('/agents/generic/brief.txt');
+    expect(vars['BRIEF_FILE']).toBe(briefPath);
     expect(vars['BRIEF_CONTENT']).toBe('briefing notes');
     // The fixed slots the collision guard protects keep their built values.
     expect(vars.MEDIA_FILE).toBeNull();

--- a/src/test-kernel/commands/LatexdiffRunPreparation.vitest.ts
+++ b/src/test-kernel/commands/LatexdiffRunPreparation.vitest.ts
@@ -1,3 +1,7 @@
+// Node imports
+import * as path from 'node:path';
+
+// Third-party imports
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -13,16 +17,7 @@ const mocks = vi.hoisted(() => ({
   info: vi.fn(),
   error: vi.fn(),
   checkToolInstalled: vi.fn(),
-  pathToLocation: vi.fn((absolutePath: string) => {
-    if (absolutePath.startsWith('/tmp/')) {
-      return { kind: 'external' as const, absolutePath };
-    }
-    return {
-      kind: 'workspace' as const,
-      absolutePath,
-      relativePath: 'paper.tex',
-    };
-  }),
+  pathToLocation: vi.fn(),
   openTextDocument: vi.fn(async (uri: unknown) => ({ uri })),
   showTextDocument: vi.fn(async () => undefined),
   showQuickPick: vi.fn(),
@@ -148,9 +143,11 @@ vi.mock('vscode', () => ({
 
 import { registerLatexdiffCommands } from '@commands/latex/latexdiffCommands';
 
+const workspaceDiffPath = path.join('/workspace', 'diff-1.tex');
+const externalDiffPath = path.join('/tmp', 'diff-2.tex');
 const mixedResults = [
-  { success: true, diffPath: '/workspace/diff-1.tex' },
-  { success: true, diffPath: '/tmp/diff-2.tex' },
+  { success: true, diffPath: workspaceDiffPath },
+  { success: true, diffPath: externalDiffPath },
 ];
 
 const runConfig = {
@@ -164,6 +161,15 @@ describe('texra.runLatexdiff result preparation and final viewer delivery', () =
     vi.clearAllMocks();
     mocks.runLatexdiffHandler = undefined;
     mocks.exists.mockResolvedValue(true);
+    mocks.pathToLocation.mockImplementation((absolutePath: string) =>
+      absolutePath === externalDiffPath
+        ? { kind: 'external' as const, absolutePath }
+        : {
+            kind: 'workspace' as const,
+            absolutePath,
+            relativePath: 'paper.tex',
+          },
+    );
     mocks.prepareBuildDisplay.mockImplementation(async () => true);
     mocks.scheduleViewerDisplay.mockResolvedValue(true);
     mocks.showLoggedMessage.mockResolvedValue(undefined);
@@ -204,7 +210,7 @@ describe('texra.runLatexdiff result preparation and final viewer delivery', () =
     expect(mocks.prepareBuildDisplay).toHaveBeenCalledTimes(2);
     expect(mocks.scheduleViewerDisplay).toHaveBeenCalledTimes(1);
     expect(mocks.openTextDocument).toHaveBeenCalledWith(
-      expect.objectContaining({ fsPath: '/workspace/diff-1.tex' }),
+      expect.objectContaining({ fsPath: workspaceDiffPath }),
     );
     expect(mocks.showTextDocument).toHaveBeenCalledTimes(1);
   });
@@ -227,7 +233,7 @@ describe('texra.runLatexdiff result preparation and final viewer delivery', () =
   it('schedules the final viewer for the last prepared diff when a later setup rejects', async () => {
     mocks.prepareBuildDisplay.mockImplementation(
       async (location: { absolutePath: string }) => {
-        if (location.absolutePath === '/workspace/diff-1.tex') return true;
+        if (location.absolutePath === workspaceDiffPath) return true;
         throw new Error('second setup failed');
       },
     );
@@ -241,7 +247,7 @@ describe('texra.runLatexdiff result preparation and final viewer delivery', () =
     );
     expect(mocks.scheduleViewerDisplay).toHaveBeenCalledTimes(1);
     expect(mocks.openTextDocument).toHaveBeenCalledWith(
-      expect.objectContaining({ fsPath: '/workspace/diff-1.tex' }),
+      expect.objectContaining({ fsPath: workspaceDiffPath }),
     );
   });
 });

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -1,5 +1,6 @@
 // Node imports
 import { access } from 'node:fs/promises';
+import * as path from 'node:path';
 
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -427,7 +428,7 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
 
       async deleteDir(): Promise<void> {
         for (const key of kvStoreBacking.keys()) {
-          if (key.startsWith(`${this.dir}/`)) kvStoreBacking.delete(key);
+          if (key.startsWith(this.prefix())) kvStoreBacking.delete(key);
         }
       }
 
@@ -446,14 +447,18 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
         if (options.transcriptOpenGate && this.dir === STREAM_LOGS_DIR) {
           await options.transcriptOpenGate;
         }
-        const prefix = `${this.dir}/`;
+        const prefix = this.prefix();
         return [...kvStoreBacking.keys()]
           .filter((key) => key.startsWith(prefix))
           .map((key) => key.slice(prefix.length));
       }
 
+      private prefix(): string {
+        return `${this.dir.replaceAll('\\', '/')}/`;
+      }
+
       private key(key: string): string {
-        return `${this.dir}/${key}`;
+        return `${this.prefix()}${key}`;
       }
     },
   }));
@@ -1322,8 +1327,9 @@ describe('DesktopProgressBridge', () => {
       throw new Error('no external viewer');
     });
     const spillPath = 'executions/abcdef123456/toolOutput/tool.txt';
+    const spillFile = path.join('/workspace/.texra/storage', spillPath);
     const bridge = await createBridge(messages, {
-      files: { [`/workspace/.texra/storage/${spillPath}`]: 'spilled output' },
+      files: { [spillFile]: 'spilled output' },
       showErrorMessage,
       openPath,
     });
@@ -1338,9 +1344,7 @@ describe('DesktopProgressBridge', () => {
       spillPath,
     });
 
-    expect(openPath).toHaveBeenCalledWith(
-      `/workspace/.texra/storage/${spillPath}`,
-    );
+    expect(openPath).toHaveBeenCalledWith(spillFile);
     expect(showErrorMessage).not.toHaveBeenCalled();
   });
 

--- a/src/test-kernel/shared/LegacyWorkflowOutput.vitest.ts
+++ b/src/test-kernel/shared/LegacyWorkflowOutput.vitest.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // Local imports
 import { runCleanMultiple, runCleanSingle } from '@housekeeping/clean';
-import { runPackMultiple } from '@housekeeping/pack';
+import { runPackMultiple, runPackSingle } from '@housekeeping/pack';
 import {
   findFilesFromPatterns,
   resolveHousekeepingTargets,
@@ -133,6 +133,29 @@ describe('filename-era workflow output grammar', () => {
     }
   });
 
+  it('packs a source-qualified agent into a filesystem-safe folder', async () => {
+    const outputRelativePath = 'paper_polish_r0_gpt-4.tex';
+    await writeFile(path.join(workspacePath, 'paper.tex'), 'source');
+    await writeFile(
+      path.join(workspacePath, outputRelativePath),
+      'generated output',
+    );
+
+    const result = await runPackSingle(
+      'gpt-4',
+      'paper.tex',
+      'custom:polish_long',
+    );
+
+    if (result.status !== 'success' || result.outputFolder === undefined) {
+      throw new Error(`Expected a successful pack, got ${result.status}`);
+    }
+    expect(path.basename(result.outputFolder)).not.toContain(':');
+    await expect(
+      access(path.join(workspacePath, result.outputFolder, outputRelativePath)),
+    ).resolves.toBeUndefined();
+  });
+
   it('packs a flat XML round output', async () => {
     const xmlRelativePath = 'paper_polish_r0_gpt-4.xml';
     await writeFile(path.join(workspacePath, 'paper.tex'), 'source');
@@ -149,6 +172,7 @@ describe('filename-era workflow output grammar', () => {
     if (result.status !== 'success' || result.outputFolder === undefined) {
       throw new Error(`Expected a successful pack, got ${result.status}`);
     }
+    expect(path.basename(result.outputFolder)).not.toContain(':');
     await expect(
       access(path.join(workspacePath, xmlRelativePath)),
     ).rejects.toMatchObject({ code: 'ENOENT' });


### PR DESCRIPTION
## What

- derive path-sensitive test fixtures with Node's platform path helpers
- make the desktop KV fake normalize only directory separators while preserving logical keys
- keep custom-agent archive folder names valid on Windows without changing workflow output matching
- retain source-qualified custom-agent coverage for single and multi-file packing

Closes #10995

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/commands/LatexdiffRunPreparation.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.ts src/test-kernel/shared/LegacyWorkflowOutput.vitest.ts src/test-kernel/agent/prompt/userVars.vitest.ts`
  - affected assertions pass; three unrelated pre-existing desktop merge-notification timing tests remain locally flaky
- relevant housekeeping suites: 13 passed
- `npm run typecheck:test-kernel`
- `npm run typecheck:workspace`
- `npm run lint`
- Prettier on changed files
- `git diff --check`

## Windows baseline

Workflow dispatch run [33569885097](https://github.com/LionSR/TeXRA/actions/runs/33569885097) reproduces the four current Windows failures fixed here. The older latexdiff path failures are recorded in run [32240694958](https://github.com/LionSR/TeXRA/actions/runs/32240694958).
