### PR TITLE
refactor(session): derive the listing tier from the summary tier at subscribe; delete the history import

### DIFF
--- a/src/agent/runtime/SessionEvents.ts
+++ b/src/agent/runtime/SessionEvents.ts
@@ -53,7 +53,11 @@ import {
   type SessionCursor,
 } from '@shared/session/sessionEvents';
 import type { StreamLogStore } from '@transcript/StreamLogStore';
-import { historicalListing, isHistoricalStream } from './historicalListing';
+import {
+  HISTORICAL_COMMITS_PER_STREAM,
+  historicalListing,
+  isHistoricalStream,
+} from './historicalListing';
 
 const logger = createLog('sessionEvents');
 
@@ -172,15 +176,26 @@ export class SessionEventLog extends Context.Service<
       SessionEventLog,
       Effect.gen(function* () {
         const identity = yield* ProcessIdentity;
-        const level = yield* SubscriptionRef.make<CommitOrdinal>(0);
-        const gate = yield* Semaphore.make(1);
-        const rows: LogRow[] = [];
         // The listing tier's membership (`historicalListing.ts`): the
         // streams that exist as this log is built. One key-set copy, no
-        // facts read; the facts are read when a reader subscribes.
+        // facts read; the facts are read when a reader first subscribes and
+        // held from then on. Their commits are reserved below the log's
+        // first row, so a log commit is the row's 1-based position above
+        // `reserved`, and the level starts there.
         const historical: ReadonlySet<StreamTabId> = new Set(
           transcripts.keys(),
         );
+        const reserved = historical.size * HISTORICAL_COMMITS_PER_STREAM;
+        let listing: SessionEvent[] | undefined;
+        const historicalRows = (): SessionEvent[] =>
+          (listing ??= historicalListing(
+            transcripts,
+            historical,
+            identity.ownerId,
+          ));
+        const level = yield* SubscriptionRef.make<CommitOrdinal>(reserved);
+        const gate = yield* Semaphore.make(1);
+        const rows: LogRow[] = [];
         // The sequence table (C1, C2): one seq counter per aggregate for
         // every row it holds, and the aggregates a tombstone closed. The
         // transcript rows already in the store when an aggregate's first
@@ -232,7 +247,7 @@ export class SessionEventLog extends Context.Service<
               Effect.uninterruptible(
                 Effect.gen(function* () {
                   for (const draft of drafts) {
-                    const commit = rows.length + 1;
+                    const commit = reserved + rows.length + 1;
                     const seq = nextSeq(draft.aggregateId);
                     if (draft.type === 'transcript.entry') {
                       rows.push({
@@ -256,39 +271,38 @@ export class SessionEventLog extends Context.Service<
                       at,
                     } as SessionEvent);
                   }
-                  const last = rows.length;
+                  const last = reserved + rows.length;
                   yield* SubscriptionRef.set(level, last);
                   return last;
                 }),
               ),
             ),
-          // `commit` is the row's 1-based position, so the rows above a
-          // commit are the slice past it.
+          // `commit` is the row's 1-based position above `reserved`, so
+          // the rows above a commit are the slice past it; a cursor inside
+          // the listing tier's space reads every log row.
           readAll: (fromCommit) =>
             Stream.unwrap(
               Effect.sync(() =>
                 Stream.fromIterable(
-                  rows.slice(fromCommit).flatMap((row) => {
-                    const event = materialize(row);
-                    return event === null ? [] : [event];
-                  }),
+                  rows
+                    .slice(Math.max(0, fromCommit - reserved))
+                    .flatMap((row) => {
+                      const event = materialize(row);
+                      return event === null ? [] : [event];
+                    }),
                 ),
               ),
             ),
           // The listing tier is the summary tier's plus the log's own
           // listing rows: every historical stream derived from the store
-          // at read time at commit 0, then the facts this process appended,
-          // which outrank them per key under the fold's commit order. No
-          // history is walked at graph open and no history row is held.
+          // on the first read, in the reserved commit space, then the facts
+          // this process appended, which outrank them per key under the
+          // fold's commit order. No history is walked at graph open.
           readListing: () =>
             Stream.unwrap(
               Effect.sync(() =>
                 Stream.fromIterable([
-                  ...historicalListing(
-                    transcripts,
-                    historical,
-                    identity.ownerId,
-                  ),
+                  ...historicalRows(),
                   ...listingRows(rows),
                 ]),
               ),

--- a/src/agent/runtime/SessionEvents.ts
+++ b/src/agent/runtime/SessionEvents.ts
@@ -53,6 +53,7 @@ import {
   type SessionCursor,
 } from '@shared/session/sessionEvents';
 import type { StreamLogStore } from '@transcript/StreamLogStore';
+import { historicalListing, isHistoricalStream } from './historicalListing';
 
 const logger = createLog('sessionEvents');
 
@@ -126,12 +127,15 @@ function listingRows(rows: readonly LogRow[]): SessionEvent[] {
  * wakes nobody cannot exist. The writer of every row is this process (C5),
  * stamped here from `ProcessIdentity`; no caller passes it.
  *
- * The memory layer is the pre-cutover store, and its transcript tier is the
- * transcript store's: `aggregate(id, fromSeq)` reads that store's rows for
- * the stream (the store's row `seqNo` is the aggregate seq), and the tail
- * holds a transcript row's place only, materialized from the store when
- * read. Nothing here reaches disk, and the cutover replaces this layer with
- * the SQLite write path under the same shape.
+ * The memory layer is the pre-cutover store, and two of its tiers are the
+ * transcript store's: the listing tier derives every historical stream from
+ * the store's resident summary tier when a reader subscribes
+ * (`historicalListing.ts`; nothing is walked at graph open, nothing held),
+ * and the transcript tier reads that store's rows for a subscribed stream
+ * (`aggregate(id, fromSeq)`, the store's row `seqNo` is the aggregate seq),
+ * while the tail holds a transcript row's place only, materialized from the
+ * store when read. Nothing here reaches disk, and the cutover replaces this
+ * layer with the SQLite write path under the same shape.
  */
 export class SessionEventLog extends Context.Service<
   SessionEventLog,
@@ -139,15 +143,9 @@ export class SessionEventLog extends Context.Service<
     readonly level: SubscriptionRef.SubscriptionRef<CommitOrdinal>;
     /** Assign each draft its aggregate seq and commit ordinal, append it
      *  under the log's permit, and move the level; returns the last ordinal.
-     *  `at` is the publish clock (C1, informational) unless a draft names
-     *  the moment its row describes, as the pre-cutover history import
-     *  does per stream. One call is one permit, one array walk with no
-     *  fiber step per row, and one level move, whatever its length: the
-     *  synchronous graph open (`sessionGraphOpener`) appends the whole
-     *  history in one call and must stay under the scheduler's yield
-     *  budget. */
+     *  `at` is the publish clock (C1, informational). */
     readonly appendAll: (
-      drafts: ReadonlyArray<SessionEventDraft & { readonly at?: number }>,
+      drafts: readonly SessionEventDraft[],
       at?: number,
     ) => Effect.Effect<CommitOrdinal>;
     readonly readAll: (
@@ -158,9 +156,9 @@ export class SessionEventLog extends Context.Service<
       aggregateId: AggregateId,
       fromSeq: number,
     ) => Stream.Stream<SessionEvent>;
-    /** Whether the aggregate's sequence row exists and is not closed (C2,
-     *  C9): a stream exists from the publish of its `run.start` until its
-     *  tombstone. Synchronous at publish: `appendAll` crosses no
+    /** Whether the aggregate exists and is not closed (C2, C9): a stream
+     *  exists from its listing (the summary tier's, or the publish of its
+     *  `run.start`) until its tombstone. Synchronous at publish: `appendAll` crosses no
      *  asynchronous boundary, so the fork `SessionHandle.publish` makes has
      *  minted its rows before that call returns, ahead of every fold. */
     readonly exists: (aggregateId: AggregateId) => Effect.Effect<boolean>;
@@ -177,6 +175,12 @@ export class SessionEventLog extends Context.Service<
         const level = yield* SubscriptionRef.make<CommitOrdinal>(0);
         const gate = yield* Semaphore.make(1);
         const rows: LogRow[] = [];
+        // The listing tier's membership (`historicalListing.ts`): the
+        // streams that exist as this log is built. One key-set copy, no
+        // facts read; the facts are read when a reader subscribes.
+        const historical: ReadonlySet<StreamTabId> = new Set(
+          transcripts.keys(),
+        );
         // The sequence table (C1, C2): one seq counter per aggregate for
         // every row it holds, and the aggregates a tombstone closed. The
         // transcript rows already in the store when an aggregate's first
@@ -230,7 +234,6 @@ export class SessionEventLog extends Context.Service<
                   for (const draft of drafts) {
                     const commit = rows.length + 1;
                     const seq = nextSeq(draft.aggregateId);
-                    const rowAt = draft.at ?? at;
                     if (draft.type === 'transcript.entry') {
                       rows.push({
                         type: 'transcript.ref',
@@ -238,7 +241,7 @@ export class SessionEventLog extends Context.Service<
                         entryId: draft.entry.id,
                         seq,
                         commit,
-                        at: rowAt,
+                        at,
                       });
                       continue;
                     }
@@ -250,7 +253,7 @@ export class SessionEventLog extends Context.Service<
                       seq,
                       commit,
                       ownerId: identity.ownerId,
-                      at: rowAt,
+                      at,
                     } as SessionEvent);
                   }
                   const last = rows.length;
@@ -272,9 +275,23 @@ export class SessionEventLog extends Context.Service<
                 ),
               ),
             ),
+          // The listing tier is the summary tier's plus the log's own
+          // listing rows: every historical stream derived from the store
+          // at read time at commit 0, then the facts this process appended,
+          // which outrank them per key under the fold's commit order. No
+          // history is walked at graph open and no history row is held.
           readListing: () =>
             Stream.unwrap(
-              Effect.sync(() => Stream.fromIterable(listingRows(rows))),
+              Effect.sync(() =>
+                Stream.fromIterable([
+                  ...historicalListing(
+                    transcripts,
+                    historical,
+                    identity.ownerId,
+                  ),
+                  ...listingRows(rows),
+                ]),
+              ),
             ),
           // The transcript tier is the store's: its rows for the stream
           // above `fromSeq`, read once without adding residency, stamped
@@ -306,9 +323,19 @@ export class SessionEventLog extends Context.Service<
                 );
               }),
             ),
