### PR TITLE
refactor: extract IncarnationMap for SessionStores' nested deletion maps

### DIFF
--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -31,6 +31,50 @@ interface GoalEntryStore {
   forget(stream: StreamTabId): Promise<void>;
 }
 
+/**
+ * A per-stream map of per-incarnation values that prunes itself: deleting a
+ * stream's last incarnation also removes the stream's now-empty inner map,
+ * so `size`, `countFor`, and `allValues` only ever see live entries. Used for
+ * `pendingStreamDeletions` and `streamDeletionClaims`, which both key first
+ * by stream, then by incarnation, and both need to prune-when-empty at every
+ * write — this centralizes that dance instead of repeating it at each site.
+ */
+class IncarnationMap<K2, V> {
+  private readonly byStream = new Map<StreamTabId, Map<K2, V>>();
+
+  get size(): number {
+    return this.byStream.size;
+  }
+
+  get(stream: StreamTabId, incarnation: K2): V | undefined {
+    return this.byStream.get(stream)?.get(incarnation);
+  }
+
+  set(stream: StreamTabId, incarnation: K2, value: V): void {
+    const byIncarnation = this.byStream.get(stream) ?? new Map<K2, V>();
+    this.byStream.set(stream, byIncarnation);
+    byIncarnation.set(incarnation, value);
+  }
+
+  delete(stream: StreamTabId, incarnation: K2): void {
+    const byIncarnation = this.byStream.get(stream);
+    if (!byIncarnation) return;
+    byIncarnation.delete(incarnation);
+    if (byIncarnation.size === 0) this.byStream.delete(stream);
+  }
+
+  /** Number of incarnations tracked for `stream`, 0 if none. */
+  countFor(stream: StreamTabId): number {
+    return this.byStream.get(stream)?.size ?? 0;
+  }
+
+  allValues(): V[] {
+    return [...this.byStream.values()].flatMap((byIncarnation) => [
+      ...byIncarnation.values(),
+    ]);
+  }
+}
+
 /** The execution-lifecycle lane a stream deletion runs on as its own step. */
 export interface ExecutionLifecycleLane {
   runExecutionStep<T>(executionId: string, step: () => Promise<T>): Promise<T>;
@@ -108,13 +152,13 @@ export class SessionStores {
    * incarnation identifies the same deletion. A re-claimed identity's new
    * incarnation starts independently. `undefined` is the unkeyed slot.
    */
-  private readonly pendingStreamDeletions = new Map<
-    StreamTabId,
-    Map<number | undefined, Promise<DeleteStreamResult>>
+  private readonly pendingStreamDeletions = new IncarnationMap<
+    number | undefined,
+    Promise<DeleteStreamResult>
   >();
-  private readonly streamDeletionClaims = new Map<
-    StreamTabId,
-    Map<number, Set<symbol>>
+  private readonly streamDeletionClaims = new IncarnationMap<
+    number,
+    Set<symbol>
   >();
   private pendingDeleteAll: Promise<DeleteAllStreamsResult> | undefined;
   private readonly deletionQueue = new PQueue({ concurrency: 1 });
@@ -140,11 +184,10 @@ export class SessionStores {
     stream: StreamTabId,
     expectedIncarnation: number,
   ): () => void {
-    const byIncarnation =
-      this.streamDeletionClaims.get(stream) ?? new Map<number, Set<symbol>>();
-    this.streamDeletionClaims.set(stream, byIncarnation);
-    const claims = byIncarnation.get(expectedIncarnation) ?? new Set<symbol>();
-    byIncarnation.set(expectedIncarnation, claims);
+    const claims =
+      this.streamDeletionClaims.get(stream, expectedIncarnation) ??
+      new Set<symbol>();
+    this.streamDeletionClaims.set(stream, expectedIncarnation, claims);
     const claim = Symbol(stream);
     claims.add(claim);
     let released = false;
@@ -152,8 +195,9 @@ export class SessionStores {
       if (released) return;
       released = true;
       claims.delete(claim);
-      if (claims.size === 0) byIncarnation.delete(expectedIncarnation);
-      if (byIncarnation.size === 0) this.streamDeletionClaims.delete(stream);
+      if (claims.size === 0) {
+        this.streamDeletionClaims.delete(stream, expectedIncarnation);
+      }
     };
   }
 
@@ -167,7 +211,7 @@ export class SessionStores {
    * when its deletion settles or fails.
    */
   hasStreamDeletionClaim(stream: StreamTabId): boolean {
-    return !!this.streamDeletionClaims.get(stream)?.size;
+    return this.streamDeletionClaims.countFor(stream) > 0;
   }
 
   /**
@@ -243,14 +287,13 @@ export class SessionStores {
     expectedIncarnation: number | undefined,
     start: () => Promise<DeleteStreamResult>,
   ): Promise<DeleteStreamResult> {
-    const byGuard =
-      this.pendingStreamDeletions.get(stream) ??
-      new Map<number | undefined, Promise<DeleteStreamResult>>();
-    this.pendingStreamDeletions.set(stream, byGuard);
-    const existing = byGuard.get(expectedIncarnation);
+    const existing = this.pendingStreamDeletions.get(
+      stream,
+      expectedIncarnation,
+    );
     if (existing) return existing;
     const pending = start();
-    byGuard.set(expectedIncarnation, pending);
+    this.pendingStreamDeletions.set(stream, expectedIncarnation, pending);
     const finish = (): void =>
       this.finishStreamDeletion(stream, expectedIncarnation, pending);
     void pending.then(finish, finish);
@@ -285,9 +328,7 @@ export class SessionStores {
       this.pendingDeleteAll !== undefined
     ) {
       await Promise.allSettled([
-        ...[...this.pendingStreamDeletions.values()].flatMap((byGuard) => [
-          ...byGuard.values(),
-        ]),
+        ...this.pendingStreamDeletions.allValues(),
         ...(this.pendingDeleteAll ? [this.pendingDeleteAll] : []),
       ]);
     }
@@ -309,10 +350,12 @@ export class SessionStores {
     expectedIncarnation: number | undefined,
     pending: Promise<DeleteStreamResult>,
   ): void {
-    const byGuard = this.pendingStreamDeletions.get(stream);
-    if (byGuard?.get(expectedIncarnation) !== pending) return;
-    byGuard.delete(expectedIncarnation);
-    if (byGuard.size === 0) this.pendingStreamDeletions.delete(stream);
+    if (
+      this.pendingStreamDeletions.get(stream, expectedIncarnation) !== pending
+    ) {
+      return;
+    }
+    this.pendingStreamDeletions.delete(stream, expectedIncarnation);
   }
 
   private async notifyDeleted(stream: StreamTabId): Promise<void> {


### PR DESCRIPTION
## Summary

A scheduled data-structure-complexity audit flagged `SessionStores.ts`'s two hand-rolled two-level maps — `pendingStreamDeletions: Map<StreamTabId, Map<number | undefined, Promise<DeleteStreamResult>>>` and `streamDeletionClaims: Map<StreamTabId, Map<number, Set<symbol>>>` — as adding avoidable maintenance cost: both are keyed first by stream, then by incarnation, and both repeat the same get-or-create-inner-map / prune-when-empty dance across `claimStreamDeletion`, `hasStreamDeletionClaim`, `trackStreamDeletion`, `finishStreamDeletion`, and `waitForPendingStreamDeletions`. This PR extracts that dance into a small private `IncarnationMap<K2, V>` helper used by both fields, with no behavior change.

## Issue acceptance gates

No linked issue — this is a direct follow-up to a scheduled codebase audit that surfaced the finding. Acceptance gate: the duplicated get-or-create/prune boilerplate is centralized in one place and every call site now reads at the level of "get/set/delete for (stream, incarnation)" rather than manually managing the inner `Map`.

## Single source of truth

`IncarnationMap` (module-private to `src/agent/storage/SessionStores.ts`) now owns the prune-when-empty invariant for both `pendingStreamDeletions` and `streamDeletionClaims`. Previously that invariant was re-implemented independently at each of the 5 call sites.

## Duplication and abstraction budget

Removed: the repeated `get(stream) ?? new Map(); set(stream, inner); ...; if (inner.size === 0) outer.delete(stream)` pattern that appeared at 4 separate sites (`claimStreamDeletion`'s claim/release, `trackStreamDeletion`, `finishStreamDeletion`). Added: one small class with two call sites in this file (`pendingStreamDeletions`, `streamDeletionClaims`), not exported outside the module — it owns a real invariant (auto-pruning empty inner maps) rather than being a pass-through wrapper.

## Net elements (R6)

+1 class (`IncarnationMap`, unexported/module-private), 0 new exported symbols (confirmed via `git diff origin/main...HEAD -- src/agent/storage/SessionStores.ts | grep -E '^[+-]export'` — no matches). Diffstat: 1 file changed, +70/-27 (net +43 lines, mostly the new class's own doc comment and method bodies; the 5 call sites it replaces got shorter).

## Consumer counts (R8)

n/a — no emit path or export was removed or re-routed. `pendingStreamDeletions` and `streamDeletionClaims` remain private fields with no external consumers (confirmed via `grep -rn "pendingStreamDeletions\|streamDeletionClaims" .` — only `SessionStores.ts` itself matches).

## Host impact

Extension: none — `SessionStores` is host-agnostic core storage, unchanged externally.

Desktop: none.

CLI: none.

## Scheduled refactoring

None — this is a self-contained internal refactor with no follow-up required. (A second, Low-severity finding from the same audit — `StatusBarDisplayInput` in `packages/cli/.../statusBarDisplay.ts` having 15/29 optional fields — was intentionally not addressed here: grouping those fields touches ~28 call sites across 8 files for a change the audit itself called cosmetic, not a correctness issue, so it wasn't worth the blast radius in this PR.)

## Validation

- `npm run typecheck` — passes across all packages (workspace, test-kernel, agent, cli, trace-viewer, desktop).
- `npx eslint src/agent/storage/SessionStores.ts` — clean.
- `npx vitest run src/test-kernel/agent/storage/SessionStores.vitest.ts` plus dependent suites (`ChildRunLoop`, `ProgressBackendCleanup`, `DesktopAgentExecution`) — all pass except one pre-existing, unrelated failure (`DesktopAgentExecution.vitest.ts > presents a merge failure that occurs before lifecycle startup`), confirmed to fail identically on `origin/main` with this diff stashed out.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XXq7nRH9hYr25AefArny4G

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXq7nRH9hYr25AefArny4G)_