### PR TITLE
Export AssistantTextAppendOptions as single source of truth

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -146,7 +146,13 @@ export interface CreatedMedia<Media> {
   readonly entries: readonly MediaEntry[];
 }
 
-interface AssistantTextAppendOptions {
+/**
+ * Options for {@link ModelHandler.appendTextToLastAssistantMessage}. Exported
+ * as the single source of truth for the append-options contract so provider
+ * overrides reference this shape by name instead of redeclaring it inline (two
+ * of them had already drifted, silently dropping `fallbackText`).
+ */
+export interface AssistantTextAppendOptions {
   /**
    * True when the current trailing user/system message may be the synthetic
    * continuation prompt. Providers decide whether to append to the previous

--- a/src/agent/modelHandlers/anthropic/anthropicMessages.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicMessages.ts
@@ -1,6 +1,7 @@
 // Local imports
 import type { AgentTrace } from '@agent/trace';
 import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
+import type { AssistantTextAppendOptions } from '../ModelHandler';
 
 // Third-party imports
 import type {
@@ -95,7 +96,7 @@ export async function addMediaToUserMessage(
 export function appendTextToLastAssistantMessage(
   messages: MessageParam[],
   text: string,
-  options: { afterContinuationPrompt?: boolean; fallbackText?: string } = {},
+  options: AssistantTextAppendOptions = {},
   deps: AnthropicAssistantMessageDeps,
 ): boolean {
   let targetIndex = messages.length - 1;

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -16,7 +16,10 @@ import type {
   AgentWorkspaceState,
   ThinkingBlock,
 } from '@agent/core/state/AgentWorkspaceState';
-import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
+import {
+  ModelHandler,
+  type AssistantTextAppendOptions,
+} from '@agent/modelHandlers/ModelHandler';
 import type { ModelCredentialSelection } from '@agent/types/ModelHandlerContracts';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { MediaEntry } from '@agent/types/mediaTypes';
@@ -1292,7 +1295,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
   protected appendTextToLastAssistantMessage(
     messages: MessageParam[],
     text: string,
-    options: { afterContinuationPrompt?: boolean; fallbackText?: string } = {},
+    options: AssistantTextAppendOptions = {},
   ): boolean {
     return appendAnthropicTextToLastAssistantMessage(messages, text, options, {
       logger: this.logger,

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -17,6 +17,7 @@ import { logProgressStatus } from '@agent/trace';
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import {
   ModelHandler,
+  type AssistantTextAppendOptions,
   type CreatedMedia,
 } from '@agent/modelHandlers/ModelHandler';
 import { reportMediaAttachmentFailure } from '@agent/modelHandlers/support/mediaAttachmentPolicy';
@@ -1257,7 +1258,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   protected appendTextToLastAssistantMessage(
     messages: Step[],
     text: string,
-    options: { afterContinuationPrompt?: boolean } = {},
+    options: AssistantTextAppendOptions = {},
   ): boolean {
     const trailingStep = messages.at(-1);
     if (

--- a/src/agent/modelHandlers/modelHandlerValidation.ts
+++ b/src/agent/modelHandlers/modelHandlerValidation.ts
@@ -21,7 +21,7 @@ import type {
 } from '@shared/schemas';
 
 // Local imports - model handlers
-import { ModelHandler } from './ModelHandler';
+import { ModelHandler, type AssistantTextAppendOptions } from './ModelHandler';
 
 // Third-party imports
 import type { ModelConfig } from 'llm-zoo';
@@ -225,7 +225,7 @@ export class ModelHandlerValidation extends ModelHandler<
   protected appendTextToLastAssistantMessage(
     _messages: ChatCompletionMessageParam[],
     _text: string,
-    _options?: { afterContinuationPrompt?: boolean; fallbackText?: string },
+    _options?: AssistantTextAppendOptions,
   ): boolean {
     return false;
   }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -72,6 +72,7 @@ import { formatToolResultTextWithAttachments } from '../utils/toolAttachmentUtil
 import { OpenAICompatibleModelHandler } from './OpenAICompatibleModelHandler';
 import { ReasoningStreamAggregator } from './ReasoningStreamAggregator';
 import { CLIENT_COMPACTION_SUMMARY_MAX_TOKENS } from '../contextManagementConstants';
+import type { AssistantTextAppendOptions } from '../ModelHandler';
 import type { NormalizeOpenAIMessageContentOptions } from './openAIMessageUtils';
 
 // Third-party imports
@@ -883,7 +884,7 @@ export class ModelHandlerOpenAI<
   protected appendTextToLastAssistantMessage(
     messages: ChatCompletionMessageParam[],
     text: string,
-    options: { afterContinuationPrompt?: boolean; fallbackText?: string } = {},
+    options: AssistantTextAppendOptions = {},
   ): boolean {
     let targetIndex = messages.length - 1;
     const trailingMessage = messages.at(-1);

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -105,6 +105,7 @@ import {
   uploadToolAttachments,
   type UploadedOpenAIResponseAttachment,
 } from './openAIResponseFileUploads';
+import type { AssistantTextAppendOptions } from '../ModelHandler';
 import type { BackgroundRunLifecycle } from '../support/BackgroundRunLifecycle';
 
 // Third-party imports
@@ -1991,7 +1992,7 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
   protected appendTextToLastAssistantMessage(
     messages: ResponseInputItem[],
     text: string,
-    options: { afterContinuationPrompt?: boolean; fallbackText?: string } = {},
+    options: AssistantTextAppendOptions = {},
   ): boolean {
     let targetIndex = messages.length - 1;
     const trailingMessage = messages.at(-1);

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -64,7 +64,7 @@ import {
   OpenRouterStreamAggregator,
   toOpenRouterReasoningEffort,
 } from './openRouterStreaming';
-import { ModelHandler } from '../ModelHandler';
+import { ModelHandler, type AssistantTextAppendOptions } from '../ModelHandler';
 import { CLIENT_COMPACTION_SUMMARY_MAX_TOKENS } from '../contextManagementConstants';
 
 // Third-party type imports
@@ -707,7 +707,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
   protected appendTextToLastAssistantMessage(
     messages: ChatMessages[],
     text: string,
-    options: { afterContinuationPrompt?: boolean; fallbackText?: string } = {},
+    options: AssistantTextAppendOptions = {},
   ): boolean {
     let targetIndex = messages.length - 1;
     const trailingMessage = messages.at(-1);

--- a/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
+++ b/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
@@ -45,7 +45,7 @@ import type {
 import { getMimeType, isImageMimeType } from '@utils/files/mimeUtils';
 
 // Local file imports
-import { ModelHandler } from '../ModelHandler';
+import { ModelHandler, type AssistantTextAppendOptions } from '../ModelHandler';
 import { toVscodeLmTools } from '../toolConversion';
 import { formatToolResultTextWithAttachments } from '../utils/toolAttachmentUtils';
 
@@ -372,7 +372,7 @@ export class ModelHandlerVscodeLm extends ModelHandler<
   protected appendTextToLastAssistantMessage(
     messages: LanguageModelMessage[],
     text: string,
-    options: { afterContinuationPrompt?: boolean } = {},
+    options: AssistantTextAppendOptions = {},
   ): boolean {
     let assistantIndex = messages.length - 1;
     const trailing = messages.at(-1);


### PR DESCRIPTION
## Summary

Exports `AssistantTextAppendOptions` from `ModelHandler.ts` as the canonical definition of the append-options contract. All model handler implementations now import and use this shared interface instead of redeclaring it inline, eliminating type drift where some implementations had already silently dropped the `fallbackText` field.

## Issue acceptance gates

Fixes silent contract violations where `ModelHandlerVscodeLm` and `ModelHandlerGoogleInteractions` were missing the `fallbackText` option that other implementations supported.

## Single source of truth

`AssistantTextAppendOptions` interface in `src/agent/modelHandlers/ModelHandler.ts` now owns the append-options contract shape. All provider overrides reference this type by name.

## Duplication and abstraction budget

Removed 8 inline type redeclarations across model handler implementations:
- `ModelHandlerAnthropic`
- `ModelHandlerValidation`
- `ModelHandlerOpenRouterNative`
- `ModelHandlerVscodeLm`
- `ModelHandlerGoogleInteractions`
- `ModelHandlerOpenAI`
- `ModelHandlerOpenAIResponse`
- `appendTextToLastAssistantMessage` helper in `anthropicMessages.ts`

All now import the shared interface, preventing future drift.

## Net elements (R6)

- **Exports added:** 1 (`AssistantTextAppendOptions`)
- **Files modified:** 9
- **Net LoC:** ~0 (type consolidation, no logic changes)

## Consumer counts (R8)

`AssistantTextAppendOptions` is now imported by 8 model handler files and 1 helper module. All are internal consumers within the model handler layer.

## Host impact

Extension: None (internal refactor)

Desktop: None (internal refactor)

CLI: None (internal refactor)

## Scheduled refactoring

None

## Validation

Type checking will verify all implementations now correctly match the exported interface shape, including the previously-missing `fallbackText` field in `ModelHandlerVscodeLm` and `ModelHandlerGoogleInteractions`.

https://claude.ai/code/session_014BtUkf7FAoYTk7T8XYXzct