### PR TITLE
refactor(cli): drop the write-only session metadata fields and the export kept for its own test

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -464,12 +464,6 @@
       "name": "TuiRepaintOptions"
     },
     {
-      "file": "packages/cli/src/chat/tui/state/resumeHint.ts",
-      "category": "production-dead",
-      "kind": "exports",
-      "name": "formatResumeUsage"
-    },
-    {
       "file": "packages/cli/src/chat/tui/state/transcript.ts",
       "category": "production-dead",
       "kind": "exports",

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -256,7 +256,6 @@ const AGENT_PROPOSAL_INSTRUCTION =
     '5. Write a structured report with any gaps or a confirmation of correctness.',
     '6. Include a short independent enumeration so the orchestrator can compare results.',
   ].join('\n');
-const CAN_DELEGATE = process.env.HARNESS_CAN_DELEGATE === '1';
 const CAN_SELECT_MODEL = process.env.HARNESS_CAN_SELECT_MODEL === '1';
 const DISABLED_MODEL_SWITCHES = new Set(
   parseList(process.env.HARNESS_DISABLED_MODEL_SWITCHES),
@@ -1237,12 +1236,10 @@ function harnessInitialEntries(): StreamLogAppendInput[] {
 
 sessionMeta.set({
   agent: 'chat',
-  category: AgentCategory.ToolUse,
   model: HARNESS_MODEL,
   modelSource: 'builtin-default',
   cwd: HARNESS_CWD,
   approvalPolicy: HARNESS_INITIAL_APPROVAL_POLICY,
-  canDelegate: CAN_DELEGATE,
   transcriptMode: 'persistent',
   teamName: TEAM_NAME,
   version: '0.0.0-harness',

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1867,7 +1867,6 @@ const SCENARIOS = [
     env: {
       HARNESS_ENTRIES: '4',
       HARNESS_BASH_APPROVAL: '1',
-      HARNESS_CAN_DELEGATE: '1',
       HARNESS_TEAM_NAME: 'Physicist',
     },
     bootExpect: '· Ctrl-C ',

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -27,7 +27,6 @@ import {
   type FollowUpQueueInput,
   type FollowUpRecoveryLease,
 } from '@agent/followUp';
-import { chatAgentSupportsDelegation } from '@cli/runtime/agents';
 import { type CliContext } from '@cli/runtime/cliContext';
 import { warnApprovalDenied } from '@cli/runtime/approval/approvalPrompts';
 import { cliApprovalPromptsUnavailable } from '@cli/runtime/approval/settleApprovals';
@@ -336,7 +335,6 @@ export function createChatSessionController(
       agent: config.agent,
       model: config.model,
       ...(modelSource ? { modelSource } : {}),
-      canDelegate: chatAgentSupportsDelegation(config.agent),
       teamName: readCliMultiAgentPresetName(cliMultiAgentPresetId),
       cliMultiAgentPresetId,
       delegationAgentScope: config.delegationAgentScope ?? undefined,

--- a/packages/cli/src/chat/tui/commands/handlers/agentModelCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/agentModelCommands.ts
@@ -1,7 +1,6 @@
 import { defaultSession } from '@agent/runtime';
 import {
   assertCliAgentLaunch,
-  chatAgentSupportsDelegation,
   resolveCliAgentInCategory,
 } from '@cli/runtime/agents';
 import { CliUsageError } from '@cli/runtime/cliContext';
@@ -60,7 +59,6 @@ export function applyInitialCliAgentSelection(
   }
   patchSessionMeta({
     agent: nextAgent,
-    canDelegate: chatAgentSupportsDelegation(nextAgent),
     teamName: undefined,
     cliMultiAgentPresetId: undefined,
     delegationAgentScope: undefined,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -10,7 +10,6 @@ import PQueue from 'p-queue';
 
 import { getVisibleAgents, loadAgents } from '@agent/index';
 import { detachSubagentsOnStop, type AgentConfig } from '@agent/runtime';
-import { chatAgentSupportsDelegation } from '@cli/runtime/agents';
 import { type CliContext, readCliVersion } from '@cli/runtime/cliContext';
 import {
   firstRunSetupAgentOverride,
@@ -276,12 +275,10 @@ export async function runChat(
     initialResume?.config.cli?.multiAgentPresetId ?? init.cliMultiAgentPresetId;
   sessionMetaSignal.set({
     agent,
-    category: AgentCategory.ToolUse,
     model,
     modelSource: defaults.modelSource,
     cwd: context.cwd,
     approvalPolicy: runtimeSession.approvalPolicy,
-    canDelegate: chatAgentSupportsDelegation(agent),
     transcriptMode: transcriptLifecycle.canResume ? 'persistent' : 'ephemeral',
     teamName: init.teamName ?? readCliMultiAgentPresetName(initialPresetId),
     cliMultiAgentPresetId: initialPresetId,

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -9,7 +9,6 @@ import {
   type TexraApprovalPolicy,
 } from '@shared/approvalPolicy';
 import type { AgentDelegationScope, StreamTabId } from '@shared/schemas';
-import { AgentCategory } from '@shared/schemas';
 import type { WorkflowRowGroup } from '@shared/streams/workflowRunModel';
 import type { WorkPlanProvenance } from '@transcript';
 import { sessionView } from './sessionView';
@@ -34,12 +33,10 @@ import type { PastedImageEntry } from '../input/draftAttachments';
  */
 export interface SessionMeta {
   readonly agent: string;
-  readonly category: AgentCategory;
   readonly model: string;
   readonly modelSource: RunModelDecisionReason;
   readonly cwd: string;
   readonly approvalPolicy: TexraApprovalPolicy;
-  readonly canDelegate: boolean;
   readonly transcriptMode: 'persistent' | 'ephemeral';
   readonly teamName?: string;
   readonly cliMultiAgentPresetId?: string;
@@ -49,12 +46,10 @@ export interface SessionMeta {
 
 const EMPTY_SESSION_META: SessionMeta = {
   agent: '',
-  category: AgentCategory.ToolUse,
   model: '',
   modelSource: 'builtin-default',
   cwd: '',
   approvalPolicy: TEXRA_APPROVAL_POLICY_DEFAULT,
-  canDelegate: false,
   transcriptMode: 'persistent',
   version: '',
 };

--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -80,7 +80,7 @@ export function collectResumeUsage(
   return isEmptyUsage(total) ? undefined : total;
 }
 
-export function formatResumeUsage(
+function formatResumeUsage(
   usage: TokenUsageStats | undefined,
 ): string | undefined {
   if (!usage || isEmptyUsage(usage)) return undefined;

--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -13,7 +13,6 @@ import {
   agentName,
   AgentCategory,
 } from '@shared/schemas';
-import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { formatResultCount } from '@utils/text/stringUtils';
 
 import { CliUsageError } from './cliContext';
@@ -125,15 +124,6 @@ export function resolveCliAgentInCategory(
     pinned.success ? pinned.data : undefined,
   )?.entry;
   return entry?.category === category ? entry : undefined;
-}
-
-/** Whether a CLI tool-use agent's tool list intersects the delegation tool set. */
-export function chatAgentSupportsDelegation(name: string): boolean {
-  return (
-    resolveCliAgentInCategory(name, AgentCategory.ToolUse)?.tools?.some(
-      (toolName) => DELEGATION_TOOLS.has(toolName),
-    ) ?? false
-  );
 }
 
 export function assertCliAgentLaunch(

--- a/src/test-kernel/cli/CliAgentShadow.vitest.ts
+++ b/src/test-kernel/cli/CliAgentShadow.vitest.ts
@@ -10,7 +10,6 @@ import { refresh } from '@agent/index/agentRegistry';
 import { chatToolUseAgentUsageError } from '@cli/chat/tui/commands/handlers/agentModelCommands';
 import {
   assertCliAgentLaunch,
-  chatAgentSupportsDelegation,
   resolveCliAgentInCategory,
 } from '@cli/runtime/agents';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
@@ -79,7 +78,6 @@ describe('CLI agent validation with a shadowed name', () => {
     expect(
       resolveCliAgentInCategory('assistant', AgentCategory.Workflow)?.source,
     ).toBe('custom');
-    expect(chatAgentSupportsDelegation('assistant')).toBe(true);
   });
 
   it('still reports the category mismatch for a workflow-only agent', () => {

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -44,7 +44,6 @@ import {
 import { transcriptToLines } from '@cli/chat/tui/state/transcriptLines';
 import { CLI_LOCAL_STREAM_ID } from '@cli/chat/tui/state/transcript';
 import {
-  AgentCategory,
   RUN_OUTCOME,
   STREAM_PHASE,
   TOOL_USE_STATUS,
@@ -76,13 +75,11 @@ const ROOT_STREAM = 'root-stream' as StreamTabId;
 const CHILD_STREAM = 'claude@agent-sdk#1' as StreamTabId;
 const SESSION_META = {
   agent: 'research',
-  category: AgentCategory.ToolUse,
   model: 'deepseekT',
   modelSource: 'builtin-default',
   cwd: '/tmp/project',
   apiMode: 'personal',
   approvalPolicy: 'ask',
-  canDelegate: false,
   transcriptMode: 'persistent',
   version: '0.38.0',
 } as const;

--- a/src/test-kernel/cli/ResumeHint.vitest.ts
+++ b/src/test-kernel/cli/ResumeHint.vitest.ts
@@ -5,7 +5,6 @@ import {
   collectResumeTargets,
   formatResumeCommand,
   formatResumeHint,
-  formatResumeUsage,
   type ResumeCommandOptions,
   type ResumeTarget,
 } from '@cli/chat/tui/state/resumeHint';
@@ -251,23 +250,49 @@ describe('formatResumeHint', () => {
     );
   });
 
-  it('flows the session cost line through the full hint', () => {
-    expect(
-      formatResumeHint([{ executionId: 'root', label: 'main', isRoot: true }], {
-        inputTokens: 100,
-        outputTokens: 20,
-        cost: 0.012,
-        usageRoute: 'relay',
-      } satisfies TokenUsageStats),
-    ).toBe(
-      [
-        'Token usage: total=120 input=100 output=20',
-        'Session cost: $0.012 via included access',
-        'Resume this session with:',
-        '  texra resume root  (main)',
-      ].join('\n'),
-    );
-  });
+  it.each<{
+    usageRoute: TokenUsageStats['usageRoute'];
+    cost: number;
+    expected: string;
+  }>([
+    {
+      usageRoute: 'relay',
+      cost: 0.012,
+      expected: '$0.012 via included access',
+    },
+    {
+      usageRoute: 'chatgpt-subscription',
+      cost: 0,
+      expected: 'Free via ChatGPT',
+    },
+    {
+      usageRoute: 'api-key',
+      cost: 0.5,
+      expected: '$0.500 via your own API keys',
+    },
+  ])(
+    'includes the $usageRoute session cost in the full hint',
+    ({ usageRoute, cost, expected }) => {
+      expect(
+        formatResumeHint(
+          [{ executionId: 'root', label: 'main', isRoot: true }],
+          {
+            inputTokens: 100,
+            outputTokens: 20,
+            cost,
+            usageRoute,
+          } satisfies TokenUsageStats,
+        ),
+      ).toBe(
+        [
+          'Token usage: total=120 input=100 output=20',
+          `Session cost: ${expected}`,
+          'Resume this session with:',
+          '  texra resume root  (main)',
+        ].join('\n'),
+      );
+    },
+  );
 
   it('is undefined when there is nothing to resume', () => {
     expect(formatResumeHint([])).toBeUndefined();
@@ -306,70 +331,5 @@ describe('collectResumeUsage', () => {
       cacheCreationInputTokens: 0,
       reasoningTokens: 5,
     });
-  });
-});
-
-describe('formatResumeUsage', () => {
-  it('omits empty usage', () => {
-    expect(
-      formatResumeUsage({ inputTokens: 0, outputTokens: 0, cost: 0 }),
-    ).toBeUndefined();
-  });
-
-  it('appends the session cost with the relay route label', () => {
-    expect(
-      formatResumeUsage({
-        inputTokens: 100,
-        outputTokens: 20,
-        cost: 0.012,
-        usageRoute: 'relay',
-      }),
-    ).toBe(
-      'Token usage: total=120 input=100 output=20\n' +
-        'Session cost: $0.012 via included access',
-    );
-  });
-
-  it('shows a covered subscription as free', () => {
-    expect(
-      formatResumeUsage({
-        inputTokens: 100,
-        outputTokens: 20,
-        cost: 0,
-        usageRoute: 'chatgpt-subscription',
-      }),
-    ).toBe(
-      'Token usage: total=120 input=100 output=20\n' +
-        'Session cost: Free via ChatGPT',
-    );
-  });
-
-  it('labels your own API keys', () => {
-    expect(
-      formatResumeUsage({
-        inputTokens: 100,
-        outputTokens: 20,
-        cost: 0.5,
-        usageRoute: 'api-key',
-      }),
-    ).toBe(
-      'Token usage: total=120 input=100 output=20\n' +
-        'Session cost: $0.500 via your own API keys',
-    );
-  });
-
-  it('shows the bare cost when no route is stamped', () => {
-    expect(
-      formatResumeUsage({ inputTokens: 100, outputTokens: 20, cost: 0.3 }),
-    ).toBe(
-      'Token usage: total=120 input=100 output=20\n' + 'Session cost: $0.300',
-    );
-  });
-
-  it('omits the cost line when there is no cost and no route', () => {
-    const usage = { inputTokens: 100, outputTokens: 20, cost: 0 };
-    expect(formatResumeUsage(usage)).toBe(
-      'Token usage: total=120 input=100 output=20',
-    );
   });
 });

--- a/src/test-kernel/cli/ResumeHint.vitest.ts
+++ b/src/test-kernel/cli/ResumeHint.vitest.ts
@@ -270,6 +270,11 @@ describe('formatResumeHint', () => {
       cost: 0.5,
       expected: '$0.500 via your own API keys',
     },
+    {
+      usageRoute: undefined,
+      cost: 0.3,
+      expected: '$0.300',
+    },
   ])(
     'includes the $usageRoute session cost in the full hint',
     ({ usageRoute, cost, expected }) => {

--- a/src/test-kernel/cli/RunChatSignalOwnership.vitest.ts
+++ b/src/test-kernel/cli/RunChatSignalOwnership.vitest.ts
@@ -28,7 +28,6 @@ const cliRequire = createRequire(
 
 const mocks = vi.hoisted(() => ({
   callOrder: [] as string[],
-  chatAgentSupportsDelegation: vi.fn(),
   chatToolUseAgentUsageError: vi.fn(),
   cleanupTerminalModes: vi.fn(),
   createChatSessionController: vi.fn(),
@@ -116,7 +115,6 @@ vi.mock(
       >();
     return {
       ...actual,
-      chatAgentSupportsDelegation: mocks.chatAgentSupportsDelegation,
       chatToolUseAgentUsageError: mocks.chatToolUseAgentUsageError,
     };
   },
@@ -269,7 +267,6 @@ describe('runChat signal ownership wiring', () => {
       modelSource: 'default',
     });
     mocks.chatToolUseAgentUsageError.mockReturnValue(undefined);
-    mocks.chatAgentSupportsDelegation.mockReturnValue(false);
     mocks.selectCliRunnableModel.mockResolvedValue({ model: 'gpt-test' });
     mocks.loadInputHistory.mockResolvedValue({
       at: vi.fn(),

--- a/src/test-kernel/cli/SlashRegistry.vitest.ts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.ts
@@ -38,7 +38,6 @@ import {
 } from '@cli/chat/tui/state/transcript';
 import type { CliModelAccessSelection } from '@cli/runtime/modelAccessRoute';
 import type { TexraApprovalPolicy } from '@shared/approvalPolicy';
-import { AgentCategory } from '@shared/schemas';
 import { loadInk, renderInteractive } from '@test/support/inkTestHarness.ts';
 import {
   createDeferred,
@@ -49,12 +48,10 @@ import { bindTestSessionView } from './fixtures/sessionViewFixture';
 
 const CHAT_SESSION: SessionMeta = {
   agent: 'chat',
-  category: AgentCategory.ToolUse,
   model: 'deepseekT',
   modelSource: 'builtin-default',
   cwd: '/tmp/workspace',
   approvalPolicy: 'ask',
-  canDelegate: false,
   transcriptMode: 'persistent',
   version: 'test',
 };

--- a/src/test-kernel/cli/StaticBandResize.vitest.ts
+++ b/src/test-kernel/cli/StaticBandResize.vitest.ts
@@ -21,7 +21,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 // Local imports
 import type { TuiRepaintOptions } from '@cli/chat/tui/render/tuiViewportController';
 import type { SessionMeta } from '@cli/chat/tui/state/cliState';
-import { AgentCategory, type StreamTabId } from '@shared/schemas';
+import type { StreamTabId } from '@shared/schemas';
 import type { TranscriptRow } from '@shared/transcript';
 import {
   FakeStdin,
@@ -51,11 +51,9 @@ afterAll(() => {
 
 const TRANSCRIPT_SESSION: Omit<SessionMeta, 'cwd'> = {
   agent: 'research',
-  category: AgentCategory.ToolUse,
   model: 'test-model',
   modelSource: 'builtin-default',
   approvalPolicy: 'ask',
-  canDelegate: false,
   transcriptMode: 'persistent',
   version: '0.0.0-test',
 };


### PR DESCRIPTION
Part of #11865
Closes #11889

## Summary

Implements the survey finding in #11889 (see the issue for the file:line evidence and consumer counts). Commits:

dd9e03aa43 refactor: remove unused CLI session metadata

## Net elements (R6)

`git diff --shortstat origin/main...HEAD`:  15 files changed, 45 insertions(+), 130 deletions(-)

Exports: +0 / -2. Files: config/ratchets/knip-baseline.json packages/cli/scripts/tui-harness.tsx packages/cli/scripts/validate-tui.mjs packages/cli/src/chat/chatSessionController.ts packages/cli/src/chat/tui/commands/handlers/agentModelCommands.ts packages/cli/src/chat/tui/runChatTui.tsx packages/cli/src/chat/tui/state/cliState.ts packages/cli/src/chat/tui/state/resumeHint.ts packages/cli/src/runtime/agents.ts src/test-kernel/cli/CliAgentShadow.vitest.ts src/test-kernel/cli/ConversationTranscript.vitest.ts src/test-kernel/cli/ResumeHint.vitest.ts src/test-kernel/cli/RunChatSignalOwnership.vitest.ts src/test-kernel/cli/SlashRegistry.vitest.ts src/test-kernel/cli/StaticBandResize.vitest.ts 

## Consumer counts (R8)

As recorded in #11889 (grepped at filing; the PR deletes only symbols whose production consumer count was zero).

## Verification

See the commit; CI runs typecheck, the kernel suites, the CLI React Compiler smoke, lint, and the dead-code ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)