### PR TITLE
refactor(desktop): make DesktopAgentExecution.runExecution private

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1185,7 +1185,7 @@ export class DesktopProgressBridge {
     return true;
   }
 
-  /** Internal launch path; every entry point above funnels through it. */
+  /** Internal launch path; every launch entry point funnels through it. */
   private runExecution(
     request: ValidatedExecutionRequest,
     options: DesktopRunExecutionOptions = {},

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1185,7 +1185,8 @@ export class DesktopProgressBridge {
     return true;
   }
 
-  runExecution(
+  /** Internal launch path; every entry point above funnels through it. */
+  private runExecution(
     request: ValidatedExecutionRequest,
     options: DesktopRunExecutionOptions = {},
   ): Promise<void> {


### PR DESCRIPTION
## Summary

`DesktopAgentExecution.runExecution` is public but has no caller outside its own class. The three uses are all internal:

- `:389` — the inbound execution request
- `:1213` — the validated launch path
- `:1237` — the prepared launch path

Marking it `private` states that, and stops the class exposing a launch entry point that bypasses the validation its public callers perform before funnelling into it.

## Issue acceptance gates

No issue — from the docs sweep. Verified against the file and a caller grep rather than taken from the source document: `grep -rn "\.runExecution("` across `src` and `packages` returns only the three internal sites, and the test kernel has zero uses. The nearby hits are **different symbols on different objects** — `runExecutionRequest` (a controller port), `runExecutionStep` (on `session.executions`), and `runExecutionId` (a test constant) — which is the trap this item could easily have fallen into.

## Single source of truth

The public launch entry points remain the single validated way in; `runExecution` is now visibly the shared implementation behind them rather than a fourth, unvalidated door.

## Duplication and abstraction budget

Nothing added or removed — a visibility modifier and a one-line comment.

## Net elements (R6)

1 file. Exported symbols: 0 added, 0 removed (this is a class member, not an export). Net LoC: **+2 / −1**.

## Consumer counts (R8)

`DesktopAgentExecution.runExecution`: **0 external callers**, 3 internal, 0 test. No emit path or export changed.

## Host impact

Extension / CLI: none — desktop-only class.

Desktop: no behavior change; TypeScript now enforces what was already true.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck:desktop` (all four desktop projects) — clean. `npm run typecheck:test-kernel` — clean. This is the check that matters for a visibility change: an external caller would surface here, and none did.
- `npx eslint` and `npx prettier --check` on the changed file — clean.
- `npx vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.ts` — **75 passed, 2 failed.**

### About those 2 failures — pre-existing, not this change

`presents a merge failure that occurs before lifecycle startup` and `presents a terminal merge failure exactly once from its result` fail in my container on a stashed-clean `origin/main` too — I verified that twice earlier today, both times `2 failed | 75 passed`, the same two tests with identical `showErrorMessage … Number of calls: 0` assertions. **CI runs them green**, so the honest reading is a container-specific flake in those two `vi.waitFor` assertions, not a repository break. They live in the merge-failure presentation path, which a visibility modifier cannot reach.

One process note, since it affects how much weight to give the above: I pushed this commit before reading the test output, then went back and checked. The result is fine and the reasoning holds, but the ordering was wrong and I'd rather say so than let the validation section imply I gated the push on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1)_