### PR TITLE
fix(subscription-usage): reject negative numeric-string timestamps; Zod-check the Codex model catalog shape

### DIFF
--- a/src/controllers/modelAccess/subscriptionUsage/subscriptionUsageParsing.ts
+++ b/src/controllers/modelAccess/subscriptionUsage/subscriptionUsageParsing.ts
@@ -60,20 +60,28 @@ const looseFiniteNumber = z.preprocess((value) => {
   return value;
 }, z.number().finite());
 
-/** A wire timestamp expressed as epoch seconds or epoch milliseconds
- *  (whichever a `looseFiniteNumber` resolves to), normalized to epoch ms. */
-const epochMsField = looseFiniteNumber.pipe(
-  z
-    .number()
-    .nonnegative()
-    .transform((value) =>
-      Math.trunc(value < 100_000_000_000 ? value * 1000 : value),
-    ),
-);
-
-/** A wire timestamp expressed as an ISO 8601 (or otherwise `Date.parse`-able)
- *  string, normalized to epoch ms. */
-const isoTimestampField = z.string().transform((value, ctx) => {
+/** A wire timestamp expressed as an epoch number (seconds or milliseconds,
+ *  whichever `looseFiniteNumber` resolves to) or an ISO 8601 string,
+ *  normalized to epoch ms. A value that parses as a number commits to the
+ *  numeric interpretation — a negative epoch is rejected outright rather
+ *  than falling through to `Date.parse`, which accepts some non-ISO
+ *  numeric-looking strings as dates (`Date.parse('-1')` resolves to
+ *  2001-01-01). */
+const timestampMsField = z.any().transform((value, ctx) => {
+  const numeric = looseFiniteNumber.safeParse(value);
+  if (numeric.success) {
+    if (numeric.data < 0) {
+      ctx.addIssue({ code: 'custom', message: 'negative epoch timestamp' });
+      return z.NEVER;
+    }
+    return Math.trunc(
+      numeric.data < 100_000_000_000 ? numeric.data * 1000 : numeric.data,
+    );
+  }
+  if (typeof value !== 'string') {
+    ctx.addIssue({ code: 'custom', message: 'not a timestamp' });
+    return z.NEVER;
+  }
   const parsed = Date.parse(value);
   if (Number.isNaN(parsed)) {
     ctx.addIssue({ code: 'custom', message: 'not a parseable date string' });
@@ -81,10 +89,6 @@ const isoTimestampField = z.string().transform((value, ctx) => {
   }
   return parsed;
 });
-
-/** Provider responses report reset timestamps either as epoch numbers (mixed
- *  seconds/ms) or as ISO strings — try the numeric form first. */
-const timestampMsField = z.union([epochMsField, isoTimestampField]);
 
 /** Pick the first field, by alias, that parses against `schema`. Every
  *  subscription-usage adapter reads the same provider concept under several

--- a/src/controllers/modelAccess/subscriptionUsage/subscriptionUsageParsing.ts
+++ b/src/controllers/modelAccess/subscriptionUsage/subscriptionUsageParsing.ts
@@ -61,12 +61,12 @@ const looseFiniteNumber = z.preprocess((value) => {
 }, z.number().finite());
 
 /** A wire timestamp expressed as an epoch number (seconds or milliseconds,
- *  whichever `looseFiniteNumber` resolves to) or an ISO 8601 string,
- *  normalized to epoch ms. A value that parses as a number commits to the
- *  numeric interpretation — a negative epoch is rejected outright rather
- *  than falling through to `Date.parse`, which accepts some non-ISO
- *  numeric-looking strings as dates (`Date.parse('-1')` resolves to
- *  2001-01-01). */
+ *  whichever `looseFiniteNumber` resolves to) or an ISO 8601 (or otherwise
+ *  `Date.parse`-able) string, normalized to epoch ms. A value that parses as
+ *  a number commits to the numeric interpretation — a negative epoch is
+ *  rejected outright rather than falling through to `Date.parse`, which
+ *  accepts some non-ISO numeric-looking strings as dates (`Date.parse('-1')`
+ *  resolves to 2001-01-01). */
 const timestampMsField = z.any().transform((value, ctx) => {
   const numeric = looseFiniteNumber.safeParse(value);
   if (numeric.success) {

--- a/src/test-kernel/controllers/modelAccess/SubscriptionUsageService.vitest.ts
+++ b/src/test-kernel/controllers/modelAccess/SubscriptionUsageService.vitest.ts
@@ -6,7 +6,10 @@ import {
   CHATGPT_USAGE_URL,
   parseChatGptUsage,
 } from '@controllers/modelAccess/subscriptionUsage/codexUsageAdapter';
-import type { SubscriptionUsageHttp } from '@controllers/modelAccess/subscriptionUsage/subscriptionUsageParsing';
+import {
+  timestampField,
+  type SubscriptionUsageHttp,
+} from '@controllers/modelAccess/subscriptionUsage/subscriptionUsageParsing';
 import {
   GLM_CODING_PLAN_INTERNATIONAL_USAGE_URL,
   GLM_CODING_PLAN_USAGE_URL,
@@ -376,6 +379,14 @@ describe('subscription usage parsers', () => {
       ['five_hour', 30],
       ['weekly', 40],
     ]);
+  });
+
+  // A numeric-looking string that fails the epoch check must not fall
+  // through to Date.parse, which accepts some non-ISO numeric strings as
+  // dates (e.g. Date.parse('-1') resolves to 2001-01-01).
+  it('rejects a negative numeric timestamp instead of misreading it as a date', () => {
+    expect(timestampField({ resetAt: -1 }, 'resetAt')).toBeUndefined();
+    expect(timestampField({ resetAt: '-1' }, 'resetAt')).toBeUndefined();
   });
 });
 

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -17,6 +17,8 @@
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
 
+import { z } from 'zod';
+
 import { isModuleNotFoundError } from '@common/errors';
 import { createLog } from '@logger/logUtils';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
@@ -147,18 +149,23 @@ type BundledCodexModel = {
   supported_reasoning_levels?: Array<{ effort?: string }>;
 };
 
+/** Just the shape `catalogSupportsXhigh` depends on — a `models` array. Model
+ *  entries stay `unknown` here and are duck-typed below, so one malformed
+ *  entry elsewhere in the catalog can't take down a lookup for a model it
+ *  doesn't concern. */
+const BundledCodexCatalogSchema = z.object({
+  models: z.array(z.unknown()),
+});
+
 function catalogSupportsXhigh(
   stdout: string,
   model: string,
 ): boolean | undefined {
   try {
     const parsed: unknown = JSON.parse(stdout);
-    if (typeof parsed !== 'object' || parsed == null || !('models' in parsed)) {
-      return undefined;
-    }
-    const models = (parsed as { models: unknown }).models;
-    if (!Array.isArray(models)) return undefined;
-    const entry = models.find(
+    const catalog = BundledCodexCatalogSchema.safeParse(parsed);
+    if (!catalog.success) return undefined;
+    const entry = catalog.data.models.find(
       (item): item is BundledCodexModel =>
         typeof item === 'object' &&
         item != null &&


### PR DESCRIPTION
## Summary

Follow-up to the dependency-audit refactor merged in #11755. That PR's automated review (Codex) caught a real regression in the new code, and a fresh scan for further reinvented-wheel candidates on the current `main` turned up one more contained fix. Both are in this PR:

1. **Negative numeric-string timestamps were misread as real dates.** `timestampMsField` in `subscriptionUsageParsing.ts` was `z.union([epochMsField, isoTimestampField])`. A value like `"-1"` correctly fails `epochMsField` (negative), but the union then retries `isoTimestampField`, and `Date.parse('-1')` resolves to `2001-01-01T00:00:00.000Z` (confirmed locally) instead of being rejected. The original hand-rolled `timestampMs()` never fell through to ISO parsing once a value parsed as a number — it returned `undefined` immediately for a negative epoch. Replaced the union with one `z.any().transform()` that commits to the numeric interpretation first, exactly matching the original control flow, plus a regression test (`timestampField({ resetAt: '-1' }, 'resetAt')` now correctly returns `undefined`).
2. **`codexImport.ts`'s `catalogSupportsXhigh`** hand-rolled the outer shape check for the Codex CLI's `debug models --bundled` JSON (`typeof parsed !== 'object' || parsed == null || !('models' in parsed)` + `!Array.isArray(models)`) instead of using Zod, which the codebase uses everywhere else for exactly this. Replaced with one `BundledCodexCatalogSchema.safeParse()` call that is provably equivalent to the manual checks it replaces (same accept/reject decision for every input) — the per-entry duck-typed matching logic underneath is untouched, so a malformed unrelated catalog entry still can't take down a lookup for a different model.

Note: `claude/festive-cerf-wx8y0j` briefly carried a stale duplicate of #11755's already-merged diff (opened as #11776, since closed without merging) before being reset onto the current `main` tip. This PR is fresh work on top of that reset — see the Codex/claude[bot] review comments on #11776 for the discussion that led to finding #1 here.

## Issue acceptance gates

No tracked issue — follow-up from #11755's automated review plus a fresh audit pass. Gate: the regression is fixed with a test pinning it, and the second finding compiles to a provably equivalent check.

## Single source of truth

- Wire-timestamp coercion in `subscriptionUsageParsing.ts`: one `timestampMsField` transform owns the numeric-vs-ISO decision (previously split across a `z.union` of two independently-evaluated branches, which is what let the union backtrack into ISO parsing).
- Codex bundled-model catalog shape: `BundledCodexCatalogSchema` (Zod) owns the "is this JSON shaped like a catalog" check; the codebase's Zod convention now covers this call site too.

## Duplication and abstraction budget

Removed: the now-redundant `epochMsField`/`isoTimestampField` intermediate schemas (folded into one `timestampMsField` transform); the hand-rolled `typeof`/`in`/`Array.isArray` shape check in `codexImport.ts`.

No new abstractions — `BundledCodexCatalogSchema` is a private, single-use schema local to `catalogSupportsXhigh`, not a new shared export.

## Net elements (R6)

`git diff origin/main...HEAD --stat`: 3 files changed, 47 insertions(+), 25 deletions(-).
Exported symbols: 0 added, 0 removed — `stringField`/`numberField`/`timestampField`/`catalogSupportsXhigh`'s caller-facing behavior are unchanged (the latter is not exported).

## Consumer counts (R8)

n/a — no emit path or export deleted or re-routed; `timestampField` and the (unexported) `catalogSupportsXhigh` keep their exact existing signatures and call sites.

## Host impact

Extension: none — both touched files are host-agnostic (`src/controllers/`, `src/tools/`), consumed without change.

Desktop: none, same host-agnostic surface.

CLI: none, same host-agnostic surface.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` (all six workspace projects: workspace, test-kernel, agent, cli, trace-viewer, desktop) — passes.
- `npm run lint` — clean across `src`, `packages/agent`, `packages/extension`, `packages/desktop`, `packages/cli`.
- `npm run check:dead-code-ratchet` — no new findings.
- `npx vitest run src/test-kernel/controllers/modelAccess src/test-kernel/common/GlmCodingPlanDetection.vitest.ts src/test-kernel/tools/CodexResumeFallback.vitest.ts` — 52/52 passing, including the new regression test.
- Verified `Date.parse('-1')` locally (`978307200000` → `2001-01-01T00:00:00.000Z`) to confirm the bug the fix addresses.
- Full `npx vitest run` kicked off as an additional sanity pass; not blocking since every suite that exercises the touched code already passed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7buPbZjDjYBcjthKZoPyx

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7buPbZjDjYBcjthKZoPyx)_