### PR TITLE
refactor(session): give the startup stream sweep one owner per host

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -285,7 +285,6 @@ export class DesktopProgressBridge {
     this.session = options.session;
     this.backend = new ProgressBackend({
       session: this.session,
-      stateOwnership: 'session',
       storage: platform().workspaceState,
       stores: options.sessionStores,
       sendMessage: (message) => this.postToRenderer(message) !== false,

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -29,6 +29,7 @@ import { tryResumeFromResumeData } from '@commands/agent/resumeFromResumeData';
 import { isFileNotFoundError } from '@common/errors';
 import { SIDEBAR_VIEWS, setActiveSidebarView } from '@common/webview';
 import { installTexraAccountProbes } from '@controllers/modelAccess/installTexraAccountProbes';
+import { createSessionStores } from '@controllers/session/createSessionStores';
 import { appSignals } from '@eventBus/AppSignals';
 import { SecretManager } from '@frontend/secretManager';
 import {
@@ -503,6 +504,11 @@ async function activateExtension(context: vscode.ExtensionContext) {
     ],
   });
   await runtimeSession.waitUntilReady();
+  // The extension's presentation is its own process owner, so it runs the
+  // shared startup sweep here at activation, mirroring the CLI
+  // (`initializeCliTranscriptSession`) and desktop (`initializeDesktopProcessStores`)
+  // hosts rather than deferring it to a later, lazily-constructed presentation.
+  await createSessionStores(runtimeSession).sweepLeftoverStreams();
   runtimeSession.setApprovalPolicy(
     readPlatformSetting<TexraApprovalPolicy>(TEXRA_APPROVAL_POLICY_CONFIG_KEY),
   );

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -69,12 +69,6 @@ export interface ProgressBackendOptions {
   /** Session that owns this backend's coordination state. */
   session: SessionHandle;
   /**
-   * `session` when the caller has already loaded and swept the session's
-   * stores at process start. A process-owned session has opened the canonical
-   * live store, so a replacement presentation must not reload or sweep it.
-   */
-  stateOwnership?: 'backend' | 'session';
-  /**
    * Commands this host's progressView inbound registry declares
    * `unsupported(...)` — pass `() => unsupportedCommands(registry)`. Threaded
    * to {@link LitSessionRenderer} so the frontend's capability gating stays a
@@ -105,7 +99,6 @@ export class ProgressBackend {
   private readonly lifecycle: ProgressBackendLifecycleOptions;
   private readonly reportTranscriptLoadError: ProgressBackendOptions['reportTranscriptLoadError'];
   private readonly postMessage: (message: ProgressViewOutboundMessage) => void;
-  private readonly stateOwnership: 'backend' | 'session';
   private readonly hasPendingPermissions: (streamId: string) => boolean;
   private readonly storageOperationQueue = new PQueue({ concurrency: 1 });
   private readonly detachEventListeners: Array<() => void> = [];
@@ -117,7 +110,6 @@ export class ProgressBackend {
 
   constructor(options: ProgressBackendOptions) {
     this.session = options.session;
-    this.stateOwnership = options.stateOwnership ?? 'backend';
     this.lifecycle = options.lifecycle;
     this.reportTranscriptLoadError = options.reportTranscriptLoadError;
     this.postMessage = (message) => {
@@ -823,7 +815,7 @@ export class ProgressBackend {
   load(): Promise<void> {
     return this.enqueueStorageOperation(async () => {
       await this.session.waitUntilReady();
-      await this.state.load(this.stateOwnership);
+      await this.state.load();
     });
   }
 

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -690,25 +690,21 @@ export class SessionState {
     return deletion;
   }
 
-  async load(stateOwnership: 'backend' | 'session' = 'backend'): Promise<void> {
+  async load(): Promise<void> {
     this.logger.info('[Persistence] Starting state load from storage');
 
     // ProgressBackend waits for SessionHandle readiness before entering this
     // method. The session owns transcript opening and sidecar hydration; a
-    // presentation must never reload those live stores.
+    // presentation must never reload those live stores. The startup sweep
+    // (dropping leftover background shells, then orphaned persisted state) is
+    // every host's own responsibility at process bring-up, before any
+    // presentation attaches — see `sweepLeftoverStreams`'s callers.
     await this.stores.waitForPendingStreamDeletions();
 
     this.logger.info(
       `[Persistence] Discovered ${this.streamLogs.keys().length} stream(s)`,
     );
 
-    // The extension's presentation *is* its process owner, so it runs the
-    // shared startup sweep here; the desktop and CLI run it from theirs, where
-    // this state is not the owner of these stores. Sweeping before the loop
-    // below means no metadata is built for a stream this load then deletes.
-    if (stateOwnership === 'backend') {
-      await this.stores.sweepLeftoverStreams();
-    }
     // No all-streams metadata loop: stream metadata is assembled lazily in
     // `getStreamMetadata` from the always-resident summary mirror, so a load
     // has nothing to seed per stream (#9947).

--- a/src/test-kernel/progressView/ProgressBackendCleanup.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendCleanup.vitest.ts
@@ -548,7 +548,7 @@ describe('ProgressBackend cleanup', () => {
       await expectStored(`executions/${orphan.executionId}`, true);
       await expectStored(`executions/${historyExecution}`, true);
 
-      await backend.state.load();
+      await backend.state.stores.sweepLeftoverStreams();
 
       await expectStored(streamDataDir(orphan.stream), false);
       await expectStored(`executions/${orphan.executionId}`, false);
@@ -574,7 +574,7 @@ describe('ProgressBackend cleanup', () => {
       await expectStored(streamDataDir(stream), false);
       expect(await seed.listStagedDeletions()).toContain(stream);
 
-      await backend.state.load();
+      await backend.state.stores.sweepLeftoverStreams();
 
       expect(await backend.state.snapshots.listStagedDeletions()).not.toContain(
         stream,
@@ -691,7 +691,9 @@ describe('ProgressBackend cleanup', () => {
       const failureSpy = install(backend, failing);
 
       try {
-        await expect(backend.state.load()).resolves.toBeUndefined();
+        await expect(
+          backend.state.stores.sweepLeftoverStreams(),
+        ).resolves.toBeUndefined();
 
         expect(warnSpy).toHaveBeenCalledWith(
           'SessionStores',
@@ -738,6 +740,7 @@ describe('ProgressBackend cleanup', () => {
     try {
       await second.session.waitUntilReady();
       await second.backend.state.load();
+      await second.backend.state.stores.sweepLeftoverStreams();
 
       expect(second.backend.state.streamLogs.has(stream)).toBe(true);
       await second.backend.state.snapshots.preload([stream]);
@@ -751,7 +754,7 @@ describe('ProgressBackend cleanup', () => {
     }
   });
 
-  it('sweeps leftover background shells at load, keeping real sessions', async () => {
+  it('sweeps leftover background shells at startup, keeping real sessions', async () => {
     // The sweep reads the persisted identity meta (kind 'process'), the
     // authority since the legacy name-prefix reader was retired.
     const shell = {
@@ -801,6 +804,7 @@ describe('ProgressBackend cleanup', () => {
     try {
       await second.session.waitUntilReady();
       await second.backend.state.load();
+      await second.backend.state.stores.sweepLeftoverStreams();
 
       expect(second.backend.state.streamLogs.has(shell.stream)).toBe(false);
       await expectStored(streamDataDir(shell.stream), false);

--- a/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
@@ -718,9 +718,8 @@ describe('ProgressBackend', () => {
     );
     // The presentation no-ops, but the sidecar store is session-owned, so it
     // keeps recording: disposing one window/webview must not stop the runtime
-    // persisting an in-flight run's outputs. The desktop already behaved this
-    // way (its `stateOwnership: 'session'` backend never detached the store);
-    // the extension now matches it.
+    // persisting an in-flight run's outputs. Desktop and the extension behave
+    // identically here — neither backend detaches the store on dispose.
     expect(backend.state.snapshots.getOutputFiles(streamId)).toEqual({
       1: [outputFile],
     });


### PR DESCRIPTION
## Summary

Scheduled codebase audit for confusing/overlapped responsibilities. `SessionState.load()` took a `stateOwnership: 'backend' | 'session'` flag whose only job was to tell host-agnostic code which host was calling it — a classic "unclear ownership boundary between components" smell, and one flagged repeatedly across `docs/dev/audits/2026-07-27/29/30-agent-sdk-readiness-checkpoint.md` and `docs/proposals/2026-09-02-runtime-host-session-lifecycle-ownership-survey.md` (finding T2) without ever being resolved.

**The overlap:** the leftover-stream startup sweep (`SessionStores.sweepLeftoverStreams()` — drops orphaned background shells, then orphaned persisted state) has one natural owner: whichever host is standing up the process. The CLI (`packages/cli/src/runtime/transcriptSession.ts`) and desktop (`packages/desktop/src/main/desktopProcessStores.ts`) already call it themselves at session bring-up. The extension alone deferred it into `SessionState.load()`, gated by `stateOwnership === 'backend'` — so every other caller of `ProgressBackend`, including desktop's own backend, had to pass `stateOwnership: 'session'` just to suppress a sweep that was never theirs to trigger. Shared, host-agnostic code (`src/controllers/session/SessionState.ts`) was branching on which host it was running under, which is exactly the coupling `CLAUDE.md`'s platform-decoupling rule exists to prevent.

**The fix:** move the sweep to the extension's own activation (`packages/extension/src/extension.ts`), right after `runtimeSession.waitUntilReady()`, mirroring the CLI and desktop exactly. `SessionState.load()` no longer takes an ownership parameter and never sweeps — it's purely "wait for pending deletions, then load." `ProgressBackendOptions.stateOwnership` is deleted, along with the private field, its default, and desktop's now-pointless passer.

## Issue acceptance gates

Not filed as an issue beforehand (found and fixed in one pass per this session's audit task); the acceptance target is `docs/proposals/2026-07-26-agent-sdk-foundation-gap.md`'s own row 1, "One owner of durable persistence … `stateOwnership` symbol absent" — that target is now met (`git grep stateOwnership` returns only historical, dated audit/proposal docs, none of which are amended per the repo's correction convention).

## Single source of truth

Each host now owns exactly one call to the startup sweep, made once at its own bring-up point, with no flag threaded through shared code to suppress a sweep another host already ran.

## Duplication and abstraction budget

Removed a two-value vocabulary (`'backend' | 'session'`) that existed solely so `SessionState.load()` could special-case one host. No abstraction added — this collapses to the pattern the CLI and desktop already used.

## Net elements (R6)

6 files changed, +22/-26 (net −4 LoC). No exported symbol added or removed (`^[+-]export` is empty across the diff) — `ProgressBackendOptions` stays exported, just narrower by one optional field. No new classes/interfaces/enums.

## Consumer counts (R8)

`stateOwnership` had exactly 2 production passers (extension: implicit default; desktop: explicit `'session'`) and 1 consumer (`SessionState.load`'s branch). All three are updated in this PR; `git grep stateOwnership` confirms zero production/test references remain.

## Host impact

Extension: now runs the startup sweep explicitly at activation instead of implicitly inside `ProgressBackend.load()`'s first call — same timing (before any presentation attaches), same effect, now visible at the call site instead of hidden behind a default.

Desktop: no behavior change — it already swept at process bring-up; only the now-redundant `stateOwnership: 'session'` passer is removed.

CLI: untouched — it never went through `ProgressBackend`/`SessionState.load()` for this.

## Scheduled refactoring

None. (`SessionStores` not being memoized per session — a related but separate finding, T1 in the same survey — is out of scope here.)

## Validation

- `npm run typecheck` — full workspace (`workspace`, `test-kernel`, `agent`, `cli`, `trace-viewer`, `desktop`) — clean.
- `npm run lint` — clean.
- `npx vitest run` on all 11 directly affected suites (progress-view backend cleanup/fact-projection/presentation/stream-lifecycle/retained-children, progress-view stores wiring, desktop agent-execution + factory + tool-edit-approval + progress-file-actions, session-presentation-boundary architecture test) — 213/213 passing.
- Full `npm test` — started; this PR will be updated if it surfaces anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QUwXSpm9wHiajJ1kMapDj

---
_Generated by [Claude Code](https://claude.ai/code/session_016QUwXSpm9wHiajJ1kMapDj)_