### PR TITLE
fix(tools): stop inferring a run's liveness from a missing outcome

### DIFF
--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -22,6 +22,12 @@ import { runIdentityName } from '@shared/schemas';
 export interface ExecutionStatusInfo {
   status: StreamPhase | 'unknown';
   elapsed: string | null;
+  /**
+   * Why the status reads the way it does, when the phase alone would mislead:
+   * a run another process holds, or one interrupted with a checkpoint still
+   * on disk. Rendered after the status by `formatStatusInfo`.
+   */
+  detail?: string;
 }
 
 /**

--- a/src/agent/runtime/detachSubagentsOnStop.ts
+++ b/src/agent/runtime/detachSubagentsOnStop.ts
@@ -24,9 +24,12 @@ import { readPlatformSetting } from '@utils/config/platformSettings';
  *   exiting process, so honoring the toggle there would strand children
  *   without finalization (`packages/cli/src/runtime/runExecution.ts`).
  *
- * Host quit is a separate axis this toggle does not govern. The extension and
- * desktop abandon native children to the restart-repair path; the CLI kills or
- * interrupts them, because the process that owns them is the one going away.
+ * Host quit is a separate axis this toggle does not govern, and detaching does
+ * not opt a child out of it: `detachActiveChildren` detaches a child from its
+ * parent without untracking its handle, so the shared exit drain
+ * (`settleLiveSessionExecutions`, #11355) still settles every tracked child on
+ * the way out, on every host. The CLI additionally kills or interrupts them,
+ * because the process that owns them is the one going away.
  *
  * The platform must be initialized before a run can be stopped or killed.
  */

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -477,8 +477,9 @@ export class ExecutionRegistry {
 
   /**
    * Kill only background OS processes (bash, codex) without touching agent
-   * stream status. Agent executions are left in RUNNING so restart recovery can
-   * restore them to WAITING (resumable) if a flow record exists.
+   * stream status. Agent executions are left in RUNNING: whether one is
+   * resumable afterwards is decided from its durable facts (a flow record on
+   * disk, and no live owner), never from a phase some later pass rewrites.
    *
    * Killing a background run's underlying OS process requires
    * `interruptBackgroundProcess()`, which only fires for a handle whose

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -328,7 +328,10 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
    * projected onto it. `meta.outcome` is the only writer of "how did this run
    * end": the result record is an interim envelope rewritten by every turn,
    * and a run can end after its last turn wrote one (interrupted between
-   * turns, stopped while suspended, failed by restart repair). A durable
+   * turns, stopped while suspended, settled by the host's exit drain). An
+   * ABSENT outcome is not liveness: a run whose owner crashed never wrote
+   * one, so "is this still going" is answered by `resolveExecutionLiveness`
+   * (`@tools/executions/executionLiveness`), never by this record. A durable
    * `completed` is never projected: it only ever agrees with the envelope,
    * whose producer may already have downgraded a nominally completed flow that
    * reported an application-level error (`buildSubagentFailureResultMeta`).

--- a/src/test-kernel/tools/ExecutionFormatters.vitest.ts
+++ b/src/test-kernel/tools/ExecutionFormatters.vitest.ts
@@ -25,6 +25,7 @@ vi.mock('@agent/storage/ExecutionKVStore', () => ({
 
 // Local imports
 import { getExecutionStatusInfo } from '@tools/executionFormatters';
+import { turnAttributionNote } from '@tools/executions/turnAttribution';
 
 /** No handle in this process, whatever the durable facts then say. */
 function noLiveHandle(): void {
@@ -116,7 +117,11 @@ describe('getExecutionStatusInfo', () => {
     const info = await getExecutionStatusInfo('exec-1');
 
     assert.strictEqual(info.status, 'cancelled');
-    assert.match(info.detail ?? '', /interrupted/);
+    // Presence, not validity: a stat cannot promise the record can be resumed.
+    assert.match(
+      info.detail ?? '',
+      /interrupted; a flow record remains \(not validated here\)/,
+    );
   });
 
   it('does not call a run cancelled while another process holds it', async () => {
@@ -163,5 +168,34 @@ describe('getExecutionStatusInfo', () => {
 
     assert.strictEqual(info.status, 'unknown');
     assert.match(info.detail ?? '', /cannot read \(lease corrupt\)/);
+  });
+});
+
+describe('turnAttributionNote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not call an accepted turn running once its stream is terminal', async () => {
+    // The handle outlives the stream's terminal phase, so handle presence
+    // alone must not word the note as "still running".
+    mocks.currentSession.mockReturnValue({
+      executions: {
+        getHandle: () => ({}),
+        getStatus: () => ({ status: 'completed', elapsed: null }),
+      },
+    });
+    const store = {
+      getExecutionId: () => 'exec-1',
+      readTurnState: async () => ({
+        activeTurn: { token: 'turn-2' },
+        lastCompletedTurn: { token: 'turn-1' },
+      }),
+    } as unknown as Parameters<typeof turnAttributionNote>[0];
+
+    const note = await turnAttributionNote(store);
+
+    assert.match(note ?? '', /turn turn-2 ended with its run \(completed\)/);
+    assert.doesNotMatch(note ?? '', /still running/);
   });
 });

--- a/src/test-kernel/tools/ExecutionFormatters.vitest.ts
+++ b/src/test-kernel/tools/ExecutionFormatters.vitest.ts
@@ -1,13 +1,14 @@
 // Third-party imports
 import * as assert from 'node:assert';
-import { describe, it, vi } from 'vitest';
+import { beforeEach, describe, it, vi } from 'vitest';
 
 import type { RunOutcome } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
   currentSession: vi.fn(),
   inspectExecutionLease: vi.fn(),
