### PR TITLE
refactor(platform): run file locks, JsonStore, per-key lane, and safe parsers on Effect

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,6 @@
     "monaco-editor": "^0.56.0",
     "mutative": "^1.3.0",
     "nanoid": "^6.0.1",
-    "neverthrow": "^8.2.0",
     "nunjucks": "^3.2.4",
     "openai": "^7.10.0",
     "p-defer": "^4.0.1",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -83,7 +83,6 @@
     "lru-cache": "^11.5.2",
     "mime-types": "^3.0.1",
     "nanoid": "^6.0.1",
-    "neverthrow": "^8.2.0",
     "nunjucks": "^3.2.4",
     "openai": "^7.10.0",
     "p-defer": "^4.0.1",

--- a/packages/cli/src/chat/tui/history/inputHistory.ts
+++ b/packages/cli/src/chat/tui/history/inputHistory.ts
@@ -6,6 +6,7 @@
 
 import { z } from 'zod';
 
+import { Result } from 'effect';
 import { parseJsonWith } from '@common/parsing/safeParseJson';
 import { GlobalStorageFS } from '@utils/files/storageFS';
 
@@ -48,8 +49,8 @@ export async function loadInputHistory(): Promise<InputHistory> {
     try {
       const raw = await GlobalStorageFS.read(HISTORY_PATH);
       for (const line of raw.split('\n')) {
-        const rec = parseJsonWith(line, HistoryRecordSchema).unwrapOr(
-          undefined,
+        const rec = Result.getOrUndefined(
+          parseJsonWith(line, HistoryRecordSchema),
         );
         if (rec && rec.v.length > 0) records.push(rec);
       }

--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
 import { z } from 'zod';
 
+import { Result } from 'effect';
 import { isFileNotFoundError } from '@common/errors';
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import { JsonStore } from '@platform/defaults/jsonStore';
@@ -339,13 +340,13 @@ async function readJsonConfigFile(
   }
 
   const parseResult = safeParseJson(raw);
-  if (parseResult.isErr()) {
+  if (Result.isFailure(parseResult)) {
     return {
       status: 'warning',
-      warning: `Could not parse ${filePath}: ${toErrorMessage(parseResult.error)}`,
+      warning: `Could not parse ${filePath}: ${toErrorMessage(parseResult.failure)}`,
     };
   }
-  const parsed = parseResult.value;
+  const parsed = parseResult.success;
   if (!isObject(parsed)) {
     return {
       status: 'warning',

--- a/packages/cli/src/runtime/supabaseAuthCallbackServer.ts
+++ b/packages/cli/src/runtime/supabaseAuthCallbackServer.ts
@@ -10,6 +10,7 @@ import pDefer from 'p-defer';
 import { z } from 'zod';
 
 // Local imports - auth
+import { Result } from 'effect';
 import { AUTH_CALLBACK_TIMEOUT_MS } from '@auth/config';
 import {
   type SupabaseSession,
@@ -224,12 +225,12 @@ function parseCallbackBody(
   rawBody: string,
 ): z.infer<typeof CallbackBodySchema> {
   const parsed = parseJsonWith(rawBody, CallbackBodySchema);
-  if (parsed.isErr()) {
+  if (Result.isFailure(parsed)) {
     throw new RecoverableCallbackRequestError(
       'Authentication callback request was malformed.',
     );
   }
-  return parsed.value;
+  return parsed.success;
 }
 
 function writeHtml(

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { execa } from 'execa';
 import { z } from 'zod';
 
+import { Result } from 'effect';
 import { parseJsonWith } from '@common/parsing/safeParseJson';
 import { createNodeStorageProvider } from '@platform/defaults/nodeStorage';
 import { GlobalStateKey } from '@shared/state/stateKeys';
@@ -175,8 +176,8 @@ function parseHomebrewFormulaVersion(
   formula = CLI_HOMEBREW_FORMULA,
 ): string | undefined {
   const parsed = parseJsonWith(stdout, HomebrewInfoSchema);
-  if (parsed.isErr()) return undefined;
-  const entry = parsed.value.formulae?.find((f) => f?.name === formula);
+  if (Result.isFailure(parsed)) return undefined;
+  const entry = parsed.success.formulae?.find((f) => f?.name === formula);
   return entry?.versions?.stable ?? undefined;
 }
 

--- a/packages/trace-viewer/package.json
+++ b/packages/trace-viewer/package.json
@@ -28,7 +28,6 @@
     "markdown-it-texmath": "^1.0.0",
     "mutative": "^1.3.0",
     "nanoid": "^6.0.1",
-    "neverthrow": "^8.2.0",
     "pathe": "^2.0.3",
     "perfect-debounce": "^2.1.0",
     "pluralize": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,9 +177,6 @@ importers:
       nanoid:
         specifier: ^6.0.1
         version: 6.0.1
-      neverthrow:
-        specifier: ^8.2.0
-        version: 8.2.0
       nunjucks:
         specifier: ^3.2.4
         version: 3.2.4(chokidar@3.6.0)
@@ -520,9 +517,6 @@ importers:
       nanoid:
         specifier: ^6.0.1
         version: 6.0.1
-      neverthrow:
-        specifier: ^8.2.0
-        version: 8.2.0
       nunjucks:
         specifier: ^3.2.4
         version: 3.2.4(chokidar@3.6.0)
@@ -1091,9 +1085,6 @@ importers:
       nanoid:
         specifier: ^6.0.1
         version: 6.0.1
-      neverthrow:
-        specifier: ^8.2.0
-        version: 8.2.0
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
@@ -2630,12 +2621,6 @@ packages:
 
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
-
-  '@rollup/rollup-linux-x64-gnu@4.62.2':
-    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -5345,10 +5330,6 @@ packages:
 
   negotiator@1.1.0:
     resolution: {integrity: sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==}
-    engines: {node: '>=18'}
-
-  neverthrow@8.2.0:
-    resolution: {integrity: sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==}
     engines: {node: '>=18'}
 
   node-abi@3.92.0:
@@ -8345,9 +8326,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/rollup-linux-x64-gnu@4.62.2':
-    optional: true
-
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@secretlint/config-creator@10.2.2':
@@ -11266,10 +11244,6 @@ snapshots:
   negotiator@1.1.0:
     dependencies:
       content-type: 2.1.0
-
-  neverthrow@8.2.0:
-    optionalDependencies:
-      '@rollup/rollup-linux-x64-gnu': 4.62.2
 
   node-abi@3.92.0:
     dependencies:

--- a/src/agent/core/flows/toolCallParsing.ts
+++ b/src/agent/core/flows/toolCallParsing.ts
@@ -1,6 +1,7 @@
 import stableStringify from 'safe-stable-stringify';
 import { z } from 'zod';
 
+import { Result } from 'effect';
 import type { AgentTrace } from '@agent/trace';
 import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
 import { safeParseJson } from '@common/parsing/safeParseJson';
@@ -90,13 +91,13 @@ export function parseToolInput(
   }
 
   const parsed = safeParseJson(raw);
-  if (parsed.isErr()) {
+  if (Result.isFailure(parsed)) {
     logger.debug(
       `Tool call ${callId}: Failed to parse input as JSON, using raw string`,
     );
     return raw;
   }
-  return parsed.value;
+  return parsed.success;
 }
 
 /**

--- a/src/agent/index/agentYamlScanner.ts
+++ b/src/agent/index/agentYamlScanner.ts
@@ -6,6 +6,7 @@ import { glob } from 'glob';
 import pMap from 'p-map';
 import { ZodError, type ZodIssue } from 'zod';
 
+import { Result } from 'effect';
 import { mergeInheritedAgentObject } from '@agent/core/definition/agentDefinitionInheritance';
 import {
   AgentDefinitionSchema,
@@ -135,17 +136,17 @@ async function readYamlDefinition(
   try {
     const content = await AbsoluteFS.read(yamlPath);
     const parsed = parseYamlWith(content, AgentDefinitionSchema);
-    if (parsed.isErr()) {
-      const message = formatScanFailure(parsed.error);
+    if (Result.isFailure(parsed)) {
+      const message = formatScanFailure(parsed.failure);
       log.warn(`Failed to scan ${yamlPath}: ${message}`);
       return { ok: false, issue: { path: displayPath, message } };
     }
     return {
       ok: true,
       value: {
-        name: parsed.value.name,
+        name: parsed.success.name,
         path: yamlPath,
-        definition: parsed.value,
+        definition: parsed.success,
       },
     };
   } catch (err) {

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -3,6 +3,7 @@
  * Encapsulates the streaming event handling logic for improved testability and readability.
  */
 // Third-party imports
+import { Result } from 'effect';
 import {
   logWebFetch,
   logWebSearch,
@@ -429,8 +430,8 @@ export class AnthropicStreamHandler {
     this.state.pendingServerTools.delete(toolUseId);
     if (!input) return '';
     const parsed = safeParseJson(input);
-    if (parsed.isOk())
-      return (parsed.value as Record<string, string>)[field] ?? '';
+    if (Result.isSuccess(parsed))
+      return (parsed.success as Record<string, string>)[field] ?? '';
     const match = input.match(new RegExp(`"${field}"\\s*:\\s*"([^"]+)"`));
     return match?.[1] ?? '';
   }

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -2,6 +2,7 @@
  * Config-loading half of the remote-agent client. The listing half — which the
  * agent index does reach — lives in `./remoteAgentList`.
  */
+import { Result } from 'effect';
 import {
   type AgentSettingInput,
   AgentPromptSchema,
@@ -46,13 +47,13 @@ export async function loadRemoteAgent(
 
     log.debug(`Parsing YAML for remote agent: ${agentName}`);
     const parsedYaml = parseYamlWith(configYaml, AgentDefinitionSchema);
-    if (parsedYaml.isErr()) {
+    if (Result.isFailure(parsedYaml)) {
       throw new Error(
-        `Failed to parse YAML for remote agent "${agentName}": ${parsedYaml.error.message}`,
-        { cause: parsedYaml.error },
+        `Failed to parse YAML for remote agent "${agentName}": ${parsedYaml.failure.message}`,
+        { cause: parsedYaml.failure },
       );
     }
-    const validated = parsedYaml.value;
+    const validated = parsedYaml.success;
 
     const settings: AgentSettingInput = validated.settings;
     const toolNames = extractToolNames(settings.tools);

--- a/src/agent/remote/remoteAgentList.ts
+++ b/src/agent/remote/remoteAgentList.ts
@@ -14,6 +14,7 @@
 import ky, { HTTPError } from 'ky';
 import { z } from 'zod';
 
+import { Result } from 'effect';
 import { SUPABASE_CONFIG } from '@auth/config';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { parseJsonWith } from '@common/parsing/safeParseJson';
@@ -120,9 +121,10 @@ async function fetchRemoteAgentListRows(
 
     const rawBody = errorDataToString(error.data);
     const parsedError = rawBody
-      ? parseJsonWith(rawBody, RemoteAgentListQueryErrorSchema).unwrapOr({
-          message: rawBody,
-        })
+      ? Result.getOrElse(
+          parseJsonWith(rawBody, RemoteAgentListQueryErrorSchema),
+          () => ({ message: rawBody }),
+        )
       : {};
     const fallbackMessage =
       `${error.response.status} ${error.response.statusText}`.trim();

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 
+import { Result } from 'effect';
 import { resolveAgent } from '@agent/index';
 import type { ResolvedAgent } from '@agent/index/agentEntry';
 import {
@@ -29,12 +30,12 @@ const CHANNEL = 'agentLoad';
  */
 export function validateAgentYamlContent(content: string): void {
   const parsed = parseYamlWith(content, AgentDefinitionSchema);
-  if (parsed.isErr()) {
-    throw new Error(`Failed to parse agent YAML: ${parsed.error.message}`, {
-      cause: parsed.error,
+  if (Result.isFailure(parsed)) {
+    throw new Error(`Failed to parse agent YAML: ${parsed.failure.message}`, {
+      cause: parsed.failure,
     });
   }
-  const data = parsed.value;
+  const data = parsed.success;
 
   if (!data.inherits) {
     AgentSettingSchema.parse(
@@ -52,13 +53,13 @@ async function loadYaml(absolutePath: string): Promise<object> {
 
   const yamlContent = await AbsoluteFS.read(absolutePath);
   const parsed = safeParseYaml(yamlContent);
-  if (parsed.isErr()) {
+  if (Result.isFailure(parsed)) {
     throw new Error(
-      `Failed to parse YAML at ${absolutePath}: ${parsed.error.message}`,
-      { cause: parsed.error },
+      `Failed to parse YAML at ${absolutePath}: ${parsed.failure.message}`,
+      { cause: parsed.failure },
     );
   }
-  return parsed.value as object;
+  return parsed.success as object;
 }
 
 export async function loadAgentSettingAndPrompts(

--- a/src/agent/runtime/bundledPrompts.ts
+++ b/src/agent/runtime/bundledPrompts.ts
@@ -28,6 +28,7 @@ import { join } from 'node:path';
 import { z } from 'zod';
 
 // Local imports
+import { Result } from 'effect';
 import { parseYamlWith } from '@common/parsing/safeParseYaml';
 import { createLog } from '@logger/logUtils';
 import { createTexraNunjucksEnvironment } from '@utils/prompt';
@@ -114,13 +115,13 @@ async function readPromptYaml<T>(
 ): Promise<T> {
   const content = await AbsoluteFS.read(filePath);
   const parsed = parseYamlWith(content, schema);
-  if (parsed.isErr()) {
+  if (Result.isFailure(parsed)) {
     throw new Error(
-      `Failed to parse ${name} prompt YAML at ${filePath}: ${parsed.error.message}`,
-      { cause: parsed.error },
+      `Failed to parse ${name} prompt YAML at ${filePath}: ${parsed.failure.message}`,
+      { cause: parsed.failure },
     );
   }
-  return parsed.value;
+  return parsed.success;
 }
 
 /** Required: no inline copy exists, so an unavailable bundle fails the call. */

--- a/src/auth/oauth/SubscriptionOAuthCoordinator.ts
+++ b/src/auth/oauth/SubscriptionOAuthCoordinator.ts
@@ -10,6 +10,7 @@
 import PQueue from 'p-queue';
 
 // Local imports
+import { Result } from 'effect';
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import { createLog } from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -143,14 +144,14 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
     const raw = await this.storage.get();
     if (!raw) return null;
     const parsedJson = safeParseJson(raw);
-    if (parsedJson.isErr()) {
+    if (Result.isFailure(parsedJson)) {
       // Present-but-corrupt is not the same as never signed in.
       log.warn(
-        `Stored subscription session is not valid JSON; treating as signed out: ${toErrorMessage(parsedJson.error)}`,
+        `Stored subscription session is not valid JSON; treating as signed out: ${toErrorMessage(parsedJson.failure)}`,
       );
       return null;
     }
-    const parsed = this.policy.sessionSchema.safeParse(parsedJson.value);
+    const parsed = this.policy.sessionSchema.safeParse(parsedJson.success);
     if (!parsed.success) {
       log.warn(
         `Stored subscription session failed schema validation; treating as signed out: ${toErrorMessage(parsed.error)}`,

--- a/src/auth/supabaseSessionTypes.ts
+++ b/src/auth/supabaseSessionTypes.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { Result } from 'effect';
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -84,14 +85,14 @@ export function parseStoredSupabaseSession(
   if (!sessionData) return null;
   const logSource = options?.logSource ?? 'SupabaseSession';
   const parsedJson = safeParseJson(sessionData);
-  if (parsedJson.isErr()) {
+  if (Result.isFailure(parsedJson)) {
     options?.warn?.(
       logSource,
-      `Failed to parse stored session: ${toErrorMessage(parsedJson.error)}`,
+      `Failed to parse stored session: ${toErrorMessage(parsedJson.failure)}`,
     );
     return null;
   }
-  const parsed = SupabaseSessionSchema.safeParse(parsedJson.value);
+  const parsed = SupabaseSessionSchema.safeParse(parsedJson.success);
   if (!parsed.success) {
     options?.warn?.(
       logSource,

--- a/src/common/errors/sdkError/errorInspection.ts
+++ b/src/common/errors/sdkError/errorInspection.ts
@@ -1,4 +1,5 @@
 import { getReasonPhrase, StatusCodes } from 'http-status-codes';
+import { Result } from 'effect';
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import { isNonEmptyString, isObject, isString } from '@utils/core';
 
@@ -278,7 +279,7 @@ export function detectRawErrorBody(err: unknown): unknown {
 
   // Google GenAI SDK may embed JSON in the error message
   if (isString(candidate.message) && candidate.message.startsWith('{')) {
-    return safeParseJson(candidate.message).unwrapOr(undefined);
+    return Result.getOrUndefined(safeParseJson(candidate.message));
   }
 
   return undefined;

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -2,6 +2,7 @@ import stableStringify from 'safe-stable-stringify';
 import { StatusCodes } from 'http-status-codes';
 import prettyMilliseconds from 'pretty-ms';
 
+import { Result } from 'effect';
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import {
   type QuotaFallbackExhaustionReason,
@@ -187,9 +188,9 @@ function describeHttpError(
         const start = extractedMessage.indexOf(opening);
         const end = extractedMessage.lastIndexOf(closing);
         if (start >= 0 && end > start) {
-          const embeddedBody = safeParseJson(
-            extractedMessage.slice(start, end + 1),
-          ).unwrapOr(undefined);
+          const embeddedBody = Result.getOrUndefined(
+            safeParseJson(extractedMessage.slice(start, end + 1)),
+          );
           try {
             wrapperMessageContainsRawBody =
               stableStringify(embeddedBody) === stableStringify(rawErrorBody);

--- a/src/common/parsing/safeParseJson.ts
+++ b/src/common/parsing/safeParseJson.ts
@@ -1,29 +1,31 @@
+import { Result } from 'effect';
 import { type ZodType } from 'zod';
-import { type Result, ok, err } from 'neverthrow';
 
 import { ensureError } from '@utils/errors/errorMessage';
 
 /**
  * Parse JSON text without throwing.
  *
- * Returns an `Ok<unknown>` with the parsed value typed as `unknown` (the
- * honest type for untrusted text), or an `Err<Error>` carrying the
- * `SyntaxError` raised by `JSON.parse`. Use this instead of a bare
- * `JSON.parse(...)` wrapped in try/catch. Branch with `result.isOk()` /
- * `result.isErr()`, or chain with `.map` / `.andThen` / `.match`.
+ * Returns a `Result.Success<unknown>` with the parsed value typed as
+ * `unknown` (the honest type for untrusted text), or a `Result.Failure<Error>`
+ * carrying the `SyntaxError` raised by `JSON.parse`. Use this instead of a
+ * bare `JSON.parse(...)` wrapped in try/catch. Branch with
+ * `Result.isSuccess` / `Result.isFailure`, or chain with `Result.map` /
+ * `Result.flatMap` / `Result.getOrElse`.
  */
-export function safeParseJson(text: string): Result<unknown, Error> {
+export function safeParseJson(text: string): Result.Result<unknown, Error> {
   try {
-    return ok(JSON.parse(text) as unknown);
+    return Result.succeed(JSON.parse(text) as unknown);
   } catch (error) {
-    return err(ensureError(error));
+    return Result.fail(ensureError(error));
   }
 }
 
 /**
  * Parse JSON text and validate the result against a Zod schema, without
- * throwing. A parse failure or a schema mismatch both yield an `Err<Error>`;
- * on success the `Ok` value is the validated, typed result.
+ * throwing. A parse failure or a schema mismatch both yield a
+ * `Result.Failure<Error>`; on success the `Result.Success` value is the
+ * validated, typed result.
  *
  * Prefer this over `JSON.parse(text) as T` whenever the text comes from an
  * untrusted source (disk, network, IPC): the cast lies if the bytes don't
@@ -32,9 +34,11 @@ export function safeParseJson(text: string): Result<unknown, Error> {
 export function parseJsonWith<T>(
   text: string,
   schema: ZodType<T>,
-): Result<T, Error> {
-  return safeParseJson(text).andThen((value) => {
+): Result.Result<T, Error> {
+  return Result.flatMap(safeParseJson(text), (value) => {
     const result = schema.safeParse(value);
-    return result.success ? ok(result.data) : err(result.error);
+    return result.success
+      ? Result.succeed(result.data)
+      : Result.fail(result.error);
   });
 }

--- a/src/common/parsing/safeParseJson.ts
+++ b/src/common/parsing/safeParseJson.ts
@@ -14,11 +14,10 @@ import { ensureError } from '@utils/errors/errorMessage';
  * `Result.flatMap` / `Result.getOrElse`.
  */
 export function safeParseJson(text: string): Result.Result<unknown, Error> {
-  try {
-    return Result.succeed(JSON.parse(text) as unknown);
-  } catch (error) {
-    return Result.fail(ensureError(error));
-  }
+  return Result.try({
+    try: () => JSON.parse(text) as unknown,
+    catch: ensureError,
+  });
 }
 
 /**

--- a/src/common/parsing/safeParseYaml.ts
+++ b/src/common/parsing/safeParseYaml.ts
@@ -15,11 +15,10 @@ import { ensureError } from '@utils/errors/errorMessage';
  * `Result.getOrElse`.
  */
 export function safeParseYaml(text: string): Result.Result<unknown, Error> {
-  try {
-    return Result.succeed(yaml.parse(text) as unknown);
-  } catch (error) {
-    return Result.fail(ensureError(error));
-  }
+  return Result.try({
+    try: () => yaml.parse(text) as unknown,
+    catch: ensureError,
+  });
 }
 
 /**

--- a/src/common/parsing/safeParseYaml.ts
+++ b/src/common/parsing/safeParseYaml.ts
@@ -1,30 +1,32 @@
-import { type ZodType } from 'zod';
-import { type Result, ok, err } from 'neverthrow';
+import { Result } from 'effect';
 import * as yaml from 'yaml';
+import { type ZodType } from 'zod';
 
 import { ensureError } from '@utils/errors/errorMessage';
 
 /**
  * Parse YAML text without throwing.
  *
- * Returns an `Ok<unknown>` with the parsed value typed as `unknown` (the
- * honest type for untrusted text), or an `Err<Error>` carrying the parse
- * error raised by `yaml.parse`. Use this instead of a bare `yaml.parse(...)`
- * wrapped in try/catch. Branch with `result.isOk()` / `result.isErr()`, or
- * chain with `.map` / `.andThen` / `.match`.
+ * Returns a `Result.Success<unknown>` with the parsed value typed as
+ * `unknown` (the honest type for untrusted text), or a `Result.Failure<Error>`
+ * carrying the parse error raised by `yaml.parse`. Use this instead of a bare
+ * `yaml.parse(...)` wrapped in try/catch. Branch with `Result.isSuccess` /
+ * `Result.isFailure`, or chain with `Result.map` / `Result.flatMap` /
+ * `Result.getOrElse`.
  */
-export function safeParseYaml(text: string): Result<unknown, Error> {
+export function safeParseYaml(text: string): Result.Result<unknown, Error> {
   try {
-    return ok(yaml.parse(text) as unknown);
+    return Result.succeed(yaml.parse(text) as unknown);
   } catch (error) {
-    return err(ensureError(error));
+    return Result.fail(ensureError(error));
   }
 }
 
 /**
  * Parse YAML text and validate the result against a Zod schema, without
- * throwing. A parse failure or a schema mismatch both yield an `Err<Error>`;
- * on success the `Ok` value is the validated, typed result.
+ * throwing. A parse failure or a schema mismatch both yield a
+ * `Result.Failure<Error>`; on success the `Result.Success` value is the
+ * validated, typed result.
  *
  * Prefer this over `yaml.parse(text) as T` / `Schema.parse(yaml.parse(text))`
  * whenever the text comes from an untrusted source (disk, network, remote
@@ -34,9 +36,11 @@ export function safeParseYaml(text: string): Result<unknown, Error> {
 export function parseYamlWith<T>(
   text: string,
   schema: ZodType<T>,
-): Result<T, Error> {
-  return safeParseYaml(text).andThen((value) => {
+): Result.Result<T, Error> {
+  return Result.flatMap(safeParseYaml(text), (value) => {
     const result = schema.safeParse(value);
-    return result.success ? ok(result.data) : err(result.error);
+    return result.success
+      ? Result.succeed(result.data)
+      : Result.fail(result.error);
   });
 }

--- a/src/platform/defaults/fileLocks.ts
+++ b/src/platform/defaults/fileLocks.ts
@@ -30,7 +30,10 @@ export interface FileLockTuning {
 /**
  * `proper-lockfile`'s cross-process lock on `canonicalPath` as a resource:
  * the acquire step creates the lock's directory and takes the lock with the
- * caller's tuning; the returned release step gives it back. A compromise
+ * caller's tuning; the returned release step gives it back. Failures keep
+ * their identity — `mkdir`'s `NodeJS.ErrnoException`, `proper-lockfile`'s
+ * `Error` with its `code` (ELOCKED, ECOMPROMISED, …) — because hosts match
+ * on them; the mappers only name the type. A compromise
  * fires from `proper-lockfile`'s renewal timer, outside any fiber, so its
  * callback only records the error; the release step then reports it in place
  * of the ERELEASED cleanup error the release call raises for a lock already
@@ -43,7 +46,7 @@ const acquireLock = Effect.fn('fileLocks.acquireLock')(function* (
 ) {
   yield* Effect.tryPromise({
     try: () => mkdir(path.dirname(canonicalPath), { recursive: true }),
-    catch: (cause) => cause,
+    catch: (cause) => cause as NodeJS.ErrnoException,
   });
   let compromised: Error | undefined;
   const release = yield* Effect.tryPromise({
@@ -57,11 +60,14 @@ const acquireLock = Effect.fn('fileLocks.acquireLock')(function* (
           compromised ??= error;
         },
       }),
-    catch: (cause) => cause,
+    catch: (cause) => cause as Error,
   });
   return Effect.gen(function* () {
     const released = yield* Effect.result(
-      Effect.tryPromise({ try: () => release(), catch: (cause) => cause }),
+      Effect.tryPromise({
+        try: () => release(),
+        catch: (cause) => cause as Error,
+      }),
     );
     if (compromised) return yield* Effect.fail(compromised);
     if (Result.isFailure(released)) return yield* Effect.fail(released.failure);
@@ -75,15 +81,16 @@ const acquireLock = Effect.fn('fileLocks.acquireLock')(function* (
  * the identity the Promise API has always thrown: the lone error itself, or
  * one `AggregateError` naming the path when the operation and the lock both
  * failed. The lock's own errors are `proper-lockfile`'s (`code` ELOCKED,
- * ECOMPROMISED, …), which hosts match on, so nothing wraps them. Defects
- * and interruption pass through untouched.
+ * ECOMPROMISED, …), which hosts match on, so nothing wraps them; they and
+ * the directory's fs error are the `Error` the failure channel adds to
+ * `self`'s own `E`. Defects and interruption pass through untouched.
  */
 export function withFileLock(
   lockPath: string,
   tuning: FileLockTuning,
-): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, unknown, R> {
+): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E | Error, R> {
   const canonicalPath = path.resolve(lockPath);
-  return (self) =>
+  return <A, E, R>(self: Effect.Effect<A, E, R>) =>
     withPerKeyPermit(
       localLocks,
       canonicalPath,
@@ -96,14 +103,17 @@ export function withFileLock(
     ).pipe(
       Effect.catchCause((cause) => {
         const failures = cause.reasons.filter(Cause.isFailReason);
-        return failures.length === cause.reasons.length
-          ? Effect.fail(
-              aggregateError(
-                failures.map((reason) => reason.error),
-                `File lock failed: ${canonicalPath}`,
-              ),
-            )
-          : Effect.failCause(cause);
+        if (failures.length !== cause.reasons.length) {
+          return Effect.failCause(cause);
+        }
+        // `aggregateError` hands a lone failure back as-is and joins several
+        // in an `AggregateError`, so the reduced value stays in `E | Error`.
+        return Effect.fail(
+          aggregateError(
+            failures.map((reason) => reason.error),
+            `File lock failed: ${canonicalPath}`,
+          ) as E | Error,
+        );
       }),
     );
 }
@@ -120,6 +130,16 @@ export function createNodeFileLocks(tuning: FileLockTuning): FileLockProvider {
       lockPath: string,
       operation: () => Promise<T>,
     ): Promise<T> {
+      // Runs on Effect's default runtime, not `effectRuntime()`: hosts hand
+      // `nodeFileLocks` to `createNodePlatform`, and the CLI and desktop
+      // hosts open their `JsonStore`s (which flush through `withFileLock`),
+      // before they call `installProcessRuntime` — see the CLI's
+      // `initPlatform` (`createCliStateStores`, `openTexraConfigStores`, then
+      // `installProcessRuntime`) — so the process runtime may not exist yet.
+      // The site is pinned by the "Effect run boundaries" ratchet in
+      // src/test-kernel/architecture/dependencyDirection.vitest.ts.
+      // `operation` is the caller's own Promise, so its rejection keeps its
+      // identity and its type stays `unknown` at this edge.
       const exit = await Effect.runPromiseExit(
         withFileLock(
           lockPath,

--- a/src/platform/defaults/fileLocks.ts
+++ b/src/platform/defaults/fileLocks.ts
@@ -1,14 +1,19 @@
 import { mkdir } from 'node:fs/promises';
 import * as path from 'node:path';
 
+import { Cause, Effect, Exit, Result } from 'effect';
 import { lock, type LockOptions } from 'proper-lockfile';
 
-import { throwAggregated } from '@utils/core';
-import { KeyedMutex } from '@utils/core/keyedMutex';
+import { aggregateError } from '@utils/core';
+import {
+  type PerKeySemaphore,
+  withPerKeyPermit,
+} from '@utils/core/perKeyQueue';
 
 import type { FileLockProvider } from '../interfaces';
 
-const localLocks = new KeyedMutex<string>();
+/** In-process lane per canonical lock path, shared by every provider. */
+const localLocks = new Map<string, PerKeySemaphore>();
 
 /** Per-caller tuning for {@link createNodeFileLocks}. */
 export interface FileLockTuning {
@@ -23,6 +28,87 @@ export interface FileLockTuning {
 }
 
 /**
+ * `proper-lockfile`'s cross-process lock on `canonicalPath` as a resource:
+ * the acquire step creates the lock's directory and takes the lock with the
+ * caller's tuning; the returned release step gives it back. A compromise
+ * fires from `proper-lockfile`'s renewal timer, outside any fiber, so its
+ * callback only records the error; the release step then reports it in place
+ * of the ERELEASED cleanup error the release call raises for a lock already
+ * marked released internally — that error carries less information than the
+ * compromise itself.
+ */
+const acquireLock = Effect.fn('fileLocks.acquireLock')(function* (
+  canonicalPath: string,
+  tuning: FileLockTuning,
+) {
+  yield* Effect.tryPromise({
+    try: () => mkdir(path.dirname(canonicalPath), { recursive: true }),
+    catch: (cause) => cause,
+  });
+  let compromised: Error | undefined;
+  const release = yield* Effect.tryPromise({
+    try: () =>
+      lock(canonicalPath, {
+        realpath: false,
+        stale: tuning.staleMs,
+        ...(tuning.updateMs === undefined ? {} : { update: tuning.updateMs }),
+        retries: tuning.retries,
+        onCompromised: (error) => {
+          compromised ??= error;
+        },
+      }),
+    catch: (cause) => cause,
+  });
+  return Effect.gen(function* () {
+    const released = yield* Effect.result(
+      Effect.tryPromise({ try: () => release(), catch: (cause) => cause }),
+    );
+    if (compromised) return yield* Effect.fail(compromised);
+    if (Result.isFailure(released)) return yield* Effect.fail(released.failure);
+  });
+});
+
+/**
+ * Hold `lockPath`'s in-process lane and its cross-process lock around
+ * `self`, releasing both on success, failure, and interruption. A failure
+ * of `self`, of the lock, or of both reaches the caller as one value with
+ * the identity the Promise API has always thrown: the lone error itself, or
+ * one `AggregateError` naming the path when the operation and the lock both
+ * failed. The lock's own errors are `proper-lockfile`'s (`code` ELOCKED,
+ * ECOMPROMISED, …), which hosts match on, so nothing wraps them. Defects
+ * and interruption pass through untouched.
+ */
+export function withFileLock(
+  lockPath: string,
+  tuning: FileLockTuning,
+): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, unknown, R> {
+  const canonicalPath = path.resolve(lockPath);
+  return (self) =>
+    withPerKeyPermit(
+      localLocks,
+      canonicalPath,
+    )(
+      Effect.acquireUseRelease(
+        acquireLock(canonicalPath, tuning),
+        () => self,
+        (release) => release,
+      ),
+    ).pipe(
+      Effect.catchCause((cause) => {
+        const failures = cause.reasons.filter(Cause.isFailReason);
+        return failures.length === cause.reasons.length
+          ? Effect.fail(
+              aggregateError(
+                failures.map((reason) => reason.error),
+                `File lock failed: ${canonicalPath}`,
+              ),
+            )
+          : Effect.failCause(cause);
+      }),
+    );
+}
+
+/**
  * Builds native cross-process locks for local shared-storage paths, with a
  * caller-tunable stale/update/retry policy. `proper-lockfile` refreshes the
  * lock mtime at `update` while the operation is still running, so critical
@@ -34,47 +120,19 @@ export function createNodeFileLocks(tuning: FileLockTuning): FileLockProvider {
       lockPath: string,
       operation: () => Promise<T>,
     ): Promise<T> {
-      const canonicalPath = path.resolve(lockPath);
-      return localLocks.runExclusive(canonicalPath, async () => {
-        await mkdir(path.dirname(canonicalPath), { recursive: true });
-        let compromised: Error | undefined;
-        const release = await lock(canonicalPath, {
-          realpath: false,
-          stale: tuning.staleMs,
-          ...(tuning.updateMs === undefined ? {} : { update: tuning.updateMs }),
-          retries: tuning.retries,
-          // proper-lockfile's default callback throws from its renewal timer,
-          // outside runExclusive's promise. Retain the failure and return it at
-          // this operation boundary instead of terminating the Node process.
-          onCompromised: (error) => {
-            compromised ??= error;
-          },
-        });
-
-        let value: T | undefined;
-        let operationFailure: unknown;
-        try {
-          value = await operation();
-        } catch (error) {
-          operationFailure = error;
-        }
-
-        let releaseFailure: unknown;
-        try {
-          await release();
-        } catch (error) {
-          // A compromised lock has already been marked released internally.
-          // Its ERELEASED cleanup error carries less information than the
-          // original compromise and must not replace it.
-          if (!compromised) releaseFailure = error;
-        }
-
-        const failures = [operationFailure, compromised, releaseFailure].filter(
-          (error) => error !== undefined,
-        );
-        throwAggregated(failures, `File lock failed: ${canonicalPath}`);
-        return value as T;
-      });
+      const exit = await Effect.runPromiseExit(
+        withFileLock(
+          lockPath,
+          tuning,
+        )(
+          Effect.tryPromise({
+            try: () => operation(),
+            catch: (cause) => cause,
+          }),
+        ),
+      );
+      if (Exit.isSuccess(exit)) return exit.value;
+      throw Cause.squash(exit.cause);
     },
   };
 }

--- a/src/platform/defaults/fileLocks.ts
+++ b/src/platform/defaults/fileLocks.ts
@@ -5,15 +5,12 @@ import { Cause, Effect, Exit, Result } from 'effect';
 import { lock, type LockOptions } from 'proper-lockfile';
 
 import { aggregateError } from '@utils/core';
-import {
-  type PerKeySemaphore,
-  withPerKeyPermit,
-} from '@utils/core/perKeyQueue';
+import { type PerKeyLane, withPerKeyLane } from '@utils/core/perKeyQueue';
 
 import type { FileLockProvider } from '../interfaces';
 
 /** In-process lane per canonical lock path, shared by every provider. */
-const localLocks = new Map<string, PerKeySemaphore>();
+const localLocks = new Map<string, PerKeyLane>();
 
 /** Per-caller tuning for {@link createNodeFileLocks}. */
 export interface FileLockTuning {
@@ -33,7 +30,9 @@ export interface FileLockTuning {
  * caller's tuning; the returned release step gives it back. Failures keep
  * their identity — `mkdir`'s `NodeJS.ErrnoException`, `proper-lockfile`'s
  * `Error` with its `code` (ELOCKED, ECOMPROMISED, …) — because hosts match
- * on them; the mappers only name the type. A compromise
+ * on them; the mappers only name the type. This is the migration's
+ * foreign-boundary adapter case (PRD R7): the lock and fs errors are the
+ * caller-facing identities, so no tagged error wraps them. A compromise
  * fires from `proper-lockfile`'s renewal timer, outside any fiber, so its
  * callback only records the error; the release step then reports it in place
  * of the ERELEASED cleanup error the release call raises for a lock already
@@ -91,7 +90,7 @@ export function withFileLock(
 ): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E | Error, R> {
   const canonicalPath = path.resolve(lockPath);
   return <A, E, R>(self: Effect.Effect<A, E, R>) =>
-    withPerKeyPermit(
+    withPerKeyLane(
       localLocks,
       canonicalPath,
     )(

--- a/src/platform/defaults/jsonStore.ts
+++ b/src/platform/defaults/jsonStore.ts
@@ -1,38 +1,34 @@
 import { chmod, mkdir, readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
+import { Cause, Effect, Exit } from 'effect';
 import writeFileAtomic from 'write-file-atomic';
 
 import { isFileNotFoundError } from '@common/errors';
-import { runOnPerKeyQueue } from '@utils/core/perKeyQueue';
-import type PQueue from 'p-queue';
+import {
+  type PerKeySemaphore,
+  withPerKeyPermit,
+} from '@utils/core/perKeyQueue';
 
-import type { FileLockProvider, StateStore } from '../interfaces';
+import type { StateStore } from '../interfaces';
+import type { FileLockTuning } from './fileLocks';
 
 /**
- * Cross-process lock for the read-modify-write flush below. Shares its
- * mechanics (KeyedMutex in-process serialization, onCompromised handling,
- * error aggregation) with `fileLocks.ts`'s other callers, tuned for this
- * store's short, frequent flushes rather than long-running work. Loaded
- * lazily, on first flush, so importing `JsonStore` doesn't pull in
- * `proper-lockfile` before any write actually happens.
+ * Cross-process lock policy for the read-modify-write flush below, tuned
+ * for this store's short, frequent flushes rather than long-running work.
+ * `fileLocks` itself is loaded on the first flush so importing `JsonStore`
+ * doesn't pull in `proper-lockfile` before any write actually happens.
  */
-let jsonStoreFileLocksPromise: Promise<FileLockProvider> | undefined;
-function getJsonStoreFileLocks(): Promise<FileLockProvider> {
-  jsonStoreFileLocksPromise ??= import('./fileLocks.js').then(
-    ({ createNodeFileLocks }) =>
-      createNodeFileLocks({
-        staleMs: 10_000,
-        retries: {
-          retries: 120,
-          factor: 1.2,
-          minTimeout: 10,
-          maxTimeout: 100,
-        },
-      }),
-  );
-  return jsonStoreFileLocksPromise;
-}
+const FLUSH_LOCK_TUNING: FileLockTuning = {
+  staleMs: 10_000,
+  retries: {
+    retries: 120,
+    factor: 1.2,
+    minTimeout: 10,
+    maxTimeout: 100,
+  },
+};
+const fileLocks = Effect.promise(() => import('./fileLocks.js'));
 
 type JsonRecord = Record<string, unknown>;
 
@@ -56,29 +52,100 @@ function dirModeFor(fileMode: number): number {
   return fileMode | ((fileMode & 0o444) >> 2);
 }
 
-async function readJsonRecord(
+/**
+ * Read the store file as a JSON object. A missing file reads as a copy of
+ * `missingFallback`; unreadable or non-object content fails with the
+ * original error (`SyntaxError`, `TypeError`, or the fs error).
+ */
+const readJsonRecord = Effect.fn('JsonStore.readJsonRecord')(function* (
   filePath: string,
   missingFallback: JsonRecord = {},
-): Promise<JsonRecord> {
-  try {
-    const content = await readFile(filePath, 'utf8');
-    const parsed: unknown = JSON.parse(content);
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed as JsonRecord;
-    }
-    throw new TypeError(`Expected ${filePath} to contain a JSON object.`);
-  } catch (error) {
-    if (isFileNotFoundError(error)) return { ...missingFallback };
-    throw error;
+) {
+  const content = yield* Effect.tryPromise({
+    try: () => readFile(filePath, 'utf8'),
+    catch: (cause) => cause,
+  }).pipe(Effect.catchIf(isFileNotFoundError, () => Effect.succeed(undefined)));
+  if (content === undefined) return { ...missingFallback };
+  const parsed = yield* Effect.try({
+    try: () => JSON.parse(content) as unknown,
+    catch: (cause) => cause,
+  });
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    return parsed as JsonRecord;
   }
-}
+  return yield* Effect.fail(
+    new TypeError(`Expected ${filePath} to contain a JSON object.`),
+  );
+});
 
 /**
- * One-at-a-time flush queue per resolved store path. Module-wide (not per
+ * Creates `dir` if missing. When `fileMode` is set, also chmods the
+ * directory to {@link dirModeFor} — `mkdir`'s own `mode` only applies at
+ * creation time, so a pre-existing directory with looser permissions needs
+ * the explicit follow-up chmod too.
+ */
+const ensureDir = Effect.fn('JsonStore.ensureDir')(function* (
+  dir: string,
+  fileMode: number | undefined,
+) {
+  const dirMode = fileMode === undefined ? undefined : dirModeFor(fileMode);
+  yield* Effect.tryPromise({
+    try: () => mkdir(dir, { recursive: true, mode: dirMode }),
+    catch: (cause) => cause,
+  });
+  if (dirMode !== undefined) {
+    yield* Effect.tryPromise({
+      try: () => chmod(dir, dirMode),
+      catch: (cause) => cause,
+    });
+  }
+});
+
+/**
+ * One-at-a-time flush lane per resolved store path. Module-wide (not per
  * instance) so writers holding separate `JsonStore` instances on the same
  * file preserve call order before entering the cross-process lock.
  */
-const writeQueues = new Map<string, PQueue>();
+const writeLanes = new Map<string, PerKeySemaphore>();
+
+/**
+ * Persist one mutation as a read-modify-write under the file's cross-process
+ * lock: prepare the directory, re-read the file (falling back to
+ * `missingFallback` when it is gone), apply the mutation, and write the
+ * result atomically.
+ */
+const flush = Effect.fn('JsonStore.flush')(function* (
+  filePath: string,
+  mode: number | undefined,
+  key: string,
+  value: unknown,
+  missingFallback: JsonRecord,
+) {
+  yield* ensureDir(dirname(filePath), mode);
+  const { withFileLock } = yield* fileLocks;
+  yield* withFileLock(
+    filePath,
+    FLUSH_LOCK_TUNING,
+  )(
+    Effect.gen(function* () {
+      const record = yield* readJsonRecord(filePath, missingFallback);
+      if (value === undefined) {
+        delete record[key];
+      } else {
+        record[key] = value;
+      }
+      yield* Effect.tryPromise({
+        try: () =>
+          writeFileAtomic(
+            filePath,
+            `${JSON.stringify(record, null, 2)}\n`,
+            mode === undefined ? undefined : { mode },
+          ),
+        catch: (cause) => cause,
+      });
+    }),
+  );
+});
 
 /**
  * File-backed key-value store, persisted as a flat JSON object.
@@ -94,7 +161,7 @@ const writeQueues = new Map<string, PQueue>();
  * operation (e.g. a network fetch) can't clobber keys a concurrent writer —
  * another process, or another instance on the same file — persisted in the
  * meantime. Flushes for a given file path are serialized through
- * {@link writeQueues} for in-process ordering, then guarded by a filesystem
+ * {@link writeLanes} for in-process ordering, then guarded by a filesystem
  * lock for cross-process exclusion. Reads (`get`, `has`, `snapshot`, `keys`)
  * still serve this instance's view: open-time contents plus its own
  * mutations; they don't observe other writers' changes.
@@ -117,7 +184,9 @@ export class JsonStore implements StateStore {
     options: JsonStoreOptions = {},
   ): Promise<JsonStore> {
     const storePath = resolve(filePath);
-    return new JsonStore(storePath, await readJsonRecord(storePath), options);
+    const exit = await Effect.runPromiseExit(readJsonRecord(storePath));
+    if (Exit.isFailure(exit)) throw Cause.squash(exit.cause);
+    return new JsonStore(storePath, exit.value, options);
   }
 
   get<T>(key: string, defaultValue?: T): T {
@@ -129,13 +198,26 @@ export class JsonStore implements StateStore {
     return Object.hasOwn(this.data, key);
   }
 
+  /**
+   * Apply the mutation in memory, then flush it on the file's lane in
+   * {@link writeLanes}. The lane is claimed synchronously, before any
+   * await, so flushes run in `set()` call order rather than racing on
+   * `mkdir`/read/`write-file-atomic` timing; a failed flush doesn't stop
+   * the lane from running subsequent flushes.
+   */
   async set(key: string, value: unknown): Promise<void> {
     if (value === undefined) {
       delete this.data[key];
     } else {
       this.data[key] = value;
     }
-    await this.enqueueFlush(key, value, this.snapshot());
+    const exit = await Effect.runPromiseExit(
+      withPerKeyPermit(
+        writeLanes,
+        this.filePath,
+      )(flush(this.filePath, this.options.mode, key, value, this.snapshot())),
+    );
+    if (Exit.isFailure(exit)) throw Cause.squash(exit.cause);
   }
 
   /** {@link StateStore} conformance; same persistence semantics as `set`. */
@@ -150,60 +232,4 @@ export class JsonStore implements StateStore {
   keys(): string[] {
     return Object.keys(this.data);
   }
-
-  /**
-   * Add the flush to the file's entry in {@link writeQueues} so flushes run
-   * in `set()` call order. The task is enqueued synchronously, before any
-   * await, so order is captured at call time rather than racing on
-   * `mkdir`/read/`write-file-atomic` timing. A failed flush doesn't stop the
-   * queue from running subsequent flushes.
-   */
-  private enqueueFlush(
-    key: string,
-    value: unknown,
-    missingFallback: JsonRecord,
-  ): Promise<void> {
-    return runOnPerKeyQueue(writeQueues, this.filePath, () =>
-      this.flush(key, value, missingFallback),
-    );
-  }
-
-  private async flush(
-    key: string,
-    value: unknown,
-    missingFallback: JsonRecord,
-  ): Promise<void> {
-    await ensureDir(dirname(this.filePath), this.options.mode);
-    const fileLocks = await getJsonStoreFileLocks();
-    await fileLocks.runExclusive(this.filePath, async () => {
-      const record = await readJsonRecord(this.filePath, missingFallback);
-      if (value === undefined) {
-        delete record[key];
-      } else {
-        record[key] = value;
-      }
-      await writeFileAtomic(
-        this.filePath,
-        `${JSON.stringify(record, null, 2)}\n`,
-        this.options.mode === undefined
-          ? undefined
-          : { mode: this.options.mode },
-      );
-    });
-  }
-}
-
-/**
- * Creates `dir` if missing. When `fileMode` is set, also chmods the
- * directory to {@link dirModeFor} — `mkdir`'s own `mode` only applies at
- * creation time, so a pre-existing directory with looser permissions needs
- * the explicit follow-up chmod too.
- */
-async function ensureDir(
-  dir: string,
-  fileMode: number | undefined,
-): Promise<void> {
-  const dirMode = fileMode === undefined ? undefined : dirModeFor(fileMode);
-  await mkdir(dir, { recursive: true, mode: dirMode });
-  if (dirMode !== undefined) await chmod(dir, dirMode);
 }

--- a/src/platform/defaults/jsonStore.ts
+++ b/src/platform/defaults/jsonStore.ts
@@ -55,7 +55,8 @@ function dirModeFor(fileMode: number): number {
 /**
  * Read the store file as a JSON object. A missing file reads as a copy of
  * `missingFallback`; unreadable or non-object content fails with the
- * original error (`SyntaxError`, `TypeError`, or the fs error).
+ * original error (`SyntaxError`, `TypeError`, or the fs error). The mappers
+ * only name those types: `JsonStore.open` rethrows the same instances.
  */
 const readJsonRecord = Effect.fn('JsonStore.readJsonRecord')(function* (
   filePath: string,
@@ -63,12 +64,12 @@ const readJsonRecord = Effect.fn('JsonStore.readJsonRecord')(function* (
 ) {
   const content = yield* Effect.tryPromise({
     try: () => readFile(filePath, 'utf8'),
-    catch: (cause) => cause,
+    catch: (cause) => cause as NodeJS.ErrnoException,
   }).pipe(Effect.catchIf(isFileNotFoundError, () => Effect.succeed(undefined)));
   if (content === undefined) return { ...missingFallback };
   const parsed = yield* Effect.try({
     try: () => JSON.parse(content) as unknown,
-    catch: (cause) => cause,
+    catch: (cause) => cause as SyntaxError,
   });
   if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
     return parsed as JsonRecord;
@@ -91,12 +92,12 @@ const ensureDir = Effect.fn('JsonStore.ensureDir')(function* (
   const dirMode = fileMode === undefined ? undefined : dirModeFor(fileMode);
   yield* Effect.tryPromise({
     try: () => mkdir(dir, { recursive: true, mode: dirMode }),
-    catch: (cause) => cause,
+    catch: (cause) => cause as NodeJS.ErrnoException,
   });
   if (dirMode !== undefined) {
     yield* Effect.tryPromise({
       try: () => chmod(dir, dirMode),
-      catch: (cause) => cause,
+      catch: (cause) => cause as NodeJS.ErrnoException,
     });
   }
 });
@@ -141,7 +142,7 @@ const flush = Effect.fn('JsonStore.flush')(function* (
             `${JSON.stringify(record, null, 2)}\n`,
             mode === undefined ? undefined : { mode },
           ),
-        catch: (cause) => cause,
+        catch: (cause) => cause as NodeJS.ErrnoException,
       });
     }),
   );
@@ -184,6 +185,12 @@ export class JsonStore implements StateStore {
     options: JsonStoreOptions = {},
   ): Promise<JsonStore> {
     const storePath = resolve(filePath);
+    // Runs on Effect's default runtime, not `effectRuntime()`: the CLI and
+    // desktop hosts open their stores before `installProcessRuntime` — the
+    // CLI's `initPlatform` calls `createCliStateStores` and
+    // `openTexraConfigStores` first — so the process runtime does not exist
+    // yet. Pinned by the "Effect run boundaries" ratchet in
+    // src/test-kernel/architecture/dependencyDirection.vitest.ts.
     const exit = await Effect.runPromiseExit(readJsonRecord(storePath));
     if (Exit.isFailure(exit)) throw Cause.squash(exit.cause);
     return new JsonStore(storePath, exit.value, options);
@@ -211,6 +218,11 @@ export class JsonStore implements StateStore {
     } else {
       this.data[key] = value;
     }
+    // Default runtime for the same reason as `open`: a store opened during
+    // host bootstrap is written through this same entry, and this module
+    // sits below the runtime install, so no entry here may assume
+    // `installProcessRuntime` has run. Pinned by the same "Effect run
+    // boundaries" ratchet.
     const exit = await Effect.runPromiseExit(
       withPerKeyPermit(
         writeLanes,

--- a/src/platform/defaults/jsonStore.ts
+++ b/src/platform/defaults/jsonStore.ts
@@ -5,10 +5,7 @@ import { Cause, Effect, Exit } from 'effect';
 import writeFileAtomic from 'write-file-atomic';
 
 import { isFileNotFoundError } from '@common/errors';
-import {
-  type PerKeySemaphore,
-  withPerKeyPermit,
-} from '@utils/core/perKeyQueue';
+import { type PerKeyLane, withPerKeyLane } from '@utils/core/perKeyQueue';
 
 import type { StateStore } from '../interfaces';
 import type { FileLockTuning } from './fileLocks';
@@ -56,7 +53,8 @@ function dirModeFor(fileMode: number): number {
  * Read the store file as a JSON object. A missing file reads as a copy of
  * `missingFallback`; unreadable or non-object content fails with the
  * original error (`SyntaxError`, `TypeError`, or the fs error). The mappers
- * only name those types: `JsonStore.open` rethrows the same instances.
+ * only name those types — the foreign-boundary adapter case of PRD R7, kept
+ * untagged because `JsonStore.open` rethrows the same instances.
  */
 const readJsonRecord = Effect.fn('JsonStore.readJsonRecord')(function* (
   filePath: string,
@@ -107,7 +105,7 @@ const ensureDir = Effect.fn('JsonStore.ensureDir')(function* (
  * instance) so writers holding separate `JsonStore` instances on the same
  * file preserve call order before entering the cross-process lock.
  */
-const writeLanes = new Map<string, PerKeySemaphore>();
+const writeLanes = new Map<string, PerKeyLane>();
 
 /**
  * Persist one mutation as a read-modify-write under the file's cross-process
@@ -224,7 +222,7 @@ export class JsonStore implements StateStore {
     // `installProcessRuntime` has run. Pinned by the same "Effect run
     // boundaries" ratchet.
     const exit = await Effect.runPromiseExit(
-      withPerKeyPermit(
+      withPerKeyLane(
         writeLanes,
         this.filePath,
       )(flush(this.filePath, this.options.mode, key, value, this.snapshot())),

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -12,6 +12,7 @@
 // CLI can consume it.
 
 import escapeRegExp from 'escape-string-regexp';
+import { Result } from 'effect';
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import {
   DELIVERY_TAG,
@@ -199,9 +200,9 @@ export function parseWorkflowScriptDeliverySummary(
   const rawSummary = innerTag(xml, 'workflow-summary');
   if (!rawSummary) return undefined;
   const parsedJson = safeParseJson(decodeXmlEntities(rawSummary));
-  if (parsedJson.isErr()) return undefined;
+  if (Result.isFailure(parsedJson)) return undefined;
   const parsed = WorkflowScriptDeliverySummarySchema.safeParse(
-    parsedJson.value,
+    parsedJson.success,
   );
   return parsed.success ? parsed.data : undefined;
 }

--- a/src/skills/frontmatter.ts
+++ b/src/skills/frontmatter.ts
@@ -1,4 +1,5 @@
 // Local imports - utilities
+import { Result } from 'effect';
 import { safeParseYaml } from '@common/parsing/safeParseYaml';
 import { normalizeLineEndings } from '@utils/text/stringUtils';
 
@@ -51,15 +52,15 @@ export function extractFrontmatter(content: string): ExtractedFrontmatter {
   }
 
   const parsed = safeParseYaml(frontmatterText);
-  if (parsed.isErr()) {
+  if (Result.isFailure(parsed)) {
     throw new SkillFrontmatterError(
-      `Invalid SKILL.md frontmatter: ${parsed.error.message}`,
-      { cause: parsed.error },
+      `Invalid SKILL.md frontmatter: ${parsed.failure.message}`,
+      { cause: parsed.failure },
     );
   }
 
   return {
-    frontmatter: parsed.value,
+    frontmatter: parsed.success,
     body,
   };
 }

--- a/src/test-kernel/architecture/dependencyDirection.vitest.ts
+++ b/src/test-kernel/architecture/dependencyDirection.vitest.ts
@@ -6,6 +6,9 @@ import { dirname, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  ALL_HOST_PRODUCTION_ROOTS,
+  expectRealCoverage,
+  productionFilesUnder,
   REPO_ROOT,
   sourceFilesUnder as sharedSourceFilesUnder,
   stripComments,
@@ -86,6 +89,28 @@ const HOST_LAYER_IMPORT_PREFIXES = [
   '@cli/',
   '@desktop/',
 ] as const;
+
+/**
+ * Effect run boundary (PRD R1, docs/prds/2026-08-26-effect-4-runtime-migration.md
+ * "Execution strategy" rule 3): production code enters Effect through the
+ * host-owned runtime, `effectRuntime()` from `@platform/processRuntime`. A
+ * bare `Effect.run*` call is allowed only where the program must run before
+ * `installProcessRuntime` — today the platform stores every host opens in its
+ * `initPlatform` (`JsonStore`) and the file-lock provider those stores flush
+ * through. The pins are exact counts: a new site anywhere fails, and a removed
+ * site is recorded by lowering (then deleting) its pin.
+ */
+const EFFECT_RUN_ROOTS = [
+  ...ALL_HOST_PRODUCTION_ROOTS,
+  'packages/agent/src',
+  'packages/trace-viewer/src',
+] as const;
+const EFFECT_RUN_CALL =
+  /\bEffect\.run(?:Promise|PromiseExit|Sync|SyncExit|Fork|Callback)(?:With)?\s*\(/g;
+const BARE_EFFECT_RUN_SITES: Readonly<Record<string, number>> = {
+  'src/platform/defaults/fileLocks.ts': 1,
+  'src/platform/defaults/jsonStore.ts': 2,
+};
 
 function sourceFilesUnder(
   zone: string,
@@ -210,5 +235,29 @@ describe('Agent core dependency direction', () => {
       .toSorted();
 
     expect(offenders).toEqual([]);
+  });
+});
+
+describe('Effect run boundaries', () => {
+  it('runs Effect only through effectRuntime() outside the pinned pre-runtime sites', () => {
+    const sites: Record<string, number> = {};
+    for (const root of EFFECT_RUN_ROOTS) {
+      for (const file of productionFilesUnder(root).toSorted()) {
+        const source = stripComments(
+          readFileSync(resolve(REPO_ROOT, file), 'utf8'),
+        );
+        const count = source.match(EFFECT_RUN_CALL)?.length ?? 0;
+        if (count > 0) sites[file] = count;
+      }
+    }
+
+    expect(
+      sites,
+      'bare Effect.run* sites must go through effectRuntime() from @platform/processRuntime; a site that has to run before installProcessRuntime is pinned in BARE_EFFECT_RUN_SITES in this PR, and a removed site lowers its pin',
+    ).toEqual(BARE_EFFECT_RUN_SITES);
+  });
+
+  it('actually scans the Effect run roots', () => {
+    expectRealCoverage(EFFECT_RUN_ROOTS);
   });
 });

--- a/src/test-kernel/common/SafeParseJson.vitest.ts
+++ b/src/test-kernel/common/SafeParseJson.vitest.ts
@@ -3,19 +3,20 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
 // Local imports
+import { Result } from 'effect';
 import { parseJsonWith, safeParseJson } from '@common/parsing/safeParseJson';
 
 describe('safeParseJson', () => {
   it('returns the parsed value for valid JSON', () => {
     const result = safeParseJson('{"a":1,"b":["x"]}');
-    expect(result.isOk()).toBe(true);
-    expect(result._unsafeUnwrap()).toEqual({ a: 1, b: ['x'] });
+    expect(Result.isSuccess(result)).toBe(true);
+    expect(Result.getOrThrow(result)).toEqual({ a: 1, b: ['x'] });
   });
 
   it('returns an error instead of throwing for malformed JSON', () => {
     const result = safeParseJson('{not json');
-    expect(result.isErr()).toBe(true);
-    expect(result._unsafeUnwrapErr()).toBeInstanceOf(Error);
+    expect(Result.isFailure(result)).toBe(true);
+    expect(Result.merge(result)).toBeInstanceOf(Error);
   });
 });
 
@@ -27,18 +28,18 @@ describe('parseJsonWith', () => {
 
   it('parses and validates against the schema', () => {
     const result = parseJsonWith('{"code":"E1","extra":true}', schema);
-    expect(result.isOk()).toBe(true);
-    expect(result._unsafeUnwrap()).toEqual({ code: 'E1' });
+    expect(Result.isSuccess(result)).toBe(true);
+    expect(Result.getOrThrow(result)).toEqual({ code: 'E1' });
   });
 
   it('fails when the parsed value does not match the schema', () => {
     const result = parseJsonWith('"just a string"', schema);
-    expect(result.isErr()).toBe(true);
-    expect(result._unsafeUnwrapErr()).toBeInstanceOf(z.ZodError);
+    expect(Result.isFailure(result)).toBe(true);
+    expect(Result.merge(result)).toBeInstanceOf(z.ZodError);
   });
 
   it('fails on malformed JSON without throwing', () => {
     const result = parseJsonWith('{nope', schema);
-    expect(result.isErr()).toBe(true);
+    expect(Result.isFailure(result)).toBe(true);
   });
 });

--- a/src/test-kernel/common/SafeParseYaml.vitest.ts
+++ b/src/test-kernel/common/SafeParseYaml.vitest.ts
@@ -3,19 +3,20 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
 // Local imports
+import { Result } from 'effect';
 import { parseYamlWith, safeParseYaml } from '@common/parsing/safeParseYaml';
 
 describe('safeParseYaml', () => {
   it('returns the parsed value for valid YAML', () => {
     const result = safeParseYaml('a: 1\nb:\n  - x\n');
-    expect(result.isOk()).toBe(true);
-    expect(result._unsafeUnwrap()).toEqual({ a: 1, b: ['x'] });
+    expect(Result.isSuccess(result)).toBe(true);
+    expect(Result.getOrThrow(result)).toEqual({ a: 1, b: ['x'] });
   });
 
   it('returns an error instead of throwing for malformed YAML', () => {
     const result = safeParseYaml('a: "unterminated');
-    expect(result.isErr()).toBe(true);
-    expect(result._unsafeUnwrapErr()).toBeInstanceOf(Error);
+    expect(Result.isFailure(result)).toBe(true);
+    expect(Result.merge(result)).toBeInstanceOf(Error);
   });
 });
 
@@ -27,18 +28,18 @@ describe('parseYamlWith', () => {
 
   it('parses and validates against the schema', () => {
     const result = parseYamlWith('code: E1\nextra: true\n', schema);
-    expect(result.isOk()).toBe(true);
-    expect(result._unsafeUnwrap()).toEqual({ code: 'E1' });
+    expect(Result.isSuccess(result)).toBe(true);
+    expect(Result.getOrThrow(result)).toEqual({ code: 'E1' });
   });
 
   it('fails when the parsed value does not match the schema', () => {
     const result = parseYamlWith('"just a string"', schema);
-    expect(result.isErr()).toBe(true);
-    expect(result._unsafeUnwrapErr()).toBeInstanceOf(z.ZodError);
+    expect(Result.isFailure(result)).toBe(true);
+    expect(Result.merge(result)).toBeInstanceOf(z.ZodError);
   });
 
   it('fails on malformed YAML without throwing', () => {
     const result = parseYamlWith('a: "unterminated', schema);
-    expect(result.isErr()).toBe(true);
+    expect(Result.isFailure(result)).toBe(true);
   });
 });

--- a/src/test-kernel/desktop/JsonStore.vitest.ts
+++ b/src/test-kernel/desktop/JsonStore.vitest.ts
@@ -134,6 +134,25 @@ describe('shared JsonStore', () => {
     });
   });
 
+  it('flushes chained sets in call order, not in wake-up order', async () => {
+    const JsonStore = await loadJsonStore();
+    const filePath = await createTempFile('state.json', '{}\n');
+    const store = await JsonStore.open(filePath);
+
+    // The third set is issued from the continuation of the first, while the
+    // second is still queued behind it. A lane that wakes waiters in a
+    // scheduled task lets the third flush barge ahead of the second and
+    // leaves the file at 2 while memory says 3.
+    const first = store.set('k', 1);
+    const second = store.set('k', 2);
+    await first;
+    const third = store.set('k', 3);
+    await Promise.all([second, third]);
+
+    expect(store.get('k')).toBe(3);
+    expect(await readStoredJson(filePath)).toEqual({ k: 3 });
+  });
+
   it('keeps the lock function callable in a split ESM bundle', async () => {
     tempDir = await makeTempDir('texra-json-store-bundle-', tempDirs);
     const outdir = join(tempDir, 'bundle');

--- a/src/test-kernel/platform/FileLocks.vitest.ts
+++ b/src/test-kernel/platform/FileLocks.vitest.ts
@@ -70,4 +70,40 @@ describe('nodeFileLocks', () => {
     await Promise.all([first, second]);
     expect(secondEntered).toBe(true);
   });
+
+  it('admits waiting callers in arrival order ahead of a later one', async () => {
+    const root = await makeTempDir('texra-file-lock-fifo-', tempDirs);
+    const lockPath = join(root, 'executionLocks', 'a8644c');
+    const entered: string[] = [];
+    let releaseFirst!: () => void;
+    const firstPaused = new Promise<void>(
+      (resolve) => (releaseFirst = resolve),
+    );
+    let firstEntered!: () => void;
+    const firstIn = new Promise<void>((resolve) => (firstEntered = resolve));
+
+    const first = nodeFileLocks.runExclusive(lockPath, async () => {
+      entered.push('first');
+      firstEntered();
+      await firstPaused;
+    });
+    await firstIn;
+    const second = nodeFileLocks.runExclusive(lockPath, async () => {
+      entered.push('second');
+    });
+    for (let turn = 0; turn < 5; turn += 1) {
+      await setImmediate();
+    }
+    releaseFirst();
+    await first;
+    // Issued from the first caller's continuation while the second is still
+    // waiting: a lane that wakes waiters in a scheduled task would admit it
+    // first.
+    const third = nodeFileLocks.runExclusive(lockPath, async () => {
+      entered.push('third');
+    });
+    await Promise.all([second, third]);
+
+    expect(entered).toEqual(['first', 'second', 'third']);
+  });
 });

--- a/src/tools/memory/memoryMeta.ts
+++ b/src/tools/memory/memoryMeta.ts
@@ -9,6 +9,7 @@
 import * as yaml from 'yaml';
 import { z } from 'zod';
 
+import { Result } from 'effect';
 import { parseYamlWith } from '@common/parsing/safeParseYaml';
 
 /**
@@ -65,12 +66,12 @@ export function parseFrontmatter(raw: string): {
 
   const block = raw.slice(FRONTMATTER_FENCE.length + 1, endIdx);
   const parsed = parseYamlWith(block, MemoryFileMetaSchema);
-  if (parsed.isErr()) {
+  if (Result.isFailure(parsed)) {
     return { meta: null, content: raw };
   }
 
   return {
-    meta: parsed.value,
+    meta: parsed.success,
     content: raw.slice(endIdx + FRONTMATTER_FENCE.length + 2), // skip "\n---\n"
   };
 }

--- a/src/utils/core/perKeyQueue.ts
+++ b/src/utils/core/perKeyQueue.ts
@@ -71,6 +71,18 @@ export interface PerKeyLane {
  * fiber started in between takes the free permit ahead of them. The lane is
  * created on first use and deleted from `lanes` once the last fiber holding
  * or waiting on it settles.
+ *
+ * A `Queue` of tickets served by one detached worker fiber (the shape
+ * `sessionFrames.ts` uses) was prototyped against this chain in review and
+ * not taken. FIFO came for free, but `Queue.make` is `withFiber`, so the
+ * queue cannot be created in the synchronous claim step: the create path
+ * had to re-check the map after `Queue.unbounded` and claim in the same
+ * synchronous step as the insert, because a lane whose count drops to zero
+ * ends its queue and a ticket offered to an ended queue waits forever. Its
+ * interruption handling was the same single `ensuring` as here, with the
+ * body still on the caller's fiber, and it measured 84 lines against these
+ * 65 while adding two lifecycle cases (raced creation, ended queue) that the
+ * chain does not have.
  */
 export function withPerKeyLane<Key>(
   lanes: Map<Key, PerKeyLane>,

--- a/src/utils/core/perKeyQueue.ts
+++ b/src/utils/core/perKeyQueue.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import { Effect, Semaphore } from 'effect';
 import PQueue from 'p-queue';
 
 interface QueueMap<Key> {
@@ -43,4 +44,49 @@ export async function runOnPerKeyQueue<Key, T>(
       queues.delete(key);
     }
   }
+}
+
+/**
+ * One in-process exclusive lane per key for Effect programs: a single-permit
+ * semaphore plus the number of fibers holding or waiting on it. The count is
+ * what lets the entry leave its map once the last fiber settles — a
+ * `Semaphore` exposes no waiter count of its own.
+ */
+export interface PerKeySemaphore {
+  readonly semaphore: Semaphore.Semaphore;
+  fibers: number;
+}
+
+/**
+ * Run `self` holding `key`'s permit — the Effect-side sibling of
+ * {@link runOnPerKeyQueue}. The lane is created on first use and deleted from
+ * `semaphores` once the last fiber holding or waiting on it settles, whether
+ * `self` succeeded, failed, or was interrupted. The lane is claimed
+ * synchronously when the effect starts, so fibers started in sequence enter
+ * in that order.
+ */
+export function withPerKeyPermit<Key>(
+  semaphores: Map<Key, PerKeySemaphore>,
+  key: Key,
+): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R> {
+  return (self) =>
+    Effect.suspend(() => {
+      let lane = semaphores.get(key);
+      if (!lane) {
+        lane = { semaphore: Semaphore.makeUnsafe(1), fibers: 0 };
+        semaphores.set(key, lane);
+      }
+      const held = lane;
+      held.fibers += 1;
+      return held.semaphore.withPermit(self).pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            held.fibers -= 1;
+            if (held.fibers === 0 && semaphores.get(key) === held) {
+              semaphores.delete(key);
+            }
+          }),
+        ),
+      );
+    });
 }

--- a/src/utils/core/perKeyQueue.ts
+++ b/src/utils/core/perKeyQueue.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { Effect, Semaphore } from 'effect';
+import { Deferred, Effect } from 'effect';
 import PQueue from 'p-queue';
 
 interface QueueMap<Key> {
@@ -47,43 +47,64 @@ export async function runOnPerKeyQueue<Key, T>(
 }
 
 /**
- * One in-process exclusive lane per key for Effect programs: a single-permit
- * semaphore plus the number of fibers holding or waiting on it. The count is
- * what lets the entry leave its map once the last fiber settles — a
- * `Semaphore` exposes no waiter count of its own.
+ * One in-process exclusive lane per key for Effect programs: the `Deferred`
+ * the most recent entrant completes when it leaves, plus the number of
+ * fibers holding or waiting on the lane. The count is what lets the entry
+ * leave its map once the last fiber settles.
  */
-export interface PerKeySemaphore {
-  readonly semaphore: Semaphore.Semaphore;
+export interface PerKeyLane {
+  tail: Deferred.Deferred<void>;
   fibers: number;
 }
 
 /**
- * Run `self` holding `key`'s permit — the Effect-side sibling of
- * {@link runOnPerKeyQueue}. The lane is created on first use and deleted from
- * `semaphores` once the last fiber holding or waiting on it settles, whether
- * `self` succeeded, failed, or was interrupted. The lane is claimed
- * synchronously when the effect starts, so fibers started in sequence enter
- * in that order.
+ * Run `self` on `key`'s lane — the Effect-side sibling of
+ * {@link runOnPerKeyQueue}, and FIFO like it: each entrant claims the lane
+ * synchronously when its effect starts by swapping its own `Deferred` in as
+ * the tail, waits for its predecessor's, and hands off in `ensuring` once
+ * `self` succeeds, fails, or is interrupted. The wait itself is
+ * interruptible; a waiter interrupted before entering hands its successor
+ * the wait for its own predecessor, so the successor still waits for whoever
+ * actually holds the lane. A hand-off through a `Deferred` resumes the next
+ * fiber directly, so fibers started in sequence enter in that order — a
+ * `Semaphore` barges: its release wakes waiters in a scheduled task, and a
+ * fiber started in between takes the free permit ahead of them. The lane is
+ * created on first use and deleted from `lanes` once the last fiber holding
+ * or waiting on it settles.
  */
-export function withPerKeyPermit<Key>(
-  semaphores: Map<Key, PerKeySemaphore>,
+export function withPerKeyLane<Key>(
+  lanes: Map<Key, PerKeyLane>,
   key: Key,
 ): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R> {
   return (self) =>
     Effect.suspend(() => {
-      let lane = semaphores.get(key);
-      if (!lane) {
-        lane = { semaphore: Semaphore.makeUnsafe(1), fibers: 0 };
-        semaphores.set(key, lane);
-      }
-      const held = lane;
+      const mine = Deferred.makeUnsafe<void>();
+      const existing = lanes.get(key);
+      const previous = existing?.tail;
+      const held = existing ?? { tail: mine, fibers: 0 };
+      if (!existing) lanes.set(key, held);
+      held.tail = mine;
       held.fibers += 1;
-      return held.semaphore.withPermit(self).pipe(
+      let entered = previous === undefined;
+      const run =
+        previous === undefined
+          ? self
+          : Effect.flatMap(Deferred.await(previous), () => {
+              entered = true;
+              return self;
+            });
+      return run.pipe(
         Effect.ensuring(
           Effect.sync(() => {
+            Deferred.doneUnsafe(
+              mine,
+              previous === undefined || entered
+                ? Effect.void
+                : Deferred.await(previous),
+            );
             held.fibers -= 1;
-            if (held.fibers === 0 && semaphores.get(key) === held) {
-              semaphores.delete(key);
+            if (held.fibers === 0 && lanes.get(key) === held) {
+              lanes.delete(key);
             }
           }),
         ),

--- a/src/utils/files/relativeFS.ts
+++ b/src/utils/files/relativeFS.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { type ZodType } from 'zod';
 
 // Local imports
+import { Result } from 'effect';
 import { parseJsonWith, safeParseJson } from '@common/parsing/safeParseJson';
 import { createLog } from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -42,13 +43,13 @@ export abstract class RelativeFS extends BaseFS {
   ): Promise<T> {
     const raw = await this.read(target);
     const result = schema ? parseJsonWith(raw, schema) : safeParseJson(raw);
-    if (result.isErr()) {
+    if (Result.isFailure(result)) {
       throw new Error(
-        `Failed to parse JSON from ${target}: ${result.error.message}`,
-        { cause: result.error },
+        `Failed to parse JSON from ${target}: ${result.failure.message}`,
+        { cause: result.failure },
       );
     }
-    return result.value as T;
+    return result.success as T;
   }
 
   /**


### PR DESCRIPTION
## Summary

Lane w6 of the Effect 4 runtime migration (docs/prds/2026-08-26-effect-4-runtime-migration.md), and the PRD's preferred first service spike: `runExclusive` already had a scoped-resource shape and a small consumer surface. Four modules move onto Effect with Promises kept at every public entry (R1): the in-process file-lock lane in `src/platform/defaults/fileLocks.ts`, the flush queue in `src/platform/defaults/jsonStore.ts`, a new Effect-side per-key lane in `src/utils/core/perKeyQueue.ts`, and the two safe parsers in `src/common/parsing/safeParseJson.ts` and `safeParseYaml.ts`, which now return Effect's `Result` instead of neverthrow's.

What was deleted (R10). In `fileLocks.ts`: the `KeyedMutex` (async-mutex) in-process lane, the three try/catch ledgers (`operationFailure`, `compromised`, `releaseFailure`), the manual failure array reduced by `throwAggregated`, and the `let value` capture; the lock is now an `acquireUseRelease` resource whose composite `Cause` is reduced once, at `withFileLock`, with the same identity rules (a lone error as-is, several as one `AggregateError` naming the path). In `jsonStore.ts`: the per-path p-queue `writeQueues` map and its `runOnPerKeyQueue` call, the `import type PQueue`, the module-level Promise memo of the lazily loaded lock provider (`jsonStoreFileLocksPromise` and `getJsonStoreFileLocks`), the try/catch plus `isFileNotFoundError` fallback in `readJsonRecord` (now `Effect.tryPromise` plus `Effect.catchIf`), and the three async helpers `readJsonRecord`, `ensureDir`, and `flush`, which are `Effect.fn` programs now; JsonStore's flush calls `withFileLock` directly, so no Promise to Effect to Promise chain runs inside the lane. In the parsers: the two hand-written try/catch blocks and the neverthrow `ok`/`err`/`andThen` usage, replaced by `Result.try({ try, catch: ensureError })` and `Result.flatMap`. Across the diff, five raw catch clauses are deleted and none added. neverthrow is removed from `package.json`, `packages/agent/package.json`, `packages/trace-viewer/package.json`, and `pnpm-lock.yaml`; no reference remains outside the PRD's prose. All 19 consumers of `safeParseJson`, `parseJsonWith`, `safeParseYaml`, and `parseYamlWith` (15 under `src/`, 4 under `packages/cli/src/`) and both parser suites are updated to `Result.isFailure`, `isSuccess`, `getOrElse`, `getOrUndefined`, `getOrThrow`, and `merge`. Where #11920's migration ratchet counts superseded package imports and raw catch clauses in migrated zones, this PR is the one that lowers those rows for these files.

What was added: `withPerKeyLane(lanes, key)` and the `PerKeyLane` interface in `perKeyQueue.ts`, a keyed FIFO exclusive lane for Effect programs (per key a `tail: Deferred<void>` plus a fiber count, so the entry leaves the map when idle), released on success, failure, and interruption (R6); and `withFileLock(lockPath, tuning)` in `fileLocks.ts`, the Effect-side lock used by both `runExclusive` and JsonStore's flush. Both are intra-lane exports with consumers in this PR only.

Preserved public signatures: `createNodeFileLocks(tuning: FileLockTuning): FileLockProvider`, `nodeFileLocks`, `FileLockTuning`, `JsonStore.open(filePath, options?): Promise<JsonStore>`, `set`, `update`, `get`, `has`, `snapshot`, `keys`, `JsonStoreOptions`, and the parser names and arguments are unchanged; only the parsers' return type changes carrier. `getOrCreatePQueue` and `runOnPerKeyQueue` are byte-identical, and their frozen consumers in `src/transcript` (`StreamSnapshotStore`, `TexraTranscriptRecorder`), `src/agent/storage` (`executionLease`), `src/agent/runtime` (`streamApprovalQueue`), and `packages/cli` (`approvalPrompts`) are not touched by this diff; they keep pinning `Map<Key, PQueue>` in their own declarations. Error identity is unchanged at every edge: proper-lockfile's own errors (`code` ELOCKED, ECOMPROMISED) and the operation's rejection are rethrown as-is, `JsonStore.open` still rejects with the `SyntaxError` or `TypeError`, and the compromise path still surfaces the compromise instead of ERELEASED.

Run boundaries. Three bare `Effect.runPromiseExit` sites, each squashing the `Cause` at the edge: `createNodeFileLocks().runExclusive`, `JsonStore.open`, and `JsonStore.set`. They run on Effect's default runtime rather than `effectRuntime()` because they predate `installProcessRuntime`: the CLI and desktop hosts open their stores (`createCliStateStores`, `openTexraConfigStores` in the CLI's `initPlatform`) before installing the process runtime, and `nodeFileLocks` is handed to `createNodePlatform` at the same point, so the process runtime may not exist when these run. Each site carries a comment saying so, and a new "Effect run boundaries" ratchet in `src/test-kernel/architecture/dependencyDirection.vitest.ts` scans `src` and `packages/*/src` for bare `Effect.run*` calls against an exact-count allowlist of those two files (1 and 2), so a fourth site fails CI and a removed site has to lower its pin (execution-strategy rule 3).

Net lines: +566/-283 overall. Excluding the lockfile (-26) and tests (+124/-18), production code is +442/-239, a net +203, of which +181 sits in `src/platform` and `src/utils`. The PRD's Phase 0 exemplar predicts this: a leaf conversion pays its own run boundary (three sites with their rationale comments), the FIFO lane is new code that sits beside the p-queue helpers frozen consumers still pin, and the doc comments now state the identity rules the deleted ledgers used to encode implicitly. Net deletion in this program comes from the shared host boundary and from choreography-heavy files, not from this lane.

Review history. Two adversarial reviews ran before this PR opened, each landing as its own commit. The Effect-idiom review (commit e821f96) raised three minor findings, all applied: the fs and proper-lockfile adapters map to `NodeJS.ErrnoException` and `Error` rather than `unknown`, so `withFileLock` is typed `Effect<A, E | Error, R>` and JsonStore's programs carry `ErrnoException | SyntaxError | TypeError | Error`, with the only remaining `unknown` being the caller's own Promise in `runExclusive`, whose rejection identity is preserved (R7, F7); the parsers use `Result.try`; and the three run sites are commented and pinned by the ratchet. The behavior-parity review (commit 1085648) found one blocking defect: the first lane serialized on a `Semaphore`, whose release wakes waiters in a scheduled task while a fiber started in between takes the free permit synchronously, so `await store.set(k, 1)` followed by `store.set(k, 3)` from the continuation flushed ahead of a queued `set(k, 2)`: memory said 3, the file said 2. Both replaced mechanisms (p-queue, async-mutex) were strict FIFO. The parity commit replaces the semaphore with the `Deferred` hand-off lane (`PerKeySemaphore` / `withPerKeyPermit` renamed `PerKeyLane` / `withPerKeyLane`): an entrant swaps in its own `Deferred` inside `Effect.suspend` so the claim is synchronous on fiber start, awaits its predecessor's, and completes its own in `Effect.ensuring`; a waiter interrupted mid-wait completes its `Deferred` with the wait for its own predecessor, so its successor still waits for whoever holds the lane. The same review's minor finding, that the lock and fs failures stay untagged, is recorded at both sites as the PRD R7 foreign-boundary adapter case: the `code` and the fs and parse instances are the caller-facing identities, and a `Data.TaggedError` wrapper unwrapped at the edge would add classes and an unwrap step for no behavior change.

Merge ordering with siblings: this branch and #11925 (`claude/effect-w3-tools-timeouts`) edit the same four manifest files for different packages and merge cleanly (checked with `git merge-tree`). This branch changes three lines of `src/auth/oauth/SubscriptionOAuthCoordinator.ts` (`isErr()`, `.error`, `.value` to `Result.isFailure`, `.failure`, `.success`); #11928 (`claude/effect-w2-auth-queues`) rewrites that file, so this PR should merge before it. #11921 is the catch-clause census this lane's deletions feed.

## Issue acceptance gates

n/a: no issue. The lane is scoped by the PRD's execution strategy and Phase 0 item 3 (`fileLocks` as the preferred service spike). Against the PRD's own gates: R1 holds (Promises at every public entry, three pinned run sites), R6 holds (lock as `acquireUseRelease`, lane hand-off in `ensuring`), R7 holds (typed failure channel; the untagged adapter case is recorded at both sites), R10's statement is the Summary above. Rule 2 of the execution strategy ("one pass per file") holds for the five converted files: no p-queue, async-mutex, neverthrow, or raw catch remains in them.

## Single source of truth

`withFileLock` in `src/platform/defaults/fileLocks.ts` now owns lock acquisition, release, compromise handling, and failure reduction for both callers (`runExclusive` and JsonStore's flush); JsonStore no longer carries its own lock-provider memo. `withPerKeyLane` in `src/utils/core/perKeyQueue.ts` owns in-process per-key FIFO ordering for Effect programs; fileLocks and jsonStore both serialize on it instead of one holding a `KeyedMutex` and the other a p-queue map. Effect's `Result` is the one carrier for the parsers' outcome. The "Effect run boundaries" ratchet in `dependencyDirection.vitest.ts` is the one record of which production files may call `Effect.run*` directly.

## Duplication and abstraction budget

Removed: two independent in-process serialization mechanisms (async-mutex in fileLocks, p-queue in jsonStore) collapse onto one lane; JsonStore's private lock-provider construction and memo collapse onto a tuning constant passed to `withFileLock`; three hand-written failure ledgers and one manual failure array collapse onto one `Cause` reduction; two hand-written try/catch parsers collapse onto `Result.try`.

Added: `withPerKeyLane` owns one invariant, FIFO admission per key with hand-off on success, failure, and interruption, and has two callers in this PR. `withFileLock` owns the lock-as-resource and the failure-identity rules and has two callers. Neither is a pass-through; the `Effect.fn` programs in jsonStore (`readJsonRecord`, `ensureDir`, `flush`) replace the async helpers of the same names one for one.

## Net elements (R6)

- Files: 33 changed, 0 added, 0 deleted (`perKeyQueue.ts` already existed).
- Exported symbols (`^[+-]export` over the diff): added `withFileLock`, `PerKeyLane`, `withPerKeyLane`; return type changed on `safeParseJson` and `safeParseYaml` (and, by inference, `parseJsonWith`, `parseYamlWith`); none deleted.
- Classes/interfaces/enums: +1 interface (`PerKeyLane`); no classes or enums added or removed.
- Dependencies: neverthrow removed from three package manifests and the lockfile.
- Raw catch clauses in converted files: 5 deleted, 0 added.
- Net LoC: +283 overall; +203 production excluding lockfile and tests (reason in the Summary).

## Consumer counts (R8)

No emit path changes. Re-routed exports: `safeParseJson` / `parseJsonWith` / `safeParseYaml` / `parseYamlWith` have 19 production consumers on main, all updated in this PR (listed by file in the diffstat: 4 in `packages/cli/src`, 15 in `src/`). `runOnPerKeyQueue` / `getOrCreatePQueue` have 5 production consumers, all untouched. `KeyedMutex` keeps its 8 other production importers; only fileLocks drops it (jsonStore's mention of it was a comment). `nodeFileLocks` / `createNodeFileLocks` have 1 production consumer (`src/platform/defaults/nodeHost.ts`) plus three test files, none changed. `withFileLock` and `withPerKeyLane` have 2 consumers each, both in this PR.

## Host impact

Extension: reaches `JsonStore` and `nodeFileLocks` through `createNodePlatform`; no extension source changes. Behavior is the same Promise API with the same error identities.

Desktop: `openTexraConfigStores` opens its `JsonStore`s before `installProcessRuntime`, which is why the run sites use the default runtime; no desktop source changes. Chained `set()` calls on a store now persist in call order under the FIFO lane (the semaphore round would have regressed this; main's p-queue already behaved this way).

CLI: four `packages/cli/src` files change only their `Result` accessors (`inputHistory`, `cliConfig`, `supabaseAuthCallbackServer`, `updateChecker`). `createCliStateStores` likewise opens stores before `installProcessRuntime`.

## Scheduled refactoring

- Once every host installs its process runtime before opening its stores, the three pinned run sites move to `effectRuntime()` and `BARE_EFFECT_RUN_SITES` drops to zero; per execution-strategy rule 3 the PR that zeroes the pin deletes the ratchet. No issue filed yet; the pin comments and the ratchet's message carry the instruction.
- The p-queue helpers `getOrCreatePQueue` / `runOnPerKeyQueue` stay until their frozen consumers in `src/transcript`, `src/agent/storage`, `src/agent/runtime`, and `packages/cli` convert in their own lanes, after which `perKeyQueue.ts` holds only `withPerKeyLane`.
- The `SubscriptionOAuthCoordinator` accessor change is superseded by #11928 (`claude/effect-w2-auth-queues`), which rewrites that file after this merges.
- The "Effect run boundaries" pin in `dependencyDirection.vitest.ts` and the `Effect.run*` allowlist row of #11920's migration ratchet count the same thing. Whichever merges second collapses onto the other in its merge-up, so one authority remains; #11920's baseline row is the intended survivor because it is the PRD's named mechanism.

## Validation

Run for each of the three commits and again by both review rounds: `npm run typecheck` (workspace and test-kernel projects), the Vitest suites (`src/test-kernel/platform/FileLocks.vitest.ts`, `FileLockCompromise.vitest.ts`, `src/test-kernel/desktop/JsonStore.vitest.ts`, `ElectronAgentDirectories.vitest.ts`, `src/test-kernel/common/SafeParseJson.vitest.ts`, `SafeParseYaml.vitest.ts`, `src/test-kernel/architecture/dependencyDirection.vitest.ts`, and the full `npm test`), `npm run lint` (eslint, including the VS Code-free-zone and host-import rules), `npm run format` (prettier), `npm run check:dead-code-ratchet` against `config/ratchets/knip-baseline.json` (the three new exports each have a consumer in this PR), and `scripts/check-browser-safe-utils.mjs` (`perKeyQueue.ts` is not on the browser-reachable list; the count and reachable set are unchanged).

Parity probe from the behavior-parity review, run against the final lane: chained sets, `runExclusive` entry order, 30 back-to-back sets from two `JsonStore` instances on one file, interruption mid-hold releasing both the lock directory and the lane, a waiter interrupted mid-wait not letting its successor barge, and rejection identity for async, sync, and string throws all pass. The two new regression cases (`JsonStore` set(1), set(2), await first, set(3) must persist 3; `nodeFileLocks` A held, B waiting, A released and awaited, C must enter as A, B, C) fail on the semaphore commit e821f96 and pass on 1085648; no new test files were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyJjcnpYcFopcGbYdWayxp