### PR TITLE
feat(runtime): record the read-only hold when a run is opened for write

### DIFF
--- a/packages/cli/src/runtime/sessionProgressSubscription.ts
+++ b/packages/cli/src/runtime/sessionProgressSubscription.ts
@@ -59,7 +59,7 @@ type CliRunFactEvent = Extract<
 
 /**
  * Project session facts onto the frozen NDJSON progress-event vocabulary.
- * `followUpSent` is intentionally session-local.
+ * `followUpSent` and `streamHoldChanged` are intentionally session-local.
  */
 function projectCliSessionFact(
   fact: SessionFact,
@@ -72,6 +72,10 @@ function projectCliSessionFact(
     case 'updateQueuedFollowUps':
       return { event: 'updateQueuedFollowUps', payload: fact.payload };
     case 'followUpSent':
+      return undefined;
+    // A read-only hold is a session-local display fact; the frozen NDJSON
+    // vocabulary carries no record for it.
+    case 'streamHoldChanged':
       return undefined;
     case 'setActiveStream':
       return { event: 'setActiveStream', payload: fact.payload };

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -102,11 +102,19 @@ const TERMINAL_STATE_BUTTONS = [
 
 /**
  * Buttons enabled while the run is unavailable here (held by another TeXRA
- * process, or its saved state unreadable): the read-only verbs only. Stop,
- * resume, re-run, restore, archive, diff, pack, and clean all act on a run
- * this process does not own. Removing the run is the tab's Delete.
+ * process, or its saved state unreadable): the read-only verbs, plus resume.
+ * Stop, re-run, restore, archive, diff, pack, and clean all act on a run this
+ * process does not own. Removing the run is the tab's Delete.
+ *
+ * Resume is here because the unavailable reading is a snapshot of a fact that
+ * can go stale — the other process exits, the unreadable file becomes
+ * readable — and resuming is the one action that re-reads it. The lease, not
+ * this table, is what keeps the attempt safe: a run another live process still
+ * holds refuses at the lease and re-words the same reading. Without it the tab
+ * is read-only for the rest of this process's life on a run nobody owns.
  */
 const UNAVAILABLE_STATE_BUTTONS = [
+  ELEMENT_IDS.RESUME_BTN,
   ELEMENT_IDS.OPEN_TASK_STORAGE_BTN,
   ELEMENT_IDS.EXPORT_TRANSCRIPT_BTN,
   ELEMENT_IDS.COPY_RUN_CONTEXT_BTN,

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -9,7 +9,10 @@ import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import type { AgentResumePort } from '@platform/interfaces';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
-import { streamHeldMessage } from '@shared/streams/streamStatusDisplay';
+import {
+  streamHeldMessage,
+  streamUnreadableMessage,
+} from '@shared/streams/streamStatusDisplay';
 import type { FollowUpQueueInput } from './FollowUpQueue';
 import type { FollowUpRecoveryLease } from './ToolUseFollowUpQueueManager';
 
@@ -194,12 +197,15 @@ export async function lookupStreamExecutionId(
  * facts: who holds the run, and whether a checkpoint is left. Read only on
  * the failure path; an unreadable fact is `not_resumable`.
  *
- * A refusal the user can see again is also recorded on the stream: the one
- * classification that means "this run is being executed elsewhere" becomes the
- * stream's read-only detail, so the tab keeps saying why after the toast is
- * gone. Every other classification read the run's state successfully, so it
- * DROPS any hold an earlier refusal left — a stream whose run is readable and
- * unowned must not stay read-only on a fact that has since changed.
+ * A refusal the user can see again is also recorded on the stream: the two
+ * classifications that mean "no flow here can execute this run" — another
+ * process holds it, or this process holds a lease with no live run behind it
+ * — become the stream's read-only detail, so the tab keeps saying why after
+ * the toast is gone. A classification that read the run's state and found it
+ * free (`finished`, `resumable`) DROPS any hold an earlier refusal left, and
+ * with it the phase that hold retained: a stream whose run is readable and
+ * unowned must neither stay read-only nor show the WAITING a failed resume
+ * rolled back to, on facts that have since changed.
  *
  * An `unclassified` run deliberately records nothing: `classifyRun` reports it
  * for any failed read, including a transient one (EMFILE, a partial read
@@ -229,38 +235,31 @@ async function classifyRefusal(
   const classification = await classifyRun(executionId);
   switch (classification.kind) {
     case 'held_elsewhere':
-      holdRefusedStream(
-        session,
+      session.status.markUnavailableOrLog(
         streamId,
         streamHeldMessage(classification.owner),
+        logger,
       );
       return 'owned_elsewhere';
+    case 'owned_here':
+      // A lease this process holds for a stream with no live flow context is
+      // a registry/lease disagreement, not a free run: it stays read-only
+      // with the same diagnostic restart repair writes for it.
+      session.status.markUnavailableOrLog(
+        streamId,
+        streamUnreadableMessage('lease owned by this process with no live run'),
+        logger,
+      );
+      return 'not_resumable';
     case 'finished':
-      session.status.clearHold(streamId);
+      session.status.clearHold(streamId, { discardRetainedPhase: true });
       return 'finished';
     case 'resumable':
-    case 'owned_here':
-      session.status.clearHold(streamId);
+      session.status.clearHold(streamId, { discardRetainedPhase: true });
       return 'not_resumable';
     case 'unclassified':
       return 'not_resumable';
   }
-}
-
-/**
- * Record why this stream stays read-only. A live reservation in this process
- * supersedes the refusal that produced `detail` (the run is being opened here
- * right now), so the skipped hold is logged rather than forced.
- */
-function holdRefusedStream(
-  session: SessionHandle,
-  streamId: StreamTabId,
-  detail: string,
-): void {
-  if (session.status.markUnavailable(streamId, detail)) return;
-  logger.debug(
-    `Kept the live reservation on stream ${streamId} instead of marking it unavailable: ${detail}`,
-  );
 }
 
 export async function submitFollowUp(

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -9,10 +9,7 @@ import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import type { AgentResumePort } from '@platform/interfaces';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
-import {
-  streamHeldMessage,
-  streamUnreadableMessage,
-} from '@shared/streams/streamStatusDisplay';
+import { streamHeldMessage } from '@shared/streams/streamStatusDisplay';
 import type { FollowUpQueueInput } from './FollowUpQueue';
 import type { FollowUpRecoveryLease } from './ToolUseFollowUpQueueManager';
 
@@ -197,11 +194,22 @@ export async function lookupStreamExecutionId(
  * facts: who holds the run, and whether a checkpoint is left. Read only on
  * the failure path; an unreadable fact is `not_resumable`.
  *
- * A refusal the user can see again is also recorded on the stream: the two
- * classifications that mean "this run cannot be opened here, and not because
- * it ended" become the stream's read-only detail, so the tab keeps saying why
- * after the toast is gone. Only the one run the user acted on is inspected,
- * and nothing is written to disk.
+ * A refusal the user can see again is also recorded on the stream: the one
+ * classification that means "this run is being executed elsewhere" becomes the
+ * stream's read-only detail, so the tab keeps saying why after the toast is
+ * gone. Every other classification read the run's state successfully, so it
+ * DROPS any hold an earlier refusal left — a stream whose run is readable and
+ * unowned must not stay read-only on a fact that has since changed.
+ *
+ * An `unclassified` run deliberately records nothing: `classifyRun` reports it
+ * for any failed read, including a transient one (EMFILE, a partial read
+ * racing another process's atomic rewrite), and a hold is sticky, so a blip
+ * would leave the tab permanently read-only. The unreadable display fact has
+ * its own producer in the run tuple's `authorityFailure`, which every later
+ * hydration re-reads.
+ *
+ * Only the one run the user acted on is inspected, and nothing is written to
+ * disk.
  */
 async function classifyRefusal(
   streamId: StreamTabId,
@@ -228,16 +236,13 @@ async function classifyRefusal(
       );
       return 'owned_elsewhere';
     case 'finished':
+      session.status.clearHold(streamId);
       return 'finished';
-    case 'unclassified':
-      holdRefusedStream(
-        session,
-        streamId,
-        streamUnreadableMessage(classification.cause),
-      );
-      return 'not_resumable';
     case 'resumable':
     case 'owned_here':
+      session.status.clearHold(streamId);
+      return 'not_resumable';
+    case 'unclassified':
       return 'not_resumable';
   }
 }

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -1,5 +1,8 @@
 /** Tool-use follow-up routing and continuation ownership. */
-import { classifyRun } from '@agent/runtime/runClassification';
+import {
+  classifyRun,
+  type RunClassification,
+} from '@agent/runtime/runClassification';
 import { readExecutionStreamIndex } from '@agent/storage/executionListing';
 import {
   currentSession,
@@ -193,11 +196,12 @@ export async function lookupStreamExecutionId(
 }
 
 /**
- * Word the refusal of a stream with no live flow here from the persisted
- * facts: who holds the run, and whether a checkpoint is left. Read only on
- * the failure path; an unreadable fact is `not_resumable`.
+ * The one mapping from a run classification to what the user's stream shows
+ * and what the refusal is called. Both refusal paths use it — a follow-up
+ * with no live flow here, and a resume whose checkpoint read came back empty
+ * — so the two cannot word or settle the same fact differently.
  *
- * A refusal the user can see again is also recorded on the stream: the two
+ * A refusal the user can see again is recorded on the stream: the two
  * classifications that mean "no flow here can execute this run" — another
  * process holds it, or this process holds a lease with no live run behind it
  * — become the stream's read-only detail, so the tab keeps saying why after
@@ -210,29 +214,18 @@ export async function lookupStreamExecutionId(
  * An `unclassified` run deliberately records nothing: `classifyRun` reports it
  * for any failed read, including a transient one (EMFILE, a partial read
  * racing another process's atomic rewrite), and a hold is sticky, so a blip
- * would leave the tab permanently read-only. The unreadable display fact has
- * its own producer in the run tuple's `authorityFailure`, which every later
- * hydration re-reads.
+ * would leave the tab permanently read-only — and dropping the hold on one
+ * would report a run another process is executing as finished. The unreadable
+ * display fact has its own producer in the run tuple's `authorityFailure`,
+ * which every later hydration re-reads.
  *
- * Only the one run the user acted on is inspected, and nothing is written to
- * disk.
+ * Nothing is written to disk.
  */
-async function classifyRefusal(
+export function recordRunRefusal(
   streamId: StreamTabId,
   session: SessionHandle,
-): Promise<FollowUpFailureReason> {
-  let executionId: ExecutionId | undefined;
-  try {
-    executionId = await lookupStreamExecutionId(streamId, session);
-  } catch (error) {
-    logger.warn(
-      `Cannot classify the refusal for ${streamId}: persisted execution identity is unreadable.`,
-      { data: { streamId, error } },
-    );
-    return 'not_resumable';
-  }
-  if (!executionId) return 'not_resumable';
-  const classification = await classifyRun(executionId);
+  classification: RunClassification,
+): FollowUpFailureReason {
   switch (classification.kind) {
     case 'held_elsewhere':
       session.status.markUnavailableOrLog(
@@ -260,6 +253,30 @@ async function classifyRefusal(
     case 'unclassified':
       return 'not_resumable';
   }
+}
+
+/**
+ * Word the refusal of a stream with no live flow here from the persisted
+ * facts: who holds the run, and whether a checkpoint is left. Read only on
+ * the failure path; an unreadable fact is `not_resumable`. Only the one run
+ * the user acted on is inspected.
+ */
+async function classifyRefusal(
+  streamId: StreamTabId,
+  session: SessionHandle,
+): Promise<FollowUpFailureReason> {
+  let executionId: ExecutionId | undefined;
+  try {
+    executionId = await lookupStreamExecutionId(streamId, session);
+  } catch (error) {
+    logger.warn(
+      `Cannot classify the refusal for ${streamId}: persisted execution identity is unreadable.`,
+      { data: { streamId, error } },
+    );
+    return 'not_resumable';
+  }
+  if (!executionId) return 'not_resumable';
+  return recordRunRefusal(streamId, session, await classifyRun(executionId));
 }
 
 export async function submitFollowUp(

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -9,6 +9,10 @@ import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import type { AgentResumePort } from '@platform/interfaces';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import {
+  streamHeldMessage,
+  streamUnreadableMessage,
+} from '@shared/streams/streamStatusDisplay';
 import type { FollowUpQueueInput } from './FollowUpQueue';
 import type { FollowUpRecoveryLease } from './ToolUseFollowUpQueueManager';
 
@@ -192,6 +196,12 @@ export async function lookupStreamExecutionId(
  * Word the refusal of a stream with no live flow here from the persisted
  * facts: who holds the run, and whether a checkpoint is left. Read only on
  * the failure path; an unreadable fact is `not_resumable`.
+ *
+ * A refusal the user can see again is also recorded on the stream: the two
+ * classifications that mean "this run cannot be opened here, and not because
+ * it ended" become the stream's read-only detail, so the tab keeps saying why
+ * after the toast is gone. Only the one run the user acted on is inspected,
+ * and nothing is written to disk.
  */
 async function classifyRefusal(
   streamId: StreamTabId,
@@ -211,14 +221,41 @@ async function classifyRefusal(
   const classification = await classifyRun(executionId);
   switch (classification.kind) {
     case 'held_elsewhere':
+      holdRefusedStream(
+        session,
+        streamId,
+        streamHeldMessage(classification.owner),
+      );
       return 'owned_elsewhere';
     case 'finished':
       return 'finished';
+    case 'unclassified':
+      holdRefusedStream(
+        session,
+        streamId,
+        streamUnreadableMessage(classification.cause),
+      );
+      return 'not_resumable';
     case 'resumable':
     case 'owned_here':
-    case 'unclassified':
       return 'not_resumable';
   }
+}
+
+/**
+ * Record why this stream stays read-only. A live reservation in this process
+ * supersedes the refusal that produced `detail` (the run is being opened here
+ * right now), so the skipped hold is logged rather than forced.
+ */
+function holdRefusedStream(
+  session: SessionHandle,
+  streamId: StreamTabId,
+  detail: string,
+): void {
+  if (session.status.markUnavailable(streamId, detail)) return;
+  logger.debug(
+    `Kept the live reservation on stream ${streamId} instead of marking it unavailable: ${detail}`,
+  );
 }
 
 export async function submitFollowUp(

--- a/src/agent/runtime/SessionEventHub.ts
+++ b/src/agent/runtime/SessionEventHub.ts
@@ -7,6 +7,7 @@ import type {
   RemoveStreamPayload,
   SetActiveStreamPayload,
   SetParentStreamPayload,
+  StreamHoldChangedPayload,
   StreamTabId,
   UpdateQueuedFollowUpsPayload,
   UpdateStreamDescriptionPayload,
@@ -53,6 +54,16 @@ export type SessionFact =
   | {
       readonly type: 'removeStream';
       readonly payload: RemoveStreamPayload;
+    }
+  | {
+      /**
+       * A read-only hold was recorded on a stream, or dropped from it. A hold
+       * carries no phase, so it cannot ride the `status` arm; without this
+       * fact the write would be invisible to every host until an unrelated
+       * metadata sync happened to republish the stream.
+       */
+      readonly type: 'streamHoldChanged';
+      readonly payload: StreamHoldChangedPayload;
     };
 
 export type SessionEvent =

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -203,9 +203,13 @@ export class StreamStatusMachine {
     // The table decides whether a transition is permitted, but not whether a
     // permitted transition changes state. A steady RUNNING resume with no
     // substate to clear must stay silent, while a real substate clear still
-    // writes and publishes from this single status owner.
+    // writes and publishes from this single status owner. A hold is never
+    // such a no-op: even when the phase it retained equals `to`, the entry is
+    // still a hold, so it has to convert through the write-and-publish path
+    // below or the stream stays read-only while this reports success.
     if (
       !fromReservation &&
+      !overwritesHold &&
       from === to &&
       previousState?.substate === options.substate
     ) {
@@ -303,8 +307,9 @@ export class StreamStatusMachine {
    * not `reserved`, so `releaseIfReserved` becomes a no-op and a failed
    * launch's rollback never runs, while the RUNNING the hold inherits from
    * `effectiveState` blocks every later `tryAcquire`. Holds lived in a side
-   * map before they became an entry arm and could not do this. The caller
-   * logs the refusal so the skipped hold is not silent.
+   * map before they became an entry arm and could not do this.
+   * {@link markUnavailableOrLog} is how every caller that has a logger asks,
+   * so the skipped hold is not silent.
    *
    * A written hold publishes, exactly like a transition does: it is a fact a
    * user action can produce while hosts are attached, so nothing may wait for
@@ -325,14 +330,40 @@ export class StreamStatusMachine {
   }
 
   /**
-   * Drop a hold. Restart repair calls this when a classification resolves
-   * without writing a phase; a `transition` that does write replaces the hold
-   * with the phase it lands on.
+   * `markUnavailable`, plus the one thing every caller does when it refuses:
+   * say in the log that the live reservation was kept instead, so a skipped
+   * hold is never silent and the sentence is not copied at three call sites.
    */
-  clearHold(stream: StreamTabId): void {
+  markUnavailableOrLog(
+    stream: StreamTabId,
+    detail: string,
+    logger: { debug(message: string): void } | undefined,
+  ): void {
+    if (this.markUnavailable(stream, detail)) return;
+    logger?.debug(
+      `Kept the live reservation on stream ${stream} instead of marking it unavailable: ${detail}`,
+    );
+  }
+
+  /**
+   * Drop a hold, restoring the phase it retained. Restart repair calls this
+   * when a classification resolves without writing a phase; a `transition`
+   * that does write replaces the hold with the phase it lands on.
+   *
+   * `discardRetainedPhase` drops that retained phase with the hold. A hold
+   * written after a failed tool-use resume carries the WAITING its rollback
+   * left, and a caller that has just re-read the run and found it finished or
+   * merely resumable has disproved that phase: restoring it would show a live
+   * run this process does not have. A caller that learned nothing new about
+   * the phase keeps the default.
+   */
+  clearHold(
+    stream: StreamTabId,
+    options: { discardRetainedPhase?: boolean } = {},
+  ): void {
     const entry = this.streams.get(stream);
     if (entry?.kind !== 'hold') return;
-    if (entry.state) {
+    if (entry.state && !options.discardRetainedPhase) {
       this.streams.set(stream, { kind: 'phase', state: entry.state });
     } else {
       this.streams.delete(stream);

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -58,11 +58,11 @@ type StreamEntry =
     }
   | {
       /**
-       * Restart classification could not settle on a phase (held by another
-       * process, or the run state unreadable). RUNNING/WAITING mean a live
-       * flow in this process, and this process never adopts anyone else's
-       * run, so a hold with no prior phase remains unclassified until the next
-       * full metadata sync publishes it.
+       * Classification could not settle on a phase (held by another process,
+       * or the run state unreadable). RUNNING/WAITING mean a live flow in this
+       * process, and this process never adopts anyone else's run, so a hold
+       * with no prior phase has no phase to publish — the `streamHoldChanged`
+       * fact carries the change instead, and hosts re-read the resolved phase.
        */
       readonly kind: 'hold';
       readonly detail: string;
@@ -149,6 +149,8 @@ export class StreamStatusMachine {
       substate: STREAM_SUBSTATE.STARTING,
       runStartedAt,
     });
+    // A reservation that replaces a hold also drops that hold's detail.
+    if (entry?.kind === 'hold') this.publishHoldChanged(stream);
     return true;
   }
 
@@ -186,6 +188,7 @@ export class StreamStatusMachine {
   ): boolean {
     const entry = this.streams.get(stream);
     const fromReservation = entry?.kind === 'reserved';
+    const overwritesHold = entry?.kind === 'hold';
     let previousState: StreamPhaseState | undefined;
     if (fromReservation) previousState = entry.rollbackTo;
     else if (entry) previousState = effectiveState(entry);
@@ -233,6 +236,9 @@ export class StreamStatusMachine {
       ...(previousPhase ? { previousPhase } : {}),
       ...(runStartedAt !== undefined ? { runStartedAt } : {}),
     });
+    // A phase that replaces a hold also drops that hold's detail, and the
+    // status fact above carries no detail of its own.
+    if (overwritesHold) this.publishHoldChanged(stream);
     return true;
   }
 
@@ -299,16 +305,22 @@ export class StreamStatusMachine {
    * `effectiveState` blocks every later `tryAcquire`. Holds lived in a side
    * map before they became an entry arm and could not do this. The caller
    * logs the refusal so the skipped hold is not silent.
+   *
+   * A written hold publishes, exactly like a transition does: it is a fact a
+   * user action can produce while hosts are attached, so nothing may wait for
+   * an unrelated metadata sync to repaint the tab.
    */
   markUnavailable(stream: StreamTabId, detail: string): boolean {
     const entry = this.streams.get(stream);
     if (entry?.kind === 'reserved') return false;
     const state = entry ? effectiveState(entry) : undefined;
+    if (entry?.kind === 'hold' && entry.detail === detail) return true;
     this.streams.set(stream, {
       kind: 'hold',
       detail,
       ...(state ? { state } : {}),
     });
+    this.publishHoldChanged(stream);
     return true;
   }
 
@@ -322,9 +334,10 @@ export class StreamStatusMachine {
     if (entry?.kind !== 'hold') return;
     if (entry.state) {
       this.streams.set(stream, { kind: 'phase', state: entry.state });
-      return;
+    } else {
+      this.streams.delete(stream);
     }
-    this.streams.delete(stream);
+    this.publishHoldChanged(stream);
   }
 
   /** The detail recorded by `markUnavailable`, if the stream has no phase here. */
@@ -353,6 +366,18 @@ export class StreamStatusMachine {
 
   isInFlight(stream: StreamTabId): boolean {
     return isInFlightPhase(this.get(stream));
+  }
+
+  /**
+   * Announce that this stream's hold was recorded or dropped. A hold has no
+   * phase, so it cannot ride the `status` fact; hosts react by re-reading the
+   * stream's resolved phase, which is where the hold's detail is rendered.
+   */
+  private publishHoldChanged(stream: StreamTabId): void {
+    this.eventHub.emit({
+      scope: 'session',
+      event: { type: 'streamHoldChanged', payload: { streamId: stream } },
+    });
   }
 
   private publishStatus(

--- a/src/agent/runtime/restartRepair.ts
+++ b/src/agent/runtime/restartRepair.ts
@@ -237,11 +237,7 @@ export async function repairRestartedStreams(
         );
         break;
     }
-    if (!options.streamStatus.markUnavailable(streamId, detail)) {
-      options.logger?.debug(
-        `Kept the live reservation on stream ${streamId} instead of marking it unavailable: ${detail}`,
-      );
-    }
+    options.streamStatus.markUnavailableOrLog(streamId, detail, options.logger);
     return true;
   };
 

--- a/src/agent/runtime/resumeRun.ts
+++ b/src/agent/runtime/resumeRun.ts
@@ -256,15 +256,21 @@ async function resumeRunWithRecoveryProvenance(
     if (queueLease) session.followUps.release(queueLease, 'recoverable');
     return REFUSED;
   }
+  // The run has just been re-read for write. A hold recorded by an earlier
+  // refusal describes facts this attempt has now re-read, so it goes here,
+  // before the refusals below and not after them: a tab whose foreign owner
+  // has since exited and whose checkpoint is gone must render its terminal
+  // state rather than stay read-only on the reason it was refused last time.
+  // The phase such a hold retained goes with it — a failed tool-use resume
+  // rolls the stream back to WAITING before the hold is written, and this
+  // read has just disproved that WAITING. An attempt that is refused again
+  // writes the current reason below; one that acquires leaves the phase it
+  // lands on.
+  session.status.clearHold(streamId, { discardRetainedPhase: true });
   if (!resume) {
     if (queueLease) session.followUps.release(queueLease, 'recoverable');
     return { failed: 'finished' };
   }
-  // The run is about to be opened for write. A hold recorded by an earlier
-  // refusal on this stream describes facts this attempt is re-reading, so it
-  // goes now: an attempt that is refused again writes the current reason
-  // below, and one that acquires leaves the phase it lands on.
-  session.status.clearHold(streamId);
   if (resume.type === 'toolUse' && queueLease) {
     return resumeQueuedToolUse(session, resume, queueLease, options);
   }
@@ -315,12 +321,11 @@ function refusalFor(
   streamId: StreamTabId,
 ): ResumeRunResult | undefined {
   if (error instanceof ExecutionLeaseActiveError) {
-    const detail = streamHeldMessage(error.owner);
-    if (!session.status.markUnavailable(streamId, detail)) {
-      logger.debug(
-        `Kept the live reservation on stream ${streamId} instead of marking it unavailable: ${detail}`,
-      );
-    }
+    session.status.markUnavailableOrLog(
+      streamId,
+      streamHeldMessage(error.owner),
+      logger,
+    );
     return { failed: 'owned_elsewhere' };
   }
   if (error instanceof ResumeSessionUnavailableError) {

--- a/src/agent/runtime/resumeRun.ts
+++ b/src/agent/runtime/resumeRun.ts
@@ -14,6 +14,7 @@ import type {
 } from '@agent/followUp/FollowUpQueue';
 import {
   lookupStreamExecutionId,
+  recordRunRefusal,
   type FollowUpFailureReason,
 } from '@agent/followUp/ToolUseFollowUp';
 import type { FollowUpRecoveryLease } from '@agent/followUp/ToolUseFollowUpQueueManager';
@@ -39,6 +40,7 @@ import {
   resumeToolUseFromResumeData,
   type SubagentRunOptions,
 } from './executeAgent';
+import { classifyRun } from './runClassification';
 import {
   retrieveSessionResumeData,
   type ToolUseResumeData,
@@ -256,21 +258,31 @@ async function resumeRunWithRecoveryProvenance(
     if (queueLease) session.followUps.release(queueLease, 'recoverable');
     return REFUSED;
   }
-  // The run has just been re-read for write. A hold recorded by an earlier
-  // refusal describes facts this attempt has now re-read, so it goes here,
-  // before the refusals below and not after them: a tab whose foreign owner
-  // has since exited and whose checkpoint is gone must render its terminal
-  // state rather than stay read-only on the reason it was refused last time.
-  // The phase such a hold retained goes with it — a failed tool-use resume
-  // rolls the stream back to WAITING before the hold is written, and this
-  // read has just disproved that WAITING. An attempt that is refused again
-  // writes the current reason below; one that acquires leaves the phase it
-  // lands on.
-  session.status.clearHold(streamId, { discardRetainedPhase: true });
   if (!resume) {
     if (queueLease) session.followUps.release(queueLease, 'recoverable');
-    return { failed: 'finished' };
+    // Nothing came back, which is two facts in one `null`: the checkpoint is
+    // gone, or the record could not be read — a torn read of the rewrite the
+    // process that owns this run is making right now parses as absent. Only
+    // the lease separates them, so this refusal is decided by `classifyRun`
+    // and recorded through the same mapping the follow-up path uses: a run
+    // held elsewhere refreshes the hold instead of dropping it and being
+    // reported finished, and an unreadable one moves nothing.
+    return {
+      failed: recordRunRefusal(
+        streamId,
+        session,
+        await classifyRun(executionId),
+      ),
+    };
   }
+  // The run is about to be opened for write, its checkpoint just re-read. A
+  // hold recorded by an earlier refusal describes facts this
+  // attempt has now re-read, so it goes, and the phase it retained goes with
+  // it — a failed tool-use resume rolls the stream back to WAITING before the
+  // hold is written, and this read has disproved that WAITING. An attempt
+  // refused below writes the current reason; one that acquires leaves the
+  // phase it lands on.
+  session.status.clearHold(streamId, { discardRetainedPhase: true });
   if (resume.type === 'toolUse' && queueLease) {
     return resumeQueuedToolUse(session, resume, queueLease, options);
   }

--- a/src/agent/runtime/resumeRun.ts
+++ b/src/agent/runtime/resumeRun.ts
@@ -19,6 +19,7 @@ import {
 import type { FollowUpRecoveryLease } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { ExecutionLeaseActiveError } from '@agent/storage/executionLease';
 import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
+import { createLog } from '@logger/logUtils';
 import type { RecoveryContinuation } from '@platform/interfaces';
 import {
   AgentCategory,
@@ -27,6 +28,7 @@ import {
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
+import { streamHeldMessage } from '@shared/streams/streamStatusDisplay';
 
 import {
   isWaitingFlowResult,
@@ -149,6 +151,8 @@ export async function resumeStream(
 
 export { lookupStreamExecutionId } from '@agent/followUp/ToolUseFollowUp';
 
+const logger = createLog('ResumeRun');
+
 const REFUSED: ResumeRunResult = { failed: 'not_resumable' };
 /** A workflow run carries no follow-up batch, so nothing awaits delivery. */
 const WORKFLOW_STARTED: ResumeRunResult = { started: true, delivered: true };
@@ -256,6 +260,11 @@ async function resumeRunWithRecoveryProvenance(
     if (queueLease) session.followUps.release(queueLease, 'recoverable');
     return { failed: 'finished' };
   }
+  // The run is about to be opened for write. A hold recorded by an earlier
+  // refusal on this stream describes facts this attempt is re-reading, so it
+  // goes now: an attempt that is refused again writes the current reason
+  // below, and one that acquires leaves the phase it lands on.
+  session.status.clearHold(streamId);
   if (resume.type === 'toolUse' && queueLease) {
     return resumeQueuedToolUse(session, resume, queueLease, options);
   }
@@ -267,7 +276,7 @@ async function resumeRunWithRecoveryProvenance(
         resume.modelHandlerCompatibilityKey,
       );
     } catch (error) {
-      return refusalFor(error) ?? Promise.reject(error);
+      return refusalFor(error, session, streamId) ?? Promise.reject(error);
     }
     return WORKFLOW_STARTED;
   }
@@ -290,9 +299,28 @@ function releaseUnstartedRecovery(
   session.followUps.release(current, 'recoverable');
 }
 
-/** The two expected launch failures a host words; anything else rejects. */
-function refusalFor(error: unknown): ResumeRunResult | undefined {
+/**
+ * The two expected launch failures a host words; anything else rejects.
+ *
+ * A refusal is also the one moment this process learns, for the run the user
+ * just asked to open, that another live TeXRA process holds it. That fact is
+ * recorded on the stream so every surface renders it read-only with the same
+ * copy until this stream is opened successfully — after the boot-time repair
+ * pass is gone, an open-for-write and a sidecar hydration are the only two
+ * producers of it.
+ */
+function refusalFor(
+  error: unknown,
+  session: SessionHandle,
+  streamId: StreamTabId,
+): ResumeRunResult | undefined {
   if (error instanceof ExecutionLeaseActiveError) {
+    const detail = streamHeldMessage(error.owner);
+    if (!session.status.markUnavailable(streamId, detail)) {
+      logger.debug(
+        `Kept the live reservation on stream ${streamId} instead of marking it unavailable: ${detail}`,
+      );
+    }
     return { failed: 'owned_elsewhere' };
   }
   if (error instanceof ResumeSessionUnavailableError) {
@@ -410,7 +438,10 @@ async function resumeQueuedToolUse(
   }
 
   if (resumeError) {
-    return refusalFor(resumeError.error) ?? Promise.reject(resumeError.error);
+    return (
+      refusalFor(resumeError.error, session, streamId) ??
+      Promise.reject(resumeError.error)
+    );
   }
   // Cancellation at flow attachment means the run was never reached; a replay
   // means it ran and returned with the batch back on the stream queue.

--- a/src/controllers/progressView/backend/LitSessionRenderer.ts
+++ b/src/controllers/progressView/backend/LitSessionRenderer.ts
@@ -464,7 +464,11 @@ export class LitSessionRenderer implements SessionRendererPort {
       category: streamInfo.agentCategory,
       status: statusDetail ? STREAM_LIFECYCLE_UNAVAILABLE : status?.phase,
       statusDetail,
-      substate: status?.substate,
+      // The unavailable sentinel travels alone: a hold keeps the phase the
+      // stream had, and shipping that phase's substate with the sentinel
+      // would light the active-run controls on a run this process cannot act
+      // on.
+      substate: statusDetail ? undefined : status?.substate,
       runStartedAt: status?.runStartedAt,
       userFollowUpSupport: streamInfo.userFollowUpSupport,
       lastTimestamp: this.state.streamLogs.getTimestampRange(streamInfo.name)

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -127,6 +127,7 @@ function sessionFactStreamIds(fact: SessionFact): StreamTabId[] {
     case 'followUpSent':
     case 'setActiveStream':
     case 'updateStreamDescription':
+    case 'streamHoldChanged':
       return fact.payload.streamId ? [fact.payload.streamId] : [];
     default:
       return assertNever(fact, 'Unhandled session fact stream identity');
@@ -358,6 +359,8 @@ export class SessionFactApplier {
               fact.substate,
               fact.runStartedAt,
             );
+          case 'streamHoldChanged':
+            return this.handleStreamHoldChanged(fact.payload.streamId);
           case 'setParentStream':
             return this.handleSetParentStream(fact.payload);
           case 'removeStream': {
@@ -702,6 +705,17 @@ export class SessionFactApplier {
       status: goal?.status,
       objective: goal?.objective,
     });
+  }
+
+  /**
+   * A read-only hold was recorded on this stream or dropped from it. The hold
+   * carries no phase of its own, so the whole change is in what
+   * `resolveStreamPhase` now answers: push the stream's metadata, which is the
+   * only wire carrying `statusDetail` and the `unavailable` sentinel derived
+   * from it.
+   */
+  private handleStreamHoldChanged(streamId: StreamTabId): void {
+    if (this.renderer.isAvailable()) this.pushStreamMetadata(streamId);
   }
 
   private handleRunConfig(streamId: StreamTabId): void {

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -979,13 +979,25 @@ export class SessionFactApplier {
       // The status being applied has not necessarily reached the status
       // machine yet (hosts and tests also call this method directly), so it
       // travels with the push instead of being re-read.
-      this.pushStreamMetadata(streamId, {
-        phaseOverride: {
-          phase: status,
-          ...(substate ? { substate } : {}),
-          ...(runStartedAt !== undefined ? { runStartedAt } : {}),
-        },
-      });
+      //
+      // Unless a hold was recorded while this handler was suspended in the
+      // rehydrate await above: this status is then the older fact, and its
+      // override would paint a live phase over the read-only detail the
+      // refusal wrote (an override suppresses `statusDetail`). Push without
+      // it and let the renderer read the resolved phase, hold included.
+      const held = this.state.streamStatus.holdState(streamId) !== undefined;
+      this.pushStreamMetadata(
+        streamId,
+        held
+          ? undefined
+          : {
+              phaseOverride: {
+                phase: status,
+                ...(substate ? { substate } : {}),
+                ...(runStartedAt !== undefined ? { runStartedAt } : {}),
+              },
+            },
+      );
     } else {
       const lastTimestamp =
         this.state.streamLogs.getTimestampRange(streamId).last;

--- a/src/shared/schemas/progressEvents.ts
+++ b/src/shared/schemas/progressEvents.ts
@@ -49,6 +49,15 @@ export interface RemoveStreamPayload {
   streamId: StreamTabId;
 }
 
+/**
+ * A stream's read-only hold was recorded or dropped. The hold itself lives on
+ * the status machine and carries no phase, so the fact names only the stream:
+ * hosts re-read the resolved phase (and its `statusDetail`) for it.
+ */
+export interface StreamHoldChangedPayload {
+  streamId: StreamTabId;
+}
+
 type UpdateStreamStatusMessage = z.infer<
   typeof UpdateStreamStatusMessageSchema
 >;

--- a/src/test-kernel/agent/runtime/DerivedStreamPhase.vitest.ts
+++ b/src/test-kernel/agent/runtime/DerivedStreamPhase.vitest.ts
@@ -254,10 +254,20 @@ describe('holds written when a run is opened for write', () => {
 
     try {
       const session = openUnrepairedHandle(transcripts);
+      // The hold has to publish: a fact a user action produces while hosts
+      // are attached cannot wait for an unrelated metadata sync to repaint.
+      const heldFacts: StreamTabId[] = [];
+      session.events.subscribeSessionFacts((fact) => {
+        if (fact.type === 'streamHoldChanged') {
+          heldFacts.push(fact.payload.streamId);
+        }
+      });
 
       await expect(
         submitFollowUp(stream, 'are you there?', { session }),
       ).resolves.toEqual({ status: 'failed', reason: 'owned_elsewhere' });
+
+      expect(heldFacts).toEqual([stream]);
 
       // The refusal is worded once and kept: no phase, nothing written to
       // disk, the transcript left open, and the tab read-only with the cause.

--- a/src/test-kernel/agent/runtime/DerivedStreamPhase.vitest.ts
+++ b/src/test-kernel/agent/runtime/DerivedStreamPhase.vitest.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { clearStoreCache, getExecutionStore } from '@agent/storage';
 import { flowKey } from '@agent/node/persistedFlow';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import { submitFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
 import { SessionState } from '@controllers/session/SessionState';
@@ -46,10 +47,14 @@ const sessions: SessionHandle[] = [];
  * `waitUntilReady`, which these tests deliberately never call, so every phase
  * below is derived at read time and not something repair wrote.
  */
-function openUnrepairedSession(transcripts: StreamLogStore): SessionState {
+function openUnrepairedHandle(transcripts: StreamLogStore): SessionHandle {
   const session = new SessionHandle({ transcripts, restartRepair: 'deferred' });
   sessions.push(session);
-  return new SessionState(session);
+  return session;
+}
+
+function openUnrepairedSession(transcripts: StreamLogStore): SessionState {
+  return new SessionState(openUnrepairedHandle(transcripts));
 }
 
 function appendRunningGroup(
@@ -224,5 +229,50 @@ describe('SessionState.resolveStreamPhase', () => {
       state: { phase: STREAM_PHASE.COMPLETED },
       origin: 'derived',
     });
+  });
+});
+
+describe('holds written when a run is opened for write', () => {
+  it('holds a foreign-owned run read-only while its owner is live', async () => {
+    const foreign = await startForeignInstance();
+    const executionId = 'eeee5555' as ExecutionId;
+    const stream = `held#${executionId}` as StreamTabId;
+    const transcripts = await StreamLogStore.open();
+    appendRunningGroup(transcripts, stream);
+    await transcripts.flush();
+    await seedSidecarFk(stream, executionId);
+    const executionStore = getExecutionStore(executionId);
+    // The authored execution→stream edge: the refusal resolves the run from
+    // it without any sidecar hydration, so the hold below is the only
+    // producer of the held fact here.
+    await executionStore.writeMeta({
+      timestamp: META_TIMESTAMP,
+      streamId: stream,
+    });
+    await executionStore.write(flowKey(executionId), validFlowRecord);
+    await writeForeignLease(executionId, undefined, foreign.owner);
+
+    try {
+      const session = openUnrepairedHandle(transcripts);
+
+      await expect(
+        submitFollowUp(stream, 'are you there?', { session }),
+      ).resolves.toEqual({ status: 'failed', reason: 'owned_elsewhere' });
+
+      // The refusal is worded once and kept: no phase, nothing written to
+      // disk, the transcript left open, and the tab read-only with the cause.
+      expect(session.status.holdState(stream)).toBe(
+        streamHeldMessage(foreign.owner),
+      );
+      expect(session.status.get(stream)).toBeUndefined();
+      expect(new SessionState(session).resolveStreamPhase(stream)).toEqual({
+        origin: 'live',
+        detail: streamHeldMessage(foreign.owner),
+      });
+      expect((await executionStore.readMeta())?.outcome).toBeUndefined();
+      expect(transcripts.get(stream)?.getRange(0)).toHaveLength(1);
+    } finally {
+      await foreign.shutdown();
+    }
   });
 });

--- a/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
@@ -483,9 +483,10 @@ describe('SessionHandle restart repair', () => {
     expect(session.status.get(reusedStreamId)).toBe(STREAM_PHASE.RUNNING);
   });
 
-  // The held-foreign-owner case now belongs to the open-for-write refusal
-  // that records it (`DerivedStreamPhase.vitest.ts`): the boot pass is no
-  // longer the producer of that display fact.
+  // The held-foreign-owner case moved to the open-for-write refusal that also
+  // records it (`DerivedStreamPhase.vitest.ts`), ahead of PR6 deleting this
+  // boot pass — which is still a producer of that display fact at this
+  // commit, just no longer the only one.
 
   it('surfaces a repair write failure at the readiness boundary', async () => {
     const transcripts = await StreamLogStore.open();

--- a/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
@@ -15,15 +15,8 @@ import {
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
-import {
-  streamHeldMessage,
-  streamUnreadableMessage,
-} from '@shared/streams/streamStatusDisplay';
-import {
-  startForeignInstance,
-  writeForeignLease,
-  writeOrphanedLease,
-} from '@test/support/executionLeaseFixtures';
+import { streamUnreadableMessage } from '@shared/streams/streamStatusDisplay';
+import { writeOrphanedLease } from '@test/support/executionLeaseFixtures';
 import { setupPlatform } from '@test/support/setupPlatform';
 import {
   appendTranscriptEntry,
@@ -490,35 +483,9 @@ describe('SessionHandle restart repair', () => {
     expect(session.status.get(reusedStreamId)).toBe(STREAM_PHASE.RUNNING);
   });
 
-  it('holds a foreign-owned run read-only while its owner is live', async () => {
-    const foreign = await startForeignInstance();
-    const heldExecutionId = '9355abcd' as ExecutionId;
-    const heldStreamId = `held#${heldExecutionId}` as StreamTabId;
-    const transcripts = await StreamLogStore.open();
-    appendRunningGroup(transcripts, heldStreamId, 'held-running-group');
-    await transcripts.flush();
-    await seedSidecarFk(heldStreamId, heldExecutionId);
-    const executionStore = getExecutionStore(heldExecutionId);
-    await executionStore.writeMeta({ timestamp: META_TIMESTAMP });
-    await executionStore.write(flowKey(heldExecutionId), validFlowRecord);
-    await writeForeignLease(heldExecutionId, undefined, foreign.owner);
-
-    const session = openDeferredSession(transcripts);
-
-    try {
-      await session.waitUntilReady();
-      // Live foreign owner: held, no phase, nothing written, transcript open.
-      expect(session.status.holdState(heldStreamId)).toBe(
-        streamHeldMessage(foreign.owner),
-      );
-      expect(session.status.get(heldStreamId)).toBeUndefined();
-      expect((await executionStore.readMeta())?.outcome).toBeUndefined();
-      expect(transcripts.get(heldStreamId)?.getRange(0)).toHaveLength(1);
-    } finally {
-      await foreign.shutdown();
-      session.dispose();
-    }
-  });
+  // The held-foreign-owner case now belongs to the open-for-write refusal
+  // that records it (`DerivedStreamPhase.vitest.ts`): the boot pass is no
+  // longer the producer of that display fact.
 
   it('surfaces a repair write failure at the readiness boundary', async () => {
     const transcripts = await StreamLogStore.open();

--- a/src/test-kernel/agent/runtime/resumeRun.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeRun.vitest.ts
@@ -25,6 +25,14 @@ vi.mock('@agent/storage/ExecutionKVStore', async (importActual) => ({
   getExecutionStore: getExecutionStoreMock,
 }));
 
+// The refusal path re-reads the durable facts, which the fixtures below do
+// not seed: the store double answers only `readConfig`/`readMeta`.
+const classifyRunMock = vi.hoisted(() => vi.fn());
+vi.mock('@agent/runtime/runClassification', async (importActual) => ({
+  ...(await importActual<typeof import('@agent/runtime/runClassification')>()),
+  classifyRun: classifyRunMock,
+}));
+
 const readExecutionStreamIndexMock = vi.hoisted(() => vi.fn());
 vi.mock('@agent/storage/executionListing', async (importActual) => ({
   ...(await importActual<typeof import('@agent/storage/executionListing')>()),
@@ -80,6 +88,7 @@ describe('resumeRun tool-use queue ownership', () => {
       readMeta: async () => ({ streamId: STREAM }),
     });
     retrieveSessionResumeDataMock.mockReset().mockResolvedValue(snapshot());
+    classifyRunMock.mockReset().mockResolvedValue({ kind: 'finished' });
     readExecutionStreamIndexMock.mockReset().mockResolvedValue({
       byStream: new Map([[STREAM, EXECUTION]]),
       unreadable: new Map(),
@@ -320,5 +329,23 @@ describe('resumeRun tool-use queue ownership', () => {
       resumeRun(EXECUTION, { session, executeWorkflow }),
     ).resolves.toEqual({ failed: 'finished' });
     expect(resumeToolUseFromResumeDataMock).not.toHaveBeenCalled();
+    expect(session.status.holdState(STREAM)).toBeUndefined();
+  });
+
+  // An empty retrieval is also what a torn read of the owner's rewrite looks
+  // like, so the refusal is decided from the lease: a run another process is
+  // executing keeps its hold instead of being reported finished.
+  it('refuses an empty retrieval held elsewhere as owned elsewhere', async () => {
+    const session = createSession();
+    retrieveSessionResumeDataMock.mockResolvedValueOnce(null);
+    classifyRunMock.mockResolvedValueOnce({
+      kind: 'held_elsewhere',
+      owner: { pid: 4321, processStart: null, hostname: 'other-host' },
+    });
+
+    await expect(
+      resumeRun(EXECUTION, { session, executeWorkflow }),
+    ).resolves.toEqual({ failed: 'owned_elsewhere' });
+    expect(session.status.holdState(STREAM)).toContain('4321');
   });
 });

--- a/src/test-kernel/cli/ResumeCommand.vitest.ts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.ts
@@ -152,6 +152,9 @@ describe('runResumeExecution', () => {
       session: {
         interactions: {},
         executions: { isActiveOrResuming: () => false },
+        // `resumeRun` drops any stale read-only hold when it opens the run
+        // for write, and records one when the lease refuses it.
+        status: { clearHold: () => undefined, markUnavailable: () => true },
         snapshots: {
           getRunMetadata: () => ({ executionId: EXECUTION_ID }),
           getParentStreamId: () => undefined,

--- a/src/test-kernel/cli/ResumeCommand.vitest.ts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.ts
@@ -419,14 +419,17 @@ describe('runResumeExecution', () => {
     expect(mocks.retrieveSessionResumeData).not.toHaveBeenCalled();
   });
 
-  it('reports empty workflow retrieval as finished', async () => {
+  // The checkpoint this seeds is readable, so the empty retrieval is the two
+  // readers disagreeing, not a finished run: the refusal is worded from the
+  // lease-aware classification, which still sees a checkpoint.
+  it('reports empty workflow retrieval against a live checkpoint as not resumable', async () => {
     await seedExecution({ config: WORKFLOW_CONFIG, meta: STAMPED_META });
     mocks.retrieveSessionResumeData.mockResolvedValue(null);
 
     await expect(run(cliContext())).resolves.toBe(2);
 
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      'This run has finished. Start a new agent task to continue.',
+      'This run cannot accept messages right now. Resume it, or start a new agent task.',
     );
     expect(mocks.runChat).not.toHaveBeenCalled();
   });

--- a/src/test-kernel/cli/ResumeCommand.vitest.ts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.ts
@@ -154,7 +154,10 @@ describe('runResumeExecution', () => {
         executions: { isActiveOrResuming: () => false },
         // `resumeRun` drops any stale read-only hold when it opens the run
         // for write, and records one when the lease refuses it.
-        status: { clearHold: () => undefined, markUnavailable: () => true },
+        status: {
+          clearHold: () => undefined,
+          markUnavailableOrLog: () => undefined,
+        },
         snapshots: {
           getRunMetadata: () => ({ executionId: EXECUTION_ID }),
           getParentStreamId: () => undefined,


### PR DESCRIPTION
Part of #11822 (S3). Stacked on #11824.

## What

`StreamStatusMachine.markUnavailable` gains production writers at open-for-write, so the "held elsewhere" display fact survives the deletion of restart repair's two boot-time producers: `resumeRun`'s refusal on `ExecutionLeaseActiveError` (both the workflow launch and the tool-use resume paths) records `streamHeldMessage(owner)` on the stream, a stale hold is dropped once at the point the run is opened for write, and `ToolUseFollowUp.classifyRefusal`'s held-elsewhere arm records the same while its successful classifications clear it. A hold now publishes as a `streamHoldChanged` session fact (a hold carries no phase, so it cannot ride the status arm), hosts re-read the resolved phase on it, and the unavailable toolbar keeps a Resume affordance so a stale hold has an in-tab action that re-reads the run. The `unclassified` arm deliberately records nothing: `classifyRun` reports it for transient read failures, and a sticky hold would turn a blip into a permanent read-only tab; the unreadable display fact keeps its producer in PR2's run tuple.

Only the one run the user acted on is inspected; nothing is added to any all-runs path, and nothing is written to disk.

## Design note

S1/S3 supersede D3/D9's "shown as held at load" clause from the single-owner-sessions proposal: after restart repair is deleted, a foreign live run is shown held once its sidecar hydrates (PR2's per-stream lease probe) or when the user acts on it (this PR), never by a boot pass.

## Verification

Typecheck, dead-code ratchet, lint, and the agent, progress-view, CLI, controllers, shared, transcript, desktop, and architecture suites green on the rebased commit. The moved test ("holds a foreign-owned run read-only while its owner is live") now drives the follow-up refusal in `DerivedStreamPhase.vitest.ts`. Adversarially reviewed; the unpublished hold, the sticky transient hold, and the missing clear on successful classification were fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)