### PR TITLE
Replace custom timestamp formatting with date-fns

### DIFF
--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -14,6 +14,7 @@
  * trusted operator terminal whose output is neither persisted nor exported.
  */
 // Third-party imports
+import { format } from 'date-fns';
 import safeStringify from 'safe-stable-stringify';
 
 // Local imports
@@ -124,14 +125,6 @@ export function isDebugModeEnabled(): boolean {
   return getConfigBeforePlatformInit('texra.logger.debugMode', false);
 }
 
-/** Local-time `yyyy-MM-dd HH:mm:ss.SSS` log-line timestamp. */
-function formatLogTimestamp(d: Date): string {
-  const p = (n: number, w = 2) => String(n).padStart(w, '0');
-  const date = `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
-  const time = `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
-  return `${date} ${time}.${p(d.getMilliseconds(), 3)}`;
-}
-
 /**
  * Write one line to the per-channel sink. Single emission point for both the
  * functional logger API and channel writers.
@@ -144,7 +137,7 @@ function writeLine(
   data: unknown,
 ): void {
   const sink = ensureChannel(channel, isAgent);
-  const timestamp = formatLogTimestamp(new Date());
+  const timestamp = format(new Date(), 'yyyy-MM-dd HH:mm:ss.SSS');
   const prefix = isAgent ? '' : `[${channel}] `;
   sink.appendLine(`${LEVEL_TAG[level]} [${timestamp}] ${prefix}${message}`);
 


### PR DESCRIPTION
## Summary

Replace the custom `formatLogTimestamp()` function with `date-fns`'s `format()` utility. This eliminates hand-rolled date formatting logic in favor of a well-tested, standard library function while maintaining identical output format (`yyyy-MM-dd HH:mm:ss.SSS`).

## Issue acceptance gates

n/a — code simplification

## Single source of truth

`date-fns` now owns timestamp formatting logic for log output.

## Duplication and abstraction budget

Removed 8 lines of custom date/time padding and formatting logic. The `date-fns` library is already a project dependency, so this consolidates on an existing abstraction rather than introducing new duplication.

## Net elements (R6)

- Files: 1 modified (`src/logger/logUtils.ts`)
- Exported symbols: 0 (internal function removed)
- Functions removed: 1 (`formatLogTimestamp`)
- Net LoC: −8 (removed custom function) +1 (added import) = −7

## Consumer counts (R8)

`formatLogTimestamp` was internal to `logUtils.ts` with a single call site in `writeLine()`. No external consumers.

## Host impact

Extension: No impact — logging behavior unchanged.

Desktop: No impact — logging behavior unchanged.

CLI: No impact — logging behavior unchanged.

## Scheduled refactoring

None

## Validation

- Timestamp format remains identical: `yyyy-MM-dd HH:mm:ss.SSS`
- Existing log output unaffected
- No new test coverage needed; this is a transparent refactor of internal implementation

https://claude.ai/code/session_01YKqNLuKz2BJwonFmF3ZvST