### PR TITLE
Extract shared OAuth session schema base for reuse

### DIFF
--- a/src/auth/codex/codexSessionTypes.ts
+++ b/src/auth/codex/codexSessionTypes.ts
@@ -13,6 +13,7 @@ import {
   SubscriptionOAuthError,
   type SubscriptionOAuthErrorKind,
 } from '../oauth/subscriptionOAuthError';
+import { SubscriptionSessionBaseSchema } from '../oauth/subscriptionSessionSchema';
 
 /** Raw response from the OAuth token endpoint (code exchange + refresh). */
 export const CodexTokenResponseSchema = z.object({
@@ -26,12 +27,7 @@ export const CodexTokenResponseSchema = z.object({
 export type CodexTokenResponse = z.infer<typeof CodexTokenResponseSchema>;
 
 /** The persisted OAuth session bundle (stored as JSON under one secret key). */
-export const CodexSessionSchema = z.object({
-  accessToken: z.string().min(1),
-  refreshToken: z.string().min(1),
-  idToken: z.string().min(1).optional(),
-  /** Absolute expiry (ms since epoch). */
-  expiresAtMs: z.number(),
+export const CodexSessionSchema = SubscriptionSessionBaseSchema.extend({
   accountId: z.string().min(1).optional(),
   email: z.string().min(1).optional(),
 });

--- a/src/auth/oauth/subscriptionSessionSchema.ts
+++ b/src/auth/oauth/subscriptionSessionSchema.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared base for a persisted OAuth subscription session (ChatGPT, Grok, …).
+ *
+ * Every provider's stored bundle carries these four fields identically; the
+ * fields that vary (`accountId`, extra claims) are added via `.extend()` on
+ * top of this base rather than restated. Mirrors the `SubscriptionSession`
+ * TypeScript interface in `SubscriptionOAuthCoordinator.ts`, which documents
+ * the same "extend, don't restate" rule at the type level.
+ */
+import { z } from 'zod';
+
+export const SubscriptionSessionBaseSchema = z.object({
+  accessToken: z.string().min(1),
+  refreshToken: z.string().min(1),
+  idToken: z.string().min(1).optional(),
+  /** Absolute expiry (ms since epoch). */
+  expiresAtMs: z.number(),
+});

--- a/src/auth/xai/xaiSessionTypes.ts
+++ b/src/auth/xai/xaiSessionTypes.ts
@@ -11,6 +11,7 @@ import {
   SubscriptionOAuthError,
   type SubscriptionOAuthErrorKind,
 } from '../oauth/subscriptionOAuthError';
+import { SubscriptionSessionBaseSchema } from '../oauth/subscriptionSessionSchema';
 
 /** Raw response from the OAuth token endpoint (code exchange + refresh). */
 export const XaiTokenResponseSchema = z.object({
@@ -31,11 +32,7 @@ export const XaiTokenResponseSchema = z.object({
 export type XaiTokenResponse = z.infer<typeof XaiTokenResponseSchema>;
 
 /** The persisted OAuth session bundle. */
-export const XaiSessionSchema = z.object({
-  accessToken: z.string().min(1),
-  refreshToken: z.string().min(1),
-  idToken: z.string().min(1).optional(),
-  expiresAtMs: z.number(),
+export const XaiSessionSchema = SubscriptionSessionBaseSchema.extend({
   email: z.string().min(1).optional(),
 });
 export type XaiSession = z.infer<typeof XaiSessionSchema>;


### PR DESCRIPTION
## Summary

Extracted the common OAuth session schema fields (`accessToken`, `refreshToken`, `idToken`, `expiresAtMs`) into a reusable `SubscriptionSessionBaseSchema` to eliminate duplication across provider implementations. Both Codex and XAI session schemas now extend this base rather than restating the identical fields.

## Issue acceptance gates

n/a — refactoring/deduplication work

## Single source of truth

`src/auth/oauth/subscriptionSessionSchema.ts` now owns the canonical definition of persisted OAuth session base fields. Provider-specific schemas (Codex, XAI) extend this base and add their own fields via `.extend()`.

## Duplication and abstraction budget

**Removed duplication:** Four identical field definitions (`accessToken`, `refreshToken`, `idToken`, `expiresAtMs`) were restated in both `CodexSessionSchema` and `XaiSessionSchema`. These are now defined once in `SubscriptionSessionBaseSchema` and composed via `.extend()`.

**Abstraction invariant:** The base schema encodes the rule documented in comments: "Every provider's stored bundle carries these four fields identically; fields that vary are added via `.extend()` on top of this base rather than restated." This mirrors the TypeScript interface pattern in `SubscriptionOAuthCoordinator.ts` and makes the constraint explicit at the schema level.

## Net elements (R6)

- **Files:** +1 (new `subscriptionSessionSchema.ts`), 2 modified
- **Exports:** +1 (`SubscriptionSessionBaseSchema`)
- **Net LoC:** ~+10 (new file) / ~−8 (removed duplication) = ~+2 net

## Consumer counts (R8)

n/a — no exports deleted or re-routed; new schema is only consumed by the two session schemas being refactored in this same PR.

## Host impact

Extension: No impact (auth layer is host-agnostic)

Desktop: No impact

CLI: No impact

## Scheduled refactoring

None — this completes the deduplication. Future providers (e.g., new OAuth integrations) should extend `SubscriptionSessionBaseSchema` rather than restate these fields.

## Validation

- Zod schema composition via `.extend()` is type-safe and preserves all field constraints
- No runtime behavior changed; schemas remain functionally identical
- Existing type inference (`z.infer<typeof CodexSessionSchema>`, etc.) unaffected

https://claude.ai/code/session_017trLZKVww3R5gPp6UABHCq