+          // A stream exists from its listing (a historical stream the
+          // summary tier lists, or a `run.start` this process appended)
+          // until its tombstone.
           exists: (aggregateId) =>
             Effect.sync(
-              () => seqs.has(aggregateId) && !closed.has(aggregateId),
+              () =>
+                !closed.has(aggregateId) &&
+                (seqs.has(aggregateId) ||
+                  isHistoricalStream(
+                    transcripts,
+                    historical,
+                    aggregateId as StreamTabId,
+                  )),
             ),
         };
       }),

--- a/src/agent/runtime/historicalListing.ts
+++ b/src/agent/runtime/historicalListing.ts
@@ -2,10 +2,13 @@
  * The pre-cutover listing tier: every historical stream of a root, derived
  * from the transcript store's always-resident summary tier when a reader
  * subscribes (`SessionEventLog.memoryLayer`, `readListing`), never appended
- * to the log and never walked at graph open. The rows carry commit 0 and
- * seq 0: below every log row, so a live `run.start`, a tombstone, or any
- * later fact for the same stream outranks them under the fold's per-key
- * commit order, and a second replay of the same rows folds nothing.
+ * to the log and never walked at graph open. The rows occupy the commit
+ * space the log reserves below its first row, `HISTORICAL_COMMITS_PER_STREAM`
+ * per historical stream in parents-first, older-first order, so `createdAt`
+ * keeps the transcript's creation order, every log row outranks them under
+ * the fold's per-key commit order, and a second replay of the same rows
+ * folds nothing. Their seq is the row's 1-based position within its stream:
+ * listing facts dedupe by commit, and no listing row moves `view.folded`.
  *
  * Historical means "existed when the graph opened": the membership is the
  * summary tier's key set taken once at the log's build, and a stream born
