### PR TITLE
fix: selected-row contrast and composer chrome simplification

### DIFF
--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.styles.ts
@@ -50,11 +50,10 @@ export const followUpInputStyles: CSSResult = css`
   }
 
   .composer-surface:focus-within {
-    border-color: color-mix(
-      in srgb,
-      var(--wa-color-focus) 42%,
-      var(--wa-color-surface-border)
-    );
+    /* One ring around the whole card; the plain native textarea inside draws
+       no focus chrome of its own. */
+    outline: var(--focus-ring-width) solid var(--wa-color-focus);
+    outline-offset: var(--focus-ring-offset);
     box-shadow:
       0 1px 2px
         color-mix(in srgb, var(--wa-color-surface-shadow) 20%, transparent),
@@ -66,32 +65,19 @@ export const followUpInputStyles: CSSResult = css`
      the max below, so a substantial instruction still gets room without
      an empty draft reserving it. field-sizing does the growing; the drag
      affordance stays for anyone who wants a taller box than their text.
-     Not Web Awesome's resize="auto": that copies the scroll height into an
-     invisible grid item which, inside a constrained composer, keeps an
-     oversized row for an empty draft. */
+     A plain native textarea, not wa-textarea: the composer strips every
+     piece of WA form-control chrome (label, hint, border, focus ring), so
+     carrying the component only meant overriding all of it away. */
   #followUpInput {
-    display: block;
-    min-width: 0;
-    width: 100%;
-    box-sizing: border-box;
-    line-height: var(--line-height-relaxed);
-    height: auto;
     --textarea-min-height: calc(2lh + var(--wa-space-xs) + var(--wa-space-3xs));
     --textarea-max-height: clamp(var(--textarea-min-height), 32vh, 240px);
-  }
-
-  #followUpInput::part(textarea-wrapper) {
-    align-items: start;
-    max-height: var(--textarea-max-height);
-    overflow: hidden;
+    display: block;
+    min-width: 0;
+    margin: 0;
     border: 0;
+    outline: none;
     background: transparent;
-    box-shadow: none;
-  }
-
-  /* The one place a textarea renders sans rather than mono: this is prose a
-     user writes to an agent, not code. */
-  #followUpInput::part(textarea) {
+    resize: vertical;
     ${proseTextareaPartRule}
   }
 
@@ -133,7 +119,7 @@ export const followUpInputStyles: CSSResult = css`
   }
 
   @container (max-width: 440px) {
-    #followUpInput::part(textarea) {
+    #followUpInput {
       padding-inline: var(--wa-space-xs);
     }
   }

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -47,7 +47,6 @@ import './QueuedFollowUps';
 
 // Web Awesome native components
 import '@awesome.me/webawesome/dist/components/details/details.js';
-import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
 
 /** True when any shadow host or light ancestor has `data-desktop-view`. */
 function hostHasDesktopViewAttribute(start: Element): boolean {
@@ -108,7 +107,7 @@ export class FollowUpInput extends UnsupportedCommandsMixin(LitElement) {
   @state() private statusAnnouncement = '';
 
   @query(`#${ELEMENT_IDS.FOLLOW_UP_INPUT}`)
-  declare private textAreaEl: HTMLElement | null;
+  declare private textAreaEl: HTMLTextAreaElement | null;
 
   @query('wa-details')
   declare private detailsEl: (HTMLElement & { open: boolean }) | null;
@@ -298,26 +297,27 @@ export class FollowUpInput extends UnsupportedCommandsMixin(LitElement) {
         }
 
         <div class="composer-surface">
-          <wa-textarea
+          <label for=${ELEMENT_IDS.FOLLOW_UP_INPUT} class="visually-hidden"
+            >Follow-up message</label
+          >
+          <textarea
             id=${ELEMENT_IDS.FOLLOW_UP_INPUT}
             name="follow-up-message"
             placeholder="Message TeXRA…"
             rows="2"
-            resize="vertical"
             autocomplete="off"
             spellcheck="true"
+            aria-describedby=${ELEMENT_IDS.FOLLOW_UP_HINT}
             ?disabled=${this.sending}
             .value=${live(this.value)}
             @input=${this.handleInput}
             @keydown=${this.handleKeydown}
             @paste=${this.handlePaste}
-          >
-            <span slot="label" class="visually-hidden">Follow-up message</span>
-            <span slot="hint" class="visually-hidden">
-              Press Enter to send or Shift+Enter for a new line. Paste images to
-              attach them.
-            </span>
-          </wa-textarea>
+          ></textarea>
+          <div id=${ELEMENT_IDS.FOLLOW_UP_HINT} class="visually-hidden">
+            Press Enter to send or Shift+Enter for a new line. Paste images to
+            attach them.
+          </div>
 
           <div class="follow-up-actions">
             ${

--- a/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
@@ -199,7 +199,11 @@ export const streamTabStyles = css`
       var(--wa-color-brand-fill-quiet) 85%,
       transparent
     );
-    color: var(--wa-color-list-active-fg, var(--wa-color-text-normal));
+    /* brand-on-quiet is the foreground paired with the quiet fill above in
+       both hosts. list-active-fg is not: it is authored to sit on the loud
+       --wa-color-list-active-bg accent (white in light themes), which made
+       the selected row white-on-near-white in light mode. */
+    color: var(--wa-color-brand-on-quiet, var(--wa-color-text-normal));
   }
 
   /*
@@ -208,7 +212,7 @@ export const streamTabStyles = css`
    * (.last-active, .model) and codicon glyphs.
    */
   .tab-container.is-active * {
-    color: var(--wa-color-list-active-fg, var(--wa-color-text-normal));
+    color: var(--wa-color-brand-on-quiet, var(--wa-color-text-normal));
   }
 
   /* Selection is the primary row state. Keep the lifecycle rail present, but

--- a/packages/extension/src/progressView/frontend/constants.ts
+++ b/packages/extension/src/progressView/frontend/constants.ts
@@ -61,6 +61,7 @@ export const ELEMENT_IDS = {
   COPY_RUN_CONTEXT_BTN: 'copyRunContextBtn',
   FOLLOW_UP_CONTAINER: 'followUpContainer',
   FOLLOW_UP_INPUT: 'followUpInput',
+  FOLLOW_UP_HINT: 'followUpHint',
   QUEUED_FOLLOW_UPS_COLLAPSIBLE: 'queuedFollowUpsCollapsible',
   QUEUED_FOLLOW_UPS_LIST: 'queuedFollowUpsList',
   RECORD_FOLLOW_UP_BTN: 'recordFollowUpBtn',

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -86,7 +86,7 @@ export class MultiAgentTab extends LitElement {
 
       .preset-card.active {
         background-color: var(--wa-color-brand-fill-quiet);
-        color: var(--wa-color-list-active-fg);
+        color: var(--wa-color-brand-on-quiet);
         border-color: var(--wa-color-focus);
       }
 

--- a/scripts/smoke-webviews-electron-runner.cjs
+++ b/scripts/smoke-webviews-electron-runner.cjs
@@ -371,7 +371,7 @@ async function assertProgressComposerLayout(window, view) {
         // Resting height of the composer, in lines. It sits at two and grows
         // with content up to --textarea-max-height; the six-line resting box
         // it replaced reserved that room for an empty draft. Keep in step
-        // with --textarea-min-height in FollowUpInput.ts.
+        // with --textarea-min-height in FollowUpInput.styles.ts.
         const COMPOSER_RESTING_ROWS = 2;
 
         function findDeep(selector, root = document) {
@@ -387,18 +387,14 @@ async function assertProgressComposerLayout(window, view) {
         const composer = findDeep('follow-up-input');
         const dock = findDeep('.conversation-composer-dock');
         const conversationLog = findDeep('.conversation-log');
-        const webAwesomeTextarea = composer?.shadowRoot?.querySelector('wa-textarea');
-        if (webAwesomeTextarea?.updateComplete) await webAwesomeTextarea.updateComplete;
-        const textarea = webAwesomeTextarea?.shadowRoot?.querySelector('textarea');
-        const wrapper = webAwesomeTextarea?.shadowRoot?.querySelector('.textarea');
+        if (composer?.updateComplete) await composer.updateComplete;
+        const textarea = composer?.shadowRoot?.querySelector('textarea');
 
         const missing = [
           ['follow-up-input', composer],
           ['composer dock', dock],
           ['conversation log', conversationLog],
-          ['wa-textarea', webAwesomeTextarea],
           ['native textarea', textarea],
-          ['textarea wrapper', wrapper],
         ]
           .filter(([, element]) => !element)
           .map(([label]) => label);
@@ -420,19 +416,15 @@ async function assertProgressComposerLayout(window, view) {
           Math.min(window.innerHeight * 0.32, 240),
         );
         const initialTextareaRect = textarea.getBoundingClientRect();
-        const initialWrapperRect = wrapper.getBoundingClientRect();
 
-        if (
-          webAwesomeTextarea.rows !== COMPOSER_RESTING_ROWS ||
-          textarea.rows !== COMPOSER_RESTING_ROWS
-        ) {
+        if (textarea.rows !== COMPOSER_RESTING_ROWS) {
           throw new Error(
-            \`${view.name} composer rows did not propagate: host=\${webAwesomeTextarea.rows} native=\${textarea.rows} expected=\${COMPOSER_RESTING_ROWS}\`,
+            \`${view.name} composer rows did not propagate: native=\${textarea.rows} expected=\${COMPOSER_RESTING_ROWS}\`,
           );
         }
-        if (webAwesomeTextarea.resize !== 'vertical' || style.resize !== 'vertical') {
+        if (style.resize !== 'vertical') {
           throw new Error(
-            \`${view.name} composer is not vertically resizable: host=\${webAwesomeTextarea.resize} native=\${style.resize}\`,
+            \`${view.name} composer is not vertically resizable: native computed resize=\${style.resize}\`,
           );
         }
         if (Math.abs(minHeight - expectedMinHeight) > 3) {
@@ -450,31 +442,11 @@ async function assertProgressComposerLayout(window, view) {
             \`${view.name} composer max-height cap is incorrect: max=\${maxHeight.toFixed(1)}px expected=\${expectedMaxHeight.toFixed(1)}px\`,
           );
         }
-        if (Math.abs(initialWrapperRect.height - initialTextareaRect.height) > 2) {
-          throw new Error(
-            \`${view.name} Web Awesome wrapper is not synchronized initially: wrapper=\${initialWrapperRect.height.toFixed(1)}px textarea=\${initialTextareaRect.height.toFixed(1)}px\`,
-          );
-        }
-
-        textarea.style.height = '1000px';
-        await new Promise((resolve) =>
-          requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(resolve, 0))),
-        );
-        const cappedTextareaRect = textarea.getBoundingClientRect();
-        const cappedWrapperRect = wrapper.getBoundingClientRect();
-        if (cappedTextareaRect.height > maxHeight + 1) {
-          throw new Error(
-            \`${view.name} native textarea exceeded its cap: rendered=\${cappedTextareaRect.height.toFixed(1)}px max=\${maxHeight.toFixed(1)}px\`,
-          );
-        }
-        if (Math.abs(cappedWrapperRect.height - cappedTextareaRect.height) > 2) {
-          throw new Error(
-            \`${view.name} Web Awesome wrapper lost sync after resize: wrapper=\${cappedWrapperRect.height.toFixed(1)}px textarea=\${cappedTextareaRect.height.toFixed(1)}px\`,
-          );
-        }
 
         const viewportWidth = document.documentElement.clientWidth;
         const viewportHeight = document.documentElement.clientHeight;
+        // Measure the dock and log at the composer's resting height, before
+        // the forced-stretch cap check below perturbs the layout.
         const composerRect = composer.getBoundingClientRect();
         const dockRect = dock.getBoundingClientRect();
         const logRect = conversationLog.getBoundingClientRect();
@@ -498,6 +470,23 @@ async function assertProgressComposerLayout(window, view) {
           );
         }
 
+        textarea.style.height = '1000px';
+        await new Promise((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(resolve, 0))),
+        );
+        const cappedTextareaRect = textarea.getBoundingClientRect();
+        if (cappedTextareaRect.height > maxHeight + 1) {
+          throw new Error(
+            \`${view.name} native textarea exceeded its cap: rendered=\${cappedTextareaRect.height.toFixed(1)}px max=\${maxHeight.toFixed(1)}px\`,
+          );
+        }
+        // Restore the resting layout so the screenshot shows what ships,
+        // and wait a frame so the capture below cannot catch the stretch.
+        textarea.style.height = '';
+        await new Promise((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(resolve, 0))),
+        );
+
         return {
           lineHeight,
           logHeight: logRect.height,
@@ -506,7 +495,6 @@ async function assertProgressComposerLayout(window, view) {
           renderedHeight: cappedTextareaRect.height,
           viewportHeight,
           viewportWidth,
-          wrapperHeight: cappedWrapperRect.height,
         };
       })();
     `,

--- a/src/shared/styles/requestPanelSharedStyles.ts
+++ b/src/shared/styles/requestPanelSharedStyles.ts
@@ -34,11 +34,11 @@ const truncateTextRule: CSSResult = css`
 
 /**
  * Sizing contract for a prose textarea an agent is written to (no selector),
- * interpolated into the `::part(textarea)` rule of every such box — the
- * request panels' feedback inputs and the progress composer
- * (`FollowUpInput.styles.ts`). Each surface still sets its own
- * `--textarea-min-height` / `--textarea-max-height`, which is the intended
- * per-surface difference.
+ * interpolated into the textarea rule of every such box — the request panels'
+ * feedback inputs (`::part(textarea)` on their wa-textarea) and the progress
+ * composer's plain native textarea (`FollowUpInput.styles.ts`). Each surface
+ * still sets its own `--textarea-min-height` / `--textarea-max-height`, which
+ * is the intended per-surface difference.
  */
 export const proseTextareaPartRule: CSSResult = css`
   field-sizing: content;

--- a/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
@@ -123,26 +123,16 @@ function expectSend(
 
 describe('follow-up-input layout', () => {
   // The composer sizes from its own content rather than reserving a fixed
-  // block for an empty draft, and keeps the manual drag affordance. Not Web
-  // Awesome's "auto" mode: it holds an oversized row for an empty draft inside
-  // a constrained composer, which is the failure the two-line floor avoids.
-  it('rests at two rows and stays vertically resizable', async () => {
+  // block for an empty draft. The two-line floor lives in
+  // FollowUpInput.styles.ts (--textarea-min-height); the manual drag
+  // affordance (resize: vertical) is asserted by the real-browser smoke
+  // suite, which can evaluate computed CSS.
+  it('rests at two rows on a plain native textarea', async () => {
     const element = createFollowUpInput('stream-layout');
     await element.updateComplete;
 
-    const textarea = element.shadowRoot?.querySelector('wa-textarea') as
-      | (HTMLElement & {
-          rows: number;
-          resize: string;
-          input: HTMLTextAreaElement;
-          updateComplete: Promise<boolean>;
-        })
-      | null;
-    await textarea?.updateComplete;
-
+    const textarea = element.shadowRoot?.querySelector('textarea');
     expect(textarea?.rows).toBe(2);
-    expect(textarea?.resize).toBe('vertical');
-    expect(textarea?.input.rows).toBe(2);
   });
 });
 


### PR DESCRIPTION
## Summary

Two user-visible defects from a desktop-app UI review, in two commits:

1. **Selected stream tab was unreadable.** The selected tab (and the settings preset card) painted text in `--wa-color-list-active-fg`, a token authored for the loud `--wa-color-list-active-bg` accent surface — white in light themes — over the subtle `--wa-color-brand-fill-quiet` background. Measured: **1.16:1** light, **1.58:1** dark (WCAG AA is 4.5:1). Both rows now use `--wa-color-brand-on-quiet`, the foreground each host defines as the counterpart to the quiet fill: **11.5:1** light, **12.3:1** dark.

2. **The progress composer carried three layers of `::part` overrides** against `wa-textarea` — chrome stripping, a focus-outline suppression, and a label/hint part hiding — and still produced ~26px of dead air above the text (the AT-only label generated an anonymous line box a full line-height tall) plus a heavy black inner focus frame inside the card. The composer is now a plain native `<textarea\>`: the label and hint are ordinary visually-hidden elements, the composer card's own focus ring is the single focus indicator, and the shared prose sizing rule applies directly.

## Issue acceptance gates

No tracking issue; user-reported desktop UI defects. Gates: selected tab readable in both appearances (measured ratios above); composer shows no inner focus frame and no dead band above the placeholder (verified via rendered Electron screenshots).

## Single source of truth

- Selected-row colors: the WA brand-quiet token pair (`fill-quiet`/`on-quiet`), already defined per host (`common.css`, `themeTokens.css`).
- Composer textarea: one native element styled by `FollowUpInput.styles.ts` + the shared `proseTextareaPartRule` sizing contract.

## Duplication and abstraction budget

Removed, not added: three `::part` override blocks and the slotted visually-hidden spans that duplicated the hiding the parts then needed. `wa-textarea` stays where its visible label/hint chrome is used (feedback / inquiry / question panels). No new abstraction.

## Net elements (R6)

- Files: 8 changed, +69/−100 (net **−31 LoC**)
- Exported symbols: none added or removed (`^[+-]export` over the diff: zero hits)
- Classes/interfaces/enums: none

## Consumer counts (R8)

- `wa-textarea`: composer consumption removed; 3 production consumers remain (`BaseFeedbackPanel`, `UserQuestionPanel`, `ExternalInquiryPanel`), untouched.
- `proseTextareaPartRule`: 1 production consumer (`FollowUpInput.styles.ts`), plus its defining module's feedback-panel rules — unchanged.
- No emit path or export deleted.

## Host impact

Extension: selected stream tab and preset card readable in light themes (same defect existed there); composer simplified, same look minus dead air.
Desktop: fixes the reported illegible selected tab and the composer's black inner frame / top whitespace.
CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm test` — 819 files, 9992 passed
- `npm run smoke:webviews` — Electron render smoke incl. the composer layout assertion (updated: no longer drills through WA's shadow root; dock/log now measured at resting height, fixing a measurement-while-stretched flake); before/after screenshots inspected
- Headless-Electron geometry probe of the live composer (dead-air decomposition: 19.5px line box + 6.5px margin, both eliminated)
- WCAG 2 relative-luminance ratios computed for all four fg/bg pairs (above)
- `npm run typecheck:workspace`, `npm run lint`, Prettier — clean