### PR TITLE
refactor(shared): consolidate wa-icon construction onto waIcon()

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -727,4 +727,22 @@ export default tseslint.config(
       ],
     },
   },
+
+  // `<wa-icon>` is constructed in exactly one place (`waIcon()`), so the
+  // Font Awesome / Web Awesome icon set stays the single icon standard
+  // instead of accumulating parallel hand-rolled `<wa-icon>` templates.
+  {
+    files: ['src/**/*.{ts,tsx}', 'packages/**/*.{ts,tsx}'],
+    ignores: ['src/shared/wa/webAwesomeIcons.ts', '**/*.vitest.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'TemplateElement[value.raw=/<wa-icon\\b/]',
+          message:
+            'Build <wa-icon> markup via waIcon() from @shared/wa/webAwesomeIcons instead of a hand-rolled template.',
+        },
+      ],
+    },
+  },
 );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -738,7 +738,7 @@ export default tseslint.config(
       'no-restricted-syntax': [
         'error',
         {
-          selector: 'TemplateElement[value.raw=/<wa-icon\\b/]',
+          selector: 'TemplateElement[value.raw=/<wa-icon[\\s>\\/]/]',
           message:
             'Build <wa-icon> markup via waIcon() from @shared/wa/webAwesomeIcons instead of a hand-rolled template.',
         },

--- a/src/shared/wa/statusIcons.ts
+++ b/src/shared/wa/statusIcons.ts
@@ -6,6 +6,7 @@ import { css, html, type CSSResult, type TemplateResult } from 'lit';
 // Local imports
 import type { ProviderKeyStatus } from '@shared/schemas';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 /**
  * Abstract terminal-run outcome, independent of any one surface's status
@@ -57,13 +58,11 @@ export function renderSetStatusIcon<Status extends string>({
   if (!fallback) {
     // `label` exposes the check's meaning to assistive technology; `title`
     // alone is a hover-only tooltip on an otherwise aria-hidden icon.
-    return html`<wa-icon
-      library="texra"
-      name="check"
-      class="status-check-icon"
-      label=${title ?? 'Set'}
-      title=${title ?? 'Set'}
-    ></wa-icon>`;
+    return waIcon('check', {
+      className: 'status-check-icon',
+      label: title ?? 'Set',
+      title: title ?? 'Set',
+    });
   }
   return html`<wa-tag variant=${fallback.variant ?? 'neutral'} size="s"
     >${fallback.label}</wa-tag


### PR DESCRIPTION
## Summary

A scheduled UI-consistency audit found that `src/shared/wa/statusIcons.ts` hand-rolled its own `<wa-icon>` Lit template (`renderSetStatusIcon`'s green-check branch) instead of reusing the shared `waIcon()` helper in `src/shared/wa/webAwesomeIcons.ts`. That left two independent places constructing `<wa-icon>` markup, free to drift on `library`, `aria-hidden`, and other attribute handling. This PR routes `statusIcons.ts` through `waIcon()` and adds an ESLint guardrail so raw `<wa-icon>` template construction stays confined to its one legitimate source.

Everything else the audit checked — Font Awesome usage across the extension/desktop/trace-viewer surfaces, inline styles, and Ink usage in the CLI — was already consistent; no other changes were warranted.

## Issue acceptance gates

No filed issue; this is a small proactive consolidation surfaced by a scheduled UI audit. Gate: the two `<wa-icon>` construction sites collapse to one, with no behavior change.

## Single source of truth

`waIcon()` in `src/shared/wa/webAwesomeIcons.ts` is now the sole place that constructs a `<wa-icon>` Lit template; `statusIcons.ts` calls it instead of duplicating the template.

## Duplication and abstraction budget

Removed: the second hand-rolled `<wa-icon>` template in `statusIcons.ts`. No new abstraction was added — `waIcon()` already existed and was already the established pattern used everywhere else.

## Net elements (R6)

Diffstat: 3 files changed. No exported-symbol delta (`^[+-]export` over the diff is empty) — `renderSetStatusIcon`'s public signature and behavior are unchanged.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed; this only changes what one function's implementation calls internally.

## Host impact

Extension: `statusIcons.ts` is consumed by the extension's Settings/progress views (API-key status icons); visually equivalent. Note (per review): the serialized markup now also carries the shared `waIcon()` attributes `variant="solid"` and `canvas="auto"`, which the old hand-rolled template did not emit — both are Web Awesome 3.12 defaults, so the resolver (which dispatches on `name` only) renders the same pixels, but an `outerHTML`/attribute-level assertion would see the difference. No such assertion exists on this icon today.

Desktop: no direct impact; shares the same `src/shared/wa/` code.

CLI: not applicable — `wa-icon`/Lit is web-only, does not reach the Ink TUI.

## Scheduled refactoring

None — this closes out the one actionable finding from the audit.

## Validation

- `npm run typecheck` — clean across all packages
- `npm run lint` — clean (verified the new `no-restricted-syntax` rule fires on a synthetic raw `<wa-icon>` template and does not false-positive on a `<wa-icon-button>` decoy, then removed the test files)
- `npx prettier --check` on changed files — clean
- `npx vitest run` on the extension test-kernel suites that exercise `statusIcons.ts` consumers (`EmptyStateHelper`, `SettingsNavigation`, `InstructionPanel`, `StreamHeader`) — 65 passed

Review notes addressed: tightened the guardrail's regex (`/<wa-icon\b/` → `/<wa-icon[\s>\/]/`) so it no longer over-matches a future `<wa-icon-button>`-style tag, and corrected the "byte-for-byte equivalent" claim above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HB6deUUYQp65iJ8pz3vbJP