### PR TITLE
feat(agent): sessions are owned by the Sessions map, with a settling close (SDK step 1)

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -85,7 +85,8 @@ opening a root twice (two runs, or a run beside a host in the same process)
 resolves the one session already open there; a second root gets its own. A
 session ends only through `closeSession(roots)`: it refuses new runs on the
 root, interrupts the runs it owns and waits for them to settle within the
-runtime's shutdown budget, flushes its artifacts, and releases the session,
+runtime's shutdown budget (or the `signal` you pass, when the close runs under
+a budget of your own), flushes its artifacts, and releases the session,
 returning `{ settled, abandoned }`. `settled` is true when every run ended in
 time; otherwise `abandoned` names the runs still live, and the session stays
 open, refusing new runs, until they end. The platform's shutdown path

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -79,10 +79,18 @@ process reads. The run's transcript rows (`StreamView.transcript`) are
 subscribed on its behalf, its stream and its descendants as they appear, and
 stay resident for the life of the process.
 
-Runs share one session per workspace storage root for the life of the
-process. It is disposed, after its live executions settle, on the platform's
-shutdown path (`lifecycle.runShutdown()`), which an embedder runs before it
-exits.
+Runs share one session per workspace storage root. The runtime's session
+owner holds it, the same owner every TeXRA host opens its sessions through, so
+opening a root twice (two runs, or a run beside a host in the same process)
+resolves the one session already open there; a second root gets its own. A
+session ends only through `closeSession(roots)`: it refuses new runs on the
+root, interrupts the runs it owns and waits for them to settle within the
+runtime's shutdown budget, flushes its artifacts, and releases the session,
+returning `{ settled, abandoned }`. `settled` is true when every run ended in
+time; otherwise `abandoned` names the runs still live, and the session stays
+open, refusing new runs, until they end. The platform's shutdown path
+(`lifecycle.runShutdown()`), which an embedder runs before it exits, closes
+the platform's session this way after the runs it owns have settled.
 
 ## Run results
 
@@ -110,11 +118,11 @@ files.
 
 ## Entry points
 
