### PR TITLE
refactor(model): delete the model-options 5s LRU and its invalidation (#11847)

### DIFF
--- a/packages/cli/src/chat/tui/state/subscriptionPreference.ts
+++ b/packages/cli/src/chat/tui/state/subscriptionPreference.ts
@@ -2,7 +2,6 @@ import {
   subscriptionProvider,
   type SubscriptionProviderId,
 } from '@controllers/modelAccess/subscriptionProviders';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { codingPlanSubscriptionRuntimes } from '@model/codingPlanSubscriptions';
 import type { SubscriptionPreferenceUpdate } from '@model/subscriptionPreference';
 import type { CodingPlanSubscriptionId } from '@shared/codingPlanSubscriptions';
@@ -11,12 +10,11 @@ import { bumpCodexPreferenceVersion } from './cliState';
 
 /**
  * Single source of truth for reacting to a subscription change (ChatGPT, Grok,
- * …) inside the running TUI: drop the cached model options and bump the
- * preference version so dependent views (model picker, status bar) re-render.
+ * …) inside the running TUI: bump the preference version so dependent views
+ * (model picker, status bar) re-render.
  * Call after any sign-in/out or preference flip.
  */
 export function refreshSubscriptionPreferenceViews(): void {
-  invalidateModelOptionsCache();
   bumpCodexPreferenceVersion();
 }
 

--- a/packages/cli/src/commands/_helpers/subscriptionAuthCommand.ts
+++ b/packages/cli/src/commands/_helpers/subscriptionAuthCommand.ts
@@ -14,7 +14,6 @@ import {
   type SubscriptionAccount,
   type SubscriptionProviderId,
 } from '@controllers/modelAccess/subscriptionProviders';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { ACCOUNT_OUTCOME } from '@shared/copy/accountAuth';
 
 import { withCliAuthError } from './cliAuthError';
@@ -86,7 +85,6 @@ export function defineSubscriptionAuthCommand(
         ? `${signedIn}\n${provider.displayName} subscription enabled for ${provider.modelFamily}.`
         : `${signedIn}\n${provider.displayName} subscription preference could not be enabled because a more specific setting overrides the config.`,
     });
-    invalidateModelOptionsCache();
     return CliExitCode.Success;
   }
 
@@ -128,7 +126,6 @@ export function defineSubscriptionAuthCommand(
       );
       if (!signOutResult.ok) return CliExitCode.ModelOrNetworkError;
       const update = signOutResult.value;
