### PR TITLE
docs: correct two comments that overstate what the code guarantees

### DIFF
--- a/docs/architecture/2026-06-20-pocketflow-state.md
+++ b/docs/architecture/2026-06-20-pocketflow-state.md
@@ -14,8 +14,8 @@ Each agent execution uses the following state slices:
 - **Run state (`AgentRunStateSnapshot`)** – Records run-level lifecycle data
   such as the total number of rounds executed, aggregate response time, and a
   `RunUsageAccumulator` that aggregates token usage across all rounds. Also a
-  plain Zod-validated object; `recordCycleMetrics`/`recordRound`
-  (`src/agent/core/state/AgentState.ts`) mutate it in place.
+  plain Zod-validated object; `recordCycleMetrics`
+  (`src/agent/core/state/AgentState.ts`) mutates it in place.
 - **Workspace state (`AgentWorkspaceState`)** – A class providing focused
   slices for response assembly, media attachments, reasoning caches, and
   document metrics. Flows mutate these slices independently when composing

--- a/src/agent/types/IModelHandler.ts
+++ b/src/agent/types/IModelHandler.ts
@@ -7,14 +7,17 @@ import type { ProviderMessage } from './ProviderMessage';
  * Common port implemented by all model handlers.
  *
  * Derived from {@link ModelHandler} via `Pick` alone — the port adds nothing
- * of its own, so it can never drift from the base class: adding, renaming, or
- * retyping a member there is automatically reflected here, and a base-class
- * signature change breaks exactly one place (the class) instead of two. Only
- * members consumers actually call through this port are picked. Omitted
- * members are reached
- * through the concrete class instead: this includes internal-only helpers
- * such as `supportsReasoningLevelOverride`, plus
- * `extractResponse`, which `helperModel` calls on its concrete handler.
+ * of its own, so a member's SIGNATURE can never drift from the base class:
+ * retyping one there is reflected here automatically, renaming one breaks this
+ * `Pick`, and a signature change breaks exactly one place (the class) instead
+ * of two.
+ *
+ * The member SET is curated, not automatic: adding a member to the base class
+ * does not surface it here, by design — only members consumers actually call
+ * through this port are picked. Omitted members are reached through the
+ * concrete class instead, including internal-only helpers such as
+ * `supportsReasoningLevelOverride` and `extractResponse`, which `helperModel`
+ * calls on its concrete handler.
  *
  * @template M - Message type specific to the provider (e.g., MessageParam for Anthropic,
  *               ChatCompletionMessageParam for OpenAI). Must extend ProviderMessage.

--- a/src/agent/types/IModelHandler.ts
+++ b/src/agent/types/IModelHandler.ts
@@ -8,9 +8,9 @@ import type { ProviderMessage } from './ProviderMessage';
  *
  * Derived from {@link ModelHandler} via `Pick` alone — the port adds nothing
  * of its own, so a member's SIGNATURE can never drift from the base class:
- * retyping one there is reflected here automatically, renaming one breaks this
- * `Pick`, and a signature change breaks exactly one place (the class) instead
- * of two.
+ * retyping one there is reflected here automatically and renaming one breaks
+ * this `Pick`, so a signature only ever needs editing in one place (the class)
+ * rather than two.
  *
  * The member SET is curated, not automatic: adding a member to the base class
  * does not surface it here, by design — only members consumers actually call


### PR DESCRIPTION
## Summary

**1. `IModelHandler`'s docblock contradicts itself.** It claimed the `Pick` "can never drift from the base class: **adding**, renaming, or retyping a member there is automatically reflected here" — and then, two sentences later, "Only members consumers actually call through this port are picked."

Both cannot be true. A `Pick<ModelHandler, …>` does propagate a **retype** and does break on a **rename**, but an **added** base-class member is not surfaced — the member list is written out by hand. The comment now separates the two guarantees: the *signature* is drift-proof, the *set* is curated by design.

This isn't pedantry: the next person adding a `ModelHandler` method will read "automatically reflected here", not add it to the `Pick`, and then wonder why consumers can't reach it. The comment should tell them the set is a deliberate allowlist. (Also fixes an awkward mid-sentence line break the old text carried.)

**2. `docs/architecture/2026-06-20-pocketflow-state.md` names a function that doesn't exist.** It described `recordCycleMetrics`/`recordRound` as the pair mutating run state. `grep -rn "recordRound" src packages` returns **nothing**, and `src/agent/core/state/AgentState.ts` exports exactly one function — `recordCycleMetrics`. Singularised.

## Issue acceptance gates

No issue — from the docs sweep. Both verified by reading the code, not taken from the source document: the `Pick` member list was read in full, and `recordRound`'s absence confirmed by repo-wide grep plus the export list of the file the doc cites.

## Single source of truth

Both changes make the prose match the code it describes rather than maintaining a second, wrong account beside it.

## Duplication and abstraction budget

n/a — comment and documentation text only. No construct added or removed.

## Net elements (R6)

2 files. Exported symbols: 0. Classes/interfaces/types: 0. Net LoC: **+5 / −4**, all comment. No runtime code.

## Consumer counts (R8)

n/a — no emit path or export changed. `IModelHandler`'s `Pick` member list is untouched; only the prose above it changes, so no consumer retypes.

## Host impact

Extension / Desktop / CLI: none — no runtime code in this diff.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck:workspace` — clean. Worth running despite this being comment-only, since the edit sits inside a type declaration file where a stray character would break the `Pick`.
- `npx eslint src/agent/types/IModelHandler.ts` — clean. `npx prettier --check` on both files — clean.
- `node scripts/check-guidance-refs.mjs` — OK across 58 files; the architecture doc's remaining backticked paths still resolve.

No tests — comment and doc text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XESXe1TEcnaq8NfzHWa4H1)_