-| Entry                     | Contents                                                                                                          |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `@texra-ai/agent`         | `runAgent`, `AgentRun`, `defineTool`, `MapToolRegistry`, and the `AgentEvent` / `ITool` / `AgentFlowResult` types |
-| `@texra-ai/agent/schemas` | Zod schemas + inferred types for agent definitions, configs, and run results                                      |
-| `@texra-ai/agent/node`    | `nodePlatform(options)`, a ready-made Node `Platform` with its workspace roots                                    |
+| Entry                     | Contents                                                                                                                                                 |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@texra-ai/agent`         | `runAgent`, `closeSession`, `AgentRun`, `defineTool`, `MapToolRegistry`, and the `AgentEvent` / `ITool` / `AgentFlowResult` / `SessionCloseReport` types |
+| `@texra-ai/agent/schemas` | Zod schemas + inferred types for agent definitions, configs, and run results                                                                             |
+| `@texra-ai/agent/node`    | `nodePlatform(options)`, a ready-made Node `Platform` with its workspace roots                                                                           |
 
 ## The platform
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -82,7 +82,7 @@ stay resident for the life of the process.
 Runs share one session per workspace storage root. The runtime's session
 owner holds it, the same owner every TeXRA host opens its sessions through, so
 opening a root twice (two runs, or a run beside a host in the same process)
-resolves the one session already open there; a second root gets its own. A
+resolves the one session already open there; a second root gets its own. When the session was opened by a host (the extension, the desktop, or the CLI in the same process), that host's decision delivery applies to every run on it: retries and approvals prompt in the host's UI and the run waits there, as PR #11893 section 8 rules; the package's inline retry denial applies only to sessions the package opened itself. A
 session ends only through `closeSession(roots)`: it refuses new runs on the
 root, interrupts the runs it owns and waits for them to settle within the
 runtime's shutdown budget (or the `signal` you pass, when the close runs under

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -158,18 +158,6 @@ interface EnteredRun {
   readonly view: RuntimeSessionHandle['viewChanges'];
 }
 
-/**
- * The package's one process-wide state, made on the first run and torn down
- * on the embedder's shutdown path: the node runtime features and the Effect
- * runtime the sessions run on (PRD 7.7, 11). The sessions themselves have
- * no package-side owner: the runtime's `Sessions` map holds one per storage
- * root, the same owner every TeXRA host opens through, so a run resolves
- * its session by the platform's roots and the map hands back the one
- * already open there or builds it. The shutdown path resets this, so the
- * package has no life of its own past it.
- */
-let packageRuntime: Promise<void> | undefined;
-
 /** The session of the platform's storage root, as the runtime's owner
  *  holds it: built on the first open, over what the package supplies then. */
 function sessionFor(platform: AgentPlatform): RuntimeSessionHandle {
@@ -402,19 +390,22 @@ class AgentRunStream implements AgentRun {
 
 /**
  * Close the session of a workspace's storage root: refuse new runs on it,
- * interrupt the ones it owns and wait for them to settle within the
- * runtime's shutdown budget, flush its artifacts, and release it. The report
- * says whether every run settled; the runs it names as `abandoned` were
- * still live when the budget ran out, and the session stays open, refusing
- * new runs, until they end. A root with no open session reports `settled`.
- * The embedder's shutdown path (`lifecycle.runShutdown()`) closes the
- * platform's session this way; call it directly to close a root before
- * that, or to close one of several roots one platform opened.
+ * interrupt the ones it owns and wait for them to settle within `signal`'s
+ * budget (the embedder's own shutdown phase) or, without one, the runtime's
+ * shutdown budget, flush its artifacts, and release it. The report says
+ * whether every run settled; the runs it names as `abandoned` were still
+ * live when the budget ran out, and the session stays open, refusing new
+ * runs, until they end. A root with no open session reports `settled`, as
+ * does a process no run has initialized. The embedder's shutdown path
+ * (`lifecycle.runShutdown()`) closes the platform's session this way, under
+ * its phase budget; call it directly to close a root before that, or to
+ * close one of several roots one platform opened.
  */
 export function closeSession(
   roots: WorkspaceRoots,
+  signal?: AbortSignal,
 ): Promise<SessionCloseReport> {
-  return closeRuntimeSession(roots.storage);
+  return closeRuntimeSession(roots.storage, signal);
 }
 
 /**
@@ -435,6 +426,9 @@ export function runAgent(input: RunAgentInput): AgentRun {
       );
     }
 
+    // The identity first: everything from the platform check to the runtime
+    // install is then synchronous, so two first runs cannot both pass it.
+    const processStart = await input.platform.processes.selfIdentity();
     const activePlatform = tryPlatform();
     if (activePlatform && activePlatform !== input.platform) {
       throw new Error(
@@ -442,35 +436,30 @@ export function runAgent(input: RunAgentInput): AgentRun {
       );
     }
     if (!activePlatform) {
+      // No composition root has run in this process, so the package is its
+      // composition root: the platform, the node agent runtime, the one
+      // Effect runtime holding the sessions' owner (PRD 7.7), and the hosts'
+      // shutdown order on the embedder's shutdown path. A run beside a host
+      // that already ran its own (the same platform object) reuses all four,
+      // its session included: the owner is process-wide, and nothing here
+      // may be installed twice.
       initPlatform(input.platform);
       initProcessWorkspaceRoots(input.platform.roots);
-    }
-    packageRuntime ??= (async () => {
       initNodeAgentRuntime(input.platform.lifecycle);
-      // The one Effect runtime of the embedding process (PRD 7.7), holding
-      // the sessions' owner.
-      const runtime = installProcessRuntime(
-        await input.platform.processes.selfIdentity(),
-      );
-      // The hosts' shutdown order, on the embedder's shutdown path: the
-      // session's agent-spawned children and agent-CLI sessions are stopped,
-      // then the platform's session is closed through its owner (its runs
-      // stopped and settled, its artifacts flushed, the session released:
-      // the headless shape, as the CLI's headless run stops and awaits its
-      // run in this phase), then the runtime that held it goes.
+      const runtime = installProcessRuntime(processStart);
+      // The session's agent-spawned children and agent-CLI sessions are
+      // stopped, then the platform's session is closed through its owner
+      // under the phase's own budget (its runs stopped and settled, its
+      // artifacts flushed, the session released: the headless shape, as the
+      // CLI's headless run stops and awaits its run in this phase), then
+      // the runtime that held it goes.
       registerRuntimeShutdownHandlers(input.platform.lifecycle, {
-        flushArtifacts: async () => {
-          await closeSession(input.platform.roots);
+        flushArtifacts: async (signal) => {
+          await closeSession(input.platform.roots, signal);
         },
-        afterExecutionSettlement: [
-          () => {
-            packageRuntime = undefined;
-          },
-          () => runtime.dispose(),
-        ],
+        afterExecutionSettlement: [() => runtime.dispose()],
       });
-    })();
-    await packageRuntime;
+    }
     const session = sessionFor(input.platform);
     await loadAgents({ includeRemote: false });
     const resolved = resolveAgent(input.agent);

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -12,7 +12,7 @@ import type { AgentEvent, AgentTrace } from '@agent/trace';
 import { loadAgents, resolveAgent } from '@agent/index';
 import {
   closeSession as closeRuntimeSession,
-  openSession,
+  openSessionAsync,
   runAgent as runValidatedAgent,
   type AgentRunHandle as RuntimeAgentRunHandle,
   type SessionHandle as RuntimeSessionHandle,
@@ -30,7 +30,10 @@ import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
 
 // Local imports - config and host services
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
-import { installProcessRuntime } from '@controllers/session/sessionLayer';
+import {
+  disposeProcessRuntime,
+  installProcessRuntime,
+} from '@controllers/session/sessionLayer';
 import { initPlatform, tryPlatform, type Platform } from '@platform/platform';
 import {
   initProcessWorkspaceRoots,
@@ -159,9 +162,11 @@ interface EnteredRun {
 }
 
 /** The session of the platform's storage root, as the runtime's owner
- *  holds it: built on the first open, over what the package supplies then. */
-function sessionFor(platform: AgentPlatform): RuntimeSessionHandle {
-  return openSession({
+ *  holds it: built on the first open, over what the package supplies then.
+ *  Registered with the owner before the returned promise is awaited, so a
+ *  close issued after `runAgent` returns finds this open. */
+function sessionFor(platform: AgentPlatform): Promise<RuntimeSessionHandle> {
+  return openSessionAsync({
     roots: platform.roots,
     transcripts: StreamLogStore.ephemeral('npm package consumer'),
     // The session's one host, for its whole life, like every TeXRA host
@@ -426,9 +431,13 @@ export function runAgent(input: RunAgentInput): AgentRun {
       );
     }
 
-    // The identity first: everything from the platform check to the runtime
-    // install is then synchronous, so two first runs cannot both pass it.
-    const processStart = await input.platform.processes.selfIdentity();
+    // Everything from the platform check to the session open is
+    // synchronous: two first runs cannot both pass the check, and the owner
+    // holds this run's session before the run's first await, so a
+    // `closeSession` or a `runShutdown` issued right after `runAgent`
+    // returns settles this launch too (the run then fails at admission
+    // instead of starting model work after the cleanup). The process
+    // identity is read while the session builds.
     const activePlatform = tryPlatform();
     if (activePlatform && activePlatform !== input.platform) {
       throw new Error(
@@ -446,21 +455,22 @@ export function runAgent(input: RunAgentInput): AgentRun {
       initPlatform(input.platform);
       initProcessWorkspaceRoots(input.platform.roots);
       initNodeAgentRuntime(input.platform.lifecycle);
-      const runtime = installProcessRuntime(processStart);
+      installProcessRuntime(input.platform.processes.selfIdentity());
       // The session's agent-spawned children and agent-CLI sessions are
       // stopped, then the platform's session is closed through its owner
       // under the phase's own budget (its runs stopped and settled, its
       // artifacts flushed, the session released: the headless shape, as the
       // CLI's headless run stops and awaits its run in this phase), then
-      // the runtime that held it goes.
+      // the runtime that held it goes, and its owner with it: a later
+      // `closeSession` answers as a process with none does.
       registerRuntimeShutdownHandlers(input.platform.lifecycle, {
         flushArtifacts: async (signal) => {
           await closeSession(input.platform.roots, signal);
         },
-        afterExecutionSettlement: [() => runtime.dispose()],
+        afterExecutionSettlement: [() => disposeProcessRuntime()],
       });
     }
-    const session = sessionFor(input.platform);
+    const session = await sessionFor(input.platform);
     await loadAgents({ includeRemote: false });
     const resolved = resolveAgent(input.agent);
     if (!resolved) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -11,9 +11,11 @@ import { Effect, Fiber, Stream } from 'effect';
 import type { AgentEvent, AgentTrace } from '@agent/trace';
 import { loadAgents, resolveAgent } from '@agent/index';
 import {
+  closeSession as closeRuntimeSession,
+  openSession,
   runAgent as runValidatedAgent,
-  SessionHandle as RuntimeSessionHandle,
   type AgentRunHandle as RuntimeAgentRunHandle,
+  type SessionHandle as RuntimeSessionHandle,
 } from '@agent/runtime';
 import type { ITool } from '@agent/core/tools/ToolTypes';
 
@@ -36,7 +38,11 @@ import {
 } from '@platform/workspaceRoots';
 import { effectRuntime } from '@platform/processRuntime';
 import { initNodeAgentRuntime } from '@platform/defaults/nodeAgentRuntime';
-import { AgentCategory, type StreamTabId } from '@shared/schemas';
+import {
+  AgentCategory,
+  type SessionCloseReport,
+  type StreamTabId,
+} from '@shared/schemas';
 import type {
   SessionView as RuntimeSessionView,
   StreamView as RuntimeStreamView,
@@ -46,6 +52,7 @@ import { registerRuntimeShutdownHandlers } from '@tools/agentCliSessionStores';
 import { StreamLogStore } from '@transcript/StreamLogStore';
 
 export type { AgentEvent } from '@agent/trace';
+export type { SessionCloseReport } from '@shared/schemas';
 export type {
   ITool,
   IToolRegistry,
@@ -153,26 +160,22 @@ interface EnteredRun {
 
 /**
  * The package's one process-wide state, made on the first run and torn down
- * on the embedder's shutdown path: the node runtime features, the Effect
- * runtime the package sessions' graphs run on, and the sessions themselves,
- * one per storage root (PRD 7.3, 11). `Sessions` keys a root's graph by its
- * storage root and bridges the transcript store the root's first handle
- * opened, so every run on a root shares one handle, or a later run's rows
- * would land in a store no graph reads. The shutdown path resets this owner,
- * so the sessions have no life of their own past it.
+ * on the embedder's shutdown path: the node runtime features and the Effect
+ * runtime the sessions run on (PRD 7.7, 11). The sessions themselves have
+ * no package-side owner: the runtime's `Sessions` map holds one per storage
+ * root, the same owner every TeXRA host opens through, so a run resolves
+ * its session by the platform's roots and the map hands back the one
+ * already open there or builds it. The shutdown path resets this, so the
+ * package has no life of its own past it.
  */
-let packageSessions: Promise<Map<string, RuntimeSessionHandle>> | undefined;
+let packageRuntime: Promise<void> | undefined;
 
-function sessionFor(
-  sessions: Map<string, RuntimeSessionHandle>,
-  platform: AgentPlatform,
-): RuntimeSessionHandle {
-  let session = sessions.get(platform.roots.storage);
-  if (!session) {
-    session = new RuntimeSessionHandle({
-      roots: platform.roots,
-      transcripts: StreamLogStore.ephemeral('npm package consumer'),
-    });
+/** The session of the platform's storage root, as the runtime's owner
+ *  holds it: built on the first open, over what the package supplies then. */
+function sessionFor(platform: AgentPlatform): RuntimeSessionHandle {
+  return openSession({
+    roots: platform.roots,
+    transcripts: StreamLogStore.ephemeral('npm package consumer'),
     // The session's one host, for its whole life, like every TeXRA host
     // attaches one per session: the interaction hub keeps a single active
     // host and tells runs apart by the stream its requests and cancellations
@@ -180,16 +183,14 @@ function sessionFor(
     // previous run's host. The package has no interactive prompts, so there
     // is nothing for a cancellation to settle; a retry prompt is denied so
     // that it never parks the run waiting for a host.
-    session.interactions.use({
+    interactions: {
       cancel: () => {},
       requestRetry: async () => ({
         action: 'deny',
         reason: 'Interactive retries are unavailable in the agent package.',
       }),
-    });
-    sessions.set(platform.roots.storage, session);
-  }
-  return session;
+    },
+  });
 }
 
 /** The run's stream and every descendant the view holds. */
@@ -400,6 +401,23 @@ class AgentRunStream implements AgentRun {
 }
 
 /**
+ * Close the session of a workspace's storage root: refuse new runs on it,
+ * interrupt the ones it owns and wait for them to settle within the
+ * runtime's shutdown budget, flush its artifacts, and release it. The report
+ * says whether every run settled; the runs it names as `abandoned` were
+ * still live when the budget ran out, and the session stays open, refusing
+ * new runs, until they end. A root with no open session reports `settled`.
+ * The embedder's shutdown path (`lifecycle.runShutdown()`) closes the
+ * platform's session this way; call it directly to close a root before
+ * that, or to close one of several roots one platform opened.
+ */
+export function closeSession(
+  roots: WorkspaceRoots,
+): Promise<SessionCloseReport> {
+  return closeRuntimeSession(roots.storage);
+}
+
+/**
  * Start one agent run and expose its trace as an asynchronous event stream.
  *
  * The platform and agent registry are process-wide. Applications should create
@@ -427,35 +445,33 @@ export function runAgent(input: RunAgentInput): AgentRun {
       initPlatform(input.platform);
       initProcessWorkspaceRoots(input.platform.roots);
     }
-    packageSessions ??= (async () => {
+    packageRuntime ??= (async () => {
       initNodeAgentRuntime(input.platform.lifecycle);
-      // The one Effect runtime of the embedding process (PRD 7.7), for the
-      // package sessions' graphs.
+      // The one Effect runtime of the embedding process (PRD 7.7), holding
+      // the sessions' owner.
       const runtime = installProcessRuntime(
         await input.platform.processes.selfIdentity(),
       );
-      const sessions = new Map<string, RuntimeSessionHandle>();
       // The hosts' shutdown order, on the embedder's shutdown path: the
-      // sessions' agent-spawned children and agent-CLI sessions are stopped
-      // and their live executions settled, then each session goes with the
-      // owner that held it, then the runtime its graph ran on.
+      // session's agent-spawned children and agent-CLI sessions are stopped,
+      // then the platform's session is closed through its owner (its runs
+      // stopped and settled, its artifacts flushed, the session released:
+      // the headless shape, as the CLI's headless run stops and awaits its
+      // run in this phase), then the runtime that held it goes.
       registerRuntimeShutdownHandlers(input.platform.lifecycle, {
         flushArtifacts: async () => {
-          for (const session of sessions.values()) {
-            await session.flushArtifacts();
-          }
+          await closeSession(input.platform.roots);
         },
         afterExecutionSettlement: [
           () => {
-            for (const session of sessions.values()) session.dispose();
-            packageSessions = undefined;
+            packageRuntime = undefined;
           },
           () => runtime.dispose(),
         ],
       });
-      return sessions;
     })();
-    const session = sessionFor(await packageSessions, input.platform);
+    await packageRuntime;
+    const session = sessionFor(input.platform);
     await loadAgents({ includeRemote: false });
     const resolved = resolveAgent(input.agent);
     if (!resolved) {

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -8,7 +8,10 @@ import { createPlatformAgentDirectories } from '@agent/index';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import type { SupabaseSessionLog } from '@auth/SupabaseSession';
 import { installTexraAccountProbes } from '@controllers/modelAccess/installTexraAccountProbes';
-import { installProcessRuntime } from '@controllers/session/sessionLayer';
+import {
+  disposeProcessRuntime,
+  installProcessRuntime,
+} from '@controllers/session/sessionLayer';
 import { setOutputChannelFactory } from '@logger/logUtils';
 import { refreshModelListAndLog } from '@model/modelListRefresh';
 import { initPlatform, platform, tryPlatform } from '@platform/platform';
@@ -304,9 +307,7 @@ export async function initCliPlatform(
     // The one Effect runtime of this process (PRD 7.7): the session graph
     // and every Promise-facing fiber run on it. Disposed after the default
     // session has released its graph.
-    const runtime = installProcessRuntime(
-      await platform().processes.selfIdentity(),
-    );
+    installProcessRuntime(await platform().processes.selfIdentity());
     initProcessSettingHost('cli');
     // TeXRA's account plane (ChatGPT / Grok sign-in). Without
     // this the model layer is bring-your-own-key. See installTexraAccountProbes.
@@ -360,7 +361,7 @@ export async function initCliPlatform(
       afterFlushArtifacts: [() => UsageLogService.dispose()],
       afterExecutionSettlement: [
         () => teardownDefaultSession(),
-        () => runtime.dispose(),
+        () => disposeProcessRuntime(),
       ],
     });
 

--- a/packages/desktop/src/main/desktopPapers.ts
+++ b/packages/desktop/src/main/desktopPapers.ts
@@ -9,8 +9,9 @@ import type { SessionStores } from '@agent/storage';
 import {
   agentResponseTextConnector,
   attachTerminalResultToast,
+  openSession,
   runInSession,
-  SessionHandle,
+  type SessionHandle,
 } from '@agent/runtime';
 import { scheduleLeftoverStreamSweep } from '@controllers/session/scheduleLeftoverStreamSweep';
 import { createTexraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
@@ -219,7 +220,7 @@ async function openPaperSession(
     const transcripts = await runWithWorkspaceRoots(roots, () =>
       StreamLogStore.openOrEphemeral(),
     );
-    const session = new SessionHandle({
+    const session = openSession({
       transcripts,
       roots,
       responseTextProcessing,

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -36,6 +36,7 @@ import {
 } from '@controllers/session/SessionBridge';
 import { createHostSnapshotSource } from '@controllers/session/hostSnapshotSource';
 import { HostDraftRequests } from '@controllers/session/hostDraftRequests';
+import { disposeProcessRuntime } from '@controllers/session/sessionLayer';
 import { createLog } from '@logger/logUtils';
 import { hasUsableSetupCredential } from '@model/setupCredentialAccess';
 import { platform } from '@platform/platform';
@@ -1511,7 +1512,7 @@ if (protocolLifecycle.ownsSingleInstanceLock) {
         afterExecutionSettlement: [
           () => processResources.dispose(),
           // Last: every paper's session has released its graph above.
-          () => platformInit.runtime.dispose(),
+          () => disposeProcessRuntime(),
         ],
       });
 

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -6,7 +6,6 @@ import { installTexraAccountProbes } from '@controllers/modelAccess/installTexra
 import { installProcessRuntime } from '@controllers/session/sessionLayer';
 import { refreshModelListAndLog } from '@model/modelListRefresh';
 import { initPlatform, platform } from '@platform/platform';
-import type { ProcessRuntime } from '@platform/processRuntime';
 import {
   initProcessWorkspaceRoots,
   type WorkspaceRoots,
@@ -66,12 +65,6 @@ export interface ElectronPlatformInitResult {
    * each re-resolve it.
    */
   resourcesPath: string;
-  /**
-   * The one Effect runtime of this process (PRD one-fold-three-renderers,
-   * 7.7): every paper's session graph runs on it. The entry disposes it last,
-   * after execution settlement and the papers' release of their graphs.
-   */
-  runtime: ProcessRuntime;
 }
 
 export async function initializeElectronPlatform(
@@ -130,10 +123,10 @@ export async function initializeElectronPlatform(
   });
   initProcessWorkspaceRoots(processRoots);
   // The one Effect runtime of this process (PRD 7.7): every paper's session
-  // graph and every Promise-facing fiber run on it.
-  const runtime = installProcessRuntime(
-    await platform().processes.selfIdentity(),
-  );
+  // graph and every Promise-facing fiber run on it. The entry disposes it
+  // last (`disposeProcessRuntime`), after execution settlement and the
+  // papers' release of their graphs.
+  installProcessRuntime(await platform().processes.selfIdentity());
   initProcessSettingHost('desktop');
   // TeXRA's account plane (ChatGPT / Grok sign-in). Without this
   // the model layer is bring-your-own-key. See installTexraAccountProbes.
@@ -192,6 +185,5 @@ export async function initializeElectronPlatform(
     lifecycle,
     dataRoot,
     resourcesPath,
-    runtime,
   };
 }

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -28,7 +28,10 @@ import { createSampleProjectWithoutWorkspace } from '@commands/system/sampleProj
 import { tryResumeFromResumeData } from '@commands/agent/resumeFromResumeData';
 import { isFileNotFoundError } from '@common/errors';
 import { SIDEBAR_VIEWS, setActiveSidebarView } from '@common/webview';
-import { installProcessRuntime } from '@controllers/session/sessionLayer';
+import {
+  disposeProcessRuntime,
+  installProcessRuntime,
+} from '@controllers/session/sessionLayer';
 import { installTexraAccountProbes } from '@controllers/modelAccess/installTexraAccountProbes';
 import { scheduleLeftoverStreamSweep } from '@controllers/session/scheduleLeftoverStreamSweep';
 import { appSignals } from '@eventBus/AppSignals';
@@ -70,7 +73,6 @@ import { refreshModelListAndLog } from '@model/modelListRefresh';
 import { invalidateRuntimeModelRegistry } from '@model/runtimeModelRegistry';
 import { SHUTDOWN_PHASE, type LifecycleHost } from '@platform/interfaces';
 import { initPlatform, platform } from '@platform/platform';
-import type { ProcessRuntime } from '@platform/processRuntime';
 import { initProcessWorkspaceRoots } from '@platform/workspaceRoots';
 import {
   bootstrapNodeAgentDirectories,
@@ -127,17 +129,13 @@ let apiKeyStatusBarItem: vscode.StatusBarItem | undefined;
 // handlers registered by a second activate() in the same process.
 let lifecycleHost: LifecycleHost | undefined;
 let extensionShutdownPromise: Promise<void> | undefined;
-/** The one Effect runtime of this extension host (PRD 7.7). */
-let processRuntime: ProcessRuntime | undefined;
 
 /**
  * Make the process runtime over the process identity and install it beside
  * the platform: the session graphs and every Promise-facing fiber run on it.
  */
 async function installRuntime(): Promise<void> {
-  processRuntime = installProcessRuntime(
-    await platform().processes.selfIdentity(),
-  );
+  installProcessRuntime(await platform().processes.selfIdentity());
 }
 
 /**
@@ -192,9 +190,7 @@ function shutdownExtension(): Promise<void> {
       if (lifecycleHost === host) lifecycleHost = undefined;
       teardownDefaultSession();
       // After the session: its graph releases on the runtime it runs on.
-      const runtime = processRuntime;
-      processRuntime = undefined;
-      await runtime?.dispose();
+      await disposeProcessRuntime();
     }
   })();
   extensionShutdownPromise = shutdownPromise;

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -10,8 +10,10 @@
  * by a boot pass. It composes {@link ExecutionRegistry},
  * {@link SessionHostInteractions}, and the other session-scoped owners.
  *
- * A session is one per host context: extension activation (per VS Code window),
- * CLI process, or desktop Electron process. The default instance is installed
+ * A session is one per workspace storage root, built and held by the
+ * process's session owner (the `Sessions` map behind `openSession`): the
+ * extension and the CLI open one over the process roots, the desktop one
+ * per paper, the SDK one per platform. The default instance is installed
  * explicitly through {@link initializeDefaultSession}; {@link defaultSession}
  * only retrieves that process-wide owner. There is no other way to reach
  * these owners: the invariant is "no session-scoped mutable module export"
@@ -50,10 +52,7 @@ import type { ResponseTextProcessing } from '@latex/texraResponseTextProcessing'
 import { createLog } from '@logger/logUtils';
 import { DisposableStore } from '@platform/disposable';
 import { effectRuntime } from '@platform/processRuntime';
-import {
-  processWorkspaceRoots,
-  type WorkspaceRoots,
-} from '@platform/workspaceRoots';
+import type { WorkspaceRoots } from '@platform/workspaceRoots';
 import {
   TEXRA_APPROVAL_POLICY_DEFAULT,
   type TexraApprovalPolicy,
@@ -80,9 +79,12 @@ import {
 } from './RunContext';
 import { ExecutionRegistry } from './executionRegistry';
 import { StreamStatusMachine } from './StreamStatusService';
-import { SessionHostInteractions } from './HostInteractions';
+import {
+  SessionHostInteractions,
+  type HostInteractions,
+} from './HostInteractions';
 import { runEventDraft, statusDraft } from './SessionEvents';
-import { openSessionGraph, type SessionGraph } from './sessionGraph';
+import { openSession, type SessionGraph } from './sessionGraph';
 import { ModelRetryGate } from './ModelRetryGate';
 import {
   createSessionApprovals,
@@ -94,18 +96,21 @@ import { createNeutralResponseTextProcessing } from './responseTextProcessing';
 const logger = createLog('sessionHandle');
 
 /**
- * A valid transcript store is required; other owners may be injected.
+ * What opening a session supplies (`openSession`): a valid transcript store
+ * is required; other owners may be injected. `interactions` is the host the
+ * session is born with, attached for its whole life, for an opener with no
+ * later attach step of its own (the SDK's headless host).
  *
  * `status` and `events` are deliberately absent: the machine publishes
  * canonical `status` through the session, and the event plane is the
- * session's graph (`openSessionGraph`), resolved by workspace root, so a
+ * session's graph, built by the session owner per workspace root, so a
  * separately-injected machine or plane could not silently drop every fact
  * of a session onto a plane nobody reads. The session co-constructs them.
  */
 export type SessionHandleInit = Pick<SessionHandle, 'transcripts'> &
   Partial<
     Pick<SessionHandle, 'snapshots' | 'responseTextProcessing' | 'roots'>
-  >;
+  > & { readonly interactions?: HostInteractions };
 
 export class SessionHandle {
   /**
@@ -201,7 +206,18 @@ export class SessionHandle {
   readonly workflowControls: WorkflowControlRegistry;
   /** LIFO owner for the session's constructor-registered teardown. */
   private readonly teardown = new DisposableStore();
-  constructor(init: SessionHandleInit) {
+  /**
+   * Built by the session owner alone (`sessionLayer.ts`), inside the root's
+   * graph, with that graph handed over as a function of the session: the
+   * request handler admits on the session, so the graph is bound to the
+   * handle it serves. Every other caller opens through `openSession`.
+   */
+  constructor(
+    init: SessionHandleInit & {
+      readonly roots: WorkspaceRoots;
+      readonly graph: (session: SessionHandle) => SessionGraph;
+    },
+  ) {
     if (init.transcripts.mode.kind === 'read-only') {
       throw new Error(
         'SessionHandle requires a writable transcript store; read-only stores are reserved for call-scoped readers.',
@@ -211,13 +227,8 @@ export class SessionHandle {
     // member fall back to a neighboring module singleton (silent-state-split).
     const transcripts = init.transcripts;
     this.transcripts = transcripts;
-    // Process roots unless the host names a folder: the extension, the CLI,
-    // and the SDK build exactly one session over the process roots; the
-    // desktop opens one session per paper and passes that paper's roots.
-    this.roots = init.roots ?? processWorkspaceRoots();
-    // The graph is keyed by the roots above and reads the transcript store
-    // at build (the pre-cutover hydration), so both are set before it opens.
-    const graph = openSessionGraph(this);
+    this.roots = init.roots;
+    const graph = init.graph(this);
     this.graph = graph;
     this.events = graph.events;
     this.view = graph.view;
@@ -271,6 +282,7 @@ export class SessionHandle {
     // Every session owns exactly one trace-flusher map. There is no
     // process-wide registry: a host drains the session it is shutting down.
     this.flushers = new Map<string, RunTraceFlushEntry>();
+    if (init.interactions) this.interactions.use(init.interactions);
     liveSessions.add(this);
     // Register teardown in reverse LIFO order so `teardown.dispose()` runs the
     // session's shutdown sequence top-to-bottom: drain traces, then unwind
@@ -278,12 +290,12 @@ export class SessionHandle {
     this.teardown.add(() => {
       liveSessions.delete(this);
     });
-    // The graph outlives every publisher above it: a late fact still lands
-    // in the log until the last owner has unwound.
+    // The graph outlives every publisher above it: the owner releases it
+    // after this store has run, so a late fact still lands in the log until
+    // the last owner has unwound.
     this.teardown.add(() => {
       this.disposed = true;
       this.statusPorts.clear();
-      this.graph.close();
     });
     this.teardown.add(() => this.resultListeners.clear());
     this.teardown.add(() => this.artifactFlushers.clear());
@@ -621,11 +633,31 @@ export class SessionHandle {
   }
 
   /**
-   * Tear down everything this session owns through the constructor-registered
-   * LIFO store. The store aggregates each disposer's failure and still runs
-   * the remaining disposers, including the final `liveSessions` removal.
+   * Unwind this session ({@link unwind}) and release it from its owner,
+   * which frees the root's graph after it. A teardown failure surfaces to
+   * the caller and still releases the session. Settles nothing: a host that
+   * needs the session's live executions ended first closes through
+   * `closeSession`, which ends here. Idempotent, so a handle released once
+   * never reaches the session its owner built over the same root later.
    */
   dispose(): void {
+    if (this.disposed) return;
+    try {
+      this.unwind();
+    } finally {
+      this.graph.close();
+    }
+  }
+
+  /**
+   * Tear down everything this session owns through the constructor-registered
+   * LIFO store, once: the store aggregates each disposer's failure and still
+   * runs the remaining disposers, including the final `liveSessions`
+   * removal. The session owner calls this as it releases the session (a
+   * `closeSession`, the runtime's disposal); {@link dispose} calls it first
+   * and then asks for that release.
+   */
+  unwind(): void {
     this.teardown.dispose();
   }
 }
@@ -775,7 +807,7 @@ export function initializeDefaultSession(
   if (cachedDefaultSession) {
     throw new Error('The default session has already been initialized.');
   }
-  cachedDefaultSession = new SessionHandle(init);
+  cachedDefaultSession = openSession(init);
   return cachedDefaultSession;
 }
 

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -84,7 +84,11 @@ import {
   type HostInteractions,
 } from './HostInteractions';
 import { runEventDraft, statusDraft } from './SessionEvents';
-import { openSession, type SessionGraph } from './sessionGraph';
+import {
+  defaultRootSession,
+  openSession,
+  type SessionGraph,
+} from './sessionGraph';
 import { ModelRetryGate } from './ModelRetryGate';
 import {
   createSessionApprovals,
@@ -797,30 +801,31 @@ export async function settleLiveSessionExecutions(
   }
 }
 
-let cachedDefaultSession: SessionHandle | undefined;
 let defaultSessionFallbackWarned = false;
 
-/** Install the process-default session after its transcript store is valid. */
+/**
+ * Open the process-default session, the session of the process roots, after
+ * its transcript store is valid. Its owner holds it, as it holds every
+ * session: {@link defaultSession} reads it from there on each call, so no
+ * second reference to it exists to go stale when the root is closed.
+ */
 export function initializeDefaultSession(
   init: SessionHandleInit,
 ): SessionHandle {
-  if (cachedDefaultSession) {
+  if (defaultRootSession()) {
     throw new Error('The default session has already been initialized.');
   }
-  cachedDefaultSession = openSession(init);
-  return cachedDefaultSession;
+  return openSession(init);
 }
 
 /** Inspect whether the host has installed its process-default session. */
 export function tryDefaultSession(): SessionHandle | undefined {
-  return cachedDefaultSession;
+  return defaultRootSession();
 }
 
-/** Clear and dispose the process-default session during host teardown. */
+/** Dispose the process-default session during host teardown. */
 export function teardownDefaultSession(): void {
-  const session = cachedDefaultSession;
-  cachedDefaultSession = undefined;
-  session?.dispose();
+  defaultRootSession()?.dispose();
 }
 
 /**
@@ -837,12 +842,12 @@ export function teardownDefaultSession(): void {
  * teardown and reinitialization of the default session.
  */
 export function defaultSession(): SessionHandle {
-  if (!cachedDefaultSession) {
+  const processDefault = defaultRootSession();
+  if (!processDefault) {
     throw new Error(
       'The default session has not been initialized. Call initializeDefaultSession() after opening its transcript store.',
     );
   }
-  const processDefault = cachedDefaultSession;
   if (
     !defaultSessionFallbackWarned &&
     [...liveSessions].some((session) => session !== processDefault)

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -324,8 +324,9 @@ export class ExecutionRegistry {
   /**
    * Refuse every execution registered from here on: the session is closing
    * (`Sessions.close`). The executions already tracked keep their handles,
-   * waiters, and status until they settle, which is what the close waits
-   * for; only new admissions are turned away.
+   * waiters, and status until they settle, and a native child loop keeps
+   * its activation until its final delivery, which is what the close waits
+   * for ({@link getActiveIds}); only new admissions are turned away.
    */
   closeAdmissions(): void {
     this.closing = true;
@@ -493,10 +494,19 @@ export class ExecutionRegistry {
     return { kind: 'no_session', streamStatus: status };
   }
 
-  /** Terminate an execution via its handle. Returns true on success. */
+  /**
+   * Terminate an execution via its handle, or, for a native child loop
+   * between turns (an activation with no turn handle), interrupt the loop
+   * itself. Returns true on success.
+   */
   kill(executionId: string, options: ExecutionStopOptions = {}): boolean {
     const handle = this.handles.get(executionId);
-    if (!handle) return false;
+    if (!handle) {
+      const activation = this.childActivations.get(executionId);
+      activation?.interrupt();
+      this.notifyWaiters(executionId);
+      return activation !== undefined;
+    }
     const visited = new Set<string>();
     if (options.detachActiveChildren === true) {
       this.detachActiveChildren(handle.childStreamId);
@@ -512,8 +522,17 @@ export class ExecutionRegistry {
     return result;
   }
 
+  /**
+   * Every execution live in this session: the tracked handles and the
+   * native child loops retained between turns, whose activation is the
+   * only record of them. This is what a close stops and waits on, so a
+   * child with final delivery still to do is never left running under a
+   * released session.
+   */
   getActiveIds(): string[] {
-    return [...this.handles.keys()];
+    return [
+      ...new Set([...this.handles.keys(), ...this.childActivations.keys()]),
+    ];
   }
 
   /**
@@ -861,5 +880,7 @@ export class ExecutionRegistry {
     if (this.childActivations.get(executionId) !== expected) return;
     this.childActivations.delete(executionId);
     this.interactionOwnership.observeChildActivation(expected, false);
+    // The loop's last record is gone: a waiter on its settlement wakes.
+    this.notifyWaiters(executionId);
   }
 }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -132,6 +132,8 @@ export class ExecutionRegistry {
   readonly interactionOwnership = new ExecutionInteractionOwnership(this);
   private readonly handles = new Map<string, AgentExecutionHandle>();
   private disposed = false;
+  /** Set by {@link closeAdmissions}: the session is closing. */
+  private closing = false;
   private readonly streamStatus: StreamStatusMachine;
   private readonly publish: (events: readonly SessionEventDraft[]) => void;
   private readonly childActivityListeners = new Set<
@@ -319,9 +321,24 @@ export class ExecutionRegistry {
     this.track(handle);
   }
 
+  /**
+   * Refuse every execution registered from here on: the session is closing
+   * (`Sessions.close`). The executions already tracked keep their handles,
+   * waiters, and status until they settle, which is what the close waits
+   * for; only new admissions are turned away.
+   */
+  closeAdmissions(): void {
+    this.closing = true;
+  }
+
   private assertActive(): void {
     if (this.disposed) {
       throw new Error('Cannot register execution work after session disposal.');
+    }
+    if (this.closing) {
+      throw new Error(
+        'Cannot register execution work while the session is closing.',
+      );
     }
   }
 

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -29,7 +29,7 @@ export {
 
 // sessionGraph: the process's session owner, as the hosts and the SDK open
 // and close sessions through it (one session per workspace storage root).
-export { closeSession, openSession } from './sessionGraph';
+export { closeSession, openSession, openSessionAsync } from './sessionGraph';
 
 // RunContext: the session scope a host enters around every touch of a
 // session's storage when it holds several sessions in one process.

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -27,6 +27,10 @@ export {
   tryDefaultSession,
 } from './SessionHandle';
 
+// sessionGraph: the process's session owner, as the hosts and the SDK open
+// and close sessions through it (one session per workspace storage root).
+export { closeSession, openSession } from './sessionGraph';
+
 // RunContext: the session scope a host enters around every touch of a
 // session's storage when it holds several sessions in one process.
 export { runInSession } from './RunContext';

--- a/src/agent/runtime/sessionGraph.ts
+++ b/src/agent/runtime/sessionGraph.ts
@@ -82,8 +82,9 @@ export interface SessionOwner {
   /** The session of `open.roots`' storage root: the one already open there,
    *  or built now over what `open` supplies. */
   open(open: SessionOpen): SessionHandle;
-  /** Close the session of a storage root, settling what it owns. */
-  close(root: string): Promise<SessionCloseReport>;
+  /** Close the session of a storage root, settling what it owns inside
+   *  `signal`'s budget, or the runtime's own when the caller passes none. */
+  close(root: string, signal?: AbortSignal): Promise<SessionCloseReport>;
 }
 
 let owner: SessionOwner | undefined;
@@ -127,13 +128,20 @@ export function openSession(init: SessionHandleInit): SessionHandle {
 /**
  * Close the session of a storage root (proposal 2026-09-05, section 9):
  * refuse new executions on it, interrupt the ones it owns and wait for
- * them to settle within the process's shutdown-phase budget, flush its
- * artifacts, and release it from its owner. A root with no open session
- * has nothing to close and reports `settled`. A session whose executions
+ * them to settle within `signal`'s budget (the caller's shutdown phase) or,
+ * without one, the process's shutdown-phase budget, flush its artifacts,
+ * and release it from its owner. A root with no open session has nothing
+ * to close and reports `settled`; so does a process with no owner
+ * installed, where no session was ever opened. A session whose executions
  * outlive the budget is reported `abandoned` and stays open, refusing new
  * work, until they end; it is released then, never before. This never
  * touches the process lifecycle or another root's session.
  */
-export function closeSession(root: string): Promise<SessionCloseReport> {
-  return sessions().close(root);
+export function closeSession(
+  root: string,
+  signal?: AbortSignal,
+): Promise<SessionCloseReport> {
+  return owner
+    ? owner.close(root, signal)
+    : Promise.resolve({ settled: true, abandoned: [] });
 }

--- a/src/agent/runtime/sessionGraph.ts
+++ b/src/agent/runtime/sessionGraph.ts
@@ -14,6 +14,7 @@
 
 import {
   processWorkspaceRoots,
+  tryProcessWorkspaceRoots,
   type WorkspaceRoots,
 } from '@platform/workspaceRoots';
 import type {
@@ -82,6 +83,12 @@ export interface SessionOwner {
   /** The session of `open.roots`' storage root: the one already open there,
    *  or built now over what `open` supplies. */
   open(open: SessionOpen): SessionHandle;
+  /** The same open for a process still reading its identity (the package):
+   *  the root's entry is registered with the owner before this returns, so
+   *  a close issued after it finds the session and waits for its build. */
+  openAsync(open: SessionOpen): Promise<SessionHandle>;
+  /** The session open on a storage root, if one is; never builds one. */
+  current(root: string): SessionHandle | undefined;
   /** Close the session of a storage root, settling what it owns inside
    *  `signal`'s budget, or the runtime's own when the caller passes none. */
   close(root: string, signal?: AbortSignal): Promise<SessionCloseReport>;
@@ -89,9 +96,13 @@ export interface SessionOwner {
 
 let owner: SessionOwner | undefined;
 
-/** Install the process's session owner. Called by `installProcessRuntime`
- *  exactly once at startup, right beside `initPlatform()`. */
-export function initSessionOwner(sessions: SessionOwner): void {
+/** Install the process's session owner, or uninstall it with `undefined`.
+ *  Called by `installProcessRuntime` exactly once at startup, right beside
+ *  `initPlatform()`, and by `disposeProcessRuntime` in the shutdown step
+ *  that disposes the runtime the owner runs on: from then on a close
+ *  answers as a process with no owner does, instead of reaching a disposed
+ *  runtime. */
+export function initSessionOwner(sessions: SessionOwner | undefined): void {
   owner = sessions;
 }
 
@@ -115,24 +126,52 @@ function sessions(): SessionOwner {
  * opener of the same root gets the session the first opener built.
  *
  * The returned handle is borrowed access to an owner-held session
- * (proposal 2026-09-05, section 3): holding it carries no disposal
- * obligation, and {@link closeSession} is how the session ends.
+ * (PR #11893, agent SDK architecture proposal, section 3): holding it
+ * carries no disposal obligation, and {@link closeSession} is how the
+ * session ends.
  */
 export function openSession(init: SessionHandleInit): SessionHandle {
-  return sessions().open({
-    ...init,
-    roots: init.roots ?? processWorkspaceRoots(),
-  });
+  return sessions().open(resolveRoots(init));
 }
 
 /**
- * Close the session of a storage root (proposal 2026-09-05, section 9):
- * refuse new executions on it, interrupt the ones it owns and wait for
- * them to settle within `signal`'s budget (the caller's shutdown phase) or,
- * without one, the process's shutdown-phase budget, flush its artifacts,
- * and release it from its owner. A root with no open session has nothing
- * to close and reports `settled`; so does a process with no owner
- * installed, where no session was ever opened. A session whose executions
+ * {@link openSession} for an opener whose process identity is still being
+ * read (the package, whose composition root is its first run): the root's
+ * entry is registered with the owner before this returns, so a close or a
+ * shutdown issued right after it settles this open too, and the handle
+ * arrives when the session is built.
+ */
+export function openSessionAsync(
+  init: SessionHandleInit,
+): Promise<SessionHandle> {
+  return sessions().openAsync(resolveRoots(init));
+}
+
+function resolveRoots(init: SessionHandleInit): SessionOpen {
+  return { ...init, roots: init.roots ?? processWorkspaceRoots() };
+}
+
+/**
+ * The session open on the process roots' storage root, if one is: the
+ * hosts' default session, read through its owner on every call rather than
+ * from a cached reference, so a root closed through the owner has no
+ * default session until one is opened again. No owner, or no process
+ * roots yet, no session.
+ */
+export function defaultRootSession(): SessionHandle | undefined {
+  const roots = tryProcessWorkspaceRoots();
+  return roots && owner?.current(roots.storage);
+}
+
+/**
+ * Close the session of a storage root (PR #11893, agent SDK architecture
+ * proposal, section 9): refuse new executions on it, interrupt the ones it
+ * owns and wait for them to settle within `signal`'s budget (the caller's
+ * shutdown phase) or, without one, the process's shutdown-phase budget,
+ * flush its artifacts, and release it from its owner. A root with no open
+ * session has nothing to close and reports `settled`; so does a process
+ * with no owner installed, where no session was ever opened or the owner
+ * has gone with its runtime. A session whose executions
  * outlive the budget is reported `abandoned` and stays open, refusing new
  * work, until they end; it is released then, never before. This never
  * touches the process lifecycle or another root's session.

--- a/src/agent/runtime/sessionGraph.ts
+++ b/src/agent/runtime/sessionGraph.ts
@@ -1,19 +1,25 @@
 /**
- * The session graph port: how a `SessionHandle` reaches the Effect services
- * of its session (PRD one-fold-three-renderers, 7.2, 7.3, 7.7) without this
- * layer importing them. The services are built per workspace root by the
- * `Sessions` layer map in `src/controllers/session/sessionLayer.ts`, on the
- * one `ManagedRuntime` each process makes at its entry
- * (`installProcessRuntime`), which installs the opener here beside
+ * The session owner port: how `src/agent` opens and closes sessions through
+ * the process's one session owner (PRD one-fold-three-renderers, 7.2, 7.3,
+ * 7.7) without importing it. The owner is the `Sessions` map in
+ * `src/controllers/session/sessionLayer.ts`, keyed by workspace storage
+ * root: it builds each root's Effect graph and the `SessionHandle` over it
+ * on the one `ManagedRuntime` the process makes at its entry
+ * (`installProcessRuntime`), which installs the owner here beside
  * `initPlatform()`, exactly as it installs the process roots. `src/agent`
- * never imports `src/controllers`, so the graph arrives through this port
+ * never imports `src/controllers`, so the owner arrives through this port
  * rather than by import; the runtime itself is reached through
  * `effectRuntime()` (`@platform/processRuntime`).
  */
 
+import {
+  processWorkspaceRoots,
+  type WorkspaceRoots,
+} from '@platform/workspaceRoots';
 import type {
   CommitOrdinal,
   LocalRuntimeState,
+  SessionCloseReport,
   SessionEvent,
   TranscriptSubscription,
 } from '@shared/schemas';
@@ -23,7 +29,7 @@ import type { SessionView } from '@shared/session/sessionView';
 import type { SessionEventsShape } from '@shared/session/sessionEvents';
 import type { SessionInputs } from '@shared/session/sessionInputs';
 import type { Context, Effect, Stream, SubscriptionRef } from 'effect';
-import type { SessionHandle } from './SessionHandle';
+import type { SessionHandle, SessionHandleInit } from './SessionHandle';
 
 /** What a session holds of its graph, resolved once at construction. */
 export interface SessionGraph {
@@ -61,26 +67,73 @@ export interface SessionGraph {
   /** The session's current commit ordinal: where a reader attaching now
    *  starts its `all` read (PRD 10.3). */
   readonly now: () => CommitOrdinal;
-  /** Release this session's hold on the graph. */
+  /** Release the session from its owner: the owner unwinds the session and
+   *  frees the root's graph after it. */
   readonly close: () => void;
 }
 
-export type SessionGraphOpener = (session: SessionHandle) => SessionGraph;
+/** What opening a session supplies, with its roots resolved. */
+export type SessionOpen = SessionHandleInit & {
+  readonly roots: WorkspaceRoots;
+};
 
-let opener: SessionGraphOpener | undefined;
-
-/** Install the process's graph opener. Called by `installProcessRuntime`
- *  exactly once at startup, right beside `initPlatform()`. */
-export function initSessionGraphs(open: SessionGraphOpener): void {
-  opener = open;
+/** The process's session owner, as `installProcessRuntime` installs it. */
+export interface SessionOwner {
+  /** The session of `open.roots`' storage root: the one already open there,
+   *  or built now over what `open` supplies. */
+  open(open: SessionOpen): SessionHandle;
+  /** Close the session of a storage root, settling what it owns. */
+  close(root: string): Promise<SessionCloseReport>;
 }
 
-/** Open the graph of `session`'s workspace root. */
-export function openSessionGraph(session: SessionHandle): SessionGraph {
-  if (!opener) {
+let owner: SessionOwner | undefined;
+
+/** Install the process's session owner. Called by `installProcessRuntime`
+ *  exactly once at startup, right beside `initPlatform()`. */
+export function initSessionOwner(sessions: SessionOwner): void {
+  owner = sessions;
+}
+
+function sessions(): SessionOwner {
+  if (!owner) {
     throw new Error(
-      'Session graphs not initialized: call installProcessRuntime() before constructing a session.',
+      'Sessions not initialized: call installProcessRuntime() before opening a session.',
     );
   }
-  return opener(session);
+  return owner;
+}
+
+/**
+ * Open the session of `init`'s workspace root, or return the one already
+ * open there: one session per storage root in a process. Process roots
+ * unless the opener names a folder: the extension, the CLI, and the SDK
+ * open exactly one session over the process roots; the desktop opens one
+ * session per paper and passes that paper's roots. What `init` supplies
+ * beyond the roots (the transcript store, the sidecar store, the response
+ * text policy) is read only when the root's session is built: a later
+ * opener of the same root gets the session the first opener built.
+ *
+ * The returned handle is borrowed access to an owner-held session
+ * (proposal 2026-09-05, section 3): holding it carries no disposal
+ * obligation, and {@link closeSession} is how the session ends.
+ */
+export function openSession(init: SessionHandleInit): SessionHandle {
+  return sessions().open({
+    ...init,
+    roots: init.roots ?? processWorkspaceRoots(),
+  });
+}
+
+/**
+ * Close the session of a storage root (proposal 2026-09-05, section 9):
+ * refuse new executions on it, interrupt the ones it owns and wait for
+ * them to settle within the process's shutdown-phase budget, flush its
+ * artifacts, and release it from its owner. A root with no open session
+ * has nothing to close and reports `settled`. A session whose executions
+ * outlive the budget is reported `abandoned` and stays open, refusing new
+ * work, until they end; it is released then, never before. This never
+ * touches the process lifecycle or another root's session.
+ */
+export function closeSession(root: string): Promise<SessionCloseReport> {
+  return sessions().close(root);
 }

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -37,6 +37,7 @@ import {
   RcMap,
   Stream,
   SubscriptionRef,
+  Fiber,
 } from 'effect';
 
 import { proveOwnerLiveness } from '@agent/storage/leaseOwnerLiveness';
@@ -476,10 +477,12 @@ const closeSession = (root: string, signal?: AbortSignal) =>
           untilSettled(executions, interrupt),
         ) as Promise<void>,
     );
-    yield* Effect.race(
-      settled,
+    // One budget for the whole close: the caller's signal, else the phase
+    // deadline, forked once so the flush below shares what settlement left.
+    const budget = yield* Effect.forkChild(
       signal ? aborted(signal) : Effect.sleep(SHUTDOWN_PHASE_DEADLINE_MS),
     );
+    yield* Effect.race(settled, Fiber.join(budget));
     const abandoned = executions.getActiveIds();
     const release =
       abandoned.length === 0
@@ -501,9 +504,22 @@ const closeSession = (root: string, signal?: AbortSignal) =>
     // The release is the flush's finalizer: the entry goes, or its release
     // is armed on the settlement, whatever the flush's exit, and a flush
     // that fails still fails this close.
-    yield* Effect.promise(
-      () =>
-        runInSession(session, () => session.flushArtifacts()) as Promise<void>,
+    yield* Effect.race(
+      Effect.promise(
+        () =>
+          runInSession(session, () =>
+            session.flushArtifacts(),
+          ) as Promise<void>,
+      ),
+      Fiber.join(budget).pipe(
+        Effect.andThen(
+          Effect.sync(() =>
+            log.warn(
+              `Session ${root}: the artifact flush ran past the close budget and was left to the process teardown`,
+            ),
+          ),
+        ),
+      ),
     ).pipe(Effect.ensuring(release));
     const report: SessionCloseReport = {
       settled: abandoned.length === 0,

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -1,15 +1,17 @@
 /**
  * The per-session Effect graph and the process's keyed family of them (PRD
  * one-fold-three-renderers, 7.3 and 7.7). `Sessions` is a `LayerMap`
- * keyed by workspace root: one graph per root and one only, built on the
- * one `ManagedRuntime` each process makes at its entry
- * (`installProcessRuntime`). The root graph holds only root-scoped
- * services: the memory log over the root's transcript store, the fold, the
- * three local sources, the owner-liveness prober, and the transcript
- * bridge. What is bound to one `SessionHandle` (its request handler) is
- * built per handle in `sessionGraphOpener`, under a scope the handle closes
- * on dispose, so two handles on one root share the graph and never each
- * other's session.
+ * keyed by workspace storage root: one session per root and one only,
+ * built on the one `ManagedRuntime` each process makes at its entry
+ * (`installProcessRuntime`). A root's entry is the complete session: the
+ * root-scoped services (the memory log over the root's transcript store,
+ * the fold, the three local sources, the owner-liveness prober, and the
+ * transcript bridge) and the `SessionHandle` built over them, whose request
+ * handler admits on that graph. Every opener (the hosts' default session,
+ * the desktop's papers, the SDK) resolves its root here, so opening a root
+ * twice returns one handle, and the map is the one owner of its lifetime:
+ * an open borrows, `close` settles and releases, and the runtime's disposal
+ * releases whatever is still open.
  *
  * Two pieces of this file exist only until the persistence cutover and are
  * marked so: the hydration importer, the first layer of the root graph,
@@ -24,20 +26,23 @@ import * as os from 'node:os';
 
 import {
   Context,
+  Duration,
   Effect,
   Equal,
-  Exit,
   Hash,
   Layer,
   LayerMap,
   ManagedRuntime,
+  Option,
   Queue,
-  Scope,
+  RcMap,
   Stream,
   SubscriptionRef,
 } from 'effect';
 
 import { proveOwnerLiveness } from '@agent/storage/leaseOwnerLiveness';
+import { runInSession } from '@agent/runtime/RunContext';
+import type { ExecutionRegistry } from '@agent/runtime/executionRegistry';
 import {
   ownerProcessStart,
   processOwnerId,
@@ -45,20 +50,22 @@ import {
   sessionEventsLayer,
   tailFrom,
 } from '@agent/runtime/SessionEvents';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
-  initSessionGraphs,
+  initSessionOwner,
   type SessionGraph,
-  type SessionGraphOpener,
+  type SessionOpen,
 } from '@agent/runtime/sessionGraph';
 import { createLog } from '@logger/logUtils';
 import {
   initProcessRuntime,
   type ProcessRuntime,
 } from '@platform/processRuntime';
-import type { WorkspaceRoots as HostWorkspaceRoots } from '@platform/workspaceRoots';
+import { SHUTDOWN_PHASE_DEADLINE_MS } from '@platform/defaults/lifecycleHost';
 import {
   USER_FOLLOW_UP_SUPPORT,
   type OwnerId,
+  type SessionCloseReport,
   type SessionEventDraft,
   type StreamTabId,
 } from '@shared/schemas';
@@ -87,28 +94,34 @@ const log = createLog('sessionLayer');
 const OWNER_LIVENESS_PROBE_INTERVAL = '5 seconds';
 
 /**
- * Which session a graph is of: its workspace roots, equal and hashed by the
- * storage root alone, the value `SessionView.key` carries, together with
- * the root's transcript store, the pre-cutover transcript tier the graph
- * reads and bridges. Two handles on one root resolve one graph, over the
- * store the first of them opened; nothing handle-bound is on the key.
+ * Which session an entry is: its storage root, the value `SessionView.key`
+ * carries, together with what the opener supplied for building it (the
+ * roots, the root's transcript store the graph reads and bridges, the
+ * sidecar store, the response text policy, the host it is born with).
+ * Equal and hashed by the storage root alone: two opens of one root resolve
+ * one session, over what the first of them supplied. Nothing store-bound
+ * can be injected past that boundary (proposal 2026-09-05, section 3).
  */
 class SessionKey implements Equal.Equal {
-  constructor(
-    readonly roots: HostWorkspaceRoots,
-    readonly transcripts: StreamLogStore,
-  ) {}
+  constructor(readonly open: SessionOpen) {}
+
+  get storage(): string {
+    return this.open.roots.storage;
+  }
 
   [Equal.symbol](that: Equal.Equal): boolean {
-    return (
-      that instanceof SessionKey && that.roots.storage === this.roots.storage
-    );
+    return that instanceof SessionKey && that.storage === this.storage;
   }
 
   [Hash.symbol](): number {
-    return Hash.string(this.roots.storage);
+    return Hash.string(this.storage);
   }
 }
+
+/** The session of one root: the handle the map built over the root's graph. */
+class Session extends Context.Service<Session, SessionHandle>()(
+  '@texra/session/Session',
+) {}
 
 /** The owner ids of the non-terminal streams another process wrote. */
 function foreignOwners(view: SessionView, self: OwnerId): OwnerId[] {
@@ -365,126 +378,245 @@ const transcriptBridge = (transcripts: StreamLogStore) =>
   );
 
 /**
- * The runtime graph of one root (PRD 7.3). `Layer.fresh`: the layer map
- * builds every key's graph through one memo map, and layers memoize by
- * reference, so without it the static service layers would be built once
- * and every root on the process would share one log and one fold.
+ * The handle of one root, over the root's graph: the last layer of the
+ * entry, so it is the first thing unwound when the entry closes and the
+ * graph outlives every publisher above it. Every release goes through the
+ * entry: `close` and the runtime's disposal invalidate it, and the handle's
+ * own `dispose` asks for the same through `graph.close`.
  */
-const sessionLayer = (key: SessionKey) =>
-  Layer.fresh(
-    Layer.mergeAll(ownerLiveness, transcriptBridge(key.transcripts)).pipe(
-      Layer.provideMerge(SessionViewService.layer),
-      Layer.provideMerge(sessionInputsLayer),
-      Layer.provideMerge(
-        sessionEventsLayer.pipe(
-          Layer.provideMerge(
-            historyImport(key.transcripts).pipe(
-              Layer.provideMerge(
-                SessionEventLog.memoryLayer(key.transcripts, key.roots),
+const sessionHandleLayer = (
+  key: SessionKey,
+  release: (key: SessionKey) => void,
+) =>
+  Layer.effect(
+    Session,
+    Effect.gen(function* () {
+      const { publish, ...reads } = yield* SessionEvents;
+      const eventLog = yield* SessionEventLog;
+      const view = yield* SessionViewService;
+      const local = yield* LocalRuntimeSource;
+      const inputs = yield* SessionInputs;
+      const subscriptions = yield* TranscriptSubscriptions;
+      const graph = (session: SessionHandle): SessionGraph => ({
+        events: reads,
+        publish,
+        view: view.ref,
+        viewChanges: view.changes,
+        // The plane's tail woken by the view's cursor instead of the log's
+        // level: the same rows `events.all` delivers, none before the fold
+        // has landed the state it produced.
+        folded: (fromCommit) =>
+          tailFrom(
+            eventLog.readAll,
+            {
+              get: SubscriptionRef.get(view.ref).pipe(
+                Effect.map((v) => v.cursor),
               ),
+              changes: SubscriptionRef.changes(view.ref).pipe(
+                Stream.map((v) => v.cursor),
+              ),
+            },
+            fromCommit,
+          ),
+        local: local.ref,
+        inputs: inputs.read,
+        subscriptions,
+        // The request handler admits on the root graph's log.
+        requests: sessionRequests(session, eventLog),
+        now: () => SubscriptionRef.getUnsafe(eventLog.level),
+        close: () => release(key),
+      });
+      return yield* Effect.acquireRelease(
+        Effect.sync(() => new SessionHandle({ ...key.open, graph })),
+        (session) => Effect.sync(() => session.unwind()),
+      );
+    }),
+  );
+
+/** The runtime graph of one root (PRD 7.3): the root-scoped services the
+ *  handle is built over. */
+const sessionGraphLayer = (key: SessionKey) =>
+  Layer.mergeAll(ownerLiveness, transcriptBridge(key.open.transcripts)).pipe(
+    Layer.provideMerge(SessionViewService.layer),
+    Layer.provideMerge(sessionInputsLayer),
+    Layer.provideMerge(
+      sessionEventsLayer.pipe(
+        Layer.provideMerge(
+          historyImport(key.open.transcripts).pipe(
+            Layer.provideMerge(
+              SessionEventLog.memoryLayer(key.open.transcripts, key.open.roots),
             ),
           ),
         ),
       ),
-      Layer.provideMerge(
-        Layer.mergeAll(
-          LocalRuntimeSource.layer,
-          TextChunkSource.layer,
-          TranscriptSubscriptions.layer,
-        ),
+    ),
+    Layer.provideMerge(
+      Layer.mergeAll(
+        LocalRuntimeSource.layer,
+        TextChunkSource.layer,
+        TranscriptSubscriptions.layer,
       ),
-      Layer.provide(Layer.succeed(WorkspaceRoots)(key.roots)),
+    ),
+    Layer.provide(Layer.succeed(WorkspaceRoots)(key.open.roots)),
+  );
+
+/**
+ * The complete session of one root: the handle over the root's graph, the
+ * handle alone being the entry's service. `Layer.fresh`: the layer map
+ * builds every key's entry through one memo map, and layers memoize by
+ * reference, so without it the static service layers would be built once
+ * and every root on the process would share one log and one fold.
+ */
+const sessionLayer = (key: SessionKey, release: (key: SessionKey) => void) =>
+  Layer.fresh(
+    sessionHandleLayer(key, release).pipe(
+      Layer.provide(sessionGraphLayer(key)),
     ),
   );
 
 /**
- * The keyed resource family the desktop's N papers need: one graph per
- * root, released when the last session holding it closes. No idle window:
- * the memory graph is free to rebuild, and a database connection worth
- * keeping warm arrives with the cutover.
+ * The keyed resource family the desktop's N papers and the SDK's N roots
+ * need: one session per root, held by the map until `close` releases it
+ * or the runtime goes. Opens borrow (the reference an open takes is
+ * released at once) and the idle lifetime is infinite, so no reader's
+ * detachment and no reference count decides a session's end: the
+ * application does, explicitly (proposal 2026-09-05, section 3).
  */
-class Sessions extends LayerMap.Service<Sessions>()('@texra/session/Sessions', {
-  lookup: (key: SessionKey) => sessionLayer(key),
-}) {}
+class Sessions extends Context.Service<
+  Sessions,
+  LayerMap.LayerMap<SessionKey, Session>
+>()('@texra/session/Sessions') {
+  /** The map, releasing an entry the handle asked to be released through
+   *  the runtime that holds the map. */
+  static layer(release: (key: SessionKey) => void) {
+    return Layer.effect(
+      Sessions,
+      LayerMap.make((key: SessionKey) => sessionLayer(key, release), {
+        idleTimeToLive: Duration.infinity,
+      }),
+    );
+  }
+}
 
-/** The process layer: the session family over the process identity. */
-const processLayer = (ownerId: OwnerId) =>
-  Sessions.layerNoDeps.pipe(Layer.provide(ProcessIdentity.layer(ownerId)));
+/** The session of `open`'s root: built now, or the one already open. A
+ *  build that fails leaves no entry behind (the map would otherwise answer
+ *  every later open of the root with the cached failure). */
+const openSession = (open: SessionOpen) =>
+  Effect.gen(function* () {
+    const sessions = yield* Sessions;
+    const key = new SessionKey(open);
+    const context = yield* sessions
+      .contextEffect(key)
+      .pipe(Effect.onError(() => sessions.invalidate(key)));
+    return Context.get(context, Session);
+  }).pipe(Effect.scoped);
+
+/** Resolve once every execution the registry holds has left it. Detaches
+ *  on `signal`, so a bounded wait leaves no listener behind. */
+async function untilSettled(
+  executions: ExecutionRegistry,
+  signal: AbortSignal,
+): Promise<void> {
+  for (;;) {
+    const active = executions.getActiveIds();
+    if (active.length === 0 || signal.aborted) return;
+    await executions.waitForAnyChange(active, signal);
+  }
+}
+
+/**
+ * Close the session of one root (proposal 2026-09-05, section 9): refuse
+ * new executions, stop the root executions it owns (the stop cascades into
+ * their children), wait for their drivers to settle them inside the
+ * lifecycle's phase budget, flush the session's artifacts while its stores
+ * are still open, and release the entry. Executions that outlive the
+ * budget are reported, and the entry stays, refusing new work, until they
+ * actually settle; only then is it released, so no later open builds a
+ * second session over a root whose stores a run still writes. Nothing here
+ * touches the process lifecycle or another root.
+ */
+const closeSession = (root: string) =>
+  Effect.gen(function* () {
+    const sessions = yield* Sessions;
+    const keys = yield* RcMap.keys(sessions.rcMap);
+    const key = [...keys].find((candidate) => candidate.storage === root);
+    if (key === undefined) return { settled: true, abandoned: [] };
+    const held = yield* sessions.contextEffectOption(key).pipe(Effect.scoped);
+    if (Option.isNone(held)) return { settled: true, abandoned: [] };
+    const session = Context.get(held.value, Session);
+    const { executions } = session;
+    executions.closeAdmissions();
+    // Every touch of the session's storage runs in its scope: the stop
+    // writes each run's outcome under the session's roots, and the flush
+    // writes its stores there.
+    yield* Effect.sync(() =>
+      runInSession(session, () => {
+        for (const executionId of executions.getActiveIds()) {
+          if (executions.getHandle(executionId)?.isChildExecution) continue;
+          executions.kill(executionId, { detachActiveChildren: false });
+        }
+      }),
+    );
+    const settled = Effect.promise(
+      (signal) =>
+        runInSession(session, () =>
+          untilSettled(executions, signal),
+        ) as Promise<void>,
+    );
+    yield* settled.pipe(Effect.timeoutOption(SHUTDOWN_PHASE_DEADLINE_MS));
+    const abandoned = executions.getActiveIds();
+    yield* Effect.promise(
+      () =>
+        runInSession(session, () => session.flushArtifacts()) as Promise<void>,
+    );
+    const release = sessions.invalidate(key);
+    if (abandoned.length === 0) {
+      yield* release;
+    } else {
+      log.warn(
+        `Session ${root} is closing with executions still live past the ${SHUTDOWN_PHASE_DEADLINE_MS}ms budget: ${abandoned.join(', ')}; it stays open, refusing new work, until they settle`,
+      );
+      // Started now, so the wait holds its listener before this close
+      // returns and no timer stands between the report and the release.
+      yield* Effect.forkDetach(settled.pipe(Effect.andThen(release)), {
+        startImmediately: true,
+      });
+    }
+    const report: SessionCloseReport = {
+      settled: abandoned.length === 0,
+      abandoned,
+    };
+    return report;
+  });
 
 /**
  * Make the one Effect runtime of this process over its identity (PRD 7.7)
- * and install it with the session graph family it serves: called by a
+ * and install it with the session family it serves: called by a
  * composition root exactly once at startup, right beside `initPlatform()`,
  * which disposes the returned runtime on its shutdown path after the last
- * session has released its graph.
+ * session has released its graph. The owner it installs is the map's
+ * Promise-and-sync face: `open` builds under `runSync`, so everything a
+ * root's graph does at build time, the history import included, must
+ * complete inside the scheduler's yield budget (`Scheduler.MaxOpsBeforeYield`
+ * steps per yield) or the open reads as asynchronous and throws. The import
+ * appends the whole history in one call for that reason; moving it to row
+ * open (#11907) is what removes the history pass from here.
  */
 export function installProcessRuntime(
   processStart: string | undefined,
 ): ProcessRuntime {
+  const release = (key: SessionKey): void => {
+    runtime.runFork(Effect.flatMap(Sessions, (s) => s.invalidate(key)));
+  };
   const runtime = ManagedRuntime.make(
-    processLayer(processOwnerId(processStart)),
+    Sessions.layer(release).pipe(
+      Layer.provide(ProcessIdentity.layer(processOwnerId(processStart))),
+    ),
   );
   initProcessRuntime(runtime);
-  initSessionGraphs(sessionGraphOpener(runtime));
+  initSessionOwner({
+    open: (open) => runtime.runSync(openSession(open)),
+    close: (root) => runtime.runPromise(closeSession(root)),
+  });
   return runtime;
-}
-
-/**
- * The opener a process installs through `installProcessRuntime`: resolves
- * the graph of the session's root under a scope the session closes on
- * dispose (building it, history import first, when the session is the
- * root's first) and builds the session-bound services under it.
- */
-function sessionGraphOpener(
-  runtime: ManagedRuntime.ManagedRuntime<Sessions, never>,
-): SessionGraphOpener {
-  return (session) => {
-    // The build runs under `runSync`, so everything a root's graph does at
-    // build time, the history import included, must complete inside the
-    // scheduler's yield budget (`Scheduler.MaxOpsBeforeYield` steps per
-    // yield) or the open reads as asynchronous and throws. The import
-    // appends the whole history in one call for that reason; moving it to
-    // row open (#11907) is what removes the history pass from here.
-    const scope = runtime.runSync(Scope.make());
-    const context = runtime.runSync(
-      Sessions.contextEffect(
-        new SessionKey(session.roots, session.transcripts),
-      ).pipe(Effect.provideService(Scope.Scope, scope)),
-    );
-    const { publish, ...reads } = Context.get(context, SessionEvents);
-    const eventLog = Context.get(context, SessionEventLog);
-    const view = Context.get(context, SessionViewService);
-    const graph: SessionGraph = {
-      events: reads,
-      publish,
-      view: view.ref,
-      viewChanges: view.changes,
-      // The plane's tail woken by the view's cursor instead of the log's
-      // level: the same rows `events.all` delivers, none before the fold
-      // has landed the state it produced.
-      folded: (fromCommit) =>
-        tailFrom(
-          eventLog.readAll,
-          {
-            get: SubscriptionRef.get(view.ref).pipe(
-              Effect.map((v) => v.cursor),
-            ),
-            changes: SubscriptionRef.changes(view.ref).pipe(
-              Stream.map((v) => v.cursor),
-            ),
-          },
-          fromCommit,
-        ),
-      local: Context.get(context, LocalRuntimeSource).ref,
-      inputs: Context.get(context, SessionInputs).read,
-      subscriptions: Context.get(context, TranscriptSubscriptions),
-      // The request handler admits on the root graph's log.
-      requests: sessionRequests(session, eventLog),
-      now: () => SubscriptionRef.getUnsafe(eventLog.level),
-      close: () => {
-        runtime.runFork(Scope.close(scope, Exit.void));
-      },
-    };
-    return graph;
-  };
 }

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -56,10 +56,7 @@ import {
   type SessionOpen,
 } from '@agent/runtime/sessionGraph';
 import { createLog } from '@logger/logUtils';
-import {
-  initProcessRuntime,
-  type ProcessRuntime,
-} from '@platform/processRuntime';
+import { effectRuntime, initProcessRuntime } from '@platform/processRuntime';
 import { SHUTDOWN_PHASE_DEADLINE_MS } from '@platform/defaults/lifecycleHost';
 import {
   type OwnerId,
@@ -97,7 +94,8 @@ const OWNER_LIVENESS_PROBE_INTERVAL = '5 seconds';
  * sidecar store, the response text policy, the host it is born with).
  * Equal and hashed by the storage root alone: two opens of one root resolve
  * one session, over what the first of them supplied. Nothing store-bound
- * can be injected past that boundary (proposal 2026-09-05, section 3).
+ * can be injected past that boundary (PR #11893, agent SDK architecture
+ * proposal, section 3).
  */
 class SessionKey implements Equal.Equal {
   constructor(readonly open: SessionOpen) {}
@@ -336,12 +334,21 @@ const sessionGraphLayer = (key: SessionKey) =>
  * handle alone being the entry's service. `Layer.fresh`: the layer map
  * builds every key's entry through one memo map, and layers memoize by
  * reference, so without it the static service layers would be built once
- * and every root on the process would share one log and one fold.
+ * and every root on the process would share one log and one fold. The
+ * process identity is provided here, per entry, rather than under the map:
+ * the map then builds synchronously, so an open issued while the identity
+ * is still being read (the package's) registers its entry with the map
+ * before its first yield, and only the entry's build waits.
  */
-const sessionLayer = (key: SessionKey, release: (key: SessionKey) => void) =>
+const sessionLayer = (
+  key: SessionKey,
+  release: (key: SessionKey) => void,
+  identity: Layer.Layer<ProcessIdentity>,
+) =>
   Layer.fresh(
     sessionHandleLayer(key, release).pipe(
       Layer.provide(sessionGraphLayer(key)),
+      Layer.provide(identity),
     ),
   );
 
@@ -351,7 +358,8 @@ const sessionLayer = (key: SessionKey, release: (key: SessionKey) => void) =>
  * or the runtime goes. Opens borrow (the reference an open takes is
  * released at once) and the idle lifetime is infinite, so no reader's
  * detachment and no reference count decides a session's end: the
- * application does, explicitly (proposal 2026-09-05, section 3).
+ * application does, explicitly (PR #11893, agent SDK architecture
+ * proposal, section 3).
  */
 class Sessions extends Context.Service<
   Sessions,
@@ -359,10 +367,13 @@ class Sessions extends Context.Service<
 >()('@texra/session/Sessions') {
   /** The map, releasing an entry the handle asked to be released through
    *  the runtime that holds the map. */
-  static layer(release: (key: SessionKey) => void) {
+  static layer(
+    release: (key: SessionKey) => void,
+    identity: Layer.Layer<ProcessIdentity>,
+  ) {
     return Layer.effect(
       Sessions,
-      LayerMap.make((key: SessionKey) => sessionLayer(key, release), {
+      LayerMap.make((key: SessionKey) => sessionLayer(key, release, identity), {
         idleTimeToLive: Duration.infinity,
       }),
     );
@@ -381,6 +392,20 @@ const openSession = (open: SessionOpen) =>
       .pipe(Effect.onError(() => sessions.invalidate(key)));
     return Context.get(context, Session);
   }).pipe(Effect.scoped);
+
+/** The session held for `root`, if the map holds one: an entry still
+ *  building is waited for, never skipped. Builds nothing. */
+const heldSession = (root: string) =>
+  Effect.gen(function* () {
+    const sessions = yield* Sessions;
+    const keys = yield* RcMap.keys(sessions.rcMap);
+    const key = [...keys].find((candidate) => candidate.storage === root);
+    if (key === undefined) return undefined;
+    const held = yield* sessions.contextEffectOption(key).pipe(Effect.scoped);
+    return Option.isNone(held)
+      ? undefined
+      : { key, session: Context.get(held.value, Session) };
+  });
 
 /** Resolve once every execution the registry holds has left it. Detaches
  *  on `signal`, so a bounded wait leaves no listener behind. */
@@ -409,9 +434,11 @@ const aborted = (signal: AbortSignal) =>
   });
 
 /**
- * Close the session of one root (proposal 2026-09-05, section 9): refuse
- * new executions, stop the root executions it owns (the stop cascades into
- * their children), wait for their drivers to settle them inside one budget,
+ * Close the session of one root (PR #11893, agent SDK architecture
+ * proposal, section 9): refuse new executions, stop the root executions it
+ * owns (the stop cascades into their children) and the children no root
+ * owns any more (a native subagent detached from a stopped parent, between
+ * turns), wait for their drivers to settle them inside one budget,
  * flush the session's artifacts while its stores are still open, and
  * release the entry. The budget is the caller's `signal` when it passes one
  * (the lifecycle's shutdown phase, whose deadline started before this
@@ -424,17 +451,16 @@ const aborted = (signal: AbortSignal) =>
 const closeSession = (root: string, signal?: AbortSignal) =>
   Effect.gen(function* () {
     const sessions = yield* Sessions;
-    const keys = yield* RcMap.keys(sessions.rcMap);
-    const key = [...keys].find((candidate) => candidate.storage === root);
-    if (key === undefined) return NOTHING_TO_CLOSE;
-    const held = yield* sessions.contextEffectOption(key).pipe(Effect.scoped);
-    if (Option.isNone(held)) return NOTHING_TO_CLOSE;
-    const session = Context.get(held.value, Session);
+    const held = yield* heldSession(root);
+    if (held === undefined) return NOTHING_TO_CLOSE;
+    const { key, session } = held;
     const { executions } = session;
     executions.closeAdmissions();
     // Every touch of the session's storage runs in its scope: the stop
     // writes each run's outcome under the session's roots, and the flush
-    // writes its stores there.
+    // writes its stores there. A child with a handle is stopped by its
+    // parent's cascade; a native child between turns has no handle, and
+    // its kill interrupts the loop the registry retains for it.
     yield* Effect.sync(() =>
       runInSession(session, () => {
         for (const executionId of executions.getActiveIds()) {
@@ -490,30 +516,54 @@ const closeSession = (root: string, signal?: AbortSignal) =>
  * Make the one Effect runtime of this process over its identity (PRD 7.7)
  * and install it with the session family it serves: called by a
  * composition root exactly once at startup, right beside `initPlatform()`,
- * which disposes the returned runtime on its shutdown path after the last
- * session has released its graph. The owner it installs is the map's
- * Promise-and-sync face: `open` builds under `runSync`, so everything a
- * root's graph does at build time, the history import included, must
- * complete inside the scheduler's yield budget (`Scheduler.MaxOpsBeforeYield`
- * steps per yield) or the open reads as asynchronous and throws. The import
- * appends the whole history in one call for that reason; moving it to row
- * open (#11907) is what removes the history pass from here.
+ * which calls {@link disposeProcessRuntime} on its shutdown path after the
+ * last session has released its graph. The identity is the process start
+ * a host read before installing, or its pending read for a process whose
+ * composition root is its first run (the package): the map itself never
+ * waits for it, so an open registers its root with the owner before the
+ * caller's first await, and only the entry's build does. The owner it
+ * installs is the map's Promise-and-sync face: `open` builds under
+ * `runSync`, so everything a root's graph does at build time, the history
+ * import included, must complete inside the scheduler's yield budget
+ * (`Scheduler.MaxOpsBeforeYield` steps per yield) or the open reads as
+ * asynchronous and throws; an opener whose identity is pending opens through
+ * `openAsync`. The import appends the whole history in one call for that
+ * reason; moving it to row open (#11907) is what removes the history pass
+ * from here.
  */
 export function installProcessRuntime(
-  processStart: string | undefined,
-): ProcessRuntime {
+  processStart: string | undefined | Promise<string | undefined>,
+): void {
+  const identity =
+    processStart instanceof Promise
+      ? Layer.effect(
+          ProcessIdentity,
+          Effect.map(
+            Effect.promise(() => processStart),
+            (start) => ({ ownerId: processOwnerId(start) }),
+          ),
+        )
+      : ProcessIdentity.layer(processOwnerId(processStart));
   const release = (key: SessionKey): void => {
     runtime.runFork(Effect.flatMap(Sessions, (s) => s.invalidate(key)));
   };
-  const runtime = ManagedRuntime.make(
-    Sessions.layer(release).pipe(
-      Layer.provide(ProcessIdentity.layer(processOwnerId(processStart))),
-    ),
-  );
+  const runtime = ManagedRuntime.make(Sessions.layer(release, identity));
   initProcessRuntime(runtime);
   initSessionOwner({
     open: (open) => runtime.runSync(openSession(open)),
+    openAsync: (open) => runtime.runPromise(openSession(open)),
+    current: (root) => runtime.runSync(heldSession(root))?.session,
     close: (root, signal) => runtime.runPromise(closeSession(root, signal)),
   });
-  return runtime;
+}
+
+/**
+ * Uninstall the session owner and dispose the runtime it ran on, releasing
+ * every session still open there: the one shutdown step for both, so a
+ * close issued after it answers as a process with no owner does instead of
+ * reaching the disposed runtime.
+ */
+export function disposeProcessRuntime(): Promise<void> {
+  initSessionOwner(undefined);
+  return effectRuntime().dispose();
 }

--- a/src/controllers/session/sessionLayer.ts
+++ b/src/controllers/session/sessionLayer.ts
@@ -50,12 +50,12 @@ import {
   tailFrom,
 } from '@agent/runtime/SessionEvents';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
-import { createLog } from '@logger/logUtils';
 import {
   initSessionOwner,
   type SessionGraph,
   type SessionOpen,
 } from '@agent/runtime/sessionGraph';
+import { createLog } from '@logger/logUtils';
 import {
   initProcessRuntime,
   type ProcessRuntime,
@@ -395,25 +395,40 @@ async function untilSettled(
   }
 }
 
+/** A root with nothing open: nothing to settle, nothing abandoned. */
+const NOTHING_TO_CLOSE: SessionCloseReport = { settled: true, abandoned: [] };
+
+/** Resolves once `signal` aborts; interrupting it detaches the listener. */
+const aborted = (signal: AbortSignal) =>
+  Effect.callback<void>((resume, interrupt) => {
+    if (signal.aborted) return resume(Effect.void);
+    signal.addEventListener('abort', () => resume(Effect.void), {
+      once: true,
+      signal: interrupt,
+    });
+  });
+
 /**
  * Close the session of one root (proposal 2026-09-05, section 9): refuse
  * new executions, stop the root executions it owns (the stop cascades into
- * their children), wait for their drivers to settle them inside the
- * lifecycle's phase budget, flush the session's artifacts while its stores
- * are still open, and release the entry. Executions that outlive the
- * budget are reported, and the entry stays, refusing new work, until they
- * actually settle; only then is it released, so no later open builds a
- * second session over a root whose stores a run still writes. Nothing here
- * touches the process lifecycle or another root.
+ * their children), wait for their drivers to settle them inside one budget,
+ * flush the session's artifacts while its stores are still open, and
+ * release the entry. The budget is the caller's `signal` when it passes one
+ * (the lifecycle's shutdown phase, whose deadline started before this
+ * close), the lifecycle's phase deadline otherwise: never both. Executions
+ * that outlive the budget are reported, and the entry stays, refusing new
+ * work, until they actually settle; only then is it released, so no later
+ * open builds a second session over a root whose stores a run still
+ * writes. Nothing here touches the process lifecycle or another root.
  */
-const closeSession = (root: string) =>
+const closeSession = (root: string, signal?: AbortSignal) =>
   Effect.gen(function* () {
     const sessions = yield* Sessions;
     const keys = yield* RcMap.keys(sessions.rcMap);
     const key = [...keys].find((candidate) => candidate.storage === root);
-    if (key === undefined) return { settled: true, abandoned: [] };
+    if (key === undefined) return NOTHING_TO_CLOSE;
     const held = yield* sessions.contextEffectOption(key).pipe(Effect.scoped);
-    if (Option.isNone(held)) return { settled: true, abandoned: [] };
+    if (Option.isNone(held)) return NOTHING_TO_CLOSE;
     const session = Context.get(held.value, Session);
     const { executions } = session;
     executions.closeAdmissions();
@@ -428,31 +443,42 @@ const closeSession = (root: string) =>
         }
       }),
     );
+    // Ends at the actual settlement, or when interrupted.
     const settled = Effect.promise(
-      (signal) =>
+      (interrupt) =>
         runInSession(session, () =>
-          untilSettled(executions, signal),
+          untilSettled(executions, interrupt),
         ) as Promise<void>,
     );
-    yield* settled.pipe(Effect.timeoutOption(SHUTDOWN_PHASE_DEADLINE_MS));
+    yield* Effect.race(
+      settled,
+      signal ? aborted(signal) : Effect.sleep(SHUTDOWN_PHASE_DEADLINE_MS),
+    );
     const abandoned = executions.getActiveIds();
+    const release =
+      abandoned.length === 0
+        ? sessions.invalidate(key)
+        : Effect.sync(() =>
+            log.warn(
+              `Session ${root} is closing with executions still live past its budget: ${abandoned.join(', ')}; it stays open, refusing new work, until they settle`,
+            ),
+          ).pipe(
+            // Started now, so the wait holds its listener before this close
+            // returns and no timer stands between the report and the release.
+            Effect.andThen(
+              Effect.forkDetach(
+                settled.pipe(Effect.andThen(sessions.invalidate(key))),
+                { startImmediately: true },
+              ),
+            ),
+          );
+    // The release is the flush's finalizer: the entry goes, or its release
+    // is armed on the settlement, whatever the flush's exit, and a flush
+    // that fails still fails this close.
     yield* Effect.promise(
       () =>
         runInSession(session, () => session.flushArtifacts()) as Promise<void>,
-    );
-    const release = sessions.invalidate(key);
-    if (abandoned.length === 0) {
-      yield* release;
-    } else {
-      log.warn(
-        `Session ${root} is closing with executions still live past the ${SHUTDOWN_PHASE_DEADLINE_MS}ms budget: ${abandoned.join(', ')}; it stays open, refusing new work, until they settle`,
-      );
-      // Started now, so the wait holds its listener before this close
-      // returns and no timer stands between the report and the release.
-      yield* Effect.forkDetach(settled.pipe(Effect.andThen(release)), {
-        startImmediately: true,
-      });
-    }
+    ).pipe(Effect.ensuring(release));
     const report: SessionCloseReport = {
       settled: abandoned.length === 0,
       abandoned,
@@ -487,7 +513,7 @@ export function installProcessRuntime(
   initProcessRuntime(runtime);
   initSessionOwner({
     open: (open) => runtime.runSync(openSession(open)),
-    close: (root) => runtime.runPromise(closeSession(root)),
+    close: (root, signal) => runtime.runPromise(closeSession(root, signal)),
   });
   return runtime;
 }

--- a/src/platform/defaults/lifecycleHost.ts
+++ b/src/platform/defaults/lifecycleHost.ts
@@ -23,9 +23,11 @@ interface Registration {
  * CLI SIGTERM indefinitely: at the deadline every handler's abort signal
  * fires, and the drain advances past a handler only after aborting it
  * (abort-then-advance), so a late BEFORE handler cannot race the ON phase's
- * disposals without having been told to stop first.
+ * disposals without having been told to stop first. The same budget bounds
+ * an explicit session close (`Sessions.close`): one settlement deadline for
+ * the process, not one per caller.
  */
-const SHUTDOWN_PHASE_DEADLINE_MS = 5_000;
+export const SHUTDOWN_PHASE_DEADLINE_MS = 5_000;
 
 interface CreateLifecycleHostOptions {
   onError?: (phase: ShutdownPhase, error: unknown) => void;

--- a/src/platform/workspaceRoots.ts
+++ b/src/platform/workspaceRoots.ts
@@ -48,6 +48,12 @@ export function initProcessWorkspaceRoots(roots: WorkspaceRoots): void {
   processRoots = Object.freeze({ ...roots });
 }
 
+/** The process roots when a composition root has installed them; a
+ *  process without roots has no session of its own to name. */
+export function tryProcessWorkspaceRoots(): WorkspaceRoots | undefined {
+  return processRoots ?? undefined;
+}
+
 function requireProcessRoots(): WorkspaceRoots {
   if (!processRoots) {
     throw new Error(

--- a/src/shared/schemas/opResults.ts
+++ b/src/shared/schemas/opResults.ts
@@ -27,6 +27,22 @@ const ExecResultSchema = z.strictObject({
 
 export type ExecResult = z.infer<typeof ExecResultSchema>;
 
+/**
+ * What closing a session settled, and what it did not: the answer of the
+ * session owner's close (`Sessions.close`, the SDK's `closeSession`). New
+ * executions were refused and the owned live ones interrupted; `settled`
+ * says every one of them ended inside the close budget. Otherwise
+ * `abandoned` names the executions still live when the budget ran out: the
+ * session stays open, refusing new work, until they actually end, and the
+ * caller must not treat the close as complete disposal.
+ */
+const SessionCloseReportSchema = z.strictObject({
+  settled: z.boolean(),
+  abandoned: z.array(z.string()),
+});
+
+export type SessionCloseReport = z.infer<typeof SessionCloseReportSchema>;
+
 const FileOpResultSchema = z.discriminatedUnion('status', [
   z.strictObject({
     status: z.literal('success'),

--- a/src/test-kernel/agent/AgentPackage.vitest.ts
+++ b/src/test-kernel/agent/AgentPackage.vitest.ts
@@ -182,7 +182,6 @@ vi.mock('@transcript/StreamLogStore', () => ({
 // Local imports - package API under test
 import type { SessionView as RuntimeSessionView } from '@shared/session/sessionView';
 import {
-  closeSession,
   runAgent,
   type AgentPlatform,
   type SessionView,
@@ -406,22 +405,6 @@ describe('agent package run lifecycle', () => {
     // process); only the reset owner is observed here.
     await runAgent(INPUT).result;
     expect(mocks.sessionInits).toHaveLength(2);
-  });
-
-  it('closeSession(roots) is the owner close of the roots storage root, reporting what it settled', async () => {
-    await runAgent(INPUT).result;
-    mocks.closeSession.mockResolvedValueOnce({
-      settled: false,
-      abandoned: ['execution-2'],
-    });
-
-    await expect(closeSession(PLATFORM.roots)).resolves.toEqual({
-      settled: false,
-      abandoned: ['execution-2'],
-    });
-    expect(mocks.closeSession).toHaveBeenCalledExactlyOnceWith(
-      PLATFORM.roots.storage,
-    );
   });
 
   it('fails the run instead of hanging when the session fold dies before the final view', async () => {

--- a/src/test-kernel/agent/AgentPackage.vitest.ts
+++ b/src/test-kernel/agent/AgentPackage.vitest.ts
@@ -27,12 +27,14 @@ type FakeSessionView = Omit<RuntimeSessionView, 'streams'> & {
 const mocks = vi.hoisted(() => ({
   activePlatform: null as object | null,
   agentCategory: 'toolUse',
+  /** The runtime owner's close, as the package reaches it: by storage root. */
+  closeSession: vi.fn(async (_root: string) => ({
+    settled: true,
+    abandoned: [] as string[],
+  })),
   detachEvents: vi.fn(),
-  detachInteractions: vi.fn(),
   disposeRuntime: vi.fn(),
-  disposeSession: vi.fn(),
   executionId: 'execution-1',
-  flushArtifacts: vi.fn(async () => {}),
   /** Fails the package session's fold, as a fold defect ends its view. */
   foldDeath: undefined as Deferred.Deferred<never, Error> | undefined,
   eventListener: undefined as ((event: unknown) => void) | undefined,
@@ -41,8 +43,9 @@ const mocks = vi.hoisted(() => ({
   initProcessWorkspaceRoots: vi.fn(),
   loadAgents: vi.fn(),
   runValidatedAgent: vi.fn(),
-  /** Every package session construction, with what it was built over. */
-  sessionInits: [] as unknown[],
+  /** Every session the owner built for the package, with what it was
+   *  built over: one per storage root. */
+  sessionInits: [] as { readonly roots: { readonly storage: string } }[],
   /** The current package session's view, advanced independently of execution. */
   sessionView: undefined as unknown,
   setTranscriptSubscriptions: vi.fn(),
@@ -57,7 +60,8 @@ const mocks = vi.hoisted(() => ({
     mocks.eventListener = listener;
     return mocks.detachEvents;
   }),
-  useInteractions: vi.fn(() => mocks.detachInteractions),
+  /** The host a session was born with, per construction. */
+  useInteractions: vi.fn(),
 }));
 
 vi.mock('@agent/core/definition/AgentConfig', () => ({
@@ -77,43 +81,59 @@ vi.mock('@agent/index', () => ({
 
 // The package reaches the runtime through the curated `@agent/runtime` barrel,
 // so the suite mocks that one door instead of each runtime module by path.
+// The owner behind `openSession` is stood in for by a map keyed by storage
+// root, as the runtime's `Sessions` map keys its entries: the package must
+// resolve every run through it and never build a session of its own.
 vi.mock('@agent/runtime', async () => {
   const { Deferred, Effect, Stream, SubscriptionRef } = await import('effect');
   const { emptySessionView } = await import('@shared/session/sessionView');
-  return {
-    SessionHandle: class {
-      readonly interactions = { use: mocks.useInteractions };
-      /** The session's view level: the pre-launch session, no stream yet. */
-      readonly view = Effect.runSync(
-        SubscriptionRef.make<FakeSessionView>({
-          ...emptySessionView('package'),
-          streams: new Map(),
-        }),
-      );
+  class FakeSession {
+    /** The session's view level: the pre-launch session, no stream yet. */
+    readonly view = Effect.runSync(
+      SubscriptionRef.make<FakeSessionView>({
+        ...emptySessionView('package'),
+        streams: new Map(),
+      }),
+    );
 
-      /** The level stream, ending as the fold does (`SessionViewService`);
-       *  the fold's fate is the test's. */
-      readonly viewChanges = Stream.unwrap(
-        Effect.sync(() =>
-          Stream.merge(
-            SubscriptionRef.changes(this.view),
-            Stream.fromEffect(
-              Deferred.await(
-                mocks.foldDeath as Deferred.Deferred<never, Error>,
-              ),
-            ),
+    /** The level stream, ending as the fold does (`SessionViewService`);
+     *  the fold's fate is the test's. */
+    readonly viewChanges = Stream.unwrap(
+      Effect.sync(() =>
+        Stream.merge(
+          SubscriptionRef.changes(this.view),
+          Stream.fromEffect(
+            Deferred.await(mocks.foldDeath as Deferred.Deferred<never, Error>),
           ),
         ),
-      );
+      ),
+    );
 
-      readonly setTranscriptSubscriptions = mocks.setTranscriptSubscriptions;
-      readonly flushArtifacts = mocks.flushArtifacts;
-      dispose = mocks.disposeSession;
+    readonly setTranscriptSubscriptions = mocks.setTranscriptSubscriptions;
 
-      constructor(init: unknown) {
-        mocks.sessionInits.push(init);
-        mocks.sessionView = this.view;
+    constructor(
+      init: (typeof mocks.sessionInits)[number] & {
+        readonly interactions?: unknown;
+      },
+    ) {
+      mocks.sessionInits.push(init);
+      mocks.sessionView = this.view;
+      if (init.interactions) mocks.useInteractions(init.interactions);
+    }
+  }
+  const sessions = new Map<string, FakeSession>();
+  return {
+    openSession: (init: ConstructorParameters<typeof FakeSession>[0]) => {
+      let session = sessions.get(init.roots.storage);
+      if (!session) {
+        session = new FakeSession(init);
+        sessions.set(init.roots.storage, session);
       }
+      return session;
+    },
+    closeSession: async (root: string) => {
+      sessions.delete(root);
+      return mocks.closeSession(root);
     },
     runAgent: mocks.runValidatedAgent,
   };
@@ -162,6 +182,7 @@ vi.mock('@transcript/StreamLogStore', () => ({
 // Local imports - package API under test
 import type { SessionView as RuntimeSessionView } from '@shared/session/sessionView';
 import {
+  closeSession,
   runAgent,
   type AgentPlatform,
   type SessionView,
@@ -234,8 +255,9 @@ async function driveRun(options: RunAgentOptions): Promise<typeof RESULT> {
 
 describe('agent package run lifecycle', () => {
   beforeEach(async () => {
-    // The package's sessions go with its runtime on the embedder's shutdown
-    // path, as the package registered it: each test starts with none.
+    // The package's session and runtime go on the embedder's shutdown path,
+    // as the package registered it: each test starts with neither.
+    await mocks.shutdownHooks?.flushArtifacts();
     for (const handler of mocks.shutdownHooks?.afterExecutionSettlement ?? []) {
       await handler();
     }
@@ -352,37 +374,54 @@ describe('agent package run lifecycle', () => {
     });
   });
 
-  it('shares one session per storage root across runs and disposes it before the runtime on shutdown', async () => {
+  it('resolves every run through the runtime session owner: two runs on one root share one session, closed through the owner before the runtime goes', async () => {
     await runAgent(INPUT).result;
     await runAgent(INPUT).result;
 
-    // Both runs folded into the one session over the platform's roots, the
-    // first run's: the graph `Sessions` keys by storage root and the
-    // transcript store it bridges are then the same for every run on that
-    // root.
+    // Both runs resolved the platform's root through the owner, which built
+    // the session once, over the package's roots, born with the package's
+    // one headless host; the second run found it open.
     expect(mocks.sessionInits).toHaveLength(1);
     expect(mocks.sessionInits[0]).toMatchObject({ roots: PLATFORM.roots });
-    expect(mocks.disposeSession).not.toHaveBeenCalled();
+    expect(mocks.useInteractions).toHaveBeenCalledOnce();
+    expect(mocks.closeSession).not.toHaveBeenCalled();
 
     const hooks = mocks.shutdownHooks;
     expect(hooks).toBeDefined();
     await hooks?.flushArtifacts();
-    expect(mocks.flushArtifacts).toHaveBeenCalledOnce();
+    expect(mocks.closeSession).toHaveBeenCalledExactlyOnceWith(
+      PLATFORM.roots.storage,
+    );
     for (const handler of hooks?.afterExecutionSettlement ?? []) {
       await handler();
     }
-    expect(mocks.disposeSession).toHaveBeenCalledOnce();
     expect(mocks.disposeRuntime).toHaveBeenCalledOnce();
-    const [disposeOrder] = mocks.disposeSession.mock.invocationCallOrder;
+    const [closeOrder] = mocks.closeSession.mock.invocationCallOrder;
     const [runtimeOrder] = mocks.disposeRuntime.mock.invocationCallOrder;
-    expect(disposeOrder).toBeLessThan(runtimeOrder);
+    expect(closeOrder).toBeLessThan(runtimeOrder);
 
-    // Shutdown took the package's sessions down with their owner: a later
-    // call finds none and builds the package state anew. Whether such a run
-    // works is out of contract (the README scopes the session to the
+    // Shutdown closed the session through its owner: a later run finds none
+    // open on the root and the owner builds it anew. Whether such a run
+    // works is out of contract (the README scopes the package state to the
     // process); only the reset owner is observed here.
     await runAgent(INPUT).result;
     expect(mocks.sessionInits).toHaveLength(2);
+  });
+
+  it('closeSession(roots) is the owner close of the roots storage root, reporting what it settled', async () => {
+    await runAgent(INPUT).result;
+    mocks.closeSession.mockResolvedValueOnce({
+      settled: false,
+      abandoned: ['execution-2'],
+    });
+
+    await expect(closeSession(PLATFORM.roots)).resolves.toEqual({
+      settled: false,
+      abandoned: ['execution-2'],
+    });
+    expect(mocks.closeSession).toHaveBeenCalledExactlyOnceWith(
+      PLATFORM.roots.storage,
+    );
   });
 
   it('fails the run instead of hanging when the session fold dies before the final view', async () => {

--- a/src/test-kernel/agent/AgentPackage.vitest.ts
+++ b/src/test-kernel/agent/AgentPackage.vitest.ts
@@ -123,7 +123,9 @@ vi.mock('@agent/runtime', async () => {
   }
   const sessions = new Map<string, FakeSession>();
   return {
-    openSession: (init: ConstructorParameters<typeof FakeSession>[0]) => {
+    openSessionAsync: async (
+      init: ConstructorParameters<typeof FakeSession>[0],
+    ) => {
       let session = sessions.get(init.roots.storage);
       if (!session) {
         session = new FakeSession(init);
@@ -140,7 +142,8 @@ vi.mock('@agent/runtime', async () => {
 });
 
 vi.mock('@controllers/session/sessionLayer', () => ({
-  installProcessRuntime: () => ({ dispose: mocks.disposeRuntime }),
+  disposeProcessRuntime: mocks.disposeRuntime,
+  installProcessRuntime: vi.fn(),
 }));
 
 vi.mock('@platform/processRuntime', async () => {
@@ -374,7 +377,11 @@ describe('agent package run lifecycle', () => {
   });
 
   it('resolves every run through the runtime session owner: two runs on one root share one session, closed through the owner before the runtime goes', async () => {
-    await runAgent(INPUT).result;
+    const first = runAgent(INPUT);
+    // The launch is the owner's before `runAgent` returns: a close or a
+    // shutdown issued now finds this session, not an unopened root.
+    expect(mocks.sessionInits).toHaveLength(1);
+    await first.result;
     await runAgent(INPUT).result;
 
     // Both runs resolved the platform's root through the owner, which built

--- a/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
+++ b/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
@@ -32,7 +32,7 @@ import {
   AgentCategory,
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import { createTestSession } from '@test/support/sessionTestUtils';
+import { createProcessSession } from '@test/support/sessionTestUtils';
 import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 import { TaskRunFileService } from '@utils/files/taskRunStorage';
 import { testModelCell } from './modelCellTestUtils';
@@ -67,7 +67,7 @@ async function runPersistedReflectionFlow(
   logger: RunReflectionFlowInput['logger'] = noopTrace,
   options: { rounds?: number; aborted?: boolean } = {},
 ): Promise<Awaited<ReturnType<typeof runReflectionFlow>>> {
-  const session = createTestSession();
+  const session = createProcessSession();
   const runScope = createRunScope({
     streamId,
     executionId,

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -45,7 +45,7 @@ import {
   AgentCategory,
 } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
-import { createTestSession } from '@test/support/sessionTestUtils';
+import { createProcessSession } from '@test/support/sessionTestUtils';
 
 import { testModelCell } from './modelCellTestUtils';
 import { reflectionFlowShared } from './progressTestUtils';
@@ -307,7 +307,7 @@ async function runPersistedFlow(
   options: PersistedFlowRunOptions = {},
 ) {
   const { attachment } = options;
-  const session = options.session ?? createTestSession();
+  const session = options.session ?? createProcessSession();
   const config = options.config ?? resume?.agentConfig ?? CONFIG;
   const userVarChannels = resume?.shared.stateSlices.userChannels ?? {
     MODEL: config.model,
@@ -1093,7 +1093,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const streamId = `chat@gpt54#abc-flow-read-failure-fresh` as StreamTabId;
     const snapshot = undefined;
     const store = getExecutionStore(executionId);
