### PR TITLE
fix: stop dropping the extension's resume-failure notice

### DIFF
--- a/docs/architecture/2026-07-26-embedding-the-agent-runtime.md
+++ b/docs/architecture/2026-07-26-embedding-the-agent-runtime.md
@@ -473,8 +473,8 @@ the runtime already knows the parking behaviour exists.
 
 `cancel` is the one **required** member of `HostInteractions`
 (`src/agent/runtime/HostInteractions.ts:336`); every other member — the seven
-request methods plus `emit`, `dispose`, `showInfoMessage`, the diagnostics
-readers, and `setApprovalBypassState` — is optional
+request methods plus `emit`, `dispose`, the diagnostics readers, and
+`setApprovalBypassState` — is optional
 (`src/agent/runtime/HostInteractions.ts:293-338`). So the compiler already
 forces you to write `{ cancel: … }` — the trap is not a badly-typed object, it
 is **never calling `interactions.use` at all**, which no type can catch.

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -367,19 +367,17 @@ export class DesktopProgressBridge {
         this.backend.approvalHandlers.toolEdit.dismiss(requestId),
       detachCause: SESSION_DISPOSED_CAUSE,
     });
-    this.hostInteractions = {
-      // The shared progress-view host port plus the Electron shell's
-      // notification surface, which the runtime reaches through
-      // `session.interactions`.
-      ...createProgressHostInteractions({
-        interactions: presentationHost,
-        session: this.session,
-        getApprovalHandlers: () => this.backend.approvalHandlers,
-        getToolEditApprovals: () => this.toolEditApprovals!,
-        setApprovalBypassState: this.backend.setApprovalBypassState,
-      }),
-      showInfoMessage: (message) => this.options.host.showInfoMessage(message),
-    };
+    // The shared progress-view host port. Every notice the runtime raises now
+    // reaches this window through `presentationHost`'s presentation-event
+    // map, so there is no second, optional channel a host can leave
+    // unimplemented.
+    this.hostInteractions = createProgressHostInteractions({
+      interactions: presentationHost,
+      session: this.session,
+      getApprovalHandlers: () => this.backend.approvalHandlers,
+      getToolEditApprovals: () => this.toolEditApprovals!,
+      setApprovalBypassState: this.backend.setApprovalBypassState,
+    });
     this.fileActions = new DesktopProgressFileActions(this.options.host, {
       startExecution: (request) => {
         const logger = this.logger;

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -91,8 +91,15 @@ async function resumeDesktopStream(
     });
     if ('started' in result) return result.delivered;
     if (!isCancellationRequested()) {
-      await session.interactions.showInfoMessage(
-        describeFollowUpFailure(result.failed),
+      // Same info-styled channel the sibling progress-view follow-up path
+      // uses for this wording; desktop renders it as an 'info' message box.
+      await session.interactions.emit(
+        'requestShowInstruction',
+        {
+          key: 'resumeRefused',
+          message: describeFollowUpFailure(result.failed),
+          showSuppress: false,
+        },
         { replayWhenAttached: true },
       );
     }

--- a/packages/extension/src/commands/agent/resumeFromResumeData.ts
+++ b/packages/extension/src/commands/agent/resumeFromResumeData.ts
@@ -49,8 +49,21 @@ export async function tryResumeFromResumeData(
     if ('started' in result) return result.delivered;
     if (!isCancellationRequested()) {
       logger.warn(`Stream ${streamId} was not resumed: ${result.failed}`);
-      await session.interactions.showInfoMessage(
-        describeFollowUpFailure(result.failed),
+      // A refused resume is actionable guidance ("start a new agent task",
+      // "send the message there"), not a failure: the shared progress-view
+      // path presents these same `describeFollowUpFailure` strings through
+      // `showInfo` on both GUI hosts (progressFollowUpSubmit.ts), so this
+      // rides the info-styled `requestShowInstruction` event -- the one
+      // presentation channel every host's compile-checked handler map must
+      // implement, so an unserved surface reads as not-delivered instead of
+      // vanishing.
+      await session.interactions.emit(
+        'requestShowInstruction',
+        {
+          key: 'resumeRefused',
+          message: describeFollowUpFailure(result.failed),
+          showSuppress: false,
+        },
         { replayWhenAttached: true },
       );
     }

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -352,8 +352,6 @@ export interface HostInteractions {
   readonly openPdf?: OpenPdfOpener;
   /** Report one agent-review finding to the active host's review session. */
   readonly reportReviewIssue?: ReportReviewIssueSink;
-  /** Present non-error information through the currently attached host. */
-  showInfoMessage?(message: string): Promise<void> | void;
   requestToolEditApproval?(
     request: ToolEditApprovalRequest,
   ): Promise<ToolEditApprovalResult> | undefined;
@@ -521,19 +519,6 @@ export class SessionHostInteractions implements HostInteractions {
 
   get reportReviewIssue(): ReportReviewIssueSink | undefined {
     return this.activeAttachment?.interactions.reportReviewIssue;
-  }
-
-  showInfoMessage(
-    message: string,
-    options: AgentRuntimeEmitOptions = {},
-  ): Promise<void> | void {
-    const active = this.activeAttachment;
-    if (active) return active.interactions.showInfoMessage?.(message);
-    if (options.replayWhenAttached && !this.disposed) {
-      this.queuePresentationReplay((interactions) =>
-        interactions.showInfoMessage?.(message),
-      );
-    }
   }
 
   requestToolEditApproval(

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -333,21 +333,15 @@ describe('session.interactions immediate capabilities', () => {
 
   it('replays only opted-in presentation notices once after reattachment', async () => {
     const session = createTestSession();
-    const firstInfo = vi.fn();
     const firstEmit = vi.fn();
     const detach = session.interactions.use({
       emit: firstEmit,
-      showInfoMessage: firstInfo,
       cancel: vi.fn(),
     });
     detach();
 
-    session.interactions.showInfoMessage('attachment-scoped');
     session.interactions.emit('requestShowError', {
       message: 'attachment-scoped',
-    });
-    session.interactions.showInfoMessage('replay this', {
-      replayWhenAttached: true,
     });
     session.interactions.emit(
       'requestShowError',
@@ -355,77 +349,77 @@ describe('session.interactions immediate capabilities', () => {
       { replayWhenAttached: true },
     );
 
-    const secondInfo = vi.fn();
     const secondEmit = vi.fn();
     const detachSecond = session.interactions.use({
       emit: secondEmit,
-      showInfoMessage: secondInfo,
       cancel: vi.fn(),
     });
-    expect(secondInfo).not.toHaveBeenCalled();
     expect(secondEmit).not.toHaveBeenCalled();
 
     await Promise.resolve();
 
-    expect(secondInfo).toHaveBeenCalledOnce();
-    expect(secondInfo).toHaveBeenCalledWith('replay this');
     expect(secondEmit).toHaveBeenCalledOnce();
     expect(secondEmit).toHaveBeenCalledWith('requestShowError', {
       message: 'replay this error',
     });
 
     detachSecond();
-    const thirdInfo = vi.fn();
     const thirdEmit = vi.fn();
     session.interactions.use({
       emit: thirdEmit,
-      showInfoMessage: thirdInfo,
       cancel: vi.fn(),
     });
     await Promise.resolve();
 
-    expect(thirdInfo).not.toHaveBeenCalled();
     expect(thirdEmit).not.toHaveBeenCalled();
-    expect(firstInfo).not.toHaveBeenCalled();
     expect(firstEmit).not.toHaveBeenCalled();
     session.dispose();
   });
 
   it('leaves remaining notices queued when replay detaches the host', async () => {
     const session = createTestSession();
-    session.interactions.showInfoMessage('first', {
-      replayWhenAttached: true,
-    });
-    session.interactions.showInfoMessage('second', {
-      replayWhenAttached: true,
-    });
+    session.interactions.emit(
+      'requestShowError',
+      { message: 'first' },
+      { replayWhenAttached: true },
+    );
+    session.interactions.emit(
+      'requestShowError',
+      { message: 'second' },
+      { replayWhenAttached: true },
+    );
 
-    const firstInfo = vi.fn();
+    const firstEmit = vi.fn();
     let detachFirst = (): void => undefined;
     detachFirst = session.interactions.use({
-      showInfoMessage: (message) => {
-        firstInfo(message);
+      emit: (event, payload) => {
+        firstEmit(event, payload);
         detachFirst();
+        return true;
       },
       cancel: vi.fn(),
     });
     await Promise.resolve();
 
-    expect(firstInfo).toHaveBeenCalledOnce();
-    expect(firstInfo).toHaveBeenCalledWith('first');
+    expect(firstEmit).toHaveBeenCalledOnce();
+    expect(firstEmit).toHaveBeenCalledWith('requestShowError', {
+      message: 'first',
+    });
 
-    const secondInfo = vi.fn();
+    const secondEmit = vi.fn();
     session.interactions.use({
-      showInfoMessage: secondInfo,
+      emit: secondEmit,
       cancel: vi.fn(),
     });
     await Promise.resolve();
 
-    expect(secondInfo).toHaveBeenCalledOnce();
-    expect(secondInfo).toHaveBeenCalledWith('second');
+    expect(secondEmit).toHaveBeenCalledOnce();
+    expect(secondEmit).toHaveBeenCalledWith('requestShowError', {
+      message: 'second',
+    });
     await Promise.resolve();
-    expect(firstInfo).toHaveBeenCalledOnce();
-    expect(secondInfo).toHaveBeenCalledOnce();
+    expect(firstEmit).toHaveBeenCalledOnce();
+    expect(secondEmit).toHaveBeenCalledOnce();
     session.dispose();
   });
 
@@ -486,34 +480,25 @@ describe('session.interactions immediate capabilities', () => {
 
   it('does not queue an opted-in notice delivered to an attached presentation', () => {
     const session = createTestSession();
-    const firstInfo = vi.fn();
     const firstEmit = vi.fn();
     const detach = session.interactions.use({
       emit: firstEmit,
-      showInfoMessage: firstInfo,
       cancel: vi.fn(),
     });
 
-    session.interactions.showInfoMessage('deliver now', {
-      replayWhenAttached: true,
-    });
     session.interactions.emit(
       'requestShowError',
       { message: 'deliver error now' },
       { replayWhenAttached: true },
     );
-    expect(firstInfo).toHaveBeenCalledOnce();
     expect(firstEmit).toHaveBeenCalledOnce();
 
     detach();
-    const secondInfo = vi.fn();
     const secondEmit = vi.fn();
     session.interactions.use({
       emit: secondEmit,
-      showInfoMessage: secondInfo,
       cancel: vi.fn(),
     });
-    expect(secondInfo).not.toHaveBeenCalled();
     expect(secondEmit).not.toHaveBeenCalled();
     session.dispose();
   });
@@ -522,15 +507,18 @@ describe('session.interactions immediate capabilities', () => {
     const session = createTestSession();
     const QUEUED = 300; // past the 256 cap
     for (let n = 0; n < QUEUED; n += 1) {
-      session.interactions.showInfoMessage(`notice-${n}`, {
-        replayWhenAttached: true,
-      });
+      session.interactions.emit(
+        'requestShowError',
+        { message: `notice-${n}` },
+        { replayWhenAttached: true },
+      );
     }
 
     const messages: string[] = [];
     session.interactions.use({
-      showInfoMessage: (message) => {
-        messages.push(message);
+      emit: (_event, payload) => {
+        messages.push((payload as { message: string }).message);
+        return true;
       },
       cancel: vi.fn(),
     });

--- a/src/test-kernel/commands/agent/ResumeFromResumeData.vitest.ts
+++ b/src/test-kernel/commands/agent/ResumeFromResumeData.vitest.ts
@@ -55,18 +55,21 @@ describe('tryResumeFromResumeData', () => {
   it('words a refusal with the shared follow-up failure vocabulary', async () => {
     const session = defaultSession();
     const has = vi.spyOn(session.transcripts, 'has').mockReturnValue(true);
-    const showInfoMessage = vi
-      .spyOn(session.interactions, 'showInfoMessage')
-      .mockReturnValue(undefined);
+    const emit = vi.spyOn(session.interactions, 'emit').mockReturnValue(false);
     mocks.resumeStream.mockResolvedValueOnce({ failed: 'finished' });
 
     await expect(tryResumeFromResumeData(STREAM)).resolves.toBe(false);
 
-    expect(showInfoMessage).toHaveBeenCalledWith(
-      'This run has finished. Start a new agent task to continue.',
+    expect(emit).toHaveBeenCalledWith(
+      'requestShowInstruction',
+      {
+        key: 'resumeRefused',
+        message: 'This run has finished. Start a new agent task to continue.',
+        showSuppress: false,
+      },
       { replayWhenAttached: true },
     );
-    showInfoMessage.mockRestore();
+    emit.mockRestore();
     has.mockRestore();
   });
 });

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -1948,14 +1948,16 @@ describe('DesktopProgressBridge', () => {
     const repairRestartedStreams: RepairRestartedStreamsMock = vi.fn(
       async () => repairGate,
     );
-    const firstInfo = vi.fn(async () => undefined);
+    const firstInstruction = vi.fn(async () => undefined);
     const bridgeRef: { current?: TestableBridge } = {};
 
     const bridge = await createBridge([], {
       configureSession: (session) => {
-        session.interactions.showInfoMessage('survive approval replay', {
-          replayWhenAttached: true,
-        });
+        session.interactions.emit(
+          'requestShowInstruction',
+          { key: 'resumeRefused', message: 'survive approval replay' },
+          { replayWhenAttached: true },
+        );
         void session.interactions.requestPlanApproval?.({
           requestId: 'close-during-attachment',
           streamId: 'attachment-close-stream' as StreamTabId,
@@ -1965,7 +1967,7 @@ describe('DesktopProgressBridge', () => {
       },
       deferReady: true,
       repairRestartedStreams,
-      showInfoMessage: firstInfo,
+      showInstructionDialog: firstInstruction,
       observeRendererMessage: (message) => {
         const progress = message as ProgressMessage;
         if (
@@ -1985,24 +1987,27 @@ describe('DesktopProgressBridge', () => {
       attachments: unknown[];
     };
     expect(interactions.attachments).toHaveLength(0);
-    expect(firstInfo).not.toHaveBeenCalled();
+    expect(firstInstruction).not.toHaveBeenCalled();
 
     const { ctor, options: firstBridgeOptions } = bridgeContext(bridge);
-    const replacementInfo = vi.fn(async () => undefined);
+    const replacementInstruction = vi.fn(async () => undefined);
     const replacement = disposeAfterTest(
       new ctor(() => undefined, {
         ...firstBridgeOptions,
         host: createStubDesktopAgentExecutionHost({
-          showInfoMessage: replacementInfo,
+          showInstructionDialog: replacementInstruction,
         }),
       }),
     );
     await replacement.waitUntilReady();
 
-    expect(replacementInfo).toHaveBeenCalledOnce();
-    expect(replacementInfo).toHaveBeenCalledWith('survive approval replay');
+    expect(replacementInstruction).toHaveBeenCalledOnce();
+    expect(replacementInstruction).toHaveBeenCalledWith(
+      'survive approval replay',
+      undefined,
+    );
     await Promise.resolve();
-    expect(replacementInfo).toHaveBeenCalledOnce();
+    expect(replacementInstruction).toHaveBeenCalledOnce();
   });
 
   it('ignores renderer switches to unknown streams', async () => {


### PR DESCRIPTION
## Summary

`HostInteractions.showInfoMessage` was an optional port member with its own bespoke replay branch, implemented by **only** the desktop adapter. The VS Code extension never attached it — yet the extension's resume path called it, so `active.interactions.showInfoMessage?.(message)` resolved to `undefined` and a user whose resume was refused saw **nothing at all**. A queued replay dropped it too.

This takes **Option 2** from the issue — delete the one-message port, route both producers through the compile-checked presentation map — but with a correction that removes the option's only stated cost.

### The issue's behavior-change caveat does not apply, and shouldn't be paid

The issue says Option 2 must promote the message to an **error** toast because "there is no info-level presentation event". There is one: **`requestShowInstruction`** (`src/agent/runtime/runtimePresentationEvents.ts:21`).

- Desktop renders it via `showInstructionDialog`, which is literally `dialog.showMessageBox({ type: 'info' })` — its own comment says "an instruction is actionable guidance, not a failure, so it uses the info-style dialog" (`desktopAgentExecution.ts:254`, `index.ts`).
- The extension renders it via `handleRequestShowInstruction` → `vscode.window.showInformationMessage` (`agentEventListeners.ts:79`).
- The CLI logs it at `info`.
- `showSuppress: false` with no actions is an established production shape (`AgentLaunchContext.ts:208-213`, `OutputNode.ts:263`).

Routing through `requestShowError` would also have been **internally inconsistent**: the sibling progress-view follow-up path already presents these exact `describeFollowUpFailure` strings through `showInfo` on both GUI hosts (`progressFollowUpSubmit.ts:82-84` → `showInfoMessage` on desktop, `showInformationMessage` on the extension). The same message would have been error-styled in one code path and info-styled in the other, in the same process.

So this is a **pure fix with no severity promotion on any host**.

`showSuppress: false` is deliberate: the extension's `showInstructionWithSuppress` only consults its persisted "never remind again" key when `showSuppress` is true, and a refusal notice must never become permanently suppressible.

## Issue acceptance gates

Closes #11766. The issue asked for a decision, not code; the decision taken is Option 2 with `requestShowInstruction` instead of `requestShowError`, which dominates both stated options — it removes the optional-member trap (Option 1 keeps it, so the next unimplemented host silently drops again) *and* costs no severity change (Option 2's only downside). Say the word if you'd rather have the three-line implementor instead and I'll swap it.

## Single source of truth

The runtime's presentation-event map (`RuntimePresentationEventPayloads`) is now the only channel from the agent runtime to a host's notification surface. There is no second, optional side channel a host can leave unimplemented.

Note the port deleted here is `HostInteractions.showInfoMessage`. The unrelated `UiHost`/`MessageHost.showInfoMessage` notification surface (`src/hosts/uiHosts.ts:34`, and ~60 desktop/settings call sites) is a different member and is untouched.

## Duplication and abstraction budget

Removes a port member, its class method, its bespoke replay branch, and its only implementor — four constructs collapsed onto one already-shared channel. No abstraction added. `queuePresentationReplay` and `AgentRuntimeEmitOptions` stay: `emit` still uses both.

## Net elements (R6)

Files: 4 production, 1 doc, 3 test. Exported symbols: 0 added, 0 removed. Interfaces: 1 member removed (`HostInteractions.showInfoMessage?`); 1 class method + its replay branch removed. Net LoC: **≈ −15 production** (the desktop spread collapses to a bare call as a side effect), with test churn roughly neutral.

## Consumer counts (R8)

`HostInteractions.showInfoMessage` — grepped at HEAD: **1 implementor** (`desktopAgentExecution.ts:381`), **2 producers** (`packages/extension/src/commands/agent/resumeFromResumeData.ts:52`, `packages/desktop/src/main/desktopAgentResume.ts:94`), **0 in `packages/cli`**, **0 in `packages/agent`**. Both producers are re-routed; the implementor is deleted. `requestShowInstruction` gains one producer and has handlers on all three hosts already.

## Host impact

Extension: **the fix** — a refused resume now shows an information message where it previously showed nothing.

Desktop: unchanged dialog class. `showInstructionDialog` is a `type: 'info'` message box, the same class `showInfoMessage` used; the only delta is a "Dismiss" button label instead of the default OK.

CLI: unchanged — it never implemented the port; the instruction event logs at `info` as before.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck:workspace`, `typecheck:test-kernel`, `typecheck:desktop` — all clean.
- `npx eslint` on all four production files — clean. `npx prettier --check` on every changed file — clean.
- `node scripts/check-guidance-refs.mjs` — OK (58 files). `docs/architecture/2026-07-26-embedding-the-agent-runtime.md:476` named `showInfoMessage` in the port's typed shape and is updated with it; that directory is inside `GUIDANCE_DIRS`.
- `npm run check:dead-code-ratchet` — OK, no new findings.
- `npx vitest run` over `SessionInteractions.vitest.ts`, `ResumeFromResumeData.vitest.ts`, `DesktopAgentResume.vitest.ts` — 45 passed, 0 failed.
- `npx vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.ts` — 75 passed, **2 failed**. See below.

### ⚠️ Two pre-existing failures on `main`, not from this PR

`DesktopAgentExecution.vitest.ts` fails these two on the current `main` as well:

- `presents a merge failure that occurs before lifecycle startup`
- `presents a terminal merge failure exactly once from its result`

Verified by stashing this branch's changes and running the same file at `origin/main` (`34adb91`) twice: **2 failed | 75 passed** both times, the same two tests, with identical `showErrorMessage … Number of calls: 0` assertions. They are in the merge-failure presentation path, which this PR does not touch. Flagging rather than fixing, since it is unrelated to the diff — happy to open a separate issue.

Test retargets are mechanical and test-only, as the issue predicted: four `SessionInteractions.vitest.ts` cases lose their now-duplicated `showInfoMessage` arms or move to `requestShowError`, `ResumeFromResumeData.vitest.ts:58-69` asserts on the emit, and the desktop replay test moves to `showInstructionDialog` (asserted with the trailing `undefined`, since the handler passes `instruction.actions` and the payload has none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1)_