### PR TITLE
fix(agent): re-check stream currency after a failed lease-lock claim

### DIFF
--- a/src/agent/runtime/restartRepair.ts
+++ b/src/agent/runtime/restartRepair.ts
@@ -322,6 +322,12 @@ export async function repairRestartedStreams(
       // A settlement that already mutated must surface; a lock that could
       // not even be taken proves nothing, so the stream stays unavailable.
       if (settleStarted) throw error;
+      if (!isCurrent(streamId, executionId)) {
+        options.logger?.debug(
+          `Skipped restart repair for stream ${streamId}: it was reused while the lease lock was unavailable`,
+        );
+        continue;
+      }
       applyHold(streamId, executionId, {
         kind: 'unclassified',
         cause: `lease lock unavailable (${toErrorMessage(error)})`,

--- a/src/test-kernel/agent/runtime/RestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/RestartRepair.vitest.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it, vi } from 'vitest';
 
+const mocks = vi.hoisted(() => ({
+  runWithInactiveExecutionLease: vi.fn(),
+}));
+
+vi.mock('@agent/storage/executionLease', async (importActual) => {
+  const actual =
+    await importActual<typeof import('@agent/storage/executionLease')>();
+  mocks.runWithInactiveExecutionLease.mockImplementation(
+    actual.runWithInactiveExecutionLease,
+  );
+  return {
+    ...actual,
+    runWithInactiveExecutionLease: mocks.runWithInactiveExecutionLease,
+  };
+});
+
 import { getExecutionStore } from '@agent/storage';
 import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
 import type {
@@ -417,6 +433,31 @@ describe('repairRestartedStreams', () => {
     });
 
     expect(setup.streamStatus.get(setup.streamId)).toBeUndefined();
+    expect(closeRunningGroups).not.toHaveBeenCalled();
+  });
+
+  it('skips a candidate reused while the lease lock was unavailable, instead of marking it unavailable', async () => {
+    const setup = setupStream('reused-during-lock');
+    const closeRunningGroups = vi.fn(closeAllGroups);
+    mocks.runWithInactiveExecutionLease.mockRejectedValueOnce(
+      new Error('lock contention'),
+    );
+    let currentCalls = 0;
+
+    await runRepair(setup, {
+      closeRunningGroups,
+      finalizeRun: createDurableFinalizer(),
+      classifyRun: classifyAs({ kind: 'resumable' }),
+      isRepairCandidateCurrent: () => {
+        currentCalls += 1;
+        // Current at the top-of-loop check (so the run reaches the lease
+        // attempt), reused by the time the lock rejects.
+        return currentCalls === 1;
+      },
+    });
+
+    expect(setup.streamStatus.get(setup.streamId)).toBeUndefined();
+    expect(setup.streamStatus.holdState(setup.streamId)).toBeUndefined();
     expect(closeRunningGroups).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

Fixes #11765, filed by the 2026-09-02 runtime/host/session/lifecycle ownership survey (`docs/proposals/2026-09-02-runtime-host-session-lifecycle-ownership-survey.md` §7) and re-verified against current `main` before implementing.

`restartRepair`'s phase-2 settle loop re-validates that a candidate stream is still current (not reused by a fresh run) at two points: the top of each iteration (`restartRepair.ts:247`) and again right before settlement (`:266`), because a stream can be reused across an `await`. The lease-lock `catch` block — reached when `runWithInactiveExecutionLease`'s own `claimLease` throws, before the settlement callback ever runs — had no such re-check, and applied `markUnavailable` unconditionally.

Since #11757 made a reservation a first-class `StreamEntry` kind, `markUnavailable`'s unconditional overwrite replaces a live `reserved` entry with a hold. `releaseIfReserved` only fires on a `kind === 'reserved'` entry, so once overwritten a failed launch's rollback can never run again, and the stream reads in-flight-and-unavailable — stuck.

## Issue acceptance gates

#11765's proposed fix is the 3-line addition: re-check `isCurrent(streamId, executionId)` in the lease-lock catch, matching its sibling at `:266` (same debug wording pattern). Implemented as described; the optional hardening (`markUnavailable` refusing to overwrite a `reserved` entry) is explicitly called out in the issue as a separate, later decision and is not included here.

## Single source of truth

No new vocabulary or module — the fix reuses the same `isCurrent` closure the two sibling checks in the same function already call.

## Duplication and abstraction budget

N/a — this is a bug fix, not a consolidation. No abstraction added or removed.

## Net elements (R6)

2 files changed, 47 insertions(+). Production: `src/agent/runtime/restartRepair.ts` +6 lines (one `if` guard). Test: `src/test-kernel/agent/runtime/RestartRepair.vitest.ts` +41 lines (one regression test plus the module-mock scaffolding it needs). No exported symbols added or removed.

## Consumer counts (R8)

N/a — no export or emit path was deleted or re-routed.

## Host impact

Extension: none (shared runtime code, not host-specific).

Desktop: none directly; benefits all hosts equally since `restartRepair` runs in the shared agent runtime.

CLI: none directly; same shared-runtime benefit.

## Scheduled refactoring

None. The issue's own "optional hardening" (making `markUnavailable` refuse to overwrite a `reserved` entry) is a separate behavior decision per the issue text and is left for a future PR if the maintainer wants it.

## Validation

- Added a regression test (`skips a candidate reused while the lease lock was unavailable, instead of marking it unavailable`) that mocks `runWithInactiveExecutionLease` (via `vi.mock` with `importActual` passthrough, so the other 15 tests in the file keep exercising the real lease implementation) to reject once, with `isRepairCandidateCurrent` reporting current at loop-entry and stale by the time the lock rejects.
- Verified the test is a real regression check: reverted the production fix locally, confirmed the new test fails with the exact bug described in #11765 (a hold's `detail` message where none should be), then re-applied the fix and confirmed it passes.
- `npm run typecheck` (workspace + test-kernel) — clean.
- `npx eslint` on both touched files — clean.
- `npx prettier --check` on both touched files — clean.
- `npx vitest run` on `RestartRepair.vitest.ts` (16/16) and the sibling `SessionRestartRepair.vitest.ts` (12/12) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQCfK7TeMFDGvueTFw4ytt
