### PR TITLE
fix(tools): await the sox process instead of sleeping before reading the file

### DIFF
--- a/src/tools/media/audio.ts
+++ b/src/tools/media/audio.ts
@@ -21,6 +21,12 @@ const log = createLog('AudioUtils');
 
 const RECORDINGS_DIR = 'recordings';
 
+/**
+ * Upper bound on how long a SIGTERM'd sox may take to flush and exit before
+ * `stopRecordingAndTranscribe` gives up waiting and reads the file anyway.
+ */
+const SOX_SHUTDOWN_TIMEOUT_MS = 5000;
+
 // Store active recording process
 let activeRecordingProcess: Subprocess | null = null;
 let activeRecordingPath: string | null = null;
@@ -151,11 +157,19 @@ export async function stopRecordingAndTranscribe(): Promise<{
     }
 
     const recordingPath = activeRecordingPath;
-    activeRecordingProcess.kill('SIGTERM');
+    const recording = activeRecordingProcess;
+    recording.kill('SIGTERM');
     resetRecordingState();
 
-    // Wait for file to be written
-    await delay(500);
+    // Await the process this module already holds rather than guessing how
+    // long sox needs to flush. `execa` was started with `reject: false`, so
+    // this settles on exit instead of throwing. The bounded race is a
+    // backstop for a wedged sox — without it a process that ignores SIGTERM
+    // would hang the tool, which the old fixed sleep could not do.
+    await Promise.race([
+      recording.catch(() => undefined),
+      delay(SOX_SHUTDOWN_TIMEOUT_MS),
+    ]);
 
     if (!AbsoluteFS.existsSync(recordingPath)) {
       return { success: false, text: '', error: 'Recording file not found' };


### PR DESCRIPTION
## Summary

`stopRecordingAndTranscribe` sent `SIGTERM`, cleared the recording state, then `await delay(500)` before stat-ing the wav file. The completion promise for that process **is already held by this module** — `execa(soxCommand.command, …, { reject: false })` is stored in `activeRecordingProcess` (`audio.ts:88-96`) — so the fixed sleep was a guess standing in for a fact the module owns.

The failure mode is worse than "slow". When sox needs longer than 500 ms to flush, the guess produces a *misleading* result rather than a late one: `existsSync` or `statSync(...).size === 0` fails and the caller gets **"Recording file not found"** or **"Recording file is empty"** instead of the recording. A timing problem is reported as a missing-data problem — the silent-degradation shape CLAUDE.md calls a defect.

The stop path now captures the handle before `resetRecordingState()` clears it and awaits it.

## Issue acceptance gates

No issue — from the docs sweep (`docs/proposals/2026-08-10-simplifier-fleet-round1-strategy.md`, theme J item 9). Verified against `src/tools/media/audio.ts` at HEAD rather than taken from the document: the held promise, the `reject: false` option, and the `delay(500)` are all still exactly as described.

## Single source of truth

Process exit is now read from the process, not inferred from a clock. `activeRecordingProcess` was already the single holder of that fact; this makes the stop path consult it.

## Duplication and abstraction budget

No abstraction added. One `await delay(500)` becomes one `await Promise.race([...])`; one named constant replaces a bare literal. The pre-existing `.then`/`.catch` at `:100-119` keeps its logging and its own `resetRecordingState()` — untouched.

## Net elements (R6)

1 file. Exported symbols: 0 added, 0 removed. Constants: +1 module-local (`SOX_SHUTDOWN_TIMEOUT_MS`). Net LoC: **+15 / −3**, most of it the comment explaining why the bound exists.

## Consumer counts (R8)

n/a — no emit path or export changed. `stopRecordingAndTranscribe`'s signature and every return shape are identical; the four callers (`packages/desktop/src/main/index.ts`, `desktopAgentExecution.ts`, `packages/extension/src/extension.ts`, and the extension's `RecordingManager` path) need no change.

## Host impact

Extension: a recording whose flush exceeds 500 ms now transcribes instead of reporting an empty file.

Desktop: same.

CLI: n/a — the audio tool is not reachable from the CLI hosts.

### The one property of the sleep worth keeping

`await delay(500)` could never hang: it always returned. A bare `await recording` could, if sox ignores `SIGTERM`. So the await is raced against a 5s bound — deliberately, not incidentally. Common case: settles as soon as sox exits (usually well under 500 ms, so this is also *faster* than before). Pathological case: bounded at 5s, then the existing file checks run and report honestly.

`.catch(() => undefined)` on the handle is belt-and-braces: `reject: false` means the promise settles rather than throws, and the already-attached handler owns the error logging — this just guarantees the race can't reject.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck:workspace` — clean.
- `npx eslint src/tools/media/audio.ts` — clean. `npx prettier --check` — clean.
- `npx vitest run src/test-kernel/frontend/RecordingManager.vitest.ts` — 1 passed (the only suite touching this surface).

No new tests. There is no existing coverage of `stopRecordingAndTranscribe` itself, and earning one would mean injecting a fake `execa` — a production seam added purely for a test, which AGENTS.md's testing discipline forbids. The change is a strict improvement on the timing behavior it replaces, and the honest statement is that it is verified by reading, typecheck and lint, not by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1)_