### PR TITLE
feat(session): fold publishes immutable levels with copy-on-touch (D5)

### DIFF
--- a/docs/proposals/2026-09-06-d5-stable-views-measurement.md
+++ b/docs/proposals/2026-09-06-d5-stable-views-measurement.md
@@ -10,6 +10,10 @@
 > No production code changes, and no benchmark script is checked in: the
 > script mirrors the fold's private spelling, so section 4 points at the
 > commit that carried it instead.
+>
+> **Adoption:** [PR #11915](https://github.com/LionSR/TeXRA/pull/11915) adopts
+> D5 in `sessionFold.ts` (2026-09-06); the adopted fold, re-measured with the
+> same method against `origin/main` on one machine, is tabled in that PR.
 
 ## 1. Question and gate
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -70,9 +70,11 @@ stops that reader while the run continues. If launch fails before the run
 enters the session, `view` ends without a value and `result` carries the
 failure.
 
-Each view is the runtime's own value, not a copy: a yielded view supersedes
-the one before it, and the maps and arrays beneath an older view may already
-show a later level. The exported `SessionView`, `StreamView`, and
+Every yielded view is immutable: an older view stays what it was for as long
+as it is held, and a branch the later level did not touch is the same object
+in both. An older view is stable to read; it is not a fold input, so nothing
+in the package folds onto anything but the latest level. The exported
+`SessionView`, `StreamView`, and
 `TranscriptView` types are read-only all the way down (`ReadonlyMap`, readonly
 arrays); a write through a cast corrupts the session every later run in the
 process reads. The run's transcript rows (`StreamView.transcript`) are

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -123,12 +123,11 @@ export interface AgentRun extends AsyncIterable<AgentEvent> {
    * The first view yielded holds the run's stream: a level from before the
    * run entered the session is not this run's and is skipped.
    *
-   * Each view is the runtime's own value, never a copy. The fold replaces
-   * the envelope per level and appends to the maps and arrays beneath it in
-   * place, so a yielded view supersedes the one before it, and a value read
-   * through an older view may already show a later level. The type is
-   * read-only all the way down; a write through a cast corrupts the session
-   * every host and every later run on it reads.
+   * Every yielded view is immutable: an older view stays what it was for as
+   * long as it is held, and a branch the later level did not touch is the
+   * same object in both. The type is read-only all the way down; a write
+   * through a cast corrupts the session every host and every later run on
+   * it reads.
    *
    * The run's transcript rows (`StreamView.transcript`) are resident for the
    * life of the package session, which is the process: its stream and, as
@@ -287,10 +286,10 @@ class AgentRunStream implements AgentRun {
     });
     // The transcript tier folds only for subscribed aggregates (PRD 7.2), on
     // a port of this run's own: its stream now, its descendants as the view
-    // gains them. The port is never cleared: the fold evicts an unsubscribed
-    // stream's rows through the maps a delivered view shares, so clearing
-    // at the terminal view would empty the transcript of the view a consumer
-    // just received. The rows live as long as the session, as a TUI's do.
+    // gains them. The port is never cleared, by choice: the run's rows stay
+    // resident for the life of the package session (the README's residency
+    // contract), as a TUI's do, so a consumer can read the transcript of a
+    // finished run from the latest level as well as from the one it held.
     const port = `sdk/${streamId}`;
     let subscribed = '';
     const subscribe = (ids: readonly StreamTabId[]): void => {

--- a/src/shared/session/sessionFold.ts
+++ b/src/shared/session/sessionFold.ts
@@ -349,12 +349,12 @@ function replaceTranscript(
   return next;
 }
 
-/** A replaced transcript value whose arrays this call may write: the arms
- *  that upsert rows or task groups start here, once per call. */
+/** A replaced transcript value whose rows this call may write: the arms
+ *  that upsert rows start here, once per call. `applyEntry`, the one arm
+ *  that also writes task groups, copies that array itself. */
 function writableTranscript(transcript: TranscriptView): TranscriptView {
   return replaceTranscript(transcript, {
     rows: writableArray(transcript.rows),
-    taskGroups: writableArray(transcript.taskGroups),
   });
 }
 
@@ -964,7 +964,10 @@ function applyEntry(
   stream: StreamView,
   entry: StreamLogEntry,
 ): TranscriptView {
-  const next = writableTranscript(stream.transcript);
+  const next = replaceTranscript(stream.transcript, {
+    rows: writableArray(stream.transcript.rows),
+    taskGroups: writableArray(stream.transcript.taskGroups),
+  });
   const indexes = indexesOf(next);
   upsertTaskGroupFromStreamLog(next.taskGroups, indexes.taskGroupIndex, entry);
   const marker = workflowMarkerOf(entry);

--- a/src/shared/session/sessionFold.ts
+++ b/src/shared/session/sessionFold.ts
@@ -33,18 +33,24 @@
  * direct child's progress. Folding a frame defers that derivation to the end
  * of the frame, so a replay of R events derives each touched board once.
  *
- * The accumulator contract that makes this O(depth): `view.streams`,
- * `view.policy`, `view.folded`, `view.latest`, `view.inflight`, and
- * `view.queuedFollowUps` are indexes reused across folds, a transcript's
- * arrays are appended in place (a copy per entry would make a replay
- * quadratic), and the fold's own indexes live in module-private maps keyed
- * by the value they index: per transcript (row and group positions, the
- * measured live text, the newest thinking row) and per view (streams by
- * owner, the streams whose lifecycle ended, the aggregates the listing
- * named). Every `StreamView` value, every `TranscriptView` value,
- * and the `SessionView` envelope are replaced on change and never mutated,
- * so a host that compares those by identity sees exactly what changed. A
- * caller holds the latest view only.
+ * The publication contract (decision D5): every view `fold` returns is
+ * immutable, and untouched branches are shared by reference between levels.
+ * `view.streams`, `view.policy`, `view.folded`, `view.latest`,
+ * `view.inflight`, `view.queuedFollowUps`, and a transcript's `rows` and
+ * `taskGroups` are copied at most once per `fold` call, on the first write
+ * (`writableMap`, `writableTranscript`), and never written after the call
+ * returns; every `StreamView` value, every `TranscriptView` value, and the
+ * `SessionView` envelope are replaced on change and never mutated. A host
+ * that compares any of these by identity sees exactly what changed, and an
+ * older view is stable to read for as long as it is held. It is not a fold
+ * input: the fold's own indexes live in module-private maps keyed by the
+ * value they index, per transcript (row and group positions, the measured
+ * live text, the newest thinking row) and per view (streams by owner, the
+ * streams whose lifecycle ended, the aggregates the listing named), and
+ * those are single-owner, advancing with the latest level only. The
+ * invariant the copy rests on: an arm that writes a container reports
+ * `changed`, so `foldWith` publishes the envelope holding the copy; a write
+ * followed by "no change" would be dropped, not shared.
  */
 import {
   AgentCategory,
@@ -147,6 +153,8 @@ export function fold(
   view: SessionView,
   input: FoldInput | readonly FoldInput[],
 ): SessionView {
+  // One call publishes one level: nothing this call did not copy is written.
+  owned = new WeakSet();
   if (!Array.isArray(input)) return foldWith(view, input as FoldInput, null);
   const deferred = new Set<StreamTabId>();
   let next = view;
@@ -165,8 +173,8 @@ function foldWith(
   input: FoldInput,
   deferred: DeferredRunModels,
 ): SessionView {
-  // The envelope is replaced, never mutated: work on a copy whose indexes
-  // are shared with the previous value.
+  // The envelope is replaced, never mutated: work on a copy whose containers
+  // are shared with the previous value until this call first writes one.
   const next: SessionView = { ...view };
   switch (input._tag) {
     case 'event': {
@@ -224,7 +232,8 @@ interface SessionIndexes {
   readonly byOwner: Map<string, Set<StreamTabId>>;
 }
 
-/** Keyed by the stream index, which every fold of a view shares. */
+/** Keyed by the stream index; a copied index inherits its predecessor's
+ *  entry, so every level of one session resolves the same indexes. */
 const SESSION_INDEXES = new WeakMap<SessionView['streams'], SessionIndexes>();
 
 function sessionIndexesOf(view: SessionView): SessionIndexes {
@@ -236,6 +245,46 @@ function sessionIndexesOf(view: SessionView): SessionIndexes {
   return indexes;
 }
 
+// ---------------------------------------------------------------------------
+// Copy on touch (D5): the containers this call owns
+// ---------------------------------------------------------------------------
+
+/**
+ * The maps and arrays this `fold` call created: written directly. Any other
+ * container belongs to a published level and is copied on its first write,
+ * into the envelope being built. Reset at `fold` entry, so a throw mid-fold
+ * cannot carry ownership into the next call.
+ */
+let owned = new WeakSet<object>();
+
+type ViewMapKey =
+  'streams' | 'policy' | 'folded' | 'latest' | 'inflight' | 'queuedFollowUps';
+
+/** The view's map under `key`, copied once per call before its first write. */
+function writableMap<K extends ViewMapKey>(
+  view: SessionView,
+  key: K,
+): SessionView[K] {
+  const current = view[key];
+  if (owned.has(current)) return current;
+  const copy = new Map(
+    current as Iterable<readonly [unknown, unknown]>,
+  ) as SessionView[K];
+  if (key === 'streams') {
+    SESSION_INDEXES.set(copy as SessionView['streams'], sessionIndexesOf(view));
+  }
+  owned.add(copy);
+  view[key] = copy;
+  return copy;
+}
+
+function writableArray<T>(array: T[]): T[] {
+  if (owned.has(array)) return array;
+  const copy = [...array];
+  owned.add(copy);
+  return copy;
+}
+
 function inflightKey(streamId: StreamTabId, rowId: string): string {
   return `${streamId}/${rowId}`;
 }
@@ -245,7 +294,7 @@ function inflightKey(streamId: StreamTabId, rowId: string): string {
 function clearInflight(view: SessionView, stream: StreamView): void {
   const prefix = `${stream.id}/`;
   for (const key of [...view.inflight.keys()]) {
-    if (key.startsWith(prefix)) view.inflight.delete(key);
+    if (key.startsWith(prefix)) writableMap(view, 'inflight').delete(key);
   }
   indexesOf(stream.transcript).streaming.clear();
 }
@@ -298,6 +347,15 @@ function replaceTranscript(
   const next: TranscriptView = { ...transcript, ...patch };
   INDEXES.set(next, indexesOf(transcript));
   return next;
+}
+
+/** A replaced transcript value whose arrays this call may write: the arms
+ *  that upsert rows or task groups start here, once per call. */
+function writableTranscript(transcript: TranscriptView): TranscriptView {
+  return replaceTranscript(transcript, {
+    rows: writableArray(transcript.rows),
+    taskGroups: writableArray(transcript.taskGroups),
+  });
 }
 
 function emptyTranscript(): TranscriptView {
@@ -417,7 +475,7 @@ function createStream(event: RunStartEvent): StreamView {
  */
 function setStream(view: SessionView, stream: StreamView): void {
   const previous = view.streams.get(stream.id);
-  view.streams.set(stream.id, stream);
+  writableMap(view, 'streams').set(stream.id, stream);
   if (previous?.ownerId !== stream.ownerId) {
     reindexOwner(view, stream.id, previous?.ownerId ?? null, stream.ownerId);
   }
@@ -427,7 +485,7 @@ function setStream(view: SessionView, stream: StreamView): void {
 }
 
 function dropStream(view: SessionView, stream: StreamView): void {
-  view.streams.delete(stream.id);
+  writableMap(view, 'streams').delete(stream.id);
   reindexOwner(view, stream.id, stream.ownerId, null);
   sessionIndexesOf(view).ended.delete(stream.id);
   countGroups(view, stream.group, undefined);
@@ -906,7 +964,7 @@ function applyEntry(
   stream: StreamView,
   entry: StreamLogEntry,
 ): TranscriptView {
-  const next = replaceTranscript(stream.transcript, {});
+  const next = writableTranscript(stream.transcript);
   const indexes = indexesOf(next);
   upsertTaskGroupFromStreamLog(next.taskGroups, indexes.taskGroupIndex, entry);
   const marker = workflowMarkerOf(entry);
@@ -925,7 +983,7 @@ function applyEntry(
   // offset zero (the bridge seeds one for every running row it publishes)
   // ends within the length held and is dropped (5.2, "In-flight text").
   if (isStreamingEntry(entry) && entry.text && !view.inflight.has(key)) {
-    view.inflight.set(key, entry.text);
+    writableMap(view, 'inflight').set(key, entry.text);
   }
   const live = isStreamingEntry(entry) ? view.inflight.get(key) : undefined;
   projectRow(
@@ -950,7 +1008,7 @@ function applyEntry(
     });
   } else {
     indexes.streaming.delete(entry.id);
-    view.inflight.delete(key);
+    writableMap(view, 'inflight').delete(key);
   }
   return next;
 }
@@ -961,12 +1019,12 @@ function withSettledTranscript(
   finishedAt: number,
 ): StreamView {
   if (!isTranscriptSettlementPhase(stream.status)) return stream;
-  const transcript = replaceTranscript(stream.transcript, {});
   const changed = settleCompactionActivities(
-    indexesOf(transcript).compactionState,
+    indexesOf(stream.transcript).compactionState,
     { finishedAt },
   );
   if (changed.length === 0) return stream;
+  const transcript = writableTranscript(stream.transcript);
   reconcileCompactionRows(transcript, changed);
   return { ...stream, transcript };
 }
@@ -1164,14 +1222,14 @@ function foldTextChunk(view: SessionView, chunk: TextChunk): boolean {
     );
   }
   const text = held.slice(0, chunk.from) + chunk.text;
-  view.inflight.set(key, text);
+  writableMap(view, 'inflight').set(key, text);
   // The row projects when its entry folds, joined with this entry.
   if (!cursor) return true;
   cursor.text =
     chunk.from === held.length
       ? appendTranscriptText(cursor.text, chunk.text, held.at(-1) ?? '')
       : transcriptText(text);
-  const transcript = replaceTranscript(stream.transcript, {});
+  const transcript = writableTranscript(stream.transcript);
   const at = indexes.rowIndex.get(chunk.rowId);
   const row = at === undefined ? undefined : transcript.rows[at];
   if (at !== undefined && row && isStreamingTextRow(row)) {
@@ -1381,7 +1439,7 @@ function applySessionSlices(
       // The initial snapshot rides the existence fact (PRD 6, item 2); a
       // legacy import carries none and leaves the entry to `approval.policy`.
       if (event.approvalPolicy && streamId !== null) {
-        view.policy.set(streamId, event.approvalPolicy);
+        writableMap(view, 'policy').set(streamId, event.approvalPolicy);
       }
       return;
     case 'approval.requested':
@@ -1403,7 +1461,8 @@ function applySessionSlices(
       );
       return;
     case 'approval.policy':
-      if (streamId !== null) view.policy.set(streamId, event.snapshot);
+      if (streamId !== null)
+        writableMap(view, 'policy').set(streamId, event.snapshot);
       return;
     case 'inquiryThreadUpdated': {
       const {
@@ -1425,7 +1484,8 @@ function applySessionSlices(
       return;
     }
     case 'updateQueuedFollowUps':
-      if (streamId !== null) view.queuedFollowUps.set(streamId, event.messages);
+      if (streamId !== null)
+        writableMap(view, 'queuedFollowUps').set(streamId, event.messages);
       return;
     default:
       return;
@@ -1500,7 +1560,7 @@ function foldDurable(
 
   const streamId = streamOf(event);
   if (streamId === null) {
-    view.latest.set(listingKey, event.commit);
+    writableMap(view, 'latest').set(listingKey, event.commit);
     applySessionSlices(view, null, event);
     return true;
   }
@@ -1509,7 +1569,7 @@ function foldDurable(
   // the view has no `run.start` for changes nothing and leaves no entry (its
   // publisher logs it).
   if (!known && event.type !== 'run.start') return false;
-  view.latest.set(listingKey, event.commit);
+  writableMap(view, 'latest').set(listingKey, event.commit);
   if (event.type === 'stream.removed') {
     return foldStreamRemoved(view, streamId, deferred);
   }
@@ -1582,7 +1642,7 @@ function foldTranscriptRow(
   if (retained === undefined || event.seq <= retained) return false;
   const stream = view.streams.get(event.aggregateId as StreamTabId);
   if (!stream) return false;
-  view.folded.set(event.aggregateId, event.seq);
+  writableMap(view, 'folded').set(event.aggregateId, event.seq);
   const withEntry: StreamView = {
     ...stream,
     lastTimestamp: event.at,
@@ -1612,9 +1672,9 @@ function foldStreamRemoved(
   if (!stream) return false;
   dropStream(view, stream);
   clearInflight(view, stream);
-  view.policy.delete(stream.id);
-  view.queuedFollowUps.delete(stream.id);
-  view.folded.delete(stream.id);
+  writableMap(view, 'policy').delete(stream.id);
+  writableMap(view, 'queuedFollowUps').delete(stream.id);
+  writableMap(view, 'folded').delete(stream.id);
   if (view.approvals.some((a) => a.streamId === stream.id)) {
     view.approvals = view.approvals.filter((a) => a.streamId !== stream.id);
   }
@@ -1707,11 +1767,11 @@ function foldSubscriptions(
 ): void {
   const subscribed = new Map(set.map((s) => [s.id, s.fromSeq]));
   for (const [id, fromSeq] of subscribed) {
-    if (!view.folded.has(id)) view.folded.set(id, fromSeq);
+    if (!view.folded.has(id)) writableMap(view, 'folded').set(id, fromSeq);
   }
   for (const id of [...view.folded.keys()]) {
     if (subscribed.has(id)) continue;
-    view.folded.delete(id);
+    writableMap(view, 'folded').delete(id);
     const stream = view.streams.get(id as StreamTabId);
     if (!stream) continue;
     clearInflight(view, stream);

--- a/src/shared/session/sessionView.ts
+++ b/src/shared/session/sessionView.ts
@@ -52,9 +52,9 @@ const SessionKeySchema = z.string().min(1);
  * keeps its incremental indexes (row and group positions, the compaction
  * projection's working state, the measured live text per streaming row, the
  * newest plan marker) beside the value in a module-private map, so a host
- * can neither depend on nor mutate them. `rows` and `taskGroups` are appended in
- * place by the fold (a copy per entry would make a replay quadratic) and the
- * slice value is replaced on every change; hosts read, never write.
+ * can neither depend on nor mutate them. The slice value is replaced on every
+ * change and `rows` and `taskGroups` are never written after the fold that
+ * produced them returns (D5); hosts read, never write.
  *
  * The row, block, and run-model elements are the shared renderers' own
  * TypeScript shapes (`transcriptRow.ts`, `compactionActivityProjection.ts`,

--- a/src/test-kernel/shared/session/sessionFold.vitest.ts
+++ b/src/test-kernel/shared/session/sessionFold.vitest.ts
@@ -589,4 +589,58 @@ describe('sessionFold', () => {
     expect(stream(reparented, PROCESS).parentId).toBeNull();
     expect(stream(reparented, PROCESS).ancestors).toStrictEqual([]);
   });
+
+  it('publishes an immutable level and shares its untouched branches with the next (D5)', () => {
+    const before = foldAll(scenario.events);
+    const childBefore = stream(before, CHILD);
+    const rowsBefore = childBefore.transcript.rows;
+    const rowCount = rowsBefore.length;
+    const key = `${CHILD}/late`;
+    const after = fold(before, [
+      tail({
+        aggregateId: CHILD,
+        seq: before.folded.get(CHILD)! + 1,
+        commit: 200,
+        ownerId: OWNER,
+        at: 4000,
+        type: 'transcript.entry',
+        entry: {
+          id: 'late',
+          type: STREAM_LOG_ENTRY_TYPES.LOG,
+          messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+          text: 'Late',
+          data: { status: 'running' },
+          seqNo: 999,
+          timestamp: 4000,
+          level: 'info',
+        },
+      }),
+      {
+        _tag: 'chunk',
+        streamId: CHILD,
+        rowId: 'late',
+        from: 4,
+        to: 6,
+        text: '!!',
+      },
+    ]);
+    // The older level reads what it did when it was published.
+    expect(before.streams.get(CHILD)).toBe(childBefore);
+    expect(childBefore.transcript.rows).toBe(rowsBefore);
+    expect(rowsBefore).toHaveLength(rowCount);
+    expect(before.inflight.has(key)).toBe(false);
+    // The next level holds the writes ...
+    const childAfter = stream(after, CHILD);
+    expect(childAfter.transcript.rows).toHaveLength(rowCount + 1);
+    expect(after.inflight.get(key)).toBe('Late!!');
+    expect(after.streams).not.toBe(before.streams);
+    // ... and shares every branch it did not touch by reference.
+    expect(after.streams.get(PROCESS)).toBe(before.streams.get(PROCESS));
+    expect(stream(after, PROCESS).transcript.rows).toBe(
+      stream(before, PROCESS).transcript.rows,
+    );
+    expect(after.policy).toBe(before.policy);
+    expect(after.latest).toBe(before.latest);
+    expect(after.queuedFollowUps).toBe(before.queuedFollowUps);
+  });
 });


### PR DESCRIPTION
## What and why

Adopts decision D5 (stable published views). The measurement in `docs/proposals/2026-09-06-d5-stable-views-measurement.md` (#11914) passed the gate but did not change the fold; `sessionFold.ts` still wrote the six session maps in place at 17 sites and appended transcript rows and task groups in place, so the maps and arrays beneath an older view could already show a later level, and four documentation clauses said so.

After this PR every view `fold` returns is immutable and untouched branches are shared by reference between levels:

- A module-private ownership set (`owned`, a `WeakSet`) is reset at `fold` entry (the single publication entry; reset at entry so a throw mid-fold cannot leak into the next call).
- `writableMap(view, key)` copies one of `streams`, `policy`, `folded`, `latest`, `inflight`, `queuedFollowUps` on its first write in a call, into the envelope being built, and returns it directly afterwards. The 17 write sites go through it. For `streams` the copy is re-keyed in `SESSION_INDEXES` so the listed/ended/byOwner indexes follow the level.
- `writableTranscript(transcript)` replaces the transcript value with `rows` copied once per call, at the arms that upsert rows; `applyEntry`, the one arm that also writes `taskGroups`, copies that array itself in its own `replaceTranscript` patch, so a text chunk or a settlement never copies an untouched `taskGroups`. `withRunModel` stays on plain `replaceTranscript` because it patches `run` only.
- The fold header, the `TranscriptView` doc, the SDK README, and the `AgentRun.view` doc drop the mutable-level clauses and state the adopted contract: immutable per published level, untouched branches shared, an older view is stable to read and is not a fold input.
- One assertion extends the existing `sessionFold` suite: an older level reads what it did after a later fold, and an untouched stream and its rows are the same objects in both levels.

`SessionViewService` needs no change (`SubscriptionRef.update` publishes what `fold` returns). No host renderer depends on in-place mutation; none was touched.

## Checklist

Delivered:
- Six session maps copied at most once per fold call, on first write, never written after publication (17 sites through `writableMap`).
- `rows` and `taskGroups` copied once per fold call instead of appended in place; the published `rows` shape stays an array.
- `SESSION_INDEXES` re-keyed to the copied streams map inside `writableMap`.
- `fold` resets the per-call ownership set at entry.
- Fold header, `sessionView.ts` `TranscriptView` doc, `packages/agent/README.md`, and `packages/agent/src/index.ts` `AgentRun.view` doc: mutable-level clauses deleted, contract stated where consumers read it ("an older view is stable to read; it is not a fold input").
- SDK transcript-port comment reworded to state the residency choice on its own terms.
- Regression coverage in the existing suite (zero new files).
- Measurement re-run against the adopted fold (below); nothing checked in.
- Status line added to the D5 measurement proposal naming this PR.

Rulings recorded (audit "decision" items):
- **Where the array copy happens:** at the writing arms, not in every `replaceTranscript` call. The audit named two arms (`applyEntry`, `foldTextChunk`); a third also writes rows, `withSettledTranscript` via `reconcileCompactionRows`, so it is on `writableTranscript` too, reordered so the copy happens only after `settleCompactionActivities` reports a change. Review repair: `writableTranscript` had pre-copied `taskGroups` for all three arms although only `applyEntry` writes it; that copy now lives in `applyEntry` alone. `withRunModel` stays on plain `replaceTranscript`.
- **Ownership set as a module-level per-call variable:** adopted. The fold is synchronous, has one export, is not re-entrant, and the set is working state of one call (same class as `deferred`); threading it would add a parameter to about a dozen private helpers for no behavioural gain.
- **SDK port comment:** behaviour kept (rows resident for the life of the package session), comment reworded; clearing the port at the terminal view is a behaviour and README change for the SDK lane, not this PR.
- **Readonly tightening of `SessionView`/`TranscriptView` types:** not done. The fold must hold mutable handles to the copies it writes; the SDK's `ReadonlyDeep` boundary is unchanged.
- **Measuring with the real fold:** the #11914 script restored into the scratchpad from `32da0de1f7`, only its `current` column run (the adopted fold is copy-on-touch itself, so no transform applies), not checked in.

Left, with reasons:
- Bucketed streams map: out of scope, the identified follow-up on #11864.
- Deleting one of the two measurement scripts: belongs to #11911's owner; its transform no longer applies to the adopted fold.
- Recording the D5 ruling on #11864 and the SDK page: owner action.
- `sessionLayer.ts` owner/close code and the `folded`/`tailFrom` consumer question: #11913 and the SDK lane.

Cross-lane notes: none. No file outside the lane needed a change.

## Measurement (adopted fold, same machine, same method as #11914)

Apple M1 Ultra, Node v26.7.0, 2026-09-06. `current` column of the #11914 script (restored into the scratchpad from `32da0de1f7`) run twice in this worktree: once with `sessionFold.ts` checked out from `origin/main` (in-place fold) and once on this branch (copy-on-touch). Nothing checked in.

Session workload: 3,000 streams, 39,005 rows, 62,077 replay inputs, 5 streaming, 400 frames.

| Metric | main (in place) | this PR |
| --- | --- | --- |
| Cold replay, frames of 512 (median of 5) | 215.73 ms | 318.94 ms (1.48x) |
| Cold replay, slowest frame | 5.21 ms | 7.98 ms |
| Cold replay, one batch (median of 5) | 195.23 ms | 187.82 ms |
| Streaming fold per frame p50 | 0.06 ms | 0.89 ms |
| Streaming fold per frame p95 | 0.08 ms | 1.86 ms |
| Streaming fold per frame max | 0.97 ms | 4.02 ms |
| Frames over 16 ms | 0 | 0 |
| Heap allocated per frame (sampled) | 52 KiB | 583 KiB |
| Retained by the last 10 levels | 0.00 MiB | 1.65 MiB |
| Retained by the last 100 levels | 0.06 MiB | 17.84 MiB |
| Older level unchanged after 400 frames | no | yes |
| Untouched stream shared by reference | yes | yes |

Long transcript: 1 stream, 40,001 rows, 1 streaming, 400 frames: cold replay frames of 512 128.45 ms on main versus 140.66 ms here (1.10x); one batch 126.13 ms versus 131.72 ms; p95 0.04 ms versus 0.50 ms; 0 frames over 16 ms on both; older level unchanged yes.

Gate (within 2x of the in-place fold on cold replay, within the 16 ms frame on sustained streaming): 1.48x per-frame cold replay, one-batch replay 4% faster, p95 1.86 ms. Passed, consistent with the #11914 numbers (1.57x, 2.19 ms).

## Net elements (R6)

- Files: A 0, D 0, M 6 (`src/shared/session/sessionFold.ts`, `src/shared/session/sessionView.ts`, `src/test-kernel/shared/session/sessionFold.vitest.ts`, `packages/agent/README.md`, `packages/agent/src/index.ts`, `docs/proposals/2026-09-06-d5-stable-views-measurement.md`).
- `^[+-]export`: 0 added, 0 removed.
- class/interface/enum declarations: 0 added, 0 removed (one file-local type alias `ViewMapKey` added).
- Net LoC (`git diff --stat` against the merge base with `origin/main`): +174 / -52, net +122; production +63 in `sessionFold.ts` (99/36), docs +5 net (README +2, index.ts -1, sessionView.ts 0, proposal +4), test +54.
- Ratchets: knip, host-agent-mock, host-agent-import baselines untouched (`check:dead-code-ratchet` OK, 281 vs 281 baselined).

## Consumer counts (R8)

- `writableMap`: 17 call sites in `sessionFold.ts` (file-local, no export).
- `writableTranscript`: 2 call sites (`withSettledTranscript`, `foldTextChunk`), file-local.
- `writableArray`: 3 call sites (`writableTranscript` for `rows`; `applyEntry` for `rows` and `taskGroups`), file-local.
- `fold`: production caller count unchanged (1: `SessionViewService` in `src/controllers/session/SessionView.ts`).
- Host readers of `SessionView` containers verified unaffected (each reads the latest level or keys a `WeakMap` by row object, which `slice` preserves): `packages/extension/src/progressView/frontend/components/TaskGroupList.ts`, `sessionSurfaces.ts`, `ProgressApp.ts`, `WorkflowRunBoard.ts`; `packages/cli/src/chat/tui/state/transcriptLines.ts`, `panes/transcriptEntries.ts`, `panes/toolRenderers.tsx`, `state/cliState.ts`, `runtime/runProgressRenderer.ts`, `chatSessionController.ts`; `packages/desktop/src/renderer/taskShell.ts`; `src/shared/session/surface.ts`; `src/controllers/session/SessionRequests.ts`, `hostRunActions.ts`, `sessionLayer.ts`. Renderers fixed: none.

## Review repair (2026-09-06)

One reviewer finding, fixed at the owner: `writableTranscript` copied `taskGroups` on every call, so a text chunk and a settlement copied an untouched array each frame, contradicting the header contract (copied on the first write). `writableTranscript` now copies `rows` only and `applyEntry`, the sole `taskGroups` writer, copies both arrays in its own `replaceTranscript` patch. No helper or flag added. The other two findings overlapped with this one and were folded into it; none asked for a guard or fallback. No review threads existed on the PR.

## Verified

- `npm run typecheck`: clean.
- `npm run lint`: clean.
- `npx vitest run src/test-kernel/shared/session/`: 11 passed (10 existing plus the D5 assertion).
- `npm test` (after the review repair, 2026-09-06): 765 files passed, 1 skipped, 9,059 tests passed, 6 skipped, no failures.
- `npm run check:dead-code-ratchet`: OK, no new findings.
- `src/utils` unchanged, so `check-browser-safe-utils` not applicable; no webview or desktop code touched.
- Measurement: the `current` column of the #11914 script against this branch and against `origin/main` (2026-09-06, tables above); the script's own parity check (the untransformed bundle folds exactly what the source does) passed on both; "Older level unchanged after 400 frames" reads yes on this branch and no on main.
- Screenshots: none. This lane has no boards; the check is the fold suites plus the measurement method.

Part of #11864
Part of #11861