-      invalidateModelOptionsCache();
       const payload = {
         authenticated: false,
         preferSubscription: update.preferenceUpdate?.effective ?? null,

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -9,7 +9,6 @@ import {
 } from '@common/teams/TeamPlan';
 import { teamHostedNamesForPreflight } from '@common/teams/TeamRoster';
 import { createLog } from '@logger/logUtils';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { platform } from '@platform/platform';
 import { AgentCategory, byCategory } from '@shared/schemas';
 import { RESEARCHER_ACCESS_AUTH } from '@shared/copy/accountAuth';
@@ -351,7 +350,6 @@ async function runOrchestration(context: CliContext): Promise<number> {
           } else {
             await runLoginCommand(context, loginInitFromArgs({}));
           }
-          invalidateModelOptionsCache();
         } catch (error: unknown) {
           writeErrorStderr(error);
         }

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -34,7 +34,6 @@ import {
   apiKeySecretName,
   type ApiProvider,
 } from '@model/apiProviders';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { hasUsableSetupCredential } from '@model/setupCredentialAccess';
 import { platform } from '@platform/platform';
 import {
@@ -363,7 +362,6 @@ function OnboardingApp(props: OnboardingAppProps): React.JSX.Element {
           void (async () => {
             try {
               await saveProviderApiKey(keyProvider, key);
-              invalidateModelOptionsCache();
               finish({
                 configured: true,
                 declined: false,
@@ -500,7 +498,6 @@ function ChatGptProgressStep(
         }
         return;
       }
-      invalidateModelOptionsCache();
       if (!isCancelled()) props.onSuccess(account);
     } catch (loginError: unknown) {
       if (!isCancelled()) props.onError(toErrorMessage(loginError));

--- a/packages/cli/src/runtime/modelAccessSelection.ts
+++ b/packages/cli/src/runtime/modelAccessSelection.ts
@@ -3,7 +3,6 @@ import {
   type SubscriptionProviderId,
 } from '@controllers/modelAccess/subscriptionProviders';
 import { hasUsableApiKey } from '@model/apiProviders';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import {
   codingPlanSubscriptionRuntimes,
   type CodingPlanSubscriptionRuntime,
@@ -98,7 +97,6 @@ async function updateSubscriptionCliModelAccess(
   const { displayName, modelFamily } = provider;
   if (selection.state === 'off') {
     const update = await provider.setPreferSubscription(false);
-    invalidateModelOptionsCache();
     return {
       message: update.effective
         ? `${displayName} subscription preference remains enabled because a more specific setting overrides ${update.target} config.`
@@ -122,7 +120,6 @@ async function updateSubscriptionCliModelAccess(
 
   const update = await provider.setPreferSubscription(true);
   await platform().globalState.update(GlobalStateKey.USE_OPENROUTER, false);
-  invalidateModelOptionsCache();
   return {
     message: update.effective
       ? `Prefer ${displayName} subscription enabled for ${modelFamily} (${accountLabel}).`
@@ -138,7 +135,6 @@ async function updateKeyedCliModelAccess(
   const plan = runtime.descriptor;
   if (selection.state === 'off') {
     await runtime.setEnabled(false);
-    invalidateModelOptionsCache();
     return {
       message: `${plan.preferenceLabel} disabled for ${plan.modelFamily}.`,
     };
@@ -152,7 +148,6 @@ async function updateKeyedCliModelAccess(
     };
   }
   await runtime.setEnabled(true);
-  invalidateModelOptionsCache();
   return {
     message: `${plan.preferenceLabel} enabled for ${plan.modelFamily} · other models still use ${formatCliModelAccessRouteInline('personal')}.`,
   };

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -66,10 +66,7 @@ import {
   hasUsableApiKey,
   lookupApiKey,
 } from '@model/apiProviders';
-import {
-  computeModelOptionsData,
-  invalidateModelOptionsCache,
-} from '@model/computeModelOptions';
+import { computeModelOptionsData } from '@model/computeModelOptions';
 import { platform } from '@platform/platform';
 import {
   COMMON_COMMANDS,
@@ -465,7 +462,6 @@ export class DesktopProgressBridge {
           'Add a provider API key in Models, then use "Retry" on the request.',
         );
       },
-      invalidateModelOptionsCache,
       isRetryPending: (stream, requestId) =>
         this.hostInteractions.isRetryPending(stream, requestId),
       triggerRetry: (stream, requestId) =>

--- a/packages/desktop/src/main/desktopCredentialSettingsController.ts
+++ b/packages/desktop/src/main/desktopCredentialSettingsController.ts
@@ -15,7 +15,6 @@ import type { ExternalOpener, MessageHost, PromptHost } from '@hosts/uiHosts';
 import {
   computeModelOptionsData,
   getEnabledModels,
-  invalidateModelOptionsCache,
 } from '@model/computeModelOptions';
 import {
   API_PROVIDERS,
@@ -264,7 +263,6 @@ export class DefaultDesktopCredentialSettingsController implements DesktopCreden
   }
 
   async refreshAuthDependentData(): Promise<void> {
-    invalidateModelOptionsCache();
     await this.postModelSelectionData();
     await this.postMainModelOptionsData();
     await this.postProfileData();
@@ -393,7 +391,6 @@ export class DefaultDesktopCredentialSettingsController implements DesktopCreden
 
   private async refreshAfterProviderKeyChange(provider: string): Promise<void> {
     invalidateApiKeyCache();
-    invalidateModelOptionsCache();
     const usageProvider = codingPlanForApiProvider(provider)?.usageProvider;
     if (usageProvider) this.subscriptionUsage.invalidate(usageProvider);
     await this.postProfileData();
@@ -407,7 +404,6 @@ export class DefaultDesktopCredentialSettingsController implements DesktopCreden
     providerId: SubscriptionProviderId,
   ): Promise<void> {
     const { usageProvider } = SUBSCRIPTION_STATUS_ROWS[providerId];
-    invalidateModelOptionsCache();
     if (usageProvider) this.subscriptionUsage.invalidate(usageProvider);
     await Promise.all([
       this.postAuthStatus(providerId),

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -9,7 +9,6 @@ import {
 } from '@controllers/settingsView/githubSubscriptions';
 import { appSignals } from '@eventBus/AppSignals';
 import type { MessageHost } from '@hosts/uiHosts';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import type { StateStore } from '@platform/interfaces';
 import { platform } from '@platform/platform';
 import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
@@ -188,9 +187,6 @@ export function createDesktopSettingsIpc(
   }
 
   async function postInitialSettingsData(): Promise<void> {
-    // Model availability can change without a session event (a server-side
-    // tier or subscription flip), so the panel must not paint a stale list.
-    invalidateModelOptionsCache();
     postSettingsSnapshot('git-author');
     options.toolingSettingsController.postLatexConfigValues();
     const goalListPosted = postGoalList();
@@ -275,7 +271,6 @@ export function createDesktopSettingsIpc(
     const invalidatesModelOptions =
       result.entry.onWrite?.invalidatesModelOptions === true;
     if (invalidatesModelOptions) {
-      invalidateModelOptionsCache();
       await options.credentialSettingsController.refreshAfterProviderSettingChange(
         key,
       );

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -67,7 +67,6 @@ import { createExtensionTexraConfig } from '@frontend/vscode/texraConfig';
 import { createTexraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import { createLog, setOutputChannelFactory } from '@logger/logUtils';
 import { redactSecrets } from '@logger/redaction';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { refreshModelListAndLog } from '@model/modelListRefresh';
 import { invalidateRuntimeModelRegistry } from '@model/runtimeModelRegistry';
 import { SHUTDOWN_PHASE, type LifecycleHost } from '@platform/interfaces';
@@ -491,7 +490,6 @@ async function activateExtension(context: vscode.ExtensionContext) {
   installTexraAccountProbes();
   const invalidateLanguageModels = () => {
     invalidateRuntimeModelRegistry();
-    invalidateModelOptionsCache();
     appSignals.emit('languageModelsChanged', undefined);
   };
   context.subscriptions.push(

--- a/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
+++ b/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
@@ -23,7 +23,6 @@ import {
 } from '@auth/SupabaseSession';
 import { classifyAuthFailureStatus } from '@auth/TokenProvider';
 import * as logger from '@logger/logUtils';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { platform } from '@platform/platform';
 import type { PlatformSecrets } from '@platform/secrets';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -242,13 +241,9 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
     return this.authCommitQueue.add(commit) as Promise<T>;
   }
 
-  /**
-   * Store a newly created session and publish the credential change: clear the
-   * caches that depend on the account and fire the session-change event.
-   */
+  /** Store a newly created session and fire the session-change event. */
   private async storeSession(session: SupabaseSession): Promise<void> {
     await this.sessionCoordinator.storeSession(session);
-    invalidateModelOptionsCache();
     this._onDidChangeSessions.fire({
       added: [this.toVSCodeSession(session)],
       removed: [],
@@ -593,7 +588,6 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   }
 
   private async afterLocalSessionCleared(sessionId: string): Promise<void> {
-    invalidateModelOptionsCache();
     await refreshRemoteAgentCatalogAfterSignOut(
       invalidateRemoteAgentsAfterSignOut,
       log.warn,

--- a/packages/extension/src/frontend/auth/subscriptionSignIn.ts
+++ b/packages/extension/src/frontend/auth/subscriptionSignIn.ts
@@ -10,7 +10,6 @@ import {
   type SubscriptionSignInPresenter,
 } from '@controllers/modelAccess/subscriptionProviders';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { ACCOUNT_OUTCOME } from '@shared/copy/accountAuth';
 
 const OPEN_DEFAULT_BROWSER = 'Open in Default Browser';
@@ -107,10 +106,6 @@ export async function signInWithSubscription(
   let update: { effective: boolean };
   try {
     update = await provider.setPreferSubscription(true);
-    // The sign-in operation owns its model-availability postcondition. Every
-    // caller may now refresh a picker without inheriting a stale pre-login
-    // snapshot, including paths that do not pass through Settings.
-    invalidateModelOptionsCache();
   } catch (error) {
     await showLoggedErrorMessage(
       channel,

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -41,7 +41,6 @@ import { RecordingManager } from '@frontend/media/RecordingManager';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import type { PromptHost } from '@hosts/uiHosts';
 import { apiKeySecretName } from '@model/apiProviders';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { getRuntimeModelDirectFallback } from '@model/runtimeModelRegistry';
 import { platform } from '@platform/platform';
 import latexPreamble from '@resources/templates/chatExport.tex';
@@ -634,7 +633,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       promptForApiKey: async (provider) => {
         await this.runViewCommand(EXTENSION_COMMANDS.SET_API_KEY, [provider]);
       },
-      invalidateModelOptionsCache,
       isRetryPending: (stream, requestId) =>
         this.interactions.isRetryPending(stream, requestId),
       triggerRetry: (stream, requestId) =>

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -50,7 +50,6 @@ import {
   requestRuntimeModelAccess,
 } from '@model/runtimeModelRegistry';
 import { setCopilotRoutePreference } from '@model/copilotRouting';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { hasUsableSetupCredential } from '@model/setupCredentialAccess';
 import {
   LANGUAGE_MODEL_PORT_ERROR_CODE,
@@ -433,9 +432,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       commands: unsupportedCommands(this.handlerRegistry),
     });
 
-    // Auth/session changes affect model availability and must not reuse a
-    // pre-login/pre-logout availability snapshot.
-    invalidateModelOptionsCache();
     await this.sendProfileAndModelSelectionData(webview);
 
     await Promise.all([
@@ -571,7 +567,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     await this.postStateSettingSnapshot(result.entry.surfaces.settingsView);
     if (result.kind !== 'applied') return;
     if (result.entry.onWrite?.invalidatesModelOptions) {
-      invalidateModelOptionsCache();
       await this.withActiveWebview((w) => this.sendModelSelectionData(w));
       await safeExecuteCommand('texra.refreshAllOptions', [], this.viewName);
     }
@@ -609,7 +604,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
   /**
    * The shared refresh tail for a credential change (API key or subscription
-   * auth): invalidate caches, re-run the host refresh commands, and push
+   * auth): drop the cached usage, re-run the host refresh commands, and push
    * fresh profile/model/usage data to the active webview. Model selection
    * availability depends on key state, so the key status command is awaited
    * before any model/profile data is sent. `refreshProfileData` selects which
@@ -620,8 +615,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     usageProvider?: SubscriptionUsageProvider;
     refreshProfileData: (webview: vscode.Webview) => Promise<void>;
   }): Promise<void> {
-    // Invalidate caches so downstream refreshes see fresh credential state.
-    invalidateModelOptionsCache();
     if (options.usageProvider) {
       this.subscriptionUsage.invalidate(options.usageProvider);
     }
@@ -708,7 +701,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       }
     } finally {
       invalidateRuntimeModelRegistry();
-      invalidateModelOptionsCache();
       await Promise.all([
         safeExecuteCommand('texra.refreshAllOptions', [], this.viewName),
         this.withActiveWebview((webview) =>
@@ -722,7 +714,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
    * canonical model to direct-provider routing. */
   private async handleClearCopilotRoute(modelName: string): Promise<void> {
     await setCopilotRoutePreference(modelName, false);
-    invalidateModelOptionsCache();
     await Promise.all([
       safeExecuteCommand('texra.refreshAllOptions', [], this.viewName),
       this.withActiveWebview((webview) => this.sendModelSelectionData(webview)),

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -61,7 +61,6 @@ export interface ProgressApiKeyRetryControllerDeps {
   /** Quota-fallback routes (ChatGPT, Grok, GLM, Kimi). Defaults to the
    *  shared runtime catalog. Tests inject a local table. */
   quotaFallbackRuntimes?: readonly QuotaFallbackRuntime[];
-  invalidateModelOptionsCache(): void;
   isRetryPending(stream: StreamTabId, requestId: string): boolean;
   triggerRetry(
     stream: StreamTabId,
@@ -283,7 +282,6 @@ export class ProgressApiKeyRetryController {
         ) {
           disabledQuotaRoutes.push(runtime.descriptor.exhaustionReason);
           await runtime.setEnabled(false);
-          this.deps.invalidateModelOptionsCache();
         }
       }
 
@@ -347,17 +345,6 @@ export class ProgressApiKeyRetryController {
     for (const restore of restores) {
       try {
         await restore();
-      } catch (error) {
-        firstFailure ??= error;
-      }
-    }
-    // Invalidate whenever a rollback was scheduled, even after a restore
-    // failure: a setter that mutated in memory before rejecting leaves the
-    // cached options describing the wrong routing. A failed invalidation
-    // must not replace the restore failure the caller can act on.
-    if (restores.length > 0) {
-      try {
-        this.deps.invalidateModelOptionsCache();
       } catch (error) {
         firstFailure ??= error;
       }

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -421,8 +421,7 @@ export function getEnabledModels(
 }
 
 /**
- * Enable or disable one model, and invalidate the options cache derived from
- * the list. The only writer of `GlobalStateKey.ENABLED_MODELS` outside the
+ * Enable or disable one model. The only writer of `GlobalStateKey.ENABLED_MODELS` outside the
  * startup reconciliation in `modelListRefresh.ts`.
  *
  * Two invariants, previously enforced only on the CLI path:

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -556,8 +556,9 @@ async function buildModelOptionData(
  * reads behind `hasUsableApiKey` are cached and invalidated in `apiProviders`
  * (`invalidateApiKeyCache`), the Copilot route catalogue in
  * `runtimeModelRegistry` (`invalidateRuntimeModelRegistry`), and the rest are
- * synchronous config and state reads, so there is no second cache to keep
- * fresh here.
+ * synchronous config and state reads plus the probe-backed sign-in status
+ * (`isCodexSignedIn`, `isXaiSignedIn`, live by design), so there is no second
+ * cache to keep fresh here.
  */
 export async function computeModelOptionsData(
   models?: readonly string[],

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -1,4 +1,3 @@
-import { LRUCache } from 'lru-cache';
 import { ModelProvider, type ModelConfig } from 'llm-zoo';
 
 import { isCodexSignedIn } from '@model/codex/codexSignedIn';
@@ -7,7 +6,6 @@ import { isPreferXaiSubscription } from '@model/xai/xaiPreference';
 import { isXaiSignedIn } from '@model/xai/xaiSignedIn';
 import type { StateStore } from '@platform/interfaces';
 import { platform } from '@platform/platform';
-import { workspaceRoots } from '@platform/workspaceRoots';
 import type { ModelAvailabilityKind, ModelOptionData } from '@shared/schemas';
 import { CHATGPT_AUTH, GROK_AUTH } from '@shared/copy/accountAuth';
 import {
@@ -19,7 +17,6 @@ import {
   isKimiSubscriptionEligible,
 } from '@shared/model/kimiCodeRetryGate';
 import { GlobalStateKey } from '@shared/state/stateKeys';
-import { coalesceAsync } from '@utils/core';
 import {
   getPreferKimiCode,
   getUseOpenRouter,
@@ -360,35 +357,28 @@ async function resolveModelAvailability(
   return availabilityStatus('missing-key');
 }
 
-const pendingAvailabilityKeyChecks = new Map<ApiProvider, Promise<boolean>>();
-
-function hasUsableApiKeyForAvailability(
-  provider: ApiProvider,
-): Promise<boolean> {
-  const pending = pendingAvailabilityKeyChecks.get(provider);
-  if (pending) return pending;
-
-  const check = hasUsableApiKey(platform().secrets, provider).catch(
-    (error: unknown) => {
-      warnModelAvailability(
-        `Failed to read ${providerDisplayName(provider)} API key status; treating it as unavailable.`,
-        error,
-      );
-      return false;
-    },
-  );
-  pendingAvailabilityKeyChecks.set(provider, check);
-  void check.then(() => {
-    if (pendingAvailabilityKeyChecks.get(provider) === check) {
-      pendingAvailabilityKeyChecks.delete(provider);
-    }
-  });
-  return check;
-}
-
 async function buildAvailabilityContext(): Promise<ModelAvailabilityContext> {
   const useOpenRouter = getUseOpenRouter();
-  const hasApiKey = hasUsableApiKeyForAvailability;
+  // One key check per provider per context: `apiProviders` coalesces the
+  // secret read, but a rejection reaches every awaiting model, and the picker
+  // warns once per provider, not once per model (#11508).
+  const keyChecks = new Map<ApiProvider, Promise<boolean>>();
+  const hasApiKey = (provider: ApiProvider): Promise<boolean> => {
+    let check = keyChecks.get(provider);
+    if (!check) {
+      check = hasUsableApiKey(platform().secrets, provider).catch(
+        (error: unknown) => {
+          warnModelAvailability(
+            `Failed to read ${providerDisplayName(provider)} API key status; treating it as unavailable.`,
+            error,
+          );
+          return false;
+        },
+      );
+      keyChecks.set(provider, check);
+    }
+    return check;
+  };
   const [hasOpenRouter, codexSignedIn, xaiSignedIn, kimiCodeKeySet] =
     await Promise.all([
       hasApiKey('openRouter'),
@@ -480,7 +470,6 @@ export async function setModelEnabled(input: {
     await state.update(GlobalStateKey.HELPER_MODEL, DEFAULT_HELPER_MODEL);
   }
 
-  invalidateModelOptionsCache();
   return next;
 }
 
@@ -560,74 +549,27 @@ async function buildModelOptionData(
   );
 }
 
-const MODEL_OPTIONS_CACHE_TTL_MS = 5_000;
-const MODEL_OPTIONS_CACHE_MAX_ENTRIES = 50;
-const VISIBLE_MODELS_CACHE_KEY = 'visible';
-const EXPLICIT_MODELS_CACHE_PREFIX = 'models:';
-
-/**
- * TTL-based cache for computeModelOptionsData.
- * Avoids redundant async work (SecretManager + server-side key checks)
- * when multiple callers request model options in quick succession.
- *
- * State is split into resolved data vs in-flight promise to avoid
- * sentinel values (like `data: []`) that could leak to callers.
- */
-const resolvedModelOptions = new LRUCache<string, ModelOptionData[]>({
-  max: MODEL_OPTIONS_CACHE_MAX_ENTRIES,
-  ttl: MODEL_OPTIONS_CACHE_TTL_MS,
-});
-const pendingModelOptions = new Map<string, Promise<ModelOptionData[]>>();
-
-/** Invalidate the shared model options cache (e.g. after key or model-list changes). */
-export function invalidateModelOptionsCache(): void {
-  resolvedModelOptions.clear();
-  pendingModelOptions.clear();
-  pendingAvailabilityKeyChecks.clear();
-}
-
 /**
  * Compute typed model options data for Lit-native rendering.
  *
  * When `models` is provided, the caller's view of the visible-models list is
- * honored verbatim. Explicit lists are cached by their exact ordered contents,
- * so alternate global-state views stay isolated while repeated settings/CLI
- * refreshes do not redo secret and server-side key checks. The key also names
- * the calling session's workspace: the subscription preferences the
- * availability context reads are workspace config, so one paper's verdict
- * must not be served to another.
- *
- * Callers that own access-state freshness invalidate the shared caches
- * ({@link invalidateModelOptionsCache}, `invalidateApiKeyCache`) instead of
- * passing their own dependency snapshot.
+ * honored verbatim. Every call recomputes from the live inputs: the secret
+ * reads behind `hasUsableApiKey` are cached and invalidated in `apiProviders`
+ * (`invalidateApiKeyCache`), the Copilot route catalogue in
+ * `runtimeModelRegistry` (`invalidateRuntimeModelRegistry`), and the rest are
+ * synchronous config and state reads, so there is no second cache to keep
+ * fresh here.
  */
 export async function computeModelOptionsData(
   models?: readonly string[],
 ): Promise<ModelOptionData[]> {
-  const cacheKey = `${workspaceRoots().workspace ?? ''}|${
-    models == null
-      ? VISIBLE_MODELS_CACHE_KEY
-      : `${EXPLICIT_MODELS_CACHE_PREFIX}${JSON.stringify(models)}`
-  }`;
-  return coalesceAsync<string, ModelOptionData[]>(
-    resolvedModelOptions,
-    pendingModelOptions,
-    cacheKey,
-    () => computeModelOptionsDataUncached(models),
-  );
-}
-
-async function computeModelOptionsDataUncached(
-  modelsOverride: readonly string[] | undefined,
-): Promise<ModelOptionData[]> {
   await discoveredCopilotRoutes();
   const availabilityCtx = await buildAvailabilityContext();
-  const models =
-    modelsOverride ??
-    visibleModelsForAccess(getEnabledModels(), availabilityCtx);
+  const visible =
+    models ?? visibleModelsForAccess(getEnabledModels(), availabilityCtx);
 
   return Promise.all(
-    models.map((model) => buildModelOptionData(model, availabilityCtx)),
+    visible.map((model) => buildModelOptionData(model, availabilityCtx)),
   );
 }
 

--- a/src/model/modelListRefresh.ts
+++ b/src/model/modelListRefresh.ts
@@ -1,6 +1,5 @@
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
-import { invalidateModelOptionsCache } from './computeModelOptions';
 import {
   DEFAULT_MODELS,
   isDeprecatedModel,
@@ -207,18 +206,15 @@ export async function refreshModelListAndLog(
   const { added, removed, reordered, routePreferencesCleared } = result;
   const changed = added.length > 0 || removed.length > 0 || reordered;
   const messages: string[] = [];
-  if (changed || routePreferencesCleared.length > 0) {
-    invalidateModelOptionsCache();
-    if (changed) {
-      messages.push(
-        `Refreshed enabled models: added [${added.join(', ')}], removed [${removed.join(', ')}]${reordered ? ', reordered' : ''}`,
-      );
-    }
-    if (routePreferencesCleared.length > 0) {
-      messages.push(
-        `Cleared stale Copilot route preferences: [${routePreferencesCleared.join(', ')}]`,
-      );
-    }
+  if (changed) {
+    messages.push(
+      `Refreshed enabled models: added [${added.join(', ')}], removed [${removed.join(', ')}]${reordered ? ', reordered' : ''}`,
+    );
+  }
+  if (routePreferencesCleared.length > 0) {
+    messages.push(
+      `Cleared stale Copilot route preferences: [${routePreferencesCleared.join(', ')}]`,
+    );
   }
   return { ...result, messages };
 }

--- a/src/model/modelListRefresh.ts
+++ b/src/model/modelListRefresh.ts
@@ -191,8 +191,7 @@ async function refreshModelListStateIfNeeded(
 }
 
 /**
- * Runs {@link refreshModelListStateIfNeeded} and, when it changed anything,
- * invalidates the model-options cache. Every host (extension, desktop, CLI)
+ * Runs {@link refreshModelListStateIfNeeded}. Every host (extension, desktop, CLI)
  * calls this at startup with the same added/removed/reordered/route-
  * preference handling; only the resulting `messages` (logged by the caller,
  * so a host can interleave its own follow-up lines, e.g. the extension's

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -36,10 +36,7 @@ import {
 import { CODEX_SESSION_SECRET_KEY } from '@auth/codex/codexConstants';
 import type { CodexSession } from '@auth/codex/codexSessionTypes';
 import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
-import {
-  computeModelOptionsData,
-  invalidateModelOptionsCache,
-} from '@model/computeModelOptions';
+import { computeModelOptionsData } from '@model/computeModelOptions';
 import { shouldRouteModelThroughOpenRouter } from '@model/openRouterRouting';
 import {
   invalidateRuntimeModelRegistry,
@@ -352,7 +349,6 @@ describe('GLM custom endpoint routing', () => {
   afterEach(() => {
     delete MODEL_CONFIGS.glm52.baseUrl;
     invalidateApiKeyCache();
-    invalidateModelOptionsCache();
   });
 
   it('keeps dispatch, availability, and credentials on the model custom route when OpenRouter is enabled', async () => {
@@ -365,7 +361,6 @@ describe('GLM custom endpoint routing', () => {
       },
     });
     invalidateApiKeyCache();
-    invalidateModelOptionsCache();
 
     const [access] = await computeModelOptionsData(['glm52']);
     const handler = await createModelHandler(MODEL_CONFIGS.glm52);
@@ -396,7 +391,6 @@ describe('GLM custom endpoint routing', () => {
       },
     });
     invalidateApiKeyCache();
-    invalidateModelOptionsCache();
 
     const [customAccess] = await computeModelOptionsData(['glm52']);
     const handler = await createModelHandler(MODEL_CONFIGS.glm52);
@@ -411,7 +405,6 @@ describe('GLM custom endpoint routing', () => {
     }
 
     delete MODEL_CONFIGS.glm52.baseUrl;
-    invalidateModelOptionsCache();
 
     const [openRouterAccess] = await computeModelOptionsData(['glm52']);
     expect(openRouterAccess).toMatchObject({

--- a/src/test-kernel/auth/SupabaseAuthProvider.vitest.ts
+++ b/src/test-kernel/auth/SupabaseAuthProvider.vitest.ts
@@ -330,8 +330,6 @@ describe('SupabaseAuthProvider model availability', () => {
     vi.clearAllMocks();
   });
 
-  // Listeners recompute model options from the session-change event, so an
-  // event published ahead of the invalidation serves the stale option list.
   // The shared client persists no session, so a remote sign-out would revoke
   // whichever session was last handed to it — at supabase-js's default global
   // scope, on every device. Sign-out clears local storage only, as on desktop

--- a/src/test-kernel/auth/SupabaseAuthProvider.vitest.ts
+++ b/src/test-kernel/auth/SupabaseAuthProvider.vitest.ts
@@ -5,7 +5,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 const providerMocks = vi.hoisted(() => ({
   asExternalUri: vi.fn(async (uri: { toString: () => string }) => uri),
   getUser: vi.fn(),
-  invalidateModelOptionsCache: vi.fn(),
   invalidateRemoteAgentsAfterSignOut: vi.fn(async () => {}),
   openExternal: vi.fn(async () => true),
   runPkceOperation: vi.fn((operation: () => Promise<unknown>) => {
@@ -110,10 +109,6 @@ vi.mock('@auth/SupabaseClient', () => ({
 vi.mock('@agent/index', () => ({
   invalidateRemoteAgentsAfterSignOut:
     providerMocks.invalidateRemoteAgentsAfterSignOut,
-}));
-
-vi.mock('@model/computeModelOptions', () => ({
-  invalidateModelOptionsCache: providerMocks.invalidateModelOptionsCache,
 }));
 
 // Local imports
@@ -337,52 +332,6 @@ describe('SupabaseAuthProvider model availability', () => {
 
   // Listeners recompute model options from the session-change event, so an
   // event published ahead of the invalidation serves the stale option list.
-  it('invalidates model availability before publishing a new session', async () => {
-    seedPendingOAuthAttempt();
-    const { provider, session, coordinator, fire } = createUnexpiredProvider();
-
-    // Drive the login path through its public seams: a late OAuth callback
-    // delivered to the registered URI handler stores the session.
-    coordinator.loadSession.mockResolvedValueOnce(null);
-    coordinator.createSessionFromCallback.mockResolvedValue({
-      success: true,
-      session,
-    });
-    let authCallback:
-      ((uri: { path: string; query: string }) => unknown) | undefined;
-    const handler = {
-      onDidReceiveCallback: (
-        listener: (uri: { path: string; query: string }) => unknown,
-      ) => {
-        authCallback = listener;
-        return { dispose: vi.fn() };
-      },
-      handleUri: vi.fn(),
-    } as unknown as SupabaseUriHandler;
-    provider.setUriHandler(handler);
-
-    await authCallback?.({
-      path: '/auth-callback',
-      query: `code=test&app_nonce=${TEST_NONCE}`,
-    });
-
-    expect(providerMocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
-    expect(
-      providerMocks.invalidateModelOptionsCache.mock.invocationCallOrder[0],
-    ).toBeLessThan(fire.mock.invocationCallOrder[0]);
-  });
-
-  it('invalidates model availability before publishing a sign-out', async () => {
-    const { provider, session, fire } = createUnexpiredProvider();
-
-    await provider.removeSession(session.id);
-
-    expect(providerMocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
-    expect(
-      providerMocks.invalidateModelOptionsCache.mock.invocationCallOrder[0],
-    ).toBeLessThan(fire.mock.invocationCallOrder[0]);
-  });
-
   // The shared client persists no session, so a remote sign-out would revoke
   // whichever session was last handed to it — at supabase-js's default global
   // scope, on every device. Sign-out clears local storage only, as on desktop

--- a/src/test-kernel/cli/CliInitPlatform.vitest.ts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.ts
@@ -81,7 +81,6 @@ const mocks = vi.hoisted(() => ({
   getCliSecrets: vi.fn(() => ({ kind: 'cli-secrets' })),
   openTexraConfigStores: vi.fn(),
   cliGlobalState: { get: vi.fn(), update: vi.fn() },
-  invalidateModelOptionsCache: vi.fn(),
   tryPlatform: vi.fn(),
   // Collects callbacks registered via the (mocked) lifecycle host's onShutdown
   // so a test can run them and assert the usage-log dispose was wired.
@@ -110,10 +109,6 @@ vi.mock('@logger/logUtils', () => ({
   info: vi.fn(),
   setOutputChannelFactory: vi.fn(),
   warn: vi.fn(),
-}));
-
-vi.mock('@model/computeModelOptions', () => ({
-  invalidateModelOptionsCache: mocks.invalidateModelOptionsCache,
 }));
 
 vi.mock('@platform/platform', () => ({
@@ -370,7 +365,6 @@ describe('CLI platform init', () => {
         cliContext({ quietLogs: false, installSignalHandlers: false }),
       );
 
-      expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
       expect(mocks.cliGlobalState.update).toHaveBeenCalledWith(
         GlobalStateKey.COPILOT_ROUTE_MODELS,
         ['gemini31p'],
@@ -410,7 +404,6 @@ describe('CLI platform init', () => {
     try {
       await initCliPlatform(cliContext({ installSignalHandlers: false }));
 
-      expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
       expect(stderrWrite).toHaveBeenCalledOnce();
       expect(stderrWrite).toHaveBeenCalledWith(
         expect.stringContaining(

--- a/src/test-kernel/cli/ConfigForm.vitest.ts
+++ b/src/test-kernel/cli/ConfigForm.vitest.ts
@@ -67,7 +67,6 @@ import {
   makeFakeSettingsStores,
 } from '@test/support/settingsStoresFake';
 
-const invalidateModelOptionsCache = vi.hoisted(() => vi.fn());
 const providerApiKeyRuntime = vi.hoisted(() => ({
   load: vi.fn(),
   save: vi.fn(),
@@ -78,9 +77,6 @@ const githubTokenRuntime = vi.hoisted(() => ({
   remove: vi.fn(),
 }));
 
-vi.mock('@model/computeModelOptions', () => ({
-  invalidateModelOptionsCache,
-}));
 vi.mock('@cli/runtime/providerApiKey', () => ({
   loadProviderApiKeyStatuses: providerApiKeyRuntime.load,
   saveProviderApiKey: providerApiKeyRuntime.save,
@@ -103,7 +99,6 @@ function apiKeyStatuses(
 }
 
 beforeEach(() => {
-  invalidateModelOptionsCache.mockClear();
   providerApiKeyRuntime.load.mockReset();
   providerApiKeyRuntime.load.mockResolvedValue(apiKeyStatuses());
   providerApiKeyRuntime.save.mockReset();
@@ -776,18 +771,6 @@ describe('/config slash command wiring', () => {
     expect(props.readValue?.(authorName)).toBe(DEFAULT_GIT_AUTHOR_NAME);
   });
 
-  it('invalidates model options when OpenRouter routing is disabled or reset', async () => {
-    const { stores } = makeFakeSettingsStores();
-    const props = openConfigFormProps(stores);
-    const openRouter = entryByKey(GlobalStateKey.USE_OPENROUTER);
-
-    await props.writeValue?.(openRouter, false);
-    expect(invalidateModelOptionsCache).toHaveBeenCalledTimes(1);
-
-    await props.resetValue?.(openRouter);
-    expect(invalidateModelOptionsCache).toHaveBeenCalledTimes(2);
-  });
-
   it('turns OpenRouter off when Prefer Kimi Code is enabled', async () => {
     const { stores, globalState } = makeFakeSettingsStores();
     await globalState.update(GlobalStateKey.USE_OPENROUTER, true);
@@ -799,7 +782,6 @@ describe('/config slash command wiring', () => {
     expect(props.readValue?.(entryByKey(GlobalStateKey.USE_OPENROUTER))).toBe(
       false,
     );
-    expect(invalidateModelOptionsCache).toHaveBeenCalled();
 
     // Disabling the preference leaves the OpenRouter toggle untouched.
     await globalState.update(GlobalStateKey.USE_OPENROUTER, true);

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.ts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.ts
@@ -23,7 +23,6 @@ const mocks = vi.hoisted(() => ({
   setPreferCodexSubscription: vi.fn(),
   isPreferXaiSubscription: vi.fn(),
   setPreferXaiSubscription: vi.fn(),
-  invalidateModelOptionsCache: vi.fn(),
   shouldUseSubscriptionDeviceCode: vi.fn(),
   signInCliSubscription: vi.fn(),
   updateGlobalState: vi.fn(),
@@ -98,10 +97,6 @@ vi.mock('@utils/config/providerConfig', () => ({
 
 vi.mock('@utils/config/platformSettings', () => ({
   writePlatformSetting: mocks.writePlatformSetting,
-}));
-
-vi.mock('@model/computeModelOptions', () => ({
-  invalidateModelOptionsCache: mocks.invalidateModelOptionsCache,
 }));
 
 vi.mock('@cli/runtime/subscriptionLogin', async (importOriginal) => {
@@ -331,7 +326,6 @@ describe('CLI model access routes', () => {
       GlobalStateKey.KIMI_CODE_PREFER,
       true,
     );
-    expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
     expect(result).toEqual({
       message:
         'Prefer Kimi Code subscription enabled for Kimi models · other models still use your own API keys.',
@@ -383,7 +377,6 @@ describe('CLI model access routes', () => {
     expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
     expect(mocks.setPreferXaiSubscription).not.toHaveBeenCalled();
     expect(mocks.updateGlobalState).not.toHaveBeenCalled();
-    expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
     expect(result).toEqual({
       message:
         'Prefer GLM Coding Plan enabled for GLM models · other models still use your own API keys.',
@@ -413,7 +406,6 @@ describe('CLI model access routes', () => {
     expect(mocks.setGLMCodingPlan).toHaveBeenCalledWith(false);
     expect(mocks.writePlatformSetting).not.toHaveBeenCalled();
     expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
-    expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
     expect(result).toEqual({
       message: 'Prefer GLM Coding Plan disabled for GLM models.',
     });
@@ -448,7 +440,6 @@ describe('CLI model access routes', () => {
       'texra.useOpenRouter',
       false,
     );
-    expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
     expect(result.message).toBe(
       'Prefer ChatGPT subscription enabled for Codex models (user@example.com).',
     );
@@ -474,7 +465,6 @@ describe('CLI model access routes', () => {
     expect(mocks.signInCliSubscription).not.toHaveBeenCalled();
     expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
     expect(mocks.writePlatformSetting).not.toHaveBeenCalled();
-    expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
     expect(result).toEqual({
       message: 'Prefer ChatGPT subscription disabled for Codex models.',
     });

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -69,7 +69,6 @@ function createHarness(options: HarnessOptions = {}): {
   glmCodingPlanValues: boolean[];
   kimiCodeValues: boolean[];
   grokSubscriptionValues: boolean[];
-  invalidations: number;
   retries: string[];
 } {
   const keys = new Map<ApiProvider, string | undefined>(
@@ -86,7 +85,6 @@ function createHarness(options: HarnessOptions = {}): {
   let preferGrokSubscription = options.grok ?? true;
   let glmCodingPlan = options.glmCodingPlan ?? true;
   let kimiCode = options.kimiCode ?? true;
-  let invalidations = 0;
   const retries: string[] = [];
 
   return {
@@ -96,9 +94,6 @@ function createHarness(options: HarnessOptions = {}): {
     glmCodingPlanValues,
     kimiCodeValues,
     grokSubscriptionValues,
-    get invalidations() {
-      return invalidations;
-    },
     retries,
     controller: new ProgressApiKeyRetryController({
       providers: PROVIDERS,
@@ -157,9 +152,6 @@ function createHarness(options: HarnessOptions = {}): {
           },
         ),
       ],
-      invalidateModelOptionsCache: () => {
-        invalidations += 1;
-      },
       isRetryPending:
         options.isRetryPending ?? (() => options.retryPending ?? true),
       triggerRetry:
@@ -190,7 +182,6 @@ describe('ProgressApiKeyRetryController', () => {
 
     expect(result).toStrictEqual(RETRIED_WITH_OWN_KEY_RESULT);
     expect(harness.prompts).toStrictEqual(['anthropic']);
-    expect(harness.invalidations).toBe(0);
     expect(harness.retries).toStrictEqual(['stream-a']);
   });
 
@@ -211,7 +202,6 @@ describe('ProgressApiKeyRetryController', () => {
 
     expect(result).toStrictEqual(IDLE_RESULT);
     expect(harness.prompts).toStrictEqual(['anthropic']);
-    expect(harness.invalidations).toBe(0);
     expect(harness.retries).toStrictEqual([]);
   });
 
@@ -229,7 +219,6 @@ describe('ProgressApiKeyRetryController', () => {
     });
 
     expect(result).toStrictEqual(IDLE_RESULT);
-    expect(harness.invalidations).toBe(0);
     expect(harness.retries).toStrictEqual([]);
   });
 
@@ -268,7 +257,6 @@ describe('ProgressApiKeyRetryController', () => {
 
     expect(result).toStrictEqual(RETRIED_WITH_OWN_KEY_RESULT);
     expect(harness.prompts).toStrictEqual([undefined]);
-    expect(harness.invalidations).toBe(0);
     expect(harness.retries).toStrictEqual(['stream-b']);
   });
 
@@ -287,7 +275,6 @@ describe('ProgressApiKeyRetryController', () => {
 
     expect(result).toStrictEqual(IDLE_RESULT);
     expect(harness.chatGptSubscriptionValues).toStrictEqual([false, true]);
-    expect(harness.invalidations).toBe(2);
     expect(harness.retries).toStrictEqual(['stream-race']);
   });
 
@@ -312,7 +299,6 @@ describe('ProgressApiKeyRetryController', () => {
     // usable, so "Use your own API key" must not jump to the key-input prompt.
     expect(harness.prompts).toStrictEqual([]);
     expect(harness.chatGptSubscriptionValues).toStrictEqual([false]);
-    expect(harness.invalidations).toBe(1);
     expect(harness.retries).toStrictEqual(['stream-d']);
   });
 
@@ -335,7 +321,6 @@ describe('ProgressApiKeyRetryController', () => {
     });
     expect(harness.prompts).toStrictEqual([]);
     expect(harness.grokSubscriptionValues).toStrictEqual([false]);
-    expect(harness.invalidations).toBe(1);
     expect(harness.retries).toStrictEqual(['stream-grok']);
   });
 
@@ -377,7 +362,6 @@ describe('ProgressApiKeyRetryController', () => {
     // usable, so "Use your own API key" must not jump to the key-input prompt.
     expect(harness.prompts).toStrictEqual([]);
     expect(harness.glmCodingPlanValues).toStrictEqual([false]);
-    expect(harness.invalidations).toBe(1);
     expect(harness.retries).toStrictEqual(['stream-glm']);
   });
 
@@ -446,7 +430,6 @@ describe('ProgressApiKeyRetryController', () => {
 
     expect(started).toBe(true);
     expect(harness.chatGptSubscriptionValues).toStrictEqual([false]);
-    expect(harness.invalidations).toBe(1);
   });
 
   it('restores ChatGPT access when an eligible Copilot fallback does not start', async () => {
@@ -464,7 +447,6 @@ describe('ProgressApiKeyRetryController', () => {
 
     expect(started).toBe(false);
     expect(harness.chatGptSubscriptionValues).toStrictEqual([false, true]);
-    expect(harness.invalidations).toBe(2);
   });
 
   it('keeps the global Copilot preference while scoping direct routing to the fallback launch', async () => {
@@ -665,7 +647,6 @@ describe('ProgressApiKeyRetryController', () => {
     expect(harness.keys.get('moonshot')).toBe('new-moonshot');
     expect(harness.keys.get('kimiCode')).toBe('old-kimi');
     expect(harness.kimiCodeValues).toStrictEqual([false]);
-    expect(harness.invalidations).toBe(1);
     expect(harness.retries).toStrictEqual(['stream-kimi-dual']);
   });
 
@@ -699,7 +680,6 @@ describe('ProgressApiKeyRetryController', () => {
     expect(harness.keys.get('moonshot')).toBe('new-moonshot');
     expect(harness.keys.get('kimiCode')).toBe('old-kimi');
     expect(harness.kimiCodeValues).toStrictEqual([]);
-    expect(harness.invalidations).toBe(0);
     expect(harness.retries).toStrictEqual(['stream-kimi-moonshot']);
   });
 
@@ -746,6 +726,5 @@ describe('ProgressApiKeyRetryController', () => {
     await expect(holder).resolves.toBe(true);
     await expect(stale).resolves.toBe(false);
     expect(startCalls).toStrictEqual(['holder']);
-    expect(harness.invalidations).toBe(0);
   });
 });

--- a/src/test-kernel/controllers/SettingsProfileController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsProfileController.vitest.ts
@@ -4,12 +4,6 @@ import { SettingsProfileController } from '@controllers/settingsView/SettingsPro
 import type { StateStore } from '@platform/interfaces';
 import { FakeStateStore } from '@test/support/FakePlatform';
 
-// The controller reads the shipped provider catalog directly, so the picker
-// invalidation it triggers is the real module function; stub it here.
-vi.mock('@model/computeModelOptions', () => ({
-  invalidateModelOptionsCache: vi.fn(),
-}));
-
 function createController(
   options: { state?: StateStore; config?: Record<string, unknown> } = {},
 ): SettingsProfileController {

--- a/src/test-kernel/desktop/DesktopCredentialSettingsController.vitest.ts
+++ b/src/test-kernel/desktop/DesktopCredentialSettingsController.vitest.ts
@@ -44,7 +44,6 @@ const modelMocks = vi.hoisted(() => ({
   compute: vi.fn(async (models: readonly string[] = []) =>
     models.map((model) => ({ value: model, label: model })),
   ),
-  invalidate: vi.fn(),
 }));
 
 vi.mock('@auth/codex', async (importOriginal) => ({
@@ -67,7 +66,6 @@ vi.mock('@model/codex/codexPreference', () => ({
 vi.mock('@model/computeModelOptions', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@model/computeModelOptions')>()),
   computeModelOptionsData: modelMocks.compute,
-  invalidateModelOptionsCache: modelMocks.invalidate,
 }));
 
 type ControllerOptions = ConstructorParameters<

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.ts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.ts
@@ -40,7 +40,6 @@ const computeModelOptionsData = vi.hoisted(() =>
 vi.mock('@model/computeModelOptions', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@model/computeModelOptions')>()),
   computeModelOptionsData,
-  invalidateModelOptionsCache: vi.fn(),
 }));
 
 type DesktopSettingsIpcModule =

--- a/src/test-kernel/frontend/CodexSubscriptionSignIn.vitest.ts
+++ b/src/test-kernel/frontend/CodexSubscriptionSignIn.vitest.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   loginWithLoopback: vi.fn(),
-  invalidateModelOptionsCache: vi.fn(),
   setPreferCodexSubscription: vi.fn(),
   showLoggedErrorMessage: vi.fn(),
   showInformationMessage: vi.fn(),
@@ -43,10 +42,6 @@ vi.mock('@model/codex/codexPreference', async (importOriginal) => ({
 
 vi.mock('@frontend/ui/errorHandlingUtils', () => ({
   showLoggedErrorMessage: mocks.showLoggedErrorMessage,
-}));
-
-vi.mock('@model/computeModelOptions', () => ({
-  invalidateModelOptionsCache: mocks.invalidateModelOptionsCache,
 }));
 
 const { signInWithSubscription } =
@@ -194,7 +189,6 @@ describe('signInWithSubscription (ChatGPT)', () => {
     const signedIn = await signInWithChatGptSubscription('TestChannel');
 
     expect(signedIn).toBe(true);
-    expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
     expect(mocks.showInformationMessage).toHaveBeenCalledWith(
       'Signed in with ChatGPT as person@example.com. ChatGPT subscription is enabled for Codex models.',
     );

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -8,7 +8,6 @@ import * as logger from '@logger/logUtils';
 import {
   computeModelOptionsData,
   getModelUnavailableReason,
-  invalidateModelOptionsCache,
 } from '@model/computeModelOptions';
 import {
   resolveDirectModelApiKeyProvider,
@@ -22,7 +21,6 @@ import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
 import type { ModelOptionData } from '@shared/schemas';
 import { FAST_FIRST_RESPONSE_HINT } from '@shared/constants/providers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
-import { createDeferred } from '@test/support/asyncTestUtils';
 import { FakeSecrets } from '@test/support/FakePlatform';
 import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 
@@ -51,7 +49,6 @@ async function installAccessPlatform(
     secrets: options.secrets ?? OPENAI_KEY_SECRETS,
   });
   invalidateApiKeyCache();
-  invalidateModelOptionsCache();
 }
 
 function codexSessionSecrets(): Record<string, string> {
@@ -91,7 +88,6 @@ describe('computeModelOptionsData availability', () => {
 
   beforeEach(() => {
     invalidateApiKeyCache();
-    invalidateModelOptionsCache();
     resetCodexCoordinator();
     // The picker reads the app's account plane through the model layer's
     // seam; install the same probes the three hosts install.
@@ -138,7 +134,7 @@ describe('computeModelOptionsData availability', () => {
     expect(model.availability).toBe('missing-key');
   });
 
-  it('warns once per provider when concurrent option contexts cannot read credentials', async () => {
+  it('warns once per provider when the picker cannot read credentials', async () => {
     const readError = new Error('credential store unavailable');
     const secrets = new FakeSecrets();
     vi.spyOn(secrets, 'get').mockRejectedValue(readError);
@@ -149,13 +145,9 @@ describe('computeModelOptionsData availability', () => {
       { secrets },
     );
     invalidateApiKeyCache();
-    invalidateModelOptionsCache();
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
 
-    const [[gpt55], [gpt56]] = await Promise.all([
-      computeModelOptionsData(['gpt55']),
-      computeModelOptionsData(['gpt56']),
-    ]);
+    const [gpt55, gpt56] = await computeModelOptionsData(['gpt55', 'gpt56']);
 
     expect(gpt55.availability).toBe('missing-key');
     expect(gpt56.availability).toBe('missing-key');
@@ -354,62 +346,11 @@ describe('computeModelOptionsData availability', () => {
 
     expect(model.availability).toBe('subscription-access');
   });
-
-  it('does not let invalidated picker checks repopulate caches with stale key state', async () => {
-    const staleRead = createDeferred<string | undefined>();
-    const readStarted = createDeferred();
-    const secrets = new FakeSecrets();
-    let openaiReads = 0;
-    vi.spyOn(secrets, 'get').mockImplementation(async (key) => {
-      if (key !== apiKeySecretName('openai')) {
-        return undefined;
-      }
-      openaiReads += 1;
-      if (openaiReads === 1) {
-        readStarted.resolve();
-        return staleRead.promise;
-      }
-      return secrets.getStored(key);
-    });
-    await installPlatform(
-      {
-        globalState: { [GlobalStateKey.ENABLED_MODELS]: ['gpt55'] },
-      },
-      { secrets },
-    );
-    invalidateApiKeyCache();
-    invalidateModelOptionsCache();
-
-    const staleOptions = computeModelOptionsData(['gpt55']);
-    await readStarted.promise;
-    await secrets.set(apiKeySecretName('openai'), 'sk-fresh');
-    invalidateApiKeyCache();
-    invalidateModelOptionsCache();
-
-    const freshOptions = await computeModelOptionsData(['gpt55']);
-    expect(freshOptions[0].availability).toBe('provider-key');
-
-    staleRead.resolve(undefined);
-    const staleResult = await staleOptions;
-    expect(staleResult[0].availability).toBe('missing-key');
-
-    const subsequentOptions = await computeModelOptionsData(['gpt55']);
-    expect(subsequentOptions).toBe(freshOptions);
-    expect(subsequentOptions[0].availability).toBe('provider-key');
-  });
-
-  it('caches explicit model-list availability', async () => {
-    const first = await computeModelOptionsData(['gpt55']);
-    const second = await computeModelOptionsData(['gpt55']);
-
-    expect(second).toBe(first);
-  });
 });
 
 describe('computeModelOptionsData Kimi Code routing (dual-backend kimi3)', () => {
   beforeEach(() => {
     invalidateApiKeyCache();
-    invalidateModelOptionsCache();
   });
 
   async function kimi3Option(

--- a/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
+++ b/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
@@ -1,9 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  computeModelOptionsData,
-  invalidateModelOptionsCache,
-} from '@model/computeModelOptions';
+import { computeModelOptionsData } from '@model/computeModelOptions';
 import {
   copilotRouteUnavailableReason,
   preferredCopilotRouteModels,
@@ -89,7 +86,6 @@ function failingDiscoveryPort(): LanguageModelPort {
 
 function resetModelCaches(): void {
   invalidateRuntimeModelRegistry();
-  invalidateModelOptionsCache();
   invalidateApiKeyCache();
 }
 

--- a/src/test-kernel/settings/CopilotRoutePreferenceHandler.vitest.ts
+++ b/src/test-kernel/settings/CopilotRoutePreferenceHandler.vitest.ts
@@ -5,7 +5,6 @@ import '@test/support/defaultSessionTestSetup';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-  invalidateModelOptionsCache: vi.fn(),
   invalidateRuntimeModelRegistry: vi.fn(),
   requestRuntimeModelAccess: vi.fn(),
   safeExecuteCommand: vi.fn(async () => undefined),
@@ -28,14 +27,6 @@ vi.mock('@model/copilotRouting', async (original) => {
   return {
     ...actual,
     setCopilotRoutePreference: mocks.setCopilotRoutePreference,
-  };
-});
-
-vi.mock('@model/computeModelOptions', async (original) => {
-  const actual = await original<typeof import('@model/computeModelOptions')>();
-  return {
-    ...actual,
-    invalidateModelOptionsCache: mocks.invalidateModelOptionsCache,
   };
 });
 

--- a/src/tools/setup/UnsetApiKeyTool.ts
+++ b/src/tools/setup/UnsetApiKeyTool.ts
@@ -8,7 +8,6 @@ import {
   invalidateApiKeyCache,
   isApiProvider,
 } from '@model/apiProviders';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { ToolError, type ToolResult } from '@shared/schemas';
 
 // Local file imports
@@ -60,10 +59,9 @@ export class UnsetApiKeyTool extends defineTool({
     }
 
     await setupSecrets.deleteApiKey(provider);
-    // Mirror the manual `texra.setApiKey` command ordering: drop cached model
-    // availability and key-origin lookups so models that just lost their
-    // credential stop appearing selectable, then refresh the status surfaces.
-    invalidateModelOptionsCache();
+    // Mirror the manual `texra.setApiKey` command ordering: drop the cached
+    // key lookups so models that just lost their credential stop appearing
+    // selectable, then refresh the status surfaces.
     invalidateApiKeyCache();
     if (platform.commands) {
       // Credential changes must remain successful when a host cannot refresh


### PR DESCRIPTION
`computeModelOptionsData` wrapped its body in a 5 s `LRUCache` with a workspace-keyed cache key plus a module-level in-flight map, and 29 call lines across the extension, desktop, and CLI hosts kept that cache fresh by hand. Every expensive input one layer down already caches itself with its own invalidation: the per-provider secret read in `apiProviders` (same 5 s TTL and `coalesceAsync`, `invalidateApiKeyCache`) and the Copilot route catalogue in `runtimeModelRegistry` (`invalidateRuntimeModelRegistry`); the remaining inputs are synchronous config and state reads or probe-backed sign-in status owned by the auth coordinators. This PR deletes the LRU, the cache key, the `invalidateModelOptionsCache` export with its 27 direct call lines and 17 imports, and the injected `invalidateModelOptionsCache` field on `ProgressApiKeyRetryControllerDeps` with its two host wirings. Freshness now has exactly two owners, `invalidateApiKeyCache` and `invalidateRuntimeModelRegistry`, both already called at the key and route mutation sites. The module-level `pendingAvailabilityKeyChecks` map becomes a per-context memo inside `buildAvailabilityContext` (as the issue prescribes) so the picker still warns once per provider rather than once per model when the credential store is unreadable (#11508); it has no invalidation and lives for one computation. I read through every one of the 27 call sites and did not find a caller whose premise fails: each one either already sits next to `invalidateApiKeyCache` / `invalidateRuntimeModelRegistry`, writes a synchronous config or state read (prefer-subscription switches, enabled models, OpenRouter toggle, Copilot route preference), or flips a session status that the auth coordinator owns (the two `SupabaseAuthProvider` sites had nothing to invalidate at all). Tests pinning the retired cache go with it; the warn-once regression test now runs one context over two models so its "once per provider" assertion keeps its meaning. One follow-up worth noting, not done here to keep the diff bounded: `refreshSubscriptionPreferenceViews` in the CLI TUI is now a one-line wrapper around `bumpCodexPreferenceVersion` with eight callers.

## Net elements (R6)

- Files: 0 added, 0 deleted, 30 modified (16 production, 14 test)
- `^[+-]export` symbols: -1 (`invalidateModelOptionsCache`), +0
- class/interface/enum declarations: 0 added, 0 removed (one field removed from `ProgressApiKeyRetryControllerDeps`)
- Module-level state: -2 caches (`resolvedModelOptions` LRU, `pendingModelOptions`), -1 in-flight map (`pendingAvailabilityKeyChecks`), -4 module constants, -1 `LRUCache` import, -1 `workspaceRoots` import, -1 `coalesceAsync` import
- Tests: -3 tests that pinned the cache (stale repopulation, explicit-list caching, ConfigForm OpenRouter invalidation), -2 `SupabaseAuthProvider` ordering tests whose only subject was the invalidation call, 13 `vi.mock` entries and about 40 reset/assert lines removed; 0 tests added
- Net LoC (`git diff --stat origin/main`): 30 files changed, 50 insertions(+), 380 deletions(-), net -330

## Consumer counts (R8)

Grepped over `src`, `packages`, `config`, `scripts` after the change:

| Deleted symbol | Callers before | After |
| --- | --- | --- |
| `invalidateModelOptionsCache` | 27 direct call lines + 2 dep wirings + 1 dep field, 17 imports, 13 test files | 0 |
| `MODEL_OPTIONS_CACHE_TTL_MS` / `MODEL_OPTIONS_CACHE_MAX_ENTRIES` | 1 each | 0 |
| `VISIBLE_MODELS_CACHE_KEY` / `EXPLICIT_MODELS_CACHE_PREFIX` | 1 each | 0 |
| `resolvedModelOptions` / `pendingModelOptions` | 2 each | 0 |
| `pendingAvailabilityKeyChecks` | 5 | 0 |
| `hasUsableApiKeyForAvailability` | 1 | 0 |
| `computeModelOptionsDataUncached` | 1 | 0 |

`knip-baseline.json` is untouched: the deleted export had consumers and was never baselined (ratchet reports 284 vs 284).

## Verified

- `npm run typecheck` (exit 0)
- `npm run lint` (clean) and `npx eslint` on the 30 changed files
- `npx prettier --write` on the changed files
- `npx vitest run` on the 14 touched suites plus `TuiApprovalRetry.vitest.ts`: 14 files, 345 tests passed
- `npm test`: 810 files passed, 1 skipped; 9733 tests passed, 6 skipped
- `npm run check:dead-code-ratchet`: OK, no new findings, baseline unchanged
- Grepped all deleted symbols across `src`, `packages`, `config`, `scripts`: 0 references
- No em dashes in added lines

Part of #11865
Closes #11847

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Accepted tradeoff
The warn-once-per-provider dedup for a failed credential read is now per `computeModelOptionsData` call (the memo lives in one `buildAvailabilityContext`), not process-wide. Two concurrent callers each log the warning once on that rare error path; no invalidation is needed for it.