### PR TITLE
Make StreamSnapshotStore's SessionFact switch exhaustive

### DIFF
--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -780,11 +780,13 @@ export class StreamSnapshotStore {
             fact.payload.parentStreamId,
           );
           return;
-        // Liveness/status and the goal, inquiry, follow-up, active-stream,
-        // hold, and removal facts carry nothing this store persists (see the
-        // liveness note above) — listed explicitly so a newly added
-        // SessionFact fails the `never` check below instead of silently
-        // no-op'ing.
+        // `status` carries liveness, which the class doc above says this
+        // store deliberately does not persist. The rest — goal, inquiry,
+        // follow-up, active-stream, hold, and removal facts — are
+        // session/render state owned by SessionFactApplier/SessionState, not
+        // by this sidecar. Both groups are listed explicitly so a newly
+        // added SessionFact fails the `never` check below instead of
+        // silently no-op'ing.
         case 'status':
         case 'goalStateChanged':
         case 'inquiryThreadUpdated':

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -780,8 +780,24 @@ export class StreamSnapshotStore {
             fact.payload.parentStreamId,
           );
           return;
-        default:
+        // Liveness/status and the goal, inquiry, follow-up, active-stream,
+        // hold, and removal facts carry nothing this store persists (see the
+        // liveness note above) — listed explicitly so a newly added
+        // SessionFact fails the `never` check below instead of silently
+        // no-op'ing.
+        case 'status':
+        case 'goalStateChanged':
+        case 'inquiryThreadUpdated':
+        case 'updateQueuedFollowUps':
+        case 'followUpSent':
+        case 'setActiveStream':
+        case 'streamHoldChanged':
+        case 'removeStream':
           return;
+        default: {
+          const unhandled: never = fact;
+          return unhandled;
+        }
       }
     });
 


### PR DESCRIPTION
## Summary

Fixes an event-channel exhaustiveness gap surfaced by a scheduled abstraction-layering audit of the codebase. `StreamSnapshotStore.attachSessionEvents()` subscribed to `SessionFact` but handled only 2 of its 10 variants, silently dropping the other 8 via `default: return` with no compile-time guard — the "`default: return` that quietly drops an unknown event" pattern CLAUDE.md names explicitly as a defect.

A second candidate from the same audit (a `permissions$` dedup-by-id workaround in `packages/extension/src/progressView/frontend/slices/permissionSlice.ts`, flagged as the "dedup in renderers" anti-pattern) was investigated but deliberately **not** changed here: the backend's `ApprovalRequestHandler.replay()` unconditionally re-sends every pending item on each call, and that full-resend-on-every-call behavior is an explicit, tested contract (`AgentPresentationHostReplayGate.vitest.ts`: "redisplays a pending tool-edit approval exactly once per webview reload" asserts `sendShow` fires again on each `replay()` call). The frontend dedup is a legitimate idempotency guard against that intentional resync semantic, not a bug masking a broken data model — changing it would contradict a directly-tested contract, so it was left as-is.

## Issue acceptance gates

No linked issue — flagged by a scheduled architectural review of the repo's layering discipline. Gate: the `SessionFact` switch in `StreamSnapshotStore.ts` is now exhaustive and fails to compile if `SessionFact` grows a new variant without an explicit decision for it.

## Single source of truth

No new ownership. `SessionFact`'s membership remains defined solely in `src/agent/runtime/SessionEventHub.ts`; this change only makes `StreamSnapshotStore.ts`'s consumption of that union exhaustive, matching the `assertNever`/`never`-check convention already used for the same union in `src/controllers/session/SessionFactApplier.ts` and for the sibling `AgentEvent` switch a few lines above in the same file.

## Duplication and abstraction budget

No new abstraction added. Reused the file's own existing `const unhandled: never = x; return unhandled;` idiom (already present just above, for run facts) instead of introducing a new helper or importing `assertNever`.

## Net elements (R6)

+19/-1 lines in one file (`src/transcript/StreamSnapshotStore.ts`). No new exports, files, classes, or interfaces.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed; only a consumer's `switch` gained exhaustive case coverage over an existing union.

## Host impact

Extension: none — host-agnostic file; the 2 previously-handled cases are unchanged, the other 8 remain no-ops (now compile-checked instead of silently dropped).

Desktop: none, same reasoning.

CLI: none, same reasoning.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck:workspace` — clean.
- `npx eslint src/transcript/StreamSnapshotStore.ts` — clean.
- `npx vitest run --config vitest.config.mjs -t "StreamSnapshotStore"` — 90 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVD59qHX21SGswyRePW54a