### PR TITLE
refactor(subscription-usage): reuse existing utilities over hand-rolled logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@anthropic-ai/sdk": "^0.122.0",
     "@awesome.me/webawesome": "^3.12.0",
     "@cantoo/pdf-lib": "^2.9.1",
+    "@date-fns/tz": "^1.5.0",
     "@fortawesome/free-solid-svg-icons": "^7.3.1",
     "@google/genai": "^2.19.0",
     "@jamesgopsill/crossref-client": "^1.1.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -45,6 +45,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.257",
     "@anthropic-ai/sdk": "^0.122.0",
     "@cantoo/pdf-lib": "^2.9.1",
+    "@date-fns/tz": "^1.5.0",
     "@google/genai": "^2.19.0",
     "@jamesgopsill/crossref-client": "^1.1.0",
     "@jitl/quickjs-wasmfile-release-sync": "0.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@cantoo/pdf-lib':
         specifier: ^2.9.1
         version: 2.9.1(html-entities@2.6.0)
+      '@date-fns/tz':
+        specifier: ^1.5.0
+        version: 1.5.0
       '@fortawesome/free-solid-svg-icons':
         specifier: ^7.3.1
         version: 7.3.1
@@ -406,6 +409,9 @@ importers:
       '@cantoo/pdf-lib':
         specifier: ^2.9.1
         version: 2.9.1(html-entities@2.6.0)
+      '@date-fns/tz':
+        specifier: ^1.5.0
+        version: 1.5.0
       '@google/genai':
         specifier: ^2.19.0
         version: 2.19.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))
@@ -1501,6 +1507,9 @@ packages:
   '@ctrl/tinycolor@4.1.0':
     resolution: {integrity: sha512-WyOx8cJQ+FQus4Mm4uPIZA64gbk3Wxh0so5Lcii0aJifqwoVOlfFtorjLE0Hen4OYyHZMXDWqMmaQemBhgxFRQ==}
     engines: {node: '>=14'}
+
+  '@date-fns/tz@1.5.0':
+    resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
 
   '@effect/language-service@0.87.2':
     resolution: {integrity: sha512-CfiSoaVQO8pZgaMZGw5VvMvRGybsJ2LaSDoLYaqiVGvo/YYPYVR2GzUKY0h1NtIweq/+SQ5XLrvtzPIttWQ0GQ==}
@@ -7380,6 +7389,8 @@ snapshots:
   '@csstools/css-tokenizer@4.0.0': {}
 
   '@ctrl/tinycolor@4.1.0': {}
+
+  '@date-fns/tz@1.5.0': {}
 
   '@effect/language-service@0.87.2': {}
 