-    const session = createTestSession();
+    const session = createProcessSession();
     const readFailure = new Error('flow storage unavailable');
     const readSpy = vi.spyOn(store, 'read').mockRejectedValueOnce(readFailure);
     const deleteSpy = vi.spyOn(store, 'delete');
@@ -1176,7 +1176,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     await writeFlowRecord(executionId, failedShared, {
       cursor: { nextNodeId: null, lastAction: FlowTransition.COMPLETE },
     });
-    const session = createTestSession();
+    const session = createProcessSession();
     const teardownFailure = new Error('flow detachment failed');
     const releaseSpy = vi.spyOn(session.followUps, 'release');
     const errorLogSpy = vi
@@ -1214,7 +1214,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const executionId = 'abc-flow-teardown-failure' as ExecutionId;
     const streamId = 'chat@gpt54#abc-flow-teardown-failure' as StreamTabId;
     const snapshot = buildToolUseResumeData(executionId, streamId);
-    const session = createTestSession();
+    const session = createProcessSession();
     const teardownFailure = new Error('flow detachment failed');
     const releaseSpy = vi.spyOn(session.followUps, 'release');
 
@@ -1250,7 +1250,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     await writeFlowRecord(executionId, snapshot.shared, {
       cursor: { nextNodeId: null, lastAction: FlowTransition.COMPLETE },
     });
