### PR TITLE
fix: migrate extension Vite config to ESM .mts

### DIFF
--- a/docs/architecture/2026-07-26-embedding-the-agent-runtime.md
+++ b/docs/architecture/2026-07-26-embedding-the-agent-runtime.md
@@ -7,7 +7,7 @@ rewrite those aliases. An external program must therefore build from a TeXRA
 checkout with equivalent alias-aware bundler configuration, or replace the
 aliases with resolvable paths. The repository's Vite builds derive their alias
 map from `tsconfig.json` (`scripts/aliases.mjs:14-20`,
-`packages/extension/vite.config.ts:39`), while the extension's esbuild bundle
+`packages/extension/vite.config.mts:5`), while the extension's esbuild bundle
 reads its generated package tsconfig (`packages/extension/esbuild.config.mjs:34-48`).
 Nothing here is a stable contract — this note documents what an external
 program has to do _today_ to get a `runAgent` call to complete, so that SDK work

--- a/packages/extension/.vscodeignore
+++ b/packages/extension/.vscodeignore
@@ -16,6 +16,7 @@ src/**
 **/tsconfig.json
 eslint.config.mjs
 esbuild.config.mjs
+vite.config.mts
 tsconfig.json
 **/*.map
 **/*.ts

--- a/packages/extension/src/common/webview/BaseViewContentProvider.ts
+++ b/packages/extension/src/common/webview/BaseViewContentProvider.ts
@@ -42,7 +42,7 @@ export class BundledViewContentProvider {
     private readonly viewName: string,
     /**
      * The one folder name a view owns: `src/<viewFolder>/index.html` holds its
-     * template and `dist/<viewFolder>/` its Vite output (see `vite.config.ts`,
+     * template and `dist/<viewFolder>/` its Vite output (see `vite.config.mts`,
      * which builds both paths from the same list).
      */
     private readonly viewFolder: string,

--- a/packages/extension/vite.config.mts
+++ b/packages/extension/vite.config.mts
@@ -33,6 +33,9 @@ export default defineConfig(({ mode }) => {
       sourcemap: isDev ? 'inline' : false,
       minify: isDev ? false : 'esbuild',
       target: 'es2022',
+      // Each webview is intentionally a single bundle for the nonce-only CSP.
+      // Keep a tight budget above the largest current production bundle.
+      chunkSizeWarningLimit: 3000,
       // Disable asset inlining to ensure all fonts are emitted as files (not base64 data URIs)
       // This is required because VS Code webview CSP font-src doesn't allow data: URIs
       // Note: KaTeX_Size3-Regular.woff2 (3.6KB) would otherwise be inlined and blocked by CSP

--- a/scripts/check-dead-code-ratchet.mjs
+++ b/scripts/check-dead-code-ratchet.mjs
@@ -51,7 +51,7 @@ function runKnip({ production = false } = {}) {
     cwd: rootDir,
     encoding: 'utf8',
     maxBuffer: 32 * 1024 * 1024,
-    // Knip's vite plugin loads packages/extension/vite.config.ts for entry
+    // Knip's vite plugin loads packages/extension/vite.config.mts for entry
     // detection, and that config throws unless VITE_WEBVIEW names a webview.
     // Without this the analyzer swallowed a permanent config-load ERROR on
     // every green run, hiding any real config failure behind it. Build callers

--- a/src/test-kernel/desktop/BuildAliasConfig.vitest.ts
+++ b/src/test-kernel/desktop/BuildAliasConfig.vitest.ts
@@ -46,7 +46,7 @@ describe('build alias configuration', () => {
 
     // The extension bundlers resolve the same root table: Vite through the
     // shared aliases.mjs, esbuild through tsconfig path mapping.
-    const extensionViteConfig = readText('packages/extension/vite.config.ts');
+    const extensionViteConfig = readText('packages/extension/vite.config.mts');
     const extensionEsbuildConfig = readText(
       'packages/extension/esbuild.config.mjs',
     );


### PR DESCRIPTION
## Summary

- Rename extension webview Vite config from `vite.config.ts` to `vite.config.mts` so `configLoader: 'native'` handles ESM without the unsupported ESM-in-CJS warning.
- Raise `build.chunkSizeWarningLimit` to `3000` to match current intentionally single-bundle webview outputs (chunk splitting remains disabled due to VS Code CSP constraints).
- Update references to the renamed config in extension docs, tests, and scripts.

## Testing

- `corepack pnpm run vite:webviews` (from `packages/extension`)
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/BuildAliasConfig.vitest.ts`