-  read: vi.fn(),
+  readMeta: vi.fn(),
+  exists: vi.fn(),
 }));
 
 vi.mock('@agent/runtime/SessionHandle', () => ({
@@ -19,7 +20,7 @@ vi.mock('@agent/storage/executionLease', () => ({
 }));
 
 vi.mock('@agent/storage/ExecutionKVStore', () => ({
-  getExecutionStore: () => ({ read: mocks.read }),
+  getExecutionStore: () => ({ readMeta: mocks.readMeta, exists: mocks.exists }),
 }));
 
 // Local imports
@@ -32,29 +33,30 @@ function noLiveHandle(): void {
   });
 }
 
-/** Persisted facts: the given metadata and no checkpoint. */
-function persistedMeta(meta: { outcome?: RunOutcome } | undefined): void {
-  mocks.read.mockImplementation((key: string) =>
-    Promise.resolve(
-      key === 'meta' && meta
-        ? { timestamp: '2026-05-15T23:42:06.000Z', ...meta }
-        : undefined,
-    ),
+/** Persisted facts: the given metadata row, and whether a checkpoint is on disk. */
+function persisted(
+  meta: { outcome?: RunOutcome } | null,
+  checkpoint: 'checkpoint' | 'no-checkpoint',
+): void {
+  mocks.readMeta.mockResolvedValue(
+    meta && { timestamp: '2026-05-15T23:42:06.000Z', ...meta },
   );
+  mocks.exists.mockResolvedValue(checkpoint === 'checkpoint');
 }
 
 describe('getExecutionStatusInfo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    noLiveHandle();
+  });
+
   it.each<{ outcome?: RunOutcome; expected: string }>([
     { outcome: undefined, expected: 'unknown' },
     { outcome: 'cancelled', expected: 'cancelled' },
   ])(
     'reports $expected when the live handle is gone and nothing owns the run',
     async ({ outcome, expected }) => {
-      noLiveHandle();
-      mocks.inspectExecutionLease.mockResolvedValue({ status: 'free' });
-      // The persisted metadata is the only outcome source — no caller passes a
-      // snapshot in. No flow record, so `classifyRun` reports `finished`.
-      persistedMeta({ outcome });
+      persisted({ outcome }, 'no-checkpoint');
 
       const info = await getExecutionStatusInfo('exec-1');
 
@@ -62,9 +64,44 @@ describe('getExecutionStatusInfo', () => {
     },
   );
 
+  it('reads no checkpoint and no lease for a row that recorded its outcome', async () => {
+    // The listing's whole budget: one metadata row (here the caller's own),
+    // and nothing else for a run that already said how it ended.
+    persisted(null, 'no-checkpoint');
+
+    const info = await getExecutionStatusInfo('exec-1', {
+      outcome: 'completed',
+    });
+
+    assert.strictEqual(info.status, 'completed');
+    assert.strictEqual(mocks.readMeta.mock.calls.length, 0);
+    assert.strictEqual(mocks.exists.mock.calls.length, 0);
+    assert.strictEqual(mocks.inspectExecutionLease.mock.calls.length, 0);
+  });
+
+  it('costs one stat and no lease read for a settled row', async () => {
+    persisted({}, 'no-checkpoint');
+
+    const info = await getExecutionStatusInfo('exec-1', {});
+
+    assert.strictEqual(info.status, 'unknown');
+    assert.strictEqual(mocks.readMeta.mock.calls.length, 0);
+    assert.strictEqual(mocks.exists.mock.calls.length, 1);
+    assert.strictEqual(mocks.inspectExecutionLease.mock.calls.length, 0);
+  });
+
+  it('calls a checkpointed run nobody owns interrupted', async () => {
+    persisted({}, 'checkpoint');
+    mocks.inspectExecutionLease.mockResolvedValue({ status: 'free' });
+
+    const info = await getExecutionStatusInfo('exec-1');
+
+    assert.strictEqual(info.status, 'cancelled');
+    assert.match(info.detail ?? '', /interrupted/);
+  });
+
   it('does not call a run cancelled while another process holds it', async () => {
-    noLiveHandle();
-    persistedMeta(undefined);
+    persisted({}, 'checkpoint');
     mocks.inspectExecutionLease.mockResolvedValue({
       status: 'held',
       owner: { pid: 4242, hostname: 'other-host' },
@@ -77,9 +114,8 @@ describe('getExecutionStatusInfo', () => {
   });
 
   it('does not settle a run whose lease this process holds with no run', async () => {
-    noLiveHandle();
     // Nothing durable behind the lease: no outcome ever written.
-    persistedMeta({});
+    persisted({}, 'checkpoint');
     mocks.inspectExecutionLease.mockResolvedValue({ status: 'owned' });
 
     const info = await getExecutionStatusInfo('exec-1');
@@ -92,12 +128,21 @@ describe('getExecutionStatusInfo', () => {
     // A finished child untracks its handle and writes the outcome long before
     // its loop releases the execution lease (#8093), and the parent reads the
     // run inside exactly that window.
-    noLiveHandle();
-    persistedMeta({ outcome: 'completed' });
+    persisted({ outcome: 'completed' }, 'checkpoint');
     mocks.inspectExecutionLease.mockResolvedValue({ status: 'owned' });
 
     const info = await getExecutionStatusInfo('exec-1');
 
     assert.strictEqual(info.status, 'completed');
+  });
+
+  it('reports an unreadable lease rather than a terminal reading', async () => {
+    persisted({}, 'checkpoint');
+    mocks.inspectExecutionLease.mockRejectedValue(new Error('lease corrupt'));
+
+    const info = await getExecutionStatusInfo('exec-1');
+
+    assert.strictEqual(info.status, 'unknown');
+    assert.match(info.detail ?? '', /cannot read \(lease corrupt\)/);
   });
 });

--- a/src/test-kernel/tools/ExecutionFormatters.vitest.ts
+++ b/src/test-kernel/tools/ExecutionFormatters.vitest.ts
@@ -6,10 +6,20 @@ import type { RunOutcome } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
   currentSession: vi.fn(),
+  inspectExecutionLease: vi.fn(),
+  exists: vi.fn(),
 }));
 
 vi.mock('@agent/runtime/SessionHandle', () => ({
   currentSession: mocks.currentSession,
+}));
+
+vi.mock('@agent/storage/executionLease', () => ({
+  inspectExecutionLease: mocks.inspectExecutionLease,
+}));
+
+vi.mock('@agent/storage/ExecutionKVStore', () => ({
+  getExecutionStore: () => ({ exists: mocks.exists }),
 }));
 
 // Local imports
@@ -20,15 +30,32 @@ describe('getExecutionStatusInfo', () => {
     { outcome: undefined, expected: 'unknown' },
     { outcome: 'cancelled', expected: 'cancelled' },
   ])(
-    'reports $expected when the live handle is gone',
-    ({ outcome, expected }) => {
+    'reports $expected when the live handle is gone and nothing owns the run',
+    async ({ outcome, expected }) => {
       mocks.currentSession.mockReturnValue({
         executions: { getHandle: () => undefined },
       });
+      mocks.inspectExecutionLease.mockResolvedValue({ status: 'free' });
+      mocks.exists.mockResolvedValue(false);
 
-      const info = getExecutionStatusInfo('exec-1', outcome);
+      const info = await getExecutionStatusInfo('exec-1', outcome);
 
       assert.strictEqual(info.status, expected);
     },
   );
+
+  it('does not call a run cancelled while another process holds it', async () => {
+    mocks.currentSession.mockReturnValue({
+      executions: { getHandle: () => undefined },
+    });
+    mocks.inspectExecutionLease.mockResolvedValue({
+      status: 'held',
+      owner: { pid: 4242, hostname: 'other-host' },
+    });
+
+    const info = await getExecutionStatusInfo('exec-1');
+
+    assert.strictEqual(info.status, 'unknown');
+    assert.match(info.detail ?? '', /pid 4242 on other-host/);
+  });
 });

--- a/src/test-kernel/tools/ExecutionFormatters.vitest.ts
+++ b/src/test-kernel/tools/ExecutionFormatters.vitest.ts
@@ -7,7 +7,7 @@ import type { RunOutcome } from '@shared/schemas';
 const mocks = vi.hoisted(() => ({
   currentSession: vi.fn(),
   inspectExecutionLease: vi.fn(),
-  exists: vi.fn(),
+  read: vi.fn(),
 }));
 
 vi.mock('@agent/runtime/SessionHandle', () => ({
@@ -19,7 +19,7 @@ vi.mock('@agent/storage/executionLease', () => ({
 }));
 
 vi.mock('@agent/storage/ExecutionKVStore', () => ({
-  getExecutionStore: () => ({ exists: mocks.exists }),
+  getExecutionStore: () => ({ read: mocks.read }),
 }));
 
 // Local imports
@@ -36,7 +36,8 @@ describe('getExecutionStatusInfo', () => {
         executions: { getHandle: () => undefined },
       });
       mocks.inspectExecutionLease.mockResolvedValue({ status: 'free' });
-      mocks.exists.mockResolvedValue(false);
+      // No metadata and no flow record: `classifyRun` reports `finished`.
+      mocks.read.mockResolvedValue(undefined);
 
       const info = await getExecutionStatusInfo('exec-1', outcome);
 

--- a/src/test-kernel/tools/ExecutionFormatters.vitest.ts
+++ b/src/test-kernel/tools/ExecutionFormatters.vitest.ts
@@ -32,6 +32,17 @@ function noLiveHandle(): void {
   });
 }
 
+/** Persisted facts: the given metadata and no checkpoint. */
+function persistedMeta(meta: { outcome?: RunOutcome } | undefined): void {
+  mocks.read.mockImplementation((key: string) =>
+    Promise.resolve(
+      key === 'meta' && meta
+        ? { timestamp: '2026-05-15T23:42:06.000Z', ...meta }
+        : undefined,
+    ),
+  );
+}
+
 describe('getExecutionStatusInfo', () => {
   it.each<{ outcome?: RunOutcome; expected: string }>([
     { outcome: undefined, expected: 'unknown' },
@@ -43,13 +54,7 @@ describe('getExecutionStatusInfo', () => {
       mocks.inspectExecutionLease.mockResolvedValue({ status: 'free' });
       // The persisted metadata is the only outcome source — no caller passes a
       // snapshot in. No flow record, so `classifyRun` reports `finished`.
-      mocks.read.mockImplementation((key: string) =>
-        Promise.resolve(
-          key === 'meta'
-            ? { timestamp: '2026-05-15T23:42:06.000Z', outcome }
-            : undefined,
-        ),
-      );
+      persistedMeta({ outcome });
 
       const info = await getExecutionStatusInfo('exec-1');
 
@@ -59,6 +64,7 @@ describe('getExecutionStatusInfo', () => {
 
   it('does not call a run cancelled while another process holds it', async () => {
     noLiveHandle();
+    persistedMeta(undefined);
     mocks.inspectExecutionLease.mockResolvedValue({
       status: 'held',
       owner: { pid: 4242, hostname: 'other-host' },
@@ -72,11 +78,26 @@ describe('getExecutionStatusInfo', () => {
 
   it('does not settle a run whose lease this process holds with no run', async () => {
     noLiveHandle();
+    // Nothing durable behind the lease: no outcome ever written.
+    persistedMeta({});
     mocks.inspectExecutionLease.mockResolvedValue({ status: 'owned' });
 
     const info = await getExecutionStatusInfo('exec-1');
 
     assert.strictEqual(info.status, 'unknown');
     assert.match(info.detail ?? '', /no live run/);
+  });
+
+  it('still reports the outcome while this process lags releasing the lease', async () => {
+    // A finished child untracks its handle and writes the outcome long before
+    // its loop releases the execution lease (#8093), and the parent reads the
+    // run inside exactly that window.
+    noLiveHandle();
+    persistedMeta({ outcome: 'completed' });
+    mocks.inspectExecutionLease.mockResolvedValue({ status: 'owned' });
+
+    const info = await getExecutionStatusInfo('exec-1');
+
+    assert.strictEqual(info.status, 'completed');
   });
 });

--- a/src/test-kernel/tools/ExecutionFormatters.vitest.ts
+++ b/src/test-kernel/tools/ExecutionFormatters.vitest.ts
@@ -48,6 +48,9 @@ describe('getExecutionStatusInfo', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     noLiveHandle();
+    // Unowned unless a case says otherwise: every outcome-less row reads the
+    // lease before it decides anything from the checkpoint.
+    mocks.inspectExecutionLease.mockResolvedValue({ status: 'free' });
   });
 
   it.each<{ outcome?: RunOutcome; expected: string }>([
@@ -79,15 +82,31 @@ describe('getExecutionStatusInfo', () => {
     assert.strictEqual(mocks.inspectExecutionLease.mock.calls.length, 0);
   });
 
-  it('costs one stat and no lease read for a settled row', async () => {
+  it('costs one lease read and one stat for a settled row', async () => {
     persisted({}, 'no-checkpoint');
 
     const info = await getExecutionStatusInfo('exec-1', {});
 
     assert.strictEqual(info.status, 'unknown');
     assert.strictEqual(mocks.readMeta.mock.calls.length, 0);
+    assert.strictEqual(mocks.inspectExecutionLease.mock.calls.length, 1);
     assert.strictEqual(mocks.exists.mock.calls.length, 1);
-    assert.strictEqual(mocks.inspectExecutionLease.mock.calls.length, 0);
+  });
+
+  it('reports a checkpointless run a live foreign owner holds as held', async () => {
+    // A background shell holds its execution lease for its whole lifetime and
+    // never writes a flow record, so the checkpoint stat cannot decide it.
+    persisted({}, 'no-checkpoint');
+    mocks.inspectExecutionLease.mockResolvedValue({
+      status: 'held',
+      owner: { pid: 5150, hostname: 'other-host' },
+    });
+
+    const info = await getExecutionStatusInfo('exec-1', {});
+
+    assert.strictEqual(info.status, 'unknown');
+    assert.match(info.detail ?? '', /pid 5150 on other-host/);
+    assert.strictEqual(mocks.exists.mock.calls.length, 0);
   });
 
   it('calls a checkpointed run nobody owns interrupted', async () => {

--- a/src/test-kernel/tools/ExecutionFormatters.vitest.ts
+++ b/src/test-kernel/tools/ExecutionFormatters.vitest.ts
@@ -25,6 +25,13 @@ vi.mock('@agent/storage/ExecutionKVStore', () => ({
 // Local imports
 import { getExecutionStatusInfo } from '@tools/executionFormatters';
 
+/** No handle in this process, whatever the durable facts then say. */
+function noLiveHandle(): void {
+  mocks.currentSession.mockReturnValue({
+    executions: { getHandle: () => undefined },
+  });
+}
+
 describe('getExecutionStatusInfo', () => {
   it.each<{ outcome?: RunOutcome; expected: string }>([
     { outcome: undefined, expected: 'unknown' },
@@ -32,23 +39,26 @@ describe('getExecutionStatusInfo', () => {
   ])(
     'reports $expected when the live handle is gone and nothing owns the run',
     async ({ outcome, expected }) => {
-      mocks.currentSession.mockReturnValue({
-        executions: { getHandle: () => undefined },
-      });
+      noLiveHandle();
       mocks.inspectExecutionLease.mockResolvedValue({ status: 'free' });
-      // No metadata and no flow record: `classifyRun` reports `finished`.
-      mocks.read.mockResolvedValue(undefined);
+      // The persisted metadata is the only outcome source — no caller passes a
+      // snapshot in. No flow record, so `classifyRun` reports `finished`.
+      mocks.read.mockImplementation((key: string) =>
+        Promise.resolve(
+          key === 'meta'
+            ? { timestamp: '2026-05-15T23:42:06.000Z', outcome }
+            : undefined,
+        ),
+      );
 
-      const info = await getExecutionStatusInfo('exec-1', outcome);
+      const info = await getExecutionStatusInfo('exec-1');
 
       assert.strictEqual(info.status, expected);
     },
   );
 
   it('does not call a run cancelled while another process holds it', async () => {
-    mocks.currentSession.mockReturnValue({
-      executions: { getHandle: () => undefined },
-    });
+    noLiveHandle();
     mocks.inspectExecutionLease.mockResolvedValue({
       status: 'held',
       owner: { pid: 4242, hostname: 'other-host' },
@@ -58,5 +68,15 @@ describe('getExecutionStatusInfo', () => {
 
     assert.strictEqual(info.status, 'unknown');
     assert.match(info.detail ?? '', /pid 4242 on other-host/);
+  });
+
+  it('does not settle a run whose lease this process holds with no run', async () => {
+    noLiveHandle();
+    mocks.inspectExecutionLease.mockResolvedValue({ status: 'owned' });
+
+    const info = await getExecutionStatusInfo('exec-1');
+
+    assert.strictEqual(info.status, 'unknown');
+    assert.match(info.detail ?? '', /no live run/);
   });
 });

--- a/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
+++ b/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
@@ -60,7 +60,7 @@ describe('tool status formatting', () => {
     );
   });
 
-  it('renders bash execution history as a process without a model', () => {
+  it('renders bash execution history as a process without a model', async () => {
     const entry: ExecutionListingEntry = {
       kind: 'run',
       identity: { kind: 'process', tool: 'bash' },
@@ -76,7 +76,7 @@ describe('tool status formatting', () => {
       outcome: 'completed',
     };
 
-    expect(formatListingLine(entry)).toBe(
+    await expect(formatListingLine(entry)).resolves.toBe(
       '16c0f3f748e4  2026-05-15 23:42:06  bash  process  [completed]  parent=fcf5150d37c6',
     );
   });

--- a/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
+++ b/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
@@ -76,8 +76,12 @@ describe('tool status formatting', () => {
       outcome: 'completed',
     };
 
+    // The status column no longer echoes the listing row's own `outcome`: it
+    // is read from the durable facts (lease, then metadata), and this fixture
+    // has no persisted run behind it. The columns under test are the `process`
+    // category and the suppressed model.
     await expect(formatListingLine(entry)).resolves.toBe(
-      '16c0f3f748e4  2026-05-15 23:42:06  bash  process  [completed]  parent=fcf5150d37c6',
+      '16c0f3f748e4  2026-05-15 23:42:06  bash  process  [unknown]  parent=fcf5150d37c6',
     );
   });
 });

--- a/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
+++ b/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
@@ -76,12 +76,11 @@ describe('tool status formatting', () => {
       outcome: 'completed',
     };
 
-    // The status column no longer echoes the listing row's own `outcome`: it
-    // is read from the durable facts (lease, then metadata), and this fixture
-    // has no persisted run behind it. The columns under test are the `process`
-    // category and the suppressed model.
+    // The row's own `outcome` is a recorded durable fact, so the status column
+    // shows it without re-reading the metadata file it came from. The other
+    // columns under test are the `process` category and the suppressed model.
     await expect(formatListingLine(entry)).resolves.toBe(
-      '16c0f3f748e4  2026-05-15 23:42:06  bash  process  [unknown]  parent=fcf5150d37c6',
+      '16c0f3f748e4  2026-05-15 23:42:06  bash  process  [completed]  parent=fcf5150d37c6',
     );
   });
 });

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -41,6 +41,7 @@ import {
   type WorkflowExecutionSnapshot,
 } from '@shared/schemas';
 import { BASH_BACKGROUND_LOG_CAP_CHARS } from '@shared/toolUse';
+import { isInFlightPhase } from '@shared/streams/streamStatus';
 import { warnAbandonedSlotValue } from '@shared/config/settingsAccess';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { assertNoParentTraversal } from '@tools/pathResolution';
@@ -430,7 +431,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       );
     }
     const category = executionDisplayCategory(identity, record);
-    const info = await getExecutionStatusInfo(executionId, meta?.outcome);
+    const info = await getExecutionStatusInfo(executionId);
     const lines = buildCompletedSummaryLines(
       executionId,
       record,
@@ -493,13 +494,17 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     );
   }
 
-  /** Fetch metas and format each child as a summary line. */
-  private async formatChildren(children: ChildRecord[]): Promise<string[]> {
-    const metas = await Promise.all(
-      children.map((c) => getExecutionStore(c.id).readMeta()),
-    );
-    return Promise.all(
-      children.map((child, i) => formatChildLine(child, metas[i])),
+  /**
+   * Fetch metas and format each child as a summary line. Bounded like the
+   * listing page: every child reads its own metadata and asks the durable
+   * owners about its run, so a wide fan-out is a wide burst of file I/O.
+   */
+  private formatChildren(children: ChildRecord[]): Promise<string[]> {
+    return pMap(
+      children,
+      async (child) =>
+        formatChildLine(child, await getExecutionStore(child.id).readMeta()),
+      { concurrency: 16 },
     );
   }
 
@@ -736,23 +741,29 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     const entries = await transcripts.readEntries(streamId);
 
     const { lines, chars } = projectProcessOutput(entries);
-    const liveness = await resolveExecutionLiveness(executionId, meta?.outcome);
-    const info = statusInfoFromLiveness(liveness, meta?.outcome);
+    const liveness = await resolveExecutionLiveness(executionId);
+    const info = statusInfoFromLiveness(liveness);
     // The footer states the same reading as the header: "no handle in this
-    // process" alone never justifies calling the command finished.
+    // process" alone never justifies calling the command finished, and a
+    // handle this process still tracks past its stream's terminal phase never
+    // justifies calling it still running.
     const retained = `this is the retained log; /executions/${executionId}/report has the result summary`;
     const footer = ((): string => {
       switch (liveness.kind) {
         case 'live':
-          return `[still running: re-read for more output, or use action='wait' on /executions/${executionId} to block until it finishes]`;
+          return isInFlightPhase(liveness.info.status)
+            ? `[still running: re-read for more output, or use action='wait' on /executions/${executionId} to block until it finishes]`
+            : `[${liveness.info.status}; ${retained}]`;
         case 'unsettled':
           return `[not running in this process (${liveness.reason}); ${retained}]`;
         case 'interrupted':
           return `[interrupted before finishing; ${retained}]`;
         case 'settled':
-          return meta?.outcome
+          // Nothing here can see a detached shell that outlived its owner, so
+          // this says only what the durable facts establish.
+          return liveness.outcome
             ? `[finished: ${retained}]`
-            : `[not running anywhere, and no result was recorded; ${retained}]`;
+            : `[no TeXRA process owns this execution and no result was recorded; ${retained}]`;
       }
     })();
     const out: string[] = [

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -70,6 +70,7 @@ import {
   formatTodoHeader,
   formatTodoSection,
   getExecutionStatusInfo,
+  statusInfoFromLiveness,
   executionDisplayCategory,
   shouldSuppressAutoDeliveredSubagentReport,
   type ExecutionDisplayCategory,
@@ -83,6 +84,7 @@ import {
 } from './formatting';
 import { serializeFilteredConfig } from './executions/configView';
 import { formatConversation } from './executions/conversationFormat';
+import { resolveExecutionLiveness } from './executions/executionLiveness';
 import { EXECUTION_PATH_LIST } from './executions/pathCatalog';
 import {
   OUTPUT_MAX_LINES,
@@ -708,8 +710,8 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     executionId: ExecutionId,
     viewRange?: [number, number],
   ): Promise<ToolResult> {
-    // A tracked handle is also the liveness fact: the shared terminal
-    // finalizer untracks it, so its presence means the command is still up.
+    // The handle names the live child stream; liveness itself is resolved
+    // below, from facts that outlive this process.
     const handle = currentSession().executions.getHandle(executionId);
     const meta = await getExecutionStore(executionId).readMeta();
     if (!meta && !handle) {
@@ -734,10 +736,25 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     const entries = await transcripts.readEntries(streamId);
 
     const { lines, chars } = projectProcessOutput(entries);
-    const info = await getExecutionStatusInfo(executionId, meta?.outcome);
-    const footer = handle
-      ? `[still running: re-read for more output, or use action='wait' on /executions/${executionId} to block until it finishes]`
-      : `[finished: this is the retained log; /executions/${executionId}/report has the result summary]`;
+    const liveness = await resolveExecutionLiveness(executionId, meta?.outcome);
+    const info = statusInfoFromLiveness(liveness, meta?.outcome);
+    // The footer states the same reading as the header: "no handle in this
+    // process" alone never justifies calling the command finished.
+    const retained = `this is the retained log; /executions/${executionId}/report has the result summary`;
+    const footer = ((): string => {
+      switch (liveness.kind) {
+        case 'live':
+          return `[still running: re-read for more output, or use action='wait' on /executions/${executionId} to block until it finishes]`;
+        case 'unsettled':
+          return `[not running in this process (${liveness.reason}); ${retained}]`;
+        case 'interrupted':
+          return `[interrupted before finishing; ${retained}]`;
+        case 'settled':
+          return meta?.outcome
+            ? `[finished: ${retained}]`
+            : `[not running anywhere, and no result was recorded; ${retained}]`;
+      }
+    })();
     const out: string[] = [
       `Output for ${executionId} (process, ${formatStatusInfo(info)}): ${chars.toLocaleString()} retained transcript chars; command-output cap ${BASH_BACKGROUND_LOG_CAP_CHARS.toLocaleString()} chars, ${lines.length.toLocaleString()} lines.`,
     ];

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -742,7 +742,10 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     const entries = await transcripts.readEntries(streamId);
 
     const { lines, chars } = projectProcessOutput(entries);
-    const liveness = await resolveExecutionLiveness(executionId, meta);
+    // No snapshot: `meta` was read before the transcript, and a command that
+    // finished during that read must not be judged against the row as it
+    // looked beforehand. One read of one execution can afford a fresh one.
+    const liveness = await resolveExecutionLiveness(executionId);
     const info = statusInfoFromLiveness(liveness);
     // The footer states the same reading as the header: "no handle in this
     // process" alone never justifies calling the command finished, and a

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -335,9 +335,9 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       offset,
       limit,
     );
-    // One page, not one directory: each line asks the durable owners about
-    // its run (a lease read, and a checkpoint stat when nothing terminalized
-    // it), so the fan-out is bounded rather than 200 wide.
+    // One page, not one directory: each line asks the durable facts about its
+    // run (a checkpoint stat, and a lease read only for a run that still has a
+    // checkpoint), so the fan-out is bounded rather than 200 wide.
     const lines = await pMap(page, (entry) => formatListingLine(entry), {
       concurrency: 16,
     });
@@ -431,7 +431,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       );
     }
     const category = executionDisplayCategory(identity, record);
-    const info = await getExecutionStatusInfo(executionId);
+    const info = await getExecutionStatusInfo(executionId, meta);
     const lines = buildCompletedSummaryLines(
       executionId,
       record,
@@ -496,8 +496,9 @@ Delegated subagent and workflow results are delivered automatically as follow-up
 
   /**
    * Fetch metas and format each child as a summary line. Bounded like the
-   * listing page: every child reads its own metadata and asks the durable
-   * owners about its run, so a wide fan-out is a wide burst of file I/O.
+   * listing page: every child reads its own metadata and, when that leaves the
+   * run unsettled, stats its checkpoint, so a wide fan-out is a wide burst of
+   * file I/O.
    */
   private formatChildren(children: ChildRecord[]): Promise<string[]> {
     return pMap(
@@ -741,7 +742,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     const entries = await transcripts.readEntries(streamId);
 
     const { lines, chars } = projectProcessOutput(entries);
-    const liveness = await resolveExecutionLiveness(executionId);
+    const liveness = await resolveExecutionLiveness(executionId, meta);
     const info = statusInfoFromLiveness(liveness);
     // The footer states the same reading as the header: "no handle in this
     // process" alone never justifies calling the command finished, and a

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -336,8 +336,9 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       limit,
     );
     // One page, not one directory: each line asks the durable facts about its
-    // run (a checkpoint stat, and a lease read only for a run that still has a
-    // checkpoint), so the fan-out is bounded rather than 200 wide.
+    // run (a lease read only for a row that recorded no outcome, and a
+    // checkpoint stat only when that lease turns out to be free), so the
+    // fan-out is bounded rather than 200 wide.
     const lines = await pMap(page, (entry) => formatListingLine(entry), {
       concurrency: 16,
     });
@@ -496,9 +497,9 @@ Delegated subagent and workflow results are delivered automatically as follow-up
 
   /**
    * Fetch metas and format each child as a summary line. Bounded like the
-   * listing page: every child reads its own metadata and, when that leaves the
-   * run unsettled, stats its checkpoint, so a wide fan-out is a wide burst of
-   * file I/O.
+   * listing page: every child reads its own metadata and, when that row
+   * recorded no outcome, its execution lease — statting the checkpoint only
+   * when that lease is free — so a wide fan-out is a wide burst of file I/O.
    */
   private formatChildren(children: ChildRecord[]): Promise<string[]> {
     return pMap(

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -5,6 +5,9 @@
  * executions.
  */
 
+// Third-party imports
+import pMap from 'p-map';
+
 // Local imports
 import {
   deriveResumability,
@@ -329,7 +332,12 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       offset,
       limit,
     );
-    const lines = page.map(formatListingLine);
+    // One page, not one directory: each line asks the durable owners about
+    // its run (a lease read, and a checkpoint stat when nothing terminalized
+    // it), so the fan-out is bounded rather than 200 wide.
+    const lines = await pMap(page, (entry) => formatListingLine(entry), {
+      concurrency: 16,
+    });
 
     return executed(
       `Executions (showing ${start}–${end} of ${total}, most recent first):\n\n${lines.join('\n')}${formatPaginationHint(end, total)}`,
@@ -420,7 +428,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       );
     }
     const category = executionDisplayCategory(identity, record);
-    const info = getExecutionStatusInfo(executionId, meta?.outcome);
+    const info = await getExecutionStatusInfo(executionId, meta?.outcome);
     const lines = buildCompletedSummaryLines(
       executionId,
       record,
@@ -488,7 +496,9 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     const metas = await Promise.all(
       children.map((c) => getExecutionStore(c.id).readMeta()),
     );
-    return children.map((child, i) => formatChildLine(child, metas[i]));
+    return Promise.all(
+      children.map((child, i) => formatChildLine(child, metas[i])),
+    );
   }
 
   private handleKill(executionId: ExecutionId): ToolResult {
@@ -724,7 +734,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     const entries = await transcripts.readEntries(streamId);
 
     const { lines, chars } = projectProcessOutput(entries);
-    const info = getExecutionStatusInfo(executionId, meta?.outcome);
+    const info = await getExecutionStatusInfo(executionId, meta?.outcome);
     const footer = handle
       ? `[still running: re-read for more output, or use action='wait' on /executions/${executionId} to block until it finishes]`
       : `[finished: this is the retained log; /executions/${executionId}/report has the result summary]`;

--- a/src/tools/executionFormatters.ts
+++ b/src/tools/executionFormatters.ts
@@ -169,7 +169,10 @@ export function statusInfoFromLiveness(
       return {
         status: RUN_OUTCOME.CANCELLED,
         elapsed: null,
-        detail: 'interrupted; a resume checkpoint remains',
+        // Presence-only: the listing decided this from a stat, which cannot
+        // tell a resumable checkpoint from a spent or malformed flow record.
+        // Only the single-run paths that parse it may promise a resume.
+        detail: 'interrupted; a flow record remains (not validated here)',
       };
     case 'settled':
       return { status: liveness.outcome ?? 'unknown', elapsed: null };

--- a/src/tools/executionFormatters.ts
+++ b/src/tools/executionFormatters.ts
@@ -31,7 +31,10 @@ import type {
 import { runIdentityName, RUN_OUTCOME, STATUS_DISPLAY } from '@shared/schemas';
 import { formatTimestamp } from '@utils/text/stringUtils';
 
-import { resolveExecutionLiveness } from './executions/executionLiveness';
+import {
+  resolveExecutionLiveness,
+  type ExecutionLiveness,
+} from './executions/executionLiveness';
 
 /**
  * The display category of a run: an agent run shows its execution mode
@@ -139,7 +142,20 @@ export async function getExecutionStatusInfo(
   executionId: string,
   outcome?: RunOutcome,
 ): Promise<ExecutionStatusInfo> {
-  const liveness = await resolveExecutionLiveness(executionId, outcome);
+  return statusInfoFromLiveness(
+    await resolveExecutionLiveness(executionId, outcome),
+    outcome,
+  );
+}
+
+/**
+ * The same reading for a caller that already resolved the liveness and needs
+ * the arm itself (to word a footer, say) as well as the status line.
+ */
+export function statusInfoFromLiveness(
+  liveness: ExecutionLiveness,
+  outcome?: RunOutcome,
+): ExecutionStatusInfo {
   switch (liveness.kind) {
     case 'live':
       return liveness.info;

--- a/src/tools/executionFormatters.ts
+++ b/src/tools/executionFormatters.ts
@@ -2,8 +2,9 @@
  * The one display model for the /executions surface: the listing lines, the
  * /executions/{id} summary line sets, and the predicates both answer their
  * questions with — what a run's display category is, whether it shows a model,
- * and which sub-paths it serves. Pure formatting, no I/O, so `listExecutions`
- * and `showSummary` only fetch and delegate here.
+ * and which sub-paths it serves. Formatting only: the one exception is the
+ * status reading, which asks `resolveExecutionLiveness` for the durable
+ * ownership facts a missing in-process handle cannot supply.
  */
 
 import type { ChildRecord, ExecutionListingEntry } from '@agent/storage';
@@ -19,7 +20,6 @@ import type {
   AgentExecutionHandle,
   ExecutionStatusInfo,
 } from '@agent/runtime/ExecutionHandle';
-import { currentSession } from '@agent/runtime/SessionHandle';
 import type {
   AgentCategory,
   ExecutionId,
@@ -28,8 +28,10 @@ import type {
   RunOutcome,
   TodoItem,
 } from '@shared/schemas';
-import { runIdentityName, STATUS_DISPLAY } from '@shared/schemas';
+import { runIdentityName, RUN_OUTCOME, STATUS_DISPLAY } from '@shared/schemas';
 import { formatTimestamp } from '@utils/text/stringUtils';
+
+import { resolveExecutionLiveness } from './executions/executionLiveness';
 
 /**
  * The display category of a run: an agent run shows its execution mode
@@ -119,26 +121,47 @@ function getAvailablePaths(
 
 /** Format status info as a display string. */
 export function formatStatusInfo(info: ExecutionStatusInfo): string {
-  return info.elapsed
+  const base = info.elapsed
     ? `${info.status} (${info.elapsed} elapsed)`
     : info.status;
+  return info.detail ? `${base}: ${info.detail}` : base;
 }
 
-/** Resolve the runtime status for an execution ID: live phase, else the persisted outcome. */
-export function getExecutionStatusInfo(
+/**
+ * The runtime status for an execution ID, from `resolveExecutionLiveness`:
+ * a live handle's phase, else the fact that forbids a terminal reading, else
+ * `cancelled` for an interrupted run, else the persisted outcome.
+ *
+ * A run nothing alive owns and nothing terminalized reads `unknown`, never a
+ * terminal outcome invented from the absence of a handle in this process.
+ */
+export async function getExecutionStatusInfo(
   executionId: string,
   outcome?: RunOutcome,
-): ExecutionStatusInfo {
-  const session = currentSession();
-  const handle = session.executions.getHandle(executionId);
-  if (handle) return session.executions.getStatus(handle);
-  return { status: outcome ?? 'unknown', elapsed: null };
+): Promise<ExecutionStatusInfo> {
+  const liveness = await resolveExecutionLiveness(executionId, outcome);
+  switch (liveness.kind) {
+    case 'live':
+      return liveness.info;
+    case 'unsettled':
+      return { status: 'unknown', elapsed: null, detail: liveness.reason };
+    case 'interrupted':
+      return {
+        status: RUN_OUTCOME.CANCELLED,
+        elapsed: null,
+        detail: 'interrupted; a resume checkpoint remains',
+      };
+    case 'settled':
+      return { status: outcome ?? 'unknown', elapsed: null };
+  }
 }
 
 /** Format a listing entry as a single summary line. */
-export function formatListingLine(entry: ExecutionListingEntry): string {
+export async function formatListingLine(
+  entry: ExecutionListingEntry,
+): Promise<string> {
   const ts = formatTimestamp(entry.timestamp);
-  const info = getExecutionStatusInfo(entry.id, entry.outcome);
+  const info = await getExecutionStatusInfo(entry.id, entry.outcome);
   const { agent, model, category } = listingDisplay(entry);
   const categoryTag = category ? `  ${category}` : '';
   const modelTag = model == null ? '' : `  ${model}`;
@@ -194,11 +217,11 @@ export function shouldSuppressAutoDeliveredSubagentReport(
 }
 
 /** Format a single child execution as a summary line. */
-export function formatChildLine(
+export async function formatChildLine(
   child: ChildRecord,
   childMeta: ExecutionMeta | null | undefined,
-): string {
-  const info = getExecutionStatusInfo(child.id, childMeta?.outcome);
+): Promise<string> {
+  const info = await getExecutionStatusInfo(child.id, childMeta?.outcome);
   const ts = formatTimestamp(child.timestamp);
   const desc = childMeta?.description ? `: ${childMeta.description}` : '';
   return `${child.id}  ${ts}  ${child.agent}  [${formatStatusInfo(info)}]${desc}`;

--- a/src/tools/executionFormatters.ts
+++ b/src/tools/executionFormatters.ts
@@ -30,6 +30,7 @@ import type {
 import { runIdentityName, RUN_OUTCOME, STATUS_DISPLAY } from '@shared/schemas';
 import { formatTimestamp } from '@utils/text/stringUtils';
 
+// Local imports - liveness
 import {
   resolveExecutionLiveness,
   type ExecutionLiveness,

--- a/src/tools/executionFormatters.ts
+++ b/src/tools/executionFormatters.ts
@@ -33,6 +33,7 @@ import { formatTimestamp } from '@utils/text/stringUtils';
 import {
   resolveExecutionLiveness,
   type ExecutionLiveness,
+  type KnownExecutionMeta,
 } from './executions/executionLiveness';
 
 /**
@@ -131,20 +132,25 @@ export function formatStatusInfo(info: ExecutionStatusInfo): string {
 
 /**
  * The runtime status for an execution ID, from `resolveExecutionLiveness`:
- * a live handle's phase, else the fact that forbids a terminal reading, else
- * `cancelled` for an interrupted run, else the outcome the classifier read.
+ * a live handle's phase, else the recorded outcome, else the fact that forbids
+ * a terminal reading, else `cancelled` for an interrupted run.
  *
- * The outcome is never passed in: a caller's snapshot can be older than the
- * facts the classifier just read, and two surfaces reading the same run must
- * not disagree about how it ended.
+ * `knownMeta` is the metadata row the caller just read for this same request
+ * (`null` when it read one and found none), so a listing row does not pay a
+ * second read of the file it was built from. Omitting it means "I have no
+ * row", and the liveness resolver reads one. Never pass an older snapshot: two
+ * surfaces reading the same run must not disagree about how it ended.
  *
  * A run nothing alive owns and nothing terminalized reads `unknown`, never a
  * terminal outcome invented from the absence of a handle in this process.
  */
 export async function getExecutionStatusInfo(
-  executionId: string,
+  executionId: ExecutionId,
+  knownMeta?: KnownExecutionMeta,
 ): Promise<ExecutionStatusInfo> {
-  return statusInfoFromLiveness(await resolveExecutionLiveness(executionId));
+  return statusInfoFromLiveness(
+    await resolveExecutionLiveness(executionId, knownMeta),
+  );
 }
 
 /**
@@ -175,7 +181,11 @@ export async function formatListingLine(
   entry: ExecutionListingEntry,
 ): Promise<string> {
   const ts = formatTimestamp(entry.timestamp);
-  const info = await getExecutionStatusInfo(entry.id);
+  // The row was built from this execution's metadata, outcome included, so the
+  // status reading reuses it instead of reading the same file again.
+  const info = await getExecutionStatusInfo(entry.id, {
+    outcome: entry.outcome,
+  });
   const { agent, model, category } = listingDisplay(entry);
   const categoryTag = category ? `  ${category}` : '';
   const modelTag = model == null ? '' : `  ${model}`;
@@ -235,7 +245,7 @@ export async function formatChildLine(
   child: ChildRecord,
   childMeta: ExecutionMeta | null | undefined,
 ): Promise<string> {
-  const info = await getExecutionStatusInfo(child.id);
+  const info = await getExecutionStatusInfo(child.id, childMeta ?? null);
   const ts = formatTimestamp(child.timestamp);
   const desc = childMeta?.description ? `: ${childMeta.description}` : '';
   return `${child.id}  ${ts}  ${child.agent}  [${formatStatusInfo(info)}]${desc}`;

--- a/src/tools/executionFormatters.ts
+++ b/src/tools/executionFormatters.ts
@@ -25,7 +25,6 @@ import type {
   ExecutionId,
   ExecutionMeta,
   RunIdentity,
-  RunOutcome,
   TodoItem,
 } from '@shared/schemas';
 import { runIdentityName, RUN_OUTCOME, STATUS_DISPLAY } from '@shared/schemas';
@@ -133,19 +132,19 @@ export function formatStatusInfo(info: ExecutionStatusInfo): string {
 /**
  * The runtime status for an execution ID, from `resolveExecutionLiveness`:
  * a live handle's phase, else the fact that forbids a terminal reading, else
- * `cancelled` for an interrupted run, else the persisted outcome.
+ * `cancelled` for an interrupted run, else the outcome the classifier read.
+ *
+ * The outcome is never passed in: a caller's snapshot can be older than the
+ * facts the classifier just read, and two surfaces reading the same run must
+ * not disagree about how it ended.
  *
  * A run nothing alive owns and nothing terminalized reads `unknown`, never a
  * terminal outcome invented from the absence of a handle in this process.
  */
 export async function getExecutionStatusInfo(
   executionId: string,
-  outcome?: RunOutcome,
 ): Promise<ExecutionStatusInfo> {
-  return statusInfoFromLiveness(
-    await resolveExecutionLiveness(executionId, outcome),
-    outcome,
-  );
+  return statusInfoFromLiveness(await resolveExecutionLiveness(executionId));
 }
 
 /**
@@ -154,7 +153,6 @@ export async function getExecutionStatusInfo(
  */
 export function statusInfoFromLiveness(
   liveness: ExecutionLiveness,
-  outcome?: RunOutcome,
 ): ExecutionStatusInfo {
   switch (liveness.kind) {
     case 'live':
@@ -168,7 +166,7 @@ export function statusInfoFromLiveness(
         detail: 'interrupted; a resume checkpoint remains',
       };
     case 'settled':
-      return { status: outcome ?? 'unknown', elapsed: null };
+      return { status: liveness.outcome ?? 'unknown', elapsed: null };
   }
 }
 
@@ -177,7 +175,7 @@ export async function formatListingLine(
   entry: ExecutionListingEntry,
 ): Promise<string> {
   const ts = formatTimestamp(entry.timestamp);
-  const info = await getExecutionStatusInfo(entry.id, entry.outcome);
+  const info = await getExecutionStatusInfo(entry.id);
   const { agent, model, category } = listingDisplay(entry);
   const categoryTag = category ? `  ${category}` : '';
   const modelTag = model == null ? '' : `  ${model}`;
@@ -237,7 +235,7 @@ export async function formatChildLine(
   child: ChildRecord,
   childMeta: ExecutionMeta | null | undefined,
 ): Promise<string> {
-  const info = await getExecutionStatusInfo(child.id, childMeta?.outcome);
+  const info = await getExecutionStatusInfo(child.id);
   const ts = formatTimestamp(child.timestamp);
   const desc = childMeta?.description ? `: ${childMeta.description}` : '';
   return `${child.id}  ${ts}  ${child.agent}  [${formatStatusInfo(info)}]${desc}`;

--- a/src/tools/executions/executionLiveness.ts
+++ b/src/tools/executions/executionLiveness.ts
@@ -11,8 +11,8 @@
  *
  * 1. a handle in this process — the registry's phase is the live truth;
  * 2. `classifyRun` names a live foreign owner, names this process's own lease
- *    with no run behind it, or cannot read the run's facts at all — nothing
- *    terminal may be claimed, and the reason is shown;
+ *    with no run behind it and no outcome written, or cannot read the run's
+ *    facts at all — nothing terminal may be claimed, and the reason is shown;
  * 3. `classifyRun` finds a resumable checkpoint and read no outcome — the run
  *    was interrupted (a crash, or a host that quit);
  * 4. otherwise the outcome `classifyRun` read, or "unknown" when there is none.
@@ -31,7 +31,10 @@
 
 import { currentSession } from '@agent/runtime/SessionHandle';
 import type { ExecutionStatusInfo } from '@agent/runtime/ExecutionHandle';
-import { classifyRun } from '@agent/runtime/runClassification';
+import {
+  classifyRun,
+  classifyRunFacts,
+} from '@agent/runtime/runClassification';
 import {
   inspectExecutionLease,
   type ExecutionLeasePresence,
@@ -68,8 +71,9 @@ function heldElsewhereReason(owner: LeaseOwnerRecord): string {
 }
 
 /**
- * This process holds the lease but tracks no run for it: the registry and the
- * lease disagree, which is a leak to report, never a run to call settled.
+ * This process holds the lease, tracks no run for it, and no outcome was ever
+ * written: the registry and the lease disagree with nothing durable to fall
+ * back on, which is a leak to report, never a run to call settled.
  */
 const OWNED_HERE_REASON = "held by this process's lease with no live run";
 
@@ -128,11 +132,24 @@ export async function resolveExecutionLiveness(
         kind: 'unsettled',
         reason: heldElsewhereReason(classification.owner),
       };
-    case 'owned_here':
+    case 'owned_here': {
+      // The lease outlives the run it guarded: `finalizeRunTerminal` writes
+      // the outcome and untracks the handle, while the child loop releases
+      // the lease only after the wake it hands the parent returns — a window
+      // that can span the resumed parent's whole turn (#8093), i.e. exactly
+      // the turn in which the parent is told the run finished and reads its
+      // output. An outcome already on disk is the run's own fact, not the
+      // lease's, so it still settles; only a lease with nothing durable
+      // behind it is the registry/lease leak this arm reports.
+      const facts = await classifyRunFacts(executionId);
+      if (facts.kind !== 'unclassified' && facts.outcome !== undefined) {
+        return { kind: 'settled', outcome: facts.outcome };
+      }
       log.warn(
-        `Execution ${executionId} holds this process's lease with no tracked run; reporting it as unsettled rather than finished`,
+        `Execution ${executionId} holds this process's lease with no tracked run and no recorded outcome; reporting it as unsettled rather than finished`,
       );
       return { kind: 'unsettled', reason: OWNED_HERE_REASON };
+    }
     case 'unclassified':
       return {
         kind: 'unsettled',

--- a/src/tools/executions/executionLiveness.ts
+++ b/src/tools/executions/executionLiveness.ts
@@ -10,24 +10,24 @@
  * alive claims the run:
  *
  * 1. a handle in this process — the registry's phase is the live truth;
- * 2. the execution lease names a live foreign owner, or cannot be read at
- *    all — nothing terminal may be claimed, and the reason is shown;
- * 3. the lease is free, no outcome was recorded, and a resume checkpoint is
- *    still on disk — the run was interrupted (a crash, or a host that quit);
+ * 2. `classifyRun` names a live foreign owner, or cannot read the run's
+ *    facts at all — nothing terminal may be claimed, and the reason is shown;
+ * 3. `classifyRun` finds a resumable checkpoint and no outcome was recorded —
+ *    the run was interrupted (a crash, or a host that quit);
  * 4. otherwise the persisted outcome, or "unknown" when there is none.
+ *
+ * Ownership and checkpoint validity are not re-derived here: `classifyRun`
+ * is the one classifier of those durable facts, and it is deliberately
+ * stricter than a file-presence stat — a spent cursor, a malformed record,
+ * or one written by a newer TeXRA is `unclassified`, never a checkpoint to
+ * promise the caller.
  */
 
 import { currentSession } from '@agent/runtime/SessionHandle';
 import type { ExecutionStatusInfo } from '@agent/runtime/ExecutionHandle';
-import { flowKey } from '@agent/node/persistedFlow';
-import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
-import { inspectExecutionLease } from '@agent/storage/executionLease';
+import { classifyRun } from '@agent/runtime/runClassification';
 import type { LeaseOwnerRecord } from '@agent/storage/leaseOwnerLiveness';
-import { createLog } from '@logger/logUtils';
 import type { ExecutionId, RunOutcome } from '@shared/schemas';
-import { toErrorMessage } from '@utils/errors/errorMessage';
-
-const log = createLog('ExecutionLiveness');
 
 /**
  * What may be said about a run right now. `unsettled` carries a mid-sentence
@@ -53,30 +53,28 @@ export async function resolveExecutionLiveness(
   const handle = executions.getHandle(executionId);
   if (handle) return { kind: 'live', info: executions.getStatus(handle) };
 
-  try {
-    const lease = await inspectExecutionLease(executionId);
-    if (lease.status === 'held') {
-      return { kind: 'unsettled', reason: heldElsewhereReason(lease.owner) };
-    }
-    if (lease.status === 'free' && outcome === undefined) {
-      // A checkpoint with no outcome and no owner is a run that stopped
-      // without finishing: the same reading restart repair used to write.
-      const checkpointPresent = await getExecutionStore(executionId).exists(
-        flowKey(executionId),
-      );
-      if (checkpointPresent) return { kind: 'interrupted' };
-    }
-  } catch (error) {
-    const cause = toErrorMessage(error);
-    log.warn(
-      `Execution ${executionId}: ownership could not be read (${cause}); reporting it as unsettled rather than finished`,
-      { data: error },
-    );
-    return {
-      kind: 'unsettled',
-      reason: `owned by a process this one cannot identify (${cause})`,
-    };
+  // `classifyRun` never throws: an unreadable lease, metadata, or checkpoint
+  // arrives as `unclassified` with its cause.
+  const classification = await classifyRun(executionId);
+  switch (classification.kind) {
+    case 'held_elsewhere':
+      return {
+        kind: 'unsettled',
+        reason: heldElsewhereReason(classification.owner),
+      };
+    case 'unclassified':
+      return {
+        kind: 'unsettled',
+        reason: `in a state this process cannot read (${classification.cause})`,
+      };
+    case 'resumable':
+      // A valid checkpoint with no outcome and no live owner is a run that
+      // stopped without finishing.
+      return outcome === undefined
+        ? { kind: 'interrupted' }
+        : { kind: 'settled' };
+    case 'owned_here':
+    case 'finished':
+      return { kind: 'settled' };
   }
-
-  return { kind: 'settled' };
 }

--- a/src/tools/executions/executionLiveness.ts
+++ b/src/tools/executions/executionLiveness.ts
@@ -5,43 +5,48 @@
  * launched, one another TeXRA process owns, and one whose owner crashed all
  * look identical from the registry, so a missing handle (or a missing
  * `meta.outcome`) can never on its own justify telling a model that a run
- * finished — or that it is still running. The order below asks the durable
- * owners first and only falls back to the persisted reading once nothing
- * alive claims the run:
+ * finished — or that it is still running. The ladder below asks the cheapest
+ * durable fact that can decide the question, and stops there:
  *
  * 1. a handle in this process — the registry's phase is the live truth;
- * 2. `classifyRun` names a live foreign owner, names this process's own lease
- *    with no run behind it and no outcome written, or cannot read the run's
- *    facts at all — nothing terminal may be claimed, and the reason is shown;
- * 3. `classifyRun` finds a resumable checkpoint and read no outcome — the run
- *    was interrupted (a crash, or a host that quit);
- * 4. otherwise the outcome `classifyRun` read, or "unknown" when there is none.
+ * 2. a persisted `meta.outcome` — the run recorded how it ended, which is its
+ *    own durable fact and outranks a lease this process is merely slow to
+ *    release (#8093);
+ * 3. no checkpoint on disk — nothing is left to continue and nothing recorded
+ *    an outcome, so the reading is settled with none ("unknown");
+ * 4. a checkpoint whose lease a live foreign owner holds, or whose lease this
+ *    process holds with no run behind it — nothing terminal may be claimed,
+ *    and the reason is shown;
+ * 5. a checkpoint nobody holds — the run was interrupted (a crash, or a host
+ *    that quit).
  *
- * The terminal readings (3 and 4) come from the classifier's own fresh read of
- * the durable facts, never from an outcome snapshot the caller took earlier,
- * and each re-checks the lease once before it is returned (see
- * {@link leaseTakenSince}).
+ * The cost is the point: the /executions listing walks this once per row, so
+ * it must stay at one metadata read (skipped entirely when the caller already
+ * holds the row), one `exists` stat, and — only for a run that still has a
+ * checkpoint — one lease read.
  *
- * Ownership and checkpoint validity are not re-derived here: `classifyRun`
- * is the one classifier of those durable facts, and it is deliberately
- * stricter than a file-presence stat — a spent cursor, a malformed record,
- * or one written by a newer TeXRA is `unclassified`, never a checkpoint to
- * promise the caller.
+ * Checkpoint *validity* is therefore deliberately not re-derived here.
+ * `deriveResumability` parses the record and is stricter than a stat (a spent
+ * cursor, a malformed record, or one written by a newer TeXRA is not a
+ * checkpoint to promise anyone), but parsing 200 flow records to fill a status
+ * column is exactly the cost this surface must not pay. A malformed checkpoint
+ * consequently reads as interrupted here; the single-run paths that would act
+ * on one (resume, restart repair) parse it and refuse loudly.
  */
 
+import { flowKey } from '@agent/node/persistedFlow';
 import { currentSession } from '@agent/runtime/SessionHandle';
 import type { ExecutionStatusInfo } from '@agent/runtime/ExecutionHandle';
-import {
-  classifyRun,
-  classifyRunFacts,
-} from '@agent/runtime/runClassification';
-import {
-  inspectExecutionLease,
-  type ExecutionLeasePresence,
-} from '@agent/storage/executionLease';
+import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
+import { inspectExecutionLease } from '@agent/storage/executionLease';
 import type { LeaseOwnerRecord } from '@agent/storage/leaseOwnerLiveness';
 import { createLog } from '@logger/logUtils';
-import type { ExecutionId, RunOutcome, StreamPhase } from '@shared/schemas';
+import type {
+  ExecutionId,
+  ExecutionMeta,
+  RunOutcome,
+  StreamPhase,
+} from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const log = createLog('ExecutionLiveness');
@@ -49,8 +54,8 @@ const log = createLog('ExecutionLiveness');
 /**
  * What may be said about a run right now. `unsettled` carries a mid-sentence
  * clause naming the fact that forbids a terminal reading, so each surface can
- * word it in its own voice. `settled` carries the outcome the classifier read,
- * so every surface renders the same durable value.
+ * word it in its own voice. `settled` carries the recorded outcome, so every
+ * surface renders the same durable value.
  */
 export type ExecutionLiveness =
   | { readonly kind: 'live'; readonly info: LiveExecutionStatusInfo }
@@ -65,6 +70,17 @@ export type ExecutionLiveness =
  */
 type LiveExecutionStatusInfo = ExecutionStatusInfo & { status: StreamPhase };
 
+/**
+ * The execution's metadata row as a caller that just read it holds it: `null`
+ * when the read found none. `undefined` (the argument omitted) means the
+ * caller has none and this module reads it, so "row present without an
+ * outcome" never costs a second read.
+ *
+ * Only a row read for this same request may be passed: an older snapshot would
+ * let two surfaces disagree about how one run ended.
+ */
+export type KnownExecutionMeta = Pick<ExecutionMeta, 'outcome'> | null;
+
 /** `executionHeldMessage`'s copy, as a clause a sentence can continue with. */
 function heldElsewhereReason(owner: LeaseOwnerRecord): string {
   return `held by another TeXRA process (pid ${owner.pid} on ${owner.hostname})`;
@@ -77,94 +93,49 @@ function heldElsewhereReason(owner: LeaseOwnerRecord): string {
  */
 const OWNED_HERE_REASON = "held by this process's lease with no live run";
 
-function unreadableReason(cause: string): string {
-  return `in a state this process cannot read (${cause})`;
-}
-
-/** The unsettled arm a non-free lease forces, or undefined when it is free. */
-function unsettledFromLease(
-  lease: ExecutionLeasePresence,
-): ExecutionLiveness | undefined {
-  if (lease.status === 'held') {
-    return { kind: 'unsettled', reason: heldElsewhereReason(lease.owner) };
-  }
-  if (lease.status === 'owned') {
-    return { kind: 'unsettled', reason: OWNED_HERE_REASON };
-  }
-  return undefined;
-}
-
-/**
- * Whether an owner took the lease while the classification was being read.
- *
- * `classifyRun` reads the lease, then the metadata, then the checkpoint; a
- * process that started (or resumed) the run across those awaits would leave a
- * terminal reading that is already stale. Costs one extra lease read per row
- * that reaches a terminal claim — the listing's other rows never pay it.
- */
-async function leaseTakenSince(
-  executionId: ExecutionId,
-): Promise<ExecutionLiveness | undefined> {
-  try {
-    return unsettledFromLease(await inspectExecutionLease(executionId));
-  } catch (error) {
-    const cause = `lease unreadable (${toErrorMessage(error)})`;
-    log.warn(`Cannot re-check the lease for ${executionId}: ${cause}`, {
-      data: error,
-    });
-    return { kind: 'unsettled', reason: unreadableReason(cause) };
-  }
-}
-
 export async function resolveExecutionLiveness(
   executionId: ExecutionId,
+  knownMeta?: KnownExecutionMeta,
 ): Promise<ExecutionLiveness> {
   const { executions } = currentSession();
   const handle = executions.getHandle(executionId);
   if (handle) return { kind: 'live', info: executions.getStatus(handle) };
 
-  // `classifyRun` never throws: an unreadable lease, metadata, or checkpoint
-  // arrives as `unclassified` with its cause.
-  const classification = await classifyRun(executionId);
-  switch (classification.kind) {
-    case 'held_elsewhere':
-      return {
-        kind: 'unsettled',
-        reason: heldElsewhereReason(classification.owner),
-      };
-    case 'owned_here': {
-      // The lease outlives the run it guarded: `finalizeRunTerminal` writes
-      // the outcome and untracks the handle, while the child loop releases
-      // the lease only after the wake it hands the parent returns — a window
-      // that can span the resumed parent's whole turn (#8093), i.e. exactly
-      // the turn in which the parent is told the run finished and reads its
-      // output. An outcome already on disk is the run's own fact, not the
-      // lease's, so it still settles; only a lease with nothing durable
-      // behind it is the registry/lease leak this arm reports.
-      const facts = await classifyRunFacts(executionId);
-      if (facts.kind !== 'unclassified' && facts.outcome !== undefined) {
-        return { kind: 'settled', outcome: facts.outcome };
-      }
+  const store = getExecutionStore(executionId);
+  try {
+    const meta = knownMeta === undefined ? await store.readMeta() : knownMeta;
+    // A recorded outcome is the run's own fact, not the lease's: a finished
+    // child untracks its handle and writes the outcome long before its loop
+    // releases the execution lease, and the parent reads the run inside
+    // exactly that window (#8093).
+    if (meta?.outcome !== undefined) {
+      return { kind: 'settled', outcome: meta.outcome };
+    }
+    if (!(await store.exists(flowKey(executionId)))) {
+      return { kind: 'settled' };
+    }
+    const lease = await inspectExecutionLease(executionId);
+    if (lease.status === 'held') {
+      return { kind: 'unsettled', reason: heldElsewhereReason(lease.owner) };
+    }
+    if (lease.status === 'owned') {
       log.warn(
         `Execution ${executionId} holds this process's lease with no tracked run and no recorded outcome; reporting it as unsettled rather than finished`,
       );
       return { kind: 'unsettled', reason: OWNED_HERE_REASON };
     }
-    case 'unclassified':
-      return {
-        kind: 'unsettled',
-        reason: unreadableReason(classification.cause),
-      };
-    case 'resumable':
-    case 'finished': {
-      const taken = await leaseTakenSince(executionId);
-      if (taken) return taken;
-      // A valid checkpoint with no outcome and no live owner is a run that
-      // stopped without finishing.
-      return classification.kind === 'resumable' &&
-        classification.outcome === undefined
-        ? { kind: 'interrupted' }
-        : { kind: 'settled', outcome: classification.outcome };
-    }
+    // A checkpoint with no outcome and no live owner is a run that stopped
+    // without finishing.
+    return { kind: 'interrupted' };
+  } catch (error) {
+    const cause = toErrorMessage(error);
+    log.warn(
+      `Cannot read the durable facts for execution ${executionId}: ${cause}`,
+      { data: error },
+    );
+    return {
+      kind: 'unsettled',
+      reason: `in a state this process cannot read (${cause})`,
+    };
   }
 }

--- a/src/tools/executions/executionLiveness.ts
+++ b/src/tools/executions/executionLiveness.ts
@@ -1,0 +1,82 @@
+/**
+ * Whether a run is still going, decided from facts that outlive this process.
+ *
+ * "No handle in this process" is not liveness. A run this shell never
+ * launched, one another TeXRA process owns, and one whose owner crashed all
+ * look identical from the registry, so a missing handle (or a missing
+ * `meta.outcome`) can never on its own justify telling a model that a run
+ * finished — or that it is still running. The order below asks the durable
+ * owners first and only falls back to the persisted reading once nothing
+ * alive claims the run:
+ *
+ * 1. a handle in this process — the registry's phase is the live truth;
+ * 2. the execution lease names a live foreign owner, or cannot be read at
+ *    all — nothing terminal may be claimed, and the reason is shown;
+ * 3. the lease is free, no outcome was recorded, and a resume checkpoint is
+ *    still on disk — the run was interrupted (a crash, or a host that quit);
+ * 4. otherwise the persisted outcome, or "unknown" when there is none.
+ */
+
+import { currentSession } from '@agent/runtime/SessionHandle';
+import type { ExecutionStatusInfo } from '@agent/runtime/ExecutionHandle';
+import { flowKey } from '@agent/node/persistedFlow';
+import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
+import { inspectExecutionLease } from '@agent/storage/executionLease';
+import type { LeaseOwnerRecord } from '@agent/storage/leaseOwnerLiveness';
+import { createLog } from '@logger/logUtils';
+import type { ExecutionId, RunOutcome } from '@shared/schemas';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+
+const log = createLog('ExecutionLiveness');
+
+/**
+ * What may be said about a run right now. `unsettled` carries a mid-sentence
+ * clause naming the fact that forbids a terminal reading, so each surface can
+ * word it in its own voice.
+ */
+export type ExecutionLiveness =
+  | { readonly kind: 'live'; readonly info: ExecutionStatusInfo }
+  | { readonly kind: 'unsettled'; readonly reason: string }
+  | { readonly kind: 'interrupted' }
+  | { readonly kind: 'settled' };
+
+/** `executionHeldMessage`'s copy, as a clause a sentence can continue with. */
+function heldElsewhereReason(owner: LeaseOwnerRecord): string {
+  return `held by another TeXRA process (pid ${owner.pid} on ${owner.hostname})`;
+}
+
+export async function resolveExecutionLiveness(
+  executionId: ExecutionId,
+  outcome: RunOutcome | undefined,
+): Promise<ExecutionLiveness> {
+  const { executions } = currentSession();
+  const handle = executions.getHandle(executionId);
+  if (handle) return { kind: 'live', info: executions.getStatus(handle) };
+
+  try {
+    const lease = await inspectExecutionLease(executionId);
+    if (lease.status === 'held') {
+      return { kind: 'unsettled', reason: heldElsewhereReason(lease.owner) };
+    }
+    if (lease.status === 'free' && outcome === undefined) {
+      // A checkpoint with no outcome and no owner is a run that stopped
+      // without finishing: the same reading restart repair used to write.
+      const checkpointPresent = await getExecutionStore(executionId).exists(
+        flowKey(executionId),
+      );
+      if (checkpointPresent) return { kind: 'interrupted' };
+    }
+  } catch (error) {
+    const cause = toErrorMessage(error);
+    log.warn(
+      `Execution ${executionId}: ownership could not be read (${cause}); reporting it as unsettled rather than finished`,
+      { data: error },
+    );
+    return {
+      kind: 'unsettled',
+      reason: `owned by a process this one cannot identify (${cause})`,
+    };
+  }
+
+  return { kind: 'settled' };
+}

--- a/src/tools/executions/executionLiveness.ts
+++ b/src/tools/executions/executionLiveness.ts
@@ -12,18 +12,24 @@
  * 2. a persisted `meta.outcome` — the run recorded how it ended, which is its
  *    own durable fact and outranks a lease this process is merely slow to
  *    release (#8093);
- * 3. no checkpoint on disk — nothing is left to continue and nothing recorded
+ * 3. a lease a live foreign owner holds, or one this process holds with no run
+ *    behind it — nothing terminal may be claimed, and the reason is shown;
+ * 4. no checkpoint on disk — nothing is left to continue and nothing recorded
  *    an outcome, so the reading is settled with none ("unknown");
- * 4. a checkpoint whose lease a live foreign owner holds, or whose lease this
- *    process holds with no run behind it — nothing terminal may be claimed,
- *    and the reason is shown;
  * 5. a checkpoint nobody holds — the run was interrupted (a crash, or a host
  *    that quit).
  *
+ * Ownership is asked before the checkpoint because a checkpoint is an agent
+ * run's artifact. A background shell and a workflow-script container hold an
+ * execution lease for their whole lifetime and never write `flow_<id>.json`,
+ * so statting first would read a live run another TeXRA process owns as
+ * settled with no outcome.
+ *
  * The cost is the point: the /executions listing walks this once per row, so
  * it must stay at one metadata read (skipped entirely when the caller already
- * holds the row), one `exists` stat, and — only for a run that still has a
- * checkpoint — one lease read.
+ * holds the row) and, for a row with no recorded outcome, one lease read plus
+ * — only when that lease is free — one `exists` stat. A row that recorded its
+ * outcome pays neither.
  *
  * Checkpoint *validity* is therefore deliberately not re-derived here.
  * `deriveResumability` parses the record and is stricter than a stat (a spent
@@ -111,9 +117,6 @@ export async function resolveExecutionLiveness(
     if (meta?.outcome !== undefined) {
       return { kind: 'settled', outcome: meta.outcome };
     }
-    if (!(await store.exists(flowKey(executionId)))) {
-      return { kind: 'settled' };
-    }
     const lease = await inspectExecutionLease(executionId);
     if (lease.status === 'held') {
       return { kind: 'unsettled', reason: heldElsewhereReason(lease.owner) };
@@ -124,9 +127,11 @@ export async function resolveExecutionLiveness(
       );
       return { kind: 'unsettled', reason: OWNED_HERE_REASON };
     }
-    // A checkpoint with no outcome and no live owner is a run that stopped
-    // without finishing.
-    return { kind: 'interrupted' };
+    // Nobody owns the run: a checkpoint left behind is one that stopped
+    // without finishing, and none at all leaves nothing to continue.
+    return (await store.exists(flowKey(executionId)))
+      ? { kind: 'interrupted' }
+      : { kind: 'settled' };
   } catch (error) {
     const cause = toErrorMessage(error);
     log.warn(

--- a/src/tools/executions/executionLiveness.ts
+++ b/src/tools/executions/executionLiveness.ts
@@ -10,11 +10,17 @@
  * alive claims the run:
  *
  * 1. a handle in this process — the registry's phase is the live truth;
- * 2. `classifyRun` names a live foreign owner, or cannot read the run's
- *    facts at all — nothing terminal may be claimed, and the reason is shown;
- * 3. `classifyRun` finds a resumable checkpoint and no outcome was recorded —
- *    the run was interrupted (a crash, or a host that quit);
- * 4. otherwise the persisted outcome, or "unknown" when there is none.
+ * 2. `classifyRun` names a live foreign owner, names this process's own lease
+ *    with no run behind it, or cannot read the run's facts at all — nothing
+ *    terminal may be claimed, and the reason is shown;
+ * 3. `classifyRun` finds a resumable checkpoint and read no outcome — the run
+ *    was interrupted (a crash, or a host that quit);
+ * 4. otherwise the outcome `classifyRun` read, or "unknown" when there is none.
+ *
+ * The terminal readings (3 and 4) come from the classifier's own fresh read of
+ * the durable facts, never from an outcome snapshot the caller took earlier,
+ * and each re-checks the lease once before it is returned (see
+ * {@link leaseTakenSince}).
  *
  * Ownership and checkpoint validity are not re-derived here: `classifyRun`
  * is the one classifier of those durable facts, and it is deliberately
@@ -26,28 +32,88 @@
 import { currentSession } from '@agent/runtime/SessionHandle';
 import type { ExecutionStatusInfo } from '@agent/runtime/ExecutionHandle';
 import { classifyRun } from '@agent/runtime/runClassification';
+import {
+  inspectExecutionLease,
+  type ExecutionLeasePresence,
+} from '@agent/storage/executionLease';
 import type { LeaseOwnerRecord } from '@agent/storage/leaseOwnerLiveness';
-import type { ExecutionId, RunOutcome } from '@shared/schemas';
+import { createLog } from '@logger/logUtils';
+import type { ExecutionId, RunOutcome, StreamPhase } from '@shared/schemas';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+
+const log = createLog('ExecutionLiveness');
 
 /**
  * What may be said about a run right now. `unsettled` carries a mid-sentence
  * clause naming the fact that forbids a terminal reading, so each surface can
- * word it in its own voice.
+ * word it in its own voice. `settled` carries the outcome the classifier read,
+ * so every surface renders the same durable value.
  */
 export type ExecutionLiveness =
-  | { readonly kind: 'live'; readonly info: ExecutionStatusInfo }
+  | { readonly kind: 'live'; readonly info: LiveExecutionStatusInfo }
   | { readonly kind: 'unsettled'; readonly reason: string }
   | { readonly kind: 'interrupted' }
-  | { readonly kind: 'settled' };
+  | { readonly kind: 'settled'; readonly outcome?: RunOutcome };
+
+/**
+ * A tracked run's status line. Its phase is a real one — the registry answers
+ * with the stream's phase, never the `unknown` the persisted arms fall back to
+ * — so a reader may ask whether it is still in flight.
+ */
+type LiveExecutionStatusInfo = ExecutionStatusInfo & { status: StreamPhase };
 
 /** `executionHeldMessage`'s copy, as a clause a sentence can continue with. */
 function heldElsewhereReason(owner: LeaseOwnerRecord): string {
   return `held by another TeXRA process (pid ${owner.pid} on ${owner.hostname})`;
 }
 
+/**
+ * This process holds the lease but tracks no run for it: the registry and the
+ * lease disagree, which is a leak to report, never a run to call settled.
+ */
+const OWNED_HERE_REASON = "held by this process's lease with no live run";
+
+function unreadableReason(cause: string): string {
+  return `in a state this process cannot read (${cause})`;
+}
+
+/** The unsettled arm a non-free lease forces, or undefined when it is free. */
+function unsettledFromLease(
+  lease: ExecutionLeasePresence,
+): ExecutionLiveness | undefined {
+  if (lease.status === 'held') {
+    return { kind: 'unsettled', reason: heldElsewhereReason(lease.owner) };
+  }
+  if (lease.status === 'owned') {
+    return { kind: 'unsettled', reason: OWNED_HERE_REASON };
+  }
+  return undefined;
+}
+
+/**
+ * Whether an owner took the lease while the classification was being read.
+ *
+ * `classifyRun` reads the lease, then the metadata, then the checkpoint; a
+ * process that started (or resumed) the run across those awaits would leave a
+ * terminal reading that is already stale. Costs one extra lease read per row
+ * that reaches a terminal claim — the listing's other rows never pay it.
+ */
+async function leaseTakenSince(
+  executionId: ExecutionId,
+): Promise<ExecutionLiveness | undefined> {
+  try {
+    return unsettledFromLease(await inspectExecutionLease(executionId));
+  } catch (error) {
+    const cause = `lease unreadable (${toErrorMessage(error)})`;
+    log.warn(`Cannot re-check the lease for ${executionId}: ${cause}`, {
+      data: error,
+    });
+    return { kind: 'unsettled', reason: unreadableReason(cause) };
+  }
+}
+
 export async function resolveExecutionLiveness(
   executionId: ExecutionId,
-  outcome: RunOutcome | undefined,
 ): Promise<ExecutionLiveness> {
   const { executions } = currentSession();
   const handle = executions.getHandle(executionId);
@@ -62,19 +128,26 @@ export async function resolveExecutionLiveness(
         kind: 'unsettled',
         reason: heldElsewhereReason(classification.owner),
       };
+    case 'owned_here':
+      log.warn(
+        `Execution ${executionId} holds this process's lease with no tracked run; reporting it as unsettled rather than finished`,
+      );
+      return { kind: 'unsettled', reason: OWNED_HERE_REASON };
     case 'unclassified':
       return {
         kind: 'unsettled',
-        reason: `in a state this process cannot read (${classification.cause})`,
+        reason: unreadableReason(classification.cause),
       };
     case 'resumable':
+    case 'finished': {
+      const taken = await leaseTakenSince(executionId);
+      if (taken) return taken;
       // A valid checkpoint with no outcome and no live owner is a run that
       // stopped without finishing.
-      return outcome === undefined
+      return classification.kind === 'resumable' &&
+        classification.outcome === undefined
         ? { kind: 'interrupted' }
-        : { kind: 'settled' };
-    case 'owned_here':
-    case 'finished':
-      return { kind: 'settled' };
+        : { kind: 'settled', outcome: classification.outcome };
+    }
   }
 }

--- a/src/tools/executions/turnAttribution.ts
+++ b/src/tools/executions/turnAttribution.ts
@@ -5,13 +5,39 @@
 // Local imports
 import type { ExecutionKVStore } from '@agent/storage';
 
+import {
+  resolveExecutionLiveness,
+  type ExecutionLiveness,
+} from './executionLiveness';
+
+/** How the accepted turn's fate reads, given what owns the run. */
+function turnFate(token: string, liveness: ExecutionLiveness): string {
+  switch (liveness.kind) {
+    case 'live':
+      return `turn ${token} is still running`;
+    case 'unsettled':
+      // Something alive owns the run elsewhere, or ownership could not be
+      // read: either way nothing here may call the turn finished.
+      return `turn ${token} is ${liveness.reason}`;
+    case 'interrupted':
+    case 'settled':
+      // No live owner anywhere and no result for this turn: the turn ended
+      // with the process that was running it.
+      return `turn ${token} was interrupted before producing a result`;
+  }
+}
+
 /**
  * One-line attribution note for /report and /result when a newer turn was
  * accepted but never persisted a result (#9531): without it, the single
  * latest-value slots would silently present the previous turn as current.
- * Reads "still running" while the execution is live and "was interrupted"
- * once it has terminalized. Returns null when the slots reflect the latest
- * accepted turn (or the execution has no turn identity at all).
+ *
+ * Reads "still running" only while something alive is running the execution —
+ * a handle in this process, or another TeXRA process holding its lease. A
+ * missing `meta.outcome` is not liveness: a run whose owner crashed leaves
+ * exactly that, and it reads as interrupted. Returns null when the slots
+ * reflect the latest accepted turn (or the execution has no turn identity at
+ * all).
  */
 export async function turnAttributionNote(
   store: ExecutionKVStore,
@@ -25,10 +51,11 @@ export async function turnAttributionNote(
   if (!active || active.token === completed) {
     return null;
   }
-  const fate =
-    meta?.outcome === undefined
-      ? `turn ${active.token} is still running`
-      : `turn ${active.token} was interrupted before producing a result`;
+  const liveness = await resolveExecutionLiveness(
+    store.getExecutionId(),
+    meta?.outcome,
+  );
+  const fate = turnFate(active.token, liveness);
   const showing = completed
     ? `showing the latest completed turn (${completed}).`
     : 'no turn has completed yet.';

--- a/src/tools/executions/turnAttribution.ts
+++ b/src/tools/executions/turnAttribution.ts
@@ -4,6 +4,7 @@
 
 // Local imports
 import type { ExecutionKVStore } from '@agent/storage';
+import { isInFlightPhase } from '@shared/streams/streamStatus';
 
 import {
   resolveExecutionLiveness,
@@ -14,7 +15,12 @@ import {
 function turnFate(token: string, liveness: ExecutionLiveness): string {
   switch (liveness.kind) {
     case 'live':
-      return `turn ${token} is still running`;
+      // A handle this process still tracks past its stream's terminal phase
+      // is not a running turn: word it from the phase the registry reports,
+      // the same way the process-output footer does.
+      return isInFlightPhase(liveness.info.status)
+        ? `turn ${token} is still running`
+        : `turn ${token} ended with its run (${liveness.info.status})`;
     case 'unsettled':
       // Something alive owns the run elsewhere, or ownership could not be
       // read: either way nothing here may call the turn finished.
@@ -32,13 +38,14 @@ function turnFate(token: string, liveness: ExecutionLiveness): string {
  * accepted but never persisted a result (#9531): without it, the single
  * latest-value slots would silently present the previous turn as current.
  *
- * Reads "still running" only while this process is running the execution. A
- * run another TeXRA process holds — or one whose ownership cannot be read at
- * all — renders that fact instead, because this process cannot see how far
- * such a turn got. A missing `meta.outcome` is not liveness: a run whose owner
- * crashed leaves exactly that, and it reads as interrupted. Returns null when
- * the slots reflect the latest accepted turn (or the execution has no turn
- * identity at all).
+ * Reads "still running" only while a handle this process tracks is still in
+ * flight; a tracked handle whose stream already reached a terminal phase is
+ * worded from that phase instead. A run another TeXRA process holds — or one
+ * whose ownership cannot be read at all — renders that fact instead, because
+ * this process cannot see how far such a turn got. A missing `meta.outcome` is
+ * not liveness: a run whose owner crashed leaves exactly that, and it reads as
+ * interrupted. Returns null when the slots reflect the latest accepted turn
+ * (or the execution has no turn identity at all).
  */
 export async function turnAttributionNote(
   store: ExecutionKVStore,

--- a/src/tools/executions/turnAttribution.ts
+++ b/src/tools/executions/turnAttribution.ts
@@ -32,29 +32,24 @@ function turnFate(token: string, liveness: ExecutionLiveness): string {
  * accepted but never persisted a result (#9531): without it, the single
  * latest-value slots would silently present the previous turn as current.
  *
- * Reads "still running" only while something alive is running the execution —
- * a handle in this process, or another TeXRA process holding its lease. A
- * missing `meta.outcome` is not liveness: a run whose owner crashed leaves
- * exactly that, and it reads as interrupted. Returns null when the slots
- * reflect the latest accepted turn (or the execution has no turn identity at
- * all).
+ * Reads "still running" only while this process is running the execution. A
+ * run another TeXRA process holds — or one whose ownership cannot be read at
+ * all — renders that fact instead, because this process cannot see how far
+ * such a turn got. A missing `meta.outcome` is not liveness: a run whose owner
+ * crashed leaves exactly that, and it reads as interrupted. Returns null when
+ * the slots reflect the latest accepted turn (or the execution has no turn
+ * identity at all).
  */
 export async function turnAttributionNote(
   store: ExecutionKVStore,
 ): Promise<string | null> {
-  const [turnState, meta] = await Promise.all([
-    store.readTurnState(),
-    store.readMeta(),
-  ]);
+  const turnState = await store.readTurnState();
   const active = turnState?.activeTurn;
   const completed = turnState?.lastCompletedTurn?.token;
   if (!active || active.token === completed) {
     return null;
   }
-  const liveness = await resolveExecutionLiveness(
-    store.getExecutionId(),
-    meta?.outcome,
-  );
+  const liveness = await resolveExecutionLiveness(store.getExecutionId());
   const fate = turnFate(active.token, liveness);
   const showing = completed
     ? `showing the latest completed turn (${completed}).`


### PR DESCRIPTION
Part of #11822 (S2/S3). Stacked on #11824.

## What

One rule, `resolveExecutionLiveness(executionId, outcome)` in `src/tools/executions/executionLiveness.ts`, answers "is this run still going" for both surfaces that used to infer it from process-local facts: a live handle in this process wins; otherwise `classifyRun` decides, and a run held by a live foreign owner, or one whose facts are unreadable, is reported as unsettled with the held-elsewhere copy, never as `cancelled`; a free lease with no outcome and a valid checkpoint reads as interrupted; everything else keeps today's reading. `getExecutionStatusInfo` and the listing and child formatters are async over it (the listing page fans out at 16-wide through `p-map`); `turnAttributionNote` says "still running" only when something alive owns the run; `showOutput`'s footer derives from the same arm as its header, so one tool result cannot contradict itself. Three stale comments that named restart repair as a recovery path are corrected.

## Why

An orchestrator polling a sibling that another process is executing was told `unknown` or "still running" before, and would have been told `cancelled` by a naive checkpoint stat. A terminal claim to a model must rest on the lease and the checkpoint's validity, not on the absence of a handle here.

## Verification

Typecheck, dead-code ratchet, lint, and the tools, agent, progress-view, CLI, controllers, shared, transcript, desktop, and architecture suites green on the rebased commit (the five CLI files that timed out under concurrent load pass alone). Adversarially reviewed across three rounds; the final ladder is a stat plus at most one lease read per row, with `classifyRun` kept only for the single-run paths that parse a record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
