### PR TITLE
fix: two startup crashes after the fold: the synchronous graph open crosses the yield budget, and the TUI reads the view before binding it

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -319,16 +319,18 @@ export async function runChat(
   // it outlives session subscriptions so a later teardown failure cannot leave
   // the user's shell in raw/kitty/mouse mode with a hidden cursor.
   const disposeTerminalRestoreOnExit = installTerminalRestoreOnExit();
+  // The one session state the TUI renders (PRD 10.1): the session's fold
+  // bridged into a signal, with every stream's transcript tier subscribed
+  // for this surface. The TUI shows the whole session, so its subscription
+  // set is the view's stream set. Bound before anything reads the view:
+  // the terminal title below derives its attention state from it on
+  // install.
+  const unbindSessionView = bindSessionView(runtimeSession.view);
   // Cosmetic, but "texra-local" (a local dev binary's own name) or a bare
   // shell prompt in every tab makes a multi-session workflow hard to
   // navigate. Keep the project name while surfacing live attention state.
   const terminalTitleUpdates = installTerminalTitleUpdates(context.cwd);
   disposables.add(terminalTitleUpdates.dispose);
-  // The one session state the TUI renders (PRD 10.1): the session's fold
-  // bridged into a signal, with every stream's transcript tier subscribed
-  // for this surface. The TUI shows the whole session, so its subscription
-  // set is the view's stream set.
-  const unbindSessionView = bindSessionView(runtimeSession.view);
   disposables.add(announceForegroundApprovals());
   let subscribedStreams = '';
   const syncTranscriptSubscriptions = (): void => {

--- a/src/agent/runtime/SessionEvents.ts
+++ b/src/agent/runtime/SessionEvents.ts
@@ -139,11 +139,15 @@ export class SessionEventLog extends Context.Service<
     readonly level: SubscriptionRef.SubscriptionRef<CommitOrdinal>;
     /** Assign each draft its aggregate seq and commit ordinal, append it
      *  under the log's permit, and move the level; returns the last ordinal.
-     *  `at` is the publish clock (C1, informational) unless the caller
-     *  names the moment its rows describe, as the pre-cutover history
-     *  import does. */
+     *  `at` is the publish clock (C1, informational) unless a draft names
+     *  the moment its row describes, as the pre-cutover history import
+     *  does per stream. One call is one permit, one array walk with no
+     *  fiber step per row, and one level move, whatever its length: the
+     *  synchronous graph open (`sessionGraphOpener`) appends the whole
+     *  history in one call and must stay under the scheduler's yield
+     *  budget. */
     readonly appendAll: (
-      drafts: readonly SessionEventDraft[],
+      drafts: ReadonlyArray<SessionEventDraft & { readonly at?: number }>,
       at?: number,
     ) => Effect.Effect<CommitOrdinal>;
     readonly readAll: (
@@ -226,6 +230,7 @@ export class SessionEventLog extends Context.Service<
                   for (const draft of drafts) {
                     const commit = rows.length + 1;
                     const seq = nextSeq(draft.aggregateId);
+                    const rowAt = draft.at ?? at;
                     if (draft.type === 'transcript.entry') {
                       rows.push({
                         type: 'transcript.ref',
@@ -233,7 +238,7 @@ export class SessionEventLog extends Context.Service<
                         entryId: draft.entry.id,
                         seq,
                         commit,
-                        at,
+                        at: rowAt,
                       });
                       continue;
                     }
@@ -245,7 +250,7 @@ export class SessionEventLog extends Context.Service<
                       seq,
                       commit,
                       ownerId: identity.ownerId,
-                      at,
+                      at: rowAt,
                     } as SessionEvent);
                   }
                   const last = rows.length;

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -439,7 +439,7 @@ function sessionGraphOpener(
     // scheduler's yield budget (`Scheduler.MaxOpsBeforeYield` steps per
     // yield) or the open reads as asynchronous and throws. The import
     // appends the whole history in one call for that reason; moving it to
-    // row open (#11865) is what removes the history pass from here.
+    // row open (#11907) is what removes the history pass from here.
     const scope = runtime.runSync(Scope.make());
     const context = runtime.runSync(
       Sessions.contextEffect(

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -276,24 +276,30 @@ function historicalStream(
 }
 
 /**
- * The history import (above): the first layer of a root's graph, one
- * ordered append per stream under the log's permit, parents before
- * children, stamped at the stream's own time, and complete before
+ * The history import (above): the first layer of a root's graph, the whole
+ * history in ONE append under the log's permit, parents before children,
+ * each row stamped at its stream's own time, and complete before
  * `sessionEventsLayer` reads its anchor, so the listing hydrate sees every
  * historical stream and the tail starts after them.
+ *
+ * One call, not one per stream: the graph is built by a synchronous run
+ * (`sessionGraphOpener`), and a fiber yields to the scheduler every
+ * `Scheduler.MaxOpsBeforeYield` steps, so an import that took the permit
+ * and moved the level once per stream crossed that budget on a few
+ * thousand streams and the open read as asynchronous. Building the drafts
+ * is plain code; the log sees one permit, one array walk, one level move.
  */
 const historyImport = (transcripts: StreamLogStore) =>
   Layer.effectDiscard(
     Effect.gen(function* () {
       const log = yield* SessionEventLog;
-      for (const streamId of streamsParentsFirst(transcripts)) {
-        const drafts = historicalStream(transcripts, streamId);
-        if (drafts === null) continue;
-        yield* log.appendAll(
-          drafts,
-          transcripts.getTimestampRange(streamId).last ?? Date.now(),
-        );
-      }
+      const drafts = streamsParentsFirst(transcripts).flatMap((streamId) => {
+        const stream = historicalStream(transcripts, streamId);
+        if (stream === null) return [];
+        const at = transcripts.getTimestampRange(streamId).last ?? Date.now();
+        return stream.map((draft) => ({ ...draft, at }));
+      });
+      if (drafts.length > 0) yield* log.appendAll(drafts);
     }),
   );
 
@@ -428,6 +434,12 @@ function sessionGraphOpener(
   runtime: ManagedRuntime.ManagedRuntime<Sessions, never>,
 ): SessionGraphOpener {
   return (session) => {
+    // The build runs under `runSync`, so everything a root's graph does at
+    // build time, the history import included, must complete inside the
+    // scheduler's yield budget (`Scheduler.MaxOpsBeforeYield` steps per
+    // yield) or the open reads as asynchronous and throws. The import
+    // appends the whole history in one call for that reason; moving it to
+    // row open (#11865) is what removes the history pass from here.
     const scope = runtime.runSync(Scope.make());
     const context = runtime.runSync(
       Sessions.contextEffect(


### PR DESCRIPTION
Part of #11861. Hotfix for two startup crashes on main since the one-fold merges (#11881, #11883, #11884): `texra chat` in any workspace with history dies before its prompt. The whole-history import that remains is the shape #11823 rules out and is filed as #11907, queued right behind this.

## Crash 1: the synchronous graph open reads as asynchronous

```
TeXRA CLI failed: AsyncFiberError: An asynchronous Effect was executed with Effect.runSync
    at Object.runSync ... at openSessionGraph ... at new SessionHandle ...
```

`sessionGraphOpener` builds the root graph under `runtime.runSync`. `historyImport` appended once per stream, each call a permit cycle plus a `SubscriptionRef.set` on the level. A fiber yields to the scheduler every `Scheduler.MaxOpsBeforeYield` (2,048) steps; with a few thousand streams the build crossed that budget enough times that the sync dispatcher no longer had the resumption flushed when `runSync` polled the exit, so the open threw while the import fiber kept running in the background.

Evidence: an instrumented build printed the crash between stream 1,000 and 1,500 of 3,989 with the import's own "done" line arriving afterwards; the same open completed with `MaxOpsBeforeYield` raised to `MAX_SAFE_INTEGER`. The liveness probe is already `Effect.forkScoped` and is not on the synchronous path.

Fix: the import builds every stream's drafts in plain code, each stamped with its stream's own `at`, and appends them in ONE `appendAll`. Op shape per open: one permit, one array walk with no fiber step per row, one level move. `appendAll` accepts a per-draft `at` (the documented history-import exception, now per stream) and keeps its signature otherwise. The opener carries a comment naming the yield-budget invariant and pointing at #11907 as what removes the history pass from the build.

## Crash 2: the session view is read before it is bound

```
TeXRA CLI failed: The session view is not bound: call bindSessionView(session.view) before rendering the TUI.
```

`runChatTui` called `installTerminalTitleUpdates(context.cwd)`, which subscribes to `sessionView()` and synchronizes on install, five lines before `bindSessionView(runtimeSession.view)`. Masked behind crash 1 on populated workspaces. Pure reorder: bind first; teardown order (disposables, then unbind) unchanged.

## Measured

`texra chat --agent research --model deepseekproT` in the TNLean workspace (3,989 summary streams), launch to input prompt, tmux recipe, same machine:

| Build | Time to prompt |
| --- | --- |
| main at 60534e9a9f (S1 complete, before the fold) | 1.6 s |
| main at 9b2e9f7b8b (fold merged) | crash |
| this branch on the lane 4 base, run 1 / run 2 | 1.6 s / 1.6 s |
| this branch rebased on main (ca83046d32), run 1 / run 2 | 2.3 s (typecheck running beside it) / 1.7 s |

## Why nothing caught it

The TUI scenarios bind the view through the harness and run on an empty workspace, so the real `runChat` startup over a populated history is never exercised, and an empty history keeps the import under the yield budget. Recorded on #11862 as a follow-up (a real-runtime startup smoke against a seeded workspace, if it earns its place); no scenario added here.

## Verification

Typecheck, lint, dead-code ratchet, the session and CLI suites on the rebased head; the TNLean runs above on the rebased build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