@@ -40,26 +43,41 @@ export function isHistoricalStream(
   return meta?.executionId !== undefined && meta.agentCategory !== undefined;
 }
 
+/** The commits the log reserves per historical stream: one per listing
+ *  fact a summary can carry (`run.start`, `run.config`, description). */
+export const HISTORICAL_COMMITS_PER_STREAM = 3;
+
 /**
  * The listing rows of every historical stream, parents before children and
  * older before newer, each stamped at its stream's own last write. Plain
  * code over the resident summary tier: no permit, no log row, no fiber step
- * per stream.
+ * per stream. Derived once per log, on the first read: the rows of a stream
+ * the store no longer holds are dropped then, and a stream deleted later
+ * leaves through its tombstone, which outranks its listing rows.
  */
 export function historicalListing(
   transcripts: StreamLogStore,
   historical: ReadonlySet<StreamTabId>,
   ownerId: OwnerId,
 ): SessionEvent[] {
-  return streamsParentsFirst(transcripts, historical).flatMap((streamId) => {
-    const drafts = historicalStream(transcripts, streamId);
-    if (drafts === null) return [];
-    const at = transcripts.getTimestampRange(streamId).last ?? Date.now();
-    return drafts.map(
-      (draft): SessionEvent =>
-        ({ ...draft, seq: 0, commit: 0, ownerId, at }) as SessionEvent,
-    );
-  });
+  return streamsParentsFirst(transcripts, historical).flatMap(
+    (streamId, index) => {
+      const drafts = historicalStream(transcripts, streamId);
+      if (drafts === null) return [];
+      const at = transcripts.getTimestampRange(streamId).last ?? Date.now();
+      const base = index * HISTORICAL_COMMITS_PER_STREAM;
+      return drafts.map(
+        (draft, position): SessionEvent =>
+          ({
+            ...draft,
+            seq: position + 1,
+            commit: base + position + 1,
+            ownerId,
+            at,
+          }) as SessionEvent,
+      );
+    },
+  );
 }
 
 /** The summary tier's streams, parents before children and older before

--- a/src/agent/runtime/historicalListing.ts
+++ b/src/agent/runtime/historicalListing.ts
@@ -1,0 +1,163 @@
+/**
+ * The pre-cutover listing tier: every historical stream of a root, derived
+ * from the transcript store's always-resident summary tier when a reader
+ * subscribes (`SessionEventLog.memoryLayer`, `readListing`), never appended
+ * to the log and never walked at graph open. The rows carry commit 0 and
+ * seq 0: below every log row, so a live `run.start`, a tombstone, or any
+ * later fact for the same stream outranks them under the fold's per-key
+ * commit order, and a second replay of the same rows folds nothing.
+ *
+ * Historical means "existed when the graph opened": the membership is the
+ * summary tier's key set taken once at the log's build, and a stream born
+ * after that enters the view through its own `run.start` row alone. The
+ * membership is what keeps the two tiers apart. A live stream's summary is
+ * projected from that same row, so a replay between the projection and the
+ * fold would otherwise mint it from here first, at commit 0, and its real
+ * row would then land on a known stream and leave `createdAt` at 0, which
+ * is a stream no renderer attached after open treats as new.
+ */
+import { createLog } from '@logger/logUtils';
+import {
+  USER_FOLLOW_UP_SUPPORT,
+  type OwnerId,
+  type SessionEvent,
+  type SessionEventDraft,
+  type StreamTabId,
+} from '@shared/schemas';
+import type { StreamLogStore } from '@transcript/StreamLogStore';
+
+const log = createLog('historicalListing');
+
+/** Whether the summary tier can list this stream: it names an execution
+ *  and a category (a summary predating the mirror names neither). */
+export function isHistoricalStream(
+  transcripts: StreamLogStore,
+  historical: ReadonlySet<StreamTabId>,
+  streamId: StreamTabId,
+): boolean {
+  if (!historical.has(streamId)) return false;
+  const meta = transcripts.getSummaryMeta(streamId);
+  return meta?.executionId !== undefined && meta.agentCategory !== undefined;
+}
+
+/**
+ * The listing rows of every historical stream, parents before children and
+ * older before newer, each stamped at its stream's own last write. Plain
+ * code over the resident summary tier: no permit, no log row, no fiber step
+ * per stream.
+ */
+export function historicalListing(
+  transcripts: StreamLogStore,
+  historical: ReadonlySet<StreamTabId>,
+  ownerId: OwnerId,
+): SessionEvent[] {
+  return streamsParentsFirst(transcripts, historical).flatMap((streamId) => {
+    const drafts = historicalStream(transcripts, streamId);
+    if (drafts === null) return [];
+    const at = transcripts.getTimestampRange(streamId).last ?? Date.now();
+    return drafts.map(
+      (draft): SessionEvent =>
+        ({ ...draft, seq: 0, commit: 0, ownerId, at }) as SessionEvent,
+    );
+  });
+}
+
+/** The summary tier's streams, parents before children and older before
+ *  newer, so the fold's creation order is the transcript's: a child folded
+ *  before its parent exists is re-rooted for good (PRD 5.2, `ancestors`). */
+function streamsParentsFirst(
+  transcripts: StreamLogStore,
+  known: ReadonlySet<StreamTabId>,
+): StreamTabId[] {
+  // A stream deleted since the membership was taken has no summary left and
+  // is not listed; the marker then folds its removal.
+  let remaining = [...known]
+    .filter((id) => transcripts.has(id))
+    .sort(
+      (a, b) =>
+        (transcripts.getTimestampRange(a).first ?? 0) -
+        (transcripts.getTimestampRange(b).first ?? 0),
+    );
+  const ordered: StreamTabId[] = [];
+  const placed = new Set<StreamTabId>();
+  while (remaining.length > 0) {
+    const next = remaining.filter((id) => {
+      const parent = transcripts.getSummaryMeta(id)?.parentStreamId;
+      return !parent || !known.has(parent) || placed.has(parent);
+    });
+    if (next.length === 0) {
+      // A parent cycle is a corrupt summary tier; import the rest as roots.
+      log.warn(
+        `Stream summaries form a parent cycle among ${remaining.join(', ')}; importing them as top-level streams`,
+      );
+      ordered.push(...remaining);
+      break;
+    }
+    for (const id of next) placed.add(id);
+    ordered.push(...next);
+    remaining = remaining.filter((id) => !placed.has(id));
+  }
+  return ordered;
+}
+
+/**
+ * Pre-cutover hydration: one historical stream's facts from the summary
+ * tier alone. `run.start` carries the summary's identity (nullish where it
+ * has none, contract C3), the launch facts the summary recorded, and the
+ * description. The summary holds no status and no holder: a historical
+ * stream's outcome is the cutover's event table, or it is not in the
+ * listing; nothing here reads an execution record or a lease. A summary
+ * that names no execution or no category predates the summary mirror and
+ * is reported and skipped rather than given a fabricated launch fact.
+ */
+function historicalStream(
+  transcripts: StreamLogStore,
+  streamId: StreamTabId,
+): SessionEventDraft[] | null {
+  const meta = transcripts.getSummaryMeta(streamId);
+  if (meta?.executionId === undefined) {
+    log.warn(
+      `Stream ${streamId} has no execution in its summary; not imported into the session view`,
+    );
+    return null;
+  }
+  if (meta.agentCategory === undefined) {
+    log.warn(
+      `Stream ${streamId} has no category in its summary; not imported into the session view`,
+    );
+    return null;
+  }
+  const { executionId } = meta;
+  const parent = meta.parentStreamId;
+  const drafts: SessionEventDraft[] = [
+    {
+      type: 'run.start',
+      aggregateId: streamId,
+      executionId,
+      identity: meta.identity ?? null,
+      userFollowUpSupport:
+        meta.userFollowUpSupport ?? USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
+      category: meta.agentCategory,
+      isRemote: false,
+      worktree: null,
+      parentStreamId:
+        parent && transcripts.has(parent as StreamTabId) ? parent : null,
+    },
+  ];
+  if (meta.model !== undefined || meta.command !== undefined) {
+    drafts.push({
+      type: 'run.config',
+      aggregateId: streamId,
+      executionId,
+      config: { model: meta.model, instruction: meta.command },
+    });
+  }
+  if (meta.description) {
+    drafts.push({
+      type: 'updateStreamDescription',
+      aggregateId: streamId,
+      description: meta.description,
+    });
+  }
+  return drafts;
+}

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -55,12 +55,7 @@ import {
   type ProcessRuntime,
 } from '@platform/processRuntime';
 import type { WorkspaceRoots as HostWorkspaceRoots } from '@platform/workspaceRoots';
