### PR TITLE
refactor: share the staged-deletion rollback path and the sr-only recipe

### DIFF
--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.styles.ts
@@ -2,7 +2,7 @@
 
 import { css, type CSSResult } from 'lit';
 
-import { sp } from '@shared/styles';
+import { sp, visuallyHiddenDeclarations } from '@shared/styles';
 
 export const userQuestionPanelStyles: CSSResult = css`
   .user-question-request__questions {
@@ -67,15 +67,7 @@ export const userQuestionPanelStyles: CSSResult = css`
      the short action cue available to assistive technology without repeating
      the question already supplied by the outer fieldset legend. */
   wa-radio-group::part(form-control-label) {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip-path: inset(50%);
-    white-space: nowrap;
-    border: 0;
+    ${visuallyHiddenDeclarations}
   }
 
   .user-question-request__option {

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.styles.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.styles.ts
@@ -2,6 +2,8 @@
 
 import { css, type CSSResult } from 'lit';
 
+import { visuallyHiddenDeclarations } from '@shared/styles';
+
 export const latexTabStyles: CSSResult = css`
   :host {
     display: block;
@@ -127,15 +129,7 @@ export const latexTabStyles: CSSResult = css`
   .setting-control-metadata::part(form-control-label),
   .setting-control-metadata::part(label),
   .setting-control-metadata::part(hint) {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip-path: inset(50%);
-    white-space: nowrap;
-    border: 0;
+    ${visuallyHiddenDeclarations}
   }
 
   .replacement-groups-row,

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -5,6 +5,7 @@ import PQueue from 'p-queue';
 import { createLog } from '@logger/logUtils';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import type { StreamLogStore, StreamSnapshotStore } from '@transcript';
+import { deleteTranscriptWithSnapshotRollback } from '@transcript/StagedDeletionCoordinator';
 import { StreamDeletionSupersededError } from '@transcript/StreamLogStore';
 import { canUseStreamDataDir } from '@transcript/streamDataPaths';
 import { throwAggregated, unique } from '@utils/core';
@@ -901,32 +902,24 @@ export class SessionStores {
       }
       throw new StreamDeletionSupersededError(stream);
     }
-    try {
-      // The transcript registry is the commit point for tab visibility.
-      // Snapshot sidecars are only renamed before this, so a failure can roll
-      // them back without reconstructing state from partial files. The guard
-      // travels into `delete` itself so it is re-checked after the durable
-      // transcript delete but before in-memory state is forgotten.
-      await this.streamLogs.delete(stream, { shouldDelete });
-      // `delete` re-checked the guard before forgetting in-memory state. This
-      // final check runs with no await between it and the snapshot commit, so
-      // a re-claim that landed during the transcript I/O above can roll the
-      // snapshot staging back instead of having its buffered sidecar writes
-      // discarded by `commit`.
-      if (shouldDelete?.() === false) {
-        throw new StreamDeletionSupersededError(stream);
-      }
-    } catch (error) {
-      try {
-        await snapshotDeletion.rollback();
-      } catch (rollbackError) {
-        throw new AggregateError(
-          [error, rollbackError],
-          `Transcript and snapshot rollback failed for stream ${stream}`,
-        );
-      }
-      throw error;
-    }
+    await deleteTranscriptWithSnapshotRollback(
+      stream,
+      snapshotDeletion,
+      async () => {
+        // The transcript registry is the commit point for tab visibility. The
+        // guard travels into `delete` itself so it is re-checked after the
+        // durable transcript delete but before in-memory state is forgotten.
+        await this.streamLogs.delete(stream, { shouldDelete });
+        // `delete` re-checked the guard before forgetting in-memory state.
+        // This final check runs with no await between it and the snapshot
+        // commit, so a re-claim that landed during the transcript I/O above
+        // can roll the snapshot staging back instead of having its buffered
+        // sidecar writes discarded by `commit`.
+        if (shouldDelete?.() === false) {
+          throw new StreamDeletionSupersededError(stream);
+        }
+      },
+    );
 
     // The snapshot commit is the irreversible sidecar delete. Inspect its
     // supersede result rather than swallowing it in `allSettled`: a re-claim

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -9,6 +9,24 @@ import {
 } from './controlStyles';
 
 /**
+ * {@link visuallyHiddenStyles} without its selector, for rules that cannot use
+ * the class: Web Awesome exposes form-control labels and hints as shadow
+ * parts, so a view hiding one writes its own `::part(...)` rule against an
+ * element it cannot add a class to. Interpolate this rather than restate it.
+ */
+export const visuallyHiddenDeclarations: CSSResult = css`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+`;
+
+/**
  * Available to the accessibility tree, absent from the layout. The canonical
  * copy across every view surface (InstructionPanel and WorktreeChip both
  * used to carry their own). Exported on its own — interpolated into
@@ -18,15 +36,7 @@ import {
  */
 export const visuallyHiddenStyles: CSSResult = css`
   .visually-hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip-path: inset(50%);
-    white-space: nowrap;
-    border: 0;
+    ${visuallyHiddenDeclarations}
   }
 `;
 

