### PR TITLE
refactor(desktop): build the settings controllers per paper, drop the active-paper proxies

### DIFF
--- a/packages/desktop/src/main/desktopPapers.ts
+++ b/packages/desktop/src/main/desktopPapers.ts
@@ -16,7 +16,7 @@ import {
 import { scheduleLeftoverStreamSweep } from '@controllers/session/scheduleLeftoverStreamSweep';
 import { createTexraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import { DisposableStore } from '@platform/disposable';
-import type { ConfigProvider, StateStore } from '@platform/interfaces';
+import type { StateStore } from '@platform/interfaces';
 import {
   runWithWorkspaceRoots,
   type WorkspaceRoots,
@@ -92,10 +92,6 @@ export interface DesktopPaperRegistry {
    * other papers' runs are untouched.
    */
   close(root: string): Promise<void>;
-  /** Workspace state of whichever paper is active at call time. */
-  readonly activeWorkspaceState: StateStore;
-  /** Config of whichever paper is active at call time. */
-  readonly activeConfig: ConfigProvider;
   summary(): Omit<DesktopPapersMessage, 'command'>;
   /** Fires after a paper opens or closes, or the active paper changes. */
   onChange(listener: () => void): () => void;
@@ -295,7 +291,6 @@ export async function openDesktopPaperRegistry(
   const openPapers = () => [...papers.values()];
   const active = (): DesktopPaper =>
     (activeRoot === undefined ? undefined : papers.get(activeRoot)) ?? fallback;
-  const activeRoots = () => active().roots;
 
   async function openPaper(root: string): Promise<DesktopPaper> {
     // Remembered before anything is built: a list that cannot be written is
@@ -402,19 +397,6 @@ export async function openDesktopPaperRegistry(
       })().finally(() => closing.delete(root));
       closing.set(root, closed);
       return closed;
-    },
-    activeWorkspaceState: {
-      get: <T>(key: string, defaultValue?: T) =>
-        activeRoots().workspaceState.get<T>(key, defaultValue),
-      update: (key, value) => activeRoots().workspaceState.update(key, value),
-    },
-    activeConfig: {
-      get: <T>(key: string, defaultValue?: T) =>
-        activeRoots().config.get<T>(key, defaultValue),
-      update: (key, value, target) =>
-        activeRoots().config.update(key, value, target),
-      inspect: (key) => activeRoots().config.inspect(key),
-      isExplicitlySet: (key) => activeRoots().config.isExplicitlySet(key),
     },
     summary: () => ({
       papers: openPapers().map(({ root = '' }) => ({

--- a/packages/desktop/src/main/desktopToolingSettingsController.ts
+++ b/packages/desktop/src/main/desktopToolingSettingsController.ts
@@ -1,7 +1,7 @@
 import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
 import type { ToolTerminalAction } from '@controllers/settingsView/ToolDashboardData';
 import { appSignals } from '@eventBus/AppSignals';
-import { workspaceRoots } from '@platform/workspaceRoots';
+import type { ConfigProvider } from '@platform/interfaces';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type {
   SettingsViewInboundHandlerRegistry,
@@ -34,6 +34,7 @@ type DesktopLatexHandlers = Pick<
 >;
 
 interface DefaultDesktopToolingSettingsControllerOptions extends SettingsStatePorts {
+  readonly config: ConfigProvider;
   readonly onError: (error: unknown) => void;
   readonly renderer: {
     postToRenderer(message: unknown): void;
@@ -119,7 +120,7 @@ export class DefaultDesktopToolingSettingsController implements DesktopToolingSe
       buildSettingsSnapshotMessage(
         'latex',
         {
-          config: workspaceRoots().config,
+          config: this.options.config,
           workspaceState: this.options.workspaceState,
           globalState: this.options.globalState,
         },

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -951,6 +951,7 @@ function createWindow(options: {
         onError: reportAsyncError,
         workspaceState: paper.roots.workspaceState,
         globalState: platform().globalState,
+        config: paper.roots.config,
         renderer: {
           postToRenderer: postToRendererIfAlive,
         },

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -747,188 +747,7 @@ function createWindow(options: {
     }
     return agentExecutionLoad;
   };
-  const agentSettingsController = new DefaultDesktopAgentSettingsController({
-    workspaceState: options.papers.activeWorkspaceState,
-    globalState: platform().globalState,
-    registry: {
-      loadAgents,
-      refreshAgents: refresh,
-      loadAgentOptionsData: computeAgentOptionsData,
-      getAgents: getAgentsByCategory,
-      getVisibleAgents,
-    },
-    directory: {
-      getCustomAgentDirectory: () => platform().agentDirectories.custom(),
-      getSourceDirectory: (source: AgentSource) => {
-        switch (source) {
-          case 'custom':
-            return platform().agentDirectories.custom();
-          case 'builtInWorkflow':
-            return platform().agentDirectories.builtIn();
-          case 'builtInToolUse':
-            return platform().agentDirectories.builtInToolUse();
-          // No local directory: remote agents live in Supabase, inline ones
-          // were supplied as values and were never written to disk.
-          case 'remote':
-          case 'inline':
-            return Promise.resolve(undefined);
-        }
-      },
-      selectCustomAgentDirectory: async () => {
-        const result = await dialog.showOpenDialog(window, {
-          title: 'Select Custom Agents Folder',
-          defaultPath: folderPickerDefaultPath(),
-          properties: ['openDirectory', 'createDirectory'],
-        });
-        return result.canceled ? undefined : result.filePaths[0];
-      },
-      openPath: previewHost.openPath,
-      revealPath: async (filePath) => shell.showItemInFolder(filePath),
-    },
-    renderer: {
-      postToRenderer: postToRendererIfAlive,
-    },
-    prompts: {
-      promptText: (input) => promptController.request(input),
-      confirm: ({ title, message }) =>
-        confirmDialog({ title, message, confirmLabel: 'Continue' }),
-      chooseTeamAvailability: presentTeamAvailabilityPrompt,
-    },
-    remoteCatalog: {
-      canAccess: () => SupabaseClient.isAuthenticated(),
-      signIn: signInForRemoteAgentCatalog,
-    },
-    notifications: { showInfoMessage, showErrorMessage },
-    resourcesPath: options.resourcesPath,
-  });
   const subscriptionUsage = new SubscriptionUsageService();
-  const credentialSettingsController =
-    new DefaultDesktopCredentialSettingsController({
-      workspaceState: options.papers.activeWorkspaceState,
-      globalState: platform().globalState,
-      config: options.papers.activeConfig,
-      secrets: platform().secrets,
-      renderer: {
-        postToRenderer: postToRendererIfAlive,
-      },
-      prompt: {
-        input: (input) =>
-          promptController.request({
-            title: input.prompt ?? 'Set API key',
-            prompt: input.prompt ?? 'Enter API key',
-            password: input.password,
-          }),
-        confirm: (message, promptOptions) =>
-          confirmDialog({
-            message,
-            detail: promptOptions?.detail,
-            confirmLabel: promptOptions?.confirmLabel,
-          }),
-      },
-      externalOpener: {
-        openExternal: previewHost.openExternal,
-        openSubscriptionSignInUrl: (url) =>
-          previewHost.openExternal(url, { reportFailure: false }),
-        presentSubscriptionSignInUrl: async (url, productName) => {
-          const result = await dialog.showMessageBox(window, {
-            type: 'info',
-            message: `Signing in with ${productName}`,
-            detail:
-              `Opened your default browser. Using a different browser for ${productName}? ` +
-              'Open this link there instead:\n\n' +
-              `${url}`,
-            buttons: ['Copy Sign-in Link', 'Close'],
-            defaultId: 0,
-            cancelId: 1,
-          });
-          if (result.response === 0) {
-            clipboard.writeText(url);
-          }
-        },
-        presentSubscriptionDeviceCode: async (prompt, productName) => {
-          // The code is copied up front: the dialog closes on any button, so
-          // the user must not have to keep it open to read the code back.
-          clipboard.writeText(prompt.userCode);
-          const result = await dialog.showMessageBox(window, {
-            type: 'info',
-            message: `Sign in with ${productName}`,
-            detail:
-              `No browser could take the sign-in callback, so ${productName} ` +
-              'is signing in with a one-time code instead.\n\n' +
-              `1. Open ${prompt.verificationUrl}\n` +
-              `2. Enter the code: ${prompt.userCode} (copied to the clipboard)\n\n` +
-              'TeXRA is waiting for you to approve it.',
-            buttons: ['Open Verification Page', 'Close'],
-            defaultId: 0,
-            cancelId: 1,
-          });
-          if (result.response === 0) {
-            await previewHost.openExternal(
-              prompt.verificationUrlComplete ?? prompt.verificationUrl,
-            );
-          }
-        },
-      },
-      notifications: { showInfoMessage, showWarningMessage, showErrorMessage },
-      auth: {
-        signIn,
-        signOut: () => desktopAuth.signOut(),
-      },
-      subscriptionUsage,
-      onCredentialChanged: async () => {
-        await onboardingIpcRef.current?.refreshOnboardingFunnel();
-      },
-      // Credential operations already show their specific failure dialog. Keep
-      // the shared callback log-only so one failure never opens a second,
-      // generic desktop-operation dialog.
-      onError: reportBackgroundError,
-    });
-  const toolingSettingsController = new DefaultDesktopToolingSettingsController(
-    {
-      onError: reportAsyncError,
-      workspaceState: options.papers.activeWorkspaceState,
-      globalState: platform().globalState,
-      renderer: {
-        postToRenderer: postToRendererIfAlive,
-      },
-      dashboard: {
-        buildItems: async (cachedResults) => {
-          const { buildToolDashboardItems } =
-            await import('@controllers/settingsView/ToolDashboardData');
-          return buildToolDashboardItems('desktop', cachedResults);
-        },
-        getCachedCheckResults: async () => getLastCheckResults() ?? undefined,
-        refreshAvailability: refreshToolAvailability,
-        planTerminalAction: async (toolId, kind) => {
-          const { planToolTerminalAction } =
-            await import('@controllers/settingsView/ToolDashboardData');
-          return planToolTerminalAction({ toolId, commandKind: kind });
-        },
-      },
-      navigation: { openExternal: previewHost.openExternal },
-      commands: {
-        run: async (command: string) => {
-          postToRendererIfAlive({
-            command: DESKTOP_WORKSPACE_COMMANDS.TERMINAL_OPEN_COMMAND,
-            initialCommand: command,
-          });
-        },
-      },
-      latexToolingController: new LatexToolingController({
-        checkToolInstalled: (tool) => checkToolInstalled(tool, false),
-        findPath: (tool) => BinaryResolver.findPath(tool),
-        detectPackageManager,
-        getPlatform: () => normalizePlatform(process.platform),
-        // Extension hosting is deliberately unavailable in TeXRA Desktop.
-        isLatexWorkshopInstalled: () => false,
-        getRecommendedStatus: () => ({
-          outDir: true,
-          autoRevealExclude: true,
-        }),
-        onDetectionError: reportBackgroundError,
-      }),
-    },
-  );
   const settingsUi: DesktopSettingsUiHost = {
     showInfoMessage,
     showErrorMessage,
@@ -969,10 +788,11 @@ function createWindow(options: {
     });
   };
   /**
-   * Bind the window to the paper it shows. The settings surface subscribes to
+   * Bind the window to the paper it shows. The settings controllers read the
+   * paper's workspace state and config, the settings surface subscribes to
    * the paper's session (goal facts, approval policy), the title follows its
    * activity, the file lists scan its root, and the progress bridge is built
-   * lazily for it; all four are released when the window switches papers.
+   * lazily for it; all of them are released when the window switches papers.
    */
   const attachActivePaper = () => {
     const paper = activePaper();
@@ -987,6 +807,191 @@ function createWindow(options: {
     paperResources.add(
       installDesktopWindowTitle(window, paper.session, paper.root),
     );
+    const agentSettingsController = new DefaultDesktopAgentSettingsController({
+      workspaceState: paper.roots.workspaceState,
+      globalState: platform().globalState,
+      registry: {
+        loadAgents,
+        refreshAgents: refresh,
+        loadAgentOptionsData: computeAgentOptionsData,
+        getAgents: getAgentsByCategory,
+        getVisibleAgents,
+      },
+      directory: {
+        getCustomAgentDirectory: () => platform().agentDirectories.custom(),
+        getSourceDirectory: (source: AgentSource) => {
+          switch (source) {
+            case 'custom':
+              return platform().agentDirectories.custom();
+            case 'builtInWorkflow':
+              return platform().agentDirectories.builtIn();
+            case 'builtInToolUse':
+              return platform().agentDirectories.builtInToolUse();
+            // No local directory: remote agents live in Supabase, inline ones
+            // were supplied as values and were never written to disk.
+            case 'remote':
+            case 'inline':
+              return Promise.resolve(undefined);
+          }
+        },
+        selectCustomAgentDirectory: async () => {
+          const result = await dialog.showOpenDialog(window, {
+            title: 'Select Custom Agents Folder',
+            defaultPath: folderPickerDefaultPath(),
+            properties: ['openDirectory', 'createDirectory'],
+          });
+          return result.canceled ? undefined : result.filePaths[0];
+        },
+        openPath: previewHost.openPath,
+        revealPath: async (filePath) => shell.showItemInFolder(filePath),
+      },
+      renderer: {
+        postToRenderer: postToRendererIfAlive,
+      },
+      prompts: {
+        promptText: (input) => promptController.request(input),
+        confirm: ({ title, message }) =>
+          confirmDialog({ title, message, confirmLabel: 'Continue' }),
+        chooseTeamAvailability: presentTeamAvailabilityPrompt,
+      },
+      remoteCatalog: {
+        canAccess: () => SupabaseClient.isAuthenticated(),
+        signIn: signInForRemoteAgentCatalog,
+      },
+      notifications: { showInfoMessage, showErrorMessage },
+      resourcesPath: options.resourcesPath,
+    });
+    const credentialSettingsController =
+      new DefaultDesktopCredentialSettingsController({
+        workspaceState: paper.roots.workspaceState,
+        globalState: platform().globalState,
+        config: paper.roots.config,
+        secrets: platform().secrets,
+        renderer: {
+          postToRenderer: postToRendererIfAlive,
+        },
+        prompt: {
+          input: (input) =>
+            promptController.request({
+              title: input.prompt ?? 'Set API key',
+              prompt: input.prompt ?? 'Enter API key',
+              password: input.password,
+            }),
+          confirm: (message, promptOptions) =>
+            confirmDialog({
+              message,
+              detail: promptOptions?.detail,
+              confirmLabel: promptOptions?.confirmLabel,
+            }),
+        },
+        externalOpener: {
+          openExternal: previewHost.openExternal,
+          openSubscriptionSignInUrl: (url) =>
+            previewHost.openExternal(url, { reportFailure: false }),
+          presentSubscriptionSignInUrl: async (url, productName) => {
+            const result = await dialog.showMessageBox(window, {
+              type: 'info',
+              message: `Signing in with ${productName}`,
+              detail:
+                `Opened your default browser. Using a different browser for ${productName}? ` +
+                'Open this link there instead:\n\n' +
+                `${url}`,
+              buttons: ['Copy Sign-in Link', 'Close'],
+              defaultId: 0,
+              cancelId: 1,
+            });
+            if (result.response === 0) {
+              clipboard.writeText(url);
+            }
+          },
+          presentSubscriptionDeviceCode: async (prompt, productName) => {
+            // The code is copied up front: the dialog closes on any button, so
+            // the user must not have to keep it open to read the code back.
+            clipboard.writeText(prompt.userCode);
+            const result = await dialog.showMessageBox(window, {
+              type: 'info',
+              message: `Sign in with ${productName}`,
+              detail:
+                `No browser could take the sign-in callback, so ${productName} ` +
+                'is signing in with a one-time code instead.\n\n' +
+                `1. Open ${prompt.verificationUrl}\n` +
+                `2. Enter the code: ${prompt.userCode} (copied to the clipboard)\n\n` +
+                'TeXRA is waiting for you to approve it.',
+              buttons: ['Open Verification Page', 'Close'],
+              defaultId: 0,
+              cancelId: 1,
+            });
+            if (result.response === 0) {
+              await previewHost.openExternal(
+                prompt.verificationUrlComplete ?? prompt.verificationUrl,
+              );
+            }
+          },
+        },
+        notifications: {
+          showInfoMessage,
+          showWarningMessage,
+          showErrorMessage,
+        },
+        auth: {
+          signIn,
+          signOut: () => desktopAuth.signOut(),
+        },
+        subscriptionUsage,
+        onCredentialChanged: async () => {
+          await onboardingIpcRef.current?.refreshOnboardingFunnel();
+        },
+        // Credential operations already show their specific failure dialog. Keep
+        // the shared callback log-only so one failure never opens a second,
+        // generic desktop-operation dialog.
+        onError: reportBackgroundError,
+      });
+    const toolingSettingsController =
+      new DefaultDesktopToolingSettingsController({
+        onError: reportAsyncError,
+        workspaceState: paper.roots.workspaceState,
+        globalState: platform().globalState,
+        renderer: {
+          postToRenderer: postToRendererIfAlive,
+        },
+        dashboard: {
+          buildItems: async (cachedResults) => {
+            const { buildToolDashboardItems } =
+              await import('@controllers/settingsView/ToolDashboardData');
+            return buildToolDashboardItems('desktop', cachedResults);
+          },
+          getCachedCheckResults: async () => getLastCheckResults() ?? undefined,
+          refreshAvailability: refreshToolAvailability,
+          planTerminalAction: async (toolId, kind) => {
+            const { planToolTerminalAction } =
+              await import('@controllers/settingsView/ToolDashboardData');
+            return planToolTerminalAction({ toolId, commandKind: kind });
+          },
+        },
+        navigation: { openExternal: previewHost.openExternal },
+        commands: {
+          run: async (command: string) => {
+            postToRendererIfAlive({
+              command: DESKTOP_WORKSPACE_COMMANDS.TERMINAL_OPEN_COMMAND,
+              initialCommand: command,
+            });
+          },
+        },
+        latexToolingController: new LatexToolingController({
+          checkToolInstalled: (tool) => checkToolInstalled(tool, false),
+          findPath: (tool) => BinaryResolver.findPath(tool),
+          detectPackageManager,
+          getPlatform: () => normalizePlatform(process.platform),
+          // Extension hosting is deliberately unavailable in TeXRA Desktop.
+          isLatexWorkshopInstalled: () => false,
+          getRecommendedStatus: () => ({
+            outDir: true,
+            autoRevealExclude: true,
+          }),
+          onDetectionError: reportBackgroundError,
+        }),
+      });
+    paperResources.add(() => toolingSettingsController.dispose());
     const settingsIpc = createDesktopSettingsIpc({
       postToRenderer: postToRendererIfAlive,
       agentSettingsController,
@@ -1039,7 +1044,6 @@ function createWindow(options: {
       postPapers();
     }),
   );
-  windowResources.add(() => toolingSettingsController.dispose());
   const progressIpc = createDesktopProgressIpc({
     source: {
       get: () => agentExecution,

--- a/src/test-kernel/desktop/DesktopSettingsCapabilityMarkers.vitest.ts
+++ b/src/test-kernel/desktop/DesktopSettingsCapabilityMarkers.vitest.ts
@@ -90,6 +90,7 @@ function realCredentialController(): DefaultDesktopCredentialSettingsController 
 function realToolingController(): DefaultDesktopToolingSettingsController {
   return new DefaultDesktopToolingSettingsController({
     ...statePorts(),
+    config: new FakeConfigProvider(),
     onError: () => undefined,
     renderer: { postToRenderer: () => undefined },
     dashboard: {

--- a/src/test-kernel/desktop/DesktopToolingSettingsController.vitest.ts
+++ b/src/test-kernel/desktop/DesktopToolingSettingsController.vitest.ts
@@ -8,7 +8,7 @@ import type { ToolDashboardItem } from '@shared/schemas';
 import { HOMEBREW_INSTALL_COMMAND } from '@shared/constants/latexToolchain';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { assertSupported, isUnsupported } from '@shared/utils/dispatcher';
-import { FakeStateStore } from '@test/support/FakePlatform';
+import { FakeConfigProvider, FakeStateStore } from '@test/support/FakePlatform';
 import type { ExternalToolCheckResult } from '@tools/toolAvailability';
 
 import { commandOf } from './desktopSettingsTestSupport';
@@ -79,6 +79,7 @@ function createFixture(overrides: FixtureOverrides = {}) {
   };
   const controller = new DefaultDesktopToolingSettingsController({
     onError: (error) => reportedErrors.push(error),
+    config: new FakeConfigProvider(),
     globalState,
     workspaceState,
     renderer: {


### PR DESCRIPTION
## Summary

One Electron window carried two answers to "which paper's state does this settings controller read": the late-bound `activeWorkspaceState` / `activeConfig` proxies on `DesktopPapers` (re-resolving `active().roots` on every call through an `activeRoots` helper), and the per-paper rebuild in `attachActivePaper`, which already recreated the settings IPC and file-selection adapter per paper.

This PR keeps one binding. The agent, credential, and tooling settings controllers are now constructed inside `attachActivePaper` from `paper.roots.workspaceState` / `paper.roots.config` and disposed in `paperResources` with the rest of the paper's resources. The two proxy objects, the two interface members, and the `activeRoots` helper are deleted from `desktopPapers.ts`; `ConfigProvider` drops from its type import. The construction blocks moved with reindent only; `SubscriptionUsageService` (the one real cache) stays window-level and is passed in as before.

Second commit, from review: the tooling settings controller took the paper's workspace state from its constructor but still read config through `workspaceRoots()`, which resolves to the process roots when `postLatexConfigValues` runs outside a session scope (the initial attach). It now receives `paper.roots.config` like the credential controller, and its `workspaceRoots` import goes away. All three controllers hold one paper binding.

"Paper" is the desktop's name for one open workspace root with its own session, workspace state, and config (`DesktopPaper` in `packages/desktop/src/main/desktopPapers.ts`); a window shows one paper at a time and can switch between open papers.

Desktop only. No new code path, no guard, no compatibility path.

## Net elements (R6)

- Files: 0 added, 0 deleted (5 modified: `packages/desktop/src/main/index.ts`, `packages/desktop/src/main/desktopPapers.ts`, `packages/desktop/src/main/desktopToolingSettingsController.ts`, two existing vitest fixtures)
- `^[+-]export` symbols: 0
- class/interface/enum declarations: 0 added, 0 removed
- Interface members: -2 (`DesktopPaperRegistry.activeWorkspaceState`, `DesktopPaperRegistry.activeConfig`), +1 (`config` on the tooling controller options, replacing an ambient `workspaceRoots()` read)
- Helpers / objects: -1 (`activeRoots`), -2 proxy objects
- Imports: -1 `ConfigProvider` (desktopPapers), -1 `workspaceRoots` (tooling controller), +1 `ConfigProvider` (tooling controller)
- Net LoC (`git diff --stat origin/main`): 5 files changed, 196 insertions(+), 206 deletions(-), net -10

## Consumer counts (R8)

- `activeWorkspaceState`: production 3 (`index.ts` agent, credential, tooling controllers), tests 0. All three now read `paper.roots.workspaceState`.
- `activeConfig`: production 1 (`index.ts` credential controller), tests 0. Now `paper.roots.config`.
- `activeRoots`: used only by the two proxies; deleted with them.
- `agentSettingsController` / `credentialSettingsController` / `toolingSettingsController`: referenced only inside `attachActivePaper` (settings IPC construction) plus the one window-scoped `toolingSettingsController.dispose()`, which moved to `paperResources`. No ref holder needed.
- `DefaultDesktopToolingSettingsController` constructor: production 1 (`index.ts`), tests 2 fixtures (`DesktopToolingSettingsController.vitest.ts`, `DesktopSettingsCapabilityMarkers.vitest.ts`), both updated to pass a `FakeConfigProvider`.
- `ConfigProvider` in `desktopPapers.ts`: 0 remaining uses after the proxy removal; import dropped.

## Verification

- `npm run typecheck`: pass
- `npx vitest run src/test-kernel/desktop src/test-kernel/architecture`: 73 files, 641 tests; two unrelated files failed under load (a 10s timeout in `DesktopProgressFileActions` and a load-sensitive assertion in `DesktopAgentExecution`) and pass when rerun alone (79/79)
- `npx eslint` on all five changed files: clean
- `npm run check:dead-code-ratchet`: OK, no new findings, baseline untouched
- `node scripts/check-guidance-refs.mjs`: OK
- No live Electron run; the paper-switch path (`attachActivePaper` on initial attach and on `papers.onChange`) is exercised only by the existing suites above.

Part of #11865
Closes #11846

🤖 Generated with [Claude Code](https://claude.com/claude-code)
