### PR TITLE
fix(agent): read both child-policy toggles through the settings catalog

### DIFF
--- a/src/agent/runtime/detachSubagentsOnStop.ts
+++ b/src/agent/runtime/detachSubagentsOnStop.ts
@@ -1,6 +1,7 @@
 import { platform } from '@platform/platform';
 import { warnAbandonedSlotValue } from '@shared/config/settingsAccess';
 import { GlobalStateKey } from '@shared/state/stateKeys';
+import { readPlatformSetting } from '@utils/config/platformSettings';
 
 /**
  * Whether stopping or killing an agent stream should detach its active child
@@ -34,12 +35,5 @@ export function detachSubagentsOnStop(): boolean {
     'workspaceState',
     platform().workspaceState,
   );
-  // `get<boolean>` casts rather than coerces, so a hand-edited `1` or "true"
-  // in the persisted state would otherwise escape as a non-boolean.
-  return (
-    platform().globalState.get<boolean>(
-      GlobalStateKey.DETACH_SUBAGENTS_ON_STOP,
-      false,
-    ) === true
-  );
+  return readPlatformSetting<boolean>(GlobalStateKey.DETACH_SUBAGENTS_ON_STOP);
 }

--- a/src/test-kernel/cli/chatSessionController.vitest.ts
+++ b/src/test-kernel/cli/chatSessionController.vitest.ts
@@ -634,7 +634,6 @@ describe('createChatSessionController', () => {
 
     expect(mocks.globalGet).toHaveBeenCalledWith(
       GlobalStateKey.DETACH_SUBAGENTS_ON_STOP,
-      false,
     );
     expect(mocks.stopAgentStream).toHaveBeenCalledWith('stream-1', {
       detachActiveChildren: true,

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -48,6 +48,7 @@ import {
   readCompletedRunTodos,
 } from '@transcript';
 import { assertNever, unique } from '@utils/core';
+import { readPlatformSetting } from '@utils/config/platformSettings';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { StorageFS } from '@utils/files/storageFS';
 import { isDirectory } from '@utils/files/fsEntryType';
@@ -519,12 +520,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       'workspaceState',
       platform().workspaceState,
     );
-    if (
-      !platform().globalState.get<boolean>(
-        GlobalStateKey.ALLOW_ORCHESTRATOR_KILL,
-        true,
-      )
-    ) {
+    if (!readPlatformSetting<boolean>(GlobalStateKey.ALLOW_ORCHESTRATOR_KILL)) {
       throw new ToolError(
         'Killing subagents is disabled. Enable it in Settings > Multi-Agent.',
       );


### PR DESCRIPTION
## Summary

Both child-policy toggles were read with a hand-rolled `platform().globalState.get(key, handPassedDefault)`, duplicating a default the settings catalog already declares. `get` **casts rather than coerces**, so a non-boolean persisted value escaped:

- `ALLOW_ORCHESTRATOR_KILL` (`ExecutionsTool.handleKill`) had no guard at all, so a persisted `"false"` **string** is truthy and read as *allowed* — the toggle fails open, re-enabling orchestrator kills.
- `DETACH_SUBAGENTS_ON_STOP` compared `=== true`, so a hand-edited `"true"` silently mapped to `false`. It fails closed, but just as silently — its own comment admitted this.

Both reads now go through `readPlatformSetting`, which resolves the row's declared slot, takes the default from its `.prefault()`, and `log.warn`s before snapping an invalid persisted value. Neither documented default changes: kill allowed, detach off.

## Issue acceptance gates

Closes #11768.

- Both raw reads replaced with `readPlatformSetting(GlobalStateKey.X)`; the default now comes from the catalog row rather than being duplicated at the call site — **done**.
- Both `warnAbandonedSlotValue` calls kept, as the issue required: they read the retired `workspaceState` slot and are a separate concern (survey §2.4 L4) — **done**.

## Single source of truth

`src/shared/schemas/stateSettings.ts` is now the only place either default is written. Both rows are `surfacedSetting` with `sameSlot('globalState')` and `z.boolean().prefault(...)` (`:1182`, `:1196`); previously the same default also existed, unvalidated, at each call site.

## Duplication and abstraction budget

Removes two duplicated defaults and one hand-rolled coercion guard. No abstraction added — `readPlatformSetting` already existed (`src/utils/config/platformSettings.ts:29-36`) and already had consumers.

## Net elements (R6)

Files: 2 production, 1 test. Exported symbols: 0 added, 0 removed. Classes/interfaces/enums: 0. Net LoC: **−11** (production −14 removed / +4 added = −10; tests −1). Diffstat: `3 files changed, 4 insertions(+), 15 deletions(-)`.

## Consumer counts (R8)

n/a for emit paths — none deleted or re-routed. For completeness on the two keys: `detachSubagentsOnStop()` has 4 production callers (`packages/cli/src/chat/chatSessionController.ts:316`, `packages/desktop/src/main/desktopAgentExecution.ts:314`, `packages/extension/src/commands/agent/agentCommands.ts:7`, `packages/extension/src/frontend/review/AgentReviewRunController.ts:123`) and its signature is unchanged, so no host edits were needed. `ALLOW_ORCHESTRATOR_KILL` has the single reader in `handleKill`.

## Host impact

Extension: no API change. A corrupted persisted value now snaps to the catalog default with a warning instead of silently mis-reading.

Desktop: same. Both rows use `sameSlot('globalState')`, so `readPlatformSetting`'s default `'vscode'` host resolves the identical slot — no host argument threaded.

CLI: same, plus the one test assertion below.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck:workspace` and `npm run typecheck:test-kernel` — clean (a raw `get<boolean>` becoming a typed catalog read is exactly the kind of change esbuild would not catch).
- `npx eslint` on both production files — clean (`import/order` required `@utils/core` before `@utils/config/platformSettings`; applied).
- `npx prettier --check` on all three changed files — clean.
- `npx vitest run src/test-kernel/cli/chatSessionController.vitest.ts src/test-kernel/utils/config/ConfigUtils.vitest.ts` — 61 passed, 0 failed.

One existing assertion changed shape, exactly as the issue predicted: `chatSessionController.vitest.ts:635` asserted `globalGet` was called with `(DETACH_SUBAGENTS_ON_STOP, false)`, but `readSetting` calls `get(entry.key)` with no default, and `toHaveBeenCalledWith` compares the full argument array. Now asserts the one-argument form. The behavioral assertion on `stopAgentStream` is untouched and still passes, as is the `beforeEach` stub — it returns `undefined`, which `readSetting` maps to the row's `.prefault(false)`, the same `false` the hand-passed default produced.

No new tests, per the testing budget: `ConfigUtils.vitest.ts:88-125` already covers `readPlatformSetting`'s default resolution and its invalid-persisted-value snapping.

### One behavior change, declared — it is the point

A persisted non-boolean for `ALLOW_ORCHESTRATOR_KILL` now snaps to the catalog default `true` with a `log.warn` instead of being read as truthy-allowed by accident. Separately, `readPlatformSetting` throws if a catalog row is ever removed, where the old read silently returned its hand-passed default. Both keys are present and pinned by `stateSettings.vitest.ts:464,471` plus the `honoredBy` reader-file-exists check, so the throw is unreachable today — but the failure mode moves from silent to loud, which is the direction the repo's silent-degradation rule asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1)_