### PR TITLE
refactor: give two swallow-and-log policies a single owner

### DIFF
--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -76,6 +76,34 @@ export class LatexMediaManager {
     private readonly fileService?: TaskRunFileService,
   ) {}
 
+  /**
+   * Run `task` over `items` at the LaTeX concurrency limit, keeping going when
+   * an individual item fails. Mirroring is best-effort by design — a deleted
+   * figure or a dependency outside the workspace must not take the surviving
+   * files down with it — so the failure is swallowed, and logged here with the
+   * offending path rather than at each call site.
+   */
+  private async forEachFile<T>(
+    items: readonly T[],
+    pathOf: (item: T) => string,
+    failureMessage: string,
+    task: (item: T) => Promise<unknown>,
+  ): Promise<void> {
+    await pMap(
+      items,
+      async (item) => {
+        try {
+          await task(item);
+        } catch (error) {
+          this.logger.debug(failureMessage, {
+            data: { path: pathOf(item), error },
+          });
+        }
+      },
+      { concurrency: LATEX_CONCURRENCY, stopOnError: false },
+    );
+  }
+
   private async mirrorFigureDependencies(
     latexFile: FileLocation,
     figures: string[],
@@ -105,18 +133,12 @@ export class LatexMediaManager {
       return;
     }
 
-    await pMap(
+    await this.forEachFile(
       [...absolutePaths],
-      async (absolutePath) => {
-        try {
-          await fileService.mirrorWorkspaceFile(pathToLocation(absolutePath));
-        } catch (error) {
-          this.logger.debug('Unable to mirror figure dependency', {
-            data: { path: absolutePath, error },
-          });
-        }
-      },
-      { concurrency: LATEX_CONCURRENCY, stopOnError: false },
+      (absolutePath) => absolutePath,
+      'Unable to mirror figure dependency',
+      (absolutePath) =>
+        fileService.mirrorWorkspaceFile(pathToLocation(absolutePath)),
     );
   }
 
@@ -272,25 +294,20 @@ export class LatexMediaManager {
       const deps = await this.collectDependencies(file);
       if (deps.length === 0) continue;
 
-      await pMap(
+      await this.forEachFile(
         deps,
+        (absolutePath) => absolutePath,
+        'Unable to mirror LaTeX dependency',
         async (absolutePath) => {
           const depLocation = pathToLocation(absolutePath);
           const isTex = hasExtension(absolutePath, '.tex');
-          try {
-            await fileService.mirrorWorkspaceFile(depLocation, {
-              snapshot: isTex,
-            });
-            if (isTex) {
-              worklist.push(depLocation);
-            }
-          } catch (error) {
-            this.logger.debug('Unable to mirror LaTeX dependency', {
-              data: { path: absolutePath, error },
-            });
+          await fileService.mirrorWorkspaceFile(depLocation, {
+            snapshot: isTex,
+          });
+          if (isTex) {
+            worklist.push(depLocation);
           }
         },
-        { concurrency: LATEX_CONCURRENCY, stopOnError: false },
       );
       this.logger.debug('Mirrored LaTeX dependencies', {
         data: { count: deps.length, from: file.absolutePath },
@@ -378,20 +395,15 @@ export class LatexMediaManager {
 
     if (candidates.length === 0) return;
 
-    await pMap(
+    await this.forEachFile(
       candidates,
+      (absolutePath) => absolutePath,
+      'Unable to mirror project sibling',
       async (absolutePath) => {
-        try {
-          const stats = await platform().fs.stat(absolutePath);
-          if (!isFile(stats.type)) return;
-          await fileService.mirrorWorkspaceFile(pathToLocation(absolutePath));
-        } catch (error) {
-          this.logger.debug('Unable to mirror project sibling', {
-            data: { path: absolutePath, error },
-          });
-        }
+        const stats = await platform().fs.stat(absolutePath);
+        if (!isFile(stats.type)) return;
+        await fileService.mirrorWorkspaceFile(pathToLocation(absolutePath));
       },
-      { concurrency: LATEX_CONCURRENCY, stopOnError: false },
     );
   }
 
@@ -411,20 +423,15 @@ export class LatexMediaManager {
     );
     if (texFiles.length === 0) return;
 
-    await pMap(
+    await this.forEachFile(
       texFiles,
+      (file) => file.absolutePath,
+      'Unable to mirror figures',
       async (file) => {
-        try {
-          const figures = await extractFigurePathsFromLatex(file);
-          if (figures.length === 0) return;
-          await this.mirrorFigureDependencies(file, figures);
-        } catch (error) {
-          this.logger.debug('Unable to mirror figures', {
-            data: { path: file.absolutePath, error },
-          });
-        }
+        const figures = await extractFigurePathsFromLatex(file);
+        if (figures.length === 0) return;
+        await this.mirrorFigureDependencies(file, figures);
       },
-      { concurrency: LATEX_CONCURRENCY, stopOnError: false },
     );
   }
 

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -30,6 +30,7 @@ import {
   buildApprovalRejectedResult,
   requestToolEditApproval,
   writeApprovedContent,
+  type ToolEditApprovalResult,
 } from '@tools/approval/toolEditApproval';
 import { filterNotNull, filterNotNullish } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
@@ -41,6 +42,39 @@ import {
   getOriginalSnapshotPath,
   inspectRunStorageEntry,
 } from '@utils/files/runStorageFs';
+
+// ============================================================================
+// Rejection bookkeeping
+// ============================================================================
+
+/**
+ * The `RejectionProvenance` channels, in the order a summary considers them
+ * when naming the file it blames. One settlement populates exactly one, but
+ * accepting a whole run can produce a mix, so each is recorded per rejection.
+ */
+const REJECTION_CHANNELS = ['feedback', 'reason', 'cause'] as const;
+
+type RejectionChannel = (typeof REJECTION_CHANNELS)[number];
+
+interface RecordedRejection {
+  readonly channel: RejectionChannel;
+  readonly path: string;
+  readonly message: string | undefined;
+}
+
+/** Narrow one declined approval to the single channel it arrived on. */
+function recordRejection(
+  approval: Exclude<ToolEditApprovalResult, { action: 'apply' }>,
+  path: string,
+): RecordedRejection {
+  if ('cause' in approval) {
+    return { channel: 'cause', path, message: approval.cause };
+  }
+  if ('reason' in approval) {
+    return { channel: 'reason', path, message: approval.reason };
+  }
+  return { channel: 'feedback', path, message: approval.feedback };
+}
 
 // ============================================================================
 // Schema
@@ -191,12 +225,7 @@ Parameters map directly to subagent-result delivery attributes:
     }[] = [];
     let rejected = 0;
     let unchanged = 0;
-    const rejectionFeedback: string[] = [];
-    const rejectionReasons: string[] = [];
-    const rejectionCauses: string[] = [];
-    let firstUserRejectionPath: string | undefined;
-    let firstPolicyDenialPath: string | undefined;
-    let firstCancellationPath: string | undefined;
+    const rejections: RecordedRejection[] = [];
 
     let totalStripped = 0;
 
@@ -219,16 +248,7 @@ Parameters map directly to subagent-result delivery attributes:
 
       if (approval.action !== 'apply') {
         rejected++;
-        if ('cause' in approval) {
-          firstCancellationPath ??= entry.original;
-          if (approval.cause) rejectionCauses.push(approval.cause);
-        } else if ('reason' in approval) {
-          firstPolicyDenialPath ??= entry.original;
-          if (approval.reason) rejectionReasons.push(approval.reason);
-        } else {
-          firstUserRejectionPath ??= entry.original;
-          if (approval.feedback) rejectionFeedback.push(approval.feedback);
-        }
+        rejections.push(recordRejection(approval, entry.original));
         results.push(`rejected: ${entry.original}${mappingNote}`);
         continue;
       }
@@ -284,24 +304,28 @@ Parameters map directly to subagent-result delivery attributes:
     // `reason`/`cause` still selects the denial/cancellation wording in
     // buildApprovalRejectedResult.
     if (rejected === changed && acceptedEntries.length === 0) {
-      const presentFirstPaths = [
-        firstUserRejectionPath,
-        firstPolicyDenialPath,
-        firstCancellationPath,
-      ].filter(filterNotNullish);
+      const firstPathOn = (channel: RejectionChannel): string | undefined =>
+        rejections.find((rejection) => rejection.channel === channel)?.path;
+      const messagesOn = (channel: RejectionChannel): string[] =>
+        rejections
+          .filter((rejection) => rejection.channel === channel)
+          .map((rejection) => rejection.message)
+          .filter((message): message is string => !!message);
+
+      const presentFirstPaths =
+        REJECTION_CHANNELS.map(firstPathOn).filter(filterNotNullish);
       const summaryPath =
         presentFirstPaths.length > 1
           ? 'multiple files'
           : (presentFirstPaths[0] ?? prepared[0].original);
+      const feedback = messagesOn('feedback');
       return buildApprovalRejectedResult(summaryPath, 'accept_run_files', {
-        ...(rejectionFeedback.length > 0
-          ? { feedback: rejectionFeedback.join('\n') }
+        ...(feedback.length > 0 ? { feedback: feedback.join('\n') } : {}),
+        ...(firstPathOn('reason') !== undefined
+          ? { reason: messagesOn('reason').join('\n') }
           : {}),
-        ...(firstPolicyDenialPath !== undefined
-          ? { reason: rejectionReasons.join('\n') }
-          : {}),
-        ...(firstCancellationPath !== undefined
-          ? { cause: rejectionCauses.join('\n') || undefined }
+        ...(firstPathOn('cause') !== undefined
+          ? { cause: messagesOn('cause').join('\n') || undefined }
           : {}),
       });
     }

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -30,7 +30,6 @@ import {
   buildApprovalRejectedResult,
   requestToolEditApproval,
   writeApprovedContent,
-  type ToolEditApprovalResult,
 } from '@tools/approval/toolEditApproval';
 import { filterNotNull, filterNotNullish } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
@@ -60,20 +59,6 @@ interface RecordedRejection {
   readonly channel: RejectionChannel;
   readonly path: string;
   readonly message: string | undefined;
-}
-
-/** Narrow one declined approval to the single channel it arrived on. */
-function recordRejection(
-  approval: Exclude<ToolEditApprovalResult, { action: 'apply' }>,
-  path: string,
-): RecordedRejection {
-  if ('cause' in approval) {
-    return { channel: 'cause', path, message: approval.cause };
-  }
-  if ('reason' in approval) {
-    return { channel: 'reason', path, message: approval.reason };
-  }
-  return { channel: 'feedback', path, message: approval.feedback };
 }
 
 // ============================================================================
@@ -248,7 +233,23 @@ Parameters map directly to subagent-result delivery attributes:
 
       if (approval.action !== 'apply') {
         rejected++;
-        rejections.push(recordRejection(approval, entry.original));
+        // Narrow the declined approval to the single channel it arrived on.
+        const path = entry.original;
+        if ('cause' in approval) {
+          rejections.push({ channel: 'cause', path, message: approval.cause });
+        } else if ('reason' in approval) {
+          rejections.push({
+            channel: 'reason',
+            path,
+            message: approval.reason,
+          });
+        } else {
+          rejections.push({
+            channel: 'feedback',
+            path,
+            message: approval.feedback,
+          });
+        }
         results.push(`rejected: ${entry.original}${mappingNote}`);
         continue;
       }


### PR DESCRIPTION
## Summary

Two spots decided the same thing at every call site instead of in one place.

**`LatexMediaManager`** mirrored files into run storage through four copies of the same `pMap` + try/catch/debug scaffold — figure dependencies, LaTeX dependencies, project siblings, and output figures. Each copy repeated the concurrency limit, `stopOnError: false`, and the swallow-and-log handling, so the best-effort mirroring policy had four places to drift and no single statement of why a failed item is tolerated. They now share one `forEachFile` helper that owns the policy and documents the rationale (per the "silent degradation is a defect" rule, a swallowed failure needs a stated reason, in one place).

**`AcceptRunFilesTool`** tracked rejected edits in six parallel locals — three message arrays and three `first*Path` variables — so the exactly-one-channel invariant of `RejectionProvenance` was implicit across all six, and adding a fourth channel would have meant touching every one. They collapse to a single `RecordedRejection[]`, with the channel order named once in `REJECTION_CHANNELS` and consumed at the read site by `firstPathOn`/`messagesOn`.

Both changes are behavior-preserving. This is a single-authority/clarity refactor, **not** a line-count reduction — see the accounting below.

## Issue acceptance gates

No issue. This came out of a codebase debt audit; these were the two findings that still held on current `main` and were clearly net-positive. Notably, the audit's headline LaTeX finding (duplicated `\DIFdel`/`\DIFadd` markup regex families in `rulesRegex.ts`) was **already fixed upstream** by #11737, so nothing was done there.

## Single source of truth

- `LatexMediaManager.forEachFile` now owns the concurrent best-effort mirroring policy: concurrency limit, `stopOnError: false`, and swallow-and-log-with-path.
- `REJECTION_CHANNELS` in `AcceptRunFilesTool` names the `RejectionProvenance` channel set and the order summaries consider them in, replacing the ordering that was previously implicit in how six separate variables were declared and read.

## Duplication and abstraction budget

Removed: 4 → 1 copies of the mirror scaffold; 6 → 1 rejection accumulators.

Added: one private method (`forEachFile`, 4 callers). It is not a pass-through layer — it owns the swallow-and-log policy that was previously restated at each call site. No new exports, no new barrels, no re-export shims.

A first draft also extracted a `recordRejection` classifier; review correctly flagged it as a single-caller extraction (banned by CLAUDE.md / AGENTS.md / checklist §13), and 71227a2 inlined it. The three-way `in`-narrowing now sits at the push site it serves.

## Net elements (R6)

Current head `71227a2`:

- Files: 2 changed, 0 added, 0 deleted (`102 insertions(+), 70 deletions(-)`).
- Exported symbols: **0 added, 0 removed** (`^[+-]export` over the diff is empty).
- Constructs: +1 interface (`RecordedRejection`), +1 type alias (`RejectionChannel`), +1 const (`REJECTION_CHANNELS`), +1 private method (`forEachFile`); −6 local variables, −3 duplicated `pMap` option/handler blocks.
- Net LoC: **+32** total; **+9** counting code lines only (the remainder is the two doc comments).

Stating it plainly: this does not reduce line count. The win is that two policies each have one owner rather than four and six respectively; element count is roughly flat.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed. Both new symbols are module- or class-private; the diff adds and removes no exported symbols.

## Host impact

Extension: none — behavior-preserving, no host wiring, no new command or setting.

Desktop: none.

CLI: none.

Both touched files are in VS Code-free zones (`src/latex/`, `src/tools/`) and stay that way; no `vscode` import, no `Platform` port added, no `bus.emit` added.

## Scheduled refactoring

None. Two audit findings were deliberately **not** acted on and need no follow-up issue:
- The per-provider `createResponseImpl` / streaming-scaffold duplication in `modelHandlers/` — the three raw streaming sites differ by deliberate, documented provider semantics (when streams open relative to the SDK retry boundary), so collapsing them would need 5+ callbacks for 3 sites and would bury that intent.
- The `*Files` schema cluster — the one interesting part (`mediaFiles` being nullable in `MainViewExecuteFilesSchema` alone) is a behavior question about what the webview actually sends, not a mechanical dedup, so it shouldn't be changed unilaterally.

## Validation

Run locally on this branch, all passing:
- `npm run typecheck` (builds don't type check, so this is the load-bearing one) — clean on both commits; it caught two real errors in the first draft (a `Promise<void>` vs returned-value mismatch, and a non-narrowing filter predicate), both fixed before the first push.
- `npm run lint` — clean.
- `npx prettier --check` on both files — clean.
- `npm test` (full Vitest suite) — **822 files / 10,012 tests passed**, 1 file + 6 tests skipped, exit 0. Run on `f594302`; the follow-up commit is a local inline of the same branch logic, revalidated with typecheck + lint + the four touched-area kernel suites (21 tests).
- `npm run check:dead-code-ratchet` — no new findings (294 vs 294 baselined).
- `npm run check:browser-safe-utils` — OK (65 total, 6 reachable, unchanged).
- `npm run check:guidance-refs`, `npm run check:tsconfig-paths` — OK.

Behavior equivalence was checked by hand on the subtle parts of the `AcceptRunFilesTool` path, since the tests don't cover the all-rejected branch directly: classification precedence (`cause` → `reason` → `feedback`), the `[feedback, reason, cause]` ordering that feeds the "multiple files" summary, the truthiness filter that drops empty messages (kept as `!!message`, not `!== undefined`, so an empty string is still excluded), and the spread conditions hinging on path presence rather than message length.