### PR TITLE
refactor(desktop): read the open-session set from the paper registry in the resume owner

### DIFF
--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -12,107 +12,106 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { launchDesktopAgent } from './desktopAgentLaunch.js';
 import { toLogData } from './desktopLogUtils.js';
 
-interface DesktopResumeContext {
-  readonly session: SessionHandle;
-  readonly logger: AgentTrace;
-  readonly isCancellationRequested: () => boolean;
-}
-
 /**
  * Process-lifetime owner of desktop stream resumption. One process holds a
  * session per open paper; a stream resumes in the session whose transcripts
- * hold it, inside that session's scope.
+ * hold it, inside that session's scope. The open-session set is read from
+ * the paper registry, so a closing paper stops being a resume target the
+ * moment the registry drops it.
  */
 export class DesktopProcessResumeOwner {
-  private readonly contexts = new Set<DesktopResumeContext>();
+  private readonly logger: AgentTrace =
+    createChannelTrace('DesktopAgentResume');
+  private shuttingDown = false;
 
-  /** Attach one paper's session once it is ready. */
-  attach(options: { session: SessionHandle }): () => void {
-    let cancelled = false;
-    const context: DesktopResumeContext = {
-      ...options,
-      logger: createChannelTrace('DesktopAgentResume'),
-      isCancellationRequested: () => cancelled,
-    };
-    this.contexts.add(context);
-    return () => {
-      cancelled = true;
-      this.contexts.delete(context);
-    };
+  constructor(
+    private readonly options: {
+      /** The sessions open right now: every paper's and the no-workspace one. */
+      readonly sessions: () => Iterable<SessionHandle>;
+    },
+  ) {}
+
+  /** Shutdown: no resume launches from here on, and in-flight ones cancel. */
+  disable(): void {
+    this.shuttingDown = true;
   }
 
   tryResumeStream(
     streamId: StreamTabId,
     recovery?: RecoveryContinuation,
   ): Promise<boolean> {
-    for (const context of this.contexts) {
-      if (!context.session.transcripts.has(streamId)) continue;
+    for (const session of this.options.sessions()) {
+      if (!session.transcripts.has(streamId)) continue;
       return Promise.resolve(
-        runInSession(context.session, () =>
-          resumeDesktopStream(streamId, context, recovery),
+        runInSession(session, () =>
+          this.resumeDesktopStream(streamId, session, recovery),
         ),
       );
     }
     return Promise.resolve(false);
   }
-}
 
-async function resumeDesktopStream(
-  streamId: StreamTabId,
-  context: DesktopResumeContext,
-  recovery: RecoveryContinuation | undefined,
-): Promise<boolean> {
-  const { session } = context;
-  if (!session.transcripts.has(streamId)) return false;
-  let transcriptMissing = false;
-  const isCancellationRequested = (): boolean => {
-    if (!transcriptMissing && !session.transcripts.has(streamId)) {
-      transcriptMissing = true;
-    }
-    return context.isCancellationRequested() || transcriptMissing;
-  };
-  // The resident transcript index is a cache of this process; the stream may
-  // have been deleted from the durable transcript store by another process
-  // since it was loaded. Read the store before resuming: neither the lease
-  // (a deleted stream holds none) nor the execution lane (in-process only)
-  // sees that fact.
-  if (!(await session.transcripts.hasAuthoritativeStream(streamId))) {
+  private isOpen(session: SessionHandle): boolean {
+    for (const open of this.options.sessions())
+      if (open === session) return true;
     return false;
   }
-  if (isCancellationRequested()) return false;
-  const terminalResult = trackTerminalResultPresentation(
-    session,
-    (event) => event.streamId === streamId,
-  );
-  try {
-    return await resumeStreamWithRefusalNotice(streamId, {
-      session,
-      recovery,
-      runtimeUnavailableTools: (
-        await import('@tools/registry')
-      ).getDefaultUnavailableToolNames('desktop'),
-      isCancellationRequested,
-      executeWorkflow: (config, id, modelHandlerCompatibilityKey) =>
-        launchDesktopAgent(
-          { kind: 'resume', config, executionId: id },
-          { session },
-          { modelHandlerCompatibilityKey, suppressErrorNotification: true },
-        ),
-    });
-  } catch (error) {
+
+  private async resumeDesktopStream(
+    streamId: StreamTabId,
+    session: SessionHandle,
+    recovery: RecoveryContinuation | undefined,
+  ): Promise<boolean> {
+    let transcriptMissing = false;
+    const isCancellationRequested = (): boolean => {
+      if (!transcriptMissing && !session.transcripts.has(streamId)) {
+        transcriptMissing = true;
+      }
+      return this.shuttingDown || transcriptMissing || !this.isOpen(session);
+    };
+    // The resident transcript index is a cache of this process; the stream may
+    // have been deleted from the durable transcript store by another process
+    // since it was loaded. Read the store before resuming: neither the lease
+    // (a deleted stream holds none) nor the execution lane (in-process only)
+    // sees that fact.
+    if (!(await session.transcripts.hasAuthoritativeStream(streamId))) {
+      return false;
+    }
     if (isCancellationRequested()) return false;
-    context.logger.error(`Failed to resume desktop stream ${streamId}`, {
-      data: toLogData(error),
-    });
-    terminalResult.reportUnhandled(() =>
-      session.interactions.emit(
-        'requestShowError',
-        { message: `Resume failed: ${toErrorMessage(error)}` },
-        { replayWhenAttached: true },
-      ),
+    const terminalResult = trackTerminalResultPresentation(
+      session,
+      (event) => event.streamId === streamId,
     );
-    return false;
-  } finally {
-    terminalResult.dispose();
+    try {
+      return await resumeStreamWithRefusalNotice(streamId, {
+        session,
+        recovery,
+        runtimeUnavailableTools: (
+          await import('@tools/registry')
+        ).getDefaultUnavailableToolNames('desktop'),
+        isCancellationRequested,
+        executeWorkflow: (config, id, modelHandlerCompatibilityKey) =>
+          launchDesktopAgent(
+            { kind: 'resume', config, executionId: id },
+            { session },
+            { modelHandlerCompatibilityKey, suppressErrorNotification: true },
+          ),
+      });
+    } catch (error) {
+      if (isCancellationRequested()) return false;
+      this.logger.error(`Failed to resume desktop stream ${streamId}`, {
+        data: toLogData(error),
+      });
+      terminalResult.reportUnhandled(() =>
+        session.interactions.emit(
+          'requestShowError',
+          { message: `Resume failed: ${toErrorMessage(error)}` },
+          { replayWhenAttached: true },
+        ),
+      );
+      return false;
+    } finally {
+      terminalResult.dispose();
+    }
   }
 }

--- a/packages/desktop/src/main/desktopPapers.ts
+++ b/packages/desktop/src/main/desktopPapers.ts
@@ -68,11 +68,6 @@ interface DesktopPaperRegistryOptions {
    */
   readonly globalConfigStore: ConfigStore;
   readonly globalState: StateStore;
-  /**
-   * Process-lifetime attachment each session needs (stream resumption).
-   * Returns the detach, which closing the paper runs before its session goes.
-   */
-  attachSession(session: SessionHandle): () => void;
   warn(message: string): void;
 }
 
@@ -214,7 +209,6 @@ async function stopPaperExecutions(session: SessionHandle): Promise<void> {
 async function openPaperSession(
   root: string | undefined,
   roots: WorkspaceRoots,
-  options: Pick<DesktopPaperRegistryOptions, 'attachSession'>,
 ): Promise<DesktopPaper> {
   const resources = new DisposableStore();
   try {
@@ -244,7 +238,6 @@ async function openPaperSession(
           TEXRA_APPROVAL_POLICY_CONFIG_KEY,
         ),
       );
-      resources.add(options.attachSession(session));
       // Off the open path: the leftover-stream sweep reads this paper's
       // whole storage root, so it starts on a timer nothing awaits. It is
       // scheduled inside the session scope, which the timer inherits, so the
@@ -283,11 +276,7 @@ export async function openDesktopPaperRegistry(
   const closing = new Map<string, Promise<void>>();
   const listeners = new Set<() => void>();
   let activeRoot: string | undefined;
-  const fallback = await openPaperSession(
-    undefined,
-    options.processRoots,
-    options,
-  );
+  const fallback = await openPaperSession(undefined, options.processRoots);
 
   const notify = () => {
     for (const listener of [...listeners]) listener();
@@ -318,7 +307,7 @@ export async function openDesktopPaperRegistry(
       config: { workspace: workspaceConfig, global: options.globalConfigStore },
       workspaceState,
     });
-    const paper = await openPaperSession(root, roots, options);
+    const paper = await openPaperSession(root, roots);
     papers.set(root, paper);
     notify();
     return paper;

--- a/packages/desktop/src/main/desktopPapers.ts
+++ b/packages/desktop/src/main/desktopPapers.ts
@@ -78,6 +78,8 @@ export interface DesktopPaperRegistry {
   list(): readonly DesktopPaper[];
   /** The paper the window shows: the active folder, else the no-workspace session. */
   active(): DesktopPaper;
+  /** The no-workspace session's paper; open for the process lifetime, never in `list()`. */
+  fallback(): DesktopPaper;
   /** Make an open paper the one the window shows, and remember it as such. */
   activate(root: string | undefined): void;
   /**
@@ -354,6 +356,7 @@ export async function openDesktopPaperRegistry(
     },
     list: openPapers,
     active,
+    fallback: () => fallback,
     activate,
     close(root) {
       const inProgress = closing.get(root);

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1373,23 +1373,24 @@ if (protocolLifecycle.ownsSingleInstanceLock) {
   app
     .whenReady()
     .then(async () => {
-      const processResumeOwner = new DesktopProcessResumeOwner();
+      // Every resume call is run-time or user-triggered, so the registry is
+      // open by the time the owner reads it.
+      let papers!: DesktopPaperRegistry;
+      const processResumeOwner = new DesktopProcessResumeOwner({
+        sessions: () =>
+          new Set([papers.active(), ...papers.list()].map((p) => p.session)),
+      });
       const platformInit = await initializeElectronPlatform(
         desktopMainDir,
         processResumeOwner,
       );
       const { lifecycle } = platformInit;
-      // Slot for every paper's resume attachment: the BEFORE drain detaches
-      // them first (before agent shutdown), and the idempotent store makes the
-      // ON-phase repeat a no-op.
-      const agentResumeHandler = new DisposableStore();
       // Process root: session-lifetime resources register at creation and are
       // disposed LIFO in the ON phase (every paper's process stores → result
       // toast → session, most recently opened first).
       const processResources = new DisposableStore();
-      let papers!: DesktopPaperRegistry;
       registerRuntimeShutdownHandlers(lifecycle, {
-        beforeAgentShutdown: [() => agentResumeHandler.dispose()],
+        beforeAgentShutdown: [() => processResumeOwner.disable()],
         afterAgentShutdown: [() => killActiveRecording()],
         // Agent shutdown runs first so its final events enter the
         // process-owned stores. Flush in BEFORE so persistence cannot be
@@ -1399,12 +1400,7 @@ if (protocolLifecycle.ownsSingleInstanceLock) {
         // quit lifecycle drains; awaiting idle keeps the process alive until
         // the directories are actually gone.
         afterFlushArtifacts: [() => diffHostDisposeQueue.onIdle()],
-        afterExecutionSettlement: [
-          () => {
-            agentResumeHandler.dispose();
-            processResources.dispose();
-          },
-        ],
+        afterExecutionSettlement: [() => processResources.dispose()],
       });
 
       // Until the initial window is fully wired, any startup failure must run
@@ -1417,8 +1413,6 @@ if (protocolLifecycle.ownsSingleInstanceLock) {
           processRoots: platformInit.processRoots,
           globalConfigStore: platformInit.globalConfigStore,
           globalState: platform().globalState,
-          attachSession: (session) =>
-            agentResumeHandler.add(processResumeOwner.attach({ session })),
           warn,
         });
         processResources.add(() => papers.dispose());

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1378,7 +1378,7 @@ if (protocolLifecycle.ownsSingleInstanceLock) {
       let papers!: DesktopPaperRegistry;
       const processResumeOwner = new DesktopProcessResumeOwner({
         sessions: () =>
-          new Set([papers.active(), ...papers.list()].map((p) => p.session)),
+          [papers.fallback(), ...papers.list()].map((p) => p.session),
       });
       const platformInit = await initializeElectronPlatform(
         desktopMainDir,

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -359,7 +359,8 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
     snapshots: ProgressSnapshotStore,
   ): SessionHandle;
   createProgressSnapshotStore(): ProgressSnapshotStore;
-  processResumeOwner: import('@desktop/main/desktopAgentResume').DesktopProcessResumeOwner;
+  /** The sessions the process resume owner reads; a test adds its own. */
+  resumeSessions: Set<SessionHandle>;
   progressSnapshotStore: ProgressSnapshotStore;
 }> {
   vi.resetModules();
@@ -448,8 +449,10 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
   );
   const { DesktopProcessResumeOwner } =
     await import('@desktop/main/desktopAgentResume');
-  const processResumeOwner = new DesktopProcessResumeOwner();
-  resumeDelegate = processResumeOwner;
+  const resumeSessions = new Set<SessionHandle>();
+  resumeDelegate = new DesktopProcessResumeOwner({
+    sessions: () => resumeSessions,
+  });
   const { initializeDefaultSession, SessionHandle } =
     await import('@agent/runtime/SessionHandle');
   initializeDefaultSession({
@@ -461,7 +464,7 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
       new SessionHandle({ transcripts, snapshots }),
     createProgressSnapshotStore,
     openTranscripts: () => StreamLogStore.open(),
-    processResumeOwner,
+    resumeSessions,
     progressSnapshotStore,
   };
 }
@@ -474,7 +477,7 @@ async function createBridge(
     bridgeModule,
     createSession,
     openTranscripts,
-    processResumeOwner,
+    resumeSessions,
     progressSnapshotStore,
   } = await loadBridgeModule(options);
   const transcripts = await openTranscripts();
@@ -510,7 +513,7 @@ async function createBridge(
       releaseStreamResources(stream, session);
     },
   });
-  const disposeResumeHandler = processResumeOwner.attach({ session });
+  resumeSessions.add(session);
   if (options.gateCanonicalLoad) {
     const gate = options.gateCanonicalLoad;
     const drain =
@@ -562,7 +565,7 @@ async function createBridge(
   disposeAfterTest({
     dispose: () => {
       bridge.dispose();
-      disposeResumeHandler();
+      resumeSessions.delete(session);
       detachTerminalResultToast();
       session.dispose();
     },
@@ -574,7 +577,7 @@ async function createBridge(
 /**
  * Resume moved off the bridge: desktop stream resumption is owned by the
  * process resume owner reached through `platform().agentResume`, which the
- * harness attaches to the same session the bridge runs on.
+ * harness lists the same session the bridge runs on.
  */
 async function tryResumeStream(streamId: string): Promise<boolean> {
   const { platform } = await import('@platform/platform');
@@ -2628,7 +2631,7 @@ describe('DesktopProgressBridge', () => {
         createProgressSnapshotStore,
         createSession,
         openTranscripts,
-        processResumeOwner,
+        resumeSessions,
       } = await loadBridgeModule({});
       const { AgentExecutionHandle } =
         await import('@agent/runtime/ExecutionHandle');
@@ -2650,9 +2653,7 @@ describe('DesktopProgressBridge', () => {
       const processStores =
         await initializeDesktopProcessStores(processSession);
       const { stores: sessionStores } = processStores;
-      const disposeResumeHandler = processResumeOwner.attach({
-        session: processSession,
-      });
+      resumeSessions.add(processSession);
       snapshotFacts(progressSnapshotStore).setRunConfig(
         streamId,
         AgentConfigSchema.parse({
@@ -2771,7 +2772,7 @@ describe('DesktopProgressBridge', () => {
       disposeAfterTest({
         dispose: () => {
           for (const bridge of presentationBridges) bridge.dispose();
-          disposeResumeHandler();
+          resumeSessions.delete(processSession);
           detachTerminalResultToast();
           processStores.dispose();
           processSession.dispose();

--- a/src/test-kernel/desktop/DesktopAgentResume.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentResume.vitest.ts
@@ -147,8 +147,7 @@ function createResumeHarness(): {
   snapshotFacts(snapshots).setRunConfig(stream, config, executionId);
   const session = createTestSession({ snapshots });
   session.transcripts.ensureStream(stream);
-  const owner = new DesktopProcessResumeOwner();
-  const detach = owner.attach({ session });
+  const owner = new DesktopProcessResumeOwner({ sessions: () => [session] });
   const detachTerminalResultToast = attachTerminalResultToast(
     session,
     session.interactions,
@@ -158,7 +157,7 @@ function createResumeHarness(): {
   const dispose = (): void => {
     if (disposed) return;
     disposed = true;
-    detach();
+    owner.disable();
     detachTerminalResultToast();
     session.dispose();
   };

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
@@ -95,7 +95,7 @@ describe('desktop composition root and launch environment', () => {
 
     expectOrderedAfter(source, 'registerRuntimeShutdownHandlers(lifecycle', [
       'beforeAgentShutdown:',
-      'agentResumeHandler.dispose()',
+      'processResumeOwner.disable()',
       'afterAgentShutdown:',
       'killActiveRecording()',
       'flushArtifacts:',


### PR DESCRIPTION
## Summary

The set of open desktop sessions was held three times: the paper registry (`desktopPapers.ts`, the owner of the liveness fact), `DesktopProcessResumeOwner.contexts` (a second Set filled only by `attach`), and `agentResumeHandler` in `index.ts` (a `DisposableStore` holding nothing but each paper's detach, which the paper's own `resources` also held). The resume owner now reads the registry through one `sessions()` option and carries a single `disable()` shutdown flag.

- `DesktopProcessResumeOwner` is constructed with `{ sessions: () => Iterable<SessionHandle> }`; `index.ts` passes `[papers.fallback(), ...papers.list()].map((p) => p.session)`. The registry exposes the no-workspace paper as `fallback()` so that session is a resume target for the process lifetime, as it was under `attach`; `active()` is not used here because `list()` already holds the active folder paper and `active()` only returns the fallback while no folder is active (review finding, fixed in 69e6a6e242).
- `tryResumeStream` iterates `sessions()`; the per-stream cancellation predicate is `shuttingDown || transcriptMissing || !isOpen(session)`.
- Deleted: `attach()`, the `contexts` Set, the `DesktopResumeContext` interface (resume is now a private method on the owner, so the context bag has no reader), `DesktopPaperRegistryOptions.attachSession` and its `resources.add` line, and `agentResumeHandler` with its two dispose sites. `beforeAgentShutdown` now runs `processResumeOwner.disable()` in the same slot, so shutdown ordering is preserved (the composition-root test pins the new string).
- Intentional behavior shift: a closing paper stops being a resume target at `papers.delete(root)`, before `stopPaperExecutions` settles, instead of after. No launch into a closing session.

## Net elements (R6)

- Files: 0 (6 touched, 0 added, 0 removed)
- `^[+-]export` symbols: 0 (no export added or removed; `DesktopProcessResumeOwner` stays the one export)
- class/interface/enum declarations: -1 (`interface DesktopResumeContext` deleted; no declaration added)
- Methods/fields: -1 `attach()`, -1 `contexts` Set, -1 `attachSession` option, -1 `agentResumeHandler` store and its 2 dispose sites; +1 constructor option `sessions`, +1 `shuttingDown` boolean, +1 `disable()`, +1 private `isOpen()`, +1 registry accessor `fallback()`
- Net LoC (`git diff --stat origin/main...HEAD`): 6 files, +109 / -124, net **-15** (production -15 across `desktopAgentResume.ts`, `desktopPapers.ts`, `index.ts`; tests net 0)

## Consumer counts (R8)

- `DesktopProcessResumeOwner`: production 2 files (`desktopAgentResume.ts`, `index.ts`); tests 2 files (`DesktopAgentResume.vitest.ts`, `DesktopAgentExecution.vitest.ts`), unchanged from main.
- `sessions` option: production 1 site (`index.ts`); tests 2 sites.
- `disable()`: production 1 site (`index.ts`, `beforeAgentShutdown`); tests 1 site (the resume harness `dispose`, which drives the two shutdown tests).
- `DesktopPaperRegistry.fallback()`: production 1 site (`index.ts`, the resume owner's `sessions` reader).
- `attach`, `attachSession`, `agentResumeHandler`, `DesktopResumeContext`: 0 remaining references across `packages/`, `src/`, `docs/`.
- `config/ratchets/knip-baseline.json`: untouched; ratchet reports 291 vs 291 baselined.

## Verification

- `npm run typecheck`: pass (on 69e6a6e242).
- `npx vitest run src/test-kernel/desktop src/test-kernel/architecture`: 73 files, 641 tests pass (on 69e6a6e242). Under parallel load the merge-presentation tests `DesktopAgentExecution > DesktopProgressBridge > presents a merge failure ...` time out; they fail the same way on a clean `origin/main` checkout and touch no resume path, so they are a pre-existing timing flake, not this change.
- `npx eslint` per changed file: clean.
- `npm run check:dead-code-ratchet`: OK, no new findings.
- `node scripts/check-guidance-refs.mjs`: OK.
- No live Electron run.

Part of #11865
Closes #11844

🤖 Generated with [Claude Code](https://claude.com/claude-code)
