### PR TITLE
fix(session): stop double-emitting the parent-edge clear on detach

### DIFF
--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -575,8 +575,13 @@ export class ExecutionRegistry {
    * Subagents continue running independently and deliver results via the
    * follow-up queue. Called when stopping an orchestrator without killing
    * children.
+   *
+   * Returns the child streams whose parent edge this call already cleared and
+   * emitted — activations included, which is why a caller must not re-derive
+   * the set from `getActiveChildren` (handles only) and emit `setParentStream`
+   * for the difference: a native child between turns would be emitted twice.
    */
-  detachActiveChildren(parentStreamId: StreamTabId): void {
+  detachActiveChildren(parentStreamId: StreamTabId): readonly StreamTabId[] {
     const detachedChildStreamIds: StreamTabId[] = [];
     for (const activation of this.activeChildActivations(parentStreamId)) {
       activation.detach();
@@ -596,6 +601,7 @@ export class ExecutionRegistry {
         parentStreamId: null,
       });
     }
+    return detachedChildStreamIds;
   }
 
   /**

--- a/src/controllers/session/createSessionStores.ts
+++ b/src/controllers/session/createSessionStores.ts
@@ -28,14 +28,12 @@ export function createSessionStores(session: SessionHandle): SessionStores {
       releaseStreamResources(stream, session);
     },
     onChildrenDetached: (parent, children) => {
-      const activeChildren = new Set(
-        session.executions
-          .getActiveChildren(parent)
-          .map(({ childStreamId }) => childStreamId),
-      );
-      session.executions.detachActiveChildren(parent);
+      // The registry clears and emits the edge for every child it detaches —
+      // activations included, which `getActiveChildren` cannot see. This hook
+      // only projects the durable children it left behind.
+      const detached = new Set(session.executions.detachActiveChildren(parent));
       for (const child of children) {
-        if (activeChildren.has(child)) continue;
+        if (detached.has(child)) continue;
         session.events.emit({
           scope: 'session',
           event: {


### PR DESCRIPTION
## Summary

`onChildrenDetached` rebuilt a set the registry already produces, and the two disagreed. `getActiveChildren` iterates `handles` only, while `detachActiveChildren` also detaches *activations* — so a native child between turns was in the registry's detach set but absent from the caller's, and received a second `setParentStream: { parentStreamId: null }` on top of the one the registry had already emitted.

`detachActiveChildren` now returns the `readonly StreamTabId[]` it was already building, and the caller derives its skip set from that return value instead of re-deriving it. This also drops the needless cost of materializing full `ActiveChildInfo` rows via `getStatus` just to read `childStreamId`.

## Issue acceptance gates

Closes #11767. Both invariants the issue required are preserved:

- **D15 ordering rider** — the registry still emits the `child.activity` roster before its null edges, and the caller's remaining emissions necessarily follow the call now that the skip set is derived from it. The `new Set(...)` is not hoisted above the call, and `emitChildActivity` is not reordered after the null-edge loop.
- **No persisted data touched** — `stageDeleteStream` nulls the durable edge itself; this hook only projects the live `SessionState`.

## Single source of truth

`ExecutionRegistry.detachActiveChildren` now owns the answer to "which children did this detach clear the parent edge for". Previously that fact existed twice: once inside the registry as `detachedChildStreamIds`, and once re-derived by the caller from a different and narrower source.

## Duplication and abstraction budget

Removes a duplicated derivation. No abstraction added — an existing method's return value is surfaced rather than discarded.

## Net elements (R6)

Files: 2 production, 0 test. Exported symbols: 0 added, 0 removed (`detachActiveChildren` is an existing public method; only its return type widens from `void`). Classes/interfaces/enums: 0. Net LoC: **+3** total (`createSessionStores.ts` −5 code / +3 comment; `executionRegistry.ts` +1 `return`, +6 doc comment, signature edited in place). Counting executable code only: **−4**, matching the issue's estimate.

## Consumer counts (R8)

`detachActiveChildren` — 3 production call sites (`executionRegistry.ts:467` in `kill`, `:623` in `stopAgentStream`, and the new caller in `createSessionStores.ts`) and 7 test call sites (`ExecutionRegistry.vitest.ts:219/1614/1656/1680`, `ChildRunLoop.vitest.ts:600/608`, `DelegationHeadless.vitest.ts:1456`). Every one other than the new caller is an expression statement whose value was already discarded, so widening `void` → `readonly StreamTabId[]` breaks none of them. The many `detachActiveChildren: true|false` grep hits are the unrelated `ExecutionStopOptions` flag.

`getActiveChildren` loses its consumer in `createSessionStores.ts` but keeps three others (`executionRegistry.ts:705` in `emitChildActivity`, `src/agent/core/flows/CommonCycleTypes.ts:115`, `packages/desktop/src/main/desktopAgentExecution.ts:451`), so it does not become dead.

`session.executions` is the concrete `ExecutionRegistry` (`SessionHandle.ts:115`) — no port interface, no test double, no hand-written `.d.ts`, and no `packages/agent/src` re-export declares this method, so the signature lives in exactly one place and the host-agent-mock ratchet is untouched.

## Host impact

`createSessionStores` is host-neutral and shared, so the change lands on all three hosts — which is the intent.

Extension: one fewer duplicate `setParentStream` fact when a parent owning a native child activation is deleted. `SessionFactApplier.handleSetParentStream` only writes `SessionState` and calls `renderer.invalidate`, so the apply is idempotent either way.

Desktop: same, via `desktopProcessStores.ts:12`.

CLI: same, via `history.ts:370` and `transcriptSession.ts:55`. **Headless-parity note:** `setParentStream` is a declared NDJSON progress event (`cliNdjsonProgressEvents.ts:88`, mapped at `sessionProgressSubscription.ts:91-92`), so headless output loses one duplicate line in this case — the same class of note D15 carried.

## Scheduled refactoring

**One residual, deliberately out of scope.** This does not eliminate every double emission the issue title could be read to imply. `detachedChildStreamIds` still receives the same stream twice for a native child detached *mid-turn*, because the per-turn handle and the activation share an `executionId` and coexist (`ExecutionRegistry.track:262-263` explicitly reconciles them) — so the registry's own loop emits that child's null edge twice, before and after this change. The caller's `new Set(...)` absorbs it, so the return contract here is unaffected. Fixing it is two lines (make `detachedChildStreamIds` a `Set` and spread it at the return) and breaks no existing test, but it is a second behavior change with its own headless-parity note, so it is flagged rather than ridden along. Say the word and I will fold it in or file it.

## Validation

- `npm run typecheck:workspace` — clean.
- `npx eslint` on both changed files — clean.
- `npx vitest run` over `ExecutionRegistry.vitest.ts`, `ChildRunLoop.vitest.ts`, `SessionStores.vitest.ts` — 90 passed; `DelegationHeadless.vitest.ts` — 41 passed.
- `npm run check:dead-code-ratchet` — OK, no new findings (294 vs 294 baselined).
- No ratchet or baseline file changes: no file added or deleted, no export added, no host-boundary import, no schema change.

No new tests: this is a behavior-preserving de-duplication, and no existing test asserted the double emission. The strictest assertion in the area (`ExecutionRegistry.vitest.ts:1617-1620`, pinning `['child.activity', 'setParentStream']` exactly) is a handle-only case, so both emission count and order there are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1)_