--- a/src/shared/styles/index.ts
+++ b/src/shared/styles/index.ts
@@ -1,5 +1,9 @@
 // Core styles
-export { commonViewStyles, visuallyHiddenStyles } from './commonViewStyles';
+export {
+  commonViewStyles,
+  visuallyHiddenDeclarations,
+  visuallyHiddenStyles,
+} from './commonViewStyles';
 export { designTokens } from './litStyles';
 
 // The canonical button/input/focus-ring/settings-row skins reach consumers

--- a/src/transcript/StagedDeletionCoordinator.ts
+++ b/src/transcript/StagedDeletionCoordinator.ts
@@ -76,6 +76,36 @@ export interface StagedStreamSnapshotDeletion {
 }
 
 /**
+ * Run the authoritative transcript deletion while a snapshot deletion is
+ * staged, rolling that staging back if the transcript step fails so neither
+ * storage domain is left half-deleted. A rollback that also fails is reported
+ * with `AggregateError` so it cannot replace the failure that caused it.
+ *
+ * Only the failure path is shared. Each caller keeps its own commit (one
+ * inspects the supersede result, the other does not) and its own pre-commit
+ * supersede check, which rolls back best-effort instead of aggregating.
+ */
+export async function deleteTranscriptWithSnapshotRollback(
+  stream: StreamTabId,
+  snapshotDeletion: Pick<StagedStreamSnapshotDeletion, 'rollback'>,
+  deleteTranscript: () => Promise<void>,
+): Promise<void> {
+  try {
+    await deleteTranscript();
+  } catch (error) {
+    try {
+      await snapshotDeletion.rollback();
+    } catch (rollbackError) {
+      throw new AggregateError(
+        [error, rollbackError],
+        `Transcript and snapshot rollback failed for stream ${stream}`,
+      );
+    }
+    throw error;
+  }
+}
+
+/**
  * The narrow port back into the snapshot store. Every member is a capability
  * the staged-deletion machine cannot own itself: durable writes and the
  * per-(stream, category) write locks (both delegated to the store's

--- a/src/transcript/adjacentStreamCleanup.ts
+++ b/src/transcript/adjacentStreamCleanup.ts
@@ -18,6 +18,7 @@ import { createLog } from '@logger/logUtils';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
+import { deleteTranscriptWithSnapshotRollback } from './StagedDeletionCoordinator';
 import {
   clearPersistedSummaryParentStream,
   deletePersistedStreamLog,
@@ -68,19 +69,9 @@ async function deletePersistedAdjacentStreamState(
     stream,
     clearChildSummaryParentEdges,
   );
-  try {
-    await deletePersistedStreamLog(stream);
-  } catch (error) {
-    try {
-      await snapshotDeletion.rollback();
-    } catch (rollbackError) {
-      throw new AggregateError(
-        [error, rollbackError],
-        `Transcript and snapshot rollback failed for stream ${stream}`,
-      );
-    }
-    throw error;
-  }
+  await deleteTranscriptWithSnapshotRollback(stream, snapshotDeletion, () =>
+    deletePersistedStreamLog(stream),
+  );
   await snapshotDeletion.commit();
 }
 


### PR DESCRIPTION
## Summary

> **This PR was retargeted.** It was opened automatically from a branch that still pointed at the already-merged commits of #11756, so it originally re-proposed that work (its old title and body described the agent-proposal factory). The branch has been reset onto current `main` and now carries one unrelated commit. Everything below describes that commit; nothing from #11756 is re-applied here.

Two duplications found by running a normalized duplicate-block scan over all 1,602 production `.ts` files, then verifying each candidate by hand before acting on it.

**1. Staged-deletion rollback.** `SessionStores.deleteStreamSidecars` and `adjacentStreamCleanup.deletePersistedAdjacentStreamState` each carried a verbatim copy of the same failure path: attempt the authoritative transcript delete, roll the snapshot staging back if it throws, and report a rollback that *also* fails with `AggregateError` so it cannot replace the error that caused it. `deleteTranscriptWithSnapshotRollback` now owns that invariant — neither storage domain is left half-deleted.

Only the failure path is shared. Each caller keeps its own commit (one inspects the supersede result, the other does not), and the pre-commit supersede check in `SessionStores` is deliberately **not** routed through the helper: it rolls back best-effort with a `log.warn` rather than aggregating, which is a different policy for a different moment.

**2. Visually-hidden declarations.** The nine-declaration screen-reader-only recipe appeared three times: once as the canonical `.visually-hidden` class in `commonViewStyles`, and twice more inside `::part(...)` rules that *cannot* use that class — Web Awesome exposes form-control labels and hints as shadow parts on elements the view cannot add a class to. Extracting `visuallyHiddenDeclarations` gives all three one source, and `visuallyHiddenStyles` is now defined in terms of it.

## Issue acceptance gates

No issue — found by a mechanical scan. No gates to satisfy.

## Single source of truth

- `deleteTranscriptWithSnapshotRollback` (`src/transcript/StagedDeletionCoordinator.ts`) owns the "roll the snapshot staging back if the transcript delete fails, and never lose either error" invariant for both storage owners.
- `visuallyHiddenDeclarations` (`src/shared/styles/commonViewStyles.ts`) owns the sr-only declaration recipe for both the class and the `::part(...)` rules that cannot reach it.

## Duplication and abstraction budget

**Removed:** one verbatim 10-line failure path duplicated across two storage owners; one 9-declaration CSS recipe duplicated across three rules.

**Added:** one exported function and one exported `CSSResult`. The function has two callers and owns a real invariant (nested error aggregation), not a pass-through. The `CSSResult` has three consumers.

**Checked and rejected** — recorded so they are not re-proposed:

| Candidate | Why rejected |
|---|---|
| Merge `StreamLogStore.delete`'s inline staged deletion into `StagedDeletionCoordinator` (the ~120 LoC item I flagged as deferred on #11756) | Verified and withdrawn. The two are structurally analogous but share no mechanism: the coordinator renames filesystem directories with on-disk crash recovery, while `StreamLogStore` uses an in-memory tombstone set, a KV delete, and reconstruction of a `StreamLog` from re-parsed entries. The shared part is the *pattern* "re-check `shouldDelete()` at each irreversible boundary", interleaved differently in each. A shared template would need 4–5 callbacks and would bury per-checkpoint comments that cite distinct failure modes. |
| `CATEGORY_ORDER` in `ToolsTab` duplicating `ToolCategorySchema`'s enum | Not a copy — it is an intentional, documented *ordered subset* (`ai-agents` is rendered by `AIAgentsTab`). Deriving it from the enum would let a new schema category silently appear in the UI in enum order. |
| Device-login flows in `codexDeviceLogin` / `xaiDeviceLogin` | Already share `pollUntilDeviceAuthorized`, `pollDeviceToken`, `deviceCodeAuthorized`/`deviceCodePending`. What remains is genuinely provider-specific (response shapes, error kinds, xAI's `slow_down` handling). |

## Net elements (R6)

| | |
|---|---|
| Files changed | 7 (0 added, 0 deleted) |
| Exported symbols | **+2** (`deleteTranscriptWithSnapshotRollback`, `visuallyHiddenDeclarations`); 0 removed |
| Classes / interfaces / enums | 0 |
| Net LoC | **+14** (82 added, 68 deleted) |

Net LoC is positive, and stated plainly rather than massaged: the helper's signature and doc comment cost more lines than the ten they replace at two call sites. The gain is one definition of a storage-correctness invariant instead of two copies that can drift, not line count. Trimming the two doc comments took this from +25 to +14; cutting further would remove the reasoning a reader needs.

## Consumer counts (R8)

No emit path or export was removed or re-routed. Both new exports ship with their consumers in this PR: `deleteTranscriptWithSnapshotRollback` has 2 (`SessionStores.ts`, `adjacentStreamCleanup.ts`); `visuallyHiddenDeclarations` has 3 (`commonViewStyles` itself, `LaTeXTab.styles.ts`, `UserQuestionPanel.styles.ts`). The third rollback site (`SessionStores.ts` pre-commit supersede) is intentionally left alone, as described above.

## Host impact

**Extension:** the two `::part(...)` style rules now interpolate the shared declarations. Rendered CSS is unchanged.

**Desktop:** no direct change; both hosts share `SessionStores`, whose deletion behavior is unchanged.

**CLI:** no direct change; same shared `SessionStores` path.

## Scheduled refactoring

None. The `StreamLogStore` deletion-lifecycle merge I had flagged as a follow-up on #11756 is withdrawn rather than deferred — see the rejection table above for why.

## Validation

All green on this branch:

- `npm run typecheck` (all six projects)
- `npm run lint`
- `npm run format:check`
- `npm run check:dead-code-ratchet` — no new findings
- `npm run check:browser-safe-utils` — 65 total, 6 reachable, unchanged
- `npm run check:guidance-refs`
- Deletion paths: `src/test-kernel/agent/storage/SessionStores.vitest.ts`, `progressView/ProgressBackendCleanup.vitest.ts`, `cli/History.vitest.ts` — 101 tests
- `src/test-kernel/transcript` + `src/test-kernel/architecture` — 25 files, 351 tests

**CSS equivalence checked, not assumed.** Since the change alters how the stylesheet is composed, I compared the generated `cssText` of the composed form against the previous literal form under whitespace normalization; they are identical (`.visually-hidden{position:absolute;width:1px;…;border:0;}`).

No new tests: behavior-preserving refactor, per the testing-budget rule in AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwkEMWscWKbLj4n2nmAPS2