### PR TITLE
refactor(tools): run bounded traversal, per-key queues, and deferreds on Effect

### DIFF
--- a/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
@@ -1,6 +1,6 @@
 import '@test/support/defaultSessionTestSetup';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
@@ -148,36 +148,36 @@ describe('tool-use follow-up progress events', () => {
     expect(run.events).toEqual([]);
   });
 
-  it('aborts a blocking wait when the owning session emits followUpSent', () => {
+  it('breaks a blocking wait when the owning session emits followUpSent', () => {
     const session = trackSession();
-    const ac = new AbortController();
+    const onFollowUp = vi.fn();
     const otherStream = 'stream:other' as StreamTabId;
 
     let cleanup: () => void = () => {};
     withRunContext(createRunContext({ session, streamId }), () => {
-      cleanup = listenForFollowUp(ac);
+      cleanup = listenForFollowUp(onFollowUp);
     });
     unsubscribeFollowUpObservers.push(cleanup);
 
     notifyFollowUpSent(otherStream, session);
-    expect(ac.signal.aborted).toBe(false);
+    expect(onFollowUp).not.toHaveBeenCalled();
 
     notifyFollowUpSent(streamId, session);
-    expect(ac.signal.aborted).toBe(true);
+    expect(onFollowUp).toHaveBeenCalledOnce();
   });
 
-  it('stops aborting waits once the follow-up listener is cleaned up', () => {
+  it('stops breaking waits once the follow-up listener is cleaned up', () => {
     const session = trackSession();
-    const ac = new AbortController();
+    const onFollowUp = vi.fn();
 
     let cleanup: () => void = () => {};
     withRunContext(createRunContext({ session, streamId }), () => {
-      cleanup = listenForFollowUp(ac);
+      cleanup = listenForFollowUp(onFollowUp);
     });
     cleanup();
 
     notifyFollowUpSent(streamId, session);
-    expect(ac.signal.aborted).toBe(false);
+    expect(onFollowUp).not.toHaveBeenCalled();
   });
 
   it('does not append through stale active contexts after final status', async () => {

--- a/src/test-kernel/settings/MemoryFileSystemConcurrency.vitest.ts
+++ b/src/test-kernel/settings/MemoryFileSystemConcurrency.vitest.ts
@@ -133,4 +133,27 @@ describe('memory filesystem listing', () => {
     await expect(countPinnedMemories(1)).resolves.toBe(1);
     expect(readStream.mock.calls.length).toBeLessThan(files.length);
   });
+
+  it('rejects the iteration with the filesystem error itself', async () => {
+    const cause = Object.assign(
+      new Error('ENOENT: no such file or directory'),
+      {
+        code: 'ENOENT',
+      },
+    );
+    vi.spyOn(StorageFS, 'readDir').mockRejectedValue(cause);
+
+    const walk = async () => {
+      for await (const entry of walkMemoryDirectory(MEMORY_STORAGE_DIR)) {
+        throw new Error(`Unexpected entry: ${entry.relativePath}`);
+      }
+    };
+    const rejection: unknown = await walk().then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toBe(cause);
+    expect(rejection).toMatchObject({ code: 'ENOENT' });
+  });
 });

--- a/src/test-kernel/tools/MemoryTool.vitest.ts
+++ b/src/test-kernel/tools/MemoryTool.vitest.ts
@@ -136,7 +136,10 @@ describe('MemoryTool view with an omitted path', () => {
   );
 
   it('preserves the model-facing directory listing bytes and depth limit', async () => {
-    vi.useFakeTimers();
+    // Only the system clock is pinned (the MODIFIED column is relative to
+    // now); the walk runs on Effect's scheduler, which needs live
+    // setImmediate/setTimeout to make progress.
+    vi.useFakeTimers({ toFake: ['Date'] });
     vi.setSystemTime(new Date('2026-01-02T00:00:00.000Z'));
 
     const alphaPath = path.join(MEMORY_STORAGE_DIR, 'alpha');

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -6,7 +6,7 @@
  */
 
 // Third-party imports
-import { Deferred, Duration, Effect } from 'effect';
+import { Data, Deferred, Duration, Effect } from 'effect';
 
 // Local imports
 import {
@@ -114,6 +114,20 @@ const log = createLog('ExecutionsTool');
  * fan-out is bounded rather than page-wide.
  */
 const DURABLE_READ_CONCURRENCY = 16;
+
+/**
+ * One row's durable metadata read (its meta file, and for an unresolved row
+ * its lease and checkpoint stat) rejected: race deletion, permission error,
+ * a corrupt file. Nothing in the fan-out recovers from this: it fails fast,
+ * and the Promise edge rethrows `cause` so the tool surfaces the same Error
+ * instance the store raised.
+ */
+class ExecutionMetaUnreadable extends Data.TaggedError(
+  'ExecutionMetaUnreadable',
+)<{
+  readonly executionId: ExecutionId;
+  readonly cause: unknown;
+}> {}
 
 /**
  * Block until one of `executionIds` changes status, the caller's stream
@@ -363,8 +377,17 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     const lines = await effectRuntime().runPromise(
       Effect.forEach(
         page,
-        (entry) => Effect.promise(() => formatListingLine(entry)),
+        (entry) =>
+          Effect.tryPromise({
+            try: () => formatListingLine(entry),
+            catch: (cause) =>
+              new ExecutionMetaUnreadable({ executionId: entry.id, cause }),
+          }),
         { concurrency: DURABLE_READ_CONCURRENCY },
+      ).pipe(
+        Effect.catchTag('ExecutionMetaUnreadable', (error) =>
+          Effect.die(error.cause),
+        ),
       ),
     );
 
@@ -529,13 +552,20 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       Effect.forEach(
         children,
         (child) =>
-          Effect.promise(async () =>
-            formatChildLine(
-              child,
-              await getExecutionStore(child.id).readMeta(),
-            ),
-          ),
+          Effect.tryPromise({
+            try: async () =>
+              formatChildLine(
+                child,
+                await getExecutionStore(child.id).readMeta(),
+              ),
+            catch: (cause) =>
+              new ExecutionMetaUnreadable({ executionId: child.id, cause }),
+          }),
         { concurrency: DURABLE_READ_CONCURRENCY },
+      ).pipe(
+        Effect.catchTag('ExecutionMetaUnreadable', (error) =>
+          Effect.die(error.cause),
+        ),
       ),
     );
   }

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -6,7 +6,7 @@
  */
 
 // Third-party imports
-import pMap from 'p-map';
+import { Deferred, Duration, Effect } from 'effect';
 
 // Local imports
 import {
@@ -31,6 +31,7 @@ import {
 } from '@agent/runtime/RunContext';
 import { createLog } from '@logger/logUtils';
 import type { FileStat } from '@platform/interfaces';
+import { effectRuntime } from '@platform/processRuntime';
 import { workspaceRoots } from '@platform/workspaceRoots';
 import {
   ExecutionIdSchema,
@@ -105,6 +106,52 @@ import {
 import { workflowExecutionView } from './executions/workflowSummaryView';
 
 const log = createLog('ExecutionsTool');
+
+/**
+ * Bound on the durable reads one listing page or one children block fans
+ * out at once: every row asks for its own metadata (and, when the row
+ * recorded no outcome, its execution lease and a checkpoint stat), so the
+ * fan-out is bounded rather than page-wide.
+ */
+const DURABLE_READ_CONCURRENCY = 16;
+
+/**
+ * Block until one of `executionIds` changes status, the caller's stream
+ * receives a follow-up (the user breaking the wait), or `timeoutSeconds`
+ * elapse — whichever comes first. `settled` is re-checked once the change
+ * listeners are registered, closing the window between the caller's
+ * pre-check and registration. Interrupting the winner-less racers aborts
+ * the registry wait's signal and disposes the follow-up listener.
+ */
+const awaitStatusChange = Effect.fn('ExecutionsTool.awaitStatusChange')(
+  function* (
+    timeoutSeconds: number,
+    executionIds: string[],
+    settled: () => boolean,
+  ) {
+    const followUp = yield* Deferred.make<void>();
+    yield* Effect.acquireRelease(
+      Effect.sync(() =>
+        listenForFollowUp(() => {
+          Deferred.doneUnsafe(followUp, Effect.void);
+        }),
+      ),
+      (stop) => Effect.sync(stop),
+    );
+    const statusChange = Effect.promise((signal) =>
+      currentSession().executions.waitForAnyChange(executionIds, signal),
+    );
+    const alreadySettled = Effect.suspend(() =>
+      settled() ? Effect.void : Effect.never,
+    );
+    yield* Effect.raceAll([
+      statusChange,
+      alreadySettled,
+      Deferred.await(followUp),
+    ]).pipe(Effect.timeoutOption(Duration.seconds(timeoutSeconds)));
+  },
+  Effect.scoped,
+);
 
 function getRunningTodos(
   session: SessionHandle,
@@ -274,11 +321,10 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     const pendingIds = candidateIds.filter((id) => !shouldSkipWait(id));
     if (pendingIds.length === 0) return;
 
-    await this.waitWithTimeout(
-      timeout,
-      (signal) =>
-        currentSession().executions.waitForAnyChange(pendingIds, signal),
-      () => pendingIds.every(shouldSkipWait),
+    await effectRuntime().runPromise(
+      awaitStatusChange(timeout, pendingIds, () =>
+        pendingIds.every(shouldSkipWait),
+      ),
     );
   }
 
@@ -288,36 +334,11 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     timeout: number,
   ): Promise<void> {
     if (shouldSkipWait(executionId)) return;
-    await this.waitWithTimeout(
-      timeout,
-      (signal) =>
-        currentSession().executions.waitForAnyChange([executionId], signal),
-      () => shouldSkipWait(executionId),
+    await effectRuntime().runPromise(
+      awaitStatusChange(timeout, [executionId], () =>
+        shouldSkipWait(executionId),
+      ),
     );
-  }
-
-  /**
-   * Shared wait choreography: arm a timeout and a follow-up listener that both
-   * abort the wait, register the change callback, then re-check `settled` to
-   * close the race window between the initial pre-check and registration.
-   */
-  private async waitWithTimeout(
-    timeout: number,
-    register: (signal: AbortSignal) => Promise<unknown>,
-    settled: () => boolean,
-  ): Promise<void> {
-    const ac = new AbortController();
-    const timer = setTimeout(() => ac.abort(), timeout * 1000);
-    // Abort early if a follow-up is sent to this stream (user wants to break the wait).
-    const cleanupFollowUp = listenForFollowUp(ac);
-    try {
-      const waitPromise = register(ac.signal);
-      if (settled()) ac.abort();
-      await waitPromise;
-    } finally {
-      clearTimeout(timer);
-      cleanupFollowUp();
-    }
   }
 
   private async listExecutions(
@@ -335,13 +356,14 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       offset,
       limit,
     );
-    // One page, not one directory: each line asks the durable facts about its
-    // run (a lease read only for a row that recorded no outcome, and a
-    // checkpoint stat only when that lease turns out to be free), so the
-    // fan-out is bounded rather than 200 wide.
-    const lines = await pMap(page, (entry) => formatListingLine(entry), {
-      concurrency: 16,
-    });
+    // One page, not one directory — see DURABLE_READ_CONCURRENCY.
+    const lines = await effectRuntime().runPromise(
+      Effect.forEach(
+        page,
+        (entry) => Effect.promise(() => formatListingLine(entry)),
+        { concurrency: DURABLE_READ_CONCURRENCY },
+      ),
+    );
 
     return executed(
       `Executions (showing ${start}–${end} of ${total}, most recent first):\n\n${lines.join('\n')}${formatPaginationHint(end, total)}`,
@@ -496,17 +518,22 @@ Delegated subagent and workflow results are delivered automatically as follow-up
   }
 
   /**
-   * Fetch metas and format each child as a summary line. Bounded like the
-   * listing page: every child reads its own metadata and, when that row
-   * recorded no outcome, its execution lease — statting the checkpoint only
-   * when that lease is free — so a wide fan-out is a wide burst of file I/O.
+   * Fetch metas and format each child as a summary line, bounded like the
+   * listing page (DURABLE_READ_CONCURRENCY).
    */
   private formatChildren(children: ChildRecord[]): Promise<string[]> {
-    return pMap(
-      children,
-      async (child) =>
-        formatChildLine(child, await getExecutionStore(child.id).readMeta()),
-      { concurrency: 16 },
+    return effectRuntime().runPromise(
+      Effect.forEach(
+        children,
+        (child) =>
+          Effect.promise(async () =>
+            formatChildLine(
+              child,
+              await getExecutionStore(child.id).readMeta(),
+            ),
+          ),
+        { concurrency: DURABLE_READ_CONCURRENCY },
+      ),
     );
   }
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -120,8 +120,11 @@ const DURABLE_READ_CONCURRENCY = 16;
  * receives a follow-up (the user breaking the wait), or `timeoutSeconds`
  * elapse — whichever comes first. `settled` is re-checked once the change
  * listeners are registered, closing the window between the caller's
- * pre-check and registration. Interrupting the winner-less racers aborts
- * the registry wait's signal and disposes the follow-up listener.
+ * pre-check and registration. The race settles on the first completion,
+ * success or defect, so a throw inside the registry wait surfaces at once
+ * instead of stalling until the deadline. Interrupting the winner-less
+ * racers aborts the registry wait's signal and disposes the follow-up
+ * listener.
  */
 const awaitStatusChange = Effect.fn('ExecutionsTool.awaitStatusChange')(
   function* (
@@ -144,7 +147,7 @@ const awaitStatusChange = Effect.fn('ExecutionsTool.awaitStatusChange')(
     const alreadySettled = Effect.suspend(() =>
       settled() ? Effect.void : Effect.never,
     );
-    yield* Effect.raceAll([
+    yield* Effect.raceAllFirst([
       statusChange,
       alreadySettled,
       Deferred.await(followUp),

--- a/src/tools/agentCliSessionRegistry.ts
+++ b/src/tools/agentCliSessionRegistry.ts
@@ -1,9 +1,10 @@
-import pDefer from 'p-defer';
+import { Data, Deferred, Effect } from 'effect';
 
 import { getExecutionStore } from '@agent/storage';
 import type { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import type { ExecutionRegistry } from '@agent/runtime/executionRegistry';
 import { createLog } from '@logger/logUtils';
+import { effectRuntime } from '@platform/processRuntime';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 const logger = createLog('AgentCliSessionRegistry');
@@ -27,6 +28,38 @@ const DEFAULT_DEPENDENCIES: AgentCliSessionRegistryDependencies = {
   },
 };
 
+/** The session-mapping write rejected or threw; `cause` is what it raised. */
+class SessionMappingWriteFailed extends Data.TaggedError(
+  'SessionMappingWriteFailed',
+)<{ readonly cause: unknown }> {}
+
+/**
+ * Persist one SDK session id for a child execution. A write failure is
+ * reported through the injected diagnostics sink and otherwise contained:
+ * registration never waits on it and never fails because of it. The sink
+ * itself throwing is a defect of the detached fiber, not a rejection anyone
+ * observes.
+ */
+const persistSessionMapping = Effect.fn(
+  'AgentCliSessionRegistry.persistSessionMapping',
+)(function* (
+  dependencies: AgentCliSessionRegistryDependencies,
+  executionId: ExecutionId,
+  key: string,
+  sessionId: string,
+) {
+  yield* Effect.tryPromise({
+    try: () => dependencies.persistSessionId(executionId, key, sessionId),
+    catch: (cause) => new SessionMappingWriteFailed({ cause }),
+  }).pipe(
+    Effect.catchTag('SessionMappingWriteFailed', (failure) =>
+      Effect.sync(() =>
+        dependencies.reportPersistenceFailure(executionId, failure.cause),
+      ),
+    ),
+  );
+});
+
 /**
  * What the registry tracks about one live agent-CLI session: the child run's
  * identity and its follow-up address. Live handles are resolved on demand
@@ -43,10 +76,18 @@ export interface AgentCliSessionEntry {
 type AgentCliSessionState =
   | {
       kind: 'reserved';
-      ready: Promise<AgentCliSessionEntry | undefined>;
-      resolve: (entry: AgentCliSessionEntry | undefined) => void;
+      ready: Deferred.Deferred<AgentCliSessionEntry | undefined>;
     }
   | { kind: 'active'; entry: AgentCliSessionEntry };
+
+function settleReservation(
+  state: AgentCliSessionState | undefined,
+  entry: AgentCliSessionEntry | undefined,
+): void {
+  if (state?.kind === 'reserved') {
+    Deferred.doneUnsafe(state.ready, Effect.succeed(entry));
+  }
+}
 
 export class AgentCliSessionRegistry {
   private readonly sessions = new Map<string, AgentCliSessionState>();
@@ -66,17 +107,15 @@ export class AgentCliSessionRegistry {
   claim(sessionId: string): (() => void) | undefined {
     if (this.sessions.has(sessionId)) return undefined;
 
-    const ready = pDefer<AgentCliSessionEntry | undefined>();
     const reservation: AgentCliSessionState = {
       kind: 'reserved',
-      ready: ready.promise,
-      resolve: ready.resolve,
+      ready: Deferred.makeUnsafe<AgentCliSessionEntry | undefined>(),
     };
     this.sessions.set(sessionId, reservation);
     return () => {
       if (this.sessions.get(sessionId) !== reservation) return;
       this.sessions.delete(sessionId);
-      reservation.resolve(undefined);
+      settleReservation(reservation, undefined);
     };
   }
 
@@ -84,27 +123,21 @@ export class AgentCliSessionRegistry {
    * Register an active external-agent session and persist its SDK id for later
    * display or cross-reference after an extension reload clears memory. When
    * the id was reserved, registration also wakes callers waiting to enqueue a
-   * follow-up on the new loop.
+   * follow-up on the new loop. The persistence write runs on a detached fiber
+   * owned by this registry's process runtime; see {@link persistSessionMapping}.
    */
   register(sessionId: string, entry: AgentCliSessionEntry): void {
     const previous = this.sessions.get(sessionId);
     this.sessions.set(sessionId, { kind: 'active', entry });
-    if (previous?.kind === 'reserved') previous.resolve(entry);
-    void Promise.resolve()
-      .then(() =>
-        this.dependencies.persistSessionId(
-          entry.executionId,
-          this.persistedSessionKey,
-          sessionId,
-        ),
-      )
-      .catch((error) => {
-        try {
-          this.dependencies.reportPersistenceFailure(entry.executionId, error);
-        } catch {
-          // Best-effort diagnostics must not create an unhandled rejection.
-        }
-      });
+    settleReservation(previous, entry);
+    effectRuntime().runFork(
+      persistSessionMapping(
+        this.dependencies,
+        entry.executionId,
+        this.persistedSessionKey,
+        sessionId,
+      ),
+    );
   }
 
   /** Track a launched loop before its SDK session id is safe to publish. */
@@ -134,13 +167,15 @@ export class AgentCliSessionRegistry {
     sessionId: string,
   ): Promise<AgentCliSessionEntry | undefined> {
     const state = this.sessions.get(sessionId);
-    return state?.kind === 'active' ? state.entry : state?.ready;
+    if (!state) return undefined;
+    if (state.kind === 'active') return state.entry;
+    return effectRuntime().runPromise(Deferred.await(state.ready));
   }
 
   release(sessionId: string): void {
     const state = this.sessions.get(sessionId);
     this.sessions.delete(sessionId);
-    if (state?.kind === 'reserved') state.resolve(undefined);
+    settleReservation(state, undefined);
   }
 
   /** Release every alias and in-flight handle owned by one child execution. */

--- a/src/tools/executions/waitCoordination.ts
+++ b/src/tools/executions/waitCoordination.ts
@@ -47,8 +47,8 @@ export function shouldSkipWait(executionId: string): boolean {
 }
 
 /**
- * Listen for follow-up messages on the current stream and abort the given
- * AbortController when one arrives. This lets users break out of a blocking
+ * Listen for follow-up messages on the current stream and call `onFollowUp`
+ * when one arrives. This lets users break out of a blocking
  * `executions wait` by sending a follow-up message.
  *
  * Observes the owning session's follow-up queue (`ToolUseFollowUpQueue.onSent`,
@@ -57,12 +57,12 @@ export function shouldSkipWait(executionId: string): boolean {
  *
  * Returns a cleanup function that removes the listener.
  */
-export function listenForFollowUp(ac: AbortController): () => void {
+export function listenForFollowUp(onFollowUp: () => void): () => void {
   const context = tryUseRunContext();
   const streamId = getRunContextStreamId(context);
   if (!streamId) return () => {};
 
   return currentSession().followUps.onSent((sentStreamId) => {
-    if (sentStreamId === streamId) ac.abort();
+    if (sentStreamId === streamId) onFollowUp();
   });
 }

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -11,7 +11,7 @@
  * 24 h detach gate) lives here once.
  */
 
-import { Data, Effect } from 'effect';
+import { Cause, Data, Effect, Exit } from 'effect';
 
 import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
@@ -409,6 +409,16 @@ export abstract class PollingSourceBase<
     }
   }
 
+  /**
+   * @adapter-until 2026-11-05 (introduced 2026-09-06). The setInterval
+   * cadence is the one timer this file keeps off Effect's clock (PRD R8):
+   * "a polling timer must never keep a host process alive on its own", and
+   * rc.112 has no unref-capable scheduler (no `unref` anywhere in
+   * node_modules/effect/dist), so a Schedule-driven fiber would pin the CLI
+   * process. Retire when Effect gains an unref-capable clock or the hosts
+   * decide at process level that a live poller may keep the process alive;
+   * the interval only drives {@link PollingSourceBase.tick}.
+   */
   private ensureTimer(): void {
     this.registerShutdownIfNeeded();
     if (this.timer) return;
@@ -479,18 +489,30 @@ export abstract class PollingSourceBase<
 
   /**
    * Poll every subscription with at most `maxConcurrent` in flight, then run
-   * the post-poll hook. Neither step fails: each hook rejection is classified
-   * or logged at its own site, so the round itself never short-circuits.
+   * the post-poll hook. Each hook rejection is classified or logged at its
+   * own site, so no expected failure short-circuits the round. A defect in
+   * one entry (a throwing `handleFailure`) does not either: every started
+   * poll is joined through its Exit before the combined cause is re-raised,
+   * so `tick`'s in-flight guard never clears while a `pollOne` is still
+   * running and the next interval cannot start an overlapping poll.
    */
   private readonly pollRound = Effect.fn('PollingSourceBase.pollRound')(
     function* (this: PollingSourceBase<K, S>) {
       const now = Date.now();
       const entries = [...this.subscriptions.entries()];
-      yield* Effect.forEach(
+      const exits = yield* Effect.forEach(
         entries,
-        ([key, state]) => this.pollEntry(key, state, now),
-        { concurrency: this.config.maxConcurrent, discard: true },
+        ([key, state]) => Effect.exit(this.pollEntry(key, state, now)),
+        { concurrency: this.config.maxConcurrent },
       );
+      const failures = exits.filter(Exit.isFailure);
+      if (failures.length > 0) {
+        yield* Effect.failCause(
+          failures
+            .map((exit) => exit.cause)
+            .reduce((left, right) => Cause.combine(left, right)),
+        );
+      }
       yield* Effect.tryPromise({
         try: () => this.afterTick(entries, now),
         catch: (cause) => new PollHookRejected({ cause }),
@@ -508,21 +530,23 @@ export abstract class PollingSourceBase<
   );
 
   /** Poll one subscription, routing any failure through handleFailure. */
-  private pollEntry(key: K, state: S, now: number): Effect.Effect<void> {
-    if (state.skipPollUntilMs > now) return Effect.void;
-    return Effect.tryPromise({
-      try: () => this.pollOne(key, state),
-      catch: (cause) => new PollHookRejected({ cause }),
-    }).pipe(
-      Effect.map(() => {
-        state.lastSuccessAt = Date.now();
-        state.consecutiveFailures = 0;
-      }),
-      Effect.catchTag('PollHookRejected', (rejection) =>
-        Effect.sync(() => this.handleFailure(key, state, rejection.cause)),
-      ),
-    );
-  }
+  private readonly pollEntry = Effect.fn('PollingSourceBase.pollEntry')(
+    function* (this: PollingSourceBase<K, S>, key: K, state: S, now: number) {
+      if (state.skipPollUntilMs > now) return;
+      yield* Effect.tryPromise({
+        try: () => this.pollOne(key, state),
+        catch: (cause) => new PollHookRejected({ cause }),
+      }).pipe(
+        Effect.map(() => {
+          state.lastSuccessAt = Date.now();
+          state.consecutiveFailures = 0;
+        }),
+        Effect.catchTag('PollHookRejected', (rejection) =>
+          Effect.sync(() => this.handleFailure(key, state, rejection.cause)),
+        ),
+      );
+    },
+  );
 
   protected handleFailure(key: K, state: S, err: unknown): void {
     const now = Date.now();

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -11,7 +11,7 @@
  * 24 h detach gate) lives here once.
  */
 
-import pMap from 'p-map';
+import { Data, Effect } from 'effect';
 
 import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
@@ -23,6 +23,7 @@ import {
   type LifecycleHost,
 } from '@platform/interfaces';
 import { platform } from '@platform/platform';
+import { effectRuntime } from '@platform/processRuntime';
 import { jitteredExponentialBackoffMs } from '@utils/core';
 import {
   createBoundedIdSet,
@@ -63,6 +64,15 @@ export function createBasePollState(
     skipPollUntilMs: 0,
   };
 }
+
+/**
+ * A subclass hook (`pollOne` or `afterTick`) rejected. `cause` is whatever it
+ * raised — for `pollOne`, one of the GitHub error classes or a transport
+ * failure that {@link PollingSourceBase.handleFailure} classifies.
+ */
+class PollHookRejected extends Data.TaggedError('PollHookRejected')<{
+  readonly cause: unknown;
+}> {}
 
 interface PollingSourceConfig {
   /** Display name used in the logger and exception messages. */
@@ -446,48 +456,72 @@ export abstract class PollingSourceBase<
     this.shutdownLifecycle = undefined;
   }
 
-  private async tick(): Promise<void> {
-    // setInterval fires every pollIntervalMs regardless of prior completion;
-    // overlapping ticks would double-emit events. The guard is process-local
-    // (one timer per source) so it's race-free.
-    if (this.tickInFlight) return;
+  /**
+   * One poll round, run on the process runtime. setInterval fires every
+   * pollIntervalMs regardless of prior completion; overlapping ticks would
+   * double-emit events. The guard is process-local (one timer per source) so
+   * the synchronous check-and-set is race-free, and `ensuring` releases it
+   * however the round ends.
+   */
+  private tick(): Promise<void> {
+    if (this.tickInFlight) return Promise.resolve();
     this.tickInFlight = true;
-    try {
+    return effectRuntime().runPromise(
+      this.pollRound().pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            this.tickInFlight = false;
+          }),
+        ),
+      ),
+    );
+  }
+
+  /**
+   * Poll every subscription with at most `maxConcurrent` in flight, then run
+   * the post-poll hook. Neither step fails: each hook rejection is classified
+   * or logged at its own site, so the round itself never short-circuits.
+   */
+  private readonly pollRound = Effect.fn('PollingSourceBase.pollRound')(
+    function* (this: PollingSourceBase<K, S>) {
       const now = Date.now();
       const entries = [...this.subscriptions.entries()];
-      await pMap(entries, ([key, state]) => this.pollEntry(key, state, now), {
-        concurrency: this.config.maxConcurrent,
-        stopOnError: false,
-      });
-      await this.runAfterTick(entries, now);
+      yield* Effect.forEach(
+        entries,
+        ([key, state]) => this.pollEntry(key, state, now),
+        { concurrency: this.config.maxConcurrent, discard: true },
+      );
+      yield* Effect.tryPromise({
+        try: () => this.afterTick(entries, now),
+        catch: (cause) => new PollHookRejected({ cause }),
+      }).pipe(
+        Effect.catchTag('PollHookRejected', (rejection) =>
+          Effect.sync(() => {
+            this.logger.warn('Post-poll hook failed', {
+              data: rejection.cause,
+            });
+          }),
+        ),
+      );
       if (this.subscriptions.size === 0) this.stopTimer();
-    } finally {
-      this.tickInFlight = false;
-    }
-  }
+    },
+  );
 
   /** Poll one subscription, routing any failure through handleFailure. */
-  private async pollEntry(key: K, state: S, now: number): Promise<void> {
-    if (state.skipPollUntilMs > now) return;
-    try {
-      await this.pollOne(key, state);
-      state.lastSuccessAt = Date.now();
-      state.consecutiveFailures = 0;
-    } catch (err) {
-      this.handleFailure(key, state, err);
-    }
-  }
-
-  /** Run the post-poll hook, logging but otherwise swallowing its errors. */
-  private async runAfterTick(
-    entries: ReadonlyArray<readonly [K, S]>,
-    now: number,
-  ): Promise<void> {
-    try {
-      await this.afterTick(entries, now);
-    } catch (err) {
-      this.logger.warn('Post-poll hook failed', { data: err });
-    }
+  private pollEntry(key: K, state: S, now: number): Effect.Effect<void> {
+    if (state.skipPollUntilMs > now) return Effect.void;
+    return Effect.tryPromise({
+      try: () => this.pollOne(key, state),
+      catch: (cause) => new PollHookRejected({ cause }),
+    }).pipe(
+      Effect.map(() => {
+        state.lastSuccessAt = Date.now();
+        state.consecutiveFailures = 0;
+      }),
+      Effect.catchTag('PollHookRejected', (rejection) =>
+        Effect.sync(() => this.handleFailure(key, state, rejection.cause)),
+      ),
+    );
   }
 
   protected handleFailure(key: K, state: S, err: unknown): void {

--- a/src/tools/memory/memoryFileSystem.ts
+++ b/src/tools/memory/memoryFileSystem.ts
@@ -10,6 +10,7 @@ import * as path from 'node:path';
 import { Data, Effect, Semaphore, Stream } from 'effect';
 
 import { debug } from '@logger/logUtils';
+import { effectRuntime } from '@platform/processRuntime';
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import type { MemoryPreview, MemoryViewItem } from '@shared/schemas';
 import {
@@ -225,7 +226,9 @@ function walkLevel(
  * Walks the memory directory tree in depth-first order, skipping dotfiles,
  * `node_modules`, and symlinks (no realpath/visited guard, so a symlink is
  * never followed rather than risking a cycle). Breaking out of the iteration
- * early interrupts the walk, so no further entries are read.
+ * early interrupts the walk, so no further entries are read. The walk's
+ * fibers are forked from the process runtime's context, like every other
+ * Promise edge in this module's neighbours.
  * @param storagePath - Directory to start walking from
  * @param relativeRoot - Path prefix used to build each entry's relativePath
  * @param options - `maxDepth` (levels below the root; unlimited if omitted)
@@ -236,10 +239,12 @@ export async function* walkMemoryDirectory(
   relativeRoot = '',
   options: MemoryWalkOptions = {},
 ): AsyncGenerator<MemoryWalkEntry> {
-  yield* Stream.toAsyncIterable(
-    Stream.unwrap(
-      Effect.map(Semaphore.make(MEMORY_LISTING_CONCURRENCY), (permits) =>
-        walkLevel(storagePath, relativeRoot, 0, options, permits),
+  yield* await effectRuntime().runPromise(
+    Stream.toAsyncIterableEffect(
+      Stream.unwrap(
+        Effect.map(Semaphore.make(MEMORY_LISTING_CONCURRENCY), (permits) =>
+          walkLevel(storagePath, relativeRoot, 0, options, permits),
+        ),
       ),
     ),
   );

--- a/src/tools/memory/memoryFileSystem.ts
+++ b/src/tools/memory/memoryFileSystem.ts
@@ -83,6 +83,18 @@ async function readStoragePrefix(
 }
 
 /**
+ * A directory could not be listed or an entry could not be stat'ed (race
+ * deletion, permission error). Nothing in the walk recovers from this: the
+ * failure ends the walk, and the Promise edge rethrows `cause` so the
+ * consumer sees the same Error instance (with its `code`) the filesystem
+ * raised.
+ */
+class MemoryEntryUnreadable extends Data.TaggedError('MemoryEntryUnreadable')<{
+  readonly storagePath: string;
+  readonly cause: unknown;
+}> {}
+
+/**
  * The frontmatter head of a memory file could not be read or parsed (race
  * deletion, permission error). Attribution is skipped rather than failing
  * the whole walk; the entry itself still lists.
@@ -157,7 +169,10 @@ const describeEntry = Effect.fn('memoryFileSystem.describeEntry')(function* (
   relativePath: string,
   type: number,
 ) {
-  const stats = yield* Effect.promise(() => StorageFS.stat(storagePath));
+  const stats = yield* Effect.tryPromise({
+    try: () => StorageFS.stat(storagePath),
+    catch: (cause) => new MemoryEntryUnreadable({ storagePath, cause }),
+  });
   const entry = {
     relativePath,
     storagePath,
@@ -183,9 +198,12 @@ function walkLevel(
   depth: number,
   options: MemoryWalkOptions,
   permits: Semaphore.Semaphore,
-): Stream.Stream<MemoryWalkEntry> {
+): Stream.Stream<MemoryWalkEntry, MemoryEntryUnreadable> {
   return Stream.fromEffect(
-    Effect.promise(() => StorageFS.readDir(storagePath)),
+    Effect.tryPromise({
+      try: () => StorageFS.readDir(storagePath),
+      catch: (cause) => new MemoryEntryUnreadable({ storagePath, cause }),
+    }),
   ).pipe(
     Stream.flatMap(Stream.fromIterable),
     // Skip symlinks to avoid cycles; we have no realpath/visited guard.
@@ -228,7 +246,8 @@ function walkLevel(
  * never followed rather than risking a cycle). Breaking out of the iteration
  * early interrupts the walk, so no further entries are read. The walk's
  * fibers are forked from the process runtime's context, like every other
- * Promise edge in this module's neighbours.
+ * Promise edge in this module's neighbours. An unreadable directory or entry
+ * rejects the iteration with the filesystem's own error.
  * @param storagePath - Directory to start walking from
  * @param relativeRoot - Path prefix used to build each entry's relativePath
  * @param options - `maxDepth` (levels below the root; unlimited if omitted)
@@ -244,6 +263,10 @@ export async function* walkMemoryDirectory(
       Stream.unwrap(
         Effect.map(Semaphore.make(MEMORY_LISTING_CONCURRENCY), (permits) =>
           walkLevel(storagePath, relativeRoot, 0, options, permits),
+        ),
+      ).pipe(
+        Stream.catchTag('MemoryEntryUnreadable', (error) =>
+          Stream.die(error.cause),
         ),
       ),
     ),

--- a/src/tools/memory/memoryFileSystem.ts
+++ b/src/tools/memory/memoryFileSystem.ts
@@ -7,8 +7,7 @@
 
 import * as path from 'node:path';
 
-import { pMapIterable, pMapSkip } from 'p-map';
-import PQueue from 'p-queue';
+import { Data, Effect, Semaphore, Stream } from 'effect';
 
 import { debug } from '@logger/logUtils';
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
@@ -82,25 +81,41 @@ async function readStoragePrefix(
   };
 }
 
-async function readMemoryMeta(storagePath: string, stats: { size: number }) {
-  try {
-    const { text: raw } = await readStoragePrefix(
-      storagePath,
-      FRONTMATTER_SCAN_BYTES,
-      stats,
-    );
-    return parseFrontmatter(raw).meta;
-  } catch (error) {
-    // Unreadable file (race deletion, permission error) — skip attribution
-    // rather than failing the whole walk; the entry itself still lists.
-    debug(
-      'memory',
-      `Skipping attribution for unreadable memory file ${storagePath}`,
-      { data: error },
-    );
-    return null;
-  }
-}
+/**
+ * The frontmatter head of a memory file could not be read or parsed (race
+ * deletion, permission error). Attribution is skipped rather than failing
+ * the whole walk; the entry itself still lists.
+ */
+class MemoryMetaUnreadable extends Data.TaggedError('MemoryMetaUnreadable')<{
+  readonly storagePath: string;
+  readonly cause: unknown;
+}> {}
+
+const readMemoryMeta = Effect.fn('memoryFileSystem.readMemoryMeta')(
+  (storagePath: string, stats: { size: number }) =>
+    Effect.tryPromise({
+      try: async () => {
+        const { text: raw } = await readStoragePrefix(
+          storagePath,
+          FRONTMATTER_SCAN_BYTES,
+          stats,
+        );
+        return parseFrontmatter(raw).meta;
+      },
+      catch: (cause) => new MemoryMetaUnreadable({ storagePath, cause }),
+    }).pipe(
+      Effect.catchTag('MemoryMetaUnreadable', (error) =>
+        Effect.sync(() => {
+          debug(
+            'memory',
+            `Skipping attribution for unreadable memory file ${error.storagePath}`,
+            { data: error.cause },
+          );
+          return null;
+        }),
+      ),
+    ),
+);
 
 /**
  * Read the head of a memory file and project it into the bounded preview the
@@ -135,99 +150,98 @@ export async function loadMemoryPreview(
   return { storagePath, preview, lineCount };
 }
 
-async function* walkDir(
+/** Stat one directory entry and, for a file, read its attribution head. */
+const describeEntry = Effect.fn('memoryFileSystem.describeEntry')(function* (
+  storagePath: string,
+  relativePath: string,
+  type: number,
+) {
+  const stats = yield* Effect.promise(() => StorageFS.stat(storagePath));
+  const entry = {
+    relativePath,
+    storagePath,
+    size: stats.size,
+    mtime: stats.mtime,
+  };
+  if (isDirectory(type)) {
+    return { ...entry, isDir: true, meta: null } satisfies MemoryWalkEntry;
+  }
+  const meta = yield* readMemoryMeta(storagePath, stats);
+  return { ...entry, isDir: false, meta } satisfies MemoryWalkEntry;
+});
+
+/**
+ * One directory level of the walk. Entries are described in listing order
+ * with at most {@link MEMORY_LISTING_CONCURRENCY} in flight per level, and
+ * `permits` bounds the metadata reads across every level of the recursion
+ * so a deep tree cannot multiply that bound.
+ */
+function walkLevel(
   storagePath: string,
   relativeRoot: string,
   depth: number,
   options: MemoryWalkOptions,
-  queue: PQueue,
-): AsyncGenerator<MemoryWalkEntry> {
-  const entries = await StorageFS.readDir(storagePath);
-
-  const results = pMapIterable(
-    entries,
-    async ([name, type]): Promise<MemoryWalkEntry | typeof pMapSkip> => {
-      if (shouldSkipEntry(name)) {
-        return pMapSkip;
-      }
-
-      // Skip symlinks to avoid cycles; we have no realpath/visited guard.
-      if (isSymlink(type)) {
-        return pMapSkip;
-      }
-
-      return queue.add(async () => {
-        const nextRelative = relativeRoot
-          ? path.join(relativeRoot, name)
-          : name;
-        const nextStoragePath = path.join(storagePath, name);
-        const stats = await StorageFS.stat(nextStoragePath);
-
-        if (isDirectory(type)) {
-          return {
-            relativePath: nextRelative,
-            storagePath: nextStoragePath,
-            size: stats.size,
-            mtime: stats.mtime,
-            isDir: true,
-            meta: null,
-          };
-        }
-
-        const meta = await readMemoryMeta(nextStoragePath, stats);
-        return {
-          relativePath: nextRelative,
-          storagePath: nextStoragePath,
-          size: stats.size,
-          mtime: stats.mtime,
-          isDir: false,
-          meta,
-        };
-      }) as Promise<MemoryWalkEntry>;
-    },
-    { concurrency: MEMORY_LISTING_CONCURRENCY },
+  permits: Semaphore.Semaphore,
+): Stream.Stream<MemoryWalkEntry> {
+  return Stream.fromEffect(
+    Effect.promise(() => StorageFS.readDir(storagePath)),
+  ).pipe(
+    Stream.flatMap(Stream.fromIterable),
+    // Skip symlinks to avoid cycles; we have no realpath/visited guard.
+    Stream.filter(([name, type]) => !shouldSkipEntry(name) && !isSymlink(type)),
+    Stream.mapEffect(
+      ([name, type]) =>
+        permits.withPermits(1)(
+          describeEntry(
+            path.join(storagePath, name),
+            relativeRoot ? path.join(relativeRoot, name) : name,
+            type,
+          ),
+        ),
+      { concurrency: MEMORY_LISTING_CONCURRENCY },
+    ),
+    Stream.flatMap((entry) => {
+      if (!entry.isDir) return Stream.make(entry);
+      const self = options.includeDirs ? Stream.make(entry) : Stream.empty;
+      const descend =
+        options.maxDepth === undefined || depth + 1 < options.maxDepth;
+      return descend
+        ? Stream.concat(
+            self,
+            walkLevel(
+              entry.storagePath,
+              entry.relativePath,
+              depth + 1,
+              options,
+              permits,
+            ),
+          )
+        : self;
+    }),
   );
-
-  for await (const entry of results) {
-    if (entry.isDir) {
-      if (options.includeDirs) {
-        yield entry;
-      }
-      if (options.maxDepth === undefined || depth + 1 < options.maxDepth) {
-        yield* walkDir(
-          entry.storagePath,
-          entry.relativePath,
-          depth + 1,
-          options,
-          queue,
-        );
-      }
-    } else {
-      yield entry;
-    }
-  }
 }
 
 /**
  * Walks the memory directory tree in depth-first order, skipping dotfiles,
  * `node_modules`, and symlinks (no realpath/visited guard, so a symlink is
- * never followed rather than risking a cycle).
+ * never followed rather than risking a cycle). Breaking out of the iteration
+ * early interrupts the walk, so no further entries are read.
  * @param storagePath - Directory to start walking from
  * @param relativeRoot - Path prefix used to build each entry's relativePath
  * @param options - `maxDepth` (levels below the root; unlimited if omitted)
  *   and `includeDirs` (whether directory entries themselves are yielded)
  */
-export function walkMemoryDirectory(
+export async function* walkMemoryDirectory(
   storagePath: string,
   relativeRoot = '',
   options: MemoryWalkOptions = {},
 ): AsyncGenerator<MemoryWalkEntry> {
-  return walkDir(
-    storagePath,
-    relativeRoot,
-    0,
-    options,
-    new PQueue({ concurrency: MEMORY_LISTING_CONCURRENCY }),
+  yield* Stream.toAsyncIterable(
+    Stream.unwrap(
+      Effect.map(Semaphore.make(MEMORY_LISTING_CONCURRENCY), (permits) =>
+        walkLevel(storagePath, relativeRoot, 0, options, permits),
+      ),
+    ),
   );
 }
 


### PR DESCRIPTION
## Summary

Lane w5 of the Effect 4 runtime migration (PRD `docs/prds/2026-08-26-effect-4-runtime-migration.md`). The four `src/tools/` files that still coordinated concurrency with p-map, p-queue, p-defer, and an AbortController now do it with Effect, each run once at its existing Promise edge through the process runtime (`effectRuntime()` from `@platform/processRuntime`). `PollingSourceBase.tick` runs one `pollRound` program per interval firing; `ExecutionsTool` runs `awaitStatusChange` for the two wait paths and an `Effect.forEach` fan-out for the listing page and the children block; `AgentCliSessionRegistry.register` forks `persistSessionMapping` and `waitForActive` awaits a `Deferred`; `walkMemoryDirectory` runs one `Stream.toAsyncIterableEffect` per walk and yields from it. Nothing below these edges calls `runPromise`, `runFork`, or `runSync` (R1). The sibling ratchet in #11920 counts superseded package imports, `new AbortController(`, and raw catch clauses in migrated zones; this PR removes those rows for its four files.

Mechanisms deleted: p-map (3 imports, 4 call sites: the `stopOnError: false` poll fan-out, the two 16-wide `ExecutionsTool` fan-outs, and the `pMapIterable`/`pMapSkip` level walk, which is now a `Stream` of `fromIterable`, `filter`, `mapEffect` with concurrency 8, and recursive `flatMap`); p-queue (1 import, the global 8-wide `PQueue` that spanned the recursive walk, now one `Semaphore` created per walk and threaded through every level); p-defer (1 import, the reserved-session promise pair, now a `Deferred` that claim, register, and release settle through one `settleReservation` helper); the `AbortController` plus `setTimeout`, `clearTimeout`, and manual follow-up abort in `ExecutionsTool.waitWithTimeout`, deleted whole and replaced by the scoped `awaitStatusChange` (`Effect.timeoutOption` for the deadline, the follow-up listener as `acquireRelease`, the registry wait as `Effect.promise` whose interruption signal replaces the controller, and the post-registration settled re-check as a third racer; R5, R6, R8); and 5 catch clauses (`PollingSourceBase.pollEntry` and `runAfterTick`, `memoryFileSystem.readMemoryMeta`, and the `.catch` plus nested `try/catch` of the registry's persist chain), each replaced by `Effect.ensuring` or a tagged error routed by `catchTag` to the existing classifier, warn, or debug-and-skip (R7). The five tagged errors are module-private: `ExecutionMetaUnreadable`, `SessionMappingWriteFailed`, `PollHookRejected`, `MemoryEntryUnreadable`, `MemoryMetaUnreadable`.

Preserved public signatures, byte-identical: `PollingSourceBase`'s abstract `pollOne(key, state): Promise<void>` and `afterTick(entries, now): Promise<void>`, `register`, `emit`, `detach`, `handleFailure`, and every exported helper; `walkMemoryDirectory(storagePath, relativeRoot?, options?): AsyncGenerator<MemoryWalkEntry>`, `loadMemoryItems()`, `countPinnedMemories(limit?)`, `setMemoryPinned(storagePath, pinned)`, `loadMemoryPreview(storagePath)`; `AgentCliSessionRegistry.claim`, `register`, `trackInFlight`, `lookup`, `getHandle`, `waitForActive(sessionId): Promise<AgentCliSessionEntry | undefined>`, `release`, `releaseByExecutionId`, `interruptAll`; the executions tool's execute contract and every `ToolError` message. Errors raised by `StorageFS` and the execution store still reach the consumer as the same Error instance, code intact, because each tagged boundary failure is caught by tag and re-raised as `Effect.die(cause)` or `Stream.die(cause)` before the Promise edge. The one signature that changed is internal: `listenForFollowUp` takes a callback instead of an `AbortController`.

One mechanism was kept with a marker. `PollingSourceBase.ensureTimer`'s `setInterval` cadence carries `@adapter-until 2026-11-05` (introduced 2026-09-06, sixty days per R10). The file pins "a polling timer must never keep a host process alive on its own" (`timer.unref`), and Effect rc.112 has no unref-capable scheduler, so a Schedule-driven fiber would pin the CLI process. Retirement condition: Effect gains an unref-capable clock, or the hosts decide at process level that a live poller may keep the process alive. The interval only drives the Effect poll round.

Net production delta is +195 lines (+409/-214 across five files; +198 including the two test edits). The honest reason: three leaf conversions each pay their own run boundary and tagged error class, as the PRD's Phase 0 exemplar measured, and the review rounds added the per-entry `Exit` aggregation, the typed filesystem and store adapters, and the adapter marker's documentation. The p-map, p-queue, and p-defer packages stay in `package.json`; 49 other production modules still import them.

Review history. An Effect-idiom review and a behavior-parity review each ran adversarially before this PR opened. The idiom review caught five findings, all fixed in the second commit: `awaitStatusChange` used `Effect.raceAll`, which in rc.112 holds a racer's Die until every racer settles, so a defect in the registry wait sat behind the two `never` racers and the timeout then dropped the cause (probe: raceAll settled as Success None after the full deadline; raceAllFirst as Failure in 2 ms), now `Effect.raceAllFirst`; `pollRound` used fail-fast `Effect.forEach`, which let a defect settle the round while a `pollOne` was still in flight, clearing `tickInFlight` early so the next interval could start an overlapping poll, now each `pollEntry` runs through `Effect.exit` and the `Cause.combine` of the failed exits is re-raised after the join, restoring p-map's `stopOnError: false` wait-for-all semantics; `walkMemoryDirectory` used `Stream.toAsyncIterable`, which forks on `Context.empty()`, now `Stream.toAsyncIterableEffect` run once through `effectRuntime().runPromise` so the walk's fibers come from the process runtime; `pollEntry` was a plain method and now carries an `Effect.fn` span like its siblings; and the retained `setInterval` lacked its `@adapter-until` marker and retirement condition, now written beside the code. The parity review caught one finding, fixed in the third commit: four rejecting reads (`StorageFS.readDir` and `StorageFS.stat` in the walk, `readMeta` in the listing page and children block) went through `Effect.promise`, so a race deletion or permission error travelled as a defect that nothing inside the lane could recover from by tag; they are now `Effect.tryPromise` with `MemoryEntryUnreadable` and `ExecutionMetaUnreadable`, caught by tag and re-raised as the original cause at the edge. `awaitStatusChange`'s `Effect.promise` over `waitForAnyChange` is unchanged because that promise never rejects.

## Issue acceptance gates

No standalone issue; the lane is scoped by the PRD's R10 statement, which this body satisfies: the mechanisms made unreachable (p-map, p-queue, p-defer, and AbortController usage in the four files, plus their catch choreography), the carriers that collapse (`waitWithTimeout`, `runAfterTick`, the p-defer promise pair, the global `PQueue`), the imports removed (four package imports across four files), the line and element counts (below), and the one adapter's introduction date and retirement condition (above). The PRD's "one pass per file" rule holds: every mechanism family in each converted file converts in this PR, and the one exception is documented as an adapter rather than deferred silently.

## Single source of truth

`effectRuntime()` from `@platform/processRuntime` owns every fiber these four files run; there is no second runtime and no `Context.empty()` fork. `awaitStatusChange` in `ExecutionsTool` owns the wait choreography (deadline, follow-up break, settled re-check) for both wait paths. `pollRound` in `PollingSourceBase` owns the round's fan-out bound, failure aggregation, and post-poll hook, and `tick` owns the in-flight guard. `settleReservation` in `AgentCliSessionRegistry` owns settling a reservation from all three settle sites. `walkLevel` owns one level of the memory walk and the per-walk `Semaphore` owns the cross-level metadata bound. `DURABLE_READ_CONCURRENCY` names the executions fan-out bound once instead of two literal 16s.

## Duplication and abstraction budget

Removed: two copies of the same wait choreography (already shared through `waitWithTimeout`, now shared through one Effect program with no controller); the duplicated literal fan-out bound in `ExecutionsTool`; the p-map, p-queue, and p-defer idioms in favor of the runtime the rest of the migration uses. Added: five module-private tagged error classes, each owning one boundary meaning from R7's catch-site table (filesystem or store boundary, hook rejection, detached write failure); `settleReservation`, a three-caller helper; `persistSessionMapping`, the named detached program that records ownership of the registry's only fire-and-forget write (R5). No pass-through layers: `waitWithTimeout` and `runAfterTick` were deleted rather than wrapped.

## Net elements (R6)

Files: 7 changed, 0 added, 0 deleted (5 production, 2 tests). Exported symbols: 0 added, 0 removed; `^[+-]export` over the diff shows only the `listenForFollowUp` parameter change and `walkMemoryDirectory` becoming an `async function*` with the same declared return type. Classes: +5 module-private `Data.TaggedError` subclasses, 0 removed; interfaces and enums unchanged. Private methods deleted: `waitWithTimeout`, `runAfterTick`, the `walkDir` generator. Net LoC: +198 total, +195 production (+409/-214).

## Consumer counts (R8)

No emit path is deleted or re-routed. `listenForFollowUp`, whose parameter type changed, has 1 production consumer (`src/tools/ExecutionsTool.ts`) and 1 test consumer (`src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts`), both updated in this PR. The `AppSignals` bus and `SessionHandle.publish` are untouched.

## Host impact

Extension: no user-visible change. The executions tool, GitHub polling sources, memory tool, and agent-CLI registry are host-neutral `src/tools/` code; wait, list, poll, and walk behavior is preserved, including the Error instances surfaced on filesystem and store failures.

Desktop: same as extension; no host wiring changed.

CLI: same behavior, and the one host-specific consideration is why the `setInterval` adapter stays: `packages/cli` consumers of `loadMemoryItems` and the GitHub pollers rely on `timer.unref` so a live poller cannot keep the `texra` process alive. Nothing in this PR changes process liveness.

## Scheduled refactoring

- Retire the `@adapter-until 2026-11-05` marker on `PollingSourceBase.ensureTimer` when Effect gains an unref-capable clock or the hosts decide a live poller may keep the process alive; the interval then becomes a Schedule-driven fiber on the runtime's clock (R8).
- The `@adapter-until` marker on `ensureTimer` becomes CI-enforced once #11920 (the Effect migration ratchet, which scans markers and fails on an expired date) merges; nothing in this lane is needed for that.
- Remove p-map, p-queue, and p-defer from `package.json` once the remaining 49 production importers convert in their own lanes.

## Validation

Run on the review and parity rounds (the second and third commits), on top of the conversion commit's own suite runs: workspace typecheck and test-kernel typecheck; vitest over `src/test-kernel/tools/` plus every suite importing a converted module (106 files, 1664 tests on the final commit); eslint and prettier on touched files; `npm run check:dead-code-ratchet`; `scripts/check-browser-safe-utils.mjs`. No test files were added; `ToolUseFollowUpProgressEvents` asserts the follow-up callback instead of an aborted controller, and `MemoryTool`'s listing test fakes only `Date` because Effect's scheduler needs live `setImmediate` and `setTimeout` to make progress. Parity probes from the review rounds: with a mocked `StorageFS`, a `readDir` ENOENT and a mid-walk `stat` EACCES each reject the `for await` with the same Error instance the filesystem raised; the raceAll versus raceAllFirst probe showed a registry-wait defect surfacing in 2 ms rather than after the full deadline. Not run: the full workspace vitest run and package builds, since the change is confined to `src/tools/` and its importing suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyJjcnpYcFopcGbYdWayxp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyJjcnpYcFopcGbYdWayxp)_