### PR TITLE
refactor(auth): run Supabase session and OAuth coordinators on Effect semaphores

### DIFF
--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -1,4 +1,4 @@
-import PQueue from 'p-queue';
+import { Semaphore } from 'effect';
 import {
   createClient,
   SupabaseClient as Client,
@@ -7,6 +7,7 @@ import {
 } from '@supabase/supabase-js';
 import { createLog } from '@logger/logUtils';
 import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
+import { callPort, runAuthProgram } from './authProgram';
 import { SUPABASE_GOTRUE_STORAGE_KEY } from './config';
 import type { SessionSecretStore } from './oauth/sessionAccess';
 import type { AuthTokenProvider, StoredSessionState } from './TokenProvider';
@@ -95,7 +96,7 @@ export class SupabaseClient {
   private static instance: Client | null = null;
   private static config: { url: string; publicKey: string } | null = null;
   private static authProvider: AuthTokenProvider | null = null;
-  private static pkceOperations = new PQueue({ concurrency: 1 });
+  private static pkceOperations = Semaphore.makeUnsafe(1);
 
   /**
    * Error that occurred during initialization, if any.
@@ -119,16 +120,19 @@ export class SupabaseClient {
     this.authProvider = null;
     this.initError = null;
     this.readinessError = null;
-    this.pkceOperations = new PQueue({ concurrency: 1 });
+    this.pkceOperations = Semaphore.makeUnsafe(1);
   }
 
   /**
    * Serialize PKCE callback exchange with OAuth initialization. Auth-js keeps
-   * each verifier in a flow-specific slot, while this queue prevents an older
-   * exchange from racing initialization in the same extension host.
+   * each verifier in a flow-specific slot, while this single permit prevents
+   * an older exchange from racing initialization in the same extension host.
+   * The operation's own rejection reaches the caller unchanged.
    */
   static async runPkceOperation<T>(operation: () => Promise<T>): Promise<T> {
-    return this.pkceOperations.add(operation) as Promise<T>;
+    return runAuthProgram(
+      this.pkceOperations.withPermits(1)(callPort(operation)),
+    );
   }
 
   /**

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -50,7 +50,9 @@ function gotrueStorage(secrets: SessionSecretStore): SupportedStorage {
   /**
    * Run one secret-store operation, unless the key is the session slot. That
    * slot and a failed store both answer `undefined`, which every caller
-   * resolves against the memory mirror.
+   * resolves against the memory mirror. This is `@supabase/auth-js`'s own
+   * Promise callback surface — a foreign-runtime boundary, not a temporary
+   * adapter — so its catch stays.
    */
   const onFlowState = async <T>(
     action: string,
@@ -150,6 +152,13 @@ export class SupabaseClient {
     return this.initError ?? this.readinessError;
   }
 
+  // `isReady`, `getAccessToken`, `getUser`, and `getStoredAccountLabel` stay
+  // Promise-native, catch clauses included: each wraps the `AuthTokenProvider`
+  // port (src/auth/TokenProvider.ts), which this subsystem's own
+  // SupabaseSessionCoordinator implements behind a Promise edge, so running
+  // them as programs here would put Effect on both sides of a Promise.
+  // Retirement condition (R10): the port becomes Effect-typed, and these
+  // convert with it in that PR. @adapter-until 2026-11-05
   /**
    * Check if auth system is fully initialized and ready for use.
    */

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -164,7 +164,8 @@ export class SupabaseClient {
   // Effect-typed, these convert with it in that PR, and the host hands the
   // coordinator's exchange program to an Effect-typed sibling of
   // `runPkceOperation` composed under the same permit, retiring the Promise
-  // callback with its suite. @adapter-until 2026-11-05
+  // callback with its suite. Introduced 2026-09-06 (lane w2 of the Effect 4
+  // migration). @adapter-until 2026-11-05
   /**
    * Check if auth system is fully initialized and ready for use.
    */

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -157,8 +157,14 @@ export class SupabaseClient {
   // port (src/auth/TokenProvider.ts), which this subsystem's own
   // SupabaseSessionCoordinator implements behind a Promise edge, so running
   // them as programs here would put Effect on both sides of a Promise.
-  // Retirement condition (R10): the port becomes Effect-typed, and these
-  // convert with it in that PR. @adapter-until 2026-11-05
+  // `runPkceOperation` is the same seam from the other side: the host passes
+  // `SupabaseSessionCoordinator.createSessionFromCallback`, a Promise edge
+  // over a program, so that call nests Promise → Effect → Promise → Effect
+  // (execution-strategy rule 1). Retirement condition (R10): the port becomes
+  // Effect-typed, these convert with it in that PR, and the host hands the
+  // coordinator's exchange program to an Effect-typed sibling of
+  // `runPkceOperation` composed under the same permit, retiring the Promise
+  // callback with its suite. @adapter-until 2026-11-05
   /**
    * Check if auth system is fully initialized and ready for use.
    */

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -1,10 +1,16 @@
-import PQueue from 'p-queue';
+import { Clock, Deferred, Effect, Semaphore } from 'effect';
 
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
   parseAuthCallbackCode,
   type AuthCallbackUriParts,
 } from './authCallback';
+import {
+  awaitWritesAhead,
+  callPort,
+  runAuthProgram,
+  type AuthPortError,
+} from './authProgram';
 import {
   parseStoredSupabaseSession,
   toStorableSupabaseSession,
@@ -51,27 +57,25 @@ const NOOP_SUPABASE_SESSION_LOG: Required<SupabaseSessionLog> = {
   error: () => undefined,
 };
 
-interface StableSessionSnapshot {
-  session: SupabaseSession | null;
-  version: number;
-}
-
 /**
  * Host-neutral coordinator for Supabase session storage, token freshness,
  * OAuth callback conversion, and refresh. Host wrappers own UI and registration.
+ *
+ * The Promise methods are the boundary; each runs one of the Effect programs
+ * below through {@link runAuthProgram}. Storage and GoTrue rejections travel
+ * as {@link AuthPortError} and reach the caller as the port's own error.
  */
 export class SupabaseSessionCoordinator implements AuthTokenProvider {
-  private refreshPromise: Promise<SupabaseSession | null> | null = null;
+  private refreshInFlight: Deferred.Deferred<SupabaseSession | null> | null =
+    null;
   private sessionMutationVersion = 0;
-  private lastStoredSession: SupabaseSession | null = null;
-  private lastStoredSessionVersion = 0;
   private lastRefreshFailure: SessionRefreshFailure | null = null;
-  // Single-flight serialized writes, same mechanism as
-  // SubscriptionOAuthCoordinator's `sessionMutations`: concurrency:1 makes
-  // `.onIdle()` alone a sufficient "no mutation in flight, and none can start
-  // without bumping sessionMutationVersion first" barrier for
-  // `loadStableSessionSnapshot`'s version-recheck loop below.
-  private readonly sessionMutations = new PQueue({ concurrency: 1 });
+  // Single-permit serialization of writes, same mechanism as
+  // SubscriptionOAuthCoordinator's `sessionMutations`: every write bumps
+  // `sessionMutationVersion` under the permit, so taking the permit alone is
+  // a sufficient "no mutation in flight, and none can start without bumping
+  // the version first" barrier for `stableSnapshot`'s version-recheck loop.
+  private readonly sessionMutations = Semaphore.makeUnsafe(1);
   private readonly log: Required<SupabaseSessionLog>;
 
   constructor(private readonly options: SupabaseSessionCoordinatorOptions) {
@@ -83,20 +87,17 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
   }
 
   async loadSession(): Promise<SupabaseSession | null> {
-    return parseStoredSupabaseSession(await this.options.storage.get(), {
-      logSource: 'SupabaseSession',
-      warn: this.log.warn,
-    });
+    return runAuthProgram(this.load());
   }
 
   async storeSession(session: SupabaseSession): Promise<void> {
-    await this.runSessionMutation(session, () =>
-      this.options.storage.store(JSON.stringify(session)),
-    );
+    await runAuthProgram(this.mutate(this.write(session)));
   }
 
   async clearSession(): Promise<void> {
-    await this.runSessionMutation(null, () => this.options.storage.delete());
+    await runAuthProgram(
+      this.mutate(callPort(() => this.options.storage.delete())),
+    );
   }
 
   /**
@@ -106,23 +107,9 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
    * delete the replacement.
    */
   async clearSessionIfCurrent(expected: SupabaseSession): Promise<boolean> {
-    return this.sessionMutations.add(async () => {
-      const current = await this.loadSession();
-      if (
-        !current ||
-        current.accessToken !== expected.accessToken ||
-        current.refreshToken !== expected.refreshToken
-      ) {
-        return false;
-      }
-
-      this.sessionMutationVersion += 1;
-      const mutationVersion = this.sessionMutationVersion;
-      await this.options.storage.delete();
-      this.lastStoredSession = null;
-      this.lastStoredSessionVersion = mutationVersion;
-      return true;
-    });
+    return runAuthProgram(
+      this.sessionMutations.withPermits(1)(this.clearIfCurrent(expected)),
+    );
   }
 
   /**
@@ -131,8 +118,12 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
    * @returns Fresh access token, or null if no session or refresh failed.
    */
   async ensureFreshToken(): Promise<string | null> {
-    const session = await this.getFreshSession();
-    return session?.accessToken ?? null;
+    return runAuthProgram(
+      Effect.map(
+        this.freshSession(),
+        (session) => session?.accessToken ?? null,
+      ),
+    );
   }
 
   /**
@@ -141,25 +132,19 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
    * the old credential's failure to the new one.
    */
   async getStoredSessionState(): Promise<StoredSessionState> {
-    try {
-      for (;;) {
-        const before = await this.loadStableSessionSnapshot();
-        if (!before.session) return 'none';
-        if (await this.getSessionTokens()) return 'authenticated';
-
-        const after = await this.loadStableSessionSnapshot();
-        if (!after.session) return 'none';
-        if (after.version !== before.version) continue;
-
-        return this.lastRefreshFailure === 'invalid' ? 'invalid' : 'transient';
-      }
-    } catch (error) {
-      this.log.error(
-        'SupabaseSession',
-        `Error classifying stored session: ${toErrorMessage(error)}`,
-      );
-      return 'transient';
-    }
+    return runAuthProgram(
+      this.storedSessionState().pipe(
+        Effect.catchTag('AuthPortError', (error) =>
+          Effect.sync(() => {
+            this.log.error(
+              'SupabaseSession',
+              `Error classifying stored session: ${toErrorMessage(error.cause)}`,
+            );
+            return 'transient' as const;
+          }),
+        ),
+      ),
+    );
   }
 
   /**
@@ -168,8 +153,9 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
    * unreadable — the caller decides what to show in its place.
    */
   async getStoredAccountLabel(): Promise<string | null> {
-    const session = await this.loadSession();
-    return session?.account.label ?? null;
+    return runAuthProgram(
+      Effect.map(this.load(), (session) => session?.account.label ?? null),
+    );
   }
 
   getLastRefreshFailure(): SessionRefreshFailure | null {
@@ -178,12 +164,16 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
 
   /** Get access and refresh tokens from secure storage. */
   async getSessionTokens(): Promise<SessionTokens | null> {
-    const session = await this.getFreshSession();
-    if (!session) return null;
-    return {
-      accessToken: session.accessToken,
-      refreshToken: session.refreshToken,
-    };
+    return runAuthProgram(
+      Effect.map(this.freshSession(), (session) =>
+        session
+          ? {
+              accessToken: session.accessToken,
+              refreshToken: session.refreshToken,
+            }
+          : null,
+      ),
+    );
   }
 
   /** Convert a PKCE OAuth callback into a host-neutral session record. */
@@ -193,17 +183,90 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
   ): Promise<SupabaseCallbackResult> {
     const parsedCode = parseAuthCallbackCode(uri);
     return parsedCode.success
-      ? this.createSessionViaCodeExchange(parsedCode.code, flowId)
+      ? runAuthProgram(this.exchangeCode(parsedCode.code, flowId))
       : parsedCode;
   }
 
-  private async createSessionViaCodeExchange(
+  /** Refresh session via Supabase native refresh, with concurrency protection. */
+  async refreshSession(
+    session: SupabaseSession,
+    expectedVersion = this.sessionMutationVersion,
+  ): Promise<SupabaseSession | null> {
+    return runAuthProgram(this.refresh(session, expectedVersion));
+  }
+
+  /** Read and parse the stored session. */
+  private readonly load = Effect.fn('SupabaseSessionCoordinator.load')(
+    function* (this: SupabaseSessionCoordinator) {
+      const raw = yield* callPort(() => this.options.storage.get());
+      return parseStoredSupabaseSession(raw, {
+        logSource: 'SupabaseSession',
+        warn: this.log.warn,
+      });
+    },
+  );
+
+  private write(session: SupabaseSession): Effect.Effect<void, AuthPortError> {
+    return callPort(() => this.options.storage.store(JSON.stringify(session)));
+  }
+
+  /** Run one storage write behind the permit, bumping the version it ran at. */
+  private mutate(
+    write: Effect.Effect<void, AuthPortError>,
+  ): Effect.Effect<void, AuthPortError> {
+    return this.sessionMutations.withPermits(1)(
+      Effect.suspend(() => {
+        this.sessionMutationVersion += 1;
+        return write;
+      }),
+    );
+  }
+
+  /** The body of {@link clearSessionIfCurrent}; the caller holds the permit. */
+  private readonly clearIfCurrent = Effect.fn(
+    'SupabaseSessionCoordinator.clearSessionIfCurrent',
+  )(function* (this: SupabaseSessionCoordinator, expected: SupabaseSession) {
+    const current = yield* this.load();
+    if (
+      !current ||
+      current.accessToken !== expected.accessToken ||
+      current.refreshToken !== expected.refreshToken
+    ) {
+      return false;
+    }
+    this.sessionMutationVersion += 1;
+    yield* callPort(() => this.options.storage.delete());
+    return true;
+  });
+
+  /** A stable read: no mutation in flight, and none started during the read. */
+  private readonly stableSnapshot = Effect.fn(
+    'SupabaseSessionCoordinator.stableSnapshot',
+  )(function* (this: SupabaseSessionCoordinator) {
+    for (;;) {
+      const versionBeforeLoad = this.sessionMutationVersion;
+      // A mutation that starts after the barrier bumps the version and
+      // re-loops.
+      yield* awaitWritesAhead(this.sessionMutations);
+      const session = yield* this.load();
+      if (versionBeforeLoad === this.sessionMutationVersion) {
+        return { session, version: versionBeforeLoad };
+      }
+    }
+  });
+
+  private readonly exchangeCode = Effect.fn(
+    'SupabaseSessionCoordinator.createSessionFromCallback',
+  )(function* (
+    this: SupabaseSessionCoordinator,
     code: string,
     flowId?: string,
-  ): Promise<SupabaseCallbackResult> {
-    const { data, error } = await this.options
-      .getClient()
-      .auth.exchangeCodeForSession(code, flowId ? { flowId } : undefined);
+  ) {
+    const { data, error } = yield* callPort(() =>
+      this.options
+        .getClient()
+        .auth.exchangeCodeForSession(code, flowId ? { flowId } : undefined),
+    );
 
     if (error || !data.session) {
       // A missing verifier means this callback belongs to a sign-in attempt
@@ -220,49 +283,65 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
               'sign-in again.'
             : error?.message || 'Code exchange failed',
         isAuthError: true,
-      };
+      } as const;
     }
 
-    return { success: true, session: toStorableSupabaseSession(data.session) };
-  }
+    return {
+      success: true,
+      session: toStorableSupabaseSession(data.session),
+    } as const;
+  });
 
-  /** Refresh session via Supabase native refresh, with concurrency protection. */
-  async refreshSession(
+  /**
+   * Single-flight refresh: concurrent callers share the in-flight result. A
+   * port rejection anywhere in the attempt is a transient failure, logged
+   * here where its disposition is decided.
+   */
+  private readonly refresh = Effect.fn(
+    'SupabaseSessionCoordinator.refreshSession',
+  )(function* (
+    this: SupabaseSessionCoordinator,
     session: SupabaseSession,
-    expectedVersion = this.sessionMutationVersion,
-  ): Promise<SupabaseSession | null> {
-    if (this.refreshPromise) {
-      return this.refreshPromise;
+    expectedVersion: number,
+  ) {
+    if (this.refreshInFlight) {
+      return yield* Deferred.await(this.refreshInFlight);
     }
-
+    const inFlight = yield* Deferred.make<SupabaseSession | null>();
+    this.refreshInFlight = inFlight;
     this.lastRefreshFailure = null;
-    this.refreshPromise = this.refreshViaSupabase(session)
-      .then((refreshed) =>
-        refreshed
-          ? this.storeRefreshIfCurrent(refreshed, expectedVersion)
-          : null,
-      )
-      .catch((error) => {
-        this.lastRefreshFailure = 'transient';
-        this.log.error(
-          'SupabaseSession',
-          `Error refreshing session: ${toErrorMessage(error)}`,
-        );
-        return null;
-      })
-      .finally(() => {
-        this.refreshPromise = null;
-      });
+    return yield* this.performRefresh(session, expectedVersion).pipe(
+      Effect.catchTag('AuthPortError', (error) =>
+        Effect.sync(() => {
+          this.lastRefreshFailure = 'transient';
+          this.log.error(
+            'SupabaseSession',
+            `Error refreshing session: ${toErrorMessage(error.cause)}`,
+          );
+          return null;
+        }),
+      ),
+      Effect.onExit((exit) =>
+        Effect.sync(() => {
+          Deferred.doneUnsafe(inFlight, exit);
+          if (this.refreshInFlight === inFlight) this.refreshInFlight = null;
+        }),
+      ),
+    );
+  });
 
-    return this.refreshPromise;
-  }
-
-  private async refreshViaSupabase(
+  private readonly performRefresh = Effect.fn(
+    'SupabaseSessionCoordinator.performRefresh',
+  )(function* (
+    this: SupabaseSessionCoordinator,
     session: SupabaseSession,
-  ): Promise<SupabaseSession | null> {
-    const { data, error } = await this.options.getClient().auth.refreshSession({
-      refresh_token: session.refreshToken,
-    });
+    expectedVersion: number,
+  ) {
+    const { data, error } = yield* callPort(() =>
+      this.options.getClient().auth.refreshSession({
+        refresh_token: session.refreshToken,
+      }),
+    );
 
     if (error || !data.session) {
       this.lastRefreshFailure = classifyAuthFailureStatus(error?.status);
@@ -270,98 +349,83 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     }
 
     this.lastRefreshFailure = null;
-    return toStorableSupabaseSession(data.session);
-  }
+    const refreshed = toStorableSupabaseSession(data.session);
+    // Decided under the permit: a mutation queued behind this refresh has not
+    // bumped the version yet, and the refreshed session must not overwrite
+    // what that mutation is about to write.
+    const stored = yield* this.sessionMutations.withPermits(1)(
+      Effect.suspend((): Effect.Effect<boolean, AuthPortError> => {
+        if (this.sessionMutationVersion !== expectedVersion) {
+          return Effect.succeed(false);
+        }
+        this.sessionMutationVersion += 1;
+        return Effect.as(this.write(refreshed), true);
+      }),
+    );
+    if (stored) return refreshed;
+    return (yield* this.stableSnapshot()).session;
+  });
 
-  private async getFreshSession(): Promise<SupabaseSession | null> {
-    try {
-      const { session, version } = await this.loadStableSessionSnapshot();
-      if (!session) {
-        return null;
-      }
-
-      const timeUntilExpiry = session.expiresAt - Date.now();
-
-      if (timeUntilExpiry < this.options.tokenRefreshThresholdMs) {
-        this.log.info(
-          'SupabaseSession',
-          `Token expires in ${Math.round(timeUntilExpiry / 1000)}s, refreshing proactively`,
-        );
-        const refreshed = await this.refreshSession(session, version);
-        if (refreshed) return refreshed;
-        if (timeUntilExpiry <= 0) {
-          this.log.warn(
+  /**
+   * The stored session, refreshed if it is near expiry. A port rejection on
+   * the read is a transient failure; refresh never fails.
+   */
+  private readonly freshSession = Effect.fn(
+    'SupabaseSessionCoordinator.freshSession',
+  )(function* (this: SupabaseSessionCoordinator) {
+    const snapshot = yield* this.stableSnapshot().pipe(
+      Effect.catchTag('AuthPortError', (error) =>
+        Effect.sync(() => {
+          this.lastRefreshFailure = 'transient';
+          this.log.error(
             'SupabaseSession',
-            'Token expired and refresh failed, returning null',
+            `Error loading fresh session: ${toErrorMessage(error.cause)}`,
           );
           return null;
-        }
-      }
-
-      this.lastRefreshFailure = null;
-      return session;
-    } catch (error) {
-      this.lastRefreshFailure = 'transient';
-      this.log.error(
-        'SupabaseSession',
-        `Error loading fresh session: ${toErrorMessage(error)}`,
-      );
-      return null;
-    }
-  }
-
-  private async loadStableSession(): Promise<SupabaseSession | null> {
-    return (await this.loadStableSessionSnapshot()).session;
-  }
-
-  private async loadStableSessionSnapshot(): Promise<StableSessionSnapshot> {
-    for (;;) {
-      const versionBeforeLoad = this.sessionMutationVersion;
-      await this.sessionMutations.onIdle();
-      const session = await this.loadSession();
-      if (versionBeforeLoad === this.sessionMutationVersion) {
-        return { session, version: versionBeforeLoad };
-      }
-    }
-  }
-
-  private async runSessionMutation(
-    session: SupabaseSession | null,
-    operation: () => Promise<void>,
-  ): Promise<void> {
-    await this.sessionMutations.add(async () => {
-      this.sessionMutationVersion += 1;
-      const mutationVersion = this.sessionMutationVersion;
-      await operation();
-      this.lastStoredSession = session;
-      this.lastStoredSessionVersion = mutationVersion;
-    });
-  }
-
-  private async storeRefreshIfCurrent(
-    refreshed: SupabaseSession,
-    expectedVersion: number,
-  ): Promise<SupabaseSession | null> {
-    if (
-      this.sessionMutationVersion !== expectedVersion ||
-      this.sessionMutations.size > 0 ||
-      this.sessionMutations.pending > 0
-    ) {
-      return this.loadStableSession();
-    }
-
-    await this.storeSession(refreshed);
-    return this.isCurrentStoredSession(refreshed)
-      ? refreshed
-      : this.loadStableSession();
-  }
-
-  private isCurrentStoredSession(session: SupabaseSession): boolean {
-    return (
-      this.lastStoredSessionVersion === this.sessionMutationVersion &&
-      this.lastStoredSession?.accessToken === session.accessToken &&
-      this.lastStoredSession.refreshToken === session.refreshToken &&
-      this.lastStoredSession.id === session.id
+        }),
+      ),
     );
-  }
+    if (!snapshot?.session) return null;
+    const { session, version } = snapshot;
+
+    const timeUntilExpiry =
+      session.expiresAt - (yield* Clock.currentTimeMillis);
+
+    if (timeUntilExpiry < this.options.tokenRefreshThresholdMs) {
+      this.log.info(
+        'SupabaseSession',
+        `Token expires in ${Math.round(timeUntilExpiry / 1000)}s, refreshing proactively`,
+      );
+      const refreshed = yield* this.refresh(session, version);
+      if (refreshed) return refreshed;
+      if (timeUntilExpiry <= 0) {
+        this.log.warn(
+          'SupabaseSession',
+          'Token expired and refresh failed, returning null',
+        );
+        return null;
+      }
+    }
+
+    this.lastRefreshFailure = null;
+    return session;
+  });
+
+  private readonly storedSessionState = Effect.fn(
+    'SupabaseSessionCoordinator.getStoredSessionState',
+  )(function* (this: SupabaseSessionCoordinator) {
+    for (;;) {
+      const before = yield* this.stableSnapshot();
+      if (!before.session) return 'none' as const;
+      if (yield* this.freshSession()) return 'authenticated' as const;
+
+      const after = yield* this.stableSnapshot();
+      if (!after.session) return 'none' as const;
+      if (after.version !== before.version) continue;
+
+      return this.lastRefreshFailure === 'invalid'
+        ? ('invalid' as const)
+        : ('transient' as const);
+    }
+  });
 }

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -351,19 +351,27 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
 
     this.lastRefreshFailure = null;
     const refreshed = toStorableSupabaseSession(data.session);
-    // Decided under the permit: a mutation queued behind this refresh has not
-    // bumped the version yet, and the refreshed session must not overwrite
-    // what that mutation is about to write.
-    const stored = yield* this.sessionMutations.run(
+    // Both decisions are made under the permit. Before the write: a mutation
+    // that ran ahead of this refresh has bumped the version, and the
+    // refreshed session must not overwrite what it wrote. After the write,
+    // still under the permit: a mutation queued behind it has not bumped the
+    // version yet but is about to replace what was just stored, so the
+    // refreshed session is not the answer either — the caller gets the
+    // post-mutation snapshot, as it did when the ledger checked after the
+    // store.
+    const current = yield* this.sessionMutations.run(
       Effect.suspend((): Effect.Effect<boolean, AuthPortError> => {
         if (this.sessionMutationVersion !== expectedVersion) {
           return Effect.succeed(false);
         }
         this.sessionMutationVersion += 1;
-        return Effect.as(this.write(refreshed), true);
+        return Effect.map(
+          this.write(refreshed),
+          () => !this.sessionMutations.hasWaiters,
+        );
       }),
     );
-    if (stored) return refreshed;
+    if (current) return refreshed;
     return (yield* this.stableSnapshot()).session;
   });
 

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -1,4 +1,4 @@
-import { Clock, Deferred, Effect, Semaphore } from 'effect';
+import { Clock, Deferred, Effect } from 'effect';
 
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
@@ -6,9 +6,9 @@ import {
   type AuthCallbackUriParts,
 } from './authCallback';
 import {
-  awaitWritesAhead,
   callPort,
   runAuthProgram,
+  SerializedWrites,
   type AuthPortError,
 } from './authProgram';
 import {
@@ -70,12 +70,11 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     null;
   private sessionMutationVersion = 0;
   private lastRefreshFailure: SessionRefreshFailure | null = null;
-  // Single-permit serialization of writes, same mechanism as
-  // SubscriptionOAuthCoordinator's `sessionMutations`: every write bumps
-  // `sessionMutationVersion` under the permit, so taking the permit alone is
-  // a sufficient "no mutation in flight, and none can start without bumping
-  // the version first" barrier for `stableSnapshot`'s version-recheck loop.
-  private readonly sessionMutations = Semaphore.makeUnsafe(1);
+  // Serialized writes, same mechanism as SubscriptionOAuthCoordinator's
+  // `sessionMutations`: every write bumps `sessionMutationVersion` under the
+  // permit, so its idle barrier plus a version recheck is `stableSnapshot`'s
+  // "no mutation in flight, and none started during the read" guarantee.
+  private readonly sessionMutations = new SerializedWrites();
   private readonly log: Required<SupabaseSessionLog>;
 
   constructor(private readonly options: SupabaseSessionCoordinatorOptions) {
@@ -108,7 +107,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
    */
   async clearSessionIfCurrent(expected: SupabaseSession): Promise<boolean> {
     return runAuthProgram(
-      this.sessionMutations.withPermits(1)(this.clearIfCurrent(expected)),
+      this.sessionMutations.run(this.clearIfCurrent(expected)),
     );
   }
 
@@ -214,7 +213,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
   private mutate(
     write: Effect.Effect<void, AuthPortError>,
   ): Effect.Effect<void, AuthPortError> {
-    return this.sessionMutations.withPermits(1)(
+    return this.sessionMutations.run(
       Effect.suspend(() => {
         this.sessionMutationVersion += 1;
         return write;
@@ -247,7 +246,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
       const versionBeforeLoad = this.sessionMutationVersion;
       // A mutation that starts after the barrier bumps the version and
       // re-loops.
-      yield* awaitWritesAhead(this.sessionMutations);
+      yield* this.sessionMutations.awaitIdle();
       const session = yield* this.load();
       if (versionBeforeLoad === this.sessionMutationVersion) {
         return { session, version: versionBeforeLoad };
@@ -293,9 +292,12 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
   });
 
   /**
-   * Single-flight refresh: concurrent callers share the in-flight result. A
-   * port rejection anywhere in the attempt is a transient failure, logged
-   * here where its disposition is decided.
+   * Single-flight refresh: concurrent callers share the in-flight result. The
+   * check and the claim share one synchronous segment — no `yield*` between
+   * them, since the runtime may yield the fiber at any op boundary — so a
+   * second caller can never mint a second refresh. A port rejection anywhere
+   * in the attempt is a transient failure, logged here where its disposition
+   * is decided.
    */
   private readonly refresh = Effect.fn(
     'SupabaseSessionCoordinator.refreshSession',
@@ -304,10 +306,9 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     session: SupabaseSession,
     expectedVersion: number,
   ) {
-    if (this.refreshInFlight) {
-      return yield* Deferred.await(this.refreshInFlight);
-    }
-    const inFlight = yield* Deferred.make<SupabaseSession | null>();
+    const existing = this.refreshInFlight;
+    if (existing) return yield* Deferred.await(existing);
+    const inFlight = Deferred.makeUnsafe<SupabaseSession | null>();
     this.refreshInFlight = inFlight;
     this.lastRefreshFailure = null;
     return yield* this.performRefresh(session, expectedVersion).pipe(
@@ -353,7 +354,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     // Decided under the permit: a mutation queued behind this refresh has not
     // bumped the version yet, and the refreshed session must not overwrite
     // what that mutation is about to write.
-    const stored = yield* this.sessionMutations.withPermits(1)(
+    const stored = yield* this.sessionMutations.run(
       Effect.suspend((): Effect.Effect<boolean, AuthPortError> => {
         if (this.sessionMutationVersion !== expectedVersion) {
           return Effect.succeed(false);

--- a/src/auth/authProgram.ts
+++ b/src/auth/authProgram.ts
@@ -1,0 +1,62 @@
+/**
+ * The Promise edge of the auth subsystem's Effect programs (Effect 4 runtime
+ * PRD, R1 and R7): one run boundary behind each Promise-facing method, and
+ * one typed failure for the host ports those programs call.
+ */
+import { Cause, Data, Effect, Exit, Option, type Semaphore } from 'effect';
+
+import { effectRuntime } from '@platform/processRuntime';
+
+/**
+ * A host port (secret storage), an SDK call, or a provider policy rejected.
+ * `cause` is that caller's own error; the Promise edge re-throws it
+ * unchanged, so every `instanceof` and message check a host makes still
+ * holds.
+ */
+export class AuthPortError extends Data.TaggedError('AuthPortError')<{
+  readonly cause: unknown;
+}> {}
+
+/** Adapt one Promise port call; its rejection becomes an {@link AuthPortError}. */
+export function callPort<A>(
+  call: () => Promise<A>,
+): Effect.Effect<A, AuthPortError> {
+  return Effect.tryPromise({
+    try: call,
+    catch: (cause) => new AuthPortError({ cause }),
+  });
+}
+
+/**
+ * Wait until every write queued ahead of us on a single-permit semaphore has
+ * run — the barrier a stable read takes before loading. The permit is freed
+ * before its waiters are woken, so a fiber that just released it and asks
+ * again would barge ahead of them; yielding first lets the woken writer take
+ * the permit, and this take then queues behind it.
+ */
+export function awaitWritesAhead(
+  writes: Semaphore.Semaphore,
+): Effect.Effect<void> {
+  return Effect.andThen(Effect.yieldNow, writes.withPermits(1)(Effect.void));
+}
+
+function rethrowPortCause(error: unknown): never {
+  throw error instanceof AuthPortError ? error.cause : error;
+}
+
+/**
+ * Run one auth program on the process runtime and settle it as a Promise.
+ * An expected failure reaches `rethrow`, which re-mints it as the error the
+ * caller matches on — by default the port's own error, unwrapped. Defects
+ * and interruption propagate as they are.
+ */
+export async function runAuthProgram<A, E>(
+  program: Effect.Effect<A, E>,
+  rethrow: (error: E) => never = rethrowPortCause,
+): Promise<A> {
+  const exit = await effectRuntime().runPromiseExit(program);
+  if (Exit.isSuccess(exit)) return exit.value;
+  const failure = Cause.findErrorOption(exit.cause);
+  if (Option.isSome(failure)) return rethrow(failure.value);
+  throw Cause.squash(exit.cause);
+}

--- a/src/auth/authProgram.ts
+++ b/src/auth/authProgram.ts
@@ -29,12 +29,13 @@ export function callPort<A>(
 
 /**
  * Serialized storage writes with an idle barrier — what a coordinator's
- * `p-queue` serializer was: one write at a time, and a reader can wait for
- * every write queued before it. A single-permit semaphore alone cannot give
- * the barrier: it frees its permit before it wakes its waiters, so a fiber
- * that just released it and asks again barges ahead of a queued write. The
- * barrier therefore counts queued writes itself and waits on a `Deferred`
- * the last one settles; it depends on no scheduler wake ordering.
+ * `p-queue` serializer was: one write at a time, a write that holds the
+ * permit runs to completion, and a reader can wait for every write queued
+ * before it. A single-permit semaphore alone cannot give the barrier: it
+ * frees its permit before it wakes its waiters, so a fiber that just
+ * released it and asks again barges ahead of a queued write. The barrier
+ * therefore counts queued writes itself and waits on a `Deferred` the last
+ * one settles; it depends on no scheduler wake ordering.
  */
 export class SerializedWrites {
   private readonly permit = Semaphore.makeUnsafe(1);
@@ -54,10 +55,27 @@ export class SerializedWrites {
     return Effect.suspend(() => {
       onQueue?.();
       this.queued += 1;
+      // Interruption is observed while waiting for the permit, never once it
+      // is held. A port write cannot be cancelled — `callPort` never aborts
+      // the Promise it wraps — so an interruptible write would release the
+      // permit and leave the barrier idle while the storage write is still
+      // pending, and the next write would run beside it. The p-queue job it
+      // replaces always finished, with later jobs queued behind it.
       return this.permit
-        .withPermits(1)(write)
+        .withPermits(1)(Effect.uninterruptible(write))
         .pipe(Effect.ensuring(Effect.sync(() => this.dequeue())));
     });
+  }
+
+  /**
+   * Whether a write is queued behind the one holding the permit. Read from
+   * inside that write, once its own port call has returned, it says the value
+   * just written is about to be replaced — what a p-queue caller could see in
+   * the version counter because the next job started synchronously on the
+   * previous one's return, and a fiber that bumps under the permit cannot.
+   */
+  get hasWaiters(): boolean {
+    return this.queued > 1;
   }
 
   private dequeue(): void {

--- a/src/auth/authProgram.ts
+++ b/src/auth/authProgram.ts
@@ -3,7 +3,7 @@
  * PRD, R1 and R7): one run boundary behind each Promise-facing method, and
  * one typed failure for the host ports those programs call.
  */
-import { Cause, Data, Effect, Exit, Option, type Semaphore } from 'effect';
+import { Cause, Data, Deferred, Effect, Exit, Option, Semaphore } from 'effect';
 
 import { effectRuntime } from '@platform/processRuntime';
 
@@ -28,16 +28,56 @@ export function callPort<A>(
 }
 
 /**
- * Wait until every write queued ahead of us on a single-permit semaphore has
- * run — the barrier a stable read takes before loading. The permit is freed
- * before its waiters are woken, so a fiber that just released it and asks
- * again would barge ahead of them; yielding first lets the woken writer take
- * the permit, and this take then queues behind it.
+ * Serialized storage writes with an idle barrier — what a coordinator's
+ * `p-queue` serializer was: one write at a time, and a reader can wait for
+ * every write queued before it. A single-permit semaphore alone cannot give
+ * the barrier: it frees its permit before it wakes its waiters, so a fiber
+ * that just released it and asks again barges ahead of a queued write. The
+ * barrier therefore counts queued writes itself and waits on a `Deferred`
+ * the last one settles; it depends on no scheduler wake ordering.
  */
-export function awaitWritesAhead(
-  writes: Semaphore.Semaphore,
-): Effect.Effect<void> {
-  return Effect.andThen(Effect.yieldNow, writes.withPermits(1)(Effect.void));
+export class SerializedWrites {
+  private readonly permit = Semaphore.makeUnsafe(1);
+  private queued = 0;
+  private idle: Deferred.Deferred<void> | null = null;
+
+  /**
+   * Queue `write` behind the permit. `onQueue` runs in the same synchronous
+   * segment that counts the write as queued — before any fiber boundary — so
+   * a caller can publish that a write is coming (bump a generation) atomically
+   * with queueing it, as a synchronous `queue.add()` used to.
+   */
+  run<A, E>(
+    write: Effect.Effect<A, E>,
+    onQueue?: () => void,
+  ): Effect.Effect<A, E> {
+    return Effect.suspend(() => {
+      onQueue?.();
+      this.queued += 1;
+      return this.permit
+        .withPermits(1)(write)
+        .pipe(Effect.ensuring(Effect.sync(() => this.dequeue())));
+    });
+  }
+
+  private dequeue(): void {
+    this.queued -= 1;
+    if (this.queued === 0 && this.idle) {
+      const idle = this.idle;
+      this.idle = null;
+      Deferred.doneUnsafe(idle, Effect.void);
+    }
+  }
+
+  /** Wait until every write queued before this call has run. */
+  readonly awaitIdle = Effect.fn('SerializedWrites.awaitIdle')(function* (
+    this: SerializedWrites,
+  ) {
+    while (this.queued > 0) {
+      this.idle ??= Deferred.makeUnsafe<void>();
+      yield* Deferred.await(this.idle);
+    }
+  });
 }
 
 function rethrowPortCause(error: unknown): never {

--- a/src/auth/codex/CodexSessionCoordinator.ts
+++ b/src/auth/codex/CodexSessionCoordinator.ts
@@ -7,8 +7,6 @@
  */
 import { Effect } from 'effect';
 
-import { effectRuntime } from '@platform/processRuntime';
-
 import { providerAuthError } from '../oauth/providerAuthBridge';
 import {
   SubscriptionOAuthCoordinator,
@@ -97,23 +95,17 @@ export class CodexSessionCoordinator extends SubscriptionOAuthCoordinator<CodexS
     super({
       storage: init.storage,
       policy: CODEX_POLICY,
-      // The grant programs run here at the coordinator's Promise boundary
-      // until the coordinator itself is an Effect program.
       client: init.client ?? {
         exchangeAuthorizationCode: (params) =>
-          effectRuntime().runPromise(
-            exchangeAuthorizationCode(params).pipe(
-              Effect.mapError((error) =>
-                providerAuthError(error, CodexAuthError),
-              ),
+          exchangeAuthorizationCode(params).pipe(
+            Effect.mapError((error) =>
+              providerAuthError(error, CodexAuthError),
             ),
           ),
         refreshTokens: (refreshToken) =>
-          effectRuntime().runPromise(
-            refreshTokens(refreshToken).pipe(
-              Effect.mapError((error) =>
-                providerAuthError(error, CodexAuthError),
-              ),
+          refreshTokens(refreshToken).pipe(
+            Effect.mapError((error) =>
+              providerAuthError(error, CodexAuthError),
             ),
           ),
       },

--- a/src/auth/oauth/SubscriptionOAuthCoordinator.ts
+++ b/src/auth/oauth/SubscriptionOAuthCoordinator.ts
@@ -5,16 +5,27 @@
  * differences (authorize URL, claim extraction, refresh buffer) live in the
  * {@link SubscriptionOAuthPolicy}; this class owns single-flight refresh,
  * generation supersede, and serialized storage writes.
+ *
+ * The Promise methods are the boundary; each runs one of the Effect programs
+ * below through {@link runAuthProgram}. Inside, the shared-machine
+ * {@link SubscriptionOAuthError} is the typed failure and a port rejection
+ * travels as {@link AuthPortError}; the edge re-mints both as the provider's
+ * own error type.
  */
 // Third-party imports
-import PQueue from 'p-queue';
+import { Deferred, Effect, Result, Semaphore } from 'effect';
 
 // Local imports
-import { Result } from 'effect';
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import { createLog } from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
+import {
+  AuthPortError,
+  awaitWritesAhead,
+  callPort,
+  runAuthProgram,
+} from '../authProgram';
 import { generateOAuthState, generatePkcePair } from './pkce';
 import {
   rethrowAsProviderAuthError,
@@ -113,14 +124,27 @@ export interface SubscriptionOAuthCoordinatorInit<
   errorType: ProviderAuthErrorCtor;
 }
 
+type MachineFailure = SubscriptionOAuthError | AuthPortError;
+
+/**
+ * A client or policy throw: the provider's own error (a
+ * {@link SubscriptionOAuthError} subclass) stays first-class so the machine
+ * can read its `kind`; anything else is that call's rejection.
+ */
+function asMachineFailure(cause: unknown): MachineFailure {
+  return cause instanceof SubscriptionOAuthError
+    ? cause
+    : new AuthPortError({ cause });
+}
+
 export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
   private readonly storage: SubscriptionSessionStorage;
   private readonly policy: SubscriptionOAuthPolicy<S>;
   private readonly client: SubscriptionOAuthClient;
   private readonly now: () => number;
   private readonly errorType: ProviderAuthErrorCtor;
-  private refreshInFlight: Promise<S> | null = null;
-  private readonly sessionMutations = new PQueue({ concurrency: 1 });
+  private refreshInFlight: Deferred.Deferred<S, MachineFailure> | null = null;
+  private readonly sessionMutations = Semaphore.makeUnsafe(1);
   private sessionGeneration = 0;
 
   constructor(init: SubscriptionOAuthCoordinatorInit<S>) {
@@ -131,110 +155,33 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
     this.errorType = init.errorType;
   }
 
-  /** Map shared-machine errors into the provider's own error type. */
-  private async mapErrors<T>(op: () => Promise<T>): Promise<T> {
-    try {
-      return await op();
-    } catch (error) {
-      rethrowAsProviderAuthError(error, this.errorType);
-    }
-  }
+  /** Re-throw a program failure as the provider's own error type. */
+  private readonly rethrowAsProviderError = (error: MachineFailure): never =>
+    rethrowAsProviderAuthError(
+      error instanceof AuthPortError ? error.cause : error,
+      this.errorType,
+    );
 
   async loadSession(): Promise<S | null> {
-    const raw = await this.storage.get();
-    if (!raw) return null;
-    const parsedJson = safeParseJson(raw);
-    if (Result.isFailure(parsedJson)) {
-      // Present-but-corrupt is not the same as never signed in.
-      log.warn(
-        `Stored subscription session is not valid JSON; treating as signed out: ${toErrorMessage(parsedJson.failure)}`,
-      );
-      return null;
-    }
-    const parsed = this.policy.sessionSchema.safeParse(parsedJson.success);
-    if (!parsed.success) {
-      log.warn(
-        `Stored subscription session failed schema validation; treating as signed out: ${toErrorMessage(parsed.error)}`,
-      );
-      return null;
-    }
-    return parsed.data;
-  }
-
-  private async storeSession(session: S): Promise<void> {
-    await this.storage.store(JSON.stringify(session));
-  }
-
-  private mutateSession(op: () => Promise<void>): Promise<void> {
-    return this.sessionMutations.add(op);
-  }
-
-  private async loadStableSession(): Promise<{
-    generation: number;
-    session: S | null;
-  }> {
-    while (true) {
-      const generation = this.sessionGeneration;
-      await this.sessionMutations.onIdle();
-      const session = await this.loadSession();
-      if (generation === this.sessionGeneration) {
-        return { generation, session };
-      }
-    }
-  }
-
-  private supersedeInFlightRefresh(): void {
-    this.sessionGeneration += 1;
-    this.refreshInFlight = null;
-  }
-
-  /**
-   * After a refresh is superseded (concurrent login/sign-out), take a stable
-   * storage snapshot and:
-   * - return a *replacement* session (different credentials) — concurrent
-   *   sign-in succeeded; do not force re-auth;
-   * - return a still-fresh same session (rare: supersede without replace);
-   * - throw `expired` when storage is empty (sign-out won);
-   * - throw `transient` when the pre-refresh session is still the only
-   *   stored value and still needs refresh (failed concurrent store, or a
-   *   server-rotated refresh that never landed) — never hand back a known-
-   *   stale token as if the refresh completed.
-   */
-  private async sessionAfterSupersede(previous: S): Promise<S> {
-    const { session } = await this.loadStableSession();
-    if (!session) {
-      throw new SubscriptionOAuthError(
-        this.policy.sessionChangedMessage,
-        'expired',
-      );
-    }
-    const replaced =
-      session.accessToken !== previous.accessToken ||
-      session.refreshToken !== previous.refreshToken;
-    if (replaced || !this.isExpiringSoon(session)) {
-      return session;
-    }
-    throw new SubscriptionOAuthError(
-      this.policy.sessionChangedMessage,
-      'transient',
-    );
+    return runAuthProgram(this.load());
   }
 
   async signOut(): Promise<void> {
-    await this.mapErrors(async () => {
-      this.supersedeInFlightRefresh();
-      await this.mutateSession(() => this.storage.delete());
-    });
+    await runAuthProgram(this.clearSession(), this.rethrowAsProviderError);
   }
 
   async getStatus(): Promise<SubscriptionSessionStatus> {
-    const session = await this.loadSession();
-    if (!session) return { signedIn: false };
-    return {
-      signedIn: true,
-      email: session.email,
-      accountId: session.accountId,
-    };
+    return runAuthProgram(
+      Effect.map(this.load(), (session) =>
+        session
+          ? {
+              signedIn: true,
+              email: session.email,
+              accountId: session.accountId,
+            }
+          : { signedIn: false },
+      ),
+    );
   }
 
   buildAuthorizeRequest(port: number): SubscriptionAuthorizeRequest {
@@ -248,23 +195,21 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
     verifier: string;
     redirectUri: string;
   }): Promise<S> {
-    return this.mapErrors(async () => {
-      const tokens = await this.client.exchangeAuthorizationCode(params);
-      const session = this.policy.buildSession(tokens, this.now());
-      this.supersedeInFlightRefresh();
-      await this.mutateSession(() => this.storeSession(session));
-      return session;
-    });
+    return runAuthProgram(
+      Effect.flatMap(
+        this.clientCall(() => this.client.exchangeAuthorizationCode(params)),
+        (tokens) => this.adoptTokens(tokens),
+      ),
+      this.rethrowAsProviderError,
+    );
   }
 
   /** Persist tokens from a successful device-code (or other) grant. */
   async storeTokens(tokens: SubscriptionTokenResponse): Promise<S> {
-    return this.mapErrors(async () => {
-      const session = this.policy.buildSession(tokens, this.now());
-      this.supersedeInFlightRefresh();
-      await this.mutateSession(() => this.storeSession(session));
-      return session;
-    });
+    return runAuthProgram(
+      this.adoptTokens(tokens),
+      this.rethrowAsProviderError,
+    );
   }
 
   isExpiringSoon(session: S): boolean {
@@ -272,52 +217,211 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
   }
 
   async getFreshAccessToken(): Promise<string> {
-    const session = await this.getFreshSession();
-    return session.accessToken;
+    return runAuthProgram(
+      Effect.map(this.freshSession(), (session) => session.accessToken),
+      this.rethrowAsProviderError,
+    );
   }
 
   async getFreshSession(): Promise<S> {
-    return this.mapErrors(async () => {
-      const { generation, session } = await this.loadStableSession();
-      if (!session) {
-        throw new SubscriptionOAuthError(
-          this.policy.notSignedInMessage,
-          'expired',
+    return runAuthProgram(this.freshSession(), this.rethrowAsProviderError);
+  }
+
+  private readonly load = Effect.fn('SubscriptionOAuthCoordinator.loadSession')(
+    function* (this: SubscriptionOAuthCoordinator<S>) {
+      const raw = yield* callPort(() => this.storage.get());
+      if (!raw) return null;
+      const parsedJson = safeParseJson(raw);
+      if (Result.isFailure(parsedJson)) {
+        // Present-but-corrupt is not the same as never signed in.
+        log.warn(
+          `Stored subscription session is not valid JSON; treating as signed out: ${toErrorMessage(parsedJson.failure)}`,
         );
+        return null;
       }
-      if (!this.isExpiringSoon(session)) return session;
-      return this.refresh(session, generation);
+      const parsed = this.policy.sessionSchema.safeParse(parsedJson.success);
+      if (!parsed.success) {
+        log.warn(
+          `Stored subscription session failed schema validation; treating as signed out: ${toErrorMessage(parsed.error)}`,
+        );
+        return null;
+      }
+      return parsed.data;
+    },
+  );
+
+  private store(session: S): Effect.Effect<void, AuthPortError> {
+    return callPort(() => this.storage.store(JSON.stringify(session)));
+  }
+
+  private clientCall<A>(
+    call: () => Promise<A>,
+  ): Effect.Effect<A, MachineFailure> {
+    return Effect.tryPromise({ try: call, catch: asMachineFailure });
+  }
+
+  private buildSession(
+    tokens: SubscriptionTokenResponse,
+    previous?: S,
+  ): Effect.Effect<S, MachineFailure> {
+    return Effect.try({
+      try: () => this.policy.buildSession(tokens, this.now(), previous),
+      catch: asMachineFailure,
     });
   }
 
-  private async refresh(previous: S, generation: number): Promise<S> {
-    if (this.refreshInFlight) return this.refreshInFlight;
-    const task = this.performRefresh(previous, generation).finally(() => {
-      if (this.refreshInFlight === task) this.refreshInFlight = null;
-    });
-    this.refreshInFlight = task;
-    return task;
+  /** Serialize one storage write behind the single mutation permit. */
+  private mutate<E>(write: Effect.Effect<void, E>): Effect.Effect<void, E> {
+    return this.sessionMutations.withPermits(1)(write);
   }
 
-  private async performRefresh(previous: S, generation: number): Promise<S> {
-    let tokens: SubscriptionTokenResponse;
-    try {
-      tokens = await this.client.refreshTokens(previous.refreshToken);
-    } catch (error) {
-      if (error instanceof SubscriptionOAuthError && error.kind === 'fatal') {
-        await this.mutateSession(async () => {
-          if (generation !== this.sessionGeneration) return;
-          await this.storage.delete();
-        });
+  private readonly stableSession = Effect.fn(
+    'SubscriptionOAuthCoordinator.stableSession',
+  )(function* (this: SubscriptionOAuthCoordinator<S>) {
+    for (;;) {
+      const generation = this.sessionGeneration;
+      // A mutation that starts after the barrier bumps the generation and
+      // re-loops.
+      yield* awaitWritesAhead(this.sessionMutations);
+      const session = yield* this.load();
+      if (generation === this.sessionGeneration) {
+        return { generation, session };
       }
-      throw error;
     }
-    const session = this.policy.buildSession(tokens, this.now(), previous);
-    await this.mutateSession(async () => {
-      if (generation !== this.sessionGeneration) return;
-      await this.storeSession(session);
-    });
-    if (generation === this.sessionGeneration) return session;
-    return this.sessionAfterSupersede(previous);
+  });
+
+  private supersedeInFlightRefresh(): void {
+    this.sessionGeneration += 1;
+    this.refreshInFlight = null;
   }
+
+  /**
+   * After a refresh is superseded (concurrent login/sign-out), take a stable
+   * storage snapshot and:
+   * - return a *replacement* session (different credentials) — concurrent
+   *   sign-in succeeded; do not force re-auth;
+   * - return a still-fresh same session (rare: supersede without replace);
+   * - fail `expired` when storage is empty (sign-out won);
+   * - fail `transient` when the pre-refresh session is still the only
+   *   stored value and still needs refresh (failed concurrent store, or a
+   *   server-rotated refresh that never landed) — never hand back a known-
+   *   stale token as if the refresh completed.
+   */
+  private readonly sessionAfterSupersede = Effect.fn(
+    'SubscriptionOAuthCoordinator.sessionAfterSupersede',
+  )(function* (this: SubscriptionOAuthCoordinator<S>, previous: S) {
+    const { session } = yield* this.stableSession();
+    if (!session) {
+      return yield* Effect.fail(
+        new SubscriptionOAuthError(
+          this.policy.sessionChangedMessage,
+          'expired',
+        ),
+      );
+    }
+    const replaced =
+      session.accessToken !== previous.accessToken ||
+      session.refreshToken !== previous.refreshToken;
+    if (replaced || !this.isExpiringSoon(session)) {
+      return session;
+    }
+    return yield* Effect.fail(
+      new SubscriptionOAuthError(
+        this.policy.sessionChangedMessage,
+        'transient',
+      ),
+    );
+  });
+
+  private readonly clearSession = Effect.fn(
+    'SubscriptionOAuthCoordinator.signOut',
+  )(function* (this: SubscriptionOAuthCoordinator<S>) {
+    this.supersedeInFlightRefresh();
+    yield* this.mutate(callPort(() => this.storage.delete()));
+  });
+
+  /** Make the session for a fresh grant the stored one, superseding any refresh in flight. */
+  private readonly adoptTokens = Effect.fn(
+    'SubscriptionOAuthCoordinator.adoptTokens',
+  )(function* (
+    this: SubscriptionOAuthCoordinator<S>,
+    tokens: SubscriptionTokenResponse,
+  ) {
+    const session = yield* this.buildSession(tokens);
+    this.supersedeInFlightRefresh();
+    yield* this.mutate(this.store(session));
+    return session;
+  });
+
+  private readonly freshSession = Effect.fn(
+    'SubscriptionOAuthCoordinator.getFreshSession',
+  )(function* (this: SubscriptionOAuthCoordinator<S>) {
+    const { generation, session } = yield* this.stableSession();
+    if (!session) {
+      return yield* Effect.fail(
+        new SubscriptionOAuthError(this.policy.notSignedInMessage, 'expired'),
+      );
+    }
+    if (!this.isExpiringSoon(session)) return session;
+    return yield* this.refresh(session, generation);
+  });
+
+  /** Single-flight refresh: concurrent callers share the in-flight result. */
+  private readonly refresh = Effect.fn('SubscriptionOAuthCoordinator.refresh')(
+    function* (
+      this: SubscriptionOAuthCoordinator<S>,
+      previous: S,
+      generation: number,
+    ) {
+      if (this.refreshInFlight) {
+        return yield* Deferred.await(this.refreshInFlight);
+      }
+      const inFlight = yield* Deferred.make<S, MachineFailure>();
+      this.refreshInFlight = inFlight;
+      return yield* this.performRefresh(previous, generation).pipe(
+        Effect.onExit((exit) =>
+          Effect.sync(() => {
+            Deferred.doneUnsafe(inFlight, exit);
+            if (this.refreshInFlight === inFlight) this.refreshInFlight = null;
+          }),
+        ),
+      );
+    },
+  );
+
+  private readonly performRefresh = Effect.fn(
+    'SubscriptionOAuthCoordinator.performRefresh',
+  )(function* (
+    this: SubscriptionOAuthCoordinator<S>,
+    previous: S,
+    generation: number,
+  ) {
+    const tokens = yield* this.clientCall(() =>
+      this.client.refreshTokens(previous.refreshToken),
+    ).pipe(
+      // A fatal rejection means the stored session is dead: clear it, unless
+      // a concurrent login or sign-out already replaced it.
+      Effect.tapError((error) =>
+        error instanceof SubscriptionOAuthError && error.kind === 'fatal'
+          ? this.mutate(
+              Effect.suspend(() =>
+                generation === this.sessionGeneration
+                  ? callPort(() => this.storage.delete())
+                  : Effect.void,
+              ),
+            )
+          : Effect.void,
+      ),
+    );
+    const session = yield* this.buildSession(tokens, previous);
+    yield* this.mutate(
+      Effect.suspend(() =>
+        generation === this.sessionGeneration
+          ? this.store(session)
+          : Effect.void,
+      ),
+    );
+    if (generation === this.sessionGeneration) return session;
+    return yield* this.sessionAfterSupersede(previous);
+  });
 }

--- a/src/auth/oauth/SubscriptionOAuthCoordinator.ts
+++ b/src/auth/oauth/SubscriptionOAuthCoordinator.ts
@@ -68,24 +68,16 @@ export interface SubscriptionAuthorizeRequest {
   redirectUri: string;
 }
 
-/**
- * Token-endpoint calls. `signal` is the calling fiber's: it aborts the request
- * when the program is interrupted (an aborted loopback login), so the fetch
- * does not run on in the background.
- */
+/** Token grants compose in the calling fiber, including request cancellation. */
 export interface SubscriptionOAuthClient {
-  exchangeAuthorizationCode(
-    params: {
-      code: string;
-      verifier: string;
-      redirectUri: string;
-    },
-    signal?: AbortSignal,
-  ): Promise<SubscriptionTokenResponse>;
+  exchangeAuthorizationCode(params: {
+    code: string;
+    verifier: string;
+    redirectUri: string;
+  }): Effect.Effect<SubscriptionTokenResponse, SubscriptionOAuthError>;
   refreshTokens(
     refreshToken: string,
-    signal?: AbortSignal,
-  ): Promise<SubscriptionTokenResponse>;
+  ): Effect.Effect<SubscriptionTokenResponse, SubscriptionOAuthError>;
 }
 
 export interface SubscriptionSessionStatus {
@@ -145,7 +137,7 @@ export interface SubscriptionOAuthCoordinatorInit<
 type MachineFailure = SubscriptionOAuthError | AuthPortError;
 
 /**
- * A client or policy throw: the provider's own error (a
+ * A policy throw: the provider's own error (a
  * {@link SubscriptionOAuthError} subclass) stays first-class so the machine
  * can read its `kind`; anything else is that call's rejection.
  */
@@ -288,17 +280,6 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
     return callPort(() => this.storage.store(JSON.stringify(session)));
   }
 
-  /**
-   * Adapt one token-endpoint call. The callback receives the fiber's abort
-   * signal, so interrupting the program cancels the request instead of
-   * leaving it to finish in the background.
-   */
-  private clientCall<A>(
-    call: (signal: AbortSignal) => Promise<A>,
-  ): Effect.Effect<A, MachineFailure> {
-    return Effect.tryPromise({ try: call, catch: asMachineFailure });
-  }
-
   private buildSession(
     tokens: SubscriptionTokenResponse,
     previous?: S,
@@ -398,9 +379,7 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
     this: SubscriptionOAuthCoordinator<S>,
     params: { code: string; verifier: string; redirectUri: string },
   ) {
-    const tokens = yield* this.clientCall((signal) =>
-      this.client.exchangeAuthorizationCode(params, signal),
-    );
+    const tokens = yield* this.client.exchangeAuthorizationCode(params);
     return yield* this.adoptTokens(tokens);
   });
 
@@ -451,9 +430,7 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
     previous: S,
     generation: number,
   ) {
-    const tokens = yield* this.clientCall((signal) =>
-      this.client.refreshTokens(previous.refreshToken, signal),
-    ).pipe(
+    const tokens = yield* this.client.refreshTokens(previous.refreshToken).pipe(
       // A fatal rejection means the stored session is dead: clear it, unless
       // a concurrent login or sign-out already replaced it.
       Effect.tapError((error) =>

--- a/src/auth/oauth/SubscriptionOAuthCoordinator.ts
+++ b/src/auth/oauth/SubscriptionOAuthCoordinator.ts
@@ -68,13 +68,24 @@ export interface SubscriptionAuthorizeRequest {
   redirectUri: string;
 }
 
+/**
+ * Token-endpoint calls. `signal` is the calling fiber's: it aborts the request
+ * when the program is interrupted (an aborted loopback login), so the fetch
+ * does not run on in the background.
+ */
 export interface SubscriptionOAuthClient {
-  exchangeAuthorizationCode(params: {
-    code: string;
-    verifier: string;
-    redirectUri: string;
-  }): Promise<SubscriptionTokenResponse>;
-  refreshTokens(refreshToken: string): Promise<SubscriptionTokenResponse>;
+  exchangeAuthorizationCode(
+    params: {
+      code: string;
+      verifier: string;
+      redirectUri: string;
+    },
+    signal?: AbortSignal,
+  ): Promise<SubscriptionTokenResponse>;
+  refreshTokens(
+    refreshToken: string,
+    signal?: AbortSignal,
+  ): Promise<SubscriptionTokenResponse>;
 }
 
 export interface SubscriptionSessionStatus {
@@ -114,6 +125,13 @@ export interface SubscriptionOAuthCoordinatorInit<
   storage: SubscriptionSessionStorage;
   policy: SubscriptionOAuthPolicy<S>;
   client: SubscriptionOAuthClient;
+  /**
+   * Wall clock for the expiry decision. It is not `Clock` (PRD R8) because
+   * `isExpiringSoon` is a public synchronous method and the coordinator
+   * suites fix the time by injecting it here; a `TestClock` would have to
+   * reach the process runtime those suites run on. It converts when that
+   * runtime's clock is injectable from a test.
+   */
   now?: () => number;
   /**
    * Provider error type. The public mutating/refreshing methods (signOut,
@@ -270,8 +288,13 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
     return callPort(() => this.storage.store(JSON.stringify(session)));
   }
 
+  /**
+   * Adapt one token-endpoint call. The callback receives the fiber's abort
+   * signal, so interrupting the program cancels the request instead of
+   * leaving it to finish in the background.
+   */
   private clientCall<A>(
-    call: () => Promise<A>,
+    call: (signal: AbortSignal) => Promise<A>,
   ): Effect.Effect<A, MachineFailure> {
     return Effect.tryPromise({ try: call, catch: asMachineFailure });
   }
@@ -375,8 +398,8 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
     this: SubscriptionOAuthCoordinator<S>,
     params: { code: string; verifier: string; redirectUri: string },
   ) {
-    const tokens = yield* this.clientCall(() =>
-      this.client.exchangeAuthorizationCode(params),
+    const tokens = yield* this.clientCall((signal) =>
+      this.client.exchangeAuthorizationCode(params, signal),
     );
     return yield* this.adoptTokens(tokens);
   });
@@ -428,8 +451,8 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
     previous: S,
     generation: number,
   ) {
-    const tokens = yield* this.clientCall(() =>
-      this.client.refreshTokens(previous.refreshToken),
+    const tokens = yield* this.clientCall((signal) =>
+      this.client.refreshTokens(previous.refreshToken, signal),
     ).pipe(
       // A fatal rejection means the stored session is dead: clear it, unless
       // a concurrent login or sign-out already replaced it.

--- a/src/auth/oauth/SubscriptionOAuthCoordinator.ts
+++ b/src/auth/oauth/SubscriptionOAuthCoordinator.ts
@@ -13,7 +13,7 @@
  * own error type.
  */
 // Third-party imports
-import { Deferred, Effect, Result, Semaphore } from 'effect';
+import { Deferred, Effect, Result } from 'effect';
 
 // Local imports
 import { safeParseJson } from '@common/parsing/safeParseJson';
@@ -22,13 +22,13 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import {
   AuthPortError,
-  awaitWritesAhead,
   callPort,
   runAuthProgram,
+  SerializedWrites,
 } from '../authProgram';
 import { generateOAuthState, generatePkcePair } from './pkce';
 import {
-  rethrowAsProviderAuthError,
+  toProviderAuthError,
   type ProviderAuthErrorCtor,
 } from './providerAuthBridge';
 import { SubscriptionOAuthError } from './subscriptionOAuthError';
@@ -144,7 +144,7 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
   private readonly now: () => number;
   private readonly errorType: ProviderAuthErrorCtor;
   private refreshInFlight: Deferred.Deferred<S, MachineFailure> | null = null;
-  private readonly sessionMutations = Semaphore.makeUnsafe(1);
+  private readonly sessionMutations = new SerializedWrites();
   private sessionGeneration = 0;
 
   constructor(init: SubscriptionOAuthCoordinatorInit<S>) {
@@ -155,12 +155,16 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
     this.errorType = init.errorType;
   }
 
-  /** Re-throw a program failure as the provider's own error type. */
-  private readonly rethrowAsProviderError = (error: MachineFailure): never =>
-    rethrowAsProviderAuthError(
+  /** A program failure as the provider's own error type. */
+  private readonly toProviderError = (error: MachineFailure): unknown =>
+    toProviderAuthError(
       error instanceof AuthPortError ? error.cause : error,
       this.errorType,
     );
+
+  private readonly rethrowAsProviderError = (error: MachineFailure): never => {
+    throw this.toProviderError(error);
+  };
 
   async loadSession(): Promise<S | null> {
     return runAuthProgram(this.load());
@@ -196,12 +200,24 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
     redirectUri: string;
   }): Promise<S> {
     return runAuthProgram(
-      Effect.flatMap(
-        this.clientCall(() => this.client.exchangeAuthorizationCode(params)),
-        (tokens) => this.adoptTokens(tokens),
-      ),
+      this.exchangeCode(params),
       this.rethrowAsProviderError,
     );
+  }
+
+  /**
+   * {@link completeLoginWithCode} as a program, for a caller already on the
+   * runtime (the loopback login yields it, so interrupting that login reaches
+   * the exchange and the store). It fails as the Promise edge would throw:
+   * the provider's own error type for a machine failure, otherwise the port's
+   * own rejection.
+   */
+  loginWithCode(params: {
+    code: string;
+    verifier: string;
+    redirectUri: string;
+  }): Effect.Effect<S, unknown> {
+    return Effect.mapError(this.exchangeCode(params), this.toProviderError);
   }
 
   /** Persist tokens from a successful device-code (or other) grant. */
@@ -270,11 +286,6 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
     });
   }
 
-  /** Serialize one storage write behind the single mutation permit. */
-  private mutate<E>(write: Effect.Effect<void, E>): Effect.Effect<void, E> {
-    return this.sessionMutations.withPermits(1)(write);
-  }
-
   private readonly stableSession = Effect.fn(
     'SubscriptionOAuthCoordinator.stableSession',
   )(function* (this: SubscriptionOAuthCoordinator<S>) {
@@ -282,7 +293,7 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
       const generation = this.sessionGeneration;
       // A mutation that starts after the barrier bumps the generation and
       // re-loops.
-      yield* awaitWritesAhead(this.sessionMutations);
+      yield* this.sessionMutations.awaitIdle();
       const session = yield* this.load();
       if (generation === this.sessionGeneration) {
         return { generation, session };
@@ -290,10 +301,11 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
     }
   });
 
-  private supersedeInFlightRefresh(): void {
+  /** Passed to `SerializedWrites.run` so it shares the queueing segment. */
+  private readonly supersedeInFlightRefresh = (): void => {
     this.sessionGeneration += 1;
     this.refreshInFlight = null;
-  }
+  };
 
   /**
    * After a refresh is superseded (concurrent login/sign-out), take a stable
@@ -336,8 +348,10 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
   private readonly clearSession = Effect.fn(
     'SubscriptionOAuthCoordinator.signOut',
   )(function* (this: SubscriptionOAuthCoordinator<S>) {
-    this.supersedeInFlightRefresh();
-    yield* this.mutate(callPort(() => this.storage.delete()));
+    yield* this.sessionMutations.run(
+      callPort(() => this.storage.delete()),
+      this.supersedeInFlightRefresh,
+    );
   });
 
   /** Make the session for a fresh grant the stored one, superseding any refresh in flight. */
@@ -348,9 +362,23 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
     tokens: SubscriptionTokenResponse,
   ) {
     const session = yield* this.buildSession(tokens);
-    this.supersedeInFlightRefresh();
-    yield* this.mutate(this.store(session));
+    yield* this.sessionMutations.run(
+      this.store(session),
+      this.supersedeInFlightRefresh,
+    );
     return session;
+  });
+
+  private readonly exchangeCode = Effect.fn(
+    'SubscriptionOAuthCoordinator.completeLoginWithCode',
+  )(function* (
+    this: SubscriptionOAuthCoordinator<S>,
+    params: { code: string; verifier: string; redirectUri: string },
+  ) {
+    const tokens = yield* this.clientCall(() =>
+      this.client.exchangeAuthorizationCode(params),
+    );
+    return yield* this.adoptTokens(tokens);
   });
 
   private readonly freshSession = Effect.fn(
@@ -366,17 +394,21 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
     return yield* this.refresh(session, generation);
   });
 
-  /** Single-flight refresh: concurrent callers share the in-flight result. */
+  /**
+   * Single-flight refresh: concurrent callers share the in-flight result. The
+   * check and the claim share one synchronous segment — no `yield*` between
+   * them, since the runtime may yield the fiber at any op boundary — so a
+   * second caller can never mint a second refresh.
+   */
   private readonly refresh = Effect.fn('SubscriptionOAuthCoordinator.refresh')(
     function* (
       this: SubscriptionOAuthCoordinator<S>,
       previous: S,
       generation: number,
     ) {
-      if (this.refreshInFlight) {
-        return yield* Deferred.await(this.refreshInFlight);
-      }
-      const inFlight = yield* Deferred.make<S, MachineFailure>();
+      const existing = this.refreshInFlight;
+      if (existing) return yield* Deferred.await(existing);
+      const inFlight = Deferred.makeUnsafe<S, MachineFailure>();
       this.refreshInFlight = inFlight;
       return yield* this.performRefresh(previous, generation).pipe(
         Effect.onExit((exit) =>
@@ -403,7 +435,7 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
       // a concurrent login or sign-out already replaced it.
       Effect.tapError((error) =>
         error instanceof SubscriptionOAuthError && error.kind === 'fatal'
-          ? this.mutate(
+          ? this.sessionMutations.run(
               Effect.suspend(() =>
                 generation === this.sessionGeneration
                   ? callPort(() => this.storage.delete())
@@ -414,7 +446,7 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
       ),
     );
     const session = yield* this.buildSession(tokens, previous);
-    yield* this.mutate(
+    yield* this.sessionMutations.run(
       Effect.suspend(() =>
         generation === this.sessionGeneration
           ? this.store(session)

--- a/src/auth/oauth/loopbackLogin.ts
+++ b/src/auth/oauth/loopbackLogin.ts
@@ -31,14 +31,18 @@ export class LoopbackTransportUnavailableError extends Error {
   }
 }
 
-/** Minimal coordinator surface the loopback flow needs. */
+/**
+ * Minimal coordinator surface the loopback flow needs. The code exchange is a
+ * program, not a Promise, so it runs on this flow's own fiber: interrupting
+ * the login reaches the token exchange and the session store.
+ */
 export interface LoopbackOAuthCoordinator<S> {
   buildAuthorizeRequest(port: number): SubscriptionAuthorizeRequest;
-  completeLoginWithCode(params: {
+  loginWithCode(params: {
     code: string;
     verifier: string;
     redirectUri: string;
-  }): Promise<S>;
+  }): Effect.Effect<S, unknown>;
 }
 
 export interface OAuthLoopbackLoginOptions<S> {
@@ -226,14 +230,10 @@ export function loginWithOAuthLoopback<S>(
         }),
       );
 
-      return yield* Effect.tryPromise({
-        try: () =>
-          coordinator.completeLoginWithCode({
-            code: authCode,
-            verifier: authorize.verifier,
-            redirectUri: authorize.redirectUri,
-          }),
-        catch: (error) => error,
+      return yield* coordinator.loginWithCode({
+        code: authCode,
+        verifier: authorize.verifier,
+        redirectUri: authorize.redirectUri,
       });
     }),
   );

--- a/src/auth/oauth/providerAuthBridge.ts
+++ b/src/auth/oauth/providerAuthBridge.ts
@@ -22,18 +22,18 @@ export type ProviderAuthErrorCtor = new (
   options?: ErrorOptions,
 ) => ProviderAuthError;
 
-/** Re-throw as the provider error type; leave unrelated errors untouched. */
-export function rethrowAsProviderAuthError(
+/** The provider error type for a machine failure; unrelated errors pass through. */
+export function toProviderAuthError(
   error: unknown,
   ErrorType: ProviderAuthErrorCtor,
-): never {
-  if (error instanceof ErrorType) throw error;
+): unknown {
+  if (error instanceof ErrorType) return error;
   if (error instanceof SubscriptionOAuthError) {
-    throw new ErrorType(error.message, error.kind, error.status, {
+    return new ErrorType(error.message, error.kind, error.status, {
       cause: error,
     });
   }
-  throw error;
+  return error;
 }
 
 /**

--- a/src/auth/xai/XaiSessionCoordinator.ts
+++ b/src/auth/xai/XaiSessionCoordinator.ts
@@ -6,8 +6,6 @@
  */
 import { Effect } from 'effect';
 
-import { effectRuntime } from '@platform/processRuntime';
-
 import { providerAuthError } from '../oauth/providerAuthBridge';
 import {
   SubscriptionOAuthCoordinator,
@@ -100,24 +98,18 @@ const XAI_POLICY: SubscriptionOAuthPolicy<XaiSession> = {
 
 export class XaiSessionCoordinator extends SubscriptionOAuthCoordinator<XaiSession> {
   constructor(init: XaiSessionCoordinatorInit) {
-    // The grant programs run here at the coordinator's Promise boundary
-    // until the coordinator itself is an Effect program.
     const client = init.client ?? {
       exchangeAuthorizationCode: (params: {
         code: string;
         verifier: string;
         redirectUri: string;
       }) =>
-        effectRuntime().runPromise(
-          exchangeAuthorizationCode(params).pipe(
-            Effect.mapError((error) => providerAuthError(error, XaiAuthError)),
-          ),
+        exchangeAuthorizationCode(params).pipe(
+          Effect.mapError((error) => providerAuthError(error, XaiAuthError)),
         ),
       refreshTokens: (refreshToken: string) =>
-        effectRuntime().runPromise(
-          refreshTokens(refreshToken).pipe(
-            Effect.mapError((error) => providerAuthError(error, XaiAuthError)),
-          ),
+        refreshTokens(refreshToken).pipe(
+          Effect.mapError((error) => providerAuthError(error, XaiAuthError)),
         ),
     };
     super({

--- a/src/test-kernel/auth/CodexLoopbackLogin.vitest.ts
+++ b/src/test-kernel/auth/CodexLoopbackLogin.vitest.ts
@@ -79,7 +79,7 @@ describe('Codex loopback login', () => {
   it('does not exchange a code when cancellation follows its callback', async () => {
     const controller = new AbortController();
     let request!: SubscriptionAuthorizeRequest;
-    const completeLoginWithCode = vi.fn();
+    const loginWithCode = vi.fn();
     const completion = runLogin(
       {
         coordinator: coordinatorStub({
@@ -89,7 +89,7 @@ describe('Codex loopback login', () => {
             request = loopbackRequest(port);
             return request;
           },
-          completeLoginWithCode,
+          loginWithCode,
         }),
         openBrowser: async () => {
           const callback = new URL(request.redirectUri);
@@ -103,7 +103,7 @@ describe('Codex loopback login', () => {
     );
 
     await expect(completion).rejects.toThrow(/interrupted/);
-    expect(completeLoginWithCode).not.toHaveBeenCalled();
+    expect(loginWithCode).not.toHaveBeenCalled();
   });
 
   it('ignores stale callback errors and accepts a later valid callback', async () => {
@@ -111,7 +111,7 @@ describe('Codex loopback login', () => {
     const verifier = 'verifier';
     const expectedSession = testSession();
     let request!: SubscriptionAuthorizeRequest;
-    const completeLoginWithCode = vi.fn(async () => expectedSession);
+    const loginWithCode = vi.fn(() => Effect.succeed(expectedSession));
     const coordinator = coordinatorStub({
       buildAuthorizeRequest: (port: number): SubscriptionAuthorizeRequest => {
         const redirectUri = `http://localhost:${port}${CODEX_CALLBACK_PATH}`;
@@ -126,7 +126,7 @@ describe('Codex loopback login', () => {
         };
         return request;
       },
-      completeLoginWithCode,
+      loginWithCode,
     });
 
     const session = await runLogin({
@@ -150,7 +150,7 @@ describe('Codex loopback login', () => {
     });
 
     expect(session).toEqual(expectedSession);
-    expect(completeLoginWithCode).toHaveBeenCalledWith({
+    expect(loginWithCode).toHaveBeenCalledWith({
       code: 'valid-code',
       verifier,
       redirectUri: request.redirectUri,

--- a/src/test-kernel/auth/CodexSessionCoordinator.vitest.ts
+++ b/src/test-kernel/auth/CodexSessionCoordinator.vitest.ts
@@ -1,4 +1,4 @@
-import { Exit } from 'effect';
+import { Deferred, Effect, Exit } from 'effect';
 import pDefer from 'p-defer';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -163,7 +163,7 @@ describe('CodexSessionCoordinator', () => {
 
   it('refreshes proactively within the 5-minute buffer', async () => {
     const storage = memoryStorage(session({ expiresAtMs: NOW + 60_000 }));
-    const refreshTokens = vi.fn(async () => tokenResponse());
+    const refreshTokens = vi.fn(() => Effect.succeed(tokenResponse()));
     const coordinator = makeCoordinator(storage, { refreshTokens });
     expect(await coordinator.getFreshAccessToken()).toBe('access-1');
     expect(refreshTokens).toHaveBeenCalledOnce();
@@ -172,8 +172,8 @@ describe('CodexSessionCoordinator', () => {
 
   it('single-flights concurrent refreshes', async () => {
     const storage = memoryStorage(expiredSession());
-    const { promise: pending, resolve } = pDefer<CodexTokenResponse>();
-    const refreshTokens = vi.fn(() => pending);
+    const pending = Deferred.makeUnsafe<CodexTokenResponse, CodexAuthError>();
+    const refreshTokens = vi.fn(() => Deferred.await(pending));
     const coordinator = makeCoordinator(storage, { refreshTokens });
 
     const a = coordinator.getFreshAccessToken();
@@ -182,7 +182,7 @@ describe('CodexSessionCoordinator', () => {
     await delay(0);
     expect(refreshTokens).toHaveBeenCalledOnce();
 
-    resolve(tokenResponse());
+    Deferred.doneUnsafe(pending, Effect.succeed(tokenResponse()));
     const [ra, rb] = await Promise.all([a, b]);
 
     expect(ra).toBe('access-1');
@@ -192,8 +192,8 @@ describe('CodexSessionCoordinator', () => {
 
   it('does not restore a session when sign-out races with refresh', async () => {
     const storage = memoryStorage(expiredSession());
-    const { promise: pending, resolve } = pDefer<CodexTokenResponse>();
-    const refreshTokens = vi.fn(() => pending);
+    const pending = Deferred.makeUnsafe<CodexTokenResponse, CodexAuthError>();
+    const refreshTokens = vi.fn(() => Deferred.await(pending));
     const coordinator = makeCoordinator(storage, { refreshTokens });
 
     const token = coordinator.getFreshAccessToken();
@@ -201,7 +201,7 @@ describe('CodexSessionCoordinator', () => {
     expect(refreshTokens).toHaveBeenCalledOnce();
 
     await coordinator.signOut();
-    resolve(tokenResponse());
+    Deferred.doneUnsafe(pending, Effect.succeed(tokenResponse()));
 
     await expect(token).rejects.toMatchObject({
       kind: 'expired',
@@ -212,7 +212,7 @@ describe('CodexSessionCoordinator', () => {
 
   it('does not restore a session when sign-out races with refresh storage', async () => {
     const storage = gatedStorage('store', expiredSession());
-    const refreshTokens = vi.fn(async () => tokenResponse());
+    const refreshTokens = vi.fn(() => Effect.succeed(tokenResponse()));
     const coordinator = makeCoordinator(storage, { refreshTokens });
 
     const token = coordinator.getFreshAccessToken();
@@ -230,11 +230,11 @@ describe('CodexSessionCoordinator', () => {
 
   it('does not erase a newer login with a blocked fatal-refresh deletion', async () => {
     const storage = gatedStorage('delete', expiredSession());
-    const refreshTokens = vi.fn(async () => {
-      throw new CodexAuthError('revoked', 'fatal', 401);
-    });
-    const exchangeAuthorizationCode = vi.fn(async () =>
-      newLoginTokenResponse(),
+    const refreshTokens = vi.fn(() =>
+      Effect.fail(new CodexAuthError('revoked', 'fatal', 401)),
+    );
+    const exchangeAuthorizationCode = vi.fn(() =>
+      Effect.succeed(newLoginTokenResponse()),
     );
     const coordinator = makeCoordinator(storage, {
       exchangeAuthorizationCode,
@@ -258,7 +258,7 @@ describe('CodexSessionCoordinator', () => {
 
   it('does not start a stale refresh for a caller entering during sign-out', async () => {
     const storage = gatedStorage('delete', expiredSession());
-    const refreshTokens = vi.fn(async () => tokenResponse());
+    const refreshTokens = vi.fn(() => Effect.succeed(tokenResponse()));
     const coordinator = makeCoordinator(storage, { refreshTokens });
 
     const signOut = coordinator.signOut();
@@ -278,9 +278,9 @@ describe('CodexSessionCoordinator', () => {
 
   it('does not overwrite a newer login for a caller entering during login', async () => {
     const storage = gatedStorage('store', expiredSession());
-    const refreshTokens = vi.fn(async () => tokenResponse());
-    const exchangeAuthorizationCode = vi.fn(async () =>
-      newLoginTokenResponse(),
+    const refreshTokens = vi.fn(() => Effect.succeed(tokenResponse()));
+    const exchangeAuthorizationCode = vi.fn(() =>
+      Effect.succeed(newLoginTokenResponse()),
     );
     const coordinator = makeCoordinator(storage, {
       exchangeAuthorizationCode,
@@ -313,8 +313,8 @@ describe('CodexSessionCoordinator', () => {
         await gated.delete();
       },
     };
-    const exchangeAuthorizationCode = vi.fn(async () =>
-      newLoginTokenResponse(),
+    const exchangeAuthorizationCode = vi.fn(() =>
+      Effect.succeed(newLoginTokenResponse()),
     );
     const coordinator = makeCoordinator(storage, { exchangeAuthorizationCode });
     const controller = new AbortController();
@@ -347,8 +347,8 @@ describe('CodexSessionCoordinator', () => {
 
   it('retries a session read superseded while storage is blocked', async () => {
     const storage = gatedStorage('get', session());
-    const exchangeAuthorizationCode = vi.fn(async () =>
-      newLoginTokenResponse(),
+    const exchangeAuthorizationCode = vi.fn(() =>
+      Effect.succeed(newLoginTokenResponse()),
     );
     const coordinator = makeCoordinator(storage, {
       exchangeAuthorizationCode,
@@ -365,10 +365,10 @@ describe('CodexSessionCoordinator', () => {
 
   it('does not clear a newer login when a stale refresh is rejected', async () => {
     const storage = memoryStorage(expiredSession());
-    const { promise: pending, reject } = pDefer<CodexTokenResponse>();
-    const refreshTokens = vi.fn(() => pending);
-    const exchangeAuthorizationCode = vi.fn(async () =>
-      newLoginTokenResponse(),
+    const pending = Deferred.makeUnsafe<CodexTokenResponse, CodexAuthError>();
+    const refreshTokens = vi.fn(() => Deferred.await(pending));
+    const exchangeAuthorizationCode = vi.fn(() =>
+      Effect.succeed(newLoginTokenResponse()),
     );
     const coordinator = makeCoordinator(storage, {
       exchangeAuthorizationCode,
@@ -380,7 +380,10 @@ describe('CodexSessionCoordinator', () => {
     expect(refreshTokens).toHaveBeenCalledOnce();
 
     await completeLogin(coordinator);
-    reject(new CodexAuthError('revoked', 'fatal', 401));
+    Deferred.doneUnsafe(
+      pending,
+      Effect.fail(new CodexAuthError('revoked', 'fatal', 401)),
+    );
 
     await expect(token).rejects.toMatchObject({
       kind: 'fatal',
@@ -392,10 +395,10 @@ describe('CodexSessionCoordinator', () => {
 
   it('returns the newer login when a successful refresh is superseded', async () => {
     const storage = memoryStorage(expiredSession());
-    const { promise: pending, resolve } = pDefer<CodexTokenResponse>();
-    const refreshTokens = vi.fn(() => pending);
-    const exchangeAuthorizationCode = vi.fn(async () =>
-      newLoginTokenResponse(),
+    const pending = Deferred.makeUnsafe<CodexTokenResponse, CodexAuthError>();
+    const refreshTokens = vi.fn(() => Deferred.await(pending));
+    const exchangeAuthorizationCode = vi.fn(() =>
+      Effect.succeed(newLoginTokenResponse()),
     );
     const coordinator = makeCoordinator(storage, {
       exchangeAuthorizationCode,
@@ -407,7 +410,7 @@ describe('CodexSessionCoordinator', () => {
     expect(refreshTokens).toHaveBeenCalledOnce();
 
     await completeLogin(coordinator);
-    resolve(tokenResponse());
+    Deferred.doneUnsafe(pending, Effect.succeed(tokenResponse()));
 
     // Concurrent sign-in is not a re-auth failure — hand back the new session.
     await expect(token).resolves.toBe('access-new');
@@ -420,15 +423,17 @@ describe('CodexSessionCoordinator', () => {
     // concurrent store that failed after supersede, or rewrote the same
     // blob) must not hand back the stale token as if refresh completed.
     const storage = memoryStorage(expiredSession());
-    const { promise: pending, resolve } = pDefer<CodexTokenResponse>();
-    const refreshTokens = vi.fn(() => pending);
-    const exchangeAuthorizationCode = vi.fn(async () =>
-      tokenResponse({
-        access_token: 'access-0',
-        refresh_token: 'refresh-0',
-        // Still inside the proactive refresh buffer.
-        expires_in: 60,
-      }),
+    const pending = Deferred.makeUnsafe<CodexTokenResponse, CodexAuthError>();
+    const refreshTokens = vi.fn(() => Deferred.await(pending));
+    const exchangeAuthorizationCode = vi.fn(() =>
+      Effect.succeed(
+        tokenResponse({
+          access_token: 'access-0',
+          refresh_token: 'refresh-0',
+          // Still inside the proactive refresh buffer.
+          expires_in: 60,
+        }),
+      ),
     );
     const coordinator = makeCoordinator(storage, {
       exchangeAuthorizationCode,
@@ -440,7 +445,10 @@ describe('CodexSessionCoordinator', () => {
     expect(refreshTokens).toHaveBeenCalledOnce();
 
     await completeLogin(coordinator);
-    resolve(tokenResponse({ access_token: 'access-stale-refresh' }));
+    Deferred.doneUnsafe(
+      pending,
+      Effect.succeed(tokenResponse({ access_token: 'access-stale-refresh' })),
+    );
 
     await expect(token).rejects.toMatchObject({
       kind: 'transient',
@@ -451,8 +459,8 @@ describe('CodexSessionCoordinator', () => {
 
   it('keeps the previous refresh token when the response omits a new one', async () => {
     const storage = memoryStorage(expiredSession());
-    const refreshTokens = vi.fn(async () =>
-      tokenResponse({ refresh_token: undefined }),
+    const refreshTokens = vi.fn(() =>
+      Effect.succeed(tokenResponse({ refresh_token: undefined })),
     );
     const coordinator = makeCoordinator(storage, { refreshTokens });
     await coordinator.getFreshAccessToken();
@@ -461,9 +469,9 @@ describe('CodexSessionCoordinator', () => {
 
   it('clears the session and surfaces re-auth on a fatal refresh', async () => {
     const storage = memoryStorage(expiredSession());
-    const refreshTokens = vi.fn(async () => {
-      throw new CodexAuthError('revoked', 'fatal', 401);
-    });
+    const refreshTokens = vi.fn(() =>
+      Effect.fail(new CodexAuthError('revoked', 'fatal', 401)),
+    );
     const coordinator = makeCoordinator(storage, { refreshTokens });
 
     await expect(coordinator.getFreshAccessToken()).rejects.toMatchObject({
@@ -475,9 +483,9 @@ describe('CodexSessionCoordinator', () => {
 
   it('keeps the session on a transient refresh failure', async () => {
     const storage = memoryStorage(expiredSession());
-    const refreshTokens = vi.fn(async () => {
-      throw new CodexAuthError('upstream 502', 'transient', 502);
-    });
+    const refreshTokens = vi.fn(() =>
+      Effect.fail(new CodexAuthError('upstream 502', 'transient', 502)),
+    );
     const coordinator = makeCoordinator(storage, { refreshTokens });
 
     await expect(coordinator.getFreshAccessToken()).rejects.toMatchObject({

--- a/src/test-kernel/auth/CodexSessionCoordinator.vitest.ts
+++ b/src/test-kernel/auth/CodexSessionCoordinator.vitest.ts
@@ -1,3 +1,4 @@
+import { Exit } from 'effect';
 import pDefer from 'p-defer';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -12,6 +13,7 @@ import type {
   CodexTokenResponse,
 } from '@auth/codex/codexSessionTypes';
 import { codexAccountLabel } from '@auth/codex/codexSessionTypes';
+import { effectRuntime } from '@platform/processRuntime';
 import { delay } from '@utils/core';
 
 const NOW = 1_900_000_000_000;
@@ -295,6 +297,52 @@ describe('CodexSessionCoordinator', () => {
     expect(await token).toBe('access-new');
     expect(refreshTokens).not.toHaveBeenCalled();
     expect(storage.peek()?.accessToken).toBe('access-new');
+  });
+
+  it('finishes an interrupted login store before a later sign-out runs', async () => {
+    const gated = gatedStorage('store');
+    const ops: string[] = [];
+    const storage: CodexSessionStorage = {
+      get: gated.get,
+      store: async (value) => {
+        ops.push('store');
+        await gated.store(value);
+      },
+      delete: async () => {
+        ops.push('delete');
+        await gated.delete();
+      },
+    };
+    const exchangeAuthorizationCode = vi.fn(async () =>
+      newLoginTokenResponse(),
+    );
+    const coordinator = makeCoordinator(storage, { exchangeAuthorizationCode });
+    const controller = new AbortController();
+
+    // The loopback login's run boundary: the host signal interrupts the
+    // login's fiber while its session store is blocked mid-write.
+    const login = effectRuntime().runPromiseExit(
+      coordinator.loginWithCode({
+        code: 'new-code',
+        verifier: 'new-verifier',
+        redirectUri: 'http://localhost:1455/auth/callback',
+      }),
+      { signal: controller.signal },
+    );
+    await gated.gateReached;
+    controller.abort();
+    const signOut = coordinator.signOut();
+    await delay(0);
+
+    // The store cannot be cancelled, so it keeps the permit: the sign-out
+    // queues behind it instead of running beside it.
+    expect(ops).toEqual(['store']);
+    gated.release();
+
+    expect(Exit.isSuccess(await login)).toBe(false);
+    await signOut;
+    expect(ops).toEqual(['store', 'delete']);
+    expect(gated.peek()).toBeUndefined();
   });
 
   it('retries a session read superseded while storage is blocked', async () => {

--- a/src/test-kernel/auth/SupabaseSessionLifecycle.vitest.ts
+++ b/src/test-kernel/auth/SupabaseSessionLifecycle.vitest.ts
@@ -14,6 +14,7 @@ import {
   type SupabaseSessionStorage,
 } from '@auth/SupabaseSession';
 import { createDeferred } from '@test/support/asyncTestUtils';
+import { delay } from '@utils/core';
 import type {
   Session as SupabaseNativeSession,
   SupabaseClient as Client,
@@ -510,6 +511,39 @@ describe('SupabaseSession', () => {
 
       assert.equal(await tokenPromise, null);
       assert.equal(read(), null);
+    });
+
+    it('does not return a refreshed token when a clear is queued behind its store', async () => {
+      const storeStarted = createDeferred();
+      const allowStore = createDeferred();
+      let value: string | undefined = JSON.stringify(expiredSession());
+      const storage: SupabaseSessionStorage = {
+        get: async () => value,
+        store: async (sessionData) => {
+          storeStarted.resolve();
+          await allowStore.promise;
+          value = sessionData;
+        },
+        delete: async () => {
+          value = undefined;
+        },
+      };
+      const coordinator = new SupabaseSessionCoordinator({
+        ...COORDINATOR_CONFIG,
+        storage,
+        getClient: () => createClient(),
+      });
+
+      const tokenPromise = coordinator.ensureFreshToken();
+      await storeStarted.promise;
+      // The refresh's store is blocked mid-write; the clear queues behind it.
+      const clearPromise = coordinator.clearSession();
+      await delay(0);
+      allowStore.resolve();
+
+      assert.equal(await tokenPromise, null);
+      await clearPromise;
+      assert.equal(parseStoredSupabaseSession(value), null);
     });
 
     it('reclassifies when a new session replaces one whose refresh failed', async () => {

--- a/src/test-kernel/auth/XaiSessionCoordinator.vitest.ts
+++ b/src/test-kernel/auth/XaiSessionCoordinator.vitest.ts
@@ -1,3 +1,4 @@
+import { Deferred, Effect } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -8,7 +9,6 @@ import {
 import { XaiSessionCoordinator } from '@auth/xai/XaiSessionCoordinator';
 import type { XaiSession, XaiTokenResponse } from '@auth/xai/xaiSessionTypes';
 import * as logger from '@logger/logUtils';
-import { createDeferred } from '@test/support/asyncTestUtils';
 
 const NOW = 1_900_000_000_000;
 const FIVE_MIN = 5 * 60 * 1000;
@@ -116,7 +116,7 @@ describe('XaiSessionCoordinator', () => {
     const coordinator = makeCoordinator({
       storage,
       client: makeClient({
-        exchangeAuthorizationCode: vi.fn(async () => tokens()),
+        exchangeAuthorizationCode: vi.fn(() => Effect.succeed(tokens())),
       }),
     });
     const stored = await coordinator.completeLoginWithCode({
@@ -131,8 +131,11 @@ describe('XaiSessionCoordinator', () => {
 
   it('refreshes when within the buffer and single-flights concurrent callers', async () => {
     const storage = memoryStorage(session({ expiresAtMs: NOW + FIVE_MIN - 1 }));
-    const refreshDeferred = createDeferred<XaiTokenResponse>();
-    const refreshTokens = vi.fn(() => refreshDeferred.promise);
+    const refreshDeferred = Deferred.makeUnsafe<
+      XaiTokenResponse,
+      XaiAuthError
+    >();
+    const refreshTokens = vi.fn(() => Deferred.await(refreshDeferred));
     const coordinator = makeCoordinator({
       storage,
       client: makeClient({ refreshTokens }),
@@ -144,7 +147,10 @@ describe('XaiSessionCoordinator', () => {
     await vi.waitFor(() => {
       expect(refreshTokens).toHaveBeenCalledTimes(1);
     });
-    refreshDeferred.resolve(tokens({ access_token: 'access-fresh' }));
+    Deferred.doneUnsafe(
+      refreshDeferred,
+      Effect.succeed(tokens({ access_token: 'access-fresh' })),
+    );
     await expect(a).resolves.toBe('access-fresh');
     await expect(b).resolves.toBe('access-fresh');
   });
@@ -154,9 +160,9 @@ describe('XaiSessionCoordinator', () => {
     const coordinator = makeCoordinator({
       storage,
       client: makeClient({
-        refreshTokens: vi.fn(async () => {
-          throw new XaiAuthError('revoked', 'fatal', 400);
-        }),
+        refreshTokens: vi.fn(() =>
+          Effect.fail(new XaiAuthError('revoked', 'fatal', 400)),
+        ),
       }),
     });
     await expect(coordinator.getFreshAccessToken()).rejects.toMatchObject({


### PR DESCRIPTION
## Summary

Serializes Supabase and subscription OAuth session writes with Effect semaphores. Concurrent refresh callers share one result, and a newer sign-in or sign-out supersedes stale refresh work. A storage write that already holds its permit finishes before a following mutation, including when its caller is interrupted. Fresh-token reads wait for queued writes before taking a stable session snapshot.

The loopback login composes `loginWithCode` directly with the token request. `SubscriptionOAuthClient` now returns Effect programs, so the Codex and xAI coordinators compose the native grant clients from #11922 without four intervening `runPromise` calls. Provider errors retain their classification, and storage failures reach the Promise caller as the original error. Loopback interruption reaches the network request and response body; an already-started storage write remains uninterruptible until it releases its permit. The existing device-login policy that completes an approved login uninterruptibly is unchanged.

## Issue acceptance gates

This implements the session-write and refresh-ownership work from `docs/prds/2026-08-26-effect-4-runtime-migration.md`. The current-generation checks, atomic refresh claim, counted write barrier, provider error identities and interruption ordering are preserved.

The amended migration rules are not fully satisfied by the original PR: `authProgram.ts` still runs an Effect below the permitted host/tool/SDK boundaries, and `SupabaseClient.ts` retains five raw catches under its Effect import and an `@adapter-until` marker. These remain unresolved; the passing build and behavior checks do not establish migration-rule compliance.

## Single source of truth

- `SerializedWrites` owns one write at a time, completion of a write holding the permit, and the queued-write count used by the idle barrier. The OAuth generation change and write registration share one synchronous segment.
- Each coordinator owns its session generation and its single in-flight refresh `Deferred`. Reading and assigning the refresh claim have no intervening fiber boundary.
- A refresh checks whether its result is still current while holding the write permit. Supabase also observes mutations queued behind its store before returning the result.
- The existing OAuth grant clients own token requests. The coordinator maps their failures to the provider's existing error type.

## Duplication and abstraction budget

Removes three `p-queue` serializers, two Promise-based refresh chains, error-translation wrappers, and the Supabase coordinator's ledger that reconstructed storage changes after they occurred. The integration with #11922 also removes four nested execution calls and the shared coordinator's Promise client adapter.

`SerializedWrites` adds the counted idle barrier that a semaphore alone does not provide. `AuthPortError`, `callPort`, and `runAuthProgram` centralize existing Promise-port error handling, although the remaining auth-level execution boundary must still move under the amended migration rules.

## Net elements (R6)

Relative to main `411c501ef8eff066311d65e2e5dd5560f15d263a`:

- 12 files changed, 1 added (`src/auth/authProgram.ts`), none deleted.
- 882 lines added and 453 removed: net +429, including +333 production lines and +96 test lines. Generator programs, the shared barrier and its invariant comments account for the increase.
- Four exports added: `AuthPortError`, `callPort`, `SerializedWrites`, and `runAuthProgram`. `toProviderAuthError` replaces `rethrowAsProviderAuthError`, for net +4 exports.
- Two classes added and one private interface removed. Three `p-queue` imports removed. No ratchet or dead-code baseline changes.

## Consumer counts (R8)

- `toProviderAuthError`: one consumer, the shared subscription OAuth coordinator.
- `LoopbackOAuthCoordinator.loginWithCode`: one call site in the shared loopback program, two provider wrapper type consumers and the existing loopback suite. The coordinator's Promise-facing `completeLoginWithCode` remains available to its existing callers.
- `SubscriptionOAuthClient`: two provider implementations and two existing coordinator suites now supply Effect programs. The native token-client implementations from #11922 remain unchanged.
- `SerializedWrites`: two coordinator consumers. `runAuthProgram` and `callPort`: three auth-module consumers each. `AuthPortError` is used by both coordinators and the shared error boundary.
- No event emit or subscription path changes.

## Host impact

Extension, desktop and CLI keep their existing Promise-facing session APIs and provider error identities. Their loopback sign-in programs preserve main's Effect return type and host-owned execution boundary. Cancelling a loopback login can interrupt its token exchange; a following sign-out waits for any storage write already in progress. Device-login completion retains main's existing interruption policy.

## Scheduled refactoring

The original PR's remaining migration work is to make the `AuthTokenProvider` and PKCE operation interfaces Effect-typed, move auth execution to the permitted host boundaries, and remove the adapter marker and remaining raw catches. The OAuth coordinator's public synchronous expiry check still uses its injected wall clock. These are existing limitations, not completed acceptance gates.

## Integration verification

Base: `411c501ef8eff066311d65e2e5dd5560f15d263a`, including #11922. Final head: `bf6a3b9e5950e78183098a307616fd828f6bfc95`.

The loopback test conflict preserves main's Effect execution and interruption behavior while using the coordinator's `loginWithCode` program. The three token-client conflicts retain main's implementations byte-for-byte. The necessary interface integration composes their Effects directly and updates the two existing coordinator suites. Independent review verified cancellation, provider error classification, guarded writes, the counted barrier and the atomic refresh claim with no actionable findings.

## Validation

Passed on the final integration:

- `npm run format`
- Full `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- Authentication and affected CLI suites: 22 files, 207 tests
- `npm run check:dead-code-ratchet`: 286/286 findings, no new findings
- `node scripts/check-browser-safe-utils.mjs`
- `npm test -- --maxWorkers=4`: 764 files and 9,071 tests passed; one file and six tests skipped
- Normal commit and pre-push hooks

`npm run check:effect-migration-ratchet` remains failing: 51 growth rows, 25 stale rows and two adapter markers across main and the original PR. Comparing the checker's actual source counts against main and the previous PR head verifies that this integration adds no counted mechanisms or markers and removes the four provider execution calls. All ratchet files remain identical to main. The original PR's specific unresolved violations are listed under Issue acceptance gates above.
