### PR TITLE
refactor(transcript): delete the dead StreamSnapshotStore.deleteStream wrapper

### DIFF
--- a/config/ratchets/store-public-surface-baseline.json
+++ b/config/ratchets/store-public-surface-baseline.json
@@ -1,5 +1,5 @@
 {
-  "semantics": "Public (static + instance) method declarations of StreamLogStore and StreamSnapshotStore, per issue #9590 Stage 5 (proof obligation 10). Every public method is a caller-verified contract, and every field exposed by a configured aggregate snapshot getter is one caller-visible contract unit. Replacing five field getters with getRunMetadata therefore leaves the StreamSnapshotStore contract budget unchanged: the aggregate method contributes five units, not one. Transcript row mutation is writer-only (TranscriptWriter via acquireWriter/loadAndAcquireWriter), snapshot event projection enters only through attachSessionEvents, and 'protected' counts as public because neither class is subclassed. The ratchet rejects growth in either public methods or configured aggregate fields. When the surface genuinely shrinks, lower this baseline in the same PR. requestEviction (2026-09-02) is the one sanctioned addition: the sidecar counterpart of StreamLogStore.requestEviction, requested by the session lifecycle for finished child streams so a long session's record set stops growing; see docs/proposals/2026-09-02-stream-lifetime-and-cancellation-simplification.md section 2.C.",
+  "semantics": "Public (static + instance) method declarations of StreamLogStore and StreamSnapshotStore, per issue #9590 Stage 5 (proof obligation 10). Every public method is a caller-verified contract, and every field exposed by a configured aggregate snapshot getter is one caller-visible contract unit. Replacing five field getters with getRunMetadata therefore leaves the StreamSnapshotStore contract budget unchanged: the aggregate method contributes five units, not one. Transcript row mutation is writer-only (TranscriptWriter via acquireWriter/loadAndAcquireWriter), snapshot event projection enters only through attachSessionEvents, and 'protected' counts as public because neither class is subclassed. The ratchet rejects growth in either public methods or configured aggregate fields. When the surface genuinely shrinks, lower this baseline in the same PR. requestEviction (2026-09-02) is the one sanctioned addition: the sidecar counterpart of StreamLogStore.requestEviction, requested by the session lifecycle for finished child streams so a long session's record set stops growing; see docs/proposals/2026-09-02-stream-lifetime-and-cancellation-simplification.md section 2.C. StreamSnapshotStore.deleteStream was removed on the same day (#11769): it was a zero-caller wrapper over stageDeleteStream + commit, so the surface returns to 21.",
   "stores": {
     "StreamLogStore": [
       "acquireWriter",
@@ -28,7 +28,6 @@
     ],
     "StreamSnapshotStore": [
       "attachSessionEvents",
-      "deleteStream",
       "flush",
       "getCompileFailures",
       "getExecutionIdMap",

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -158,6 +158,20 @@ async function stageDeletionWithBufferedClear(): Promise<{
   return { store, deletion };
 }
 
+/**
+ * The production deletion path — `stageDeleteStream` then `commit`, exactly as
+ * SessionStores.deleteStreamSidecars and adjacentStreamCleanup drive it. The
+ * store has no one-shot delete method; this is a test convenience, not a
+ * surface unit.
+ */
+async function deleteStream(
+  store: StreamSnapshotStore,
+  stream: StreamTabId,
+): Promise<void> {
+  const deletion = await store.stageDeleteStream(stream);
+  await deletion.commit();
+}
+
 /** The work plan a fresh store reads back from disk. */
 async function reloadWorkPlan(stream: StreamTabId = STREAM): Promise<WorkPlan> {
   const reloaded = new StreamSnapshotStore();
@@ -1377,7 +1391,7 @@ describe('StreamSnapshotStore', () => {
     const wasDeletedDuringHydration = injectDuringExecutionConfigHydration(
       executionId,
       () => {
-        deletion = store.deleteStream(STREAM);
+        deletion = deleteStream(store, STREAM);
       },
     );
 
@@ -1424,13 +1438,13 @@ describe('StreamSnapshotStore', () => {
     await store.flush();
   });
 
-  it('deleteStream cancels queued writes before removing the sidecar directory', async () => {
+  it('deleting a stream cancels queued writes before removing the sidecar directory', async () => {
     const dir = streamDataDir(STREAM);
     const store = new StreamSnapshotStore();
     await store.load([]);
 
     snapshotFacts(store).addUsage(STREAM, RUN, usage(1, 2, 0.03));
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
 
     expect(await StorageFS.exists(dir)).toBe(false);
   });
@@ -1446,7 +1460,7 @@ describe('StreamSnapshotStore', () => {
       .spyOn(StorageFS, 'rename')
       .mockRejectedValueOnce(deletionError);
 
-    await expect(store.deleteStream(STREAM)).rejects.toBe(deletionError);
+    await expect(deleteStream(store, STREAM)).rejects.toBe(deletionError);
 
     expect(store.getWorkPlan(STREAM)).toEqual({
       todos: [TODO],
@@ -1461,7 +1475,7 @@ describe('StreamSnapshotStore', () => {
     });
 
     renameSpy.mockRestore();
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('recovers a crash-interrupted staged deletion before hydration', async () => {
@@ -1490,7 +1504,7 @@ describe('StreamSnapshotStore', () => {
       planSummary: PLAN_SUMMARY,
     });
     expect(await StorageFS.exists(streamDataDir(STREAM))).toBe(true);
-    await recovered.deleteStream(STREAM);
+    await deleteStream(recovered, STREAM);
   });
 
   it('buffers sidecar writes until a staged deletion rolls back', async () => {
@@ -1539,7 +1553,7 @@ describe('StreamSnapshotStore', () => {
       plan: null,
       todos: [TODO],
     });
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('serializes overlapping staged deletions for one stream', async () => {
@@ -1583,7 +1597,7 @@ describe('StreamSnapshotStore', () => {
     await store.flush();
 
     expect((await reloadWorkPlan()).plan).toBeNull();
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('retains buffered writes when rollback persistence fails', async () => {
@@ -1608,7 +1622,7 @@ describe('StreamSnapshotStore', () => {
     const retry = await store.stageDeleteStream(STREAM);
     await retry.rollback();
     expect((await reloadWorkPlan()).plan).toEqual(revisedPlan);
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('retries retained live rollback writes during flush', async () => {
@@ -1623,7 +1637,7 @@ describe('StreamSnapshotStore', () => {
     writeSpy.mockRestore();
     await store.flush();
     expect((await reloadWorkPlan()).plan).toBeNull();
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('waits unrelated writes before flush reports a recovery failure', async () => {
@@ -1671,8 +1685,8 @@ describe('StreamSnapshotStore', () => {
     expect((await reloadWorkPlan(OTHER_STREAM)).plan).toEqual(PLAN);
 
     await store.flush();
-    await store.deleteStream(STREAM);
-    await store.deleteStream(OTHER_STREAM);
+    await deleteStream(store, STREAM);
+    await deleteStream(store, OTHER_STREAM);
   });
 
   it('does not recreate live storage while setup residue is staged', async () => {
@@ -1700,7 +1714,7 @@ describe('StreamSnapshotStore', () => {
     const retry = await store.stageDeleteStream(STREAM);
     await retry.rollback();
     expect((await reloadWorkPlan()).plan).toBeNull();
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('drains dirty writes when deletion staging fails during setup', async () => {
@@ -1729,7 +1743,7 @@ describe('StreamSnapshotStore', () => {
     writeSpy.mockRestore();
     await store.flush();
     expect((await reloadWorkPlan()).plan).toBeNull();
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('retains refresh authority when initial deletion staging inspection fails', async () => {
@@ -1796,7 +1810,7 @@ describe('StreamSnapshotStore', () => {
     const retry = await store.stageDeleteStream(STREAM);
     await retry.rollback();
     expect((await reloadWorkPlan()).plan).toEqual(PLAN);
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('mirrors writes when rollback moved data before reporting failure', async () => {
@@ -1832,7 +1846,7 @@ describe('StreamSnapshotStore', () => {
       todos: [TODO],
     });
     await store.flush();
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('retains prior rollback writes when retry setup also fails', async () => {
@@ -1859,7 +1873,7 @@ describe('StreamSnapshotStore', () => {
       plan: null,
       todos: [TODO],
     });
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('revalidates storage during setup recovery before returning', async () => {
@@ -1886,7 +1900,7 @@ describe('StreamSnapshotStore', () => {
       plan: null,
       todos: [TODO],
     });
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('retries buffered writes after staged-directory reconciliation', async () => {
@@ -1916,7 +1930,7 @@ describe('StreamSnapshotStore', () => {
       discarded: [],
     });
     expect((await reloadWorkPlan()).plan).toBeNull();
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('keeps the staged base when failed rollback data also has live residue', async () => {
@@ -1946,7 +1960,7 @@ describe('StreamSnapshotStore', () => {
     const reloaded = await new StreamSnapshotStore().read(STREAM);
     expect(reloaded.plan).toBeNull();
     expect(reloaded.runUsage[RUN]).toMatchObject(usage(100, 20, 0.5));
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('discards staged residue when failed rollback data has a live base', async () => {
@@ -1987,7 +2001,7 @@ describe('StreamSnapshotStore', () => {
     expect(reloaded.plan).toBeNull();
     expect(reloaded.runUsage[RUN]).toMatchObject(usage(100, 20, 0.5));
     expect(await StorageFS.exists(stagedDir)).toBe(false);
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('does not restore staged residue after a live base disappears', async () => {
@@ -2022,7 +2036,7 @@ describe('StreamSnapshotStore', () => {
     });
     expect((await reloadWorkPlan()).plan).toBeNull();
     expect(await StorageFS.exists(stagedDir)).toBe(false);
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('recreates live storage from buffered writes when both bases vanish', async () => {
@@ -2039,7 +2053,7 @@ describe('StreamSnapshotStore', () => {
     await store.flush();
     expect((await reloadWorkPlan()).plan).toBeNull();
     expect(await StorageFS.exists(streamDataDir(STREAM))).toBe(true);
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('serializes a staging retry behind failed rollback reconciliation', async () => {
@@ -2086,7 +2100,7 @@ describe('StreamSnapshotStore', () => {
     recoverySpy.mockRestore();
 
     expect((await reloadWorkPlan()).plan).toBeNull();
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('restores committed residue for complete orphan cleanup', async () => {
@@ -2124,7 +2138,7 @@ describe('StreamSnapshotStore', () => {
 
     statSpy.mockRestore();
     expect(await StorageFS.exists(liveDir)).toBe(true);
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('settles staging and retains writes when setup recovery fails', async () => {
@@ -2153,7 +2167,7 @@ describe('StreamSnapshotStore', () => {
     const retry = await store.stageDeleteStream(STREAM);
     await retry.rollback();
     expect((await reloadWorkPlan()).plan).toBeNull();
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('serializes setup recovery before another staging attempt can cancel its writes', async () => {
@@ -2206,7 +2220,7 @@ describe('StreamSnapshotStore', () => {
     await retry.rollback();
 
     expect((await reloadWorkPlan()).plan).toBeNull();
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
   });
 
   it('waits for active hydration before staging deletion', async () => {
@@ -2226,7 +2240,7 @@ describe('StreamSnapshotStore', () => {
     const wasDeleteInjected = injectDuringExecutionConfigHydration(
       executionId,
       () => {
-        deletion = store.deleteStream(STREAM);
+        deletion = deleteStream(store, STREAM);
         void deletion.catch(() => undefined);
       },
     );
@@ -2245,7 +2259,7 @@ describe('StreamSnapshotStore', () => {
     expect((await reloadWorkPlan()).todos).toEqual([TODO]);
   });
 
-  it('does not resurrect a deleted sidecar dir when deleteStream lands during hydration', async () => {
+  it('does not resurrect a deleted sidecar dir when a stream deletion lands during hydration', async () => {
     // applyStreamData awaits execution-config hydration mid-seed. If the
     // stream is deleted during that await, the continuation must not
     // re-resolve a record for the evicted stream and flush merged sidecars,
@@ -2265,7 +2279,7 @@ describe('StreamSnapshotStore', () => {
       executionId,
       () => {
         snapshotFacts(store).updateMissingOutputs(STREAM, { 1: ['late.tex'] });
-        deletion = store.deleteStream(STREAM);
+        deletion = deleteStream(store, STREAM);
       },
     );
 
@@ -2462,7 +2476,7 @@ describe('StreamSnapshotStore', () => {
 
     snapshotFacts(store).setPlan(STREAM, PLAN);
     await vi.waitFor(() => expect(writeSpy).toHaveBeenCalledTimes(1));
-    await store.deleteStream(STREAM);
+    await deleteStream(store, STREAM);
     await store.flush();
 
     expect(await StorageFS.exists(streamDataDir(STREAM))).toBe(false);
@@ -2528,15 +2542,15 @@ describe('StreamSnapshotStore', () => {
     expect(order).toEqual(['first-start', 'first-end', 'second-start']);
   });
 
-  it('deleteStream refuses reserved stream ids before sidecar directory removal', async () => {
+  it('staged deletion refuses reserved stream ids before sidecar directory removal', async () => {
     const sentinel = path.join(STREAM_DATA_DIR, 'sentinel.json');
     await StorageFS.ensureDir(STREAM_DATA_DIR);
     await StorageFS.write(sentinel, '{}');
 
     const store = new StreamSnapshotStore();
-    await store.deleteStream('' as StreamTabId);
-    await store.deleteStream('.' as StreamTabId);
-    await store.deleteStream('..' as StreamTabId);
+    await deleteStream(store, '' as StreamTabId);
+    await deleteStream(store, '.' as StreamTabId);
+    await deleteStream(store, '..' as StreamTabId);
 
     expect(await StorageFS.exists(sentinel)).toBe(true);
   });

--- a/src/transcript/SidecarWriteCoordinator.ts
+++ b/src/transcript/SidecarWriteCoordinator.ts
@@ -6,8 +6,8 @@
  * confirmed durable, and retried a bounded number of times by
  * `retryDirtyWrites` before remaining dirt is allowed to fail a flush.
  * Eviction safety is the other half: a write queued before
- * `evict()`/`deleteStream()` drops its chain key must not fire afterward and
- * resurrect the deleted `streamData/{id}/` directory.
+ * `evict()`/`stageDeleteStream()` drops its chain key must not fire afterward
+ * and resurrect the deleted `streamData/{id}/` directory.
  *
  * It reaches the rest of the store only through {@link SidecarWriteHost} —
  * the staged-deletion write buffer, the revocable stream-generation guard,
@@ -104,7 +104,7 @@ export class SidecarWriteCoordinator {
     const mutex = this.writeMutexes.get(chainKey) ?? new Mutex();
     this.writeMutexes.set(chainKey, mutex);
     return mutex.runExclusive(() => {
-      // Eviction guard: `evict()`/`deleteStream()` drop this chain key. A
+      // Eviction guard: `evict()`/`stageDeleteStream()` drop this chain key. A
       // write queued before that must NOT fire afterward, or a late `kv()`
       // would re-create the `streamData/{id}/` dir `deleteDir()` just removed.
       if (!this.writeMutexes.has(chainKey)) return;

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1315,12 +1315,6 @@ export class StreamSnapshotStore {
     };
   }
 
-  /** Delete a stream's sidecars and in-memory state as one committed action. */
-  async deleteStream(stream: StreamTabId): Promise<void> {
-    const deletion = await this.stageDeleteStream(stream);
-    await deletion.commit();
-  }
-
   private setTodos(stream: StreamTabId, todos: TodoItem[]): void {
     // Same eager-apply + overlay shape as the round/usage mutators: a live
     // updateTodos must be readable via getWorkPlan before the stream seeds,


### PR DESCRIPTION
## Summary

`StreamSnapshotStore.deleteStream` was a two-line convenience wrapper over `stageDeleteStream` + `commit` with **zero production callers**. The real deletion path is the staged one, and both of its drivers stay: `adjacentStreamCleanup.ts:67` and `SessionStores.ts:884`.

Deleting it takes the ratcheted `StreamSnapshotStore` surface from **22 to 21** — handing back the row #11762 spent on `requestEviction`, at no cost to the eviction work that spent it.

To be explicit about what this PR does *not* claim: `requestEviction` does **not** supersede `deleteStream`. They are different operations — `requestEviction` releases a resident record that re-seeds from disk on the next read (a memory concern), while deletion removes sidecars from disk. This rests only on the wrapper being dead; the baseline offset is an accounting argument, not a functional one.

## Issue acceptance gates

Closes #11769.

- Method deleted — **done**.
- Baseline row dropped, 22 → 21 — **done**, plus a sentence appended to the baseline's own `semantics` string recording why, matching how #11762 documented the addition.
- Direct test coverage retargeted onto `stageDeleteStream` + `commit` — **done** (32 call sites; see below).
- `npm run check:dead-code-ratchet` run — **done**, OK.

**Fresh caller audit at `34adb91`**, which is the bar your #11463 closing comment set. `grep -rn '\.deleteStream(' src packages` outside the test kernel returns exactly three hits, all on *different* classes: `ProgressViewCommandHandlers.ts:332` (the host lifecycle port), `SessionFactApplier.ts:411` (an injected option), `desktopProcessStores.ts:57` (`SessionStores`). `snapshots.deleteStream` and `snapshotStore.deleteStream` return nothing. This is also a different method from the four in #11463 (`reload`, `evictAll`, `clearAll`, `getAllStreamStates`), whose premise had gone stale.

## Single source of truth

`stageDeleteStream` is now the only entry point to snapshot deletion, so the staged protocol (stage → commit/rollback) cannot be bypassed by a call that hides it.

## Duplication and abstraction budget

Removes a pass-through wrapper; adds no abstraction. The test file gains a local `deleteStream(store, stream)` helper — a test convenience with no production reachability, not a relocated contract. The ratcheted surface genuinely shrinks by one unit.

## Net elements (R6)

Files: 2 production changed, 1 baseline JSON, 1 test file. Exported symbols: 0 added, 0 removed (`^[+-]export` over the diff is empty — this is a class member, not an export). Classes/interfaces/enums: 0. Net LoC: **−7 shipped** (−6 in `StreamSnapshotStore.ts`, −1 baseline row), **+14 test**. Ratcheted surface: **−1 unit** (22 → 21 methods; 26 → 25 contract units counting the `getRunMetadata` aggregate).

## Consumer counts (R8)

`StreamSnapshotStore.deleteStream`: **0 production**, 32 test (all in `src/test-kernel/transcript/StreamSnapshotStore.vitest.ts`). No emit path deleted or re-routed. Same-named methods on `SessionStores`, `ProgressBackend` and the host lifecycle ports are untouched — I verified each of the ~40 same-named test call sites in `SessionStores.vitest.ts`, `ProgressBackendStreamLifecycle.vitest.ts`, `ProgressViewOnboardingRefresh.vitest.ts`, `ProgressViewStoresWiring.vitest.ts`, `ProgressViewCommandHandlers.vitest.ts`, `ProgressViewRunCommands.vitest.ts` and `DesktopAgentExecution.vitest.ts` resolves to a different class, and left them alone.

## Host impact

Extension: none — no production caller existed.

Desktop: none.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck:workspace` and `npm run typecheck:test-kernel` — clean.
- `npx vitest run src/test-kernel/architecture/storePublicSurfaceRatchet.vitest.ts` — 4 passed (this is the enforcer for the baseline edit; the array stays sorted and duplicate-free).
- `npx vitest run src/test-kernel/transcript/StreamSnapshotStore.vitest.ts src/test-kernel/agent/storage/SessionStores.vitest.ts` — 118 passed, 0 failed.
- `npm run check:dead-code-ratchet` — OK, no new findings.
- `npx eslint` on all three changed source files — clean. `npx prettier --check` on the test file and the baseline JSON — clean.

**The baseline edit is mandatory, not cosmetic:** the ratchet only enforces `currentUnits <= baselineUnits`, so omitting it would still pass CI while leaving a spent row in the budget — which is the whole point of the issue.

No tests deleted and no new ones added. The 32 call sites moved to a file-local stage-and-commit helper because every one of them tests real deletion behavior (write cancellation, staged-rename failure and rollback, crash recovery, hydration races, reserved-id refusal), not the wrapper's existence. The helper preserves timing for the three tests that capture the delete promise from inside a synchronous hydration callback — an async function body runs synchronously to its first `await`, so `stageDeleteStream` still starts on the same tick — and it neither wraps nor swallows, so the two `rejects.toBe(deletionError)` identity assertions still hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1)_