### PR TITLE
refactor(modelHandlers): unify AssistantTextAppendOptions contract

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -146,7 +146,13 @@ export interface CreatedMedia<Media> {
   readonly entries: readonly MediaEntry[];
 }
 
-interface AssistantTextAppendOptions {
+/**
+ * Options for {@link ModelHandler.appendTextToLastAssistantMessage}. Exported
+ * as the single source of truth for the append-options contract so provider
+ * overrides reference this shape by name instead of redeclaring it inline (two
+ * of them had already drifted, silently dropping `fallbackText`).
+ */
+export interface AssistantTextAppendOptions {
   /**
    * True when the current trailing user/system message may be the synthetic
    * continuation prompt. Providers decide whether to append to the previous

--- a/src/agent/modelHandlers/anthropic/anthropicMessages.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicMessages.ts
@@ -1,6 +1,7 @@
 // Local imports
 import type { AgentTrace } from '@agent/trace';
 import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
+import type { AssistantTextAppendOptions } from '../ModelHandler';
 
 // Third-party imports
 import type {
@@ -95,7 +96,7 @@ export async function addMediaToUserMessage(
 export function appendTextToLastAssistantMessage(
   messages: MessageParam[],
   text: string,
-  options: { afterContinuationPrompt?: boolean; fallbackText?: string } = {},
+  options: AssistantTextAppendOptions = {},
   deps: AnthropicAssistantMessageDeps,
 ): boolean {
   let targetIndex = messages.length - 1;

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -16,7 +16,10 @@ import type {
   AgentWorkspaceState,
   ThinkingBlock,
 } from '@agent/core/state/AgentWorkspaceState';
-import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
+import {
+  ModelHandler,
+  type AssistantTextAppendOptions,
+} from '@agent/modelHandlers/ModelHandler';
 import type { ModelCredentialSelection } from '@agent/types/ModelHandlerContracts';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { MediaEntry } from '@agent/types/mediaTypes';
@@ -1292,7 +1295,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
   protected appendTextToLastAssistantMessage(
     messages: MessageParam[],
     text: string,
-    options: { afterContinuationPrompt?: boolean; fallbackText?: string } = {},
+    options: AssistantTextAppendOptions = {},
   ): boolean {
     return appendAnthropicTextToLastAssistantMessage(messages, text, options, {
       logger: this.logger,

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -17,6 +17,7 @@ import { logProgressStatus } from '@agent/trace';
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import {
   ModelHandler,
+  type AssistantTextAppendOptions,
   type CreatedMedia,
 } from '@agent/modelHandlers/ModelHandler';
 import { reportMediaAttachmentFailure } from '@agent/modelHandlers/support/mediaAttachmentPolicy';
@@ -1257,7 +1258,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   protected appendTextToLastAssistantMessage(
     messages: Step[],
     text: string,
-    options: { afterContinuationPrompt?: boolean } = {},
+    options: AssistantTextAppendOptions = {},
   ): boolean {
     const trailingStep = messages.at(-1);
     if (

--- a/src/agent/modelHandlers/modelHandlerValidation.ts
+++ b/src/agent/modelHandlers/modelHandlerValidation.ts
@@ -21,7 +21,7 @@ import type {
 } from '@shared/schemas';
 
 // Local imports - model handlers
-import { ModelHandler } from './ModelHandler';
+import { ModelHandler, type AssistantTextAppendOptions } from './ModelHandler';
 
 // Third-party imports
 import type { ModelConfig } from 'llm-zoo';
@@ -225,7 +225,7 @@ export class ModelHandlerValidation extends ModelHandler<
   protected appendTextToLastAssistantMessage(
     _messages: ChatCompletionMessageParam[],
     _text: string,
-    _options?: { afterContinuationPrompt?: boolean; fallbackText?: string },
+    _options?: AssistantTextAppendOptions,
   ): boolean {
     return false;
   }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -72,6 +72,7 @@ import { formatToolResultTextWithAttachments } from '../utils/toolAttachmentUtil
 import { OpenAICompatibleModelHandler } from './OpenAICompatibleModelHandler';
 import { ReasoningStreamAggregator } from './ReasoningStreamAggregator';
 import { CLIENT_COMPACTION_SUMMARY_MAX_TOKENS } from '../contextManagementConstants';
+import type { AssistantTextAppendOptions } from '../ModelHandler';
 import type { NormalizeOpenAIMessageContentOptions } from './openAIMessageUtils';
 
 // Third-party imports
@@ -883,7 +884,7 @@ export class ModelHandlerOpenAI<
   protected appendTextToLastAssistantMessage(
     messages: ChatCompletionMessageParam[],
     text: string,
-    options: { afterContinuationPrompt?: boolean; fallbackText?: string } = {},
+    options: AssistantTextAppendOptions = {},
   ): boolean {
     let targetIndex = messages.length - 1;
     const trailingMessage = messages.at(-1);

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -105,6 +105,7 @@ import {
   uploadToolAttachments,
   type UploadedOpenAIResponseAttachment,
 } from './openAIResponseFileUploads';
+import type { AssistantTextAppendOptions } from '../ModelHandler';
 import type { BackgroundRunLifecycle } from '../support/BackgroundRunLifecycle';
 
 // Third-party imports
@@ -1991,7 +1992,7 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
   protected appendTextToLastAssistantMessage(
     messages: ResponseInputItem[],
     text: string,
-    options: { afterContinuationPrompt?: boolean; fallbackText?: string } = {},
+    options: AssistantTextAppendOptions = {},
   ): boolean {
     let targetIndex = messages.length - 1;
     const trailingMessage = messages.at(-1);

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -64,7 +64,7 @@ import {
   OpenRouterStreamAggregator,
   toOpenRouterReasoningEffort,
 } from './openRouterStreaming';
-import { ModelHandler } from '../ModelHandler';
+import { ModelHandler, type AssistantTextAppendOptions } from '../ModelHandler';
 import { CLIENT_COMPACTION_SUMMARY_MAX_TOKENS } from '../contextManagementConstants';
 
 // Third-party type imports
@@ -707,7 +707,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
   protected appendTextToLastAssistantMessage(
     messages: ChatMessages[],
     text: string,
-    options: { afterContinuationPrompt?: boolean; fallbackText?: string } = {},
+    options: AssistantTextAppendOptions = {},
   ): boolean {
     let targetIndex = messages.length - 1;
     const trailingMessage = messages.at(-1);

--- a/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
+++ b/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
@@ -45,7 +45,7 @@ import type {
 import { getMimeType, isImageMimeType } from '@utils/files/mimeUtils';
 
 // Local file imports
-import { ModelHandler } from '../ModelHandler';
+import { ModelHandler, type AssistantTextAppendOptions } from '../ModelHandler';
 import { toVscodeLmTools } from '../toolConversion';
 import { formatToolResultTextWithAttachments } from '../utils/toolAttachmentUtils';
 
@@ -372,7 +372,7 @@ export class ModelHandlerVscodeLm extends ModelHandler<
   protected appendTextToLastAssistantMessage(
     messages: LanguageModelMessage[],
     text: string,
-    options: { afterContinuationPrompt?: boolean } = {},
+    options: AssistantTextAppendOptions = {},
   ): boolean {
     let assistantIndex = messages.length - 1;
     const trailing = messages.at(-1);


### PR DESCRIPTION
## Summary

The base `ModelHandler.appendTextToLastAssistantMessage` abstract method already types its `options` parameter as `AssistantTextAppendOptions`, but all eight provider overrides and helpers redeclared the same options shape inline. Two of them had **drifted**: `modelHandlerGoogleInteractions` and `modelHandlerVscodeLm` declared only `{ afterContinuationPrompt?: boolean }`, silently omitting `fallbackText` from their accepted contract — even though the sole caller (`updateMessageContent`) always passes both fields.

This PR exports the interface as the single source of truth and references it by name at every override and helper.

**Behavior is unchanged.** The Google/VscodeLm append paths never read `fallbackText` (they don't do the assistant-message-shape re-serialization that Anthropic/OpenAI/OpenRouter use it for), so widening their accepted type to match the base contract is a no-op at runtime. The append-options contract now has one definition instead of nine, and a future field cannot drift across providers unnoticed.

This was surfaced by a codebase refactoring audit. Notably, the larger structural targets the audit flagged (the "triplicated" create-response pipeline, the transcript run-metadata handoff resets, an ID-generation "consolidation") were each investigated and found to be **intentional or false positives** — the apparent duplication encodes documented per-provider/per-execution semantics, or the sites weren't actually equivalent. This contract unification was the one genuinely clean, behavior-preserving consolidation.

## Issue acceptance gates

No issue — proactive refactor from the audit. Gate: remove the duplicated/drifted options contract without changing runtime behavior. Satisfied.

## Single source of truth

`AssistantTextAppendOptions` in `src/agent/modelHandlers/ModelHandler.ts` now owns the append-options shape for the base abstract method, all six provider overrides, the standalone `anthropicMessages.appendTextToLastAssistantMessage` helper, and the `ModelHandlerValidation` stub.

## Duplication and abstraction budget

Removed: 8 inline redeclarations of the append-options shape (2 of which had drifted from the base contract). No new abstraction added — the interface already existed; it is simply exported and referenced rather than copied. No pass-through layers.

## Net elements (R6)

- Files: 9 changed, 0 added/deleted (diffstat: +26 / −13, net +13 LoC — the increase is the interface doc comment plus type-only import lines that replace inline literals of similar length).
- Exported symbols: **+1** (`AssistantTextAppendOptions` — the interface existed but was unexported; now consumed by 8 sites).
- Classes/interfaces/enums: 0 net new (interface already existed).

## Consumer counts (R8)

No emit path or export was deleted or re-routed away. One export was **added** (`AssistantTextAppendOptions`), with 8 in-repo consumers (the base method's own reference plus the 8 override/helper sites), so it is not dead — confirmed by `check:dead-code-ratchet`.

## Host impact

Extension: none — host-agnostic core (`src/agent/modelHandlers/`), behavior unchanged.

Desktop: none — same.

CLI: none — same.

## Scheduled refactoring

None.

## Validation

- `pnpm run typecheck:workspace` — exit 0.
- `eslint` on all 9 changed files — exit 0 (import order auto-fixed).
- `pnpm run check:dead-code-ratchet` — OK, no new findings.
- `vitest run src/test-kernel/agent/modelHandlers` — 757 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BtUkf7FAoYTk7T8XYXzct

---
_Generated by [Claude Code](https://claude.ai/code/session_014BtUkf7FAoYTk7T8XYXzct)_