### PR TITLE
Add Gemini 3.8 Flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Shared (all surfaces)
 
+#### Features
+
+- **Gemini 3.8 Flash is available** — the new Flash model replaces Gemini 3.7
+  Flash in the default model list with improved reasoning and coding at the
+  same introductory price. Existing selections of Gemini 3.7 Flash keep
+  working while Google serves them.
+
 #### Bug Fixes
 
 - **Prevent crashes in long-running CLI sessions** — CLI sessions that run many

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -65,7 +65,7 @@ GPT-5 reasoning summaries require account verification. Enable them with `texra.
 | Model ID    | Use Case                       | Cost | Speed  |
 | :---------- | :----------------------------- | :--- | :----- |
 | `gemini31p` | Pro with reasoning, 1M context | $$$  | Medium |
-| `gemini37f` | Flash model with 1M context    | $$   | Fast   |
+| `gemini38f` | Flash model with 1M context    | $$   | Fast   |
 
 ## DeepSeek models
 

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "katex": "^0.18.4",
     "ky": "^2.1.0",
     "lit": "^3.3.3",
-    "llm-zoo": "^1.32.0",
+    "llm-zoo": "^1.33.0",
     "lru-cache": "^11.5.2",
     "markdown-it": "^15.0.1",
     "markdown-it-texmath": "^1.0.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -78,7 +78,7 @@
     "is-network-error": "^1.3.2",
     "is-wsl": "^3.1.1",
     "ky": "^2.1.0",
-    "llm-zoo": "^1.32.0",
+    "llm-zoo": "^1.33.0",
     "lru-cache": "^11.5.2",
     "mime-types": "^3.0.1",
     "nanoid": "^6.0.1",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1085,7 +1085,7 @@
     "identifiers-arxiv": "^0.1.1",
     "katex": "^0.18.4",
     "lit": "^3.3.3",
-    "llm-zoo": "^1.32.0",
+    "llm-zoo": "^1.33.0",
     "lru-cache": "^11.5.2",
     "markdown-it": "^15.0.1",
     "markdown-it-texmath": "^1.0.0",

--- a/packages/trace-viewer/package.json
+++ b/packages/trace-viewer/package.json
@@ -23,7 +23,7 @@
     "highlightjs-lean": "^1.2.0",
     "katex": "^0.18.4",
     "lit": "^3.3.3",
-    "llm-zoo": "^1.32.0",
+    "llm-zoo": "^1.33.0",
     "lru-cache": "^11.5.2",
     "markdown-it": "^15.0.1",
     "markdown-it-texmath": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,8 +157,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       llm-zoo:
-        specifier: ^1.32.0
-        version: 1.32.0(zod@4.4.3)
+        specifier: ^1.33.0
+        version: 1.33.0(zod@4.4.3)
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2
@@ -509,8 +509,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       llm-zoo:
-        specifier: ^1.32.0
-        version: 1.32.0(zod@4.4.3)
+        specifier: ^1.33.0
+        version: 1.33.0(zod@4.4.3)
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2
@@ -878,8 +878,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       llm-zoo:
-        specifier: ^1.32.0
-        version: 1.32.0(zod@4.4.3)
+        specifier: ^1.33.0
+        version: 1.33.0(zod@4.4.3)
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2
@@ -1080,8 +1080,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       llm-zoo:
-        specifier: ^1.32.0
-        version: 1.32.0(zod@4.4.3)
+        specifier: ^1.33.0
+        version: 1.33.0(zod@4.4.3)
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2
@@ -5094,8 +5094,8 @@ packages:
   lit@3.3.3:
     resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
 
-  llm-zoo@1.32.0:
-    resolution: {integrity: sha512-vogZ+DWYtLFhRGtUpg762w/VukhhhwtlG7feeLfnv64x14jGtYV8vWk9PIeeawMDimbcZPK0xSGmbK20Us2YZg==}
+  llm-zoo@1.33.0:
+    resolution: {integrity: sha512-u7gcpHav8ksIwDrvjH0GxLaLHvou83MmsLWfoh5DoyarUMmA/oebnLQeb5seENkFdO3qWHBv7AnwNs5m59xNoQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
@@ -11082,7 +11082,7 @@ snapshots:
       lit-element: 4.2.2
       lit-html: 3.3.2
 
-  llm-zoo@1.32.0(zod@4.4.3):
+  llm-zoo@1.33.0(zod@4.4.3):
     optionalDependencies:
       zod: 4.4.3
 

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -42,7 +42,7 @@ export const PREFERRED_DEFAULT_MODELS: readonly string[] = [
   'gpt56',
   'gpt56-',
   'gpt56--',
-  'gemini37f',
+  'gemini38f',
   'gemini31p',
   'deepseekT',
   'deepseekproT',

--- a/src/test-kernel/model/ModelListRefresh.vitest.ts
+++ b/src/test-kernel/model/ModelListRefresh.vitest.ts
@@ -75,20 +75,22 @@ describe('refreshModelListAndLog', () => {
     expect(enabledModels(state)).not.toContain('grok4');
   });
 
-  it('adds Gemini 3.7 Flash while preserving Gemini 3.6 Flash from the previous model list', async () => {
-    const previousVersion = 494_338_219;
+  it('adds Gemini 3.8 Flash while preserving Gemini 3.7 Flash from the previous model list', async () => {
+    expect(MODEL_CONFIGS.gemini38f?.deprecated).not.toBe(true);
+    expect(MODEL_CONFIGS.gemini37f?.deprecated).toBe(true);
+    const previousVersion = 953_335_914;
     const state = new FakeStateStore({
       [GlobalStateKey.MODEL_LIST_VERSION]: previousVersion,
-      [GlobalStateKey.ENABLED_MODELS]: ['gemini36f'],
+      [GlobalStateKey.ENABLED_MODELS]: ['gemini37f'],
     });
 
     const result = await refreshModelListAndLog(state);
 
     expect(result.previousVersion).toBe(previousVersion);
-    expect(result.added).toContain('gemini37f');
-    expect(result.removed).not.toContain('gemini36f');
+    expect(result.added).toContain('gemini38f');
+    expect(result.removed).not.toContain('gemini37f');
+    expect(enabledModels(state)).toContain('gemini38f');
     expect(enabledModels(state)).toContain('gemini37f');
-    expect(enabledModels(state)).toContain('gemini36f');
     expect(state.get(GlobalStateKey.MODEL_LIST_VERSION)).toBe(
       MODEL_LIST_VERSION,
     );


### PR DESCRIPTION
## Summary

- add Gemini 3.8 Flash to the model catalog used by every app surface
- make it the preferred Flash default while preserving existing Gemini 3.7 Flash selections
- update the model guide and changelog for the new default

`llm-zoo` 1.33.0 publishes `gemini38f` as active at the same introductory price as 3.7 Flash, and marks `gemini37f` deprecated but not retired.

## Validation

- `corepack pnpm install --frozen-lockfile` (already up to date)
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/model/ModelListRefresh.vitest.ts src/test-kernel/model/ModelOptionsBasic.vitest.ts src/test-kernel/model/RuntimeModelRegistry.vitest.ts` (46 tests passed)
- `corepack pnpm run typecheck` (all six typecheck stages passed)
- `corepack pnpm run lint` (passed)
- `corepack pnpm run compile:fast` (passed)
- `corepack pnpm exec prettier --check CHANGELOG.md docs/guide/models.md package.json packages/agent/package.json packages/extension/package.json packages/trace-viewer/package.json pnpm-lock.yaml src/model/modelOptionsBasic.ts src/test-kernel/model/ModelListRefresh.vitest.ts` (all files matched)
- `corepack pnpm run check:extension-package-invariants` (in sync)