-    const session = createTestSession();
+    const session = createProcessSession();
     const teardownFailure = new Error('flow detachment failed');
 
     await expect(
@@ -1368,7 +1368,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       await writeFlowRecord(executionId, storedShared);
       const store = getExecutionStore(executionId);
       const deleteSpy = vi.spyOn(store, 'delete');
-      const session = createTestSession();
+      const session = createProcessSession();
       const releaseSpy = vi.spyOn(session.followUps, 'release');
       const realRead = store.read.bind(store);
       let flowContext: ToolUseSetupContext | undefined;
@@ -1429,7 +1429,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       const streamId = 'chat@gpt54#abc-reused-cancel-attachment' as StreamTabId;
       const storedShared = activeHandlerShared();
       await writeFlowRecord(executionId, storedShared);
-      const session = createTestSession();
+      const session = createProcessSession();
       const releaseSpy = vi.spyOn(session.followUps, 'release');
       const dispositions: Array<'preserve' | 'delete'> = [];
 
@@ -1477,7 +1477,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       const executionId = 'abc-fresh-cancel-setup' as ExecutionId;
       const streamId = 'chat@gpt54#abc-fresh-cancel-setup' as StreamTabId;
       const store = getExecutionStore(executionId);
-      const session = createTestSession();
+      const session = createProcessSession();
       let flowContext: ToolUseSetupContext | undefined;
       const readSpy = vi.spyOn(store, 'read').mockImplementation(async () => {
         flowContext?.interrupt();
@@ -1541,7 +1541,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
           flowContext = context;
         },
       },
-      session: createTestSession(),
+      session: createProcessSession(),
       isSubagent: false,
       onIdle: () => flowContext?.interrupt(),
     });
