### PR TITLE
docs(streams): record the EndGroupStatus arm as a permanent parse boundary

### DIFF
--- a/src/shared/streams/taskGroupProjection.ts
+++ b/src/shared/streams/taskGroupProjection.ts
@@ -21,6 +21,17 @@ import {
  * Current producers write `TaskGroupStatus`. A trace exported before the
  * status migration can still contain the legacy `EndGroupStatus`, so the
  * read projection maps it to the same canonical value used by persistence.
+ *
+ * Permanent, not a dated shim (ruled in
+ * docs/proposals/2026-07-03-session-scoped-runtime-architecture.md §8.3 and
+ * recorded in §8.6). In-app this arm is unreachable — `StreamLogStore`
+ * normalizes every persisted row at read (`normalizeGroupStatusEntry`). Its
+ * one live input is the standalone trace viewer, which forwards a static
+ * exported `trace.json`'s `trace.entries` verbatim into this same pipeline
+ * (`packages/trace-viewer/src/replayTrace.ts`); those files are never
+ * rewritten, so the legacy vocabulary never ages out. Removing the arm would
+ * not delete dead code: `TraceGroupLogPayloadSchema.status` catches to
+ * `undefined`, so a legacy 'error' would silently project as COMPLETED.
  */
 function taskGroupEndStatus(
   value: TaskGroupStatus | EndGroupStatus | undefined,


### PR DESCRIPTION
## Summary

Implements **#11771 ruling 2**, as decided: the code comments are right and the dated ledger row is rescoped to permanent. `taskGroupProjection.ts` was the only site in this cohort carrying **neither a date stamp nor the permanence claim** its siblings in `log.ts`, `taskGroup.ts` and `StreamLogStore.ts` already state — and it is the file #9627's 2026-10-31 row names, which is plausibly how that row came to be dated in the first place. This adds the missing statement so the next sweep does not re-derive the conflict.

Comment only. No behavior, schema, or test change.

## Issue acceptance gates

Part of #11771 (ruling 2); rulings 1 and 3 ship separately.

**Why the code wins over the ledger row, on three counts:**

1. **#9627 is closed (`not_planned`)**, and its closing comment says: *"Rather than preserve a broad queue indefinitely, use each source-local date plus the `AGENTS.md` compatibility rule as the trigger… Their source-local dates remain authoritative."* The ledger already deferred to the code.
2. **The row's own completion condition sanctions this:** *"add its exact source path and date here, **or classify it explicitly as a permanent external/public parse boundary**."*
3. **The row's removal condition is a claim about writers, not inputs.** "Current group-end rows use `TaskGroupStatus`" was already true the day the row was written, so its date has no discriminating power. A retirement date bets the producing population ages out; here the inputs are static `trace.json` files on users' disks that TeXRA never rewrites.

**Firing the row would be silent data corruption, not dead-code removal.** `TraceGroupLogPayloadSchema` (`taskGroup.ts:72-81`) applies `.catch(undefined)` to `status`. Drop `EndGroupStatusSchema` from the union and a legacy trace's `'error'` no longer parses → `undefined` → `taskGroupEndStatus(undefined)` returns `COMPLETED` (`taskGroupProjection.ts:29-31`). **A historical failed run would render as completed, with no warning** — the CLAUDE.md silent-degradation case, produced by a calendar entry rather than by evidence.

Permanence was also ruled by proposal, not merely asserted in a comment: `docs/proposals/2026-07-03-session-scoped-runtime-architecture.md` §8.3 and §8.6 say verbatim *"**Permanent, not debt.** … plus `GroupLogPayloadSchema`'s legacy `EndGroupStatus` union member … a static exported `trace.json` stays legacy-shaped forever"* — naming the exact member under ruling, and predating the row.

## Single source of truth

All four sites in the cohort now state the same thing: `log.ts:13-31`, `taskGroup.ts:29-52`, `StreamLogStore.ts` and, as of this PR, `taskGroupProjection.ts`. No site is left undated-and-unclassified for a future sweep to re-open.

## Duplication and abstraction budget

n/a — comment only, no code construct added or removed.

## Net elements (R6)

Files: 1. Exported symbols: 0. Net LoC: **+13 comment lines**, 0 code lines.

## Consumer counts (R8)

n/a — no emit path or export changed. For the record: repo-wide grep for `END_GROUP_STATUS|EndGroupStatus` returns only the schema definition (`log.ts`), the two read normalizers (`StreamLogStore.ts`, `taskGroupProjection.ts:28-31` and `:80-83`), the trace-viewer read (`replayTrace.ts:124-128`), and tests. `legacyEndGroupStatusForOutcome` and the CLI headless `endGroupStatus` projection are already gone (zero hits) — **no live writer remains**, which is exactly why the arm is a read boundary rather than debt.

The three consumers of `upsertTaskGroupFromStreamLog` confirm the reachability claim: `transcriptFold.ts:203` and `logSlice.ts:160` are both fed by `StreamLogStore` (normalized at read), while `packages/trace-viewer/src/replayTrace.ts:184+` builds a `LogDeltaMessage` with `entries: trace.entries` **verbatim**. Exported `trace.json` is the only remaining input carrying the legacy vocabulary.

## Host impact

Extension: none. Desktop: none. CLI: none. The trace viewer's behavior is unchanged — this PR documents why it must stay that way.

## Scheduled refactoring

**Issue bookkeeping for you, not code:** #9627 is closed, so the row should be reclassified by comment rather than by reopening. Flagged while there, **not acted on**: that issue's other group-status row ("2026-11-17 — Pre-#10774 settled/running `GROUP_START` normalization in `normalizeGroupStatusEntry`") also looks stale — the current `normalizeGroupStatusEntry` has only `STOPPED`/`ERROR` arms, with no settled/running arm to retire. Worth a separate check.

## Validation

- `npm run typecheck:workspace` — clean.
- `npx eslint` and `npx prettier --check` on the changed file — clean.
- `npx vitest run src/test-kernel/shared/TaskGroupProjection.vitest.ts src/test-kernel/traceViewer` — 14 passed, 0 failed.

No new tests: existing coverage already pins this boundary in both directions (`replayTrace.vitest.ts:100-140`, `StreamLogStoreLoad.vitest.ts:1212-1249`, `TaskGroupProjection.vitest.ts`).

Deliberately **not** touched, all correct as written: `log.ts:13-31`, `taskGroup.ts:29-54`, `taskGroup.ts:72-81`, `StreamLogStore.ts:212-253`, `replayTrace.ts:93-128`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1)_