### PR TITLE
refactor(session): read run facts at row open; delete the background hydration pass

### DIFF
--- a/config/ratchets/store-public-surface-baseline.json
+++ b/config/ratchets/store-public-surface-baseline.json
@@ -1,5 +1,5 @@
 {
-  "semantics": "Public (static + instance) method declarations of StreamLogStore and StreamSnapshotStore, per issue #9590 Stage 5 (proof obligation 10). Every public method is a caller-verified contract, and every field exposed by a configured aggregate snapshot getter is one caller-visible contract unit. Replacing five field getters with getRunMetadata therefore leaves the StreamSnapshotStore contract budget unchanged: the aggregate method contributes five units, not one. Transcript row mutation is writer-only (TranscriptWriter via acquireWriter/loadAndAcquireWriter), snapshot event projection enters only through attachSessionEvents, and 'protected' counts as public because neither class is subclassed. The ratchet rejects growth in either public methods or configured aggregate fields. When the surface genuinely shrinks, lower this baseline in the same PR. requestEviction (2026-09-02) is the one sanctioned addition: the sidecar counterpart of StreamLogStore.requestEviction, requested by the session lifecycle for finished child streams so a long session's record set stops growing; see docs/proposals/2026-09-02-stream-lifetime-and-cancellation-simplification.md section 2.C. StreamSnapshotStore.deleteStream was removed on the same day (#11769): it was a zero-caller wrapper over stageDeleteStream + commit, so the surface returns to 21. S1 read-time phase derivation (2026-09-04): StreamLogStore is net zero. hasUnfinishedOutput replaces getUnfinishedStreamIds, whose two callers (SessionHandle.computeStartupSeedSet and runRestartRepair) now filter keys() through it, so the scan lives with the caller that wanted it and the store answers one stream at a time. StreamSnapshotStore grows by four caller-visible units, 25 to 29: getRunPhaseFacts is one method plus the three extra units of the four-field RunPhaseFacts tuple (outcome, checkpointPresent, lease, authorityFailure) that SessionState.resolveStreamPhase reads for a stream with no live flow context. It is registered in aggregateContracts beside getRunMetadata, so those four fields are counted and pinned rather than hidden behind one method name: the rule that stops five getters from becoming one cuts the same way for a tuple its author likes, and a fifth field added later must be recorded here. The four are deliberately NOT on getRunMetadata, whose five fields are the record's and go with it, because these must outlive the record a bounded-residency release drops (#9947). Nothing offsets the growth in this commit: the offset proposed in review does not hold, because getExecutionIdMap has a second production consumer outside restart repair (SessionStores.deleteAllOnce). The row is interim and goes when the persistence substrate's executions rows carry outcome and resumability, returning StreamSnapshotStore to 25.",
+  "semantics": "Public (static + instance) method declarations of StreamLogStore and StreamSnapshotStore, per issue #9590 Stage 5 (proof obligation 10). Every public method is a caller-verified contract, and every field exposed by a configured aggregate snapshot getter is one caller-visible contract unit. Replacing five field getters with getRunMetadata therefore leaves the StreamSnapshotStore contract budget unchanged: the aggregate method contributes five units, not one. Transcript row mutation is writer-only (TranscriptWriter via acquireWriter/loadAndAcquireWriter), snapshot event projection enters only through attachSessionEvents, and 'protected' counts as public because neither class is subclassed. The ratchet rejects growth in either public methods or configured aggregate fields. When the surface genuinely shrinks, lower this baseline in the same PR. requestEviction (2026-09-02) is the one sanctioned addition: the sidecar counterpart of StreamLogStore.requestEviction, requested by the session lifecycle for finished child streams so a long session's record set stops growing; see docs/proposals/2026-09-02-stream-lifetime-and-cancellation-simplification.md section 2.C. StreamSnapshotStore.deleteStream was removed on the same day (#11769): it was a zero-caller wrapper over stageDeleteStream + commit, so the surface returns to 21. S1 read-time phase derivation (2026-09-04): StreamLogStore is net zero. hasUnfinishedOutput replaces getUnfinishedStreamIds, whose two callers (SessionHandle.computeStartupSeedSet and runRestartRepair) now filter keys() through it, so the scan lives with the caller that wanted it and the store answers one stream at a time. StreamSnapshotStore is net zero too, and stays at 25: the run tuple the phase rule needs (outcome, checkpointPresent, lease, authorityFailure) is not the store's. It is read at ROW OPEN by SessionState.hydrateRunFacts, held in that session's own in-memory map, and never persisted, so getRunPhaseFacts and its four aggregate fields are gone again and the store keeps only what a record owns.",
   "stores": {
     "StreamLogStore": [
       "acquireWriter",
@@ -36,7 +36,6 @@
       "getOutputFiles",
       "getParentStreamId",
       "getRunMetadata",
-      "getRunPhaseFacts",
       "getRunUsage",
       "getWorkPlan",
       "hasProvenance",
@@ -59,12 +58,6 @@
         "executionId",
         "identity",
         "userFollowUpSupport"
-      ],
-      "getRunPhaseFacts": [
-        "authorityFailure",
-        "checkpointPresent",
-        "lease",
-        "outcome"
       ]
     }
   }

--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -92,6 +92,19 @@ export function sessionStreamPhase(
   return BOUND.get()?.state.getStreamPhaseState(streamId);
 }
 
+/** Read the durable run facts for the stream the user just focused, then
+ *  repaint the readers that render its phase. The CLI's one caller of the
+ *  session's row-open hydration — nothing here walks the roster, so a stream
+ *  the user has not focused renders from its always-resident summary. */
+export async function hydrateFocusedStreamRunFacts(
+  streamId: StreamTabId,
+): Promise<void> {
+  const bound = BOUND.get();
+  if (!bound) return;
+  await bound.state.hydrateRunFacts(streamId);
+  invalidateChildStreams();
+}
+
 /** Canonical reason a stream is unavailable in this session: held by another
  *  process, or its run state could not be read. Same rule as the phase, so a
  *  foreign owner locks the composer without waiting for a refused send. */

--- a/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
@@ -34,7 +34,10 @@ import {
   registerCliStateResetHook,
   setTransientNotice,
 } from './cliState';
