### PR TITLE
Add Muse Spark 1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
   Flash in the default model list with improved reasoning and coding at the
   same introductory price. Existing selections of Gemini 3.7 Flash keep
   working while Google serves them.
+- **Muse Spark 1.3 is available** — Meta's latest standard model joins the
+  default model list with a 1M-token context window, multimodal input, prompt
+  caching, web search, and configurable reasoning. Existing selections of Muse
+  Spark 1.1 keep working while Meta serves them.
 
 #### Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "katex": "^0.18.4",
     "ky": "^2.1.0",
     "lit": "^3.3.3",
-    "llm-zoo": "^1.33.0",
+    "llm-zoo": "^1.34.0",
     "lru-cache": "^11.5.2",
     "markdown-it": "^15.0.1",
     "markdown-it-texmath": "^1.0.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -78,7 +78,7 @@
     "is-network-error": "^1.3.2",
     "is-wsl": "^3.1.1",
     "ky": "^2.1.0",
-    "llm-zoo": "^1.33.0",
+    "llm-zoo": "^1.34.0",
     "lru-cache": "^11.5.2",
     "mime-types": "^3.0.1",
     "nanoid": "^6.0.1",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1085,7 +1085,7 @@
     "identifiers-arxiv": "^0.1.1",
     "katex": "^0.18.4",
     "lit": "^3.3.3",
-    "llm-zoo": "^1.33.0",
+    "llm-zoo": "^1.34.0",
     "lru-cache": "^11.5.2",
     "markdown-it": "^15.0.1",
     "markdown-it-texmath": "^1.0.0",

--- a/packages/trace-viewer/package.json
+++ b/packages/trace-viewer/package.json
@@ -23,7 +23,7 @@
     "highlightjs-lean": "^1.2.0",
     "katex": "^0.18.4",
     "lit": "^3.3.3",
-    "llm-zoo": "^1.33.0",
+    "llm-zoo": "^1.34.0",
     "lru-cache": "^11.5.2",
     "markdown-it": "^15.0.1",
     "markdown-it-texmath": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,8 +157,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       llm-zoo:
-        specifier: ^1.33.0
-        version: 1.33.0(zod@4.4.3)
+        specifier: ^1.34.0
+        version: 1.34.0(zod@4.4.3)
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2
@@ -509,8 +509,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       llm-zoo:
-        specifier: ^1.33.0
-        version: 1.33.0(zod@4.4.3)
+        specifier: ^1.34.0
+        version: 1.34.0(zod@4.4.3)
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2
@@ -878,8 +878,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       llm-zoo:
-        specifier: ^1.33.0
-        version: 1.33.0(zod@4.4.3)
+        specifier: ^1.34.0
+        version: 1.34.0(zod@4.4.3)
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2
@@ -1080,8 +1080,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       llm-zoo:
-        specifier: ^1.33.0
-        version: 1.33.0(zod@4.4.3)
+        specifier: ^1.34.0
+        version: 1.34.0(zod@4.4.3)
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2
@@ -5094,8 +5094,8 @@ packages:
   lit@3.3.3:
     resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
 
-  llm-zoo@1.33.0:
-    resolution: {integrity: sha512-u7gcpHav8ksIwDrvjH0GxLaLHvou83MmsLWfoh5DoyarUMmA/oebnLQeb5seENkFdO3qWHBv7AnwNs5m59xNoQ==}
+  llm-zoo@1.34.0:
+    resolution: {integrity: sha512-a/QfJU4VMhK/oQ+TkJJJ+PZCfGncuIQ18Od33KQPdg4fFD72KM45QpODEHN8vcha4W6KV5l280Sc4NSdt+pqGg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
@@ -11082,7 +11082,7 @@ snapshots:
       lit-element: 4.2.2
       lit-html: 3.3.2
 
-  llm-zoo@1.33.0(zod@4.4.3):
+  llm-zoo@1.34.0(zod@4.4.3):
     optionalDependencies:
       zod: 4.4.3
 

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -44,6 +44,7 @@ export const PREFERRED_DEFAULT_MODELS: readonly string[] = [
   'gpt56--',
   'gemini38f',
   'gemini31p',
+  'musespark13',
   'deepseekT',
   'deepseekproT',
   'kimi26T',

--- a/src/model/setupModelDefaults.ts
+++ b/src/model/setupModelDefaults.ts
@@ -67,7 +67,7 @@ const SETUP_PROVIDER_DEFAULTS: Readonly<Record<string, SetupProviderDefaults>> =
       fallbackSource: ModelProvider.MINIMAX,
     },
     glm: { preferredModel: 'glm5', fallbackSource: ModelProvider.GLM },
-    meta: { preferredModel: 'musespark11', fallbackSource: ModelProvider.META },
+    meta: { preferredModel: 'musespark13', fallbackSource: ModelProvider.META },
   };
 
 /** Whether `config` is safe to hand to the setup assistant for `setupProvider`. */

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -519,12 +519,12 @@ describe('OpenAI model handler routing', () => {
       expected: 'ModelHandlerOpenRouterNative',
     },
     {
-      model: 'musespark11',
+      model: 'musespark13',
       useOpenRouter: false,
       expected: 'ModelHandlerMeta',
     },
     {
-      model: 'musespark11',
+      model: 'musespark13',
       useOpenRouter: true,
       expected: 'ModelHandlerOpenRouterNative',
     },

--- a/src/test-kernel/model/ModelListRefresh.vitest.ts
+++ b/src/test-kernel/model/ModelListRefresh.vitest.ts
@@ -75,22 +75,26 @@ describe('refreshModelListAndLog', () => {
     expect(enabledModels(state)).not.toContain('grok4');
   });
 
-  it('adds Gemini 3.8 Flash while preserving Gemini 3.7 Flash from the previous model list', async () => {
+  it('adds current models while preserving superseded selections', async () => {
     expect(MODEL_CONFIGS.gemini38f?.deprecated).not.toBe(true);
     expect(MODEL_CONFIGS.gemini37f?.deprecated).toBe(true);
     const previousVersion = 953_335_914;
     const state = new FakeStateStore({
       [GlobalStateKey.MODEL_LIST_VERSION]: previousVersion,
-      [GlobalStateKey.ENABLED_MODELS]: ['gemini37f'],
+      [GlobalStateKey.ENABLED_MODELS]: ['gemini37f', 'musespark11'],
     });
 
     const result = await refreshModelListAndLog(state);
 
     expect(result.previousVersion).toBe(previousVersion);
     expect(result.added).toContain('gemini38f');
+    expect(result.added).toContain('musespark13');
     expect(result.removed).not.toContain('gemini37f');
+    expect(result.removed).not.toContain('musespark11');
     expect(enabledModels(state)).toContain('gemini38f');
     expect(enabledModels(state)).toContain('gemini37f');
+    expect(enabledModels(state)).toContain('musespark13');
+    expect(enabledModels(state)).toContain('musespark11');
     expect(state.get(GlobalStateKey.MODEL_LIST_VERSION)).toBe(
       MODEL_LIST_VERSION,
     );


### PR DESCRIPTION
## Summary

- update every TeXRA workspace consumer to `llm-zoo` 1.34
- add Muse Spark 1.3 to the curated model list and Meta setup probe
- retain existing Muse Spark 1.1 selections while Meta continues serving them
- exercise the current model through model-list reconciliation and handler routing tests

The training-eligible Contributor variant is intentionally not exposed.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `npm test` (10,011 passed, 6 skipped)

## Sources

- https://github.com/meta-models/meta-model-cookbook
- https://dev.meta.ai/docs/pricing-rate-limits
- https://dev.meta.ai/docs/features/reasoning