### PR TITLE
docs(agents): fix stale Webview Consistency Patterns section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ subset of the same files under the same options.
 - Use the path aliases defined in `tsconfig.json` (for example `@frontend/*`, `@common/*`, `@utils/*`) instead of long relative import chains.
 - Document functions with concise comments. Use JSDoc style for public APIs.
 - Keep functions small and focused; extract helpers or modules when logic becomes complex.
-- Keep the directory structure aligned among different webviews (webview, progressView, settingsView). Use the same folder names for modules of the same type and functionality but in different webviews.
+- Keep the directory structure aligned among different webviews where they share a concern (e.g. `components/`, `styles/`). `progressView` and `settingsView` intentionally diverge beyond that — see "Webview Consistency Patterns" for which folders are pattern-specific (`settingsView/frontend/slices/` vs `progressView/frontend/formatters/`) rather than a naming drift to fix.
 - Place a host's own request handling beside the view it serves (e.g. `packages/extension/src/progressView/extensionHostRequests.ts`, `packages/desktop/src/main/desktopHostRequests.ts`). Host-neutral session bridging lives under `src/controllers/session/` (e.g. `src/controllers/session/SessionBridge.ts`), per the `controllers/` host-neutral-orchestration rule.
 
 ### Naming conventions
@@ -540,13 +540,40 @@ travel through the flows are described in `docs/architecture/2026-06-20-pocketfl
 
 ### Webview Consistency Patterns
 
-- **Base Classes**: All webviews (webview, progressView, settingsView) extend `BaseViewContentProvider` and `BaseViewMessageHandler` from `packages/extension/src/common/webview/` for consistent error handling, logging, and cleanup.
-- **Naming Convention**: Follow `[Domain]View[Component]` pattern (e.g., `MainViewContentProvider`, `SettingsViewMessageHandler`, `ProgressViewContentProvider`)
-- **Command Constants**: Define commands in `src/shared/ipc.ts` — `COMMON_COMMANDS` plus the per-view groups (`MAIN_VIEW_COMMANDS`, etc.) in that same file — use constants, not string literals
-- **Message Handlers**: Delegate to domain-specific manager classes (FileManager, SettingsManager, etc.) for separation of concerns
+Two message-passing architectures coexist for the extension's views. Match the
+one the view you're touching already uses — `BaseViewMessageHandler` is not a
+default to reach for, it's `settingsView`'s pattern specifically:
+
+- **`settingsView`** is request/response: `SettingsViewMessageHandler`
+  (`packages/extension/src/settingsView/`) extends `BaseViewMessageHandler`
+  (`packages/extension/src/common/webview/`) for inbound dispatch through a
+  `HandlerRegistry`, delegating tab-shaped groups to focused handler classes in
+  `settingsView/handlers/` (`AgentHandlers`, `LatexSettingsHandlers`,
+  `MemoryHandlers`, `GitHubSubscriptionHandlers`, `SubscriptionHandlers`).
+  Commands are named constants in `src/shared/ipc.ts` (`COMMON_COMMANDS`,
+  `SETTINGS_VIEW_CMD`, `PROFILE_VIEW_COMMANDS`, `MEMORY_VIEW_COMMANDS`) — use
+  those, not string literals. Frontend state lives in Redux-style slices under
+  `settingsView/frontend/slices/`.
+- **`progressView`** (the sidebar and editor-tab conversation shell) is
+  event-fold, not request/response: `ProgressViewProvider` implements
+  `vscode.WebviewViewProvider` directly — composed with
+  `BundledViewContentProvider` for shared webview boilerplate, not extending
+  `BaseViewContentProvider` — and routes through `SessionBridge` /
+  `HostDraftRequests` as typed `runtime.request` / `host.request` calls (see
+  `docs/proposals/2026-09-03-one-view-state-three-renderers.md`). Its Lit
+  components (`progressView/frontend/components/`) read the `SessionView` fold
+  (`src/shared/session/sessionView.ts`) and `Surface` records as properties
+  directly; there is no command-constant registry or slice layer here.
+- **`webview/frontend`** is not a third view with its own content provider —
+  it's the shared Lit component library (banners, file pickers, onboarding
+  cards) that `progressView` composes. There is no `MainViewContentProvider`.
+- **Naming Convention**: within whichever pattern applies, follow
+  `[Domain]View[Component]` (e.g. `SettingsViewMessageHandler`,
+  `ProgressViewProvider`). Adding a genuinely new pattern needs an update to
+  this section, not a silent third variant.
 - **Client-Side State**: Add empty handlers with `/* State saved client-side */` comment for checkbox/toggle operations
 - **Resource Access**: Include all common module paths in `localResourceRoots` to prevent 401 errors
-- **Module Structure**: Keep UI managers focused on a single responsibility
+- **Module Structure**: Keep UI managers/handlers focused on a single responsibility
 - **Trust Dependencies**: Use APIs as documented. When behavior is unclear, check the source in `node_modules/` first. Add a workaround only for a documented quirk, with a comment explaining it
 - **Dropdown Menus**: Should close when clicking outside, not just on toggle
 - **CSS Organization**: Keep per-component styles as TypeScript in each view's `frontend/` directory, shared tokens in `packages/extension/src/common/styles/common.css`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -552,13 +552,18 @@ default to reach for, it's `settingsView`'s pattern specifically:
   `MemoryHandlers`, `GitHubSubscriptionHandlers`, `SubscriptionHandlers`).
   Commands are named constants in `src/shared/ipc.ts` (`COMMON_COMMANDS`,
   `SETTINGS_VIEW_CMD`, `PROFILE_VIEW_COMMANDS`, `MEMORY_VIEW_COMMANDS`) — use
-  those, not string literals. Frontend state lives in Redux-style slices under
-  `settingsView/frontend/slices/`.
+  those, not string literals. Frontend state lives in module-level reactive
+  signals declared in `settingsView/frontend/settingsState.ts`
+  (`trackedSignal`); `settingsView/frontend/slices/` holds the domain-grouped
+  outbound message-handler registries (`agentSelectionSlice.ts`,
+  `latexSlice.ts`, etc., each `satisfies Partial<SettingsViewOutboundHandlerRegistry>`)
+  that mutate those signals — there is no Redux store or reducer.
 - **`progressView`** (the sidebar and editor-tab conversation shell) is
   event-fold, not request/response: `ProgressViewProvider` implements
   `vscode.WebviewViewProvider` directly — composed with
-  `BundledViewContentProvider` for shared webview boilerplate, not extending
-  `BaseViewContentProvider` — and routes through `SessionBridge` /
+  `BundledViewContentProvider` (`common/webview/BaseViewContentProvider.ts`;
+  there is no `BaseViewContentProvider` class, despite the file name) for
+  shared webview boilerplate — and routes through `SessionBridge` /
   `HostDraftRequests` as typed `runtime.request` / `host.request` calls (see
   `docs/proposals/2026-09-03-one-view-state-three-renderers.md`). Its Lit
   components (`progressView/frontend/components/`) read the `SessionView` fold


### PR DESCRIPTION
## Summary

Scheduled codebase audit for confusing/overlapped responsibilities. Surveyed three areas in parallel (webview trees, agent runtime/session-event ownership, storage/tools/model-handler boundaries). Two areas came back clean — both had already been through recent, thorough internal audits (the `2026-09-02` runtime-ownership survey and the SSOT consolidation docs), and the architecture they analyzed has since been replaced or already tracks its remaining gaps. The webview area produced one genuine, undocumented issue, fixed here.

### The issue

`AGENTS.md`'s "Webview Consistency Patterns" section (and a related bullet under "Coding style") describes an architecture that only `settingsView` still follows:

- It claims all three webviews (`webview`, `progressView`, `settingsView`) extend `BaseViewContentProvider` / `BaseViewMessageHandler`. In the actual tree, `extends BaseViewMessageHandler` has exactly one hit (`SettingsViewMessageHandler.ts`), and `extends BaseViewContentProvider` has zero — everyone uses the `BundledViewContentProvider` composition helper instead.
- It points contributors at `src/shared/ipc.ts` command constants (`MAIN_VIEW_COMMANDS`, etc.) that no longer exist there; `progressView` now routes through `SessionBridge`/`HostDraftRequests` as typed `runtime.request`/`host.request` calls (per `docs/proposals/2026-09-03-one-view-state-three-renderers.md`), with no command-constant registry at all.
- It treats `webview` as a third peer view, but `packages/extension/src/webview/frontend` is no longer an independent view with its own content provider — it's the shared Lit component library (banners, file pickers, onboarding cards) that `progressView` composes. `MainViewContentProvider`, the doc's own example name, doesn't exist anywhere in the tree.
- The directory-structure bullet under "Coding style" says to keep webview folders aligned, but `settingsView/frontend/slices/` and `progressView/frontend/formatters/` now diverge by design (request/response state vs. reading an event fold as Lit properties) — not a naming drift to fix.

**Why it matters**: a contributor extending any view, or fixing a bug in one, reads AGENTS.md's explicit instruction to extend `BaseViewMessageHandler`/`BaseViewContentProvider` and use the `ipc.ts` command-constant registry, then finds neither pattern in two of the three views the doc names. There was no proposal or doc anywhere ruling on whether the split is deliberate — it read as an abandoned migration plus a stale doc, i.e. exactly the "which pattern do I follow" confusion a design-guardrail doc exists to prevent.

### The fix

Rewrote the section to name the two actual, coexisting patterns and which view follows which:
- `settingsView`: request/response via `BaseViewMessageHandler` + `HandlerRegistry`, tab-shaped handler classes in `settingsView/handlers/`, named command constants in `ipc.ts`, slice-based frontend state.
- `progressView`: event-fold via `SessionBridge`/`HostDraftRequests`, `vscode.WebviewViewProvider` implemented directly (composed with `BundledViewContentProvider`), Lit components reading the `SessionView` fold and `Surface` records as properties.
- `webview/frontend`: named explicitly as the shared component library `progressView` composes, not a third view.

Also updated the "Coding style" directory-alignment bullet to reference the same distinction instead of implying a single expected folder shape across both views.

No production code changed — this PR only corrects the doc to match current architecture, which is itself the "single source of truth" fix here (the doc was the second, stale copy of the real architecture).

## Issue acceptance gates

Not filed against a tracked issue — found and fixed during a scheduled "confusing/overlapped responsibilities" audit. Gate: AGENTS.md's webview section names the actual current base classes, routing mechanism, and file layout for each of `settingsView` and `progressView`, and no longer implies a shared base class or command registry that doesn't exist. Verified by grep (see Summary) before writing the replacement text.

## Single source of truth

`AGENTS.md`'s "Webview Consistency Patterns" section is the doc; the code it now accurately describes remains the actual source of truth (`SettingsViewMessageHandler.ts`, `ProgressViewProvider.ts`, `docs/proposals/2026-09-03-one-view-state-three-renderers.md`).

## Duplication and abstraction budget

No code duplication touched — this is a documentation correction, not a code consolidation. No new abstraction added.

## Net elements (R6)

N/A — docs-only change (not a refactor/simplify/consolidate/dedupe/extract PR). 1 file changed, +33/-6 lines, no exported symbols or declarations touched.

## Consumer counts (R8)

N/A — no emit path or export deleted or re-routed.

## Host impact

Extension: none (doc-only; clarifies the extension's own two webview architectures for future contributors).

Desktop: none.

CLI: none.

## Scheduled refactoring

None filed as an issue in this PR. Two smaller, lower-severity items surfaced during the same audit but were left undone as out of scope for this fix:
- A same-concept `readProposedContent` exists on two independently-named interfaces (`DiffViewHost` in `src/hosts/uiHosts.ts`, only implemented by the extension, versus `ToolEditPreview`/`ToolEditApprovalHost` in `src/controllers/approval/ToolEditApprovalController.ts`, implemented by both extension and desktop). No live bug — CLI implements neither — but the layering between the two interfaces is accidental rather than documented.
- `src/agent/runtime/SessionEvents.ts` and `src/shared/session/sessionEvents.ts` share a name across two directories; the former (not the schema-adjacent latter) is where `runEventDraft`/`statusDraft` actually live, which is a "which file do I edit" trap for anyone extending the event vocabulary per CLAUDE.md's "Event channels" instructions.

Neither rose to the significance of the webview doc drift, and both are speculative-severity enough that filing a tracked issue felt like padding rather than a real find — flagging here in case a maintainer wants to open one.

## Validation

- `npx prettier --write AGENTS.md` (no changes needed beyond the edit itself)
- `node scripts/check-guidance-refs.mjs` (passed — 58 files checked, no broken guidance references)
- `git diff --check` (no whitespace errors)
- No code changed, so `typecheck`/`lint`/`test`/`check:dead-code-ratchet` were not run — they're a no-op for a docs-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwqu29JPH9WCM26afY2Kua

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xwqu29JPH9WCM26afY2Kua)_