### PR TITLE
docs: correct two statements that contradict the repo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,10 @@ directory, but they have different publication boundaries.
 
 ## Public website source
 
-- `index.md`, `launch.md`, and `providers.md` are public root pages.
+- `index.md`, `launch.md`, `providers.md`, and `work-using-texra.md` are
+  public root pages, as are `changelog.md` and `terms.md`, which the
+  `sync-content` script generates into the docs root at build time from the
+  repo-root `CHANGELOG.md` and `TERMS_OF_SERVICE.md`.
 - `guide/` contains public user guides, except pages explicitly excluded in
   `.vitepress/publicDocs.js`.
 - `public/` contains static assets copied directly into the website.

--- a/docs/dev/texra-cli-checkout.md
+++ b/docs/dev/texra-cli-checkout.md
@@ -1,9 +1,11 @@
 # TeXRA CLI — Checkout Workflow
 
 Developer-only notes for running the `texra` CLI from a local repository
-checkout. These instructions assume read access to the TeXRA source tree and
-are not part of the public CLI guide (`docs/guide/texra-cli.md`) because the
-repository is not open source.
+checkout. These instructions assume a working build toolchain and a cloned
+source tree, so they live here rather than in the public CLI guide
+(`docs/guide/texra-cli.md`), which covers the published `texra` command. The
+client software itself is Apache-2.0 (see `LICENSE` and
+`docs/guide/open-source.md`).
 
 For end-user CLI usage (`texra run`, `texra completion`, workspace defaults,
 history, tools), see the [public CLI guide](../guide/texra-cli.md).
@@ -27,7 +29,8 @@ npm run texra-local:link    # one-time; override the install dir with TEXRA_LOCA
 ```
 
 Run with `texra-local` instead of `texra`. Re-run `texra-local:build` to refresh.
-See also the "Local CLI (`texra-local`)" section of `CLAUDE.md`.
+The two scripts are defined in the repo-root `package.json`; the link step is
+`scripts/link-texra-local.mjs`.
 
 ### Override the published `texra`
 


### PR DESCRIPTION
## Summary

Second batch from the docs sweep. Two documents assert things the repository contradicts.

**1. `docs/dev/texra-cli-checkout.md` says the repo is closed source.** It justifies living outside the public CLI guide "because the repository is not open source." The client software is **Apache-2.0** — `LICENSE` is the Apache 2.0 text, and `docs/guide/open-source.md` states it on the published site ("TeXRA's client software is licensed under the Apache License 2.0"). Replaced with the actual reason the page is internal: it documents building from a source checkout, which the published-command guide doesn't cover.

**2. The same page has a dangling pointer.** It says *See also the "Local CLI (`texra-local`)" section of `CLAUDE.md`* — grep finds no `texra-local` and no `Local CLI` in `CLAUDE.md` or `AGENTS.md`. It now names where the scripts actually live: the repo-root `package.json` (`texra-local:build`, `texra-local:link`) and `scripts/link-texra-local.mjs`.

**3. `docs/README.md` undercounts the public root surface.** It lists three root pages; `docs/.vitepress/publicDocs.js` — the file it names one line later as "the source of truth" — lists six. The missing three are `work-using-texra.md` and the two the `sync-content` script generates into the docs root at build time (`changelog.md`, `terms.md`).

That third one is worth more than a typo fix: `publicDocs.js` is what the root-boundary gate enforces, and a README that undercounts it is exactly the drift that invites an unclassified root doc — the failure mode CLAUDE.md warns freezes the texra.ai deploy. (#11798 wires that gate into CI, which currently never runs it.)

## Issue acceptance gates

No issue — from the sweep of existing survey/audit documents. Each claim re-verified against the repository, not taken from the source document.

**One item from the same finding was discarded on verification.** The sweep reported "three stale symbol names in the CLI round-trips architecture diagrams". Two of them (`CliInteractivePreflight`, `CliMultiAgentPlanSnapshot`) do not exist in the codebase — but reading `docs/architecture/2026-06-20-cli-runtime-round-trips.md:202,206` shows them inside *recommendations* ("Introduce a small `CliInteractivePreflight`…", "Return a `CliMultiAgentPlanSnapshot` from the planner…"). They are proposed future names, not dangling references, and renaming them would corrupt the proposal. Not touched.

## Single source of truth

`docs/.vitepress/publicDocs.js` is the declared source of truth for the publish boundary; `docs/README.md` now describes it accurately instead of maintaining a second, shorter list beside it.

## Duplication and abstraction budget

n/a — documentation only. The README change reduces a divergent second copy of the root allowlist to an accurate description of the real one.

## Net elements (R6)

2 files, documentation only. No code, no exports, no schemas, no tests.

## Consumer counts (R8)

n/a — no emit path or export changed.

## Host impact

Extension / Desktop / CLI: none. No runtime code touched.

## Scheduled refactoring

None.

## Validation

- `node docs/scripts/check-root-docs.mjs` — clean (6 public docs, 1 public dir, 5 internal areas excluded and timestamped).
- `node scripts/check-guidance-refs.mjs` — clean across 58 files, `docs/dev/texra-cli-checkout.md` included; the replaced pointer resolves.
- `npx prettier --check` on both files — clean.
- Claims verified directly: `head -3 LICENSE` (Apache License 2.0), `grep -n "texra-local\|Local CLI" CLAUDE.md AGENTS.md` (zero hits), `node -e` over `package.json` scripts (both `texra-local:*` scripts exist), and the six-entry root list read out of `publicDocs.js:20-25`.

No tests — documentation-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1)_