### PR TITLE
docs: record consolidation/native-methods survey pass (2026-09-03)

### DIFF
--- a/docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md
+++ b/docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md
@@ -117,17 +117,30 @@ setTimeout(...))`), `JSON.parse(JSON.stringify(` deep clones, `.filter(...)`
   because an operation failed. No `catch`, no backoff, no error
   classification — the same "bounded re-drain reconciling concurrent state,
   not `p-retry`-shaped error-driven retry" species as
-  `MAX_DIRTY_WRITE_RETRIES`, adjudicated the same way. Not a candidate.
+  `MAX_DIRTY_WRITE_RETRIES`, adjudicated the same way. Not a candidate. A
+  third, pre-existing instance the sweep's `i`-only variable-name regex also
+  missed: `src/tools/delegation/inBandSubagentExecution.ts:624`'s `for (let
+attempt = 0; attempt < nextAttempt; attempt += 1)`, scanning a bounded
+  range `[0, nextAttempt)` of persisted durable-attempt sequence numbers
+  looking for a recoverable one — already classified by the 2026-08-30 round
+  as this same durable-reconciliation species. Not a candidate.
 - **Hand-rolled `debounce`/`throttle`:** the sweep's regex required the
-  literal function name `debounce`/`throttle` and missed
+  literal function name `debounce`/`throttle` and missed two hits.
   `createFlushableDebounce` (`src/utils/core/index.ts:256`, pre-existing, not
-  new this window). Its own doc comment states the reason a library
+  new this window): its own doc comment states the reason a library
   debouncer doesn't fit: call sites need a synchronous flush escape hatch
   (run the pending call now, typically pre-teardown) and re-entrant
   `schedule()` from inside the callback itself — the CLI's transcript sync
   re-schedules from within its own flush callback, which `es-toolkit`'s
-  invoke-then-cancel debounce silently drops. An accepted exception, not a
-  candidate, but should have been counted rather than reported as zero.
+  invoke-then-cancel debounce silently drops. `AnnotationFetchBudget`
+  (`src/tools/github/annotationFetchBudget.ts:38-72`, a hand-rolled
+  continuous-refill token bucket, pre-existing): its own doc comment gives
+  the reason `p-throttle` doesn't fit — callers need a synchronous,
+  non-blocking `tryClaim`/defer check with an injectable clock for
+  deterministic tests, where `p-throttle` only offers an async
+  queue-and-wait contract. Both accepted exceptions with a stated,
+  checkable rationale, not candidates, but should have been counted rather
+  than reported as zero.
 - **Defensive-copy-then-iterate of a mutated collection:** not one of this
   survey's stated tells, but a related native-construct nit surfaced by
   review: `packages/cli/src/chat/chatSessionController.ts:372` iterates

--- a/docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md
+++ b/docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md
@@ -10,15 +10,19 @@ delete five dead surfaces in the runtime and CLI approval layers`,
 > surfaced three real, pre-existing candidates from
 > `2026-08-25-cli-controller-seam-audit.md` that three prior survey passes
 > (2026-08-29, 2026-08-30, 2026-09-02) and this entry's own first draft all
-> failed to file — now filed as #11809, #11810, and #11811.** No code changes
-> accompany this entry.
+> failed to file, plus a fourth new hand-rolled-sleep hit this entry's own
+> sweep missed — filed as #11809, #11810, #11811, and #11812.** No code
+> changes accompany this entry.
 
 ## 0. Why this pass is targeted rather than a full re-sweep
 
 Six full simplification survey rounds (2026-08-25 through 2026-08-27) and
 three prior dedicated passes on this exact question (2026-08-29, 2026-08-30,
-2026-09-02) already swept the repo end-to-end and found nothing outstanding
-in either lens. Between 2026-09-02's grounding commit (`646475d`) and this
+2026-09-02) _reported_ nothing outstanding in either lens — a description
+this entry's own §3 revises: three real, applicable candidates from the
+2026-08-25 audit had gone unfiled through all of them, surfaced only by this
+entry's own PR review. Between 2026-09-02's grounding commit (`646475d`) and
+this
 one, 28 commits landed, 23 of them touching `src/` or `packages/*/src/` (the
 other five are docs-only, dependency bumps, or a workspace pnpm version
 alignment) — and, as with the prior window, a large share of that volume was
@@ -66,15 +70,21 @@ setTimeout(...))`), `JSON.parse(JSON.stringify(` deep clones, `.filter(...)`
 
 - **`.hasOwnProperty()` direct calls:** zero repo-wide.
 - **Hand-rolled sleeps:** the sweep's regex required `setTimeout` as the
-  direct executor body and missed the nested form; one production hit
-  exists, `src/platform/defaults/lifecycleHost.ts:70-72`:
+  direct executor body and missed two production hits with a nested or
+  wrapped form. `src/platform/defaults/lifecycleHost.ts:70-72`:
   `new Promise<void>((resolve) => onAbort(signal, () => setTimeout(resolve, 0)))`,
   raced against a shutdown-phase promise. Structurally not a plain sleep —
   the delay only starts once `signal` aborts, giving shutdown handlers one
   macrotask to settle after the abort fires, not a fixed wait from now — so
   it is not a direct `node:timers/promises` `setTimeout(ms)` swap without
   restructuring the abort-then-yield sequencing. Plausibly intentional, but
-  should have been enumerated rather than reported as test-only. All other
+  should have been enumerated rather than reported as test-only.
+  `packages/extension/src/frontend/latex/openBuild.ts:234-255`'s
+  `scheduleViewerDisplay`, by contrast, _is_ the plain case: an unconditional
+  `new Promise<boolean>((resolve) => setTimeout(async () => { ... resolve(...) }, ms))`
+  in the Node-based extension-host frontend, straightforwardly rewritable as
+  an `async` function awaiting `node:timers/promises`' `setTimeout`. A real
+  miss, not an accepted exception — filed as #11812. All other
   remaining hits are `src/test-kernel/**` timer-flush fixtures — same
   conclusion as every prior round for those.
 - **`JSON.parse(JSON.stringify(` deep clones:** the one production hit,
@@ -206,11 +216,16 @@ desktop/extension `workspace` adapter; the desktop/extension resume-result
 skeleton, reinforced by a new copy-pasted block in this very window's
 `810abdc`) had gone unfiled through this entry's first draft and all three
 prior dedicated passes, surviving purely because nobody had turned the
-audit's table rows into tracked issues. Two are low-risk mechanical fixes;
-the third carries a real behavior decision the audit itself flagged and
-this entry preserves rather than silently resolving. Filed now as #11809,
-#11810, and #11811 — the actual output of this round.
+audit's table rows into tracked issues. Review also caught a fourth,
+independent miss in this entry's own sweep: `scheduleViewerDisplay`
+(`openBuild.ts`) hand-rolls the exact `new Promise(resolve =>
+setTimeout(...))` sleep pattern this survey's tells target, in production
+code the regex's executor-body assumption didn't match. Three of the four
+are low-risk mechanical fixes; the resume-skeleton pair carries a real
+behavior decision the audit itself flagged and this entry preserves rather
+than silently resolving. Filed now as #11809, #11810, #11811, and #11812 —
+the actual output of this round.
 
 This entry exists to record that the routine ran and to save the next pass
 from re-treading the same ground; no code changes accompany this cycle, but
-three follow-up issues do.
+four follow-up issues do.

--- a/docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md
+++ b/docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md
@@ -1,0 +1,124 @@
+# Survey: code consolidation and native-method opportunities (2026-09-03)
+
+> **Status:** Written 2026-09-03 against branch HEAD `d418d45` (`refactor:
+delete five dead surfaces in the runtime and CLI approval layers`,
+> #11792). Scheduled routine re-ran the standing question — "find
+> duplicate/similar logic to consolidate, and hand-rolled code that a native
+> method or the standard library already covers" — one day after
+> `2026-09-02-consolidation-and-native-methods-survey.md`. **Verdict: nothing
+> new survives scrutiny.** No code changes accompany this entry.
+
+## 0. Why this pass is targeted rather than a full re-sweep
+
+Six full simplification survey rounds (2026-08-25 through 2026-08-27) and
+three prior dedicated passes on this exact question (2026-08-29, 2026-08-30,
+2026-09-02) already swept the repo end-to-end and found nothing outstanding
+in either lens. Between 2026-09-02's grounding commit (`646475d`) and this
+one, 28 commits landed touching `src/` or `packages/*/src/` — and, as with
+the prior window, a large share of that volume was itself
+already-completed consolidation work: `refactor: give two swallow-and-log
+policies a single owner` (#11784), `refactor: use date-fns for log timestamp
+formatting` (#11777), `Replace custom cache with LRUCache in
+SubscriptionUsageService` (#11778), `refactor: consolidate quota-limit types
+and drop a hand-rolled sleep` (#11779), `refactor(shared): consolidate
+wa-icon construction onto waIcon()` (#11781), `refactor(hosts): consolidate
+the message-host trio into one interface` (#11754), `refactor:
+subscription-usage reuse existing utilities over hand-rolled logic`
+(#11755), `refactor: share agent-proposal wiring across hosts, key
+warned-set by stream` (#11756), `refactor: share the staged-deletion
+rollback path and the sr-only recipe` (#11775), and two dead-code deletions
+(#11788, #11792). Given that volume of upstream simplification work already
+targeting this exact question, this pass re-ran the standard native-method
+tells against current HEAD and read the 28-commit diff's production files
+for newly introduced duplication, rather than re-deriving the prior full-repo
+rounds' conclusions from scratch.
+
+## 1. Method
+
+- Repo-wide `rg` sweeps of `src/` and `packages/*/src/` (production code
+  only, test-kernel excluded) for the classic tells: `.hasOwnProperty(`,
+  hand-rolled `setTimeout`-based sleeps (`new Promise(resolve =>
+setTimeout(...))`), `JSON.parse(JSON.stringify(` deep clones, `.filter(...)`
+  dedup via `.indexOf(...)`, `.indexOf(...) !== -1` in place of `.includes(`,
+  hand-rolled `Math.random().toString(36)` ID generation, hand-rolled
+  `isEqual`/`deepEqual` functions, hand-rolled attempt-counter `for` loops,
+  hand-rolled `debounce`/`throttle` definitions, and new `Object.assign(`
+  call sites.
+- Read of every production file touched by the 28 commits between `646475d`
+  and `d418d45` (`git diff --stat`, non-test files only — 87 of the 127
+  changed files) to check for newly introduced duplication the tells above
+  would miss (e.g. two host adapters re-solving the same dispatch shape).
+- Targeted read of the four per-provider subscription-quota detection
+  modules (`chatgptSubscriptionDetection.ts`, `glmCodingPlanDetection.ts`,
+  `kimiCodeSubscriptionDetection.ts`, `xaiSubscriptionDetection.ts`) — the
+  one area in the diff window that visually resembles repeated per-provider
+  boilerplate — against their shared `errorInspection.ts` /
+  `sdkRequestEndpoint.ts` helpers.
+
+## 2. What was checked and ruled out
+
+- **`.hasOwnProperty()` direct calls:** zero repo-wide.
+- **Hand-rolled sleeps:** zero in production `src/`/`packages/*/src/`
+  (all remaining hits are `src/test-kernel/**` timer-flush fixtures) — same
+  conclusion as every prior round.
+- **`JSON.parse(JSON.stringify(` deep clones:** the one production hit,
+  `src/agent/workflowScript/parseScript.ts:130`, remains the already-adjudicated
+  `vm.Script` sandbox literal, not a clone helper. No new hits.
+- **`.indexOf(...) !== -1` / dedup-via-filter-and-indexOf:** zero.
+- **Hand-rolled `Math.random().toString(36)` IDs:** zero in production (one
+  hit, in a `test-kernel` fixture).
+- **Hand-rolled `isEqual`/`deepEqual`:** zero.
+- **Hand-rolled attempt-counter `for` loops:** zero new hits; the recurring
+  `MAX_DIRTY_WRITE_RETRIES` durability-flush loop already traced to
+  `SidecarWriteCoordinator.retryDirtyWrites` in the 2026-09-02 round did not
+  change shape in this window.
+- **Hand-rolled `debounce`/`throttle`:** zero.
+- **New `Object.assign(` call sites in the diff:** none of the 87 touched
+  production files added one; the repo-wide set is unchanged from the prior
+  round's already-accepted "mutating an owned, function-local object" pattern.
+- **Per-provider subscription-quota detection files (4 files, one new
+  reference this round):** each file's distinguishing signal is genuinely
+  different — GLM matches a numeric `code` field plus a `Asia/Shanghai`
+  timestamp parse, Kimi Code matches a request-endpoint stamp plus a message
+  regex, xAI matches a credential-route stamp plus a different message
+  regex, ChatGPT/Codex matches a `type` discriminant field. All four already
+  route their common parts (`errorBodyCandidates`, `pickStringField`,
+  `pickNumberField`, `matchUsageLimitMessage`, `detectSdkRequestBaseURL`,
+  `detectSdkCredentialRoute`) through the shared `errorInspection.ts` /
+  `sdkRequestEndpoint.ts` modules. Forcing the remaining provider-specific
+  matching into one table-driven function would trade four short, readable,
+  independently-testable files for one function branching on
+  provider-specific field shapes — a net readability loss for no duplication
+  removed. Not a candidate.
+- **New `linkAbortSignals` helper (`src/utils/core/index.ts`):** a genuinely
+  new shared abstraction added in this window (used by `src/tools/timeouts.ts`
+  and elsewhere), replacing per-call-site `AbortSignal.any([...])` composites
+  that would otherwise pin a long-lived source signal's listener graph for the
+  source's whole lifetime. This is consolidation _arriving_, not a
+  duplication left behind — nothing further to flag.
+- **CLI approval dispatch (`packages/cli/src/runtime/approvalAdapter.ts`,
+  `approvalPrompts.ts`):** already collapsed in this window (part of #11775)
+  from a `CliDecisionApprovalRequest` discriminated-union dispatch into one
+  `decideGated` helper taking an already-computed settlement plus prompt
+  content — the exact shape a fresh survey would otherwise propose.
+- **Cross-host duplication (CLI / desktop / extension):** the "message-host
+  trio" consolidation (#11754) and "share agent-proposal wiring across
+  hosts" (#11756) already landed in this window; the remaining per-host
+  files read in this pass (`desktopAgentExecution.ts`,
+  `ProgressViewMessageHandler.ts`, `chatSessionController.ts`) each own
+  host-specific wiring (Electron IPC, VS Code webview messages, terminal
+  rendering) with no shared logic duplicated across them beyond what the
+  existing base classes already cover.
+
+## 3. Verdict
+
+No candidate in either lens clears the bar the six prior full-repo rounds and
+the three prior dedicated passes on this exact question set. As with
+2026-09-02, the volume of upstream `refactor:`/`consolidate:` commits landed
+in the 28-commit window between surveys (ten explicitly targeting this class
+of work, several landing the exact shape a fresh pass would otherwise
+propose) is itself evidence the surface this routine watches is being
+actively worked, not neglected.
+
+This entry exists to record that the routine ran and to save the next pass
+from re-treading the same ground; no code changes accompany this cycle.

--- a/docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md
+++ b/docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md
@@ -65,9 +65,18 @@ setTimeout(...))`), `JSON.parse(JSON.stringify(` deep clones, `.filter(...)`
 ## 2. What was checked and ruled out
 
 - **`.hasOwnProperty()` direct calls:** zero repo-wide.
-- **Hand-rolled sleeps:** zero in production `src/`/`packages/*/src/`
-  (all remaining hits are `src/test-kernel/**` timer-flush fixtures) — same
-  conclusion as every prior round.
+- **Hand-rolled sleeps:** the sweep's regex required `setTimeout` as the
+  direct executor body and missed the nested form; one production hit
+  exists, `src/platform/defaults/lifecycleHost.ts:70-72`:
+  `new Promise<void>((resolve) => onAbort(signal, () => setTimeout(resolve, 0)))`,
+  raced against a shutdown-phase promise. Structurally not a plain sleep —
+  the delay only starts once `signal` aborts, giving shutdown handlers one
+  macrotask to settle after the abort fires, not a fixed wait from now — so
+  it is not a direct `node:timers/promises` `setTimeout(ms)` swap without
+  restructuring the abort-then-yield sequencing. Plausibly intentional, but
+  should have been enumerated rather than reported as test-only. All other
+  remaining hits are `src/test-kernel/**` timer-flush fixtures — same
+  conclusion as every prior round for those.
 - **`JSON.parse(JSON.stringify(` deep clones:** the one production hit,
   `src/agent/workflowScript/parseScript.ts:130`, remains the already-adjudicated
   `vm.Script` sandbox literal, not a clone helper. No new hits.
@@ -78,8 +87,9 @@ setTimeout(...))`), `JSON.parse(JSON.stringify(` deep clones, `.filter(...)`
   every occurrence of a math-environment delimiter and needs the matched
   _position_ to advance past it, so `.includes()` does not apply — not a
   candidate, but should have been enumerated rather than reported as zero.
-- **Hand-rolled `Math.random().toString(36)` IDs:** zero in production (one
-  hit, in a `test-kernel` fixture).
+- **Hand-rolled `Math.random().toString(36)` IDs:** zero in production (two
+  hits, both in the same `test-kernel` fixture —
+  `src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts:106,114`).
 - **Hand-rolled `isEqual`/`deepEqual`:** zero.
 - **Hand-rolled attempt-counter `for` loops:** the recurring
   `MAX_DIRTY_WRITE_RETRIES` durability-flush loop already traced to
@@ -106,6 +116,18 @@ setTimeout(...))`), `JSON.parse(JSON.stringify(` deep clones, `.filter(...)`
   re-schedules from within its own flush callback, which `es-toolkit`'s
   invoke-then-cancel debounce silently drops. An accepted exception, not a
   candidate, but should have been counted rather than reported as zero.
+- **Defensive-copy-then-iterate of a mutated collection:** not one of this
+  survey's stated tells, but a related native-construct nit surfaced by
+  review: `packages/cli/src/chat/chatSessionController.ts:372` iterates
+  `[...liveOwnerships]`, a spread copy of a `Set`, so that each
+  `ownership.release()` call (which deletes only _that_ ownership from the
+  live `Set`, confirmed by reading the callback at line 414) can safely
+  mutate the collection mid-loop. Deleting the current element during a
+  `Set` iterator's traversal is well-defined, so the copy is unnecessary —
+  `for (const ownership of liveOwnerships)` would do. Real, correct, and
+  genuinely tiny (one allocation removed, no behavior change); not filed as
+  a separate issue per this survey's own bar for thin candidates, and out of
+  scope for a docs-only PR to fix inline.
 - **New `Object.assign(` call sites in the diff:** none of the 93 touched
   production files added one; the repo-wide set is unchanged from the prior
   round's already-accepted "mutating an owned, function-local object" pattern.

--- a/docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md
+++ b/docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md
@@ -14,8 +14,10 @@ Six full simplification survey rounds (2026-08-25 through 2026-08-27) and
 three prior dedicated passes on this exact question (2026-08-29, 2026-08-30,
 2026-09-02) already swept the repo end-to-end and found nothing outstanding
 in either lens. Between 2026-09-02's grounding commit (`646475d`) and this
-one, 28 commits landed touching `src/` or `packages/*/src/` — and, as with
-the prior window, a large share of that volume was itself
+one, 28 commits landed, 23 of them touching `src/` or `packages/*/src/` (the
+other five are docs-only, dependency bumps, or a workspace pnpm version
+alignment) — and, as with the prior window, a large share of that volume was
+itself
 already-completed consolidation work: `refactor: give two swallow-and-log
 policies a single owner` (#11784), `refactor: use date-fns for log timestamp
 formatting` (#11777), `Replace custom cache with LRUCache in
@@ -44,10 +46,10 @@ setTimeout(...))`), `JSON.parse(JSON.stringify(` deep clones, `.filter(...)`
   `isEqual`/`deepEqual` functions, hand-rolled attempt-counter `for` loops,
   hand-rolled `debounce`/`throttle` definitions, and new `Object.assign(`
   call sites.
-- Read of every production file touched by the 28 commits between `646475d`
-  and `d418d45` (`git diff --stat`, non-test files only — 87 of the 127
-  changed files) to check for newly introduced duplication the tells above
-  would miss (e.g. two host adapters re-solving the same dispatch shape).
+- Read of every production file touched between `646475d` and `d418d45`
+  (`git diff --stat`, non-test files only — 93 of the 127 changed files) to
+  check for newly introduced duplication the tells above would miss (e.g. two
+  host adapters re-solving the same dispatch shape).
 - Targeted read of the four per-provider subscription-quota detection
   modules (`chatgptSubscriptionDetection.ts`, `glmCodingPlanDetection.ts`,
   `kimiCodeSubscriptionDetection.ts`, `xaiSubscriptionDetection.ts`) — the
@@ -73,7 +75,7 @@ setTimeout(...))`), `JSON.parse(JSON.stringify(` deep clones, `.filter(...)`
   `SidecarWriteCoordinator.retryDirtyWrites` in the 2026-09-02 round did not
   change shape in this window.
 - **Hand-rolled `debounce`/`throttle`:** zero.
-- **New `Object.assign(` call sites in the diff:** none of the 87 touched
+- **New `Object.assign(` call sites in the diff:** none of the 93 touched
   production files added one; the repo-wide set is unchanged from the prior
   round's already-accepted "mutating an owned, function-local object" pattern.
 - **Per-provider subscription-quota detection files (4 files, one new
@@ -97,7 +99,8 @@ setTimeout(...))`), `JSON.parse(JSON.stringify(` deep clones, `.filter(...)`
   source's whole lifetime. This is consolidation _arriving_, not a
   duplication left behind — nothing further to flag.
 - **CLI approval dispatch (`packages/cli/src/runtime/approvalAdapter.ts`,
-  `approvalPrompts.ts`):** already collapsed in this window (part of #11775)
+  `packages/cli/src/runtime/approval/approvalPrompts.ts`):** already collapsed
+  in this window (part of #11775)
   from a `CliDecisionApprovalRequest` discriminated-union dispatch into one
   `decideGated` helper taking an already-computed settlement plus prompt
   content — the exact shape a fresh survey would otherwise propose.
@@ -115,10 +118,11 @@ setTimeout(...))`), `JSON.parse(JSON.stringify(` deep clones, `.filter(...)`
 No candidate in either lens clears the bar the six prior full-repo rounds and
 the three prior dedicated passes on this exact question set. As with
 2026-09-02, the volume of upstream `refactor:`/`consolidate:` commits landed
-in the 28-commit window between surveys (ten explicitly targeting this class
-of work, several landing the exact shape a fresh pass would otherwise
-propose) is itself evidence the surface this routine watches is being
-actively worked, not neglected.
+in the 28-commit window between surveys (eleven explicitly targeting this
+class of work — nine consolidation refactors plus two dead-code deletions,
+enumerated in §0 — several landing the exact shape a fresh pass would
+otherwise propose) is itself evidence the surface this routine watches is
+being actively worked, not neglected.
 
 This entry exists to record that the routine ran and to save the next pass
 from re-treading the same ground; no code changes accompany this cycle.

--- a/docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md
+++ b/docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md
@@ -70,10 +70,21 @@ setTimeout(...))`), `JSON.parse(JSON.stringify(` deep clones, `.filter(...)`
 - **Hand-rolled `Math.random().toString(36)` IDs:** zero in production (one
   hit, in a `test-kernel` fixture).
 - **Hand-rolled `isEqual`/`deepEqual`:** zero.
-- **Hand-rolled attempt-counter `for` loops:** zero new hits; the recurring
+- **Hand-rolled attempt-counter `for` loops:** the recurring
   `MAX_DIRTY_WRITE_RETRIES` durability-flush loop already traced to
   `SidecarWriteCoordinator.retryDirtyWrites` in the 2026-09-02 round did not
-  change shape in this window.
+  change shape in this window. One genuinely new instance: `e599027`
+  (#11762) adds a `MAX_EVICTION_DRAIN_ATTEMPTS` loop to
+  `StreamSnapshotStore.requestEviction` (`src/transcript/StreamSnapshotStore.ts:1203`).
+  Read in full: each iteration awaits the record's in-flight seed chain and
+  `retryDirtyWrites`, then re-checks the record's identity (generation,
+  seed-chain reference, ownership, a caller liveness check) before evicting;
+  it loops (bounded at 3 attempts) only when a write lands on an
+  already-seeded record during the drain, re-armed by a fresh mutation, not
+  because an operation failed. No `catch`, no backoff, no error
+  classification — the same "bounded re-drain reconciling concurrent state,
+  not `p-retry`-shaped error-driven retry" species as
+  `MAX_DIRTY_WRITE_RETRIES`, adjudicated the same way. Not a candidate.
 - **Hand-rolled `debounce`/`throttle`:** zero.
 - **New `Object.assign(` call sites in the diff:** none of the 93 touched
   production files added one; the repo-wide set is unchanged from the prior
@@ -100,8 +111,8 @@ setTimeout(...))`), `JSON.parse(JSON.stringify(` deep clones, `.filter(...)`
   duplication left behind — nothing further to flag.
 - **CLI approval dispatch (`packages/cli/src/runtime/approvalAdapter.ts`,
   `packages/cli/src/runtime/approval/approvalPrompts.ts`):** already collapsed
-  in this window (part of #11775)
-  from a `CliDecisionApprovalRequest` discriminated-union dispatch into one
+  in this window (part of #11792, not #11775) from a
+  `CliDecisionApprovalRequest` discriminated-union dispatch into one
   `decideGated` helper taking an already-computed settlement plus prompt
   content — the exact shape a fresh survey would otherwise propose.
 - **Cross-host duplication (CLI / desktop / extension):** the "message-host

--- a/docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md
+++ b/docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md
@@ -7,10 +7,10 @@ delete five dead surfaces in the runtime and CLI approval layers`,
 > method or the standard library already covers" — one day after
 > `2026-09-02-consolidation-and-native-methods-survey.md`. **Verdict: no
 > duplication newly introduced in this window, but PR review on this entry
-> surfaced two real, pre-existing candidates from
+> surfaced three real, pre-existing candidates from
 > `2026-08-25-cli-controller-seam-audit.md` that three prior survey passes
 > (2026-08-29, 2026-08-30, 2026-09-02) and this entry's own first draft all
-> failed to file — now filed as #11809 and #11810.** No code changes
+> failed to file — now filed as #11809, #11810, and #11811.** No code changes
 > accompany this entry.
 
 ## 0. Why this pass is targeted rather than a full re-sweep
@@ -111,8 +111,10 @@ setTimeout(...))`), `JSON.parse(JSON.stringify(` deep clones, `.filter(...)`
   round's already-accepted "mutating an owned, function-local object" pattern.
 - **Per-provider subscription-quota detection files (4 files, one new
   reference this round):** each file's distinguishing signal is genuinely
-  different — GLM matches a numeric `code` field plus a `Asia/Shanghai`
-  timestamp parse, Kimi Code matches a request-endpoint stamp plus a message
+  different — GLM matches a numeric-looking string `code` field (via
+  `pickStringField`, tested against a `ReadonlySet<string>`, e.g. `'1310'`)
+  plus a `Asia/Shanghai` timestamp parse, Kimi Code matches a request-endpoint
+  stamp plus a message
   regex, xAI matches a credential-route stamp plus a different message
   regex, ChatGPT/Codex matches a `type` discriminant field. All four already
   route their common parts (`errorBodyCandidates`, `pickStringField`,
@@ -151,7 +153,17 @@ locatePath, exists }` adapter wrapping the same two `WorkspaceFS` static
   inline snapshot-port re-projections... plus a byte-identical `workspace`
   pair"). Filed as #11810. `chatSessionController.ts` (CLI) owns unrelated
   terminal-rendering wiring with no shared logic duplicated against either
-  host file.
+  host file. A second pair also survived this window's host consolidations:
+  `desktopAgentResume.ts:50-116` and `resumeFromResumeData.ts:19-70` run an
+  identical six-step resume-result skeleton (already named, unfiled, as the
+  2026-08-25 audit's C11 row), and `810abdc` (#11789, in-window) reinforced
+  it by adding the same new `requestShowInstruction` settlement block to
+  both files independently rather than to one shared implementation. Unlike
+  the workspace-adapter pair, C11 carries an explicit caveat blocking a
+  silent fold — desktop's skeleton has a `hasAuthoritativeStream` precheck
+  the extension's lacks, so unifying is a behavior decision, not a
+  mechanical dedup ("Flag explicitly; do not fold silently," per the audit).
+  Filed as #11811 with that decision named as the prerequisite.
 
 ## 3. Verdict
 
@@ -165,15 +177,18 @@ the exact shape a fresh pass would otherwise propose) is itself evidence the
 surface this routine watches is being actively worked, not neglected.
 
 That said, this entry's own PR review is itself the counter-example to
-treating "nothing new" as "nothing outstanding": two real, low-risk,
-already-scoped candidates from `2026-08-25-cli-controller-seam-audit.md`
-(`fetchWithTimeout`'s reimplemented, leaking `AbortSignal.timeout`; the
-byte-identical desktop/extension `workspace` adapter) had gone unfiled
-through this entry's first draft and all three prior dedicated passes,
-surviving purely because nobody had turned the audit's table rows into
-tracked issues. Filed now as #11809 and #11810 — the actual output of this
-round.
+treating "nothing new" as "nothing outstanding": three real candidates from
+`2026-08-25-cli-controller-seam-audit.md` (`fetchWithTimeout`'s
+reimplemented, leaking `AbortSignal.timeout`; the byte-identical
+desktop/extension `workspace` adapter; the desktop/extension resume-result
+skeleton, reinforced by a new copy-pasted block in this very window's
+`810abdc`) had gone unfiled through this entry's first draft and all three
+prior dedicated passes, surviving purely because nobody had turned the
+audit's table rows into tracked issues. Two are low-risk mechanical fixes;
+the third carries a real behavior decision the audit itself flagged and
+this entry preserves rather than silently resolving. Filed now as #11809,
+#11810, and #11811 — the actual output of this round.
 
 This entry exists to record that the routine ran and to save the next pass
 from re-treading the same ground; no code changes accompany this cycle, but
-two follow-up issues do.
+three follow-up issues do.

--- a/docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md
+++ b/docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md
@@ -11,7 +11,9 @@ delete five dead surfaces in the runtime and CLI approval layers`,
 > `2026-08-25-cli-controller-seam-audit.md` that three prior survey passes
 > (2026-08-29, 2026-08-30, 2026-09-02) and this entry's own first draft all
 > failed to file, plus a fourth new hand-rolled-sleep hit this entry's own
-> sweep missed — filed as #11809, #11810, #11811, and #11812.** No code
+> sweep missed — filed as #11809, #11810, #11811, and #11812. #11809's
+> initial "leaked composite" framing was itself disproven by a later review
+> pass plus an empirical GC test and has been corrected (§2).** No code
 > changes accompany this entry.
 
 ## 0. Why this pass is targeted rather than a full re-sweep
@@ -160,14 +162,25 @@ setTimeout(...))`), `JSON.parse(JSON.stringify(` deep clones, `.filter(...)`
 - **New `linkAbortSignals` helper (`src/utils/core/index.ts`):** a genuinely
   new shared abstraction added in this window (used by `src/tools/timeouts.ts`
   and elsewhere), replacing per-call-site `AbortSignal.any([...])` composites
-  that would otherwise pin a long-lived source signal's listener graph for the
-  source's whole lifetime. It has not reached every pre-existing call site,
-  though: `src/auth/fetchWithTimeout.ts:10-23` still builds an undetached
-  `AbortSignal.any([options.signal, controller.signal])` on every call and
-  only aborts it on the timeout path, never on success — the same leak shape,
-  pre-existing (not new this window) and already named, unfiled, in
-  `docs/proposals/2026-08-25-cli-controller-seam-audit.md`
-  ("`fetchWithTimeout` reimplements `AbortSignal.timeout`"). Filed as #11809.
+  in cases where an application-level listener stays attached to the
+  composite indefinitely — that pattern does pin the composite (and its
+  source-side listener) for as long as the source lives, verified below.
+  `src/auth/fetchWithTimeout.ts:10-23` builds an undetached
+  `AbortSignal.any([options.signal, controller.signal])` on every call, which
+  looked like the same shape at first read. **It is not**, verified
+  empirically (Node v22, `--expose-gc` + `FinalizationRegistry`): a composite
+  built the same way and passed straight into a real `fetch()` call _is_
+  collected once the request settles, even with the long-lived source signal
+  still alive and never aborted, because `fetch`/undici removes its own
+  internal abort listener from the given signal once the request completes —
+  and once that listener is gone, nothing else keeps the composite reachable.
+  `fetchWithTimeout`'s composite is handed to `fetch` and touched by nothing
+  else, so it does not leak. (A first pass of this doc asserted the leak
+  and filed #11809 on that basis; a second Codex review pass challenged it,
+  the empirical test above confirmed the challenge, and #11809 has been
+  corrected to drop the leak claim while keeping the still-valid,
+  independent finding: `fetchWithTimeout` hand-rolls a timeout
+  `AbortSignal.timeout()` already covers, for one consumer.)
 - **CLI approval dispatch (`packages/cli/src/runtime/approvalAdapter.ts`,
   `packages/cli/src/runtime/approval/approvalPrompts.ts`):** already collapsed
   in this window (part of #11792, not #11775) from a
@@ -210,21 +223,26 @@ surface this routine watches is being actively worked, not neglected.
 
 That said, this entry's own PR review is itself the counter-example to
 treating "nothing new" as "nothing outstanding": three real candidates from
-`2026-08-25-cli-controller-seam-audit.md` (`fetchWithTimeout`'s
-reimplemented, leaking `AbortSignal.timeout`; the byte-identical
-desktop/extension `workspace` adapter; the desktop/extension resume-result
-skeleton, reinforced by a new copy-pasted block in this very window's
-`810abdc`) had gone unfiled through this entry's first draft and all three
-prior dedicated passes, surviving purely because nobody had turned the
-audit's table rows into tracked issues. Review also caught a fourth,
-independent miss in this entry's own sweep: `scheduleViewerDisplay`
-(`openBuild.ts`) hand-rolls the exact `new Promise(resolve =>
-setTimeout(...))` sleep pattern this survey's tells target, in production
-code the regex's executor-body assumption didn't match. Three of the four
-are low-risk mechanical fixes; the resume-skeleton pair carries a real
-behavior decision the audit itself flagged and this entry preserves rather
-than silently resolving. Filed now as #11809, #11810, #11811, and #11812 —
-the actual output of this round.
+`2026-08-25-cli-controller-seam-audit.md` (`fetchWithTimeout`'s reimplemented
+`AbortSignal.timeout`; the byte-identical desktop/extension `workspace`
+adapter; the desktop/extension resume-result skeleton, reinforced by a new
+copy-pasted block in this very window's `810abdc`) had gone unfiled through
+this entry's first draft and all three prior dedicated passes, surviving
+purely because nobody had turned the audit's table rows into tracked issues.
+Review also caught a fourth, independent miss in this entry's own sweep:
+`scheduleViewerDisplay` (`openBuild.ts`) hand-rolls the exact `new
+Promise(resolve => setTimeout(...))` sleep pattern this survey's tells
+target, in production code the regex's executor-body assumption didn't
+match. Review process caught itself, too: this entry's _own_ first
+adjudication of the `fetchWithTimeout` finding claimed its composite signal
+leaked the same way `linkAbortSignals` was built to prevent; a second Codex
+pass challenged that, and an empirical GC test (§2) proved the challenge
+right — `fetch`'s own listener cleanup means it doesn't leak. #11809 is
+corrected accordingly. All four filed issues are low-risk; the
+resume-skeleton pair (#11811) carries a real behavior decision the audit
+itself flagged and this entry preserves rather than silently resolving.
+Filed now as #11809, #11810, #11811, and #11812 — the actual output of this
+round.
 
 This entry exists to record that the routine ran and to save the next pass
 from re-treading the same ground; no code changes accompany this cycle, but

--- a/docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md
+++ b/docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md
@@ -5,8 +5,13 @@ delete five dead surfaces in the runtime and CLI approval layers`,
 > #11792). Scheduled routine re-ran the standing question — "find
 > duplicate/similar logic to consolidate, and hand-rolled code that a native
 > method or the standard library already covers" — one day after
-> `2026-09-02-consolidation-and-native-methods-survey.md`. **Verdict: nothing
-> new survives scrutiny.** No code changes accompany this entry.
+> `2026-09-02-consolidation-and-native-methods-survey.md`. **Verdict: no
+> duplication newly introduced in this window, but PR review on this entry
+> surfaced two real, pre-existing candidates from
+> `2026-08-25-cli-controller-seam-audit.md` that three prior survey passes
+> (2026-08-29, 2026-08-30, 2026-09-02) and this entry's own first draft all
+> failed to file — now filed as #11809 and #11810.** No code changes
+> accompany this entry.
 
 ## 0. Why this pass is targeted rather than a full re-sweep
 
@@ -66,7 +71,13 @@ setTimeout(...))`), `JSON.parse(JSON.stringify(` deep clones, `.filter(...)`
 - **`JSON.parse(JSON.stringify(` deep clones:** the one production hit,
   `src/agent/workflowScript/parseScript.ts:130`, remains the already-adjudicated
   `vm.Script` sandbox literal, not a clone helper. No new hits.
-- **`.indexOf(...) !== -1` / dedup-via-filter-and-indexOf:** zero.
+- **`.indexOf(...) !== -1` / dedup-via-filter-and-indexOf:** the sweep's
+  regex missed the assignment-in-condition form; one real hit exists,
+  `src/replacement/advanced.ts:329`:
+  `while ((startIdx = text.indexOf(env.start, startIdx)) !== -1)`. This walks
+  every occurrence of a math-environment delimiter and needs the matched
+  _position_ to advance past it, so `.includes()` does not apply — not a
+  candidate, but should have been enumerated rather than reported as zero.
 - **Hand-rolled `Math.random().toString(36)` IDs:** zero in production (one
   hit, in a `test-kernel` fixture).
 - **Hand-rolled `isEqual`/`deepEqual`:** zero.
@@ -85,7 +96,16 @@ setTimeout(...))`), `JSON.parse(JSON.stringify(` deep clones, `.filter(...)`
   classification — the same "bounded re-drain reconciling concurrent state,
   not `p-retry`-shaped error-driven retry" species as
   `MAX_DIRTY_WRITE_RETRIES`, adjudicated the same way. Not a candidate.
-- **Hand-rolled `debounce`/`throttle`:** zero.
+- **Hand-rolled `debounce`/`throttle`:** the sweep's regex required the
+  literal function name `debounce`/`throttle` and missed
+  `createFlushableDebounce` (`src/utils/core/index.ts:256`, pre-existing, not
+  new this window). Its own doc comment states the reason a library
+  debouncer doesn't fit: call sites need a synchronous flush escape hatch
+  (run the pending call now, typically pre-teardown) and re-entrant
+  `schedule()` from inside the callback itself — the CLI's transcript sync
+  re-schedules from within its own flush callback, which `es-toolkit`'s
+  invoke-then-cancel debounce silently drops. An accepted exception, not a
+  candidate, but should have been counted rather than reported as zero.
 - **New `Object.assign(` call sites in the diff:** none of the 93 touched
   production files added one; the repo-wide set is unchanged from the prior
   round's already-accepted "mutating an owned, function-local object" pattern.
@@ -107,8 +127,13 @@ setTimeout(...))`), `JSON.parse(JSON.stringify(` deep clones, `.filter(...)`
   new shared abstraction added in this window (used by `src/tools/timeouts.ts`
   and elsewhere), replacing per-call-site `AbortSignal.any([...])` composites
   that would otherwise pin a long-lived source signal's listener graph for the
-  source's whole lifetime. This is consolidation _arriving_, not a
-  duplication left behind — nothing further to flag.
+  source's whole lifetime. It has not reached every pre-existing call site,
+  though: `src/auth/fetchWithTimeout.ts:10-23` still builds an undetached
+  `AbortSignal.any([options.signal, controller.signal])` on every call and
+  only aborts it on the timeout path, never on success — the same leak shape,
+  pre-existing (not new this window) and already named, unfiled, in
+  `docs/proposals/2026-08-25-cli-controller-seam-audit.md`
+  ("`fetchWithTimeout` reimplements `AbortSignal.timeout`"). Filed as #11809.
 - **CLI approval dispatch (`packages/cli/src/runtime/approvalAdapter.ts`,
   `packages/cli/src/runtime/approval/approvalPrompts.ts`):** already collapsed
   in this window (part of #11792, not #11775) from a
@@ -117,23 +142,38 @@ setTimeout(...))`), `JSON.parse(JSON.stringify(` deep clones, `.filter(...)`
   content — the exact shape a fresh survey would otherwise propose.
 - **Cross-host duplication (CLI / desktop / extension):** the "message-host
   trio" consolidation (#11754) and "share agent-proposal wiring across
-  hosts" (#11756) already landed in this window; the remaining per-host
-  files read in this pass (`desktopAgentExecution.ts`,
-  `ProgressViewMessageHandler.ts`, `chatSessionController.ts`) each own
-  host-specific wiring (Electron IPC, VS Code webview messages, terminal
-  rendering) with no shared logic duplicated across them beyond what the
-  existing base classes already cover.
+  hosts" (#11756) already landed in this window, but neither happened to
+  touch one pre-existing pair: `desktopAgentExecution.ts:521-524` and
+  `ProgressViewMessageHandler.ts:661-664` each build
+  `ProgressFollowUpController` with a byte-identical `workspace: {
+locatePath, exists }` adapter wrapping the same two `WorkspaceFS` static
+  methods. Also already named, unfiled, in the 2026-08-25 seam audit ("Ten
+  inline snapshot-port re-projections... plus a byte-identical `workspace`
+  pair"). Filed as #11810. `chatSessionController.ts` (CLI) owns unrelated
+  terminal-rendering wiring with no shared logic duplicated against either
+  host file.
 
 ## 3. Verdict
 
-No candidate in either lens clears the bar the six prior full-repo rounds and
-the three prior dedicated passes on this exact question set. As with
-2026-09-02, the volume of upstream `refactor:`/`consolidate:` commits landed
-in the 28-commit window between surveys (eleven explicitly targeting this
-class of work — nine consolidation refactors plus two dead-code deletions,
-enumerated in §0 — several landing the exact shape a fresh pass would
-otherwise propose) is itself evidence the surface this routine watches is
-being actively worked, not neglected.
+No _newly introduced_ duplication in the `646475d..d418d45` window clears the
+bar the six prior full-repo rounds and the three prior dedicated passes on
+this exact question set. As with 2026-09-02, the volume of upstream
+`refactor:`/`consolidate:` commits landed in the 28-commit window between
+surveys (eleven explicitly targeting this class of work — nine consolidation
+refactors plus two dead-code deletions, enumerated in §0 — several landing
+the exact shape a fresh pass would otherwise propose) is itself evidence the
+surface this routine watches is being actively worked, not neglected.
+
+That said, this entry's own PR review is itself the counter-example to
+treating "nothing new" as "nothing outstanding": two real, low-risk,
+already-scoped candidates from `2026-08-25-cli-controller-seam-audit.md`
+(`fetchWithTimeout`'s reimplemented, leaking `AbortSignal.timeout`; the
+byte-identical desktop/extension `workspace` adapter) had gone unfiled
+through this entry's first draft and all three prior dedicated passes,
+surviving purely because nobody had turned the audit's table rows into
+tracked issues. Filed now as #11809 and #11810 — the actual output of this
+round.
 
 This entry exists to record that the routine ran and to save the next pass
-from re-treading the same ground; no code changes accompany this cycle.
+from re-treading the same ground; no code changes accompany this cycle, but
+two follow-up issues do.


### PR DESCRIPTION
## Summary

Scheduled routine re-ran the standing question — "find duplicate/similar
logic to consolidate, and hand-rolled code that a native method or the
standard library already covers" — against the 28 commits landed since the
prior pass (`2026-09-02-consolidation-and-native-methods-survey.md`,
baseline `646475d`, current HEAD `d418d45`).

**Verdict: no duplication newly introduced in this window**, but nine
rounds of PR review (Codex plus one Claude Approvals pass) turned this into
a much more thorough audit than the first draft: four real, previously-unfiled
candidates got filed as tracked issues, one filed issue's initial premise
was itself disproven and corrected via an empirical GC test, and roughly a
dozen more regex-completeness gaps got enumerated and adjudicated (mostly
accepted exceptions with their own stated, checkable rationale — a
durability-reconciliation loop, a hand-rolled token-bucket throttle, a
re-entrant flushable debounce — that this survey's grep-based tells simply
didn't match syntactically).

Filed issues:

- #11809 — `fetchWithTimeout` hand-rolls a timeout `AbortSignal.timeout()`
  already covers (single consumer). Originally also claimed a leaking
  `AbortSignal.any` composite; a later Codex pass challenged that, and an
  empirical GC test (Node v22, `--expose-gc` + `FinalizationRegistry`,
  including a real `fetch()` call against a local http server) proved the
  challenge right — the composite is collected once `fetch` removes its own
  abort listener on completion. Leak claim retracted from both the issue and
  the doc.
- #11810 — desktop and extension progress-view controllers build a
  byte-identical `workspace` adapter.
- #11811 — desktop and extension resume paths run an identical six-step
  result-handling skeleton, reinforced by a new copy-pasted block in this
  very window; carries a real behavior decision the seam audit explicitly
  flagged as "do not fold silently," so filed rather than mechanically fixed.
- #11812 — `scheduleViewerDisplay` hand-rolls the exact `new
  Promise(resolve => setTimeout(...))` sleep pattern this survey's tells
  target, in Node-based extension-host production code.

Full method, every per-tell finding, and the complete adjudication trail
(including the self-correction) are in the proposal doc — all 19 reviewer
threads got a verified reply and either a doc correction or a filed issue.

No code changes accompany this cycle — the doc is the entry, plus four
follow-up issues.

## Issue acceptance gates

N/A — recurring scheduled survey, not tied to a specific issue.

## Single source of truth

N/A — no logic or ownership changed; this PR only adds a dated proposal doc.

## Duplication and abstraction budget

N/A — no code touched. The doc records why each candidate considered this
round (notably the four per-provider quota-detection files) was rejected as
already appropriately factored through shared `errorInspection.ts` /
`sdkRequestEndpoint.ts` helpers, rather than force-merged into one
table-driven function, and records the four real candidates filed as issues
instead of fixed here.

## Net elements (R6)

N/A — not a refactor/simplify/consolidate/dedupe PR. 1 file changed
(docs/proposals/2026-09-03-consolidation-and-native-methods-survey.md)
across 9 commits (initial entry plus eight rounds of review-driven
corrections), no exported symbols or code constructs touched.

## Consumer counts (R8)

N/A — no emit path, export, or public symbol changed or deleted.

## Host impact

Extension: none (docs-only)

Desktop: none (docs-only)

CLI: none (docs-only)

## Scheduled refactoring

#11809, #11810, #11811, #11812 — filed this round, not fixed here (see
Summary).

## Validation

- `npm run check:guidance-refs` — OK (58 files checked), re-run after every
  revision
- `npx prettier --write` on the doc after every revision
- `git diff --check` — no whitespace errors
- Empirical GC test (Node v22, `--expose-gc` + `FinalizationRegistry`, real
  `fetch()` against a local http server) to verify/retract the #11809 leak
  claim before it went into a filed issue
- CI green on the final commit (`e561bc9`): `validate` gate, docs build,
  guidance references all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiLfXf8HfNDBcL6uHJ3JtH