### PR TITLE
feat(extension): close the one-surface shell gaps and make the LaTeXDiffs section the sheet's body (lane ext-shell)

### DIFF
--- a/packages/desktop/design-harness/scenes/extension.ts
+++ b/packages/desktop/design-harness/scenes/extension.ts
@@ -39,7 +39,7 @@ function host(): HostSnapshot {
     ...emptyHostSnapshot(PAPER),
     agentOptions: {
       toolUse: [
-        { value: 'orchestrator', label: 'orchestrator' },
+        { value: 'orchestrator', label: 'orchestrator', isOrchestrator: true },
         { value: 'polish', label: 'polish' },
         { value: 'search', label: 'search' },
       ],

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -80,12 +80,11 @@ export function createDesktopShellActions(
     void openCustomAgentDirectory().catch(reportAsyncError);
   }
 
+  // New Session is the header's "+" (PRD 12.4): the New-task state with
+  // the launcher's selections as they are.
   function resetMainView() {
     renderer.postToRenderer({
       command: DESKTOP_SHELL_COMMANDS.SHOW_LAUNCHER,
-    });
-    renderer.postToRenderer({
-      command: DESKTOP_SHELL_COMMANDS.RESET_LAUNCHER,
     });
   }
 

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -27,7 +27,6 @@ import { hostBridge, postMessage } from '@shared/hostBridge';
 import { DESKTOP_THEME_KIND } from '@shared/schemas';
 import { resolvePostMessageTargetOrigin } from '@shared/postMessageOrigin';
 import { applyShellAction, type Shell } from '@shared/session/shell';
-import { emptySurface } from '@shared/session/surface';
 import { PersistedState } from '@shared/state/PersistedState';
 
 import { formatDesktopAccelerator } from '@shared/commands/accelerators';
@@ -935,7 +934,9 @@ const desktopRendererCommandActions: DesktopCommandActions = {
   toggleBottomBar: toggleBottomBarVisibility,
   toggleSidePanel: toggleSidePanelVisibility,
   toggleSummaryBar: toggleSummaryBarVisibility,
-  resetMainView: resetLauncher,
+  // New Session is the header's "+" (PRD 12.4): the New-task state with
+  // the launcher's selections as they are, the same as the extension.
+  resetMainView: returnToLauncher,
 };
 const shortcutBootstrap = createDesktopShortcutBootstrap({
   createRegistry: (openCommands) =>
@@ -969,15 +970,6 @@ function returnToLauncher(): void {
   paperSessions.act(shell.active, { kind: 'selectNew' });
 }
 
-// The launcher's selections back to their defaults, and the empty state.
-function resetLauncher(): void {
-  paperSessions.act(shell.active, {
-    kind: 'launch',
-    patch: emptySurface(shell.active).launch,
-  });
-  returnToLauncher();
-}
-
 const LAYOUT_PANEL_TOGGLES: Record<DesktopLayoutPanel, () => void> = {
   bottomBar: toggleBottomBarVisibility,
   sidePanel: toggleSidePanelVisibility,
@@ -997,7 +989,6 @@ const MESSAGE_ROUTES = createMessageRoutes({
   },
   isBootstrapFailed: () => bootstrapFailed,
   returnToLauncher,
-  resetLauncher,
   openKind: (kind) =>
     paperWorkbenches.get(shell.active)?.workbench.openKind(kind),
   toggleLayoutPanel: (panel) => {
@@ -1192,6 +1183,10 @@ function wireShellEvents(): void {
   appRoot.addEventListener('surface-action', (event) => {
     const key = sessionOf(event);
     if (key) paperSessions.act(key, event.detail);
+  });
+  appRoot.addEventListener('composer-submit', (event) => {
+    const key = sessionOf(event);
+    if (key) paperSessions.submit(key);
   });
 }
 

--- a/packages/desktop/src/renderer/messageRoutes.ts
+++ b/packages/desktop/src/renderer/messageRoutes.ts
@@ -11,7 +11,6 @@ import {
 
 import {
   DesktopOpenWorkbenchMessageSchema,
-  DesktopResetLauncherMessageSchema,
   DesktopSaveFileMessageSchema,
   DesktopShowLauncherMessageSchema,
   DesktopToggleLayoutMessageSchema,
@@ -64,8 +63,6 @@ interface DesktopMessageRouteHandlers {
   /** Live read of whether bootstrap failed (routes must not fire then). */
   isBootstrapFailed(): boolean;
   returnToLauncher(): void;
-  /** The launcher's selections back to their defaults. */
-  resetLauncher(): void;
   openKind(kind: WorkbenchKind): void;
   toggleLayoutPanel(panel: DesktopLayoutPanel): void;
   onboarding: {
@@ -122,9 +119,6 @@ export function createMessageRoutes(
     }),
     messageRoute(DesktopShowLauncherMessageSchema, () => {
       if (!handlers.isBootstrapFailed()) handlers.returnToLauncher();
-    }),
-    messageRoute(DesktopResetLauncherMessageSchema, () => {
-      if (!handlers.isBootstrapFailed()) handlers.resetLauncher();
     }),
     messageRoute(DesktopOpenWorkbenchMessageSchema, (message) => {
       if (!handlers.isBootstrapFailed()) handlers.openKind(message.kind);

--- a/packages/desktop/src/shared/desktopOutboundMessages.ts
+++ b/packages/desktop/src/shared/desktopOutboundMessages.ts
@@ -31,7 +31,6 @@ import {
 import { DesktopShowPromptMessageSchema } from './desktopPromptMessages.js';
 import {
   DesktopOpenWorkbenchMessageSchema,
-  DesktopResetLauncherMessageSchema,
   DesktopSaveFileMessageSchema,
   DesktopShowLauncherMessageSchema,
   DesktopToggleLayoutMessageSchema,
@@ -75,7 +74,6 @@ export const DesktopOutboundMessageSchema = z.discriminatedUnion('command', [
   DesktopOpenWorkbenchMessageSchema,
   DesktopSaveFileMessageSchema,
   DesktopShowLauncherMessageSchema,
-  DesktopResetLauncherMessageSchema,
   DesktopToggleLayoutMessageSchema,
   DesktopSetLogMessageSchema,
   DesktopOnboardingSetStateMessageSchema,

--- a/packages/desktop/src/shared/desktopShellMessages.ts
+++ b/packages/desktop/src/shared/desktopShellMessages.ts
@@ -5,7 +5,6 @@ export const DESKTOP_SHELL_COMMANDS = {
   SAVE_FILE: 'desktop:saveFile',
   SHOW_LAUNCHER: 'desktop:showLauncher',
   /** Clear the launcher's selections back to their defaults. */
-  RESET_LAUNCHER: 'desktop:resetLauncher',
   TOGGLE_LAYOUT: 'desktop:toggleLayout',
 } as const;
 
@@ -19,10 +18,6 @@ export const DesktopOpenWorkbenchMessageSchema = z.object({
 
 export const DesktopShowLauncherMessageSchema = z.object({
   command: z.literal(DESKTOP_SHELL_COMMANDS.SHOW_LAUNCHER),
-});
-
-export const DesktopResetLauncherMessageSchema = z.object({
-  command: z.literal(DESKTOP_SHELL_COMMANDS.RESET_LAUNCHER),
 });
 
 export const DesktopSaveFileMessageSchema = z.object({

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -397,7 +397,7 @@
       },
       {
         "command": "texra.toggleView",
-        "title": "Toggle Launcher/Progress View",
+        "title": "Toggle Sessions Drawer",
         "category": "TeXRA",
         "icon": "$(split-horizontal)"
       },

--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -50,7 +50,6 @@ import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import { runCleanBuild, runCleanOutput } from '@housekeeping/clean';
 import type { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import type { SettingsViewProvider } from '@settingsView/SettingsViewProvider';
-import { emptySurface } from '@shared/session/surface';
 import { dispatchCommandFromRegistry } from '@shared/commands/registry';
 
 // Local file imports
@@ -71,15 +70,9 @@ export function createExtensionCommandActions(
     showSettings(tab, agentSubTab) {
       return settingsViewProvider.showSettingsView(tab, agentSubTab);
     },
-    async resetMainView() {
-      // The launcher's selections back to their defaults, and the New-task
-      // state into view.
-      progressViewProvider.surfaceAction({
-        kind: 'launch',
-        patch: emptySurface(progressViewProvider.bridge.key).launch,
-      });
-      await progressViewProvider.showLauncher();
-    },
+    // New Session is the header's "+" (PRD 12.4): the New-task state into
+    // view with the launcher's selections as they are.
+    resetMainView: () => progressViewProvider.showLauncher(),
     cleanBuild: runCleanBuild,
     cleanOutput: runCleanOutput,
     pack: fileHandlePack,
@@ -116,18 +109,18 @@ export function createExtensionCommandActions(
     cloneOverleafProject: gitCloneOverleafProject,
     removeApiKey: () => apiRemoveApiKey(refreshAfterProviderKeyChange),
     showImportOptions: sysShowImportOptions,
-    async toggleView() {
-      const target = progressViewProvider.sidebarShowsProgress()
-        ? 'texra.showMainView'
-        : 'texra.showProgressView';
-      await vscode.commands.executeCommand(target);
-    },
+    toggleView: () => progressViewProvider.toggleDrawer(),
     showProgressView: progressShowProgressView,
     setApiKey: (provider) =>
       apiSetApiKey(refreshAfterProviderKeyChange, provider),
     createAgentWithAI: (category) =>
       agentHandleCreateAgentWithAI(context, category),
-    execute: agentRunExecuteCommand,
+    // Without a configuration the command is the composer's accelerator
+    // (Cmd+Alt+E): the launcher's instruction runs as its Send would.
+    execute: (input) =>
+      input === undefined
+        ? Promise.resolve(progressViewProvider.submitLaunch())
+        : agentRunExecuteCommand(input),
   };
 }
 

--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -116,10 +116,10 @@ export function createExtensionCommandActions(
     createAgentWithAI: (category) =>
       agentHandleCreateAgentWithAI(context, category),
     // Without a configuration the command is the composer's accelerator
-    // (Cmd+Alt+E): the launcher's instruction runs as its Send would.
+    // (Cmd+Alt+E): its Send, in the view the user is in.
     execute: (input) =>
       input === undefined
-        ? Promise.resolve(progressViewProvider.submitLaunch())
+        ? progressViewProvider.submit()
         : agentRunExecuteCommand(input),
   };
 }

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -66,7 +66,6 @@ import { workspaceRoots } from '@platform/workspaceRoots';
 import {
   agentKeyOf,
   AgentCategory,
-  STREAM_PHASE,
   type OnboardingFunnelState,
   type StreamTabId,
 } from '@shared/schemas';
@@ -97,7 +96,7 @@ export type ProgressStreamRevealResult = 'revealed' | 'missing';
 interface Port {
   readonly attached: AttachedPort;
   readonly disposables: vscode.Disposable[];
-  /** A frame for this port alone (`surfaceActionOnce`). */
+  /** A frame for this port alone (the chime, the accelerator, the drawer). */
   readonly send: (message: DownMessage) => void;
 }
 
@@ -117,9 +116,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   /** The sidebar's `WebviewView` while VS Code holds one resolved. */
   private sidebarView: vscode.WebviewView | undefined;
   private sidebarPort: Port | undefined;
-  /** The editor tab while popped out. */
-  private editorPanel: vscode.WebviewPanel | undefined;
-  private editorPort: Port | undefined;
+  /** The popped-out tab and its port, attached and released together. */
+  private editor: { panel: vscode.WebviewPanel; port: Port } | undefined;
 
   /** Last computed funnel state, so credential hooks can detect the
    *  in-session State 0 to 1 transition. Session-scoped by design. */
@@ -201,43 +199,31 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       resolveToolEditPermission: () => undefined,
       detachCause: SESSION_DISPOSED_CAUSE,
     });
-    const resolvedApprovals = effectRuntime().runFork(
+    // The session's events from now on: a resolved approval discards its
+    // staged preview, and a workflow run's `result` is the completion
+    // chime, one per process (PRD 12.4), never a renderer transition hook
+    // that every subscriber would replay. A failed run does not chime.
+    const sessionEvents = effectRuntime().runFork(
       Stream.runForEach(session.events.all(session.now()), (event) =>
         Effect.sync(() => {
-          if (event.type !== 'approval.resolved') return;
-          this.toolEditApprovals.handleAction({
-            requestId: event.requestId,
-            action: 'reject',
-          });
-        }),
-      ),
-    );
-    // The completion chime: one per process, decided here from the view's
-    // status transitions and sent to one port (PRD 12.4), never a renderer
-    // transition hook that every subscriber would replay.
-    let statuses = new Map<StreamTabId, string>();
-    const chimes = effectRuntime().runFork(
-      Stream.runForEach(SubscriptionRef.changes(session.view), (view) =>
-        Effect.sync(() => {
-          const next = new Map<StreamTabId, string>();
-          let chime = false;
-          for (const stream of view.streams.values()) {
-            next.set(stream.id, stream.status);
-            chime ||=
-              stream.category === 'workflow' &&
-              statuses.get(stream.id) === STREAM_PHASE.RUNNING &&
-              (stream.status === STREAM_PHASE.COMPLETED ||
-                stream.status === STREAM_PHASE.CANCELLED);
+          if (event.type === 'approval.resolved') {
+            this.toolEditApprovals.handleAction({
+              requestId: event.requestId,
+              action: 'reject',
+            });
+          } else if (
+            event.type === 'result' &&
+            event.category === 'workflow' &&
+            event.outcome !== 'failed'
+          ) {
+            this.chime();
           }
-          statuses = next;
-          if (chime) this.surfaceActionOnce({ kind: 'chime' });
         }),
       ),
     );
     this.disposables.push({
       dispose: () => {
-        effectRuntime().runFork(Fiber.interrupt(resolvedApprovals));
-        effectRuntime().runFork(Fiber.interrupt(chimes));
+        effectRuntime().runFork(Fiber.interrupt(sessionEvents));
       },
     });
 
@@ -525,30 +511,44 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     this.bridge.surfaceAction(action);
   }
 
-  /** An action for one surface, not every port: the sidebar's when it is
-   *  attached, else the editor tab's. A chime plays once per process, a
-   *  keybinding launches once, and the drawer toggles where the keybinding
-   *  is bound (the sidebar). */
-  private surfaceActionOnce(action: SurfaceActionMessage['action']): void {
-    const port = this.sidebarPort ?? this.editorPort;
-    port?.send({ kind: 'surface.action', session: this.bridge.key, action });
+  private frameOf(
+    action: SurfaceActionMessage['action'],
+  ): SurfaceActionMessage {
+    return { kind: 'surface.action', session: this.bridge.key, action };
   }
 
-  /** `texra.execute` with no configuration: send the launcher's instruction
-   *  as the composer's Run would (Cmd+Alt+E). */
-  public submitLaunch(): void {
-    this.surfaceActionOnce({ kind: 'submitLaunch' });
+  /** The completion chime plays once per process: in the sidebar when it
+   *  has ever been resolved (it retains its context while hidden, so a
+   *  collapsed sidebar still receives and plays it), else in the editor
+   *  tab. No port means no renderer to play it, and nothing to play. */
+  private chime(): void {
+    const port = this.sidebarPort ?? this.editor?.port;
+    port?.send(this.frameOf({ kind: 'chime' }));
+  }
+
+  /** `texra.execute` with no configuration (Cmd+Alt+E): the composer's
+   *  Send in the view the user is in. The editor tab when it is the active
+   *  panel; otherwise the sidebar, shown first so the action has a surface
+   *  to land on. */
+  public async submit(): Promise<void> {
+    const editor = this.editor;
+    if (editor?.panel.active === true) {
+      editor.port.send(this.frameOf({ kind: 'submit' }));
+      return;
+    }
+    await this.showInSidebar();
+    this.sidebarPort?.send(this.frameOf({ kind: 'submit' }));
   }
 
   /** `texra.toggleView`: the Sessions drawer of the sidebar. */
   public async toggleDrawer(): Promise<void> {
     await this.showInSidebar();
-    this.surfaceActionOnce({ kind: 'toggleDrawer' });
+    this.sidebarPort?.send(this.frameOf({ kind: 'toggleDrawer' }));
   }
 
   public isViewVisible(): boolean {
     return (
-      this.sidebarView?.visible === true || this.editorPanel?.visible === true
+      this.sidebarView?.visible === true || this.editor?.panel.visible === true
     );
   }
 
@@ -570,8 +570,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   public async showProgressView(options?: {
     inPlace?: boolean;
   }): Promise<void> {
-    if (this.editorPanel) {
-      this.editorPanel.reveal(vscode.ViewColumn.One);
+    if (this.editor) {
+      this.editor.panel.reveal(vscode.ViewColumn.One);
       return;
     }
     if (!options?.inPlace) await this.showInSidebar();
@@ -606,8 +606,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   }
 
   public async popOutToEditor(): Promise<void> {
-    if (this.editorPanel) {
-      this.editorPanel.reveal(vscode.ViewColumn.One);
+    if (this.editor) {
+      this.editor.panel.reveal(vscode.ViewColumn.One);
       return;
     }
     const panel = vscode.window.createWebviewPanel(
@@ -625,24 +625,21 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       },
     );
     panel.iconPath = new vscode.ThemeIcon('pulse');
-    this.editorPanel = panel;
     const port = this.attach('editor', panel);
-    this.editorPort = port;
+    this.editor = { panel, port };
     port.disposables.push(
       panel.onDidDispose(() => {
-        this.closePort(this.editorPort);
-        this.editorPort = undefined;
-        this.editorPanel = undefined;
+        this.closePort(port);
+        this.editor = undefined;
       }),
     );
   }
 
   public dispose(): void {
     this.closeSidebarPort();
-    this.closePort(this.editorPort);
-    this.editorPort = undefined;
-    this.editorPanel?.dispose();
-    this.editorPanel = undefined;
+    this.closePort(this.editor?.port);
+    this.editor?.panel.dispose();
+    this.editor = undefined;
     this.bridge.dispose();
     for (const disposable of this.disposables.splice(0)) disposable.dispose();
     if (ProgressViewProvider._instance === this) {

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -66,12 +66,16 @@ import { workspaceRoots } from '@platform/workspaceRoots';
 import {
   agentKeyOf,
   AgentCategory,
+  STREAM_PHASE,
   type OnboardingFunnelState,
   type StreamTabId,
 } from '@shared/schemas';
 import { SESSION_DISPOSED_CAUSE } from '@shared/copy/interactionCancellation';
 import { paperDisplayOf } from '@shared/session/hostSnapshot';
-import type { SurfaceActionMessage } from '@shared/session/sessionFrames';
+import type {
+  DownMessage,
+  SurfaceActionMessage,
+} from '@shared/session/sessionFrames';
 import {
   readOnboardingFlags,
   setOnboardingDeclined,
@@ -93,6 +97,8 @@ export type ProgressStreamRevealResult = 'revealed' | 'missing';
 interface Port {
   readonly attached: AttachedPort;
   readonly disposables: vscode.Disposable[];
+  /** A frame for this port alone (`surfaceActionOnce`). */
+  readonly send: (message: DownMessage) => void;
 }
 
 export class ProgressViewProvider implements vscode.WebviewViewProvider {
@@ -206,9 +212,33 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
         }),
       ),
     );
+    // The completion chime: one per process, decided here from the view's
+    // status transitions and sent to one port (PRD 12.4), never a renderer
+    // transition hook that every subscriber would replay.
+    let statuses = new Map<StreamTabId, string>();
+    const chimes = effectRuntime().runFork(
+      Stream.runForEach(SubscriptionRef.changes(session.view), (view) =>
+        Effect.sync(() => {
+          const next = new Map<StreamTabId, string>();
+          let chime = false;
+          for (const stream of view.streams.values()) {
+            next.set(stream.id, stream.status);
+            chime ||=
+              stream.category === 'workflow' &&
+              statuses.get(stream.id) === STREAM_PHASE.RUNNING &&
+              (stream.status === STREAM_PHASE.COMPLETED ||
+                stream.status === STREAM_PHASE.CANCELLED);
+          }
+          statuses = next;
+          if (chime) this.surfaceActionOnce({ kind: 'chime' });
+        }),
+      ),
+    );
     this.disposables.push({
-      dispose: () =>
-        effectRuntime().runFork(Fiber.interrupt(resolvedApprovals)),
+      dispose: () => {
+        effectRuntime().runFork(Fiber.interrupt(resolvedApprovals));
+        effectRuntime().runFork(Fiber.interrupt(chimes));
+      },
     });
 
     const hostRequests = createExtensionHostRequests({
@@ -458,27 +488,25 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       sessionKey: this.bridge.key,
       placement: id,
     });
-    const attached = this.bridge.attach({
-      id,
-      send: (message) => {
-        void Promise.resolve(view.webview.postMessage(message)).then(
-          (delivered) => {
-            if (!delivered) {
-              log.warn(`A ${message.kind} message was not delivered to ${id}`);
-            }
-          },
-          (error: unknown) => {
-            log.warn(
-              `Posting a ${message.kind} message to ${id} failed: ${toErrorMessage(error)}`,
-            );
-          },
-        );
-      },
-    });
+    const send = (message: DownMessage): void => {
+      void Promise.resolve(view.webview.postMessage(message)).then(
+        (delivered) => {
+          if (!delivered) {
+            log.warn(`A ${message.kind} message was not delivered to ${id}`);
+          }
+        },
+        (error: unknown) => {
+          log.warn(
+            `Posting a ${message.kind} message to ${id} failed: ${toErrorMessage(error)}`,
+          );
+        },
+      );
+    };
+    const attached = this.bridge.attach({ id, send });
     const disposables: vscode.Disposable[] = [
       view.webview.onDidReceiveMessage((message) => attached.receive(message)),
     ];
-    return { attached, disposables };
+    return { attached, disposables, send };
   }
 
   private closePort(port: Port | undefined): void {
@@ -497,6 +525,27 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     this.bridge.surfaceAction(action);
   }
 
+  /** An action for one surface, not every port: the sidebar's when it is
+   *  attached, else the editor tab's. A chime plays once per process, a
+   *  keybinding launches once, and the drawer toggles where the keybinding
+   *  is bound (the sidebar). */
+  private surfaceActionOnce(action: SurfaceActionMessage['action']): void {
+    const port = this.sidebarPort ?? this.editorPort;
+    port?.send({ kind: 'surface.action', session: this.bridge.key, action });
+  }
+
+  /** `texra.execute` with no configuration: send the launcher's instruction
+   *  as the composer's Run would (Cmd+Alt+E). */
+  public submitLaunch(): void {
+    this.surfaceActionOnce({ kind: 'submitLaunch' });
+  }
+
+  /** `texra.toggleView`: the Sessions drawer of the sidebar. */
+  public async toggleDrawer(): Promise<void> {
+    await this.showInSidebar();
+    this.surfaceActionOnce({ kind: 'toggleDrawer' });
+  }
+
   public isViewVisible(): boolean {
     return (
       this.sidebarView?.visible === true || this.editorPanel?.visible === true
@@ -504,7 +553,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   }
 
   /** Whether the sidebar shows a conversation or the New-task state. */
-  public sidebarShowsProgress(): boolean {
+  private sidebarShowsProgress(): boolean {
     return getActiveSidebarView() === SIDEBAR_VIEWS.PROGRESS;
   }
 

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -33,11 +33,7 @@ import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 // Local imports - shared webview
 import '@shared/wa/spinner';
 import type {
-  AgentConfigBannerActionDetail,
-  ApiKeyBannerActionDetail,
   CheckboxChangeDetail,
-  GettingStartedActionDetail,
-  InstallGuideDetail,
   MultipleFilesActionDetail,
   MultipleFilesTypeActionDetail,
   RemoveFileDetail,
@@ -59,15 +55,11 @@ import { getBasename } from '@utils/core';
 import { progressAppStyles } from './progressAppStyles';
 import './components/StreamTabs';
 import './components/StreamConversation';
+import './components/SessionBanners';
 import './components/SessionComposer';
 import './components/SessionDrawer';
 import './components/ToolsSheet';
-import '@webview/frontend/components/AgentConfigBanner';
-import '@webview/frontend/components/ApiKeyBanner';
-import '@webview/frontend/components/DependencyBanner';
 import '@webview/frontend/components/FileSelectGroup';
-import '@webview/frontend/components/GettingStartedBanner';
-import '@webview/frontend/components/LoginBanner';
 import '@webview/frontend/components/OnboardingSetupCard';
 import '@webview/frontend/components/OnboardingWelcomeCard';
 
@@ -287,7 +279,7 @@ export class ProgressApp extends LitElement {
           })}
           ${
             stream
-              ? this.renderOverflow(stream, host)
+              ? nothing
               : renderIconActionButton({
                   id: 'shell-dashboard',
                   icon: 'gear',
@@ -296,13 +288,16 @@ export class ProgressApp extends LitElement {
                   onClick: this.openDashboard,
                 })
           }
+          ${this.renderOverflow(stream, host)}
         </div>
       </header>
     `;
   }
 
+  /** The overflow in both states, so the Tools sheet is reachable from the
+   *  New-task state; the debug section needs a stream's output. */
   private renderOverflow(
-    stream: StreamView,
+    stream: StreamView | null,
     host: HostSnapshot,
   ): TemplateResult {
     const inEditor = this.placement === 'editor';
@@ -351,7 +346,7 @@ export class ProgressApp extends LitElement {
           Count</wa-dropdown-item
         >
         ${
-          host.debugMode
+          host.debugMode && stream
             ? html`<wa-divider></wa-divider>
                 <wa-dropdown-item value="pack"
                   >${waIcon('box-archive', { slot: 'icon' })}Pack output to
@@ -401,72 +396,33 @@ export class ProgressApp extends LitElement {
     `;
   }
 
-  /** The five banners and the setup card, host-owned state (8.1); each
-   *  action leaves as the `host.request` arm it names. */
-  private renderBanners(host: HostSnapshot, surface: Surface): TemplateResult {
-    const { banners } = host;
-    const hostRequest = (request: Parameters<typeof SessionUiEvents.host>[0]) =>
-      this.dispatchEvent(SessionUiEvents.host(request));
-    return html`
-      ${
-        host.onboarding === 'setup'
-          ? html`<onboarding-setup-card
-              @onboarding-run-setup=${() =>
-                hostRequest({ kind: 'onboarding', action: 'runSetup' })}
-              @onboarding-open-getting-started=${() =>
-                hostRequest({
-                  kind: 'onboarding',
-                  action: 'openGettingStarted',
-                })}
-              @onboarding-skip-setup=${() =>
-                hostRequest({ kind: 'onboarding', action: 'skipSetup' })}
-            ></onboarding-setup-card>`
-          : nothing
-      }
-      <div
-        class="banners"
-        @api-key-action=${({ detail }: CustomEvent<ApiKeyBannerActionDetail>) =>
-          hostRequest({
-            kind: 'apiKeyBanner',
-            action: detail.action,
-            provider: banners.apiKey.provider,
-          })}
-        @agent-config-action=${({
-          detail,
-        }: CustomEvent<AgentConfigBannerActionDetail>) =>
-          hostRequest({
-            kind: 'agentConfigBanner',
-            action: detail.action,
-            sessionType: surface.launch.sessionType,
-            customDirSet: banners.agentConfig.customDirSet,
-          })}
-        @dependency-dismiss=${() =>
-          hostRequest({ kind: 'dismissBanner', banner: 'dependency' })}
-        @recheck-dependencies=${() =>
-          hostRequest({ kind: 'recheckDependencies' })}
-        @open-install-guide=${({ detail }: CustomEvent<InstallGuideDetail>) =>
-          hostRequest({ kind: 'openInstallGuide', tool: detail.tool })}
-        @sign-in=${() => hostRequest({ kind: 'signIn' })}
-        @dismiss-login=${() =>
-          hostRequest({ kind: 'dismissBanner', banner: 'login' })}
-        @dismiss-getting-started=${() =>
-          hostRequest({ kind: 'dismissBanner', banner: 'gettingStarted' })}
-        @getting-started-action=${({
-          detail,
-        }: CustomEvent<GettingStartedActionDetail>) =>
-          hostRequest({ kind: 'gettingStarted', action: detail.action })}
-      >
-        <api-key-banner .state=${banners.apiKey}></api-key-banner>
-        <agent-config-banner
-          .state=${banners.agentConfig}
-        ></agent-config-banner>
-        <dependency-banner .state=${banners.dependency}></dependency-banner>
-        <getting-started-banner
-          .visible=${banners.gettingStarted}
-        ></getting-started-banner>
-        <login-banner .visible=${banners.login}></login-banner>
+  /** The hero, or the setup card in its place while the funnel is pending
+   *  (PRD 12.1); each card action leaves as the `onboarding` host arm. */
+  private renderHero(host: HostSnapshot): TemplateResult {
+    if (host.onboarding === 'setup') {
+      const onboarding = (
+        action: 'runSetup' | 'openGettingStarted' | 'skipSetup',
+      ) =>
+        this.dispatchEvent(
+          SessionUiEvents.host({ kind: 'onboarding', action }),
+        );
+      return html`<onboarding-setup-card
+        @onboarding-run-setup=${() => onboarding('runSetup')}
+        @onboarding-open-getting-started=${() =>
+          onboarding('openGettingStarted')}
+        @onboarding-skip-setup=${() => onboarding('skipSetup')}
+      ></onboarding-setup-card>`;
+    }
+    return html`<section class="hero" aria-labelledby="shell-hero-title">
+      <div class="hero-mark" aria-hidden="true">
+        ${waIcon('wand-magic-sparkles')}
       </div>
-    `;
+      <h1 id="shell-hero-title">What are you working on?</h1>
+      <p>
+        ${host.paper.name}. Describe the outcome you want: a polish, a review, a
+        literature pass, a proof check.
+      </p>
+    </section>`;
   }
 
   private renderEmptyState(
@@ -507,17 +463,7 @@ export class ProgressApp extends LitElement {
     return html`
       <div class="empty">
         <div class="hero-wrap">
-          <section class="hero" aria-labelledby="shell-hero-title">
-            <div class="hero-mark" aria-hidden="true">
-              ${waIcon('wand-magic-sparkles')}
-            </div>
-            <h1 id="shell-hero-title">What are you working on?</h1>
-            <p>
-              ${host.paper.name}. Describe the outcome you want: a polish, a
-              review, a literature pass, a proof check.
-            </p>
-          </section>
-          ${this.renderBanners(host, surface)}
+          ${this.renderHero(host)}
           <wa-details class="context">
             <span slot="summary" class="context-summary"
               >${waIcon('file-circle-plus')} Context and attachments
@@ -597,6 +543,11 @@ export class ProgressApp extends LitElement {
               </section>`
             : nothing
         }
+        <session-banners
+          class="launch-banners"
+          .host=${host}
+          .sessionType=${launch.sessionType}
+        ></session-banners>
         <session-composer
           class="launch-composer"
           .view=${view}

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -115,10 +115,6 @@ export class ProgressApp extends LitElement {
     this.dispatchEvent(SessionUiEvents.surface({ kind: 'toggleDrawer' }));
   };
 
-  private openDashboard = (): void => {
-    this.dispatchEvent(SessionUiEvents.host({ kind: 'openDashboard' }));
-  };
-
   private stopStream(stream: StreamView): void {
     this.dispatchEvent(
       SessionUiEvents.runtime({ kind: 'stream.stop', streamId: stream.id }),
@@ -277,25 +273,15 @@ export class ProgressApp extends LitElement {
             tooltip: 'New task',
             onClick: this.selectNew,
           })}
-          ${
-            stream
-              ? nothing
-              : renderIconActionButton({
-                  id: 'shell-dashboard',
-                  icon: 'gear',
-                  label: 'Open dashboard',
-                  tooltip: 'Open dashboard',
-                  onClick: this.openDashboard,
-                })
-          }
           ${this.renderOverflow(stream, host)}
         </div>
       </header>
     `;
   }
 
-  /** The overflow in both states, so the Tools sheet is reachable from the
-   *  New-task state; the debug section needs a stream's output. */
+  /** The overflow in both states, so Open dashboard and the Tools sheet
+   *  have one home reachable from the New-task state; the debug section
+   *  needs a stream's output. */
   private renderOverflow(
     stream: StreamView | null,
     host: HostSnapshot,
@@ -545,7 +531,7 @@ export class ProgressApp extends LitElement {
         }
         <session-banners
           class="launch-banners"
-          .host=${host}
+          .banners=${host.banners}
           .sessionType=${launch.sessionType}
         ></session-banners>
         <session-composer

--- a/packages/extension/src/progressView/frontend/components/BaseStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseStreamContent.ts
@@ -19,7 +19,9 @@ export abstract class BaseStreamContent extends LitElement {
   @property({ attribute: false }) stream: StreamView | null = null;
   @property({ attribute: false }) view: SessionView | null = null;
   @property({ attribute: false }) surface: Surface | null = null;
-  @property({ attribute: false }) host: HostSnapshot | null = null;
+  /** The app renders a conversation only once the first snapshot is in
+   *  (`ProgressApp.render`), so there is no null arm here. */
+  @property({ attribute: false }) host!: HostSnapshot;
   /** The host's clock, for elapsed readings (G4). */
   @property({ type: Number }) nowMs: number | null = null;
 

--- a/packages/extension/src/progressView/frontend/components/ConversationContent.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/ConversationContent.styles.ts
@@ -103,8 +103,9 @@ export const conversationContentStyles: CSSResult = css`
     );
   }
 
-  .conversation-composer-dock follow-up-input {
+  .conversation-composer-dock session-banners {
     display: block;
+    padding: 0 var(--wa-space-3xs);
   }
 
   .conversation-composer-banner {

--- a/packages/extension/src/progressView/frontend/components/SessionBanners.ts
+++ b/packages/extension/src/progressView/frontend/components/SessionBanners.ts
@@ -44,7 +44,7 @@ export class SessionBanners extends LitElement {
     }
   `;
 
-  @property({ attribute: false }) host: HostSnapshot | null = null;
+  @property({ attribute: false }) banners!: HostSnapshot['banners'];
   /** The launcher's mode, which the agent-config banner's actions name. */
   @property() sessionType: SessionType = 'toolUse';
 
@@ -52,10 +52,8 @@ export class SessionBanners extends LitElement {
     this.dispatchEvent(SessionUiEvents.host(request));
   }
 
-  override render(): TemplateResult | null {
-    const host = this.host;
-    if (!host) return null;
-    const { banners } = host;
+  override render(): TemplateResult {
+    const { banners } = this;
     return html`
       <div
         class="strip"

--- a/packages/extension/src/progressView/frontend/components/SessionBanners.ts
+++ b/packages/extension/src/progressView/frontend/components/SessionBanners.ts
@@ -1,0 +1,111 @@
+/**
+ * `<session-banners>`: the five host-owned banners (API key, agent config,
+ * dependency, getting started, login) in one strip, host state read from
+ * the `host` snapshot (8.1) and every action dispatched as the
+ * `host.request` arm it names. The empty state renders it above the launch
+ * composer; a conversation renders it as the thin strip above the follow-up
+ * (PRD 12.4).
+ */
+import { css, html, LitElement, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import type {
+  AgentConfigBannerActionDetail,
+  ApiKeyBannerActionDetail,
+  GettingStartedActionDetail,
+  InstallGuideDetail,
+  SessionType,
+} from '@shared/schemas';
+import type { HostSnapshot } from '@shared/session/hostSnapshot';
+import { SessionUiEvents } from '@shared/session/uiEvents';
+import '@webview/frontend/components/AgentConfigBanner';
+import '@webview/frontend/components/ApiKeyBanner';
+import '@webview/frontend/components/DependencyBanner';
+import '@webview/frontend/components/GettingStartedBanner';
+import '@webview/frontend/components/LoginBanner';
+
+@customElement('session-banners')
+export class SessionBanners extends LitElement {
+  /* Each banner hides itself (display: none through its `visible`
+     attribute), so the strip is zero height until one shows; the spacing
+     below it exists only then. */
+  static override styles = css`
+    :host {
+      display: block;
+      min-width: 0;
+    }
+    .strip {
+      display: flex;
+      flex-direction: column;
+      gap: var(--wa-space-2xs);
+    }
+    .strip:has([visible]) {
+      padding-bottom: var(--wa-space-2xs);
+    }
+  `;
+
+  @property({ attribute: false }) host: HostSnapshot | null = null;
+  /** The launcher's mode, which the agent-config banner's actions name. */
+  @property() sessionType: SessionType = 'toolUse';
+
+  private request(request: Parameters<typeof SessionUiEvents.host>[0]): void {
+    this.dispatchEvent(SessionUiEvents.host(request));
+  }
+
+  override render(): TemplateResult | null {
+    const host = this.host;
+    if (!host) return null;
+    const { banners } = host;
+    return html`
+      <div
+        class="strip"
+        @api-key-action=${({ detail }: CustomEvent<ApiKeyBannerActionDetail>) =>
+          this.request({
+            kind: 'apiKeyBanner',
+            action: detail.action,
+            provider: banners.apiKey.provider,
+          })}
+        @agent-config-action=${({
+          detail,
+        }: CustomEvent<AgentConfigBannerActionDetail>) =>
+          this.request({
+            kind: 'agentConfigBanner',
+            action: detail.action,
+            sessionType: this.sessionType,
+            customDirSet: banners.agentConfig.customDirSet,
+          })}
+        @dependency-dismiss=${() =>
+          this.request({ kind: 'dismissBanner', banner: 'dependency' })}
+        @recheck-dependencies=${() =>
+          this.request({ kind: 'recheckDependencies' })}
+        @open-install-guide=${({ detail }: CustomEvent<InstallGuideDetail>) =>
+          this.request({ kind: 'openInstallGuide', tool: detail.tool })}
+        @sign-in=${() => this.request({ kind: 'signIn' })}
+        @dismiss-login=${() =>
+          this.request({ kind: 'dismissBanner', banner: 'login' })}
+        @dismiss-getting-started=${() =>
+          this.request({ kind: 'dismissBanner', banner: 'gettingStarted' })}
+        @getting-started-action=${({
+          detail,
+        }: CustomEvent<GettingStartedActionDetail>) =>
+          this.request({ kind: 'gettingStarted', action: detail.action })}
+      >
+        <api-key-banner .state=${banners.apiKey}></api-key-banner>
+        <agent-config-banner
+          .state=${banners.agentConfig}
+        ></agent-config-banner>
+        <dependency-banner .state=${banners.dependency}></dependency-banner>
+        <getting-started-banner
+          .visible=${banners.gettingStarted}
+        ></getting-started-banner>
+        <login-banner .visible=${banners.login}></login-banner>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'session-banners': SessionBanners;
+  }
+}

--- a/packages/extension/src/progressView/frontend/components/SessionComposer.ts
+++ b/packages/extension/src/progressView/frontend/components/SessionComposer.ts
@@ -405,34 +405,10 @@ export class SessionComposer extends LitElement {
     return this.draft.images.some((image) => image.path === null);
   }
 
+  /** Send is the root's decision (`SessionSurfaces.submit`): the same one
+   *  the run accelerator reaches, so the two cannot diverge. */
   private send = (): void => {
-    const text = this.text.trim();
-    const stream = this.stream;
-    if (stream) {
-      const draft = this.draft;
-      if (text === '' && draft.images.length === 0) return;
-      if (this.imagesPending) return;
-      const mediaFiles = draft.images.flatMap((image) =>
-        image.path === null ? [] : [image.path],
-      );
-      this.dispatchEvent(
-        SessionUiEvents.runtime({
-          kind: 'followUp.send',
-          streamId: stream.id,
-          text: text === '' ? '(image)' : text,
-          mediaFiles: mediaFiles.length > 0 ? mediaFiles : null,
-        }),
-      );
-      return;
-    }
-    if (text === '' || !this.surface) return;
-    this.dispatchEvent(
-      SessionUiEvents.host({
-        kind: 'launch',
-        launch: this.surface.launch,
-        instruction: text,
-      }),
-    );
+    this.dispatchEvent(SessionUiEvents.submit());
   };
 
   private polish = (): void => {

--- a/packages/extension/src/progressView/frontend/components/SessionComposer.ts
+++ b/packages/extension/src/progressView/frontend/components/SessionComposer.ts
@@ -21,8 +21,8 @@ import { repeat } from 'lit/directives/repeat.js';
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/dropdown/dropdown.js';
 import '@awesome.me/webawesome/dist/components/dropdown-item/dropdown-item.js';
+import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
 import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 import type { SessionType, StreamTabId } from '@shared/schemas';
@@ -49,6 +49,35 @@ import './QueuedFollowUps';
 const MODE_LABELS: Record<SessionType, string> = {
   toolUse: 'Interactive',
   workflow: 'Workflow',
+};
+
+/** The hint under the expanded composer, keyed by what the launch is. */
+type SessionHintKey = SessionType | 'orchestrator' | 'team';
+
+const SESSION_HINT_COPY: Record<
+  SessionHintKey,
+  { lede: string; body: string; time: string }
+> = {
+  workflow: {
+    lede: 'Deep pass.',
+    body: 'Drafts, reviews its own work, then revises, across your whole document.',
+    time: 'Typically 5 to 10 min on fast models, 10 to 30 min on frontier reasoning. Pick a smaller model if you need faster turnaround.',
+  },
+  toolUse: {
+    lede: 'Conversational.',
+    body: 'Reads, edits, and searches in a running dialogue you steer turn by turn.',
+    time: 'Turns stream back in seconds; tool-heavy runs take a minute or two. Pick a stronger model for longer chains of reasoning.',
+  },
+  orchestrator: {
+    lede: 'Orchestrator.',
+    body: 'Plans a pipeline of specialized agents and dispatches them for you. Name agents to steer delegation, or ask it which one to use.',
+    time: 'For example, "use polish on the intro, then review the math", or leave it blank. Approve tasks in Sessions as they arrive.',
+  },
+  team: {
+    lede: 'Team run.',
+    body: 'Starts the team lead in an interactive session with delegation limited to this team.',
+    time: '',
+  },
 };
 
 interface ChipMenu {
@@ -143,17 +172,10 @@ export class SessionComposer extends LitElement {
           var(--wa-space-2xs);
         border-radius: var(--wa-border-radius-xl, 20px);
       }
-      .composer.is-compact wa-textarea {
+      .composer.is-compact textarea {
         flex: 1 1 auto;
-        min-width: 0;
-      }
-      .composer.is-compact wa-textarea::part(base) {
-        min-height: 0;
-      }
-      .composer.is-compact wa-textarea::part(textarea) {
-        min-height: 1.5em;
-        height: auto;
-        padding-block: var(--wa-space-3xs);
+        --textarea-min-height: calc(1lh + 2 * var(--wa-space-3xs));
+        --textarea-max-height: 10em;
       }
       .composer.is-compact .row {
         flex: 0 0 auto;
@@ -170,19 +192,39 @@ export class SessionComposer extends LitElement {
         display: contents;
       }
 
-      wa-textarea::part(base) {
-        border: none;
-        box-shadow: none;
+      /* A plain native textarea (#11851): the card draws the one focus
+         ring, so the field carries no chrome of its own and grows with its
+         content between the two heights each state sets. */
+      textarea {
+        display: block;
+        width: 100%;
+        min-width: 0;
+        margin: 0;
+        border: 0;
+        outline: none;
         background: transparent;
-      }
-      wa-textarea::part(textarea) {
-        padding-inline: var(--wa-space-3xs);
+        color: inherit;
+        resize: none;
+        box-sizing: border-box;
+        field-sizing: content;
+        height: auto;
+        min-height: var(--textarea-min-height);
+        max-height: var(--textarea-max-height);
+        padding: var(--wa-space-3xs);
+        overflow-x: hidden;
+        overflow-y: auto;
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
         font-family: var(--wa-font-family-body, inherit);
         font-size: var(--font-size);
         line-height: var(--line-height-normal);
-        field-sizing: content;
-        min-height: 0;
-        max-height: 10em;
+      }
+      textarea::placeholder {
+        color: var(--wa-color-text-quiet);
+      }
+      .composer:not(.is-compact) textarea {
+        --textarea-min-height: calc(3lh + 2 * var(--wa-space-3xs));
+        --textarea-max-height: clamp(var(--textarea-min-height), 32vh, 240px);
       }
 
       .row {
@@ -228,7 +270,7 @@ export class SessionComposer extends LitElement {
       .chips-collapsed {
         display: none;
       }
-      @container (max-width: 380px) {
+      @container (max-width: 440px) {
         .chips {
           display: none;
         }
@@ -248,6 +290,33 @@ export class SessionComposer extends LitElement {
         min-width: 0;
         margin-bottom: var(--wa-space-2xs);
       }
+
+      /* The session hint under the expanded composer: a brand callout at
+         IDE density, one row. */
+      .session-hint {
+        margin-top: var(--wa-space-2xs);
+        padding: var(--wa-space-3xs) var(--wa-space-2xs);
+        font-size: var(--font-size-sm);
+        line-height: var(--line-height-relaxed);
+      }
+      .session-hint::part(message) {
+        display: flex;
+        gap: var(--wa-space-2xs);
+        align-items: flex-start;
+        color: var(--wa-color-text-quiet);
+      }
+      .session-hint-lede {
+        color: var(--wa-color-text-normal);
+        font-weight: var(--font-weight-semibold);
+        letter-spacing: 0.01em;
+        white-space: nowrap;
+      }
+      .session-hint-body {
+        flex: 1 1 auto;
+      }
+      .session-hint-time {
+        color: var(--wa-color-text-quiet);
+      }
     `,
   ];
 
@@ -259,7 +328,7 @@ export class SessionComposer extends LitElement {
 
   @state() private announcement = '';
 
-  @query('wa-textarea') private textArea?: HTMLElement;
+  @query('textarea') private textArea?: HTMLTextAreaElement;
 
   private get compact(): boolean {
     return this.stream !== null;
@@ -535,7 +604,7 @@ export class SessionComposer extends LitElement {
               : nothing
           }
           <wa-dropdown-item value="settings:agents"
-            >Agent settings…</wa-dropdown-item
+            >Browse all agents…</wa-dropdown-item
           >
         `,
         onSelect: (value) => {
@@ -730,6 +799,41 @@ export class SessionComposer extends LitElement {
     </div>`;
   }
 
+  /** What the launch is: the team when one is chosen, else an orchestrator
+   *  agent, else the mode. */
+  private renderSessionHint(): TemplateResult | typeof nothing {
+    const launch = this.surface?.launch;
+    const host = this.host;
+    if (!launch || !host) return nothing;
+    const { sessionType } = launch;
+    const agent = host.agentOptions[sessionType]?.find(
+      (option) => option.value === launch.agent[sessionType],
+    );
+    let key: SessionHintKey = sessionType;
+    if (sessionType === 'toolUse' && launch.launchTarget === 'team') {
+      key = 'team';
+    } else if (sessionType === 'toolUse' && agent?.isOrchestrator === true) {
+      key = 'orchestrator';
+    }
+    const copy = SESSION_HINT_COPY[key];
+    return html`<wa-callout
+      class="session-hint"
+      variant="brand"
+      role="note"
+      data-hint-key=${key}
+    >
+      <span class="session-hint-lede">${copy.lede}</span>
+      <span class="session-hint-body">
+        ${copy.body}
+        ${
+          copy.time
+            ? html` <span class="session-hint-time">${copy.time}</span>`
+            : nothing
+        }
+      </span>
+    </wa-callout>`;
+  }
+
   override render(): TemplateResult | typeof nothing {
     const stream = this.stream;
     if (stream && stream.followUpSupport === 'unsupported') return nothing;
@@ -759,27 +863,27 @@ export class SessionComposer extends LitElement {
           'has-text': text.trim() !== '' || this.draft.images.length > 0,
         })}
       >
-        <wa-textarea
+        <label for="composer-text" class="visually-hidden"
+          >${compact ? 'Follow-up message' : 'Instruction'}</label
+        >
+        <textarea
+          id="composer-text"
           name=${compact ? 'follow-up-message' : 'instruction'}
           placeholder=${compact ? 'Follow-up' : 'Describe the outcome you want…'}
           rows=${compact ? '1' : '3'}
-          resize="auto"
           autocomplete="off"
           spellcheck="true"
+          aria-describedby="composer-text-hint"
           ?disabled=${readOnly}
           .value=${live(text)}
           @input=${this.handleInput}
           @keydown=${this.handleKeydown}
           @paste=${this.handlePaste}
-        >
-          <span slot="label" class="visually-hidden"
-            >${compact ? 'Follow-up message' : 'Instruction'}</span
-          >
-          <span slot="hint" class="visually-hidden">
-            Press Enter to send or Shift+Enter for a new line. Paste images to
-            attach them.
-          </span>
-        </wa-textarea>
+        ></textarea>
+        <div id="composer-text-hint" class="visually-hidden">
+          Press Enter to send or Shift+Enter for a new line. Paste images to
+          attach them.
+        </div>
         <div class="row">
           ${compact ? html`<span class="spacer"></span>` : this.renderChips()}
           <span class="expand"
@@ -848,6 +952,7 @@ export class SessionComposer extends LitElement {
           >
         </div>
       </div>
+      ${compact ? nothing : this.renderSessionHint()}
       <div class="visually-hidden" role="status">${this.announcement}</div>
     `;
   }

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -285,10 +285,11 @@ export class StreamHeader extends LitElement {
         font-size: var(--font-size-xs);
       }
 
-      /* The ancestors path, root first. Segments are laid out in reverse DOM
-         order so that when the path cannot fit, the root end is what the
-         overflow clips: the nearest ancestor always survives (per-segment
-         eviction). The title beside it takes the remaining width. */
+      /* The ancestors path, root first, capped at 40 percent of the header
+         (PRD 12.1). Segments are laid out in reverse DOM order so that when
+         the path cannot fit, the root end is what the overflow clips: the
+         nearest ancestor always survives (per-segment eviction). The title
+         beside it takes the remaining width. */
       .ancestors {
         display: flex;
         flex-direction: row-reverse;
@@ -296,6 +297,7 @@ export class StreamHeader extends LitElement {
         align-items: center;
         gap: var(--wa-space-3xs);
         flex: 0 1 auto;
+        max-width: 40%;
         min-width: 0;
         overflow: hidden;
         white-space: nowrap;

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -11,7 +11,6 @@ import { repeat } from 'lit/directives/repeat.js';
 import {
   GETTING_STARTED_ACTION_PRESENTATION,
   GettingStartedActionSchema,
-  STREAM_PHASE,
   type GettingStartedAction,
   type RunOutcome,
   type StreamLifecycleStatus,
@@ -53,9 +52,6 @@ import { ELEMENT_IDS, GROUP_DOM_IDS } from '../constants';
 
 // Local imports - progress view styles
 import { logStyles } from '../styles/logStyles';
-
-// Local imports - progress view utils
-import { playCompletionSound } from '../audioNotification';
 
 // Local imports - formatters
 import { formatLogEntry } from '../formatters';
@@ -222,9 +218,6 @@ export class TaskGroupList extends LitElement {
    */
   @property({ type: Boolean, reflect: true }) terminal = false;
 
-  /** Track previous group statuses to detect completion (not rendered — no @state needed) */
-  private previousStatuses = new Map<string, string>();
-
   /** The transcript partitioned for render: rebuilt when `groups` or
    *  `rows` change; the rows arrive in wire order and the groups keyed, so
    *  the partition is one pass (PRD 10.2). */
@@ -291,18 +284,6 @@ export class TaskGroupList extends LitElement {
 
   override willUpdate(changedProperties: Map<string, unknown>): void {
     const transcriptChanged = changedProperties.has('transcript');
-
-    // The painted status is a fold of the group and the run's durable
-    // outcome, so a change in any of the three is a change in what the
-    // chime's memory holds: a run that becomes durably final repaints its
-    // open groups as its outcome without any group row changing.
-    if (
-      transcriptChanged ||
-      changedProperties.has('streamDurablyFinal') ||
-      changedProperties.has('streamStatus')
-    ) {
-      this.checkForCompletedRuns();
-    }
     if (this.terminal || !transcriptChanged) return;
     this.timeline = transcriptTimeline(this.groups, this.rows);
     // The windows count from the tail; a transcript that shrank (a
@@ -315,34 +296,6 @@ export class TaskGroupList extends LitElement {
     ) {
       this.resetRenderWindows();
     }
-  }
-
-  /**
-   * Play the completion sound when a workflow round group leaves `running` for
-   * a terminal phase other than `failed`: a finished or cancelled round chimes,
-   * a failed one does not.
-   */
-  private checkForCompletedRuns(): void {
-    const nextStatuses = new Map<string, string>();
-    for (const group of this.groups) {
-      // The status the row PAINTS, not the raw one: a group the run never
-      // closed reads as the run's own outcome once nothing can still close
-      // it, and the chime's memory has to agree with the pixels or the next
-      // paint sees a transition that never happened.
-      const status = taskGroupDisplayStatus(group, this.runDurableOutcome);
-      const prev = this.previousStatuses.get(group.id);
-      const isRunGroup = !this.isToolUse && group.kind === 'round';
-      const wasRunning = prev === STREAM_PHASE.RUNNING;
-      const isNowComplete =
-        status === STREAM_PHASE.COMPLETED || status === STREAM_PHASE.CANCELLED;
-
-      if (isRunGroup && wasRunning && isNowComplete) {
-        playCompletionSound();
-      }
-
-      nextStatuses.set(group.id, status);
-    }
-    this.previousStatuses = nextStatuses;
   }
 
   private resetRenderWindows(): void {

--- a/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -8,6 +8,7 @@ import './StreamHeader';
 import './TodoList';
 import './PlanView';
 import './BackgroundTasksPanel';
+import './SessionBanners';
 import './SessionComposer';
 
 const RUN_ENDED_MESSAGE = 'This run has ended.';
@@ -57,6 +58,10 @@ export class ToolUseStreamContent extends BaseStreamContent {
       </div>
       <div class="conversation-composer-dock">
         <div class="conversation-column">
+          <session-banners
+            .host=${this.host}
+            .sessionType=${stream.category}
+          ></session-banners>
           <div
             class=${
               showComposer

--- a/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -59,7 +59,7 @@ export class ToolUseStreamContent extends BaseStreamContent {
       <div class="conversation-composer-dock">
         <div class="conversation-column">
           <session-banners
-            .host=${this.host}
+            .banners=${this.host.banners}
             .sessionType=${stream.category}
           ></session-banners>
           <div

--- a/packages/extension/src/progressView/frontend/components/ToolsSheet.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolsSheet.ts
@@ -132,7 +132,6 @@ export class ToolsSheet extends LitElement {
           })}
         </div>
         <latexdiffs-section
-          .visible=${true}
           .baseFile=${launch.baseFile}
           .baseFileOptions=${[...host.fileOptions.baseFile]}
           .editedFile=${editedFile}

--- a/packages/extension/src/progressView/frontend/constants.ts
+++ b/packages/extension/src/progressView/frontend/constants.ts
@@ -88,7 +88,7 @@ const STOP_STREAM_BUTTON = Object.freeze({
 const RESTORE_STATE_BUTTON = Object.freeze({
   id: ELEMENT_IDS.RESTORE_STATE_BTN,
   icon: 'reply',
-  title: 'Setup this configuration in the main view',
+  title: 'Edit as new task',
   className: 'restore-button',
 });
 

--- a/packages/extension/src/progressView/frontend/progressAppStyles.ts
+++ b/packages/extension/src/progressView/frontend/progressAppStyles.ts
@@ -131,8 +131,11 @@ export const progressAppStyles = css`
     .shell.is-editor .dock {
       display: flex;
     }
+    /* The dock cell carries the paper name and the one New task control;
+       the main cell keeps only the stream's actions. */
     .shell.is-editor .sessions-button,
     .shell.is-editor .header-main-title,
+    .shell.is-editor #shell-new-task,
     .shell.is-editor session-drawer {
       display: none;
     }
@@ -248,9 +251,16 @@ export const progressAppStyles = css`
     min-height: 0;
   }
 
-  .launch-composer {
+  /* The five banners sit directly above the composer (PRD 12.1); the free
+     space is above them. */
+  .launch-banners {
     flex: 0 0 auto;
     margin-top: auto;
+    padding: 0 var(--wa-space-xs);
+  }
+
+  .launch-composer {
+    flex: 0 0 auto;
     padding: var(--wa-space-3xs) var(--wa-space-xs) var(--wa-space-xs);
   }
 

--- a/packages/extension/src/progressView/frontend/progressWebview.ts
+++ b/packages/extension/src/progressView/frontend/progressWebview.ts
@@ -40,6 +40,9 @@ export function mountProgressWebview(app: ProgressApp): void {
   app.addEventListener('surface-action', (event) => {
     sessions.act(sessionKey, event.detail);
   });
+  app.addEventListener('composer-submit', () => {
+    sessions.submit(sessionKey);
+  });
 
   let reportedView: 'main' | 'progress' | null = null;
   const assign = (): void => {

--- a/packages/extension/src/progressView/frontend/sessionSurfaces.ts
+++ b/packages/extension/src/progressView/frontend/sessionSurfaces.ts
@@ -60,6 +60,10 @@ export interface SessionSurfaces {
   act(key: string, action: SurfaceAction): void;
   runtimeRequest(key: string, request: RuntimeRequest): void;
   hostRequest(key: string, request: HostRequest): void;
+  /** The composer's Send for the resolved selection: a follow-up to the
+   *  selected stream, else a launch from the launcher's instruction. The
+   *  button and the run accelerator both land here. */
+  submit(key: string): void;
   /** Fires after any session's view, surface, or host changed. */
   onChange(listener: () => void): () => void;
   dispose(): void;
@@ -335,6 +339,76 @@ export function createSessionSurfaces(options: {
       });
   }
 
+  function runtimeRequestFor(entry: Held, request: RuntimeRequest): void {
+    const { key } = entry;
+    if (request.kind === 'followUp.send') {
+      const current = entry.surface$.get();
+      if (current.sending.has(request.streamId)) return;
+      setSurface(entry, {
+        ...current,
+        sending: new Set([...current.sending, request.streamId]),
+      });
+    }
+    // Keep text and images until admission succeeds. A rejection needs
+    // no restoration, and a later edit remains independent of this send.
+    const submitted =
+      request.kind === 'followUp.send'
+        ? entry.surface$.get().drafts.get(request.streamId)
+        : undefined;
+    void transport
+      .request({
+        kind: 'runtime.request',
+        session: key,
+        requestId: requestId(),
+        request,
+      })
+      .then((result) => {
+        if (held.get(key) !== entry || request.kind !== 'followUp.send') return;
+        const current = entry.surface$.get();
+        const sending = new Set(current.sending);
+        sending.delete(request.streamId);
+        setSurface(entry, { ...current, sending });
+        if (!result.ok) return;
+        if (
+          submitted !== undefined &&
+          entry.surface$.get().drafts.get(request.streamId) === submitted
+        ) {
+          act(entry, {
+            kind: 'draft',
+            streamId: request.streamId,
+            patch: EMPTY_DRAFT,
+          });
+        }
+      });
+  }
+
+  /** A follow-up sends once the host has stored every pasted image; an
+   *  empty draft, like an empty launcher instruction, sends nothing. */
+  function submit(entry: Held): void {
+    const surface = entry.surface$.get();
+    const streamId = resolveSelected(entry.view$.get(), surface);
+    if (streamId !== null) {
+      const draft = surface.drafts.get(streamId) ?? EMPTY_DRAFT;
+      const text = draft.text.trim();
+      if (text === '' && draft.images.length === 0) return;
+      if (draft.images.some((image) => image.path === null)) return;
+      const mediaFiles = draft.images.flatMap((image) =>
+        image.path === null ? [] : [image.path],
+      );
+      runtimeRequestFor(entry, {
+        kind: 'followUp.send',
+        streamId,
+        text: text === '' ? '(image)' : text,
+        mediaFiles: mediaFiles.length > 0 ? mediaFiles : null,
+      });
+      return;
+    }
+    const { launch } = surface;
+    const instruction = launch.instruction[launch.sessionType].trim();
+    if (instruction === '') return;
+    hostRequestFor(entry, { kind: 'launch', launch, instruction });
+  }
+
   transport.onSurfaceAction((key, action) => {
     const entry = held.get(key);
     if (!entry) return;
@@ -343,14 +417,8 @@ export function createSessionSurfaces(options: {
       playCompletionSound();
       return;
     }
-    if (action.kind === 'submitLaunch') {
-      // The run accelerator: send the launcher's instruction as the
-      // composer would.
-      const { launch } = entry.surface$.get();
-      const instruction = launch.instruction[launch.sessionType].trim();
-      if (instruction !== '') {
-        hostRequestFor(entry, { kind: 'launch', launch, instruction });
-      }
+    if (action.kind === 'submit') {
+      submit(entry);
       return;
     }
     act(entry, action);
@@ -380,51 +448,15 @@ export function createSessionSurfaces(options: {
     },
     runtimeRequest(key, request) {
       const entry = held.get(key);
-      if (!entry) return;
-      if (request.kind === 'followUp.send') {
-        const current = entry.surface$.get();
-        if (current.sending.has(request.streamId)) return;
-        setSurface(entry, {
-          ...current,
-          sending: new Set([...current.sending, request.streamId]),
-        });
-      }
-      // Keep text and images until admission succeeds. A rejection needs
-      // no restoration, and a later edit remains independent of this send.
-      const submitted =
-        request.kind === 'followUp.send'
-          ? entry.surface$.get().drafts.get(request.streamId)
-          : undefined;
-      void transport
-        .request({
-          kind: 'runtime.request',
-          session: key,
-          requestId: requestId(),
-          request,
-        })
-        .then((result) => {
-          if (held.get(key) !== entry || request.kind !== 'followUp.send')
-            return;
-          const current = entry.surface$.get();
-          const sending = new Set(current.sending);
-          sending.delete(request.streamId);
-          setSurface(entry, { ...current, sending });
-          if (!result.ok) return;
-          if (
-            submitted !== undefined &&
-            entry.surface$.get().drafts.get(request.streamId) === submitted
-          ) {
-            act(entry, {
-              kind: 'draft',
-              streamId: request.streamId,
-              patch: EMPTY_DRAFT,
-            });
-          }
-        });
+      if (entry) runtimeRequestFor(entry, request);
     },
     hostRequest(key, hostRequest) {
       const entry = held.get(key);
       if (entry) hostRequestFor(entry, hostRequest);
+    },
+    submit(key) {
+      const entry = held.get(key);
+      if (entry) submit(entry);
     },
     onChange(listener) {
       listeners.add(listener);

--- a/packages/extension/src/progressView/frontend/sessionSurfaces.ts
+++ b/packages/extension/src/progressView/frontend/sessionSurfaces.ts
@@ -34,6 +34,7 @@ import {
 } from '@shared/session/surface';
 import { PersistedState } from '@shared/state/PersistedState';
 
+import { playCompletionSound } from './audioNotification';
 import {
   installWebviewTransport,
   transcriptAggregates,
@@ -337,6 +338,11 @@ export function createSessionSurfaces(options: {
   transport.onSurfaceAction((key, action) => {
     const entry = held.get(key);
     if (!entry) return;
+    if (action.kind === 'chime') {
+      // The host already decided the transition and chose this port.
+      playCompletionSound();
+      return;
+    }
     if (action.kind === 'submitLaunch') {
       // The run accelerator: send the launcher's instruction as the
       // composer would.

--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -1,9 +1,10 @@
-/** LaTeXDiff section with base/edited file selectors, commit selector, and diff actions. */
+/** LaTeXDiff section with base/edited file selectors, commit selector, and
+ *  diff actions. The Tools sheet is its container (PRD 12.1); it carries no
+ *  disclosure of its own. */
 
-// Side-effect imports - register WA button, button-group, details, select, option & tooltip components
+// Side-effect imports - register WA button, button-group, select, option & tooltip components
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/button-group/button-group.js';
-import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
 import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
@@ -23,7 +24,6 @@ import {
   renderLabeledActionButtonParts,
 } from '@shared/wa/actionButtons';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
-import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { byString } from '@utils/core';
 import { MainViewEvents } from '../events';
 import { fileSelectLayoutStyles } from '../fileSelectStyles';
@@ -120,49 +120,8 @@ export class LatexDiffsSection extends LitElement {
         display: block;
       }
 
-      .latexdiffs-details {
-        margin-bottom: var(--wa-space-s);
-      }
-
-      .latexdiffs-details::part(base) {
-        background-color: transparent;
-        border: none;
-        border-radius: var(--border-radius);
-        overflow: visible;
-      }
-
-      .latexdiffs-details[open]::part(base) {
-        background-color: var(--background-color);
-        border: var(--border-thin) solid
-          var(--wa-color-surface-border, var(--dropdown-border));
-      }
-
-      .latexdiffs-details::part(header) {
-        padding: var(--wa-space-s) var(--wa-space-xs) 0;
-        min-height: var(--height-control-compact);
-      }
-
-      .latexdiffs-details[open]::part(header) {
-        padding: var(--wa-space-xs) var(--wa-space-xs) var(--wa-space-3xs);
-      }
-
-      .latexdiffs-details::part(content) {
+      .latexdiffs-body {
         padding: 0 var(--wa-space-xs) var(--wa-space-xs);
-        overflow: visible;
-      }
-
-      .latexdiffs-summary {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--wa-space-3xs);
-        color: var(--text-color);
-        font-size: var(--font-size);
-        line-height: var(--line-height-normal);
-        white-space: nowrap;
-      }
-
-      .latexdiffs-details[open] .latexdiffs-summary {
-        color: var(--wa-color-text-normal);
       }
 
       #commit::part(listbox) {
@@ -193,9 +152,6 @@ export class LatexDiffsSection extends LitElement {
     `,
   ];
 
-  /** Whether the section is expanded */
-  @property({ attribute: false }) visible = false;
-
   /** Base file value */
   @property({ attribute: false }) baseFile = '';
 
@@ -216,11 +172,6 @@ export class LatexDiffsSection extends LitElement {
 
   /** Whether this is a git repo */
   @property({ attribute: false }) isGitRepo = true;
-
-  private handleDetailsOpenChange(event: Event, visible: boolean): void {
-    if (event.target !== event.currentTarget) return;
-    this.dispatchEvent(MainViewEvents.latexDiffsToggle({ visible }));
-  }
 
   private handleBaseSelectChange(event: Event): void {
     this.dispatchEvent(
@@ -319,147 +270,134 @@ export class LatexDiffsSection extends LitElement {
 
   override render(): TemplateResult {
     return html`
-      <wa-details
-        class="latexdiffs-details"
-        ?open=${this.visible}
-        @wa-show=${(event: Event) => this.handleDetailsOpenChange(event, true)}
-        @wa-hide=${(event: Event) => this.handleDetailsOpenChange(event, false)}
-      >
-        <span slot="summary" class="latexdiffs-summary">
-          ${waIcon('code-branch')} LaTeXDiffs
-        </span>
-        <div id="latexdiffsContent">
-          <div class="file-select">
-            <div class="file-select-header">
-              <div class="file-select-label-group">
-                <label for="baseFile">Base</label>
-              </div>
-              <div class="file-select-actions">
-                ${renderIconActionButton({
-                  id: 'currentBaseFileButton',
-                  icon: 'file-code',
-                  label: 'Set current file as base',
-                  tooltip: 'Set current file as base',
-                  onClick: () =>
-                    this.dispatchEvent(
-                      MainViewEvents.getCurrentFile({ type: 'base' }),
-                    ),
-                })}
-                ${renderIconActionButton({
-                  id: 'emptyBaseFileButton',
-                  icon: 'xmark',
-                  label: 'Clear base file',
-                  tooltip: 'Clear base file',
-                  onClick: () =>
-                    this.dispatchEvent(
-                      MainViewEvents.emptyFile({ type: 'base' }),
-                    ),
-                })}
-              </div>
+      <div class="latexdiffs-body">
+        <div class="file-select">
+          <div class="file-select-header">
+            <div class="file-select-label-group">
+              <label for="baseFile">Base</label>
             </div>
-            <wa-select
-              id="baseFile"
-              placement="top"
-              .value=${this.baseFile}
-              @change=${this.handleBaseSelectChange}
-            >
-              ${this.renderFileOptions(this.baseFileOptions)}
-            </wa-select>
-          </div>
-          <div class="file-select">
-            <div class="file-select-header">
-              <div class="file-select-label-group">
-                <label id="editedFileLabel" for="editedFile">Edited</label>
-                <wa-tooltip for="editedFileLabel">
-                  File containing edits to merge into the base file
-                </wa-tooltip>
-              </div>
-              <div class="file-select-actions">
-                ${renderIconActionButton({
-                  id: 'refreshEditedFileButton',
-                  icon: 'pencil',
-                  label: 'Refresh edited files',
-                  tooltip: 'Refresh edited files',
-                  onClick: this.handleRefreshEditedFiles,
-                })}
-                ${renderIconActionButton({
-                  id: 'currentEditedFileButton',
-                  icon: 'file-code',
-                  label: 'Set current file as edited',
-                  tooltip: 'Set current file as edited',
-                  onClick: () =>
-                    this.dispatchEvent(
-                      MainViewEvents.getCurrentFile({ type: 'edited' }),
-                    ),
-                })}
-                ${renderIconActionButton({
-                  id: 'emptyEditedFileButton',
-                  icon: 'xmark',
-                  label: 'Clear edited file',
-                  tooltip: 'Clear edited file',
-                  onClick: () =>
-                    this.dispatchEvent(
-                      MainViewEvents.emptyFile({ type: 'edited' }),
-                    ),
-                })}
-              </div>
-            </div>
-            <wa-select
-              id="editedFile"
-              placement="top"
-              .value=${this.editedFile}
-              @change=${this.handleEditedSelectChange}
-            >
-              ${this.renderFileOptions(this.editedFileOptions)}
-            </wa-select>
-            <div class="diff-actions">
-              ${this.renderDiffActionGroup(
-                'Review changes',
-                EDITED_REVIEW_ACTIONS,
-              )}
-              ${this.renderDiffActionGroup(
-                'Apply changes',
-                EDITED_APPLY_ACTIONS,
-              )}
+            <div class="file-select-actions">
+              ${renderIconActionButton({
+                id: 'currentBaseFileButton',
+                icon: 'file-code',
+                label: 'Set current file as base',
+                tooltip: 'Set current file as base',
+                onClick: () =>
+                  this.dispatchEvent(
+                    MainViewEvents.getCurrentFile({ type: 'base' }),
+                  ),
+              })}
+              ${renderIconActionButton({
+                id: 'emptyBaseFileButton',
+                icon: 'xmark',
+                label: 'Clear base file',
+                tooltip: 'Clear base file',
+                onClick: () =>
+                  this.dispatchEvent(
+                    MainViewEvents.emptyFile({ type: 'base' }),
+                  ),
+              })}
             </div>
           </div>
-          <div class="file-select">
-            <div class="file-select-header">
-              <div class="file-select-label-group">
-                <label for="commit">Commit</label>
-              </div>
-              <div class="file-select-actions">
-                ${renderIconActionButton({
-                  id: 'refreshCommitsButton',
-                  icon: 'circle-dot',
-                  label: 'Refresh commit list',
-                  tooltip: 'Refresh commit list',
-                  onClick: this.handleRefreshCommits,
-                })}
-              </div>
+          <wa-select
+            id="baseFile"
+            placement="top"
+            .value=${this.baseFile}
+            @change=${this.handleBaseSelectChange}
+          >
+            ${this.renderFileOptions(this.baseFileOptions)}
+          </wa-select>
+        </div>
+        <div class="file-select">
+          <div class="file-select-header">
+            <div class="file-select-label-group">
+              <label id="editedFileLabel" for="editedFile">Edited</label>
+              <wa-tooltip for="editedFileLabel">
+                File containing edits to merge into the base file
+              </wa-tooltip>
             </div>
-            <wa-select
-              id="commit"
-              placement="top"
-              .value=${this.commit}
-              ?disabled=${!this.isGitRepo}
-              @change=${this.handleCommitSelectChange}
-            >
-              ${this.renderCommitOptions()}
-            </wa-select>
-            <div class="diff-actions">
-              ${this.renderDiffActionGroup(
-                'Diff against commit',
-                COMMIT_DIFF_ACTIONS,
-              )}
-              ${this.renderDiffActionGroup(
-                'Manage diff output',
-                COMMIT_MANAGE_ACTIONS,
-              )}
+            <div class="file-select-actions">
+              ${renderIconActionButton({
+                id: 'refreshEditedFileButton',
+                icon: 'pencil',
+                label: 'Refresh edited files',
+                tooltip: 'Refresh edited files',
+                onClick: this.handleRefreshEditedFiles,
+              })}
+              ${renderIconActionButton({
+                id: 'currentEditedFileButton',
+                icon: 'file-code',
+                label: 'Set current file as edited',
+                tooltip: 'Set current file as edited',
+                onClick: () =>
+                  this.dispatchEvent(
+                    MainViewEvents.getCurrentFile({ type: 'edited' }),
+                  ),
+              })}
+              ${renderIconActionButton({
+                id: 'emptyEditedFileButton',
+                icon: 'xmark',
+                label: 'Clear edited file',
+                tooltip: 'Clear edited file',
+                onClick: () =>
+                  this.dispatchEvent(
+                    MainViewEvents.emptyFile({ type: 'edited' }),
+                  ),
+              })}
             </div>
+          </div>
+          <wa-select
+            id="editedFile"
+            placement="top"
+            .value=${this.editedFile}
+            @change=${this.handleEditedSelectChange}
+          >
+            ${this.renderFileOptions(this.editedFileOptions)}
+          </wa-select>
+          <div class="diff-actions">
+            ${this.renderDiffActionGroup(
+              'Review changes',
+              EDITED_REVIEW_ACTIONS,
+            )}
+            ${this.renderDiffActionGroup('Apply changes', EDITED_APPLY_ACTIONS)}
           </div>
         </div>
-      </wa-details>
+        <div class="file-select">
+          <div class="file-select-header">
+            <div class="file-select-label-group">
+              <label for="commit">Commit</label>
+            </div>
+            <div class="file-select-actions">
+              ${renderIconActionButton({
+                id: 'refreshCommitsButton',
+                icon: 'circle-dot',
+                label: 'Refresh commit list',
+                tooltip: 'Refresh commit list',
+                onClick: this.handleRefreshCommits,
+              })}
+            </div>
+          </div>
+          <wa-select
+            id="commit"
+            placement="top"
+            .value=${this.commit}
+            ?disabled=${!this.isGitRepo}
+            @change=${this.handleCommitSelectChange}
+          >
+            ${this.renderCommitOptions()}
+          </wa-select>
+          <div class="diff-actions">
+            ${this.renderDiffActionGroup(
+              'Diff against commit',
+              COMMIT_DIFF_ACTIONS,
+            )}
+            ${this.renderDiffActionGroup(
+              'Manage diff output',
+              COMMIT_MANAGE_ACTIONS,
+            )}
+          </div>
+        </div>
+      </div>
     `;
   }
 }

--- a/packages/extension/src/webview/frontend/events.ts
+++ b/packages/extension/src/webview/frontend/events.ts
@@ -20,7 +20,6 @@ import type {
   InstallGuideDetail,
   InstructionChangeDetail,
   LatexDiffsActionDetail,
-  LatexDiffsToggleDetail,
   LaunchTargetChangeDetail,
   ModelChangeDetail,
   MultipleFilesActionDetail,
@@ -110,12 +109,7 @@ export const MainViewEvents = {
   gettingStartedAction: (detail: GettingStartedActionDetail) =>
     createEvent('getting-started-action', detail),
 
-  dismissSessionHint: () => createEvent('dismiss-session-hint', undefined),
-
   // LaTeXDiffs events
-  latexDiffsToggle: (detail: LatexDiffsToggleDetail) =>
-    createEvent('latexdiffs-toggle', detail),
-
   latexDiffsAction: (detail: LatexDiffsActionDetail) =>
     createEvent('latexdiffs-action', detail),
 

--- a/packages/extension/src/webview/frontend/events.ts
+++ b/packages/extension/src/webview/frontend/events.ts
@@ -6,8 +6,6 @@
 
 // Local imports - shared utilities
 import type {
-  ActionDetail,
-  AgentChangeDetail,
   AgentConfigBannerActionDetail,
   ApiKeyBannerActionDetail,
   BaseFileChangeDetail,
@@ -15,20 +13,13 @@ import type {
   CommitChangeDetail,
   EditedFileChangeDetail,
   FileActionDetail,
-  FocusInstructionDetail,
   GettingStartedActionDetail,
   InstallGuideDetail,
-  InstructionChangeDetail,
   LatexDiffsActionDetail,
-  LaunchTargetChangeDetail,
-  ModelChangeDetail,
   MultipleFilesActionDetail,
   MultipleFilesTypeActionDetail,
   ReorderFilesDetail,
   RemoveFileDetail,
-  SessionTypeChangeDetail,
-  TeamChangeDetail,
-  WorkingDirectoryChangeDetail,
 } from '@shared/schemas';
 import { createEvent } from '@shared/utils/events';
 export const MainViewEvents = {
@@ -67,9 +58,6 @@ export const MainViewEvents = {
     createEvent('commit-change', detail),
 
   refreshCommits: () => createEvent('refresh-commits', undefined),
-
-  focusInstruction: (detail: FocusInstructionDetail) =>
-    createEvent('focus-instruction', detail),
 
   // Banner events
   apiKeyAction: (detail: ApiKeyBannerActionDetail) =>
@@ -112,39 +100,4 @@ export const MainViewEvents = {
   // LaTeXDiffs events
   latexDiffsAction: (detail: LatexDiffsActionDetail) =>
     createEvent('latexdiffs-action', detail),
-
-  // InstructionPanel events
-  sessionTypeChange: (detail: SessionTypeChangeDetail) =>
-    createEvent('session-type-change', detail),
-
-  launchTargetChange: (detail: LaunchTargetChangeDetail) =>
-    createEvent('launch-target-change', detail),
-
-  teamChange: (detail: TeamChangeDetail) => createEvent('team-change', detail),
-
-  agentChange: (detail: AgentChangeDetail) =>
-    createEvent('agent-change', detail),
-
-  modelChange: (detail: ModelChangeDetail) =>
-    createEvent('model-change', detail),
-
-  workingDirectoryChange: (detail: WorkingDirectoryChangeDetail) =>
-    createEvent('working-directory-change', detail),
-
-  instructionInput: (detail: InstructionChangeDetail) =>
-    createEvent('instruction-input', detail),
-
-  panelAction: (detail: ActionDetail) => createEvent('panel-action', detail),
-
-  execute: () => createEvent('execute', undefined),
-
-  agentSettings: () => createEvent('agent-settings', undefined),
-
-  browseAllAgents: () => createEvent('browse-all-agents', undefined),
-
-  teamSettings: () => createEvent('team-settings', undefined),
-
-  manageTeams: () => createEvent('manage-teams', undefined),
-
-  modelSettings: () => createEvent('model-settings', undefined),
 } as const;

--- a/scripts/smoke-webviews-electron-runner.cjs
+++ b/scripts/smoke-webviews-electron-runner.cjs
@@ -335,9 +335,7 @@ async function assertProgressComposerLayout(window, view) {
         const dock = findDeep('.conversation-composer-dock');
         const conversationLog = findDeep('.conversation-log');
         if (composer?.updateComplete) await composer.updateComplete;
-        const waTextarea = composer?.shadowRoot?.querySelector('wa-textarea');
-        if (waTextarea?.updateComplete) await waTextarea.updateComplete;
-        const textarea = waTextarea?.shadowRoot?.querySelector('textarea');
+        const textarea = composer?.shadowRoot?.querySelector('textarea');
 
         const missing = [
           ['session-composer', composer],

--- a/src/controllers/session/hostRunActions.ts
+++ b/src/controllers/session/hostRunActions.ts
@@ -354,6 +354,6 @@ export function createHostRunActions(
 /** The launcher's form of a run configuration (PRD 8.5, `launch`). */
 export function launchPatchOf(config: AgentConfig) {
   const state = buildMainViewState(config);
-  const { openedFiles: _opened, latexdiffsVisible: _diffs, ...launch } = state;
+  const { openedFiles: _opened, ...launch } = state;
   return launch;
 }

--- a/src/shared/commands/catalog.ts
+++ b/src/shared/commands/catalog.ts
@@ -303,7 +303,7 @@ export const commandCatalog = [
   {
     id: 'texra.toggleView',
     extensionRegistry: true,
-    title: 'Toggle Launcher/Progress View',
+    title: 'Toggle Sessions Drawer',
     category: 'TeXRA',
     icon: '$(split-horizontal)',
     keybinding: {

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -254,10 +254,7 @@ type StringValueDetail = z.infer<typeof StringValueDetailSchema>;
 
 export type BaseFileChangeDetail = StringValueDetail;
 export type EditedFileChangeDetail = StringValueDetail;
-export type ModelChangeDetail = StringValueDetail;
-export type InstructionChangeDetail = StringValueDetail;
 export type CommitChangeDetail = StringValueDetail;
-export type WorkingDirectoryChangeDetail = StringValueDetail;
 
 const FileActionDetailSchema = z.object({
   type: CurrentFileTypeSchema,
@@ -387,38 +384,3 @@ const LatexDiffsActionDetailSchema = z.object({
 export type LatexDiffsActionDetail = z.infer<
   typeof LatexDiffsActionDetailSchema
 >;
-
-const FocusInstructionDetailSchema = z.object({
-  key: z.string(),
-  text: z.string(),
-});
-export type FocusInstructionDetail = z.infer<
-  typeof FocusInstructionDetailSchema
->;
-
-const SessionTypeChangeDetailSchema = z.object({
-  value: SessionTypeSchema,
-});
-export type SessionTypeChangeDetail = z.infer<
-  typeof SessionTypeChangeDetailSchema
->;
-
-const AgentChangeDetailSchema = z.object({
-  sessionType: SessionTypeSchema,
-  value: z.string(),
-});
-export type AgentChangeDetail = z.infer<typeof AgentChangeDetailSchema>;
-
-const LaunchTargetChangeDetailSchema = z.object({
-  value: LaunchTargetSchema,
-});
-export type LaunchTargetChangeDetail = z.infer<
-  typeof LaunchTargetChangeDetailSchema
->;
-
-export type TeamChangeDetail = StringValueDetail;
-
-const ActionDetailSchema = z.object({
-  action: z.string(),
-});
-export type ActionDetail = z.infer<typeof ActionDetailSchema>;

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -373,13 +373,6 @@ const InstallGuideDetailSchema = z.object({
 });
 export type InstallGuideDetail = z.infer<typeof InstallGuideDetailSchema>;
 
-const LatexDiffsToggleDetailSchema = z.object({
-  visible: z.boolean(),
-});
-export type LatexDiffsToggleDetail = z.infer<
-  typeof LatexDiffsToggleDetailSchema
->;
-
 const LatexDiffsActionDetailSchema = z.object({
   action: z.enum([
     'latexdiff',

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -165,7 +165,6 @@ export const MainViewPersistedStateSchema = UIFileFieldsSchema.merge(
     })
     .prefault({}),
   baseFile: z.string().prefault(''),
-  latexdiffsVisible: z.boolean().prefault(false),
   openedFiles: z.array(z.string()).nullish(),
 });
 export type MainViewPersistedState = z.infer<

--- a/src/shared/session/sessionFrames.ts
+++ b/src/shared/session/sessionFrames.ts
@@ -125,7 +125,9 @@ const SurfaceActionMessageSchema = z.object({
     z.object({ kind: z.literal('selectNew') }),
     z.object({ kind: z.literal('select'), streamId: StreamTabIdSchema }),
     z.object({ kind: z.literal('toggleDrawer') }),
-    z.object({ kind: z.literal('submitLaunch') }),
+    /** The run accelerator: the composer's Send for the surface's resolved
+     *  selection, a follow-up to the selected stream or a launch (PRD 12.4). */
+    z.object({ kind: z.literal('submit') }),
     /** A workflow run of this session left running for finished or
      *  cancelled: the host decides the transition once and sends it to one
      *  port, which plays the completion chime (PRD 12.4). */

--- a/src/shared/session/sessionFrames.ts
+++ b/src/shared/session/sessionFrames.ts
@@ -126,6 +126,10 @@ const SurfaceActionMessageSchema = z.object({
     z.object({ kind: z.literal('select'), streamId: StreamTabIdSchema }),
     z.object({ kind: z.literal('toggleDrawer') }),
     z.object({ kind: z.literal('submitLaunch') }),
+    /** A workflow run of this session left running for finished or
+     *  cancelled: the host decides the transition once and sends it to one
+     *  port, which plays the completion chime (PRD 12.4). */
+    z.object({ kind: z.literal('chime') }),
     /** A run's setup restored into the launcher (`restoreIntoLauncher`,
      *  `restoreProposalConfig`), or the setup agent selected by the
      *  onboarding funnel. */

--- a/src/shared/session/surface.ts
+++ b/src/shared/session/surface.ts
@@ -25,13 +25,11 @@ import type { SessionView } from './sessionView';
 
 /**
  * The new-task composer's selections: `MainViewPersistedState` minus the
- * host-derived fields. `openedFiles` and the LaTeXDiffs visibility are the
- * host's (`openedFiles`) or the Tools sheet's (`toolsSheetOpen` below), so
- * a per-view copy would answer a question the host snapshot already owns.
+ * host-derived `openedFiles`, which the host snapshot already owns, so a
+ * per-view copy would answer a question two surfaces cannot differ on.
  */
 export const LaunchSurfaceSchema = MainViewPersistedStateSchema.omit({
   openedFiles: true,
-  latexdiffsVisible: true,
 });
 type LaunchSurface = z.infer<typeof LaunchSurfaceSchema>;
 

--- a/src/shared/session/uiEvents.ts
+++ b/src/shared/session/uiEvents.ts
@@ -1,10 +1,13 @@
 /**
- * The three events a shell component dispatches. Each carries one arm of
- * the record it changes, unchanged, as its `detail`: a `RuntimeRequest` for
+ * The events a shell component dispatches. Three carry one arm of the
+ * record they change, unchanged, as their `detail`: a `RuntimeRequest` for
  * the session runtime, a `HostRequest` for a host capability, and a
- * `SurfaceAction` for the surface the root owns. The root installs one
- * listener per event; nothing translates in between (PRD 8, identity
- * translation), and a harness that assigns fixtures simply ignores them.
+ * `SurfaceAction` for the surface the root owns. The fourth, `submit`, is
+ * the composer's Send: the root resolves what it sends (a follow-up to the
+ * selected stream, or a launch) from the surface, so the button and the
+ * run accelerator share one decision. The root installs one listener per
+ * event; nothing translates in between (PRD 8, identity translation), and
+ * a harness that assigns fixtures simply ignores them.
  */
 import type { HostRequest } from './hostRequest';
 import type { RuntimeRequest } from './runtimeRequest';
@@ -14,6 +17,7 @@ const SESSION_UI_EVENT = {
   runtime: 'runtime-request',
   host: 'host-request',
   surface: 'surface-action',
+  submit: 'composer-submit',
 } as const;
 
 function uiEvent<T>(type: string, detail: T): CustomEvent<T> {
@@ -25,6 +29,7 @@ export const SessionUiEvents = {
     uiEvent(SESSION_UI_EVENT.runtime, detail),
   host: (detail: HostRequest) => uiEvent(SESSION_UI_EVENT.host, detail),
   surface: (detail: SurfaceAction) => uiEvent(SESSION_UI_EVENT.surface, detail),
+  submit: () => uiEvent(SESSION_UI_EVENT.submit, undefined),
 };
 
 declare global {
@@ -32,5 +37,6 @@ declare global {
     'runtime-request': CustomEvent<RuntimeRequest>;
     'host-request': CustomEvent<HostRequest>;
     'surface-action': CustomEvent<SurfaceAction>;
+    'composer-submit': CustomEvent<undefined>;
   }
 }

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.ts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.ts
@@ -168,14 +168,13 @@ describe('desktop IPC adapters', () => {
     ]);
   });
 
-  it('resets the launcher through the shell messages', async () => {
+  it('shows the launcher for New Session through the shell messages', async () => {
     const { actions, postToRenderer } = await createShellHarness();
 
     actions.resetMainView();
 
     expect(postToRenderer.mock.calls.map(([message]) => message)).toEqual([
       { command: 'desktop:showLauncher' },
-      { command: 'desktop:resetLauncher' },
     ]);
   });
 


### PR DESCRIPTION
## What and why

Lane ext-shell (8a + 8b) of the one-fold PRD: the extension's one surface (header, drawer, docked list, composer states, banners, commands) and the Tools sheet. The shell itself landed in #11883; this PR closes every gap the audit against main found, in build order, and records the rulings the audit asked for. The second commit is the review repair: every finding fixed at its owner, two refuted with evidence below.

Part of #11866
Closes #11872
Closes #11873

## Delivered

- Completion chime: `ProgressViewProvider` folds it into its existing `session.events.all` subscription. A workflow run's durable `result` whose outcome is not `failed` sends one `surface.action { kind: 'chime' }` frame (arm in `sessionFrames.ts`) to one port: the sidebar when it has ever been resolved (it retains its context while hidden, so a collapsed sidebar still plays it), else the editor tab. `sessionSurfaces.ts` plays it with no memory. The renderer hook in `TaskGroupList` (`previousStatuses`, `checkForCompletedRuns`, the `willUpdate` trigger, the `playCompletionSound` import) is deleted, so `playCompletionSound` has exactly one caller and a completion chimes once per process.
- Cmd+Alt+E is the composer's Send (PRD 12.4). The frame arm is `submit`; `SessionSurfaces.submit` resolves the selection with `resolveSelected` exactly as the composer did: a follow-up to the selected stream through the same `sending` latch (`runtimeRequestFor`), else a launch from the launcher's instruction; an empty draft sends nothing, as the button does. The composer's Send dispatches the new `composer-submit` UI event, so the button and the accelerator share one decision and cannot diverge. The host sends the frame to the editor tab when it is the active panel (`WebviewPanel.active`), otherwise to the sidebar after `showInSidebar()`, the shape `toggleDrawer` already has, so `texra.execute` with no view open lands somewhere visible. The editor panel and its port are one field, attached and released together.
- `texra.toggleView` toggles the Sessions drawer (`toggleDrawer` frame, sidebar shown first); the command title is now "Toggle Sessions Drawer" in `package.json` and the catalog.
- Open dashboard has one home, the overflow item, in both states (PRD 12.1); the empty-state gear is deleted. The overflow renders in both states so the Tools sheet is reachable from the New-task state; the debug section still needs a stream.
- Banners: `session-banners` (one element, two callers) takes `banners` and the mode only, renders the five host banners above the launch composer in the empty state and as the thin strip above the follow-up in `tool-use-stream-content`. The strip is zero height while every banner hides itself. `BaseStreamContent.host` has no null arm: the app renders a conversation only after the first snapshot (`ProgressApp.render`).
- Session hint callout re-homed under the expanded composer, keyed by `surface.launch.sessionType`, `launchTarget`, and the agent option's `isOrchestrator`.
- Composer on a native `textarea` (#11851 chrome): the three `::part` layers are gone, the card's focus-within ring is the one focus indicator, `getTextareaValue`/`insertTextAtCursor` callers unchanged.
- Chips collapse at 440 px.
- Ancestors path capped at `max-width: 40%` with the existing per-segment eviction.
- Docked layout: `#shell-new-task` hidden under the 720 px editor query, so the dock's "+" is the one New task control there.
- New Session (`texra.mainView.reset`) only selects new, the same as the header "+", on both hosts: the extension binds it to `showLauncher()`, the desktop binds it to `returnToLauncher` and its main-process menu posts `desktop:showLauncher` alone. The `desktop:resetLauncher` message, its schema, its route, and the renderer's `resetLauncher` are deleted, so the `launch` reset has no host-side caller left.
- Restore button reads "Edit as new task".
- `latexdiffsVisible` leaves `MainViewPersistedStateSchema`, the `LaunchSurfaceSchema` omit, and `launchPatchOf`; `toolsSheetOpen` is the one home for the sheet's state. Persisted blobs that still carry the key are stripped by `z.object`.
- `latexdiffs-section` drops its own `wa-details`, the `visible` property, and the `latexdiffs-toggle` event; the sheet is its container. `ToolsSheet` no longer passes `.visible`.
- Dead `MainViewEvents` members (15) and the `Detail` types that lost their last consumer with `InstructionPanel` are deleted.
- The Electron webview smoke probes the composer's native textarea instead of `wa-textarea`'s shadow root.
- Harness fixture: the orchestrator option carries `isOrchestrator: true`, the registry's real shape (`agentRegistry.ts`), so Real-ExtensionNew renders the orchestrator hint the board shows.

## Rulings recorded

- Banner placement: moved to sit directly above `<session-composer class="launch-composer">` (the `.launch-banners` element carries the `margin-top: auto`), per the PRD's "the five banners sit above the composer".
- Loading skeleton: the pre-snapshot frame (`host === null`) is not a state. The first host snapshot arrives with the first frame; the blank first paint is accepted and the checklist line is dropped. No skeleton branch, no pending arm, in the app or in the components below its gate.
- "Browse all agents…" and "Agent settings…" opened the same settings tab before the merge (`MainApp` bound `@browse-all-agents` to `onEditAgentConfig`). One action gets one item: the agent chip's last item is "Browse all agents…" and it opens the agents settings tab, the model chip keeps "Model settings…", the team section keeps "Manage teams…".
- Chips collapse at 440 px as the issue names; the harness sidebar (about 420 px) therefore shows the collapsed popover in Real-ExtensionNew.
- Context key stays `'main'` (the menus compare against `'progress'` only).
- PRD 8.5 names the accelerator arm `submitLaunch`; it ships as `submit` because 12.4 rules the accelerator is Send, and Send with a stream selected is a follow-up, not a launch. The PRD line is the doc owner's to update.

## Review findings refuted

- "Chime dies in a hidden sidebar" (the `surfaceActionOnce` finding): `commands.ts` registers the sidebar with `retainContextWhenHidden: true`, so a collapsed sidebar's webview stays live and receives `postMessage`; the sidebar-first choice for the chime is correct. The accelerator half of that finding stands and is fixed by the focus fact above.
- `Map<StreamTabId, string>` typing: moot, the map is gone with the view diff.

## Cross-lane notes (files this lane does not own)

- `ToolUseStreamContent.composerVisible` still derives from `status`/`lastTimestamp`. The ruling is that the fold owns whether a stream takes a follow-up: lane d5 (`sessionFold.ts`) should make `followUpSupport` become `'unsupported'` once the run is durably final, after which `composerVisible` reduces to `followUpSupport !== 'unsupported' && !readOnly`.
- The desktop chime (its main process applying the same `result` rule) is lane desktop's; the `composer-submit` listener in `packages/desktop/src/renderer/main.ts` and the `resetLauncher` deletion are in this PR because the composer event and the shared command id force them.
- Harness scenes for empty-with-no-streams, running-only, waiting, interrupted, narrow (250 px), and many-sessions (lane desktop); not added here.

## Net elements (R6)

- Files: A 1 (`SessionBanners.ts`), D 0, M 31.
- `^[+-]export`: +1 (`SessionBanners`), -11 (`LatexDiffsToggleDetail`, nine `Detail` types with no consumer, `DesktopResetLauncherMessageSchema`).
- class/interface/enum declarations: +1 class (`SessionBanners`), 0 removed.
- Net LoC from `git diff --stat origin/main`: 32 files, +668 / -662 (+6). The repair commit alone is 22 files, +185 / -253 (-68).

## Consumer counts (R8)

- `session-banners`: 2 render sites (`ProgressApp`, `ToolUseStreamContent`).
- `SessionSurfaces.submit`: 3 callers (`composer-submit` listener in `progressWebview.ts`, the same in desktop `main.ts`, the `submit` frame handler).
- `submit` frame: 1 sender (`ProgressViewProvider.submit`, from `extensionCommandSurface.execute`), 1 handler.
- `toggleDrawer` frame: 1 sender (`extensionCommandSurface.toggleView`), 1 handler.
- `chime` frame: 1 sender (`ProgressViewProvider.chime`), 1 handler; `playCompletionSound` 1 caller.
- `renderSessionHint`, `renderHero`, `renderOverflow`: 1 caller each, private methods.

## Verified

- `npm run typecheck` clean.
- `npm run lint` clean.
- `npx vitest run src/test-kernel/webview src/test-kernel/progressView src/test-kernel/commands src/test-kernel/desktop src/test-kernel/controllers/session src/test-kernel/shared/session src/test-kernel/architecture`: 113 files; one timeout in `DesktopProgressFileActions.vitest.ts` (latexdiff, untouched here) under a concurrent lint; passes alone in 2.5 s.
- `npm test`: 765 files pass, 1 skipped; 9060 tests pass, 6 skipped (after the repair commit).
- `npm run check:dead-code-ratchet`: 281 findings vs 281 baselined, no new findings; no baseline widened.
- `npm run smoke:webviews` (first commit): passes (progress, progress-populated composer layout, progress-approval, settings).
- Design harness (port 5193) after the repair: Real-ExtensionNew (no gear, overflow present, orchestrator hint under the orchestrator chip), Real-ExtensionSession, Real-ExtensionDrawer, Real-ExtensionWide, Real-ExtensionTools reshot with no page or console errors. Screenshots under `scratchpad/wf-shots/ext-shell-repair/`.
- No new test files. Zero em dashes in the diff.
