### PR TITLE
refactor(cli): read the child stop targets from the session view instead of an app-level map

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -90,6 +90,7 @@ import {
 import {
   currentView,
   focusTreeOf,
+  killableExecutionId,
   sessionView,
   streamPhaseOf,
   streamLabelOf,
@@ -130,26 +131,6 @@ function executionLabelsOf(view: SessionView): ExecutionLabels {
     }
   }
   return labels;
-}
-
-/** Execution ids of the in-flight child streams among `ids`: the fold's
- *  `running` and `waiting` groups, the two a kill can still reach. */
-function activeChildExecutionIds(
-  view: SessionView,
-  ids: readonly StreamTabId[],
-): Map<StreamTabId, string> {
-  const out = new Map<StreamTabId, string>();
-  for (const id of ids) {
-    const stream = streamViewOf(view, id);
-    if (
-      stream &&
-      stream.parentId !== null &&
-      (stream.group === 'running' || stream.group === 'waiting')
-    ) {
-      out.set(id, stream.executionId);
-    }
-  }
-  return out;
 }
 
 export interface AppProps {
@@ -288,10 +269,6 @@ export function App(props: AppProps): React.JSX.Element {
     view,
     streamViewOf(view, childListTarget),
   );
-  const activeSubagentExecutionIds = useMemo(
-    () => activeChildExecutionIds(view, sessions),
-    [sessions, view],
-  );
   const workflowPopupStreamId =
     foregroundReader?.kind === 'workflow'
       ? foregroundReader.streamId
@@ -299,12 +276,6 @@ export function App(props: AppProps): React.JSX.Element {
   const workflowPopupRoot = streamViewOf(view, workflowPopupStreamId);
   const workflowPopupModel = workflowPopupRoot?.transcript.run ?? undefined;
   const workflowPopup = useSignal(workflowPopupViewSignal);
-  // The popup controls its own grandchildren: the workflow's in-flight
-  // children, read from the fold.
-  const workflowPopupExecutionIds = useMemo(
-    () => activeChildExecutionIds(view, workflowPopupRoot?.childIds ?? []),
-    [view, workflowPopupRoot],
-  );
   const pendingApprovalsForRows = useMemo(
     () => groupPendingApprovalsByRow(view.approvals),
     [view.approvals],
@@ -312,8 +283,7 @@ export function App(props: AppProps): React.JSX.Element {
   const childListValues = sessions;
   const childListAvailable = childListValues.length > 0;
   const selectedChildKillable =
-    selectedChildValue !== undefined &&
-    activeSubagentExecutionIds.has(selectedChildValue);
+    killableExecutionId(streamViewOf(view, selectedChildValue)) !== undefined;
   useEffect(() => {
     dispatchChildListSelection({
       kind: 'reconcile',
@@ -422,7 +392,6 @@ export function App(props: AppProps): React.JSX.Element {
         }
         return (
           <WorkflowPopup
-            activeSubagentExecutionIds={workflowPopupExecutionIds}
             availableRows={availableRows}
             model={workflowPopupModel}
             onClose={closeForegroundReader}
@@ -745,7 +714,6 @@ export function App(props: AppProps): React.JSX.Element {
           sessions,
           selectedChildValue,
           subagentExecutionLabels,
-          activeSubagentExecutionIds,
           listRootStreamId: childListTarget,
           pendingApprovals: pendingApprovalsForRows,
         }}

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -55,7 +55,6 @@ interface ConversationRegionSnapshot {
   /** The child-list rows: the list root, then its descendants newest first. */
   readonly sessions: readonly StreamTabId[];
   readonly subagentExecutionLabels: ExecutionLabels;
-  readonly activeSubagentExecutionIds: ReadonlyMap<StreamTabId, string>;
   readonly listRootStreamId: StreamTabId | undefined;
   readonly pendingApprovals: ReadonlyMap<
     string,
@@ -253,7 +252,6 @@ export function ConversationRegion({
               listRootStreamId={snapshot.listRootStreamId}
               selectedValue={snapshot.selectedChildValue}
               sessions={snapshot.sessions}
-              activeSubagentExecutionIds={snapshot.activeSubagentExecutionIds}
             />
             <TodosPlanPanel
               maxRows={todosPlanRows}

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -14,6 +14,7 @@ import { formatResultCount } from '@utils/text/stringUtils';
 import { childElapsed } from '../state/childControls';
 import {
   cumulativeUsageOf,
+  killableExecutionId,
   sessionView,
   streamLabelOf,
   streamPhaseOf,
@@ -179,7 +180,6 @@ export interface SubagentListProps {
   /** The focus tree: the list root first, then its children. */
   readonly sessions?: readonly StreamTabId[];
   readonly listRootStreamId?: StreamTabId;
-  readonly activeSubagentExecutionIds?: ReadonlyMap<StreamTabId, string>;
 }
 
 export function SubagentList(
@@ -219,7 +219,7 @@ export function SubagentList(
       const streamId = props.selectedValue;
       if (!streamId) return;
       if (input.toLowerCase() !== 'k') return;
-      const executionId = props.activeSubagentExecutionIds?.get(streamId);
+      const executionId = killableExecutionId(streamsByValue.get(streamId));
       if (executionId) props.onKillExecution?.(executionId);
     },
     { isActive: props.keyboardActive ?? false },

--- a/packages/cli/src/chat/tui/panes/WorkflowPopup.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkflowPopup.tsx
@@ -60,6 +60,7 @@ import { scrollableModalTextRowsBudget } from '../modals/ScrollableModalText';
 import { type WorkflowPopupView } from '../state/cliState';
 import {
   cumulativeUsageOf,
+  killableExecutionId,
   sessionView,
   streamViewOf,
 } from '../state/sessionView';
@@ -230,7 +231,6 @@ interface WorkflowPopupProps {
   readonly streamId: StreamTabId;
   readonly model: WorkflowRunModel;
   readonly view: WorkflowPopupView;
-  readonly activeSubagentExecutionIds: ReadonlyMap<StreamTabId, string>;
   readonly pendingApprovals: ReadonlyMap<
     string,
     readonly PendingApprovalKind[]
@@ -247,7 +247,6 @@ interface WorkflowPopupProps {
 }
 
 export function WorkflowPopup({
-  activeSubagentExecutionIds,
   availableRows,
   model,
   onClose,
@@ -332,19 +331,13 @@ export function WorkflowPopup({
   const selectedChildStreamId = selectedTask
     ? childStreamOf(selectedTask)
     : undefined;
-  const selectedExecutionId =
-    selectedChildStreamId !== undefined
-      ? activeSubagentExecutionIds.get(selectedChildStreamId)
-      : undefined;
+  const selectedChildStream = streamViewOf(sessionState, selectedChildStreamId);
+  const selectedExecutionId = killableExecutionId(selectedChildStream);
   // A workflow-script grandchild `agent()` call is the only skip/retry-able
   // row: a native agent run (an external CLI tool's child is driven by that
   // tool and would no-op) whose parent is the workflow run — one identity
   // hop, which excludes the run stream itself.
-  const selectedChildIdentity =
-    selectedChildStreamId !== undefined
-      ? (streamViewOf(sessionState, selectedChildStreamId)?.identity ??
-        undefined)
-      : undefined;
+  const selectedChildIdentity = selectedChildStream?.identity;
   const controllable =
     selectedExecutionId !== undefined &&
     selectedChildIdentity?.kind === 'agent' &&

--- a/packages/cli/src/chat/tui/state/sessionView.ts
+++ b/packages/cli/src/chat/tui/state/sessionView.ts
@@ -95,6 +95,17 @@ export function streamViewOf(
   return streamId === undefined ? undefined : view.streams.get(streamId);
 }
 
+/** The execution to stop when a child is still running or waiting. */
+export function killableExecutionId(
+  stream: StreamView | undefined,
+): string | undefined {
+  return stream &&
+    stream.parentId !== null &&
+    (stream.group === 'running' || stream.group === 'waiting')
+    ? stream.executionId
+    : undefined;
+}
+
 /** Whether a focused child stream takes the composer's follow-ups (PRD 10.1). */
 export function focusedChildAcceptsFollowUps(stream: StreamView): boolean {
   return (

--- a/src/test-kernel/cli/WorkflowPopup.vitest.ts
+++ b/src/test-kernel/cli/WorkflowPopup.vitest.ts
@@ -90,7 +90,6 @@ async function renderPopup(
   const rendered = renderInteractive(
     ink,
     React.createElement(WorkflowPopup, {
-      activeSubagentExecutionIds: new Map(),
       availableRows,
       model,
       onClose: vi.fn(),


### PR DESCRIPTION
Part of #11865
Closes #11890

## Summary

Implements the survey finding in #11890 (see the issue for the file:line evidence and consumer counts). Commits:

760ca30d20 refactor: read child stop targets from session views

## Net elements (R6)

`git diff --shortstat origin/main...HEAD`:  6 files changed, 19 insertions(+), 50 deletions(-)

Exports: +1 / -0. Files: packages/cli/src/chat/tui/App.tsx packages/cli/src/chat/tui/panes/ConversationRegion.tsx packages/cli/src/chat/tui/panes/SubagentList.tsx packages/cli/src/chat/tui/panes/WorkflowPopup.tsx packages/cli/src/chat/tui/state/sessionView.ts src/test-kernel/cli/WorkflowPopup.vitest.ts 

## Consumer counts (R8)

As recorded in #11890 (grepped at filing; the PR deletes only symbols whose production consumer count was zero).

## Verification

See the commit; CI runs typecheck, the kernel suites, the CLI React Compiler smoke, lint, and the dead-code ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)