-import {
-  USER_FOLLOW_UP_SUPPORT,
-  type OwnerId,
-  type SessionEventDraft,
-  type StreamTabId,
-} from '@shared/schemas';
+import { type OwnerId, type StreamTabId } from '@shared/schemas';
 import { ProcessIdentity, SessionEvents } from '@shared/session/sessionEvents';
 import type { SessionView } from '@shared/session/sessionView';
 import { isTerminalOutcomePhase } from '@shared/streams/streamStatus';

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -49,7 +49,6 @@ import {
   type SessionGraph,
   type SessionGraphOpener,
 } from '@agent/runtime/sessionGraph';
-import { createLog } from '@logger/logUtils';
 import {
   initProcessRuntime,
   type ProcessRuntime,
@@ -74,8 +73,6 @@ import {
 import { SessionViewService } from './SessionView';
 import { sessionInputsLayer } from './sessionInputs';
 import { WorkspaceRoots } from './WorkspaceRoots';
-
-const log = createLog('sessionLayer');
 
 /** How often the owners the view names are re-probed (PRD 5.2). */
 const OWNER_LIVENESS_PROBE_INTERVAL = '5 seconds';

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -11,14 +11,13 @@
  * on dispose, so two handles on one root share the graph and never each
  * other's session.
  *
- * Two pieces of this file exist only until the persistence cutover and are
- * marked so: the hydration importer, the first layer of the root graph,
- * which reads the summary tier once per root and seeds the memory log with
- * the historical streams before the plane's anchor is read (the only path a
- * historical stream enters the view; the event table replaces it), and the
- * transcript bridge, which turns the root's transcript store's change feed
- * into `transcript.entry` rows and in-flight text (the runtime's flow rows
- * replace it).
+ * One piece of this file exists only until the persistence cutover and is
+ * marked so: the transcript bridge, which turns the root's transcript
+ * store's change feed into `transcript.entry` rows and in-flight text (the
+ * runtime's flow rows replace it). The historical streams enter the view
+ * through the memory log's listing tier (`historicalListing.ts`), read
+ * from the summary tier when a reader subscribes; the event table replaces
+ * that.
  */
 import * as os from 'node:os';
 
@@ -182,128 +181,6 @@ const ownerLiveness = Layer.effectDiscard(
   }),
 );
 