-import { isChildStreamRemoved } from './childExecutions';
+import {
+  hydrateFocusedStreamRunFacts,
+  isChildStreamRemoved,
+} from './childExecutions';
 
 /** Bumped whenever the artifact projection changes: after a focus/`/plan`
  *  preload completes or when a live fact mutates the snapshot store. Renderers
@@ -164,6 +167,10 @@ export async function hydrateStreamArtifacts(
   if (!streamCanReceiveArtifacts(streamId, generation, requestIsCurrent)) {
     return undefined;
   }
+  // After the preload, which backfills the summary mirror the run facts'
+  // execution FK comes from. This focus is the one moment the CLI reads them;
+  // an unfocused stream's phase stays what its always-resident summary says.
+  await hydrateFocusedStreamRunFacts(streamId);
   bumpStreamArtifactRevision();
   return { kind: 'complete' };
 }

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -398,6 +398,29 @@ function normalizeWorkspaceFilePaths(paths: readonly string[]): string[] {
   return [...normalized].sort(byString);
 }
 
+/**
+ * The execution row's CORE fields, parsed strictly, without the optional
+ * `workflow` projection.
+ *
+ * The one read for callers that display what a past run turned out to be —
+ * the sidecar hydration and the row-open phase probe. Every fact they take
+ * from the row (outcome, identity, follow-up support, description) lives in
+ * the core schema, so a malformed projection must not cost them:
+ * {@link ExecutionKVStore.readMetaStrict} throws on one (which would strand a
+ * valid historical run on "unavailable"), and {@link ExecutionKVStore.readMeta}
+ * swallows a malformed CORE row as absence (which would render a corrupt
+ * execution as a healthy, sendable stream). Same raw read, same schema, same
+ * "malformed core is unreadable" rule as `deriveResumability`.
+ *
+ * Throws on an unreadable row or a malformed core; `null` means absent.
+ */
+export async function readExecutionMetaCore(
+  store: ExecutionKVStore,
+): Promise<ExecutionMeta | null> {
+  const raw = await store.read(KEYS.META);
+  return raw === undefined ? null : ExecutionMetaCoreSchema.parse(raw);
+}
+
 // ============================================================================
 // Factory
 // ============================================================================

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -19,6 +19,7 @@ export {
   getExecutionStore,
   clearStoreCache,
   isReservedKvKeyName,
+  readExecutionMetaCore,
 } from './ExecutionKVStore';
 export {
   buildCliWorkflowResultMeta,

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -1,5 +1,3 @@
-import { setTimeout } from 'node:timers/promises';
-
 import PQueue from 'p-queue';
 
 import { RUN_FACT_EVENT_TYPES } from '@agent/trace';
@@ -38,13 +36,6 @@ import { canUseStreamDataDir } from '@transcript/streamDataPaths';
 import { aggregateError } from '@utils/core';
 
 const log = createLog('ProgressBackend');
-
-/**
- * How many stream sidecars the post-load hydration pass warms per turn. Small
- * enough that one chunk's reads and its metadata pushes never hold the event
- * loop, and matched to the snapshot store's own seed concurrency.
- */
-const BACKGROUND_HYDRATION_CHUNK = 8;
 
 type ProgressBackendApprovalOptions = Omit<
   BuildApprovalRequestHandlerSetParams,
@@ -109,8 +100,6 @@ export class ProgressBackend {
   private activationGeneration = 0;
   private latestActivationTarget: PresentedStreamId = '';
   private readonly inFlightActivationGenerations = new Set<number>();
-  /** Cancels the post-load sidecar hydration pass; see `load`. */
-  private backgroundHydration: AbortController | undefined;
   private transcriptPresentationLease?: TranscriptPresentationLease;
   private disposed = false;
 
@@ -332,7 +321,14 @@ export class ProgressBackend {
     this.inFlightActivationGenerations.add(generation);
     const hydration = await Promise.allSettled([
       leasePromise,
-      this.state.snapshots.preload([stream]),
+      // Opening the row is the one moment this host reads the stream's
+      // durable run facts, and it rides the preload it already performs:
+      // chained after it because the preload backfills the summary mirror the
+      // execution FK comes from. There is no pass over the other rows —
+      // an unopened one renders from the always-resident summary tier.
+      this.state.snapshots
+        .preload([stream])
+        .then(() => this.state.hydrateRunFacts(stream)),
     ]);
     this.inFlightActivationGenerations.delete(generation);
     const transcriptLeaseResult = hydration[0];
@@ -369,9 +365,9 @@ export class ProgressBackend {
     if (transcriptLeaseResult.status !== 'fulfilled')
       throw transcriptLeaseResult.reason;
 
-    // The preload just established this stream's run facts, so publish the
-    // phase they resolve to now. The background pass reaches every tab
-    // eventually, but the one the user just opened must not wait its turn.
+    // The open just read this stream's run facts, so publish the phase they
+    // resolve to. This is the only moment a restored row's phase converges
+    // from "not opened yet" to what actually happened to that run.
     this.renderer.updateStreamMetadata(stream);
 
     const previousStream = this.presentation.activeStream;
@@ -871,105 +867,7 @@ export class ProgressBackend {
     return this.enqueueStorageOperation(async () => {
       await this.session.waitUntilReady();
       await this.state.load();
-      this.startBackgroundStreamHydration();
     });
-  }
-
-  /**
-   * Warm the rail's sidecars behind the first paint, so each restored tab's
-   * phase converges from "not hydrated yet" to what actually happened to that
-   * run. Deliberately un-awaited: no host may wait for it, and disposal
-   * cancels it.
-   *
-   * Interim. It exists because the run tuple the phase rule needs (outcome,
-   * checkpoint, lease) currently lives one file read per stream away. Once
-   * the persistence substrate's `executions` rows carry outcome and
-   * resumability, the rail answers from the listing and this pass goes.
-   */
-  private startBackgroundStreamHydration(): void {
-    if (this.backgroundHydration || this.disposed) return;
-    const controller = new AbortController();
-    this.backgroundHydration = controller;
-    void this.hydrateStreamsInBackground(controller.signal);
-  }
-
-  private async hydrateStreamsInBackground(signal: AbortSignal): Promise<void> {
-    // Newest first: the tabs a user looks at after a restart are the ones
-    // whose run just ended.
-    const streams = this.state.selectableStreamNames();
-    for (
-      let start = 0;
-      start < streams.length;
-      start += BACKGROUND_HYDRATION_CHUNK
-    ) {
-      if (signal.aborted || this.disposed) return;
-      // The roster was captured once, so a stream can be deleted while this
-      // pass walks the chunks behind it. Re-check membership here and again
-      // after the reads: preloading a deleted stream mints a resident record
-      // for it, and pushing its metadata splices its tab back into the view.
-      const chunk = streams
-        .slice(start, start + BACKGROUND_HYDRATION_CHUNK)
-        .filter((stream) => this.isStreamOnRail(stream));
-      if (chunk.length > 0) {
-        // Through the storage queue, for the reason the queue exists: a chunk
-        // must not interleave with a deletion committing the same stream.
-        await this.enqueueStorageOperation(() =>
-          this.hydrateStreamChunk(chunk, signal),
-        );
-      }
-      // Yield between chunks so a long history never starves the UI.
-      await setTimeout(0);
-    }
-  }
-
-  /** Hydrate one chunk, publish its phases, and give the records back. */
-  private async hydrateStreamChunk(
-    chunk: readonly StreamTabId[],
-    signal: AbortSignal,
-  ): Promise<void> {
-    // One preload per stream, all settled. A single `preload(chunk)` rejects
-    // fail-fast through `pMap`, which would release the storage queue and
-    // publish this chunk's phases while its siblings were still writing into
-    // their records. One unreadable stream must not end the pass either: the
-    // rule renders it from whatever the hydration did establish, and says why.
-    const hydrations = await Promise.allSettled(
-      chunk.map((stream) => this.state.snapshots.preload([stream])),
-    );
-    for (const [index, hydration] of hydrations.entries()) {
-      if (hydration.status === 'rejected') {
-        log.warn('Background sidecar hydration failed for a stream', {
-          data: { stream: chunk[index], error: hydration.reason },
-        });
-      }
-    }
-    if (signal.aborted || this.disposed) return;
-    for (const stream of chunk) {
-      if (!this.isStreamOnRail(stream)) continue;
-      this.renderer.updateStreamMetadata(stream);
-      // Bounded residency (#9947): the phase this push carried came from the
-      // store's run-fact map, which outlives the record, so a record this
-      // chunk warmed for a child nobody presents goes straight back through
-      // the session's one retirement rule, which asks whether any run owns
-      // the stream rather than whether one finished it: a stream held
-      // elsewhere, an unreadable one, and one with nothing durable left are
-      // as unowned as a completed one. Without that the pass would end with
-      // every hydrated child's whole sidecar resident — the exact cost the
-      // policy exists to avoid. Root streams stay, as they did before this
-      // pass existed: their resident execution id is what
-      // `lookupStreamExecutionId` resumes from.
-      this.factApplier.retireSidecarIfFinishedChild(stream);
-    }
-  }
-
-  /**
-   * Whether this stream is still on the rail — neither committed away nor
-   * behind a provisional removal barrier. The same pair `activateStream`
-   * rejects a focus request on.
-   */
-  private isStreamOnRail(stream: StreamTabId): boolean {
-    return (
-      !this.state.isStreamRemoved(stream) && this.state.streamLogs.has(stream)
-    );
   }
 
   /**
@@ -1023,7 +921,6 @@ export class ProgressBackend {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    this.backgroundHydration?.abort();
     for (const detach of this.detachEventListeners.splice(0)) detach();
     // Disposal is this host's last "stops presenting", and the session
     // outlives the window, so nothing else would revisit a finished child

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -719,6 +719,11 @@ export class SessionFactApplier {
   }
 
   private handleRunConfig(streamId: StreamTabId): void {
+    // A run is taking this stream over, so whatever a previous row open read
+    // about the last run — its outcome, checkpoint, and lease — is not this
+    // run's. The live phase answers while the run is in flight; the next row
+    // open reads the durable tuple again.
+    this.state.clearRunFacts(streamId);
     // No explicit refresh: `getStreamMetadata` overlays the summary mirror —
     // already updated synchronously by the snapshot store's projection of
     // this same fact — at read time (#9947).
@@ -834,9 +839,9 @@ export class SessionFactApplier {
    *
    * The single owner of that rule, so every moment it can become true — the
    * run ends while nothing presents it, a host stops presenting a stream no
-   * run owns, and a background hydration warms a record for a tab nobody
-   * opened — asks the same question. The rule is re-read after the store's
-   * drain: a relaunch or a fresh presentation during it keeps the record.
+   * run owns, and an activation abandons a record it warmed — asks the same
+   * question. The rule is re-read after the store's drain: a relaunch or a
+   * fresh presentation during it keeps the record.
    */
   retireSidecarIfFinishedChild(streamId: StreamTabId): void {
     if (!this.isRetiredSidecarCandidate(streamId)) return;
@@ -859,12 +864,12 @@ export class SessionFactApplier {
     // left are equally nobody's to write, and their records are equally pure
     // accumulators; keying on the outcome alone left each of those resident
     // for the life of the process, the cost bounded residency exists to bound
-    // (#9947). The run facts survive the release, so the phase stays
-    // answerable afterwards.
+    // (#9947). The run facts live on the session, not the record, so the
+    // phase stays answerable after the release.
     //
     // Two origins keep the record. `live` is a producer in this process.
-    // `pending` is a stream that has never hydrated, whose record may be the
-    // only home of a live fact — releasing that loses it rather than parking
+    // `pending` is a row nobody has opened, whose record may be the only home
+    // of a live fact — releasing that loses it rather than parking
     // it. `none` is the one answer that is ambiguous about which of the two
     // it is: it is also what a run reads as between its `run.config` and its
     // first status, so a record naming an execution the hydration did not

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -1,8 +1,14 @@
 import {
+  getExecutionStore,
   SessionStores,
   type DeleteAllStreamsResult,
   type DeleteStreamResult,
 } from '@agent/storage';
+import {
+  inspectExecutionLease,
+  type ExecutionLeasePresence,
+} from '@agent/storage/executionLease';
+import { flowKey } from '@agent/node/persistedFlow';
 import type { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type {
   StreamPhaseState,
@@ -19,10 +25,13 @@ import {
   type ContextStateData,
   type ConversationProgress,
   type StreamStage,
+  type ExecutionId,
+  type RunOutcome,
   type StreamIdentityFields,
   type StreamPhase,
   type StreamTabId,
   AgentCategory,
+  ExecutionMetaCoreSchema,
   STREAM_PHASE,
 } from '@shared/schemas';
 import { compareByNewestCreationTime } from '@shared/streams/streamOrdering';
@@ -31,6 +40,7 @@ import {
   streamUnreadableMessage,
 } from '@shared/streams/streamStatusDisplay';
 import type { StreamLogStore, StreamSnapshotStore } from '@transcript';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 /**
  * Config-derived display fields: undefined until the stream's `RunConfig`
@@ -113,6 +123,31 @@ interface EphemeralStreamState {
 }
 
 /**
+ * What {@link SessionState.hydrateRunFacts} learned about the run a stream
+ * last carried: enough for {@link SessionState.resolveStreamPhase} to say
+ * what happened to a stream with no live flow context in this process, and
+ * nothing more.
+ *
+ * In memory only — nothing here is written to a sidecar or a summary file,
+ * and a fresh process learns it again the next time the row is opened.
+ *
+ * Display-only. Each field was true at the instant the row was opened, so a
+ * caller about to WRITE (open, resume, delete) re-reads the authority under
+ * the lease instead of trusting them: a process-local mirror cannot observe
+ * another host's finalize.
+ */
+interface RunPhaseFacts {
+  /** `ExecutionMeta.outcome`: absent for a run that never finalized. */
+  readonly outcome?: RunOutcome;
+  /** Whether a resumable flow checkpoint file exists (existence, not validity). */
+  readonly checkpointPresent?: boolean;
+  /** Who held the execution lease when the row was opened. */
+  readonly lease?: ExecutionLeasePresence;
+  /** Why this stream's execution authority could not be read, if it could not. */
+  readonly authorityFailure?: string;
+}
+
+/**
  * What {@link SessionState.resolveStreamPhase} decided about one stream, and
  * on what evidence. See that method for the meaning of each `origin`.
  */
@@ -148,6 +183,14 @@ export class SessionState {
     StreamTabId,
     CachedStreamMetadata
   >();
+  /**
+   * What each opened row's last run turned out to be — see
+   * {@link RunPhaseFacts}. Written by {@link hydrateRunFacts}, which only the
+   * row-open paths call, so this map holds an entry per row the user has
+   * actually opened rather than one per stream in the workspace. Dropped when
+   * the stream's execution changes hands, and with the stream itself.
+   */
+  private readonly _runFacts = new Map<StreamTabId, RunPhaseFacts>();
   /**
    * Per-stream incarnation generation, bumped only by a legitimate claim on
    * the identity (`claimStreamIdentity`, from a workflow attachment with live
@@ -341,6 +384,85 @@ export class SessionState {
   // -- Stream phase ------------------------------------------------------------
 
   /**
+   * Read what this stream's last run turned out to be, for the row the user
+   * just opened. Three small reads against that row's execution: the
+   * read-only lease inspection (a dead claim reports as absent and is
+   * unlinked by the next claim, never by this call), one `exists` stat for
+   * the flow checkpoint (never a parse of the often ~600 KB record), and a
+   * core-schema parse of the execution row for the outcome.
+   *
+   * Called from the row-open paths only, one stream at a time — never over a
+   * roster. That is the whole point: an unopened row renders from the
+   * always-resident summary tier, and {@link resolveStreamPhase}'s unhydrated
+   * arm already answers for it, so no startup pass has to walk the history to
+   * make the first screen correct.
+   *
+   * Never throws. A read that fails lands in `authorityFailure`, which the
+   * rule renders read-only with the cause rather than as a run that never
+   * happened.
+   *
+   * ORDERING INVARIANT — lease, then checkpoint, then outcome, sequentially.
+   * A foreign finalize writes the outcome, deletes the checkpoint, then
+   * releases the lease. Reading in that same order means a free lease is
+   * always followed by the outcome read that a finalize which released it has
+   * already written. Any other order (a parallel batch included) can splice
+   * "lease free, no checkpoint" observed after the finalize onto "no outcome"
+   * observed before it, and leave the row reading Ready.
+   */
+  async hydrateRunFacts(stream: StreamTabId): Promise<void> {
+    // The always-resident summary mirror is the FK: a caller that preloaded
+    // the sidecar first (every row-open path does) has already backfilled it
+    // for a legacy row whose summary predates the mirror.
+    const executionId = this.getStreamMetadata(stream).executionId;
+    const facts = await this.readRunFacts(executionId);
+    // Re-checked after the reads: a deletion or a fresh execution during them
+    // makes this tuple somebody else's.
+    if (this.isStreamRemoved(stream)) return;
+    if (this.getStreamMetadata(stream).executionId !== executionId) return;
+    // Published even when it is empty: the entry's existence is what says
+    // this row has been read, and an empty tuple is the honest answer for a
+    // stream that never had an execution.
+    this._runFacts.set(stream, Object.freeze(facts));
+  }
+
+  private async readRunFacts(
+    executionId: ExecutionId | undefined,
+  ): Promise<RunPhaseFacts> {
+    if (!executionId) return {};
+    try {
+      const store = getExecutionStore(executionId);
+      const lease = await inspectExecutionLease(executionId);
+      const checkpointPresent = await store.exists(flowKey(executionId));
+      // Core-only, and strict on the core: a malformed row is an unreadable
+      // authority, but a malformed OPTIONAL `workflow` projection must not
+      // cost a valid outcome beside it.
+      const raw = await store.read('meta');
+      const meta =
+        raw === undefined ? undefined : ExecutionMetaCoreSchema.parse(raw);
+      return {
+        checkpointPresent,
+        lease,
+        ...(meta?.outcome !== undefined && { outcome: meta.outcome }),
+      };
+    } catch (error) {
+      this.logger.warn(
+        `Could not read run phase facts for execution ${executionId}.`,
+        { data: { executionId, error } },
+      );
+      return { authorityFailure: toErrorMessage(error) };
+    }
+  }
+
+  /**
+   * Drop a stream's run facts. Called when a fresh run takes the stream over
+   * — the previous run's outcome, checkpoint, and lease are not this run's —
+   * and when the stream itself is cleared.
+   */
+  clearRunFacts(stream: StreamTabId): void {
+    this._runFacts.delete(stream);
+  }
+
+  /**
    * The one read-time rule for a stream's phase, and the only place that
    * decides what a stream with no live flow context in this process is.
    *
@@ -351,16 +473,17 @@ export class SessionState {
    * - `derived` — no producer exists anywhere: the lease is free and the
    *   durable facts say what happened. Only this value licenses a reader to
    *   treat the stream's rows as final.
-   * - `pending` — the stream's sidecar has not hydrated yet, so the tuple is
-   *   unknown rather than absent. It converges once hydration lands.
-   * - `none` — hydrated, lease free, and nothing durable is left of the run.
+   * - `pending` — this row has not been opened yet, so the run tuple is
+   *   unknown rather than absent. It converges when the row is opened and
+   *   {@link hydrateRunFacts} reads it.
+   * - `none` — read, lease free, and nothing durable is left of the run.
    *
    * `detail` is the human sentence for a stream that has no phase and cannot
    * get one (held elsewhere, or unreadable); a caller renders it read-only
    * with the `unavailable` sentinel. Pure and synchronous: every fact it
    * reads is already resident (the status machine, the always-resident
-   * transcript summary, and the run tuple captured by this stream's own
-   * sidecar hydration). It never writes and never starts a read.
+   * transcript summary, and the run tuple this row's own open captured). It
+   * never writes and never starts a read.
    */
   resolveStreamPhase(stream: StreamTabId): ResolvedStreamPhase {
     const live = this.streamStatus.getStreamState(stream);
@@ -375,14 +498,13 @@ export class SessionState {
     }
     if (live) return { state: live, origin: 'live' };
 
-    // The run tuple, not the record: it is small, it is written once per
-    // hydration, and it outlives the record the hydration warmed, so asking
+    // The run tuple this row's own open read, not the sidecar record: asking
     // it here neither loads a sidecar nor pins one resident (#9947). Absent
-    // means this stream has never hydrated — the tuple is unknown rather than
+    // means the row has never been opened — the tuple is unknown rather than
     // empty. The transcript summary is resident for every stream either way,
     // so a transcript left open is enough to say the run was interrupted
-    // without reading anything.
-    const run = this.snapshots.getRunPhaseFacts(stream);
+    // without reading anything, which is what an unopened row renders from.
+    const run = this._runFacts.get(stream);
     if (!run) {
       return this.streamLogs.hasUnfinishedOutput(stream)
         ? { state: { phase: STREAM_PHASE.CANCELLED }, origin: 'derived' }
@@ -610,6 +732,7 @@ export class SessionState {
     // the fresh run has already tracked its own phase there.
     this._ephemeralState.delete(stream);
     this._streamMetadataCache.delete(stream);
+    this._runFacts.delete(stream);
     return { incarnation, changedRosterParents };
   }
 
@@ -695,13 +818,14 @@ export class SessionState {
     return changedParents;
   }
 
-  /** Drop the ephemeral status/session/execution/metadata-cache state a
-   *  cleared stream leaves behind. Callers still own tombstoning it in
+  /** Drop the ephemeral status/session/execution/metadata-cache/run-fact
+   *  state a cleared stream leaves behind. Callers still own tombstoning it in
    *  `_removedStreams` and, for `clearAll`, scrubbing rosters. */
   private clearEphemeralStreamState(stream: StreamTabId): void {
     this.streamStatus.clearStream(stream);
     this._ephemeralState.delete(stream);
     this._streamMetadataCache.delete(stream);
+    this._runFacts.delete(stream);
   }
 
   private incarnationOf(stream: StreamTabId): number {

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -416,10 +416,16 @@ export class SessionState {
     // the sidecar first (every row-open path does) has already backfilled it
     // for a legacy row whose summary predates the mirror.
     const executionId = this.getStreamMetadata(stream).executionId;
+    // The incarnation is the one fact every legitimate re-claim bumps,
+    // including a deterministic re-run that reuses the same execution id and
+    // a `claimStreamIdentity` that drops a tombstone without touching the
+    // mirror; the execution-id comparison alone would miss both.
+    const incarnation = this.incarnationOf(stream);
     const facts = await this.readRunFacts(executionId);
-    // Re-checked after the reads: a deletion or a fresh execution during them
-    // makes this tuple somebody else's.
+    // Re-checked after the reads: a deletion, a re-claim, or a fresh
+    // execution during them makes this tuple somebody else's.
     if (this.isStreamRemoved(stream)) return;
+    if (this.incarnationOf(stream) !== incarnation) return;
     if (this.getStreamMetadata(stream).executionId !== executionId) return;
     // Published even when it is empty: the entry's existence is what says
     // this row has been read, and an empty tuple is the honest answer for a

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -1,5 +1,6 @@
 import {
   getExecutionStore,
+  readExecutionMetaCore,
   SessionStores,
   type DeleteAllStreamsResult,
   type DeleteStreamResult,
@@ -31,7 +32,6 @@ import {
   type StreamPhase,
   type StreamTabId,
   AgentCategory,
-  ExecutionMetaCoreSchema,
   STREAM_PHASE,
 } from '@shared/schemas';
 import { compareByNewestCreationTime } from '@shared/streams/streamOrdering';
@@ -385,11 +385,13 @@ export class SessionState {
 
   /**
    * Read what this stream's last run turned out to be, for the row the user
-   * just opened. Three small reads against that row's execution: the
+   * just opened. Four small reads against that row's execution: the
    * read-only lease inspection (a dead claim reports as absent and is
    * unlinked by the next claim, never by this call), one `exists` stat for
-   * the flow checkpoint (never a parse of the often ~600 KB record), and a
-   * core-schema parse of the execution row for the outcome.
+   * the flow checkpoint (never a parse of the often ~600 KB record), a
+   * core-schema parse of the execution row for the outcome, and the run
+   * record — the same pair of authority reads the sidecar preload makes, so
+   * a row the preload found unreadable can never look healthy here.
    *
    * Called from the row-open paths only, one stream at a time — never over a
    * roster. That is the whole point: an unopened row renders from the
@@ -436,9 +438,14 @@ export class SessionState {
       // Core-only, and strict on the core: a malformed row is an unreadable
       // authority, but a malformed OPTIONAL `workflow` projection must not
       // cost a valid outcome beside it.
-      const raw = await store.read('meta');
-      const meta =
-        raw === undefined ? undefined : ExecutionMetaCoreSchema.parse(raw);
+      const meta = await readExecutionMetaCore(store);
+      // The same config read the sidecar preload makes, and the reason it is
+      // here: that preload catches an unreadable `config.json` into its own
+      // authority failure, so without this read the row would come back with a
+      // healthy tuple and render as completed/cancelled off a run whose
+      // authority is half unreadable. Last, so the lease → checkpoint →
+      // outcome ordering above is untouched.
+      await store.readConfig();
       return {
         checkpointPresent,
         lease,

--- a/src/test-kernel/agent/runtime/DerivedStreamPhase.vitest.ts
+++ b/src/test-kernel/agent/runtime/DerivedStreamPhase.vitest.ts
@@ -210,6 +210,37 @@ describe('SessionState.resolveStreamPhase', () => {
     });
   });
 
+  it('shows a finished run whose config.json is malformed as unavailable', async () => {
+    const executionId = 'ffff6666' as ExecutionId;
+    const stream = `badconfig#${executionId}` as StreamTabId;
+    const transcripts = await StreamLogStore.open();
+    await seedSidecarFk(stream, executionId);
+    const executionStore = getExecutionStore(executionId);
+    // A valid row with a terminal outcome, beside a run record that cannot be
+    // parsed. The sidecar preload reads both and calls that authority
+    // unreadable, so the phase probe must not answer COMPLETED off the half
+    // it can still read. (`writeMeta` creates the execution directory.)
+    await executionStore.writeMeta({
+      timestamp: META_TIMESTAMP,
+      outcome: RUN_OUTCOME.COMPLETED,
+    });
+    await StorageFS.write(
+      `executions/${executionId}/config.json`,
+      '{ not json',
+    );
+
+    const state = openUnrepairedSession(transcripts);
+    await state.snapshots.preload([stream]);
+    await state.hydrateRunFacts(stream);
+
+    expect(state.resolveStreamPhase(stream)).toEqual({
+      origin: 'derived',
+      // The cause is the JSON parser's, so only the sentence around it is
+      // this rule's own.
+      detail: expect.stringContaining("Could not read this run's state"),
+    });
+  });
+
   it('keeps a completed outcome when only the optional workflow projection is malformed', async () => {
     const executionId = 'eeee5555' as ExecutionId;
     const stream = `projection#${executionId}` as StreamTabId;

--- a/src/test-kernel/agent/runtime/DerivedStreamPhase.vitest.ts
+++ b/src/test-kernel/agent/runtime/DerivedStreamPhase.vitest.ts
@@ -121,6 +121,7 @@ describe('SessionState.resolveStreamPhase', () => {
 
     const state = openUnrepairedSession(transcripts);
     await state.snapshots.preload([stream]);
+    await state.hydrateRunFacts(stream);
 
     // The persisted outcome is the display fact, and CANCELLED is what every
     // downstream table already renders with Resume enabled.
@@ -167,6 +168,7 @@ describe('SessionState.resolveStreamPhase', () => {
     try {
       const state = openUnrepairedSession(transcripts);
       await state.snapshots.preload([stream]);
+      await state.hydrateRunFacts(stream);
 
       // A checkpoint plus no outcome is also what a crash looks like; the
       // live lease is what keeps this out of the terminal arm.
@@ -198,6 +200,7 @@ describe('SessionState.resolveStreamPhase', () => {
 
     const state = openUnrepairedSession(transcripts);
     await state.snapshots.preload([stream]);
+    await state.hydrateRunFacts(stream);
 
     // A failed authority read is not "nothing ran": it renders read-only with
     // the cause, so the failure cannot degrade into a quiet `ready`.
@@ -224,6 +227,7 @@ describe('SessionState.resolveStreamPhase', () => {
 
     const state = openUnrepairedSession(transcripts);
     await state.snapshots.preload([stream]);
+    await state.hydrateRunFacts(stream);
 
     expect(state.resolveStreamPhase(stream)).toEqual({
       state: { phase: STREAM_PHASE.COMPLETED },

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -200,10 +200,9 @@ function injectDuringExecutionConfigHydration(
 }
 
 /**
- * Replace the execution row read (`meta.json`) that BOTH the metadata
- * hydration and the phase probe make; every other read passes through. The
- * store parses that raw row itself (core schema only), so there is no typed
- * accessor left to stub.
+ * Replace the execution row read (`meta.json`) the metadata hydration makes;
+ * every other read passes through. The store parses that raw row itself (core
+ * schema only), so there is no typed accessor left to stub.
  */
 function mockExecutionMetaRead(
   executionId: ExecutionId,

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -21,11 +21,6 @@ import { z } from 'zod';
 
 import { getExecutionStore, type ExecutionKVStore } from '@agent/storage';
 import type { AgentEvent } from '@agent/trace';
-import { flowKey } from '@agent/node/persistedFlow';
-import {
-  inspectExecutionLease,
-  type ExecutionLeasePresence,
-} from '@agent/storage/executionLease';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { isFileNotFoundError } from '@common/errors';
@@ -52,7 +47,6 @@ import {
   type ExtendedTokenUsageStats,
   type OutputFileInfo,
   type RunIdentity,
-  type RunOutcome,
   type Plan,
   type ReadonlyRoundIndexed,
   type RoundIndexed,
@@ -169,9 +163,9 @@ type OutputFilesPatch = Map<number, OutputFileInfo[] | null>;
 interface HydratedRunState {
   /**
    * Why the execution authority could not be read, or `undefined` when it
-   * was read completely. One field rather than a boolean plus a cause: a
-   * reader that shows the failure needs the words, and a second field could
-   * disagree with the first.
+   * was read completely. Carries the cause rather than a bare boolean so the
+   * `summaryMetaHydrationFallback` decision below and the warning that
+   * accompanies it cannot disagree about what went wrong.
    */
   authorityFailure?: string;
   config?: AgentConfig;
@@ -181,57 +175,11 @@ interface HydratedRunState {
 }
 
 /**
- * The display-only half of a run's read-time tuple. Deliberately NOT part of
- * {@link HydratedRunState}: the metadata restore in `applyStreamData` runs
- * with a record's accumulators holding raw disk state until its overlays are
- * replayed, so nothing that merely feeds a status pill may lengthen that
- * window. This probe is started beside the metadata read and awaited once the
- * record is whole again.
- */
-interface RunPhaseProbe {
-  checkpointPresent?: boolean;
-  lease?: ExecutionLeasePresence;
-  /** Persisted run outcome from `ExecutionMeta.outcome`; absent while a run
-   *  is live and forever for a run that crashed before finalizing. */
-  outcome?: RunOutcome;
-  /** Why the probe could not answer, if it could not. */
-  failure?: string;
-}
-
-/**
- * What a hydration learned about the run a stream last carried: enough for a
- * reader to say what happened to a stream with no live flow context in this
- * process, and nothing more.
- *
- * Held OUTSIDE the stream record, in a small always-resident map, for the
- * reason bounded residency exists (#9947): a rail that wants every tab's
- * phase would otherwise have to keep every tab's whole sidecar record
- * resident. Four small fields per stream survive the record; the accumulators
- * behind them do not. In memory only — nothing here is written to a sidecar
- * or a summary file, and a fresh process learns it all again by hydrating.
- *
- * Display-only. Each field was true at the instant the stream hydrated, so a
- * caller about to WRITE (open, resume, delete) re-reads the authority under
- * the lease instead of trusting them — a process-local mirror cannot observe
- * another host's finalize (see `listExecutions`' own note on that rule).
- */
-export interface RunPhaseFacts {
-  /** `ExecutionMeta.outcome`: absent for a run that never finalized. */
-  readonly outcome?: RunOutcome;
-  /** Whether a resumable flow checkpoint file exists (existence, not validity). */
-  readonly checkpointPresent?: boolean;
-  /** Who held the execution lease when this stream hydrated. */
-  readonly lease?: ExecutionLeasePresence;
-  /** Why this stream's execution authority could not be read, if it could not. */
-  readonly authorityFailure?: string;
-}
-
-/**
  * The execution row's CORE fields, parsed strictly, without the optional
- * `workflow` projection. Every read-time phase fact this store needs —
- * identity, description, outcome — lives in the core schema, so a malformed
- * projection must not cost a valid outcome: `readMetaStrict` throws on one
- * (which would strand a completed historical run on "unavailable"), and
+ * `workflow` projection. Every fact this store hydrates from the row —
+ * identity, follow-up support, description — lives in the core schema, so a
+ * malformed projection must not cost them: `readMetaStrict` throws on one
+ * (which would strand a valid historical run on "unavailable"), and
  * `readMeta` swallows a malformed CORE row as absence (which would render a
  * corrupt execution as a healthy, sendable stream). Same raw read, same
  * schema, same "malformed core is unreadable" rule as `deriveResumability`.
@@ -562,15 +510,6 @@ export class StreamSnapshotStore {
     overlays: {},
   }));
   /**
-   * What each hydrated stream's last run turned out to be — see
-   * {@link RunPhaseFacts}. Kept beside the records rather than in them so it
-   * outlives the record: a rail that shows every tab's phase must not pin
-   * every tab's accumulators (#9947). An entry is written when a stream
-   * hydrates, dropped when its execution changes hands, and dropped with the
-   * stream itself; a record released for residency keeps its entry.
-   */
-  private readonly runFacts = new Map<StreamTabId, RunPhaseFacts>();
-  /**
    * The crash-safe staged-deletion + rollback-recovery machine. It owns which
    * namespace holds a staged stream's data and the sidecar writes buffered
    * behind that rename; this store keeps the records and stream generations
@@ -584,7 +523,7 @@ export class StreamSnapshotStore {
       this.writes.cancelPendingWritesForStream(stream),
     invalidateStreamGeneration: (stream) => this.rotateGeneration(stream),
     seedChain: (stream) => this.records.get(stream)?.seedChain,
-    evict: (stream) => this.forget(stream),
+    evict: (stream) => this.evict(stream),
   } satisfies StagedDeletionHost);
 
   /**
@@ -1295,28 +1234,12 @@ export class StreamSnapshotStore {
     }
   }
 
-  /**
-   * Release a stream's resident record. The stream itself lives on, so its
-   * {@link RunPhaseFacts} stay: releasing the accumulators is what bounded
-   * residency buys, and dropping the four fields with them would make every
-   * released tab's phase read as unknown again. Disk cleanup is the caller's
-   * job.
-   */
+  /** Drop a stream's in-memory state. Disk cleanup is the caller's job. */
   private evict(stream: StreamTabId): void {
     this.records.delete(stream);
     this.seedQueues.delete(stream);
     this.writes.dropStreamWrites(stream);
     this.unseededReadWarned.delete(stream);
-  }
-
-  /**
-   * Drop everything this store holds for a stream that is gone — a committed
-   * deletion, or a stream the authoritative roster no longer lists. The one
-   * eviction that also forgets the run facts.
-   */
-  private forget(stream: StreamTabId): void {
-    this.evict(stream);
-    this.runFacts.delete(stream);
   }
 
   /**
@@ -1515,7 +1438,6 @@ export class StreamSnapshotStore {
       record.runIdentity = undefined;
       record.userFollowUpSupport = undefined;
       record.description = undefined;
-      this.runFacts.delete(stream);
       record.summaryMetaHydrationFallback = undefined;
     }
     record.summaryMetaHydrationFallback = withoutSummaryMetaFields(
@@ -1551,7 +1473,6 @@ export class StreamSnapshotStore {
     if (previous && previous !== executionId) {
       record.runConfig = undefined;
       record.description = undefined;
-      this.runFacts.delete(stream);
       // Only what the departing execution owned: the stream's parent edge and
       // its summed usage outlive any single run, and on a record minted after
       // a release the fallback is their only source until seeding lands.
@@ -1615,20 +1536,6 @@ export class StreamSnapshotStore {
       config: record?.runConfig,
       description: record?.description,
     });
-  }
-
-  /**
-   * What this stream's last run turned out to be, or `undefined` for a stream
-   * that has never hydrated — see {@link RunPhaseFacts}.
-   *
-   * Deliberately not part of {@link getRunMetadata}: those five fields are the
-   * record's, and go with it. These four are the store's, and survive a
-   * record released for residency, which is the only reason a caller can ask
-   * every tab's phase without making every tab resident. Never warns about an
-   * unseeded read — "not hydrated yet" is one of the answers.
-   */
-  getRunPhaseFacts(stream: StreamTabId): RunPhaseFacts | undefined {
-    return this.runFacts.get(stream);
   }
 
   /**
@@ -1919,13 +1826,8 @@ export class StreamSnapshotStore {
   }
 
   private evictStreamsExcept(keep: ReadonlySet<StreamTabId>): void {
-    // `load` is authoritative about the stream set, so a stream missing from
-    // it is gone rather than merely released: forget its run facts too.
-    for (const stream of new Set([
-      ...this.records.keys(),
-      ...this.runFacts.keys(),
-    ])) {
-      if (!keep.has(stream)) this.forget(stream);
+    for (const stream of [...this.records.keys()]) {
+      if (!keep.has(stream)) this.evict(stream);
     }
   }
 
@@ -2019,7 +1921,7 @@ export class StreamSnapshotStore {
         // Core-only, and strict on the core (see {@link readMetaCore}): a
         // malformed row is an unreadable authority, but a malformed OPTIONAL
         // `workflow` projection is not — the identity and description below
-        // parsed, and so did the outcome the probe reads.
+        // parsed either way.
         const [execMeta, execConfig] = await Promise.all([
           readMetaCore(store),
           store.readConfig(),
@@ -2056,49 +1958,6 @@ export class StreamSnapshotStore {
       userFollowUpSupport,
       description,
     };
-  }
-
-  /**
-   * Who holds the execution lease, whether a resumable checkpoint file
-   * exists, and how the run ended. Each is one small read: the checkpoint is
-   * a single `exists` stat, never a parse of the (often ~600 KB) flow record;
-   * the lease inspection reads only — a dead claim reports as absent and is
-   * unlinked by the next claim, never by this call; and the outcome is a
-   * core-schema parse of the execution row (see {@link readMetaCore}). Never
-   * throws: an unreadable probe reports its cause, which the phase rule
-   * renders as unavailable rather than as a run that never happened.
-   *
-   * ORDERING INVARIANT — lease, then checkpoint, then outcome, sequentially.
-   * A foreign finalize writes the outcome, deletes the checkpoint, then
-   * releases the lease. Reading in that same order means a free lease is
-   * always followed by the outcome read that a finalize which released it has
-   * already written. Any other order (a parallel batch included) can splice
-   * "lease free, no checkpoint" observed after the finalize onto "no outcome"
-   * observed before it, cache that phantom `none` in `runFacts`, and leave the
-   * tab reading Ready until the next explicit preload. The cost is one more
-   * small row read per seed — deliberately NOT folded into the metadata read
-   * that runs beside this probe, because that read is unordered against the
-   * lease.
-   */
-  private async probeRunPhase(
-    executionId: ExecutionId,
-  ): Promise<RunPhaseProbe> {
-    try {
-      const store = getExecutionStore(executionId);
-      const lease = await inspectExecutionLease(executionId);
-      const checkpointPresent = await store.exists(flowKey(executionId));
-      const meta = await readMetaCore(store);
-      return {
-        checkpointPresent,
-        lease,
-        ...(meta?.outcome !== undefined && { outcome: meta.outcome }),
-      };
-    } catch (error) {
-      log.warn(`Could not read run phase facts for execution ${executionId}.`, {
-        data: { executionId, error },
-      });
-      return { failure: toErrorMessage(error) };
-    }
   }
 
   /** Seed the in-memory accumulators for one stream. */
@@ -2155,18 +2014,8 @@ export class StreamSnapshotStore {
       // from (#9590 Stage 6); when identity changes hands, drop it with the
       // pair and invalidate any authority read already in flight.
       record.description = undefined;
-      this.runFacts.delete(stream);
       record.summaryMetaHydrationFallback = undefined;
     }
-    // Started before the metadata await so both reads overlap, and awaited at
-    // the very end so a display-only fact never delays the record's restore.
-    const phaseProbe = executionId
-      ? this.probeRunPhase(executionId)
-      : undefined;
-    // Accumulated locally and published once at the end: the map is what
-    // readers see, and half a tuple would render a stopped run as a healthy
-    // one for the length of the probe.
-    let runFacts: RunPhaseFacts = {};
     if (meta) {
       const pendingLiveWrite = metaOverlay !== undefined;
       const configBeforeHydration = record.runConfig;
@@ -2205,16 +2054,6 @@ export class StreamSnapshotStore {
         if (!liveRunConfig) {
           record.runConfig = hydrated.config ?? record.runConfig;
         }
-        // Whole-value: this read is the only producer of the authority
-        // failure, so it replaces rather than fills, and a failed read says
-        // so with the cause attached instead of leaving a quiet absence. The
-        // outcome is NOT read here — it belongs to the probe's ordered
-        // lease→checkpoint→outcome sequence.
-        runFacts = {
-          ...(hydrated.authorityFailure !== undefined && {
-            authorityFailure: hydrated.authorityFailure,
-          }),
-        };
       }
     }
 
@@ -2259,31 +2098,6 @@ export class StreamSnapshotStore {
     // a handoff, only facts belonging to the new execution are published.
     if (this.records.get(stream) === record) {
       this.publishSummaryMeta(stream);
-    }
-
-    if (phaseProbe) {
-      const probe = await phaseProbe;
-      runFacts = {
-        ...runFacts,
-        ...(probe.outcome !== undefined && { outcome: probe.outcome }),
-        ...(probe.checkpointPresent !== undefined && {
-          checkpointPresent: probe.checkpointPresent,
-        }),
-        ...(probe.lease !== undefined && { lease: probe.lease }),
-        ...(runFacts.authorityFailure === undefined &&
-          probe.failure !== undefined && { authorityFailure: probe.failure }),
-      };
-    }
-    // Published even when it is empty: the entry's existence is what says this
-    // stream hydrated, and it is the only such marker that outlives the
-    // record. A deletion (which rotates the generation) or a handoff to
-    // another execution during the awaits above makes this tuple somebody
-    // else's, so neither publishes.
-    if (
-      this.isCurrentGeneration(stream, generation) &&
-      record.runExecutionId === executionId
-    ) {
-      this.runFacts.set(stream, Object.freeze(runFacts));
     }
   }
 

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -19,7 +19,7 @@
 import pMap from 'p-map';
 import { z } from 'zod';
 
-import { getExecutionStore, type ExecutionKVStore } from '@agent/storage';
+import { getExecutionStore, readExecutionMetaCore } from '@agent/storage';
 import type { AgentEvent } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
@@ -31,7 +31,6 @@ import {
   cloneRoundIndexed,
   EMPTY_ROUND_INDEXED,
   emptyUsageStats,
-  ExecutionMetaCoreSchema,
   isEmptyUsage,
   OutputFileInfoListSchema,
   PersistedWorkPlanSchema,
@@ -43,7 +42,6 @@ import {
   TokenUsageStatsParsingBaseSchema,
   type CompileFailure,
   type ExecutionId,
-  type ExecutionMeta,
   type ExtendedTokenUsageStats,
   type OutputFileInfo,
   type RunIdentity,
@@ -172,23 +170,6 @@ interface HydratedRunState {
   identity?: RunIdentity;
   userFollowUpSupport?: UserFollowUpSupport;
   description?: string;
-}
-
-/**
- * The execution row's CORE fields, parsed strictly, without the optional
- * `workflow` projection. Every fact this store hydrates from the row —
- * identity, follow-up support, description — lives in the core schema, so a
- * malformed projection must not cost them: `readMetaStrict` throws on one
- * (which would strand a valid historical run on "unavailable"), and
- * `readMeta` swallows a malformed CORE row as absence (which would render a
- * corrupt execution as a healthy, sendable stream). Same raw read, same
- * schema, same "malformed core is unreadable" rule as `deriveResumability`.
- */
-async function readMetaCore(
-  store: ExecutionKVStore,
-): Promise<ExecutionMeta | null> {
-  const raw = await store.read('meta');
-  return raw === undefined ? null : ExecutionMetaCoreSchema.parse(raw);
 }
 
 function withoutSummaryMetaFields(
@@ -1918,12 +1899,12 @@ export class StreamSnapshotStore {
       let config: AgentConfig | null = null;
       try {
         const store = getExecutionStore(executionId);
-        // Core-only, and strict on the core (see {@link readMetaCore}): a
-        // malformed row is an unreadable authority, but a malformed OPTIONAL
-        // `workflow` projection is not — the identity and description below
-        // parsed either way.
+        // Core-only, and strict on the core (see {@link
+        // readExecutionMetaCore}): a malformed row is an unreadable authority,
+        // but a malformed OPTIONAL `workflow` projection is not — the identity
+        // and description below parsed either way.
         const [execMeta, execConfig] = await Promise.all([
-          readMetaCore(store),
+          readExecutionMetaCore(store),
           store.readConfig(),
         ]);
         // Identity comes only from the stamped execution row; a row without


### PR DESCRIPTION
Part of #11822 (S1/S3), correcting two pieces of #11824 after the architecture audit: the post-load background hydration was an O(history) pass moved off the ready path, and the run facts widened a frozen store surface.

## What

- **No boot pass over rows.** `ProgressBackend`'s background hydration (chunked walk over every selectable stream with a checkpoint stat and a lease read each) is deleted outright. Rows the user has not opened render from the always-resident summary tier; the open-transcript flags give the interrupted arm at zero I/O; everything else reads as pending until opened.
- **Run facts belong to the controller.** `StreamSnapshotStore` loses `probeRunPhase`, the `runFacts` map, `getRunPhaseFacts`, and the hydration-time lease, checkpoint, and outcome reads. `SessionState` keeps an in-memory per-stream tuple (outcome, checkpoint present, lease, authority failure; never persisted) filled by one `hydrateRunFacts(stream)` at row open, reading the lease, then the checkpoint stat, then the core metadata, in that order so a free lease is always followed by the outcome a completed finalize already wrote. Cleared on execution handoff and stream deletion. `resolveStreamPhase`'s arms are unchanged; they read the tuple instead of the store.
- **Row open is the only caller**: the progress backend's selection hydration and the CLI's focused-stream hydration. No all-rows path.
- **Ratchet reverted**: `config/ratchets/store-public-surface-baseline.json` returns `StreamSnapshotStore` to its pre-#11824 five-field `getRunMetadata` with no new method; `StreamLogStore` keeps `hasUnfinishedOutput`.

Net: 9 files, +200 / -344.

## Why

The startup proposal forbids any boot-time walk over history, bounded or not, and the repo freezes the shared store surfaces. A liveness probe belongs at row open (S3), not at hydration or at boot.

## Verification

Typecheck clean; lint and prettier clean; progress-view, transcript, architecture (including the store-surface ratchet against the lowered baseline), desktop, and agent-runtime suites green; `DerivedStreamPhase` cases re-seeded through `hydrateRunFacts`. Central dead-code ratchet and CLI suites run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)