--- a/src/common/errors/sdkError/glmCodingPlanDetection.ts
+++ b/src/common/errors/sdkError/glmCodingPlanDetection.ts
@@ -1,3 +1,5 @@
+import { TZDate } from '@date-fns/tz';
+
 import {
   errorBodyCandidates,
   pickNumberField,
@@ -23,8 +25,8 @@ import {
  *
  * The reset hint is derived from either a `resets_in_seconds` field or the
  * absolute reset timestamp embedded in the message (e.g. "您的限额将在
- * 2026-08-08 11:32:36 重置" — a UTC+8 China-time timestamp). The timestamp is
- * parsed as UTC+8 and converted to seconds-until-reset.
+ * 2026-08-08 11:32:36 重置" — a China-time timestamp). The timestamp is a
+ * wall-clock reading in `Asia/Shanghai`, converted to seconds-until-reset.
  */
 export interface GlmCodingPlanLimit {
   /** Reset hint when the backend reports one (seconds until quota resets). */
@@ -51,22 +53,28 @@ const GLM_CODING_PLAN_RATE_LIMIT_CODES: ReadonlySet<string> = new Set([
   '1305', // The service may be temporarily overloaded
 ]);
 
-/** UTC+8 (China Standard Time) offset in milliseconds. */
-const CST_OFFSET_MS = 8 * 60 * 60 * 1000;
+/** Timezone the GLM Coding Plan backend reports reset timestamps in. */
+const GLM_CODING_PLAN_TIME_ZONE = 'Asia/Shanghai';
 
 /** Match a `YYYY-MM-DD HH:MM:SS` reset timestamp in the error message. */
-const RESET_TIMESTAMP_PATTERN = /(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2}:\d{2})/;
+const RESET_TIMESTAMP_PATTERN =
+  /(\d{4})-(\d{2})-(\d{2})\s+(\d{2}):(\d{2}):(\d{2})/;
 
-/** Seconds until the quota resets, from a UTC+8 `YYYY-MM-DD HH:MM:SS` timestamp. */
+/** Seconds until the quota resets, from an `Asia/Shanghai` `YYYY-MM-DD HH:MM:SS` timestamp. */
 function secondsUntilReset(timestamp: string): number | undefined {
   const match = RESET_TIMESTAMP_PATTERN.exec(timestamp);
   if (!match) return undefined;
-  const [date, time] = [match[1], match[2]];
-  // Parse as UTC+8: treat the wall-clock as UTC, then subtract the CST offset
-  // to get the true UTC instant.
-  const utcMs = Date.parse(`${date}T${time}Z`);
-  if (Number.isNaN(utcMs)) return undefined;
-  const resetMs = utcMs - CST_OFFSET_MS;
+  const [, year, month, day, hour, minute, second] = match.map(Number);
+  const resetMs = new TZDate(
+    year,
+    month - 1,
+    day,
+    hour,
+    minute,
+    second,
+    GLM_CODING_PLAN_TIME_ZONE,
+  ).getTime();
+  if (Number.isNaN(resetMs)) return undefined;
   return Math.max(0, Math.floor((resetMs - Date.now()) / 1000));
 }
 

--- a/src/controllers/modelAccess/subscriptionUsage/SubscriptionUsageService.ts
+++ b/src/controllers/modelAccess/subscriptionUsage/SubscriptionUsageService.ts
@@ -7,6 +7,7 @@ import type {
   SubscriptionUsageSnapshot,
 } from '@shared/schemas';
 import { SUBSCRIPTION_USAGE_PROVIDERS } from '@shared/schemas';
+import { coalesceAsync } from '@utils/core';
 import { useChinaRegion } from '@utils/config/providerConfig';
 
 import {
@@ -180,6 +181,25 @@ export class SubscriptionUsageService {
     }
   }
 
+  // Return-path choice (D16, define-out-of-existence §1e): when invalidate()
+  // races an in-flight fetch, coalesceAsync's own identity check keeps the
+  // stale result out of the cache, but the already-waiting caller still
+  // receives it — one accepted stale read on a read-only usage display.
+  private readonly cacheReader = {
+    get: (key: string): SubscriptionUsageSnapshot | undefined => {
+      const cached = this.cache.get(key);
+      return cached && cached.expiresAt > this.now()
+        ? cached.snapshot
+        : undefined;
+    },
+    set: (key: string, snapshot: SubscriptionUsageSnapshot): void => {
+      this.cache.set(key, {
+        snapshot,
+        expiresAt: this.now() + this.cacheTtlMs,
+      });
+    },
+  };
+
   async getUsage(
     provider: SubscriptionUsageProvider,
     options: { readonly forceRefresh?: boolean } = {},
@@ -196,35 +216,11 @@ export class SubscriptionUsageService {
     if (options.forceRefresh) {
       this.cache.delete(key);
       this.pending.delete(key);
-    } else {
-      const cached = this.cache.get(key);
-      if (cached && cached.expiresAt > this.now()) return cached.snapshot;
     }
 
-    const inFlight = this.pending.get(key);
-    if (inFlight) return inFlight;
-
-    // Return-path choice (D16, define-out-of-existence §1e): when invalidate()
-    // races an in-flight fetch, the identity check below keeps the stale result
-    // out of the cache, but the already-waiting caller still receives it — one
-    // accepted stale read on a read-only usage display.
-    const request = this.fetchUsage(provider, variant).then((snapshot) => {
-      if (this.pending.get(key) === request) {
-        this.cache.set(key, {
-          snapshot,
-          expiresAt: this.now() + this.cacheTtlMs,
-        });
-      }
-      return snapshot;
-    });
-    this.pending.set(key, request);
-    try {
-      return await request;
-    } finally {
-      if (this.pending.get(key) === request) {
-        this.pending.delete(key);
-      }
-    }
+    return coalesceAsync(this.cacheReader, this.pending, key, () =>
+      this.fetchUsage(provider, variant),
+    );
   }
 
   private unavailable(

--- a/src/controllers/modelAccess/subscriptionUsage/subscriptionUsageParsing.ts
+++ b/src/controllers/modelAccess/subscriptionUsage/subscriptionUsageParsing.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import type { SubscriptionUsageWindow } from '@shared/schemas';
 import { clamp, isObject } from '@utils/core';
 
@@ -50,55 +52,75 @@ export function asObject(value: unknown): JsonObject | undefined {
   return isObject(value) ? value : undefined;
 }
 
-function finiteNumber(value: unknown): number | undefined {
-  let parsed = Number.NaN;
-  if (typeof value === 'number') parsed = value;
-  if (typeof value === 'string' && value.trim() !== '') parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
+/** A loosely-typed wire number: a real number, or a non-blank numeric string
+ *  (provider responses mix both for the same logical field). */
+const looseFiniteNumber = z.preprocess((value) => {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string' && value.trim() !== '') return Number(value);
+  return value;
+}, z.number().finite());
+
+/** A wire timestamp expressed as epoch seconds or epoch milliseconds
+ *  (whichever a `looseFiniteNumber` resolves to), normalized to epoch ms. */
+const epochMsField = looseFiniteNumber.pipe(
+  z
+    .number()
+    .nonnegative()
+    .transform((value) =>
+      Math.trunc(value < 100_000_000_000 ? value * 1000 : value),
+    ),
+);
+
+/** A wire timestamp expressed as an ISO 8601 (or otherwise `Date.parse`-able)
+ *  string, normalized to epoch ms. */
+const isoTimestampField = z.string().transform((value, ctx) => {
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) {
+    ctx.addIssue({ code: 'custom', message: 'not a parseable date string' });
+    return z.NEVER;
+  }
+  return parsed;
+});
+
+/** Provider responses report reset timestamps either as epoch numbers (mixed
+ *  seconds/ms) or as ISO strings — try the numeric form first. */
+const timestampMsField = z.union([epochMsField, isoTimestampField]);
+
+/** Pick the first field, by alias, that parses against `schema`. Every
+ *  subscription-usage adapter reads the same provider concept under several
+ *  different wire spellings (`reset_at` / `resets_at` / `resetTime` / …), so
+ *  the alias fallback lives once here instead of once per detector. */
+function pickField<Value>(
+  schema: z.ZodType<Value>,
+  object: JsonObject | undefined,
+  keys: readonly string[],
+): Value | undefined {
+  for (const key of keys) {
+    const result = schema.safeParse(object?.[key]);
+    if (result.success) return result.data;
+  }
+  return undefined;
 }
 
 export function stringField(
   object: JsonObject | undefined,
   ...keys: readonly string[]
 ): string | undefined {
-  for (const key of keys) {
-    const value = object?.[key];
-    if (typeof value === 'string' && value.trim() !== '') return value.trim();
-  }
-  return undefined;
+  return pickField(z.string().trim().min(1), object, keys);
 }
 
 export function numberField(
   object: JsonObject | undefined,
   ...keys: readonly string[]
 ): number | undefined {
-  for (const key of keys) {
-    const value = finiteNumber(object?.[key]);
-    if (value !== undefined) return value;
-  }
-  return undefined;
-}
-
-function timestampMs(value: unknown): number | undefined {
-  const numeric = finiteNumber(value);
-  if (numeric !== undefined) {
-    if (numeric < 0) return undefined;
-    return Math.trunc(numeric < 100_000_000_000 ? numeric * 1000 : numeric);
-  }
-  if (typeof value !== 'string') return undefined;
-  const parsed = Date.parse(value);
-  return Number.isNaN(parsed) ? undefined : parsed;
+  return pickField(looseFiniteNumber, object, keys);
 }
 
 export function timestampField(
   object: JsonObject | undefined,
   ...keys: readonly string[]
 ): number | undefined {
-  for (const key of keys) {
-    const parsed = timestampMs(object?.[key]);
-    if (parsed !== undefined) return parsed;
-  }
-  return undefined;
+  return pickField(timestampMsField, object, keys);
 }
 
 export function usageWindow(


### PR DESCRIPTION
## Summary

A scheduled dependency audit flagged three spots in `src/controllers/modelAccess/subscriptionUsage/` and `src/common/errors/sdkError/` that hand-rolled a pattern the codebase already has a good answer for. This PR fixes those three, in order of impact:

1. **`SubscriptionUsageService.getUsage()`** hand-rolled a `cache: Map` + `pending: Map` TTL-cache-and-coalesce dance (~30 lines, including a race-guard comment about invalidate() racing an in-flight fetch). `src/utils/core/index.ts` already exports `coalesceAsync` implementing exactly that shape — `computeModelOptionsData` in `src/model/computeModelOptions.ts` already uses it. `getUsage()` now calls it too, via a small `cacheReader` adapter that preserves the service's injectable `now()`/`cacheTtlMs` (needed for the existing deterministic-TTL tests).
2. **GLM Coding Plan quota-reset parsing** (`glmCodingPlanDetection.ts`) regex-matched a bare `YYYY-MM-DD HH:MM:SS` timestamp, glued on a fake `Z` suffix, and subtracted a hardcoded `CST_OFFSET_MS = 8 * 60 * 60 * 1000` constant. Added `@date-fns/tz` (the actively-maintained companion to the `date-fns` v4 already in use) and parse the timestamp directly as a wall-clock reading in `Asia/Shanghai` via `TZDate`.
3. **`subscriptionUsageParsing.ts`'s `stringField`/`numberField`/`timestampField`** re-implemented Zod's job by hand: manual blank-string checks, a manual `Number.isFinite` guard, and a manual epoch-seconds-vs-milliseconds heuristic. Rebuilt on Zod schemas (`z.preprocess`, `.pipe()`, `z.union`) behind the same alias-fallback public API, so `codexUsageAdapter.ts`, `kimiCodeUsageAdapter.ts`, and `glmCodingPlanUsageAdapter.ts` needed no changes at all.

**Deliberately out of scope:** `errorInspection.ts`'s `pickStringField`/`pickNumberField` look like a fourth near-duplicate of (3), but they walk heterogeneous, undocumented SDK error shapes across many provider detectors rather than a fixed wire contract — closer to AGENTS.md's external-SDK-type exception than to a duplicate worth collapsing, and touching it would widen this PR across many more call sites for little gain.

## Issue acceptance gates

No tracked issue — this follows directly from a scheduled dependency-audit report. Gate: each of the three findings above is fixed with existing tests passing and no behavior change.

## Single source of truth

- Cache/coalesce semantics for short-lived, per-key async results: `coalesceAsync` (`src/utils/core/index.ts`), now with two callers.
- Wire-field coercion for the subscription-usage adapters: the Zod schemas in `subscriptionUsageParsing.ts` (`looseFiniteNumber`, `epochMsField`, `isoTimestampField`, `timestampMsField`), behind the unchanged `stringField`/`numberField`/`timestampField` API.
- GLM Coding Plan reset-timestamp timezone: the named `Asia/Shanghai` zone via `@date-fns/tz`, not a local magic-constant offset.

## Duplication and abstraction budget

Removed: the hand-rolled cache/pending coalescing logic in `SubscriptionUsageService` (now delegates to the already-existing, already-tested `coalesceAsync`); the hand-written numeric/timestamp coercion logic in `subscriptionUsageParsing.ts` (now delegates to Zod); the hardcoded UTC+8 offset constant and regex-to-fake-UTC-string parsing in `glmCodingPlanDetection.ts`.

No new abstractions added — `coalesceAsync` and Zod were already in the codebase with an established convention (AGENTS.md's "normalize once with Zod" rule); this PR brings a straggler in line with it rather than inventing something new.

## Net elements (R6)

`git diff --stat`: 6 files changed, 109 insertions(+), 70 deletions(-) (mostly `pnpm-lock.yaml` and two `package.json` dependency entries for `@date-fns/tz`).
Exported symbols: 0 added, 0 removed (`grep -E '^[+-].*export'` over the diff of the three touched source files returns nothing — all three files' public APIs are unchanged).
Classes/interfaces/enums: unchanged.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed; all touched public APIs (`getUsage`, `stringField`, `numberField`, `timestampField`, `secondsUntilReset`'s caller-facing behavior) keep their exact existing signatures and consumers.

## Host impact

Extension: none — `subscriptionUsage/` and `sdkError/` are host-agnostic (`src/controllers/`, `src/common/`), consumed via the extension's usage views without change.

Desktop: none, same host-agnostic surface.

CLI: none, same host-agnostic surface.

`packages/agent`'s bundle validator (`scripts/validate-artifacts.mjs`) requires every externally-imported package to be declared in `packages/agent/package.json`; added `@date-fns/tz` there too since `glmCodingPlanDetection.ts` is reachable from the agent bundle's error-classification path.

## Scheduled refactoring

None — this is the full scope of the audit's findings; no follow-up planned.

## Validation

- `npm run typecheck` (all six workspace projects: workspace, test-kernel, agent, cli, trace-viewer, desktop) — passes, including the agent bundle's artifact-declaration validator after adding `@date-fns/tz` to `packages/agent/package.json`.
- `npm run lint` — clean across `src`, `packages/agent`, `packages/extension`, `packages/desktop`, `packages/cli`.
- `npm run check:dead-code-ratchet` — no new findings.
- `npx vitest run src/test-kernel/controllers/modelAccess src/test-kernel/common/GlmCodingPlanDetection.vitest.ts` — 49/49 passing, including the deterministic-TTL, forced-refresh, invalidate-race, and concurrent-request-coalescing tests, and every existing parser-format test across ChatGPT/Kimi/GLM.
- Full `npx vitest run` kicked off as an additional sanity pass; not blocking since every test suite that exercises the touched code already passed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7buPbZjDjYBcjthKZoPyx

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7buPbZjDjYBcjthKZoPyx)_