### PR TITLE
perf(cli): advertise a resumable history row from one stat, not a checkpoint parse

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -581,6 +581,17 @@ export function createChatSessionController(
         session.streamId = streamId;
         session.executionId = id;
         rootStreamId.set(streamId);
+        // The session held no stream until the line above: `markRunPending`,
+        // inside the synchronous slot claim at the top of `resume`, dropped
+        // the pre-resume one, so a Ctrl-C in the window before adoption could
+        // not fabricate an interrupted marker on a stream this resume is
+        // leaving behind. It also found nothing to interrupt, so re-read the
+        // request here — the way `startRootRun`'s `onStreamResolved` does —
+        // and let it land on the run the user asked to continue. `resumeRun`
+        // re-reads `isCancellationRequested` once this hook returns, so the
+        // stop still refuses the launch; this only decides which stream it
+        // marks recoverable.
+        if (session.stopRequested) interruptActiveRun();
 
         await runtimeSession.transcripts.ensureLoaded(streamId);
         // `load` evicts every other record synchronously before its async

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -12,6 +12,7 @@ import {
   describeFollowUpFailure,
   detachSubagentsOnStop,
   lookupStreamExecutionId,
+  probeResumeRefusal,
   resumeRun,
   runAgent,
   type AgentConfig,
@@ -556,6 +557,22 @@ export function createChatSessionController(
       if (!recovery) {
         restoreInterruptedRecovery(supersededRecovery);
         appendLocalErrorTranscript(describeFollowUpFailure('not_resumable'));
+        session.markRunCompleted();
+        resolveRunPromise();
+        return;
+      }
+
+      // Validate before mutating anything. A history row is advertised from
+      // its checkpoint file alone (one `stat`, no parse), so a run whose saved
+      // state cannot be loaded reaches here; refusing it after the transcript
+      // was cleared and the session switched to its dead stream would take the
+      // user's chat with it and answer in the wrong window.
+      const refusal = await probeResumeRefusal(id, config, streamId);
+      if (refusal) {
+        runtimeSession.followUps.release(recovery, 'recoverable');
+        recovery = undefined;
+        restoreInterruptedRecovery(supersededRecovery);
+        appendLocalErrorTranscript(describeFollowUpFailure(refusal));
         session.markRunCompleted();
         resolveRunPromise();
         return;

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -12,7 +12,6 @@ import {
   describeFollowUpFailure,
   detachSubagentsOnStop,
   lookupStreamExecutionId,
-  probeResumeRefusal,
   resumeRun,
   runAgent,
   type AgentConfig,
@@ -562,68 +561,49 @@ export function createChatSessionController(
         return;
       }
 
-      // Validate before mutating anything. A history row is advertised from
-      // its checkpoint file alone (one `stat`, no parse), so a run whose saved
-      // state cannot be loaded reaches here; refusing it after the transcript
-      // was cleared and the session switched to its dead stream would take the
-      // user's chat with it and answer in the wrong window.
-      const refusal = await probeResumeRefusal(id, config, streamId);
-      if (refusal) {
-        runtimeSession.followUps.release(recovery, 'recoverable');
-        recovery = undefined;
-        restoreInterruptedRecovery(supersededRecovery);
-        appendLocalErrorTranscript(describeFollowUpFailure(refusal));
-        session.markRunCompleted();
-        resolveRunPromise();
-        return;
-      }
-
-      clearLocalTranscript();
-      followUpQueue.clear();
-      session.streamId = streamId;
-      session.executionId = id;
-      rootStreamId.set(streamId);
-
       const sessionContext = beginRunContext(config, 'history');
-
-      await runtimeSession.transcripts.ensureLoaded(streamId);
-      // `load` evicts every other record synchronously before its async seed,
-      // and the store reports no provenance for an evicted record, so nothing
-      // projects an evicted/unseeded stream (or re-emits warnIfUnseeded)
-      // mid-seed without any marker bookkeeping here. A previously seeded
-      // retained root deliberately keeps its provenance during reseeding:
-      // this keeps its canonical pre-resume projection visible at the cost of
-      // bounded warnIfUnseeded notices until the seed completes.
-      await snapshotStore.load([streamId]);
-      // Drop the projection memo before the log sync below can render a stale
-      // pre-resume projection. The load also re-establishes this stream's
-      // work-plan provenance in the store, which is what an open `/plan`
-      // reader re-reads to clear its failure-time mask.
-      bumpStreamArtifactRevision();
-      // A resumed stream may be one the user /clear-ed; the empty patch mints
-      // the slice and drops the retired mark so `syncStreamLog` and
-      // `focusStream` accept it again.
-      patchStream(streamId, (slice) => ({ ...slice }));
-      syncStreamLog(runtimeSession, streamId);
-      focusStream(streamId);
-
       const { approvalsUnavailable, ownExecution, finalize } =
         setupRunHost(sessionContext);
       ownExecution(id);
 
-      // A Ctrl-C during the rehydration awaits above (resume resolution,
-      // `ensureLoaded`, `snapshotStore.load`) lands here as
-      // `session.stopRequested`. Honor it before starting the real run chain —
-      // matching `tryResumeStream()`'s stop-check after its own preparatory
-      // awaits — instead of starting an agent the user already cancelled.
-      if (session.stopRequested) {
-        runtimeSession.followUps.release(recovery, 'recoverable');
-        recovery = undefined;
-        restoreInterruptedRecovery(supersededRecovery);
-        finalize();
-        resolveRunPromise();
-        return;
-      }
+      // Adopting the resumed stream is the mutation a refusal must not cost.
+      // A history row is advertised from its checkpoint file alone (one
+      // `stat`, no parse), so a run whose saved state cannot be loaded is
+      // offered and refused; `resumeRun` calls this only once that state
+      // loaded, so the refusal reaches the chat the user is looking at
+      // instead of a cleared transcript switched onto a dead stream. A Ctrl-C
+      // during the awaits below lands as `session.stopRequested` and is
+      // honored by `isCancellationRequested`, which `resumeRun` re-reads once
+      // this returns, rather than starting an agent the user cancelled.
+      const adoptResumedStream = async (): Promise<void> => {
+        clearLocalTranscript();
+        followUpQueue.clear();
+        session.streamId = streamId;
+        session.executionId = id;
+        rootStreamId.set(streamId);
+
+        await runtimeSession.transcripts.ensureLoaded(streamId);
+        // `load` evicts every other record synchronously before its async
+        // seed, and the store reports no provenance for an evicted record, so
+        // nothing projects an evicted/unseeded stream (or re-emits
+        // warnIfUnseeded) mid-seed without any marker bookkeeping here. A
+        // previously seeded retained root deliberately keeps its provenance
+        // during reseeding: this keeps its canonical pre-resume projection
+        // visible at the cost of bounded warnIfUnseeded notices until the seed
+        // completes.
+        await snapshotStore.load([streamId]);
+        // Drop the projection memo before the log sync below can render a
+        // stale pre-resume projection. The load also re-establishes this
+        // stream's work-plan provenance in the store, which is what an open
+        // `/plan` reader re-reads to clear its failure-time mask.
+        bumpStreamArtifactRevision();
+        // A resumed stream may be one the user /clear-ed; the empty patch
+        // mints the slice and drops the retired mark so `syncStreamLog` and
+        // `focusStream` accept it again.
+        patchStream(streamId, (slice) => ({ ...slice }));
+        syncStreamLog(runtimeSession, streamId);
+        focusStream(streamId);
+      };
 
       // The seeded batch stays this call's until the stream queue takes it
       // over. Every refusal before that point (the stream already active
@@ -639,6 +619,7 @@ export function createChatSessionController(
             ...toolUseResumeOptions(sessionContext, approvalsUnavailable),
             recovery,
             extraFollowUps: supersededRecovery?.followUps,
+            onResumeResolved: adoptResumedStream,
             onFollowUpQueueReady: () => {
               followUpQueueReady = true;
             },

--- a/packages/cli/src/commands/resumeExecution.ts
+++ b/packages/cli/src/commands/resumeExecution.ts
@@ -86,8 +86,11 @@ export async function runResumeExecution(
       writeTextStderr(`Execution ${id} is already running in this process.`);
       return CliExitCode.Usage;
     case 'unclassified':
+      // A history row is advertised from its checkpoint file alone, so a run
+      // whose saved state cannot be read lands here. It gets the same words
+      // the chat's open path gives that cohort, with the fact that decided it.
       writeTextStderr(
-        `Could not read the state of execution ${id}: ${classification.cause}`,
+        `${describeFollowUpFailure('unusable_checkpoint')} (${classification.cause})`,
       );
       return CliExitCode.AgentError;
     case 'finished':

--- a/packages/cli/src/commands/resumeExecution.ts
+++ b/packages/cli/src/commands/resumeExecution.ts
@@ -97,9 +97,14 @@ export async function runResumeExecution(
       break;
   }
   // FK-first: the stream id stamped at registration is the reproduction
-  // contract. A row without one has no persisted stream to continue.
+  // contract. A row without one predates stamping, so there is no persisted
+  // stream to reopen — a different fact from "this run finished", and worth
+  // saying plainly since only an explicitly named id reaches here (the
+  // history listing never advertises such a row).
   if (!meta?.streamId) {
-    writeTextStderr(describeFollowUpFailure('finished'));
+    writeTextStderr(
+      `Execution ${id} predates transcript stream stamping and cannot be continued. Start a new agent task instead.`,
+    );
     return CliExitCode.Usage;
   }
 

--- a/packages/cli/src/commands/resumeExecution.ts
+++ b/packages/cli/src/commands/resumeExecution.ts
@@ -87,10 +87,14 @@ export async function runResumeExecution(
       return CliExitCode.Usage;
     case 'unclassified':
       // A history row is advertised from its checkpoint file alone, so a run
-      // whose saved state cannot be read lands here. It gets the same words
-      // the chat's open path gives that cohort, with the fact that decided it.
+      // whose checkpoint is corrupt lands here and gets the same words the
+      // chat's open path gives that cohort, with the fact that decided it.
+      // A lease or metadata read that failed says nothing about the
+      // checkpoint, so it stays the operational fact it is.
       writeTextStderr(
-        `${describeFollowUpFailure('unusable_checkpoint')} (${classification.cause})`,
+        classification.fault === 'checkpoint-malformed'
+          ? `${describeFollowUpFailure('unusable_checkpoint')} (${classification.cause})`
+          : `Could not read the state of execution ${id}: ${classification.cause}`,
       );
       return CliExitCode.AgentError;
     case 'finished':

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -4,9 +4,9 @@ import * as path from 'node:path';
 import pMap from 'p-map';
 
 import {
+  checkpointExists,
   deleteAllExecutions,
   deleteExecution,
-  flowKey,
   getExecutionStore,
   isUserVisibleExecution,
   listExecutions,
@@ -191,21 +191,26 @@ export async function readCliHistoryDetails(
     readCompletedRunConversation(id),
     store.readWorkspaceFiles(),
     listRunGeneratedFiles(id),
-    store.exists(flowKey(id)),
+    checkpointExists(id),
   ]);
   const conversation = conversationResult.conversation;
   const hasTranscriptEvidence =
     hasCompletedRunConversationEvidence(conversationResult);
   // The same rule the listing applies, from the same facts: `status` is a
   // frozen contract, so `history show` must not answer it differently from
-  // `history list` for the run in the row the caller just read.
-  const resumable = await isCliRunResumable({
-    id,
-    checkpointPresent,
-    streamId: meta?.streamId,
-    agentCategory: config?.agentCategory,
-    outcome: meta?.outcome,
-  });
+  // `history list` for the run in the row the caller just read. A run whose
+  // config is missing or malformed has no category to resume under and no
+  // config for a host to adopt, so it is not offered — the listing never
+  // reaches this rule for such a row, which lists as incomplete.
+  const resumable =
+    config !== null &&
+    (await isCliRunResumable({
+      id,
+      checkpointPresent,
+      streamId: meta?.streamId,
+      agentCategory: config.agentCategory,
+      outcome: meta?.outcome,
+    }));
   const currentModel = config
     ? await readCliResumedModel(id, config)
     : undefined;

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -6,6 +6,7 @@ import pMap from 'p-map';
 import {
   deleteAllExecutions,
   deleteExecution,
+  flowKey,
   getExecutionStore,
   isUserVisibleExecution,
   listExecutions,
@@ -45,10 +46,7 @@ import { byStringProp } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { CliUsageError } from './cliContext';
-import {
-  isCliListingResumable,
-  readCliResumeDataForDetails,
-} from './toolUseResumeData';
+import { isCliRunResumable, readCliResumedModel } from './toolUseResumeData';
 import {
   formatCliHistoryAgentLabel,
   formatCliHistorySubject,
@@ -84,10 +82,12 @@ export interface CliHistoryEntry {
   readonly status: HistoryRunStatus;
   /**
    * Whether the durable facts say this run can be continued: a checkpoint
-   * exists and the row carries the stream id stamped at registration.
-   * Ownership is settled when the run is opened, not per listed row, so a run
-   * live in another process still lists here and refuses on open. Independent
-   * of `status`, which stays a frozen contract: a failed run can be resumable.
+   * file exists and the row carries the stream id stamped at registration.
+   * Ownership and loadability are settled when the run is opened, not per
+   * listed row, so a run live in another process — or one whose checkpoint
+   * turns out to be unloadable — still lists here and is refused, in its own
+   * words, on open. Independent of `status`, which stays a frozen contract: a
+   * failed run can be resumable.
    */
   readonly resumable: boolean;
   readonly inputBasename: string;
@@ -107,7 +107,7 @@ interface CliHistoryDetails {
   readonly conversationPreview: CliHistoryConversationPreview | null;
   readonly conversation?: CliHistoryConversationPreview | null;
   readonly files: readonly RunGeneratedFile[];
-  /** Whether a category-valid flow record is available for resumption. */
+  /** Whether a checkpoint file exists for this run. */
   readonly hasFlowRecord: boolean;
   readonly currentModel?: string;
 }
@@ -160,8 +160,8 @@ export function parseCliHistoryId(raw: string): ExecutionId | undefined {
 export async function listCliHistoryEntries(): Promise<CliHistoryEntry[]> {
   const entries = await listExecutions();
   // A row's resumability comes from the checkpoint `stat` the listing already
-  // did; only a candidate workflow row still reads its persisted state. That
-  // read is bounded here so a history full of workflow runs cannot open one
+  // did; only a failed workflow row still reads its persisted state. That read
+  // is bounded here so a history full of failed workflow runs cannot open one
   // file handle burst per run. `pMap` preserves input order.
   return pMap(entries.filter(isUserVisibleExecution), toCliHistoryEntry, {
     concurrency: HISTORY_ENTRY_CONCURRENCY,
@@ -181,6 +181,7 @@ export async function readCliHistoryDetails(
     conversationResult,
     persistedWorkspaceFilePaths,
     generatedFiles,
+    checkpointPresent,
   ] = await Promise.all([
     store.readMeta(),
     store.readConfig(),
@@ -190,13 +191,24 @@ export async function readCliHistoryDetails(
     readCompletedRunConversation(id),
     store.readWorkspaceFiles(),
     listRunGeneratedFiles(id),
+    store.exists(flowKey(id)),
   ]);
   const conversation = conversationResult.conversation;
   const hasTranscriptEvidence =
     hasCompletedRunConversationEvidence(conversationResult);
-  const resumeData = config
-    ? await readCliResumeDataForDetails(id, config)
-    : null;
+  // The same rule the listing applies, from the same facts: `status` is a
+  // frozen contract, so `history show` must not answer it differently from
+  // `history list` for the run in the row the caller just read.
+  const resumable = await isCliRunResumable({
+    id,
+    checkpointPresent,
+    streamId: meta?.streamId,
+    agentCategory: config?.agentCategory,
+    outcome: meta?.outcome,
+  });
+  const currentModel = config
+    ? await readCliResumedModel(id, config)
+    : undefined;
   const conversationPreview = createConversationPreview(conversation);
   const fullConversation = options.includeFullConversation
     ? createConversationTranscript(conversation)
@@ -219,17 +231,14 @@ export async function readCliHistoryDetails(
     !config &&
     !conversationPreview &&
     !fullConversation &&
-    !resumeData &&
+    !checkpointPresent &&
     !hasTranscriptEvidence
   ) {
     return null;
   }
   return {
     id,
-    status: resolveHistoryRunStatus({
-      resumable: resumeData !== null,
-      outcome: meta?.outcome,
-    }),
+    status: resolveHistoryRunStatus({ resumable, outcome: meta?.outcome }),
     meta,
     config,
     result: resultMeta ? unwrapResultMeta(resultMeta) : null,
@@ -239,9 +248,8 @@ export async function readCliHistoryDetails(
       ? { conversation: fullConversation }
       : {}),
     files,
-    hasFlowRecord: resumeData !== null,
-    currentModel:
-      resumeData?.type === 'toolUse' ? resumeData.agentConfig.model : undefined,
+    hasFlowRecord: checkpointPresent,
+    currentModel,
   };
 }
 
@@ -539,7 +547,13 @@ async function toCliHistoryEntry(
   const config = entry.record;
   const firstInputFile = config.inputFiles.at(0);
   const inputBasename = firstInputFile ? path.basename(firstInputFile) : '-';
-  const resumable = await isCliListingResumable(entry);
+  const resumable = await isCliRunResumable({
+    id: entry.id,
+    checkpointPresent: entry.checkpointPresent,
+    streamId: entry.streamId,
+    agentCategory: config.agentCategory,
+    outcome: entry.outcome,
+  });
   return {
     id: entry.id,
     timestamp: entry.timestamp,

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -45,7 +45,10 @@ import { byStringProp } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { CliUsageError } from './cliContext';
-import { readCliResumeDataForListing } from './toolUseResumeData';
+import {
+  isCliListingResumable,
+  readCliResumeDataForDetails,
+} from './toolUseResumeData';
 import {
   formatCliHistoryAgentLabel,
   formatCliHistorySubject,
@@ -80,8 +83,11 @@ export interface CliHistoryEntry {
   readonly model: string;
   readonly status: HistoryRunStatus;
   /**
-   * Whether a checkpoint exists and nobody alive owns the run. Independent of
-   * `status`, which stays a frozen contract: a failed run can be resumable.
+   * Whether the durable facts say this run can be continued: a checkpoint
+   * exists and the row carries the stream id stamped at registration.
+   * Ownership is settled when the run is opened, not per listed row, so a run
+   * live in another process still lists here and refuses on open. Independent
+   * of `status`, which stays a frozen contract: a failed run can be resumable.
    */
   readonly resumable: boolean;
   readonly inputBasename: string;
@@ -153,9 +159,10 @@ export function parseCliHistoryId(raw: string): ExecutionId | undefined {
 
 export async function listCliHistoryEntries(): Promise<CliHistoryEntry[]> {
   const entries = await listExecutions();
-  // Every row costs a resumability probe plus an optional resume-data read.
-  // One at a time makes a long history crawl; all at once opens one file
-  // handle burst per run, so keep it bounded. `pMap` preserves input order.
+  // A row's resumability comes from the checkpoint `stat` the listing already
+  // did; only a candidate workflow row still reads its persisted state. That
+  // read is bounded here so a history full of workflow runs cannot open one
+  // file handle burst per run. `pMap` preserves input order.
   return pMap(entries.filter(isUserVisibleExecution), toCliHistoryEntry, {
     concurrency: HISTORY_ENTRY_CONCURRENCY,
   });
@@ -188,7 +195,7 @@ export async function readCliHistoryDetails(
   const hasTranscriptEvidence =
     hasCompletedRunConversationEvidence(conversationResult);
   const resumeData = config
-    ? await readCliResumeDataForListing(id, config)
+    ? await readCliResumeDataForDetails(id, config)
     : null;
   const conversationPreview = createConversationPreview(conversation);
   const fullConversation = options.includeFullConversation
@@ -532,20 +539,17 @@ async function toCliHistoryEntry(
   const config = entry.record;
   const firstInputFile = config.inputFiles.at(0);
   const inputBasename = firstInputFile ? path.basename(firstInputFile) : '-';
-  const resumeData = await readCliResumeDataForListing(entry.id, config);
+  const resumable = await isCliListingResumable(entry);
   return {
     id: entry.id,
     timestamp: entry.timestamp,
     agent: config.agent,
-    model:
-      resumeData?.type === 'toolUse'
-        ? resumeData.agentConfig.model
-        : config.model,
-    status: resolveHistoryRunStatus({
-      resumable: resumeData !== null,
-      outcome: entry.outcome,
-    }),
-    resumable: resumeData !== null,
+    // The model the run started under. A run resumed under a different model
+    // records that only inside its checkpoint, which a listing no longer
+    // parses; `history show` still reports the resumed model.
+    model: config.model,
+    status: resolveHistoryRunStatus({ resumable, outcome: entry.outcome }),
+    resumable,
     inputBasename,
     category: config.agentCategory,
     description: entry.description,

--- a/packages/cli/src/runtime/toolUseResumeData.ts
+++ b/packages/cli/src/runtime/toolUseResumeData.ts
@@ -1,98 +1,101 @@
 import {
-  classifyRun,
   hasTerminalPersistedCompileRejection,
   retrieveSessionResumeData,
   type AgentConfig,
 } from '@agent/runtime';
-import {
-  getExecutionStore,
-  type AgentExecutionListingEntry,
-} from '@agent/storage';
+import { getExecutionStore } from '@agent/storage';
 import { createLog } from '@logger/logUtils';
-import { AgentCategory, type ExecutionId } from '@shared/schemas';
+import {
+  AgentCategory,
+  RUN_OUTCOME,
+  type ExecutionId,
+  type RunOutcome,
+  type StreamTabId,
+} from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const logger = createLog('CliToolUseResumeData');
-type CliSessionResumeData = NonNullable<
-  Awaited<ReturnType<typeof retrieveSessionResumeData>>
->;
 
 /**
- * Whether a history listing may advertise a row as continuable, decided from
- * facts the listing already carries: a checkpoint file exists (one `stat` per
- * row in `listExecutions`) and the row has the stream id stamped on its
- * metadata at registration — the reproduction contract, without which there is
- * no persisted stream to continue.
- *
- * Ownership is deliberately not inspected here. A run another process is
- * executing right now has a checkpoint and no outcome, so it lists as
- * resumable and is refused when the user opens it; that costs one lease read
- * on the one run they picked instead of one per row.
- *
- * The one read left is the workflow compile-rejection filter, and only for a
- * workflow row the two free facts have already accepted: such a run's
- * checkpoint exists but records a rejection at its round cap, so resume
- * refuses it and the listing must not offer it. An unreadable or malformed
- * record is not advertised either — that is unknown state, not a continuable
- * run.
+ * The durable facts a run's continuability is decided from. `history list`
+ * reads them off the listing row it already has; `history show` reads the
+ * same ones for the single run it was asked about. One rule, so the frozen
+ * `status` contract cannot report two different values for one run.
  */
-export async function isCliListingResumable(
-  entry: AgentExecutionListingEntry,
+export interface CliRunResumabilityFacts {
+  readonly id: ExecutionId;
+  /** A checkpoint file exists on disk — one `stat`, never a parse. */
+  readonly checkpointPresent: boolean;
+  /**
+   * The stream stamped on metadata at registration: the reproduction
+   * contract, without which there is no persisted stream to continue.
+   */
+  readonly streamId?: StreamTabId;
+  readonly agentCategory?: AgentConfig['agentCategory'];
+  readonly outcome?: RunOutcome;
+}
+
+/**
+ * Whether the CLI may offer a run as continuable, from facts that cost a
+ * `stat` at most.
+ *
+ * Ownership is deliberately not inspected. A run another process is executing
+ * right now has a checkpoint and no outcome, so it is offered here and refused
+ * when the user opens it: one lease read on the run they picked instead of one
+ * per row. Loadability is not inspected either — a checkpoint that exists but
+ * cannot be parsed is refused at open time as `unusable_checkpoint`, which is
+ * what that cohort actually is.
+ *
+ * The one exception buys back a refusal the user would otherwise be walked
+ * into: a workflow that stopped at its round cap on an unresolved compile
+ * rejection has a checkpoint that only replays the same rejection. Reading it
+ * is a full Zod parse, so it runs only where such a rejection can have been
+ * recorded — `resolveOutcome` feeds `deriveRunOutcome` with `failed` ahead of
+ * `cancelled`, so a terminal rejection always finalizes the run FAILED. A
+ * cancelled or still-outcome-less workflow row, which is what people resume,
+ * costs one stat like every other row.
+ */
+export async function isCliRunResumable(
+  facts: CliRunResumabilityFacts,
 ): Promise<boolean> {
-  if (!entry.checkpointPresent || !entry.streamId) return false;
-  if (entry.record.agentCategory !== AgentCategory.Workflow) return true;
+  if (!facts.checkpointPresent || !facts.streamId) return false;
+  if (facts.agentCategory !== AgentCategory.Workflow) return true;
+  if (facts.outcome !== RUN_OUTCOME.FAILED) return true;
   try {
-    return !(await hasTerminalPersistedCompileRejection(entry.id));
+    return !(await hasTerminalPersistedCompileRejection(facts.id));
   } catch (error) {
     logger.warn(
-      `Not advertising workflow ${entry.id} as resumable: its persisted state is unreadable: ${toErrorMessage(error)}`,
+      `Not advertising workflow ${facts.id} as resumable: its persisted state is unreadable: ${toErrorMessage(error)}`,
       { data: error },
     );
     return false;
   }
 }
 
-async function readCliSessionResumeData(
-  id: ExecutionId,
-  config: AgentConfig,
-): Promise<CliSessionResumeData | null> {
-  // FK-first: the stream id stamped on execution metadata at registration is
-  // the reproduction contract — never re-derived from agent/model. A row
-  // without a stamped stream id has no persisted stream and is not resumable.
-  const streamId = (await getExecutionStore(id).readMeta())?.streamId;
-  if (!streamId) return null;
-  return (await retrieveSessionResumeData(streamId, id, config)) ?? null;
-}
-
 /**
- * Category-aware resume validation for the one run `history show` was asked
- * about, where a full checkpoint parse is proportionate: it answers both
- * "is there a category-valid flow record" and "what model would a resume run
- * under". Never throws — an unreadable flow record degrades to `null` rather
- * than failing the whole detail read.
+ * The model a resume of this run would actually use. A tool-use session that
+ * was switched to another model records that only inside its checkpoint, so
+ * `history show` parses it — one parse for the one run asked about — while a
+ * listing reports the model the run started under.
  *
- * It asks `classifyRun` rather than the durable-state-only
- * `deriveResumability` because it reports to a person: a run that is
- * executing right now also has a flow record and no outcome, and
- * `texra resume` would refuse it anyway.
+ * Never throws: a checkpoint that cannot be loaded has no model to report, and
+ * refusing such a run is the open path's job, not this row's.
  */
-export async function readCliResumeDataForDetails(
+export async function readCliResumedModel(
   id: ExecutionId,
   config: AgentConfig,
-): Promise<CliSessionResumeData | null> {
+): Promise<string | undefined> {
   try {
-    if ((await classifyRun(id)).kind !== 'resumable') return null;
-    if (
-      config.agentCategory === AgentCategory.Workflow &&
-      (await hasTerminalPersistedCompileRejection(id))
-    ) {
-      return null;
-    }
-    return await readCliSessionResumeData(id, config);
+    // FK-first: the stream id stamped on execution metadata at registration is
+    // the reproduction contract — never re-derived from agent/model.
+    const streamId = (await getExecutionStore(id).readMeta())?.streamId;
+    if (!streamId) return undefined;
+    const resume = await retrieveSessionResumeData(streamId, id, config);
+    return resume?.type === 'toolUse' ? resume.agentConfig.model : undefined;
   } catch (error) {
     logger.debug(
-      `Ignoring unreadable resume data for history entry ${id}: ${toErrorMessage(error)}`,
+      `No resumed model for history entry ${id}: ${toErrorMessage(error)}`,
     );
-    return null;
+    return undefined;
   }
 }

--- a/packages/cli/src/runtime/toolUseResumeData.ts
+++ b/packages/cli/src/runtime/toolUseResumeData.ts
@@ -4,7 +4,10 @@ import {
   retrieveSessionResumeData,
   type AgentConfig,
 } from '@agent/runtime';
-import { getExecutionStore } from '@agent/storage';
+import {
+  getExecutionStore,
+  type AgentExecutionListingEntry,
+} from '@agent/storage';
 import { createLog } from '@logger/logUtils';
 import { AgentCategory, type ExecutionId } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -13,6 +16,41 @@ const logger = createLog('CliToolUseResumeData');
 type CliSessionResumeData = NonNullable<
   Awaited<ReturnType<typeof retrieveSessionResumeData>>
 >;
+
+/**
+ * Whether a history listing may advertise a row as continuable, decided from
+ * facts the listing already carries: a checkpoint file exists (one `stat` per
+ * row in `listExecutions`) and the row has the stream id stamped on its
+ * metadata at registration — the reproduction contract, without which there is
+ * no persisted stream to continue.
+ *
+ * Ownership is deliberately not inspected here. A run another process is
+ * executing right now has a checkpoint and no outcome, so it lists as
+ * resumable and is refused when the user opens it; that costs one lease read
+ * on the one run they picked instead of one per row.
+ *
+ * The one read left is the workflow compile-rejection filter, and only for a
+ * workflow row the two free facts have already accepted: such a run's
+ * checkpoint exists but records a rejection at its round cap, so resume
+ * refuses it and the listing must not offer it. An unreadable or malformed
+ * record is not advertised either — that is unknown state, not a continuable
+ * run.
+ */
+export async function isCliListingResumable(
+  entry: AgentExecutionListingEntry,
+): Promise<boolean> {
+  if (!entry.checkpointPresent || !entry.streamId) return false;
+  if (entry.record.agentCategory !== AgentCategory.Workflow) return true;
+  try {
+    return !(await hasTerminalPersistedCompileRejection(entry.id));
+  } catch (error) {
+    logger.warn(
+      `Not advertising workflow ${entry.id} as resumable: its persisted state is unreadable: ${toErrorMessage(error)}`,
+      { data: error },
+    );
+    return false;
+  }
+}
 
 async function readCliSessionResumeData(
   id: ExecutionId,
@@ -27,17 +65,18 @@ async function readCliSessionResumeData(
 }
 
 /**
- * Category-aware, listing-safe resume validation. History listings enrich
- * many entries at once, so one unreadable flow record must not abort the whole
- * listing: degrade to `null` on retrieval failure. The returned value is the
- * same category-specific state accepted by the active resume path.
+ * Category-aware resume validation for the one run `history show` was asked
+ * about, where a full checkpoint parse is proportionate: it answers both
+ * "is there a category-valid flow record" and "what model would a resume run
+ * under". Never throws — an unreadable flow record degrades to `null` rather
+ * than failing the whole detail read.
  *
- * Listings advertise resumability to a person, so they ask `classifyRun`
- * rather than the durable-state-only `deriveResumability`: a run that is
+ * It asks `classifyRun` rather than the durable-state-only
+ * `deriveResumability` because it reports to a person: a run that is
  * executing right now also has a flow record and no outcome, and
  * `texra resume` would refuse it anyway.
  */
-export async function readCliResumeDataForListing(
+export async function readCliResumeDataForDetails(
   id: ExecutionId,
   config: AgentConfig,
 ): Promise<CliSessionResumeData | null> {

--- a/packages/cli/src/runtime/toolUseResumeData.ts
+++ b/packages/cli/src/runtime/toolUseResumeData.ts
@@ -42,33 +42,51 @@ export interface CliRunResumabilityFacts {
  * Ownership is deliberately not inspected. A run another process is executing
  * right now has a checkpoint and no outcome, so it is offered here and refused
  * when the user opens it: one lease read on the run they picked instead of one
- * per row. Loadability is not inspected either — a checkpoint that exists but
- * cannot be parsed is refused at open time as `unusable_checkpoint`, which is
- * what that cohort actually is.
+ * per row. Loadability is not inspected for its own sake either — a checkpoint
+ * that exists but cannot be parsed is refused at open time as
+ * `unusable_checkpoint`, which is what that cohort actually is — so where the
+ * exception below does read a record, a parse failure defers to open rather
+ * than deciding anything here.
  *
  * The one exception buys back a refusal the user would otherwise be walked
  * into: a workflow that stopped at its round cap on an unresolved compile
  * rejection has a checkpoint that only replays the same rejection. Reading it
- * is a full Zod parse, so it runs only where such a rejection can have been
- * recorded — `resolveOutcome` feeds `deriveRunOutcome` with `failed` ahead of
- * `cancelled`, so a terminal rejection always finalizes the run FAILED. A
- * cancelled or still-outcome-less workflow row, which is what people resume,
- * costs one stat like every other row.
+ * is a full Zod parse, so it runs only where such a rejection can still be
+ * recorded. `OutputNode` writes the marker during the final round, before the
+ * run lifecycle records `meta.outcome`, so the terminal outcomes that prove
+ * `resolveOutcome` already ran — CANCELLED and COMPLETED, neither of which
+ * `deriveRunOutcome` can produce over a terminal rejection — skip the parse,
+ * while FAILED and a missing outcome are read.
+ *
+ * The cost of covering the missing outcome is one parse per outcome-less
+ * workflow row that already passed both free gates: a workflow that crashed
+ * between the marker write and its finalization. Legacy rows predating the
+ * outcome field are outcome-less too but carry no stamped stream id, so they
+ * are refused by the gate above without a read.
  */
 export async function isCliRunResumable(
   facts: CliRunResumabilityFacts,
 ): Promise<boolean> {
   if (!facts.checkpointPresent || !facts.streamId) return false;
   if (facts.agentCategory !== AgentCategory.Workflow) return true;
-  if (facts.outcome !== RUN_OUTCOME.FAILED) return true;
+  if (
+    facts.outcome === RUN_OUTCOME.CANCELLED ||
+    facts.outcome === RUN_OUTCOME.COMPLETED
+  ) {
+    return true;
+  }
   try {
     return !(await hasTerminalPersistedCompileRejection(facts.id));
   } catch (error) {
+    // A record that cannot be read is not evidence of a terminal rejection,
+    // and hiding the row would be the one silent refusal on this surface:
+    // every other unreadable checkpoint is advertised and refused at open as
+    // `unusable_checkpoint`. Advertise, and let the open path word it.
     logger.warn(
-      `Not advertising workflow ${facts.id} as resumable: its persisted state is unreadable: ${toErrorMessage(error)}`,
+      `Advertising workflow ${facts.id} as resumable without reading its persisted state: ${toErrorMessage(error)}`,
       { data: error },
     );
-    return false;
+    return true;
   }
 }
 

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -24,13 +24,18 @@ import type { FollowUpRecoveryLease } from './ToolUseFollowUpQueueManager';
  * {@link presentFollowUpResult}.
  *
  * - `finished`: the run has no checkpoint left to continue from.
+ * - `unusable_checkpoint`: a checkpoint file is there but could not be turned
+ *   into resume state (malformed, a spent cursor, shared state the category
+ *   no longer accepts). A history listing advertises a run from the file
+ *   alone, so this is the refusal that cohort meets — never `finished`, which
+ *   would claim the run ended normally.
  * - `owned_elsewhere`: another TeXRA process holds the run.
  * - `not_resumable`: the stream has no live flow here and the submission was
  *   refused (a terminalized queue, a disposed session, a run this process
  *   cannot classify).
  */
 export type FollowUpFailureReason =
-  'finished' | 'owned_elsewhere' | 'not_resumable';
+  'finished' | 'unusable_checkpoint' | 'owned_elsewhere' | 'not_resumable';
 
 /**
  * Three outcomes: the input reached a live flow, it waits in the stream's
@@ -67,6 +72,8 @@ interface SubmitFollowUpOptions {
 
 const FAILURE_MESSAGES: Record<FollowUpFailureReason, string> = {
   finished: 'This run has finished. Start a new agent task to continue.',
+  unusable_checkpoint:
+    "This run's saved state could not be loaded, so it cannot be continued. Delete it from history and start a new agent task.",
   owned_elsewhere:
     'This run is live in another TeXRA window. Send the message there.',
   not_resumable:

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -10,7 +10,10 @@
  */
 
 import { deriveResumability } from '@agent/storage';
-import type { FlowRecord } from '@agent/node/persistedFlow';
+import {
+  PersistedFlowStateError,
+  type FlowRecord,
+} from '@agent/node/persistedFlow';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { ReflectionFlowStateSchema } from '@agent/implementations/flows/reflection/ReflectionFlowState';
 import {
@@ -64,8 +67,15 @@ async function probeResumableFlowRecord(
   const resumability = await deriveResumability(executionId);
   if (resumability.kind === 'checkpoint') return resumability.flowRecord;
   // Unreadable storage is a failure to report, never "nothing to resume":
-  // the caller's catch re-wraps it so hosts can word the difference.
+  // the caller's catch re-wraps it so hosts can word the difference. A record
+  // that is present but malformed is the one fault that names the checkpoint
+  // itself, so it throws the typed error the resume boundary refuses as
+  // unusable saved state; a metadata or transient read failure stays an
+  // untyped operational error there.
   if (resumability.kind === 'unreadable') {
+    if (resumability.fault === 'checkpoint-malformed') {
+      throw new PersistedFlowStateError(executionId, 'unsupported-record');
+    }
     throw new Error(`Unable to read resume storage: ${resumability.cause}`);
   }
   logger.warn('Execution is not resumable', {

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -75,11 +75,7 @@ export {
 } from './terminalResultToast';
 
 // resumeRun
-export {
-  lookupStreamExecutionId,
-  probeResumeRefusal,
-  resumeRun,
-} from './resumeRun';
+export { lookupStreamExecutionId, resumeRun } from './resumeRun';
 export type { ResumeRunOptions } from './resumeRun';
 // The refusal wording a host applies to a `ResumeRunResult` failure, and the
 // stream -> execution lookup the stream-keyed host resume ports need.

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -75,7 +75,11 @@ export {
 } from './terminalResultToast';
 
 // resumeRun
-export { lookupStreamExecutionId, resumeRun } from './resumeRun';
+export {
+  lookupStreamExecutionId,
+  probeResumeRefusal,
+  resumeRun,
+} from './resumeRun';
 export type { ResumeRunOptions } from './resumeRun';
 // The refusal wording a host applies to a `ResumeRunResult` failure, and the
 // stream -> execution lookup the stream-keyed host resume ports need.

--- a/src/agent/runtime/resumeRun.ts
+++ b/src/agent/runtime/resumeRun.ts
@@ -18,9 +18,13 @@ import {
   type FollowUpFailureReason,
 } from '@agent/followUp/ToolUseFollowUp';
 import type { FollowUpRecoveryLease } from '@agent/followUp/ToolUseFollowUpQueueManager';
-import { ExecutionLeaseActiveError } from '@agent/storage/executionLease';
+import {
+  ExecutionLeaseActiveError,
+  inspectExecutionLease,
+} from '@agent/storage/executionLease';
 import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
-import { flowKey } from '@agent/node/persistedFlow';
+import { checkpointExists } from '@agent/storage/resumability';
+import { PersistedFlowStateError } from '@agent/node/persistedFlow';
 import { createLog } from '@logger/logUtils';
 import type { RecoveryContinuation } from '@platform/interfaces';
 import {
@@ -107,7 +111,8 @@ export interface ResumeRunOptions extends Pick<
    * (clearing a transcript, switching the focused stream) does it here rather
    * than reading the same checkpoint first to decide whether it may: a
    * history listing advertises a row from its checkpoint file alone (one
-   * `stat`, never a parse), so an unusable checkpoint refuses above this hook
+   * `stat`, never a parse) and inspects no lease per row, so both an unusable
+   * checkpoint and a run another TeXRA process holds refuse above this hook
    * with the user's window untouched. A rejection propagates to the caller; a
    * stop requested while it runs is honored, because
    * {@link isCancellationRequested} is re-read once it returns.
@@ -176,36 +181,24 @@ const REFUSED: ResumeRunResult = { failed: 'not_resumable' };
 const WORKFLOW_STARTED: ResumeRunResult = { started: true, delivered: true };
 
 /**
- * Retrieval yielded no resume state: say whether the checkpoint file is still
- * on disk. `unusable_checkpoint` when it is — history listings advertise a row
- * from that file alone (one `stat`, never a parse), so this cohort must meet a
- * refusal worded as unusable state, never as a run that finished. `undefined`
- * when the file is gone, leaving the caller to word a finished run or rethrow
- * the storage failure it caught.
+ * Positive evidence that the checkpoint itself is what failed, walking the
+ * cause chain the retrieval boundary wraps its failures in. `persistedFlow`
+ * throws this for a record that cannot be resumed (malformed, spent, an
+ * unsupported format); its `read-failed` reason is a transient storage
+ * failure, which is not evidence about the record. Every other failure on the
+ * resume path — a rejected snapshot preload, a KV or metadata read, a lease
+ * read — stays the operational error the host words with its cause.
  */
-async function unusableCheckpointReason(
-  executionId: ExecutionId,
-  cause?: unknown,
-): Promise<'unusable_checkpoint' | undefined> {
-  let present: boolean;
-  try {
-    present = await getExecutionStore(executionId).exists(flowKey(executionId));
-  } catch (error) {
-    // The stat itself failing is evidence of nothing; keep the caller's own
-    // error rather than replacing it with this one.
-    log.warn(
-      `Could not stat the checkpoint of ${executionId}: ${toErrorMessage(error)}`,
-      { data: error },
-    );
-    return undefined;
+function namesUnusableCheckpoint(error: unknown): boolean {
+  for (let current = error, depth = 0; depth < 8; depth++) {
+    if (current instanceof PersistedFlowStateError) {
+      return current.reason !== 'read-failed';
+    }
+    if (!(current instanceof Error) || current.cause === undefined)
+      return false;
+    current = current.cause;
   }
-  if (!present) return undefined;
-  log.warn(
-    `Refusing to resume ${executionId}: its checkpoint holds no resumable state${
-      cause === undefined ? '.' : `: ${toErrorMessage(cause)}`
-    }`,
-  );
-  return 'unusable_checkpoint';
+  return false;
 }
 
 export async function resumeRun(
@@ -297,11 +290,15 @@ async function resumeRunWithRecoveryProvenance(
   } catch (error) {
     if (queueLease) session.followUps.release(queueLease, 'recoverable');
     // A checkpoint that is on disk but cannot be turned into resume state (a
-    // malformed envelope, a spent cursor) throws here. That is a refusal to
-    // word for the row that advertised it, not an unexpected storage failure.
-    const reason = await unusableCheckpointReason(executionId, error);
-    if (!reason) throw error;
-    return { failed: reason };
+    // malformed envelope, an unsupported record) throws here. That is a
+    // refusal to word for the row that advertised it; anything else that
+    // failed on the way is the storage error it has always been.
+    if (!namesUnusableCheckpoint(error)) throw error;
+    log.warn(
+      `Refusing to resume ${executionId}: its checkpoint holds no resumable state: ${toErrorMessage(error)}`,
+      { data: error },
+    );
+    return { failed: 'unusable_checkpoint' };
   }
   if (
     isCancellationRequested() ||
@@ -330,11 +327,21 @@ async function resumeRunWithRecoveryProvenance(
     ) {
       return { failed };
     }
-    // The durable facts are read and nobody holds the run, so what is left is
-    // the checkpoint file: history listings advertise a row from that file
-    // alone (one `stat`, never a parse), so a present file must meet a refusal
-    // worded as unusable state, never as a run that finished.
-    return { failed: (await unusableCheckpointReason(executionId)) ?? failed };
+    // Nobody holds it, so the checkpoint file is what is left to word from.
+    // History listings advertise a row from that file alone (one `stat`,
+    // never a parse), so a record this category rejected and a malformed one
+    // both meet a refusal worded as unusable state rather than as a run that
+    // finished. Only `checkpoint-malformed` names the file itself; every
+    // other fault is a read that says nothing about it.
+    const unusable =
+      classification.kind === 'unclassified'
+        ? classification.fault === 'checkpoint-malformed'
+        : await checkpointExists(executionId);
+    if (!unusable) return { failed };
+    log.warn(
+      `Refusing to resume ${executionId}: its checkpoint holds no resumable state.`,
+    );
+    return { failed: 'unusable_checkpoint' };
   }
   // The run is about to be opened for write, its checkpoint just re-read. A
   // hold recorded by an earlier refusal describes facts this
@@ -348,6 +355,26 @@ async function resumeRunWithRecoveryProvenance(
   // queue lease agree; a disagreement refuses, so no host rearranges for it.
   const willLaunch = (resume.type === 'toolUse') === (queueLease !== undefined);
   if (willLaunch && options.onResumeResolved) {
+    // One lease read per open, taken here because the hook is where a host
+    // rearranges itself onto the resumed run: a row another TeXRA process is
+    // live on must refuse before that, not after the launch's own acquire
+    // raises `ExecutionLeaseActiveError` onto a cleared window. The acquire
+    // still settles the race this read cannot see.
+    const lease = await inspectExecutionLease(executionId).catch(
+      (error: unknown) => {
+        if (queueLease) session.followUps.release(queueLease, 'recoverable');
+        throw error;
+      },
+    );
+    if (lease.status === 'held') {
+      if (queueLease) session.followUps.release(queueLease, 'recoverable');
+      session.status.markUnavailableOrLog(
+        streamId,
+        streamHeldMessage(lease.owner),
+        log,
+      );
+      return { failed: 'owned_elsewhere' };
+    }
     try {
       await options.onResumeResolved();
     } catch (error) {

--- a/src/agent/runtime/resumeRun.ts
+++ b/src/agent/runtime/resumeRun.ts
@@ -20,6 +20,7 @@ import {
 import type { FollowUpRecoveryLease } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { ExecutionLeaseActiveError } from '@agent/storage/executionLease';
 import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
+import { flowKey } from '@agent/node/persistedFlow';
 import { createLog } from '@logger/logUtils';
 import type { RecoveryContinuation } from '@platform/interfaces';
 import {
@@ -30,6 +31,7 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { streamHeldMessage } from '@shared/streams/streamStatusDisplay';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import {
   isWaitingFlowResult,
@@ -153,11 +155,69 @@ export async function resumeStream(
 
 export { lookupStreamExecutionId } from '@agent/followUp/ToolUseFollowUp';
 
-const logger = createLog('ResumeRun');
+const log = createLog('ResumeRun');
 
 const REFUSED: ResumeRunResult = { failed: 'not_resumable' };
 /** A workflow run carries no follow-up batch, so nothing awaits delivery. */
 const WORKFLOW_STARTED: ResumeRunResult = { started: true, delivered: true };
+
+/**
+ * Retrieval yielded no resume state: say whether the checkpoint file is still
+ * on disk. `unusable_checkpoint` when it is — history listings advertise a row
+ * from that file alone (one `stat`, never a parse), so this cohort must meet a
+ * refusal worded as unusable state, never as a run that finished. `undefined`
+ * when the file is gone, leaving the caller to word a finished run or rethrow
+ * the storage failure it caught.
+ */
+async function unusableCheckpointReason(
+  executionId: ExecutionId,
+  cause?: unknown,
+): Promise<'unusable_checkpoint' | undefined> {
+  let present: boolean;
+  try {
+    present = await getExecutionStore(executionId).exists(flowKey(executionId));
+  } catch (error) {
+    // The stat itself failing is evidence of nothing; keep the caller's own
+    // error rather than replacing it with this one.
+    log.warn(
+      `Could not stat the checkpoint of ${executionId}: ${toErrorMessage(error)}`,
+      { data: error },
+    );
+    return undefined;
+  }
+  if (!present) return undefined;
+  log.warn(
+    `Refusing to resume ${executionId}: its checkpoint holds no resumable state${
+      cause === undefined ? '.' : `: ${toErrorMessage(cause)}`
+    }`,
+  );
+  return 'unusable_checkpoint';
+}
+
+/**
+ * Why this run cannot be continued, answered before a host mutates anything to
+ * open it, or `undefined` when its persisted state loads. A history listing
+ * advertises a row from its checkpoint file alone, so the CLI chat asks here
+ * first and keeps the user's transcript and focused stream where they are when
+ * the answer is a refusal. A failure with no checkpoint left on disk is not a
+ * refusal at all and still throws.
+ */
+export async function probeResumeRefusal(
+  executionId: ExecutionId,
+  config: AgentConfig,
+  streamId: StreamTabId,
+): Promise<FollowUpFailureReason | undefined> {
+  try {
+    if (await retrieveSessionResumeData(streamId, executionId, config)) {
+      return undefined;
+    }
+  } catch (error) {
+    const reason = await unusableCheckpointReason(executionId, error);
+    if (!reason) throw error;
+    return reason;
+  }
+  return (await unusableCheckpointReason(executionId)) ?? 'finished';
+}
 
 export async function resumeRun(
   executionId: ExecutionId,
@@ -247,7 +307,12 @@ async function resumeRunWithRecoveryProvenance(
     });
   } catch (error) {
     if (queueLease) session.followUps.release(queueLease, 'recoverable');
-    throw error;
+    // A checkpoint that is on disk but cannot be turned into resume state (a
+    // malformed envelope, a spent cursor) throws here. That is a refusal to
+    // word for the row that advertised it, not an unexpected storage failure.
+    const reason = await unusableCheckpointReason(executionId, error);
+    if (!reason) throw error;
+    return { failed: reason };
   }
   if (
     isCancellationRequested() ||
@@ -260,20 +325,27 @@ async function resumeRunWithRecoveryProvenance(
   }
   if (!resume) {
     if (queueLease) session.followUps.release(queueLease, 'recoverable');
-    // Nothing came back, which is two facts in one `null`: the checkpoint is
-    // gone, or the record could not be read — a torn read of the rewrite the
-    // process that owns this run is making right now parses as absent. Only
-    // the lease separates them, so this refusal is decided by `classifyRun`
-    // and recorded through the same mapping the follow-up path uses: a run
-    // held elsewhere refreshes the hold instead of dropping it and being
-    // reported finished, and an unreadable one moves nothing.
-    return {
-      failed: recordRunRefusal(
-        streamId,
-        session,
-        await classifyRun(executionId),
-      ),
-    };
+    // Nothing came back, which is several facts in one `null`: the checkpoint
+    // is gone, the record could not be read — a torn read of the rewrite the
+    // process that owns this run is making right now parses as absent — or the
+    // file is there and holds no state this category can resume. Ownership is
+    // what the lease alone settles, so the refusal is decided first by
+    // `classifyRun` and recorded through the same mapping the follow-up path
+    // uses: a run held elsewhere refreshes the hold instead of dropping it and
+    // being reported finished.
+    const classification = await classifyRun(executionId);
+    const failed = recordRunRefusal(streamId, session, classification);
+    if (
+      classification.kind === 'held_elsewhere' ||
+      classification.kind === 'owned_here'
+    ) {
+      return { failed };
+    }
+    // The durable facts are read and nobody holds the run, so what is left is
+    // the checkpoint file: history listings advertise a row from that file
+    // alone (one `stat`, never a parse), so a present file must meet a refusal
+    // worded as unusable state, never as a run that finished.
+    return { failed: (await unusableCheckpointReason(executionId)) ?? failed };
   }
   // The run is about to be opened for write, its checkpoint just re-read. A
   // hold recorded by an earlier refusal describes facts this
@@ -336,7 +408,7 @@ function refusalFor(
     session.status.markUnavailableOrLog(
       streamId,
       streamHeldMessage(error.owner),
-      logger,
+      log,
     );
     return { failed: 'owned_elsewhere' };
   }

--- a/src/agent/runtime/resumeRun.ts
+++ b/src/agent/runtime/resumeRun.ts
@@ -343,6 +343,23 @@ async function resumeRunWithRecoveryProvenance(
     );
     return { failed: 'unusable_checkpoint' };
   }
+  // Both branches below launch only when the checkpoint's category and the
+  // queue lease agree; a disagreement refuses, so no host rearranges for it.
+  const willLaunch = (resume.type === 'toolUse') === (queueLease !== undefined);
+  // One lease read per open, taken before the hold below is touched: a read
+  // that fails leaves the earlier refusal's hold standing, since this attempt
+  // learned nothing that disproves it. The hook is where a host rearranges
+  // itself onto the resumed run, so a row another TeXRA process is live on
+  // must refuse before that, not after the launch's own acquire raises
+  // `ExecutionLeaseActiveError` onto a cleared window. The acquire still
+  // settles the race this read cannot see.
+  const lease =
+    willLaunch && options.onResumeResolved
+      ? await inspectExecutionLease(executionId).catch((error: unknown) => {
+          if (queueLease) session.followUps.release(queueLease, 'recoverable');
+          throw error;
+        })
+      : undefined;
   // The run is about to be opened for write, its checkpoint just re-read. A
   // hold recorded by an earlier refusal describes facts this
   // attempt has now re-read, so it goes, and the phase it retained goes with
@@ -351,30 +368,16 @@ async function resumeRunWithRecoveryProvenance(
   // refused below writes the current reason; one that acquires leaves the
   // phase it lands on.
   session.status.clearHold(streamId, { discardRetainedPhase: true });
-  // Both branches below launch only when the checkpoint's category and the
-  // queue lease agree; a disagreement refuses, so no host rearranges for it.
-  const willLaunch = (resume.type === 'toolUse') === (queueLease !== undefined);
-  if (willLaunch && options.onResumeResolved) {
-    // One lease read per open, taken here because the hook is where a host
-    // rearranges itself onto the resumed run: a row another TeXRA process is
-    // live on must refuse before that, not after the launch's own acquire
-    // raises `ExecutionLeaseActiveError` onto a cleared window. The acquire
-    // still settles the race this read cannot see.
-    const lease = await inspectExecutionLease(executionId).catch(
-      (error: unknown) => {
-        if (queueLease) session.followUps.release(queueLease, 'recoverable');
-        throw error;
-      },
+  if (lease?.status === 'held') {
+    if (queueLease) session.followUps.release(queueLease, 'recoverable');
+    session.status.markUnavailableOrLog(
+      streamId,
+      streamHeldMessage(lease.owner),
+      log,
     );
-    if (lease.status === 'held') {
-      if (queueLease) session.followUps.release(queueLease, 'recoverable');
-      session.status.markUnavailableOrLog(
-        streamId,
-        streamHeldMessage(lease.owner),
-        log,
-      );
-      return { failed: 'owned_elsewhere' };
-    }
+    return { failed: 'owned_elsewhere' };
+  }
+  if (willLaunch && options.onResumeResolved) {
     try {
       await options.onResumeResolved();
     } catch (error) {

--- a/src/agent/runtime/resumeRun.ts
+++ b/src/agent/runtime/resumeRun.ts
@@ -101,6 +101,20 @@ export interface ResumeRunOptions extends Pick<
    */
   readonly onFollowUpQueueReady?: (recovery: FollowUpRecoveryLease) => void;
   /**
+   * Fires once this run's persisted state has been retrieved and its launch
+   * is the next step. It is the last point at which a refusal costs the
+   * caller nothing, so a host that must rearrange itself onto the resumed run
+   * (clearing a transcript, switching the focused stream) does it here rather
+   * than reading the same checkpoint first to decide whether it may: a
+   * history listing advertises a row from its checkpoint file alone (one
+   * `stat`, never a parse), so an unusable checkpoint refuses above this hook
+   * with the user's window untouched. A rejection propagates to the caller; a
+   * stop requested while it runs is honored, because
+   * {@link isCancellationRequested} is re-read once it returns.
+   */
+  readonly onResumeResolved?: () => Promise<void> | void;
+
+  /**
    * Workflow launch owns stream acquisition and status transitions through
    * `runAgent`; each host supplies its own launcher.
    */
@@ -192,31 +206,6 @@ async function unusableCheckpointReason(
     }`,
   );
   return 'unusable_checkpoint';
-}
-
-/**
- * Why this run cannot be continued, answered before a host mutates anything to
- * open it, or `undefined` when its persisted state loads. A history listing
- * advertises a row from its checkpoint file alone, so the CLI chat asks here
- * first and keeps the user's transcript and focused stream where they are when
- * the answer is a refusal. A failure with no checkpoint left on disk is not a
- * refusal at all and still throws.
- */
-export async function probeResumeRefusal(
-  executionId: ExecutionId,
-  config: AgentConfig,
-  streamId: StreamTabId,
-): Promise<FollowUpFailureReason | undefined> {
-  try {
-    if (await retrieveSessionResumeData(streamId, executionId, config)) {
-      return undefined;
-    }
-  } catch (error) {
-    const reason = await unusableCheckpointReason(executionId, error);
-    if (!reason) throw error;
-    return reason;
-  }
-  return (await unusableCheckpointReason(executionId)) ?? 'finished';
 }
 
 export async function resumeRun(
@@ -355,6 +344,24 @@ async function resumeRunWithRecoveryProvenance(
   // refused below writes the current reason; one that acquires leaves the
   // phase it lands on.
   session.status.clearHold(streamId, { discardRetainedPhase: true });
+  // Both branches below launch only when the checkpoint's category and the
+  // queue lease agree; a disagreement refuses, so no host rearranges for it.
+  const willLaunch = (resume.type === 'toolUse') === (queueLease !== undefined);
+  if (willLaunch && options.onResumeResolved) {
+    try {
+      await options.onResumeResolved();
+    } catch (error) {
+      if (queueLease) session.followUps.release(queueLease, 'recoverable');
+      throw error;
+    }
+    if (
+      isCancellationRequested() ||
+      session.executions.isActiveOrResuming(streamId)
+    ) {
+      if (queueLease) session.followUps.release(queueLease, 'recoverable');
+      return REFUSED;
+    }
+  }
   if (resume.type === 'toolUse' && queueLease) {
     return resumeQueuedToolUse(session, resume, queueLease, options);
   }

--- a/src/agent/runtime/runClassification.ts
+++ b/src/agent/runtime/runClassification.ts
@@ -24,7 +24,10 @@
  */
 import { inspectExecutionLease } from '@agent/storage/executionLease';
 import type { LeaseOwnerRecord } from '@agent/storage/leaseOwnerLiveness';
-import { deriveResumability } from '@agent/storage/resumability';
+import {
+  deriveResumability,
+  type ResumabilityFault,
+} from '@agent/storage/resumability';
 import { createLog } from '@logger/logUtils';
 import type { ExecutionId, RunOutcome } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -36,7 +39,17 @@ export type RunClassification =
   | { readonly kind: 'owned_here' }
   | { readonly kind: 'resumable'; readonly outcome?: RunOutcome }
   | { readonly kind: 'finished'; readonly outcome?: RunOutcome }
-  | { readonly kind: 'unclassified'; readonly cause: string };
+  | {
+      readonly kind: 'unclassified';
+      readonly cause: string;
+      /**
+       * Which durable fact was unreadable, when a fact-level probe named one.
+       * A caller words a run's refusal from this, never from `cause`, which is
+       * display text. Absent when the classification failed above the facts
+       * (an unreadable stream index, a lease lock that could not be taken).
+       */
+      readonly fault?: ResumabilityFault | 'lease-unreadable';
+    };
 
 /** What the durable facts alone decide, ownership already settled. */
 export type RunFactsClassification = Exclude<
@@ -60,7 +73,7 @@ export async function classifyRunFacts(
     return { kind: 'finished', outcome: facts.outcome };
   }
   log.warn(`Cannot classify ${executionId}: ${facts.cause}`);
-  return { kind: 'unclassified', cause: facts.cause };
+  return { kind: 'unclassified', cause: facts.cause, fault: facts.fault };
 }
 
 /** Classify one execution. Never throws: an unreadable fact is `unclassified`. */
@@ -76,7 +89,7 @@ export async function classifyRun(
   } catch (error) {
     const cause = `lease unreadable (${toErrorMessage(error)})`;
     log.warn(`Cannot classify ${executionId}: ${cause}`, { data: error });
-    return { kind: 'unclassified', cause };
+    return { kind: 'unclassified', cause, fault: 'lease-unreadable' };
   }
   return classifyRunFacts(executionId);
 }

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -54,6 +54,20 @@ interface ExecutionListingBase {
   outcome?: RunOutcome;
   /** AI-generated summary of what the session aimed to accomplish. */
   description?: string;
+  /**
+   * Whether a checkpoint (persisted flow record) exists on disk — one `stat`
+   * per row, never a parse. This is what a listing needs to advertise "this
+   * run can be continued"; deciding whether the record is actually loadable
+   * belongs to the resume path, which parses it once for the one run asked
+   * for and refuses loudly.
+   */
+  checkpointPresent: boolean;
+  /**
+   * The stream stamped on metadata at registration — the reproduction
+   * contract. Absent on rows written before stamping, which have no
+   * persisted stream to continue.
+   */
+  streamId?: StreamTabId;
 }
 
 /** A native or tool-backed agent run: its record is always an AgentConfig. */
@@ -237,16 +251,18 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
   const entries = await readDirOrEmpty(RUNS_STORAGE_DIR);
   const executionDirs = listExecutionDirs(entries);
 
-  // Read meta + config with bounded concurrency. Large histories should not
-  // enqueue one storage read pair per execution all at once.
+  // Read meta + config, and stat the checkpoint, with bounded concurrency.
+  // Large histories should not enqueue one storage read burst per execution
+  // all at once.
   const results = await pMap(
     executionDirs,
     async (id): Promise<ExecutionListingEntry | null> => {
       try {
         const store = getExecutionStore(id);
-        const [meta, record] = await Promise.all([
+        const [meta, record, checkpointPresent] = await Promise.all([
           store.readMeta(),
           store.readRunRecord(),
+          store.exists(flowKey(id)),
         ]);
 
         if (!meta) return null;
@@ -257,6 +273,8 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
           parentExecutionId: meta.parentExecutionId,
           outcome: meta.outcome,
           description: meta.description,
+          checkpointPresent,
+          streamId: meta.streamId,
         };
         const agentRecord = record && isAgentRunRecord(record) ? record : null;
         const identity = meta.identity;

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -32,6 +32,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { isDirectory } from '@utils/files/fsEntryType';
 
 import { getExecutionStore } from './ExecutionKVStore';
+import { checkpointExists } from './resumability';
 import {
   inspectExecutionLease,
   runWithInactiveExecutionLease,
@@ -259,10 +260,13 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
     async (id): Promise<ExecutionListingEntry | null> => {
       try {
         const store = getExecutionStore(id);
+        // The checkpoint probe answers "no" and warns when the `stat` itself
+        // fails: a row whose meta and record are readable still belongs in
+        // history, and the open path re-reads the file anyway.
         const [meta, record, checkpointPresent] = await Promise.all([
           store.readMeta(),
           store.readRunRecord(),
-          store.exists(flowKey(id)),
+          checkpointExists(id),
         ]);
 
         if (!meta) return null;

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -45,10 +45,11 @@ export {
   deleteAllExecutions,
   isUserVisibleExecution,
 } from './executionListing';
-export { deriveResumability, type ResumabilityDecision } from './resumability';
-/** The KV key of a run's checkpoint: hosts `stat` it to answer "is there
- *  something to continue" without parsing the record. */
-export { flowKey } from '@agent/node/persistedFlow';
+export {
+  checkpointExists,
+  deriveResumability,
+  type ResumabilityDecision,
+} from './resumability';
 export { formatConversationMessage } from './conversationFormat';
 export {
   ExecutionLeaseActiveError,

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -46,6 +46,9 @@ export {
   isUserVisibleExecution,
 } from './executionListing';
 export { deriveResumability, type ResumabilityDecision } from './resumability';
+/** The KV key of a run's checkpoint: hosts `stat` it to answer "is there
+ *  something to continue" without parsing the record. */
+export { flowKey } from '@agent/node/persistedFlow';
 export { formatConversationMessage } from './conversationFormat';
 export {
   ExecutionLeaseActiveError,

--- a/src/agent/storage/resumability.ts
+++ b/src/agent/storage/resumability.ts
@@ -33,6 +33,20 @@ const ResumableFlowRecordSchema = PersistedFlowRecordEnvelopeSchema.refine(
 });
 
 /**
+ * Which durable fact was unreadable. Only `checkpoint-malformed` positively
+ * names the checkpoint's own content, so it is the one fault a caller may
+ * word as "this run's saved state cannot be resumed"; the rest are read
+ * failures that say nothing about the checkpoint and stay operational
+ * errors. Callers discriminate on this, never on {@link
+ * ResumabilityDecision.cause}, which is display text.
+ */
+export type ResumabilityFault =
+  | 'metadata-unreadable'
+  | 'metadata-malformed'
+  | 'checkpoint-unreadable'
+  | 'checkpoint-malformed';
+
+/**
  * What the durable run facts alone say about continuing an execution:
  * a valid checkpoint exists, nothing is left to resume, or the storage
  * itself could not be read (reported with its cause, never guessed).
@@ -44,7 +58,11 @@ export type ResumabilityDecision =
       readonly outcome?: RunOutcome;
     }
   | { readonly kind: 'none'; readonly outcome?: RunOutcome }
-  | { readonly kind: 'unreadable'; readonly cause: string };
+  | {
+      readonly kind: 'unreadable';
+      readonly cause: string;
+      readonly fault: ResumabilityFault;
+    };
 
 /**
  * Single storage-owned resumability decision.
@@ -72,6 +90,7 @@ export async function deriveResumability(
     );
     return {
       kind: 'unreadable',
+      fault: 'metadata-unreadable',
       cause: `execution metadata could not be read (${toErrorMessage(error)})`,
     };
   }
@@ -86,7 +105,11 @@ export async function deriveResumability(
         )}`,
         { data: metaResult.error },
       );
-      return { kind: 'unreadable', cause: 'execution metadata is malformed' };
+      return {
+        kind: 'unreadable',
+        fault: 'metadata-malformed',
+        cause: 'execution metadata is malformed',
+      };
     }
     meta = metaResult.data;
   }
@@ -102,6 +125,7 @@ export async function deriveResumability(
     );
     return {
       kind: 'unreadable',
+      fault: 'checkpoint-unreadable',
       cause: `checkpoint could not be read (${toErrorMessage(error)})`,
     };
   }
@@ -113,8 +137,36 @@ export async function deriveResumability(
   const flowResult = ResumableFlowRecordSchema.safeParse(rawFlowRecord);
   if (!flowResult.success) {
     // A present-but-malformed checkpoint is corruption, not an absent run.
-    return { kind: 'unreadable', cause: 'checkpoint is malformed' };
+    return {
+      kind: 'unreadable',
+      fault: 'checkpoint-malformed',
+      cause: 'checkpoint is malformed',
+    };
   }
 
   return { kind: 'checkpoint', flowRecord: flowResult.data, ...metaFields };
+}
+
+/**
+ * Whether a run's checkpoint file is on disk — one `stat`, never a parse.
+ *
+ * A probe that fails answers "no checkpoint" and says so at `warn` with the
+ * execution it belongs to: a listing must still show the row it can read from
+ * meta and record rather than dropping the run out of history, and the open
+ * path re-reads the file and refuses there if it disagrees.
+ */
+export async function checkpointExists(
+  executionId: ExecutionId,
+): Promise<boolean> {
+  try {
+    return await getExecutionStore(executionId).exists(flowKey(executionId));
+  } catch (error) {
+    log.warn(
+      `Could not stat the checkpoint of ${executionId}: ${toErrorMessage(
+        error,
+      )}`,
+      { data: error },
+    );
+    return false;
+  }
 }

--- a/src/test-kernel/agent/runtime/resumeRun.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeRun.vitest.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { PersistedFlowStateError } from '@agent/node/persistedFlow';
 import type { ResumeToolUseFromResumeDataOptions } from '@agent/runtime/executeAgent';
 import { resumeRun, resumeStream } from '@agent/runtime/resumeRun';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { AgentCategory, RUN_OUTCOME } from '@shared/schemas';
+import { streamHeldMessage } from '@shared/streams/streamStatusDisplay';
 import { createDeferred } from '@test/support/asyncTestUtils';
 import { createTestSession } from '@test/support/sessionTestUtils';
 import { createToolUseResumeData } from '@test/support/toolUseResumeTestUtils';
@@ -26,11 +28,17 @@ vi.mock('@agent/storage/ExecutionKVStore', async (importActual) => ({
 }));
 
 // The refusal path re-reads the durable facts, which the fixtures below do
-// not seed: the store double answers only `readConfig`/`readMeta`.
+// not seed: the store double answers only `readConfig`/`readMeta`/`exists`.
 const classifyRunMock = vi.hoisted(() => vi.fn());
 vi.mock('@agent/runtime/runClassification', async (importActual) => ({
   ...(await importActual<typeof import('@agent/runtime/runClassification')>()),
   classifyRun: classifyRunMock,
+}));
+
+const inspectExecutionLeaseMock = vi.hoisted(() => vi.fn());
+vi.mock('@agent/storage/executionLease', async (importActual) => ({
+  ...(await importActual<typeof import('@agent/storage/executionLease')>()),
+  inspectExecutionLease: inspectExecutionLeaseMock,
 }));
 
 const readExecutionStreamIndexMock = vi.hoisted(() => vi.fn());
@@ -90,6 +98,7 @@ describe('resumeRun tool-use queue ownership', () => {
     });
     retrieveSessionResumeDataMock.mockReset().mockResolvedValue(snapshot());
     classifyRunMock.mockReset().mockResolvedValue({ kind: 'finished' });
+    inspectExecutionLeaseMock.mockReset().mockResolvedValue({ status: 'free' });
     readExecutionStreamIndexMock.mockReset().mockResolvedValue({
       byStream: new Map([[STREAM, EXECUTION]]),
       unreadable: new Map(),
@@ -362,10 +371,12 @@ describe('resumeRun tool-use queue ownership', () => {
         void retrieveSessionResumeDataMock.mockResolvedValueOnce(null),
     ],
     [
-      'retrieval throws on malformed state',
+      'retrieval throws on a record it cannot resume',
       (): void =>
         void retrieveSessionResumeDataMock.mockRejectedValueOnce(
-          new Error('Unable to read resume storage: checkpoint is malformed'),
+          new Error('Failed to retrieve tool-use resume data', {
+            cause: new PersistedFlowStateError(EXECUTION, 'unsupported-record'),
+          }),
         ),
     ],
   ])(
@@ -385,4 +396,40 @@ describe('resumeRun tool-use queue ownership', () => {
       expect(resumeToolUseFromResumeDataMock).not.toHaveBeenCalled();
     },
   );
+
+  // Only a cause that names the checkpoint refuses as unusable state. A
+  // transient storage failure is the operational error it has always been, so
+  // the host words it with the cause instead of telling the user to delete a
+  // run whose saved state may be fine.
+  it('propagates a transient retrieval failure over a present checkpoint', async () => {
+    const session = createSession();
+    getExecutionStoreMock.mockReturnValue({
+      readConfig: async () => snapshot().agentConfig,
+      readMeta: async () => ({ streamId: STREAM }),
+      exists: async () => true,
+    });
+    retrieveSessionResumeDataMock.mockRejectedValueOnce(
+      new Error('KV timeout'),
+    );
+
+    await expect(
+      resumeRun(EXECUTION, { session, executeWorkflow }),
+    ).rejects.toThrow('KV timeout');
+  });
+
+  // The launch's own acquire would raise `ExecutionLeaseActiveError` only
+  // after the host cleared its window and switched onto the resumed stream.
+  it('refuses a run a live foreign owner holds before the host rearranges', async () => {
+    const session = createSession();
+    const owner = { pid: 4321, hostname: 'other-host' };
+    inspectExecutionLeaseMock.mockResolvedValue({ status: 'held', owner });
+    const onResumeResolved = vi.fn();
+
+    await expect(
+      resumeRun(EXECUTION, { session, executeWorkflow, onResumeResolved }),
+    ).resolves.toEqual({ failed: 'owned_elsewhere' });
+    expect(onResumeResolved).not.toHaveBeenCalled();
+    expect(resumeToolUseFromResumeDataMock).not.toHaveBeenCalled();
+    expect(session.status.holdState(STREAM)).toBe(streamHeldMessage(owner));
+  });
 });

--- a/src/test-kernel/agent/runtime/resumeRun.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeRun.vitest.ts
@@ -86,6 +86,7 @@ describe('resumeRun tool-use queue ownership', () => {
     getExecutionStoreMock.mockReset().mockReturnValue({
       readConfig: async () => snapshot().agentConfig,
       readMeta: async () => ({ streamId: STREAM }),
+      exists: async () => false,
     });
     retrieveSessionResumeDataMock.mockReset().mockResolvedValue(snapshot());
     classifyRunMock.mockReset().mockResolvedValue({ kind: 'finished' });
@@ -308,6 +309,7 @@ describe('resumeRun tool-use queue ownership', () => {
         agentCategory: AgentCategory.Workflow,
       }),
       readMeta: async () => ({ streamId: STREAM }),
+      exists: async () => false,
     });
     retrieveSessionResumeDataMock.mockResolvedValueOnce(null);
 
@@ -348,4 +350,39 @@ describe('resumeRun tool-use queue ownership', () => {
     ).resolves.toEqual({ failed: 'owned_elsewhere' });
     expect(session.status.holdState(STREAM)).toContain('4321');
   });
+
+  // History listings advertise a row from the checkpoint file alone, so a file
+  // that yields no resume state is refused as unusable state — telling that
+  // user the run "has finished", or throwing retrieval's internal wording at
+  // them, are the two ways this used to go wrong.
+  it.each([
+    [
+      'retrieval answers empty',
+      (): void =>
+        void retrieveSessionResumeDataMock.mockResolvedValueOnce(null),
+    ],
+    [
+      'retrieval throws on malformed state',
+      (): void =>
+        void retrieveSessionResumeDataMock.mockRejectedValueOnce(
+          new Error('Unable to read resume storage: checkpoint is malformed'),
+        ),
+    ],
+  ])(
+    'refuses a checkpoint as unusable when %s',
+    async (_description, arrange) => {
+      const session = createSession();
+      getExecutionStoreMock.mockReturnValue({
+        readConfig: async () => snapshot().agentConfig,
+        readMeta: async () => ({ streamId: STREAM }),
+        exists: async () => true,
+      });
+      arrange();
+
+      await expect(
+        resumeRun(EXECUTION, { session, executeWorkflow }),
+      ).resolves.toEqual({ failed: 'unusable_checkpoint' });
+      expect(resumeToolUseFromResumeDataMock).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
@@ -142,6 +142,7 @@ describe('execution listing normalization', () => {
         timestamp: '2026-07-15T10:00:00.000Z',
         identity: { kind: 'agent', agent: 'assistant' },
         record: agentConfig,
+        checkpointPresent: false,
       },
     ]);
     expect(entries.filter(isUserVisibleExecution)).toHaveLength(1);
@@ -188,6 +189,7 @@ describe('execution listing normalization', () => {
       kind: 'incomplete',
       id: incompleteId,
       timestamp: '2026-07-15T07:00:00.000Z',
+      checkpointPresent: false,
     });
     expect(entries.filter(isUserVisibleExecution)).toEqual([entries[1]]);
   });

--- a/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
@@ -72,6 +72,22 @@ describe('execution listing normalization', () => {
     ]);
   });
 
+  // A row is dropped only when the facts it is built from are unreadable. The
+  // checkpoint probe is not one of them: it decides an advertisement, so a
+  // failing `stat` costs the row its Resume affordance, never its place in
+  // history.
+  it('keeps a row whose checkpoint probe fails, without a checkpoint', async () => {
+    const id = 'eee556' as ExecutionId;
+    await writeExecution(id, '2026-07-15T11:00:00.000Z', config('assistant'));
+    vi.spyOn(getExecutionStore(id), 'exists').mockRejectedValue(
+      new Error('stat failed'),
+    );
+
+    expect(await listExecutions()).toEqual([
+      expect.objectContaining({ id, kind: 'run', checkpointPresent: false }),
+    ]);
+  });
+
   it('lists only readable execution metadata with an explicit stream reference', async () => {
     const referenced = 'f9892001' as ExecutionId;
     const withoutStream = 'f9892002' as ExecutionId;

--- a/src/test-kernel/agent/storage/Resumability.vitest.ts
+++ b/src/test-kernel/agent/storage/Resumability.vitest.ts
@@ -209,6 +209,9 @@ describe('deriveResumability', () => {
 
     await expect(deriveResumability(executionId)).resolves.toEqual({
       kind: 'unreadable',
+      // The one fault that names the record itself: callers refuse this
+      // cohort as unusable saved state, and every other fault operationally.
+      fault: 'checkpoint-malformed',
       cause: 'checkpoint is malformed',
     });
   });

--- a/src/test-kernel/cli/ChatDefaults.vitest.ts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.ts
@@ -72,6 +72,7 @@ function historyEntry(
     id: 'abc123' as ExecutionId,
     timestamp,
     identity: { kind: 'agent', agent },
+    checkpointPresent: false,
     record: AgentConfigSchema.parse({
       agent,
       model: 'sonnet46T',

--- a/src/test-kernel/cli/History.vitest.ts
+++ b/src/test-kernel/cli/History.vitest.ts
@@ -35,7 +35,7 @@ const mocks = vi.hoisted(() => ({
   listExecutions: vi.fn(),
   deleteExecution: vi.fn(),
   deleteAllExecutions: vi.fn(),
-  readCliResumeDataForListing: vi.fn(),
+  readCliResumeDataForDetails: vi.fn(),
   assembleTrace: vi.fn(),
 }));
 
@@ -62,9 +62,17 @@ vi.mock('@agent/storage', async () => {
   };
 });
 
-vi.mock('@cli/runtime/toolUseResumeData', () => ({
-  readCliResumeDataForListing: mocks.readCliResumeDataForListing,
-}));
+// `isCliListingResumable` stays real: it is the listing rule under test, and
+// it decides from the listing row's own facts without touching storage.
+vi.mock('@cli/runtime/toolUseResumeData', async () => {
+  const actual = await vi.importActual<
+    typeof import('@cli/runtime/toolUseResumeData')
+  >('@cli/runtime/toolUseResumeData');
+  return {
+    ...actual,
+    readCliResumeDataForDetails: mocks.readCliResumeDataForDetails,
+  };
+});
 
 vi.mock('@transcript', async () => {
   const actual =
@@ -234,14 +242,12 @@ function mockBulkDelete(deleted: string[]): void {
   });
 }
 
-// An interrupted tool-use run whose resume data carries `agentConfig`, so the
-// history list labels it as resumable.
-function mockResumableToolUseListing(agentConfig: unknown): void {
-  mocks.readCliResumeDataForListing.mockResolvedValue({
-    type: 'toolUse',
-    agentConfig,
-  });
-}
+// The durable facts that make a listing row resumable: a checkpoint on disk
+// and the stream id stamped at registration.
+const RESUMABLE_ROW_FACTS = {
+  checkpointPresent: true,
+  streamId: 'correct@run#resumable' as StreamTabId,
+};
 
 // A fresh temp directory to point --assets-dir at.
 async function makeAssetsDestDir(prefix: string): Promise<string> {
@@ -279,7 +285,7 @@ describe('CLI history runtime', () => {
     mocks.readResultMeta.mockResolvedValue(null);
     mocks.readReport.mockResolvedValue(null);
     mocks.exists.mockResolvedValue(false);
-    mocks.readCliResumeDataForListing.mockResolvedValue(null);
+    mocks.readCliResumeDataForDetails.mockResolvedValue(null);
   });
 
   it('formats history list rows with the stable tab-separated text shape', async () => {
@@ -299,7 +305,9 @@ describe('CLI history runtime', () => {
         entry: entries[0],
       },
     ]);
-    expect(mocks.readCliResumeDataForListing).toHaveBeenCalledTimes(1);
+    // The listing reads no resume data at all: `resumable` comes from the
+    // checkpoint stat the listing already carries.
+    expect(mocks.readCliResumeDataForDetails).not.toHaveBeenCalled();
   });
 
   it('projects NDJSON status onto the frozen pre-consolidation vocabulary', async () => {
@@ -403,9 +411,9 @@ describe('CLI history runtime', () => {
         timestamp: '2026-05-18T10:00:00.000Z',
         record: teamConfig,
         outcome: 'cancelled',
+        ...RESUMABLE_ROW_FACTS,
       }),
     ]);
-    mockResumableToolUseListing(teamConfig);
 
     const entries = await listCliHistoryEntries();
 
@@ -425,9 +433,9 @@ describe('CLI history runtime', () => {
         record: chatConfig,
         outcome: 'cancelled',
         description: 'Sketch a proof outline',
+        ...RESUMABLE_ROW_FACTS,
       }),
     ]);
-    mockResumableToolUseListing(chatConfig);
 
     const entries = await listCliHistoryEntries();
 
@@ -567,7 +575,7 @@ describe('CLI history runtime', () => {
       agentCategory: 'toolUse',
     });
     mocks.readConfig.mockResolvedValue(toolUseConfig);
-    mocks.readCliResumeDataForListing.mockResolvedValue(
+    mocks.readCliResumeDataForDetails.mockResolvedValue(
       createToolUseResumeData({
         agentConfig: { ...toolUseConfig, model: 'gpt55' },
       }),

--- a/src/test-kernel/cli/History.vitest.ts
+++ b/src/test-kernel/cli/History.vitest.ts
@@ -11,7 +11,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { makeTempDir, useTempDirs } from '@test/support/tempDirPlatform';
-import { createToolUseResumeData } from '@test/support/toolUseResumeTestUtils';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { KVStore } from '@common/storage/KVStore';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
@@ -35,7 +34,7 @@ const mocks = vi.hoisted(() => ({
   listExecutions: vi.fn(),
   deleteExecution: vi.fn(),
   deleteAllExecutions: vi.fn(),
-  readCliResumeDataForDetails: vi.fn(),
+  readCliResumedModel: vi.fn(),
   assembleTrace: vi.fn(),
 }));
 
@@ -62,15 +61,15 @@ vi.mock('@agent/storage', async () => {
   };
 });
 
-// `isCliListingResumable` stays real: it is the listing rule under test, and
-// it decides from the listing row's own facts without touching storage.
+// `isCliRunResumable` stays real: it is the rule under test on both surfaces,
+// and it decides from the row's own facts without touching storage.
 vi.mock('@cli/runtime/toolUseResumeData', async () => {
   const actual = await vi.importActual<
     typeof import('@cli/runtime/toolUseResumeData')
   >('@cli/runtime/toolUseResumeData');
   return {
     ...actual,
-    readCliResumeDataForDetails: mocks.readCliResumeDataForDetails,
+    readCliResumedModel: mocks.readCliResumedModel,
   };
 });
 
@@ -285,7 +284,7 @@ describe('CLI history runtime', () => {
     mocks.readResultMeta.mockResolvedValue(null);
     mocks.readReport.mockResolvedValue(null);
     mocks.exists.mockResolvedValue(false);
-    mocks.readCliResumeDataForDetails.mockResolvedValue(null);
+    mocks.readCliResumedModel.mockResolvedValue(undefined);
   });
 
   it('formats history list rows with the stable tab-separated text shape', async () => {
@@ -307,7 +306,7 @@ describe('CLI history runtime', () => {
     ]);
     // The listing reads no resume data at all: `resumable` comes from the
     // checkpoint stat the listing already carries.
-    expect(mocks.readCliResumeDataForDetails).not.toHaveBeenCalled();
+    expect(mocks.readCliResumedModel).not.toHaveBeenCalled();
   });
 
   it('projects NDJSON status onto the frozen pre-consolidation vocabulary', async () => {
@@ -575,11 +574,7 @@ describe('CLI history runtime', () => {
       agentCategory: 'toolUse',
     });
     mocks.readConfig.mockResolvedValue(toolUseConfig);
-    mocks.readCliResumeDataForDetails.mockResolvedValue(
-      createToolUseResumeData({
-        agentConfig: { ...toolUseConfig, model: 'gpt55' },
-      }),
-    );
+    mocks.readCliResumedModel.mockResolvedValue('gpt55');
 
     const details = await readCliHistoryDetails('a1' as ExecutionId);
     const text = formatCliHistoryDetailsText(details!);

--- a/src/test-kernel/cli/HistoryStatus.vitest.ts
+++ b/src/test-kernel/cli/HistoryStatus.vitest.ts
@@ -194,4 +194,17 @@ describe('CLI history status formatting', () => {
       'Flow record: present',
     );
   });
+
+  // A checkpoint alone is not enough: without a config there is no category
+  // to resume under and nothing for a host to adopt, so the row says so.
+  it('does not offer a run whose config is missing as resumable', async () => {
+    const id = 'checkpoint-without-config' as ExecutionId;
+    await seedFlowRecord(id, TOOL_USE_CONFIG, 'orchestrator', {});
+    await getExecutionStore(id).delete('config');
+
+    const details = await readCliHistoryDetails(id);
+
+    expect(details?.hasFlowRecord).toBe(true);
+    expect(details?.status).not.toBe(HISTORY_RUN_STATUS.RESUMABLE);
+  });
 });

--- a/src/test-kernel/cli/HistoryStatus.vitest.ts
+++ b/src/test-kernel/cli/HistoryStatus.vitest.ts
@@ -131,20 +131,40 @@ describe('CLI history status formatting', () => {
     expect(text).not.toContain(`Status: ${EXECUTION_STATUS.COMPLETED}`);
   });
 
-  it('does not mark invalid flow records as resumable', async () => {
-    const id = 'abc123' as ExecutionId;
-    await seedFlowRecord(id, TOOL_USE_CONFIG, 'orchestrator', null);
+  // `status` is a frozen contract, so `history show` answers it from the same
+  // facts as `history list`: the checkpoint file, the stamped stream id, and
+  // the terminal-rejection filter. A record the resume path could not load is
+  // therefore still advertised here and refused, in its own words, on open —
+  // what it must never become is 'completed' (the crash-masking guard).
+  it.each([
+    [
+      'shared state that is not an object',
+      TOOL_USE_CONFIG,
+      'orchestrator',
+      null,
+    ],
+    [
+      'workflow state the category no longer accepts',
+      WORKFLOW_CONFIG,
+      'correct',
+      { currentRound: 1, totalRounds: 2, messages: [] },
+    ],
+  ])(
+    'still advertises a checkpoint with %s, and never calls it completed',
+    async (description, config, agent, shared) => {
+      const id = `unloadable-${description.split(' ')[0]}` as ExecutionId;
+      await seedFlowRecord(id, config, agent, shared);
 
-    const details = await readCliHistoryDetails(id);
+      const details = await readCliHistoryDetails(id);
 
-    expect(details?.hasFlowRecord).toBe(false);
-    // Absent terminal status without a valid flow record is reported as
-    // 'unknown', never invented as completed (crash-masking guard).
-    expect(details?.status).toBe('unknown');
-    expect(formatCliHistoryDetailsText(details!)).not.toContain(
-      'Flow record: present',
-    );
-  });
+      expect(details?.hasFlowRecord).toBe(true);
+      expect(details?.status).toBe(HISTORY_RUN_STATUS.RESUMABLE);
+      expect(details?.status).not.toBe(EXECUTION_STATUS.COMPLETED);
+      expect(formatCliHistoryDetailsText(details!)).toContain(
+        'Flow record: present',
+      );
+    },
+  );
 
   it('marks workflow flow records as CLI-resumable', async () => {
     const id = 'workflow-with-flow' as ExecutionId;
@@ -173,19 +193,5 @@ describe('CLI history status formatting', () => {
     expect(formatCliHistoryDetailsText(details!)).toContain(
       'Flow record: present',
     );
-  });
-
-  it('does not mark category-invalid workflow checkpoints as resumable', async () => {
-    const id = 'workflow-with-retired-state' as ExecutionId;
-    await seedFlowRecord(id, WORKFLOW_CONFIG, 'correct', {
-      currentRound: 1,
-      totalRounds: 2,
-      messages: [],
-    });
-
-    const details = await readCliHistoryDetails(id);
-
-    expect(details?.hasFlowRecord).toBe(false);
-    expect(details?.status).toBe('unknown');
   });
 });

--- a/src/test-kernel/cli/ResumeCommand.vitest.ts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.ts
@@ -6,7 +6,7 @@ import {
   AgentConfigSchema,
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
-import { flowKey } from '@agent/node/persistedFlow';
+import { flowKey, PersistedFlowStateError } from '@agent/node/persistedFlow';
 import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
 import {
   acquireFreshExecutionLease,
@@ -413,13 +413,10 @@ describe('runResumeExecution', () => {
 
     await expect(run(cliContext())).resolves.toBe(1);
 
-    // The run is refused as state that could not be loaded, and the fact that
-    // decided it stays in the message: this arm covers an unreadable lease as
-    // well as the malformed checkpoint a listing row can advertise.
+    // An unreadable lease says nothing about the checkpoint, so it keeps the
+    // operational wording rather than telling the user to delete the run.
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      "This run's saved state could not be loaded, so it cannot be continued. " +
-        'Delete it from history and start a new agent task. ' +
-        '(lease unreadable (lease disk offline))',
+      `Could not read the state of execution ${EXECUTION_ID}: lease unreadable (lease disk offline)`,
     );
     expect(mocks.retrieveSessionResumeData).not.toHaveBeenCalled();
   });
@@ -441,13 +438,28 @@ describe('runResumeExecution', () => {
     expect(mocks.runChat).not.toHaveBeenCalled();
   });
 
-  // Retrieval failing over a checkpoint that is still on disk is the same
-  // cohort a listing advertised, whatever failed inside it, so it earns the
-  // same refusal instead of an internal retrieval message. The cause is
-  // logged, not printed.
-  it('refuses a checkpoint whose retrieval fails as unusable state', async () => {
+  // A transient failure over a checkpoint that is still on disk says nothing
+  // about the record, so it stays the operational error it was.
+  it('reports a transient resume-state load failure as an operational error', async () => {
     await seedExecution({ config: WORKFLOW_CONFIG, meta: STAMPED_META });
     mocks.retrieveSessionResumeData.mockRejectedValue(new Error('KV timeout'));
+
+    await expect(run(cliContext())).resolves.toBe(1);
+
+    expect(mocks.runChat).not.toHaveBeenCalled();
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      `Could not load session ${EXECUTION_ID}: KV timeout`,
+    );
+  });
+
+  // The positive cohort: retrieval named the record itself, which is what a
+  // listing advertised from the file alone, so it earns the unusable-state
+  // refusal instead of an internal retrieval message.
+  it('refuses a checkpoint whose record cannot be resumed as unusable state', async () => {
+    await seedExecution({ config: WORKFLOW_CONFIG, meta: STAMPED_META });
+    mocks.retrieveSessionResumeData.mockRejectedValue(
+      new PersistedFlowStateError(EXECUTION_ID, 'unsupported-record'),
+    );
 
     await expect(run(cliContext())).resolves.toBe(2);
 

--- a/src/test-kernel/cli/ResumeCommand.vitest.ts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.ts
@@ -413,36 +413,47 @@ describe('runResumeExecution', () => {
 
     await expect(run(cliContext())).resolves.toBe(1);
 
+    // The run is refused as state that could not be loaded, and the fact that
+    // decided it stays in the message: this arm covers an unreadable lease as
+    // well as the malformed checkpoint a listing row can advertise.
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      `Could not read the state of execution ${EXECUTION_ID}: lease unreadable (lease disk offline)`,
+      "This run's saved state could not be loaded, so it cannot be continued. " +
+        'Delete it from history and start a new agent task. ' +
+        '(lease unreadable (lease disk offline))',
     );
     expect(mocks.retrieveSessionResumeData).not.toHaveBeenCalled();
   });
 
   // The checkpoint this seeds is readable, so the empty retrieval is the two
-  // readers disagreeing, not a finished run: the refusal is worded from the
-  // lease-aware classification, which still sees a checkpoint.
-  it('reports empty workflow retrieval against a live checkpoint as not resumable', async () => {
+  // readers disagreeing, not a finished run. The lease-aware classification
+  // decides that first and still sees a checkpoint; a history listing
+  // advertises a row from that file alone, so what the user is told is that
+  // the saved state could not be loaded, never that the run finished.
+  it('separates an unusable checkpoint from a run that finished', async () => {
     await seedExecution({ config: WORKFLOW_CONFIG, meta: STAMPED_META });
     mocks.retrieveSessionResumeData.mockResolvedValue(null);
 
     await expect(run(cliContext())).resolves.toBe(2);
 
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      'This run cannot accept messages right now. Resume it, or start a new agent task.',
+      "This run's saved state could not be loaded, so it cannot be continued. Delete it from history and start a new agent task.",
     );
     expect(mocks.runChat).not.toHaveBeenCalled();
   });
 
-  it('reports resume-state load failures as operational errors', async () => {
+  // Retrieval failing over a checkpoint that is still on disk is the same
+  // cohort a listing advertised, whatever failed inside it, so it earns the
+  // same refusal instead of an internal retrieval message. The cause is
+  // logged, not printed.
+  it('refuses a checkpoint whose retrieval fails as unusable state', async () => {
     await seedExecution({ config: WORKFLOW_CONFIG, meta: STAMPED_META });
     mocks.retrieveSessionResumeData.mockRejectedValue(new Error('KV timeout'));
 
-    await expect(run(cliContext())).resolves.toBe(1);
+    await expect(run(cliContext())).resolves.toBe(2);
 
     expect(mocks.runChat).not.toHaveBeenCalled();
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      `Could not load session ${EXECUTION_ID}: KV timeout`,
+      "This run's saved state could not be loaded, so it cannot be continued. Delete it from history and start a new agent task.",
     );
   });
 });

--- a/src/test-kernel/cli/ResumeCommand.vitest.ts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.ts
@@ -362,7 +362,7 @@ describe('runResumeExecution', () => {
     expect(mocks.runChat).not.toHaveBeenCalled();
   });
 
-  it('reports a row without a stamped stream id as finished', async () => {
+  it('names stream stamping when a row has no stream id', async () => {
     await seedExecution({
       config: TOOL_USE_CONFIG,
       meta: META_WITHOUT_STREAM_ID,
@@ -371,7 +371,7 @@ describe('runResumeExecution', () => {
     await expect(run(cliContext())).resolves.toBe(2);
 
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      'This run has finished. Start a new agent task to continue.',
+      `Execution ${EXECUTION_ID} predates transcript stream stamping and cannot be continued. Start a new agent task instead.`,
     );
     expect(mocks.runChat).not.toHaveBeenCalled();
   });

--- a/src/test-kernel/cli/ToolUseResumeData.vitest.ts
+++ b/src/test-kernel/cli/ToolUseResumeData.vitest.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { clearStoreCache, getExecutionStore } from '@agent/storage';
+import type { AgentExecutionListingEntry } from '@agent/storage';
 import type { AgentConfig } from '@agent/runtime';
 import { flowKey } from '@agent/node/persistedFlow';
-import { readCliResumeDataForListing } from '@cli/runtime/toolUseResumeData';
-import type { ExecutionId } from '@shared/schemas';
+import { isCliListingResumable } from '@cli/runtime/toolUseResumeData';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { StorageFS } from '@utils/files/storageFS';
 
@@ -15,6 +16,22 @@ const config = {
   agentCategory: 'workflow',
   model: 'deepseekT',
 } as AgentConfig;
+
+function listingEntry(
+  executionId: ExecutionId,
+  overrides: Partial<AgentExecutionListingEntry> = {},
+): AgentExecutionListingEntry {
+  return {
+    kind: 'run',
+    identity: { kind: 'agent', agent: config.agent },
+    id: executionId,
+    timestamp: '2026-05-18T08:00:00.000Z',
+    record: config,
+    checkpointPresent: true,
+    streamId: `${config.agent}@run#${executionId}` as StreamTabId,
+    ...overrides,
+  };
+}
 
 async function writeFlowRecord(
   executionId: ExecutionId,
@@ -33,7 +50,41 @@ afterEach(async () => {
   );
 });
 
-describe('CLI listing resume data', () => {
+describe('CLI listing resumability', () => {
+  it.each([
+    ['no checkpoint file', { checkpointPresent: false }],
+    ['no stamped stream id', { streamId: undefined }],
+  ])(
+    'does not advertise a row with %s, without reading its state',
+    async (description, overrides) => {
+      const executionId =
+        `gate-${description.replaceAll(' ', '-')}` as ExecutionId;
+      // A terminal rejection is on disk, so a `true` answer could only come
+      // from reading it — the two free facts must decide first.
+      await writeFlowRecord(executionId, {
+        currentRound: 1,
+        totalRounds: 2,
+        unresolvedCompileRejection: true,
+      });
+
+      await expect(
+        isCliListingResumable(listingEntry(executionId, overrides)),
+      ).resolves.toBe(false);
+    },
+  );
+
+  it('advertises a checkpointed, stamped row without parsing its checkpoint', async () => {
+    const executionId = 'toolUse-checkpointed' as ExecutionId;
+
+    await expect(
+      isCliListingResumable(
+        listingEntry(executionId, {
+          record: { ...config, agentCategory: 'toolUse' } as AgentConfig,
+        }),
+      ),
+    ).resolves.toBe(true);
+  });
+
   it.each([
     [
       'the unresolved rejection marker',
@@ -59,8 +110,8 @@ describe('CLI listing resume data', () => {
       await writeFlowRecord(executionId, shared);
 
       await expect(
-        readCliResumeDataForListing(executionId, config),
-      ).resolves.toBeNull();
+        isCliListingResumable(listingEntry(executionId)),
+      ).resolves.toBe(false);
     },
   );
 });

--- a/src/test-kernel/cli/ToolUseResumeData.vitest.ts
+++ b/src/test-kernel/cli/ToolUseResumeData.vitest.ts
@@ -1,11 +1,17 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { clearStoreCache, getExecutionStore } from '@agent/storage';
-import type { AgentExecutionListingEntry } from '@agent/storage';
 import type { AgentConfig } from '@agent/runtime';
 import { flowKey } from '@agent/node/persistedFlow';
-import { isCliListingResumable } from '@cli/runtime/toolUseResumeData';
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import {
+  isCliRunResumable,
+  type CliRunResumabilityFacts,
+} from '@cli/runtime/toolUseResumeData';
+import {
+  RUN_OUTCOME,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { StorageFS } from '@utils/files/storageFS';
 
@@ -17,21 +23,26 @@ const config = {
   model: 'deepseekT',
 } as AgentConfig;
 
-function listingEntry(
+/** A failed workflow row: the one shape whose checkpoint is still read. */
+function listingFacts(
   executionId: ExecutionId,
-  overrides: Partial<AgentExecutionListingEntry> = {},
-): AgentExecutionListingEntry {
+  overrides: Partial<CliRunResumabilityFacts> = {},
+): CliRunResumabilityFacts {
   return {
-    kind: 'run',
-    identity: { kind: 'agent', agent: config.agent },
     id: executionId,
-    timestamp: '2026-05-18T08:00:00.000Z',
-    record: config,
     checkpointPresent: true,
     streamId: `${config.agent}@run#${executionId}` as StreamTabId,
+    agentCategory: config.agentCategory,
+    outcome: RUN_OUTCOME.FAILED,
     ...overrides,
   };
 }
+
+const TERMINAL_REJECTION = {
+  currentRound: 1,
+  totalRounds: 2,
+  unresolvedCompileRejection: true,
+};
 
 async function writeFlowRecord(
   executionId: ExecutionId,
@@ -59,41 +70,39 @@ describe('CLI listing resumability', () => {
     async (description, overrides) => {
       const executionId =
         `gate-${description.replaceAll(' ', '-')}` as ExecutionId;
-      // A terminal rejection is on disk, so a `true` answer could only come
-      // from reading it — the two free facts must decide first.
-      await writeFlowRecord(executionId, {
-        currentRound: 1,
-        totalRounds: 2,
-        unresolvedCompileRejection: true,
-      });
+      // A continuable record is on disk, so reading it would answer `true`.
+      // Only the two free facts can produce the `false` asserted below.
+      await writeFlowRecord(executionId, { currentRound: 0, totalRounds: 4 });
 
       await expect(
-        isCliListingResumable(listingEntry(executionId, overrides)),
+        isCliRunResumable(listingFacts(executionId, overrides)),
       ).resolves.toBe(false);
     },
   );
 
-  it('advertises a checkpointed, stamped row without parsing its checkpoint', async () => {
-    const executionId = 'toolUse-checkpointed' as ExecutionId;
-
-    await expect(
-      isCliListingResumable(
-        listingEntry(executionId, {
-          record: { ...config, agentCategory: 'toolUse' } as AgentConfig,
-        }),
-      ),
-    ).resolves.toBe(true);
-  });
-
   it.each([
     [
-      'the unresolved rejection marker',
-      {
-        currentRound: 1,
-        totalRounds: 2,
-        unresolvedCompileRejection: true,
-      },
+      'a tool-use row',
+      { agentCategory: 'toolUse' as AgentConfig['agentCategory'] },
     ],
+    ['a workflow row that did not fail', { outcome: RUN_OUTCOME.CANCELLED }],
+  ])(
+    'advertises %s without parsing its checkpoint',
+    async (description, overrides) => {
+      const executionId =
+        `free-${description.replaceAll(' ', '-')}` as ExecutionId;
+      // A terminal rejection is on disk, so a parse would answer `false`.
+      // Only the short-circuit can produce the `true` asserted below.
+      await writeFlowRecord(executionId, TERMINAL_REJECTION);
+
+      await expect(
+        isCliRunResumable(listingFacts(executionId, overrides)),
+      ).resolves.toBe(true);
+    },
+  );
+
+  it.each([
+    ['the unresolved rejection marker', TERMINAL_REJECTION],
     [
       'legacy compile failure context',
       {
@@ -109,9 +118,9 @@ describe('CLI listing resumability', () => {
         `workflow-terminal-${description.replaceAll(' ', '-')}` as ExecutionId;
       await writeFlowRecord(executionId, shared);
 
-      await expect(
-        isCliListingResumable(listingEntry(executionId)),
-      ).resolves.toBe(false);
+      await expect(isCliRunResumable(listingFacts(executionId))).resolves.toBe(
+        false,
+      );
     },
   );
 });

--- a/src/test-kernel/cli/chatSessionController.vitest.ts
+++ b/src/test-kernel/cli/chatSessionController.vitest.ts
@@ -28,6 +28,7 @@ const mocks = vi.hoisted(() => ({
   attachSessionSignalsAdapter: vi.fn(),
   createTuiHostInteractions: vi.fn(),
   resumeRun: vi.fn(),
+  probeResumeRefusal: vi.fn(),
   lookupStreamExecutionId: vi.fn(),
   syncStreamLog: vi.fn(),
   notify: vi.fn(),
@@ -48,6 +49,7 @@ vi.mock('@agent/storage', () => ({
 
 vi.mock('@agent/runtime/resumeRun', () => ({
   resumeRun: mocks.resumeRun,
+  probeResumeRefusal: mocks.probeResumeRefusal,
   lookupStreamExecutionId: mocks.lookupStreamExecutionId,
 }));
 
@@ -124,7 +126,10 @@ vi.mock('@cli/chat/tui/notifications/terminalNotifier', () => ({
   notify: mocks.notify,
 }));
 
-import type { FollowUpRecoveryLease } from '@agent/followUp';
+import {
+  describeFollowUpFailure,
+  type FollowUpRecoveryLease,
+} from '@agent/followUp';
 import type {
   AgentConfig,
   AgentConfigPayload,
@@ -555,6 +560,7 @@ describe('createChatSessionController', () => {
     mocks.createTuiHostInteractions.mockReturnValue({});
     installSession();
     mocks.resumeRun.mockImplementation(defaultResumeRun);
+    mocks.probeResumeRefusal.mockResolvedValue(undefined);
     mocks.lookupStreamExecutionId.mockResolvedValue('exec-1');
     installResumeExecutionStore();
     rootStreamId.set(undefined);
@@ -1168,6 +1174,29 @@ describe('createChatSessionController', () => {
       cliMultiAgentPresetId: 'physicist',
       delegationAgentScope: config.delegationAgentScope,
     });
+  });
+
+  // A history row is advertised from its checkpoint file alone, so a run whose
+  // saved state cannot be loaded is offered and refused. The refusal has to
+  // reach the chat the user is looking at: clearing the transcript and
+  // switching the session onto the dead stream first would answer in a window
+  // that no longer holds their conversation.
+  it('refuses an unloadable checkpoint without clearing the chat or switching streams', async () => {
+    const session = makeSession();
+    mocks.probeResumeRefusal.mockResolvedValueOnce('unusable_checkpoint');
+    const ctrl = createChatSessionController(makeInit({ session }));
+
+    await ctrl.resume('exec-resume' as ExecutionId);
+
+    expect(mocks.appendLocalErrorTranscript).toHaveBeenCalledWith(
+      describeFollowUpFailure('unusable_checkpoint'),
+    );
+    expect(mocks.clearLocalTranscript).not.toHaveBeenCalled();
+    expect(session.streamId).toBeUndefined();
+    expect(session.executionId).toBeUndefined();
+    expect(rootStreamId.get()).toBeUndefined();
+    expect(mocks.resumeRun).not.toHaveBeenCalled();
+    expect(session.runCompleted).toBe(true);
   });
 
   it('treats a manually resumed subagent returning to WAITING as a successful turn', async () => {

--- a/src/test-kernel/cli/chatSessionController.vitest.ts
+++ b/src/test-kernel/cli/chatSessionController.vitest.ts
@@ -28,7 +28,6 @@ const mocks = vi.hoisted(() => ({
   attachSessionSignalsAdapter: vi.fn(),
   createTuiHostInteractions: vi.fn(),
   resumeRun: vi.fn(),
-  probeResumeRefusal: vi.fn(),
   lookupStreamExecutionId: vi.fn(),
   syncStreamLog: vi.fn(),
   notify: vi.fn(),
@@ -49,7 +48,6 @@ vi.mock('@agent/storage', () => ({
 
 vi.mock('@agent/runtime/resumeRun', () => ({
   resumeRun: mocks.resumeRun,
-  probeResumeRefusal: mocks.probeResumeRefusal,
   lookupStreamExecutionId: mocks.lookupStreamExecutionId,
 }));
 
@@ -397,6 +395,10 @@ const defaultResumeRun = async (
   _executionId: ExecutionId,
   options: ResumeRunOptions,
 ): Promise<typeof STARTED> => {
+  // The real `resumeRun` rearranges the host onto the resumed stream only
+  // after its own retrieval succeeded, so every stand-in that reaches a launch
+  // must run the hook or the caller never adopts the stream.
+  if (options.onResumeResolved) await options.onResumeResolved();
   options.onFollowUpQueueReady?.({
     streamId: 'stream:test' as StreamTabId,
     kind: 'recovery',
@@ -437,6 +439,7 @@ async function retainInterruptedFollowUp(
 ): Promise<void> {
   mocks.resumeRun
     .mockReset()
+    .mockImplementation(defaultResumeRun)
     .mockResolvedValueOnce({ failed: 'not_resumable' });
   const admission = ctrl.admitInterruptedFollowUp({ text });
   expect(admission.kind).toBe('accepted');
@@ -560,7 +563,6 @@ describe('createChatSessionController', () => {
     mocks.createTuiHostInteractions.mockReturnValue({});
     installSession();
     mocks.resumeRun.mockImplementation(defaultResumeRun);
-    mocks.probeResumeRefusal.mockResolvedValue(undefined);
     mocks.lookupStreamExecutionId.mockResolvedValue('exec-1');
     installResumeExecutionStore();
     rootStreamId.set(undefined);
@@ -1183,10 +1185,13 @@ describe('createChatSessionController', () => {
   // that no longer holds their conversation.
   it('refuses an unloadable checkpoint without clearing the chat or switching streams', async () => {
     const session = makeSession();
-    mocks.probeResumeRefusal.mockResolvedValueOnce('unusable_checkpoint');
+    // A refusal `resumeRun` reaches before its own retrieval yields resume
+    // state: the adoption hook is never called, so nothing here rearranged.
+    mocks.resumeRun.mockResolvedValueOnce({ failed: 'unusable_checkpoint' });
     const ctrl = createChatSessionController(makeInit({ session }));
 
     await ctrl.resume('exec-resume' as ExecutionId);
+    await session.runPromise;
 
     expect(mocks.appendLocalErrorTranscript).toHaveBeenCalledWith(
       describeFollowUpFailure('unusable_checkpoint'),
@@ -1195,16 +1200,17 @@ describe('createChatSessionController', () => {
     expect(session.streamId).toBeUndefined();
     expect(session.executionId).toBeUndefined();
     expect(rootStreamId.get()).toBeUndefined();
-    expect(mocks.resumeRun).not.toHaveBeenCalled();
     expect(session.runCompleted).toBe(true);
   });
 
   it('treats a manually resumed subagent returning to WAITING as a successful turn', async () => {
     const session = makeSession({ runCompleted: true });
-    mocks.resumeRun.mockImplementationOnce(async () => ({
-      ...STARTED,
-      outcome: STREAM_PHASE.WAITING,
-    }));
+    mocks.resumeRun.mockImplementationOnce(
+      async (_id: ExecutionId, options: ResumeRunOptions) => {
+        await options.onResumeResolved?.();
+        return { ...STARTED, outcome: STREAM_PHASE.WAITING };
+      },
+    );
     // A fake store, like every other resume test: the real store against
     // this harness's storage-less platform now fails loudly (KVStore no
     // longer converts I/O errors into misses), which resume() treats as a
@@ -1326,6 +1332,14 @@ describe('createChatSessionController', () => {
       runCompleted: true,
     });
     const snapshotStore = makeResumeSnapshotStore({});
+    mocks.resumeRun.mockImplementationOnce(
+      async (_id: ExecutionId, options: ResumeRunOptions) => {
+        await options.onResumeResolved?.();
+        return options.isCancellationRequested?.()
+          ? { failed: 'not_resumable' as const }
+          : STARTED;
+      },
+    );
     const ctrl = createChatSessionController(
       makeInit({ session, snapshotStore }),
     );
@@ -1367,8 +1381,9 @@ describe('createChatSessionController', () => {
 
     ensureLoaded.resolve();
     await resumed;
+    await session.runPromise;
 
-    expect(mocks.resumeRun).not.toHaveBeenCalled();
+    expect(session.runExitCode).toBe(CliExitCode.Interrupted);
     expect(session.runCompleted).toBe(true);
     expect(session.interruptedStreamId).toBe('stream-resume');
   });
@@ -1388,11 +1403,11 @@ describe('createChatSessionController', () => {
     );
 
     await expect(ctrl.resume('aaaaaa' as ExecutionId)).resolves.toBeUndefined();
+    await session.runPromise;
 
     expect(mocks.appendLocalErrorTranscript).toHaveBeenCalledWith(
       'snapshot load failed',
     );
-    expect(mocks.resumeRun).not.toHaveBeenCalled();
     expect(session.runExitCode).toBe(CliExitCode.AgentError);
     expect(session.runCompleted).toBe(true);
     expect(session.interruptedStreamId).toBe('stream-interrupted');
@@ -1789,13 +1804,16 @@ describe('createChatSessionController', () => {
         .fn<() => Promise<void>>()
         .mockRejectedValueOnce(new Error('load failed')),
     });
-    const { ctrl } = makeInterruptedController(
+    const { ctrl, session } = makeInterruptedController(
       Promise.resolve(),
       true,
       snapshotStore,
     );
     await retainInterruptedFollowUp(ctrl, 'First attempt.');
     await ctrl.resume('aaaaaa' as ExecutionId);
+    // The rollback rides the run chain now that the rehydration runs inside
+    // `resumeRun`'s adoption hook, so the retry follows the settled resume.
+    await session.runPromise;
     await expectInterruptedRetry(ctrl, ['First attempt.', 'Retry.']);
   });
 

--- a/src/test-kernel/cli/chatSessionController.vitest.ts
+++ b/src/test-kernel/cli/chatSessionController.vitest.ts
@@ -1388,6 +1388,46 @@ describe('createChatSessionController', () => {
     expect(session.interruptedStreamId).toBe('stream-resume');
   });
 
+  it('marks the resumed stream, not the previous one, for a Ctrl-C issued before adoption', async () => {
+    // The synchronous slot claim drops the pre-resume stream, so a stop in the
+    // window before `onResumeResolved` has no stream to mark: without the
+    // re-read at adoption the user's Ctrl-C would leave no recoverable
+    // conversation, and any stale stream it did find would be the wrong one.
+    const resumeReached = pDefer<void>();
+    const session = makeSession({
+      streamId: 'stream-previous' as StreamTabId,
+      runCompleted: true,
+    });
+    mocks.resumeRun.mockImplementationOnce(
+      async (_id: ExecutionId, options: ResumeRunOptions) => {
+        await resumeReached.promise;
+        await options.onResumeResolved?.();
+        return options.isCancellationRequested?.()
+          ? { failed: 'not_resumable' as const }
+          : STARTED;
+      },
+    );
+    const ctrl = createChatSessionController(
+      makeInit({ session, snapshotStore: makeResumeSnapshotStore({}) }),
+    );
+
+    const resumed = ctrl.resume('aaaaaa' as ExecutionId);
+    await vi.waitFor(() => expect(mocks.resumeRun).toHaveBeenCalledOnce());
+    ctrl.stop();
+    expect(session.interruptedStreamId).toBeUndefined();
+
+    resumeReached.resolve();
+    await resumed;
+    await session.runPromise;
+
+    expect(session.interruptedStreamId).toBe('stream-resume');
+    expect(mocks.stopAgentStream).not.toHaveBeenCalledWith(
+      'stream-previous',
+      expect.anything(),
+    );
+    expect(session.runExitCode).toBe(CliExitCode.Interrupted);
+  });
+
   it('reports resume rehydration failures without rejecting the TUI submit path', async () => {
     const session = makeSession({
       interruptedStreamId: 'stream-interrupted' as StreamTabId,

--- a/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
+++ b/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
@@ -74,6 +74,7 @@ describe('tool status formatting', () => {
         agentCategory: 'toolUse',
       }),
       outcome: 'completed',
+      checkpointPresent: false,
     };
 
     expect(formatListingLine(entry)).toBe(


### PR DESCRIPTION
Part of #11822 (S1, second half). Independent of the PR3 to PR5 stack.

## What

- `listExecutions` carries `checkpointPresent` (one `exists` stat inside the per-execution reads it already does) and the `streamId` it already read. `texra history list` and the `/resume` picker derive `resumable` and `status` from those facts through the unchanged `resolveHistoryRunStatus`, so the per-row lease inspection and the two or three full checkpoint parses per row are gone. One rule, `isCliRunResumable`, serves both the listing and `history show`, so the two surfaces cannot disagree; the detail path keeps a single parse only for the resumed model.
- Two free gates stay: a row without a stamped stream id is not resumable (the ~1,100 legacy rows in a large workspace no longer fill the picker), and a workflow row is checked for a terminal compile rejection only when its outcome is FAILED (a terminal rejection always finalizes FAILED), so cancelled and interrupted workflow rows cost one stat.
- The open path is honest about what the listing admits. A new `unusable_checkpoint` refusal ("This run's saved state could not be loaded, so it cannot be continued. Delete it from history and start a new agent task.") is returned by `resumeRun` when retrieval yields nothing while the checkpoint file exists, and by `texra resume` for an unclassifiable record; a run predating stream stamping says so instead of "finished". The chat TUI now probes the resume before it clears the transcript or switches streams, so a refused resume leaves the conversation as it was (one regression test).

## Accepted consequences

A run another process is executing right now lists as resumable and is refused when opened (PR5's hold at open-for-write). The `model` column shows the startup model; the resumed-model override lives only inside the checkpoint and `history show` still reports it.

## Verification

Typecheck, dead-code ratchet, lint, and the CLI, agent, tools, storage, architecture, and progress-view suites green on the rebased commit run alone. Adversarially reviewed; the reviewer's blocker (unusable rows advertised and then refused with misleading wording) is what the open-path changes address, without re-adding any parse to the listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)