### PR TITLE
refactor(storage): delete the taskRuns absolute-path arm

### DIFF
--- a/docs/prds/2026-08-16-sqlite-workspace-state.md
+++ b/docs/prds/2026-08-16-sqlite-workspace-state.md
@@ -130,14 +130,12 @@ workspace storage today                     workspace storage after
                                             ├── pasted/  recordings/
                                             │                 (user-media caches: pasted
                                             │                  images, audio — documents)
-                                            └── taskRuns/     (legacy, until #6981
-                                                               retention drains it)
 ```
 
-Legacy `taskRuns/` (`WORKSPACE_STORAGE_LAYOUT.legacyRuns`) is grandfathered:
-it stays read-only on its existing #6981 retention path, is never migrated
-into rows, and its layout key retires when that policy drains it. It is the
-one deliberate exception to the §2 rule, time-bounded by retention.
+Legacy `taskRuns/` is not part of the target layout. Its last writer was
+retired on 2026-02-12, its absolute-path reader and the
+`WORKSPACE_STORAGE_LAYOUT.legacyRuns` key were deleted (#11771 ruling 1), and
+any residual directory is inert on disk. There is no §2 exception.
 
 Engine: `node:sqlite` (fallback: `better-sqlite3`, accepting the packaging
 cost, if Stage 0 finds the built-in flagged or unfit on any host). Schema and
@@ -711,7 +709,7 @@ public surfaces (`store-public-surface-baseline`); hosts-as-renderers plane
 rules untouched. **Added:** the §2 rule, pinned by a new architecture test.
 The test lands at Stage 1 as a **shrinking ratchet, not a strict gate**: it
 starts with an explicit allowlist of the not-yet-migrated directories
-(`streamLogSummaries/`, `streamData/`, `streamData.deleting/`, `taskRuns/` — the staged-
+(`streamLogSummaries/`, `streamData/`, `streamData.deleting/` — the staged-
 deletion namespace `StagedDeletionCoordinator` renames into, retained in
 the baseline through the **Stage-7** deletion-protocol cutover that retires
 the coordinator — `streamLogs/`, `executions/` KV records, lease/lock
@@ -739,11 +737,7 @@ After Stage 6 one **importer-owned temporary** entry remains alongside the perma
 `*.pre-sqlite-backup`, which the §5 retirement window requires for 90 days
 and two releases — the importer-removal PR deletes the backups and this
 ratchet entry together. Strict (permanent entries only) is that removal
-PR's exit criterion, not Stage 6's — and strictness is additionally
-conditional on legacy `taskRuns/` having drained under #6981's own
-retirement condition, which is independent of the importer window: if the
-importer retires first, `taskRuns/` remains a shrinking temporary entry
-until #6981 removes it, never a re-widen.
+PR's exit criterion, not Stage 6's.
 
 ## 8. Non-goals
 
@@ -766,8 +760,7 @@ normalization of entry payload internals; no publication of this doc
   `{ texra.db, texra.db-wal, texra.db-shm, original, memories, state.json,
 config.json, _workspace.json, pasted, recordings }` plus the per-execution
   artifacts
-  area (§5 Stage 5) — and legacy `taskRuns/` until #6981 retention drains
-  it (§3.1 exception). The §7 `exports` allowlist entry is a category for
+  area (§5 Stage 5). The §7 `exports` allowlist entry is a category for
   caller-chosen destinations outside the workspace-storage bucket, not a
   `WORKSPACE_STORAGE_LAYOUT` key. §7 and this criterion therefore enumerate
   the same bucket set by construction; a divergence between the two lists is

--- a/src/common/storage/storageLayout.ts
+++ b/src/common/storage/storageLayout.ts
@@ -9,7 +9,6 @@ export const WORKSPACE_STORAGE_LAYOUT = Object.freeze({
   memory: 'memories',
   runs: 'executions',
   executionLeases: 'executionLeases',
-  legacyRuns: 'taskRuns',
   streamData: 'streamData',
   streamLogs: 'streamLogs',
   streamLogSummaries: 'streamLogSummaries',

--- a/src/test-kernel/utils/files/RunStorageEntryInspection.vitest.ts
+++ b/src/test-kernel/utils/files/RunStorageEntryInspection.vitest.ts
@@ -162,7 +162,7 @@ describe('inspectRunStorageEntry', () => {
     ).rejects.toThrow('Denied');
   });
 
-  it('recovers execution identity from current and legacy absolute paths', () => {
+  it('recovers execution identity from absolute run-storage paths', () => {
     expect(
       runStorageLocationFromAnyAbsolutePath(
         storagePath('executions', executionId, 'r2', 'result.tex'),
@@ -171,15 +171,6 @@ describe('inspectRunStorageEntry', () => {
       kind: 'runStorage',
       executionId,
       relativePath: 'r2/result.tex',
-    });
-    expect(
-      runStorageLocationFromAnyAbsolutePath(
-        storagePath('taskRuns', executionId, 'result.tex'),
-      ),
-    ).toMatchObject({
-      kind: 'runStorage',
-      executionId,
-      relativePath: 'result.tex',
     });
     expect(
       runStorageLocationFromAnyAbsolutePath(
@@ -204,15 +195,6 @@ describe('inspectRunStorageEntry', () => {
       kind: 'runStorage',
       executionId,
       relativePath: 'r1/draft.tex',
-    });
-    expect(
-      fileService.locateSource(
-        storagePath('taskRuns', executionId, 'legacy.tex'),
-      ),
-    ).toMatchObject({
-      kind: 'runStorage',
-      executionId,
-      relativePath: 'legacy.tex',
     });
   });
 });

--- a/src/utils/files/runStorageFs.ts
+++ b/src/utils/files/runStorageFs.ts
@@ -4,7 +4,6 @@ import { promises as fs } from 'node:fs';
 
 // Local imports
 import { isFileNotFoundError } from '@common/errors';
-import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
 import { createLog } from '@logger/logUtils';
 import {
   resolveRunOriginalSnapshotPath,
@@ -163,39 +162,25 @@ export function runStorageLocationFromAbsolutePath(
   return createRunStorageLocation(absolutePath, relativePath, executionId);
 }
 
-/**
- * Recover execution identity from an absolute run-storage path.
- *
- * The released extension may retain transcripts and resume records containing
- * absolute `taskRuns` paths. Keep parsing those paths without probing the
- * filesystem until that released-data retention policy expires (#6981).
- */
+/** Recover execution identity from an absolute run-storage path. */
 export function runStorageLocationFromAnyAbsolutePath(
   absolutePath: string,
 ): RunStorageFileLocation | undefined {
   if (!path.isAbsolute(absolutePath)) return undefined;
 
-  const roots = [
-    StorageFS.fullPath(resolveRunStoragePath()),
-    StorageFS.fullPath(WORKSPACE_STORAGE_LAYOUT.legacyRuns),
-  ];
-  for (const root of roots) {
-    const runRelativePath = resolveRunStorageRelativePath(absolutePath, root);
-    if (!runRelativePath) continue;
+  const root = StorageFS.fullPath(resolveRunStoragePath());
+  const runRelativePath = resolveRunStorageRelativePath(absolutePath, root);
+  if (!runRelativePath) return undefined;
 
-    const [rawExecutionId, ...entrySegments] = getPathSegments(runRelativePath);
-    const executionId = ExecutionIdSchema.safeParse(rawExecutionId);
-    if (!executionId.success || entrySegments.length === 0) return undefined;
+  const [rawExecutionId, ...entrySegments] = getPathSegments(runRelativePath);
+  const executionId = ExecutionIdSchema.safeParse(rawExecutionId);
+  if (!executionId.success || entrySegments.length === 0) return undefined;
 
-    const relativePath = entrySegments.join('/');
-    return createRunStorageLocation(
-      path.resolve(root, runRelativePath),
-      relativePath,
-      executionId.data,
-    );
-  }
-
-  return undefined;
+  return createRunStorageLocation(
+    path.resolve(root, runRelativePath),
+    entrySegments.join('/'),
+    executionId.data,
+  );
 }
 
 export async function ensureParentDir(filePath: string): Promise<void> {


### PR DESCRIPTION
## Summary

Implements **#11771 ruling 1**, as decided: delete the arm, create no tracker row.

`runStorageLocationFromAnyAbsolutePath` looped over a second root when classifying absolute paths from persisted transcripts and resume records, citing a #6981 retention policy that exists as a row nowhere.

**The "stamp it" option was not available.** #6981 (completed 2026-08-09), #9422 and #9627 (both `not_planned`, same day) are all closed, and no open tracking-labelled retirement ledger exists. Stamping would have meant first creating an issue whose only purpose is to hold a row for this code.

**The arm is unreachable, not merely stale.** Both roots are built with `StorageFS.fullPath(...)`, which joins against the *current* storage base, and matching is `isPathWithin` — so it can only match `<current storage root>/taskRuns/<executionId>/…`. The last build that wrote `taskRuns/` was **2026-02-12** (`bedbf19e64`, pinned by #9623); the extension's storage port moved to the shared `~/.texra` root on **2026-07-16** (#8622 / PR #8624). Five months apart, so no build ever wrote that combination. Absolute `taskRuns` paths in released transcripts sit under the *old* VS Code root and fail `isPathWithin` against the current one. The one route that could have produced such a directory was #9623's migration, which *consumed* it into `executions/` — and #10887 deleted that migration outright.

**It was not load-bearing even on a hypothetical match.** `childRunOutput.ts:18` uses the result purely as a lookup token and immediately re-resolves through `inspectRunStorageEntry(reference.executionId, reference.relativePath)` — under `executions/`, never `taskRuns/`. The arm relabels a path; it cannot restore access to anything.

**#10887's R8 keep rested on a factual error.** It reasoned `runStorageFs.ts:180` "still reads it under a *different* retention (#6981…) — a live reader outside this ruling's scope." #6981 had closed nine days earlier. Deleting it applies that PR's own recorded ruling that dated compat horizons for intermediate-era data are void.

## Issue acceptance gates

Part of #11771 (ruling 1); rulings 2 and 3 ship separately.

- Arm deleted, `legacyRuns` layout key deleted with its only reader, two compat-only test assertions deleted — **done**.
- SQLite PRD edited — **done, in all five places**, not the one the issue named: `docs/prds/2026-08-16-sqlite-workspace-state.md` lines 133-134 (§3.1 target-layout diagram), 137-140 (the grandfathering paragraph), 714 (§7 ratchet allowlist), 742-746 (the strictness condition), 769-770 (§9 acceptance criterion). §7 and §9 still enumerate the same set, as that criterion requires. Line 126 stays — it is the "today" column and describes a directory that can still sit on disk.
- **No tracker row created**, as ruled.

## Single source of truth

`resolveRunStoragePath()` → `executions/` is now the only run-storage root anywhere. This was the last surviving two-root site: `findExistingRunStoragePath`, `findRunDir`, `ensureRunDir`, `getRunStorageAbsolutePath` and `inspectRunStorageEntry` already resolved exclusively through it.

## Duplication and abstraction budget

Removes a two-root loop and the layout key that fed it. No abstraction added. The single-root form also fixes a latent quirk: today a path under the primary root with a bad execution id returns `undefined` immediately rather than falling through to the second root, so behavior for the surviving root is unchanged.

## Net elements (R6)

Files: 2 production, 1 test, 1 doc. Exported symbols: 0 added, 0 removed (`WORKSPACE_STORAGE_LAYOUT` stays exported and used; it loses one key). Net LoC: **≈ −40** including doc edits.

## Consumer counts (R8)

`WORKSPACE_STORAGE_LAYOUT.legacyRuns` / `taskRuns`: **1 production reader** (`runStorageFs.ts:180`, deleted). Remaining hits before this PR were two compat-only test assertions (`RunStorageEntryInspection.vitest.ts:177`, `:210`, both deleted), the PRD, and historical proposal docs. Post-change grep across `src`/`packages` returns nothing.

`runStorageLocationFromAnyAbsolutePath` keeps its three callers (`childRunOutput.ts:18`, `taskRunStorage.ts:122` and `:145`); only the second root is gone.

## Host impact

Extension: a hypothetical `~/.texra/workspace-storage/<id>/taskRuns/…` path in a persisted transcript now classifies as workspace/external rather than `runStorage`. No shipped writer produces that path.

Desktop: same, and it never wrote `taskRuns/` under the shared root at all (it was on `~/.texra` from #7987).

CLI: same.

### Accepted behavioral outcome, stated loudly

If such a directory somehow exists and a transcript references it, `TaskRunFileService.locateSource` classifies the path as workspace/external and `resolveChildRunOutput` throws **"Workflow output is not inside task-run storage."** That is a loud failure on data no shipped writer produces — not silent degradation.

## Scheduled refactoring

None. No ledger row created, no other tracker needs updating.

Noted while here, **not acted on**: two other code comments point at "a row on #9627", a closed tracker — `src/shared/deliveryTags.ts:55` and `src/agent/storage/executionLease.ts:104`. That is a separate, wider hygiene problem outside this ruling.

## Validation

- `npm run typecheck:workspace` and `npm run typecheck:test-kernel` — clean.
- `npx vitest run src/test-kernel/utils/files` — 36 passed, 0 failed.
- `npx eslint` on both changed source files — clean. `npx prettier --check` on all changed files — clean.
- `npm run check:dead-code-ratchet` — OK, no new findings.
- `node docs/scripts/check-root-docs.mjs` — OK (the edit is under `docs/prds/`, already excluded from publication, so the texra.ai deploy is untouched).

No new tests: the remaining cases in `RunStorageEntryInspection.vitest.ts` already cover the surviving single-root behavior, and the one test whose title claimed "current and legacy" is renamed to match what it now asserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1)_