### PR TITLE
refactor: convert command-tool schemas to discriminated unions

### DIFF
--- a/src/test-kernel/tools/InlineCommentTool.vitest.ts
+++ b/src/test-kernel/tools/InlineCommentTool.vitest.ts
@@ -27,7 +27,9 @@ describe('InlineCommentTool.call', () => {
   it('validates required fields for add', async () => {
     const result = await tool.call({ command: 'add', path: 'p.tex', line: 3 });
     expect(result.status).toBe('error');
-    expect(result.error).toContain('requires path, line, and body');
+    // The discriminated-union schema now rejects a missing `body` up front.
+    expect(result.error).toContain('Invalid input');
+    expect(result.error).toContain('body');
   });
 
   it('reports a missing thread on reply', async () => {

--- a/src/tools/comment/InlineCommentTool.ts
+++ b/src/tools/comment/InlineCommentTool.ts
@@ -81,47 +81,81 @@ function requireProvider(): InlineCommentProvider {
   return provider;
 }
 
-const InlineCommentInputSchema = z.strictObject({
-  command: z
-    .enum(['add', 'reply', 'resolve', 'unresolve', 'list'])
-    .describe(
-      "add: open a new comment thread on a file range. reply: append a comment to an existing thread. resolve/unresolve: toggle a thread's resolved state. list: read open threads and their comments, including the user's replies.",
-    ),
-  path: z
-    .string()
-    .trim()
-    .min(1)
-    .nullish()
-    .describe(
-      'add: file the comment anchors to (required). list: restrict to one file (omit for all threads). Workspace-relative or absolute.',
-    ),
-  line: z
-    .int()
-    .min(1)
-    .nullish()
-    .describe('add: 1-based start line the comment anchors to (required).'),
-  endLine: z
-    .int()
-    .min(1)
-    .nullish()
-    .describe(
-      'add: 1-based end line of the range; defaults to the start line.',
-    ),
-  body: z
-    .string()
-    .min(1)
-    .nullish()
-    .describe('add / reply: the comment text (Markdown supported).'),
-  threadId: z
-    .string()
-    .min(1)
-    .nullish()
-    .describe(
-      'reply / resolve / unresolve: the thread id returned by "add" or "list".',
-    ),
-});
+const THREAD_ID_DESCRIPTION = 'The thread id returned by "add" or "list".';
+const COMMENT_BODY_DESCRIPTION = 'The comment text (Markdown supported).';
+
+// Branches use looseObject (not strictObject): provider conversion flattens the
+// discriminated union into one advertised object and OpenAI-compatible providers
+// null-fill the properties belonging to the other commands. See AGENTS.md
+// "Tool input schemas".
+const InlineCommentInputSchema = z.discriminatedUnion('command', [
+  z
+    .looseObject({
+      command: z
+        .literal('add')
+        .describe('Open a new comment thread on a file range.'),
+      path: z
+        .string()
+        .trim()
+        .min(1)
+        .describe(
+          'File the comment anchors to. Workspace-relative or absolute.',
+        ),
+      line: z
+        .int()
+        .min(1)
+        .describe('1-based start line the comment anchors to.'),
+      endLine: z
+        .int()
+        .min(1)
+        .nullish()
+        .describe('1-based end line of the range; defaults to the start line.'),
+      body: z.string().min(1).describe(COMMENT_BODY_DESCRIPTION),
+    })
+    .refine((data) => data.endLine == null || data.endLine >= data.line, {
+      message: 'endLine must be greater than or equal to line.',
+      path: ['endLine'],
+    }),
+  z.looseObject({
+    command: z
+      .literal('reply')
+      .describe('Append a comment to an existing thread.'),
+    threadId: z.string().min(1).describe(THREAD_ID_DESCRIPTION),
+    body: z.string().min(1).describe(COMMENT_BODY_DESCRIPTION),
+  }),
+  z.looseObject({
+    command: z.literal('resolve').describe('Mark a thread resolved.'),
+    threadId: z.string().min(1).describe(THREAD_ID_DESCRIPTION),
+  }),
+  z.looseObject({
+    command: z.literal('unresolve').describe('Reopen a resolved thread.'),
+    threadId: z.string().min(1).describe(THREAD_ID_DESCRIPTION),
+  }),
+  z.looseObject({
+    command: z
+      .literal('list')
+      .describe(
+        "Read open threads and their comments, including the user's replies.",
+      ),
+    path: z
+      .string()
+      .trim()
+      .min(1)
+      .nullish()
+      .describe(
+        'Restrict to one file (omit for all threads). Workspace-relative or absolute.',
+      ),
+  }),
+]);
 
 type InlineCommentInput = z.infer<typeof InlineCommentInputSchema>;
+type AddCommentInput = Extract<InlineCommentInput, { command: 'add' }>;
+type ReplyCommentInput = Extract<InlineCommentInput, { command: 'reply' }>;
+type SetResolvedInput = Extract<
+  InlineCommentInput,
+  { command: 'resolve' | 'unresolve' }
+>;
+type ListCommentInput = Extract<InlineCommentInput, { command: 'list' }>;
 
 /** Render a thread for the agent: a header line plus each comment indented. */
 function formatThread(thread: InlineCommentThreadView): string {
@@ -161,14 +195,8 @@ export class InlineCommentTool extends defineTool({
     }
   }
 
-  private addThread(input: InlineCommentInput): ToolResult {
+  private addThread(input: AddCommentInput): ToolResult {
     const { path, line, endLine, body } = input;
-    if (path == null || line == null || body == null) {
-      throw new ToolError('The "add" command requires path, line, and body.');
-    }
-    if (endLine != null && endLine < line) {
-      throw new ToolError('endLine must be greater than or equal to line.');
-    }
     try {
       const workingDirectory =
         getRunContextWorkingDirectory(tryUseRunContext());
@@ -196,11 +224,8 @@ export class InlineCommentTool extends defineTool({
     }
   }
 
-  private reply(input: InlineCommentInput): ToolResult {
+  private reply(input: ReplyCommentInput): ToolResult {
     const { threadId, body } = input;
-    if (threadId == null || body == null) {
-      throw new ToolError('The "reply" command requires threadId and body.');
-    }
     if (!requireProvider().reply({ threadId, body })) {
       return this.threadNotFound(threadId);
     }
@@ -208,16 +233,8 @@ export class InlineCommentTool extends defineTool({
     return executed(summary, summary);
   }
 
-  private setResolved(
-    input: InlineCommentInput,
-    resolved: boolean,
-  ): ToolResult {
+  private setResolved(input: SetResolvedInput, resolved: boolean): ToolResult {
     const { threadId } = input;
-    if (threadId == null) {
-      throw new ToolError(
-        `The "${resolved ? 'resolve' : 'unresolve'}" command requires threadId.`,
-      );
-    }
     if (!requireProvider().setResolved({ threadId, resolved })) {
       return this.threadNotFound(threadId);
     }
@@ -225,7 +242,7 @@ export class InlineCommentTool extends defineTool({
     return executed(summary, summary);
   }
 
-  private list(input: InlineCommentInput): ToolResult {
+  private list(input: ListCommentInput): ToolResult {
     let absolutePath: string | undefined;
     if (input.path != null) {
       const workingDirectory =

--- a/src/tools/comment/InlineCommentTool.ts
+++ b/src/tools/comment/InlineCommentTool.ts
@@ -94,13 +94,12 @@ const InlineCommentInputSchema = z.discriminatedUnion('command', [
       command: z
         .literal('add')
         .describe('Open a new comment thread on a file range.'),
-      path: z
-        .string()
-        .trim()
-        .min(1)
-        .describe(
-          'File the comment anchors to. Workspace-relative or absolute.',
-        ),
+      path: z.string().trim().min(1).describe(
+        // Provider conversion advertises one `path` for all commands and keeps
+        // this first-declared branch's description (flattenTopLevelUnion), so
+        // it must also carry the list command's guidance.
+        'File the comment anchors to (add), or the file to restrict to (list; omit for all threads). Workspace-relative or absolute.',
+      ),
       line: z
         .int()
         .min(1)

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -53,31 +53,70 @@ import { SharedIssuePollingSource } from './IssuePollingSource';
 import { SharedPRPollingSource } from './PRPollingSource';
 import type { GhIssue, GhPullRequest } from './prTypes';
 
-const GitHubSubscriptionInputSchema = z.strictObject({
-  command: z.enum(['subscribe', 'unsubscribe', 'list', 'find_current']),
-  /**
-   * Subscription target — mirrors GitHub's REST URL shape. Required for
-   * `subscribe`/`unsubscribe`; ignored for `list`/`find_current`.
-   *
-   * - `owner/repo`               — repo-wide coarse subscription.
-   * - `owner/repo/pulls/N`       — per-PR nuanced subscription.
-   * - `owner/repo/issues/N`      — per-issue subscription.
-   */
-  path: z.string().nullish(),
-  /**
-   * Lowest inline check-annotation level to send for PR subscriptions.
-   * Defaults to failures only; use "warning" to include warnings, or
-   * "notice" to include every annotation GitHub reports.
-   */
-  min_annotation_level: z.enum(['failure', 'warning', 'notice']).nullish(),
-  /**
-   * Working directory for `find_current` to resolve the current branch's PR.
-   * Defaults to the agent's working directory.
-   */
-  working_directory: z.string().nullish(),
-});
+const SUBSCRIPTION_PATH_DESCRIPTION =
+  'Subscription target, mirroring GitHub\'s REST URL shape: "owner/repo" (repo-wide, coarse), "owner/repo/pulls/N" (per-PR, nuanced), or "owner/repo/issues/N" (per-issue).';
+
+// Branches use looseObject (not strictObject): provider conversion flattens the
+// discriminated union into one advertised object and OpenAI-compatible providers
+// null-fill the properties belonging to the other commands. See AGENTS.md
+// "Tool input schemas".
+const GitHubSubscriptionInputSchema = z.discriminatedUnion('command', [
+  z.looseObject({
+    command: z.literal('subscribe').describe('Start watching the path.'),
+    path: z.string().describe(SUBSCRIPTION_PATH_DESCRIPTION),
+    /**
+     * Lowest inline check-annotation level to send for PR subscriptions.
+     * Defaults to failures only; use "warning" to include warnings, or
+     * "notice" to include every annotation GitHub reports.
+     */
+    min_annotation_level: z
+      .enum(['failure', 'warning', 'notice'])
+      .nullish()
+      .describe(
+        'Lowest inline check-annotation level for PR subscriptions. Defaults to failures only; "warning" includes warnings, "notice" includes every annotation.',
+      ),
+  }),
+  z.looseObject({
+    command: z.literal('unsubscribe').describe('Stop watching the path.'),
+    path: z.string().describe(SUBSCRIPTION_PATH_DESCRIPTION),
+  }),
+  z.looseObject({
+    command: z
+      .literal('list')
+      .describe('List active subscriptions on this stream.'),
+  }),
+  z.looseObject({
+    command: z
+      .literal('find_current')
+      .describe(
+        'Resolve the current git branch to its PR path ("owner/repo/pulls/N").',
+      ),
+    /**
+     * Working directory for `find_current` to resolve the current branch's PR.
+     * Defaults to the agent's working directory.
+     */
+    working_directory: z
+      .string()
+      .nullish()
+      .describe(
+        "Working directory to resolve the current branch's PR. Defaults to the agent's working directory.",
+      ),
+  }),
+]);
 
 type GitHubSubscriptionInput = z.infer<typeof GitHubSubscriptionInputSchema>;
+type SubscribeInput = Extract<
+  GitHubSubscriptionInput,
+  { command: 'subscribe' }
+>;
+type UnsubscribeInput = Extract<
+  GitHubSubscriptionInput,
+  { command: 'unsubscribe' }
+>;
+type FindCurrentInput = Extract<
+  GitHubSubscriptionInput,
+  { command: 'find_current' }
+>;
 
 interface ParsedRepoPath {
   kind: 'repo';
@@ -137,7 +176,7 @@ function slugOf(target: { owner: string; repo: string }): string {
   return `${target.owner}/${target.repo}`;
 }
 
-function requirePath(input: GitHubSubscriptionInput): ParsedPath {
+function requirePath(input: { command: string; path: string }): ParsedPath {
   if (!input.path) {
     throw new ToolError(
       `command="${input.command}" requires a path ("owner/repo", "owner/repo/pulls/N", or "owner/repo/issues/N").`,
@@ -162,9 +201,7 @@ function prSubscriptionActivitySentence(
   return `New comments, reviews, line comments, failed CI checks, inline check annotations (${annotationLevelDescription} pinned to file:line), and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups.`;
 }
 
-async function execSubscribe(
-  input: GitHubSubscriptionInput,
-): Promise<ToolResult> {
+async function execSubscribe(input: SubscribeInput): Promise<ToolResult> {
   await requireToken();
   const { streamId } = requireRunStream('github_subscription');
   const target = requirePath(input);
@@ -269,7 +306,7 @@ async function resolveIssueIsPR(
   return res.data.pull_request != null;
 }
 
-function execUnsubscribe(input: GitHubSubscriptionInput): ToolResult {
+function execUnsubscribe(input: UnsubscribeInput): ToolResult {
   const { streamId } = requireRunStream('github_subscription');
   const target = requirePath(input);
   const slug = slugOf(target);
@@ -424,9 +461,7 @@ async function getFindCurrentFallbackInfo(
   };
 }
 
-async function execFindCurrent(
-  input: GitHubSubscriptionInput,
-): Promise<ToolResult> {
+async function execFindCurrent(input: FindCurrentInput): Promise<ToolResult> {
   await requireToken();
   const cwd =
     parseWorkingDirectory(input.working_directory) ??


### PR DESCRIPTION
## Summary

`InlineCommentTool` and `githubSubscriptionTool` were the two command/action tools still declaring a flat `z.strictObject` with a `z.enum` discriminator, every field marked optional-nullable, and per-command required-ness re-derived at runtime with hand-written `"X command requires Y"` throws. That made invalid field combinations *representable* (a `reply` with no `threadId`, an `add` with no `body`, both type-checked) and duplicated in imperative code what a schema can state declaratively — directly against the repo's own guidance to prefer `z.discriminatedUnion()`, which 7 sibling command-tools already follow (`MemoryTool`, `PlanTool`, `ExternalInquiryTool`, `DiagnosticsTool`, `LoogleTool`, `CrossrefSearchTool`, `executions/toolInput`).

Both are now `z.discriminatedUnion('command', …)` with one `looseObject` variant per command declaring exactly the fields that command requires. Each per-command handler is narrowed to its matching variant via `Extract<Input, { command: … }>`, so the field accesses are statically known-present instead of null-guarded. The `endLine >= line` check moves onto the `add` branch as a `.refine`. Bad inputs are now rejected up front by `BaseTool.call`'s validation path with a field-level message rather than a bespoke runtime throw inside `execute`.

Branches use `looseObject` (not `strictObject`) deliberately: provider conversion flattens a top-level discriminated union back into one advertised object (`flattenTopLevelUnion` in `toolConversion.ts`), and OpenAI-compatible providers null-fill the properties belonging to the other commands — `strictObject` would reject those.

**Model-facing schema:** the advertised parameters stay a single flat object (all fields optional except `command`, whose per-literal descriptions are joined). Two intended, minor differences from the old flat schema, from `flattenTopLevelUnion`'s first-branch-wins property merge: a property declared by more than one branch keeps only its first branch's shape/description (so `inline_comment`'s `path` — declared by both `add` and `list` — now carries the list guidance folded into the `add` description, see the follow-up commit; `github_subscription`'s `path` uses one shared constant, so nothing is lost there), and `additionalProperties: false` is no longer emitted (the `looseObject` tradeoff). All fields except `command` remain optional, so this does not change what the model must supply.

## Issue acceptance gates

No issue — this implements finding #4 ("command-tool schema inconsistency") from a codebase debt audit. Gate: the two outlier tools match the discriminated-union pattern the rest of the tool tree and the Zod guidance already use, with no behavior change beyond where/how invalid input is rejected.

## Single source of truth

The per-command Zod variant is now the single source of truth for which fields each command requires. The `switch (input.command)` in each tool's `execute` narrows to that variant; there is no second, imperative enumeration of required-ness.

## Duplication and abstraction budget

Removes the parallel imperative validation layer (4 `throw new ToolError('… requires …')` sites and one `endLine < line` throw) that restated the schema's intent in code. No new abstraction or pass-through layer added; only local variant types (`AddCommentInput`, `SubscribeInput`, …) derived with `Extract<>`.

## Net elements (R6)

- Files: 3 changed, 0 added, 0 deleted (`src/tools/comment/InlineCommentTool.ts`, `src/tools/github/githubSubscriptionTool.ts`, `src/test-kernel/tools/InlineCommentTool.vitest.ts`).
- Exported symbols: **no change** (`^[+-]export` over the diff is empty). New types are file-local.
- Classes/interfaces/enums: no runtime classes added; the flat `z.enum` discriminator is replaced by per-branch `z.literal`s; 5 local `type … = Extract<>` aliases added.
- Net LoC: **~+58** (two commits; the declarative union with per-variant field descriptions is more verbose than the flat object it replaces, while the deleted code is the imperative validation — 4 throws). The win here is correctness (invalid command/field combinations become unrepresentable and are caught at the schema boundary) and type-narrowed handlers, not line count.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed. The changed input types (`InlineCommentInput`, `GitHubSubscriptionInput`) are file-local with zero external consumers; `requirePath`'s parameter type was narrowed but it is a file-local helper.

## Host impact

Extension: none — `inline_comment` runs only in the extension host; its agent-facing surface (advertised JSON schema, error results) is unchanged apart from the intended description/`additionalProperties` differences noted above.

Desktop: none.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — passes (exit 0, all packages).
- `npx vitest run src/test-kernel/tools/` — 767 passed; `AgentPromptContracts` (731) passes.
- `AgentPromptContracts`, `ToolRegistryAliases`, `GitHubSubscriptionProgressEvents`, `InlineComments` suites — pass (updated the one `InlineCommentTool` assertion that pinned the old imperative error string to the schema-validation message; fixed an em-dash prompt-contract violation introduced by moving a description from a JSDoc comment into a `.describe()` literal).
- `npx eslint` on the changed files — clean.
- `npx prettier` — formatted.
- Follow-up commit `2b6a825` addresses TeXRA review feedback: folds the `list` command's `path` guidance into the surviving advertised description (see the Model-facing schema note above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtPRadyDG4dtvV6KejssAe