@@ -1608,7 +1608,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const executionId = 'abc-cancel-followup' as ExecutionId;
     const streamId = 'chat@gpt54#abc-cancel-followup' as StreamTabId;
     const snapshot = buildToolUseResumeData(executionId, streamId);
-    const session = createTestSession();
+    const session = createProcessSession();
 
     try {
       const result = await runPersistedFlow(executionId, streamId, snapshot, {
@@ -1638,7 +1638,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
   it('preserves late input when an orphaned host-resumed subagent is cancelled mid-turn', async () => {
     const executionId = 'abc-cancel-active-followup' as ExecutionId;
     const streamId = 'chat@gpt54#abc-cancel-active-followup' as StreamTabId;
-    const session = createTestSession();
+    const session = createProcessSession();
     const storedShared = activeHandlerShared();
     const snapshot = buildToolUseResumeData(executionId, streamId);
     await writeFlowRecord(executionId, storedShared);
@@ -1695,7 +1695,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     // own wait, but dropping the owner's queued items is not its call to make.
     const executionId = 'abc-cancel-child-followup' as ExecutionId;
     const streamId = 'chat@gpt54#abc-cancel-child-followup' as StreamTabId;
-    const session = createTestSession();
+    const session = createProcessSession();
     const storedShared = activeHandlerShared();
     const snapshot = buildToolUseResumeData(executionId, streamId);
     await writeFlowRecord(executionId, storedShared);

--- a/src/test-kernel/agent/runtime/DefaultSessionLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/DefaultSessionLifecycle.vitest.ts
@@ -214,11 +214,7 @@ describe('default session lifecycle', () => {
       }),
     ).toThrow('already been initialized');
 
-    const originalDispose = first.dispose.bind(first);
-    const disposeSpy = vi.spyOn(first, 'dispose').mockImplementation(() => {
-      expect(tryDefaultSession()).toBeUndefined();
-      originalDispose();
-    });
+    const disposeSpy = vi.spyOn(first, 'dispose');
 
     teardownDefaultSession();
 
@@ -231,6 +227,13 @@ describe('default session lifecycle', () => {
     try {
       expect(defaultSession()).toBe(second);
       expect(second).not.toBe(first);
+      // The default session is read from its owner: closing its root
+      // through the owner leaves no default session behind.
+      const { closeSession } = await import('@agent/runtime/sessionGraph');
+      const { processWorkspaceRoots } =
+        await import('@platform/workspaceRoots');
+      await closeSession(processWorkspaceRoots().storage);
+      expect(tryDefaultSession()).toBeUndefined();
     } finally {
       teardownDefaultSession();
     }

--- a/src/test-kernel/agent/runtime/DefaultSessionLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/DefaultSessionLifecycle.vitest.ts
@@ -50,28 +50,17 @@ async function importSessionRuntime() {
   await installPlatform();
   await import('@test/support/sessionGraphTestSetup');
   const sessionModule = await import('@agent/runtime/SessionHandle');
-  const { openSession } = await import('@agent/runtime/sessionGraph');
   const { StreamLogStore } = await import('@transcript');
-  const { createFakeWorkspaceRoots } =
-    await import('@test/support/FakePlatform');
-  /** A session beside the process default: its own storage root, as a
-   *  desktop paper's, since one root holds one session. */
-  const openOther = (
-    transcripts: Parameters<typeof openSession>[0]['transcripts'],
-  ) =>
-    openSession({
-      transcripts,
-      roots: createFakeWorkspaceRoots({
-        storagePath: `/workspace/other/${transcripts.mode.kind === 'ephemeral' ? transcripts.mode.reason : 'store'}`,
-      }),
-    });
-  return { ...sessionModule, openOther, StreamLogStore };
+  // A session beside the process default: its own storage root, as a
+  // desktop paper's, since one root holds one session.
+  const { createTestSession } = await import('@test/support/sessionTestUtils');
+  return { ...sessionModule, createTestSession, StreamLogStore };
 }
 
 describe('default session lifecycle', () => {
   it('warns once only when a non-default session is live at resolution', async () => {
     const {
-      openOther,
+      createTestSession,
       defaultSession,
       initializeDefaultSession,
       teardownDefaultSession,
@@ -85,16 +74,16 @@ describe('default session lifecycle', () => {
       expect(defaultSession()).toBe(processDefault);
       expect(channelTraceMocks.warn).not.toHaveBeenCalled();
 
-      const disposedSession = openOther(
-        StreamLogStore.ephemeral('disposed non-default'),
-      );
+      const disposedSession = createTestSession({
+        transcripts: StreamLogStore.ephemeral('disposed non-default'),
+      });
       disposedSession.dispose();
       expect(defaultSession()).toBe(processDefault);
       expect(channelTraceMocks.warn).not.toHaveBeenCalled();
 
-      const liveSession = openOther(
-        StreamLogStore.ephemeral('live non-default'),
-      );
+      const liveSession = createTestSession({
+        transcripts: StreamLogStore.ephemeral('live non-default'),
+      });
       try {
         expect(defaultSession()).toBe(processDefault);
         expect(channelTraceMocks.warn).toHaveBeenCalledOnce();
@@ -115,7 +104,7 @@ describe('default session lifecycle', () => {
       throw warningFailure;
     });
     const {
-      openOther,
+      createTestSession,
       defaultSession,
       initializeDefaultSession,
       teardownDefaultSession,
@@ -124,7 +113,9 @@ describe('default session lifecycle', () => {
     const processDefault = initializeDefaultSession({
       transcripts: StreamLogStore.ephemeral('process default'),
     });
-    const liveSession = openOther(StreamLogStore.ephemeral('live non-default'));
+    const liveSession = createTestSession({
+      transcripts: StreamLogStore.ephemeral('live non-default'),
+    });
 
     try {
       expect(defaultSession()).toBe(processDefault);
@@ -180,13 +171,17 @@ describe('default session lifecycle', () => {
   });
 
   it('resolves an explicitly threaded session without a process default', async () => {
-    const { openOther, currentSession, tryDefaultSession, StreamLogStore } =
-      await importSessionRuntime();
+    const {
+      createTestSession,
+      currentSession,
+      tryDefaultSession,
+      StreamLogStore,
+    } = await importSessionRuntime();
     const { createRunContext, withRunContext } =
       await import('@agent/runtime/RunContext');
-    const owned = openOther(
-      StreamLogStore.ephemeral('explicitly threaded session'),
-    );
+    const owned = createTestSession({
+      transcripts: StreamLogStore.ephemeral('explicitly threaded session'),
+    });
 
     try {
       const resolved = withRunContext(

--- a/src/test-kernel/agent/runtime/DefaultSessionLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/DefaultSessionLifecycle.vitest.ts
@@ -50,14 +50,28 @@ async function importSessionRuntime() {
   await installPlatform();
   await import('@test/support/sessionGraphTestSetup');
   const sessionModule = await import('@agent/runtime/SessionHandle');
+  const { openSession } = await import('@agent/runtime/sessionGraph');
   const { StreamLogStore } = await import('@transcript');
-  return { ...sessionModule, StreamLogStore };
+  const { createFakeWorkspaceRoots } =
+    await import('@test/support/FakePlatform');
+  /** A session beside the process default: its own storage root, as a
+   *  desktop paper's, since one root holds one session. */
+  const openOther = (
+    transcripts: Parameters<typeof openSession>[0]['transcripts'],
+  ) =>
+    openSession({
+      transcripts,
+      roots: createFakeWorkspaceRoots({
+        storagePath: `/workspace/other/${transcripts.mode.kind === 'ephemeral' ? transcripts.mode.reason : 'store'}`,
+      }),
+    });
+  return { ...sessionModule, openOther, StreamLogStore };
 }
 
 describe('default session lifecycle', () => {
   it('warns once only when a non-default session is live at resolution', async () => {
     const {
-      SessionHandle,
+      openOther,
       defaultSession,
       initializeDefaultSession,
       teardownDefaultSession,
@@ -71,16 +85,16 @@ describe('default session lifecycle', () => {
       expect(defaultSession()).toBe(processDefault);
       expect(channelTraceMocks.warn).not.toHaveBeenCalled();
 
-      const disposedSession = new SessionHandle({
-        transcripts: StreamLogStore.ephemeral('disposed non-default'),
-      });
+      const disposedSession = openOther(
+        StreamLogStore.ephemeral('disposed non-default'),
+      );
       disposedSession.dispose();
       expect(defaultSession()).toBe(processDefault);
       expect(channelTraceMocks.warn).not.toHaveBeenCalled();
 
-      const liveSession = new SessionHandle({
-        transcripts: StreamLogStore.ephemeral('live non-default'),
-      });
+      const liveSession = openOther(
+        StreamLogStore.ephemeral('live non-default'),
+      );
       try {
         expect(defaultSession()).toBe(processDefault);
         expect(channelTraceMocks.warn).toHaveBeenCalledOnce();
@@ -101,7 +115,7 @@ describe('default session lifecycle', () => {
       throw warningFailure;
     });
     const {
-      SessionHandle,
+      openOther,
       defaultSession,
       initializeDefaultSession,
       teardownDefaultSession,
@@ -110,9 +124,7 @@ describe('default session lifecycle', () => {
     const processDefault = initializeDefaultSession({
       transcripts: StreamLogStore.ephemeral('process default'),
     });
-    const liveSession = new SessionHandle({
-      transcripts: StreamLogStore.ephemeral('live non-default'),
-    });
+    const liveSession = openOther(StreamLogStore.ephemeral('live non-default'));
 
     try {
       expect(defaultSession()).toBe(processDefault);
@@ -168,13 +180,13 @@ describe('default session lifecycle', () => {
   });
 
   it('resolves an explicitly threaded session without a process default', async () => {
-    const { SessionHandle, currentSession, tryDefaultSession, StreamLogStore } =
+    const { openOther, currentSession, tryDefaultSession, StreamLogStore } =
       await importSessionRuntime();
     const { createRunContext, withRunContext } =
       await import('@agent/runtime/RunContext');
-    const owned = new SessionHandle({
-      transcripts: StreamLogStore.ephemeral('explicitly threaded session'),
-    });
+    const owned = openOther(
+      StreamLogStore.ephemeral('explicitly threaded session'),
+    );
 
     try {
       const resolved = withRunContext(

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -193,7 +193,7 @@ describe('SessionHandle', () => {
     const transcripts =
       await StreamLogStore.openReadOnlyForStream('any-stream');
 
-    expect(() => new SessionHandle({ transcripts })).toThrow(
+    expect(() => createTestSession({ transcripts })).toThrow(
       'requires a writable transcript store',
     );
   });

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.ts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.ts
@@ -1010,6 +1010,9 @@ describe('CLI run progress renderer', () => {
         }),
       );
       const detach = host.attachRunProgressRenderer(session);
+      // The session's graph is fresh: let its fold subscribe before the
+      // facts land, so each fact paints as its own level.
+      await settle();
       await publishRun(session, { streamId: 'gate-stream' });
       detach();
       await host.close();
@@ -1030,6 +1033,9 @@ describe('CLI run progress renderer', () => {
         }),
       );
       const detach = host.attachRunProgressRenderer(session);
+      // The session's graph is fresh: let its fold subscribe before the
+      // facts land, so each fact paints as its own level.
+      await settle();
 
       await publishRun(session, { streamId: 'status-line-stream' });
       // Status travels only as a session fact (run-scope status is no longer

--- a/src/test-kernel/controllers/session/sessionEvents.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionEvents.vitest.ts
@@ -347,11 +347,25 @@ describe('Sessions owner', () => {
     track(session, 'exec:settled');
     // The run completes: its driver untracks it as it unwinds.
     session.executions.untrack('exec:settled');
+    // A native child between turns, detached from its stopped parent: its
+    // activation is its only record, so the close must stop it itself, and
+    // wait for the loop to release the activation after its last delivery.
+    let releaseChild = (): void => {};
+    const interrupt = vi.fn(() => releaseChild());
+    releaseChild = session.executions.reserveChildActivation({
+      executionId: 'exec:child' as ExecutionId,
+      parentStreamId: 'stream:exec:settled' as StreamTabId,
+      childStreamId: 'stream:exec:child' as StreamTabId,
+      interrupt,
+      detach: () => {},
+      isDetached: () => true,
+    });
 
     await expect(closeSession('/workspace/owner/settled')).resolves.toEqual({
       settled: true,
       abandoned: [],
     });
+    expect(interrupt).toHaveBeenCalledOnce();
     expect(isLive(session)).toBe(false);
   });
 

--- a/src/test-kernel/controllers/session/sessionEvents.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionEvents.vitest.ts
@@ -317,9 +317,8 @@ describe('session events and view', () => {
 });
 
 /**
- * The session owner (PRD 7.3; proposal 2026-09-05, sections 3 and 9): the
- * `Sessions` map behind `openSession` holds one session per storage root,
- * and `closeSession` is how a session ends.
+ * The session owner (proposal 2026-09-05, sections 3 and 9): `closeSession`
+ * is how a session the `Sessions` map holds behind `openSession` ends.
  */
 describe('Sessions owner', () => {
   const open = (storagePath: string) =>
@@ -327,38 +326,25 @@ describe('Sessions owner', () => {
       roots: createFakeWorkspaceRoots({ storagePath }),
       transcripts: StreamLogStore.ephemeral('sessions owner test'),
     });
-  const live = (): SessionHandle[] => {
-    const sessions: SessionHandle[] = [];
-    forEachLiveSession((session) => sessions.push(session));
-    return sessions;
+  const isLive = (session: SessionHandle): boolean => {
+    let live = false;
+    forEachLiveSession((candidate) => {
+      live ||= candidate === session;
+    });
+    return live;
   };
-
-  it('opens one session per storage root: a root opened twice is one session, a second root its own', async () => {
-    const first = open('/workspace/owner/a');
-    const again = open('/workspace/owner/a');
-    const other = open('/workspace/owner/b');
-    try {
-      expect(again).toBe(first);
-      expect(first.roots.storage).toBe('/workspace/owner/a');
-      expect(other).not.toBe(first);
-      expect(other.executions).not.toBe(first.executions);
-    } finally {
-      await closeSession('/workspace/owner/a');
-      await closeSession('/workspace/owner/b');
-    }
-    expect(live()).not.toContain(first);
-    expect(live()).not.toContain(other);
-  });
-
-  it('close reports settled once the run ended, and releases the session', async () => {
-    const session = open('/workspace/owner/settled');
+  const track = (session: SessionHandle, executionId: string) =>
     session.executions.track(
       testExecutionHandle({
-        executionId: 'exec:settled',
-        parentStreamId: 'stream:settled' as StreamTabId,
+        executionId,
+        parentStreamId: `stream:${executionId}` as StreamTabId,
         agent: 'chat',
       }),
     );
+
+  it('close reports settled once the run ended, and releases the session', async () => {
+    const session = open('/workspace/owner/settled');
+    track(session, 'exec:settled');
     // The run completes: its driver untracks it as it unwinds.
     session.executions.untrack('exec:settled');
 
@@ -366,28 +352,13 @@ describe('Sessions owner', () => {
       settled: true,
       abandoned: [],
     });
-    expect(live()).not.toContain(session);
-    // The root is free: the next open builds a new session, and a root
-    // with nothing open has nothing to close.
-    const next = open('/workspace/owner/settled');
-    expect(next).not.toBe(session);
-    await closeSession('/workspace/owner/settled');
-    await expect(closeSession('/workspace/owner/settled')).resolves.toEqual({
-      settled: true,
-      abandoned: [],
-    });
+    expect(isLive(session)).toBe(false);
   });
 
-  it('close reports abandoned when a run is still live past the budget, refuses new work, and releases at the actual settlement', async () => {
+  it('close reports a run still live past the budget as abandoned, and releases the session at its settlement', async () => {
     const session = open('/workspace/owner/abandoned');
     // A run that ignores its interrupt: no handler, no driver to unwind it.
-    session.executions.track(
-      testExecutionHandle({
-        executionId: 'exec:slow',
-        parentStreamId: 'stream:slow' as StreamTabId,
-        agent: 'chat',
-      }),
-    );
+    track(session, 'exec:slow');
     vi.useFakeTimers();
     try {
       const closing = closeSession('/workspace/owner/abandoned');
@@ -399,21 +370,8 @@ describe('Sessions owner', () => {
     } finally {
       vi.useRealTimers();
     }
-    // Still the root's session, gated: a reopen finds it, new work is refused.
-    expect(live()).toContain(session);
-    expect(open('/workspace/owner/abandoned')).toBe(session);
-    expect(() =>
-      session.executions.track(
-        testExecutionHandle({
-          executionId: 'exec:late',
-          parentStreamId: 'stream:late' as StreamTabId,
-          agent: 'chat',
-        }),
-      ),
-    ).toThrow('while the session is closing');
-
-    // The run settles at last: the owner releases the session then.
+    expect(isLive(session)).toBe(true);
     session.executions.untrack('exec:slow');
-    await vi.waitFor(() => expect(live()).not.toContain(session));
+    await vi.waitFor(() => expect(isLive(session)).toBe(false));
   });
 });

--- a/src/test-kernel/controllers/session/sessionEvents.vitest.ts
+++ b/src/test-kernel/controllers/session/sessionEvents.vitest.ts
@@ -11,14 +11,21 @@
  * process holds (`self`) or whose owner is alive (`heldBy`) folds to
  * `waiting`; the same log with the owner gone folds to `interrupted`.
  */
+import '@test/support/sessionGraphTestSetup';
+
 import { it } from '@effect/vitest';
 import { Effect, Fiber, Layer, Stream, SubscriptionRef } from 'effect';
-import { describe, expect } from 'vitest';
+import { describe, expect, vi } from 'vitest';
 
 import {
   SessionEventLog,
   sessionEventsLayer,
 } from '@agent/runtime/SessionEvents';
+import {
+  forEachLiveSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
+import { closeSession, openSession } from '@agent/runtime/sessionGraph';
 import {
   LocalRuntimeSource,
   TextChunkSource,
@@ -27,6 +34,7 @@ import {
 import { SessionViewService } from '@controllers/session/SessionView';
 import { sessionInputsLayer } from '@controllers/session/sessionInputs';
 import { WorkspaceRoots } from '@controllers/session/WorkspaceRoots';
+import { SHUTDOWN_PHASE_DEADLINE_MS } from '@platform/defaults/lifecycleHost';
 import {
   AgentCategory,
   STREAM_PHASE,
@@ -36,6 +44,7 @@ import {
 } from '@shared/schemas';
 import { ProcessIdentity, SessionEvents } from '@shared/session/sessionEvents';
 import type { SessionView } from '@shared/session/sessionView';
+import { testExecutionHandle } from '@test/support/executionHandleFixtures';
 import { createFakeWorkspaceRoots } from '@test/support/FakePlatform';
 import { StreamLogStore } from '@transcript/StreamLogStore';
 
@@ -238,4 +247,106 @@ describe('session events and view', () => {
         expect(held.streams.get(STREAM)?.readOnly).toBe(true);
       }).pipe(Effect.provide(graph([runStart, waiting, requested]))),
   );
+});
+
+/**
+ * The session owner (PRD 7.3; proposal 2026-09-05, sections 3 and 9): the
+ * `Sessions` map behind `openSession` holds one session per storage root,
+ * and `closeSession` is how a session ends.
+ */
+describe('Sessions owner', () => {
+  const open = (storagePath: string) =>
+    openSession({
+      roots: createFakeWorkspaceRoots({ storagePath }),
+      transcripts: StreamLogStore.ephemeral('sessions owner test'),
+    });
+  const live = (): SessionHandle[] => {
+    const sessions: SessionHandle[] = [];
+    forEachLiveSession((session) => sessions.push(session));
+    return sessions;
+  };
+
+  it('opens one session per storage root: a root opened twice is one session, a second root its own', async () => {
+    const first = open('/workspace/owner/a');
+    const again = open('/workspace/owner/a');
+    const other = open('/workspace/owner/b');
+    try {
+      expect(again).toBe(first);
+      expect(first.roots.storage).toBe('/workspace/owner/a');
+      expect(other).not.toBe(first);
+      expect(other.executions).not.toBe(first.executions);
+    } finally {
+      await closeSession('/workspace/owner/a');
+      await closeSession('/workspace/owner/b');
+    }
+    expect(live()).not.toContain(first);
+    expect(live()).not.toContain(other);
+  });
+
+  it('close reports settled once the run ended, and releases the session', async () => {
+    const session = open('/workspace/owner/settled');
+    session.executions.track(
+      testExecutionHandle({
+        executionId: 'exec:settled',
+        parentStreamId: 'stream:settled' as StreamTabId,
+        agent: 'chat',
+      }),
+    );
+    // The run completes: its driver untracks it as it unwinds.
+    session.executions.untrack('exec:settled');
+
+    await expect(closeSession('/workspace/owner/settled')).resolves.toEqual({
+      settled: true,
+      abandoned: [],
+    });
+    expect(live()).not.toContain(session);
+    // The root is free: the next open builds a new session, and a root
+    // with nothing open has nothing to close.
+    const next = open('/workspace/owner/settled');
+    expect(next).not.toBe(session);
+    await closeSession('/workspace/owner/settled');
+    await expect(closeSession('/workspace/owner/settled')).resolves.toEqual({
+      settled: true,
+      abandoned: [],
+    });
+  });
+
+  it('close reports abandoned when a run is still live past the budget, refuses new work, and releases at the actual settlement', async () => {
+    const session = open('/workspace/owner/abandoned');
+    // A run that ignores its interrupt: no handler, no driver to unwind it.
+    session.executions.track(
+      testExecutionHandle({
+        executionId: 'exec:slow',
+        parentStreamId: 'stream:slow' as StreamTabId,
+        agent: 'chat',
+      }),
+    );
+    vi.useFakeTimers();
+    try {
+      const closing = closeSession('/workspace/owner/abandoned');
+      await vi.advanceTimersByTimeAsync(SHUTDOWN_PHASE_DEADLINE_MS);
+      await expect(closing).resolves.toEqual({
+        settled: false,
+        abandoned: ['exec:slow'],
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+    // Still the root's session, gated: a reopen finds it, new work is refused.
+    expect(live()).toContain(session);
+    expect(open('/workspace/owner/abandoned')).toBe(session);
+    expect(() =>
+      session.executions.track(
+        testExecutionHandle({
+          executionId: 'exec:late',
+          parentStreamId: 'stream:late' as StreamTabId,
+          agent: 'chat',
+        }),
+      ),
+    ).toThrow('while the session is closing');
+
+    // The run settles at last: the owner releases the session then.
+    session.executions.untrack('exec:slow');
+    await vi.waitFor(() => expect(live()).not.toContain(session));
+  });
 });

--- a/src/test-kernel/desktop/DesktopAgentResume.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentResume.vitest.ts
@@ -1,5 +1,5 @@
 // Test setup imports
-import '@test/support/defaultSessionTestSetup';
+import '@test/support/sessionGraphTestSetup';
 
 // Third-party imports
 import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest';
@@ -25,7 +25,7 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { createDeferred } from '@test/support/asyncTestUtils';
-import { createTestSession } from '@test/support/sessionTestUtils';
+import { createProcessSession } from '@test/support/sessionTestUtils';
 import { createToolUseResumeData } from '@test/support/toolUseResumeTestUtils';
 import { snapshotFacts } from '@test/support/storeTestDrivers';
 import { StreamSnapshotStore } from '@transcript';
@@ -145,7 +145,7 @@ function createResumeHarness(): {
 } {
   const snapshots = new StreamSnapshotStore();
   snapshotFacts(snapshots).setRunConfig(stream, config, executionId);
-  const session = createTestSession({ snapshots });
+  const session = createProcessSession({ snapshots });
   session.transcripts.ensureStream(stream);
   const owner = new DesktopProcessResumeOwner({ sessions: () => [session] });
   const detachTerminalResultToast = attachTerminalResultToast(

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.ts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.ts
@@ -87,7 +87,12 @@ function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
     overrides.session ??
     disposeAfterTest(
       createTestSession({
-        roots: { ...workspaceRoots(), config, workspaceState },
+        roots: {
+          ...workspaceRoots(),
+          storage: '/workspace/settings-ipc/storage',
+          config,
+          workspaceState,
+        },
       }),
     );
   const settings = createDesktopSettingsIpc({

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
@@ -72,9 +72,10 @@ describe('desktop composition root and launch environment', () => {
       readFile(desktopSourcePath('main', 'desktopPapers.ts'), 'utf8'),
     ]);
 
-    // Sessions are constructed in the paper registry only, one per root.
-    expect(source).not.toMatch(/new SessionHandle\(/u);
-    expect(papersSource.match(/new SessionHandle\(/gu)).toHaveLength(1);
+    // Sessions are opened in the paper registry only, one per root, through
+    // the process's session owner.
+    expect(source).not.toMatch(/openSession\(/u);
+    expect(papersSource.match(/openSession\(/gu)).toHaveLength(1);
     expect(
       papersSource.match(/StreamLogStore\.openOrEphemeral\(\)/gu),
     ).toHaveLength(1);

--- a/src/test-kernel/support/sessionTestUtils.ts
+++ b/src/test-kernel/support/sessionTestUtils.ts
@@ -16,11 +16,10 @@ type TestSessionInit = Omit<SessionHandleInit, 'transcripts'> & {
 let opened = 0;
 
 /**
- * Open an isolated session with an explicitly ephemeral transcript. A
- * session is one per workspace storage root (the `Sessions` owner returns
- * the session already open on a root), so each call names its own storage
- * root under the process roots, as a desktop paper would: two test sessions
- * never share a graph, and neither shares the process default session's.
+ * Open an isolated session with an explicitly ephemeral transcript, on a
+ * storage root of its own under the process roots (one root holds one
+ * session): it shares a graph with no other test session and not with the
+ * process default session.
  */
 export function createTestSession(init: TestSessionInit = {}): SessionHandle {
   const process = processWorkspaceRoots();
@@ -39,11 +38,10 @@ export function createTestSession(init: TestSessionInit = {}): SessionHandle {
 }
 
 /**
- * Open a fresh session over the process roots, for a file that installs no
- * default session and seeds or reads the process storage outside the
- * session's scope. One root holds one session, so a session still open
- * there (a previous test's, left undisposed) is released first: the caller
- * gets a session of its own, over the store it supplies.
+ * Open a fresh session over the process roots, for a file that seeds or
+ * reads the process storage outside the session's scope. One root holds one
+ * session, so a session still open there (a previous test's) is released
+ * first: the caller gets its own, over the store it supplies.
  */
 export function createProcessSession(
   init: TestSessionInit = {},

--- a/src/test-kernel/support/sessionTestUtils.ts
+++ b/src/test-kernel/support/sessionTestUtils.ts
@@ -1,20 +1,61 @@
 import '@test/support/sessionGraphTestSetup';
 
+import { openSession } from '@agent/runtime/sessionGraph';
 import {
-  SessionHandle,
+  forEachLiveSession,
+  type SessionHandle,
   type SessionHandleInit,
 } from '@agent/runtime/SessionHandle';
+import { processWorkspaceRoots } from '@platform/workspaceRoots';
 import { StreamLogStore } from '@transcript';
 
 type TestSessionInit = Omit<SessionHandleInit, 'transcripts'> & {
   readonly transcripts?: StreamLogStore;
 };
 
-/** Construct an isolated session with an explicitly ephemeral transcript. */
+let opened = 0;
+
+/**
+ * Open an isolated session with an explicitly ephemeral transcript. A
+ * session is one per workspace storage root (the `Sessions` owner returns
+ * the session already open on a root), so each call names its own storage
+ * root under the process roots, as a desktop paper would: two test sessions
+ * never share a graph, and neither shares the process default session's.
+ */
 export function createTestSession(init: TestSessionInit = {}): SessionHandle {
-  return new SessionHandle({
+  const process = processWorkspaceRoots();
+  opened += 1;
+  return openSession({
     ...init,
+    roots: init.roots ?? {
+      workspace: process.workspace,
+      storage: `${process.storage}/test-sessions/${opened}`,
+      config: process.config,
+      workspaceState: process.workspaceState,
+    },
     transcripts:
       init.transcripts ?? StreamLogStore.ephemeral('isolated test session'),
+  });
+}
+
+/**
+ * Open a fresh session over the process roots, for a file that installs no
+ * default session and seeds or reads the process storage outside the
+ * session's scope. One root holds one session, so a session still open
+ * there (a previous test's, left undisposed) is released first: the caller
+ * gets a session of its own, over the store it supplies.
+ */
+export function createProcessSession(
+  init: TestSessionInit = {},
+): SessionHandle {
+  const roots = processWorkspaceRoots();
+  forEachLiveSession((live) => {
+    if (live.roots.storage === roots.storage) live.dispose();
+  });
+  return openSession({
+    ...init,
+    roots,
+    transcripts:
+      init.transcripts ?? StreamLogStore.ephemeral('process test session'),
   });
 }

--- a/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
@@ -40,7 +40,11 @@ import { ModelCell } from '@agent/runtime/ModelCell';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { executeAgent } from '@agent/runtime/executeAgent';
 import { resumeRun } from '@agent/runtime/resumeRun';
-import { SessionHandle } from '@agent/runtime/SessionHandle';
+import {
+  initializeDefaultSession,
+  teardownDefaultSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
 
 // Local imports - shared/runtime boundaries
 import { deliverChildRunFollowUp } from '@agent/followUp/childRunDelivery';
@@ -353,7 +357,12 @@ describe('native subagent production delivery path', { retry: 2 }, () => {
     clearStoreCache();
     clearInlineAgents();
     registerInlineAgents([inlineAgent(PARENT_AGENT), inlineAgent(CHILD_AGENT)]);
-    session = new SessionHandle({ transcripts: await StreamLogStore.open() });
+    // The process session over a persistent store: one session per root,
+    // so the ephemeral default this file's setup installed gives way to it.
+    teardownDefaultSession();
+    session = initializeDefaultSession({
+      transcripts: await StreamLogStore.open(),
+    });
     childId = undefined;
     resumedStreams = [];
     completedResumes = [];
@@ -363,7 +372,7 @@ describe('native subagent production delivery path', { retry: 2 }, () => {
     interruptActiveExecutions(session);
     if (childId) await waitForLeaseRelease(childId);
     await releaseOwnedExecutionLease(PARENT_EXECUTION_ID);
-    session.dispose();
+    teardownDefaultSession();
     clearInlineAgents();
     clearStoreCache();
     vi.restoreAllMocks();

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -75,7 +75,7 @@ import {
   useTempDirs,
 } from '@test/support/tempDirPlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
-import { createTestSession } from '@test/support/sessionTestUtils';
+import { createProcessSession } from '@test/support/sessionTestUtils';
 import { createToolUseResumeData } from '@test/support/toolUseResumeTestUtils';
 import {
   appendTranscriptEntry,
@@ -427,7 +427,7 @@ describe('completedRunArchive facade', () => {
       cursor: { nextNodeId: 'start' },
     });
 
-    const session = createTestSession({ transcripts: logs });
+    const session = createProcessSession({ transcripts: logs });
     const loadAndAcquireWriter = logs.loadAndAcquireWriter.bind(logs);
     const resumedWriter = vi
       .spyOn(logs, 'loadAndAcquireWriter')


### PR DESCRIPTION
## Summary

SDK step 1 of the agent SDK plan (PR #11893, agent SDK architecture proposal, sections 3 and 9): the `Sessions` map is the one owner of every session, and closing a session is an operation on that owner.

**What.** The `Sessions` `LayerMap` in `src/controllers/session/sessionLayer.ts` used to key only a root's Effect graph; each `SessionHandle` was built above it by whoever constructed one (the hosts' `initializeDefaultSession`, the desktop's paper registry, and the package's own per-root map in `packages/agent/src/index.ts`). Now a map entry is the complete session: the root graph, then the `SessionHandle` built over it as the entry's last layer, released by the entry. Every opener goes through `openSession` (the port in `src/agent/runtime/sessionGraph.ts`, installed by `installProcessRuntime`), so opening one storage root twice, from the SDK and from a host alike, returns one handle, and a second root gets its own. `packageSessions` and the package-side construction choreography are deleted; `sessionFor` is one `openSession` call whose init carries the package's headless host, attached at construction (`SessionHandleInit.interactions`), so a later open of the same root cannot displace it. The package keeps no init flag either: it is the process's composition root only when no platform is installed (the identity is awaited first, so the check and the install are one synchronous span), and a run beside a host that installed the same platform object reuses the host's node agent runtime, process runtime, session owner and shutdown order; a different platform throws, as the README states.

`Sessions.close(root, signal?)` is the new operation: it gates new admissions on the root (`ExecutionRegistry.closeAdmissions`), stops the root executions the session owns and waits for their drivers to settle them inside one budget (the caller's `signal` when it passes one, otherwise `SHUTDOWN_PHASE_DEADLINE_MS`, the lifecycle's per-phase deadline, now exported from `src/platform/defaults/lifecycleHost.ts`; no new timeout value, and never two budgets nested), flushes the session's artifacts with the entry's release as the flush's finalizer (`Effect.ensuring`: the release happens whatever the flush's exit, and a flush failure still fails the close), and returns `{ settled, abandoned }`. It never touches the process `LifecycleHost`. The Promise surface is `closeSession(roots, signal?)` beside `runAgent`; the package's shutdown handler passes the phase's signal into it. The port answers `{ settled: true, abandoned: [] }` when no owner is installed (nothing was ever opened), so a `finally` cleanup before the first run is safe. README paragraph and entry table updated.

**Why.** One owner, no second registry (proposal section 3): a session chosen by root must never be backed by an unrelated caller's private store, and helpers hold borrowed access with no disposal obligation. A close that reports what did not settle, instead of pretending (proposal section 9).

**The owner, in words.** The composition root makes one `ManagedRuntime` over `Sessions`. `Sessions` holds one entry per workspace storage root; an entry is the root graph (event log, fold, local sources, liveness prober, transcript bridge) with the `SessionHandle` on top, keyed by `SessionKey` (equal by storage root; the first opener's stores and policy build it). `openSession` borrows: the map retains the entry with an infinite idle lifetime, so no reader detachment and no reference count ends a session. `close` settles then invalidates the entry; `dispose()` on a handle unwinds it and asks the owner for the same release; the runtime's disposal releases whatever is still open. Runs are execution scopes under the session, untouched by this PR.

**One thing to know about `invalidate`.** `RcMap.invalidate` removes the key immediately, so a later open of that root would build a second session over stores a still-live run writes. The close therefore holds the invalidate until the actual settlement: on an incomplete close the entry stays, gated, and a detached fiber releases it when the last execution leaves the registry. That is what keeps the owner unavailable for replacement until it settles.

## Issue acceptance gates

Part of #11864 (SDK lane), step 1: the package keeps no per-root map; `sessionFor` resolves through `Sessions`; `Sessions.close(root)` with a settlement report; `closeSession(roots)` on the Promise surface; README states the owner and the close contract. Part of #11861.

## Single source of truth

`Sessions` (`src/controllers/session/sessionLayer.ts`) owns every session's lifetime. `src/agent` reaches it through the port in `src/agent/runtime/sessionGraph.ts` (`openSession`, `closeSession`), installed once by `installProcessRuntime`.

## Duplication and abstraction budget

Deleted: the package's per-root `Map<string, SessionHandle>` and its dispose loop; the per-handle scope and `sessionGraphOpener` in `sessionLayer.ts`; `openSessionGraph` / `initSessionGraphs` / `SessionGraphOpener` (the graph port becomes the owner port, same file, same role). Added: `Sessions.close` (the settlement is the desktop's `stopPaperExecutions` shape, bounded, with a report) and `ExecutionRegistry.closeAdmissions` (the gate). No pass-through layer: `sessionHandleLayer` is where the handle is built, `openSession`/`closeSession` are the port's two functions.

## Net elements (R6)

- Files: 28 changed, 0 added, 0 deleted (14 production, 13 tests, 1 README).
- Exported symbols (`^[+-]export` over the diff): added `openSession`, `closeSession`, `initSessionOwner`, `SessionOpen`, `SessionOwner` (port), `SessionCloseReport` (type, `@shared/schemas`), `SHUTDOWN_PHASE_DEADLINE_MS`, package `closeSession` + `SessionCloseReport` type re-export, barrel re-export of `openSession`/`closeSession`, test fixture `createProcessSession`; deleted `openSessionGraph`, `initSessionGraphs`, `SessionGraphOpener`. Module-level state deleted: `packageSessions` (replaced by a once-promise for the runtime install, `packageRuntime`, which is not a session map).
- Classes/services: `Session` (Context tag for the entry's handle) added; `Sessions` changes from `LayerMap.Service` to a `Context.Service` over `LayerMap.make` so the map's lookup can carry the release; `SessionHandle` gains `unwind()` (the owner's teardown entry) and `SessionHandleInit.interactions`.
- Net LoC (after review round 2, over the merged main): production +424 (698/274), tests +182 (280/98), README +9; total +615. Round 2 added production +121 (232/111) and tests +24 (32/8): the per-entry identity and `openAsync`/`current` on the owner, `disposeProcessRuntime`, the registry's activation-aware live set, and the default session read from the owner. The production growth is the close operation (about 100 lines with its docs), the owner port's docs, and the moved handle construction; the package itself shrinks by about 40 lines (the per-root map and the once-promise for the runtime install are both gone).

## Consumer counts (R8)

- `SessionHandle` constructor: 1 production caller after (the map's `sessionHandleLayer`); before: `initializeDefaultSession`, `desktopPapers.openPaperSession`, package `sessionFor` (3).
- `openSession`: 3 callers (`initializeDefaultSession`, `desktopPapers`, test fixtures); `openSessionAsync`: 1 caller (package `sessionFor`).
- `closeSession` (port): 2 callers (package `closeSession`, package shutdown handler via it) plus the owner tests.
- `SessionHandle.dispose()` callers unchanged: `teardownDefaultSession` (extension, CLI), `desktopPapers` resources, tests. They now release through the owner.
- `SHUTDOWN_PHASE_DEADLINE_MS`: 2 consumers (lifecycle host, `Sessions.close`).
- `disposeProcessRuntime`: 4 callers (package shutdown handler, extension, CLI, desktop); `installProcessRuntime` returns nothing now, so no host holds the runtime.
- `defaultRootSession`: 4 callers, all in `SessionHandle.ts` (`initializeDefaultSession`, `tryDefaultSession`, `teardownDefaultSession`, `defaultSession`); `tryProcessWorkspaceRoots`: 1 caller (`defaultRootSession`).
- No emit path or subscribe surface changed.

## Host impact

Extension: none observable; `initializeDefaultSession` opens through the owner.

Desktop: `openPaperSession` opens through the owner (one line). Paper close still runs the desktop's own `stopPaperExecutions` (unbounded wait) and then `session.dispose()`; routing it through `closeSession` changes the resource order and the bounded/unbounded semantics, so it is listed as a follow-up.

CLI: none observable; `initializeDefaultSession` opens through the owner.

Tests: `createTestSession()` now names its own storage root per call (one root holds one session, so an isolated test session is its own paper); `createProcessSession()` stays for the four suites that seed or read the process storage outside the session scope (`ReflectionFlowStateRecovery`, `SessionResumeRetrieval`, `completedRunArchive`, `DesktopAgentResume`): swapping them to `createTestSession()` fails 31 tests, since their execution stores resolve under the process roots.

## Scheduled refactoring

- Route the desktop paper close (`desktopPapers.close`) through `closeSession` and delete `stopPaperExecutions`; decide whether the paper's other resources go before or after the session release.
- Route `teardownDefaultSession` on the CLI and extension through `closeSession` (today the ON-phase drain settles executions first and teardown only releases).
- The owner still takes the transcript store from the first opener (`SessionKey.open`); moving store opening into the owner is the next step of the same proposal section.

## Validation

- `npm run format` on changed files
- `npm run typecheck`
- `npm run lint`
- `npx vitest run src/test-kernel/agent src/test-kernel/controllers/session src/test-kernel/architecture`
- `npm test` (full)
- `npm run check:dead-code-ratchet`

## Verified

- Two opens of one root return one `SessionHandle`; a second root gets its own (`sessionEvents.vitest.ts`, real owner).
- `closeSession` reports `settled` after the run left the registry and releases the session; the next open builds anew; closing an unopened root reports settled with nothing abandoned.
- `closeSession` reports `abandoned` with the live execution id when the budget passes (fake timers over `SHUTDOWN_PHASE_DEADLINE_MS`; the runtime is the production `ManagedRuntime`, so no `TestClock`), keeps the session live, and releases it when the execution settles.
- A synchronous `dispose()` then reopen of the same root builds a fresh session: `runFork` evaluates the release fiber before returning and `RcMap.invalidate` removes the key before its first yield (checked with a throwaway test, not kept).
- Package: two runs on one root share one construction with one headless host attach; shutdown closes through the owner before the runtime is disposed; `closeSession(roots)` returns the owner's report (`AgentPackage.vitest.ts`).
- `SessionHandle.dispose()` still unwinds synchronously (the isolation and default-session lifecycle suites), and a teardown failure still surfaces from `dispose()`.

## Review round 2

- Launch admission (P1): the process identity is a per-entry layer of the `Sessions` map, so the map builds synchronously and `installProcessRuntime` takes the pending identity read. The package installs everything and opens through the owner's `openAsync` before its first await; the root's entry is registered synchronously, and a `closeSession` or `runShutdown` issued right after `runAgent` returns waits for the build, closes admissions, and fails the run at registration. No flag.
- Retained children (P1): `ExecutionRegistry.getActiveIds()` includes `ChildExecutionActivation`s, `kill()` interrupts an activation with no handle, and releasing one wakes its waiters; the close, the desktop's paper close, and the exit drain read that one set.
- Default session (P1): `cachedDefaultSession` deleted; `defaultSession`, `tryDefaultSession`, `teardownDefaultSession` read the process roots' session from the owner (`SessionOwner.current`, `defaultRootSession`), and `initializeDefaultSession` opens that root through the owner.
- Owner after disposal: `disposeProcessRuntime()` uninstalls the owner and disposes the runtime in one step; the four composition roots call it.
- Citations of the unmerged proposal file point at PR #11893.

Part of #11864
Part of #11861