-/** The summary tier's streams, parents before children and older before
- *  newer, so the fold's creation order is the transcript's: a child folded
- *  before its parent exists is re-rooted for good (PRD 5.2, `ancestors`). */
-function streamsParentsFirst(transcripts: StreamLogStore): StreamTabId[] {
-  const known = new Set(transcripts.keys());
-  let remaining = [...known].sort(
-    (a, b) =>
-      (transcripts.getTimestampRange(a).first ?? 0) -
-      (transcripts.getTimestampRange(b).first ?? 0),
-  );
-  const ordered: StreamTabId[] = [];
-  const placed = new Set<StreamTabId>();
-  while (remaining.length > 0) {
-    const next = remaining.filter((id) => {
-      const parent = transcripts.getSummaryMeta(id)?.parentStreamId;
-      return !parent || !known.has(parent) || placed.has(parent);
-    });
-    if (next.length === 0) {
-      // A parent cycle is a corrupt summary tier; import the rest as roots.
-      log.warn(
-        `Stream summaries form a parent cycle among ${remaining.join(', ')}; importing them as top-level streams`,
-      );
-      ordered.push(...remaining);
-      break;
-    }
-    for (const id of next) placed.add(id);
-    ordered.push(...next);
-    remaining = remaining.filter((id) => !placed.has(id));
-  }
-  return ordered;
-}
-
-/**
- * Pre-cutover hydration: one historical stream's facts from the summary
- * tier alone. `run.start` carries the summary's identity (nullish where it
- * has none, contract C3), the launch facts the summary recorded, and the
- * description. The summary holds no status and no holder: a historical
- * stream's outcome is the cutover's event table, or it is not in the
- * listing; nothing here reads an execution record or a lease. A summary
- * that names no execution or no category predates the summary mirror and
- * is reported and skipped rather than given a fabricated launch fact.
- */
-function historicalStream(
-  transcripts: StreamLogStore,
-  streamId: StreamTabId,
-): SessionEventDraft[] | null {
-  const meta = transcripts.getSummaryMeta(streamId);
-  if (meta?.executionId === undefined) {
-    log.warn(
-      `Stream ${streamId} has no execution in its summary; not imported into the session view`,
-    );
-    return null;
-  }
-  if (meta.agentCategory === undefined) {
-    log.warn(
-      `Stream ${streamId} has no category in its summary; not imported into the session view`,
-    );
-    return null;
-  }
-  const { executionId } = meta;
-  const parent = meta.parentStreamId;
-  const drafts: SessionEventDraft[] = [
-    {
-      type: 'run.start',
-      aggregateId: streamId,
-      executionId,
-      identity: meta.identity ?? null,
-      userFollowUpSupport:
-        meta.userFollowUpSupport ?? USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
-      category: meta.agentCategory,
-      isRemote: false,
-      worktree: null,
-      parentStreamId:
-        parent && transcripts.has(parent as StreamTabId) ? parent : null,
-    },
-  ];
-  if (meta.model !== undefined || meta.command !== undefined) {
-    drafts.push({
-      type: 'run.config',
-      aggregateId: streamId,
-      executionId,
-      config: { model: meta.model, instruction: meta.command },
-    });
-  }
-  if (meta.description) {
-    drafts.push({
-      type: 'updateStreamDescription',
-      aggregateId: streamId,
-      description: meta.description,
-    });
-  }
-  return drafts;
-}
-
-/**
- * The history import (above): the first layer of a root's graph, the whole
- * history in ONE append under the log's permit, parents before children,
- * each row stamped at its stream's own time, and complete before
- * `sessionEventsLayer` reads its anchor, so the listing hydrate sees every
- * historical stream and the tail starts after them.
- *
- * One call, not one per stream: the graph is built by a synchronous run
- * (`sessionGraphOpener`), and a fiber yields to the scheduler every
- * `Scheduler.MaxOpsBeforeYield` steps, so an import that took the permit
- * and moved the level once per stream crossed that budget on a few
- * thousand streams and the open read as asynchronous. Building the drafts
- * is plain code; the log sees one permit, one array walk, one level move.
- */
-const historyImport = (transcripts: StreamLogStore) =>
-  Layer.effectDiscard(
-    Effect.gen(function* () {
-      const log = yield* SessionEventLog;
-      const drafts = streamsParentsFirst(transcripts).flatMap((streamId) => {
-        const stream = historicalStream(transcripts, streamId);
-        if (stream === null) return [];
-        const at = transcripts.getTimestampRange(streamId).last ?? Date.now();
-        return stream.map((draft) => ({ ...draft, at }));
-      });
-      if (drafts.length > 0) yield* log.appendAll(drafts);
-    }),
-  );
-
 /**
  * The transcript bridge, until the cutover: the root's transcript store's
  * change feed, in emission order, as `transcript.entry` rows on the plane
@@ -378,11 +255,7 @@ const sessionLayer = (key: SessionKey) =>
       Layer.provideMerge(
         sessionEventsLayer.pipe(
           Layer.provideMerge(
-            historyImport(key.transcripts).pipe(
-              Layer.provideMerge(
-                SessionEventLog.memoryLayer(key.transcripts, key.roots),
-              ),
-            ),
+            SessionEventLog.memoryLayer(key.transcripts, key.roots),
           ),
         ),
       ),
@@ -432,19 +305,18 @@ export function installProcessRuntime(
 /**
  * The opener a process installs through `installProcessRuntime`: resolves
  * the graph of the session's root under a scope the session closes on
- * dispose (building it, history import first, when the session is the
- * root's first) and builds the session-bound services under it.
+ * dispose (building it when the session is the root's first) and builds
+ * the session-bound services under it.
  */
 function sessionGraphOpener(
   runtime: ManagedRuntime.ManagedRuntime<Sessions, never>,
 ): SessionGraphOpener {
   return (session) => {
-    // The build runs under `runSync`, so everything a root's graph does at
-    // build time, the history import included, must complete inside the
-    // scheduler's yield budget (`Scheduler.MaxOpsBeforeYield` steps per
-    // yield) or the open reads as asynchronous and throws. The import
-    // appends the whole history in one call for that reason; moving it to
-    // row open (#11907) is what removes the history pass from here.
+    // The build runs under `runSync`: nothing a root's graph does at build
+    // time may walk the history or cross the scheduler's yield budget
+    // (`Scheduler.MaxOpsBeforeYield` steps per yield), or the open reads as
+    // asynchronous and throws. History is read when a reader subscribes
+    // (`SessionEventLog.memoryLayer`), never here.
     const scope = runtime.runSync(Scope.make());
     const context = runtime.runSync(
       Sessions.contextEffect(

--- a/src/test-kernel/controllers/session/sessionEvents.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionEvents.vitest.ts
@@ -35,6 +35,7 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { ProcessIdentity, SessionEvents } from '@shared/session/sessionEvents';
+import { DownMessageSchema } from '@shared/session/sessionFrames';
 import type { SessionView } from '@shared/session/sessionView';
 import { createFakeWorkspaceRoots } from '@test/support/FakePlatform';
 import { StreamLogStore } from '@transcript/StreamLogStore';
@@ -43,6 +44,24 @@ const SELF = '4242:self-start';
 const OTHER = '4343:other-start';
 const STREAM = 'stream:framing' as StreamTabId;
 const EXECUTION = 'ab12cd' as ExecutionId;
+const OLDER = 'stream:older' as StreamTabId;
+const NEWER = 'stream:newer' as StreamTabId;
+
+/** A store holding two finished streams' summaries, as a reopened
+ *  workspace does before any graph is built over it. */
+function storeWithHistory(): StreamLogStore {
+  const store = StreamLogStore.ephemeral('session events history');
+  store.recordSummaryMeta(OLDER, {
+    executionId: 'a1b2c3' as ExecutionId,
+    agentCategory: AgentCategory.ToolUse,
+  });
+  store.recordSummaryMeta(NEWER, {
+    executionId: 'b2c3d4' as ExecutionId,
+    agentCategory: AgentCategory.Workflow,
+    description: 'the newer run',
+  });
+  return store;
+}
 
 /** Wait on the fold's level until it holds a view `ready` accepts: the ref
  *  replays its current value on subscribe, so a view already there ends the
@@ -89,7 +108,10 @@ const requested: SessionEventDraft = {
  *  bits: the log seeded with `history` before the plane reads its anchor
  *  (the pre-cutover importer's position), the plane, the fold, and the
  *  three local sources. */
-const graph = (history: readonly SessionEventDraft[]) => {
+const graph = (
+  history: readonly SessionEventDraft[],
+  transcripts = StreamLogStore.ephemeral('session events test'),
+) => {
   const roots = createFakeWorkspaceRoots({ storagePath: '/workspace/framing' });
   const seeded = Layer.effectDiscard(
     Effect.gen(function* () {
@@ -103,12 +125,7 @@ const graph = (history: readonly SessionEventDraft[]) => {
       sessionEventsLayer.pipe(
         Layer.provideMerge(
           seeded.pipe(
-            Layer.provideMerge(
-              SessionEventLog.memoryLayer(
-                StreamLogStore.ephemeral('session events test'),
-                roots,
-              ),
-            ),
+            Layer.provideMerge(SessionEventLog.memoryLayer(transcripts, roots)),
           ),
         ),
       ),
@@ -237,5 +254,55 @@ describe('session events and view', () => {
         expect(held.streams.get(STREAM)?.group).toBe('waiting');
         expect(held.streams.get(STREAM)?.readOnly).toBe(true);
       }).pipe(Effect.provide(graph([runStart, waiting, requested]))),
+  );
+  it.effect(
+    'lists the streams the store held at build below the log, in order and on the wire',
+    () =>
+      Effect.gen(function* () {
+        const events = yield* SessionEvents;
+        const log = yield* SessionEventLog;
+        const view = yield* SessionViewService;
+        yield* settle(view.ref, (v) => v.streams.size === 2);
+        const listed = yield* SubscriptionRef.get(view.ref);
+        const older = listed.streams.get(OLDER);
+        const newer = listed.streams.get(NEWER);
+        // Distinct commits in the store's order, so the roster keeps the
+        // transcript's creation order rather than falling back to the id.
+        expect(older?.createdAt).toBeGreaterThanOrEqual(1);
+        expect(newer?.createdAt).toBeGreaterThan(older?.createdAt ?? 0);
+        expect(newer?.description).toBe('the newer run');
+        // Every listing row is a wire-valid event: the webview parses the
+        // replay frame whole and drops it on one bad seq.
+        const rows = yield* Stream.runCollect(log.readListing());
+        const frame = DownMessageSchema.safeParse({
+          kind: 'events',
+          session: 'k',
+          generation: 0,
+          cursor: 0,
+          events: rows.map((event) => ({
+            _tag: 'event',
+            read: 'listing',
+            event,
+          })),
+          chunks: [],
+          local: null,
+          host: null,
+          replayComplete: true,
+        });
+        expect(
+          frame.success,
+          frame.success ? '' : JSON.stringify(frame.error.issues, null, 1),
+        ).toBe(true);
+        // A stream born after the build enters through its own row alone,
+        // above the reserved space, so a renderer attached at open sees it
+        // as new.
+        yield* events.publish([{ ...runStart, aggregateId: STREAM }]);
+        yield* settle(view.ref, (v) => v.streams.has(STREAM));
+        const live = yield* SubscriptionRef.get(view.ref);
+        expect(live.streams.get(STREAM)?.createdAt).toBeGreaterThan(
+          newer?.createdAt ?? 0,
+        );
+        expect(live.streams.size).toBe(3);
+      }).pipe(Effect.provide(graph([], storeWithHistory()))),
   );
 });


### PR DESCRIPTION
Closes #11907. Part of #11865 and #11861; the S1 shape of docs/proposals/2026-09-03-startup-repair-is-the-wrong-shape.md applied to the session graph.

## What

The memory log no longer imports the history at the root's first open. Its listing tier is now derived from the transcript store's always-resident summary tier when a reader subscribes, the same way its transcript tier already reads the store's rows for a subscribed stream:

- `historicalListing.ts` (moved from `sessionLayer.ts`): the historical streams' `run.start` / `run.config` / `updateStreamDescription` rows, parents before children, older before newer, each stamped at its stream's own last write. Plain code over resident data: no permit, no log row, no fiber step per stream. Derived once per log on the first read and held (round 1: 74f521b81c).
- Commit space: the log reserves `HISTORICAL_COMMITS_PER_STREAM` (3) commits per historical stream below its first row, from the membership count alone, and the listing rows occupy it in that order (stream i at 3i+1..3i+3, seq = position within the stream). `createdAt` keeps the transcript's creation order as the deleted import's commits did, every log row outranks the listing rows, the level starts at the reserved count, and every row is wire-valid (seq positive), which the webview transport's frame parse requires.
- `SessionEventLog.memoryLayer`: `readListing` = the historical rows, then the log's own listing rows; `exists` = listed by the summary tier or appended by this process, and not tombstoned.
- `historyImport` deleted from the graph composition, with the yield-budget paragraph on the opener and the per-draft `at` widening on `appendAll` that the hotfix (#11909) needed for it.

Historical means "existed when the graph opened": the membership is the summary tier's key set taken once at the log's build (one Set copy, no facts read; the facts are read on the first subscribe). A stream born after that enters the view through its own `run.start` row alone. This is load-bearing, not tidiness: a live stream's summary entry is projected from its `run.start`, so a replay between that projection and the fold would mint it from the listing tier at commit 0 first, and its real row would then land on a known stream and leave `createdAt` at 0, which the headless run-progress renderer does not treat as a stream created after it attached. The CLI progress renderer suite caught exactly that on the first cut.

Why membership rather than ordering the log's rows first: a live child of a historical parent must fold after its parent or the fold re-roots it for good (PRD 5.2, `ancestors`), so summary rows have to come first.

## What does not change

- The fold, `SessionInputs`, the framer, and the webview graphs: the replay batch has the same shape, the rows just come from the store instead of the log.
- Row-open transcript reads: listing rows never move `view.folded`, so a subscribed stream still reads its transcript from seq 0.
- `createdAt` of a re-run historical stream stays at its listing commit, as it did at the import's commit.

## Measured

`texra chat --agent research --model deepseekproT` in the TNLean workspace (3,989 summary streams), launch to input prompt, tmux recipe, nothing else running:

| Build | Time to prompt |
| --- | --- |
| main at 48c5cca091 (#11909) | 1.6 s, 1.6 s |
| this branch (66cba40189) | 1.6 s, 1.6 s |
| this branch after round 1 (74f521b81c), load average under 8 | 1.6 s, 1.6 s |

The number is the floor either way; what this PR removes is the O(history) log pass at every open and the log's copy of every historical row, and with them the yield-budget dependence the hotfix documented.

## Verification

Typecheck, lint, dead-code ratchet, and the full vitest suite on this head; the TNLean runs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
