### PR TITLE
fix(cli): the real-runtime text run ends with the shared completed label again

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1472,12 +1472,6 @@
       "name": "resolveStateSettingWrite"
     },
     {
-      "file": "src/shared/streams/streamStatusDisplay.ts",
-      "category": "production-dead",
-      "kind": "types",
-      "name": "StreamStatusLabelStyle"
-    },
-    {
       "file": "src/shared/subagentFollowup.ts",
       "category": "production-dead",
       "kind": "exports",

--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -808,12 +808,14 @@ function validateRunCommand() {
       text.stdout.trim() === copiedOutputPath,
       'text run output should print the filesystem copy path when --output is used',
     );
+    // The progress line prints the fold's status label from the one table in
+    // src/shared/streams/streamStatusDisplay.ts (STREAM_STATUS_LABELS).
     assert(
-      text.stderr.includes(' · completed ·'),
+      text.stderr.includes(' · Completed ·'),
       `text run progress should end with the shared completed label\nstderr:\n${text.stderr}`,
     );
     assert(
-      !text.stderr.includes(' · stopped ·'),
+      !text.stderr.includes(' · Stopped ·'),
       `a successful text run should not report the cancelled stopped label\nstderr:\n${text.stderr}`,
     );
 

--- a/src/shared/streams/streamStatusDisplay.ts
+++ b/src/shared/streams/streamStatusDisplay.ts
@@ -50,40 +50,24 @@ function streamStatusDisplayKey(
   return substate ?? status;
 }
 
-// cli and cliCompact share every label except the STARTING ellipsis, so
-// cliCompact is derived from cli rather than hand-synced.
-const cliStreamStatusLabels: Record<StreamStatusCopyKey, string> = {
-  [STREAM_SUBSTATE.STARTING]: 'starting\u2026',
-  [STREAM_PHASE.RUNNING]: 'running',
-  [STREAM_PHASE.FAILED]: 'error',
-  [STREAM_PHASE.COMPLETED]: 'completed',
-  [STREAM_PHASE.CANCELLED]: 'stopped',
-  ready: 'ready',
-  [STREAM_PHASE.WAITING]: 'idle',
-  [STREAM_SUBSTATE.RESUMING]: 'resuming',
-  [STREAM_LIFECYCLE_UNAVAILABLE]: 'unavailable',
-  [STREAM_DISPLAY_INTERRUPTED]: 'interrupted',
-} as const;
-
-const STREAM_STATUS_LABELS = {
-  cli: cliStreamStatusLabels,
-  cliCompact: {
-    ...cliStreamStatusLabels,
-    [STREAM_SUBSTATE.STARTING]: 'starting',
-  },
-  progressHeader: {
-    [STREAM_SUBSTATE.STARTING]: 'Initializing',
-    [STREAM_PHASE.RUNNING]: 'Running',
-    [STREAM_PHASE.FAILED]: 'Error',
-    [STREAM_PHASE.COMPLETED]: 'Completed',
-    [STREAM_PHASE.CANCELLED]: 'Stopped',
-    ready: 'Ready',
-    [STREAM_PHASE.WAITING]: 'Idle',
-    [STREAM_SUBSTATE.RESUMING]: 'Resuming',
-    [STREAM_LIFECYCLE_UNAVAILABLE]: 'Unavailable',
-    [STREAM_DISPLAY_INTERRUPTED]: 'Interrupted',
-  },
-} as const;
+/**
+ * The one status label table (PRD one-fold-three-renderers, G4): the fold
+ * reads it into `StreamView.statusLabel`, and every renderer prints that
+ * word as is. `packages/cli/scripts/validate-run.mjs` pins the completed and
+ * stopped words from here against the real headless run.
+ */
+const STREAM_STATUS_LABELS: Record<StreamStatusCopyKey, string> = {
+  [STREAM_SUBSTATE.STARTING]: 'Initializing',
+  [STREAM_PHASE.RUNNING]: 'Running',
+  [STREAM_PHASE.FAILED]: 'Error',
+  [STREAM_PHASE.COMPLETED]: 'Completed',
+  [STREAM_PHASE.CANCELLED]: 'Stopped',
+  ready: 'Ready',
+  [STREAM_PHASE.WAITING]: 'Idle',
+  [STREAM_SUBSTATE.RESUMING]: 'Resuming',
+  [STREAM_LIFECYCLE_UNAVAILABLE]: 'Unavailable',
+  [STREAM_DISPLAY_INTERRUPTED]: 'Interrupted',
+};
 
 /**
  * The one status-to-tone mapping (PRD one-fold-three-renderers, G4 and 15):
@@ -130,7 +114,7 @@ export function streamStatusCopy(
     ? STREAM_DISPLAY_INTERRUPTED
     : streamStatusDisplayKey(status, options.substate);
   return {
-    statusLabel: STREAM_STATUS_LABELS.progressHeader[key],
+    statusLabel: STREAM_STATUS_LABELS[key],
     tone: STREAM_STATUS_TONES[key],
   };
 }
@@ -152,10 +136,7 @@ export function streamUnreadableMessage(cause: string): string {
   return `Could not read this run's state: ${cause}. Delete removes it.`;
 }
 
-export type StreamStatusLabelStyle = keyof typeof STREAM_STATUS_LABELS;
-
 interface FormatStreamStatusLabelOptions {
-  readonly style?: StreamStatusLabelStyle;
   readonly missingLabel?: string;
   readonly substate?: StreamSubstate;
 }
@@ -180,14 +161,11 @@ export function formatStreamStatusLabel(
   options: FormatStreamStatusLabelOptions = {},
 ): string | undefined {
   if (status === undefined) return options.missingLabel;
-  const style = options.style ?? 'progressHeader';
-  const key = streamStatusDisplayKey(status, options.substate);
-  return STREAM_STATUS_LABELS[style][key];
+  return STREAM_STATUS_LABELS[streamStatusDisplayKey(status, options.substate)];
 }
 
 /**
- * One-stop label + display-key derivation for the progress-header style.
- * `formatStreamStatusLabel(..., { style: 'progressHeader' })` and
+ * One-stop label + display-key derivation. `formatStreamStatusLabel` and
  * `streamStatusDisplayKey` are the same status→vocabulary lookup seen from
  * two sides (a label and the key that drives icon/state styling), so callers
  * that need both compute them together instead of double-parsing the status.

--- a/src/test-kernel/shared/SharedStreams.vitest.ts
+++ b/src/test-kernel/shared/SharedStreams.vitest.ts
@@ -15,7 +15,6 @@ import {
   formatStageLabel,
   formatStreamStatusLabel,
   progressHeaderStatus,
-  type StreamStatusLabelStyle,
 } from '@shared/streams/streamStatusDisplay';
 
 // ---------------------------------------------------------------------------
@@ -63,44 +62,24 @@ describe('formatStageLabel', () => {
 });
 
 describe('stream status display labels', () => {
-  const wordingCases: Array<
-    [StreamStatusLabelStyle, StreamLifecycleStatus, string]
-  > = [
-    ['cli', STREAM_PHASE.WAITING, 'idle'],
-    ['cliCompact', STREAM_PHASE.WAITING, 'idle'],
-    ['progressHeader', STREAM_PHASE.WAITING, 'Idle'],
-    ['cliCompact', STREAM_PHASE.COMPLETED, 'completed'],
-    ['progressHeader', STREAM_PHASE.COMPLETED, 'Completed'],
-    ['cliCompact', STREAM_PHASE.CANCELLED, 'stopped'],
-    ['progressHeader', STREAM_PHASE.CANCELLED, 'Stopped'],
-    ['cli', STREAM_STATUS.READY, 'ready'],
-    ['progressHeader', STREAM_STATUS.READY, 'Ready'],
+  const wordingCases: Array<[StreamLifecycleStatus, string]> = [
+    [STREAM_PHASE.WAITING, 'Idle'],
+    [STREAM_PHASE.COMPLETED, 'Completed'],
+    [STREAM_PHASE.CANCELLED, 'Stopped'],
+    [STREAM_STATUS.READY, 'Ready'],
   ];
 
-  it.each(wordingCases)(
-    'preserves %s wording: %s -> "%s"',
-    (style, status, label) => {
-      expect(formatStreamStatusLabel(status, { style })).toBe(label);
-    },
-  );
+  it.each(wordingCases)('preserves wording: %s -> "%s"', (status, label) => {
+    expect(formatStreamStatusLabel(status)).toBe(label);
+  });
 
-  const substateWordingCases: Array<[StreamStatusLabelStyle, string]> = [
-    ['cli', 'starting\u2026'],
-    ['cliCompact', 'starting'],
-    ['progressHeader', 'Initializing'],
-  ];
-
-  it.each(substateWordingCases)(
-    'preserves %s STARTING wording: "%s"',
-    (style, label) => {
-      expect(
-        formatStreamStatusLabel(STREAM_PHASE.RUNNING, {
-          style,
-          substate: STREAM_SUBSTATE.STARTING,
-        }),
-      ).toBe(label);
-    },
-  );
+  it('preserves the STARTING wording', () => {
+    expect(
+      formatStreamStatusLabel(STREAM_PHASE.RUNNING, {
+        substate: STREAM_SUBSTATE.STARTING,
+      }),
+    ).toBe('Initializing');
+  });
 
   it('supports an explicit missing label', () => {
     expect(formatStreamStatusLabel(undefined, { missingLabel: '-' })).toBe('-');
@@ -109,10 +88,9 @@ describe('stream status display labels', () => {
   it('uses substate display keys for current running phases', () => {
     expect(
       formatStreamStatusLabel(STREAM_PHASE.RUNNING, {
-        style: 'cli',
         substate: STREAM_SUBSTATE.RESUMING,
       }),
-    ).toBe('resuming');
+    ).toBe('Resuming');
     expect(
       progressHeaderStatus(STREAM_PHASE.RUNNING, STREAM_SUBSTATE.RESUMING)
         .displayKey,


### PR DESCRIPTION
## Root cause

The headless progress line of `texra run --print` prints the fold's status label (`StreamView.statusLabel`), read from the one title-case table in `src/shared/streams/streamStatusDisplay.ts`. The run therefore ends with `[r2/2] · polish paper.tex · Completed · 0s`, while `packages/cli/scripts/validate-run.mjs` still asserted the pre-fold lowercase `' · completed ·'` (and `' · stopped ·'`).

## Introducing commit

47b7e8522a (#11881, PRD lanes 1 to 3): lane 3 replaced the renderer's `formatStreamStatusLabel(status, { style: 'cli' })` with the fold's `root.statusLabel`, which `streamStatusCopy` reads from the title-case vocabulary. #11883 did not change the label further.

## Why PR CI missed it

The "runtime validation (linux)" job is gated `if: github.event_name != 'pull_request'`; it runs only on push to main, manual dispatch, merge groups, and the nightly schedule. Every pull request was green; every push to main since 47b7e8522a failed this job (latest: run 33983248009 on 48c5cca091).

## Fix

The product change was deliberate (the fold's one status vocabulary), so the validator now pins the words of that table. The lowercase `cli` and `cliCompact` vocabularies lost their last two producers in the same commit (`sessionStatus.ts` and `runProgressRenderer.ts` both read the fold now), which made them a dead second label table: `STREAM_STATUS_LABELS` collapses to the one table, the `style` option and `StreamStatusLabelStyle` go with it, and the knip baseline shrinks by that entry. The existing `SharedStreams.vitest.ts` rows for the retired styles are pruned. No fallback, no second label, no new tests.

## Validation

- `pnpm --filter @texra-ai/cli validate:run` (the CI command): reproduced the failure on origin/main, passes after the fix
- `npm run typecheck`, `npm run lint`
- `npx vitest run src/test-kernel/shared/SharedStreams.vitest.ts src/test-kernel/cli`: 135 files, 2215 passed
- `npm run check:dead-code-ratchet`: OK, baseline shrunk by one entry

Part of #11861

🤖 Generated with [Claude Code](https://claude.com/claude-code)
