### PR TITLE
Document rationale for two thin barrel modules

### DIFF
--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -1,5 +1,12 @@
 /**
- * Agent index module - public API for the agent registry.
+ * Public door onto the agent registry and roster — the agent-catalog
+ * loading, resolution, and directory-scanning surface hosts reach instead of
+ * deep-reaching `./agentRegistry`, `./AgentDirectoryService`, or
+ * `../roster/AgentRosterController` by path. Following the same pattern as
+ * `@agent/runtime` (#10011) and `@agent/storage`, this decouples host code
+ * from the registry's internal file layout, and the R-b deep-import width
+ * ratchet (`config/ratchets/host-agent-import-baseline.json`) collapses each
+ * host's `@agent/index` specifier to this single door.
  */
 
 export type { AgentSource } from '@shared/schemas';

--- a/src/shared/styles/index.ts
+++ b/src/shared/styles/index.ts
@@ -1,3 +1,12 @@
+// Public door onto the shared Lit style sheets the webview frontends compose
+// into their components — the common view chrome, design tokens, and the
+// handful of widely-reused component sheets below. This is a documented
+// exception to "no convenience barrels": components pull `commonViewStyles`
+// and friends from here instead of naming each sheet's file, because nearly
+// every view composes the same handful of sheets. A module stays out of this
+// barrel (and gets a direct import instead) when it has few consumers or is
+// reached indirectly through another export — see the two call-outs below.
+
 // Core styles
 export {
   commonViewStyles,


### PR DESCRIPTION
## Summary

A scheduled abstraction-layer audit swept the codebase against its documented layering rules (VS Code coupling boundaries, AppSignals/eventBus scope, `src/utils/` browser-safety, `shared`→`agent` imports, single-caller wrapper classes, barrel exports, silent-catch discipline, render-time business logic in webview frontends, command-handler business logic, and ratchet baselines). No functional violations survived verification — the codebase is already well enforced, largely via existing ESLint zone rules, `dependencyDirection.vitest.ts`, and the `config/ratchets/*` baselines.

The one cosmetic gap: two barrel (`index.ts`) files carried a one-line description instead of the rationale paragraph every sibling barrel (`@agent/runtime`, `@agent/storage`, `@agent/templates`, etc.) uses to explain why the barrel exists and what it decouples. This PR brings those two up to the same bar:

- `src/agent/index/index.ts` — now explains the door it provides onto the agent registry/roster, mirrors the `@agent/runtime` pattern, and names the R-b deep-import width ratchet (`config/ratchets/host-agent-import-baseline.json`) it satisfies (this barrel is already tracked there for all four hosts).
- `src/shared/styles/index.ts` — now states upfront why the shared Lit style-sheet barrel exists (documented exception to "no convenience barrels" — nearly every webview view composes the same handful of sheets) before the existing call-outs on what's intentionally excluded.

No behavior changes — comment-only.

## Issue acceptance gates

n/a — follow-up from a scheduled audit, not an issue-tracked task. No open issue targeted.

## Single source of truth

Unchanged. Both files remain the single public barrel for their respective internals (`src/agent/index/*` and `src/shared/styles/*`); this PR only documents why.

## Duplication and abstraction budget

No duplication added or removed; no new abstraction. Comment-only change to two existing, already-justified barrels.

## Net elements (R6)

n/a — not a refactor/simplify/consolidate/dedupe/extract PR. Zero exported symbols, files, or LoC added/removed (2 files touched, comments only).

## Consumer counts (R8)

n/a — no emit path or export was re-routed or deleted.

## Host impact

Extension: none (comment-only)
Desktop: none (comment-only)
CLI: none (comment-only)

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — passed (all workspaces: root, test-kernel, agent, cli, trace-viewer, desktop)
- `npx eslint src/agent/index/index.ts src/shared/styles/index.ts` — clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WP2HKhigUVepMoTqKi1mRo

---
_Generated by [Claude Code](https://claude.ai/code/session_01WP2HKhigUVepMoTqKi1mRo)_