### PR TITLE
fix(transcript): make StreamSnapshotStore's event switch exhaustive over the real union

### DIFF
--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -749,9 +749,9 @@ export class StreamSnapshotStore {
           return;
         // `status`, `run.activate`, `stage.start`, `result`, and
         // `stream.removed` carry liveness and lifecycle, which the class doc
-        // above says this store deliberately does not persist; the approval
-        // pair, `context.state`, and `conversation.progress` are run-scoped
-        // session facts the fold owns; `transcript.entry` is the transcript
+        // above says this store deliberately does not persist; the three
+        // approval facts, `context.state`, and `conversation.progress` are
+        // run-scoped session facts the fold owns; `transcript.entry` is the transcript
         // tier; goal, inquiry, and follow-up facts are session/render state
         // owned by SessionFactApplier/SessionState, not by this sidecar.
         // Every arm is listed explicitly so a newly added SessionEvent type

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -747,24 +747,33 @@ export class StreamSnapshotStore {
         case 'setParentStream':
           this.setParentStream(event.aggregateId, event.parentStreamId);
           return;
-        // `status` carries liveness, which the class doc above says this
-        // store deliberately does not persist. The rest — goal, inquiry,
-        // follow-up, active-stream, hold, and removal facts — are
-        // session/render state owned by SessionFactApplier/SessionState, not
-        // by this sidecar. Both groups are listed explicitly so a newly
-        // added SessionFact fails the `never` check below instead of
-        // silently no-op'ing.
+        // `status`, `run.activate`, `stage.start`, `result`, and
+        // `stream.removed` carry liveness and lifecycle, which the class doc
+        // above says this store deliberately does not persist; the approval
+        // pair, `context.state`, and `conversation.progress` are run-scoped
+        // session facts the fold owns; `transcript.entry` is the transcript
+        // tier; goal, inquiry, and follow-up facts are session/render state
+        // owned by SessionFactApplier/SessionState, not by this sidecar.
+        // Every arm is listed explicitly so a newly added SessionEvent type
+        // fails the `never` check below instead of silently no-op'ing.
         case 'status':
+        case 'run.activate':
+        case 'stage.start':
+        case 'result':
+        case 'stream.removed':
+        case 'approval.policy':
+        case 'approval.requested':
+        case 'approval.resolved':
+        case 'context.state':
+        case 'conversation.progress':
+        case 'transcript.entry':
         case 'goalStateChanged':
+        case 'goalPaused':
         case 'inquiryThreadUpdated':
         case 'updateQueuedFollowUps':
-        case 'followUpSent':
-        case 'setActiveStream':
-        case 'streamHoldChanged':
-        case 'removeStream':
           return;
         default: {
-          const unhandled: never = fact;
+          const unhandled: never = event;
           return unhandled;
         }
       }


### PR DESCRIPTION
## Summary

`main` has been red since #11880 (9375fd9, merged 07:34Z): that change closed the switch in `StreamSnapshotStore`'s fact applier with a `never` check, but named four arms that are not `SessionEventDraft` types (`followUpSent`, `setActiveStream`, `streamHoldChanged`, `removeStream`) and referenced an undeclared `fact`, so `npm run typecheck` fails with six errors in `src/transcript/StreamSnapshotStore.ts` and every PR's `static checks` job fails on the merge commit.

The switch now lists the eleven real arms the sidecar ignores (`run.activate`, `stage.start`, `result`, `stream.removed`, `approval.policy`, `approval.requested`, `approval.resolved`, `context.state`, `conversation.progress`, `transcript.entry`, `goalPaused`) beside the four it already listed, groups them in the comment by why the sidecar ignores each (liveness and lifecycle, run-scoped session facts the fold owns, the transcript tier, session/render state), and narrows `event` in the `default` arm. The union was taken from the `durable(...)` calls in `src/shared/schemas/sessionEvent.ts`.

Behavior is unchanged: every arm added here was a silent no-op under the `default: return` that #11880 replaced, and the `never` check now compiles, so a newly added event type fails typecheck as #11880 intended.

## Issue acceptance gates

n/a: repairs #11880 on `main`; no issue.

## Single source of truth

The switch's arm list is derived from the `SessionEventSchema` discriminated union; the `never` check is what keeps them in step.

## Duplication and abstraction budget

n/a: one switch, arms only.

## Net elements (R6)

1 file, +19/-10 lines, no exports, classes, or dependencies changed.

## Consumer counts (R8)

n/a: no emit path or export changes.

## Host impact

Extension: none.

Desktop: none.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npx tsc --noEmit -p tsconfig.json --checkers 8`: 0 errors (6 on `main`).
- `npx tsc --noEmit -p tsconfig.test-kernel.json --checkers 8`: 0 errors.
- `npx vitest run src/test-kernel/transcript`: 10 files, 243 tests, all passing.
- eslint and prettier on the file: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyJjcnpYcFopcGbYdWayxp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyJjcnpYcFopcGbYdWayxp)_