### PR TITLE
fix(agent): keep a live reservation when restart repair holds a stream

### DIFF
--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -289,15 +289,27 @@ export class StreamStatusMachine {
     return false;
   }
 
-  /** Record why restart classification could not settle this stream. */
-  markUnavailable(stream: StreamTabId, detail: string): void {
+  /**
+   * Record why restart classification could not settle this stream. Returns
+   * `false` without writing when a live reservation owns the stream: a hold
+   * describes a run some earlier process left behind, which a reservation has
+   * by definition superseded, and overwriting one strands the tab — a hold is
+   * not `reserved`, so `releaseIfReserved` becomes a no-op and a failed
+   * launch's rollback never runs, while the RUNNING the hold inherits from
+   * `effectiveState` blocks every later `tryAcquire`. Holds lived in a side
+   * map before they became an entry arm and could not do this. The caller
+   * logs the refusal so the skipped hold is not silent.
+   */
+  markUnavailable(stream: StreamTabId, detail: string): boolean {
     const entry = this.streams.get(stream);
+    if (entry?.kind === 'reserved') return false;
     const state = entry ? effectiveState(entry) : undefined;
     this.streams.set(stream, {
       kind: 'hold',
       detail,
       ...(state ? { state } : {}),
     });
+    return true;
   }
 
   /**

--- a/src/agent/runtime/restartRepair.ts
+++ b/src/agent/runtime/restartRepair.ts
@@ -237,7 +237,11 @@ export async function repairRestartedStreams(
         );
         break;
     }
-    options.streamStatus.markUnavailable(streamId, detail);
+    if (!options.streamStatus.markUnavailable(streamId, detail)) {
+      options.logger?.debug(
+        `Kept the live reservation on stream ${streamId} instead of marking it unavailable: ${detail}`,
+      );
+    }
     return true;
   };
 
@@ -322,6 +326,12 @@ export async function repairRestartedStreams(
       // A settlement that already mutated must surface; a lock that could
       // not even be taken proves nothing, so the stream stays unavailable.
       if (settleStarted) throw error;
+      if (!isCurrent(streamId, executionId)) {
+        options.logger?.debug(
+          `Skipped restart repair for stream ${streamId}: it was reused before settlement`,
+        );
+        continue;
+      }
       applyHold(streamId, executionId, {
         kind: 'unclassified',
         cause: `lease lock unavailable (${toErrorMessage(error)})`,
@@ -335,6 +345,12 @@ export async function repairRestartedStreams(
       // registry/lease disagreement as `owned_here`, never another window.
       if (isInFlightPhase(options.streamStatus.get(streamId))) continue;
       const self = await currentLeaseOwner();
+      if (!isCurrent(streamId, executionId)) {
+        options.logger?.debug(
+          `Skipped restart repair for stream ${streamId}: it was reused before settlement`,
+        );
+        continue;
+      }
       const { owner } = maintenance;
       // Same process requires both identities known and equal: two unknown
       // identities prove nothing, and such an owner is held, not ours.

--- a/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
+++ b/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
@@ -115,6 +115,22 @@ describe('StreamStatusMachine', () => {
     expect(machine.tryAcquire(streamId)).toBe(false);
   });
 
+  it('refuses to overwrite a live reservation with a hold', () => {
+    const { machine, streamId } = setupMachine(
+      'stream-status-reservation-vs-hold',
+    );
+
+    expect(machine.tryAcquire(streamId)).toBe(true);
+    expect(machine.markUnavailable(streamId, 'lease lock unavailable')).toBe(
+      false,
+    );
+    expect(machine.holdState(streamId)).toBeUndefined();
+
+    // The rollback the reservation owns still runs.
+    machine.releaseIfReserved(streamId);
+    expect(machine.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+  });
+
   it('closes the active window in WAITING and restamps after the resume gap', () => {
     vi.useFakeTimers({ now: 1_000 });
     const { machine, streamId } = setupMachine(


### PR DESCRIPTION
## Summary

`StreamStatusMachine.markUnavailable` replaced whatever `StreamEntry` was present, a live `reserved` one included. Because `effectiveState` synthesizes `{ phase: RUNNING, substate: STARTING, runStartedAt }` for a reservation, the hold inherited a running-looking state. A stream that a fresh run reserved while restart repair was mid-flight was therefore left reading in-flight **and** unavailable: `releaseIfReserved` bails on a non-`reserved` entry, so a pre-activation launch failure never rolled back, and the inherited RUNNING made `canAcquireStreamReservation` refuse every later `tryAcquire`.

`git show 03fa583^` settles the ownership question rather than inventing a policy: before #11757 `markUnavailable` was `this.holds.set(stream, detail)` against a *separate* map, and a hold could not destroy a reservation. This restores that invariant inside the collapsed single-entry model — `markUnavailable` returns `false` without writing when a reservation owns the stream, and `applyHold` logs the refusal so it is not silent.

Restart repair also gains the two staleness re-checks its siblings already carry. The lease-lock catch at `restartRepair.ts` ran after an await with no `isCurrent` re-check at all; the `maintenance.status === 'active'` branch was mostly fenced by `isInFlightPhase` but left a narrow window open across `await currentLeaseOwner()`. Both now route through the one staleness authority (`isRepairCandidateCurrent`) and reuse the sibling site's wording.

**One correction to the issue's severity claim.** The issue implies the stream is stuck until Delete. Traced through `transitionRunStart`: a launch that *succeeds* does clear the hold (LIFECYCLE is refused by the table, RESUME is allowed, and the `:204-210` short-circuit does not fire because the inherited substate is STARTING while `options.substate` is `undefined`), and a post-activation failure recovers via `compensateActivatedFailure`. The genuinely stranding path is the **pre-activation** launch failure at `AgentLaunchContext.ts:665-669`, where `releaseIfReserved` no-ops and no execution handle was ever registered, so no stop is reachable. That is still exactly the "a failed launch's rollback never runs" the issue describes.

## Issue acceptance gates

Closes #11765.

- Missing `isCurrent` re-check added at the lease-lock catch, matching the sibling and reusing its debug wording — **done**.
- The "optional hardening, separate call" — `markUnavailable` refusing to overwrite a `reserved` entry — is **included**, deliberately. The re-check alone is not sufficient: `applyHold` has four call sites and the `maintenance.status === 'active'` one is reachable through its own await window, so the machine-level guard is the durable fix. The issue asked for the owner decision to be stated rather than ridden along silently: **the reservation wins**, and this restores pre-#11757 behavior rather than establishing new policy.

## Single source of truth

`StreamStatusMachine` owns "may a hold overwrite this entry" — the decision moves out of the four `applyHold` call sites and into the one place that owns the entry map. `isRepairCandidateCurrent` (via the local `isCurrent`) remains the single staleness authority; both new re-checks route through it rather than re-deriving staleness.

## Duplication and abstraction budget

No new abstraction. The two new re-check blocks intentionally duplicate the literal debug string of the sibling at `restartRepair.ts:266-270`; extracting a helper for a two-line literal with three call sites inside one function would be shallow indirection, which the repo bans.

## Net elements (R6)

Files: 2 production, 1 test. Exported symbols: 0 added, 0 removed. Classes/interfaces/enums: 0. Net LoC: +18 code and +8 comment lines in production, 1 signature line modified (`void` → `boolean`), 0 deletions; +15 test lines. This supersedes the issue's "+3 production lines", which counted only a one-site fix and understated even that (the sibling re-check block it points at is six lines).

## Consumer counts (R8)

`markUnavailable` — repo-wide grep returns 7 hits: 2 production callers (`restartRepair.ts` `applyHold`, and the unreadable-stream pass), 3 test callers, 2 declaration/doc lines. No interface, port, structural mock, or `Pick<StreamStatusMachine, …>` declares it anywhere in `packages/`, so the `void` → `boolean` widening lands in exactly one place. No emit path is deleted or re-routed.

## Host impact

Extension: no API change; a stream reused mid-repair no longer strands as in-flight-and-unavailable.

Desktop: same. `DesktopAgentExecution.vitest.ts:1745` reads `holdState` only, whose signature is unchanged.

CLI: same. `AppEscapeRouting.vitest.ts:951` calls `markUnavailable` after `clearStream`, so no entry is present and it writes as before.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck:workspace` — clean (mandatory here: `markUnavailable`'s return type changed, and builds only strip types).
- `npx eslint src/agent/runtime/restartRepair.ts src/agent/runtime/StreamStatusService.ts` — clean.
- `npx prettier --check` on all three changed files — clean.
- `npx vitest run` over `StreamStatusService.vitest.ts`, `RestartRepair.vitest.ts`, `SessionRestartRepair.vitest.ts`, `AppEscapeRouting.vitest.ts`, `DesktopAgentExecution.vitest.ts` — 160 passed, 0 failed.
- Ratchets: none affected — no new export, no host→`@agent/*` specifier, no schema, no snapshot. `grep -rn markUnavailable config/ratchets/` is empty.

**No CHANGELOG entry**, per AGENTS.md: the defect was introduced by #11757 (`03fa583`), which is unreleased — its entry still sits under `## Unreleased` and the newest released heading is `## [0.40.7]`.

### Two behavior changes, declared

1. A stream reused mid-repair now carries no hold detail, matching the already-fenced siblings — the fresh run owns the stream and publishes its own status.
2. `runWithInactiveExecutionLease` can throw *after* `operation` succeeded (`await unlinkOwnClaim(...)` sits outside its try). Previously that overwrote a specific hold detail with the generic `lease lock unavailable (…)`; now the generation compare sees the write and skips, so the specific detail survives. That is an improvement, but the debug line reads "it was reused before settlement" for what is really a lease-release failure. Accepted for vocabulary consistency with the sibling site.

One regression test added (`refuses to overwrite a live reservation with a hold`), extending the existing suite at the status machine's durable boundary. No restart-repair-level test for the two re-checks: `runWithInactiveExecutionLease` and `currentLeaseOwner` are direct module imports, not injectable options, so pinning them would mean adding a production seam purely for a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1)_