### PR TITLE
refactor(hosts): consolidate the message-host trio into one interface

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecutionHost.ts
+++ b/packages/desktop/src/main/desktopAgentExecutionHost.ts
@@ -1,14 +1,13 @@
 import type { MainViewExecutionLaunchHost } from '@controllers/mainView/backend/MainViewExecutionLaunchController';
 import type { TranscriptExportFormat } from '@controllers/progressView/exportTranscript';
-import type { DiffViewHost } from '@hosts/uiHosts';
+import type { DiffViewHost, MessageHost } from '@hosts/uiHosts';
 import type { InstructionAction } from '@shared/schemas';
 import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 
 /** Required desktop capabilities used throughout an agent execution. */
-export interface DesktopAgentExecutionHost extends MainViewExecutionLaunchHost {
-  showErrorMessage(message: string): Promise<void> | void;
-  showWarningMessage(message: string): Promise<void> | void;
-  showInfoMessage(message: string): Promise<void> | void;
+export interface DesktopAgentExecutionHost
+  extends MainViewExecutionLaunchHost,
+    MessageHost {
   /**
    * Presents an instruction (e.g. a missing API key) as an actionable
    * dialog: each token in `actions` becomes a button — dispatched to the

--- a/packages/desktop/src/main/desktopAgentExecutionHost.ts
+++ b/packages/desktop/src/main/desktopAgentExecutionHost.ts
@@ -6,8 +6,7 @@ import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 
 /** Required desktop capabilities used throughout an agent execution. */
 export interface DesktopAgentExecutionHost
-  extends MainViewExecutionLaunchHost,
-    MessageHost {
+  extends MainViewExecutionLaunchHost, MessageHost {
   /**
    * Presents an instruction (e.g. a missing API key) as an actionable
    * dialog: each token in `actions` becomes a button — dispatched to the

--- a/packages/desktop/src/main/desktopAgentSettingsController.ts
+++ b/packages/desktop/src/main/desktopAgentSettingsController.ts
@@ -23,6 +23,7 @@ import {
 } from '@controllers/settingsView/backend/templateAgentCreation';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
 import { applySettingsTeamRoster } from '@controllers/settingsView/SettingsTeamRosterController';
+import type { MessageHost } from '@hosts/uiHosts';
 import { MAIN_VIEW_COMMANDS, SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   agentKey,
@@ -109,10 +110,10 @@ interface DefaultDesktopAgentSettingsControllerOptions extends SettingsStatePort
     readonly canAccess: () => Promise<boolean>;
     readonly signIn: () => Promise<boolean>;
   };
-  readonly notifications: {
-    readonly showInfoMessage: (message: string) => Promise<void>;
-    readonly showErrorMessage: (message: string) => Promise<void>;
-  };
+  readonly notifications: Pick<
+    MessageHost,
+    'showInfoMessage' | 'showErrorMessage'
+  >;
 }
 
 export interface DesktopAgentSettingsController {

--- a/packages/desktop/src/main/desktopCredentialSettingsController.ts
+++ b/packages/desktop/src/main/desktopCredentialSettingsController.ts
@@ -11,7 +11,7 @@ import { SubscriptionUsageService } from '@controllers/modelAccess/subscriptionU
 import { SettingsProfileKeyController } from '@controllers/settingsView/SettingsProfileKeyController';
 import { SettingsProfileController } from '@controllers/settingsView/SettingsProfileController';
 import { SettingsModelSelectionController } from '@controllers/settingsView/SettingsModelSelectionController';
-import type { ExternalOpener, PromptHost } from '@hosts/uiHosts';
+import type { ExternalOpener, MessageHost, PromptHost } from '@hosts/uiHosts';
 import {
   computeModelOptionsData,
   getEnabledModels,
@@ -64,11 +64,7 @@ interface DesktopCredentialSettingsControllerOptions extends SettingsStatePorts 
       productName: string,
     ): void | Promise<void>;
   };
-  readonly notifications: {
-    showInfoMessage(message: string): Promise<void>;
-    showWarningMessage(message: string): Promise<void>;
-    showErrorMessage(message: string): Promise<void>;
-  };
+  readonly notifications: MessageHost;
   readonly auth: {
     signIn(): Promise<void>;
     signOut(): Promise<void>;
@@ -285,11 +281,11 @@ export class DefaultDesktopCredentialSettingsController implements DesktopCreden
     error: unknown,
   ): void {
     this.options.onError(error);
-    void this.options.notifications
-      .showErrorMessage(
+    void Promise.resolve(
+      this.options.notifications.showErrorMessage(
         `Failed to display ${displayName} sign-in instructions: ${toErrorMessage(error)}`,
-      )
-      .catch(this.options.onError);
+      ),
+    ).catch(this.options.onError);
   }
 
   private signInPresenter(displayName: string): SubscriptionSignInPresenter {

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -8,6 +8,7 @@ import {
   unsubscribeGitHubKey,
 } from '@controllers/settingsView/githubSubscriptions';
 import { appSignals } from '@eventBus/AppSignals';
+import type { MessageHost } from '@hosts/uiHosts';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import type { ConfigProvider } from '@platform/interfaces';
 import { platform } from '@platform/platform';
@@ -56,7 +57,8 @@ import type { DesktopAgentSettingsController } from './desktopAgentSettingsContr
 import type { DesktopCredentialSettingsController } from './desktopCredentialSettingsController.js';
 import type { DesktopToolingSettingsController } from './desktopToolingSettingsController.js';
 
-export interface DesktopSettingsUiHost {
+export interface DesktopSettingsUiHost
+  extends Pick<MessageHost, 'showInfoMessage' | 'showErrorMessage'> {
   openPath(filePath: string): Promise<void>;
   /**
    * Select the stream as the window's active stream. `'unavailable'` covers a
@@ -78,8 +80,6 @@ export interface DesktopSettingsUiHost {
     prompt: string;
   }): Promise<string | undefined>;
   openExternal(url: string): Promise<void>;
-  showInfoMessage(message: string): Promise<void>;
-  showErrorMessage(message: string): Promise<void>;
   confirmAction(message: string, confirmLabel?: string): Promise<boolean>;
   onError(error: unknown): void;
 }
@@ -122,7 +122,9 @@ export function createDesktopSettingsIpc(
   // Commands declared `unsupported(...)` in settingsHandlers below surface as
   // a visible info dialog instead of a console-only error log.
   const onError = createDesktopErrorReporter(options.ui.onError, (error) => {
-    void options.ui.showInfoMessage(error.reason).catch(options.ui.onError);
+    void Promise.resolve(options.ui.showInfoMessage(error.reason)).catch(
+      options.ui.onError,
+    );
   });
   const settingsHost = new SettingsViewHost({
     state: { workspaceState, globalState },
@@ -383,7 +385,9 @@ export function createDesktopSettingsIpc(
     // Marking a stored token as rejected would need a new status on the wire.
     appSignals.on('githubTokenInvalid', ({ message }) =>
       runAsync(
-        options.ui.showErrorMessage(gitHubTokenRejectedMessage(message)),
+        Promise.resolve(
+          options.ui.showErrorMessage(gitHubTokenRejectedMessage(message)),
+        ),
       ),
     ),
   );

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -57,8 +57,10 @@ import type { DesktopAgentSettingsController } from './desktopAgentSettingsContr
 import type { DesktopCredentialSettingsController } from './desktopCredentialSettingsController.js';
 import type { DesktopToolingSettingsController } from './desktopToolingSettingsController.js';
 
-export interface DesktopSettingsUiHost
-  extends Pick<MessageHost, 'showInfoMessage' | 'showErrorMessage'> {
+export interface DesktopSettingsUiHost extends Pick<
+  MessageHost,
+  'showInfoMessage' | 'showErrorMessage'
+> {
   openPath(filePath: string): Promise<void>;
   /**
    * Select the stream as the window's active stream. `'unavailable'` covers a

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -1,3 +1,4 @@
+import type { MessageHost } from '@hosts/uiHosts';
 import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import type {
   MainViewInboundMessage,
@@ -26,7 +27,8 @@ import {
   type DesktopCommandActions,
 } from '../shared/desktopCommandSurface.js';
 
-interface DesktopShellActionFactoryOptions {
+interface DesktopShellActionFactoryOptions
+  extends Pick<MessageHost, 'showInfoMessage'> {
   getCustomAgentDirectory(): Promise<string>;
   openExternalUrl(url: string): Promise<void>;
   openLogFolder(): Promise<void>;
@@ -42,7 +44,6 @@ interface DesktopShellActionFactoryOptions {
     commits: string[];
     isGitRepo: boolean;
   }>;
-  showInfoMessage(message: string): Promise<void> | void;
   onAsyncError?: (error: unknown) => void;
 }
 

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -27,8 +27,10 @@ import {
   type DesktopCommandActions,
 } from '../shared/desktopCommandSurface.js';
 
-interface DesktopShellActionFactoryOptions
-  extends Pick<MessageHost, 'showInfoMessage'> {
+interface DesktopShellActionFactoryOptions extends Pick<
+  MessageHost,
+  'showInfoMessage'
+> {
   getCustomAgentDirectory(): Promise<string>;
   openExternalUrl(url: string): Promise<void>;
   openLogFolder(): Promise<void>;

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -21,6 +21,7 @@ import {
   type SupabaseSessionLog,
 } from '@auth/SupabaseSession';
 import type { AuthCallbackUriParts } from '@auth/authCallback';
+import type { MessageHost } from '@hosts/uiHosts';
 import type { StateStore } from '@platform/interfaces';
 import type { PlatformSecrets } from '@platform/secrets';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -62,10 +63,9 @@ export interface DesktopAuthCallbackState {
 
 type DesktopAuthLog = Pick<Console, 'debug' | 'info' | 'warn' | 'error'>;
 
-export interface DesktopSupabaseAuthHost {
+export interface DesktopSupabaseAuthHost
+  extends Pick<MessageHost, 'showInfoMessage' | 'showErrorMessage'> {
   openExternalUrl(url: string): Promise<void>;
-  showInfoMessage(message: string): Promise<void> | void;
-  showErrorMessage(message: string): Promise<void> | void;
   onSessionChanged(): Promise<void> | void;
 }
 

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -63,8 +63,10 @@ export interface DesktopAuthCallbackState {
 
 type DesktopAuthLog = Pick<Console, 'debug' | 'info' | 'warn' | 'error'>;
 
-export interface DesktopSupabaseAuthHost
-  extends Pick<MessageHost, 'showInfoMessage' | 'showErrorMessage'> {
+export interface DesktopSupabaseAuthHost extends Pick<
+  MessageHost,
+  'showInfoMessage' | 'showErrorMessage'
+> {
   openExternalUrl(url: string): Promise<void>;
   onSessionChanged(): Promise<void> | void;
 }

--- a/src/controllers/settingsView/SettingsTeamRosterController.ts
+++ b/src/controllers/settingsView/SettingsTeamRosterController.ts
@@ -20,8 +20,10 @@ type SettingsTeamRosterCatalog = TeamRosterApplicationDeps['catalog'] & {
   ): string | undefined;
 };
 
-interface SettingsTeamRosterPresentation
-  extends Pick<MessageHost, 'showInfoMessage' | 'showErrorMessage'> {
+interface SettingsTeamRosterPresentation extends Pick<
+  MessageHost,
+  'showInfoMessage' | 'showErrorMessage'
+> {
   chooseTeamAvailability(
     prompt: TeamAvailabilityPrompt,
   ): Promise<TeamAvailabilityChoice | undefined>;

--- a/src/controllers/settingsView/SettingsTeamRosterController.ts
+++ b/src/controllers/settingsView/SettingsTeamRosterController.ts
@@ -9,6 +9,7 @@ import {
   applyTeamRosterWithPreflight,
   type TeamRosterApplicationDeps,
 } from '@common/teams/TeamRosterApplication';
+import type { MessageHost } from '@hosts/uiHosts';
 import { assertNever } from '@utils/core';
 import { formatResultCount } from '@utils/text/stringUtils';
 
@@ -19,12 +20,11 @@ type SettingsTeamRosterCatalog = TeamRosterApplicationDeps['catalog'] & {
   ): string | undefined;
 };
 
-interface SettingsTeamRosterPresentation {
+interface SettingsTeamRosterPresentation
+  extends Pick<MessageHost, 'showInfoMessage' | 'showErrorMessage'> {
   chooseTeamAvailability(
     prompt: TeamAvailabilityPrompt,
   ): Promise<TeamAvailabilityChoice | undefined>;
-  showInfoMessage(message: string): Promise<void>;
-  showErrorMessage(message: string): Promise<void>;
 }
 
 interface SettingsTeamRosterOptions extends Omit<

--- a/src/controllers/settingsView/backend/SettingsAgentActions.ts
+++ b/src/controllers/settingsView/backend/SettingsAgentActions.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 
 // Local imports - controllers
 import type { SettingsAgentDirectoryController } from '@controllers/settingsView/SettingsAgentDirectoryController';
+import type { MessageHost } from '@hosts/uiHosts';
 // Local imports - shared
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { AgentSource, SettingsMessageFor } from '@shared/schemas';
@@ -50,8 +51,8 @@ interface SettingsAgentActionsOptions {
     message: string,
     confirmLabel: string,
   ) => Promise<boolean>;
-  readonly showInfoMessage: (message: string) => Promise<void>;
-  readonly showErrorMessage: (message: string) => Promise<void>;
+  readonly showInfoMessage: MessageHost['showInfoMessage'];
+  readonly showErrorMessage: MessageHost['showErrorMessage'];
   readonly refreshAfterMutation: () => Promise<void>;
   readonly run: (
     failureMessage: string,

--- a/src/hosts/uiHosts.ts
+++ b/src/hosts/uiHosts.ts
@@ -24,6 +24,18 @@ export interface ExternalOpener {
   openExternal(url: string): Promise<void>;
 }
 
+/**
+ * A host capable of surfacing simple, non-blocking notifications to the
+ * user. Distinct from {@link PromptHost}, which additionally supports
+ * action items and awaits the user's choice; this is fire-and-forget
+ * status reporting (a saved credential, a failed operation, a caveat).
+ */
+export interface MessageHost {
+  showInfoMessage(message: string): Promise<void> | void;
+  showWarningMessage(message: string): Promise<void> | void;
+  showErrorMessage(message: string): Promise<void> | void;
+}
+
 export type PromptMessageItem<T extends string = string> =
   | T
   | {


### PR DESCRIPTION
## Summary

Found while auditing the codebase for overlapping responsibilities: the `showInfoMessage` / `showWarningMessage` / `showErrorMessage` notification trio was independently hand-declared inline in 8 separate interfaces across desktop controllers and settings controllers, instead of reusing a shared type. Because TypeScript structural typing hides duplication like this (everything still compiled), the signatures had already drifted — some declared `Promise<void>`, others `Promise<void> | void`; some included `showWarningMessage`, others silently omitted it. A future change (e.g. adding a detail/action-button parameter, as the existing `PromptMessageOptions` already models for prompts) would have to be threaded through 8 independent interfaces by hand, with a high chance of missing one.

This PR adds a single `MessageHost` interface to `src/hosts/uiHosts.ts` — which already centralizes the analogous `DiffViewHost`, `ExternalOpener`, and `PromptHost` UI-interaction ports — and updates each of the 8 sites to derive from it (`extends`, `Pick<MessageHost, ...>`, or an indexed-access type reference) instead of re-declaring the trio.

`src/agent/runtime/HostInteractions.ts` also declares a `showInfoMessage`, but it's deliberately left untouched: it's one capability among a larger family of individually-optional, individually-documented host-attachment methods on a different, session-scoped port — not an instance of this duplication pattern.

## Issue acceptance gates

No linked issue — found and fixed during a scheduled codebase audit for confusing/overlapped responsibilities. Acceptance gate: the trio has exactly one declaration site, every consumer site typechecks against it, and no runtime behavior changes.

## Single source of truth

`MessageHost` in `src/hosts/uiHosts.ts` now owns the shape of the info/warning/error notification capability. The 8 previously-independent declarations (`DesktopAgentExecutionHost`, `DesktopSettingsUiHost`, `DesktopSupabaseAuthHost`, the `notifications` field types in `desktopCredentialSettingsController.ts` and `desktopAgentSettingsController.ts`, `DesktopShellActionFactoryOptions`, `SettingsTeamRosterPresentation`, and `SettingsAgentActionsOptions`) now reference it instead of redefining it.

## Duplication and abstraction budget

Removed: 8 independently hand-rolled copies of the same 1-3 method trio, with 2 already-drifted signature variants. No new abstraction layer — `MessageHost` sits alongside the existing `DiffViewHost`/`ExternalOpener`/`PromptHost` ports in the same file, following the same pattern.

## Net elements (R6)

9 files changed, 48 insertions(+), 34 deletions(-). Exported symbols: +1 (`MessageHost`); the 3 other exported interfaces touched (`DesktopAgentExecutionHost`, `DesktopSettingsUiHost`, `DesktopSupabaseAuthHost`) keep their identity, only their `extends` clause changed. No classes added or removed.

## Consumer counts (R8)

n/a — no emit path, event key, or public export was deleted or re-routed; this widens (via `Pick`/indexed access) the source of an existing shape, it doesn't remove one.

## Host impact

Extension: none (extension code doesn't touch these desktop-only interfaces).

Desktop: `desktopAgentExecutionHost.ts`, `desktopSettingsIpc.ts`, `desktopSupabaseAuth.ts`, `desktopCredentialSettingsController.ts`, `desktopAgentSettingsController.ts`, and `desktopShellIpc.ts` now import `MessageHost` from `@hosts/uiHosts`; 3 call sites that called `.catch(...)` directly on a `showXMessage(...)` result were wrapped in `Promise.resolve(...)` since the shared type's return signature is the safe superset (`Promise<void> | void`) needed by two of the sites.

CLI: none.

## Scheduled refactoring

None — the remaining findings from the audit (a "trace" naming overload across `src/agent/trace/` and `src/transcript/`, the goal tool's implementation living under `src/tools/plan/` rather than `src/tools/goal/`, and a few lower-confidence items) were docs-only or too low-value to act on in this pass.

## Validation

- `npm run typecheck` (full workspace: root, test-kernel, agent, cli, trace-viewer, desktop) — clean.
- `npx eslint` on all 9 touched files — clean.
- `npx vitest run` on the test suites exercising the touched interfaces (`AgentHandlersDelete`, `DesktopAgentExecution`, `AuthCommandsStoredSession`) — one pre-existing failure (`DesktopAgentExecution.vitest.ts` > "presents a merge failure that occurs before lifecycle startup") reproduces identically on the unmodified `main` tree, confirmed via `git stash` before touching it; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQCfK7TeMFDGvueTFw4ytt


---
_Generated by [Claude Code](https://claude.ai/code/session_01NQCfK7TeMFDGvueTFw4ytt)_