### PR TITLE
refactor(desktop): per-paper adapters take the paper, paper commands through createCommandHandler

### DIFF
--- a/packages/desktop/src/main/desktopFileSelection.ts
+++ b/packages/desktop/src/main/desktopFileSelection.ts
@@ -11,7 +11,6 @@ import {
 import { listWorkspaceFiles } from '@common/files/workspaceFileListing';
 import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
-import { workspaceRoots } from '@platform/workspaceRoots';
 import { relativeToRoot } from '@platform/defaults/nodeWorkspace';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import {
@@ -42,11 +41,12 @@ interface DesktopFileSelectionDialogOptions {
 
 interface DesktopFileSelectionOptions {
   postToRenderer(message: unknown): void;
-  getWorkspacePath?: () => string | undefined;
-  showOpenFileDialog?: (
+  /** Root of the paper the adapter serves; undefined for the no-workspace session. */
+  workspacePath: string | undefined;
+  showOpenFileDialog: (
     options: DesktopFileSelectionDialogOptions,
   ) => Promise<string[] | undefined>;
-  onError?: (error: unknown) => void;
+  onError: (error: unknown) => void;
 }
 
 export interface DesktopFileSelection extends DesktopMessageHandler {
@@ -96,9 +96,6 @@ function listFiles(
  */
 export async function listDesktopWorkspaceFiles(
   fileType: ListableFileType,
-  // Not a default parameter: callers inject a getter that returns undefined to
-  // mean "no workspace", and a default would discard that and re-read the
-  // process-wide workspace instead.
   workspacePath: string | undefined,
 ): Promise<string[]> {
   const config = getFileListConfig(fileType, loadFileListSettings());
@@ -131,8 +128,7 @@ function toWorkspaceRelative(workspacePath: string, filePath: string): string {
 export function createDesktopFileSelection(
   options: DesktopFileSelectionOptions,
 ): DesktopFileSelection {
-  const getWorkspacePath =
-    options.getWorkspacePath ?? (() => workspaceRoots().workspace);
+  const { workspacePath } = options;
   const onError = createDesktopErrorReporter(options.onError);
   let port: DesktopFileSelectionOptions['postToRenderer'] | undefined =
     options.postToRenderer;
@@ -155,7 +151,7 @@ export function createDesktopFileSelection(
   }
 
   function list(fileType: ListableFileType): Promise<string[]> {
-    return listDesktopWorkspaceFiles(fileType, getWorkspacePath());
+    return listDesktopWorkspaceFiles(fileType, workspacePath);
   }
 
   // The base file is listed from the input rules: base is a single-slot view
@@ -179,7 +175,6 @@ export function createDesktopFileSelection(
   }
 
   async function updateEditedFiles(baseFile?: string) {
-    const workspacePath = getWorkspacePath();
     if (!baseFile || !workspacePath) {
       postFileList('edited', []);
       return;
@@ -198,7 +193,6 @@ export function createDesktopFileSelection(
   }
 
   async function selectMultipleFiles(message: SelectMultipleFilesMessage) {
-    if (!options.showOpenFileDialog) return;
     if (!isDesktopMultiFileType(message.fileType)) {
       // The shared webview posts this for 'output' too, which the desktop has
       // no picker for. Say so rather than dropping it: handleMessage already
@@ -206,7 +200,6 @@ export function createDesktopFileSelection(
       logger.warn(`Unsupported multiple file selection: ${message.fileType}`);
       return;
     }
-    const workspacePath = getWorkspacePath();
     if (!workspacePath) return;
 
     const fileType = message.fileType;

--- a/packages/desktop/src/main/desktopPapers.ts
+++ b/packages/desktop/src/main/desktopPapers.ts
@@ -33,22 +33,12 @@ import {
   TEXRA_APPROVAL_POLICY_CONFIG_KEY,
   type TexraApprovalPolicy,
 } from '@shared/approvalPolicy';
-import { COMMON_COMMANDS } from '@shared/ipc';
 import { StreamLogStore } from '@transcript';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-import {
-  DESKTOP_PAPER_COMMANDS,
-  DesktopClosePaperMessageSchema,
-  DesktopSelectPaperMessageSchema,
-  type DesktopPapersMessage,
-} from '../shared/desktopPaperMessages.js';
 import { initializeDesktopProcessStores } from './desktopProcessStores.js';
-import type {
-  DesktopCommandMessage,
-  DesktopMessageHandler,
-} from './desktopIpcTypes.js';
+import type { DesktopPapersMessage } from '../shared/desktopPaperMessages.js';
 
 export interface DesktopPaper {
   /** Canonical folder path, or undefined for the no-workspace session. */
@@ -109,15 +99,6 @@ export interface DesktopPaperRegistry {
   summary(): Omit<DesktopPapersMessage, 'command'>;
   /** Fires after a paper opens or closes, or the active paper changes. */
   onChange(listener: () => void): () => void;
-  /**
-   * Renderer traffic about papers: `SELECT_PAPER` requests, and the main
-   * view's ready signal, after which the renderer needs the papers list.
-   */
-  ipc(handlers: {
-    select(root: string): void;
-    close(root: string): void;
-    postPapers(): void;
-  }): DesktopMessageHandler;
   flushArtifacts(): Promise<void>;
   /** Dispose every session, the most recently opened first. */
   dispose(): void;
@@ -448,31 +429,6 @@ export async function openDesktopPaperRegistry(
         listeners.delete(listener);
       };
     },
-    ipc: (handlers) => ({
-      handleMessage(message: DesktopCommandMessage): boolean {
-        if (message.command === COMMON_COMMANDS.WEBVIEW_READY) {
-          // A pass-through like the progress ready signal: the main view's
-          // ready message still reaches the startup handler.
-          if ((message as { view?: unknown }).view === 'main') {
-            handlers.postPapers();
-          }
-          return false;
-        }
-        if (message.command === DESKTOP_PAPER_COMMANDS.CLOSE_PAPER) {
-          const parsed = DesktopClosePaperMessageSchema.safeParse(message);
-          if (!parsed.success) return false;
-          handlers.close(parsed.data.root);
-          return true;
-        }
-        if (message.command !== DESKTOP_PAPER_COMMANDS.SELECT_PAPER) {
-          return false;
-        }
-        const parsed = DesktopSelectPaperMessageSchema.safeParse(message);
-        if (!parsed.success) return false;
-        handlers.select(parsed.data.root);
-        return true;
-      },
-    }),
     async flushArtifacts() {
       const failures: string[] = [];
       for (const paper of [fallback, ...papers.values()]) {

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -10,7 +10,7 @@ import {
 import { appSignals } from '@eventBus/AppSignals';
 import type { MessageHost } from '@hosts/uiHosts';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
-import type { ConfigProvider } from '@platform/interfaces';
+import type { StateStore } from '@platform/interfaces';
 import { platform } from '@platform/platform';
 import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
 import { codingPlanForUsageSetting } from '@shared/codingPlanSubscriptions';
@@ -28,7 +28,6 @@ import {
 import { unsupported, unsupportedCommands } from '@shared/utils/dispatcher';
 import { buildSettingsSnapshotMessage } from '@shared/settingsView/handlers/settingsSnapshot';
 import type { SettingsStores } from '@shared/config/settingsAccess';
-import type { SettingsStatePorts } from '@shared/settingsView/types';
 import { loadRuntimeSkillDisplay } from '@skills/runtimeSkills';
 import { GoalStore, subscribeGoalStateChanges } from '@tools/goal';
 import { refreshToolAvailability } from '@tools/toolAvailability';
@@ -86,14 +85,15 @@ export interface DesktopSettingsIpcOptions {
   agentSettingsController: DesktopAgentSettingsController;
   credentialSettingsController: DesktopCredentialSettingsController;
   toolingSettingsController: DesktopToolingSettingsController;
-  state: SettingsStatePorts;
-  config: ConfigProvider;
+  /** Main-process global store, threaded in by the caller (see mainViewIpc). */
+  globalState: StateStore;
   ui: DesktopSettingsUiHost;
   /**
-   * The session of the paper this settings surface serves. Goal mutations are
-   * emitted on it, so the Goals tab follows a run without a manual refresh,
-   * and app-signal listeners re-read the paper's state inside its scope. The
-   * desktop has no process-default session, so it must be passed.
+   * The session of the paper this settings surface serves. Its roots supply
+   * the paper's workspace state and config; goal mutations are emitted on it,
+   * so the Goals tab follows a run without a manual refresh, and app-signal
+   * listeners re-read the paper's state inside its scope. The desktop has no
+   * process-default session, so it must be passed.
    */
   session: SessionHandle;
 }
@@ -116,7 +116,8 @@ export interface DesktopSettingsIpc extends DesktopMessageHandler {
 export function createDesktopSettingsIpc(
   options: DesktopSettingsIpcOptions,
 ): DesktopSettingsIpc {
-  const { globalState, workspaceState } = options.state;
+  const { globalState } = options;
+  const { workspaceState, config } = options.session.roots;
   // Commands declared `unsupported(...)` in settingsHandlers below surface as
   // a visible info dialog instead of a console-only error log.
   const onError = createDesktopErrorReporter(options.ui.onError, (error) => {
@@ -141,7 +142,7 @@ export function createDesktopSettingsIpc(
   });
 
   const settingsStores: SettingsStores = {
-    config: options.config,
+    config,
     workspaceState,
     globalState,
   };

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -85,7 +85,12 @@ import {
   DESKTOP_WORKSPACE_COMMANDS,
   EMPTY_DESKTOP_ENVIRONMENT_SUMMARY,
 } from '../shared/desktopWorkspaceMessages.js';
-import { DESKTOP_PAPER_COMMANDS } from '../shared/desktopPaperMessages.js';
+import {
+  DESKTOP_PAPER_COMMANDS,
+  DesktopClosePaperMessageSchema,
+  DesktopSelectPaperMessageSchema,
+} from '../shared/desktopPaperMessages.js';
+import { createCommandHandler } from './desktopIpcTypes.js';
 import { installDesktopProtocolCallbackLifecycle } from './desktopProtocolCallbacks.js';
 import {
   attachRendererConsoleLog,
@@ -987,11 +992,7 @@ function createWindow(options: {
       agentSettingsController,
       credentialSettingsController,
       toolingSettingsController,
-      state: {
-        globalState: platform().globalState,
-        workspaceState: paper.roots.workspaceState,
-      },
-      config: paper.roots.config,
+      globalState: platform().globalState,
       ui: settingsUi,
       session: paper.session,
     });
@@ -1009,7 +1010,7 @@ function createWindow(options: {
     // renderer document this paper has since loaded.
     const fileSelection = createDesktopFileSelection({
       postToRenderer: postToRendererIfAlive,
-      getWorkspacePath: () => paper.root,
+      workspacePath: paper.root,
       showOpenFileDialog: async (options) => {
         const result = await dialog.showOpenDialog(window, {
           title: options.title,
@@ -1277,11 +1278,28 @@ function createWindow(options: {
     },
     progress: progressIpc,
     onboarding: onboardingIpc,
-    papers: options.papers.ipc({
-      select: selectPaper,
-      close: closePaper,
-      postPapers,
-    }),
+    papers: createCommandHandler(
+      {
+        // A broadcast like the progress ready signal: the main view's ready
+        // message still reaches the startup handler.
+        [MAIN_VIEW_COMMANDS.WEBVIEW_READY]: {
+          when: (message) => message.view === 'main',
+          run: postPapers,
+          claim: false,
+        },
+        // safeParse, not parse: dispatch runs under `runInSession` with no
+        // catch, so a malformed message is dropped, not an unhandled rejection.
+        [DESKTOP_PAPER_COMMANDS.SELECT_PAPER]: (message) => {
+          const parsed = DesktopSelectPaperMessageSchema.safeParse(message);
+          if (parsed.success) selectPaper(parsed.data.root);
+        },
+        [DESKTOP_PAPER_COMMANDS.CLOSE_PAPER]: (message) => {
+          const parsed = DesktopClosePaperMessageSchema.safeParse(message);
+          if (parsed.success) closePaper(parsed.data.root);
+        },
+      },
+      { onAsyncError: reportAsyncError },
+    ),
     globalState: platform().globalState,
     inActiveSession: (dispatch) => {
       void runInSession(activePaper().session, dispatch);

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -35,7 +35,7 @@ interface DesktopMainViewIpcOptions {
   progress: DesktopMessageHandler;
   onboarding: DesktopMessageHandler;
   /** Open-paper selection and the papers list the main view needs once ready. */
-  papers?: DesktopMessageHandler;
+  papers: DesktopMessageHandler;
   /**
    * Editor file I/O, terminal pty sessions, and embedded browser control.
    * Owned by the caller because the pty host and browser views outlive a single
@@ -58,7 +58,7 @@ interface DesktopMainViewIpcOptions {
    * Runs every renderer message dispatch inside the active paper's session
    * scope, so session-rooted services resolve to the paper the window shows.
    */
-  inActiveSession?: (dispatch: () => void) => void;
+  inActiveSession: (dispatch: () => void) => void;
   onAsyncError?: (error: unknown) => void;
 }
 
@@ -81,9 +81,7 @@ export function installDesktopMainViewIpc(
 
   function handleRendererMessage(message: unknown): void {
     if (!isDesktopCommandMessage(message)) return;
-    const dispatch = () => dispatchRendererMessage(message);
-    if (options.inActiveSession) options.inActiveSession(dispatch);
-    else dispatch();
+    options.inActiveSession(() => dispatchRendererMessage(message));
   }
 
   const bridge = installDesktopHostBridge(window, {
@@ -119,9 +117,9 @@ export function installDesktopMainViewIpc(
     options.settings,
     options.progress,
     options.onboarding,
-    // Filtered because these are optional; an undefined entry in the chain
+    options.papers,
+    // Filtered because workspace is optional; an undefined entry in the chain
     // would throw on the first message dispatched.
-    ...(options.papers ? [options.papers] : []),
     ...(options.workspace ? [options.workspace] : []),
     viewState,
     logs,

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.ts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.ts
@@ -1,9 +1,9 @@
 import '@test/support/defaultSessionTestSetup';
 
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
-import { defaultSession } from '@agent/runtime/SessionHandle';
+import { runInSession } from '@agent/runtime';
 import { MODEL_LIST_VERSION } from '@model/modelOptionsBasic';
-import type { StateStore } from '@platform/interfaces';
+import type { ConfigProvider, StateStore } from '@platform/interfaces';
 import { workspaceRoots } from '@platform/workspaceRoots';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
@@ -17,9 +17,11 @@ import {
   FakeScopedConfigProvider,
   FakeStateStore,
 } from '@test/support/FakePlatform';
+import { createTestSession } from '@test/support/sessionTestUtils';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { GoalStore } from '@tools/goal';
 
+import { disposeAfterTest } from './desktopAgentExecutionTestHarness.ts';
 import {
   commandOf,
   createStubDesktopAgentSettingsController,
@@ -53,10 +55,10 @@ type RendererMessage = Parameters<
 
 type SettingsFixtureOverrides = Omit<
   Partial<DesktopSettingsIpcOptions>,
-  'state' | 'ui'
+  'ui'
 > & {
-  globalState?: StateStore;
   workspaceState?: StateStore;
+  config?: ConfigProvider;
   ui?: Partial<DesktopSettingsIpcOptions['ui']>;
 };
 
@@ -80,6 +82,15 @@ function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
     ...settingsOverrides
   } = overrides;
   const postToRenderer = overrides.postToRenderer ?? (() => undefined);
+  // The paper's workspace state and config reach the IPC through its
+  // session's roots, as the desktop passes them.
+  const session =
+    overrides.session ??
+    disposeAfterTest(
+      createTestSession({
+        roots: { ...workspaceRoots(), config, workspaceState },
+      }),
+    );
   const settings = createDesktopSettingsIpc({
     ...settingsOverrides,
     agentSettingsController:
@@ -100,16 +111,15 @@ function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
             values: {},
           }),
       }),
-    state: { globalState, workspaceState },
-    config,
+    globalState,
     ui: createStubDesktopSettingsUiHost(ui),
-    session: overrides.session ?? defaultSession(),
+    session,
     postToRenderer,
   });
-  // The IPC subscribes to the process-global session and app-signal buses, so
-  // a fixture left undisposed would keep reacting to later tests' emits.
+  // The IPC subscribes to its session's goal facts and the process app-signal
+  // bus, so a fixture left undisposed would keep reacting to later tests' emits.
   liveSettingsIpcs.push(settings);
-  return { globalState, settings, workspaceState };
+  return { globalState, session, settings, workspaceState };
 }
 
 function createCapturedSettingsFixture(
@@ -472,9 +482,12 @@ describe('desktop settings IPC', () => {
 
     it('reposts the goal list when a run mutates a goal', async () => {
       const streamId = 'stream:desktop-settings-goal-push' as StreamTabId;
-      const { posted } = createCapturedSettingsFixture();
+      const { posted, session } = createCapturedSettingsFixture();
 
-      await GoalStore.start(streamId, 'Finish the proof');
+      // A run mutates goals inside its paper's session, as the desktop does.
+      await runInSession(session, () =>
+        GoalStore.start(streamId, 'Finish the proof'),
+      );
       await flushAsyncWork();
 
       expect(posted.at(-1)).toMatchObject({

--- a/src/test-kernel/desktop/ElectronFileSelection.vitest.ts
+++ b/src/test-kernel/desktop/ElectronFileSelection.vitest.ts
@@ -79,7 +79,13 @@ describe('desktop file selection', () => {
     const messages: unknown[] = [];
     const files = createDesktopFileSelection({
       postToRenderer: (message) => messages.push(message),
-      getWorkspacePath: () => workspacePath,
+      workspacePath,
+      showOpenFileDialog: async () => undefined,
+      // A listing failure the test did not ask for surfaces as an unhandled
+      // rejection instead of vanishing.
+      onError: (error) => {
+        throw error;
+      },
       ...overrides,
     });
     return { files, messages };
@@ -175,7 +181,7 @@ describe('desktop file selection', () => {
   it.each([
     {
       name: 'without a workspace',
-      overrides: { getWorkspacePath: () => undefined },
+      overrides: { workspacePath: undefined },
       request: { fileType: 'input' },
     },
     {
@@ -226,7 +232,7 @@ describe('desktop file selection', () => {
   it('reports asynchronous file-listing errors without rejecting from handleMessage', async () => {
     const onError = vi.fn();
     const { files } = await createFileSelection({
-      getWorkspacePath: () => join(workspacePath, 'missing'),
+      workspacePath: join(workspacePath, 'missing'),
       onError,
     });
 

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts
@@ -59,6 +59,8 @@ interface MainViewIpcModule {
       settings: { handleMessage(message: { command: string }): boolean };
       progress: { handleMessage(message: { command: string }): boolean };
       onboarding: { handleMessage(message: { command: string }): boolean };
+      papers: { handleMessage(message: { command: string }): boolean };
+      inActiveSession(dispatch: () => void): void;
       shellActions: TestDesktopShellActions;
       getAuthStatus?: () => Promise<{ authenticated: boolean }>;
       loadStartupOptions?: () => Promise<{
@@ -194,6 +196,8 @@ function createMainViewCommandCapabilities() {
     settings: createUnhandledCapability(),
     progress: createUnhandledCapability(),
     onboarding: createUnhandledCapability(),
+    papers: createUnhandledCapability(),
+    inActiveSession: (dispatch: () => void) => dispatch(),
     globalState: new FakeStateStore(),
     logs: {
       readLog: () => ({ path: undefined, text: '', truncated: false }),


### PR DESCRIPTION
## Summary

Implements #11845, two batched desktop tidies in the per-paper adapters that #11827 rebuilt.

**1. Per-paper adapters take the paper they serve.** `attachActivePaper` rebuilds these adapters per paper, but their option types still carried single-session optionality:

- `desktopFileSelection.ts`: `getWorkspacePath?` with a `workspaceRoots().workspace` fallback becomes `workspacePath: string | undefined` (the caller passes `paper.root`, a constant for the adapter's life). `showOpenFileDialog` and `onError` are required, so the silent `if (!options.showOpenFileDialog) return;` drop is gone along with the `workspaceRoots` import and the stale "callers inject a getter" comment on `listDesktopWorkspaceFiles`.
- `desktopSettingsIpc.ts`: `state: SettingsStatePorts` and `config: ConfigProvider` are replaced by `globalState: StateStore`; workspace state and config are read from `options.session.roots`, which `openPaperSession` builds from the same `roots` object. `globalState` stays threaded for the reason recorded in `mainViewIpc.ts`.
- `mainViewIpc.ts`: `papers` and `inActiveSession` are required; the `papers` filter spread and the `else dispatch()` branch are deleted. `workspace?` and its documented harness siblings stay.

**2. Paper commands go through `createCommandHandler`.** `DesktopPaperRegistry.ipc()` hand-rolled the `WEBVIEW_READY` + `view === 'main'` + `claim: false` broadcast and two `safeParse` dispatches without reading any registry state. The method is deleted from the interface and implementation; `index.ts` builds the table with `createCommandHandler` beside the other main-view handlers. `safeParse` stays inside each `run` (not `.parse()`): `mainViewIpc.ts` has no try/catch around `handleMessage` and dispatch runs under `void runInSession`, so a malformed message must be dropped rather than become an unhandled rejection.

Test fixtures follow the issue: the file-selection helper gains `showOpenFileDialog` and `onError` defaults, the settings fixture builds its session via `createTestSession({ roots })` (and the goal-push test mutates the goal inside that session, as a desktop run does), and the main-view harness passes a no-op `papers` handler and `(d) => d()`.

## Net elements (R6)

- Files: 8 changed (5 production, 3 test), 0 added, 0 deleted.
- `^[+-]export` symbols: 0 added, 0 removed.
- Class/interface/enum declarations: 0 added, 0 removed. Members: `DesktopPaperRegistry.ipc` removed (-1 interface method); option fields `getWorkspacePath`, `showOpenFileDialog?`, `onError?` -> 3 required fields with `workspacePath` replacing the getter; `state` + `config` -> `globalState` (-1 field); `papers?`/`inActiveSession?` -> required (-2 optionality markers).
- Imports removed: `workspaceRoots` (desktopFileSelection), `ConfigProvider` -> `StateStore` swap and `SettingsStatePorts` (desktopSettingsIpc), `COMMON_COMMANDS`, `DESKTOP_PAPER_COMMANDS`, the two paper schemas, `DesktopCommandMessage`, `DesktopMessageHandler` (desktopPapers). Added: `createCommandHandler` and the two paper schemas in index.ts.
- Dead branches removed: the `workspaceRoots` fallback, the silent `showOpenFileDialog` return, the `papers` filter spread, the `else dispatch()` branch, and the 25-line hand-rolled `handleMessage`.
- Net LoC (`git diff --stat origin/main`): 91 insertions, 102 deletions, **-11** overall; production -34 (+53/-87 across the 5 main files: desktopPapers -44, desktopFileSelection -7, mainViewIpc -2, desktopSettingsIpc +1, index +18), tests +23.

## Consumer counts (R8)

Grepped over `packages/desktop/src`, `src/test-kernel`, and `e2e` on origin/main:

- `getWorkspacePath` option of `createDesktopFileSelection`: production passers 1 (`index.ts`, passing `() => paper.root`), fallback path consumers 0; test passers 3, all with a getter.
- `showOpenFileDialog` / `onError` absent-path consumers: 0 (index.ts always passes both).
- `workspaceRoots` in `desktopFileSelection.ts`: 1 use (the fallback), now 0.
- `state` / `config` options of `createDesktopSettingsIpc`: production passers 1 (`index.ts`, from `paper.roots`), tests 1 fixture.
- `papers?` / `inActiveSession?` omitters of `installDesktopMainViewIpc`: production 0 (index.ts passes both), tests 1 harness (now passes both).
- `DesktopPaperRegistry.ipc(`: production 1 (`index.ts`), tests 0, e2e 0. After: 0.
- `createCommandHandler`: 6 production callers before, 7 after.

## Verification

- `npm run typecheck`: pass.
- `npx vitest run src/test-kernel/desktop src/test-kernel/architecture`: 73 files, 641 tests, all pass (rerun per directory after one load-related failure in the combined run).
- `npx eslint` on the 8 changed files: clean (one import/order finding in desktopPapers.ts fixed with `--fix`).
- `npm run check:dead-code-ratchet`: 291 vs 291 baselined, no new findings.
- `node scripts/check-guidance-refs.mjs`: OK.
- Not verified: no live Electron run was done. The paper-switch, papers-list-on-ready, and select/close-paper paths were exercised only through the unit suites above.

Closes #11845

🤖 Generated with [Claude Code](https://claude.com/claude-code)
