### PR TITLE
simplify: drop per-stream entries from the desktop command palette

### DIFF
--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -7,8 +7,6 @@ import '@awesome.me/webawesome/dist/components/dialog/dialog.js';
 import '@awesome.me/webawesome/dist/components/input/input.js';
 import { html, nothing, render } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
-import { streamDisplayLabel } from '@progressView/frontend/utils';
-import type { StreamTabId, StreamTabInfo } from '@shared/schemas';
 import {
   formatDesktopAccelerator,
   type DesktopPlatform,
@@ -54,12 +52,9 @@ export interface CommandPaletteController {
 interface DesktopCommandPaletteOptions {
   document: Document;
   actions: DesktopCommandActions;
-  getStreams?: () => readonly StreamTabInfo[];
   getShortcuts?: () => readonly DesktopShortcutEntry[];
   platform?: DesktopPlatform;
 }
-
-const DESKTOP_SWITCH_STREAM_COMMAND_PREFIX = 'texra.desktop.switchStream:';
 
 // Combobox wiring lives on the wa-input HOST, not its shadow input: ARIA
 // IDREFs (aria-controls/aria-activedescendant) cannot cross the shadow
@@ -132,25 +127,20 @@ export function executeCommandPaletteEntry(
 export function createDesktopCommandPalette({
   document,
   actions,
-  getStreams,
   getShortcuts,
   platform = getRendererPlatform(document.defaultView),
 }: DesktopCommandPaletteOptions): CommandPaletteController {
   const getEntries = (): CommandPaletteEntry[] => {
-    const streams = actions.showStream == null ? [] : (getStreams?.() ?? []);
     const shortcutsById = new Map(
       (getShortcuts?.() ?? []).map((entry) => [entry.id, entry]),
     );
-    return [
-      ...getDesktopCommandMenuEntries(platform).map((entry) =>
-        toPaletteEntry(entry, shortcutsById.get(entry.id), platform),
-      ),
-      ...streams.map(toStreamPaletteEntry),
-    ];
+    return getDesktopCommandMenuEntries(platform).map((entry) =>
+      toPaletteEntry(entry, shortcutsById.get(entry.id), platform),
+    );
   };
 
   const onExecute = (id: string): boolean | Promise<boolean> =>
-    dispatchDesktopPaletteCommand(id, actions);
+    dispatchDesktopCommand(id as DesktopCommandMenuEntry['id'], actions);
 
   // Reactive state: every mutation calls renderTemplate() to keep the DOM in
   // sync. wa-dialog handles modal backdrop, focus trap, escape key, and focus
@@ -374,49 +364,6 @@ export function createDesktopCommandPalette({
 
   renderTemplate();
   return { element: dialog, open, close };
-}
-
-function dispatchDesktopPaletteCommand(
-  id: string,
-  actions: DesktopCommandActions,
-): boolean | Promise<boolean> {
-  const streamId = parseSwitchStreamCommandId(id);
-  if (streamId != null) {
-    if (!actions.showStream) return false;
-    actions.showStream(streamId);
-    return true;
-  }
-  return dispatchDesktopCommand(id as DesktopCommandMenuEntry['id'], actions);
-}
-
-function toStreamPaletteEntry(stream: StreamTabInfo): CommandPaletteEntry {
-  return {
-    id: buildSwitchStreamCommandId(stream.name),
-    label: `Switch to ${stream.label || stream.name}`,
-    // `label` is normally `runIdentityDisplayName(identity)` by construction
-    // (`buildStreamTabInfo`), so the subtitle reads the same cleaned name the
-    // title shows instead of re-deriving it from the raw identity fields,
-    // which printed a source-prefixed id ('custom:reviewer') beside the
-    // cleaned title. The schema still permits an empty label, so both title and
-    // subtitle retain a fallback for that edge case.
-    description:
-      stream.description ||
-      stream.command ||
-      streamDisplayLabel(stream) ||
-      'Stream',
-    icon: 'terminal',
-    category: 'Tasks',
-  };
-}
-
-function buildSwitchStreamCommandId(streamId: StreamTabId): string {
-  return `${DESKTOP_SWITCH_STREAM_COMMAND_PREFIX}${streamId}`;
-}
-
-function parseSwitchStreamCommandId(id: string): StreamTabId | undefined {
-  if (!id.startsWith(DESKTOP_SWITCH_STREAM_COMMAND_PREFIX)) return undefined;
-  const streamId = id.slice(DESKTOP_SWITCH_STREAM_COMMAND_PREFIX.length);
-  return streamId || undefined;
 }
 
 function toPaletteEntry(

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -31,7 +31,6 @@ import {
   handleToolbarCommand,
   runCompileFixer,
   requestStreamDeselection,
-  requestStreamSwitch,
 } from '@progressView/frontend/eventHandlers';
 import { dispatchMessage } from '@progressView/frontend/messageDispatcher';
 import {
@@ -50,7 +49,6 @@ import { COMMON_COMMANDS } from '@shared/ipc';
 import '@settingsView/frontend';
 import '@webview/frontend';
 import { hostBridge, postMessage } from '@shared/hostBridge';
-import type { StreamTabId } from '@shared/schemas';
 
 import { Signal, subscribeToSignalChanges } from '@shared/signals';
 import { resolvePostMessageTargetOrigin } from '@shared/postMessageOrigin';
@@ -922,7 +920,6 @@ const desktopRendererCommandActions: DesktopCommandActions = {
   showLauncher: returnToLauncher,
   openWorkbench: workbench.openKind,
   showSettings: openSettingsTab,
-  showStream: switchToStream,
   openDesktopDocs: () => {
     postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS);
   },
@@ -960,7 +957,6 @@ const shortcutBootstrap = createDesktopShortcutBootstrap({
     createDesktopCommandPalette({
       document,
       actions: desktopRendererCommandActions,
-      getStreams: () => topLevelStreams$.get(),
       getShortcuts: () => registry.entries(),
     }),
   appendPalette: (element) => document.body.append(element),
@@ -975,11 +971,6 @@ const shortcutBootstrap = createDesktopShortcutBootstrap({
 
 function openCommandPalette(): void {
   shortcutBootstrap.open();
-}
-
-function switchToStream(streamId: StreamTabId): void {
-  if (!appState.get().streamById.has(streamId)) return;
-  requestStreamSwitch(streamId);
 }
 
 // Clear the active stream so the center pane swaps back to <main-app>.

--- a/packages/desktop/src/shared/desktopCommandSurface.ts
+++ b/packages/desktop/src/shared/desktopCommandSurface.ts
@@ -2,7 +2,6 @@ import type {
   AgentCategory,
   GettingStartedAction,
   SettingsTabPanelName,
-  StreamTabId,
 } from '@shared/schemas';
 import { MAIN_VIEW_COMMANDS, SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
@@ -159,15 +158,12 @@ export interface DesktopCommandMenuEntry {
  * over the same `CommandId` union with their host-specific actions, and both
  * require every action a registered handler can reach, so a miswired host
  * fails to compile instead of producing a menu item that silently does
- * nothing. `showStream` is the one genuine option: it is reachable only from
- * the renderer's palette (stream rows), never from the native menu, so the
- * main-process action set does not implement it.
+ * nothing.
  */
 export interface DesktopCommandActions {
   showLauncher(): void;
   openWorkbench(kind: DesktopWorkbenchKind): void;
   showSettings(tab?: SettingsTabPanelName, agentSubTab?: AgentCategory): void;
-  showStream?(streamId: StreamTabId): void;
   openDesktopDocs(): void;
   openLogFolder(): void;
   openWorkspaceFolder(): void;

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -35,7 +35,7 @@ export function handleStreamSwitch(
 }
 
 /** Record reversible tab feedback, then ask the backend to hydrate it. */
-export function requestStreamSwitch(streamId: StreamTabId): void {
+function requestStreamSwitch(streamId: StreamTabId): void {
   const requestId = crypto.randomUUID();
   appState.set(
     create(appState.get(), (draft) => {

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.ts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.ts
@@ -1,8 +1,7 @@
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
-// Local imports - shared schemas
-import { AgentCategory } from '@shared/schemas';
+// Local imports
 import { delay } from '@utils/core';
 
 // Local imports - test DOM utilities
@@ -21,9 +20,7 @@ interface DesktopCommandPaletteModule {
       showLauncher(): void;
       openWorkbench(kind: 'settings' | 'logs'): void;
       showSettings(tab?: string): void;
-      showStream?(streamId: string): void;
     };
-    getStreams?: () => DesktopPaletteStream[];
     platform?: NodeJS.Platform;
     canOpen?: () => boolean;
   }): DesktopCommandPaletteController;
@@ -40,16 +37,6 @@ interface DesktopCommandPaletteModule {
     entry: { id: string; label: string } | undefined,
     onExecute: (id: string) => boolean | Promise<boolean>,
   ): boolean;
-}
-
-interface DesktopPaletteStream {
-  name: string;
-  label: string;
-  agentCategory: string;
-  creationTimestamp: number;
-  description?: string;
-  agent?: string;
-  modelLabel?: string;
 }
 
 async function loadDesktopCommandPalette(): Promise<DesktopCommandPaletteModule> {
@@ -199,43 +186,6 @@ describe('desktop command palette', () => {
     await flushDialogTicks();
 
     expect(actions.showSettings).toHaveBeenCalledWith('models');
-    expect(controller.element.open).toBe(false);
-  });
-
-  it('adds current streams as switch commands when opened', async () => {
-    const actions = {
-      ...createActionsStub(),
-      showStream: vi.fn(),
-    };
-    let streams: DesktopPaletteStream[] = [];
-    const controller = await mountPalette({
-      actions,
-      getStreams: () => streams,
-    });
-
-    streams = [
-      {
-        name: 'stream-proof',
-        label: 'Spectral proof run',
-        agentCategory: AgentCategory.Workflow,
-        creationTimestamp: 1,
-        description: 'Checking the main lemma',
-      },
-    ];
-    controller.open();
-    await flushDialogTicks();
-
-    setWaInputValue(controller.element, 'spectral lemma');
-    await flushDialogTicks();
-
-    expect(paletteCommandIds(controller.element)).toEqual([
-      'texra.desktop.switchStream:stream-proof',
-    ]);
-
-    pressKey(paletteInput(controller.element), { key: 'Enter' });
-    await flushDialogTicks();
-
-    expect(actions.showStream).toHaveBeenCalledWith('stream-proof');
     expect(controller.element.open).toBe(false);
   });
 

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.ts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.ts
@@ -58,7 +58,6 @@ function makeDesktopActions(): MockedDesktopActions {
     showFirstRunWalkthrough: vi.fn(),
     showLauncher: vi.fn(),
     showSettings: vi.fn(),
-    showStream: vi.fn(),
     toggleBottomBar: vi.fn(),
     toggleSidePanel: vi.fn(),
     toggleSummaryBar: vi.fn(),


### PR DESCRIPTION
## Summary

The desktop command palette appended one "Switch to <stream>" row per open stream. On any busy session that drowned the actual commands under dozens of near-identical entries (user screenshot: a full viewport of "Switch to leanOrchestrator" / "Switch to leanSimplifier" / …). Streams already have their dedicated surface — the task rail — so the palette now lists catalog commands only.

Removing the entries made the entire switch-stream path dead, and it is deleted with them: the `getStreams` palette option, the switch-stream command-id prefix/build/parse helpers, the palette's dispatch branch, and `DesktopCommandActions.showStream` (its own docstring noted the palette was the only caller), plus `main.ts`'s `switchToStream` wiring and its two orphaned imports.

## Issue acceptance gates

No tracking issue; user-reported UX defect. Gate: opening the palette shows only catalog commands — verified by the updated palette suite (no stream rows rendered, filter/dispatch/keyboard behavior unchanged).

## Single source of truth

`getDesktopCommandMenuEntries(platform)` — the palette's entries now come from the command catalog alone; there is no second entry source.

## Duplication and abstraction budget

Removes a duplication of the task rail's stream-switching capability inside the palette. No new abstraction; one dispatch wrapper (`dispatchDesktopPaletteCommand`) inlined away.

## Net elements (R6)

- Files: 5 changed, +6/−123 (net **−117 LoC**)
- Exported symbols: none added; none removed from any public surface (deleted helpers were file-local; `showStream` was an interface member, not an export)
- Classes/interfaces/enums: one interface member removed (`DesktopCommandActions.showStream`)

## Consumer counts (R8)

- `DesktopCommandActions.showStream`: 1 consumer before (the palette's switch rows) → 0; both implementors (renderer actions, main-process shell IPC) drop it; the interface's own comment documented the palette as the sole caller.
- `getStreams` palette option: 1 producer (`main.ts`) → 0; `topLevelStreams$` remains consumed by the task rail.
- Stream switching itself is unaffected: the rail goes through `handleStreamSwitch`/`PROGRESS_VIEW_COMMANDS.SWITCH_STREAM`, covered by `DesktopProgressIpc.vitest.ts`.

## Host impact

Extension: none.
Desktop: palette shows catalog commands only; stream switching stays on the task rail.
CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm test` — 819 files, 9991 passed (one palette test deleted with the feature)
- `npm run typecheck:workspace` + `npm run typecheck:desktop` — clean
- `npm run lint`, Prettier — clean
- Not run: a live desktop-app launch; behavior verified through the jsdom palette suite and type checks